### PR TITLE
[ROCM] Enable redzone allocator on ROCM platform

### DIFF
--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -71,7 +71,6 @@ limitations under the License.
 #include "tsl/util/proto/proto_utils.h"
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
-#include "third_party/gpus/cudnn/cudnn_ops_infer.h"
 #include "third_party/gpus/cudnn/cudnn.h"  // IWYU pragma: keep
 #include "third_party/gpus/cudnn/cudnn_ops_infer.h"
 #include "xla/service/gpu/buffer_comparator.h"

--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -71,6 +71,7 @@ limitations under the License.
 #include "tsl/util/proto/proto_utils.h"
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
+#include "third_party/gpus/cudnn/cudnn_ops_infer.h"
 #include "third_party/gpus/cudnn/cudnn.h"  // IWYU pragma: keep
 #include "third_party/gpus/cudnn/cudnn_ops_infer.h"
 #include "xla/service/gpu/buffer_comparator.h"

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -111,7 +111,6 @@ StatusOr<AutotuneResult> GetBestAlgorithm(
     if (!autotune_config.should_check_correctness()) {
       continue;
     }
-#if GOOGLE_CUDA  // redzone check is not yet available on ROCm
     TF_ASSIGN_OR_RETURN(
         se::RedzoneAllocator::RedzoneCheckStatus rz_check_status,
         allocator.CheckRedzones());
@@ -124,7 +123,6 @@ StatusOr<AutotuneResult> GetBestAlgorithm(
       CHECK(!autotune_config.should_crash_on_check_failure());
       continue;
     }
-#endif  // GOOGLE_CUDA
 
     if (!reference_algorithm) {
       stream->ThenMemcpy(&reference_buffer, output_buffer,

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -675,13 +675,11 @@ xla_cc_binary(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:dnn",
         "//xla/stream_executor/host:host_platform",
-        "//xla/stream_executor/rocm:rocm_platform_id",
         "//xla/tests:test_utils",
         "//xla/tools:hlo_module_loader",
         "@llvm-project//llvm:Target",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:platform_port",
-        "@tsl//tsl/platform:rocm_rocdl_path",
         "@tsl//tsl/util:command_line_flags",
     ] + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_platform_id",

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -597,22 +597,3 @@ cc_library(
         }),
     ),
 )
