### PR TITLE
[XLA:CPU] use ducc FFT for single-threaded FFT

### DIFF
--- a/third_party/ducc/BUILD
+++ b/third_party/ducc/BUILD
@@ -1,0 +1,30 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "ducc",
+    srcs = [
+        "src/ducc0/fft/fft1d.h",
+        "src/ducc0/infra/aligned_array.h",
+        "src/ducc0/infra/error_handling.h",
+        "src/ducc0/infra/mav.h",
+        "src/ducc0/infra/misc_utils.h",
+        "src/ducc0/infra/simd.h",
+        "src/ducc0/infra/threading.cc",
+        "src/ducc0/infra/threading.h",
+        "src/ducc0/infra/useful_macros.h",
+        "src/ducc0/math/cmplx.h",
+        "src/ducc0/math/unity_roots.h",
+    ],
+    hdrs = ["src/ducc0/fft/fft.h"],
+    copts = [
+        "-fexceptions",
+        "-ffast-math",
+    ],
+    features = ["-use_header_modules"],
+    include_prefix = "ducc",
+    includes = [
+        "src",
+    ],
+)

--- a/third_party/ducc/BUILD
+++ b/third_party/ducc/BUILD
@@ -16,8 +16,11 @@ cc_library(
         "src/ducc0/infra/useful_macros.h",
         "src/ducc0/math/cmplx.h",
         "src/ducc0/math/unity_roots.h",
+        "src/ducc0/external/ducc0_custom_lowlevel_threading.h"
     ],
