### PR TITLE
Update path of cuda_build_defs in Bazel config

### DIFF
--- a/third_party/nccl/system.BUILD.tpl
+++ b/third_party/nccl/system.BUILD.tpl
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(
-    "@xla//tensorflow/platform/default:cuda_build_defs.bzl",
+    "@tsl//tsl/platform/default:cuda_build_defs.bzl",
     "cuda_rpath_flags"
 )
 

--- a/third_party/tsl/third_party/nccl/system.BUILD.tpl
+++ b/third_party/tsl/third_party/nccl/system.BUILD.tpl
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(
-    "@tsl//tensorflow/platform/default:cuda_build_defs.bzl",
+    "@tsl//tsl/platform/default:cuda_build_defs.bzl",
     "cuda_rpath_flags"
 )
 


### PR DESCRIPTION
We are seeing [failures when building jaxlib against CUDA 12.1](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6493878343/job/17635858664#step:10:533) due to the following error:
```
ERROR: /root/.cache/bazel/_bazel_root/938be0cf9dc59c1b3a9c4bf28d15e057/external/tsl/tsl/platform/default/BUILD:70:11: error loading package '@local_config_nccl//': Label '@tsl//tensorflow/platform/default:cuda_build_defs.bzl' is invalid because 'tensorflow/platform/default' is not a package; perhaps you meant to put the colon here: '@tsl//:tensorflow/platform/default/cuda_build_defs.bzl'? and referenced by '@tsl//tsl/platform/default:dso_loader'
```

Strangely, the failure does not happen when building for CUDA 12.2.