### PR TITLE
[ROCM] Enable rocm

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -780,6 +780,8 @@ def system_specific_test_config(environ_cp):
       write_to_bazelrc('test --test_env=LD_LIBRARY_PATH')
     else:
       test_and_build_filters.append('-gpu')
+    if (environ_cp.get('TF_NEED_ROCM', None) == '1'):
+      test_and_build_filters.append('-no_rocm')
 
   write_to_bazelrc('test --test_tag_filters=%s' %
                    ','.join(test_and_build_filters + test_only_filters))

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -196,6 +196,7 @@ def _rocm_include_path(repository_ctx, rocm_config, bash_bin):
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/13.0.0/include")
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/14.0.0/include")
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/15.0.0/include")
+    inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/16.0.0/include")
 
     # Support hcc based off clang 10.0.0 (for ROCm 3.3)
     inc_dirs.append(rocm_toolkit_path + "/hcc/compiler/lib/clang/10.0.0/include/")

--- a/xla/python/BUILD
+++ b/xla/python/BUILD
@@ -15,6 +15,7 @@ load(
     "if_cuda_or_rocm",
 )
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("@tsl//tsl:tsl.default.bzl", "tsl_pybind_extension")
 load("//xla:pytype.default.bzl", "pytype_library")
 
@@ -327,7 +328,8 @@ cc_library(
         "-fexceptions",
         "-fno-strict-aliasing",
     ],
