### PR TITLE
Move stream attributes from hlo.proto to gpu backend config

### DIFF
--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -3774,12 +3774,6 @@ void HloInstruction::PrintExtraAttributes(
                 "statistics=", StatisticsVizToString(statistics_viz()));
     });
   }
-
-  if (operation_queue_id_ != -1) {
-    printer.Next([this](Printer* printer) {
-      AppendCat(printer, "operation_queue_id=", operation_queue_id_);
-    });
-  }
 }
 
 std::vector<std::string> HloInstruction::ExtraAttributesToString(

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -1922,15 +1922,6 @@ class HloInstruction {
   bool is_default_config() const { return is_default_config_; }
   void set_default_config() { is_default_config_ = true; }
 
-  void set_operation_queue_id(int64_t operation_queue_id) {
-    operation_queue_id_ = operation_queue_id;
-  }
-
-  std::optional<int64_t> operation_queue_id() const {
-    if (operation_queue_id_ == -1) return std::nullopt;
-    return operation_queue_id_;
-  }
-
   // Returns a string representation of a proto in the format used by
   // raw_backend_config_string.
   //

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -204,6 +204,18 @@ message CudnnfMHABackendConfig {
 
 // Generic backend config for XLA:GPU
 message GpuBackendConfig {
+  // Specifies which operation queue the current instruction will run on.
+  // A backend may have multiple operation queues to run instructions
+  // concurrently, use this to signal the backend which queue to dispatch to.
+  // The backend should keep a mapping of
+  // operation_queue_id->actual_hardware_queue_id if runtime will create
+  // different IDs.
+  int64 operation_queue_id = 1;
+
+  // Specifies which operation queues to await for data when running with
+  // multiple operation queues.
+  repeated int64 wait_on_operation_queues = 2;
+
   oneof backend_config {
     CudnnConvBackendConfig cudnn_conv_backend_config = 3;
 

--- a/xla/service/gpu/backend_configs_test.cc
+++ b/xla/service/gpu/backend_configs_test.cc
@@ -49,13 +49,116 @@ TEST_F(BackendConfigsTest, DefaultCollectiveBackendConfig) {
       std::unique_ptr<HloModule> module,
       ParseAndReturnVerifiedModule(kHloString, /*replica_count=*/2));
 
-  const HloInstruction *ags = FindInstruction(module.get(), "agf32-start");
+  const HloInstruction* ags = FindInstruction(module.get(), "agf32-start");
   EXPECT_THAT(ags->has_backend_config(), IsFalse());
-  auto collective_backend_config =
-      ags->backend_config<CollectiveBackendConfig>();
-  EXPECT_THAT(collective_backend_config.status(), IsOk());
-  EXPECT_THAT(collective_backend_config->is_sync(), IsFalse());
-  EXPECT_THAT(collective_backend_config->no_parallel_custom_call(), IsFalse());
+  TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig gpu_config,
+                          ags->backend_config<GpuBackendConfig>());
+  auto collective_backend_config = gpu_config.collective_backend_config();
+  EXPECT_THAT(collective_backend_config.is_sync(), IsFalse());
+  EXPECT_THAT(collective_backend_config.no_parallel_custom_call(), IsFalse());
+}
+
+TEST_F(BackendConfigsTest, DefaultGpuBackendConfigParseOpQueue) {
+  constexpr absl::string_view kHloString = R"(
+  HloModule ModuleWithAsync
+
+  ENTRY entry {
+    p0f32 = f32[4, 4] parameter(0)
+    p1f32 = f32[4, 4] parameter(1)
+
+    ROOT addf32 = f32[4, 4] add(p0f32, p1f32), backend_config={"operation_queue_id":"2"}
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloString));
+
+  HloInstruction* add = module->entry_computation()->root_instruction();
+  EXPECT_TRUE(add->has_backend_config());
+  auto real_gpu_backend_config = add->backend_config<GpuBackendConfig>();
+  EXPECT_THAT(real_gpu_backend_config.status(), IsOk());
+  EXPECT_EQ(real_gpu_backend_config->operation_queue_id(), 2);
+}
+
+TEST_F(BackendConfigsTest, DefaultGpuBackendConfigParseWaitOnQueue) {
+  constexpr absl::string_view kHloString = R"(
+  HloModule ModuleWithAsync
+
+  ENTRY entry {
+    p0f32 = f32[4, 4] parameter(0)
+    p1f32 = f32[4, 4] parameter(1)
+
+    ROOT addf32 = f32[4, 4] add(p0f32, p1f32), backend_config={"wait_on_operation_queues":[0, 1]}
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloString));
+
+  HloInstruction* add = module->entry_computation()->root_instruction();
+  EXPECT_TRUE(add->has_backend_config());
+  auto real_gpu_backend_config = add->backend_config<GpuBackendConfig>();
+  EXPECT_THAT(real_gpu_backend_config.status(), IsOk());
+  std::vector<int64_t> expected_ids = {0, 1};
+  EXPECT_EQ(real_gpu_backend_config->wait_on_operation_queues().size(),
+            expected_ids.size());
+  for (int64_t i = 0; i < expected_ids.size(); i++) {
+    EXPECT_EQ(expected_ids[i],
+              real_gpu_backend_config->wait_on_operation_queues()[i]);
+  }
+}
+
+TEST_F(BackendConfigsTest, DefaultGpuBackendConfigSetOpQueue) {
+  constexpr absl::string_view kHloString = R"(
+  HloModule ModuleWithAsync
+
+  ENTRY entry {
+    p0f32 = f32[4, 4] parameter(0)
+    p1f32 = f32[4, 4] parameter(1)
+
+    ROOT addf32 = f32[4, 4] add(p0f32, p1f32)
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloString));
+
+  HloInstruction* add = module->entry_computation()->root_instruction();
+  EXPECT_FALSE(add->has_backend_config());
+  GpuBackendConfig gpu_backend_config;
+  gpu_backend_config.set_operation_queue_id(2);
+  EXPECT_THAT(add->set_backend_config(gpu_backend_config), IsOk());
+  EXPECT_EQ(add->raw_backend_config_string(),
+            "{\"operation_queue_id\":\"2\",\"wait_on_operation_queues\":[]}");
+}
+
+TEST_F(BackendConfigsTest, DefaultGpuBackendConfigSetWaitOnQueue) {
+  constexpr absl::string_view kHloString = R"(
+  HloModule ModuleWithAsync
+
+  ENTRY entry {
+    p0f32 = f32[4, 4] parameter(0)
+    p1f32 = f32[4, 4] parameter(1)
+
+    ROOT addf32 = f32[4, 4] add(p0f32, p1f32)
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloString));
+
+  HloInstruction* add = module->entry_computation()->root_instruction();
+  EXPECT_FALSE(add->has_backend_config());
+  GpuBackendConfig gpu_backend_config;
+  // Wait on queues {0, 1}
+  gpu_backend_config.mutable_wait_on_operation_queues()->Add(0);
+  gpu_backend_config.mutable_wait_on_operation_queues()->Add(1);
+  EXPECT_THAT(add->set_backend_config(gpu_backend_config), IsOk());
+  EXPECT_EQ(add->raw_backend_config_string(),
+            "{\"operation_queue_id\":\"0\",\"wait_on_operation_queues\":[\"0\","
+            "\"1\"]}");
+  TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig config,
+                          add->backend_config<GpuBackendConfig>());
 }
 
 }  // namespace