-    hdrs = ["src/ducc0/fft/fft.h"],
+    hdrs = [
+        "src/ducc0/fft/fft.h",
+    ],
     copts = [
         "-fexceptions",
         "-ffast-math",
@@ -26,5 +29,7 @@ cc_library(
     include_prefix = "ducc",
     includes = [
         "src",
+        "src/ducc0/external",
     ],
+    defines = ["DUCC0_NO_LOWLEVEL_THREADING"]
 )

--- a/third_party/ducc/threading.patch
+++ b/third_party/ducc/threading.patch
@@ -1,0 +1,4 @@
+--- /dev/null	2023-04-06 08:42:12.988021940 +0800
++++ src/ducc0/external/ducc0_custom_lowlevel_threading.h	2023-04-06 14:30:52.458062889 +0800
+@@ -0,0 +1 @@
++

--- a/third_party/ducc/workspace.bzl
+++ b/third_party/ducc/workspace.bzl
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bazel workspace for DUCC (CPU FFTs)."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def repo():
+    http_archive(
+        name = "ducc",
+        strip_prefix = "ducc-356d619a4b5f6f8940d15913c14a043355ef23be",
+        sha256 = "d23eb2d06f03604867ad40af4fe92dec7cccc2c59f5119e9f01b35b973885c61",
+        urls = [
+            "https://github.com/mreineck/ducc/archive/356d619a4b5f6f8940d15913c14a043355ef23be.tar.gz",
+            "https://storage.googleapis.com/jax-releases/mirror/ducc/ducc-356d619a4b5f6f8940d15913c14a043355ef23be.tar.gz",
+        ],
+        build_file = "@//third_party/ducc:BUILD",
+    )

--- a/third_party/ducc/workspace.bzl
+++ b/third_party/ducc/workspace.bzl
@@ -19,11 +19,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def repo():
     http_archive(
         name = "ducc",
-        strip_prefix = "ducc-356d619a4b5f6f8940d15913c14a043355ef23be",
-        sha256 = "d23eb2d06f03604867ad40af4fe92dec7cccc2c59f5119e9f01b35b973885c61",
+        strip_prefix = "ducc-e33fb4bdca38be02b869d96d6329ad5a2c3a335c",
+        sha256 = "21371a0a7d2895d7813da7f2eb0ed097014d4a327b4b7712aeb17cf92634a202",
         urls = [
-            "https://github.com/mreineck/ducc/archive/356d619a4b5f6f8940d15913c14a043355ef23be.tar.gz",
-            "https://storage.googleapis.com/jax-releases/mirror/ducc/ducc-356d619a4b5f6f8940d15913c14a043355ef23be.tar.gz",
+            "https://github.com/mreineck/ducc/archive/e33fb4bdca38be02b869d96d6329ad5a2c3a335c.tar.gz",
         ],
         build_file = "@//third_party/ducc:BUILD",
+        patches = [
+            "//third_party/ducc:threading.patch",
+        ]
     )

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -9,12 +9,14 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 
 # Import third party repository rules. See go/tfbr-thirdparty.
 load("//third_party/dlpack:workspace.bzl", dlpack = "repo")
+load("//third_party/ducc:workspace.bzl", ducc = "repo")
 load("//third_party/stablehlo:workspace.bzl", stablehlo = "repo")
 load("//third_party/triton:workspace.bzl", triton = "repo")
 
 def _initialize_third_party():
     """ Load third party repositories.  See above load() statements. """
     dlpack()
+    ducc()
     stablehlo()
     triton()
 

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -915,6 +915,7 @@ cc_library(
     copts = runtime_copts(),
     visibility = ["//visibility:public"],
     deps = [
+        "@ducc",
         ":runtime_lightweight_check",
         "//xla:executable_run_options",
         "//xla:types",
@@ -1039,6 +1040,7 @@ cc_library(
     copts = runtime_copts(),
     visibility = ["//visibility:public"],
     deps = [
+        "@ducc",
         "//xla:types",
         "//xla:xla_data_proto_cc",
         "@com_google_absl//absl/base:core_headers",

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1035,6 +1035,7 @@ cc_library(
     srcs = [
         "runtime_fft_impl.h",
         "runtime_single_threaded_fft.cc",
+        "runtime_fft_impl.cc",
     ],
     hdrs = ["runtime_single_threaded_fft.h"],
     copts = runtime_copts(),

--- a/xla/service/cpu/cpu_runtime.cc
+++ b/xla/service/cpu/cpu_runtime.cc
@@ -105,8 +105,8 @@ extern const char* const kEigenConv3DF16SymbolName =
 extern const char* const kEigenConv3DF32SymbolName =
     "__xla_cpu_runtime_EigenConv3DF32";
 extern const char* const kEigenFftSymbolName = "__xla_cpu_runtime_EigenFft";
-extern const char* const kEigenSingleThreadedFftSymbolName =
-    "__xla_cpu_runtime_EigenSingleThreadedFft";
+extern const char* const kDuccSingleThreadedFftSymbolName =
+    "__xla_cpu_runtime_DuccSingleThreadedFft";
 extern const char* const kEigenSingleThreadedMatMulF16SymbolName =
     "__xla_cpu_runtime_EigenSingleThreadedMatMulF16";
 extern const char* const kEigenSingleThreadedMatMulF32SymbolName =

--- a/xla/service/cpu/cpu_runtime.h
+++ b/xla/service/cpu/cpu_runtime.h
@@ -61,7 +61,7 @@ extern const char* const kEigenConv2DF32SymbolName;
 extern const char* const kEigenConv3DF16SymbolName;
 extern const char* const kEigenConv3DF32SymbolName;
 extern const char* const kEigenFftSymbolName;
-extern const char* const kEigenSingleThreadedFftSymbolName;
+extern const char* const kDuccSingleThreadedFftSymbolName;
 extern const char* const kEigenSingleThreadedMatMulF16SymbolName;
 extern const char* const kEigenSingleThreadedMatMulF32SymbolName;
 extern const char* const kEigenSingleThreadedMatMulF64SymbolName;

--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -1114,7 +1114,7 @@ Status IrEmitter::HandleFft(HloInstruction* fft) {
       hlo_module_config_.debug_options().xla_cpu_multi_thread_eigen();
   const char* fn_name = multi_threaded_eigen
                             ? runtime::kEigenFftSymbolName
-                            : runtime::kEigenSingleThreadedFftSymbolName;
+                            : runtime::kDuccSingleThreadedFftSymbolName;
   const int fft_rank = fft_length.size();
   EmitCallToFunc(
       fn_name,

--- a/xla/service/cpu/runtime_fft_impl.cc
+++ b/xla/service/cpu/runtime_fft_impl.cc
@@ -1,0 +1,112 @@
+
+#include "xla/service/cpu/runtime_fft_impl.h"
+#include "ducc/src/ducc0/fft/fft.h"
+
+namespace xla {
+
+using shape_t = ducc0::fmav_info::shape_t;
+using stride_t = ducc0::fmav_info::stride_t;
+
+// TODO: add thread pool
+void DuccFftImpl(void *out, void *in, internal::FftType fft_type,
+                 bool double_precision, int32_t fft_rank, int64_t input_batch, 
+                 int64_t fft_length0, int64_t fft_length1, int64_t fft_length2) {
+  // What we do: similar to the Eigen-based implementation we reinterpret 
+  // the shape as [input_batch, ..fft_lengths] with some additional transform
+  // to the last out/in shape axis for R2C and C2R respectively.
+  //
+  // TODO: convert this to generics?
+  auto forward = fft_type == internal::FftType::FFT || fft_type == internal::FftType::RFFT;
+  shape_t shape;  
+  shape_t axes;
+  double scale = 1.;
+  // While the parameter computation is inexpensive, one wonders whether it is worth 
+  // amortizing the cost at IR emission time...
+  switch (fft_rank) {
+    case 1:
+      shape = {input_batch, fft_length0};
+      axes = {1};
+      if (!forward) {
+        scale = 1. / fft_length0;
+      }
+      break;
+    case 2:
+      shape = {input_batch, fft_length0, fft_length1};
+      axes = {1, 2};
+      if (!forward) {
+        scale = 1. / (fft_length0 * fft_length1);
+      }
+      break;
+    case 3:
+      shape = {input_batch, fft_length0, fft_length1, fft_length2};
+      axes = {1, 2, 3};
+      if (!forward) {
+        scale = 1. / (fft_length0 * fft_length1 * fft_length2);
+      }
+      break;
+    default:
+      // Unsupported FFT rank
+      abort();
+  }
+
+  switch (fft_type) {
+  case internal::FftType::IFFT:
+  case internal::FftType::FFT:
+    // TODO(jon-chuang): swap to double first
+    if (!double_precision) {
+      ducc0::cfmav<std::complex<float>> m_in(
+          reinterpret_cast<std::complex<float> *>(in), shape);
+      ducc0::vfmav<std::complex<float>> m_out(
+          reinterpret_cast<std::complex<float> *>(out), shape);
+      ducc0::c2c(m_in, m_out, axes, forward, static_cast<float>(scale));
+    } else {
+      ducc0::cfmav<std::complex<double>> m_in(
+          reinterpret_cast<std::complex<double> *>(in), shape);
+      ducc0::vfmav<std::complex<double>> m_out(
+          reinterpret_cast<std::complex<double> *>(out), shape);
+      ducc0::c2c(m_in, m_out, axes, forward, scale);
+    }
+    break;
+  case internal::FftType::IRFFT:
+    // C2R
+    if (!double_precision) {
+      auto shape_in = shape;
+      shape_in[axes.back()] = shape_in[axes.back()] / 2 + 1;
+      ducc0::cfmav<std::complex<float>> m_in(
+          reinterpret_cast<std::complex<float> *>(in), shape_in);
+      ducc0::vfmav<float> m_out(reinterpret_cast<float *>(out), shape);
+      ducc0::c2r(m_in, m_out, axes, false, static_cast<float>(scale));
+    } else {
+      auto shape_in = shape;
+      shape_in[axes.back()] = shape_in[axes.back()] / 2 + 1;
+      ducc0::cfmav<std::complex<double>> m_in(
+          reinterpret_cast<std::complex<double> *>(in), shape_in);
+      ducc0::vfmav<double> m_out(reinterpret_cast<double *>(out), shape);
+      ducc0::c2r(m_in, m_out, axes, false, scale);
+    }
+    break;
+  case internal::FftType::RFFT:
+    // R2C
+    if (!double_precision) {
+      auto shape_out = shape;
+      shape_out[axes.back()] = shape_out[axes.back()] / 2 + 1;
+      ducc0::cfmav<float> m_in(reinterpret_cast<float *>(in), shape);
+      ducc0::vfmav<std::complex<float>> m_out(
+          reinterpret_cast<std::complex<float> *>(out), shape_out);
+      ducc0::r2c(m_in, m_out, axes, true, static_cast<float>(scale));
+    } else {
+      auto shape_out = shape;
+      shape_out[axes.back()] = shape_out[axes.back()] / 2 + 1;
+      ducc0::cfmav<double> m_in(reinterpret_cast<double *>(in), shape);
+      ducc0::vfmav<std::complex<double>> m_out(
+          reinterpret_cast<std::complex<double> *>(out), shape_out);
+      ducc0::r2c(m_in, m_out, axes, true, scale);
+    }
+    break;
+  default:
+    // Unsupported FFT type
+    abort();
+  }
+}
+
+}  // namespace xla

--- a/xla/service/cpu/runtime_fft_impl.cc
+++ b/xla/service/cpu/runtime_fft_impl.cc
@@ -7,8 +7,7 @@ namespace xla {
 using shape_t = ducc0::fmav_info::shape_t;
 using stride_t = ducc0::fmav_info::stride_t;
 
-// TODO: add thread pool
-void DuccFftImpl(void *out, void *in, internal::FftType fft_type,
+void DuccFftImpl(bool use_thread_pool, void *out, void *in, internal::FftType fft_type,
                  bool double_precision, int32_t fft_rank, int64_t input_batch, 
                  int64_t fft_length0, int64_t fft_length1, int64_t fft_length2) {
   // What we do: similar to the Eigen-based implementation we reinterpret 
@@ -16,6 +15,7 @@ void DuccFftImpl(void *out, void *in, internal::FftType fft_type,
   // to the last out/in shape axis for R2C and C2R respectively.
   //
   // TODO: convert this to generics?
+  std::ignore = use_thread_pool;
   auto forward = fft_type == internal::FftType::FFT || fft_type == internal::FftType::RFFT;
   shape_t shape;  
   shape_t axes;

--- a/xla/service/cpu/runtime_fft_impl.h
+++ b/xla/service/cpu/runtime_fft_impl.h
@@ -262,7 +262,9 @@ void EigenFftImpl(const EigenDevice& device, void* out, void* operand,
       abort();
   }
 }
-void DuccFftImpl(void *out, void *in, internal::FftType fft_type,
+
+// For now, we will use Eigen thread pools via `EigenDevice`
+void DuccFftImpl(bool use_thread_pool, void *out, void *in, internal::FftType fft_type,
                  bool double_precision, int32_t fft_rank, int64_t input_batch, 
                  int64_t fft_length0, int64_t fft_length1, int64_t fft_length2);
 

--- a/xla/service/cpu/runtime_fft_impl.h
+++ b/xla/service/cpu/runtime_fft_impl.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "Eigen/Core"  // from @eigen_archive
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "xla/types.h"
+#include "ducc/src/ducc0/fft/fft.h"
 
 namespace xla {
 
@@ -260,6 +261,112 @@ void EigenFftImpl(const EigenDevice& device, void* out, void* operand,
     default:
       // Unsupported FFT rank
       abort();
+  }
+}
+
+using shape_t = ducc0::fmav_info::shape_t;
+using stride_t = ducc0::fmav_info::stride_t;
+
+// TODO: add thread pool
+void DuccFftImpl(void *out, void *in, internal::FftType fft_type,
+                 bool double_precision, int32_t fft_rank, int64_t input_batch, 
+                 int64_t fft_length0, int64_t fft_length1, int64_t fft_length2) {
+  // What we do: similar to the Eigen-based implementation we reinterpret 
+  // the shape as [input_batch, ..fft_lengths] with some additional transform
+  // to the last out/in shape axis for R2C and C2R respectively.
+  //
+  // TODO: convert this to generics?
+  auto forward = fft_type == internal::FftType::FFT || fft_type == internal::FftType::RFFT;
+  shape_t shape;  
+  shape_t axes;
+  double scale = 1.;
+  // While the parameter computation is inexpensive, one wonders whether it is worth 
+  // amortizing the cost at IR emission time...
+  switch (fft_rank) {
+    case 1:
+      shape = {input_batch, fft_length0};
+      axes = {1};
+      if (!forward) {
+        scale = 1. / fft_length0;
+      }
+      break;
+    case 2:
+      shape = {input_batch, fft_length0, fft_length1};
+      axes = {1, 2};
+      if (!forward) {
+        scale = 1. / (fft_length0 * fft_length1);
+      }
+      break;
+    case 3:
+      shape = {input_batch, fft_length0, fft_length1, fft_length2};
+      axes = {1, 2, 3};
+      if (!forward) {
+        scale = 1. / (fft_length0 * fft_length1 * fft_length2);
+      }
+      break;
+    default:
+      // Unsupported FFT rank
+      abort();
+  }
+  scale = 100.;
+
+  switch (fft_type) {
+  case internal::FftType::IFFT:
+  case internal::FftType::FFT:
+    // TODO(jon-chuang): swap to double first
+    if (!double_precision) {
+      ducc0::cfmav<std::complex<float>> m_in(
+          reinterpret_cast<std::complex<float> *>(in), shape);
+      ducc0::vfmav<std::complex<float>> m_out(
+          reinterpret_cast<std::complex<float> *>(out), shape);
+      ducc0::c2c(m_in, m_out, axes, forward, static_cast<float>(scale));
+    } else {
+      ducc0::cfmav<std::complex<double>> m_in(
+          reinterpret_cast<std::complex<double> *>(in), shape);
+      ducc0::vfmav<std::complex<double>> m_out(
+          reinterpret_cast<std::complex<double> *>(out), shape);
+      ducc0::c2c(m_in, m_out, axes, forward, scale);
+    }
+    break;
+  case internal::FftType::IRFFT:
+    // C2R
+    if (!double_precision) {
+      auto shape_in = shape;
+      shape_in[axes.back()] = shape_in[axes.back()] / 2 + 1;
+      ducc0::cfmav<std::complex<float>> m_in(
+          reinterpret_cast<std::complex<float> *>(in), shape_in);
+      ducc0::vfmav<float> m_out(reinterpret_cast<float *>(out), shape);
+      ducc0::c2r(m_in, m_out, axes, false, static_cast<float>(scale));
+    } else {
+      auto shape_in = shape;
+      shape_in[axes.back()] = shape_in[axes.back()] / 2 + 1;
+      ducc0::cfmav<std::complex<double>> m_in(
+          reinterpret_cast<std::complex<double> *>(in), shape_in);
+      ducc0::vfmav<double> m_out(reinterpret_cast<double *>(out), shape);
+      ducc0::c2r(m_in, m_out, axes, false, scale);
+    }
+    break;
+  case internal::FftType::RFFT:
+    // R2C
+    if (!double_precision) {
+      auto shape_out = shape;
+      shape_out[axes.back()] = shape_out[axes.back()] / 2 + 1;
+      ducc0::cfmav<float> m_in(reinterpret_cast<float *>(in), shape);
+      ducc0::vfmav<std::complex<float>> m_out(
+          reinterpret_cast<std::complex<float> *>(out), shape_out);
+      ducc0::r2c(m_in, m_out, axes, true, static_cast<float>(scale));
+    } else {
+      auto shape_out = shape;
+      shape_out[axes.back()] = shape_out[axes.back()] / 2 + 1;
+      ducc0::cfmav<double> m_in(reinterpret_cast<double *>(in), shape);
+      ducc0::vfmav<std::complex<double>> m_out(
+          reinterpret_cast<std::complex<double> *>(out), shape_out);
+      ducc0::r2c(m_in, m_out, axes, true, scale);
+    }
+    break;
+  default:
+    // Unsupported FFT type
+    abort();
   }
 }
 

--- a/xla/service/cpu/runtime_fft_impl.h
+++ b/xla/service/cpu/runtime_fft_impl.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include "Eigen/Core"  // from @eigen_archive
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "xla/types.h"
-#include "ducc/src/ducc0/fft/fft.h"
 
 namespace xla {
 
@@ -263,111 +262,9 @@ void EigenFftImpl(const EigenDevice& device, void* out, void* operand,
       abort();
   }
 }
-
-using shape_t = ducc0::fmav_info::shape_t;
-using stride_t = ducc0::fmav_info::stride_t;
-
-// TODO: add thread pool
 void DuccFftImpl(void *out, void *in, internal::FftType fft_type,
                  bool double_precision, int32_t fft_rank, int64_t input_batch, 
-                 int64_t fft_length0, int64_t fft_length1, int64_t fft_length2) {
-  // What we do: similar to the Eigen-based implementation we reinterpret 
-  // the shape as [input_batch, ..fft_lengths] with some additional transform
-  // to the last out/in shape axis for R2C and C2R respectively.
-  //
-  // TODO: convert this to generics?
-  auto forward = fft_type == internal::FftType::FFT || fft_type == internal::FftType::RFFT;
-  shape_t shape;  
-  shape_t axes;
-  double scale = 1.;
-  // While the parameter computation is inexpensive, one wonders whether it is worth 
-  // amortizing the cost at IR emission time...
-  switch (fft_rank) {
-    case 1:
-      shape = {input_batch, fft_length0};
-      axes = {1};
-      if (!forward) {
-        scale = 1. / fft_length0;
-      }
-      break;
-    case 2:
-      shape = {input_batch, fft_length0, fft_length1};
-      axes = {1, 2};
-      if (!forward) {
-        scale = 1. / (fft_length0 * fft_length1);
-      }
-      break;
-    case 3:
-      shape = {input_batch, fft_length0, fft_length1, fft_length2};
-      axes = {1, 2, 3};
-      if (!forward) {
-        scale = 1. / (fft_length0 * fft_length1 * fft_length2);
-      }
-      break;
-    default:
-      // Unsupported FFT rank
-      abort();
-  }
-
-  switch (fft_type) {
-  case internal::FftType::IFFT:
-  case internal::FftType::FFT:
-    // TODO(jon-chuang): swap to double first
-    if (!double_precision) {
-      ducc0::cfmav<std::complex<float>> m_in(
-          reinterpret_cast<std::complex<float> *>(in), shape);
-      ducc0::vfmav<std::complex<float>> m_out(
-          reinterpret_cast<std::complex<float> *>(out), shape);
-      ducc0::c2c(m_in, m_out, axes, forward, static_cast<float>(scale));
-    } else {
-      ducc0::cfmav<std::complex<double>> m_in(
-          reinterpret_cast<std::complex<double> *>(in), shape);
-      ducc0::vfmav<std::complex<double>> m_out(
-          reinterpret_cast<std::complex<double> *>(out), shape);
-      ducc0::c2c(m_in, m_out, axes, forward, scale);
-    }
-    break;
-  case internal::FftType::IRFFT:
-    // C2R
-    if (!double_precision) {
-      auto shape_in = shape;
-      shape_in[axes.back()] = shape_in[axes.back()] / 2 + 1;
-      ducc0::cfmav<std::complex<float>> m_in(
-          reinterpret_cast<std::complex<float> *>(in), shape_in);
-      ducc0::vfmav<float> m_out(reinterpret_cast<float *>(out), shape);
-      ducc0::c2r(m_in, m_out, axes, false, static_cast<float>(scale));
-    } else {
-      auto shape_in = shape;
-      shape_in[axes.back()] = shape_in[axes.back()] / 2 + 1;
-      ducc0::cfmav<std::complex<double>> m_in(
-          reinterpret_cast<std::complex<double> *>(in), shape_in);
-      ducc0::vfmav<double> m_out(reinterpret_cast<double *>(out), shape);
-      ducc0::c2r(m_in, m_out, axes, false, scale);
-    }
-    break;
-  case internal::FftType::RFFT:
-    // R2C
-    if (!double_precision) {
-      auto shape_out = shape;
-      shape_out[axes.back()] = shape_out[axes.back()] / 2 + 1;
-      ducc0::cfmav<float> m_in(reinterpret_cast<float *>(in), shape);
-      ducc0::vfmav<std::complex<float>> m_out(
-          reinterpret_cast<std::complex<float> *>(out), shape_out);
-      ducc0::r2c(m_in, m_out, axes, true, static_cast<float>(scale));
-    } else {
-      auto shape_out = shape;
-      shape_out[axes.back()] = shape_out[axes.back()] / 2 + 1;
-      ducc0::cfmav<double> m_in(reinterpret_cast<double *>(in), shape);
-      ducc0::vfmav<std::complex<double>> m_out(
-          reinterpret_cast<std::complex<double> *>(out), shape_out);
-      ducc0::r2c(m_in, m_out, axes, true, scale);
-    }
-    break;
-  default:
-    // Unsupported FFT type
-    abort();
-  }
-}
+                 int64_t fft_length0, int64_t fft_length1, int64_t fft_length2);
 
 }  // namespace xla
 

--- a/xla/service/cpu/runtime_fft_impl.h
+++ b/xla/service/cpu/runtime_fft_impl.h
@@ -308,7 +308,6 @@ void DuccFftImpl(void *out, void *in, internal::FftType fft_type,
       // Unsupported FFT rank
       abort();
   }
-  scale = 100.;
 
   switch (fft_type) {
   case internal::FftType::IFFT:

--- a/xla/service/cpu/runtime_single_threaded_fft.cc
+++ b/xla/service/cpu/runtime_single_threaded_fft.cc
@@ -18,12 +18,11 @@ limitations under the License.
 #include "absl/base/dynamic_annotations.h"
 #include "xla/service/cpu/runtime_fft_impl.h"
 
-ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_EigenSingleThreadedFft(
+ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_DuccSingleThreadedFft(
     const void* run_options_ptr, void* out, void* operand, int32_t fft_type,
     int32_t double_precision, int32_t fft_rank, int64_t input_batch,
     int64_t fft_length0, int64_t fft_length1, int64_t fft_length2) {
-  xla::DuccFftImpl(//Eigen::DefaultDevice(), 
-                    out, operand,
+  xla::DuccFftImpl(false, out, operand,
                     static_cast<xla::internal::FftType>(fft_type),
                     static_cast<bool>(double_precision), fft_rank, input_batch,
                     fft_length0, fft_length1, fft_length2);

--- a/xla/service/cpu/runtime_single_threaded_fft.cc
+++ b/xla/service/cpu/runtime_single_threaded_fft.cc
@@ -22,7 +22,8 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_EigenSingleThreadedFft(
     const void* run_options_ptr, void* out, void* operand, int32_t fft_type,
     int32_t double_precision, int32_t fft_rank, int64_t input_batch,
     int64_t fft_length0, int64_t fft_length1, int64_t fft_length2) {
-  xla::EigenFftImpl(Eigen::DefaultDevice(), out, operand,
+  xla::DuccFftImpl(//Eigen::DefaultDevice(), 
+                    out, operand,
                     static_cast<xla::internal::FftType>(fft_type),
                     static_cast<bool>(double_precision), fft_rank, input_batch,
                     fft_length0, fft_length1, fft_length2);

--- a/xla/service/cpu/runtime_single_threaded_fft.h
+++ b/xla/service/cpu/runtime_single_threaded_fft.h
@@ -20,7 +20,7 @@ limitations under the License.
 
 extern "C" {
 
-extern void __xla_cpu_runtime_EigenSingleThreadedFft(
+extern void __xla_cpu_runtime_DuccSingleThreadedFft(
     const void* /* xla::ExecutableRunOptions* */ run_options_ptr, void* out,
     void* operand, int32_t fft_type, int32_t double_precision, int32_t fft_rank,
     int64_t input_batch, int64_t fft_length0, int64_t fft_length1,

--- a/xla/service/cpu/simple_orc_jit.cc
+++ b/xla/service/cpu/simple_orc_jit.cc
@@ -306,7 +306,7 @@ bool RegisterKnownJITSymbols() {
   REGISTER_CPU_RUNTIME_SYMBOL(EigenSingleThreadedConv2DF32);
   REGISTER_CPU_RUNTIME_SYMBOL(EigenSingleThreadedConv3DF16);
   REGISTER_CPU_RUNTIME_SYMBOL(EigenSingleThreadedConv3DF32);
-  REGISTER_CPU_RUNTIME_SYMBOL(EigenSingleThreadedFft);
+  REGISTER_CPU_RUNTIME_SYMBOL(DuccSingleThreadedFft);
   REGISTER_CPU_RUNTIME_SYMBOL(EigenSingleThreadedMatMulF16);
   REGISTER_CPU_RUNTIME_SYMBOL(EigenSingleThreadedMatMulF32);
   REGISTER_CPU_RUNTIME_SYMBOL(EigenSingleThreadedMatMulF64);

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -857,6 +857,24 @@ xla_test(
 )
 
 xla_test(
+    name = "fft_test_single_threaded",
+    srcs = ["fft_test.cc"],
+    backend_args = {
+        "cpu": [
+            "--xla_cpu_multi_thread_eigen=false",
+        ],
+    },
+    deps = [
+        ":hlo_test_base",
+        ":test_macros_header",
+        ":test_utils",
+        ":xla_internal_test_main",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+
+xla_test(
     name = "dot_operation_test",
     srcs = ["dot_operation_test.cc"],
     shard_count = 20,


### PR DESCRIPTION
TODO:
- do we need a benchmark?

Future work:
1. Wrap `Eigen::ThreadPoolDevice` into a [ducc `thread_pool` virtual class](https://github.com/mreineck/ducc/pull/9), enable for multi-threaded. Deprecate `Eigen`-based FFT?

### Related
See: https://github.com/google/jax/issues/14664 for context