### PR TITLE
[ROCM] fixing topk_kernel_test after StreamExecutor refactoring

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -401,10 +401,7 @@ rocm_library(
 
 xla_cc_test(
     name = "topk_kernel_test",
-    srcs = ["topk_kernel_test.cc"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    srcs = if_gpu_is_configured(["topk_kernel_test.cc"]),
     tags = tf_gpu_tests_tags(),
     deps = [
         ":gpu_kernel_helper",

--- a/xla/service/gpu/runtime/topk_kernel_test.cc
+++ b/xla/service/gpu/runtime/topk_kernel_test.cc
@@ -200,6 +200,12 @@ void BM_SmallTopk(benchmark::State& state) {
   se::DeviceMemory<uint32_t> output_indices =
       executor->AllocateArray<uint32_t>(k, 0);
 
+  if(input_buffer.is_null() || output_values.is_null() || 
+      output_indices.is_null()) {
+    state.SkipWithError("Unable to allocate GPU memory: aborting benchmark");
+    return;
+  }
+
   auto source = RandomVec<T>(n);
   stream.ThenMemcpy(&input_buffer, source.data(), n * sizeof(T));
 
@@ -211,7 +217,7 @@ void BM_SmallTopk(benchmark::State& state) {
     CHECK_OK(stream.BlockHostUntilDone());
     auto timer_duration = timer.value().GetElapsedDuration();
     CHECK_OK(timer_duration.status());
-    state.SetIterationTime(absl::ToDoubleMicroseconds(timer_duration.value()));
+    state.SetIterationTime(absl::ToDoubleSeconds(timer_duration.value()));
   }
   size_t items_processed = batch_size * n * state.iterations();
   state.SetItemsProcessed(items_processed);

--- a/xla/service/gpu/runtime/topk_kernel_test.cc
+++ b/xla/service/gpu/runtime/topk_kernel_test.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "Eigen/Core"  // from @eigen_archive
 #include "xla/service/gpu/runtime/gpu_kernel_helper.h"
+#include "xla/stream_executor/gpu/gpu_init.h"
 #include "xla/stream_executor/gpu/gpu_stream.h"
 #include "xla/stream_executor/gpu/gpu_timer.h"
 #include "xla/stream_executor/gpu/gpu_types.h"
@@ -73,12 +74,8 @@ PrimitiveType Get(float) { return PrimitiveType::F32; }
 PrimitiveType Get(Eigen::bfloat16) { return PrimitiveType::BF16; }
 
 se::StreamExecutor *GetGpuExecutor() {
-  se::Platform* platform =
-#if GOOGLE_CUDA
-      se::MultiPlatformManager::PlatformWithName("CUDA").value();
-#elif TENSORFLOW_USE_ROCM
-      se::MultiPlatformManager::PlatformWithName("ROCM").value();
-#endif
+  auto* platform = se::MultiPlatformManager::PlatformWithName(
+          se::GpuPlatformName()).value();
   return platform->ExecutorForDevice(0).value();
 }
 

--- a/xla/stream_executor/device_memory_allocator.h
+++ b/xla/stream_executor/device_memory_allocator.h
@@ -82,7 +82,7 @@ class ScopedDeviceMemory {
   // object.
   //
   // Postcondition: other == nullptr.
-  ScopedDeviceMemory(ScopedDeviceMemory &&other)
+  ScopedDeviceMemory(ScopedDeviceMemory &&other) noexcept
       : wrapped_(other.Release()),
         device_ordinal_(other.device_ordinal_),
         allocator_(other.allocator_) {}
@@ -94,7 +94,7 @@ class ScopedDeviceMemory {
   // Moves ownership of the memory from other to this object.
   //
   // Postcondition: other == nullptr.
-  ScopedDeviceMemory &operator=(ScopedDeviceMemory &&other) {
+  ScopedDeviceMemory &operator=(ScopedDeviceMemory &&other) noexcept {
     TF_CHECK_OK(Free());
     wrapped_ = other.Release();
     allocator_ = other.allocator_;


### PR DESCRIPTION
In this PR, I fix topk_kernel_test (which was failing on ROCM platform due to recent refactorings in https://github.com/openxla/xla/pull/7314.

To summarize, there are following updates:
-  use ```absl::ToDoubleSeconds()``` in benchmark test, otherwise elapsed time is incorrect: the function ```SetIterationTime``` of gbenchmark takes time in seconds
- use ```AllocateOwnedArray``` to create```ScopedDeviceMemory``` objects: otherwise the test crashes on CUDA and ROCM platform when all GPU memory is consumed
- bugfixing ```BM_SmallTopk```: batch size was missing when allocating **output_values** and **output_indices** arrays
- added ```noexcept``` for ScopedDeviceMemory move constuctor and operator=
- fill-in **input_buffer** in ```BM_SmallTopk``` with meaningful values for adequate running time

@xla-rotation: could you have a look, please ?
