### PR TITLE
[XLA:GPU] Error out for ptxas 12.3.1 version

### DIFF
--- a/xla/stream_executor/gpu/asm_compiler.cc
+++ b/xla/stream_executor/gpu/asm_compiler.cc
@@ -263,7 +263,7 @@ tsl::StatusOr<std::vector<uint8_t>> CompileGpuAsm(int cc_major, int cc_minor,
   if (ptxas_version_tuple.value() == std::array<int64_t, 3>{12, 3, 1}) {
     return tsl::errors::Internal(
         absl::StrFormat("ptxas 12.3.1 has a bug that we think can affect XLA. "
-                        "Please use a different vesrion."));
+                        "Please use a different version."));
   }
   std::string ptxas_path =
       FindCudaExecutable("ptxas", options.preferred_cuda_dir);

--- a/xla/stream_executor/gpu/asm_compiler.cc
+++ b/xla/stream_executor/gpu/asm_compiler.cc
@@ -258,6 +258,13 @@ tsl::StatusOr<std::vector<uint8_t>> CompileGpuAsm(int cc_major, int cc_minor,
                                                   const char* ptx_contents,
                                                   GpuAsmOpts options,
                                                   bool cancel_if_reg_spill) {
+  auto ptxas_version_tuple =
+      se::GetAsmCompilerVersion(options.preferred_cuda_dir);
+  if (ptxas_version_tuple.value() == std::array<int64_t, 3>{12, 3, 1}) {
+    return tsl::errors::Internal(
+        absl::StrFormat("ptxas 12.3.1 has a bug that we think can affect XLA. "
+                        "Please use a different vesrion."));
+  }
   std::string ptxas_path =
       FindCudaExecutable("ptxas", options.preferred_cuda_dir);
 

--- a/xla/stream_executor/gpu/asm_compiler.cc
+++ b/xla/stream_executor/gpu/asm_compiler.cc
@@ -259,7 +259,7 @@ tsl::StatusOr<std::vector<uint8_t>> CompileGpuAsm(int cc_major, int cc_minor,
                                                   GpuAsmOpts options,
                                                   bool cancel_if_reg_spill) {
   auto ptxas_version_tuple =
-      se::GetAsmCompilerVersion(options.preferred_cuda_dir);
+      GetAsmCompilerVersion(options.preferred_cuda_dir);
   if (ptxas_version_tuple.value() == std::array<int64_t, 3>{12, 3, 1}) {
     return tsl::errors::Internal(
         absl::StrFormat("ptxas 12.3.1 has a bug that we think can affect XLA. "


### PR DESCRIPTION
ptxas 12.3.1 has a bug that we think can affect XLA. Error out for this version.