### PR TITLE
Fix compilation error:  'error: identifier uint64_t is undefined'

### DIFF
--- a/xla/service/gpu/buffer_comparator.cu.cc
+++ b/xla/service/gpu/buffer_comparator.cu.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <stdint.h>
+
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>


### PR DESCRIPTION
Fix compilation error:  'error: identifier uint64_t is undefined'
Introduced by:
```
commit fb67091154574430a8fd17b7eae7ceadd79f7139
Author: Eugene Zhulenev <ezhulenev@google.com>
Date:   Tue Nov 7 15:31:41 2023 -0800

    [xla:gpu] NFC: Split buffer comparator kernel into a separate cuda library

    PiperOrigin-RevId: 580320334
```

@ezhulenev 