### PR TITLE
CPU offloading for GPUs: generate memcpy D2H/H2D

### DIFF
--- a/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -331,6 +331,24 @@ def LHLOGPU_AllToAllDoneOp: LHLOGPU_Op<"all_to_all_done"> {
   let arguments = (ins MHLO_Token:$token);
 }
 
+def LHLOGPU_CopyStartOp : LHLOGPU_Op<"copy_start"> {
+  let summary = "CopyStart operator";
+  let description = [{
+     Performs memory copies followed by a copy_done instruction.
+  }];
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$input,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output,
+    I64Attr:$memory_space);
+  let results = (outs MHLO_Token:$token);
+}
+
+def LHLOGPU_CopyDoneOp : LHLOGPU_Op<"copy_done"> {
+  let summary = "CopyDone operator";
+  let arguments = (ins MHLO_Token:$token);
+}
+
+
 def LHLOGPU_CudnnNormOp : LHLOGPU_Op<"Norm", [AttrSizedOperandSegments]> {
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$x,

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -104,6 +104,7 @@ limitations under the License.
 #include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/statusor.h"
 #include "xla/stream_executor/integrations/tf_allocator_adapter.h"
+#include "xla/stream_executor/integrations/device_mem_allocator.h"
 #include "xla/util.h"
 
 namespace xla {
@@ -849,6 +850,16 @@ GetStreamExecutorGpuDeviceAllocator(
                             ordinal_and_device.second->compute_stream(),
                             /*memory_space=*/1);
   }
+
+  for (const auto& ordinal_and_device : addressable_devices) {
+    auto host_allocator =
+        GetGpuHostAllocator(ordinal_and_device.second->executor());
+    allocators.emplace_back(std::move(host_allocator),
+                            ordinal_and_device.second->compute_stream(),
+                            /*memory_space=*/
+                               static_cast<int>(se::MemoryType::kHost));
+  }
+
   return std::make_unique<se::MultiDeviceAdapter>(platform,
                                                   std::move(allocators));
 }

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3682,8 +3682,8 @@ xla_cc_test(
     deps = [
         ":horizontal_loop_fusion",
         ":metrics",
-       "//xla/hlo/utils:hlo_matchers",
-       "//xla/service:hlo_rematerialization_test_utils",
+        "//xla/hlo/utils:hlo_matchers",
+        "//xla/service:hlo_rematerialization_test_utils",
         "//xla:autotune_results_proto_cc",
         "//xla/service:gpu_plugin",
         "//xla/service:pattern_matcher",
@@ -3696,6 +3696,12 @@ xla_cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/lib/core:status_test_util",
+        "//xla/hlo/ir:hlo",
+        "//xla:shape_util",
+        "//xla/service:hlo_cost_analysis",
+        "//xla/service:hlo_memory_scheduler",
+        "//xla:util",
+        "@tsl//tsl/platform:statusor",
     ],
 )
 

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -387,6 +387,7 @@ cc_library(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:launch_dim",
         "//xla/stream_executor/gpu:gpu_blas_lt",
+        "//xla/stream_executor/integrations:device_mem_allocator",
         "//xla/translate/hlo_to_mhlo:hlo_utils",
         "//xla/translate/mhlo_to_hlo:attribute_exporter",
         "//xla/translate/mhlo_to_hlo:location_exporter",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3676,6 +3676,31 @@ xla_test(
 )
 
 xla_cc_test(
+    name = "gpu_offloading_test",
+    srcs = ["gpu_offloading_test.cc"],
+    tags = tf_cuda_tests_tags(),
+    deps = [
+        ":horizontal_loop_fusion",
+        ":metrics",
+       "//xla/hlo/utils:hlo_matchers",
+       "//xla/service:hlo_rematerialization_test_utils",
+        "//xla:autotune_results_proto_cc",
+        "//xla/service:gpu_plugin",
+        "//xla/service:pattern_matcher",
+        "//xla/service:pattern_matcher_gmock",
+        "//xla/service:xla_debug_info_manager",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/base:log_severity",
+        "@com_google_absl//absl/log:scoped_mock_log",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+        "@tsl//tsl/lib/core:status_test_util",
+    ],
+)
+
+
+xla_cc_test(
     name = "auto_sharding_gpu_compiler_test",
     srcs = ["auto_sharding_gpu_compiler_test.cc"],
     tags = tf_cuda_tests_tags() + ["no_oss"],  # TODO(b/277355322): Make autosharding work in OSS

--- a/xla/service/gpu/gpu_offloading_test.cc
+++ b/xla/service/gpu/gpu_offloading_test.cc
@@ -1,0 +1,220 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/hlo_rematerialization.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/base/log_severity.h"
+#include "absl/log/scoped_mock_log.h"
+#include "absl/strings/string_view.h"
+#include "xla/autotune_results.pb.h"
+#include "xla/service/gpu/horizontal_loop_fusion.h"
+#include "xla/service/gpu/metrics.h"
+#include "xla/service/pattern_matcher.h"
+#include "xla/service/pattern_matcher_gmock.h"
+#include "xla/service/xla_debug_info_manager.h"
+#include "xla/tests/hlo_test_base.h"
+#include "tsl/lib/core/status_test_util.h"
+
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_matchers.h"
+#include "xla/layout.h"
+#include "xla/service/hlo_cost_analysis.h"
+#include "xla/service/hlo_memory_scheduler.h"
+#include "xla/service/hlo_rematerialization_test_utils.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/util.h"
+#include "tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+namespace m = ::xla::match;
+namespace op = xla::testing::opcode_matchers;
+
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::TempDir;
+
+class GpuCompilerTest : public HloTestBase {
+ public:
+  StatusOr<std::unique_ptr<BufferAssignment>> AssignBuffers(HloModule* module) {
+    auto compiler = backend().compiler();
+    return compiler->AssignBuffers(module, backend().default_stream_executor());
+  }
+ protected:
+  StatusOr<bool> RunHloRematerialization(int64_t memory_limit_bytes,
+                                         HloModule* module,
+                                         int64_t min_remat_size = 0) {
+    TF_EXPECT_OK(verifier().Run(module).status());
+    if (!module->has_schedule()) {
+      HloMemoryScheduler scheduler(
+          [](const BufferValue& buffer) {
+	    return ::xla::ShapeUtil::ByteSizeOf(buffer.shape());
+	  },
+          ComputationSchedulerToModuleScheduler(DefaultMemoryScheduler));
+      TF_EXPECT_OK(scheduler.Run(module).status());
+    }
+    // Create a configuration where any compute is much much slower than any
+    // number of number of copies.
+    HloCostAnalysis::Options hlo_cost_analysis_options;
+    hlo_cost_analysis_options.shape_size = [](const Shape& shape) {
+      return ::xla::ShapeUtil::ByteSizeOf(shape);
+    };
+    hlo_cost_analysis_options.set_flops_per_second(flops_per_second_);
+    hlo_cost_analysis_options.set_transcendentals_per_second(
+        transcendentals_per_second_);
+    HloCostAnalysis cost_analysis(hlo_cost_analysis_options);
+    HloRematerialization::RematerializationModeConfig config(
+        /*recompute=*/false, /*compress=*/false, /*host_offload=*/true);
+    HloRematerialization::HostMemoryOffloadConfig host_memory_offload_config(
+        kHostMemorySpaceColor, copy_to_host_speed_, copy_from_host_speed_);
+    HloRematerialization::Options options(
+        cost_analysis, config, memory_limit_bytes,
+        /*block_size_limit=*/1, /*block_rematerialization_factor=*/1,
+        min_remat_size, /*compact_shape_function=*/nullptr,
+        host_memory_offload_config);
+    HloRematerialization::RematerializationSizes sizes;
+    HloRematerialization remat(options, sizes);
+    return remat.Run(module);
+  }
+  void SetCopyToHostSpeed(float val) { copy_to_host_speed_ = val; }
+  void SetCopyFromHostSpeed(float val) { copy_from_host_speed_ = val; }
+  void SetFlopsPerSecond(float val) { flops_per_second_ = val; }
+  void SetTranscendentalsPerSecond(float val) {
+    transcendentals_per_second_ = val;
+  }
+
+  static constexpr const int64_t kHostMemorySpaceColor{5};
+
+ private:
+  float copy_to_host_speed_{1.0f};
+  float copy_from_host_speed_{1.0f};
+  float flops_per_second_{1.0f};
+  float transcendentals_per_second_{1.0f};
+};
+
+TEST_F(GpuCompilerTest, OriginalTest) {
+  const char* hlo_text = R"(
+  HloModule test
+
+ENTRY %main (param_0: f32[1024], param_1: f32[1024]) -> f32[1024] {
+  %param_1 = f32[1024]{0} parameter(1)
+  %param_0 = f32[1024]{0} parameter(0)
+  %res_3 = f32[1024]{0} add(f32[1024]{0} %param_0, f32[1024]{0} %param_1)
+  %copy-start = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_3)
+  %res_4 = f32[1024]{0} tanh(f32[1024]{0} %res_3)
+  %copy-start.2 = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_4)
+  %res_5 = f32[1024]{0} tanh(f32[1024]{0} %res_4)
+  %copy-done = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start)
+  %res_6 = f32[1024]{0} tanh(f32[1024]{0} %res_5)
+  %copy-done.2 = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start.2)
+  %copy-start.3 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done.2)
+  %res_7 = f32[1024]{0} add(f32[1024]{0} %res_6, f32[1024]{0} %res_6)
+  %copy-start.1 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done)
+  %res_8 = f32[1024]{0} add(f32[1024]{0} %res_7, f32[1024]{0} %res_5)
+  %copy-done.3 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.3)
+  %res_9 = f32[1024]{0} add(f32[1024]{0} %res_8, f32[1024]{0} %copy-done.3)
+  %copy-done.1 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.1)
+  %res_10 = f32[1024]{0} add(f32[1024]{0} %res_9, f32[1024]{0} %copy-done.1)
+  ROOT %res_11 = f32[1024]{0} tanh(f32[1024]{0} %res_10)
+}
+)";
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{/*aabs=*/1e-6, /*arel=*/1e-6}));
+
+}
+
+TEST_F(GpuCompilerTest, CompiledProgramsCount) {
+  const char* hlo_text = R"(
+  HloModule test
+
+  ENTRY main {
+    param_0 = f32[1024]{0} parameter(0)
+    param_1 = f32[1024]{0} parameter(1)
+    res_3 = f32[1024]{0} add(param_0, param_1)
+    res_4 = f32[1024]{0} tanh(res_3)
+    res_5 = f32[1024]{0} tanh(res_4)
+    res_6 = f32[1024]{0} tanh(res_5)
+    res_7 = f32[1024]{0} add(res_6, res_6)
+    res_8 = f32[1024]{0} add(res_7, res_5)
+    res_9 = f32[1024]{0} add(res_8, res_4)
+    res_10 = f32[1024]{0} add(res_9, res_3)
+    ROOT res_11 = f32[1024]{0} tanh(res_10)
+  }
+)";
+
+  auto module = ParseAndReturnVerifiedModule(hlo_text).value();
+  auto module_ref = ParseAndReturnVerifiedModule(hlo_text).value();
+
+  // Set some "hardware" constants so that we can test that instructions are
+  // placed in the places we expect.
+  SetCopyToHostSpeed(4.0 * 1024);
+  SetCopyFromHostSpeed(4.0 * 1024);
+  SetFlopsPerSecond(2 * 1024);
+  SetTranscendentalsPerSecond(2 * 1024);
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          RunHloRematerialization(
+                              /*memory_limit_bytes=*/10 * 1024, module.get()));
+  ASSERT_TRUE(changed);
+
+  // The module should still have a schedule.
+  ASSERT_TRUE(module->has_schedule());
+
+    // Verify that exactly two instructions are rematerialized.
+  auto res_3_matcher = op::Add(op::Parameter(), op::Parameter());
+  auto res_3_rematted_matcher = op::AsyncCopy(
+      xla::Layout::kDefaultMemorySpace, kHostMemorySpaceColor,
+      op::AsyncCopy(kHostMemorySpaceColor, xla::Layout::kDefaultMemorySpace,
+                    res_3_matcher));
+  auto res_4_matcher = op::Tanh(res_3_matcher);
+  auto res_4_rematted_matcher = op::AsyncCopy(
+      xla::Layout::kDefaultMemorySpace, kHostMemorySpaceColor,
+      op::AsyncCopy(kHostMemorySpaceColor, xla::Layout::kDefaultMemorySpace,
+                    res_4_matcher));
+  auto res_5_matcher = op::Tanh(res_4_matcher);
+  auto res_6_matcher = op::Tanh(res_5_matcher);
+  auto res_7_matcher = op::Add(res_6_matcher, res_6_matcher);
+  auto res_8_matcher = op::Add(res_7_matcher, res_5_matcher);
+  auto res_9_matcher = op::Add(res_8_matcher, res_4_rematted_matcher);
+  auto res_10_matcher = op::Add(res_9_matcher, res_3_rematted_matcher);
+
+  const auto instruction_sequence =
+      module->schedule().sequence(module->entry_computation());
+  ASSERT_THAT(instruction_sequence.instructions().back(),
+              op::Tanh(res_10_matcher));
+  // module has the graph optimized by rematerialization and schedule
+  // module_ref has the original graph without rematerialization
+  EXPECT_TRUE(RunAndCompareTwoModules(std::move(module), std::move(module_ref),
+      ErrorSpec{/*aabs=*/1e-6, /*arel=*/1e-6}, /*run_hlo_passes=*/false));
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -166,6 +166,7 @@ limitations under the License.
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
 #include "xla/stream_executor/launch_dim.h"
