### PR TITLE
[NVIDIA XLA] Added a helper function to assign suffix to instruction name when cloning

### DIFF
--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -45,13 +45,6 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "tsl/lib/gtl/iterator_range.h"
-#include "tsl/lib/gtl/map_util.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/human_readable_json.h"
-#include "tsl/platform/logging.h"  // IWYU pragma: keep
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
 #include "xla/comparison_util.h"
 #include "xla/hlo/ir/dfs_hlo_visitor.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
@@ -82,6 +75,13 @@ limitations under the License.
 #include "xla/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
+#include "tsl/lib/gtl/iterator_range.h"
+#include "tsl/lib/gtl/map_util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/human_readable_json.h"
+#include "tsl/platform/logging.h"  // IWYU pragma: keep
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
 
 namespace xla {
 
@@ -2074,12 +2074,12 @@ bool HloInstruction::HasSideEffect() const {
          execution_threads_set.contains(execution_thread);
 }
 
-void HloInstruction::AddSuffixToInstructionName(const std::string& suffix) {
+void HloInstruction::AddSuffixToInstructionName(const absl::string_view suffix) {
   // If an instruction is cloned multiple times avoid names like
   // foo.suffix.suffix.suffix. Instead of repeating the suffix add a numeric
   // suffix. Specifically, the clone of foo.suffix is named foo.suffix2, the
   // clone of foo.suffix2 is named foo.suffix3 and so on.
-  const std::string dot_suffix = "." + suffix;
+  const std::string dot_suffix = absl::StrCat(".", suffix);
   size_t index = name().rfind(dot_suffix);
   if (index == std::string::npos) {
     // Existing name does not include ".suffix".

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -2338,6 +2338,9 @@ class HloInstruction {
     kFalseComputationIndex = 1,
   };
 
+  // Change instruction's name to have a given suffix.
+  void AddSuffixToInstructionName(const std::string& suffix);
+
  private:
   friend class HloComputation;
   // Wrapper class of string format and protobuf format of BackendConfig.

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -2339,7 +2339,7 @@ class HloInstruction {
   };
 
   // Change instruction's name to have a given suffix.
-  void AddSuffixToInstructionName(const std::string& suffix);
+  void AddSuffixToInstructionName(const absl::string_view suffix);
 
  private:
   friend class HloComputation;

--- a/xla/service/hlo_instruction_test.cc
+++ b/xla/service/hlo_instruction_test.cc
@@ -749,8 +749,13 @@ TEST_F(HloInstructionTest, PreserveMetadataInFusionAndClone) {
   EXPECT_TRUE(protobuf_util::ProtobufEquals(
       metadata, fusion->fused_expression_root()->operand(0)->metadata()));
 
-  auto cloned = fusion->CloneWithNewOperands(fusion->shape(), {});
+  std::string new_name = "foobarfoo";
+  HloCloneContext context(module.get(), new_name);
+  auto cloned = fusion->CloneWithNewOperands(fusion->shape(), {}, &context);
   EXPECT_TRUE(protobuf_util::ProtobufEquals(metadata, fusion->metadata()));
+
+  size_t index = cloned->name().rfind(new_name);
+  EXPECT_TRUE(index != std::string::npos);
 }
 
 TEST_F(HloInstructionTest, BinaryCallOp) {

--- a/xla/service/hlo_module_test.cc
+++ b/xla/service/hlo_module_test.cc
@@ -233,7 +233,7 @@ ENTRY entry () -> s32[] {
   HloComputation* cloned_computation =
       cloned_module->GetComputationWithName("add_s32.clone");
   HloInstruction* cloned_custom_call =
-      cloned_module->entry_computation()->GetInstructionWithName("custom-call");
+      cloned_module->entry_computation()->GetInstructionWithName("custom-call.clone");
 
   EXPECT_TRUE(cloned_computation->IsCustomCallComputation());
   EXPECT_EQ(cloned_computation->CustomCallInstruction(), cloned_custom_call);
@@ -273,8 +273,7 @@ ENTRY entry () -> s32[] {
   HloComputation* cloned_computation_1 =
       cloned_module->GetComputationWithName("add_s32_1.clone");
   HloInstruction* cloned_custom_call =
-      cloned_module->entry_computation()->GetInstructionWithName("custom-call");
-
+      cloned_module->entry_computation()->GetInstructionWithName("custom-call.clone");
   EXPECT_TRUE(cloned_computation_0->IsCustomCallComputation());
   EXPECT_EQ(cloned_computation_0->CustomCallInstruction(), cloned_custom_call);
   EXPECT_TRUE(cloned_computation_1->IsCustomCallComputation());
@@ -301,7 +300,7 @@ ENTRY main {
   HloComputation* cloned_computation =
       cloned_module->GetComputationWithName("fused_computation.clone");
   HloInstruction* cloned_fusion_instr =
-      cloned_module->entry_computation()->GetInstructionWithName("fusion");
+      cloned_module->entry_computation()->GetInstructionWithName("fusion.clone");
 
   EXPECT_TRUE(cloned_computation->IsFusionComputation());
   EXPECT_EQ(cloned_computation->FusionInstruction(), cloned_fusion_instr);


### PR DESCRIPTION
CloneWithNewOperands function doesnt add suffix to the cloned instruction even suffix is specified in the context.
Reuse existing logic to add suffix.