### PR TITLE
Layer Norm Fusion

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -984,6 +984,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_fused_attention_use_cudnn_rng),
       debug_options->xla_gpu_fused_attention_use_cudnn_rng(),
       "Use cudnn random number generator for fused attention kernel."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_cudnn_layer_norm",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_cudnn_layer_norm),
+      debug_options->xla_gpu_enable_cudnn_layer_norm(),
+      "Rewrite layer norm patterns into cuDNN library call."));
   flag_list->push_back(
       tsl::Flag("xla_gpu_enable_cublaslt",
                 bool_setter_for(&DebugOptions::set_xla_gpu_enable_cublaslt),
@@ -1402,11 +1407,6 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_cub_radix_sort),
       debug_options->xla_gpu_enable_cub_radix_sort(),
       "Enable radix sort using CUB for simple shapes"));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_cudnn_layer_norm",
-      bool_setter_for(&DebugOptions::set_xla_gpu_enable_cudnn_layer_norm),
-      debug_options->xla_gpu_enable_cudnn_layer_norm(),
-      "Rewrite layer norm patterns into cuDNN library call."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -209,6 +209,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_filter_kernels_spilling_registers_on_autotuning(true);
   opts.set_xla_gpu_llvm_verification_level(0);
   opts.set_xla_gpu_enable_cub_radix_sort(true);
+  opts.set_xla_gpu_enable_cudnn_layer_norm(false);
 
   return opts;
 }
@@ -1401,6 +1402,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_cub_radix_sort),
       debug_options->xla_gpu_enable_cub_radix_sort(),
       "Enable radix sort using CUB for simple shapes"));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_cudnn_layer_norm",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_cudnn_layer_norm),
+      debug_options->xla_gpu_enable_cudnn_layer_norm(),
+      "Rewrite layer norm patterns into cuDNN library call."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
+++ b/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
@@ -61,6 +61,7 @@ using mlir::lmhlo_gpu::CublasLtMatmulF8Op;
 using mlir::lmhlo_gpu::CublasLtMatmulOp;
 using mlir::lmhlo_gpu::CudnnConvReorderFilterAndBiasOp;
 using mlir::lmhlo_gpu::CudnnConvReorderFilterOp;
+using mlir::lmhlo_gpu::CudnnNormOp;
 using mlir::lmhlo_gpu::GEMMOp;
 using mlir::lmhlo_gpu::RadixSortOp;
 
@@ -540,6 +541,56 @@ class CholeskyOpLowering : public OpRewritePattern<CholeskyOp> {
   CustomCallDeclarations& custom_calls_;
 };
 
+class NormOpLowering : public OpRewritePattern<CudnnNormOp> {
+ private:
+  static constexpr const char kCustomCallTarget[] = "xla.gpu.norm";
+
+ public:
+  NormOpLowering(MLIRContext* ctx, UidGenerator& uid,
+                 CustomCallDeclarations& custom_calls)
+      : OpRewritePattern<CudnnNormOp>(ctx),
+        uid_(uid),
+        custom_calls_(custom_calls) {}
+
+  LogicalResult matchAndRewrite(CudnnNormOp op,
+                                PatternRewriter& rewriter) const override {
+    // Get or create a Custom Call function declaration.
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    func::FuncOp callee = custom_calls_.GetOrCreate(b, kCustomCallTarget, op);
+
+    // Convert norm to a function call.
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), callee.getName(),
+                                              TypeRange(), op.getOperands());
+
+    // Assign a unique id to this instance of a norm operation.
+    call->setAttr(b.getStringAttr("uid"), b.getI64IntegerAttr(uid_.uid()));
+
+    // Copy backend specific attributes.
+    call->setAttr(b.getStringAttr("norm_algorithm_config"),
+                  op.getAlgorithmConfigAttr());
+    call->setAttr(b.getStringAttr("epsilon"), op.getEpsilonAttr());
+
+    mlir::ArrayAttr array = op.getOperandLayouts();
+    int rank = array.size();
+    SmallVector<int64_t> values;
+    for (auto array_elem : array) {
+      mlir::IntegerAttr attr = array_elem.dyn_cast<mlir::IntegerAttr>();
+      values.push_back(attr.getInt());
+    }
+    call->setAttr(b.getStringAttr("operand_layouts"),
+                  b.getI64TensorAttr(values));
+
+    // Erase the original norm operation.
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+
+ private:
+  UidGenerator& uid_;
+  CustomCallDeclarations& custom_calls_;
+};
+
 using mlir::lmhlo_gpu::fusedMHAOp;
 
 template <typename FusedDotAttentionForward>
