### PR TITLE
[XLA:GPU] Add command buffer memory Free command

### DIFF
--- a/xla/service/gpu/buffer_allocations.cc
+++ b/xla/service/gpu/buffer_allocations.cc
@@ -54,7 +54,23 @@ se::DeviceMemoryBase BufferAllocations::GetDeviceAddress(
     BufferAllocation::Index buffer_index) const {
   CHECK_GE(buffer_index, 0);
   CHECK_LT(buffer_index, buffers_.size());
-  return buffers_[buffer_index];
+  se::DeviceMemoryBase base = buffers_[buffer_index];
+  if (reinterpret_cast<uintptr_t>(base.opaque()) == kExternalAllocationMarker) {
+    if (!external_allocations_) {
+      LOG(ERROR) << "Does not have external allocations for buffer "
+                 << buffer_index;
+      return se::DeviceMemoryBase();
+    }
+    auto external_address =
+        external_allocations_->GetDeviceAddress(buffer_index);
+    if (external_address.ok()) {
+      return external_address.value();
+    }
+    LOG(ERROR) << "External address for allocation" << buffer_index
+               << " is not allocated yet";
+    return se::DeviceMemoryBase();
+  }
+  return base;
 }
 
 se::DeviceMemoryBase& BufferAllocations::GetMutableDeviceAddress(
@@ -74,14 +90,26 @@ se::DeviceMemoryBase BufferAllocations::GetDeviceAddress(
       buffer_slice.size());
 }
 
-StatusOr<se::DeviceMemoryBase> BufferAllocations::GetDeviceAddress(
-    const BufferAllocation::Slice& buffer_slice,
-    const ExternalAllocations& external_allocations) const {
-  // Check if base memory address is an external allocation.
-  se::DeviceMemoryBase base = GetDeviceAddress(buffer_slice.index());
-  return reinterpret_cast<uintptr_t>(base.opaque()) == kExternalAllocationMarker
-             ? external_allocations.GetDeviceAddress(buffer_slice)
-             : GetDeviceAddress(buffer_slice);
+Status BufferAllocations::AddExternalAllocation(BufferAllocation::Index index,
+                              se::DeviceMemoryBase memory) const {
+  if (external_allocations_ == nullptr) {
+    return InternalError(
+        "Calling external allocations, but no allocation tracker is provided"
+        "for allocation %d",
+        index);
+  }
+  return external_allocations_->AddAllocation(index, memory);
+}
+
+Status BufferAllocations::EraseExternalAllocation(
+    BufferAllocation::Index index) const {
+  if (external_allocations_ == nullptr) {
+    return InternalError(
+        "Calling external allocations, but no allocation tracker is provided"
+        "for allocation %d",
+        index);
+  }
+  return external_allocations_->EraseAllocation(index);
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/buffer_allocations.h
+++ b/xla/service/gpu/buffer_allocations.h
@@ -54,18 +54,29 @@ class BufferAllocations {
    public:
     virtual ~ExternalAllocations() = default;
 
-    // Return a device address for a given buffer slice. Returns error if
+    // Return a device address for a given buffer allocation. Returns error if
     // corresponding allocation is not yet allocated.
     virtual StatusOr<se::DeviceMemoryBase> GetDeviceAddress(
-        BufferAllocation::Slice buffer_slice) const = 0;
+        BufferAllocation::Index index) const = 0;
+
+    // Adds an external allocation for a given buffer index. Returns error if
+    // allocation already exists.
+    virtual Status AddAllocation(BufferAllocation::Index index,
+                                 se::DeviceMemoryBase memory) = 0;
+
+    // Erases an external allocation for a given buffer index. Returns error if
+    // allocation does not exists.
+    virtual Status EraseAllocation(BufferAllocation::Index index) = 0;
   };
 
   BufferAllocations(absl::Span<se::DeviceMemoryBase const> buffers,
                     int device_ordinal,
-                    se::DeviceMemoryAllocator* memory_allocator)
+                    se::DeviceMemoryAllocator* memory_allocator,
+                    ExternalAllocations* external_allocations = nullptr)
       : buffers_(buffers.begin(), buffers.end()),
         device_ordinal_(device_ordinal),
