### PR TITLE
[GPU] NCCL User Buffer registration (1/3)

### DIFF
--- a/third_party/tsl/tsl/cuda/nccl.symbols
+++ b/third_party/tsl/tsl/cuda/nccl.symbols
@@ -11,6 +11,8 @@ ncclCommGetAsyncError
 ncclCommInitAll
 ncclCommInitRank
 ncclCommInitRankConfig
+ncclCommDeregister
+ncclCommRegister
 ncclCommSplit
 ncclCommUserRank
 ncclGetErrorString
@@ -40,6 +42,8 @@ pncclCommGetAsyncError
 pncclCommInitAll
 pncclCommInitRank
 pncclCommInitRankConfig
+pncclCommDeregister
+pncclCommRegister
 pncclCommSplit
 pncclCommUserRank
 pncclGetErrorString

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -138,6 +138,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_custom_fusions(false);
   opts.set_xla_gpu_nccl_termination_timeout_seconds(-1);
   opts.set_xla_gpu_enable_shared_constants(true);
+  opts.set_xla_gpu_enable_nccl_user_buffers(false);
 
   // Set 4GB space limit for redzone scratch allocator.
   opts.set_xla_gpu_redzone_scratch_max_megabytes(1LL << 12);
@@ -1080,6 +1081,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_shared_constants),
       debug_options->xla_gpu_enable_shared_constants(),
       "Enable constant sharing between GPU executables"));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_nccl_user_buffers",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_nccl_user_buffers),
