### PR TITLE
[NVIDIA XLA GPU] Expose collective matmul trigger in debug options

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -212,7 +212,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_target_config_filename("");
   opts.set_xla_gpu_enable_cub_radix_sort(true);
   opts.set_xla_gpu_enable_cudnn_layer_norm(false);
-
+  opts.set_xla_gpu_threshold_for_windowed_einsum_mib(100000);
   return opts;
 }
 
@@ -1428,6 +1428,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_cub_radix_sort),
       debug_options->xla_gpu_enable_cub_radix_sort(),
       "Enable radix sort using CUB for simple shapes"));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_threshold_for_windowed_einsum_mib",
+      int64_setter_for(
+          &DebugOptions::set_xla_gpu_threshold_for_windowed_einsum_mib),
+      debug_options->xla_gpu_threshold_for_windowed_einsum_mib(),
+      "Threshold to enable windowed einsum (collective matmul) in MB."
+      "Default is 100000"));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -521,7 +521,8 @@ Status GpuCompiler::OptimizeHloModule(HloModule* hlo_module,
         /*is_spmd=*/true, /*propagate_metadata=*/false,
         hlo_module->config().allow_spmd_sharding_propagation_to_output());
     spmd_pipeline.AddPass<spmd::StatefulRngSpmdPartitioner>(
-        num_partitions, hlo_module->config().replica_count());
+        num_partitions, hlo_module->config().replica_count(),
+        debug_options.xla_gpu_threshold_for_windowed_einsum_mib());
     spmd_pipeline.AddPass<CollectivePermuteMotion>();
     TF_RETURN_IF_ERROR(spmd_pipeline.Run(hlo_module).status());
   } else {

--- a/xla/service/spmd/stateful_rng_spmd_partitioner.h
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner.h
@@ -45,9 +45,11 @@ class StatefulRngSpmdPartitioningVisitor
 
 class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
  public:
-  StatefulRngSpmdPartitioner(int64_t num_partitions, int64_t num_replicas)
-      : spmd::SpmdPartitioner(num_partitions, num_replicas,
-                              GetSpmdPartitionerOptions()) {}
+  StatefulRngSpmdPartitioner(int64_t num_partitions, int64_t num_replicas,
+                             int64_t threshold_for_windowed_einsum_mib = 100000)
+      : spmd::SpmdPartitioner(
+            num_partitions, num_replicas,
+            GetSpmdPartitionerOptions(threshold_for_windowed_einsum_mib)) {}
 
  protected:
   std::unique_ptr<spmd::SpmdPartitioningVisitor> CreateVisitor(
@@ -64,12 +66,12 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
       const HloInstruction* hlo) override;
 
  private:
-  static spmd::SpmdPartitionerOptions GetSpmdPartitionerOptions() {
+  static spmd::SpmdPartitionerOptions GetSpmdPartitionerOptions(
+      int64_t threshold_for_windowed_einsum_mib) {
     spmd::SpmdPartitionerOptions options;
     options.allow_module_signature_change = true;
-    // Setting windowed einsum threshold to be large to disable it for GPU by
-    // default.
-    options.threshold_for_windowed_einsum_mib = 100000;
+    options.threshold_for_windowed_einsum_mib =
+        threshold_for_windowed_einsum_mib;
     return options;
   }
 };

--- a/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
@@ -116,6 +116,16 @@ ENTRY entry {
   VerifyNoAllReduce(module.get());
 }
 
+TEST_F(StatefulRngSpmdPartitionerTest, VerifyThresholdSetCorrectly) {
+  auto debug_options = HloTestBase::GetDebugOptionsForTest();
+  int64_t threshold = 400;
+  debug_options.set_xla_gpu_threshold_for_windowed_einsum_mib(threshold);
+  StatefulRngSpmdPartitioner rng_spmd_partitioner(
+      /*num_partitions=*/2, /*num_replicas*/ 1,
+      debug_options.xla_gpu_threshold_for_windowed_einsum_mib());
+  EXPECT_EQ(rng_spmd_partitioner.options().threshold_for_windowed_einsum_mib,
+            threshold);
+}
 }  // namespace
 }  // namespace spmd
 }  // namespace xla

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -672,7 +672,10 @@ message DebugOptions {
   // Enable radix sort using CUB.
   bool xla_gpu_enable_cub_radix_sort = 259;
 
-  // Next id: 265
+  // Threshold to enable windowed einsum (collective matmul) in MB.
+  int64 xla_gpu_threshold_for_windowed_einsum_mib = 265;
+
+  // Next id: 266
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
expose threshold_for_windowed_einsum_mib through debug options as the first step of enabling collective matmul for gpu.