### PR TITLE
Update cudnn frontend version in workspace2.bazl to 0.9

### DIFF
--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -32,9 +32,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "bfcf778030831f325cfc13ae5995388cc834fbff2995a297ba580d9ec65ca3b6",
-        strip_prefix = "cudnn-frontend-0.8",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.8.zip"),
+        sha256 = "d8dba9e2607a0c256aa8eacb45b39986ab6f3f24a4d431d4397047a3cb0cd4fb",
+        strip_prefix = "cudnn-frontend-0.9",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.9.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
Following up on this [pr](https://github.com/openxla/xla/commit/190fb8651c27cefdd40be5ce1123c4c20b92451a) which updated patch files to support cudnn fronetend 0.9, we need to upgrade frontend library to use 0.9 archive in openxla.