### PR TITLE
[ROCM][NFC] refactoring gemm functionality: MatrixDescriptors

### DIFF
--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -90,7 +90,8 @@ StatusOr<AutotuneResult> GetBestAlgorithm(
                        output_buffer);
     }
 
-    TF_ASSIGN_OR_RETURN(auto profile_result, run_benchmark(algorithm));
+    TF_ASSIGN_OR_RETURN(se::blas::ProfileResult profile_result,
+                        run_benchmark(algorithm));
 
     results.emplace_back();
     AutotuneResult& result = results.back();

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -90,8 +90,7 @@ StatusOr<AutotuneResult> GetBestAlgorithm(
                        output_buffer);
     }
 
-    TF_ASSIGN_OR_RETURN(se::blas::ProfileResult profile_result,
-                        run_benchmark(algorithm));
+    TF_ASSIGN_OR_RETURN(auto profile_result, run_benchmark(algorithm));
 
     results.emplace_back();
     AutotuneResult& result = results.back();
@@ -233,13 +232,13 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
   VLOG(3) << "Starting autotune of GemmThunk " << gemm->ToString();
   se::DeviceMemoryAllocator* allocator = autotune_config.GetAllocator();
   TF_ASSIGN_OR_RETURN(se::Stream* const stream, autotune_config.GetStream());
-  GemmBackendConfig gemm_config =
+  GemmBackendConfig backend_config =
       gemm->backend_config<GemmBackendConfig>().value();
   const DebugOptions& debug_options =
       gemm->GetModule()->config().debug_options();
   const bool deterministic_ops = debug_options.xla_gpu_deterministic_ops();
 
-  TF_ASSIGN_OR_RETURN(GemmConfig config, GemmConfig::For(gemm));
+  TF_ASSIGN_OR_RETURN(GemmConfig gemm_config, GemmConfig::For(gemm));
   // Don't run autotuning concurrently on the same GPU.
   absl::MutexLock gpu_lock(&GetGpuMutex(stream->parent()));
 
@@ -278,18 +277,18 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
   HloModuleConfig& hlo_module_config = gemm->GetModule()->mutable_config();
   AutotuneResult best_algorithm;
   if (IsCublasLtMatmul(*gemm)) {
-    bool has_matrix_bias = config.beta != 0.;
+    bool has_matrix_bias = gemm_config.beta != 0.;
 
     TF_ASSIGN_OR_RETURN(
         bool has_vector_bias,
-        xla::gpu::gpublas_lt::EpilogueAddsVectorBias(gemm_config.epilogue()));
+        gpublas_lt::EpilogueAddsVectorBias(backend_config.epilogue()));
 
     TF_ASSIGN_OR_RETURN(bool has_aux_output,
-                        xla::gpu::gpublas_lt::EpilogueHasAuxiliaryOutput(
-                            gemm_config.epilogue()));
+                        gpublas_lt::EpilogueHasAuxiliaryOutput(
+                            backend_config.epilogue()));
 
     TF_ASSIGN_OR_RETURN(auto epilogue,
-                        AsBlasLtEpilogue(gemm_config.epilogue()));
+                        AsBlasLtEpilogue(backend_config.epilogue()));
 
     se::DeviceMemoryBase bias_buffer;
     if (has_vector_bias) {
@@ -311,7 +310,7 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
     }
 
     TF_ASSIGN_OR_RETURN(auto plan,
-                        BlasLt::GetMatmulPlan(stream, config, epilogue));
+                        BlasLt::GetMatmulPlan(stream, gemm_config, epilogue));
 
     TF_ASSIGN_OR_RETURN(auto algorithms, plan->GetAlgorithms());
 
