### PR TITLE
Pre-prepare profiler annotations for kernels/thunks and modules

### DIFF
--- a/third_party/tsl/tsl/profiler/lib/BUILD
+++ b/third_party/tsl/tsl/profiler/lib/BUILD
@@ -4,6 +4,10 @@ load("//tsl:tsl.default.bzl", "filegroup")
 load("//tsl:tsl.bzl", "if_not_android", "set_external_visibility")
 load("//tsl/platform:build_config.bzl", "tsl_cc_test")
 load(
+    "//tsl/platform/default:cuda_build_defs.bzl",
+    "if_cuda_is_configured",
+)
+load(
     "//tsl/profiler/builds:build_config.bzl",
     "tf_profiler_copts",
     "tf_profiler_pybind_cc_library_wrapper",
@@ -269,8 +273,8 @@ cc_library(
         "//tsl/platform:macros",
         "//tsl/platform:types",
         "@com_google_absl//absl/strings",
-    ] + if_not_android([
-        "//tsl/profiler/backends/cpu:annotation_stack",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers", # NVTX headers
     ]),
 )
 

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
@@ -68,9 +68,11 @@ inline bool RangesEnabled() {
 // is to use std::string and have the NVTX implementation copy a C-style
 // string every time. The other option is to pass a struct implementing two
 // methods:
+//
 //   std::string_view Title() const;
-//   nvtxStringHandle_t NVTXRegisteredTitle() const;
-// in which case NVTXRegisteredTitle() will be used when starting NVTX ranges,
+//   nvtxStringHandle_t NvtxRegisteredTitle() const;
+//
+// in which case NvtxRegisteredTitle() will be used when starting NVTX ranges,
 // avoiding this string copy.
 // The Title() method is needed because AnnotationStack::PushAnnotation(...) is
 // the backend for some annotations when NVTX is not enabled, and it does not
@@ -81,14 +83,14 @@ inline constexpr bool has_annotation_api_v =
     !std::is_same_v<AnnotationType, std::string>;
 
 template <typename AnnotationType>
-void rangePush(nvtxDomainHandle_t domain, AnnotationType const& annotation) {
+void RangePush(nvtxDomainHandle_t domain, const AnnotationType& annotation) {
 #if GOOGLE_CUDA
   nvtxEventAttributes_t attrs{};
   attrs.version = NVTX_VERSION;
   attrs.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
   if constexpr (has_annotation_api_v<std::decay_t<AnnotationType>>) {
     attrs.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
-    attrs.message.registered = annotation.NVTXRegisteredTitle();
+    attrs.message.registered = annotation.NvtxRegisteredTitle();
   } else {
     attrs.messageType = NVTX_MESSAGE_TYPE_ASCII;
     attrs.message.ascii = annotation.c_str();

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
@@ -24,17 +24,16 @@ limitations under the License.
 
 #if GOOGLE_CUDA
 #include "nvtx3/nvToolsExt.h"
+#else
+// Some typedef to help build without NVTX.
+typedef void* nvtxEventAttributes_t;
+typedef void* nvtxDomainHandle_t;
+typedef void* nvtxStringHandle_t;
 #endif
 
 namespace tsl {
 namespace profiler {
 namespace nvtx {
-
-// Some typedef to help build without NVTX.
-#if !GOOGLE_CUDA
-typedef void* nvtxEventAttributes_t;
-typedef void* nvtxDomainHandle_t;
-#endif
 
 // A helper function that return the domains to use if NVTX profiling
 // is enabled.
@@ -65,15 +64,36 @@ inline bool RangesEnabled() {
 #endif
 }
 
-// Note: The memory backing msg must persist until the result of this function
-// has been consumed by an NVTX API.
-inline void MakeAttributes(const char* msg, nvtxEventAttributes_t* result) {
-  *result = {0};
+// Two types of NVTX range annotation are supported, the older/simpler option
+// is to use std::string and have the NVTX implementation copy a C-style
+// string every time. The other option is to pass a struct implementing two
+// methods:
+//   std::string_view Title() const;
+//   nvtxStringHandle_t NVTXRegisteredTitle() const;
+// in which case NVTXRegisteredTitle() will be used when starting NVTX ranges,
+// avoiding this string copy.
+// The Title() method is needed because AnnotationStack::PushAnnotation(...) is
+// the backend for some annotations when NVTX is not enabled, and it does not
+// recognise registered strings. has_annotation_api_v<AnnotationType>
+// distinguishes between the two types of annotation.
+template <typename AnnotationType>
+inline constexpr bool has_annotation_api_v =
+    !std::is_same_v<AnnotationType, std::string>;
+
+template <typename AnnotationType>
+void rangePush(nvtxDomainHandle_t domain, AnnotationType const& annotation) {
 #if GOOGLE_CUDA
-  result->version = NVTX_VERSION;
-  result->size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-  result->messageType = NVTX_MESSAGE_TYPE_ASCII;
-  result->message.ascii = msg;
+  nvtxEventAttributes_t attrs{};
+  attrs.version = NVTX_VERSION;
+  attrs.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  if constexpr (has_annotation_api_v<std::decay_t<AnnotationType>>) {
+    attrs.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
+    attrs.message.registered = annotation.NVTXRegisteredTitle();
+  } else {
+    attrs.messageType = NVTX_MESSAGE_TYPE_ASCII;
+    attrs.message.ascii = annotation.c_str();
+  }
+  ::nvtxDomainRangePushEx(domain, &attrs);
 #endif
 }
 

--- a/third_party/tsl/tsl/profiler/lib/scoped_annotation.h
+++ b/third_party/tsl/tsl/profiler/lib/scoped_annotation.h
@@ -53,10 +53,7 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      nvtxEventAttributes_t attrs;
-      std::string name_str(name);
-      tsl::profiler::nvtx::MakeAttributes(name_str.c_str(), &attrs);
-      ::nvtxDomainRangePushEx(domain.value(), &attrs);
+      tsl::profiler::nvtx::rangePush(domain.value(), std::string{name});
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -74,9 +71,7 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      nvtxEventAttributes_t attrs;
-      tsl::profiler::nvtx::MakeAttributes(name.c_str(), &attrs);
-      ::nvtxDomainRangePushEx(domain.value(), &attrs);
+      tsl::profiler::nvtx::rangePush(domain.value(), name);
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -91,9 +86,7 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      nvtxEventAttributes_t attrs;
-      tsl::profiler::nvtx::MakeAttributes(name.c_str(), &attrs);
-      ::nvtxDomainRangePushEx(domain.value(), &attrs);
+      tsl::profiler::nvtx::rangePush(domain.value(), name);
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -109,15 +102,17 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      auto name = name_generator();
-      nvtxEventAttributes_t attrs;
-      tsl::profiler::nvtx::MakeAttributes(name.c_str(), &attrs);
-      ::nvtxDomainRangePushEx(domain.value(), &attrs);
+      tsl::profiler::nvtx::rangePush(domain.value(), name_generator());
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
-      auto name = name_generator();
-      old_length_ = AnnotationStack::PushAnnotation(name);
+      auto annotation = name_generator();
+      if constexpr (tsl::profiler::nvtx::has_annotation_api_v<
+                        std::decay_t<decltype(annotation)>>) {
+        old_length_ = AnnotationStack::PushAnnotation(annotation.Title());
+      } else {
+        old_length_ = AnnotationStack::PushAnnotation(std::move(annotation));
+      }
     }
 #endif
   }

--- a/third_party/tsl/tsl/profiler/lib/scoped_annotation.h
+++ b/third_party/tsl/tsl/profiler/lib/scoped_annotation.h
@@ -53,7 +53,7 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      tsl::profiler::nvtx::rangePush(domain.value(), std::string{name});
+      tsl::profiler::nvtx::RangePush(domain.value(), std::string{name});
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -71,7 +71,7 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      tsl::profiler::nvtx::rangePush(domain.value(), name);
+      tsl::profiler::nvtx::RangePush(domain.value(), name);
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -86,7 +86,7 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      tsl::profiler::nvtx::rangePush(domain.value(), name);
+      tsl::profiler::nvtx::RangePush(domain.value(), name);
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -102,7 +102,7 @@ class ScopedAnnotationT {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      tsl::profiler::nvtx::rangePush(domain.value(), name_generator());
+      tsl::profiler::nvtx::RangePush(domain.value(), name_generator());
     } else  // NOLINT
 #endif
         if (always_annotate || TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {

--- a/third_party/tsl/tsl/profiler/lib/scoped_annotation_stack.h
+++ b/third_party/tsl/tsl/profiler/lib/scoped_annotation_stack.h
@@ -55,10 +55,7 @@ class ScopedAnnotationStack {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      nvtxEventAttributes_t attrs;
-      std::string name_str(name);
-      tsl::profiler::nvtx::MakeAttributes(name_str.c_str(), &attrs);
-      ::nvtxDomainRangePushEx(domain.value(), &attrs);
+      tsl::profiler::nvtx::rangePush(domain.value(), name);
     } else  // NOLINT
 #endif
         if (TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -83,15 +80,17 @@ class ScopedAnnotationStack {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      auto name = name_generator();
-      nvtxEventAttributes_t attrs;
-      std::string name_str(name);
-      tsl::profiler::nvtx::MakeAttributes(name_str.c_str(), &attrs);
-      ::nvtxDomainRangePushEx(domain.value(), &attrs);
+      tsl::profiler::nvtx::rangePush(domain.value(), name_generator());
     } else  // NOLINT
 #endif
         if (TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
-      return AnnotationStack::PushAnnotation(name_generator());
+      auto annotation = name_generator();
+      if constexpr (tsl::profiler::nvtx::has_annotation_api_v<
+                        std::decay_t<decltype(annotation)>>) {
+        return AnnotationStack::PushAnnotation(annotation.Title());
+      } else {
+        return AnnotationStack::PushAnnotation(std::move(annotation));
+      }
     }
 #endif
     return kInvalidActivity;

--- a/third_party/tsl/tsl/profiler/lib/scoped_annotation_stack.h
+++ b/third_party/tsl/tsl/profiler/lib/scoped_annotation_stack.h
@@ -55,7 +55,7 @@ class ScopedAnnotationStack {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      tsl::profiler::nvtx::rangePush(domain.value(), name);
+      tsl::profiler::nvtx::RangePush(domain.value(), name);
     } else  // NOLINT
 #endif
         if (TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -80,7 +80,7 @@ class ScopedAnnotationStack {
     std::optional<nvtxDomainHandle_t> domain =
         tsl::profiler::nvtx::GetNVTXDomain();
     if (TF_PREDICT_FALSE(domain.has_value())) {
-      tsl::profiler::nvtx::rangePush(domain.value(), name_generator());
+      tsl::profiler::nvtx::RangePush(domain.value(), name_generator());
     } else  // NOLINT
 #endif
         if (TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -1128,7 +1128,9 @@ cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:protobuf",
+        "@tsl//tsl/profiler/lib:scoped_annotation",
     ],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     alwayslink = 1,
 )
 
@@ -4963,7 +4965,9 @@ cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:status",
+        "@tsl//tsl/profiler/lib:scoped_annotation",
     ],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
 )
 
 xla_cc_test(

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -743,7 +743,7 @@ StatusOr<ExecutionOutput> GpuExecutable::ExecuteAsyncOnStreamImpl(
 
 namespace {
 struct ModuleAnnotationManager {
-  ModuleAnnotationManager(std::optional<ModuleAnnotations> const& annotations) {
+  ModuleAnnotationManager(const std::optional<ModuleAnnotations>& annotations) {
     if (annotations.has_value()) {
       m_old_annotations = SetCurrentModuleAnnotations(&(*annotations));
     }
@@ -755,7 +755,7 @@ struct ModuleAnnotationManager {
   }
 
  private:
-  std::optional<ModuleAnnotations const*> m_old_annotations;
+  std::optional<const ModuleAnnotations*> m_old_annotations;
 };
 }  // namespace
 

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -43,6 +43,7 @@ limitations under the License.
 #include "xla/service/gpu/gpu_constants.h"
 #include "xla/service/gpu/non_atomically_upgradeable_rw_lock.h"
 #include "xla/service/gpu/runtime/executable.h"
+#include "xla/service/gpu/runtime/tracing.h"
 #include "xla/service/gpu/stream_executor_util.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/service/hlo_parser.h"
@@ -143,6 +144,9 @@ GpuExecutable::GpuExecutable(GpuExecutable::Params params)
   *(uint64_t*)(&binary_[binary_.size() - 16]) = tsl::EnvTime::NowNanos();
   *(uint64_t*)(&binary_[binary_.size() - 8]) = tsl::random::New64();
 #endif
+  if (has_module()) {
+    annotation_info_.emplace(module());
+  }
   if (has_module() && enable_debug_info_manager_) {
     XlaDebugInfoManager::Get()->RegisterModule(shared_module(),
                                                buffer_assignment_->ToProto());
@@ -226,15 +230,6 @@ Status ExecuteThunks(const std::string& module_name, ModuleIdentifier module_id,
   tsl::profiler::TraceMe hlo_module_activity(
       [&] { return absl::StrCat(module_name, ":XLA GPU module"); },
       tsl::profiler::TraceMeLevel::kInfo);
-
-  ScopedAnnotationAlways annotation([&] {
-    std::string module_id_str;
-    if (module_id >= 0) {
-      module_id_str = absl::StrFormat(",program_id=%d", module_id);
-    }
-    return absl::StrFormat("XlaModule:#hlo_module=%s%s#", module_name,
-                           module_id_str);
-  });
 
   for (const std::unique_ptr<Thunk>& thunk : thunk_sequence) {
     // Annotate execution of this op if tracing was enabled when we started
@@ -514,15 +509,6 @@ static Status ExecuteXlaRuntime(const std::string& module_name,
       [&] { return absl::StrCat(module_name, ":XLA GPU module"); },
       tsl::profiler::TraceMeLevel::kInfo);
 
-  ScopedAnnotationAlways annotation([&] {
-    std::string module_id_str;
-    if (module_id >= 0) {
-      module_id_str = absl::StrFormat(",program_id=%d", module_id);
-    }
-    return absl::StrFormat("XlaModule:#hlo_module=%s%s#", module_name,
-                           module_id_str);
-  });
-
   auto executed = gpu_runtime_executable.Execute(
       run_options, asm_text, binary, buffer_allocations, gpu_lock, temp_buffer);
   if (!executed.ok()) return executed;
@@ -755,6 +741,24 @@ StatusOr<ExecutionOutput> GpuExecutable::ExecuteAsyncOnStreamImpl(
   return std::move(result);
 }
 
+namespace {
+struct ModuleAnnotationManager {
+  ModuleAnnotationManager(std::optional<ModuleAnnotations> const& annotations) {
+    if (annotations.has_value()) {
+      m_old_annotations = SetCurrentModuleAnnotations(&(*annotations));
+    }
+  }
+  ~ModuleAnnotationManager() {
+    if (m_old_annotations.has_value()) {
+      SetCurrentModuleAnnotations(*m_old_annotations);
+    }
+  }
+
+ private:
+  std::optional<ModuleAnnotations const*> m_old_annotations;
+};
+}  // namespace
+
 Status GpuExecutable::ExecuteThunksOrXlaRuntime(
     const ServiceExecutableRunOptions* run_options,
     const BufferAllocations& buffer_allocations, bool block_host_until_done,
@@ -767,6 +771,15 @@ Status GpuExecutable::ExecuteThunksOrXlaRuntime(
   if (has_module()) {
     unique_id = module().unique_id();
   }
+
+  ScopedAnnotationAlways annotation([&]() -> ModuleAnnotation {
+    if (annotation_info_) {
+      return annotation_info_->top_level;
+    } else {
+      return {module_name_, unique_id};
+    }
+  });
+  ModuleAnnotationManager set_current_kernel_annotations{annotation_info_};
 
   if (thunks_) {
     se::StreamExecutor* executor = run_options->stream()->parent();
@@ -953,6 +966,7 @@ GpuExecutable::GpuExecutable(
       output_info_(std::move(output_info)),
       enable_debug_info_manager_(true) {
   if (has_module()) {
+    annotation_info_.emplace(module());
     XlaDebugInfoManager::Get()->RegisterModule(shared_module(),
                                                BufferAssignmentProto());
   }

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -38,6 +38,7 @@ limitations under the License.
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/non_atomically_upgradeable_rw_lock.h"
+#include "xla/service/gpu/runtime/annotation.h"
 #include "xla/service/gpu/runtime/executable.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/service/hlo_execution_profile.h"
@@ -306,6 +307,8 @@ class GpuExecutable : public Executable {
   //
   // This object is also used for dumping debug info.
   std::unique_ptr<const xla::BufferAssignment> buffer_assignment_;
+
+  std::optional<ModuleAnnotations> annotation_info_;
 
   bool enable_persistent_temp_buffers_ = false;
 

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -724,8 +724,14 @@ cc_library(
 
 cc_library(
     name = "tracing",
-    srcs = ["annotation.cc", "tracing.cc"],
-    hdrs = ["annotation.h", "tracing.h"],
+    srcs = [
+        "annotation.cc",
+        "tracing.cc",
+    ],
+    hdrs = [
+        "annotation.h",
+        "tracing.h",
+    ],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":support",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -724,8 +724,8 @@ cc_library(
 
 cc_library(
     name = "tracing",
-    srcs = ["tracing.cc"],
-    hdrs = ["tracing.h"],
+    srcs = ["annotation.cc", "tracing.cc"],
+    hdrs = ["annotation.h", "tracing.h"],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":support",

--- a/xla/service/gpu/runtime/annotation.cc
+++ b/xla/service/gpu/runtime/annotation.cc
@@ -7,6 +7,7 @@ namespace gpu {
 
 namespace {
 nvtxStringHandle_t registerString(const char* str) {
+#if GOOGLE_CUDA
   auto domain = tsl::profiler::nvtx::GetNVTXDomain();
   if (!domain) {
     // NVTX not enabled, so don't bother registering strings with it
@@ -23,6 +24,9 @@ nvtxStringHandle_t registerString(const char* str) {
     str = buffer.c_str();
   }
   return nvtxDomainRegisterStringA(*domain, str);
+#else
+  return {};
+#endif
 }
 
 template <typename Visitor>

--- a/xla/service/gpu/runtime/annotation.cc
+++ b/xla/service/gpu/runtime/annotation.cc
@@ -1,0 +1,212 @@
+#include "xla/service/gpu/runtime/annotation.h"
+
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+
+namespace xla {
+namespace gpu {
+
+namespace {
+nvtxStringHandle_t registerString(const char* str) {
+  auto domain = tsl::profiler::nvtx::GetNVTXDomain();
+  if (!domain) {
+    // NVTX not enabled, so don't bother registering strings with it
+    return {};
+  }
+  std::string buffer{};
+  constexpr auto max_length = 65330;
+  if (auto const length = std::strlen(str); length >= max_length) {
+    // nvbugs 4340868
+    std::string_view suffix{"\n[truncated]\n"};
+    buffer.reserve(max_length);
+    buffer.assign(str, str + length - suffix.size());
+    buffer.append(suffix);
+    str = buffer.c_str();
+  }
+  return nvtxDomainRegisterStringA(*domain, str);
+}
+
+template <typename Visitor>
+Status visit_inst_and_called_but_not_operands(Visitor& visitor,
+                                              HloInstruction const& inst) {
+  // Visit the given instruction, and the things it calls, but not its operands.
+  TF_RETURN_IF_ERROR(visitor.DefaultAction(&inst));
+  for (HloComputation const* called : inst.called_computations()) {
+    HloInstruction const* const root = called->root_instruction();
+    TF_RETURN_IF_ERROR(root->Accept(&visitor, false /* call_finish_visit */,
+                                    true /* ignore_control_predecessors */,
+                                    true /* cross_computation */));
+  }
+  return OkStatus();
+}
+
+// Split `a` and `b` by `delim` into two lists of possibly-empty tokens, then
+// rejoin the first N of those lists that match by `delim`. Note: it is
+// unspecified which argument the return value points into.
+std::string_view longest_prefix(std::string_view a, std::string_view b,
+                                char delim = '/') {
+  if (a.size() > b.size()) a.swap(b);  // allow assumption that b is longer
+  for (auto start_a = a.begin(), iter_a = start_a, start_b = b.begin(),
+            iter_b = start_b;
+       ; ++iter_a, ++iter_b) {
+    if (iter_a == a.end() && (iter_b == b.end() || *iter_b == delim)) {
+      // reached both ends without finding a mismatch, or reached the end of `a`
+      // and not `b` but it was the end of the chunk in `b`
+      return a;
+    }
+    if (*iter_a != *iter_b) {
+      // mismatch in this chunk
+      return {a.begin(),
+              static_cast<std::size_t>(std::distance(a.begin(), start_a))};
+    }
+    if (*iter_a == delim) {
+      // end of this chunk, start the next one
+      start_a = iter_a;
+      start_b = iter_b;
+    }
+  }
+}
+
+// Find the longest prefix among instructions' op_name metadata
+// Chunk this by delimiting slashes, i.e. given a/b/cat and a/b/cabbage, the
+// longest prefix is a/b not a/b/ca
+class OpNamePrefixVisitor : public ConstDfsHloVisitorWithDefault {
+ public:
+  Status DefaultAction(HloInstruction const* inst) final {
+    auto const& op_name = inst->metadata().op_name();
+    if (!op_name.empty()) {
+      prefix = prefix ? longest_prefix(*prefix, op_name) : op_name;
+    }
+    return OkStatus();
+  }
+  std::string_view longest_op_name_prefix() const {
+    return prefix.value_or(std::string_view{});
+  }
+
+ private:
+  std::optional<std::string_view> prefix{};
+};
+
+std::string_view get_longest_op_name_prefix(HloInstruction const& inst,
+                                            bool include_operands) {
+  OpNamePrefixVisitor visitor{};
+  if (!(include_operands
+            ? inst.Accept(&visitor, false /* call_finish_visit */,
+                          true /* ignore_control_predecessors */,
+                          true /* cross_computation */)
+            : visit_inst_and_called_but_not_operands(visitor, inst))
+           .ok()) {
+    return "[error]";
+  }
+  return visitor.longest_op_name_prefix();
+}
+
+std::string make_title(HloModule const& mod, std::string_view longest_prefix) {
+  if (longest_prefix.empty()) {
+    return absl::StrFormat("XlaModule:#hlo_module=%s,program_id=%d#",
+                           mod.name(), mod.unique_id());
+  }
+  return absl::StrFormat("XlaModule:#prefix=%s,hlo_module=%s,program_id=%d#",
+                         longest_prefix, mod.name(), mod.unique_id());
+}
+}  // namespace
+
+ModuleAnnotation::ModuleAnnotation(std::string module_name_, int module_id_)
+    : longest_prefix{},
+      title_str{
+          module_id_ >= 0
+              ? absl::StrFormat("XlaModule:#hlo_module=%s,program_id=%d",
+                                module_name_, module_id_)
+              : absl::StrFormat("XlaModule:#hlo_module=%s", module_name_)},
+      title{registerString(title_str.c_str())} {}
+
+ModuleAnnotation::ModuleAnnotation(HloModule const& mod)
+    : longest_prefix{get_longest_op_name_prefix(
+          *mod.entry_computation()->root_instruction(), true)},
+      title_str{make_title(mod, longest_prefix)},
+      title{registerString(title_str.c_str())} {}
+
+std::string_view ModuleAnnotation::longest_op_name_prefix() const {
+  return longest_prefix;
+}
+
+std::string_view ModuleAnnotation::Title() const { return title_str; }
+
+nvtxStringHandle_t ModuleAnnotation::NVTXRegisteredTitle() const {
+  return title;
+}
+
+namespace {
+std::string make_kernel_name(std::string_view prefix,
+                             HloInstruction const& inst) {
+  // Sometimes an instruction doesn't have metadata, but the computations that
+  // it calls do have metadata. Consider all of those metadata op_name entries
+  // and attach the longest prefix to this launch.
+  std::string_view op_name = get_longest_op_name_prefix(inst, false);
+  if (op_name.empty()) {
+    return absl::StrFormat("Thunk:#hlo_op=%s#", inst.name());
+  } else {
+    // remove the prefix that's in the parent module annotation
+    if (op_name.substr(0, prefix.size()) != prefix) {
+      std::string msg{op_name};
+      msg += " did not start with ";
+      msg += prefix;
+      throw std::runtime_error(std::move(msg));
+    }
+    auto short_name = op_name.substr(prefix.size());
+    // remove the leading / if there is one (prefix might be an empty string)
+    if (!short_name.empty() && short_name.front() == '/') {
+      short_name = short_name.substr(1);
+    }
+    return absl::StrFormat("Thunk:#name=%s,hlo_op=%s#", short_name,
+                           inst.name());
+  }
+}
+}  // namespace
+
+KernelAnnotation::KernelAnnotation(ModuleAnnotation const& module_annotation,
+                                   HloInstruction const& inst)
+    : title_str{make_kernel_name(module_annotation.longest_op_name_prefix(),
+                                 inst)},
+      title{registerString(title_str.c_str())} {}
+
+std::string_view KernelAnnotation::Title() const { return title_str; }
+
+nvtxStringHandle_t KernelAnnotation::NVTXRegisteredTitle() const {
+  return title;
+}
+
+ModuleAnnotations::ModuleAnnotations(HloModule const& mod) : top_level{mod} {
+  // loop through `mod` and populate `kernels` (string -> KernelAnnotation map)
+  // with the information we want to attach to individual kernels.
+  for (HloComputation const* computation :
+       mod.computations()) {  // top-level blocks in the module
+    for (HloInstruction const* inst :
+         computation->instructions()) {  // statements within block
+      // working assumption: only custom calls and fusions end up with NVTX
+      // ranges named after them. bad assumption [at least partially]: cuda
+      // graph launches are not handled correctly
+      switch (inst->opcode()) {
+        case HloOpcode::kCustomCall:
+        case HloOpcode::kFusion: {
+          // e.g. inst.name is "fusion.6", inst.opcode is "kFusion" and called
+          // is ["fused_computation.5"], in which case the content of
+          // "fused_computation.5" ends up under an NVTX range called
+          // "fusion.6". We want to construct a useful annotation for that NVTX
+          // range based on the content of `inst`, including `called` etc.
+          // FIXME: using try_emplace here was sensitive to
+          // https://github.com/abseil/abseil-cpp/issues/388.
+          auto const [iter, inserted] =
+              kernels.insert({inst->name(), {top_level, *inst}});
+          if (!inserted) {
+            throw std::runtime_error(
+                absl::StrCat("Name collision: ", inst->name()));
+          }
+        } break;
+        default:
+          break;
+      }
+    }
+  }
+}
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/runtime/annotation.h
+++ b/xla/service/gpu/runtime/annotation.h
@@ -1,0 +1,45 @@
+#ifndef XLA_SERVICE_GPU_GPU_ANNOTATION_H_
+#define XLA_SERVICE_GPU_GPU_ANNOTATION_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "tsl/profiler/lib/nvtx_utils.h"
+#include "xla/hlo/ir/hlo_module.h"
+
+namespace xla {
+namespace gpu {
+// Prepared information for the top level NVTX/profiler range covering an
+// HloModule
+struct ModuleAnnotation {
+  ModuleAnnotation(std::string module_name, int module_id);
+  ModuleAnnotation(HloModule const& mod);
+  std::string_view longest_op_name_prefix() const;
+  nvtxStringHandle_t NVTXRegisteredTitle() const;
+  std::string_view Title() const;
+
+ private:
+  std::string longest_prefix{}, title_str{};
+  nvtxStringHandle_t title{};
+};
+
+// Prepared information for a kernel/thunk/fusion/... within an HloModule
+struct KernelAnnotation {
+  KernelAnnotation(ModuleAnnotation const& module_annotaion,
+                   HloInstruction const& inst);
+  nvtxStringHandle_t NVTXRegisteredTitle() const;
+  std::string_view Title() const;
+
+ private:
+  std::string title_str{};
+  nvtxStringHandle_t title{};
+};
+// Parsed/prepared information for an HloModule that gets propagated to NVTX
+// ranges/profilers/... at execution time.
+struct ModuleAnnotations {
+  ModuleAnnotations(HloModule const&);
+  ModuleAnnotation top_level;
+  absl::flat_hash_map<std::string_view, KernelAnnotation> kernels{};
+};
+}  // namespace gpu
+}  // namespace xla
+
+#endif

--- a/xla/service/gpu/runtime/annotation.h
+++ b/xla/service/gpu/runtime/annotation.h
@@ -1,3 +1,18 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 #ifndef XLA_SERVICE_GPU_GPU_ANNOTATION_H_
 #define XLA_SERVICE_GPU_GPU_ANNOTATION_H_
 
@@ -13,11 +28,12 @@ struct ModuleAnnotation {
   ModuleAnnotation(std::string module_name, int module_id);
   ModuleAnnotation(HloModule const& mod);
   std::string_view longest_op_name_prefix() const;
-  nvtxStringHandle_t NVTXRegisteredTitle() const;
+  nvtxStringHandle_t NvtxRegisteredTitle() const;
   std::string_view Title() const;
 
  private:
-  std::string longest_prefix{}, title_str{};
+  std::string longest_prefix;
+  std::string title_str;
   nvtxStringHandle_t title{};
 };
 
@@ -25,11 +41,11 @@ struct ModuleAnnotation {
 struct KernelAnnotation {
   KernelAnnotation(ModuleAnnotation const& module_annotaion,
                    HloInstruction const& inst);
-  nvtxStringHandle_t NVTXRegisteredTitle() const;
+  nvtxStringHandle_t NvtxRegisteredTitle() const;
   std::string_view Title() const;
 
  private:
-  std::string title_str{};
+  std::string title_str;
   nvtxStringHandle_t title{};
 };
 // Parsed/prepared information for an HloModule that gets propagated to NVTX

--- a/xla/service/gpu/runtime/annotation.h
+++ b/xla/service/gpu/runtime/annotation.h
@@ -20,13 +20,12 @@ limitations under the License.
 #include "tsl/profiler/lib/nvtx_utils.h"
 #include "xla/hlo/ir/hlo_module.h"
 
-namespace xla {
-namespace gpu {
+namespace xla::gpu {
 // Prepared information for the top level NVTX/profiler range covering an
 // HloModule
 struct ModuleAnnotation {
   ModuleAnnotation(std::string module_name, int module_id);
-  ModuleAnnotation(HloModule const& mod);
+  ModuleAnnotation(const HloModule& mod);
   std::string_view longest_op_name_prefix() const;
   nvtxStringHandle_t NvtxRegisteredTitle() const;
   std::string_view Title() const;
@@ -39,8 +38,8 @@ struct ModuleAnnotation {
 
 // Prepared information for a kernel/thunk/fusion/... within an HloModule
 struct KernelAnnotation {
-  KernelAnnotation(ModuleAnnotation const& module_annotaion,
-                   HloInstruction const& inst);
+  KernelAnnotation(const ModuleAnnotation& module_annotaion,
+                   const HloInstruction& inst);
   nvtxStringHandle_t NvtxRegisteredTitle() const;
   std::string_view Title() const;
 
@@ -51,11 +50,10 @@ struct KernelAnnotation {
 // Parsed/prepared information for an HloModule that gets propagated to NVTX
 // ranges/profilers/... at execution time.
 struct ModuleAnnotations {
-  ModuleAnnotations(HloModule const&);
+  ModuleAnnotations(const HloModule&);
   ModuleAnnotation top_level;
   absl::flat_hash_map<std::string_view, KernelAnnotation> kernels{};
 };
-}  // namespace gpu
-}  // namespace xla
+}  // namespace xla::gpu
 
 #endif

--- a/xla/service/gpu/runtime/tracing.cc
+++ b/xla/service/gpu/runtime/tracing.cc
@@ -45,7 +45,7 @@ void RegisterTracingTypeIdNames(runtime::TypeIDNameRegistry& registry) {
 //===----------------------------------------------------------------------===//
 
 namespace {
-thread_local ModuleAnnotations const* current_annotations{};
+thread_local const ModuleAnnotations* current_annotations{};
 }
 
 static absl::StatusOr<int64_t> ActivityStart(runtime::HloTrace annotation) {
@@ -53,7 +53,7 @@ static absl::StatusOr<int64_t> ActivityStart(runtime::HloTrace annotation) {
   if (current_annotations) {
     // We know which HloModule we belong to, and may have pre-prepared
     // annotation structs ready to use
-    auto const iter = current_annotations->kernels.find(annotation.hlo_op);
+    const auto iter = current_annotations->kernels.find(annotation.hlo_op);
     if (iter != current_annotations->kernels.end()) {
       // Have a pre-prepared annotation, use it
       return ScopedAnnotationStack::ActivityStart([&] { return iter->second; });
@@ -85,8 +85,8 @@ void RegisterTracingCustomCalls(runtime::DirectCustomCallRegistry& registry) {
   registry.Register("xla.trace.activity_end", End);
 }
 
-ModuleAnnotations const* SetCurrentModuleAnnotations(
-    ModuleAnnotations const* annotations) {
+const ModuleAnnotations* SetCurrentModuleAnnotations(
+    const ModuleAnnotations* annotations) {
   return std::exchange(current_annotations, annotations);
 }
 

--- a/xla/service/gpu/runtime/tracing.cc
+++ b/xla/service/gpu/runtime/tracing.cc
@@ -44,11 +44,23 @@ void RegisterTracingTypeIdNames(runtime::TypeIDNameRegistry& registry) {
 // Tracing custom calls implementation.
 //===----------------------------------------------------------------------===//
 
+namespace {
+thread_local ModuleAnnotations const* current_annotations{};
+}
+
 static absl::StatusOr<int64_t> ActivityStart(runtime::HloTrace annotation) {
   SetCurrentTracingScope(annotation.hlo_op);
+  if (current_annotations) {
+    // We know which HloModule we belong to, and may have pre-prepared
+    // annotation structs ready to use
+    auto const iter = current_annotations->kernels.find(annotation.hlo_op);
+    if (iter != current_annotations->kernels.end()) {
+      // Have a pre-prepared annotation, use it
+      return ScopedAnnotationStack::ActivityStart([&] { return iter->second; });
+    }
+  }
   return ScopedAnnotationStack::ActivityStart([&] {
-    // We use the same tracing annotation scheme as the ThunkSequence (see
-    // implementation of `GetThunkInfo` in `ir_emitter_unnested.cc`).
+    // We use the same tracing annotation scheme as the ThunkSequence.
     return absl::StrFormat("Thunk:#hlo_op=%s#", annotation.hlo_op);
   });
 }
@@ -71,6 +83,11 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
 void RegisterTracingCustomCalls(runtime::DirectCustomCallRegistry& registry) {
   registry.Register("xla.trace.activity_start", Start);
   registry.Register("xla.trace.activity_end", End);
+}
+
+ModuleAnnotations const* SetCurrentModuleAnnotations(
+    ModuleAnnotations const* annotations) {
+  return std::exchange(current_annotations, annotations);
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/runtime/tracing.h
+++ b/xla/service/gpu/runtime/tracing.h
@@ -29,8 +29,8 @@ void RegisterTracingTypeIdNames(runtime::TypeIDNameRegistry& registry);
 
 void RegisterTracingCustomCalls(runtime::DirectCustomCallRegistry& registry);
 
-ModuleAnnotations const* SetCurrentModuleAnnotations(
-    ModuleAnnotations const* annotations);
+const ModuleAnnotations* SetCurrentModuleAnnotations(
+    const ModuleAnnotations* annotations);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/runtime/tracing.h
+++ b/xla/service/gpu/runtime/tracing.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "xla/runtime/custom_call_registry.h"
 #include "xla/runtime/type_id.h"
+#include "xla/service/gpu/runtime/annotation.h"
 
 namespace xla {
 namespace gpu {
@@ -27,6 +28,9 @@ namespace gpu {
 void RegisterTracingTypeIdNames(runtime::TypeIDNameRegistry& registry);
 
 void RegisterTracingCustomCalls(runtime::DirectCustomCallRegistry& registry);
+
+ModuleAnnotations const* SetCurrentModuleAnnotations(
+    ModuleAnnotations const* annotations);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/hlo_pass_pipeline.cc
+++ b/xla/service/hlo_pass_pipeline.cc
@@ -148,10 +148,10 @@ Status HloPassPipeline::RunInvariantCheckers(
 }
 
 namespace {
-std::string unique_id(HloModule const& mod) {
+std::string UniqueId(HloModule const& mod) {
   return std::to_string(mod.unique_id());
 }
-std::string unique_id(HloModuleGroup const& group) {
+std::string UniqueId(HloModuleGroup const& group) {
   return absl::StrJoin(group.modules(), "-",
                        [](std::string* out, HloModule const* mod) {
                          out->append(std::to_string(mod->unique_id()));
@@ -172,7 +172,7 @@ StatusOr<bool> HloPassPipeline::RunPassesInternal(
   std::string pipeline_name = std::string(name());
   tsl::profiler::ScopedAnnotation annotation{[&] {
     return absl::StrFormat("XlaPassPipeline:#name=%s,module=%s,program_id=%s#",
-                           pipeline_name, hlo->name(), unique_id(*hlo));
+                           pipeline_name, hlo->name(), UniqueId(*hlo));
   }};
 
   TF_RETURN_IF_ERROR(

--- a/xla/service/hlo_pass_pipeline.cc
+++ b/xla/service/hlo_pass_pipeline.cc
@@ -148,12 +148,12 @@ Status HloPassPipeline::RunInvariantCheckers(
 }
 
 namespace {
-std::string UniqueId(HloModule const& mod) {
+std::string UniqueId(const HloModule& mod) {
   return std::to_string(mod.unique_id());
 }
-std::string UniqueId(HloModuleGroup const& group) {
+std::string UniqueId(const HloModuleGroup& group) {
   return absl::StrJoin(group.modules(), "-",
-                       [](std::string* out, HloModule const* mod) {
+                       [](std::string* out, const HloModule* mod) {
                          out->append(std::to_string(mod->unique_id()));
                        });
 }

--- a/xla/service/hlo_pass_pipeline.cc
+++ b/xla/service/hlo_pass_pipeline.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "tsl/platform/errors.h"
 #include "tsl/platform/logging.h"
 #include "tsl/platform/status.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
 
 namespace xla {
 
@@ -146,6 +147,18 @@ Status HloPassPipeline::RunInvariantCheckers(
   return OkStatus();
 }
 
+namespace {
+std::string unique_id(HloModule const& mod) {
+  return std::to_string(mod.unique_id());
+}
+std::string unique_id(HloModuleGroup const& group) {
+  return absl::StrJoin(group.modules(), "-",
+                       [](std::string* out, HloModule const* mod) {
+                         out->append(std::to_string(mod->unique_id()));
+                       });
+}
+}  // namespace
+
 template <typename HloT>
 StatusOr<bool> HloPassPipeline::RunPassesInternal(
     HloT* hlo, const DebugOptions& debug_options,
@@ -157,6 +170,10 @@ StatusOr<bool> HloPassPipeline::RunPassesInternal(
   static constexpr absl::string_view kPipelineStart = "pipeline-start";
   static constexpr absl::string_view kPipelineEnd = "pipeline-end";
   std::string pipeline_name = std::string(name());
+  tsl::profiler::ScopedAnnotation annotation{[&] {
+    return absl::StrFormat("XlaPassPipeline:#name=%s,module=%s,program_id=%s#",
+                           pipeline_name, hlo->name(), unique_id(*hlo));
+  }};
 
   TF_RETURN_IF_ERROR(
       RunInvariantCheckers(hlo, kPipelineStart, execution_threads));
@@ -176,6 +193,8 @@ StatusOr<bool> HloPassPipeline::RunPassesInternal(
     HloPassInterface* pass = passes[i];
     XLA_SCOPED_LOGGING_TIMER(absl::StrCat("HLO pass: ", pass->name()));
     std::string pass_name = std::string(pass->name());
+    tsl::profiler::ScopedAnnotation annotation{
+        [&] { return "XlaPass:" + pass_name; }};
     VLOG(1) << "  HLO pass " << pass_name;
     VLOG(2) << "  Module hash " << absl::HashOf(*hlo);
     if (!pass->IsPassPipeline()) {


### PR DESCRIPTION
There are two parts to this change:
- `tsl::profiler::ScopedAnnotation` and friends can now accept annotations that are custom structs as well as plain `std::string` annotations. This allows optimisations when used to emit NVTX ranges, such as using [registered strings](https://nvidia.github.io/NVTX/doxygen/group___s_t_r_i_n_g___r_e_g_i_s_t_r_a_t_i_o_n.html). 
- Annotations for HLO module executions and individual kernel/thunk launches within are now prepared in advance, rather than on the fly. This makes it reasonable to generate more complex annotations, and this is done using the `op_name` metadata:

![Screenshot 2023-11-14 at 20 54 21](https://github.com/openxla/xla/assets/6459623/06821dbd-935d-4158-8cee-c1194e22a183)

Prior to this change, the annotation title was simply `Thunk:#hlo_op=wrapped_slice.91#`. Also add annotations on some compilation stages, improving the profiling experience by making it obvious which time is spent autotuning kernels:
![Screenshot 2023-11-14 at 20 55 48](https://github.com/openxla/xla/assets/6459623/c1d3a644-894d-4bb2-aa64-c8aac1bec369)
