### PR TITLE
[XLA:GPU ] add cuDNN flash attention support in XLA (2nd PR with only MLIR lowering and thunk/runtime)

### DIFF
--- a/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
+++ b/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
@@ -691,7 +691,8 @@ class FusedAttentionForwardLowering
     set_attr("fmha_scale", op.getFmhaScaleAttr());
     set_attr("dropout_rate", op.getDropoutRateAttr());
     set_attr("seed", op.getSeedAttr());
-
+    set_attr("is_flash_attention", op.getIsFlashAttentionAttr());
+    set_attr("is_causal_mask", op.getIsCausalMaskAttr());
     set_attr("fused_mha_dag", op.getFusedMhaDagAttr());
     set_attr("algorithm_config", op.getAlgorithmConfigAttr());
     set_attr("bmm1_dot_dimension_numbers", op.getBmm1DotDimensionNumbers());
@@ -734,8 +735,10 @@ template <typename FusedDotAttentionBackward>
 class FusedAttentionBackwardLowering
     : public OpRewritePattern<FusedDotAttentionBackward> {
  private:
-  static constexpr const char kCustomCallTarget[] =
+  static constexpr const char kFusedAttentionCustomCallTarget[] =
       "xla.gpu.fused.attention.backward.";
+  static constexpr const char kFlashAttentionCustomCallTarget[] =
+      "xla.gpu.flash.attention.backward.";
 
  public:
   explicit FusedAttentionBackwardLowering(MLIRContext* ctx, UidGenerator& uid,
@@ -747,63 +750,92 @@ class FusedAttentionBackwardLowering
   LogicalResult matchAndRewrite(FusedDotAttentionBackward op,
                                 PatternRewriter& rewriter) const override {
     // Get the custom call target.
-    std::string fused_attention = kCustomCallTarget;
+    bool is_flash_attention = op.getIsFlashAttention();
+    std::string fused_attention = is_flash_attention
+                                      ? kFlashAttentionCustomCallTarget
+                                      : kFusedAttentionCustomCallTarget;
     auto num_operands = op.getNumOperands();
-    switch (op.getFusedMhaDag()) {
-      case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
-          BackwardScaleBiasSoftmax:
-        if (num_operands == 10) {
-          fused_attention += "scale.softmax";
-        } else if (num_operands == 11) {
-          fused_attention += "scale.dbias.softmax";
-        } else {
-          return op.emitOpError(
-              "unexpected number of operands for fused attention backward - "
-              "BMM_Bias_Softmax_BMM");
-        }
-        break;
+    if (!is_flash_attention) {
+      switch (op.getFusedMhaDag()) {
+        case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+            BackwardScaleBiasSoftmax:
+          if (num_operands == 10) {
+            fused_attention += "scale.softmax";
+          } else if (num_operands == 11) {
+            fused_attention += "scale.dbias.softmax";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for fused attention backward - "
+                "BMM_Bias_Softmax_BMM");
+          }
+          break;
 
-      case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
-          BackwardScaleBiasSoftmaxDropout:
-        if (num_operands == 10) {
-          fused_attention += "scale.softmax.dropout";
-        } else if (num_operands == 11) {
-          fused_attention += "scale.dbias.softmax.dropout";
-        } else {
-          return op.emitOpError(
-              "unexpected number of operands for fused attention backward - "
-              "BMM_Bias_Softmax_Dropout_BMM");
-        }
-        break;
+        case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+            BackwardScaleBiasSoftmaxDropout:
+          if (num_operands == 10) {
+            fused_attention += "scale.softmax.dropout";
+          } else if (num_operands == 11) {
+            fused_attention += "scale.dbias.softmax.dropout";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for fused attention backward - "
+                "BMM_Bias_Softmax_Dropout_BMM");
+          }
+          break;
 
-      case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
-          BackwardScaleBiasMaskSoftmax:
-        if (num_operands == 11) {
-          fused_attention += "scale.mask.softmax";
-        } else if (num_operands == 12) {
-          fused_attention += "scale.dbias.mask.softmax";
-        } else {
-          return op.emitOpError(
-              "unexpected number of operands for fused attention backward - "
-              "BMM_Bias_Mask_Softmax_BMM");
-        }
-        break;
+        case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+            BackwardScaleBiasMaskSoftmax:
+          if (num_operands == 11) {
+            fused_attention += "scale.mask.softmax";
+          } else if (num_operands == 12) {
+            fused_attention += "scale.dbias.mask.softmax";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for fused attention backward - "
+                "BMM_Bias_Mask_Softmax_BMM");
+          }
+          break;
 
-      case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
-          BackwardScaleBiasMaskSoftmaxDropout:
-        if (num_operands == 11) {
-          fused_attention += "scale.mask.softmax.dropout";
-        } else if (num_operands == 12) {
-          fused_attention += "scale.dbias.mask.softmax.dropout";
-        } else {
-          return op.emitOpError(
-              "unexpected number of operands for fused attention backward - "
-              "BMM_Bias_Mask_Softmax_Dropout_BMM");
-        }
-        break;
+        case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+            BackwardScaleBiasMaskSoftmaxDropout:
+          if (num_operands == 11) {
+            fused_attention += "scale.mask.softmax.dropout";
+          } else if (num_operands == 12) {
+            fused_attention += "scale.dbias.mask.softmax.dropout";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for fused attention backward - "
+                "BMM_Bias_Mask_Softmax_Dropout_BMM");
+          }
+          break;
 
-      default:
-        return op.emitOpError("Undefined fused attention DAG signature");
+        default:
+          return op.emitOpError("Undefined fused attention DAG signature");
+      }
+    } else {
+      switch (op.getFusedMhaDag()) {
+        case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
+            BackwardScaleBiasSoftmax:
+          if (num_operands == 13) {
+            fused_attention += "scale.bias.softmax";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for flash attention backward - "
+                "BMM_Bias_Softmax_BMM");
+          }
+          break;
+        case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmax:
+          if (num_operands == 12) {
+            fused_attention += "scale.softmax";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for flash attention backward - "
+                "BMM_Softmax_BMM");
+          }
+          break;
+        default:
+          return op.emitOpError("Undefined flash attention DAG signature");
+      }
     }
 
     // Get or create a custom call function declaration.
@@ -827,7 +859,8 @@ class FusedAttentionBackwardLowering
     set_attr("fmha_scale", op.getFmhaScaleAttr());
     set_attr("dropout_rate", op.getDropoutRateAttr());
     set_attr("seed", op.getSeedAttr());
-
+    set_attr("is_flash_attention", op.getIsFlashAttentionAttr());
+    set_attr("is_causal_mask", op.getIsCausalMaskAttr());
     set_attr("fused_mha_dag", op.getFusedMhaDagAttr());
     set_attr("algorithm_config", op.getAlgorithmConfigAttr());
     set_attr("bmm1_grad_gemm1_dot_dimension_numbers",
@@ -838,6 +871,20 @@ class FusedAttentionBackwardLowering
              op.getBmm2GradGemm1DotDimensionNumbers());
     set_attr("bmm2_grad_gemm2_dot_dimension_numbers",
              op.getBmm2GradGemm2DotDimensionNumbers());
+
+    auto set_xi64 = [&](StringRef name, mlir::ArrayAttr array) {
+      int rank = array.size();
+      SmallVector<int64_t> values;
+      for (int i = 0; i < rank; i++) {
+        mlir::IntegerAttr attr = array[i].dyn_cast<mlir::IntegerAttr>();
+        values.push_back(attr.getInt());
+      }
+      set_attr(name, b.getI64TensorAttr(values));
+    };
+
+    set_xi64("intermediate_tensor_dimensions",
+             op.getIntermediateTensorDimensions());
+    set_xi64("intermediate_tensor_layout", op.getIntermediateTensorLayout());
 
     // Erase the original fused dot attention operation.
     rewriter.eraseOp(op);

--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -347,7 +347,9 @@ def LHLOGPU_fusedMHAOp : LHLOGPU_Op<"fMHA", [AttrSizedOperandSegments]> {
     FusedMhaDagSignatureAttr:$fused_mha_dag,
     FusedMHAAlgorithmConfigAttr:$algorithm_config,
     OptionalAttr<F64Attr>:$dropout_rate,
-    OptionalAttr<I64Attr>:$seed
+    OptionalAttr<I64Attr>:$seed,
+    BoolAttr:$is_flash_attention,
+    BoolAttr:$is_causal_mask
     );
 }
 
