### PR TITLE
Workaround msvc build by replacing forward decl with decl

### DIFF
--- a/xla/pjrt/transpose.cc
+++ b/xla/pjrt/transpose.cc
@@ -1325,19 +1325,6 @@ std::string TransposePlan::ToString() const {
       scratch_size_, nodes_str);
 }
 
-struct TransposePlanCacheKey {
-  size_t elem_size_in_bytes;
-  absl::InlinedVector<int64_t, 4> dims;
-  absl::InlinedVector<int64_t, 4> permutation;
-  bool input_layout_is_tiling;
-  absl::InlinedVector<int64_t, 4> input_layout;
-  absl::InlinedVector<int64_t, 4> output_tiling;
-  TransposePlan::Transformation transformation;
-  int num_threads;
-
-  bool operator==(const TransposePlanCacheKey& other) const;
-};
-
 bool TransposePlanCacheKey::operator==(
     const TransposePlanCacheKey& other) const {
   return elem_size_in_bytes == other.elem_size_in_bytes && dims == other.dims &&

--- a/xla/pjrt/transpose.cc
+++ b/xla/pjrt/transpose.cc
@@ -1325,7 +1325,7 @@ std::string TransposePlan::ToString() const {
       scratch_size_, nodes_str);
 }
 
-bool TransposePlanCacheKey::operator==(
+bool TransposePlanCache::TransposePlanCacheKey::operator==(
     const TransposePlanCacheKey& other) const {
   return elem_size_in_bytes == other.elem_size_in_bytes && dims == other.dims &&
          permutation == other.permutation &&
@@ -1337,7 +1337,7 @@ bool TransposePlanCacheKey::operator==(
 }
 
 template <typename H>
-H AbslHashValue(H h, const TransposePlanCacheKey& key) {
+H AbslHashValue(H h, const TransposePlanCache::TransposePlanCacheKey& key) {
   return H::combine(std::move(h), key.elem_size_in_bytes,
                     key.input_layout_is_tiling, key.num_threads,
                     key.transformation, key.dims, key.permutation,

--- a/xla/pjrt/transpose.h
+++ b/xla/pjrt/transpose.h
@@ -240,7 +240,18 @@ class TransposePlan {
   int64_t scratch_size_ = 0;
 };
 
-struct TransposePlanCacheKey;
+struct TransposePlanCacheKey {
+  size_t elem_size_in_bytes;
+  absl::InlinedVector<int64_t, 4> dims;
+  absl::InlinedVector<int64_t, 4> permutation;
+  bool input_layout_is_tiling;
+  absl::InlinedVector<int64_t, 4> input_layout;
+  absl::InlinedVector<int64_t, 4> output_tiling;
+  TransposePlan::Transformation transformation;
+  int num_threads;
+
+  bool operator==(const TransposePlanCacheKey& other) const;
+};
 
 template <typename H>
 H AbslHashValue(H h, const TransposePlanCacheKey& key);


### PR DESCRIPTION
```
<omitted>\\include\\xstddef(106): error C2678: binary '==': no operator found which takes a left-hand operand of type 'const _Ty' (or there is no acceptable conversion)
        with
        [
            _Ty=xla::TransposePlanCacheKey
        ]
<omitted>\\include\\thread(242): note: could be 'bool std::operator ==(std::thread::id,std::thread::id) noexcept'
<omitted>\\include\\variant(1677): note: or       'bool std::operator ==(std::monostate,std::monostate) noexcept'
<omitted>\\include\\complex(1495): note: or       'bool std::operator ==(const _Ty &,const std::complex<_Other> &)'
...
```

and other 300 lines of incomprehensible long error. Due to the missing of the `opeartor==(...)` for `TransposePlanCacheKey`.