+#include "xla/stream_executor/integrations/device_mem_allocator.h"
 #include "xla/translate/hlo_to_mhlo/hlo_utils.h"
 #include "xla/translate/mhlo_to_hlo/attribute_exporter.h"
 #include "xla/translate/mhlo_to_hlo/location_exporter.h"
@@ -2739,6 +2740,65 @@ static std::optional<GlobalDeviceId> DeviceConstraint(
   return std::nullopt;
 }
 
+absl::Status IrEmitterUnnested::EmitCopyStartThunk(
+    const HloCopyStartInstruction* instr) {
+
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst_buffer,
+                      GetAllocationSliceForHlo(instr, {}));
+
+  const HloInstruction* src = instr->operand(0);
+  const Shape& input_shape = src->shape();
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice src_buffer,
+                      GetAllocationSliceForHlo(src, {}));
+  Shape shape = instr->shape();
+  CHECK(shape.IsTuple());
+
+  if (shape.mutable_tuple_shapes(0)->has_layout() &&
+      shape.mutable_tuple_shapes(0)->mutable_layout()->memory_space() ==
+          static_cast<int>(stream_executor::MemoryType::kHost)) {
+    VLOG(3) << "Device to Host: host memory space " <<
+        static_cast<int>(stream_executor::MemoryType::kHost);
+    auto thunk = std::make_unique<DeviceToHostCopyThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(instr),
+      /*source_buffer=*/src_buffer,
+      /*destination_buffer=*/dst_buffer,
+      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
+      /*source_value=*/nullptr,
+      /*destination_value=*/nullptr);
+    AddThunkToThunkSequence(std::move(thunk));
+    return absl::OkStatus();
+  }
+  if (shape.mutable_tuple_shapes(1)->has_layout() &&
+      shape.mutable_tuple_shapes(1)->mutable_layout()->memory_space() ==
+      static_cast<int>(stream_executor::MemoryType::kHost)) {
+    VLOG(3) << "Host to Device from the host memory space " <<
+        static_cast<int>(stream_executor::MemoryType::kHost);;
+    auto thunk = std::make_unique<HostToDeviceCopyThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(instr),
+      /*source_buffer=*/src_buffer,
+      /*destination_buffer=*/dst_buffer,
+      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
+      /*source_value=*/nullptr,
+      /*destination_value=*/nullptr);
+    AddThunkToThunkSequence(std::move(thunk));
+    return absl::OkStatus();
+  }
+
+  // Disabled the generation of memcpy D2D as only H2D and D2H are useful
+  // for memory offload now.
+
+  auto thunk = std::make_unique<DeviceToDeviceCopyThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(instr),
+      /*source_buffer=*/src_buffer,
+      /*destination_buffer=*/dst_buffer,
+      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
+      /*source_value=*/nullptr,
+      /*destination_value=*/nullptr);
+    AddThunkToThunkSequence(std::move(thunk));
+
+  return absl::OkStatus();
+}
+
 absl::Status IrEmitterUnnested::EmitSendThunk(const HloSendInstruction* instr) {
   if (!instr->channel_id().has_value())
     return absl::InternalError("Unknown send instruction channel id");
@@ -3026,6 +3086,9 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       return EmitSort(Cast<HloSortInstruction>(instr));
     case HloOpcode::kWhile:
       return EmitWhile(instr);
+    case HloOpcode::kCopyStart:
+      return EmitCopyStartThunk(Cast<HloCopyStartInstruction>(instr));
+
 
     // HLO module is already scheduled, so instructions for ordering are noops.
     case HloOpcode::kAddDependency:
@@ -3036,6 +3099,7 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
     case HloOpcode::kGetTupleElement:
     case HloOpcode::kParameter:
     case HloOpcode::kTuple:
+    case HloOpcode::kCopyDone:
       return absl::OkStatus();
     default:
       return Internal("Unsupported instruction opcode: %s",

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2743,8 +2743,12 @@ static std::optional<GlobalDeviceId> DeviceConstraint(
 absl::Status IrEmitterUnnested::EmitCopyStartThunk(
     const HloCopyStartInstruction* instr) {
 
+  // copy-start has a tuple shape: {host, device, context},
+  // or {device, host, context}.
+  // Only the destination shape is needed to get the output buffer.
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst_buffer,
-                      GetAllocationSliceForHlo(instr, {}));
+                      GetAllocationSliceForHlo(instr,
+                      /*ShapeIndex=*/{0}));
 
   const HloInstruction* src = instr->operand(0);
   const Shape& input_shape = src->shape();

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2766,9 +2766,7 @@ absl::Status IrEmitterUnnested::EmitCopyStartThunk(
       Thunk::ThunkInfo::WithProfileAnnotation(instr),
       /*source_buffer=*/src_buffer,
       /*destination_buffer=*/dst_buffer,
-      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
-      /*source_value=*/nullptr,
-      /*destination_value=*/nullptr);
+      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape));
     AddThunkToThunkSequence(std::move(thunk));
     return absl::OkStatus();
   }
