### PR TITLE
[NVIDIA XLA:GPU] Introducing training support for cudnn fused mha (stream executor, 1st out of 3)

### DIFF
--- a/third_party/tsl/tsl/protobuf/dnn.proto
+++ b/third_party/tsl/tsl/protobuf/dnn.proto
@@ -21,6 +21,7 @@ enum DataType {
   kF8E4M3FN = 9;
   kF8E5M2FNUZ = 10;
   kF8E4M3FNUZ = 11;
+  kInt64 = 12;
 }
 
 // Describes how a convolution input or output layer's data is formatted.

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -22,13 +22,17 @@ limitations under the License.
 #include <string>
 #include <utility>
 
+#include "Eigen/Core"  // from @eigen_archive
 #include "absl/base/optimization.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "Eigen/Core"  // from @eigen_archive
+#include "tsl/cuda/cudnn_version.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/tensor_float_32_utils.h"
+#include "tsl/util/env_var.h"
 #include "xla/stream_executor/cuda/cuda_activation.h"
 #include "xla/stream_executor/cuda/cuda_diagnostics.h"
 #include "xla/stream_executor/cuda/cuda_driver.h"
@@ -45,10 +49,6 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor_internal.h"
 #include "xla/stream_executor/stream_executor_pimpl.h"
-#include "tsl/cuda/cudnn_version.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/tensor_float_32_utils.h"
-#include "tsl/util/env_var.h"
 
 // clang-format off
 #include "third_party/gpus/cudnn/cudnn.h"
@@ -1124,6 +1124,8 @@ cudnnDataType_t ToCudnnDataType(
       }
     case dnn::DataType::kInt32:
       return CUDNN_DATA_INT32;
+    case dnn::DataType::kInt64:
+      return CUDNN_DATA_INT64;
 #if CUDNN_VERSION >= 8200
     case dnn::DataType::kBF16:
       return CUDNN_DATA_BFLOAT16;