--- a/xla/service/gpu/command_buffer_scheduling_test.cc
+++ b/xla/service/gpu/command_buffer_scheduling_test.cc
@@ -200,7 +200,7 @@ TEST_F(CommandBufferSchedulingTest, AllReduceStartFollowedByDone) {
       %a = s32[4] parameter(0)
       %start = s32[4]{0} all-reduce-start(s32[4]{0} %a),
         replica_groups={{0,1}}, to_apply=%add,
-        backend_config={"is_sync":true,"no_parallel_custom_call":false}
+        backend_config={"collective_backend_config": {"is_sync":true,"no_parallel_custom_call":false}}
       ROOT %done = s32[4]{0} all-reduce-done(s32[4]{0} %start)
     })";
 
@@ -234,7 +234,7 @@ TEST_F(CommandBufferSchedulingTest, AllGatherStartFollowedByDone) {
 
       %start = (s32[2]{0}, s32[4]{0}) all-gather-start(%a),
         channel_id=555, replica_groups={{0,1}}, dimensions={0},
-        backend_config={"is_sync":true,"no_parallel_custom_call":false}
+        backend_config={"collective_backend_config": {"is_sync":true,"no_parallel_custom_call":false}}
 
       ROOT %done = s32[4]{0} all-gather-done(%start)
     })";
@@ -275,7 +275,7 @@ TEST_F(CommandBufferSchedulingTest, ReduceScatterStartFollowedByDone) {
 
       %start = ((s32[4]{0}), s32[2]{0}) reduce-scatter-start(%a),
         channel_id=555, replica_groups={{0,1}}, dimensions={0}, to_apply=add,
-        backend_config={"is_sync":true,"no_parallel_custom_call":false}
+        backend_config={"collective_backend_config": {"is_sync":true,"no_parallel_custom_call":false}}
 
       ROOT %done = s32[2]{0} reduce-scatter-done(%start)
     })";

