### PR TITLE
ReplaceInstructionWithDifferentShape should return false if old_instruction HasControlDependencies

### DIFF
--- a/xla/hlo/ir/hlo_computation.cc
+++ b/xla/hlo/ir/hlo_computation.cc
@@ -1185,6 +1185,10 @@ StatusOr<bool> HloComputation::ReplaceInstructionWithDifferentShape(
     TF_RETURN_IF_ERROR(
         new_instruction->CopyAllControlDepsFrom(old_instruction));
     TF_RETURN_IF_ERROR(old_instruction->DropAllControlDeps());
+  } else if (old_instruction->HasControlDependencies()) {
+    VLOG(10) << "Skipping replacement because old instruction has "
+                "control dependencies";
+    return false;
   }
   VLOG(10) << "transformed " << old_instruction->ToString() << " to "
            << new_instruction->ToString();


### PR DESCRIPTION
There are two `ReplaceInstructionWithDifferentShape` functions.
The default value for `relay_control_dependency` is `false`.
```
  StatusOr<bool> ReplaceInstructionWithDifferentShape(
      HloInstruction* old_instruction, 
      HloInstruction* new_instruction,
      bool preserve_sharding, 
      bool relay_control_dependency = false,
      bool remove_unused_operands = true
  );

  StatusOr<bool> ReplaceInstructionWithDifferentShape(
      HloInstruction* old_instruction, 
      HloInstruction* new_instruction
  );
```
Many users use `ReplaceInstructionWithDifferentShape` functions providing only old and new instructions and leave all other parameters with default values.

If old_instruction has ControlDependencies then it will be impossible to replace it because ReplaceInstruction copies and drops ControlDependencies from old to new instruction only if `relay_control_dependency` is set to `true`.
Currently the function will Fail if we try to use it for the case when old_instruction has ControlDependencies. It will fail because `RemoveInstruction(old_instruction)` will fail because `IsSafelyRemovable` check will return false.

Instead of failing, ReplaceInstructionWithDifferentShape should simply return false - indicating that the validation checks for ReplaceInstruction was not satisfied.

@Tongfei-Guo @jurahul Can you have a look?
