### PR TITLE
[XLA:GPU] remove unused buffers to fix cudnn graph

### DIFF
--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6737,7 +6737,9 @@ class CudnnExecutionPlanRunner<void(Args...)>
     if (sizeof...(Args) == 7 || sizeof...(Args) == 11) {
       // is fused attention fwd and bwd
       // remove empty buffers from the list
-      data_ptrs_vec.erase(std::remove(data_ptrs_vec.begin(), data_ptrs_vec.end(), nullptr), data_ptrs_vec.end());
+      data_ptrs_vec.erase(
+          std::remove(data_ptrs_vec.begin(), data_ptrs_vec.end(), nullptr),
+          data_ptrs_vec.end());
       // ensure the size is equal after removing useless pointers
       CHECK(data_ptrs_vec.size() == data_uids_vec.size());
     }

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6734,6 +6734,14 @@ class CudnnExecutionPlanRunner<void(Args...)>
       data_ptrs_vec.pop_back();
     }
 
+    if (sizeof...(Args) == 7 || sizeof...(Args) == 11) {
+      // is fused attention fwd and bwd
+      // remove empty buffers from the list
+      data_ptrs_vec.erase(std::remove(data_ptrs_vec.begin(), data_ptrs_vec.end(), nullptr), data_ptrs_vec.end());
+      // ensure the size is equal after removing useless pointers
+      CHECK(data_ptrs_vec.size() == data_uids_vec.size());
+    }
+
     if (should_add_scalars) {
       data_uids_vec.insert(data_uids_vec.end(), scalar_input_uids_.begin(),
                            scalar_input_uids_.end());


### PR DESCRIPTION
This PR is to fix the bug introduced in commit https://github.com/openxla/xla/pull/5184/commits/25aa1baa87abb259e3e0350737c4d39a715183a0 in runner clean up PR: https://github.com/openxla/xla/pull/5184.

Unused buffers in fused attention need to be removed from data_vec so cudnn graph finalization doesn't error out.