### PR TITLE
copy edited XLA custom call doc

### DIFF
--- a/docs/custom_call.md
+++ b/docs/custom_call.md
@@ -1,27 +1,27 @@
 # XLA custom calls
 
-This document describes how to write and use XLA "custom calls". Custom calls
+This document describes how to write and use XLA custom calls. Custom calls
 let you invoke code written in a programming language like C++ or CUDA from an
 XLA program.
 
-!!! Warning
+> **Caution:**
     Custom calls are a low-level power-user feature. It is easy to break your
     program in difficult-to-debug (and even difficult-to-notice) ways using
-    custom-calls. You shouldn't use custom calls unless you're prepared to debug
+    custom calls. You shouldn't use custom calls unless you're prepared to debug
     XLA yourself when something goes wrong, and you should expect relatively
     less assistance from XLA developers if you run into trouble.
 
-!!! Warning
+> **Caution:**
     The custom-call API/ABI is not currently stable. We don't intend to
     change it capriciously, but it may change. Some possible future changes are
     described below.
 
-## Custom-call on CPU
+## Create a custom call on CPU
 
-You can create an HLO instruction which represents a custom-call via XLA's
-client API. For example, the following code uses a custom-call to compute `A[i]
-= B[i % 128]+ C[i]` on the CPU. (Of course you could -- and should! -- do this
-with regular HLO.)
+You can create an HLO instruction that represents a custom call via XLA's
+client API. For example, the following code uses a custom call to compute `A[i]
+= B[i % 128]+ C[i]` on the CPU. (Of course you could &ndash; and should! &ndash;
+do this with regular HLO.)
 
 ```c++
 #include "xla/client/xla_builder.h"
@@ -50,14 +50,14 @@ XLA_REGISTER_CUSTOM_CALL_TARGET(do_custom_call, "Host");
 ```
 
 Notice that the function `do_custom_call` needs to know the dimensions of the
-buffers it operates over. In this example we hardcode the sizes 128 and 2048. If
-you don't want to do this, you can pass the dimensions in as parameters to the
-call.
+buffers it operates over. In this example we hardcode the sizes `128` and `2048`.
+If you don't want to do this, you can pass the dimensions in as parameters to
+the call.
 
-## Custom-call on GPU
+## Create a custom call on GPU
 
 The GPU custom call framework is somewhat different than that on the CPU. Here
-is a CUDA example that does the same `A[i] = B[i % 128] + C[i]` computation as
+is a CUDA example that does the same computation (`A[i] = B[i % 128] + C[i]`) as
 the CPU code above.
 
 ```c++
@@ -83,24 +83,23 @@ XLA_REGISTER_CUSTOM_CALL_TARGET(do_custom_call, "CUDA");
 ```
 
 Notice first that the GPU custom call function *is still a function executed on
-the CPU*. Our `do_custom_call` CPU function is responsible for enqueueing work
+the CPU*. The `do_custom_call` CPU function is responsible for enqueueing work
 on the GPU. Here it launches a CUDA kernel, but it could also do something else,
-like call cublas.
+like call cuBLAS.
 
-`buffers` is an array of pointers which lives on the host, and each element it
+`buffers` is an array of pointers that lives on the host, and each element it
 contains points to device (i.e. GPU) memory. The parameters come first, followed
 by the output value. This is notably different from the CPU calling convention,
-which has two params, `ins` and `out`. The main reason we diverge is to make it
-possible to handle tuple-shaped inputs/outputs efficiently; see the section
-below.
+which has two params, `ins` and `out`. The GPU calling convention makes it
+possible to handle tuple-shaped inputs/outputs efficiently.
 
 As in the CPU example, we've hardcoded the input and output buffer sizes into
 our custom call. However unlike in the CPU case, passing the buffer sizes in as
 operands to the custom call would not work well. Usually we need the buffer
-sizes available to us on the CPU; e.g. when launching a kernel, we need to know
-the block/grid dimensions to use. But if we were to pass the buffer sizes as
+sizes available to us on the CPU (e.g. when launching a kernel, we need to know
+the block/grid dimensions to use). But if we were to pass the buffer sizes as
 operands to our custom call, their values would live in GPU memory. We'd then
-have to do an expensive synchronous device-to-host memcpy at the start of our
+have to do an expensive synchronous device-to-host `memcpy` at the start of our
 operation just to read the sizes.
 
 To let you work around this, we provide the `opaque` parameter. You can set this
