### PR TITLE
[XLA:CPU] Adding support for oneDNN MatMul+GELU/ReLU fusion

### DIFF
--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -75,7 +75,7 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
 
   auto lhs_md = lhs_minfo.GetOneDnnMemDesc();
   auto rhs_md = rhs_minfo.GetOneDnnMemDesc();
-  auto bias_md = memory::desc(nullptr);
+  auto bias_md = memory::desc();
   auto result_md = result_minfo.GetOneDnnMemDesc();
 
   // Update dims and strides for transposed inputs.
@@ -100,45 +100,61 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
   auto bias_mem = memory(nullptr);
   auto result_mem = memory(result_md, cpu_engine, result_minfo.Data());
 
-  bool bias_fusion = (!matmul_config.fused_ops().empty() &&
-                      matmul_config.fused_ops(0) == OneDnnMatMulConfig::BIAS);
+  // Currently, GELU/ReLU only fusion is supported.
+  dnnl::post_ops post_ops;
+  for (auto& fused_op : matmul_config.fused_ops()) {
+    switch (fused_op) {
+      case OneDnnMatMulConfig::RELU:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_relu, 0.f, 0.f);
+        break;
+      case OneDnnMatMulConfig::TANH:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_tanh, 0.f, 0.f);
+        break;
+      case OneDnnMatMulConfig::GELU_TANH:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_gelu_tanh, 0.f, 0.f);
+        break;
+      case OneDnnMatMulConfig::GELU_ERF:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_gelu_erf, 0.f, 0.f);
+        break;
+      case OneDnnMatMulConfig::BIAS: {
+        MemrefInfo bias_minfo(args[arg_indx++]);
+        bias_md = bias_minfo.GetOneDnnMemDesc();
 
-  auto matmul_pd =
-      matmul::primitive_desc(cpu_engine, lhs_md, rhs_md, result_md);
-
-  if (bias_fusion) {
-    auto bias_mem_desc = [](MemrefInfo base, dnnl::memory::data_type dtype) {
-      std::vector<int64_t> dims(base.GetRank(), 1);
-      std::vector<int64_t> strides(base.GetRank(), 1);
-      dims.at(base.GetRank() - 1) = base.GetChannels();
-      return memory::desc{dims, dtype, strides};
-    };
-    MemrefInfo bias_minfo(args[arg_indx++]);
-    bias_md = bias_minfo.GetOneDnnMemDesc();
-
-    // extend bias rank to match result rank
-    auto missed_rank = result_md.get_ndims() - bias_md.get_ndims();
-    XLA_LIGHTWEIGHT_CHECK(missed_rank >= 0);
-    if (missed_rank > 0) {
-      auto bias_dims = bias_md.get_dims();
-      bias_dims.insert(bias_dims.begin(), missed_rank, 1);
-      bias_md = bias_md.reshape(bias_dims);
+        // Extend bias rank to match result rank.
+        auto missed_rank = result_md.get_ndims() - bias_md.get_ndims();
+        XLA_LIGHTWEIGHT_CHECK(missed_rank >= 0);
+        if (missed_rank > 0) {
+          auto bias_dims = bias_md.get_dims();
+          bias_dims.insert(bias_dims.begin(), missed_rank, 1);
+          bias_md = bias_md.reshape(bias_dims);
+        }
+        bias_mem = memory(bias_md, cpu_engine, bias_minfo.Data());
+      } break;
+      default:
+        std::cerr << __FILE__ << ":" << __LINE__
+                  << " Attempt to call OneDNN MatMul runtime library with "
+                     "unsupported post op."
+                  << std::endl;
+        std::abort();
     }
-
-    bias_mem = memory(bias_md, cpu_engine, bias_minfo.Data());
-    matmul_pd =
-        matmul::primitive_desc(cpu_engine, lhs_md, rhs_md, bias_md, result_md);
   }
 
   XLA_LIGHTWEIGHT_CHECK(num_args == arg_indx);
 
+  dnnl::primitive_attr attrs;
+  if (post_ops.len() > 0) {
+    attrs.set_post_ops(post_ops);
+  }
+
+  auto matmul_pd = matmul::primitive_desc(cpu_engine, lhs_md, rhs_md, bias_md,
+                                          result_md, attrs);
+
   auto matmul_prim = matmul(matmul_pd);
 
