### PR TITLE
[NVIDIA XLA] Use a seperate mutex for callback_stream_map to avoid deadlocks during shutdown.

### DIFF
--- a/xla/pjrt/local_device_state.cc
+++ b/xla/pjrt/local_device_state.cc
@@ -118,6 +118,7 @@ Status LocalDeviceState::SynchronizeAllActivity() {
   // fixed, we could remove the BlockHostUntilDone call.
   status.Update(compute_stream_->BlockHostUntilDone());
   if (callback_stream_map_.has_value()) {
+    absl::MutexLock lock(&callback_stream_map_mu_);
     for (auto& callback_stream : callback_stream_map_.value()) {
       status.Update(callback_stream.second->BlockHostUntilDone());
     }

--- a/xla/pjrt/local_device_state.cc
+++ b/xla/pjrt/local_device_state.cc
@@ -147,7 +147,7 @@ void LocalDeviceState::ThenExecuteCallback(se::Stream* stream,
   tsl::profiler::TraceMe traceme("ThenExecuteCallback");
   if (callback_stream_map_.has_value()) {
     // Prevent concurrent updates to the callback stream map.
-    absl::MutexLock lock(&mu_);
+    absl::MutexLock lock(&callback_stream_map_mu_);
     auto callback_stream = callback_stream_map_->find(stream);
     if (callback_stream == callback_stream_map_->end()) {
       auto new_stream = std::make_unique<se::Stream>(executor_);

--- a/xla/pjrt/local_device_state.h
+++ b/xla/pjrt/local_device_state.h
@@ -227,7 +227,7 @@ class LocalDeviceState {
   // preventing the device-side stream from doing useful work.
   absl::Mutex callback_stream_map_mu_;
   std::optional<absl::flat_hash_map<se::Stream*, std::unique_ptr<se::Stream>>>
-      callback_stream_map_ ABSL_GUARDED_BY(callback_stream_map_mu_);
+      callback_stream_map_;
 
   // A worker thread, used for replicated computation launches.
   std::unique_ptr<WorkerThread> execute_thread_;

--- a/xla/pjrt/local_device_state.h
+++ b/xla/pjrt/local_device_state.h
@@ -225,8 +225,9 @@ class LocalDeviceState {
   // Callback map pairs callback stream with a device stream and is used for
   // running short host-side callbacks after device side events, without
   // preventing the device-side stream from doing useful work.
+  absl::Mutex callback_stream_map_mu_;
   std::optional<absl::flat_hash_map<se::Stream*, std::unique_ptr<se::Stream>>>
-      callback_stream_map_;
+      callback_stream_map_ ABSL_GUARDED_BY(callback_stream_map_mu_);
 
   // A worker thread, used for replicated computation launches.
   std::unique_ptr<WorkerThread> execute_thread_;


### PR DESCRIPTION
In `LocalDeviceState`, currently one mutex `mu_` is used to guard multiple things. In  `ThenExecuteCallback()` it is used to guard `callback_stream_map_` while in `ReturnStreamToPool()` it is used to guard `usage_stream_pool_`.

I have encountered a deadlock during executor shutdown where the mutex is being held by `ThenExecuteCallback()` while it is waiting on `cuEventRecord`. At the same, a cuda callback which runs `ReturnStreamToPool()` is blocked while it waits for the mutex. The stalled cuda callback prevents forward progress on the stream and cuEventRecord is unable to finish.

To fix this, I added a separate mutex for `ThenExecuteCallback` which is only used to guard `callback_stream_map_`, to avoid the false dependency on changes to `usage_stream_pool_`.