-    defines = if_cuda(["GOOGLE_CUDA=1"]),
+    defines = if_cuda(["GOOGLE_CUDA=1"]) +
+      if_rocm(["TENSORFLOW_USE_ROCM=1"]),
     features = ["-use_header_modules"],
     deps = [
         ":exceptions",
@@ -375,6 +377,9 @@ cc_library(
         "@tsl//tsl/python/lib/core:numpy",
     ] + if_cuda([
         "@local_config_cuda//cuda:cuda_headers",
+    ])
+    + if_rocm([
+        "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
 

--- a/xla/python/py_client_gpu.cc
+++ b/xla/python/py_client_gpu.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include <vector>
 
+#include "tsl/platform/errors.h"
 #include "absl/base/casts.h"
 #include "absl/strings/numbers.h"
 #if TENSORFLOW_USE_ROCM
@@ -28,12 +29,14 @@ limitations under the License.
 #include "xla/python/exceptions.h"
 
 #if TENSORFLOW_USE_ROCM
+#define gpuSuccess hipSuccess
 #define gpuStreamHandle hipStream_t
 #define gpuMemcpyAsync hipMemcpyAsync
 #define gpuStreamSynchronize hipStreamSynchronize
 #define gpuMemcpyDeviceToHost hipMemcpyDeviceToHost
 #define gpuMemcpyHostToDevice hipMemcpyHostToDevice
 #else
+#define gpuSuccess cudaSuccess
 #define gpuStreamHandle CUstream
 #define gpuMemcpyAsync cudaMemcpyAsync
 #define gpuStreamSynchronize cudaStreamSynchronize
@@ -69,10 +72,12 @@ void XlaPythonGpuCallback(gpuStreamHandle stream, void** buffers,
     void* buf = new char[arg.size_in_bytes];
     host_input_buffers[i] = buf;
     // TODO(b/238441608): Use pinned memory here to speed up the transfer.
-    gpuMemcpyAsync(buf, buffers[i], arg.size_in_bytes, gpuMemcpyDeviceToHost,
-                   stream);
+    auto gpu_res = gpuMemcpyAsync(buf, buffers[i], arg.size_in_bytes, gpuMemcpyDeviceToHost,
+                              stream);
+    CHECK_EQ(gpu_res, gpuSuccess) << "Failed to gpuMemcpyAsync";
   }
-  gpuStreamSynchronize(stream);
+  CHECK_EQ(gpuStreamSynchronize(stream), gpuSuccess)
+      << "Failed to gpuStreamSynchronize";
   py::gil_scoped_acquire gil;
   py::tuple host_input_arrays(arity);
   for (size_t i = 0; i < arity; ++i) {
@@ -108,8 +113,9 @@ void XlaPythonGpuCallback(gpuStreamHandle stream, void** buffers,
     absl::Span<int64_t const> strides(
         reinterpret_cast<const int64_t*>(array.strides()), array.ndim());
     if (strides == result.expected_strides) {
-      gpuMemcpyAsync(buffers[arity + i], array.data(), result.size_in_bytes,
-                     gpuMemcpyHostToDevice, stream);
+      auto gpu_res = gpuMemcpyAsync(buffers[arity + i], array.data(), result.size_in_bytes,
+                             gpuMemcpyHostToDevice, stream);
+      CHECK_EQ(gpu_res, gpuSuccess) << "Failed to gpuMemcpyAsync";
     } else {
       void* temp = new char[result.size_in_bytes];
       temp_buffers.push_back(temp);
@@ -122,12 +128,14 @@ void XlaPythonGpuCallback(gpuStreamHandle stream, void** buffers,
         throw xla::XlaRuntimeError(plan.status().ToString());
       }
       plan.value()->Execute(array.data(), temp);
-      gpuMemcpyAsync(buffers[arity + i], temp, result.size_in_bytes,
-                     gpuMemcpyHostToDevice, stream);
+      auto gpu_res = gpuMemcpyAsync(buffers[arity + i], temp, result.size_in_bytes,
+                                gpuMemcpyHostToDevice, stream);
+      CHECK_EQ(gpu_res, gpuSuccess) << "Failed to gpuMemcpyAsync";
     }
   }
   py::gil_scoped_release release;
-  gpuStreamSynchronize(stream);
+  CHECK_EQ(gpuStreamSynchronize(stream), gpuSuccess)
+      << "Failed to gpuStreamSynchronize";
   for (int i = 0; i < temp_buffers.size(); ++i) {
     delete[] static_cast<char*>(temp_buffers[i]);
   }

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -26,6 +26,7 @@ load(
 )
 load("//xla/stream_executor:build_defs.bzl", "if_gpu_is_configured")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("//xla/service:xla_compile.bzl", "xla_aot_compile_cpu", "xla_aot_compile_gpu", "xla_aot_compile_gpu_runtime_autotuning")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
@@ -1281,6 +1282,7 @@ cc_library(
         "//xla/stream_executor",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:device_memory_allocator",
+	"//xla/stream_executor:timer",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
@@ -6968,7 +6970,14 @@ xla_cc_binary(
         "//xla/service/gpu:executable_proto_cc",
         "//xla/service/gpu:gpu_compiler",
         "//xla/service/gpu:nvptx_compiler_impl",
-    ]) + if_cuda(["//xla/stream_executor/cuda:cublas_plugin"]),
+    ])
+    + if_rocm_is_configured([
+        "//xla/service/gpu:executable_proto_cc",
+        "//xla/service/gpu:gpu_compiler",
+        "//xla/service/gpu:amdgpu_compiler_impl",
+    ])
+    + if_cuda(["//xla/stream_executor/cuda:cublas_plugin"])
+    + if_rocm(["//xla/stream_executor/rocm:rocblas_plugin"]),
 )
 
 # A simple test of xla_aot_compile which generates an output file from an mhlo file.

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -237,7 +237,7 @@ cc_library(
 xla_cc_test(
     name = "gpu_device_info_test",
     srcs = if_cuda_is_configured(["gpu_device_info_test.cc"]),
-    tags = tf_cuda_tests_tags(),
+    tags = tf_cuda_tests_tags() + ["no_rocm"],
     deps = if_cuda_is_configured([
         ":gpu_device_info_for_tests",
         "@com_google_absl//absl/strings",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -623,6 +623,7 @@ tsl_gpu_library(
         "//xla/service:collective_ops_utils",
         "//xla/service:global_device_id",
         "//xla/service/llvm_ir:llvm_util",
+        "//xla/stream_executor/gpu:gpu_activation",
         "//xla/stream_executor/gpu:gpu_activation_header",
         "//xla/stream_executor/gpu:gpu_stream",
         "//xla/translate/hlo_to_mhlo:hlo_utils",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3231,6 +3231,7 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_asm_opts",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/gpu:gpu_stream_header",
+        "//xla/stream_executor/rocm:rocm_helpers",
     ]),
 )
 

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -811,7 +811,10 @@ xla_cc_binary(
         "//xla/service/gpu:nvptx_compiler_impl",
         "//xla/stream_executor/cuda:cublas_plugin",
     ]) + if_rocm_is_configured([
+        "@tsl//tsl/platform:rocm_rocdl_path",
         "//xla/service/gpu:amdgpu_compiler_impl",
+        "//xla/stream_executor/rocm:rocblas_plugin",
+        "//xla/stream_executor/rocm:rocm_helpers",
     ]),
 )
 

--- a/xla/service/xla_compile_main.cc
+++ b/xla/service/xla_compile_main.cc
@@ -38,10 +38,14 @@ limitations under the License.
 #include "tsl/platform/protobuf.h"
 #include "tsl/util/command_line_flags.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "xla/service/gpu/executable.pb.h"
 #include "xla/service/gpu/gpu_compiler.h"
+#endif
+#if GOOGLE_CUDA
 #include "xla/service/gpu/nvptx_compiler.h"
+#elif TENSORFLOW_USE_ROCM
+#include "xla/service/gpu/amdgpu_compiler.h"
 #endif
 
 namespace xla {
@@ -68,25 +72,29 @@ StatusOr<std::string> AotCompileCpuExecutable(
   return result;
 }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 StatusOr<std::string> AotCompileGpuExecutable(
     std::unique_ptr<HloModule> hlo_module,
     const gpu::GpuTargetConfig& gpu_target_config,
     const AutotuneResults& autotune_results = AutotuneResults()) {
-  gpu::NVPTXCompiler nvptx_compiler;
+#if GOOGLE_CUDA
+  auto gpu_compiler_ = gpu::NVPTXCompiler();
+#elif TENSORFLOW_USE_ROCM
+  auto gpu_compiler_ = gpu::AMDGPUCompiler();
+#endif
   Compiler::CompileOptions compile_options;
   TF_ASSIGN_OR_RETURN(std::unique_ptr<HloModule> module_after_opt,
-                      nvptx_compiler.RunHloPassesWithoutDevice(
+                      gpu_compiler_.RunHloPassesWithoutDevice(
                           std::move(hlo_module), compile_options,
                           gpu_target_config, autotune_results));
 
   auto module_group =
       std::make_unique<HloModuleGroup>(std::move(module_after_opt));
-  AotCompilationOptions aot_options(nvptx_compiler.PlatformId());
+  AotCompilationOptions aot_options(gpu_compiler_.PlatformId());
   aot_options.set_target_config(gpu_target_config);
   TF_ASSIGN_OR_RETURN(
       std::vector<std::unique_ptr<AotCompilationResult>> aot_results,
-      nvptx_compiler.CompileAheadOfTime(std::move(module_group), aot_options));
+      gpu_compiler_.CompileAheadOfTime(std::move(module_group), aot_options));
   TF_ASSIGN_OR_RETURN(std::string result, aot_results[0]->SerializeAsString());
   return result;
 }
@@ -131,7 +139,7 @@ xla::Status XlaCompileMain(const std::string& module_path,
   std::string result;
   if (platform == "cpu") {
     TF_ASSIGN_OR_RETURN(result, AotCompileCpuExecutable(std::move(hlo_module)));
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   } else if (platform == "gpu") {
     // Parse GpuTargetConfig.
     std::string gpu_target_config_string;

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -146,6 +146,7 @@ tsl_gpu_cc_test(
     srcs = ["cuda_driver_test.cc"],
     tags = tf_cuda_tests_tags() + [
         "no_cuda_asan",  # TODO(b/171512140): re-enable.
+        "no_rocm",
     ],
     deps = [
         ":cuda_driver",

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -267,6 +267,7 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_activation_header",
         "//xla/stream_executor/gpu:gpu_stream_header",
         "//xla/stream_executor/gpu:gpu_timer_header",
+	"//xla/stream_executor/gpu:gpu_types_header",
         "//xla/stream_executor/platform",
         "//xla/stream_executor/platform:dso_loader",
         "@com_google_absl//absl/algorithm:container",

--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -2,6 +2,7 @@ load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
 load("//xla/tests:build_defs.bzl", "xla_test")
 load("@tsl//tsl:tsl.bzl", "if_cuda_or_rocm")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("//xla:xla.bzl", "xla_cc_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
@@ -15,6 +16,7 @@ build_test(
     name = "hlo_runner_main_build_test",
     tags = [
         "gpu",
+        "no_rocm",
     ],
     targets = [
         ":hlo_runner_main",
@@ -45,6 +47,8 @@ xla_cc_binary(
         "//xla/service:gpu_plugin",
     ]) + if_cuda([
         "//xla/stream_executor:cuda_platform",
+    ]) + if_rocm([
+        "//xla/stream_executor:rocm_platform",
     ]),
 )
 

--- a/xla/translate/mhlo_to_lhlo_with_xla/BUILD
+++ b/xla/translate/mhlo_to_lhlo_with_xla/BUILD
@@ -1,6 +1,7 @@
 load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
 load("//xla:xla.bzl", "xla_cc_binary")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 package(
@@ -116,5 +117,6 @@ xla_cc_binary(
         "@llvm-project//mlir:MlirOptLib",
         "@stablehlo//:register",
         "@tsl//tsl/platform:platform_port",
-    ] + if_cuda(["//xla/stream_executor/cuda:cublas_plugin"]),
+    ] + if_cuda(["//xla/stream_executor/cuda:cublas_plugin"])
+      + if_rocm(["//xla/stream_executor/rocm:rocblas_plugin"]),
 )

--- a/xla/xla.bzl
+++ b/xla/xla.bzl
@@ -56,6 +56,8 @@ def xla_cc_binary(deps = None, copts = tsl_copts(), **kwargs):
         "@tsl//tsl/protobuf:autotuning_proto_cc_impl",
         "@tsl//tsl/protobuf:protos_all_cc_impl",
         "@tsl//tsl/protobuf:dnn_proto_cc_impl",
+        "@tsl//tsl/framework:allocator",
+        "@tsl//tsl/framework:allocator_registry_impl",
         "@tsl//tsl/util:determinism",
     ]
     native.cc_binary(deps = deps, copts = copts, **kwargs)


### PR DESCRIPTION
This PR is a collection of fixes and edits needed to get stand alone OpenXLA building out-of-the-box for ROCm.
This set should allow for a proper build against ROCM 5.4.

There is one non-ROCM focused commit here: Handling return codes properly in py_client_gpu