### PR TITLE
[XLA:CPU] oneDNN MatMul constant weights pre-packing

### DIFF
--- a/xla/pjrt/cpu/cpu_client.cc
+++ b/xla/pjrt/cpu/cpu_client.cc
@@ -645,7 +645,8 @@ static StatusOr<std::unique_ptr<xla::Executable>> JitCompile(
     const XlaComputation& computation,
     const absl::Span<const Shape* const> argument_layouts,
     const ExecutableBuildOptions& build_options,
-    const ExecutionOptions& execution_options) {
+    const ExecutionOptions& execution_options,
+    const xla::Compiler::CompileOptions& compile_options) {
   TF_ASSIGN_OR_RETURN(ProgramShape program_shape,
                       computation.GetProgramShape());
   // Unoptimized HloModuleConfig.
@@ -669,14 +670,14 @@ static StatusOr<std::unique_ptr<xla::Executable>> JitCompile(
   bool allow_sparse_shapes =
       hlo_module->config().debug_options().xla_cpu_use_xla_runtime();
   cpu::CpuCompiler compiler(allow_sparse_shapes);
-  xla::Compiler::CompileOptions dummy;
   TF_ASSIGN_OR_RETURN(hlo_module,
                       compiler.RunHloPasses(std::move(hlo_module),
-                                            /*stream_exec=*/nullptr, dummy));
+                                            /*stream_exec=*/nullptr,
+                                            compile_options));
 
   // Run backend.
   return compiler.RunBackend(std::move(hlo_module), /*stream_exec=*/nullptr,
-                             dummy);
+                             compile_options);
 }
 
 StatusOr<std::unique_ptr<PjRtLoadedExecutable>> TfrtCpuClient::Compile(
@@ -758,9 +759,14 @@ StatusOr<std::unique_ptr<PjRtLoadedExecutable>> TfrtCpuClient::Compile(
                       computation.GetProgramShape());
   ExecutionOptions execution_options =
       CreateExecutionOptions(build_options, &program_shape);
+  xla::Compiler::CompileOptions compile_options{
+            build_options.device_allocator(),
+            build_options.compile_thread_pool(),
+            build_options.layout_canonicalization_callback()};
   TF_ASSIGN_OR_RETURN(std::unique_ptr<Executable> cpu_executable,
                       JitCompile(computation, argument_layout_pointers,
-                                 build_options, execution_options));
+                                 build_options, execution_options,
+                                 compile_options));
   auto cpu_executable_ptr =
       tensorflow::down_cast<cpu::CpuExecutable*>(cpu_executable.get());
 

