### PR TITLE
[NVIDIA:GPU] Add XLA compilations flags per this discussion in this thread https:/…

### DIFF
--- a/xla/python/xla_compiler.cc
+++ b/xla/python/xla_compiler.cc
@@ -924,7 +924,22 @@ void BuildXlaCompilerSubmodule(py::module& m) {
                     &DebugOptions::xla_dump_hlo_pipeline_re,
                     [](DebugOptions* self, std::string value) {
                       self->set_xla_dump_hlo_pipeline_re(value);
-                    });
+                    })
+      .def_property("xla_gpu_enable_async_all_reduce",
+                    &DebugOptions::xla_gpu_enable_async_all_reduce,
+                    &DebugOptions::set_xla_gpu_enable_async_all_reduce)
+      .def_property("xla_gpu_enable_async_all_gather",
+                    &DebugOptions::xla_gpu_enable_async_all_gather,
+                    &DebugOptions::set_xla_gpu_enable_async_all_gather)
+      .def_property("xla_gpu_enable_async_collective_permute",
+                    &DebugOptions::xla_gpu_enable_async_collective_permute,
+                    &DebugOptions::set_xla_gpu_enable_async_collective_permute)
+      .def_property("xla_gpu_enable_async_all_to_all",
+                    &DebugOptions::xla_gpu_enable_async_all_to_all,
+                    &DebugOptions::set_xla_gpu_enable_async_all_to_all)
+      .def_property("xla_gpu_enable_async_reduce_scatter",
+                    &DebugOptions::xla_gpu_enable_async_reduce_scatter,
+                    &DebugOptions::set_xla_gpu_enable_async_reduce_scatter);
 
   py::class_<ExecutableBuildOptions>(m, "ExecutableBuildOptions")
       .def(py::init<>())

--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -272,6 +272,11 @@ class DebugOptions:
   xla_dump_hlo_as_long_text: bool
   xla_dump_disable_metadata: bool
   xla_dump_hlo_pipeline_re: str
+  xla_gpu_enable_async_all_reduce: bool
+  xla_gpu_enable_async_all_gather: bool
+  xla_gpu_enable_async_collective_permute: bool
+  xla_gpu_enable_async_all_to_all: bool
+  xla_gpu_enable_async_reduce_scatter: bool
 
 class CompiledMemoryStats:
   generated_code_size_in_bytes: int


### PR DESCRIPTION
…/mail.google.com/chat/\\#chat/space/AAAAQuUms_4/6XkLzS2sEUA:

As of now there are tons of works in XLA sharding. To have the tests maintainable, we were thinking to disable all async collectives. To do so we need to be able to control the following flags:

xla_gpu_enable_async_all_reduce
xla_gpu_enable_async_all_gather
xla_gpu_enable_async_collective_permute
xla_gpu_enable_async_all_to_all
xla_gpu_enable_async_reduce_scatter

Setting them to true/false we can on or off related collectives.