### PR TITLE
Fix lint for stream_executor/rocm/build_defs.bzl

### DIFF
--- a/xla/stream_executor/rocm/build_defs.bzl
+++ b/xla/stream_executor/rocm/build_defs.bzl
@@ -4,8 +4,10 @@
 load("@local_config_rocm//rocm:build_defs.bzl", "rocm_gpu_architectures")
 
 def rocm_embedded_test_modules(name, srcs, testonly = True, **kwargs):
-    """Compile srcs into hsaco files and create a header only cc_library with embeded
-       files as constant data.
+    """Compile srcs into hsaco files and create a header only cc_library.
+
+    Compile srcs into hsaco files and create a header only cc_library with embeded
+    files as constant data.
 
     Args:
         name: name for the generated cc_library target, and the base name for


### PR DESCRIPTION
Fix lint errors
```
xla/stream_executor/rocm/build_defs.bzl:7: function-docstring-header: The docstring for the function "rocm_embedded_test_modules" should start with a one-line summary. 
(https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#function-docstring-header)
Error: Process completed with exit code 4.
```

Recent PRs with this error:
- https://github.com/openxla/xla/actions/runs/7351388978/job/20014655171?pr=8073
- https://github.com/openxla/xla/actions/runs/7337927622/job/19979608845?pr=8049

Tested the fix locally
```
$ buildifier --lint=warn --warnings=-out-of-order-load -r xla/
$ echo $?
0
```

I'm using the latest version of buildifier - 6.4.0
```
$ buildifier --version
buildifier version: 6.4.0 
buildifier scm revision: 433ea8554e82832e4fa4bdd530ca471564071511
```

I also opened PR to update buildifier to version 6.4.0 https://github.com/openxla/xla/pull/8076

@ezhulenev @ddunl 
