### PR TITLE
[NVIDIA XLA:GPU] Introducing training support for cudnn fused mha (LHLO lowering and thunk, 2nd out of 3)

### DIFF
--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -313,17 +313,19 @@ def LHLOGPU_fusedMHAOp : LHLOGPU_Op<"fMHA"> {
     Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm2,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output,
     Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$activation,
     MHLO_DotDimensionNumbers:$bmm1_dot_dimension_numbers,
     MHLO_DotDimensionNumbers:$bmm2_dot_dimension_numbers,
     I64ArrayAttr:$intermediate_tensor_dimensions,
     I64ArrayAttr:$intermediate_tensor_layout,
+    F64Attr:$fmha_scale,
     OptionalAttr<F64Attr>:$dropout_rate,
     FusedMhaDagSignatureAttr:$fused_mha_dag,
     FusedMHAAlgorithmConfigAttr:$algorithm_config,
     OptionalAttr<I64Attr>:$seed);
 }
 
-def LHLOGPU_fusedMHAWithScaledMaskOp : LHLOGPU_Op<"fMHAWithScaledMask"> {
+def LHLOGPU_fusedMHAWithScaledMaskOp : LHLOGPU_Op<"fMHAWithScaledMask", [AttrSizedOperandSegments]> {
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$lhs_bmm1,
     Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm1,
@@ -332,6 +334,7 @@ def LHLOGPU_fusedMHAWithScaledMaskOp : LHLOGPU_Op<"fMHAWithScaledMask"> {
     Arg<Optional<LHLO_Buffer>, "", [MemRead]>:$bias,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output,
     Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$activation,
     MHLO_DotDimensionNumbers:$bmm1_dot_dimension_numbers,
     MHLO_DotDimensionNumbers:$bmm2_dot_dimension_numbers,
     I64ArrayAttr:$intermediate_tensor_dimensions,
@@ -352,6 +355,7 @@ def LHLOGPU_fusedMHAWithScaledBiasOp : LHLOGPU_Op<"fMHAWithScaledBias"> {
     Arg<LHLO_Buffer, "", [MemRead]>:$bias,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output,
     Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$activation,
     MHLO_DotDimensionNumbers:$bmm1_dot_dimension_numbers,
     MHLO_DotDimensionNumbers:$bmm2_dot_dimension_numbers,
     I64ArrayAttr:$intermediate_tensor_dimensions,
@@ -359,6 +363,56 @@ def LHLOGPU_fusedMHAWithScaledBiasOp : LHLOGPU_Op<"fMHAWithScaledBias"> {
     F64Attr:$fmha_scale,
     OptionalAttr<F64Attr>:$dropout_rate,
     FusedMhaDagSignatureAttr:$fused_mha_dag,
+    FusedMHAAlgorithmConfigAttr:$algorithm_config,
+    OptionalAttr<I64Attr>:$seed
+    );
+}
+
+def LHLOGPU_fusedMHABackwardOp : LHLOGPU_Op<"fMHABackward"> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm1_rhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm2_rhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm2_rhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm1_lhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$d_output,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_lhs,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_rhs,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm2_rhs,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_S,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$d_bias,
+    MHLO_DotDimensionNumbers:$bmm1_grad_gemm1_dot_dimension_numbers,
+    MHLO_DotDimensionNumbers:$bmm1_grad_gemm2_dot_dimension_numbers,
+    MHLO_DotDimensionNumbers:$bmm2_grad_gemm1_dot_dimension_numbers,
+    MHLO_DotDimensionNumbers:$bmm2_grad_gemm2_dot_dimension_numbers,
+    F64Attr:$fmha_scale,
+    OptionalAttr<F64Attr>:$dropout_rate,
+    FusedMhaBackwardDagSignatureAttr:$fused_mha_dag,
+    FusedMHAAlgorithmConfigAttr:$algorithm_config,
+    OptionalAttr<I64Attr>:$seed);
+}
+
+def LHLOGPU_fusedMHAWithMaskBackwardOp : LHLOGPU_Op<"fMHAWithMaskBackward"> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm1_rhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm2_rhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm2_rhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm1_lhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$d_output,
+    Arg<LHLO_Buffer, "", [MemRead]>:$mask,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_lhs,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_rhs,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm2_rhs,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$d_S,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$d_bias,
+    MHLO_DotDimensionNumbers:$bmm1_grad_gemm1_dot_dimension_numbers,
+    MHLO_DotDimensionNumbers:$bmm1_grad_gemm2_dot_dimension_numbers,
+    MHLO_DotDimensionNumbers:$bmm2_grad_gemm1_dot_dimension_numbers,
+    MHLO_DotDimensionNumbers:$bmm2_grad_gemm2_dot_dimension_numbers,
+    F64Attr:$fmha_scale,
+    OptionalAttr<F64Attr>:$dropout_rate,
+    FusedMhaBackwardDagSignatureAttr:$fused_mha_dag,
     FusedMHAAlgorithmConfigAttr:$algorithm_config,
     OptionalAttr<I64Attr>:$seed
     );

--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
@@ -137,6 +137,11 @@ def FusedMhaDagSoftmax : I32EnumAttrCase<"Softmax", 6>;
 def FusedMhaDagScaleBiasSoftmaxDropout : I32EnumAttrCase<"ScaleBiasSoftmaxDropout", 7>;
 def FusedMhaDagScaleBiasSoftmax : I32EnumAttrCase<"ScaleBiasSoftmax", 8>;
 
+def FusedMhaBackwardDagScaleBiasSoftmaxDropout : I32EnumAttrCase<"BackwardScaleBiasSoftmaxDropout", 0>;
+def FusedMhaBackwardDagScaleBiasSoftmax : I32EnumAttrCase<"BackwardScaleBiasSoftmax", 1>;
+def FusedMhaBackwardDagScaleBiasMaskSoftmax : I32EnumAttrCase<"BackwardScaleBiasMaskSoftmax", 2>;
+def FusedMhaBackwardDagScaleBiasMaskSoftmaxDropout : I32EnumAttrCase<"BackwardScaleBiasMaskSoftmaxDropout", 3>;
+
 def FusedMhaDagSignature: I32EnumAttr<"FusedMhaDagSignature",
     "DAG configuration for Fused Multi-Headed Attention",
     [FusedMhaDagDefault, 
@@ -152,6 +157,17 @@ def FusedMhaDagSignature: I32EnumAttr<"FusedMhaDagSignature",
   let cppNamespace = "::mlir::lmhlo_gpu";
 }
 
-def FusedMhaDagSignatureAttr : EnumAttr<LmhloGpuDialect, FusedMhaDagSignature, "fused_mha_dag">;
+def FusedMhaBackwardDagSignature: I32EnumAttr<"FusedMhaBackwardDagSignature",
+    "DAG configuration for Fused Multi-Headed Attention Backward",
+    [
+    FusedMhaBackwardDagScaleBiasSoftmaxDropout,
+    FusedMhaBackwardDagScaleBiasSoftmax,
+    FusedMhaBackwardDagScaleBiasMaskSoftmax,
+    FusedMhaBackwardDagScaleBiasMaskSoftmaxDropout]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::lmhlo_gpu";
+}
 
