### PR TITLE
[NVIDIA XLA GPU] Build tracing and support with cuda if possible

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -501,6 +501,7 @@ cc_library(
     name = "support",
     srcs = ["support.cc"],
     hdrs = ["support.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         "//xla:shape_util",
         "//xla/mlir/runtime/transforms:custom_call_encoding",
@@ -542,6 +543,7 @@ cc_library(
     name = "tracing",
     srcs = ["tracing.cc"],
     hdrs = ["tracing.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":support",
         "//xla/runtime:custom_call",


### PR DESCRIPTION
Enable building tracing and support module in gpu/runtime with cuda if possible. This affects the nvptx markers when profiling.