### PR TITLE
Provide NCCL Support for F8 AllGather, AllToAll and CollectivePermute

### DIFF
--- a/xla/service/float_support.cc
+++ b/xla/service/float_support.cc
@@ -24,7 +24,6 @@ namespace xla {
 bool FloatSupport::SupportsLowPrecisionOperand(const HloInstruction& hlo,
                                                int64_t operand_index) const {
   switch (hlo.opcode()) {
-    case HloOpcode::kAllGather:
     case HloOpcode::kCall:
     case HloOpcode::kConditional:
     case HloOpcode::kCustomCall:
@@ -45,7 +44,6 @@ bool FloatSupport::SupportsLowPrecisionOperand(const HloInstruction& hlo,
 
 bool FloatSupport::SupportsLowPrecisionOutput(const HloInstruction& hlo) const {
   switch (hlo.opcode()) {
-    case HloOpcode::kAllGather:
     case HloOpcode::kCall:
     case HloOpcode::kConditional:
     case HloOpcode::kCustomCall:

--- a/xla/service/float_support.cc
+++ b/xla/service/float_support.cc
@@ -24,6 +24,7 @@ namespace xla {
 bool FloatSupport::SupportsLowPrecisionOperand(const HloInstruction& hlo,
                                                int64_t operand_index) const {
   switch (hlo.opcode()) {
+    case HloOpcode::kAllGather:
     case HloOpcode::kCall:
     case HloOpcode::kConditional:
     case HloOpcode::kCustomCall:
@@ -44,6 +45,7 @@ bool FloatSupport::SupportsLowPrecisionOperand(const HloInstruction& hlo,
 
 bool FloatSupport::SupportsLowPrecisionOutput(const HloInstruction& hlo) const {
   switch (hlo.opcode()) {
+    case HloOpcode::kAllGather:
     case HloOpcode::kCall:
     case HloOpcode::kConditional:
     case HloOpcode::kCustomCall:

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -21,7 +21,6 @@ namespace gpu {
 bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
   switch (hlo.opcode()) {
     // Collective ops.
-    case HloOpcode::kAllGather:
     case HloOpcode::kAllReduce:
     case HloOpcode::kAllReduceStart:
     case HloOpcode::kAllReduceDone:
@@ -31,6 +30,9 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     // Handled by Triton GEMM.
     case HloOpcode::kDot:
       return LowPrecisionType() == BF16;
+    case HloOpcode::kAllGather:
+      return LowPrecisionType() == BF16 || LowPrecisionType() == F8E4M3FN ||
+             LowPrecisionType() == F8E5M2;
     // Data movement only ops.
     case HloOpcode::kBroadcast:
     case HloOpcode::kConcatenate:

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -24,17 +24,15 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     case HloOpcode::kAllReduce:
     case HloOpcode::kAllReduceStart:
     case HloOpcode::kAllReduceDone:
-    case HloOpcode::kAllToAll:
-    case HloOpcode::kCollectivePermute:
     case HloOpcode::kReduceScatter:
     // Handled by Triton GEMM.
     case HloOpcode::kDot:
       return LowPrecisionType() == BF16;
-    case HloOpcode::kAllGather:
-      return LowPrecisionType() == BF16 || LowPrecisionType() == F8E4M3FN ||
-             LowPrecisionType() == F8E5M2;
     // Data movement only ops.
+    case HloOpcode::kAllGather:
+    case HloOpcode::kAllToAll:
     case HloOpcode::kBroadcast:
+    case HloOpcode::kCollectivePermute:
     case HloOpcode::kConcatenate:
     case HloOpcode::kCopy:
     case HloOpcode::kDynamicSlice:

--- a/xla/service/gpu/nccl_collective_thunk.cc
+++ b/xla/service/gpu/nccl_collective_thunk.cc
@@ -56,6 +56,8 @@ bool IsTypeSupportedByNccl(PrimitiveType element_type,
       // 16-bit integer reductions are not directly supported by NCCL and cannot
       // be implicitly converted into other 16-bit types like ncclFloat16 as
       // they involve actual computation and not just data movement.
+    case F8E5M2:
+    case F8E4M3FN:
       return !IsReductionCollective(reduction_op);
     default:
       return false;

--- a/xla/service/gpu/nccl_utils.cc
+++ b/xla/service/gpu/nccl_utils.cc
@@ -72,6 +72,8 @@ StatusOr<ncclDataType_t> ToNcclDataType(PrimitiveType element_type,
                                         Thunk::Kind reduction_op) {
   switch (element_type) {
     case S8:
+    case F8E5M2:
+    case F8E4M3FN:
       return ncclInt8;
     case PRED:
     case U8:


### PR DESCRIPTION
Provide NCCL Support for F8 AllGather, AllToAll and CollectivePermute by allowing F8 types as low precision types in gpu_float_support since they just move data.