### PR TITLE
Add a debug option to toggle reduction epilogue fusion

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -189,7 +189,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_collect_cost_model_stats(false);
   opts.set_xla_gpu_enable_split_k_autotuning(true);
 
-  opts.set_xla_gpu_single_wave_autotuning(true);
+  opts.set_xla_gpu_single_wave_autotuning(false);
+  opts.set_xla_gpu_enable_reduction_epilogue_fusion(true);
   return opts;
 }
 
@@ -1245,6 +1246,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "Enable single \"wave\" autotuning. This uses more memory for "
       "compilation, but utilizes CPU cores better, so compilation can be "
       "faster."));
+
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_reduction_epilogue_fusion",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_reduction_epilogue_fusion),
+      debug_options->xla_gpu_enable_reduction_epilogue_fusion(),
+      "Enable fusion for reduction epilogues"));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -388,6 +388,12 @@ FusionDecision IsProducerConsumerFusible(const HloInstruction& producer,
   }
 
   if (IsInputFusibleReduction(producer)) {
+    if (!producer.GetModule()
+             ->config()
+             .debug_options()
+             .xla_gpu_enable_reduction_epilogue_fusion()) {
+      return "Reduction epilogue fusion is not enabled.";
+    }
     if (!AllSatisfy(consumer, [](const HloInstruction* hlo) {
           return IsIntermediate(hlo, /*allowed_operand_count=*/1);
         })) {

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -607,7 +607,10 @@ message DebugOptions {
   bool xla_gpu_enable_split_k_autotuning = 241;
 
   bool xla_gpu_single_wave_autotuning = 242;
-  // Next id: 243
+  // Whether reduction epilogue fusion is enabled in fusion passes.
+  bool xla_gpu_enable_reduction_epilogue_fusion = 243;
+
+  // Next id: 244
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This is to follow up on the original [pr](https://github.com/openxla/xla/commit/f91402af93e86752c5e7c5d0a42ec54f89c007fe) to enable reduction epilogue fusion in xla gpu fusion modules.
We saw improvements some a lot of use cases and also saw schedules improved for some. But there's a regression in 1 use case with data type fp8+bfloat16. fp8 introduces a lot of reduction kernels for large arrays that store amax, when they get fused, the final fused kernels have long runtime(currently under investigation).
This PR adds a debug option to turn off reduction epilogue fusion for cases that it wont be beneficial, the flag is on by default.