-  std::unordered_map<int, memory> matmul_args;
-  matmul_args.insert({DNNL_ARG_SRC, lhs_mem});
-  matmul_args.insert({DNNL_ARG_WEIGHTS, rhs_mem});
-  matmul_args.insert({DNNL_ARG_BIAS, bias_mem});
-  matmul_args.insert({DNNL_ARG_DST, result_mem});
+  std::unordered_map<int, memory> matmul_args{{DNNL_ARG_SRC, lhs_mem},
+                                              {DNNL_ARG_WEIGHTS, rhs_mem},
+                                              {DNNL_ARG_BIAS, bias_mem},
+                                              {DNNL_ARG_DST, result_mem}};
 
   matmul_prim.execute(onednn_stream, matmul_args);
 }

--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -136,7 +136,6 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
                    << " Attempt to call OneDNN MatMul runtime library with "
                       "unsupported post op."
                    << std::endl;
-        std::abort();
     }
   }
 

--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_memory_util.h"
 #include "xla/service/cpu/runtime_lightweight_check.h"
+#include "tsl/platform/logging.h"
 #include "tsl/util/onednn_threadpool.h"
 
 namespace xla {
@@ -131,10 +132,10 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
         bias_mem = memory(bias_md, cpu_engine, bias_minfo.Data());
       } break;
       default:
-        std::cerr << __FILE__ << ":" << __LINE__
-                  << " Attempt to call OneDNN MatMul runtime library with "
-                     "unsupported post op."
-                  << std::endl;
+        LOG(FATAL) << __FILE__ << ":" << __LINE__
+                   << " Attempt to call OneDNN MatMul runtime library with "
+                      "unsupported post op."
+                   << std::endl;
         std::abort();
     }
   }

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -284,7 +284,7 @@ TEST_F(MatmulTest, ApproxGELUTestF32) {
   )");
 }
 
-// GPTJ BIAS+GELU pattern with reduced sizes for test time:
+// GPT-J Bias+GELU pattern with reduced sizes for test time:
 // batch=32; seq_len=32; hidden_size=64; intermediate_size=256
 TEST_F(MatmulTest, BiasAndApproxGELUTestF32) {
   const char* matmul_module_str = R"(

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -244,6 +244,125 @@ TEST_F(MatmulTest, SimpleTestF32TransposeBWithBiasAddFusion) {
   MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_);
 }
 
