### PR TITLE
Update build_from_source.md doc to point to latest-gpu docker image

### DIFF
--- a/docs/build_from_source.md
+++ b/docs/build_from_source.md
@@ -33,7 +33,7 @@ We recommend using a suitable docker container to build/test XLA, such as
 [TensorFlow's docker container](https://www.tensorflow.org/install/docker):
 
 ```
-docker run --name xla -w /xla -it -d --rm -v $PWD:/xla tensorflow/build:latest-python3.9 bash
+docker run --name xla_gpu -w /xla -it -d --rm -v $PWD:/xla tensorflow/tensorflow:latest-gpu bash
 ```
 
 Using a docker container you can build XLA with CPU support using the following commands:

--- a/docs/build_from_source.md
+++ b/docs/build_from_source.md
@@ -33,7 +33,7 @@ We recommend using a suitable docker container to build/test XLA, such as
 [TensorFlow's docker container](https://www.tensorflow.org/install/docker):
 
 ```
-docker run --name xla_gpu -w /xla -it -d --rm -v $PWD:/xla tensorflow/tensorflow:latest-gpu bash
+docker run --name xla -w /xla -it -d --rm -v $PWD:/xla tensorflow/tensorflow:latest-gpu bash
 ```
 
 Using a docker container you can build XLA with CPU support using the following commands:


### PR DESCRIPTION
The "devel" docker image is not updated and does not seem maintained anymore. We probably should recommend a most up-to-date image.