### PR TITLE
[XLA:GPU] fused attention runner clean up

### DIFF
--- a/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
+++ b/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
@@ -527,8 +527,6 @@ class CholeskyOpLowering : public OpRewritePattern<CholeskyOp> {
 };
 
 using mlir::lmhlo_gpu::fusedMHAOp;
-using mlir::lmhlo_gpu::fusedMHAWithScaledBiasOp;
-using mlir::lmhlo_gpu::fusedMHAWithScaledMaskOp;
 
 template <typename FusedDotAttentionForward>
 class FusedAttentionForwardLowering
@@ -716,20 +714,7 @@ class FusedAttentionForwardOpLowering
   using FusedAttentionForwardLowering::FusedAttentionForwardLowering;
 };
 
-class FusedAttentionScaledMaskForwardOpLowering
-    : public FusedAttentionForwardLowering<fusedMHAWithScaledMaskOp> {
- public:
-  using FusedAttentionForwardLowering::FusedAttentionForwardLowering;
-};
-
-class FusedAttentionScaledBiasForwardOpLowering
-    : public FusedAttentionForwardLowering<fusedMHAWithScaledBiasOp> {
- public:
-  using FusedAttentionForwardLowering::FusedAttentionForwardLowering;
-};
-
 using mlir::lmhlo_gpu::fusedMHABackwardOp;
-using mlir::lmhlo_gpu::fusedMHAWithMaskBackwardOp;
 
 template <typename FusedDotAttentionBackward>
 class FusedAttentionBackwardLowering
@@ -747,10 +732,6 @@ class FusedAttentionBackwardLowering
 
   LogicalResult matchAndRewrite(FusedDotAttentionBackward op,
                                 PatternRewriter& rewriter) const override {
-    // if (auto bwd_op =
-    // dyn_cast<fusedMHAWithMaskBackwardOp>(op.getOperation())) {
-    //   return op.emitOpError("fusedMHAWithMaskBackwardOp not supported yet.");
-    // }
     // Get the custom call target.
     std::string fused_attention = kCustomCallTarget;
     auto num_operands = op.getNumOperands();
@@ -861,12 +842,6 @@ class FusedAttentionBackwardOpLowering
   using FusedAttentionBackwardLowering::FusedAttentionBackwardLowering;
 };
 
-class FusedAttentionScaledMaskBackwardOpLowering
-    : public FusedAttentionBackwardLowering<fusedMHAWithMaskBackwardOp> {
- public:
-  using FusedAttentionBackwardLowering::FusedAttentionBackwardLowering;
-};
-
 //===----------------------------------------------------------------------===//
 
 void ConvertLmhloGpuToGpuRuntimePass::runOnOperation() {
@@ -901,16 +876,13 @@ void ConvertLmhloGpuToGpuRuntimePass::runOnOperation() {
   // Each unique fused_attention operation in the module will get assigned a
   // uid.
   UidGenerator fused_attention_uid;
-  patterns.insert<FusedAttentionForwardOpLowering,
-                  FusedAttentionScaledMaskForwardOpLowering,
-                  FusedAttentionScaledBiasForwardOpLowering>(
+  patterns.insert<FusedAttentionForwardOpLowering>(
       ctx, fused_attention_uid, custom_calls);
 
   // Each unique fused_attention_backward operation in the module will get
   // assigned a uid.
   UidGenerator fused_attention_backward_uid;
-  patterns.insert<FusedAttentionBackwardOpLowering,
-                  FusedAttentionScaledMaskBackwardOpLowering>(
+  patterns.insert<FusedAttentionBackwardOpLowering>(
       ctx, fused_attention_backward_uid, custom_calls);
 
   if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))

--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -337,9 +337,9 @@ def LHLOGPU_fusedMHAOp : LHLOGPU_Op<"fMHA", [AttrSizedOperandSegments]> {
     I64ArrayAttr:$intermediate_tensor_dimensions,
     I64ArrayAttr:$intermediate_tensor_layout,
     F64Attr:$fmha_scale,
-    OptionalAttr<F64Attr>:$dropout_rate,
     FusedMhaDagSignatureAttr:$fused_mha_dag,
     FusedMHAAlgorithmConfigAttr:$algorithm_config,
+    OptionalAttr<F64Attr>:$dropout_rate,
     OptionalAttr<I64Attr>:$seed
     );
 }
@@ -363,9 +363,9 @@ def LHLOGPU_fusedMHABackwardOp : LHLOGPU_Op<"fMHABackward", [AttrSizedOperandSeg
     MHLO_DotDimensionNumbers:$bmm2_grad_gemm1_dot_dimension_numbers,
     MHLO_DotDimensionNumbers:$bmm2_grad_gemm2_dot_dimension_numbers,
     F64Attr:$fmha_scale,
-    OptionalAttr<F64Attr>:$dropout_rate,
     FusedMhaBackwardDagSignatureAttr:$fused_mha_dag,
     FusedMHAAlgorithmConfigAttr:$algorithm_config,
+    OptionalAttr<F64Attr>:$dropout_rate,
     OptionalAttr<I64Attr>:$seed);
 }
 

--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -322,31 +322,12 @@ def LHLOGPU_AllToAllDoneOp: LHLOGPU_Op<"all_to_all_done"> {
   let arguments = (ins MHLO_Token:$token);
 }
 
