### PR TITLE
[ROCm] fixing XLA build brake & enabling cub_sort for ROCm platform

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3,10 +3,10 @@
 
 load("//xla/tests:build_defs.bzl", "xla_test")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//xla:xla.bzl", "xla_cc_test", "xla_cub_deps", "xla_export_hlo_deps")
+load("//xla:xla.bzl", "xla_cc_test", "xla_export_hlo_deps")
 load(
     "//xla/service/gpu:build_defs.bzl",
-    "build_cub_sort_kernels",
+    "build_cub_sort_kernels", 
     "get_cub_sort_kernel_types",
 )
 load(
@@ -253,9 +253,9 @@ cc_library(
     name = "ir_emitter_unnested",
     srcs = ["ir_emitter_unnested.cc"],
     hdrs = ["ir_emitter_unnested.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]) + if_rocm_hipblaslt([
-        "TF_HIPBLASLT=1",
-    ]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]) + 
+                    if_rocm_hipblaslt(["TF_HIPBLASLT=1"]),
     deps = [
         ":backend_configs_cc",
         ":fft_thunk",
@@ -1086,14 +1086,31 @@ cc_library(
 )
 
 cc_library(
+    name = "gpu_prim_hdrs",
+    hdrs = ["gpu_prim.h"],
+    deps = [
+        "@eigen_archive//:eigen3",
+        "@tsl//tsl/platform:bfloat16",
+    ] +    
+    if_cuda_is_configured([
+        "@local_config_cuda//cuda:cub_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocprim",
+    ]),
+)
+
+cc_library(
     name = "cub_sort_thunk",
     srcs = if_gpu_is_configured(["cub_sort_thunk.cc"]),
     hdrs = if_gpu_is_configured(["cub_sort_thunk.h"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
     deps = if_gpu_is_configured([
         ":buffer_allocations",
         ":thunk",
         "@com_google_absl//absl/log:check",
-        "@local_config_cuda//cuda:cuda_headers",
+        ":gpu_prim_hdrs",
         "//xla/service:buffer_assignment",
         "//xla:shape_util",
         "//xla/stream_executor:device_memory",
@@ -1110,7 +1127,8 @@ build_cub_sort_kernels(
     deps = if_gpu_is_configured([
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
-    ] + xla_cub_deps()),
+        ":gpu_prim_hdrs",
+    ]),
 )
 
 cc_library(

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -113,12 +113,10 @@ Status AMDGPUCompiler::OptimizeHloConvolutionCanonicalization(
 
 Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
     HloModule* hlo_module, se::StreamExecutor* stream_exec,
-    const CompileOptions& options, const GpuTargetConfig& gpu_target_config,
-    const AutotuneResults* autotune_results,
+    const CompileOptions& options, const TargetConfig& gpu_target_config,
     tsl::thread::ThreadPool* thread_pool) {
   TF_RETURN_IF_ERROR(GpuCompiler::OptimizeHloPostLayoutAssignment(
-      hlo_module, stream_exec, options, gpu_target_config, autotune_results,
-      thread_pool));
+      hlo_module, stream_exec, options, gpu_target_config, thread_pool));
 
   HloPassPipeline post_pipeline("AMDGPU post-layout_assignment");
 

--- a/xla/service/gpu/amdgpu_compiler.h
+++ b/xla/service/gpu/amdgpu_compiler.h
@@ -40,8 +40,7 @@ class AMDGPUCompiler : public GpuCompiler {
 
   Status OptimizeHloPostLayoutAssignment(
       HloModule* hlo_module, se::StreamExecutor* stream_exec,
-      const CompileOptions& options, const GpuTargetConfig& gpu_target_config,
-      const AutotuneResults* autotune_results,
+      const CompileOptions& options, const TargetConfig& gpu_target_config,
       tsl::thread::ThreadPool* thread_pool) override;
 
   bool RequiresCollectiveScheduleLinearizer(

--- a/xla/service/gpu/build_defs.bzl
+++ b/xla/service/gpu/build_defs.bzl
@@ -31,8 +31,6 @@ def get_cub_sort_kernel_types(name = ""):
         "u64_b32",
         "u64_b64",
     ]
-    # TODO reimplement this using a custom rule in order to include
-    # + if_rocm_is_configured(["bf16"])
 
 def build_cub_sort_kernels(name, types, **kwargs):
     """ Create build rules for all CUB sort kernels.

--- a/xla/service/gpu/build_defs.bzl
+++ b/xla/service/gpu/build_defs.bzl
@@ -2,6 +2,9 @@
 """
 
 load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library")
+load("@local_config_rocm//rocm:build_defs.bzl",
+    "rocm_copts", 
+)
 
 def get_cub_sort_kernel_types(name = ""):
     """ List of supported types for CUB sort kernels.
@@ -28,6 +31,8 @@ def get_cub_sort_kernel_types(name = ""):
         "u64_b32",
         "u64_b64",
     ]
+    # TODO reimplement this using a custom rule in order to include
+    # + if_rocm_is_configured(["bf16"])
 
 def build_cub_sort_kernels(name, types, **kwargs):
     """ Create build rules for all CUB sort kernels.
@@ -36,5 +41,6 @@ def build_cub_sort_kernels(name, types, **kwargs):
         cuda_library(
             name = name + "_" + suffix,
             local_defines = ["CUB_TYPE_" + suffix.upper()],
+            copts = rocm_copts(),
             **kwargs
         )

--- a/xla/service/gpu/cub_sort_kernel.cu.cc
+++ b/xla/service/gpu/cub_sort_kernel.cu.cc
@@ -14,34 +14,43 @@ limitations under the License.
 ==============================================================================*/
 
 #include "xla/service/gpu/cub_sort_kernel.h"
+#include "xla/service/gpu/gpu_prim.h"
 
 #include <cstddef>
 #include <cstdint>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
-#include "cub/device/device_radix_sort.cuh"
 
 namespace xla {
 namespace gpu {
 namespace {
 
+#if GOOGLE_CUDA
+#define CHK_GPU_ERR(err) if(err != cudaSuccess) { \
+      return absl::InvalidArgumentError(  \
+        absl::StrCat("CUB error: ", cudaGetErrorString(err))); \
+    }
+#elif TENSORFLOW_USE_ROCM
+#define CHK_GPU_ERR(err) if(err != hipSuccess) { \
+      return absl::InvalidArgumentError(  \
+        absl::StrCat("HIPCUB error: ", hipGetErrorString(err))); \
+    }
+#endif        
+
+
 template <typename KeyT>
 absl::Status CubSortKeys(void* d_temp_storage, size_t& temp_bytes,
                          const void* d_keys_in, void* d_keys_out,
                          size_t num_items, bool descending) {
-  cudaError_t err =
-      descending
-          ? cub::DeviceRadixSort::SortKeysDescending<KeyT>(
+  auto err = descending
+          ? gpuprim::DeviceRadixSort::SortKeysDescending<KeyT>(
                 d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
                 static_cast<KeyT*>(d_keys_out), num_items)
-          : cub::DeviceRadixSort::SortKeys<KeyT>(
+          : gpuprim::DeviceRadixSort::SortKeys<KeyT>(
                 d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
                 static_cast<KeyT*>(d_keys_out), num_items);
-  if (err != 0) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("CUB error: ", cudaGetErrorString(err)));
-  }
+  CHK_GPU_ERR(err)
   return absl::OkStatus();
 }
 
@@ -50,22 +59,18 @@ absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
                           const void* d_keys_in, void* d_keys_out,
                           const void* d_values_in, void* d_values_out,
                           size_t num_items, bool descending) {
-  cudaError_t err =
-      descending
-          ? cub::DeviceRadixSort::SortPairsDescending<KeyT, ValT>(
+  auto err = descending
+          ? gpuprim::DeviceRadixSort::SortPairsDescending<KeyT, ValT>(
                 d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
                 static_cast<KeyT*>(d_keys_out),
                 static_cast<const ValT*>(d_values_in),
                 static_cast<ValT*>(d_values_out), num_items)
-          : cub::DeviceRadixSort::SortPairs<KeyT, ValT>(
+          : gpuprim::DeviceRadixSort::SortPairs<KeyT, ValT>(
                 d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
                 static_cast<KeyT*>(d_keys_out),
                 static_cast<const ValT*>(d_values_in),
                 static_cast<ValT*>(d_values_out), num_items);
-  if (err != 0) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("CUB error: ", cudaGetErrorString(err)));
-  }
+  CHK_GPU_ERR(err)
   return absl::OkStatus();
 }
 
@@ -91,7 +96,11 @@ absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
 
 // Floating point types.
 #ifdef CUB_TYPE_BF16
+#if GOOGLE_CUDA
 XLA_CUB_DEFINE_SORT_KEYS(bf16, __nv_bfloat16)
+#elif TENSORFLOW_USE_ROCM
+XLA_CUB_DEFINE_SORT_KEYS(bf16, hip_bfloat16)
+#endif
 #endif
 #ifdef CUB_TYPE_F16
 XLA_CUB_DEFINE_SORT_KEYS(f16, __half)

--- a/xla/service/gpu/cub_sort_thunk.cc
+++ b/xla/service/gpu/cub_sort_thunk.cc
@@ -124,6 +124,10 @@ Status CubSortPairsImpl::Run(const Thunk::ExecuteParams& params,
 std::unique_ptr<CubSortRunnerInterface> CreateCubSortRunner(
     PrimitiveType type) {
   switch (type) {
+// #if TENSORFLOW_USE_ROCM    
+//     case BF16:
+//       return std::make_unique<CubSortKeysImpl>(CubSortKeys_bf16, BF16);
+// #endif 
     case F16:
       return std::make_unique<CubSortKeysImpl>(CubSortKeys_f16, F16);
     case F32:

--- a/xla/service/gpu/cub_sort_thunk.cc
+++ b/xla/service/gpu/cub_sort_thunk.cc
@@ -124,10 +124,6 @@ Status CubSortPairsImpl::Run(const Thunk::ExecuteParams& params,
 std::unique_ptr<CubSortRunnerInterface> CreateCubSortRunner(
     PrimitiveType type) {
   switch (type) {
-// #if TENSORFLOW_USE_ROCM    
-//     case BF16:
-//       return std::make_unique<CubSortKeysImpl>(CubSortKeys_bf16, BF16);
-// #endif 
     case F16:
       return std::make_unique<CubSortKeysImpl>(CubSortKeys_f16, F16);
     case F32:

--- a/xla/service/gpu/gpu_prim.h
+++ b/xla/service/gpu/gpu_prim.h
@@ -1,0 +1,119 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+To in writing unless required by applicable law or agreed,
+distributed on an, software distributed under the license is "AS IS"
+BASIS, WITHOUT OF ANY KIND WARRANTIES OR CONDITIONS, either express
+or implied. For the specific language governing permissions and
+limitations under the license, the license you must see.
+==============================================================================*/
+#ifndef XLA_SERVICE_GPU_GPU_PRIM_H_
+#define XLA_SERVICE_GPU_GPU_PRIM_H_
+
+#include "tsl/platform/bfloat16.h"
+
+#if GOOGLE_CUDA
+#include "cub/block/block_load.cuh"
+#include "cub/block/block_scan.cuh"
+#include "cub/block/block_store.cuh"
+#include "cub/device/device_histogram.cuh"
+#include "cub/device/device_radix_sort.cuh"
+#include "cub/device/device_reduce.cuh"
+#include "cub/device/device_scan.cuh"
+#include "cub/device/device_segmented_radix_sort.cuh"
+#include "cub/device/device_segmented_reduce.cuh"
+#include "cub/device/device_select.cuh"
+#include "cub/iterator/counting_input_iterator.cuh"
+#include "cub/iterator/transform_input_iterator.cuh"
+#include "cub/thread/thread_operators.cuh"
+#include "cub/warp/warp_reduce.cuh"
+#include "third_party/gpus/cuda/include/cusparse.h"
+
+namespace gpuprim = ::cub;
+
+// Required for sorting Eigen::half and bfloat16.
+namespace cub {
+template <>
+__device__ __forceinline__ void ThreadStoreVolatilePtr<Eigen::half>(
+    Eigen::half *ptr, Eigen::half val, Int2Type<true> /*is_primitive*/) {
+  *reinterpret_cast<volatile uint16_t *>(ptr) =
+      Eigen::numext::bit_cast<uint16_t>(val);
+}
+
+template <>
+__device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer<Eigen::half>(
+    Eigen::half *ptr, Int2Type<true> /*is_primitive*/) {
+  uint16_t result = *reinterpret_cast<volatile uint16_t *>(ptr);
+  return Eigen::numext::bit_cast<Eigen::half>(result);
+}
+
+template <>
+__device__ __forceinline__ void ThreadStoreVolatilePtr<tsl::bfloat16>(
+    tsl::bfloat16 *ptr, tsl::bfloat16 val,
+    Int2Type<true> /*is_primitive*/) {
+  *reinterpret_cast<volatile uint16_t *>(ptr) =
+      Eigen::numext::bit_cast<uint16_t>(val);
+}
+
+template <>
+__device__ __forceinline__ tsl::bfloat16
+ThreadLoadVolatilePointer<tsl::bfloat16>(tsl::bfloat16 *ptr,
+                                           Int2Type<true> /*is_primitive*/) {
+  uint16_t result = *reinterpret_cast<volatile uint16_t *>(ptr);
+  return Eigen::numext::bit_cast<tsl::bfloat16>(result);
+}
+
+template <>
+struct NumericTraits<Eigen::half>
+    : BaseTraits</*_CATEGORY=*/FLOATING_POINT, /*_PRIMITIVE=*/true,
+                 /*_NULL_TYPE=*/false, /*_UnsignedBits=*/uint16_t,
+                 /*T=*/Eigen::half> {};
+template <>
+struct NumericTraits<tsl::bfloat16>
+    : BaseTraits</*_CATEGORY=*/FLOATING_POINT, /*_PRIMITIVE=*/true,
+                 /*_NULL_TYPE=*/false, /*_UnsignedBits=*/uint16_t,
+                 /*T=*/tsl::bfloat16> {};
+}  // namespace cub
+#elif TENSORFLOW_USE_ROCM
+
+#include "rocm/include/hipcub/hipcub.hpp"
+#include "rocm/rocm_config.h"
+namespace gpuprim = ::hipcub;
+
+// Required for sorting Eigen::half and bfloat16.
+namespace rocprim {
+namespace detail {
+
+#if (TF_ROCM_VERSION >= 50200)
+template <>
+struct float_bit_mask<Eigen::half> {
+  static constexpr uint16_t sign_bit = 0x8000;
+  static constexpr uint16_t exponent = 0x7C00;
+  static constexpr uint16_t mantissa = 0x03FF;
+  using bit_type = uint16_t;
+};
+
+template <>
+struct float_bit_mask<tsl::bfloat16> {
+  static constexpr uint16_t sign_bit = 0x8000;
+  static constexpr uint16_t exponent = 0x7F80;
+  static constexpr uint16_t mantissa = 0x007F;
+  using bit_type = uint16_t;
+};
+#endif
+template <>
+struct radix_key_codec_base<Eigen::half>
+    : radix_key_codec_floating<Eigen::half, uint16_t> {};
+template <>
+struct radix_key_codec_base<tsl::bfloat16>
+    : radix_key_codec_floating<tsl::bfloat16, uint16_t> {};
+};  // namespace detail
+};  // namespace rocprim
+
+#endif  // TENSORFLOW_USE_ROCM
+
+#endif  // XLA_SERVICE_GPU_GPU_PRIM_H_

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1040,32 +1040,6 @@ Status IrEmitterUnnested::EmitConvolutionReorderThunk(mlir::Operation* op) {
   return OkStatus();
 }
 
-Status IrEmitterUnnested::EmitCubDeviceRadixSort(mlir::Operation* op) {
-  auto radix_sort_op = mlir::cast<mlir::lmhlo_gpu::RadixSortOp>(op);
-  if (radix_sort_op.getInputs().size() != 1 &&
-      radix_sort_op.getInputs().size() != 2) {
-    return InternalError("Invalid number of operands for radix sort");
-  }
-
-  TF_ASSIGN_OR_RETURN(std::vector<BufferAllocation::Slice> operands,
-                      GetAllocationSlices(radix_sort_op.getInputs()));
-  TF_ASSIGN_OR_RETURN(std::vector<BufferAllocation::Slice> results,
-                      GetAllocationSlices(radix_sort_op.getOutput()));
-  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice scratch,
-                      GetAllocationSlice(radix_sort_op.getScratch()));
-
-  auto thunk = std::make_unique<CubSortThunk>(
-      Thunk::ThunkInfo::WithProfileAnnotation(op),
-      GetShape(op->getOperand(0)).element_type(),
-      radix_sort_op.getInputs().size() == 2
-          ? std::optional(GetShape(op->getOperand(1)).element_type())
-          : std::nullopt,
-      operands, results, scratch, radix_sort_op.getDescending());
-
-  AddThunkToThunkSequence(std::move(thunk));
-  return OkStatus();
-}
-
 Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
   using mlir::dyn_cast;
   using mlir::lmhlo_gpu::fusedMHAOp;
@@ -1352,6 +1326,33 @@ StatusOr<BufferAllocation::Slice> IrEmitterUnnested::GetAllocationSliceForHlo(
 }
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+Status IrEmitterUnnested::EmitCubDeviceRadixSort(mlir::Operation* op) {
+  auto radix_sort_op = mlir::cast<mlir::lmhlo_gpu::RadixSortOp>(op);
+  if (radix_sort_op.getInputs().size() != 1 &&
+      radix_sort_op.getInputs().size() != 2) {
+    return InternalError("Invalid number of operands for radix sort");
+  }
+
+  TF_ASSIGN_OR_RETURN(std::vector<BufferAllocation::Slice> operands,
+                      GetAllocationSlices(radix_sort_op.getInputs()));
+  TF_ASSIGN_OR_RETURN(std::vector<BufferAllocation::Slice> results,
+                      GetAllocationSlices(radix_sort_op.getOutput()));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice scratch,
+                      GetAllocationSlice(radix_sort_op.getScratch()));
+
+  auto thunk = std::make_unique<CubSortThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(op),
+      GetShape(op->getOperand(0)).element_type(),
+      radix_sort_op.getInputs().size() == 2
+          ? std::optional(GetShape(op->getOperand(1)).element_type())
+          : std::nullopt,
+      operands, results, scratch, radix_sort_op.getDescending());
+
+  AddThunkToThunkSequence(std::move(thunk));
+  return OkStatus();
+}
+
 Status IrEmitterUnnested::EmitCholeskyThunk(mlir::Operation* op) {
   auto cholesky_op = mlir::cast<mlir::lmhlo_gpu::CholeskyOp>(op);
 
@@ -3096,9 +3097,6 @@ Status IrEmitterUnnested::EmitOp(
   if (mlir::isa<mlir::lmhlo_gpu::fusedMHABackwardOp>(op)) {
     return EmitFusedMHABackwardThunk(op);
   }
-  if (mlir::isa<mlir::lmhlo_gpu::RadixSortOp>(op)) {
-    return EmitCubDeviceRadixSort(op);
-  }
 #endif  // GOOGLE_CUDA
 
   if (mlir::isa<mlir::lmhlo_gpu::ConvForwardOp,
@@ -3111,6 +3109,9 @@ Status IrEmitterUnnested::EmitOp(
   }
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  if (mlir::isa<mlir::lmhlo_gpu::RadixSortOp>(op)) {
+    return EmitCubDeviceRadixSort(op);
+  }
   if (mlir::isa<mlir::lmhlo_gpu::CholeskyOp>(op)) {
     if (ir_emitter_context_->emit_ir_from_hlo()) {
       return EmitCholeskyThunk(hlo_for_lmhlo.at(op));

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -146,9 +146,9 @@ class IrEmitterUnnested : public IrEmitter {
           hlo_for_lmhlo);
   Status EmitFusedMHAThunk(mlir::Operation* op);
   Status EmitFusedMHABackwardThunk(mlir::Operation* op);
-  Status EmitCubDeviceRadixSort(mlir::Operation* op);
 #endif  // GOOGLE_CUDA
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  Status EmitCubDeviceRadixSort(mlir::Operation* op);
   Status EmitCholeskyThunk(mlir::Operation* op);
   Status EmitCholeskyThunk(const HloInstruction* instr);
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -183,7 +183,8 @@ cc_library(
     name = "cub_sort",
     srcs = ["cub_sort.cc"],
     hdrs = ["cub_sort.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":support",
         "//xla/runtime:custom_call",
@@ -193,7 +194,7 @@ cc_library(
         "//xla/service:executable",
         "//xla/stream_executor:device_memory",
         "@com_google_absl//absl/status",
-    ] + if_cuda_is_configured([
+    ] + if_gpu_is_configured([
         "//xla/service/gpu:cub_sort_thunk",
     ]),
 )

--- a/xla/service/gpu/runtime/cub_sort.cc
+++ b/xla/service/gpu/runtime/cub_sort.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "xla/service/service_executable_run_options.h"
 #include "xla/stream_executor/device_memory.h"
 
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "xla/service/gpu/cub_sort_thunk.h"
 #endif
 
@@ -41,7 +41,7 @@ using ::xla::runtime::FlatMemrefView;
 absl::Status CubDeviceRadixSortKeysImpl(
     const ServiceExecutableRunOptions* run_options, FlatMemrefView input_view,
     FlatMemrefView output_view, FlatMemrefView scratch_view, bool descending) {
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   return RunCubSort(input_view.dtype, std::nullopt,
                     GetDeviceAddress(input_view), DeviceMemoryBase(),
                     GetDeviceAddress(output_view), DeviceMemoryBase(),
@@ -56,7 +56,7 @@ absl::Status CubDeviceRadixSortPairsImpl(
     FlatMemrefView input_keys_view, FlatMemrefView input_values_view,
     FlatMemrefView output_keys_view, FlatMemrefView output_values_view,
     FlatMemrefView scratch_view, bool descending) {
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   return RunCubSort(
       input_keys_view.dtype, input_values_view.dtype,
       GetDeviceAddress(input_keys_view), GetDeviceAddress(input_values_view),

--- a/xla/service/gpu/runtime/executable.cc
+++ b/xla/service/gpu/runtime/executable.cc
@@ -94,14 +94,13 @@ void RegisterXlaGpuRuntimeCustomCalls(DirectCustomCallRegistry& registry) {
 #if GOOGLE_CUDA
   RegisterFusedAttentionCustomCalls(registry);
   RegisterFusedAttentionBackwardCustomCalls(registry);
-  RegisterCubSortCustomCalls(registry);
 #endif  // GOOGLE_CUDA
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   // Graph launch kernels depend on Cuda Graph API.
   RegisterGraphLaunchCustomCalls(registry);
   RegisterConcurrentRegionCustomCalls(registry);
   RegisterStreamSynchronizationCustomCalls(registry);
-
+  RegisterCubSortCustomCalls(registry);
   RegisterXlaClassicCustomCalls(registry);
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 }

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -699,6 +699,8 @@ xla_cc_test(
     name = "sorting_test",
     srcs = ["sorting_test.cc"],
     tags = tf_cuda_tests_tags(),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",

--- a/xla/service/gpu/tests/sorting_test.cc
+++ b/xla/service/gpu/tests/sorting_test.cc
@@ -189,11 +189,9 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::Values(
             // TODO(b/300112551): upgrade CUB to version 1.13
-// #if TENSORFLOW_USE_ROCM
-//             CreateRandomLiteral<BF16, bfloat16>(
-//               bfloat16(),
-//               Eigen::bfloat16_impl::float_to_bfloat16_rtne<true>(1)),
-// #endif              
+            // CreateRandomLiteral<BF16, bfloat16>(
+            //   bfloat16(),
+            //   Eigen::bfloat16_impl::float_to_bfloat16_rtne<true>(1)),
             CreateRandomLiteral<F16, half>(
                 half(), Eigen::half_impl::float_to_half_rtne(1)),
             CreateRandomLiteral<F32, float>(0, 1),

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -748,6 +748,17 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
                      "hipDrvGraphAddMemcopyNode is not available on ROCm yet"};
 }
 
+/* static */ tsl::Status GpuDriver::GraphAddChildNode(
+    hipGraphNode_t* node, hipGraph_t graph, absl::Span<hipGraphNode_t> deps,
+    hipGraph_t child) {
+  VLOG(2) << "Create a new node by cloning the child graph " << child
+          << " and add it to " << graph << "; deps: " << deps.size();
+
+  RETURN_IF_ROCM_ERROR(
+      wrap::hipGraphAddChildGraphNode(node, graph, deps.data(), deps.size(), child),
+      "Failed to create a child graph node and add it to a HIP graph");
+}
+
 /* static */ tsl::Status GpuDriver::LaunchKernel(
     GpuContext* context, absl::string_view kernel_name, hipFunction_t function,
     unsigned int grid_dim_x, unsigned int grid_dim_y, unsigned int grid_dim_z,

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -99,6 +99,7 @@ namespace wrap {
   __macro(hipGetDeviceProperties)                   \
   __macro(hipGetErrorString)                        \
   __macro(hipGraphAddKernelNode)                    \
+  __macro(hipGraphAddChildGraphNode)                \
   __macro(hipGraphAddMemcpyNode)                    \
   __macro(hipGraphCreate)                           \
   __macro(hipGraphDebugDotPrint)                    \

--- a/xla/xla.bzl
+++ b/xla/xla.bzl
@@ -136,5 +136,3 @@ def xla_export_hlo_deps():
 def xla_nvml_deps():
     return ["@local_config_cuda//cuda:nvml_headers"]
 
-def xla_cub_deps():
-    return ["@local_config_cuda//cuda:cuda_headers"]


### PR DESCRIPTION
This PR fixes XLA build on ROCm platform and also adds support for CUB device sort.
The original offending PR was: https://github.com/openxla/xla/pull/5966/files#diff-35357ad3b3b70062889668b03399a71db3249cd2a01e90e0b0ed8ebe9c817272

Here, I ported gpu_prim.h from Tensorflow repo to be able to use CUB/HIPCUB libraries together. 
Not sure if this is a correct way to do this since now we will have two gpu_prim.h in TF and XLA. 
Possibly, later on, one can remove gpu_prim.h from TF and use the one from XLA only.

Other suggestions are welcome: one can also implement this directly without gpu_prim.h, just using macros.
But I suspect, there will be further CUB additions in XLA where this gpu_prim abstraction might be useful too.

@akuegel, @ddunl could you please have a look at this fix ?
