### PR TITLE
[ROCm] enable ROCm autotune

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1486,7 +1486,8 @@ cc_library(
     name = "gpu_conv_algorithm_picker",
     srcs = if_gpu_is_configured(["gpu_conv_algorithm_picker.cc"]),
     hdrs = if_gpu_is_configured(["gpu_conv_algorithm_picker.h"]),
-    copts = if_cuda_is_configured(["-DGOOGLE_CUDA=1"]),
+    copts = if_cuda_is_configured(["-DGOOGLE_CUDA=1"]) +
+            if_rocm_is_configured(["-DTENSORFLOW_USE_ROCM=1"]),
     deps = if_gpu_is_configured([
         ":backend_configs_cc",
         ":gpu_asm_opts_util",
@@ -2650,6 +2651,7 @@ cc_library(
         "amdgpu_compiler.h",
     ]),
     deps = if_rocm_is_configured([
+        ":autotuner_util",
         ":cusolver_rewriter",
         ":gemm_rewriter",
         ":gpu_compiler",
@@ -2664,6 +2666,7 @@ cc_library(
         ":tree_reduction_rewriter",
         ":triangular_solve_rewriter",
         "//xla:statusor",
+        "//xla:xla_proto_cc",
         "//xla/service:algebraic_simplifier",
         "//xla/service:call_inliner",
         "//xla/hlo/ir:hlo",

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -12,6 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <memory>
+#include <optional>
+#include <vector>
 
 #include "xla/service/gpu/amdgpu_compiler.h"
 
@@ -123,6 +126,82 @@ Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
 
   TF_RETURN_IF_ERROR(post_pipeline.Run(hlo_module).status());
 
+  return OkStatus();
+}
+
+bool AMDGPUCompiler::EnableCollectiveScheduleLinearizerForSpmd(
+    HloModule* hlo_module, se::StreamExecutor* stream_exec) {
+  return hlo_module->config().use_spmd_partitioning() &&
+         stream_exec != nullptr &&
+         GpuConvAlgorithmPicker::IsEnabled(hlo_module);
+}
+
+bool AMDGPUCompiler::RequiresCollectiveScheduleLinearizer(
+    const HloModule* module) {
+  for (const HloComputation* comp : module->MakeNonfusionComputations()) {
+    for (const HloInstruction* inst : comp->instructions()) {
+      if (GpuConvAlgorithmPicker::IsCandidate(inst)) {
+        return true;
+      }
+    }
+  }
+  // No convolution auto-tuning candidates found in the module.
+  return false;
+}
+
+Status AMDGPUCompiler::AddAutotuningPasses(
+    HloPassPipeline* pipeline, HloModule* hlo_module,
+    se::StreamExecutor* stream_exec, const DebugOptions& debug_options,
+    const CompileOptions& options, const GpuTargetConfig& gpu_target_config,
+    const AutotuneResults* autotune_results,
+    tsl::thread::ThreadPool* thread_pool) {
+  AutotuneConfig autotune_config =
+      stream_exec
+          ? AutotuneConfig{DeviceConfig{stream_exec, options.device_allocator},
+                           debug_options}
+          : AutotuneConfig{
+                DevicelessConfig{gpu_target_config.device_description_str},
+                debug_options};
+  if (autotune_config.IsDeviceless()) {
+    AutotunerUtil::ClearAutotuneResults();
+    TF_RETURN_IF_ERROR(AutotunerUtil::LoadAutotuneResults(*autotune_results));
+  }
+  if (GpuConvAlgorithmPicker::IsEnabled(hlo_module)) {
+    pipeline->AddPass<GpuConvAlgorithmPicker>(autotune_config);
+  }
+  // TODO:
+  // pipeline->AddPass<GemmAlgorithmPicker>(autotune_config);
+  // pipeline->AddPass<TritonAutotuner>(autotune_config, thread_pool);
+  return OkStatus();
+}
+
+Status AMDGPUCompiler::LoadAutotuneResultsFromFile(
+    const DebugOptions& debug_options) {
+  // We are doing this before the timer is started.
+  if (absl::string_view file_path =
+          debug_options.xla_gpu_load_autotune_results_from();
+      !file_path.empty()) {
+    static absl::once_flag once;
+    Status status = OkStatus();
+    absl::call_once(once, [&file_path, &status] {
+      status = AutotunerUtil::LoadAutotuneResultsFromFile(file_path);
+    });
+    TF_RETURN_IF_ERROR(status);
+  }
+  return OkStatus();
+}
+
+Status AMDGPUCompiler::SerializeAutotuneResultsToFile(
+    const DebugOptions& debug_options) {
+  // We are doing this after the timer is finished.
+  if (absl::string_view file_path =
+          debug_options.xla_gpu_dump_autotune_results_to();
+      !file_path.empty()) {
+    // Warning: This writes the autotune results at every compilation, possibly
+    // multiple times per process.
+    TF_RETURN_IF_ERROR(
+        AutotunerUtil::SerializeAutotuneResultsToFile(file_path));
+  }
   return OkStatus();
 }
 

--- a/xla/service/gpu/amdgpu_compiler.h
+++ b/xla/service/gpu/amdgpu_compiler.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/gpu/gpu_compiler.h"
 #include "xla/statusor.h"
+#include "xla/xla.pb.h"
 
 namespace xla {
 namespace gpu {
@@ -41,6 +42,25 @@ class AMDGPUCompiler : public GpuCompiler {
       HloModule* hlo_module, se::StreamExecutor* stream_exec,
       const CompileOptions& options, const GpuTargetConfig& gpu_target_config,
       const AutotuneResults* autotune_results) override;
+
+  bool EnableCollectiveScheduleLinearizerForSpmd(
+      HloModule* hlo_module, se::StreamExecutor* stream_exec) override;
+
+  bool RequiresCollectiveScheduleLinearizer(const HloModule* module) override;
+
+  Status AddAutotuningPasses(HloPassPipeline* pipeline, HloModule* hlo_module,
+                             se::StreamExecutor* stream_exec,
+                             const DebugOptions& debug_options,
+                             const CompileOptions& options,
+                             const GpuTargetConfig& gpu_target_config,
+                             const AutotuneResults* autotune_results,
+                             tsl::thread::ThreadPool* thread_pool) override;
+
+  Status LoadAutotuneResultsFromFile(
+      const DebugOptions& debug_options) override;
+
+  Status SerializeAutotuneResultsToFile(
+      const DebugOptions& debug_options) override;
 
   GpuVersion GetGpuVersion(se::StreamExecutor* stream_exec) override;
 


### PR DESCRIPTION
this is enable amdgpu_compiler for autotune due to https://github.com/tensorflow/tensorflow/commit/6df30ad6ffc82464047a92e81ae4c62a441dcfe6

now we only have conv autotune, but gemm and triton support will be added in the future so I left it // TODO

Thanks in advance @akuegel  @ddunl 