### PR TITLE
The CHECK macros can give warnings or errors on redefinition

### DIFF
--- a/xla/hlo/ir/BUILD
+++ b/xla/hlo/ir/BUILD
@@ -87,6 +87,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/functional:function_ref",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/xla/hlo/ir/hlo_computation.h
+++ b/xla/hlo/ir/hlo_computation.h
@@ -26,6 +26,8 @@ limitations under the License.
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/functional/function_ref.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"


### PR DESCRIPTION
These macros can be defined in more than one external project leading to warnings or errors as there is no guard against redefinition in abseil. So ensure that the abseil defines come first to prevent such issues.