### PR TITLE
Setup initial XLA codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners are default owners for now to ensure that no PRs are dropped.
+*       @ddunl @tpopp


### PR DESCRIPTION
This is currently just to ensure that no PRs are lost.