### PR TITLE
[XLA:GPU] add flash attention dropout in XLA runtime

### DIFF
--- a/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
+++ b/xla/mlir/backends/gpu/transforms/lmhlo_gpu_to_gpu_runtime.cc
@@ -818,6 +818,17 @@ class FusedAttentionBackwardLowering
         }
         break;
 
+      case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::BackwardSoftmaxDropout:
+        if (is_flash_attention) {
+          if (num_operands == 12) {
+            fused_attention += "scale.softmax.dropout";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for flash attention backward - "
+                "BMM_Softmax_Dropout_BMM");
+          }
+        }
+        break;
       case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
           BackwardScaleBiasSoftmax:
         if (is_flash_attention) {
@@ -843,6 +854,16 @@ class FusedAttentionBackwardLowering
 
       case mlir::lmhlo_gpu::FusedMhaBackwardDagSignature::
           BackwardScaleBiasSoftmaxDropout:
+        if (is_flash_attention) {
+          if (num_operands == 13) {
+            fused_attention += "scale.bias.softmax.dropout";
+          } else {
+            return op.emitOpError(
+                "unexpected number of operands for flash attention backward - "
+                "BMM_Bias_Softmax_Dropout_BMM");
+          }
+          break;
+        }
         if (num_operands == 10) {
           fused_attention += "scale.softmax.dropout";
         } else if (num_operands == 11) {

--- a/xla/service/gpu/runtime/fused_attention.cc
+++ b/xla/service/gpu/runtime/fused_attention.cc
@@ -1119,6 +1119,50 @@ XLA_RUNTIME_DEFINE_CUSTOM_CALL(
         .Value(std::optional<int64_t>())  // seed
 );
 
+XLA_RUNTIME_DEFINE_CUSTOM_CALL(
+    FlashAttentionScaleBiasSoftmaxDropoutBackward,
+    FunctionWrapper<FusedAttentionBackwardImpl>(), checks,
+    BindFusedAttentionBackwardAttributes(
+        FusedAttentionBackwardCall(
+            "xla.gpu.flash.attention.backward.scale.bias.softmax.dropout")
+            .Value(std::optional<StridedMemrefView>())  // mask
+            .Arg<StridedMemrefView>()                   // bias
+            .Arg<StridedMemrefView>()                   // fwd_output
+            .Arg<StridedMemrefView>()                   // d_bmm1_lhs
+            .Arg<StridedMemrefView>()                   // d_bmm1_rhs
+            .Arg<StridedMemrefView>()                   // d_bmm2_rhs
+            .Value(std::optional<StridedMemrefView>())  // d_S
+            .Arg<StridedMemrefView>()                   // softmax_sum
+            .Arg<StridedMemrefView>()                   // d_Q_accum
+            .Arg<FlatMemrefView>()                      // scratch
+            .Value(std::optional<StridedMemrefView>())  // d_bias
+        )
+        .Attr<double>("dropout_rate")  // dropout_rate
+        .Attr<int64_t>("seed")         // seed
+);
+
+XLA_RUNTIME_DEFINE_CUSTOM_CALL(
+    FlashAttentionScaleSoftmaxDropoutBackward,
+    FunctionWrapper<FusedAttentionBackwardImpl>(), checks,
+    BindFusedAttentionBackwardAttributes(
+        FusedAttentionBackwardCall(
+            "xla.gpu.flash.attention.backward.scale.softmax.dropout")
+            .Value(std::optional<StridedMemrefView>())  // mask
+            .Value(std::optional<StridedMemrefView>())  // bias
+            .Arg<StridedMemrefView>()                   // fwd_output
+            .Arg<StridedMemrefView>()                   // d_bmm1_lhs
+            .Arg<StridedMemrefView>()                   // d_bmm1_rhs
+            .Arg<StridedMemrefView>()                   // d_bmm2_rhs
+            .Value(std::optional<StridedMemrefView>())  // d_S
+            .Arg<StridedMemrefView>()                   // softmax_sum
+            .Arg<StridedMemrefView>()                   // d_Q_accum
+            .Arg<FlatMemrefView>()                      // scratch
+            .Value(std::optional<StridedMemrefView>())  // d_bias
+        )
+        .Attr<double>("dropout_rate")  // dropout_rate
+        .Attr<int64_t>("seed")         // seed
+);
+
 //===----------------------------------------------------------------------===//
 // cuBLASLt custom calls bindings and registration.
 //===----------------------------------------------------------------------===//
@@ -1195,6 +1239,10 @@ void RegisterFusedAttentionBackwardCustomCalls(
                     FlashAttentionScaleBiasSoftmaxBackward);
   registry.Register(flash_attention("scale.softmax"),
                     FlashAttentionScaleSoftmaxBackward);
+  registry.Register(flash_attention("scale.bias.softmax.dropout"),
+                    FlashAttentionScaleBiasSoftmaxDropoutBackward);
+  registry.Register(flash_attention("scale.softmax.dropout"),
+                    FlashAttentionScaleSoftmaxDropoutBackward);
 }
 }  // namespace gpu
 }  // namespace xla

--- a/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
+++ b/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
@@ -1485,6 +1485,19 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnfMHABackward(
           custom_call, operands);
       return set_common_fmha_backward_attributes(fmha_backward);
     }
+    case xla::gpu::CudnnfMHAKind::kBackwardSoftmaxDropout: {
+      // push fwd output for bwd here if it is flash attention
+      if (config.is_flash_attention()) {
+        TF_RETURN_IF_ERROR(GetOrCreateView(custom_call->operand(5), &operands));
+      }
+      TF_RETURN_IF_ERROR(GetOrCreateView(custom_call, &operands));
+      auto fmha_backward = CreateOpWithoutAttrs<lmhlo_gpu::fusedMHABackwardOp>(
+          custom_call, operands);
+      fmha_backward.setDropoutRateAttr(
+          builder_.getF64FloatAttr(config.dropout_rate()));
+      fmha_backward.setSeedAttr(builder_.getI64IntegerAttr(config.seed()));
+      return set_common_fmha_backward_attributes(fmha_backward);
+    }
     case xla::gpu::CudnnfMHAKind::kBackwardScaleBiasSoftmax: {
       // push fwd output for bwd here if it is flash attention
       if (config.is_flash_attention()) {


### PR DESCRIPTION
* Fix a missing conversion from HLO to MHLO for bmm1-softmax-dropout-bmm2 pattern
* Add XLA runtime support for bmm1-(bias)-softmax-dropout-bmm2 pattern. Thunk support is already added but XLA runtime support is missing.