### PR TITLE
Remove default CODEOWNERS and assign reviewers with workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# These owners are default owners for now to ensure that no PRs are dropped.
-*       @ddunl @tpopp
+# TODO: Have default codeowners but note that it will add reviewers to copybara
+# exports also

--- a/.github/workflows/trusted-partners.yml
+++ b/.github/workflows/trusted-partners.yml
@@ -55,9 +55,14 @@ jobs:
             case "arm.com":
               console.log(await script.filter({github, context, domain}));
               break;
-            case "google.com":
-              console.log("Googler. No action necessary");
-              break;
+            # Disable googler flow, so default reviewers are added for now
+            # case "google.com":
+              # console.log("Googler. No action necessary");
+              # break;
             default:
-              console.log("Skip Trusted Partner Action");
+              # For now, add default reviewers to all PRs to ensure none are
+              # missed until further reviewer processes are setup.
+              console.log(await script.filter({github, context, domain}));
+              console.log("Default reviewers added");
+              # console.log("Skip Trusted Partner Action");
             }

--- a/.github/workflows/trusted_partners.js
+++ b/.github/workflows/trusted_partners.js
@@ -51,7 +51,7 @@ const get_email_domain = async ({github, username}) => {
   @return {string} Returns the message with labels attached and assignees added
 */
 const filter_action = async ({github, context, domain}) => {
-  const labels = ['kokoro:force-run'];
+  let labels = ['kokoro:force-run'];
 
   let assignees = [];
   const title =
@@ -91,6 +91,11 @@ const filter_action = async ({github, context, domain}) => {
   if (lowercased_title.includes('tf-mot') && lowercased_title.includes('arm') &&
       domain.includes('arm.com')) {
     assignees.push('rino20', 'yyoon', 'lenscloth');
+  }
+  // Add default reviewers. Make labels constant once this is removed.
+  if (assignees.length == 0) {
+    assignees.push('xla-rotation', 'tpopp', 'ddunl');
+    labels = [];
   }
 
   const resp_label = await github.rest.issues.addLabels({


### PR DESCRIPTION
Previously, we added reviewers to all changes through the CODEOWNERS file to ensure no PRs were missed. This created too much spam as copybara-service PRs also added reviewers now. This new flow will only add reviewers to PRs from an actual user. This is implemented by the trusted-partners workflow only executing for actual users and by then assigning certain reviewers in the case that no more appropriate reviewers were added.