+def FusedMhaDagSignatureAttr : EnumAttr<LmhloGpuDialect, FusedMhaDagSignature, "fused_mha_dag">;
+def FusedMhaBackwardDagSignatureAttr : EnumAttr<LmhloGpuDialect, FusedMhaBackwardDagSignature, "fused_mha_backward_dag">;
 #endif // LHLO_GPU_OPS_ENUMS

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -127,17 +127,24 @@ message CudnnfMHABackendConfig {
   // Opaque algorithm number and tuning knobs chosen for this fMHA.
   stream_executor.dnn.AlgorithmProto algorithm = 8;
 
-  // The scaling factor multiplied with the BMM1 result. fmha_scale is 0 if the
+  // The scaling factor multiplied with the BMM1 result. fmha_scale is 1 if the
   // MHA pattern has no scaling.
   double fmha_scale = 10;
 
   // Dropout factor in MHA
   double dropout_rate = 13;
 
+// Configs for mha bmms in the forward graph
   xla.DotDimensionNumbers bmm1_dot_dimension_numbers = 11;
   xla.DotDimensionNumbers bmm2_dot_dimension_numbers = 12;
 
   xla.ShapeProto intermediate_tensor_shape = 14;
+
+  // Configs for mha bmms in the backward graph
+  xla.DotDimensionNumbers bmm1_grad_gemm1_dot_dimension_numbers = 16;
+  xla.DotDimensionNumbers bmm1_grad_gemm2_dot_dimension_numbers = 17;
+  xla.DotDimensionNumbers bmm2_grad_gemm1_dot_dimension_numbers = 18;
+  xla.DotDimensionNumbers bmm2_grad_gemm2_dot_dimension_numbers = 19;
 
   // Random seed used by dropout
   int64 seed = 15;

--- a/xla/service/gpu/cublas_cudnn.cc
+++ b/xla/service/gpu/cublas_cudnn.cc
@@ -56,7 +56,7 @@ const absl::string_view kCudnnConvReorderFilterCallTarget =
 const absl::string_view kCudnnConvReorderFilterAndBiasCallTarget =
     "__cudnn$convReorderFilterAndBias";
 
-// fMHA call targets.
+// fMHA forward call targets.
 const absl::string_view kCudnnfMHABmmBmmCallTarget = "__cudnn$fhmaBmmBmm";
 const absl::string_view kCudnnfMHASoftmaxCallTarget = "__cudnn$fhmaSoftmax";
 const absl::string_view kCudnnfMHAScaleBiasMaskSoftmaxCallTarget =
@@ -73,6 +73,27 @@ const absl::string_view kCudnnfMHAScaleMaskSoftmaxDropoutCallTarget =
     "__cudnn$fhmaScaleMaskSoftmaxDropout";
 const absl::string_view kCudnnfMHASoftmaxDropoutCallTarget =
     "__cudnn$fhmaSoftmaxDropout";
+
+// fMHA backward call targets.
+const absl::string_view kCudnnfMHABmmBmmBackwardCallTarget =
+    "__cudnn$fhmaBmmBmmBackward";
+const absl::string_view kCudnnfMHASoftmaxBackwardCallTarget =
+    "__cudnn$fhmaSoftmaxBackward";
+const absl::string_view kCudnnfMHAScaleBiasMaskSoftmaxBackwardCallTarget =
+    "__cudnn$fhmaScaleBiasMaskSoftmaxBackward";
+const absl::string_view
+    kCudnnfMHAScaleBiasMaskSoftmaxDropoutBackwardCallTarget =
+        "__cudnn$fhmaScaleBiasMaskSoftmaxDropoutBackward";
+const absl::string_view kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget =
+    "__cudnn$fhmaScaleBiasSoftmaxDropoutBackward";
+const absl::string_view kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget =
+    "__cudnn$fhmaScaleBiasSoftmaxBackward";
+const absl::string_view kCudnnfMHAScaleMaskSoftmaxBackwardCallTarget =
+    "__cudnn$fhmaScaleMaskSoftmaxBackward";
+const absl::string_view kCudnnfMHAScaleMaskSoftmaxDropoutBackwardCallTarget =
+    "__cudnn$fhmaScaleMaskSoftmaxDropoutBackward";
+const absl::string_view kCudnnfMHASoftmaxDropoutBackwardCallTarget =
+    "__cudnn$fhmaSoftmaxDropoutBackward";
 
 bool IsCustomCallToDnnConvolution(const HloInstruction& hlo) {
   if (hlo.opcode() != HloOpcode::kCustomCall) {
@@ -94,7 +115,10 @@ bool IsCudnnConvolutionReorder(const HloInstruction& hlo) {
          target == kCudnnConvReorderFilterAndBiasCallTarget;
 }
 
-bool IsCustomCallTofMHA(const HloInstruction& hlo) {
+bool IsFwdCustomCallTofMHA(const HloInstruction& hlo) {
+  if (hlo.opcode() != HloOpcode::kCustomCall) {
+    return false;
+  }
   const auto& target = hlo.custom_call_target();
   return target == kCudnnfMHABmmBmmCallTarget ||
          target == kCudnnfMHASoftmaxCallTarget ||
@@ -105,6 +129,37 @@ bool IsCustomCallTofMHA(const HloInstruction& hlo) {
          target == kCudnnfMHASoftmaxDropoutCallTarget ||
          target == kCudnnfMHAScaleBiasSoftmaxCallTarget ||
          target == kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget;
+}
+
+bool IsBwdCustomCallTofMHA(const HloInstruction& hlo) {
+  if (hlo.opcode() != HloOpcode::kCustomCall) {
+    return false;
+  }
+  const auto& target = hlo.custom_call_target();
+  return target == kCudnnfMHABmmBmmBackwardCallTarget ||
+         target == kCudnnfMHASoftmaxBackwardCallTarget ||
+         target == kCudnnfMHAScaleBiasMaskSoftmaxBackwardCallTarget ||
+         target == kCudnnfMHAScaleBiasMaskSoftmaxDropoutBackwardCallTarget ||
+         target == kCudnnfMHAScaleMaskSoftmaxBackwardCallTarget ||
+         target == kCudnnfMHAScaleMaskSoftmaxDropoutBackwardCallTarget ||
+         target == kCudnnfMHASoftmaxDropoutBackwardCallTarget ||
+         target == kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget ||
+         target == kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget;
+}
+
+bool MHACallHasDropout(const absl::string_view fmha_call_name) {
+  return fmha_call_name == kCudnnfMHAScaleBiasMaskSoftmaxDropoutCallTarget ||
+         fmha_call_name == kCudnnfMHAScaleMaskSoftmaxDropoutCallTarget ||
+         fmha_call_name == kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget ||
+         fmha_call_name ==
+             kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget ||
+         fmha_call_name ==
+             kCudnnfMHAScaleBiasMaskSoftmaxDropoutBackwardCallTarget ||
+         fmha_call_name == kCudnnfMHAScaleMaskSoftmaxDropoutBackwardCallTarget;
+}
+
+bool IsCustomCallTofMHA(const HloInstruction& hlo) {
+  return (IsFwdCustomCallTofMHA(hlo) || IsBwdCustomCallTofMHA(hlo));
 }
 
 StatusOr<CudnnConvKind> GetCudnnConvKind(
@@ -157,7 +212,25 @@ StatusOr<CudnnfMHAKind> GetCudnnfMHAKind(
     return CudnnfMHAKind::kScaleBiasSoftmax;
   if (target == kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget)
     return CudnnfMHAKind::kScaleBiasSoftmaxDropout;
-
+  // backward
+  if (target == kCudnnfMHABmmBmmBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardBmmBmm;
+  if (target == kCudnnfMHAScaleBiasMaskSoftmaxBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax;
+  if (target == kCudnnfMHAScaleBiasMaskSoftmaxDropoutBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout;
+  if (target == kCudnnfMHAScaleMaskSoftmaxBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardScaleMaskSoftmax;
+  if (target == kCudnnfMHAScaleMaskSoftmaxDropoutBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout;
+  if (target == kCudnnfMHASoftmaxDropoutBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardSoftmaxDropout;
+  if (target == kCudnnfMHASoftmaxBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardSoftmax;
+  if (target == kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardScaleBiasSoftmax;
+  if (target == kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget)
+    return CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout;
   return InternalError("Unexpected call target: %s", target);
 }
 
@@ -181,8 +254,101 @@ std::string CudnnfMHAKindToString(CudnnfMHAKind kind) {
       return "fmha_bias_softmax_with_dropout";
     case CudnnfMHAKind::kScaleBiasSoftmax:
       return "fmha_bias_softmax";
+    // backward
+    case CudnnfMHAKind::kBackwardBmmBmm:
+      return "fused_batched_matmuls_backward";
+    case CudnnfMHAKind::kBackwardSoftmax:
+      return "fmha_softmax_backward";
+    case CudnnfMHAKind::kBackwardSoftmaxDropout:
+      return "fmha_softmax_with_dropout_backward";
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+      return "fmha_scaled_masked_softmax_backward";
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+      return "fmha_scaled_masked_softmax_with_dropout_backward";
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+      return "fmha_scaled_bias_masked_softmax_backward";
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
+      return "fmha_scaled_bias_masked_softmax_with_dropout_backward";
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+      return "fmha_bias_softmax_with_dropout_backward";
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
+      return "fmha_bias_softmax_backward";
   }
 }
 
+std::string GetFMHAInstructionPrefix(const std::string& custom_call_target) {
+  if (custom_call_target == kCudnnfMHABmmBmmCallTarget) {
+    return "fmha-bmm-bmm";
+  }
+  if (custom_call_target == kCudnnfMHASoftmaxDropoutCallTarget) {
+    return "fmha-bmm-softmax-dropout-bmm";
+  }
+  if (custom_call_target == kCudnnfMHAScaleMaskSoftmaxCallTarget) {
+    return "fmha-bmm-scale-mask-softmax-bmm";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleMaskSoftmaxDropoutCallTarget) {
+    return "fmha-bmm-scale-mask-softmax-dropout-bmm";
+  }
+  if (custom_call_target == kCudnnfMHAScaleBiasMaskSoftmaxCallTarget) {
+    return "fmha-bmm-scale-bias-mask-softmax-bmm";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleBiasMaskSoftmaxDropoutCallTarget) {
+    return "fmha-bmm-scale-bias-mask-softmax-dropout-bmm";
+  }
+  if (custom_call_target == kCudnnfMHASoftmaxCallTarget) {
+    return "fmha-bmm-softmax-bmm";
+  }
+  if (custom_call_target == kCudnnfMHAScaleBiasSoftmaxCallTarget) {
+    return "fmha-bmm-scale-bias-softmax-bmm";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget) {
+    return "fmha-bmm-scale-bias-softmax-dropout-bmm";
+  }
+
+  // Backward calls
+  if (custom_call_target == kCudnnfMHABmmBmmBackwardCallTarget) {
+    return "fmha-bmm-bmm-backward";
+  }
+  if (custom_call_target ==
+      kCudnnfMHASoftmaxDropoutBackwardCallTarget) {
+    return "fmha-bmm-softmax-dropout-bmm-backward";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleMaskSoftmaxBackwardCallTarget) {
+    return "fmha-bmm-scale-mask-softmax-bmm-backward";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleMaskSoftmaxDropoutBackwardCallTarget) {
+    return "fmha-bmm-scale-mask-softmax-dropout-bmm-backward";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleBiasMaskSoftmaxBackwardCallTarget) {
+    return "fmha-bmm-scale-bias-mask-softmax-bmm-backward";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleBiasMaskSoftmaxDropoutBackwardCallTarget) {
+    return "fmha-bmm-scale-bias-mask-softmax-dropout-bmm-backward";
+  }
+  if (custom_call_target == kCudnnfMHASoftmaxBackwardCallTarget) {
+    return "fmha-bmm-softmax-bmm-backward";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget) {
+    return "fmha-bmm-scale-bias-softmax-bmm-backward";
+  }
+  if (custom_call_target ==
+      kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget) {
+    return "fmha-bmm-scale-bias-softmax-dropout-bmm-backward";
+  }
+}
+
+// Give fmha instruction a more useful name than "custom-call.42".
+Status SetFMHAInstructionName(HloModule* module, HloInstruction* fmha) {
+  module->SetAndUniquifyInstrName(fmha, GetFMHAInstructionPrefix(fmha->custom_call_target()));
+  return OkStatus();
+}
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -17,8 +17,9 @@ limitations under the License.
 #define XLA_SERVICE_GPU_CUBLAS_CUDNN_H_
 
 #include "absl/strings/string_view.h"
-#include "xla/hlo/ir/hlo_instructions.h"
 #include "tsl/platform/statusor.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
 
 namespace xla {
 namespace gpu {
@@ -55,6 +56,15 @@ enum class CudnnfMHAKind {
   kSoftmax,
   kScaleBiasSoftmax,
   kScaleBiasSoftmaxDropout,
+  kBackwardBmmBmm,
+  kBackwardScaleBiasMaskSoftmax,
+  kBackwardScaleBiasMaskSoftmaxDropout,
+  kBackwardScaleMaskSoftmax,
+  kBackwardScaleMaskSoftmaxDropout,
+  kBackwardSoftmaxDropout,
+  kBackwardSoftmax,
+  kBackwardScaleBiasSoftmax,
+  kBackwardScaleBiasSoftmaxDropout,
 };
 
 StatusOr<CudnnConvKind> GetCudnnConvKind(const HloCustomCallInstruction* instr);
@@ -152,6 +162,7 @@ bool IsCudnnConvolutionReorder(const HloInstruction& hlo);
 // 6. BMM1 - Softmax - Dropout - BMM2
 // 7. BMM1 - Softmax - BMM2
 // 8. BMM1 - scale - Bias - Softmax - BMM2
+// Forward calls
 extern const absl::string_view kCudnnfMHABmmBmmCallTarget;
 extern const absl::string_view kCudnnfMHASoftmaxCallTarget;
 extern const absl::string_view kCudnnfMHAScaleBiasMaskSoftmaxCallTarget;
@@ -161,13 +172,30 @@ extern const absl::string_view kCudnnfMHAScaleMaskSoftmaxDropoutCallTarget;
 extern const absl::string_view kCudnnfMHASoftmaxDropoutCallTarget;
 extern const absl::string_view kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget;
 extern const absl::string_view kCudnnfMHAScaleBiasSoftmaxCallTarget;
+// Backward calls
+extern const absl::string_view kCudnnfMHABmmBmmBackwardCallTarget;
+extern const absl::string_view kCudnnfMHASoftmaxBackwardCallTarget;
+extern const absl::string_view kCudnnfMHAScaleBiasMaskSoftmaxBackwardCallTarget;
+extern const absl::string_view
+    kCudnnfMHAScaleBiasMaskSoftmaxDropoutBackwardCallTarget;
+extern const absl::string_view kCudnnfMHAScaleMaskSoftmaxBackwardCallTarget;
+extern const absl::string_view
+    kCudnnfMHAScaleMaskSoftmaxDropoutBackwardCallTarget;
+extern const absl::string_view kCudnnfMHASoftmaxDropoutBackwardCallTarget;
+extern const absl::string_view
+    kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget;
+extern const absl::string_view kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget;
 
+bool IsFwdCustomCallTofMHA(const HloInstruction& hlo);
+bool IsBwdCustomCallTofMHA(const HloInstruction& hlo);
 bool IsCustomCallTofMHA(const HloInstruction& hlo);
 
 StatusOr<CudnnfMHAKind> GetCudnnfMHAKind(const HloCustomCallInstruction* instr);
 
 std::string CudnnfMHAKindToString(CudnnfMHAKind kind);
+Status SetFMHAInstructionName(HloModule* module, HloInstruction* fmha);
 
+bool MHACallHasDropout(const absl::string_view fmha_call_name);
 }  // namespace gpu
 }  // namespace xla
 

--- a/xla/service/gpu/fused_mha_thunk.cc
+++ b/xla/service/gpu/fused_mha_thunk.cc
@@ -31,15 +31,12 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-FusedMHAThunk::FusedMHAThunk(ThunkInfo thunk_info, GpufMHAConfig config,
-                             BufferAllocation::Slice lhs_bmm1,
-                             BufferAllocation::Slice rhs_bmm1,
-                             BufferAllocation::Slice rhs_bmm2,
-                             BufferAllocation::Slice output,
-                             BufferAllocation::Slice scratch,
-                             BufferAllocation::Slice mask,
-                             BufferAllocation::Slice bias)
-    : Thunk(Kind::kFusedMHA, thunk_info),
+FusedMHAThunk::FusedMHAThunk(
+    ThunkInfo thunk_info, GpufMHAConfig config,
+    BufferAllocation::Slice lhs_bmm1, BufferAllocation::Slice rhs_bmm1,
+    BufferAllocation::Slice rhs_bmm2, BufferAllocation::Slice output,
+    BufferAllocation::Slice scratch, BufferAllocation::Slice mask,
+    BufferAllocation::Slice bias, BufferAllocation::Slice activation)    : Thunk(Kind::kFusedMHA, thunk_info),
       lhs_bmm1_buffer_(lhs_bmm1),
       rhs_bmm1_buffer_(rhs_bmm1),
       rhs_bmm2_buffer_(rhs_bmm2),
@@ -47,6 +44,7 @@ FusedMHAThunk::FusedMHAThunk(ThunkInfo thunk_info, GpufMHAConfig config,
       scratch_buffer_(scratch),
       mask_buffer_(mask),
       bias_buffer_(bias),
+      activation_buffer_(activation),
       config_(std::move(config)) {}
 
 FusedMultiHeadedAttentionRunner& FusedMHAThunk::GetOrCreateRunner(
@@ -84,16 +82,117 @@ Status FusedMHAThunk::ExecuteOnStream(const ExecuteParams& params) {
     bias_buffer = buffer_allocations.GetDeviceAddress(bias_buffer_);
   }
 
+  se::DeviceMemoryBase activation_buffer;
+  if (activation_buffer_.allocation() != nullptr) {
+    activation_buffer = buffer_allocations.GetDeviceAddress(activation_buffer_);
+  }
+
   RunFusedMHAOptions opts;
   opts.runner_cache = &GetOrCreateRunner(params.stream);
 
   TF_RETURN_IF_ERROR(RunGpuFMHA(config_, lhs_bmm1_buffer, rhs_bmm1_buffer,
                                 rhs_bmm2_buffer, output_buffer, scratch_buffer,
-                                mask_buffer, bias_buffer, params.stream, opts));
+                                mask_buffer, bias_buffer, activation_buffer, params.stream, opts));
   if (!params.stream->ok()) {
     return InternalError("FusedMHAThunk::ExecuteOnStream failed.");
   }
   return OkStatus();
 }
+FusedMHABackwardThunk::FusedMHABackwardThunk(
+    ThunkInfo thunk_info, GpufMHABackwardConfig config,
+    BufferAllocation::Slice bmm1_grad_gemm1_rhs,
+    BufferAllocation::Slice bmm1_grad_gemm2_rhs,
+    BufferAllocation::Slice bmm2_grad_gemm1_lhs,
+    BufferAllocation::Slice bmm2_grad_gemm2_rhs,
+    BufferAllocation::Slice d_output, BufferAllocation::Slice scratch,
+    BufferAllocation::Slice d_bmm1_lhs, BufferAllocation::Slice d_bmm1_rhs,
+    BufferAllocation::Slice d_bmm2_rhs, BufferAllocation::Slice d_S,
+    BufferAllocation::Slice mask, BufferAllocation::Slice d_bias)
+    : Thunk(Kind::kFusedMHA, thunk_info),
+      bmm1_grad_gemm1_rhs_buffer_(bmm1_grad_gemm1_rhs),
+      bmm1_grad_gemm2_rhs_buffer_(bmm1_grad_gemm2_rhs),
+      bmm2_grad_gemm1_lhs_buffer_(bmm2_grad_gemm1_lhs),
+      bmm2_grad_gemm2_rhs_buffer_(bmm2_grad_gemm2_rhs),
+      d_output_buffer_(d_output),
+      scratch_buffer_(scratch),
+      d_bmm1_lhs_buffer_(d_bmm1_lhs),
+      d_bmm1_rhs_buffer_(d_bmm1_rhs),
+      d_bmm2_rhs_buffer_(d_bmm2_rhs),
+      d_S_buffer_(d_S),
+      mask_buffer_(mask),
+      d_bias_buffer_(d_bias),
+      config_(std::move(config)) {}
+
+FusedMultiHeadedAttentionBackwardRunner&
+FusedMHABackwardThunk::GetOrCreateRunner(
+    const stream_executor::Stream* stream) {
+  absl::MutexLock lock(&mu_);
+  auto it = runner_cache_.find(stream);
+  if (it == runner_cache_.end()) {
+    it = runner_cache_
+             .insert({stream,
+                      std::make_unique<FusedMultiHeadedAttentionBackwardRunner>(
+                          config_)})
+             .first;
+  }
+  return *it->second;
+}
+
+Status FusedMHABackwardThunk::ExecuteOnStream(const ExecuteParams& params) {
+  const auto& buffer_allocations = *params.buffer_allocations;
+  se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer =
+      buffer_allocations.GetDeviceAddress(bmm1_grad_gemm1_rhs_buffer_);
+
+  se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer =
+      buffer_allocations.GetDeviceAddress(bmm1_grad_gemm2_rhs_buffer_);
+
+  se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer =
+      buffer_allocations.GetDeviceAddress(bmm2_grad_gemm1_lhs_buffer_);
+
+  se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer =
+      buffer_allocations.GetDeviceAddress(bmm2_grad_gemm2_rhs_buffer_);
+
+  se::DeviceMemoryBase d_output_buffer =
+      buffer_allocations.GetDeviceAddress(d_output_buffer_);
+
+  se::DeviceMemoryBase scratch_buffer =
+      buffer_allocations.GetDeviceAddress(scratch_buffer_);
+
+  se::DeviceMemoryBase d_bmm1_lhs_buffer =
+      buffer_allocations.GetDeviceAddress(d_bmm1_lhs_buffer_);
+
+  se::DeviceMemoryBase d_bmm1_rhs_buffer =
+      buffer_allocations.GetDeviceAddress(d_bmm1_rhs_buffer_);
+
+  se::DeviceMemoryBase d_bmm2_rhs_buffer =
+      buffer_allocations.GetDeviceAddress(d_bmm2_rhs_buffer_);
+
+  se::DeviceMemoryBase d_S_buffer =
+      buffer_allocations.GetDeviceAddress(d_S_buffer_);
+
+  se::DeviceMemoryBase mask_buffer;
+  if (mask_buffer_.allocation() != nullptr) {
+    mask_buffer = buffer_allocations.GetDeviceAddress(mask_buffer_);
+  }
+
+  se::DeviceMemoryBase d_bias_buffer;
+  if (d_bias_buffer_.allocation() != nullptr) {
+    d_bias_buffer = buffer_allocations.GetDeviceAddress(d_bias_buffer_);
+  }
+  RunFusedMHABackwardOptions opts;
+
+  opts.runner_cache = &GetOrCreateRunner(params.stream);
+
+  TF_RETURN_IF_ERROR(RunGpuFMHABackward(
+      config_, bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
+      bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer, d_output_buffer,
+      scratch_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer, d_bmm2_rhs_buffer,
+      d_S_buffer, mask_buffer, d_bias_buffer, params.stream, opts));
+  if (!params.stream->ok()) {
+    return InternalError("FusedMHABackwardThunk::ExecuteOnStream failed.");
+  }
+  return OkStatus();
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/fused_mha_thunk.h
+++ b/xla/service/gpu/fused_mha_thunk.h
@@ -49,7 +49,8 @@ class FusedMHAThunk : public Thunk {
                 BufferAllocation::Slice output_slice,
                 BufferAllocation::Slice scratch_slice,
                 BufferAllocation::Slice mask_slice, /* may be null */
-                BufferAllocation::Slice bias_slice /* may be null */);
+                BufferAllocation::Slice bias_slice /* may be null */,
+                BufferAllocation::Slice activation_slice /* may be null */);
 
   FusedMHAThunk(const FusedMHAThunk&) = delete;
   FusedMHAThunk& operator=(const FusedMHAThunk&) = delete;
@@ -64,6 +65,7 @@ class FusedMHAThunk : public Thunk {
   BufferAllocation::Slice scratch_buffer_;
   BufferAllocation::Slice mask_buffer_;
   BufferAllocation::Slice bias_buffer_;
+  BufferAllocation::Slice activation_buffer_;
 
   FusedMultiHeadedAttentionRunner& GetOrCreateRunner(
       const stream_executor::Stream* stream);
@@ -73,6 +75,53 @@ class FusedMHAThunk : public Thunk {
   absl::Mutex mu_;
   absl::flat_hash_map<const stream_executor::Stream*,
                       std::unique_ptr<FusedMultiHeadedAttentionRunner>>
+      runner_cache_ ABSL_GUARDED_BY(mu_);
+};
+
+class FusedMHABackwardThunk : public Thunk {
+ public:
+  // Constructs a thunk for launching a DNN FMHA backward.
+  FusedMHABackwardThunk(ThunkInfo thunk_info, GpufMHABackwardConfig config,
+                        BufferAllocation::Slice bmm1_grad_gemm1_rhs_slice,
+                        BufferAllocation::Slice bmm1_grad_gemm2_rhs_slice,
+                        BufferAllocation::Slice bmm2_grad_gemm1_lhs_slice,
+                        BufferAllocation::Slice bmm2_grad_gemm2_rhs_slice,
+                        BufferAllocation::Slice d_output_slice,
+                        BufferAllocation::Slice scratch_slice,
+                        BufferAllocation::Slice d_bmm1_lhs_slice,
+                        BufferAllocation::Slice d_bmm1_rhs_slice,
+                        BufferAllocation::Slice d_bmm2_rhs_slice,
+                        BufferAllocation::Slice d_S_slice,
+                        BufferAllocation::Slice mask_slice,
+                        BufferAllocation::Slice d_bias_slice);
+
+  FusedMHABackwardThunk(const FusedMHABackwardThunk&) = delete;
+  FusedMHABackwardThunk& operator=(const FusedMHABackwardThunk&) = delete;
+
+  Status ExecuteOnStream(const ExecuteParams& params) override;
+
+ private:
+  BufferAllocation::Slice bmm1_grad_gemm1_rhs_buffer_;
+  BufferAllocation::Slice bmm1_grad_gemm2_rhs_buffer_;
+  BufferAllocation::Slice bmm2_grad_gemm1_lhs_buffer_;
+  BufferAllocation::Slice bmm2_grad_gemm2_rhs_buffer_;
+  BufferAllocation::Slice d_output_buffer_;
+  BufferAllocation::Slice scratch_buffer_;
+  BufferAllocation::Slice d_bmm1_lhs_buffer_;
+  BufferAllocation::Slice d_bmm1_rhs_buffer_;
+  BufferAllocation::Slice d_bmm2_rhs_buffer_;
+  BufferAllocation::Slice d_S_buffer_;
+  BufferAllocation::Slice mask_buffer_;
+  BufferAllocation::Slice d_bias_buffer_;
+
+  FusedMultiHeadedAttentionBackwardRunner& GetOrCreateRunner(
+      const stream_executor::Stream* stream);
+
+  // FusedMHA backward config
+  const GpufMHABackwardConfig config_;
+  absl::Mutex mu_;
+  absl::flat_hash_map<const stream_executor::Stream*,
+                      std::unique_ptr<FusedMultiHeadedAttentionBackwardRunner>>
       runner_cache_ ABSL_GUARDED_BY(mu_);
 };
 }  // namespace gpu

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -44,7 +44,8 @@ Status RunFusedMHABmmBmm(GpufMHAParams params, se::Stream *stream,
                          DeviceMemory<ElementType> rhs_bmm1_buffer,
                          DeviceMemory<ElementType> rhs_bmm2_buffer,
                          DeviceMemory<OutputType> output_buffer,
-                         DeviceMemoryBase scratch_memory) {
+                         DeviceMemoryBase scratch_memory,
+                         DeviceMemoryBase activation_output) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp> *lazy_runner =
       options.runner_cache->AsFusedMHASoftmaxRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>> local_runner;
@@ -67,13 +68,14 @@ Status RunFusedMHABmmBmm(GpufMHAParams params, se::Stream *stream,
       params.config->rhs_bmm2,
       params.config->intermediate_lhs_bmm2,
       params.config->output,
+      params.config->activation,
       dropout_rate,
       seed};
   TF_ASSIGN_OR_RETURN(auto *runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, rhs_bmm2_buffer,
-                   output_buffer);
+                   output_buffer, activation_output);
   return OkStatus();
 }
 
@@ -85,7 +87,8 @@ Status RunFusedMHAScaleMaskSoftmax(GpufMHAParams params, se::Stream *stream,
                                    DeviceMemory<ElementType> rhs_bmm2_buffer,
                                    DeviceMemory<OutputType> output_buffer,
                                    DeviceMemory<ElementType> mask_buffer,
-                                   DeviceMemoryBase scratch_memory) {
+                                   DeviceMemoryBase scratch_memory,
+                                   DeviceMemoryBase activation_output) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp> *lazy_runner =
       options.runner_cache->AsFusedMHAMaskRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>>
@@ -114,13 +117,14 @@ Status RunFusedMHAScaleMaskSoftmax(GpufMHAParams params, se::Stream *stream,
       params.config->intermediate_lhs_bmm2,
       params.config->output,
       *params.config->mask,
+      params.config->activation,
       dropout_rate,
       seed};
   TF_ASSIGN_OR_RETURN(auto *runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, mask_buffer,
-                   rhs_bmm2_buffer, output_buffer);
+                   rhs_bmm2_buffer, output_buffer, activation_output);
   return OkStatus();
 }
 
@@ -132,7 +136,7 @@ Status RunFusedMHAScaleBiasMaskSoftmax(
     DeviceMemory<ElementType> rhs_bmm2_buffer,
     DeviceMemory<OutputType> output_buffer,
     DeviceMemory<ElementType> mask_buffer, DeviceMemory<BiasType> bias_buffer,
-    DeviceMemoryBase scratch_memory) {
+    DeviceMemoryBase scratch_memory, DeviceMemoryBase activation_output) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp> *lazy_runner =
       options.runner_cache->AsFusedMHABiasMaskRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>
@@ -162,13 +166,14 @@ Status RunFusedMHAScaleBiasMaskSoftmax(
       params.config->output,
       *params.config->bias,
       *params.config->mask,
+      params.config->activation,
       dropout_rate,
       seed};
   TF_ASSIGN_OR_RETURN(auto *runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, mask_buffer, bias_buffer,
-                   rhs_bmm2_buffer, output_buffer);
+                   rhs_bmm2_buffer, output_buffer, activation_output);
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -179,7 +184,8 @@ Status RunFusedMHAScaleBiasSoftmax(GpufMHAParams params, se::Stream *stream,
                                    DeviceMemory<ElementType> rhs_bmm2_buffer,
                                    DeviceMemory<OutputType> output_buffer,
                                    DeviceMemory<BiasType> bias_buffer,
-                                   DeviceMemoryBase scratch_memory) {
+                                   DeviceMemoryBase scratch_memory,
+                                   DeviceMemoryBase activation_output) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp> *lazy_runner =
       options.runner_cache->AsFusedMHABiasRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>>
@@ -208,13 +214,14 @@ Status RunFusedMHAScaleBiasSoftmax(GpufMHAParams params, se::Stream *stream,
       params.config->intermediate_lhs_bmm2,
       params.config->output,
       *params.config->bias,
+      params.config->activation,
       dropout_rate,
       seed};
   TF_ASSIGN_OR_RETURN(auto *runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, bias_buffer,
-                   rhs_bmm2_buffer, output_buffer);
+                   rhs_bmm2_buffer, output_buffer, activation_output);
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -225,7 +232,10 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
   auto rhs_bmm1_buffer = se::DeviceMemory<ElementType>(params.rhs_bmm1_buffer);
   auto rhs_bmm2_buffer = se::DeviceMemory<ElementType>(params.rhs_bmm2_buffer);
   auto output_buffer = se::DeviceMemory<OutputType>(params.output_buffer);
-
+  auto activation_buffer =
+      params.activation_buffer.is_null()
+          ? se::DeviceMemoryBase()
+          : se::DeviceMemory<OutputType>(params.activation_buffer);
   se::dnn::AlgorithmDesc algorithm = params.config->algorithm;
   if (options.runner_cache) {
     algorithm = options.runner_cache->ToAlgorithmDesc();
@@ -238,7 +248,7 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
     case CudnnfMHAKind::kSoftmax:
       run_status = RunFusedMHABmmBmm<ElementType, OutputType>(
           params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
-          rhs_bmm2_buffer, output_buffer, scratch_memory);
+          rhs_bmm2_buffer, output_buffer, scratch_memory, activation_buffer);
       break;
 
     case CudnnfMHAKind::kScaleMaskSoftmax:
@@ -247,7 +257,8 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
       run_status = RunFusedMHAScaleMaskSoftmax<ElementType, OutputType>(
           params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
           rhs_bmm2_buffer, output_buffer,
-          se::DeviceMemory<ElementType>(*params.mask_buffer), scratch_memory);
+          se::DeviceMemory<ElementType>(*params.mask_buffer), scratch_memory,
+          activation_buffer);
       break;
 
     case CudnnfMHAKind::kScaleBiasMaskSoftmax:
@@ -259,7 +270,8 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
               params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
               rhs_bmm2_buffer, output_buffer,
               se::DeviceMemory<ElementType>(*params.mask_buffer),
-              se::DeviceMemory<BiasType>(*params.bias_buffer), scratch_memory);
+              se::DeviceMemory<BiasType>(*params.bias_buffer), scratch_memory,
+              activation_buffer);
       break;
     case CudnnfMHAKind::kScaleBiasSoftmax:
     case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
@@ -268,7 +280,8 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
           RunFusedMHAScaleBiasSoftmax<ElementType, BiasType, OutputType>(
               params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
               rhs_bmm2_buffer, output_buffer,
-              se::DeviceMemory<BiasType>(*params.bias_buffer), scratch_memory);
+              se::DeviceMemory<BiasType>(*params.bias_buffer), scratch_memory,
+              activation_buffer);
       break;
 
     default:
@@ -393,6 +406,200 @@ void AssignSeed(GpufMHAConfig &config,
   }
 }
 
+template <typename ElementType, typename OutputType>
+Status RunFusedMHABmmBmmBackward(
+    GpufMHABackwardParams params, se::Stream *stream,
+    RunFusedMHABackwardOptions options,
+    DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
+    DeviceMemory<ElementType> bmm1_grad_gemm2_rhs_buffer,
+    DeviceMemory<ElementType> bmm2_grad_gemm1_lhs_buffer,
+    DeviceMemory<ElementType> bmm2_grad_gemm2_rhs_buffer,
+    DeviceMemory<ElementType> d_output_buffer,
+    DeviceMemory<OutputType> d_bmm1_lhs_buffer,
+    DeviceMemory<OutputType> d_bmm1_rhs_buffer,
+    DeviceMemory<OutputType> d_bmm2_rhs_buffer,
+    DeviceMemory<OutputType> d_S_buffer, DeviceMemoryBase d_bias_buffer,
+    DeviceMemoryBase scratch_memory) {
+  se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp> *lazy_runner =
+      options.runner_cache->AsFusedMHASoftmaxBackwardRunner();
+  std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>
+      local_runner;
+  if (!lazy_runner) {
+    local_runner.emplace(params.config->algorithm);
+    lazy_runner = &*local_runner;
+  }
+  // FMHA TODO: add GetDNNFusedMHAKindFromCudnnfMHAKind here
+  TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
+                      GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
+  std::optional<double> dropout_rate;
+  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+
+  double scale = 1.0;
+  if (params.config->fmha_scale) scale = *params.config->fmha_scale;
+
+  std::optional<int64_t> seed;
+  if (params.config->seed) seed = *params.config->seed;
+
+  se::dnn::FusedMHASoftmaxBackwardOp::Config config{
+      kind,
+      scale,
+      params.config->bmm1_grad_gemm1_rhs,
+      params.config->bmm1_grad_gemm2_rhs,
+      params.config->bmm2_grad_gemm1_lhs,
+      params.config->bmm2_grad_gemm2_rhs,
+      params.config->d_output,
+      params.config->d_bmm1_lhs,
+      params.config->d_bmm1_rhs,
+      params.config->d_bmm2_rhs,
+      params.config->d_S,
+      params.config->d_bias,
+      dropout_rate,
+      seed};
+  TF_ASSIGN_OR_RETURN(auto *runner,
+                      lazy_runner->GetOrCreateRunner(config, stream));
+  return (*runner)(stream, options.profile_result, scratch_memory,
+                   bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
+                   bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
+                   d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
+                   d_bmm2_rhs_buffer, d_S_buffer, d_bias_buffer);
+  return OkStatus();
+}
+
+template <typename ElementType, typename OutputType>
+Status RunFusedMHAScaleMaskSoftmaxBackward(
+    GpufMHABackwardParams params, se::Stream *stream,
+    RunFusedMHABackwardOptions options,
+    DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
+    DeviceMemory<ElementType> bmm1_grad_gemm2_rhs_buffer,
+    DeviceMemory<ElementType> bmm2_grad_gemm1_lhs_buffer,
+    DeviceMemory<ElementType> bmm2_grad_gemm2_rhs_buffer,
+    DeviceMemory<ElementType> d_output_buffer,
+    DeviceMemory<OutputType> d_bmm1_lhs_buffer,
+    DeviceMemory<OutputType> d_bmm1_rhs_buffer,
+    DeviceMemory<OutputType> d_bmm2_rhs_buffer,
+    DeviceMemory<OutputType> d_S_buffer, DeviceMemory<ElementType> mask_buffer,
+    DeviceMemoryBase d_bias_buffer, DeviceMemoryBase scratch_memory) {
+  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>
+      *lazy_runner = options.runner_cache->AsFusedMHAMaskBackwardRunner();
+  std::optional<
+      se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>
+      local_runner;
+  if (!lazy_runner) {
+    local_runner.emplace(params.config->algorithm);
+    lazy_runner = &*local_runner;
+  }
+  TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
+                      GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
+  std::optional<double> dropout_rate;
+  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+
+  double scale = 1.0;
+  if (params.config->fmha_scale) scale = *params.config->fmha_scale;
+
+  std::optional<int64_t> seed;
+  if (params.config->seed) seed = *params.config->seed;
+
+  se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp::Config config{
+      kind,
+      scale,
+      params.config->bmm1_grad_gemm1_rhs,
+      params.config->bmm1_grad_gemm2_rhs,
+      params.config->bmm2_grad_gemm1_lhs,
+      params.config->bmm2_grad_gemm2_rhs,
+      params.config->d_output,
+      params.config->d_bmm1_lhs,
+      params.config->d_bmm1_rhs,
+      params.config->d_bmm2_rhs,
+      params.config->d_S,
+      *params.config->mask,
+      params.config->d_bias,
+      dropout_rate,
+      seed};
+  TF_ASSIGN_OR_RETURN(auto *runner,
+                      lazy_runner->GetOrCreateRunner(config, stream));
+  return (*runner)(stream, options.profile_result, scratch_memory,
+                   bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
+                   bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
+                   d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
+                   d_bmm2_rhs_buffer, d_S_buffer, mask_buffer, d_bias_buffer);
+  return OkStatus();
+}
+
+template <typename ElementType, typename BiasType, typename OutputType>
+Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
+                              se::Stream *stream,
+                              se::DeviceMemoryBase scratch_memory,
+                              RunFusedMHABackwardOptions options) {
+  auto bmm1_grad_gemm1_rhs_buffer =
+      se::DeviceMemory<ElementType>(params.bmm1_grad_gemm1_rhs_buffer);
+  auto bmm1_grad_gemm2_rhs_buffer =
+      se::DeviceMemory<ElementType>(params.bmm1_grad_gemm2_rhs_buffer);
+  auto bmm2_grad_gemm1_lhs_buffer =
+      se::DeviceMemory<ElementType>(params.bmm2_grad_gemm1_lhs_buffer);
+  auto bmm2_grad_gemm2_rhs_buffer =
+      se::DeviceMemory<ElementType>(params.bmm2_grad_gemm2_rhs_buffer);
+  auto d_output_buffer = se::DeviceMemory<ElementType>(params.d_output_buffer);
+  auto d_bmm1_lhs_buffer =
+      se::DeviceMemory<OutputType>(params.d_bmm1_lhs_buffer);
+  auto d_bmm1_rhs_buffer =
+      se::DeviceMemory<OutputType>(params.d_bmm1_rhs_buffer);
+  auto d_bmm2_rhs_buffer =
+      se::DeviceMemory<OutputType>(params.d_bmm2_rhs_buffer);
+  auto d_S_buffer = se::DeviceMemory<OutputType>(params.d_S_buffer);
+
+  auto d_bias_buffer = params.d_bias_buffer.is_null()
+                           ? se::DeviceMemoryBase()
+                           : se::DeviceMemory<OutputType>(params.d_bias_buffer);
+
+  se::dnn::AlgorithmDesc algorithm = params.config->algorithm;
+  if (options.runner_cache) {
+    algorithm = options.runner_cache->ToAlgorithmDesc();
+  }
+
+  Status run_status = OkStatus();
+  switch (params.config->kind) {
+    case CudnnfMHAKind::kBackwardBmmBmm:
+    case CudnnfMHAKind::kBackwardSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+      run_status = RunFusedMHABmmBmmBackward<ElementType, OutputType>(
+          params, stream, options, bmm1_grad_gemm1_rhs_buffer,
+          bmm1_grad_gemm2_rhs_buffer, bmm2_grad_gemm1_lhs_buffer,
+          bmm2_grad_gemm2_rhs_buffer, d_output_buffer, d_bmm1_lhs_buffer,
+          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_S_buffer, d_bias_buffer,
+          scratch_memory);
+      break;
+
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
+      TF_RET_CHECK(params.mask_buffer.has_value());
+      run_status = RunFusedMHAScaleMaskSoftmaxBackward<ElementType, OutputType>(
+          params, stream, options, bmm1_grad_gemm1_rhs_buffer,
+          bmm1_grad_gemm2_rhs_buffer, bmm2_grad_gemm1_lhs_buffer,
+          bmm2_grad_gemm2_rhs_buffer, d_output_buffer, d_bmm1_lhs_buffer,
+          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_S_buffer,
+          se::DeviceMemory<ElementType>(*params.mask_buffer), d_bias_buffer,
+          scratch_memory);
+      break;
+    default:
+      return InternalError("Invalid cuDNN fMHA kind");
+  }
+
+  if (run_status != OkStatus()) {
+    return run_status;
+  }
+
+  if (!stream->ok()) {
+    return InternalError("Unable to launch FMHA with type %s and algorithm %s",
+                         CudnnfMHAKindToString(params.config->kind),
+                         algorithm.ToString());
+  }
+
+  return run_status;
+}
 }  // namespace
 
 /*static*/ StatusOr<GpufMHAConfig> GpufMHAConfig::For(
@@ -402,7 +609,7 @@ void AssignSeed(GpufMHAConfig &config,
   const Shape &rhs_bmm1_shape = desc.rhs_bmm1_shape;
   const Shape &rhs_bmm2_shape = desc.rhs_bmm2_shape;
   const Shape &intermediate_lhs_bmm2_shape = desc.intermediate_lhs_bmm2_shape;
-  const Shape &output_shape = desc.output_shape;
+  const Shape &output_shape = desc.output_shapes[0];
 
   // Get DNN dtype from primtive types
   TF_ASSIGN_OR_RETURN(
@@ -452,6 +659,18 @@ void AssignSeed(GpufMHAConfig &config,
   config.output = TensorDescriptor::For(output_type, output_shape.dimensions(),
                                         output_shape.layout().minor_to_major());
 
+  if (desc.output_shapes.size() > 1) {
+    const Shape &activation_shape = desc.output_shapes.back();
+    // Generally, activation should have same type as output, but set it
+    // explicityly just to be safe.
+    TF_ASSIGN_OR_RETURN(
+        DataType activation_type,
+        GetDNNDataTypeFromPrimitiveType(activation_shape.element_type()));
+    config.activation =
+        TensorDescriptor::For(activation_type, activation_shape.dimensions(),
+                              activation_shape.layout().minor_to_major());
+  }
+
   config.kind = desc.kind;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
@@ -464,17 +683,207 @@ void AssignSeed(GpufMHAConfig &config,
   return config;
 }
 
+/*static*/ StatusOr<GpufMHABackwardConfig> GpufMHABackwardConfig::For(
+    const GpufMHABackwardDescriptor &desc) {
+  // Get shapes from desc.
+
+  const Shape &bmm1_grad_gemm1_rhs_shape = desc.bmm1_grad_gemm1_rhs_shape;
+  const Shape &bmm1_grad_gemm2_rhs_shape = desc.bmm1_grad_gemm2_rhs_shape;
+  const Shape &bmm2_grad_gemm1_lhs_shape = desc.bmm2_grad_gemm1_lhs_shape;
+  const Shape &bmm2_grad_gemm2_rhs_shape = desc.bmm2_grad_gemm2_rhs_shape;
+  const Shape &d_output_shape = desc.d_output_shape;
+  const Shape &d_bmm1_lhs_shape = desc.d_bmm1_lhs_shape;
+  const Shape &d_bmm1_rhs_shape = desc.d_bmm1_rhs_shape;
+  const Shape &d_bmm2_rhs_shape = desc.d_bmm2_rhs_shape;
+
+  // Get DNN dtype from primtive types
+  TF_ASSIGN_OR_RETURN(DataType bmm1_grad_gemm1_rhs_type,
+                      GetDNNDataTypeFromPrimitiveType(
+                          bmm1_grad_gemm1_rhs_shape.element_type()));
+
+  TF_ASSIGN_OR_RETURN(DataType bmm1_grad_gemm2_rhs_type,
+                      GetDNNDataTypeFromPrimitiveType(
+                          bmm1_grad_gemm2_rhs_shape.element_type()));
+
+  TF_ASSIGN_OR_RETURN(DataType bmm2_grad_gemm1_lhs_type,
+                      GetDNNDataTypeFromPrimitiveType(
+                          bmm2_grad_gemm1_lhs_shape.element_type()));
+
+  TF_ASSIGN_OR_RETURN(DataType bmm2_grad_gemm2_rhs_type,
+                      GetDNNDataTypeFromPrimitiveType(
+                          bmm2_grad_gemm2_rhs_shape.element_type()));
+
+  TF_ASSIGN_OR_RETURN(
+      DataType d_output_type,
+      GetDNNDataTypeFromPrimitiveType(d_output_shape.element_type()));
+
+  TF_ASSIGN_OR_RETURN(
+      DataType d_bmm1_lhs_type,
+      GetDNNDataTypeFromPrimitiveType(d_bmm1_lhs_shape.element_type()));
+
+  TF_ASSIGN_OR_RETURN(
+      DataType d_bmm1_rhs_type,
+      GetDNNDataTypeFromPrimitiveType(d_bmm1_rhs_shape.element_type()));
+
+  TF_ASSIGN_OR_RETURN(
+      DataType d_bmm2_rhs_type,
+      GetDNNDataTypeFromPrimitiveType(d_bmm2_rhs_shape.element_type()));
+
+  GpufMHABackwardConfig config;
+  config.input_type = bmm1_grad_gemm1_rhs_shape.element_type();
+  config.output_type = d_bmm1_lhs_shape.element_type();
+
+  // Get MatmulTensorDescriptors for lhs of BMM1 grad GEMM 1
+  config.bmm1_grad_gemm1_rhs = MatmulTensorDescriptor::For(
+      bmm1_grad_gemm1_rhs_type, bmm1_grad_gemm1_rhs_shape.dimensions(),
+      desc.bmm1_grad_gemm1_rhs_shape.layout().minor_to_major(),
+      desc.bmm1_grad_gemm1_dnums.rhs_batch_dimensions(),
+      desc.bmm1_grad_gemm1_dnums.rhs_contracting_dimensions());
+
+  // Get MatmulTensorDescriptors for rhs of BMM1 grad GEMM 2
+  config.bmm1_grad_gemm2_rhs = MatmulTensorDescriptor::For(
+      bmm1_grad_gemm2_rhs_type, bmm1_grad_gemm2_rhs_shape.dimensions(),
+      desc.bmm1_grad_gemm2_rhs_shape.layout().minor_to_major(),
+      desc.bmm1_grad_gemm2_dnums.rhs_batch_dimensions(),
+      desc.bmm1_grad_gemm2_dnums.rhs_contracting_dimensions());
+
+  // Get MatmulTensorDescriptors for BMM2 grad GEMM 1
+  config.bmm2_grad_gemm1_lhs = MatmulTensorDescriptor::For(
+      bmm2_grad_gemm1_lhs_type, bmm2_grad_gemm1_lhs_shape.dimensions(),
+      desc.bmm2_grad_gemm1_lhs_shape.layout().minor_to_major(),
+      desc.bmm2_grad_gemm1_dnums.lhs_batch_dimensions(),
+      desc.bmm2_grad_gemm1_dnums.lhs_contracting_dimensions());
+
+  config.d_output = MatmulTensorDescriptor::For(
+      d_output_type, d_output_shape.dimensions(),
+      desc.d_output_shape.layout().minor_to_major(),
+      desc.bmm2_grad_gemm1_dnums.rhs_batch_dimensions(),
+      desc.bmm2_grad_gemm1_dnums.rhs_contracting_dimensions());
+
+  // Get MatmulTensorDescriptors for BMM2 grad GEMM 2
+  config.bmm2_grad_gemm2_rhs = MatmulTensorDescriptor::For(
+      bmm2_grad_gemm2_rhs_type, bmm2_grad_gemm2_rhs_shape.dimensions(),
+      desc.bmm2_grad_gemm2_rhs_shape.layout().minor_to_major(),
+      desc.bmm2_grad_gemm2_dnums.rhs_batch_dimensions(),
+      desc.bmm2_grad_gemm2_dnums
+          .rhs_contracting_dimensions());  // FMHA TODO: transpose here?
+
+  config.d_bmm1_lhs =
+      TensorDescriptor::For(d_bmm1_lhs_type, d_bmm1_lhs_shape.dimensions(),
+                            d_bmm1_lhs_shape.layout().minor_to_major());
+  config.d_bmm1_rhs =
+      TensorDescriptor::For(d_bmm1_rhs_type, d_bmm1_rhs_shape.dimensions(),
+                            d_bmm1_rhs_shape.layout().minor_to_major());
+  config.d_bmm2_rhs =
+      TensorDescriptor::For(d_bmm2_rhs_type, d_bmm2_rhs_shape.dimensions(),
+                            d_bmm2_rhs_shape.layout().minor_to_major());
+  config.d_S = TensorDescriptor::For(
+      bmm2_grad_gemm1_lhs_type, bmm2_grad_gemm1_lhs_shape.dimensions(),
+      bmm2_grad_gemm1_lhs_shape.layout().minor_to_major());
+
+  if (desc.d_bias_shape) {
+    const Shape &d_bias_shape = *desc.d_bias_shape;
+
+    // Get DNN dtype from primtive types
+    TF_ASSIGN_OR_RETURN(DataType d_bias_type, GetDNNDataTypeFromPrimitiveType(
+                                                  d_bias_shape.element_type()));
+    config.d_bias =
+        TensorDescriptor::For(d_bias_type, d_bias_shape.dimensions(),
+                              d_bias_shape.layout().minor_to_major());
+  }
+
+  config.kind = desc.kind;
+  const CudnnfMHABackendConfig &backend_config = desc.backend_config;
+  config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
+
+  auto check_and_assign_mask = [&]() -> Status {
+    if (desc.mask_shape) {
+      const Shape &mask_shape = *desc.mask_shape;
+
+      TF_ASSIGN_OR_RETURN(DataType mask_type, GetDNNDataTypeFromPrimitiveType(
+                                                  mask_shape.element_type()));
+      config.mask = TensorDescriptor::For(mask_type, mask_shape.dimensions(),
+                                          mask_shape.layout().minor_to_major());
+      return OkStatus();
+    } else {
+      return InternalError(
+          "GpufMHADescriptor should have non-nul mask shape but found null "
+          "mask shape");
+    }
+  };
+
+  auto assign_scale = [&]() {
+    config.fmha_scale.emplace();
+    double &fmha_scale = *config.fmha_scale;
+    fmha_scale = backend_config.fmha_scale();
+  };
+
+  auto assign_dropout_rate = [&]() {
+    config.dropout_rate.emplace();
+    double &dropout_rate = *config.dropout_rate;
+    dropout_rate = backend_config.dropout_rate();
+  };
+
+  auto assign_seed = [&]() {
+    config.seed.emplace();
+    int64_t &seed = *config.seed;
+    seed = backend_config.seed();
+  };
+
+  switch (config.kind) {
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+      TF_RETURN_IF_ERROR(check_and_assign_mask());
+      assign_scale();
+      break;
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
+      TF_RETURN_IF_ERROR(check_and_assign_mask());
+      assign_scale();
+      assign_dropout_rate();
+      assign_seed();
+      break;
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+      TF_RETURN_IF_ERROR(check_and_assign_mask());
+      assign_scale();
+      break;
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+      TF_RETURN_IF_ERROR(check_and_assign_mask());
+      assign_scale();
+      assign_dropout_rate();
+      assign_seed();
+      break;
+    case CudnnfMHAKind::kBackwardBmmBmm:
+    case CudnnfMHAKind::kBackwardSoftmax:
+      break;
+    case CudnnfMHAKind::kBackwardSoftmaxDropout:
+      assign_dropout_rate();
+      assign_seed();
+      break;
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+      assign_scale();
+      assign_dropout_rate();
+      assign_seed();
+      break;
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
+      assign_scale();
+      break;
+    default:
+      return InternalError("Unknown backward fmha kind");
+  }
+  return config;
+}
+
 /*static*/ StatusOr<GpufMHAParams> GpufMHAParams::For(
     const GpufMHAConfig &config, se::DeviceMemoryBase lhs_bmm1_buffer,
     se::DeviceMemoryBase rhs_bmm1_buffer, se::DeviceMemoryBase rhs_bmm2_buffer,
     se::DeviceMemoryBase output_buffer, se::DeviceMemoryBase mask_buffer,
-    se::DeviceMemoryBase bias_buffer) {
+    se::DeviceMemoryBase bias_buffer, se::DeviceMemoryBase activation_buffer) {
   GpufMHAParams params;
   params.config = &config;
   params.lhs_bmm1_buffer = lhs_bmm1_buffer;
   params.rhs_bmm1_buffer = rhs_bmm1_buffer;
   params.rhs_bmm2_buffer = rhs_bmm2_buffer;
   params.output_buffer = output_buffer;
+  params.activation_buffer = activation_buffer;
 
   auto assign_mask_buffer = [&]() {
     params.mask_buffer.emplace();
@@ -509,6 +918,59 @@ void AssignSeed(GpufMHAConfig &config,
     case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
       TF_RET_CHECK(!bias_buffer.is_null());
       assign_bias_buffer();
+      break;
+    default:
+      return InternalError("Unknown forward CudnnfMHAKind");
+  }
+  return params;
+}
+
+/*static*/ StatusOr<GpufMHABackwardParams> GpufMHABackwardParams::For(
+    const GpufMHABackwardConfig &config,
+    se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+    se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase d_output_buffer,
+    se::DeviceMemoryBase d_bmm1_lhs_buffer,
+    se::DeviceMemoryBase d_bmm1_rhs_buffer,
+    se::DeviceMemoryBase d_bmm2_rhs_buffer, se::DeviceMemoryBase d_S_buffer,
+    se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase d_bias_buffer) {
+  GpufMHABackwardParams params;
+  params.config = &config;
+  params.bmm1_grad_gemm1_rhs_buffer = bmm1_grad_gemm1_rhs_buffer;
+  params.bmm1_grad_gemm2_rhs_buffer = bmm1_grad_gemm2_rhs_buffer;
+  params.bmm2_grad_gemm1_lhs_buffer = bmm2_grad_gemm1_lhs_buffer;
+  params.bmm2_grad_gemm2_rhs_buffer = bmm2_grad_gemm2_rhs_buffer;
+  params.d_output_buffer = d_output_buffer;
+  params.d_bmm1_lhs_buffer = d_bmm1_lhs_buffer;
+  params.d_bmm1_rhs_buffer = d_bmm1_rhs_buffer;
+  params.d_bmm2_rhs_buffer = d_bmm2_rhs_buffer;
+  params.d_S_buffer = d_S_buffer;
+  params.d_bias_buffer = d_bias_buffer;
+
+  auto assign_mask_buffer = [&]() {
+    params.mask_buffer.emplace();
+    se::DeviceMemoryBase &mask = *params.mask_buffer;
+    mask = mask_buffer;
+  };
+
+  switch (config.kind) {
+    case CudnnfMHAKind::kBackwardBmmBmm:
+    case CudnnfMHAKind::kBackwardSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+      break;
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
+      TF_RET_CHECK(!mask_buffer.is_null());
+      assign_mask_buffer();
+      break;
+    default:
+      return InternalError("Unknown backward CudnnfMHAKind");
   }
   return params;
 }
@@ -518,12 +980,12 @@ Status RunGpuFMHA(
     se::DeviceMemoryBase rhs_bmm1_buffer, se::DeviceMemoryBase rhs_bmm2_buffer,
     se::DeviceMemoryBase output_buffer, se::DeviceMemoryBase scratch_buffer,
     se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase bias_buffer,
-    se::Stream *stream, RunFusedMHAOptions options) {
+    se::DeviceMemoryBase activation_buffer, se::Stream *stream, RunFusedMHAOptions options) {
   TF_ASSIGN_OR_RETURN(
       GpufMHAParams params,
       GpufMHAParams::For(fmha_config, lhs_bmm1_buffer, rhs_bmm1_buffer,
                          rhs_bmm2_buffer, output_buffer, mask_buffer,
-                         bias_buffer));
+                         bias_buffer, activation_buffer));
   PrimitiveType input_primitive_type = fmha_config.input_type;
   switch (input_primitive_type) {
     case F16:
@@ -535,6 +997,40 @@ Status RunGpuFMHA(
     default:
       return absl::UnimplementedError(absl::StrFormat(
           "Unimplemented fused MHA with %s", ToString(fmha_config)));
+  }
+  return OkStatus();
+}
+
+Status RunGpuFMHABackward(
+    const GpufMHABackwardConfig &fmha_config,
+    se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+    se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase d_output_buffer, se::DeviceMemoryBase scratch_buffer,
+    se::DeviceMemoryBase d_bmm1_lhs_buffer,
+    se::DeviceMemoryBase d_bmm1_rhs_buffer,
+    se::DeviceMemoryBase d_bmm2_rhs_buffer, se::DeviceMemoryBase d_S_buffer,
+    se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase d_bias_buffer,
+    se::Stream *stream, RunFusedMHABackwardOptions options) {
+  TF_ASSIGN_OR_RETURN(
+      GpufMHABackwardParams params,
+      GpufMHABackwardParams::For(
+          fmha_config, bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
+          bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
+          d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
+          d_bmm2_rhs_buffer, d_S_buffer, mask_buffer, d_bias_buffer));
+  PrimitiveType input_primitive_type = fmha_config.input_type;
+  switch (input_primitive_type) {
+    case F16:
+      return RunGpuFMHABackwardImpl<Eigen::half, Eigen::half, Eigen::half>(
+          params, stream, scratch_buffer, options);
+    case BF16:
+      return RunGpuFMHABackwardImpl<Eigen::bfloat16, Eigen::bfloat16,
+                                    Eigen::bfloat16>(params, stream,
+                                                     scratch_buffer, options);
+    default:
+      return Unimplemented("Unimplemented fused MHA backward");
   }
   return OkStatus();
 }

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -56,10 +56,14 @@ Status RunFusedMHABmmBmm(GpufMHAParams params, se::Stream *stream,
   TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
                       GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
   std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+  if (params.config->dropout_rate) {
+    dropout_rate = *params.config->dropout_rate;
+  }
 
   std::optional<int64_t> seed;
-  if (params.config->seed) seed = *params.config->seed;
+  if (params.config->seed) {
+    seed = *params.config->seed;
+  }
 
   se::dnn::FusedMHASoftmaxOp::Config config{
       kind,
@@ -76,7 +80,6 @@ Status RunFusedMHABmmBmm(GpufMHAParams params, se::Stream *stream,
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, rhs_bmm2_buffer,
                    output_buffer, activation_output);
-  return OkStatus();
 }
 
 template <typename ElementType, typename OutputType>
@@ -100,13 +103,19 @@ Status RunFusedMHAScaleMaskSoftmax(GpufMHAParams params, se::Stream *stream,
   TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
                       GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
   std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+  if (params.config->dropout_rate) {
+    dropout_rate = *params.config->dropout_rate;
+  }
 
   double scale = 1.0;
-  if (params.config->fmha_scale) scale = *params.config->fmha_scale;
+  if (params.config->fmha_scale) {
+    scale = *params.config->fmha_scale;
+  }
 
   std::optional<int64_t> seed;
-  if (params.config->seed) seed = *params.config->seed;
+  if (params.config->seed) {
+    seed = *params.config->seed;
+  }
 
   se::dnn::FusedMHAScaleMaskSoftmaxOp::Config config{
       kind,
@@ -125,7 +134,6 @@ Status RunFusedMHAScaleMaskSoftmax(GpufMHAParams params, se::Stream *stream,
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, mask_buffer,
                    rhs_bmm2_buffer, output_buffer, activation_output);
-  return OkStatus();
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -148,13 +156,19 @@ Status RunFusedMHAScaleBiasMaskSoftmax(
   TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
                       GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
   std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+  if (params.config->dropout_rate) {
+    dropout_rate = *params.config->dropout_rate;
+  }
 
   double scale = 1.0;
-  if (params.config->fmha_scale) scale = *params.config->fmha_scale;
+  if (params.config->fmha_scale) {
+    scale = *params.config->fmha_scale;
+  }
 
   std::optional<int64_t> seed;
-  if (params.config->seed) seed = *params.config->seed;
+  if (params.config->seed) {
+    seed = *params.config->seed;
+  }
 
   se::dnn::FusedMHAScaleBiasMaskSoftmaxOp::Config config{
       kind,
@@ -197,13 +211,19 @@ Status RunFusedMHAScaleBiasSoftmax(GpufMHAParams params, se::Stream *stream,
   TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
                       GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
   std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+  if (params.config->dropout_rate) {
+    dropout_rate = *params.config->dropout_rate;
+  }
 
   double scale = 1.0;
-  if (params.config->fmha_scale) scale = *params.config->fmha_scale;
+  if (params.config->fmha_scale) {
+    scale = *params.config->fmha_scale;
+  }
 
   std::optional<int64_t> seed;
-  if (params.config->seed) seed = *params.config->seed;
+  if (params.config->seed) {
+    seed = *params.config->seed;
+  }
 
   se::dnn::FusedMHAScaleBiasSoftmaxOp::Config config{
       kind,
@@ -432,13 +452,19 @@ Status RunFusedMHABmmBmmBackward(
   TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
                       GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
   std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+  if (params.config->dropout_rate) {
+    dropout_rate = *params.config->dropout_rate;
+  }
 
   double scale = 1.0;
-  if (params.config->fmha_scale) scale = *params.config->fmha_scale;
+  if (params.config->fmha_scale) {
+    scale = *params.config->fmha_scale;
+  }
 
   std::optional<int64_t> seed;
-  if (params.config->seed) seed = *params.config->seed;
+  if (params.config->seed) {
+    seed = *params.config->seed;
+  }
 
   se::dnn::FusedMHASoftmaxBackwardOp::Config config{
       kind,
@@ -462,7 +488,6 @@ Status RunFusedMHABmmBmmBackward(
                    bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
                    d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
                    d_bmm2_rhs_buffer, d_S_buffer, d_bias_buffer);
-  return OkStatus();
 }
 
 template <typename ElementType, typename OutputType>
@@ -491,13 +516,19 @@ Status RunFusedMHAScaleMaskSoftmaxBackward(
   TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
                       GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
   std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) dropout_rate = *params.config->dropout_rate;
+  if (params.config->dropout_rate) {
+    dropout_rate = *params.config->dropout_rate;
+  }
 
   double scale = 1.0;
-  if (params.config->fmha_scale) scale = *params.config->fmha_scale;
+  if (params.config->fmha_scale) {
+    scale = *params.config->fmha_scale;
+  }
 
   std::optional<int64_t> seed;
-  if (params.config->seed) seed = *params.config->seed;
+  if (params.config->seed) {
+    seed = *params.config->seed;
+  }
 
   se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp::Config config{
       kind,
@@ -522,7 +553,6 @@ Status RunFusedMHAScaleMaskSoftmaxBackward(
                    bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
                    d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
                    d_bmm2_rhs_buffer, d_S_buffer, mask_buffer, d_bias_buffer);
-  return OkStatus();
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -795,7 +825,6 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   config.kind = desc.kind;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
-
   auto check_and_assign_mask = [&]() -> Status {
     if (desc.mask_shape) {
       const Shape &mask_shape = *desc.mask_shape;
@@ -813,21 +842,15 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   };
 
   auto assign_scale = [&]() {
-    config.fmha_scale.emplace();
-    double &fmha_scale = *config.fmha_scale;
-    fmha_scale = backend_config.fmha_scale();
+    config.fmha_scale.emplace(backend_config.fmha_scale());
   };
 
   auto assign_dropout_rate = [&]() {
-    config.dropout_rate.emplace();
-    double &dropout_rate = *config.dropout_rate;
-    dropout_rate = backend_config.dropout_rate();
+    config.dropout_rate.emplace(backend_config.dropout_rate());
   };
 
   auto assign_seed = [&]() {
-    config.seed.emplace();
-    int64_t &seed = *config.seed;
-    seed = backend_config.seed();
+    config.seed.emplace(backend_config.seed());
   };
 
   switch (config.kind) {
@@ -980,7 +1003,8 @@ Status RunGpuFMHA(
     se::DeviceMemoryBase rhs_bmm1_buffer, se::DeviceMemoryBase rhs_bmm2_buffer,
     se::DeviceMemoryBase output_buffer, se::DeviceMemoryBase scratch_buffer,
     se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase bias_buffer,
-    se::DeviceMemoryBase activation_buffer, se::Stream *stream, RunFusedMHAOptions options) {
+    se::DeviceMemoryBase activation_buffer, se::Stream *stream,
+    RunFusedMHAOptions options) {
   TF_ASSIGN_OR_RETURN(
       GpufMHAParams params,
       GpufMHAParams::For(fmha_config, lhs_bmm1_buffer, rhs_bmm1_buffer,

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -49,7 +49,8 @@ struct GpufMHADescriptor {
   Shape rhs_bmm1_shape;
   Shape rhs_bmm2_shape;
   Shape intermediate_lhs_bmm2_shape;
-  Shape output_shape;
+  // This will contain both output shape and activation shape
+  std::vector<Shape> output_shapes;
   DotDimensionNumbers bmm1_dnums;
   DotDimensionNumbers bmm2_dnums;
 
@@ -57,6 +58,25 @@ struct GpufMHADescriptor {
   std::optional<Shape> bias_shape;
 };
 
+struct GpufMHABackwardDescriptor {
+  CudnnfMHAKind kind;
+  CudnnfMHABackendConfig backend_config;
+  Shape bmm1_grad_gemm1_rhs_shape;
+  Shape bmm1_grad_gemm2_rhs_shape;
+  Shape bmm2_grad_gemm1_lhs_shape;
+  Shape bmm2_grad_gemm2_rhs_shape;
+  Shape d_output_shape;
+  Shape d_bmm1_lhs_shape;
+  Shape d_bmm1_rhs_shape;
+  Shape d_bmm2_rhs_shape;
+  DotDimensionNumbers bmm1_grad_gemm1_dnums;
+  DotDimensionNumbers bmm1_grad_gemm2_dnums;
+  DotDimensionNumbers bmm2_grad_gemm1_dnums;
+  DotDimensionNumbers bmm2_grad_gemm2_dnums;
+
+  std::optional<Shape> mask_shape;
+  std::optional<Shape> d_bias_shape;
+};
 // Structure to describe static properties of a GPU fused Multi-Headed
 // Attention.
 struct GpufMHAConfig {
@@ -79,8 +99,39 @@ struct GpufMHAConfig {
   se::dnn::MatmulTensorDescriptor intermediate_lhs_bmm2;
   se::dnn::TensorDescriptor output;
 
+  std::optional<se::dnn::TensorDescriptor> activation;
   std::optional<se::dnn::TensorDescriptor> mask;
   std::optional<se::dnn::TensorDescriptor> bias;
+};
+
+// Structure to describe static properties of a GPU fused Multi-Headed
+// Attention backward.
+struct GpufMHABackwardConfig {
+  static StatusOr<GpufMHABackwardConfig> For(
+      const GpufMHABackwardDescriptor& fmha_desc);
+  PrimitiveType
+      input_type;  // Capture the primitive type of one of the inputs of BMM1
+  PrimitiveType output_type;
+  CudnnfMHAKind kind;
+  std::optional<double> fmha_scale;
+  std::optional<double> dropout_rate;
+  std::optional<int64_t> seed;
+
+  se::dnn::AlgorithmDesc algorithm;
+
+  // mask -> [batch_size, 1, q_seq_len, kv_seq_len]
+  // d_bias -> [1, num_heads, q_seq_len, kv_seq_len]
+  se::dnn::MatmulTensorDescriptor bmm1_grad_gemm1_rhs;
+  se::dnn::MatmulTensorDescriptor bmm1_grad_gemm2_rhs;
+  se::dnn::MatmulTensorDescriptor bmm2_grad_gemm1_lhs;
+  se::dnn::MatmulTensorDescriptor bmm2_grad_gemm2_rhs;
+  se::dnn::MatmulTensorDescriptor d_output;
+  se::dnn::TensorDescriptor d_bmm1_lhs;
+  se::dnn::TensorDescriptor d_bmm1_rhs;
+  se::dnn::TensorDescriptor d_bmm2_rhs;
+  se::dnn::TensorDescriptor d_S;
+  std::optional<se::dnn::TensorDescriptor> d_bias;
+  std::optional<se::dnn::TensorDescriptor> mask;
 };
 
 // Implementation struct exposed for debugging and log analysis.
@@ -91,15 +142,44 @@ struct GpufMHAParams {
                                      se::DeviceMemoryBase rhs_bmm2_buffer,
                                      se::DeviceMemoryBase output_buffer,
                                      se::DeviceMemoryBase mask_buffer,
-                                     se::DeviceMemoryBase bias_buffer);
+                                     se::DeviceMemoryBase bias_buffer,
+                                     se::DeviceMemoryBase activation_buffer);
 
   const GpufMHAConfig* config;  // Not owned
   se::DeviceMemoryBase lhs_bmm1_buffer;
   se::DeviceMemoryBase rhs_bmm1_buffer;
   se::DeviceMemoryBase rhs_bmm2_buffer;
   se::DeviceMemoryBase output_buffer;
+  se::DeviceMemoryBase activation_buffer;
   std::optional<se::DeviceMemoryBase> mask_buffer;
   std::optional<se::DeviceMemoryBase> bias_buffer;
+};
+
+struct GpufMHABackwardParams {
+  static StatusOr<GpufMHABackwardParams> For(
+      const GpufMHABackwardConfig& config,
+      se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+      se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+      se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+      se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+      se::DeviceMemoryBase d_output_buffer,
+      se::DeviceMemoryBase d_bmm1_lhs_buffer,
+      se::DeviceMemoryBase d_bmm1_rhs_buffer,
+      se::DeviceMemoryBase d_bmm2_rhs_buffer, se::DeviceMemoryBase d_S_buffer,
+      se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase d_bias_buffer);
+
+  const GpufMHABackwardConfig* config;  // Not owned
+  se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer;
+  se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer;
+  se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer;
+  se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer;
+  se::DeviceMemoryBase d_output_buffer;
+  se::DeviceMemoryBase d_bmm1_lhs_buffer;
+  se::DeviceMemoryBase d_bmm1_rhs_buffer;
+  se::DeviceMemoryBase d_bmm2_rhs_buffer;
+  se::DeviceMemoryBase d_S_buffer;
+  se::DeviceMemoryBase d_bias_buffer;
+  std::optional<se::DeviceMemoryBase> mask_buffer;
 };
 
 class FusedMultiHeadedAttentionRunner {
@@ -222,6 +302,111 @@ class FusedMultiHeadedAttentionRunner {
         return std::make_unique<
             se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>(
             config.algorithm);
+      default:
+        LOG(FATAL) << "Internal error: unsupported CUDNN MHA kind in "
+                      "FusedMultiHeadedAttentionRunner";
+    }
+  }
+
+  struct ToAlgorithmDescVisitor {
+    template <typename RunnerPtr>
+    se::dnn::AlgorithmDesc operator()(const RunnerPtr& runner) {
+      return runner->ToAlgorithmDesc();
+    }
+
+    se::dnn::AlgorithmDesc operator()(const std::monostate&) {
+      CHECK(false) << "Internal error: uninitialized runner in ToAlgorithmDesc";
+    }
+  };
+
+  Repr repr_;
+};
+
+class FusedMultiHeadedAttentionBackwardRunner {
+ public:
+  using Repr = std::variant<
+      std::monostate,  // To allow XXX default ctor
+      std::unique_ptr<
+          se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>,
+      std::unique_ptr<
+          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>>;
+
+  FusedMultiHeadedAttentionBackwardRunner() = default;
+
+  explicit FusedMultiHeadedAttentionBackwardRunner(
+      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>
+          runner)
+      : repr_(std::move(runner)) {}
+
+  explicit FusedMultiHeadedAttentionBackwardRunner(
+      std::unique_ptr<
+          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>
+          runner)
+      : repr_(std::move(runner)) {}
+
+  explicit FusedMultiHeadedAttentionBackwardRunner(Repr runner)
+      : repr_(std::move(runner)) {}
+
+  explicit FusedMultiHeadedAttentionBackwardRunner(
+      const GpufMHABackwardConfig& config)
+      : FusedMultiHeadedAttentionBackwardRunner(CreateRunner(config)) {
+    if (std::holds_alternative<std::monostate>(repr_)) {
+      CHECK(false)
+          << "Cannot construct FusedMultiHeadedAttentionBackwardRunner with "
+             "std::monostate";
+    }
+  }
+
+  se::dnn::AlgorithmDesc ToAlgorithmDesc() const {
+    return std::visit(ToAlgorithmDescVisitor{}, repr_);
+  }
+
+  se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>*
+  AsFusedMHASoftmaxBackwardRunner() {
+    CHECK(
+        std::holds_alternative<std::unique_ptr<
+            se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>>(repr_));
+    return std::get<std::unique_ptr<
+        se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>>(repr_)
+        .get();
+  }
+
+  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>*
+  AsFusedMHAMaskBackwardRunner() {
+    CHECK(std::holds_alternative<std::unique_ptr<se::dnn::LazyOpRunner<
+              se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>>(repr_));
+    return std::get<std::unique_ptr<
+        se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>>(
+               repr_)
+        .get();
+  }
+
+ private:
+  //  The CreateRunner function is defined as static because it
+  //  doesn't need access to any non-static member variables of the
+  //  FusedMultiHeadedAttentionBackwardRunner class. Defining it static makes it
+  //  easy to use and makes it clear that it is a utility function that doesn't
+  //  rely on the state of any specific instance of the class.
+  static Repr CreateRunner(const GpufMHABackwardConfig& config) {
+    switch (config.kind) {
+      case CudnnfMHAKind::kBackwardBmmBmm:
+      case CudnnfMHAKind::kBackwardSoftmaxDropout:
+      case CudnnfMHAKind::kBackwardSoftmax:
+      case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
+      case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+        return std::make_unique<
+            se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>(
+            config.algorithm);
+      case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+      case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
+      case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+      case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+        return std::make_unique<
+            se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>(
+            config.algorithm);
+      default:
+        LOG(FATAL) << "Internal error: unsupported CUDNN MHA kind in "
+                      "FusedMultiHeadedAttentionBackwardRunner";
     }
   }
 
@@ -250,12 +435,39 @@ struct RunFusedMHAOptions {
   FusedMultiHeadedAttentionRunner* runner_cache;
 };
 
+struct RunFusedMHABackwardOptions {
+  // Nullable output-parameter pointer for profiling results.
+  // Profile results remain unused for now since cuDNN FMHA has only one
+  // algorithm for now.
+  se::dnn::ProfileResult* profile_result = nullptr;
+
+  // Use this runner cache (and its configured algorithm), instead of the one
+  // from the instruction.
+  FusedMultiHeadedAttentionBackwardRunner* runner_cache;
+};
+
 Status RunGpuFMHA(
     const GpufMHAConfig& fmha_config, se::DeviceMemoryBase lhs_bmm1_buffer,
     se::DeviceMemoryBase rhs_bmm1_buffer, se::DeviceMemoryBase rhs_bmm2_buffer,
     se::DeviceMemoryBase output_buffer, se::DeviceMemoryBase scratch_buffer,
     se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase bias_buffer,
-    se::Stream* stream, RunFusedMHAOptions = {});
+    se::DeviceMemoryBase activation_buffer, se::Stream* stream,
+    RunFusedMHAOptions = {});
+
+Status RunGpuFMHABackward(const GpufMHABackwardConfig& fmha_config,
+                          se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+                          se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+                          se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+                          se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+                          se::DeviceMemoryBase d_output_buffer,
+                          se::DeviceMemoryBase scratch_buffer,
+                          se::DeviceMemoryBase d_bmm1_lhs_buffer,
+                          se::DeviceMemoryBase d_bmm1_rhs_buffer,
+                          se::DeviceMemoryBase d_bmm2_rhs_buffer,
+                          se::DeviceMemoryBase d_S_buffer,
+                          se::DeviceMemoryBase mask_buffer,
+                          se::DeviceMemoryBase d_bias_buffer,
+                          se::Stream* stream, RunFusedMHABackwardOptions = {});
 
 std::string ToString(const GpufMHAConfig& config);
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -519,7 +519,31 @@ StatusOr<xla::gpu::CudnnfMHAKind> AsCudnnfMHAKind(
     case mlir::lmhlo_gpu::FusedMhaDagSignature::ScaleBiasSoftmaxDropout:
       return xla::gpu::CudnnfMHAKind::kScaleBiasSoftmaxDropout;
     default:
-      return xla::InternalError("unknown fused_mha_dag_signature");
+      return xla::InternalError("Unsupported fused_mha_dag_signature");
+  }
+}
+
+StatusOr<xla::gpu::CudnnfMHAKind> AsCudnnBackwardfMHAKind(
+    mlir::lmhlo_gpu::FusedMhaBackwardDagSignature signature) {
+  switch (signature) {
+    // backward
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+        BackwardScaleBiasSoftmax:
+      return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax;
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+        BackwardScaleBiasSoftmaxDropout:
+      return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout;
+      break;
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+        BackwardScaleBiasMaskSoftmax:
+      return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax;
+      break;
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+        BackwardScaleBiasMaskSoftmaxDropout:
+      return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout;
+      break;
+    default:
+      return xla::InternalError("Unsupported fused_mha_backward_dag_signature");
   }
 }
 
@@ -1288,9 +1312,12 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
   using mlir::lmhlo_gpu::fusedMHAWithScaledMaskOp;
   GpufMHADescriptor descriptor;
   BufferAllocation::Slice lhs_bmm1_slice, rhs_bmm1_slice, rhs_bmm2_slice,
-      output_slice, scratch_slice;
+      output_slice, scratch_slice, activation_slice;
 
   auto populate_common = [&](auto fmha) -> Status {
+    descriptor.backend_config.set_fmha_scale(
+      fmha.getFmhaScale().convertToDouble());
+
     if (fmha.getDropoutRate()) {
       descriptor.backend_config.set_dropout_rate(
           (*fmha.getDropoutRate()).convertToDouble());
@@ -1338,10 +1365,10 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
         GetShape(fmha.getRhsBmm2()).layout().minor_to_major());
     TF_ASSIGN_OR_RETURN(rhs_bmm2_slice, GetAllocationSlice(fmha.getRhsBmm2()));
 
-    descriptor.output_shape = ShapeUtil::MakeShapeWithDenseLayout(
+    descriptor.output_shapes.push_back(ShapeUtil::MakeShapeWithDenseLayout(
         GetShape(fmha.getOutput()).element_type(),
         GetShape(fmha.getOutput()).dimensions(),
-        GetShape(fmha.getOutput()).layout().minor_to_major());
+        GetShape(fmha.getOutput()).layout().minor_to_major()));
     TF_ASSIGN_OR_RETURN(output_slice, GetAllocationSlice(fmha.getOutput()));
 
     TF_ASSIGN_OR_RETURN(scratch_slice, GetAllocationSlice(fmha.getScratch()));
@@ -1349,6 +1376,14 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
     TF_ASSIGN_OR_RETURN(auto intermediate_tensor_dims_array,
                         ConvertMlirArrayAttrToInt64Array(
                             fmha.getIntermediateTensorDimensions()));
+    if (fmha.getActivation() != nullptr) {
+      descriptor.output_shapes.push_back(ShapeUtil::MakeShapeWithDenseLayout(
+          GetShape(fmha.getActivation()).element_type(),
+          GetShape(fmha.getActivation()).dimensions(),
+          GetShape(fmha.getActivation()).layout().minor_to_major()));
+      TF_ASSIGN_OR_RETURN(activation_slice, GetAllocationSlice(fmha.getActivation()));
+    }
+
     TF_ASSIGN_OR_RETURN(
         auto intermediate_tensor_layout_array,
         ConvertMlirArrayAttrToInt64Array(fmha.getIntermediateTensorLayout()));
@@ -1375,8 +1410,6 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
         CudnnfMHAKind kind,
         AsCudnnfMHAKind(fmha_with_scaled_mask_op.getFusedMhaDag()));
     descriptor.kind = kind;
-    descriptor.backend_config.set_fmha_scale(
-        fmha_with_scaled_mask_op.getFmhaScale().convertToDouble());
 
     TF_RET_CHECK(kind != xla::gpu::CudnnfMHAKind::kBmmBmm &&
                  kind != xla::gpu::CudnnfMHAKind::kSoftmaxDropout &&
@@ -1413,8 +1446,6 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
     descriptor.kind = kind;
     TF_RET_CHECK(kind == xla::gpu::CudnnfMHAKind::kScaleBiasSoftmax ||
                  kind == xla::gpu::CudnnfMHAKind::kScaleBiasSoftmaxDropout);
-    descriptor.backend_config.set_fmha_scale(
-        fmha_with_bias_op.getFmhaScale().convertToDouble());
 
     descriptor.bias_shape = ShapeUtil::MakeShapeWithDenseLayout(
         GetShape(fmha_with_bias_op.getBias()).element_type(),
@@ -1432,11 +1463,173 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
 
   AddThunkToThunkSequence(std::make_unique<FusedMHAThunk>(
       GetThunkInfo(op), std::move(config), lhs_bmm1_slice, rhs_bmm1_slice,
-      rhs_bmm2_slice, output_slice, scratch_slice, mask_slice, bias_slice));
+      rhs_bmm2_slice, output_slice, scratch_slice, mask_slice, bias_slice, activation_slice));
 
   return OkStatus();
 }
 
+Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
+  using mlir::dyn_cast;
+  using mlir::lmhlo_gpu::fusedMHABackwardOp;
+  using mlir::lmhlo_gpu::fusedMHAWithMaskBackwardOp;
+
+  GpufMHABackwardDescriptor descriptor;
+  BufferAllocation::Slice bmm1_grad_gemm1_rhs_slice, bmm1_grad_gemm2_rhs_slice,
+      bmm2_grad_gemm1_lhs_slice, bmm2_grad_gemm2_rhs_slice, d_output_slice,
+      scratch_slice, mask_slice;
+  BufferAllocation::Slice d_bmm1_lhs_slice, d_bmm1_rhs_slice, d_bmm2_rhs_slice,
+      d_S_slice, d_bias_slice;
+
+  auto populate_common = [&](auto fmha) -> Status {
+    descriptor.backend_config.set_fmha_scale(
+        fmha.getFmhaScale().convertToDouble());
+
+    if (fmha.getDropoutRate()) {
+      descriptor.backend_config.set_dropout_rate(
+          (*fmha.getDropoutRate()).convertToDouble());
+    }
+
+    if (fmha.getSeed()) {
+      descriptor.backend_config.set_seed((*fmha.getSeed()));
+    }
+
+    auto* algorithm = descriptor.backend_config.mutable_algorithm();
+    algorithm->set_algo_id(fmha.getAlgorithmConfig().getAlgorithm());
+    for (int i = 0; i < fmha.getAlgorithmConfig().getKnobIds().size(); ++i) {
+      // N.B. tuning_knobs is a map rather than a repeated field, so this
+      // doesn't require reserving space up front.
+      (*algorithm->mutable_tuning_knobs())[fmha.getAlgorithmConfig()
+                                               .getKnobIds()[i]] =
+          fmha.getAlgorithmConfig().getKnobValues()[i];
+    }
+    algorithm->set_is_cudnn_frontend(true);
+    auto workspace_size = fmha.getAlgorithmConfig().getWorkspaceSize();
+    if (workspace_size >= 0) {
+      algorithm->mutable_workspace_size()->set_value(workspace_size);
+    }
+
+    descriptor.bmm1_grad_gemm1_dnums =
+        ConvertDotDimensionNumbers(fmha.getBmm1GradGemm1DotDimensionNumbers());
+    descriptor.bmm1_grad_gemm2_dnums =
+        ConvertDotDimensionNumbers(fmha.getBmm1GradGemm2DotDimensionNumbers());
+    descriptor.bmm2_grad_gemm1_dnums =
+        ConvertDotDimensionNumbers(fmha.getBmm2GradGemm1DotDimensionNumbers());
+    descriptor.bmm2_grad_gemm2_dnums =
+        ConvertDotDimensionNumbers(fmha.getBmm2GradGemm2DotDimensionNumbers());
+
+    descriptor.bmm1_grad_gemm1_rhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getBmm1GradGemm1Rhs()).element_type(),
+        GetShape(fmha.getBmm1GradGemm1Rhs()).dimensions(),
+        GetShape(fmha.getBmm1GradGemm1Rhs()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(bmm1_grad_gemm1_rhs_slice,
+                        GetAllocationSlice(fmha.getBmm1GradGemm1Rhs()));
+
+    descriptor.bmm1_grad_gemm2_rhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getBmm1GradGemm2Rhs()).element_type(),
+        GetShape(fmha.getBmm1GradGemm2Rhs()).dimensions(),
+        GetShape(fmha.getBmm1GradGemm2Rhs()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(bmm1_grad_gemm2_rhs_slice,
+                        GetAllocationSlice(fmha.getBmm1GradGemm2Rhs()));
+
+    descriptor.bmm2_grad_gemm1_lhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getBmm2GradGemm1Lhs()).element_type(),
+        GetShape(fmha.getBmm2GradGemm1Lhs()).dimensions(),
+        GetShape(fmha.getBmm2GradGemm1Lhs()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(bmm2_grad_gemm1_lhs_slice,
+                        GetAllocationSlice(fmha.getBmm2GradGemm1Lhs()));
+
+    descriptor.bmm2_grad_gemm2_rhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getBmm2GradGemm2Rhs()).element_type(),
+        GetShape(fmha.getBmm2GradGemm2Rhs()).dimensions(),
+        GetShape(fmha.getBmm2GradGemm2Rhs()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(bmm2_grad_gemm2_rhs_slice,
+                        GetAllocationSlice(fmha.getBmm2GradGemm2Rhs()));
+
+    descriptor.d_output_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getDOutput()).element_type(),
+        GetShape(fmha.getDOutput()).dimensions(),
+        GetShape(fmha.getDOutput()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(d_output_slice, GetAllocationSlice(fmha.getDOutput()));
+    descriptor.d_bmm1_lhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getDBmm1Lhs()).element_type(),
+        GetShape(fmha.getDBmm1Lhs()).dimensions(),
+        GetShape(fmha.getDBmm1Lhs()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(d_bmm1_lhs_slice,
+                        GetAllocationSlice(fmha.getDBmm1Lhs()));
+
+    descriptor.d_bmm1_rhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getDBmm1Rhs()).element_type(),
+        GetShape(fmha.getDBmm1Rhs()).dimensions(),
+        GetShape(fmha.getDBmm1Rhs()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(d_bmm1_rhs_slice,
+                        GetAllocationSlice(fmha.getDBmm1Rhs()));
+
+    descriptor.d_bmm2_rhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getDBmm2Rhs()).element_type(),
+        GetShape(fmha.getDBmm2Rhs()).dimensions(),
+        GetShape(fmha.getDBmm2Rhs()).layout().minor_to_major());
+    TF_ASSIGN_OR_RETURN(d_bmm2_rhs_slice,
+                        GetAllocationSlice(fmha.getDBmm2Rhs()));
+
+    TF_ASSIGN_OR_RETURN(scratch_slice, GetAllocationSlice(fmha.getScratch()));
+
+    TF_ASSIGN_OR_RETURN(d_S_slice, GetAllocationSlice(fmha.getD_S()));
+
+    if (fmha.getDBias() != nullptr) {
+      descriptor.d_bias_shape = ShapeUtil::MakeShapeWithDenseLayout(
+          GetShape(fmha.getDBias()).element_type(),
+          GetShape(fmha.getDBias()).dimensions(),
+          GetShape(fmha.getDBias()).layout().minor_to_major());
+      TF_ASSIGN_OR_RETURN(d_bias_slice, GetAllocationSlice(fmha.getDBias()));
+    }
+
+    return OkStatus();
+  };
+
+  if (auto fmha_backward_op = dyn_cast<fusedMHABackwardOp>(op)) {
+    TF_RET_CHECK(fmha_backward_op != nullptr);
+    TF_ASSIGN_OR_RETURN(CudnnfMHAKind kind,
+                        AsCudnnBackwardfMHAKind(fmha_backward_op.getFusedMhaDag()));
+    descriptor.kind = kind;
+    TF_RETURN_IF_ERROR(populate_common(fmha_backward_op));
+  } else if (auto fmha_with_mask_backward_op =
+                 dyn_cast<fusedMHAWithMaskBackwardOp>(op)) {
+    TF_RET_CHECK(fmha_with_mask_backward_op != nullptr);
+    TF_ASSIGN_OR_RETURN(
+        CudnnfMHAKind kind,
+        AsCudnnBackwardfMHAKind(fmha_with_mask_backward_op.getFusedMhaDag()));
+    descriptor.kind = kind;
+
+    TF_RET_CHECK(kind != xla::gpu::CudnnfMHAKind::kBackwardBmmBmm &&
+                 kind != xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout &&
+                 kind != xla::gpu::CudnnfMHAKind::kBackwardSoftmax);
+
+    descriptor.mask_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha_with_mask_backward_op.getMask()).element_type(),
+        GetShape(fmha_with_mask_backward_op.getMask()).dimensions(),
+        GetShape(fmha_with_mask_backward_op.getMask())
+            .layout()
+            .minor_to_major());
+
+    TF_ASSIGN_OR_RETURN(
+        mask_slice, GetAllocationSlice(fmha_with_mask_backward_op.getMask()));
+
+    TF_RETURN_IF_ERROR(populate_common(fmha_with_mask_backward_op));
+  } else {
+    return InternalError("Unexpected operation");
+  }
+  TF_ASSIGN_OR_RETURN(GpufMHABackwardConfig config,
+                      GpufMHABackwardConfig::For(descriptor));
+
+  AddThunkToThunkSequence(std::move(std::make_unique<FusedMHABackwardThunk>(
+      GetThunkInfo(op), std::move(config), bmm1_grad_gemm1_rhs_slice,
+      bmm1_grad_gemm2_rhs_slice, bmm2_grad_gemm1_lhs_slice,
+      bmm2_grad_gemm2_rhs_slice, d_output_slice, scratch_slice,
+      d_bmm1_lhs_slice, d_bmm1_rhs_slice, d_bmm2_rhs_slice, d_S_slice,
+      mask_slice, d_bias_slice)));
+
+  return OkStatus();
+}
 #endif  // GOOGLE_CUDA
 
 namespace {
@@ -6052,6 +6245,10 @@ Status IrEmitterUnnested::EmitOp(mlir::Operation* op) {
                 mlir::lmhlo_gpu::fusedMHAWithScaledMaskOp,
                 mlir::lmhlo_gpu::fusedMHAWithScaledBiasOp>(op)) {
     return EmitFusedMHAThunk(op);
+  }
+  if (mlir::isa<mlir::lmhlo_gpu::fusedMHABackwardOp,
+                mlir::lmhlo_gpu::fusedMHAWithMaskBackwardOp>(op)) {
+    return EmitFusedMHABackwardThunk(op);
   }
 #endif  // GOOGLE_CUDA
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -533,15 +533,12 @@ StatusOr<xla::gpu::CudnnfMHAKind> AsCudnnBackwardfMHAKind(
     case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
         BackwardScaleBiasSoftmaxDropout:
       return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout;
-      break;
     case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
         BackwardScaleBiasMaskSoftmax:
       return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax;
-      break;
     case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
         BackwardScaleBiasMaskSoftmaxDropout:
       return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout;
-      break;
     default:
       return xla::InternalError("Unsupported fused_mha_backward_dag_signature");
   }

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -202,6 +202,7 @@ class IrEmitterUnnested : public IrEmitter {
   Status EmitTritonFusion(mlir::Operation* op,
                           const AutotuneResult::TritonGemmKey& config);
   Status EmitFusedMHAThunk(mlir::Operation* op);
+  Status EmitFusedMHABackwardThunk(mlir::Operation* op);
 #endif  // GOOGLE_CUDA
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   Status EmitCholeskyThunk(mlir::Operation* op);

--- a/xla/service/gpu/stream_executor_util.cc
+++ b/xla/service/gpu/stream_executor_util.cc
@@ -505,6 +505,17 @@ StatusOr<se::dnn::FusedMHAKind> GetDNNFusedMHAKindFromCudnnfMHAKind(
       return se::dnn::FusedMHAKind::BMM1_OUTPUT_INPUT_TYPE;
     case CudnnfMHAKind::kSoftmax:
       return se::dnn::FusedMHAKind::BMM1_OUTPUT_FLOAT;
+    // backward
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardBmmBmm:
+    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+    case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
+    case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardSoftmaxDropout:
+    case CudnnfMHAKind::kBackwardSoftmax:
+      return se::dnn::FusedMHAKind::BMM1_OUTPUT_INPUT_TYPE;
   }
   return InternalError("Unexpected fMHA kind");
 }

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -7459,14 +7459,18 @@ CudnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
   scalar_values.push_back(dropout_scale);
   int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
 
+  std::vector<int64_t> uids = {
+      CudnnfMHAUid::Q_ID,  CudnnfMHAUid::K_ID,  CudnnfMHAUid::P_ID,
+      CudnnfMHAUid::V_ID,  CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
+      CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID};
+  if (d_bias_descriptor != std::nullopt) {
+    uids.push_back(CudnnfMHAUid::dBIAS_ID);
+  }
+
   TF_ASSIGN_OR_RETURN(
       auto runner,
       CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxBackwardSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan),
-          {CudnnfMHAUid::Q_ID, CudnnfMHAUid::K_ID, CudnnfMHAUid::P_ID,
-           CudnnfMHAUid::V_ID, CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
-           CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID,
-           CudnnfMHAUid::dBIAS_ID},
+          parent_, cudnn_.get(), std::move(execution_plan), uids,
           /*need_side_input*/ true, /*has_activation_output*/ false,
           scalar_uids, scalar_values, dropout_rng_seed,
           /*dropout_rng_offset*/ 0));
@@ -7536,14 +7540,19 @@ CudnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
   scalar_values.push_back(dropout_scale);
   int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
 
+  std::vector<int64_t> uids = {CudnnfMHAUid::Q_ID,  CudnnfMHAUid::K_ID,
+                               CudnnfMHAUid::P_ID,  CudnnfMHAUid::V_ID,
+                               CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
+                               CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID,
+                               CudnnfMHAUid::dS_ID, CudnnfMHAUid::MASK_ID};
+  if (d_bias_descriptor != std::nullopt) {
+    uids.push_back(CudnnfMHAUid::dBIAS_ID);
+  }
+
   TF_ASSIGN_OR_RETURN(
       auto runner,
       CudnnExecutionPlanRunner<dnn::FusedMHAMaskBackwardSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan),
-          {CudnnfMHAUid::Q_ID, CudnnfMHAUid::K_ID, CudnnfMHAUid::P_ID,
-           CudnnfMHAUid::V_ID, CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
-           CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID,
-           CudnnfMHAUid::MASK_ID, CudnnfMHAUid::dBIAS_ID},
+          parent_, cudnn_.get(), std::move(execution_plan), uids,
           /*need_side_input*/ false, /*has_activation_output*/ false,
           scalar_uids, scalar_values, dropout_rng_seed,
           /*dropout_rng_offset*/ 0));

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -25,11 +25,11 @@ limitations under the License.
 
 #include "absl/base/thread_annotations.h"
 #include "absl/types/span.h"
+#include "tsl/platform/status.h"
 #include "xla/stream_executor/cuda/cuda_activation.h"
 #include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/plugin_registry.h"
 #include "xla/stream_executor/temporary_device_memory.h"
-#include "tsl/platform/status.h"
 
 namespace stream_executor {
 namespace gpu {
@@ -285,6 +285,7 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
 
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
@@ -296,6 +297,7 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor& mask_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
 
@@ -308,6 +310,7 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor& mask_descriptor,
       const dnn::TensorDescriptor& bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
@@ -321,6 +324,7 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor& bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
 

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -200,6 +200,7 @@ DnnSupport::FusedMHASoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
+    std::optional<dnn::TensorDescriptor> activation_descriptor,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
   return absl::UnimplementedError(
       "FusedMHASoftmaxRunnerFromDesc not implemented.");
@@ -214,6 +215,7 @@ DnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
+    std::optional<dnn::TensorDescriptor> activation_descriptor,
     const dnn::TensorDescriptor& mask_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
   return absl::UnimplementedError(
@@ -229,6 +231,7 @@ DnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
+    std::optional<dnn::TensorDescriptor> activation_descriptor,
     const dnn::TensorDescriptor& mask_descriptor,
     const dnn::TensorDescriptor& bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
@@ -245,6 +248,7 @@ DnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
+    std::optional<dnn::TensorDescriptor> activation_descriptor,
     const dnn::TensorDescriptor& bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
   return absl::UnimplementedError(

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -988,14 +988,16 @@ using FusedMatmulRunner = OpRunner<FusedMatmulSignature>;
 using FusedMHASoftmaxSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                       DeviceMemoryBase /* BMM1_inputB_data */,
                                       DeviceMemoryBase /* BMM2_inputA_data */,
-                                      DeviceMemoryBase /* output_data */);
+                                      DeviceMemoryBase /* output_data */,
+                                      DeviceMemoryBase /* activation_data */);
 using FusedMHASoftmaxRunner = OpRunner<FusedMHASoftmaxSignature>;
 
 using FusedMHAMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                    DeviceMemoryBase /* BMM1_inputB_data */,
                                    DeviceMemoryBase /* mask_data */,
                                    DeviceMemoryBase /* BMM2_inputA_data */,
-                                   DeviceMemoryBase /* output_data */);
+                                   DeviceMemoryBase /* output_data */,
+                                   DeviceMemoryBase /* activation_data */);
 using FusedMHAMaskRunner = OpRunner<FusedMHAMaskSignature>;
 
 using FusedMHABiasMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
@@ -1003,14 +1005,16 @@ using FusedMHABiasMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                        DeviceMemoryBase /* mask_data */,
                                        DeviceMemoryBase /* bias_data */,
                                        DeviceMemoryBase /* BMM2_inputA_data */,
-                                       DeviceMemoryBase /* output_data */);
+                                       DeviceMemoryBase /* output_data */,
+                                       DeviceMemoryBase /* activation_data */);
 using FusedMHABiasMaskRunner = OpRunner<FusedMHABiasMaskSignature>;
 
 using FusedMHABiasSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                    DeviceMemoryBase /* BMM1_inputB_data */,
                                    DeviceMemoryBase /* bias_data */,
                                    DeviceMemoryBase /* BMM2_inputA_data */,
-                                   DeviceMemoryBase /* output_data */);
+                                   DeviceMemoryBase /* output_data */,
+                                   DeviceMemoryBase /* activation_data */);
 using FusedMHABiasRunner = OpRunner<FusedMHABiasSignature>;
 
 using FusedMHASoftmaxBackwardSignature =
@@ -1668,6 +1672,7 @@ class DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
   virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
@@ -1679,6 +1684,7 @@ class DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor& mask_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
@@ -1691,6 +1697,7 @@ class DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor& mask_descriptor,
       const dnn::TensorDescriptor& bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
@@ -1704,6 +1711,7 @@ class DnnSupport {
       const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor& bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 

--- a/xla/stream_executor/lazy_op_runner.h
+++ b/xla/stream_executor/lazy_op_runner.h
@@ -213,6 +213,7 @@ struct FusedMHASoftmaxOp {
     const MatmulTensorDescriptor& bmm2_rhs_descriptor;
     const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
     const TensorDescriptor& output_descriptor;
+    std::optional<TensorDescriptor> activation_descriptor;
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
   };
@@ -225,7 +226,7 @@ struct FusedMHASoftmaxOp {
         desc, config.kind, config.bmm1_lhs_descriptor,
         config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
         config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
-        config.dropout_rate, config.seed);
+        config.activation_descriptor, config.dropout_rate, config.seed);
   }
 };
 
@@ -241,6 +242,7 @@ struct FusedMHAScaleMaskSoftmaxOp {
     const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
     const TensorDescriptor& output_descriptor;
     const TensorDescriptor& mask_descriptor;
+    std::optional<TensorDescriptor> activation_descriptor;
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
   };
@@ -252,7 +254,8 @@ struct FusedMHAScaleMaskSoftmaxOp {
         desc, config.kind, config.bmm1_lhs_descriptor,
         config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
         config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
-        config.mask_descriptor, config.scale, config.dropout_rate, config.seed);
+        config.activation_descriptor, config.mask_descriptor, config.scale,
+        config.dropout_rate, config.seed);
   }
 };
 
