### PR TITLE
Add dlfcn-win32 as dep

### DIFF
--- a/third_party/triton/BUILD.dlfcn-win32
+++ b/third_party/triton/BUILD.dlfcn-win32
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "dlfcn-win32",
+    hdrs = ["dlfcn.h"],
+    srcs = ["dlfcn.c"],
+)

--- a/third_party/triton/workspace.bzl
+++ b/third_party/triton/workspace.bzl
@@ -5,6 +5,14 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 def repo():
     """Imports Triton."""
 
+    tf_http_archive(
+        name = "dlfcn-win32",
+        build_file = "@xla//third_party/triton:BUILD.dlfcn-win32",
+        sha256 = "4f611c4372eef7f0179a33f76f84d54857c4fe676b60b654c6c5d91a6d4dad55",
+        strip_prefix = "dlfcn-win32-1.3.1/src",
+        urls = tf_mirror_urls("https://github.com/dlfcn-win32/dlfcn-win32/archive/refs/tags/v1.3.1.zip"),
+    )
+
     TRITON_COMMIT = "1627e0c27869b4098e5fa720717645c1baaf5972"
     TRITON_SHA256 = "574436dab7c65f185834bd80c1d92167bacb7471b0c25906db60686835c46e21"
 


### PR DESCRIPTION
Introduce [dlfcn-win32](https://github.com/dlfcn-win32/dlfcn-win32) as a dependency for triton. It is also used for windows build in upstream openai/triton.