### PR TITLE
[ROCm] Fix rocm register, GraphNodeGetType build error and rocm_blas stream

### DIFF
--- a/xla/stream_executor/rocm/rocblas_wrapper.h
+++ b/xla/stream_executor/rocm/rocblas_wrapper.h
@@ -263,6 +263,7 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
   __macro(rocblas_ztrsm_batched)                \
   __macro(rocblas_create_handle)                \
   __macro(rocblas_destroy_handle)               \
+  __macro(rocblas_get_stream)                   \
   __macro(rocblas_set_stream)                   \
   __macro(rocblas_set_atomics_mode)
 

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -136,6 +136,28 @@ bool ROCMBlas::SetStream(Stream *stream) {
   CHECK(AsGpuStreamValue(stream) != nullptr);
   CHECK(blas_ != nullptr);
   gpu::ScopedActivateExecutorContext sac{parent_};
+
+  hipStream_t current_stream;
+  rocblas_status get_current_stream = 
+        wrap::rocblas_get_stream(blas_, &current_stream);
+  if (get_current_stream != rocblas_status_success){
+    LOG(ERROR) << "failed to get current stream for rocBLAS calls: "
+               << ToString(get_current_stream);
+    return false;
+  }
+
+  // Do not set stream if it's already set
+  if (current_stream == ROCMStream(stream)) return true;
+
+  // Check the set stream is not in capture mode  
+  hipStreamCaptureStatus capture_status;
+  hipStreamIsCapturing(ROCMStream(stream), &capture_status);
+  if (capture_status == hipStreamCaptureStatusActive) {
+    LOG(ERROR) << "ROCmblasSetStream should not be called during graph capture, "
+                  "since it will reset rocBLAS workspace";
+    return false;
+  }
+
   rocblas_status ret =
       wrap::rocblas_set_stream(blas_, AsGpuStreamValue(stream));
   if (ret != rocblas_status_success) {
@@ -144,6 +166,13 @@ bool ROCMBlas::SetStream(Stream *stream) {
   }
 
   return true;
+}
+
+hipStream_t ROCMBlas::ROCMStream(Stream *stream){
+  CHECK(stream != nullptr);
+  CHECK(AsGpuStreamValue(stream) != nullptr);
+  gpu::ScopedActivateExecutorContext sac{parent_};
+  return AsGpuStreamValue(stream);
 }
 
 namespace {

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -108,6 +108,9 @@ class ROCMBlas : public blas::BlasSupport {
   // invoked before calling into rocBLAS.
   bool SetStream(Stream *stream) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
+  // Returns the underlying ROCm stream
+  hipStream_t ROCMStream(Stream *stream);
+
   // A helper function that calls the real rocBLAS function together with error
   // handling.
   //

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -588,6 +588,47 @@ static std::string_view StreamCaptureModeToString(
   return ::tsl::OkStatus();
 }
 
+/* static */ tsl::StatusOr<GpuDriver::GraphNodeType>
+GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
+  hipGraphNodeType node_type = hipGraphNodeTypeCount;
+  RETURN_IF_ROCM_ERROR(hipGraphNodeGetType(node, &node_type),
+                       "Failed to get HIP graph node type");
+
+  switch (node_type) {
+    case hipGraphNodeTypeCount:
+      break;
+    case hipGraphNodeTypeKernel:
+      return GraphNodeType::kKernel;
+    case hipGraphNodeTypeMemcpy:
+    case hipGraphNodeTypeMemcpyFromSymbol:
+    case hipGraphNodeTypeMemcpyToSymbol:
+      return GraphNodeType::kMemcpy;
+    case hipGraphNodeTypeMemset:
+      return GraphNodeType::kMemset;
+    case hipGraphNodeTypeHost:
+      return GraphNodeType::kHost;
+    case hipGraphNodeTypeGraph:
+      return GraphNodeType::kGraph;
+    case hipGraphNodeTypeEmpty:
+      return GraphNodeType::kEmpty;
+    case hipGraphNodeTypeWaitEvent:
+      return GraphNodeType::kWaitEvent;
+    case hipGraphNodeTypeEventRecord:
+      return GraphNodeType::kEventRecord;
+    case hipGraphNodeTypeExtSemaphoreSignal:
+      return GraphNodeType::kExtSemasSignal;
+    case hipGraphNodeTypeExtSemaphoreWait:
+      return GraphNodeType::kExtSemasWait;
+    case hipGraphNodeTypeMemAlloc:
+      return GraphNodeType::kMemAlloc;
+    case hipGraphNodeTypeMemFree:
+      return GraphNodeType::kMemFree;
+  }
+
+  return tsl::Status(absl::StatusCode::kInternal,
+                     "Invalid HIP graph node type");
+}
+
 /* static */ tsl::Status GpuDriver::GraphDebugDotPrint(hipGraph_t graph,
                                                        const char* path) {
   VLOG(2) << "Print HIP graph " << graph << " debug dot file to " << path;

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -97,15 +97,16 @@ namespace wrap {
   __macro(hipGetDeviceCount)                        \
   __macro(hipGetDeviceProperties)                   \
   __macro(hipGetErrorString)                        \
+  __macro(hipGraphAddKernelNode)                    \
+  __macro(hipGraphAddMemcpyNode)                    \
+  __macro(hipGraphCreate)                           \
   __macro(hipGraphDebugDotPrint)                    \
   __macro(hipGraphDestroy)                          \
   __macro(hipGraphExecDestroy)                      \
   __macro(hipGraphExecUpdate)                       \
   __macro(hipGraphInstantiate)                      \
   __macro(hipGraphLaunch)                           \
-  __macro(hipGraphCreate)                           \
-  __macro(hipGraphAddKernelNode)                    \
-  __macro(hipGraphAddMemcpyNode)                    \
+  __macro(hipGraphNodeGetType)                      \
   __macro(hipHostFree)                              \
   __macro(hipHostMalloc)                            \
   __macro(hipHostRegister)                          \

--- a/xla/stream_executor/rocm/rocm_platform.cc
+++ b/xla/stream_executor/rocm/rocm_platform.cc
@@ -146,14 +146,6 @@ ROCmPlatform::GetUncachedExecutor(const StreamExecutorConfig& config) {
   return std::move(executor);
 }
 
-void ROCmPlatform::RegisterTraceListener(
-    std::unique_ptr<TraceListener> listener) {
-  LOG(FATAL) << "not yet implemented: register ROCM trace listener";
-}
-
-void ROCmPlatform::UnregisterTraceListener(TraceListener* listener) {
-  LOG(FATAL) << "not yet implemented: unregister ROCM trace listener";
-}
 
 }  // namespace gpu
 

--- a/xla/stream_executor/rocm/rocm_platform.h
+++ b/xla/stream_executor/rocm/rocm_platform.h
@@ -73,10 +73,6 @@ class ROCmPlatform : public Platform {
   tsl::StatusOr<std::unique_ptr<StreamExecutor>> GetUncachedExecutor(
       const StreamExecutorConfig& config) override;
 
-  void RegisterTraceListener(std::unique_ptr<TraceListener> listener) override;
-
-  void UnregisterTraceListener(TraceListener* listener) override;
-
  private:
   // Determines the number of NUMA nodes and the assignment of executor to each.
   void InspectNumaNodes();


### PR DESCRIPTION
this PR has fixed rocm build errors due to 
1. RegisterTraceListener  https://github.com/openxla/xla/commit/335c8a09aa4de15ac565b0eab2baa7dcc5882c0f
2. GraphNodeGetType  https://github.com/openxla/xla/commit/cf83ac10d5a0d588c7e6d1ca7f7067cbfe1369c1
3. BLAS Stream https://github.com/openxla/xla/commit/48cf9228704851b5a1c5fb28f4f95b53af6afeab

@akuegel @anlunx Thanks in advance!