### PR TITLE
[ROCM] fixing build brakes 23-11-13

### DIFF
--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -160,12 +160,12 @@ limitations under the License.
 #include "tsl/protobuf/dnn.pb.h"
 
 #if GOOGLE_CUDA || TF_HIPBLASLT
-#include "xla/service/gpu/cub_sort_thunk.h"
 #include "xla/service/gpu/gpublas_lt_matmul_thunk.h"
-#include "xla/service/gpu/ir_emitter_triton.h"
 #endif  // GOOGLE_CUDA || TF_HIPBLASLT
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "xla/service/gpu/cub_sort_thunk.h"
+#include "xla/service/gpu/ir_emitter_triton.h"
 #include "xla/service/gpu/runtime3/cholesky_thunk.h"
 #include "xla/service/gpu/runtime3/triangular_solve_thunk.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/xla/service/gpu/kernels/BUILD
+++ b/xla/service/gpu/kernels/BUILD
@@ -1,6 +1,3 @@
-load("//xla/tests:build_defs.bzl", "xla_test")
-load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library")
-load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -781,6 +781,18 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
   return tsl::OkStatus();
 }
 
+/*static*/ tsl::Status GpuDriver::GraphExecChildNodeSetParams(
+        GpuGraphExecHandle exec, GpuGraphNodeHandle node, GpuGraphHandle child) {
+  VLOG(2) << "Set child node params " << node << " in graph executable " << exec
+          << "to params contained in " << child;
+
+  RETURN_IF_ROCM_ERROR(
+       wrap::hipGraphExecChildGraphNodeSetParams(exec, node, child),
+       "Failed to set ROCm graph child node params");
+
+  return tsl::OkStatus();
+}
+
 /* static */ tsl::Status GpuDriver::LaunchKernel(
     GpuContext* context, absl::string_view kernel_name, hipFunction_t function,
     unsigned int grid_dim_x, unsigned int grid_dim_y, unsigned int grid_dim_z,

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -106,6 +106,7 @@ namespace wrap {
   __macro(hipGraphAddChildGraphNode)                \
   __macro(hipGraphAddMemcpyNode)                    \
   __macro(hipGraphAddMemcpyNode1D)                  \
+  __macro(hipGraphExecChildGraphNodeSetParams)      \
   __macro(hipGraphCreate)                           \
   __macro(hipGraphDebugDotPrint)                    \
   __macro(hipGraphDestroy)                          \


### PR DESCRIPTION
Here is a fix for the oncoming build brakes due to recebt changes in GpuDriver API.

Besides, I have also fixed the issue with headers in xla/service/gpu/ir_emitter_unnested.cc: otherwise, this would generate linker errors on ROCM platform when TF_HIPBLASLT=0

@xla-rotation: would you have a look, please ?