### PR TITLE
[ROCm] copybara uncomment + correct hipblast version

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1117,9 +1117,8 @@ cc_library(
     name = "cub_sort_thunk",
     srcs = if_gpu_is_configured(["cub_sort_thunk.cc"]),
     hdrs = if_gpu_is_configured(["cub_sort_thunk.h"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = if_gpu_is_configured([
         ":buffer_allocations",
         ":thunk",
@@ -1139,14 +1138,14 @@ build_cub_sort_kernels(
     name = "cub_sort_kernel",
     srcs = if_gpu_is_configured(["cub_sort_kernel.cu.cc"]),
     hdrs = if_gpu_is_configured(["cub_sort_kernel.h"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     types = get_cub_sort_kernel_types(),
-    deps = if_cuda_is_configured([
+    deps = if_gpu_is_configured([
         "@com_google_absl//absl/status",
-        "@com_google_absl//absl/strings",
-    ]) + if_cuda_is_configured([":gpu_prim_cuda"]) + if_rocm_is_configured([":gpu_prim_rocm"]),
+        "@com_google_absl//absl/strings"]) + 
+        if_cuda_is_configured([":gpu_prim_cuda"]) + 
+        if_rocm_is_configured([":gpu_prim_rocm"]),
 )
 
 cc_library(

--- a/xla/service/gpu/gpu_prim_rocm.h
+++ b/xla/service/gpu/gpu_prim_rocm.h
@@ -42,7 +42,7 @@ struct float_bit_mask<tsl::bfloat16> {
   static constexpr uint16_t mantissa = 0x007F;
   using bit_type = uint16_t;
 };
-#endif
+#endif  // TF_ROCM_VERSION >= 50200
 template <>
 struct radix_key_codec_base<Eigen::half>
     : radix_key_codec_floating<Eigen::half, uint16_t> {};

--- a/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/xla/stream_executor/rocm/hip_blas_utils.h
@@ -25,7 +25,7 @@ limitations under the License.
 
 #if TF_HIPBLASLT
 
-#if TF_ROCM_VERSION < 50700
+#if TF_ROCM_VERSION < 60000
 #define hipblasltDatatype_t hipblasDatatype_t
 #define HIPBLASLT_R_16F HIPBLAS_R_16F
 #define HIPBLASLT_R_16B HIPBLAS_R_16B


### PR DESCRIPTION
ROCm code has been commented out during merging our last PR https://github.com/openxla/xla/pull/6386/files#diff-cfbbdf314333ac9529e3481c49c68bd2d200b2cc622039eb7fbd6eb886491789R42

wondering is it by mistake?

@ddunl 

