### PR TITLE
[ROCm] Fixing move constructor: make sure 'shape' is properly initialized for 'other'

### DIFF
--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -1086,6 +1086,11 @@ StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
   return std::make_unique<HloConstantInstruction>(std::move(literal));
 }
 
+/* static */ std::unique_ptr<HloInstruction> HloInstruction::CreateConstant(
+    Literal literal, const Shape& shape) {
+  return std::make_unique<HloConstantInstruction>(std::move(literal), shape);
+}
+
 /* static */ std::unique_ptr<HloInstruction> HloInstruction::CreateIota(
     const Shape& shape, int64_t iota_dimension) {
   return std::make_unique<HloIotaInstruction>(shape, iota_dimension);

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -566,6 +566,9 @@ class HloInstruction {
   // Creates a literal constant instruction.
   static std::unique_ptr<HloInstruction> CreateConstant(Literal literal);
 
+  // Creates a literal constant instruction with a given shape
+  static std::unique_ptr<HloInstruction> CreateConstant(Literal literal, const Shape& shape);
+
   // Creates an Iota instruction.
   static std::unique_ptr<HloInstruction> CreateIota(const Shape& shape,
                                                     int64_t iota_dimension);

--- a/xla/literal.cc
+++ b/xla/literal.cc
@@ -305,7 +305,7 @@ void Literal::DeallocateBuffers() {
       });
 }
 
-Literal::Literal(Literal&& other) : MutableLiteralBase() {
+Literal::Literal(Literal&& other) : Literal() {
   *this = std::move(other);
 }
 

--- a/xla/service/layout_normalization.cc
+++ b/xla/service/layout_normalization.cc
@@ -65,11 +65,10 @@ class LayoutNormalizationVisitor : public DfsHloRewriteVisitor {
       return OkStatus();
     }
 
-    Shape normalized_shape = Normalize(hlo->shape());
-    *literal.mutable_shape_do_not_use() = normalized_shape;
+    Shape normalized_shape = Normalize(shape);
 
     HloInstruction* normalized = hlo->parent()->AddInstruction(
-        HloInstruction::CreateConstant(std::move(literal)), &hlo->metadata());
+        HloInstruction::CreateConstant(std::move(literal), normalized_shape), &hlo->metadata());
     HloInstruction* bc_to_orig = MakeBitcastHlo(normalized, shape);
     TF_RETURN_IF_ERROR(ReplaceInstruction(hlo, bc_to_orig));
     return OkStatus();


### PR DESCRIPTION
The move ctor of class Literal is implemented in terms of the move operator which swaps shapes of two objects leaving the shape of 'other' object unitialized. As a result accessing other.shape() leads to segmentation fault. The crash was initially observed in xla::HloInstruction::ToString() when the logging level is set to 3, after the call to LayoutNormalizationVisitor::HandleConstant(xla::HloInstruction*) which uses the move constructor of Literal.
This fix properly initializes literal's shape before calling the move operator.

Hi @akuegel : can you please review it ?