@@ -920,6 +971,10 @@ void ConvertLmhloGpuToGpuRuntimePass::runOnOperation() {
   patterns.insert<CudnnConvReorderFilterAndBiasOpLowering>(ctx, custom_calls);
   patterns.insert<CholeskyOpLowering>(ctx, custom_calls);
   patterns.insert<RadixSortOpLowering>(ctx, custom_calls);
+
+  // Each unique Norm operation in the module will get assigned a uid.
+  UidGenerator norm_uid;
+  patterns.insert<NormOpLowering>(ctx, norm_uid, custom_calls);
 
   // Each unique fused_attention operation in the module will get assigned a
   // uid.

--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -329,6 +329,21 @@ def LHLOGPU_AllToAllDoneOp: LHLOGPU_Op<"all_to_all_done"> {
   let arguments = (ins MHLO_Token:$token);
 }
 
+def LHLOGPU_CudnnNormOp : LHLOGPU_Op<"Norm", [AttrSizedOperandSegments]> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$input,
+    Arg<LHLO_Buffer, "", [MemRead]>:$scale,
+    Arg<LHLO_Buffer, "", [MemRead]>:$bias,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$expectation,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$norm_factor,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
+    NormAlgorithmConfigAttr:$algorithm_config,
+    F64Attr:$epsilon,
+    I64ArrayAttr:$operand_layouts
+    );
+}
+
 def LHLOGPU_fusedMHAOp : LHLOGPU_Op<"fMHA", [AttrSizedOperandSegments]> {
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$lhs_bmm1,

--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
@@ -110,6 +110,17 @@ def CublasLtMatmulEpilogue: I32EnumAttr<"CublasLtMatmulEpilogue",
 
 def CublasLtMatmulEpilogueAttr : EnumAttr<LmhloGpuDialect, CublasLtMatmulEpilogue, "epilogue">;
 
+def NormAlgorithmConfigAttr : AttrDef<
+  LmhloGpuDialect, "NormAlgorithmConfig"> {
+  let mnemonic = "norm_algorithm_config";
+  let parameters = (ins
+  "int64_t":$algorithm,
+  "int64_t":$workspace_size
+ );
+  let assemblyFormat = "`<` struct(params) `>`";
+ let summary = "GPU Norm Algorithm configuration";
+}
+
 def FusedMHAAlgorithmConfigAttr : AttrDef<
   LmhloGpuDialect, "FusedMHAAlgorithmConfig"> {
   let mnemonic = "fHMA_algorithm_config";

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3986,7 +3986,7 @@ test_suite(
         # TODO(anlunx): Re-enable when the FFI mechanism is avalable in Thunk-based runtime.
         # copybara:uncomment # "//third_party/py/jax/experimental/jax2tf/tests:primitives_test_gpu",
         # copybara:uncomment "//third_party/py/jax/tests:pmap_test_gpu",
-        # copybara:uncomment "//tests:fft_test_gpu",
+        # copybara:uncomment "//tensorflow/compiler/tests:fft_test_gpu",
         "//xla/python:xla_client_test_gpu",
         "//xla/service/gpu/tests:add_preds.hlo.test",
         "//xla/service/gpu/tests:concat.hlo.test",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -272,6 +272,7 @@ cc_library(
         ":gpu_executable",
         ":gpu_fused_mha_runner",
         ":gpu_fusible",
+        ":gpu_norm_runner",
         ":hlo_fusion_analysis",
         ":hlo_to_ir_bindings",
         ":ir_emission_utils",
@@ -899,6 +900,7 @@ cc_library(
         "gpu_executable.cc",
         "infeed_thunk.cc",
         "kernel_thunk.cc",
+        "norm_thunk.cc",
         "memset_thunk.cc",
         "outfeed_thunk.cc",
         "replica_id_thunk.cc",
@@ -915,6 +917,7 @@ cc_library(
         "gpu_executable.h",
         "infeed_thunk.h",
         "kernel_thunk.h",
+        "norm_thunk.h",
         "memset_thunk.h",
         "outfeed_thunk.h",
         "replica_id_thunk.h",
@@ -934,6 +937,7 @@ cc_library(
         ":gpu_conv_runner",
         ":gpu_executable_run_options",
         ":gpu_fused_mha_runner",
+        ":gpu_norm_runner",
         ":io_feed_manager",
         ":ir_emission_utils",
         ":kernel_arguments",
@@ -1729,6 +1733,31 @@ cc_library(
         "//xla/stream_executor:lazy_op_runner",
         "@com_google_absl//absl/strings",
     ],
+)
+
+cc_library(
+    name = "gpu_norm_runner",
+    srcs = ["gpu_norm_runner.cc"],
+    hdrs = ["gpu_norm_runner.h"],
+    deps = [
+        ":backend_configs_cc",
+        ":cublas_cudnn",
+        ":stream_executor_util",
+        "//xla:shape_util",
+        "//xla:status",
+        "//xla:status_macros",
+        "//xla:statusor",
+        "//xla:types",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/stream_executor",
+        "//xla/stream_executor:dnn",
+        "//xla/stream_executor:lazy_op_runner",
+        "@com_google_absl//absl/strings",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ])
 )
 
 cc_library(
@@ -2868,6 +2897,7 @@ cc_library(
         ":cudnn_fused_conv_rewriter",
         ":cudnn_fused_mha_rewriter",
         ":cudnn_fused_mha_transpose_fusion",
+        ":cudnn_norm_rewriter",
         ":cudnn_pad_for_convolutions",
         ":cudnn_simplify_padding",
         ":cudnn_vectorize_convolutions",
@@ -3478,6 +3508,43 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "cudnn_norm_rewriter",
+    srcs = ["cudnn_norm_rewriter.cc"],
+    hdrs = ["cudnn_norm_rewriter.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    deps = [
+        ":backend_configs_cc",
+        ":cublas_cudnn",
+        "//xla:shape_util",
+        "//xla:window_util",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:hlo_creation_utils",
+        "//xla/service:hlo_pass",
+        "//xla/service:pattern_matcher",
+        "//xla:status",
+] + if_cuda_is_configured([
+            "@local_config_cuda//cuda:cuda_headers",
+            "@local_config_cuda//cuda:cudnn_header",
+        ]),
+    )
+
+xla_cc_test(
+    name = "cudnn_norm_rewriter_test",
+    srcs = ["cudnn_norm_rewriter_test.cc"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    deps = [
+        ":cublas_cudnn",
+        ":cudnn_norm_rewriter",
+        "//xla/service/gpu/tests:gpu_codegen_test",
+        "//xla/tests:filecheck",
+        "@com_google_googletest//:gtest_main",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudnn_header",
+    ]),
+)
+
+cc_library(
     name = "cudnn_fused_mha_rewriter",
     srcs = ["cudnn_fused_mha_rewriter.cc"],
     hdrs = ["cudnn_fused_mha_rewriter.h"],
@@ -3919,7 +3986,7 @@ test_suite(
         # TODO(anlunx): Re-enable when the FFI mechanism is avalable in Thunk-based runtime.
         # copybara:uncomment # "//third_party/py/jax/experimental/jax2tf/tests:primitives_test_gpu",
         # copybara:uncomment "//third_party/py/jax/tests:pmap_test_gpu",
-        # copybara:uncomment "//tensorflow/compiler/tests:fft_test_gpu",
+        # copybara:uncomment "//tests:fft_test_gpu",
         "//xla/python:xla_client_test_gpu",
         "//xla/service/gpu/tests:add_preds.hlo.test",
         "//xla/service/gpu/tests:concat.hlo.test",

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -140,6 +140,15 @@ message FusionBackendConfig {
   ReificationCost reification_cost = 3;
 }
 
+// Backed config for norm executed by cuDNN.
+message CudnnNormBackendConfig {
+  // Epsilon parameter.
+  double epsilon = 1;
+
+  // Opaque algorithm number.
+  stream_executor.dnn.AlgorithmProto algorithm = 2;
+}
+
 // Backend config for a fused Multi-Headed Attention (fMHA) that runs through
 // cudnn.
 message CudnnfMHABackendConfig {

--- a/xla/service/gpu/cublas_cudnn.cc
+++ b/xla/service/gpu/cublas_cudnn.cc
@@ -60,7 +60,7 @@ const absl::string_view kCudnnConvReorderFilterCallTarget =
 const absl::string_view kCudnnConvReorderFilterAndBiasCallTarget =
     "__cudnn$convReorderFilterAndBias";
 
-const absl::string_view kCubDeviceRadixSortTarget = "__cub$DeviceRadixSort";
+const absl::string_view kCudnnNormCallTarget = "__cudnn$norm";
 
 // fMHA forward call targets.
 const absl::string_view kCudnnfMHABmmBmmCallTarget = "__cudnn$fhmaBmmBmm";
@@ -101,6 +101,8 @@ const absl::string_view kCudnnfMHAScaleMaskSoftmaxDropoutBackwardCallTarget =
 const absl::string_view kCudnnfMHASoftmaxDropoutBackwardCallTarget =
     "__cudnn$fhmaSoftmaxDropoutBackward";
 
+const absl::string_view kCubDeviceRadixSortTarget = "__cub$DeviceRadixSort";
+
 bool IsCustomCallToDnnConvolution(const HloInstruction& hlo) {
   if (hlo.opcode() != HloOpcode::kCustomCall) {
     return false;
@@ -122,9 +124,12 @@ bool IsCudnnConvolutionReorder(const HloInstruction& hlo) {
          target == kCudnnConvReorderFilterAndBiasCallTarget;
 }
 
-bool IsCubDeviceRadixSort(const HloInstruction& hlo) {
-  return hlo.opcode() == HloOpcode::kCustomCall &&
-         hlo.custom_call_target() == kCubDeviceRadixSortTarget;
+bool IsCustomCallToDnnNorm(const HloInstruction& hlo) {
+  if (hlo.opcode() != HloOpcode::kCustomCall) {
+    return false;
+  }
+  const auto& target = hlo.custom_call_target();
+  return target == kCudnnNormCallTarget;
 }
 
 bool IsFwdCustomCallTofMHA(const HloInstruction& hlo) {
@@ -172,6 +177,11 @@ bool MHACallHasDropout(const absl::string_view fmha_call_name) {
 
 bool IsCustomCallTofMHA(const HloInstruction& hlo) {
   return (IsFwdCustomCallTofMHA(hlo) || IsBwdCustomCallTofMHA(hlo));
+}
+
+bool IsCubDeviceRadixSort(const HloInstruction& hlo) {
+  return hlo.opcode() == HloOpcode::kCustomCall &&
+         hlo.custom_call_target() == kCubDeviceRadixSortTarget;
 }
 
 StatusOr<CudnnConvKind> GetCudnnConvKind(

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -151,11 +151,11 @@ bool IsCustomCallToDnnConvolution(const HloInstruction& hlo);
 // reordering helper (required for int8x32 convolutions).
 bool IsCudnnConvolutionReorder(const HloInstruction& hlo);
 
-// CUB library calls.
-// Reference: https://nvlabs.github.io/cub/
-extern const absl::string_view kCubDeviceRadixSortTarget;
+// A call to cuDNN for a fused norm.
+extern const absl::string_view kCudnnNormCallTarget;
 
-bool IsCubDeviceRadixSort(const HloInstruction& hlo);
+// Returns true if `hlo` will be implemented as a call to a cuDNN norm kernel.
+bool IsCustomCallToDnnNorm(const HloInstruction& hlo);
 
 // The fused_mha_rewriter phase where each of the MHA signatures are pattern
 // matched and rewritten into a custom-call with specific custom-call target.
@@ -205,6 +205,12 @@ std::string CudnnfMHAKindToString(CudnnfMHAKind kind);
 Status SetFMHAInstructionName(HloModule* module, HloInstruction* fmha);
 
 bool MHACallHasDropout(absl::string_view fmha_call_name);
+
+// CUB library calls.
+// Reference: https://nvlabs.github.io/cub/
+extern const absl::string_view kCubDeviceRadixSortTarget;
+
+bool IsCubDeviceRadixSort(const HloInstruction& hlo);
 }  // namespace gpu
 }  // namespace xla
 

--- a/xla/service/gpu/cudnn_norm_rewriter.cc
+++ b/xla/service/gpu/cudnn_norm_rewriter.cc
@@ -1,0 +1,629 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/cudnn_norm_rewriter.h"
+
+#include <numeric>
+
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/service/hlo_creation_utils.h"
+#include "xla/service/pattern_matcher.h"
+
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cudnn/cudnn.h"
+#endif
+
+namespace xla {
+namespace gpu {
+
+namespace {
+
+namespace m = match;
+
+bool IsReduceAdd(const HloInstruction* instr) {
+  HloComputation* reduce_comp = instr->to_apply();
+  HloInstruction* reduce_comp_root = reduce_comp->root_instruction();
+  return instr->operand_count() == 2 &&
+         instr->operand(1)->opcode() == HloOpcode::kConstant &&
+         ShapeUtil::IsScalar(instr->operand(1)->shape()) &&
+         instr->operand(1)->literal().GetAsDouble({}) == 0. &&
+         reduce_comp_root->opcode() == HloOpcode::kAdd &&
+         reduce_comp_root->operand(0)->opcode() == HloOpcode::kParameter &&
+         reduce_comp_root->operand(1)->opcode() == HloOpcode::kParameter;
+}
+
+bool CompatibleElementType(HloInstruction* instr) {
+  PrimitiveType element_type = instr->shape().element_type();
+  if (element_type == BF16 || element_type == F16 || element_type == F32) {
+    return true;
+  }
+  return false;
+}
+
+StatusOr<int64_t> CConstant(se::CudaComputeCapability cuda_compute_capability) {
+  if (cuda_compute_capability.major == se::CudaComputeCapability::AMPERE) {
+    return 32 * 128;
+  } else if (cuda_compute_capability.major ==
+             se::CudaComputeCapability::HOPPER) {
+    return 32 * 144;
+  }
+  return xla::InternalError(
+      "Norm kernels require Ampere or newer architecture.");
+}
+
+// Matches pattern, convert(pattern), reshape(pattern),
+// convert(reshape(pattern)) and reshape(convert(pattern)).
+template <typename Pattern>
+auto OptionalConvertAndOrReshape(Pattern pattern) {
+  auto shared_subpattern = m::SharedSubpattern(pattern);
+  return m::AnyOf<HloInstruction>(
+      m::Convert(m::Reshape(shared_subpattern)),
+      m::Reshape(m::Convert(shared_subpattern)), m::Convert(shared_subpattern),
+      m::Reshape(shared_subpattern), shared_subpattern);
+}
+
+// Rsqrt with optional convert and/or reshape.
+template <typename Pattern>
+auto Rsqrt(Pattern pattern) {
+  return OptionalConvertAndOrReshape(m::Rsqrt(pattern));
+}
+
+// AddAnyOrder with optional convert and/or reshape.
+template <typename Pattern0, typename Pattern1>
+auto AddAnyOrder(Pattern0 pattern0, Pattern1 pattern1) {
+  return OptionalConvertAndOrReshape(m::AddAnyOrder(pattern0, pattern1));
+}
+
+// Subtract with optional convert and/or reshape.
+template <typename Pattern0, typename Pattern1>
+auto Subtract(Pattern0 pattern0, Pattern1 pattern1) {
+  return OptionalConvertAndOrReshape(m::Subtract(pattern0, pattern1));
+}
+
+// Capturing subtract with optional convert and/or reshape.
+template <typename Pattern0, typename Pattern1>
+auto Subtract(HloInstruction** subtract, Pattern0 pattern0, Pattern1 pattern1) {
+  return OptionalConvertAndOrReshape(m::Subtract(subtract, pattern0, pattern1));
+}
+
+// Multiply with optional convert and/or reshape.
+template <typename Pattern0, typename Pattern1>
+auto MultiplyAnyOrder(Pattern0 pattern0, Pattern1 pattern1) {
+  return OptionalConvertAndOrReshape(m::MultiplyAnyOrder(pattern0, pattern1));
+}
+
+// Capturing multiply with optional convert and/or reshape.
+template <typename Pattern0, typename Pattern1>
+auto MultiplyAnyOrder(HloInstruction** multiply, Pattern0 pattern0,
+                      Pattern1 pattern1) {
+  return OptionalConvertAndOrReshape(
+      m::MultiplyAnyOrder(multiply, pattern0, pattern1));
+}
+
+// Multiplication of pattern by itself with optional convert and/or reshape.
+template <typename Pattern>
+auto Square(Pattern pattern) {
+  return MultiplyAnyOrder(pattern, pattern)
+      .WithPredicate([](const HloInstruction* instr) {
+        return instr->unique_operands().size() == 1;
+      });
+}
+
+// Reduction-addition of pattern with optional convert and/or reshape and
+// constant 0 scalar.
+template <typename Pattern>
+auto ReduceAdd(Pattern pattern) {
+  return OptionalConvertAndOrReshape(
+      m::Reduce(pattern, m::ConstantScalar(0))
+          .WithPredicate(
+              [](const HloInstruction* instr) { return IsReduceAdd(instr); }));
+}
+
+// Capturing reduction-addition of pattern with optional convert and/or reshape
+// and constant 0 scalar.
+template <typename Pattern>
+auto ReduceAdd(HloInstruction** reduction, Pattern pattern) {
+  return OptionalConvertAndOrReshape(
+      m::Reduce(reduction, pattern, m::ConstantScalar(0))
+          .WithPredicate(
+              [](const HloInstruction* instr) { return IsReduceAdd(instr); }));
+}
+
+// Expected value, or mean, with optional broadcast.
+template <typename Pattern>
+auto Expectation(Pattern pattern) {
+  auto shared_subpattern =
+      MultiplyAnyOrder(m::Broadcast(m::ConstantScalar()), ReduceAdd(pattern));
+  return m::AnyOf<HloInstruction>(m::Broadcast(shared_subpattern),
+                                  shared_subpattern);
+}
+
+// Expected value, or mean, with optional broadcast.
+template <typename Pattern>
+auto Expectation(HloInstruction** expectation, Pattern pattern) {
+  auto shared_subpattern = MultiplyAnyOrder(
+      expectation, m::Broadcast(m::ConstantScalar()), ReduceAdd(pattern));
+  return m::AnyOf<HloInstruction>(m::Broadcast(shared_subpattern),
+                                  shared_subpattern);
+}
+
+// Expected value, or mean, with optional broadcast.
+template <typename Pattern>
+auto Expectation(HloInstruction** expectation, HloInstruction** reduction,
+                 Pattern pattern) {
+  auto shared_subpattern =
+      MultiplyAnyOrder(expectation, m::Broadcast(m::ConstantScalar()),
+                       ReduceAdd(reduction, pattern));
+  return m::AnyOf<HloInstruction>(m::Broadcast(shared_subpattern),
+                                  shared_subpattern);
+}
+
+// Variance, expressed as E[(X - E[X])^2] or E[X^2] - E[X]^2 where E is the
+// expecation.
+auto Variance(HloInstruction** input0, HloInstruction** input1) {
+  return m::AnyOf<HloInstruction>(
+      Subtract(Expectation(Square(m::Op(input0))),
+               Square(Expectation(m::Op(input1)))),
+      Expectation(Square(Subtract(m::Op(input0), Expectation(m::Op(input1))))));
+}
+
+// Variance, expressed as E[(X - E[X])^2] or E[X^2] - E[X]^2 where E is the
+// expecation.
+auto Variance(HloInstruction** variance, HloInstruction** expectation,
+              HloInstruction** input0, HloInstruction** input1) {
+  return m::AnyOf<HloInstruction>(
+      Subtract(variance, Expectation(Square(m::Op(input0))),
+               Square(Expectation(expectation, m::Op(input1)))),
+      Expectation(variance,
+                  Square(Subtract(m::Op(input0),
+                                  Expectation(expectation, m::Op(input1))))));
+}
+
+// Reciprocal of the square root of variance + epsilon with optional broadcast.
+auto NormFactor(HloInstruction** input0, HloInstruction** input1,
+                HloInstruction** epsilon) {
+  auto shared_subpattern = Rsqrt(AddAnyOrder(
+      Variance(input0, input1), m::Broadcast(m::ConstantScalar(epsilon))));
+  return m::AnyOf<HloInstruction>(m::Broadcast(shared_subpattern),
+                                  shared_subpattern);
+}
+
+// Reciprocal of the square root of variance + epsilon with optional broadcast.
+auto NormFactor(HloInstruction** input0, HloInstruction** input1,
+                HloInstruction** variance, HloInstruction** expectation,
+                HloInstruction** epsilon) {
+  auto shared_subpattern = m::SharedSubpattern(
+      Rsqrt(AddAnyOrder(Variance(variance, expectation, input0, input1),
+                        m::Broadcast(m::ConstantScalar(epsilon)))));
+  return m::AnyOf<HloInstruction>(m::Broadcast(shared_subpattern),
+                                  shared_subpattern);
+}
+
+// Any order of p0 * p1 * p2.
+template <typename P0, typename P1, typename P2>
+auto MultiplyMultiplyAnyOrder(P0 p0, P1 p1, P2 p2) {
+  return m::AnyOf<HloInstruction>(
+      MultiplyAnyOrder(p0, MultiplyAnyOrder(p1, p2)),
+      MultiplyAnyOrder(p1, MultiplyAnyOrder(p0, p2)),
+      MultiplyAnyOrder(p2, MultiplyAnyOrder(p0, p1)));
+}
+
+// Any order of p0 - p1 + p2.
+template <typename P0, typename P1, typename P2>
+auto SubtractAddAnyOrder(P0 p0, P1 p1, P2 p2) {
+  return m::AnyOf<HloInstruction>(m::AddAnyOrder(m::Subtract(p0, p1), p2),
+                                  m::AddAnyOrder(m::Subtract(p2, p1), p0),
+                                  m::Subtract(m::AddAnyOrder(p0, p2), p1));
+}
+
+// Any order of (p0 - p1) * p2 * p3 + p4.
+template <typename P0, typename P1, typename P2, typename P3, typename P4>
+auto SubtractMultiplyAddAnyOrder(P0 p0, P1 p1, P2 p2, P3 p3, P4 p4) {
+  return m::AnyOf<HloInstruction>(
+      SubtractAddAnyOrder(MultiplyMultiplyAnyOrder(p0, p2, p3),
+                          MultiplyMultiplyAnyOrder(p1, p2, p3), p4),
+      m::AddAnyOrder(MultiplyMultiplyAnyOrder(Subtract(p0, p1), p2, p3), p4));
+}
+
+class CudnnNormRewriterVisitor : public DfsHloRewriteVisitor {
+ public:
+  explicit CudnnNormRewriterVisitor(
+      const se::CudaComputeCapability cuda_compute_capability)
+      : cuda_compute_capability_(cuda_compute_capability) {}
+
+  Status HandleAdd(HloInstruction* instr) override {
+    return MatchLayerNorm(instr);
+  }
+
+  Status HandleSubtract(HloInstruction* instr) override {
+    return MatchLayerNorm(instr);
+  }
+
+  Status HandleDivide(HloInstruction* instr) override {
+    return MatchNormfactor(instr);
+  }
+
+  // Matches and rewrites a layer norm pattern with scale multiplication and
+  // bias addition into a Custom Call to cuDNN. The pattern matching employs
+  // modularity to cover the scope of realizations.
+  Status MatchLayerNorm(HloInstruction* instr) {
+    HloInstruction *input, *input0, *input1, *input2, *epsilon, *scale, *bias,
+        *expectation, *reduce;
+    if (Match(instr,
+              SubtractMultiplyAddAnyOrder(
+                  m::Op(&input),
+                  Expectation(&expectation, &reduce, m::Op(&input0)),
+                  NormFactor(&input1, &input2, &epsilon),
+                  m::Broadcast(m::Op(&scale)), m::Broadcast(m::Op(&bias))))) {
+#if CUDNN_VERSION < 8905
+      // Layer Norm kernels are available with cuDNN 8.9.5 and above.
+      VLOG(1) << "Layer norm Custom Calls require cuDNN 8.9.5.";
+      return OkStatus();
+#endif  // CUDNN_VERSION < 8905
+
+      // Layer norm kernels require Ampere or newer architectures.
+      if (!cuda_compute_capability_.IsAtLeast(
+              se::CudaComputeCapability::AMPERE)) {
+        VLOG(1)
+            << "Layer norm Custom Calls require Ampere or newer architecture.";
+        return OkStatus();
+      }
+
+      // Verify the uniqueness of the inputs.
+      auto is_input = [input](HloInstruction* inputx) -> bool {
+        return inputx->unique_id() == input->unique_id() ||
+               inputx->operand_count() == 1 &&
+                   inputx->operand(0)->unique_id() == input->unique_id();
+      };
+      if (!is_input(input0) || !is_input(input1) || !is_input(input2)) {
+        VLOG(1) << "Layer norm operands not unique.";
+        return OkStatus();
+      }
+
+      // Skip initial convert, if present.
+      if (input->opcode() == HloOpcode::kConvert) {
+        input = input->mutable_operand(0);
+      }
+
+      // Verify the element types. The types and shapes of the scale and bias
+      // must match.
+      if (!CompatibleElementType(input) || !CompatibleElementType(instr) ||
+          !CompatibleElementType(scale) || !CompatibleElementType(bias) ||
+          !ShapeUtil::Equal(scale->shape(), bias->shape())) {
+        VLOG(1) << "Layer norm input types not supported.";
+        return OkStatus();
+      }
+
+      // Verify that the shapes of scale and bias are compatible with the
+      // operation.
+      std::vector<int64_t> norm_dims(reduce->dimensions().begin(),
+                                     reduce->dimensions().end());
+      if (norm_dims.size() != scale->shape().dimensions_size()) {
+        VLOG(1) << "Layer norm input dimensions not supported.";
+        return OkStatus();
+      }
+      for (int i = 0; i < norm_dims.size(); ++i) {
+        if (input->shape().dimensions(norm_dims[i]) !=
+            scale->shape().dimensions(i)) {
+          VLOG(1) << "Layer norm input dimensions not supported.";
+          return OkStatus();
+        }
+      }
+
+      // If necessary, transpose the input so that the dimensions not being
+      // normalized are the leading dimensions.
+      std::vector<int64_t> non_norm_dims;
+      for (int64_t dim = 0; dim < input->shape().rank(); ++dim) {
+        if (std::find(norm_dims.begin(), norm_dims.end(), dim) ==
+            norm_dims.end()) {
+          non_norm_dims.emplace_back(dim);
+        }
+      }
+      std::vector<int64_t> transpose_order = non_norm_dims;
+      transpose_order.insert(transpose_order.end(), norm_dims.begin(),
+                             norm_dims.end());
+
+      bool apply_transpose = false;
+      for (int i = 0; i < transpose_order.size(); ++i) {
+        if (transpose_order[i] != i) {
+          apply_transpose = true;
+          break;
+        }
+      }
+
+      std::optional<HloInstruction*> transpose;
+      std::vector<int64_t> inverse_transpose_order(transpose_order.size());
+      if (apply_transpose) {
+        for (int k = 0; k < transpose_order.size(); ++k) {
+          inverse_transpose_order[transpose_order[k]] = k;
+        }
+
+        std::vector<int64_t> transposed_dims;
+        for (int64_t non_norm_dim : non_norm_dims) {
+          transposed_dims.emplace_back(input->shape().dimensions(non_norm_dim));
+        }
+        for (int64_t norm_dim : norm_dims) {
+          transposed_dims.emplace_back(input->shape().dimensions(norm_dim));
+        }
+        TF_ASSIGN_OR_RETURN(transpose,
+                            MakeTransposeHlo(input, transpose_order));
+      }
+
+      // Combine the dimensions not normalized into the first dimension of the
+      // input as required by cuDNN.
+      std::vector<int64_t> reshaped_dims = {1};
+      for (auto non_norm_dim : non_norm_dims) {
+        reshaped_dims[0] *= input->shape().dimensions(non_norm_dim);
+      }
+      for (auto norm_dim : norm_dims) {
+        reshaped_dims.emplace_back(input->shape().dimensions(norm_dim));
+      }
+      // cuDNN requires tensors to have at least four dimensions.
+      while (reshaped_dims.size() < 4) {
+        reshaped_dims.emplace_back(1);
+      }
+
+      Shape reshaped_shape =
+          ShapeUtil::MakeShape(input->shape().element_type(), reshaped_dims);
+      TF_ASSIGN_OR_RETURN(
+          HloInstruction * reshape,
+          MakeReshapeHlo(reshaped_shape, transpose.value_or(input)));
+
+      // Reshape the scale and bias.
+      std::vector<int64_t> reshaped_scale_dims(reshaped_dims.begin() + 1,
+                                               reshaped_dims.end());
+      // cuDNN requires tensors to have at least four dimensions.
+      while (reshaped_scale_dims.size() < 4) {
+        reshaped_scale_dims.emplace_back(1);
+      }
+      Shape scale_bias_shape = ShapeUtil::MakeShape(
+          scale->shape().element_type(), reshaped_scale_dims);
+      TF_ASSIGN_OR_RETURN(HloInstruction * reshaped_scale,
+                          MakeReshapeHlo(scale_bias_shape, scale));
+      TF_ASSIGN_OR_RETURN(HloInstruction * reshaped_bias,
+                          MakeReshapeHlo(scale_bias_shape, bias));
+
+      CudnnNormBackendConfig backend_config;
+      backend_config.set_epsilon(epsilon->literal().GetAsDouble({}).value());
+      auto* algorithm = backend_config.mutable_algorithm();
+      algorithm->set_algo_id(0);
+      algorithm->set_math_type(se::dnn::AlgorithmProto::TENSOR_OP_MATH);
+      algorithm->set_is_cudnn_frontend(true);
+
+      // Set the workspace size to its upper bound.
+      // TODO(philipphack): Consider autotuning the norm kernels.
+      TF_ASSIGN_OR_RETURN(const int64_t c_constant,
+                          CConstant(cuda_compute_capability_));
+      const int64_t workspace_size =
+          (2 * c_constant * (4 + 256)) + (2 * reshaped_dims[0] * 4) + 64;
+      algorithm->mutable_workspace_size()->set_value(workspace_size);
+
+      // The output of the Custom Call is a tuple, the second element of which
+      // describes the scratch space.
+      Shape custom_call_shape = ShapeUtil::MakeTupleShape(
+          {reshape->shape(), ShapeUtil::MakeShape(U8, {workspace_size})});
+
+      HloInstruction* custom_call =
+          instr->AddInstruction(HloInstruction::CreateCustomCall(
+              custom_call_shape, {reshape, reshaped_scale, reshaped_bias},
+              kCudnnNormCallTarget));
+      TF_RETURN_IF_ERROR(custom_call->set_backend_config(backend_config));
+
+      TF_ASSIGN_OR_RETURN(HloInstruction * gte,
+                          MakeGetTupleElementHlo(custom_call, 0));
+      TF_ASSIGN_OR_RETURN(
+          HloInstruction * inverse_reshape,
+          MakeReshapeHlo(transpose.value_or(instr)->shape(), gte));
+
+      if (!apply_transpose) {
+        TF_RETURN_IF_ERROR(ReplaceInstruction(instr, inverse_reshape));
+      } else {
+        TF_ASSIGN_OR_RETURN(
+            HloInstruction * inverse_transpose,
+            MakeTransposeHlo(inverse_reshape, inverse_transpose_order));
+        TF_RETURN_IF_ERROR(ReplaceInstruction(instr, inverse_transpose));
+      }
+
+      VLOG(1) << "Layer norm rewritten into Custom Call.";
+    }
+
+    return OkStatus();
+  }
+
+  // The layer norm training graph separately contains the expectation as well
+  // as the norm factor and its cube, (variance + epsilon)^-1/2 and (variance +
+  // epsilon)^-3/2. When identified in the graph, these quantities are fused
+  // into the layer norm Custom Call.
+  Status MatchNormfactor(HloInstruction* instr) {
+    HloInstruction *custom_call = nullptr, *input, *input0, *expectation,
+                   *variance, *vairance0, *epsilon, *epsilon0, *gte;
+    if (Match(
+            instr,
+            m::Divide(
+                NormFactor(&input, &input0, &variance, &expectation, &epsilon),
+                AddAnyOrder(m::Op(&vairance0),
+                            m::Broadcast(m::ConstantScalar(&epsilon0)))))) {
+      // Verify the uniqueness of the operands.
+      if (variance->unique_id() != vairance0->unique_id() ||
+          epsilon->unique_id() != epsilon0->unique_id() ||
+          input->unique_id() != input0->unique_id()) {
+        VLOG(1) << "Layer norm operands not unique.";
+        return OkStatus();
+      }
+      if (!CompatibleElementType(instr) ||
+          !CompatibleElementType(expectation)) {
+        VLOG(1) << "Layer norm input types not compatible.";
+        return OkStatus();
+      }
+
+      // A layer norm Custom Call must be another user of input, possibly
+      // separated by a type conversion.
+      if (input->opcode() == HloOpcode::kConvert) {
+        input = input->mutable_operand(0);
+      }
+      for (HloInstruction* user : input->users()) {
+        if ((custom_call = FindLayerNormRecursive(user))) {
+          break;
+        }
+      }
+      if (!custom_call) {
+        VLOG(1) << "Unable to identify layer norm Custom Call.";
+        return OkStatus();
+      }
+
+      // The single user of the Custom Call must be a Get-Tuple-Element
+      // accessing the output.
+      if (custom_call->user_count() == 1 &&
+          custom_call->users()[0]->opcode() == HloOpcode::kGetTupleElement &&
+          custom_call->users()[0]->tuple_index() == 0) {
+        gte = custom_call->users()[0];
+      } else {
+        VLOG(1) << "Incompatible users of layer norm Custom Call.";
+        return OkStatus();
+      }
+
+      auto make_compatible_shape = [](Shape shape) -> Shape {
+        // Eliminate any leading degenerate dimensions.
+        Shape compatible_shape = ShapeUtil::DropDegenerateDimensions(shape);
+        // cuDNN requires tensors to have at least four dimensions.
+        while (compatible_shape.rank() < 4) {
+          ShapeUtil::AppendMinorDimension(1, &compatible_shape);
+        }
+        return compatible_shape;
+      };
+
+      Shape expectation_shape = make_compatible_shape(expectation->shape());
+      Shape norm_factor_shape = make_compatible_shape(instr->shape());
+
+      // The augmented Custom Call additionally returns the expecation and the
+      // norm factor.
+      std::vector<Shape> tuple_shapes = custom_call->shape().tuple_shapes();
+      tuple_shapes.insert(tuple_shapes.begin() + 1,
+                          {expectation_shape, norm_factor_shape});
+
+      Shape custom_call_shape = ShapeUtil::MakeTupleShape(tuple_shapes);
+
+      HloInstruction* new_custom_call = instr->AddInstruction(
+          custom_call->CloneWithNewShape(custom_call_shape));
+
+      // Update the workspace size.
+      TF_ASSIGN_OR_RETURN(const int64_t c_constant,
+                          CConstant(cuda_compute_capability_));
+      const int64_t workspace_size = (2 * c_constant * (4 + 256)) + 32;
+      TF_ASSIGN_OR_RETURN(
+          CudnnNormBackendConfig backend_config,
+          custom_call->backend_config<xla::gpu::CudnnNormBackendConfig>());
+      backend_config.mutable_algorithm()->mutable_workspace_size()->set_value(
+          workspace_size);
+      TF_RETURN_IF_ERROR(custom_call->set_backend_config(backend_config));
+
+      auto replace_with_new_cc = [new_custom_call, this](
+                                     HloInstruction* old_instr,
+                                     int tuple_index) -> Status {
+        TF_ASSIGN_OR_RETURN(
+            HloInstruction * new_gte,
+            MakeGetTupleElementHlo(new_custom_call, tuple_index));
+        HloInstruction* new_instr = new_gte;
+        if (!ShapeUtil::Equal(new_gte->shape(), old_instr->shape())) {
+          TF_ASSIGN_OR_RETURN(new_instr,
+                              MakeReshapeHlo(old_instr->shape(), new_gte));
+        }
+        if (tuple_index != 2) {
+          // Replace the result of the layer norm or the expectation.
+          TF_RETURN_IF_ERROR(ReplaceInstruction(old_instr, new_instr));
+        } else {
+          // Replace the norm factor, (variance + epsilon)^-1/2.
+          TF_RETURN_IF_ERROR(
+              ReplaceInstruction(old_instr->mutable_operand(0), new_instr));
+          // Also replace the norm factor to the power of 3, (variance +
+          // epsilon)^-1/2 / (variance + epsilon) = ((variance +
+          // epsilon)^-1/2)^3.
+          TF_ASSIGN_OR_RETURN(
+              HloInstruction * new_multiply0,
+              MakeBinaryHlo(HloOpcode::kMultiply, new_instr, new_instr));
+          TF_ASSIGN_OR_RETURN(
+              HloInstruction * new_multiply1,
+              MakeBinaryHlo(HloOpcode::kMultiply, new_multiply0, new_instr));
+          TF_RETURN_IF_ERROR(ReplaceInstruction(old_instr, new_multiply1));
+        }
+        return OkStatus();
+      };
+
+      // Replace the result of the original Custom Call as well as the
+      // expectation and the norm factor with the augmented Custom Call.
+      TF_RETURN_IF_ERROR(replace_with_new_cc(gte, 0));
+      TF_RETURN_IF_ERROR(replace_with_new_cc(expectation, 1));
+      TF_RETURN_IF_ERROR(replace_with_new_cc(instr, 2));
+
+      VLOG(1)
+          << "Expectation and norm factor fused into layer norm Custom Call.";
+    }
+    return OkStatus();
+  }
+
+  // Recursively traverses the graph downward across reshapes and transposes,
+  // starting from instr, and returns a pointer to the layer norm Custom Call,
+  // if found. Returns nullptr otherwise.
+  HloInstruction* FindLayerNormRecursive(HloInstruction* instr) {
+    if (Match(instr, m::CustomCall({kCudnnNormCallTarget}))) {
+      return instr;
+    }
+    if (Match(instr, m::AnyOf<HloInstruction>(m::Reshape(), m::Transpose()))) {
+      for (HloInstruction* user : instr->users()) {
+        HloInstruction* custom_call = FindLayerNormRecursive(user);
+        if (custom_call) {
+          return custom_call;
+        }
+      }
+    }
+    return nullptr;
+  }
+
+ private:
+  se::CudaComputeCapability cuda_compute_capability_;
+};
+
+StatusOr<bool> RunOnComputation(
+    HloComputation* computation,
+    se::CudaComputeCapability cuda_compute_capability) {
+  CudnnNormRewriterVisitor visitor(cuda_compute_capability);
+  TF_RETURN_IF_ERROR(computation->Accept(&visitor));
+  return visitor.changed();
+}
+
+}  // anonymous namespace
+
+CudnnNormRewriter::CudnnNormRewriter(
+    se::CudaComputeCapability cuda_compute_capability)
+    : cuda_compute_capability_(cuda_compute_capability) {}
+
+StatusOr<bool> CudnnNormRewriter::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+  for (HloComputation* computation :
+       module->MakeNonfusionComputations(execution_threads)) {
+    TF_ASSIGN_OR_RETURN(
+        bool result, RunOnComputation(computation, cuda_compute_capability_));
+    changed |= result;
+  }
+  return changed;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/cudnn_norm_rewriter.h
+++ b/xla/service/gpu/cudnn_norm_rewriter.h
@@ -1,0 +1,44 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_CUDNN_NORM_REWRITER_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_CUDNN_NORM_REWRITER_H_
+
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/hlo_pass_interface.h"
+
+namespace xla {
+namespace gpu {
+
+class CudnnNormRewriter : public HloModulePass {
+ public:
+  explicit CudnnNormRewriter(
+      const se::CudaComputeCapability cuda_compute_capability);
+  absl::string_view name() const override { return "norm-rewriter"; }
+
+  using HloPassInterface::Run;
+  StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  se::CudaComputeCapability cuda_compute_capability_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_CUDNN_NORM_REWRITER_H_

--- a/xla/service/gpu/cudnn_norm_rewriter.h
+++ b/xla/service/gpu/cudnn_norm_rewriter.h
@@ -23,7 +23,8 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-// Rewrites norm patterns into Custom Calls to the cuDNN library.
+// Rewrites norm patterns into Custom Calls to the cuDNN library. Currently, the
+// forward pass of layer norm patterns is implemented.
 class CudnnNormRewriter : public HloModulePass {
  public:
   explicit CudnnNormRewriter(

--- a/xla/service/gpu/cudnn_norm_rewriter.h
+++ b/xla/service/gpu/cudnn_norm_rewriter.h
@@ -23,6 +23,7 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
+// Rewrites norm patterns into Custom Calls to the cuDNN library.
 class CudnnNormRewriter : public HloModulePass {
  public:
   explicit CudnnNormRewriter(

--- a/xla/service/gpu/cudnn_norm_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_norm_rewriter_test.cc
@@ -56,8 +56,10 @@ TEST_F(CudnnNormRewriterTest, LayerNorm2D1) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }
@@ -123,8 +125,10 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D3) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }
@@ -190,8 +194,10 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D2) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }
@@ -258,8 +264,10 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D12) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }
@@ -326,8 +334,10 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D3IncorrectScaleBroadcast) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }
@@ -381,8 +391,10 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain2D1) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }
@@ -456,8 +468,10 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain4D3) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }
@@ -531,8 +545,10 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain4D12) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
-  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
-      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+  if (!(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::AMPERE) &&
+      !(GetCudaComputeCapability().major ==
+        se::CudaComputeCapability::HOPPER)) {
     GTEST_SKIP()
         << "Layer norm kernels require Ampere or Hopper architectures.";
   }

--- a/xla/service/gpu/cudnn_norm_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_norm_rewriter_test.cc
@@ -1,0 +1,538 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/cudnn_norm_rewriter.h"
+
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cudnn/cudnn.h"
+#endif
+
+#include "tsl/lib/core/status_test_util.h"
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
+#include "xla/tests/filecheck.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class CudnnNormRewriterTest : public GpuCodegenTest {
+ public:
+  se::CudaComputeCapability GetCudaComputeCapability() {
+    return backend()
+        .default_stream_executor()
+        ->GetDeviceDescription()
+        .cuda_compute_capability();
+  }
+
+ protected:
+  void TestNorm(std::string hlo_text, std::string optimized_hlo) {
+    EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
+    MatchOptimizedHlo(hlo_text, optimized_hlo);
+  }
+};
+
+TEST_F(CudnnNormRewriterTest, LayerNorm2N1) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Layer norm kernels require Ampere or newer architecture.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,4] parameter(0)
+        multiply3 = f32[2,4] multiply(input, input)
+        c0 = f32[] constant(0)
+        reduce1 = f32[2] reduce(multiply3, c0), dimensions={1}, to_apply=apply
+        c1 = f32[] constant(0.25)
+        c1_bcast = f32[2] broadcast(c1), dimensions={}
+        multiply9 = f32[2] multiply(reduce1, c1_bcast)
+        reduce = f32[2] reduce(input, c0),dimensions={1}, to_apply=apply
+        multiply8 = f32[2] multiply(reduce, c1_bcast)
+        multiply4 = f32[2] multiply(multiply8, multiply8)
+        subtract = f32[2] subtract(multiply9, multiply4)
+        c2 = f32[] constant(0.001)
+        c2_bcast = f32[2] broadcast(c2), dimensions={}
+        add3 = f32[2] add(subtract, c2_bcast)
+        rsqrt1 = f32[2] rsqrt(add3)
+        broadcast15 = f32[2,4] broadcast(rsqrt1), dimensions={0}
+        broadcast4 = f32[2,4] broadcast(multiply8), dimensions={0}
+        subtract1 = f32[2,4] subtract(input, broadcast4)
+        multiply6 = f32[2,4] multiply(broadcast15, subtract1)
+        scale = f32[4] parameter(1)
+        broadcast17 = f32[2,4] broadcast(scale), dimensions={1}
+        multiply7 = f32[2,4] multiply(multiply6, broadcast17)
+        bias = f32[4] parameter(2)
+        broadcast18 = f32[2,4] broadcast(bias), dimensions={1}
+        ROOT out = f32[2,4] add(multiply7, broadcast18)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,4], scale: f32[4], bias: f32[4]) -> f32[2,4] {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[2,4]{1,0} parameter(0)
+; CHECK-NEXT:    [[P0_BITCAST:%[^ ]+]] = f32[2,4,1,1]{3,2,1,0} bitcast([[P0]])
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[4]{0} parameter(1)
+; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[4,1,1,1]{3,2,1,0} bitcast([[P1]])
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[4]{0} parameter(2)
+; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[4,1,1,1]{3,2,1,0} bitcast([[P2]])
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[2,4,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK:           custom_call_target="__cudnn$norm",
+; CHECK:           backend_config={
+; CHECK-DAG:         "epsilon":0.001
+; CHECK:           }
+; CHECK-NEXT:    [[GTE:%[^ ]+]] = f32[2,4,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
+; CHECK-NEXT:  ROOT [[GTE_BITCAST:%[^ ]+]] = f32[2,4]{1,0} bitcast([[GTE]])
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
+TEST_F(CudnnNormRewriterTest, LayerNorm4D3) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Layer norm kernels require Ampere or newer architecture.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,4,6,8] parameter(0)
+        multiply3 = f32[2,4,6,8] multiply(input, input)
+        c0 = f32[] constant(0)
+        reduce1 = f32[2,4,6] reduce(multiply3, c0), dimensions={3}, to_apply=apply
+        c1 = f32[] constant(0.125)
+        c1_bcast = f32[2,4,6] broadcast(c1), dimensions={}
+        multiply9 = f32[2,4,6] multiply(reduce1, c1_bcast)
+        reduce = f32[2,4,6] reduce(input,c0), dimensions={3}, to_apply=apply
+        multiply8 = f32[2,4,6] multiply(reduce, c1_bcast)
+        multiply4 = f32[2,4,6] multiply(multiply8, multiply8)
+        subtract = f32[2,4,6] subtract(multiply9, multiply4)
+        c2 = f32[] constant(0.001)
+        c2_bcast = f32[2,4,6] broadcast(c2), dimensions={}
+        add3 = f32[2,4,6] add(subtract, c2_bcast)
+        rsqrt1 = f32[2,4,6] rsqrt(add3)
+        broadcast15 = f32[2,4,6,8] broadcast(rsqrt1), dimensions={0,1,2}
+        broadcast4 = f32[2,4,6,8] broadcast(multiply8), dimensions={0,1,2}
+        subtract1 = f32[2,4,6,8] subtract(input, broadcast4)
+        multiply6 = f32[2,4,6,8] multiply(broadcast15, subtract1)
+        scale = f32[8] parameter(1)
+        broadcast17 = f32[2,4,6,8] broadcast(scale), dimensions={3}
+        multiply7 = f32[2,4,6,8] multiply(multiply6, broadcast17)
+        bias = f32[8] parameter(2)
+        broadcast18 = f32[2,4,6,8] broadcast(bias), dimensions={3}
+        ROOT out = f32[2,4,6,8] add(multiply7, broadcast18)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,4,6,8], scale: f32[8], bias: f32[8]) -> f32[2,4,6,8] {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    [[P0_BITCAST:%[^ ]+]] = f32[48,8,1,1]{3,2,1,0} bitcast([[P0]])
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[8]{0} parameter(1)
+; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[8,1,1,1]{3,2,1,0} bitcast([[P1]])
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[8]{0} parameter(2)
+; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[8,1,1,1]{3,2,1,0} bitcast([[P2]])
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[48,8,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK:           custom_call_target="__cudnn$norm",
+; CHECK:           backend_config={
+; CHECK-DAG:         "epsilon":0.001
+; CHECK:           }
+; CHECK-NEXT:    [[GTE:%[^ ]+]] = f32[48,8,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
+; CHECK-NEXT:  ROOT [[GTE_BITCAST:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} bitcast([[GTE]])
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
+TEST_F(CudnnNormRewriterTest, LayerNorm4D2) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Layer norm kernels require Ampere or newer architecture.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,4,6,8] parameter(0)
+        multiply3 = f32[2,4,6,8] multiply(input, input)
+        c0 = f32[] constant(0)
+        reduce1 = f32[2,4,8] reduce(multiply3, c0), dimensions={2}, to_apply=apply
+        c1 = f32[] constant(0.166667)
+        c1_bcast = f32[2,4,8] broadcast(c1), dimensions={}
+        multiply9 = f32[2,4,8] multiply(reduce1, c1_bcast)
+        reduce = f32[2,4,8] reduce(input,c0), dimensions={2}, to_apply=apply
+        multiply8 = f32[2,4,8] multiply(reduce, c1_bcast)
+        multiply4 = f32[2,4,8] multiply(multiply8, multiply8)
+        subtract = f32[2,4,8] subtract(multiply9, multiply4)
+        c2 = f32[] constant(0.001)
+        c2_bcast = f32[2,4,8] broadcast(c2), dimensions={}
+        add3 = f32[2,4,8] add(subtract, c2_bcast)
+        rsqrt1 = f32[2,4,8] rsqrt(add3)
+        broadcast15 = f32[2,4,6,8] broadcast(rsqrt1), dimensions={0,1,3}
+        broadcast4 = f32[2,4,6,8] broadcast(multiply8), dimensions={0,1,3}
+        subtract1 = f32[2,4,6,8] subtract(input, broadcast4)
+        multiply6 = f32[2,4,6,8] multiply(broadcast15, subtract1)
+        scale = f32[6] parameter(1)
+        broadcast17 = f32[2,4,6,8] broadcast(scale), dimensions={2}
+        multiply7 = f32[2,4,6,8] multiply(multiply6, broadcast17)
+        bias = f32[6] parameter(2)
+        broadcast18 = f32[2,4,6,8] broadcast(bias), dimensions={2}
+        ROOT out = f32[2,4,6,8] add(multiply7, broadcast18)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,4,6,8], scale: f32[6], bias: f32[6]) -> f32[2,4,6,8] {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    [[TRANSPOSE:%[^ ]+]] = f32[2,4,8,6]{3,2,1,0} transpose([[P0]]), dimensions={0,1,3,2}
+; CHECK-NEXT:    [[P0_BITCAST:%[^ ]+]] = f32[64,6,1,1]{3,2,1,0} bitcast([[TRANSPOSE]])
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[6]{0} parameter(1)
+; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[6,1,1,1]{3,2,1,0} bitcast([[P1]])
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[6]{0} parameter(2)
+; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[6,1,1,1]{3,2,1,0} bitcast([[P2]])
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[64,6,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK:           custom_call_target="__cudnn$norm",
+; CHECK:           backend_config={
+; CHECK-DAG:         "epsilon":0.001
+; CHECK:           }
+; CHECK-NEXT:    [[GTE:%[^ ]+]] = f32[64,6,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
+; CHECK-NEXT:  ROOT [[FUSION:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} fusion([[GTE]]), kind=kLoop, calls=[[FUSED_COMPUTATION:%[^ ]+]]
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
+TEST_F(CudnnNormRewriterTest, LayerNorm4D12) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Layer norm kernels require Ampere or newer architecture.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,4,6,8] parameter(0)
+        multiply3 = f32[2,4,6,8] multiply(input, input)
+        c0 = f32[] constant(0)
+        reduce1 = f32[2,8] reduce(multiply3, c0), dimensions={1,2}, to_apply=apply
+        c1 = f32[] constant(0.041667)
+        c1_bcast = f32[2,8] broadcast(c1), dimensions={}
+        multiply9 = f32[2,8] multiply(reduce1, c1_bcast)
+        reduce = f32[2,8] reduce(input,c0), dimensions={1,2}, to_apply=apply
+        multiply8 = f32[2,8] multiply(reduce, c1_bcast)
+        multiply4 = f32[2,8] multiply(multiply8, multiply8)
+        subtract = f32[2,8] subtract(multiply9, multiply4)
+        c2 = f32[] constant(0.001)
+        c2_bcast = f32[2,8] broadcast(c2), dimensions={}
+        add3 = f32[2,8] add(subtract,c2_bcast)
+        rsqrt1 = f32[2,8] rsqrt(add3)
+        broadcast15 = f32[2,4,6,8] broadcast(rsqrt1), dimensions={0,3}
+        broadcast4 = f32[2,4,6,8] broadcast(multiply8), dimensions={0,3}
+        subtract1 = f32[2,4,6,8] subtract(input, broadcast4)
+        multiply6 = f32[2,4,6,8] multiply(broadcast15, subtract1)
+        scale = f32[4,6] parameter(1)
+        broadcast17 = f32[2,4,6,8] broadcast(scale), dimensions={1,2}
+        multiply7 = f32[2,4,6,8] multiply(multiply6, broadcast17)
+        bias = f32[4,6] parameter(2)
+        broadcast18 = f32[2,4,6,8] broadcast(bias), dimensions={1,2}
+        ROOT out = f32[2,4,6,8] add(multiply7, broadcast18)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,4,6,8], scale: f32[4,6], bias: f32[4,6]) -> f32[2,4,6,8] {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    [[TRANSPOSE:%[^ ]+]] = f32[2,8,4,6]{3,2,1,0} transpose([[P0]]), dimensions={0,3,1,2}
+; CHECK-NEXT:    [[P0_BITCAST:%[^ ]+]] = f32[16,4,6,1]{3,2,1,0} bitcast([[TRANSPOSE]])
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[4,6]{1,0} parameter(1)
+; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[4,6,1,1]{3,2,1,0} bitcast([[P1]])
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[4,6]{1,0} parameter(2)
+; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[4,6,1,1]{3,2,1,0} bitcast([[P2]])
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[16,4,6,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK:           custom_call_target="__cudnn$norm",
+; CHECK:           backend_config={
+; CHECK-DAG:         "epsilon":0.001
+; CHECK:           }
+; CHECK-NEXT:    [[GTE:%[^ ]+]] = f32[16,4,6,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
+; CHECK-NEXT:  ROOT  [[FUSION:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} fusion([[GTE]]), kind=kLoop, calls=[[FUSED_COMPUTATION:%[^ ]+]]
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
+TEST_F(CudnnNormRewriterTest, LayerNormTrain2D1) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Layer norm kernels require Ampere or newer architecture.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,4] parameter(0)
+        multiply3 = f32[2,4] multiply(input, input)
+        c0 = f32[] constant(0)
+        reduce1 = f32[2] reduce(multiply3, c0), dimensions={1}, to_apply=apply
+        c1 = f32[] constant(0.25)
+        c1_bcast = f32[2] broadcast(c1), dimensions={}
+        multiply9 = f32[2] multiply(reduce1,c1_bcast)
+        reduce = f32[2] reduce(input,c0), dimensions={1}, to_apply=apply
+        multiply8 = f32[2] multiply(reduce,c1_bcast)
+        multiply4 = f32[2] multiply(multiply8,multiply8)
+        subtract = f32[2] subtract(multiply9,multiply4)
+        c2 = f32[] constant(0.001)
+        c2_bcast = f32[2] broadcast(c2), dimensions={}
+        add3 = f32[2] add(subtract,c2_bcast)
+        rsqrt1 = f32[2] rsqrt(add3)
+        broadcast15 = f32[2,4] broadcast(rsqrt1), dimensions={0}
+        broadcast4 = f32[2,4] broadcast(multiply8), dimensions={0}
+        subtract1 = f32[2,4] subtract(input,broadcast4)
+        multiply6 = f32[2,4] multiply(broadcast15,subtract1)
+        scale = f32[4] parameter(1)
+        broadcast17 = f32[2,4] broadcast(scale), dimensions={1}
+        multiply7 = f32[2,4] multiply(multiply6,broadcast17)
+        bias = f32[4] parameter(2)
+        broadcast18 = f32[2,4] broadcast(bias), dimensions={1}
+        add = f32[2,4] add(multiply7,broadcast18)
+        divide = f32[2] divide(rsqrt1, add3)
+        ROOT out = (f32[2,4], f32[2], f32[2], f32[2]) tuple(add, multiply8, divide, rsqrt1)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,4], scale: f32[4], bias: f32[4]) -> (f32[2,4], f32[2], f32[2], f32[2]) {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[2,4]{1,0} parameter(0)
+; CHECK-NEXT:    [[P0_BITCAST:%[^ ]+]] = f32[2,4,1,1]{3,2,1,0} bitcast([[P0]])
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[4]{0} parameter(1)
+; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[4,1,1,1]{3,2,1,0} bitcast([[P1]])
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[4]{0} parameter(2)
+; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[4,1,1,1]{3,2,1,0} bitcast([[P2]])
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[2,4,1,1]{3,2,1,0}, f32[2,1,1,1]{3,2,1,0}, f32[2,1,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK:           custom_call_target="__cudnn$norm",
+; CHECK:           backend_config={
+; CHECK-DAG:         "epsilon":0.001
+; CHECK:           }
+; CHECK-NEXT:    [[GTE0:%[^ ]+]] = f32[2,4,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
+; CHECK-NEXT:    [[GTE0_BITCAST:%[^ ]+]] = f32[2,4]{1,0} bitcast([[GTE0]])
+; CHECK-NEXT:    [[GTE1:%[^ ]+]] = f32[2,1,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=1
+; CHECK-NEXT:    [[GTE1_BITCAST:%[^ ]+]] = f32[2]{0} bitcast([[GTE1]])
+; CHECK-NEXT:    [[GTE2:%[^ ]+]] = f32[2,1,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=2
+; CHECK-NEXT:    [[FUSION:%[^ ]+]] = f32[2]{0} fusion([[GTE2]]), kind=kLoop, calls=[[FUSED_COMPUTATION:%[^ ]+]]
+; CHECK-NEXT:    [[GTE2_BITCAST:%[^ ]+]] = f32[2]{0} bitcast([[GTE2]])
+; CHECK-NEXT:  ROOT [[OUT:%[^ ]+]] = (f32[2,4]{1,0}, f32[2]{0}, f32[2]{0}, f32[2]{0}) tuple([[GTE0_BITCAST]], [[GTE1_BITCAST]], [[FUSION]], [[GTE2_BITCAST]])
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
+TEST_F(CudnnNormRewriterTest, LayerNormTrain4D3) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Layer norm kernels require Ampere or newer architecture.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,4,6,8] parameter(0)
+        multiply3 = f32[2,4,6,8] multiply(input, input)
+        c0 = f32[] constant(0)
+        reduce1 = f32[2,4,6] reduce(multiply3, c0), dimensions={3}, to_apply=apply
+        c1 = f32[] constant(0.125)
+        c1_bcast = f32[2,4,6] broadcast(c1), dimensions={}
+        multiply9 = f32[2,4,6] multiply(reduce1,c1_bcast)
+        reduce = f32[2,4,6] reduce(input,c0), dimensions={3}, to_apply=apply
+        multiply8 = f32[2,4,6] multiply(reduce,c1_bcast)
+        multiply4 = f32[2,4,6] multiply(multiply8,multiply8)
+        subtract = f32[2,4,6] subtract(multiply9,multiply4)
+        c2 = f32[] constant(0.001)
+        c2_bcast = f32[2,4,6] broadcast(c2), dimensions={}
+        add3 = f32[2,4,6] add(subtract,c2_bcast)
+        rsqrt1 = f32[2,4,6] rsqrt(add3)
+        broadcast15 = f32[2,4,6,8] broadcast(rsqrt1), dimensions={0,1,2}
+        broadcast4 = f32[2,4,6,8] broadcast(multiply8), dimensions={0,1,2}
+        subtract1 = f32[2,4,6,8] subtract(input,broadcast4)
+        multiply6 = f32[2,4,6,8] multiply(broadcast15,subtract1)
+        scale = f32[8] parameter(1)
+        broadcast17 = f32[2,4,6,8] broadcast(scale), dimensions={3}
+        multiply7 = f32[2,4,6,8] multiply(multiply6,broadcast17)
+        bias = f32[8] parameter(2)
+        broadcast18 = f32[2,4,6,8] broadcast(bias), dimensions={3}
+        add = f32[2,4,6,8] add(multiply7,broadcast18)
+        divide = f32[2,4,6] divide(rsqrt1, add3)
+        ROOT out = (f32[2,4,6,8], f32[2,4,6], f32[2,4,6], f32[2,4,6]) tuple(add, multiply8, divide, rsqrt1)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,4,6,8], scale: f32[8], bias: f32[8]) -> (f32[2,4,6,8], f32[2,4,6], f32[2,4,6], f32[2,4,6]) {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    [[P0_BITCAST:%[^ ]+]] = f32[48,8,1,1]{3,2,1,0} bitcast([[P0]])
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[8]{0} parameter(1)
+; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[8,1,1,1]{3,2,1,0} bitcast([[P1]])
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[8]{0} parameter(2)
+; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[8,1,1,1]{3,2,1,0} bitcast([[P2]])
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[48,8,1,1]{3,2,1,0}, f32[2,4,6,1]{3,2,1,0}, f32[2,4,6,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK:           custom_call_target="__cudnn$norm",
+; CHECK:           backend_config={
+; CHECK-DAG:         "epsilon":0.001
+; CHECK:           }
+; CHECK-NEXT:    [[GTE0:%[^ ]+]] = f32[48,8,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
+; CHECK-NEXT:    [[GTE0_BITCAST:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} bitcast([[GTE0]])
+; CHECK-NEXT:    [[GTE1:%[^ ]+]] = f32[2,4,6,1]{3,2,1,0} get-tuple-element([[CC]]), index=1
+; CHECK-NEXT:    [[GTE1_BITCAST:%[^ ]+]] = f32[2,4,6]{2,1,0} bitcast([[GTE1]])
+; CHECK-NEXT:    [[GTE2:%[^ ]+]] = f32[2,4,6,1]{3,2,1,0} get-tuple-element([[CC]]), index=2
+; CHECK-NEXT:    [[FUSION:%[^ ]+]] = f32[2,4,6]{2,1,0} fusion([[GTE2]]), kind=kLoop, calls=[[FUSED_COMPUTATION:%[^ ]+]]
+; CHECK-NEXT:    [[GTE2_BITCAST:%[^ ]+]] = f32[2,4,6]{2,1,0} bitcast([[GTE2]])
+; CHECK-NEXT:  ROOT [[OUT:%[^ ]+]] = (f32[2,4,6,8]{3,2,1,0}, f32[2,4,6]{2,1,0}, f32[2,4,6]{2,1,0}, f32[2,4,6]{2,1,0}) tuple([[GTE0_BITCAST]], [[GTE1_BITCAST]], [[FUSION]], [[GTE2_BITCAST]])
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
+TEST_F(CudnnNormRewriterTest, LayerNormTrain4D12) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Layer norm kernels require Ampere or newer architecture.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,4,6,8] parameter(0)
+        multiply3 = f32[2,4,6,8] multiply(input, input)
+        c0 = f32[] constant(0)
+        reduce1 = f32[2,8] reduce(multiply3, c0), dimensions={1,2}, to_apply=apply
+        c1 = f32[] constant(0.041667)
+        c1_bcast = f32[2,8] broadcast(c1), dimensions={}
+        multiply9 = f32[2,8] multiply(reduce1, c1_bcast)
+        reduce = f32[2,8] reduce(input,c0), dimensions={1,2}, to_apply=apply
+        multiply8 = f32[2,8] multiply(reduce, c1_bcast)
+        multiply4 = f32[2,8] multiply(multiply8, multiply8)
+        subtract = f32[2,8] subtract(multiply9, multiply4)
+        c2 = f32[] constant(0.001)
+        c2_bcast = f32[2,8] broadcast(c2), dimensions={}
+        add3 = f32[2,8] add(subtract,c2_bcast)
+        rsqrt1 = f32[2,8] rsqrt(add3)
+        broadcast15 = f32[2,4,6,8] broadcast(rsqrt1), dimensions={0,3}
+        broadcast4 = f32[2,4,6,8] broadcast(multiply8), dimensions={0,3}
+        subtract1 = f32[2,4,6,8] subtract(input, broadcast4)
+        multiply6 = f32[2,4,6,8] multiply(broadcast15, subtract1)
+        scale = f32[4,6] parameter(1)
+        broadcast17 = f32[2,4,6,8] broadcast(scale), dimensions={1,2}
+        multiply7 = f32[2,4,6,8] multiply(multiply6, broadcast17)
+        bias = f32[4,6] parameter(2)
+        broadcast18 = f32[2,4,6,8] broadcast(bias), dimensions={1,2}
+        add = f32[2,4,6,8] add(multiply7, broadcast18)
+        divide = f32[2,8] divide(rsqrt1, add3)
+        ROOT out = (f32[2,4,6,8], f32[2,8], f32[2,8], f32[2,8]) tuple(add, multiply8, divide, rsqrt1)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,4,6,8], scale: f32[4,6], bias: f32[4,6]) -> (f32[2,4,6,8], f32[2,8], f32[2,8], f32[2,8]) {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    [[TRANSPOSE:%[^ ]+]] = f32[2,8,4,6]{3,2,1,0} transpose([[P0]]), dimensions={0,3,1,2}
+; CHECK-NEXT:    [[P0_BITCAST:%[^ ]+]] = f32[16,4,6,1]{3,2,1,0} bitcast([[TRANSPOSE]])
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[4,6]{1,0} parameter(1)
+; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[4,6,1,1]{3,2,1,0} bitcast([[P1]])
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[4,6]{1,0} parameter(2)
+; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[4,6,1,1]{3,2,1,0} bitcast([[P2]])
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[16,4,6,1]{3,2,1,0}, f32[2,8,1,1]{3,2,1,0}, f32[2,8,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK:           custom_call_target="__cudnn$norm",
+; CHECK:           backend_config={
+; CHECK-DAG:         "epsilon":0.001
+; CHECK:           }
+; CHECK-NEXT:    [[GTE0:%[^ ]+]] = f32[16,4,6,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
+; CHECK-NEXT:    [[FUSION0:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} fusion([[GTE0]]), kind=kLoop, calls=[[FUSED_COMPUTATION0:%[^ ]+]]
+; CHECK-NEXT:    [[GTE1:%[^ ]+]] = f32[2,8,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=1
+; CHECK-NEXT:    [[GTE1_BITCAST:%[^ ]+]] = f32[2,8]{1,0} bitcast([[GTE1]])
+; CHECK-NEXT:    [[GTE2:%[^ ]+]] = f32[2,8,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=2
+; CHECK-NEXT:    [[FUSION1:%[^ ]+]] = f32[2,8]{1,0} fusion([[GTE2]]), kind=kLoop, calls=[[FUSED_COMPUTATION1:%[^ ]+]]
+; CHECK-NEXT:    [[GTE2_BITCAST:%[^ ]+]] = f32[2,8]{1,0} bitcast([[GTE2]])
+; CHECK-NEXT:  ROOT [[OUT:%[^ ]+]] = (f32[2,4,6,8]{3,2,1,0}, f32[2,8]{1,0}, f32[2,8]{1,0}, f32[2,8]{1,0}) tuple([[FUSION0]], [[GTE1_BITCAST]], [[FUSION1]], [[GTE2_BITCAST]])
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/cudnn_norm_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_norm_rewriter_test.cc
@@ -75,11 +75,11 @@ TEST_F(CudnnNormRewriterTest, LayerNorm2D1) {
         input_square = f32[2,4] multiply(input, input)
         c0 = f32[] constant(0)
         input_square_sum = f32[2] reduce(input_square, c0), dimensions={1}, to_apply=apply
-        n_elems = f32[] constant(0.25)
-        n_elems_bcast = f32[2] broadcast(n_elems), dimensions={}
-        input_square_mean = f32[2] multiply(input_square_sum, n_elems_bcast)
+        r_nelems = f32[] constant(0.25)
+        r_nelems_bcast = f32[2] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2] multiply(input_square_sum, r_nelems_bcast)
         input_sum = f32[2] reduce(input, c0),dimensions={1}, to_apply=apply
-        input_mean = f32[2] multiply(input_sum, n_elems_bcast)
+        input_mean = f32[2] multiply(input_sum, r_nelems_bcast)
         input_mean_square = f32[2] multiply(input_mean, input_mean)
         variance = f32[2] subtract(input_square_mean, input_mean_square)
         epsilon = f32[] constant(0.001)
@@ -142,11 +142,11 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D3) {
         input_square = f32[2,4,6,8] multiply(input, input)
         c0 = f32[] constant(0)
         input_square_sum = f32[2,4,6] reduce(input_square, c0), dimensions={3}, to_apply=apply
-        n_elems = f32[] constant(0.125)
-        n_elems_bcast = f32[2,4,6] broadcast(n_elems), dimensions={}
-        input_square_mean = f32[2,4,6] multiply(input_square_sum, n_elems_bcast)
+        r_nelems = f32[] constant(0.125)
+        r_nelems_bcast = f32[2,4,6] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2,4,6] multiply(input_square_sum, r_nelems_bcast)
         input_sum = f32[2,4,6] reduce(input, c0), dimensions={3}, to_apply=apply
-        input_mean = f32[2,4,6] multiply(input_sum, n_elems_bcast)
+        input_mean = f32[2,4,6] multiply(input_sum, r_nelems_bcast)
         input_mean_square = f32[2,4,6] multiply(input_mean, input_mean)
         variance = f32[2,4,6] subtract(input_square_mean, input_mean_square)
         epsilon = f32[] constant(0.001)
@@ -209,11 +209,11 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D2) {
         input_square = f32[2,4,6,8] multiply(input, input)
         c0 = f32[] constant(0)
         input_square_sum = f32[2,4,8] reduce(input_square, c0), dimensions={2}, to_apply=apply
-        n_elems = f32[] constant(0.166667)
-        n_elems_bcast = f32[2,4,8] broadcast(n_elems), dimensions={}
-        input_square_mean = f32[2,4,8] multiply(input_square_sum, n_elems_bcast)
+        r_nelems = f32[] constant(0.166667)
+        r_nelems_bcast = f32[2,4,8] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2,4,8] multiply(input_square_sum, r_nelems_bcast)
         reduce = f32[2,4,8] reduce(input, c0), dimensions={2}, to_apply=apply
-        input_mean = f32[2,4,8] multiply(reduce, n_elems_bcast)
+        input_mean = f32[2,4,8] multiply(reduce, r_nelems_bcast)
         input_mean_square = f32[2,4,8] multiply(input_mean, input_mean)
         variance = f32[2,4,8] subtract(input_square_mean, input_mean_square)
         epsilon = f32[] constant(0.001)
@@ -277,11 +277,11 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D12) {
         multiply3 = f32[2,4,6,8] multiply(input, input)
         c0 = f32[] constant(0)
         input_square_sum = f32[2,8] reduce(multiply3, c0), dimensions={1,2}, to_apply=apply
-        n_elems = f32[] constant(0.041667)
-        n_elems_bcast = f32[2,8] broadcast(n_elems), dimensions={}
-        input_square_mean = f32[2,8] multiply(input_square_sum, n_elems_bcast)
+        r_nelems = f32[] constant(0.041667)
+        r_nelems_bcast = f32[2,8] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2,8] multiply(input_square_sum, r_nelems_bcast)
         reduce = f32[2,8] reduce(input, c0), dimensions={1,2}, to_apply=apply
-        input_mean = f32[2,8] multiply(reduce, n_elems_bcast)
+        input_mean = f32[2,8] multiply(reduce, r_nelems_bcast)
         input_mean_square = f32[2,8] multiply(input_mean, input_mean)
         variance = f32[2,8] subtract(input_square_mean, input_mean_square)
         epsilon = f32[] constant(0.001)
@@ -322,6 +322,61 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D12) {
   TestNorm(hlo_text, optimized_hlo);
 }
 
+TEST_F(CudnnNormRewriterTest, LayerNorm4D3IncorrectScaleBroadcast) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
+  GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
+#endif
+  if (!GetCudaComputeCapability().Is(se::CudaComputeCapability::AMPERE) &&
+      !GetCudaComputeCapability().Is(se::CudaComputeCapability::HOPPER)) {
+    GTEST_SKIP()
+        << "Layer norm kernels require Ampere or Hopper architectures.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] add(a,b)
+    }
+
+    ENTRY test {
+        input = f32[2,2,2,2] parameter(0)
+        input_square = f32[2,2,2,2] multiply(input, input)
+        c0 = f32[] constant(0)
+        input_square_sum = f32[2,2,2] reduce(input_square, c0), dimensions={3}, to_apply=apply
+        r_nelems = f32[] constant(0.5)
+        r_nelems_bcast = f32[2,2,2] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2,2,2] multiply(input_square_sum, r_nelems_bcast)
+        input_sum = f32[2,2,2] reduce(input, c0), dimensions={3}, to_apply=apply
+        input_mean = f32[2,2,2] multiply(input_sum, r_nelems_bcast)
+        input_mean_square = f32[2,2,2] multiply(input_mean, input_mean)
+        variance = f32[2,2,2] subtract(input_square_mean, input_mean_square)
+        epsilon = f32[] constant(0.001)
+        epsilon_bcast = f32[2,2,2] broadcast(epsilon), dimensions={}
+        variance_plus_epsilon = f32[2,2,2] add(variance, epsilon_bcast)
+        norm_factor = f32[2,2,2] rsqrt(variance_plus_epsilon)
+        norm_factor_bcast = f32[2,2,2,2] broadcast(norm_factor), dimensions={0,1,2}
+        input_mean_bcast = f32[2,2,2,2] broadcast(input_mean), dimensions={0,1,2}
+        input_center = f32[2,2,2,2] subtract(input, input_mean_bcast)
+        norm = f32[2,2,2,2] multiply(norm_factor_bcast, input_center)
+        scale = f32[2] parameter(1)
+        scale_bcast = f32[2,2,2,2] broadcast(scale), dimensions={2}
+        norm_scale = f32[2,2,2,2] multiply(norm, scale_bcast)
+        bias = f32[2] parameter(2)
+        bias_bcast = f32[2,2,2,2] broadcast(bias), dimensions={3}
+        ROOT out = f32[2,2,2,2] add(norm_scale, bias_bcast)
+    })";
+
+  const char* optimized_hlo = R"(
+
+; CHECK-LABEL: ENTRY %test (input: f32[2,2,2,2], scale: f32[2], bias: f32[2]) -> f32[2,2,2,2] {
+; CHECK-NOT:           custom_call_target="__cudnn$norm"
+  )";
+
+  TestNorm(hlo_text, optimized_hlo);
+}
+
 TEST_F(CudnnNormRewriterTest, LayerNormTrain2D1) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
@@ -345,11 +400,11 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain2D1) {
         multiply3 = f32[2,4] multiply(input, input)
         c0 = f32[] constant(0)
         input_square_sum = f32[2] reduce(multiply3, c0), dimensions={1}, to_apply=apply
-        n_elems = f32[] constant(0.25)
-        n_elems_bcast = f32[2] broadcast(n_elems), dimensions={}
-        input_square_mean = f32[2] multiply(input_square_sum,n_elems_bcast)
+        r_nelems = f32[] constant(0.25)
+        r_nelems_bcast = f32[2] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2] multiply(input_square_sum,r_nelems_bcast)
         reduce = f32[2] reduce(input, c0), dimensions={1}, to_apply=apply
-        input_mean = f32[2] multiply(reduce,n_elems_bcast)
+        input_mean = f32[2] multiply(reduce,r_nelems_bcast)
         input_mean_square = f32[2] multiply(input_mean,input_mean)
         variance = f32[2] subtract(input_square_mean,input_mean_square)
         epsilon = f32[] constant(0.001)
@@ -420,11 +475,11 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain4D3) {
         multiply3 = f32[2,4,6,8] multiply(input, input)
         c0 = f32[] constant(0)
         input_square_sum = f32[2,4,6] reduce(multiply3, c0), dimensions={3}, to_apply=apply
-        n_elems = f32[] constant(0.125)
-        n_elems_bcast = f32[2,4,6] broadcast(n_elems), dimensions={}
-        input_square_mean = f32[2,4,6] multiply(input_square_sum, n_elems_bcast)
+        r_nelems = f32[] constant(0.125)
+        r_nelems_bcast = f32[2,4,6] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2,4,6] multiply(input_square_sum, r_nelems_bcast)
         reduce = f32[2,4,6] reduce(input, c0), dimensions={3}, to_apply=apply
-        input_mean = f32[2,4,6] multiply(reduce, n_elems_bcast)
+        input_mean = f32[2,4,6] multiply(reduce, r_nelems_bcast)
         input_mean_square = f32[2,4,6] multiply(input_mean, input_mean)
         variance = f32[2,4,6] subtract(input_square_mean, input_mean_square)
         epsilon = f32[] constant(0.001)
@@ -454,16 +509,16 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain4D3) {
 ; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[8,1,1,1]{3,2,1,0} bitcast([[P1]])
 ; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[8]{0} parameter(2)
 ; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[8,1,1,1]{3,2,1,0} bitcast([[P2]])
-; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[48,8,1,1]{3,2,1,0}, f32[2,4,6,1]{3,2,1,0}, f32[2,4,6,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[48,8,1,1]{3,2,1,0}, f32[48,1,1,1]{3,2,1,0}, f32[48,1,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
 ; CHECK:           custom_call_target="__cudnn$norm",
 ; CHECK:           backend_config={
 ; CHECK-DAG:         "epsilon":0.001
 ; CHECK:           }
 ; CHECK-NEXT:    [[GTE0:%[^ ]+]] = f32[48,8,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
 ; CHECK-NEXT:    [[GTE0_BITCAST:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} bitcast([[GTE0]])
-; CHECK-NEXT:    [[GTE1:%[^ ]+]] = f32[2,4,6,1]{3,2,1,0} get-tuple-element([[CC]]), index=1
+; CHECK-NEXT:    [[GTE1:%[^ ]+]] = f32[48,1,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=1
 ; CHECK-NEXT:    [[GTE1_BITCAST:%[^ ]+]] = f32[2,4,6]{2,1,0} bitcast([[GTE1]])
-; CHECK-NEXT:    [[GTE2:%[^ ]+]] = f32[2,4,6,1]{3,2,1,0} get-tuple-element([[CC]]), index=2
+; CHECK-NEXT:    [[GTE2:%[^ ]+]] = f32[48,1,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=2
 ; CHECK-NEXT:    [[GTE2_BITCAST:%[^ ]+]] = f32[2,4,6]{2,1,0} bitcast([[GTE2]])
 ; CHECK-NEXT:    [[FUSION:%[^ ]+]] = f32[2,4,6]{2,1,0} fusion([[GTE2]]), kind=kLoop, calls=[[FUSED_COMPUTATION:%[^ ]+]]
 ; CHECK-NEXT:  ROOT [[OUT:%[^ ]+]] = (f32[2,4,6,8]{3,2,1,0}, f32[2,4,6]{2,1,0}, f32[2,4,6]{2,1,0}, f32[2,4,6]{2,1,0}) tuple([[GTE0_BITCAST]], [[GTE1_BITCAST]], [[GTE2_BITCAST]], [[FUSION]])
@@ -495,11 +550,11 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain4D12) {
         multiply3 = f32[2,4,6,8] multiply(input, input)
         c0 = f32[] constant(0)
         input_square_sum = f32[2,8] reduce(multiply3, c0), dimensions={1,2}, to_apply=apply
-        n_elems = f32[] constant(0.041667)
-        n_elems_bcast = f32[2,8] broadcast(n_elems), dimensions={}
-        input_square_mean = f32[2,8] multiply(input_square_sum, n_elems_bcast)
+        r_nelems = f32[] constant(0.041667)
+        r_nelems_bcast = f32[2,8] broadcast(r_nelems), dimensions={}
+        input_square_mean = f32[2,8] multiply(input_square_sum, r_nelems_bcast)
         reduce = f32[2,8] reduce(input, c0), dimensions={1,2}, to_apply=apply
-        input_mean = f32[2,8] multiply(reduce, n_elems_bcast)
+        input_mean = f32[2,8] multiply(reduce, r_nelems_bcast)
         input_mean_square = f32[2,8] multiply(input_mean, input_mean)
         variance = f32[2,8] subtract(input_square_mean, input_mean_square)
         epsilon = f32[] constant(0.001)
@@ -530,16 +585,16 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain4D12) {
 ; CHECK-NEXT:    [[P1_BITCAST:%[^ ]+]] = f32[4,6,1,1]{3,2,1,0} bitcast([[P1]])
 ; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[4,6]{1,0} parameter(2)
 ; CHECK-NEXT:    [[P2_BITCAST:%[^ ]+]] = f32[4,6,1,1]{3,2,1,0} bitcast([[P2]])
-; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[16,4,6,1]{3,2,1,0}, f32[2,8,1,1]{3,2,1,0}, f32[2,8,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
+; CHECK-NEXT:    [[CC:%[^ ]+]] = (f32[16,4,6,1]{3,2,1,0}, f32[16,1,1,1]{3,2,1,0}, f32[16,1,1,1]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[P0_BITCAST]], [[P1_BITCAST]], [[P2_BITCAST]]),
 ; CHECK:           custom_call_target="__cudnn$norm",
 ; CHECK:           backend_config={
 ; CHECK-DAG:         "epsilon":0.001
 ; CHECK:           }
 ; CHECK-NEXT:    [[GTE0:%[^ ]+]] = f32[16,4,6,1]{3,2,1,0} get-tuple-element([[CC]]), index=0
 ; CHECK-NEXT:    [[FUSION0:%[^ ]+]] = f32[2,4,6,8]{3,2,1,0} fusion([[GTE0]]), kind=kLoop, calls=[[FUSED_COMPUTATION0:%[^ ]+]]
-; CHECK-NEXT:    [[GTE1:%[^ ]+]] = f32[2,8,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=1
+; CHECK-NEXT:    [[GTE1:%[^ ]+]] = f32[16,1,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=1
 ; CHECK-NEXT:    [[GTE1_BITCAST:%[^ ]+]] = f32[2,8]{1,0} bitcast([[GTE1]])
-; CHECK-NEXT:    [[GTE2:%[^ ]+]] = f32[2,8,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=2
+; CHECK-NEXT:    [[GTE2:%[^ ]+]] = f32[16,1,1,1]{3,2,1,0} get-tuple-element([[CC]]), index=2
 ; CHECK-NEXT:    [[GTE2_BITCAST:%[^ ]+]] = f32[2,8]{1,0} bitcast([[GTE2]])
 ; CHECK-NEXT:    [[FUSION1:%[^ ]+]] = f32[2,8]{1,0} fusion([[GTE2]]), kind=kLoop, calls=[[FUSED_COMPUTATION1:%[^ ]+]]
 ; CHECK-NEXT:  ROOT [[OUT:%[^ ]+]] = (f32[2,4,6,8]{3,2,1,0}, f32[2,8]{1,0}, f32[2,8]{1,0}, f32[2,8]{1,0}) tuple([[FUSION0]], [[GTE1_BITCAST]], [[GTE2_BITCAST]], [[FUSION1]])

--- a/xla/service/gpu/gpu_norm_runner.cc
+++ b/xla/service/gpu/gpu_norm_runner.cc
@@ -17,16 +17,10 @@ limitations under the License.
 
 #include <vector>
 
-#include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "xla/layout_util.h"
 #include "xla/service/gpu/backend_configs.pb.h"
-#include "xla/shape_util.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/dnn.h"
-#include "xla/util.h"
 
 namespace xla {
 namespace gpu {
@@ -41,12 +35,8 @@ Status RunGpuNorm(const gpu::GpuNormConfig& config,
                   const se::DeviceMemoryBase& scratch_memory,
                   se::Stream* stream, RunNormOptions options) {
   se::dnn::LazyOpRunner<se::dnn::NormOp>* lazy_runner =
-      options.runner_cache->AsNormRunner();
+      options.norm_runner->AsNormRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::NormOp>> local_runner;
-  if (!lazy_runner) {
-    local_runner.emplace(config.algorithm);
-    lazy_runner = &local_runner.value();
-  }
 
   se::dnn::NormOp::Config ln_config{config.epsilon,
                                     config.input_descriptor,

--- a/xla/service/gpu/gpu_norm_runner.cc
+++ b/xla/service/gpu/gpu_norm_runner.cc
@@ -1,0 +1,77 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/gpu_norm_runner.h"
+
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#include "xla/layout_util.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/shape_util.h"
+#include "xla/status_macros.h"
+#include "xla/stream_executor/dnn.h"
+#include "xla/util.h"
+
+namespace xla {
+namespace gpu {
+
+Status RunGpuNorm(const gpu::GpuNormConfig& config,
+                  const se::DeviceMemoryBase& input_buffer,
+                  const se::DeviceMemoryBase& scale_buffer,
+                  const se::DeviceMemoryBase& bias_buffer,
+                  const se::DeviceMemoryBase& output_buffer,
+                  std::optional<se::DeviceMemoryBase> expectation_buffer,
+                  std::optional<se::DeviceMemoryBase> norm_factor_buffer,
+                  const se::DeviceMemoryBase& scratch_memory,
+                  se::Stream* stream, RunNormOptions options) {
+  se::dnn::LazyOpRunner<se::dnn::NormOp>* lazy_runner =
+      options.runner_cache->AsNormRunner();
+  std::optional<se::dnn::LazyOpRunner<se::dnn::NormOp>> local_runner;
+  if (!lazy_runner) {
+    local_runner.emplace(config.algorithm);
+    lazy_runner = &local_runner.value();
+  }
+
+  se::dnn::NormOp::Config ln_config{config.epsilon,
+                                    config.input_descriptor,
+                                    config.scale_descriptor,
+                                    config.bias_descriptor,
+                                    config.output_descriptor,
+                                    config.expectation_descriptor,
+                                    config.norm_factor_descriptor};
+  TF_ASSIGN_OR_RETURN(auto* runner,
+                      lazy_runner->GetOrCreateRunner(ln_config, stream));
+
+  std::vector<se::DeviceMemoryBase> operands;
+  operands.emplace_back(input_buffer);
+  operands.emplace_back(scale_buffer);
+  operands.emplace_back(bias_buffer);
+  operands.emplace_back(output_buffer);
+  if (expectation_buffer) {
+    operands.emplace_back(expectation_buffer.value());
+  }
+  if (norm_factor_buffer) {
+    operands.emplace_back(norm_factor_buffer.value());
+  }
+
+  return (*runner)(stream, options.profile_result, scratch_memory, operands);
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/gpu_norm_runner.h
+++ b/xla/service/gpu/gpu_norm_runner.h
@@ -1,0 +1,144 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_GPU_NORM_RUNNER_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_GPU_NORM_RUNNER_H_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/service/gpu/stream_executor_util.h"
+#include "xla/status.h"
+#include "xla/statusor.h"
+#include "xla/stream_executor/dnn.h"
+#include "xla/stream_executor/lazy_op_runner.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/types.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace gpu {
+
+// Intermediate structure used as input to construct GpuNormConfig.
+struct GpuNormDescriptor {
+  CudnnNormBackendConfig backend_config;
+  Shape input_shape;
+  Shape scale_shape;
+  Shape bias_shape;
+  Shape output_shape;
+  std::optional<Shape> expectation_shape;
+  std::optional<Shape> norm_factor_shape;
+  size_t scratch_size;
+};
+
+// Structure to describe static properties of a fused norm op.
+struct GpuNormConfig {
+  static StatusOr<GpuNormConfig> For(const GpuNormDescriptor& desc) {
+    std::vector<PrimitiveType> output_types;
+
+    GpuNormConfig config;
+    config.epsilon = desc.backend_config.epsilon();
+    config.algorithm = se::dnn::AlgorithmDesc(desc.backend_config.algorithm());
+
+    auto tensor_descriptor_from_shape =
+        [](Shape shape) -> StatusOr<se::dnn::TensorDescriptor> {
+      TF_ASSIGN_OR_RETURN(
+          se::dnn::DataType data_type,
+          GetDNNDataTypeFromPrimitiveType(shape.element_type()));
+      return se::dnn::TensorDescriptor::For(data_type, shape.dimensions(),
+                                            shape.layout().minor_to_major());
+    };
+
+    TF_ASSIGN_OR_RETURN(config.input_descriptor,
+                        tensor_descriptor_from_shape(desc.input_shape));
+    TF_ASSIGN_OR_RETURN(config.scale_descriptor,
+                        tensor_descriptor_from_shape(desc.scale_shape));
+    TF_ASSIGN_OR_RETURN(config.bias_descriptor,
+                        tensor_descriptor_from_shape(desc.bias_shape));
+    TF_ASSIGN_OR_RETURN(config.output_descriptor,
+                        tensor_descriptor_from_shape(desc.output_shape));
+    if (desc.expectation_shape) {
+      TF_ASSIGN_OR_RETURN(
+          config.expectation_descriptor,
+          tensor_descriptor_from_shape(desc.expectation_shape.value()));
+    }
+    if (desc.norm_factor_shape) {
+      TF_ASSIGN_OR_RETURN(
+          config.norm_factor_descriptor,
+          tensor_descriptor_from_shape(desc.norm_factor_shape.value()));
+    }
+    return config;
+  }
+
+  double epsilon;
+  se::dnn::AlgorithmDesc algorithm;
+  se::dnn::TensorDescriptor input_descriptor;
+  se::dnn::TensorDescriptor scale_descriptor;
+  se::dnn::TensorDescriptor bias_descriptor;
+  se::dnn::TensorDescriptor output_descriptor;
+  std::optional<se::dnn::TensorDescriptor> expectation_descriptor;
+  std::optional<se::dnn::TensorDescriptor> norm_factor_descriptor;
+};
+
+class NormRunner {
+ public:
+  NormRunner() = default;
+
+  explicit NormRunner(
+      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::NormOp>> runner)
+      : repr_(std::move(runner)) {}
+
+  explicit NormRunner(const GpuNormConfig& config)
+      : NormRunner(std::make_unique<se::dnn::LazyOpRunner<se::dnn::NormOp>>(
+            config.algorithm)) {}
+
+  se::dnn::AlgorithmDesc ToAlgorithmDesc() const {
+    return repr_->ToAlgorithmDesc();
+  }
+
+  se::dnn::LazyOpRunner<se::dnn::NormOp>* AsNormRunner() { return repr_.get(); }
+
+ private:
+  std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::NormOp>> repr_;
+};
+
+struct RunNormOptions {
+  // Nullable output-parameter pointer for profiling results.
+  se::dnn::ProfileResult* profile_result = nullptr;
+
+  // Use this runner cache (and its configured algorithm), instead of the one
+  // from the instruction.
+  NormRunner* runner_cache;
+};
+
+Status RunGpuNorm(const GpuNormConfig& conv_config,
+                  const se::DeviceMemoryBase& input_buffer,
+                  const se::DeviceMemoryBase& scale_buffer,
+                  const se::DeviceMemoryBase& bias_buffer,
+                  const se::DeviceMemoryBase& output_buffer,
+                  std::optional<se::DeviceMemoryBase> exepctation_buffer,
+                  std::optional<se::DeviceMemoryBase> norm_factor_buffer,
+                  const se::DeviceMemoryBase& scratch_memory,
+                  se::Stream* stream, RunNormOptions options = {});
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_GPU_NORM_RUNNER_H_

--- a/xla/service/gpu/gpu_norm_runner.h
+++ b/xla/service/gpu/gpu_norm_runner.h
@@ -123,9 +123,8 @@ struct RunNormOptions {
   // Nullable output-parameter pointer for profiling results.
   se::dnn::ProfileResult* profile_result = nullptr;
 
-  // Use this runner cache (and its configured algorithm), instead of the one
-  // from the instruction.
-  NormRunner* runner_cache;
+  // Cannot be nullptr.
+  NormRunner* norm_runner;
 };
 
 Status RunGpuNorm(const GpuNormConfig& conv_config,

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -53,30 +53,25 @@ limitations under the License.
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Linker/Linker.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"                 // from @llvm-project
+#include "mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
 #include "mlir/Dialect/Func/Extensions/AllExtensions.h"  // from @llvm-project
-#include "mlir/Dialect/Func/IR/FuncOps.h"                // from @llvm-project
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"              // from @llvm-project
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"             // from @llvm-project
-#include "mlir/Dialect/MemRef/IR/MemRef.h"               // from @llvm-project
-#include "mlir/IR/Attributes.h"                          // from @llvm-project
-#include "mlir/IR/Builders.h"                            // from @llvm-project
-#include "mlir/IR/BuiltinAttributes.h"                   // from @llvm-project
-#include "mlir/IR/BuiltinOps.h"                          // from @llvm-project
-#include "mlir/IR/BuiltinTypes.h"                        // from @llvm-project
-#include "mlir/IR/Operation.h"                           // from @llvm-project
-#include "mlir/IR/Value.h"                               // from @llvm-project
-#include "mlir/IR/ValueRange.h"                          // from @llvm-project
+#include "mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"  // from @llvm-project
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"  // from @llvm-project
+#include "mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
+#include "mlir/IR/Attributes.h"  // from @llvm-project
+#include "mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/IR/BuiltinOps.h"  // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/IR/Operation.h"  // from @llvm-project
+#include "mlir/IR/Value.h"  // from @llvm-project
+#include "mlir/IR/ValueRange.h"  // from @llvm-project
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"  // from @llvm-project
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"  // from @llvm-project
 #include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"  // from @llvm-project
 #include "mlir/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.h"  // from @llvm-project
 #include "mlir/Target/LLVMIR/Export.h"  // from @llvm-project
-#include "tsl/platform/errors.h"
-#include "tsl/platform/human_readable_json.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
-#include "tsl/protobuf/dnn.pb.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/ffi.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
@@ -155,6 +150,11 @@ limitations under the License.
 #include "xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/human_readable_json.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/protobuf/dnn.pb.h"
 
 #if GOOGLE_CUDA || TF_HIPBLASLT
 #include "xla/service/gpu/cub_sort_thunk.h"

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -139,6 +139,7 @@ class IrEmitterUnnested : public IrEmitter {
 #if GOOGLE_CUDA
   Status EmitCublasLtMatmulThunkF8(mlir::Operation* op);
   Status EmitConvolutionReorderThunk(mlir::Operation* op);
+  Status EmitNormThunk(mlir::Operation* op);
   Status EmitTritonFusion(
       const HloFusionAnalysis& hlo_fusion_analysis, mlir::Operation* op,
       const TritonGemmConfig& config,

--- a/xla/service/gpu/norm_thunk.cc
+++ b/xla/service/gpu/norm_thunk.cc
@@ -1,0 +1,103 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/norm_thunk.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "tsl/platform/logging.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/types.h"
+#include "xla/util.h"
+
+namespace xla {
+namespace gpu {
+
+NormThunk::NormThunk(ThunkInfo thunk_info, GpuNormConfig config,
+                     BufferAllocation::Slice input_slice,
+                     BufferAllocation::Slice scale_slice,
+                     BufferAllocation::Slice bias_slice,
+                     BufferAllocation::Slice output_slice,
+                     std::optional<BufferAllocation::Slice> expectation_slice,
+                     std::optional<BufferAllocation::Slice> norm_factor_slice,
+                     BufferAllocation::Slice scratch_slice)
+    : Thunk(Kind::kNorm, thunk_info),
+      input_buffer_(input_slice),
+      scale_buffer_(scale_slice),
+      bias_buffer_(bias_slice),
+      output_buffer_(output_slice),
+      expectation_buffer_(expectation_slice),
+      norm_factor_buffer_(norm_factor_slice),
+      scratch_buffer_(scratch_slice),
+      config_(config) {}
+
+NormRunner& NormThunk::GetOrCreateRunner(
+    const stream_executor::Stream* stream) {
+  absl::MutexLock lock(&mu_);
+  auto it = runner_cache_.find(stream);
+  if (it == runner_cache_.end()) {
+    it = runner_cache_.insert({stream, std::make_unique<NormRunner>(config_)})
+             .first;
+  }
+  return *it->second;
+}
+
+Status NormThunk::ExecuteOnStream(const ExecuteParams& params) {
+  const auto& buffer_allocations = *params.buffer_allocations;
+
+  se::DeviceMemoryBase input_se_buffer =
+      buffer_allocations.GetDeviceAddress(input_buffer_);
+  se::DeviceMemoryBase scale_se_buffer =
+      buffer_allocations.GetDeviceAddress(scale_buffer_);
+  se::DeviceMemoryBase bias_se_buffer =
+      buffer_allocations.GetDeviceAddress(bias_buffer_);
+  se::DeviceMemoryBase output_se_buffer =
+      buffer_allocations.GetDeviceAddress(output_buffer_);
+
+  std::optional<se::DeviceMemoryBase> expectation_se_buffer,
+      norm_factor_se_buffer;
+  if (expectation_buffer_) {
+    expectation_se_buffer =
+        buffer_allocations.GetDeviceAddress(expectation_buffer_.value());
+  }
+  if (norm_factor_buffer_) {
+    norm_factor_se_buffer =
+        buffer_allocations.GetDeviceAddress(norm_factor_buffer_.value());
+  }
+
+  se::DeviceMemoryBase scratch =
+      buffer_allocations.GetDeviceAddress(scratch_buffer_);
+
+  RunNormOptions opts;
+  opts.runner_cache = &GetOrCreateRunner(params.stream);
+
+  TF_RETURN_IF_ERROR(RunGpuNorm(config_, input_se_buffer, scale_se_buffer,
+                                bias_se_buffer, output_se_buffer,
+                                expectation_se_buffer, norm_factor_se_buffer,
+                                scratch, params.stream, opts));
+
+  if (!params.stream->ok()) {
+    return InternalError("NormThunk::ExecuteOnStream failed.");
+  }
+  return OkStatus();
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/norm_thunk.cc
+++ b/xla/service/gpu/norm_thunk.cc
@@ -86,7 +86,7 @@ Status NormThunk::ExecuteOnStream(const ExecuteParams& params) {
       buffer_allocations.GetDeviceAddress(scratch_buffer_);
 
   RunNormOptions opts;
-  opts.runner_cache = &GetOrCreateRunner(params.stream);
+  opts.norm_runner = &GetOrCreateRunner(params.stream);
 
   TF_RETURN_IF_ERROR(RunGpuNorm(config_, input_se_buffer, scale_se_buffer,
                                 bias_se_buffer, output_se_buffer,

--- a/xla/service/gpu/norm_thunk.h
+++ b/xla/service/gpu/norm_thunk.h
@@ -1,0 +1,72 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_NORM_THUNK_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_NORM_THUNK_H_
+
+#include <memory>
+#include <optional>
+
+#include "absl/container/flat_hash_map.h"
+#include "tsl/platform/status.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/buffer_assignment.h"
+#include "xla/service/gpu/buffer_allocations.h"
+#include "xla/service/gpu/gpu_executable.h"
+#include "xla/service/gpu/gpu_norm_runner.h"
+#include "xla/service/gpu/thunk.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/types.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace gpu {
+
+class NormThunk : public Thunk {
+ public:
+  NormThunk(ThunkInfo thunk_info, GpuNormConfig config,
+            BufferAllocation::Slice input, BufferAllocation::Slice scale,
+            BufferAllocation::Slice bias, BufferAllocation::Slice output,
+            std::optional<BufferAllocation::Slice> expectation,
+            std::optional<BufferAllocation::Slice> norm_factor,
+            BufferAllocation::Slice scratch);
+
+  NormThunk(const NormThunk&) = delete;
+  NormThunk& operator=(const NormThunk&) = delete;
+
+  Status ExecuteOnStream(const ExecuteParams& params) override;
+
+ private:
+  BufferAllocation::Slice input_buffer_;
+  BufferAllocation::Slice scale_buffer_;
+  BufferAllocation::Slice bias_buffer_;
+  BufferAllocation::Slice output_buffer_;
+  std::optional<BufferAllocation::Slice> expectation_buffer_;
+  std::optional<BufferAllocation::Slice> norm_factor_buffer_;
+  BufferAllocation::Slice scratch_buffer_;
+  NormRunner& GetOrCreateRunner(const stream_executor::Stream*);
+
+  GpuNormConfig config_;
+  absl::Mutex mu_;
+  absl::flat_hash_map<const stream_executor::Stream*,
+                      std::unique_ptr<NormRunner>>
+      runner_cache_ ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_NORM_THUNK_H_

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -29,6 +29,11 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Support/SourceMgr.h"
+#include "tsl/platform/path.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/profiler/lib/traceme.h"
+#include "tsl/util/env_var.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/algebraic_simplifier.h"
 #include "xla/service/call_inliner.h"
@@ -46,6 +51,7 @@ limitations under the License.
 #include "xla/service/gpu/cudnn_fused_conv_rewriter.h"
 #include "xla/service/gpu/cudnn_fused_mha_rewriter.h"
 #include "xla/service/gpu/cudnn_fused_mha_transpose_fusion.h"
+#include "xla/service/gpu/cudnn_norm_rewriter.h"
 #include "xla/service/gpu/cudnn_pad_for_convolutions.h"
 #include "xla/service/gpu/cudnn_simplify_padding.h"
 #include "xla/service/gpu/cudnn_vectorize_convolutions.h"
@@ -81,11 +87,6 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor_internal.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
-#include "tsl/platform/path.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
-#include "tsl/profiler/lib/traceme.h"
-#include "tsl/util/env_var.h"
 
 namespace xla {
 namespace gpu {
@@ -245,6 +246,9 @@ Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
     mha_fusion_pipeline.AddPass<HloCSE>(/*is_layout_sensitive=*/true);
     TF_RETURN_IF_ERROR(mha_fusion_pipeline.Run(hlo_module).status());
   }
+
+  // Rewrite normalization patterns into cuDNN Custom Calls.
+  pre_pipeline.AddPass<CudnnNormRewriter>(cuda_compute_capability);
 
   pre_pipeline.AddPass<DotDimensionMerger>();
 

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -141,6 +141,45 @@ cc_library(
 )
 
 cc_library(
+    name = "conv_reorder",
+    srcs = ["conv_reorder.cc"],
+    hdrs = ["conv_reorder.h"],
+    deps = [
+        ":support",
+        "//xla:xla_proto_cc",
+        "//xla/runtime:custom_call",
+        "//xla/runtime:custom_call_registry",
+        "//xla/runtime:executable",
+        "//xla/service:executable",
+    ],
+)
+
+cc_library(
+    name = "norm",
+    srcs = ["norm.cc"],
+    hdrs = ["norm.h"],
+    deps = [
+        ":support",
+        "//xla:status",
+        "//xla:xla_proto_cc",
+        "//xla/mlir/runtime/transforms:custom_call_encoding",
+        "//xla/runtime:custom_call",
+        "//xla/runtime:custom_call_registry",
+        "//xla/runtime:executable",
+        "//xla/service:executable",
+        "//xla/service/gpu:gpu_asm_opts_util",
+        "//xla/service/gpu:gpu_norm_runner",
+        "//xla/stream_executor:device_memory",
+        "//xla/stream_executor:device_memory_allocator",
+        "//xla/translate/mhlo_to_hlo:attribute_exporter",
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/functional:function_ref",
+        "@com_google_absl//absl/synchronization",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "fused_attention",
     srcs = ["fused_attention.cc"],
     hdrs = ["fused_attention.h"],
@@ -165,19 +204,6 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "conv_reorder",
-    srcs = ["conv_reorder.cc"],
-    hdrs = ["conv_reorder.h"],
-    deps = [
-        ":support",
-        "//xla:xla_proto_cc",
-        "//xla/runtime:custom_call",
-        "//xla/runtime:custom_call_registry",
-        "//xla/runtime:executable",
-        "//xla/service:executable",
-    ],
-)
 
 cc_library(
     name = "cub_sort",
@@ -253,6 +279,7 @@ cc_library(
         ":graph_launch",
         ":io_feed",
         ":kernel_launch",
+        ":norm",
         ":memcpy",
         ":memset",
         ":send_recv",

--- a/xla/service/gpu/runtime/executable.cc
+++ b/xla/service/gpu/runtime/executable.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/container/inlined_vector.h"
+#include "tsl/protobuf/dnn.pb.h"
 #include "xla/mlir/runtime/transforms/compilation_pipeline_gpu.h"
 #include "xla/runtime/executable.h"
 #include "xla/runtime/jit_executable.h"
@@ -43,6 +44,7 @@ limitations under the License.
 #include "xla/service/gpu/runtime/io_feed.h"
 #include "xla/service/gpu/runtime/memcpy.h"
 #include "xla/service/gpu/runtime/memset.h"
+#include "xla/service/gpu/runtime/norm.h"
 #include "xla/service/gpu/runtime/send_recv.h"
 #include "xla/service/gpu/runtime/stream_synchronization.h"
 #include "xla/service/gpu/runtime/support.h"
@@ -53,7 +55,6 @@ limitations under the License.
 #include "xla/service/stream_pool.h"
 #include "xla/statusor.h"
 #include "xla/stream_executor/stream.h"
-#include "tsl/protobuf/dnn.pb.h"
 
 namespace xla {
 namespace gpu {
@@ -92,6 +93,7 @@ void RegisterXlaGpuRuntimeCustomCalls(DirectCustomCallRegistry& registry) {
   RegisterMatmulCustomCalls(registry);
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if GOOGLE_CUDA
+  RegisterNormCustomCalls(registry);
   RegisterFusedAttentionCustomCalls(registry);
   RegisterFusedAttentionBackwardCustomCalls(registry);
 #endif  // GOOGLE_CUDA
@@ -120,6 +122,7 @@ void RegisterXlaGpuTypeIdNames(TypeIDNameRegistry& registry) {
   registry.Register<Tagged<se::gpu::BlasLt::Epilogue>>(
       "__type_id_se_gpublas_lt_epilogue");
   RegisterFusedAttentionTypeIdNames(registry);
+  RegisterNormTypeIdNames(registry);
 #endif  // GOOGLE_CUDA || TF_HIPBLASLT
 }
 
@@ -134,6 +137,7 @@ void RegisterXlaGpuAttrEncoding(CustomCallAttrEncodingSet& encoding) {
   PopulateFusedAttentionAlgorithmConfigAttrEncoding(encoding);
   PopulateFusedAttentionForwardDAGSignatureAttrEncoding(encoding);
   PopulateFusedAttentionBackwardDAGSignatureAttrEncoding(encoding);
+  PopulateNormAlgorithmConfigAttrEncoding(encoding);
 #endif  // GOOGLE_CUDA || TF_HIPBLASLT
 }
 
@@ -410,6 +414,8 @@ Status GpuRuntimeExecutable::Execute(
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  StreamExecutorNormRunners::Snapshot norm_runners =
+      norm_runners_(executor)->snapshot();
   StreamExecutorFusedAttentionRunners::Snapshot fused_attention_runners =
       fused_attention_runners_(executor)->snapshot();
   StreamExecutorFusedAttentionBackwardRunners::Snapshot
@@ -428,7 +434,8 @@ Status GpuRuntimeExecutable::Execute(
 #if GOOGLE_CUDA
       // Auxiliary data that is available only if compiled with CUDA support
       // only.
-      &fused_attention_runners, &fused_attention_backward_runners,
+      &norm_runners, &fused_attention_runners,
+      &fused_attention_backward_runners,
 #endif  // GOOGLE_CUDA
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
       &graph_instances, &execution_count,

--- a/xla/service/gpu/runtime/executable.h
+++ b/xla/service/gpu/runtime/executable.h
@@ -37,6 +37,7 @@ limitations under the License.
 #include "xla/service/gpu/runtime/gpublas_lt_matmul.h"
 #include "xla/service/gpu/runtime/graph_launch.h"
 #include "xla/service/gpu/runtime/kernel_launch.h"
+#include "xla/service/gpu/runtime/norm.h"
 #include "xla/service/service_executable_run_options.h"
 #include "xla/xla.pb.h"
 
@@ -162,6 +163,10 @@ class GpuRuntimeExecutable {
 
   // Keep a cache for conv configs for all conv operations in the program.
   ConvRunners conv_runners_;
+
+  // Keep a cache for fused norm configs for all fused norm operations in the
+  // program.
+  NormRunnerStates norm_runners_;
 
   // Keep a cache for fused_dot_attention configs for all fused_dot_attention
   // operations in the program.

--- a/xla/service/gpu/runtime/norm.cc
+++ b/xla/service/gpu/runtime/norm.cc
@@ -183,7 +183,7 @@ static absl::Status NormImpl(const ServiceExecutableRunOptions* run_options,
   se::DeviceMemoryBase scratch_buffer = GetDeviceAddress(scratch.value());
 
   RunNormOptions opts;
-  opts.runner_cache = &current_runner.value()->runner;
+  opts.norm_runner = &current_runner.value()->runner;
 
   // Run the norm.
   return RunGpuNorm(current_runner.value()->config, input_buffer, scale_buffer,

--- a/xla/service/gpu/runtime/norm.cc
+++ b/xla/service/gpu/runtime/norm.cc
@@ -1,0 +1,231 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/runtime/norm.h"
+
+#include <limits>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "llvm/ADT/Sequence.h"
+#include "xla/mlir/runtime/transforms/custom_call_encoding.h"
+#include "xla/runtime/custom_call.h"
+#include "xla/runtime/executable.h"
+#include "xla/service/gpu/gpu_asm_opts_util.h"
+#include "xla/service/gpu/runtime/support.h"
+#include "xla/service/service_executable_run_options.h"
+#include "xla/status.h"
+#include "xla/stream_executor/device_memory.h"
+#include "xla/stream_executor/device_memory_allocator.h"
+#include "xla/translate/mhlo_to_hlo/attribute_exporter.h"
+#include "xla/xla.pb.h"
+
+namespace xla {
+
+using xla::runtime::CustomCall;
+using xla::runtime::EnumAttrEncoding;
+using xla::runtime::FlatMemrefView;
+using xla::runtime::State;
+using xla::runtime::StridedMemrefView;
+using xla::runtime::Tagged;
+
+namespace lmhlo_gpu = ::mlir::lmhlo_gpu;
+namespace gpu {
+
+struct NormAlgorithmConfig {
+  int64_t algorithm;
+  int64_t workspace_size;
+};
+
+void PopulateNormAlgorithmConfigAttrEncoding(
+    runtime::CustomCallAttrEncodingSet& encoding) {
+  {  // --- Encode `lmhlo_gpu::NormAlgorithmConfigAttr`.
+    using Attr = mlir::lmhlo_gpu::NormAlgorithmConfigAttr;
+    encoding
+        .Add<xla::runtime::AggregateAttrEncoding<Attr, NormAlgorithmConfig>>(
+            encoding, xla::runtime::AggregateAttrDef<Attr>()
+                          .Add("algorithm", &Attr::getAlgorithm)
+                          .Add("workspace_size", &Attr::getWorkspaceSize));
+  }
+}
+}  // namespace gpu
+
+namespace runtime {
+XLA_RUNTIME_REGISTER_AGGREGATE_ATTR_DECODING(
+    xla::gpu::NormAlgorithmConfig,  //
+    AggregateMember<int64_t>("algorithm"),
+    AggregateMember<int64_t>("workspace_size"));
+}  // namespace runtime
+
+namespace gpu {
+
+void RegisterNormTypeIdNames(runtime::TypeIDNameRegistry& registry) {
+  registry.Register<Tagged<NormAlgorithmConfig>>(
+      "__type_id_norm_algorithm_config");
+}
+
+static GpuNormDescriptor GetGpuNormDescriptor(
+    StridedMemrefView input, StridedMemrefView scale, StridedMemrefView bias,
+    StridedMemrefView output, std::optional<StridedMemrefView> expectation,
+    std::optional<StridedMemrefView> norm_factor, double epsilon,
+    NormAlgorithmConfig algorithm_config,
+    absl::Span<const int64_t> operand_layouts) {
+  GpuNormDescriptor descriptor;
+
+  auto* algorithm = descriptor.backend_config.mutable_algorithm();
+  algorithm->set_algo_id(algorithm_config.algorithm);
+  algorithm->set_is_cudnn_frontend(true);
+  if (algorithm_config.workspace_size >= 0) {
+    algorithm->mutable_workspace_size()->set_value(
+        algorithm_config.workspace_size);
+  }
+
+  // Apply backend config layout to the shape.
+  int layout_idx = 0;
+  auto apply_shape = [&operand_layouts,
+                      &layout_idx](const StridedMemrefView& memref) -> Shape {
+    std::vector<int64_t> minor_to_major = {
+        operand_layouts.begin() + layout_idx,
+        operand_layouts.begin() + layout_idx + memref.sizes.size()};
+    layout_idx += memref.sizes.size();
+    Shape shape = ToShape(memref);
+    return ShapeUtil::MakeShapeWithDenseLayout(
+        shape.element_type(), shape.dimensions(), minor_to_major);
+  };
+
+  descriptor.input_shape = apply_shape(input);
+  descriptor.scale_shape = apply_shape(scale);
+  descriptor.bias_shape = apply_shape(bias);
+  descriptor.output_shape = apply_shape(output);
+  if (expectation) {
+    descriptor.expectation_shape = apply_shape(*expectation);
+  }
+  if (norm_factor) {
+    descriptor.norm_factor_shape = apply_shape(*norm_factor);
+  }
+
+  descriptor.backend_config.set_epsilon(epsilon);
+
+  return descriptor;
+}
+
+static absl::Status NormImpl(const ServiceExecutableRunOptions* run_options,
+                             const DebugOptions* debug_options,
+                             State<NormRunnerState> runner_state,
+                             StridedMemrefView input, StridedMemrefView scale,
+                             StridedMemrefView bias, StridedMemrefView output,
+                             CustomCall::RemainingArgs remaining_args,
+                             int64_t uid, double epsilon,
+                             absl::Span<const int64_t> operand_layouts,
+                             NormAlgorithmConfig algorithm_config) {
+  std::optional<StridedMemrefView> expectation, norm_factor;
+  // Final remaining arg is the scratch space.
+  if (remaining_args.size() == 3) {
+    auto expectation_ = remaining_args.get<StridedMemrefView>(0);
+    if (failed(expectation_)) {
+      return absl::InternalError("Failure while retrieving expectation.");
+    }
+    expectation = expectation_.value();
+
+    auto norm_factor_ = remaining_args.get<StridedMemrefView>(1);
+    if (failed(norm_factor_)) {
+      return absl::InternalError("Failure while retrieving norm factor.");
+    }
+    norm_factor = norm_factor_.value();
+  }
+
+  GpuNormDescriptor descriptor =
+      GetGpuNormDescriptor(input, scale, bias, output, expectation, norm_factor,
+                           epsilon, algorithm_config, operand_layouts);
+
+  auto config = GpuNormConfig::For(descriptor);
+  if (!config.ok()) {
+    return tsl::ToAbslStatus(config.status());
+  }
+  auto current_runner =
+      runner_state.GetOrCreate([&config]() -> absl::StatusOr<NormRunnerState> {
+        return NormRunnerState(std::move(config.value()));
+      });
+  if (!current_runner.ok()) {
+    return tsl::ToAbslStatus(current_runner.status());
+  }
+
+  se::DeviceMemoryBase input_buffer = GetDeviceAddress(input);
+  se::DeviceMemoryBase scale_buffer = GetDeviceAddress(scale);
+  se::DeviceMemoryBase bias_buffer = GetDeviceAddress(bias);
+  se::DeviceMemoryBase output_buffer = GetDeviceAddress(output);
+  std::optional<se::DeviceMemoryBase> expectation_buffer, norm_factor_buffer;
+  if (expectation) {
+    expectation_buffer = GetDeviceAddress(expectation.value());
+  }
+  if (norm_factor) {
+    norm_factor_buffer = GetDeviceAddress(norm_factor.value());
+  }
+
+  auto scratch = remaining_args.get<FlatMemrefView>(remaining_args.size() - 1);
+  if (failed(scratch)) {
+    return absl::InternalError("Failure while retrieving scratch.");
+  }
+  se::DeviceMemoryBase scratch_buffer = GetDeviceAddress(scratch.value());
+
+  RunNormOptions opts;
+  opts.runner_cache = &current_runner.value()->runner;
+
+  // Run the norm.
+  return RunGpuNorm(current_runner.value()->config, input_buffer, scale_buffer,
+                    bias_buffer, output_buffer, expectation_buffer,
+                    norm_factor_buffer, scratch_buffer, run_options->stream(),
+                    opts);
+}
+
+template <typename... Ts>
+auto BindNormAttributes(runtime::CustomCallBinding<Ts...> binding) {
+  return std::move(binding)
+      // Unique convolution id for caching state.
+      .template Attr<int64_t>("uid")
+      .template Attr<double>("epsilon")
+      .template Attr<absl::Span<const int64_t>>("operand_layouts")
+      .template Attr<NormAlgorithmConfig>("norm_algorithm_config");
+}
+
+auto NormCall(const char* name) {
+  return CustomCall::Bind(name)
+      .UserData<const ServiceExecutableRunOptions*>()
+      .UserData<const DebugOptions*>()
+      .State<NormRunnerState>("uid")
+      .Arg<StridedMemrefView>()   // input
+      .Arg<StridedMemrefView>()   // scale
+      .Arg<StridedMemrefView>()   // bias
+      .Arg<StridedMemrefView>();  // output
+}
+
+XLA_RUNTIME_DEFINE_CUSTOM_CALL(
+    Norm, FunctionWrapper<NormImpl>(), checks,
+    BindNormAttributes(NormCall("xla.gpu.norm").RemainingArgs()));
+
+void RegisterNormCustomCalls(runtime::DirectCustomCallRegistry& registry) {
+  registry.Register("xla.gpu.norm", Norm);
+}
+
+StreamExecutorNormRunners* NormRunnerStates::operator()(
+    se::StreamExecutor* executor) {
+  absl::MutexLock lock(&mutex_);
+  return &runners_[executor];
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/runtime/norm.h
+++ b/xla/service/gpu/runtime/norm.h
@@ -1,0 +1,65 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_RUNTIME_NORM_H_
+#define XLA_SERVICE_GPU_RUNTIME_NORM_H_
+
+#include <memory>
+#include <utility>
+
+#include "absl/container/node_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/mlir/runtime/transforms/custom_call_encoding.h"
+#include "xla/runtime/custom_call_registry.h"
+#include "xla/service/gpu/gpu_norm_runner.h"
+
+namespace xla {
+namespace gpu {
+
+// Registers XLA GPU runtime norm custom calls.
+void RegisterNormCustomCalls(runtime::DirectCustomCallRegistry& registry);
+
+// Register type names for norm attributes defined by MHLO dialect.
+void RegisterNormTypeIdNames(runtime::TypeIDNameRegistry& registry);
+
+void PopulateNormAlgorithmConfigAttrEncoding(
+    runtime::CustomCallAttrEncodingSet& encoding);
+
+// State of the norm runners between invocations.
+struct NormRunnerState {
+  explicit NormRunnerState(GpuNormConfig config)
+      : config(std::move(config)), runner(this->config) {}
+  GpuNormConfig config;
+  NormRunner runner;
+};
+
+class StreamExecutorNormRunners : public runtime::StateVector<NormRunnerState> {
+};
+
+// XLA executable keeps a mapping from stream executors to norm runners.
+class NormRunnerStates {
+ public:
+  StreamExecutorNormRunners* operator()(se::StreamExecutor* executor);
+
+ private:
+  mutable absl::Mutex mutex_;
+  absl::node_hash_map<se::StreamExecutor*, StreamExecutorNormRunners> runners_
+      ABSL_GUARDED_BY(mutex_);
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_RUNTIME_NORM_H_

--- a/xla/service/gpu/thunk.cc
+++ b/xla/service/gpu/thunk.cc
@@ -74,6 +74,7 @@ Thunk::ExecuteParams::ExecuteParams(
     CASE(kKernel);
     CASE(kMemset32BitValue);
     CASE(kMemzero);
+    CASE(kNorm);
     CASE(kOutfeed);
     CASE(kReplicaId);
     CASE(kPartitionId);

--- a/xla/service/gpu/thunk.h
+++ b/xla/service/gpu/thunk.h
@@ -96,6 +96,7 @@ class Thunk {
     kNcclAllToAllDone,
     kNcclSend,
     kNcclRecv,
+    kNorm,
     kOutfeed,
     kReplicaId,
     kPartitionId,

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -7351,11 +7351,19 @@ GetCudnnFlashAttentionBackwardOperationGraph(
 }  // namespace
 
 static tsl::StatusOr<cudnn_frontend::ExecutionPlan> GetExecPlanFromHeuristics(
-    cudnn_frontend::OperationGraph&& opGraph, const CudnnHandle& cudnn) {
+    cudnn_frontend::OperationGraph&& opGraph, const CudnnHandle& cudnn,
+    bool fallback_heuristics = false) {
 #if (CUDNN_VERSION >= 8800)
   cudnn_frontend::EngineConfigList engine_configs;
-  cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph,
-                                         allowAllConfig, engine_configs, true);
+  if (!fallback_heuristics) {
+    cudnn_frontend::get_heuristics_list<1>(
+        {"heuristics_instant"}, opGraph, allowAllConfig, engine_configs, true);
+  } else {
+    cudnn_frontend::get_heuristics_list<2>(
+        {"heuristics_instant", "heuristics_fallback"}, opGraph, allowAllConfig,
+        engine_configs, true);
+  }
+
   if (VLOG_IS_ON(4)) {
     VLOG(4) << "Heuristic has " << engine_configs.size() << " configurations ";
   }
@@ -7363,12 +7371,19 @@ static tsl::StatusOr<cudnn_frontend::ExecutionPlan> GetExecPlanFromHeuristics(
     return absl::InternalError(
         "No engine configurations found for this opGraph and heuristics.");
   }
-  auto plan = cudnn_frontend::ExecutionPlanBuilder()
-                  .setHandle(cudnn.handle())
-                  .setEngineConfig(engine_configs[0], opGraph.getTag())
-                  .build();
 
-  return plan;
+  for (auto engine_config : engine_configs) {
+    cudnn_frontend::ExecutionPlan plan =
+        cudnn_frontend::ExecutionPlanBuilder()
+            .setHandle(cudnn.handle())
+            .setEngineConfig(engine_config, opGraph.getTag())
+            .build();
+    if (plan.get_status() == CUDNN_STATUS_SUCCESS) {
+      return plan;
+    }
+  }
+
+  return tsl::errors::Internal("Failed to generate cuDNN execution plan.");
 #else
   return absl::UnimplementedError("Supported only for cuDNN >= 8.8.0");
 #endif
@@ -8990,6 +9005,130 @@ bool CudnnSupport::GetConvolveAlgorithms(
   }
 
   return true;
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::NormRunner>>
+CudnnSupport::NormRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc, double epsilon,
+    const dnn::TensorDescriptor& input_descriptor,
+    const dnn::TensorDescriptor& scale_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    std::optional<dnn::TensorDescriptor> expectation_descriptor,
+    std::optional<dnn::TensorDescriptor> norm_factor_descriptor) {
+#if (CUDNN_VERSION >= 8905 && TF_ENABLE_CUDNN_FRONTEND)
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  std::vector<int64_t> uids;
+  auto next_uid = [&uids]() -> int64_t {
+    if (uids.empty()) {
+      return uids.emplace_back(0);
+    }
+    return uids.emplace_back(uids.back() + 1);
+  };
+
+  TF_ASSIGN_OR_RETURN(
+      auto xTensor,
+      CreateCudnnTensor(input_descriptor.dimensions(),
+                        input_descriptor.GetPhysicalStridesMajorToMinor(),
+                        next_uid(), input_descriptor.type(), 1, -1));
+  TF_ASSIGN_OR_RETURN(
+      auto scaleTensor,
+      CreateCudnnTensor(scale_descriptor.dimensions(),
+                        scale_descriptor.GetPhysicalStridesMajorToMinor(),
+                        next_uid(), scale_descriptor.type(), 1, -1));
+  TF_ASSIGN_OR_RETURN(
+      auto biasTensor,
+      CreateCudnnTensor(bias_descriptor.dimensions(),
+                        bias_descriptor.GetPhysicalStridesMajorToMinor(),
+                        next_uid(), bias_descriptor.type(), 1, -1));
+  TF_ASSIGN_OR_RETURN(
+      auto yTensor,
+      CreateCudnnTensor(output_descriptor.dimensions(),
+                        output_descriptor.GetPhysicalStridesMajorToMinor(),
+                        next_uid(), output_descriptor.type(), 1, -1));
+  std::optional<cudnn_frontend::Tensor> expectation_tensor, norm_factor_tensor;
+  if (expectation_descriptor) {
+    TF_ASSIGN_OR_RETURN(
+        expectation_tensor,
+        CreateCudnnTensor(
+            expectation_descriptor->dimensions(),
+            expectation_descriptor->GetPhysicalStridesMajorToMinor(),
+            next_uid(), expectation_descriptor->type(), 1, -1));
+  }
+  if (norm_factor_descriptor) {
+    TF_ASSIGN_OR_RETURN(
+        norm_factor_tensor,
+        CreateCudnnTensor(
+            norm_factor_descriptor->dimensions(),
+            norm_factor_descriptor->GetPhysicalStridesMajorToMinor(),
+            next_uid(), norm_factor_descriptor->type(), 1, -1));
+  }
+
+  std::vector<int64_t> scale_dim(4, 1), scalar_uids;
+  TF_ASSIGN_OR_RETURN(
+      auto epsilonTensor,
+      CreateCudnnTensor(scale_dim, scale_dim,
+                        scalar_uids.emplace_back(uids.back() + 1),
+                        dnn::DataType::kDouble, 1, -1, /*is_virtual=*/false,
+                        CUDNN_TENSOR_REORDERING_NONE,
+                        /*is_value=*/true));
+
+  cudnnBackendNormMode_t normalizationMode = CUDNN_LAYER_NORM;
+
+  std::optional<cudnn_frontend::Operation> norm_op;
+  if (!expectation_descriptor) {
+    cudnnBackendNormFwdPhase_t phase = CUDNN_NORM_FWD_INFERENCE;
+    norm_op = cudnn_frontend::OperationBuilder(
+                  CUDNN_BACKEND_OPERATION_NORM_FORWARD_DESCRIPTOR)
+                  .setNormalizationMode(normalizationMode)
+                  .setNormFwdPhase(phase)
+                  .setxDesc(xTensor)
+                  .setScaleAndBias(scaleTensor, biasTensor)
+                  .setEpsilonTensor(epsilonTensor)
+                  .setyDesc(yTensor)
+                  .build();
+  } else {
+    cudnnBackendNormFwdPhase_t phase = CUDNN_NORM_FWD_TRAINING;
+    norm_op = cudnn_frontend::OperationBuilder(
+                  CUDNN_BACKEND_OPERATION_NORM_FORWARD_DESCRIPTOR)
+                  .setNormalizationMode(normalizationMode)
+                  .setNormFwdPhase(phase)
+                  .setxDesc(xTensor)
+                  .setScaleAndBias(scaleTensor, biasTensor)
+                  .setEpsilonTensor(epsilonTensor)
+                  .setSavedMeanAndInvVar(expectation_tensor.value(),
+                                         norm_factor_tensor.value())
+                  .setyDesc(yTensor)
+                  .build();
+  }
+
+  std::array<cudnn_frontend::Operation const*, 1> ops = {&norm_op.value()};
+  auto op_graph = cudnn_frontend::OperationGraphBuilder()
+                      .setHandle(cudnn.handle())
+                      .setOperationGraph(ops.size(), ops.data())
+                      .build();
+
+  TF_ASSIGN_OR_RETURN(auto execution_plan,
+                      GetExecPlanFromHeuristics(std::move(op_graph), cudnn,
+                                                /*fallback_heuristics=*/true));
+  std::vector<ScalingParam> scalar_input_values = {
+      ScalingParam(epsilon, dnn::DataType::kDouble)};
+
+  TF_ASSIGN_OR_RETURN(
+      auto runner,
+      CudnnExecutionPlanRunner<dnn::NormSignature>::Create(
+          parent_, cudnn_.get(), std::move(execution_plan), uids,
+          /*need_side_input=*/false, /*has_activation_output=*/false,
+          scalar_uids, scalar_input_values, 0, 0,
+          /*is_flash_attention=*/false));
+  return {std::make_unique<CudnnExecutionPlanRunner<dnn::NormSignature>>(
+      std::move(runner))};
+
+#else
+  return absl::UnimplementedError(
+      "Layer norm kernels require cuDNN 8.9.5 or higher.");
+#endif  // CUDNN_VERSION >= 8905 && TF_ENABLE_CUDNN_FRONTEND
 }
 
 // Returns the offset to increment for the dropout rng.

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -295,6 +295,15 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode) override;
 
+  tsl::StatusOr<std::unique_ptr<const dnn::NormRunner>> NormRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc, double epsilon,
+      const dnn::TensorDescriptor& input_descriptor,
+      const dnn::TensorDescriptor& scale_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> expectation_descriptor,
+      std::optional<dnn::TensorDescriptor> norm_factor_descriptor) override;
+
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
   FusedMHARunnerFromDesc(
       Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -80,6 +80,10 @@ struct CudaComputeCapability {
     return major >= CudaComputeCapabilities::HOPPER;
   }
 
+  bool Is(int other_major, int other_minor = 0) const {
+    return !(*this == CudaComputeCapability{other_major, other_minor});
+  }
+
   bool operator<(const CudaComputeCapability &other) const {
     return ToPair() < other.ToPair();
   }

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -80,10 +80,6 @@ struct CudaComputeCapability {
     return major >= CudaComputeCapabilities::HOPPER;
   }
 
-  bool Is(int other_major, int other_minor = 0) const {
-    return *this == CudaComputeCapability{other_major, other_minor};
-  }
-
   bool operator<(const CudaComputeCapability &other) const {
     return ToPair() < other.ToPair();
   }

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -81,7 +81,7 @@ struct CudaComputeCapability {
   }
 
   bool Is(int other_major, int other_minor = 0) const {
-    return !(*this == CudaComputeCapability{other_major, other_minor});
+    return *this == CudaComputeCapability{other_major, other_minor};
   }
 
   bool operator<(const CudaComputeCapability &other) const {

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -217,6 +217,18 @@ DnnSupport::FusedConvolveRunnerFromDesc(
       "FusedConvolveRunnerFromDesc not implemented.");
 }
 
+tsl::StatusOr<std::unique_ptr<const dnn::NormRunner>>
+DnnSupport::NormRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc, double epsilon,
+    const dnn::TensorDescriptor& input_descriptor,
+    const dnn::TensorDescriptor& scale_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    std::optional<dnn::TensorDescriptor> expectation_descriptor,
+    std::optional<dnn::TensorDescriptor> norm_factor_descriptor) {
+  return tsl::errors::Unimplemented("NormRunnerFromDesc not implemented.");
+};
+
 tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
 DnnSupport::FusedMHARunnerFromDesc(
     Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -978,6 +978,9 @@ using FusedMatmulSignature = void(DeviceMemoryBase /* a_data */,
                                   DeviceMemoryBase /* c_data */);
 using FusedMatmulRunner = OpRunner<FusedMatmulSignature>;
 
+using NormSignature = void(std::vector<DeviceMemoryBase>);
+using NormRunner = OpRunner<NormSignature>;
+
 using FusedMHASignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                DeviceMemoryBase /* BMM1_inputB_data */,
                                DeviceMemoryBase /* BMM2_inputA_data */,
@@ -1647,6 +1650,16 @@ class DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::NormRunner>>
+  NormRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc, double epsilon,
+      const dnn::TensorDescriptor& input_descriptor,
+      const dnn::TensorDescriptor& scale_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> expectation_descriptor,
+      std::optional<dnn::TensorDescriptor> norm_factor_descriptor);
 
   virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
   FusedMHARunnerFromDesc(

--- a/xla/stream_executor/lazy_op_runner.h
+++ b/xla/stream_executor/lazy_op_runner.h
@@ -217,9 +217,6 @@ struct FusedConvOp {
 struct NormOp {
   using Signature = NormSignature;
 
-  // Config is mainly used in RunnerFromAlgorithmDesc() to lazily create the
-  // runner. At this moment we only get existing runners and don't implement
-  // this feature.
   struct Config {
     double epsilon;
     const TensorDescriptor& input_descriptor;

--- a/xla/stream_executor/lazy_op_runner.h
+++ b/xla/stream_executor/lazy_op_runner.h
@@ -213,6 +213,33 @@ struct FusedConvOp {
   }
 };
 
+// Implementation of the concept required by LazyOpRunner, for NormRunner.
+struct NormOp {
+  using Signature = NormSignature;
+
+  // Config is mainly used in RunnerFromAlgorithmDesc() to lazily create the
+  // runner. At this moment we only get existing runners and don't implement
+  // this feature.
+  struct Config {
+    double epsilon;
+    const TensorDescriptor& input_descriptor;
+    const TensorDescriptor& scale_descriptor;
+    const TensorDescriptor& bias_descriptor;
+    const TensorDescriptor& output_descriptor;
+    std::optional<dnn::TensorDescriptor> expectation_descriptor;
+    std::optional<dnn::TensorDescriptor> norm_factor_descriptor;
+  };
+
+  static tsl::StatusOr<std::unique_ptr<const OpRunner<Signature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->NormRunnerFromDesc(
+        desc, config.epsilon, config.input_descriptor, config.scale_descriptor,
+        config.bias_descriptor, config.output_descriptor,
+        config.expectation_descriptor, config.norm_factor_descriptor);
+  }
+};
+
 // Implementation of the concept required by LazyOpRunner, for FusedMatmul.
 struct FusedMatmulOp {
   using Signature = FusedMatmulSignature;

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -446,6 +446,24 @@ class Stream {
         convolution_descriptor, activation_mode);
   }
 
+  tsl::StatusOr<std::unique_ptr<const dnn::NormRunner>> NormRunnerFromDesc(
+      const dnn::AlgorithmDesc& algorithm_desc, double epsilon,
+      const dnn::TensorDescriptor& input_descriptor,
+      const dnn::TensorDescriptor& scale_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      std::optional<dnn::TensorDescriptor> expectation_descriptor,
+      std::optional<dnn::TensorDescriptor> norm_factor_descriptor) {
+    dnn::DnnSupport* dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->NormRunnerFromDesc(
+        this, algorithm_desc, epsilon, input_descriptor, scale_descriptor,
+        bias_descriptor, output_descriptor, expectation_descriptor,
+        norm_factor_descriptor);
+  }
+
   tsl::StatusOr<std::unique_ptr<const dnn::FusedMHARunner>>
   FusedMHARunnerFromDesc(
       const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,

--- a/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.h
+++ b/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.h
@@ -93,6 +93,8 @@ class LhloDialectEmitter : public xla::ConstDfsHloVisitorWithDefault {
       const xla::HloCustomCallInstruction* custom_call);
   xla::StatusOr<Operation*> EmitDnnfMHABackward(
       const xla::HloCustomCallInstruction* custom_call);
+  tsl::StatusOr<Operation*> EmitDnnNorm(
+      const xla::HloCustomCallInstruction* custom_call);
   xla::StatusOr<Operation*> EmitCubDeviceRadixSort(
       const xla::HloCustomCallInstruction* custom_call);
   tsl::StatusOr<memref::GetGlobalOp> EmitConstant(

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -655,7 +655,10 @@ message DebugOptions {
   // Enable radix sort using CUB.
   bool xla_gpu_enable_cub_radix_sort = 259;
 
-  // Next id: 261
+  // Rewrite layer norm patterns into cuDNN library calls.
+  bool xla_gpu_enable_cudnn_layer_norm = 261;
+
+  // Next id: 262
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -415,6 +415,9 @@ message DebugOptions {
   bool xla_gpu_enable_cudnn_fmha = 218;
   bool xla_gpu_fused_attention_use_cudnn_rng = 235;
 
+  // Rewrite layer norm patterns into cuDNN library calls.
+  bool xla_gpu_enable_cudnn_layer_norm = 261;
+
   // Disable dumping metadata in HLO dumps.
   bool xla_dump_disable_metadata = 153;
 
@@ -654,9 +657,6 @@ message DebugOptions {
 
   // Enable radix sort using CUB.
   bool xla_gpu_enable_cub_radix_sort = 259;
-
-  // Rewrite layer norm patterns into cuDNN library calls.
-  bool xla_gpu_enable_cudnn_layer_norm = 261;
 
   // Next id: 262
 


### PR DESCRIPTION
Rewrites layer norm patterns

(X, S, B, epsilon) -> (Y, [E, N]),

where, X, S and B are the input, scale and bias tensors, epsilon is a scalar and Y is the result of the normalization, into a Custom Call to the cuDNN library. Optionally also fuses the expectation E and the normalization factor N, which separately occur in the training graph, into the Custom Call.