@@ -268,6 +271,7 @@ struct FusedMHAScaleBiasMaskSoftmaxOp {
     const TensorDescriptor& output_descriptor;
     const TensorDescriptor& bias_descriptor;
     const TensorDescriptor& mask_descriptor;
+    std::optional<TensorDescriptor> activation_descriptor;
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
   };
@@ -280,8 +284,8 @@ struct FusedMHAScaleBiasMaskSoftmaxOp {
         desc, config.kind, config.bmm1_lhs_descriptor,
         config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
         config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
-        config.mask_descriptor, config.bias_descriptor, config.scale,
-        config.dropout_rate, config.seed);
+        config.activation_descriptor, config.mask_descriptor,
+        config.bias_descriptor, config.scale, config.dropout_rate, config.seed);
   }
 };
 
@@ -296,6 +300,7 @@ struct FusedMHAScaleBiasSoftmaxOp {
     const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
     const TensorDescriptor& output_descriptor;
     const TensorDescriptor& bias_descriptor;
+    std::optional<TensorDescriptor> activation_descriptor;
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
   };
@@ -307,7 +312,8 @@ struct FusedMHAScaleBiasSoftmaxOp {
         desc, config.kind, config.bmm1_lhs_descriptor,
         config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
         config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
-        config.bias_descriptor, config.scale, config.dropout_rate, config.seed);
+        config.activation_descriptor, config.bias_descriptor, config.scale,
+        config.dropout_rate, config.seed);
   }
 };
 

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -466,6 +466,7 @@ class Stream {
       const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor &output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
@@ -474,7 +475,7 @@ class Stream {
     return dnn_support->FusedMHASoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
         bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-        output_descriptor, dropout_rate, seed);
+        output_descriptor, activation_descriptor, dropout_rate, seed);
   }
 
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
@@ -485,6 +486,7 @@ class Stream {
       const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor &output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor &mask_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
@@ -494,7 +496,8 @@ class Stream {
     return dnn_support->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
         bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-        output_descriptor, mask_descriptor, scale, dropout_rate, seed);
+        output_descriptor, activation_descriptor, mask_descriptor, scale,
+        dropout_rate, seed);
   }
 
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
@@ -505,6 +508,7 @@ class Stream {
       const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor &output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor &mask_descriptor,
       const dnn::TensorDescriptor &bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
@@ -515,8 +519,8 @@ class Stream {
     return dnn_support->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
         bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-        output_descriptor, mask_descriptor, bias_descriptor, scale,
-        dropout_rate, seed);
+        output_descriptor, activation_descriptor, mask_descriptor,
+        bias_descriptor, scale, dropout_rate, seed);
   }
 
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
@@ -527,6 +531,7 @@ class Stream {
       const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
       const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor &output_descriptor,
+      std::optional<dnn::TensorDescriptor> activation_descriptor,
       const dnn::TensorDescriptor &bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
@@ -536,7 +541,8 @@ class Stream {
     return dnn_support->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
         bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-        output_descriptor, bias_descriptor, scale, dropout_rate, seed);
+        output_descriptor, activation_descriptor, bias_descriptor, scale,
+        dropout_rate, seed);
   }
 
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>

