### PR TITLE
[ROCm] add AMD devices info for MI210, MI100 and MI50/60

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -248,21 +248,25 @@ cc_library(
 
 xla_cc_test(
     name = "gpu_device_info_test",
-    srcs = if_cuda_is_configured(["gpu_device_info_test.cc"]),
-    tags = tf_cuda_tests_tags() + ["no_rocm"],
-    deps = if_cuda_is_configured([
+    srcs = ["gpu_device_info_test.cc"],
+    tags = tf_cuda_tests_tags(),
+    deps = [
         ":gpu_device_info",
         ":gpu_device_info_for_tests",
         "@com_google_absl//absl/strings",
-        "@local_config_cuda//cuda:cuda_headers",
+        "@tsl//tsl/platform:test",       
+        "//xla/tests:xla_internal_test_main",         
         "//xla/service:pattern_matcher_gmock",
+        "//xla/stream_executor",        
         "//xla/stream_executor/gpu:gpu_executor_header",
-        "//xla/stream_executor",
-        "//xla/stream_executor:device_description",
+        "//xla/stream_executor:device_description",        
+        ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
         "//xla/stream_executor/cuda:cuda_gpu_executor_header",
-        "//xla/tests:xla_internal_test_main",
-        "@tsl//tsl/platform:test",
-    ]),
+        ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+        "//xla/stream_executor/rocm:rocm_gpu_executor_header",
+        ]),
 )
 
 cc_library(

--- a/xla/service/gpu/gpu_device_info_for_tests.cc
+++ b/xla/service/gpu/gpu_device_info_for_tests.cc
@@ -41,5 +41,28 @@ GpuDeviceInfo TestGpuDeviceInfo::RTXA6000DeviceInfo() {
   return info;
 }
 
+
+GpuDeviceInfo TestGpuDeviceInfo::AMDMI210DeviceInfo() {
+  GpuDeviceInfo info;
+  info.name = "AMD Instinct MI210";
+  info.threads_per_block_limit = 1024;
+  info.threads_per_warp = 64;
+  info.shared_memory_per_block = 64 * 1024;
+  info.shared_memory_per_block_optin = 0;
+  info.shared_memory_per_core = 64 * 1024;
+  info.threads_per_core_limit = 2048;
+  info.core_count = 104;
+  info.fpus_per_core = 0;
+  info.block_dim_limit_x = 2'147'483'647;
+  info.block_dim_limit_y = 2'147'483'647;
+  info.block_dim_limit_z = 2'147'483'647;
+  info.memory_bandwidth = 1'638'400'000'000; 
+  info.l2_cache_size = 8 * 1024 * 1024;
+  info.clock_rate_ghz = 1.7;
+  info.device_memory_size = 67'628'957'696;
+  return info;
+}
+
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/gpu_device_info_for_tests.h
+++ b/xla/service/gpu/gpu_device_info_for_tests.h
@@ -24,6 +24,7 @@ namespace gpu {
 class TestGpuDeviceInfo {
  public:
   static GpuDeviceInfo RTXA6000DeviceInfo();
+  static GpuDeviceInfo AMDMI210DeviceInfo();
 };
 
 }  // namespace gpu

--- a/xla/service/gpu/gpu_device_info_test.cc
+++ b/xla/service/gpu/gpu_device_info_test.cc
@@ -20,6 +20,10 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_executor.h"
 #include "tsl/platform/test.h"
 
+#if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif
+
 namespace stream_executor {
 namespace gpu {
 namespace {
@@ -27,8 +31,12 @@ namespace {
 namespace se = stream_executor;
 
 TEST(DeviceInfoTest, DeviceInfoIsCorrect) {
-  se::Platform* platform =
-      se::MultiPlatformManager::PlatformWithName("cuda").value();
+  string test_platform = "cuda";
+#if TENSORFLOW_USE_ROCM 
+  test_platform = "rocm";
+#endif  
+  se::Platform* platform = 
+      se::MultiPlatformManager::PlatformWithName(test_platform).value();
   se::StreamExecutor* executor = platform->ExecutorForDevice(0).value();
   const xla::gpu::GpuDeviceInfo dev_info = xla::gpu::GetGpuDeviceInfo(executor);
   absl::string_view name(dev_info.name);
@@ -82,9 +90,61 @@ TEST(DeviceInfoTest, DeviceInfoIsCorrect) {
                              /*l2_cache_size=*/4 * 1024 * 1024,
                              /*clock_rate_ghz=*/::testing::Ge(1.4),
                              /*device_memory_size=*/17'066'622'976));
-  } else {
-    VLOG(1) << "Not tested for " << name;
+  } 
+#if TF_ROCM_VERSION >= 50500
+  else if (name == "AMD Instinct MI210") {
+    xla::gpu::GpuDeviceInfo test_info =
+        xla::gpu::TestGpuDeviceInfo::AMDMI210DeviceInfo();
+    EXPECT_THAT(
+            dev_info,
+            ::testing::FieldsAre(
+                test_info.name, test_info.threads_per_block_limit,
+                test_info.threads_per_warp, test_info.shared_memory_per_block,
+                test_info.shared_memory_per_block_optin,
+                test_info.shared_memory_per_core, test_info.threads_per_core_limit,
+                test_info.core_count, test_info.fpus_per_core,
+                test_info.block_dim_limit_x, test_info.block_dim_limit_y,
+                test_info.block_dim_limit_z, test_info.memory_bandwidth,
+                test_info.l2_cache_size,
+                ::testing::Ge(test_info.clock_rate_ghz),
+                dev_info.device_memory_size));
   }
+  else if (name == "AMD Instinct MI100"){
+    EXPECT_THAT(
+            dev_info,
+            ::testing::FieldsAre(name, /*threads_per_block_limit=*/1024,
+            /*threads_per_warp=*/64, /*shared_memory_per_block=*/64 * 1024,
+            /*shared_memory_per_block_optin=*/0, 
+            /*shared_memory_per_core=*/64 * 1024,
+            /*threads_per_core_limit=*/2560, /*core_count=*/120, 
+            /*fpus_per_core=*/0, /*block_dim_limit_x=*/2'147'483'647,
+            /*block_dim_limit_y=*/2'147'483'647,
+            /*block_dim_limit_z=*/2'147'483'647,
+            /*memory_bandwidth=*/1228800000000, 
+            /*l2_cache_size=*/8 * 1024 * 1024,
+            /*clock_rate_ghz=*/::testing::Ge(1.5),
+            /*device_memory_size=*/33'806'090'240));
+  }  
+  else if (name == "AMD Instinct M100"){
+    EXPECT_THAT(
+            dev_info,
+            ::testing::FieldsAre(name, /*threads_per_block_limit=*/1024,
+            /*threads_per_warp=*/64, /*shared_memory_per_block=*/64 * 1024,
+            /*shared_memory_per_block_optin=*/0,
+            /*shared_memory_per_core=*/64 * 1024,
+            /*threads_per_core_limit=*/2560, /*core_count=*/60,
+            /*fpus_per_core=*/0, /*block_dim_limit_x=*/2'147'483'647,
+            /*block_dim_limit_y=*/2'147'483'647,
+            /*block_dim_limit_z=*/2'147'483'647,
+            /*memory_bandwidth=*/256000000000,
+            /*l2_cache_size=*/8 * 1024 * 1024,
+            /*clock_rate_ghz=*/::testing::Ge(1.7),
+            /*device_memory_size=*/17'163'091'968));
+  }  
+#endif // TF_ROCM_VERSION >= 50500
+  else {
+    VLOG(1) << "Not tested for " << name;
+  }    
 }
 
 }  // namespace

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -85,6 +85,7 @@ cc_library(
 cc_library(
     name = "rocm_gpu_executor",
     srcs = if_rocm_is_configured(["rocm_gpu_executor.cc"]),
+    hdrs = if_rocm_is_configured(["rocm_gpu_executor.h"]),
     deps = if_rocm_is_configured([
         ":rocm_diagnostics",
         ":rocm_driver",
@@ -109,6 +110,19 @@ cc_library(
     ]),
     alwayslink = True,
 )
+
+cc_library(
+    name = "rocm_gpu_executor_header",
+    textual_hdrs = if_rocm_is_configured(["rocm_gpu_executor.h"]),
+    visibility = ["//visibility:public"],
+    deps = if_rocm_is_configured([
+        ":rocm_kernel",
+        "//xla/stream_executor:event",
+        "//xla/stream_executor/gpu:gpu_executor_header",
+        "//xla/stream_executor/platform",
+    ]),
+)
+
 
 cc_library(
     name = "rocm_kernel",

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -915,6 +915,8 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
     int64_t memory_bandwidth = 2 * (int64_t(prop.memoryBusWidth) / 8) *
                                (int64_t(prop.memoryClockRate) * 1000);
     builder.set_memory_bandwidth(memory_bandwidth);
+
+    builder.set_l2_cache_size(prop.l2CacheSize);
   }
 
   {

--- a/xla/stream_executor/rocm/rocm_gpu_executor.h
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.h
@@ -1,0 +1,35 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// The ROCm implementation of the StreamExecutorInterface functionality.
+// ROCm inclusions are ideally confined to this implementation file.
+//
+// The notions from the StreamExecutor basically correspond to the ROCm streams
+// programming model provided by the librocm.so driver APIs, so we don't have
+// to do much more than wrap the calls to the libraries appropriately.
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_GPU_EXECUTOR_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_GPU_EXECUTOR_H_
+
+#include "xla/stream_executor/gpu/gpu_executor.h"
+
+namespace stream_executor {
+namespace rocm {
+
+using ROCMExecutor = gpu::GpuExecutor;
+
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_GPU_EXECUTOR_H_


### PR DESCRIPTION
This PR brings back gpu_device_info_test  for ROCm and add AMD gpu device info on MI210, MI100 and MI50/60

Thanks