@@ -359,21 +361,30 @@ def LHLOGPU_fusedMHABackwardOp : LHLOGPU_Op<"fMHABackward", [AttrSizedOperandSeg
     Arg<LHLO_Buffer, "", [MemRead]>:$bmm2_grad_gemm1_lhs,
     Arg<LHLO_Buffer, "", [MemRead]>:$d_output,
     Arg<Optional<LHLO_Buffer>, "", [MemRead]>:$mask,
+    Arg<Optional<LHLO_Buffer>, "", [MemRead]>:$bias,
+    Arg<Optional<LHLO_Buffer>, "", [MemRead]>:$fwd_output,
     Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_lhs,
     Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm1_rhs,
     Arg<LHLO_Buffer, "", [MemWrite]>:$d_bmm2_rhs,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$d_S,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$d_S,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$softmax_sum,
+    Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$d_Q_accum,
     Arg<LHLO_Buffer, "", [MemWrite]>:$scratch,
     Arg<Optional<LHLO_Buffer>, "", [MemWrite]>:$d_bias,
     MHLO_DotDimensionNumbers:$bmm1_grad_gemm1_dot_dimension_numbers,
     MHLO_DotDimensionNumbers:$bmm1_grad_gemm2_dot_dimension_numbers,
     MHLO_DotDimensionNumbers:$bmm2_grad_gemm1_dot_dimension_numbers,
     MHLO_DotDimensionNumbers:$bmm2_grad_gemm2_dot_dimension_numbers,
+    I64ArrayAttr:$intermediate_tensor_dimensions,
+    I64ArrayAttr:$intermediate_tensor_layout,
     F64Attr:$fmha_scale,
     FusedMhaBackwardDagSignatureAttr:$fused_mha_dag,
     FusedMHAAlgorithmConfigAttr:$algorithm_config,
     OptionalAttr<F64Attr>:$dropout_rate,
-    OptionalAttr<I64Attr>:$seed);
+    OptionalAttr<I64Attr>:$seed,
+    BoolAttr:$is_flash_attention,
+    BoolAttr:$is_causal_mask
+    );
 }
 
 def LHLOGPU_RadixSortOp: LHLOGPU_Op<"radix_sort", [SameVariadicOperandSize]> {

--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
@@ -142,6 +142,8 @@ def FusedMhaBackwardDagScaleBiasSoftmaxDropout : I32EnumAttrCase<"BackwardScaleB
 def FusedMhaBackwardDagScaleBiasSoftmax : I32EnumAttrCase<"BackwardScaleBiasSoftmax", 1>;
 def FusedMhaBackwardDagScaleBiasMaskSoftmax : I32EnumAttrCase<"BackwardScaleBiasMaskSoftmax", 2>;
 def FusedMhaBackwardDagScaleBiasMaskSoftmaxDropout : I32EnumAttrCase<"BackwardScaleBiasMaskSoftmaxDropout", 3>;
+def FusedMhaBackwardDagSoftmax : I32EnumAttrCase<"BackwardSoftmax", 4>;
+def FusedMhaBackwardDagSoftmaxDropout : I32EnumAttrCase<"BackwardSoftmaxDropout", 5>;
 
 def FusedMhaDagSignature: I32EnumAttr<"FusedMhaDagSignature",
     "DAG configuration for Fused Multi-Headed Attention",
@@ -164,7 +166,9 @@ def FusedMhaBackwardDagSignature: I32EnumAttr<"FusedMhaBackwardDagSignature",
     FusedMhaBackwardDagScaleBiasSoftmaxDropout,
     FusedMhaBackwardDagScaleBiasSoftmax,
     FusedMhaBackwardDagScaleBiasMaskSoftmax,
-    FusedMhaBackwardDagScaleBiasMaskSoftmaxDropout]> {
+    FusedMhaBackwardDagScaleBiasMaskSoftmaxDropout,
+    FusedMhaBackwardDagSoftmax,
+    FusedMhaBackwardDagSoftmaxDropout]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::lmhlo_gpu";
 }

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -167,4 +167,10 @@ message CudnnfMHABackendConfig {
 
   // Random seed used by dropout
   int64 seed = 15;
+
+  // Is flash attention
+  bool is_flash_attention = 20;
+
+  // Is causal mask
+  bool is_causal_mask = 21;
 }

--- a/xla/service/gpu/fused_mha_thunk.h
+++ b/xla/service/gpu/fused_mha_thunk.h
@@ -91,9 +91,13 @@ class FusedMHABackwardThunk : public Thunk {
                         BufferAllocation::Slice d_bmm1_lhs_slice,
                         BufferAllocation::Slice d_bmm1_rhs_slice,
                         BufferAllocation::Slice d_bmm2_rhs_slice,
-                        BufferAllocation::Slice d_S_slice,
+                        BufferAllocation::Slice d_s_slice,
+                        BufferAllocation::Slice softmax_sum_slice,
+                        BufferAllocation::Slice d_Q_accum_slice,
                         BufferAllocation::Slice mask_slice,
-                        BufferAllocation::Slice d_bias_slice);
+                        BufferAllocation::Slice d_bias_slice,
+                        BufferAllocation::Slice fwd_output_slice,
+                        BufferAllocation::Slice bias_slice);
 
   FusedMHABackwardThunk(const FusedMHABackwardThunk&) = delete;
   FusedMHABackwardThunk& operator=(const FusedMHABackwardThunk&) = delete;
