### PR TITLE
[NVIDIA GPU SPMD] Add runtime support to run windowed einsum in multiple streams

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -810,6 +810,7 @@ cc_library(
     srcs = ["thunk.cc"],
     hdrs = ["thunk.h"],
     deps = [
+        ":backend_configs_cc",
         ":buffer_allocations",
         ":gpu_executable_run_options",
         ":nccl_clique",
@@ -832,6 +833,7 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@llvm-project//mlir:IR",
+        "@tsl//tsl/lib/gtl:int_type",
         "@tsl//tsl/platform:statusor",
     ],
 )

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -371,6 +371,7 @@ cc_library(
         "//xla/service/gpu/runtime3:replica_id_thunk",
         "//xla/service/gpu/runtime3:send_recv_thunk",
         "//xla/service/gpu/runtime3:sequential_thunk",
+        "//xla/service/gpu/runtime3:wait_for_streams_thunk",
         "//xla/service/gpu/runtime3:while_thunk",
         "//xla/service/llvm_ir:buffer_assignment_util",
         "//xla/service/llvm_ir:dynamic_update_slice_util",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -303,6 +303,26 @@ absl::Status MaybeRendezvousAfterInitialization(
     const ServiceExecutableRunOptions* run_options,
     RendezvousSingleFlag& thunks_initialized);
 
+absl::flat_hash_set<ExecutionStreamId>
+  ExtractAdditionalComputeStreamIds(
+    const HloModule& module) {
+  absl::flat_hash_set<ExecutionStreamId> stream_ids;
+  for (const HloComputation* comp : module.computations()) {
+    for (const HloInstruction* hlo : comp->instructions()) {
+      if (hlo->has_backend_config() &&
+          hlo->backend_config<GpuBackendConfig>().ok()) {
+        int64_t op_queue_id = hlo->backend_config<GpuBackendConfig>()
+                                  .value()
+                                  .operation_queue_id();
+        if (op_queue_id > 0) {
+          stream_ids.insert(ExecutionStreamId(op_queue_id));
+        }
+      }
+    }
+  }
+  return stream_ids;
+}
+
 absl::Status ExecuteThunks(const std::string& module_name,
                            ModuleIdentifier module_id,
                            const ThunkSequence& thunk_sequence,
@@ -311,7 +331,9 @@ absl::Status ExecuteThunks(const std::string& module_name,
                            const BufferAllocations& buffer_allocations,
                            bool block_host_until_done,
                            bool use_highest_priority_for_async_stream,
-                           RendezvousSingleFlag& thunks_initialized) {
+                           RendezvousSingleFlag& thunks_initialized,
+                           absl::flat_hash_set<ExecutionStreamId>
+                            additional_compute_stream_ids) {
   se::Stream* main_stream = run_options->stream();
   se::StreamExecutor* executor = main_stream->parent();
   stream_executor::StreamPriority stream_priority =
@@ -340,6 +362,24 @@ absl::Status ExecuteThunks(const std::string& module_name,
     command_buffer_trace_stream = borrowed_command_buffer_trace_stream->get();
   }
 
+  // Borrow stream for additional compute streams
+  Thunk::ExecutionStreamIdMap additional_compute_streams;
+  std::vector<StreamPool::Ptr> additional_streams;
+  int num_streams = additional_compute_stream_ids.size();
+  if (num_streams > 0) {
+    TF_ASSIGN_OR_RETURN(
+      additional_streams,
+        run_options->BorrowStreams(executor->device_ordinal(),
+                                    num_streams));
+
+    int64_t i = 0;
+    for (auto& stream : additional_compute_stream_ids) {
+      additional_compute_streams[stream] =
+        additional_streams.at(i).get();
+      i++;
+    }
+    VLOG(2) << "Using " << num_streams << " additional compute streams.";
+  }
   tsl::profiler::TraceMe hlo_module_activity(
       [&] { return absl::StrCat(module_name, ":XLA GPU module"); },
       tsl::profiler::TraceMeLevel::kInfo);
@@ -401,7 +441,7 @@ absl::Status ExecuteThunks(const std::string& module_name,
   Thunk::ExecuteParams execute_params = Thunk::ExecuteParams::Create(
       *run_options, buffer_allocations, main_stream,
       command_buffer_trace_stream, async_comms_streams, &collective_params,
-      &collective_cliques);
+      &collective_cliques, additional_compute_streams);
 
   for (const std::unique_ptr<Thunk>& thunk : thunk_sequence) {
     // Annotate execution of this op if tracing was enabled when we started
@@ -959,6 +999,12 @@ absl::Status GpuExecutable::ExecuteThunksOrXlaRuntime(
 
   ModuleIdentifier unique_id = has_module() ? module().unique_id() : -1;
 
+  absl::flat_hash_set<ExecutionStreamId> additional_compute_stream_ids;
+  if (has_module()) {
+    additional_compute_stream_ids =
+      ExtractAdditionalComputeStreamIds(module());
+  }
+
   if (thunks_) {
     Thunk::ExecutableSource executable_source = {text_, binary_};
 
@@ -970,7 +1016,7 @@ absl::Status GpuExecutable::ExecuteThunksOrXlaRuntime(
                            .debug_options()
                            .xla_gpu_enable_highest_priority_async_stream()
                      : false,
-        thunks_initialized_flag_);
+        thunks_initialized_flag_, additional_compute_stream_ids);
   }
 
   // Match IrEmitter's temp buffer allocation for kernel launches. See

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -3799,7 +3799,6 @@ absl::Status IrEmitterUnnested::EmitNcclAsyncDone(Thunk::Kind kind,
 absl::Status IrEmitterUnnested::EmitWaitForStreamsThunk(
     const HloInstruction* inst, GpuBackendConfig& gpu_config,
     bool is_async_done) {
-  const HloInstruction* wrapped = inst->async_wrapped_instruction();
   std::vector<ExecutionStreamId> wait_on_streams;
   ExecutionStreamId source_stream_id = Thunk::GetMainComputeStreamId();
   // If it's for an async done, then we need to sychronize on the execution

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -142,6 +142,7 @@ limitations under the License.
 #include "xla/service/gpu/runtime3/replica_id_thunk.h"
 #include "xla/service/gpu/runtime3/send_recv_thunk.h"
 #include "xla/service/gpu/runtime3/sequential_thunk.h"
+#include "xla/service/gpu/runtime3/wait_for_streams_thunk.h"
 #include "xla/service/gpu/runtime3/while_thunk.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/service/llvm_ir/buffer_assignment_util.h"
@@ -3795,6 +3796,37 @@ absl::Status IrEmitterUnnested::EmitNcclAsyncDone(Thunk::Kind kind,
   return absl::OkStatus();
 }
 
+absl::Status IrEmitterUnnested::EmitWaitForStreamsThunk(
+    const HloInstruction* inst, GpuBackendConfig& gpu_config,
+    bool is_async_done) {
+  const HloInstruction* wrapped = inst->async_wrapped_instruction();
+  std::vector<ExecutionStreamId> wait_on_streams;
+  ExecutionStreamId source_stream_id = Thunk::GetMainComputeStreamId();
+  // If it's for an async done, then we need to sychronize on the execution
+  // stream of the instruction from main compute stream
+  if (is_async_done) {
+    wait_on_streams.push_back(
+        ExecutionStreamId(gpu_config.operation_queue_id()));
+  } else if (gpu_config.wait_on_operation_queues().size() == 0) {
+    // If wait on queue is empty, we just synchronize on the main compute
+    // stream from the execution stream.
+    wait_on_streams.push_back(Thunk::GetMainComputeStreamId());
+    source_stream_id = gpu_config.operation_queue_id();
+  } else {
+    // Else, we synchronize on all specified
+    // streams from the execution stream.
+    for (int64_t stream_id : gpu_config.wait_on_operation_queues()) {
+      wait_on_streams.push_back(ExecutionStreamId(stream_id));
+    }
+    source_stream_id = gpu_config.operation_queue_id();
+  }
+
+  AddThunkToThunkSequence(std::make_unique<WaitForStreamsThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(inst), source_stream_id,
+      wait_on_streams));
+  return absl::OkStatus();
+}
+
 absl::StatusOr<std::vector<ShapedSlice>> IrEmitterUnnested::GetShapedSlices(
     mlir::Operation::operand_range operands) {
   std::vector<ShapedSlice> shaped_slices;
@@ -4562,9 +4594,23 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
           return EmitNcclAsyncDone(Thunk::kNcclReduceScatterDone, instr);
         case HloOpcode::kAllToAll:
           return EmitNcclAsyncDone(Thunk::kNcclAllToAllDone, instr);
-        default:
+        default: {
+          if (wrapped->has_backend_config()) {
+            TF_ASSIGN_OR_RETURN(
+                xla::gpu::GpuBackendConfig gpu_config,
+                wrapped->backend_config<xla::gpu::GpuBackendConfig>());
+            if (gpu_config.operation_queue_id() != 0) {
+              // If there an async-done instruction that wraps an instruction
+              // that runs on a non-default stream, then we will
+              // just emit syncOnStreamThunk().
+              return EmitWaitForStreamsThunk(instr, gpu_config,
+                                            /*is_async_done=*/true);
+            }
+          }
+
           return Internal("Unsupported async done wrapped instruction: %s",
                           HloOpcodeString(wrapped->opcode()));
+        }
       }
     }
     case HloOpcode::kAsyncStart: {
@@ -4582,9 +4628,26 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
           return EmitNcclThunk<NcclAllToAllStartThunk, HloAllToAllInstruction>(
               Thunk::kNcclAllToAll, instr, all_to_all, std::nullopt);
         }
-        default:
+        default: {
+          if (wrapped->has_backend_config()) {
+            TF_ASSIGN_OR_RETURN(
+                xla::gpu::GpuBackendConfig gpu_config,
+                wrapped->backend_config<xla::gpu::GpuBackendConfig>());
+            if (gpu_config.operation_queue_id() != 0) {
+              // If there an async instruction that wraps an instruction
+              // that runs on a non-default stream, then we will
+              // emit syncOnStreamThunk(source=execution_stream,
+              //                        wait_on=main_compute_stream)
+              // then the thunk of wrapped instruction.
+              TF_RETURN_IF_ERROR(
+                  EmitWaitForStreamsThunk(instr, gpu_config,
+                                         /*is_async_done=*/false));
+              return EmitHloInstruction(wrapped);
+            }
+          }
           return Internal("Unsupported async start wrapped instruction: %s",
                           HloOpcodeString(wrapped->opcode()));
+        }
       }
     }
 

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -227,6 +227,9 @@ class IrEmitterUnnested : public IrEmitter {
 
   absl::Status EmitNcclAsyncDone(Thunk::Kind kind, const HloInstruction* instr);
 
+  absl::Status EmitWaitForStreamsThunk(const HloInstruction* inst,
+                                      GpuBackendConfig& gpu_config,
+                                      bool is_async_done);
   template <typename ThunkType, typename OpT>
   absl::Status EmitReplicaOrPartitionId(mlir::Operation* op);
   template <typename ThunkType>

--- a/xla/service/gpu/runtime3/BUILD
+++ b/xla/service/gpu/runtime3/BUILD
@@ -105,6 +105,7 @@ cc_library(
         ":nccl_all_reduce_thunk",
         ":replica_id_thunk",
         ":sequential_thunk",
+        ":wait_for_streams_thunk",
         ":while_thunk",
         "//xla:status",
         "//xla:statusor",
@@ -643,5 +644,17 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",
+    ],
+)
+
+cc_library(
+    name = "wait_for_streams_thunk",
+    srcs = ["wait_for_streams_thunk.cc"],
+    hdrs = ["wait_for_streams_thunk.h"],
+    deps = [
+        "//xla/service:global_device_id",
+        "//xla/service/gpu:thunk",
+        "@com_google_absl//absl/status",
+        "@tsl//tsl/platform:statusor",
     ],
 )

--- a/xla/service/gpu/runtime3/BUILD
+++ b/xla/service/gpu/runtime3/BUILD
@@ -655,6 +655,8 @@ cc_library(
         "//xla/service:global_device_id",
         "//xla/service/gpu:thunk",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:statusor",
     ],
 )

--- a/xla/service/gpu/runtime3/command_buffer_cmd_emitter.cc
+++ b/xla/service/gpu/runtime3/command_buffer_cmd_emitter.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "xla/service/gpu/runtime3/nccl_all_reduce_thunk.h"
 #include "xla/service/gpu/runtime3/replica_id_thunk.h"
 #include "xla/service/gpu/runtime3/sequential_thunk.h"
+#include "xla/service/gpu/runtime3/wait_for_streams_thunk.h"
 #include "xla/service/gpu/runtime3/while_thunk.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/util.h"
@@ -226,6 +227,7 @@ static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
     case Thunk::Kind::kNcclAllGatherDone:
     case Thunk::Kind::kNcclAllReduceDone:
     case Thunk::Kind::kNcclReduceScatterDone:
+    case Thunk::Kind::kWaitForStreams:
       return absl::OkStatus();
 
     default:

--- a/xla/service/gpu/runtime3/gemm_thunk.cc
+++ b/xla/service/gpu/runtime3/gemm_thunk.cc
@@ -48,10 +48,14 @@ absl::Status GemmThunk::ExecuteOnStream(const ExecuteParams& params) {
   if (workspace_.has_value()) {
     workspace = allocs.GetDeviceAddress(workspace_.value());
   }
+  TF_ASSIGN_OR_RETURN(se::Stream* stream, GetStreamForExecution(
+                                  Thunk::execution_stream_id(),
+                                  params));
+
   return RunGemm(config_, allocs.GetDeviceAddress(lhs_buffer_),
                  allocs.GetDeviceAddress(rhs_buffer_),
                  allocs.GetDeviceAddress(output_buffer_), workspace,
-                 deterministic_, params.stream);
+                 deterministic_, stream);
 }
 
 absl::Status GemmThunk::Initialize(const InitializeParams& params) {

--- a/xla/service/gpu/runtime3/wait_for_streams_thunk.cc
+++ b/xla/service/gpu/runtime3/wait_for_streams_thunk.cc
@@ -1,0 +1,46 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/runtime3/wait_for_streams_thunk.h"
+
+#include <string>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "xla/service/gpu/thunk.h"
+#include "tsl/platform/errors.h"
+
+namespace xla::gpu {
+
+absl::Status WaitForStreamsThunk::ExecuteOnStream(const ExecuteParams& params) {
+  TF_ASSIGN_OR_RETURN(se::Stream* stream,
+      Thunk::GetStreamForExecution(stream_id_, params));
+
+  VLOG(5) << "Waiting for stream ids: " <<
+              absl::StrJoin(wait_for_stream_ids_, ", ",
+                [&](std::string* s, const ExecutionStreamId& stream_id) {
+                  absl::StrAppend(s, stream_id.value());
+                });
+  for (const auto& stream_id : wait_for_stream_ids_) {
+    TF_ASSIGN_OR_RETURN(se::Stream* wait_on_stream,
+        Thunk::GetStreamForExecution(stream_id, params));
+
+    stream->ThenWaitFor(wait_on_stream);
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/runtime3/wait_for_streams_thunk.h
+++ b/xla/service/gpu/runtime3/wait_for_streams_thunk.h
@@ -1,0 +1,55 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_RUNTIME3_WAIT_FOR_STREAMS_THUNK_H_
+#define XLA_SERVICE_GPU_RUNTIME3_WAIT_FOR_STREAMS_THUNK_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "xla/service/gpu/thunk.h"
+
+namespace xla::gpu {
+
+// This thunk
+class WaitForStreamsThunk : public Thunk {
+ public:
+  WaitForStreamsThunk(ThunkInfo thunk_info, ExecutionStreamId stream_id,
+                     std::vector<ExecutionStreamId> wait_for_stream_ids)
+      : Thunk(Kind::kWaitForStreams, thunk_info),
+        stream_id_(stream_id),
+        wait_for_stream_ids_(wait_for_stream_ids){};
+
+  WaitForStreamsThunk(const WaitForStreamsThunk&) = delete;
+  WaitForStreamsThunk& operator=(const WaitForStreamsThunk&) = delete;
+
+  const ExecutionStreamId& stream_id() const {
+    return stream_id_;
+  }
+
+  const std::vector<ExecutionStreamId>& wait_for_stream_ids() const {
+    return wait_for_stream_ids_;
+  }
+
+  absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+
+ private:
+  ExecutionStreamId stream_id_;
+  std::vector<ExecutionStreamId> wait_for_stream_ids_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_RUNTIME3_WAIT_FOR_STREAMS_THUNK_H_

--- a/xla/service/gpu/thunk.cc
+++ b/xla/service/gpu/thunk.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "xla/executable_run_options.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/global_device_id.h"
+#include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/service/gpu/nccl_clique.h"
@@ -154,14 +155,16 @@ Thunk::ExecuteParams Thunk::ExecuteParams::Create(
     se::Stream* command_buffer_trace_stream,
     absl::Span<se::Stream* const> async_streams,
     CollectiveExecuteParams* collective_params,
-    CollectiveCliques* collective_cliques) {
+    CollectiveCliques* collective_cliques,
+    ExecutionStreamIdMap additional_compute_streams) {
   return ExecuteParams(&buffer_allocations, stream, command_buffer_trace_stream,
                        {async_streams.begin(), async_streams.end()},
                        collective_params, collective_cliques,
                        run_options.run_options().device_to_host_stream(),
                        run_options.run_options().host_to_device_stream(),
                        run_options.run_options().send_device_memory_function(),
-                       run_options.run_options().recv_device_memory_function());
+                       run_options.run_options().recv_device_memory_function(),
+                       additional_compute_streams);
 }
 
 Thunk::ExecuteParams::ExecuteParams(
@@ -172,7 +175,8 @@ Thunk::ExecuteParams::ExecuteParams(
     CollectiveCliques* collective_cliques, se::Stream* device_to_host_stream,
     se::Stream* host_to_device_stream,
     SendDeviceMemoryFunction* send_device_memory_function,
-    RecvDeviceMemoryFunction* recv_device_memory_function)
+    RecvDeviceMemoryFunction* recv_device_memory_function,
+    ExecutionStreamIdMap additional_compute_streams)
     : buffer_allocations(buffer_allocations),
       stream(stream),
       command_buffer_trace_stream(command_buffer_trace_stream),
@@ -182,7 +186,8 @@ Thunk::ExecuteParams::ExecuteParams(
       device_to_host_stream(device_to_host_stream),
       host_to_device_stream(host_to_device_stream),
       send_device_memory_function(send_device_memory_function),
-      recv_device_memory_function(recv_device_memory_function) {}
+      recv_device_memory_function(recv_device_memory_function),
+      additional_compute_streams(additional_compute_streams) {}
 
 //===----------------------------------------------------------------------===//
 
@@ -238,7 +243,22 @@ Thunk::ExecuteParams::ExecuteParams(
     CASE(kTriangularSolve);
     CASE(kWhile);
     CASE(kFusedMHA);
+    CASE(kWaitForStreams);
   }
+}
+
+/*static*/
+absl::StatusOr<se::Stream*> Thunk::GetStreamForExecution(
+  ExecutionStreamId stream_id,
+  const ExecuteParams& params) {
+  if (stream_id == GetMainComputeStreamId()) {
+    return params.stream;
+  }
+  auto iter = params.additional_compute_streams.find(stream_id);
+  if (iter == params.additional_compute_streams.end()) {
+    return absl::InvalidArgumentError("Invalid execution stream id.");
+  }
+  return iter->second;
 }
 
 std::ostream& operator<<(std::ostream& os, Thunk::Kind kind) {
@@ -293,6 +313,12 @@ Thunk::ThunkInfo Thunk::ThunkInfo::WithProfileAnnotation(
   ThunkInfo thunk_info(nullptr);
   thunk_info.profile_annotation =
       absl::StrFormat("Thunk:#hlo_op=%s#", instr->name());
+  auto gpu_backend_config = instr->backend_config<GpuBackendConfig>();
+  if (gpu_backend_config.ok()) {
+    thunk_info.execution_stream_id =
+        std::max(Thunk::GetMainComputeStreamId().value(),
+                 gpu_backend_config->operation_queue_id());
+  }
   return thunk_info;
 }
 

--- a/xla/service/gpu/thunk.h
+++ b/xla/service/gpu/thunk.h
@@ -303,9 +303,6 @@ class Thunk {
     // avoid accidental tracing of unrelated activities on a main stream.
     se::Stream* command_buffer_trace_stream;
 
-    // Additional compute streams on which thunks launch operations.
-    ExecutionStreamIdMap additional_compute_streams;
-
     // Streams for asynchronous collective communications.
     // TODO(ezhulenev): Move this into `CollectiveExecuteParams`.
     absl::InlinedVector<se::Stream*, 4> async_comms_streams;
@@ -323,6 +320,9 @@ class Thunk {
     // Send/Recv callbacks passed to XLA from PjRt.
     SendDeviceMemoryFunction* send_device_memory_function;
     RecvDeviceMemoryFunction* recv_device_memory_function;
+
+    // Additional compute streams on which thunks launch operations.
+    ExecutionStreamIdMap additional_compute_streams;
 
    private:
     ExecuteParams(const BufferAllocations* buffer_allocations,


### PR DESCRIPTION
This PR contains the runtime changes to be able to run windowed einsum in multiple cuda streams.
This pr follows(https://github.com/openxla/xla/pull/7854) which adds stream attributes to the HLO graph.
We take the stream attributes and dispatch corresponding kernels to separate cuda streams.

We do this by wrapping the kernel with an asyncStartDone pair and non-default stream id.
The emitter will emit a SyncOnStreamsThunk and then the kernel's thunk for AsyncStart. For asyncStartDone, it will just emit SyncOnStreamsThunk.

Detailed discussion [here](https://github.com/openxla/xla/discussions/8865).