### PR TITLE
[ROCm] HipBLASLt row major layout support.

### DIFF
--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -1846,8 +1846,6 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
                         MatrixIsColumnMajor(instr, gemm_backend_config));
 
     if (std::holds_alternative<se::RocmComputeCapability>(gpu_version_)) {
-      if (!output_is_column_major) return false;
-
       auto rocm_compute_capability_ =
           std::get<se::RocmComputeCapability>(gpu_version_);
 

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -875,7 +875,7 @@ StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
   rhs_layout.batch_size = batch_size;
 
   bool must_swap_operands =
-      MakeOutputColumnMajor(lhs_layout, rhs_layout, c_layout, output_layout);
+      MakeOutputColumnMajor(lhs_layout, rhs_layout, output_layout, c_layout);
 
   // Do not transopse either input. Note the cuBLASLt documentation somewhat
   // incorrectly claims "A must be transposed and B non-transposed" when A and B
@@ -884,8 +884,8 @@ StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
   // *not* be transposed, and if B is row-major, B must be transposed. We never
   // transpose A or B, and expect the caller to ensure A is row-major and B is
   // column when A and B are FP8.
-  const se::blas::Transpose trans_a = se::blas::Transpose::kNoTranspose;
-  const se::blas::Transpose trans_b = se::blas::Transpose::kNoTranspose;
+  se::blas::Transpose trans_a = se::blas::Transpose::kNoTranspose;
+  se::blas::Transpose trans_b = se::blas::Transpose::kNoTranspose;
   if (primitive_util::IsF8Type(lhs_layout.dtype) &&
       lhs_layout.order == MatrixLayout::Order::kColumnMajor) {
     return InternalError("The F8 LHS must be column-major");
@@ -901,6 +901,17 @@ StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
       se::blas::ComputationType computation_type,
       GetBlasComputationType(lhs_layout.dtype, output_layout.dtype,
                              config.compute_precision));
+
+  #if TENSORFLOW_USE_ROCM
+	if (lhs_layout.order == MatrixLayout::Order::kRowMajor) {
+	  trans_a = se::blas::Transpose::kTranspose;
+	  lhs_layout.Transpose();
+	}
+  	if (rhs_layout.order == MatrixLayout::Order::kRowMajor) {
+	  trans_b = se::blas::Transpose::kTranspose;
+	  rhs_layout.Transpose();
+	}
+  #endif
 
   TF_ASSIGN_OR_RETURN(
       se::gpu::BlasLt::MatmulDesc op_desc,

--- a/xla/service/gpu/runtime/executable.h
+++ b/xla/service/gpu/runtime/executable.h
@@ -171,7 +171,8 @@ class GpuRuntimeExecutable {
   // Keep a cache of fft plans for all FFT operations in the program.
   FftPlans fft_plans_;
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM  // Keep matmul execution plans.
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  // Keep matmul execution plans (only if cuBLASLt is available).
   MatmulPlans cublas_lt_matmul_plans_;
   // Keep captured and instantiated GPU graphs instances.
   GraphInstances graph_instances_;

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -123,11 +123,9 @@ xla_cc_test(
 
 xla_cc_test(
     name = "gemm_rewrite_test",
-    srcs = if_cuda_is_configured(["gemm_rewrite_test.cc"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
-    tags = tf_cuda_tests_tags() + [
-        "no_rocm",
-    ],
+    srcs = if_cuda_is_configured(["gemm_rewrite_test.cc"]) + if_rocm_is_configured(["gemm_rewrite_test.cc"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    tags = tf_cuda_tests_tags(),
     deps = [
         ":gpu_codegen_test",
         "//xla:statusor",
@@ -146,6 +144,8 @@ xla_cc_test(
         "@tsl//tsl/platform:test_main",
     ] + if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
 

--- a/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -76,6 +76,7 @@ ENTRY AddDotsFunc {
   }
 }
 
+#if GOOGLE_CUDA
 TEST_F(GemmRewriteTest, TestBatchedAutotuning) {
   if (GetCudaComputeCapability().IsAtLeast(se::CudaComputeCapability::AMPERE)) {
     GTEST_SKIP()
@@ -97,6 +98,7 @@ ENTRY %test {
 ; CHECK: selected_algorithm
       )");
 }
+#endif
 
 TEST_F(GemmRewriteTest, SimpleRewriteDeterministic) {
   const char* hlo_text = R"(
@@ -184,6 +186,7 @@ ENTRY broadcast {
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
+#if GOOGLE_CUDA
 // A test fixture class for tests which should have similar results with legacy
 // cublas and cublasLt
 class ParameterizedGemmRewriteTest
@@ -1262,6 +1265,7 @@ ENTRY main {
 
 INSTANTIATE_TEST_SUITE_P(CublasTestsBothLegacyAndLt,
                          ParameterizedGemmRewriteTest, ::testing::Bool());
+#endif
 
 // A test fixture class for tests which are specific to legacy cublas
 class LegacyCublasGemmRewriteTest : public GemmRewriteTest {
@@ -1693,6 +1697,8 @@ ENTRY test {
 )");
 }
 
+
+#if GOOGLE_CUDA
 // Test gemm matrix bias add fusion with mix type
 TEST_F(LegacyCublasGemmRewriteTest, MatrixBiasMixType) {
   std::vector<std::tuple<absl::string_view, absl::string_view>>
@@ -1763,6 +1769,7 @@ ENTRY test {
                                          m::Negate(m::Parameter(2)))));
   }
 }
+#endif
 
 // Test batch gemm matrix bias add fusion with mix type that is not supported
 TEST_F(LegacyCublasGemmRewriteTest, MatrixBiasMixTypeNotSupported) {
@@ -1896,6 +1903,7 @@ ENTRY test {
           m::CustomCall(m::Parameter(0), m::Parameter(1), m::Constant()))));
 }
 
+#if GOOGLE_CUDA
 // A test fixture class for tests which are specific to cublasLt
 class CublasLtGemmRewriteTest : public GemmRewriteTest {
  public:
@@ -7062,6 +7070,7 @@ TEST_P(ParameterizedFp8GemmRewriteTest, FnuzTypeF8) {
 
 INSTANTIATE_TEST_SUITE_P(Fp8CublasTestsBothLegacyAndLt,
                          ParameterizedFp8GemmRewriteTest, ::testing::Bool());
+#endif
 
 TEST_F(GemmRewriteTest, NoFuseBiasBroadcast) {
   const char* hlo = R"(

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -36,11 +36,14 @@ limitations under the License.
 #define SET_ATTR(setter, handle, attr, value) \
   ToStatus(setter(handle, attr, &value, sizeof(decltype(value))), #setter)
 
+// hipblasLtMatmulDescGetAttribute does not allow nullptr for the last 
+// argument (size_t* sizeWritten)
 #define GET_ATTR(getter, handle, attr, ValueT)                            \
   [&]() -> tsl::StatusOr<ValueT> {                                        \
     ValueT value;                                                         \
+    size_t size;                                                          \
     TF_RETURN_IF_ERROR(ToStatus(                                          \
-        getter(handle, attr, &value, sizeof(ValueT), nullptr), #getter)); \
+        getter(handle, attr, &value, sizeof(ValueT), &size), #getter));   \
     return std::move(value);                                              \
   }()
 
@@ -57,7 +60,7 @@ tsl::Status SetAttr(hipblasLtMatrixLayout_t handle,
 template <typename T>
 tsl::StatusOr<T> GetAttr(hipblasLtMatrixLayout_t handle,
                          hipblasLtMatrixLayoutAttribute_t attr) {
-  return GET_ATTR(hipblasLtMatrixLayoutGetAttribute, handle, attr, T);
+  return GET_ATTR(wrap::hipblasLtMatrixLayoutGetAttribute, handle, attr, T);
 }
 
 template <typename T>
@@ -69,7 +72,7 @@ tsl::Status SetAttr(hipblasLtMatmulDesc_t handle,
 template <typename T>
 tsl::StatusOr<T> GetAttr(hipblasLtMatmulDesc_t handle,
                          hipblasLtMatmulDescAttributes_t attr) {
-  return GET_ATTR(hipblasLtMatmulDescGetAttribute, handle, attr, T);
+  return GET_ATTR(wrap::hipblasLtMatmulDescGetAttribute, handle, attr, T);
 }
 
 template <typename T>
@@ -207,6 +210,19 @@ tsl::StatusOr<std::vector<BlasLt::MatmulAlgorithm>> BlasLt::GetMatmulAlgorithms(
     TF_RET_CHECK(blas_lt_ != nullptr);
 
     gpu::ScopedActivateExecutorContext sac{parent_};
+
+    // Right now, hipBlasLt would require setting the bias pointer (even a dummy one)
+    // before finding the algorithms for HIPBLASLT_MATMUL_DESC_BIAS_POINTER.
+    // Can remove this later once this restriction is gone.
+    static int dummy_pointer = 0;
+    TF_ASSIGN_OR_RETURN(hipblasLtEpilogue_t epilogue, 
+                       GetAttr<hipblasLtEpilogue_t>(plan.op_desc.get(), 
+                       HIPBLASLT_MATMUL_DESC_EPILOGUE) );
+    if (epilogue == HIPBLASLT_EPILOGUE_BIAS) {
+      TF_RETURN_IF_ERROR(SetAttr(plan.op_desc.get(),
+                                HIPBLASLT_MATMUL_DESC_BIAS_POINTER,
+                                &dummy_pointer));
+    }
 
     int found_algorithm_count = 0;
     auto error = wrap::hipblasLtMatmulAlgoGetHeuristic(


### PR DESCRIPTION
hipBlasLt currently only supports column major. This PR enables using hipBLASLt for matrices of row major layout by swapping the operands and manipulating the transpose attributes.