### PR TITLE
[ROCm] fixed rocm build error

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -978,7 +978,6 @@ cc_library(
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:stream_executor_rocm",
         "@local_config_rocm//rocm:rocm_headers",
-        "@tsl//tsl/platform:random",
     ]),
 )
 

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -953,7 +953,9 @@ Status GpuCompiler::OptimizeHloPostLayoutAssignment(
     // in the softmax codegen pipeline. However we should run before
     // ReductionDimensionGrouper, as that makes matching the softmax pattern
     // harder.
-    if (debug_options.xla_gpu_enable_triton_softmax_fusion()) {
+    if (debug_options.xla_gpu_enable_triton_softmax_fusion() &&
+        std::holds_alternative<se::CudaComputeCapability>(
+              gpu_target_config.gpu_version)) {
       pipeline.AddPass<HloPassFix<AlgebraicSimplifier>>(options);
       pipeline.AddPass<SoftmaxRewriterTriton>(gpu_target_config.gpu_version);
     }

--- a/xla/service/gpu/nccl_utils.h
+++ b/xla/service/gpu/nccl_utils.h
@@ -16,6 +16,10 @@ limitations under the License.
 #ifndef XLA_SERVICE_GPU_NCCL_UTILS_H_
 #define XLA_SERVICE_GPU_NCCL_UTILS_H_
 
+#if TENSORFLOW_USE_ROCM
+#define __HIP_DISABLE_CPP_FUNCTIONS__
+#endif
+
 #include <memory>
 #include <utility>
 #include <vector>

--- a/xla/stream_executor/rocm/hipblaslt_wrapper.h
+++ b/xla/stream_executor/rocm/hipblaslt_wrapper.h
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_HIPBLASLT_WRAPPER_H_
 #define XLA_STREAM_EXECUTOR_ROCM_HIPBLASLT_WRAPPER_H_
 
+#define __HIP_DISABLE_CPP_FUNCTIONS__
+
 #include "rocm/rocm_config.h"
 #if TF_ROCM_VERSION >= 50500
 #include "rocm/include/hipblaslt/hipblaslt.h"

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -141,10 +141,13 @@ namespace wrap {
   __macro(hipStreamWaitEvent)  // clang-format on
 
 HIP_ROUTINE_EACH(STREAM_EXECUTOR_HIP_WRAP)
+
+
 #undef HIP_ROUTINE_EACH
 #undef STREAM_EXECUTOR_HIP_WRAP
 #undef TO_STR
 #undef TO_STR_
+
 }  // namespace wrap
 }  // namespace stream_executor
 


### PR DESCRIPTION
there are few build errors in ROCm side

1. tsl//tsl/platform:random duplicate in bazel build
2. we haven't fully enable triton_softmax_fusion (ROCm triton backend is WIP)
3. some include errors between hipblas-lt and gpu.graph PR 

This PR has fixed all the above on ROCm side.

Thanks in advance @akuegel  @ddunl 