-def LHLOGPU_fusedMHAOp : LHLOGPU_Op<"fMHA"> {
+def LHLOGPU_fusedMHAOp : LHLOGPU_Op<"fMHA", [AttrSizedOperandSegments]> {
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$lhs_bmm1,
     Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm1,
     Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm2,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$output,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
-    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$activation,
-    MHLO_DotDimensionNumbers:$bmm1_dot_dimension_numbers,
-    MHLO_DotDimensionNumbers:$bmm2_dot_dimension_numbers,
-    I64ArrayAttr:$intermediate_tensor_dimensions,
-    I64ArrayAttr:$intermediate_tensor_layout,
-    F64Attr:$fmha_scale,
-    OptionalAttr<F64Attr>:$dropout_rate,
-    FusedMhaDagSignatureAttr:$fused_mha_dag,
-    FusedMHAAlgorithmConfigAttr:$algorithm_config,
-    OptionalAttr<I64Attr>:$seed);
-}
-
-def LHLOGPU_fusedMHAWithScaledMaskOp : LHLOGPU_Op<"fMHAWithScaledMask", [AttrSizedOperandSegments]> {
-  let arguments = (ins
-    Arg<LHLO_Buffer, "", [MemRead]>:$lhs_bmm1,
-    Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm1,
-    Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm2,
-    Arg<LHLO_Buffer, "", [MemRead]>:$mask,
+    Arg<Optional<LHLO_Buffer>, "", [MemRead]>:$mask,
     Arg<Optional<LHLO_Buffer>, "", [MemRead]>:$bias,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output,
     Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
@@ -363,34 +344,14 @@ def LHLOGPU_fusedMHAWithScaledMaskOp : LHLOGPU_Op<"fMHAWithScaledMask", [AttrSiz
     );
 }
 
-def LHLOGPU_fusedMHAWithScaledBiasOp : LHLOGPU_Op<"fMHAWithScaledBias"> {
-  let arguments = (ins
-    Arg<LHLO_Buffer, "", [MemRead]>:$lhs_bmm1,
-    Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm1,
-    Arg<LHLO_Buffer, "", [MemRead]>:$rhs_bmm2,
-    Arg<LHLO_Buffer, "", [MemRead]>:$bias,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$output,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
-    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$activation,
-    MHLO_DotDimensionNumbers:$bmm1_dot_dimension_numbers,
-    MHLO_DotDimensionNumbers:$bmm2_dot_dimension_numbers,
-    I64ArrayAttr:$intermediate_tensor_dimensions,
-    I64ArrayAttr:$intermediate_tensor_layout,
-    F64Attr:$fmha_scale,
-    OptionalAttr<F64Attr>:$dropout_rate,
-    FusedMhaDagSignatureAttr:$fused_mha_dag,
-    FusedMHAAlgorithmConfigAttr:$algorithm_config,
-    OptionalAttr<I64Attr>:$seed
-    );
-}
-
-def LHLOGPU_fusedMHABackwardOp : LHLOGPU_Op<"fMHABackward"> {
+def LHLOGPU_fusedMHABackwardOp : LHLOGPU_Op<"fMHABackward", [AttrSizedOperandSegments]> {
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm1_rhs,
     Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm2_rhs,
     Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm2_rhs,
     Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm1_lhs,
     Arg<LHLO_Buffer, "", [MemRead]>:$d_output,
+    Arg<Optional<LHLO_Buffer>, "", [MemRead]>:$mask,
     Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_lhs,
     Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_rhs,
     Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm2_rhs,
@@ -406,32 +367,6 @@ def LHLOGPU_fusedMHABackwardOp : LHLOGPU_Op<"fMHABackward"> {
     FusedMhaBackwardDagSignatureAttr:$fused_mha_dag,
     FusedMHAAlgorithmConfigAttr:$algorithm_config,
     OptionalAttr<I64Attr>:$seed);
-}
-
-def LHLOGPU_fusedMHAWithMaskBackwardOp : LHLOGPU_Op<"fMHAWithMaskBackward"> {
-  let arguments = (ins
-    Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm1_rhs,
-    Arg<LHLO_Buffer, "", [MemRead]>:$bmm1_grad_gemm2_rhs,
-    Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm2_rhs,
-    Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm1_lhs,
-    Arg<LHLO_Buffer, "", [MemRead]>:$d_output,
-    Arg<LHLO_Buffer, "", [MemRead]>:$mask,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_lhs,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_rhs,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm2_rhs,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$d_S,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
-    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$d_bias,
-    MHLO_DotDimensionNumbers:$bmm1_grad_gemm1_dot_dimension_numbers,
-    MHLO_DotDimensionNumbers:$bmm1_grad_gemm2_dot_dimension_numbers,
-    MHLO_DotDimensionNumbers:$bmm2_grad_gemm1_dot_dimension_numbers,
-    MHLO_DotDimensionNumbers:$bmm2_grad_gemm2_dot_dimension_numbers,
-    F64Attr:$fmha_scale,
-    OptionalAttr<F64Attr>:$dropout_rate,
-    FusedMhaBackwardDagSignatureAttr:$fused_mha_dag,
-    FusedMHAAlgorithmConfigAttr:$algorithm_config,
-    OptionalAttr<I64Attr>:$seed
-    );
 }
 
 #endif // LHLO_GPU_OPS

--- a/xla/service/gpu/fused_mha_thunk.cc
+++ b/xla/service/gpu/fused_mha_thunk.cc
@@ -90,11 +90,11 @@ Status FusedMHAThunk::ExecuteOnStream(const ExecuteParams& params) {
 
   RunFusedMHAOptions opts;
   opts.runner_cache = &GetOrCreateRunner(params.stream);
-
   TF_RETURN_IF_ERROR(RunGpuFMHA(config_, lhs_bmm1_buffer, rhs_bmm1_buffer,
                                 rhs_bmm2_buffer, output_buffer, scratch_buffer,
                                 mask_buffer, bias_buffer, activation_buffer,
                                 params.stream, opts));
+
   if (!params.stream->ok()) {
     return InternalError("FusedMHAThunk::ExecuteOnStream failed.");
   }

--- a/xla/service/gpu/fused_mha_thunk.cc
+++ b/xla/service/gpu/fused_mha_thunk.cc
@@ -74,16 +74,16 @@ Status FusedMHAThunk::ExecuteOnStream(const ExecuteParams& params) {
   se::DeviceMemoryBase scratch_buffer =
       buffer_allocations.GetDeviceAddress(scratch_buffer_);
 
-  se::DeviceMemoryBase mask_buffer;
+  std::optional<se::DeviceMemoryBase> mask_buffer;
   if (mask_buffer_.allocation() != nullptr) {
     mask_buffer = buffer_allocations.GetDeviceAddress(mask_buffer_);
   }
-  se::DeviceMemoryBase bias_buffer;
+  std::optional<se::DeviceMemoryBase> bias_buffer;
   if (bias_buffer_.allocation() != nullptr) {
     bias_buffer = buffer_allocations.GetDeviceAddress(bias_buffer_);
   }
 
-  se::DeviceMemoryBase activation_buffer;
+  std::optional<se::DeviceMemoryBase> activation_buffer;
   if (activation_buffer_.allocation() != nullptr) {
     activation_buffer = buffer_allocations.GetDeviceAddress(activation_buffer_);
   }
@@ -172,12 +172,12 @@ Status FusedMHABackwardThunk::ExecuteOnStream(const ExecuteParams& params) {
   se::DeviceMemoryBase d_S_buffer =
       buffer_allocations.GetDeviceAddress(d_s_buffer_);
 
-  se::DeviceMemoryBase mask_buffer;
+  std::optional<se::DeviceMemoryBase> mask_buffer;
   if (mask_buffer_.allocation() != nullptr) {
     mask_buffer = buffer_allocations.GetDeviceAddress(mask_buffer_);
   }
 
-  se::DeviceMemoryBase d_bias_buffer;
+  std::optional<se::DeviceMemoryBase> d_bias_buffer;
   if (d_bias_buffer_.allocation() != nullptr) {
     d_bias_buffer = buffer_allocations.GetDeviceAddress(d_bias_buffer_);
   }

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -37,18 +37,20 @@ using se::dnn::DataType;
 using se::dnn::MatmulTensorDescriptor;
 using se::dnn::TensorDescriptor;
 
-template <typename ElementType, typename OutputType>
-Status RunFusedMHABmmBmm(GpufMHAParams params, se::Stream *stream,
-                         RunFusedMHAOptions options,
-                         DeviceMemory<ElementType> lhs_bmm1_buffer,
-                         DeviceMemory<ElementType> rhs_bmm1_buffer,
-                         DeviceMemory<ElementType> rhs_bmm2_buffer,
-                         DeviceMemory<OutputType> output_buffer,
-                         DeviceMemoryBase scratch_memory,
-                         DeviceMemoryBase activation_output) {
-  se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp> *lazy_runner =
-      options.runner_cache->AsFusedMHASoftmaxRunner();
-  std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>> local_runner;
+
+template <typename ElementType, typename BiasType, typename OutputType>
+Status RunFusedMHA(
+    GpufMHAParams params, se::Stream *stream, RunFusedMHAOptions options,
+    DeviceMemory<ElementType> lhs_bmm1_buffer,
+    DeviceMemory<ElementType> rhs_bmm1_buffer,
+    DeviceMemory<ElementType> rhs_bmm2_buffer,
+    DeviceMemory<OutputType> output_buffer,
+    DeviceMemoryBase mask_buffer, DeviceMemoryBase bias_buffer,
+    DeviceMemoryBase scratch_memory, DeviceMemoryBase activation_output) {
+  se::dnn::LazyOpRunner<se::dnn::FusedMHAOp> *lazy_runner =
+      options.runner_cache->AsFusedMHARunner();
+  std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>>
+      local_runner;
   if (!lazy_runner) {
     local_runner.emplace(params.config->algorithm);
     lazy_runner = &*local_runner;
@@ -60,18 +62,26 @@ Status RunFusedMHABmmBmm(GpufMHAParams params, se::Stream *stream,
     dropout_rate = *params.config->dropout_rate;
   }
 
+  double scale = 1.0;
+  if (params.config->fmha_scale) {
+    scale = *params.config->fmha_scale;
+  }
+
   std::optional<int64_t> seed;
   if (params.config->seed) {
     seed = *params.config->seed;
   }
 
-  se::dnn::FusedMHASoftmaxOp::Config config{
+  se::dnn::FusedMHAOp::Config config{
       kind,
+      scale,
       params.config->lhs_bmm1,
       params.config->rhs_bmm1,
       params.config->rhs_bmm2,
       params.config->intermediate_lhs_bmm2,
       params.config->output,
+      params.config->bias,
+      params.config->mask,
       params.config->activation,
       dropout_rate,
       seed};
@@ -79,169 +89,7 @@ Status RunFusedMHABmmBmm(GpufMHAParams params, se::Stream *stream,
                       lazy_runner->GetOrCreateRunner(config, stream));
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, rhs_bmm2_buffer,
-                   output_buffer, activation_output);
-}
-
-template <typename ElementType, typename OutputType>
-Status RunFusedMHAScaleMaskSoftmax(GpufMHAParams params, se::Stream *stream,
-                                   RunFusedMHAOptions options,
-                                   DeviceMemory<ElementType> lhs_bmm1_buffer,
-                                   DeviceMemory<ElementType> rhs_bmm1_buffer,
-                                   DeviceMemory<ElementType> rhs_bmm2_buffer,
-                                   DeviceMemory<OutputType> output_buffer,
-                                   DeviceMemory<ElementType> mask_buffer,
-                                   DeviceMemoryBase scratch_memory,
-                                   DeviceMemoryBase activation_output) {
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp> *lazy_runner =
-      options.runner_cache->AsFusedMHAMaskRunner();
-  std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>>
-      local_runner;
-  if (!lazy_runner) {
-    local_runner.emplace(params.config->algorithm);
-    lazy_runner = &*local_runner;
-  }
-  TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
-                      GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
-  std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) {
-    dropout_rate = *params.config->dropout_rate;
-  }
-
-  double scale = 1.0;
-  if (params.config->fmha_scale) {
-    scale = *params.config->fmha_scale;
-  }
-
-  std::optional<int64_t> seed;
-  if (params.config->seed) {
-    seed = *params.config->seed;
-  }
-
-  se::dnn::FusedMHAScaleMaskSoftmaxOp::Config config{
-      kind,
-      scale,
-      params.config->lhs_bmm1,
-      params.config->rhs_bmm1,
-      params.config->rhs_bmm2,
-      params.config->intermediate_lhs_bmm2,
-      params.config->output,
-      *params.config->mask,
-      params.config->activation,
-      dropout_rate,
-      seed};
-  TF_ASSIGN_OR_RETURN(auto *runner,
-                      lazy_runner->GetOrCreateRunner(config, stream));
-  return (*runner)(stream, options.profile_result, scratch_memory,
-                   lhs_bmm1_buffer, rhs_bmm1_buffer, mask_buffer,
-                   rhs_bmm2_buffer, output_buffer, activation_output);
-}
-
-template <typename ElementType, typename BiasType, typename OutputType>
-Status RunFusedMHAScaleBiasMaskSoftmax(
-    GpufMHAParams params, se::Stream *stream, RunFusedMHAOptions options,
-    DeviceMemory<ElementType> lhs_bmm1_buffer,
-    DeviceMemory<ElementType> rhs_bmm1_buffer,
-    DeviceMemory<ElementType> rhs_bmm2_buffer,
-    DeviceMemory<OutputType> output_buffer,
-    DeviceMemory<ElementType> mask_buffer, DeviceMemory<BiasType> bias_buffer,
-    DeviceMemoryBase scratch_memory, DeviceMemoryBase activation_output) {
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp> *lazy_runner =
-      options.runner_cache->AsFusedMHABiasMaskRunner();
-  std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>
-      local_runner;
-  if (!lazy_runner) {
-    local_runner.emplace(params.config->algorithm);
-    lazy_runner = &*local_runner;
-  }
-  TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
-                      GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
-  std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) {
-    dropout_rate = *params.config->dropout_rate;
-  }
-
-  double scale = 1.0;
-  if (params.config->fmha_scale) {
-    scale = *params.config->fmha_scale;
-  }
-
-  std::optional<int64_t> seed;
-  if (params.config->seed) {
-    seed = *params.config->seed;
-  }
-
-  se::dnn::FusedMHAScaleBiasMaskSoftmaxOp::Config config{
-      kind,
-      scale,
-      params.config->lhs_bmm1,
-      params.config->rhs_bmm1,
-      params.config->rhs_bmm2,
-      params.config->intermediate_lhs_bmm2,
-      params.config->output,
-      *params.config->bias,
-      *params.config->mask,
-      params.config->activation,
-      dropout_rate,
-      seed};
-  TF_ASSIGN_OR_RETURN(auto *runner,
-                      lazy_runner->GetOrCreateRunner(config, stream));
-  return (*runner)(stream, options.profile_result, scratch_memory,
-                   lhs_bmm1_buffer, rhs_bmm1_buffer, mask_buffer, bias_buffer,
-                   rhs_bmm2_buffer, output_buffer, activation_output);
-}
-
-template <typename ElementType, typename BiasType, typename OutputType>
-Status RunFusedMHAScaleBiasSoftmax(GpufMHAParams params, se::Stream *stream,
-                                   RunFusedMHAOptions options,
-                                   DeviceMemory<ElementType> lhs_bmm1_buffer,
-                                   DeviceMemory<ElementType> rhs_bmm1_buffer,
-                                   DeviceMemory<ElementType> rhs_bmm2_buffer,
-                                   DeviceMemory<OutputType> output_buffer,
-                                   DeviceMemory<BiasType> bias_buffer,
-                                   DeviceMemoryBase scratch_memory,
-                                   DeviceMemoryBase activation_output) {
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp> *lazy_runner =
-      options.runner_cache->AsFusedMHABiasRunner();
-  std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>>
-      local_runner;
-  if (!lazy_runner) {
-    local_runner.emplace(params.config->algorithm);
-    lazy_runner = &*local_runner;
-  }
-  TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
-                      GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
-  std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) {
-    dropout_rate = *params.config->dropout_rate;
-  }
-
-  double scale = 1.0;
-  if (params.config->fmha_scale) {
-    scale = *params.config->fmha_scale;
-  }
-
-  std::optional<int64_t> seed;
-  if (params.config->seed) {
-    seed = *params.config->seed;
-  }
-
-  se::dnn::FusedMHAScaleBiasSoftmaxOp::Config config{
-      kind,
-      scale,
-      params.config->lhs_bmm1,
-      params.config->rhs_bmm1,
-      params.config->rhs_bmm2,
-      params.config->intermediate_lhs_bmm2,
-      params.config->output,
-      *params.config->bias,
-      params.config->activation,
-      dropout_rate,
-      seed};
-  TF_ASSIGN_OR_RETURN(auto *runner,
-                      lazy_runner->GetOrCreateRunner(config, stream));
-  return (*runner)(stream, options.profile_result, scratch_memory,
-                   lhs_bmm1_buffer, rhs_bmm1_buffer, bias_buffer,
-                   rhs_bmm2_buffer, output_buffer, activation_output);
+                   output_buffer, mask_buffer, bias_buffer, activation_output);
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -256,6 +104,14 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
       params.activation_buffer.is_null()
           ? se::DeviceMemoryBase()
           : se::DeviceMemory<OutputType>(params.activation_buffer);
+  auto mask_buffer =
+      params.mask_buffer.is_null()
+          ? se::DeviceMemoryBase()
+          : se::DeviceMemory<ElementType>(params.mask_buffer);
+  auto bias_buffer =
+      params.bias_buffer.is_null()
+          ? se::DeviceMemoryBase()
+          : se::DeviceMemory<BiasType>(params.bias_buffer);
   se::dnn::AlgorithmDesc algorithm = params.config->algorithm;
   if (options.runner_cache) {
     algorithm = options.runner_cache->ToAlgorithmDesc();
@@ -266,44 +122,18 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
     case CudnnfMHAKind::kBmmBmm:
     case CudnnfMHAKind::kSoftmaxDropout:
     case CudnnfMHAKind::kSoftmax:
-      run_status = RunFusedMHABmmBmm<ElementType, OutputType>(
-          params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
-          rhs_bmm2_buffer, output_buffer, scratch_memory, activation_buffer);
-      break;
-
     case CudnnfMHAKind::kScaleMaskSoftmax:
     case CudnnfMHAKind::kScaleMaskSoftmaxDropout:
-      TF_RET_CHECK(params.mask_buffer.has_value());
-      run_status = RunFusedMHAScaleMaskSoftmax<ElementType, OutputType>(
-          params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
-          rhs_bmm2_buffer, output_buffer,
-          se::DeviceMemory<ElementType>(*params.mask_buffer), scratch_memory,
-          activation_buffer);
-      break;
-
     case CudnnfMHAKind::kScaleBiasMaskSoftmax:
     case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
-      TF_RET_CHECK(params.bias_buffer.has_value());
-      TF_RET_CHECK(params.mask_buffer.has_value());
-      run_status =
-          RunFusedMHAScaleBiasMaskSoftmax<ElementType, BiasType, OutputType>(
-              params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
-              rhs_bmm2_buffer, output_buffer,
-              se::DeviceMemory<ElementType>(*params.mask_buffer),
-              se::DeviceMemory<BiasType>(*params.bias_buffer), scratch_memory,
-              activation_buffer);
-      break;
     case CudnnfMHAKind::kScaleBiasSoftmax:
     case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
-      TF_RET_CHECK(params.bias_buffer.has_value());
       run_status =
-          RunFusedMHAScaleBiasSoftmax<ElementType, BiasType, OutputType>(
+          RunFusedMHA<ElementType, BiasType, OutputType>(
               params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
               rhs_bmm2_buffer, output_buffer,
-              se::DeviceMemory<BiasType>(*params.bias_buffer), scratch_memory,
-              activation_buffer);
+              mask_buffer, bias_buffer, scratch_memory, activation_buffer);
       break;
-
     default:
       return InternalError("Invalid cuDNN fMHA kind");
   }
@@ -319,59 +149,6 @@ Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
   }
 
   return OkStatus();
-}
-
-Status CheckAndAssignMask(const GpufMHADescriptor &desc,
-                          GpufMHAConfig &config) {
-  switch (config.kind) {
-    case CudnnfMHAKind::kScaleBiasMaskSoftmax:
-    case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
-    case CudnnfMHAKind::kScaleMaskSoftmax:
-    case CudnnfMHAKind::kScaleMaskSoftmaxDropout:
-      if (desc.mask_shape) {
-        const Shape &mask_shape = *desc.mask_shape;
-
-        TF_ASSIGN_OR_RETURN(DataType mask_type, GetDNNDataTypeFromPrimitiveType(
-                                                    mask_shape.element_type()));
-        config.mask =
-            TensorDescriptor::For(mask_type, mask_shape.dimensions(),
-                                  mask_shape.layout().minor_to_major());
-        return OkStatus();
-      } else {
-        return InternalError(
-            "GpufMHADescriptor should have non-null mask shape but found null "
-            "mask shape");
-      }
-    default:
-      return OkStatus();
-  }
-}
-
-Status CheckAndAssignBias(const GpufMHADescriptor &desc,
-                          GpufMHAConfig &config) {
-  switch (config.kind) {
-    case CudnnfMHAKind::kScaleBiasMaskSoftmax:
-    case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
-    case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
-    case CudnnfMHAKind::kScaleBiasSoftmax:
-      if (desc.bias_shape) {
-        const Shape &bias_shape = *desc.bias_shape;
-
-        TF_ASSIGN_OR_RETURN(DataType bias_type, GetDNNDataTypeFromPrimitiveType(
-                                                    bias_shape.element_type()));
-
-        config.bias =
-            TensorDescriptor::For(bias_type, bias_shape.dimensions(),
-                                  bias_shape.layout().minor_to_major());
-        return OkStatus();
-      } else {
-        return InternalError(
-            "GpufMHADescriptor should have non-null bias shape but found null "
-            "bias shape");
-      }
-    default:
-      return OkStatus();
-  }
 }
 
 void AssignScale(GpufMHAConfig &config,
@@ -427,7 +204,7 @@ void AssignSeed(GpufMHAConfig &config,
 }
 
 template <typename ElementType, typename OutputType>
-Status RunFusedMHABmmBmmBackward(
+Status RunFusedMHABackward(
     GpufMHABackwardParams params, se::Stream *stream,
     RunFusedMHABackwardOptions options,
     DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
@@ -438,76 +215,14 @@ Status RunFusedMHABmmBmmBackward(
     DeviceMemory<OutputType> d_bmm1_lhs_buffer,
     DeviceMemory<OutputType> d_bmm1_rhs_buffer,
     DeviceMemory<OutputType> d_bmm2_rhs_buffer,
-    DeviceMemory<OutputType> d_S_buffer, DeviceMemoryBase d_bias_buffer,
+    DeviceMemory<OutputType> d_s_buffer,
+    DeviceMemoryBase mask_buffer,
+    DeviceMemoryBase d_bias_buffer,
     DeviceMemoryBase scratch_memory) {
-  se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp> *lazy_runner =
-      options.runner_cache->AsFusedMHASoftmaxBackwardRunner();
-  std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>
-      local_runner;
-  if (!lazy_runner) {
-    local_runner.emplace(params.config->algorithm);
-    lazy_runner = &*local_runner;
-  }
-  // FMHA TODO: add GetDNNFusedMHAKindFromCudnnfMHAKind here
-  TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
-                      GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
-  std::optional<double> dropout_rate;
-  if (params.config->dropout_rate) {
-    dropout_rate = *params.config->dropout_rate;
-  }
-
-  double scale = 1.0;
-  if (params.config->fmha_scale) {
-    scale = *params.config->fmha_scale;
-  }
-
-  std::optional<int64_t> seed;
-  if (params.config->seed) {
-    seed = *params.config->seed;
-  }
-
-  se::dnn::FusedMHASoftmaxBackwardOp::Config config{
-      kind,
-      scale,
-      params.config->bmm1_grad_gemm1_rhs,
-      params.config->bmm1_grad_gemm2_rhs,
-      params.config->bmm2_grad_gemm1_lhs,
-      params.config->bmm2_grad_gemm2_rhs,
-      params.config->d_output,
-      params.config->d_bmm1_lhs,
-      params.config->d_bmm1_rhs,
-      params.config->d_bmm2_rhs,
-      params.config->d_s,
-      params.config->d_bias,
-      dropout_rate,
-      seed};
-  TF_ASSIGN_OR_RETURN(auto *runner,
-                      lazy_runner->GetOrCreateRunner(config, stream));
-  return (*runner)(stream, options.profile_result, scratch_memory,
-                   bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
-                   bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
-                   d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
-                   d_bmm2_rhs_buffer, d_S_buffer, d_bias_buffer);
-}
-
-template <typename ElementType, typename OutputType>
-Status RunFusedMHAScaleMaskSoftmaxBackward(
-    GpufMHABackwardParams params, se::Stream *stream,
-    RunFusedMHABackwardOptions options,
-    DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
-    DeviceMemory<ElementType> bmm1_grad_gemm2_rhs_buffer,
-    DeviceMemory<ElementType> bmm2_grad_gemm1_lhs_buffer,
-    DeviceMemory<ElementType> bmm2_grad_gemm2_rhs_buffer,
-    DeviceMemory<ElementType> d_output_buffer,
-    DeviceMemory<OutputType> d_bmm1_lhs_buffer,
-    DeviceMemory<OutputType> d_bmm1_rhs_buffer,
-    DeviceMemory<OutputType> d_bmm2_rhs_buffer,
-    DeviceMemory<OutputType> d_S_buffer, DeviceMemory<ElementType> mask_buffer,
-    DeviceMemoryBase d_bias_buffer, DeviceMemoryBase scratch_memory) {
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>
-      *lazy_runner = options.runner_cache->AsFusedMHAMaskBackwardRunner();
+  se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>
+      *lazy_runner = options.runner_cache->AsFusedMHABackwardRunner();
   std::optional<
-      se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>
+      se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>
       local_runner;
   if (!lazy_runner) {
     local_runner.emplace(params.config->algorithm);
@@ -530,7 +245,7 @@ Status RunFusedMHAScaleMaskSoftmaxBackward(
     seed = *params.config->seed;
   }
 
-  se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp::Config config{
+  se::dnn::FusedMHABackwardOp::Config config{
       kind,
       scale,
       params.config->bmm1_grad_gemm1_rhs,
@@ -542,7 +257,7 @@ Status RunFusedMHAScaleMaskSoftmaxBackward(
       params.config->d_bmm1_rhs,
       params.config->d_bmm2_rhs,
       params.config->d_s,
-      *params.config->mask,
+      params.config->mask,
       params.config->d_bias,
       dropout_rate,
       seed};
@@ -552,7 +267,7 @@ Status RunFusedMHAScaleMaskSoftmaxBackward(
                    bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
                    bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
                    d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
-                   d_bmm2_rhs_buffer, d_S_buffer, mask_buffer, d_bias_buffer);
+                   d_bmm2_rhs_buffer, d_s_buffer, mask_buffer, d_bias_buffer);
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -575,7 +290,11 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
       se::DeviceMemory<OutputType>(params.d_bmm1_rhs_buffer);
   auto d_bmm2_rhs_buffer =
       se::DeviceMemory<OutputType>(params.d_bmm2_rhs_buffer);
-  auto d_S_buffer = se::DeviceMemory<OutputType>(params.d_s_buffer);
+  auto d_s_buffer = se::DeviceMemory<OutputType>(params.d_s_buffer);
+
+  auto mask_buffer = params.mask_buffer.is_null()
+                           ? se::DeviceMemoryBase()
+                           : se::DeviceMemory<ElementType>(params.mask_buffer);
 
   auto d_bias_buffer = params.d_bias_buffer.is_null()
                            ? se::DeviceMemoryBase()
@@ -593,26 +312,16 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
     case CudnnfMHAKind::kBackwardSoftmax:
     case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
     case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
-      run_status = RunFusedMHABmmBmmBackward<ElementType, OutputType>(
-          params, stream, options, bmm1_grad_gemm1_rhs_buffer,
-          bmm1_grad_gemm2_rhs_buffer, bmm2_grad_gemm1_lhs_buffer,
-          bmm2_grad_gemm2_rhs_buffer, d_output_buffer, d_bmm1_lhs_buffer,
-          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_S_buffer, d_bias_buffer,
-          scratch_memory);
-      break;
-
     case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
     case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
     case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
     case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
-      TF_RET_CHECK(params.mask_buffer.has_value());
-      run_status = RunFusedMHAScaleMaskSoftmaxBackward<ElementType, OutputType>(
+      run_status = RunFusedMHABackward<ElementType, OutputType>(
           params, stream, options, bmm1_grad_gemm1_rhs_buffer,
           bmm1_grad_gemm2_rhs_buffer, bmm2_grad_gemm1_lhs_buffer,
           bmm2_grad_gemm2_rhs_buffer, d_output_buffer, d_bmm1_lhs_buffer,
-          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_S_buffer,
-          se::DeviceMemory<ElementType>(*params.mask_buffer), d_bias_buffer,
-          scratch_memory);
+          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_s_buffer,
+          mask_buffer, d_bias_buffer, scratch_memory);
       break;
     default:
       return InternalError("Invalid cuDNN fMHA kind");
@@ -701,12 +410,27 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
                               activation_shape.layout().minor_to_major());
   }
 
+  if (desc.mask_shape) {
+    const Shape &mask_shape = *desc.mask_shape;
+    TF_ASSIGN_OR_RETURN(DataType mask_type, GetDNNDataTypeFromPrimitiveType(
+                                                mask_shape.element_type()));
+    config.mask =
+        TensorDescriptor::For(mask_type, mask_shape.dimensions(),
+                              mask_shape.layout().minor_to_major());
+  }
+
+  if (desc.bias_shape) {
+    const Shape &bias_shape = *desc.bias_shape;
+    TF_ASSIGN_OR_RETURN(DataType bias_type, GetDNNDataTypeFromPrimitiveType(
+                                                bias_shape.element_type()));
+    config.bias =
+        TensorDescriptor::For(bias_type, bias_shape.dimensions(),
+                              bias_shape.layout().minor_to_major());
+  }
   config.kind = desc.kind;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
 
-  TF_RETURN_IF_ERROR(CheckAndAssignMask(desc, config));
-  TF_RETURN_IF_ERROR(CheckAndAssignBias(desc, config));
   AssignScale(config, backend_config);
   AssignDropoutRate(config, backend_config);
   AssignSeed(config, backend_config);
@@ -822,24 +546,16 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
                               d_bias_shape.layout().minor_to_major());
   }
 
+  if (desc.mask_shape) {
+    const Shape &mask_shape = *desc.mask_shape;
+    TF_ASSIGN_OR_RETURN(DataType mask_type, GetDNNDataTypeFromPrimitiveType(
+                                                mask_shape.element_type()));
+    config.mask = TensorDescriptor::For(mask_type, mask_shape.dimensions(),
+                                        mask_shape.layout().minor_to_major());
+  }
   config.kind = desc.kind;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
-  auto check_and_assign_mask = [&]() -> Status {
-    if (desc.mask_shape) {
-      const Shape &mask_shape = *desc.mask_shape;
-
-      TF_ASSIGN_OR_RETURN(DataType mask_type, GetDNNDataTypeFromPrimitiveType(
-                                                  mask_shape.element_type()));
-      config.mask = TensorDescriptor::For(mask_type, mask_shape.dimensions(),
-                                          mask_shape.layout().minor_to_major());
-      return OkStatus();
-    } else {
-      return InternalError(
-          "GpufMHADescriptor should have non-nul mask shape but found null "
-          "mask shape");
-    }
-  };
 
   auto assign_scale = [&]() {
     config.fmha_scale.emplace(backend_config.fmha_scale());
@@ -850,45 +566,9 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   };
 
   auto assign_seed = [&]() { config.seed.emplace(backend_config.seed()); };
-
-  switch (config.kind) {
-    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
-      TF_RETURN_IF_ERROR(check_and_assign_mask());
-      assign_scale();
-      break;
-    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
-      TF_RETURN_IF_ERROR(check_and_assign_mask());
-      assign_scale();
-      assign_dropout_rate();
-      assign_seed();
-      break;
-    case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
-      TF_RETURN_IF_ERROR(check_and_assign_mask());
-      assign_scale();
-      break;
-    case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
-      TF_RETURN_IF_ERROR(check_and_assign_mask());
-      assign_scale();
-      assign_dropout_rate();
-      assign_seed();
-      break;
-    case CudnnfMHAKind::kBackwardBmmBmm:
-    case CudnnfMHAKind::kBackwardSoftmax:
-      break;
-    case CudnnfMHAKind::kBackwardSoftmaxDropout:
-      assign_dropout_rate();
-      assign_seed();
-      break;
-    case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
-      assign_scale();
-      assign_dropout_rate();
-      assign_seed();
-      break;
-    case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
-      assign_scale();
-      break;
-    default:
-      return InternalError("Unknown backward fmha kind");
+  assign_scale();
+  assign_dropout_rate();
+  assign_seed();
   }
   return config;
 }
@@ -905,44 +585,9 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   params.rhs_bmm2_buffer = rhs_bmm2_buffer;
   params.output_buffer = output_buffer;
   params.activation_buffer = activation_buffer;
+  params.mask_buffer = mask_buffer;
+  params.bias_buffer = bias_buffer;
 
-  auto assign_mask_buffer = [&]() {
-    params.mask_buffer.emplace();
-    se::DeviceMemoryBase &mask = *params.mask_buffer;
-    mask = mask_buffer;
-  };
-
-  auto assign_bias_buffer = [&]() {
-    params.bias_buffer.emplace();
-    se::DeviceMemoryBase &bias = *params.bias_buffer;
-    bias = bias_buffer;
-  };
-
-  switch (config.kind) {
-    case CudnnfMHAKind::kBmmBmm:
-    case CudnnfMHAKind::kSoftmaxDropout:
-    case CudnnfMHAKind::kSoftmax:
-      break;
-    case CudnnfMHAKind::kScaleMaskSoftmax:
-    case CudnnfMHAKind::kScaleMaskSoftmaxDropout:
-      TF_RET_CHECK(!mask_buffer.is_null());
-      assign_mask_buffer();
-      break;
-    case CudnnfMHAKind::kScaleBiasMaskSoftmax:
-    case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
-      TF_RET_CHECK(!mask_buffer.is_null());
-      TF_RET_CHECK(!bias_buffer.is_null());
-      assign_mask_buffer();
-      assign_bias_buffer();
-      break;
-    case CudnnfMHAKind::kScaleBiasSoftmax:
-    case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
-      TF_RET_CHECK(!bias_buffer.is_null());
-      assign_bias_buffer();
-      break;
-    default:
-      return InternalError("Unknown forward CudnnfMHAKind");
-  }
   return params;
 }
 
@@ -968,31 +613,9 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   params.d_bmm1_rhs_buffer = d_bmm1_rhs_buffer;
   params.d_bmm2_rhs_buffer = d_bmm2_rhs_buffer;
   params.d_s_buffer = d_s_buffer;
+  params.mask_buffer = mask_buffer;
   params.d_bias_buffer = d_bias_buffer;
 
-  auto assign_mask_buffer = [&]() {
-    params.mask_buffer.emplace();
-    se::DeviceMemoryBase &mask = *params.mask_buffer;
-    mask = mask_buffer;
-  };
-
-  switch (config.kind) {
-    case CudnnfMHAKind::kBackwardBmmBmm:
-    case CudnnfMHAKind::kBackwardSoftmaxDropout:
-    case CudnnfMHAKind::kBackwardSoftmax:
-    case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
-    case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
-      break;
-    case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
-    case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
-    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
-    case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
-      TF_RET_CHECK(!mask_buffer.is_null());
-      assign_mask_buffer();
-      break;
-    default:
-      return InternalError("Unknown backward CudnnfMHAKind");
-  }
   return params;
 }
 

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -569,7 +569,6 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   assign_scale();
   assign_dropout_rate();
   assign_seed();
-  }
   return config;
 }
 

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -142,18 +142,18 @@ struct GpufMHAParams {
                                      se::DeviceMemoryBase rhs_bmm1_buffer,
                                      se::DeviceMemoryBase rhs_bmm2_buffer,
                                      se::DeviceMemoryBase output_buffer,
-                                     se::DeviceMemoryBase mask_buffer,
-                                     se::DeviceMemoryBase bias_buffer,
-                                     se::DeviceMemoryBase activation_buffer);
+                                     std::optional<se::DeviceMemoryBase> mask_buffer,
+                                     std::optional<se::DeviceMemoryBase> bias_buffer,
+                                     std::optional<se::DeviceMemoryBase> activation_buffer);
 
   const GpufMHAConfig* config;  // Not owned
   se::DeviceMemoryBase lhs_bmm1_buffer;
   se::DeviceMemoryBase rhs_bmm1_buffer;
   se::DeviceMemoryBase rhs_bmm2_buffer;
   se::DeviceMemoryBase output_buffer;
