### PR TITLE
[GPU] NCCL User Buffer Registration - Create CollectiveBFCAllocator in PJRT (3/3)

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -61,6 +61,8 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
            {"allocator", PJRT_NamedValue_Type::PJRT_NamedValue_kString},
            {"memory_fraction", PJRT_NamedValue_Type::PJRT_NamedValue_kFloat},
            {"preallocate", PJRT_NamedValue_Type::PJRT_NamedValue_kBool},
+           {"collective_memory_size",
+            PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
            {"visible_devices",
             PJRT_NamedValue_Type::PJRT_NamedValue_kInt64List},
            {"node_id", PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
@@ -98,6 +100,10 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
   if (auto it = create_options.find("preallocate");
       it != create_options.end()) {
     allocator_config.preallocate = std::get<bool>(it->second);
+  }
+  if (auto it = create_options.find("collective_memory_size");
+      it != create_options.end()) {
+    allocator_config.collective_memory_size = std::get<int64_t>(it->second);
   }
   std::optional<std::set<int>> visible_devices;
   if (auto it = create_options.find("visible_devices");

--- a/xla/pjrt/gpu/gpu_helpers.cc
+++ b/xla/pjrt/gpu/gpu_helpers.cc
@@ -118,7 +118,7 @@ StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
       absl::StrCat("GPU_", device_ordinal, "_bfc"), opts);
 }
 
-// Builds a BFCAllocator for all local GPUs.
+// Builds a BFCAllocator for all local GPUs that uses collective memory.
 StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
     se::StreamExecutor* executor, size_t allocator_memory, bool preallocate) {
   int device_ordinal = executor->device_ordinal();

--- a/xla/pjrt/gpu/gpu_helpers.cc
+++ b/xla/pjrt/gpu/gpu_helpers.cc
@@ -84,7 +84,9 @@ StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
   int device_ordinal = executor->device_ordinal();
   auto sub_allocator = std::make_unique<se::DeviceMemAllocator>(
       executor, tsl::PlatformDeviceId(device_ordinal),
-      /*use_unified_memory=*/enable_unified_memory,
+      /*memory_type=*/
+          enable_unified_memory ? stream_executor::MemoryType::kUnified
+                                : stream_executor::MemoryType::kDevice,
       /*alloc_visitors=*/std::vector<tsl::SubAllocator::Visitor>(),
       /*free_visitors=*/std::vector<tsl::SubAllocator::Visitor>());
 
@@ -114,6 +116,33 @@ StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
   return std::make_unique<tsl::BFCAllocator>(
       std::move(sub_allocator), allocator_memory,
       absl::StrCat("GPU_", device_ordinal, "_bfc"), opts);
+}
+
+// Builds a BFCAllocator for all local GPUs.
+StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
+    se::StreamExecutor* executor, size_t allocator_memory, bool preallocate) {
+  int device_ordinal = executor->device_ordinal();
+  auto sub_allocator = std::make_unique<se::DeviceMemAllocator>(
+      executor, tsl::PlatformDeviceId(device_ordinal),
+      /*memory_type=*/stream_executor::MemoryType::kCollective,
+      /*alloc_visitors=*/std::vector<tsl::SubAllocator::Visitor>(),
+      /*free_visitors=*/std::vector<tsl::SubAllocator::Visitor>());
+
+  if (preallocate) {
+    LOG(INFO) << "XLA backend allocating " << allocator_memory
+              << " bytes on device " << device_ordinal
+              << " for CollectiveBFCAllocator.";
+  } else {
+    LOG(INFO) << "XLA backend will use up to " << allocator_memory
+              << " bytes on device " << device_ordinal
+              << " for CollectiveBFCAllocator.";
+  }
+
+  tsl::BFCAllocator::Options opts;
+  opts.allow_growth = !preallocate;
+  return std::make_unique<tsl::BFCAllocator>(
+      std::move(sub_allocator), allocator_memory,
+      absl::StrCat("GPU_collectivememory_", device_ordinal, "_bfc"), opts);
 }
 
 // Returns a GPU pinned host memory allocator to use when staging host->GPU

