### PR TITLE
[XLA:GPU] Add `Allocate` command to command buffer

### DIFF
--- a/xla/backends/interpreter/executor.h
+++ b/xla/backends/interpreter/executor.h
@@ -48,9 +48,11 @@ class XlaInterpreterExecutor : public internal::StreamExecutorInterface {
   XlaInterpreterExecutor() = default;
 
   tsl::Status Init(int device_ordinal, DeviceOptions device_options) override {
+    device_ordinal_ = device_ordinal;
     return ::tsl::OkStatus();
   }
 
+  int device_ordinal() const override { return device_ordinal_; };
   tsl::Status GetKernel(const MultiKernelLoaderSpec &spec,
                         Kernel *kernel) override {
     return tsl::errors::Unimplemented("Not Implemented");
@@ -182,6 +184,11 @@ class XlaInterpreterExecutor : public internal::StreamExecutorInterface {
   }
 
  private:
+
+  // The device ordinal value that this executor was initialized with; recorded
+  // for use in getting device metadata. Immutable post-initialization.
+  int device_ordinal_;
+ 
   DeviceMemoryBase AllocateSingleOutput(const xla::Shape &shape);
 
   tsl::StatusOr<DeviceMemoryBase> AllocateOutputBuffer(const xla::Shape &shape);

--- a/xla/service/gpu/buffer_allocations.cc
+++ b/xla/service/gpu/buffer_allocations.cc
@@ -79,5 +79,25 @@ se::DeviceMemoryBase BufferAllocations::GetDeviceAddress(
       buffer_slice.size());
 }
 
+se::DeviceMemoryBase BufferAllocations::GetDeviceAddress(
+    const BufferAllocation::Slice& buffer_slice,
+    const se::CommandBuffer* command_buffer) const {
+  se::DeviceMemoryBase base = GetDeviceAddress(buffer_slice.index());
+  CHECK_LE(buffer_slice.offset(), base.size());
+  CHECK_LE(buffer_slice.offset() + buffer_slice.size(), base.size());
+  if (base.isLazyAllocationMarker()) {
+    auto cmd_buffer_base =
+        command_buffer->GetAllocationAddress(buffer_slice.allocation()->index());
+    CHECK(cmd_buffer_base.ok())
+        << "Get allocation address from command_buffer failed";
+    CHECK(!cmd_buffer_base.value().is_null())
+        << "Allocation is not yet allocated by command buffer for slice: "
+        << buffer_slice.ToString();
+    return cmd_buffer_base.value();
+  } else {
+    return base;
+  }
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/buffer_allocations.h
+++ b/xla/service/gpu/buffer_allocations.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/statusor.h"
+#include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/device_memory_allocator.h"
 #include "xla/stream_executor/stream_executor.h"
 
@@ -68,6 +69,15 @@ class BufferAllocations {
   se::DeviceMemoryBase GetDeviceAddress(
       const BufferAllocation::Slice& buffer_slice) const;
 
+  // For buffers that are lazily allocated through command buffer, this is
+  // indicated by specifying a special buffer address
+  // (LAZY_ALLOCATE_ADDRESS_MARKER), the real buffer address is tracked in
+  // CommandBuffer, this API will fetches the real address from CommandBuffer
+  // runtime.
+  se::DeviceMemoryBase GetDeviceAddress(
+      const BufferAllocation::Slice& buffer_slice,
+      const se::CommandBuffer* commd_buffer) const;
+
   // Tears down all buffers allocated by this object that are not in
   // `live_addresses`.
   Status TearDown(const std::set<se::DeviceMemoryBase>& live_addresses,
@@ -89,6 +99,10 @@ class BufferAllocations {
   // An array of device pointers that stores the address of each buffer
   // indexed by Index. Each element can point to a temporary buffer, an
   // input buffer, or nullptr if no buffer is needed for that Index.
+
+  // a special buffer (SE::LAZY_ALLOCATION_MARKER) with non-zero size buffer is
+  // assumed to be lazily allocated buffer, and will be allocated through
+  // command buffer Allocate command during runtime.
   std::vector<se::DeviceMemoryBase> buffers_;
   int device_ordinal_;
   se::DeviceMemoryAllocator* memory_allocator_;

--- a/xla/service/gpu/runtime3/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime3/command_buffer_cmd.cc
@@ -130,7 +130,8 @@ Status LaunchCmd::Record(const RecordParams& params,
 
   absl::InlinedVector<se::DeviceMemoryBase, 4> buffers;
   for (const BufferAllocation::Slice& arg : args_) {
-    se::DeviceMemoryBase buf = params.buffer_allocations->GetDeviceAddress(arg);
+    se::DeviceMemoryBase buf =
+        params.buffer_allocations->GetDeviceAddress(arg, command_buffer);
     VLOG(5) << "  Arg: " << arg << ": " << buf.opaque();
     buffers.push_back(buf);
   }
@@ -164,8 +165,10 @@ Status MemcpyDeviceToDeviceCmd::Record(const RecordParams& params,
                                        se::CommandBuffer* command_buffer) {
   VLOG(5) << "MemcpyDeviceToDeviceCmd: dst=" << dst_ << ", src=" << src_
           << ", num_bytes=" << num_bytes_;
-  se::DeviceMemoryBase dst = params.buffer_allocations->GetDeviceAddress(dst_);
-  se::DeviceMemoryBase src = params.buffer_allocations->GetDeviceAddress(src_);
+  se::DeviceMemoryBase dst =
+      params.buffer_allocations->GetDeviceAddress(dst_, command_buffer);
+  se::DeviceMemoryBase src =
+      params.buffer_allocations->GetDeviceAddress(src_, command_buffer);
   return command_buffer->MemcpyDeviceToDevice(&dst, src, num_bytes_);
 }
 
@@ -205,6 +208,26 @@ CommandBufferCmd::Slices IfCmd::slices() {
 }
 
 //===----------------------------------------------------------------------===//
+// AllocateCmd
+//===----------------------------------------------------------------------===//
+
+AllocateCmd::AllocateCmd(BufferAllocation* allocation)
+    : allocation_(allocation) {}
+
+Status AllocateCmd::Record(const RecordParams& params,
+                           se::CommandBuffer* command_buffer) {
+  // Memory allocation address is returned on graph creation, and there is no
+  // update operation
+  VLOG(5) << "AllocationCmd: index=" << allocation_->index();
+  return command_buffer->Allocate(se::CommandBuffer::AllocIndexSize{
+      allocation_->index(), static_cast<uint64_t>(allocation_->size())});
+}
+
+CommandBufferCmd::Slices AllocateCmd::slices() {
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // GemmCmd
 //===----------------------------------------------------------------------===//
 
@@ -235,12 +258,11 @@ Status GemmCmd::Record(const RecordParams& params,
   se::DeviceMemoryBase workspace(nullptr, 0);
 
   se::DeviceMemoryBase lhs =
-      params.buffer_allocations->GetDeviceAddress(lhs_buffer_);
+      params.buffer_allocations->GetDeviceAddress(lhs_buffer_, command_buffer);
   se::DeviceMemoryBase rhs =
-      params.buffer_allocations->GetDeviceAddress(rhs_buffer_);
+      params.buffer_allocations->GetDeviceAddress(rhs_buffer_, command_buffer);
   se::DeviceMemoryBase out =
-      params.buffer_allocations->GetDeviceAddress(output_buffer_);
-
+      params.buffer_allocations->GetDeviceAddress(output_buffer_, command_buffer);
   TF_ASSIGN_OR_RETURN(
       auto nested_buffer,
       se::CommandBuffer::Trace(params.executor, [&](se::Stream* stream) {

--- a/xla/service/gpu/runtime3/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime3/command_buffer_cmd.h
@@ -53,6 +53,11 @@ class CommandBufferCmd {
   // buffer. For example when we emit command buffer cmd sequence from an HLO
   // module, we only know the buffer slices required for HLO operations, but the
   // concrete device pointers become available only at run time.
+  //
+  // For allocations that performed through command buffer Allocate command, the
+  // target addresses are tracked by command buffer runtime. To record command
+  // that consumes buffers allocated inside command buffer, user should specify
+  // the target address as se::DeviceMemoryBase{nullptr, size}.
   struct RecordParams {
     se::StreamExecutor* executor;
     const BufferAllocations* buffer_allocations;
@@ -199,10 +204,26 @@ class IfCmd : public CommandBufferCmd {
                 se::CommandBuffer* command_buffer) override;
 
   Slices slices() override;
-
  private:
   BufferAllocation::Slice pred_;
   CommandBufferCmdSequence then_cmds_;
+};
+
+//===----------------------------------------------------------------------===//
+// AllocateCmd
+//===----------------------------------------------------------------------===//
+
+class AllocateCmd : public CommandBufferCmd {
+ public:
+  AllocateCmd(BufferAllocation* dst);
+
+  // After calling this function, the allocated memory address is updated to
+  Status Record(const RecordParams& params,
+                se::CommandBuffer* command_buffer) override;
+
+  Slices slices() override;
+ private:
+  BufferAllocation* allocation_;
 };
 
 //===----------------------------------------------------------------------===//

--- a/xla/service/gpu/runtime3/command_buffer_thunk.cc
+++ b/xla/service/gpu/runtime3/command_buffer_thunk.cc
@@ -104,4 +104,14 @@ CommandBufferThunk::GetOrCreateCommandBuffer(se::StreamExecutor* executor) {
   return &emplaced.first->second;
 }
 
+StatusOr<se::DeviceMemoryBase> CommandBufferThunk::GetLazyAllocationAddress(
+    const ExecuteParams& params, int64_t index) {
+  se::StreamExecutor* executor = params.stream->parent();
+  TF_ASSIGN_OR_RETURN(ExecutorCommandBuffer * cmd_buffer,
+                      GetOrCreateCommandBuffer(executor));
+  absl::MutexLock lock(&cmd_buffer->mutex);
+  return cmd_buffer->command_buffer.GetAllocationAddress(index);
+}
+
+
 }  // namespace xla::gpu

--- a/xla/service/gpu/runtime3/command_buffer_thunk.h
+++ b/xla/service/gpu/runtime3/command_buffer_thunk.h
@@ -39,6 +39,12 @@ class CommandBufferThunk : public Thunk {
   Status Initialize(se::StreamExecutor*, ExecutableSource) override;
   Status ExecuteOnStream(const ExecuteParams& params) override;
 
+  // Return the allocation address that was lazilly allocated inside command
+  // buffer. This API is required when the buffers are allocated inside command
+  // buffer but will be consumed by non-command buffer operations.
+  StatusOr<se::DeviceMemoryBase> GetLazyAllocationAddress(
+      const ExecuteParams& params, int64_t index);
+
  private:
   // Command buffer instantiated on a `se::StreamExecutor` instance, and
   // auxiliary state required for efficient command buffer updates.

--- a/xla/service/gpu/runtime3/command_buffer_thunk_test.cc
+++ b/xla/service/gpu/runtime3/command_buffer_thunk_test.cc
@@ -104,6 +104,62 @@ TEST(CommandBufferThunkTest, MemcpyCmd) {
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
 }
 
+// This test does the following operations:
+// 1. Allocates memory region "a" and "c" outside command buffer.
+// 2. Allocates memory region "b" inside command buffer.
+// 3. MemCopyDeviceToDevice from "a" to "b" inside command buffer.
+// 4. MemCopyDEviceToDevice from "b" to "c" inside command buffer.
+// 5. Verify that region "c" has the same content as "a".
+TEST(CommandBufferThunkTest, MemallocCmd) {
+  se::StreamExecutor* executor = CudaExecutor();
+
+  se::Stream stream(executor);
+  stream.Init();
+  ASSERT_TRUE(stream.ok());
+
+  // Prepare arguments:
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+
+  BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
+  BufferAllocation alloc_b(/*index=*/1, byte_length, /*color=*/0);
+  BufferAllocation alloc_c(/*index=*/2, byte_length, /*color=*/0);
+  BufferAllocation::Slice slice_a(&alloc_a, 0, byte_length);
+  BufferAllocation::Slice slice_b(&alloc_b, 0, byte_length);
+  BufferAllocation::Slice slice_c(&alloc_c, 0, byte_length);
+
+  // Prepare commands sequence for constructing command buffer.
+  CommandBufferCmdSequence commands;
+  commands.Emplace<AllocateCmd>(&alloc_b);
+  commands.Emplace<MemcpyDeviceToDeviceCmd>(slice_b, slice_a, byte_length);
+  commands.Emplace<MemcpyDeviceToDeviceCmd>(slice_c, slice_b, byte_length);
+
+  // Construct a thunk with command sequence.
+  CommandBufferThunk thunk(std::move(commands), Thunk::ThunkInfo(nullptr));
+
+  // Prepare arguments: a=42, b=0
+  se::DeviceMemory<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
+  stream.ThenMemset32(&a, 42, byte_length);
+
+  se::DeviceMemory<int32_t> b =
+      se::DeviceMemory<int32_t>::MakeLazyAllocationFromByteSize(byte_length);
+  se::DeviceMemory<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
+  BufferAllocations allocations({a, b, c}, 0, executor->GetAllocator());
+
+  ServiceExecutableRunOptions run_options;
+  Thunk::ExecuteParams params(run_options, allocations, &stream, {});
+
+  // Execute command buffer thunk and verify that it copied the memory.
+  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+
+  // Copy `b` data back to host.
+  std::vector<int32_t> dst(4, 0);
+  stream.ThenMemcpy(dst.data(), allocations.GetMutableDeviceAddress(2),
+                    byte_length);
+
+  ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
+}
+
 TEST(CommandBufferThunkTest, LaunchCmd) {
   se::StreamExecutor* executor = CudaExecutor();
 

--- a/xla/stream_executor/command_buffer.cc
+++ b/xla/stream_executor/command_buffer.cc
@@ -148,6 +148,15 @@ tsl::Status CommandBuffer::While(StreamExecutor* executor,
                                 std::move(body_builder));
 }
 
+tsl::Status CommandBuffer::Allocate(CommandBuffer::AllocIndexSize alloc) {
+  return implementation_->Allocate(alloc);
+}
+
+tsl::StatusOr<DeviceMemoryBase> CommandBuffer::GetAllocationAddress(
+    int64_t index) const {
+  return implementation_->GetAllocationAddress(index);
+}
+
 CommandBuffer::Mode CommandBuffer::mode() const {
   return implementation_->mode();
 }

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -53,6 +53,10 @@ class CommandBuffer {
  public:
   // Builder constructs nested command buffers owned by a parent command buffer.
   using Builder = std::function<tsl::Status(CommandBuffer*)>;
+  struct AllocIndexSize {
+    int64_t index;
+    uint64_t size;
+  };
 
   ~CommandBuffer();
   CommandBuffer(CommandBuffer&&);
@@ -167,6 +171,13 @@ class CommandBuffer {
                     Builder cond_builder, Builder body_builder);
 
   //--------------------------------------------------------------------------//
+  // Adds a device memory allocation command to the command buffer, allocated
+  // address is tracked by command buffer runtime.
+  tsl::Status Allocate(AllocIndexSize alloc);
+
+  // Get the device address for allocations previously allocated through
+  // Allocate command.
+  tsl::StatusOr<DeviceMemoryBase> GetAllocationAddress(int64_t index) const;
 
   // Finalizes command buffer and makes it executable. Once command buffer is
   // finalized no commands can be added to it.

--- a/xla/stream_executor/cuda/cuda_driver.cc
+++ b/xla/stream_executor/cuda/cuda_driver.cc
@@ -842,6 +842,7 @@ GpuDriver::GraphAddNode(CUgraphNode* node, CUgraph graph,
   return ::tsl::OkStatus();
 }
 
+
 /*static*/ tsl::Status GpuDriver::GraphExecKernelNodeSetParams(
     CUgraphExec exec, CUgraphNode node, absl::string_view kernel_name,
     CUfunction function, unsigned int grid_dim_x, unsigned int grid_dim_y,
@@ -880,6 +881,101 @@ GpuDriver::GraphAddNode(CUgraphNode* node, CUgraph graph,
                            "Failed to set CUDA graph kernel node params");
 
   return ::tsl::OkStatus();
+}
+
+static tsl::StatusOr<CUmemAccess_flags> toCudaMemAccessFlags(
+   GpuDriver::MemAccessFlags access_flags) {
+  switch (access_flags) {
+    case GpuDriver::MemAccessFlags::kNone:
+      return CU_MEM_ACCESS_FLAGS_PROT_NONE;
+    case GpuDriver::MemAccessFlags::kRead:
+      return CU_MEM_ACCESS_FLAGS_PROT_READ;
+    case GpuDriver::MemAccessFlags::kReadWrite:
+      return CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    default:
+      return tsl::errors::Internal("Unknown cuda memory access flag type");
+  }
+}
+
+static tsl::StatusOr<CUmemLocationType> toCudaLocationType(
+    GpuDriver::MemLocationType location_type) {
+  switch (location_type) {
+    case GpuDriver::MemLocationType::kInvalid:
+      return CU_MEM_LOCATION_TYPE_INVALID;
+    case GpuDriver::MemLocationType::kDevice:
+      return CU_MEM_LOCATION_TYPE_DEVICE;
+    case GpuDriver::MemLocationType::kHost:
+      return CU_MEM_LOCATION_TYPE_HOST;
+    case GpuDriver::MemLocationType::kHostNuma:
+      return CU_MEM_LOCATION_TYPE_HOST_NUMA;
+    case GpuDriver::MemLocationType::kHostNumaCurrent:
+      return CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT;
+    default:
+      return tsl::errors::Internal("Unknown cuda memory location type");
+  }
+}
+
+static tsl::StatusOr<CUmemAllocationType> toCudaAllocationType(
+    GpuDriver::MemAllocationType alocation_type) {
+  switch (alocation_type) {
+    case GpuDriver::MemAllocationType::kInvalid:
+      return CU_MEM_ALLOCATION_TYPE_INVALID;
+    case GpuDriver::MemAllocationType::kPinned:
+      return CU_MEM_ALLOCATION_TYPE_PINNED;
+    default:
+      return tsl::errors::Internal("Unknown cuda memory allocation type");
+  }
+}
+
+/*static*/ tsl::Status GpuDriver::GraphAddMemAllocNode(
+    CUgraphNode* node, CUgraph graph, absl::Span<CUgraphNode> deps,
+    GpuDriver::MemAccessFlags access_flags,
+    GpuDriver::MemLocationType location_type, int device_id,
+    GpuDriver::MemAllocationType allocation_type, uint64_t size,
+    CUdeviceptr* d_ptr, uint64_t max_pool_size) {
+  CUDA_MEM_ALLOC_NODE_PARAMS memAllocParams;
+
+  CUmemLocation mem_location;
+  mem_location.id = device_id;
+  TF_ASSIGN_OR_RETURN(mem_location.type, toCudaLocationType(location_type));
+
+  CUmemAccessDesc mem_desc;
+  TF_ASSIGN_OR_RETURN(mem_desc.flags, toCudaMemAccessFlags(access_flags));
+  mem_desc.location = mem_location;
+
+  CUmemPoolProps mem_pool_props;
+  TF_ASSIGN_OR_RETURN(mem_pool_props.allocType,
+                      toCudaAllocationType(allocation_type));
+  mem_pool_props.handleTypes = CU_MEM_HANDLE_TYPE_NONE;
+  mem_pool_props.location = mem_location;
+  mem_pool_props.maxSize = max_pool_size;
+  mem_pool_props.win32SecurityAttributes = nullptr;
+
+  // cuda graph requires reserved space initialized to 0
+  memset(mem_pool_props.reserved, 0, sizeof(mem_pool_props.reserved));
+
+  memAllocParams.accessDescCount = 1;
+  memAllocParams.bytesize = size;
+  memAllocParams.accessDescs = &mem_desc;
+  memAllocParams.poolProps = mem_pool_props;
+
+  RETURN_IF_CUDA_RES_ERROR(
+      cuGraphAddMemAllocNode(node, graph, deps.data(), deps.size(), &memAllocParams),
+      "Failed to add memory allocation node to a CUDA graph");
+
+  VLOG(2) << "Add MemAllocNode to a graph " << graph << " size " << size
+          << " address " << reinterpret_cast<void*>(memAllocParams.dptr);
+
+  *d_ptr = memAllocParams.dptr;
+  return ::tsl::OkStatus();
+}
+
+/*static*/ tsl::StatusOr<std::pair<CUdeviceptr, uint64_t>>
+GpuDriver::GraphGetMemAllocNodeParams(CUgraphNode& node) {
+  CUDA_MEM_ALLOC_NODE_PARAMS memAllocParams;
+  RETURN_IF_CUDA_RES_ERROR(cuGraphMemAllocNodeGetParams(node, &memAllocParams),
+                           "Failed to get memory allocation node parameter");
+  return std::pair<CUdeviceptr, uint64_t>{memAllocParams.dptr, memAllocParams.bytesize};
 }
 
 /* static */ tsl::Status GpuDriver::GraphAddMemcpyD2DNode(

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -273,6 +273,55 @@ tsl::Status GpuCommandBuffer::MemcpyDeviceToDevice(DeviceMemoryBase* dst,
   return UnsupportedStateError(state_);
 }
 
+tsl::Status GpuCommandBuffer::Allocate(CommandBuffer::AllocIndexSize alloc) {
+  TF_RETURN_IF_ERROR(CheckNotFinalized());
+
+  // Adds a new memalloc node to the graph under construction.
+  if (state_ == State::kCreate) {
+    Dependencies deps = GetDependencies();
+    GpuGraphNodeHandle* node = &nodes_.emplace_back();
+    GpuDevicePtr gpu_dptr;
+    TF_RETURN_IF_ERROR(GpuDriver::GraphAddMemAllocNode(
+        node, graph_, absl::MakeSpan(deps),
+        GpuDriver::MemAccessFlags::kReadWrite,
+        GpuDriver::MemLocationType::kDevice, parent_->device_ordinal(),
+        GpuDriver::MemAllocationType::kPinned, alloc.size, &gpu_dptr));
+    // For CUDA impl, VA range is reserved when adding memory allocation node.
+    CHECK(gpu_dptr) << "Graph add memory allocation node return null ptr";
+    VLOG(2) << "Setting device memory base with opaque pointer "
+            << reinterpret_cast<void*>(gpu_dptr)
+            << " device ordinal: " << parent_->device_ordinal();
+    allocations_map_[alloc.index] =
+        DeviceMemoryBase{reinterpret_cast<void*>(gpu_dptr), alloc.size};
+    return tsl::OkStatus();
+  }
+
+  if (state_ == State::kUpdate) {
+    // memalloc node implemented through CUDA graph does not allocate new memory
+    // region on update, just return the memory region allocated during the
+    // create step.
+    TF_ASSIGN_OR_RETURN(
+        AllocationResult params,
+        GpuDriver::GraphGetMemAllocNodeParams(nodes_[update_state_.node_idx]));
+    update_state_.node_idx++;
+    allocations_map_[alloc.index] =
+        DeviceMemoryBase{reinterpret_cast<void*>(params.first), params.second};
+    return tsl::OkStatus();
+  }
+
+  return UnsupportedStateError(state_);
+}
+
+tsl::StatusOr<DeviceMemoryBase> GpuCommandBuffer::GetAllocationAddress(
+    int64_t index) const {
+  if (allocations_map_.contains(index)) {
+    return allocations_map_.at(index);
+  } else {
+    return absl::InternalError(
+        absl::StrCat("Allocation is not yet allocated "));
+  }
+}
+
 //--------------------------------------------------------------------------//
 // Command buffer condtitional commands API
 //--------------------------------------------------------------------------//

--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -491,6 +491,46 @@ class GpuDriver {
       unsigned int block_dim_z, unsigned int shared_mem_bytes,
       void** kernel_params, void** extra);
 
+  // Memory protection flags for mappings.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1gfba87b8c4a8cd091554d8e2c3fc9b40a
+  enum class MemAccessFlags {
+    kNone,
+    kRead,
+    kReadWrite,
+  };
+
+  // Specifies the type of memory location
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1g75cfd5b9fa5c1c6ee2be2547bfbe882e
+  enum class MemLocationType {
+    kInvalid,
+    kDevice,
+    kHost,
+    kHostNuma,
+    kHostNumaCurrent,
+  };
+
+  // The memory allocation type
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1g7ed3482e0df8712d79a99bcb3bc4a95b
+  enum class MemAllocationType {
+    kInvalid,
+    kPinned,
+  };
+
+  // Creates a memalloc node and adds it to a graph.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g73a351cb71b2945a0bcb913a93f69ec9
+  static tsl::Status GraphAddMemAllocNode(
+      GpuGraphNodeHandle* node, GpuGraphHandle graph,
+      absl::Span<GpuGraphNodeHandle> deps, MemAccessFlags access_flags,
+      MemLocationType location_type, int device_id,
+      MemAllocationType allocation_type, uint64_t size, GpuDevicePtr* d_ptr,
+      uint64_t max_pool_size = 0);
+
+
+  // Fetch memory allocation node's allocated address;
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1gee2c7d66d3d96b1470c1d1a769f250a2
+  static tsl::StatusOr<std::pair<GpuDevicePtr, uint64_t>>
+  GraphGetMemAllocNodeParams(GpuGraphNodeHandle& node);
+
   // Creates a memcpy node and adds it to a graph.
   // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g674da6ab54a677f13e0e0e8206ff5073
   static tsl::Status GraphAddMemcpyD2DNode(GpuContext* context,

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -101,6 +101,8 @@ class GpuExecutor : public internal::StreamExecutorInterface {
 
   tsl::Status Init(int device_ordinal, DeviceOptions device_options) override;
 
+  int device_ordinal() const override { return device_ordinal_; };
+
   tsl::Status GetKernel(const MultiKernelLoaderSpec& spec,
                         Kernel* kernel) override;
 

--- a/xla/stream_executor/host/host_gpu_executor.cc
+++ b/xla/stream_executor/host/host_gpu_executor.cc
@@ -45,6 +45,7 @@ HostStream* AsHostStream(Stream* stream) {
 
 tsl::Status HostExecutor::Init(int device_ordinal,
                                DeviceOptions device_options) {
+  device_ordinal_ = device_ordinal;
   auto it =
       device_options.non_portable_tags.find("host_thread_stack_size_in_bytes");
   if (it != device_options.non_portable_tags.end()) {

--- a/xla/stream_executor/host/host_gpu_executor.h
+++ b/xla/stream_executor/host/host_gpu_executor.h
@@ -59,6 +59,7 @@ class HostExecutor : public internal::StreamExecutorInterface {
     return tsl::errors::Unimplemented("Not Implemented");
   }
 
+  int device_ordinal() const override { return device_ordinal_; };
   DeviceMemoryBase Allocate(uint64_t size, int64_t memory_space) override;
   void* GetSubBuffer(DeviceMemoryBase* parent, uint64_t offset_bytes,
                      uint64_t size_bytes) override;
@@ -152,6 +153,10 @@ class HostExecutor : public internal::StreamExecutorInterface {
   std::unique_ptr<internal::StreamInterface> GetStreamImplementation() override;
 
  private:
+  // The device ordinal value that this executor was initialized with; recorded
+  // for use in getting device metadata. Immutable post-initialization.
+  int device_ordinal_;
+
   // Size of thread stacks for streams in bytes. '0' means "the default size".
   size_t thread_stack_size_in_bytes_ = 0;
 };

--- a/xla/stream_executor/stream_executor_internal.h
+++ b/xla/stream_executor/stream_executor_internal.h
@@ -172,6 +172,11 @@ class CommandBufferInterface {
   virtual tsl::Status For(StreamExecutor* executor, int32_t num_iteration,
                           DeviceMemory<int32_t> loop_index,
                           CommandBuffer::Builder body_builder) = 0;
+  // Adds a device memory allocation node to the command buffer.
+  virtual tsl::Status Allocate(CommandBuffer::AllocIndexSize alloc) = 0;
+
+  // Get the device address for allocations performed through command buffer Allocate command.
+  virtual tsl::StatusOr<DeviceMemoryBase> GetAllocationAddress(int64_t index) const = 0;
 
   // Adds a conditional operation that will execute a command buffer constructed
   // by the `cond_builder` that must update `pred` value, and then depending on
@@ -279,6 +284,10 @@ class StreamExecutorInterface {
   virtual std::optional<std::string> MakeDeviceDescriptionStr() const {
     return std::nullopt;
   }
+
+  virtual int device_ordinal() const {
+    return -1;
+  };
 
   virtual tsl::Status GetKernel(const MultiKernelLoaderSpec& spec,
                                 Kernel* kernel) {

--- a/xla/stream_executor/tpu/tpu_executor.cc
+++ b/xla/stream_executor/tpu/tpu_executor.cc
@@ -52,6 +52,7 @@ TpuExecutor::~TpuExecutor() { ExecutorApiFn()->TpuExecutor_FreeFn(executor_); }
 
 Status TpuExecutor::Init(int device_ordinal,
                          ::stream_executor::DeviceOptions device_options) {
+  device_ordinal_ = device_ordinal;
   StatusHelper status;
   SE_DeviceOptions* options =
       ExecutorApiFn()->TpuExecutor_NewDeviceOptionsFn(device_options.flags());

--- a/xla/stream_executor/tpu/tpu_executor.h
+++ b/xla/stream_executor/tpu/tpu_executor.h
@@ -68,6 +68,7 @@ class TpuExecutor : public tensorflow::tpu::TpuExecutorInterface {
   tsl::Status Init(int device_ordinal,
                    ::stream_executor::DeviceOptions device_options) override;
 
+  int device_ordinal() const override { return device_ordinal_; };
   DeviceMemoryBase Allocate(uint64_t size, int64_t memory_space) override;
 
   tsl::Status AllocateEvent(Event* event) override;
@@ -226,7 +227,7 @@ class TpuExecutor : public tensorflow::tpu::TpuExecutorInterface {
     absl::MutexLock m(&tpu_platform().mutex());
     return stream_map()[ptr];
   }
-
+  int device_ordinal_;
   tensorflow::tpu::TpuPlatformInterface* platform_;
   SE_StreamExecutor* executor_;
 };


### PR DESCRIPTION
This PR add the `Allocate` command to command buffer. 

The `Allocate` command is constructed with the pointer to `BufferAllocation`. The allocation will be performed when the command is recorded, the allocated address will be tracked by command buffer runtime through allocation index.  For the consumer commands who want to access the allocated buffer, the record parameter buffer address should be provided as se::DeviceMemoryBase with special address (LAZY_ALLOCATE_ADDRESS_MARKER) and non-zero size, and it can be created with API  se::DeviceMemory<>::MakeLazyAllocAddressFromByteSize(byte_length);

Below is an example how to construct command sequences that access buffers allocated inside command buffer:

```
  BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
  BufferAllocation alloc_b(/*index=*/1, byte_length, /*color=*/0);
  BufferAllocation alloc_c(/*index=*/2, byte_length, /*color=*/0);
  BufferAllocation::Slice slice_a(&alloc_a, 0, byte_length);
  BufferAllocation::Slice slice_b(&alloc_b, 0, byte_length);
  BufferAllocation::Slice slice_c(&alloc_c, 0, byte_length);

  // Prepare commands sequence for constructing command buffer.
  CommandBufferCmdSequence commands;
  commands.Emplace<AllocateCmd>(&alloc_b);
  commands.Emplace<MemcpyDeviceToDeviceCmd>(slice_b, slice_a, byte_length);
  commands.Emplace<MemcpyDeviceToDeviceCmd>(slice_c, slice_b, byte_length);

  // Construct a thunk with command sequence.
  CommandBufferThunk thunk(std::move(commands), Thunk::ThunkInfo(nullptr));

  // Prepare arguments: a=42, b=0
  se::DeviceMemory<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
  stream.ThenMemset32(&a, 42, byte_length);

  se::DeviceMemory<int32_t> b = se::DeviceMemory<int32_t>::MakeLazyAllocAddressFromByteSize(byte_length);
  se::DeviceMemory<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
  BufferAllocations allocations({a, b, c}, 0, executor->GetAllocator());

  ServiceExecutableRunOptions run_options;
  Thunk::ExecuteParams params(run_options, allocations, &stream, {});

  // Execute command buffer thunk and verify that it copied the memory.
  TF_ASSERT_OK(thunk.ExecuteOnStream(params));

```

For CUDA implementation, the command has no update parameters, which means that when the command is added to command buffer, the address range allocated for this command is fixed across command buffer launches.
  
The `Allocation` command is only implemented for CUDA platform