### PR TITLE
Incresed the tolerance for Ampere 

### DIFF
--- a/xla/service/gpu/ir_emitter_triton_test.cc
+++ b/xla/service/gpu/ir_emitter_triton_test.cc
@@ -1445,7 +1445,7 @@ ENTRY e {
       GmockMatch(m::Fusion(m::Parameter(), m::Parameter(), m::Parameter())
                      .WithFusionKind(HloInstruction::FusionKind::kCustom)));
 
-  EXPECT_TRUE(RunAndCompare(kHloText, ErrorSpec{/*aabs=*/1e-1, /*arel=*/1e-3}));
+  EXPECT_TRUE(RunAndCompare(kHloText, ErrorSpec{/*aabs=*/1e-1, /*arel=*/1e-2}));
 }
 
 TEST_F(TritonGemmLevel2Test, BinaryOperationWithLargeInputsIsNotFused) {


### PR DESCRIPTION
The TritonGemmLevel2Test.BinaryOperationWithSmallInputsIsFused. fails on A100 gpu, cuda version is 12.1.
It passes on volta. Increasing the relative error is increased to 1e-2(default is 1e-3) for A100 to pass it on A100 gpu. 

