### PR TITLE
Fix incorrect device memory limit on non root processes.

### DIFF
--- a/xla/python/py_client.cc
+++ b/xla/python/py_client.cc
@@ -375,9 +375,15 @@ StatusOr<std::shared_ptr<PyLoadedExecutable>> PyClient::Compile(
   auto* pjrt_compatible_client =
       llvm::dyn_cast_or_null<ifrt::PjRtCompatibleClient>(ifrt_client_.get());
   if (pjrt_compatible_client != nullptr) {
-    auto devices = pjrt_compatible_client->pjrt_client()->devices();
-    if (!devices.empty()) {
-      auto stats = devices[0]->GetAllocatorStats();
+    auto addressable_devices =
+        pjrt_compatible_client->pjrt_client()->addressable_devices();
+    if (!addressable_devices.empty()) {
+      int device_ordinal = options.executable_build_options.device_ordinal();
+      if (device_ordinal < 0) {
+        device_ordinal = 0;
+      }
+      CHECK_LT(device_ordinal, addressable_devices.size());
+      auto stats = addressable_devices[device_ordinal]->GetAllocatorStats();
       if (stats.ok() && stats->bytes_limit) {
         options.executable_build_options.set_device_memory_size(
             *stats->bytes_limit);


### PR DESCRIPTION
@hawkinsp 

In a multiprocess config, this code was attempting to get the memory limit from device 0 which is only local to process 0. For all other processes, the memory limit was being set to 0.

This was causing the memory limit in the latency hiding scheduler to be different between process 0 and the other processes, leading to a different scheduled order of collectives and causing deadlocks.


To fix this, use addressable_devices instead of all global device and index using the device_ordinal.
Currently, jax doesn't appear to set `options.executable_build_options.device_ordinal()` so we will default to 0 in that case.

