### PR TITLE
Add gradient accumulation rewriter

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -129,6 +129,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   opts.set_xla_gpu_enable_reassociation_for_converted_ar(true);
 
+  opts.set_xla_enable_grad_acc_all_reduce_rewriter(false);
+
   opts.set_xla_cpu_enable_xprof_traceme(false);
   opts.set_xla_gpu_unsafe_fallback_to_driver_on_ptxas_not_found(false);
   opts.set_xla_multiheap_size_constraint_per_heap(-1);
@@ -964,6 +966,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "wider type. "
       "The reassociated allreduce will be promoted to a wider-typed "
       "allreduce."));
+  flag_list->push_back(tsl::Flag(
+      "xla_enable_grad_acc_all_reduce_rewriter",
+      bool_setter_for(
+          &DebugOptions::set_xla_enable_grad_acc_all_reduce_rewriter),
+      debug_options->xla_enable_grad_acc_all_reduce_rewriter(),
+      "Enable the rewrite of allreduce introduced by the data parallel "
+      "backward process when using gradient accumulation."));
   flag_list->push_back(
       tsl::Flag("xla_gpu_dump_llvmir",
                 bool_setter_for(&DebugOptions::set_xla_gpu_dump_llvmir),

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -250,6 +250,34 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "grad_acc_all_reduce_rewriter",
+    srcs = ["grad_acc_all_reduce_rewriter.cc"],
+    hdrs = ["grad_acc_all_reduce_rewriter.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:hlo_pass",
+        "//xla/service/spmd:spmd_partitioner",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "grad_acc_all_reduce_rewriter_test",
+    srcs = ["grad_acc_all_reduce_rewriter_test.cc"],
+    deps = [
+        ":hlo_verifier",
+        ":grad_acc_all_reduce_rewriter",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/utils:hlo_matchers",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/strings",
+        "@tsl//tsl/lib/core:status_test_util",
+    ],
+)
+
+cc_library(
     name = "float_support",
     srcs = ["float_support.cc"],
     hdrs = ["float_support.h"],

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2842,6 +2842,7 @@ cc_library(
         "//xla/service:float_support",
         "//xla/service:gather_expander",
         "//xla/service:gather_simplifier",
+        "//xla/service:grad_acc_all_reduce_rewriter",
         "//xla/service:hlo_computation_deduplicator",
         "//xla/service:hlo_constant_folding",
         "//xla/service:hlo_cse",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -118,6 +118,7 @@ limitations under the License.
 #include "xla/service/float_support.h"
 #include "xla/service/gather_expander.h"
 #include "xla/service/gather_simplifier.h"
+#include "xla/service/grad_acc_all_reduce_rewriter.h"
 #include "xla/service/gpu/alias_passthrough_params.h"
 #include "xla/service/gpu/all_reduce_blueconnect.h"
 #include "xla/service/gpu/autotuner_util.h"
@@ -808,6 +809,9 @@ Status GpuCompiler::OptimizeHloModule(HloModule* hlo_module,
   {
     HloPassPipeline collectives_pipeline("collective-optimizations");
     collectives_pipeline.AddPass<AllReduceFolder>();
+    if (debug_options.xla_enable_grad_acc_all_reduce_rewriter()) {
+      collectives_pipeline.AddPass<GradAccAllReduceRewriter>();
+    }
     collectives_pipeline.AddPass<ReduceScatterCreator>();
     collectives_pipeline.AddPass<AllGatherOptimizer>();
     collectives_pipeline.AddPass<AllReduceReassociate>(

--- a/xla/service/grad_acc_all_reduce_rewriter.cc
+++ b/xla/service/grad_acc_all_reduce_rewriter.cc
@@ -1,0 +1,189 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/grad_acc_all_reduce_rewriter.h"
+
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/spmd/spmd_partitioner_util.h"
+
+namespace xla {
+namespace {
+
+HloInstruction* GetAllReduce(HloInstruction* src) {
+  auto opcode = src->opcode();
+  if (opcode == HloOpcode::kAllReduce) {
+    return src;
+  } else if (opcode == HloOpcode::kConvert || opcode == HloOpcode::kReshape ||
+             opcode == HloOpcode::kCopy || opcode == HloOpcode::kBitcast ||
+             opcode == HloOpcode::kTranspose ||
+             opcode == HloOpcode::kDynamicSlice) {
+    return GetAllReduce(src->mutable_operand(0));
+  } else if (opcode == HloOpcode::kMultiply) {
+    HloInstruction* lhs = GetAllReduce(src->mutable_operand(0));
+    HloInstruction* rhs = GetAllReduce(src->mutable_operand(1));
+
+    if (lhs != nullptr && rhs == nullptr) {
+      return lhs;
+    } else if (lhs == nullptr && rhs != nullptr) {
+      return rhs;
+    }
+  }
+
+  return nullptr;
+}
+
+HloInstruction* GetParameter(HloInstruction* src) {
+  auto opcode = src->opcode();
+  if (opcode == HloOpcode::kParameter) {
+    return src;
+  } else if (opcode == HloOpcode::kConvert || opcode == HloOpcode::kReshape ||
+             opcode == HloOpcode::kCopy || opcode == HloOpcode::kBitcast ||
+             opcode == HloOpcode::kTranspose ||
+             opcode == HloOpcode::kDynamicSlice) {
+    return GetParameter(src->mutable_operand(0));
+  }
+  return nullptr;
+}
+
+bool IsBackWard(HloInstruction* src) {
+  return absl::StrContains(src->metadata().op_name(), "backward");
+}
+
+bool IsInBackWard(HloInstruction* src) {
+  // TODO: improve matching accuracy.
+  auto opcode = src->opcode();
+  if (IsBackWard(src)) {
+    return true;
+  } else if (opcode == HloOpcode::kDot) {
+    auto lhs_is_bw = IsInBackWard(src->mutable_operand(0));
+    auto rhs_is_bw = IsInBackWard(src->mutable_operand(1));
+    if (lhs_is_bw || rhs_is_bw) return true;
+
+    for (auto user : src->mutable_operand(0)->users()) {
+      lhs_is_bw |= IsBackWard(user);
+    }
+    for (auto user : src->mutable_operand(1)->users()) {
+      rhs_is_bw |= IsBackWard(user);
+    }
+    return lhs_is_bw || rhs_is_bw;
+  } else if (opcode == HloOpcode::kConvert || opcode == HloOpcode::kReshape ||
+             opcode == HloOpcode::kCopy || opcode == HloOpcode::kBitcast ||
+             opcode == HloOpcode::kTranspose ||
+             opcode == HloOpcode::kBroadcast ||
+             opcode == HloOpcode::kScatter || opcode == HloOpcode::kPad) {
+    return IsInBackWard(src->mutable_operand(0));
+  } else if (opcode == HloOpcode::kSelect) {
+    for (auto operand : src->operands()) {
+      if (IsInBackWard(operand)) return true;
+    }
+  }
+  return false;
+}
+
+bool IsUsedBy(HloInstruction* src, HloInstruction* dst) {
+  bool ret = false;
+  if (src->IsDead()) return ret;
+
+  for (auto user: src->users()) {
+    auto opcode = user->opcode();
+    if (user == dst) {
+      return true;
+    } else if (opcode == HloOpcode::kConvert || opcode == HloOpcode::kReshape ||
+               opcode == HloOpcode::kCopy || opcode == HloOpcode::kBitcast ||
+               opcode == HloOpcode::kTranspose) {
+      ret = IsUsedBy(user, dst);
+    }
+  }
+  return ret;
+}
+
+} // namespace
+
+StatusOr<bool> GradAccAllReduceRewriter::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  HloComputation* entry = module->entry_computation();
+  for (HloInstruction* instr : entry->MakeInstructionPostOrder()) {
+    HloInstruction* ar_instr = nullptr;
+
+    if (instr->opcode() == HloOpcode::kAdd) {
+      // pattern: allreduce(->dynamicslice)(->transpose)(->convert)->add->...
+      if (GetParameter(instr->mutable_operand(0)) == nullptr) {
+        continue;
+      }
+      ar_instr = GetAllReduce(instr->mutable_operand(1));
+    } else if (IsUsedBy(instr, entry->root_instruction())) {
+      // pattern: allreduce(->dynamicslice)(->transpose)(->convert)->root
+      ar_instr = GetAllReduce(instr);
+    }
+
+    // Only rewrite allreduce in the backward process.
+    // The current implementation requires that the metadata op_name
+    // for allreduce upstream instructions must include "backward".
+    if (ar_instr == nullptr || !IsInBackWard(ar_instr->mutable_operand(0))) {
+      continue;
+    }
+
+    if (!IsUsedBy(instr, entry->root_instruction())) {
+      // In most cases, after updating the model weights, the gradient will be
+      // set to zero/none and therefore will not be used as outputs.
+      CHECK(instr->opcode() == HloOpcode::kAdd);
+      const Shape& new_shape = instr->shape();
+      auto old_ar = Cast<HloAllReduceInstruction>(ar_instr);
+      // We create new allreduce other than move old one to avoid compatibility
+      // issues caused by type conversions such as bf16->fp32.
+      auto new_ar =
+          entry->AddInstruction(HloInstruction::CreateAllReduce(
+              new_shape,
+              {instr},
+              spmd::MakeBinaryAdd(new_shape.element_type(), entry->parent()),
+              old_ar->replica_groups(),
+              old_ar->constrain_layout(), old_ar->channel_id(),
+              old_ar->use_global_device_ids()));
+      new_ar->set_metadata(old_ar->metadata());
+
+      for (auto instr_user : instr->users()) {
+        if (instr_user == new_ar) {
+          continue;
+        }
+        for (size_t i = 0; i < instr_user->operand_count(); ++i) {
+          if (instr_user->operand(i) == instr) {
+            TF_CHECK_OK(instr_user->ReplaceOperandWith(i, new_ar));
+          }
+        }
+      }
+      VLOG(1) << "Added instruction: " << new_ar->ToString();
+    }
+
+    // remove allreduce
+    for (auto ar_user : ar_instr->users()) {
+      TF_CHECK_OK(ar_instr->ReplaceUseWith(ar_user,
+          ar_instr->mutable_operand(0)));
+    }
+    ar_instr->DetachFromOperandsAndUsers();
+    TF_CHECK_OK(entry->RemoveInstruction(ar_instr));
+    VLOG(1) << "Skipped instruction: " << ar_instr->ToString();
+  }
+
+  return true;
+}
+
+}  // namespace xla

--- a/xla/service/grad_acc_all_reduce_rewriter.h
+++ b/xla/service/grad_acc_all_reduce_rewriter.h
@@ -1,0 +1,68 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GRAD_ACC_ALL_REDUCE_REWRITER_H_
+#define XLA_SERVICE_GRAD_ACC_ALL_REDUCE_REWRITER_H_
+
+#include "xla/service/hlo_pass_interface.h"
+
+namespace xla {
+
+// Rewrite allreduce introduced by the data parallel backward process when
+// using gradient accumulation.
+//
+// Case1: Skip allreduce for non-optimizer-step iteration:
+// Pattern before this pass:
+// grad_param = ...
+// d = dot(...)
+// a = allreduce(d)
+// grad_out = add(grad_param, a) if grad_param else a
+//
+// Pattern After this pass:
+// grad_param = ...
+// d = dot(...)
+// grad_out = add(grad_param, d) if grad_param else d
+//
+// Case2: Move allreduce after add for optimizer-step iteration:
+// Pattern before this pass:
+// grad_param = ...
+// d = dot(...)
+// a = allreduce(d)
+// new_grad = add(grad_param, a)
+//
+// Pattern before this pass:
+// grad_param = ...
+// d = dot(...)
+// new_grad = add(grad_param, d)
+// a = allreduce(new_grad)
+
+
+class GradAccAllReduceRewriter : public HloModulePass {
+ public:
+  GradAccAllReduceRewriter() = default;
+  ~GradAccAllReduceRewriter() override = default;
+  absl::string_view name() const override {
+    return "grad_acc_all_reduce_rewriter";
+  }
+
+  using HloPassInterface::Run;
+  StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GRAD_ACC_ALL_REDUCE_REWRITER_H_

--- a/xla/service/grad_acc_all_reduce_rewriter_test.cc
+++ b/xla/service/grad_acc_all_reduce_rewriter_test.cc
@@ -1,0 +1,359 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/grad_acc_all_reduce_rewriter.h"
+
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_matchers.h"
+#include "xla/service/hlo_verifier.h"
+#include "xla/tests/hlo_test_base.h"
+#include "tsl/lib/core/status_test_util.h"
+
+namespace xla {
+namespace {
+
+namespace op = ::xla::testing::opcode_matchers;
+using ::testing::NotNull;
+
+class GradAccAllReduceRewriterTest : public HloTestBase {
+ public:
+  template <HloOpcode op>
+  HloInstruction* find_op(HloComputation* computation) {
+    return *std::find_if(computation->instructions().begin(),
+                         computation->instructions().end(),
+                         HloPredicateIsOp<op>);
+  }
+};
+
+TEST_F(GradAccAllReduceRewriterTest, SkipBackwardAllReduce) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule backward_all_reduce_output
+
+    %add (x: bf16[], y: bf16[]) -> bf16[] {
+      %x = bf16[] parameter(0)
+      %y = bf16[] parameter(1)
+      ROOT %add.1 = bf16[] add(bf16[] %x, bf16[] %y)
+    }
+
+    ENTRY backward_all_reduce_output {
+      %constant = bf16[] constant(0.1)
+      %constant.1 = bf16[] constant(0.2)
+      %broadcast =  bf16[16,1024]{1,0} broadcast(bf16[] %constant)
+      %broadcast.1 =  bf16[16,1024]{1,0} broadcast(bf16[] %constant.1)
+      %dot = bf16[1024,1024]{1,0} dot(bf16[16,1024]{1,0} %broadcast, bf16[16,1024]{1,0} %broadcast.1), lhs_contracting_dims={0}, rhs_contracting_dims={0}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %all-reduce = bf16[1024,1024]{1,0} all-reduce(bf16[1024,1024]{1,0} %dot), channel_id=3, replica_groups={{0}}, to_apply=%add, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %convert = f32[1024,1024]{1,0} convert(bf16[1024,1024]{1,0} %all-reduce)
+      %transpose = f32[1024,1024]{0,1} transpose(f32[1024,1024]{1,0} %convert), dimensions={1,0}
+      ROOT %tuple.1 = (f32[1024,1024]{1,0}, f32[1024,1024]{1,0}) tuple(f32[1024,1024]{1,0} %convert, f32[1024,1024]{0,1} %transpose)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool skip_allreduce,
+                          GradAccAllReduceRewriter().Run(module.get()));
+  ASSERT_TRUE(skip_allreduce);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  auto entry = module->entry_computation();
+  EXPECT_THAT(entry->instructions(), Each(Not(op::AllReduce())));
+  auto dot_instr =
+      entry->root_instruction()->operand(0)->operand(0);
+  EXPECT_THAT(dot_instr, op::Dot());
+}
+
+TEST_F(GradAccAllReduceRewriterTest, SkipBackwardInSelectAllReduce) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule backward_all_reduce_output
+
+    %AddComputation.1579 (x.1580: f32[], y.1581: f32[]) -> f32[] {
+      %x.1580 = f32[] parameter(0)
+      %y.1581 = f32[] parameter(1)
+      ROOT %add.1582 = f32[] add(f32[] %x.1580, f32[] %y.1581)
+    }
+
+    ENTRY backward_all_reduce_output {
+      %param.1 = s64[4096,1]{1,0} parameter(0)
+      %param.2 = f32[4096,1,4096]{2,1,0} parameter(1)
+      %constant.826 = u32[1]{0} constant({0})
+      %convert.296 = pred[1]{0} convert(u32[1]{0} %constant.826), metadata={op_type="aten__index_put" op_name="aten__index_put"}
+      %reshape.2038 = pred[] reshape(pred[1]{0} %convert.296), metadata={op_type="aten__index_put" op_name="aten__index_put"}
+      %broadcast.583 = pred[32001,4096]{1,0} broadcast(pred[] %reshape.2038), dimensions={}, metadata={op_type="aten__index_put" op_name="aten__index_put"}
+      %constant.482 = f32[] constant(0), metadata={op_type="aten__nll_loss_backward" op_name="aten__nll_loss_backward"}
+      %broadcast.582 = f32[32001,4096]{1,0} broadcast(f32[] %constant.482), dimensions={}, metadata={op_type="aten__index_put" op_name="aten__index_put"}
+      %param.3 = f32[32001,4096]{1,0} parameter(2), metadata={op_type="xla__device_data" op_name="xla__device_data"}
+      %select.25 = f32[32001,4096]{1,0} select(pred[32001,4096]{1,0} %broadcast.583, f32[32001,4096]{1,0} %broadcast.582, f32[32001,4096]{1,0} %param.3), metadata={op_type="aten__index_put" op_name="aten__index_put"}
+      %scatter.1 = f32[32001,4096]{1,0} scatter(f32[32001,4096]{1,0} %select.25, s64[4096,1]{1,0} %param.1, f32[4096,1,4096]{2,1,0} %param.2), update_window_dims={1,2}, inserted_window_dims={}, scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%AddComputation.1579, metadata={op_type="aten__index_put" op_name="aten__index_put"}
+      %all-reduce.29 = f32[32001,4096]{1,0} all-reduce(f32[32001,4096]{1,0} %scatter.1), channel_id=48, replica_groups={{0,4},{1,5},{2,6},{3,7}}, use_global_device_ids=true, to_apply=%AddComputation.1579, metadata={op_type="aten__index_put" op_name="aten__index_put"}
+      ROOT %tuple.1 = (f32[32001,4096]{1,0}, f32[32001,4096]{1,0}) tuple(f32[32001,4096]{1,0} %param.3, f32[32001,4096]{1,0} %all-reduce.29)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool skip_allreduce,
+                          GradAccAllReduceRewriter().Run(module.get()));
+  ASSERT_TRUE(skip_allreduce);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  auto entry = module->entry_computation();
+  EXPECT_THAT(entry->instructions(), Each(Not(op::AllReduce())));
+  auto scatter_instr = entry->root_instruction()->operand(1);
+  EXPECT_THAT(scatter_instr, op::Scatter());
+}
+
+TEST_F(GradAccAllReduceRewriterTest, SkipBackwardAllReduceAdd) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule backward_all_reduce_output
+
+    %add (x: bf16[], y: bf16[]) -> bf16[] {
+      %x = bf16[] parameter(0)
+      %y = bf16[] parameter(1)
+      ROOT %add.1 = bf16[] add(bf16[] %x, bf16[] %y)
+    }
+
+    ENTRY backward_all_reduce_output {
+      %param.1 = f32[1024,1024]{1,0} parameter(0)
+      %constant = bf16[] constant(0.1)
+      %constant.1 = bf16[] constant(0.2)
+      %broadcast =  bf16[16,1024]{1,0} broadcast(bf16[] %constant)
+      %broadcast.1 =  bf16[16,1024]{1,0} broadcast(bf16[] %constant.1)
+      %dot = bf16[1024,1024]{1,0} dot(bf16[16,1024]{1,0} %broadcast, bf16[16,1024]{1,0} %broadcast.1), lhs_contracting_dims={0}, rhs_contracting_dims={0}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %all-reduce = bf16[1024,1024]{1,0} all-reduce(bf16[1024,1024]{1,0} %dot), channel_id=3, replica_groups={{0}}, to_apply=%add, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %transpose = bf16[1024,1024]{0,1} transpose(bf16[1024,1024]{1,0} %all-reduce), dimensions={1,0}, metadata={op_type="aten__mul" op_name="aten__mul"}
+      %convert = f32[1024,1024]{0,1} convert(bf16[1024,1024]{0,1} %transpose), metadata={op_type="aten__mul" op_name="aten__mul"}
+      %add = f32[1024,1024]{1,0} add(f32[1024,1024]{1,0} %param.1, f32[1024,1024]{0,1} %convert), metadata={op_type="aten__add" op_name="aten__add"}
+      ROOT %tuple.1 = (f32[1024,1024]{1,0}) tuple(f32[1024,1024]{1,0} %add)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool skip_allreduce,
+                          GradAccAllReduceRewriter().Run(module.get()));
+  ASSERT_TRUE(skip_allreduce);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  auto entry = module->entry_computation();
+  EXPECT_THAT(entry->instructions(), Each(Not(op::AllReduce())));
+  auto add_instr = entry->root_instruction()->operand(0);
+  auto dot_instr = add_instr->operand(1)->operand(0)->operand(0);
+  EXPECT_THAT(dot_instr, op::Dot());
+}
+
+TEST_F(GradAccAllReduceRewriterTest, MoveBackwardAllReduceAdd) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule backward_all_reduce_add
+
+    %add (x: bf16[], y: bf16[]) -> bf16[] {
+      %x = bf16[] parameter(0)
+      %y = bf16[] parameter(1)
+      ROOT %add.1 = bf16[] add(bf16[] %x, bf16[] %y)
+    }
+
+    ENTRY backward_all_reduce_add {
+      %param.1 = f32[1024,1024]{1,0} parameter(0)
+      %param.2 = f32[1024,1024]{1,0} parameter(1)
+      %param.3 = f32[] parameter(2)
+      %param.4 = f32[1024,1024]{1,0} parameter(3)
+      %broadcast.9 = f32[1024,1024]{1,0} broadcast(f32[] %param.3), dimensions={}, metadata={op_type="aten__mul" op_name="aten__lerp.1/aten__mul"}
+      %constant = bf16[] constant(0.1)
+      %constant.1 = bf16[] constant(0.2)
+      %broadcast =  bf16[16,1024]{1,0} broadcast(bf16[] %constant)
+      %broadcast.1 =  bf16[16,1024]{1,0} broadcast(bf16[] %constant.1)
+      %dot = bf16[1024,1024]{1,0} dot(bf16[16,1024]{1,0} %broadcast, bf16[16,1024]{1,0} %broadcast.1), lhs_contracting_dims={0}, rhs_contracting_dims={0}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %all-reduce = bf16[1024,1024]{1,0} all-reduce(bf16[1024,1024]{1,0} %dot), channel_id=3, replica_groups={{0}}, to_apply=%add, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %transpose = bf16[1024,1024]{0,1} transpose(bf16[1024,1024]{1,0} %all-reduce), dimensions={1,0}, metadata={op_type="aten__mul" op_name="aten__mul"}
+      %convert = f32[1024,1024]{0,1} convert(bf16[1024,1024]{0,1} %transpose), metadata={op_type="aten__mul" op_name="aten__mul"}
+      %add.10 = f32[1024,1024]{1,0} add(f32[1024,1024]{1,0} %param.1, f32[1024,1024]{0,1} %convert), metadata={op_type="aten__add" op_name="aten__add"}
+      %subtract.1 = f32[1024,1024]{1,0} subtract(f32[1024,1024]{1,0} %add.10, f32[1024,1024]{1,0} %param.2), metadata={op_type="aten__sub" op_name="aten__lerp.2/aten__sub"}
+      %multiply.10 = f32[1024,1024]{1,0} multiply(f32[1024,1024]{1,0} %broadcast.9, f32[1024,1024]{1,0} %subtract.1), metadata={op_type="aten__mul" op_name="aten__lerp.2/aten__mul"}
+      %add.11 = f32[1024,1024]{1,0} add(f32[1024,1024]{1,0} %param.4, f32[1024,1024]{1,0} %multiply.10), metadata={op_type="aten__add" op_name="aten__lerp.2/aten__add"}
+      ROOT %tuple.1 = (f32[1024,1024]{1,0}) tuple(f32[1024,1024]{1,0} %add.11)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool skip_allreduce,
+                          GradAccAllReduceRewriter().Run(module.get()));
+  ASSERT_TRUE(skip_allreduce);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+
+  auto entry = module->entry_computation();
+  auto moved_all_reduce =
+      DynCast<HloAllReduceInstruction>(find_op<HloOpcode::kAllReduce>(entry));
+  ASSERT_THAT(moved_all_reduce, NotNull());
+  EXPECT_THAT(moved_all_reduce, op::ReplicaGroups({{0}}));
+  EXPECT_THAT(moved_all_reduce, op::Shape("f32[1024, 1024]"));
+
+  EXPECT_THAT(moved_all_reduce->operand(0), op::Add());
+  EXPECT_THAT(moved_all_reduce->users()[0], op::Subtract());
+}
+
+TEST_F(GradAccAllReduceRewriterTest, SkipBackwardAllReduceDynamicSlice) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule backward_all_reduce_output
+
+    %add (x: bf16[], y: bf16[]) -> bf16[] {
+      %x = bf16[] parameter(0)
+      %y = bf16[] parameter(1)
+      ROOT %add.1 = bf16[] add(bf16[] %x, bf16[] %y)
+    }
+
+    ENTRY backward_all_reduce_output {
+      %constant.398 = s32[] constant(0)
+      %constant = bf16[] constant(0.1)
+      %constant.1 = bf16[] constant(0.2)
+      %constant.1580 = s32[] constant(2)
+      %broadcast =  bf16[1024,1024]{1,0} broadcast(bf16[] %constant)
+      %broadcast.1 =  bf16[1024,4096]{1,0} broadcast(bf16[] %constant.1)
+      %dot = bf16[1024,4096]{1,0} dot(bf16[1024,1024]{1,0} %broadcast, bf16[1024,4096]{1,0} %broadcast.1), lhs_contracting_dims={0}, rhs_contracting_dims={0}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %all-reduce.35 = bf16[1024,4096]{1,0} all-reduce(bf16[1024,4096]{1,0} %dot), channel_id=3, replica_groups={{0}}, to_apply=%add, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %dynamic-slice.1 = bf16[1024,2048]{1,0} dynamic-slice(bf16[1024,4096]{1,0} %all-reduce.35, s32[] %constant.398, s32[] %constant.1580), dynamic_slice_sizes={1024,2048}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %transpose.1 = bf16[2048,1024]{0,1} transpose(bf16[1024,2048]{1,0} %dynamic-slice.1), dimensions={1,0}, metadata={op_type="aten__permute" op_name="aten__permute"}
+      %convert.1 = f32[2048,1024]{0,1} convert(bf16[2048,1024]{0,1} %transpose.1), metadata={op_type="aten__permute" op_name="aten__permute"}
+      ROOT %tuple.1 = (f32[2048,1024]{1,0}) tuple(f32[2048,1024]{1,0} %convert.1)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool skip_allreduce,
+                          GradAccAllReduceRewriter().Run(module.get()));
+  ASSERT_TRUE(skip_allreduce);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  auto entry = module->entry_computation();
+  EXPECT_THAT(entry->instructions(), Each(Not(op::AllReduce())));
+  auto dyna_slice_instr =
+      entry->root_instruction()->operand(0)->operand(0)->operand(0);
+  EXPECT_THAT(dyna_slice_instr, op::DynamicSlice());
+  auto dot_instr = dyna_slice_instr->operand(0);
+  EXPECT_THAT(dot_instr, op::Dot());
+}
+
+TEST_F(GradAccAllReduceRewriterTest, SkipBackwardAllReduceDynamicSliceAdd) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule backward_all_reduce_output
+
+    %add (x: bf16[], y: bf16[]) -> bf16[] {
+      %x = bf16[] parameter(0)
+      %y = bf16[] parameter(1)
+      ROOT %add.1 = bf16[] add(bf16[] %x, bf16[] %y)
+    }
+
+    ENTRY backward_all_reduce_output {
+      %param.1 = f32[1024,2048]{1,0} parameter(0)
+      %constant.398 = s32[] constant(0)
+      %constant = bf16[] constant(0.1)
+      %constant.1 = bf16[] constant(0.2)
+      %constant.1580 = s32[] constant(2)
+      %broadcast =  bf16[1024,1024]{1,0} broadcast(bf16[] %constant)
+      %broadcast.1 =  bf16[1024,4096]{1,0} broadcast(bf16[] %constant.1)
+      %dot = bf16[1024,4096]{1,0} dot(bf16[1024,1024]{1,0} %broadcast, bf16[1024,4096]{1,0} %broadcast.1), lhs_contracting_dims={0}, rhs_contracting_dims={0}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %all-reduce.35 = bf16[1024,4096]{1,0} all-reduce(bf16[1024,4096]{1,0} %dot), channel_id=3, replica_groups={{0}}, to_apply=%add, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %dynamic-slice.1 = bf16[1024,2048]{1,0} dynamic-slice(bf16[1024,4096]{1,0} %all-reduce.35, s32[] %constant.398, s32[] %constant.1580), dynamic_slice_sizes={1024,2048}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %convert.1 = f32[1024,2048]{0,1} convert(bf16[1024,2048]{0,1} %dynamic-slice.1), metadata={op_type="xla__cast" op_name="xla__cast"}
+      %add.153 = f32[1024,2048]{1,0} add(f32[1024,2048]{1,0} %param.1, f32[1024,2048]{1,0} %convert.1), metadata={op_type="aten__add" op_name="aten__add"}
+      %transpose.557 = f32[2048,1024]{0,1} transpose(f32[1024,2048]{1,0} %add.153), dimensions={1,0}, metadata={op_type="aten__add" op_name="aten__add"}
+      ROOT %tuple.1 = (f32[2048,1024]{1,0}) tuple(f32[2048,1024]{1,0} %transpose.557)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool skip_allreduce,
+                          GradAccAllReduceRewriter().Run(module.get()));
+  ASSERT_TRUE(skip_allreduce);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  auto entry = module->entry_computation();
+  EXPECT_THAT(entry->instructions(), Each(Not(op::AllReduce())));
+  auto dyna_slice_instr =
+      entry->root_instruction()->operand(0)->operand(0)->operand(1)->operand(0);
+  EXPECT_THAT(dyna_slice_instr, op::DynamicSlice());
+  auto dot_instr = dyna_slice_instr->operand(0);
+  EXPECT_THAT(dot_instr, op::Dot());
+}
+
+TEST_F(GradAccAllReduceRewriterTest, MoveBackwardAllReduceDynamicSliceAdd) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule backward_all_reduce_add
+
+    %add (x: bf16[], y: bf16[]) -> bf16[] {
+      %x = bf16[] parameter(0)
+      %y = bf16[] parameter(1)
+      ROOT %add.1 = bf16[] add(bf16[] %x, bf16[] %y)
+    }
+
+    ENTRY backward_all_reduce_add {
+      %param.1 = f32[2048,1024]{1,0} parameter(0)
+      %param.2 = f32[2048,1024]{1,0} parameter(1)
+      %param.3 = f32[] parameter(2)
+      %param.4 = f32[2048,1024]{1,0} parameter(3)
+      %broadcast.9 = f32[2048,1024]{1,0} broadcast(f32[] %param.3), dimensions={}
+      %constant = bf16[] constant(0.1)
+      %constant.1 = bf16[] constant(0.2)
+      %broadcast =  bf16[1024,1024]{1,0} broadcast(bf16[] %constant)
+      %broadcast.1 =  bf16[1024,4096]{1,0} broadcast(bf16[] %constant.1)
+      %constant.398 = s32[] constant(0)
+      %constant.1580 = s32[] constant(2)
+      %dot = bf16[1024,4096]{1,0} dot(bf16[1024,1024]{1,0} %broadcast, bf16[1024,4096]{1,0} %broadcast.1), lhs_contracting_dims={0}, rhs_contracting_dims={0}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %all-reduce.35 = bf16[1024,4096]{1,0} all-reduce(bf16[1024,4096]{1,0} %dot), channel_id=3, replica_groups={{0}}, to_apply=%add, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %dynamic-slice.1 = bf16[1024,2048]{1,0} dynamic-slice(bf16[1024,4096]{1,0} %all-reduce.35, s32[] %constant.398, s32[] %constant.1580), dynamic_slice_sizes={1024,2048}, metadata={op_type="xla__einsum_backward" op_name="xla__einsum_backward"}
+      %transpose = bf16[2048,1024]{0,1} transpose(bf16[1024,2048]{1,0} %dynamic-slice.1), dimensions={1,0}, metadata={op_type="aten__mul" op_name="aten__mul"}
+      %convert = f32[2048,1024]{0,1} convert(bf16[2048,1024]{0,1} %transpose), metadata={op_type="aten__mul" op_name="aten__mul"}
+      %add.10 = f32[2048,1024]{1,0} add(f32[2048,1024]{1,0} %param.1, f32[2048,1024]{0,1} %convert), metadata={op_type="aten__add" op_name="aten__add"}
+      %subtract.1 = f32[2048,1024]{1,0} subtract(f32[2048,1024]{1,0} %add.10, f32[2048,1024]{1,0} %param.2), metadata={op_type="aten__sub" op_name="aten__lerp.2/aten__sub"}
+      %multiply.10 = f32[2048,1024]{1,0} multiply(f32[2048,1024]{1,0} %broadcast.9, f32[2048,1024]{1,0} %subtract.1), metadata={op_type="aten__mul" op_name="aten__lerp.2/aten__mul"}
+      %add.11 = f32[2048,1024]{1,0} add(f32[2048,1024]{1,0} %param.4, f32[2048,1024]{1,0} %multiply.10), metadata={op_type="aten__add" op_name="aten__lerp.2/aten__add"}
+      ROOT %tuple.1 = (f32[2048,1024]{1,0}) tuple(f32[2048,1024]{1,0} %add.11)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool skip_allreduce,
+                          GradAccAllReduceRewriter().Run(module.get()));
+  ASSERT_TRUE(skip_allreduce);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+
+  auto entry = module->entry_computation();
+  auto moved_all_reduce =
+      DynCast<HloAllReduceInstruction>(find_op<HloOpcode::kAllReduce>(entry));
+  ASSERT_THAT(moved_all_reduce, NotNull());
+  EXPECT_THAT(moved_all_reduce, op::ReplicaGroups({{0}}));
+  EXPECT_THAT(moved_all_reduce, op::Shape("f32[2048, 1024]"));
+
+  EXPECT_THAT(moved_all_reduce->operand(0), op::Add());
+  EXPECT_THAT(moved_all_reduce->users()[0], op::Subtract());
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -396,6 +396,10 @@ message DebugOptions {
   // type. The resulting allreduce will be promoted to a wider-typed allreduce.
   bool xla_gpu_enable_reassociation_for_converted_ar = 209;
 
+  // Enable the rewrite of allreduce introduced by the data parallel backward
+  // process when using gradient accumulation.
+  bool xla_enable_grad_acc_all_reduce_rewriter = 501;
+
   // Number of devices per host for first stage of BlueConnect decomposition
   // pass. The pass will attempt to decompose all-reduces ops into a
   // ReduceScatter-AllReduce-AllGather sequence, with the initial ReduceScatter


### PR DESCRIPTION
This commit removes unnecessary allreduce from the data parallel backward process when gradient accumulation is turned on (resolve #6750 ).

When implementing data parallelism using SPMD, SPMD inserts allreduce communication in the backward process, regardless of whether gradient accumulation is turned on or not. However, when using gradient accumulation, only global synchronization of gradients (via allreduce between DP ranks) is needed in iterations where the optimizer updates the weights. In non-updated weight iterations, only local gradient accumulation is needed without additional allreduce to synchronize the gradients.

To recognize backward processes in HLO, users are required to set the op_name containing "backward" to the instruction's metadata. For example, `XLA_IR_DEBUG=1 XLA_HLO_DEBUG=1` needs to be set in torch_xla.