### PR TITLE
ENH Prioritizes finding `ptxas` in preferred CUDA paths before searching `$PATH`

### DIFF
--- a/xla/stream_executor/gpu/asm_compiler.cc
+++ b/xla/stream_executor/gpu/asm_compiler.cc
@@ -188,33 +188,42 @@ std::string FindCudaExecutable(const std::string& binary_name,
     return it->second;
   }
 
-  // Try searching in the default PATH first if applicable.
-  if (tsl::PreferPtxasFromPath() &&
-      GetToolVersionString(binary_filename).ok()) {
+  auto env = tsl::Env::Default();
+  std::string binary_path = preferred_cuda_dir;
+
+  // Search in the preferred cuda directory
+  VLOG(2) << "Looking for " << binary_filename << " at " << binary_path;
+  if (env->FileExists(binary_path).ok() &&
+      GetToolVersionString(binary_path).ok()) {
+    VLOG(2) << "Using " << binary_filename << " at " << binary_path;
+    seen_binary_paths->emplace(std::move(cache_key), binary_path);
+    return binary_path;
+  }
+
+  // Try searching in PATH if the preferred cuda directory didn't work.
+  if (GetToolVersionString(binary_filename).ok()) {
     VLOG(2) << "Using " << binary_filename;
     seen_binary_paths->emplace(std::move(cache_key), binary_filename);
     return binary_filename;
   }
 
   // Search in cuda root candidates.
-  auto env = tsl::Env::Default();
-  std::string binary_path;
-  for (const std::string& cuda_root :
-       tsl::CandidateCudaRoots(preferred_cuda_dir)) {
+  for (const std::string& cuda_root : tsl::CandidateCudaRoots()) {
     binary_path = tsl::io::JoinPath(cuda_root, "bin", binary_filename);
     VLOG(2) << "Looking for " << binary_filename << " at " << binary_path;
     if (env->FileExists(binary_path).ok() &&
         GetToolVersionString(binary_path).ok()) {
-      break;
+      VLOG(2) << "Using " << binary_filename << " at " << binary_path;
+      seen_binary_paths->emplace(std::move(cache_key), binary_path);
+      return binary_path;
     }
   }
-  if (!env->FileExists(binary_path).ok()) {
-    // Give up and just rely on subprocess invocation to find the correct
-    // binary. This won't work, in all probability, given we already tried that
-    // above, but it's the best we can do.
-    VLOG(2) << "Unable to find " << binary_name;
-    binary_path = binary_filename;
-  }
+
+  // Give up and just rely on subprocess invocation to find the correct
+  // binary. This won't work, in all probability, given we already tried that
+  // above, but it's the best we can do.
+  VLOG(2) << "Unable to find " << binary_name;
+  binary_path = binary_filename;
   VLOG(2) << "Using " << binary_filename << " at " << binary_path;
   seen_binary_paths->emplace(std::move(cache_key), binary_path);
   return binary_path;


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/18578

When searching for a valid `ptxas` binary, we now prefer to find one in `CandidateCudaRoots(GpuAsmOpts.preferred_cuda_dir)`. If none are found, then `$PATH` will be searched. If neither of the above work we fallback to the usual subprocess invocation.

> [!NOTE]  
> Would folks prefer an environment variable toggling this priority, e.g. `PTXAS_PREFER_PATH`? I think that `preferred_cuda_dir` over `$PATH` is a reasonable assumption for _the vast majority_ of users, but there may be cases where system `ptxas` installations are worth prioritizing.

>[!WARNING]
> I have not been able to test and verify this locally due to the lack of run-time version information for XLA's found `ptxas` version. I'm also not sure how to enable `VLOG` information. I tried setting `TF_CPP_MIN_LOG_LEVEL=0 TF_CPP_VMODULE="asm_compiler=3"`, however no logs were produced. I'd appreciate if anyone could tell me how to correct this :)
