### PR TITLE
[ROCm] fixed redefine stream priority

### DIFF
--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -1408,10 +1408,5 @@ static tsl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   return max_blocks;
 }
 
-/* static */ int GpuDriver::GetGpuStreamPriority(
-    GpuContext* context, stream_executor::StreamPriority stream_priority) {
-  return 0;
-}
-
 }  // namespace gpu
 }  // namespace stream_executor


### PR DESCRIPTION
This following new merged PR has broken ROCm build as we already have implemented stream priority (https://github.com/openxla/xla/pull/3483) recently.

https://github.com/openxla/xla/commit/357c9d3753ff43090ec3ae08444f5a53e75cf563#diff-3f21301ab0bb47f6adc6ea9a97ab53e68ff45a3f7b2af3fe4d6f7038b7419ea3R1411-R1415

Thanks in advance!

@akuegel @ddunl