### PR TITLE
adding fix for local_client_aot_test target build failure

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -536,7 +536,7 @@ cc_library(
         "//xla/stream_executor:command_buffer",
         "//xla/stream_executor:kernel",
         "//xla/stream_executor:plugin_registry",
-        "//xla/stream_executor:stream_executor_headers",
+        "//xla/stream_executor:stream_executor",
         "//xla/stream_executor:stream_executor_internal",
         "//xla/stream_executor/gpu:asm_compiler",
         "//xla/stream_executor/gpu:gpu_command_buffer",


### PR DESCRIPTION
Fixing build failure for local_client_aot_test_target.

Command: bazel test --config=cuda --jobs=150 --test_timeout=3600 --nocheck_visibility --test_output=streamed                                        //xla/tests:local_client_aot_test

ERROR: /xla/xla/tests/BUILD:230:14: Linking xla/tests/local_client_aot_test_helper [for tool] failed: (Exit 1): 
/usr/bin/ld: bazel-out/k8-opt-exec-50AE0418/bin/xla/stream_executor/cuda/libcuda_executor.lo(cuda_executor.o): in function `stream_executor::gpu::GpuExecutor::GetKernel(stream_executor::MultiKernelLoaderSpec const&, stream_executor::Kernel*)':
cuda_executor.cc:(.text._ZN15stream_executor3gpu11GpuExecutor9GetKernelERKNS_21MultiKernelLoaderSpecEPNS_6KernelE+0x2b5): undefined reference to `stream_executor::CudaPtxInMemory::text(int, int) const'
/usr/bin/ld: cuda_executor.cc:(.text._ZN15stream_executor3gpu11GpuExecutor9GetKernelERKNS_21MultiKernelLoaderSpecEPNS_6KernelE+0x4df): undefined reference to `stream_executor::CudaPtxInMemory::default_text() const'
collect2: error: ld returned 1 exit status
[9,413 / 9,416] 1 / 1 tests, 1 failed; checking cached actions
Target //xla/tests:local_client_aot_test failed to build

Fix:
replaced stream_executor_headers with stream_executor in cuda_executor dependencies to create a dependency path from cuda_blas to kernel_spec. 
In addition, adding command line argument --define=framework_shared_object=false in bazel command will fix the error.