-
-xla_cc_test(
-    name = "redzone_allocator_test",
-    srcs = ["redzone_allocator_test.cc"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
-    tags = tf_cuda_tests_tags() + [
-        "no_cuda_asan",  # TODO(b/171512140): re-enable.
-    ],
-    deps = [
-        ":cuda_executor",
-        "//xla/stream_executor",
-        "//xla/stream_executor:device_memory_allocator",
-        "//xla/stream_executor/gpu:gpu_asm_opts",
-        "//xla/stream_executor/gpu:redzone_allocator",
-        "@tsl//tsl/lib/core:status_test_util",
-        "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
-    ],
-)

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -492,9 +492,6 @@ cc_library(
 xla_cc_test(
     name = "redzone_allocator_test",
     srcs = if_gpu_is_configured(["redzone_allocator_test.cc"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
     tags = tf_gpu_tests_tags() + [
         "no_cuda_asan",  # TODO(b/171512140): re-enable.
     ],

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -6,6 +6,10 @@ load(
     "xla_test",
 )
 load(
+    "//xla:xla.bzl",
+    "xla_cc_test",
+)
+load(
     "@local_config_cuda//cuda:build_defs.bzl",
     "if_cuda",
 )
@@ -32,6 +36,7 @@ load(
 load(
     "@tsl//tsl/platform:build_config_root.bzl",
     "if_static",
+    "tf_gpu_tests_tags",
 )
 load(
     "@tsl//tsl/platform:rules_cc.bzl",
@@ -430,6 +435,26 @@ cc_library(
     ]) + ["@tsl//tsl/platform:statusor"],
 )
 
+gpu_kernel_library(
+    name = "redzone_allocator_kernel",
+    srcs = if_gpu_is_configured(["redzone_allocator.cu.cc"]),
+    hdrs = if_gpu_is_configured(["redzone_allocator.h"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
+    deps = if_gpu_is_configured([
+        ":gpu_asm_opts",
+        "//xla/stream_executor:device_memory",
+        "//xla/stream_executor:device_memory_allocator",
+        "//xla/stream_executor:stream_executor_headers",
+    ]) +
+    if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
+)
+
 cc_library(
     name = "redzone_allocator",
     srcs = if_gpu_is_configured(["redzone_allocator.cc"]),
@@ -459,7 +484,29 @@ cc_library(
         "//xla/stream_executor:device_memory_allocator",
         "//xla/stream_executor:stream_executor_headers",
         "@tsl//tsl/platform:status",
+    ]) + if_rocm_is_configured([
+        ":redzone_allocator_kernel",
     ]),
+)
+
+xla_cc_test(
+    name = "redzone_allocator_test",
+    srcs = if_gpu_is_configured(["redzone_allocator_test.cc"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
+    tags = tf_gpu_tests_tags() + [
+        "no_cuda_asan",  # TODO(b/171512140): re-enable.
+    ],
+    deps = [
+        "//xla/stream_executor",
+        "//xla/stream_executor:device_memory_allocator",
+        ":gpu_asm_opts",
+        ":redzone_allocator",
+        "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/platform:test_main",
+    ],
 )
 
 # TODO(tlongeri): Remove gpu_cudamallocasync_allocator header/impl split

--- a/xla/stream_executor/gpu/redzone_allocator.cc
+++ b/xla/stream_executor/gpu/redzone_allocator.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "tsl/framework/allocator.h"
 #include "tsl/platform/errors.h"
 #include "tsl/platform/status.h"
+#include "tsl/lib/math/math_util.h"
 
 namespace stream_executor {
 
@@ -52,7 +53,7 @@ using RedzoneCheckStatus = RedzoneAllocator::RedzoneCheckStatus;
 
 RedzoneAllocator::RedzoneAllocator(Stream* stream,
                                    DeviceMemoryAllocator* memory_allocator,
-                                   GpuAsmOpts gpu_compilation_opts,
+                                   const GpuAsmOpts& gpu_compilation_opts,
                                    int64_t memory_limit, int64_t redzone_size,
                                    uint8_t redzone_pattern)
     : device_ordinal_(stream->parent()->device_ordinal()),
@@ -308,6 +309,7 @@ static tsl::StatusOr<RedzoneCheckStatus> CheckRedzonesForBuffer(
 tsl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
   StreamExecutor* executor = stream_->parent();
 
+#if GOOGLE_CUDA
   absl::Span<const uint8_t> compiled_ptx = {};
   tsl::StatusOr<absl::Span<const uint8_t>> compiled_ptx_or =
       CompileGpuAsmOrGetCached(executor->device_ordinal(), redzone_checker_ptx,
@@ -324,11 +326,6 @@ tsl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
     });
   }
 
-  ScopedDeviceMemory<uint64_t> out_param =
-      executor->AllocateOwnedScalar<uint64_t>();
-  stream_->ThenMemZero(out_param.ptr(), sizeof(uint64_t));
-
-#if GOOGLE_CUDA
   TF_ASSIGN_OR_RETURN(
       std::shared_ptr<ComparisonKernelT> loaded_kernel,
       (LoadKernelOrGetPtr<DeviceMemory<uint8_t>, uint8_t, uint64_t,
@@ -338,9 +335,12 @@ tsl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
   TF_ASSIGN_OR_RETURN(
       std::unique_ptr<ComparisonKernelT> loaded_kernel,
       (executor->CreateTypedKernel<DeviceMemory<uint8>, uint8, uint64_t,
-                                   DeviceMemory<uint64_t>>(
-          "redzone_checker", redzone_checker_ptx, compiled_ptx)));
+                                    DeviceMemory<uint64_t>>(
+          "redzone_checker", kernel_symbol())));
 #endif  // GOOGLE_CUDA
+
+  auto out_param = executor->AllocateOwnedScalar<uint64_t>();
+  stream_->ThenMemZero(out_param.ptr(), sizeof(uint64_t));
 
   for (const auto& buf_and_size : allocated_buffers_) {
     TF_ASSIGN_OR_RETURN(

--- a/xla/stream_executor/gpu/redzone_allocator.cu.cc
+++ b/xla/stream_executor/gpu/redzone_allocator.cu.cc
@@ -1,0 +1,44 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include "xla/stream_executor/gpu/redzone_allocator.h"
+
+namespace stream_executor {
+
+namespace {
+#if TENSORFLOW_USE_ROCM
+
+__global__ void redzone_checker_kernel(uint8_t* input_buffer,
+                                 uint8_t redzone_pattern,
+                                 uint64_t buffer_length,
+                                 int* out_mismatched_ptr) {
+   uint64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
+   if (idx >= buffer_length) return;
+   if (input_buffer[idx] != redzone_pattern) atomicAdd(out_mismatched_ptr, 1);
+}
+
+#endif
+}  // namespace
+
+void *RedzoneAllocator::kernel_symbol() const {
+#if TENSORFLOW_USE_ROCM
+  return reinterpret_cast<void*>(&redzone_checker_kernel);
+#else
+  return nullptr;
+#endif
+}
+
+}  // namespace stream_executor

--- a/xla/stream_executor/gpu/redzone_allocator.h
+++ b/xla/stream_executor/gpu/redzone_allocator.h
@@ -20,11 +20,9 @@ limitations under the License.
 #include <vector>
 
 #include "xla/stream_executor/device_memory_allocator.h"
-#include "xla/stream_executor/gpu/asm_compiler.h"
 #include "xla/stream_executor/gpu/gpu_asm_opts.h"
 #include "xla/stream_executor/scratch_allocator.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "tsl/lib/math/math_util.h"
 
 namespace stream_executor {
 
@@ -45,7 +43,7 @@ class RedzoneAllocator : public ScratchAllocator {
       1LL << 23;  // 8MiB per side, 16MiB total.
   static constexpr uint8_t kDefaultRedzonePattern = -1;  // NOLINT
   RedzoneAllocator(Stream* stream, DeviceMemoryAllocator* memory_allocator,
-                   GpuAsmOpts gpu_compilation_opts_,
+                   const GpuAsmOpts& gpu_compilation_opts_,
                    int64_t memory_limit = (1LL << 32),  // 4GB
                    int64_t redzone_size = kDefaultRedzoneSize,
                    uint8_t redzone_pattern = kDefaultRedzonePattern);
@@ -100,6 +98,9 @@ class RedzoneAllocator : public ScratchAllocator {
   tsl::StatusOr<RedzoneCheckStatus> CheckRedzones() const;
 
   Stream* stream() const { return stream_; }
+
+  // Return a pointer to in-process kernel symbol (used to check redzones).
+  void* kernel_symbol() const;
 
  private:
   const int device_ordinal_;


### PR DESCRIPTION
Here we enable RedzoneAllocator on ROCM. Previously, it was not possible due to the lack of PTX support on ROCM, but since StreamExecutor supports in-process kernel symbols, it can be done quite easily now.

I did it by analogy to [BufferComparator](https://github.com/ROCmSoftwarePlatform/xla/blob/ef4c0456417ee6bf2216a4cb5244eba92471fe93/xla/service/gpu/buffer_comparator.cc#L78-L82) which also used to be implemented in terms of PTX previously.

Note that, I have only changed the ROCM implementation to use in-process kernel and left the CUDA side intact. Possibly, CUDA side can also be switched to use  in-process kernel as I do not see any direct benefit of using PTX here.

Also, I have moved ```redzone_allocator_test``` from ```xla/stream_executor/cuda/BUILD``` to ```xla/stream_executor/gpu/BUILD``` as it works now for both platforms.

Finally, I have fixed the target ```//xla/service/gpu/tests:hlo_to_llvm_ir``` by removing duplicate ROCM-side deps (after this cleanup PR: https://github.com/openxla/xla/pull/7297)

@xla-rotation: could you have a look, please ?