--- a/xla/pjrt/gpu/gpu_helpers.h
+++ b/xla/pjrt/gpu/gpu_helpers.h
@@ -58,9 +58,11 @@ struct GpuAllocatorConfig {
   // allocator will allocate more memory as allocations are requested.
   bool preallocate = true;
 
-  // Amount of collective memory (ncclMemAlloc) to reserve. If this value is 0,
-  // collective memory will not be used.
-  size_t collective_memory_size = 1 * (1LL << 30);
+  // Amount of collective memory (ncclMemAlloc) to reserve. Must be set when
+  // using `xla_gpu_enable_nccl_user_buffers=true`. If this value is 0,
+  // collective memory will not be allocated. Should be set to a multiple of
+  // 512MB to avoid wasting memory due to granularity requirements.
+  size_t collective_memory_size = 0;
 };
 
 std::unique_ptr<tsl::BFCAllocator> GetGpuHostAllocator(

--- a/xla/pjrt/gpu/gpu_helpers.h
+++ b/xla/pjrt/gpu/gpu_helpers.h
@@ -57,6 +57,10 @@ struct GpuAllocatorConfig {
   // fragmentation, allowing more of the total memory to be used. If false, the
   // allocator will allocate more memory as allocations are requested.
   bool preallocate = true;
+
+  // Amount of collective memory (ncclMemAlloc) to reserve. If this value is 0,
+  // collective memory will not be used.
+  size_t collective_memory_size = 1 * (1LL << 30);
 };
 
 std::unique_ptr<tsl::BFCAllocator> GetGpuHostAllocator(
@@ -65,6 +69,10 @@ std::unique_ptr<tsl::BFCAllocator> GetGpuHostAllocator(
 // Builds a BFCAllocator for all local GPUs.
 StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
     se::StreamExecutor* executor, double memory_fraction, bool preallocate);
+
+// Builds a BFCAllocator for all local GPUs using collective memory.
+StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
+    se::StreamExecutor* executor, size_t allocator_memory, bool preallocate);
 
 }  // namespace xla
 

--- a/xla/pjrt/gpu/gpu_helpers.h
+++ b/xla/pjrt/gpu/gpu_helpers.h
@@ -70,7 +70,7 @@ std::unique_ptr<tsl::BFCAllocator> GetGpuHostAllocator(
 StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
     se::StreamExecutor* executor, double memory_fraction, bool preallocate);
 
