### PR TITLE
[ROCm] enable rocm-id for GpuCompiler

### DIFF
--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -14,7 +14,15 @@ load(
     "tf_cuda_tests_tags",
 )
 load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
-
+load(
+    "@tsl//tsl/platform/default:cuda_build_defs.bzl",
+    "if_cuda_is_configured",
+)
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "if_rocm_hipblaslt",
+    "if_rocm_is_configured",
+)
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
     default_visibility = [":friends"],
@@ -2340,6 +2348,8 @@ xla_cc_test(
     name = "llvm_compiler_test",
     srcs = if_gpu_is_configured(["llvm_compiler_test.cc"]),
     tags = tf_cuda_tests_tags(),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM"]),
     deps = if_gpu_is_configured([
         ":verified_hlo_module",
         "//xla:literal_util",
@@ -2352,10 +2362,13 @@ xla_cc_test(
         "//xla/service:platform_util",
         "//xla/service/cpu:cpu_compiler",
         "//xla/service/gpu:gpu_compiler",
-        "//xla/stream_executor",
-        "//xla/stream_executor/cuda:cuda_platform_id",
+        "//xla/stream_executor",        
         "@tsl//tsl/platform:env",
         "@tsl//tsl/platform:test_main",
+        ]) + if_cuda_is_configured([
+            "//xla/stream_executor/cuda:cuda_platform_id",
+        ]) + if_rocm_is_configured([
+            "//xla/stream_executor/rocm:rocm_platform_id",        
     ]),
 )
 

--- a/xla/tests/llvm_compiler_test.cc
+++ b/xla/tests/llvm_compiler_test.cc
@@ -26,7 +26,11 @@ limitations under the License.
 #include "xla/service/cpu/cpu_compiler.h"
 #include "xla/service/gpu/gpu_compiler.h"
 #include "xla/service/platform_util.h"
+#if GOOGLE_CUDA
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
+#elif TENSORFLOW_USE_ROCM
+#include "xla/stream_executor/rocm/rocm_platform_id.h"
+#endif
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/test_helpers.h"
@@ -39,14 +43,18 @@ namespace gpu {
 // Creating dummy data structure needed to initialize a GpuDummyCompiler
 constexpr char kDummyTriple[] = "dummy-triple";
 constexpr char kDummyLayout[] = "e";
-
+const se::Platform::Id kGpuPlatformId = 
+#if GOOGLE_CUDA         
+        se::cuda::kCudaPlatformId;
+#elif TENSORFLOW_USE_ROCM
+        se::rocm::kROCmPlatformId;
+#endif
 // This class is a dummy implementation of GpuCompiler and is targeted for unit
 // test only
 class GpuDummyCompiler : public GpuCompiler {
  public:
   GpuDummyCompiler()
-      : GpuCompiler(se::cuda::kCudaPlatformId, kDummyTriple, kDummyLayout) {}
-
+      : GpuCompiler(kGpuPlatformId, kDummyTriple, kDummyLayout) {}
   Status OptimizeHloConvolutionCanonicalization(
       HloModule* hlo_module, se::GpuComputeCapability gpu_version,
       se::dnn::VersionInfo dnn_version,


### PR DESCRIPTION
This PR has enable llvm_compiler_test on ROCm side due to https://github.com/openxla/xla/commit/5a4af6d13feffc1b7d057925e811645f003d2d9f#diff-dd5a95ee9691db93e5378eed0d4fbfd63c4b1413a7933537f3027c87f4796971


Please check @xla-rotation  Thanks in advance!