### PR TITLE
Upgrade minimum Cuda Capability requirement from 3.5 to 5.2

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -31,7 +31,7 @@ except ImportError:
 
 _DEFAULT_CUDA_VERSION = '11'
 _DEFAULT_CUDNN_VERSION = '2'
-_DEFAULT_CUDA_COMPUTE_CAPABILITIES = '3.5,7.0'
+_DEFAULT_CUDA_COMPUTE_CAPABILITIES = '5.2,7.0'
 
 _DEFAULT_PROMPT_ASK_ATTEMPTS = 10
 
@@ -688,7 +688,7 @@ def set_tf_cuda_compute_capabilities(environ_cp):
         ' binary GPU code, or as "sm_xy" to only include the binary '
         'code.\nPlease note that each additional compute capability '
         'significantly increases your build time and binary size, and that '
-        'XLA only supports compute capabilities >= 3.5 [Default is: '
+        'XLA only supports compute capabilities >= 5.2 [Default is: '
         '%s]: ' % default_cuda_compute_capabilities)
     tf_cuda_compute_capabilities = get_from_env_or_user_or_default(
         environ_cp, 'TF_CUDA_COMPUTE_CAPABILITIES',
@@ -701,7 +701,7 @@ def set_tf_cuda_compute_capabilities(environ_cp):
     for compute_capability in tf_cuda_compute_capabilities.split(','):
       m = re.match('[0-9]+.[0-9]+', compute_capability)
       if not m:
-        # We now support sm_35,sm_50,sm_60,compute_70.
+        # We now support sm_52,compute_70.
         sm_compute_match = re.match('(sm|compute)_?([0-9]+[0-9]+)',
                                     compute_capability)
         if not sm_compute_match:
@@ -709,25 +709,19 @@ def set_tf_cuda_compute_capabilities(environ_cp):
           all_valid = False
         else:
           ver = int(sm_compute_match.group(2))
-          if ver < 30:
+          if ver < 52:
             print(
                 'ERROR: XLA only supports small CUDA compute'
-                ' capabilities of sm_30 and higher. Please re-specify the list'
+                ' capabilities of sm_52 and higher. Please re-specify the list'
                 ' of compute capabilities excluding version %s.' % ver)
             all_valid = False
-          if ver < 35:
-            print('WARNING: XLA does not support CUDA compute capabilities '
-                  'lower than sm_35. Disable XLA when running on older GPUs.')
       else:
         ver = float(m.group(0))
-        if ver < 3.0:
-          print('ERROR: XLA only supports CUDA compute capabilities 3.0 '
+        if ver < 5.2:
+          print('ERROR: XLA only supports CUDA compute capabilities 5.2 '
                 'and higher. Please re-specify the list of compute '
                 'capabilities excluding version %s.' % ver)
           all_valid = False
-        if ver < 3.5:
-          print('WARNING: XLA does not support CUDA compute capabilities '
-                'lower than 3.5. Disable XLA when running on older GPUs.')
 
     if all_valid:
       break

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -21,7 +21,7 @@
   * `CUDNN_INSTALL_PATH` (deprecated): The path to the cuDNN library. Default is
     `/usr/local/cuda`.
   * `TF_CUDA_COMPUTE_CAPABILITIES`: The CUDA compute capabilities. Default is
-    `3.5,5.2`.
+    `5.2`.
   * `PYTHON_BIN_PATH`: The python binary path
 """
 
@@ -325,7 +325,7 @@ def compute_capabilities(repository_ctx):
     capabilities = get_host_environ(
         repository_ctx,
         _TF_CUDA_COMPUTE_CAPABILITIES,
-        "compute_35,compute_52",
+        "compute_52",
     ).split(",")
 
     # Map old 'x.y' capabilities to 'compute_xy'.


### PR DESCRIPTION
Nvidia dropped support for Kepler in Cuda 12.2. Seems like requiring Maxwell is a reasonable minimum moving forward.