@@ -111,8 +115,12 @@ class FusedMHABackwardThunk : public Thunk {
   BufferAllocation::Slice d_bmm1_rhs_buffer_;
   BufferAllocation::Slice d_bmm2_rhs_buffer_;
   BufferAllocation::Slice d_s_buffer_;
+  BufferAllocation::Slice softmax_sum_buffer_;
+  BufferAllocation::Slice d_Q_accum_buffer_;
   BufferAllocation::Slice mask_buffer_;
   BufferAllocation::Slice d_bias_buffer_;
+  BufferAllocation::Slice fwd_output_buffer_;
+  BufferAllocation::Slice bias_buffer_;
 
   FusedMultiHeadedAttentionBackwardRunner& GetOrCreateRunner(
       const stream_executor::Stream* stream);

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -83,8 +83,8 @@ Status RunFusedMHA(GpufMHAParams params, se::Stream *stream,
                                      params.config->activation,
                                      dropout_rate,
                                      seed,
-                                     false,
-                                     false};
+                                     params.config->is_flash_attention,
+                                     params.config->is_causal_mask};
   TF_ASSIGN_OR_RETURN(auto *runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
   return (*runner)(stream, options.profile_result, scratch_memory,
@@ -201,20 +201,21 @@ void AssignSeed(GpufMHAConfig &config,
 }
 
 template <typename ElementType, typename OutputType>
-Status RunFusedMHABackward(GpufMHABackwardParams params, se::Stream *stream,
-                           RunFusedMHABackwardOptions options,
-                           DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
-                           DeviceMemory<ElementType> bmm1_grad_gemm2_rhs_buffer,
-                           DeviceMemory<ElementType> bmm2_grad_gemm1_lhs_buffer,
-                           DeviceMemory<ElementType> bmm2_grad_gemm2_rhs_buffer,
-                           DeviceMemory<ElementType> d_output_buffer,
-                           DeviceMemory<OutputType> d_bmm1_lhs_buffer,
-                           DeviceMemory<OutputType> d_bmm1_rhs_buffer,
-                           DeviceMemory<OutputType> d_bmm2_rhs_buffer,
-                           DeviceMemory<OutputType> d_s_buffer,
-                           DeviceMemoryBase mask_buffer,
-                           DeviceMemoryBase d_bias_buffer,
-                           DeviceMemoryBase scratch_memory) {
+Status RunFusedMHABackward(
+    GpufMHABackwardParams params, se::Stream *stream,
+    RunFusedMHABackwardOptions options,
+    DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
+    DeviceMemory<ElementType> bmm1_grad_gemm2_rhs_buffer,
+    DeviceMemory<ElementType> bmm2_grad_gemm1_lhs_buffer,
+    DeviceMemory<ElementType> bmm2_grad_gemm2_rhs_buffer,
+    DeviceMemory<ElementType> d_output_buffer,
+    DeviceMemory<OutputType> d_bmm1_lhs_buffer,
+    DeviceMemory<OutputType> d_bmm1_rhs_buffer,
+    DeviceMemory<OutputType> d_bmm2_rhs_buffer, DeviceMemoryBase d_s_buffer,
+    DeviceMemoryBase softmax_buffer, DeviceMemoryBase d_Q_accum_buffer,
+    DeviceMemoryBase mask_buffer, DeviceMemoryBase d_bias_buffer,
+    DeviceMemoryBase fwd_output_buffer, DeviceMemoryBase bias_buffer,
+    DeviceMemoryBase scratch_memory) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp> *lazy_runner =
       options.runner_cache->AsFusedMHABackwardRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>
@@ -223,6 +224,7 @@ Status RunFusedMHABackward(GpufMHABackwardParams params, se::Stream *stream,
     local_runner.emplace(params.config->algorithm);
     lazy_runner = &*local_runner;
   }
+  // FMHA TODO: add GetDNNFusedMHAKindFromCudnnfMHAKind here
   TF_ASSIGN_OR_RETURN(se::dnn::FusedMHAKind kind,
                       GetDNNFusedMHAKindFromCudnnfMHAKind(params.config->kind));
   std::optional<double> dropout_rate;
@@ -239,7 +241,6 @@ Status RunFusedMHABackward(GpufMHABackwardParams params, se::Stream *stream,
   if (params.config->seed) {
     seed = *params.config->seed;
   }
-  // TODO: set is_flash_attention to real value, set it to false for now
   se::dnn::FusedMHABackwardOp::Config config{
       kind,
       scale,
@@ -251,15 +252,15 @@ Status RunFusedMHABackward(GpufMHABackwardParams params, se::Stream *stream,
       params.config->d_bmm1_lhs,
       params.config->d_bmm1_rhs,
       params.config->d_bmm2_rhs,
-      std::optional<TensorDescriptor>(params.config->d_s),
+      params.config->d_s,
       params.config->mask,
       params.config->d_bias,
-      std::nullopt,
-      std::nullopt,
+      params.config->fwd_output,
+      params.config->bias,
       dropout_rate,
       seed,
-      false,
-      false};
+      params.config->is_flash_attention,
+      params.config->is_causal_mask};
   TF_ASSIGN_OR_RETURN(auto *runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
   // TODO: pass in real softmax_sum, dQ_accum, fwd_output
@@ -267,9 +268,10 @@ Status RunFusedMHABackward(GpufMHABackwardParams params, se::Stream *stream,
                    bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
                    bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
                    d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
-                   d_bmm2_rhs_buffer, d_s_buffer, se::DeviceMemoryBase(),
-                   se::DeviceMemoryBase(), mask_buffer, d_bias_buffer,
-                   se::DeviceMemoryBase(), se::DeviceMemoryBase());
+                   d_bmm2_rhs_buffer, d_s_buffer, softmax_buffer,
+                   d_Q_accum_buffer, mask_buffer, d_bias_buffer,
+                   fwd_output_buffer, bias_buffer);
+  return OkStatus();
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -292,7 +294,20 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
       se::DeviceMemory<OutputType>(params.d_bmm1_rhs_buffer);
   auto d_bmm2_rhs_buffer =
       se::DeviceMemory<OutputType>(params.d_bmm2_rhs_buffer);
-  auto d_s_buffer = se::DeviceMemory<OutputType>(params.d_s_buffer);
+
+  // optional buffers
+  auto d_s_buffer = params.d_s_buffer.has_value()
+                        ? se::DeviceMemory<OutputType>(*params.d_s_buffer)
+                        : se::DeviceMemoryBase();
+  auto softmax_sum_buffer =
+      params.softmax_sum_buffer.has_value()
+          ? se::DeviceMemory<float>(*params.softmax_sum_buffer)
+          : se::DeviceMemoryBase();
+
+  auto d_Q_accum_buffer =
+      params.d_Q_accum_buffer.has_value()
+          ? se::DeviceMemory<float>(*params.d_Q_accum_buffer)
+          : se::DeviceMemoryBase();
 
   auto mask_buffer = params.mask_buffer.has_value()
                          ? se::DeviceMemory<ElementType>(*params.mask_buffer)
@@ -301,6 +316,15 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   auto d_bias_buffer = params.d_bias_buffer.has_value()
                            ? se::DeviceMemory<OutputType>(*params.d_bias_buffer)
                            : se::DeviceMemoryBase();
+
+  auto fwd_output_buffer =
+      params.fwd_output_buffer.has_value()
+          ? se::DeviceMemory<ElementType>(*params.fwd_output_buffer)
+          : se::DeviceMemoryBase();
+
+  auto bias_buffer = params.bias_buffer.has_value()
+                         ? se::DeviceMemory<BiasType>(*params.bias_buffer)
+                         : se::DeviceMemoryBase();
 
   se::dnn::AlgorithmDesc algorithm = params.config->algorithm;
   if (options.runner_cache) {
@@ -322,8 +346,9 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
           params, stream, options, bmm1_grad_gemm1_rhs_buffer,
           bmm1_grad_gemm2_rhs_buffer, bmm2_grad_gemm1_lhs_buffer,
           bmm2_grad_gemm2_rhs_buffer, d_output_buffer, d_bmm1_lhs_buffer,
-          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_s_buffer, mask_buffer,
-          d_bias_buffer, scratch_memory);
+          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_s_buffer, softmax_sum_buffer,
+          d_Q_accum_buffer, mask_buffer, d_bias_buffer, fwd_output_buffer,
+          bias_buffer, scratch_memory);
       break;
     default:
       return InternalError("Invalid cuDNN fMHA kind");
@@ -428,6 +453,8 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
                                         bias_shape.layout().minor_to_major());
   }
   config.kind = desc.kind;
+  config.is_flash_attention = desc.is_flash_attention;
+  config.is_causal_mask = desc.is_causal_mask;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
 
@@ -449,7 +476,6 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   const Shape &d_bmm1_lhs_shape = desc.d_bmm1_lhs_shape;
   const Shape &d_bmm1_rhs_shape = desc.d_bmm1_rhs_shape;
   const Shape &d_bmm2_rhs_shape = desc.d_bmm2_rhs_shape;
-
   // Get DNN dtype from primtive types
   TF_ASSIGN_OR_RETURN(DataType bmm1_grad_gemm1_rhs_type,
                       GetDNNDataTypeFromPrimitiveType(
@@ -537,7 +563,6 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
 
   if (desc.d_bias_shape) {
     const Shape &d_bias_shape = *desc.d_bias_shape;
-
     // Get DNN dtype from primtive types
     TF_ASSIGN_OR_RETURN(DataType d_bias_type, GetDNNDataTypeFromPrimitiveType(
                                                   d_bias_shape.element_type()));
@@ -553,7 +578,27 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
     config.mask = TensorDescriptor::For(mask_type, mask_shape.dimensions(),
                                         mask_shape.layout().minor_to_major());
   }
+  if (desc.fwd_output_shape) {
+    const Shape &fwd_output_shape = *desc.fwd_output_shape;
+    TF_ASSIGN_OR_RETURN(
+        DataType fwd_output_type,
+        GetDNNDataTypeFromPrimitiveType(fwd_output_shape.element_type()));
+    config.fwd_output =
+        TensorDescriptor::For(fwd_output_type, fwd_output_shape.dimensions(),
+                              fwd_output_shape.layout().minor_to_major());
+  }
+
+  if (desc.bias_shape) {
+    const Shape &bias_shape = *desc.bias_shape;
+    TF_ASSIGN_OR_RETURN(DataType bias_type, GetDNNDataTypeFromPrimitiveType(
+                                                bias_shape.element_type()));
+    config.bias = TensorDescriptor::For(bias_type, bias_shape.dimensions(),
+                                        bias_shape.layout().minor_to_major());
+  }
+
   config.kind = desc.kind;
+  config.is_flash_attention = desc.is_flash_attention;
+  config.is_causal_mask = desc.is_causal_mask;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
 
@@ -601,9 +646,14 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
     se::DeviceMemoryBase d_output_buffer,
     se::DeviceMemoryBase d_bmm1_lhs_buffer,
     se::DeviceMemoryBase d_bmm1_rhs_buffer,
-    se::DeviceMemoryBase d_bmm2_rhs_buffer, se::DeviceMemoryBase d_s_buffer,
+    se::DeviceMemoryBase d_bmm2_rhs_buffer,
+    std::optional<se::DeviceMemoryBase> d_s_buffer,
+    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
+    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
     std::optional<se::DeviceMemoryBase> mask_buffer,
-    std::optional<se::DeviceMemoryBase> d_bias_buffer) {
+    std::optional<se::DeviceMemoryBase> d_bias_buffer,
+    std::optional<se::DeviceMemoryBase> fwd_output_buffer,
+    std::optional<se::DeviceMemoryBase> bias_buffer) {
   GpufMHABackwardParams params;
   params.config = &config;
   params.bmm1_grad_gemm1_rhs_buffer = bmm1_grad_gemm1_rhs_buffer;
@@ -615,9 +665,12 @@ Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   params.d_bmm1_rhs_buffer = d_bmm1_rhs_buffer;
   params.d_bmm2_rhs_buffer = d_bmm2_rhs_buffer;
   params.d_s_buffer = d_s_buffer;
+  params.softmax_sum_buffer = softmax_sum_buffer;
+  params.d_Q_accum_buffer = d_Q_accum_buffer;
   params.mask_buffer = mask_buffer;
   params.d_bias_buffer = d_bias_buffer;
-
+  params.fwd_output_buffer = fwd_output_buffer;
+  params.bias_buffer = bias_buffer;
   return params;
 }
 
@@ -651,28 +704,32 @@ Status RunGpuFMHA(const GpufMHAConfig &fmha_config,
   return OkStatus();
 }
 
-Status RunGpuFMHABackward(const GpufMHABackwardConfig &fmha_config,
-                          se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
-                          se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
-                          se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
-                          se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
-                          se::DeviceMemoryBase d_output_buffer,
-                          se::DeviceMemoryBase scratch_buffer,
-                          se::DeviceMemoryBase d_bmm1_lhs_buffer,
-                          se::DeviceMemoryBase d_bmm1_rhs_buffer,
-                          se::DeviceMemoryBase d_bmm2_rhs_buffer,
-                          se::DeviceMemoryBase d_s_buffer,
-                          std::optional<se::DeviceMemoryBase> mask_buffer,
-                          std::optional<se::DeviceMemoryBase> d_bias_buffer,
-                          se::Stream *stream,
-                          RunFusedMHABackwardOptions options) {
+Status RunGpuFMHABackward(
+    const GpufMHABackwardConfig &fmha_config,
+    se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+    se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase d_output_buffer, se::DeviceMemoryBase scratch_buffer,
+    se::DeviceMemoryBase d_bmm1_lhs_buffer,
+    se::DeviceMemoryBase d_bmm1_rhs_buffer,
+    se::DeviceMemoryBase d_bmm2_rhs_buffer,
+    std::optional<se::DeviceMemoryBase> d_s_buffer,
+    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
+    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
+    std::optional<se::DeviceMemoryBase> mask_buffer,
+    std::optional<se::DeviceMemoryBase> d_bias_buffer,
+    std::optional<se::DeviceMemoryBase> fwd_output_buffer,
+    std::optional<se::DeviceMemoryBase> bias_buffer, se::Stream *stream,
+    RunFusedMHABackwardOptions options) {
   TF_ASSIGN_OR_RETURN(
       GpufMHABackwardParams params,
       GpufMHABackwardParams::For(
           fmha_config, bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
           bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
           d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
-          d_bmm2_rhs_buffer, d_s_buffer, mask_buffer, d_bias_buffer));
+          d_bmm2_rhs_buffer, d_s_buffer, softmax_sum_buffer, d_Q_accum_buffer,
+          mask_buffer, d_bias_buffer, fwd_output_buffer, bias_buffer));
   PrimitiveType input_primitive_type = fmha_config.input_type;
   switch (input_primitive_type) {
     case F16:

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -201,21 +201,24 @@ void AssignSeed(GpufMHAConfig &config,
 }
 
 template <typename ElementType, typename OutputType>
-Status RunFusedMHABackward(
-    GpufMHABackwardParams params, se::Stream *stream,
-    RunFusedMHABackwardOptions options,
-    DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
-    DeviceMemory<ElementType> bmm1_grad_gemm2_rhs_buffer,
-    DeviceMemory<ElementType> bmm2_grad_gemm1_lhs_buffer,
-    DeviceMemory<ElementType> bmm2_grad_gemm2_rhs_buffer,
-    DeviceMemory<ElementType> d_output_buffer,
-    DeviceMemory<OutputType> d_bmm1_lhs_buffer,
-    DeviceMemory<OutputType> d_bmm1_rhs_buffer,
-    DeviceMemory<OutputType> d_bmm2_rhs_buffer, DeviceMemoryBase d_s_buffer,
-    DeviceMemoryBase softmax_buffer, DeviceMemoryBase d_Q_accum_buffer,
-    DeviceMemoryBase mask_buffer, DeviceMemoryBase d_bias_buffer,
-    DeviceMemoryBase fwd_output_buffer, DeviceMemoryBase bias_buffer,
-    DeviceMemoryBase scratch_memory) {
+Status RunFusedMHABackward(GpufMHABackwardParams params, se::Stream *stream,
+                           RunFusedMHABackwardOptions options,
+                           DeviceMemory<ElementType> bmm1_grad_gemm1_rhs_buffer,
+                           DeviceMemory<ElementType> bmm1_grad_gemm2_rhs_buffer,
+                           DeviceMemory<ElementType> bmm2_grad_gemm1_lhs_buffer,
+                           DeviceMemory<ElementType> bmm2_grad_gemm2_rhs_buffer,
+                           DeviceMemory<ElementType> d_output_buffer,
+                           DeviceMemory<OutputType> d_bmm1_lhs_buffer,
+                           DeviceMemory<OutputType> d_bmm1_rhs_buffer,
+                           DeviceMemory<OutputType> d_bmm2_rhs_buffer,
+                           DeviceMemoryBase d_s_buffer,
+                           DeviceMemoryBase softmax_buffer,
+                           DeviceMemoryBase d_Q_accum_buffer,
+                           DeviceMemoryBase mask_buffer,
+                           DeviceMemoryBase d_bias_buffer,
+                           DeviceMemoryBase fwd_output_buffer,
+                           DeviceMemoryBase bias_buffer,
+                           DeviceMemoryBase scratch_memory) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp> *lazy_runner =
       options.runner_cache->AsFusedMHABackwardRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>
@@ -704,24 +707,25 @@ Status RunGpuFMHA(const GpufMHAConfig &fmha_config,
   return OkStatus();
 }
 
-Status RunGpuFMHABackward(
-    const GpufMHABackwardConfig &fmha_config,
-    se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
-    se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
-    se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
-    se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
-    se::DeviceMemoryBase d_output_buffer, se::DeviceMemoryBase scratch_buffer,
-    se::DeviceMemoryBase d_bmm1_lhs_buffer,
-    se::DeviceMemoryBase d_bmm1_rhs_buffer,
-    se::DeviceMemoryBase d_bmm2_rhs_buffer,
-    std::optional<se::DeviceMemoryBase> d_s_buffer,
-    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
-    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
-    std::optional<se::DeviceMemoryBase> mask_buffer,
-    std::optional<se::DeviceMemoryBase> d_bias_buffer,
-    std::optional<se::DeviceMemoryBase> fwd_output_buffer,
-    std::optional<se::DeviceMemoryBase> bias_buffer, se::Stream *stream,
-    RunFusedMHABackwardOptions options) {
+Status RunGpuFMHABackward(const GpufMHABackwardConfig &fmha_config,
+                          se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+                          se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+                          se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+                          se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+                          se::DeviceMemoryBase d_output_buffer,
+                          se::DeviceMemoryBase scratch_buffer,
+                          se::DeviceMemoryBase d_bmm1_lhs_buffer,
+                          se::DeviceMemoryBase d_bmm1_rhs_buffer,
+                          se::DeviceMemoryBase d_bmm2_rhs_buffer,
+                          std::optional<se::DeviceMemoryBase> d_s_buffer,
+                          std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
+                          std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
+                          std::optional<se::DeviceMemoryBase> mask_buffer,
+                          std::optional<se::DeviceMemoryBase> d_bias_buffer,
+                          std::optional<se::DeviceMemoryBase> fwd_output_buffer,
+                          std::optional<se::DeviceMemoryBase> bias_buffer,
+                          se::Stream *stream,
+                          RunFusedMHABackwardOptions options) {
   TF_ASSIGN_OR_RETURN(
       GpufMHABackwardParams params,
       GpufMHABackwardParams::For(

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -46,6 +46,8 @@ namespace gpu {
 struct GpufMHADescriptor {
   CudnnfMHAKind kind;
   CudnnfMHABackendConfig backend_config;
+  bool is_flash_attention;
+  bool is_causal_mask;
   Shape lhs_bmm1_shape;
   Shape rhs_bmm1_shape;
   Shape rhs_bmm2_shape;
@@ -62,6 +64,8 @@ struct GpufMHADescriptor {
 struct GpufMHABackwardDescriptor {
   CudnnfMHAKind kind;
   CudnnfMHABackendConfig backend_config;
+  bool is_flash_attention;
+  bool is_causal_mask;
   Shape bmm1_grad_gemm1_rhs_shape;
   Shape bmm1_grad_gemm2_rhs_shape;
   Shape bmm2_grad_gemm1_lhs_shape;
@@ -75,8 +79,11 @@ struct GpufMHABackwardDescriptor {
   DotDimensionNumbers bmm2_grad_gemm1_dnums;
   DotDimensionNumbers bmm2_grad_gemm2_dnums;
 
+  std::optional<Shape> d_s_shape;
+  std::optional<Shape> fwd_output_shape;
   std::optional<Shape> mask_shape;
   std::optional<Shape> d_bias_shape;
+  std::optional<Shape> bias_shape;
 };
 // Structure to describe static properties of a GPU fused Multi-Headed
 // Attention.
@@ -91,7 +98,8 @@ struct GpufMHAConfig {
   std::optional<int64_t> seed;
 
   se::dnn::AlgorithmDesc algorithm;
-
+  bool is_flash_attention;
+  bool is_causal_mask;
   // bias -> [1, num_attn_heads, q_seq_len, kv_seq_len]
   // mask -> [batch_size, 1, q_seq_len, kv_seq_len]
   se::dnn::MatmulTensorDescriptor lhs_bmm1;
@@ -119,7 +127,8 @@ struct GpufMHABackwardConfig {
   std::optional<int64_t> seed;
 
   se::dnn::AlgorithmDesc algorithm;
-
+  bool is_flash_attention;
+  bool is_causal_mask;
   // mask -> [batch_size, 1, q_seq_len, kv_seq_len]
   // d_bias -> [1, num_heads, q_seq_len, kv_seq_len]
   se::dnn::MatmulTensorDescriptor bmm1_grad_gemm1_rhs;
@@ -130,9 +139,11 @@ struct GpufMHABackwardConfig {
   se::dnn::TensorDescriptor d_bmm1_lhs;
   se::dnn::TensorDescriptor d_bmm1_rhs;
   se::dnn::TensorDescriptor d_bmm2_rhs;
-  se::dnn::TensorDescriptor d_s;
-  std::optional<se::dnn::TensorDescriptor> d_bias;
+  std::optional<se::dnn::TensorDescriptor> d_s;
   std::optional<se::dnn::TensorDescriptor> mask;
+  std::optional<se::dnn::TensorDescriptor> d_bias;
+  std::optional<se::dnn::TensorDescriptor> fwd_output;
+  std::optional<se::dnn::TensorDescriptor> bias;
 };
 
 // Implementation struct exposed for debugging and log analysis.
@@ -165,9 +176,14 @@ struct GpufMHABackwardParams {
       se::DeviceMemoryBase d_output_buffer,
       se::DeviceMemoryBase d_bmm1_lhs_buffer,
       se::DeviceMemoryBase d_bmm1_rhs_buffer,
-      se::DeviceMemoryBase d_bmm2_rhs_buffer, se::DeviceMemoryBase d_s_buffer,
+      se::DeviceMemoryBase d_bmm2_rhs_buffer,
+      std::optional<se::DeviceMemoryBase> d_s_buffer,
+      std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
+      std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
       std::optional<se::DeviceMemoryBase> mask_buffer,
-      std::optional<se::DeviceMemoryBase> d_bias_buffer);
+      std::optional<se::DeviceMemoryBase> d_bias_buffer,
+      std::optional<se::DeviceMemoryBase> fwd_output_buffer,
+      std::optional<se::DeviceMemoryBase> bias_buffer);
 
   const GpufMHABackwardConfig* config;  // Not owned
   se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer;
@@ -178,9 +194,13 @@ struct GpufMHABackwardParams {
   se::DeviceMemoryBase d_bmm1_lhs_buffer;
   se::DeviceMemoryBase d_bmm1_rhs_buffer;
   se::DeviceMemoryBase d_bmm2_rhs_buffer;
-  se::DeviceMemoryBase d_s_buffer;
-  std::optional<se::DeviceMemoryBase> d_bias_buffer;
+  std::optional<se::DeviceMemoryBase> d_s_buffer;
+  std::optional<se::DeviceMemoryBase> softmax_sum_buffer;
+  std::optional<se::DeviceMemoryBase> d_Q_accum_buffer;
   std::optional<se::DeviceMemoryBase> mask_buffer;
+  std::optional<se::DeviceMemoryBase> d_bias_buffer;
+  std::optional<se::DeviceMemoryBase> fwd_output_buffer;
+  std::optional<se::DeviceMemoryBase> bias_buffer;
 };
 
 class FusedMultiHeadedAttentionRunner {
@@ -371,20 +391,24 @@ Status RunGpuFMHA(const GpufMHAConfig& fmha_config,
                   std::optional<se::DeviceMemoryBase> activation_buffer,
                   se::Stream* stream, RunFusedMHAOptions = {});
 
-Status RunGpuFMHABackward(const GpufMHABackwardConfig& fmha_config,
-                          se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
-                          se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
-                          se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
-                          se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
-                          se::DeviceMemoryBase d_output_buffer,
-                          se::DeviceMemoryBase scratch_buffer,
-                          se::DeviceMemoryBase d_bmm1_lhs_buffer,
-                          se::DeviceMemoryBase d_bmm1_rhs_buffer,
-                          se::DeviceMemoryBase d_bmm2_rhs_buffer,
-                          se::DeviceMemoryBase d_s_buffer,
-                          std::optional<se::DeviceMemoryBase> mask_buffer,
-                          std::optional<se::DeviceMemoryBase> d_bias_buffer,
-                          se::Stream* stream, RunFusedMHABackwardOptions = {});
+Status RunGpuFMHABackward(
+    const GpufMHABackwardConfig& fmha_config,
+    se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+    se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+    se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+    se::DeviceMemoryBase d_output_buffer, se::DeviceMemoryBase scratch_buffer,
+    se::DeviceMemoryBase d_bmm1_lhs_buffer,
+    se::DeviceMemoryBase d_bmm1_rhs_buffer,
+    se::DeviceMemoryBase d_bmm2_rhs_buffer,
+    std::optional<se::DeviceMemoryBase> d_s_buffer,
+    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
+    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
+    std::optional<se::DeviceMemoryBase> mask_buffer,
+    std::optional<se::DeviceMemoryBase> d_bias_buffer,
+    std::optional<se::DeviceMemoryBase> fwd_output_buffer,
+    std::optional<se::DeviceMemoryBase> bias_buffer, se::Stream* stream,
+    RunFusedMHABackwardOptions = {});
 
 std::string ToString(const GpufMHAConfig& config);
 

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -391,24 +391,25 @@ Status RunGpuFMHA(const GpufMHAConfig& fmha_config,
                   std::optional<se::DeviceMemoryBase> activation_buffer,
                   se::Stream* stream, RunFusedMHAOptions = {});
 
-Status RunGpuFMHABackward(
-    const GpufMHABackwardConfig& fmha_config,
-    se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
-    se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
-    se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
-    se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
-    se::DeviceMemoryBase d_output_buffer, se::DeviceMemoryBase scratch_buffer,
-    se::DeviceMemoryBase d_bmm1_lhs_buffer,
-    se::DeviceMemoryBase d_bmm1_rhs_buffer,
-    se::DeviceMemoryBase d_bmm2_rhs_buffer,
-    std::optional<se::DeviceMemoryBase> d_s_buffer,
-    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
-    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
-    std::optional<se::DeviceMemoryBase> mask_buffer,
-    std::optional<se::DeviceMemoryBase> d_bias_buffer,
-    std::optional<se::DeviceMemoryBase> fwd_output_buffer,
-    std::optional<se::DeviceMemoryBase> bias_buffer, se::Stream* stream,
-    RunFusedMHABackwardOptions = {});
+Status RunGpuFMHABackward(const GpufMHABackwardConfig& fmha_config,
+                          se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer,
+                          se::DeviceMemoryBase bmm1_grad_gemm2_rhs_buffer,
+                          se::DeviceMemoryBase bmm2_grad_gemm1_lhs_buffer,
+                          se::DeviceMemoryBase bmm2_grad_gemm2_rhs_buffer,
+                          se::DeviceMemoryBase d_output_buffer,
+                          se::DeviceMemoryBase scratch_buffer,
+                          se::DeviceMemoryBase d_bmm1_lhs_buffer,
+                          se::DeviceMemoryBase d_bmm1_rhs_buffer,
+                          se::DeviceMemoryBase d_bmm2_rhs_buffer,
+                          std::optional<se::DeviceMemoryBase> d_s_buffer,
+                          std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
+                          std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
+                          std::optional<se::DeviceMemoryBase> mask_buffer,
+                          std::optional<se::DeviceMemoryBase> d_bias_buffer,
+                          std::optional<se::DeviceMemoryBase> fwd_output_buffer,
+                          std::optional<se::DeviceMemoryBase> bias_buffer,
+                          se::Stream* stream,
+                          RunFusedMHABackwardOptions = {});
 
 std::string ToString(const GpufMHAConfig& config);
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -232,6 +232,13 @@ StatusOr<xla::gpu::CudnnfMHAKind> AsCudnnBackwardfMHAKind(
     case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
         BackwardScaleBiasMaskSoftmaxDropout:
       return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout;
+      break;
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmax:
+      return xla::gpu::CudnnfMHAKind::kBackwardSoftmax;
+      break;
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmaxDropout:
+      return xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout;
+      break;
     default:
       return xla::InternalError("Unsupported fused_mha_backward_dag_signature");
   }
@@ -1143,6 +1150,11 @@ Status IrEmitterUnnested::EmitFusedMHAThunk(mlir::Operation* op) {
         ShapeUtil::MakeShapeWithDenseLayout(
             GetShape(fmha.getOutput()).element_type(),
             intermediate_tensor_dims_array, intermediate_tensor_layout_array);
+
+    // set if flash attention here
+    descriptor.is_flash_attention = fmha.getIsFlashAttention();
+    // set if causal mask here
+    descriptor.is_causal_mask = fmha.getIsCausalMask();
     return OkStatus();
   };
 
@@ -1170,9 +1182,9 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
   GpufMHABackwardDescriptor descriptor;
   BufferAllocation::Slice bmm1_grad_gemm1_rhs_slice, bmm1_grad_gemm2_rhs_slice,
       bmm2_grad_gemm1_lhs_slice, bmm2_grad_gemm2_rhs_slice, d_output_slice,
-      scratch_slice, mask_slice;
+      scratch_slice, mask_slice, fwd_output_slice, bias_slice;
   BufferAllocation::Slice d_bmm1_lhs_slice, d_bmm1_rhs_slice, d_bmm2_rhs_slice,
-      d_S_slice, d_bias_slice;
+      d_s_slice, softmax_sum_slice, d_Q_accum_slice, d_bias_slice;
 
   auto populate_common = [&](auto fmha) -> Status {
     descriptor.backend_config.set_fmha_scale(
@@ -1202,6 +1214,10 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
       algorithm->mutable_workspace_size()->set_value(workspace_size);
     }
 
+    // set if flash attention here
+    descriptor.is_flash_attention = fmha.getIsFlashAttention();
+    // set if causal mask here
+    descriptor.is_causal_mask = fmha.getIsCausalMask();
     descriptor.bmm1_grad_gemm1_dnums =
         ConvertDotDimensionNumbers(fmha.getBmm1GradGemm1DotDimensionNumbers());
     descriptor.bmm1_grad_gemm2_dnums =
@@ -1225,10 +1241,31 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
     TF_ASSIGN_OR_RETURN(bmm1_grad_gemm2_rhs_slice,
                         GetAllocationSlice(fmha.getBmm1GradGemm2Rhs()));
 
-    descriptor.bmm2_grad_gemm1_lhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
-        GetShape(fmha.getBmm2GradGemm1Lhs()).element_type(),
-        GetShape(fmha.getBmm2GradGemm1Lhs()).dimensions(),
-        GetShape(fmha.getBmm2GradGemm1Lhs()).layout().minor_to_major());
+    // fwd activation
+    // fmha.getBmm2GradGemm1Lhs() could be bmm2_grad_gemm1_lhs for regular
+    // attention or softmax stats for flash attention here we set the shape to
+    // be bmm2_grad_gemm1_lhs even it is flash attention
+    if (descriptor.is_flash_attention) {
+      // flash attention TODO: make sure the layout is correct for
+      // bmm2_grad_gemm1_lhs
+      TF_ASSIGN_OR_RETURN(auto intermediate_tensor_dims_array,
+                          ConvertMlirArrayAttrToInt64Array(
+                              fmha.getIntermediateTensorDimensions()));
+      TF_ASSIGN_OR_RETURN(
+          auto intermediate_tensor_layout_array,
+          ConvertMlirArrayAttrToInt64Array(fmha.getIntermediateTensorLayout()));
+
+      descriptor.bmm2_grad_gemm1_lhs_shape =
+          ShapeUtil::MakeShapeWithDenseLayout(
+              GetShape(fmha.getDOutput()).element_type(),
+              intermediate_tensor_dims_array, intermediate_tensor_layout_array);
+    } else {
+      descriptor.bmm2_grad_gemm1_lhs_shape =
+          ShapeUtil::MakeShapeWithDenseLayout(
+              GetShape(fmha.getBmm2GradGemm1Lhs()).element_type(),
+              GetShape(fmha.getBmm2GradGemm1Lhs()).dimensions(),
+              GetShape(fmha.getBmm2GradGemm1Lhs()).layout().minor_to_major());
+    }
     TF_ASSIGN_OR_RETURN(bmm2_grad_gemm1_lhs_slice,
                         GetAllocationSlice(fmha.getBmm2GradGemm1Lhs()));
 
@@ -1267,7 +1304,13 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
 
     TF_ASSIGN_OR_RETURN(scratch_slice, GetAllocationSlice(fmha.getScratch()));
 
-    TF_ASSIGN_OR_RETURN(d_S_slice, GetAllocationSlice(fmha.getD_S()));
+    if (fmha.getD_S() != nullptr) {
+      descriptor.d_s_shape = ShapeUtil::MakeShapeWithDenseLayout(
+          GetShape(fmha.getD_S()).element_type(),
+          GetShape(fmha.getD_S()).dimensions(),
+          GetShape(fmha.getD_S()).layout().minor_to_major());
+      TF_ASSIGN_OR_RETURN(d_s_slice, GetAllocationSlice(fmha.getD_S()));
+    }
 
     if (fmha.getDBias() != nullptr) {
       descriptor.d_bias_shape = ShapeUtil::MakeShapeWithDenseLayout(
@@ -1291,6 +1334,33 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
 
       TF_ASSIGN_OR_RETURN(mask_slice, GetAllocationSlice(fmha.getMask()));
     }
+    // add flash attention backward related slice here
+    if (fmha.getBias() != nullptr) {
+      descriptor.bias_shape = ShapeUtil::MakeShapeWithDenseLayout(
+          GetShape(fmha.getBias()).element_type(),
+          GetShape(fmha.getBias()).dimensions(),
+          GetShape(fmha.getBias()).layout().minor_to_major());
+      TF_ASSIGN_OR_RETURN(bias_slice, GetAllocationSlice(fmha.getBias()));
+    }
+
+    if (fmha.getSoftmaxSum() != nullptr) {
+      TF_ASSIGN_OR_RETURN(softmax_sum_slice,
+                          GetAllocationSlice(fmha.getSoftmaxSum()));
+    }
+
+    if (fmha.getD_QAccum() != nullptr) {
+      TF_ASSIGN_OR_RETURN(d_Q_accum_slice,
+                          GetAllocationSlice(fmha.getD_QAccum()));
+    }
+
+    if (fmha.getFwdOutput() != nullptr) {
+      descriptor.fwd_output_shape = ShapeUtil::MakeShapeWithDenseLayout(
+          GetShape(fmha.getFwdOutput()).element_type(),
+          GetShape(fmha.getFwdOutput()).dimensions(),
+          GetShape(fmha.getFwdOutput()).layout().minor_to_major());
+      TF_ASSIGN_OR_RETURN(fwd_output_slice,
+                          GetAllocationSlice(fmha.getFwdOutput()));
+    }
     return OkStatus();
   };
 
@@ -1312,7 +1382,8 @@ Status IrEmitterUnnested::EmitFusedMHABackwardThunk(mlir::Operation* op) {
       bmm1_grad_gemm1_rhs_slice, bmm1_grad_gemm2_rhs_slice,
       bmm2_grad_gemm1_lhs_slice, bmm2_grad_gemm2_rhs_slice, d_output_slice,
       scratch_slice, d_bmm1_lhs_slice, d_bmm1_rhs_slice, d_bmm2_rhs_slice,
-      d_S_slice, mask_slice, d_bias_slice));
+      d_s_slice, softmax_sum_slice, d_Q_accum_slice, mask_slice, d_bias_slice,
+      fwd_output_slice, bias_slice));
 
   return OkStatus();
 }

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -29,6 +29,11 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Support/SourceMgr.h"
+#include "tsl/platform/path.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/profiler/lib/traceme.h"
+#include "tsl/util/env_var.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/algebraic_simplifier.h"
 #include "xla/service/call_inliner.h"
@@ -81,11 +86,6 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor_internal.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
-#include "tsl/platform/path.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
-#include "tsl/profiler/lib/traceme.h"
-#include "tsl/util/env_var.h"
 
 namespace xla {
 namespace gpu {
@@ -226,11 +226,11 @@ Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
       mha_fusion_pipeline.AddPass<ReshapeDecomposer>();
       mha_fusion_pipeline.AddPass<LayoutNormalization>();
     }
+
     mha_fusion_pipeline.AddPass<HloCSE>(/*is_layout_sensitive=*/true);
     mha_fusion_pipeline.AddPass<HloPassFix<AlgebraicSimplifier>>(
         alg_sim_options);
     mha_fusion_pipeline.AddPass<HloCSE>(/*is_layout_sensitive=*/true);
-
     // Rewrite Multi-Headed Attention modules to Fused MHA custom-calls.
     if (stream_exec) {
       mha_fusion_pipeline.AddPass<CudnnFusedMHARewriter>(

--- a/xla/service/gpu/runtime/fused_attention.cc
+++ b/xla/service/gpu/runtime/fused_attention.cc
@@ -114,6 +114,10 @@ static auto EncodeFusedAttentionBackwardDAGSignature(
     lmhlo_gpu::FusedMhaBackwardDagSignature signature) {
   switch (signature) {
     // backward
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmax:
+      return xla::gpu::CudnnfMHAKind::kBackwardSoftmax;
+    case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmaxDropout:
+      return xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout;
     case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
         BackwardScaleBiasSoftmax:
       return xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax;
@@ -193,8 +197,8 @@ static GpufMHADescriptor GetGpufMHADescriptor(
     absl::Span<const int64_t> intermediate_tensor_dimensions,
     absl::Span<const int64_t> intermediate_tensor_layout, AlgorithmConfig algo,
     DotDimensionNumbers bmm1_dot_dimension_numbers,
-    DotDimensionNumbers bmm2_dot_dimension_numbers,
-    std::optional<DropoutAttrs> dropout = std::nullopt) {
+    DotDimensionNumbers bmm2_dot_dimension_numbers, bool is_flash_attention,
+    bool is_causal_mask, std::optional<DropoutAttrs> dropout = std::nullopt) {
   GpufMHADescriptor descriptor;
   descriptor.backend_config.set_fmha_scale(fmha_scale);
 
@@ -250,7 +254,8 @@ static GpufMHADescriptor GetGpufMHADescriptor(
   }
 
   descriptor.kind = kind;
-
+  descriptor.is_flash_attention = is_flash_attention;
+  descriptor.is_causal_mask = is_causal_mask;
   return descriptor;
 }
 
@@ -262,11 +267,19 @@ static GpufMHABackwardDescriptor GetGpufMHABackwardDescriptor(
     std::optional<StridedMemrefView> mask,
     std::optional<StridedMemrefView> d_bias, StridedMemrefView d_bmm1_lhs,
     StridedMemrefView d_bmm1_rhs, StridedMemrefView d_bmm2_rhs,
-    StridedMemrefView d_S, double fmha_scale, AlgorithmConfig algo,
+    std::optional<StridedMemrefView> d_S,
+    std::optional<StridedMemrefView> softmax_sum,
+    std::optional<StridedMemrefView> d_Q_accum,
+    std::optional<StridedMemrefView> fwd_output,
+    std::optional<StridedMemrefView> bias, double fmha_scale,
+    AlgorithmConfig algo,
     DotDimensionNumbers bmm1_grad_gemm1_dot_dimension_numbers,
     DotDimensionNumbers bmm1_grad_gemm2_dot_dimension_numbers,
     DotDimensionNumbers bmm2_grad_gemm1_dot_dimension_numbers,
     DotDimensionNumbers bmm2_grad_gemm2_dot_dimension_numbers,
+    absl::Span<const int64_t> intermediate_tensor_dimensions,
+    absl::Span<const int64_t> intermediate_tensor_layout,
+    bool is_flash_attention, bool is_causal_mask,
     std::optional<DropoutAttrs> dropout_attrs = std::nullopt) {
   GpufMHABackwardDescriptor descriptor;
   descriptor.backend_config.set_fmha_scale(fmha_scale);
@@ -313,7 +326,15 @@ static GpufMHABackwardDescriptor GetGpufMHABackwardDescriptor(
   descriptor.bmm1_grad_gemm1_rhs_shape = apply_shape(bmm1_grad_gemm1_rhs);
   descriptor.bmm1_grad_gemm2_rhs_shape = apply_shape(bmm1_grad_gemm2_rhs);
   descriptor.bmm2_grad_gemm2_rhs_shape = apply_shape(bmm2_grad_gemm2_rhs);
-  descriptor.bmm2_grad_gemm1_lhs_shape = apply_shape(bmm2_grad_gemm1_lhs);
+  if (is_flash_attention) {
+    // if it is flash attention then bmm2_grad_gemm1_lhs will be softmax_stats
+    // instead of P we need to use real P layout
+    descriptor.bmm2_grad_gemm1_lhs_shape = ShapeUtil::MakeShapeWithDenseLayout(
+        descriptor.bmm2_grad_gemm2_rhs_shape.element_type(),
+        intermediate_tensor_dimensions, intermediate_tensor_layout);
+  } else {
+    descriptor.bmm2_grad_gemm1_lhs_shape = apply_shape(bmm2_grad_gemm1_lhs);
+  }
 
   descriptor.d_output_shape = apply_shape(d_output);
   descriptor.d_bmm1_lhs_shape = apply_shape(d_bmm1_lhs);
@@ -326,14 +347,20 @@ static GpufMHABackwardDescriptor GetGpufMHABackwardDescriptor(
   if (d_bias.has_value()) {
     descriptor.d_bias_shape = apply_shape(*d_bias);
   }
-
+  if (fwd_output.has_value()) {
+    descriptor.fwd_output_shape = apply_shape(*fwd_output);
+  }
+  if (bias.has_value()) {
+    descriptor.bias_shape = apply_shape(*bias);
+  }
   if (dropout_attrs.has_value()) {
     descriptor.backend_config.set_dropout_rate(dropout_attrs->dropout_rate);
     descriptor.backend_config.set_seed(dropout_attrs->seed);
   }
 
   descriptor.kind = kind;
-
+  descriptor.is_flash_attention = is_flash_attention;
+  descriptor.is_causal_mask = is_causal_mask;
   return descriptor;
 }
 
@@ -344,7 +371,8 @@ static absl::Status FusedAttentionForwardImpl(
     StridedMemrefView rhs_bmm2, std::optional<StridedMemrefView> mask,
     std::optional<StridedMemrefView> bias, StridedMemrefView output,
     FlatMemrefView scratch, std::optional<StridedMemrefView> activation,
-    int64_t uid, double fmha_scale,
+    int64_t uid, double fmha_scale, bool is_flash_attention,
+    bool is_causal_mask,
     absl::Span<const int64_t> intermediate_tensor_dimensions,
     absl::Span<const int64_t> intermediate_tensor_layout,
     DotDimensionNumbers bmm1_dot_dimension_numbers,
@@ -364,7 +392,7 @@ static absl::Status FusedAttentionForwardImpl(
             fmha_scale, intermediate_tensor_dimensions,
             intermediate_tensor_layout, algorithm_config,
             bmm1_dot_dimension_numbers, bmm2_dot_dimension_numbers,
-            dropout_attrs);
+            is_flash_attention, is_causal_mask, dropout_attrs);
 
         StatusOr<GpufMHAConfig> config = GpufMHAConfig::For(descriptor);
         if (!config.ok()) return tsl::ToAbslStatus(config.status());
@@ -414,10 +442,17 @@ static absl::Status FusedAttentionBackwardImpl(
     StridedMemrefView bmm1_grad_gemm2_rhs,
     StridedMemrefView bmm2_grad_gemm2_rhs,
     StridedMemrefView bmm2_grad_gemm1_lhs, StridedMemrefView d_output,
-    std::optional<StridedMemrefView> mask, StridedMemrefView d_bmm1_lhs,
+    std::optional<StridedMemrefView> mask,
+    std::optional<StridedMemrefView> bias,
+    std::optional<StridedMemrefView> fwd_output, StridedMemrefView d_bmm1_lhs,
     StridedMemrefView d_bmm1_rhs, StridedMemrefView d_bmm2_rhs,
-    StridedMemrefView d_S, FlatMemrefView scratch,
+    std::optional<StridedMemrefView> d_S,
+    std::optional<StridedMemrefView> softmax_sum,
+    std::optional<StridedMemrefView> d_Q_accum, FlatMemrefView scratch,
     std::optional<StridedMemrefView> d_bias, int64_t uid, double fmha_scale,
+    bool is_flash_attention, bool is_causal_mask,
+    absl::Span<const int64_t> intermediate_tensor_dimensions,
+    absl::Span<const int64_t> intermediate_tensor_layout,
     DotDimensionNumbers bmm1_grad_gemm1_dot_dimension_numbers,
     DotDimensionNumbers bmm1_grad_gemm2_dot_dimension_numbers,
     DotDimensionNumbers bmm2_grad_gemm1_dot_dimension_numbers,
@@ -436,12 +471,13 @@ static absl::Status FusedAttentionBackwardImpl(
         GpufMHABackwardDescriptor descriptor = GetGpufMHABackwardDescriptor(
             kind, bmm1_grad_gemm1_rhs, bmm1_grad_gemm2_rhs, bmm2_grad_gemm2_rhs,
             bmm2_grad_gemm1_lhs, d_output, mask, d_bias, d_bmm1_lhs, d_bmm1_rhs,
-            d_bmm2_rhs, d_S, fmha_scale, algorithm_config,
-            bmm1_grad_gemm1_dot_dimension_numbers,
+            d_bmm2_rhs, d_S, softmax_sum, d_Q_accum, fwd_output, bias,
+            fmha_scale, algorithm_config, bmm1_grad_gemm1_dot_dimension_numbers,
             bmm1_grad_gemm2_dot_dimension_numbers,
             bmm2_grad_gemm1_dot_dimension_numbers,
-            bmm2_grad_gemm2_dot_dimension_numbers, dropout_attrs);
-
+            bmm2_grad_gemm2_dot_dimension_numbers,
+            intermediate_tensor_dimensions, intermediate_tensor_layout,
+            is_flash_attention, is_causal_mask, dropout_attrs);
         StatusOr<GpufMHABackwardConfig> config =
             GpufMHABackwardConfig::For(descriptor);
         if (!config.ok()) return tsl::ToAbslStatus(config.status());
@@ -463,8 +499,12 @@ static absl::Status FusedAttentionBackwardImpl(
   se::DeviceMemoryBase d_bmm1_lhs_buffer = GetDeviceAddress(d_bmm1_lhs);
   se::DeviceMemoryBase d_bmm1_rhs_buffer = GetDeviceAddress(d_bmm1_rhs);
   se::DeviceMemoryBase d_bmm2_rhs_buffer = GetDeviceAddress(d_bmm2_rhs);
-  se::DeviceMemoryBase d_S_buffer = GetDeviceAddress(d_S);
   se::DeviceMemoryBase scratch_buffer = GetDeviceAddress(scratch);
+
+  se::DeviceMemoryBase d_S_buffer;
+  if (d_S.has_value()) {
+    d_S_buffer = GetDeviceAddress(*d_S);
+  }
 
   se::DeviceMemoryBase mask_buffer;
   if (mask.has_value()) {
@@ -476,6 +516,26 @@ static absl::Status FusedAttentionBackwardImpl(
     d_bias_buffer = GetDeviceAddress(*d_bias);
   }
 
+  se::DeviceMemoryBase softmax_sum_buffer;
+  if (softmax_sum.has_value()) {
+    softmax_sum_buffer = GetDeviceAddress(*softmax_sum);
+  }
+
+  se::DeviceMemoryBase d_Q_accum_buffer;
+  if (d_Q_accum.has_value()) {
+    d_Q_accum_buffer = GetDeviceAddress(*d_Q_accum);
+  }
+
+  se::DeviceMemoryBase fwd_output_buffer;
+  if (fwd_output.has_value()) {
+    fwd_output_buffer = GetDeviceAddress(*fwd_output);
+  }
+
+  se::DeviceMemoryBase bias_buffer;
+  if (bias.has_value()) {
+    bias_buffer = GetDeviceAddress(*bias);
+  }
+
   RunFusedMHABackwardOptions opts;
   opts.runner_cache = &(*fda)->runner;
 
@@ -484,7 +544,9 @@ static absl::Status FusedAttentionBackwardImpl(
       (*fda)->config, bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
       bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer, d_output_buffer,
       scratch_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer, d_bmm2_rhs_buffer,
-      d_S_buffer, mask_buffer, d_bias_buffer, run_options->stream(), opts);
+      d_S_buffer, softmax_sum_buffer, d_Q_accum_buffer, mask_buffer,
+      d_bias_buffer, fwd_output_buffer, bias_buffer, run_options->stream(),
+      opts);
   if (!st.ok() || !run_options->stream()->ok()) {
     return tsl::ToAbslStatus(st);
   }
@@ -500,6 +562,8 @@ auto BindFusedAttentionAttributes(runtime::CustomCallBinding<Ts...> binding) {
   return std::move(binding)
       .template Attr<int64_t>("uid")
       .template Attr<double>("fmha_scale")
+      .template Attr<bool>("is_flash_attention")
+      .template Attr<bool>("is_causal_mask")
       .template Attr<absl::Span<const int64_t>>(
           "intermediate_tensor_dimensions")
       .template Attr<absl::Span<const int64_t>>("intermediate_tensor_layout")
@@ -805,6 +869,11 @@ auto BindFusedAttentionBackwardAttributes(
   return std::move(binding)
       .template Attr<int64_t>("uid")
       .template Attr<double>("fmha_scale")
+      .template Attr<bool>("is_flash_attention")
+      .template Attr<bool>("is_causal_mask")
+      .template Attr<absl::Span<const int64_t>>(
+          "intermediate_tensor_dimensions")
+      .template Attr<absl::Span<const int64_t>>("intermediate_tensor_layout")
       .template Attr<DotDimensionNumbers>(
           "bmm1_grad_gemm1_dot_dimension_numbers")
       .template Attr<DotDimensionNumbers>(
@@ -822,11 +891,11 @@ auto FusedAttentionBackwardCall(const char* name) {
       .UserData<const ServiceExecutableRunOptions*>()
       .UserData<const DebugOptions*>()
       .State<FusedAttentionBackwardRunner>("uid")
-      .Arg<StridedMemrefView>()  // bmm1_grad_gemm1_rhs
-      .Arg<StridedMemrefView>()  // bmm1_grad_gemm2_rhs
-      .Arg<StridedMemrefView>()  // bmm2_grad_gemm2_rhs
-      .Arg<StridedMemrefView>()  // bmm2_grad_gemm1_lhs
-      .Arg<StridedMemrefView>();
+      .Arg<StridedMemrefView>()   // bmm1_grad_gemm1_rhs
+      .Arg<StridedMemrefView>()   // bmm1_grad_gemm2_rhs
+      .Arg<StridedMemrefView>()   // bmm2_grad_gemm2_rhs
+      .Arg<StridedMemrefView>()   // bmm2_grad_gemm1_lhs
+      .Arg<StridedMemrefView>();  // d_output
 }
 
 XLA_RUNTIME_DEFINE_CUSTOM_CALL(
@@ -836,10 +905,14 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.dbias.softmax")
             .Value(std::optional<StridedMemrefView>())  // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
             .Arg<StridedMemrefView>()                   // d_bmm1_lhs
             .Arg<StridedMemrefView>()                   // d_bmm1_rhs
             .Arg<StridedMemrefView>()                   // d_bmm2_rhs
             .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
             .Arg<FlatMemrefView>()                      // scratch
             .Arg<StridedMemrefView>()                   // d_bias
         )
@@ -854,10 +927,14 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.softmax")
             .Value(std::optional<StridedMemrefView>())  // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
             .Arg<StridedMemrefView>()                   // d_bmm1_lhs
             .Arg<StridedMemrefView>()                   // d_bmm1_rhs
             .Arg<StridedMemrefView>()                   // d_bmm2_rhs
             .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
             .Arg<FlatMemrefView>()                      // scratch
             .Value(std::optional<StridedMemrefView>())  // d_bias
         )
@@ -872,10 +949,14 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.dbias.softmax.dropout")
             .Value(std::optional<StridedMemrefView>())  // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
             .Arg<StridedMemrefView>()                   // d_bmm1_lhs
             .Arg<StridedMemrefView>()                   // d_bmm1_rhs
             .Arg<StridedMemrefView>()                   // d_bmm2_rhs
             .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
             .Arg<FlatMemrefView>()                      // scratch
             .Arg<StridedMemrefView>()                   // d_bias
         )
@@ -890,10 +971,14 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.softmax.dropout")
             .Value(std::optional<StridedMemrefView>())  // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
             .Arg<StridedMemrefView>()                   // d_bmm1_lhs
             .Arg<StridedMemrefView>()                   // d_bmm1_rhs
             .Arg<StridedMemrefView>()                   // d_bmm2_rhs
             .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
             .Arg<FlatMemrefView>()                      // scratch
             .Value(std::optional<StridedMemrefView>())  // d_bias
         )
@@ -907,13 +992,17 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
     BindFusedAttentionBackwardAttributes(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.dbias.mask.softmax")
-            .Arg<StridedMemrefView>()  // mask
-            .Arg<StridedMemrefView>()  // d_bmm1_lhs
-            .Arg<StridedMemrefView>()  // d_bmm1_rhs
-            .Arg<StridedMemrefView>()  // d_bmm2_rhs
-            .Arg<StridedMemrefView>()  // d_S
-            .Arg<FlatMemrefView>()     // scratch
-            .Arg<StridedMemrefView>()  // d_bias
+            .Arg<StridedMemrefView>()                   // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
+            .Arg<StridedMemrefView>()                   // d_bmm1_lhs
+            .Arg<StridedMemrefView>()                   // d_bmm1_rhs
+            .Arg<StridedMemrefView>()                   // d_bmm2_rhs
+            .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
+            .Arg<FlatMemrefView>()                      // scratch
+            .Arg<StridedMemrefView>()                   // d_bias
         )
         .Value(std::optional<double>())   // dropout_rate
         .Value(std::optional<int64_t>())  // seed
@@ -926,10 +1015,14 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.mask.softmax")
             .Arg<StridedMemrefView>()                   // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
             .Arg<StridedMemrefView>()                   // d_bmm1_lhs
             .Arg<StridedMemrefView>()                   // d_bmm1_rhs
             .Arg<StridedMemrefView>()                   // d_bmm2_rhs
             .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
             .Arg<FlatMemrefView>()                      // scratch
             .Value(std::optional<StridedMemrefView>())  // d_bias
         )
@@ -943,13 +1036,17 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
     BindFusedAttentionBackwardAttributes(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.dbias.mask.softmax.dropout")
-            .Arg<StridedMemrefView>()  // mask
-            .Arg<StridedMemrefView>()  // d_bmm1_lhs
-            .Arg<StridedMemrefView>()  // d_bmm1_rhs
-            .Arg<StridedMemrefView>()  // d_bmm2_rhs
-            .Arg<StridedMemrefView>()  // d_S
-            .Arg<FlatMemrefView>()     // scratch
-            .Arg<StridedMemrefView>()  // d_bias
+            .Arg<StridedMemrefView>()                   // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
+            .Arg<StridedMemrefView>()                   // d_bmm1_lhs
+            .Arg<StridedMemrefView>()                   // d_bmm1_rhs
+            .Arg<StridedMemrefView>()                   // d_bmm2_rhs
+            .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
+            .Arg<FlatMemrefView>()                      // scratch
+            .Arg<StridedMemrefView>()                   // d_bias
         )
         .Attr<double>("dropout_rate")  // dropout_rate
         .Attr<int64_t>("seed")         // seed
@@ -962,16 +1059,66 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
         FusedAttentionBackwardCall(
             "xla.gpu.fused.attention.backward.scale.mask.softmax.dropout")
             .Arg<StridedMemrefView>()                   // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Value(std::optional<StridedMemrefView>())  // fwd_output
             .Arg<StridedMemrefView>()                   // d_bmm1_lhs
             .Arg<StridedMemrefView>()                   // d_bmm1_rhs
             .Arg<StridedMemrefView>()                   // d_bmm2_rhs
             .Arg<StridedMemrefView>()                   // d_S
+            .Value(std::optional<StridedMemrefView>())  // softmax_sum
+            .Value(std::optional<StridedMemrefView>())  // d_Q_accum
             .Arg<FlatMemrefView>()                      // scratch
             .Value(std::optional<StridedMemrefView>())  // d_bias
         )
         .Attr<double>("dropout_rate")  // dropout_rate
         .Attr<int64_t>("seed")         // seed
 );
+
+// flash attention backward custom call
+XLA_RUNTIME_DEFINE_CUSTOM_CALL(
+    FlashAttentionScaleBiasSoftmaxBackward,
+    FunctionWrapper<FusedAttentionBackwardImpl>(), checks,
+    BindFusedAttentionBackwardAttributes(
+        FusedAttentionBackwardCall(
+            "xla.gpu.flash.attention.backward.scale.bias.softmax")
+            .Value(std::optional<StridedMemrefView>())  // mask
+            .Arg<StridedMemrefView>()                   // bias
+            .Arg<StridedMemrefView>()                   // fwd_output
+            .Arg<StridedMemrefView>()                   // d_bmm1_lhs
+            .Arg<StridedMemrefView>()                   // d_bmm1_rhs
+            .Arg<StridedMemrefView>()                   // d_bmm2_rhs
+            .Value(std::optional<StridedMemrefView>())  // d_S
+            .Arg<StridedMemrefView>()                   // softmax_sum
+            .Arg<StridedMemrefView>()                   // d_Q_accum
+            .Arg<FlatMemrefView>()                      // scratch
+            .Value(std::optional<StridedMemrefView>())  // d_bias
+        )
+        .Value(std::optional<double>())   // dropout_rate
+        .Value(std::optional<int64_t>())  // seed
+);
+
+XLA_RUNTIME_DEFINE_CUSTOM_CALL(
+    FlashAttentionScaleSoftmaxBackward,
+    FunctionWrapper<FusedAttentionBackwardImpl>(), checks,
+    BindFusedAttentionBackwardAttributes(
+        FusedAttentionBackwardCall(
+            "xla.gpu.flash.attention.backward.scale.softmax")
+            .Value(std::optional<StridedMemrefView>())  // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Arg<StridedMemrefView>()                   // fwd_output
+            .Arg<StridedMemrefView>()                   // d_bmm1_lhs
+            .Arg<StridedMemrefView>()                   // d_bmm1_rhs
+            .Arg<StridedMemrefView>()                   // d_bmm2_rhs
+            .Value(std::optional<StridedMemrefView>())  // d_S
+            .Arg<StridedMemrefView>()                   // softmax_sum
+            .Arg<StridedMemrefView>()                   // d_Q_accum
+            .Arg<FlatMemrefView>()                      // scratch
+            .Value(std::optional<StridedMemrefView>())  // d_bias
+        )
+        .Value(std::optional<double>())   // dropout_rate
+        .Value(std::optional<int64_t>())  // seed
+);
+
 //===----------------------------------------------------------------------===//
 // cuBLASLt custom calls bindings and registration.
 //===----------------------------------------------------------------------===//
@@ -1040,6 +1187,14 @@ void RegisterFusedAttentionBackwardCustomCalls(
                     FusedAttentionScaleBiasMaskSoftmaxDropoutBackward);
   registry.Register(fused_attention("scale.mask.softmax.dropout"),
                     FusedAttentionScaleMaskSoftmaxDropoutBackward);
+  // flash attention bwd
+  auto flash_attention = [](std::string name) {
+    return "xla.gpu.flash.attention.backward." + name;
+  };
+  registry.Register(flash_attention("scale.bias.softmax"),
+                    FlashAttentionScaleBiasSoftmaxBackward);
+  registry.Register(flash_attention("scale.softmax"),
+                    FlashAttentionScaleSoftmaxBackward);
 }
 }  // namespace gpu
 }  // namespace xla

--- a/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
+++ b/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
@@ -772,6 +772,12 @@ AsLhloFusedMhaBackwardDagSignature(xla::gpu::CudnnfMHAKind kind) {
       return lmhlo_gpu::FusedMhaBackwardDagSignature::
           BackwardScaleBiasMaskSoftmaxDropout;
       break;
+    case xla::gpu::CudnnfMHAKind::kBackwardSoftmax:
+      return lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmax;
+      break;
+    case xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout:
+      return lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmaxDropout;
+      break;
     default:
       return xla::InternalError("unknown cudnn fmha bwd kind");
   }
@@ -1221,13 +1227,17 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHA(
                                has_activation ? 1 : 0};
     op->setAttr(op.getOperandSegmentSizeAttr(),
                 builder_.getDenseI32ArrayAttr(operand_sizes));
+    // set is flash attention here
+    op.setIsFlashAttentionAttr(
+        builder_.getBoolAttr(config.is_flash_attention()));
+    // set is causal mask here
+    op.setIsCausalMaskAttr(builder_.getBoolAttr(config.is_causal_mask()));
     return op.getOperation();
   };
   llvm::SmallVector<Value, 8> operands;
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(0), &operands));
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(1), &operands));
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(2), &operands));
-
   switch (kind) {
     case xla::gpu::CudnnfMHAKind::kBmmBmm:
     case xla::gpu::CudnnfMHAKind::kSoftmax: {
@@ -1316,8 +1326,11 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
   TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
                       xla::gpu::GetCudnnfMHAKind(custom_call));
 
-  bool has_dbias = custom_call->shape().tuple_shapes().size() == 6;
+  bool is_flash_attention = config.is_flash_attention();
+  bool has_dbias =
+      custom_call->shape().tuple_shapes().size() == 6 && !is_flash_attention;
   bool has_mask = false;
+  bool has_bias = false;
 
   auto set_common_fmha_backward_attributes =
       [&, this](auto op) -> tsl::StatusOr<Operation*> {
@@ -1335,13 +1348,44 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
     op.setBmm2GradGemm2DotDimensionNumbersAttr(GetDotDimensionNumbersAttr(
         builder_, config.bmm2_grad_gemm2_dot_dimension_numbers()));
 
+    auto intermediate_tensor_shape = Shape(config.intermediate_tensor_shape());
+    auto arrayref = [](absl::Span<const int64_t> array) {
+      return llvm::ArrayRef<int64_t>{array.data(), array.size()};
+    };
+    auto intermediate_tensor_dims = builder_.getI64ArrayAttr(
+        arrayref(intermediate_tensor_shape.dimensions()));
+    op.setIntermediateTensorDimensionsAttr(intermediate_tensor_dims);
+
+    auto intermediate_tensor_layout = builder_.getI64ArrayAttr(
+        arrayref(intermediate_tensor_shape.layout().minor_to_major()));
+    op.setIntermediateTensorLayoutAttr(intermediate_tensor_layout);
+
     op.setFmhaScaleAttr(builder_.getF64FloatAttr(config.fmha_scale()));
 
-    int32_t operand_sizes[] = {1, 1, 1, 1, 1, has_mask ? 1 : 0,
-                               1, 1, 1, 1, 1, has_dbias ? 1 : 0};
+    int32_t operand_sizes[] = {1,
+                               1,
+                               1,
+                               1,
+                               1,
+                               has_mask ? 1 : 0,
+                               has_bias ? 1 : 0,
+                               is_flash_attention ? 1 : 0,  // fwd_output
+                               1,
+                               1,
+                               1,
+                               is_flash_attention ? 0 : 1,  // d_S
+                               is_flash_attention ? 1 : 0,  // softmax_sum
+                               is_flash_attention ? 1 : 0,  // d_Q_accum
+                               1,
+                               has_dbias ? 1 : 0};
     op->setAttr(op.getOperandSegmentSizeAttr(),
                 builder_.getDenseI32ArrayAttr(operand_sizes));
 
+    // set is flash attention here
+    op.setIsFlashAttentionAttr(
+        builder_.getBoolAttr(config.is_flash_attention()));
+    // set is causal mask here
+    op.setIsCausalMaskAttr(builder_.getBoolAttr(config.is_causal_mask()));
     const auto& algorithm = config.algorithm();
     std::vector<int64_t> knob_ids;
     std::vector<int64_t> knob_values;
@@ -1357,7 +1401,7 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
     return op.getOperation();
   };
 
-  llvm::SmallVector<Value, 12> operands;
+  llvm::SmallVector<Value, 15> operands;
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(0), &operands));
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(1), &operands));
   TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(2), &operands));
@@ -1366,15 +1410,35 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
 
   switch (kind) {
     case xla::gpu::CudnnfMHAKind::kBackwardBmmBmm:
-    case xla::gpu::CudnnfMHAKind::kBackwardSoftmax:
-    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax: {
+    case xla::gpu::CudnnfMHAKind::kBackwardSoftmax: {
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+      }
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
       auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
           custom_call, operands);
       return set_common_fmha_backward_attributes(fmha_backward);
     }
-    case xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax: {
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        has_bias = true;
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(6), &operands));
+      }
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
+      auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
+          custom_call, operands);
+      return set_common_fmha_backward_attributes(fmha_backward);
+    }
     case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout: {
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        has_bias = true;
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(6), &operands));
+      }
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
       auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
           custom_call, operands);