+      debug_options->xla_gpu_enable_nccl_user_buffers(),
+      "Enables NCCL User Buffer Registration. collective_memory_size in the "
+      "allocator config must also be set to a non-zero value that is large "
+      "enough to meet peak collective memory usage."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_redzone_scratch_max_megabytes",
       int64_setter_for(

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -912,6 +912,7 @@ tsl_gpu_library(
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:statusor",
     ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
         "@local_config_nccl//:nccl",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rccl",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -108,6 +108,12 @@ cc_library(
 )
 
 cc_library(
+    name = "gpu_memory_space_assignment",
+    hdrs = ["gpu_memory_space_assignment.h"],
+    deps = ["//xla/service:buffer_assignment"],
+)
+
+cc_library(
     name = "launch_dimensions",
     srcs = [
         "launch_dimensions.cc",
@@ -2919,6 +2925,7 @@ cc_library(
         ":executable_proto_cc",
         ":gpu_constants",
         ":gpu_executable",
+        ":gpu_memory_space_assignment",
         ":ir_emitter_context",
         ":ir_emitter_unnested",
         ":metrics",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -912,7 +912,6 @@ tsl_gpu_library(
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:statusor",
     ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_headers",
         "@local_config_nccl//:nccl",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rccl",

--- a/xla/service/gpu/compile_module_to_llvm_ir.cc
+++ b/xla/service/gpu/compile_module_to_llvm_ir.cc
@@ -64,6 +64,7 @@ limitations under the License.
 #include "xla/service/dump.h"
 #include "xla/service/gpu/gpu_constants.h"
 #include "xla/service/gpu/gpu_executable.h"
+#include "xla/service/gpu/gpu_memory_space_assignment.h"
 #include "xla/service/gpu/ir_emitter_context.h"
 #include "xla/service/gpu/ir_emitter_unnested.h"
 #include "xla/service/gpu/metrics.h"
@@ -323,7 +324,12 @@ StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
           /*color_alignment=*/
           [](LogicalBuffer::Color) { return kXlaAllocatedBufferAlignBytes; },
           /*allocate_buffers_for_constants=*/true,
-          /*colorer=*/BufferAssigner::DefaultColorer(),
+          /*colorer=*/
+          hlo_module->config()
+                  .debug_options()
+                  .xla_gpu_enable_nccl_user_buffers()
+              ? CollectiveColorer()
+              : BufferAssigner::DefaultColorer(),
           /*must_not_live_out=*/{}, can_share_buffer_function));
 
   VLOG(1) << "Buffer Assignment Stats for " << hlo_module->name() << "\n"

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -428,7 +428,9 @@ StatusOr<se::DeviceMemoryBase> GpuExecutable::BufferForAllocation(
     se::DeviceMemoryBase buffer_address;
     if (buffer_size > 0) {
       StatusOr<se::OwningDeviceMemory> buffer =
-          memory_allocator->Allocate(device_ordinal, buffer_size);
+          memory_allocator->Allocate(device_ordinal, buffer_size,
+                                     /*retry_on_failure=*/true,
+                                     /*memory_space=*/allocation.color());
       if (!buffer.ok()) {
         return ResourceExhausted("%s\n%s\n", buffer.status().message(),
                                  buffer_assignment_->ToVerboseString(
@@ -654,7 +656,9 @@ StatusOr<ExecutionOutput> GpuExecutable::ExecuteAsyncOnStreamImpl(
         int64_t allocation_size =
             ShapeUtil::ByteSizeOf(ShapeUtil::GetSubshape(output_shape_, index));
         StatusOr<se::OwningDeviceMemory> allocated_buffer =
-            memory_allocator->Allocate(device_ordinal, allocation_size);
+            memory_allocator->Allocate(device_ordinal, allocation_size,
+                                       /*retry_on_failure=*/true,
+                                       /*memory_space=*/allocation->color());
         if (!allocated_buffer.ok()) {
           return ResourceExhausted("%s\n%s\n",
                                    allocated_buffer.status().message(),
@@ -793,7 +797,10 @@ Status GpuExecutable::SetUpMlirAllocation(
     absl::flat_hash_map<ShapeIndex, GpuExecutable::OutputInfo>* output_info,
     Shape* output_shape) {
   for (int i = 0; i < buffer_sizes.size(); i++) {
-    allocations->emplace_back(i, buffer_sizes[i], 0);
+    // This code path is taken when using the non-thunk based runtime. Memory
+    // space is being set to 0 for all allocations. We need to copy over the
+    // value from BufferAssignment instead.
+    allocations->emplace_back(i, buffer_sizes[i], /*memory_space=*/0);
   }
 
   for (int i = 0; i < func.getNumArguments(); i++) {

--- a/xla/service/gpu/gpu_memory_space_assignment.h
+++ b/xla/service/gpu/gpu_memory_space_assignment.h
@@ -1,0 +1,59 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_GPU_MEMORY_SPACE_ASSIGNMENT_H_
+#define XLA_SERVICE_GPU_GPU_MEMORY_SPACE_ASSIGNMENT_H_
+
+#include "xla/service/buffer_assignment.h"
+
+namespace xla {
+namespace gpu {
+
+inline constexpr int64_t kCollectiveMemorySpaceColor = 1;
+
+// Set memory space to kCollectiveMemorySpaceColor for all allocations used by
+// all-reduce, all-gather, and reduce-scatter. This memory space maps to
+// collective memory using ncclMemAlloc in the runtime.
+BufferAssigner::Colorer CollectiveColorer() {
+  return [](HloAliasAnalysis* alias_analysis, const HloOrdering&) {
+    for (HloValue* value : alias_analysis->dataflow_analysis().values()) {
+      auto& buffer = alias_analysis->GetBufferContainingValue(*value);
+      for (const auto& alias : buffer.values()) {
+        if ((alias->instruction()->opcode() == HloOpcode::kAllReduce ||
+             alias->instruction()->opcode() == HloOpcode::kAllReduceStart ||
+             alias->instruction()->opcode() == HloOpcode::kAllReduceDone ||
+             alias->instruction()->opcode() == HloOpcode::kAllGather ||
+             alias->instruction()->opcode() == HloOpcode::kAllGatherStart ||
+             alias->instruction()->opcode() == HloOpcode::kAllGatherDone ||
+             alias->instruction()->opcode() == HloOpcode::kReduceScatter) ||
+            ((alias->instruction()->opcode() == HloOpcode::kAsyncStart ||
+              alias->instruction()->opcode() == HloOpcode::kAsyncDone) &&
+             alias->instruction()->async_wrapped_opcode() ==
+                 HloOpcode::kReduceScatter)) {
+          value->set_color(kCollectiveMemorySpaceColor);
+        }
+      }
+      if (!value->has_color()) {
+        value->set_color(0);
+      }
+    }
+    return OkStatus();
+  };
+}
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_GPU_MEMORY_SPACE_ASSIGNMENT_H_

--- a/xla/service/gpu/nccl_all_gather_thunk.cc
+++ b/xla/service/gpu/nccl_all_gather_thunk.cc
@@ -152,6 +152,7 @@ Status RunAllGather(std::vector<DeviceBufferPair>& buffers, se::Stream& stream,
 #if XLA_ENABLE_XCCL
   int device_ordinal = stream.parent()->device_ordinal();
   VLOG(3) << "Performing all-gather from device ordinal: " << device_ordinal;
+  TF_RETURN_IF_ERROR(MaybeRegisterBuffers(device_ordinal, buffers, comm));
 
   se::gpu::GpuStreamHandle gpu_stream = se::gpu::AsGpuStreamValue(&stream);
 

--- a/xla/service/gpu/nccl_all_reduce_thunk.cc
+++ b/xla/service/gpu/nccl_all_reduce_thunk.cc
@@ -51,6 +51,7 @@ Status RunAllReduce(ReductionKind reduction_kind,
 #if XLA_ENABLE_XCCL
   int device_ordinal = stream.parent()->device_ordinal();
   VLOG(3) << "Performing all-reduce from device ordinal: " << device_ordinal;
+  TF_RETURN_IF_ERROR(MaybeRegisterBuffers(device_ordinal, buffers, comm));
 
   ncclRedOp_t reduce_op = ToNcclReduction(reduction_kind);
 
@@ -370,6 +371,7 @@ Status RunReduceScatter(ReductionKind reduction_kind,
   int device_ordinal = stream.parent()->device_ordinal();
   VLOG(3) << "Performing reduce-scatter from device ordinal: "
           << device_ordinal;
+  TF_RETURN_IF_ERROR(MaybeRegisterBuffers(device_ordinal, buffers, comm));
 
   ncclRedOp_t reduce_op = ToNcclReduction(reduction_kind);
 

--- a/xla/service/gpu/nccl_collective_thunk.cc
+++ b/xla/service/gpu/nccl_collective_thunk.cc
@@ -263,6 +263,7 @@ StatusOr<std::vector<DeviceBufferPair>> ConvertToDeviceBuffers(
 // allocated using ncclMemAlloc.
 StatusOr<bool> IsBufferInCollectiveMemory(int device_ordinal,
                                           const void* buffer) {
+#if XLA_ENABLE_XCCL
   // Get base address, size.
   CUdeviceptr base_ptr;
   size_t base_size;
@@ -295,6 +296,11 @@ StatusOr<bool> IsBufferInCollectiveMemory(int device_ordinal,
   // Check granularity and property requirements are met.
   return base_ptr % granularity == 0 && base_size % granularity == 0 &&
          prop.requestedHandleTypes & CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+#else  // XLA_ENABLE_XCCL
+  return Unimplemented(
+      "NCCL support is not available: this binary was not built with a CUDA "
+      "compiler, which is necessary to build the NCCL source library.");
+#endif  // XLA_ENABLE_XCCL
 }
 
 Status MaybeRegisterBuffers(int device_ordinal,

--- a/xla/service/gpu/nccl_collective_thunk.cc
+++ b/xla/service/gpu/nccl_collective_thunk.cc
@@ -259,6 +259,47 @@ StatusOr<std::vector<DeviceBufferPair>> ConvertToDeviceBuffers(
   return device_buffers;
 }
 
+Status MaybeRegisterBuffers(int device_ordinal,
+                            const std::vector<DeviceBufferPair>& buffers,
+                            ncclComm_t comm) {
+  // TODO(tmorris): Only register if xla_gpu_enable_nccl_user_buffers is true.
+  // Remove this function when cuda graphs are enabled for nccl collectives.
+#if XLA_ENABLE_XCCL
+  // Keep track of which communicators we have registered for already.
+  // Each device has one NCCL buffer which only needs to be registered once per
+  // each comm.
+  struct RegisteredBuffers {
+    absl::Mutex mu;
+    absl::flat_hash_map<int, absl::flat_hash_set<ncclComm_t>> per_device_comms
+        ABSL_GUARDED_BY(mu);
+    // Buffers could be deregistered with ncclCommDeregister.
+    std::vector<void*> handles ABSL_GUARDED_BY(mu);
+  };
+  static auto& all_registered = *new RegisteredBuffers;
+
+  absl::MutexLock lock(&all_registered.mu);
+  for (int i = 0; i < buffers.size(); ++i) {
+    if (!all_registered.per_device_comms[device_ordinal].contains(comm)) {
+      void* handle;
+      VLOG(1) << "ncclCommRegister comm=" << comm << " buff=" << buffers[i].source_buffer.opaque()
+              << " size=" << buffers[i].source_buffer.size();
+      // Since source_buffer and destination_buffer are both slices into the
+      // same ncclMemAlloc buffer, we only need to register one of them and nccl
+      // will register the whole buffer.
+      XLA_CUDA_RETURN_IF_ERROR(ncclCommRegister(
+          comm, const_cast<void*>(buffers[i].source_buffer.opaque()), buffers[i].source_buffer.size(), &handle));
+      all_registered.handles.push_back(handle);
+      all_registered.per_device_comms[device_ordinal].insert(comm);
+    }
+  }
+  return OkStatus();
+#else  // XLA_ENABLE_XCCL
+  return Unimplemented(
+      "NCCL support is not available: this binary was not built with a CUDA "
+      "compiler, which is necessary to build the NCCL source library.");
+#endif  // XLA_ENABLE_XCCL
+}
+
 Status NcclCollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
 #if XLA_ENABLE_XCCL
   VLOG(1) << absl::StreamFormat("Starting %s %s.", IsAsync() ? "async" : "sync",

--- a/xla/service/gpu/nccl_collective_thunk.h
+++ b/xla/service/gpu/nccl_collective_thunk.h
@@ -234,6 +234,16 @@ StatusOr<std::vector<DeviceBufferPair>> ConvertToDeviceBuffers(
     const std::vector<NcclCollectiveThunk::Buffer>& buffers,
     const std::vector<PrimitiveType>& element_types);
 
+// When using ncclMemAlloc, register buffers with the communicator to enable
+// copyless collectives.
+// Registration is only needed when not using cudaGraphs. Remove this function
+// when cudagraphs + nccl is enabled.
+// See
+// https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html
+Status MaybeRegisterBuffers(int device_ordinal,
+                            const std::vector<DeviceBufferPair>& buffers,
+                            ncclComm_t comm);
+
 }  // namespace gpu
 }  // namespace xla
 

--- a/xla/service/gpu/nccl_utils.cc
+++ b/xla/service/gpu/nccl_utils.cc
@@ -73,6 +73,19 @@ Status ToStatus(ncclResult_t s, const char* file, int64_t line,
       file, line, expr, ncclGetErrorString(s), ncclGetLastError(nullptr)));
 }
 
+Status ToStatus(CUresult s, const char* file, int64_t line, const char* expr) {
+  if (s == CUDA_SUCCESS) {
+    return OkStatus();
+  }
+  const char* name;
+  cuGetErrorName(s, &name);
+  const char* message;
+  cuGetErrorString(s, &message);
+  return tsl::errors::Internal(
+      absl::StrFormat("%s:%d: CUDA operation %s failed: %s, %s", file, line,
+                      expr, name, message));
+}
+
 ncclRedOp_t ToNcclReduction(ReductionKind kind) {
   switch (kind) {
     case ReductionKind::SUM:

--- a/xla/service/gpu/nccl_utils.h
+++ b/xla/service/gpu/nccl_utils.h
@@ -49,10 +49,13 @@ limitations under the License.
 #include "rocm/include/rccl.h"
 #endif
 #else
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/driver_types.h"
 #include "third_party/nccl/nccl.h"
 #endif
+
+#if XLA_ENABLE_XCCL
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/driver_types.h"
+#endif  // XLA_ENABLE_XCCL
 
 namespace xla {
 namespace gpu {
@@ -66,7 +69,9 @@ bool IsGlobalNcclConfig();
 
 Status ToStatus(ncclResult_t s, const char* file, int64_t line,
                 const char* expr);
+#if XLA_ENABLE_XCCL
 Status ToStatus(CUresult s, const char* file, int64_t line, const char* expr);
+#endif  // XLA_ENABLE_XCCL
 
 // Macros to return or warn on CUDA/NCCL errors.  (The same macro works for both
 // NCCL and CUDA errors.)

--- a/xla/service/gpu/nccl_utils.h
+++ b/xla/service/gpu/nccl_utils.h
@@ -49,6 +49,8 @@ limitations under the License.
 #include "rocm/include/rccl.h"
 #endif
 #else
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/driver_types.h"
 #include "third_party/nccl/nccl.h"
 #endif
 
@@ -64,6 +66,7 @@ bool IsGlobalNcclConfig();
 
 Status ToStatus(ncclResult_t s, const char* file, int64_t line,
                 const char* expr);
+Status ToStatus(CUresult s, const char* file, int64_t line, const char* expr);
 
 // Macros to return or warn on CUDA/NCCL errors.  (The same macro works for both
 // NCCL and CUDA errors.)

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -665,7 +665,10 @@ message DebugOptions {
   // Enables currently disabled features within Triton for Hopper.
   bool xla_gpu_enable_triton_hopper = 266;
 
-  // Next id: 267
+  // Enable NCCL user buffers.
+  bool xla_gpu_enable_nccl_user_buffers = 267;
+
+  // Next id: 268
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR enables XLA to take advantage of [NCCL User Buffer Registration](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html) in NCCL 2.19:
> User Buffer Registration is a feature that allows NCCL to directly send/receive/operate data through the user buffer without extra internal copy. It can accelerate collectives and reduce the resource usage (e.g. #channel usage).

NCCL supports this feature for all reduce, all gather, and reduce scatter. To use the feature, A buffer must be allocated with `ncclMemAlloc`. Then, the buffer must be registered using `ncclCommRegister` for all communicators. If capturing collectives using cuda graphs, `ncclCommRegister` can be skipped. Finally, when performing a collective using offsets to this buffer, all devices must have the same offset into the buffer.

This PR contains the following components to enable this feature:

1. Compiler
   - If flag `xla_gpu_enable_nccl_user_buffers` is true, a custom "colorer" function will be passed to `BufferAssignment` which will mark all buffers for all reduce, all gather, and reduce scatter to use alternate memory space `1`.
2. Runtime
   -  The StreamExecutorGpuClient will create a second `BFCAllocator` for each device which uses `ncclMemAlloc/ncclMemFree` as its suballocator. The amount of memory reserved can be configured using `GpuAllocatorConfig.collective_memory_size`.
   - `MultiDeviceAllocator` will read the `memory_space` value for each allocation and use it to route the allocation to the correct allocator. Since `memory_space` is not passed to the deallocate function, it uses a hash map to remember which memory space each address belongs to.
   - When running a collective, the first time a buffer is encountered for each communicator it is registered using `ncclCommRegister`. The collective buffers will use a slice of the `ncclMemAlloc`'d CollectiveBFCAllocator memory, but `ncclCommRegister` will automatically locate the base address and size to register the entire `ncclMemAlloc` memory. Once, cudagraph capture of nccl collectives is supported, this code can be removed.

NCCL 2.19 is required for `ncclCommRegister`.

PJRT Changes: https://github.com/openxla/xla/pull/7963
StreamExecutor Changes: https://github.com/openxla/xla/pull/7962
