### PR TITLE
[XLA:GPU] Refactor cub_sort_kernel.cu.cc to not use abseil

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1156,10 +1156,7 @@ build_cub_sort_kernels(
         "TENSORFLOW_USE_ROCM=1",
     ]),
     types = get_cub_sort_kernel_types(),
-    deps = if_gpu_is_configured([
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/strings",
-    ]) + if_cuda_is_configured([
+    deps = if_cuda_is_configured([
         ":gpu_prim_cuda",
     ]) + if_rocm_is_configured([
         ":gpu_prim_rocm",

--- a/xla/service/gpu/cub_sort_kernel.h
+++ b/xla/service/gpu/cub_sort_kernel.h
@@ -19,18 +19,20 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 
-#include "absl/status/status.h"
-
 namespace xla {
 namespace gpu {
 
-#define XLA_CUB_DECLARE_SORT_KEYS(suffix)                                     \
-  absl::Status CubSortKeys_##suffix(void* d_temp_storage, size_t& temp_bytes, \
-                                    const void* d_keys_in, void* d_keys_out,  \
-                                    size_t num_items, bool descending);
+// Returns nullptr if no error, otherwise the error message as a null-terminated
+// string (cudaGetErrorString or similar).
+#define XLA_CUB_DECLARE_SORT_KEYS(suffix)                                    \
+  const char* CubSortKeys_##suffix(void* d_temp_storage, size_t& temp_bytes, \
+                                   const void* d_keys_in, void* d_keys_out,  \
+                                   size_t num_items, bool descending);
 
+// Returns nullptr if no error, otherwise the error message as a null-terminated
+// string (cudaGetErrorString or similar).
 #define XLA_CUB_DECLARE_SORT_PAIRS(suffix)                             \
-  absl::Status CubSortPairs_##suffix(                                  \
+  const char* CubSortPairs_##suffix(                                   \
       void* d_temp_storage, size_t& temp_bytes, const void* d_keys_in, \
       void* d_keys_out, const void* d_values_in, void* d_values_out,   \
       size_t num_items, bool descending);


### PR DESCRIPTION
A recent change caused the cuda 11.8 nvcc to barf on any absl::Status use:
```
external/com_google_absl/absl/strings/internal/str_format/bind.h: In constructor 'absl::lts_20230802::str_format_internal::FormatSpecTemplate<Args>::FormatSpecTemplate(const absl::lts_20230802::str_format_internal::ExtendedParsedFormat<absl::lts_20230802::FormatConversionCharSet(C)...>&)':
external/com_google_absl/absl/strings/internal/str_format/bind.h:172:1: error: parse error in template argument list
  172 |     CheckArity<sizeof...(C), sizeof...(Args)>();
      | ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

To be safe and avoid this kind of breakage in this future, this change factors out the absl usage into cub_sort_thunk.cc, so nvcc doesn't interact with it at all.