### PR TITLE
[NVIDIA XLA] Fix crash caused by unset predicate in CollectivePipeliner::Config

### DIFF
--- a/xla/service/collective_pipeliner.h
+++ b/xla/service/collective_pipeliner.h
@@ -77,11 +77,15 @@ class CollectivePipeliner : public HloModulePass {
     HloPredicate should_process;
     // Filter acceptable formatting ops for for forward piplining to discard
     // cases that pipeline formatting operations that we don't want to support.
-    HloPredicate acceptable_formatting;
+    HloPredicate acceptable_formatting = [](const HloInstruction*) {
+      return true;
+    };
     // If the pipelined op has same input/output size the we reuse  the same
     // buffer we are storing the value in in the output loop for forward
     // pipelining. This function allows to not do it for certain ops.
-    HloPredicate reuse_pipelined_op_buffer;
+    HloPredicate reuse_pipelined_op_buffer = [](const HloInstruction*) {
+      return false;
+    };
   };
   static const char* const kInsertedByPreviousStep;
   static const char* const kSunkByPreviousStep;

--- a/xla/service/collective_pipeliner.h
+++ b/xla/service/collective_pipeliner.h
@@ -77,15 +77,11 @@ class CollectivePipeliner : public HloModulePass {
     HloPredicate should_process;
     // Filter acceptable formatting ops for for forward piplining to discard
     // cases that pipeline formatting operations that we don't want to support.
-    HloPredicate acceptable_formatting = [](const HloInstruction*) {
-      return true;
-    };
+    HloPredicate acceptable_formatting;
     // If the pipelined op has same input/output size the we reuse  the same
     // buffer we are storing the value in in the output loop for forward
     // pipelining. This function allows to not do it for certain ops.
-    HloPredicate reuse_pipelined_op_buffer = [](const HloInstruction*) {
-      return false;
-    };
+    HloPredicate reuse_pipelined_op_buffer;
   };
   static const char* const kInsertedByPreviousStep;
   static const char* const kSunkByPreviousStep;

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -639,7 +639,10 @@ Status GpuCompiler::OptimizeHloModule(HloModule* hlo_module,
           /*process_different_sized_ops=*/true,
           /*pipelining_direction=*/
           CollectivePipeliner::PipeliningDirection::kForward,
-          /*should_process=*/HloPredicateIsOp<HloOpcode::kAllReduce>};
+          /*should_process=*/HloPredicateIsOp<HloOpcode::kAllReduce>,
+          /*acceptable_formatting*/ [](const HloInstruction*) { return true; },
+          /*reuse_pipelined_op_buffer*/
+          [](const HloInstruction*) { return false; }};
       collectives_pipeline.AddPass<CollectivePipeliner>(config);
     }
     if (enable_all_pipelined ||
@@ -652,7 +655,10 @@ Status GpuCompiler::OptimizeHloModule(HloModule* hlo_module,
           /*process_different_sized_ops=*/true,
           /*pipelining_direction=*/
           CollectivePipeliner::PipeliningDirection::kBackward,
-          /*should_process=*/HloPredicateIsOp<HloOpcode::kAllGather>};
+          /*should_process=*/HloPredicateIsOp<HloOpcode::kAllGather>,
+          /*acceptable_formatting*/ [](const HloInstruction*) { return true; },
+          /*reuse_pipelined_op_buffer*/
+          [](const HloInstruction*) { return false; }};
       collectives_pipeline.AddPass<CollectivePipeliner>(config);
     }
     if (enable_all_pipelined ||
@@ -665,7 +671,10 @@ Status GpuCompiler::OptimizeHloModule(HloModule* hlo_module,
           /*process_different_sized_ops=*/true,
           /*pipelining_direction=*/
           CollectivePipeliner::PipeliningDirection::kForward,
-          /*should_process=*/HloPredicateIsOp<HloOpcode::kReduceScatter>};
+          /*should_process=*/HloPredicateIsOp<HloOpcode::kReduceScatter>,
+          /*acceptable_formatting*/ [](const HloInstruction*) { return true; },
+          /*reuse_pipelined_op_buffer*/
+          [](const HloInstruction*) { return false; }};
       collectives_pipeline.AddPass<CollectivePipeliner>(config);
     }
 


### PR DESCRIPTION
Added default values for acceptable_formatting and reuse_pipelined_op_buffer. Otherwise they will crash since gpu_compiler doesnt set these when calling collective pipeliner