### PR TITLE
Turn the HLO verifier always on around float normalization on GPU

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1416,7 +1416,7 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
                          LayoutAssignment::InstructionCanChangeLayout)
                      .VerifyBroadcastDimensionsOrder()
                      .VerifyReshapeIsBitcast(),
-                 /*debug_only=*/false);
+                 /*debug_only=*/true);
 
   // Linearize collective schedule if online autotuning of convolutions is
   // enabled.
@@ -1469,6 +1469,10 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   pipeline.AddPass<HloCSE>(/*is_layout_sensitive=*/true,
                            /*only_fusion_computations=*/false,
                            /*ignore_control_dependencies=*/true);
+
+  pipeline.AddPass<HloVerifier>(/*layout_sensitive=*/true,
+                                /*allow_mixed_precision=*/false);
+
   TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
 
   return absl::OkStatus();

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1416,7 +1416,7 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
                          LayoutAssignment::InstructionCanChangeLayout)
                      .VerifyBroadcastDimensionsOrder()
                      .VerifyReshapeIsBitcast(),
-                 /*debug_only=*/true);
+                 /*debug_only=*/false);
 
   // Linearize collective schedule if online autotuning of convolutions is
   // enabled.

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1470,8 +1470,15 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
                            /*only_fusion_computations=*/false,
                            /*ignore_control_dependencies=*/true);
 
-  pipeline.AddPass<HloVerifier>(/*layout_sensitive=*/true,
-                                /*allow_mixed_precision=*/false);
+  pipeline.AddPass<HloVerifier>(
+      std::make_unique<DefaultVerifierMetadata>(
+          HloVerifierOpts{}
+              .MakeLayoutSensitive()
+              .WithInstructionCanChangeLayout(
+                  LayoutAssignment::InstructionCanChangeLayout)
+              .VerifyBroadcastDimensionsOrder()
+              .VerifyReshapeIsBitcast()),
+      "end-of-post-layout_assignment");
 
   TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
 

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1470,6 +1470,9 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
                            /*only_fusion_computations=*/false,
                            /*ignore_control_dependencies=*/true);
 
+#ifdef NDEBUG
+  // Verify the module in non-debug builds. For debug builds, the verifier
+  // already runs after every pass.
   pipeline.AddPass<HloVerifier>(
       std::make_unique<DefaultVerifierMetadata>(
           HloVerifierOpts{}
@@ -1479,6 +1482,7 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
               .VerifyBroadcastDimensionsOrder()
               .VerifyReshapeIsBitcast()),
       "end-of-post-layout_assignment");
+#endif  // NDEBUG
 
   TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
 


### PR DESCRIPTION
Currently, the GPU pipeline only turns the verifier around float normalization on only in debug. If float normalization generates ill-typed IR, the compiler can produce invalid code without anything failing. This patch turns the verification always on.