### PR TITLE
[ROCm] enable more ROCm tests

### DIFF
--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -592,7 +592,7 @@ xla_cc_test(
 xla_cc_test(
     name = "gpu_unrolling_test",
     srcs = ["gpu_unrolling_test.cc"],
-    tags = tf_cuda_tests_tags() + ["no_rocm"],
+    tags = tf_cuda_tests_tags(),
     deps = [
         ":gpu_codegen_test",
         "//xla/service:hlo_module_config",

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -1188,7 +1188,6 @@ xla_test(
     backends = ["gpu"],
     shard_count = 50,
     tags = [
-        "no_rocm",
         "nozapfhahn",
         "optonly",
     ],
@@ -1270,7 +1269,6 @@ xla_test(
         "interpreter",
     ],
     shard_count = 40,
-    tags = ["no_rocm"],
     deps = [
         ":client_library_test_base",
         ":hlo_test_base",

--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -16,7 +16,6 @@ build_test(
     name = "hlo_runner_main_build_test",
     tags = [
         "gpu",
-        "no_rocm",
     ],
     targets = [
         ":hlo_runner_main",


### PR DESCRIPTION
We found out 4 tests that are disable on ROCm for a long time that no longer valid

1. gpu_unrolling_test
2. convolution_test_cudnn_frontend_disabled
3. batch_normalization_test
4. hlo_runner_main_build_test

@akuegel Thanks in advance!