### PR TITLE
[XLA:GPU] add back pointer in while body computation to trace back to while call

### DIFF
--- a/xla/hlo/ir/hlo_computation.cc
+++ b/xla/hlo/ir/hlo_computation.cc
@@ -79,7 +79,9 @@ HloComputation::HloComputation(
       custom_call_instruction_(nullptr),
       is_custom_call_computation_(false),
       collective_call_instruction_(nullptr),
-      is_collective_called_computation_(false) {
+      is_collective_called_computation_(false),
+      while_call_instruction_(nullptr),
+      is_while_call_body_computation_(false) {
   param_instructions_.resize(parameter_count, nullptr);
   bool root_found = false;
   for (auto& instruction : *instructions) {

--- a/xla/hlo/ir/hlo_computation.h
+++ b/xla/hlo/ir/hlo_computation.h
@@ -644,7 +644,8 @@ class HloComputation {
   // computation.
   HloInstruction* FusionInstruction() const { return fusion_instruction_; }
   void SetFusionInstruction(HloInstruction* fusion_instruction) {
-    CHECK(!IsCustomCallComputation() && !IsAsyncComputation());
+    CHECK(!IsCustomCallComputation() && !IsAsyncComputation() &&
+          !IsCollectiveCalledComputation() && !IsWhileBodyComputation());
     fusion_instruction_ = fusion_instruction;
     is_fusion_computation_ |= (fusion_instruction != nullptr);
   }
@@ -658,7 +659,8 @@ class HloComputation {
     return custom_call_instruction_;
   }
   void SetCustomCallInstruction(HloInstruction* custom_call_instruction) {
-    CHECK(!IsFusionComputation() && !IsAsyncComputation());
+    CHECK(!IsFusionComputation() && !IsAsyncComputation() &&
+          !IsCollectiveCalledComputation() && !IsWhileBodyComputation());
     custom_call_instruction_ = custom_call_instruction;
     is_custom_call_computation_ |= (custom_call_instruction != nullptr);
   }
@@ -677,10 +679,30 @@ class HloComputation {
   void SetCollectiveCallInstruction(
       HloInstruction* collective_call_instruction) {
     CHECK(!IsFusionComputation() && !IsAsyncComputation() &&
-          !IsCustomCallComputation());
+          !IsCustomCallComputation() && !IsWhileBodyComputation());
     collective_call_instruction_ = collective_call_instruction;
     is_collective_called_computation_ |=
         (collective_call_instruction != nullptr);
+  }
+
+  // Returns if this computation is a body computation of a while.
+  bool IsWhileBodyComputation() const {
+    return is_while_call_body_computation_;
+  }
+
+  // Returns the owning while call instruction, or nullptr if this is not a
+  // while call body computation.
+  HloInstruction* WhileCallInstruction() const {
+    return while_call_instruction_;
+  }
+
+  void SetWhileCallInstruction(HloInstruction* while_call_instruction) {
+    CHECK(!IsFusionComputation() && !IsAsyncComputation() &&
+          !IsCustomCallComputation() && !IsCollectiveCalledComputation());
+    CHECK(while_call_instruction != nullptr);
+    CHECK(while_call_instruction->opcode() == HloOpcode::kWhile);
+    while_call_instruction_ = while_call_instruction;
+    is_while_call_body_computation_ |= (while_call_instruction != nullptr);
   }
 
   // Returns if this computation is an async computation.
@@ -839,6 +861,13 @@ class HloComputation {
 
   // Determines whether this computation is a collective sub-computation.
   bool is_collective_called_computation_;
+
+  // If this computation is a while body computation, this field points to
+  // the corresponding while instruction. Otherwise, this is null.
+  HloInstruction* while_call_instruction_;
+
+  // Determines whether this computation is a while body computation.
+  bool is_while_call_body_computation_;
 
   // If this computation is an async computation, this field points to the
   // corresponding async instructions (if live) that call this computation.

--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -1542,6 +1542,8 @@ HloInstruction::CreateAddDependency(HloInstruction* data_operand,
   // Body comes before condition computation in the vector.
   instruction->called_computations_.push_back(body);
   instruction->called_computations_.push_back(condition);
+  // Set back pointer from body computation to the while call instruction
+  body->SetWhileCallInstruction(instruction.get());
   return instruction;
 }
 


### PR DESCRIPTION
add back pointer in while body computation to trace back to while call for data dependency analysis and pattern matching.