### PR TITLE
[ROCM] Using grad_x/y attributes for GEMMs to fix dot_operation_test

### DIFF
--- a/xla/tests/dot_operation_test.cc
+++ b/xla/tests/dot_operation_test.cc
@@ -385,8 +385,6 @@ void ParametricDotTest::TestImpl() {
   auto prim_type = primitive_util::NativeToPrimitiveType<NativeT>();
     
   if(propagate_grad_xy_ != 0) {
-
-    VLOG(0) << "setting " << (propagate_grad_xy_ == 1 ? "grad_x" : "grad_y");
     FrontendAttributes attributes;
     if(propagate_grad_xy_ == 1)
       (*attributes.mutable_map())["grad_x"] = "true";


### PR DESCRIPTION
This PR was originally focused on XLA runtime fixes which are not relevant anymore (deprecated).
Hence, here I only fix dot_operation_test which fails due to denormal issues on MI210 platform. For that, we set grad_x/y attributes which activate alternative GEMM implementation on ROCM and has no effect on CUDA side.

@xla-rotation: could you please have a look ?

