### PR TITLE
Add mlir namespace to mlir casts

### DIFF
--- a/xla/service/gpu/model/tile_analysis.cc
+++ b/xla/service/gpu/model/tile_analysis.cc
@@ -1018,7 +1018,7 @@ bool AffineExprReducesToScalar(
     case AffineExprKind::Mod:
     case AffineExprKind::FloorDiv:
     case AffineExprKind::CeilDiv: {
-      auto binop_expr = cast<AffineBinaryOpExpr>(expr);
+      auto binop_expr = mlir::cast<AffineBinaryOpExpr>(expr);
       return AffineExprReducesToScalar(binop_expr.getLHS(),
                                        trivial_symbol_ids) &&
              AffineExprReducesToScalar(binop_expr.getRHS(), trivial_symbol_ids);
@@ -1029,7 +1029,7 @@ bool AffineExprReducesToScalar(
       return true;
     case AffineExprKind::SymbolId:
       return trivial_symbol_ids.contains(
-          cast<AffineSymbolExpr>(expr).getPosition());
+          mlir::cast<AffineSymbolExpr>(expr).getPosition());
   }
 }
 
@@ -1041,7 +1041,7 @@ bool AffineExprIsStridedRangeExpression(
   switch (expr.getKind()) {
     case AffineExprKind::Add:
     case AffineExprKind::Mul: {
-      auto binop_expr = cast<AffineBinaryOpExpr>(expr);
+      auto binop_expr = mlir::cast<AffineBinaryOpExpr>(expr);
       return AffineExprReducesToScalar(binop_expr.getLHS(),
                                        trivial_symbol_ids) ||
              AffineExprReducesToScalar(binop_expr.getRHS(), trivial_symbol_ids);


### PR DESCRIPTION
To avoid errors like:
xla/service/gpu/model/tile_analysis.cc:1021:25: error: ‘cast’ was not declared in this scope
 1021 |       auto binop_expr = cast<AffineBinaryOpExpr>(expr);

on gcc