@@ -320,7 +319,7 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
         GetBestAlgorithm<BlasLt::MatmulAlgorithm>(
             stream, buffer_allocator, gemm->ToString(), autotune_config,
             lhs_buffer, rhs_buffer, output_buffer, algorithms, output_shape,
-            hlo_module_config, gemm_config.beta(),
+            hlo_module_config, backend_config.beta(),
             [&](const BlasLt::MatmulAlgorithm& algorithm)
                 -> StatusOr<se::blas::ProfileResult> {
               se::OwningScratchAllocator<> scratch_allocator(
@@ -350,7 +349,7 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
         GetBestBlasAlgorithm(
             stream, buffer_allocator, gemm->ToString(), autotune_config,
             lhs_buffer, rhs_buffer, output_buffer, algorithms, output_shape,
-            hlo_module_config, gemm_config.beta(),
+            hlo_module_config, backend_config.beta(),
             [&](const se::blas::AlgorithmType& algorithm)
                 -> StatusOr<se::blas::ProfileResult> {
               se::blas::ProfileResult profile_result;
@@ -361,7 +360,7 @@ StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
               // should always return true, and the actual
               // success-ness is returned in
               // ProfileResult::is_valid.
-              TF_RETURN_IF_ERROR(RunGemm(config, lhs_buffer, rhs_buffer,
+              TF_RETURN_IF_ERROR(RunGemm(gemm_config, lhs_buffer, rhs_buffer,
                                          output_buffer, workspace_buffer,
                                          deterministic_ops, stream, algorithm,
                                          &profile_result));
@@ -383,11 +382,11 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
                                 const AutotuneConfig& config) {
   VLOG(3) << "Loading the autotune result of GemmThunk " << gemm->ToString();
 
-  GemmBackendConfig gemm_config =
+  GemmBackendConfig backend_config =
       gemm->backend_config<GemmBackendConfig>().value();
   // Degenerate gemms replaced with memzero operation, no need to auto tune it.
-  if (gemm_config.alpha_real() == 0.0 && gemm_config.alpha_imag() == 0.0 &&
-      gemm_config.beta() == 0.0) {
+  if (backend_config.alpha_real() == 0.0 && 
+      backend_config.alpha_imag() == 0.0 && backend_config.beta() == 0.0) {
     VLOG(3) << "Skip degenerate gemm instruction auto tuning";
     return false;
   }
@@ -399,7 +398,7 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
                         return DoGemmAutotuneNoCache(gemm, key, config);
                       }));
 
-  GemmBackendConfig updated_config = gemm_config;
+  GemmBackendConfig updated_config = backend_config;
 
   // We only set the 'algorithm' field on non-Ampere architectures, as for
   // Ampere it's ignored in any case.
@@ -417,7 +416,7 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
     }
   }
   TF_RETURN_IF_ERROR(gemm->set_backend_config(updated_config));
-  return updated_config.SerializeAsString() != gemm_config.SerializeAsString();
+  return updated_config.SerializeAsString() != backend_config.SerializeAsString();
 }
 
 StatusOr<bool> RunOnComputation(HloComputation* computation,

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -382,11 +382,11 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
                                 const AutotuneConfig& config) {
   VLOG(3) << "Loading the autotune result of GemmThunk " << gemm->ToString();
 
-  GemmBackendConfig backend_config =
+  GemmBackendConfig gemm_config =
       gemm->backend_config<GemmBackendConfig>().value();
   // Degenerate gemms replaced with memzero operation, no need to auto tune it.
-  if (backend_config.alpha_real() == 0.0 && 
-      backend_config.alpha_imag() == 0.0 && backend_config.beta() == 0.0) {
+  if (gemm_config.alpha_real() == 0.0 && 
+      gemm_config.alpha_imag() == 0.0 && gemm_config.beta() == 0.0) {
     VLOG(3) << "Skip degenerate gemm instruction auto tuning";
     return false;
   }
@@ -398,7 +398,7 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
                         return DoGemmAutotuneNoCache(gemm, key, config);
                       }));
 
-  GemmBackendConfig updated_config = backend_config;
+  GemmBackendConfig updated_config = gemm_config;
 
   // We only set the 'algorithm' field on non-Ampere architectures, as for
   // Ampere it's ignored in any case.
@@ -416,7 +416,7 @@ StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
     }
   }
   TF_RETURN_IF_ERROR(gemm->set_backend_config(updated_config));
-  return updated_config.SerializeAsString() != backend_config.SerializeAsString();
+  return updated_config.SerializeAsString() != gemm_config.SerializeAsString();
 }
 
 StatusOr<bool> RunOnComputation(HloComputation* computation,

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -163,7 +163,7 @@ StatusOr<Shape> GetBatchRowColumnShape(const Shape& shape,
   int64_t num_rows = shape.dimensions(1);
   int64_t num_cols = shape.dimensions(2);
 
-  MatrixLayout::Order order = MatrixLayout::Order::kRowMajor;
+  auto order = MatrixLayout::Order::kRowMajor;
   int64_t leading_dim_stride = num_cols;
   int64_t batch_stride = num_rows * num_cols;
 
@@ -190,11 +190,12 @@ StatusOr<Shape> GetBatchRowColumnShape(const Shape& shape,
       return Unimplemented("batch in most minor dimension");
   }
 
-  if (batch_size == 1) batch_stride = 0;
-  return MatrixLayout{
-      shape.element_type(), num_rows,           num_cols,     order,
-      batch_size,           leading_dim_stride, batch_stride,
-  };
+  if (batch_size == 1) {
+    batch_stride = 0;
+  }
+  return MatrixLayout{se::gpu::MatrixLayout{shape.element_type(), 
+      num_rows, num_cols, order, batch_size, 
+      leading_dim_stride, batch_stride}};
 }
 
 /*static*/ StatusOr<MatrixLayout> MatrixLayout::For(
@@ -484,48 +485,64 @@ StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
       grad_y);
 }
 