-        memory_allocator_(memory_allocator) {}
+        memory_allocator_(memory_allocator),
+        external_allocations_(external_allocations) {}
 
   BufferAllocations(BufferAllocations&& other) = default;
   BufferAllocations& operator=(BufferAllocations&& other) = default;
@@ -92,12 +103,12 @@ class BufferAllocations {
   se::DeviceMemoryBase GetDeviceAddress(
       const BufferAllocation::Slice& buffer_slice) const;
 
-  // Finds an allocation for a given buffer slice, and if it happens to be an
-  // external allocation resolves it using user-provided external allocations.
-  // Returns error if external allocations do not have an address for a slice.
-  StatusOr<se::DeviceMemoryBase> GetDeviceAddress(
-      const BufferAllocation::Slice& buffer_slice,
-      const ExternalAllocations& external_allocations) const;
+  // Add new allocation allocated by external allocator.
+  Status AddExternalAllocation(BufferAllocation::Index index,
+                               se::DeviceMemoryBase memory) const;
+
+  // Remove allocation freed by external allocator.
+  Status EraseExternalAllocation(BufferAllocation::Index index) const;
 
   // Tears down all buffers allocated by this object that are not in
   // `live_addresses`.
@@ -121,12 +132,16 @@ class BufferAllocations {
   // indexed by Index. Each element can point to a temporary buffer, an
   // input buffer, or nullptr if no buffer is needed for that Index.
 
-  // a nullptr buffer with non-zero size buffer is assumed to be lazily
-  // allocated buffer, and will be allocated through command buffer Allocate
-  // command during runtime.
+  // a special address (se::kExternalAllocationMarker) with non-zero size buffer is
+  // assumed to be lazily allocated buffer, and will be allocated through
+  // command buffer Allocate command during runtime.
   std::vector<se::DeviceMemoryBase> buffers_;
   int device_ordinal_;
   se::DeviceMemoryAllocator* memory_allocator_;
+
+  // For buffer address that marked as ExternalAllocations, tracks its real
+  // address here.
+  ExternalAllocations* external_allocations_;
 };
 
 }  // namespace gpu

