### PR TITLE
[GPU] NCCL User Buffer Registration - Add CollectiveMemoryAllocate using ncclMemAlloc to SE (2/3)

### DIFF
--- a/third_party/tsl/tsl/cuda/nccl.symbols
+++ b/third_party/tsl/tsl/cuda/nccl.symbols
@@ -19,6 +19,8 @@ ncclGetUniqueId
 ncclGetVersion
 ncclGroupEnd
 ncclGroupStart
+ncclMemAlloc
+ncclMemFree
 ncclRecv
 ncclRedOpCreatePreMulSum
 ncclRedOpDestroy
@@ -40,6 +42,8 @@ pncclCommInitRank
 pncclCommInitRankConfig
 pncclCommSplit
 pncclCommUserRank
+pncclMemAlloc
+pncclMemFree
 pncclGetErrorString
 pncclGetLastError
 pncclGetUniqueId

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -136,6 +136,7 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_nccl//:nccl",
         "//xla/stream_executor:device_options",
         "//xla/stream_executor:stream_executor_headers",
         "//xla/stream_executor/gpu:gpu_diagnostics_header",

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -563,6 +563,10 @@ int GpuExecutor::CompareOccupancy(int* initial_blocks,
 }
 
 DeviceMemoryBase GpuExecutor::Allocate(uint64_t size, int64_t memory_space) {
+  if (memory_space == 1) {
+    return DeviceMemoryBase(GpuDriver::CollectiveMemoryAllocate(context_, size),
+                            size);
+  }
   CHECK_EQ(memory_space, 0);
   return DeviceMemoryBase(GpuDriver::DeviceAllocate(context_, size), size);
 }

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -564,8 +564,11 @@ int GpuExecutor::CompareOccupancy(int* initial_blocks,
 
 DeviceMemoryBase GpuExecutor::Allocate(uint64_t size, int64_t memory_space) {
   if (memory_space == 1) {
-    return DeviceMemoryBase(GpuDriver::CollectiveMemoryAllocate(context_, size),
-                            size);
+    auto result = GpuDriver::CollectiveMemoryAllocate(context_, size);
+    if (!result.ok()) {
+      LOG(ERROR) << result.status();
+    }
+    return DeviceMemoryBase(*result, size);
   }
   CHECK_EQ(memory_space, 0);
   return DeviceMemoryBase(GpuDriver::DeviceAllocate(context_, size), size);

--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -136,13 +136,15 @@ class GpuDriver {
   // the given context via ncclMemAlloc.
   // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclmemalloc
   // (supported on CUDA only)
-  static void* CollectiveMemoryAllocate(GpuContext* context, uint64_t bytes);
+  static tsl::StatusOr<void*> CollectiveMemoryAllocate(GpuContext* context,
+                                                       uint64_t bytes);
 
   // Deallocates a collective device memory space of size bytes associated with
   // the given context via ncclMemFree.
   // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclmemfree
   // (supported on CUDA only)
-  static void CollectiveMemoryDeallocate(GpuContext* context, void* location);
+  static tsl::Status CollectiveMemoryDeallocate(GpuContext* context,
+                                                void* location);
 
   // Allocates page-locked and CUDA-registered memory on the host via
   // cuMemAllocHost/hipHostMalloc.

--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -132,6 +132,18 @@ class GpuDriver {
   // (supported on CUDA only)
   static void UnifiedMemoryDeallocate(GpuContext* context, void* location);
 
+  // Allocates a collective device memory space of size bytes associated with
+  // the given context via ncclMemAlloc.
+  // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclmemalloc
+  // (supported on CUDA only)
+  static void* CollectiveMemoryAllocate(GpuContext* context, uint64_t bytes);
+
+  // Deallocates a collective device memory space of size bytes associated with
+  // the given context via ncclMemFree.
+  // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclmemfree
+  // (supported on CUDA only)
+  static void CollectiveMemoryDeallocate(GpuContext* context, void* location);
+
   // Allocates page-locked and CUDA-registered memory on the host via
   // cuMemAllocHost/hipHostMalloc.
   // http://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1gdd8311286d2c2691605362c689bc64e0

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -153,6 +153,14 @@ class GpuExecutor : public internal::StreamExecutorInterface {
     return GpuDriver::UnifiedMemoryDeallocate(context_, location);
   }
 
+  void* CollectiveMemoryAllocate(uint64_t size) override {
+    return GpuDriver::CollectiveMemoryAllocate(context_, size);
+  }
+
+  void CollectiveMemoryDeallocate(void* location) override {
+    return GpuDriver::CollectiveMemoryDeallocate(context_, location);
+  }
+
   // CUDA allocation/registration functions are necessary because the driver
   // internally sets up buffers for DMA operations (and page locks them).
   // There's no external interface for us to otherwise control these DMA

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -153,11 +153,11 @@ class GpuExecutor : public internal::StreamExecutorInterface {
     return GpuDriver::UnifiedMemoryDeallocate(context_, location);
   }
 
-  void* CollectiveMemoryAllocate(uint64_t size) override {
+  tsl::StatusOr<void*> CollectiveMemoryAllocate(uint64_t size) override {
     return GpuDriver::CollectiveMemoryAllocate(context_, size);
   }
 
-  void CollectiveMemoryDeallocate(void* location) override {
+  tsl::Status CollectiveMemoryDeallocate(void* location) override {
     return GpuDriver::CollectiveMemoryDeallocate(context_, location);
   }
 

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -1083,19 +1083,17 @@ GpuDriver::GraphAddNode(hipGraphNode_t* node, hipGraph_t graph,
       << "Feature not supported on ROCm platform (UnifiedMemoryDeallocate)";
 }
 
-/* static */ void* GpuDriver::CollectiveMemoryAllocate(GpuContext* context,
-                                                       uint64_t bytes) {
+/* static */ tsl::StatusOr<void*> GpuDriver::CollectiveMemoryAllocate(
+    GpuContext* context, uint64_t bytes) {
   ScopedActivateContext activated{context};
-
-  LOG(ERROR)
-      << "Feature not supported on ROCm platform (CollectiveMemoryAllocate)";
-  return nullptr;
+  return absl::UnimplementedError(
+      "Feature not supported on ROCm platform (CollectiveMemoryAllocate)");
 }
 
-/* static */ void GpuDriver::CollectiveMemoryDeallocate(GpuContext* context,
-                                                        void* location) {
-  LOG(ERROR)
-      << "Feature not supported on ROCm platform (CollectiveMemoryDeallocate)";
+/* static */ tsl::Status GpuDriver::CollectiveMemoryDeallocate(
+    GpuContext* context, void* location) {
+  return absl::UnimplementedError(
+      "Feature not supported on ROCm platform (CollectiveMemoryDeallocate)");
 }
 
 /* static */ void* GpuDriver::HostAllocate(GpuContext* context,

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -1083,6 +1083,21 @@ GpuDriver::GraphAddNode(hipGraphNode_t* node, hipGraph_t graph,
       << "Feature not supported on ROCm platform (UnifiedMemoryDeallocate)";
 }
 
+/* static */ void* GpuDriver::CollectiveMemoryAllocate(GpuContext* context,
+                                                       uint64_t bytes) {
+  ScopedActivateContext activated{context};
+
+  LOG(ERROR)
+      << "Feature not supported on ROCm platform (CollectiveMemoryAllocate)";
+  return nullptr;
+}
+
+/* static */ void GpuDriver::CollectiveMemoryDeallocate(GpuContext* context,
+                                                        void* location) {
+  LOG(ERROR)
+      << "Feature not supported on ROCm platform (CollectiveMemoryDeallocate)";
+}
+
 /* static */ void* GpuDriver::HostAllocate(GpuContext* context,
                                            uint64_t bytes) {
   ScopedActivateContext activation{context};

--- a/xla/stream_executor/stream_executor_internal.h
+++ b/xla/stream_executor/stream_executor_internal.h
@@ -332,6 +332,8 @@ class StreamExecutorInterface {
   // Deallocates unified memory space previously allocated with
   // UnifiedMemoryAllocate.
   virtual void UnifiedMemoryDeallocate(void* mem) {}
+  virtual void* CollectiveMemoryAllocate(uint64_t size) { return nullptr; }
+  virtual void CollectiveMemoryDeallocate(void* mem) {}
   virtual void* HostMemoryAllocate(uint64_t size) = 0;
   virtual void HostMemoryDeallocate(void* mem) = 0;
   virtual bool HostMemoryRegister(void* mem, uint64_t size) = 0;

--- a/xla/stream_executor/stream_executor_internal.h
+++ b/xla/stream_executor/stream_executor_internal.h
@@ -332,8 +332,12 @@ class StreamExecutorInterface {
   // Deallocates unified memory space previously allocated with
   // UnifiedMemoryAllocate.
   virtual void UnifiedMemoryDeallocate(void* mem) {}
-  virtual void* CollectiveMemoryAllocate(uint64_t size) { return nullptr; }
-  virtual void CollectiveMemoryDeallocate(void* mem) {}
+  virtual tsl::StatusOr<void*> CollectiveMemoryAllocate(uint64_t size) {
+    return tsl::errors::Internal("Not implemented");
+  }
+  virtual tsl::Status CollectiveMemoryDeallocate(void* mem) {
+    return tsl::errors::Internal("Not implemented");
+  }
   virtual void* HostMemoryAllocate(uint64_t size) = 0;
   virtual void HostMemoryDeallocate(void* mem) = 0;
   virtual bool HostMemoryRegister(void* mem, uint64_t size) = 0;

--- a/xla/stream_executor/stream_executor_pimpl.cc
+++ b/xla/stream_executor/stream_executor_pimpl.cc
@@ -524,14 +524,15 @@ void StreamExecutor::UnifiedMemoryDeallocate(void* location) {
   return implementation_->UnifiedMemoryDeallocate(location);
 }
 
-void* StreamExecutor::CollectiveMemoryAllocate(uint64_t bytes) {
-  void* buffer = implementation_->CollectiveMemoryAllocate(bytes);
+tsl::StatusOr<void*> StreamExecutor::CollectiveMemoryAllocate(uint64_t bytes) {
+  TF_ASSIGN_OR_RETURN(void* buffer,
+                      implementation_->CollectiveMemoryAllocate(bytes));
   VLOG(1) << "Called StreamExecutor::CollectiveMemoryAllocate(size=" << bytes
           << ") returns " << buffer << StackTraceIfVLOG10();
   return buffer;
 }
 
-void StreamExecutor::CollectiveMemoryDeallocate(void* location) {
+tsl::Status StreamExecutor::CollectiveMemoryDeallocate(void* location) {
   VLOG(1) << "Called StreamExecutor::CollectiveMemoryDeallocate(location="
           << location << ")" << StackTraceIfVLOG10();
 

--- a/xla/stream_executor/stream_executor_pimpl.cc
+++ b/xla/stream_executor/stream_executor_pimpl.cc
@@ -524,6 +524,20 @@ void StreamExecutor::UnifiedMemoryDeallocate(void* location) {
   return implementation_->UnifiedMemoryDeallocate(location);
 }
 
+void* StreamExecutor::CollectiveMemoryAllocate(uint64_t bytes) {
+  void* buffer = implementation_->CollectiveMemoryAllocate(bytes);
+  VLOG(1) << "Called StreamExecutor::CollectiveMemoryAllocate(size=" << bytes
+          << ") returns " << buffer << StackTraceIfVLOG10();
+  return buffer;
+}
+
+void StreamExecutor::CollectiveMemoryDeallocate(void* location) {
+  VLOG(1) << "Called StreamExecutor::CollectiveMemoryDeallocate(location="
+          << location << ")" << StackTraceIfVLOG10();
+
+  return implementation_->CollectiveMemoryDeallocate(location);
+}
+
 void* StreamExecutor::HostMemoryAllocate(uint64_t size) {
   void* buffer = implementation_->HostMemoryAllocate(size);
   VLOG(1) << "Called StreamExecutor::HostMemoryAllocate(size=" << size

--- a/xla/stream_executor/stream_executor_pimpl.h
+++ b/xla/stream_executor/stream_executor_pimpl.h
@@ -192,11 +192,11 @@ class StreamExecutor {
   // See
   // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html
   // for more details on User Buffer Registration.
-  void* CollectiveMemoryAllocate(uint64_t size);
+  tsl::StatusOr<void*> CollectiveMemoryAllocate(uint64_t size);
 
   // Deallocate collective device memory previously allocated with
   // CollectiveMemoryAllocate.
-  void CollectiveMemoryDeallocate(void* mem);
+  tsl::Status CollectiveMemoryDeallocate(void* mem);
 
   // Allocates a region of host memory and registers it with the platform API.
   // Memory allocated in this manner (or allocated and registered with

--- a/xla/stream_executor/stream_executor_pimpl.h
+++ b/xla/stream_executor/stream_executor_pimpl.h
@@ -188,6 +188,16 @@ class StreamExecutor {
   // UnifiedMemoryAllocate.
   void UnifiedMemoryDeallocate(void* location);
 
+  // Allocate collective device memory using ncclMemAlloc.
+  // See
+  // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html
+  // for more details on User Buffer Registration.
+  void* CollectiveMemoryAllocate(uint64_t size);
+
+  // Deallocate collective device memory previously allocated with
+  // CollectiveMemoryAllocate.
+  void CollectiveMemoryDeallocate(void* mem);
+
   // Allocates a region of host memory and registers it with the platform API.
   // Memory allocated in this manner (or allocated and registered with
   // HostMemoryRegister() is required for use in asynchronous memcpy operations,


### PR DESCRIPTION
This PR adds new functions `CollectiveMemoryAllocate` and `CollectiveMemoryDeallocate` to the stream executor which are implemented using `ncclMemAlloc` and `ncclMemFree` for CUDA.

NCCL 2.19 is required for `ncclMemAlloc`/`ncclMemFree`

Main PR here: https://github.com/openxla/xla/pull/7843