### PR TITLE
fix build failure of run_hlo_module and interactive_graphviz

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -420,7 +420,6 @@ cc_library(
     name = "command_buffer",
     srcs = ["command_buffer.cc"],
     hdrs = ["command_buffer.h"],
-    visibility = ["//visibility:private"],
     deps = [
         ":stream_executor_headers",
         ":stream_executor_internal",

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -503,6 +503,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "//xla/stream_executor:command_buffer",
         "//xla/stream_executor:plugin_registry",
         "//xla/stream_executor:stream_executor_headers",
         "//xla/stream_executor:stream_executor_internal",


### PR DESCRIPTION
cuda_executor references command_buffer here: 
https://github.com/openxla/xla/blob/main/xla/stream_executor/cuda/cuda_executor.cc#L426

tsl::Status GpuExecutor::Submit(Stream* stream,
                                const CommandBuffer& command_buffer) {
  if (command_buffer.mode() != CommandBuffer::Mode::kPrimary) {
    return absl::InvalidArgumentError(
        "Can't submit non-primary command buffer for execution");
  }

  auto exec = GpuCommandBuffer::Cast(&command_buffer)->executable();
  VLOG(3) << "Launch command buffer execuable graph " << exec
          << " on a stream: " << stream->DebugStreamPointers();
  return GpuDriver::GraphLaunch(exec, AsGpuStreamValue(stream));
}


There are some missing dependencies declarations