### PR TITLE
Include token as part of the input/output tuple in all-gather and reduce-scatter

### DIFF
--- a/xla/client/xla_builder.cc
+++ b/xla/client/xla_builder.cc
@@ -2950,6 +2950,12 @@ XlaOp XlaBuilder::AllGatherImpl(const XlaOp operand,
         return Unimplemented("0 element tuple AllGather is not supported");
       }
       for (int i = 0; i < operand_shape->tuple_shapes_size(); ++i) {
+        if (operand_shape->tuple_shapes(i).element_type() !=
+            operand_shape->tuple_shapes(0).element_type()) {
+          return Unimplemented(
+              "All the shapes of a tuple input of AllGather must have the same "
+              "element type");
+        }
         operand_shapes.push_back(&operand_shape->tuple_shapes(i));
         operands.push_back(GetTupleElement(operand, i));
       }

--- a/xla/client/xla_builder_test.cc
+++ b/xla/client/xla_builder_test.cc
@@ -432,11 +432,12 @@ TEST_F(XlaBuilderTest, AllGatherR2) {
       ShapeUtil::Equal(root->shape(), ShapeUtil::MakeShape(F32, {4, 64})));
 }
 
-TEST_F(XlaBuilderTest, AllGatherWithTuple) {
+TEST_F(XlaBuilderTest, AllGatherWithToken) {
   XlaBuilder b(TestName());
   auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {4}), "x");
   auto x2 = Parameter(&b, 1, ShapeUtil::MakeShape(F32, {16, 4}), "x2");
-  AllGather(Tuple(&b, {x, x2}), /*all_gather_dimension=*/0,
+  auto t = Parameter(&b, 2, ShapeUtil::MakeScalarShape(F32), "t");
+  AllGather(Tuple(&b, {x, x2, t}), /*all_gather_dimension=*/0,
             /*shard_count=*/4);
   TF_ASSERT_OK_AND_ASSIGN(auto module, BuildHloModule(&b));
   auto root = module->entry_computation()->root_instruction();
@@ -445,7 +446,8 @@ TEST_F(XlaBuilderTest, AllGatherWithTuple) {
   EXPECT_TRUE(ShapeUtil::Equal(
       root->shape(),
       ShapeUtil::MakeTupleShape({ShapeUtil::MakeShape(F32, {16}),
-                                 ShapeUtil::MakeShape(F32, {64, 4})})));
+                                 ShapeUtil::MakeShape(F32, {64, 4}),
+                                 ShapeUtil::MakeScalarShape(F32)})));
 }
 
 TEST_F(XlaBuilderTest, ReduceScatter) {
@@ -474,7 +476,7 @@ TEST_F(XlaBuilderTest, ReduceScatter) {
       ShapeUtil::Equal(root->shape(), ShapeUtil::MakeShape(F32, {4, 8})));
 }
 
-TEST_F(XlaBuilderTest, ReduceScatterWithTuple) {
+TEST_F(XlaBuilderTest, ReduceScatterWithToken) {
   XlaBuilder b(TestName());
   XlaComputation to_apply;
   {
@@ -488,10 +490,11 @@ TEST_F(XlaBuilderTest, ReduceScatterWithTuple) {
   }
   auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {4, 16}), "x");
   auto x2 = Parameter(&b, 1, ShapeUtil::MakeShape(F32, {16, 4}), "x2");
+  auto t = Parameter(&b, 2, ShapeUtil::MakeScalarShape(F32), "t");
   ReplicaGroup group;
   group.add_replica_ids(0);
   group.add_replica_ids(1);
-  ReduceScatter(Tuple(&b, {x, x2}), to_apply, /*scatter_dimension=*/1,
+  ReduceScatter(Tuple(&b, {x, x2, t}), to_apply, /*scatter_dimension=*/1,
                 /*shard_count=*/2,
                 /*replica_groups=*/{group});
   TF_ASSERT_OK_AND_ASSIGN(auto module, BuildHloModule(&b));
@@ -501,7 +504,8 @@ TEST_F(XlaBuilderTest, ReduceScatterWithTuple) {
   EXPECT_TRUE(ShapeUtil::Equal(
       root->shape(),
       ShapeUtil::MakeTupleShape({ShapeUtil::MakeShape(F32, {4, 8}),
-                                 ShapeUtil::MakeShape(F32, {16, 2})})));
+                                 ShapeUtil::MakeShape(F32, {16, 2}),
+                                 ShapeUtil::MakeScalarShape(F32)})));
 }
 
 TEST_F(XlaBuilderTest, AllToAll) {

--- a/xla/service/all_gather_decomposer_test.cc
+++ b/xla/service/all_gather_decomposer_test.cc
@@ -155,14 +155,15 @@ ENTRY entry {
                   op::Constant(), op::Multiply(id, op::Constant()))));
 }
 
