### PR TITLE
Augment NVTX annotations attached to HLO modules and thunks

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -313,7 +313,8 @@ absl::Status ExecuteThunks(
     const ServiceExecutableRunOptions* run_options,
     const BufferAllocations& buffer_allocations, bool block_host_until_done,
     bool use_highest_priority_for_async_stream,
-    const absl::flat_hash_set<ExecutionStreamId>& execution_stream_ids) {
+    const absl::flat_hash_set<ExecutionStreamId>& execution_stream_ids,
+    const ModuleAnnotations& module_annotations) {
   se::Stream* main_stream = run_options->stream();
   se::StreamExecutor* executor = main_stream->parent();
   stream_executor::StreamPriority stream_priority =
@@ -424,7 +425,8 @@ absl::Status ExecuteThunks(
     // Annotate execution of this op if tracing was enabled when we started
     // running this module.  If tracing is enabled *while* we're running the
     // module, we won't get any data, but that's probably an OK trade-off.
-    tsl::profiler::ScopedAnnotation annotation(thunk->profile_annotation());
+    auto annotation =
+        GetKernelAnnotation(&module_annotations, thunk->profile_annotation());
     VLOG(3) << "Executing the thunk for " << thunk->profile_annotation();
     if (NeedsAsyncCommsStream(*thunk)) {
       for (se::Stream* async_stream : async_comms_streams) {
@@ -954,7 +956,7 @@ absl::Status GpuExecutable::ExecuteThunksOrXlaRuntime(
                            .debug_options()
                            .xla_gpu_enable_highest_priority_async_stream()
                      : false,
-        execution_stream_ids_);
+        execution_stream_ids_, module_annotations_);
   }
 
   return FailedPrecondition("Expected XLA gpu executable is not supplied.");

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1704,8 +1704,11 @@ absl::Status IrEmitterUnnested::EmitTriangularSolveCustomCall(
   if (thunks.size() == 1) {
     AddThunkToThunkSequence(std::move(thunks[0]));
   } else {
-    AddThunkToThunkSequence(std::make_unique<SequentialThunk>(
-        Thunk::ThunkInfo::WithProfileAnnotation(instr), std::move(thunks)));
+    auto thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(instr);
+    // Don't repeat the annotation from inside thunks
+    thunk_info.profile_annotation = {};
+    AddThunkToThunkSequence(
+        std::make_unique<SequentialThunk>(thunk_info, std::move(thunks)));
   }
   return absl::OkStatus();
 }

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -67,6 +67,7 @@ cc_library(
         "GOOGLE_CUDA=1",
     ]),
     deps = [
+	":annotation",
         ":custom_call_thunk",
         ":nccl_all_gather_thunk",
         ":nccl_all_reduce_thunk",
@@ -203,7 +204,9 @@ cc_library(
     name = "command_buffer_thunk",
     srcs = ["command_buffer_thunk.cc"],
     hdrs = ["command_buffer_thunk.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
+	":annotation",
         ":command_buffer_allocations",
         ":command_buffer_cmd",
         "//xla:status",
@@ -630,6 +633,7 @@ cc_library(
         "TENSORFLOW_USE_ROCM=1",
     ]),
     deps = [
+	":annotation",
         "//xla:status",
         "//xla/hlo/ir:hlo",
         "//xla/service/gpu:buffer_allocations",

--- a/xla/service/gpu/runtime/annotation.cc
+++ b/xla/service/gpu/runtime/annotation.cc
@@ -30,8 +30,11 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "tsl/platform/errors.h"
 #include "tsl/profiler/lib/nvtx_utils.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
 
 namespace xla::gpu {
+
+using ::tsl::profiler::ScopedAnnotation;
 namespace {
 
 nvtxStringHandle_t RegisterString(const std::string& str) {
@@ -53,6 +56,183 @@ nvtxStringHandle_t RegisterString(const std::string& str) {
   return {};
 #endif
 }
+
+// Nsight Systems supports some basic HTML markup in annotation strings. This
+// escaping stops things like <module> from disappearing.
+std::ostream& PrintEscaped(std::ostream& os, std::string_view str) {
+  for (char c : str) {
+    switch (c) {
+      case '<':
+        os << "&lt;";
+        break;
+      case '>':
+        os << "&gt;";
+        break;
+      default:
+        os << c;
+    }
+  }
+  return os;
+}
+
+// Print options for profiler annotations.
+HloPrintOptions PrintOptions() {
+  auto opts = HloPrintOptions::ShortParsable();
+  opts.set_print_large_constants(false);
+  opts.set_print_control_dependencies(true);
+  opts.set_print_operand_index_annotation_interval(5);
+  opts.set_print_backend_config(true);
+  opts.set_print_metadata(true);
+  opts.set_print_name_after_closing_brace(true);
+  return opts;
+}
+
+// Sortable struct representing a frame in the Python stacktrace attached to a
+// given instruction.
+struct StackFrame {
+  std::string_view file_name, function_name, op_name;
+  int line, column;
+
+ private:
+  auto tied() const {
+    return std::tie(file_name, line, column, function_name, op_name);
+  }
+  friend bool operator==(StackFrame const& lhs, StackFrame const& rhs) {
+    return lhs.tied() == rhs.tied();
+  }
+  friend bool operator<(StackFrame const& lhs, StackFrame const& rhs) {
+    return lhs.tied() < rhs.tied();
+  }
+};
+
+// Walk through the HLO graph from an instruction and collect the source
+// file/line information we see along the way. This allows us to generate an
+// annotation for each kernel that shows the (merged) Python stacktraces of the
+// operations that were traced and compiled int this kernel. For example:
+//
+// - /opt/jax/examples/mnist_vae.py:143[<module>]
+// -- /opt/jax/examples/mnist_vae.py:127[run_epoch]
+// --- /opt/jax/examples/mnist_vae.py:125[body_fun]
+// ---- /opt/jax/examples/mnist_vae.py:124[<lambda>]
+// ----- /opt/jax/examples/mnist_vae.py:122[body_fun] transpose[permutation=(1, 0)]
+// --- /opt/jax/examples/mnist_vae.py:126[body_fun] add
+// --- /opt/jax/examples/mnist_vae.py:126[body_fun] mul
+// --- /opt/jax/examples/mnist_vae.py:126[body_fun] sub
+//
+// shows four merged stacktraces (3 of depth 3, 1 of depth 5).
+class SourceLocationVisitor : public ConstDfsHloVisitorWithDefault {
+ public:
+  SourceLocationVisitor(std::string_view op_name_prefix_to_remove_ = {})
+      : op_name_prefix_to_remove{op_name_prefix_to_remove_} {}
+
+  std::string AsString(int32_t common_prefix) const {
+    // Format the call stacks we've collected; if call stack collection was not
+    // enabled then each "stack" just has depth 1 and no column/function name
+    // information. Skip the first `common_prefix` elements of each stack trace
+    if (common_prefix < 0) {
+      return "[invalid common_prefix]";
+    }
+    std::ostringstream oss{};
+    oss << '\n';
+    std::vector<StackFrame> current_state{};
+    for (auto const& call_stack : location_set) {
+      for (auto depth = 0; depth < call_stack.size() - common_prefix; ++depth) {
+        auto const& frame = call_stack[common_prefix + depth];
+        if (depth < current_state.size() && current_state[depth] == frame) {
+          continue;
+        }
+        current_state.resize(depth + 1);
+        current_state[depth] = frame;
+        FormatFrame(oss, frame, depth);
+      }
+    }
+    return std::move(oss).str();
+  }
+
+  Status DefaultAction(HloInstruction const* inst) final {
+    OpMetadata const& meta = inst->metadata();
+    // The full op_name is split across three places: the module-level
+    // annotation shows the prefix that is common to the whole module, the
+    // kernel-level annotation removes that prefix and shows whatever middle
+    // sections of the name are common to all operations in the kernel, and the
+    // individual call stack frames in the kernel-level annotation show the
+    // final parts of the op_name that have not already been shown.
+    std::string_view op_name = meta.op_name();
+    if (!op_name.empty()) {
+      op_name = op_name.substr(op_name_prefix_to_remove.size());
+    }
+    if (!op_name.empty() && op_name.front() == '/') {
+      op_name = op_name.substr(1);
+    }
+    if (int frame_id = meta.stack_frame_id(); frame_id != 0) {
+      std::vector<StackFrame> call_stack{};
+      HloModule const* const hlo_module = inst->parent()->parent();
+      while (frame_id != 0) {
+        HloModule::StackFrame frame = hlo_module->get_stack_frame(frame_id);
+        if (frame.empty()) {
+          break;
+        }
+        frame_id = frame.parent_frame_id;
+        call_stack.emplace_back(StackFrame{frame.file_name, frame.function_name,
+                                           op_name, frame.line, frame.column});
+        // only attach the op_name to the most-nested frame
+        op_name = {};
+      }
+      // re-order to be [caller, callee, ...]
+      std::reverse(call_stack.begin(), call_stack.end());
+      location_set.emplace(call_stack);
+    } else if (!meta.source_file().empty() && meta.source_line() != 0) {
+      location_set.emplace(1, StackFrame{meta.source_file(),
+                                         {/* function_name */},
+                                         op_name,
+                                         meta.source_line()});
+    }
+    return OkStatus();
+  }
+
+  std::pair<nvtxStringHandle_t, int32_t> LongestSourceLocationPrefix() const {
+    // Find the longest common prefix along the members of location_set and
+    // return a formatted version of that prefix, along with its length. As
+    // location_set is sorted, that just means looking for the longest common
+    // prefix of the first and last elements.
+    if (location_set.size() < 2) {
+      // Only extract a prefix if there are enough stack traces.
+      return {};
+    }
+    const auto& first_loc = *location_set.begin();
+    const auto common_end = std::mismatch(first_loc.begin(), first_loc.end(),
+                                          location_set.rbegin()->begin(),
+                                          location_set.rbegin()->end())
+                                .first;
+    std::ostringstream oss{};
+    oss << '\n';
+    std::for_each(first_loc.begin(), common_end,
+                  [&oss](const StackFrame& frame) { FormatFrame(oss, frame); });
+    const int32_t prefix_frames = std::distance(first_loc.begin(), common_end);
+    return {RegisterString(std::move(oss).str()), prefix_frames};
+  }
+
+ private:
+  static void FormatFrame(std::ostringstream& oss, const StackFrame& frame,
+                          int depth = -1) {
+    if (depth >= 0) {
+      oss << std::string(depth + 1, '-') << ' ';
+    }
+    PrintEscaped(oss, frame.file_name) << ':' << frame.line;
+    if (frame.column) {
+      oss << ':' << frame.column;
+    }
+    if (!frame.function_name.empty()) {
+      PrintEscaped(oss << '[', frame.function_name) << ']';
+    }
+    if (!frame.op_name.empty()) {
+      PrintEscaped(oss << ' ', frame.op_name);
+    }
+    oss << '\n';
+  }
+  std::string_view op_name_prefix_to_remove{};
+  std::set<std::vector<StackFrame>> location_set{};
+};
 
 template <typename Visitor>
 absl::Status VisitInstAndCalledButNotOperands(Visitor& visitor,
@@ -140,16 +320,121 @@ std::string MakeTitle(const HloModule& mod, std::string_view longest_prefix) {
   return absl::StrFormat("XlaModule:#prefix=%s,hlo_module=%s,program_id=%d#",
                          longest_prefix, mod.name(), mod.unique_id());
 }
+
+std::string FormatSourceLocations(HloInstruction const& inst,
+                                  int32_t common_frames) {
+  // Inside the source location/backtrace report the op_name too, but remove the
+  // kernel-wide prefix for brevity
+  SourceLocationVisitor visitor{GetLongestOpNamePrefix(inst)};
+  // Visit the given instruction, and the things it calls, but not its operands
+  // -- we don't want to collect the source code locations that produced the
+  // inputs to this kernel, just those corresponding to the kernel itself.
+  if (!VisitInstAndCalledButNotOperands(visitor, inst).ok()) {
+    return "[error]";
+  }
+  return visitor.AsString(common_frames);
+}
+
+// Get the string representation of this instruction as an std::string.
+std::string InstructionAsString(HloInstruction const& inst) {
+  StringPrinter printer;
+  inst.Print(&printer, PrintOptions());
+  return std::move(printer).ToString();
+}
+
+// Get the string representation of the HLO code called by this instruction,
+// but not the instruction itself. The typical example is a fusion instruction,
+// where InstructionAsString(fusion_inst) would be something like
+//   fusion.N = ... fusion(...), calls=fused_computation.N ...
+// and CalledInstructionsAsString(fusion_inst) would be something like
+//   fused_computation.N { ... }
+std::string CalledInstructionsAsString(HloInstruction const& inst) {
+  StringPrinter printer;
+  auto const opts = PrintOptions();
+  for (HloComputation const* called : inst.called_computations()) {
+    called->Print(&printer, opts);
+  }
+  return std::move(printer).ToString();
+}
+
+// Get a string representing the longest common prefix of source locations in
+// this module, and the number of frames that that represents.
+std::pair<nvtxStringHandle_t, int32_t> GetLongestSourceLocationPrefix(
+    const HloModule& mod) {
+  // In the presence of (at least) debug callbacks, calling Accept on the root
+  // instruction of the module may not reach all instructions in the module.
+  SourceLocationVisitor visitor{};
+  for (const HloComputation* computation : mod.computations()) {
+    for (const HloInstruction* inst : computation->instructions()) {
+      if (!visitor.DefaultAction(inst).ok()) {
+        return {};
+      }
+    }
+  }
+  return visitor.LongestSourceLocationPrefix();
+}
 }  // namespace
 
-ModuleAnnotation::ModuleAnnotation(std::string_view module_name)
-    : title_str(absl::StrFormat("XlaModule:#hlo_module=%s", module_name)),
-      title(RegisterString(title_str)) {}
+ModuleAnnotation::ModuleAnnotation(std::string_view module_name_)
+    : title_str(absl::StrFormat("XlaModule:#hlo_module=%s#", module_name_)),
+      title(RegisterString(title_str)),
+      module_name(RegisterString(std::string{module_name_})) {}
 
 ModuleAnnotation::ModuleAnnotation(const HloModule& mod)
     : longest_prefix(GetLongestOpNamePrefix(mod)),
       title_str(MakeTitle(mod, longest_prefix)),
-      title(RegisterString(title_str)) {}
+      title(RegisterString(title_str)),
+      module_name(RegisterString(mod.name())),
+      module_id(mod.unique_id()) {
+  std::tie(common_src_locations, common_stack_frames_) =
+      GetLongestSourceLocationPrefix(mod);
+}
+
+#if GOOGLE_CUDA
+namespace {
+auto schema_entry(uint64_t type, const char* name, uint64_t offset) {
+  nvtxPayloadSchemaEntry_t r{};
+  r.type = type;
+  r.name = name;
+  r.offset = offset;
+  return r;
+}
+}  // namespace
+#endif
+
+uint64_t ModuleAnnotation::NvtxSchemaId() {
+  static std::uint64_t schemaId = []() -> std::uint64_t {
+#if GOOGLE_CUDA
+    auto domain_opt = tsl::profiler::GetNVTXDomain();
+    if (!domain_opt.has_value()) {
+      return 0;
+    }
+    const nvtxPayloadSchemaEntry_t schema[] = {
+        schema_entry(NVTX_PAYLOAD_ENTRY_TYPE_NVTX_REGISTERED_STRING_HANDLE,
+                     "Name", offsetof(ModuleAnnotation, module_name)),
+        schema_entry(NVTX_PAYLOAD_ENTRY_TYPE_INT32, "Unique ID",
+                     offsetof(ModuleAnnotation, module_id)),
+        schema_entry(NVTX_PAYLOAD_ENTRY_TYPE_NVTX_REGISTERED_STRING_HANDLE,
+                     "Common source locations",
+                     offsetof(ModuleAnnotation, common_src_locations))};
+    const nvtxPayloadSchemaAttr_t schemaAttr = {
+        /* .fieldMask = */ NVTX_PAYLOAD_SCHEMA_ATTR_NAME |
+            NVTX_PAYLOAD_SCHEMA_ATTR_TYPE | NVTX_PAYLOAD_SCHEMA_ATTR_ENTRIES |
+            NVTX_PAYLOAD_SCHEMA_ATTR_NUM_ENTRIES |
+            NVTX_PAYLOAD_SCHEMA_ATTR_STATIC_SIZE,
+        /* .name = */ "XlaModule",
+        /* .type = */ NVTX_PAYLOAD_SCHEMA_TYPE_STATIC,
+        /* .flags = */ NVTX_PAYLOAD_SCHEMA_FLAG_NONE,
+        /* .entries = */ schema,
+        /* .numEntries = */ sizeof(schema) / sizeof(schema[0]),
+        /* .payloadStaticSize = */ sizeof(ModuleAnnotation)};
+    return nvtxPayloadSchemaRegister(*domain_opt, &schemaAttr);
+#else
+    return 0;
+#endif
+  }();
+  return schemaId;
+}
 
 namespace {
 std::string MakeKernelName(std::string_view prefix,
@@ -181,36 +466,64 @@ KernelAnnotation::KernelAnnotation(const ModuleAnnotation& module_annotation,
                                    const HloInstruction& inst)
     : title_str(
           MakeKernelName(module_annotation.longest_op_name_prefix(), inst)),
-      title(RegisterString(title_str)) {}
+      title(RegisterString(title_str)),
+      hlo_dump(RegisterString(InstructionAsString(inst))),
+      src_locations(RegisterString(FormatSourceLocations(
+          inst, module_annotation.common_stack_frames()))),
+      called_hlo_dump(RegisterString("\n" + CalledInstructionsAsString(inst))) {
+}
 
 ModuleAnnotations::ModuleAnnotations(std::string_view module_name)
     : top_level(module_name) {}
 
+uint64_t KernelAnnotation::NvtxSchemaId() {
+  static std::uint64_t schemaId = []() -> std::uint64_t {
+#if GOOGLE_CUDA
+    auto domain_opt = tsl::profiler::GetNVTXDomain();
+    if (!domain_opt.has_value()) {
+      return 0;
+    }
+    const nvtxPayloadSchemaEntry_t schema[] = {
+        schema_entry(NVTX_PAYLOAD_ENTRY_TYPE_NVTX_REGISTERED_STRING_HANDLE,
+                     "Source locations",
+                     offsetof(KernelAnnotation, src_locations)),
+        schema_entry(NVTX_PAYLOAD_ENTRY_TYPE_NVTX_REGISTERED_STRING_HANDLE,
+                     "HLO", offsetof(KernelAnnotation, hlo_dump)),
+        schema_entry(NVTX_PAYLOAD_ENTRY_TYPE_NVTX_REGISTERED_STRING_HANDLE,
+                     "Called HLO",
+                     offsetof(KernelAnnotation, called_hlo_dump))};
+    const nvtxPayloadSchemaAttr_t schemaAttr = {
+        /* .fieldMask = */ NVTX_PAYLOAD_SCHEMA_ATTR_NAME |
+            NVTX_PAYLOAD_SCHEMA_ATTR_TYPE | NVTX_PAYLOAD_SCHEMA_ATTR_ENTRIES |
+            NVTX_PAYLOAD_SCHEMA_ATTR_NUM_ENTRIES |
+            NVTX_PAYLOAD_SCHEMA_ATTR_STATIC_SIZE,
+        /* .name = */ "XlaKernel",
+        /* .type = */ NVTX_PAYLOAD_SCHEMA_TYPE_STATIC,
+        /* .flags = */ NVTX_PAYLOAD_SCHEMA_FLAG_NONE,
+        /* .entries = */ schema,
+        /* .numEntries = */ sizeof(schema) / sizeof(schema[0]),
+        /* .payloadStaticSize = */ sizeof(KernelAnnotation)};
+    return nvtxPayloadSchemaRegister(*domain_opt, &schemaAttr);
+#else
+    return 0;
+#endif
+  }();
+  return schemaId;
+}
+
 ModuleAnnotations::ModuleAnnotations(const HloModule& mod) : top_level{mod} {
   // loop through `mod` and populate `kernels` (string -> KernelAnnotation map)
   // with the information we want to attach to individual kernels.
-  for (const HloComputation* computation :
-       mod.computations()) {  // top-level blocks in the module
-    for (const HloInstruction* inst :
-         computation->instructions()) {  // statements within block
-      // working assumption: only custom calls and fusions end up with NVTX
-      // ranges named after them. bad assumption [at least partially]: cuda
-      // graph launches are not handled correctly
-      switch (inst->opcode()) {
-        case HloOpcode::kCustomCall:
-        case HloOpcode::kFusion: {
-          // e.g. inst.name is "fusion.6", inst.opcode is "kFusion" and called
-          // is ["fused_computation.5"], in which case the content of
-          // "fused_computation.5" ends up under an NVTX range called
-          // "fusion.6". We want to construct a useful annotation for that NVTX
-          // range based on the content of `inst`, including `called` etc.
-          // FIXME: using try_emplace here was sensitive to
-          // https://github.com/abseil/abseil-cpp/issues/388.
-          kernels.insert({inst->name(), {top_level, *inst}});
-        } break;
-        default:
-          break;
-      }
+  for (const HloComputation* computation : mod.computations()) {
+    for (const HloInstruction* inst : computation->instructions()) {
+      // e.g. inst.name is "fusion.6", inst.opcode is "kFusion" and called
+      // is ["fused_computation.5"], in which case the content of
+      // "fused_computation.5" ends up under an NVTX range called
+      // "fusion.6". We want to construct a useful annotation for that NVTX
+      // range based on the content of `inst`, including `called` etc.
+      // FIXME: using try_emplace here was sensitive to
+      // https://github.com/abseil/abseil-cpp/issues/388.
+      kernels.insert({inst->name(), {top_level, *inst}});
     }
   }
 }
@@ -233,6 +546,23 @@ ScopedModuleAnnotations::~ScopedModuleAnnotations() {
 
 const ModuleAnnotations* GetCurrentModuleAnnotations() {
   return current_annotations;
+}
+
+std::optional<ScopedAnnotation> GetKernelAnnotation(
+    const ModuleAnnotations* annotations, std::string_view profile_annotation) {
+  if (profile_annotation.empty()) {
+    return {};
+  }
+  if (annotations) {
+    // Have a set of pre-prepared thunk/kernel annotations to use
+    const auto iter = annotations->kernels.find(profile_annotation);
+    if (iter != annotations->kernels.end()) {
+      // Have a pre-prepared annotation, use it
+      return std::optional<ScopedAnnotation>{[&] { return iter->second; }};
+    }
+  }
+  return std::optional<ScopedAnnotation>{
+      [&] { return absl::StrFormat("Thunk:#hlo_op=%s#", profile_annotation); }};
 }
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -48,6 +48,7 @@ limitations under the License.
 #include "xla/service/gpu/nccl_clique.h"
 #include "xla/service/gpu/nccl_clique_key.h"
 #include "xla/service/gpu/nccl_collective_thunk.h"
+#include "xla/service/gpu/runtime/annotation.h"
 #include "xla/service/gpu/runtime/nccl_all_gather_thunk.h"
 #include "xla/service/gpu/runtime/nccl_all_reduce_thunk.h"
 #include "xla/service/gpu/stream_executor_util.h"
@@ -245,6 +246,7 @@ absl::Status CommandBufferCmdSequence::Record(
   // Track the number of commands recorded between barriers.
   int64_t num_recorded_commands = 0;
 
+  const ModuleAnnotations* annotations = GetCurrentModuleAnnotations();
   for (auto& command : commands_) {
     if (command.requires_barrier) {
       VLOG(3) << "Add command buffer barrier after " << num_recorded_commands
@@ -252,7 +254,8 @@ absl::Status CommandBufferCmdSequence::Record(
       TF_RETURN_IF_ERROR(command_buffer->Barrier(params.stream->parent()));
       num_recorded_commands = 0;
     }
-
+    auto annotation =
+        GetKernelAnnotation(annotations, command.cmd->profile_annotation());
     TF_RETURN_IF_ERROR(command.cmd->Record(params, state, command_buffer));
     ++num_recorded_commands;
   }

--- a/xla/service/gpu/runtime/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime/command_buffer_cmd.h
@@ -175,6 +175,14 @@ class CommandBufferCmd {
 
   // Returns true if command implemented as a nested command buffer.
   virtual bool IsNestedCommandBuffer() const { return false; }
+
+  std::string_view profile_annotation() const { return profile_annotation_; }
+  void set_profile_annotation(std::string_view profile_annotation) {
+    profile_annotation_ = profile_annotation;
+  }
+
+ private:
+  std::string profile_annotation_;
 };
 
 //===----------------------------------------------------------------------===//

--- a/xla/service/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -163,16 +163,25 @@ static absl::StatusOr<Command> Convert(const CustomCallThunk& thunk) {
 }
 
 //===----------------------------------------------------------------------===//
+static absl::StatusOr<Command> CopyMetadata(absl::StatusOr<Command> cmd,
+                                            const Thunk& thunk) {
+  if (cmd.ok()) {
+    (*cmd)->set_profile_annotation(thunk.profile_annotation());
+    return cmd;
+  }
+  return cmd;
+}
 
 template <typename ThunkType>
 static absl::StatusOr<Command> Convert(const Thunk& thunk) {
-  return Convert(static_cast<const ThunkType&>(thunk));
+  return CopyMetadata(Convert(static_cast<const ThunkType&>(thunk)), thunk);
 }
 
 template <typename ThunkType>
 static absl::StatusOr<Command> Convert(const Thunk& thunk,
                                        bool force_barriers) {
-  return Convert(static_cast<const ThunkType&>(thunk), force_barriers);
+  return CopyMetadata(
+      Convert(static_cast<const ThunkType&>(thunk), force_barriers), thunk);
 }
 
 static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,

--- a/xla/service/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/service/gpu/runtime/command_buffer_thunk.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
+#include "xla/service/gpu/runtime/annotation.h"
 #include "xla/service/gpu/runtime/command_buffer_cmd.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -37,13 +38,11 @@ limitations under the License.
 #include "tsl/platform/logging.h"
 #include "tsl/platform/statusor.h"
 #include "tsl/profiler/lib/profiler_lock.h"
-#include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
 #include "tsl/profiler/lib/traceme_encode.h"
 
 namespace xla::gpu {
 
-using tsl::profiler::ScopedAnnotation;
 using tsl::profiler::TraceMe;
 using tsl::profiler::TraceMeEncode;
 
@@ -197,8 +196,10 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   if (tsl::profiler::ProfilerLock::HasActiveSession() && thunks_.has_value()) {
     VLOG(1) << "Execute command buffer thunk as a regular thunk sequence "
                "because we detected active profiling session";
+    const ModuleAnnotations* annotations = GetCurrentModuleAnnotations();
     for (auto& thunk : *thunks_) {
-      ScopedAnnotation annotation([&] { return thunk->profile_annotation(); });
+      auto annotation =
+          GetKernelAnnotation(annotations, thunk->profile_annotation());
       TF_RETURN_IF_ERROR(thunk->ExecuteOnStream(params));
     }
     return absl::OkStatus();

--- a/xla/service/gpu/runtime/sequential_thunk.cc
+++ b/xla/service/gpu/runtime/sequential_thunk.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "xla/service/gpu/runtime/annotation.h"
 #include "xla/service/gpu/thunk.h"
 #include "tsl/platform/errors.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
@@ -54,8 +55,10 @@ absl::Status SequentialThunk::Initialize(const InitializeParams& params) {
 }
 
 absl::Status SequentialThunk::ExecuteOnStream(const ExecuteParams& params) {
+  const ModuleAnnotations* annotations = GetCurrentModuleAnnotations();
   for (const auto& thunk : thunks_) {
-    ScopedAnnotation annotation([&] { return thunk->profile_annotation(); });
+    auto annotation =
+        GetKernelAnnotation(annotations, thunk->profile_annotation());
     TF_RETURN_IF_ERROR(thunk->ExecuteOnStream(params));
   }
   return absl::OkStatus();

--- a/xla/service/gpu/thunk.cc
+++ b/xla/service/gpu/thunk.cc
@@ -305,16 +305,15 @@ bool IsReductionCollective(Thunk::Kind kind) {
 
 Thunk::ThunkInfo Thunk::ThunkInfo::WithProfileAnnotation(mlir::Operation* op) {
   ThunkInfo thunk_info(op);
-  thunk_info.profile_annotation = absl::StrFormat(
-      "Thunk:#hlo_op=%s#", mlir::mhlo::GetDebugNameFromLocation(op->getLoc()));
+  thunk_info.profile_annotation =
+      mlir::mhlo::GetDebugNameFromLocation(op->getLoc());
   return thunk_info;
 }
 
 Thunk::ThunkInfo Thunk::ThunkInfo::WithProfileAnnotation(
     const HloInstruction* instr) {
   ThunkInfo thunk_info(nullptr);
-  thunk_info.profile_annotation =
-      absl::StrFormat("Thunk:#hlo_op=%s#", instr->name());
+  thunk_info.profile_annotation = instr->name();
   auto gpu_backend_config = instr->backend_config<GpuBackendConfig>();
   if (gpu_backend_config.ok()) {
     thunk_info.execution_stream_id =

--- a/xla/service/gpu/thunk.h
+++ b/xla/service/gpu/thunk.h
@@ -362,7 +362,7 @@ class Thunk {
 
   virtual std::string ToStringExtra(int indent) const { return ""; }
   Kind kind() const { return kind_; }
-  std::string profile_annotation() const { return profile_annotation_; }
+  std::string_view profile_annotation() const { return profile_annotation_; }
 
   // Only valid during compilation, i.e., lowering thunks to kernel-launch
   // related XLA runtime custom calls). nullptr at runtime. MLIR codegen will


### PR DESCRIPTION
This builds on the work in #7106 to make the NVTX annotations shown in the NSight Systems profiler more helpful.

Now the string representation of the HLO, and the Python stack trace of the traced model code, are shown in these annotations. For example, for a cuBLAS kernel:

```
Thunk:#name=while/body/transpose[permutation=(1, 0)],hlo_op=custom-call.49#
Begins: 13.3989s
Ends: 13.3989s (+10.209 μs)
Thread: 42903
XlaKernel
Source locations: 
- /opt/jax/examples/mnist_vae.py:143[<module>]
-- /opt/jax/examples/mnist_vae.py:127[run_epoch]
--- /opt/jax/examples/mnist_vae.py:125[body_fun]
---- /opt/jax/examples/mnist_vae.py:124[<lambda>]
----- /opt/jax/examples/mnist_vae.py:122[body_fun]

HLO: custom-call.49 = (f32[512,20]{1,0}, s8[68096]{0}) custom-call(fusion.46, wrapped_concatenate.28), custom_call_target="__cublas$gemm", metadata={op_name="jit(run_epoch)/jit(main)/while/body/transpose[permutation=(1, 0)]" source_file="/opt/jax/examples/mnist_vae.py" source_line=122}, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"gemm_backend_config":{"alpha_real":1,"alpha_imag":0,"beta":0,"dot_dimension_numbers":{"lhs_contracting_dimensions":["0"],"rhs_contracting_dimensions":["0"],"lhs_batch_dimensions":[],"rhs_batch_dimensions":[]},"precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},"epilogue":"DEFAULT","lhs_stride":"16384","rhs_stride":"640","grad_x":false,"grad_y":false}}
```
or with a fusion:
```
Source locations: 
- /opt/jax/examples/mnist_vae.py:143[<module>]
-- /opt/jax/examples/mnist_vae.py:127[run_epoch]
--- /opt/jax/examples/mnist_vae.py:126[body_fun]

HLO: fusion.133 = f32[512,512]{1,0} fusion(get-tuple-element.681), kind=kLoop, calls=fused_computation.7, metadata={op_name="jit(run_epoch)/jit(main)/while/body/mul" source_file="/opt/jax/examples/mnist_vae.py" source_line=126 deduplicated_name="fusion.7"}
Called HLO: 
fused_computation.7 {
  param_0.9 = f32[512,512]{1,0} parameter(0)
  constant_378 = f32[] constant(0.9)
  broadcast.575 = f32[512,512]{1,0} broadcast(constant_378), dimensions={}
  ROOT multiply.250 = f32[512,512]{1,0} multiply(param_0.9, broadcast.575), metadata={op_name="jit(run_epoch)/jit(main)/while/body/mul" source_file="/opt/jax/examples/mnist_vae.py" source_line=126}
}
```