### PR TITLE
Raise an error if it get an optimized graph as input to run optimization passes

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -540,6 +540,15 @@ Status GpuCompiler::OptimizeHloModule(HloModule* hlo_module,
                                       se::StreamExecutor* stream_exec,
                                       const CompileOptions& options,
                                       const TargetConfig& gpu_target_config) {
+
+  CHECK(!hlo_module->has_schedule())
+      << "\nThe current HLO module "
+      << hlo_module->name() << " is scheduled and optimized. \n"
+      << "It is not expected to run optimization passes again.\nPlease use "
+      << "RunAndCompareNoHloPasses() or RunAndCompareTwoModules() instead of "
+      << "RunAndCompare()\nif running unit tests as they set"
+      << " run_hlo_passes=false.";
+
   const DebugOptions& debug_options = hlo_module->config().debug_options();
 
   MaybeOwningThreadPool thread_pool = MaybeOwningThreadPool::GetOrCreate(

--- a/xla/service/gpu/ir_emitter_triton_test.cc
+++ b/xla/service/gpu/ir_emitter_triton_test.cc
@@ -1289,7 +1289,7 @@ ENTRY entry {
 // https://github.com/openai/triton/issues/1864
 TEST_F(TritonGemmTest, TritonCompilerDoesNotFailOnConstants) {
   TF_CHECK_OK(GetOptimizedModule(R"(
-HloModule m, is_scheduled=true
+HloModule m
 
 triton_gemm___computation {
   parameter_0 = f32[92,11]{1,0} parameter(0)


### PR DESCRIPTION
This is to set the right expectation that an already optimized graph shouldn't be optimized again.