-// Builds a BFCAllocator for all local GPUs using collective memory.
+// Builds a BFCAllocator for all local GPUs that uses collective memory.
 StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
     se::StreamExecutor* executor, size_t allocator_memory, bool preallocate);
 

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -651,12 +651,13 @@ namespace {
 
 #if defined(GOOGLE_CUDA) && CUDA_VERSION >= 11020
 
-StatusOr<std::unique_ptr<se::MultiDeviceAdapter>> CreateCudaAsyncAllocator(
+StatusOr<std::vector<se::MultiDeviceAdapter::AllocatorInfo>>
+CreateCudaAsyncAllocator(
     se::Platform* platform,
     const std::map<int, std::unique_ptr<LocalDeviceState>>& addressable_devices,
     double memory_fraction, bool preallocate) {
   CHECK_GT(addressable_devices.size(), 0);
-  std::vector<se::MultiDeviceAdapter::AllocatorWithStream> allocators;
+  std::vector<se::MultiDeviceAdapter::AllocatorInfo> allocators;
 
   for (auto& ordinal_and_device : addressable_devices) {
     se::StreamExecutor* executor = ordinal_and_device.second->executor();
@@ -690,15 +691,16 @@ StatusOr<std::unique_ptr<se::MultiDeviceAdapter>> CreateCudaAsyncAllocator(
             ->platform_specific_handle()
             .stream);
     allocators.emplace_back(std::move(allocator),
-                            ordinal_and_device.second->compute_stream());
+                            ordinal_and_device.second->compute_stream(),
+                            /*memory_space=*/0);
   }
-  return std::make_unique<se::MultiDeviceAdapter>(platform,
-                                                  std::move(allocators));
+  return allocators;
 }
 
 #else  // defined(GOOGLE_CUDA) && CUDA_VERSION >= 11020
 
-StatusOr<std::unique_ptr<se::MultiDeviceAdapter>> CreateCudaAsyncAllocator(
+StatusOr<std::vector<se::MultiDeviceAdapter::AllocatorInfo>>
+CreateCudaAsyncAllocator(
     se::Platform* platform,
     const std::map<int, std::unique_ptr<LocalDeviceState>>& addressable_devices,
     double memory_fraction, bool preallocate) {
@@ -730,39 +732,35 @@ GetStreamExecutorGpuDeviceAllocator(
     se::Platform* platform, const GpuAllocatorConfig& allocator_config,
     const std::map<int, std::unique_ptr<LocalDeviceState>>&
         addressable_devices) {
-  std::unique_ptr<se::DeviceMemoryAllocator> allocator;
+  std::vector<se::MultiDeviceAdapter::AllocatorInfo> allocators;
   switch (allocator_config.kind) {
     case GpuAllocatorConfig::Kind::kCudaAsync: {
-      auto allocator_or = CreateCudaAsyncAllocator(
+      auto allocators_or = CreateCudaAsyncAllocator(
           platform, addressable_devices, allocator_config.memory_fraction,
           allocator_config.preallocate);
-      if (allocator_or.ok()) {
+      if (allocators_or.ok()) {
         LOG(INFO) << "Using CUDA async allocator.";
-        allocator = std::move(allocator_or.value());
+        allocators = std::move(allocators_or.value());
         break;
       }
       LOG(ERROR) << "Failed to initialize CUDA async allocator: "
-                 << allocator_or.status() << "; falling back to BFC.";
+                 << allocators_or.status() << "; falling back to BFC.";
       [[fallthrough]];
     }
 
     case GpuAllocatorConfig::Kind::kDefault:
     case GpuAllocatorConfig::Kind::kBFC: {
       LOG(INFO) << "Using BFC allocator.";
-      std::vector<se::MultiDeviceAdapter::AllocatorWithStream>
-          allocators_and_streams;
       for (const auto& ordinal_and_device : addressable_devices) {
         TF_ASSIGN_OR_RETURN(
             auto bfc_allocator,
             CreateBFCAllocator(ordinal_and_device.second->executor(),
                                allocator_config.memory_fraction,
                                allocator_config.preallocate));
-        allocators_and_streams.emplace_back(
-            std::move(bfc_allocator),
-            ordinal_and_device.second->compute_stream());
+        allocators.emplace_back(std::move(bfc_allocator),
+                                ordinal_and_device.second->compute_stream(),
+                                /*memory_space=*/0);
       }
-      allocator = std::make_unique<se::MultiDeviceAdapter>(
-          platform, std::move(allocators_and_streams));
       break;
     }
 
@@ -770,7 +768,24 @@ GetStreamExecutorGpuDeviceAllocator(
       LOG(INFO) << "Using platform allocator.";
       break;
   }
-  return std::move(allocator);
+
+  // Add any additional allocators for alternate memory spaces.
+  if (allocator_config.collective_memory_size != 0) {
+    for (const auto& ordinal_and_device : addressable_devices) {
+      TF_ASSIGN_OR_RETURN(
+          auto collective_bfc_allocator,
+          CreateCollectiveBFCAllocator(
+              ordinal_and_device.second->executor(),
+              /*allocator_memory=*/allocator_config.collective_memory_size,
+              /*preallocate=*/true));
+      allocators.emplace_back(std::move(collective_bfc_allocator),
+                              ordinal_and_device.second->compute_stream(),
+                              /*memory_space=*/1);
+    }
+  }
+
+  return std::make_unique<se::MultiDeviceAdapter>(platform,
+                                                  std::move(allocators));
 }
 
 Status BuildDistributedDevices(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -766,7 +766,14 @@ GetStreamExecutorGpuDeviceAllocator(
 
     case GpuAllocatorConfig::Kind::kPlatform:
       LOG(INFO) << "Using platform allocator.";
-      break;
+      if (allocator_config.collective_memory_size != 0) {
+        LOG(WARNING)
+            << "collective_memory_size is non-zero, but allocator kind is set "
+               "to \"platform\". Collective memory will not be allocated.";
+      }
+      // Returning null will cause the client to use the default backend
+      // allocator.
+      return nullptr;
   }
 
   // Add any additional allocators for alternate memory spaces.

--- a/xla/python/xla.cc
+++ b/xla/python/xla.cc
@@ -590,7 +590,9 @@ static void Init(py::module_& m) {
   alloc_config.def(py::init<>())
       .def_readwrite("kind", &GpuAllocatorConfig::kind)
       .def_readwrite("memory_fraction", &GpuAllocatorConfig::memory_fraction)
-      .def_readwrite("preallocate", &GpuAllocatorConfig::preallocate);
+      .def_readwrite("preallocate", &GpuAllocatorConfig::preallocate)
+      .def_readwrite("collective_memory_size",
+                     &GpuAllocatorConfig::collective_memory_size);
   py::enum_<GpuAllocatorConfig::Kind>(alloc_config, "Kind")
       .value("DEFAULT", GpuAllocatorConfig::Kind::kDefault)
       .value("PLATFORM", GpuAllocatorConfig::Kind::kPlatform)

--- a/xla/python/xla_client.py
+++ b/xla/python/xla_client.py
@@ -103,6 +103,8 @@ def make_gpu_client(
     config.memory_fraction = options['memory_fraction']
   if 'preallocate' in options:
     config.preallocate = options['preallocate']
+  if 'collective_memory_size' in options:
+    config.collective_memory_size = options['collective_memory_size']
   register_custom_call_handler('CUDA', _xla.register_custom_call_target)
   register_custom_call_handler('ROCM', _xla.register_custom_call_target)
 

--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -453,6 +453,7 @@ class GpuAllocatorConfig:
       kind: Kind = ...,
       memory_fraction: float = ...,
       preallocate: bool = ...,
+      collective_memory_size: int = ...,
   ) -> None: ...
 
 class HostBufferSemantics(enum.IntEnum):

--- a/xla/stream_executor/integrations/BUILD
+++ b/xla/stream_executor/integrations/BUILD
@@ -1,3 +1,4 @@
+load("//xla:xla.bzl", "xla_cc_test")
 load("//xla/stream_executor:build_defs.bzl", "stream_executor_friends")
 load("@tsl//tsl:tsl.bzl", "set_external_visibility")
 load("@tsl//tsl:tsl.default.bzl", "filegroup")
@@ -66,5 +67,20 @@ cc_library(
         "@tsl//tsl/framework:allocator",
         "@tsl//tsl/framework:device_id",
         "@tsl//tsl/profiler/lib:traceme",
+    ],
+)
+
+xla_cc_test(
+    name = "tf_allocator_adapter_test",
+    srcs = ["tf_allocator_adapter_test.cc"],
+    deps = [
+        ":tf_allocator_adapter",
+        "//xla/service:cpu_plugin",
+        "//xla/service:platform_util",
+        "//xla/stream_executor",
+        "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/platform:test_main",
     ],
 )

--- a/xla/stream_executor/integrations/BUILD
+++ b/xla/stream_executor/integrations/BUILD
@@ -53,6 +53,7 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@tsl//tsl/framework:allocator",
         "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
     ],
 )
 

--- a/xla/stream_executor/integrations/device_mem_allocator.h
+++ b/xla/stream_executor/integrations/device_mem_allocator.h
@@ -25,6 +25,8 @@ limitations under the License.
 
 namespace stream_executor {
 
+enum class MemoryType { kDevice = 0, kUnified, kCollective };
+
 // Suballocator for StreamExecutor-based device memory.
 class DeviceMemAllocator : public tsl::SubAllocator {
  public:
@@ -33,13 +35,13 @@ class DeviceMemAllocator : public tsl::SubAllocator {
   // Note: stream_exec cannot be null.
   explicit DeviceMemAllocator(StreamExecutor* stream_exec,
                               tsl::PlatformDeviceId device_id,
-                              bool use_unified_memory,
+                              MemoryType memory_type,
                               const std::vector<Visitor>& alloc_visitors,
                               const std::vector<Visitor>& free_visitors)
       : SubAllocator(alloc_visitors, free_visitors),
         stream_exec_(stream_exec),
         device_id_(device_id),
-        use_unified_memory_(use_unified_memory) {
+        memory_type_(memory_type) {
     CHECK(stream_exec_ != nullptr);
   }
 
@@ -52,8 +54,10 @@ class DeviceMemAllocator : public tsl::SubAllocator {
     void* ptr = nullptr;
     *bytes_received = num_bytes;
     if (num_bytes > 0) {
-      if (use_unified_memory_) {
+      if (memory_type_ == MemoryType::kUnified) {
         ptr = stream_exec_->UnifiedMemoryAllocate(num_bytes);
+      } else if (memory_type_ == MemoryType::kCollective) {
+        ptr = stream_exec_->CollectiveMemoryAllocate(num_bytes);
       } else {
         ptr = stream_exec_->AllocateArray<char>(num_bytes).opaque();
       }
@@ -67,8 +71,10 @@ class DeviceMemAllocator : public tsl::SubAllocator {
 
     if (ptr != nullptr) {
       VisitFree(ptr, device_id_.value(), num_bytes);
-      if (use_unified_memory_) {
+      if (memory_type_ == MemoryType::kUnified) {
         stream_exec_->UnifiedMemoryDeallocate(ptr);
+      } else if (memory_type_ == MemoryType::kCollective) {
+        stream_exec_->CollectiveMemoryDeallocate(ptr);
       } else {
         DeviceMemoryBase device_ptr(ptr);
         stream_exec_->Deallocate(&device_ptr);
@@ -85,7 +91,7 @@ class DeviceMemAllocator : public tsl::SubAllocator {
  private:
   StreamExecutor* stream_exec_;  // not owned, non-null
   const tsl::PlatformDeviceId device_id_;
-  const bool use_unified_memory_ = false;
+  const MemoryType memory_type_ = MemoryType::kDevice;
 
   DeviceMemAllocator(const DeviceMemAllocator&) = delete;
   void operator=(const DeviceMemAllocator&) = delete;

--- a/xla/stream_executor/integrations/device_mem_allocator.h
+++ b/xla/stream_executor/integrations/device_mem_allocator.h
@@ -25,6 +25,7 @@ limitations under the License.
 
 namespace stream_executor {
 
+// The type of memory that the allocator will use.
 enum class MemoryType { kDevice = 0, kUnified, kCollective };
 
 // Suballocator for StreamExecutor-based device memory.

--- a/xla/stream_executor/integrations/device_mem_allocator.h
+++ b/xla/stream_executor/integrations/device_mem_allocator.h
@@ -58,7 +58,9 @@ class DeviceMemAllocator : public tsl::SubAllocator {
       if (memory_type_ == MemoryType::kUnified) {
         ptr = stream_exec_->UnifiedMemoryAllocate(num_bytes);
       } else if (memory_type_ == MemoryType::kCollective) {
-        ptr = stream_exec_->CollectiveMemoryAllocate(num_bytes);
+        auto status_or = stream_exec_->CollectiveMemoryAllocate(num_bytes);
+        CHECK(status_or.ok()) << status_or.status().message();
+        ptr = status_or.value();
       } else {
         ptr = stream_exec_->AllocateArray<char>(num_bytes).opaque();
       }
@@ -75,7 +77,8 @@ class DeviceMemAllocator : public tsl::SubAllocator {
       if (memory_type_ == MemoryType::kUnified) {
         stream_exec_->UnifiedMemoryDeallocate(ptr);
       } else if (memory_type_ == MemoryType::kCollective) {
-        stream_exec_->CollectiveMemoryDeallocate(ptr);
+        auto status = stream_exec_->CollectiveMemoryDeallocate(ptr);
+        CHECK(status.ok()) << status.message();
       } else {
         DeviceMemoryBase device_ptr(ptr);
         stream_exec_->Deallocate(&device_ptr);

--- a/xla/stream_executor/integrations/tf_allocator_adapter.cc
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.cc
@@ -39,7 +39,6 @@ TfAllocatorAdapter::~TfAllocatorAdapter() {}
 absl::StatusOr<OwningDeviceMemory> TfAllocatorAdapter::Allocate(
     int device_ordinal, uint64_t size, bool retry_on_failure,
     int64_t memory_space) {
-  CHECK_EQ(memory_space, 0);
   tsl::AllocationAttributes attrs;
   attrs.retry_on_failure = retry_on_failure;
   void *data = nullptr;

--- a/xla/stream_executor/integrations/tf_allocator_adapter.h
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "tsl/framework/allocator.h"
+#include "tsl/platform/statusor.h"
 
 namespace stream_executor {
 

--- a/xla/stream_executor/integrations/tf_allocator_adapter.h
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.h
@@ -140,6 +140,7 @@ class MultiDeviceAdapter : public DeviceMemoryAllocator {
       auto it = buffer_memory_spaces_.find({device_ordinal, mem.opaque()});
       CHECK(it != buffer_memory_spaces_.end());
       memory_space = it->second;
+      buffer_memory_spaces_.erase(it);
     }
 
     auto it = memory_space_to_per_device_allocators_.find(memory_space);

--- a/xla/stream_executor/integrations/tf_allocator_adapter.h
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.h
@@ -21,7 +21,11 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+<<<<<<< HEAD
 #include "absl/status/statusor.h"
+=======
+#include "absl/container/flat_hash_map.h"
+>>>>>>> Allow MultiDeviceAdapter to switch between different allocators based on memory_space
 #include "xla/stream_executor/device_memory.h"
 #include "xla/stream_executor/device_memory_allocator.h"
 #include "xla/stream_executor/platform.h"
@@ -46,9 +50,16 @@ class TfAllocatorAdapter : public DeviceMemoryAllocator {
 
   ~TfAllocatorAdapter() override;
 
+<<<<<<< HEAD
   absl::StatusOr<OwningDeviceMemory> Allocate(int device_ordinal, uint64_t size,
                                               bool retry_on_failure,
                                               int64_t memory_space) override;
+=======
+  // Memory space is unused from this point down
+  tsl::StatusOr<OwningDeviceMemory> Allocate(int device_ordinal, uint64_t size,
+                                             bool retry_on_failure,
+                                             int64_t memory_space) override;
+>>>>>>> Allow MultiDeviceAdapter to switch between different allocators based on memory_space
 
   absl::Status Deallocate(int device_ordinal, DeviceMemoryBase mem) override;
 
@@ -75,56 +86,74 @@ class TfAllocatorAdapter : public DeviceMemoryAllocator {
 // asynchronous deallocation; see comment on `AllowsAsynchronousDeallocation()`.
 class MultiDeviceAdapter : public DeviceMemoryAllocator {
  public:
-  using AllocatorWithStream =
-      std::pair<std::unique_ptr<tsl::Allocator>, Stream *>;
-  using AllocatorWithLogicalIdAndStream =
-      std::tuple<std::unique_ptr<tsl::Allocator>, int, Stream *>;
+  struct AllocatorInfo {
+    std::unique_ptr<tsl::Allocator> allocator;
+    Stream *stream;
+    int64_t memory_space;
+    std::optional<int> device_ordinal = std::nullopt;
+
+    AllocatorInfo(std::unique_ptr<tsl::Allocator> allocator, Stream *stream,
+                  int64_t memory_space,
+                  std::optional<int> device_ordinal = std::nullopt)
+        : allocator(std::move(allocator)),
+          stream(stream),
+          memory_space(memory_space),
+          device_ordinal(device_ordinal) {}
+  };
 
   MultiDeviceAdapter(const Platform *platform,
-                     std::vector<AllocatorWithStream> tf_allocators)
+                     std::vector<AllocatorInfo> tf_allocators)
       : DeviceMemoryAllocator(platform) {
     tf_allocators_.reserve(tf_allocators.size());
-    for (AllocatorWithStream &p : tf_allocators) {
-      int device_ordinal = p.second->parent()->device_ordinal();
-      if (per_device_allocators_.size() <= device_ordinal) {
-        per_device_allocators_.resize(device_ordinal + 1);
+    for (AllocatorInfo &info : tf_allocators) {
+      auto &per_device_allocators =
+          memory_space_to_per_device_allocators_[info.memory_space];
+      int device_ordinal = info.device_ordinal.has_value()
+                               ? *info.device_ordinal
+                               : info.stream->parent()->device_ordinal();
+      if (per_device_allocators.size() <= device_ordinal) {
+        per_device_allocators.resize(device_ordinal + 1);
       }
-      CHECK(!per_device_allocators_[device_ordinal]);
-      per_device_allocators_[device_ordinal] =
-          std::make_unique<TfAllocatorAdapter>(p.first.get(), p.second);
-      tf_allocators_.push_back(std::move(p.first));
-    }
-  }
-
-  MultiDeviceAdapter(const Platform *platform,
-                     std::vector<AllocatorWithLogicalIdAndStream> tf_allocators)
-      : DeviceMemoryAllocator(platform) {
-    tf_allocators_.reserve(tf_allocators.size());
-    for (AllocatorWithLogicalIdAndStream &t : tf_allocators) {
-      const int device_ordinal = std::get<1>(t);
-      Stream *stream = std::get<2>(t);
-      if (per_device_allocators_.size() <= device_ordinal) {
-        per_device_allocators_.resize(device_ordinal + 1);
-      }
-      CHECK(!per_device_allocators_[device_ordinal]);
-      per_device_allocators_[device_ordinal] =
-          std::make_unique<TfAllocatorAdapter>(std::get<0>(t).get(), stream);
-      tf_allocators_.push_back(std::move(std::get<0>(t)));
+      CHECK(!per_device_allocators[device_ordinal]);
+      per_device_allocators[device_ordinal] =
+          std::make_unique<TfAllocatorAdapter>(info.allocator.get(),
+                                               info.stream);
+      tf_allocators_.push_back(std::move(info.allocator));
     }
   }
 
   absl::StatusOr<OwningDeviceMemory> Allocate(int device_ordinal, uint64_t size,
                                               bool retry_on_failure,
                                               int64_t memory_space) override {
-    CHECK_LT(device_ordinal, per_device_allocators_.size());
-    return per_device_allocators_[device_ordinal]->Allocate(
-        device_ordinal, size, retry_on_failure, memory_space);
+    // memory_space is used here to select allocator. This isn't a need to pass
+    // it any lower to TfAllocatorAdapter.
+    auto it = memory_space_to_per_device_allocators_.find(memory_space);
+    CHECK(it != memory_space_to_per_device_allocators_.end());
+    CHECK_LT(device_ordinal, it->second.size());
+    TF_ASSIGN_OR_RETURN(
+        auto result, it->second[device_ordinal]->Allocate(
+                         device_ordinal, size, retry_on_failure, memory_space));
+
+    absl::MutexLock lock(&mu_);
+    buffer_memory_spaces_[result->opaque()] = memory_space;
+    return result;
   }
 
   absl::Status Deallocate(int device_ordinal, DeviceMemoryBase mem) override {
-    CHECK_LT(device_ordinal, per_device_allocators_.size());
-    return per_device_allocators_[device_ordinal]->Deallocate(device_ordinal,
-                                                              mem);
+    // Memory space is not passed to deallocate, look up in
+    // buffer_memory_spaces_.
+    int64_t memory_space;
+    {
+      absl::MutexLock lock(&mu_);
+      auto it = buffer_memory_spaces_.find(mem.opaque());
+      CHECK(it != buffer_memory_spaces_.end());
+      memory_space = it->second;
+    }
+
+    auto it = memory_space_to_per_device_allocators_.find(memory_space);
+    CHECK(it != memory_space_to_per_device_allocators_.end());
+    CHECK_LT(device_ordinal, it->second.size());
+    return it->second[device_ordinal]->Deallocate(device_ordinal, mem);
   }
 
   // The Tensorflow BFC allocator used on GPU allows host-side deallocation
@@ -137,15 +166,25 @@ class MultiDeviceAdapter : public DeviceMemoryAllocator {
   bool AllowsAsynchronousDeallocation() const override { return true; }
 
   absl::StatusOr<Stream *> GetStream(int device_ordinal) override {
-    return per_device_allocators_[device_ordinal]->GetStream(device_ordinal);
+    // Both allocators should use the same stream, so just use 0.
+    return memory_space_to_per_device_allocators_[0][device_ordinal]->GetStream(
+        device_ordinal);
   }
 
   absl::StatusOr<tsl::Allocator *> GetAllocator(int device_ordinal) {
-    return per_device_allocators_[device_ordinal]->GetAllocator(device_ordinal);
+    // GetAllocator is used for memory stats. Currently we will only see stats
+    // for main device memory allocator.
+    return memory_space_to_per_device_allocators_[0][device_ordinal]
+        ->GetAllocator(device_ordinal);
   }
 
  private:
-  std::vector<std::unique_ptr<TfAllocatorAdapter>> per_device_allocators_;
+  absl::flat_hash_map<int64_t, std::vector<std::unique_ptr<TfAllocatorAdapter>>>
+      memory_space_to_per_device_allocators_;
+  // Map of buffer to which memory space it resides in.
+  absl::Mutex mu_;
+  absl::flat_hash_map<void *, int64_t> buffer_memory_spaces_
+      ABSL_GUARDED_BY(mu_);
   // The wrapped TF allocators backing per_device_allocators_
   // (TfAllocatorAdapter does not take ownership of its underlying Allocator).
   std::vector<std::unique_ptr<tsl::Allocator>> tf_allocators_;

--- a/xla/stream_executor/integrations/tf_allocator_adapter.h
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.h
@@ -21,11 +21,8 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-<<<<<<< HEAD
-#include "absl/status/statusor.h"
-=======
 #include "absl/container/flat_hash_map.h"
->>>>>>> Allow MultiDeviceAdapter to switch between different allocators based on memory_space
+#include "absl/status/statusor.h"
 #include "xla/stream_executor/device_memory.h"
 #include "xla/stream_executor/device_memory_allocator.h"
 #include "xla/stream_executor/platform.h"
@@ -50,16 +47,9 @@ class TfAllocatorAdapter : public DeviceMemoryAllocator {
 
   ~TfAllocatorAdapter() override;
 
-<<<<<<< HEAD
   absl::StatusOr<OwningDeviceMemory> Allocate(int device_ordinal, uint64_t size,
                                               bool retry_on_failure,
                                               int64_t memory_space) override;
-=======
-  // Memory space is unused from this point down
-  tsl::StatusOr<OwningDeviceMemory> Allocate(int device_ordinal, uint64_t size,
-                                             bool retry_on_failure,
-                                             int64_t memory_space) override;
->>>>>>> Allow MultiDeviceAdapter to switch between different allocators based on memory_space
 
   absl::Status Deallocate(int device_ordinal, DeviceMemoryBase mem) override;
 
@@ -140,6 +130,7 @@ class MultiDeviceAdapter : public DeviceMemoryAllocator {
   }
 
   absl::Status Deallocate(int device_ordinal, DeviceMemoryBase mem) override {
+    if (mem.opaque() == nullptr) return absl::OkStatus();
     // Memory space is not passed to deallocate, look up in
     // buffer_memory_spaces_.
     int64_t memory_space;

--- a/xla/stream_executor/integrations/tf_allocator_adapter_test.cc
+++ b/xla/stream_executor/integrations/tf_allocator_adapter_test.cc
@@ -1,0 +1,96 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/integrations/tf_allocator_adapter.h"
+
+#include "tsl/framework/allocator.h"
+#include "tsl/lib/core/status_test_util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/test.h"
+#include "xla/service/platform_util.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace se = stream_executor;
+
+// Each allocatotion will have an incrementing address.
+class TestAllocator : public tsl::Allocator {
+ public:
+  TestAllocator(size_t start_address) : start_address_(start_address) {}
+
+  std::string Name() { return "test"; }
+
+  void* AllocateRaw(size_t alignment, size_t num_bytes) {
+    void* ptr = reinterpret_cast<void*>(++start_address_);
+    allocations_.insert(ptr);
+    return ptr;
+  }
+
+  void DeallocateRaw(void* ptr) {
+    auto it = allocations_.find(ptr);
+    if (it == allocations_.end()) {
+      ADD_FAILURE() << "Allocation not found (double free?)";
+    } else {
+      allocations_.erase(it);
+    }
+  }
+
+ private:
+  std::set<void*> allocations_;
+  size_t start_address_;
+};
+
+TEST(MultiDeviceAdapter, UsesCorrectAllocator) {
+  TF_ASSERT_OK_AND_ASSIGN(auto* platform,
+                          xla::PlatformUtil::GetDefaultPlatform());
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                          xla::PlatformUtil::GetStreamExecutors(platform));
+  se::Stream stream(executors[0]);
+  stream.Init();
+
+  std::vector<se::MultiDeviceAdapter::AllocatorInfo> infos;
+  infos.emplace_back(std::make_unique<TestAllocator>(0x1000), &stream,
+                     /*memory_space=*/0, /*device_ordinal=*/0);
+  infos.emplace_back(std::make_unique<TestAllocator>(0x2000), &stream,
+                     /*memory_space=*/0, /*device_ordinal=*/1);
+  infos.emplace_back(std::make_unique<TestAllocator>(0x3000), &stream,
+                     /*memory_space=*/1, /*device_ordinal=*/0);
+  infos.emplace_back(std::make_unique<TestAllocator>(0x4000), &stream,
+                     /*memory_space=*/1, /*device_ordinal=*/1);
+  std::unique_ptr<se::DeviceMemoryAllocator> allocator =
+      std::make_unique<se::MultiDeviceAdapter>(platform, std::move(infos));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      se::OwningDeviceMemory buff0,
+      allocator->Allocate(/*device_ordinal=*/0, 4, false, /*memory_space=*/0));
+  CHECK_EQ(reinterpret_cast<size_t>(buff0->opaque()), 0x1001);
+  TF_ASSERT_OK_AND_ASSIGN(
+      se::OwningDeviceMemory buff1,
+      allocator->Allocate(/*device_ordinal=*/0, 4, false, /*memory_space=*/0));
+  CHECK_EQ(reinterpret_cast<size_t>(buff1->opaque()), 0x1002);
+  TF_ASSERT_OK_AND_ASSIGN(
+      se::OwningDeviceMemory buff2,
+      allocator->Allocate(/*device_ordinal=*/0, 4, false, /*memory_space=*/1));
+  CHECK_EQ(reinterpret_cast<size_t>(buff2->opaque()), 0x3001);
+  TF_ASSERT_OK_AND_ASSIGN(
+      se::OwningDeviceMemory buff3,
+      allocator->Allocate(/*device_ordinal=*/1, 4, false, /*memory_space=*/0));
+  CHECK_EQ(reinterpret_cast<size_t>(buff3->opaque()), 0x2001);
+  TF_ASSERT_OK_AND_ASSIGN(
+      se::OwningDeviceMemory buff4,
+      allocator->Allocate(/*device_ordinal=*/1, 4, false, /*memory_space=*/1));
+  CHECK_EQ(reinterpret_cast<size_t>(buff4->opaque()), 0x4001);
+}

--- a/xla/tests/pjrt_gpu_client_registry.cc
+++ b/xla/tests/pjrt_gpu_client_registry.cc
@@ -26,6 +26,7 @@ const bool kUnused =
        gpu_config.kind = xla::GpuAllocatorConfig::Kind::kDefault;
        gpu_config.preallocate = true;
        gpu_config.memory_fraction = 0.08;
+       gpu_config.collective_memory_size = 0;
        GpuClientOptions options;
        options.allocator_config = gpu_config;
        return GetStreamExecutorGpuClient(options);


### PR DESCRIPTION
If `collective_memory_size` is non-zero in the `GPUAllocatorConfig`, then a second BFCAllocator will be created for each device that uses `CollectiveMemoryAllocate` for its suballocator. For allocations with `memory_space == 1`, the allocators will be routed to this `CollectiveBFCAllocator` instead of the regular device memory allocator.

Main PR here: https://github.com/openxla/xla/pull/7843