--- a/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
+++ b/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
@@ -31,24 +31,27 @@ limitations under the License.
 #include "absl/types/optional.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include "mlir/AsmParser/AsmParser.h"  // from @llvm-project
-#include "mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/AsmParser/AsmParser.h"                     // from @llvm-project
+#include "mlir/Dialect/Arith/IR/Arith.h"                  // from @llvm-project
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"  // from @llvm-project
-#include "mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
-#include "mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
-#include "mlir/IR/Attributes.h"  // from @llvm-project
-#include "mlir/IR/Builders.h"  // from @llvm-project
-#include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
-#include "mlir/IR/BuiltinOps.h"  // from @llvm-project
-#include "mlir/IR/BuiltinTypes.h"  // from @llvm-project
-#include "mlir/IR/Location.h"  // from @llvm-project
-#include "mlir/IR/MLIRContext.h"  // from @llvm-project
-#include "mlir/IR/OpDefinition.h"  // from @llvm-project
-#include "mlir/IR/Operation.h"  // from @llvm-project
-#include "mlir/IR/SymbolTable.h"  // from @llvm-project
-#include "mlir/IR/Verifier.h"  // from @llvm-project
-#include "mlir/Pass/Pass.h"  // from @llvm-project
-#include "mlir/Tools/mlir-translate/Translation.h"  // from @llvm-project
+#include "mlir/Dialect/Func/IR/FuncOps.h"                 // from @llvm-project
+#include "mlir/Dialect/MemRef/IR/MemRef.h"                // from @llvm-project
+#include "mlir/IR/Attributes.h"                           // from @llvm-project
+#include "mlir/IR/Builders.h"                             // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"                    // from @llvm-project
+#include "mlir/IR/BuiltinOps.h"                           // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"                         // from @llvm-project
+#include "mlir/IR/Location.h"                             // from @llvm-project
+#include "mlir/IR/MLIRContext.h"                          // from @llvm-project
+#include "mlir/IR/OpDefinition.h"                         // from @llvm-project
+#include "mlir/IR/Operation.h"                            // from @llvm-project
+#include "mlir/IR/SymbolTable.h"                          // from @llvm-project
+#include "mlir/IR/Verifier.h"                             // from @llvm-project
+#include "mlir/Pass/Pass.h"                               // from @llvm-project
+#include "mlir/Tools/mlir-translate/Translation.h"        // from @llvm-project
+#include "tsl/platform/errors.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
 #include "xla/debug_options_flags.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_opcode.h"
