### PR TITLE
[ROCm] Fix multihost hlo runner linker error

### DIFF
--- a/xla/pjrt/BUILD
+++ b/xla/pjrt/BUILD
@@ -362,7 +362,7 @@ cc_library(
     hdrs = ["metrics.h"],
     deps = [
         "//xla/stream_executor",
-        "//xla/stream_executor/gpu:gpu_init",
+        "//xla/stream_executor/gpu:gpu_init_impl",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -63,26 +63,22 @@ limitations under the License.
 #include "tfrt/host_context/host_allocator.h"  // from @tf_runtime
 #include "tfrt/host_context/host_context.h"  // from @tf_runtime
 
-#ifdef GOOGLE_CUDA
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
 #include "xla/pjrt/compile_options.pb.h"
 #include "xla/pjrt/gpu/nccl_id_store.h"
 #include "xla/pjrt/metrics.h"
 #include "xla/pjrt/stream_executor_executable.pb.h"
 #include "xla/service/gpu/gpu_compiler.h"
-#include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
 #include "xla/xla.pb.h"
-#endif  // GOOGLE_CUDA
+#endif // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-#ifdef TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
+#elif TENSORFLOW_USE_ROCM
 #include "rocm/rocm_config.h"
-#include "xla/pjrt/compile_options.pb.h"  // NOLINT(build/include)
-#include "xla/pjrt/gpu/nccl_id_store.h"  // NOLINT(build/include)
-#include "xla/pjrt/stream_executor_executable.pb.h"  // NOLINT(build/include)
-#include "xla/service/gpu/gpu_compiler.h"  // NOLINT(build/include)
-#include "xla/xla.pb.h"  // NOLINT(build/include)
-#endif  // TENSORFLOW_USE_ROCM
+#endif  
 
 #include "xla/client/client_library.h"
 #include "xla/service/gpu/gpu_executable_run_options.h"
@@ -542,10 +538,9 @@ StreamExecutorGpuClient::Compile(const XlaComputation& computation,
                                  CompileOptions options) {
   auto executable = PjRtStreamExecutorClient::Compile(computation, options);
 
-#ifdef GOOGLE_CUDA
+#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
   metrics::RecordFreeGpuSystemMemory();
-#endif  // GOOGLE_CUDA
-
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   return executable;
 }
 


### PR DESCRIPTION
@ezhulenev : can you please have a look at this fix ?

The original linker error was:
```
ERROR: /tf/xla/xla/tools/multihost_hlo_runner/BUILD:25:14: Linking xla/tools/multihost_hlo_runner/hlo_runner_main failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing command (from target //xla/tools/multihost_hlo_runner:hlo_runner_main) external/local_config_rocm/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc @bazel-out/k8-opt/bin/xla/tools/multihost_hlo_runner/hlo_runner_main-2.params                                                 
bazel-out/k8-opt/bin/xla/pjrt/_objs/metrics/metrics.o:metrics.cc:function xla::metrics::RecordFreeGpuSystemMemory(): error: undefined reference to 'stream_executor::GPUMachineManager()'
```

By looking at gpu_cudamallocasync_allocator target, I realized that the dependency to gpu_init_impl was missing..
Though, I am not sure whether this is legitimate considering a new SE package interace.
 