@@ -1384,9 +1448,26 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
       return set_common_fmha_backward_attributes(fmha_backward);
     }
 
-    case xla::gpu::CudnnfMHAKind::kBackwardScaleMaskSoftmax:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleMaskSoftmax: {
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(6), &operands));
+      }
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
+      has_mask = true;
+      auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
+          custom_call, operands);
+      return set_common_fmha_backward_attributes(fmha_backward);
+    }
     case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        has_bias = true;
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(6), &operands));
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(7), &operands));
+      }
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
       has_mask = true;
       auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
@@ -1394,9 +1475,31 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
       return set_common_fmha_backward_attributes(fmha_backward);
     }
 
-    case xla::gpu::CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout:
+    case xla::gpu::CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout: {
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(6), &operands));
+      }
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
+      has_mask = true;
+      auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
+          custom_call, operands);
+      fmha_backward.setDropoutRateAttr(
+          builder_.getF64FloatAttr(config.dropout_rate()));
+      fmha_backward.setSeedAttr(builder_.getI64IntegerAttr(config.seed()));
+      return set_common_fmha_backward_attributes(fmha_backward);
+    }
     case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout: {
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        has_bias = true;
+        TF_RETURN_IF_ERROR(
+            GetOrCreateView(custom_call->operand(6), &operands));  // bias
+        TF_RETURN_IF_ERROR(
+            GetOrCreateView(custom_call->operand(7), &operands));  // fwd_output
+      }
       TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
       has_mask = true;
       auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(


### PR DESCRIPTION
This is the 2nd PR of splitting https://github.com/openxla/xla/pull/5910 with only MLIR lowering and thunk/runtime
1st PR https://github.com/openxla/xla/pull/6293 merged.

* Added MLIR lowering for flash attention.
* Added thunk/runner/runtime support for flash attention.