### PR TITLE
[XLA:CPU][Bug-fix] Fix bias fusion to oneDNN mamtul.

### DIFF
--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "xla/service/cpu/onednn_matmul_rewriter.h"
 
+#include "tsl/platform/logging.h"  // IWYU pragma: keep
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -26,7 +27,6 @@ limitations under the License.
 #include "xla/service/cpu/onednn_util.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
-#include "tsl/platform/logging.h"  // IWYU pragma: keep
 
 namespace xla {
 namespace cpu {
@@ -47,23 +47,6 @@ inline Status ValidateDotDimensionNumbers(
   TF_RET_CHECK(
       absl::c_equal(batch_dim_numbers, dim_numbers.rhs_batch_dimensions()));
   return OkStatus();
-}
-
-template <typename Pattern>
-inline auto AllowedIntermediateInstructions(HloInstruction** bitcast,
-                                            Pattern pattern) {
-  // Checks the presence of some intermediate operations that can be moved /
-  // folded to allow dot fusion with add.
-  // We try to match either of the following:
-  // 1. custom-call -> bf16-to-fp32 convert
-  // 2. custom-call -> bf16-to-fp32 convert -> bitcast
-  auto common =
-      m::AnyOf<HloInstruction>(m::Convert(std::move(pattern).WithOneUser())
-                                   .WithElementType(PrimitiveType::F32),
-                               std::move(pattern).WithOneUser())
-          .WithOneUser();
-  return m::AnyOf<HloInstruction>(m::Bitcast(bitcast, common), common)
-      .WithOneUser();
 }
 
 // We also check if the convert instruction has only one use.
@@ -92,16 +75,6 @@ inline auto OneDnnMatmulInstr(HloInstruction** instr) {
 inline auto ConvertBF16ToF32(HloInstruction** instr) {
   return m::Convert(m::Op(instr).WithElementType(PrimitiveType::BF16))
       .WithElementType(PrimitiveType::F32);
-}
-
-inline void GetBF16Bias(HloInstruction* dot, HloInstruction** old_bias,
-                        HloInstruction** new_bias) {
-  if (dot->shape().element_type() == PrimitiveType::BF16 &&
-      (((*old_bias)->operand_count() == 1 &&
-        Match((*old_bias)->mutable_operand(0), ConvertBF16ToF32(new_bias))) ||
-       Match(*old_bias, ConvertBF16ToF32(new_bias)))) {
-    *old_bias = *new_bias;
-  }
 }
 
 inline auto BcastConstScalar(HloInstruction** instr, double value) {
@@ -178,12 +151,27 @@ auto GELUActivation(HloInstruction* instr, HloInstruction** src) {
                    .WithOneUser());
 }
 
-StatusOr<Shape> AdjustBiasShape(const HloInstruction* instr,
-                                const absl::Span<const int64_t>& dot_dims) {
-  auto bcast = Cast<HloBroadcastInstruction>(instr);
-  // OneDNN matmul apply auto-broadcast to BIAS
-  // Replace Broadcast with Bitcast to match rank
+// OneDNN matmul can fuse add operaton with automatic broadcasting along the
+// addend's dimensions that are 1s. When compatible Broadcast can be replaced by
+// Bitcast which is much cheaper. Computue new shape for the Bitcast.
+StatusOr<Shape> AdjustBiasShape(const HloInstruction* broadcast_instr,
+                                const Shape& dot_shape) {
+  if (broadcast_instr->opcode() != HloOpcode::kBroadcast) {
+    return absl::InvalidArgumentError(
+        "Hlo instruction is not a Broadcast insruction.");
+  }
+  auto bcast = Cast<HloBroadcastInstruction>(broadcast_instr);
   Shape new_shape = bcast->shape();
+  // Broadcast instruction has "dimension" parameter along which its input's
+  // dim should not change. For exmaple,
+  //      dot = f32[3,4,5,6] dot(...)
+  //      arg = f32[3,6]{1,0} parameter(0)
+  //      broad = f32[3,4,5,6]{3,2,1,0} broadcast(arg), dimensions={0,3}
+  //      add = f32[3,4,5,6]{3,2,1,0} add(dot, arg)
+  // can be replaced with the following
+  //      arg = f32[3,6]{1,0} parameter(0)
+  //      bitcast = f32[3,1,1,6]{3,2,1,0} bitcast(arg)
+  //      fused = f32[3,4,5,6]{3,2,1,0} custom-call((..., bitcast)
   auto kept_dimensions = bcast->dimensions();
   for (int i = 0; i < new_shape.rank(); i++) {
     if (!absl::c_linear_search(kept_dimensions, i)) {
@@ -191,27 +179,126 @@ StatusOr<Shape> AdjustBiasShape(const HloInstruction* instr,
     }
   }
 
-  // Remove dimensions with value=1 to match dot dimensions
-  bool more_dims_to_delete = true;
-  while (more_dims_to_delete && new_shape.rank() > dot_dims.size()) {
-    for (int64_t i = 0; i < new_shape.rank(); i++) {
-      if (new_shape.dimensions()[i] == 1) {
-        new_shape.DeleteDimension(i);
-        break;
-      }
+  // If rank(new_shape) > rank(dot), extra dimensions with value = 1 can be
+  // deleted from the new_shape.
+  int64_t rank_difference = new_shape.rank() - dot_shape.rank();
+  auto new_dims = new_shape.dimensions();
+  std::vector<int64_t> dims_to_delete;
+  for (int i = 0; i < rank_difference; ++i) {
+    if (new_dims[i] == 1) {
+      dims_to_delete.push_back(i);
     }
-    more_dims_to_delete = false;
+  }
+  new_shape = ShapeUtil::DeleteDimensions(dims_to_delete, new_shape);
+
+  // New shape for bias should satisfy the condition: rank(new_shape) <=
+  // rank(dot).
+  if (new_shape.rank() > dot_shape.rank()) {
+    return absl::CancelledError(
+        "Bias shape could not be adjusted for a fusion.");
   }
 
-  // Validate dimensions
-  auto new_shape_dims = new_shape.dimensions();
-  for (int i = 0; i < dot_dims.size() - 2; i++) {
-    if (new_shape_dims[i] != 1 && new_shape_dims[i] != dot_dims[i]) {
-      return absl::CancelledError("bias cannot be fused - dimensions mismatch");
-    }
-  }
   return new_shape;
 };
+
+inline bool IsOperandFusible(HloInstruction* operand, HloInstruction* dot) {
+  // Check if one of binary operand shape is compatible with matmul for fusion.
+  // An operand is fusable if
+  //    1. rank(oeprand) <= rank(dot) and
+  //    2. Starting from the last dim in backward direction, the dimension
+  //       size of operand is either 1 or same to dot.
+  auto operand_dims = operand->shape().dimensions();
+  auto dot_dims = dot->shape().dimensions();
+  if (operand_dims.size() <= dot_dims.size()) {
+    int operand_idx = operand_dims.size() - 1;
+    int dot_idx = dot_dims.size() - 1;
+    for (; operand_idx >= 0; --operand_idx, --dot_idx) {
+      if (operand_dims[operand_idx] != 1 &&
+          operand_dims[operand_idx] != dot_dims[dot_idx])
+        return false;
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
+inline bool IsRowMajor(const Shape& shape) {
+  return LayoutUtil::IsMonotonicWithDim0Major(shape.layout());
+}
+
+// Whether the element type of instr is compatible with oneDNN kernels.
+// TODO(intel-tf): Restict compatible types based on instruction kind.
+inline bool CompatibleElementType(const HloInstruction* instr) {
+  PrimitiveType element_type = instr->shape().element_type();
+  return element_type == BF16 || element_type == F32;
+}
+
+// Type conversion from and to any of BF16 and FP32.
+// TODO(intel-tf): Support more types when enabled.
+template <typename Pattern>
+inline auto SupportedConvert(Pattern pattern) {
+  auto supported_convert = [](const HloInstruction* instr) -> bool {
+    return CompatibleElementType(instr) &&
+           CompatibleElementType(instr->operand(0));
+  };
+  return m::Convert(pattern).WithPredicate(supported_convert);
+}
+
+template <typename Pattern>
+inline auto SupportedConvert(HloInstruction** convert, Pattern pattern) {
+  auto supported_convert = [](const HloInstruction* instr) -> bool {
+    return CompatibleElementType(instr) &&
+           CompatibleElementType(instr->operand(0));
+  };
+  return m::Convert(convert, pattern).WithPredicate(supported_convert);
+}
+
+template <typename Pattern>
+inline auto BitcastWithReshapeSemantics(HloInstruction** bitcast,
+                                        Pattern pattern) {
+  // TODO(intel-tf): Add stronger condition that Bitcast does not have transpose
+  // semantics. Some of the HLO passes replaces Transpose with Bitcast. Here
+  // the layouts are checked to be rowmajor since the current pass runs after
+  // the layout assignment and oneDNN matmul is enabled for rowmajor layouts.
+  auto is_reshape = [](const HloInstruction* instr) -> bool {
+    if (instr) {
+      auto input_shape = instr->operand(0)->shape();
+      auto output_shape = instr->shape();
+      bool is_same_type = ShapeUtil::SameElementType(input_shape, output_shape);
+      bool has_equal_num_elems = ShapeUtil::ElementsIn(input_shape) ==
+                                 ShapeUtil::ElementsIn(output_shape);
+      bool has_rowmajor_layout =
+          IsRowMajor(input_shape) && IsRowMajor(output_shape);
+      return is_same_type && has_equal_num_elems && has_rowmajor_layout;
+    } else {
+      false;
+    }
+  };
+  return m::Bitcast(bitcast, pattern).WithPredicate(is_reshape);
+}
+
+template <typename Pattern>
+inline auto OptionalConvertAndBitcast(HloInstruction** optional_convert,
+                                      HloInstruction** optional_bitcast,
+                                      Pattern pattern) {
+  // Checks the presence of some intermediate operations that can be moved /
+  // folded to allow dot fusion with add.
+  // Try to match either of the following:
+  //   1. pattern-root -> bf16-to-fp32 convert -> bitcast
+  //   2. pattern-root -> bf16-to-fp32 convert
+  //   3. pattern-root -> bitcast
+  //   4. pattern-root
+  auto common =
+      m::AnyOf<HloInstruction>(
+          SupportedConvert(optional_convert, std::move(pattern).WithOneUser())
+              .WithOperand(0, m::Op().WithElementType(PrimitiveType::BF16))
+              .WithElementType(PrimitiveType::F32),
+          std::move(pattern).WithOneUser())
+          .WithOneUser();
+  return m::AnyOf<HloInstruction>(
+      BitcastWithReshapeSemantics(optional_bitcast, common), common);
+}
 
 }  // namespace
 
@@ -243,9 +330,8 @@ bool OneDnnMatMulRewriter::ShouldRewrite(const HloInstruction* dot_instr) {
   }
   // Layout should be row-major, contraction dimensions captures transpose
   // scenarios in last two dimensions.
-  if (!LayoutUtil::IsMonotonicWithDim0Major(lhs_shape.layout()) ||
-      !LayoutUtil::IsMonotonicWithDim0Major(rhs_shape.layout()) ||
-      !LayoutUtil::IsMonotonicWithDim0Major(output_shape.layout())) {
+  if (!IsRowMajor(lhs_shape) || !IsRowMajor(rhs_shape) ||
+      !IsRowMajor(output_shape)) {
     return false;
   }
 
@@ -331,33 +417,41 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
   }
 
   Status HandleAdd(HloInstruction* instr) override {
-    HloInstruction *addend, *dot, *bcast_input, *bitcast_input;
-    HloInstruction* bitcast = nullptr;
+    // Try to do a fusion for Dot(onednn-matmul) + Add. However,
+    // HLO Add instruction might receive the addends after additional
+    // processing like Broadcast, Bitcast, Convert etc. applied to the raw
+    // addends. Here, the following possible pattern is matched.
+    //
+    // clang-format off
+    //
+    //            Dot                               addend
+    //             |                                  |
+    //             v                                  v
+    //     optional instructions            optional instructions
+    //    (e.g, Convert, Bitcast)         (e.g, Convert, Broadcast)
+    //             |                                  |
+    //             +--------------+-------------------+
+    //                            |
+    //                            v
+    //                           Add
+    //
+    // clang-format on
 
-    auto pattern =
-        m::Op(&instr)
-            .WithOpcode(HloOpcode::kAdd)
-            .WithBinaryOperandsAnyOrder(
-                AllowedIntermediateInstructions(
-                    &bitcast, m::Op(&dot)
-                                  .WithOneUser()
-                                  .WithOpcode(HloOpcode::kCustomCall)
-                                  .WithCustomCallTarget({"__onednn$matmul"})),
-                m::Op(&addend).WithOneUser());
+    HloInstruction *addend_intermediate, *dot;
+    HloInstruction* optional_dot_bitcast = nullptr;
+    HloInstruction* optional_dot_convert = nullptr;
 
-    auto nonscalar_broadcast =
-        m::Broadcast(m::Op(&bcast_input)
-                         .WithPredicate([](const HloInstruction* ins) {
-                           return !ShapeUtil::IsEffectiveScalar(ins->shape());
-                         })
-                         .WithOneUser())
-            .WithOneUser();
-
-    auto addend_reshape =
-        m::Bitcast(m::Op(&bitcast_input).WithOneUser()).WithOneUser();
+    auto pattern = m::AddAnyOrder(
+        &instr,
+        OptionalConvertAndBitcast(&optional_dot_convert, &optional_dot_bitcast,
+                                  OneDnnMatmulInstr(&dot))
+            .WithOneUser(),
+        m::Op(&addend_intermediate).WithOneUser());
 
     if (Match(instr, pattern)) {
       if (!IsSupportedType(dot->shape().element_type())) return OkStatus();
+      // TODO(intel-tf): Remove the condition below when the fusion Dot +
+      // Add(bias) + Add(e.g., residual) is enabled.
       if (!dot->backend_config<BackendConfig>()
                ->mutable_onednn_matmul_config()
                ->fused_ops()
@@ -372,64 +466,58 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
         new_operands.push_back(operand);
       }
 
-      // For addend, match one of these patterns:
-      // 1. any(addend) -> broadcast -> add
-      // 2. any(addend) -> bitcast -> add
-      bool bias_bcast = Match(addend, nonscalar_broadcast);
-      bool check_addend = Match(addend, addend_reshape);
+      // At this point, the addend could have one of the following
+      // possiblities that the current fusion can handle:
+      //
+      //   - addend -> Convert -> Broadcast -> Add
+      //   - addend -> Broadcast -> Convert -> Add
+      //   - addend -> Convert
+      //   - addend -> Broadcast
+      //   - addend
+      //
+      // Hunt for addend through possible sequences above and check the addend
+      // is compatible to onednn-matmul fusion.
+      HloInstruction* addend = nullptr;
+      HloInstruction* optional_addend_broadcast = nullptr;
+      auto addend_pattern = m::AnyOf<HloInstruction>(
+          m::Broadcast(&optional_addend_broadcast,
+                       m::Convert(&addend, m::Op())),
+          m::Convert(m::Broadcast(&optional_addend_broadcast, m::Op(&addend))),
+          m::Convert(&addend, m::Op()),
+          m::Broadcast(&optional_addend_broadcast, m::Op(&addend)),
+          m::Op(&addend));
+      if (!Match(addend_intermediate, addend_pattern)) return OkStatus();
 
-      HloInstruction *bf16_addend, *bf16_bcast_input, *bf16_bitcast_input;
-      // If addend is bf16 and being converted to f32, get the original bf16
-      // one.
-      GetBF16Bias(dot, &addend, &bf16_addend);
-      if (bias_bcast) {
-        GetBF16Bias(dot, &bcast_input, &bf16_bcast_input);
-      }
-      if (check_addend) {
-        GetBF16Bias(dot, &bitcast_input, &bf16_bitcast_input);
-      }
-
-      if (bias_bcast) {
-        if (bcast_input->shape().rank() == 1) {
-          new_operands.push_back(bcast_input);
+      if (optional_addend_broadcast && addend->shape().rank() != 1) {
+        auto new_shape =
+            AdjustBiasShape(optional_addend_broadcast, dot->shape());
+        if (new_shape.ok()) {
+          addend = addend->AddInstruction(
+              HloInstruction::CreateBitcast(new_shape.value(), addend));
         } else {
-          auto new_shape = AdjustBiasShape(addend, dot->shape().dimensions());
-          if (new_shape.ok()) {
-            auto bitcast = bcast_input->AddInstruction(
-                HloInstruction::CreateBitcast(new_shape.value(), bcast_input));
-            new_operands.push_back(bitcast);
-          } else {
-            LOG(WARNING) << new_shape.status();
-            new_operands.push_back(nullptr);
-          }
+          VLOG(2) << new_shape.status();
+          return OkStatus();
         }
-      } else if (absl::c_equal(dot->shape().dimensions(),
-                               addend->shape().dimensions())) {
-        new_operands.push_back(addend);
-      } else if (check_addend &&
-                 absl::c_equal(dot->shape().dimensions(),
-                               bitcast_input->shape().dimensions())) {
-        new_operands.push_back(bitcast_input);
-      } else {
-        new_operands.push_back(nullptr);
       }
 
-      if (new_operands.back() == nullptr) {
+      // Validate addend for fusion.
+      if (CompatibleElementType(addend) && IsOperandFusible(addend, dot)) {
+        new_operands.push_back(addend);
+      } else {
         return OkStatus();
       }
-
-      bool nd_bias = absl::c_count_if(new_operands.back()->shape().dimensions(),
-                                      [](int64_t dim) { return dim > 1; }) > 1;
 
       auto matmul_call = Cast<HloCustomCallInstruction>(instr->AddInstruction(
           dot->CloneWithNewOperands(dot->shape(), new_operands)));
 
       auto backend_config = matmul_call->backend_config<BackendConfig>();
       backend_config->mutable_onednn_matmul_config()->add_fused_ops(
-          nd_bias ? OneDnnMatMulConfig::BINARY_ADD : OneDnnMatMulConfig::BIAS);
-      backend_config->mutable_onednn_matmul_config()->set_bias_broadcast(
-          bias_bcast);
-
+          addend->shape().rank() != 1 ? OneDnnMatMulConfig::BINARY_ADD
+                                      : OneDnnMatMulConfig::BIAS);
+      if (optional_addend_broadcast) {
+        backend_config->mutable_onednn_matmul_config()->set_bias_broadcast(
+            true);
+      }
       TF_RETURN_IF_ERROR(matmul_call->set_backend_config(*backend_config));
 
       HloInstruction* new_instr;
@@ -437,7 +525,8 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
       // insert bitcast after the new fusion to maintain the correct shape
       // (new-custom-call -> bitcast). Also, this will be followed by -> convert
       // for bf16 case to avoid datatype mismatch.
-      if (bitcast != nullptr && bitcast->opcode() == HloOpcode::kBitcast) {
+      if (optional_dot_bitcast != nullptr &&
+          optional_dot_bitcast->opcode() == HloOpcode::kBitcast) {
         if (matmul_call->shape().element_type() == PrimitiveType::BF16) {
           auto bitcast_call =
               matmul_call->AddInstruction(HloInstruction::CreateBitcast(

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -17,13 +17,13 @@ limitations under the License.
 
 #include <utility>
 
+#include "tsl/platform/cpu_info.h"
 #include "xla/literal.h"
 #include "xla/shape_util.h"
 #include "xla/test.h"
 #include "xla/test_helpers.h"
 #include "xla/tests/hlo_test_base.h"
 #include "xla/tests/test_macros.h"
-#include "tsl/platform/cpu_info.h"
 
 namespace xla {
 namespace cpu {
@@ -48,19 +48,29 @@ class MatmulTest : public HloTestBase {
     ; CHECK-DAG:   }
     ; CHECK:     }
     )";
+  const char* matmul_rewrite_str_ = R"(
+    ; CHECK:     custom_call_target="__onednn$matmul",
+    ; CHECK:       backend_config={
+    ; CHECK-DAG:     "outer_dimension_partitions":[],
+    ; CHECK-DAG:     "onednn_matmul_config":{
+    ; CHECK-DAG:       "fused_ops":[]
+    ; CHECK-DAG:   }
+    ; CHECK:     }
+    )";
 };
 
 TEST_F(MatmulTest, SimpleTestF32) {
   const char* matmul_module_str = R"(
-  HloModule matmul.test.f32, entry_computation_layout={(f32[2,8,4,16]{3,2,1,0},f32[2,8,16,32]{3,2,1,0})->f32[2,8,4,32]{3,2,1,0}}
+  HloModule matmul.test.f32, entry_computation_layout={(f32[32,8,128,64]{3,2,1,0},f32[32,8,64,128]{3,2,1,0})->f32[32,8,128,128]{3,2,1,0}}
 
   ENTRY matmul.test.f32 {
-    arg.0 = f32[2,8,4,16]{3,2,1,0} parameter(0), parameter_replication={false}
-    arg.1 = f32[2,8,16,32]{3,2,1,0} parameter(1), parameter_replication={false}
-    ROOT onednn.matmul.0 = f32[2,8,4,32]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+    arg.0 = f32[32,8,128,64]{3,2,1,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[32,8,64,128]{3,2,1,0} parameter(1), parameter_replication={false}
+    ROOT onednn.matmul.0 = f32[32,8,128,128]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, matmul_rewrite_str_);
 }
 
 TEST_F(MatmulTest, SimpleTestBF16) {
@@ -73,38 +83,30 @@ TEST_F(MatmulTest, SimpleTestBF16) {
   }
 
   const char* matmul_module_str = R"(
-  HloModule matmul.test.bf16, entry_computation_layout={(bf16[2,8,4,16]{3,2,1,0},bf16[2,8,16,32]{3,2,1,0})->bf16[2,8,4,32]{3,2,1,0}}
+  HloModule matmul.test.bf16, entry_computation_layout={(bf16[32,8,128,64]{3,2,1,0},bf16[32,8,64,128]{3,2,1,0})->bf16[32,8,128,128]{3,2,1,0}}
 
   ENTRY matmul.test.bf16 {
-    arg.0 = bf16[2,8,4,16]{3,2,1,0} parameter(0), parameter_replication={false}
-    arg.1 = bf16[2,8,16,32]{3,2,1,0} parameter(1), parameter_replication={false}
-    ROOT onednn.matmul.0 = bf16[2,8,4,32]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+    arg.0 = bf16[32,8,128,64]{3,2,1,0} parameter(0), parameter_replication={false}
+    arg.1 = bf16[32,8,64,128]{3,2,1,0} parameter(1), parameter_replication={false}
+    ROOT onednn.matmul.0 = bf16[32,8,128,128]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
   })";
 
-  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
-  MatchOptimizedHlo(matmul_module_str,
-                    R"(
-  ; CHECK:     custom_call_target="__onednn$matmul",
-  ; CHECK:       backend_config={
-  ; CHECK-DAG:     "outer_dimension_partitions":[],
-  ; CHECK-DAG:     "onednn_matmul_config":{
-  ; CHECK-DAG:       "fused_ops":[]
-  ; CHECK-DAG:   }
-  ; CHECK:     }
-  )");
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, matmul_rewrite_str_);
 }
 
 TEST_F(MatmulTest, SimpleTestF32TransposeB) {
   const char* matmul_module_str = R"(
-  HloModule matmul.test.1, entry_computation_layout={(f32[2,8,4,16]{3,1,2,0},f32[2,8,4,16]{3,1,2,0})->f32[2,8,4,4]{3,2,1,0}}
+  HloModule matmul.test.1, entry_computation_layout={(f32[32,8,128,64]{3,1,2,0},f32[32,8,128,64]{3,1,2,0})->f32[32,8,128,128]{3,2,1,0}}
 
   ENTRY matmul.test.1 {
-    arg.0 = f32[2,8,4,16]{3,1,2,0} parameter(0), parameter_replication={false}
-    arg.1 = f32[2,8,4,16]{3,1,2,0} parameter(1), parameter_replication={false}
-    ROOT onednn.matmul.0 = f32[2,8,4,4]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}
+    arg.0 = f32[32,8,128,64]{3,1,2,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[32,8,128,64]{3,1,2,0} parameter(1), parameter_replication={false}
+    ROOT onednn.matmul.0 = f32[32,8,128,128]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, matmul_rewrite_str_);
 }
 
 TEST_F(MatmulTest, SimpleTestF32WithBiasAddFusion1) {
@@ -271,6 +273,27 @@ TEST_F(MatmulTest, SimpleTestF32TransposeBWithBiasAddFusion) {
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
   MatchOptimizedHlo(matmul_module_str, fused_matmul_binary_add_);
+}
+
+TEST_F(MatmulTest, F32BiasAddFusionNonCompatibleBias) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32, entry_computation_layout={(f32[12288,2]{1,0},f32[2,1024]{1,0})->f32[32,384,1024]{2,1,0}}
+
+  ENTRY matmul.test.1 {
+    arg.0 = f32[12288,2]{1,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[2,1024]{1,0} parameter(1), parameter_replication={false}
+    dot.0 = f32[12288,1024]{1,0} dot(arg.0, arg.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    reshape.0 = f32[32,384,1024]{2,1,0} reshape(dot.0)
+    constant.0 = f32[1,384,1024]{2,1,0} constant(15)
+    reshape.1 = f32[384,1024]{1,0} reshape(constant.0)
+    broadcast.0 = f32[32,384,1024]{2,1,0} broadcast(reshape.1), dimensions={1,2}
+    add.0 = f32[32,384,1024]{2,1,0} add(reshape.0, broadcast.0)
+    tuple.0 = (f32[32,384,1024]{2,1,0}) tuple(add.0)
+    ROOT get-tuple-element.0 = f32[32,384,1024]{2,1,0} get-tuple-element(tuple.0), index=0
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, matmul_rewrite_str_);
 }
 
 TEST_F(MatmulTest, ApproxGELUTestF32) {


### PR DESCRIPTION
This PR fixes a bug in the bias fusion to oneDNN matmul by not allowing fusion when the bias shape is non-compatible. Note that oneDNN matmul has a binary-add operation semantic for bias. This is more general than the usual bias having feature dimension only. While fixing the bug, this PR also does the following:

- Refactors pattern matching of bias fusion
- Adds more documentations in the source code
- Adds more checks for a valid fusion