--- a/xla/service/gpu/runtime3/BUILD
+++ b/xla/service/gpu/runtime3/BUILD
@@ -155,6 +155,7 @@ xla_test(
     deps = [
         ":command_buffer_cmd",
         ":command_buffer_thunk",
+        ":command_buffer_allocations",
         "//xla:shape_util",
         "//xla:types",
         "//xla/service:buffer_assignment",

--- a/xla/service/gpu/runtime3/command_buffer_allocations.cc
+++ b/xla/service/gpu/runtime3/command_buffer_allocations.cc
@@ -28,16 +28,14 @@ limitations under the License.
 namespace xla::gpu {
 
 StatusOr<se::DeviceMemoryBase> CommandBufferAllocations::GetDeviceAddress(
-    BufferAllocation::Slice buffer_slice) const {
-  auto base = allocs_.find(buffer_slice.index());
+    BufferAllocation::Index index) const {
+  auto base = allocs_.find(index);
   if (base == allocs_.end()) {
     return absl::InternalError(absl::StrCat("Command buffer allocation #",
-                                            buffer_slice.index(),
+                                            index,
                                             " was not allocated"));
   }
-
-  char* ptr = static_cast<char*>(const_cast<void*>(base->second.opaque()));
-  return se::DeviceMemoryBase(ptr + buffer_slice.offset(), buffer_slice.size());
+  return allocs_.at(index);
 }
 
 Status CommandBufferAllocations::AddAllocation(BufferAllocation::Index index,

--- a/xla/service/gpu/runtime3/command_buffer_allocations.h
+++ b/xla/service/gpu/runtime3/command_buffer_allocations.h
@@ -31,16 +31,16 @@ namespace xla::gpu {
 class CommandBufferAllocations : public BufferAllocations::ExternalAllocations {
  public:
   StatusOr<se::DeviceMemoryBase> GetDeviceAddress(
-      BufferAllocation::Slice buffer_slice) const override;
+      BufferAllocation::Index index) const override;
 
   // Adds an external allocation for a given buffer index. Returns error if
   // allocation already exists.
   Status AddAllocation(BufferAllocation::Index index,
-                       se::DeviceMemoryBase memory);
+                       se::DeviceMemoryBase memory) override;
 
   // Erases an external allocation for a given buffer index. Returns error if
   // allocation does not exists.
-  Status EraseAllocation(BufferAllocation::Index index);
+  Status EraseAllocation(BufferAllocation::Index index) override;
 
  private:
   absl::flat_hash_map<BufferAllocation::Index, se::DeviceMemoryBase> allocs_;

--- a/xla/service/gpu/runtime3/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime3/command_buffer_cmd.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/service/gpu/matmul_utils.h"
+#include "xla/service/gpu/runtime3/command_buffer_allocations.h"
 #include "xla/service/gpu/stream_executor_util.h"
 #include "xla/status.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -153,9 +154,7 @@ Status LaunchCmd::Record(const RecordParams& params,
 
   absl::InlinedVector<se::DeviceMemoryBase, 4> buffers;
   for (const BufferAllocation::Slice& arg : args_) {
-    TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase buf,
-                        params.buffer_allocations->GetDeviceAddress(
-                            arg, *params.command_buffer_allocations));
+    se::DeviceMemoryBase buf = params.buffer_allocations->GetDeviceAddress(arg);
     VLOG(5) << "  Arg: " << arg << ": " << buf.opaque();
     buffers.push_back(buf);
   }
@@ -187,16 +186,13 @@ MemcpyDeviceToDeviceCmd::MemcpyDeviceToDeviceCmd(BufferAllocation::Slice dst,
 
 Status MemcpyDeviceToDeviceCmd::Record(const RecordParams& params,
                                        se::CommandBuffer* command_buffer) {
-  VLOG(5) << "MemcpyDeviceToDeviceCmd: dst=" << dst_ << ", src=" << src_
-          << ", num_bytes=" << num_bytes_;
+  se::DeviceMemoryBase dst = params.buffer_allocations->GetDeviceAddress(dst_);
+  se::DeviceMemoryBase src = params.buffer_allocations->GetDeviceAddress(src_);
 
-  TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase dst,
-                      params.buffer_allocations->GetDeviceAddress(
-                          dst_, *params.command_buffer_allocations));
-  TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase src,
-                      params.buffer_allocations->GetDeviceAddress(
-                          src_, *params.command_buffer_allocations));
-
+  VLOG(5) << "MemcpyDeviceToDeviceCmd: dst=" << dst_ << "("
+          << reinterpret_cast<void*>(dst.opaque()) << ")"
+          << ", src=" << src_ << "(" << reinterpret_cast<void*>(src.opaque())
+          << ")" << ", num_bytes=" << num_bytes_;
   return command_buffer->MemcpyDeviceToDevice(&dst, src, num_bytes_);
 }
 
@@ -369,25 +365,45 @@ CommandBufferCmd::Slices WhileCmd::slices() {
 // AllocateCmd
 //===----------------------------------------------------------------------===//
 
-AllocateCmd::AllocateCmd(BufferAllocation* allocation)
+AllocateCmd::AllocateCmd(BufferAllocation allocation)
     : allocation_(allocation) {}
 
 Status AllocateCmd::Record(const RecordParams& params,
                            se::CommandBuffer* command_buffer) {
   // Memory allocation address is returned on graph creation, and there is no
   // update operation
-  VLOG(5) << "AllocationCmd: index=" << allocation_->index();
+  VLOG(2) << "AllocationCmd: index=" << allocation_.index();
 
   TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase buffer,
-                      command_buffer->Allocate(allocation_->size()));
-
-  TF_RETURN_IF_ERROR(params.command_buffer_allocations->AddAllocation(
-      allocation_->index(), buffer));
-
-  return OkStatus();
+                      command_buffer->Allocate(allocation_.size()));
+  return params.buffer_allocations->AddExternalAllocation(allocation_.index(),
+                                                          buffer);
 }
 
 CommandBufferCmd::Slices AllocateCmd::slices() { return {}; }
+
+//===----------------------------------------------------------------------===//
+// FreeCmd
+//===----------------------------------------------------------------------===//
+
+FreeCmd::FreeCmd(BufferAllocation allocation) : allocation_(allocation) {}
+
+Status FreeCmd::Record(const RecordParams& params,
+                       se::CommandBuffer* command_buffer) {
+  VLOG(2) << "FreeCmd: index=" << allocation_.index();
+
+  se::DeviceMemoryBase address =
+      params.buffer_allocations->GetDeviceAddress(allocation_.index());
+
+  // Free is in the same command buffer
+  TF_RETURN_IF_ERROR(command_buffer->Free(address));
+
+  // Remove the buffer from external allocations.
+  return params.buffer_allocations->EraseExternalAllocation(
+      allocation_.index());
+}
+
+CommandBufferCmd::Slices FreeCmd::slices() { return {}; }
 
 //===----------------------------------------------------------------------===//
 // GemmCmd
@@ -419,16 +435,15 @@ Status GemmCmd::Record(const RecordParams& params,
 
   se::DeviceMemoryBase workspace(nullptr, 0);
 
-  TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase lhs,
-                      params.buffer_allocations->GetDeviceAddress(
-                          lhs_buffer_, *params.command_buffer_allocations));
-  TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase rhs,
-                      params.buffer_allocations->GetDeviceAddress(
-                          rhs_buffer_, *params.command_buffer_allocations));
-  TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase out,
-                      params.buffer_allocations->GetDeviceAddress(
-                          output_buffer_, *params.command_buffer_allocations));
+  se::DeviceMemoryBase lhs =
+      params.buffer_allocations->GetDeviceAddress(lhs_buffer_);
 
