### PR TITLE
Add if_rocm checks to static build targets

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -150,9 +150,17 @@ cc_library(
 cc_library(
     name = "rocblas_if_static",
     deps = if_static([
+        ":rocblas_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "rocblas_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:rocblas",
     ]),
 )
+
 
 cc_library(
     name = "rocblas_wrapper",
@@ -205,6 +213,13 @@ cc_library(
 cc_library(
     name = "hipfft_if_static",
     deps = if_static([
+        ":hipfft_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "hipfft_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:hipfft",
     ]),
 )
@@ -237,6 +252,13 @@ cc_library(
 cc_library(
     name = "miopen_if_static",
     deps = if_static([
+        ":miopen_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "miopen_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:miopen",
     ]),
 )
@@ -283,6 +305,13 @@ cc_library(
 cc_library(
     name = "hiprand_if_static",
     deps = if_static([
+        ":hiprand_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "hiprand_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:hiprand",
     ]),
 )
@@ -314,6 +343,13 @@ cc_library(
 cc_library(
     name = "hipsparse_if_static",
     deps = if_static([
+        ":hipsparse_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "hipsparse_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:hipsparse",
     ]),
 )
@@ -337,9 +373,17 @@ cc_library(
 cc_library(
     name = "rocsolver_if_static",
     deps = if_static([
+        ":rocsolver_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "rocsolver_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:rocsolver",
     ]),
 )
+
 
 cc_library(
     name = "rocsolver_wrapper",
@@ -360,6 +404,13 @@ cc_library(
 cc_library(
     name = "hipsolver_if_static",
     deps = if_static([
+        ":hipsolver_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "hipsolver_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:hipsolver",
     ]),
 )
@@ -383,6 +434,13 @@ cc_library(
 cc_library(
     name = "roctracer_if_static",
     deps = if_static([
+        ":roctracer_if_rocm_configured",
+    ]),
+)
+
+cc_library(
+    name = "roctracer_if_rocm_configured",
+    deps = if_rocm_is_configured([
         "@local_config_rocm//rocm:roctracer",
     ]),
 )


### PR DESCRIPTION
Some targets were gated on static configuration but not rocm configuration like all other targets in the file.