### PR TITLE
[ROCm] Adding driver APIs for unified stream ordered allocation implementation

### DIFF
--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -925,10 +925,19 @@ class GpuDriver {
       GpuContext* context, GpuFunctionHandle kernel, int threads_per_block,
       size_t dynamic_shared_memory_bytes);
 
+  // Returns the context on the device with ordinal number dev via cuDevicePrimaryCtxRetain.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__PRIMARY__CTX.html#group__CUDA__PRIMARY__CTX_1g9051f2d5c31501997a6cb0530290a300
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___context.html#gab6e1014e9a4dbe281b84e38d89ff2409
   static absl::StatusOr<GpuContextHandle> DevicePrimaryCtxRetain(GpuDeviceHandle dev);
 
+  //Returns the default memory pool on the device (ordinal dev) via cuDeviceGetDefaultMemPool.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__DEVICE.html#group__CUDA__DEVICE_1gc8bca3c97a78816303b8aa5773b741f2
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___device.html#ga16d31ff3398a0c76ea5148563406412a
   static absl::Status DeviceGetDefaultMemPool(GpuContext* context, GpuMemoryPoolHandle* pool_ptr, GpuDeviceHandle dev);
 
+  // The memory pool attribute
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1g5af6ea9ddd7633be98cb7de1bbf1d9f0
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___global_defs.html#ga987c8e7a7e8171832a6647150854ca2e
   enum class  MemPoolAttribute{
 	  kReuseFollowEventDependencies,
 	  kReuseAllowOpportunistic,
@@ -940,20 +949,31 @@ class GpuDriver {
 	  kUsedMemHigh,
   };
 
+  // Returns the attributes of a memory pool via cuMemPoolGetAttribute.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MALLOC__ASYNC.html#group__CUDA__MALLOC__ASYNC_1gd45ea7c43e4a1add4b971d06fa72eda4
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___stream_o.html#
   static absl::Status MemPoolGetAttribute(GpuContext* context, GpuMemoryPoolHandle pool, MemPoolAttribute attr, void* value);
 
+  // Set the attributes of a memory pool via cuMemPoolSetAttribute.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MALLOC__ASYNC.html#group__CUDA__MALLOC__ASYNC_1g223e786cb217709235a06e41bccaec00
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___stream_o.html#ga89006d354ee6e0428a432d6f2e76c8bf
   static absl::Status MemPoolSetAttribute(GpuContext* context, GpuMemoryPoolHandle pool, MemPoolAttribute attr, void* value);
-  
+
+  // Set the control visibility of a pool between devices via cuMemPoolSetAccess
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MALLOC__ASYNC.html#group__CUDA__MALLOC__ASYNC_1gff3ce33e252443f4b087b94e42913406
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___stream_o.html#
   static absl::Status MemPoolSetAccess(GpuContext* context, GpuMemoryPoolHandle pool, const GpuMemAccessDesc& desc, size_t count);
 
   // Allocates a GPU memory space of size bytes associated with the given
   // context via cuMemAllocFromPoolAsync/hipMemAllocFromPoolAsync in stream order.
   // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MALLOC__ASYNC.html#group__CUDA__MALLOC__ASYNC_1gf1dd6e1e2e8f767a5e0ea63f38ff260b
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___stream_o.html#ga24cab3e20805d8df79a06db1bb0d9938
   static void* DeviceAllocateAsync(GpuContext* context, uint64_t bytes, GpuMemoryPoolHandle pool, GpuStreamHandle stream);
 
   // Deallocates a GPU memory space of size bytes allocated in stream order
   // and associated with the given context via cuMemFreeAsync/hipFree.
   // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MALLOC__ASYNC.html#group__CUDA__MALLOC__ASYNC_1g41acf4131f672a2a75cd93d3241f10cf
+  // https://docs.amd.com/projects/HIP/en/docs-5.7.0/.doxygen/docBin/html/group___stream_o.html#ga42543ee2625b87cfd4f6ec29ae11c3d8
   static void DeviceDeallocateAsync(GpuContext* context, void* location, GpuStreamHandle stream);
 
   // Seam for injecting an error at CUDA initialization time for testing

--- a/xla/stream_executor/gpu/gpu_types.h
+++ b/xla/stream_executor/gpu/gpu_types.h
@@ -62,6 +62,9 @@ using GpuGraphHandle = hipGraph_t;
 using GpuGraphExecHandle = hipGraphExec_t;
 using GpuGraphNodeHandle = hipGraphNode_t;
 using GpuGraphConditionalHandle = UnsupportedGpuFeature;
+using GpuMemoryPoolHandle = hipMemPool_t;
+using GpuMemAccessDesc = hipMemAccessDesc;
+using GpuMemPoolAttribute = hipMemPoolAttr;
 #else  // CUDA
 
 using GpuContextHandle = CUcontext;
@@ -82,6 +85,9 @@ using GpuDoubleComplexType = cuDoubleComplex;
 using GpuGraphHandle = CUgraph;
 using GpuGraphExecHandle = CUgraphExec;
 using GpuGraphNodeHandle = CUgraphNode;
+using GpuMemoryPoolHandle = CUmemoryPool;
+using GpuMemAccessDesc = CUmemAccessDesc;
+using GpuMemPoolAttribute = CUmemPool_attribute;
 
 #if CUDA_VERSION >= 12030
 using GpuGraphConditionalHandle = CUgraphConditionalHandle;

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -2123,7 +2123,7 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
 
 /* static */ absl::StatusOr<GpuContextHandle> GpuDriver::DevicePrimaryCtxRetain(GpuDeviceHandle dev){
   hipCtx_t ctx;
-  RETURN_IF_ROCM_ERROR(hipDevicePrimaryCtxRetain(&ctx, dev),
+  RETURN_IF_ROCM_ERROR(wrap::hipDevicePrimaryCtxRetain(&ctx, dev),
                        absl::StrFormat("Failed to retain context"));
   return ctx;
 }
@@ -2132,7 +2132,7 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
                                                   GpuMemoryPoolHandle* pool_ptr,
                                                   GpuDeviceHandle dev){
   ScopedActivateContext activated{context};
-  hipError_t res = hipDeviceGetDefaultMemPool(pool_ptr, dev);
+  hipError_t res = wrap::hipDeviceGetDefaultMemPool(pool_ptr, dev);
   if (res != hipSuccess || pool_ptr == nullptr){
     return absl::InternalError(
         absl::StrFormat("Failed to get default CUDA pool: %s", ToString(res)));
@@ -2146,7 +2146,7 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
                                               void* value){
   ScopedActivateContext activated{context};
   hipMemPoolAttr hip_mem_pool_attr = ToHipMemPoolAttribute(attr);
-  hipError_t res = hipMemPoolGetAttribute(pool, hip_mem_pool_attr, value);
+  hipError_t res = wrap::hipMemPoolGetAttribute(pool, hip_mem_pool_attr, value);
   if (res != hipSuccess){
     return absl::InternalError(
         absl::StrFormat("Failed to get CUDA pool attribute: %s", ToString(res)));
@@ -2164,7 +2164,7 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
 	  (hip_mem_pool_attr == hipMemPoolAttrUsedMemCurrent)){
 	return absl::InternalError("Trying to set unsupported memory pool attribute.");
   }
-  hipError_t res = hipMemPoolSetAttribute(pool, hip_mem_pool_attr, value);
+  hipError_t res = wrap::hipMemPoolSetAttribute(pool, hip_mem_pool_attr, value);
   if (res != hipSuccess){
     return absl::InternalError(
         absl::StrFormat("Failed to set CUDA pool attribute: %s", ToString(res)));
@@ -2177,7 +2177,7 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
                                            const GpuMemAccessDesc& desc,
                                            size_t  count){
   ScopedActivateContext activated{context};
-  hipError_t res = hipMemPoolSetAccess(pool, &desc, count);
+  hipError_t res = wrap::hipMemPoolSetAccess(pool, &desc, count);
   if (res != hipSuccess){
     return absl::InternalError(
         absl::StrFormat("Error when setting access to the pool: location id: %d\n error: %s", desc.location.id, ToString(res)));
@@ -2195,7 +2195,7 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
 
   ScopedActivateContext activated{context};
   hipDeviceptr_t result = 0;
-  hipError_t res = 	hipMallocFromPoolAsync(&result, bytes, pool, stream);
+  hipError_t res = 	wrap::hipMallocFromPoolAsync(&result, bytes, pool, stream);
   if (res != hipSuccess) {
     LOG(INFO) << "failed to allocate "
               << tsl::strings::HumanReadableNumBytes(bytes) << " (" << bytes
@@ -2214,7 +2214,7 @@ static absl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
                                                    hipStream_t stream) {
   ScopedActivateContext activation(context);
   hipDeviceptr_t pointer = absl::bit_cast<hipDeviceptr_t>(location);
-  hipError_t res = hipFreeAsync(pointer, stream);
+  hipError_t res = wrap::hipFreeAsync(pointer, stream);
   if (res != hipSuccess) {
     LOG(ERROR) << "failed to free device memory at " << location
                << "; result: " << ToString(res);


### PR DESCRIPTION
This commit is served as preparation for a later PR which will implement an unified driver interface of stream ordered memory allocation for both CUDA and ROCm. The current implementation `gpu_cudamallocaysnc_allocator.cc ` is platform dependent. This PR pulls out the driver APIs from the source file `gpu_cudamalloasync_allocator.cc`, puts a set of APIs in the class ` GpuDriver`, and add platform dependent implementation in corresponding directories (cuda and rocm) like other driver APIs. 

Another way to implement this is adding preprocessors in `gpu_cudamalloasync_allocator.cc`. May I ask which way is preferred for adding this functionality to ROCm? Your comments are appreciated.
`