--- a/xla/pjrt/cpu/cpu_client.cc
+++ b/xla/pjrt/cpu/cpu_client.cc
@@ -670,10 +670,9 @@ static StatusOr<std::unique_ptr<xla::Executable>> JitCompile(
   bool allow_sparse_shapes =
       hlo_module->config().debug_options().xla_cpu_use_xla_runtime();
   cpu::CpuCompiler compiler(allow_sparse_shapes);
-  TF_ASSIGN_OR_RETURN(hlo_module,
-                      compiler.RunHloPasses(std::move(hlo_module),
-                                            /*stream_exec=*/nullptr,
-                                            compile_options));
+  TF_ASSIGN_OR_RETURN(hlo_module, compiler.RunHloPasses(std::move(hlo_module),
+                                                        /*stream_exec=*/nullptr,
+                                                        compile_options));
 
   // Run backend.
   return compiler.RunBackend(std::move(hlo_module), /*stream_exec=*/nullptr,
@@ -760,13 +759,12 @@ StatusOr<std::unique_ptr<PjRtLoadedExecutable>> TfrtCpuClient::Compile(
   ExecutionOptions execution_options =
       CreateExecutionOptions(build_options, &program_shape);
   xla::Compiler::CompileOptions compile_options{
-            build_options.device_allocator(),
-            build_options.compile_thread_pool(),
-            build_options.layout_canonicalization_callback()};
-  TF_ASSIGN_OR_RETURN(std::unique_ptr<Executable> cpu_executable,
-                      JitCompile(computation, argument_layout_pointers,
-                                 build_options, execution_options,
-                                 compile_options));
+      build_options.device_allocator(), build_options.compile_thread_pool(),
+      build_options.layout_canonicalization_callback()};
+  TF_ASSIGN_OR_RETURN(
+      std::unique_ptr<Executable> cpu_executable,
+      JitCompile(computation, argument_layout_pointers, build_options,
+                 execution_options, compile_options));
   auto cpu_executable_ptr =
       tensorflow::down_cast<cpu::CpuExecutable*>(cpu_executable.get());
 

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1675,6 +1675,7 @@ cc_library(
     deps = [
         ":backend_config_proto_cc",
         ":onednn_memory_util",
+        ":onednn_matmul",
         "//xla:status_macros",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1572,6 +1572,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":runtime_lightweight_check",
+        "//xla:literal",
         "//xla:shape_util",
         "//xla:status_macros",
         "//xla:statusor",
@@ -1670,14 +1671,18 @@ cc_library(
     hdrs = [
         "onednn_matmul_rewriter.h",
         "onednn_util.h",
+        "onednn_matmul.h",
+        "@tsl//tsl/util:onednn_util_hdrs",
     ],
     copts = tsl_copts(),
     deps = [
         ":backend_config_proto_cc",
         ":onednn_memory_util",
         ":onednn_matmul",
+        "//xla:executable_run_options",
         "//xla:status_macros",
         "//xla:xla_data_proto_cc",
+        "//xla/hlo/evaluator:hlo_evaluator",
         "//xla/hlo/ir:hlo",
         "//xla/service:hlo_creation_utils",
         "//xla/service:hlo_pass",

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -600,8 +600,7 @@ void AddHloVerifier(HloPassPipeline* pipeline, bool allow_sparse_shapes,
 
 Status CpuCompiler::RunHloPassesThroughLayoutAssn(
     HloModule* module, bool is_aot_compile,
-    LLVMTargetMachineFeatures* target_machine_features,
-    const CompileOptions& compile_options, bool is_mlir_compile) {
+    LLVMTargetMachineFeatures* target_machine_features, bool is_mlir_compile) {
   const int64_t num_partitions = module->config().num_partitions();
   if (num_partitions > 1) {
     if (!module->config().use_spmd_partitioning()) {
@@ -961,8 +960,7 @@ Status CpuCompiler::RunHloPasses(HloModule* module, bool is_aot_compile,
                                  bool is_mlir_compile) {
   LLVMTargetMachineFeatures target_machine_features(target_machine);
   TF_RETURN_IF_ERROR(RunHloPassesThroughLayoutAssn(
-      module, is_aot_compile, &target_machine_features, compile_options,
-      is_mlir_compile));
+      module, is_aot_compile, &target_machine_features, is_mlir_compile));
 
   return RunHloPassesAfterLayoutAssn(module, is_aot_compile,
                                      &target_machine_features, compile_options,

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -901,11 +901,10 @@ Status CpuCompiler::RunHloPassesAfterLayoutAssn(
           compile_options.thread_pool->NumThreads()));
     } else {
       eigen_intraop_pool.reset(new tsl::thread::ThreadPool(
-          tsl::Env::Default(), "XLACpuCompile",
-          tsl::port::MaxParallelism()));
-      threadpool_device.reset(new Eigen::ThreadPoolDevice(
-          eigen_intraop_pool->AsEigenThreadPool(),
-          eigen_intraop_pool->NumThreads()));
+          tsl::Env::Default(), "XLACpuCompile", tsl::port::MaxParallelism()));
+      threadpool_device.reset(
+          new Eigen::ThreadPoolDevice(eigen_intraop_pool->AsEigenThreadPool(),
+                                      eigen_intraop_pool->NumThreads()));
     }
 
     pipeline.AddPass<OneDnnMatMulRewriter>(threadpool_device.get());
@@ -975,12 +974,12 @@ Status CpuCompiler::RunHloPasses(HloModule* module, bool is_aot_compile,
                                  bool is_mlir_compile) {
   LLVMTargetMachineFeatures target_machine_features(target_machine);
   TF_RETURN_IF_ERROR(RunHloPassesThroughLayoutAssn(
-      module, is_aot_compile, &target_machine_features,
-      compile_options, is_mlir_compile));
+      module, is_aot_compile, &target_machine_features, compile_options,
+      is_mlir_compile));
 
   return RunHloPassesAfterLayoutAssn(module, is_aot_compile,
-                                     &target_machine_features,
-                                     compile_options, is_mlir_compile);
+                                     &target_machine_features, compile_options,
+                                     is_mlir_compile);
 }
 
 namespace {
@@ -1103,7 +1102,7 @@ StatusOr<std::unique_ptr<HloModule>> CpuCompiler::RunHloPasses(
 
   TF_RETURN_IF_ERROR(RunHloPasses(
       module.get(), /*is_aot_compile=*/false, jit_target_machine.get(),
-      /*compile_options=*/ options,
+      /*compile_options=*/options,
       /*is_mlir_compile=*/
       module->config().debug_options().xla_cpu_use_xla_runtime()));
   return std::move(module);

--- a/xla/service/cpu/cpu_compiler.h
+++ b/xla/service/cpu/cpu_compiler.h
@@ -194,8 +194,7 @@ class CpuCompiler : public LLVMCompiler {
   Status RunHloPassesThroughLayoutAssn(
       HloModule* module, bool /*is_aot_compile*/,
       LLVMTargetMachineFeatures* target_machine_features,
-      const CompileOptions& compile_options,
-      bool is_mlir_compile = false);
+      const CompileOptions& compile_options, bool is_mlir_compile = false);
 
   // Runs HLO passes after layout assignment.
   Status RunHloPassesAfterLayoutAssn(

--- a/xla/service/cpu/cpu_compiler.h
+++ b/xla/service/cpu/cpu_compiler.h
@@ -194,7 +194,7 @@ class CpuCompiler : public LLVMCompiler {
   Status RunHloPassesThroughLayoutAssn(
       HloModule* module, bool /*is_aot_compile*/,
       LLVMTargetMachineFeatures* target_machine_features,
-      const CompileOptions& compile_options, bool is_mlir_compile = false);
+      bool is_mlir_compile = false);
 
   // Runs HLO passes after layout assignment.
   Status RunHloPassesAfterLayoutAssn(

--- a/xla/service/cpu/cpu_compiler.h
+++ b/xla/service/cpu/cpu_compiler.h
@@ -187,18 +187,21 @@ class CpuCompiler : public LLVMCompiler {
   // correctness.
   Status RunHloPasses(HloModule* module, bool is_aot_compile,
                       llvm::TargetMachine* target_machine,
+                      const CompileOptions& compile_options,
                       bool is_mlir_compile = false);
 
   // Runs HLO passes up to and including layout assignment.
   Status RunHloPassesThroughLayoutAssn(
       HloModule* module, bool /*is_aot_compile*/,
       LLVMTargetMachineFeatures* target_machine_features,
+      const CompileOptions& compile_options,
       bool is_mlir_compile = false);
 
   // Runs HLO passes after layout assignment.
   Status RunHloPassesAfterLayoutAssn(
       HloModule* module, bool is_aot_compile,
-      LLVMTargetMachineFeatures* target_machine_features, bool is_mlir_compile);
+      LLVMTargetMachineFeatures* target_machine_features,
+      const CompileOptions& compile_options, bool is_mlir_compile);
 
   StatusOr<std::unique_ptr<CpuExecutable>> CompileLegacyCpuExecutable(
       std::unique_ptr<HloModule> module);

--- a/xla/service/cpu/cpu_runtime.cc
+++ b/xla/service/cpu/cpu_runtime.cc
@@ -164,6 +164,8 @@ extern const char* const kOneDnnSoftmaxSymbolName =
     "__xla_cpu_runtime_OneDnnSoftmax";
 extern const char* const kOneDnnLayerNormSymbolName =
     "__xla_cpu_runtime_OneDnnLayerNorm";
+extern const char* const kOneDnnMatMulReorderSymbolName =
+    "__xla_cpu_runtime_OneDnnMatMulReorder";
 
 namespace {
 

--- a/xla/service/cpu/cpu_runtime.h
+++ b/xla/service/cpu/cpu_runtime.h
@@ -89,6 +89,7 @@ extern const char* const kReduceScatterSymbolName;
 extern const char* const kOneDnnMatMulSymbolName;
 extern const char* const kOneDnnSoftmaxSymbolName;
 extern const char* const kOneDnnLayerNormSymbolName;
+extern const char* const kOneDnnMatMulReorderSymbolName;
 
 // All symbol names for XLA CPU runtime functions need to start with this
 // prefix.

--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -2706,6 +2706,96 @@ Status IrEmitter::HandleOneDnnSoftmax(HloInstruction* custom_call) {
   return OkStatus();
 }
 
+Status IrEmitter::HandleOneDnnMatMulReorder(HloInstruction* custom_call) {
+  // We would like to emit LLVM IR for the following function call
+  //      custom_call_target(void* result, void** args)
+  // args can be thought of an array of pointers allocated on the stack,
+  // i.e., alloca [nargs x ptr], as such
+  //      args[0]: ptr to nargs
+  //      args[1]: ptr to ExecutableRunOptions
+  //      args[2]: ptr to OneDnnMatMulConfig
+  //      args[3...]: ptrs to operands
+  //  This allows us to pass variable number of operands to the
+  //  custom_call_target function.
+  //
+  //  Currently, we assume that neither operands nor results are packed into
+  //  tuple(s).
+
+  // First three arguments: nargs, ExecutableRunOptions, and
+  // OneDnnMatMulConfig.
+  const int nargs_offset = 3;
+  const int num_operands = custom_call->operand_count();
+  const int nargs = nargs_offset + num_operands;
+  int arg_indx = 0;
+
+  llvm::Type* i64_type = b_.getInt64Ty();
+  llvm::Type* ptr_type = b_.getPtrTy();
+  llvm::ArrayType* ptr_array_type = llvm::ArrayType::get(ptr_type, nargs);
+  llvm::Value* args_val = llvm::UndefValue::get(ptr_array_type);
+
+  // Insert nargs.
+  llvm::Value* nargs_val = b_.getInt64(nargs);
+  llvm::Value* nargs_ptr =
+      llvm_ir::EmitAllocaAtFunctionEntry(i64_type, "nargs", &b_);
+  llvm::Value* nargs_life_start =
+      b_.CreateLifetimeStart(nargs_ptr, b_.getInt64(-1));
+  llvm::Value* nargs_store = b_.CreateStore(nargs_val, nargs_ptr);
+  args_val = b_.CreateInsertValue(args_val, nargs_ptr, arg_indx++);
+
+  // Insert ExecutableRunOptions.
+  llvm::Value* run_opts_val = GetExecutableRunOptionsArgument();
+  args_val = b_.CreateInsertValue(args_val, run_opts_val, arg_indx++);
+
+  // Insert OneDnnMatMulConfig.
+  auto typed_custom_call = Cast<HloCustomCallInstruction>(custom_call);
+  auto backend_config = typed_custom_call->backend_config<BackendConfig>();
+  OneDnnMatMulConfig matmul_config;
+  matmul_config.CopyFrom(backend_config->onednn_matmul_config());
+  std::string str_config;
+  matmul_config.SerializeToString(&str_config);
+  llvm::Value* matmul_config_val =
+      b_.CreateGlobalStringPtr(llvm_ir::AsStringRef(str_config));
+  args_val = b_.CreateInsertValue(args_val, matmul_config_val, arg_indx++);
+
+  // Insert operands.
+  std::vector<StackAlloca> operands_stack_alloca;
+  operands_stack_alloca.reserve(num_operands);
+  absl::c_transform(custom_call->operands(), operands_stack_alloca.begin(),
+                    [this](HloInstruction* instr) {
+                      llvm_ir::IrArray ir_array(GetIrArrayFor(instr));
+                      return GetAllocaAndEmitMemrefInfo(b_, ir_array);
+                    });
+  for (int i = 0; i < num_operands; ++i) {
+    args_val = b_.CreateInsertValue(args_val, operands_stack_alloca[i].value,
+                                    arg_indx++);
+  }
+  TF_RET_CHECK(nargs == arg_indx)
+      << "Number of arguments don't equal the last argument index.";
+
+  llvm::Value* args_ptr =
+      llvm_ir::EmitAllocaAtFunctionEntry(ptr_array_type, "matmul.args", &b_);
+  llvm::Value* args_life_start =
+      b_.CreateLifetimeStart(args_ptr, b_.getInt64(-1));
+  llvm::Value* args_store = b_.CreateStore(args_val, args_ptr);
+
+  TF_RETURN_IF_ERROR(EmitTargetAddressForOp(custom_call));
+  llvm_ir::IrArray result_array = GetIrArrayFor(custom_call);
+  auto result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
+
+  EmitCallToFunc(runtime::kOneDnnMatMulReorderSymbolName,
+                 {result_stack_alloca.value, args_ptr}, b_.getVoidTy());
+
+  // Lifetime ends for all stack allocations.
+  b_.CreateLifetimeEnd(nargs_ptr, b_.getInt64(-1));
+  for (int i = 0; i < num_operands; ++i) {
+    operands_stack_alloca[i].EmitLifetimeEnd();
+  }
+  b_.CreateLifetimeEnd(args_ptr, b_.getInt64(-1));
+  result_stack_alloca.EmitLifetimeEnd();
+
+  return OkStatus();
+}
+
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 
 Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
@@ -2727,6 +2817,9 @@ Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
   }
   if (custom_call->custom_call_target() == "__onednn$layernorm") {
     return HandleOneDnnLayerNorm(custom_call);
+  }
+  if (custom_call->custom_call_target() == "__onednn$matmul_reorder") {
+    return HandleOneDnnMatMulReorder(custom_call);
   }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   absl::Span<HloInstruction* const> operands(custom_call->operands());

--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -2517,7 +2517,8 @@ Status IrEmitter::HandleTopK(HloInstruction* hlo) {
 }
 
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
-Status IrEmitter::HandleOneDnnMatMul(HloInstruction* custom_call) {
+Status IrEmitter::HandleOneDnnMatMulCalls(HloInstruction* custom_call,
+                                          std::string runtime_symbol_name) {
   // We would like to emit LLVM IR for the following function call
   //      custom_call_target(void* result, void** args)
   // args can be thought of an array of pointers allocated on the stack,
@@ -2592,7 +2593,7 @@ Status IrEmitter::HandleOneDnnMatMul(HloInstruction* custom_call) {
   llvm_ir::IrArray result_array = GetIrArrayFor(custom_call);
   auto result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
 
-  EmitCallToFunc(runtime::kOneDnnMatMulSymbolName,
+  EmitCallToFunc(std::move(runtime_symbol_name),
                  {result_stack_alloca.value, args_ptr}, b_.getVoidTy());
 
   // Lifetime ends for all stack allocations.
@@ -2705,97 +2706,6 @@ Status IrEmitter::HandleOneDnnSoftmax(HloInstruction* custom_call) {
 
   return OkStatus();
 }
-
-Status IrEmitter::HandleOneDnnMatMulReorder(HloInstruction* custom_call) {
-  // We would like to emit LLVM IR for the following function call
-  //      custom_call_target(void* result, void** args)
-  // args can be thought of an array of pointers allocated on the stack,
-  // i.e., alloca [nargs x ptr], as such
-  //      args[0]: ptr to nargs
-  //      args[1]: ptr to ExecutableRunOptions
-  //      args[2]: ptr to OneDnnMatMulConfig
-  //      args[3...]: ptrs to operands
-  //  This allows us to pass variable number of operands to the
-  //  custom_call_target function.
-  //
-  //  Currently, we assume that neither operands nor results are packed into
-  //  tuple(s).
-
-  // First three arguments: nargs, ExecutableRunOptions, and
-  // OneDnnMatMulConfig.
-  const int nargs_offset = 3;
-  const int num_operands = custom_call->operand_count();
-  const int nargs = nargs_offset + num_operands;
-  int arg_indx = 0;
-
-  llvm::Type* i64_type = b_.getInt64Ty();
-  llvm::Type* ptr_type = b_.getPtrTy();
-  llvm::ArrayType* ptr_array_type = llvm::ArrayType::get(ptr_type, nargs);
-  llvm::Value* args_val = llvm::UndefValue::get(ptr_array_type);
-
-  // Insert nargs.
-  llvm::Value* nargs_val = b_.getInt64(nargs);
-  llvm::Value* nargs_ptr =
-      llvm_ir::EmitAllocaAtFunctionEntry(i64_type, "nargs", &b_);
-  llvm::Value* nargs_life_start =
-      b_.CreateLifetimeStart(nargs_ptr, b_.getInt64(-1));
-  llvm::Value* nargs_store = b_.CreateStore(nargs_val, nargs_ptr);
-  args_val = b_.CreateInsertValue(args_val, nargs_ptr, arg_indx++);
-
-  // Insert ExecutableRunOptions.
-  llvm::Value* run_opts_val = GetExecutableRunOptionsArgument();
-  args_val = b_.CreateInsertValue(args_val, run_opts_val, arg_indx++);
-
-  // Insert OneDnnMatMulConfig.
-  auto typed_custom_call = Cast<HloCustomCallInstruction>(custom_call);
-  auto backend_config = typed_custom_call->backend_config<BackendConfig>();
-  OneDnnMatMulConfig matmul_config;
-  matmul_config.CopyFrom(backend_config->onednn_matmul_config());
-  std::string str_config;
-  matmul_config.SerializeToString(&str_config);
-  llvm::Value* matmul_config_val =
-      b_.CreateGlobalStringPtr(llvm_ir::AsStringRef(str_config));
-  args_val = b_.CreateInsertValue(args_val, matmul_config_val, arg_indx++);
-
-  // Insert operands.
-  std::vector<StackAlloca> operands_stack_alloca;
-  operands_stack_alloca.reserve(num_operands);
-  absl::c_transform(custom_call->operands(), operands_stack_alloca.begin(),
-                    [this](HloInstruction* instr) {
-                      llvm_ir::IrArray ir_array(GetIrArrayFor(instr));
-                      return GetAllocaAndEmitMemrefInfo(b_, ir_array);
-                    });
-  for (int i = 0; i < num_operands; ++i) {
-    args_val = b_.CreateInsertValue(args_val, operands_stack_alloca[i].value,
-                                    arg_indx++);
-  }
-  TF_RET_CHECK(nargs == arg_indx)
-      << "Number of arguments don't equal the last argument index.";
-
-  llvm::Value* args_ptr =
-      llvm_ir::EmitAllocaAtFunctionEntry(ptr_array_type, "matmul.args", &b_);
-  llvm::Value* args_life_start =
-      b_.CreateLifetimeStart(args_ptr, b_.getInt64(-1));
-  llvm::Value* args_store = b_.CreateStore(args_val, args_ptr);
-
-  TF_RETURN_IF_ERROR(EmitTargetAddressForOp(custom_call));
-  llvm_ir::IrArray result_array = GetIrArrayFor(custom_call);
-  auto result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
-
-  EmitCallToFunc(runtime::kOneDnnMatMulReorderSymbolName,
-                 {result_stack_alloca.value, args_ptr}, b_.getVoidTy());
-
-  // Lifetime ends for all stack allocations.
-  b_.CreateLifetimeEnd(nargs_ptr, b_.getInt64(-1));
-  for (int i = 0; i < num_operands; ++i) {
-    operands_stack_alloca[i].EmitLifetimeEnd();
-  }
-  b_.CreateLifetimeEnd(args_ptr, b_.getInt64(-1));
-  result_stack_alloca.EmitLifetimeEnd();
-
-  return OkStatus();
-}
-
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 
 Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
@@ -2810,7 +2720,8 @@ Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
   }
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
   if (custom_call->custom_call_target() == "__onednn$matmul") {
-    return HandleOneDnnMatMul(custom_call);
+    return HandleOneDnnMatMulCalls(custom_call,
+                                   runtime::kOneDnnMatMulSymbolName);
   }
   if (custom_call->custom_call_target() == "__onednn$softmax") {
     return HandleOneDnnSoftmax(custom_call);
@@ -2819,7 +2730,8 @@ Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
     return HandleOneDnnLayerNorm(custom_call);
   }
   if (custom_call->custom_call_target() == "__onednn$matmul_reorder") {
-    return HandleOneDnnMatMulReorder(custom_call);
+    return HandleOneDnnMatMulCalls(custom_call,
+                                   runtime::kOneDnnMatMulReorderSymbolName);
   }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   absl::Span<HloInstruction* const> operands(custom_call->operands());

--- a/xla/service/cpu/ir_emitter.h
+++ b/xla/service/cpu/ir_emitter.h
@@ -195,10 +195,10 @@ class IrEmitter : public DfsHloVisitorWithDefault,
   Status HandleAllReduceSingleReplica(HloInstruction* crs);
   Status HandleAllReduceMultipleReplica(HloInstruction* crs);
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
-  Status HandleOneDnnMatMul(HloInstruction* hlo);
+  Status HandleOneDnnMatMulCalls(HloInstruction* hlo,
+                                 std::string runtime_symbol_name);
   Status HandleOneDnnSoftmax(HloInstruction* hlo);
   Status HandleOneDnnLayerNorm(HloInstruction* hlo);
-  Status HandleOneDnnMatMulReorder(HloInstruction* hlo);
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   // Private helper to initialize an IR function for the computation.
   void InitializeIrFunction(const std::string& function_name);

--- a/xla/service/cpu/ir_emitter.h
+++ b/xla/service/cpu/ir_emitter.h
@@ -198,6 +198,7 @@ class IrEmitter : public DfsHloVisitorWithDefault,
   Status HandleOneDnnMatMul(HloInstruction* hlo);
   Status HandleOneDnnSoftmax(HloInstruction* hlo);
   Status HandleOneDnnLayerNorm(HloInstruction* hlo);
+  Status HandleOneDnnMatMulReorder(HloInstruction* hlo);
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   // Private helper to initialize an IR function for the computation.
   void InitializeIrFunction(const std::string& function_name);

--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -33,6 +33,8 @@ limitations under the License.
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_memory_util.h"
 #include "xla/service/cpu/runtime_lightweight_check.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
 #include "tsl/platform/logging.h"
 #include "tsl/util/onednn_threadpool.h"
 
@@ -43,7 +45,112 @@ using dnnl::engine;
 using dnnl::matmul;
 using dnnl::memory;
 using dnnl::stream;
+
+dnnl::memory::desc Transpose(const dnnl::memory::desc& md) {
+  int64_t ndims = md.get_ndims();
+  // Do not transpose 1D
+  if (ndims == 1) {
+    return md;
+  }
+
+  std::vector<int> permutation(ndims);
+  std::iota(permutation.begin(), permutation.end(), 0);
+  std::swap(permutation[ndims - 1], permutation[ndims - 2]);
+  return md.permute_axes(permutation);
+}
+
+dnnl::memory::desc ShapeToMemDesc(const Shape& shape, bool transpose = false) {
+  auto dimensions = shape.dimensions();
+  if (dimensions.size() == 0) {
+    return dnnl::memory::desc{};
+  }
+
+  auto dims = dnnl::memory::dims(dimensions.begin(), dimensions.end());
+
+  dnnl::memory::dims strides(dims.size());
+  dnnl::memory::dim stride = 1;
+  for (auto i : shape.layout().minor_to_major()) {
+    strides.at(i) = stride;
+    stride *= dims.at(i);
+  }
+
+  auto dt = ToOneDnnDataType(static_cast<PrimitiveType>(shape.element_type()));
+
+  return transpose
+        ? Transpose(dnnl::memory::desc(dims, dt, strides))
+        : dnnl::memory::desc(dims, dt, strides);
+}
+
+dnnl::memory::desc
+OneDnnMatMulOptWeightsDesc(const dnnl::engine& engine,
+                           const dnnl::memory::desc& input_md,
+                           const dnnl::memory::desc& weights_md,
+                           const dnnl::memory::desc& bias_md,
+                           const dnnl::memory::desc& output_md) {
+  auto weights_any_md = memory::desc(weights_md.get_dims(),
+                                     weights_md.get_data_type(),
+                                     dnnl::memory::format_tag::any);
+
+  auto matmul_pd = matmul::primitive_desc(engine, input_md, weights_any_md,
+                                          bias_md, output_md);
+
+  return matmul_pd.weights_desc();
+}
+
+dnnl::memory::desc
+OneDnnMatMulOptWeightsDesc(const dnnl::engine& engine,
+                           const Shape& input_shape,
+                           const Shape& weights_shape,
+                           const Shape& bias_shape,
+                           const Shape& output_shape,
+                           const OneDnnMatMulConfig* matmul_config) {
+  auto input_md   = ShapeToMemDesc(input_shape, matmul_config->transpose_a());
+  auto weights_md = ShapeToMemDesc(weights_shape, matmul_config->transpose_b());
+  auto bias_md    = absl::c_count(matmul_config->fused_ops(),
+                          OneDnnMatMulConfig::BIAS) > 0
+                    ? ShapeToMemDesc(bias_shape)
+                    : dnnl::memory::desc{};
+  auto output_md  = ShapeToMemDesc(output_shape);
+
+  // extend bias rank to match result rank
+  auto missed_rank = output_md.get_ndims() - bias_md.get_ndims();
+  XLA_LIGHTWEIGHT_CHECK(missed_rank >= 0);
+  if( !bias_md.is_zero() && missed_rank > 0 ) {
+    auto bias_dims = bias_md.get_dims();
+    bias_dims.insert(bias_dims.begin(), missed_rank, 1);
+    bias_md = bias_md.reshape(bias_dims);
+  }
+
+  return OneDnnMatMulOptWeightsDesc(engine,
+                                    input_md, weights_md,
+                                    bias_md, output_md);
+}
+
+Shape MemDescToXlaShape(const dnnl::memory::desc& md) {
+  auto dtype = md.get_data_type();
+  auto element_size = dnnl::memory::data_type_size(dtype);
+  int64_t bytes_num = md.get_size();
+  XLA_LIGHTWEIGHT_CHECK(bytes_num % element_size == 0);
+  int64_t elements_num = static_cast<int64_t>(bytes_num / element_size);
+  return ShapeUtil::MakeShape(ToXlaPrimitiveType(dtype), {elements_num});
+}
+
 }  // namespace
+
+Shape OneDnnMatMulOptWeightsShape(const Shape& input_shape,
+                                  const Shape& weights_shape,
+                                  const Shape& bias_shape,
+                                  const Shape& output_shape,
+                                  const OneDnnMatMulConfig* matmul_config) {
+  engine cpu_engine(engine::kind::cpu, 0);
+  auto optimized_weights_md = OneDnnMatMulOptWeightsDesc(cpu_engine,
+                                                         input_shape,
+                                                         weights_shape,
+                                                         bias_shape,
+                                                         output_shape,
+                                                         matmul_config);
+  return MemDescToXlaShape(optimized_weights_md);
+}
 
 ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
     void* result, void** args) {
@@ -82,26 +189,14 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
   auto result_md = result_minfo.GetOneDnnMemDesc();
 
   // Update dims and strides for transposed inputs.
-  bool transpose_a = matmul_config.transpose_a();
-  if (transpose_a) {
-    int64_t ndims = lhs_md.get_ndims();
-    std::vector<int> permutation(ndims);
-    std::iota(permutation.begin(), permutation.end(), 0);
-    std::swap(permutation[ndims - 1], permutation[ndims - 2]);
-    lhs_md = lhs_md.permute_axes(permutation);
+  if (matmul_config.transpose_a()) {
+    lhs_md = Transpose(lhs_md);
   }
-  bool transpose_b = matmul_config.transpose_b();
-  if (transpose_b) {
-    int64_t ndims = rhs_md.get_ndims();
-    std::vector<int> permutation(ndims);
-    std::iota(permutation.begin(), permutation.end(), 0);
-    std::swap(permutation[ndims - 1], permutation[ndims - 2]);
-    rhs_md = rhs_md.permute_axes(permutation);
+
+  if (matmul_config.transpose_b()) {
+    rhs_md = Transpose(rhs_md);
   }
-  auto lhs_mem = memory(lhs_md, cpu_engine, lhs_minfo.Data());
-  auto rhs_mem = memory(rhs_md, cpu_engine, rhs_minfo.Data());
   auto bias_mem = memory(nullptr);
-  auto result_mem = memory(result_md, cpu_engine, result_minfo.Data());
   std::vector<std::pair<int, dnnl::memory>> postop_args;
 
   // Currently, GELU/ReLU only fusion is supported.
@@ -165,6 +260,26 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
     attrs.set_post_ops(post_ops);
   }
 
+  bool weights_packed = rhs_md.get_ndims() == 1
+                     && rhs_md.get_dims().front() != lhs_md.get_dims().back();
+  if (weights_packed) {
+    // expected 2D buffer with last dim of input and last dim of output
+    auto rhs_any_md = memory::desc(
+                        {
+                          lhs_md.get_dims().back(),
+                          result_md.get_dims().back()},
+                        rhs_md.get_data_type(),
+                        memory::format_tag::any);
+
+    rhs_md = OneDnnMatMulOptWeightsDesc(cpu_engine,
+                                        lhs_md, rhs_any_md,
+                                        bias_md, result_md);
+  }
+
+  auto lhs_mem = memory(lhs_md, cpu_engine, lhs_minfo.Data());
+  auto rhs_mem = memory(rhs_md, cpu_engine, rhs_minfo.Data());
+  auto result_mem = memory(result_md, cpu_engine, result_minfo.Data());
+
   auto matmul_pd = matmul::primitive_desc(cpu_engine, lhs_md, rhs_md, bias_md,
                                           result_md, attrs);
 
@@ -182,6 +297,89 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
   matmul_args.insert(postop_args.begin(), postop_args.end());
 
   matmul_prim.execute(onednn_stream, matmul_args);
+}
+
+ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMulReorder(
+    void* result, void** args) {
+  // args[0]: ptr to nargs
+  // args[1]: ptr to ExecutableRunOptions
+  // args[2]: ptr to OneDnnMatMulConfig
+  // args[3...]: ptrs to operands
+  int arg_indx = 0;
+  const int64_t num_args = *(static_cast<int64_t*>(args[arg_indx++]));
+
+  const xla::ExecutableRunOptions* run_options =
+      static_cast<const xla::ExecutableRunOptions*>(args[arg_indx++]);
+  XLA_LIGHTWEIGHT_CHECK(run_options != nullptr);
+  XLA_LIGHTWEIGHT_CHECK(run_options->intra_op_thread_pool() != nullptr);
+  tsl::OneDnnThreadPool thread_pool(
+      run_options->intra_op_thread_pool()->getPool(), false);
+  engine cpu_engine(engine::kind::cpu, 0);
+#ifndef ENABLE_ONEDNN_OPENMP
+  auto onednn_stream =
+      stream(dnnl::threadpool_interop::make_stream(cpu_engine, &thread_pool));
+#else
+  auto onednn_stream = stream(cpu_engine);
+#endif  // ENABLE_ONEDNN_OPENMP
+
+  std::string config_str(static_cast<const char*>(args[arg_indx++]));
+  OneDnnMatMulConfig matmul_config;
+  matmul_config.ParseFromString(config_str);
+
+  MemrefInfo input_minfo(args[arg_indx++]);
+  MemrefInfo weight_minfo(args[arg_indx++]);
+  MemrefInfo output_minfo(args[arg_indx++]);
+  MemrefInfo result_minfo(result);
+
+  auto input_md = input_minfo.GetOneDnnMemDesc();
+  auto weight_md = weight_minfo.GetOneDnnMemDesc();
+  auto output_md = output_minfo.GetOneDnnMemDesc();
+
+  auto bias_md = dnnl::memory::desc{};
+  if (absl::c_count(matmul_config.fused_ops(), OneDnnMatMulConfig::BIAS) > 0) {
+    MemrefInfo bias_minfo(args[arg_indx++]);
+    bias_md = bias_minfo.GetOneDnnMemDesc();
+  }
+
+  XLA_LIGHTWEIGHT_CHECK(num_args >= arg_indx);
+
+  // Update dims and strides for transposed inputs.
+  bool transpose_a = matmul_config.transpose_a();
+  if (transpose_a) {
+    input_md = Transpose(input_md);
+  }
+  bool transpose_b = matmul_config.transpose_b();
+  if (transpose_b) {
+    weight_md = Transpose(weight_md);
+  }
+
+  // extend bias rank to match result rank
+  if (!bias_md.is_zero()) {
+    auto missed_rank = output_md.get_ndims() - bias_md.get_ndims();
+    XLA_LIGHTWEIGHT_CHECK(missed_rank >= 0);
+    if( missed_rank > 0 ) {
+      auto bias_dims = bias_md.get_dims();
+      bias_dims.insert(bias_dims.begin(), missed_rank, 1);
+      bias_md = bias_md.reshape(bias_dims);
+    }
+  }
+
+  auto result_md = OneDnnMatMulOptWeightsDesc(cpu_engine,
+                                              input_md,
+                                              weight_md,
+                                              bias_md,
+                                              output_md);
+
+  XLA_LIGHTWEIGHT_CHECK(result_minfo.GetOneDnnMemDesc().get_size()
+                     == result_md.get_size());
+
+  auto weight_mem = dnnl::memory{weight_md, cpu_engine, weight_minfo.Data()};
+  auto result_mem = dnnl::memory{result_md, cpu_engine, result_minfo.Data()};
+
+
+  dnnl::reorder rdr{weight_mem, result_mem};
+  rdr.execute(onednn_stream, weight_mem, result_mem);
+  onednn_stream.wait();
 }
 
 }  // namespace cpu

--- a/xla/service/cpu/onednn_matmul.h
+++ b/xla/service/cpu/onednn_matmul.h
@@ -17,8 +17,8 @@ limitations under the License.
 #define XLA_SERVICE_CPU_ONEDNN_MATMUL_H_
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
-#include "xla/shape.h"
 #include "xla/service/cpu/backend_config.pb.h"
+#include "xla/shape.h"
 
 namespace xla {
 namespace cpu {

--- a/xla/service/cpu/onednn_matmul.h
+++ b/xla/service/cpu/onednn_matmul.h
@@ -17,11 +17,21 @@ limitations under the License.
 #define XLA_SERVICE_CPU_ONEDNN_MATMUL_H_
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
+#include "xla/shape.h"
+#include "xla/service/cpu/backend_config.pb.h"
+
 namespace xla {
 namespace cpu {
 
+Shape OneDnnMatMulOptWeightsShape(const Shape& input_shape,
+                                  const Shape& weights_shape,
+                                  const Shape& bias_shape,
+                                  const Shape& output_shape,
+                                  const OneDnnMatMulConfig* matmul_config);
+
 extern "C" {
 extern void __xla_cpu_runtime_OneDnnMatMul(void* result, void** args);
+extern void __xla_cpu_runtime_OneDnnMatMulReorder(void* result, void** args);
 }  // extern "C"
 
 }  // namespace cpu

--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -663,11 +663,11 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
 
 class OneDnnMatMulReorderVisitor : public DfsHloRewriteVisitor {
  public:
-  OneDnnMatMulReorderVisitor(int intraop_parallelism,
+  OneDnnMatMulReorderVisitor(int intra_op_parallelism,
                              const tsl::thread::ThreadPool* compile_threadpool)
-      : intraop_parallelism_(intraop_parallelism > 0
-                                 ? intraop_parallelism
-                                 : tsl::port::MaxParallelism()),
+      : intra_op_parallelism_(intra_op_parallelism > 0
+                                  ? intra_op_parallelism
+                                  : tsl::port::MaxParallelism()),
         evaluator_(/*max_loop_iterations=*/0) {
     if (compile_threadpool) {
       threadpool_device_.reset(
@@ -745,7 +745,7 @@ class OneDnnMatMulReorderVisitor : public DfsHloRewriteVisitor {
 
 #ifndef ENABLE_ONEDNN_OPENMP
       // set oneDNN cuncurrency settings (which is thread-local)
-      tsl::OneDnnThreadPool::set_onednn_max_threads(intraop_parallelism_);
+      tsl::OneDnnThreadPool::set_onednn_max_threads(intra_op_parallelism_);
 #endif
       auto new_weight_shape = OneDnnMatMulOptWeightsShape(
           input_shape, weight_shape, bias_shape, output_shape, &matmul_config);
@@ -786,7 +786,7 @@ class OneDnnMatMulReorderVisitor : public DfsHloRewriteVisitor {
   }
 
  private:
-  int intraop_parallelism_;
+  int intra_op_parallelism_;
   HloEvaluator evaluator_;
   std::unique_ptr<tsl::thread::ThreadPool> threadpool_handle_;
   std::unique_ptr<Eigen::ThreadPoolDevice> threadpool_device_;
@@ -799,7 +799,7 @@ StatusOr<bool> OneDnnMatMulRewriter::Run(
   TF_ASSIGN_OR_RETURN(auto result,
                       visitor.RunOnModule(module, execution_threads));
 
-  OneDnnMatMulReorderVisitor reorder_visitor(intraop_parallelism_,
+  OneDnnMatMulReorderVisitor reorder_visitor(intra_op_parallelism_,
                                              compile_threadpool_);
   TF_ASSIGN_OR_RETURN(auto result2,
                       reorder_visitor.RunOnModule(module, execution_threads));

--- a/xla/service/cpu/onednn_matmul_rewriter.h
+++ b/xla/service/cpu/onednn_matmul_rewriter.h
@@ -20,10 +20,10 @@ limitations under the License.
 #include <optional>
 
 #include "absl/algorithm/container.h"
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/hlo_pass_interface.h"
-#include "unsupported/Eigen/CXX11/Tensor" // from @eigen_archive
 
 namespace xla {
 namespace cpu {
@@ -44,7 +44,7 @@ class OneDnnMatMulRewriter : public HloModulePass {
 
   static bool ShouldRewrite(const HloInstruction* dot_instr);
 
-private:
+ private:
   const Eigen::ThreadPoolDevice* threadpool_device_;
 };
 

--- a/xla/service/cpu/onednn_matmul_rewriter.h
+++ b/xla/service/cpu/onednn_matmul_rewriter.h
@@ -33,9 +33,9 @@ namespace cpu {
 // calls.
 class OneDnnMatMulRewriter : public HloModulePass {
  public:
-  OneDnnMatMulRewriter(int intraop_parallelism,
+  OneDnnMatMulRewriter(int intra_op_parallelism,
                        const tsl::thread::ThreadPool* compile_threadpool)
-      : intraop_parallelism_(intraop_parallelism),
+      : intra_op_parallelism_(intra_op_parallelism),
         compile_threadpool_(compile_threadpool) {}
 
   absl::string_view name() const override { return "onednn-matmul-rewriter"; }
@@ -48,7 +48,7 @@ class OneDnnMatMulRewriter : public HloModulePass {
   static bool ShouldRewrite(const HloInstruction* dot_instr);
 
  private:
-  int intraop_parallelism_;
+  int intra_op_parallelism_;
   const tsl::thread::ThreadPool* compile_threadpool_;
 };
 

--- a/xla/service/cpu/onednn_matmul_rewriter.h
+++ b/xla/service/cpu/onednn_matmul_rewriter.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/hlo_pass_interface.h"
+#include "unsupported/Eigen/CXX11/Tensor" // from @eigen_archive
 
 namespace xla {
 namespace cpu {
@@ -31,6 +32,9 @@ namespace cpu {
 // calls.
 class OneDnnMatMulRewriter : public HloModulePass {
  public:
+  OneDnnMatMulRewriter(const Eigen::ThreadPoolDevice* threadpool_device)
+      : threadpool_device_(threadpool_device) {}
+
   absl::string_view name() const override { return "onednn-matmul-rewriter"; }
 
   using HloPassInterface::Run;
@@ -39,6 +43,9 @@ class OneDnnMatMulRewriter : public HloModulePass {
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
 
   static bool ShouldRewrite(const HloInstruction* dot_instr);
+
+private:
+  const Eigen::ThreadPoolDevice* threadpool_device_;
 };
 
 }  // namespace cpu

--- a/xla/service/cpu/onednn_matmul_rewriter.h
+++ b/xla/service/cpu/onednn_matmul_rewriter.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/hlo_pass_interface.h"
+#include "tsl/platform/threadpool.h"
 
 namespace xla {
 namespace cpu {
@@ -32,8 +33,10 @@ namespace cpu {
 // calls.
 class OneDnnMatMulRewriter : public HloModulePass {
  public:
-  OneDnnMatMulRewriter(const Eigen::ThreadPoolDevice* threadpool_device)
-      : threadpool_device_(threadpool_device) {}
+  OneDnnMatMulRewriter(int intraop_parallelism,
+                       const tsl::thread::ThreadPool* compile_threadpool)
+      : intraop_parallelism_(intraop_parallelism),
+        compile_threadpool_(compile_threadpool) {}
 
   absl::string_view name() const override { return "onednn-matmul-rewriter"; }
 
@@ -45,7 +48,8 @@ class OneDnnMatMulRewriter : public HloModulePass {
   static bool ShouldRewrite(const HloInstruction* dot_instr);
 
  private:
-  const Eigen::ThreadPoolDevice* threadpool_device_;
+  int intraop_parallelism_;
+  const tsl::thread::ThreadPool* compile_threadpool_;
 };
 
 }  // namespace cpu

--- a/xla/service/cpu/onednn_memory_util.cc
+++ b/xla/service/cpu/onednn_memory_util.cc
@@ -50,6 +50,26 @@ struct MemrefInfoPOD {
   void* data;
 };
 
+MemrefInfoHandler CreateMemrefInfoFromLiteral(const Literal* literal) {
+  MemrefInfoHandler result(new MemrefInfoPOD);
+
+  const auto& shape = literal->shape();
+  result->dtype = shape.element_type();
+  result->rank = shape.rank();
+  auto dimensions = shape.dimensions();
+  std::copy(dimensions.begin(), dimensions.end(), absl::MakeSpan(result->dims).begin());
+
+  int64_t stride = 1;
+  for (int i : shape.layout().minor_to_major()) {
+    result->strides[i] = stride;
+    stride *= dimensions.at(i);
+  }
+
+  result->data = const_cast<void*>(literal->untyped_data());
+
+  return result;
+}
+
 StackAlloca GetAllocaAndEmitMemrefInfo(llvm::IRBuilder<>& builder,
                                        const llvm_ir::IrArray& ir_array) {
   const Shape& shape = ir_array.GetShape();

--- a/xla/service/cpu/onednn_memory_util.cc
+++ b/xla/service/cpu/onednn_memory_util.cc
@@ -57,7 +57,8 @@ MemrefInfoHandler CreateMemrefInfoFromLiteral(const Literal* literal) {
   result->dtype = shape.element_type();
   result->rank = shape.rank();
   auto dimensions = shape.dimensions();
-  std::copy(dimensions.begin(), dimensions.end(), absl::MakeSpan(result->dims).begin());
+  std::copy(dimensions.begin(), dimensions.end(),
+            absl::MakeSpan(result->dims).begin());
 
   int64_t stride = 1;
   for (int i : shape.layout().minor_to_major()) {

--- a/xla/service/cpu/onednn_memory_util.h
+++ b/xla/service/cpu/onednn_memory_util.h
@@ -22,8 +22,11 @@ limitations under the License.
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Value.h"
+#include "xla/literal.h"
 #include "xla/service/llvm_ir/ir_array.h"
 #include "xla/xla_data.pb.h"
+
+#include <memory>
 
 namespace xla {
 namespace cpu {
@@ -40,6 +43,9 @@ struct StackAlloca {
 
 // Declare as opaque to put structure definition together with dependant code.
 struct MemrefInfoPOD;
+using MemrefInfoHandler = std::shared_ptr<MemrefInfoPOD>;
+
+MemrefInfoHandler CreateMemrefInfoFromLiteral(const Literal* literal);
 
 StackAlloca GetAllocaAndEmitMemrefInfo(llvm::IRBuilder<>& builder,
                                        const llvm_ir::IrArray& ir_array);

--- a/xla/service/cpu/onednn_memory_util.h
+++ b/xla/service/cpu/onednn_memory_util.h
@@ -17,6 +17,8 @@ limitations under the License.
 #define XLA_SERVICE_CPU_ONEDNN_MEMORY_UTIL_H_
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
+#include <memory>
+
 #include "dnnl.hpp"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -25,8 +27,6 @@ limitations under the License.
 #include "xla/literal.h"
 #include "xla/service/llvm_ir/ir_array.h"
 #include "xla/xla_data.pb.h"
-
-#include <memory>
 
 namespace xla {
 namespace cpu {

--- a/xla/service/cpu/simple_orc_jit.cc
+++ b/xla/service/cpu/simple_orc_jit.cc
@@ -539,6 +539,7 @@ bool RegisterKnownJITSymbols() {
   REGISTER_CPU_RUNTIME_SYMBOL(OneDnnMatMul);
   REGISTER_CPU_RUNTIME_SYMBOL(OneDnnSoftmax);
   REGISTER_CPU_RUNTIME_SYMBOL(OneDnnLayerNorm);
+  REGISTER_CPU_RUNTIME_SYMBOL(OneDnnMatMulReorder);
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 
   registry->Register("__gnu_f2h_ieee", reinterpret_cast<void*>(__gnu_f2h_ieee),

--- a/xla/service/hlo_runner.cc
+++ b/xla/service/hlo_runner.cc
@@ -641,11 +641,14 @@ HloRunner::CreateExecutableWithBufferAssignment(
                       "are enabled.";
     }
     auto module_group = std::make_unique<HloModuleGroup>(std::move(module));
+    xla::Compiler::CompileOptions compile_options {
+      backend().memory_allocator(),
+      backend().eigen_intra_op_thread_pool()};
     TF_ASSIGN_OR_RETURN(
         auto executables,
         backend().compiler()->Compile(std::move(module_group),
                                       {{backend().default_stream_executor()}},
-                                      backend().memory_allocator()));
+                                      compile_options));
     return std::move(executables[0]);
   }
   return backend().compiler()->RunBackendWithBufferAssignment(

--- a/xla/service/hlo_runner.cc
+++ b/xla/service/hlo_runner.cc
@@ -641,9 +641,8 @@ HloRunner::CreateExecutableWithBufferAssignment(
                       "are enabled.";
     }
     auto module_group = std::make_unique<HloModuleGroup>(std::move(module));
-    xla::Compiler::CompileOptions compile_options {
-      backend().memory_allocator(),
-      backend().eigen_intra_op_thread_pool()};
+    xla::Compiler::CompileOptions compile_options{
+        backend().memory_allocator(), backend().eigen_intra_op_thread_pool()};
     TF_ASSIGN_OR_RETURN(
         auto executables,
         backend().compiler()->Compile(std::move(module_group),

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -482,21 +482,42 @@ TEST_F(MatmulTest, DivisionByConstantWithEltwiseLinearF32) {
   )");
 }
 
-TEST_F(MatmulTest, TestF32Reorder) {
+TEST_F(MatmulTest, TestF32NonConstantWeights) {
   const char* matmul_module_str = R"(
-  HloModule matmul.test.f32, entry_computation_layout={(f32[8,4,16]{2,1,0},f32[16,32]{1,0})->f32[8,4,32]{2,1,0}}
+  HloModule matmul.test.f32, entry_computation_layout={(f32[64,256,16]{2,1,0},f32[16,32]{1,0})->f32[64,256,32]{2,1,0}}
 
   ENTRY matmul.test.f32 {
-    arg.0 = f32[8,4,16]{2,1,0} parameter(0), parameter_replication={false}
+    arg.0 = f32[64,256,16]{2,1,0} parameter(0), parameter_replication={false}
     arg.1 = f32[16,32]{1,0} parameter(1), parameter_replication={false}
-    ROOT onednn.matmul.0 = f32[8,4,32]{2,1,0} dot(arg.0, arg.1), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+    ROOT onednn.matmul.0 = f32[64,256,32]{2,1,0} dot(arg.0, arg.1), lhs_contracting_dims={2}, rhs_contracting_dims={0}
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
   MatchOptimizedHlo(matmul_module_str,
                     R"(
-  ; CHECK:     custom_call_target="__onednn$matmul_reorder",
-  ; CHECK:     custom_call_target="__onednn$matmul",
+  ; CHECK:     %matmul.test.f32
+  ; CHECK-NOT: custom_call_target="__onednn$matmul_reorder",
+  ; CHECK:     custom-call(%{{[a-z,A-Z,0-9,\.]*}}, %arg.1), custom_call_target="__onednn$matmul",
+  )");
+}
+
+TEST_F(MatmulTest, TestF32ConstantWeights) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32, entry_computation_layout={(f32[64,256,16]{2,1,0})->f32[64,256,32]{2,1,0}}
+
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[64,256,16]{2,1,0} parameter(0), parameter_replication={false}
+    constant = f32[] constant(1)
+    arg.1 = f32[16,32]{1,0} broadcast(constant), dimensions={}
+    ROOT onednn.matmul.0 = f32[64,256,32]{2,1,0} dot(arg.0, arg.1), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:     %matmul.test.f32
+  ; CHECK-NOT: custom_call_target="__onednn$matmul_reorder",
+  ; CHECK:     custom-call(%{{[a-z,A-Z,0-9,\.]*}}, %constant{{[a-z,A-Z,0-9,\.]*}}), custom_call_target="__onednn$matmul",
   )");
 }
 

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -482,6 +482,24 @@ TEST_F(MatmulTest, DivisionByConstantWithEltwiseLinearF32) {
   )");
 }
 
+TEST_F(MatmulTest, TestF32Reorder) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32, entry_computation_layout={(f32[8,4,16]{2,1,0},f32[16,32]{1,0})->f32[8,4,32]{2,1,0}}
+
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[8,4,16]{2,1,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[16,32]{1,0} parameter(1), parameter_replication={false}
+    ROOT onednn.matmul.0 = f32[8,4,32]{2,1,0} dot(arg.0, arg.1), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$matmul_reorder",
+  ; CHECK:     custom_call_target="__onednn$matmul",
+  )");
+}
+
 }  // namespace cpu
 }  // namespace xla
 


### PR DESCRIPTION
This PR implements MatMul constant weights pre-packing(reordering) to optimized layout at compile time for performant MatMul execution at runtime. Non-constant weights kept unchanged to avoid buffers reordering at runtime.

As far as oneDNN MatMul weights optimization depends on runtime intra-op parallelization(concurrency) level, following changes made as well:
* Added static method to `OneDnnThreadPool` which allows to configure oneDNN parallelization level at compile time.
* PJRT CPU client and HLO runner modified to pass intra-op parallelization level to `HloModule` configuration.

To let weights pre-packing run faster at compile time, `compile_thread_pool` is used for `dnnl::reorder` calls, to manage this configuration properly following changes were made:
* `CpuCompiler::RunHloPasses()` signature is updated to receive `CompileOptions`.
* PJRT CPU client is modified to setup `CompileOptions::compile_thread_pool` for `CpuCompiler` calls.