+TEST_F(MatmulTest, ApproxGELUTestF32) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32, entry_computation_layout={(f32[32,32,4,16]{3,2,1,0},f32[32,32,16,32]{3,2,1,0})->f32[32,32,4,32]{3,2,1,0}}
+
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[32,32,4,16]{3,2,1,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[32,32,16,32]{3,2,1,0} parameter(1), parameter_replication={false}
+    onednn.matmul.0 = f32[32,32,4,32]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+    mul.0 = f32[32,32,4,32]{3,2,1,0} multiply(onednn.matmul.0, onednn.matmul.0)
+    mul.1 = f32[32,32,4,32]{3,2,1,0} multiply(onednn.matmul.0, mul.0)
+    const.0 = f32[] constant(0.044715)
+    bcast.0 = f32[32,32,4,32]{3,2,1,0} broadcast(const.0), dimensions={}
+    mul.2 = f32[32,32,4,32]{3,2,1,0} multiply(mul.1, bcast.0)
+    add.0 = f32[32,32,4,32]{3,2,1,0} add(onednn.matmul.0, mul.2)
+    const.1 = f32[] constant(0.797884583)
+    bcast.1 = f32[32,32,4,32]{3,2,1,0} broadcast(const.1), dimensions={}
+    mul.3 = f32[32,32,4,32]{3,2,1,0} multiply(add.0, bcast.1)
+    tanh = f32[32,32,4,32]{3,2,1,0} tanh(mul.3)
+    const.2 = f32[] constant(1)
+    bcast.2 = f32[32,32,4,32]{3,2,1,0} broadcast(const.2), dimensions={}
+    add.2 = f32[32,32,4,32]{3,2,1,0} add(tanh, bcast.2)
+    const.3 = f32[] constant(0.5)
+    bcast.3 = f32[32,32,4,32]{3,2,1,0} broadcast(const.3), dimensions={}
+    mul.4 = f32[32,32,4,32]{3,2,1,0} multiply(add.2, bcast.3)
+    ROOT out = f32[32,32,4,32]{3,2,1,0} multiply(onednn.matmul.0, mul.4)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$matmul",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "outer_dimension_partitions":[],
+  ; CHECK-DAG:     "onednn_matmul_config":{
+  ; CHECK-DAG:       "fused_ops":["GELU_TANH"]
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
+// GPTJ BIAS+GELU pattern with reduced sizes for test time:
+// batch=32; seq_len=32; hidden_size=64; intermediate_size=256
+TEST_F(MatmulTest, BiasAndApproxGELUTestF32) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32, entry_computation_layout={(f32[32,32,64]{2,1,0}, f32[64,256]{1,0}, f32[256]{0})->f32[32,32,256]{2,1,0}}
+
+  ENTRY matmul.test.f32 {
+  Arg_5.6 = f32[32,32,64]{2,1,0} parameter(0), sharding={replicated}
+  Arg_7.8 = f32[64,256]{1,0} parameter(1), sharding={replicated}
+  dot.232 = f32[32,32,256]{2,1,0} dot(Arg_5.6, Arg_7.8), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  Arg_6.7 = f32[256]{0} parameter(2), sharding={replicated}
+  reshape.233 = f32[1,1,256]{2,1,0} reshape(Arg_6.7)
+  broadcast.234 = f32[1,1,256]{2,1,0} broadcast(reshape.233), dimensions={0,1,2}
+  reshape.235 = f32[256]{0} reshape(broadcast.234)
+  broadcast.236 = f32[32,32,256]{2,1,0} broadcast(reshape.235), dimensions={2}
+  add.237 = f32[32,32,256]{2,1,0} add(dot.232, broadcast.236)
+  multiply.238 = f32[32,32,256]{2,1,0} multiply(add.237, add.237)
+  multiply.239 = f32[32,32,256]{2,1,0} multiply(add.237, multiply.238)
+  constant.20 = f32[] constant(0.044715)
+  broadcast.21 = f32[32,32,256]{2,1,0} broadcast(constant.20), dimensions={}
+  multiply.240 = f32[32,32,256]{2,1,0} multiply(multiply.239, broadcast.21)
+  add.241 = f32[32,32,256]{2,1,0} add(add.237, multiply.240)
+  constant.18 = f32[] constant(0.797884583)
+  broadcast.19 = f32[32,32,256]{2,1,0} broadcast(constant.18), dimensions={}
+  multiply.242 = f32[32,32,256]{2,1,0} multiply(add.241, broadcast.19)
+  tanh.243 = f32[32,32,256]{2,1,0} tanh(multiply.242)
+  constant.16 = f32[] constant(1)
+  broadcast.17 = f32[32,32,256]{2,1,0} broadcast(constant.16), dimensions={}
+  add.244 = f32[32,32,256]{2,1,0} add(tanh.243, broadcast.17)
+  constant.14 = f32[] constant(0.5)
+  broadcast.15 = f32[32,32,256]{2,1,0} broadcast(constant.14), dimensions={}
+  multiply.245 = f32[32,32,256]{2,1,0} multiply(add.244, broadcast.15)
+  ROOT out = f32[32,32,256]{2,1,0} multiply(add.237, multiply.245)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$matmul",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "outer_dimension_partitions":[],
+  ; CHECK-DAG:     "onednn_matmul_config":{
+  ; CHECK-DAG:       "fused_ops":["BIAS","GELU_TANH"]
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
+TEST_F(MatmulTest, ReLUTestF32) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32, entry_computation_layout={(f32[32,32,4,16]{3,2,1,0},f32[32,32,16,32]{3,2,1,0})->f32[32,32,4,32]{3,2,1,0}}
+
+  relu.1 {
+    Arg_0.3 = f32[32,32,4,32]{3,2,1,0} parameter(0)
+    constant.4 = f32[] constant(0)
+    broadcast.5 = f32[32,32,4,32]{3,2,1,0} broadcast(constant.4), dimensions={}
+    ROOT maximum.6 = f32[32,32,4,32]{3,2,1,0} maximum(Arg_0.3, broadcast.5)
+  }
+
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[32,32,4,16]{3,2,1,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[32,32,16,32]{3,2,1,0} parameter(1), parameter_replication={false}
+    onednn.matmul.0 = f32[32,32,4,32]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+    ROOT call.7 = f32[32,32,4,32]{3,2,1,0} call(onednn.matmul.0), to_apply=relu.1
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$matmul",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "outer_dimension_partitions":[],
+  ; CHECK-DAG:     "onednn_matmul_config":{
+  ; CHECK-DAG:       "fused_ops":["RELU"]
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
 }  // namespace cpu
 }  // namespace xla
 


### PR DESCRIPTION
This PR enables OneDNN library call for the matched XLA HLO MatMul + GELU/ReLU patterns through custom_call instruction. In particular, this PR:

* Enables MatMul + GELU/ReLU pattern matching with oneDNN rewrite
* Enables OneDNN MatMul post-operations support in the custom call handler
* Adds tests with different variations of MatMul + + GELU/ReLU pattern