### PR TITLE
[ROCm] Fixing XLA tests build brake

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -2,7 +2,7 @@ load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library", "cuda_default_co
 load("//xla:xla.bzl", "xla_cc_test")
 load(
     "@local_config_rocm//rocm:build_defs.bzl",
-    "if_rocm_is_configured", "rocm_default_copts", "if_rocm"
+    "if_rocm_is_configured", "rocm_default_copts"
 )
 load(
     "@tsl//tsl/platform:build_config_root.bzl",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -10,10 +10,7 @@ load(
 )
 load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 
-load(
-    "@tsl//tsl:tsl.bzl",
-    "if_cuda_or_rocm",
-)
+load("@tsl//tsl:tsl.bzl", "if_cuda_or_rocm")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -61,20 +58,6 @@ cc_library(
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
-
-# rocm_library(
-#     name = "sleep_kernel_rocm",
-#     srcs = if_rocm_is_configured(
-#         [
-#             "sleep_kernel.cu.cc",
-#         ],
-#     ),
-#     hdrs = if_rocm_is_configured(["sleep_kernel.h"]),
-#     compatible_with = [],
-#     deps = [
-#         "@local_config_rocm//rocm:rocm_headers",
-#     ],
-# )
 
 cc_library(
     name = "collectives",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -1,14 +1,19 @@
-load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library")
+load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library", "cuda_default_copts")
 load("//xla:xla.bzl", "xla_cc_test")
 load(
     "@local_config_rocm//rocm:build_defs.bzl",
-    "if_rocm_is_configured",
+    "if_rocm_is_configured", "rocm_default_copts", "if_rocm"
 )
 load(
     "@tsl//tsl/platform:build_config_root.bzl",
     "tf_cuda_tests_tags",
 )
 load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
+
+load(
+    "@tsl//tsl:tsl.bzl",
+    "if_cuda_or_rocm",
+)
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -40,19 +45,36 @@ cc_library(
     ],
 )
 
-cuda_library(
-    name = "sleep_kernel_cuda",
-    srcs = if_cuda_is_configured(
+cc_library(
+    name = "sleep_kernel_gpu",
+    srcs = if_cuda_or_rocm(
         [
             "sleep_kernel.cu.cc",
         ],
     ),
-    hdrs = if_cuda_is_configured(["sleep_kernel.h"]),
+    copts = rocm_default_copts() + cuda_default_copts(),
+    hdrs = if_cuda_or_rocm(["sleep_kernel.h"]),
     compatible_with = [],
-    deps = [
+    deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
-    ],
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
 )
+
+# rocm_library(
+#     name = "sleep_kernel_rocm",
+#     srcs = if_rocm_is_configured(
+#         [
+#             "sleep_kernel.cu.cc",
+#         ],
+#     ),
+#     hdrs = if_rocm_is_configured(["sleep_kernel.h"]),
+#     compatible_with = [],
+#     deps = [
+#         "@local_config_rocm//rocm:rocm_headers",
+#     ],
+# )
 
 cc_library(
     name = "collectives",
@@ -76,12 +98,17 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
-    ] + if_cuda_is_configured([
-        ":sleep_kernel_cuda",
-        "@local_config_cuda//cuda:cuda_headers",
+    ] + if_cuda_or_rocm([
+        ":sleep_kernel_gpu",
         "//xla/stream_executor/gpu:gpu_types_header",
         "//xla/stream_executor/gpu:gpu_stream_header",
-    ]),
+        ])
+    + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+        
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ])
 )
 
 cc_library(

--- a/xla/service/gpu/runtime/collectives.cc
+++ b/xla/service/gpu/runtime/collectives.cc
@@ -44,9 +44,11 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 
 #if XLA_ENABLE_XCCL
+#if GOOGLE_CUDA
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/driver_types.h"
 #include "third_party/gpus/cuda/include/vector_types.h"
+#endif
 #include "xla/service/gpu/runtime/sleep_kernel.h"
 #include "xla/stream_executor/gpu/gpu_stream.h"
 #include "xla/stream_executor/gpu/gpu_types.h"
@@ -179,20 +181,38 @@ absl::Status AsyncDoneImpl(const ServiceExecutableRunOptions* run_options,
 #endif  // XLA_ENABLE_XCCL
 }
 
+// TODO: shall we use GpuDriver::LaunchKernel() to avoid macros here ?
 #if XLA_ENABLE_XCCL
 absl::Status NcclMockImplCommon(se::Stream* stream) {
   se::gpu::GpuStreamHandle gpu_stream = se::gpu::AsGpuStreamValue(stream);
   uint32_t sleep_duration_ns = 1000;
   void* kernel = GetSleepKernel();
-  void* kernel_args[] = {&sleep_duration_ns};
   dim3 gridDim = {1, 1, 1};
   dim3 blockDim = {512, 1, 1};
+#if GOOGLE_CUDA
+  void* kernel_args[] = {&sleep_duration_ns};
   cudaError_t launch_status =
       cudaLaunchKernel(kernel, gridDim, blockDim, kernel_args, 0, gpu_stream);
   if (launch_status != cudaSuccess) {
     return absl::InternalError(absl::StrCat("Failed to launch kernel: ",
                                             cudaGetErrorString(launch_status)));
   }
+#elif TENSORFLOW_USE_ROCM
+#define CHK(x) \
+  if (auto res = (x); res != hipSuccess) { \
+    return absl::InternalError(absl::StrFormat("HIP call failed with '%s' at line %d", \
+            hipGetErrorString(res), __LINE__)); \
+  }
+  int devID = 0;
+  hipDeviceProp_t prop{};
+  CHK(hipGetDevice(&devID));
+  CHK(hipGetDeviceProperties(&prop, devID));
+
+  void* kernel_args[] = {&sleep_duration_ns, &prop.clockRate};
+  CHK(hipLaunchKernel(kernel, gridDim, blockDim, kernel_args, 0, gpu_stream));
+
+#undef CHK
+#endif 
   return absl::OkStatus();
 }
 #endif  // XLA_ENABLE_XCCL

--- a/xla/service/gpu/runtime/collectives.cc
+++ b/xla/service/gpu/runtime/collectives.cc
@@ -207,12 +207,10 @@ absl::Status NcclMockImplCommon(se::Stream* stream) {
   hipDeviceProp_t prop{};
   CHK(hipGetDevice(&devID));
   CHK(hipGetDeviceProperties(&prop, devID));
-
   void* kernel_args[] = {&sleep_duration_ns, &prop.clockRate};
   CHK(hipLaunchKernel(kernel, gridDim, blockDim, kernel_args, 0, gpu_stream));
-
 #undef CHK
-#endif 
+#endif // TENSORFLOW_USE_ROCM
   return absl::OkStatus();
 }
 #endif  // XLA_ENABLE_XCCL

--- a/xla/service/gpu/runtime/sleep_kernel.cu.cc
+++ b/xla/service/gpu/runtime/sleep_kernel.cu.cc
@@ -17,6 +17,7 @@ limitations under the License.
 namespace xla::gpu {
 namespace {
 
+#if GOOGLE_CUDA
 __global__ void mock_nccl_call(unsigned sleep_ns) {
 #if __CUDA_ARCH__ >= 700  // __nanosleep requires compute capability 7.0
   // Passing too high a number to __nanosleep makes it sleep for much less time
@@ -28,7 +29,18 @@ __global__ void mock_nccl_call(unsigned sleep_ns) {
   __nanosleep(rem);
 #endif
 }
-
+#elif TENSORFLOW_USE_ROCM
+__global__ void mock_nccl_call(unsigned sleep_ns, unsigned clock_rate_khz) {
+    if (threadIdx.x < warpSize) {
+        // s_sleep causes a wave to sleep for (64 * SIMM16[6:0] + 1..64) clocks. 
+        uint32_t nclocks = (uint32_t)((float)clock_rate_khz / 64e6 * sleep_ns);
+        for (uint32_t i = 0; i < nclocks / 64; i++) {
+          __builtin_amdgcn_s_sleep(64);
+        }
+    }
+    __syncthreads();
+}
+#endif // TENSORFLOW_USE_ROCM
 }  // namespace
 
 void* GetSleepKernel() { return reinterpret_cast<void*>(&mock_nccl_call); }

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -310,6 +310,12 @@ tsl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
 
 tsl::Status GpuExecutor::Submit(Stream* stream,
                                 const CommandBuffer& command_buffer) {
+  if (command_buffer.mode() != CommandBuffer::Mode::kPrimary) {
+    return absl::InvalidArgumentError(
+        "Can't submit non-primary command buffer for execution");
+  }
+  VLOG(-1) << "Calling Submit function!";
+
   auto exec = GpuCommandBuffer::Cast(&command_buffer)->executable();
   VLOG(3) << "Launch command buffer execuable graph " << exec
           << " on a stream: " << stream->DebugStreamPointers();
@@ -732,11 +738,11 @@ GpuExecutor::GetStreamImplementation() {
 }
 
 tsl::StatusOr<std::unique_ptr<internal::CommandBufferInterface>>
-GpuExecutor::GetCommandBufferImplementation() {
+GpuExecutor::GetCommandBufferImplementation(CommandBuffer::Mode mode) {
   VLOG(2) << "Create ROCm command buffer (ROCm graph)";
   GpuGraphHandle graph = nullptr;
   TF_RETURN_IF_ERROR(GpuDriver::CreateGraph(&graph));
-  return std::make_unique<GpuCommandBuffer>(this, graph);
+  return std::make_unique<GpuCommandBuffer>(mode, /*parent=*/this, graph);
 }
 
 void* GpuExecutor::GpuContextHack() { return context_; }

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -314,7 +314,6 @@ tsl::Status GpuExecutor::Submit(Stream* stream,
     return absl::InvalidArgumentError(
         "Can't submit non-primary command buffer for execution");
   }
-  VLOG(-1) << "Calling Submit function!";
 
   auto exec = GpuCommandBuffer::Cast(&command_buffer)->executable();
   VLOG(3) << "Launch command buffer execuable graph " << exec

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -308,6 +308,14 @@ tsl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
       args.number_of_shared_bytes(), hipstream, nullptr, (void**)&config);
 }
 
+tsl::Status GpuExecutor::Submit(Stream* stream,
+                                const CommandBuffer& command_buffer) {
+  auto exec = GpuCommandBuffer::Cast(&command_buffer)->executable();
+  VLOG(3) << "Launch command buffer execuable graph " << exec
+          << " on a stream: " << stream->DebugStreamPointers();
+  return GpuDriver::GraphLaunch(exec, AsGpuStreamValue(stream));
+}
+
 int GpuExecutor::CalculateOccupancy(const DeviceDescription& device_description,
                                     uint64_t registers_per_thread,
                                     uint64_t shared_memory_per_block,


### PR DESCRIPTION
Recently there was a PR which broke our build process: https://github.com/openxla/xla/commit/933e2adb0e8c0c97db0c1f6793a7a59dc5ba6059
by adding CUDA-specific functions without any macro guards.

Additionally, after the recent changes, there was an implementation of GpuExecutor::Submit() missing for ROCm platform
which caused a linker error.

@akuegel: can you please review this fix ? 