@@ -74,9 +77,6 @@ limitations under the License.
 #include "xla/util.h"
 #include "xla/window_util.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
 
 using xla::BufferAllocation;
 using xla::BufferAssignment;
@@ -746,8 +746,11 @@ tsl::StatusOr<mlir::Operation*> LhloDialectEmitter::EmitCustomCallOp(
   if (xla::gpu::IsCudnnConvolutionReorder(*instr)) {
     return EmitDnnConvolutionReorderVectorized(custom_call_instr);
   }
-  if (xla::gpu::IsCustomCallTofMHA(*instr)) {
+  if (xla::gpu::IsFwdCustomCallTofMHA(*instr)) {
     return EmitDnnfMHA(custom_call_instr);
+  }
+  if (xla::gpu::IsBwdCustomCallTofMHA(*instr)) {
+    return EmitDnnfMHABackward(custom_call_instr);
   }
 
   // For custom call, if there are any token operands or results, they will not
@@ -925,10 +928,31 @@ tsl::StatusOr<lmhlo_gpu::FusedMhaDagSignature> AsLhloFusedMhaDagSignature(
     case xla::gpu::CudnnfMHAKind::kScaleBiasSoftmaxDropout:
       return lmhlo_gpu::FusedMhaDagSignature::ScaleBiasSoftmaxDropout;
     default:
-      return xla::InternalError("unknown cudnn fmha kind");
+      return xla::InternalError("unknown cudnn fmha fwd kind");
   }
 }
-
+tsl::StatusOr<lmhlo_gpu::FusedMhaBackwardDagSignature>
+AsLhloFusedMhaBackwardDagSignature(xla::gpu::CudnnfMHAKind kind) {
+  switch (kind) {
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax:
+      return lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardScaleBiasSoftmax;
+      break;
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+      return lmhlo_gpu::FusedMhaBackwardDagSignature::
+          BackwardScaleBiasSoftmaxDropout;
+      break;
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+      return lmhlo_gpu::FusedMhaBackwardDagSignature::
+          BackwardScaleBiasMaskSoftmax;
+      break;
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
+      return lmhlo_gpu::FusedMhaBackwardDagSignature::
+          BackwardScaleBiasMaskSoftmaxDropout;
+      break;
+    default:
+      return xla::InternalError("unknown cudnn fmha bwd kind");
+  }
+}
 }  // namespace
 
 tsl::StatusOr<Operation*> LhloDialectEmitter::EmitGemm(
@@ -1329,11 +1353,11 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
     auto intermediate_tensor_layout = builder_.getI64ArrayAttr(
         arrayref(intermediate_tensor_shape.layout().minor_to_major()));
     op.setIntermediateTensorLayoutAttr(intermediate_tensor_layout);
-
+    op.setFmhaScaleAttr(builder_.getF64FloatAttr(config.fmha_scale()));
     return op.getOperation();
   };
 
