### PR TITLE
[XLA::GPU] Enable stable pointer for input/temp/output buffers

### DIFF
--- a/third_party/tsl/tsl/framework/bfc_allocator.cc
+++ b/third_party/tsl/tsl/framework/bfc_allocator.cc
@@ -683,7 +683,16 @@ void BFCAllocator::SplitChunk(BFCAllocator::ChunkHandle h, size_t num_bytes) {
   InsertFreeChunkIntoBin(h_new_chunk);
 }
 
+void BFCAllocator::FreeExternalAllocation(void* ptr) {
+  sub_allocator_->Free(ptr, GetExternalAllocationSize(ptr));
+}
+
 void BFCAllocator::DeallocateRaw(void* ptr) {
+  // Allocation was made by external allocator, removing tracking pointers.
+  if (IsExternalAllocationAlive(ptr)) {
+    FreeExternalAllocation(ptr);
+    return;
+  }
   VLOG(3) << "DeallocateRaw " << Name() << " "
           << (ptr ? RequestedSize(ptr) : 0);
   VLOG(4) << "[mem-debug] DeallocateRaw," << Name() << ","

--- a/third_party/tsl/tsl/framework/bfc_allocator.h
+++ b/third_party/tsl/tsl/framework/bfc_allocator.h
@@ -107,6 +107,8 @@ class BFCAllocator : public Allocator {
 
   MemoryDump RecordMemoryMap();
 
+void FreeExternalAllocation(void* ptr) override;
+
  private:
   struct Bin;
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -101,6 +101,9 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
   opts.set_xla_gpu_graph_num_runs_to_instantiate(-1);
+  opts.set_xla_gpu_enable_persistent_input_buffers(false);
+  opts.set_xla_gpu_enable_persistent_temp_buffers(false);
+  opts.set_xla_gpu_enable_persistent_output_buffers(false);
   opts.set_xla_gpu_graph_min_graph_size(5);
   opts.set_xla_gpu_graph_enable_concurrent_region(false);
   opts.set_xla_gpu_graph_eviction_timeout_seconds(60);
@@ -1031,6 +1034,38 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "Timeout in seconds to evict instantiated Gpu graphs from device. When "
       "XLA instantiates new Gpu graphs, it evicts graphs that were not "
       "recently executed to free space on device."));
