### PR TITLE
[ROCm] Renaming cublas_lt -> gpublas_lt and hipblas-lt fixes for future ROCM versions

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1325,12 +1325,8 @@ cc_library(
 
 cc_library(
     name = "gpublas_lt_matmul_thunk",
-    srcs = if_cuda_is_configured(["gpublas_lt_matmul_thunk.cc"]) + if_rocm_is_configured([
-        "gpublas_lt_matmul_thunk.cc",
-    ]),
-    hdrs = if_cuda_is_configured(["gpublas_lt_matmul_thunk.h"]) + if_rocm_is_configured([
-        "gpublas_lt_matmul_thunk.h",
-    ]),
+    srcs = if_gpu_is_configured(["gpublas_lt_matmul_thunk.cc"]),
+    hdrs = if_gpu_is_configured(["gpublas_lt_matmul_thunk.h"]),
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
         "TENSORFLOW_USE_ROCM=1",
     ]),
@@ -1343,12 +1339,7 @@ cc_library(
         "//xla/stream_executor",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:statusor",
-    ]) + if_cuda_is_configured([
-        "//xla/stream_executor/cuda:cublas_lt_header",
-        "//xla/stream_executor/cuda:cublas_plugin",
-    ]) + if_rocm_is_configured([
-        "//xla/stream_executor/rocm:hipblas_lt_header",
-    ]),
+    ])
 )
 
 cc_library(

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -343,7 +343,7 @@ cc_library(
         "@tsl//tsl/protobuf:dnn_proto_cc",
     ] + if_gpu_is_configured([
         ":cub_sort_thunk",
-        ":cublas_lt_matmul_thunk",
+        ":gpublas_lt_matmul_thunk",
         ":ir_emitter_triton",
         "//xla/service/gpu/runtime3:cholesky_thunk",
         "//xla/service/gpu/runtime3:triangular_solve_thunk",
@@ -1324,12 +1324,12 @@ cc_library(
 )
 
 cc_library(
-    name = "cublas_lt_matmul_thunk",
-    srcs = if_cuda_is_configured(["cublas_lt_matmul_thunk.cc"]) + if_rocm_is_configured([
-        "cublas_lt_matmul_thunk.cc",
+    name = "gpublas_lt_matmul_thunk",
+    srcs = if_cuda_is_configured(["gpublas_lt_matmul_thunk.cc"]) + if_rocm_is_configured([
+        "gpublas_lt_matmul_thunk.cc",
     ]),
-    hdrs = if_cuda_is_configured(["cublas_lt_matmul_thunk.h"]) + if_rocm_is_configured([
-        "cublas_lt_matmul_thunk.h",
+    hdrs = if_cuda_is_configured(["gpublas_lt_matmul_thunk.h"]) + if_rocm_is_configured([
+        "gpublas_lt_matmul_thunk.h",
     ]),
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
         "TENSORFLOW_USE_ROCM=1",

--- a/xla/service/gpu/gpublas_lt_matmul_thunk.cc
+++ b/xla/service/gpu/gpublas_lt_matmul_thunk.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "xla/service/gpu/cublas_lt_matmul_thunk.h"
+#include "xla/service/gpu/gpublas_lt_matmul_thunk.h"
 
 #include <memory>
 #include <utility>

--- a/xla/service/gpu/gpublas_lt_matmul_thunk.h
+++ b/xla/service/gpu/gpublas_lt_matmul_thunk.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef XLA_SERVICE_GPU_CUBLAS_LT_MATMUL_THUNK_H_
-#define XLA_SERVICE_GPU_CUBLAS_LT_MATMUL_THUNK_H_
+#ifndef XLA_SERVICE_GPU_GPUBLAS_LT_MATMUL_THUNK_H_
+#define XLA_SERVICE_GPU_GPUBLAS_LT_MATMUL_THUNK_H_
 
 #include <memory>
 #include <optional>
@@ -76,4 +76,4 @@ class CublasLtMatmulThunk : public Thunk {
 }  // namespace gpu
 }  // namespace xla
 
-#endif  // XLA_SERVICE_GPU_CUBLAS_LT_MATMUL_THUNK_H_
+#endif  // XLA_SERVICE_GPU_GPUBLAS_LT_MATMUL_THUNK_H_

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -146,7 +146,7 @@ limitations under the License.
 
 #if GOOGLE_CUDA || TF_HIPBLASLT
 #include "xla/service/gpu/cub_sort_thunk.h"
-#include "xla/service/gpu/cublas_lt_matmul_thunk.h"
+#include "xla/service/gpu/gpublas_lt_matmul_thunk.h"
 #include "xla/service/gpu/ir_emitter_triton.h"
 #endif  // GOOGLE_CUDA || TF_HIPBLASLT
 

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -242,7 +242,7 @@ cc_library(
         ":conv",
         ":conv_reorder",
         ":cub_sort",
-        ":cublas_lt_matmul",
+        ":gpublas_lt_matmul",
         ":custom_call",
         ":custom_call_registry",
         ":fft",
@@ -339,7 +339,7 @@ xla_cc_test(
     name = "topk_kernel_test",
     srcs = if_cuda_is_configured(["topk_kernel_test.cc"]),
     linkstatic = 1,
-    tags = tf_cuda_tests_tags(),
+    tags = ["no_rocm"] + tf_cuda_tests_tags(),
     deps = [
         ":topk_kernel",
         "//xla:xla_data_proto_cc",
@@ -549,9 +549,9 @@ cc_library(
 )
 
 cc_library(
-    name = "cublas_lt_matmul",
-    srcs = ["cublas_lt_matmul.cc"],
-    hdrs = ["cublas_lt_matmul.h"],
+    name = "gpublas_lt_matmul",
+    srcs = ["gpublas_lt_matmul.cc"],
+    hdrs = ["gpublas_lt_matmul.h"],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM"]),
     deps = [
         ":support",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -339,7 +339,7 @@ xla_cc_test(
     name = "topk_kernel_test",
     srcs = if_cuda_is_configured(["topk_kernel_test.cc"]),
     linkstatic = 1,
-    tags = ["no_rocm"] + tf_cuda_tests_tags(),
+    tags = tf_cuda_tests_tags(),
     deps = [
         ":topk_kernel",
         "//xla:xla_data_proto_cc",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -565,7 +565,6 @@ cc_library(
         "//xla/service:executable",
         "//xla/service/gpu:matmul_utils",
         "//xla/stream_executor",
-        "//xla/stream_executor/cuda:cublas_lt_header",
         "@tsl//tsl/platform:status",
     ] + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",

--- a/xla/service/gpu/runtime/executable.cc
+++ b/xla/service/gpu/runtime/executable.cc
@@ -34,7 +34,7 @@ limitations under the License.
 #include "xla/service/gpu/runtime/conv.h"
 #include "xla/service/gpu/runtime/conv_reorder.h"
 #include "xla/service/gpu/runtime/cub_sort.h"
-#include "xla/service/gpu/runtime/cublas_lt_matmul.h"
+#include "xla/service/gpu/runtime/gpublas_lt_matmul.h"
 #include "xla/service/gpu/runtime/custom_call.h"
 #include "xla/service/gpu/runtime/custom_call_registry.h"
 #include "xla/service/gpu/runtime/fft.h"
@@ -444,7 +444,7 @@ Status GpuRuntimeExecutable::Execute(
   FftPlans::Snapshot fft_plans = fft_plans_.snapshot();
 
 #if GOOGLE_CUDA || TF_HIPBLASLT
-  MatmulPlans::Snapshot matmul_plans = cublas_lt_matmul_plans_.snapshot();
+  MatmulPlans::Snapshot matmul_plans = gpublas_lt_matmul_plans_.snapshot();
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/xla/service/gpu/runtime/executable.h
+++ b/xla/service/gpu/runtime/executable.h
@@ -31,7 +31,7 @@ limitations under the License.
 #include "xla/service/gpu/non_atomically_upgradeable_rw_lock.h"
 #include "xla/service/gpu/runtime/collectives.h"
 #include "xla/service/gpu/runtime/conv.h"
-#include "xla/service/gpu/runtime/cublas_lt_matmul.h"
+#include "xla/service/gpu/runtime/gpublas_lt_matmul.h"
 #include "xla/service/gpu/runtime/fft.h"
 #include "xla/service/gpu/runtime/fused_attention.h"
 #include "xla/service/gpu/runtime/gemm.h"
@@ -172,7 +172,7 @@ class GpuRuntimeExecutable {
   FftPlans fft_plans_;
 
 #if GOOGLE_CUDA || TF_HIPBLASLT  // Keep matmul execution plans.
-  MatmulPlans cublas_lt_matmul_plans_;
+  MatmulPlans gpublas_lt_matmul_plans_;
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/xla/service/gpu/runtime/gpublas_lt_matmul.cc
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.1
 ==============================================================================*/
 
-#include "xla/service/gpu/runtime/cublas_lt_matmul.h"
+#include "xla/service/gpu/runtime/gpublas_lt_matmul.h"
 
 #include <optional>
 #include <string>

--- a/xla/service/gpu/runtime/gpublas_lt_matmul.h
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef XLA_SERVICE_GPU_RUNTIME_CUBLAS_LT_MATMUL_H_
-#define XLA_SERVICE_GPU_RUNTIME_CUBLAS_LT_MATMUL_H_
+#ifndef XLA_SERVICE_GPU_RUNTIME_GPUBLAS_LT_MATMUL_H_
+#define XLA_SERVICE_GPU_RUNTIME_GPUBLAS_LT_MATMUL_H_
 
 #include "xla/mlir/runtime/transforms/custom_call_encoding.h"
 #include "xla/runtime/custom_call_registry.h"
@@ -43,4 +43,4 @@ class MatmulPlans
 }  // namespace gpu
 }  // namespace xla
 
-#endif  // XLA_SERVICE_GPU_RUNTIME_CUBLAS_LT_MATMUL_H_
+#endif  // XLA_SERVICE_GPU_RUNTIME_GPUBLAS_LT_MATMUL_H_

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -27,30 +27,36 @@ limitations under the License.
 #include "tsl/platform/tensor_float_32_utils.h"
 #endif
 
-namespace stream_executor::gpu {
+namespace stream_executor {
 
-tsl::StatusOr<blas::DataType> AsBlasDataType(xla::PrimitiveType dtype) {
+namespace gpu {
+
+using xla::PrimitiveType;
+using blas::DataType;
+using blas::ComputationType;
+
+tsl::StatusOr<DataType> AsBlasDataType(PrimitiveType dtype) {
   switch (dtype) {
-    case xla::PrimitiveType::F8E5M2:
-      return blas::DataType::kF8E5M2;
-    case xla::PrimitiveType::F8E4M3FN:
-      return blas::DataType::kF8E4M3FN;
-    case xla::PrimitiveType::S8:
-      return blas::DataType::kInt8;
-    case xla::PrimitiveType::F16:
-      return blas::DataType::kHalf;
-    case xla::PrimitiveType::BF16:
-      return blas::DataType::kBF16;
-    case xla::PrimitiveType::F32:
-      return blas::DataType::kFloat;
-    case xla::PrimitiveType::S32:
-      return blas::DataType::kInt32;
-    case xla::PrimitiveType::F64:
-      return blas::DataType::kDouble;
-    case xla::PrimitiveType::C64:
-      return blas::DataType::kComplexFloat;
-    case xla::PrimitiveType::C128:
-      return blas::DataType::kComplexDouble;
+    case PrimitiveType::F8E5M2:
+      return DataType::kF8E5M2;
+    case PrimitiveType::F8E4M3FN:
+      return DataType::kF8E4M3FN;
+    case PrimitiveType::S8:
+      return DataType::kInt8;
+    case PrimitiveType::F16:
+      return DataType::kHalf;
+    case PrimitiveType::BF16:
+      return DataType::kBF16;
+    case PrimitiveType::F32:
+      return DataType::kFloat;
+    case PrimitiveType::S32:
+      return DataType::kInt32;
+    case PrimitiveType::F64:
+      return DataType::kDouble;
+    case PrimitiveType::C64:
+      return DataType::kComplexFloat;
+    case PrimitiveType::C128:
+      return DataType::kComplexDouble;
     default:
       return xla::InternalError(
           "AsBlasDataType: unsupported type: %s",
@@ -58,59 +64,59 @@ tsl::StatusOr<blas::DataType> AsBlasDataType(xla::PrimitiveType dtype) {
   }
 }
 
-tsl::StatusOr<xla::PrimitiveType> AsXlaPrimitiveType(blas::DataType dtype) {
+tsl::StatusOr<PrimitiveType> AsXlaPrimitiveType(DataType dtype) {
   switch (dtype) {
-    case blas::DataType::kF8E5M2:
-      return xla::PrimitiveType::F8E5M2;
-    case blas::DataType::kF8E4M3FN:
-      return xla::PrimitiveType::F8E4M3FN;
-    case blas::DataType::kInt8:
-      return xla::PrimitiveType::S8;
-    case blas::DataType::kHalf:
-      return xla::PrimitiveType::F16;
-    case blas::DataType::kBF16:
-      return xla::PrimitiveType::BF16;
-    case blas::DataType::kFloat:
-      return xla::PrimitiveType::F32;
-    case blas::DataType::kInt32:
-      return xla::PrimitiveType::S32;
-    case blas::DataType::kDouble:
-      return xla::PrimitiveType::F64;
-    case blas::DataType::kComplexFloat:
-      return xla::PrimitiveType::C64;
-    case blas::DataType::kComplexDouble:
-      return xla::PrimitiveType::C128;
+    case DataType::kF8E5M2:
+      return PrimitiveType::F8E5M2;
+    case DataType::kF8E4M3FN:
+      return PrimitiveType::F8E4M3FN;
+    case DataType::kInt8:
+      return PrimitiveType::S8;
+    case DataType::kHalf:
+      return PrimitiveType::F16;
+    case DataType::kBF16:
+      return PrimitiveType::BF16;
+    case DataType::kFloat:
+      return PrimitiveType::F32;
+    case DataType::kInt32:
+      return PrimitiveType::S32;
+    case DataType::kDouble:
+      return PrimitiveType::F64;
+    case DataType::kComplexFloat:
+      return PrimitiveType::C64;
+    case DataType::kComplexDouble:
+      return PrimitiveType::C128;
     default:
       return xla::InternalError("AsXlaPrimitiveType: unsupported dtype");
   }
 }
 
-tsl::StatusOr<blas::ComputationType> GetBlasComputationType(
-    xla::PrimitiveType lhs_dtype, xla::PrimitiveType output_dtype,
+tsl::StatusOr<ComputationType> GetBlasComputationType(
+    PrimitiveType lhs_dtype, PrimitiveType output_dtype,
     int64_t compute_precision) {
   switch (output_dtype) {
-    case xla::PrimitiveType::F8E5M2:    // fall-through
-    case xla::PrimitiveType::F8E4M3FN:  // fall-through
-    case xla::PrimitiveType::F16:       // fall-through
-    case xla::PrimitiveType::BF16:
+    case PrimitiveType::F8E5M2:    // fall-through
+    case PrimitiveType::F8E4M3FN:  // fall-through
+    case PrimitiveType::F16:       // fall-through
+    case PrimitiveType::BF16:
       // Accumulate in f32 precision.
-      return blas::ComputationType::kF32;
-    case xla::PrimitiveType::F32:  // fall-through
-    case xla::PrimitiveType::C64:
+      return ComputationType::kF32;
+    case PrimitiveType::F32:  // fall-through
+    case PrimitiveType::C64:
 #if GOOGLE_CUDA
       if (tsl::tensor_float_32_execution_enabled() && compute_precision <= 1 &&
           lhs_dtype == output_dtype) {
         // CublasLt requires compute type to be F32 for F8 matmul.
         // TF32 should only be chosen for FP32 or C64 gemm
-        return blas::ComputationType::kTF32AsF32;
+        return ComputationType::kTF32AsF32;
       }
 #endif
-      return blas::ComputationType::kF32;
-    case xla::PrimitiveType::F64:  // fall-through
-    case xla::PrimitiveType::C128:
-      return blas::ComputationType::kF64;
-    case xla::PrimitiveType::S32:
-      return blas::ComputationType::kI32;
+      return ComputationType::kF32;
+    case PrimitiveType::F64:  // fall-through
+    case PrimitiveType::C128:
+      return ComputationType::kF64;
+    case PrimitiveType::S32:
+      return ComputationType::kI32;
     default:
       return xla::InternalError("GetBlasComputationType: unsupported type");
   }
@@ -149,12 +155,12 @@ bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
   return (blas != nullptr ? blas->GetBlasLt() : nullptr);
 }
 
-blas::DataType GetScaleType(blas::DataType c_type,
-                            blas::ComputationType computation_type) {
-  return ((computation_type == blas::ComputationType::kF32) &&
-          (c_type != blas::DataType::kComplexFloat))
-             ? blas::DataType::kFloat
-             : c_type;
+DataType GetScaleType(DataType c_type,
+                            ComputationType computation_type) {
+  return (computation_type == ComputationType::kF32 &&
+          c_type != DataType::kComplexFloat ? DataType::kFloat : c_type);
 }
 
-}  // namespace stream_executor::gpu
+} // namespace gpu
+
+}  // namespace stream_executor

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -421,39 +421,31 @@ tsl::Status BlasLt::MatmulPlan::DoMatmul(
 
 namespace {
 
-using cudaDataType_t = hipblasDatatype_t;
-#define CUDA_R_16BF HIPBLAS_R_16B
-#define CUDA_R_16F HIPBLAS_R_16F
-#define CUDA_R_32F HIPBLAS_R_32F
-#define CUDA_R_64F HIPBLAS_R_64F
-#define CUDA_C_32F HIPBLAS_C_32F
-#define CUDA_C_64F HIPBLAS_C_64F
-
-template <cudaDataType_t CudaT>
-struct CudaToNativeT;
+template <hipblasltDatatype_t>
+struct HipToNativeT;
 
 template <>
-struct CudaToNativeT<CUDA_R_16BF> {
+struct HipToNativeT<HIPBLASLT_R_16B> {
   using type = Eigen::bfloat16;
 };
 template <>
-struct CudaToNativeT<CUDA_R_16F> {
+struct HipToNativeT<HIPBLASLT_R_16F> {
   using type = Eigen::half;
 };
 template <>
-struct CudaToNativeT<CUDA_R_32F> {
+struct HipToNativeT<HIPBLASLT_R_32F> {
   using type = float;
 };
 template <>
-struct CudaToNativeT<CUDA_R_64F> {
+struct HipToNativeT<HIPBLASLT_R_64F> {
   using type = double;
 };
 template <>
-struct CudaToNativeT<CUDA_C_32F> {
+struct HipToNativeT<HIPBLASLT_C_32F> {
   using type = complex64;
 };
 template <>
-struct CudaToNativeT<CUDA_C_64F> {
+struct HipToNativeT<HIPBLASLT_C_64F> {
   using type = complex128;
 };
 
@@ -476,22 +468,22 @@ tsl::Status BlasLt::MatmulPlan::ExecuteOnStream(
 #define TYPED_MATMUL(SCALENTYPE, ATYPE, BTYPE, CTYPE, DTYPE)                \
   if (operand_types == std::make_tuple(ATYPE, BTYPE, CTYPE, DTYPE)) {       \
     return gpu::BlasLt::MatmulPlan::DoMatmul<                               \
-        SCALENTYPE, CudaToNativeT<ATYPE>::type, CudaToNativeT<BTYPE>::type, \
-        CudaToNativeT<CTYPE>::type, CudaToNativeT<DTYPE>::type>(            \
+        SCALENTYPE, HipToNativeT<ATYPE>::type, HipToNativeT<BTYPE>::type, \
+        HipToNativeT<CTYPE>::type, HipToNativeT<DTYPE>::type>(            \
         stream, alpha_, a, b, beta_, c, d, bias, aux, a_scale, b_scale,     \
         c_scale, d_scale, d_amax, algorithm, scratch_allocator,             \
         profile_result);                                                    \
   }
 
   // Other data types:
-  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(float, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(double, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F)
-  TYPED_MATMUL(complex64, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
-  TYPED_MATMUL(complex128, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
+  TYPED_MATMUL(float, HIPBLASLT_R_16B, HIPBLASLT_R_16B, HIPBLASLT_R_16B, HIPBLASLT_R_16B)
+  TYPED_MATMUL(float, HIPBLASLT_R_16F, HIPBLASLT_R_16F, HIPBLASLT_R_16F, HIPBLASLT_R_16F)
+  TYPED_MATMUL(float, HIPBLASLT_R_16B, HIPBLASLT_R_16B, HIPBLASLT_R_32F, HIPBLASLT_R_32F)
+  TYPED_MATMUL(float, HIPBLASLT_R_16F, HIPBLASLT_R_16F, HIPBLASLT_R_32F, HIPBLASLT_R_32F)
+  TYPED_MATMUL(float, HIPBLASLT_R_32F, HIPBLASLT_R_32F, HIPBLASLT_R_32F, HIPBLASLT_R_32F)
+  TYPED_MATMUL(double, HIPBLASLT_R_64F, HIPBLASLT_R_64F, HIPBLASLT_R_64F, HIPBLASLT_R_64F)
+  TYPED_MATMUL(complex64, HIPBLASLT_C_32F, HIPBLASLT_C_32F, HIPBLASLT_C_32F, HIPBLASLT_C_32F)
+  TYPED_MATMUL(complex128, HIPBLASLT_C_64F, HIPBLASLT_C_64F, HIPBLASLT_C_64F, HIPBLASLT_C_64F)
 
 #undef TYPED_MATMUL
 

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -21,8 +21,6 @@ limitations under the License.
 #include "rocm/rocm_config.h"
 #include "xla/primitive_util.h"
 #include "xla/status_macros.h"
-#include "xla/stream_executor/blas.h"
-#include "xla/stream_executor/rocm/hip_blas_utils.h"
 #include "xla/util.h"
 
 #if TF_HIPBLASLT
@@ -137,13 +135,13 @@ tsl::Status BlasLt::Init() {
                              ? m.num_cols
                              : m.num_rows;
   }
-
+  auto hipblas_data_type_ = AsHipblasDataType(type);
   hipblasLtMatrixLayout_t hip_layout;
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatrixLayoutCreate(
-      &hip_layout, AsHipblasDataType(type), m.num_rows, m.num_cols,
+      &hip_layout, hipblas_data_type_, m.num_rows, m.num_cols,
       *leading_dim_stride));
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
-  BlasLt::MatrixLayout layout(hip_layout);
+  BlasLt::MatrixLayout layout(hip_layout, hipblas_data_type_);
   if (m.order != gpu::MatrixLayout::Order::kColumnMajor)
     return tsl::errors::Internal(
         "HipblasLT does not support row-major matrices");
@@ -167,14 +165,16 @@ tsl::Status BlasLt::Init() {
   VLOG(2) << "BlasLt::MatmulDesc::Create compute_type" << int(compute_type)
           << " scale_type " << int(scale_type) << " epilogue " << int(epilogue)
           << " pointer_mode " << int(pointer_mode);
+  auto hip_scale_type = AsHipblasDataType(scale_type);        
+  auto hip_compute_type = AsHipblasComputeType(compute_type);
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatmulDescCreate(
-      &hip_desc, AsHipblasComputeType(compute_type),
-      AsHipblasDataType(scale_type)));
+      &hip_desc, hip_compute_type, hip_scale_type));
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
-  BlasLt::MatmulDesc desc(hip_desc);
+  BlasLt::MatmulDesc desc(hip_desc, hip_compute_type, hip_scale_type);
   if (pointer_mode != PointerMode::kHost) {
     return tsl::errors::Internal("hipblaslt does not support device pointers");
   }
+
   TF_RETURN_IF_ERROR(SetAttr(hip_desc, HIPBLASLT_MATMUL_DESC_TRANSA,
                              AsHipblasOperation(trans_a)));
   TF_RETURN_IF_ERROR(SetAttr(hip_desc, HIPBLASLT_MATMUL_DESC_TRANSB,

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -24,7 +24,6 @@ limitations under the License.
 
 #include "rocm/rocm_config.h"
 #include "xla/stream_executor/rocm/hip_blas_utils.h"
-#include "xla/stream_executor/rocm/hipblaslt_wrapper.h"
 
 namespace stream_executor {
 
@@ -43,7 +42,7 @@ class BlasLt : public gpu::BlasLt {
   struct MatrixLayout {
     static tsl::StatusOr<MatrixLayout> Create(const gpu::MatrixLayout& m);
 
-    hipblasDatatype_t type() const { return HIPBLAS_R_32F; }
+    hipblasltDatatype_t type() const { return HIPBLASLT_R_32F; }
     hipblasLtMatrixLayout_t get() const { return handle_.get(); }
 
    private:
@@ -65,7 +64,7 @@ class BlasLt : public gpu::BlasLt {
     hipblasLtComputeType_t compute_type() const {
       return HIPBLASLT_COMPUTE_F32;
     }
-    hipblasDatatype_t scale_type() const { return HIPBLAS_R_32F; }
+    hipblasltDatatype_t scale_type() const { return HIPBLASLT_R_32F; }
     hipblasPointerMode_t pointer_mode() const {
       return HIPBLAS_POINTER_MODE_HOST;
     }

--- a/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -32,27 +32,27 @@ tsl::Status ToStatus(hipblasStatus_t status, const char* prefix) {
   return tsl::OkStatus();
 }
 
-hipblasDatatype_t AsHipblasDataType(blas::DataType type) {
+hipblasltDatatype_t AsHipblasDataType(blas::DataType type) {
   switch (type) {
     case blas::DataType::kF8E5M2:
     case blas::DataType::kF8E4M3FN:
       LOG(FATAL) << "hipblaslt does not support F8 yet";
     case blas::DataType::kHalf:
-      return HIPBLAS_R_16F;
+      return HIPBLASLT_R_16F;
     case blas::DataType::kBF16:
-      return HIPBLAS_R_16B;
+      return HIPBLASLT_R_16B;
     case blas::DataType::kFloat:
-      return HIPBLAS_R_32F;
+      return HIPBLASLT_R_32F;
     case blas::DataType::kDouble:
-      return HIPBLAS_R_64F;
+      return HIPBLASLT_R_64F;
     case blas::DataType::kInt8:
-      return HIPBLAS_R_8I;
+      return HIPBLASLT_R_8I;
     case blas::DataType::kInt32:
-      return HIPBLAS_R_32I;
+      return HIPBLASLT_R_32I;
     case blas::DataType::kComplexFloat:
-      return HIPBLAS_C_32F;
+      return HIPBLASLT_C_32F;
     case blas::DataType::kComplexDouble:
-      return HIPBLAS_C_64F;
+      return HIPBLASLT_C_64F;
     default:
       LOG(FATAL) << "unknown data type";
   }

--- a/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/xla/stream_executor/rocm/hip_blas_utils.h
@@ -25,6 +25,18 @@ limitations under the License.
 
 #if TF_HIPBLASLT
 
+#if TF_ROCM_VERSION < 50700
+#define hipblasltDatatype_t hipblasDatatype_t
+#define HIPBLASLT_R_16F HIPBLAS_R_16F
+#define HIPBLASLT_R_16B HIPBLAS_R_16B
+#define HIPBLASLT_R_32F HIPBLAS_R_32F
+#define HIPBLASLT_R_64F HIPBLAS_R_64F
+#define HIPBLASLT_R_8I HIPBLAS_R_8I
+#define HIPBLASLT_R_32I HIPBLAS_R_32I
+#define HIPBLASLT_C_32F HIPBLAS_C_32F
+#define HIPBLASLT_C_64F HIPBLAS_C_64F
+#endif
+
 namespace stream_executor {
 namespace rocm {
 
@@ -32,7 +44,7 @@ namespace rocm {
   TF_RETURN_IF_ERROR(::stream_executor::rocm::ToStatus(expr, #expr))
 
 tsl::Status ToStatus(hipblasStatus_t status, const char* prefix);
-hipblasDatatype_t AsHipblasDataType(blas::DataType type);
+hipblasltDatatype_t AsHipblasDataType(blas::DataType type);
 hipblasLtComputeType_t AsHipblasComputeType(blas::ComputationType type);
 hipblasOperation_t AsHipblasOperation(blas::Transpose trans);
 


### PR DESCRIPTION
In this PR I renamed some files after unified blas-lt API integration: cublas_lt_* -> gpublas_lt_* for consistency.

Also, added macro typedefs to support future rocm versions (where hipblaslt* datatypes are defined),
and some cosmetics to improve code readability..

@akuegel, can you please have a look ? 

with the original commit: https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/fd16e1fe9982ff2df0ce6b3f3fe1330e2f3ded1c

I specifically checked that in TF there are no direct references to cublas_lt_matmul / cublas_lt_matmul_thunk libs, therefore renaming cublas_lt_ -> gpublas_lt_ should not brake TF builds. And another change I made here is local to hip_blas_lt and is already integrated into out ROCm tensorflow fork.