### PR TITLE
[ROCm] Fixed hlo_runner_main build error on ROCm

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -63,26 +63,22 @@ limitations under the License.
 #include "tfrt/host_context/host_allocator.h"  // from @tf_runtime
 #include "tfrt/host_context/host_context.h"  // from @tf_runtime
 
-#ifdef GOOGLE_CUDA
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
 #include "xla/pjrt/compile_options.pb.h"
 #include "xla/pjrt/gpu/nccl_id_store.h"
 #include "xla/pjrt/metrics.h"
 #include "xla/pjrt/stream_executor_executable.pb.h"
 #include "xla/service/gpu/gpu_compiler.h"
-#include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
 #include "xla/xla.pb.h"
-#endif  // GOOGLE_CUDA
+#endif // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-#ifdef TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
+#elif TENSORFLOW_USE_ROCM
 #include "rocm/rocm_config.h"
-#include "xla/pjrt/compile_options.pb.h"  // NOLINT(build/include)
-#include "xla/pjrt/gpu/nccl_id_store.h"  // NOLINT(build/include)
-#include "xla/pjrt/stream_executor_executable.pb.h"  // NOLINT(build/include)
-#include "xla/service/gpu/gpu_compiler.h"  // NOLINT(build/include)
-#include "xla/xla.pb.h"  // NOLINT(build/include)
-#endif  // TENSORFLOW_USE_ROCM
+#endif  
 
 #include "xla/client/client_library.h"
 #include "xla/service/gpu/gpu_executable_run_options.h"
@@ -542,10 +538,9 @@ StreamExecutorGpuClient::Compile(const XlaComputation& computation,
                                  CompileOptions options) {
   auto executable = PjRtStreamExecutorClient::Compile(computation, options);
 
-#ifdef GOOGLE_CUDA
+#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
   metrics::RecordFreeGpuSystemMemory();
-#endif  // GOOGLE_CUDA
-
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   return executable;
 }
 

--- a/xla/xla.bzl
+++ b/xla/xla.bzl
@@ -56,6 +56,7 @@ def xla_cc_binary(deps = None, copts = tsl_copts(), **kwargs):
         "//xla/service/gpu/model:hlo_op_profile_proto_cc_impl",
         "//xla/stream_executor:device_description_proto_cc_impl",
         "//xla/stream_executor:stream_executor_impl",
+        "//xla/stream_executor/gpu:gpu_init_impl",        
         "@tsl//tsl/platform:env_impl",
         "@tsl//tsl/platform:tensor_float_32_utils",
         "@tsl//tsl/profiler/utils:time_utils_impl",


### PR DESCRIPTION
This PR is enable some ROCm features on PjRt side based on https://github.com/openxla/xla/commit/5324ef5ccc05d70c9cd3dfcd8e1c77896fd1a562 and https://github.com/openxla/xla/commit/8422226150968965613e6d998f0dd0cff1b9abfe

Thanks in adavance! @akuegel 

As a side note, we can also remove this `if_static` https://github.com/openxla/xla/blob/main/xla/stream_executor/gpu/BUILD#L184 to avoid the change on metrics.h deps, but not sure whether it's ok to do this way.