-  se::DeviceMemoryBase activation_buffer;
-  se::DeviceMemoryBase mask_buffer;
-  se::DeviceMemoryBase bias_buffer;
+  std::optional<se::DeviceMemoryBase> activation_buffer;
+  std::optional<se::DeviceMemoryBase> mask_buffer;
+  std::optional<se::DeviceMemoryBase> bias_buffer;
 };
 
 struct GpufMHABackwardParams {
@@ -166,8 +166,8 @@ struct GpufMHABackwardParams {
       se::DeviceMemoryBase d_output_buffer,
       se::DeviceMemoryBase d_bmm1_lhs_buffer,
       se::DeviceMemoryBase d_bmm1_rhs_buffer,
-      se::DeviceMemoryBase d_bmm2_rhs_buffer, se::DeviceMemoryBase d_S_buffer,
-      se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase d_bias_buffer);
+      se::DeviceMemoryBase d_bmm2_rhs_buffer, se::DeviceMemoryBase d_s_buffer,
+      std::optional<se::DeviceMemoryBase> mask_buffer, std::optional<se::DeviceMemoryBase> d_bias_buffer);
 
   const GpufMHABackwardConfig* config;  // Not owned
   se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer;
@@ -179,8 +179,8 @@ struct GpufMHABackwardParams {
   se::DeviceMemoryBase d_bmm1_rhs_buffer;
   se::DeviceMemoryBase d_bmm2_rhs_buffer;
   se::DeviceMemoryBase d_s_buffer;
-  se::DeviceMemoryBase d_bias_buffer;
-  se::DeviceMemoryBase mask_buffer;
+  std::optional<se::DeviceMemoryBase> d_bias_buffer;
+  std::optional<se::DeviceMemoryBase> mask_buffer;
 };
 
 class FusedMultiHeadedAttentionRunner {
@@ -367,8 +367,8 @@ Status RunGpuFMHA(
     const GpufMHAConfig& fmha_config, se::DeviceMemoryBase lhs_bmm1_buffer,
     se::DeviceMemoryBase rhs_bmm1_buffer, se::DeviceMemoryBase rhs_bmm2_buffer,
     se::DeviceMemoryBase output_buffer, se::DeviceMemoryBase scratch_buffer,
-    se::DeviceMemoryBase mask_buffer, se::DeviceMemoryBase bias_buffer,
-    se::DeviceMemoryBase activation_buffer, se::Stream* stream,
+    std::optional<se::DeviceMemoryBase> mask_buffer, std::optional<se::DeviceMemoryBase> bias_buffer,
+    std::optional<se::DeviceMemoryBase> activation_buffer, se::Stream* stream,
     RunFusedMHAOptions = {});
 
 Status RunGpuFMHABackward(const GpufMHABackwardConfig& fmha_config,
@@ -381,9 +381,9 @@ Status RunGpuFMHABackward(const GpufMHABackwardConfig& fmha_config,
                           se::DeviceMemoryBase d_bmm1_lhs_buffer,
                           se::DeviceMemoryBase d_bmm1_rhs_buffer,
                           se::DeviceMemoryBase d_bmm2_rhs_buffer,
-                          se::DeviceMemoryBase d_S_buffer,
-                          se::DeviceMemoryBase mask_buffer,
-                          se::DeviceMemoryBase d_bias_buffer,
+                          se::DeviceMemoryBase d_s_buffer,
+                          std::optional<se::DeviceMemoryBase> mask_buffer,
+                          std::optional<se::DeviceMemoryBase> d_bias_buffer,
                           se::Stream* stream, RunFusedMHABackwardOptions = {});
 
 std::string ToString(const GpufMHAConfig& config);

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -152,8 +152,8 @@ struct GpufMHAParams {
   se::DeviceMemoryBase rhs_bmm2_buffer;
   se::DeviceMemoryBase output_buffer;
   se::DeviceMemoryBase activation_buffer;
-  std::optional<se::DeviceMemoryBase> mask_buffer;
-  std::optional<se::DeviceMemoryBase> bias_buffer;
+  se::DeviceMemoryBase mask_buffer;
+  se::DeviceMemoryBase bias_buffer;
 };
 
 struct GpufMHABackwardParams {
@@ -180,43 +180,19 @@ struct GpufMHABackwardParams {
   se::DeviceMemoryBase d_bmm2_rhs_buffer;
   se::DeviceMemoryBase d_s_buffer;
   se::DeviceMemoryBase d_bias_buffer;
-  std::optional<se::DeviceMemoryBase> mask_buffer;
+  se::DeviceMemoryBase mask_buffer;
 };
 
 class FusedMultiHeadedAttentionRunner {
  public:
   using Repr = std::variant<
       std::monostate,  // To allow XXX default ctor
-      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>>,
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>>,
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>>,
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>>;
+      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>>>;
 
   FusedMultiHeadedAttentionRunner() = default;
 
   explicit FusedMultiHeadedAttentionRunner(
-      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>> runner)
-      : repr_(std::move(runner)) {}
-
-  explicit FusedMultiHeadedAttentionRunner(
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>>
-          runner)
-      : repr_(std::move(runner)) {}
-
-  explicit FusedMultiHeadedAttentionRunner(
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>
-          runner)
-      : repr_(std::move(runner)) {}
-
-  explicit FusedMultiHeadedAttentionRunner(
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>>
-          runner)
+      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>> runner)
       : repr_(std::move(runner)) {}
 
   explicit FusedMultiHeadedAttentionRunner(Repr runner)
@@ -234,44 +210,14 @@ class FusedMultiHeadedAttentionRunner {
     return std::visit(ToAlgorithmDescVisitor{}, repr_);
   }
 
-  se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>* AsFusedMHASoftmaxRunner() {
+  se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>* AsFusedMHARunner() {
     CHECK(std::holds_alternative<
-          std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>>>(
+          std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>>>(
         repr_));
     return std::
-        get<std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>>>(
+        get<std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>>>(
                repr_)
             .get();
-  }
-
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>*
-  AsFusedMHAMaskRunner() {
-    CHECK(std::holds_alternative<std::unique_ptr<
-              se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>>>(
-        repr_));
-    return std::get<std::unique_ptr<
-        se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>>>(repr_)
-        .get();
-  }
-
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>*
-  AsFusedMHABiasMaskRunner() {
-    CHECK(std::holds_alternative<std::unique_ptr<
-              se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>>(
-        repr_));
-    return std::get<std::unique_ptr<
-        se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>>(repr_)
-        .get();
-  }
-
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>*
-  AsFusedMHABiasRunner() {
-    CHECK(std::holds_alternative<std::unique_ptr<
-              se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>>>(
-        repr_));
-    return std::get<std::unique_ptr<
-        se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>>>(repr_)
-        .get();
   }
 
  private:
@@ -285,23 +231,14 @@ class FusedMultiHeadedAttentionRunner {
       case CudnnfMHAKind::kBmmBmm:
       case CudnnfMHAKind::kSoftmaxDropout:
       case CudnnfMHAKind::kSoftmax:
-        return std::make_unique<
-            se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxOp>>(
-            config.algorithm);
       case CudnnfMHAKind::kScaleBiasSoftmax:
       case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
-        return std::make_unique<
-            se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasSoftmaxOp>>(
-            config.algorithm);
       case CudnnfMHAKind::kScaleMaskSoftmax:
       case CudnnfMHAKind::kScaleMaskSoftmaxDropout:
-        return std::make_unique<
-            se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxOp>>(
-            config.algorithm);
       case CudnnfMHAKind::kScaleBiasMaskSoftmax:
       case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
         return std::make_unique<
-            se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleBiasMaskSoftmaxOp>>(
+            se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>>(
             config.algorithm);
       default:
         LOG(FATAL) << "Internal error: unsupported CUDNN MHA kind in "
@@ -328,20 +265,12 @@ class FusedMultiHeadedAttentionBackwardRunner {
   using Repr = std::variant<
       std::monostate,  // To allow XXX default ctor
       std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>,
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>>;
+          se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>>;
 
   FusedMultiHeadedAttentionBackwardRunner() = default;
 
   explicit FusedMultiHeadedAttentionBackwardRunner(
-      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>
-          runner)
-      : repr_(std::move(runner)) {}
-
-  explicit FusedMultiHeadedAttentionBackwardRunner(
-      std::unique_ptr<
-          se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>
+      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>
           runner)
       : repr_(std::move(runner)) {}
 
@@ -362,23 +291,13 @@ class FusedMultiHeadedAttentionBackwardRunner {
     return std::visit(ToAlgorithmDescVisitor{}, repr_);
   }
 
-  se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>*
-  AsFusedMHASoftmaxBackwardRunner() {
+  se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>*
+  AsFusedMHABackwardRunner() {
     CHECK(
         std::holds_alternative<std::unique_ptr<
-            se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>>(repr_));
+            se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>>(repr_));
     return std::get<std::unique_ptr<
-        se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>>(repr_)
-        .get();
-  }
-
-  se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>*
-  AsFusedMHAMaskBackwardRunner() {
-    CHECK(std::holds_alternative<std::unique_ptr<se::dnn::LazyOpRunner<
-              se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>>(repr_));
-    return std::get<std::unique_ptr<
-        se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>>(
-               repr_)
+        se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>>(repr_)
         .get();
   }
 
@@ -395,15 +314,12 @@ class FusedMultiHeadedAttentionBackwardRunner {
       case CudnnfMHAKind::kBackwardSoftmax:
       case CudnnfMHAKind::kBackwardScaleBiasSoftmax:
       case CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout:
-        return std::make_unique<
-            se::dnn::LazyOpRunner<se::dnn::FusedMHASoftmaxBackwardOp>>(
-            config.algorithm);
       case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax:
       case CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout:
       case CudnnfMHAKind::kBackwardScaleMaskSoftmax:
       case CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
         return std::make_unique<
-            se::dnn::LazyOpRunner<se::dnn::FusedMHAScaleMaskSoftmaxBackwardOp>>(
+            se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>(
             config.algorithm);
       default:
         LOG(FATAL) << "Internal error: unsupported CUDNN MHA kind in "

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1016,11 +1016,9 @@ Status IrEmitterUnnested::EmitConvolutionReorderThunk(mlir::Operation* op) {
 Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
   using mlir::dyn_cast;
   using mlir::lmhlo_gpu::fusedMHAOp;
-  using mlir::lmhlo_gpu::fusedMHAWithScaledBiasOp;
-  using mlir::lmhlo_gpu::fusedMHAWithScaledMaskOp;
   GpufMHADescriptor descriptor;
   BufferAllocation::Slice lhs_bmm1_slice, rhs_bmm1_slice, rhs_bmm2_slice,
-      output_slice, scratch_slice, activation_slice;
+      output_slice, scratch_slice, activation_slice, mask_slice, bias_slice;
 
   auto populate_common = [&](auto fmha) -> Status {
     descriptor.backend_config.set_fmha_scale(
@@ -1093,6 +1091,27 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
                           GetAllocationSlice(fmha.getActivation()));
     }
 
+    if (fmha.getBias() != nullptr) {
+      descriptor.bias_shape = ShapeUtil::MakeShapeWithDenseLayout(
+          GetShape(fmha.getBias()).element_type(),
+          GetShape(fmha.getBias()).dimensions(),
+          GetShape(fmha.getBias())
+              .layout()
+              .minor_to_major());
+
+      TF_ASSIGN_OR_RETURN(
+          bias_slice, GetAllocationSlice(fmha.getBias()));
+    }
+
+    if (fmha.getMask() != nullptr) {
+      descriptor.mask_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        GetShape(fmha.getMask()).element_type(),
+        GetShape(fmha.getMask()).dimensions(),
+        GetShape(fmha.getMask()).layout().minor_to_major());
+
+      TF_ASSIGN_OR_RETURN(mask_slice,
+                          GetAllocationSlice(fmha.getMask()));
+    }
     TF_ASSIGN_OR_RETURN(
         auto intermediate_tensor_layout_array,
         ConvertMlirArrayAttrToInt64Array(fmha.getIntermediateTensorLayout()));
@@ -1104,84 +1123,26 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
     return OkStatus();
   };
 
-  BufferAllocation::Slice mask_slice;
-  BufferAllocation::Slice bias_slice;
   if (auto fmha_op = dyn_cast<fusedMHAOp>(op)) {
     TF_RET_CHECK(fmha_op != nullptr);
     TF_ASSIGN_OR_RETURN(CudnnfMHAKind kind,
                         AsCudnnfMHAKind(fmha_op.getFusedMhaDag()));
     descriptor.kind = kind;
     TF_RETURN_IF_ERROR(populate_common(fmha_op));
-  } else if (auto fmha_with_scaled_mask_op =
-                 dyn_cast<fusedMHAWithScaledMaskOp>(op)) {
-    TF_RET_CHECK(fmha_with_scaled_mask_op != nullptr);
-    TF_ASSIGN_OR_RETURN(
-        CudnnfMHAKind kind,
-        AsCudnnfMHAKind(fmha_with_scaled_mask_op.getFusedMhaDag()));
-    descriptor.kind = kind;
-
-    TF_RET_CHECK(kind != xla::gpu::CudnnfMHAKind::kBmmBmm &&
-                 kind != xla::gpu::CudnnfMHAKind::kSoftmaxDropout &&
-                 kind != xla::gpu::CudnnfMHAKind::kSoftmax);
-
-    descriptor.mask_shape = ShapeUtil::MakeShapeWithDenseLayout(
-        GetShape(fmha_with_scaled_mask_op.getMask()).element_type(),
-        GetShape(fmha_with_scaled_mask_op.getMask()).dimensions(),
-        GetShape(fmha_with_scaled_mask_op.getMask()).layout().minor_to_major());
-
-    TF_ASSIGN_OR_RETURN(mask_slice,
-                        GetAllocationSlice(fmha_with_scaled_mask_op.getMask()));
-
-    if (fmha_with_scaled_mask_op.getBias() != nullptr) {
-      TF_RET_CHECK(kind == xla::gpu::CudnnfMHAKind::kScaleBiasMaskSoftmax ||
-                   kind ==
-                       xla::gpu::CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout);
-
-      descriptor.bias_shape = ShapeUtil::MakeShapeWithDenseLayout(
-          GetShape(fmha_with_scaled_mask_op.getBias()).element_type(),
-          GetShape(fmha_with_scaled_mask_op.getBias()).dimensions(),
-          GetShape(fmha_with_scaled_mask_op.getBias())
-              .layout()
-              .minor_to_major());
-
-      TF_ASSIGN_OR_RETURN(
-          bias_slice, GetAllocationSlice(fmha_with_scaled_mask_op.getBias()));
-    }
-    TF_RETURN_IF_ERROR(populate_common(fmha_with_scaled_mask_op));
-  } else if (auto fmha_with_bias_op = dyn_cast<fusedMHAWithScaledBiasOp>(op)) {
-    TF_RET_CHECK(fmha_with_bias_op != nullptr);
-    TF_ASSIGN_OR_RETURN(CudnnfMHAKind kind,
-                        AsCudnnfMHAKind(fmha_with_bias_op.getFusedMhaDag()));
-    descriptor.kind = kind;
-    TF_RET_CHECK(kind == xla::gpu::CudnnfMHAKind::kScaleBiasSoftmax ||
-                 kind == xla::gpu::CudnnfMHAKind::kScaleBiasSoftmaxDropout);
-
-    descriptor.bias_shape = ShapeUtil::MakeShapeWithDenseLayout(
-        GetShape(fmha_with_bias_op.getBias()).element_type(),
-        GetShape(fmha_with_bias_op.getBias()).dimensions(),
-        GetShape(fmha_with_bias_op.getBias()).layout().minor_to_major());
-
-    TF_ASSIGN_OR_RETURN(bias_slice,
-                        GetAllocationSlice(fmha_with_bias_op.getBias()));
-
-    TF_RETURN_IF_ERROR(populate_common(fmha_with_bias_op));
   } else {
     return InternalError("Unexpected operation");
   }
   TF_ASSIGN_OR_RETURN(GpufMHAConfig config, GpufMHAConfig::For(descriptor));
-
   AddThunkToThunkSequence(std::make_unique<FusedMHAThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(op), std::move(config),
       lhs_bmm1_slice, rhs_bmm1_slice, rhs_bmm2_slice, output_slice,
       scratch_slice, mask_slice, bias_slice, activation_slice));
-
   return OkStatus();
 }
 
 Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
   using mlir::dyn_cast;
   using mlir::lmhlo_gpu::fusedMHABackwardOp;
-  using mlir::lmhlo_gpu::fusedMHAWithMaskBackwardOp;
 
   GpufMHABackwardDescriptor descriptor;
   BufferAllocation::Slice bmm1_grad_gemm1_rhs_slice, bmm1_grad_gemm2_rhs_slice,
@@ -1293,6 +1254,22 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
       TF_ASSIGN_OR_RETURN(d_bias_slice, GetAllocationSlice(fmha.getDBias()));
     }
 
+    if (fmha.getMask() != nullptr) {
+      // has mask input
+      TF_RET_CHECK(descriptor.kind  != xla::gpu::CudnnfMHAKind::kBackwardBmmBmm &&
+                 descriptor.kind  != xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout &&
+                 descriptor.kind  != xla::gpu::CudnnfMHAKind::kBackwardSoftmax);
+
+      descriptor.mask_shape = ShapeUtil::MakeShapeWithDenseLayout(
+          GetShape(fmha.getMask()).element_type(),
+          GetShape(fmha.getMask()).dimensions(),
+          GetShape(fmha.getMask())
+              .layout()
+              .minor_to_major());
+
+      TF_ASSIGN_OR_RETURN(
+          mask_slice, GetAllocationSlice(fmha.getMask()));
+    }
     return OkStatus();
   };
 
@@ -1303,29 +1280,6 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
         AsCudnnBackwardfMHAKind(fmha_backward_op.getFusedMhaDag()));
     descriptor.kind = kind;
     TF_RETURN_IF_ERROR(populate_common(fmha_backward_op));
-  } else if (auto fmha_with_mask_backward_op =
-                 dyn_cast<fusedMHAWithMaskBackwardOp>(op)) {
-    TF_RET_CHECK(fmha_with_mask_backward_op != nullptr);
-    TF_ASSIGN_OR_RETURN(
-        CudnnfMHAKind kind,
-        AsCudnnBackwardfMHAKind(fmha_with_mask_backward_op.getFusedMhaDag()));
-    descriptor.kind = kind;
-
-    TF_RET_CHECK(kind != xla::gpu::CudnnfMHAKind::kBackwardBmmBmm &&
-                 kind != xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout &&
-                 kind != xla::gpu::CudnnfMHAKind::kBackwardSoftmax);
-
-    descriptor.mask_shape = ShapeUtil::MakeShapeWithDenseLayout(
-        GetShape(fmha_with_mask_backward_op.getMask()).element_type(),
-        GetShape(fmha_with_mask_backward_op.getMask()).dimensions(),
-        GetShape(fmha_with_mask_backward_op.getMask())
-            .layout()
-            .minor_to_major());
-
-    TF_ASSIGN_OR_RETURN(
-        mask_slice, GetAllocationSlice(fmha_with_mask_backward_op.getMask()));
-
-    TF_RETURN_IF_ERROR(populate_common(fmha_with_mask_backward_op));
   } else {
     return InternalError("Unexpected operation");
   }
@@ -3055,13 +3009,10 @@ Status IrEmitterUnnested::EmitOp(
                 mlir::lmhlo_gpu::CudnnConvReorderFilterAndBiasOp>(op)) {
     return EmitConvolutionReorderThunk(op);
   }
-  if (mlir::isa<mlir::lmhlo_gpu::fusedMHAOp,
-                mlir::lmhlo_gpu::fusedMHAWithScaledMaskOp,
-                mlir::lmhlo_gpu::fusedMHAWithScaledBiasOp>(op)) {
+  if (mlir::isa<mlir::lmhlo_gpu::fusedMHAOp>(op)) {
     return EmitFusedMHAThunk(op);
   }
-  if (mlir::isa<mlir::lmhlo_gpu::fusedMHABackwardOp,
-                mlir::lmhlo_gpu::fusedMHAWithMaskBackwardOp>(op)) {
+  if (mlir::isa<mlir::lmhlo_gpu::fusedMHABackwardOp>(op)) {
     return EmitFusedMHABackwardThunk(op);
   }
 #endif  // GOOGLE_CUDA

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5094,9 +5094,9 @@ GetCudnnFusedMHAOperationGraph(
     const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
     const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-    const dnn::TensorDescriptor& mask_descriptor,
-    const dnn::TensorDescriptor& bias_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
+    std::optional<dnn::TensorDescriptor> mask_descriptor,
+    std::optional<dnn::TensorDescriptor> bias_descriptor,
     std::optional<dnn::TensorDescriptor> activation_descriptor, int64_t& s_uid,
     dnn::FusedMHAKind kind, std::optional<double> dropout_rate,
     std::optional<int64_t> seed, CudnnHandle& cudnn, double scale,
@@ -5212,7 +5212,7 @@ GetCudnnFusedMHAOperationGraph(
           auto bias_out,
           CreateCudnnBiasTensor(intermediate_ops, intermediate_bmm2_lhs_dims,
                                 intermediate_bmm2_lhs_strides,
-                                bias_descriptor.type(), bmm2_input_tensor,
+                                (*bias_descriptor).type(), bmm2_input_tensor,
                                 use_mask));
       bmm2_input_tensor =
           std::make_shared<cudnn_frontend::Tensor>(std::move(bias_out));
@@ -5713,7 +5713,6 @@ GetCudnnFusedMHABackwardOperationGraph(
     const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
     const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
     const dnn::MatmulTensorDescriptor& d_output_descriptor,
-    const dnn::TensorDescriptor& mask_descriptor,
     const dnn::TensorDescriptor& d_s_descriptor,
     const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
     const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
@@ -6735,11 +6734,10 @@ class CudnnExecutionPlanRunner<void(Args...)>
       }
     }
 
-    if (!data_ptrs_vec.empty() && data_ptrs_vec.back() == nullptr &&
-        !has_activation_output_) {
-      data_ptrs_vec.pop_back();
-    }
-
+    // remove empty buffers from the list
+    data_ptrs_vec.erase(std::remove(data_ptrs_vec.begin(), data_ptrs_vec.end(), nullptr), data_ptrs_vec.end());
+    // ensure the size is equal after removing useless pointers
+    CHECK(data_ptrs_vec.size() == data_uids_vec.size());
     if (should_add_scalars) {
       data_uids_vec.insert(data_uids_vec.end(), scalar_input_uids_.begin(),
                            scalar_input_uids_.end());
@@ -7704,8 +7702,8 @@ int64_t GetDropoutRngOffset(std::vector<int64_t>& intermediate_shape) {
   return max_seq_len * max_seq_len / cudnn_mha_num_threads;
 }
 
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
-CudnnSupport::FusedMHASoftmaxRunnerFromDesc(
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
+CudnnSupport::FusedMHARunnerFromDesc(
     Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
     dnn::FusedMHAKind kind,
     const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
@@ -7714,99 +7712,38 @@ CudnnSupport::FusedMHASoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
     std::optional<dnn::TensorDescriptor> activation_descriptor,
+    std::optional<dnn::TensorDescriptor> mask_descriptor,
+    std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
 #if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
   auto cudnn = cudnn_->GetHandle(parent_, stream);
-
-  // Create empty descriptors for bias and mask tensors
-  dnn::TensorDescriptor empty_mask_desc;
-  dnn::TensorDescriptor empty_bias_desc;
   bool use_dropout = dropout_rate && *dropout_rate > 0.0;
   int64_t s_uid = -1;
   std::vector<int64_t> intermediate_shape;
-
   TF_ASSIGN_OR_RETURN(
       auto op_graph,
       GetCudnnFusedMHAOperationGraph(
           bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
-          intermediate_bmm2_lhs_descriptor, empty_mask_desc, empty_bias_desc,
-          output_descriptor, activation_descriptor, s_uid, kind, dropout_rate,
-          seed, cudnn, 1.0f, intermediate_shape, use_dropout));
+          intermediate_bmm2_lhs_descriptor, output_descriptor, mask_descriptor, bias_descriptor,
+          activation_descriptor, s_uid, kind, dropout_rate,
+          seed, cudnn, scale, intermediate_shape, use_dropout,
+           /*use_mask*/ mask_descriptor != std::nullopt, /*use_bias*/ bias_descriptor != std::nullopt));
 
   TF_ASSIGN_OR_RETURN(auto execution_plan,
                       GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
   std::vector<int64_t> u_ids = {'q', 'k', 'v', 'o'};
+  if (mask_descriptor) {
+    u_ids.push_back('P');
+  }
+
+  if (bias_descriptor) {
+    u_ids.push_back('B');
+  }
+
   if (activation_descriptor) {
     u_ids.push_back(s_uid);
   }
 
-  ScalingParam alpha_scale(1.0, bmm1_lhs_descriptor.type());
-  std::vector<ScalingParam> scalar_input_values = {alpha_scale};
-  std::vector<int64_t> scalar_input_uids = {CudnnfMHAUid::ALPHA_SCALE_ID};
-
-  int64_t dropout_rng_offset = 0;
-  if (use_dropout) {
-    scalar_input_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
-    double dropout_scale_value = (1.0 / (1.0 - *dropout_rate));
-    ScalingParam dropout_scale(dropout_scale_value, bmm1_lhs_descriptor.type());
-    scalar_input_values.push_back(dropout_scale);
-    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
-  }
-  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
-
-  TF_ASSIGN_OR_RETURN(
-      auto runner,
-      CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan), u_ids,
-          /*need_side_input*/ true,
-          /*has_activation_output*/ (activation_descriptor != std::nullopt),
-          scalar_input_uids, scalar_input_values, dropout_rng_seed,
-          dropout_rng_offset));
-  return {
-      std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxSignature>>(
-          std::move(runner))};
-#else
-  return absl::UnimplementedError(
-      "Cudnn execution plans are only supported with Cudnn >= 8.8.");
-#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
-}
-
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
-CudnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-    const dnn::TensorDescriptor& output_descriptor,
-    std::optional<dnn::TensorDescriptor> activation_descriptor,
-    const dnn::TensorDescriptor& mask_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
-  auto cudnn = cudnn_->GetHandle(parent_, stream);
-
-  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
-  // Create empty bias decriptor
-  dnn::TensorDescriptor empty_bias_desc;
-  int64_t s_uid = -1;
-  std::vector<int64_t> intermediate_shape;
-
-  TF_ASSIGN_OR_RETURN(
-      auto op_graph,
-      GetCudnnFusedMHAOperationGraph(
-          bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
-          intermediate_bmm2_lhs_descriptor, mask_descriptor, empty_bias_desc,
-          output_descriptor, activation_descriptor, s_uid, kind, dropout_rate,
-          seed, cudnn, scale, intermediate_shape, use_dropout,
-          /*use_mask*/ true));
-
-  TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
-  std::vector<int64_t> u_ids = {'q', 'k', 'P', 'v', 'o'};
-  if (activation_descriptor) {
-    u_ids.push_back(s_uid);
-  }
 
   ScalingParam alpha_scale(scale, bmm1_lhs_descriptor.type());
   std::vector<ScalingParam> scalar_input_values = {alpha_scale};
@@ -7824,72 +7761,7 @@ CudnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
 
   TF_ASSIGN_OR_RETURN(
       auto runner,
-      CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan), u_ids,
-          /*need_side_input*/ true,
-          /*has_activation_output*/ (activation_descriptor != std::nullopt),
-          scalar_input_uids, scalar_input_values, dropout_rng_seed,
-          dropout_rng_offset));
-
-  return {
-      std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>>(
-          std::move(runner))};
-#else
-  return absl::UnimplementedError(
-      "Cudnn execution plans are only supported with Cudnn >= 8.8.");
-#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
-}
-
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
-CudnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-    const dnn::TensorDescriptor& output_descriptor,
-    std::optional<dnn::TensorDescriptor> activation_descriptor,
-    const dnn::TensorDescriptor& mask_descriptor,
-    const dnn::TensorDescriptor& bias_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
-  auto cudnn = cudnn_->GetHandle(parent_, stream);
-  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
-  int64_t s_uid = -1;
-  std::vector<int64_t> intermediate_shape;
-  TF_ASSIGN_OR_RETURN(
-      auto op_graph,
-      GetCudnnFusedMHAOperationGraph(
-          bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
-          intermediate_bmm2_lhs_descriptor, mask_descriptor, bias_descriptor,
-          output_descriptor, activation_descriptor, s_uid, kind, dropout_rate,
-          seed, cudnn, scale, intermediate_shape, use_dropout,
-          /*use_mask*/ true, /*use_bias*/ true));
-
-  TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
-  std::vector<int64_t> u_ids = {'q', 'k', 'P', 'B', 'v', 'o'};
-  if (activation_descriptor) {
-    u_ids.push_back(s_uid);
-  }
-  ScalingParam alpha_scale(scale, bmm1_lhs_descriptor.type());
-  std::vector<ScalingParam> scalar_input_values = {alpha_scale};
-  std::vector<int64_t> scalar_input_uids = {CudnnfMHAUid::ALPHA_SCALE_ID};
-  int64_t dropout_rng_offset = 0;
-
-  if (use_dropout) {
-    scalar_input_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
-    double dropout_scale_value = (1.0 / (1.0 - *dropout_rate));
-    ScalingParam dropout_scale(dropout_scale_value, bmm1_lhs_descriptor.type());
-    scalar_input_values.push_back(dropout_scale);
-    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
-  }
-  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
-
-  TF_ASSIGN_OR_RETURN(
-      auto runner,
-      CudnnExecutionPlanRunner<dnn::FusedMHABiasMaskSignature>::Create(
+      CudnnExecutionPlanRunner<dnn::FusedMHASignature>::Create(
           parent_, cudnn_.get(), std::move(execution_plan), u_ids,
           /*need_side_input*/ true,
           /*has_activation_output*/ (activation_descriptor != std::nullopt),
@@ -7897,7 +7769,7 @@ CudnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
           dropout_rng_offset));
 
   return {std::make_unique<
-      CudnnExecutionPlanRunner<dnn::FusedMHABiasMaskSignature>>(
+      CudnnExecutionPlanRunner<dnn::FusedMHASignature>>(
       std::move(runner))};
 #else
   return absl::UnimplementedError(
@@ -7905,75 +7777,8 @@ CudnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
 #endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
 }
 
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
-CudnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-    const dnn::TensorDescriptor& output_descriptor,
-    std::optional<dnn::TensorDescriptor> activation_descriptor,
-    const dnn::TensorDescriptor& bias_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
-  auto cudnn = cudnn_->GetHandle(parent_, stream);
-  // Create empty descriptors for mask tensors
-  dnn::TensorDescriptor empty_mask_desc;
-  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
-  int64_t s_uid = -1;
-  std::vector<int64_t> intermediate_shape;
-  TF_ASSIGN_OR_RETURN(
-      auto op_graph,
-      GetCudnnFusedMHAOperationGraph(
-          bmm1_lhs_descriptor, bmm1_rhs_descriptor, bmm2_rhs_descriptor,
-          intermediate_bmm2_lhs_descriptor, empty_mask_desc, bias_descriptor,
-          output_descriptor, activation_descriptor, s_uid, kind, dropout_rate,
-          seed, cudnn, scale, intermediate_shape, use_dropout,
-          /*use_mask*/ false, /*use_bias*/ true));
-
-  TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
-
-  std::vector<int64_t> u_ids = {'q', 'k', 'B', 'v', 'o'};
-  if (activation_descriptor) {
-    u_ids.push_back(s_uid);
-  }
-
-  ScalingParam alpha_scale(scale, bmm1_lhs_descriptor.type());
-
-  std::vector<ScalingParam> scalar_input_values = {alpha_scale};
-  std::vector<int64_t> scalar_input_uids = {CudnnfMHAUid::ALPHA_SCALE_ID};
-  int64_t dropout_rng_offset = 0;
-
-  if (use_dropout) {
-    scalar_input_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
-    double dropout_scale_value = (1.0 / (1.0 - *dropout_rate));
-    ScalingParam dropout_scale(dropout_scale_value, bmm1_lhs_descriptor.type());
-    scalar_input_values.push_back(dropout_scale);
-    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
-  }
-  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
-
-  TF_ASSIGN_OR_RETURN(
-      auto runner,
-      CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan), u_ids,
-          /*need_side_input*/ true,
-          /*has_activation_output*/ (activation_descriptor != std::nullopt),
-          scalar_input_uids, scalar_input_values, dropout_rng_seed,
-          dropout_rng_offset));
-  return {
-      std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>>(
-          std::move(runner))};
-#else
-  return absl::UnimplementedError(
-      "Cudnn execution plans are only supported with Cudnn >= 8.8.");
-#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
-}
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
-CudnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABackwardRunner>>
+CudnnSupport::FusedMHABackwardRunnerFromDesc(
     Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
     dnn::FusedMHAKind kind,
     const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
@@ -7985,89 +7790,7 @@ CudnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
     const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
     const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
     const dnn::TensorDescriptor& d_s_descriptor,
-    std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-#if (CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND)
-  auto cudnn = cudnn_->GetHandle(parent_, stream);
-
-  // Create empty descriptors for bias and mask tensors
-  dnn::TensorDescriptor empty_mask_desc;
-  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
-  TF_ASSIGN_OR_RETURN(
-      auto op_graph,
-      GetCudnnFusedMHABackwardOperationGraph(
-          bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
-          bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
-          d_output_descriptor, empty_mask_desc, d_s_descriptor,
-          d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
-          kind, dropout_rate, seed, cudnn, scale, use_dropout,
-          /*use_mask*/ false,
-          /*use_bias*/ d_bias_descriptor != std::nullopt));
-
-  TF_ASSIGN_OR_RETURN(auto execution_plan,
-                      GetExecPlanFromHeuristics(std::move(*op_graph), cudnn));
-
-  std::vector<int64_t> scalar_uids = {CudnnfMHAUid::ALPHA_SCALE_ID,
-                                      CudnnfMHAUid::ZERO_VAL_ID,
-                                      CudnnfMHAUid::ONE_VAL_ID};
-  ScalingParam alpha_scale(scale, dnn::DataType::kFloat);
-  double zero_value = 0.0f;
-  ScalingParam zero(zero_value, dnn::DataType::kFloat);
-  double one_value = 1.0f;
-  ScalingParam one(one_value, dnn::DataType::kFloat);
-  std::vector<ScalingParam> scalar_values = {alpha_scale, zero, one};
-
-  // TODO cudnn doesn't support no dropout, so setting dropout rate to 0
-  // here to mimic no dropout. Change this when cudnn graph is more
-  // flexible.
-  scalar_uids.push_back(CudnnfMHAUid::DROPOUT_SCALE_ID);
-  double dropout_scale_value =
-      use_dropout ? (1.0 / (1.0 - *dropout_rate)) : 1.0;
-  ScalingParam dropout_scale(dropout_scale_value, dnn::DataType::kFloat);
-  scalar_values.push_back(dropout_scale);
-  int64_t dropout_rng_seed = seed == std::nullopt ? 0 : *seed;
-
-  std::vector<int64_t> uids = {
-      CudnnfMHAUid::Q_ID,  CudnnfMHAUid::K_ID,  CudnnfMHAUid::P_ID,
-      CudnnfMHAUid::V_ID,  CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
-      CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID};
-  if (d_bias_descriptor != std::nullopt) {
-    uids.push_back(CudnnfMHAUid::dBIAS_ID);
-  }
-
-  TF_ASSIGN_OR_RETURN(
-      auto runner,
-      CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxBackwardSignature>::Create(
-          parent_, cudnn_.get(), std::move(execution_plan), uids,
-          /*need_side_input*/ true, /*has_activation_output*/ false,
-          scalar_uids, scalar_values, dropout_rng_seed,
-          /*dropout_rng_offset*/ 0));
-
-  return {std::make_unique<
-      CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxBackwardSignature>>(
-      std::move(runner))};
-#else
-  return absl::UnimplementedError(
-      "Cudnn execution plans with dbias calculation in bwd are only "
-      "supported "
-      "with Cudnn >= 8.8.");
-#endif  // CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
-}
-
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
-CudnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& d_output_descriptor,
-    const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
-    const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
-    const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
-    const dnn::TensorDescriptor& d_s_descriptor,
-    const dnn::TensorDescriptor& mask_descriptor,
+    std::optional<dnn::TensorDescriptor> mask_descriptor,
     std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
 #if (CUDNN_VERSION >= 8901 && TF_ENABLE_CUDNN_FRONTEND)
@@ -8079,10 +7802,10 @@ CudnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
       GetCudnnFusedMHABackwardOperationGraph(
           bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
           bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
-          d_output_descriptor, mask_descriptor, d_s_descriptor,
+          d_output_descriptor, d_s_descriptor,
           d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
           kind, dropout_rate, seed, cudnn, scale, use_dropout,
-          /*use_mask*/ true,
+          /*use_mask*/ mask_descriptor != std::nullopt,
           /*use_bias*/ d_bias_descriptor != std::nullopt));
 
   TF_ASSIGN_OR_RETURN(auto execution_plan,
@@ -8112,20 +7835,23 @@ CudnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
                                CudnnfMHAUid::P_ID,  CudnnfMHAUid::V_ID,
                                CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
                                CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID,
-                               CudnnfMHAUid::dS_ID, CudnnfMHAUid::MASK_ID};
+                               CudnnfMHAUid::dS_ID};
+  if (mask_descriptor != std::nullopt) {
+    uids.push_back(CudnnfMHAUid::MASK_ID);
+  }
   if (d_bias_descriptor != std::nullopt) {
     uids.push_back(CudnnfMHAUid::dBIAS_ID);
   }
 
   TF_ASSIGN_OR_RETURN(
       auto runner,
-      CudnnExecutionPlanRunner<dnn::FusedMHAMaskBackwardSignature>::Create(
+      CudnnExecutionPlanRunner<dnn::FusedMHABackwardSignature>::Create(
           parent_, cudnn_.get(), std::move(execution_plan), uids,
           /*need_side_input*/ true, /*has_activation_output*/ false,
           scalar_uids, scalar_values, dropout_rng_seed,
           /*dropout_rng_offset*/ 0));
   return {std::make_unique<
-      CudnnExecutionPlanRunner<dnn::FusedMHAMaskBackwardSignature>>(
+      CudnnExecutionPlanRunner<dnn::FusedMHABackwardSignature>>(
       std::move(runner))};
 #else
   return absl::UnimplementedError(

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5208,6 +5208,7 @@ GetCudnnFusedMHAOperationGraph(
   if (is_s_virtual) {
     if (use_bias) {
       // Create bias op and tensor
+      DCHECK(bias_descriptor != std::nullopt);
       TF_ASSIGN_OR_RETURN(
           auto bias_out,
           CreateCudnnBiasTensor(intermediate_ops, intermediate_bmm2_lhs_dims,

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6717,10 +6717,11 @@ class CudnnExecutionPlanRunner<void(Args...)>
       }
     }
 
-    // remove empty buffers from the list
-    data_ptrs_vec.erase(std::remove(data_ptrs_vec.begin(), data_ptrs_vec.end(), nullptr), data_ptrs_vec.end());
-    // ensure the size is equal after removing useless pointers
-    CHECK(data_ptrs_vec.size() == data_uids_vec.size());
+    if (!data_ptrs_vec.empty() && data_ptrs_vec.back() == nullptr &&
+        !has_activation_output_) {
+      data_ptrs_vec.pop_back();
+    }
+
     if (should_add_scalars) {
       data_uids_vec.insert(data_uids_vec.end(), scalar_input_uids_.begin(),
                            scalar_input_uids_.end());

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -298,8 +298,8 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode) override;
 
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
-  FusedMHASoftmaxRunnerFromDesc(
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
+  FusedMHARunnerFromDesc(
       Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
       dnn::FusedMHAKind kind,
       const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
@@ -308,50 +308,12 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
       std::optional<dnn::TensorDescriptor> activation_descriptor,
+      std::optional<dnn::TensorDescriptor> mask_descriptor,
+      std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
 
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
-  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor& output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor& mask_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
-  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor& output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor& mask_descriptor,
-      const dnn::TensorDescriptor& bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
-  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor& output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor& bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
-  FusedMHASoftmaxBackwardRunnerFromDesc(
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABackwardRunner>>
+  FusedMHABackwardRunnerFromDesc(
       Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
       dnn::FusedMHAKind kind,
       const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
@@ -363,23 +325,7 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
       const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
       const dnn::TensorDescriptor& d_s_descriptor,
-      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
-  FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& d_output_descriptor,
-      const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
-      const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
-      const dnn::TensorDescriptor& d_bmm2_rhs_descriptor,
-      const dnn::TensorDescriptor& d_s_descriptor,
-      const dnn::TensorDescriptor& mask_descriptor,
+      std::optional<dnn::TensorDescriptor> mask_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
   bool GetRnnAlgorithms(

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -217,8 +217,9 @@ DnnSupport::FusedConvolveRunnerFromDesc(
       "FusedConvolveRunnerFromDesc not implemented.");
 }
 
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
-DnnSupport::FusedMHASoftmaxRunnerFromDesc(
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
+DnnSupport::FusedMHARunnerFromDesc(
     Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
     dnn::FusedMHAKind kind,
     const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
@@ -227,62 +228,15 @@ DnnSupport::FusedMHASoftmaxRunnerFromDesc(
     const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
     const dnn::TensorDescriptor& output_descriptor,
     std::optional<dnn::TensorDescriptor> activation_descriptor,
+    std::optional<dnn::TensorDescriptor> mask_descriptor,
+    std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
   return absl::UnimplementedError(
-      "FusedMHASoftmaxRunnerFromDesc not implemented.");
+      "FusedMHARunnerFromDesc not implemented.");
 }
 
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
-DnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-    const dnn::TensorDescriptor& output_descriptor,
-    std::optional<dnn::TensorDescriptor> activation_descriptor,
-    const dnn::TensorDescriptor& mask_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return absl::UnimplementedError(
-      "FusedMHAScaleMaskSoftmaxRunnerFromDesc not implemented.");
-}
-
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
-DnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-    const dnn::TensorDescriptor& output_descriptor,
-    std::optional<dnn::TensorDescriptor> activation_descriptor,
-    const dnn::TensorDescriptor& mask_descriptor,
-    const dnn::TensorDescriptor& bias_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return absl::UnimplementedError(
-      "FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc not implemented.");
-}
-
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
-DnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-    const dnn::TensorDescriptor& output_descriptor,
-    std::optional<dnn::TensorDescriptor> activation_descriptor,
-    const dnn::TensorDescriptor& bias_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return absl::UnimplementedError(
-      "FusedMHAScaleBiasSoftmaxRunnerFromDesc not implemented.");
-}
-
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
-DnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABackwardRunner>>
+DnnSupport::FusedMHABackwardRunnerFromDesc(
     Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
     dnn::FusedMHAKind kind,
     const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
@@ -294,30 +248,11 @@ DnnSupport::FusedMHASoftmaxBackwardRunnerFromDesc(
     const TensorDescriptor& d_bmm1_rhs_descriptor,
     const TensorDescriptor& d_bmm2_rhs_descriptor,
     const TensorDescriptor& d_s_descriptor,
+    std::optional<dnn::TensorDescriptor> mask_descriptor,
     std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed) {
   return absl::UnimplementedError(
-      "FusedMHASoftmaxBackwardRunnerFromDesc not implemented.");
-}
-
-tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
-DnnSupport::FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
-    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-    dnn::FusedMHAKind kind,
-    const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
-    const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
-    const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
-    const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
-    const MatmulTensorDescriptor& d_output_descriptor,
-    const TensorDescriptor& d_bmm1_lhs_descriptor,
-    const TensorDescriptor& d_bmm1_rhs_descriptor,
-    const TensorDescriptor& d_bmm2_rhs_descriptor,
-    const TensorDescriptor& d_s_descriptor,
-    const TensorDescriptor& mask_descriptor,
-    std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
-    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-  return absl::UnimplementedError(
-      "FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc not implemented.");
+      "FusedMHABackwardRunnerFromDesc not implemented.");
 }
 
 bool DnnSupport::GetMIOpenConvolveAlgorithms(

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -988,52 +988,16 @@ using FusedMatmulSignature = void(DeviceMemoryBase /* a_data */,
                                   DeviceMemoryBase /* c_data */);
 using FusedMatmulRunner = OpRunner<FusedMatmulSignature>;
 
-using FusedMHASoftmaxSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
-                                      DeviceMemoryBase /* BMM1_inputB_data */,
-                                      DeviceMemoryBase /* BMM2_inputA_data */,
-                                      DeviceMemoryBase /* output_data */,
-                                      DeviceMemoryBase /* activation_data */);
-using FusedMHASoftmaxRunner = OpRunner<FusedMHASoftmaxSignature>;
-
-using FusedMHAMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
-                                   DeviceMemoryBase /* BMM1_inputB_data */,
-                                   DeviceMemoryBase /* mask_data */,
-                                   DeviceMemoryBase /* BMM2_inputA_data */,
-                                   DeviceMemoryBase /* output_data */,
-                                   DeviceMemoryBase /* activation_data */);
-using FusedMHAMaskRunner = OpRunner<FusedMHAMaskSignature>;
-
-using FusedMHABiasMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+using FusedMHASignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                        DeviceMemoryBase /* BMM1_inputB_data */,
-                                       DeviceMemoryBase /* mask_data */,
-                                       DeviceMemoryBase /* bias_data */,
                                        DeviceMemoryBase /* BMM2_inputA_data */,
                                        DeviceMemoryBase /* output_data */,
+                                       DeviceMemoryBase /* mask_data */,
+                                       DeviceMemoryBase /* bias_data */,
                                        DeviceMemoryBase /* activation_data */);
-using FusedMHABiasMaskRunner = OpRunner<FusedMHABiasMaskSignature>;
+using FusedMHARunner = OpRunner<FusedMHASignature>;
 
-using FusedMHABiasSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
-                                   DeviceMemoryBase /* BMM1_inputB_data */,
-                                   DeviceMemoryBase /* bias_data */,
-                                   DeviceMemoryBase /* BMM2_inputA_data */,
-                                   DeviceMemoryBase /* output_data */,
-                                   DeviceMemoryBase /* activation_data */);
-using FusedMHABiasRunner = OpRunner<FusedMHABiasSignature>;
-
-using FusedMHASoftmaxBackwardSignature =
-    void(DeviceMemoryBase /* BMM1_GRAD_GEMM1_inputA_data */,
-         DeviceMemoryBase /* BMM1_GRAD_GEMM2_inputB_data */,
-         DeviceMemoryBase /* BMM2_GRAD_GEMM1_inputA_data */,
-         DeviceMemoryBase /* BMM2_GRAD_GEMM2_inputB_data */,
-         DeviceMemoryBase /* d_output_data */,
-         DeviceMemoryBase /* d_BMM1_inputA_data */,
-         DeviceMemoryBase /* d_BMM1_inputB_data */,
-         DeviceMemoryBase /* d_BMM2_inputB_data */,
-         DeviceMemoryBase /* d_S_data */, DeviceMemoryBase /* d_bias_data */);
-using FusedMHASoftmaxBackwardRunner =
-    OpRunner<FusedMHASoftmaxBackwardSignature>;
-
-using FusedMHAMaskBackwardSignature = void(
+using FusedMHABackwardSignature = void(
     DeviceMemoryBase /* BMM1_GRAD_GEMM1_inputA_data */,
     DeviceMemoryBase /* BMM1_GRAD_GEMM2_inputB_data */,
     DeviceMemoryBase /* BMM2_GRAD_GEMM1_inputA_data */,
@@ -1041,9 +1005,9 @@ using FusedMHAMaskBackwardSignature = void(
     DeviceMemoryBase /* d_output_data */,
     DeviceMemoryBase /* d_BMM1_inputA_data */,
     DeviceMemoryBase /* d_BMM1_inputB_data */,
-    DeviceMemoryBase /* d_BMM2_inputB_data */, DeviceMemoryBase /* d_S_data */,
+    DeviceMemoryBase /* d_BMM2_inputB_data */, DeviceMemoryBase /* d_s_data */,
     DeviceMemoryBase /* mask_data */, DeviceMemoryBase /* d_bias_data */);
-using FusedMHAMaskBackwardRunner = OpRunner<FusedMHAMaskBackwardSignature>;
+using FusedMHABackwardRunner = OpRunner<FusedMHABackwardSignature>;
 
 // Describes the configuration for the algorithms that will used.
 //
@@ -1687,8 +1651,8 @@ class DnnSupport {
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode);
 
-  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
-  FusedMHASoftmaxRunnerFromDesc(
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
+  FusedMHARunnerFromDesc(
       Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
       dnn::FusedMHAKind kind,
       const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
@@ -1697,51 +1661,12 @@ class DnnSupport {
       const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor& output_descriptor,
       std::optional<dnn::TensorDescriptor> activation_descriptor,
+      std::optional<dnn::TensorDescriptor> mask_descriptor,
+      std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
-  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
-  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor& output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor& mask_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed);
-
-  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
-  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor& output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor& mask_descriptor,
-      const dnn::TensorDescriptor& bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed);
-
-  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
-  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor& output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor& bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed);
-
-  virtual tsl::StatusOr<
-      std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
-  FusedMHASoftmaxBackwardRunnerFromDesc(
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABackwardRunner>>
+  FusedMHABackwardRunnerFromDesc(
       Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
       dnn::FusedMHAKind kind,
       const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
@@ -1753,23 +1678,7 @@ class DnnSupport {
       const TensorDescriptor& d_bmm1_rhs_descriptor,
       const TensorDescriptor& d_bmm2_rhs_descriptor,
       const TensorDescriptor& d_s_descriptor,
-      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed);
-
-  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
-  FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
-      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
-      dnn::FusedMHAKind kind,
-      const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
-      const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
-      const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
-      const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
-      const MatmulTensorDescriptor& d_output_descriptor,
-      const TensorDescriptor& d_bmm1_lhs_descriptor,
-      const TensorDescriptor& d_bmm1_rhs_descriptor,
-      const TensorDescriptor& d_bmm2_rhs_descriptor,
-      const TensorDescriptor& d_s_descriptor,
-      const TensorDescriptor& mask_descriptor,
+      std::optional<dnn::TensorDescriptor> mask_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed);
 

--- a/xla/stream_executor/lazy_op_runner.h
+++ b/xla/stream_executor/lazy_op_runner.h
@@ -229,36 +229,8 @@ struct FusedMatmulOp {
   }
 };
 
-struct FusedMHASoftmaxOp {
-  using Signature = FusedMHASoftmaxSignature;
-
-  struct Config {
-    FusedMHAKind kind;
-    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
-    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
-    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
-    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
-    const TensorDescriptor& output_descriptor;
-    std::optional<TensorDescriptor> activation_descriptor;
-    std::optional<double> dropout_rate;
-    std::optional<int64_t> seed;
-  };
-
-  static tsl::StatusOr<
-      std::unique_ptr<const OpRunner<FusedMHASoftmaxSignature>>>
-  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
-                          Stream* stream) {
-    return stream->FusedMHASoftmaxRunnerFromDesc(
-        desc, config.kind, config.bmm1_lhs_descriptor,
-        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
-        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
-        config.activation_descriptor, config.dropout_rate, config.seed);
-  }
-};
-
-struct FusedMHAScaleMaskSoftmaxOp {
-  using Signature = FusedMHAMaskSignature;
-
+struct FusedMHAOp {
+  using Signature = FusedMHASignature;
   struct Config {
     FusedMHAKind kind;
     double scale;
@@ -267,46 +239,18 @@ struct FusedMHAScaleMaskSoftmaxOp {
     const MatmulTensorDescriptor& bmm2_rhs_descriptor;
     const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
     const TensorDescriptor& output_descriptor;
-    const TensorDescriptor& mask_descriptor;
-    std::optional<TensorDescriptor> activation_descriptor;
-    std::optional<double> dropout_rate;
-    std::optional<int64_t> seed;
-  };
-
-  static tsl::StatusOr<std::unique_ptr<const OpRunner<FusedMHAMaskSignature>>>
-  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
-                          Stream* stream) {
-    return stream->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
-        desc, config.kind, config.bmm1_lhs_descriptor,
-        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
-        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
-        config.activation_descriptor, config.mask_descriptor, config.scale,
-        config.dropout_rate, config.seed);
-  }
-};
-
-struct FusedMHAScaleBiasMaskSoftmaxOp {
-  using Signature = FusedMHABiasMaskSignature;
-  struct Config {
-    FusedMHAKind kind;
-    double scale;
-    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
-    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
-    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
-    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
-    const TensorDescriptor& output_descriptor;
-    const TensorDescriptor& bias_descriptor;
-    const TensorDescriptor& mask_descriptor;
+    std::optional<TensorDescriptor> bias_descriptor;
+    std::optional<TensorDescriptor> mask_descriptor;
     std::optional<TensorDescriptor> activation_descriptor;
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
   };
 
   static tsl::StatusOr<
-      std::unique_ptr<const OpRunner<FusedMHABiasMaskSignature>>>
+      std::unique_ptr<const OpRunner<FusedMHASignature>>>
   RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
                           Stream* stream) {
-    return stream->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+    return stream->FusedMHARunnerFromDesc(
         desc, config.kind, config.bmm1_lhs_descriptor,
         config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
         config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
@@ -315,36 +259,8 @@ struct FusedMHAScaleBiasMaskSoftmaxOp {
   }
 };
 
-struct FusedMHAScaleBiasSoftmaxOp {
-  using Signature = FusedMHABiasSignature;
-  struct Config {
-    FusedMHAKind kind;
-    double scale;
-    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
-    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
-    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
-    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
-    const TensorDescriptor& output_descriptor;
-    const TensorDescriptor& bias_descriptor;
-    std::optional<TensorDescriptor> activation_descriptor;
-    std::optional<double> dropout_rate;
-    std::optional<int64_t> seed;
-  };
-
-  static tsl::StatusOr<std::unique_ptr<const OpRunner<FusedMHABiasSignature>>>
-  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
-                          Stream* stream) {
-    return stream->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
-        desc, config.kind, config.bmm1_lhs_descriptor,
-        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
-        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
-        config.activation_descriptor, config.bias_descriptor, config.scale,
-        config.dropout_rate, config.seed);
-  }
-};
-
-struct FusedMHASoftmaxBackwardOp {
-  using Signature = FusedMHASoftmaxBackwardSignature;
+struct FusedMHABackwardOp {
+  using Signature = FusedMHABackwardSignature;
 
   struct Config {
     FusedMHAKind kind;
@@ -358,53 +274,17 @@ struct FusedMHASoftmaxBackwardOp {
     const TensorDescriptor& d_bmm1_rhs_descriptor;
     const TensorDescriptor& d_bmm2_rhs_descriptor;
     const TensorDescriptor& d_s_descriptor;
+    std::optional<TensorDescriptor> mask_descriptor;
     std::optional<TensorDescriptor> d_bias_descriptor;
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
   };
 
   static tsl::StatusOr<
-      std::unique_ptr<const OpRunner<FusedMHASoftmaxBackwardSignature>>>
+      std::unique_ptr<const OpRunner<FusedMHABackwardSignature>>>
   RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
                           Stream* stream) {
-    return stream->FusedMHASoftmaxBackwardRunnerFromDesc(
-        desc, config.kind, config.bmm1_grad_gemm1_rhs_descriptor,
-        config.bmm1_grad_gemm2_rhs_descriptor,
-        config.bmm2_grad_gemm1_lhs_descriptor,
-        config.bmm2_grad_gemm2_rhs_descriptor, config.d_output_descriptor,
-        config.d_bmm1_lhs_descriptor, config.d_bmm1_rhs_descriptor,
-        config.d_bmm2_rhs_descriptor, config.d_s_descriptor,
-        config.d_bias_descriptor, config.scale, config.dropout_rate,
-        config.seed);
-  }
-};
-
-struct FusedMHAScaleMaskSoftmaxBackwardOp {
-  using Signature = FusedMHAMaskBackwardSignature;
-
-  struct Config {
-    FusedMHAKind kind;
-    double scale;
-    const MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor;
-    const MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor;
-    const MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor;
-    const MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor;
-    const MatmulTensorDescriptor& d_output_descriptor;
-    const TensorDescriptor& d_bmm1_lhs_descriptor;
-    const TensorDescriptor& d_bmm1_rhs_descriptor;
-    const TensorDescriptor& d_bmm2_rhs_descriptor;
-    const TensorDescriptor& d_s_descriptor;
-    const TensorDescriptor& mask_descriptor;
-    std::optional<TensorDescriptor> d_bias_descriptor;
-    std::optional<double> dropout_rate;
-    std::optional<int64_t> seed;
-  };
-
-  static tsl::StatusOr<
-      std::unique_ptr<const OpRunner<FusedMHAMaskBackwardSignature>>>
-  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
-                          Stream* stream) {
-    return stream->FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+    return stream->FusedMHABackwardRunnerFromDesc(
         desc, config.kind, config.bmm1_grad_gemm1_rhs_descriptor,
         config.bmm1_grad_gemm2_rhs_descriptor,
         config.bmm2_grad_gemm1_lhs_descriptor,

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -453,8 +453,8 @@ class Stream {
         convolution_descriptor, activation_mode);
   }
 
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
-  FusedMHASoftmaxRunnerFromDesc(
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
+  FusedMHARunnerFromDesc(
       const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
       const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
       const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
@@ -462,86 +462,22 @@ class Stream {
       const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
       const dnn::TensorDescriptor &output_descriptor,
       std::optional<dnn::TensorDescriptor> activation_descriptor,
+      std::optional<dnn::TensorDescriptor> mask_descriptor,
+      std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
       return absl::UnimplementedError("DNN library is not found.");
     }
-    return dnn_support->FusedMHASoftmaxRunnerFromDesc(
-        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
-        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-        output_descriptor, activation_descriptor, dropout_rate, seed);
-  }
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
-  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
-      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor &output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor &mask_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-    dnn::DnnSupport *dnn_support = parent_->AsDnn();
-    if (!dnn_support) {
-      return absl::UnimplementedError("DNN library is not found.");
-    }
-    return dnn_support->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
-        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
-        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-        output_descriptor, activation_descriptor, mask_descriptor, scale,
-        dropout_rate, seed);
-  }
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
-  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
-      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor &output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor &mask_descriptor,
-      const dnn::TensorDescriptor &bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-    dnn::DnnSupport *dnn_support = parent_->AsDnn();
-    if (!dnn_support) {
-      return absl::UnimplementedError("DNN library is not found.");
-    }
-    return dnn_support->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+    return dnn_support->FusedMHARunnerFromDesc(
         this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
         bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
         output_descriptor, activation_descriptor, mask_descriptor,
         bias_descriptor, scale, dropout_rate, seed);
   }
 
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
-  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
-      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
-      const dnn::TensorDescriptor &output_descriptor,
-      std::optional<dnn::TensorDescriptor> activation_descriptor,
-      const dnn::TensorDescriptor &bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-    dnn::DnnSupport *dnn_support = parent_->AsDnn();
-    if (!dnn_support) {
-      return absl::UnimplementedError("DNN library is not found.");
-    }
-    return dnn_support->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
-        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
-        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
-        output_descriptor, activation_descriptor, bias_descriptor, scale,
-        dropout_rate, seed);
-  }
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxBackwardRunner>>
-  FusedMHASoftmaxBackwardRunnerFromDesc(
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABackwardRunner>>
+  FusedMHABackwardRunnerFromDesc(
       const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
       const dnn::MatmulTensorDescriptor &bmm1_grad_gemm1_rhs_descriptor,
       const dnn::MatmulTensorDescriptor &bmm1_grad_gemm2_rhs_descriptor,
@@ -552,40 +488,14 @@ class Stream {
       const dnn::TensorDescriptor &d_bmm1_rhs_descriptor,
       const dnn::TensorDescriptor &d_bmm2_rhs_descriptor,
       const dnn::TensorDescriptor &d_s_descriptor,
+      std::optional<dnn::TensorDescriptor> mask_descriptor,
       std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed) {
     dnn::DnnSupport *dnn_support = parent_->AsDnn();
     if (!dnn_support) {
       return absl::UnimplementedError("DNN library is not found.");
     }
-    return dnn_support->FusedMHASoftmaxBackwardRunnerFromDesc(
-        this, algorithm_desc, kind, bmm1_grad_gemm1_rhs_descriptor,
-        bmm1_grad_gemm2_rhs_descriptor, bmm2_grad_gemm1_lhs_descriptor,
-        bmm2_grad_gemm2_rhs_descriptor, d_output_descriptor,
-        d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
-        d_s_descriptor, d_bias_descriptor, scale, dropout_rate, seed);
-  }
-
-  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskBackwardRunner>>
-  FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
-      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
-      const dnn::MatmulTensorDescriptor &bmm1_grad_gemm1_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm1_grad_gemm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm2_grad_gemm1_lhs_descriptor,
-      const dnn::MatmulTensorDescriptor &bmm2_grad_gemm2_rhs_descriptor,
-      const dnn::MatmulTensorDescriptor &d_output_descriptor,
-      const dnn::TensorDescriptor &d_bmm1_lhs_descriptor,
-      const dnn::TensorDescriptor &d_bmm1_rhs_descriptor,
-      const dnn::TensorDescriptor &d_bmm2_rhs_descriptor,
-      const dnn::TensorDescriptor &d_s_descriptor,
-      const dnn::TensorDescriptor &mask_descriptor,
-      std::optional<dnn::TensorDescriptor> d_bias_descriptor, double scale,
-      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
-    dnn::DnnSupport *dnn_support = parent_->AsDnn();
-    if (!dnn_support) {
-      return absl::UnimplementedError("DNN library is not found.");
-    }
-    return dnn_support->FusedMHAScaleMaskSoftmaxBackwardRunnerFromDesc(
+    return dnn_support->FusedMHABackwardRunnerFromDesc(
         this, algorithm_desc, kind, bmm1_grad_gemm1_rhs_descriptor,
         bmm1_grad_gemm2_rhs_descriptor, bmm2_grad_gemm1_lhs_descriptor,
         bmm2_grad_gemm2_rhs_descriptor, d_output_descriptor,

--- a/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
+++ b/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
@@ -1142,6 +1142,10 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
   TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
                       xla::gpu::GetCudnnfMHAKind(custom_call));
 
+  bool has_activation = xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
+  bool has_mask = false;
+  bool has_bias = false;
+
   auto set_common_fmha_attributes =
       [&, this](auto op) -> tsl::StatusOr<Operation*> {
     TF_ASSIGN_OR_RETURN(lmhlo_gpu::FusedMhaDagSignature fused_mha_dag_signature,
@@ -1178,9 +1182,16 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
         arrayref(intermediate_tensor_shape.layout().minor_to_major()));
     op.setIntermediateTensorLayoutAttr(intermediate_tensor_layout);
     op.setFmhaScaleAttr(builder_.getF64FloatAttr(config.fmha_scale()));
+    op.setDropoutRateAttr(
+        builder_.getF64FloatAttr(config.dropout_rate()));
+    op.setSeedAttr(
+        builder_.getI64IntegerAttr(config.seed()));
+    int32_t operand_sizes[] = {1, 1, 1, has_mask ? 1 : 0, has_bias ? 1 : 0, 1, 1, has_activation ? 1 : 0};
+    op->setAttr(
+        op.getOperandSegmentSizeAttr(),
+        builder_.getDenseI32ArrayAttr(operand_sizes));
     return op.getOperation();
   };
-
   llvm::SmallVector<Value, 8> operands;
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(0), &operands));
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(1), &operands));
@@ -1188,119 +1199,37 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
 
   switch (kind) {
     case xla::gpu::CudnnfMHAKind::kBmmBmm:
-    case xla::gpu::CudnnfMHAKind::kSoftmax: {
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      auto fmha_default =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAOp>(custom_call, operands);
-      return set_common_fmha_attributes(fmha_default);
-    }
+    case xla::gpu::CudnnfMHAKind::kSoftmax:
     case xla::gpu::CudnnfMHAKind::kSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      auto fmha_softmax_dropout =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAOp>(custom_call, operands);
-      fmha_softmax_dropout.setDropoutRateAttr(
-          builder_.getF64FloatAttr(config.dropout_rate()));
-      fmha_softmax_dropout.setSeedAttr(
-          builder_.getI64IntegerAttr(config.seed()));
-      return set_common_fmha_attributes(fmha_softmax_dropout);
+      auto fmha = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAOp>(custom_call, operands);
+      return set_common_fmha_attributes(fmha);
     }
-    case xla::gpu::CudnnfMHAKind::kScaleMaskSoftmax: {
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      bool has_activation =
-          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
-      auto fmha_scale_mask_softmax =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
-                                                                    operands);
-      fmha_scale_mask_softmax.setFmhaScaleAttr(
-          builder_.getF64FloatAttr(config.fmha_scale()));
-      int32_t operand_sizes[] = {1, 1, 1, 1, 0, 1, 1, has_activation ? 1 : 0};
-      fmha_scale_mask_softmax->setAttr(
-          fmha_scale_mask_softmax.getOperandSegmentSizeAttr(),
-          builder_.getDenseI32ArrayAttr(operand_sizes));
-      return set_common_fmha_attributes(fmha_scale_mask_softmax);
-    }
+    case xla::gpu::CudnnfMHAKind::kScaleMaskSoftmax:
     case xla::gpu::CudnnfMHAKind::kScaleMaskSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      bool has_activation =