@@ -3437,6 +3439,10 @@ dnn::DataType GetConvAccumulatorType(dnn::DataType data_type) {
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 
 namespace {
+static bool allowAllConfig(cudnnBackendDescriptor_t engine_config) {
+  (void)engine_config;
+  return false;
+}
 
 cudnnBackendDescriptorType_t GetCudnnConvolutionType(
     dnn::ConvolutionKind kind) {
@@ -3552,11 +3558,91 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
 #endif
 
 #if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+enum CudnnfMHAUid {
+  Q_ID = 400,
+  K_ID,
+  V_ID,
+  P_ID,
+  O_ID,
+  dQ_ID,
+  dK_ID,
+  dV_ID,
+  dP_ID,
+  dO_ID,
+  dS_ID,
+  dBIAS_ID,
+  BIAS_ID,
+  MASK_ID,
+  ZERO_VAL_ID,
+  ONE_VAL_ID,
+  ALPHA_SCALE_ID,
+  DROPOUT_SCALE_ID,
+  Q_SEQLEN_ID,
+  K_SEQLEN_ID,
+  D_OFFSET_ID,
+  D_SEED_ID,
+  VIRTUAL_ID = 34857
+};
+
+tsl::StatusOr<cudnn_frontend::PointWiseDesc> CreatePwDesc(
+    dnn::DataType dtype, cudnnPointwiseMode_t mode) {
+  auto pw_desc_created = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(mode)
+                             .setComputeType(ToCudnnDataType(dtype))
+                             .build();
+  RETURN_MSG_IF_CUDNN_ERROR(pw_desc_created);
+  return pw_desc_created;
+}
+
+tsl::StatusOr<cudnn_frontend::Operation> CreateUnaryPwOp(
+    cudnn_frontend::Tensor const& xDesc, cudnn_frontend::Tensor const& yDesc,
+    cudnn_frontend::PointWiseDesc const& pwDesc) {
+  auto pw_op_created = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(xDesc)
+                           .setyDesc(yDesc)
+                           .setpwDesc(pwDesc)
+                           .build();
+  RETURN_MSG_IF_CUDNN_ERROR(pw_op_created);
+  return pw_op_created;
+}
+
+tsl::StatusOr<cudnn_frontend::Operation> CreateBinaryPwOp(
+    cudnn_frontend::Tensor const& xDesc, cudnn_frontend::Tensor const& bDesc,
+    cudnn_frontend::Tensor const& yDesc,
+    cudnn_frontend::PointWiseDesc const& pwDesc) {
+  auto pw_op_created = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(xDesc)
+                           .setbDesc(bDesc)
+                           .setyDesc(yDesc)
+                           .setpwDesc(pwDesc)
+                           .build();
+  RETURN_MSG_IF_CUDNN_ERROR(pw_op_created);
+  return pw_op_created;
+}
+
+tsl::StatusOr<cudnn_frontend::Operation> CreateTernaryPwOp(
+    cudnn_frontend::Tensor const& xDesc, cudnn_frontend::Tensor const& bDesc,
+    cudnn_frontend::Tensor const& tDesc, cudnn_frontend::Tensor const& yDesc,
+    cudnn_frontend::PointWiseDesc const& pwDesc) {
+  auto pw_op_created = cudnn_frontend::OperationBuilder(
+                           CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(xDesc)
+                           .setbDesc(bDesc)
+                           .settDesc(tDesc)
+                           .setyDesc(yDesc)
+                           .setpwDesc(pwDesc)
+                           .build();
+  RETURN_MSG_IF_CUDNN_ERROR(pw_op_created);
+  return pw_op_created;
+}
+
 // Returns a cudnn tensor that's the output of the mask op
 tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnMaskTensor(
     std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
     absl::Span<const int64_t> strides, dnn::DataType dtype,
-    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, double scale) {
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor) {
   std::vector<int64_t> mask_dim(dims.size(), 1);
   std::vector<int64_t> mask_stride(strides.size(), 1);
 
@@ -3589,7 +3675,6 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnMaskTensor(
                      CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                      .setxDesc((*input_tensor))
                      .setbDesc(mask_tensor)
-                     .setAlpha(scale)
                      .setyDesc(mask_out_tensor)
                      .setpwDesc(mask_desc)
                      .build();
@@ -3603,12 +3688,41 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnMaskTensor(
   return mask_out_tensor;
 }
 
+// Returns a cudnn tensor that's the output of the alpha scale
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnScaleTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor) {
+  std::vector<int64_t> scale_dims(dims.size(), 1);
+  std::vector<int64_t> scale_strides(strides.size(), 1);
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_alpha_scale,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, CudnnfMHAUid::ALPHA_SCALE_ID, dtype, 1, -1,
+          /* is_virtual */ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
+  TF_ASSIGN_OR_RETURN(auto scale_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
+  TF_ASSIGN_OR_RETURN(auto tensor_alpha_scale_out,
+                      CreateCudnnTensor(dims, strides, VIRTUAL_ID + 600, dtype,
+                                        1, -1, /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(auto scale_op,
+                      CreateBinaryPwOp((*input_tensor), tensor_alpha_scale,
+                                       tensor_alpha_scale_out, scale_desc));
+  // Add scale to op list
+  ops.push_back(std::move(scale_op));
+
+  return tensor_alpha_scale_out;
+}
+
 // Returns a cudnn tensor that's the output of the bias addition op
 tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnBiasTensor(
     std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
     absl::Span<const int64_t> strides, dnn::DataType dtype,
-    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, double alpha_scale,
-    bool use_mask) {
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, bool use_mask) {
   // Create the bias tensor.
   TF_ASSIGN_OR_RETURN(auto bias_tensor,
                       CreateCudnnTensor(dims, strides, 'B', dtype, 1, -1));
@@ -3631,7 +3745,6 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnBiasTensor(
                      .setxDesc((*input_tensor))
                      .setbDesc(bias_tensor)
                      .setyDesc(bias_out_tensor)
-                     .setAlpha(alpha_scale)
                      .setpwDesc(bias_desc)
                      .build();
 
@@ -3648,7 +3761,7 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnBiasTensor(
 tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnSoftmaxFwdTensor(
     std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
     absl::Span<const int64_t> strides, dnn::DataType dtype,
-    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, bool use_dropout,
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor,
     bool is_virtual = false) {
   // softmax's typical computation is:
   // exp(input - reduce_max(input)) / reduce_sum(exp(input - reduce_max(input)))
@@ -3750,18 +3863,12 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnSoftmaxFwdTensor(
   RETURN_MSG_IF_CUDNN_ERROR(sum_reduction_op);
 
   // Create output tensor of the divide op.
-  // cudnnBackendTensorReordering_t tensor_ordering =
-  //     use_dropout ? CUDNN_TENSOR_REORDERING_F16x16
-  //                 : CUDNN_TENSOR_REORDERING_NONE;
-  cudnnBackendTensorReordering_t tensor_ordering = CUDNN_TENSOR_REORDERING_NONE;
-  if (use_dropout) {
-    tensor_ordering = CUDNN_TENSOR_REORDERING_F16x16;
-  }
   TF_ASSIGN_OR_RETURN(
       auto divide_output_tensor,
-      CreateCudnnTensor(dims, strides, 'd', dtype, 1, -1,
-                        /*is_virtual*/ is_virtual,
-                        /*cudnn_tensor_order_type*/ tensor_ordering));
+      CreateCudnnTensor(
+          dims, strides, 'd', dtype, 1, -1,
+          /*is_virtual*/ is_virtual,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_F16x16));
   // Create the divide descriptor
   auto divide_desc = cudnn_frontend::PointWiseDescBuilder()
                          .setMode(CUDNN_POINTWISE_DIV)
@@ -3799,7 +3906,11 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnDropoutTensor(
     std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
     absl::Span<const int64_t> strides, dnn::DataType dtype,
     std::shared_ptr<cudnn_frontend::Tensor> input_tensor, double dropout_rate,
-    int64_t seed) {
+    int64_t seed, bool is_virtual = false) {
+  // Create scale tensor
+  std::vector<int64_t> scale_dims(dims.size(), 1);
+  std::vector<int64_t> scale_strides(strides.size(), 1);
+
   // Create tensor for dropout's mask.
   TF_ASSIGN_OR_RETURN(
       auto mask_tensor,
@@ -3809,9 +3920,28 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnDropoutTensor(
   TF_ASSIGN_OR_RETURN(
       auto dropout_out_tensor,
       CreateCudnnTensor(
-          dims, strides, 'D', dtype, 1, -1, /*is_virtual*/ true,
+          dims, strides, 'D', dtype, 1, -1, /*is_virtual*/ is_virtual,
           /*cudnn_tensor_order_type*/
           cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16));
+  // Create offset tensor of dropout node
+  TF_ASSIGN_OR_RETURN(
+      auto dropout_offset_tensor,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, CudnnfMHAUid::D_OFFSET_ID,
+          dnn::DataType::kInt64, 1, -1, /*is_virtual*/ false,
+          /*cudnn_tensor_order_type*/
+          cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
+
+  // Create seed tensor of dropout node
+  TF_ASSIGN_OR_RETURN(
+      auto dropout_seed_tensor,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, CudnnfMHAUid::D_SEED_ID,
+          dnn::DataType::kInt64, 1, -1, /*is_virtual*/ false,
+          /*cudnn_tensor_order_type*/
+          cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
 
   // Create description for rng node
   auto rng_desc = cudnn_frontend::RngDescBuilder()
@@ -3822,7 +3952,8 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnDropoutTensor(
   auto rng_op =
       cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
           .setyDesc(mask_tensor)
-          .setSeed(seed)
+          .setSeedDesc(dropout_seed_tensor)
+          .setOffsetDesc(dropout_offset_tensor)
           .setRngDesc(rng_desc)
           .build();
   RETURN_MSG_IF_CUDNN_ERROR(rng_op);
@@ -3842,14 +3973,14 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnDropoutTensor(
                         .build();
   RETURN_MSG_IF_CUDNN_ERROR(masking_op);
 
-  // Create scale tensor
-  std::vector<int64_t> scale_dims(dims.size(), 1);
-  std::vector<int64_t> scale_strides(strides.size(), 1);
   TF_ASSIGN_OR_RETURN(
       auto dropout_scale_tensor,
       CreateCudnnTensor(
-          scale_dims, scale_strides, 'l', dtype, 1, -1, /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE));
+          scale_dims, scale_strides, CudnnfMHAUid::DROPOUT_SCALE_ID, dtype, 1,
+          -1,
+          /*is_virtual*/ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
 
   // Create output of scale node
   TF_ASSIGN_OR_RETURN(
@@ -3880,7 +4011,7 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnDropoutTensor(
 
   return dropout_scale_out_tensor;
 }
-#endif
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 
 tsl::StatusOr<std::unique_ptr<cudnn_frontend::OperationGraph>>
 GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType input_type,
@@ -4490,9 +4621,10 @@ GetCudnnFusedMHAOperationGraph(
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& mask_descriptor,
     const dnn::TensorDescriptor& bias_descriptor,
-    const dnn::TensorDescriptor& output_descriptor, dnn::FusedMHAKind kind,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed,
-    CudnnHandle& cudnn, double scale, bool use_dropout = false,
+    const dnn::TensorDescriptor& output_descriptor, int64_t& s_uid,
+    dnn::FusedMHAKind kind, std::optional<double> dropout_rate,
+    std::optional<int64_t> seed, CudnnHandle& cudnn, double scale,
+    std::vector<int64_t>& intermediate_shape, bool use_dropout = false,
     bool use_mask = false, bool use_bias = false) {
   if (VLOG_IS_ON(4)) {
     VLOG(4) << "\n bmm1_lhs(q): " << bmm1_lhs_descriptor.ToString()
@@ -4538,7 +4670,8 @@ GetCudnnFusedMHAOperationGraph(
   TF_ASSIGN_OR_RETURN(auto tensor_k,
                       CreateCudnnTensor(bmm1_rhs_dims, bmm1_rhs_strides, 'k',
                                         bmm1_rhs_descriptor.type(), 1, -1));
-
+  std::shared_ptr<cudnn_frontend::Tensor> bmm2_input_tensor =
+      std::make_shared<cudnn_frontend::Tensor>(std::move(tensor_k));
   std::vector<int64_t> intermediate_bmm2_lhs_dims =
       intermediate_bmm2_lhs_descriptor.GetCudnnCompatibleDimensions(true);
   std::vector<int64_t> intermediate_bmm2_lhs_strides =
@@ -4557,6 +4690,13 @@ GetCudnnFusedMHAOperationGraph(
                         intermediate_bmm2_lhs_strides, 's', s_tensor_type, 1,
                         -1, /*is_virtual=*/true));
 
+  // Create scale op and tensor
+  TF_ASSIGN_OR_RETURN(
+      auto alpha_scale_out,
+      CreateCudnnScaleTensor(intermdiate_ops, bmm1_rhs_dims, bmm1_rhs_strides,
+                             bmm1_rhs_descriptor.type(), bmm2_input_tensor));
+  bmm2_input_tensor =
+      std::make_shared<cudnn_frontend::Tensor>(std::move(alpha_scale_out));
   auto bmm1_desc = cudnn_frontend::MatMulDescBuilder()
                        .setComputeType(CUDNN_DATA_FLOAT)
                        .build();
@@ -4564,18 +4704,17 @@ GetCudnnFusedMHAOperationGraph(
   auto bmm1_op = cudnn_frontend::OperationBuilder(
                      CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
                      .setaMatDesc(tensor_q)
-                     .setbMatDesc(tensor_k)
+                     .setbMatDesc(alpha_scale_out)
                      .setcMatDesc(tensor_s)
                      .setmatmulDesc(bmm1_desc)
                      .build();
   RETURN_MSG_IF_CUDNN_ERROR(bmm1_op);
+  bmm2_input_tensor =
+      std::make_shared<cudnn_frontend::Tensor>(std::move(tensor_s));
   intermdiate_ops.push_back(std::move(bmm1_op));
 
-  std::shared_ptr<cudnn_frontend::Tensor> bmm2_input_tensor =
-      std::make_shared<cudnn_frontend::Tensor>(std::move(tensor_s));
   if (use_dropout || use_mask || kind == dnn::FusedMHAKind::BMM1_OUTPUT_FLOAT ||
       use_bias) {
-    double alpha_scale = scale;
     if (use_bias) {
       // Create bias op and tensor
       TF_ASSIGN_OR_RETURN(
@@ -4583,11 +4722,9 @@ GetCudnnFusedMHAOperationGraph(
           CreateCudnnBiasTensor(intermdiate_ops, intermediate_bmm2_lhs_dims,
                                 intermediate_bmm2_lhs_strides,
                                 bias_descriptor.type(), bmm2_input_tensor,
-                                alpha_scale, use_mask));
+                                use_mask));
       bmm2_input_tensor =
           std::make_shared<cudnn_frontend::Tensor>(std::move(bias_out));
-      // Scaling is done, reset the scale back to 1.
-      alpha_scale = 1.0f;
     }
     if (use_mask) {
       // Create mask op and tensor
@@ -4596,22 +4733,24 @@ GetCudnnFusedMHAOperationGraph(
           CreateCudnnMaskTensor(intermdiate_ops, intermediate_bmm2_lhs_dims,
                                 intermediate_bmm2_lhs_strides,
                                 intermediate_bmm2_lhs_descriptor.type(),
-                                bmm2_input_tensor, alpha_scale));
+                                bmm2_input_tensor));
       bmm2_input_tensor =
           std::make_shared<cudnn_frontend::Tensor>(std::move(mask_out));
     }
-    // Create Softmax tensor
-    // The output is always a virtual for inference mode.
-    TF_ASSIGN_OR_RETURN(auto softmax_fwd_out,
-                        CreateCudnnSoftmaxFwdTensor(
-                            intermdiate_ops, intermediate_bmm2_lhs_dims,
-                            intermediate_bmm2_lhs_strides,
-                            intermediate_bmm2_lhs_descriptor.type(),
-                            /*input_tensor*/ bmm2_input_tensor, use_dropout,
-                            /*is_virtual*/ true));
-
-    bmm2_input_tensor =
-        std::make_shared<cudnn_frontend::Tensor>(std::move(softmax_fwd_out));
+    if (kind == dnn::FusedMHAKind::BMM1_OUTPUT_FLOAT || use_bias ||
+        use_dropout || use_mask) {
+      // Create Softmax tensor
+      // The output is always a virtual for inference mode.
+      TF_ASSIGN_OR_RETURN(auto softmax_fwd_out,
+                          CreateCudnnSoftmaxFwdTensor(
+                              intermdiate_ops, intermediate_bmm2_lhs_dims,
+                              intermediate_bmm2_lhs_strides,
+                              intermediate_bmm2_lhs_descriptor.type(),
+                              /*input_tensor*/ bmm2_input_tensor,
+                              /*is_virtual*/ true));
+      bmm2_input_tensor =
+          std::make_shared<cudnn_frontend::Tensor>(std::move(softmax_fwd_out));
+    }
 
     if (use_dropout) {
       // Create dropout tensor
@@ -4621,7 +4760,7 @@ GetCudnnFusedMHAOperationGraph(
                                    intermediate_bmm2_lhs_strides,
                                    intermediate_bmm2_lhs_descriptor.type(),
                                    /*input_tensor*/ bmm2_input_tensor,
-                                   *dropout_rate, *seed));
+                                   *dropout_rate, *seed, /*is_virtual*/ true));
       bmm2_input_tensor =
           std::make_shared<cudnn_frontend::Tensor>(std::move(dropout_out));
     }
@@ -4686,9 +4825,774 @@ GetCudnnFusedMHAOperationGraph(
           << "\nOpGraph: " << op_graph.describe();
   return std::make_unique<cudnn_frontend::OperationGraph>(std::move(op_graph));
 }
+
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnDropoutBwdTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    cudnn_frontend::Tensor const& tensor_dropout_scale,
+    cudnn_frontend::Tensor const& tensor_p,
+    cudnn_frontend::Tensor const& tensor_p_abs,
+    cudnn_frontend::Tensor const& tensor_dp) {
+  // create zero tensor
+  std::vector<int64_t> scale_dims(dims.size(), 1);
+  std::vector<int64_t> scale_strides(strides.size(), 1);
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_zero,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, CudnnfMHAUid::ZERO_VAL_ID,
+          dnn::DataType::kFloat, 1, -1,
+          /* is_virtual */ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
+
+  auto tensor_dropout_mask = cudnn_frontend::TensorBuilder()
+                                 .setDim(dims.size(), dims.data())
+                                 .setStride(strides.size(), strides.data())
+                                 .setId(VIRTUAL_ID + 400)
+                                 .setAlignment(32)
+                                 .setDataType(CUDNN_DATA_BOOLEAN)
+                                 .setVectorCountAndDimension(1, -1)
+                                 .setVirtual(true)
+#if CUDNN_VERSION >= 8300
+                                 .setReorderType(CUDNN_TENSOR_REORDERING_NONE)
+#endif
+                                 .setByValue(false)
+                                 .build();
+  TF_ASSIGN_OR_RETURN(
+      auto greater_than_0_desc,
+      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_CMP_GT));
+
+  TF_ASSIGN_OR_RETURN(
+      auto greater_than_0_op,
+      CreateBinaryPwOp(tensor_p, tensor_zero, tensor_dropout_mask,
+                       greater_than_0_desc));
+
+  ops.push_back(std::move(greater_than_0_op));
+  // scale for the dropout
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_dp_scale,
+      CreateCudnnTensor(dims, strides, VIRTUAL_ID + 401, dnn::DataType::kFloat,
+                        1,
+                        -1,  // FMHA TODO TYPE: why it is float here?
+                        /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(auto mul_0_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
+
+  TF_ASSIGN_OR_RETURN(auto mul_0_op,
+                      CreateBinaryPwOp(tensor_dp, tensor_dropout_scale,
+                                       tensor_dp_scale, mul_0_desc));
+  ops.push_back(std::move(mul_0_op));
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_dp_scale_dropout,
+      CreateCudnnTensor(dims, strides, VIRTUAL_ID + 402, dnn::DataType::kFloat,
+                        1,
+                        -1,  // FMHA TODO TYPE: why it is float here?
+                        /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(
+      auto selection_0_desc,
+      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_BINARY_SELECT));
+  TF_ASSIGN_OR_RETURN(
+      auto selection_0_op,
+      CreateTernaryPwOp(tensor_dp_scale, tensor_zero, tensor_dropout_mask,
+                        tensor_dp_scale_dropout, selection_0_desc));
+  ops.push_back(std::move(selection_0_op));
+  return tensor_dp_scale_dropout;
+}
+
+// Returns a cudnn tensor that's the output of the softmax backward op
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnSoftmaxBwdTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    cudnn_frontend::Tensor const& tensor_y,
+    cudnn_frontend::Tensor const& tensor_dy) {
+  // softmax's typical backward computation is:
+  // y * (dy - sum(y  * dy))
+  // we also do alpha scale here
+  // We need to create each op and add it to the op list sequentially.
+  std::vector<int64_t> p_reduction_dims(dims.begin(), dims.end() - 1);
+  p_reduction_dims.push_back(1);
+
+  // Divide every stride by the last dim value.
+  std::vector<int64_t> p_reduction_strides;
+  int64_t reduced_dim_len = dims.back();
+  for (auto stride : strides) {
+    p_reduction_strides.push_back(stride / reduced_dim_len);
+  }
+
+  std::vector<int64_t> scale_dims(dims.size(), 1);
+  std::vector<int64_t> scale_strides(strides.size(), 1);
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_alpha_scale,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, CudnnfMHAUid::ALPHA_SCALE_ID,
+          dnn::DataType::kFloat, 1, -1, /* is_virtual */ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_y_mul_dy,
+      CreateCudnnTensor(dims, strides, VIRTUAL_ID + 500, dnn::DataType::kFloat,
+                        1, -1, /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_mul_reduction,
+      CreateCudnnTensor(p_reduction_dims, p_reduction_strides, VIRTUAL_ID + 501,
+                        dnn::DataType::kFloat, 1, -1, /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_mul_reduction_sub,
+      CreateCudnnTensor(dims, strides, VIRTUAL_ID + 502, dnn::DataType::kFloat,
+                        1, -1, /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(auto tensor_mul_reduction_sub_mul,
+                      CreateCudnnTensor(dims, strides, VIRTUAL_ID + 503,
+                                        dnn::DataType::kFloat, 1, -1,
+                                        /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_mul_reduction_sub_mul_alpha_scale,
+      CreateCudnnTensor(dims, strides, VIRTUAL_ID + 504, dnn::DataType::kFloat,
+                        1, -1, /* is_virtual */ true));
+  // mul (y * dy)
+  TF_ASSIGN_OR_RETURN(auto mul_1_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
+
+  TF_ASSIGN_OR_RETURN(
+      auto mul_1_op,
+      CreateBinaryPwOp(tensor_y, tensor_dy, tensor_y_mul_dy, mul_1_desc));
+
+  // reduction add sum (y * dy)
+  auto reduction_add_desc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                .build();
+  RETURN_MSG_IF_CUDNN_ERROR(reduction_add_desc);
+  auto reduction_add_op = cudnn_frontend::OperationBuilder(
+                              CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                              .setxDesc(tensor_y_mul_dy)
+                              .setyDesc(tensor_mul_reduction)
+                              .setreductionDesc(reduction_add_desc)
+                              .build();
+  RETURN_MSG_IF_CUDNN_ERROR(reduction_add_op);
+
+  // subtraction (dy - sum(y * dy))
+  TF_ASSIGN_OR_RETURN(auto sub_0_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_SUB));
+
+  TF_ASSIGN_OR_RETURN(auto sub_0_op,
+                      CreateBinaryPwOp(tensor_dy, tensor_mul_reduction,
+                                       tensor_mul_reduction_sub, sub_0_desc));
+
+  // mul (y * (dy - sum(y * dy)))
+  TF_ASSIGN_OR_RETURN(auto mul_2_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
+
+  TF_ASSIGN_OR_RETURN(
+      auto mul_2_op,
+      CreateBinaryPwOp(tensor_y, tensor_mul_reduction_sub,
+                       tensor_mul_reduction_sub_mul, mul_2_desc));
+
+  // mul (scale * dx)
+  TF_ASSIGN_OR_RETURN(auto mul_3_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
+
+  TF_ASSIGN_OR_RETURN(
+      auto mul_3_op,
+      CreateBinaryPwOp(tensor_mul_reduction_sub_mul, tensor_alpha_scale,
+                       tensor_mul_reduction_sub_mul_alpha_scale, mul_3_desc));
+
+  ops.push_back(std::move(mul_1_op));
+  ops.push_back(std::move(reduction_add_op));
+  ops.push_back(std::move(sub_0_op));
+  ops.push_back(std::move(mul_2_op));
+  ops.push_back(std::move(mul_3_op));
+
+  return tensor_mul_reduction_sub_mul_alpha_scale;
+}
+
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnMaskBwdTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    cudnn_frontend::Tensor const& input_tensor, bool use_mask) {
+  std::vector<int64_t> scale_dims(dims.size(), 1);
+  std::vector<int64_t> scale_strides(strides.size(), 1);
+
+  // with mask input: dummy_binary_selection(mul(input, mask_input), 0, 1)
+  // without use_mask: dummy_binary_selection(input, 0, 1)
+  if (use_mask) {
+    TF_ASSIGN_OR_RETURN(
+        auto mask_tensor,
+        CreateCudnnTensor(dims, strides, CudnnfMHAUid::MASK_ID, dtype, 1, -1));
+
+    TF_ASSIGN_OR_RETURN(
+        auto mask_out_tensor,
+        CreateCudnnTensor(dims, strides, CudnnfMHAUid::VIRTUAL_ID + 700,
+                          dnn::DataType::kFloat, 1, -1,
+                          /*is_virtual=*/true));
+
+    TF_ASSIGN_OR_RETURN(
+        auto zero_tensor,
+        CreateCudnnTensor(
+            scale_dims, scale_strides, CudnnfMHAUid::ZERO_VAL_ID,
+            dnn::DataType::kFloat, 1, -1,
+            /*is_virtual=*/false,
+            /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+            /*is_value*/ true));
+
+    // Create the mask tensor
+    TF_ASSIGN_OR_RETURN(
+        auto one_tensor,
+        CreateCudnnTensor(
+            scale_dims, scale_strides, CudnnfMHAUid::ONE_VAL_ID,
+            dnn::DataType::kFloat, 1, -1,
+            /*is_virtual=*/false,
+            /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+            /*is_value*/ true));
+
+    // Create the mask output tensor
+    TF_ASSIGN_OR_RETURN(
+        auto dummy_mask_out_tensor,
+        CreateCudnnTensor(
+            dims, strides, CudnnfMHAUid::dS_ID, dtype, 1, -1,
+            /*is_virtual=*/false,
+            /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_F16x16));
+
+    // create mask op
+    TF_ASSIGN_OR_RETURN(auto mul_desc, CreatePwDesc(dnn::DataType::kFloat,
+                                                    CUDNN_POINTWISE_MUL));
+
+    TF_ASSIGN_OR_RETURN(
+        auto mul_op,
+        CreateBinaryPwOp(input_tensor, mask_tensor, mask_out_tensor, mul_desc));
+
+    // Create the dummpy binary selection mask op.
+    TF_ASSIGN_OR_RETURN(
+        auto mask_desc,
+        CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_BINARY_SELECT));
+
+    TF_ASSIGN_OR_RETURN(
+        auto mask_op,
+        CreateTernaryPwOp(mask_out_tensor, zero_tensor, one_tensor,
+                          dummy_mask_out_tensor, mask_desc));
+
+    // Add mask to op list
+    ops.push_back(std::move(mul_op));
+    ops.push_back(std::move(mask_op));
+
+    return dummy_mask_out_tensor;
+  } else {
+    TF_ASSIGN_OR_RETURN(
+        auto zero_tensor,
+        CreateCudnnTensor(
+            scale_dims, scale_strides, CudnnfMHAUid::ZERO_VAL_ID,
+            dnn::DataType::kFloat, 1, -1,
+            /*is_virtual=*/false,
+            /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+            /*is_value*/ true));
+
+    // Create the mask tensor
+    TF_ASSIGN_OR_RETURN(
+        auto one_tensor,
+        CreateCudnnTensor(
+            scale_dims, scale_strides, CudnnfMHAUid::ONE_VAL_ID,
+            dnn::DataType::kFloat, 1, -1,
+            /*is_virtual=*/false,
+            /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+            /*is_value*/ true));
+
+    // Create the mask output tensor
+    TF_ASSIGN_OR_RETURN(
+        auto dummy_mask_out_tensor,
+        CreateCudnnTensor(
+            dims, strides, CudnnfMHAUid::dS_ID, dtype, 1, -1,
+            /*is_virtual=*/false,
+            /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_F16x16));
+
+    // Create the dummpy binary selection mask op.
+    TF_ASSIGN_OR_RETURN(
+        auto mask_desc,
+        CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_BINARY_SELECT));
+
+    TF_ASSIGN_OR_RETURN(auto mask_op,
+                        CreateTernaryPwOp(input_tensor, zero_tensor, one_tensor,
+                                          dummy_mask_out_tensor, mask_desc));
+
+    // Add mask to op list
+    ops.push_back(std::move(mask_op));
+
+    return dummy_mask_out_tensor;
+  }
+}
+#if (CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND)
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnBiasBwdTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    cudnn_frontend::Tensor const& input_tensor) {
+  std::vector<int64_t> scale_dims(dims.size(), 1);
+  std::vector<int64_t> scale_strides(strides.size(), 1);
+  std::vector<int64_t> dbias_dims(dims.begin(), dims.end());
+  std::vector<int64_t> dbias_strides(strides.begin(), strides.end());
+  // reduction over batch dim
+  dbias_dims[0] = 1;
+
+  TF_ASSIGN_OR_RETURN(auto dbias_tensor,
+                      CreateCudnnTensor(dbias_dims, dbias_strides,
+                                        CudnnfMHAUid::dBIAS_ID, dtype, 1, -1));
+
+  TF_ASSIGN_OR_RETURN(
+      auto alpha_scale_tensor,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, CudnnfMHAUid::ALPHA_SCALE_ID,
+          dnn::DataType::kFloat, 1, -1,
+          /*is_virtual=*/false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
+
+  TF_ASSIGN_OR_RETURN(auto alpha_scale_reciprocal_tensor,
+                      CreateCudnnTensor(scale_dims, scale_strides,
+                                        CudnnfMHAUid::VIRTUAL_ID + 600,
+                                        dnn::DataType::kFloat, 1, -1,
+                                        /*is_virtual=*/true));
+
+  TF_ASSIGN_OR_RETURN(
+      auto dbias_before_scale_tensor,
+      CreateCudnnTensor(dbias_dims, dbias_strides,
+                        CudnnfMHAUid::VIRTUAL_ID + 601, dnn::DataType::kFloat,
+                        1, -1, /*is_virtual=*/true));
+
+  // Create the reduction op.
+  auto reduction_add_desc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                .build();
+  RETURN_MSG_IF_CUDNN_ERROR(reduction_add_desc);
+  auto reduction_add_op = cudnn_frontend::OperationBuilder(
+                              CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                              .setxDesc(input_tensor)
+                              .setyDesc(dbias_before_scale_tensor)
+                              .setreductionDesc(reduction_add_desc)
+                              .build();
+  RETURN_MSG_IF_CUDNN_ERROR(reduction_add_op);
+
+  // take the reciprocal of the scale
+  TF_ASSIGN_OR_RETURN(
+      auto reciprocal_scale_desc,
+      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_RECIPROCAL));
+
+  TF_ASSIGN_OR_RETURN(
+      auto reciprocal_scale_op,
+      CreateUnaryPwOp(alpha_scale_tensor, alpha_scale_reciprocal_tensor,
+                      reciprocal_scale_desc));
+
+  // apply the scale
+  TF_ASSIGN_OR_RETURN(auto dBias_scale_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
+
+  TF_ASSIGN_OR_RETURN(
+      auto dBias_scale_op,
+      CreateBinaryPwOp(dbias_before_scale_tensor, alpha_scale_reciprocal_tensor,
+                       dbias_tensor, dBias_scale_desc));
+  // Add mask to op list
+  ops.push_back(std::move(reduction_add_op));
+  ops.push_back(std::move(reciprocal_scale_op));
+  ops.push_back(std::move(dBias_scale_op));
+
+  return dbias_tensor;
+}
+#endif  // (CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND)
+tsl::StatusOr<std::unique_ptr<cudnn_frontend::OperationGraph>>
+GetCudnnFusedMHABackwardOperationGraph(
+    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& d_output_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor,
+    const dnn::TensorDescriptor& d_S_descriptor,
+    const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
+    const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
+    const dnn::TensorDescriptor& d_bmm2_rhs_descriptor, dnn::FusedMHAKind kind,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed,
+    CudnnHandle& cudnn, double scale, bool use_dropout = false,
+    bool use_mask = false, bool use_bias = false) {
+  if (VLOG_IS_ON(4)) {
+    VLOG(4) << "\n bmm1_grad_gemm1_rhs(q): "
+            << bmm1_grad_gemm1_rhs_descriptor.ToString()
+            << "\n bmm1_grad_gemm2_rhs(k): "
+            << bmm1_grad_gemm2_rhs_descriptor.ToString()
+            << "\n bmm2_grad_gemm1_lhs(p): "
+            << bmm2_grad_gemm1_lhs_descriptor.ToString()
+            << "\n bmm2_grad_gemm2_rhs(v^t): "
+            << bmm2_grad_gemm2_rhs_descriptor.ToString()
+            << "\n d_output(do): " << d_output_descriptor.ToString()
+            << "\n d_bmm1_lhs(dq): " << d_bmm1_lhs_descriptor.ToString()
+            << "\n d_bmm1_rhs(dk): " << d_bmm1_rhs_descriptor.ToString()
+            << "\n d_bmm2_rhs(dv): " << d_bmm2_rhs_descriptor.ToString();
+  }
+  // cnn_infer needs to be preloaded for fMHA as well. Reusing the function
+  // created for convolution for fMHA.
+  PreloadCudnnSubLibsHelper(dnn::ConvolutionKind::FORWARD);
+
+  std::vector<cudnn_frontend::Operation const*> ops;
+  std::vector<cudnn_frontend::Operation> intermdiate_ops;
+
+  // fp16 or bf16 is required
+  auto dtype = bmm1_grad_gemm1_rhs_descriptor.type();
+
+  std::vector<int64_t> q_dims =
+      bmm1_grad_gemm1_rhs_descriptor.GetCudnnCompatibleDimensions(false);
+  std::vector<int64_t> q_strides =
+      bmm1_grad_gemm1_rhs_descriptor.GetCudnnCompatibleStrides(false);
+
+  // used for create scale tensor or zero tensor
+  std::vector<int64_t> scale_dims(q_dims.size(), 1);
+  std::vector<int64_t> scale_strides(q_strides.size(), 1);
+
+  VLOG(2) << "\n cuDNN compatible bmm1_grad_gemm1_rhs_dims: "
+          << absl::StrJoin(q_dims, ",")
+          << "\n cuDNN compatible bmm1_grad_gemm1_rhs_strides: "
+          << absl::StrJoin(q_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_q,
+      CreateCudnnTensor(q_dims, q_strides, CudnnfMHAUid::Q_ID, dtype, 1, -1));
+
+  std::vector<int64_t> k_dims =
+      bmm1_grad_gemm2_rhs_descriptor.GetCudnnCompatibleDimensions(false);
+  std::vector<int64_t> k_strides =
+      bmm1_grad_gemm2_rhs_descriptor.GetCudnnCompatibleStrides(false);
+
+  VLOG(2) << "\n cuDNN compatible bmm1_grad_gemm2_rhs_dims: "
+          << absl::StrJoin(k_dims, ",")
+          << "\n cuDNN compatible bmm1_grad_gemm2_rhs_strides: "
+          << absl::StrJoin(k_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_k,
+      CreateCudnnTensor(k_dims, k_strides, CudnnfMHAUid::K_ID, dtype, 1, -1));
+
+  std::vector<int64_t> p_dims =
+      bmm2_grad_gemm1_lhs_descriptor.GetCudnnCompatibleDimensions(true);
+  std::vector<int64_t> p_strides =
+      bmm2_grad_gemm1_lhs_descriptor.GetCudnnCompatibleStrides(true);
+
+  VLOG(2) << "\n cuDNN compatible bmm2_grad_gemm1_lhs_dims: "
+          << absl::StrJoin(p_dims, ",")
+          << "\n cuDNN compatible bmm2_grad_gemm1_lhs_strides: "
+          << absl::StrJoin(p_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_p,
+      CreateCudnnTensor(
+          p_dims, p_strides, CudnnfMHAUid::P_ID, dtype, 1, -1,
+          /*is_virtual*/ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_F16x16));
+
+  std::vector<int64_t> v_dims =
+      bmm2_grad_gemm2_rhs_descriptor.GetCudnnCompatibleDimensions(false);
+  std::vector<int64_t> v_strides =
+      bmm2_grad_gemm2_rhs_descriptor.GetCudnnCompatibleStrides(false);
+
+  VLOG(2) << "\n cuDNN compatible bmm2_grad_gemm2_rhs_dims: "
+          << absl::StrJoin(v_dims, ",")
+          << "\n cuDNN compatible bmm2_grad_gemm2_rhs_strides: "
+          << absl::StrJoin(v_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_vt,
+      CreateCudnnTensor(v_dims, v_strides, CudnnfMHAUid::V_ID, dtype, 1, -1));
+
+  // FMHA TODO: be really careful here about dim
+  std::vector<int64_t> do_dims =
+      d_output_descriptor.GetCudnnCompatibleDimensions(false);
+  std::vector<int64_t> do_strides =
+      d_output_descriptor.GetCudnnCompatibleStrides(false);
+  VLOG(2) << "\n cuDNN compatible d_output_dims: "
+          << absl::StrJoin(do_dims, ",")
+          << "\n cuDNN compatible d_output_strides: "
+          << absl::StrJoin(do_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_do,
+                      CreateCudnnTensor(do_dims, do_strides,
+                                        CudnnfMHAUid::dO_ID, dtype, 1, -1));
+
+  std::vector<int64_t> dq_dims = d_bmm1_lhs_descriptor.dimensions();
+  std::vector<int64_t> dq_strides = d_bmm1_lhs_descriptor.GetLogicalStrides();
+
+  VLOG(2) << "\n cuDNN compatible d_bmm1_lhs_dims: "
+          << absl::StrJoin(dq_dims, ",")
+          << "\n cuDNN compatible d_bmm1_lhs_strides: "
+          << absl::StrJoin(dq_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_dq,
+                      CreateCudnnTensor(dq_dims, dq_strides,
+                                        CudnnfMHAUid::dQ_ID, dtype, 1, -1));
+
+  std::vector<int64_t> dk_dims = d_bmm1_rhs_descriptor.dimensions();
+  std::vector<int64_t> dk_strides = d_bmm1_rhs_descriptor.GetLogicalStrides();
+
+  VLOG(2) << "\n cuDNN compatible d_bmm1_rhs_dims: "
+          << absl::StrJoin(dk_dims, ",")
+          << "\n cuDNN compatible d_bmm1_rhs_strides: "
+          << absl::StrJoin(dk_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_dk,
+                      CreateCudnnTensor(dk_dims, dk_strides,
+                                        CudnnfMHAUid::dK_ID, dtype, 1, -1));
+
+  std::vector<int64_t> dv_dims = d_bmm2_rhs_descriptor.dimensions();
+  std::vector<int64_t> dv_strides = d_bmm2_rhs_descriptor.GetLogicalStrides();
+
+  VLOG(2) << "\n cuDNN compatible d_bmm2_rhs_dims: "
+          << absl::StrJoin(dv_dims, ",")
+          << "\n cuDNN compatible d_bmm2_rhs_strides: "
+          << absl::StrJoin(dv_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_dv,
+                      CreateCudnnTensor(dv_dims, dv_strides,
+                                        CudnnfMHAUid::dV_ID, dtype, 1, -1));
+
+  // reshape + scale dropout + abs for p
+  auto p_transpose_dims = p_dims;
+  auto p_transpose_strides = p_strides;
+  auto rank = p_transpose_dims.size();
+  std::swap(p_transpose_dims[rank - 1], p_transpose_dims[rank - 2]);
+  std::swap(p_transpose_strides[rank - 1], p_transpose_strides[rank - 2]);
+
+  TF_ASSIGN_OR_RETURN(auto tensor_p_transpose,
+                      CreateCudnnTensor(p_transpose_dims, p_transpose_strides,
+                                        VIRTUAL_ID + 300, dtype, 1, -1,
+                                        /* is_virtual */ true));
+
+  auto reshape_op = cudnn_frontend::OperationBuilder(
+                        CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                        .setxDesc(tensor_p)
+                        .setyDesc(tensor_p_transpose)
+                        .build();
+  RETURN_MSG_IF_CUDNN_ERROR(reshape_op);
+
+  // Create scale tensor
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_dropout_scale,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, CudnnfMHAUid::DROPOUT_SCALE_ID,
+          dnn::DataType::kFloat, 1, -1,
+          /*is_virtual*/ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
+
+  // Create output of scale
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_p_transpose_scale,
+      CreateCudnnTensor(p_transpose_dims, p_transpose_strides, VIRTUAL_ID + 301,
+                        dtype, 1, -1, /*is_virtual*/ true));
+  // Create the scaling desc
+  TF_ASSIGN_OR_RETURN(auto scale_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
+
+  // Create the scaling op
+  TF_ASSIGN_OR_RETURN(auto scale_op,
+                      CreateBinaryPwOp(tensor_p_transpose, tensor_dropout_scale,
+                                       tensor_p_transpose_scale, scale_desc));
+  // create abs operation here to clear the sign bit
+  // sign bit is used to store the mask for dropout
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_p_transpose_scale_abs,
+      CreateCudnnTensor(p_transpose_dims, p_transpose_strides, VIRTUAL_ID + 302,
+                        dtype, 1, -1, /*is_virtual*/ true));
+
+  TF_ASSIGN_OR_RETURN(auto abs_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_ABS));
+
+  TF_ASSIGN_OR_RETURN(auto abs_op,
+                      CreateUnaryPwOp(tensor_p_transpose_scale,
+                                      tensor_p_transpose_scale_abs, abs_desc));
+
+  intermdiate_ops.push_back(std::move(reshape_op));
+  intermdiate_ops.push_back(std::move(scale_op));
+  intermdiate_ops.push_back(std::move(abs_op));
+
+  // matmul to calculate dv
+  auto bmm2_grad_gemm1_desc = cudnn_frontend::MatMulDescBuilder()
+                                  .setComputeType(CUDNN_DATA_FLOAT)
+                                  .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm1_desc);
+  auto bmm2_grad_gemm1_op = cudnn_frontend::OperationBuilder(
+                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(tensor_p_transpose_scale_abs)
+                                .setbMatDesc(tensor_do)
+                                .setcMatDesc(tensor_dv)
+                                .setmatmulDesc(bmm2_grad_gemm1_desc)
+                                .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm1_op);
+  intermdiate_ops.push_back(std::move(bmm2_grad_gemm1_op));
+
+  // matmul to calculate dp
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_dp,
+      CreateCudnnTensor(p_dims, p_strides, VIRTUAL_ID + 303,
+                        dnn::DataType::kFloat, 1,
+                        -1,  // FMHA TODO TYPE: why it is float here?
+                        /* is_virtual */ true));
+
+  auto bmm2_grad_gemm2_desc = cudnn_frontend::MatMulDescBuilder()
+                                  .setComputeType(CUDNN_DATA_FLOAT)
+                                  .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm2_desc);
+  auto bmm2_grad_gemm2_op = cudnn_frontend::OperationBuilder(
+                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(tensor_do)
+                                .setbMatDesc(tensor_vt)
+                                .setcMatDesc(tensor_dp)
+                                .setmatmulDesc(bmm2_grad_gemm2_desc)
+                                .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm2_op);
+  intermdiate_ops.push_back(std::move(bmm2_grad_gemm2_op));
+
+  // mask out the sign bit here
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_p_abs,
+      CreateCudnnTensor(p_dims, p_strides, VIRTUAL_ID + 304, dtype, 1, -1,
+                        /* is_virtual */ true));
+
+  TF_ASSIGN_OR_RETURN(auto p_abs_desc,
+                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_ABS));
+
+  TF_ASSIGN_OR_RETURN(auto p_abs_op,
+                      CreateUnaryPwOp(tensor_p, tensor_p_abs, p_abs_desc));
+  intermdiate_ops.push_back(std::move(p_abs_op));
+
+  // dropout backward
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_dp_scale_dropout,
+      CreateCudnnDropoutBwdTensor(intermdiate_ops, p_dims, p_strides, dtype,
+                                  tensor_dropout_scale, tensor_p, tensor_p_abs,
+                                  tensor_dp));
+  // softmax backward
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_ds,
+      CreateCudnnSoftmaxBwdTensor(intermdiate_ops, p_dims, p_strides, dtype,
+                                  tensor_p_abs, tensor_dp_scale_dropout));
+  // mask backward
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_ds_mask,
+      CreateCudnnMaskBwdTensor(intermdiate_ops, p_dims, p_strides, dtype,
+                               tensor_ds, use_mask));
+
+#if (CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND)
+  // bias backward
+  TF_ASSIGN_OR_RETURN(auto tensor_dbias, CreateCudnnBiasBwdTensor(
+                                             intermdiate_ops, p_dims, p_strides,
+                                             dtype, tensor_ds_mask));
+#else
+  return tsl::errors::Internal("Bias backward op requires cudnn >= 8.9.1");
 #endif
 
+  // calculate dq
+  auto bmm1_grad_gemm2_desc = cudnn_frontend::MatMulDescBuilder()
+                                  .setComputeType(CUDNN_DATA_FLOAT)
+                                  .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm2_desc);
+  auto bmm1_grad_gemm2_op = cudnn_frontend::OperationBuilder(
+                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(tensor_ds_mask)
+                                .setbMatDesc(tensor_k)
+                                .setcMatDesc(tensor_dq)
+                                .setmatmulDesc(bmm1_grad_gemm2_desc)
+                                .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm2_op);
+  intermdiate_ops.push_back(std::move(bmm1_grad_gemm2_op));
+
+  // calculate dk
+  TF_ASSIGN_OR_RETURN(auto tensor_ds_mask_reshape,
+                      CreateCudnnTensor(p_transpose_dims, p_transpose_strides,
+                                        VIRTUAL_ID + 305, dtype, 1, -1,
+                                        /* is_virtual */ true));
+
+  auto reshape_2_op = cudnn_frontend::OperationBuilder(
+                          CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                          .setxDesc(tensor_ds_mask)
+                          .setyDesc(tensor_ds_mask_reshape)
+                          .build();
+
+  intermdiate_ops.push_back(std::move(reshape_2_op));
+  auto bmm1_grad_gemm1_desc = cudnn_frontend::MatMulDescBuilder()
+                                  .setComputeType(CUDNN_DATA_FLOAT)
+                                  .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm1_desc);
+  auto bmm1_grad_gemm1_op = cudnn_frontend::OperationBuilder(
+                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(tensor_ds_mask_reshape)
+                                .setbMatDesc(tensor_q)
+                                .setcMatDesc(tensor_dk)
+                                .setmatmulDesc(bmm1_grad_gemm1_desc)
+                                .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm1_op);
+  intermdiate_ops.push_back(std::move(bmm1_grad_gemm1_op));
+
+  for (auto& intermediate_op : intermdiate_ops) {
+    ops.push_back(&intermediate_op);
+  }
+
+  auto op_graph = cudnn_frontend::OperationGraphBuilder()
+                      .setHandle(cudnn.handle())
+                      .setOperationGraph(ops.size(), ops.data())
+                      .build();
+  RETURN_MSG_IF_CUDNN_ERROR(op_graph);
+
+  VLOG(4) << "\nTensor_q: " << tensor_q.describe()
+          << "\nTensor_k: " << tensor_k.describe()
+          << "\nTensor_p: " << tensor_p.describe()
+          << "\nTensor_vt: " << tensor_vt.describe()
+          << "\nTensor_do: " << tensor_do.describe()
+          << "\nTensor_dq: " << tensor_dq.describe()
+          << "\nTensor_dk: " << tensor_dk.describe()
+          << "\nTensor_dv: " << tensor_dv.describe()
+          << "\nBMM2_grad_gemm1: " << bmm2_grad_gemm1_desc.describe()
+          << "\nBMM2_grad_gemm1_op: " << bmm2_grad_gemm1_op.describe()
+          << "\nBMM2_grad_gemm2: " << bmm2_grad_gemm2_desc.describe()
+          << "\nBMM2_grad_gemm2_op: " << bmm2_grad_gemm2_op.describe()
+          << "\nBMM1_grad_gemm1: " << bmm1_grad_gemm1_desc.describe()
+          << "\nBMM1_grad_gemm1_op: " << bmm1_grad_gemm1_op.describe()
+          << "\nBMM1_grad_gemm2: " << bmm1_grad_gemm2_desc.describe()
+          << "\nBMM1_grad_gemm2_op: " << bmm1_grad_gemm2_op.describe()
+          << "\nOpGraph: " << op_graph.describe();
+  return std::unique_ptr<cudnn_frontend::OperationGraph>(
+      new cudnn_frontend::OperationGraph(std::move(op_graph)));
+}
+
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+
 }  // namespace
+
+static tsl::StatusOr<cudnn_frontend::ExecutionPlan> GetExecPlanFromHeuristics(
+    cudnn_frontend::OperationGraph&& opGraph, const CudnnHandle& cudnn) {
+#if (CUDNN_VERSION >= 8800)
+  cudnn_frontend::EngineConfigList engine_configs;
+  cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph,
+                                         allowAllConfig, engine_configs, true);
+  if (VLOG_IS_ON(4)) {
+    VLOG(4) << "Heuristic has " << engine_configs.size() << " configurations ";
+  }
+  if (engine_configs.size() == 0) {
+    return tsl::errors::Internal(
+        "No engine configurations found for this opGraph and heuristics.");
+  }
+  auto plan = cudnn_frontend::ExecutionPlanBuilder()
+                  .setHandle(cudnn.handle())
+                  .setEngineConfig(engine_configs[0], opGraph.getTag())
+                  .build();
+
+  return plan;
+#else
+  return tsl::errors::Unimplemented("Supported only for cuDNN >= 8.8.0");
+#endif
+}
 
 static tsl::StatusOr<cudnn_frontend::ExecutionPlan> RebuildExecutionPlan(
     const CudnnHandle& cudnn, const dnn::AlgorithmDesc& desc,
@@ -5065,8 +5969,68 @@ tsl::Status CudnnSupport::DoConvolve(
                 output_data);
 }
 
-#if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
+// Utility for dealing with CUDA's type-erased scaling parameters, where some
+// sets of parameters expect a void* pointing at a float while others expect it
+// to point at a double.
+//
+// This is rather ugly, but its purpose is to quarantine the corresponding
+// ugliness that already exists in the CUDA API.
+class ScalingParam {
+ public:
+  explicit ScalingParam(double value)
+      : as_double_(value),
+        as_float_(value),
+        as_half_(value),
+        as_bfloat16_(value),
+        default_target_dtype_(dnn::DataType::kFloat) {}
+  explicit ScalingParam(double value, dnn::DataType element_type)
+      : as_double_(value),
+        as_float_(value),
+        as_half_(value),
+        as_bfloat16_(value),
+        default_target_dtype_(element_type) {}
 
+  // Return a pointer to the appropriate representation type for the given
+  // element type.
+  //
+  // See
+  // https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#scaling-parameters
+  // for more info; the behavior for int8 result tensors is not described there,
+  // but is maintained from the existing behavior (namely, using a float scaling
+  // parameter).
+  void* ToVoidPointer(dnn::DataType element_type) {
+    if (element_type == dnn::DataType::kDouble) {
+      return &as_double_;
+    } else if (element_type == dnn::DataType::kHalf) {
+      return &as_half_;
+    } else if (element_type == dnn::DataType::kBF16) {
+      return &as_bfloat16_;
+    } else {
+      return &as_float_;
+    }
+  }
+
+  const void* ToVoidPointer() const {
+    if (default_target_dtype_ == dnn::DataType::kDouble) {
+      return &as_double_;
+    } else if (default_target_dtype_ == dnn::DataType::kHalf) {
+      return &as_half_;
+    } else if (default_target_dtype_ == dnn::DataType::kBF16) {
+      return &as_bfloat16_;
+    } else {
+      return &as_float_;
+    }
+  }
+
+ private:
+  double as_double_;
+  float as_float_;
+  Eigen::half as_half_;
+  Eigen::bfloat16 as_bfloat16_;
+  dnn::DataType default_target_dtype_;
+};
+
+#if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 struct BackendDescriptorDeleter {
   void operator()(cudnnBackendDescriptor_t desc) {
     cudnnBackendDestroyDescriptor(desc);
@@ -5235,18 +6199,45 @@ class CudnnExecutionPlanRunner<void(Args...)>
 
     size_t workspace_size = plan_.getWorkspaceSize();
     RETURN_MSG_IF_CUDNN_ERROR(plan_);
-
+    bool should_add_scalars =
+        scalar_input_uids_.size() > 0 && scalar_input_values_.size() > 0;
+    CHECK(scalar_input_uids_.size() == scalar_input_values_.size());
     std::array<void*, sizeof...(Args)> data_ptrs = {inputs.opaque()...};
 
-    absl::InlinedVector<int64_t, sizeof...(Args)> data_uids_vec(
-        data_uids_.cbegin(), data_uids_.cend());
-    absl::InlinedVector<void*, sizeof...(Args)> data_ptrs_vec(
-        data_ptrs.cbegin(), data_ptrs.cend());
+    std::vector<int64_t> data_uids_vec(data_uids_.cbegin(), data_uids_.cend());
+    std::vector<void*> data_ptrs_vec(data_ptrs.cbegin(), data_ptrs.cend());
     // We use need_side_input to determine if the side input 'z' from
     // {'x', 'w', 'z', 'b', 'y'} is needed for the conv-<add>-bias-act patterns.
     if (sizeof...(Args) == 5 && !need_side_input_) {
       data_uids_vec.erase(data_uids_vec.begin() + 2);
       data_ptrs_vec.erase(data_ptrs_vec.begin() + 2);
+    }
+
+    if (data_ptrs_vec[sizeof...(Args) - 1] == nullptr &&
+        !has_activation_output_) {
+      data_ptrs_vec.pop_back();
+    }
+
+    if (should_add_scalars) {
+      data_uids_vec.insert(data_uids_vec.end(), scalar_input_uids_.begin(),
+                           scalar_input_uids_.end());
+      for (int64_t i = 0; i < scalar_input_values_.size(); i++) {
+        data_ptrs_vec.push_back(
+            const_cast<void*>(scalar_input_values_[i].ToVoidPointer()));
+      }
+    }
+    if (offset_increment_ > 0) {
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+      initial_offset_ += offset_increment_;
+      data_uids_vec.push_back(CudnnfMHAUid::D_SEED_ID);
+      data_uids_vec.push_back(CudnnfMHAUid::D_OFFSET_ID);
+      data_ptrs_vec.push_back((void*)(&rng_seed_));
+      data_ptrs_vec.push_back((void*)(&initial_offset_));
+#else
+      return tsl::errors::Unimplemented(
+          "Cudnn dropout offset and seed are only supported with Cudnn >= "
+          "8.8.");
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
     }
 
     auto variantPack =
@@ -5290,60 +6281,68 @@ class CudnnExecutionPlanRunner<void(Args...)>
       bool need_side_input) {
     auto workspace_size = static_cast<uint64_t>(plan.getWorkspaceSize());
     RETURN_MSG_IF_CUDNN_ERROR(plan);
+    return {{parent,
+             cudnn,
+             std::move(plan),
+             workspace_size,
+             uids,
+             need_side_input,
+             false,
+             {},
+             {},
+             0,
+             0}};
+  }
+
+  static tsl::StatusOr<CudnnExecutionPlanRunner> Create(
+      GpuExecutor* parent, CudnnAccess* cudnn,
+      cudnn_frontend::ExecutionPlan plan, absl::Span<const int64_t> uids,
+      bool need_side_input, bool has_activation_output,
+      std::vector<int64_t> scalar_input_uids,
+      std::vector<ScalingParam> scalar_input_values, int64_t dropout_rng_seed,
+      int64_t dropout_rng_offset) {
+    auto workspace_size = static_cast<uint64_t>(plan.getWorkspaceSize());
+    RETURN_MSG_IF_CUDNN_ERROR(plan);
     return {{parent, cudnn, std::move(plan), workspace_size, uids,
-             need_side_input}};
+             need_side_input, has_activation_output, scalar_input_uids,
+             scalar_input_values, dropout_rng_seed, dropout_rng_offset}};
   }
 
  private:
   CudnnExecutionPlanRunner(GpuExecutor* parent, CudnnAccess* cudnn,
                            cudnn_frontend::ExecutionPlan plan,
                            size_t workspace_size,
-                           absl::Span<const int64_t> uids, bool need_side_input)
+                           absl::Span<const int64_t> uids, bool need_side_input,
+                           bool has_activation_output,
+                           std::vector<int64_t> scalar_input_uids,
+                           std::vector<ScalingParam> scalar_input_values,
+                           int64_t dropout_rng_seed, int64_t dropout_rng_offset)
       : parent_(parent),
         cudnn_(cudnn),
         plan_(std::move(plan)),
         workspace_size_(workspace_size),
         data_uids_(uids.begin(), uids.end()),
-        need_side_input_(need_side_input) {}
+        need_side_input_(need_side_input),
+        has_activation_output_(has_activation_output),
+        scalar_input_uids_(scalar_input_uids),
+        scalar_input_values_(scalar_input_values),
+        offset_increment_(dropout_rng_offset),
+        rng_seed_(dropout_rng_seed) {}
   GpuExecutor* parent_;
   CudnnAccess* cudnn_;
   cudnn_frontend::ExecutionPlan plan_;
   size_t workspace_size_;
   absl::InlinedVector<int64_t, sizeof...(Args)> data_uids_;
   bool need_side_input_;
+  bool has_activation_output_;
+  std::vector<int64_t> scalar_input_uids_;
+  std::vector<ScalingParam> scalar_input_values_;
+  // This is the state kept for rng if cudnn graph contains dropout.
+  mutable int64_t initial_offset_ = 0;
+  int64_t offset_increment_ = 0;
+  int64_t rng_seed_;
 };
 #endif  // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
-
-// Utility for dealing with CUDA's type-erased scaling parameters, where some
-// sets of parameters expect a void* pointing at a float while others expect it
-// to point at a double.
-//
-// This is rather ugly, but its purpose is to quarantine the corresponding
-// ugliness that already exists in the CUDA API.
-class ScalingParam {
- public:
-  explicit ScalingParam(double value) : as_double_(value), as_float_(value) {}
-
-  // Return a pointer to the appropriate representation type for the given
-  // element type.
-  //
-  // See
-  // https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#scaling-parameters
-  // for more info; the behavior for int8 result tensors is not described there,
-  // but is maintained from the existing behavior (namely, using a float scaling
-  // parameter).
-  void* ToVoidPointer(dnn::DataType element_type) {
-    if (element_type == dnn::DataType::kDouble) {
-      return &as_double_;
-    } else {
-      return &as_float_;
-    }
-  }
-
- private:
-  double as_double_;
-  float as_float_;
-};
 
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 namespace {
@@ -5513,9 +6512,9 @@ tsl::Status CudnnSupport::GetConvolveRunners(
           stream, algo, kind, input_type, output_type, input_descriptor,
           filter_descriptor, output_descriptor, convolution_descriptor);
       if (!runner_or.ok()) {
-        // Failures here can result from trying to query the workspace size for
-        // algorithms that aren't supported for the present configuration.  This
-        // means we'll now return only supported algorithms, unlike the
+        // Failures here can result from trying to query the workspace size
+        // for algorithms that aren't supported for the present configuration.
+        // This means we'll now return only supported algorithms, unlike the
         // predecessor 'GetConvolveAlgorithms', which returned all existing
         // algorithms regardless of any particular configuration.
         //
@@ -5667,7 +6666,8 @@ class CudnnLegacyFusedConvRunner : public dnn::FusedConvRunner {
     if (static_cast<internal::StreamExecutorInterface*>(parent_) !=
         stream->parent()->implementation()) {
       return tsl::errors::Internal(
-          "CudnnLegacyFusedConvRunner cached across multiple StreamExecutors.");
+          "CudnnLegacyFusedConvRunner cached across multiple "
+          "StreamExecutors.");
     }
 
     auto algo = MakeAlgorithmDesc();
@@ -6039,8 +7039,8 @@ tsl::Status CudnnSupport::GetFusedMatmulRunners(
   }
   auto op_graph = std::move(op_graph_status).value();
 
-  // The "need_side_input" will not actually affect the matmul execution. It was
-  // proposed to work around a convolution issue with five inputs (see
+  // The "need_side_input" will not actually affect the matmul execution. It
+  // was proposed to work around a convolution issue with five inputs (see
   // SideInputNeeded()). Here, we set it true to make sure none of the inputs
   // get dropped in case the number of inputs get increased in the future.
   return CreateOpRunners<dnn::FusedMatmulSignature>(
@@ -6093,6 +7093,19 @@ bool CudnnSupport::GetConvolveAlgorithms(
   return true;
 }
 
+// Returns the offset to increment for the dropout rng.
+// The offset is used by runner to increment by the offset_increment for
+// every call to cudnn fmha kernel to make sure dropout mask is evenly
+// distributed. The recommended offset value by cudnn is max_sequence_length
+// * max_sequence_length / number_of_threads_launched in kernel.
+int64_t GetDropoutRngOffset(std::vector<int64_t>& intermediate_shape) {
+  int64_t kv_seq_len = intermediate_shape[intermediate_shape.size() - 1];
+  int64_t q_seq_len = intermediate_shape[intermediate_shape.size() - 2];
+  int64_t max_seq_len = std::max(q_seq_len, kv_seq_len);
+  int64_t cudnn_mha_num_threads = 256;
+  return max_seq_len * max_seq_len / cudnn_mha_num_threads;
+}
+
 tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
 CudnnSupport::FusedMHASoftmaxRunnerFromDesc(
     Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
@@ -6103,35 +7116,56 @@ CudnnSupport::FusedMHASoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
   auto cudnn = cudnn_->GetHandle(parent_, stream);
 
   // Create empty descriptors for bias and mask tensors
   dnn::TensorDescriptor empty_mask_desc;
   dnn::TensorDescriptor empty_bias_desc;
   bool use_dropout = dropout_rate && *dropout_rate > 0.0;
-  TF_ASSIGN_OR_RETURN(auto op_graph,
-                      GetCudnnFusedMHAOperationGraph(
-                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
-                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-                          empty_mask_desc, empty_bias_desc, output_descriptor,
-                          kind, dropout_rate, seed, cudnn, 1.0f, use_dropout));
+  int64_t s_uid = -1;
+  std::vector<int64_t> intermediate_shape;
+
+  TF_ASSIGN_OR_RETURN(
+      auto op_graph,
+      GetCudnnFusedMHAOperationGraph(
+          bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
+          intermediate_bmm2_lhs_descriptor, empty_mask_desc, empty_bias_desc,
+          output_descriptor, s_uid, kind, dropout_rate, seed, cudnn, 1.0f,
+          intermediate_shape, use_dropout));
 
   TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
+  std::vector<int64_t> u_ids = {'q', 'k', 'v', 'o'};
+
+  ScalingParam alpha_scale(1.0, bmm1_lhs_descriptor.type());
+  std::vector<ScalingParam> scalar_input_values = {alpha_scale};
+  std::vector<int64_t> scalar_input_uids = {CudnnfMHAUid::ALPHA_SCALE_ID};
+
+  int64_t dropout_rng_offset = 0;
+  if (use_dropout) {
+    scalar_input_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
+    double dropout_scale_value = (1.0 / (1.0 - *dropout_rate));
+    ScalingParam dropout_scale(dropout_scale_value, bmm1_lhs_descriptor.type());
+    scalar_input_values.push_back(dropout_scale);
+    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
+  }
+  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
 
   TF_ASSIGN_OR_RETURN(
       auto runner,
       CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan),
-          {'q', 'k', 'v', 'o'}, false));
+          parent_, cudnn_.get(), std::move(execution_plan), u_ids,
+          /*need_side_input*/ true,
+          /*has_activation_output*/ false, scalar_input_uids,
+          scalar_input_values, dropout_rng_seed, dropout_rng_offset));
   return {
       std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxSignature>>(
           std::move(runner))};
 #else
   return tsl::errors::Unimplemented(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
-#endif
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
 
 tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
@@ -6145,33 +7179,57 @@ CudnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
     const dnn::TensorDescriptor& output_descriptor,
     const dnn::TensorDescriptor& mask_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
   auto cudnn = cudnn_->GetHandle(parent_, stream);
 
   bool use_dropout = dropout_rate && *dropout_rate > 0.0;
   // Create empty bias decriptor
   dnn::TensorDescriptor empty_bias_desc;
-  TF_ASSIGN_OR_RETURN(auto op_graph,
-                      GetCudnnFusedMHAOperationGraph(
-                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
-                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-                          mask_descriptor, empty_bias_desc, output_descriptor,
-                          kind, dropout_rate, seed, cudnn, scale, use_dropout,
-                          /*use_mask*/ true));
+  int64_t s_uid = -1;
+  std::vector<int64_t> intermediate_shape;
+
+  TF_ASSIGN_OR_RETURN(
+      auto op_graph,
+      GetCudnnFusedMHAOperationGraph(
+          bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
+          intermediate_bmm2_lhs_descriptor, mask_descriptor, empty_bias_desc,
+          output_descriptor, s_uid, kind, dropout_rate, seed, cudnn, scale,
+          intermediate_shape, use_dropout,
+          /*use_mask*/ true));
 
   TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
+  std::vector<int64_t> u_ids = {'q', 'k', 'P', 'v', 'o'};
+
+  ScalingParam alpha_scale(scale, bmm1_lhs_descriptor.type());
+  std::vector<ScalingParam> scalar_input_values = {alpha_scale};
+  std::vector<int64_t> scalar_input_uids = {CudnnfMHAUid::ALPHA_SCALE_ID};
+  int64_t dropout_rng_offset = 0;
+
+  if (use_dropout) {
+    scalar_input_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
+    double dropout_scale_value = (1.0 / (1.0 - *dropout_rate));
+    ScalingParam dropout_scale(dropout_scale_value, bmm1_lhs_descriptor.type());
+    scalar_input_values.push_back(dropout_scale);
+    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
+  }
+  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
+
   TF_ASSIGN_OR_RETURN(
-      auto runner, CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>::Create(
-                       parent_, cudnn_.get(), std::move(execution_plan),
-                       {'q', 'k', 'P', 'v', 'o'}, true));
+      auto runner,
+      CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>::Create(
+          parent_, cudnn_.get(), std::move(execution_plan), u_ids,
+          /*need_side_input*/ true,
+          /*has_activation_output*/ false, scalar_input_uids,
+          scalar_input_values, dropout_rng_seed, dropout_rng_offset));
+
   return {
       std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>>(
           std::move(runner))};
 #else
   return tsl::errors::Unimplemented(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
-#endif
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
 
 tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
@@ -6186,32 +7244,52 @@ CudnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
     const dnn::TensorDescriptor& mask_descriptor,
     const dnn::TensorDescriptor& bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
   auto cudnn = cudnn_->GetHandle(parent_, stream);
   bool use_dropout = dropout_rate && *dropout_rate > 0.0;
-  TF_ASSIGN_OR_RETURN(auto op_graph,
-                      GetCudnnFusedMHAOperationGraph(
-                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
-                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-                          mask_descriptor, bias_descriptor, output_descriptor,
-                          kind, dropout_rate, seed, cudnn, scale, use_dropout,
-                          /*use_mask*/ true, /*use_bias*/ true));
+  int64_t s_uid = -1;
+  std::vector<int64_t> intermediate_shape;
+  TF_ASSIGN_OR_RETURN(
+      auto op_graph,
+      GetCudnnFusedMHAOperationGraph(
+          bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
+          intermediate_bmm2_lhs_descriptor, mask_descriptor, bias_descriptor,
+          output_descriptor, s_uid, kind, dropout_rate, seed, cudnn, scale,
+          intermediate_shape, use_dropout,
+          /*use_mask*/ true, /*use_bias*/ true));
 
   TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
+  std::vector<int64_t> u_ids = {'q', 'k', 'P', 'B', 'v', 'o'};
+  ScalingParam alpha_scale(scale, bmm1_lhs_descriptor.type());
+  std::vector<ScalingParam> scalar_input_values = {alpha_scale};
+  std::vector<int64_t> scalar_input_uids = {CudnnfMHAUid::ALPHA_SCALE_ID};
+  int64_t dropout_rng_offset = 0;
+
+  if (use_dropout) {
+    scalar_input_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
+    double dropout_scale_value = (1.0 / (1.0 - *dropout_rate));
+    ScalingParam dropout_scale(dropout_scale_value, bmm1_lhs_descriptor.type());
+    scalar_input_values.push_back(dropout_scale);
+    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
+  }
+  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
 
   TF_ASSIGN_OR_RETURN(
       auto runner,
       CudnnExecutionPlanRunner<dnn::FusedMHABiasMaskSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan),
-          {'q', 'k', 'P', 'B', 'v', 'o'}, true));
+          parent_, cudnn_.get(), std::move(execution_plan), u_ids,
+          /*need_side_input*/ true,
+          /*has_activation_output*/ false, scalar_input_uids,
+          scalar_input_values, dropout_rng_seed, dropout_rng_offset));
+
   return {std::make_unique<
       CudnnExecutionPlanRunner<dnn::FusedMHABiasMaskSignature>>(
       std::move(runner))};
 #else
   return tsl::errors::Unimplemented(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
-#endif
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
 
 tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
@@ -6225,33 +7303,215 @@ CudnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
     const dnn::TensorDescriptor& output_descriptor,
     const dnn::TensorDescriptor& bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
   auto cudnn = cudnn_->GetHandle(parent_, stream);
   // Create empty descriptors for mask tensors
   dnn::TensorDescriptor empty_mask_desc;
   bool use_dropout = dropout_rate && *dropout_rate > 0.0;
-  TF_ASSIGN_OR_RETURN(auto op_graph,
-                      GetCudnnFusedMHAOperationGraph(
-                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
-                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-                          empty_mask_desc, bias_descriptor, output_descriptor,
-                          kind, dropout_rate, seed, cudnn, scale, use_dropout,
-                          /*use_mask*/ false, /*use_bias*/ true));
+  int64_t s_uid = -1;
+  std::vector<int64_t> intermediate_shape;
+  TF_ASSIGN_OR_RETURN(
+      auto op_graph,
+      GetCudnnFusedMHAOperationGraph(
+          bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
+          intermediate_bmm2_lhs_descriptor, empty_mask_desc, bias_descriptor,
+          output_descriptor, s_uid, kind, dropout_rate, seed, cudnn, scale,
+          intermediate_shape, use_dropout,
+          /*use_mask*/ false, /*use_bias*/ true));
 
   TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
+
+  std::vector<int64_t> u_ids = {'q', 'k', 'B', 'v', 'o'};
+
+  ScalingParam alpha_scale(scale, bmm1_lhs_descriptor.type());
+
+  std::vector<ScalingParam> scalar_input_values = {alpha_scale};
+  std::vector<int64_t> scalar_input_uids = {CudnnfMHAUid::ALPHA_SCALE_ID};
+  int64_t dropout_rng_offset = 0;
+
+  if (use_dropout) {
+    scalar_input_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
+    double dropout_scale_value = (1.0 / (1.0 - *dropout_rate));
+    ScalingParam dropout_scale(dropout_scale_value, bmm1_lhs_descriptor.type());
+    scalar_input_values.push_back(dropout_scale);
+    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
+  }
+  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
 
   TF_ASSIGN_OR_RETURN(
-      auto runner, CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>::Create(
-                       parent_, cudnn_.get(), std::move(execution_plan),
-                       {'q', 'k', 'B', 'v', 'o'}, true));
+      auto runner,
+      CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>::Create(
+          parent_, cudnn_.get(), std::move(execution_plan), u_ids,
+          /*need_side_input*/ true,
+          /*has_activation_output*/ false, scalar_input_uids,
+          scalar_input_values, dropout_rng_seed, dropout_rng_offset));
   return {
       std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>>(
           std::move(runner))};
 #else
   return tsl::errors::Unimplemented(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
-#endif
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+}
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
+CudnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& d_output_descriptor,
+    const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
+    const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
+    const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
+    const dnn::TensorDescriptor& d_S_descriptor,
+    std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+#if (CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND)
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  // Create empty descriptors for bias and mask tensors
+  dnn::TensorDescriptor empty_mask_desc;
+  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
+  TF_ASSIGN_OR_RETURN(
+      auto op_graph,
+      GetCudnnFusedMHABackwardOperationGraph(
+          bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
+          bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
+          d_output_descriptor, empty_mask_desc, d_S_descriptor,
+          d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
+          kind, dropout_rate, seed, cudnn, scale, use_dropout,
+          /*use_mask*/ false,
+          /*use_bias*/ d_bias_descriptor != std::nullopt));
+  // The function  GetExecPlanFromHeuristics uses
+  // cudnn_frontend::cudnnException which is currently not recommended for
+  // use by Google. Hence commenting out the call.
+  // TODO - Create a status wrapper to wrap the exception to avoid it being
+  // exposed to the runtime. TF_ASSIGN_OR_RETURN(auto execution_plan,
+  //                       GetExecPlanFromHeuristics(std::move(*op_graph),
+  //                       cudnn));
+
+  TF_ASSIGN_OR_RETURN(auto execution_plan,
+                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
+
+  std::vector<int64_t> scalar_uids = {CudnnfMHAUid::ALPHA_SCALE_ID,
+                                      CudnnfMHAUid::ZERO_VAL_ID,
+                                      CudnnfMHAUid::ONE_VAL_ID};
+  ScalingParam alpha_scale(scale, dnn::DataType::kFloat);
+  double zero_value = 0.0f;
+  ScalingParam zero(zero_value, dnn::DataType::kFloat);
+  double one_value = 1.0f;
+  ScalingParam one(one_value, dnn::DataType::kFloat);
+  std::vector<ScalingParam> scalar_values = {alpha_scale, zero, one};
+
+  // TODO cudnn doesn't support no dropout, so setting dropout rate to 0
+  // here to mimic no dropout. Change this when cudnn graph is more
+  // flexible.
+  scalar_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
+  double dropout_scale_value =
+      use_dropout ? (1.0 / (1.0 - *dropout_rate)) : 1.0;
+  ScalingParam dropout_scale(dropout_scale_value, dnn::DataType::kFloat);
+  scalar_values.push_back(dropout_scale);
+  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
+
+  TF_ASSIGN_OR_RETURN(
+      auto runner,
+      CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxBackwardSignature>::Create(
+          parent_, cudnn_.get(), std::move(execution_plan),
+          {CudnnfMHAUid::Q_ID, CudnnfMHAUid::K_ID, CudnnfMHAUid::P_ID,
+           CudnnfMHAUid::V_ID, CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
+           CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID,
+           CudnnfMHAUid::dBIAS_ID},
+          /*need_side_input*/ true, /*has_activation_output*/ false,
+          scalar_uids, scalar_values, dropout_rng_seed,
+          /*dropout_rng_offset*/ 0));
+
+  return {std::make_unique<
+      CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxBackwardSignature>>(
+      std::move(runner))};
+#else
+  return tsl::errors::Unimplemented(
+      "Cudnn execution plans with dbias calculation in bwd are only "
+      "supported "
+      "with Cudnn >= 8.8.");
+#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
+CudnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& d_output_descriptor,
+    const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
+    const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
+    const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
+    const dnn::TensorDescriptor& d_S_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor,
+    std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+#if (CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND)
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
+  TF_ASSIGN_OR_RETURN(
+      auto op_graph,
+      GetCudnnFusedMHABackwardOperationGraph(
+          bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
+          bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
+          d_output_descriptor, mask_descriptor, d_S_descriptor,
+          d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
+          kind, dropout_rate, seed, cudnn, scale, use_dropout,
+          /*use_mask*/ true,
+          /*use_bias*/ d_bias_descriptor != std::nullopt));
+
+  TF_ASSIGN_OR_RETURN(auto execution_plan,
+                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
+
+  std::vector<int64_t> scalar_uids = {CudnnfMHAUid::ALPHA_SCALE_ID,
+                                      CudnnfMHAUid::ZERO_VAL_ID,
+                                      CudnnfMHAUid::ONE_VAL_ID};
+  ScalingParam alpha_scale(scale, dnn::DataType::kFloat);
+  double zero_value = 0.0f;
+  ScalingParam zero(zero_value, dnn::DataType::kFloat);
+  double one_value = 1.0f;
+  ScalingParam one(one_value, dnn::DataType::kFloat);
+  std::vector<ScalingParam> scalar_values = {alpha_scale, zero, one};
+
+  // TODO cudnn doesn't support no dropout, so setting dropout rate to 0
+  // here to mimic no dropout. Change this when cudnn graph is more
+  // flexible.
+  scalar_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
+  double dropout_scale_value =
+      use_dropout ? (1.0 / (1.0 - *dropout_rate)) : 1.0;
+  ScalingParam dropout_scale(dropout_scale_value, dnn::DataType::kFloat);
+  scalar_values.push_back(dropout_scale);
+  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
+
+  TF_ASSIGN_OR_RETURN(
+      auto runner,
+      CudnnExecutionPlanRunner<dnn::FusedMHAMaskBackwardSignature>::Create(
+          parent_, cudnn_.get(), std::move(execution_plan),
+          {CudnnfMHAUid::Q_ID, CudnnfMHAUid::K_ID, CudnnfMHAUid::P_ID,
+           CudnnfMHAUid::V_ID, CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
+           CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID,
+           CudnnfMHAUid::MASK_ID, CudnnfMHAUid::dBIAS_ID},
+          /*need_side_input*/ false, /*has_activation_output*/ false,
+          scalar_uids, scalar_values, dropout_rng_seed,
+          /*dropout_rng_offset*/ 0));
+  return {std::make_unique<
+      CudnnExecutionPlanRunner<dnn::FusedMHAMaskBackwardSignature>>(
+      std::move(runner))};
+#else
+  return tsl::errors::Unimplemented(
+      "Cudnn execution plans with mask input in bwd are only supported with "
+      "Cudnn >= 8.9.1");
+#endif  // CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND
 }
 
 bool CudnnSupport::GetRnnAlgorithms(
@@ -6463,7 +7723,8 @@ tsl::Status CudnnSupport::DoBatchNormalizationForwardImpl(
   };
   const cudnnBatchNormOps_t bn_ops = get_bn_ops();
 
-  // We use Nan propagation to be consistent with CudnnSupport::DoActivate(...).
+  // We use Nan propagation to be consistent with
+  // CudnnSupport::DoActivate(...).
   CudnnActivationDescriptor activation_desc(
       activation_mode, CUDNN_PROPAGATE_NAN, x_desc.value_max());
 
@@ -6490,11 +7751,10 @@ tsl::Status CudnnSupport::DoBatchNormalizationForwardImpl(
   auto check_no_side_input_or_activation = [&]() -> tsl::Status {
     if (activation_mode != dnn::ActivationMode::kNone ||
         !side_input.is_null()) {
-      return tsl::Status(
-          absl::StatusCode::kInternal,
-          absl::StrCat(
-              "Side input and activation are not supported by cuDNN version: ",
-              CUDNN_VERSION));
+      return tsl::Status(absl::StatusCode::kInternal,
+                         absl::StrCat("Side input and activation are not "
+                                      "supported by cuDNN version: ",
+                                      CUDNN_VERSION));
     } else {
       return ::tsl::OkStatus();
     }
@@ -6760,7 +8020,8 @@ tsl::Status CudnnSupport::DoFusedConvolve(
   if (input_type == dnn::DataType::kInt8 &&
       !stream->GetCudaComputeCapability().IsAtLeast(6, 1)) {
     return tsl::errors::Unimplemented(
-        "cudnnConvolutionBiasActivationForward() for int8 is only supported "
+        "cudnnConvolutionBiasActivationForward() for int8 is only "
+        "supported "
         "on GPUs with compute capability 6.1 or later.");
   }
 
@@ -6870,8 +8131,8 @@ tsl::Status CudnnSupport::DoPrepareForCtcLoss(
       static_cast<const CudnnRnnStateTensorDescriptor&>(grads_desc);
 
   // Try running with `algo`, if successful then pick it. The
-  // non-deterministic algorithm is first and thus preferentially picked when
-  // determinism is not required.
+  // non-deterministic algorithm is first and thus preferentially picked
+  // when determinism is not required.
   auto algo = RequireCudnnDeterminism(numeric_options)
                   ? CUDNN_CTC_LOSS_ALGO_DETERMINISTIC
                   : CUDNN_CTC_LOSS_ALGO_NON_DETERMINISTIC;
@@ -7177,9 +8438,9 @@ bool CudnnSupport::DoActivate(Stream* stream,
 namespace {
 
 // Cudnn legacy API only supports int32 indexing and can handle a maximum of
-// 2^31-1 elements. For pooling operations, we split the big tensor along the
-// batch axis into multiple small tensors when possible and then call cudnn API
-// sequentially.
+// 2^31-1 elements. For pooling operations, we split the big tensor along
+// the batch axis into multiple small tensors when possible and then call
+// cudnn API sequentially.
 struct PoolingSplitsSpec {
   int64_t num_batches;
   int64_t input_offset_in_bytes;
@@ -7294,8 +8555,8 @@ tsl::Status CudnnSupport::DoPoolForward(
   dnn::BatchDescriptor output_split = output_dimensions;
   for (int i = 0; i < splits.size(); i++) {
     // It is safe to cap the batch dimension, since it is the leading
-    // dimension and will have no effect on the computation of strides in both
-    // kBatchYXDepth and kBatchDepthYX formats.
+    // dimension and will have no effect on the computation of strides in
+    // both kBatchYXDepth and kBatchDepthYX formats.
     input_split.set_count(splits[i].num_batches);
     output_split.set_count(splits[i].num_batches);
     CudnnTensorDescriptor src_desc(input_split, cudnn_input_type);
@@ -7378,8 +8639,8 @@ tsl::Status CudnnSupport::DoPoolBackward(
   dnn::BatchDescriptor output_split = output_dimensions;
   for (int i = 0; i < splits.size(); i++) {
     // It is safe to cap the batch dimension, since it is the leading
-    // dimension and will have no effect on the computation of strides in both
-    // kBatchYXDepth and kBatchDepthYX formats.
+    // dimension and will have no effect on the computation of strides in
+    // both kBatchYXDepth and kBatchDepthYX formats.
     input_split.set_count(splits[i].num_batches);
     output_split.set_count(splits[i].num_batches);
     CudnnTensorDescriptor src_desc(input_split, cudnn_input_type);

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5490,7 +5490,7 @@ GetCudnnFusedMHABackwardOperationGraph(
                                              intermdiate_ops, p_dims, p_strides,
                                              dtype, tensor_ds_mask));
 #else
-  return tsl::errors::Internal("Bias backward op requires cudnn >= 8.9.1");
+  return absl::InternalError("Bias backward op requires cudnn >= 8.9.1");
 #endif
 
   // calculate dq
@@ -5580,7 +5580,7 @@ static tsl::StatusOr<cudnn_frontend::ExecutionPlan> GetExecPlanFromHeuristics(
     VLOG(4) << "Heuristic has " << engine_configs.size() << " configurations ";
   }
   if (engine_configs.size() == 0) {
-    return tsl::errors::Internal(
+    return absl::InternalError(
         "No engine configurations found for this opGraph and heuristics.");
   }
   auto plan = cudnn_frontend::ExecutionPlanBuilder()
@@ -5590,7 +5590,7 @@ static tsl::StatusOr<cudnn_frontend::ExecutionPlan> GetExecPlanFromHeuristics(
 
   return plan;
 #else
-  return tsl::errors::Unimplemented("Supported only for cuDNN >= 8.8.0");
+  return absl::UnimplementedError("Supported only for cuDNN >= 8.8.0");
 #endif
 }
 
@@ -6234,7 +6234,7 @@ class CudnnExecutionPlanRunner<void(Args...)>
       data_ptrs_vec.push_back((void*)(&rng_seed_));
       data_ptrs_vec.push_back((void*)(&initial_offset_));
 #else
-      return tsl::errors::Unimplemented(
+      return absl::UnimplementedError(
           "Cudnn dropout offset and seed are only supported with Cudnn >= "
           "8.8.");
 #endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
@@ -7163,7 +7163,7 @@ CudnnSupport::FusedMHASoftmaxRunnerFromDesc(
       std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxSignature>>(
           std::move(runner))};
 #else
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
 #endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
@@ -7227,7 +7227,7 @@ CudnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
       std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>>(
           std::move(runner))};
 #else
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
 #endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
@@ -7287,7 +7287,7 @@ CudnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
       CudnnExecutionPlanRunner<dnn::FusedMHABiasMaskSignature>>(
       std::move(runner))};
 #else
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
 #endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
@@ -7350,7 +7350,7 @@ CudnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
       std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>>(
           std::move(runner))};
 #else
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "Cudnn execution plans are only supported with Cudnn >= 8.8.");
 #endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
@@ -7385,13 +7385,6 @@ CudnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
           kind, dropout_rate, seed, cudnn, scale, use_dropout,
           /*use_mask*/ false,
           /*use_bias*/ d_bias_descriptor != std::nullopt));
-  // The function  GetExecPlanFromHeuristics uses
-  // cudnn_frontend::cudnnException which is currently not recommended for
-  // use by Google. Hence commenting out the call.
-  // TODO - Create a status wrapper to wrap the exception to avoid it being
-  // exposed to the runtime. TF_ASSIGN_OR_RETURN(auto execution_plan,
-  //                       GetExecPlanFromHeuristics(std::move(*op_graph),
-  //                       cudnn));
 
   TF_ASSIGN_OR_RETURN(auto execution_plan,
                       GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
@@ -7432,7 +7425,7 @@ CudnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
       CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxBackwardSignature>>(
       std::move(runner))};
 #else
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "Cudnn execution plans with dbias calculation in bwd are only "
       "supported "
       "with Cudnn >= 8.8.");
@@ -7508,7 +7501,7 @@ CudnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
       CudnnExecutionPlanRunner<dnn::FusedMHAMaskBackwardSignature>>(
       std::move(runner))};
 #else
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "Cudnn execution plans with mask input in bwd are only supported with "
       "Cudnn >= 8.9.1");
 #endif  // CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -336,9 +336,9 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
       const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
       const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
-      const dnn::TensorDescriptor& d_S_descriptor,
+      const dnn::TensorDescriptor& d_s_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
 
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
   FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
@@ -352,10 +352,10 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
       const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
       const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
-      const dnn::TensorDescriptor& d_S_descriptor,
+      const dnn::TensorDescriptor& d_s_descriptor,
       const dnn::TensorDescriptor& mask_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -25,11 +25,11 @@ limitations under the License.
 
 #include "absl/base/thread_annotations.h"
 #include "absl/types/span.h"
+#include "tsl/platform/status.h"
 #include "xla/stream_executor/cuda/cuda_activation.h"
 #include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/plugin_registry.h"
 #include "xla/stream_executor/temporary_device_memory.h"
-#include "tsl/platform/status.h"
 
 namespace stream_executor {
 namespace gpu {
@@ -324,6 +324,38 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::TensorDescriptor& bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
 
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
+  FusedMHASoftmaxBackwardRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& d_output_descriptor,
+      const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
+      const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
+      const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
+      const dnn::TensorDescriptor& d_S_descriptor,
+      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
+  FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& d_output_descriptor,
+      const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
+      const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
+      const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
+      const dnn::TensorDescriptor& d_S_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor,
+      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 

--- a/xla/stream_executor/data_type.h
+++ b/xla/stream_executor/data_type.h
@@ -78,6 +78,10 @@ struct ToDataType<int32_t> {
   static constexpr DataType value = DataType::kInt32;
 };
 template <>
+struct ToDataType<int64_t> {
+  static constexpr DataType value = DataType::kInt64;
+};
+template <>
 struct ToDataType<std::complex<float>> {
   static constexpr DataType value = DataType::kComplexFloat;
 };

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -201,7 +201,7 @@ DnnSupport::FusedMHASoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "FusedMHASoftmaxRunnerFromDesc not implemented.");
 }
 
@@ -216,7 +216,7 @@ DnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
     const dnn::TensorDescriptor& output_descriptor,
     const dnn::TensorDescriptor& mask_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "FusedMHAScaleMaskSoftmaxRunnerFromDesc not implemented.");
 }
 
@@ -232,7 +232,7 @@ DnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
     const dnn::TensorDescriptor& mask_descriptor,
     const dnn::TensorDescriptor& bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc not implemented.");
 }
 
@@ -247,7 +247,7 @@ DnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
     const dnn::TensorDescriptor& output_descriptor,
     const dnn::TensorDescriptor& bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "FusedMHAScaleBiasSoftmaxRunnerFromDesc not implemented.");
 }
 
@@ -266,7 +266,7 @@ DnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
     const TensorDescriptor& d_S_descriptor,
     std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "FusedMHASoftmaxBackwardRunnerFromDesc not implemented.");
 }
 
@@ -286,7 +286,7 @@ DnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
     const TensorDescriptor& mask_descriptor,
     std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return tsl::errors::Unimplemented(
+  return absl::UnimplementedError(
       "FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc not implemented.");
 }
 

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -25,9 +25,9 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/types/span.h"
-#include "xla/stream_executor/numeric_options.h"
 #include "tsl/lib/strings/proto_serialization.h"
 #include "tsl/protobuf/dnn.pb.h"
+#include "xla/stream_executor/numeric_options.h"
 
 namespace stream_executor {
 namespace dnn {
@@ -263,7 +263,7 @@ DnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
     const TensorDescriptor& d_bmm1_lhs_descriptor,
     const TensorDescriptor& d_bmm1_rhs_descriptor,
     const TensorDescriptor& d_bmm2_rhs_descriptor,
-    const TensorDescriptor& d_S_descriptor,
+    const TensorDescriptor& d_s_descriptor,
     std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
   return absl::UnimplementedError(
@@ -282,7 +282,7 @@ DnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
     const TensorDescriptor& d_bmm1_lhs_descriptor,
     const TensorDescriptor& d_bmm1_rhs_descriptor,
     const TensorDescriptor& d_bmm2_rhs_descriptor,
-    const TensorDescriptor& d_S_descriptor,
+    const TensorDescriptor& d_s_descriptor,
     const TensorDescriptor& mask_descriptor,
     std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -60,6 +60,7 @@ constexpr DataType ToDataType<Eigen::half>::value;
 constexpr DataType ToDataType<Eigen::bfloat16>::value;
 constexpr DataType ToDataType<int8_t>::value;
 constexpr DataType ToDataType<int32_t>::value;
+constexpr DataType ToDataType<int64_t>::value;
 constexpr DataType ToDataType<std::complex<float>>::value;
 constexpr DataType ToDataType<std::complex<double>>::value;
 
@@ -248,6 +249,45 @@ DnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
   return tsl::errors::Unimplemented(
       "FusedMHAScaleBiasSoftmaxRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
+DnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+    const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+    const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+    const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+    const MatmulTensorDescriptor& d_output_descriptor,
+    const TensorDescriptor& d_bmm1_lhs_descriptor,
+    const TensorDescriptor& d_bmm1_rhs_descriptor,
+    const TensorDescriptor& d_bmm2_rhs_descriptor,
+    const TensorDescriptor& d_S_descriptor,
+    std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHASoftmaxBackwardRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
+DnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+    const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+    const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+    const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+    const MatmulTensorDescriptor& d_output_descriptor,
+    const TensorDescriptor& d_bmm1_lhs_descriptor,
+    const TensorDescriptor& d_bmm1_rhs_descriptor,
+    const TensorDescriptor& d_bmm2_rhs_descriptor,
+    const TensorDescriptor& d_S_descriptor,
+    const TensorDescriptor& mask_descriptor,
+    std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc not implemented.");
 }
 
 bool DnnSupport::GetMIOpenConvolveAlgorithms(

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1013,6 +1013,31 @@ using FusedMHABiasSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                    DeviceMemoryBase /* output_data */);
 using FusedMHABiasRunner = OpRunner<FusedMHABiasSignature>;
 
+using FusedMHASoftmaxBackwardSignature =
+    void(DeviceMemoryBase /* BMM1_GRAD_GEMM1_inputA_data */,
+         DeviceMemoryBase /* BMM1_GRAD_GEMM2_inputB_data */,
+         DeviceMemoryBase /* BMM2_GRAD_GEMM1_inputA_data */,
+         DeviceMemoryBase /* BMM2_GRAD_GEMM2_inputB_data */,
+         DeviceMemoryBase /* d_output_data */,
+         DeviceMemoryBase /* d_BMM1_inputA_data */,
+         DeviceMemoryBase /* d_BMM1_inputB_data */,
+         DeviceMemoryBase /* d_BMM2_inputB_data */,
+         DeviceMemoryBase /* d_S_data */, DeviceMemoryBase /* d_bias_data */);
+using FusedMHASoftmaxBackwardRunner =
+    OpRunner<FusedMHASoftmaxBackwardSignature>;
+
+using FusedMHAMaskBackwardSignature = void(
+    DeviceMemoryBase /* BMM1_GRAD_GEMM1_inputA_data */,
+    DeviceMemoryBase /* BMM1_GRAD_GEMM2_inputB_data */,
+    DeviceMemoryBase /* BMM2_GRAD_GEMM1_inputA_data */,
+    DeviceMemoryBase /* BMM2_GRAD_GEMM2_inputB_data */,
+    DeviceMemoryBase /* d_output_data */,
+    DeviceMemoryBase /* d_BMM1_inputA_data */,
+    DeviceMemoryBase /* d_BMM1_inputB_data */,
+    DeviceMemoryBase /* d_BMM2_inputB_data */, DeviceMemoryBase /* d_S_data */,
+    DeviceMemoryBase /* mask_data */, DeviceMemoryBase /* d_bias_data */);
+using FusedMHAMaskBackwardRunner = OpRunner<FusedMHAMaskBackwardSignature>;
+
 // Describes the configuration for the algorithms that will used.
 //
 // Arguments:
@@ -1680,6 +1705,40 @@ class DnnSupport {
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
       const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+ virtual tsl::StatusOr<
+      std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
+  FusedMHASoftmaxBackwardRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+      const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+      const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+      const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+      const MatmulTensorDescriptor& d_output_descriptor,
+      const TensorDescriptor& d_bmm1_lhs_descriptor,
+      const TensorDescriptor& d_bmm1_rhs_descriptor,
+      const TensorDescriptor& d_bmm2_rhs_descriptor,
+      const TensorDescriptor& d_S_descriptor,
+      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
+  FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
+      const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
+      const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
+      const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
+      const MatmulTensorDescriptor& d_output_descriptor,
+      const TensorDescriptor& d_bmm1_lhs_descriptor,
+      const TensorDescriptor& d_bmm1_rhs_descriptor,
+      const TensorDescriptor& d_bmm2_rhs_descriptor,
+      const TensorDescriptor& d_S_descriptor,
+      const TensorDescriptor& mask_descriptor,
+      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
   virtual bool GetMIOpenConvolveAlgorithms(

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -34,9 +34,11 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "google/protobuf/wrappers.pb.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
+#include "google/protobuf/wrappers.pb.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
 #include "xla/stream_executor/data_type.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/device_description.pb.h"
@@ -45,8 +47,6 @@ limitations under the License.
 #include "xla/stream_executor/numeric_options.h"
 #include "xla/stream_executor/platform/logging.h"
 #include "xla/stream_executor/platform/port.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
 
 namespace Eigen {
 struct half;
@@ -1707,7 +1707,7 @@ class DnnSupport {
       const dnn::TensorDescriptor& bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
- virtual tsl::StatusOr<
+  virtual tsl::StatusOr<
       std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
   FusedMHASoftmaxBackwardRunnerFromDesc(
       Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
@@ -1720,7 +1720,7 @@ class DnnSupport {
       const TensorDescriptor& d_bmm1_lhs_descriptor,
       const TensorDescriptor& d_bmm1_rhs_descriptor,
       const TensorDescriptor& d_bmm2_rhs_descriptor,
-      const TensorDescriptor& d_S_descriptor,
+      const TensorDescriptor& d_s_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
@@ -1736,7 +1736,7 @@ class DnnSupport {
       const TensorDescriptor& d_bmm1_lhs_descriptor,
       const TensorDescriptor& d_bmm1_rhs_descriptor,
       const TensorDescriptor& d_bmm2_rhs_descriptor,
-      const TensorDescriptor& d_S_descriptor,
+      const TensorDescriptor& d_s_descriptor,
       const TensorDescriptor& mask_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);

--- a/xla/stream_executor/lazy_op_runner.h
+++ b/xla/stream_executor/lazy_op_runner.h
@@ -325,7 +325,7 @@ struct FusedMHASoftmaxBackwardOp {
     const TensorDescriptor& d_bmm1_lhs_descriptor;
     const TensorDescriptor& d_bmm1_rhs_descriptor;
     const TensorDescriptor& d_bmm2_rhs_descriptor;
-    const TensorDescriptor& d_S_descriptor;
+    const TensorDescriptor& d_s_descriptor;
     std::optional<TensorDescriptor> d_bias_descriptor;
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
@@ -341,7 +341,7 @@ struct FusedMHASoftmaxBackwardOp {
         config.bmm2_grad_gemm1_lhs_descriptor,
         config.bmm2_grad_gemm2_rhs_descriptor, config.d_output_descriptor,
         config.d_bmm1_lhs_descriptor, config.d_bmm1_rhs_descriptor,
-        config.d_bmm2_rhs_descriptor, config.d_S_descriptor,
+        config.d_bmm2_rhs_descriptor, config.d_s_descriptor,
         config.d_bias_descriptor, config.scale, config.dropout_rate,
         config.seed);
   }
@@ -361,7 +361,7 @@ struct FusedMHAScaleMaskSoftmaxBackwardOp {
     const TensorDescriptor& d_bmm1_lhs_descriptor;
     const TensorDescriptor& d_bmm1_rhs_descriptor;
     const TensorDescriptor& d_bmm2_rhs_descriptor;
-    const TensorDescriptor& d_S_descriptor;
+    const TensorDescriptor& d_s_descriptor;
     const TensorDescriptor& mask_descriptor;
     std::optional<TensorDescriptor> d_bias_descriptor;
     std::optional<double> dropout_rate;
@@ -378,7 +378,7 @@ struct FusedMHAScaleMaskSoftmaxBackwardOp {
         config.bmm2_grad_gemm1_lhs_descriptor,
         config.bmm2_grad_gemm2_rhs_descriptor, config.d_output_descriptor,
         config.d_bmm1_lhs_descriptor, config.d_bmm1_rhs_descriptor,
-        config.d_bmm2_rhs_descriptor, config.d_S_descriptor,
+        config.d_bmm2_rhs_descriptor, config.d_s_descriptor,
         config.mask_descriptor, config.d_bias_descriptor, config.scale,
         config.dropout_rate, config.seed);
   }

--- a/xla/stream_executor/lazy_op_runner.h
+++ b/xla/stream_executor/lazy_op_runner.h
@@ -311,6 +311,79 @@ struct FusedMHAScaleBiasSoftmaxOp {
   }
 };
 
+struct FusedMHASoftmaxBackwardOp {
+  using Signature = FusedMHASoftmaxBackwardSignature;
+
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor;
+    const MatmulTensorDescriptor& d_output_descriptor;
+    const TensorDescriptor& d_bmm1_lhs_descriptor;
+    const TensorDescriptor& d_bmm1_rhs_descriptor;
+    const TensorDescriptor& d_bmm2_rhs_descriptor;
+    const TensorDescriptor& d_S_descriptor;
+    std::optional<TensorDescriptor> d_bias_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<
+      std::unique_ptr<const OpRunner<FusedMHASoftmaxBackwardSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHASoftmaxBackwardRunnerFromDesc(
+        desc, config.kind, config.bmm1_grad_gemm1_rhs_descriptor,
+        config.bmm1_grad_gemm2_rhs_descriptor,
+        config.bmm2_grad_gemm1_lhs_descriptor,
+        config.bmm2_grad_gemm2_rhs_descriptor, config.d_output_descriptor,
+        config.d_bmm1_lhs_descriptor, config.d_bmm1_rhs_descriptor,
+        config.d_bmm2_rhs_descriptor, config.d_S_descriptor,
+        config.d_bias_descriptor, config.scale, config.dropout_rate,
+        config.seed);
+  }
+};
+
+struct FusedMHAScaleMaskSoftmaxBackwardOp {
+  using Signature = FusedMHAMaskBackwardSignature;
+
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor;
+    const MatmulTensorDescriptor& d_output_descriptor;
+    const TensorDescriptor& d_bmm1_lhs_descriptor;
+    const TensorDescriptor& d_bmm1_rhs_descriptor;
+    const TensorDescriptor& d_bmm2_rhs_descriptor;
+    const TensorDescriptor& d_S_descriptor;
+    const TensorDescriptor& mask_descriptor;
+    std::optional<TensorDescriptor> d_bias_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<
+      std::unique_ptr<const OpRunner<FusedMHAMaskBackwardSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+        desc, config.kind, config.bmm1_grad_gemm1_rhs_descriptor,
+        config.bmm1_grad_gemm2_rhs_descriptor,
+        config.bmm2_grad_gemm1_lhs_descriptor,
+        config.bmm2_grad_gemm2_rhs_descriptor, config.d_output_descriptor,
+        config.d_bmm1_lhs_descriptor, config.d_bmm1_rhs_descriptor,
+        config.d_bmm2_rhs_descriptor, config.d_S_descriptor,
+        config.mask_descriptor, config.d_bias_descriptor, config.scale,
+        config.dropout_rate, config.seed);
+  }
+};
+
 }  // namespace dnn
 }  // namespace stream_executor
 

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -539,6 +539,60 @@ class Stream {
         output_descriptor, bias_descriptor, scale, dropout_rate, seed);
   }
 
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
+  FusedMHASoftmaxBackwardRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_grad_gemm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_grad_gemm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &d_output_descriptor,
+      const dnn::TensorDescriptor &d_bmm1_lhs_descriptor,
+      const dnn::TensorDescriptor &d_bmm1_rhs_descriptor,
+      const dnn::TensorDescriptor &d_bmm2_rhs_descriptor,
+      const dnn::TensorDescriptor &d_S_descriptor,
+      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHASoftmaxBackwardRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_grad_gemm1_rhs_descriptor,
+        bmm1_grad_gemm2_rhs_descriptor, bmm2_grad_gemm1_lhs_descriptor,
+        bmm2_grad_gemm2_rhs_descriptor, d_output_descriptor,
+        d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
+        d_S_descriptor, d_bias_descriptor, scale, dropout_rate, seed);
+  }
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
+  FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_grad_gemm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_grad_gemm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_grad_gemm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &d_output_descriptor,
+      const dnn::TensorDescriptor &d_bmm1_lhs_descriptor,
+      const dnn::TensorDescriptor &d_bmm1_rhs_descriptor,
+      const dnn::TensorDescriptor &d_bmm2_rhs_descriptor,
+      const dnn::TensorDescriptor &d_S_descriptor,
+      const dnn::TensorDescriptor &mask_descriptor,
+      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_grad_gemm1_rhs_descriptor,
+        bmm1_grad_gemm2_rhs_descriptor, bmm2_grad_gemm1_lhs_descriptor,
+        bmm2_grad_gemm2_rhs_descriptor, d_output_descriptor,
+        d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
+        d_S_descriptor, mask_descriptor, d_bias_descriptor, scale, dropout_rate,
+        seed);
+  }
+
   Stream &ThenSeparableConvolve(
       const dnn::BatchDescriptor &input_descriptor,
       const DeviceMemory<float> &input_data,

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -469,7 +469,7 @@ class Stream {
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
-      return tsl::errors::Unimplemented("DNN library is not found.");
+      return absl::UnimplementedError("DNN library is not found.");
     }
     return dnn_support->FusedMHASoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
@@ -489,7 +489,7 @@ class Stream {
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
-      return tsl::errors::Unimplemented("DNN library is not found.");
+      return absl::UnimplementedError("DNN library is not found.");
     }
     return dnn_support->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
@@ -510,7 +510,7 @@ class Stream {
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
-      return tsl::errors::Unimplemented("DNN library is not found.");
+      return absl::UnimplementedError("DNN library is not found.");
     }
     return dnn_support->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
@@ -531,7 +531,7 @@ class Stream {
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
-      return tsl::errors::Unimplemented("DNN library is not found.");
+      return absl::UnimplementedError("DNN library is not found.");
     }
     return dnn_support->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
@@ -555,7 +555,7 @@ class Stream {
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
-      return tsl::errors::Unimplemented("DNN library is not found.");
+      return absl::UnimplementedError("DNN library is not found.");
     }
     return dnn_support->FusedMHASoftmaxBackwardRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_grad_gemm1_rhs_descriptor,
@@ -582,7 +582,7 @@ class Stream {
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
-      return tsl::errors::Unimplemented("DNN library is not found.");
+      return absl::UnimplementedError("DNN library is not found.");
     }
     return dnn_support->FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_grad_gemm1_rhs_descriptor,

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -550,7 +550,7 @@ class Stream {
       const dnn::TensorDescriptor &d_bmm1_lhs_descriptor,
       const dnn::TensorDescriptor &d_bmm1_rhs_descriptor,
       const dnn::TensorDescriptor &d_bmm2_rhs_descriptor,
-      const dnn::TensorDescriptor &d_S_descriptor,
+      const dnn::TensorDescriptor &d_s_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
@@ -562,7 +562,7 @@ class Stream {
         bmm1_grad_gemm2_rhs_descriptor, bmm2_grad_gemm1_lhs_descriptor,
         bmm2_grad_gemm2_rhs_descriptor, d_output_descriptor,
         d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
-        d_S_descriptor, d_bias_descriptor, scale, dropout_rate, seed);
+        d_s_descriptor, d_bias_descriptor, scale, dropout_rate, seed);
   }
 
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
@@ -576,7 +576,7 @@ class Stream {
       const dnn::TensorDescriptor &d_bmm1_lhs_descriptor,
       const dnn::TensorDescriptor &d_bmm1_rhs_descriptor,
       const dnn::TensorDescriptor &d_bmm2_rhs_descriptor,
-      const dnn::TensorDescriptor &d_S_descriptor,
+      const dnn::TensorDescriptor &d_s_descriptor,
       const dnn::TensorDescriptor &mask_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
@@ -589,7 +589,7 @@ class Stream {
         bmm1_grad_gemm2_rhs_descriptor, bmm2_grad_gemm1_lhs_descriptor,
         bmm2_grad_gemm2_rhs_descriptor, d_output_descriptor,
         d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
-        d_S_descriptor, mask_descriptor, d_bias_descriptor, scale, dropout_rate,
+        d_s_descriptor, mask_descriptor, d_bias_descriptor, scale, dropout_rate,
         seed);
   }
 


### PR DESCRIPTION
This is the commit to include only stream executor changes to support fmha training. In total, it's broken into 3 PRs.
This is the first of 3. The other PRs' links:
Rewriter changes are in this [pr](https://github.com/openxla/xla/pull/3726)
lhlo lowering logic is in this [pr](https://github.com/openxla/xla/pull/3886)