@@ -113,17 +112,19 @@ xla::CustomCall(&b, "do_custom_call", /*operands=*/{param0, param1},
                 opaque);
 ```
 
-Since `xla::Shape` has a protocol buffer representation, you could store this
+Because `xla::Shape` has a protocol buffer representation, you could store this
 serialized proto inside of `opaque` and deserialize it within your GPU
-custom-call. Note however that although `xla::ShapeProto` does not change
-frequently, it *does* change. Check the git log to see how it has changed in the
+custom call. Note however that although `xla::ShapeProto` does not change
+frequently, it *does* change. Check the Git log to see how it has changed in the
 past.
 
 ## Signalling an error
 
 If your custom call encounters an error, you can signal the error to the XLA
 runtime (instead of e.g. crashing or returning nonsense in the output buffers)
-by using the following signature for your function on CPU:
+by using the following signature for your function:
+
+**On CPU:**
 
 ```c++
 #include "xla/service/custom_call_status.h"
@@ -131,7 +132,7 @@ by using the following signature for your function on CPU:
 void do_custom_call(void* out, const void** in, XlaCustomCallStatus* status);
 ```
 
-... and on GPU:
+**on GPU:**
 
 ```c++
 #include "xla/service/custom_call_status.h"
@@ -172,7 +173,7 @@ xla::CustomCall(&b, "do_custom_call", /*operands=*/{param0, param1},
                 /*api_version=*/API_VERSION_STATUS_RETURNING);
 ```
 
-!!! Note
+> **Note:**
   In the future all clients will be required to migrate their custom call
   functions to the new API version and the old one will be deprecated. For
   custom calls that can't fail, you can simply add the new
@@ -182,9 +183,9 @@ On failure, none of the custom call outputs will be used; the XLA runtime will
 terminate the computation. It is not possible for an HLO computation to recover
 from the error (e.g. by catching and handling it).
 
-## Passing tuples to custom-calls
+## Passing tuples to custom calls
 
-Consider the following custom-call.
+Consider the following custom call.
 
 ```c++
 using xla::ShapeUtil;
@@ -207,10 +208,10 @@ xla::CustomCall(&b, "do_custom_call", /*operands=*/{p0}, out_shape);
 ```
 
 On both CPU and GPU, a tuple is represented in memory as an array of pointers.
-In C++-pseudocode, parameter 0 above is laid out as follows.
+In C++ pseudocode, parameter 0 above is laid out as follows.
 
 ```c++
-// In-memory layout of parameter 0 from custom-call above.  True on both CPU
+// In-memory layout of parameter 0 from custom call above. True on both CPU
 // and GPU.
 float* subbuf0 = new float[32];
 float* subbuf1 = new float[64];
@@ -232,15 +233,15 @@ are handled differently in the CPU and GPU custom-call calling conventions.
 
 ### Tuple outputs as temp buffers
 
-Tuple inputs to custom-calls are a convenience, but they aren't strictly
+Tuple inputs to custom calls are a convenience, but they aren't strictly
 necessary. If we didn't support tuple inputs to custom calls, you could always
 unpack the tuples using get-tuple-element before passing them to the custom
 call.
 
 On the other hand, tuple *outputs* do let you do things you couldn't otherwise.
 
-The obvious reason to have tuple outputs is, that's how a custom call (or any
-other XLA op) returns multiple independent arrays.
+The obvious reason to have tuple outputs is that tuple outputs are how a custom
+call (or any other XLA op) returns multiple independent arrays.
 
 But less obviously, a tuple output is also a way to give your custom call temp
 memory. Yes, an *output* can represent a temp buffer. Consider, an output buffer
@@ -251,14 +252,14 @@ In the example above, suppose we wanted to use the `F32[1024]` as a temp buffer.
 Then we'd write the HLO just as above, and we'd simply never read tuple index 1
 of the custom call's output.
 
-### Tuples in CPU custom-calls
+### Tuples in CPU custom calls
 
 In CPU code, we have a function `do_custom_call(const void** ins, void* out)`.
 `ins` is an array with just one element, which points to `param0`. The
 subbuffers of `param0` are accessible by dereferencing that pointer, and the
 subbuffers of `output_tuple` are accessible by dereferencing `out`.
 
-### Tuples in GPU custom-calls
+### Tuples in GPU custom calls
 
 In GPU code, we have a function `do_custom_call(..., void** buffers, ...)`. In
 this case `buffers` is a host array of *six* device pointers, one for each leaf


### PR DESCRIPTION
This guide has a little bit of a non-standard voice (uses "we" a lot, uses "e.g." and "i.e."), but I think it works, and it's good documentation. I didn't mess with it too much. 