@@ -2781,9 +2779,7 @@ absl::Status IrEmitterUnnested::EmitCopyStartThunk(
       Thunk::ThunkInfo::WithProfileAnnotation(instr),
       /*source_buffer=*/src_buffer,
       /*destination_buffer=*/dst_buffer,
-      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
-      /*source_value=*/nullptr,
-      /*destination_value=*/nullptr);
+      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape));
     AddThunkToThunkSequence(std::move(thunk));
     return absl::OkStatus();
   }
@@ -2795,9 +2791,7 @@ absl::Status IrEmitterUnnested::EmitCopyStartThunk(
       Thunk::ThunkInfo::WithProfileAnnotation(instr),
       /*source_buffer=*/src_buffer,
       /*destination_buffer=*/dst_buffer,
-      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
-      /*source_value=*/nullptr,
-      /*destination_value=*/nullptr);
+      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape));
     AddThunkToThunkSequence(std::move(thunk));
 
   return absl::OkStatus();

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -192,6 +192,8 @@ class IrEmitterUnnested : public IrEmitter {
   absl::Status EmitCollectivePermute(
       const HloCollectivePermuteInstruction* instr);
 
+  absl::Status EmitCopyStartThunk(const HloCopyStartInstruction* instr);
+
   absl::Status EmitHloInstruction(const HloInstruction* instr);
 
   absl::Status EmitTargetElementLoop(

--- a/xla/service/gpu/runtime/copy_thunk.cc
+++ b/xla/service/gpu/runtime/copy_thunk.cc
@@ -40,7 +40,8 @@ absl::Status DeviceToDeviceCopyThunk::ExecuteOnStream(
       params.buffer_allocations->GetDeviceAddress(destination_buffer_);
   se::DeviceMemoryBase source_data =
       params.buffer_allocations->GetDeviceAddress(source_buffer_);
-  VLOG(3) << "Memcpy D2D";
+  VLOG(3) << "Memcpy D2D of size " << mem_size_ << " from "
+      << source_data.opaque() << " to " << destination_data.opaque();
   params.stream->ThenMemcpy(&destination_data, source_data, mem_size_);
   return absl::OkStatus();
 }
@@ -63,7 +64,8 @@ absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
   se::DeviceMemoryBase source_data =
       params.buffer_allocations->GetDeviceAddress(source());
    void *cpu_dst = destination_data.opaque();
-  VLOG(3) << "Memcpy D2H for memory offload";
+  VLOG(3) << "Memcpy D2H for memory offload from "
+          << source_data.opaque() << " to " << cpu_dst;
   params.stream->ThenMemcpy(cpu_dst, source_data, size_bytes());
   return absl::OkStatus();
 }
@@ -86,7 +88,8 @@ absl::Status HostToDeviceCopyThunk::ExecuteOnStream(
   se::DeviceMemoryBase source_data =
       params.buffer_allocations->GetDeviceAddress(source());
   void *cpu_src = source_data.opaque();
-  VLOG(3) << "Memcpy H2D for memory offload";
+  VLOG(3) << "Memcpy H2D for memory offload from " << cpu_src
+          << " to " << destination_data.opaque();
   params.stream->ThenMemcpy(&destination_data, cpu_src, size_bytes());
   return absl::OkStatus();
 }

--- a/xla/service/gpu/runtime/copy_thunk.cc
+++ b/xla/service/gpu/runtime/copy_thunk.cc
@@ -48,14 +48,11 @@ absl::Status DeviceToDeviceCopyThunk::ExecuteOnStream(
 
 DeviceToHostCopyThunk::DeviceToHostCopyThunk(
     ThunkInfo thunk_info, const BufferAllocation::Slice& source_buffer,
-    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
-    mlir::Value source_value, mlir::Value destination_value)
+    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size)
     : DeviceToDeviceCopyThunk(thunk_info,
                               source_buffer,
                               destination_buffer,
-                              mem_size,
-                              source_value,
-                              destination_value) {}
+                              mem_size) {}
 
 absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
     const ExecuteParams& params) {
@@ -72,14 +69,11 @@ absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
 
 HostToDeviceCopyThunk::HostToDeviceCopyThunk(
     ThunkInfo thunk_info, const BufferAllocation::Slice& source_buffer,
-    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
-    mlir::Value source_value, mlir::Value destination_value)
+    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size)
     : DeviceToDeviceCopyThunk(thunk_info,
                               source_buffer,
                               destination_buffer,
-                              mem_size,
-                              source_value,
-                              destination_value) {}
+                              mem_size) {}
 
 absl::Status HostToDeviceCopyThunk::ExecuteOnStream(
     const ExecuteParams& params) {

--- a/xla/service/gpu/runtime/copy_thunk.cc
+++ b/xla/service/gpu/runtime/copy_thunk.cc
@@ -40,7 +40,56 @@ absl::Status DeviceToDeviceCopyThunk::ExecuteOnStream(
       params.buffer_allocations->GetDeviceAddress(destination_buffer_);
   se::DeviceMemoryBase source_data =
       params.buffer_allocations->GetDeviceAddress(source_buffer_);
-  return params.stream->Memcpy(&destination_data, source_data, mem_size_);
+  VLOG(3) << "Memcpy D2D";
+  params.stream->ThenMemcpy(&destination_data, source_data, mem_size_);
+  return absl::OkStatus();
 }
+
+DeviceToHostCopyThunk::DeviceToHostCopyThunk(
+    ThunkInfo thunk_info, const BufferAllocation::Slice& source_buffer,
+    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
+    mlir::Value source_value, mlir::Value destination_value)
+    : DeviceToDeviceCopyThunk(thunk_info,
+                              source_buffer,
+                              destination_buffer,
+                              mem_size,
+                              source_value,
+                              destination_value) {}
+
+absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
+    const ExecuteParams& params) {
+  se::DeviceMemoryBase destination_data =
+      params.buffer_allocations->GetDeviceAddress(destination());
+  se::DeviceMemoryBase source_data =
+      params.buffer_allocations->GetDeviceAddress(source());
+   void *cpu_dst = destination_data.opaque();
+  VLOG(3) << "Memcpy D2H for memory offload";
+  params.stream->ThenMemcpy(cpu_dst, source_data, size_bytes());
+  return absl::OkStatus();
+}
+
+HostToDeviceCopyThunk::HostToDeviceCopyThunk(
+    ThunkInfo thunk_info, const BufferAllocation::Slice& source_buffer,
+    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
+    mlir::Value source_value, mlir::Value destination_value)
+    : DeviceToDeviceCopyThunk(thunk_info,
+                              source_buffer,
+                              destination_buffer,
+                              mem_size,
+                              source_value,
+                              destination_value) {}
+
+absl::Status HostToDeviceCopyThunk::ExecuteOnStream(
+    const ExecuteParams& params) {
+  se::DeviceMemoryBase destination_data =
+      params.buffer_allocations->GetDeviceAddress(destination());
+  se::DeviceMemoryBase source_data =
+      params.buffer_allocations->GetDeviceAddress(source());
+  void *cpu_src = source_data.opaque();
+  VLOG(3) << "Memcpy H2D for memory offload";
+  params.stream->ThenMemcpy(&destination_data, cpu_src, size_bytes());
+  return absl::OkStatus();
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/runtime/copy_thunk.h
+++ b/xla/service/gpu/runtime/copy_thunk.h
@@ -59,8 +59,7 @@ class DeviceToHostCopyThunk : public DeviceToDeviceCopyThunk {
    DeviceToHostCopyThunk(ThunkInfo thunk_info,
                          const BufferAllocation::Slice& source_buffer,
                          const BufferAllocation::Slice& destination_buffer,
-                         uint64_t mem_size, mlir::Value source_value,
-                         mlir::Value destination_value);
+                         uint64_t mem_size);
    absl::Status ExecuteOnStream(const ExecuteParams& params) override;
 };
 
