### PR TITLE
[GPU] NCCL User Buffers - collective memory allocation improvements

### DIFF
--- a/xla/pjrt/gpu/gpu_helpers.cc
+++ b/xla/pjrt/gpu/gpu_helpers.cc
@@ -120,13 +120,25 @@ StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
 
 // Builds a BFCAllocator for all local GPUs that uses collective memory.
 StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
-    se::StreamExecutor* executor, size_t allocator_memory, bool preallocate) {
+    se::StreamExecutor* executor, double memory_fraction,
+    size_t collective_memory_size) {
   int device_ordinal = executor->device_ordinal();
   auto sub_allocator = std::make_unique<se::DeviceMemAllocator>(
       executor, tsl::PlatformDeviceId(device_ordinal),
       /*memory_type=*/stream_executor::MemoryType::kCollective,
       /*alloc_visitors=*/std::vector<tsl::SubAllocator::Visitor>(),
       /*free_visitors=*/std::vector<tsl::SubAllocator::Visitor>());
+
+  int64_t free_memory;
+  int64_t total_memory;
+  if (!executor->DeviceMemoryUsage(&free_memory, &total_memory)) {
+    return Unavailable("Failed to query available memory from device %i",
+                       device_ordinal);
+  }
+  bool preallocate = collective_memory_size != 0;
+  size_t allocator_memory = preallocate
+                              ? collective_memory_size
+                              : total_memory * memory_fraction;
 
   if (preallocate) {
     LOG(INFO) << "XLA backend allocating " << allocator_memory

--- a/xla/pjrt/gpu/gpu_helpers.h
+++ b/xla/pjrt/gpu/gpu_helpers.h
@@ -58,11 +58,13 @@ struct GpuAllocatorConfig {
   // allocator will allocate more memory as allocations are requested.
   bool preallocate = true;
 
-  // Amount of collective memory (ncclMemAlloc) to reserve. Must be set when
-  // using `xla_gpu_enable_nccl_user_buffers=true`. If this value is 0,
+  // Maximum amount of collective memory (ncclMemAlloc) to reserve. Must be set
+  // when using `xla_gpu_enable_nccl_user_buffers=true`. If this value is 0,
   // collective memory will not be allocated. Should be set to a multiple of
-  // 512MB to avoid wasting memory due to granularity requirements.
-  size_t collective_memory_size = 0;
+  // 512MB to avoid wasting memory due to granularity requirements. If
+  // TF_COLLECTIVE_MEMORY_PREALLOCATE=1 is set, the allocator will immediately
+  // allocate the maximum amount.
+  size_t collective_memory_size = 4 * (1LL << 30);
 };
 
 std::unique_ptr<tsl::BFCAllocator> GetGpuHostAllocator(

--- a/xla/pjrt/gpu/gpu_helpers.h
+++ b/xla/pjrt/gpu/gpu_helpers.h
@@ -58,13 +58,12 @@ struct GpuAllocatorConfig {
   // allocator will allocate more memory as allocations are requested.
   bool preallocate = true;
 
-  // Maximum amount of collective memory (ncclMemAlloc) to reserve. Must be set
-  // when using `xla_gpu_enable_nccl_user_buffers=true`. If this value is 0,
-  // collective memory will not be allocated. Should be set to a multiple of
-  // 512MB to avoid wasting memory due to granularity requirements. If
-  // TF_COLLECTIVE_MEMORY_PREALLOCATE=1 is set, the allocator will immediately
-  // allocate the maximum amount.
-  size_t collective_memory_size = 4 * (1LL << 30);
+  // Amount of collective memory (ncclMemAlloc) to preallocate. If this value is
+  // 0, collective memory space will be grown as needed to fit the application's
+  // usage, with the drawback of potentially higher fragmentation. If set,
+  // should be set to a multiple of 512MB to avoid wasting memory due to
+  // granularity requirements.
+  size_t collective_memory_size = 0;
 };
 
 std::unique_ptr<tsl::BFCAllocator> GetGpuHostAllocator(
@@ -76,7 +75,7 @@ StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
 
 // Builds a BFCAllocator for all local GPUs that uses collective memory.
 StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
-    se::StreamExecutor* executor, size_t allocator_memory, bool preallocate);
+    se::StreamExecutor* executor, double memory_fraction, size_t collective_memory_size);
 
 }  // namespace xla
 

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -779,24 +779,17 @@ GetStreamExecutorGpuDeviceAllocator(
   }
 
   // Add any additional allocators for alternate memory spaces.
-  if (allocator_config.collective_memory_size != 0) {
-    bool preallocate;
-    TF_RETURN_IF_ERROR(tsl::ReadBoolFromEnvVar(
-        "TF_COLLECTIVE_MEMORY_PREALLOCATE", false, &preallocate));
-
-    for (const auto& ordinal_and_device : addressable_devices) {
-      TF_ASSIGN_OR_RETURN(
-          auto collective_bfc_allocator,
-          CreateCollectiveBFCAllocator(
-              ordinal_and_device.second->executor(),
-              /*allocator_memory=*/allocator_config.collective_memory_size,
-              /*preallocate=*/preallocate));
-      allocators.emplace_back(std::move(collective_bfc_allocator),
-                              ordinal_and_device.second->compute_stream(),
-                              /*memory_space=*/1);
-    }
+  for (const auto& ordinal_and_device : addressable_devices) {
+    TF_ASSIGN_OR_RETURN(
+        auto collective_bfc_allocator,
+        CreateCollectiveBFCAllocator(
+            ordinal_and_device.second->executor(),
+            /*memory_fraction=*/1.0 - allocator_config.memory_fraction,
+            allocator_config.collective_memory_size));
+    allocators.emplace_back(std::move(collective_bfc_allocator),
+                            ordinal_and_device.second->compute_stream(),
+                            /*memory_space=*/1);
   }
-
   return std::make_unique<se::MultiDeviceAdapter>(platform,
                                                   std::move(allocators));
 }

--- a/xla/python/xla_client.py
+++ b/xla/python/xla_client.py
@@ -213,6 +213,7 @@ def generate_pjrt_gpu_plugin_options(
   allocator = os.getenv('XLA_PYTHON_CLIENT_ALLOCATOR', 'default').lower()
   memory_fraction = os.getenv('XLA_PYTHON_CLIENT_MEM_FRACTION', '')
   preallocate = os.getenv('XLA_PYTHON_CLIENT_PREALLOCATE', '')
+  collective_memory_size = os.getenv('XLA_PYTHON_CLIENT_COLLECTIVE_MEM_SIZE_MB', '')
   if allocator not in ('default', 'platform', 'bfc', 'cuda_async'):
     raise ValueError(
         'XLA_PYTHON_CLIENT_ALLOCATOR env var must be "default", "platform", '
@@ -223,6 +224,8 @@ def generate_pjrt_gpu_plugin_options(
     options['memory_fraction'] = float(memory_fraction)
   if preallocate:
     options['preallocate'] = preallocate not in ('false', 'False', '0')
+  if collective_memory_size:
+    options["collective_memory_size"] = int(collective_memory_size) * (1 << 20)
   return options
 
 

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -881,6 +881,7 @@ cc_library(
         "//xla/service/llvm_ir:llvm_util",
         "//xla/stream_executor",
         "//xla/stream_executor/gpu:gpu_activation_header",
+        "//xla/stream_executor/gpu:gpu_driver_header",
         "//xla/stream_executor/gpu:gpu_stream",
         "//xla/translate/hlo_to_mhlo:hlo_utils",
         "//xla/translate/mhlo_to_hlo:attribute_exporter",
@@ -908,6 +909,7 @@ cc_library(
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rccl",
     ]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
 )
 
 #===-------------------------------------------------------------------------------------------===//

--- a/xla/service/gpu/nccl_collective_thunk.cc
+++ b/xla/service/gpu/nccl_collective_thunk.cc
@@ -51,6 +51,7 @@ limitations under the License.
 #include "xla/statusor.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/gpu/gpu_activation.h"
+#include "xla/stream_executor/gpu/gpu_driver.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/util.h"
 #include "tsl/platform/errors.h"
@@ -299,39 +300,55 @@ absl::StatusOr<std::vector<DeviceBufferPair>> ConvertToDeviceBuffers(
   return device_buffers;
 }
 
-Status MaybeRegisterBuffers(NcclApi* nccl_api, int device_ordinal,
-                            const std::vector<DeviceBufferPair>& buffers,
-                            NcclApi::NcclCommHandle comm) {
+Status RegisterBufferOnce(NcclApi* nccl_api, int device_ordinal,
+                          NcclApi::NcclCommHandle comm,
+                          se::DeviceMemoryBase buffer) {
   // Keep track of which communicators we have registered for already.
-  // Each device has one NCCL buffer which only needs to be registered once per
-  // each comm.
+  // Each ncclMemAlloc'd buffer needs to be registered once per comm.
   struct RegisteredBuffers {
     absl::Mutex mu;
-    absl::flat_hash_map<int, absl::flat_hash_set<NcclApi::NcclCommHandle>>
-        per_device_comms ABSL_GUARDED_BY(mu);
+    // Device ordinal, communicator, and base pointer address.
+    absl::flat_hash_set<
+        std::tuple<int, NcclApi::NcclCommHandle, se::gpu::GpuDevicePtr>>
+        records ABSL_GUARDED_BY(mu);
     // Buffers could be deregistered with ncclCommDeregister.
     std::vector<NcclApi::NcclRegisteredBufferHandle> handles
         ABSL_GUARDED_BY(mu);
   };
   static auto& all_registered = *new RegisteredBuffers;
 
+  // Since each XLA buffer is a slice into a larger BFCAllocator chunk, first
+  // get the base address of buffer. We will use the base address to keep track
+  // of which chunks we have registered.
+  se::gpu::GpuDevicePtr base_ptr;
+  size_t base_size;
+  TF_RETURN_IF_ERROR(se::gpu::GpuDriver::GetPointerAddressRange(
+      reinterpret_cast<se::gpu::GpuDevicePtr>(buffer.opaque()), &base_ptr,
+      &base_size));
+
   absl::MutexLock lock(&all_registered.mu);
+  if (!all_registered.records.contains({device_ordinal, comm, base_ptr})) {
+    // ncclCommRegister will internally get and use the base address/size of the
+    // address we provide.
+    TF_ASSIGN_OR_RETURN(NcclApi::NcclRegisteredBufferHandle handle,
+                        nccl_api->RegisterBuffer(comm, buffer));
+    all_registered.handles.push_back(handle);
+    all_registered.records.insert({device_ordinal, comm, base_ptr});
+  }
+  return OkStatus();
+}
+
+Status MaybeRegisterBuffers(NcclApi* nccl_api, int device_ordinal,
+                            const std::vector<DeviceBufferPair>& buffers,
+                            NcclApi::NcclCommHandle comm) {
   for (int i = 0; i < buffers.size(); ++i) {
-    if (!all_registered.per_device_comms[device_ordinal].contains(comm)) {
-      if (buffers[i].source_memory_space == kCollectiveMemorySpaceColor) {
-        TF_ASSIGN_OR_RETURN(
-            NcclApi::NcclRegisteredBufferHandle handle,
-            nccl_api->RegisterBuffer(comm, buffers[i].source_buffer));
-        all_registered.handles.push_back(handle);
-        all_registered.per_device_comms[device_ordinal].insert(comm);
-      }
-      if (buffers[i].destination_memory_space == kCollectiveMemorySpaceColor) {
-        TF_ASSIGN_OR_RETURN(
-            NcclApi::NcclRegisteredBufferHandle handle,
-            nccl_api->RegisterBuffer(comm, buffers[i].destination_buffer));
-        all_registered.handles.push_back(handle);
-        all_registered.per_device_comms[device_ordinal].insert(comm);
-      }
+    if (buffers[i].source_memory_space == kCollectiveMemorySpaceColor) {
+      TF_RETURN_IF_ERROR(RegisterBufferOnce(nccl_api, device_ordinal, comm,
+                                            buffers[i].source_buffer));
+    }
+    if (buffers[i].destination_memory_space == kCollectiveMemorySpaceColor) {
+      TF_RETURN_IF_ERROR(RegisterBufferOnce(nccl_api, device_ordinal, comm,
+                                            buffers[i].destination_buffer));
     }
   }
   return OkStatus();


### PR DESCRIPTION
Followup to https://github.com/openxla/xla/pull/7843 https://github.com/openxla/xla/pull/7962 https://github.com/openxla/xla/pull/7963

This PR aims to address the issue that `collective_memory_size` must be configured properly in order to use `--xla_gpu_enable_nccl_user_buffers=true`. 

* The default behavior sets the collective memory BFC allocator in "allow growth" mode. It will start without allocating any `ncclMemAlloc` memory and will grow as needed. If there are no collectives using the user buffers, no collective memory will ever be allocated.
* If the user instead wants to preallocate a block of memory like before, `XLA_PYTHON_CLIENT_COLLECTIVE_MEM_SIZE_MB` can be used.