-  llvm::SmallVector<Value, 7> operands;
+  llvm::SmallVector<Value, 8> operands;
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(0), &operands));
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(1), &operands));
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(2), &operands));
@@ -1359,18 +1383,24 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
     case xla::gpu::CudnnfMHAKind::kScaleMaskSoftmax: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-
+      bool has_activation =
+          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
       auto fmha_scale_mask_softmax =
           CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
                                                                     operands);
       fmha_scale_mask_softmax.setFmhaScaleAttr(
           builder_.getF64FloatAttr(config.fmha_scale()));
+      int32_t operand_sizes[] = {1, 1, 1, 1, 0, 1, 1, has_activation ? 1 : 0};
+      fmha_scale_mask_softmax->setAttr(
+          fmha_scale_mask_softmax.getOperandSegmentSizeAttr(),
+          builder_.getDenseI32ArrayAttr(operand_sizes));
       return set_common_fmha_attributes(fmha_scale_mask_softmax);
     }
     case xla::gpu::CudnnfMHAKind::kScaleMaskSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-
+      bool has_activation =
+          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
       auto fmha_scale_mask_softmax_dropout =
           CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
                                                                     operands);
@@ -1380,24 +1410,35 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
           builder_.getF64FloatAttr(config.dropout_rate()));
       fmha_scale_mask_softmax_dropout.setSeedAttr(
           builder_.getI64IntegerAttr(config.seed()));
