### PR TITLE
Fix an incorrect static_assert

### DIFF
--- a/xla/ffi/api/ffi.h
+++ b/xla/ffi/api/ffi.h
@@ -108,9 +108,15 @@ class Error {
 
 namespace internal {
 
+// A workaround for the fact that a static_assertion can be evaluated
+// whether or not the template is instantiated
+template <DataType dtype>
+struct always_false : std::false_type {
+};
+
 template <DataType dtype>
 struct PtrType {
-  static_assert(sizeof(dtype) == 0, "unsupported data type");
+  static_assert(always_false<dtype>::value, "unsupported data type");
 };
 
 // clang-format off
@@ -133,7 +139,7 @@ template <> struct PtrType<DataType::BF16> { using Type = std::uint16_t; };
 
 template <DataType dtype>
 struct BufferBase {
-  internal::PtrType<dtype>::Type* data;
+  typename internal::PtrType<dtype>::Type* data;
   Span<const int64_t> dimensions;
 };
 
@@ -149,7 +155,7 @@ struct ArgDecoding<BufferBase<dtype>> {
     auto* buf = reinterpret_cast<XLA_FFI_Buffer*>(arg);
     // TODO(slebedev): Emit a user-friendly error instead.
     if (static_cast<DataType>(buf->dtype) != dtype) return std::nullopt;
-    auto* data = static_cast<internal::PtrType<dtype>::Type*>(buf->data);
+    auto* data = static_cast<typename internal::PtrType<dtype>::Type*>(buf->data);
 
     return BufferBase<dtype>{data, Span<const int64_t>(buf->dims, buf->rank)};
   }


### PR DESCRIPTION
The size of a uint8_t is 1 so a static_assert
to check that it is 0 makes no sense, fix it.
Also fix a couple of warnings about lack of
typename