### PR TITLE
[ROCM] enabling gemm_algorithm_picker on ROCM platform

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -18,7 +18,9 @@ load(
     "@local_config_rocm//rocm:build_defs.bzl",
     "if_rocm_hipblaslt",
     "if_rocm_is_configured",
+    "rocm_copts",
 )
+
 load("@tsl//tsl:tsl.bzl", "if_google", "if_nccl", "tsl_copts", "tsl_gpu_library")
 load("@tsl//tsl:tsl.default.bzl", "filegroup", "get_compatible_with_portable")
 load(
@@ -29,6 +31,7 @@ load(
     "@tsl//tsl/platform:build_config_root.bzl",
     "if_static",
     "tf_cuda_tests_tags",
+    "tf_gpu_tests_tags",
 )
 load(
     "@tsl//tsl/platform/default:cuda_build_defs.bzl",
@@ -1377,9 +1380,8 @@ cc_library(
     name = "gpublas_lt_matmul_thunk",
     srcs = if_gpu_is_configured(["gpublas_lt_matmul_thunk.cc"]),
     hdrs = if_gpu_is_configured(["gpublas_lt_matmul_thunk.h"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = if_gpu_is_configured([
         ":matmul_utils",
         ":thunk",
@@ -1394,10 +1396,11 @@ cc_library(
 
 cc_library(
     name = "gemm_algorithm_picker",
-    srcs = if_cuda_is_configured(["gemm_algorithm_picker.cc"]),
-    hdrs = if_cuda_is_configured(["gemm_algorithm_picker.h"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
-    deps = if_cuda_is_configured([
+    srcs = if_gpu_is_configured(["gemm_algorithm_picker.cc"]),
+    hdrs = if_gpu_is_configured(["gemm_algorithm_picker.h"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    deps = if_gpu_is_configured([
         ":backend_configs_cc",
         ":buffer_comparator",
         ":gemm_thunk",
@@ -1414,8 +1417,7 @@ cc_library(
         "//xla:status_macros",
         "//xla/stream_executor",
         "//xla/stream_executor:blas",
-        "//xla/stream_executor/cuda:cublas_lt_header",
-        "//xla/stream_executor/cuda:cublas_plugin",
+        "//xla/stream_executor/gpu:gpu_blas_lt",
         "//xla/stream_executor:device_memory",
         "//xla/stream_executor:device_memory_allocator",
         "//xla/stream_executor/gpu:redzone_allocator",
@@ -3110,6 +3112,7 @@ cc_library(
         ":autotuner_util",
         ":cusolver_rewriter",
         ":gemm_rewriter",
+        ":gemm_algorithm_picker",
         ":gpu_compiler",
         ":conv_algorithm_picker",
         ":gpu_conv_padding_legalization",
@@ -3466,9 +3469,11 @@ xla_cc_test(
 
 cc_library(
     name = "buffer_comparator",
-    srcs = if_cuda_is_configured(["buffer_comparator.cc"]),
-    hdrs = if_cuda_is_configured(["buffer_comparator.h"]),
-    deps = if_cuda_is_configured([
+    srcs = if_gpu_is_configured(["buffer_comparator.cc"]),
+    hdrs = if_gpu_is_configured(["buffer_comparator.h"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    deps = if_gpu_is_configured([
         ":launch_dimensions",
         ":buffer_comparator_kernel",
         ":gpu_asm_opts_util",
@@ -3488,21 +3493,30 @@ cc_library(
 
 cuda_library(
     name = "buffer_comparator_kernel",
-    srcs = if_cuda_is_configured(["buffer_comparator.cu.cc"]),
-    deps = ["@local_config_cuda//cuda:cuda_headers"],
+    srcs = if_gpu_is_configured(["buffer_comparator.cu.cc"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    copts = rocm_copts(),  
+    deps = if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
 )
 
 xla_cc_test(
     name = "buffer_comparator_test",
-    srcs = if_cuda_is_configured(["buffer_comparator_test.cc"]),
-    tags = tf_cuda_tests_tags(),
+    srcs = if_gpu_is_configured(["buffer_comparator_test.cc"]),
+    tags = tf_gpu_tests_tags(),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":stream_executor_util",
         "//xla:shape_util",
         "//xla:types",
         "@tsl//tsl/platform:test",
         "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
+    ] + if_gpu_is_configured([
         ":buffer_comparator",
         "//xla/stream_executor:device_memory",
     ]),

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "xla/service/gpu/conv_algorithm_picker.h"
 #include "xla/service/gpu/cusolver_rewriter.h"
 #include "xla/service/gpu/gemm_rewriter.h"
+#include "xla/service/gpu/gemm_algorithm_picker.h"
 #include "xla/service/gpu/gpu_conv_padding_legalization.h"
 #include "xla/service/gpu/gpu_conv_rewriter.h"
 #include "xla/service/gpu/gpu_layout_assignment.h"
@@ -153,8 +154,7 @@ Status AMDGPUCompiler::AddConvAndGemmAutotuningPasses(
   if (GpuConvAlgorithmPicker::IsEnabled(hlo_module)) {
     pipeline->AddPass<GpuConvAlgorithmPicker>(autotune_config);
   }
-  // TODO:
-  // pipeline->AddPass<GemmAlgorithmPicker>(autotune_config);
+  pipeline->AddPass<GemmAlgorithmPicker>(autotune_config);
   return OkStatus();
 }
 

--- a/xla/service/gpu/buffer_comparator.cc
+++ b/xla/service/gpu/buffer_comparator.cc
@@ -184,7 +184,7 @@ StatusOr<bool> BufferComparator::CompareEqual(
       return CompareEqualParameterized<tsl::float8_e5m2, float>(
           stream, current, expected, shape_, config_, "fp8_e5m2_comparison",
           buffer_comparator::fp8_e5m2_comparison());
-#endif          
+#endif // GOOGLE_CUDA
     case xla::F16:
       return CompareEqualParameterized<Eigen::half, float>(
           stream, current, expected, shape_, config_, "fp16_comparison",

--- a/xla/service/gpu/buffer_comparator.cc
+++ b/xla/service/gpu/buffer_comparator.cc
@@ -168,7 +168,6 @@ static StatusOr<bool> CompareEqualParameterized(se::Stream* stream,
                                             stream, current, expected)));
   CHECK_EQ(host_return, result)
       << "Host comparison succeeded even though GPU comparison failed.";
-
   return false;
 }
 
@@ -176,6 +175,7 @@ StatusOr<bool> BufferComparator::CompareEqual(
     se::Stream* stream, se::DeviceMemoryBase current,
     se::DeviceMemoryBase expected) const {
   switch (shape_.element_type()) {
+#if GOOGLE_CUDA // not available for ROCm yet..
     case xla::F8E4M3FN:
       return CompareEqualParameterized<tsl::float8_e4m3fn, float>(
           stream, current, expected, shape_, config_, "fp8_e4m3fn_comparison",
@@ -184,6 +184,7 @@ StatusOr<bool> BufferComparator::CompareEqual(
       return CompareEqualParameterized<tsl::float8_e5m2, float>(
           stream, current, expected, shape_, config_, "fp8_e5m2_comparison",
           buffer_comparator::fp8_e5m2_comparison());
+#endif          
     case xla::F16:
       return CompareEqualParameterized<Eigen::half, float>(
           stream, current, expected, shape_, config_, "fp16_comparison",

--- a/xla/service/gpu/buffer_comparator.cu.cc
+++ b/xla/service/gpu/buffer_comparator.cu.cc
@@ -13,9 +13,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#if GOOGLE_CUDA                    
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
+
+using bfloat16 = __nv_bfloat16;
+#define BF16_TO_F32 __bfloat162float
+
+#elif TENSORFLOW_USE_ROCM
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+
+using bfloat16 = hip_bfloat16;
+#define BF16_TO_F32 float
+
+#endif
 
 #include <cstdint>
 
@@ -36,6 +49,7 @@ __device__ __inline__ float Canonicalize(float input) {
   return isnan(input) ? input : max(-65505.0f, min(input, 65505.0f));
 }
 
+#if GOOGLE_CUDA
 __global__ void xla_fp8_e4m3fn_comparison(__nv_fp8_storage_t* buffer_a,
                                           __nv_fp8_storage_t* buffer_b,
                                           float rel_error_threshold,
@@ -81,6 +95,7 @@ __global__ void xla_fp8_e5m2_comparison(__nv_fp8_storage_t* buffer_a,
   if (rel_error > rel_error_threshold || isnan(rel_error))
     atomicAdd(mismatch_count, 1);
 }
+#endif // GOOGLE_CUDA
 
 __global__ void xla_fp16_comparison(__half* buffer_a, __half* buffer_b,
                                     float rel_error_threshold,
@@ -134,15 +149,15 @@ __global__ void xla_fp64_comparison(double* buffer_a, double* buffer_b,
     atomicAdd(mismatch_count, 1);
 }
 
-__global__ void xla_bf16_comparison(__nv_bfloat16* buffer_a,
-                                    __nv_bfloat16* buffer_b,
+__global__ void xla_bf16_comparison(bfloat16* buffer_a,
+                                    bfloat16* buffer_b,
                                     float rel_error_threshold,
                                     uint64_t buffer_length,
                                     int* mismatch_count) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
   if (idx >= buffer_length) return;
-  float elem_a = __bfloat162float(buffer_a[idx]);
-  float elem_b = __bfloat162float(buffer_b[idx]);
+  float elem_a = BF16_TO_F32(buffer_a[idx]);
+  float elem_b = BF16_TO_F32(buffer_b[idx]);
   elem_a = Canonicalize(elem_a);
   elem_b = Canonicalize(elem_b);
   if (isnan(elem_a) && isnan(elem_b)) return;
@@ -182,6 +197,7 @@ __global__ void xla_int32_comparison(int* buffer_a, int* buffer_b,
 
 }  // namespace
 
+#if GOOGLE_CUDA
 void* fp8_e4m3fn_comparison() {
   return reinterpret_cast<void*>(&xla_fp8_e4m3fn_comparison);
 }
@@ -189,6 +205,7 @@ void* fp8_e4m3fn_comparison() {
 void* fp8_e5m2_comparison() {
   return reinterpret_cast<void*>(&xla_fp8_e5m2_comparison);
 }
+#endif
 
 void* fp16_comparison() {
   return reinterpret_cast<void*>(&xla_fp16_comparison);

--- a/xla/service/gpu/buffer_comparator_test.cc
+++ b/xla/service/gpu/buffer_comparator_test.cc
@@ -34,7 +34,11 @@ namespace {
 class BufferComparatorTest : public testing::Test {
  protected:
   BufferComparatorTest()
-      : platform_(se::MultiPlatformManager::PlatformWithName("cuda").value()),
+#if GOOGLE_CUDA  
+      : platform_(se::MultiPlatformManager::PlatformWithName("CUDA").value()),
+#elif TENSORFLOW_USE_ROCM
+      : platform_(se::MultiPlatformManager::PlatformWithName("ROCM").value()),
+#endif
         stream_exec_(platform_->ExecutorForDevice(0).value()) {}
 
   // Take floats only for convenience. Still uses ElementType internally.
@@ -162,7 +166,7 @@ TEST_F(BufferComparatorTest, TestInfs) {
   EXPECT_FALSE(CompareEqualFloatBuffers<double>({inf}, {-20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<double>({-inf}, {20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<double>({-inf}, {-20}));
-
+#if GOOGLE_CUDA
   EXPECT_TRUE(
       CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {std::nanf("")}));
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {inf}));
@@ -182,6 +186,7 @@ TEST_F(BufferComparatorTest, TestInfs) {
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {-20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {-20}));
+#endif // GOOGLE_CUDA 
 }
 
 TEST_F(BufferComparatorTest, TestNumbers) {
@@ -209,7 +214,7 @@ TEST_F(BufferComparatorTest, TestNumbers) {
   EXPECT_TRUE(CompareEqualFloatBuffers<int8_t>({90}, {100}));
   EXPECT_TRUE(CompareEqualFloatBuffers<int8_t>({100}, {90}));
   EXPECT_FALSE(CompareEqualFloatBuffers<int8_t>({-128}, {127}));
-
+#if GOOGLE_CUDA
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({20}, {20.1}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({0}, {1}));
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({0.9}, {1}));
@@ -221,6 +226,7 @@ TEST_F(BufferComparatorTest, TestNumbers) {
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({0.9}, {1}));
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({11}, {12}));
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({12}, {11}));
+#endif // GOOGLE_CUDA 
 }
 
 TEST_F(BufferComparatorTest, TestMultiple) {
@@ -291,7 +297,7 @@ TEST_F(BufferComparatorTest, TestMultiple) {
       rhs[i] = 0;
     }
   }
-
+#if GOOGLE_CUDA
   {
     EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>(
         {20, 30, 40, 50, 60}, {20.1, 30.1, 40.1, 50.1, 60.1}));
@@ -325,6 +331,7 @@ TEST_F(BufferComparatorTest, TestMultiple) {
       rhs[i] = 0;
     }
   }
+#endif // GOOGLE_CUDA  
 }
 
 TEST_F(BufferComparatorTest, BF16) {

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -47,10 +47,8 @@ limitations under the License.
 #include "tsl/platform/statusor.h"
 #include "tsl/util/proto/proto_utils.h"
 
-#if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "xla/service/gpu/buffer_comparator.h"
-#include "xla/stream_executor/cuda/cuda_blas_lt.h"
-#include "xla/stream_executor/gpu/redzone_allocator.h"
 #endif
 
 namespace xla {
@@ -113,7 +111,7 @@ StatusOr<AutotuneResult> GetBestAlgorithm(
     if (!autotune_config.should_check_correctness()) {
       continue;
     }
-
+#if GOOGLE_CUDA // redzone check is not yet available on ROCm
     TF_ASSIGN_OR_RETURN(
         se::RedzoneAllocator::RedzoneCheckStatus rz_check_status,
         allocator.CheckRedzones());
@@ -126,6 +124,7 @@ StatusOr<AutotuneResult> GetBestAlgorithm(
       CHECK(!autotune_config.should_crash_on_check_failure());
       continue;
     }
+#endif
 
     if (!reference_algorithm) {
       stream->ThenMemcpy(&reference_buffer, output_buffer,
@@ -195,31 +194,33 @@ StatusOr<AutotuneResult> GetBestBlasAlgorithm(
 
 namespace {
 
-StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
+using se::gpu::BlasLt;
+
+StatusOr<BlasLt::Epilogue> AsBlasLtEpilogue(
     GemmBackendConfig_Epilogue epilogue) {
   switch (epilogue) {
     case GemmBackendConfig::DEFAULT:
-      return se::gpu::BlasLt::Epilogue::kDefault;
+      return BlasLt::Epilogue::kDefault;
     case GemmBackendConfig::RELU:
-      return se::gpu::BlasLt::Epilogue::kReLU;
+      return BlasLt::Epilogue::kReLU;
     case GemmBackendConfig::GELU:
-      return se::gpu::BlasLt::Epilogue::kGELU;
+      return BlasLt::Epilogue::kGELU;
     case GemmBackendConfig::GELU_AUX:
-      return se::gpu::BlasLt::Epilogue::kGELUWithAux;
+      return BlasLt::Epilogue::kGELUWithAux;
     case GemmBackendConfig::BIAS:
-      return se::gpu::BlasLt::Epilogue::kBias;
+      return BlasLt::Epilogue::kBias;
     case GemmBackendConfig::BIAS_RELU:
-      return se::gpu::BlasLt::Epilogue::kBiasThenReLU;
+      return BlasLt::Epilogue::kBiasThenReLU;
     case GemmBackendConfig::BIAS_GELU:
-      return se::gpu::BlasLt::Epilogue::kBiasThenGELU;
+      return BlasLt::Epilogue::kBiasThenGELU;
     case GemmBackendConfig::BIAS_GELU_AUX:
-      return se::gpu::BlasLt::Epilogue::kBiasThenGELUWithAux;
+      return BlasLt::Epilogue::kBiasThenGELUWithAux;
     default:
       return InternalError("Unsupported Epilogue.");
   }
 }
 
-#if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
     const HloInstruction* gemm, const AutotuneCacheKey& key,
@@ -310,17 +311,17 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
     }
 
     TF_ASSIGN_OR_RETURN(
-        auto plan, se::gpu::BlasLt::GetMatmulPlan(stream, config, epilogue));
+        auto plan, BlasLt::GetMatmulPlan(stream, config, epilogue));
 
     TF_ASSIGN_OR_RETURN(auto algorithms, plan->GetAlgorithms());
 
     TF_ASSIGN_OR_RETURN(
         best_algorithm,
-        GetBestAlgorithm<se::gpu::BlasLt::MatmulAlgorithm>(
+        GetBestAlgorithm<BlasLt::MatmulAlgorithm>(
             stream, buffer_allocator, gemm->ToString(), autotune_config,
             lhs_buffer, rhs_buffer, output_buffer, algorithms, output_shape,
             hlo_module_config, gemm_config.beta(),
-            [&](const se::gpu::BlasLt::MatmulAlgorithm& algorithm)
+            [&](const BlasLt::MatmulAlgorithm& algorithm)
                 -> StatusOr<se::blas::ProfileResult> {
               se::OwningScratchAllocator<> scratch_allocator(
                   stream->parent()->device_ordinal(), allocator);
@@ -335,6 +336,14 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
   } else {
     std::vector<se::blas::AlgorithmType> algorithms;
     TF_RET_CHECK(stream->parent()->GetBlasGemmAlgorithms(stream, &algorithms));
+
+#if TENSORFLOW_USE_ROCM // Blas gemm algorithms are not yet supported
+    if (algorithms.empty()) { // nothing to autotune
+      VLOG(1) << "Skipping autotuning for ROCm..";
+      best_algorithm.mutable_gemm()->set_algorithm(se::blas::kDefaultAlgorithm);
+      return best_algorithm;
+    }
+#endif
 
     TF_ASSIGN_OR_RETURN(
         best_algorithm,
@@ -366,7 +375,7 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
   return best_algorithm;
 }
 
-#endif  // (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // Do Gemm Autotune without stream executor. Use results from autotune cache
 // only.
@@ -390,12 +399,15 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
                         return DoGemmAutotuneNoCache(gemm, key, config);
                       }));
 
-  se::CudaComputeCapability capability = config.GetCudaComputeCapability();
   GemmBackendConfig updated_config = gemm_config;
 
   // We only set the 'algorithm' field on non-Ampere architectures, as for
   // Ampere it's ignored in any case.
-  if (!capability.IsAtLeast(se::CudaComputeCapability::AMPERE)) {
+#if GOOGLE_CUDA
+  auto capability = config.GetCudaComputeCapability();
+  if (!capability.IsAtLeast(se::CudaComputeCapability::AMPERE)) 
+#endif    
+  {
     if (algorithm.has_gemm()) {
       updated_config.set_selected_algorithm(algorithm.gemm().algorithm());
     } else {

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -124,7 +124,7 @@ StatusOr<AutotuneResult> GetBestAlgorithm(
       CHECK(!autotune_config.should_crash_on_check_failure());
       continue;
     }
-#endif
+#endif // GOOGLE_CUDA
 
     if (!reference_algorithm) {
       stream->ThenMemcpy(&reference_buffer, output_buffer,

--- a/xla/service/gpu/gemm_algorithm_picker.h
+++ b/xla/service/gpu/gemm_algorithm_picker.h
@@ -32,9 +32,8 @@ limitations under the License.
 #include "xla/stream_executor/device_memory_allocator.h"
 #include "xla/stream_executor/stream_executor.h"
 
-#if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "xla/service/gpu/gpu_conv_runner.h"
-#include "xla/stream_executor/cuda/cuda_blas_lt.h"
 #include "xla/stream_executor/gpu/redzone_allocator.h"
 #endif
 

--- a/xla/service/gpu/gemm_algorithm_picker_test.cc
+++ b/xla/service/gpu/gemm_algorithm_picker_test.cc
@@ -33,12 +33,22 @@ namespace {
 
 namespace m = ::xla::match;
 
-class GemmAlgorithmPickerTest : public HloTestBase {
+class GemmAlgorithmPickerTest : public HloTestBase,
+        public ::testing::WithParamInterface<bool> {
  public:
-  GemmAlgorithmPickerTest() { AutotunerUtil::ClearAutotuneResults(); }
+  GemmAlgorithmPickerTest() { 
+    AutotunerUtil::ClearAutotuneResults();
+  }
+
+  DebugOptions GetDebugOptionsForTest() override {
+    DebugOptions debug_options = HloTestBase::GetDebugOptionsForTest();
+    debug_options.set_xla_gpu_enable_cublaslt(GetParam());
+    debug_options.set_xla_gpu_enable_triton_gemm(false);
+    return debug_options;
+  }
 };
 
-TEST_F(GemmAlgorithmPickerTest, SetAlgorithm) {
+TEST_P(GemmAlgorithmPickerTest, SetAlgorithm) {
   constexpr absl::string_view kHlo = R"(
 HloModule module
 
@@ -47,7 +57,9 @@ ENTRY main {
   %arg1 = f32[100,100]{1,0} parameter(1)
   ROOT %dot = f32[100,100]{1,0} dot(arg0, arg1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
 })";
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kHlo));
+
+  auto module_cfg = GetModuleConfigForTest();
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kHlo, module_cfg));
 
   se::Platform* platform = PlatformUtil::GetDefaultPlatform().value();
   TF_ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
@@ -57,7 +69,7 @@ ENTRY main {
   bool changed = false;
   TF_ASSERT_OK_AND_ASSIGN(
       changed, RunHloPass(GemmRewriter(stream_exec->GetDeviceDescription()
-                                           .cuda_compute_capability()),
+                                           .gpu_compute_capability()),
                           m.get()));
   changed = false;
   DebugOptions opts;
@@ -79,11 +91,11 @@ ENTRY main {
 
   // Now send the same module through GemmAlgorithmPicker again.  The dot should
   // have the new algorithm.
-  TF_ASSERT_OK_AND_ASSIGN(m, ParseAndReturnVerifiedModule(kHlo));
+  TF_ASSERT_OK_AND_ASSIGN(m, ParseAndReturnVerifiedModule(kHlo, module_cfg));
   changed = false;
   TF_ASSERT_OK_AND_ASSIGN(
       changed, RunHloPass(GemmRewriter(stream_exec->GetDeviceDescription()
-                                           .cuda_compute_capability()),
+                                           .gpu_compute_capability()),
                           m.get()));
   changed = false;
   TF_ASSERT_OK_AND_ASSIGN(changed,
@@ -92,15 +104,20 @@ ENTRY main {
 
   SCOPED_TRACE(m->ToString());
   HloInstruction* dot;
-  ASSERT_THAT(m->entry_computation()->root_instruction(),
-              GmockMatch(m::GetTupleElement(m::CustomCall(&dot), 0)));
+  if(module_cfg.debug_options().xla_gpu_enable_cublaslt()) {
+    ASSERT_THAT(m->entry_computation()->root_instruction(), 
+        GmockMatch(m::CustomCall(&dot)));
+  } else {
+    ASSERT_THAT(m->entry_computation()->root_instruction(), 
+        GmockMatch(m::GetTupleElement(m::CustomCall(&dot), 0)));
+  }
 
   TF_ASSERT_OK_AND_ASSIGN(GemmBackendConfig config,
                           dot->backend_config<GemmBackendConfig>());
   EXPECT_EQ(config.selected_algorithm(), new_algo_id);
 }
 
-TEST_F(GemmAlgorithmPickerTest, GetAlgorithmWithoutDevice) {
+TEST_P(GemmAlgorithmPickerTest, GetAlgorithmWithoutDevice) {
   constexpr absl::string_view kHlo = R"(
 HloModule module
 
@@ -109,7 +126,8 @@ ENTRY main {
   %arg1 = f32[100,100]{1,0} parameter(1)
   ROOT %dot = f32[100,100]{1,0} dot(arg0, arg1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
 })";
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kHlo));
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kHlo, 
+          GetModuleConfigForTest()));
 
   se::Platform* platform = PlatformUtil::GetDefaultPlatform().value();
   TF_ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
@@ -120,7 +138,7 @@ ENTRY main {
   bool changed = false;
   TF_ASSERT_OK_AND_ASSIGN(
       changed, RunHloPass(GemmRewriter(stream_exec->GetDeviceDescription()
-                                           .cuda_compute_capability()),
+                                           .gpu_compute_capability()),
                           m.get()));
   changed = false;
 
@@ -142,9 +160,10 @@ ENTRY main {
   AutotunerUtil::ClearAutotuneResults();
   TF_ASSERT_OK(AutotunerUtil::LoadAutotuneResults(results));
 
+  auto module_cfg = GetModuleConfigForTest();
   // Now send the same module through GemmAlgorithmPicker again.  The dot should
   // have the new algorithm.
-  TF_ASSERT_OK_AND_ASSIGN(m, ParseAndReturnVerifiedModule(kHlo));
+  TF_ASSERT_OK_AND_ASSIGN(m, ParseAndReturnVerifiedModule(kHlo, module_cfg));
   changed = false;
 
   DevicelessConfig deviceless_config{
@@ -153,7 +172,7 @@ ENTRY main {
   AutotuneConfig deviceless_cfg{deviceless_config, opts};
   TF_ASSERT_OK_AND_ASSIGN(
       changed, RunHloPass(GemmRewriter(stream_exec->GetDeviceDescription()
-                                           .cuda_compute_capability()),
+                                           .gpu_compute_capability()),
                           m.get()));
   changed = false;
   TF_ASSERT_OK_AND_ASSIGN(
@@ -162,13 +181,22 @@ ENTRY main {
 
   SCOPED_TRACE(m->ToString());
   HloInstruction* dot;
-  ASSERT_THAT(m->entry_computation()->root_instruction(),
-              GmockMatch(m::GetTupleElement(m::CustomCall(&dot), 0)));
+
+  if(module_cfg.debug_options().xla_gpu_enable_cublaslt()) {
+    ASSERT_THAT(m->entry_computation()->root_instruction(), 
+        GmockMatch(m::CustomCall(&dot)));
+  } else {
+    ASSERT_THAT(m->entry_computation()->root_instruction(), 
+        GmockMatch(m::GetTupleElement(m::CustomCall(&dot), 0)));
+  }
 
   TF_ASSERT_OK_AND_ASSIGN(GemmBackendConfig config,
                           dot->backend_config<GemmBackendConfig>());
   EXPECT_EQ(config.selected_algorithm(), new_algo_id);
 }
+
+INSTANTIATE_TEST_SUITE_P(GemmAlgorithmPickerTestSuite,
+                         GemmAlgorithmPickerTest, ::testing::Bool());
 
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -1979,7 +1979,7 @@ class GemmWorkspaceRewriteVisitor : public DfsHloRewriteVisitor {
     // Pass a user-managed workspace to legacy cuBLAS operations, as
     // otherwise cuBLAS will use its own internal pool which will be competing
     // with XLA allocator for device memory.
-    int64_t workspace = cuda_cc == nullptr ? 0
+    int64_t workspace = cuda_cc == nullptr ? GemmConfig::kDefaultWorkspace
                         : cuda_cc->IsAtLeastHopper()
                             ? GemmConfig::kHopperWorkspace
                             : GemmConfig::kDefaultWorkspace;

--- a/xla/service/gpu/ir_emitter_context.h
+++ b/xla/service/gpu/ir_emitter_context.h
@@ -63,14 +63,17 @@ class IrEmitterContext {
   const se::DeviceDescription& gpu_device_info() const {
     return gpu_device_info_;
   }
+  const se::GpuComputeCapability& gpu_compute_capability() const {
+    return gpu_device_info_.gpu_compute_capability();
+  }
   se::CudaComputeCapability cuda_compute_capability() const {
     auto* cc = std::get_if<se::CudaComputeCapability>(
-        &gpu_device_info_.gpu_compute_capability());
+        &gpu_compute_capability());
     return cc != nullptr ? *cc : se::CudaComputeCapability();
   }
   se::RocmComputeCapability rocm_compute_capability() const {
     auto* cc = std::get_if<se::RocmComputeCapability>(
-        &gpu_device_info_.gpu_compute_capability());
+        &gpu_compute_capability());
     return cc != nullptr ? *cc : se::RocmComputeCapability();
   }
   mlir::MLIRContext* mlir_context() { return mlir_context_; }

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -571,6 +571,7 @@ Status DoGemm(int64_t batch_size, int64_t m, int64_t n, int64_t k,
   se::blas::BlasSupport::ScopedWorkspace scoped_workspace(
       stream->parent()->AsBlas(), &workspace);
 
+// TODO: enable DoGemmWithAlgorithm for ROCm !
 #if GOOGLE_CUDA
   if (algorithm) {
     return DoGemmWithAlgorithm<Scale, Input, Output>(

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -46,9 +46,8 @@ cc_library(
     name = "cholesky",
     srcs = ["cholesky.cc"],
     hdrs = ["cholesky.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":support",
         "//xla:xla_proto_cc",
@@ -491,7 +490,8 @@ cc_library(
     name = "gemm",
     srcs = ["gemm.cc"],
     hdrs = ["gemm.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":support",
         "//xla:status",
@@ -510,7 +510,7 @@ cc_library(
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/status",
         "@tsl//tsl/platform:errors",
-    ] + if_cuda_is_configured([
+    ] + if_gpu_is_configured([
         "//xla/service/gpu:gemm_algorithm_picker",
         "//xla/stream_executor/gpu:redzone_allocator",
     ]),
@@ -626,7 +626,8 @@ cc_library(
     name = "gpublas_lt_matmul",
     srcs = ["gpublas_lt_matmul.cc"],
     hdrs = ["gpublas_lt_matmul.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":support",
         "//xla:xla_proto_cc",
@@ -678,7 +679,8 @@ cc_library(
     name = "support",
     srcs = ["support.cc"],
     hdrs = ["support.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         "//xla:shape_util",
         "//xla/mlir/runtime/transforms:custom_call_encoding",

--- a/xla/service/gpu/runtime/gemm.cc
+++ b/xla/service/gpu/runtime/gemm.cc
@@ -36,7 +36,7 @@ limitations under the License.
 #include "xla/xla.pb.h"
 #include "tsl/platform/errors.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "xla/service/gpu/gemm_algorithm_picker.h"
 #include "xla/stream_executor/gpu/redzone_allocator.h"
 #endif
@@ -48,7 +48,7 @@ using xla::runtime::CustomCall;
 using xla::runtime::State;
 using xla::runtime::StridedMemrefView;
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // TODO(ezhulenev): Delete run time auto tuning from XLA.
 Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
@@ -108,7 +108,7 @@ Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
     return InternalError("Runtime autotuning failed to select an algorithm");
   }
 }
-#endif
+#endif // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 static absl::Status GemmImpl(const ServiceExecutableRunOptions* run_options,
                              const DebugOptions* debug_options,
@@ -144,7 +144,7 @@ static absl::Status GemmImpl(const ServiceExecutableRunOptions* run_options,
   // outside of state.GetOrCreate() because otherwise it would be a potential
   // deadlock.
   if (gemm_config->algorithm == stream_executor::blas::kRuntimeAutotuning) {
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM 
     auto status = DoRuntimeAutotuning(stream, *gemm_config, lhs_data, rhs_data,
                                       output_data, output_shape, beta,
                                       debug_options, gpu_lock);

--- a/xla/service/gpu/runtime/gpublas_lt_matmul.cc
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul.cc
@@ -109,6 +109,11 @@ absl::Status DoMatmul(
   }));
 
   TF_ASSIGN_OR_RETURN(auto algos, (*plan)->GetAlgorithms());
+  if((size_t)algorithm >= algos.size()) {
+    return absl::InternalError("A required gpublas-lt matmul algorithm is not found. "
+            "Total algorithms available: " + std::to_string(algos.size()) + 
+            " algorithm: " + std::to_string(algorithm));
+  }
 
   se::DeviceMemoryBase a_data = GetDeviceAddress(a);
   se::DeviceMemoryBase b_data = GetDeviceAddress(b);

--- a/xla/service/gpu/runtime/gpublas_lt_matmul.cc
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul.cc
@@ -109,10 +109,10 @@ absl::Status DoMatmul(
   }));
 
   TF_ASSIGN_OR_RETURN(auto algos, (*plan)->GetAlgorithms());
-  if((size_t)algorithm >= algos.size()) {
-    return absl::InternalError("A required gpublas-lt matmul algorithm is not found. "
-            "Total algorithms available: " + std::to_string(algos.size()) + 
-            " algorithm: " + std::to_string(algorithm));
+  if(static_cast<size_t>(algorithm) >= algos.size()) {
+    return absl::InternalError(absl::StrFormat("The requested gpublas-lt matmul "
+      "algorithm is not found. Total algorithms available: %zu; requested: %zu",
+        algos.size(), static_cast<size_t>(algorithm)));
   }
 
   se::DeviceMemoryBase a_data = GetDeviceAddress(a);

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -409,7 +409,8 @@ cc_library(
     srcs = if_gpu_is_configured(["redzone_allocator.cc"]),
     hdrs = if_gpu_is_configured(["redzone_allocator.h"]),
     copts = tsl_copts(),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     visibility = set_external_visibility([
         "//xla/service/gpu:__subpackages__",
         "//xla/stream_executor:__subpackages__",
@@ -507,9 +508,8 @@ cc_library(
     name = "gpu_blas_lt",
     srcs = ["gpu_blas_lt.cc"],
     hdrs = ["gpu_blas_lt.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         "//xla:shape_util",
         "//xla:status",

--- a/xla/stream_executor/gpu/redzone_allocator.cc
+++ b/xla/stream_executor/gpu/redzone_allocator.cc
@@ -336,7 +336,7 @@ tsl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
       (LoadKernelOrGetPtr<DeviceMemory<uint8_t>, uint8_t, uint64_t,
                           DeviceMemory<uint64_t>>(
           executor, "redzone_checker", redzone_checker_ptx, compiled_ptx)));
-#else
+#elif TENSORFLOW_USE_ROCM
   TF_ASSIGN_OR_RETURN(
       std::unique_ptr<ComparisonKernelT> loaded_kernel,
       (executor->CreateTypedKernel<DeviceMemory<uint8>, uint8, uint64_t,

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -110,6 +110,7 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_event",
         "//xla/stream_executor/gpu:gpu_kernel_header",
         "//xla/stream_executor/gpu:gpu_command_buffer",
+        "//xla/stream_executor/gpu:gpu_runtime_header",
         "//xla/stream_executor/gpu:gpu_stream",
         "//xla/stream_executor/gpu:gpu_timer",
         "//xla/stream_executor/platform",

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -373,6 +373,7 @@ tsl::Status BlasLt::MatmulPlan::DoMatmul(
     workspace = gpu::GpuMemoryMutable(&alloc);
   }
 
+  auto palgo = std::any_cast<hipblasLtMatmulAlgo_t>(&algorithm.opaque_algo);
   {
     absl::MutexLock lock(&blas_lt_ref_.mu_);
     TF_RET_CHECK(blas_lt_ref_.blas_lt_ != nullptr);
@@ -399,8 +400,7 @@ tsl::Status BlasLt::MatmulPlan::DoMatmul(
 
     gpu::ScopedActivateExecutorContext sac{blas_lt_ref_.parent_};
 
-    if (auto palgo =
-            std::any_cast<hipblasLtMatmulAlgo_t>(&algorithm.opaque_algo)) {
+    if (palgo != nullptr) {
       SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatmul(
           blas_lt_ref_.blas_lt_.get(), op_desc_.get(), alpha, a.opaque(),
           a_desc_.get(), b.opaque(), b_desc_.get(), beta, c.opaque(),
@@ -413,6 +413,8 @@ tsl::Status BlasLt::MatmulPlan::DoMatmul(
 
   if (profile_result != nullptr) {
     TF_ASSIGN_OR_RETURN(absl::Duration elapsed, timer->GetElapsedDuration());
+    // set algorithm ID to be unique (otherwise it gets kDefaultAlgorithm ID)
+    profile_result->set_algorithm(reinterpret_cast<blas::AlgorithmType>(palgo));
     profile_result->set_is_valid(true);
     profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
   }

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -432,7 +432,11 @@ bool DeviceOptionsToContextFlags(const DeviceOptions& device_options,
 
 /* static */ tsl::Status GpuDriver::FuncSetCacheConfig(
     hipFunction_t function, hipFuncCache_t cache_config) {
-  RETURN_IF_ROCM_ERROR(wrap::hipFuncSetCacheConfig(function, cache_config),
+
+  // NOTE: this function is only available for in-process GPU kernels: 
+  // https://rocm.docs.amd.com/projects/HIP/en/latest/.doxygen/docBin/html/group___execution.html#gafdb33ef569eb89808fc5178d04b508ba
+  // but it is no-op for the current HIP release !
+  RETURN_IF_ROCM_ERROR(wrap::hipFuncSetCacheConfig((const void *)function, cache_config),
                        "Failed to set ROCM kernel cache config.");
   return tsl::OkStatus();
 }
@@ -804,13 +808,27 @@ GpuDriver::GraphNodeGetType(hipGraphNode_t node) {
           << " gdy: " << grid_dim_y << " gdz: " << grid_dim_z
           << " bdx: " << block_dim_x << " bdy: " << block_dim_y
           << " bdz: " << block_dim_z << " smem: " << shared_mem_bytes;
-  RETURN_IF_ROCM_ERROR(wrap::hipModuleLaunchKernel(
-                           function, grid_dim_x, grid_dim_y, grid_dim_z,
-                           block_dim_x, block_dim_y, block_dim_z,
-                           shared_mem_bytes, stream, kernel_params, extra),
-                       "Failed to launch ROCm kernel: ", kernel_name,
+
+  // for in-process kernel this function returns mangled kernel function name,
+  // and null otherwise
+  auto name = wrap::hipKernelNameRefByPtr((const void *)function, stream);
+
+  auto res = hipSuccess;
+  if(name != nullptr) {
+    res = wrap::hipLaunchKernel(
+               (const void *)function, dim3(grid_dim_x, grid_dim_y, grid_dim_z),
+                dim3(block_dim_x, block_dim_y, block_dim_z),
+                kernel_params, shared_mem_bytes, stream);  
+  } else {
+    res = wrap::hipModuleLaunchKernel(
+                function, grid_dim_x, grid_dim_y, grid_dim_z,
+                block_dim_x, block_dim_y, block_dim_z,
+                shared_mem_bytes, stream, kernel_params, extra);
+  }
+  RETURN_IF_ROCM_ERROR(res, "Failed to launch ROCm kernel: ", kernel_name,
                        " with block dimensions: ", block_dim_x, "x",
-                       block_dim_y, "x", block_dim_z);
+                       block_dim_y, "x", block_dim_z);  
+
   VLOG(2) << "successfully launched kernel";
   return tsl::OkStatus();
 }

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -120,7 +120,9 @@ namespace wrap {
   __macro(hipHostRegister)                          \
   __macro(hipHostUnregister)                        \
   __macro(hipInit)                                  \
+  __macro(hipKernelNameRefByPtr)                    \
   __macro(hipLaunchHostFunc)                        \
+  __macro(hipLaunchKernel)                          \
   __macro(hipMalloc)                                \
   __macro(hipMemGetAddressRange)                    \
   __macro(hipMemGetInfo)                            \

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_event.h"
 #include "xla/stream_executor/gpu/gpu_executor.h"
 #include "xla/stream_executor/gpu/gpu_kernel.h"
+#include "xla/stream_executor/gpu/gpu_runtime.h"
 #include "xla/stream_executor/gpu/gpu_stream.h"
 #include "xla/stream_executor/gpu/gpu_timer.h"
 #include "xla/stream_executor/platform.h"
@@ -201,13 +202,7 @@ tsl::Status GpuExecutor::GetKernel(const MultiKernelLoaderSpec& spec,
   hipModule_t module = nullptr;
   const string* kernel_name;
 
-  const OnDiskKernelLoaderSpec* on_disk_spec = nullptr;
-
-  VLOG(3) << "GetKernel on kernel " << kernel << " : " << kernel->name();
-
-  if (spec.has_cuda_cubin_on_disk()) on_disk_spec = &spec.cuda_cubin_on_disk();
-
-  if (on_disk_spec != nullptr) {
+  if (spec.has_cuda_cubin_on_disk()) {
     return tsl::errors::Internal(
         "Loading ROCM kernel from disk is not supported");
   } else if (spec.has_cuda_cubin_in_memory()) {
@@ -221,22 +216,40 @@ tsl::Status GpuExecutor::GetKernel(const MultiKernelLoaderSpec& spec,
       TF_RETURN_IF_ERROR(GpuDriver::LoadHsaco(context_, hsaco, &module));
     }
     kernel_to_gpu_binary_[kernel] = hsaco;
+  } else if (spec.has_in_process_symbol()) {
+
+    kernel_name = &spec.in_process_symbol().kernel_name();
+    void* symbol = spec.in_process_symbol().symbol();
+
+    VLOG(1) << "Resolve ROCM kernel " << *kernel_name
+            << " from symbol pointer: " << symbol;
+
+    *rocm_kernel->gpu_function_ptr() = static_cast< hipFunction_t >(
+            spec.in_process_symbol().symbol());
   } else {
     return tsl::errors::Internal("No method of loading ROCM kernel provided");
   }
 
-  VLOG(2) << "getting function " << *kernel_name << " from module " << module;
-  TF_RETURN_IF_ERROR(GpuDriver::GetModuleFunction(
+  // If we resolved kernel from a symbol pointer, there is no need to load it
+  // from a module, as ROCm runtime did that automatically for us.
+  if (!spec.has_in_process_symbol()) {
+    VLOG(2) << "getting function " << *kernel_name << " from module " << module;
+    TF_RETURN_IF_ERROR(GpuDriver::GetModuleFunction(
       context_, module, kernel_name->c_str(), rocm_kernel->gpu_function_ptr()));
+  }
 
   // We have to trust the kernel loader spec arity because there doesn't appear
   // to be a way to reflect on the number of expected arguments w/the ROCM API.
   rocm_kernel->set_arity(spec.arity());
 
-  KernelMetadata kernel_metadata;
-  TF_RETURN_IF_ERROR(GetKernelMetadata(rocm_kernel, &kernel_metadata));
-  kernel->set_metadata(kernel_metadata);
+  // unable to get kernel metadata for in-process kernel
+  if (!spec.has_in_process_symbol()) {
+    KernelMetadata kernel_metadata;
+    TF_RETURN_IF_ERROR(GetKernelMetadata(rocm_kernel, &kernel_metadata));
+    kernel->set_metadata(kernel_metadata);
+  }
   kernel->set_name(*kernel_name);
+  kernel->set_kernel_args_packing(spec.kernel_args_packing());
   return tsl::OkStatus();
 }
 
@@ -275,7 +288,7 @@ tsl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
       launched_kernels_.insert(hipfunc);
     }
   }
-
+  
   if (rocm_kernel->GetPreferredCacheConfig() !=
       KernelCacheConfig::kNoPreference) {
     TF_RETURN_IF_ERROR(GpuDriver::FuncSetCacheConfig(


### PR DESCRIPTION
Here we enable gemm_algorithm_picker  as well as buffer_comparator on ROCM.

Some comments are due:

- the function BlasSupport::DoBlasGemmWithAlgorithm is currently NYI, therefore, I integrated a workaround to skip autotuning on ROCm for Blas (i.e. only Blas-lt autotuning is supported on ROCm).

- there is no support for in-process kernels through driver API: so I added a temporary workaround until a required function is added to HIP runtime (basically, the analogue of **cudaGetFuncBySymbol** is needed

- bugfixed algorithm selection for hip/cuda-blas-lt gemms: previously blas-lt API did not set algorithm ID in blas::ProfileResult, hence autotuning always returned **kDefaultAlgorithm**: see xla/stream_executor/cuda/cuda_blas_lt.cc and xla/stream_executor/rocm/hip_blas_lt.cc, respectively

- extended xla/service/gpu/gemm_algorithm_picker_test.cc to test not only for blas$gemm but also for blas$lt$gemm (added a test boolean parameter)

- added vector size check in xla/service/gpu/runtime/gpublas_lt_matmul.cc which otherwise may crash if the number of found algorithms is too small


@xla-rotation: would you have a look, please ?