### PR TITLE
[ROCm] Restore private visibility of stream executor private targets

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -103,8 +103,6 @@ cc_library(
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/strings",
         "//xla/stream_executor",
-        "//xla/stream_executor:command_buffer",
-        "//xla/stream_executor:kernel",
         "//xla/stream_executor:plugin_registry",
         "//xla/stream_executor/gpu:gpu_activation_header",
         "//xla/stream_executor/gpu:gpu_event",


### PR DESCRIPTION
fixed rocm build due to https://github.com/openxla/xla/commit/33fc605a8a118368eaf8f748c8e90eeb18f2e0d3


@xla-rotation