### PR TITLE
[NVIDIA XLA GPU] Turn the cudnn fused attention feature ON by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -85,7 +85,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_fast_math_honor_division(true);
 
   // TODO(AyanmoI): Remove this flag when cuDNN FMHA is fully supported.
-  opts.set_xla_gpu_enable_cudnn_fmha(false);
+  opts.set_xla_gpu_enable_cudnn_fmha(true);
 
   opts.set_xla_gpu_fused_attention_use_cudnn_rng(false);
 


### PR DESCRIPTION
Now that CUDA 12 and cuDNN 8.9.4 are now in CI and the feature is in a steady state, it is time to turn this ON by default and reap the benefits.
Note that this doesn't include Flash Attention.