-TEST_F(AllGatherDecomposerTest, CrossReplicaAllGatherWithTuple) {
+TEST_F(AllGatherDecomposerTest, CrossReplicaAllGatherWithToken) {
   const std::string module_str = R"(
 HloModule module
 
 ENTRY entry {
   param0 = f32[10,20] parameter(0)
   param1 = f32[10,16] parameter(1)
-  ROOT ag = (f32[10,80], f32[10,64], f32[]) all-gather(param0, param1),
+  t = f32[] parameter(2)
+  ROOT ag = (f32[10,80], f32[10,64], f32[]) all-gather(param0, param1, t),
     replica_groups={}, dimensions={1}
 }
 )";
@@ -180,7 +181,8 @@ ENTRY entry {
               op::Multiply(op::ReplicaId(), op::Constant()))),
           op::AllReduce(op::DynamicUpdateSlice(
               op::Broadcast(op::Constant()), op::Parameter(1), op::Constant(),
-              op::Multiply(op::ReplicaId(), op::Constant()))));
+              op::Multiply(op::ReplicaId(), op::Constant()))),
+          op::Parameter(2)));
 }
 
 }  // namespace

--- a/xla/service/all_gather_decomposer_test.cc
+++ b/xla/service/all_gather_decomposer_test.cc
@@ -162,7 +162,7 @@ HloModule module
 ENTRY entry {
   param0 = f32[10,20] parameter(0)
   param1 = f32[10,16] parameter(1)
-  ROOT ag = (f32[10,80], f32[10,64]) all-gather(param0, param1),
+  ROOT ag = (f32[10,80], f32[10,64], f32[]) all-gather(param0, param1),
     replica_groups={}, dimensions={1}
 }
 )";
@@ -180,7 +180,7 @@ ENTRY entry {
               op::Multiply(op::ReplicaId(), op::Constant()))),
           op::AllReduce(op::DynamicUpdateSlice(
               op::Broadcast(op::Constant()), op::Parameter(1), op::Constant(),
-              op::Multiply(op::ReplicaId(), op::Constant())))));
+              op::Multiply(op::ReplicaId(), op::Constant()))));
 }
 
 }  // namespace

