### PR TITLE
[ROCM] adding occupancy calculation & renamed to rocm_executor

### DIFF
--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -672,25 +672,23 @@ xla_cc_binary(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:dnn",
         "//xla/stream_executor/host:host_platform",
-        "//xla/stream_executor/rocm:rocm_platform_id",
         "//xla/tests:test_utils",
         "//xla/tools:hlo_module_loader",
         "@com_google_absl//absl/status",
         "@llvm-project//llvm:Target",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:platform_port",
-        "@tsl//tsl/platform:rocm_rocdl_path",
         "@tsl//tsl/util:command_line_flags",
     ] + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_platform_id",
         "//xla/service/gpu:nvptx_compiler_impl",
         "//xla/stream_executor/cuda:cublas_plugin",
     ]) + if_rocm_is_configured([
-        "//xla/stream_executor/rocm:rocm_platform_id",
+        "//xla/stream_executor/rocm:rocm_platform_id", # build_cleaner: keep
         "//xla/stream_executor/rocm:rocblas_plugin",
         "//xla/stream_executor/rocm:rocm_helpers",
         "//xla/service/gpu:amdgpu_compiler_impl",
-        "@tsl//tsl/platform:rocm_rocdl_path",
+        "@tsl//tsl/platform:rocm_rocdl_path",          # build_cleaner: keep
     ]),
 )
 

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -131,13 +131,11 @@ class GpuExecutor : public internal::StreamExecutorInterface {
   absl::Status Submit(Stream* stream,
                       const CommandBuffer& command_buffer) override;
 
-  // (supported on CUDA only)
   int CalculateOccupancy(const DeviceDescription& device_description,
                          uint64_t registers_per_thread,
                          uint64_t shared_memory_per_block,
                          const ThreadDim& thread_dims, GpuFunctionHandle func);
 
-  // (supported on CUDA only)
   int CompareOccupancy(int* initial_blocks,
                        const DeviceDescription& device_description,
                        uint64_t registers_per_thread,

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -121,8 +121,8 @@ cc_library(
 )
 
 cc_library(
-    name = "rocm_gpu_executor",
-    srcs = if_rocm_is_configured(["rocm_gpu_executor.cc"]),
+    name = "rocm_executor",
+    srcs = if_rocm_is_configured(["rocm_executor.cc"]),
     deps = if_rocm_is_configured([
         ":rocm_diagnostics",
         ":rocm_driver",
@@ -171,7 +171,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = if_rocm_is_configured([
         ":rocm_driver",
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         ":rocm_runtime",
         "@com_google_absl//absl/base",
@@ -209,7 +209,7 @@ cc_library(
     hdrs = if_rocm_is_configured(["rocblas_wrapper.h"]),
     deps = if_rocm_is_configured([
         ":rocblas_if_static",
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         "@local_config_rocm//rocm:rocm_headers",
         "//xla/stream_executor/platform",
@@ -229,7 +229,7 @@ cc_library(
         ":rocblas_if_static",
         ":rocblas_wrapper",
         ":hipblas_lt_header",
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         "@eigen_archive//:eigen3",
         "//xla/stream_executor",
@@ -316,7 +316,7 @@ cc_library(
         ":miopen_if_static",
         ":rocm_diagnostics",
         ":rocm_driver",
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         "@eigen_archive//:eigen3",
         "//xla/stream_executor",
@@ -373,7 +373,7 @@ cc_library(
     hdrs = if_rocm_is_configured(["hipsparse_wrapper.h"]),
     deps = if_rocm_is_configured([
         ":hipsparse_if_static",
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         "@local_config_rocm//rocm:rocm_headers",
         "//xla/stream_executor/platform",
@@ -402,7 +402,7 @@ cc_library(
     srcs = if_rocm_is_configured(["rocsolver_wrapper.h"]),
     hdrs = if_rocm_is_configured(["rocsolver_wrapper.h"]),
     deps = if_rocm_is_configured([
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         ":rocsolver_if_static",
         "@local_config_rocm//rocm:rocm_headers",
@@ -432,7 +432,7 @@ cc_library(
     srcs = if_rocm_is_configured(["hipsolver_wrapper.h"]),
     hdrs = if_rocm_is_configured(["hipsolver_wrapper.h"]),
     deps = if_rocm_is_configured([
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         ":hipsolver_if_static",
         "@local_config_rocm//rocm:rocm_headers",
@@ -459,7 +459,7 @@ cc_library(
         "hip_blas_utils.h",
     ]),
     deps = if_rocm_is_configured([
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         ":rocblas_plugin",
         ":hip_blas_utils",
@@ -533,7 +533,7 @@ cc_library(
     srcs = if_rocm_is_configured(["roctracer_wrapper.h"]),
     hdrs = if_rocm_is_configured(["roctracer_wrapper.h"]),
     deps = if_rocm_is_configured([
-        ":rocm_gpu_executor",
+        ":rocm_executor",
         ":rocm_platform_id",
         ":roctracer_if_static",
         "@local_config_rocm//rocm:rocm_headers",

--- a/xla/stream_executor/rocm/rocm_activation.h
+++ b/xla/stream_executor/rocm/rocm_activation.h
@@ -17,7 +17,7 @@ limitations under the License.
 // It reaches into the ROCM implementation to activate an underlying ROCM
 // context.
 //
-// Having this file separate from rocm/rocm_gpu_executor.h means that dependent
+// Having this file separate from rocm/rocm_executor.h means that dependent
 // code does not also have to depend on rocm.h.
 
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_ACTIVATION_H_

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -2105,21 +2105,24 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   ScopedActivateContext activation{context};
 
   int max_blocks = 0;
-  hipError_t result = hipSuccess;
-  // TODO(ROCm) implement this feature in HIP
-  if (result != hipSuccess) {
-    return absl::Status{
-        absl::StatusCode::kInternal,
-        absl::StrFormat("failed to calculate occupancy of kernel %p: %s",
-                        kernel, ToString(result).c_str())};
-  }
-
+  RETURN_IF_ROCM_ERROR(wrap::hipModuleOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_blocks, kernel, threads_per_block, dynamic_shared_memory_bytes),
+         "Failed to calculate maximal active blocks per SM");
   return max_blocks;
 }
 
 }  // namespace gpu
 
 namespace rocm {
+
+absl::Status OccupancyGetMaxPotentialBlockSize(int* gridSize, int* blockSize, 
+          hipFunction_t kernel, size_t dynSharedMemPerBlk, int blockSizeLimit)
+{
+  RETURN_IF_ROCM_ERROR(wrap::hipModuleOccupancyMaxPotentialBlockSize(
+      gridSize, blockSize, kernel, dynSharedMemPerBlk, blockSizeLimit),
+        "Failed to calculate maximal potential block size");
+  return absl::OkStatus();
+}
 
 hipCtx_t CurrentContextOrDie() {
   hipCtx_t current = nullptr;

--- a/xla/stream_executor/rocm/rocm_driver.h
+++ b/xla/stream_executor/rocm/rocm_driver.h
@@ -177,6 +177,10 @@ namespace rocm {
 using MemorySpace = gpu::MemorySpace;
 using ScopedActivateContext = gpu::ScopedActivateContext;
 
+// TODO: this function shall be added to the GpuDriver API as well 
+absl::Status OccupancyGetMaxPotentialBlockSize(int* gridSize, int* blockSize, 
+          hipFunction_t func, size_t dynSharedMemPerBlk, int blockSizeLimit);
+
 // Returns the current context set in ROCm. This is done by calling ROCm
 // driver (e.g., this value is not our cached view of the current context).
 hipCtx_t CurrentContextOrDie();

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -154,6 +154,8 @@ namespace wrap {
   __macro(hipModuleLaunchKernel)                    \
   __macro(hipModuleLoadData)                        \
   __macro(hipModuleUnload)                          \
+  __macro(hipModuleOccupancyMaxActiveBlocksPerMultiprocessor) \
+  __macro(hipModuleOccupancyMaxPotentialBlockSize)  \
   __macro(hipPointerGetAttribute)                   \
   __macro(hipPointerGetAttributes)                  \
   __macro(hipRuntimeGetVersion)                     \

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "xla/stream_executor/platform/initialize.h"
 #include "xla/stream_executor/platform/port.h"
 #include "xla/stream_executor/plugin_registry.h"
+#include "xla/stream_executor/rocm/rocm_driver.h"
 #include "xla/stream_executor/rocm/rocm_diagnostics.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/stream.h"
@@ -340,27 +341,8 @@ absl::Status GpuExecutor::Submit(Stream* stream,
   return GpuDriver::GraphLaunch(exec, AsGpuStreamValue(stream));
 }
 
-int GpuExecutor::CalculateOccupancy(const DeviceDescription& device_description,
-                                    uint64_t registers_per_thread,
-                                    uint64_t shared_memory_per_block,
-                                    const ThreadDim& thread_dims,
-                                    GpuFunctionHandle func) {
-  LOG(FATAL) << "Feature not supported on ROCM platform (CalculateOccupancy)";
-  return 0;
-}
-
-int GpuExecutor::CompareOccupancy(int* initial_blocks,
-                                  const DeviceDescription& device_description,
-                                  uint64_t registers_per_thread,
-                                  uint64_t shared_memory_per_block,
-                                  const ThreadDim& thread_dims,
-                                  GpuFunctionHandle func) {
-  LOG(FATAL) << "Feature not supported on ROCM platform (CompareOccupancy)";
-  return 0;
-}
-
 absl::Status GpuExecutor::LoadModule(const MultiModuleLoaderSpec& spec,
-                                     ModuleHandle* module_handle) {
+                                    ModuleHandle* module_handle) {
   // In GpuExecutor we store the pointer to the  HSACO binary  as
   // ModuleHandle::id().
   hipModule_t hip_module = nullptr;
@@ -414,7 +396,72 @@ absl::Status GpuExecutor::LoadModuleFromHsaco(const char* hsaco,
 void GpuExecutor::VlogOccupancyInfo(const Kernel& kernel,
                                     const ThreadDim& thread_dims,
                                     const BlockDim& block_dims) {
-  // TODO(ROCm) implement this feature in HIP
+  VLOG(2) << "Computing kernel occupancy for kernel "
+          << kernel.demangled_name();
+  VLOG(2) << "Thread dimensions (" << thread_dims.x << ", " << thread_dims.y
+          << ", " << thread_dims.z << ")";
+
+  auto regs_per_thread = kernel.metadata().registers_per_thread();
+  auto smem_per_block = kernel.metadata().shared_memory_bytes();
+
+  if (!regs_per_thread && !smem_per_block) {
+    return;
+  }
+
+  const DeviceDescription& device_description =
+      kernel.parent()->GetDeviceDescription();
+
+  const GpuKernel* rocm_kernel = AsGpuKernel(&kernel);
+  auto hipfunc = rocm_kernel->AsGpuFunctionHandle();
+
+  int blocks_per_sm = CalculateOccupancy(device_description, *regs_per_thread,
+                                         *smem_per_block, thread_dims, hipfunc);
+  VLOG(2) << "Resident blocks per SM is " << blocks_per_sm;
+
+  int suggested_threads =
+      CompareOccupancy(&blocks_per_sm, device_description, *regs_per_thread,
+                       *smem_per_block, thread_dims, hipfunc);
+  if (suggested_threads != 0) {
+    VLOG(2) << "The rocm occupancy calculator recommends using "
+            << suggested_threads
+            << " threads per block to achieve an occupancy of " << blocks_per_sm
+            << " blocks per SM.";
+  }
+}
+
+// Compute and return maximum blocks per core (occupancy) based on the
+// device description, some kernel characteristics and the number of threads per
+// block.  If unable to compute occupancy, zero is returned.
+int GpuExecutor::CalculateOccupancy(const DeviceDescription& device_description,
+                                    uint64_t registers_per_thread,
+                                    uint64_t shared_memory_per_block,
+                                    const ThreadDim& thread_dims,
+                                    GpuFunctionHandle func) {
+  int suggested_blocks = 0;
+  int suggested_threads = 0;
+  (void)rocm::OccupancyGetMaxPotentialBlockSize(&suggested_blocks, &suggested_threads, 
+      func, shared_memory_per_block, 0);
+  return suggested_blocks;
+}
+
+// Compute and return the suggested thread count to achieve ideal occupancy.
+// If the provided thread dimensions match this number, zero is returned.
+int GpuExecutor::CompareOccupancy(int* initial_blocks,
+                                  const DeviceDescription& device_description,
+                                  uint64_t registers_per_thread,
+                                  uint64_t shared_memory_per_block,
+                                  const ThreadDim& thread_dims,
+                                  GpuFunctionHandle func) {
+  int suggested_blocks = 0;
+  int suggested_threads = 0;
+  (void)rocm::OccupancyGetMaxPotentialBlockSize(&suggested_blocks, &suggested_threads, 
+      func, shared_memory_per_block, 0);
+  if (suggested_blocks > *initial_blocks) {
+    *initial_blocks = suggested_blocks;
+    return suggested_threads;
+  } else {
+    return 0;
+  }
 }
 
 DeviceMemoryBase GpuExecutor::Allocate(uint64_t size, int64_t memory_space) {
@@ -960,4 +1007,4 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
 
 }  // namespace stream_executor
 
-REGISTER_MODULE_INITIALIZER(rocm_gpu_executor, {});
+REGISTER_MODULE_INITIALIZER(rocm_executor, {});


### PR DESCRIPTION
In this PR, I add missing features for rocm_gpu_executor: occupancy calculation and also renamed it to rocm_executor to be aligned with CUDA side.

@xla-rotation: could you please have a look ?