### PR TITLE
[ROCm] fixing static linkage problems

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -432,6 +432,7 @@ cc_library(
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
     ],
+    alwayslink = True,
 )
 
 cc_library(
@@ -465,6 +466,7 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@tsl//tsl/platform:statusor",
     ],
+    alwayslink = True,
 )
 
 cc_library(
@@ -502,6 +504,7 @@ cc_library(
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
     ],
+    alwayslink = True,
 )
 
 cc_library(
@@ -608,6 +611,7 @@ cc_library(
         "@tsl//tsl/protobuf:dnn_proto_cc",
         "@tsl//tsl/util:env_var",
     ],
+    alwayslink = True,
 )
 
 # We have a separate `stream_executor_impl` target because in open source we are building multiple


### PR DESCRIPTION
This is a small fix of static linker errors on ROCm platform. Namely, the following tests fail to build for our nightly CI job:
```
09:16:34  //xla/service/gpu/runtime:topk_kernel_test                      FAILED TO BUILD
09:16:34  //xla/service/gpu/tests:add_preds.hlo.test                      FAILED TO BUILD
09:16:34  //xla/service/gpu/tests:calling_convention.hlo.test             FAILED TO BUILD
09:16:34  //xla/service/gpu/tests:concat.hlo.test                         FAILED TO BUILD
09:16:34  //xla/service/gpu/tests:constant.hlo.test                       FAILED TO BUILD
and also //xla/tests:local_client_aot_test
```
'alwaysLink'=True flag ensures that unused global symbols won't be removed by the compiler during static linkage.
Anyway, I am puzzled why some tests have 'linkStatic' flag set to True. Maybe this was left due to historical reasons ?

@akuegel , @ddunl could some of you have a look ? thanks!