### PR TITLE
Better error and a small doc fix

### DIFF
--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -2844,10 +2844,16 @@ Status HloInstruction::ReplaceAllUsesWithDifferentShape(
   return OkStatus();
 }
 
-Status HloInstruction::ReplaceAllUsesWith(HloInstruction* new_producer) {
+Status HloInstruction::ReplaceAllUsesWith(HloInstruction* new_producer, absl::string_view trigger) {
+  auto print_options = HloPrintOptions::ShortParsable()
+    .set_print_operand_shape(true)
+    .set_print_extra_attributes(false);
   TF_RET_CHECK(
-      ShapeUtil::CompatibleIgnoringFpPrecision(shape(), new_producer->shape()))
-      << shape() << " is not compatible with " << new_producer->shape();
+    ShapeUtil::CompatibleIgnoringFpPrecision(shape(), new_producer->shape()))
+    << "The shape doesn't match when replacing '" << ToString(print_options)
+    << "' with '" << new_producer->ToString(print_options) << "'. " << shape()
+    << " is not compatible with " << new_producer->shape() << "\n '" << trigger
+    << "' triggered this wrong replacement.";
   return ReplaceAllUsesWithDifferentShape(new_producer);
 }
 

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -1420,7 +1420,11 @@ class HloInstruction {
   //
   // If a user is a fusion instruction, this function will remove any duplicated
   // operands of it which could be created due to this replacement.
-  Status ReplaceAllUsesWith(HloInstruction* new_producer);
+  //
+  // trigger is a string used in the error message if the new and the
+  // current instruction don't have a compatible shape.
+  Status ReplaceAllUsesWith(HloInstruction* new_producer,
+			    absl::string_view trigger = "");
 
   // Same as ReplaceAllUsesWith, but new_producer can have a different shape.
   Status ReplaceAllUsesWithDifferentShape(HloInstruction* new_producer);

--- a/xla/service/sharding_remover.cc
+++ b/xla/service/sharding_remover.cc
@@ -53,7 +53,7 @@ StatusOr<bool> ShardingRemover::Run(
       CHECK(instruction->operand_count() == 1)
           << "Sharding instruction must have exactly one operand";
       TF_RETURN_IF_ERROR(
-          instruction->ReplaceAllUsesWith(instruction->mutable_operand(0)));
+          instruction->ReplaceAllUsesWith(instruction->mutable_operand(0), name()));
       changed = true;
     }
   }

--- a/xla/tools/multihost_hlo_runner/README.md
+++ b/xla/tools/multihost_hlo_runner/README.md
@@ -17,7 +17,7 @@ If we have enough GPUs, we can replay these HLOs like this:
 
 ```
 bazel run -c opt --config=cuda --dynamic_mode=off \
-  //tensorflow/compiler/xla/tools/multihost_hlo_runner:hlo_runner_main \
+  //xla/tools/multihost_hlo_runner:hlo_runner_main \
   -- --device_type=gpu --use_spmd_partitioning=true \
   --num_partitions=2 --num_replicas=1 \
   --hlo_file=my-hlo.txt


### PR DESCRIPTION
If I try to use run_hlo_module with a module that is multi-GPU. The error message doesn't give any hint of the issue.

The way I implemented it, it prevent testing the shapes twice.
If you prefer to not extend the API, we could do it while duplicating the check. This would also allows a better error message, but I'm not sure it is worth it.

@cheshire 