### PR TITLE
[XLA:CPU] [oneDNN] Layer Norm XLA HLO Pattern Matcher with oneDNN custom call rewrite

### DIFF
--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -211,6 +211,7 @@ cc_library(
         ":hlo_xla_runtime_pipeline",
         ":ir_emission_utils",
         ":ir_emitter",
+        ":onednn_ops_rewriter",
         ":onednn_rewriter",
         ":parallel_task_assignment",
         ":simple_orc_jit",
@@ -509,6 +510,7 @@ cc_library(
     deps = [
         ":compiler_functor",
         ":cpu_runtime",
+        ":onednn_layer_norm",
         ":onednn_matmul",
         ":orc_jit_memory_mapper",
         ":runtime_conv2d",
@@ -1622,9 +1624,35 @@ cc_library(
 )
 
 cc_library(
+    name = "onednn_layer_norm",
+    srcs = ["onednn_layer_norm.cc"],
+    hdrs = [
+        "onednn_layer_norm.h",
+        "@tsl//tsl/util:onednn_util_hdrs",
+    ],
+    copts = runtime_copts() + tsl_copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":onednn_memory_util",
+        ":backend_config_proto_cc",
+        ":runtime_lightweight_check",
+        "//xla:executable_run_options",
+        "@eigen_archive//:eigen3",
+        "@tsl//tsl/platform:blocking_counter",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/platform:platform_port",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/base:dynamic_annotations",
+    ] + mkl_deps(),
+)
+
+cc_library(
     name = "onednn_rewriter",
     srcs = ["onednn_rewriter.cc"],
-    hdrs = ["onednn_rewriter.h"],
+    hdrs = [
+        "onednn_rewriter.h",
+        "onednn_util.h",
+    ],
     copts = tsl_copts(),
     deps = [
         ":backend_config_proto_cc",
@@ -1682,4 +1710,24 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:errors",
     ],
+)
+
+cc_library(
+    name = "onednn_ops_rewriter",
+    srcs = ["onednn_ops_rewriter.cc"],
+    hdrs = [
+        "onednn_ops_rewriter.h",
+        "onednn_util.h",
+    ],
+    copts = tsl_copts(),
+    deps = [
+        ":onednn_memory_util",
+        ":backend_config_proto_cc",
+        "//xla:status_macros",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:hlo_creation_utils",
+        "//xla/service:hlo_pass",
+        "//xla/service:pattern_matcher",
+    ] + mkl_deps(),
 )

--- a/xla/service/cpu/backend_config.proto
+++ b/xla/service/cpu/backend_config.proto
@@ -10,6 +10,7 @@ message BackendConfig {
   repeated int64 outer_dimension_partitions = 1;
   // Configuration to be used by oneDNN matmul
   OneDnnMatMulConfig onednn_matmul_config = 2;
+  OneDnnLayerNormConfig onednn_layer_norm_config = 3;
 }
 
 message OneDnnMatMulConfig {
@@ -23,5 +24,17 @@ message OneDnnMatMulConfig {
     GELU_ERF = 4;
     GELU_TANH = 5;
   }
-  repeated FusionKind fused_ops = 3;
+  repeated FusionKind fused_ops = 4;
+}
+
+message OneDnnLayerNormConfig {
+  // These enum needs to be mapped to oneDNN enum for post_op algorithm.
+  // TODO(intel-tf): Add kinds supported by oneDNN.
+  enum FusionKind {
+    UNDEF = 0;
+    SCALE = 1;
+    SHIFT = 2;
+    SCALE_AND_SHIFT = 3;
+  }
+  FusionKind fused_ops = 5;
 }

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -65,29 +65,35 @@ limitations under the License.
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"  // from @llvm-project
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"  // from @llvm-project
 #include "mlir/Dialect/Affine/IR/AffineOps.h"  // from @llvm-project
-#include "mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
+#include "mlir/Dialect/Arith/IR/Arith.h"       // from @llvm-project
 #include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"  // from @llvm-project
-#include "mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/Dialect/Func/IR/FuncOps.h"     // from @llvm-project
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"  // from @llvm-project
-#include "mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/Dialect/Linalg/IR/Linalg.h"    // from @llvm-project
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"  // from @llvm-project
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"  // from @llvm-project
-#include "mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
-#include "mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
-#include "mlir/Dialect/Vector/IR/VectorOps.h"  // from @llvm-project
-#include "mlir/IR/Attributes.h"  // from @llvm-project
-#include "mlir/IR/Builders.h"  // from @llvm-project
-#include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
-#include "mlir/IR/BuiltinTypes.h"  // from @llvm-project
-#include "mlir/IR/OperationSupport.h"  // from @llvm-project
-#include "mlir/IR/OwningOpRef.h"  // from @llvm-project
-#include "mlir/Pass/PassManager.h"  // from @llvm-project
-#include "mlir/Support/LLVM.h"  // from @llvm-project
-#include "mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "mlir/Dialect/SCF/IR/SCF.h"                // from @llvm-project
+#include "mlir/Dialect/Tensor/IR/Tensor.h"          // from @llvm-project
+#include "mlir/Dialect/Vector/IR/VectorOps.h"       // from @llvm-project
+#include "mlir/IR/Attributes.h"                     // from @llvm-project
+#include "mlir/IR/Builders.h"                       // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"              // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"                   // from @llvm-project
+#include "mlir/IR/OperationSupport.h"               // from @llvm-project
+#include "mlir/IR/OwningOpRef.h"                    // from @llvm-project
+#include "mlir/Pass/PassManager.h"                  // from @llvm-project
+#include "mlir/Support/LLVM.h"                      // from @llvm-project
+#include "mlir/Support/LogicalResult.h"             // from @llvm-project
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"  // from @llvm-project
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"  // from @llvm-project
-#include "mlir/Target/LLVMIR/Export.h"  // from @llvm-project
+#include "mlir/Target/LLVMIR/Export.h"          // from @llvm-project
 #include "mlir/Transforms/DialectConversion.h"  // from @llvm-project
+#include "tsl/platform/casts.h"
+#include "tsl/platform/cpu_info.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"  // IWYU pragma: keep
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
 #include "xla/cpu_function_runtime.h"
 #include "xla/debug_options_flags.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
@@ -227,14 +233,9 @@ limitations under the License.
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
-#include "tsl/platform/cpu_info.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/logging.h"  // IWYU pragma: keep
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
 
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+#include "xla/service/cpu/onednn_ops_rewriter.h"
 #include "xla/service/cpu/onednn_rewriter.h"
 #endif
 
@@ -698,6 +699,11 @@ Status CpuCompiler::RunHloPassesThroughLayoutAssn(
   // AOT compiled code runs in single thread.
   if (!is_aot_compile) {
     pipeline.AddPass<OneDnnRewriter>();
+
+    // Placing OneDnnOpsRewriter here to match the flax patterns
+    // TODO: Decide where would be the appropriate place for this pass to make
+    // it more generic
+    pipeline.AddPass<OneDnnOpsRewriter>();
   }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 

--- a/xla/service/cpu/cpu_runtime.cc
+++ b/xla/service/cpu/cpu_runtime.cc
@@ -151,6 +151,8 @@ extern const char* const kPartitionIdSymbolName =
 extern const char* const kReplicaIdSymbolName = "__xla_cpu_runtime_ReplicaId";
 extern const char* const kOneDnnMatMulSymbolName =
     "__xla_cpu_runtime_OneDnnMatMul";
+extern const char* const kOneDnnLayerNormSymbolName =
+    "__xla_cpu_runtime_OneDnnLayerNorm";
 
 namespace {
 

--- a/xla/service/cpu/cpu_runtime.h
+++ b/xla/service/cpu/cpu_runtime.h
@@ -86,6 +86,7 @@ extern const char* const kTracingEndSymbolName;
 extern const char* const kAllToAllSymbolName;
 extern const char* const kAllGatherSymbolName;
 extern const char* const kOneDnnMatMulSymbolName;
+extern const char* const kOneDnnLayerNormSymbolName;
 
 // All symbol names for XLA CPU runtime functions need to start with this
 // prefix.

--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -47,6 +47,9 @@ limitations under the License.
 #include "llvm/IR/IntrinsicsX86.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Value.h"
+#include "tsl/lib/math/math_util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
@@ -79,9 +82,6 @@ limitations under the License.
 #include "xla/util.h"
 #include "xla/window_util.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/lib/math/math_util.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/logging.h"
 
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 #include "xla/service/cpu/onednn_memory_util.h"
@@ -2500,6 +2500,85 @@ Status IrEmitter::HandleOneDnnMatMul(HloInstruction* custom_call) {
 
   return OkStatus();
 }
+
+Status IrEmitter::HandleOneDnnLayerNorm(HloInstruction* custom_call) {
+  //      args[0]: ptr to nargs
+  //      args[1]: ptr to ExecutableRunOptions
+  //      args[2]: ptr to OneDnnLayerNormConfig
+  //      args[3...]: ptrs to operands
+
+  // First three arguments: nargs, ExecutableRunOptions, and
+  // OneDnnLayerNormConfig.
+  const int nargs_offset = 3;
+  const int num_operands = custom_call->operand_count();
+  const int nargs = nargs_offset + num_operands;
+  int arg_indx = 0;
+
+  llvm::Type* i64_type = b_.getInt64Ty();
+  llvm::Type* ptr_type = b_.getPtrTy();
+  llvm::ArrayType* ptr_array_type = llvm::ArrayType::get(ptr_type, nargs);
+  llvm::Value* args_val = llvm::UndefValue::get(ptr_array_type);
+
+  // Insert nargs.
+  llvm::Value* nargs_val = b_.getInt64(nargs);
+  llvm::Value* nargs_ptr =
+      llvm_ir::EmitAllocaAtFunctionEntry(i64_type, "nargs", &b_);
+  llvm::Value* nargs_life_start =
+      b_.CreateLifetimeStart(nargs_ptr, b_.getInt64(-1));
+  llvm::Value* nargs_store = b_.CreateStore(nargs_val, nargs_ptr);
+  args_val = b_.CreateInsertValue(args_val, nargs_ptr, arg_indx++);
+
+  // Insert ExecutableRunOptions.
+  llvm::Value* run_opts_val = GetExecutableRunOptionsArgument();
+  args_val = b_.CreateInsertValue(args_val, run_opts_val, arg_indx++);
+
+  // Insert OneDnnLayerNormConfig.
+  auto typed_custom_call = Cast<HloCustomCallInstruction>(custom_call);
+  auto backend_config = typed_custom_call->backend_config<BackendConfig>();
+  OneDnnLayerNormConfig ln_config;
+  ln_config.CopyFrom(backend_config->onednn_layer_norm_config());
+  std::string str_config;
+  ln_config.SerializeToString(&str_config);
+  llvm::Value* ln_config_val =
+      b_.CreateGlobalStringPtr(llvm_ir::AsStringRef(str_config));
+  args_val = b_.CreateInsertValue(args_val, ln_config_val, arg_indx++);
+
+  // Insert operands.
+  std::vector<StackAlloca> operands_stack_alloca;
+  operands_stack_alloca.reserve(num_operands);
+  absl::c_transform(custom_call->operands(), operands_stack_alloca.begin(),
+                    [this](HloInstruction* instr) {
+                      llvm_ir::IrArray ir_array(GetIrArrayFor(instr));
+                      return GetAllocaAndEmitMemrefInfo(b_, ir_array);
+                    });
+  for (int i = 0; i < num_operands; ++i) {
+    args_val = b_.CreateInsertValue(args_val, operands_stack_alloca[i].value,
+                                    arg_indx++);
+  }
+
+  llvm::Value* args_ptr =
+      llvm_ir::EmitAllocaAtFunctionEntry(ptr_array_type, "layernorm.args", &b_);
+  llvm::Value* args_life_start =
+      b_.CreateLifetimeStart(args_ptr, b_.getInt64(-1));
+  llvm::Value* args_store = b_.CreateStore(args_val, args_ptr);
+
+  TF_RETURN_IF_ERROR(EmitTargetAddressForOp(custom_call));
+  llvm_ir::IrArray result_array = GetIrArrayFor(custom_call);
+  auto result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
+
+  EmitCallToFunc(runtime::kOneDnnLayerNormSymbolName,
+                 {result_stack_alloca.value, args_ptr}, b_.getVoidTy());
+
+  // Lifetime ends for all stack allocations.
+  b_.CreateLifetimeEnd(nargs_ptr, b_.getInt64(-1));
+  for (int i = 0; i < num_operands; ++i) {
+    operands_stack_alloca[i].EmitLifetimeEnd();
+  }
+  b_.CreateLifetimeEnd(args_ptr, b_.getInt64(-1));
+  result_stack_alloca.EmitLifetimeEnd();
+
+  return OkStatus();
+}
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 
 Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
@@ -2515,6 +2594,9 @@ Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
   if (custom_call->custom_call_target() == "__onednn$matmul") {
     return HandleOneDnnMatMul(custom_call);
+  }
+  if (custom_call->custom_call_target() == "__onednn$layernorm") {
+    return HandleOneDnnLayerNorm(custom_call);
   }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   absl::Span<HloInstruction* const> operands(custom_call->operands());

--- a/xla/service/cpu/ir_emitter.h
+++ b/xla/service/cpu/ir_emitter.h
@@ -196,6 +196,7 @@ class IrEmitter : public DfsHloVisitorWithDefault,
   Status HandleAllReduceMultipleReplica(HloInstruction* crs);
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
   Status HandleOneDnnMatMul(HloInstruction* hlo);
+  Status HandleOneDnnLayerNorm(HloInstruction* hlo);
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   // Private helper to initialize an IR function for the computation.
   void InitializeIrFunction(const std::string& function_name);

--- a/xla/service/cpu/onednn_layer_norm.cc
+++ b/xla/service/cpu/onednn_layer_norm.cc
@@ -1,0 +1,108 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "xla/service/cpu/onednn_layer_norm.h"
+
+#include <algorithm>
+#include <cmath>
+#include <initializer_list>
+#include <vector>
+
+#define EIGEN_USE_THREADS
+
+#include "absl/base/dynamic_annotations.h"
+#include "dnnl.hpp"
+#include "tsl/util/onednn_threadpool.h"
+#include "xla/executable_run_options.h"
+#include "xla/service/cpu/backend_config.pb.h"
+#include "xla/service/cpu/onednn_memory_util.h"
+#include "xla/service/cpu/runtime_lightweight_check.h"
+#include "unsupported/Eigen/CXX11/Tensor"
+
+namespace xla {
+namespace cpu {
+namespace {
+using dnnl::engine;
+using dnnl::layer_normalization_forward;
+using dnnl::memory;
+using dnnl::normalization_flags;
+using dnnl::prop_kind;
+using dnnl::stream;
+}  // namespace
+
+ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnLayerNorm(
+    void* result, void** args) {
+  // args[0]: ptr to nargs
+  // args[1]: ptr to ExecutableRunOptions
+  // args[2]: ptr to OneDnnLayerNormConfig
+  // args[3...]: ptrs to operands
+  int arg_indx = 0;
+  const int64_t num_args = *(static_cast<int64_t*>(args[arg_indx++]));
+
+  const xla::ExecutableRunOptions* run_options =
+      static_cast<const xla::ExecutableRunOptions*>(args[arg_indx++]);
+  XLA_LIGHTWEIGHT_CHECK(run_options != nullptr);
+  XLA_LIGHTWEIGHT_CHECK(run_options->intra_op_thread_pool() != nullptr);
+  tsl::OneDnnThreadPool thread_pool(
+      run_options->intra_op_thread_pool()->getPool(), false);
+  engine cpu_engine(engine::kind::cpu, 0);
+#ifndef ENABLE_ONEDNN_OPENMP
+  auto onednn_stream =
+      stream(dnnl::threadpool_interop::make_stream(cpu_engine, &thread_pool));
+#else
+  auto onednn_stream = stream(cpu_engine);
+#endif  // ENABLE_ONEDNN_OPENMP
+  std::string config_str(static_cast<const char*>(args[arg_indx++]));
+  OneDnnLayerNormConfig ln_config;
+  ln_config.ParseFromString(config_str);
+
+  MemrefInfo layer_minfo(args[arg_indx++]);
+  MemrefInfo gamma_minfo(args[arg_indx++]);
+  MemrefInfo beta_minfo(args[arg_indx++]);
+  MemrefInfo result_minfo(result);
+
+  auto src_md = layer_minfo.GetOneDnnMemDesc();
+  auto dst_md = result_minfo.GetOneDnnMemDesc();
+  auto scaleshift_md = beta_minfo.GetOneDnnMemDesc();
+
+  auto src_mem = memory(src_md, cpu_engine, layer_minfo.Data());
+  auto dst_mem = memory(dst_md, cpu_engine, result_minfo.Data());
+  auto scale_mem = memory(scaleshift_md, cpu_engine, gamma_minfo.Data());
+  auto shift_mem = memory(scaleshift_md, cpu_engine, beta_minfo.Data());
+
+  // TODO(intel-tf): Move epsilon to OneDnnLayerNormConfig.
+  const float epsilon = 1.e-5f;
+
+  auto lnorm_pd = layer_normalization_forward::primitive_desc(
+      cpu_engine, prop_kind::forward_inference, src_md, dst_md, epsilon,
+      normalization_flags::use_scale | normalization_flags::use_shift);
+
+  auto lnorm_prim = layer_normalization_forward(lnorm_pd);
+
+  std::unordered_map<int, memory> ln_args;
+  ln_args.insert({DNNL_ARG_SRC, src_mem});
+  ln_args.insert({DNNL_ARG_SCALE, scale_mem});
+  ln_args.insert({DNNL_ARG_SHIFT, shift_mem});
+  ln_args.insert({DNNL_ARG_DST, dst_mem});
+
+  lnorm_prim.execute(onednn_stream, ln_args);
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/xla/service/cpu/onednn_layer_norm.h
+++ b/xla/service/cpu/onednn_layer_norm.h
@@ -1,0 +1,31 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_CPU_ONEDNN_LAYERNORM_H_
+#define XLA_SERVICE_CPU_ONEDNN_LAYERNORM_H_
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+namespace xla {
+namespace cpu {
+
+extern "C" {
+extern void __xla_cpu_runtime_OneDnnLayerNorm(void* result, void** args);
+}  // extern "C"
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+#endif  // XLA_SERVICE_CPU_ONEDNN_LAYERNORM_H_

--- a/xla/service/cpu/onednn_ops_rewriter.cc
+++ b/xla/service/cpu/onednn_ops_rewriter.cc
@@ -1,0 +1,274 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "xla/service/cpu/onednn_ops_rewriter.h"
+
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/service/cpu/backend_config.pb.h"
+#include "xla/service/cpu/onednn_memory_util.h"
+#include "xla/service/cpu/onednn_util.h"
+#include "xla/service/pattern_matcher.h"
+#include "xla/status_macros.h"
+
+namespace xla {
+namespace cpu {
+
+namespace {
+namespace m = match;
+
+auto ConvertPattern(HloInstruction** instr) {
+  return m::Convert(m::Op(instr).WithElementType(PrimitiveType::BF16))
+      .WithElementType(PrimitiveType::F32);
+}
+
+HloInstruction* FindLayerNormScale(HloInstruction* instr) {
+  HloInstruction* scale = nullptr;
+  auto scalePattern = m::Multiply().WithBinaryOperandsAnyOrder(
+      m::Broadcast(m::Op(&scale).WithOpcode(HloOpcode::kReshape)),
+      m::Broadcast(m::Reshape(m::Broadcast(m::Rsqrt()))).WithOneUser());
+  auto m = Match(instr, scalePattern);
+  return scale;
+}
+
+HloInstruction* FindLayerNormShift(HloInstruction* instr) {
+  HloInstruction* shift = nullptr;
+  auto m = Match(
+      instr,
+      m::Add().WithBinaryOperandsAnyOrder(
+          m::Multiply()
+              .WithBinaryOperandsAnyOrder(
+                  m::Op(), m::Subtract(m::Op(), m::Broadcast().WithOneUser())
+                               .WithOneUser())
+              .WithOneUser(),
+          m::Broadcast(m::Op(&shift))));
+  return shift;
+}
+
+}  // namespace
+
+class OneDnnOpsRewriterVisitor : public DfsHloRewriteVisitor {
+ public:
+  Status HandleAdd(HloInstruction* instr) override {
+    HloInstruction *slicemu1, *slicemu2;
+    HloInstruction *slicesource1, *slicesource2;
+    HloInstruction *musquare1, *musquare2;
+    HloInstruction *prod_c, *prod_l, *prod_s, *prod_r;
+    HloInstruction *slicevar, *hinge;
+
+    bool scaleFound = false;
+    bool shiftFound = false;
+
+    auto spine = m::Add().WithBinaryOperandsAnyOrder(
+        m::Broadcast(),
+        m::Multiply()
+            .WithBinaryOperandsAnyOrder(
+                m::Op(&hinge).WithOneUser(),
+                m::Subtract(
+                    m::Op(&prod_s),
+                    m::Broadcast(
+                        m::Reshape(
+                            m::Broadcast(
+                                m::Reshape(
+                                    m::Op(&slicemu1)
+                                        .WithOpcode(HloOpcode::kSlice)
+                                        .WithOperand(
+                                            0, m::Op(&slicesource1)
+                                                   .WithOpcode(
+                                                       HloOpcode::kDivide)))
+                                    .WithOneUser())
+                                .WithOneUser())
+                            .WithOneUser())
+                        .WithOneUser())
+                    .WithOneUser())
+            .WithOneUser());
+
+    if (!Match(instr, spine)) {
+      return OkStatus();
+    }
+
+    const Shape& prod_shape = prod_s->shape();
+    if (!IsSupportedType(prod_shape.element_type())) return OkStatus();
+
+    HloInstruction* shift = FindLayerNormShift(instr);
+    shiftFound = (shift != nullptr);
+
+    HloInstruction* scale = FindLayerNormScale(hinge);
+    scaleFound = (scale != nullptr);
+
+    // Currently patterns without scale and shift are
+    // not supported.
+    // OneDNN only supports 2 <= rank <= 5
+    if (!(prod_shape.rank() >= 2 && prod_shape.rank() <= 5) || !shiftFound ||
+        !scaleFound) {
+      return OkStatus();
+    }
+
+    auto main_pipeline = m::Multiply().WithBinaryOperandsAnyOrder(
+        m::Op(),
+        m::Broadcast(
+            m::Reshape(
+                m::Broadcast(
+                    m::Rsqrt(
+                        m::Add()
+                            .WithBinaryOperandsAnyOrder(
+                                m::Broadcast(m::Constant()),
+                                m::Reshape(
+                                    m::Maximum()
+                                        .WithBinaryOperandsAnyOrder(
+                                            m::Broadcast(),
+                                            m::Subtract(
+                                                m::Reshape(
+                                                    m::Op(&slicevar)
+                                                        .WithOpcode(
+                                                            HloOpcode::kSlice)
+                                                        .WithOperand(
+                                                            0,
+                                                            m::Op(&slicesource2)
+                                                                .WithOpcode(
+                                                                    HloOpcode::
+                                                                        kDivide)))
+                                                    .WithOneUser(),
+                                                m::Multiply(
+                                                    m::Op(&musquare1),
+                                                    m::Op(&musquare2)
+                                                        .WithOperand(
+                                                            0,
+                                                            m::Op(&slicemu2)
+                                                                .WithOpcode(
+                                                                    HloOpcode::
+                                                                        kSlice)))
+                                                    .WithOneUser())
+                                                .WithOneUser())
+                                        .WithOneUser())
+                                    .WithOneUser())
+                            .WithOneUser())
+                        .WithOneUser())
+                    .WithOneUser())
+                .WithOneUser())
+            .WithOneUser());
+
+    if (!Match(hinge, main_pipeline) || slicemu1 != slicemu2 ||
+        musquare1 != musquare2 || slicesource1 != slicesource2) {
+      return OkStatus();
+    }
+
+    // Check if the slices are compatible
+    if (!(absl::c_all_of(slicemu1->slice_starts(),
+                         [](int64_t i) { return i == 0; }) &&
+          absl::c_equal(slicemu1->slice_limits(),
+                        slicemu1->shape().dimensions())) &&
+        !(absl::c_all_of(slicevar->slice_starts(),
+                         [](int64_t i) { return i == 0; }) &&
+          absl::c_equal(slicevar->slice_limits(),
+                        slicevar->shape().dimensions()))) {
+      return OkStatus();
+    }
+
+    auto empirical_expectations = m::Divide(
+        m::Reduce(m::Concatenate()
+                      .WithBinaryOperandsAnyOrder(
+                          m::Reshape(m::Multiply(m::Op(&prod_l), m::Op(&prod_c))
+                                         .WithOneUser())
+                              .WithOneUser(),
+                          m::Reshape(m::Op(&prod_r)).WithOneUser())
+                      .WithPredicate([](const HloInstruction* comb) {
+                        return (comb->dimensions().size() == 1 &&
+                                comb->dimensions()[0] == 0 &&
+                                comb->shape().dimensions(0) == 2);
+                      })
+                      .WithOneUser(),
+                  m::Constant())
+            .WithPredicate([](const HloInstruction* reduce) {
+              HloComputation* reducer = reduce->to_apply();
+              return (reducer->root_instruction()->opcode() ==
+                          HloOpcode::kAdd &&
+                      reduce->dimensions().size() == 1 &&
+                      reduce->dimensions()[0] == reduce->shape().rank());
+            })
+            .WithOneUser(),
+        m::Broadcast(m::ConstantScalar().WithPredicate(
+            [orig = prod_s](const HloInstruction* divisor) {
+              std::optional<double> actual =
+                  static_cast<const HloConstantInstruction*>(divisor)
+                      ->literal()
+                      .GetAsDouble({});
+              return (actual.has_value() &&
+                      orig->shape().dimensions(orig->shape().rank() - 1) ==
+                          *actual);
+            })));
+
+    HloInstruction *src1, *src2;
+    if (Match(slicesource2, empirical_expectations) &&
+        // Float32 pattern check
+        ((prod_l == prod_c && prod_c == prod_r && prod_l == prod_s) ||
+         // Bfloat16 pattern check
+         (prod_l == prod_c && prod_c == prod_r &&
+          Match(prod_l, ConvertPattern(&src1)) &&
+          Match(prod_s, ConvertPattern(&src2)) && src1 == src2))) {
+      HloInstruction* ln_call =
+          instr->AddInstruction(HloInstruction::CreateCustomCall(
+              prod_shape, {prod_r, scale, shift}, "__onednn$layernorm"));
+      BackendConfig backend_config;
+      OneDnnLayerNormConfig* ln_config =
+          backend_config.mutable_onednn_layer_norm_config();
+      ln_config->set_fused_ops(OneDnnLayerNormConfig::SCALE_AND_SHIFT);
+      TF_RETURN_IF_ERROR(ln_call->set_backend_config(backend_config));
+      TF_RETURN_IF_ERROR(ReplaceInstruction(instr, ln_call));
+    }
+
+    return OkStatus();
+  }
+
+  Status HandleConvert(HloInstruction* instr) override {
+    HloInstruction* ln_instr;
+    auto pattern = m::Convert(m::Op(&ln_instr)
+                                  .WithOneUser()
+                                  .WithOpcode(HloOpcode::kCustomCall)
+                                  .WithCustomCallTarget({"__onednn$layernorm"})
+                                  .WithElementType(PrimitiveType::F32))
+                       .WithElementType(PrimitiveType::BF16);
+
+    if (!IsSupportedType(instr->shape().element_type())) return OkStatus();
+    if (Match(instr, pattern)) {
+      HloInstruction* producer = instr->mutable_operand(0)->mutable_operand(0);
+      HloInstruction* newinp =
+          producer->AddInstruction(HloInstruction::CreateConvert(
+              ShapeUtil::ChangeElementType(producer->shape(),
+                                           instr->shape().element_type()),
+              {producer}));
+      absl::InlinedVector<HloInstruction*, 2> newoperands =
+          ln_instr->mutable_operands();
+      newoperands.at(0) = newinp;
+      HloInstruction* ln_call = instr->AddInstruction(
+          ln_instr->CloneWithNewOperands(instr->shape(), newoperands));
+      TF_RETURN_IF_ERROR(ReplaceInstruction(instr, ln_call));
+    }
+
+    return OkStatus();
+  }
+};
+
+StatusOr<bool> OneDnnOpsRewriter::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  OneDnnOpsRewriterVisitor visitor;
+  return visitor.RunOnModule(module, execution_threads);
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/xla/service/cpu/onednn_ops_rewriter.h
+++ b/xla/service/cpu/onednn_ops_rewriter.h
@@ -1,0 +1,44 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef XLA_SERVICE_CPU_ONEDNN_OPS_REWRITER_H_
+#define XLA_SERVICE_CPU_ONEDNN_OPS_REWRITER_H_
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include <optional>
+
+#include "absl/algorithm/container.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/hlo_pass_interface.h"
+
+namespace xla {
+namespace cpu {
+
+// This pass pattern-matches elementwise hlo instructions and rewrites into
+// custom calls.
+class OneDnnOpsRewriter : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "onednn-ops-rewriter"; }
+
+  using HloPassInterface::Run;
+  StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+#endif  // XLA_SERVICE_CPU_ONEDNN_OPS_REWRITER_H_

--- a/xla/service/cpu/onednn_rewriter.cc
+++ b/xla/service/cpu/onednn_rewriter.cc
@@ -17,13 +17,14 @@ limitations under the License.
 
 #include "xla/service/cpu/onednn_rewriter.h"
 
+#include "tsl/platform/cpu_info.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_memory_util.h"
+#include "xla/service/cpu/onednn_util.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
-#include "tsl/platform/cpu_info.h"
 
 namespace xla {
 namespace cpu {
@@ -43,21 +44,6 @@ Status ValidateDotDimensionNumbers(const DotDimensionNumbers& dim_numbers) {
   TF_RET_CHECK(
       absl::c_equal(batch_dim_numbers, dim_numbers.rhs_batch_dimensions()));
   return OkStatus();
-}
-
-bool IsSupportedType(xla::PrimitiveType dtype) {
-  using tsl::port::CPUFeature;
-  using tsl::port::TestCPUFeature;
-  switch (dtype) {
-    case F32:
-      return true;
-    case BF16:
-      return TestCPUFeature(CPUFeature::AVX512_BF16) ||
-             TestCPUFeature(CPUFeature::AMX_BF16);
-    default:
-      return false;
-  }
-  return false;
 }
 
 }  // namespace

--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -1,0 +1,45 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_CPU_ONEDNN_UTIL_H_
+#define XLA_SERVICE_CPU_ONEDNN_UTIL_H_
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "tsl/platform/cpu_info.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace cpu {
+
+inline bool IsSupportedType(xla::PrimitiveType dtype) {
+  using namespace tsl::port;
+  static bool is_bf16_supported = TestCPUFeature(CPUFeature::AVX512_BF16) ||
+                                  TestCPUFeature(CPUFeature::AMX_BF16);
+  switch (dtype) {
+    case F32:
+      return true;
+    case BF16:
+      return is_bf16_supported;
+    default:
+      break;
+  }
+  return false;
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+#endif  // XLA_SERVICE_CPU_ONEDNN_UTIL_H_

--- a/xla/service/cpu/simple_orc_jit.cc
+++ b/xla/service/cpu/simple_orc_jit.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "llvm/Support/Process.h"
 #include "llvm/TargetParser/Host.h"
 #include "mlir/ExecutionEngine/CRunnerUtils.h"  // from @llvm-project
+#include "tsl/platform/logging.h"
 #include "xla/service/cpu/cpu_runtime.h"
 #include "xla/service/cpu/orc_jit_memory_mapper.h"
 #include "xla/service/cpu/runtime_conv2d.h"
@@ -61,9 +62,9 @@ limitations under the License.
 #include "xla/service/custom_call_target_registry.h"
 #include "xla/types.h"
 #include "xla/util.h"
-#include "tsl/platform/logging.h"
 
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+#include "xla/service/cpu/onednn_layer_norm.h"
 #include "xla/service/cpu/onednn_matmul.h"
 #endif
 
@@ -526,6 +527,7 @@ bool RegisterKnownJITSymbols() {
   REGISTER_CPU_RUNTIME_SYMBOL(TracingEnd);
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
   REGISTER_CPU_RUNTIME_SYMBOL(OneDnnMatMul);
+  REGISTER_CPU_RUNTIME_SYMBOL(OneDnnLayerNorm);
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 
   registry->Register("__gnu_f2h_ieee", reinterpret_cast<void*>(__gnu_f2h_ieee),

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -2858,3 +2858,21 @@ xla_test(
         "@tsl//tsl/platform:platform_port",
     ],
 )
+
+xla_test(
+    name = "onednn_layer_norm_test",
+    srcs = ["onednn_layer_norm_test.cc"],
+    backends = [
+        "cpu",
+    ],
+    copts = tsl_copts(),
+    deps = [
+        ":hlo_test_base",
+        ":test_macros_header",
+        ":xla_internal_test_main",
+        "//xla:literal",
+        "//xla:shape_util",
+        "//xla:test",
+        "//xla:test_helpers",
+    ],
+)

--- a/xla/tests/onednn_layer_norm_test.cc
+++ b/xla/tests/onednn_layer_norm_test.cc
@@ -1,0 +1,174 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <utility>
+
+#include "xla/literal.h"
+#include "xla/shape_util.h"
+#include "xla/test.h"
+#include "xla/test_helpers.h"
+#include "xla/tests/hlo_test_base.h"
+#include "xla/tests/test_macros.h"
+
+namespace xla {
+namespace {
+
+class LayerNormTest : public HloTestBase {};
+
+TEST_F(LayerNormTest, SimpleTest) {
+  const char* layer_norm_module_str = R"(
+  HloModule layer_norm.test, entry_computation_layout={(f32[4,1,256]{2,1,0}, f32[1,1,256]{2,1,0}, f32[1,1,256]{2,1,0})->f32[4,1,256]{2,1,0}}
+
+  region_add {
+    Arg_0.7555 = f32[] parameter(0)
+    Arg_1.7556 = f32[] parameter(1)
+    ROOT add.7557 = f32[] add(Arg_0.7555, Arg_1.7556)
+  }
+
+  ENTRY main {
+    Arg_0.1 = f32[4,1,256]{2,1,0} parameter(0), sharding={replicated}
+    Arg_0.2 = f32[1,1,256]{2,1,0} parameter(1), sharding={replicated}
+    Arg_0.3 = f32[1,1,256]{2,1,0} parameter(2), sharding={replicated}
+    reshape.9744 = f32[1,4,1,256]{3,2,1,0} reshape(Arg_0.1)
+    multiply.9743 = f32[4,1,256]{2,1,0} multiply(Arg_0.1, Arg_0.1)
+    reshape.9745 = f32[1,4,1,256]{3,2,1,0} reshape(multiply.9743)
+    concatenate.9746 = f32[2,4,1,256]{3,2,1,0} concatenate(reshape.9744, reshape.9745), dimensions={0}
+    constant.9731 = f32[] constant(0)
+    reduce.9747 = f32[2,4,1]{2,1,0} reduce(concatenate.9746, constant.9731), dimensions={3}, to_apply=region_add
+    constant.9729 = f32[] constant(256)
+    broadcast.9730 = f32[2,4,1]{2,1,0} broadcast(constant.9729), dimensions={}
+    divide.9748 = f32[2,4,1]{2,1,0} divide(reduce.9747, broadcast.9730)
+    slice.9749 = f32[1,4,1]{2,1,0} slice(divide.9748), slice={[0:1], [0:4], [0:1]}
+    reshape.9756 = f32[4,1,1]{2,1,0} reshape(slice.9749)
+    broadcast.9758 = f32[4,1,1]{2,1,0} broadcast(reshape.9756), dimensions={0,1,2}
+    reshape.9759 = f32[4,1]{1,0} reshape(broadcast.9758)
+    broadcast.9760 = f32[4,1,256]{2,1,0} broadcast(reshape.9759), dimensions={0,1}
+    subtract.9761 = f32[4,1,256]{2,1,0} subtract(Arg_0.1, broadcast.9760)
+    slice.9751 = f32[1,4,1]{2,1,0} slice(divide.9748), slice={[1:2], [0:4], [0:1]}
+    reshape.9752 = f32[4,1]{1,0} reshape(slice.9751)
+    reshape.9750 = f32[4,1]{1,0} reshape(slice.9749)
+    multiply.9753 = f32[4,1]{1,0} multiply(reshape.9750, reshape.9750)
+    subtract.9754 = f32[4,1]{1,0} subtract(reshape.9752, multiply.9753)
+    constant.9727 = f32[] constant(0)
+    broadcast.9728 = f32[4,1]{1,0} broadcast(constant.9727), dimensions={}
+    maximum.9755 = f32[4,1]{1,0} maximum(subtract.9754, broadcast.9728)
+    reshape.9757 = f32[4,1,1]{2,1,0} reshape(maximum.9755)
+    constant.9725 = f32[] constant(1e-05)
+    broadcast.9726 = f32[4,1,1]{2,1,0} broadcast(constant.9725), dimensions={}
+    add.9762 = f32[4,1,1]{2,1,0} add(reshape.9757, broadcast.9726)
+    rsqrt.9763 = f32[4,1,1]{2,1,0} rsqrt(add.9762)
+    broadcast.9764 = f32[4,1,1]{2,1,0} broadcast(rsqrt.9763), dimensions={0,1,2}
+    reshape.9765 = f32[4,1]{1,0} reshape(broadcast.9764)
+    broadcast.9766 = f32[4,1,256]{2,1,0} broadcast(reshape.9765), dimensions={0,1}
+    broadcast.9767 = f32[1,1,256]{2,1,0} broadcast(Arg_0.2), dimensions={0,1,2}
+    reshape.9768 = f32[1,256]{1,0} reshape(broadcast.9767)
+    broadcast.9769 = f32[4,1,256]{2,1,0} broadcast(reshape.9768), dimensions={1,2}
+    multiply.9770 = f32[4,1,256]{2,1,0} multiply(broadcast.9766, broadcast.9769)
+    multiply.9771 = f32[4,1,256]{2,1,0} multiply(subtract.9761, multiply.9770)
+    broadcast.9772 = f32[1,1,256]{2,1,0} broadcast(Arg_0.3), dimensions={0,1,2}
+    reshape.9773 = f32[1,256]{1,0} reshape(broadcast.9772)
+    broadcast.9774 = f32[4,1,256]{2,1,0} broadcast(reshape.9773), dimensions={1,2}
+    ROOT add.9775 = f32[4,1,256]{2,1,0} add(multiply.9771, broadcast.9774)
+  }  
+)";
+
+  EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(layer_norm_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$layernorm",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "onednn_layer_norm_config":{
+  ; CHECK-DAG:       "fused_ops":"SCALE_AND_SHIFT"
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
+TEST_F(LayerNormTest, SimpleTestBF16) {
+  const char* layer_norm_module_str = R"(
+  HloModule layer_norm_bf16.test, entry_computation_layout={(f32[768]{0}, f32[768]{0}, bf16[16,128,768]{2,1,0})->bf16[16,128,768]{2,1,0}}, allow_spmd_sharding_propagation_to_output={true}
+
+  region_0.16 {
+    Arg_0.17 = f32[] parameter(0)
+    Arg_1.18 = f32[] parameter(1)
+    ROOT add.19 = f32[] add(Arg_0.17, Arg_1.18)
+  }
+
+  ENTRY main.53 {
+    Arg_2.3 = bf16[16,128,768]{2,1,0} parameter(2), sharding={replicated}
+    convert.31 = f32[16,128,768]{2,1,0} convert(Arg_2.3)
+    convert.11 = f32[16,128,768]{2,1,0} convert(Arg_2.3)
+    reshape.13 = f32[1,16,128,768]{3,2,1,0} reshape(convert.11)
+    multiply.12 = f32[16,128,768]{2,1,0} multiply(convert.11, convert.11)
+    reshape.14 = f32[1,16,128,768]{3,2,1,0} reshape(multiply.12)
+    concatenate.15 = f32[2,16,128,768]{3,2,1,0} concatenate(reshape.13, reshape.14), dimensions={0}
+    constant.10 = f32[] constant(0)
+    reduce.20 = f32[2,16,128]{2,1,0} reduce(concatenate.15, constant.10), dimensions={3}, to_apply=region_0.16
+    constant.8 = f32[] constant(768)
+    broadcast.9 = f32[2,16,128]{2,1,0} broadcast(constant.8), dimensions={}
+    divide.21 = f32[2,16,128]{2,1,0} divide(reduce.20, broadcast.9)
+    slice.22 = f32[1,16,128]{2,1,0} slice(divide.21), slice={[0:1], [0:16], [0:128]}
+    reshape.29 = f32[16,128,1]{2,1,0} reshape(slice.22)
+    broadcast.32 = f32[16,128,1]{2,1,0} broadcast(reshape.29), dimensions={0,1,2}
+    reshape.33 = f32[16,128]{1,0} reshape(broadcast.32)
+    broadcast.34 = f32[16,128,768]{2,1,0} broadcast(reshape.33), dimensions={0,1}
+    subtract.35 = f32[16,128,768]{2,1,0} subtract(convert.31, broadcast.34)
+    slice.24 = f32[1,16,128]{2,1,0} slice(divide.21), slice={[1:2], [0:16], [0:128]}
+    reshape.25 = f32[16,128]{1,0} reshape(slice.24)
+    reshape.23 = f32[16,128]{1,0} reshape(slice.22)
+    multiply.26 = f32[16,128]{1,0} multiply(reshape.23, reshape.23)
+    subtract.27 = f32[16,128]{1,0} subtract(reshape.25, multiply.26)
+    constant.6 = f32[] constant(0)
+    broadcast.7 = f32[16,128]{1,0} broadcast(constant.6), dimensions={}
+    maximum.28 = f32[16,128]{1,0} maximum(subtract.27, broadcast.7)
+    reshape.30 = f32[16,128,1]{2,1,0} reshape(maximum.28)
+    constant.4 = f32[] constant(1e-06)
+    broadcast.5 = f32[16,128,1]{2,1,0} broadcast(constant.4), dimensions={}
+    add.36 = f32[16,128,1]{2,1,0} add(reshape.30, broadcast.5)
+    rsqrt.37 = f32[16,128,1]{2,1,0} rsqrt(add.36)
+    broadcast.39 = f32[16,128,1]{2,1,0} broadcast(rsqrt.37), dimensions={0,1,2}
+    reshape.40 = f32[16,128]{1,0} reshape(broadcast.39)
+    broadcast.41 = f32[16,128,768]{2,1,0} broadcast(reshape.40), dimensions={0,1}
+    Arg_1.2 = f32[768]{0} parameter(1), sharding={replicated}
+    reshape.38 = f32[1,1,768]{2,1,0} reshape(Arg_1.2)
+    broadcast.42 = f32[1,1,768]{2,1,0} broadcast(reshape.38), dimensions={0,1,2}
+    reshape.43 = f32[768]{0} reshape(broadcast.42)
+    broadcast.44 = f32[16,128,768]{2,1,0} broadcast(reshape.43), dimensions={2}
+    multiply.45 = f32[16,128,768]{2,1,0} multiply(broadcast.41, broadcast.44)
+    multiply.46 = f32[16,128,768]{2,1,0} multiply(subtract.35, multiply.45)
+    Arg_0.1 = f32[768]{0} parameter(0), sharding={replicated}
+    reshape.47 = f32[1,1,768]{2,1,0} reshape(Arg_0.1)
+    broadcast.48 = f32[1,1,768]{2,1,0} broadcast(reshape.47), dimensions={0,1,2}
+    reshape.49 = f32[768]{0} reshape(broadcast.48)
+    broadcast.50 = f32[16,128,768]{2,1,0} broadcast(reshape.49), dimensions={2}
+    add.51 = f32[16,128,768]{2,1,0} add(multiply.46, broadcast.50)
+    ROOT convert.52 = bf16[16,128,768]{2,1,0} convert(add.51)
+  }
+)";
+
+  EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-2, 1e-2}));
+  MatchOptimizedHlo(layer_norm_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$layernorm",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "onednn_layer_norm_config":{
+  ; CHECK-DAG:       "fused_ops":"SCALE_AND_SHIFT"
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
+}  // namespace
+}  // namespace xla


### PR DESCRIPTION
This PR enables oneDNN library call for the matched XLA HLO Layer Norm pattern through custom_call instruction. In particular, this PR adds:

1. oneDNN ops rewriter pass that will rewrite custom oneDNN ops like Layer Norm and Softmax. Currently, this pass is located before the BF16 all-reduce to F32 promotion.
2. Layer Norm pattern matcher as seen in some Flax models
3. oneDNN Layer Norm custom call rewrite
4. Variable number of arguments for oneDNN custom call targets
5. A test for XLA HLO Layer Norm pattern match and rewrite verification