### PR TITLE
[ROCM] fixing build brake 24-01-03

### DIFF
--- a/xla/service/gpu/model/tile_analysis.cc
+++ b/xla/service/gpu/model/tile_analysis.cc
@@ -1018,7 +1018,7 @@ bool AffineExprReducesToScalar(
     case AffineExprKind::Mod:
     case AffineExprKind::FloorDiv:
     case AffineExprKind::CeilDiv: {
-      auto binop_expr = cast<AffineBinaryOpExpr>(expr);
+      auto binop_expr = llvm::cast<AffineBinaryOpExpr>(expr);
       return AffineExprReducesToScalar(binop_expr.getLHS(),
                                        trivial_symbol_ids) &&
              AffineExprReducesToScalar(binop_expr.getRHS(), trivial_symbol_ids);
@@ -1029,7 +1029,7 @@ bool AffineExprReducesToScalar(
       return true;
     case AffineExprKind::SymbolId:
       return trivial_symbol_ids.contains(
-          cast<AffineSymbolExpr>(expr).getPosition());
+          llvm::cast<AffineSymbolExpr>(expr).getPosition());
   }
 }
 
@@ -1041,7 +1041,7 @@ bool AffineExprIsStridedRangeExpression(
   switch (expr.getKind()) {
     case AffineExprKind::Add:
     case AffineExprKind::Mul: {
-      auto binop_expr = cast<AffineBinaryOpExpr>(expr);
+      auto binop_expr = llvm::cast<AffineBinaryOpExpr>(expr);
       return AffineExprReducesToScalar(binop_expr.getLHS(),
                                        trivial_symbol_ids) ||
              AffineExprReducesToScalar(binop_expr.getRHS(), trivial_symbol_ids);

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -671,13 +671,11 @@ xla_cc_binary(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:dnn",
         "//xla/stream_executor/host:host_platform",
-        "//xla/stream_executor/rocm:rocm_platform_id",
         "//xla/tests:test_utils",
         "//xla/tools:hlo_module_loader",
         "@llvm-project//llvm:Target",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:platform_port",
-        "@tsl//tsl/platform:rocm_rocdl_path",
         "@tsl//tsl/util:command_line_flags",
     ] + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_platform_id",

--- a/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -214,10 +214,7 @@ tsl::Status GpuExecutor::GetKernel(const MultiKernelLoaderSpec& spec,
   hipModule_t module = nullptr;
   const string* kernel_name;
 
-  if (spec.has_cuda_cubin_on_disk()) {
-    return tsl::errors::Internal(
-        "Loading ROCM kernel from disk is not supported");
-  } else if (spec.has_cuda_cubin_in_memory()) {
+  if (spec.has_cuda_cubin_in_memory()) {
     kernel_name = &spec.cuda_cubin_in_memory().kernel_name();
 
     const char* hsaco = spec.cuda_cubin_in_memory().bytes();


### PR DESCRIPTION
This is an ongoing build brake fix for ROCM.

I have also fixed the target ```//xla/service/gpu/tests:hlo_to_llvm_ir``` after build cleaner application [here](https://github.com/openxla/xla/commit/c0103b5f1b31fd2779ce185bc8e079e2830d4d44#diff-fa4514f3f50735f2a4da97025c358ca00d9c10f6759c14cecf921747b691f8f5L755-L761) 
Is it possible to tell build cleaner somehow not to modify this target anymore ?

@xla-rotation: would you please take a look ?