+  se::DeviceMemoryBase rhs =
+      params.buffer_allocations->GetDeviceAddress(rhs_buffer_);
+
+  se::DeviceMemoryBase out =
+      params.buffer_allocations->GetDeviceAddress(output_buffer_);
+  
   TF_ASSIGN_OR_RETURN(
       auto nested_buffer,
       se::CommandBuffer::Trace(params.executor, [&](se::Stream* stream) {

--- a/xla/service/gpu/runtime3/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime3/command_buffer_cmd.h
@@ -62,7 +62,6 @@ class CommandBufferCmd {
   struct RecordParams {
     se::StreamExecutor* executor;
     const BufferAllocations* buffer_allocations;
-    CommandBufferAllocations* command_buffer_allocations;
   };
 
   // Prepares a command for recording on a given executor. We split it into a
@@ -310,16 +309,35 @@ class WhileCmd : public CommandBufferCmd {
 
 class AllocateCmd : public CommandBufferCmd {
  public:
-  explicit AllocateCmd(BufferAllocation* allocation);
+  AllocateCmd(BufferAllocation allocation);
 
-  // After calling this function, the allocated memory address is updated to
+  // After calling this function, the allocated memory is tracked in
+  // CommandBuffer object.
+  Status Record(const RecordParams& params,
+                se::CommandBuffer* command_buffer) override;
+
+  Slices slices() override;
+ private:
+  BufferAllocation allocation_;
+};
+
+//===----------------------------------------------------------------------===//
+// FreeCmd
+//===----------------------------------------------------------------------===//
+
+class FreeCmd : public CommandBufferCmd {
+ public:
+  FreeCmd(BufferAllocation allocation);
+
+  // After calling this function, the allocated memory address for dst
+  // BufferAllocation is freed, no update is required.
   Status Record(const RecordParams& params,
                 se::CommandBuffer* command_buffer) override;
 
   Slices slices() override;
 
  private:
-  BufferAllocation* allocation_;
+  BufferAllocation allocation_;
 };
 
 //===----------------------------------------------------------------------===//

--- a/xla/service/gpu/runtime3/command_buffer_thunk.cc
+++ b/xla/service/gpu/runtime3/command_buffer_thunk.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
+#include "xla/service/gpu/runtime3/command_buffer_allocations.h"
 #include "xla/service/gpu/runtime3/command_buffer_cmd.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/status.h"
@@ -79,7 +80,7 @@ Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   absl::MutexLock lock(&cmd_buffer->mutex);
 
   CommandBufferCmd::RecordParams record_params = {
-      executor, params.buffer_allocations, &cmd_buffer->allocations};
+      executor, const_cast<BufferAllocations*>(params.buffer_allocations)};
 
   if (cmd_buffer->ShouldUpdateCommandBuffer(commands_, record_params)) {
     TF_RETURN_IF_ERROR(

--- a/xla/service/gpu/runtime3/command_buffer_thunk.h
+++ b/xla/service/gpu/runtime3/command_buffer_thunk.h
@@ -40,6 +40,12 @@ class CommandBufferThunk : public Thunk {
   Status Initialize(se::StreamExecutor*, ExecutableSource) override;
   Status ExecuteOnStream(const ExecuteParams& params) override;
 
+  // Return the allocation address that was lazilly allocated inside command
+  // buffer. This API is required when the buffers are allocated inside command
+  // buffer but will be consumed by non-command buffer operations.
+  StatusOr<se::DeviceMemoryBase> GetCommandBufferAllocationAddress(
+      const ExecuteParams& params, int64_t index);
+
  private:
   // Command buffer instantiated on a `se::StreamExecutor` instance, and
   // auxiliary state required for efficient command buffer updates.

--- a/xla/service/gpu/runtime3/command_buffer_thunk_test.cc
+++ b/xla/service/gpu/runtime3/command_buffer_thunk_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -25,6 +26,7 @@ limitations under the License.
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/service/gpu/matmul_utils.h"
+#include "xla/service/gpu/runtime3/command_buffer_allocations.h"
 #include "xla/service/gpu/runtime3/command_buffer_cmd.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/service/service_executable_run_options.h"
@@ -110,9 +112,11 @@ TEST(CommandBufferThunkTest, MemcpyCmd) {
 // 1. Allocates memory region "a" and "c" outside command buffer.
 // 2. Allocates memory region "b" inside command buffer.
 // 3. MemCopyDeviceToDevice from "a" to "b" inside command buffer.
-// 4. MemCopyDEviceToDevice from "b" to "c" inside command buffer.
-// 5. Verify that region "c" has the same content as "a".
-TEST(CommandBufferThunkTest, AllocateCmd) {
+
+// 4. MemCopyDeviceToDevice from "b" to "c" inside command buffer.
+// 5. Free memory region "b" inside command buffer.
+// 6. Verify that region "c" has the same content as "a".
+TEST(CommandBufferThunkTest, MemallocFreeCmdSameThunk) {
   se::StreamExecutor* executor = CudaExecutor();
 
   se::Stream stream(executor);
@@ -132,9 +136,10 @@ TEST(CommandBufferThunkTest, AllocateCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<AllocateCmd>(&alloc_b);
+  commands.Emplace<AllocateCmd>(alloc_b);
   commands.Emplace<MemcpyDeviceToDeviceCmd>(slice_b, slice_a, byte_length);
   commands.Emplace<MemcpyDeviceToDeviceCmd>(slice_c, slice_b, byte_length);
+  commands.Emplace<FreeCmd>(alloc_b);
 
   // Construct a thunk with command sequence.
   CommandBufferThunk thunk(std::move(commands), Thunk::ThunkInfo(nullptr));
@@ -142,11 +147,17 @@ TEST(CommandBufferThunkTest, AllocateCmd) {
   // Prepare arguments: a=42, b=0
   se::DeviceMemory<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
   stream.ThenMemset32(&a, 42, byte_length);
+
   se::DeviceMemory<int32_t> b(se::DeviceMemoryBase(
       reinterpret_cast<int32_t*>(BufferAllocations::kExternalAllocationMarker),
       byte_length));
   se::DeviceMemory<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
-  BufferAllocations allocations({a, b, c}, 0, executor->GetAllocator());
+
+  std::unique_ptr<CommandBufferAllocations> external_allocation =
+      std::make_unique<CommandBufferAllocations>();
+
+  BufferAllocations allocations({a, b, c}, 0, executor->GetAllocator(),
+                                external_allocation.get());
 
   ServiceExecutableRunOptions run_options;
   Thunk::ExecuteParams params(run_options, allocations, &stream, {});
@@ -156,6 +167,79 @@ TEST(CommandBufferThunkTest, AllocateCmd) {
   TF_ASSERT_OK(stream.BlockHostUntilDone());
 
   // Copy `b` data back to host.
+  std::vector<int32_t> dst(4, 0);
+  stream.ThenMemcpy(dst.data(), allocations.GetMutableDeviceAddress(2),
+                    byte_length);
+
+  ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
+}
+
+// This test does the following operations:
+// 1. Allocates memory region "a" and "c" outside command buffer.
+// 2. Allocates memory region "b" inside command buffer thunk 1.
+// 3. MemCopyDeviceToDevice from "a" to "b" inside command buffer 1.
+// 4. MemCopyDeviceToDevice from "b" to "c" inside command buffer 2.
+// 5. Free memory region "b" inside command buffer 2.
+// 6. Verify that region "c" has the same content as "a".
+TEST(CommandBufferThunkTest, MemallocFreeCmdAcrossThunk) {
+  se::StreamExecutor* executor = CudaExecutor();
+
+  se::Stream stream(executor);
+  stream.Init();
+  ASSERT_TRUE(stream.ok());
+
+  // Prepare arguments:
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+
+  BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
+  BufferAllocation alloc_b(/*index=*/1, byte_length, /*color=*/0);
+  BufferAllocation alloc_c(/*index=*/2, byte_length, /*color=*/0);
+  BufferAllocation::Slice slice_a(&alloc_a, 0, byte_length);
+  BufferAllocation::Slice slice_b(&alloc_b, 0, byte_length);
+  BufferAllocation::Slice slice_c(&alloc_c, 0, byte_length);
+
+  // =================Thunk 1=================================
+  // Prepare commands sequence for constructing command buffer.
+  CommandBufferCmdSequence commands1;
+  commands1.Emplace<AllocateCmd>(alloc_b);
+  commands1.Emplace<MemcpyDeviceToDeviceCmd>(slice_b, slice_a, byte_length);
+
+  // Construct a thunk with command sequence.
+  CommandBufferThunk thunk1(std::move(commands1), Thunk::ThunkInfo(nullptr));
+
+  // Prepare arguments: a=42, b=0
+  se::DeviceMemory<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
+  stream.ThenMemset32(&a, 42, byte_length);
+  se::DeviceMemory<int32_t> b(se::DeviceMemoryBase(
+    reinterpret_cast<int32_t*>(BufferAllocations::kExternalAllocationMarker),
+    byte_length));
+  se::DeviceMemory<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
+
+  std::unique_ptr<CommandBufferAllocations> external_allocation =
+      std::make_unique<CommandBufferAllocations>();
+
+  BufferAllocations allocations({a, b, c}, 0, executor->GetAllocator(),
+                                external_allocation.get());
+
+  ServiceExecutableRunOptions run_options;
+  Thunk::ExecuteParams params(run_options, allocations, &stream, {});
+
+  // Execute command buffer thunk and verify that it copied the memory.
+  TF_ASSERT_OK(thunk1.ExecuteOnStream(params));
+
+  // =================Thunk 2=================================
+  CommandBufferCmdSequence commands2;
+  commands2.Emplace<MemcpyDeviceToDeviceCmd>(slice_c, slice_b, byte_length);
+  commands2.Emplace<FreeCmd>(alloc_b);
+
+  // Construct a thunk with command sequence.
+  CommandBufferThunk thunk2(std::move(commands2), Thunk::ThunkInfo(nullptr));
+
+  // Execute command buffer thunk and verify that it copied the memory.
+  TF_ASSERT_OK(thunk2.ExecuteOnStream(params));
+
+  // Copy `c` data back to host.
   std::vector<int32_t> dst(4, 0);
   stream.ThenMemcpy(dst.data(), allocations.GetMutableDeviceAddress(2),
                     byte_length);

--- a/xla/stream_executor/command_buffer.cc
+++ b/xla/stream_executor/command_buffer.cc
@@ -174,6 +174,10 @@ tsl::Status CommandBuffer::While(StreamExecutor* executor,
                                 std::move(body_builder));
 }
 
+tsl::Status CommandBuffer::Free(DeviceMemoryBase dst) {
+  return implementation_->Free(dst);
+}
+
 CommandBuffer::Mode CommandBuffer::mode() const {
   return implementation_->mode();
 }

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -181,6 +181,9 @@ class CommandBuffer {
   // Adds a device memory allocation command to the command buffer.
   tsl::StatusOr<DeviceMemoryBase> Allocate(size_t bytes);
 
+  // This API free buffer that is allocated by Allocate command
+  tsl::Status Free(DeviceMemoryBase dst);
+
   // Finalizes command buffer and makes it executable. Once command buffer is
   // finalized no commands can be added to it.
   tsl::Status Finalize();

--- a/xla/stream_executor/cuda/cuda_driver.cc
+++ b/xla/stream_executor/cuda/cuda_driver.cc
@@ -979,6 +979,15 @@ GpuDriver::GraphGetMemAllocNodeParams(CUgraphNode node) {
   return std::pair<CUdeviceptr, uint64_t>{params.dptr, params.bytesize};
 }
 
+/*static*/ tsl::Status GpuDriver::GraphAddMemFreeNode(
+    CUgraphNode* node, CUgraph graph, absl::Span<CUgraphNode> deps,
+    CUdeviceptr gpu_dst) {
+  RETURN_IF_CUDA_RES_ERROR(
+      cuGraphAddMemFreeNode(node, graph, deps.data(), deps.size(), gpu_dst),
+      "Failed to add memory free node to a CUDA graph");
+  return ::tsl::OkStatus();
+}
+
 /* static */ tsl::Status GpuDriver::GraphAddMemcpyD2DNode(
     GpuContext* context, CUgraphNode* node, CUgraph graph,
     absl::Span<CUgraphNode> deps, CUdeviceptr gpu_dst, CUdeviceptr gpu_src,

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -65,6 +65,8 @@ class GpuCommandBuffer : public internal::CommandBufferInterface {
 
   tsl::StatusOr<DeviceMemoryBase> Allocate(size_t bytes) override;
 
+  tsl::Status Free(DeviceMemoryBase dst) override;
+  
   tsl::Status If(StreamExecutor* executor, DeviceMemory<bool> predicate,
                  CommandBuffer::Builder then_builder) override;
 

--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -531,6 +531,13 @@ class GpuDriver {
   static tsl::StatusOr<std::pair<GpuDevicePtr, uint64_t>>
   GraphGetMemAllocNodeParams(GpuGraphNodeHandle node);
 
+  // Create a memfree node and adds it to a graph.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1geb7cdce5d9be2d28d9428e74eb00fa53
+  static tsl::Status GraphAddMemFreeNode(GpuGraphNodeHandle* node,
+                                         GpuGraphHandle graph,
+                                         absl::Span<GpuGraphNodeHandle> deps,
+                                         GpuDevicePtr gpu_dst);
+
   // Creates a memcpy node and adds it to a graph.
   // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g674da6ab54a677f13e0e0e8206ff5073
   static tsl::Status GraphAddMemcpyD2DNode(GpuContext* context,

--- a/xla/stream_executor/stream_executor_internal.h
+++ b/xla/stream_executor/stream_executor_internal.h
@@ -204,6 +204,10 @@ class CommandBufferInterface {
                             CommandBuffer::Builder cond_builder,
                             CommandBuffer::Builder body_builder) = 0;
 
+  // Adds a device memory free command to the command buffer, buffer is
+  // allocated in other command buffer, free through real address.
+  virtual tsl::Status Free(DeviceMemoryBase dst) = 0;
+
   // Finalizes command buffer and makes it executable. Once command buffer is
   // finalized no commands can be added to it.
   virtual tsl::Status Finalize() = 0;


### PR DESCRIPTION
This PR adds the memory Free command to command buffer. 

The Free command is used to free previously allocated memory regions through command buffer Allocate command.  
The Free command is constructed with BufferAllocation object.

During runtime, there are two cases that the Free command needs to handle. 

case 1.   The allocation that is going to be freed is allocated in the same command buffer, so the real allocation address is tracked by command buffer runtime, The record parameter (address of memory to be freed) of Free command is specified as LazyAllocationMarker, command buffer runtime will fetch real address from internal tracked allocation address map indexed by current allocation index.  

case2. Free the allocation that is allocated in other command buffer thunk, for this case, the real allocation address is not tracked by current command buffer, and the record parameter of Free commands needs to be specified as real address. 
 