-          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
-      auto fmha_scale_mask_softmax_dropout =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
-                                                                    operands);
-      fmha_scale_mask_softmax_dropout.setFmhaScaleAttr(
-          builder_.getF64FloatAttr(config.fmha_scale()));
-      fmha_scale_mask_softmax_dropout.setDropoutRateAttr(
-          builder_.getF64FloatAttr(config.dropout_rate()));
-      fmha_scale_mask_softmax_dropout.setSeedAttr(
-          builder_.getI64IntegerAttr(config.seed()));
-      int32_t operand_sizes[] = {1, 1, 1, 1, 0, 1, 1, has_activation ? 1 : 0};
-      fmha_scale_mask_softmax_dropout->setAttr(
-          fmha_scale_mask_softmax_dropout.getOperandSegmentSizeAttr(),
-          builder_.getDenseI32ArrayAttr(operand_sizes));
-      return set_common_fmha_attributes(fmha_scale_mask_softmax_dropout);
+      auto fmha = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAOp>(custom_call, operands);
+      has_mask = true;
+      return set_common_fmha_attributes(fmha);
     }
-    case xla::gpu::CudnnfMHAKind::kScaleBiasMaskSoftmax: {
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(4), &operands));
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      bool has_activation =
-          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
-      auto fmha_scale_bias_mask_softmax =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
-                                                                    operands);
-      fmha_scale_bias_mask_softmax.setFmhaScaleAttr(
-          builder_.getF64FloatAttr(config.fmha_scale()));
-      int32_t operand_sizes[] = {1, 1, 1, 1, 1, 1, 1, has_activation ? 1 : 0};
-      fmha_scale_bias_mask_softmax->setAttr(
-          fmha_scale_bias_mask_softmax.getOperandSegmentSizeAttr(),
-          builder_.getDenseI32ArrayAttr(operand_sizes));
-      return set_common_fmha_attributes(fmha_scale_bias_mask_softmax);
-    }
+    case xla::gpu::CudnnfMHAKind::kScaleBiasMaskSoftmax:
     case xla::gpu::CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(4), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      bool has_activation =
