### PR TITLE
[ROCM] refactoring overload pattern and adapted some ROCM tests

### DIFF
--- a/xla/service/gpu/autotuner_util.h
+++ b/xla/service/gpu/autotuner_util.h
@@ -54,7 +54,8 @@ struct DevicelessConfig {
 
   // A field to determine the architecture of the device. We only pick an
   // algorithm for non-Ampere architectures.
-  se::CudaComputeCapability cuda_compute_capability{0, 0};
+  se::GpuComputeCapability gpu_compute_capability
+                {se::CudaComputeCapability{0, 0}};
 };
 
 class AutotuneCacheKey {
@@ -132,11 +133,11 @@ class AutotuneConfig {
     return GetAllocator()->GetStream(GetExecutor()->device_ordinal());
   }
 
-  se::CudaComputeCapability GetCudaComputeCapability() const {
+  const se::GpuComputeCapability& GetGpuComputeCapability() const {
     if (auto c = std::get_if<DeviceConfig>(&config_)) {
-      return c->stream_exec->GetDeviceDescription().cuda_compute_capability();
+      return c->stream_exec->GetDeviceDescription().gpu_compute_capability();
     }
-    return std::get<DevicelessConfig>(config_).cuda_compute_capability;
+    return std::get<DevicelessConfig>(config_).gpu_compute_capability;
   }
 
   bool IsDeviceless() const {

--- a/xla/service/gpu/cublas_padding_requirements.cc
+++ b/xla/service/gpu/cublas_padding_requirements.cc
@@ -26,17 +26,10 @@ namespace gpu {
 
 namespace {
 
-template <class... Ts>
-struct Overload : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
-
 bool DimensionRequiresPadding(const int64_t size, const PrimitiveType data_type,
                               const se::GpuComputeCapability& gpu_cc) {
   return std::visit(
-      Overload{
+      se::VariantVisitor{
           [&](const se::CudaComputeCapability& cc) {
             for (const auto& req : CublasPaddingRequirements) {
               if (cc.IsAtLeast(req.min_compute_capability) &&

--- a/xla/service/gpu/float_support_test.cc
+++ b/xla/service/gpu/float_support_test.cc
@@ -26,11 +26,9 @@ namespace {
 
 class FloatSupportTest : public HloTestBase {
  public:
-  se::CudaComputeCapability GetCudaComputeCapability() {
-    return backend()
-        .default_stream_executor()
-        ->GetDeviceDescription()
-        .cuda_compute_capability();
+  const se::GpuComputeCapability& GetGpuComputeCapability() {
+    return backend().default_stream_executor()
+        ->GetDeviceDescription().gpu_compute_capability();
   }
 };
 
@@ -72,9 +70,18 @@ ENTRY e {
 }
 
 TEST_F(FloatSupportTestWithTriton, MixedTypeDotWithBF16IsNotUpcasted) {
-  if (!GetCudaComputeCapability().IsAtLeast(
-          se::CudaComputeCapability::AMPERE)) {
-    GTEST_SKIP() << "No BF16 before Ampere.";
+
+  bool skip_test = std::visit(se::VariantVisitor{
+    [](const se::CudaComputeCapability& cc) {
+      return !cc.IsAtLeast(se::CudaComputeCapability::AMPERE);
+    },
+    [](const se::RocmComputeCapability&) {
+      return true;
+    }
+  }, GetGpuComputeCapability());
+  
+  if(skip_test) {
+    GTEST_SKIP() << "Not supported on this GPU architecture";
   }
 
   constexpr absl::string_view kHloText = R"(

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -265,10 +265,16 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
       AutotunerUtil::CreateBuffer(buffer_allocator, output_shape,
                                   autotune_config, rng_state));
 
-  int64_t workspace_size =
-      autotune_config.GetCudaComputeCapability().IsAtLeastHopper()
-          ? GemmConfig::kHopperWorkspace
+  int64_t workspace_size = std::visit(se::VariantVisitor{
+    [](const se::CudaComputeCapability& cc) {
+      return cc.IsAtLeastHopper() ? GemmConfig::kHopperWorkspace
           : GemmConfig::kDefaultWorkspace;
+    },
+    [](const se::RocmComputeCapability&) {
+      return GemmConfig::kDefaultWorkspace;
+    }
+  }, autotune_config.GetGpuComputeCapability());
+  
   TF_ASSIGN_OR_RETURN(
       se::DeviceMemoryBase workspace_buffer,
       AutotunerUtil::CreateBuffer(buffer_allocator,
@@ -401,13 +407,17 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
 
   GemmBackendConfig updated_config = gemm_config;
 
-  // We only set the 'algorithm' field on non-Ampere architectures, as for
-  // Ampere it's ignored in any case.
-  bool update_algorithm = true;
-#if GOOGLE_CUDA
-  auto capability = config.GetCudaComputeCapability();
-  update_algorithm = !capability.IsAtLeast(se::CudaComputeCapability::AMPERE);
-#endif
+  bool update_algorithm = std::visit(se::VariantVisitor{
+    [](const se::CudaComputeCapability& cc) {
+      // We only set the 'algorithm' field on non-Ampere architectures, as for
+      // Ampere it's ignored in any case.
+      return !cc.IsAtLeast(se::CudaComputeCapability::AMPERE);
+    },
+    [](const se::RocmComputeCapability&) {
+      return true; // TODO: not decided yet
+    }
+  }, config.GetGpuComputeCapability());
+
   if (update_algorithm) {
     if (algorithm.has_gemm()) {
       updated_config.set_selected_algorithm(algorithm.gemm().algorithm());

--- a/xla/service/gpu/gemm_algorithm_picker_test.cc
+++ b/xla/service/gpu/gemm_algorithm_picker_test.cc
@@ -44,6 +44,18 @@ class GemmAlgorithmPickerTest : public HloTestBase,
     debug_options.set_xla_gpu_enable_triton_gemm(false);
     return debug_options;
   }
+
+  void SetUp() override {
+    const auto& gpu_cc = backend().default_stream_executor()
+        ->GetDeviceDescription().gpu_compute_capability();
+
+    if(auto *procm = std::get_if< se::RocmComputeCapability >(&gpu_cc)) {
+      if(GetDebugOptionsForTest().xla_gpu_enable_cublaslt() && 
+            !procm->has_hipblaslt()) {
+        GTEST_SKIP() << "No gpublas-lt support on this architecture!";
+      }
+    }
+  }
 };
 
 TEST_P(GemmAlgorithmPickerTest, SetAlgorithm) {

--- a/xla/service/gpu/gemm_rewriter_triton.cc
+++ b/xla/service/gpu/gemm_rewriter_triton.cc
@@ -61,13 +61,6 @@ namespace gpu {
 
 namespace {
 
-template <class... Ts>
-struct Overload : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
-
 using triton_fusion::CombineRequirements;
 using triton_fusion::DimensionOrder;
 using triton_fusion::DimOrderMap;

--- a/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -981,6 +981,9 @@ ENTRY bf16gemm {
 }
 
 TEST_P(ParameterizedGemmRewriteTest, Int8Gemm) {
+  if (CudaOrRocmCheck(Switch::False, Switch::True)) {
+    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
+  }
 
   const char* hlo_text = R"(
 HloModule int8gemm
@@ -1037,6 +1040,9 @@ ENTRY main.4 {
 }
 
 TEST_P(ParameterizedGemmRewriteTest, Int8GemmNoAlphaRewrite) {
+  if (CudaOrRocmCheck(Switch::False, Switch::True)) {
+    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
+  }
   const char* hlo_text = R"(
 HloModule int8gemm
 
@@ -1072,6 +1078,9 @@ ENTRY int8gemm {
 }
 
 TEST_P(ParameterizedGemmRewriteTest, Int8GemmNoBetaRewrite) {
+  if (CudaOrRocmCheck(Switch::False, Switch::True)) {
+    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
+  }
   const char* hlo_text = R"(
 HloModule int8gemm
 
@@ -1885,6 +1894,9 @@ ENTRY test {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 // Test gemm matrix bias add fusion with mix type
 TEST_F(LegacyCublasGemmRewriteTest, MatrixBiasMixType) {
+  if (CudaOrRocmCheck(Switch::False, Switch::True)) {
+    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
+  }
   std::vector<std::tuple<absl::string_view, absl::string_view>>
       type_combinations = {
           {"f16", "f32"},
@@ -1923,6 +1935,9 @@ ENTRY test {
 
 // Test batch gemm matrix bias add fusion with mix type
 TEST_F(LegacyCublasGemmRewriteTest, MatrixBiasMixTypeBatched) {
+  if (CudaOrRocmCheck(Switch::False, Switch::True)) {
+    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
+  }
   std::vector<std::tuple<absl::string_view, absl::string_view>>
       type_combinations = {
           {"f16", "f32"},

--- a/xla/service/gpu/triton_autotuner.cc
+++ b/xla/service/gpu/triton_autotuner.cc
@@ -229,10 +229,12 @@ class GemmConfigSetCollector : public ConstDfsHloVisitorWithDefault {
   GemmConfigSet GetGemmConfigSet(const HloFusionInstruction* fusion) {
     const DebugOptions& debug_options =
         fusion->GetModule()->config().debug_options();
+    auto cuda_comp = std::get< se::CudaComputeCapability >(
+                                    config_.GetGpuComputeCapability());
     return {GetPossibleMatmulAutotuneConfigs(
         *Cast<HloDotInstruction>(hlo_query::GetFirstInstructionWithOpcode(
             *fusion->called_computations().at(0), HloOpcode::kDot)),
-        config_.GetCudaComputeCapability(), debug_options,
+        cuda_comp, debug_options,
         config_.ExhaustiveTilingSearch())};
   }
 
@@ -456,7 +458,7 @@ StatusOr<std::unique_ptr<HloModule>> CublasGemmAutotuneExtractor(
       AutotunerUtil::ExtractComputationIntoNewModule(*fusion_computation);
   new_module->mutable_config().set_debug_options(debug_opts);
 
-  GemmRewriter rewriter(config.GetCudaComputeCapability());
+  GemmRewriter rewriter(config.GetGpuComputeCapability());
   GpuInstructionFusion fusion_pass(
       /*may_duplicate=*/false, config.GetExecutor()->GetDeviceDescription());
   TF_RETURN_IF_ERROR(rewriter.Run(new_module.get()).status());

--- a/xla/service/gpu/triton_support.cc
+++ b/xla/service/gpu/triton_support.cc
@@ -26,13 +26,6 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-template <class... Ts>
-struct Overload : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-Overload(Ts...) -> Overload<Ts...>;
-
 bool IsDistributiveOverAddition(const HloInstruction& hlo) {
   // The list is most likely incomplete.
   // For example division can be added too but only for operand #0.
@@ -66,14 +59,13 @@ bool IsTritonSupportedDataType(PrimitiveType type,
       return true;
     case BF16:
       return std::visit(
-          Overload{[](const se::CudaComputeCapability& cc) {
-                     return cc.IsAtLeast(
-                         stream_executor::CudaComputeCapability::AMPERE);
-                   },
-                   [](const se::RocmComputeCapability& cc) {
-                     return cc.has_bf16_dtype_support();
-                   }},
-          gpu_version);
+         se::VariantVisitor{[](const se::CudaComputeCapability& cc) {
+            return cc.IsAtLeast(stream_executor::CudaComputeCapability::AMPERE);
+         },
+         [](const se::RocmComputeCapability& cc) {
+           return cc.has_bf16_dtype_support();
+         }},
+         gpu_version);
     default:
       return false;
   }

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -220,6 +220,11 @@ class RocmComputeCapability {
   };
 };
 
+// structure supporting C++17 overload pattern:
+// https://en.cppreference.com/w/cpp/utility/variant/visit
+template<class... Ts> struct VariantVisitor : Ts... { using Ts::operator()...; };
+template<class... Ts> VariantVisitor(Ts...) -> VariantVisitor<Ts...>;
+
 using GpuComputeCapability =
     std::variant<CudaComputeCapability, RocmComputeCapability>;
 

--- a/xla/tests/matmul_test.cc
+++ b/xla/tests/matmul_test.cc
@@ -33,6 +33,17 @@ class MatmulTestWithCublas : public HloTestBase,
     debug_options.set_xla_gpu_enable_cublaslt(use_cublas_lt_);
     return debug_options;
   }
+  void SetUp() override {
+    auto dbg  = GetDebugOptionsForTest();
+    if(dbg.xla_gpu_enable_cublaslt()) {
+      const auto& gpu_cc = backend().default_stream_executor()
+                  ->GetDeviceDescription().gpu_compute_capability();
+      if(auto *rocm = std::get_if< se::RocmComputeCapability >(&gpu_cc); 
+              rocm != nullptr && !rocm->has_hipblaslt())  {
+        GTEST_SKIP() << "No hipblas-lt support on this architecture!";
+      }
+    }
+  }
 
  private:
   const bool use_cublas_lt_{GetParam()};


### PR DESCRIPTION
In this PR I removed Overloaded template used in several places together with std::visit and replaced it with VariantVisitor, and also added GPU architecture checks  for some ROCM tests.

These changes are taken from the original (large) PR: https://github.com/openxla/xla/pull/7782

@xla-rotation: would you please have a look ?