### PR TITLE
[GPU] Improve NCCL error reporting

### DIFF
--- a/xla/service/gpu/nccl_utils.cc
+++ b/xla/service/gpu/nccl_utils.cc
@@ -50,8 +50,10 @@ Status ToStatus(ncclResult_t s, const char* file, int64_t line,
     return OkStatus();
   }
   return tsl::errors::Internal(
-      absl::StrFormat("%s:%d: NCCL operation %s failed: %s", file, line, expr,
-                      ncclGetErrorString(s)));
+      absl::StrFormat("%s:%d: NCCL operation %s failed: %s."
+                      " Last NCCL warning(error) log entry (may be unrelated) '%s'.",
+                      file, line, expr, ncclGetErrorString(s),
+                      ncclGetLastError(NULL)));
 }
 
 ncclRedOp_t ToNcclReduction(ReductionKind kind) {
@@ -210,7 +212,9 @@ void CheckNcclAsyncError(NcclComm& lockable_comm) {
     if (async_err != ncclSuccess) {
       LOG(ERROR) << "Aborting communicator: " << comm
                  << " due to async NCCL error: "
-                 << ncclGetErrorString(async_err);
+                 << ncclGetErrorString(async_err)
+                 << ". Last NCCL warning(error) log entry (may be unrelated): "
+                 << ncclGetLastError(NULL);
       XLA_CUDA_RETURN_IF_ERROR(ncclCommAbort(comm));
     }
     return XLA_CUDA_STATUS(async_err);


### PR DESCRIPTION
ncclGetLastError return the last log entry generated at the "WARN/ERROR" level.

Here is an example of the new error:
```
NCCL operation ncclCommInitRank(&comm, nranks, id, rank) failed: unhandled cuda error (run with NCCL_DEBUG=INFO for details). Last NCCL warning(error) log entry (may be unrelated) 'Cuda failure 2 'out of memory''.; current tracing scope: all-reduce-start.285; current profiling annotation: XlaModule:#hlo_module=pjit__wrapped_step_fn,program_id=25#.
```

The new part is:
```
Last NCCL warning(error) log entry (may be unrelated) 'Cuda failure 2 'out of memory''.
```