### PR TITLE
Use buildifier 6.4.0 433ea85

### DIFF
--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -34,6 +34,6 @@ jobs:
       - name: "Checking out repository"
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
       - name: "Install buildifier"
-        run: go install github.com/bazelbuild/buildtools/buildifier@7d855c5
+        run: go install github.com/bazelbuild/buildtools/buildifier@433ea85 # 6.4.0
       - name: "Run buildifier"
         run: buildifier --lint=warn --warnings=-out-of-order-load -r xla/


### PR DESCRIPTION
Currently We are using pre-released version 6.4.0 of buildifier (7d855c5 Sep 26, 2023)

Version [6.4.0](https://github.com/bazelbuild/buildtools/commits/v6.4.0) (commit 433ea85 Nov 3, 2023 ) was released recently - we ca use it now.

Related PR https://github.com/openxla/xla/pull/8075

@ddunl 