### PR TITLE
Switch to use compiler param file for msvc

### DIFF
--- a/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
@@ -599,6 +599,7 @@ def _features(cpu, compiler, ctx):
         ]
     elif cpu == "x64_windows":
         return [
+            feature(name = "compiler_param_file"),
             feature(name = "no_legacy_features"),
             feature(
                 name = "common_flags",
@@ -623,12 +624,6 @@ def _features(cpu, compiler, ctx):
                     flag_set(
                         actions = all_compile_actions(),
                         flag_groups = [
-                            flag_group(
-                                flags = [
-                                    "-B",
-                                    "external/local_config_cuda/crosstool/windows/msvc_wrapper_for_nvcc.py",
-                                ],
-                            ),
                             _nologo(),
                             flag_group(
                                 flags = [

--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -193,7 +193,30 @@ def InvokeNvcc(argv, log=False):
   proc.wait()
   return proc.returncode
 
+def ExpandParamsFileForArgv():
+  new_argv = []
+  for arg in sys.argv:
+    if arg.startswith("@"):
+      with open(arg.strip("@")) as f:
+        new_argv.extend([l.strip() for l in f.readlines()])
+    else:
+      new_argv.append(arg)
+
+  sys.argv = new_argv
+
+def ProcessFlagForCommandFile(flag):
+  if flag.startswith("/D") or flag.startswith("-D"):
+    # We need to re-escape /DFOO="BAR" as /DFOO=\"BAR\", so that we get
+    # `#define FOO "BAR"` after expansion as a string literal define
+    if flag.endswith('"') and not flag.endswith('\\"'):
+      flag = '\\"'.join(flag.split('"', 1))
+      flag = '\\"'.join(flag.rsplit('"', 1))
+      return flag
+  return flag
+
+
 def main():
+  ExpandParamsFileForArgv()
   parser = ArgumentParser()
   parser.add_argument('-x', nargs=1)
   parser.add_argument('--cuda_log', action='store_true')
@@ -213,7 +236,18 @@ def main():
                              if not flag.startswith(('--cuda_log'))
                              and not flag.startswith(('-nvcc_options'))]
 
-  return subprocess.call([CPU_COMPILER] + cpu_compiler_flags)
+  output = [flag for flag in cpu_compiler_flags if flag.startswith("/Fo")]
+
+  # Store command line options in a file to avoid hitting the character limit.
+  if len(output) == 1:
+    commandfile_path = output[0][3:] + ".msvc_params"
+    commandfile = open(commandfile_path, "w")
+    cpu_compiler_flags = [ProcessFlagForCommandFile(flag) for flag in cpu_compiler_flags]
+    commandfile.write("\n".join(cpu_compiler_flags))
+    commandfile.close()
+    return subprocess.call([CPU_COMPILER, "@" + commandfile_path])
+  else:
+    return subprocess.call([CPU_COMPILER] + cpu_compiler_flags)
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -168,7 +168,7 @@ def _get_win_cuda_defines(repository_ctx):
         ),
     )
 
-    msvc_cl_path = get_python_bin(repository_ctx)
+    msvc_cl_path = "windows/msvc_wrapper_for_nvcc.bat"
     msvc_ml_path = find_msvc_tool(repository_ctx, vc_path, "ml64.exe").replace(
         "\\",
         "/",
@@ -1300,6 +1300,11 @@ def _create_local_cuda_repository(repository_ctx):
             "crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc",
             tpl_paths["crosstool:clang/bin/crosstool_wrapper_driver_is_not_gcc"],
             wrapper_defines,
+        )
+        repository_ctx.file(
+            "crosstool/windows/msvc_wrapper_for_nvcc.bat",
+            content = "@echo OFF\n{} -B external/local_config_cuda/crosstool/windows/msvc_wrapper_for_nvcc.py %*".format(
+                get_python_bin(repository_ctx))
         )
         repository_ctx.template(
             "crosstool/windows/msvc_wrapper_for_nvcc.py",

--- a/third_party/tsl/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
+++ b/third_party/tsl/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
@@ -599,6 +599,7 @@ def _features(cpu, compiler, ctx):
         ]
     elif cpu == "x64_windows":
         return [
+            feature(name = "compiler_param_file"),
             feature(name = "no_legacy_features"),
             feature(
                 name = "common_flags",
@@ -623,12 +624,6 @@ def _features(cpu, compiler, ctx):
                     flag_set(
                         actions = all_compile_actions(),
                         flag_groups = [
-                            flag_group(
-                                flags = [
-                                    "-B",
-                                    "external/local_config_cuda/crosstool/windows/msvc_wrapper_for_nvcc.py",
-                                ],
-                            ),
                             _nologo(),
                             flag_group(
                                 flags = [

--- a/third_party/tsl/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/tsl/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -193,6 +193,16 @@ def InvokeNvcc(argv, log=False):
   proc.wait()
   return proc.returncode
 
+def ExpandParamsFileForArgv():
+  new_argv = []
+  for arg in sys.argv:
+    if arg.startswith("@"):
+      with open(arg.strip("@")) as f:
+        new_argv.extend([l.strip() for l in f.readlines()])
+    else:
+      new_argv.append(arg)
+
+  sys.argv = new_argv
 
 def ProcessFlagForCommandFile(flag):
   if flag.startswith("/D") or flag.startswith("-D"):
@@ -206,6 +216,7 @@ def ProcessFlagForCommandFile(flag):
 
 
 def main():
+  ExpandParamsFileForArgv()
   parser = ArgumentParser()
   parser.add_argument('-x', nargs=1)
   parser.add_argument('--cuda_log', action='store_true')

--- a/third_party/tsl/third_party/gpus/cuda_configure.bzl
+++ b/third_party/tsl/third_party/gpus/cuda_configure.bzl
@@ -168,7 +168,7 @@ def _get_win_cuda_defines(repository_ctx):
         ),
     )
 
-    msvc_cl_path = get_python_bin(repository_ctx)
+    msvc_cl_path = "windows/msvc_wrapper_for_nvcc.bat"
     msvc_ml_path = find_msvc_tool(repository_ctx, vc_path, "ml64.exe").replace(
         "\\",
         "/",
@@ -1300,6 +1300,11 @@ def _create_local_cuda_repository(repository_ctx):
             "crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc",
             tpl_paths["crosstool:clang/bin/crosstool_wrapper_driver_is_not_gcc"],
             wrapper_defines,
+        )
+        repository_ctx.file(
+            "crosstool/windows/msvc_wrapper_for_nvcc.bat",
+            content = "@echo OFF\n{} -B external/local_config_cuda/crosstool/windows/msvc_wrapper_for_nvcc.py %*".format(
+                get_python_bin(repository_ctx))
         )
         repository_ctx.template(
             "crosstool/windows/msvc_wrapper_for_nvcc.py",


### PR DESCRIPTION
These changes make the nvcc wrapper for msvc to fully support command file for msvc.

Previously, multiple `command is longer than CreateProcessW's limit (32767 characters)` errors pop up here and there due to the excessive `_virtual_includes` introduced by mlir.

This makes
1. the wrapper to accept a params file, that is, `<wrapper.bat> <params_file>
2. the wrapper to generate filtered params file (command file as of msvc if you want to search it) for the successive msvc invocation, `<params_file> -->filter--> <msvc_param_file>`), that is in `<wrapper.py>`, we call `Popen(<msvc>, <msvc_param_file>)`