--- a/xla/service/hlo_verifier.cc
+++ b/xla/service/hlo_verifier.cc
@@ -441,6 +441,9 @@ static Status CheckCommonAllGatherInvariants(HloInstruction* hlo,
   TF_RET_CHECK(ag->operand_count() >= 1);
 
   int64_t shard_count;
+  // There can be one token in the input Tuple. The token is a scalar or
+  // `token`.
+  bool token_encountered = false;
   for (int64_t i = 0; i < ag->operand_count(); ++i) {
     TF_RET_CHECK(ag->all_gather_dimension() < ag->operand(i)->shape().rank());
 
@@ -528,6 +531,8 @@ Status ShapeVerifier::HandleReduceScatter(HloInstruction* hlo) {
   TF_RET_CHECK(ars->scatter_dimension() >= 0);
   TF_RET_CHECK(ars->operand_count() >= 1);
 
+  // There can be one token in the inputs. The token is a scalar or `token`.
+  bool token_encountered = false;
   for (int64_t i = 0; i < ars->operand_count(); ++i) {
     TF_RET_CHECK(ars->scatter_dimension() < ars->operand(i)->shape().rank());
 

--- a/xla/service/hlo_verifier_test.cc
+++ b/xla/service/hlo_verifier_test.cc
@@ -2392,6 +2392,7 @@ TEST_F(HloVerifierTest, ReduceScatterNonUniformGroups) {
               HasSubstr("Replica groups expected to be of uniform size"));
 }
 
+
 TEST_F(HloVerifierTest, ScatterInvalidScatterDim) {
   const char* const hlo_string = R"(
   HloModule Module
@@ -2418,6 +2419,7 @@ TEST_F(HloVerifierTest, ScatterInvalidScatterDim) {
   EXPECT_THAT(status.message(),
               HasSubstr("Invalid scatter_dims_to_operand_dims mapping"));
 }
+
 
 TEST_F(HloVerifierTest, VerifyBroadcastDimensionsOrder) {
   const char* const hlo = R"(

--- a/xla/service/hlo_verifier_test.cc
+++ b/xla/service/hlo_verifier_test.cc
@@ -2366,7 +2366,7 @@ TEST_F(HloVerifierTest, ReduceScatterInvalidScatterDim) {
   ASSERT_FALSE(status.ok());
   EXPECT_THAT(
       status.message(),
-      HasSubstr("ars->scatter_dimension() < ars->operand(i)->shape().rank()"));
+      HasSubstr("ars->scatter_dimension() < operand_shape.rank()"));
 }
 
 TEST_F(HloVerifierTest, ReduceScatterNonUniformGroups) {
@@ -2420,6 +2420,59 @@ TEST_F(HloVerifierTest, ScatterInvalidScatterDim) {
               HasSubstr("Invalid scatter_dims_to_operand_dims mapping"));
 }
 
+
+TEST_F(HloVerifierTest, ReduceScatterTwoTokens) {
+  const char* const hlo_string = R"(
+  HloModule Module
+  add {
+    lhs = f32[] parameter(0)
+    rhs = f32[] parameter(1)
+    ROOT add = f32[] add(lhs, rhs)
+  }
+
+  ENTRY CRS {
+    input = f32[8]{0} parameter(0)
+    token1 = f32[] parameter(1)
+    token2 = f32[] parameter(2)
+    ROOT crs = (f32[4]{0}, f32[], f32[]) reduce-scatter(input, token1, token2),
+                                         replica_groups={}, to_apply=add,
+                                         dimensions={0}
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnUnverifiedModule(hlo_string));
+
+  auto status = verifier().Run(module.get()).status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(status.message(),
+              HasSubstr("ReduceScatter can have at most 1 token."));
+}
+
+
+
+TEST_F(HloVerifierTest, AllGatherTwoTokens) {
+  const char* const hlo_string = R"(
+  HloModule Module
+  add {
+    lhs = f32[] parameter(0)
+    rhs = f32[] parameter(1)
+    ROOT add = f32[] add(lhs, rhs)
+  }
+
+  ENTRY CRS {
+    input = f32[8]{0} parameter(0)
+    token1 = f32[] parameter(1)
+    token2 = f32[] parameter(2)
+    ROOT crs = (f32[4]{0}, f32[], f32[]) all-gather(input, token1, token2),
+                                         replica_groups={}, dimensions={0}
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnUnverifiedModule(hlo_string));
+
+  auto status = verifier().Run(module.get()).status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(status.message(),
+              HasSubstr("AllGather can have at most 1 token."));
+}
 
 TEST_F(HloVerifierTest, VerifyBroadcastDimensionsOrder) {
   const char* const hlo = R"(

--- a/xla/service/shape_inference.cc
+++ b/xla/service/shape_inference.cc
@@ -2135,7 +2135,16 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
 
   std::vector<Shape> output_shapes;
   output_shapes.reserve(operand_shapes.size());
+  // There can be one token in the input Tuple. The token is a scalar or
+  // `token`.
+  bool token_encountered = false;
   for (const Shape* operand_shape : operand_shapes) {
+    if (operand_shape->IsToken() || operand_shape->rank() == 0) {
+      TF_RET_CHECK(!token_encountered);
+      token_encountered = true;
+      output_shapes.push_back(*operand_shape);
+      continue;
+    }
     TF_RET_CHECK(all_gather_dimension < operand_shape->rank());
     TF_RETURN_IF_ERROR(ExpectArray(*operand_shape, "operand of all-gather"));
 
@@ -2191,7 +2200,16 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
 
   std::vector<Shape> output_shapes;
   output_shapes.reserve(operand_shapes.size());
+  // There can be one token in the input Tuple. The token is a scalar or
+  // `token`.
+  bool token_encountered = false;
   for (const Shape* operand_shape : operand_shapes) {
+    if (operand_shape->IsToken() || operand_shape->rank() == 0) {
+      TF_RET_CHECK(!token_encountered);
+      token_encountered = true;
+      output_shapes.push_back(*operand_shape);
+      continue;
+    }
     TF_RET_CHECK(scatter_dimension < operand_shape->rank());
     TF_RETURN_IF_ERROR(
         ExpectArray(*operand_shape, "operand of reduce-scatter"));


### PR DESCRIPTION
This is a follow up change to https://github.com/openxla/xla/pull/5740 to include token as part of the input/output tuple in all-gather and reduce-scatter. The change helps clean up the interface to be similar to all-reduce and also enable to use to XLA token type. Per https://github.com/openxla/xla/pull/5740#pullrequestreview-1640506684 in the previous PR we have opened RFC discussion on [openxla-discuss](https://groups.google.com/a/openxla.org/g/openxla-discuss/c/bSm78k-iAtg/m/7VPzd_WxAQAJ).