### PR TITLE
Added py::bytes wrappings to backend config strings in custom partitioner

### DIFF
--- a/xla/python/custom_call_sharding.cc
+++ b/xla/python/custom_call_sharding.cc
@@ -122,7 +122,7 @@ class PyCustomCallPartitioner : public CustomCallPartitioner {
       auto py_result =
           partition_(GetArgShapes(instruction), GetArgShardings(instruction),
                      instruction->shape(), instruction->sharding(),
-                     instruction->raw_backend_config_string());
+                     py::bytes(instruction->raw_backend_config_string()));
 
       const XlaComputation* computation = nullptr;  // Kept alive by py_result.
       std::vector<HloSharding> arg_shardings;
@@ -192,7 +192,7 @@ class PyCustomCallPartitioner : public CustomCallPartitioner {
     // part of the sharding spec.
     auto result = py::cast<HloSharding>(
         prop_user_sharding_(sharding, instruction->shape(),
-                            instruction->raw_backend_config_string()));
+                            py::bytes(instruction->raw_backend_config_string())));
     return result;
   }
   std::optional<HloSharding> InferShardingFromOperands(
@@ -202,7 +202,7 @@ class PyCustomCallPartitioner : public CustomCallPartitioner {
     py::gil_scoped_acquire gil;
     auto py_result = infer_sharding_from_operands_(
         arg_shapes, arg_shardings, instruction->shape(),
-        instruction->raw_backend_config_string());
+        py::bytes(instruction->raw_backend_config_string()));
     if (py_result.is_none()) {
       return std::nullopt;
     }


### PR DESCRIPTION
Fixes #6718 

There was an issue where the registered custom partitioning would pass a normal python string for the backend configuration string. However, python will try to convert this string to utf-8 first. If your configuration string contains non valid utf-8 bytes, this conversion fails with a somewhat cryptic error. 

This PR fixes that issue by wrapping all of the strings in `py::bytes` instead. 