@@ -69,8 +68,7 @@ class HostToDeviceCopyThunk : public DeviceToDeviceCopyThunk {
    HostToDeviceCopyThunk(ThunkInfo thunk_info,
                          const BufferAllocation::Slice& source_buffer,
                          const BufferAllocation::Slice& destination_buffer,
-                         uint64_t mem_size, mlir::Value source_value,
-                         mlir::Value destination_value);
+                         uint64_t mem_size);
    absl::Status ExecuteOnStream(const ExecuteParams& params) override;
 };
 

--- a/xla/service/gpu/runtime/copy_thunk.h
+++ b/xla/service/gpu/runtime/copy_thunk.h
@@ -54,6 +54,26 @@ class DeviceToDeviceCopyThunk : public Thunk {
   const uint64_t mem_size_;
 };
 
+class DeviceToHostCopyThunk : public DeviceToDeviceCopyThunk {
+  public:
+   DeviceToHostCopyThunk(ThunkInfo thunk_info,
+                         const BufferAllocation::Slice& source_buffer,
+                         const BufferAllocation::Slice& destination_buffer,
+                         uint64_t mem_size, mlir::Value source_value,
+                         mlir::Value destination_value);
+   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+};
+
+class HostToDeviceCopyThunk : public DeviceToDeviceCopyThunk {
+  public:
+   HostToDeviceCopyThunk(ThunkInfo thunk_info,
+                         const BufferAllocation::Slice& source_buffer,
+                         const BufferAllocation::Slice& destination_buffer,
+                         uint64_t mem_size, mlir::Value source_value,
+                         mlir::Value destination_value);
+   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+};
+
 }  // namespace gpu
 }  // namespace xla
 

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -602,6 +602,7 @@ cuda_only_cc_library(
         "//xla/stream_executor",
         "//xla/stream_executor:plugin_registry",
         "//xla/stream_executor:stream_executor_internal",
+        "//xla/stream_executor/integrations:device_mem_allocator",
         "//xla/stream_executor/gpu:gpu_collectives_header",
         "//xla/stream_executor/gpu:gpu_command_buffer",
         "//xla/stream_executor/gpu:gpu_diagnostics_header",

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -77,6 +77,7 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/stream_executor/stream_executor_internal.h"
+#include "xla/stream_executor/integrations/device_mem_allocator.h"
 #include "tsl/platform/env.h"
 #include "tsl/platform/errors.h"
 #include "tsl/platform/fingerprint.h"
@@ -632,6 +633,9 @@ DeviceMemoryBase GpuExecutor::Allocate(uint64_t size, int64_t memory_space) {
       LOG(ERROR) << result.status();
     }
     return DeviceMemoryBase(*result, size);
+  } else if (memory_space ==
+        static_cast<int64_t>(stream_executor::MemoryType::kHost)) {
+    return DeviceMemoryBase(GpuDriver::HostAllocate(context_, size), size);
   }
   CHECK_EQ(memory_space, 0);
   return DeviceMemoryBase(GpuDriver::DeviceAllocate(context_, size), size);

