### PR TITLE
[xla_compile][NFC] Optionally export the optimized HLO module.

### DIFF
--- a/xla/service/xla_compile_main.cc
+++ b/xla/service/xla_compile_main.cc
@@ -191,7 +191,8 @@ Status XlaCompileMain(
     cfg = (use_attached_device) ? std::nullopt
                                 : std::make_optional(*std::move(target_config));
   }
-  auto result = CompileExecutable(std::move(hlo_module), platform, cfg);
+  auto result = CompileExecutable(
+      std::move(hlo_module), platform, cfg, compilation_result);
   if (!result.ok()) {
     *compilation_result.mutable_status() = tsl::StatusToProto(result.status());
     return result.status();

--- a/xla/tools/xla_compile_lib.cc
+++ b/xla/tools/xla_compile_lib.cc
@@ -68,7 +68,7 @@ static StatusOr<std::string> AotCompileCpuExecutable(
 static StatusOr<std::string> CompileGpuExecutable(
     std::unique_ptr<HloModule> hlo_module,
     std::optional<Compiler::TargetConfig> target_config,
-    std::optional<CompilationResult> result) {
+    CompilationResult& result) {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   const bool aot = target_config.has_value();
 
@@ -100,9 +100,7 @@ static StatusOr<std::string> CompileGpuExecutable(
       gpu_compiler.RunHloPasses(std::move(hlo_module), stream_executor,
                                 compile_options));
 
-  if (result.has_value()) {
-    *result->mutable_hlo_module() = module_after_opt->ToProto();
-  }
+  *result->mutable_hlo_module() = module_after_opt->ToProto();
   if (aot) {
     auto module_group =
         std::make_unique<HloModuleGroup>(std::move(module_after_opt));

--- a/xla/tools/xla_compile_lib.cc
+++ b/xla/tools/xla_compile_lib.cc
@@ -101,7 +101,7 @@ static StatusOr<std::string> CompileGpuExecutable(
                                 compile_options));
 
   if (result.has_value()) {
-    *result.mutable_hlo_module() = module_after_opt->ToProto();
+    *result->mutable_hlo_module() = module_after_opt->ToProto();
   }
   if (aot) {
     auto module_group =
@@ -131,11 +131,12 @@ static StatusOr<std::string> CompileGpuExecutable(
 
 StatusOr<std::string> CompileExecutable(
     std::unique_ptr<HloModule> hlo_module, absl::string_view platform,
-    std::optional<Compiler::TargetConfig> target_config) {
+    std::optional<Compiler::TargetConfig> target_config,
+    CompilationResult& result) {
   if (platform == "cpu") {
     return AotCompileCpuExecutable(std::move(hlo_module));
   } else if (platform == "gpu") {
-    return CompileGpuExecutable(std::move(hlo_module), target_config);
+    return CompileGpuExecutable(std::move(hlo_module), target_config, result);
   }
 
   return absl::UnimplementedError(

--- a/xla/tools/xla_compile_lib.cc
+++ b/xla/tools/xla_compile_lib.cc
@@ -100,7 +100,7 @@ static StatusOr<std::string> CompileGpuExecutable(
       gpu_compiler.RunHloPasses(std::move(hlo_module), stream_executor,
                                 compile_options));
 
-  *result->mutable_hlo_module() = module_after_opt->ToProto();
+  *result.mutable_hlo_module() = module_after_opt->ToProto();
   if (aot) {
     auto module_group =
         std::make_unique<HloModuleGroup>(std::move(module_after_opt));

--- a/xla/tools/xla_compile_lib.h
+++ b/xla/tools/xla_compile_lib.h
@@ -21,24 +21,26 @@ limitations under the License.
 #include <string>
 
 #include "absl/strings/string_view.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/compiler.h"
 #include "xla/service/xla_compile_result.pb.h"
 #include "xla/util.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
 
 namespace xla {
 
 // Compiles the provided module for the given platform, either "cpu" or "gpu".
 // When compiling for GPU, if the target config is provided, the compilation
 // will be AOT. If it is not provided, an attached GPU will be used. When
-// compiling for CPU, the compilation will always be AOT.
+// compiling for CPU, the compilation will always be AOT. If a result is
+// provided, the post-optimization module will be stored in it.
 //
 // This is the expected entry point to the compilation functionality.
 StatusOr<std::string> CompileExecutable(
     std::unique_ptr<HloModule> hlo_module, absl::string_view platform,
-    std::optional<Compiler::TargetConfig> target_config);
+    std::optional<Compiler::TargetConfig> target_config,
+    CompilationResult& result);
 
 // Merges the measured duration into compilation_result and writes
 // compilation_result to result_output_file in the wire format.

--- a/xla/tools/xla_compile_lib_test.cc
+++ b/xla/tools/xla_compile_lib_test.cc
@@ -79,14 +79,16 @@ class XlaCompileLibTest : public HloTestBase {
 };
 
 TEST_F(XlaCompileLibTest, DISABLED_ON_GPU(CompilesForCpu)) {
+  CompilationResult result;
   EXPECT_THAT(
-      CompileExecutable(std::move(module_), "cpu", std::nullopt, std::nullopt),
+      CompileExecutable(std::move(module_), "cpu", std::nullopt, result),
       IsOkAndHolds(Not(IsEmpty())));
 }
 
 TEST_F(XlaCompileLibTest, DISABLED_ON_CPU(CompilesForGpuWithDevice)) {
+  CompilationResult result;
   EXPECT_THAT(
-      CompileExecutable(std::move(module_), "gpu", std::nullopt, std::nullopt),
+      CompileExecutable(std::move(module_), "gpu", std::nullopt, result),
       IsOkAndHolds(Not(IsEmpty())));
 }
 
@@ -97,8 +99,9 @@ TEST_F(XlaCompileLibTest, DISABLED_ON_CPU(CompilesForGpuWithoutDevice)) {
   stream_executor::GpuTargetConfigProto target_config;
   TF_ASSERT_OK(tsl::ReadTextProto(tsl::Env::Default(), target_config_path,
                                   &target_config));
+  CompilationResult result;
   EXPECT_THAT(
-      CompileExecutable(std::move(module_), "gpu", std::nullopt, std::nullopt),
+      CompileExecutable(std::move(module_), "gpu", std::nullopt, result),
       IsOkAndHolds(Not(IsEmpty())));
 }
 
@@ -112,7 +115,8 @@ TEST_F(XlaCompileLibTest,
 }
 
 TEST_F(XlaCompileLibTest, DISABLED_ON_GPU(ErrorsOnUnexpectedPlatform)) {
-  EXPECT_THAT(CompileExecutable(nullptr, "tpu", std::nullopt, std::nullopt),
+  CompilationResult result;
+  EXPECT_THAT(CompileExecutable(nullptr, "tpu", std::nullopt, result),
               StatusIs(tsl::error::UNIMPLEMENTED));
 }
 


### PR DESCRIPTION
Only GPU compilations actually optimize the module today, so the module is only returned for them.

While here, run clang-format in Google style for these files, which reordered headers.