-          xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
-      auto fmha_scale_bias_mask_softmax_dropout =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledMaskOp>(custom_call,
-                                                                    operands);
-      fmha_scale_bias_mask_softmax_dropout.setFmhaScaleAttr(
-          builder_.getF64FloatAttr(config.fmha_scale()));
-      fmha_scale_bias_mask_softmax_dropout.setDropoutRateAttr(
-          builder_.getF64FloatAttr(config.dropout_rate()));
-      fmha_scale_bias_mask_softmax_dropout.setSeedAttr(
-          builder_.getI64IntegerAttr(config.seed()));
-      int32_t operand_sizes[] = {1, 1, 1, 1, 1, 1, 1, has_activation ? 1 : 0};
-      fmha_scale_bias_mask_softmax_dropout->setAttr(
-          fmha_scale_bias_mask_softmax_dropout.getOperandSegmentSizeAttr(),
-          builder_.getDenseI32ArrayAttr(operand_sizes));
-      return set_common_fmha_attributes(fmha_scale_bias_mask_softmax_dropout);
+      auto fmha = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAOp>(custom_call, operands);
+      has_mask = true;
+      has_bias = true;
+      return set_common_fmha_attributes(fmha);
     }
+    case xla::gpu::CudnnfMHAKind::kScaleBiasSoftmax:
     case xla::gpu::CudnnfMHAKind::kScaleBiasSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      auto fmha_bias_softmax_dropout =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledBiasOp>(custom_call,
-                                                                    operands);
-      fmha_bias_softmax_dropout.setFmhaScaleAttr(
-          builder_.getF64FloatAttr(config.fmha_scale()));
-      fmha_bias_softmax_dropout.setDropoutRateAttr(
-          builder_.getF64FloatAttr(config.dropout_rate()));
-      fmha_bias_softmax_dropout.setSeedAttr(
-          builder_.getI64IntegerAttr(config.seed()));
-      return set_common_fmha_attributes(fmha_bias_softmax_dropout);
-    }
-    case xla::gpu::CudnnfMHAKind::kScaleBiasSoftmax: {
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(3), &operands));
-      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      auto fmha_bias_softmax =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithScaledBiasOp>(custom_call,
-                                                                    operands);
-      fmha_bias_softmax.setFmhaScaleAttr(
-          builder_.getF64FloatAttr(config.fmha_scale()));
-      return set_common_fmha_attributes(fmha_bias_softmax);
+      auto fmha = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAOp>(custom_call, operands);
+      has_bias = true;
+      return set_common_fmha_attributes(fmha);
     }
     default:
       return xla::InternalError("Unknown forward fused MHA call.");
