### PR TITLE
[NVIDIA XLA GPU] Generalize DBIAS matcher to match any non-3d consumers

### DIFF
--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -1322,12 +1322,8 @@ bool IsDbiasOnlyUserBesidesGradGemm(HloInstruction* d_intermediate,
   };
   // user_count == 1 && (reduce-> {convert} ->bitcast)
   return user_count == 1 &&
-         Match(dbias_user, m::Reduce(&reduce, m::Op(), m::Op()).WithOneUse()) &&
-         ConsumeExtraConvert(&reduce) &&
-         Match(reduce->users()[0],
-               m::AnyOf<HloInstruction>(m::Reshape(dbias, m::Op()),
-                                        m::Bitcast(dbias, m::Op()))
-                   .WithOneUse());
+         Match(dbias_user, m::Reduce(dbias, m::Op(), m::Op()).WithOneUse()) &&
+         (*dbias)->shape().rank() == 3 && ConsumeExtraConvert(dbias);
 }
 
 StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
@@ -1459,12 +1455,24 @@ StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
   output_shapes.push_back(ShapeUtil::MakeShape(U8, {0}));
 
   HloInstruction* dbias = nullptr;
-  if (d_intermediate &&
-      IsDbiasOnlyUserBesidesGradGemm(d_intermediate, bmm_1_grad_1, bmm_1_grad_2,
-                                     &dbias)) {
-    output_shapes.push_back(dbias->shape());
+  if (d_intermediate) {
+    if (IsDbiasOnlyUserBesidesGradGemm(d_intermediate, bmm_1_grad_1,
+                                       bmm_1_grad_2, &dbias)) {
+      // Cudnn kernel only outputs dbias in this shape [1, num_heads, seq, seq],
+      // so we add a dimension of 1 to existing dbias' shape.
+      std::vector<int64_t> dbias_shape_vector =
+          SpanToVector(dbias->shape().dimensions());
+      dbias_shape_vector.insert(dbias_shape_vector.begin(), 1);
+      Shape cudnn_dbias_shape = ShapeUtil::MakeShape(
+          dbias->shape().element_type(), dbias_shape_vector);
+      output_shapes.push_back(cudnn_dbias_shape);
+    } else {
+      VLOG(2) << "Intermediate gradient has other users outside of gradient "
+                 "gemms and dbias"
+              << " which is not supported by CUDNN for now. Skipping.";
+      return false;
+    }
   }
-
   Shape call_shape = ShapeUtil::MakeTupleShape(output_shapes);
   HloInstruction* fmha_bwd_call =
       comp->AddInstruction(HloInstruction::CreateCustomCall(
@@ -1485,12 +1493,23 @@ StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
   TF_RETURN_IF_ERROR(comp->ReplaceWithNewInstruction(
       bmm_2_grad_1, HloInstruction::CreateGetTupleElement(bmm_2_grad_1->shape(),
                                                           fmha_bwd_call, 2)));
-  // d_intermediate tensor
+
   if (dbias) {
-    // does not really need d_intermediate
-    TF_RETURN_IF_ERROR(comp->ReplaceWithNewInstruction(
-        dbias, HloInstruction::CreateGetTupleElement(dbias->shape(),
-                                                     fmha_bwd_call, 5)));
+    // Reshape fmha dbias output to original user's input shape.
+    // If the reshape doesn't involve physical data movement,
+    // algebraic simplifer can change it to a no-op bitcast.
+    Shape original_shape = dbias->shape();
+    HloInstruction* dbias_user = dbias->users()[0];
+    HloInstruction* cudnn_dbias_output =
+        comp->AddInstruction(HloInstruction::CreateGetTupleElement(
+            output_shapes.back(), fmha_bwd_call, 5));
+    HloInstruction* reshape_dbias = comp->AddInstruction(
+        HloInstruction::CreateReshape(original_shape, cudnn_dbias_output));
+    TF_RETURN_IF_ERROR(dbias_user->ReplaceOperandWith(
+        dbias_user->operand_index(dbias), reshape_dbias));
+
+    TF_RETURN_IF_ERROR(
+        comp->ReplaceInstructionWithDifferentShape(dbias, cudnn_dbias_output));
   }
   return true;
 }

--- a/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
@@ -1721,8 +1721,10 @@ ENTRY main.146 {
                   m::Transpose(m::Transpose(m::GetTupleElement(
                                    m::CustomCall({backward_target}), 2)))
                       .WithShape(BF16, {16, 256, 16, 64}),
-                  m::GetTupleElement(  // dbias
-                      m::CustomCall({backward_target}), dbias_index)),
+                  m::Reshape(
+                      m::Reshape(m::GetTupleElement(  // dbias
+                          m::CustomCall({backward_target}), dbias_index)))
+                      .WithShape(BF16, {1, 16, 256, 256})),
               0)),
           m::Op(), m::Op(), m::Op(), m::Op())));
   TF_ASSERT_OK_AND_ASSIGN(auto config,
@@ -1909,8 +1911,10 @@ ENTRY main.146 {
                   m::Transpose(m::Transpose(m::GetTupleElement(
                                    m::CustomCall({backward_target}), 2)))
                       .WithShape(F16, {16, 256, 16, 64}),
-                  m::GetTupleElement(  // dbias
-                      m::CustomCall({backward_target}), dbias_index)),
+                  m::Reshape(
+                      m::Reshape(m::GetTupleElement(  // dbias
+                          m::CustomCall({backward_target}), dbias_index)))
+                      .WithShape(F16, {1, 16, 256, 256})),
               0)),
           m::Op(), m::Op(), m::Op(), m::Op())));
   TF_ASSERT_OK_AND_ASSIGN(auto config,
@@ -2693,6 +2697,199 @@ ENTRY main.82 {
                           fmha->backend_config<CudnnfMHABackendConfig>());
   EXPECT_EQ(fmha->operands().size(), 6);
   EXPECT_NEAR(config.dropout_rate(), 0, 1e-2);
+}
+
+TEST_F(CudnnFusedMhaRewriterTestHloTest,
+       BF16TrainingBmm1ScaleBiasSoftmaxDropoutBmm2DbiasShouldHaveUserShape) {
+  const char* module_str = R"(
+HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(bf16[16,256,16,64]{3,2,1,0},bf16[16,256,16,64]{3,2,1,0},bf16[16,256,16,64]{3,2,1,0},bf16[1,16,256,256]{3,2,1,0},pred[16,1,256,256]{3,2,1,0},bf16[16,256,16,64]{3,2,1,0})->(bf16[16,256,16,64]{3,2,1,0}, bf16[16,256,16,64]{3,2,1,0}, bf16[16,256,16,64]{3,2,1,0}, bf16[16,256,16,64]{3,2,1,0}, bf16[1,16,256,256]{3,2,1,0})}
+
+region_0.54 {
+  Arg_0.55 = bf16[] parameter(0)
+  Arg_1.56 = bf16[] parameter(1)
+  ROOT maximum.57 = bf16[] maximum(Arg_0.55, Arg_1.56)
+}
+
+region_1.66 {
+  Arg_0.67 = f32[] parameter(0)
+  Arg_1.68 = f32[] parameter(1)
+  ROOT add.69 = f32[] add(Arg_0.67, Arg_1.68)
+}
+
+region_2.114 {
+  Arg_0.115 = bf16[] parameter(0)
+  Arg_1.116 = bf16[] parameter(1)
+  ROOT add.117 = bf16[] add(Arg_0.115, Arg_1.116)
+}
+
+ENTRY main.146 {
+  Arg_2.3 = bf16[16,256,16,64]{3,2,1,0} parameter(2), sharding={replicated}
+  copy = bf16[16,256,16,64]{1,3,2,0} copy(Arg_2.3), sharding={replicated}
+  transpose.5 = bf16[16,16,64,256]{3,2,1,0} transpose(copy), dimensions={0,2,3,1}
+  Arg_0.1 = bf16[16,256,16,64]{3,2,1,0} parameter(0), sharding={replicated}
+  copy.1 = bf16[16,256,16,64]{3,1,2,0} copy(Arg_0.1), sharding={replicated}
+  transpose = bf16[16,16,256,64]{3,2,1,0} transpose(copy.1), dimensions={0,2,1,3}
+  Arg_1.2 = bf16[16,256,16,64]{3,2,1,0} parameter(1), sharding={replicated}
+  copy.2 = bf16[16,256,16,64]{1,3,2,0} copy(Arg_1.2), sharding={replicated}
+  transpose.1 = bf16[16,16,64,256]{3,2,1,0} transpose(copy.2), dimensions={0,2,3,1}
+  dot = bf16[16,16,256,256]{3,2,1,0} dot(transpose, transpose.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  Arg_4.5 = pred[16,1,256,256]{3,2,1,0} parameter(4), sharding={replicated}
+  convert.35 = s32[16,1,256,256]{3,2,1,0} convert(Arg_4.5)
+  constant.28 = s32[] constant(0)
+  broadcast.29 = s32[16,1,256,256]{3,2,1,0} broadcast(constant.28), dimensions={}
+  compare.36 = pred[16,1,256,256]{3,2,1,0} compare(convert.35, broadcast.29), direction=GT
+  constant.30 = bf16[] constant(0)
+  broadcast.1 = bf16[16,1,256,256]{3,2,1,0} broadcast(constant.30), dimensions={}
+  constant.10 = bf16[] constant(-9.999e+09)
+  broadcast.3 = bf16[16,1,256,256]{3,2,1,0} broadcast(constant.10), dimensions={}
+  select.39 = bf16[16,1,256,256]{3,2,1,0} select(compare.36, broadcast.1, broadcast.3)
+  reshape.41 = bf16[16,256,256]{2,1,0} reshape(select.39)
+  broadcast.42 = bf16[16,16,256,256]{3,2,1,0} broadcast(reshape.41), dimensions={0,2,3}
+  Arg_3.4 = bf16[1,16,256,256]{3,2,1,0} parameter(3), sharding={replicated}
+  reshape.44 = bf16[16,256,256]{2,1,0} reshape(Arg_3.4)
+  broadcast.45 = bf16[16,16,256,256]{3,2,1,0} broadcast(reshape.44), dimensions={1,2,3}
+  add.46 = bf16[16,16,256,256]{3,2,1,0} add(broadcast.42, broadcast.45)
+  add.53 = bf16[16,16,256,256]{3,2,1,0} add(dot, add.46)
+  constant.31 = bf16[] constant(-inf)
+  reduce.58 = bf16[16,16,256]{2,1,0} reduce(add.53, constant.31), dimensions={3}, to_apply=region_0.54
+  broadcast.62 = bf16[16,16,256,256]{3,2,1,0} broadcast(reduce.58), dimensions={0,1,2}
+  subtract.63 = bf16[16,16,256,256]{3,2,1,0} subtract(add.53, broadcast.62)
+  exponential.64 = bf16[16,16,256,256]{3,2,1,0} exponential(subtract.63)
+  convert.65 = f32[16,16,256,256]{3,2,1,0} convert(exponential.64)
+  constant.11 = f32[] constant(0)
+  reduce.70 = f32[16,16,256]{2,1,0} reduce(convert.65, constant.11), dimensions={3}, to_apply=region_1.66
+  convert.4 = bf16[16,16,256]{2,1,0} convert(reduce.70)
+  broadcast.75 = bf16[16,16,256,256]{3,2,1,0} broadcast(convert.4), dimensions={0,1,2}
+  divide.76 = bf16[16,16,256,256]{3,2,1,0} divide(exponential.64, broadcast.75)
+  constant.22 = u32[1]{0} constant({255383827})
+  constant.21 = u32[1]{0} constant({267815257})
+  constant.2 = u32[1]{0} constant({0})
+  constant.23 = u32[1]{0} constant({3213575472})
+  custom-call.49 = (u32[1]{0}, u32[1]{0}) custom-call(constant.22, constant.21, constant.2, constant.23), custom_call_target="cu_threefry2x32", operand_layout_constraints={u32[1]{0}, u32[1]{0}, u32[1]{0}, u32[1]{0}}, api_version=API_VERSION_STATUS_RETURNING, backend_config="\001\000\000\000\000\000\000\000"
+  get-tuple-element.50 = u32[1]{0} get-tuple-element(custom-call.49), index=0
+  reshape.80 = u32[] reshape(get-tuple-element.50)
+  broadcast.84 = u32[32768]{0} broadcast(reshape.80), dimensions={}
+  get-tuple-element.51 = u32[1]{0} get-tuple-element(custom-call.49), index=1
+  reshape.81 = u32[] reshape(get-tuple-element.51)
+  broadcast.85 = u32[32768]{0} broadcast(reshape.81), dimensions={}
+  iota.79 = u32[65536]{0} iota(), iota_dimension=0
+  slice.82 = u32[32768]{0} slice(iota.79), slice={[0:32768]}
+  slice.83 = u32[32768]{0} slice(iota.79), slice={[32768:65536]}
+  custom-call.86 = (u32[32768]{0}, u32[32768]{0}) custom-call(broadcast.84, broadcast.85, slice.82, slice.83), custom_call_target="cu_threefry2x32", operand_layout_constraints={u32[32768]{0}, u32[32768]{0}, u32[32768]{0}, u32[32768]{0}}, api_version=API_VERSION_STATUS_RETURNING, backend_config="\000\200\000\000\000\000\000\000"
+  get-tuple-element.87 = u32[32768]{0} get-tuple-element(custom-call.86), index=0
+  get-tuple-element.88 = u32[32768]{0} get-tuple-element(custom-call.86), index=1
+  concatenate.89 = u32[65536]{0} concatenate(get-tuple-element.87, get-tuple-element.88), dimensions={0}
+  constant.17 = u32[] constant(9)
+  broadcast.13 = u32[65536]{0} broadcast(constant.17), dimensions={}
+  shift-right-logical.0 = u32[65536]{0} shift-right-logical(concatenate.89, broadcast.13)
+  constant.15 = u32[] constant(1065353216)
+  broadcast.21 = u32[65536]{0} broadcast(constant.15), dimensions={}
+  or.0 = u32[65536]{0} or(shift-right-logical.0, broadcast.21)
+  bitcast-convert.0 = f32[65536]{0} bitcast-convert(or.0)
+  constant.3 = f32[] constant(-1)
+  broadcast.30 = f32[65536]{0} broadcast(constant.3), dimensions={}
+  add.1 = f32[65536]{0} add(bitcast-convert.0, broadcast.30)
+  broadcast.31 = f32[65536]{0} broadcast(constant.11), dimensions={}
+  maximum.0 = f32[65536]{0} maximum(add.1, broadcast.31)
+  constant.9 = f32[] constant(0.9)
+  broadcast.32 = f32[65536]{0} broadcast(constant.9), dimensions={}
+  compare.0 = pred[65536]{0} compare(maximum.0, broadcast.32), direction=LT
+  constant = bf16[] constant(1.109)
+  broadcast.33 = bf16[65536]{0} broadcast(constant), dimensions={}
+  broadcast.34 = bf16[65536]{0} broadcast(constant.30), dimensions={}
+  select.2 = bf16[65536]{0} select(compare.0, broadcast.33, broadcast.34)
+  reshape.39 = bf16[16,16,256]{2,1,0} reshape(select.2)
+  broadcast.9 = bf16[16,16,256,256]{3,2,1,0} broadcast(reshape.39), dimensions={0,1,3}
+  multiply.101 = bf16[16,16,256,256]{3,2,1,0} multiply(divide.76, broadcast.9)
+  dot.1 = bf16[16,16,64,256]{3,2,1,0} dot(transpose.5, multiply.101), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}
+  transpose.103 = bf16[16,256,16,64]{1,3,2,0} transpose(dot.1), dimensions={0,3,1,2}
+  Arg_5.6 = bf16[16,256,16,64]{3,2,1,0} parameter(5), sharding={replicated}
+  copy.3 = bf16[16,256,16,64]{3,1,2,0} copy(Arg_5.6), sharding={replicated}
+  transpose.4 = bf16[16,16,256,64]{3,2,1,0} transpose(copy.3), dimensions={0,2,1,3}
+  dot.2 = bf16[16,16,256,256]{3,2,1,0} dot(transpose.4, transpose.5), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  multiply.108 = bf16[16,16,256,256]{3,2,1,0} multiply(dot.2, broadcast.9)
+  divide.124 = bf16[16,16,256,256]{3,2,1,0} divide(multiply.108, broadcast.75)
+  constant.19 = bf16[] constant(1)
+  broadcast.24 = bf16[16,16,256]{2,1,0} broadcast(constant.19), dimensions={}
+  multiply.2 = bf16[16,16,256]{2,1,0} multiply(convert.4, convert.4)
+  divide.0 = bf16[16,16,256]{2,1,0} divide(broadcast.24, multiply.2)
+  broadcast.111 = bf16[16,16,256,256]{3,2,1,0} broadcast(divide.0), dimensions={0,1,2}
+  multiply.112 = bf16[16,16,256,256]{3,2,1,0} multiply(multiply.108, broadcast.111)
+  multiply.113 = bf16[16,16,256,256]{3,2,1,0} multiply(multiply.112, exponential.64)
+  reduce.118 = bf16[16,16,256]{2,1,0} reduce(multiply.113, constant.30), dimensions={3}, to_apply=region_2.114
+  negate.1 = bf16[16,16,256]{2,1,0} negate(reduce.118)
+  broadcast.11 = bf16[16,16,256,256]{3,2,1,0} broadcast(negate.1), dimensions={0,1,2}
+  add.133 = bf16[16,16,256,256]{3,2,1,0} add(divide.124, broadcast.11)
+  multiply.134 = bf16[16,16,256,256]{3,2,1,0} multiply(add.133, exponential.64)
+  copy.4 = bf16[16,256,16,64]{3,1,2,0} copy(Arg_1.2), sharding={replicated}
+  transpose.9 = bf16[16,16,256,64]{3,2,1,0} transpose(copy.4), dimensions={0,2,1,3}
+  dot.4 = bf16[16,16,256,64]{3,2,1,0} dot(multiply.134, transpose.9), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  transpose.144 = bf16[16,256,16,64]{3,1,2,0} transpose(dot.4), dimensions={0,2,1,3}
+  dot.3 = bf16[16,16,256,64]{3,2,1,0} dot(multiply.134, transpose), lhs_batch_dims={0,1}, lhs_contracting_dims={2}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  transpose.142 = bf16[16,256,16,64]{3,1,2,0} transpose(dot.3), dimensions={0,2,1,3}
+  copy.5 = bf16[16,256,16,64]{1,3,2,0} copy(Arg_5.6), sharding={replicated}
+  transpose.104 = bf16[16,16,64,256]{3,2,1,0} transpose(copy.5), dimensions={0,2,3,1}
+  dot.106 = bf16[16,16,64,256]{3,2,1,0} dot(transpose.104, multiply.101), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  transpose.107 = bf16[16,256,16,64]{1,3,2,0} transpose(dot.106), dimensions={0,3,1,2}
+  reduce.139 = bf16[16,256,256]{2,1,0} reduce(multiply.134, constant.30), dimensions={0}, to_apply=region_2.114
+  bitcast.111 = bf16[1,16,256,256]{3,2,1,0} bitcast(reduce.139)
+  all-reduce = bf16[1,16,256,256]{3,2,1,0} all-reduce(bitcast.111), channel_id=85, replica_groups={{0}}, to_apply=region_2.114
+  tuple.145 = (bf16[16,256,16,64]{1,3,2,0}, bf16[16,256,16,64]{3,1,2,0}, bf16[16,256,16,64]{3,1,2,0}, bf16[16,256,16,64]{1,3,2,0}, bf16[1,16,256,256]{3,2,1,0}) tuple(transpose.103, transpose.144, transpose.142, transpose.107, all-reduce)
+  get-tuple-element = bf16[16,256,16,64]{1,3,2,0} get-tuple-element(tuple.145), index=0
+  copy.6 = bf16[16,256,16,64]{3,2,1,0} copy(get-tuple-element)
+  get-tuple-element.1 = bf16[16,256,16,64]{3,1,2,0} get-tuple-element(tuple.145), index=1
+  copy.7 = bf16[16,256,16,64]{3,2,1,0} copy(get-tuple-element.1)
+  get-tuple-element.2 = bf16[16,256,16,64]{3,1,2,0} get-tuple-element(tuple.145), index=2
+  copy.8 = bf16[16,256,16,64]{3,2,1,0} copy(get-tuple-element.2)
+  get-tuple-element.3 = bf16[16,256,16,64]{1,3,2,0} get-tuple-element(tuple.145), index=3
+  copy.9 = bf16[16,256,16,64]{3,2,1,0} copy(get-tuple-element.3)
+  get-tuple-element.4 = bf16[1,16,256,256]{3,2,1,0} get-tuple-element(tuple.145), index=4
+  ROOT tuple = (bf16[16,256,16,64]{3,2,1,0}, bf16[16,256,16,64]{3,2,1,0}, bf16[16,256,16,64]{3,2,1,0}, bf16[16,256,16,64]{3,2,1,0}, bf16[1,16,256,256]{3,2,1,0}) tuple(copy.6, copy.7, copy.8, copy.9, get-tuple-element.4)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
+  CudnnFusedMHARewriter fusedMhaRewriter{
+      GetCudaComputeCapability(),
+      GetCudnnVersionWithDbiasAndMaskBwdInputSupport()};
+  TF_ASSERT_OK(RunHloPass(&fusedMhaRewriter, m.get()).status());
+
+  HloDCE dce;
+  TF_ASSERT_OK(RunHloPass(&dce, m.get()).status());
+
+  ComputationLayout computation_layout(
+      m->entry_computation()->ComputeProgramShape());
+
+  const HloInstruction* fmha;
+  const absl::string_view backward_target =
+      kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget;
+  auto dbias_index = 5;
+  SCOPED_TRACE(m->ToString());
+  EXPECT_THAT(
+      m->entry_computation()->root_instruction(),
+      GmockMatch(m::Tuple(
+          m::Copy(m::GetTupleElement(
+              m::Tuple(
+                  m::Transpose().WithShape(BF16, {16, 256, 16, 64}),
+                  m::Transpose(m::GetTupleElement(
+                                   m::CustomCall(&fmha, {backward_target}), 0))
+                      .WithShape(BF16, {16, 256, 16, 64}),
+                  m::Transpose(
+                      m::GetTupleElement(m::CustomCall({backward_target}), 1))
+                      .WithShape(BF16, {16, 256, 16, 64}),
+                  m::Transpose(m::Transpose(m::GetTupleElement(
+                                   m::CustomCall({backward_target}), 2)))
+                      .WithShape(BF16, {16, 256, 16, 64}),
+                  m::AllReduce(m::Bitcast(m::Reshape(m::GetTupleElement(  // dbias
+                                              m::CustomCall({backward_target}),
+                                              dbias_index))
+                                   .WithShape(BF16, {16, 256, 256})))),
+              0)),
+          m::Op(), m::Op(), m::Op(), m::Op())));
+  TF_ASSERT_OK_AND_ASSIGN(auto config,
+                          fmha->backend_config<CudnnfMHABackendConfig>());
+  EXPECT_EQ(fmha->operands().size(), 5);
+  EXPECT_NEAR(config.dropout_rate(), 0.1, 1e-2);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
The dbias pattern used to have the assumption that dbias consumer will always be a 3d tensor, we loose this requirement by reshaping the dbias output of the fused mha kernel, which is a 4-d tensor, to the original consumer's input shape.