### PR TITLE
[XLA:GPU] Fix cuDNN MHA rewriter bmm2_grad1/dbias pattern match

### DIFF
--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -986,8 +986,6 @@ MatchBwdResult MatchBwdBmmSoftmaxDropoutBmm(MatchBwdResult previous_result,
   }
   // try to pattern match dbias
   if (has_scale || has_mask) {
-    std::cerr << "called\n";
-    std::cerr << d_softmax->user_count() << "\n";
     // bmm1-(scale)-(bias)-(mask)-softmax pattern
     // users could be dbias besides mask bwd or scale bwd
     if (d_softmax->user_count() == 1) {
@@ -999,7 +997,6 @@ MatchBwdResult MatchBwdBmmSoftmaxDropoutBmm(MatchBwdResult previous_result,
     } else {
       match_result.has_match = false;
     }
-    std::cerr << match_result.has_match << "\n";
   } else {
     // bmm1-(bias)-softmax pattern
     // users could be dbias besides bmm1grad1 bmm1grad2

--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -730,17 +730,12 @@ MatchBwdResult MatchBmm1GradGemm2(MatchBwdResult previous_result,
   auto bmm_1_grad_2_it = std::find_if(
       d_s->users().begin(), d_s->users().end(), [&](HloInstruction* instr) {
         return instr != match_result.matched_bmm_1_grad_1 &&
-               instr->opcode() != HloOpcode::kReduce;
+               instr->opcode() == HloOpcode::kDot;
       });
   if (bmm_1_grad_2_it != d_s->users().end()) {
     bmm_1_grad_2 = *bmm_1_grad_2_it;
   } else {
     return match_result;
-  }
-  if (bmm_1_grad_2->opcode() == HloOpcode::kBitcast &&
-      bmm_1_grad_2->user_count() == 1) {
-    d_s = bmm_1_grad_2;
-    bmm_1_grad_2 = bmm_1_grad_2->users()[0];
   }
 
   match_result.matched_bmm_1_grad_2 = bmm_1_grad_2;

--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -79,7 +79,7 @@ struct MatchBwdResult {
 
   HloInstruction* matched_bmm_2_grad_1 = nullptr;
   HloInstruction* matched_bmm_2_grad_2 = nullptr;
-  HloInstruction* matched_d_intermediate = nullptr;
+  HloInstruction* matched_dbias = nullptr;
   // We use this to keep track of all gradient bmms that need
   // canonicalization.
   bool bmm_1_grad_1_need_canonicalization = false;
@@ -799,6 +799,33 @@ MatchBwdResult MatchBmm2GradGemm2(MatchBwdResult previous_result,
   return match_result;
 }
 
+MatchBwdResult MatchDbias(MatchBwdResult previous_result,
+                          HloInstruction* d_intermediate,
+                          const absl::flat_hash_set<HloInstruction*> users) {
+  MatchBwdResult match_result = previous_result;
+  auto user_count = d_intermediate->user_count();
+  HloInstruction* dbias_user = nullptr;
+  HloInstruction* dbias = nullptr;
+  for (auto user : d_intermediate->users()) {
+    if (users.contains(user)) {
+      user_count -= 1;
+    } else {
+      dbias_user = user;
+    }
+  }
+  auto ConsumeExtraConvert = [](HloInstruction* instr) {
+    Match(instr->users()[0], m::Convert(&instr, m::Op()).WithOneUse());
+    return true;
+  };
+  // user_count == 1 && (reduce-> {convert} ->bitcast)
+  match_result.has_match =
+      user_count == 1 &&
+      Match(dbias_user, m::Reduce(&dbias, m::Op(), m::Op()).WithOneUse()) &&
+      dbias->shape().rank() == 3 && ConsumeExtraConvert(dbias);
+  match_result.matched_dbias = dbias;
+  return match_result;
+}
+
 MatchBwdResult MatchBwdBmmSoftmaxDropoutBmm(MatchBwdResult previous_result,
                                             HloInstruction* fwd_fmha_call,
                                             HloInstruction* mask) {
@@ -806,6 +833,7 @@ MatchBwdResult MatchBwdBmmSoftmaxDropoutBmm(MatchBwdResult previous_result,
   bool is_bmm1_grad1_canonicalized =
       match_result.bmm_1_grad_1_need_canonicalization;
   match_result.has_match = false;
+  bool has_scale = false;
   bool has_dropout = false;
   bool has_mask = false;
   // Backward dropout pattern
@@ -880,14 +908,15 @@ MatchBwdResult MatchBwdBmmSoftmaxDropoutBmm(MatchBwdResult previous_result,
 
   auto bwd_scale_pattern =
       m::MultiplyAnyOrder(m::Op(&bwd_scale_input),
-                          m::Broadcast(m::Constant().WithPredicate(IsScalar)));
+                          m::Broadcast(m::Constant().WithPredicate(IsScalar)))
+          .WithNumUser(2);
   int intermediate_input_pos = is_bmm1_grad1_canonicalized ? 1 : 0;
 
   HloInstruction* intermediate_input =
       match_result.matched_bmm_1_grad_1->mutable_operand(
           intermediate_input_pos);
 
-  if (Match(intermediate_input, bwd_scale_pattern)) {
+  if (has_scale = Match(intermediate_input, bwd_scale_pattern)) {
     intermediate_input = bwd_scale_input;
   }
 
@@ -955,22 +984,35 @@ MatchBwdResult MatchBwdBmmSoftmaxDropoutBmm(MatchBwdResult previous_result,
       match_result.matched_custom_call_name =
           kCudnnfMHASoftmaxBackwardCallTarget;
   }
-
-  // If d_softmax tensor has 3 consumers, then we need to output the
-  // intermediate tensor.
-  bool need_d_intermediate = d_softmax->user_count() == 3;
-  if ((match_result.matched_custom_call_name ==
-           kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget ||
-       match_result.matched_custom_call_name ==
-           kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget ||
-       match_result.matched_custom_call_name ==
-           kCudnnfMHAScaleBiasMaskSoftmaxDropoutBackwardCallTarget ||
-       match_result.matched_custom_call_name ==
-           kCudnnfMHAScaleBiasMaskSoftmaxBackwardCallTarget) &&
-      need_d_intermediate) {
-    match_result.matched_d_intermediate = d_softmax;
+  // try to pattern match dbias
+  if (has_scale || has_mask) {
+    std::cerr << "called\n";
+    std::cerr << d_softmax->user_count() << "\n";
+    // bmm1-(scale)-(bias)-(mask)-softmax pattern
+    // users could be dbias besides mask bwd or scale bwd
+    if (d_softmax->user_count() == 1) {
+      // no dbias
+      match_result.has_match = true;
+    } else if (d_softmax->user_count() == 2) {
+      match_result = MatchDbias(match_result, d_softmax,
+                                {bwd_scale_input, bwd_mask_input});
+    } else {
+      match_result.has_match = false;
+    }
+    std::cerr << match_result.has_match << "\n";
+  } else {
+    // bmm1-(bias)-softmax pattern
+    // users could be dbias besides bmm1grad1 bmm1grad2
+    if (d_softmax->user_count() == 2) {
+      match_result.has_match = true;
+    } else if (d_softmax->user_count() == 3) {
+      match_result = MatchDbias(match_result, d_softmax,
+                                {match_result.matched_bmm_1_grad_1,
+                                 match_result.matched_bmm_1_grad_2});
+    } else {
+      match_result.has_match = false;
+    }
   }
-  match_result.has_match = true;
   return match_result;
 }
 // First, we look for the bmm2 gradient gemm 1 which takes the activation
@@ -1347,36 +1389,11 @@ StatusOr<HloInstruction*> FuseFwdMultiHeadedAttentionBlock(
   return fmha_call;
 }
 
-bool IsDbiasOnlyUserBesidesGradGemm(HloInstruction* d_intermediate,
-                                    HloInstruction* bmm_1_grad_1,
-                                    HloInstruction* bmm_1_grad_2,
-                                    HloInstruction** dbias) {
-  auto user_count = d_intermediate->user_count();
-  HloInstruction* dbias_user = nullptr;
-  for (auto user : d_intermediate->users()) {
-    if (user == bmm_1_grad_1) {
-      user_count -= 1;
-    } else if (user == bmm_1_grad_2) {
-      user_count -= 1;
-    } else {
-      dbias_user = user;
-    }
-  }
-  auto ConsumeExtraConvert = [](HloInstruction** instr) {
-    Match((*instr)->users()[0], m::Convert(instr, m::Op()).WithOneUse());
-    return true;
-  };
-  // user_count == 1 && (reduce-> {convert} ->bitcast)
-  return user_count == 1 &&
-         Match(dbias_user, m::Reduce(dbias, m::Op(), m::Op()).WithOneUse()) &&
-         (*dbias)->shape().rank() == 3 && ConsumeExtraConvert(dbias);
-}
-
 StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
     HloComputation* comp, HloInstruction* bmm_1_grad_1,
     HloInstruction* bmm_1_grad_2, HloInstruction* bmm_2_grad_1,
     HloInstruction* bmm_2_grad_2, HloInstruction* fwd_fmha_call,
-    HloInstruction* d_intermediate, HloInstruction* mask,
+    HloInstruction* dbias, HloInstruction* mask,
     std::string& bwd_custom_call_name, bool fwd_bmm_2_canonicalized,
     bool is_bmm2_grad1_canonicalized) {
   HloInstruction* rhs_bmm1_grad_gemm1;
@@ -1518,24 +1535,15 @@ StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
   // Reserved placeholder for workspace
   output_shapes.push_back(ShapeUtil::MakeShape(U8, {0}));
 
-  HloInstruction* dbias = nullptr;
-  if (d_intermediate) {
-    if (IsDbiasOnlyUserBesidesGradGemm(d_intermediate, bmm_1_grad_1,
-                                       bmm_1_grad_2, &dbias)) {
-      // Cudnn kernel only outputs dbias in this shape [1, num_heads, seq, seq],
-      // so we add a dimension of 1 to existing dbias' shape.
-      std::vector<int64_t> dbias_shape_vector =
-          SpanToVector(dbias->shape().dimensions());
-      dbias_shape_vector.insert(dbias_shape_vector.begin(), 1);
-      Shape cudnn_dbias_shape = ShapeUtil::MakeShape(
-          dbias->shape().element_type(), dbias_shape_vector);
-      output_shapes.push_back(cudnn_dbias_shape);
-    } else {
-      VLOG(2) << "Intermediate gradient has other users outside of gradient "
-                 "gemms and dbias"
-              << " which is not supported by CUDNN for now. Skipping.";
-      return false;
-    }
+  if (dbias) {
+    // Cudnn kernel only outputs dbias in this shape [1, num_heads, seq, seq],
+    // so we add a dimension of 1 to existing dbias' shape.
+    std::vector<int64_t> dbias_shape_vector =
+        SpanToVector(dbias->shape().dimensions());
+    dbias_shape_vector.insert(dbias_shape_vector.begin(), 1);
+    Shape cudnn_dbias_shape =
+        ShapeUtil::MakeShape(dbias->shape().element_type(), dbias_shape_vector);
+    output_shapes.push_back(cudnn_dbias_shape);
   }
   Shape call_shape = ShapeUtil::MakeTupleShape(output_shapes);
   HloInstruction* fmha_bwd_call =
@@ -1694,16 +1702,10 @@ StatusOr<bool> CudnnFusedMHARewriter::Run(
               comp->ReplaceInstruction(activation_gte, cloned_activation));
           continue;
         }
-        // check if dbias is the only user of d_intermediate besides
-        // bmm_1_grad_1 and bmm_1_grad_2 and the cudnn version is > 8.9.1. We
+        // check if dbias exist and the cudnn version is > 8.9.1. We
         // won't lower bwd if this condition is not met as we won't deal with
         // unswizzling now
-        HloInstruction* dbias = nullptr;
-        if (matched_bwd_result.matched_d_intermediate &&
-            !IsDbiasOnlyUserBesidesGradGemm(
-                matched_bwd_result.matched_d_intermediate,
-                matched_bwd_result.matched_bmm_1_grad_1,
-                matched_bwd_result.matched_bmm_1_grad_2, &dbias) &&
+        if (matched_bwd_result.matched_dbias &&
             !IsComputeCapabilityAndCudnnSupported(
                 compute_capability_, cudnn_version_, stream_executor_,
                 stream_executor::dnn::VersionInfo(8, 9, 1))) {
@@ -1743,8 +1745,7 @@ StatusOr<bool> CudnnFusedMHARewriter::Run(
                 matched_bwd_result.matched_bmm_1_grad_2,
                 matched_bwd_result.matched_bmm_2_grad_1,
                 matched_bwd_result.matched_bmm_2_grad_2, fwd_fmha_call,
-                matched_bwd_result.matched_d_intermediate,
-                matched_result.matched_mask,
+                matched_bwd_result.matched_dbias, matched_result.matched_mask,
                 matched_bwd_result.matched_custom_call_name,
                 matched_result.need_canonicalization,
                 matched_bwd_result.bmm_2_grad_1_need_canonicalization));

--- a/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
@@ -3656,6 +3656,92 @@ ENTRY main.82 {
               GmockMatch(m::Tuple(m::Dot(), m::Dot(), m::Dot(), m::Dot())));
 }
 
+TEST_F(CudnnFusedMhaRewriterTestHloTest, F16TrainingBmm2Grad1IncorrectPattern) {
+  const char* module_str = R"(
+HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(f16[2,6,64,128]{3,2,1,0},f16[2,6,64,128]{3,2,1,0},f16[2,6,128,64]{3,2,1,0},f16[2,6,128,64]{3,2,1,0})->(f16[2,6,128,64]{3,2,1,0}, f16[2,6,128,64]{3,2,1,0}, f16[2,6,64,128]{3,2,1,0}, f16[2,6,128,64]{3,2,1,0}, f16[2,6,128,128]{3,2,1,0})}, allow_spmd_sharding_propagation_to_output={true,true,true,true}
+
+region_0.21 {
+  Arg_0.22 = f16[] parameter(0)
+  Arg_1.23 = f16[] parameter(1)
+  ROOT maximum = f16[] maximum(Arg_0.22, Arg_1.23)
+}
+
+region_1.33 {
+  Arg_0.34 = f32[] parameter(0)
+  Arg_1.35 = f32[] parameter(1)
+  ROOT add = f32[] add(Arg_0.34, Arg_1.35)
+}
+
+region_2.55 {
+  Arg_0.56 = f16[] parameter(0)
+  Arg_1.57 = f16[] parameter(1)
+  ROOT add.1 = f16[] add(Arg_0.56, Arg_1.57)
+}
+
+ENTRY main.82 {
+  Arg_0.1 = f16[2,6,64,128]{3,2,1,0} parameter(0), sharding={replicated}
+  Arg_1.2 = f16[2,6,64,128]{3,2,1,0} parameter(1), sharding={replicated}
+  dot.17 = f16[2,6,128,128]{3,2,1,0} dot(Arg_0.1, Arg_1.2), lhs_batch_dims={0,1}, lhs_contracting_dims={2}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  constant.22 = f16[] constant(2)
+  broadcast.24 = f16[2,6,128,128]{3,2,1,0} broadcast(constant.22), dimensions={}
+  multiply.2 = f16[2,6,128,128]{3,2,1,0} multiply(dot.17, broadcast.24)
+  constant.19 = f16[] constant(1)
+  broadcast.13 = f16[2,6,128,128]{3,2,1,0} broadcast(constant.19), dimensions={}
+  add.3 = f16[2,6,128,128]{3,2,1,0} add(multiply.2, broadcast.13)
+  constant.21 = f16[] constant(0)
+  constant.15 = f16[] constant(-inf)
+  reduce.25 = f16[2,6,128]{2,1,0} reduce(add.3, constant.15), dimensions={3}, to_apply=region_0.21
+  broadcast.17 = f16[2,6,128,128]{3,2,1,0} broadcast(reduce.25), dimensions={0,1,2}
+  subtract.1 = f16[2,6,128,128]{3,2,1,0} subtract(add.3, broadcast.17)
+  exponential.1 = f16[2,6,128,128]{3,2,1,0} exponential(subtract.1)
+  convert.5 = f32[2,6,128,128]{3,2,1,0} convert(exponential.1)
+  constant.17 = f32[] constant(0)
+  reduce.37 = f32[2,6,128]{2,1,0} reduce(convert.5, constant.17), dimensions={3}, to_apply=region_1.33
+  convert.9 = f16[2,6,128]{2,1,0} convert(reduce.37)
+  broadcast.26 = f16[2,6,128,128]{3,2,1,0} broadcast(convert.9), dimensions={0,1,2}
+  divide.5 = f16[2,6,128,128]{3,2,1,0} divide(exponential.1, broadcast.26)
+  Arg_2.3 = f16[2,6,128,64]{3,2,1,0} parameter(2), sharding={replicated}
+  dot.46 = f16[2,6,128,64]{3,2,1,0} dot(divide.5, Arg_2.3), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  Arg_3.4 = f16[2,6,128,64]{3,2,1,0} parameter(3), sharding={replicated}
+  dot.49 = f16[2,6,128,128]{3,2,1,0} dot(Arg_3.4, Arg_2.3), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}
+  divide.4 = f16[2,6,128,128]{3,2,1,0} divide(dot.49, broadcast.26)
+  broadcast.20 = f16[2,6,128]{2,1,0} broadcast(constant.19), dimensions={}
+  multiply.3 = f16[2,6,128]{2,1,0} multiply(convert.9, convert.9)
+  divide.3 = f16[2,6,128]{2,1,0} divide(broadcast.20, multiply.3)
+  broadcast.21 = f16[2,6,128,128]{3,2,1,0} broadcast(divide.3), dimensions={0,1,2}
+  multiply.4 = f16[2,6,128,128]{3,2,1,0} multiply(dot.49, broadcast.21)
+  multiply.5 = f16[2,6,128,128]{3,2,1,0} multiply(multiply.4, exponential.1)
+  reduce.59 = f16[2,6,128]{2,1,0} reduce(multiply.5, constant.21), dimensions={3}, to_apply=region_2.55
+  negate.2 = f16[2,6,128]{2,1,0} negate(reduce.59)
+  broadcast.25 = f16[2,6,128,128]{3,2,1,0} broadcast(negate.2), dimensions={0,1,2}
+  add.5 = f16[2,6,128,128]{3,2,1,0} add(divide.4, broadcast.25)
+  multiply.8 = f16[2,6,128,128]{3,2,1,0} multiply(add.5, exponential.1)
+  multiply.9 = f16[2,6,128,128]{3,2,1,0} multiply(multiply.8, broadcast.24)
+  dot.80 = f16[2,6,128,64]{3,2,1,0} dot(multiply.9, Arg_1.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}
+  dot = f16[2,6,64,128]{3,2,1,0} dot(Arg_0.1, multiply.9), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  // add another user of ds multiply.9 here, neg.1 should not be pattern matched as bmm2grad1
+  neg.1 = f16[2,6,128,128]{3,2,1,0} negate(multiply.9)
+  dot.1 = f16[2,6,128,64]{3,2,1,0} dot(divide.5, Arg_3.4), lhs_batch_dims={0,1}, lhs_contracting_dims={2}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  ROOT tuple.81 = (f16[2,6,128,64]{3,2,1,0}, f16[2,6,128,64]{3,2,1,0}, f16[2,6,64,128]{3,2,1,0}, f16[2,6,128,64]{3,2,1,0}, f16[2,6,128,128]{3,2,1,0}) tuple(dot.46, dot.80, dot, dot.1, neg.1)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
+  CudnnFusedMHARewriter fusedMhaRewriter{
+      GetCudaComputeCapability(),
+      GetCudnnVersionWithDbiasAndMaskBwdInputSupport()};
+  TF_ASSERT_OK(RunHloPass(&fusedMhaRewriter, m.get()).status());
+  HloDCE dce;
+  TF_ASSERT_OK(RunHloPass(&dce, m.get()).status());
+
+  ComputationLayout computation_layout(
+      m->entry_computation()->ComputeProgramShape());
+
+  SCOPED_TRACE(m->ToString());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Tuple(m::Dot(), m::Dot(), m::Dot(), m::Dot(),
+                                  m::Negate())));
+}
 }  // anonymous namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
* Fix a case where dS has additional users that is not bmm2_grad1 but being pattern matched as bmm2_grad1.
    * bmm2_grad1 and bmm2_grad2 shares the same input dS in attention backward, Explicitly require bmm2_grad1 to be dot instruction in pattern match.
* Fix dbias pattern match in cases where scale exists.
    * If scale exist, other users of softmax bwd output besides dbias will be input to scale bwd. (Add support for this case)
    * If scale does not exist, other users besides dbias will be bmm1grad and bmm1grad2.