@@ -1315,6 +1244,9 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
 
   TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
                       xla::gpu::GetCudnnfMHAKind(custom_call));
+
+  bool has_dbias = custom_call->shape().tuple_shapes().size() == 6;
+  bool has_mask = false;
 
   auto set_common_fmha_backward_attributes =
       [&, this](auto op) -> tsl::StatusOr<Operation*> {
@@ -1333,6 +1265,11 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
         builder_, config.bmm2_grad_gemm2_dot_dimension_numbers()));
 
     op.setFmhaScaleAttr(builder_.getF64FloatAttr(config.fmha_scale()));
+
+    int32_t operand_sizes[] = {1, 1, 1, 1, 1, has_mask ? 1 : 0, 1, 1, 1, 1, 1, has_dbias ? 1 : 0};
+    op->setAttr(
+        op.getOperandSegmentSizeAttr(),
+        builder_.getDenseI32ArrayAttr(operand_sizes));
 
     const auto& algorithm = config.algorithm();
     std::vector<int64_t> knob_ids;
@@ -1361,10 +1298,10 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
     case xla::gpu::CudnnfMHAKind::kBackwardSoftmax:
     case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-      auto fmha_default_backward =
+      auto fmha_backward =
           CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(custom_call,
                                                               operands);
-      return set_common_fmha_backward_attributes(fmha_default_backward);
+      return set_common_fmha_backward_attributes(fmha_backward);
     }
     case xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout:
     case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout: {
@@ -1395,16 +1332,16 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
     case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
-
-      auto fmha_scale_mask_softmax_backward =
-          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHAWithMaskBackwardOp>(
+      has_mask = true;
+      auto fmha_backward =
+          CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
               custom_call, operands);
       fmha_scale_mask_softmax_backward.setDropoutRateAttr(
           builder_.getF64FloatAttr(config.dropout_rate()));
       fmha_scale_mask_softmax_backward.setSeedAttr(
           builder_.getI64IntegerAttr(config.seed()));
       return set_common_fmha_backward_attributes(
-          fmha_scale_mask_softmax_backward);
+          fmha_backward);
     }
 
     default:


### PR DESCRIPTION
This is a follow up PR for cleaning up the redundant almost duplicated runners and MLIR op.
There are currently 4 runners and 3 MLIR op defined for fmha fwd. Different runner is chosen based on if there is bias/mask.
There are currently 2 runners and 2 MLIR op defined for fmha bwd. Different runner is chosen based on if there is mask.
We can merge all fwd runner/MLIR op into one and all bwd runner/MLIR op into one with `AttrSizedOperandSegments` since with flash attention there will be more optional buffers. So there is no point of keeping multiple runners/MLIR which is hard for code maintenance and introducing code bloat. 