### PR TITLE
[ROCm] Fixed head file in rocm_collectives

### DIFF
--- a/xla/service/gpu/tests/hlo_to_llvm_ir.cc
+++ b/xla/service/gpu/tests/hlo_to_llvm_ir.cc
@@ -110,7 +110,7 @@ absl::Status CompileAndPrintLlvmIr(const std::string& hlo_text,
                                       hlo_module->config().debug_options()));
     std::cout << ptx << std::endl;
 #elif TENSORFLOW_USE_ROCM
-    return absl::kUnimplementedError("Feature not yet implemented in ROCm"
+    return absl::kUnimplementedError("Feature not yet implemented in ROCm");
   };
 #endif
   }

--- a/xla/service/gpu/tests/hlo_to_llvm_ir.cc
+++ b/xla/service/gpu/tests/hlo_to_llvm_ir.cc
@@ -110,10 +110,9 @@ absl::Status CompileAndPrintLlvmIr(const std::string& hlo_text,
                                       hlo_module->config().debug_options()));
     std::cout << ptx << std::endl;
 #elif TENSORFLOW_USE_ROCM
-    return absl::kUnimplementedError("Feature not yet implemented in ROCm");
-  };
-#endif
-  }
+    return absl::UnimplementedError("Feature not yet implemented in ROCm");
+#endif  
+  } 
 #endif
   return absl::OkStatus();
 }

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -16,7 +16,7 @@ load(
     "if_rocm_is_configured",
     "rocm_library",
 )
-load("@tsl//tsl:tsl.bzl", "set_external_visibility", "tsl_copts")
+load("@tsl//tsl:tsl.bzl", "set_external_visibility", "if_nccl", "tsl_copts")
 load("@tsl//tsl/platform:build_config_root.bzl", "if_static")
 load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
 
@@ -100,6 +100,7 @@ cc_library(
     deps = if_rocm_is_configured([
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "//xla/stream_executor/gpu:gpu_collectives_header",
         "//xla/stream_executor/gpu:gpu_driver_header",
     ]),
 )

--- a/xla/stream_executor/rocm/rocm_collectives.cc
+++ b/xla/stream_executor/rocm/rocm_collectives.cc
@@ -18,6 +18,8 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "xla/stream_executor/gpu/gpu_driver.h"
+#include "xla/stream_executor/gpu/gpu_collectives.h"
+
 
 namespace stream_executor::gpu {
 

--- a/xla/stream_executor/rocm/rocm_driver.h
+++ b/xla/stream_executor/rocm/rocm_driver.h
@@ -29,42 +29,7 @@ namespace stream_executor {
 namespace gpu {
 // Formats hipError_t to output prettified values into a log stream.
 // Error summaries taken from:
-string ToString(hipError_t result) {
-#define OSTREAM_ROCM_ERROR(__name) \
-  case hipError##__name:           \
-    return "HIP_ERROR_" #__name;
-
-  switch (result) {
-    OSTREAM_ROCM_ERROR(InvalidValue)
-    OSTREAM_ROCM_ERROR(OutOfMemory)
-    OSTREAM_ROCM_ERROR(NotInitialized)
-    OSTREAM_ROCM_ERROR(Deinitialized)
-    OSTREAM_ROCM_ERROR(NoDevice)
-    OSTREAM_ROCM_ERROR(InvalidDevice)
-    OSTREAM_ROCM_ERROR(InvalidImage)
-    OSTREAM_ROCM_ERROR(InvalidContext)
-    OSTREAM_ROCM_ERROR(InvalidHandle)
-    OSTREAM_ROCM_ERROR(NotFound)
-    OSTREAM_ROCM_ERROR(NotReady)
-    OSTREAM_ROCM_ERROR(NoBinaryForGpu)
-
-    // Encountered an uncorrectable ECC error during execution.
-    OSTREAM_ROCM_ERROR(ECCNotCorrectable)
-
-    // Load/store on an invalid address. Must reboot all context.
-    case 700:
-      return "ROCM_ERROR_ILLEGAL_ADDRESS";
-    // Passed too many / wrong arguments, too many threads for register count.
-    case 701:
-      return "ROCM_ERROR_LAUNCH_OUT_OF_RESOURCES";
-
-      OSTREAM_ROCM_ERROR(ContextAlreadyInUse)
-      OSTREAM_ROCM_ERROR(PeerAccessUnsupported)
-      OSTREAM_ROCM_ERROR(Unknown)  // Unknown internal error to ROCM.
-    default:
-      return absl::StrCat("hipError_t(", static_cast<int>(result), ")");
-  }
-}
+string ToString(hipError_t result);
 
 // GpuContext wraps the device_ordinal and hipCtx_t handle.
 class GpuContext {

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_diagnostics.h"
 #include "xla/stream_executor/rocm/rocm_driver.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
+#include "xla/stream_executor/gpu/gpu_collectives.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/stream_executor/stream_executor_internal.h"


### PR DESCRIPTION
This has fixed the build errors at ROCm side due to https://github.com/openxla/xla/commit/1814dfb29b59f7a48f86e1484999020e9bcd0699#diff-32820be91248a95c0249fe50be1ea8a696ec80ca9092aa11265f967362cff0b4R113

and issues on rocm_collectives.



@xla-rotation