### PR TITLE
[GPU] Use ncclCommSplit to create communicators

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -212,6 +212,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_cub_radix_sort(true);
   opts.set_xla_gpu_enable_cudnn_layer_norm(false);
   opts.set_xla_gpu_threshold_for_windowed_einsum_mib(100000);
+  opts.set_xla_gpu_enable_nccl_resource_sharing(true);
   return opts;
 }
 
@@ -1427,6 +1428,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_threshold_for_windowed_einsum_mib(),
       "Threshold to enable windowed einsum (collective matmul) in MB."
       "Default is 100000"));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_nccl_resource_sharing",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_nccl_resource_sharing),
+      debug_options->xla_gpu_enable_nccl_resource_sharing(),
+      "Allow NCCL communicators to share internal resources via "
+      "ncclCommSplit"));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/collective_ops_utils.h
+++ b/xla/service/collective_ops_utils.h
@@ -108,6 +108,13 @@ absl::string_view CollectiveOpGroupModeToString(
 StatusOr<CollectiveOpGroupMode> GetCollectiveOpGroupMode(
     bool has_channel_id, std::optional<bool> use_global_device_ids);
 
+// Returns which group (by index) device_id belongs to. This is used when
+// splitting a communicator into subchannels.
+StatusOr<int> GetGroupId(GlobalDeviceId device_id,
+                         const DeviceAssignment& device_assignment,
+                         absl::Span<const ReplicaGroup> replica_groups,
+                         CollectiveOpGroupMode group_mode);
+
 // Figures out subgroups of participating devices from given replica_groups and
 // group_mode.
 //

--- a/xla/service/gpu/nccl_collective_thunk.h
+++ b/xla/service/gpu/nccl_collective_thunk.h
@@ -196,7 +196,7 @@ StatusOr<NcclComm::Lock> LockNcclComm(
     const NcclExecuteParams& params,
     const std::vector<ReplicaGroup>& replica_groups,
     CollectiveOpGroupMode group_mode, int64_t op_id, int64_t stream_id,
-    bool enable_clique_optimization);
+    bool enable_clique_optimization, std::optional<ncclComm_t> parent_comm);
 #endif  // XLA_ENABLE_XCCL
 
 struct DeviceBufferPair {

--- a/xla/service/gpu/nccl_utils.h
+++ b/xla/service/gpu/nccl_utils.h
@@ -130,7 +130,8 @@ StatusOr<NcclComm::Lock> AcquireNcclComm(
     RunId run_id, OpId op_id, std::vector<GlobalDeviceId> participants,
     size_t num_local_participants,
     const NcclUniqueIdCallback& unique_id_callback, int rank, int64_t stream_id,
-    bool enable_clique_optimization);
+    bool enable_clique_optimization, std::optional<ncclComm_t> parent_comm,
+    std::optional<int> group_id);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -674,7 +674,10 @@ message DebugOptions {
   // Threshold to enable windowed einsum (collective matmul) in MB.
   int64 xla_gpu_threshold_for_windowed_einsum_mib = 265;
 
-  // Next id: 266
+  // Allow NCCL communicators to share internal resources via ncclCommSplit.
+  bool xla_gpu_enable_nccl_resource_sharing = 266;
+
+  // Next id: 267
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR adds a new flag `--xla_gpu_enable_nccl_resource_sharing`. If enabled, XLA will use ncclCommSplit to create new communicators by splitting a parent communicator. The child communicators will be able to reuse internal resources from the parent communicator, which should reduce the memory footprint from NCCL, especially in situations where many different device groupings are used.

In most cases, there will be only one parent communicator which will be created when the first nccl communicator is created. After that, all communicators will be split off from the parent communicator.


### Questions/Other Details
1. Currently, there will be separate parent communicators for the async and sync communicators since async and sync collectives can happen in parallel and we don't want contention over the shared internal nccl resources - although I'm not 100% sure how this is handled. Using the same parent for async and sync communicators could actually help avoid avoid synchronization issues. I'm not super familiar with the use case of async + sync communicators so it would be great to have someone weigh in here.
2. For the rendezvous (if not using clique optimization), there will basically be two host syncs here - one to retrieve the parent comm (first call to LockNcclComm) and another to retrieve the split comm (second call). I am thinking we should avoid the first call to LockNcclComm once the communicators have been created since the parent comm is only needed at initialization to create the child comm. Does that sound right? I would need to find a way to know if the comm has been created in GetNcclComm - perhaps retrieving the parent communicator needs to be moved deeper, like around AcquireNcclComm.
4. This implementation only affects the new runtime (non-thunk based). Let me know if I should support it for the thunk runtime as well.
5. Is there any place to add tests for this or are different collective groupings already covered well?

### References
* ncclCommSplit API: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommsplit
* splitShare option in NCCL config: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html#c.splitShare
