### PR TITLE
[ROCM] Implementing GemmBlasWithAlgorithm BLAS API routines

### DIFF
--- a/xla/service/gpu/autotuner_util.h
+++ b/xla/service/gpu/autotuner_util.h
@@ -54,7 +54,8 @@ struct DevicelessConfig {
 
   // A field to determine the architecture of the device. We only pick an
   // algorithm for non-Ampere architectures.
-  se::CudaComputeCapability cuda_compute_capability{0, 0};
+  se::GpuComputeCapability gpu_compute_capability
+                {se::CudaComputeCapability{0, 0}};
 };
 
 class AutotuneCacheKey {
@@ -132,11 +133,11 @@ class AutotuneConfig {
     return GetAllocator()->GetStream(GetExecutor()->device_ordinal());
   }
 
-  se::CudaComputeCapability GetCudaComputeCapability() const {
+  const se::GpuComputeCapability& GetGpuComputeCapability() const {
     if (auto c = std::get_if<DeviceConfig>(&config_)) {
-      return c->stream_exec->GetDeviceDescription().cuda_compute_capability();
+      return c->stream_exec->GetDeviceDescription().gpu_compute_capability();
     }
-    return std::get<DevicelessConfig>(config_).cuda_compute_capability;
+    return std::get<DevicelessConfig>(config_).gpu_compute_capability;
   }
 
   bool IsDeviceless() const {

--- a/xla/service/gpu/cublas_padding_requirements.cc
+++ b/xla/service/gpu/cublas_padding_requirements.cc
@@ -26,17 +26,10 @@ namespace gpu {
 
 namespace {
 
-template <class... Ts>
-struct Overload : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
-
 bool DimensionRequiresPadding(const int64_t size, const PrimitiveType data_type,
                               const se::GpuComputeCapability& gpu_cc) {
   return std::visit(
-      Overload{
+      se::VariantVisitor{
           [&](const se::CudaComputeCapability& cc) {
             for (const auto& req : CublasPaddingRequirements) {
               if (cc.IsAtLeast(req.min_compute_capability) &&

--- a/xla/service/gpu/float_support_test.cc
+++ b/xla/service/gpu/float_support_test.cc
@@ -26,11 +26,9 @@ namespace {
 
 class FloatSupportTest : public HloTestBase {
  public:
-  se::CudaComputeCapability GetCudaComputeCapability() {
-    return backend()
-        .default_stream_executor()
-        ->GetDeviceDescription()
-        .cuda_compute_capability();
+  const se::GpuComputeCapability& GetGpuComputeCapability() {
+    return backend().default_stream_executor()
+        ->GetDeviceDescription().gpu_compute_capability();
   }
 };
 
@@ -72,9 +70,18 @@ ENTRY e {
 }
 
 TEST_F(FloatSupportTestWithTriton, MixedTypeDotWithBF16IsNotUpcasted) {
-  if (!GetCudaComputeCapability().IsAtLeast(
-          se::CudaComputeCapability::AMPERE)) {
-    GTEST_SKIP() << "No BF16 before Ampere.";
+
+  bool skip_test = std::visit(se::VariantVisitor{
+    [](const se::CudaComputeCapability& cc) {
+      return !cc.IsAtLeast(se::CudaComputeCapability::AMPERE);
+    },
+    [](const se::RocmComputeCapability&) {
+      return true;
+    }
+  }, GetGpuComputeCapability());
+  
+  if(skip_test) {
+    GTEST_SKIP() << "Not supported on this GPU architecture";
   }
 
   constexpr absl::string_view kHloText = R"(

--- a/xla/service/gpu/gemm_algorithm_picker_test.cc
+++ b/xla/service/gpu/gemm_algorithm_picker_test.cc
@@ -44,6 +44,18 @@ class GemmAlgorithmPickerTest : public HloTestBase,
     debug_options.set_xla_gpu_enable_triton_gemm(false);
     return debug_options;
   }
+
+  void SetUp() override {
+    const auto& gpu_cc = backend().default_stream_executor()
+        ->GetDeviceDescription().gpu_compute_capability();
+
+    if(auto *procm = std::get_if< se::RocmComputeCapability >(&gpu_cc)) {
+      if(GetDebugOptionsForTest().xla_gpu_enable_cublaslt() && 
+            !procm->has_hipblaslt()) {
+        GTEST_SKIP() << "No gpublas-lt support on this architecture!";
+      }
+    }
+  }
 };
 
 TEST_P(GemmAlgorithmPickerTest, SetAlgorithm) {

--- a/xla/service/gpu/gemm_rewriter_triton.cc
+++ b/xla/service/gpu/gemm_rewriter_triton.cc
@@ -61,13 +61,6 @@ namespace gpu {
 
 namespace {
 
-template <class... Ts>
-struct Overload : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
-
 using triton_fusion::CombineRequirements;
 using triton_fusion::DimensionOrder;
 using triton_fusion::DimOrderMap;

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -156,6 +156,12 @@ struct GemmConfig : public se::gpu::GemmConfig {
         op.getAlgorithm(), compute_precision, /*grad_x=*/false,
         /*grad_y=*/false);
   }
+
+  using DescriptorsTuple = std::tuple< se::gpu::MatrixDescriptor, 
+                                       se::gpu::MatrixDescriptor, 
+                                       se::gpu::MatrixOutDescriptor, bool >;
+  DescriptorsTuple MatrixDescriptors(se::DeviceMemoryBase lhs_buf, 
+        se::DeviceMemoryBase rhs_buf, se::DeviceMemoryBase out_buf) const;
 };
 
 // Run the given GEMM instruction `gemm` subject to the configuration

--- a/xla/service/gpu/runtime/gemm.cc
+++ b/xla/service/gpu/runtime/gemm.cc
@@ -51,14 +51,18 @@ using xla::runtime::StridedMemrefView;
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // TODO(ezhulenev): Delete run time auto tuning from XLA.
-Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
-                           se::DeviceMemoryBase lhs, se::DeviceMemoryBase rhs,
-                           se::DeviceMemoryBase out, const Shape& output_shape,
-                           double beta, const DebugOptions* debug_options,
-                           NonAtomicallyUpgradeableRWLock* gpu_lock) {
+Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig *config,
+              se::DeviceMemoryBase lhs_buffer, se::DeviceMemoryBase rhs_buffer,
+              se::DeviceMemoryBase output_buffer, const Shape& output_shape,
+              double beta, const DebugOptions* debug_options,
+              NonAtomicallyUpgradeableRWLock* gpu_lock) {
   VLOG(3) << "Running GEMM runtime autotuning";
   std::vector<se::blas::AlgorithmType> algorithms;
-  stream->parent()->GetBlasGemmAlgorithms(stream, &algorithms);
+  auto [lhs, rhs, output, operands_swapped] = 
+        config->MatrixDescriptors(lhs_buffer, rhs_buffer, output_buffer);
+
+  stream->parent()->GetBlasGemmAlgorithms(stream, lhs, rhs, &output, 
+                                &config->alpha, &config->beta, &algorithms);
   const bool deterministic_ops = debug_options->xla_gpu_deterministic_ops();
 
   AutotuneConfig autotune_config{
@@ -86,7 +90,8 @@ Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
       AutotuneResult best_algorithm,
       GetBestBlasAlgorithm(
           stream, buffer_allocator, /*gemm_str=*/std::nullopt, autotune_config,
-          lhs, rhs, out, algorithms, output_shape, HloModuleConfig(), beta,
+          lhs_buffer, rhs_buffer, output_buffer, algorithms, 
+          output_shape, HloModuleConfig(), beta,
           [&](const se::blas::AlgorithmType& algorithm)
               -> StatusOr<se::blas::ProfileResult> {
             se::blas::ProfileResult profile_result;
@@ -96,13 +101,14 @@ Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
             // always return true, and the actual success-ness is returned in
             // ProfileResult::is_valid.
             TF_RETURN_IF_ERROR(
-                RunGemm(config, lhs, rhs, out, se::DeviceMemoryBase(nullptr, 0),
-                        deterministic_ops, stream, algorithm, &profile_result));
+                RunGemm(*config, lhs_buffer, rhs_buffer, output_buffer, 
+                    se::DeviceMemoryBase(nullptr, 0), deterministic_ops, stream, 
+                    algorithm, &profile_result));
             return std::move(profile_result);
           }));
 
   if (best_algorithm.has_gemm()) {
-    config.algorithm = algorithms[best_algorithm.gemm().algorithm()];
+    config->algorithm = algorithms[best_algorithm.gemm().algorithm()];
     return OkStatus();
   } else {
     return InternalError("Runtime autotuning failed to select an algorithm");
@@ -145,7 +151,7 @@ static absl::Status GemmImpl(const ServiceExecutableRunOptions* run_options,
   // deadlock.
   if (gemm_config->algorithm == stream_executor::blas::kRuntimeAutotuning) {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-    auto status = DoRuntimeAutotuning(stream, *gemm_config, lhs_data, rhs_data,
+    auto status = DoRuntimeAutotuning(stream, gemm_config, lhs_data, rhs_data,
                                       output_data, output_shape, beta,
                                       debug_options, gpu_lock);
     if (!status.ok()) {
@@ -153,7 +159,7 @@ static absl::Status GemmImpl(const ServiceExecutableRunOptions* run_options,
     }
 #else
     return absl::InternalError(
-        "Failed to run runtime autotuner because CUDA is not enabled");
+        "Failed to run runtime autotuner because GPU support is not enabled");
 #endif
   }
 

--- a/xla/service/gpu/triton_autotuner.cc
+++ b/xla/service/gpu/triton_autotuner.cc
@@ -229,10 +229,12 @@ class GemmConfigSetCollector : public ConstDfsHloVisitorWithDefault {
   GemmConfigSet GetGemmConfigSet(const HloFusionInstruction* fusion) {
     const DebugOptions& debug_options =
         fusion->GetModule()->config().debug_options();
+    auto cuda_comp = std::get< se::CudaComputeCapability >(
+                                    config_.GetGpuComputeCapability());
     return {GetPossibleMatmulAutotuneConfigs(
         *Cast<HloDotInstruction>(hlo_query::GetFirstInstructionWithOpcode(
             *fusion->called_computations().at(0), HloOpcode::kDot)),
-        config_.GetCudaComputeCapability(), debug_options,
+        cuda_comp, debug_options,
         config_.ExhaustiveTilingSearch())};
   }
 
@@ -456,7 +458,7 @@ StatusOr<std::unique_ptr<HloModule>> CublasGemmAutotuneExtractor(
       AutotunerUtil::ExtractComputationIntoNewModule(*fusion_computation);
   new_module->mutable_config().set_debug_options(debug_opts);
 
-  GemmRewriter rewriter(config.GetCudaComputeCapability());
+  GemmRewriter rewriter(config.GetGpuComputeCapability());
   GpuInstructionFusion fusion_pass(
       /*may_duplicate=*/false, config.GetExecutor()->GetDeviceDescription());
   TF_RETURN_IF_ERROR(rewriter.Run(new_module.get()).status());

--- a/xla/service/gpu/triton_support.cc
+++ b/xla/service/gpu/triton_support.cc
@@ -26,13 +26,6 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-template <class... Ts>
-struct Overload : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
-
 bool IsDistributiveOverAddition(const HloInstruction& hlo) {
   // The list is most likely incomplete.
   // For example division can be added too but only for operand #0.
@@ -66,14 +59,13 @@ bool IsTritonSupportedDataType(PrimitiveType type,
       return true;
     case BF16:
       return std::visit(
-          Overload{[](const se::CudaComputeCapability& cc) {
-                     return cc.IsAtLeast(
-                         stream_executor::CudaComputeCapability::AMPERE);
-                   },
-                   [](const se::RocmComputeCapability& cc) {
-                     return cc.has_bf16_dtype_support();
-                   }},
-          gpu_version);
+         se::VariantVisitor{[](const se::CudaComputeCapability& cc) {
+            return cc.IsAtLeast(stream_executor::CudaComputeCapability::AMPERE);
+         },
+         [](const se::RocmComputeCapability& cc) {
+           return cc.has_bf16_dtype_support();
+         }},
+         gpu_version);
     default:
       return false;
   }

--- a/xla/stream_executor/blas.h
+++ b/xla/stream_executor/blas.h
@@ -61,6 +61,8 @@ namespace stream_executor {
 
 namespace gpu {
 struct BlasLt;
+struct MatrixDescriptor;
+struct MatrixOutDescriptor;
 }
 
 class Stream;
@@ -337,8 +339,10 @@ class BlasSupport {
                                  blas::CallContext context) = 0;
 
   // Gets a list of supported algorithms for DoBlasGemmWithAlgorithm.
-  virtual bool GetBlasGemmAlgorithms(
-      Stream *stream, std::vector<AlgorithmType> *out_algorithms) = 0;
+  virtual bool GetBlasGemmAlgorithms(Stream* stream,
+      const gpu::MatrixDescriptor& a, const gpu::MatrixDescriptor& b,
+      gpu::MatrixOutDescriptor *c, const void *alpha, const void *beta, 
+      std::vector<blas::AlgorithmType> *out_algorithms) = 0;
 
   // Like DoBlasGemm, but accepts an algorithm and an compute type.
   //
@@ -614,9 +618,10 @@ class BlasSupport {
       const void *beta, DeviceMemoryBase *c, int ldc,                          \
       const NumericOptions &numeric_options, blas::CallContext context)        \
       override;                                                                \
-  bool GetBlasGemmAlgorithms(Stream *stream,                                   \
-                             std::vector<blas::AlgorithmType> *out_algorithms) \
-      override;                                                                \
+  bool GetBlasGemmAlgorithms(Stream* stream,                                   \
+      const gpu::MatrixDescriptor& a, const gpu::MatrixDescriptor& b,          \
+      gpu::MatrixOutDescriptor *c, const void *alpha, const void *beta,        \
+      std::vector<blas::AlgorithmType> *out_algorithms) override;              \
   tsl::Status DoBlasGemmWithAlgorithm(                                         \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64_t m, uint64 n, uint64 k, const void *alpha,                       \

--- a/xla/stream_executor/cuda/cuda_blas.cc
+++ b/xla/stream_executor/cuda/cuda_blas.cc
@@ -897,8 +897,10 @@ tsl::Status CUDABlas::DoBlasGemmStridedBatchedWithAlgorithm(
   return ::tsl::OkStatus();
 }
 
-bool CUDABlas::GetBlasGemmAlgorithms(
-    Stream *stream, std::vector<blas::AlgorithmType> *out_algorithms) {
+bool CUDABlas::GetBlasGemmAlgorithms(Stream* stream, 
+  const gpu::MatrixDescriptor&, const gpu::MatrixDescriptor&,
+  gpu::MatrixOutDescriptor *, const void *, const void *,
+  std::vector<blas::AlgorithmType> *out_algorithms) {
   // cublasGemmAlgo_t (and the function that accepts this type, cublasGemmEx)
   // were first introduced in CUDA 8.
   //

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -220,6 +220,11 @@ class RocmComputeCapability {
   };
 };
 
+// structure supporting C++17 overload pattern:
+// https://en.cppreference.com/w/cpp/utility/variant/visit
+template<class... Ts> struct VariantVisitor : Ts... { using Ts::operator()...; };
+template<class... Ts> VariantVisitor(Ts...) -> VariantVisitor<Ts...>;
+
 using GpuComputeCapability =
     std::variant<CudaComputeCapability, RocmComputeCapability>;
 

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -91,6 +91,33 @@ tsl::StatusOr<PrimitiveType> AsXlaPrimitiveType(DataType dtype) {
   }
 }
 
+MatrixLayout::MatrixLayout(xla::PrimitiveType dtype_, int64_t num_rows_,
+        int64_t num_cols_, MatrixLayout::Order order_, int64_t batch_size_,
+        std::optional<int64_t> leading_dim_stride_,
+        std::optional<int64_t> batch_stride_,
+        std::optional<blas::Transpose> transpose_) : dtype(dtype_),
+  num_rows(num_rows_), num_cols(num_cols_), 
+  order(order_), batch_size(batch_size_) {
+    
+  if (!leading_dim_stride_) {
+    leading_dim_stride = order == Order::kRowMajor ? num_cols : num_rows;
+  } else {
+    leading_dim_stride = *leading_dim_stride_;
+  }
+  if (!batch_stride_) {
+    batch_stride = (batch_size > 1) ? num_rows * num_cols : 0;
+  } else {
+    batch_stride = *batch_stride_;
+  }
+  transpose = transpose_ ? *transpose_ : blas::Transpose::kNoTranspose;
+}
+
+void MatrixLayout::Transpose() {
+  std::swap(num_rows, num_cols);
+  order =
+        (order == Order::kRowMajor) ? Order::kColumnMajor : Order::kRowMajor;
+}
+
 tsl::StatusOr<ComputationType> GetBlasComputationType(
     PrimitiveType lhs_dtype, PrimitiveType output_dtype,
     int64_t compute_precision) {
@@ -125,15 +152,17 @@ tsl::StatusOr<ComputationType> GetBlasComputationType(
 // BLAS GeMM's output is column-major. If we require row-major, use identity:
 // C^T = (A @ B)^T = B^T @ A^T.
 bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
-                           MatrixLayout& output, MatrixLayout* pC) {
+                           MatrixLayout& output, MatrixLayout* pc) {
   bool swap_operands = output.order != MatrixLayout::Order::kColumnMajor;
   if (swap_operands) {
     std::swap(lhs, rhs);
     rhs.Transpose();
-    lhs.Transpose();
-    // prevent pC and output from being swapped two times if they are equal!
-    if (pC != nullptr && pC != &output) {
-      pC->Transpose();
+    // prevent layouts from being swapped two times if they are equal
+    if(&lhs != &rhs) {
+      lhs.Transpose();
+    }
+    if (pc != nullptr && pc != &output) {
+      pc->Transpose();
     }
     output.Transpose();
   }

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -51,12 +51,14 @@ struct MatrixLayout {  // plain MatrixLayout which is extended with create
     kColumnMajor,  // Elements in the same column are contiguous in memory.
   };
 
-  void Transpose() {
-    std::swap(num_rows, num_cols);
-    order =
-        (order == Order::kRowMajor) ? Order::kColumnMajor : Order::kRowMajor;
-  }
+  MatrixLayout(xla::PrimitiveType dtype_, int64_t num_rows_,
+        int64_t num_cols_, Order order_, int64_t batch_size_ = 1,
+      std::optional<int64_t> leading_dim_stride_ = {},
+      std::optional<int64_t> batch_stride_ = {},
+      std::optional<blas::Transpose> transpose_ = {});
 
+  void Transpose();
+  
   xla::PrimitiveType dtype;
   // `num_rows` / `num_cols` are for the "logical" matrix shape:
   // i.e. the contracting dim has size `num_cols` for LHS operands and
@@ -65,16 +67,36 @@ struct MatrixLayout {  // plain MatrixLayout which is extended with create
   int64_t num_cols;
   Order order;
   int64_t batch_size;
-  std::optional<int64_t> leading_dim_stride;
+  int64_t leading_dim_stride;
   // `batch_stride` is set to `0` when `batch_size == 1`.
-  std::optional<int64_t> batch_stride;
-  std::optional<blas::Transpose> transpose;
+  int64_t batch_stride;
+  blas::Transpose transpose;
+};
+
+// compact version of the matrix layout to be used o pass matrices
+// to underlying blas API
+struct MatrixDescriptor {
+  DeviceMemoryBase data;
+  int64_t leading_dim_stride;
+  int64_t batch_stride;
+  blas::DataType type;
+  blas::Transpose transpose;
+
+  template <typename T>
+  DeviceMemory<T> cast() const {
+    return DeviceMemory<T>(data);
+  }
+};
+
+struct MatrixOutDescriptor : public MatrixDescriptor {
+  int64_t batch_size, m, n, k;
+  blas::ComputationType compute_type;
 };
 
 // BLAS GeMM's output is column-major. If we require row-major, use identity:
 // C^T = (A @ B)^T = B^T @ A^T.
 bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
-                           MatrixLayout& output, MatrixLayout* pC = nullptr);
+                           MatrixLayout& output, MatrixLayout* pc = nullptr);
 
 struct GemmConfig {  // plain GemmConfig which is extended with create functions
                      // in matmul_utils.h
@@ -90,17 +112,6 @@ struct GemmConfig {  // plain GemmConfig which is extended with create functions
   bool grad_y;
   std::optional<blas::ComputationType> compute_type;
 };
-
-// template < cudaDataType_t What, cudaDataType_t SrcT, class Z, class... T>
-// struct ChooseType {
-//    using type = std::conditional_t< What == SrcT, Z,
-//         typename ChooseType< What, T...>::type>;
-// };
-
-// template < cudaDataType_t What >
-// using CudaToNativeT = typename ChooseType< What, CUDA_R_8F_E4M3,
-// tsl::float8_e4m3fn,
-//         CUDA_R_8F_E5M2, tsl::float8_e5m2, ... >::type;
 
 struct BlasLt {
   enum class Epilogue {

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -130,17 +130,11 @@ tsl::Status BlasLt::Init() {
     const gpu::MatrixLayout& m) {
   TF_ASSIGN_OR_RETURN(auto type, gpu::AsBlasDataType(m.dtype));
 
-  auto leading_dim_stride = m.leading_dim_stride;
-  if (!leading_dim_stride) {
-    leading_dim_stride = (m.order == gpu::MatrixLayout::Order::kRowMajor)
-                             ? m.num_cols
-                             : m.num_rows;
-  }
   auto hipblas_data_type_ = AsHipblasDataType(type);
   hipblasLtMatrixLayout_t hip_layout;
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatrixLayoutCreate(
       &hip_layout, hipblas_data_type_, m.num_rows, m.num_cols,
-      *leading_dim_stride));
+      m.leading_dim_stride));
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
   BlasLt::MatrixLayout layout(hip_layout, hipblas_data_type_);
   if (m.order != gpu::MatrixLayout::Order::kColumnMajor)
@@ -149,18 +143,14 @@ tsl::Status BlasLt::Init() {
   TF_RETURN_IF_ERROR(SetAttr(hip_layout, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
                              static_cast<int32_t>(m.batch_size)));
 
-  auto batch_stride = m.batch_stride;
-  if (!batch_stride) {
-    batch_stride = (m.batch_size > 1) ? m.num_rows * m.num_cols : 0;
-  }
   VLOG(2) << "BlasLt::MatrixLayout::Create type: " << (int)type
           << " rows: " << m.num_rows << " cols: " << m.num_cols
           << " batch_size: " << m.batch_size
-          << " leading_dim_stride: " << *leading_dim_stride
-          << " batch_stride: " << *batch_stride;
+          << " leading_dim_stride: " << m.leading_dim_stride
+          << " batch_stride: " << m.batch_stride;
 
   TF_RETURN_IF_ERROR(SetAttr(
-      hip_layout, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, *batch_stride));
+      hip_layout, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, m.batch_stride));
   return std::move(layout);
 }
 
@@ -273,10 +263,7 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& cfg, Epilogue epilogue) const
   // *not* be transposed, and if B is row-major, B must be transposed. We never
   // transpose A or B, and expect the caller to ensure A is row-major and B is
   // column when A and B are FP8.
-  auto trans_a = lhs_layout.transpose ? *lhs_layout.transpose
-                                      : blas::Transpose::kNoTranspose;
-  auto trans_b = rhs_layout.transpose ? *rhs_layout.transpose
-                                      : blas::Transpose::kNoTranspose;
+  auto trans_a = lhs_layout.transpose, trans_b = rhs_layout.transpose;
 
   if (xla::primitive_util::IsF8Type(lhs_layout.dtype) &&
       lhs_layout.order == gpu::MatrixLayout::Order::kColumnMajor) {

--- a/xla/stream_executor/rocm/rocblas_wrapper.h
+++ b/xla/stream_executor/rocm/rocblas_wrapper.h
@@ -20,6 +20,8 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCBLAS_WRAPPER_H_
 #define XLA_STREAM_EXECUTOR_ROCM_ROCBLAS_WRAPPER_H_
 
+// needed for rocblas_gemm_ex_get_solutions* functionality
+#define ROCBLAS_BETA_FEATURES_API
 #include "rocm/include/rocblas/rocblas.h"
 #include "xla/stream_executor/gpu/gpu_activation.h"
 #include "xla/stream_executor/platform/dso_loader.h"
@@ -32,21 +34,20 @@ namespace wrap {
 using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
 
 #ifdef PLATFORM_GOOGLE
-#define ROCBLAS_API_WRAPPER(__name)           \
-  struct WrapperShim__##__name {              \
-    static const char* kName;                 \
-    template <typename... Args>               \
-    rocblas_status operator()(Args... args) { \
-      return ::__name(args...);               \
-    }                                         \
-  } __name;                                   \
-  const char* WrapperShim__##__name::kName = #__name;
+#define ROCBLAS_API_WRAPPER(__name)               \
+  struct WrapperShim__##__name {                  \
+    constexpr static const char* kName = #__name; \
+    template <typename... Args>                   \
+    rocblas_status operator()(Args... args) {     \
+      return ::__name(args...);                   \
+    }                                             \
+  } __name;                                       \
 
 #else
 
 #define ROCBLAS_API_WRAPPER(__name)                                 \
   struct DynLoadShim__##__name {                                    \
-    static const char* kName;                                       \
+    constexpr static const char* kName = #__name;                   \
     using FuncPtrT = std::add_pointer<decltype(::__name)>::type;    \
     static void* GetDsoHandle() {                                   \
       auto s = GetRocblasDsoHandle();                               \
@@ -69,7 +70,6 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
       return DynLoad()(args...);                                    \
     }                                                               \
   } __name;                                                         \
-  const char* DynLoadShim__##__name::kName = #__name;
 
 #endif
 
@@ -257,6 +257,11 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
   __macro(rocblas_zgemm_strided_batched)        \
   __macro(rocblas_gemm_ex)                      \
   __macro(rocblas_gemm_strided_batched_ex)      \
+  __macro(rocblas_gemm_ex_get_solutions)        \
+  __macro(rocblas_gemm_ex_get_solutions_by_type) \
+  __macro(rocblas_gemm_batched_ex_get_solutions) \
+  __macro(rocblas_gemm_batched_ex_get_solutions_by_type) \
+  __macro(rocblas_gemm_strided_batched_ex_get_solutions) \
   __macro(rocblas_strsm_batched)                \
   __macro(rocblas_dtrsm_batched)                \
   __macro(rocblas_ctrsm_batched)                \

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -52,48 +52,55 @@ extern void rocm_Broadcast_fp32(void *stream, float *dst, int dst_stride,
                                 int size);
 
 template <class T>
-const typename RocBlasTypeConversionHelper<T>::mapped_type *complex_cast(
+const RocBlasType_t<T> *complex_cast(
     const DeviceMemory<T> &a) {
   return reinterpret_cast<
-      const typename RocBlasTypeConversionHelper<T>::mapped_type *>(
+      const RocBlasType_t<T> *>(
       GpuMemory(a));
 }
 
 template <class T>
-const typename RocBlasTypeConversionHelper<T>::mapped_type *complex_cast(
+const RocBlasType_t<T> *complex_cast(
     const T &a) {
   return reinterpret_cast<
-      const typename RocBlasTypeConversionHelper<T>::mapped_type *>(&a);
+      const RocBlasType_t<T> *>(&a);
 }
 template <class T>
-typename RocBlasTypeConversionHelper<T>::mapped_type *complex_cast(
+RocBlasType_t<T> *complex_cast(
     DeviceMemory<T> *a) {
   return reinterpret_cast<
-      typename RocBlasTypeConversionHelper<T>::mapped_type *>(
+      RocBlasType_t<T> *>(
       GpuMemoryMutable(a));
 }
 
 static void blas_log(const char *c) {}
 
 static string ToString(rocblas_status status) {
+
+#define XVAL(x) case x: return #x
   switch (status) {
-    case rocblas_status_success:
-      return "rocblas_status_success";
-    case rocblas_status_invalid_handle:
-      return "rocblas_status_invalid_handle";
-    case rocblas_status_not_implemented:
-      return "rocblas_status_not_implemented";
-    case rocblas_status_invalid_pointer:
-      return "rocblas_status_invalid_pointer";
-    case rocblas_status_invalid_size:
-      return "rocblas_status_invalid_size";
-    case rocblas_status_memory_error:
-      return "rocblas_status_memory_error";
-    case rocblas_status_internal_error:
-      return "rocblas_status_internal_error";
+    XVAL(rocblas_status_success);
+    XVAL(rocblas_status_invalid_handle);
+    XVAL(rocblas_status_not_implemented);
+    XVAL(rocblas_status_invalid_pointer);
+    XVAL(rocblas_status_invalid_size);
+    XVAL(rocblas_status_memory_error);
+    XVAL(rocblas_status_internal_error);
+#if TF_ROCM_VERSION >= 60000
+    XVAL(rocblas_status_perf_degraded);
+    XVAL(rocblas_status_size_query_mismatch);
+    XVAL(rocblas_status_size_increased);
+    XVAL(rocblas_status_size_unchanged);
+    XVAL(rocblas_status_invalid_value);
+    XVAL(rocblas_status_continue);
+    XVAL(rocblas_status_check_numerics_fail);
+    XVAL(rocblas_status_excluded_from_build);
+    XVAL(rocblas_status_arch_mismatch);
+#endif
     default:
       return absl::StrCat("<invalid rocBLAS status: ", status, ">");
   }
+#undef XVAL
 }
 
 bool ROCMBlas::Init() {
@@ -203,17 +210,62 @@ rocblas_side ROCMBlasSide(blas::Side side) {
   }
 }
 
+
+static tsl::StatusOr<rocblas_datatype> AsRocBlasType(blas::DataType type) {
+  switch(type) {
+  case blas::DataType::kHalf:
+    return rocblas_datatype_f16_r;
+  case blas::DataType::kBF16:
+    return rocblas_datatype_bf16_r;
+  case blas::DataType::kFloat:
+    return rocblas_datatype_f32_r;
+  case blas::DataType::kDouble:
+    return rocblas_datatype_f64_r;
+  case blas::DataType::kInt8:
+    return rocblas_datatype_i8_r;
+  case blas::DataType::kInt32:
+    return rocblas_datatype_i32_r;
+  case blas::DataType::kComplexFloat:
+    return rocblas_datatype_f32_c;
+  case blas::DataType::kComplexDouble:
+    return rocblas_datatype_f64_c;
+  default:
+    return tsl::errors::Internal(absl::StrFormat("Unsupported blas data type: %d",
+        (int)type));
+  }
+}
+
+static tsl::StatusOr<rocblas_datatype> AsRocBlasComputeType(
+              blas::ComputationType type) {
+  switch(type) {
+  case blas::ComputationType::kF16:
+    return rocblas_datatype_f16_r;
+  case blas::ComputationType::kF32:
+    return rocblas_datatype_f32_r;
+  case blas::ComputationType::kF64:
+    return rocblas_datatype_f64_r;
+  case blas::ComputationType::kI32:
+    return rocblas_datatype_i32_r;
+  case blas::ComputationType::kF16AsF32:
+  case blas::ComputationType::kBF16AsF32:
+  case blas::ComputationType::kTF32AsF32:
+  default:
+    return tsl::errors::Internal(absl::StrFormat("Unsupported compute type: %d",
+        (int)type));
+  }
+}
+
 }  // namespace
 
 template <typename FuncT, typename... Args>
-bool ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
+tsl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
                                   bool pointer_mode_host, bool err_on_failure,
-                                  Args... args) {
+                                  Args&&... args) {
   absl::MutexLock lock{&mu_};
 
   CHECK(blas_ != nullptr);
   if (!SetStream(stream)) {
-    return false;
+    return tsl::errors::Internal("Setting stream failed");
   }
 
   gpu::ScopedActivateExecutorContext sac{parent_};
@@ -225,16 +277,20 @@ bool ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
     ret = wrap::rocblas_set_atomics_mode(blas_, rocblas_atomics_not_allowed);
     if (err_on_failure && ret != rocblas_status_success) {
       LOG(ERROR) << "failed to to set atomics mode before "
-                 << rocblas_func.kName << ": " << ToString(ret);
+                 << FuncT::kName << ": " << ToString(ret);
     }
   }
 
-  ret = rocblas_func(blas_, args...);
-  if (err_on_failure && ret != rocblas_status_success) {
-    LOG(ERROR) << "failed to run ROCBLAS routine " << rocblas_func.kName << ": "
-               << ToString(ret);
+  ret = rocblas_func(blas_, std::forward<Args>(args)...);
+  if(ret != rocblas_status_success) {
+    auto err_str = absl::StrFormat("%s failed with: %s", 
+        FuncT::kName, ToString(ret));
+    if (err_on_failure) {
+      LOG(ERROR) << err_str;
+    }
+    return tsl::errors::Internal(err_str);
   }
-  return ret == rocblas_status_success;
+  return tsl::OkStatus();
 }
 
 bool ROCMBlas::DoBlasAxpy(Stream *stream, uint64_t elem_count, float alpha,
@@ -420,21 +476,10 @@ bool ROCMBlas::DoBlasSbmv(Stream *stream, blas::UpperLower uplo, uint64_t n,
       incx, &beta, GpuMemoryMutable(y), incy);
 }
 
-tsl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
-                                 blas::Transpose transb, uint64_t m, uint64 n,
-                                 uint64_t k, blas::DataType dtype,
-                                 const void *alpha, const DeviceMemoryBase &a,
-                                 int lda, const DeviceMemoryBase &b, int ldb,
-                                 const void *beta, DeviceMemoryBase *c, int ldc,
-                                 const NumericOptions &numeric_options,
-                                 blas::CallContext context) {
-  blas_log("DoBlasGemm");
-  VLOG(1) << absl::StreamFormat(
-      "doing rocBLAS GEMM: at=%d bt=%d m=%u n=%u "
-      "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
-      "c=%p ldc=%d",
-      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
-      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc);
+static void CheckPreconditions(blas::Transpose transa, blas::Transpose transb, 
+          uint64_t m, uint64_t n, uint64_t k, blas::DataType dtype, 
+          int lda, int ldb)
+{
   if (dtype == blas::DataType::kHalf || dtype == blas::DataType::kFloat) {
     if (transa == blas::Transpose::kNoTranspose) {
       if (lda < static_cast<int64_t>(m)) {
@@ -459,6 +504,25 @@ tsl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
       }
     }
   }
+}
+
+tsl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
+                                 blas::Transpose transb, uint64_t m, uint64_t n,
+                                 uint64_t k, blas::DataType dtype,
+                                 const void *alpha, const DeviceMemoryBase &a,
+                                 int lda, const DeviceMemoryBase &b, int ldb,
+                                 const void *beta, DeviceMemoryBase *c, int ldc,
+                                 const NumericOptions &numeric_options,
+                                 blas::CallContext context) {
+  blas_log("DoBlasGemm");
+  VLOG(1) << absl::StreamFormat(
+      "doing rocBLAS GEMM: at=%d bt=%d m=%u n=%u "
+      "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
+      "c=%p ldc=%d",
+      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
+      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc);
+
+  CheckPreconditions(transa, transb, m, n, k, dtype, lda, ldb);
 
   switch (dtype) {
     case blas::DataType::kHalf: {
@@ -467,7 +531,7 @@ tsl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
         VLOG(1) << "Using rocblas_gemm_ex";
         bool is_backprop = (context == blas::CallContext::kBackpropInput1) ||
                            (context == blas::CallContext::kBackpropInput2);
-
+        
         uint32_t flags = rocblas_gemm_flags_none;
 #if TF_ROCM_VERSION >= 50000
         if (is_backprop) {
@@ -553,37 +617,226 @@ tsl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
   }
 }
 
+static tsl::Status PopulateProfileFromTimer(
+    std::optional<GpuTimer> &timer, blas::AlgorithmType algorithm,
+    blas::ProfileResult *output_profile_result) {
+  if (output_profile_result) {
+    TF_ASSIGN_OR_RETURN(absl::Duration duration, timer->GetElapsedDuration());
+    output_profile_result->set_is_valid(true);
+    output_profile_result->set_algorithm(algorithm);
+    output_profile_result->set_elapsed_time_in_ms(
+        absl::ToDoubleMilliseconds(duration));
+  }
+  return ::tsl::OkStatus();
+}
+
 tsl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, const void *alpha, const DeviceMemoryBase &a,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceMemoryBase &a,
     blas::DataType type_a, int lda, const DeviceMemoryBase &b,
     blas::DataType type_b, int ldb, const void *beta, DeviceMemoryBase *c,
     blas::DataType type_c, int ldc, blas::ComputationType computation_type,
     blas::AlgorithmType algorithm, const NumericOptions &numeric_options,
-    blas::ProfileResult *output_profile_result, blas::CallContext context) {
-  // ROCM TODO: properly implement the interface
-  return tsl::errors::Internal("DoBlasGemmWithAlgorithm ",
-                               "is not implemented on ROCm yet");
+    blas::ProfileResult *profile_result, blas::CallContext context) {
+
+  blas_log("DoBlasGemmWithAlgorithm");
+  if(type_a != type_b) {
+    return tsl::errors::Internal(absl::StrFormat(
+        "DoBlasGemmWithAlgorithm: different "
+        "datatypes for the inputs a (%d) and b (%d) are unsupported",
+        static_cast<int>(type_a), static_cast<int>(type_b)));
+  }
+  // NOTE: currently we always use default algorithm!
+  algorithm = blas::kDefaultAlgorithm;
+
+  TF_ASSIGN_OR_RETURN(auto timer, 
+        GpuTimer::CreateIfNeeded(AsGpuStream(stream), 
+              profile_result != nullptr));
+
+  // fall back to the default implementation
+  if(algorithm == blas::kDefaultAlgorithm && type_a == type_c) 
+  {
+    TF_RETURN_IF_ERROR(DoBlasGemm(stream, transa, transb, m, n,k, type_a,
+      alpha, a, lda, b, ldb, beta, c, ldc, numeric_options, context));
+  
+  } else {
+  
+    CheckPreconditions(transa, transb, m, n, k, type_a, lda, ldb);
+    TF_ASSIGN_OR_RETURN(auto roc_type_a, AsRocBlasType(type_a));
+    TF_ASSIGN_OR_RETURN(auto roc_type_c, AsRocBlasType(type_c));
+    TF_ASSIGN_OR_RETURN(auto roc_comp_type, 
+                                      AsRocBlasComputeType(computation_type));
+
+    VLOG(1) << absl::StreamFormat(
+      "doing rocBLAS GEMM with Algorithm: at=%d bt=%d m=%u n=%u "
+      "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
+      "c=%p ldc=%d algorithm=%d type_a/b=%d type_c=%d comp_type=%d",
+      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
+      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc, algorithm,
+      static_cast<int>(roc_type_a), static_cast<int>(roc_type_c), 
+      static_cast<int>(roc_comp_type));
+
+    TF_RETURN_IF_ERROR(DoBlasInternalImpl(
+          wrap::rocblas_gemm_ex, stream, 
+          /* pointer_mode_host = */ true,
+          /* error_on_failure = */ false,
+          ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), (rocblas_int)m,
+          (rocblas_int)n, (rocblas_int)k, alpha, a.opaque(),
+          roc_type_a, lda, b.opaque(), roc_type_a,
+          ldb, beta, c->opaque(), roc_type_c, ldc, c->opaque(),
+          roc_type_c, ldc, roc_comp_type,
+          rocblas_gemm_algo_solution_index, algorithm, 0));
+  }
+  TF_RETURN_IF_ERROR(
+      PopulateProfileFromTimer(timer, algorithm, profile_result));
+
+  return tsl::OkStatus();
 }
 
 tsl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, const void *alpha, const DeviceMemoryBase &a,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceMemoryBase &a,
     blas::DataType type_a, int lda, int64_t stride_a, const DeviceMemoryBase &b,
     blas::DataType type_b, int ldb, int64_t stride_b, const void *beta,
     DeviceMemoryBase *c, blas::DataType type_c, int ldc, int64_t stride_c,
     int batch_count, blas::ComputationType computation_type,
     blas::AlgorithmType algorithm, const NumericOptions &numeric_options,
-    blas::ProfileResult *output_profile_result, blas::CallContext context) {
-  // ROCM TODO: properly implement the interface
-  return tsl::errors::Internal("DoBlasGemmStridedBatchedWithAlgorithm ",
-                               "is not implemented on ROCm yet");
+    blas::ProfileResult *profile_result, blas::CallContext context) {
+
+  blas_log("DoBlasGemmStridedBatchedWithAlgorithm");
+  if(type_a != type_b) {
+    return tsl::errors::Internal(absl::StrFormat(
+        "DoBlasGemmStridedBatchedWithAlgorithm: different "
+        "datatypes for the inputs a (%d) and b (%d) are unsupported",
+        static_cast<int>(type_a), static_cast<int>(type_b)));
+  }
+  // NOTE: currently we always use default algorithm!
+  algorithm = blas::kDefaultAlgorithm;
+
+  TF_ASSIGN_OR_RETURN(auto timer, 
+        GpuTimer::CreateIfNeeded(AsGpuStream(stream), 
+              profile_result != nullptr));
+
+  // fall back to the default implementation 
+  if(algorithm == blas::kDefaultAlgorithm && type_a == type_c) {
+    TF_RETURN_IF_ERROR(DoBlasGemmStridedBatched(stream, transa, transb, m, n, k, 
+        type_a, alpha, a, lda, stride_a, b, ldb, stride_b, beta,
+        c, ldc, stride_c, batch_count, numeric_options, context));
+  } else {
+
+    VLOG(1) << absl::StreamFormat(
+      "doing rocBLAS GEMM strided batched with Algorithm: at=%d bt=%d m=%u n=%u "
+      "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
+      "c=%p ldc=%d algorithm=%d type_a/b=%d type_c=%d stride_a/b/c=%d/%d/%d "
+      "batch_count=%d",
+      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
+      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc, algorithm,
+      static_cast<int>(type_a), static_cast<int>(type_c), 
+      stride_a, stride_b, stride_c, batch_count);
+
+    TF_ASSIGN_OR_RETURN(auto roc_type_a, AsRocBlasType(type_a));
+    TF_ASSIGN_OR_RETURN(auto roc_type_c, AsRocBlasType(type_c));
+    TF_ASSIGN_OR_RETURN(auto roc_comp_type, AsRocBlasComputeType(computation_type));
+
+    TF_RETURN_IF_ERROR(DoBlasInternalImpl(wrap::rocblas_gemm_strided_batched_ex, 
+          stream, /* pointer_mode_host = */ true,
+          /* error_on_failure = */ false,
+          ROCMBlasTranspose(transa), 
+          ROCMBlasTranspose(transb), (rocblas_int)m, (rocblas_int)n, 
+          (rocblas_int)k, alpha, a.opaque(), roc_type_a, lda, stride_a,
+          b.opaque(), roc_type_a,  ldb, stride_b, beta, 
+          c->opaque(), roc_type_c, ldc, stride_c, 
+          c->opaque(), roc_type_c, ldc, stride_c, batch_count, roc_comp_type,
+          rocblas_gemm_algo_solution_index, algorithm, 0));
+  }
+  TF_RETURN_IF_ERROR(
+      PopulateProfileFromTimer(timer, algorithm, profile_result));
+
+  return tsl::OkStatus();
 }
 
-bool ROCMBlas::GetBlasGemmAlgorithms(
-    Stream *stream, std::vector<blas::AlgorithmType> *out_algorithms) {
-  // ROCM TODO: properly implement the interface
-  return true;
+template < class Lambda >
+struct NameWrap : Lambda {
+  using Lambda::operator();
+  constexpr static const char *kName = "rocblas_gemm_ex_get_solutions";
+};
+template<class Func> NameWrap(Func) -> NameWrap<Func>;
+
+bool ROCMBlas::GetBlasGemmAlgorithms(Stream* stream, 
+  const gpu::MatrixDescriptor& a, const gpu::MatrixDescriptor& b,
+  gpu::MatrixOutDescriptor *c, const void *alpha, const void *beta, 
+  std::vector<blas::AlgorithmType> *out_algorithms)
+{
+#define ASSIGN_OR_FALSE(lhs, rexpr) \
+  result = (rexpr);                                  \
+  if (TF_PREDICT_FALSE(!result.ok())) return false;  \
+  lhs = std::move(result).value()
+
+    out_algorithms->clear();
+    auto blas_lambda = [this, out_algorithms](auto handle, 
+            auto&& blas_func, auto&&... rest) {
+      rocblas_int num_sols = 0;
+
+      if(auto ret = blas_func(handle, std::forward<decltype(rest)>(rest)..., 
+                  nullptr, &num_sols); ret != rocblas_status_success) {
+        return ret;
+      }
+      solutions_.resize(num_sols);
+      if(auto ret = blas_func(handle, std::forward<decltype(rest)>(rest)..., 
+                solutions_.data(), &num_sols); ret != rocblas_status_success) {
+        return ret;
+      }
+      // NOTE: this is currently disabled due to stability issues
+      //out_algorithms->resize(num_sols);
+      // for(rocblas_int i = 0; i < num_sols; i++) {
+      //   (*out_algorithms)[i] = solutions_[i];
+      // }
+      return rocblas_status_success;
+    };
+
+    VLOG(1) << absl::StreamFormat(
+      "GetBlasAlgorithms: at=%d bt=%d m=%u n=%u "
+      "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
+      "c=%p ldc=%d type_a/b=%d type_c=%d stride_a/b/c=%d/%d/%d "
+      "batch_count=%d",
+      static_cast<int>(a.transpose), static_cast<int>(b.transpose), 
+      c->m, c->n, c->k, alpha,
+      a.data.opaque(), a.leading_dim_stride, 
+      b.data.opaque(), b.leading_dim_stride, beta, 
+      c->data.opaque(), c->leading_dim_stride, 
+      static_cast<int>(a.type), static_cast<int>(c->type), 
+      a.batch_stride, b.batch_stride, c->batch_stride, c->batch_size);
+
+  if(a.type != b.type) {
+    LOG(ERROR) << "Gemm arguments types differ: no feasible solutions!";
+    return false;
+  }
+  tsl::StatusOr<rocblas_datatype> result;
+  ASSIGN_OR_FALSE(auto roc_type_a, AsRocBlasType(a.type)); 
+  ASSIGN_OR_FALSE(auto roc_type_c, AsRocBlasType(c->type));
+  ASSIGN_OR_FALSE(auto roc_comp_type, AsRocBlasComputeType(c->compute_type));
+
+  if(c->batch_size == 1) {
+    return DoBlasInternalFailureOK(NameWrap{blas_lambda}, stream, true,
+          wrap::rocblas_gemm_ex_get_solutions, 
+          ROCMBlasTranspose(a.transpose), ROCMBlasTranspose(b.transpose),
+          c->m, c->n, c->k, alpha,
+          a.data.opaque(), roc_type_a, a.leading_dim_stride,
+          b.data.opaque(), roc_type_a, b.leading_dim_stride, beta,
+          c->data.opaque(), roc_type_c, c->leading_dim_stride,
+          c->data.opaque(), roc_type_c, c->leading_dim_stride,
+          roc_comp_type, rocblas_gemm_algo_solution_index, 0);
+  } 
+  return DoBlasInternalFailureOK(NameWrap{blas_lambda}, stream, true,
+       wrap::rocblas_gemm_strided_batched_ex_get_solutions, 
+       ROCMBlasTranspose(a.transpose), ROCMBlasTranspose(b.transpose),
+       c->m, c->n, c->k, alpha,
+       a.data.opaque(), roc_type_a, a.leading_dim_stride, a.batch_stride,
+       b.data.opaque(), roc_type_a, b.leading_dim_stride, b.batch_stride,
+       beta,
+       c->data.opaque(), roc_type_c, c->leading_dim_stride, c->batch_stride,
+       c->data.opaque(), roc_type_c, c->leading_dim_stride, c->batch_stride,
+       c->batch_size, roc_comp_type, rocblas_gemm_algo_solution_index, 0);
 }
 
 struct MemoryCopyOp {
@@ -700,19 +953,13 @@ tsl::Status ReorganizeMemory(Stream *stream,
 }
 
 template <typename T>
-tsl::Status ROCMBlas::AllocateStridedBuffer(
-    const std::vector<typename RocBlasTypeConversionHelper<T>::mapped_type *>
-        &raw_ptrs,
+auto ROCMBlas::AllocateStridedBuffer(
+    const std::vector< RocBlasType_t<T> *>& raw_ptrs,
     int batch_count, uint64_t batch_stride, ScratchAllocator *scratch_allocator,
-    Stream *stream,
-    std::unique_ptr<TemporaryDeviceMemory<
-        typename RocBlasTypeConversionHelper<T>::mapped_type>> *temp_memory,
-    DeviceMemory<typename RocBlasTypeConversionHelper<T>::mapped_type>
-        *device_memory,
-    bool copy_data, bool &reallocated) {
-  assert(device_memory != nullptr);
+    Stream *stream, bool copy_data) -> tsl::StatusOr<AllocateStridedResult<T>> {
 
-  using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
+  using MAPPED_T = RocBlasType_t<T>;
+  AllocateStridedResult<T> res;
 
   bool needs_allocate_strided = false;
   for (int i = 1; i < batch_count; ++i) {
@@ -728,42 +975,40 @@ tsl::Status ROCMBlas::AllocateStridedBuffer(
 
   // No need to do re-allocation, take the short cut and return
   if (!needs_allocate_strided) {
-    *device_memory = DeviceMemory<MAPPED_T>(
+    res.device_mem = DeviceMemory<MAPPED_T>(
         DeviceMemoryBase(raw_ptrs[0], matrix_batch_byte_size));
-    reallocated = false;
-    return tsl::OkStatus();
+    res.reallocated = false;
+    return res;
   }
 
   if (scratch_allocator != nullptr) {
     TF_ASSIGN_OR_RETURN(
         DeviceMemory<uint8> batch_matrix_bytes,
         scratch_allocator->AllocateBytes(matrix_batch_byte_size));
-    *device_memory = DeviceMemory<MAPPED_T>(batch_matrix_bytes);
+    res.device_mem = DeviceMemory<MAPPED_T>(batch_matrix_bytes);
   } else {
-    assert(temp_memory != nullptr);
-    TF_ASSIGN_OR_RETURN(*temp_memory, stream->AllocateTemporaryArray<MAPPED_T>(
+    TF_ASSIGN_OR_RETURN(res.temp_mem, stream->AllocateTemporaryArray<MAPPED_T>(
                                           matrix_batch_byte_size));
-    *device_memory =
-        DeviceMemory<MAPPED_T>(*(*temp_memory)->mutable_device_memory());
+    res.device_mem =
+        DeviceMemory<MAPPED_T>(*(res.temp_mem)->mutable_device_memory());
   }
-
-  reallocated = true;
-
-  if (copy_data)
-    return ReorganizeMemory(stream, device_memory, raw_ptrs, batch_count,
+  res.reallocated = true;
+  if (copy_data) {
+    return ReorganizeMemory(stream, &res.device_mem, raw_ptrs, batch_count,
                             batch_stride, true);
-  return tsl::OkStatus();
+  }
+  return res;
 }
 
 template <typename T, typename FuncT>
 tsl::Status ROCMBlas::DoBlasGemmBatchedInternal(
     FuncT rocblas_func, Stream *stream, blas::Transpose transa,
-    blas::Transpose transb, uint64_t m, uint64 n, uint64 k, T alpha,
+    blas::Transpose transb, uint64_t m, uint64_t n, uint64_t k, T alpha,
     DeviceMemorySlice<T> a_ptrs_to_wrappers, int lda,
     DeviceMemorySlice<T> b_ptrs_to_wrappers, int ldb, T beta,
     DeviceMemorySlice<T> c_ptrs_to_wrappers, int ldc, int batch_count,
     ScratchAllocator *scratch_allocator) {
-  using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
+  using MAPPED_T = RocBlasType_t<T>;
 
   // Sanity checks before making any further progress
   uint64_t batch_stride_a = 0;
@@ -790,46 +1035,29 @@ tsl::Status ROCMBlas::DoBlasGemmBatchedInternal(
   }
 
   // Allocate local vectors to hold device pointers to matrices
-  std::vector<MAPPED_T *> a_raw_ptrs, b_raw_ptrs, c_raw_ptrs;
+  std::vector<MAPPED_T *> a_raw_ptrs(batch_count), b_raw_ptrs(batch_count), 
+                          c_raw_ptrs(batch_count);
   for (int i = 0; i < batch_count; ++i) {
     // static_cast does work when converting Eigen::half* to rocblas_half*,
     // hence the use of reinterpret_cast
-    a_raw_ptrs.push_back(
-        reinterpret_cast<MAPPED_T *>(a_ptrs_to_wrappers[i]->opaque()));
-    b_raw_ptrs.push_back(
-        reinterpret_cast<MAPPED_T *>(b_ptrs_to_wrappers[i]->opaque()));
-    c_raw_ptrs.push_back(
-        reinterpret_cast<MAPPED_T *>(c_ptrs_to_wrappers[i]->opaque()));
+    a_raw_ptrs[i] = reinterpret_cast<MAPPED_T *>(a_ptrs_to_wrappers[i]->opaque());
+    b_raw_ptrs[i] = reinterpret_cast<MAPPED_T *>(b_ptrs_to_wrappers[i]->opaque());
+    c_raw_ptrs[i] = reinterpret_cast<MAPPED_T *>(c_ptrs_to_wrappers[i]->opaque());
   }
 
-  DeviceMemory<MAPPED_T> a;
   // Make sure the temporary memory are in-scope before the function returns
-  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> a_temp;
-  bool reallocated_a, reallocated_b, reallocated_c;
-  tsl::Status a_allocation_status = AllocateStridedBuffer<T>(
+  //std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> a_temp, b_temp, c_temp;
+  TF_ASSIGN_OR_RETURN(auto a, AllocateStridedBuffer<T>(
       a_raw_ptrs, batch_count, batch_stride_a, scratch_allocator, stream,
-      &a_temp, &a, true, reallocated_a);
-  if (a_allocation_status != tsl::OkStatus()) {
-    return a_allocation_status;
-  }
+      true));
 
-  DeviceMemory<MAPPED_T> b;
-  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> b_temp;
-  tsl::Status b_allocation_status = AllocateStridedBuffer<T>(
+  TF_ASSIGN_OR_RETURN(auto b, AllocateStridedBuffer<T>(
       b_raw_ptrs, batch_count, batch_stride_b, scratch_allocator, stream,
-      &b_temp, &b, true, reallocated_b);
-  if (b_allocation_status != tsl::OkStatus()) {
-    return b_allocation_status;
-  }
+      true));
 
-  DeviceMemory<MAPPED_T> c;
-  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> c_temp;
-  tsl::Status c_allocation_status = AllocateStridedBuffer<T>(
+  TF_ASSIGN_OR_RETURN(auto c, AllocateStridedBuffer<T>(
       c_raw_ptrs, batch_count, batch_stride_c, scratch_allocator, stream,
-      &c_temp, &c, true, reallocated_c);  // can disable copy if beta=0
-  if (c_allocation_status != tsl::OkStatus()) {
-    return c_allocation_status;
-  }
+      true));  // can disable copy if beta=0
 
   bool ok;
   if constexpr (std::is_same_v<T, Eigen::bfloat16>) {
@@ -841,33 +1069,38 @@ tsl::Status ROCMBlas::DoBlasGemmBatchedInternal(
     ok = DoBlasInternal(
         rocblas_func, stream, /* pointer_mode_host = */ true,
         ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-        alpha_ptr, a.opaque(), rocblas_datatype_bf16_r, lda, batch_stride_a,
-        b.opaque(), rocblas_datatype_bf16_r, ldb, batch_stride_b, beta_ptr,
-        c.opaque(), rocblas_datatype_bf16_r, ldc, batch_stride_c, c.opaque(),
+        alpha_ptr, 
+        a.device_mem.opaque(), rocblas_datatype_bf16_r, lda, batch_stride_a,
+        b.device_mem.opaque(), rocblas_datatype_bf16_r, ldb, batch_stride_b, 
+        beta_ptr,
+        c.device_mem.opaque(), rocblas_datatype_bf16_r, ldc, batch_stride_c, 
+        c.device_mem.opaque(),
         rocblas_datatype_bf16_r, ldc, batch_stride_c, batch_count,
         rocblas_datatype_f32_r, rocblas_gemm_algo_standard, 0, 0);
   } else {
     MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
     MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
     ok = DoBlasInternal(rocblas_func, stream, /* pointer_mode_host = */ true,
-                        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
-                        n, k, GpuComplex(alpha_ptr), GpuMemory(a), lda,
-                        batch_stride_a, GpuMemory(b), ldb, batch_stride_b,
-                        GpuComplex(beta_ptr), GpuMemoryMutable(&c), ldc,
-                        batch_stride_c, batch_count);
+             ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
+             n, k, GpuComplex(alpha_ptr), GpuMemory(a.device_mem), lda,
+             batch_stride_a, GpuMemory(b.device_mem), ldb, batch_stride_b,
+             GpuComplex(beta_ptr), GpuMemoryMutable(&c.device_mem), ldc,
+             batch_stride_c, batch_count);
   }
-  if (!ok)
+  if (!ok) {
     return tsl::Status(absl::StatusCode::kInternal,
                        "failed BLAS call, see log for details");
-  if (reallocated_c)
-    return ReorganizeMemory(stream, &c, c_raw_ptrs, batch_count, batch_stride_c,
-                            false);
+  }
+  if (c.reallocated) {
+    return ReorganizeMemory(stream, &c.device_mem, c_raw_ptrs, batch_count, 
+            batch_stride_c, false);
+  }
   return tsl::OkStatus();
 }
 
 bool ROCMBlas::DoBlasGemmBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, float alpha, DeviceMemorySlice<Eigen::half> a,
+    uint64_t n, uint64_t k, float alpha, DeviceMemorySlice<Eigen::half> a,
     int lda, DeviceMemorySlice<Eigen::half> b, int ldb, float beta,
     DeviceMemorySlice<Eigen::half> c, int ldc, int batch_count,
     const NumericOptions &numeric_options, ScratchAllocator *scratch_allocator,
@@ -889,7 +1122,7 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 bool ROCMBlas::DoBlasGemmBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, float alpha,
+    uint64_t n, uint64_t k, float alpha,
     DeviceMemorySlice<Eigen::bfloat16> a_array, int lda,
     DeviceMemorySlice<Eigen::bfloat16> b_array, int ldb, float beta,
     DeviceMemorySlice<Eigen::bfloat16> c_array, int ldc, int batch_count,
@@ -911,7 +1144,7 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 bool ROCMBlas::DoBlasGemmBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, float alpha, DeviceMemorySlice<float> a_array,
+    uint64_t n, uint64_t k, float alpha, DeviceMemorySlice<float> a_array,
     int lda, DeviceMemorySlice<float> b_array, int ldb, float beta,
     DeviceMemorySlice<float> c_array, int ldc, int batch_count,
     const NumericOptions &numeric_options, ScratchAllocator *scratch_allocator,
@@ -925,11 +1158,11 @@ bool ROCMBlas::DoBlasGemmBatched(
     LOG(ERROR) << status;
   }
   return status.ok();
-}
+} 
 
 bool ROCMBlas::DoBlasGemmBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, double alpha, DeviceMemorySlice<double> a_array,
+    uint64_t n, uint64_t k, double alpha, DeviceMemorySlice<double> a_array,
     int lda, DeviceMemorySlice<double> b_array, int ldb, double beta,
     DeviceMemorySlice<double> c_array, int ldc, int batch_count,
     const NumericOptions &numeric_options, ScratchAllocator *scratch_allocator,
@@ -947,7 +1180,7 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 bool ROCMBlas::DoBlasGemmBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, std::complex<float> alpha,
+    uint64_t n, uint64_t k, std::complex<float> alpha,
     DeviceMemorySlice<std::complex<float>> a_array, int lda,
     DeviceMemorySlice<std::complex<float>> b_array, int ldb,
     std::complex<float> beta, DeviceMemorySlice<std::complex<float>> c_array,
@@ -966,7 +1199,7 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 bool ROCMBlas::DoBlasGemmBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, std::complex<double> alpha,
+    uint64_t n, uint64_t k, std::complex<double> alpha,
     DeviceMemorySlice<std::complex<double>> a_array, int lda,
     DeviceMemorySlice<std::complex<double>> b_array, int ldb,
     std::complex<double> beta, DeviceMemorySlice<std::complex<double>> c_array,
@@ -985,7 +1218,7 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
                           blas::UpperLower uplo, blas::Transpose transa,
-                          blas::Diagonal diag, uint64_t m, uint64 n,
+                          blas::Diagonal diag, uint64_t m, uint64_t n,
                           float alpha, const DeviceMemory<float> &a, int lda,
                           DeviceMemory<float> *b, int ldb) {
   blas_log("DoBlasTrsm");
@@ -998,7 +1231,7 @@ bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
 
 bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
                           blas::UpperLower uplo, blas::Transpose transa,
-                          blas::Diagonal diag, uint64_t m, uint64 n,
+                          blas::Diagonal diag, uint64_t m, uint64_t n,
                           double alpha, const DeviceMemory<double> &a, int lda,
                           DeviceMemory<double> *b, int ldb) {
   blas_log("DoBlasTrsm");
@@ -1011,7 +1244,7 @@ bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
 
 bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
                           blas::UpperLower uplo, blas::Transpose transa,
-                          blas::Diagonal diag, uint64_t m, uint64 n,
+                          blas::Diagonal diag, uint64_t m, uint64_t n,
                           std::complex<float> alpha,
                           const DeviceMemory<std::complex<float>> &a, int lda,
                           DeviceMemory<std::complex<float>> *b, int ldb) {
@@ -1024,7 +1257,7 @@ bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
 
 bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
                           blas::UpperLower uplo, blas::Transpose transa,
-                          blas::Diagonal diag, uint64_t m, uint64 n,
+                          blas::Diagonal diag, uint64_t m, uint64_t n,
                           std::complex<double> alpha,
                           const DeviceMemory<std::complex<double>> &a, int lda,
                           DeviceMemory<std::complex<double>> *b, int ldb) {
@@ -1037,7 +1270,7 @@ bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  blas::UpperLower uplo, blas::Transpose transa,
-                                 blas::Diagonal diag, uint64_t m, uint64 n,
+                                 blas::Diagonal diag, uint64_t m, uint64_t n,
                                  float alpha, const DeviceMemory<float *> &as,
                                  int lda, DeviceMemory<float *> *bs, int ldb,
                                  int batch_count) {
@@ -1050,7 +1283,7 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  blas::UpperLower uplo, blas::Transpose transa,
-                                 blas::Diagonal diag, uint64_t m, uint64 n,
+                                 blas::Diagonal diag, uint64_t m, uint64_t n,
                                  double alpha, const DeviceMemory<double *> &as,
                                  int lda, DeviceMemory<double *> *bs, int ldb,
                                  int batch_count) {
@@ -1063,7 +1296,7 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  blas::UpperLower uplo, blas::Transpose transa,
-                                 blas::Diagonal diag, uint64_t m, uint64 n,
+                                 blas::Diagonal diag, uint64_t m, uint64_t n,
                                  std::complex<float> alpha,
                                  const DeviceMemory<std::complex<float> *> &as,
                                  int lda,
@@ -1080,7 +1313,7 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  blas::UpperLower uplo, blas::Transpose transa,
-                                 blas::Diagonal diag, uint64_t m, uint64 n,
+                                 blas::Diagonal diag, uint64_t m, uint64_t n,
                                  std::complex<double> alpha,
                                  const DeviceMemory<std::complex<double> *> &as,
                                  int lda,
@@ -1097,17 +1330,18 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
 
 tsl::Status ROCMBlas::DoBlasGemmStridedBatched(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64 k, blas::DataType dtype, const void *alpha,
+    uint64_t n, uint64_t k, blas::DataType dtype, const void *alpha,
     const DeviceMemoryBase &a, int lda, int64_t stride_a,
     const DeviceMemoryBase &b, int ldb, int64_t stride_b, const void *beta,
     DeviceMemoryBase *c, int ldc, int64_t stride_c, int batch_count,
     const NumericOptions &numeric_options, blas::CallContext context) {
   VLOG(1) << absl::StreamFormat(
-      "doing rocBLAS SGEMM Strided Batched<float>: at=%d bt=%d m=%u n=%u "
+      "doing rocBLAS GEMM Strided Batched: at=%d bt=%d m=%u n=%u "
       "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
-      "c=%p ldc=%d",
+      "c=%p ldc=%d stride_a/b/c=%d/%d/%d batch_count=%d",
       static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
-      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc);
+      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc,
+      stride_a, stride_b, stride_c, batch_count);
 
   switch (dtype) {
     case blas::DataType::kHalf: {

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -24,6 +24,8 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "rocm/rocm_config.h"
+
+#define ROCBLAS_BETA_FEATURES_API
 #if TF_ROCM_VERSION >= 50600
 #include "rocm/include/rocblas/rocblas.h"
 #else
@@ -43,32 +45,33 @@ class Stream;
 
 namespace gpu {
 
+template < bool ErrorIfMissing, class Target, class A, class B, class... T>
+struct ChooseType {
+  using type = std::conditional_t< std::is_same_v<Target, A>, B,
+       typename ChooseType< ErrorIfMissing, Target, T... >::type>;
+};
+
+template < class Target, class A, class B >
+struct ChooseType< false, Target, A, B > {
+  // default case: return the same type Target if there is no recursive match 
+  using type = std::conditional_t< std::is_same_v<Target, A>, B, Target>;
+};
+
+template < class Target, class A, class B >
+struct ChooseType< true, Target, A, B > {
+  // default case: return compile error if type is not found
+  static_assert(std::is_same_v<Target, A>, 
+      "ChooseType: the target type is not found!");
+  using type = B;
+};
+
 // Type conversion helper that helps to map non-rocblas types to rocblas types
-// Right now, it only converts the Eigen::half type to rocblas_half type
 template <typename T>
-struct RocBlasTypeConversionHelper {
-  using mapped_type = T;
-};
-
-template <>
-struct RocBlasTypeConversionHelper<Eigen::half> {
-  using mapped_type = rocblas_half;
-};
-
-template <>
-struct RocBlasTypeConversionHelper<Eigen::bfloat16> {
-  using mapped_type = rocblas_bfloat16;
-};
-
-template <>
-struct RocBlasTypeConversionHelper<std::complex<float>> {
-  using mapped_type = rocblas_float_complex;
-};
-
-template <>
-struct RocBlasTypeConversionHelper<std::complex<double>> {
-  using mapped_type = rocblas_double_complex;
-};
+using RocBlasType_t = typename ChooseType< false, T, 
+    Eigen::half, rocblas_half, 
+    Eigen::bfloat16, rocblas_bfloat16,
+    std::complex<float>, rocblas_float_complex,
+    std::complex<double>, rocblas_double_complex >::type;
 
 class GpuExecutor;
 
@@ -124,48 +127,53 @@ class ROCMBlas : public blas::BlasSupport {
   // err_on_failure:     Whether to print an error if the rocBLAS function
   // fails. args:               Arguments of rocBLAS function.
   template <typename FuncT, typename... Args>
-  bool DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
+  tsl::Status DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
                           bool pointer_mode_host, bool err_on_failure,
-                          Args... args);
+                          Args&&... args);
 
   // Convenience functions that call DoBlasInternalImpl with different values
   // for err_on_failure.
   template <typename FuncT, typename... Args>
   bool DoBlasInternal(FuncT rocblas_func, Stream *stream,
-                      bool pointer_mode_host, Args... args) {
-    return DoBlasInternalImpl(rocblas_func, stream, pointer_mode_host,
-                              /*err_on_failure=*/true, args...);
+                      bool pointer_mode_host, Args&&... args) {
+    auto ret = DoBlasInternalImpl(rocblas_func, stream, pointer_mode_host,
+                          /*err_on_failure=*/true, std::forward<Args>(args)...);
+    return ret.ok();
   }
 
   // Same as above, but returns tsl::Status.
-  template <typename... Args>
-  tsl::Status DoBlasInternalStatus(Args... args) {
-    if (!DoBlasInternal(args...)) {
-      return tsl::errors::Internal("Failed calling rocBLAS");
-    }
-    return tsl::OkStatus();
+  template <typename FuncT, typename... Args>
+  tsl::Status DoBlasInternalStatus(FuncT rocblas_func, Stream *stream,
+                      bool pointer_mode_host, Args&&... args) {
+    return DoBlasInternalImpl(rocblas_func, stream, pointer_mode_host,
+                          /*err_on_failure=*/true, std::forward<Args>(args)...);
   }
 
   template <typename FuncT, typename... Args>
   bool DoBlasInternalFailureOK(FuncT rocblas_func, Stream *stream,
-                               bool pointer_mode_host, Args... args) {
-    return DoBlasInternalImpl(rocblas_func, stream, pointer_mode_host,
-                              /*err_on_failure=*/false, args...);
+                               bool pointer_mode_host, Args&&... args) {
+    auto ret = DoBlasInternalImpl(rocblas_func, stream, pointer_mode_host,
+                         /*err_on_failure=*/false, std::forward<Args>(args)...);
+    return ret.ok();
   }
+
+  template <typename T>
+  struct AllocateStridedResult 
+  {
+    using Type = RocBlasType_t<T>;
+    std::unique_ptr<TemporaryDeviceMemory< Type > > temp_mem;
+    DeviceMemory<Type> device_mem;
+    bool reallocated;
+  };
 
   // A helper allocation function to convert raw pointers memory layout to
   // strided flavor
   template <typename T>
-  tsl::Status AllocateStridedBuffer(
-      const std::vector<typename RocBlasTypeConversionHelper<T>::mapped_type *>
-          &raw_ptrs,
+  tsl::StatusOr<AllocateStridedResult<T>> AllocateStridedBuffer(
+      const std::vector<RocBlasType_t<T> *> &raw_ptrs,
       int batch_count, uint64_t batch_stride,
       ScratchAllocator *scratch_allocator, Stream *stream,
-      std::unique_ptr<TemporaryDeviceMemory<
-          typename RocBlasTypeConversionHelper<T>::mapped_type>> *temp_memory,
-      DeviceMemory<typename RocBlasTypeConversionHelper<T>::mapped_type>
-          *device_memory,
-      bool copy_data, bool &reallocated);
+      bool copy_data);
 
   // A helper function to implement DoBlasGemmBatched interfaces for generic
   // types.
@@ -186,7 +194,7 @@ class ROCMBlas : public blas::BlasSupport {
   template <typename T, typename FuncT>
   tsl::Status DoBlasGemmBatchedInternal(
       FuncT rocblas_func, Stream *stream, blas::Transpose transa,
-      blas::Transpose transb, uint64_t m, uint64 n, uint64 k, T alpha,
+      blas::Transpose transb, uint64_t m, uint64_t n, uint64_t k, T alpha,
       DeviceMemorySlice<T> a_ptrs_to_wrappers, int lda,
       DeviceMemorySlice<T> b_ptrs_to_wrappers, int ldb, T beta,
       DeviceMemorySlice<T> c_ptrs_to_wrappers, int ldc, int batch_count,
@@ -201,6 +209,9 @@ class ROCMBlas : public blas::BlasSupport {
 
   // rocBLAS library handle on the device.
   rocblas_handle blas_ ABSL_GUARDED_BY(mu_);
+  
+  // container holding solutions vector (to avoid reallocating it each time)
+  std::vector< rocblas_int > solutions_;
 
 #if TF_HIPBLASLT
   rocm::BlasLt blas_lt_;

--- a/xla/stream_executor/stream_executor_pimpl.cc
+++ b/xla/stream_executor/stream_executor_pimpl.cc
@@ -340,13 +340,16 @@ bool StreamExecutor::GetRnnAlgorithms(
   return dnn_support->GetRnnAlgorithms(out_algorithms);
 }
 
-bool StreamExecutor::GetBlasGemmAlgorithms(
-    Stream* stream, std::vector<blas::AlgorithmType>* out_algorithms) {
+bool StreamExecutor::GetBlasGemmAlgorithms(Stream* stream, 
+     const gpu::MatrixDescriptor& a, const gpu::MatrixDescriptor& b,
+     gpu::MatrixOutDescriptor *c, const void *alpha, const void *beta, 
+     std::vector<blas::AlgorithmType> *out_algorithms) {
   blas::BlasSupport* blas_support = AsBlas();
   if (!blas_support) {
     return false;
   }
-  return blas_support->GetBlasGemmAlgorithms(stream, out_algorithms);
+  return blas_support->GetBlasGemmAlgorithms(stream, a, b, c, 
+     alpha, beta, out_algorithms);
 }
 
 tsl::StatusOr<std::unique_ptr<dnn::RnnDescriptor>>

--- a/xla/stream_executor/stream_executor_pimpl.h
+++ b/xla/stream_executor/stream_executor_pimpl.h
@@ -335,7 +335,9 @@ class StreamExecutor {
 
   // Get the list of supported algorithms for BLAS gemm.
   bool GetBlasGemmAlgorithms(Stream* stream,
-                             std::vector<blas::AlgorithmType>* out_algorithms);
+      const gpu::MatrixDescriptor& a, const gpu::MatrixDescriptor& b,
+      gpu::MatrixOutDescriptor *c, const void *alpha, const void *beta, 
+      std::vector<blas::AlgorithmType> *out_algorithms);
 
   // Create an RNN descriptor based on model shapes and configurations.
   // The caller retains the ownership of the descriptor.

--- a/xla/tests/matmul_test.cc
+++ b/xla/tests/matmul_test.cc
@@ -33,6 +33,17 @@ class MatmulTestWithCublas : public HloTestBase,
     debug_options.set_xla_gpu_enable_cublaslt(use_cublas_lt_);
     return debug_options;
   }
+  void SetUp() override {
+    auto dbg  = GetDebugOptionsForTest();
+    if(dbg.xla_gpu_enable_cublaslt()) {
+      const auto& gpu_cc = backend().default_stream_executor()
+                  ->GetDeviceDescription().gpu_compute_capability();
+      if(auto *rocm = std::get_if< se::RocmComputeCapability >(&gpu_cc); 
+              rocm != nullptr && !rocm->has_hipblaslt())  {
+        GTEST_SKIP() << "No hipblas-lt support on this architecture!";
+      }
+    }
+  }
 
  private:
   const bool use_cublas_lt_{GetParam()};


### PR DESCRIPTION
In this PR, we (partially) enable BLAS-with-algorithm functionality, and, as a consequence, also enable several gemm-related tests on ROCM platform.

BLAS API functions implemented: 
-  DoBlasGemmWithAlgorithm
-  DoBlasGemmStridedBatchedWithAlgorithm
-  GetBlasGemmAlgorithms (partially)
	
The main difficulty was the implementation of ```GetBlasGemmAlgorithms```. Unlike CUDA side, where the set of algorithms is static, rocBLAS provides rouines ```rocblas_gemm_ex_get_solutions``` or ```rocblas_gemm_strided_batched_ex_get_solutions``` 
which requires a full set of GEMM parameters to retrieve feasible solutions.

Therefore, I had to adjust BlasSupport interface for ```GetBlasGemmAlgorithms``` function.
And, in order to avoid duplicate code, I had to perform a small refactoring in xla/service/gpu/matmul_utils.cc and xla/service/gpu/runtime/gemm.cc since ```GetBlasGemmAlgorithms``` basically require the same arguments as RunGemm() from matmul_utils.cc.

Namely, I added a member function ```GemmConfig::MatrixDescriptors()``` which constructs a tuple input/output parameters for GemmConfig to be passed to the underlying BLAS routines (so-called MatrixDescriptors replacing the original ```MatrixDescriptor``` struct from xla/service/gpu/matmul_utils.cc). 

Besides, I added a constructor for ```MatrixLayout``` class in order to "unpack" std::optional values earlier (see, e.g., ```leading_dim_stride```), and removed duplicate code from cuda_blas_lt.cc and hip_blas_lt.cc. This facilitates my implementation of MatrixDescriptors function.

Finally, small cleanup issues: I removed ```Overloaded``` template used in several places together with std::visit and replaced it with ```VariantVisitor```.

@xla-rotation: would you please have a look ?

PS: I also specifically tested Tensorflow cross-compilation with my changes to be sure it builds fine since TF directly uses se::gpu::MatrixLayout creation in [matmul_util](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/matmul_util.cc#L156-L160)