+      int32_t operand_sizes[] = {1, 1, 1, 1, 0, 1, 1, has_activation ? 1 : 0};
+      fmha_scale_mask_softmax_dropout->setAttr(
+          fmha_scale_mask_softmax_dropout.getOperandSegmentSizeAttr(),
+          builder_.getDenseI32ArrayAttr(operand_sizes));
       return set_common_fmha_attributes(fmha_scale_mask_softmax_dropout);
     }
     case xla::gpu::CudnnfMHAKind::kScaleBiasMaskSoftmax: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(4), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-
+      bool has_activation =
+          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
       auto fmha_scale_bias_mask_softmax =
           CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
                                                                     operands);
       fmha_scale_bias_mask_softmax.setFmhaScaleAttr(
           builder_.getF64FloatAttr(config.fmha_scale()));
+      int32_t operand_sizes[] = {1, 1, 1, 1, 1, 1, 1, has_activation ? 1 : 0};
+      fmha_scale_bias_mask_softmax->setAttr(
+          fmha_scale_bias_mask_softmax.getOperandSegmentSizeAttr(),
+          builder_.getDenseI32ArrayAttr(operand_sizes));
       return set_common_fmha_attributes(fmha_scale_bias_mask_softmax);
     }
     case xla::gpu::CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(4), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
