### PR TITLE
Fix a couple of compile issues

### DIFF
--- a/xla/service/gpu/model/tile_analysis.cc
+++ b/xla/service/gpu/model/tile_analysis.cc
@@ -950,9 +950,9 @@ struct IndexingMapSimplifier {
         return getAffineBinaryOpExpr(expr.getKind(), lhs, rhs);
       }
       case AffineExprKind::Mod:
-        return RewriteMod(cast<AffineBinaryOpExpr>(expr));
+        return RewriteMod(mlir::cast<AffineBinaryOpExpr>(expr));
       case AffineExprKind::FloorDiv:
-        return RewriteFloorDiv(cast<AffineBinaryOpExpr>(expr));
+        return RewriteFloorDiv(mlir::cast<AffineBinaryOpExpr>(expr));
       default:
         return expr;
     }

--- a/xla/service/gpu/model/tile_analysis.h
+++ b/xla/service/gpu/model/tile_analysis.h
@@ -24,6 +24,7 @@ limitations under the License.
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/log/check.h"
 #include "absl/types/span.h"
 #include "llvm/ADT/Hashing.h"
 #include "mlir/IR/AffineMap.h"  // from @llvm-project


### PR DESCRIPTION
These fix warnings on clang.

The macro redefinition arises because both absl and tsl define various CHECK macros. However the tsl macros also have a #undefine first which allows them to be pulled in after absl but not the other way around without generating a warning. Adding the include ensures that the absl versions are found first.

Make the use of cast be specific as mlir::case to be consistent with other usages in the file.