--- a/xla/stream_executor/stream_executor_pimpl.h
+++ b/xla/stream_executor/stream_executor_pimpl.h
@@ -352,14 +352,13 @@ class StreamExecutor {
   // Creates and initializes a Stream.
   absl::StatusOr<std::unique_ptr<Stream>> CreateStream(
       std::optional<std::variant<StreamPriority, int>> priority = std::nullopt);
+  // Deallocates a region of host memory allocated by HostMemoryAllocate().
+  void HostMemoryDeallocate(void* data, uint64_t size);
 
  private:
   friend class Event;
   friend class Stream;
   friend class HostMemoryAllocation;
-
-  // Deallocates a region of host memory allocated by HostMemoryAllocate().
-  void HostMemoryDeallocate(void* data, uint64_t size);
 
   // Synchronously allocates size bytes on the underlying platform and returns
   // a DeviceMemoryBase representing that allocation. In the case of failure,


### PR DESCRIPTION
This memory offload implementation includes:
- Add the mlir for copy-start/copy-done
- Generate copy_thunk from HLO instructions for the new runtime
- Add the host memory allocator/deallocator for the host memory space
- Generate async memcpy d2h/h2d

Tested locally with a Jax code, by 
- enabling the HLO rematerialization offloading to create copy-start/copy-done
- disabling recompute/compress 

The log showed memcpy d2h and h2d were created by copy_thunk, meaning this offload implementation works.