+      bool has_activation =
+          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
       auto fmha_scale_bias_mask_softmax_dropout =
           CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
                                                                     operands);
@@ -1407,6 +1448,10 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
           builder_.getF64FloatAttr(config.dropout_rate()));
       fmha_scale_bias_mask_softmax_dropout.setSeedAttr(
           builder_.getI64IntegerAttr(config.seed()));
+      int32_t operand_sizes[] = {1, 1, 1, 1, 1, 1, 1, has_activation ? 1 : 0};
+      fmha_scale_bias_mask_softmax_dropout->setAttr(
+          fmha_scale_bias_mask_softmax_dropout.getOperandSegmentSizeAttr(),
+          builder_.getDenseI32ArrayAttr(operand_sizes));
       return set_common_fmha_attributes(fmha_scale_bias_mask_softmax_dropout);
     }
     case xla::gpu::CudnnfMHAKind::kScaleBiasSoftmaxDropout: {
@@ -1433,6 +1478,89 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
           builder_.getF64FloatAttr(config.fmha_scale()));
       return set_common_fmha_attributes(fmha_bias_softmax);
     }
+    default:
+      return xla::InternalError("Unknown forward fused MHA call.");
+  }
+}
+
+tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
+    const HloCustomCallInstruction* custom_call) {
+  TF_ASSIGN_OR_RETURN(
+      auto const config,
+      custom_call->backend_config<xla::gpu::CudnnfMHABackendConfig>());
+
+  TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
+                      xla::gpu::GetCudnnfMHAKind(custom_call));
+
+  auto set_common_fmha_backward_attributes =
+      [&, this](auto op) -> tsl::StatusOr<Operation*> {
+    TF_ASSIGN_OR_RETURN(lmhlo_gpu::FusedMhaBackwardDagSignature
+                            fused_mha_backward_dag_signature,
+                        AsLhloFusedMhaBackwardDagSignature(kind));
+    op.setFusedMhaDagAttr(lmhlo_gpu::FusedMhaBackwardDagSignatureAttr::get(
+        builder_.getContext(), fused_mha_backward_dag_signature));
+    op.setBmm1GradGemm1DotDimensionNumbersAttr(GetDotDimensionNumbersAttr(
+        builder_, config.bmm1_grad_gemm1_dot_dimension_numbers()));
+    op.setBmm1GradGemm2DotDimensionNumbersAttr(GetDotDimensionNumbersAttr(
+        builder_, config.bmm1_grad_gemm2_dot_dimension_numbers()));
+    op.setBmm2GradGemm1DotDimensionNumbersAttr(GetDotDimensionNumbersAttr(
+        builder_, config.bmm2_grad_gemm1_dot_dimension_numbers()));
+    op.setBmm2GradGemm2DotDimensionNumbersAttr(GetDotDimensionNumbersAttr(
+        builder_, config.bmm2_grad_gemm2_dot_dimension_numbers()));
+
+    op.setFmhaScaleAttr(builder_.getF64FloatAttr(config.fmha_scale()));
+    op.setDropoutRateAttr(builder_.getF64FloatAttr(config.dropout_rate()));
+    op.setSeedAttr(builder_.getI64IntegerAttr(config.seed()));
+
+    const auto& algorithm = config.algorithm();
+    std::vector<int64_t> knob_ids;
+    std::vector<int64_t> knob_values;
+    for (const auto& entry : algorithm.tuning_knobs()) {
+      knob_ids.push_back(entry.first);
+      knob_values.push_back(entry.second);
+    }
+    auto fmha_algo_config = mlir::lmhlo_gpu::FusedMHAAlgorithmConfigAttr::get(
+        builder_.getContext(), algorithm.algo_id(), knob_ids, knob_values,
+        algorithm.has_workspace_size() ? algorithm.workspace_size().value()
+                                       : -1);
+    op.setAlgorithmConfigAttr(fmha_algo_config);
+    return op.getOperation();
+  };
+
+  llvm::SmallVector<Value, 12> operands;
+  TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(0), &operands));
+  TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(1), &operands));
+  TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(2), &operands));
+  TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
+  TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(4), &operands));
+
+  switch (kind) {
+    case xla::gpu::CudnnfMHAKind::kBackwardBmmBmm:
+    case xla::gpu::CudnnfMHAKind::kBackwardSoftmax:
+    case xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax: {
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
+      auto fmha_default_backward =
+          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(custom_call,
+                                                              operands);
+      return set_common_fmha_backward_attributes(fmha_default_backward);
+    }
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout: {
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
+
+      auto fmha_scale_mask_softmax_backward =
+          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithMaskBackwardOp>(
+              custom_call, operands);
+      return set_common_fmha_backward_attributes(
+          fmha_scale_mask_softmax_backward);
+    }
+    default:
+      return xla::InternalError("Unknown backward fused MHA call.");
   }
 }
 

--- a/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.h
+++ b/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.h
@@ -23,15 +23,15 @@ limitations under the License.
 
 #include "absl/types/optional.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
-#include "mlir/IR/Builders.h"  // from @llvm-project
-#include "mlir/IR/BuiltinOps.h"  // from @llvm-project
+#include "mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/mlir_hlo/lhlo/IR/lhlo_ops.h"
 #include "xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/shape_util.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
 
 namespace mlir {
 
@@ -84,7 +84,8 @@ class LhloDialectEmitter : public xla::ConstDfsHloVisitorWithDefault {
       const xla::HloCustomCallInstruction* custom_call);
   xla::StatusOr<Operation*> EmitDnnfMHA(
       const xla::HloCustomCallInstruction* custom_call);
-
+  xla::StatusOr<Operation*> EmitDnnfMHABackward(
+      const xla::HloCustomCallInstruction* custom_call);
   tsl::StatusOr<memref::GetGlobalOp> EmitConstant(
       const xla::HloInstruction* instr);
 


### PR DESCRIPTION
This is a follow-up pr for [this](https://github.com/openxla/xla/pull/3886).
In total, fused MHA training changes are broken into 3 PRs.
This is the 2nd of 3. The other PRs' links:
1st - Stream executor changes are in this https://github.com/openxla/xla/pull/3886 (merged)
3rd - Rewriter changes are in this https://github.com/openxla/xla/pull/3726
This pr contains changes to lower lhlo fused mha custom call to cudnnFMHA thunk and runner for both forward and backward fmha calls. It also adds activation output to forward calls in thunk, runner and stream executor to support training cases.
All the functional and unit testing will be in the 3rd and final PR.