### PR TITLE
Fix multi-GPU cublasLt crash

### DIFF
--- a/xla/service/gpu/gpublas_lt_matmul_thunk.cc
+++ b/xla/service/gpu/gpublas_lt_matmul_thunk.cc
@@ -55,11 +55,7 @@ CublasLtMatmulThunk::CublasLtMatmulThunk(
 
 Status CublasLtMatmulThunk::ExecuteOnStream(const ExecuteParams& params) {
   TF_ASSIGN_OR_RETURN(auto plan, GetMatmulPlan(params.stream));
-  if (!algorithm_) {
-    TF_ASSIGN_OR_RETURN(auto algorithms, plan->GetAlgorithms());
-    TF_RET_CHECK(algorithm_idx_ >= 0 && algorithm_idx_ < algorithms.size());
-    algorithm_ = algorithms[algorithm_idx_];
-  }
+  TF_ASSIGN_OR_RETURN(auto algorithm, GetMatmulAlgorithm(plan));
 
   VLOG(3) << "Running cublas_lt matmul thunk";
   const BufferAllocations& allocs = *params.buffer_allocations;
@@ -95,7 +91,7 @@ Status CublasLtMatmulThunk::ExecuteOnStream(const ExecuteParams& params) {
       params.stream, allocs.GetDeviceAddress(a_buffer_),
       allocs.GetDeviceAddress(b_buffer_), allocs.GetDeviceAddress(c_buffer_),
       allocs.GetDeviceAddress(d_buffer_), bias, aux, a_scale, b_scale, c_scale,
-      d_scale, d_amax, *algorithm_, scratch_allocator);
+      d_scale, d_amax, *algorithm, scratch_allocator);
 }
 
 StatusOr<se::gpu::BlasLt::MatmulPlan*> CublasLtMatmulThunk::GetMatmulPlan(
@@ -108,6 +104,20 @@ StatusOr<se::gpu::BlasLt::MatmulPlan*> CublasLtMatmulThunk::GetMatmulPlan(
     it = matmul_plans_cache_.emplace(stream, std::move(plan)).first;
   }
   return it->second.get();
+}
+
+StatusOr<std::optional<se::gpu::BlasLt::MatmulAlgorithm> >
+CublasLtMatmulThunk::GetMatmulAlgorithm(
+    const se::gpu::BlasLt::MatmulPlan* plan) {
+  absl::MutexLock lock(&matmul_algorithm_cache_mutex_);
+  auto it = matmul_algorithm_cache_.find(plan);
+  if (it == matmul_algorithm_cache_.end()) {
+    TF_ASSIGN_OR_RETURN(auto algorithms, plan->GetAlgorithms());
+    TF_RET_CHECK(algorithm_idx_ >= 0 && algorithm_idx_ < algorithms.size());
+    auto algorithm = algorithms[algorithm_idx_];
+    it = matmul_algorithm_cache_.emplace(plan, algorithm).first;
+  }
+  return it->second;
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/gpublas_lt_matmul_thunk.h
+++ b/xla/service/gpu/gpublas_lt_matmul_thunk.h
@@ -50,11 +50,18 @@ class CublasLtMatmulThunk : public Thunk {
  private:
   StatusOr<se::gpu::BlasLt::MatmulPlan*> GetMatmulPlan(
       const stream_executor::Stream* stream);
+  StatusOr<std::optional<se::gpu::BlasLt::MatmulAlgorithm> > GetMatmulAlgorithm(
+      const se::gpu::BlasLt::MatmulPlan* plan);
 
   absl::Mutex matmul_plans_cache_mutex_;
   absl::flat_hash_map<const stream_executor::Stream*,
                       se::gpu::BlasLt::MatmulPlanPtr>
       matmul_plans_cache_ ABSL_GUARDED_BY(matmul_plans_cache_mutex_);
+
+  absl::Mutex matmul_algorithm_cache_mutex_;
+  absl::flat_hash_map<const se::gpu::BlasLt::MatmulPlan*,
+                      se::gpu::BlasLt::MatmulAlgorithm>
+      matmul_algorithm_cache_ ABSL_GUARDED_BY(matmul_algorithm_cache_mutex_);
 
   GemmConfig gemm_config_;
   se::gpu::BlasLt::Epilogue epilogue_;
@@ -70,7 +77,6 @@ class CublasLtMatmulThunk : public Thunk {
   BufferAllocation::Slice c_scale_buffer_;
   BufferAllocation::Slice d_scale_buffer_;
   BufferAllocation::Slice d_amax_buffer_;
-  std::optional<se::gpu::BlasLt::MatmulAlgorithm> algorithm_;
 };
 
 }  // namespace gpu


### PR DESCRIPTION
The issue was that each device shared a algorithm_ in CublasLtMatmulThunk.  To fix, now each stream has a different algorithm cache. Fix #6370 cc @kaixih @philipphack 