### PR TITLE
[ROCM] fixing rocm buildbrakes 23-11-08

### DIFF
--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1952,7 +1952,7 @@ static Status ProcessFusionForConversion(mlir::Region* region,
   });
 
   region->walk([&](mlir::bufferization::MaterializeInDestinationOp store) {
-    if (!isa<mlir::TensorType>(store.getDest().getType())) return;
+    if (!llvm::isa<mlir::TensorType>(store.getDest().getType())) return;
     if (store.getDest().getParentRegion() != region) {
       stores.push_back(store);
     }

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -283,8 +283,12 @@ tsl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
         hipfunc, rocm_kernel->GetGpuCacheConfig()));
   }
 
-  void** kernel_params = const_cast<void**>(args.argument_addresses().data());
-  size_t size = sizeof(void*) * args.argument_addresses().size();
+  auto* packed_args = DynCast<KernelArgsPackedArrayBase>(&args);
+  if (!packed_args)
+    return absl::InternalError("Unsupported kernel arguments type");
+
+  void** kernel_params =
+      const_cast<void**>(packed_args->argument_addresses().data());
 
   return GpuDriver::LaunchKernel(
       GetGpuContext(stream), kernel.name(), hipfunc, block_dims.x, block_dims.y,


### PR DESCRIPTION
There are two issues here (static_assert was in the meantime already fixed):
- added llvm namespace: strangely enough rocm compiler complains about isa<> template 
- fixed kernel args passing in rocm_gpu_executor

@xla-rotation would you have a look, please?