+auto GemmConfig::MatrixDescriptors(se::DeviceMemoryBase lhs_buf, 
+        se::DeviceMemoryBase rhs_buf, se::DeviceMemoryBase out_buf) const 
+                                                        -> DescriptorsTuple
+{
+  auto create = [](const se::gpu::MatrixLayout& m, se::DeviceMemoryBase data) {
+      // BLAS is column-major by default.
+    auto trans = (m.order == se::gpu::MatrixLayout::Order::kColumnMajor)
+         ? se::blas::Transpose::kNoTranspose : se::blas::Transpose::kTranspose;
+    auto vtype = se::gpu::AsBlasDataType(m.dtype);
+    // unsupported datatypes will be handled by the underlying BLAS layer
+    // which performs one more conversion anyway from gpu::DataType to native
+    // cu/roc BLAS datatype
+    auto type = vtype.ok() ? vtype.value() : 
+       static_cast< se::blas::DataType >(std::numeric_limits< int32_t >::max());
+
+    return se::gpu::MatrixDescriptor{
+      data, m.leading_dim_stride, m.batch_stride, type, trans
+    };
+  };
+  // make a local copy to prevent modification of layouts, 
+  // but maybe we can modify them once instead during creation ?
+  auto lhs = lhs_layout, rhs = rhs_layout, out = output_layout;
+
+  bool must_swap_operands = MakeOutputColumnMajor(lhs, rhs, out);
+  if (must_swap_operands) {
+    std::swap(lhs_buf, rhs_buf);
+  }
+
+   auto comp_vtype = se::gpu::GetBlasComputationType(lhs.dtype, out.dtype,
+            se::blas::kDefaultComputePrecision);
+  // unsupported datatypes will be handled by the underlying BLAS layer
+  auto comp_type = comp_vtype.ok() ? comp_vtype.value() :
+        static_cast< se::blas::ComputationType >(
+            std::numeric_limits< int32_t >::max());
+
+  auto out_desc = se::gpu::MatrixOutDescriptor{ create(out, out_buf) };
+  out_desc.batch_size = out.batch_size;
+  out_desc.m = out.num_rows;
+  out_desc.n = out.num_cols;
+  out_desc.k = lhs.num_cols;
+  out_desc.compute_type = comp_type;
+
+  return std::tuple{ create(lhs, lhs_buf), create(rhs, rhs_buf),
+                     out_desc, must_swap_operands };
+}
+
 namespace {
 
-// This struct contains the metadata of a matrix, e.g., its base address and
-// dimensions.
-struct MatrixDescriptor {
-  se::DeviceMemoryBase data;
-  int64_t leading_dim_stride;
-  int64_t batch_stride;
-  se::blas::Transpose transpose;
-
-  template <typename T>
-  se::DeviceMemory<T> cast() const {
-    return se::DeviceMemory<T>(data);
-  }
-};
-
-se::blas::Transpose AsBlasTranspose(MatrixLayout::Order order) {
-  // BLAS is column-major by default.
-  return (order == MatrixLayout::Order::kColumnMajor)
-             ? se::blas::Transpose::kNoTranspose
-             : se::blas::Transpose::kTranspose;
-}
-
-MatrixDescriptor GetMatrixDesc(const MatrixLayout& layout,
-                               se::DeviceMemoryBase data) {
-  return MatrixDescriptor{
-      data,
-      *layout.leading_dim_stride,
-      *layout.batch_stride,
-      AsBlasTranspose(layout.order),
-  };
-}
-
 template <typename Scale, typename Input, typename Output>
-Status DoGemmWithAlgorithm(
-    int64_t batch_size, int64_t m, int64_t n, int64_t k,
-    const MatrixDescriptor& lhs, const MatrixDescriptor& rhs,
-    const MatrixDescriptor& output, se::DeviceMemoryBase workspace, Scale alpha,
-    Scale beta, se::Stream* stream, se::blas::AlgorithmType algorithm,
+Status DoGemmWithAlgorithm(const se::gpu::MatrixDescriptor& lhs, 
+    const se::gpu::MatrixDescriptor& rhs,
+    const se::gpu::MatrixOutDescriptor& output, se::DeviceMemoryBase workspace, 
+    Scale alpha, Scale beta, se::Stream* stream, 
+    se::blas::AlgorithmType algorithm, 
     se::blas::ComputePrecision compute_precision,
     const se::NumericOptions& numeric_options,
     se::blas::ProfileResult* profile_result, se::blas::CallContext context) {
+      
   CHECK(output.transpose == se::blas::Transpose::kNoTranspose);
   PrimitiveType lhs_type = primitive_util::NativeToPrimitiveType<Input>();
   PrimitiveType output_type = primitive_util::NativeToPrimitiveType<Output>();
@@ -538,26 +555,28 @@ Status DoGemmWithAlgorithm(
   se::blas::BlasSupport::ScopedWorkspace scoped_workspace(
       stream->parent()->AsBlas(), &workspace);
 
-  if (batch_size != 1) {
+  if (output.batch_size != 1) {
     return stream->ThenBlasGemmStridedBatchedWithAlgorithm(
-        lhs.transpose, rhs.transpose, m, n, k, alpha, lhs.cast<Input>(),
-        lhs.leading_dim_stride, lhs.batch_stride, rhs.cast<Input>(),
-        rhs.leading_dim_stride, rhs.batch_stride, beta, &output_data,
-        output.leading_dim_stride, output.batch_stride, batch_size,
-        computation_type, algorithm, numeric_options, profile_result, context);
+        lhs.transpose, rhs.transpose, output.m, output.n, output.k, alpha, 
+        lhs.cast<Input>(), lhs.leading_dim_stride, lhs.batch_stride, 
+        rhs.cast<Input>(), rhs.leading_dim_stride, rhs.batch_stride, 
+        beta, &output_data, output.leading_dim_stride, output.batch_stride, 
+        output.batch_size, computation_type, algorithm, numeric_options, 
+        profile_result, context);
   } else {
     return stream->ThenBlasGemmWithAlgorithm(
-        lhs.transpose, rhs.transpose, m, n, k, alpha, lhs.cast<Input>(),
-        lhs.leading_dim_stride, rhs.cast<Input>(), rhs.leading_dim_stride, beta,
-        &output_data, output.leading_dim_stride, computation_type, algorithm,
-        numeric_options, profile_result, context);
+        lhs.transpose, rhs.transpose, output.m, output.n, output.k, alpha, 
+        lhs.cast<Input>(), lhs.leading_dim_stride, rhs.cast<Input>(), 
+        rhs.leading_dim_stride, beta, &output_data, output.leading_dim_stride, 
+        computation_type, algorithm, numeric_options, profile_result, context);
   }
 }
 
 template <typename Scale, typename Input, typename Output>
-Status DoGemm(int64_t batch_size, int64_t m, int64_t n, int64_t k,
-              const MatrixDescriptor& lhs, const MatrixDescriptor& rhs,
-              const MatrixDescriptor& output, se::DeviceMemoryBase workspace,
+Status DoGemm(const se::gpu::MatrixDescriptor& lhs, 
+              const se::gpu::MatrixDescriptor& rhs,
+              const se::gpu::MatrixOutDescriptor& output, 
+              se::DeviceMemoryBase workspace,
               Scale alpha, Scale beta, se::Stream* stream,
               std::optional<se::blas::AlgorithmType> algorithm,
               se::blas::ComputePrecision compute_precision,
@@ -575,24 +594,25 @@ Status DoGemm(int64_t batch_size, int64_t m, int64_t n, int64_t k,
 #if GOOGLE_CUDA
   if (algorithm) {
     return DoGemmWithAlgorithm<Scale, Input, Output>(
-        batch_size, m, n, k, lhs, rhs, output, workspace, alpha, beta, stream,
+        lhs, rhs, output, workspace, alpha, beta, stream,
         *algorithm, compute_precision, numeric_options, profile_result,
         context);
   }
 #endif
 
-  if (batch_size != 1) {
+  if (output.batch_size != 1) {
     return stream->ThenBlasGemmStridedBatched(
-        lhs.transpose, rhs.transpose, m, n, k, alpha, lhs.cast<Input>(),
-        lhs.leading_dim_stride, lhs.batch_stride, rhs.cast<Input>(),
-        rhs.leading_dim_stride, rhs.batch_stride, beta, &output_data,
-        output.leading_dim_stride, output.batch_stride, batch_size,
-        numeric_options, context);
+        lhs.transpose, rhs.transpose, output.m, output.n, output.k, alpha, 
+        lhs.cast<Input>(), lhs.leading_dim_stride, lhs.batch_stride, 
+        rhs.cast<Input>(), rhs.leading_dim_stride, rhs.batch_stride, 
+        beta, &output_data, output.leading_dim_stride, output.batch_stride, 
+        output.batch_size, numeric_options, context);
   }
 
   return stream->ThenBlasGemm(
-      lhs.transpose, rhs.transpose, m, n, k, alpha, lhs.cast<Input>(),
-      lhs.leading_dim_stride, rhs.cast<Input>(), rhs.leading_dim_stride, beta,
+      lhs.transpose, rhs.transpose, output.m, output.n, output.k, alpha, 
+      lhs.cast<Input>(), lhs.leading_dim_stride, 
+      rhs.cast<Input>(), rhs.leading_dim_stride, beta,
       &output_data, output.leading_dim_stride, numeric_options, context);
 }
 
@@ -607,40 +627,26 @@ Status RunGemm(const GemmConfig& config, se::DeviceMemoryBase lhs_buffer,
                se::blas::ProfileResult* profile_result) {
   VLOG(2) << "Executing a GemmThunk";
 
-  auto lhs_layout = MatrixLayout{config.lhs_layout},
-       rhs_layout = MatrixLayout{config.rhs_layout},
-       output_layout = MatrixLayout{config.output_layout};
-  bool must_swap_operands =
-      se::gpu::MakeOutputColumnMajor(lhs_layout, rhs_layout, output_layout);
-  if (must_swap_operands) {
-    std::swap(lhs_buffer, rhs_buffer);
-  }
+  auto [lhs, rhs, output, operands_swapped] = 
+        config.MatrixDescriptors(lhs_buffer, rhs_buffer, output_buffer);
 
-  int64_t m = output_layout.num_rows;
-  int64_t n = output_layout.num_cols;
-  int64_t k = lhs_layout.num_cols;
-  MatrixDescriptor lhs = GetMatrixDesc(lhs_layout, lhs_buffer);
-  MatrixDescriptor rhs = GetMatrixDesc(rhs_layout, rhs_buffer);
-  MatrixDescriptor output = GetMatrixDesc(output_layout, output_buffer);
-  int64_t batch_size = output_layout.batch_size;
-  se::NumericOptions numeric_options{
-      deterministic_ops,
+  se::NumericOptions numeric_options{deterministic_ops,
       /*allow_tf32=*/config.compute_precision <= 1};
 
   if (!algorithm) algorithm = config.algorithm;
 
   se::blas::CallContext context = se::blas::CallContext::kNone;
   if (config.grad_x) {
-    context = must_swap_operands ? se::blas::CallContext::kBackpropInput2
+    context = operands_swapped ? se::blas::CallContext::kBackpropInput2
                                  : se::blas::CallContext::kBackpropInput1;
   }
   if (config.grad_y) {
-    context = must_swap_operands ? se::blas::CallContext::kBackpropInput1
+    context = operands_swapped ? se::blas::CallContext::kBackpropInput1
                                  : se::blas::CallContext::kBackpropInput2;
   }
 
-  std::tuple<PrimitiveType, PrimitiveType, PrimitiveType> operand_types{
-      lhs_layout.dtype, rhs_layout.dtype, output_layout.dtype};
+  std::tuple operand_types{config.lhs_layout.dtype, config.rhs_layout.dtype, 
+                           config.output_layout.dtype};
 
   // Skip degenerate gemm with memzero. In general this is not safe, because it
   // will suppress NaN propagation, however cuBLAS internally has exactly the
@@ -660,7 +666,7 @@ Status RunGemm(const GemmConfig& config, se::DeviceMemoryBase lhs_buffer,
     using NativeAType = primitive_util::PrimitiveTypeToNative<ATYPE>::type;  \
     using NativeCType = primitive_util::PrimitiveTypeToNative<CTYPE>::type;  \
     return DoGemm<NativeScaleType, NativeAType, NativeCType>(                \
-        batch_size, m, n, k, lhs, rhs, output, workspace_buffer,             \
+        lhs, rhs, output, workspace_buffer,                                  \
         static_cast<NativeScaleType>(config.alpha.real()),                   \
         static_cast<NativeScaleType>(config.beta), stream, algorithm,        \
         config.compute_precision, numeric_options, profile_result, context); \
@@ -673,16 +679,16 @@ Status RunGemm(const GemmConfig& config, se::DeviceMemoryBase lhs_buffer,
     using NativeAType = primitive_util::PrimitiveTypeToNative<ATYPE>::type;  \
     using NativeCType = primitive_util::PrimitiveTypeToNative<CTYPE>::type;  \
     return DoGemm<NativeScaleType, NativeAType, NativeCType>(                \
-        batch_size, m, n, k, lhs, rhs, output, workspace_buffer,             \
+        lhs, rhs, output, workspace_buffer,                                  \
         static_cast<NativeScaleType>(config.alpha),                          \
         static_cast<NativeScaleType>(config.beta), stream, algorithm,        \
         config.compute_precision, numeric_options, profile_result, context); \
   }
 
-  if (output_layout.dtype == S32) {
+  if (config.output_layout.dtype == S32) {
     if (!algorithm) algorithm = se::blas::kDefaultGemmAlgo;
     return DoGemmWithAlgorithm<int32_t, int8_t, int32_t>(
-        batch_size, m, n, k, lhs, rhs, output, workspace_buffer,
+        lhs, rhs, output, workspace_buffer,
         static_cast<int32_t>(config.alpha.real()),
         static_cast<int32_t>(config.beta), stream, *algorithm,
         se::blas::kDefaultComputePrecision, numeric_options, profile_result,
@@ -703,9 +709,9 @@ Status RunGemm(const GemmConfig& config, se::DeviceMemoryBase lhs_buffer,
 #undef TYPED_GEMM_COMPLEX
   return InternalError(
       "Unexpected GEMM dtype: %s %s %s",
-      primitive_util::LowercasePrimitiveTypeName(lhs_layout.dtype),
-      primitive_util::LowercasePrimitiveTypeName(rhs_layout.dtype),
-      primitive_util::LowercasePrimitiveTypeName(output_layout.dtype));
+      primitive_util::LowercasePrimitiveTypeName(config.lhs_layout.dtype),
+      primitive_util::LowercasePrimitiveTypeName(config.rhs_layout.dtype),
+      primitive_util::LowercasePrimitiveTypeName(config.output_layout.dtype));
 }  // namespace gpu
 
 namespace gpublas_lt {
@@ -746,22 +752,23 @@ StatusOr<bool> EpilogueHasAuxiliaryOutput(GemmBackendConfig_Epilogue epilogue) {
 
 StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
     mlir::lmhlo_gpu::CublasLtMatmulEpilogue epilogue) {
+  using mlir::lmhlo_gpu::CublasLtMatmulEpilogue;
   switch (epilogue) {
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Default:
+    case CublasLtMatmulEpilogue::Default:
       return se::gpu::BlasLt::Epilogue::kDefault;
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Relu:
+    case CublasLtMatmulEpilogue::Relu:
       return se::gpu::BlasLt::Epilogue::kReLU;
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Gelu:
+    case CublasLtMatmulEpilogue::Gelu:
       return se::gpu::BlasLt::Epilogue::kGELU;
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::GeluAux:
+    case CublasLtMatmulEpilogue::GeluAux:
       return se::gpu::BlasLt::Epilogue::kGELUWithAux;
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Bias:
+    case CublasLtMatmulEpilogue::Bias:
       return se::gpu::BlasLt::Epilogue::kBias;
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::BiasRelu:
+    case CublasLtMatmulEpilogue::BiasRelu:
       return se::gpu::BlasLt::Epilogue::kBiasThenReLU;
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::BiasGelu:
+    case CublasLtMatmulEpilogue::BiasGelu:
       return se::gpu::BlasLt::Epilogue::kBiasThenGELU;
-    case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::BiasGeluAux:
+    case CublasLtMatmulEpilogue::BiasGeluAux:
       return se::gpu::BlasLt::Epilogue::kBiasThenGELUWithAux;
   }
   return InternalError("unexpected epilogue value");

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -163,7 +163,7 @@ StatusOr<Shape> GetBatchRowColumnShape(const Shape& shape,
   int64_t num_rows = shape.dimensions(1);
   int64_t num_cols = shape.dimensions(2);
 
-  auto order = MatrixLayout::Order::kRowMajor;
+  Order order{Order::kRowMajor};
   int64_t leading_dim_stride = num_cols;
   int64_t batch_stride = num_rows * num_cols;
 
@@ -174,7 +174,7 @@ StatusOr<Shape> GetBatchRowColumnShape(const Shape& shape,
     case 012:  // (B,R,C) (major-to-minor)
       break;
     case 021:  // (B,C,R)
-      order = MatrixLayout::Order::kColumnMajor;
+      order = Order::kColumnMajor;
       leading_dim_stride = num_rows;
       break;
     case 0102:  // (R,B,C)
@@ -182,7 +182,7 @@ StatusOr<Shape> GetBatchRowColumnShape(const Shape& shape,
       batch_stride = num_cols;
       break;
     case 0201:  // (C,B,R)
-      order = MatrixLayout::Order::kColumnMajor;
+      order = Order::kColumnMajor;
       leading_dim_stride = batch_size * num_rows;
       batch_stride = num_rows;
       break;

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -156,6 +156,12 @@ struct GemmConfig : public se::gpu::GemmConfig {
         op.getAlgorithm(), compute_precision, /*grad_x=*/false,
         /*grad_y=*/false);
   }
+
+  using DescriptorsTuple = std::tuple< se::gpu::MatrixDescriptor, 
+                                       se::gpu::MatrixDescriptor, 
+                                       se::gpu::MatrixOutDescriptor, bool >;
+  DescriptorsTuple MatrixDescriptors(se::DeviceMemoryBase lhs_buf, 
+        se::DeviceMemoryBase rhs_buf, se::DeviceMemoryBase out_buf) const;
 };
 
 // Run the given GEMM instruction `gemm` subject to the configuration

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -157,11 +157,15 @@ struct GemmConfig : public se::gpu::GemmConfig {
         /*grad_y=*/false);
   }
 
-  using DescriptorsTuple = std::tuple< se::gpu::MatrixDescriptor, 
-                                       se::gpu::MatrixDescriptor, 
-                                       se::gpu::MatrixOutDescriptor, bool >;
-  DescriptorsTuple MatrixDescriptors(se::DeviceMemoryBase lhs_buf, 
-        se::DeviceMemoryBase rhs_buf, se::DeviceMemoryBase out_buf) const;
+  struct DescriptorsTuple {
+    se::gpu::MatrixDescriptor lhs;
+    se::gpu::MatrixDescriptor rhs;
+    se::gpu::OutputMatrixDescriptor output;
+    bool operands_swapped;
+  };
+  tsl::StatusOr< DescriptorsTuple >  GetMatrixDescriptors(
+        se::DeviceMemoryBase lhs_buf, se::DeviceMemoryBase rhs_buf, 
+        se::DeviceMemoryBase out_buf) const;
 };
 
 // Run the given GEMM instruction `gemm` subject to the configuration

--- a/xla/service/gpu/runtime/gemm.cc
+++ b/xla/service/gpu/runtime/gemm.cc
@@ -51,11 +51,11 @@ using xla::runtime::StridedMemrefView;
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // TODO(ezhulenev): Delete run time auto tuning from XLA.
-Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
-                           se::DeviceMemoryBase lhs, se::DeviceMemoryBase rhs,
-                           se::DeviceMemoryBase out, const Shape& output_shape,
-                           double beta, const DebugOptions* debug_options,
-                           NonAtomicallyUpgradeableRWLock* gpu_lock) {
+Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig *config,
+              se::DeviceMemoryBase lhs_buffer, se::DeviceMemoryBase rhs_buffer,
+              se::DeviceMemoryBase output_buffer, const Shape& output_shape,
+              double beta, const DebugOptions* debug_options,
+              NonAtomicallyUpgradeableRWLock* gpu_lock) {
   VLOG(3) << "Running GEMM runtime autotuning";
   std::vector<se::blas::AlgorithmType> algorithms;
   stream->parent()->GetBlasGemmAlgorithms(stream, &algorithms);
@@ -86,7 +86,8 @@ Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
       AutotuneResult best_algorithm,
       GetBestBlasAlgorithm(
           stream, buffer_allocator, /*gemm_str=*/std::nullopt, autotune_config,
-          lhs, rhs, out, algorithms, output_shape, HloModuleConfig(), beta,
+          lhs_buffer, rhs_buffer, output_buffer, algorithms, 
+          output_shape, HloModuleConfig(), beta,
           [&](const se::blas::AlgorithmType& algorithm)
               -> StatusOr<se::blas::ProfileResult> {
             se::blas::ProfileResult profile_result;
@@ -96,13 +97,14 @@ Status DoRuntimeAutotuning(se::Stream* stream, GemmConfig& config,
             // always return true, and the actual success-ness is returned in
             // ProfileResult::is_valid.
             TF_RETURN_IF_ERROR(
-                RunGemm(config, lhs, rhs, out, se::DeviceMemoryBase(nullptr, 0),
-                        deterministic_ops, stream, algorithm, &profile_result));
+                RunGemm(*config, lhs_buffer, rhs_buffer, output_buffer, 
+                    se::DeviceMemoryBase(nullptr, 0), deterministic_ops, stream, 
+                    algorithm, &profile_result));
             return std::move(profile_result);
           }));
 
   if (best_algorithm.has_gemm()) {
-    config.algorithm = algorithms[best_algorithm.gemm().algorithm()];
+    config->algorithm = algorithms[best_algorithm.gemm().algorithm()];
     return OkStatus();
   } else {
     return InternalError("Runtime autotuning failed to select an algorithm");
@@ -145,7 +147,7 @@ static absl::Status GemmImpl(const ServiceExecutableRunOptions* run_options,
   // deadlock.
   if (gemm_config->algorithm == stream_executor::blas::kRuntimeAutotuning) {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-    auto status = DoRuntimeAutotuning(stream, *gemm_config, lhs_data, rhs_data,
+    auto status = DoRuntimeAutotuning(stream, gemm_config, lhs_data, rhs_data,
                                       output_data, output_shape, beta,
                                       debug_options, gpu_lock);
     if (!status.ok()) {
@@ -153,7 +155,7 @@ static absl::Status GemmImpl(const ServiceExecutableRunOptions* run_options,
     }
 #else
     return absl::InternalError(
-        "Failed to run runtime autotuner because CUDA is not enabled");
+        "Failed to run runtime autotuner because GPU support is not enabled");
 #endif
   }
 

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -91,6 +91,33 @@ tsl::StatusOr<PrimitiveType> AsXlaPrimitiveType(DataType dtype) {
   }
 }
 
+MatrixLayout::MatrixLayout(xla::PrimitiveType dtype_, int64_t num_rows_,
+        int64_t num_cols_, MatrixLayout::Order order_, int64_t batch_size_,
+        std::optional<int64_t> leading_dim_stride_,
+        std::optional<int64_t> batch_stride_,
+        std::optional<blas::Transpose> transpose_) : dtype(dtype_),
+  num_rows(num_rows_), num_cols(num_cols_), 
+  order(order_), batch_size(batch_size_) {
+    
+  if (!leading_dim_stride_) {
+    leading_dim_stride = order == Order::kRowMajor ? num_cols : num_rows;
+  } else {
+    leading_dim_stride = *leading_dim_stride_;
+  }
+  if (!batch_stride_) {
+    batch_stride = (batch_size > 1) ? num_rows * num_cols : 0;
+  } else {
+    batch_stride = *batch_stride_;
+  }
+  transpose = transpose_ ? *transpose_ : blas::Transpose::kNoTranspose;
+}
+
+void MatrixLayout::Transpose() {
+  std::swap(num_rows, num_cols);
+  order =
+        (order == Order::kRowMajor) ? Order::kColumnMajor : Order::kRowMajor;
+}
+
 tsl::StatusOr<ComputationType> GetBlasComputationType(
     PrimitiveType lhs_dtype, PrimitiveType output_dtype,
     int64_t compute_precision) {
@@ -125,15 +152,17 @@ tsl::StatusOr<ComputationType> GetBlasComputationType(
 // BLAS GeMM's output is column-major. If we require row-major, use identity:
 // C^T = (A @ B)^T = B^T @ A^T.
 bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
-                           MatrixLayout& output, MatrixLayout* pC) {
+                           MatrixLayout& output, MatrixLayout* pc) {
   bool swap_operands = output.order != MatrixLayout::Order::kColumnMajor;
   if (swap_operands) {
     std::swap(lhs, rhs);
     rhs.Transpose();
-    lhs.Transpose();
-    // prevent pC and output from being swapped two times if they are equal!
-    if (pC != nullptr && pC != &output) {
-      pC->Transpose();
+    // prevent layouts from being swapped two times if they are equal
+    if(&lhs != &rhs) {
+      lhs.Transpose();
+    }
+    if (pc != nullptr && pc != &output) {
+      pc->Transpose();
     }
     output.Transpose();
   }

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -152,7 +152,7 @@ tsl::StatusOr<ComputationType> GetBlasComputationType(
 // BLAS GeMM's output is column-major. If we require row-major, use identity:
 // C^T = (A @ B)^T = B^T @ A^T.
 bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
-                           MatrixLayout& output, MatrixLayout* pc) {
+                           MatrixLayout& output, MatrixLayout* c) {
   bool swap_operands = output.order != MatrixLayout::Order::kColumnMajor;
   if (swap_operands) {
     std::swap(lhs, rhs);
@@ -161,8 +161,8 @@ bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
     if(&lhs != &rhs) {
       lhs.Transpose();
     }
-    if (pc != nullptr && pc != &output) {
-      pc->Transpose();
+    if (c != nullptr && c != &output) {
+      c->Transpose();
     }
     output.Transpose();
   }

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -51,12 +51,14 @@ struct MatrixLayout {  // plain MatrixLayout which is extended with create
     kColumnMajor,  // Elements in the same column are contiguous in memory.
   };
 
-  void Transpose() {
-    std::swap(num_rows, num_cols);
-    order =
-        (order == Order::kRowMajor) ? Order::kColumnMajor : Order::kRowMajor;
-  }
+  MatrixLayout(xla::PrimitiveType dtype_, int64_t num_rows_,
+        int64_t num_cols_, Order order_, int64_t batch_size_ = 1,
+      std::optional<int64_t> leading_dim_stride_ = {},
+      std::optional<int64_t> batch_stride_ = {},
+      std::optional<blas::Transpose> transpose_ = {});
 
+  void Transpose();
+  
   xla::PrimitiveType dtype;
   // `num_rows` / `num_cols` are for the "logical" matrix shape:
   // i.e. the contracting dim has size `num_cols` for LHS operands and
@@ -65,16 +67,36 @@ struct MatrixLayout {  // plain MatrixLayout which is extended with create
   int64_t num_cols;
   Order order;
   int64_t batch_size;
-  std::optional<int64_t> leading_dim_stride;
+  int64_t leading_dim_stride;
   // `batch_stride` is set to `0` when `batch_size == 1`.
-  std::optional<int64_t> batch_stride;
-  std::optional<blas::Transpose> transpose;
+  int64_t batch_stride;
+  blas::Transpose transpose;
+};
+
+// compact version of the matrix layout to be used o pass matrices
+// to underlying blas API
+struct MatrixDescriptor {
+  DeviceMemoryBase data;
+  int64_t leading_dim_stride;
+  int64_t batch_stride;
+  blas::DataType type;
+  blas::Transpose transpose;
+
+  template <typename T>
+  DeviceMemory<T> cast() const {
+    return DeviceMemory<T>(data);
+  }
+};
+
+struct MatrixOutDescriptor : public MatrixDescriptor {
+  int64_t batch_size, m, n, k;
+  blas::ComputationType compute_type;
 };
 
 // BLAS GeMM's output is column-major. If we require row-major, use identity:
 // C^T = (A @ B)^T = B^T @ A^T.
 bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
-                           MatrixLayout& output, MatrixLayout* pC = nullptr);
+                           MatrixLayout& output, MatrixLayout* pc = nullptr);
 
 struct GemmConfig {  // plain GemmConfig which is extended with create functions
                      // in matmul_utils.h
@@ -90,17 +112,6 @@ struct GemmConfig {  // plain GemmConfig which is extended with create functions
   bool grad_y;
   std::optional<blas::ComputationType> compute_type;
 };
-
-// template < cudaDataType_t What, cudaDataType_t SrcT, class Z, class... T>
-// struct ChooseType {
-//    using type = std::conditional_t< What == SrcT, Z,
-//         typename ChooseType< What, T...>::type>;
-// };
-
-// template < cudaDataType_t What >
-// using CudaToNativeT = typename ChooseType< What, CUDA_R_8F_E4M3,
-// tsl::float8_e4m3fn,
-//         CUDA_R_8F_E5M2, tsl::float8_e5m2, ... >::type;
 
 struct BlasLt {
   enum class Epilogue {

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -73,14 +73,14 @@ struct MatrixLayout {  // plain MatrixLayout which is extended with create
   blas::Transpose transpose;
 };
 
-// compact version of the matrix layout to be used o pass matrices
+// compact version of the matrix layout to be used to pass matrices
 // to underlying blas API
 struct MatrixDescriptor {
   DeviceMemoryBase data;
-  int64_t leading_dim_stride;
-  int64_t batch_stride;
-  blas::DataType type;
-  blas::Transpose transpose;
+  int64_t leading_dim_stride = 0;
+  int64_t batch_stride = 0;
+  blas::DataType type{};
+  blas::Transpose transpose{};
 
   template <typename T>
   DeviceMemory<T> cast() const {
@@ -88,15 +88,18 @@ struct MatrixDescriptor {
   }
 };
 
-struct MatrixOutDescriptor : public MatrixDescriptor {
-  int64_t batch_size, m, n, k;
-  blas::ComputationType compute_type;
+struct OutputMatrixDescriptor : public MatrixDescriptor {
+  OutputMatrixDescriptor(MatrixDescriptor&& parent) noexcept :
+        MatrixDescriptor(std::move(parent)) {}
+  int64_t batch_size = 0;
+  int64_t m = 0, n = 0, k = 0;
+  blas::ComputationType compute_type{};
 };
 
 // BLAS GeMM's output is column-major. If we require row-major, use identity:
 // C^T = (A @ B)^T = B^T @ A^T.
 bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
-                           MatrixLayout& output, MatrixLayout* pc = nullptr);
+                           MatrixLayout& output, MatrixLayout* c = nullptr);
 
 struct GemmConfig {  // plain GemmConfig which is extended with create functions
                      // in matmul_utils.h

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -130,17 +130,11 @@ tsl::Status BlasLt::Init() {
     const gpu::MatrixLayout& m) {
   TF_ASSIGN_OR_RETURN(auto type, gpu::AsBlasDataType(m.dtype));
 
-  auto leading_dim_stride = m.leading_dim_stride;
-  if (!leading_dim_stride) {
-    leading_dim_stride = (m.order == gpu::MatrixLayout::Order::kRowMajor)
-                             ? m.num_cols
-                             : m.num_rows;
-  }
   auto hipblas_data_type_ = AsHipblasDataType(type);
   hipblasLtMatrixLayout_t hip_layout;
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatrixLayoutCreate(
       &hip_layout, hipblas_data_type_, m.num_rows, m.num_cols,
-      *leading_dim_stride));
+      m.leading_dim_stride));
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
   BlasLt::MatrixLayout layout(hip_layout, hipblas_data_type_);
   if (m.order != gpu::MatrixLayout::Order::kColumnMajor)
@@ -149,18 +143,14 @@ tsl::Status BlasLt::Init() {
   TF_RETURN_IF_ERROR(SetAttr(hip_layout, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
                              static_cast<int32_t>(m.batch_size)));
 
-  auto batch_stride = m.batch_stride;
-  if (!batch_stride) {
-    batch_stride = (m.batch_size > 1) ? m.num_rows * m.num_cols : 0;
-  }
   VLOG(2) << "BlasLt::MatrixLayout::Create type: " << (int)type
           << " rows: " << m.num_rows << " cols: " << m.num_cols
           << " batch_size: " << m.batch_size
-          << " leading_dim_stride: " << *leading_dim_stride
-          << " batch_stride: " << *batch_stride;
+          << " leading_dim_stride: " << m.leading_dim_stride
+          << " batch_stride: " << m.batch_stride;
 
   TF_RETURN_IF_ERROR(SetAttr(
-      hip_layout, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, *batch_stride));
+      hip_layout, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, m.batch_stride));
   return std::move(layout);
 }
 
@@ -273,10 +263,7 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& cfg, Epilogue epilogue) const
   // *not* be transposed, and if B is row-major, B must be transposed. We never
   // transpose A or B, and expect the caller to ensure A is row-major and B is
   // column when A and B are FP8.
-  auto trans_a = lhs_layout.transpose ? *lhs_layout.transpose
-                                      : blas::Transpose::kNoTranspose;
-  auto trans_b = rhs_layout.transpose ? *rhs_layout.transpose
-                                      : blas::Transpose::kNoTranspose;
+  auto trans_a = lhs_layout.transpose, trans_b = rhs_layout.transpose;
 
   if (xla::primitive_util::IsF8Type(lhs_layout.dtype) &&
       lhs_layout.order == gpu::MatrixLayout::Order::kColumnMajor) {


### PR DESCRIPTION
In this PR, I refactor some gemm functionality by adding MatrixDescriptors. This is needed in a preparation to enabling BlasGemm*WithAlgorithm functionality for ROCM to avoid code duplication.

Namely, I added a member function GemmConfig::MatrixDescriptors() which constructs a tuple input/output parameters for GemmConfig to be passed to the underlying BLAS routines (so-called MatrixDescriptors replacing the original MatrixDescriptor struct from xla/service/gpu/matmul_utils.cc).

Besides, I added a constructor for MatrixLayout class in order to "unpack" std::optional values earlier (see, e.g., leading_dim_stride), and removed duplicate code from cuda_blas_lt.cc and hip_blas_lt.cc. This facilitates my implementation of MatrixDescriptors function. Here, there are no functional changes, only refactoring tasks.

The idea behind is that instead of calling GEMM routines by passing all **same arguments** over again, e.g. from xla/service/gpu/matmul_utils.cc:
```
stream->ThenBlasGemmStridedBatched(
        lhs.transpose, rhs.transpose, m, n, k, alpha, lhs.cast<Input>(),
        lhs.leading_dim_stride, lhs.batch_stride, rhs.cast<Input>(),
        rhs.leading_dim_stride, rhs.batch_stride, beta, &output_data,
        output.leading_dim_stride, output.batch_stride, batch_size,
        numeric_options, context);
```
later on, we can refactor it as follows:
```
stream->ThenBlasGemmStridedBatched(
    lhs_mat_descriptor, rhs_mat_descriptor, out_mat_descriptor, numeric_options, context);
```
Particularly, this will be used in the upcoming ```GetBlasGemmAlgorithms``` routine which, on the ROCM side, should take the same input arguments as a regular GEMM operation. This was extracted from a (large) PR https://github.com/openxla/xla/pull/7782

@xla-rotation: would you please have a look ?

PS: I also specifically tested Tensorflow cross-compilation with my changes to be sure it builds fine since TF directly uses se::gpu::MatrixLayout creation in [matmul_util](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/matmul_util.cc#L156-L160)