### PR TITLE
[ROCM] fixing build brakes 231106

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -479,7 +479,8 @@ cc_library(
     name = "graph_launch",
     srcs = ["graph_launch.cc"],
     hdrs = ["graph_launch.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":concurrent_region",
         ":conv",
@@ -558,7 +559,8 @@ cc_library(
     name = "kernel_launch",
     srcs = ["kernel_launch.cc"],
     hdrs = ["kernel_launch.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":concurrent_region",
         ":support",

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -338,7 +338,7 @@ bool DeviceOptionsToContextFlags(const DeviceOptions& device_options,
   unsigned int former_primary_context_flags;
   int former_primary_context_is_active;
   CHECK_EQ(hipSuccess,
-           hipDevicePrimaryCtxGetState(device, &former_primary_context_flags,
+           wrap::hipDevicePrimaryCtxGetState(device, &former_primary_context_flags,
                                        &former_primary_context_is_active));
   if (former_primary_context_flags != flags) {
     if (former_primary_context_is_active) {
@@ -347,15 +347,15 @@ bool DeviceOptionsToContextFlags(const DeviceOptions& device_options,
           << former_primary_context_flags << ") than the desired flag set ("
           << flags << ").";
     } else {
-      CHECK_EQ(hipSuccess, hipDevicePrimaryCtxSetFlags(device, flags));
+      CHECK_EQ(hipSuccess, wrap::hipDevicePrimaryCtxSetFlags(device, flags));
     }
   }
 
   former_context = rocm::CurrentContextOrDie();
-  res = hipDevicePrimaryCtxRetain(&new_context, device);
+  res = wrap::hipDevicePrimaryCtxRetain(&new_context, device);
   if (former_context != nullptr) {
     hipDevice_t former_device;
-    if (hipCtxGetDevice(&former_device) == hipSuccess) {
+    if (wrap::hipCtxGetDevice(&former_device) == hipSuccess) {
       if (former_device == device) {
         if (former_context == new_context) {
           VLOG(2) << "The primary context " << former_context << " for device "
@@ -374,7 +374,7 @@ bool DeviceOptionsToContextFlags(const DeviceOptions& device_options,
                  << former_context;
     }
   }
-  CHECK_EQ(hipSuccess, hipCtxSetCurrent(former_context));
+  CHECK_EQ(hipSuccess, wrap::hipCtxSetCurrent(former_context));
 
   if (res == hipSuccess) {
     *context = CreatedContexts::Add(new_context, device_ordinal);
@@ -404,12 +404,12 @@ bool DeviceOptionsToContextFlags(const DeviceOptions& device_options,
     return;
   }
   hipCtx_t former_context = CurrentContext();
-  hipError_t res = hipCtxSetCurrent(context->context());
+  hipError_t res = wrap::hipCtxSetCurrent(context->context());
   hipDevice_t device;
-  CHECK_EQ(hipSuccess, hipCtxGetDevice(&device));
-  CHECK_EQ(hipSuccess, hipCtxSetCurrent(former_context));
+  CHECK_EQ(hipSuccess, wrap::hipCtxGetDevice(&device));
+  CHECK_EQ(hipSuccess, wrap::hipCtxSetCurrent(former_context));
 
-  res = hipDevicePrimaryCtxRelease(device);
+  res = wrap::hipDevicePrimaryCtxRelease(device);
 
   if (res != hipSuccess) {
     LOG(ERROR) << "failed to release HIP context; leaking: " << ToString(res);
@@ -456,7 +456,7 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
 
 /* static */ tsl::Status GpuDriver::CreateGraph(hipGraph_t* graph) {
   VLOG(2) << "Create new HIP graph";
-  RETURN_IF_ROCM_ERROR(hipGraphCreate(graph, /*flags=*/0),
+  RETURN_IF_ROCM_ERROR(wrap::hipGraphCreate(graph, /*flags=*/0),
                        "Failed to create HIP graph");
   VLOG(2) << "Created HIP graph " << *graph;
   return ::tsl::OkStatus();
@@ -464,7 +464,7 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
 
 /* static */ tsl::Status GpuDriver::DestroyGraph(hipGraph_t graph) {
   VLOG(2) << "Destroy HIP graph " << graph;
-  RETURN_IF_ROCM_ERROR(hipGraphDestroy(graph), "Failed to destroy HIP graph");
+  RETURN_IF_ROCM_ERROR(wrap::hipGraphDestroy(graph), "Failed to destroy HIP graph");
   return ::tsl::OkStatus();
 }
 
@@ -497,7 +497,7 @@ static std::string_view StreamCaptureModeToString(
 
   VLOG(2) << "Beging stream " << stream << " capture in "
           << StreamCaptureModeToString(mode) << " mode";
-  RETURN_IF_ROCM_ERROR(hipStreamBeginCapture(stream, hip_mode),
+  RETURN_IF_ROCM_ERROR(wrap::hipStreamBeginCapture(stream, hip_mode),
                        "Failed to begin stream capture");
   return ::tsl::OkStatus();
 }
@@ -506,7 +506,7 @@ static std::string_view StreamCaptureModeToString(
                                                      hipGraph_t* graph) {
   VLOG(2) << "End stream " << stream << " capture";
 
-  RETURN_IF_ROCM_ERROR(hipStreamEndCapture(stream, graph),
+  RETURN_IF_ROCM_ERROR(wrap::hipStreamEndCapture(stream, graph),
                        "Failed to end stream capture");
 
   return ::tsl::OkStatus();
@@ -520,7 +520,7 @@ static std::string_view StreamCaptureModeToString(
           << "device_launch=" << flags.device_launch << ", "
           << "use_node_priority=" << flags.use_node_prirotiy << ", "
           << "upload=" << flags.upload << ")";
-  RETURN_IF_ROCM_ERROR(hipGraphInstantiate(exec, graph, nullptr, nullptr, 0),
+  RETURN_IF_ROCM_ERROR(wrap::hipGraphInstantiate(exec, graph, nullptr, nullptr, 0),
                        "Failed to instantiate HIP graph");
   return ::tsl::OkStatus();
 }
@@ -529,7 +529,7 @@ static std::string_view StreamCaptureModeToString(
                                                 GpuStreamHandle stream) {
   VLOG(2) << "Launching HIP executable graph " << exec << " on a stream "
           << stream;
-  RETURN_IF_ROCM_ERROR(hipGraphLaunch(exec, stream),
+  RETURN_IF_ROCM_ERROR(wrap::hipGraphLaunch(exec, stream),
                        "Failed to launch HIP graph");
   return ::tsl::OkStatus();
 }
@@ -540,7 +540,7 @@ static std::string_view StreamCaptureModeToString(
 
   hipGraphExecUpdateResult hip_result = hipGraphExecUpdateError;
   hipGraphNode_t error_node = nullptr;
-  auto hip_error = hipGraphExecUpdate(exec, graph, &error_node, &hip_result);
+  auto hip_error = wrap::hipGraphExecUpdate(exec, graph, &error_node, &hip_result);
 
   if (error_node) {
     result->error_node = error_node;
@@ -580,7 +580,7 @@ static std::string_view StreamCaptureModeToString(
 
 /* static */ tsl::Status GpuDriver::DestroyGraphExec(hipGraphExec_t exec) {
   VLOG(2) << "Destroying HIP executable graph" << exec;
-  RETURN_IF_ROCM_ERROR(hipGraphExecDestroy(exec),
+  RETURN_IF_ROCM_ERROR(wrap::hipGraphExecDestroy(exec),
                        "Failed to destroy HIP graph");
   return ::tsl::OkStatus();
 }
@@ -631,7 +631,7 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
   VLOG(2) << "Print HIP graph " << graph << " debug dot file to " << path;
 
   int flags = hipGraphDebugDotFlagsVerbose;
-  RETURN_IF_ROCM_ERROR(hipGraphDebugDotPrint(graph, path, flags),
+  RETURN_IF_ROCM_ERROR(wrap::hipGraphDebugDotPrint(graph, path, flags),
                        "Failed to print gpu graph debug file");
 
   if (VLOG_IS_ON(100)) {
@@ -648,7 +648,7 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
 
 /* static */ tsl::Status GpuDriver::DeviceGraphMemTrim(GpuDeviceHandle device) {
   VLOG(2) << "Trim ROCM device graph memory " << device;
-  RETURN_IF_ROCM_ERROR(hipDeviceGraphMemTrim(device),
+  RETURN_IF_ROCM_ERROR(wrap::hipDeviceGraphMemTrim(device),
                            "Failed to trim device graph memory");
   return tsl::OkStatus();
 }
@@ -658,7 +658,7 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
   VLOG(2) << "Checking if stream " << stream << " is capturing";
 
   hipStreamCaptureStatus status;
-  RETURN_IF_ROCM_ERROR(hipStreamIsCapturing(stream, &status),
+  RETURN_IF_ROCM_ERROR(wrap::hipStreamIsCapturing(stream, &status),
                        "Failed to check stream capturing status");
 
   return status == hipStreamCaptureStatusActive;
@@ -693,14 +693,14 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
 
   if (shared_mem_bytes != 0) {
     RETURN_IF_ROCM_ERROR(
-        hipFuncSetAttribute(function,
+        wrap::hipFuncSetAttribute(function,
                             hipFuncAttributeMaxDynamicSharedMemorySize,
                             shared_mem_bytes),
         "Failed to set shared memory size");
   }
 
   RETURN_IF_ROCM_ERROR(
-      hipGraphAddKernelNode(node, graph, deps.data(), deps.size(), &params),
+      wrap::hipGraphAddKernelNode(node, graph, deps.data(), deps.size(), &params),
       "Failed to add kernel node to a HIP graph");
 
   return ::tsl::OkStatus();
@@ -735,7 +735,7 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
 
   if (shared_mem_bytes != 0) {
     RETURN_IF_ROCM_ERROR(
-        hipFuncSetAttribute(function,
+        wrap::hipFuncSetAttribute(function,
                             hipFuncAttributeMaxDynamicSharedMemorySize,
                             shared_mem_bytes),
         "Failed to set shared memory size");
@@ -937,7 +937,7 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
     GpuContext* context) {
   ScopedActivateContext activated{context};
   hipDevice_t device = -1;
-  hipError_t result = hipCtxGetDevice(&device);
+  hipError_t result = wrap::hipCtxGetDevice(&device);
   if (result == hipSuccess) return device;
 
   return tsl::Status(
@@ -1429,7 +1429,7 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
     hipDeviceptr_t pointer) {
   GpuContext* context = nullptr;
   hipError_t result =
-      hipPointerGetAttribute(&context, HIP_POINTER_ATTRIBUTE_CONTEXT, pointer);
+      wrap::hipPointerGetAttribute(&context, HIP_POINTER_ATTRIBUTE_CONTEXT, pointer);
   if (result == hipSuccess) {
     if (context == nullptr) {
       return tsl::Status(
@@ -1523,7 +1523,7 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
 /* static */ tsl::StatusOr<bool> GpuDriver::GetMFMASupport() {
   hipDeviceProp_t props;
   int dev = 0;
-  hipError_t result = hipGetDevice(&dev);
+  hipError_t result = wrap::hipGetDevice(&dev);
   result = wrap::hipGetDeviceProperties(&props, dev);
   if (result == hipSuccess) {
     std::string gcnArchName = props.gcnArchName;
@@ -1778,7 +1778,7 @@ static tsl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
 /* static */ bool GpuDriver::CanEnablePeerAccess(GpuDeviceHandle from,
                                                  GpuDeviceHandle to) {
   int can_access_peer = -1;
-  hipError_t result = hipDeviceCanAccessPeer(&can_access_peer, from, to);
+  hipError_t result = wrap::hipDeviceCanAccessPeer(&can_access_peer, from, to);
   if (result != hipSuccess) {
     LOG(ERROR) << "failed to detect peer access capability: "
                << ToString(result);

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -646,6 +646,13 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
   return ::tsl::OkStatus();
 }
 
+/* static */ tsl::Status GpuDriver::DeviceGraphMemTrim(GpuDeviceHandle device) {
+  VLOG(2) << "Trim ROCM device graph memory " << device;
+  RETURN_IF_ROCM_ERROR(hipDeviceGraphMemTrim(device),
+                           "Failed to trim device graph memory");
+  return tsl::OkStatus();
+}
+
 /* static */ tsl::StatusOr<bool> GpuDriver::StreamIsCapturing(
     GpuStreamHandle stream) {
   VLOG(2) << "Checking if stream " << stream << " is capturing";

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -79,8 +79,11 @@ namespace wrap {
   __macro(hipDeviceGetName)                         \
   __macro(hipDeviceGetPCIBusId)                     \
   __macro(hipDeviceGetSharedMemConfig)              \
+  __macro(hipDeviceGraphMemTrim)                    \
   __macro(hipDevicePrimaryCtxGetState)              \
   __macro(hipDevicePrimaryCtxSetFlags)              \
+  __macro(hipDevicePrimaryCtxRetain)                \
+  __macro(hipDevicePrimaryCtxRelease)               \
   __macro(hipDeviceSetSharedMemConfig)              \
   __macro(hipDeviceSynchronize)                     \
   __macro(hipDeviceTotalMem)                        \
@@ -94,6 +97,7 @@ namespace wrap {
   __macro(hipFree)                                  \
   __macro(hipFuncSetCacheConfig)                    \
   __macro(hipFuncGetAttribute)                      \
+  __macro(hipFuncSetAttribute)                      \
   __macro(hipGetDevice)                             \
   __macro(hipGetDeviceCount)                        \
   __macro(hipGetDeviceProperties)                   \
@@ -138,6 +142,7 @@ namespace wrap {
   __macro(hipModuleLaunchKernel)                    \
   __macro(hipModuleLoadData)                        \
   __macro(hipModuleUnload)                          \
+  __macro(hipPointerGetAttribute)                   \
   __macro(hipPointerGetAttributes)                  \
   __macro(hipSetDevice)                             \
   __macro(hipDeviceGetStreamPriorityRange)          \

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -283,28 +283,13 @@ tsl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
         hipfunc, rocm_kernel->GetGpuCacheConfig()));
   }
 
-  // prepare kernargs
-  // KernelArgsArrayBase keeps the pointer of arguments
-  // deference them here
-  std::vector<void*> kernargs;
-  KernelArgIterator iter = args.arg_iterator();
-  while (iter.has_next()) {
-    KernelArg arg = iter.next();
-    VLOG(2) << "*(arg.address): "
-            << reinterpret_cast<void*>(
-                   *static_cast<const uint64_t*>(arg.address));
-    kernargs.push_back(
-        reinterpret_cast<void*>(*static_cast<const uint64_t*>(arg.address)));
-  }
-
-  size_t size = sizeof(void*) * kernargs.size();
-  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, kernargs.data(),
-                    HIP_LAUNCH_PARAM_BUFFER_SIZE, &size, HIP_LAUNCH_PARAM_END};
+  void** kernel_params = const_cast<void**>(args.argument_addresses().data());
+  size_t size = sizeof(void*) * args.argument_addresses().size();
 
   return GpuDriver::LaunchKernel(
       GetGpuContext(stream), kernel.name(), hipfunc, block_dims.x, block_dims.y,
       block_dims.z, thread_dims.x, thread_dims.y, thread_dims.z,
-      args.number_of_shared_bytes(), hipstream, nullptr, (void**)&config);
+      args.number_of_shared_bytes(), hipstream, kernel_params, nullptr);
 }
 
 tsl::Status GpuExecutor::Submit(Stream* stream,


### PR DESCRIPTION
This is a PR for fixing ongoing ROCm build brakes due to GpuExecutor interface changes.
Also, HIP calls are now used through the wrapper to utilize lazy loading.

@xla-rotation would you please have a look, please? 