### PR TITLE
[ROCm] hotfix on ROCm build

### DIFF
--- a/xla/service/gpu/kernels/BUILD
+++ b/xla/service/gpu/kernels/BUILD
@@ -106,6 +106,7 @@ xla_test(
     name = "cutlass_gemm_fusion_test",
     srcs = ["cutlass_gemm_fusion_test.cc"],
     backends = ["gpu"],
+    tags = ["no_rocm"],
     deps = [
         ":custom_fusion_pattern",
         ":cutlass_gemm_fusion",

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -135,6 +135,7 @@ cc_library(
         "//xla/stream_executor/cuda:cuda_kernels",
         "//xla/stream_executor/cuda:cuda_conditional_kernels",
     ]) + if_rocm_is_configured([
+        "//xla/stream_executor/rocm:rocm_kernels",
         "//xla/stream_executor/rocm:hip_conditional_kernels",
     ]),
 )

--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -370,6 +370,7 @@ class GpuDriver {
 
   // Enables or disables the specified node in the given exec.
   // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1g371b20eb0c0658731e38db7e68f12c78
+  // https://rocm.docs.amd.com/projects/HIP/en/latest/.doxygen/docBin/html/group___graph.html#ga8902200d9fed1df7644fc7a51c4d327b
   static tsl::Status GraphNodeSetEnabled(GpuGraphExecHandle exec,
                                          GpuGraphNodeHandle node, bool enabled);
 

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -7,6 +7,7 @@ load(
 )
 load(
     "@local_config_rocm//rocm:build_defs.bzl",
+    "if_rocm",
     "if_rocm_hipblaslt",
     "if_rocm_is_configured",
     "rocm_library",
@@ -132,6 +133,16 @@ rocm_library(
     name = "hip_conditional_kernels",
     srcs = if_rocm_is_configured(["hip_conditional_kernels.cu.cc"]),
     deps = if_rocm_is_configured(["@local_config_rocm//rocm:rocm_headers"]),
+)
+
+rocm_library(
+    name = "rocm_kernels",
+    srcs = if_rocm(["rocm_kernels.cu.cc"],
+                    ["rocm_kernels.cc"]),
+    deps = [
+        "@com_google_absl//absl/log",
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
 )
 
 cc_library(

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -526,7 +526,7 @@ static std::string_view StreamCaptureModeToString(
 /* static */ tsl::Status GpuDriver::GraphInstantiate(
     hipGraphExec_t* exec, hipGraph_t graph,
     const GraphInstantiateFlags& flags) {
-  VLOG(2) << "Instante HIP executable graph from graph " << graph << " ("
+  VLOG(2) << "Instantiate HIP executable graph from graph " << graph << " ("
           << "auto_free_on_launch=" << flags.auto_free_on_launch << ", "
           << "device_launch=" << flags.device_launch << ", "
           << "use_node_priority=" << flags.use_node_prirotiy << ", "
@@ -545,6 +545,19 @@ static std::string_view StreamCaptureModeToString(
                        "Failed to launch HIP graph");
   return ::tsl::OkStatus();
 }
+
+/* static */ tsl::Status GpuDriver::GraphNodeSetEnabled(hipGraphExec_t exec,
+                                                        hipGraphNode_t node,
+                                                        bool enabled) {
+  // Node is enabled if value != 0, otherwise the node is disabled.
+  unsigned value = enabled ? 1 : 0;
+  VLOG(2) << "Set HIP executable graph " << exec << " node " << node
+          << " enabled flag to " << value;
+  RETURN_IF_ROCM_ERROR(wrap::hipGraphNodeSetEnabled(exec, node, value),
+                           "Failed to set HIP graph node enabled flag");
+  return ::tsl::OkStatus();
+}
+
 
 /* static */ tsl::Status GpuDriver::GraphExecUpdate(
     hipGraphExec_t exec, hipGraph_t graph, GraphExecUpdateResultInfo* result) {
@@ -800,7 +813,7 @@ GpuDriver::GraphAddNode(hipGraphNode_t* node, hipGraph_t graph,
 
   RETURN_IF_ROCM_ERROR(
       wrap::hipGraphExecChildGraphNodeSetParams(exec, node, child),
-      "Failed to set ROCm graph child node params");
+      "Failed to set HIP graph child node params");
 
   return tsl::OkStatus();
 }
@@ -846,7 +859,7 @@ static hipMemAllocationType ToHipAllocationType(
     absl::Span<GpuGraphNodeHandle> deps, GpuDevicePtr gpu_dst) {
   RETURN_IF_ROCM_ERROR(wrap::hipGraphAddMemFreeNode(node, graph, deps.data(),
                                                     deps.size(), gpu_dst),
-                       "Failed to add memory free node to a ROCM graph");
+                       "Failed to add memory free node to a HIP graph");
   return ::tsl::OkStatus();
 }
 

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -122,6 +122,7 @@ namespace wrap {
   __macro(hipGraphMemAllocNodeGetParams)            \
   __macro(hipGraphLaunch)                           \
   __macro(hipGraphNodeGetType)                      \
+  __macro(hipGraphNodeSetEnabled)                   \
   __macro(hipHostFree)                              \
   __macro(hipHostMalloc)                            \
   __macro(hipHostRegister)                          \

--- a/xla/stream_executor/rocm/rocm_kernels.cc
+++ b/xla/stream_executor/rocm/rocm_kernels.cc
@@ -1,0 +1,22 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "absl/log/log.h"
+
+namespace stream_executor::gpu {
+
+void* GetNoOpKernel() {
+  LOG(ERROR) << "XLA compiled without --config=rocm";
+  return nullptr;
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_kernels.cu.cc
+++ b/xla/stream_executor/rocm/rocm_kernels.cu.cc
@@ -1,0 +1,31 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <array>
+#include <cstdint>
+#include <hip/hip_runtime.h>
+
+
+namespace stream_executor {
+namespace rocm {
+namespace {
+
+__global__ void NoOp() {}
+
+}  // namespace
+}  // namespace rocm
+
+namespace gpu {
+void* GetNoOpKernel() { return reinterpret_cast<void*>(&rocm::NoOp); }
+}  // namespace gpu
+
+}  // namespace stream_executor


### PR DESCRIPTION
1. add hipGraphNodeSetEnabled;  https://github.com/openxla/xla/commit/2ca01bd5abc57af9e0447668b0133bc3cde9f764
2. add no_op for rocm_kernels;  https://github.com/openxla/xla/commit/ff3c0da0bbf1f4a065e5d216c143a87b72395d29 
3. disable cutlass_gemm_fusion_test for rocm (we have [Composable Kernels](https://github.com/ROCm/composable_kernel) compared to cutlass and we will add related GEMM fusion support on it later)


Please review it @xla-rotation  thanks in advance! 