### PR TITLE
[python:xla_extension] Handle unbounded recursion in cyclical PyTrees

### DIFF
--- a/xla/python/pytree.cc
+++ b/xla/python/pytree.cc
@@ -185,7 +185,12 @@ void PyTreeDef::FlattenIntoImpl(
   } else {
     node.kind = GetKind(handle, &node.custom);
     auto recurse = [this, &leaf_predicate, &leaves](py::handle child) {
+      if (Py_EnterRecursiveCall(
+              " in flatten; PyTree may have cyclical node references.")) {
+        return;
+      }
       FlattenInto(child, leaves, leaf_predicate);
+      Py_LeaveRecursiveCall();
     };
     switch (node.kind) {
       case PyTreeKind::kNone:
@@ -265,6 +270,10 @@ PyTreeDef::Flatten(py::handle x, std::optional<py::function> leaf_predicate) {
   std::vector<py::object> leaves;
   auto tree = std::make_unique<PyTreeDef>();
   tree->FlattenInto(x, leaves, leaf_predicate);
+  // Handle the unbounded recursion error for trees with cyclical node references.
+  if (PyErr_Occurred()) {
+    throw py::error_already_set();
+  }
   return std::make_pair(std::move(leaves), std::move(tree));
 }
 

--- a/xla/python/xla_client.py
+++ b/xla/python/xla_client.py
@@ -44,7 +44,7 @@ profiler = _xla.profiler
 
 # Just an internal arbitrary increasing number to help with backward-compatible
 # changes.
-_version = 165
+_version = 166
 
 # Version number for MLIR:Python components.
 mlir_api_version = 51


### PR DESCRIPTION
Provides more graceful handling of an unbounded recursion error that can occur when attempting to flatten a PyTree with cyclical node references. 

Example from https://github.com/google/jax/issues/15711:
```Python
import jax.tree_util as jtu
a = []
a.append(a)
jtu.tree_flatten(a)
# “python” terminated by signal SIGSEGV (Address boundary error)
```

With this pull, the above snippet now returns the error message:
```Python
RecursionError: maximum recursion depth exceeded in flatten; PyTree may have cyclical node references.
```

The maximum recursion depth before the error is throw, is controlled by the Python interpreter.