### PR TITLE
Skipping the test for ampere+

### DIFF
--- a/xla/service/gpu/gemm_algorithm_picker_test.cc
+++ b/xla/service/gpu/gemm_algorithm_picker_test.cc
@@ -47,6 +47,12 @@ class GemmAlgorithmPickerTest : public HloTestBase,
 };
 
 TEST_P(GemmAlgorithmPickerTest, SetAlgorithm) {
+  auto comp = backend().default_stream_executor()->GetDeviceDescription().cuda_compute_capability();
+  if (comp.IsAtLeast(se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Skipping this test for Ampere+ as it is supported and recommended with "
+                    "the Nvidia Volta+ GPUs.";
+  }
+
   constexpr absl::string_view kHlo = R"(
 HloModule module
 
@@ -117,6 +123,12 @@ ENTRY main {
 }
 
 TEST_P(GemmAlgorithmPickerTest, GetAlgorithmWithoutDevice) {
+  auto comp = backend().default_stream_executor()->GetDeviceDescription().cuda_compute_capability();
+  if (comp.IsAtLeast(se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Skipping this test for Ampere+ as it is supported and recommended with "
+                    "the Nvidia Volta+ GPUs.";
+  }
+
   constexpr absl::string_view kHlo = R"(
 HloModule module
 


### PR DESCRIPTION
//xla/service/gpu:gemm_algorithm_picker_test_gpu fails on A100 GPU but passes for V100. The test is tagged with equires-gpu-sm70-only so it is supposed to be running on Volta+, added GTEST_SKIP lines for these tests if they are running on ampere