### PR TITLE
[NVIDIA] Bump up cudnn frontend to v1.0

### DIFF
--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,5 +1,5 @@
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
-index 56d8bec..8ceb19c 100644
+index 1240282..cba52ec 100644
 --- a/include/cudnn_backend_base.h
 +++ b/include/cudnn_backend_base.h
 @@ -24,7 +24,7 @@
@@ -12,7 +12,7 @@ index 56d8bec..8ceb19c 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_ConvDesc.h b/include/cudnn_frontend_ConvDesc.h
-index ded7e67..68341e1 100644
+index 6e1d7ab..4deec88 100644
 --- a/include/cudnn_frontend_ConvDesc.h
 +++ b/include/cudnn_frontend_ConvDesc.h
 @@ -29,8 +29,8 @@
@@ -27,7 +27,7 @@ index ded7e67..68341e1 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Engine.h b/include/cudnn_frontend_Engine.h
-index 7e18cd7..d26f4ee 100644
+index b95efb8..867541e 100644
 --- a/include/cudnn_frontend_Engine.h
 +++ b/include/cudnn_frontend_Engine.h
 @@ -30,8 +30,8 @@
@@ -42,7 +42,7 @@ index 7e18cd7..d26f4ee 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineConfig.h b/include/cudnn_frontend_EngineConfig.h
-index ea68554..0888858 100644
+index 973e777..97f0883 100644
 --- a/include/cudnn_frontend_EngineConfig.h
 +++ b/include/cudnn_frontend_EngineConfig.h
 @@ -29,8 +29,8 @@
@@ -57,7 +57,7 @@ index ea68554..0888858 100644
  #include "cudnn_frontend_Engine.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineFallbackList.h b/include/cudnn_frontend_EngineFallbackList.h
-index 323106a..d90a1ea 100644
+index 4d4e5be..6390bc5 100644
 --- a/include/cudnn_frontend_EngineFallbackList.h
 +++ b/include/cudnn_frontend_EngineFallbackList.h
 @@ -22,7 +22,7 @@
@@ -70,7 +70,7 @@ index 323106a..d90a1ea 100644
  #include "cudnn_frontend_Heuristics.h"
  
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index e361821..88f5790 100644
+index afceeb3..3d426e2 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
 @@ -30,8 +30,8 @@
@@ -82,10 +82,10 @@ index e361821..88f5790 100644
 +#include "third_party/gpus/cudnn/cudnn.h"
 +#include "third_party/gpus/cudnn/cudnn_backend.h"
  
+ #include "cudnn_frontend_EngineConfig.h"
  #include "cudnn_frontend_Engine.h"
- #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_Filters.h b/include/cudnn_frontend_Filters.h
-index aac4086..ed1f343 100644
+index 676f0f2..4d1c020 100644
 --- a/include/cudnn_frontend_Filters.h
 +++ b/include/cudnn_frontend_Filters.h
 @@ -22,7 +22,7 @@
@@ -98,7 +98,7 @@ index aac4086..ed1f343 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index 680906a..3df8924 100644
+index dda3fb3..3e89237 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -25,8 +25,8 @@
@@ -113,7 +113,7 @@ index 680906a..3df8924 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_EngineConfig.h"
 diff --git a/include/cudnn_frontend_MatMulDesc.h b/include/cudnn_frontend_MatMulDesc.h
-index e7dd8f7..7a5d443 100644
+index c9258ba..141f2f9 100644
 --- a/include/cudnn_frontend_MatMulDesc.h
 +++ b/include/cudnn_frontend_MatMulDesc.h
 @@ -29,8 +29,8 @@
@@ -128,7 +128,7 @@ index e7dd8f7..7a5d443 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index fe75d5b..a43d696 100644
+index bf16cfa..f3086e1 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -30,8 +30,8 @@
@@ -143,7 +143,7 @@ index fe75d5b..a43d696 100644
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_PointWiseDesc.h"
 diff --git a/include/cudnn_frontend_OperationGraph.h b/include/cudnn_frontend_OperationGraph.h
-index 919a190..5e31484 100644
+index c5e2704..71589b2 100644
 --- a/include/cudnn_frontend_OperationGraph.h
 +++ b/include/cudnn_frontend_OperationGraph.h
 @@ -30,8 +30,8 @@
@@ -158,7 +158,7 @@ index 919a190..5e31484 100644
  #include "cudnn_frontend_Operation.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_PointWiseDesc.h b/include/cudnn_frontend_PointWiseDesc.h
-index ad1f943..f320a27 100644
+index afa71ce..56b6507 100644
 --- a/include/cudnn_frontend_PointWiseDesc.h
 +++ b/include/cudnn_frontend_PointWiseDesc.h
 @@ -30,8 +30,8 @@
@@ -173,7 +173,7 @@ index ad1f943..f320a27 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_ReductionDesc.h b/include/cudnn_frontend_ReductionDesc.h
-index e22a0fb..d69e8c6 100644
+index 5df2c5e..419fc93 100644
 --- a/include/cudnn_frontend_ReductionDesc.h
 +++ b/include/cudnn_frontend_ReductionDesc.h
 @@ -29,8 +29,8 @@
@@ -188,7 +188,7 @@ index e22a0fb..d69e8c6 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Resample.h b/include/cudnn_frontend_Resample.h
-index 4d2d197..1b7c24d 100644
+index 351e2da..b1a1904 100644
 --- a/include/cudnn_frontend_Resample.h
 +++ b/include/cudnn_frontend_Resample.h
 @@ -29,8 +29,8 @@
@@ -203,7 +203,7 @@ index 4d2d197..1b7c24d 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Rng.h b/include/cudnn_frontend_Rng.h
-index 0001ac6..80a623b 100644
+index 9d4e6ca..4224b61 100644
 --- a/include/cudnn_frontend_Rng.h
 +++ b/include/cudnn_frontend_Rng.h
 @@ -29,8 +29,8 @@
@@ -218,7 +218,7 @@ index 0001ac6..80a623b 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_VariantPack.h b/include/cudnn_frontend_VariantPack.h
-index dc68207..8b47fce 100644
+index 455ab8b..4173860 100644
 --- a/include/cudnn_frontend_VariantPack.h
 +++ b/include/cudnn_frontend_VariantPack.h
 @@ -30,8 +30,8 @@

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -32,9 +32,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "d8dba9e2607a0c256aa8eacb45b39986ab6f3f24a4d431d4397047a3cb0cd4fb",
-        strip_prefix = "cudnn-frontend-0.9",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.9.zip"),
+        sha256 = "015ea933139a30e9ccd177b5e0dbfb16f3d08df78334aaacea57880275df734b",
+        strip_prefix = "cudnn-frontend-1.0.0",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.0.0.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
This pull request updates the cuDNN frontend to [the latest version 1.0](https://github.com/NVIDIA/cudnn-frontend/releases/tag/v1.0.0).
