### PR TITLE
[NVIDIA] Remove the use of RNN plan for new RNN APIs

### DIFF
--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -552,13 +552,13 @@ struct RnnDescriptorDeleter {
     CHECK_CUDNN_OK(cudnnDestroyRNNDescriptor(descriptor));
   }
 };
+#if CUDNN_VERSION < 8100
 struct PersistentRnnPlanDeleter {
   void operator()(cudnnPersistentRNNPlan_t plan) const {
-#if CUDNN_VERSION < 8100
     CHECK_CUDNN_OK(cudnnDestroyPersistentRNNPlan(plan));
-#endif  // CUDNN_VERSION < 8100
   }
 };
+#endif  // CUDNN_VERSION < 8100
 #if CUDNN_VERSION >= 7603
 struct CtcLossDescriptorDeleter {
   void operator()(cudnnCTCLossDescriptor_t descriptor) const {


### PR DESCRIPTION
With the introduction of cuDNN v9, the `cudnnPersistentRNNPlan_t` will be removed. Consequently, this pull request aims to eliminate its reliance, particularly since our transition from the older APIs from version 8.1.

In a previous update, our cuDNN team removed all deprecated RNN functions, inadvertently overlooking the definition of the `cudnnPersistentRNNPlan_t` struct. This has been fixed in the latest version.

cc. @reedwm 