--- a/xla/service/gpu/triton_autotuner_test.cc
+++ b/xla/service/gpu/triton_autotuner_test.cc
@@ -631,7 +631,7 @@ ENTRY e {
         RunFileCheck(
             module->ToString(HloPrintOptions{}.set_print_operand_shape(false)),
             R"(
-// CHECK: backend_config={"fusion_backend_config":{"kind":"__triton_gemm","triton_gemm_config":{"block_m":"32","block_n":"32","block_k":"32","split_k":"1","num_stages":"1","num_warps":"4"}}}
+// CHECK: backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"fusion_backend_config":{"kind":"__triton_gemm","triton_gemm_config":{"block_m":"32","block_n":"32","block_k":"32","split_k":"1","num_stages":"1","num_warps":"4"}}}
             )"));
     EXPECT_TRUE(filecheck_matches);
   } else {

--- a/xla/service/hlo.proto
+++ b/xla/service/hlo.proto
@@ -111,7 +111,7 @@ enum CustomCallApiVersion {
 }
 
 // Serialization of HloInstruction.
-// Next ID: 86
+// Next ID: 84
 message HloInstructionProto {
   reserved 10;
   reserved "parameter_name";
@@ -363,23 +363,11 @@ message HloInstructionProto {
   int64 k = 81;
 
   // Represents the largest flag for top-k.
-  bool largest = 85;
+  bool largest = 83;
 
   // Represents the information for tracking propagation of values within HLO
   // graph.
   xla.StatisticsViz statistics_viz = 82;
-
-  // Specifies which operation queue the current instruction will run on.
-  // A backend may have multiple operation queues to run instructions
-  // concurrently, use this to signal the backend which queue to dispatch to.
-  // The backend should keep a mapping of
-  // operation_queue_id->actual_hardware_queue_id if runtime will create
-  // different IDs.
-  int64 operation_queue_id = 83;
-
-  // Specifies which operation queues to await for data when running with
-  // multiple operation queues.
-  repeated int64 wait_on_operation_queues = 84;
 }
 
 // Serialization of HloComputation.

--- a/xla/service/hlo_instruction_test.cc
+++ b/xla/service/hlo_instruction_test.cc
@@ -2574,39 +2574,6 @@ TEST_F(HloInstructionTest, PrintCycle) {
   ASSERT_IS_OK(send_done->DropAllControlDeps());
 }
 
-TEST_F(HloInstructionTest, SetOperationQueueId) {
-  std::unique_ptr<HloComputation> main_computation;
-  HloComputation::Builder main_builder("Entry");
-  const Shape scalar_shape = ShapeUtil::MakeScalarShape(F32);
-  HloInstruction* param0 = main_builder.AddInstruction(
-      HloInstruction::CreateParameter(0, scalar_shape, "p0"));
-  HloInstruction* param1 = main_builder.AddInstruction(
-      HloInstruction::CreateParameter(1, scalar_shape, "p1"));
-
-  HloInstruction* add =
-      main_builder.AddInstruction(HloInstruction::CreateBinary(
-          scalar_shape, HloOpcode::kAdd, param0, param1));
-  add->set_operation_queue_id(3);
-  auto module = CreateNewVerifiedModule();
-  module->AddEntryComputation(main_builder.Build());
-
-  auto options = HloPrintOptions().set_print_metadata(false);
-  EXPECT_EQ(module->entry_computation()->root_instruction()->ToString(options),
-            "%add = f32[] add(f32[] %p0, f32[] %p1), operation_queue_id=3");
-}
-
-TEST_F(HloInstructionTest, ParseOperationQueueId) {
-  constexpr char kHloString[] = R"(
-  ENTRY main {
-    c0 = f32[] constant(0)
-    ROOT add0 = f32[] add(c0, c0), operation_queue_id=2
-  })";
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnVerifiedModule(kHloString));
-  EXPECT_EQ(
-      module->entry_computation()->root_instruction()->operation_queue_id(), 2);
-}
-
 TEST_F(HloInstructionTest, VerifyBodyComputationPointsToWhile) {
   auto module = CreateNewVerifiedModule();
   const Shape scalar_shape = ShapeUtil::MakeScalarShape(F32);

--- a/xla/service/hlo_parser.cc
+++ b/xla/service/hlo_parser.cc
@@ -1322,10 +1322,6 @@ bool HloParserImpl::ParseInstructionRhs(HloComputation::Builder* builder,
   attrs["backend_config"] = {/*required=*/false, AttrTy::kStringOrJsonDict,
                              &backend_config};
 
-  optional<int64_t> operation_queue_id;
-  attrs["operation_queue_id"] = {/*required=*/false, AttrTy::kInt64,
-                                 &operation_queue_id};
-
   std::optional<Shape> maybe_shape;
   if (parse_shape) {
     maybe_shape = shape;
@@ -1396,9 +1392,6 @@ bool HloParserImpl::ParseInstructionRhs(HloComputation::Builder* builder,
   }
   if (statistics_viz) {
     instruction->set_statistics_viz(*statistics_viz);
-  }
-  if (operation_queue_id) {
-    instruction->set_operation_queue_id(*operation_queue_id);
   }
 
   return AddInstruction(name, instruction, name_loc);


### PR DESCRIPTION
This is to follow up on this pr(https://github.com/openxla/xla/pull/7025) to move stream attributes from hlo.proto to gpuBackendConfig.