### PR TITLE
Force the cublasCreate call before we start the graph.

### DIFF
--- a/xla/service/gpu/gemm_thunk.cc
+++ b/xla/service/gpu/gemm_thunk.cc
@@ -47,5 +47,13 @@ Status GemmThunk::ExecuteOnStream(const ExecuteParams& params) {
                  params.stream);
 }
 
+Status GemmThunk::Initialize(const GpuExecutable& executable,
+                  se::StreamExecutor* executor) {
+  if (!executor->AsBlas()) {
+    return absl::InternalError("Failed to initialize BLAS support");
+  }
+  return OkStatus();
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/gemm_thunk.h
+++ b/xla/service/gpu/gemm_thunk.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "xla/service/gpu/matmul_utils.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/status.h"
+#include "xla/stream_executor/stream_executor.h"
 
 namespace xla {
 namespace gpu {
@@ -38,6 +39,8 @@ class GemmThunk : public Thunk {
   GemmThunk& operator=(const GemmThunk&) = delete;
 
   Status ExecuteOnStream(const ExecuteParams& params) override;
+  Status Initialize(const GpuExecutable& executable,
+                    se::StreamExecutor* executor) override;
 
  private:
   const GemmConfig config_;


### PR DESCRIPTION
Calling cublasCreate() need locks and can sync the context. If we have kernels that are already running and are waiting for something, like a NCCL kernel, we end up with deadlock. [Section 20.5.1 (Concurent Execution) of the CUDA programing guide
](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#concurrent-execution) talk about that.

This small PR is only a partial fix for the old runtime.
There is 2 cases not covered:
- the new runtime
- a rare case, imagine 2 xla graph. The first one is started but don't need cublas. It fill the GPU with long kernel and return async. Then you start another graph. Possibly compiling it. Then executing it. The first graph is still running here!
Now, we still call cublasCreate() while the other graph is still running. So the old runtime still risk a deadlock.
@ezhulenev I think this interest you.

We need to also check if cudnn need such fix.