+
+  flag_list->push_back(
+      tsl::Flag("xla_gpu_enable_persistent_input_buffers",
+                bool_setter_for(
+                    &DebugOptions::set_xla_gpu_enable_persistent_temp_buffers),
+                debug_options->xla_gpu_enable_persistent_input_buffers(),
+                "Allocate input buffers once during the first execution of an "
+                "executable. "
+                "Reuse the allocated buffers in subsequent executions. User's "
+                "input buffer will be copied to the persistent input buffers. "
+                "Executables cannot run concurrently if this is enabled."));
+  
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_persistent_temp_buffers",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_enable_persistent_temp_buffers),
+      debug_options->xla_gpu_enable_persistent_temp_buffers(),
+      "Allocate temp buffers once during the first execution of an executable. "
+      "Reuse the allocated buffers in subsequent executions. Executables cannot"
+      " run concurrently if this is enabled."));
+
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_persistent_output_buffers",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_enable_persistent_output_buffers),
+      debug_options->xla_gpu_enable_persistent_output_buffers(),
+      "Allocate output buffers once during the first execution of an "
+      "executable. "
+      "Reuse the allocated buffers in subsequent executions. Executables cannot"
+      " run concurrently if this is enabled. User should make sure that result "
+      "are consumed before re-calling the executable, as output buffer will be "
+      "overwritten"));
 
   flag_list->push_back(
       tsl::Flag("xla_dump_disable_metadata",

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -1038,7 +1038,7 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
   flag_list->push_back(
       tsl::Flag("xla_gpu_enable_persistent_input_buffers",
                 bool_setter_for(
-                    &DebugOptions::set_xla_gpu_enable_persistent_temp_buffers),
+                    &DebugOptions::set_xla_gpu_enable_persistent_input_buffers),
                 debug_options->xla_gpu_enable_persistent_input_buffers(),
                 "Allocate input buffers once during the first execution of an "
                 "executable. "

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -761,6 +761,7 @@ cc_library(
     srcs = ["buffer_allocations.cc"],
     hdrs = ["buffer_allocations.h"],
     deps = [
+        ":gpu_constants",
         "//xla:status",
         "//xla:statusor",
         "//xla:util",
@@ -1092,6 +1093,8 @@ cc_library(
         "//xla/service/gpu/runtime3:custom_call_thunk",
         "//xla/service/gpu/runtime3:fft_thunk",
         "//xla/service/gpu/runtime3:send_recv_thunk",
+        "//xla/service/gpu/runtime3:command_buffer_thunk",
+        "//xla/service/gpu/runtime3:command_buffer_allocations",
         "//xla/stream_executor",
         "//xla/stream_executor:blas",
         "//xla/stream_executor:device_description",

--- a/xla/service/gpu/autotuner_compile_util.cc
+++ b/xla/service/gpu/autotuner_compile_util.cc
@@ -92,6 +92,9 @@ AutotunerCompileUtil::AutotunerCompileUtil(const AutotuneConfig& config,
   // Avoid using GPU graphs as we don't want to measure graph construction time.
   opts_.clear_xla_gpu_enable_command_buffer();
   opts_.set_xla_embed_ir_in_executable(false);
+  opts_.set_xla_gpu_enable_persistent_input_buffers(false);
+  opts_.set_xla_gpu_enable_persistent_temp_buffers(false);
+  opts_.set_xla_gpu_enable_persistent_output_buffers(false);
 }
 
 StatusOr<std::optional<AutotunerCompileUtil::ProfilingOutput>>

--- a/xla/service/gpu/buffer_allocations.h
+++ b/xla/service/gpu/buffer_allocations.h
@@ -142,7 +142,7 @@ class BufferAllocations {
       // const auto& buf = buffers_[i];
       StatusOr<se::DeviceMemoryBase> buf = GetDeviceAddress(i);
       if (buf.ok()) {
-        absl::StrAppendFormat(&out, "Buffer %d -> %p (%d B)", i, buf.value().opaque(),
+        absl::StrAppendFormat(&out, "Buffer %d -> %p (%d B) ", i, buf.value().opaque(),
                               buf.value().size());
       } else {
         absl::StrAppendFormat(&out, "Buffer %d -> ERROR", i);

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -480,6 +480,18 @@ GpuThunkAotCompilationResult::LoadExecutable(
     return std::string();
   };
 
+  bool enable_persistent_input_buffers =
+      hlo_module->config()
+          .debug_options()
+          .xla_gpu_enable_persistent_input_buffers();
+  bool enable_persistent_temp_buffers =
+      hlo_module->config()
+          .debug_options()
+          .xla_gpu_enable_persistent_temp_buffers();
+  bool enable_persistent_output_buffers =
+      hlo_module->config()
+          .debug_options()
+          .xla_gpu_enable_persistent_output_buffers();
   int64_t debug_buffer_assignment_show_max =
       hlo_module->config()
           .debug_options()
@@ -498,6 +510,9 @@ GpuThunkAotCompilationResult::LoadExecutable(
           /*output_shape=*/std::move(output_shape),
           /*mlir_allocations=*/std::nullopt,
           /*buffer_assignment=*/std::move(buffer_assignment),
+          /*enable_persistent_input_buffers=*/enable_persistent_input_buffers,
+          /*enable_persistent_temp_buffers=*/enable_persistent_temp_buffers,
+          /*enable_persistent_output_buffers=*/enable_persistent_output_buffers,
           /*debug_buffer_assignment_show_max=*/debug_buffer_assignment_show_max,
           /*debug_module=*/std::move(hlo_module),
           /*enable_debug_info_manager=*/true}));
@@ -1845,6 +1860,14 @@ StatusOr<std::unique_ptr<Executable>> GpuCompiler::RunBackend(
       module->config().debug_options().xla_embed_ir_in_executable();
   int64_t debug_buffer_assignment_show_max =
       module->config().debug_options().xla_debug_buffer_assignment_show_max();
+  bool enable_persistent_input_buffers =
+      module->config()
+          .debug_options()
+          .xla_gpu_enable_persistent_input_buffers();
+  bool enable_persistent_temp_buffers =
+      module->config().debug_options().xla_gpu_enable_persistent_temp_buffers();
+  bool enable_persistent_output_buffers =
+      module->config().debug_options().xla_gpu_enable_persistent_output_buffers();
 
   TF_ASSIGN_OR_RETURN(
       auto gpu_executable,
@@ -1866,6 +1889,9 @@ StatusOr<std::unique_ptr<Executable>> GpuCompiler::RunBackend(
                : std::move(res.compile_module_results.allocations)),
           /*buffer_assignment=*/
           std::move(res.compile_module_results.buffer_assignment),
+          /*enable_persistent_input_buffers=*/enable_persistent_input_buffers,
+          /*enable_persistent_temp_buffers=*/enable_persistent_temp_buffers,
+          /*enable_persistent_output_buffers=*/enable_persistent_output_buffers,
           /*debug_buffer_assignment_show_max=*/debug_buffer_assignment_show_max,
           /*debug_module=*/options.is_autotuning_compilation
               ? std::unique_ptr<HloModule>()

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -61,7 +61,6 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/device_memory.h"
-#include "xla/stream_executor/gpu/gpu_graph.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/stream.h"

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -488,16 +488,11 @@ StatusOr<se::DeviceMemoryBase> GpuExecutable::BufferForAllocation(
           return registered_buffer;
         }
 
-        // for pass through output buffers, it works even user does not donate
-        // the input, as there is no writes.
-        if (aliased_output->second.passthrough) {
-          return registered_buffer;
-        }
-
         // for must_alias output, not trying to copy parameter buffers if user
         // does not donate it.
         return FailedPrecondition(
-            "Must aliased output buffer, but user does not donate it ");
+            "An input was configured to be must-alias at compile time but not "
+            "donated at runtime:");
       }
 
       if (maybe_owning_memory && maybe_owning_memory->HasOwnership()) {

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -48,7 +48,6 @@ limitations under the License.
 #include "xla/statusor.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/device_memory_allocator.h"
-#include "xla/stream_executor/gpu/gpu_graph.h"
 #include "xla/stream_executor/stream_executor.h"
 
 namespace xla {

--- a/xla/service/gpu/runtime3/BUILD
+++ b/xla/service/gpu/runtime3/BUILD
@@ -23,6 +23,7 @@ cc_library(
     srcs = ["command_buffer_allocations.cc"],
     hdrs = ["command_buffer_allocations.h"],
     deps = [
+        ":command_buffer_thunk",
         "//xla:status",
         "//xla:statusor",
         "//xla/service:buffer_assignment",
@@ -40,7 +41,6 @@ cc_library(
     srcs = ["command_buffer_cmd.cc"],
     hdrs = ["command_buffer_cmd.h"],
     deps = [
-        ":command_buffer_allocations",
         "//xla:status",
         "//xla:types",
         "//xla/service:buffer_assignment",
@@ -148,7 +148,6 @@ cc_library(
     srcs = ["command_buffer_thunk.cc"],
     hdrs = ["command_buffer_thunk.h"],
     deps = [
-        ":command_buffer_allocations",
         ":command_buffer_cmd",
         "//xla:status",
         "//xla:statusor",
@@ -172,12 +171,10 @@ xla_test(
     name = "command_buffer_thunk_test",
     srcs = if_gpu_is_configured(["command_buffer_thunk_test.cc"]),
     backend_tags = {
-        "gpu_a100": ["config-cuda-only"],
-        "gpu_v100": ["config-cuda-only"],
+        "gpu": ["config-cuda-only"],
     },
     backends = [
-        "gpu_a100",
-        "gpu_v100",
+        "gpu",
     ],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [

--- a/xla/service/gpu/runtime3/command_buffer_allocations.cc
+++ b/xla/service/gpu/runtime3/command_buffer_allocations.cc
@@ -21,11 +21,17 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "xla/service/buffer_assignment.h"
+#include "xla/service/gpu/runtime3/command_buffer_cmd.h"
 #include "xla/status.h"
 #include "xla/statusor.h"
 #include "xla/stream_executor/device_memory.h"
 
 namespace xla::gpu {
+
+bool CommandBufferAllocations::IsAllocated(
+    BufferAllocation::Index index) const {
+  return allocs_.find(index) != allocs_.end();
+}
 
 StatusOr<se::DeviceMemoryBase> CommandBufferAllocations::GetDeviceAddress(
     BufferAllocation::Index index) const {
@@ -40,7 +46,8 @@ StatusOr<se::DeviceMemoryBase> CommandBufferAllocations::GetDeviceAddress(
 Status CommandBufferAllocations::AddAllocation(BufferAllocation::Index index,
                                                se::DeviceMemoryBase memory) {
   VLOG(2) << "Add comand buffer allocation: index=" << index
-          << "; ptr=" << memory.opaque();
+          << "; ptr=" << memory.opaque() << " to allocation "
+          << reinterpret_cast<void*>(this);
 
   auto emplaced = allocs_.try_emplace(index, std::move(memory));
   if (emplaced.second == false) {
@@ -60,5 +67,119 @@ Status CommandBufferAllocations::EraseAllocation(
   }
   return OkStatus();
 }
+
+Status CommandBufferAllocations::Allocate(
+    const BufferAllocations& buffer_allocations,
+    const ServiceExecutableRunOptions& run_options) {
+  if (!alloc_thunk_) {
+    VLOG(2)
+        << "Constructing command buffer allocations for buffer_allocations: "
+        << buffer_allocations.ToString();
+
+    // Add allocate command for allocation marked with kExternalAllocationMarker
+    // address.
+    CommandBufferCmdSequence commands;
+    for (BufferAllocation::Index i = 0; i < buffer_allocations.size(); i++) {
+      if (buffer_allocations.IsExternalAllocation(i)) {
+        allocations_map_.emplace(
+            i, BufferAllocation{/*index=*/i,
+                                (int64_t)buffer_allocations.GetAllocationSize(i),
+                                /*color=*/0});
+        commands.Emplace<AllocateCmd>(allocations_map_.at(i));
+        VLOG(2) << "Adding AllocateCmd for allocation: " << i;
+      }
+    }
+
+    // For allocations that are copied from other allocations, add Copy command.
+    if (remapped_allocations_) {
+      for (const auto& item : remapped_allocations_.value()) {
+        BufferAllocation& dst = allocations_map_.at(item.first);
+        BufferAllocation& src = allocations_map_.at(item.second);
+        BufferAllocation::Slice dst_slice(&dst, 0, dst.size());
+        BufferAllocation::Slice src_slice(&src, 0, src.size());
+        commands.Emplace<MemcpyDeviceToDeviceCmd>(dst_slice, src_slice,
+                                                  dst_slice.size());
+        VLOG(2) << "Adding MemcpyDeviceToDeviceCmd from allocation "
+                << src.index() << "to allocation " << dst.index();
+      }
+    }
+
+    if (commands.size() == 0) {
+      return OkStatus();
+    }
+
+    alloc_thunk_ = std::move(std::make_unique<CommandBufferThunk>(
+        std::move(commands), Thunk::ThunkInfo(nullptr)));
+  }
+
+  TF_RETURN_IF_ERROR(
+      buffer_allocations.GetMutableExternalAllocations()->Clear());
+
+  VLOG(2) << "Allocating through command buffer for "
+          << buffer_allocations.ToString();
+  Thunk::ExecuteParams params(run_options, buffer_allocations,
+                              run_options.stream(), nullptr, {});
+  TF_RETURN_IF_ERROR(alloc_thunk_->ExecuteOnStream(params));
+
+  se::DeviceMemoryAllocator* const memory_allocator = run_options.allocator();
+  int device_ordinal = run_options.stream()->parent()->device_ordinal();
+ 
+  for (auto item : allocs_) {
+    TF_RETURN_IF_ERROR(
+        memory_allocator->NotifyExternalAllocate(device_ordinal, item.second));
+  }
+
+  TF_RETURN_IF_ERROR(run_options.stream()->BlockHostUntilDone());
+  VLOG(2) << "Allocating results: " << buffer_allocations.ToString()
+          << " External allocation size " << Size();
+  return OkStatus();
+}
+
+Status CommandBufferAllocations::Free(const BufferAllocations& buffer_allocations,
+            const absl::flat_hash_set<BufferAllocation::Index>& live_allocation_indexes,
+            const ServiceExecutableRunOptions& run_options) {
+  se::DeviceMemoryAllocator* const memory_allocator = run_options.allocator();
+  int device_ordinal = run_options.stream()->parent()->device_ordinal();
+
+  // Notify memory allocator the release of external allocation.
+  for (BufferAllocation::Index i = 0; i < buffer_allocations.size(); i++) {
+    if (buffer_allocations.IsExternalAllocation(i) &&
+        !live_allocation_indexes.contains(i)) {
+      TF_RETURN_IF_ERROR(
+          memory_allocator->NotifyExternalFree(device_ordinal, allocs_.at(i)));
+    }
+  }
+
+  if (!free_thunk_) {
+    CommandBufferCmdSequence commands;
+    for (BufferAllocation::Index i = 0; i < buffer_allocations.size(); i++) {
+      // Only allocations that are allocated through command buffer are assumed
+      // to be freed here.
+      if (buffer_allocations.IsExternalAllocation(i) &&
+          !live_allocation_indexes.contains(i)) {
+        CHECK(allocations_map_.find(i) != allocations_map_.end())
+            << "CommandBuffer freed region " << i << " is not allocated yet";
+        commands.Emplace<FreeCmd>(allocations_map_.at(i));
+        VLOG(2) << "Adding FreeCmd for allocation: " << i;
+      }
+    }
+
+    if (commands.size() == 0) {
+      return OkStatus();
+    }
+
+    VLOG(2) << "Constructing command buffer free for buffer_allocations: "
+            << buffer_allocations.ToString();
+    free_thunk_ = std::move(std::make_unique<CommandBufferThunk>(
+        std::move(commands), Thunk::ThunkInfo(nullptr)));
+  }
+
+  Thunk::ExecuteParams params(run_options, buffer_allocations,
+                              run_options.stream(), nullptr, {});
+  TF_RETURN_IF_ERROR(free_thunk_->ExecuteOnStream(params));
+  TF_RETURN_IF_ERROR(run_options.stream()->BlockHostUntilDone());
+  return OkStatus();
+}
+
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/runtime3/command_buffer_allocations.h
+++ b/xla/service/gpu/runtime3/command_buffer_allocations.h
@@ -16,9 +16,12 @@ limitations under the License.
 #ifndef XLA_SERVICE_GPU_RUNTIME3_COMMAND_BUFFER_ALLOCATIONS_H_
 #define XLA_SERVICE_GPU_RUNTIME3_COMMAND_BUFFER_ALLOCATIONS_H_
 
+#include <sys/types.h>
 #include "absl/container/flat_hash_map.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
+#include "xla/service/gpu/runtime3/command_buffer_thunk.h"
+#include "xla/service/service_executable_run_options.h"
 #include "xla/status.h"
 #include "xla/statusor.h"
 #include "xla/stream_executor/device_memory.h"
@@ -30,6 +33,12 @@ namespace xla::gpu {
 // buffers and memory allocation Gpu graph nodes).
 class CommandBufferAllocations : public BufferAllocations::ExternalAllocations {
  public:
+
+  // key is the allocation index where it has remapped (copied), and the value
+  // is the index where we put the original allocation in the buffers_ list.
+  using RemappedAllocations =
+      std::map<BufferAllocation::Index, BufferAllocation::Index>;
+
   StatusOr<se::DeviceMemoryBase> GetDeviceAddress(
       BufferAllocation::Index index) const override;
 
@@ -38,12 +47,57 @@ class CommandBufferAllocations : public BufferAllocations::ExternalAllocations {
   Status AddAllocation(BufferAllocation::Index index,
                        se::DeviceMemoryBase memory) override;
 
+  bool IsAllocated(BufferAllocation::Index index) const override;
+
   // Erases an external allocation for a given buffer index. Returns error if
   // allocation does not exists.
   Status EraseAllocation(BufferAllocation::Index index) override;
 
+  // Given a BufferAllocation object filled with external allocation marker,
+  // this function constructs the command buffer thunk to do the allocation.
+  Status Allocate(const BufferAllocations& buffer_allocations,
+                  const ServiceExecutableRunOptions& run_options);
+
+  // Free the allocations that was previously allocated with command buffer
+  // thunk, keep the allocations in set `live_allocation_indexes`.
+  Status Free(const BufferAllocations& buffer_allocations,
+              const absl::flat_hash_set<BufferAllocation::Index>&
+                  live_allocation_indexes,
+              const ServiceExecutableRunOptions& run_optionsconst);
+
+  // Clear all previous allocations.
+  Status Clear() override {
+    allocs_.clear();
+    return OkStatus();
+  };
+
+  // When running a module through GpuExecutable::ExecuteAsyncOnStreamImpl,
+  // there are cases that we need to copy the parameter allocation into a new
+  // allocation(e.g. the XLA module was compiled with input/output buffer
+  // alised, but the user does not donate the input buffer, or we want to copy
+  // the parameter allocation to some fix memory address to get stable input
+  // memory pointer). To enable copying between original parameter allocation
+  // and copied allocation through command buffer, we need to include both
+  // the original and copied allocations in the BufferAllocations list.
+
+  // The original allocation's address is added to the end of BufferAllocations,
+  // and the copied allocation takes the index of the original allocation.
+  // RemappedAllocations describes where the copied allocation is copied from
+  // which allocation in the BufferAllocations.
+  void SetRemappedAllocations(const RemappedAllocations& remapped_allocation) {
+    remapped_allocations_ = remapped_allocation;
+  };
+
+  uint Size() {
+    return allocs_.size();
+  };
+
  private:
   absl::flat_hash_map<BufferAllocation::Index, se::DeviceMemoryBase> allocs_;
+  std::unique_ptr<CommandBufferThunk> alloc_thunk_;
+  std::unique_ptr<CommandBufferThunk> free_thunk_;
+  std::optional<RemappedAllocations> remapped_allocations_ = std::nullopt;
+  absl::flat_hash_map<BufferAllocation::Index, BufferAllocation> allocations_map_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/runtime3/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime3/command_buffer_cmd.cc
@@ -636,7 +636,10 @@ Status AllocateCmd::Record(const RecordParams& params,
                                                           buffer);
 }
 
-CommandBufferCmd::BufferUsageVector AllocateCmd::buffers() { return {}; }
+CommandBufferCmd::BufferUsageVector AllocateCmd::buffers() {
+  return {{BufferAllocation::Slice{&allocation_, 0, allocation_.size()},
+           MemoryAccess::kWrite}};
+}
 
 //===----------------------------------------------------------------------===//
 // FreeCmd
@@ -659,7 +662,10 @@ Status FreeCmd::Record(const RecordParams& params,
       allocation_.index());
 }
 
-CommandBufferCmd::BufferUsageVector FreeCmd::buffers() { return {}; }
+CommandBufferCmd::BufferUsageVector FreeCmd::buffers() {
+  return {{BufferAllocation::Slice{&allocation_, 0, allocation_.size()},
+          MemoryAccess::kWrite}};
+}
 
 //===----------------------------------------------------------------------===//
 // GemmCmd

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -55,6 +55,10 @@ class CommandBuffer {
  public:
   // Builder constructs nested command buffers owned by a parent command buffer.
   using Builder = std::function<tsl::Status(CommandBuffer*)>;
+  struct AllocIndexSize {
+    int64_t index;
+    uint64_t size;
+  };
 
   ~CommandBuffer();
   CommandBuffer(CommandBuffer&&);

--- a/xla/stream_executor/cuda/cuda_driver.cc
+++ b/xla/stream_executor/cuda/cuda_driver.cc
@@ -849,7 +849,7 @@ GpuDriver::GraphAddNode(CUgraphNode* node, CUgraph graph,
 }
 
 /* static */ tsl::Status GpuDriver::GraphAddKernelNode(
-    CUgraphNode* node, CUgraph graph, absl::Span<CUgraphNode> deps,
+    CUgraphNode* node, CUgraph graph, absl::Span<GpuGraphNodeHandle> deps,
     absl::string_view kernel_name, CUfunction function, unsigned int grid_dim_x,
     unsigned int grid_dim_y, unsigned int grid_dim_z, unsigned int block_dim_x,
     unsigned int block_dim_y, unsigned int block_dim_z,
@@ -892,6 +892,7 @@ GpuDriver::GraphAddNode(CUgraphNode* node, CUgraph graph,
 
   return ::tsl::OkStatus();
 }
+
 
 /*static*/ tsl::Status GpuDriver::GraphExecKernelNodeSetParams(
     CUgraphExec exec, CUgraphNode node, absl::string_view kernel_name,
@@ -1043,7 +1044,7 @@ GpuDriver::GraphGetMemAllocNodeParams(CUgraphNode node) {
 
 /* static */ tsl::Status GpuDriver::GraphAddMemcpyD2DNode(
     GpuContext* context, CUgraphNode* node, CUgraph graph,
-    absl::Span<CUgraphNode> deps, CUdeviceptr gpu_dst, CUdeviceptr gpu_src,
+    absl::Span<GpuGraphNodeHandle> deps, CUdeviceptr gpu_dst, CUdeviceptr gpu_src,
     uint64_t size) {
   VLOG(2) << "Add memcpy d2d node to a graph " << graph
           << "; dst: " << reinterpret_cast<void*>(gpu_dst)
@@ -1188,7 +1189,7 @@ struct BitPatternToValue {
 }
 
 /* static */ tsl::Status GpuDriver::GraphAddChildNode(
-    CUgraphNode* node, CUgraph graph, absl::Span<CUgraphNode> deps,
+    CUgraphNode* node, CUgraph graph, absl::Span<GpuGraphNodeHandle> deps,
     CUgraph child) {
   VLOG(2) << "Create a new node by cloning the child graph " << child
           << " and add it to " << graph << "; deps: " << deps.size();
@@ -2101,6 +2102,8 @@ GpuDriver::CreateMemoryHandle(GpuContext* context, uint64_t bytes) {
                                                    CUstream stream) {
   ScopedActivateContext activation(context);
   CUresult result;
+  VLOG(2) << "AsynchronousMemcpyD2D dst: " << reinterpret_cast<void*>(gpu_dst)
+          << " src " << reinterpret_cast<void*>(gpu_src);
 
   // In graph capture mode we never have operations that access peer memory, so
   // we can always make a call to cuMemcpyDtoDAsync.

--- a/xla/stream_executor/cuda/cuda_driver.cc
+++ b/xla/stream_executor/cuda/cuda_driver.cc
@@ -849,7 +849,7 @@ GpuDriver::GraphAddNode(CUgraphNode* node, CUgraph graph,
 }
 
 /* static */ tsl::Status GpuDriver::GraphAddKernelNode(
-    CUgraphNode* node, CUgraph graph, absl::Span<GpuGraphNodeHandle> deps,
+    CUgraphNode* node, CUgraph graph, absl::Span<CUgraphNode> deps,
     absl::string_view kernel_name, CUfunction function, unsigned int grid_dim_x,
     unsigned int grid_dim_y, unsigned int grid_dim_z, unsigned int block_dim_x,
     unsigned int block_dim_y, unsigned int block_dim_z,

--- a/xla/stream_executor/device_memory.h
+++ b/xla/stream_executor/device_memory.h
@@ -78,6 +78,11 @@ class DeviceMemoryBase {
   void *opaque() { return opaque_; }
   const void *opaque() const { return opaque_; }
 
+  // This function is called when memory allocation is not ready when the object
+  // is constructed, e.g, the memory allocation node in GPU cuda-graph is
+  // available when the after memory allocation node is added to the graph.
+  void SetOpaque(void *dptr) { opaque_ = dptr; }
+
   // Returns the payload of this memory region.
   uint64_t payload() const { return payload_; }
 
@@ -101,6 +106,12 @@ class DeviceMemoryBase {
 
     return DeviceMemoryBase(
         reinterpret_cast<std::byte *>(opaque_) + offset_bytes, size_bytes);
+  }
+
+  std::string ToString() const {
+    std::string out;
+    absl::StrAppendFormat(&out, "(Addr: %p, ByteSize: %d)", opaque_, size_);
+    return out;
   }
 
  protected:

--- a/xla/stream_executor/device_memory_allocator.h
+++ b/xla/stream_executor/device_memory_allocator.h
@@ -213,6 +213,17 @@ class DeviceMemoryAllocator {
   // TODO(cheshire): Add deprecation notice.
   virtual tsl::Status Deallocate(int device_ordinal, DeviceMemoryBase mem) = 0;
 
+  virtual tsl::Status NotifyExternalAllocate(int device_ordinal,
+                                             DeviceMemoryBase mem) {}
+
+  virtual tsl::Status NotifyExternalFree(int device_ordinal,
+                                         DeviceMemoryBase mem) {}
+
+  virtual tsl::StatusOr<bool> IsExternalAllocationAlive(int device_ordinal,
+                                                       DeviceMemoryBase mem) {
+    return false;
+  }
+
   // Return the platform that the allocator allocates memory on.
   const Platform *platform() const { return platform_; }
 

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -241,6 +241,9 @@ class GpuCommandBuffer : public internal::CommandBufferInterface {
   tsl::Status CheckNumCommandBuffers(
       const ConditionalCommandBuffers& cmd_buffers, size_t num_cmd_buffers);
 
+  // Keep tracks of allocations that is performed by allocation command.
+  absl::flat_hash_map<int64_t, DeviceMemoryBase> allocations_map_;
+
   static_assert(std::is_pointer_v<GpuGraphHandle>,
                 "GpuGraphHandle must be a pointer");
   static_assert(std::is_pointer_v<GpuGraphExecHandle>,

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
@@ -340,6 +340,12 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
 }
 void GpuCudaMallocAsyncAllocator::DeallocateRaw(void* ptr) {
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
+  // Allocation was made by external allocator, removing tracking pointers.
+  if (IsExternalAllocationAlive(ptr)) {
+    FreeExternalAllocation(ptr);
+    return;
+  }
+  
   if (ptr == nullptr) return;
   // The lock is only needed when stats are enabled, but it must be around
   // the cuMemFreeAsync call as well to ensure consistency of the stats update.

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
@@ -77,8 +77,10 @@ class GpuCudaMallocAsyncAllocator : public tsl::Allocator {
   void DeallocateRaw(void* ptr) override ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
   void FreeExternalAllocation(void* ptr) override {
+#if TF_CUDA_MALLOC_ASYNC_SUPPORTED
     NotifyExternalFree(ptr);
     cuMemFree(reinterpret_cast<const CUdeviceptr&>(ptr));
+#endif
   }
 
   bool TracksAllocationSizes() const override;

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
@@ -76,6 +76,11 @@ class GpuCudaMallocAsyncAllocator : public tsl::Allocator {
                     size_t num_bytes) override ABSL_NO_THREAD_SAFETY_ANALYSIS;
   void DeallocateRaw(void* ptr) override ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
+  void FreeExternalAllocation(void* ptr) override {
+    NotifyExternalFree(ptr);
+    cuMemFree(reinterpret_cast<const CUdeviceptr&>(ptr));
+  }
+
   bool TracksAllocationSizes() const override;
 
   size_t RequestedSize(const void* ptr) const override;

--- a/xla/stream_executor/gpu/gpu_types.h
+++ b/xla/stream_executor/gpu/gpu_types.h
@@ -18,6 +18,7 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_GPU_GPU_TYPES_H_
 #define XLA_STREAM_EXECUTOR_GPU_GPU_TYPES_H_
 
+#include "absl/container/inlined_vector.h"
 #if TENSORFLOW_USE_ROCM
 
 #define __HIP_DISABLE_CPP_FUNCTIONS__

--- a/xla/stream_executor/host/host_gpu_executor.cc
+++ b/xla/stream_executor/host/host_gpu_executor.cc
@@ -45,6 +45,7 @@ HostStream* AsHostStream(Stream* stream) {
 
 tsl::Status HostExecutor::Init(int device_ordinal,
                                DeviceOptions device_options) {
+  device_ordinal_ = device_ordinal;
   auto it =
       device_options.non_portable_tags.find("host_thread_stack_size_in_bytes");
   if (it != device_options.non_portable_tags.end()) {

--- a/xla/stream_executor/host/host_gpu_executor.h
+++ b/xla/stream_executor/host/host_gpu_executor.h
@@ -59,6 +59,7 @@ class HostExecutor : public internal::StreamExecutorInterface {
     return tsl::errors::Unimplemented("Not Implemented");
   }
 
+  int device_ordinal() const override { return device_ordinal_; };
   DeviceMemoryBase Allocate(uint64_t size, int64_t memory_space) override;
   void Deallocate(DeviceMemoryBase* mem) override;
 
@@ -150,6 +151,10 @@ class HostExecutor : public internal::StreamExecutorInterface {
   std::unique_ptr<internal::StreamInterface> GetStreamImplementation() override;
 
  private:
+  // The device ordinal value that this executor was initialized with; recorded
+  // for use in getting device metadata. Immutable post-initialization.
+  int device_ordinal_;
+
   // Size of thread stacks for streams in bytes. '0' means "the default size".
   size_t thread_stack_size_in_bytes_ = 0;
 };

--- a/xla/stream_executor/integrations/tf_allocator_adapter.cc
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.cc
@@ -58,6 +58,23 @@ tsl::Status TfAllocatorAdapter::Deallocate(int device_ordinal,
   return ::tsl::OkStatus();
 }
 
+tsl::Status TfAllocatorAdapter::NotifyExternalAllocate(int device_ordinal,
+                                                       DeviceMemoryBase mem) {
+  wrapped_->NotifyExternalAllocate(mem.opaque(), mem.size());
+  return ::tsl::OkStatus();
+}
+
+tsl::Status TfAllocatorAdapter::NotifyExternalFree(int device_ordinal,
+                                                   DeviceMemoryBase mem) {
+  wrapped_->NotifyExternalFree(mem.opaque());
+  return ::tsl::OkStatus();
+}
+
+tsl::StatusOr<bool> TfAllocatorAdapter::IsExternalAllocationAlive(
+    int device_ordinal, DeviceMemoryBase mem) {
+  return wrapped_->IsExternalAllocationAlive(mem.opaque());
+}
+
 tsl::StatusOr<Stream *> TfAllocatorAdapter::GetStream(int device_ordinal) {
   CHECK_EQ(stream_->parent()->device_ordinal(), device_ordinal);
   return stream_;

--- a/xla/stream_executor/integrations/tf_allocator_adapter.h
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.h
@@ -52,6 +52,11 @@ class TfAllocatorAdapter : public DeviceMemoryAllocator {
 
   tsl::Status Deallocate(int device_ordinal, DeviceMemoryBase mem) override;
 
+  tsl::Status NotifyExternalAllocate(int device_ordinal, DeviceMemoryBase mem) override;
+  tsl::Status NotifyExternalFree(int device_ordinal, DeviceMemoryBase mem) override;
+  tsl::StatusOr<bool> IsExternalAllocationAlive(int device_ordinal,
+                                               DeviceMemoryBase mem) override;
+
   // The Tensorflow BFC allocator used on GPU allows host-side deallocation
   // before GPU execution takes place. Tensorflow uses the ordering of the main
   // compute stream to enforce a happens-before relationship between a memory
@@ -125,6 +130,25 @@ class MultiDeviceAdapter : public DeviceMemoryAllocator {
     CHECK_LT(device_ordinal, per_device_allocators_.size());
     return per_device_allocators_[device_ordinal]->Deallocate(device_ordinal,
                                                               mem);
+  }
+
+  tsl::Status NotifyExternalAllocate(int device_ordinal, DeviceMemoryBase mem) {
+    CHECK_LT(device_ordinal, per_device_allocators_.size());
+    return per_device_allocators_[device_ordinal]->NotifyExternalAllocate(
+        device_ordinal, mem);
+  }
+
+  tsl::Status NotifyExternalFree(int device_ordinal, DeviceMemoryBase mem) {
+    CHECK_LT(device_ordinal, per_device_allocators_.size());
+    return per_device_allocators_[device_ordinal]->NotifyExternalFree(
+        device_ordinal, mem);
+  }
+
+  tsl::StatusOr<bool> IsExternalAllocationAlive(int device_ordinal,
+                                               DeviceMemoryBase mem) {
+    CHECK_LT(device_ordinal, per_device_allocators_.size());
+    return per_device_allocators_[device_ordinal]->IsExternalAllocationAlive(
+        device_ordinal, mem);
   }
 
   // The Tensorflow BFC allocator used on GPU allows host-side deallocation

--- a/xla/stream_executor/tpu/tpu_executor.cc
+++ b/xla/stream_executor/tpu/tpu_executor.cc
@@ -52,6 +52,7 @@ TpuExecutor::~TpuExecutor() { ExecutorApiFn()->TpuExecutor_FreeFn(executor_); }
 
 Status TpuExecutor::Init(int device_ordinal,
                          ::stream_executor::DeviceOptions device_options) {
+  device_ordinal_ = device_ordinal;
   StatusHelper status;
   SE_DeviceOptions* options =
       ExecutorApiFn()->TpuExecutor_NewDeviceOptionsFn(device_options.flags());

--- a/xla/stream_executor/tpu/tpu_executor.h
+++ b/xla/stream_executor/tpu/tpu_executor.h
@@ -68,6 +68,7 @@ class TpuExecutor : public tensorflow::tpu::TpuExecutorInterface {
   tsl::Status Init(int device_ordinal,
                    ::stream_executor::DeviceOptions device_options) override;
 
+  int device_ordinal() const override { return device_ordinal_; };
   DeviceMemoryBase Allocate(uint64_t size, int64_t memory_space) override;
 
   tsl::Status AllocateEvent(Event* event) override;
@@ -222,7 +223,7 @@ class TpuExecutor : public tensorflow::tpu::TpuExecutorInterface {
     absl::MutexLock m(&tpu_platform().mutex());
     return stream_map()[ptr];
   }
-
+  int device_ordinal_;
   tensorflow::tpu::TpuPlatformInterface* platform_;
   SE_StreamExecutor* executor_;
 };

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -491,6 +491,23 @@ message DebugOptions {
   // executed to free space on device.
   int32 xla_gpu_graph_eviction_timeout_seconds = 230;
 
+  // Allocate input buffers once during the first execution of an executable.
+  // Reuse the allocated buffers in subsequent executions. User's input 
+  //buffer will be copied to the allocations on each iteration. 
+  // Executables cannot run concurrently if this is enabled.
+  bool xla_gpu_enable_persistent_input_buffers = 340;
+
+  // Allocate temp buffers once during the first execution of an executable.
+  // Reuse the allocated buffers in subsequent executions. Executables cannot
+  // run concurrently if this is enabled.
+  bool xla_gpu_enable_persistent_temp_buffers = 280;
+
+  // Allocate output buffers once during the first execution of an 
+  // executable. Reuse the allocated buffers in subsequent executions. Executables 
+  // cannot run concurrently if this is enabled. User should make sure that result 
+  // are consumed before re-calling the executable, as output buffer will be overwritten.
+  bool xla_gpu_enable_persistent_output_buffers = 300;
+
   // Size threshold (in megabytes) for the GPU redzone scratch allocator.
   int64 xla_gpu_redzone_scratch_max_megabytes = 167;
 


### PR DESCRIPTION
This PR enables allocating HLOModule's input/output/temp buffer with stable pointer, so be good to cuda-graph performance (With stable pointer, cuda-graph relaunching does not incur the `update` costs ).  

The implementation doc of this PR is: https://docs.google.com/document/d/1iLADZww73DPyMvyr462zzcqEWcGwQ_lBDVza4aaoj-s/edit 

This PR create 3 flags, which can enable stable pointer separately for input/output/temp buffers.

`enable_persisitent_input_buffer`:  this will trigger a copy of user’s input buffer to the allocation that has stable pointer;
`enable_persistent_temp_buffer` : use cuda-graph to do the allocation, the VA range will be reserved across iterations, but physical memory will be freed
`enable_persistent_output_buffer`:  (This implies that the output buffer will be overwritten during the next iteration, user should aware of these when turning on this option)

All these options will be defaulting disabled, the fully functional/perf tested is required before enabling them by default. 
 