### PR TITLE
[Draft][XLA:GPU] Add sycl runtime

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -293,6 +293,11 @@ build:rocm --define=using_rocm_hipcc=true
 build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
 build:rocm --repo_env TF_NEED_ROCM=1
 
+build:sycl --crosstool_top=@local_config_sycl//crosstool:toolchain
+build:sycl --define=using_sycl=true
+build:sycl --define=tensorflow_mkldnn_contraction_kernel=0
+build:sycl --repo_env TF_NEED_SYCL=1
+
 # Options to disable default on features
 build:noaws --define=no_aws_support=true
 build:nogcp --define=no_gcp_support=true

--- a/third_party/tsl/third_party/gpus/crosstool/BUILD.sycl.tpl
+++ b/third_party/tsl/third_party/gpus/crosstool/BUILD.sycl.tpl
@@ -1,0 +1,71 @@
+# This file is expanded from a template sycl_configure.bzl
+# Update sycl_configure.bzl#verify_build_defines when adding new variables.
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+licenses(["restricted"])
+
+package(default_visibility = ["//visibility:public"])
+
+toolchain(
+    name = "toolchain-linux-x86_64",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    toolchain = ":cc-compiler-local",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+cc_toolchain_suite(
+    name = "toolchain",
+    toolchains = {
+        "local|compiler": ":cc-compiler-local",
+        "k8": ":cc-compiler-local",
+    },
+)
+
+cc_toolchain(
+    name = "cc-compiler-local",
+    all_files = ":crosstool_wrapper_driver_is_not_gcc",
+    compiler_files = ":crosstool_wrapper_driver_is_not_gcc",
+    ar_files = ":crosstool_wrapper_driver_is_not_gcc",
+    as_files = ":crosstool_wrapper_driver_is_not_gcc",
+    dwp_files = ":empty",
+    linker_files = ":crosstool_wrapper_driver_is_not_gcc",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    # To support linker flags that need to go to the start of command line
+    # we need the toolchain to support parameter files. Parameter files are
+    # last on the command line and contain all shared libraries to link, so all
+    # regular options will be left of them.
+    supports_param_files = 1,
+    toolchain_identifier = "local_linux",
+    toolchain_config = ":cc-compiler-local-config",
+)
+
+cc_toolchain_config(
+    name = "cc-compiler-local-config",
+    cpu = "local",
+    builtin_include_directories = [%{cxx_builtin_include_directories}],
+    extra_no_canonical_prefixes_flags = [%{extra_no_canonical_prefixes_flags}],
+    host_compiler_path = "%{host_compiler_path}",
+    host_compiler_prefix = "%{host_compiler_prefix}",
+    host_unfiltered_compile_flags = [%{unfiltered_compile_flags}],
+    linker_bin_path = "%{linker_bin_path}",
+    compiler = "unknown",
+)
+
+filegroup(
+    name = "empty",
+    srcs = [],
+)
+
+filegroup(
+    name = "crosstool_wrapper_driver_is_not_gcc",
+    srcs = ["clang/bin/crosstool_wrapper_driver_is_not_gcc"]
+)

--- a/third_party/tsl/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_sycl.tpl
+++ b/third_party/tsl/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_sycl.tpl
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Crosstool wrapper for compiling SYCL program
+
+SYNOPSIS:
+  crosstool_wrapper_driver_sycl [options passed in by cc_library()
+                                or cc_binary() rule]
+
+DESCRIPTION:
+  This script is expected to be called by the cc_library() or cc_binary() bazel
+  rules. When the option "sycl_compile" is present in the list of arguments passed
+  to this script, it invokes the sycl compiler. When "sycl_compile" is not
+  present, this wrapper invokes gcc with the input arguments as is.
+"""
+
+from __future__ import print_function
+from argparse import ArgumentParser
+import os
+import subprocess
+import sys
+import shlex
+
+CPU_COMPILER = ('%{cpu_compiler}')
+
+def system(cmd):
+  """Invokes cmd with os.system()"""
+  
+  ret = os.system(cmd)
+  if os.WIFEXITED(ret):
+    return os.WEXITSTATUS(ret)
+  else:
+    return -os.WTERMSIG(ret)
+
+def call_compiler(argv):
+  parser = ArgumentParser()
+  parser.add_argument('-c', nargs=1, action='append')
+  parser.add_argument('-o', nargs=1, action='append')
+  args, leftover = parser.parse_known_args(argv)
+
+  flags = leftover
+
+  common_flags = []
+  common_flags.append("-fno-finite-math-only")
+  common_flags.append("-fno-fast-math")
+  common_flags.append("-fexceptions")
+
+  in_files, out_files = [], []
+  if args.c:
+    in_files.append('-c')
+    in_files.extend(args.c[0])
+  if args.o:
+    out_files.append('-o')
+    out_files.extend(args.o[0])
+  flags += (common_flags + in_files + out_files)
+  print("cmd: ", " ".join([CPU_COMPILER] + flags))
+  return subprocess.call([CPU_COMPILER] + flags)
+
+def main():
+  parser = ArgumentParser()
+  parser = ArgumentParser(fromfile_prefix_chars='@')
+  parser.add_argument('-sycl_compile', action='store_true')
+  args, leftover = parser.parse_known_args(sys.argv[1:])
+
+  return call_compiler(leftover)
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/third_party/tsl/third_party/gpus/crosstool/sycl_cc_toolchain_config.bzl.tpl
+++ b/third_party/tsl/third_party/gpus/crosstool/sycl_cc_toolchain_config.bzl.tpl
@@ -1,0 +1,598 @@
+"""cc_toolchain_config rule for configuring SYCL toolchains on Linux."""
+
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "action_config",
+    "artifact_name_pattern",
+    "env_entry",
+    "env_set",
+    "feature",
+    "feature_set",
+    "flag_group",
+    "flag_set",
+    "tool",
+    "tool_path",
+    "variable_with_value",
+    "with_feature_set",
+)
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+def all_assembly_actions():
+    return [
+        ACTION_NAMES.assemble,
+        ACTION_NAMES.preprocess_assemble,
+    ]
+
+def all_compile_actions():
+    return [
+        ACTION_NAMES.assemble,
+        ACTION_NAMES.c_compile,
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.cpp_header_parsing,
+        ACTION_NAMES.cpp_module_codegen,
+        ACTION_NAMES.cpp_module_compile,
+        ACTION_NAMES.linkstamp_compile,
+        ACTION_NAMES.preprocess_assemble,
+    ]
+
+def all_c_compile_actions():
+    return [
+        ACTION_NAMES.c_compile,
+    ]
+
+def all_cpp_compile_actions():
+    return [
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.cpp_header_parsing,
+        ACTION_NAMES.cpp_module_codegen,
+        ACTION_NAMES.cpp_module_compile,
+        ACTION_NAMES.linkstamp_compile,
+    ]
+
+def all_preprocessed_actions():
+    return [
+        ACTION_NAMES.c_compile,
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.cpp_header_parsing,
+        ACTION_NAMES.cpp_module_codegen,
+        ACTION_NAMES.cpp_module_compile,
+        ACTION_NAMES.linkstamp_compile,
+        ACTION_NAMES.preprocess_assemble,
+    ]
+
+def all_link_actions():
+    return [
+        ACTION_NAMES.cpp_link_executable,
+        ACTION_NAMES.cpp_link_dynamic_library,
+        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+    ]
+
+def all_executable_link_actions():
+    return [
+        ACTION_NAMES.cpp_link_executable,
+    ]
+
+def all_shared_library_link_actions():
+    return [
+        ACTION_NAMES.cpp_link_dynamic_library,
+        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+    ]
+
+def all_archive_actions():
+    return [ACTION_NAMES.cpp_link_static_library]
+
+def all_strip_actions():
+    return [ACTION_NAMES.strip]
+
+def _library_to_link(flag_prefix, value, iterate = None):
+    return flag_group(
+        flags = [
+            "{}%{{libraries_to_link.{}}}".format(
+                flag_prefix,
+                iterate if iterate else "name",
+            ),
+        ],
+        iterate_over = ("libraries_to_link." + iterate if iterate else None),
+        expand_if_equal = variable_with_value(
+            name = "libraries_to_link.type",
+            value = value,
+        ),
+    )
+
+def _surround_static_library(prefix, suffix):
+    return [
+        flag_group(
+            flags = [prefix, "%{libraries_to_link.name}", suffix],
+            expand_if_true = "libraries_to_link.is_whole_archive",
+        ),
+        flag_group(
+            flags = ["%{libraries_to_link.name}"],
+            expand_if_false = "libraries_to_link.is_whole_archive",
+        ),
+    ]
+
+def _prefix_static_library(prefix):
+    return [
+        flag_group(
+            flags = ["%{libraries_to_link.name}"],
+            expand_if_false = "libraries_to_link.is_whole_archive",
+        ),
+        flag_group(
+            flags = [prefix + "%{libraries_to_link.name}"],
+            expand_if_true = "libraries_to_link.is_whole_archive",
+        ),
+    ]
+
+def _static_library_to_link(alwayslink_prefix, alwayslink_suffix = None):
+    if alwayslink_suffix:
+        flag_groups = _surround_static_library(alwayslink_prefix, alwayslink_suffix)
+    else:
+        flag_groups = _prefix_static_library(alwayslink_prefix)
+    return flag_group(
+        flag_groups = flag_groups,
+        expand_if_equal = variable_with_value(
+            name = "libraries_to_link.type",
+            value = "static_library",
+        ),
+    )
+
+def _iterate_flag_group(iterate_over, flags = [], flag_groups = []):
+    return flag_group(
+        iterate_over = iterate_over,
+        expand_if_available = iterate_over,
+        flag_groups = flag_groups,
+        flags = flags,
+    )
+
+def _libraries_to_link_group(flavour):
+    if flavour == "linux":
+        return _iterate_flag_group(
+            iterate_over = "libraries_to_link",
+            flag_groups = [
+                flag_group(
+                    flags = ["-Wl,--start-lib"],
+                    expand_if_equal = variable_with_value(
+                        name = "libraries_to_link.type",
+                        value = "object_file_group",
+                    ),
+                ),
+                _library_to_link("", "object_file_group", "object_files"),
+                flag_group(
+                    flags = ["-Wl,--end-lib"],
+                    expand_if_equal = variable_with_value(
+                        name = "libraries_to_link.type",
+                        value = "object_file_group",
+                    ),
+                ),
+                _library_to_link("", "object_file"),
+                _library_to_link("", "interface_library"),
+                _static_library_to_link("-Wl,-whole-archive", "-Wl,-no-whole-archive"),
+                _library_to_link("-l", "dynamic_library"),
+                _library_to_link("-l:", "versioned_dynamic_library"),
+            ],
+        )
+
+def _action_configs_with_tool(path, actions):
+    return [
+        action_config(
+            action_name = name,
+            enabled = True,
+            tools = [tool(path = path)],
+        )
+        for name in actions
+    ]
+
+def _action_configs(assembly_path, c_compiler_path, cc_compiler_path, archiver_path, linker_path, strip_path):
+    return _action_configs_with_tool(
+        assembly_path,
+        all_assembly_actions(),
+    ) + _action_configs_with_tool(
+        c_compiler_path,
+        all_c_compile_actions(),
+    ) + _action_configs_with_tool(
+        cc_compiler_path,
+        all_cpp_compile_actions(),
+    ) + _action_configs_with_tool(
+        archiver_path,
+        all_archive_actions(),
+    ) + _action_configs_with_tool(
+        linker_path,
+        all_link_actions(),
+    ) + _action_configs_with_tool(
+        strip_path,
+        all_strip_actions(),
+    )
+
+def _tool_paths(cpu, ctx):
+    if cpu == "local":
+        return [
+            tool_path(name = "gcc", path = ctx.attr.host_compiler_path),
+            tool_path(name = "ar", path = ctx.attr.host_compiler_prefix + "/ar"),
+            tool_path(name = "compat-ld", path = ctx.attr.host_compiler_prefix + "/ld"),
+            tool_path(name = "cpp", path = ctx.attr.host_compiler_prefix + "/cpp"),
+            tool_path(name = "dwp", path = ctx.attr.host_compiler_prefix + "/dwp"),
+            tool_path(name = "gcov", path = ctx.attr.host_compiler_prefix + "/gcov"),
+            tool_path(name = "ld", path = ctx.attr.host_compiler_prefix + "/ld"),
+            tool_path(name = "nm", path = ctx.attr.host_compiler_prefix + "/nm"),
+            tool_path(name = "objcopy", path = ctx.attr.host_compiler_prefix + "/objcopy"),
+            tool_path(name = "objdump", path = ctx.attr.host_compiler_prefix + "/objdump"),
+            tool_path(name = "strip", path = ctx.attr.host_compiler_prefix + "/strip"),
+        ]
+    else:
+        fail("Unreachable")
+
+def _sysroot_group():
+    return flag_group(
+        flags = ["--sysroot=%{sysroot}"],
+        expand_if_available = "sysroot",
+    )
+
+def _no_canonical_prefixes_group(extra_flags):
+    return flag_group(
+        flags = [
+            "-no-canonical-prefixes",
+        ] + extra_flags,
+    )
+
+def _nologo():
+    return flag_group(flags = ["/nologo"])
+
+def _features(cpu, compiler, ctx):
+    if cpu == "local":
+        return [
+            feature(name = "no_legacy_features"),
+            feature(
+                name = "all_compile_flags",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = all_compile_actions(),
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-MD", "-MF", "%{dependency_file}"],
+                                expand_if_available = "dependency_file",
+                            ),
+                            flag_group(
+                                flags = ["-gsplit-dwarf"],
+                                expand_if_available = "per_object_debug_info_file",
+                            ),
+                        ],
+                    ),
+                    flag_set(
+                        actions = all_preprocessed_actions(),
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-frandom-seed=%{output_file}"],
+                                expand_if_available = "output_file",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["-D%{preprocessor_defines}"],
+                                iterate_over = "preprocessor_defines",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["-include", "%{includes}"],
+                                iterate_over = "includes",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["-iquote", "%{quote_include_paths}"],
+                                iterate_over = "quote_include_paths",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["-I%{include_paths}"],
+                                iterate_over = "include_paths",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["-isystem", "%{system_include_paths}"],
+                                iterate_over = "system_include_paths",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["-F", "%{framework_include_paths}"],
+                                iterate_over = "framework_include_paths",
+                            ),
+                        ] + ([
+                            flag_group(flags = ctx.attr.host_unfiltered_compile_flags),
+                        ] if ctx.attr.host_unfiltered_compile_flags else []),
+                    ),
+                    flag_set(
+                        actions = all_cpp_compile_actions(),
+                        flag_groups = [
+                            flag_group(flags = [
+                                "-fmerge-all-constants",
+                            ]),
+                        ] if compiler == "clang" else [],
+                    ),
+                    flag_set(
+                        actions = all_compile_actions(),
+                        flag_groups = [
+                            flag_group(
+                                flags = [
+                                    "-Wno-builtin-macro-redefined",
+                                    "-D__DATE__=\"redacted\"",
+                                    "-D__TIMESTAMP__=\"redacted\"",
+                                    "-D__TIME__=\"redacted\"",
+                                ],
+                            ),
+                            flag_group(
+                                flags = ["-fPIC"],
+                                expand_if_available = "pic",
+                            ),
+                            flag_group(
+                                flags = ["-fPIE"],
+                                expand_if_not_available = "pic",
+                            ),
+                            flag_group(
+                                flags = [
+                                    "-U_FORTIFY_SOURCE",
+                                    "-D_FORTIFY_SOURCE=1",
+                                    "-fstack-protector",
+                                    "-Wall",
+                                ] + ctx.attr.host_compiler_warnings + [
+                                    "-fno-omit-frame-pointer",
+                                ],
+                            ),
+                            _no_canonical_prefixes_group(
+                                ctx.attr.extra_no_canonical_prefixes_flags,
+                            ),
+                        ],
+                    ),
+                    flag_set(
+                        actions = all_compile_actions(),
+                        flag_groups = [flag_group(flags = ["-DNDEBUG"])],
+                        with_features = [with_feature_set(features = ["disable-assertions"])],
+                    ),
+                    flag_set(
+                        actions = all_compile_actions(),
+                        flag_groups = [
+                            flag_group(
+                                flags = [
+                                    "-g0",
+                                    "-O2",
+                                    "-ffunction-sections",
+                                    "-fdata-sections",
+                                ],
+                            ),
+                        ],
+                        with_features = [with_feature_set(features = ["opt"])],
+                    ),
+                    flag_set(
+                        actions = all_compile_actions(),
+                        flag_groups = [flag_group(flags = ["-g"])],
+                        with_features = [with_feature_set(features = ["dbg"])],
+                    ),
+                ] + [
+                    flag_set(
+                        actions = all_compile_actions(),
+                        flag_groups = [
+                            _iterate_flag_group(
+                                flags = ["%{user_compile_flags}"],
+                                iterate_over = "user_compile_flags",
+                            ),
+                            _sysroot_group(),
+                            flag_group(
+                                expand_if_available = "source_file",
+                                flags = ["-c", "%{source_file}"],
+                            ),
+                            flag_group(
+                                expand_if_available = "output_assembly_file",
+                                flags = ["-S"],
+                            ),
+                            flag_group(
+                                expand_if_available = "output_preprocess_file",
+                                flags = ["-E"],
+                            ),
+                            flag_group(
+                                expand_if_available = "output_file",
+                                flags = ["-o", "%{output_file}"],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            feature(
+                name = "all_archive_flags",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = all_archive_actions(),
+                        flag_groups = [
+                            flag_group(
+                                expand_if_available = "linker_param_file",
+                                flags = ["@%{linker_param_file}"],
+                            ),
+                            flag_group(flags = ["rcsD"]),
+                            flag_group(
+                                flags = ["%{output_execpath}"],
+                                expand_if_available = "output_execpath",
+                            ),
+                            flag_group(
+                                iterate_over = "libraries_to_link",
+                                flag_groups = [
+                                    flag_group(
+                                        flags = ["%{libraries_to_link.name}"],
+                                        expand_if_equal = variable_with_value(
+                                            name = "libraries_to_link.type",
+                                            value = "object_file",
+                                        ),
+                                    ),
+                                    flag_group(
+                                        flags = ["%{libraries_to_link.object_files}"],
+                                        iterate_over = "libraries_to_link.object_files",
+                                        expand_if_equal = variable_with_value(
+                                            name = "libraries_to_link.type",
+                                            value = "object_file_group",
+                                        ),
+                                    ),
+                                ],
+                                expand_if_available = "libraries_to_link",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            feature(
+                name = "all_link_flags",
+                enabled = True,
+                flag_sets = [
+                    flag_set(
+                        actions = all_shared_library_link_actions(),
+                        flag_groups = [flag_group(flags = ["-shared"])],
+                    ),
+                    flag_set(
+                        actions = all_link_actions(),
+                        flag_groups = ([
+                            flag_group(flags = ["-Wl,-no-as-needed"]),
+                        ] if cpu == "local" else []) + ([
+                            flag_group(flags = ["-B" + ctx.attr.linker_bin_path]),
+                        ] if ctx.attr.linker_bin_path else []) + [
+                            flag_group(
+                                flags = ["@%{linker_param_file}"],
+                                expand_if_available = "linker_param_file",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["%{linkstamp_paths}"],
+                                iterate_over = "linkstamp_paths",
+                            ),
+                            flag_group(
+                                flags = ["-o", "%{output_execpath}"],
+                                expand_if_available = "output_execpath",
+                            ),
+                            _iterate_flag_group(
+                                flags = ["-L%{library_search_directories}"],
+                                iterate_over = "library_search_directories",
+                            ),
+                            _iterate_flag_group(
+                                iterate_over = "runtime_library_search_directories",
+                                flags = [
+                                    "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
+                                ] if cpu == "local" else [
+                                    "-Wl,-rpath,@loader_path/%{runtime_library_search_directories}",
+                                ],
+                            ),
+                            _libraries_to_link_group("linux"),
+                            _iterate_flag_group(
+                                flags = ["%{user_link_flags}"],
+                                iterate_over = "user_link_flags",
+                            ),
+                            flag_group(
+                                flags = ["-Wl,--gdb-index"],
+                                expand_if_available = "is_using_fission",
+                            ),
+                            flag_group(
+                                flags = ["-Wl,-S"],
+                                expand_if_available = "strip_debug_symbols",
+                            ),
+                            flag_group(flags = ["-lstdc++"]),
+                            _no_canonical_prefixes_group(
+                                ctx.attr.extra_no_canonical_prefixes_flags,
+                            ),
+                        ],
+                    ),
+                    flag_set(
+                        actions = all_executable_link_actions(),
+                        flag_groups = [flag_group(flags = ["-pie"])],
+                    ),
+                ] + ([
+                    flag_set(
+                        actions = all_link_actions(),
+                        flag_groups = [flag_group(flags = [
+                            "-Wl,-z,relro,-z,now",
+                        ])],
+                    ),
+                ]) + ([
+                    flag_set(
+                        actions = all_link_actions(),
+                        flag_groups = [
+                            flag_group(flags = ["-Wl,--gc-sections"]),
+                            flag_group(
+                                flags = ["-Wl,--build-id=md5", "-Wl,--hash-style=gnu"],
+                            ),
+                        ],
+                    ),
+                ]) + [
+                    flag_set(
+                        actions = all_link_actions(),
+                        flag_groups = [
+                            _sysroot_group(),
+                        ],
+                    ),
+                ],
+            ),
+            feature(name = "disable-assertions"),
+            feature(
+                name = "opt",
+                implies = ["disable-assertions"],
+            ),
+            feature(name = "fastbuild"),
+            feature(name = "dbg"),
+            feature(name = "supports_dynamic_linker", enabled = True),
+            feature(name = "pic", enabled = True),
+            feature(name = "supports_pic", enabled = True),
+            feature(name = "has_configured_linker_path", enabled = True),
+        ]
+    else:
+        fail("Unreachable")
+
+def _impl(ctx):
+    cpu = ctx.attr.cpu
+    compiler = ctx.attr.compiler
+
+    if (cpu == "local"):
+        toolchain_identifier = "local_linux"
+        target_cpu = "local"
+        target_libc = "local"
+        action_configs = _action_configs(
+            assembly_path = ctx.attr.host_compiler_path,
+            c_compiler_path = ctx.attr.host_compiler_path,
+            cc_compiler_path = ctx.attr.host_compiler_path,
+            archiver_path = ctx.attr.host_compiler_prefix + "/ar",
+            linker_path = ctx.attr.host_compiler_path,
+            strip_path = ctx.attr.host_compiler_prefix + "/strip",
+        )
+        artifact_name_patterns = []
+    else:
+        fail("Unreachable")
+
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(out, "Fake executable")
+    return [
+        cc_common.create_cc_toolchain_config_info(
+            ctx = ctx,
+            features = _features(cpu, compiler, ctx),
+            action_configs = action_configs,
+            artifact_name_patterns = artifact_name_patterns,
+            cxx_builtin_include_directories = ctx.attr.builtin_include_directories,
+            toolchain_identifier = toolchain_identifier,
+            host_system_name = "local",
+            target_system_name = "local",
+            target_cpu = target_cpu,
+            target_libc = target_libc,
+            compiler = compiler,
+            abi_version = "local",
+            abi_libc_version = "local",
+            tool_paths = _tool_paths(cpu, ctx),
+            make_variables = [],
+            builtin_sysroot = ctx.attr.builtin_sysroot,
+            cc_target_os = None,
+        ),
+        DefaultInfo(
+            executable = out,
+        ),
+    ]
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {
+        "cpu": attr.string(mandatory = True, values = ["local"]),
+        "compiler": attr.string(values = ["clang", "unknown"], default = "unknown"),
+        "builtin_include_directories": attr.string_list(),
+        "extra_no_canonical_prefixes_flags": attr.string_list(),
+        "host_compiler_path": attr.string(),
+        "host_compiler_prefix": attr.string(),
+        "host_compiler_warnings": attr.string_list(),
+        "host_unfiltered_compile_flags": attr.string_list(),
+        "linker_bin_path": attr.string(),
+        "builtin_sysroot": attr.string(),
+    },
+    provides = [CcToolchainConfigInfo],
+    executable = True,
+)

--- a/third_party/tsl/third_party/gpus/find_sycl_config.py
+++ b/third_party/tsl/third_party/gpus/find_sycl_config.py
@@ -1,0 +1,132 @@
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Prints SYCL library and header directories and versions found on the system.
+
+The script searches for SYCL library and header files on the system, inspects
+them to determine their version and prints the configuration to stdout.
+The path to inspect is specified through an environment variable (SYCL_PATH).
+If no valid configuration is found, the script prints to stderr and
+returns an error code.
+
+The script takes the directory specified by the SYCL_PATH environment variable.
+The script looks for headers and library files in a hard-coded set of
+subdirectories from base path of the specified directory. If SYCL_PATH is not
+specified, then "/opt/sycl" is used as it default value
+
+"""
+
+import io
+import os
+import re
+import sys
+
+
+class ConfigError(Exception):
+  pass
+
+def _get_default_sycl_toolkit_path():
+  return "/opt/intel/oneapi/compiler/latest"
+
+def _get_toolkit_path():
+  """Determines and returns the SYCL installation path."""
+  sycl_toolkit_path = None
+  sycl_toolkit_path = _get_default_sycl_toolkit_path()
+  if "SYCL_TOOLKIT_PATH" in os.environ:
+    sycl_toolkit_path = os.environ["SYCL_TOOLKIT_PATH"]
+  return os.path.realpath(sycl_toolkit_path)
+
+def _get_basekit_path():
+  return _get_toolkit_path().split("/compiler/")[0]
+
+def _get_basekit_version():
+  return _get_toolkit_path().split("/compiler/")[1].split("/")[0]
+
+def _get_composite_version_number(major, minor, patch):
+  return 10000 * major + 100 * minor + patch
+
+
+def _get_header_version(path, name):
+  """Returns preprocessor defines in C header file."""
+  for line in io.open(path, "r", encoding="utf-8"):
+    match = re.match(r"#define %s +(\d+)" % name, line)
+    if match:
+      value = match.group(1)
+      return int(value)
+
+  raise ConfigError('#define "{}" is either\n'.format(name) +
+                    "  not present in file {} OR\n".format(path) +
+                    "  its value is not an integer literal")
+
+
+def _find_sycl_config(basekit_path):
+
+  def sycl_version_numbers(path):
+    possible_version_files = [
+        "compiler/latest/linux/include/sycl/version.hpp",
+        "compiler/latest/include/sycl/version.hpp",
+    ]
+    version_file = None
+    for f in possible_version_files:
+      version_file_path = os.path.join(path, f)
+      if os.path.exists(version_file_path):
+        version_file = version_file_path
+        break
+    if not version_file:
+      raise ConfigError(
+          "SYCL version file not found in {}".format(possible_version_files))
+
+    major = _get_header_version(version_file, "__LIBSYCL_MAJOR_VERSION")
+    minor = _get_header_version(version_file, "__LIBSYCL_MINOR_VERSION")
+    patch = _get_header_version(version_file, "__LIBSYCL_PATCH_VERSION")
+    return major, minor, patch
+
+  major, minor, patch = sycl_version_numbers(basekit_path)
+
+  sycl_config = {
+      "sycl_version_number": _get_composite_version_number(major, minor, patch),
+      "sycl_basekit_version_number": _get_basekit_version(),
+  }
+
+  return sycl_config
+
+
+def find_sycl_config():
+  """Returns a dictionary of SYCL components config info."""
+  basekit_path = _get_basekit_path()
+  toolkit_path = _get_toolkit_path()
+  if not os.path.exists(basekit_path):
+    raise ConfigError(
+        'Specified SYCL_TOOLKIT_PATH "{}" does not exist'.format(basekit_path))
+
+  result = {}
+
+  result["sycl_basekit_path"] = basekit_path
+  result["sycl_toolkit_path"] = toolkit_path
+  result.update(_find_sycl_config(basekit_path))
+
+  return result
+
+
+def main():
+  try:
+    for key, value in sorted(find_sycl_config().items()):
+      print("%s: %s" % (key, value))
+  except ConfigError as e:
+    sys.stderr.write("\nERROR: {}\n\n".format(str(e)))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/third_party/tsl/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/tsl/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -39,6 +39,10 @@ def rocm_version_number():
     return %{rocm_version_number}
 
 def if_gpu_is_configured(if_true, if_false = []):
+    """Tests if ROCm or CUDA or SYCL was enabled during the configure process."""
+    return select({"//conditions:default": %{gpu_is_configured}})
+
+def if_cuda_or_rocm(if_true, if_false = []):
     """Tests if ROCm or CUDA was enabled during the configure process.
 
     Unlike if_rocm() or if_cuda(), this does not require that we are building
@@ -46,7 +50,7 @@ def if_gpu_is_configured(if_true, if_false = []):
     code to depend on ROCm or CUDA libraries.
 
     """
-    return select({"//conditions:default": %{gpu_is_configured}})
+    return select({"//conditions:default": %{cuda_or_rocm}})
 
 def if_rocm_is_configured(x):
     """Tests if the ROCm was enabled during the configure process.

--- a/third_party/tsl/third_party/gpus/rocm_configure.bzl
+++ b/third_party/tsl/third_party/gpus/rocm_configure.bzl
@@ -16,6 +16,10 @@ load(
     "to_list_of_strings",
 )
 load(
+    ":sycl_configure.bzl",
+    "enable_sycl",
+)
+load(
     "//third_party/remote_config:common.bzl",
     "config_repo_label",
     "err_out",
@@ -450,7 +454,8 @@ def _create_dummy_repository(repository_ctx):
         "rocm:build_defs.bzl",
         {
             "%{rocm_is_configured}": "False",
-            "%{gpu_is_configured}": "if_true" if enable_cuda(repository_ctx) else "if_false",
+            "%{gpu_is_configured}": "if_true" if enable_cuda(repository_ctx) or enable_sycl(repository_ctx) else "if_false",
+            "%{cuda_or_rocm}": "if_true" if enable_cuda(repository_ctx) else "if_false",
             "%{rocm_extra_copts}": "[]",
             "%{rocm_gpu_architectures}": "[]",
             "%{rocm_version_number}": "0",
@@ -637,6 +642,7 @@ def _create_local_rocm_repository(repository_ctx):
         {
             "%{rocm_is_configured}": "True",
             "%{gpu_is_configured}": "if_true",
+            "%{cuda_or_rocm}": "if_true",
             "%{rocm_extra_copts}": _compute_rocm_extra_copts(
                 repository_ctx,
                 rocm_config.amdgpu_targets,
@@ -766,6 +772,7 @@ def _create_remote_rocm_repository(repository_ctx, remote_config_repo):
         {
             "%{rocm_is_configured}": "True",
             "%{gpu_is_configured}": "if_true",
+            "%{cuda_or_rocm}": "if_true",
             "%{rocm_extra_copts}": _compute_rocm_extra_copts(
                 repository_ctx,
                 [],  #_compute_capabilities(repository_ctx)

--- a/third_party/tsl/third_party/gpus/sycl/BUILD
+++ b/third_party/tsl/third_party/gpus/sycl/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/third_party/tsl/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/tsl/third_party/gpus/sycl/BUILD.tpl
@@ -23,10 +23,10 @@ cc_library(
 cc_library(
     name = "sycl",
     srcs = [
-        %{core_sycl_libs},
+        %{core_sycl_libs}
     ],
     data = [
-        %{core_sycl_libs},
+        %{core_sycl_libs}
     ],
     includes = [
         ".",
@@ -43,13 +43,13 @@ cc_library(
         "sycl/lib/%{mkl_intel_ilp64_lib}",
         "sycl/lib/%{mkl_sequential_lib}",
         "sycl/lib/%{mkl_core_lib}",
-        %{mkl_sycl_libs},
+        %{mkl_sycl_libs}
     ],
     data = [
         "sycl/lib/%{mkl_intel_ilp64_lib}",
         "sycl/lib/%{mkl_sequential_lib}",
         "sycl/lib/%{mkl_core_lib}",
-        %{mkl_sycl_libs},
+        %{mkl_sycl_libs}
     ],
     includes = [
         ".",

--- a/third_party/tsl/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/tsl/third_party/gpus/sycl/BUILD.tpl
@@ -1,0 +1,63 @@
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "using_sycl",
+    values = {
+        "define": "using_sycl=true",
+    },
+)
+
+cc_library(
+    name = "sycl_headers",
+    hdrs = [
+        %{sycl_headers}
+    ],
+    includes = [
+        ".",
+        "sycl/include",
+        "sycl/include/sycl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "sycl",
+    srcs = [
+        %{core_sycl_libs},
+    ],
+    data = [
+        %{core_sycl_libs},
+    ],
+    includes = [
+        ".",
+        "sycl/include",
+    ],
+    linkopts = ["-lze_loader"],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mkl",
+    srcs = [
+        "sycl/lib/%{mkl_intel_ilp64_lib}",
+        "sycl/lib/%{mkl_sequential_lib}",
+        "sycl/lib/%{mkl_core_lib}",
+        %{mkl_sycl_libs},
+    ],
+    data = [
+        "sycl/lib/%{mkl_intel_ilp64_lib}",
+        "sycl/lib/%{mkl_sequential_lib}",
+        "sycl/lib/%{mkl_core_lib}",
+        %{mkl_sycl_libs},
+    ],
+    includes = [
+        ".",
+        "sycl/include",
+    ],
+    # linkopts = ["-Wl,-Bstatic,-lsvml,-lirng,-limf,-lirc,-lirc_s,-Bdynamic"],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+)
+
+%{copy_rules}

--- a/third_party/tsl/third_party/gpus/sycl/build_defs.bzl.tpl
+++ b/third_party/tsl/third_party/gpus/sycl/build_defs.bzl.tpl
@@ -1,0 +1,39 @@
+# Macros for building SYCL code.
+def if_sycl(if_true, if_false = []):
+    """Shorthand for select()'ing on whether we're building with SYCL.
+
+    Returns a select statement which evaluates to if_true if we're building
+    with SYCL enabled.  Otherwise, the select statement evaluates to if_false.
+
+    """
+    return select({
+        "@local_config_sycl//sycl:using_sycl": if_true,
+        "//conditions:default": if_false,
+    })
+
+def sycl_default_copts():
+    """Default options for all SYCL compilations."""
+    return if_sycl(["-x", "sycl"])
+
+def sycl_build_is_configured():
+    """Returns true if SYCL compiler was enabled during the configure process."""
+    return %{sycl_build_is_configured}
+
+def if_sycl_is_configured(x):
+    """Tests if the SYCL was enabled during the configure process.
+
+    Unlike if_sycl(), this does not require that we are building with
+    --config=sycl. Used to allow non-SYCL code to depend on SYCL libraries.
+    """
+    if %{sycl_is_configured}:
+      return select({"//conditions:default": x})
+    return select({"//conditions:default": []})
+
+def if_sycl_build_is_configured(x, y):
+    if sycl_build_is_configured():
+      return x
+    return y
+
+def sycl_library(copts = [], **kwargs):
+    """Wrapper over cc_library which adds default SYCL options."""
+    native.cc_library(copts = sycl_default_copts() + copts, **kwargs)

--- a/third_party/tsl/third_party/gpus/sycl_configure.bzl
+++ b/third_party/tsl/third_party/gpus/sycl_configure.bzl
@@ -1,0 +1,535 @@
+"""Repository rule for SYCL autoconfiguration.
+
+`sycl_configure` depends on the following environment variables:
+"""
+
+load(
+    ":cuda_configure.bzl",
+    "make_copy_dir_rule",
+    "make_copy_files_rule",
+    "to_list_of_strings",
+)
+load(
+    "//third_party/remote_config:common.bzl",
+    "config_repo_label",
+    "err_out",
+    "execute",
+    "files_exist",
+    "get_bash_bin",
+    "get_cpu_value",
+    "get_host_environ",
+    "get_python_bin",
+    "raw_exec",
+    "realpath",
+    "which",
+)
+
+_GCC_HOST_COMPILER_PATH = "GCC_HOST_COMPILER_PATH"
+_GCC_HOST_COMPILER_PREFIX = "GCC_HOST_COMPILER_PREFIX"
+
+def _mkl_path(sycl_config):
+    return sycl_config.sycl_basekit_path + "/mkl/" + sycl_config.sycl_basekit_version_number
+
+def _sycl_header_path(repository_ctx, sycl_config, bash_bin):
+    sycl_header_path = sycl_config.sycl_basekit_path + "/compiler/" + sycl_config.sycl_basekit_version_number
+    include_dir = sycl_header_path + "/include"
+    if not files_exist(repository_ctx, [include_dir], bash_bin)[0]:
+        sycl_header_path = sycl_header_path + "/linux"
+        include_dir = sycl_header_path + "/include"
+        if not files_exist(repository_ctx, [include_dir], bash_bin)[0]:
+            auto_configure_fail("Cannot find sycl headers in {}".format(include_dir))
+    return sycl_header_path
+
+def _sycl_include_path(repository_ctx, sycl_config, bash_bin):
+    """Generates the cxx_builtin_include_directory entries for sycl inc dirs.
+
+    Args:
+      repository_ctx: The repository context.
+      sycl_config: The path to the gcc host compiler.
+
+    Returns:
+      A string containing the Starlark string for each of the gcc
+      host compiler include directories, which can be added to the CROSSTOOL
+      file.
+    """
+    inc_dirs = []
+
+    inc_dirs.append(_mkl_path(sycl_config) + "/include")
+    inc_dirs.append(_sycl_header_path(repository_ctx, sycl_config, bash_bin) + "/include")
+    inc_dirs.append(_sycl_header_path(repository_ctx, sycl_config, bash_bin) + "/include/sycl")
+
+    return inc_dirs
+
+def enable_sycl(repository_ctx):
+    """Returns whether to build with SYCL support."""
+    return int(get_host_environ(repository_ctx, "TF_NEED_SYCL", False))
+
+def auto_configure_fail(msg):
+    """Output failure message when auto configuration fails."""
+    red = "\033[0;31m"
+    no_color = "\033[0m"
+    fail("\n%sAuto-Configuration Error:%s %s\n" % (red, no_color, msg))
+
+def find_cc(repository_ctx):
+    """Find the C++ compiler."""
+
+    # Return a dummy value for GCC detection here to avoid error
+    target_cc_name = "gcc"
+    cc_path_envvar = _GCC_HOST_COMPILER_PATH
+    cc_name = target_cc_name
+
+    cc_name_from_env = get_host_environ(repository_ctx, cc_path_envvar)
+    if cc_name_from_env:
+        cc_name = cc_name_from_env
+    if cc_name.startswith("/"):
+        # Absolute path, maybe we should make this supported by our which function.
+        return cc_name
+    cc = which(repository_ctx, cc_name)
+    if cc == None:
+        fail(("Cannot find {}, either correct your path or set the {}" +
+              " environment variable").format(target_cc_name, cc_path_envvar))
+    return cc
+
+def find_sycl_root(repository_ctx, sycl_config):
+    sycl_name = str(repository_ctx.path(sycl_config.sycl_toolkit_path.strip()).realpath)
+    if sycl_name.startswith("/"):
+        return sycl_name
+    fail("Cannot find SYCL compiler, please correct your path")
+
+def find_sycl_include_path(repository_ctx, sycl_config):
+    base_path = find_sycl_root(repository_ctx, sycl_config)
+    bin_path = repository_ctx.path(base_path + "/" + "bin" + "/" + "icpx")
+    icpx_extra = ""
+    if not bin_path.exists:
+        bin_path = repository_ctx.path(base_path + "/" + "bin" + "/" + "clang")
+        if not bin_path.exists:
+            fail("Cannot find SYCL compiler, please correct your path")
+    else:
+        icpx_extra = "-fsycl"
+    gcc_path = repository_ctx.which("gcc")
+    gcc_install_dir = repository_ctx.execute([gcc_path, "-print-libgcc-file-name"])
+    gcc_install_dir_opt = "--gcc-install-dir=" + str(repository_ctx.path(gcc_install_dir.stdout.strip()).dirname)
+    cmd_out = repository_ctx.execute([bin_path, icpx_extra, gcc_install_dir_opt, "-xc++", "-E", "-v", "/dev/null", "-o", "/dev/null"])
+    outlist = cmd_out.stderr.split("\n")
+    real_base_path = str(repository_ctx.path(base_path).realpath).strip()
+    include_dirs = []
+    for l in outlist:
+        if l.startswith(" ") and l.strip().startswith("/") and str(repository_ctx.path(l.strip()).realpath) not in include_dirs:
+            include_dirs.append(str(repository_ctx.path(l.strip()).realpath))
+    return include_dirs
+
+def _lib_name(lib, version = "", static = False):
+    """Constructs the name of a library on Linux.
+
+    Args:
+      lib: The name of the library, such as "mkl"
+      version: The version of the library.
+      static: True the library is static or False if it is a shared object.
+
+    Returns:
+      The platform-specific name of the library.
+    """
+    if static:
+        return "lib%s.a" % lib
+    else:
+        if version:
+            version = ".%s" % version
+        return "lib%s.so%s" % (lib, version)
+
+def _sycl_lib_paths(repository_ctx, lib, basedir):
+    file_name = _lib_name(lib, version = "", static = False)
+    return [
+        repository_ctx.path("%s/lib/%s" % (basedir, file_name)),
+        repository_ctx.path("%s/lib/intel64/%s" % (basedir, file_name)),
+    ]
+
+def _batch_files_exist(repository_ctx, libs_paths, bash_bin):
+    all_paths = []
+    for _, lib_paths in libs_paths:
+        for lib_path in lib_paths:
+            all_paths.append(lib_path)
+    return files_exist(repository_ctx, all_paths, bash_bin)
+
+def _select_sycl_lib_paths(repository_ctx, libs_paths, bash_bin):
+    test_results = _batch_files_exist(repository_ctx, libs_paths, bash_bin)
+
+    libs = {}
+    i = 0
+    for name, lib_paths in libs_paths:
+        selected_path = None
+        for path in lib_paths:
+            if test_results[i] and selected_path == None:
+                # For each lib select the first path that exists.
+                selected_path = path
+            i = i + 1
+        if selected_path == None:
+            auto_configure_fail("Cannot find sycl library %s in %s" % (name, path))
+
+        libs[name] = struct(file_name = selected_path.basename, path = realpath(repository_ctx, selected_path, bash_bin))
+
+    return libs
+
+def _find_libs(repository_ctx, sycl_config, bash_bin):
+    """Returns the SYCL libraries on the system.
+
+    Args:
+      repository_ctx: The repository context.
+      sycl_config: The SYCL config as returned by _get_sycl_config
+      bash_bin: the path to the bash interpreter
+
+    Returns:
+      Map of library names to structs of filename and path
+    """
+    mkl_path = _mkl_path(sycl_config)
+    sycl_path = _sycl_header_path(repository_ctx, sycl_config, bash_bin)
+    libs_paths = [
+        (name, _sycl_lib_paths(repository_ctx, name, path))
+        for name, path in [
+            ("sycl", sycl_path),
+            ("OpenCL", sycl_path),
+            ("mkl_intel_ilp64", mkl_path),
+            ("mkl_sequential", mkl_path),
+            ("mkl_core", mkl_path),
+        ]
+    ]
+    if sycl_config.sycl_basekit_version_number < "2024":
+        libs_paths.append(("mkl_sycl", _sycl_lib_paths(repository_ctx, "mkl_sycl", mkl_path)))
+    else:
+        libs_paths.append(("mkl_sycl_blas", _sycl_lib_paths(repository_ctx, "mkl_sycl_blas", mkl_path)))
+        libs_paths.append(("mkl_sycl_lapack", _sycl_lib_paths(repository_ctx, "mkl_sycl_lapack", mkl_path)))
+        libs_paths.append(("mkl_sycl_sparse", _sycl_lib_paths(repository_ctx, "mkl_sycl_sparse", mkl_path)))
+        libs_paths.append(("mkl_sycl_dft", _sycl_lib_paths(repository_ctx, "mkl_sycl_dft", mkl_path)))
+        libs_paths.append(("mkl_sycl_vm", _sycl_lib_paths(repository_ctx, "mkl_sycl_vm", mkl_path)))
+        libs_paths.append(("mkl_sycl_rng", _sycl_lib_paths(repository_ctx, "mkl_sycl_rng", mkl_path)))
+        libs_paths.append(("mkl_sycl_stats", _sycl_lib_paths(repository_ctx, "mkl_sycl_stats", mkl_path)))
+        libs_paths.append(("mkl_sycl_data_fitting", _sycl_lib_paths(repository_ctx, "mkl_sycl_data_fitting", mkl_path)))
+    return _select_sycl_lib_paths(repository_ctx, libs_paths, bash_bin)
+
+def find_sycl_config(repository_ctx):
+    """Returns SYCL config dictionary from running find_sycl_config.py"""
+    python_bin = get_python_bin(repository_ctx)
+    exec_result = execute(repository_ctx, [python_bin, repository_ctx.attr._find_sycl_config])
+    if exec_result.return_code:
+        auto_configure_fail("Failed to run find_sycl_config.py: %s" % err_out(exec_result))
+
+    # Parse the dict from stdout.
+    return dict([tuple(x.split(": ")) for x in exec_result.stdout.splitlines()])
+
+def _get_sycl_config(repository_ctx, bash_bin):
+    """Detects and returns information about the SYCL installation on the system.
+
+    Args:
+      repository_ctx: The repository context.
+      bash_bin: the path to the path interpreter
+    """
+    config = find_sycl_config(repository_ctx)
+    sycl_basekit_path = config["sycl_basekit_path"]
+    sycl_toolkit_path = config["sycl_toolkit_path"]
+    sycl_version_number = config["sycl_version_number"]
+    sycl_basekit_version_number = config["sycl_basekit_version_number"]
+    return struct(
+        sycl_basekit_path = sycl_basekit_path,
+        sycl_toolkit_path = sycl_toolkit_path,
+        sycl_version_number = sycl_version_number,
+        sycl_basekit_version_number = sycl_basekit_version_number,
+    )
+
+def _tpl_path(repository_ctx, labelname):
+    return repository_ctx.path(Label("//third_party/gpus/%s.tpl" % labelname))
+
+def _tpl(repository_ctx, tpl, substitutions = {}, out = None):
+    if not out:
+        out = tpl.replace(":", "/")
+    repository_ctx.template(
+        out,
+        _tpl_path(repository_ctx, tpl),
+        substitutions,
+    )
+
+_INC_DIR_MARKER_BEGIN = "#include <...>"
+
+def _cxx_inc_convert(path):
+    """Convert path returned by cc -E xc++ in a complete path."""
+    path = path.strip()
+    return path
+
+def _normalize_include_path(repository_ctx, path):
+    """Normalizes include paths before writing them to the crosstool.
+
+      If path points inside the 'crosstool' folder of the repository, a relative
+      path is returned.
+      If path points outside the 'crosstool' folder, an absolute path is returned.
+      """
+    path = str(repository_ctx.path(path))
+    crosstool_folder = str(repository_ctx.path(".").get_child("crosstool"))
+
+    if path.startswith(crosstool_folder):
+        # We drop the path to "$REPO/crosstool" and a trailing path separator.
+        return "\"" + path[len(crosstool_folder) + 1:] + "\""
+    return "\"" + path + "\""
+
+def _get_cxx_inc_directories_impl(repository_ctx, cc, lang_is_cpp):
+    """Compute the list of default C or C++ include directories."""
+    if lang_is_cpp:
+        lang = "c++"
+    else:
+        lang = "c"
+
+    result = raw_exec(repository_ctx, [
+        cc,
+        "-no-canonical-prefixes",
+        "-E",
+        "-x" + lang,
+        "-",
+        "-v",
+    ])
+    stderr = err_out(result)
+    index1 = stderr.find(_INC_DIR_MARKER_BEGIN)
+    if index1 == -1:
+        return []
+    index1 = stderr.find("\n", index1)
+    if index1 == -1:
+        return []
+    index2 = stderr.rfind("\n ")
+    if index2 == -1 or index2 < index1:
+        return []
+    index2 = stderr.find("\n", index2 + 1)
+    if index2 == -1:
+        inc_dirs = stderr[index1 + 1:]
+    else:
+        inc_dirs = stderr[index1 + 1:index2].strip()
+
+    return [
+        str(repository_ctx.path(_cxx_inc_convert(p)))
+        for p in inc_dirs.split("\n")
+    ]
+
+def get_cxx_inc_directories(repository_ctx, cc):
+    """Compute the list of default C and C++ include directories."""
+
+    # For some reason `clang -xc` sometimes returns include paths that are
+    # different from the ones from `clang -xc++`. (Symlink and a dir)
+    # So we run the compiler with both `-xc` and `-xc++` and merge resulting lists
+    includes_cpp = _get_cxx_inc_directories_impl(repository_ctx, cc, True)
+    includes_c = _get_cxx_inc_directories_impl(repository_ctx, cc, False)
+
+    includes_cpp_set = depset(includes_cpp)
+    return includes_cpp + [
+        inc
+        for inc in includes_c
+        if inc not in includes_cpp_set.to_list()
+    ]
+
+_DUMMY_CROSSTOOL_BZL_FILE = """
+def error_gpu_disabled():
+  fail("ERROR: Building with --config=sycl but TensorFlow is not configured " +
+       "to build with GPU support. Please re-run ./configure and enter 'Y' " +
+       "at the prompt to build with GPU support.")
+
+  native.genrule(
+      name = "error_gen_crosstool",
+      outs = ["CROSSTOOL"],
+      cmd = "echo 'Should not be run.' && exit 1",
+  )
+
+  native.filegroup(
+      name = "crosstool",
+      srcs = [":CROSSTOOL"],
+      output_licenses = ["unencumbered"],
+  )
+"""
+
+_DUMMY_CROSSTOOL_BUILD_FILE = """
+load("//crosstool:error_gpu_disabled.bzl", "error_gpu_disabled")
+
+error_gpu_disabled()
+"""
+
+def _create_dummy_repository(repository_ctx):
+    # Set up BUILD file for sycl/.
+    _tpl(repository_ctx, "sycl:build_defs.bzl")
+    _tpl(repository_ctx, "sycl:BUILD")
+
+    # If sycl_configure is not configured to build with SYCL support, and the user
+    # attempts to build with --config=sycl, add a dummy build rule to intercept
+    # this and fail with an actionable error message.
+    repository_ctx.file(
+        "crosstool/error_gpu_disabled.bzl",
+        _DUMMY_CROSSTOOL_BZL_FILE,
+    )
+    repository_ctx.file("crosstool/BUILD", _DUMMY_CROSSTOOL_BUILD_FILE)
+
+    _tpl(
+        repository_ctx,
+        "sycl:build_defs.bzl",
+        {
+            "%{sycl_is_configured}": "False",
+            "%{sycl_build_is_configured}": "False",
+        },
+    )
+
+def _create_local_sycl_repository(repository_ctx):
+    tpl_paths = {labelname: _tpl_path(repository_ctx, labelname) for labelname in [
+        "sycl:build_defs.bzl",
+        "sycl:BUILD",
+        "crosstool:BUILD.sycl",
+        "crosstool:sycl_cc_toolchain_config.bzl",
+        "crosstool:clang/bin/crosstool_wrapper_driver_sycl",
+    ]}
+
+    bash_bin = get_bash_bin(repository_ctx)
+    sycl_config = _get_sycl_config(repository_ctx, bash_bin)
+
+    # Copy header and library files to execroot.
+    copy_rules = [
+        make_copy_dir_rule(
+            repository_ctx,
+            name = "sycl-include",
+            src_dir = _sycl_header_path(repository_ctx, sycl_config, bash_bin) + "/include",
+            out_dir = "sycl/include",
+        ),
+    ]
+    copy_rules.append(make_copy_dir_rule(
+        repository_ctx,
+        name = "mkl-include",
+        src_dir = _mkl_path(sycl_config) + "/include",
+        out_dir = "sycl/include",
+    ))
+
+    sycl_libs = _find_libs(repository_ctx, sycl_config, bash_bin)
+    sycl_lib_srcs = []
+    sycl_lib_outs = []
+    for lib in sycl_libs.values():
+        sycl_lib_srcs.append(lib.path)
+        sycl_lib_outs.append("sycl/lib/" + lib.file_name)
+    copy_rules.append(make_copy_files_rule(
+        repository_ctx,
+        name = "sycl-lib",
+        srcs = sycl_lib_srcs,
+        outs = sycl_lib_outs,
+    ))
+
+    # Set up BUILD file for sycl/
+    repository_ctx.template(
+        "sycl/build_defs.bzl",
+        tpl_paths["sycl:build_defs.bzl"],
+        {
+            "%{sycl_is_configured}": "True",
+            "%{sycl_build_is_configured}": "True",
+        },
+    )
+
+    if sycl_config.sycl_basekit_version_number < "2024":
+        mkl_sycl_libs = '"{}"'.format(
+            "sycl/lib/" + sycl_libs["mkl_sycl"].file_name,
+        )
+    else:
+        mkl_sycl_libs = '"{}",\n"{}",\n"{}",\n"{}",\n"{}",\n"{}",\n"{}",\n"{}"'.format(
+            "sycl/lib/" + sycl_libs["mkl_sycl_blas"].file_name,
+            "sycl/lib/" + sycl_libs["mkl_sycl_lapack"].file_name,
+            "sycl/lib/" + sycl_libs["mkl_sycl_sparse"].file_name,
+            "sycl/lib/" + sycl_libs["mkl_sycl_dft"].file_name,
+            "sycl/lib/" + sycl_libs["mkl_sycl_vm"].file_name,
+            "sycl/lib/" + sycl_libs["mkl_sycl_rng"].file_name,
+            "sycl/lib/" + sycl_libs["mkl_sycl_stats"].file_name,
+            "sycl/lib/" + sycl_libs["mkl_sycl_data_fitting"].file_name,
+        )
+    core_sycl_libs = '"{}",\n"{}"'.format(
+        "sycl/lib/" + sycl_libs["sycl"].file_name,
+        "sycl/lib/" + sycl_libs["OpenCL"].file_name,
+    )
+    repository_dict = {
+        "%{mkl_intel_ilp64_lib}": sycl_libs["mkl_intel_ilp64"].file_name,
+        "%{mkl_sequential_lib}": sycl_libs["mkl_sequential"].file_name,
+        "%{mkl_core_lib}": sycl_libs["mkl_core"].file_name,
+        "%{mkl_sycl_libs}": mkl_sycl_libs,
+        "%{core_sycl_libs}": core_sycl_libs,
+        "%{copy_rules}": "\n".join(copy_rules),
+        "%{sycl_headers}": ('":mkl-include",\n":sycl-include",\n'),
+    }
+    repository_ctx.template(
+        "sycl/BUILD",
+        tpl_paths["sycl:BUILD"],
+        repository_dict,
+    )
+
+    # Set up crosstool/
+
+    cc = find_cc(repository_ctx)
+
+    host_compiler_includes = get_cxx_inc_directories(repository_ctx, cc)
+
+    host_compiler_prefix = get_host_environ(repository_ctx, _GCC_HOST_COMPILER_PREFIX, "/usr/bin")
+
+    sycl_defines = {}
+
+    sycl_defines["%{host_compiler_prefix}"] = host_compiler_prefix
+    sycl_defines["%{host_compiler_path}"] = "clang/bin/crosstool_wrapper_driver_is_not_gcc"
+
+    sycl_defines["%{cpu_compiler}"] = str(cc)
+    sycl_defines["%{linker_bin_path}"] = "/usr/bin"
+
+    sycl_internal_inc_dirs = find_sycl_include_path(repository_ctx, sycl_config)
+    cxx_builtin_includes_list = sycl_internal_inc_dirs + _sycl_include_path(repository_ctx, sycl_config, bash_bin) + host_compiler_includes
+
+    sycl_defines["%{cxx_builtin_include_directories}"] = to_list_of_strings(cxx_builtin_includes_list)
+    sycl_defines["%{extra_no_canonical_prefixes_flags}"] = "\"-fno-canonical-system-headers\""
+    sycl_defines["%{unfiltered_compile_flags}"] = to_list_of_strings([
+        "-DTENSORFLOW_USE_SYCL=1",
+        "-DMKL_ILP64",
+        "-fPIC",
+    ])
+    sycl_defines["%{sycl_compiler_root}"] = str(sycl_config.sycl_toolkit_path)
+    sycl_defines["%{SYCL_ROOT_DIR}"] = str(sycl_config.sycl_toolkit_path)
+    sycl_defines["%{basekit_path}"] = str(sycl_config.sycl_basekit_path)
+    sycl_defines["%{basekit_version}"] = str(sycl_config.sycl_basekit_version_number)
+    sycl_defines["%{MKL_PATH}"] = _mkl_path(sycl_config)
+
+    # Only expand template variables in the BUILD file
+    repository_ctx.template(
+        "crosstool/BUILD",
+        tpl_paths["crosstool:BUILD.sycl"],
+        sycl_defines,
+    )
+
+    # No templating of cc_toolchain_config - use attributes and templatize the
+    # BUILD file.
+    repository_ctx.template(
+        "crosstool/cc_toolchain_config.bzl",
+        tpl_paths["crosstool:sycl_cc_toolchain_config.bzl"],
+        sycl_defines,
+    )
+
+    repository_ctx.template(
+        "crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc",
+        tpl_paths["crosstool:clang/bin/crosstool_wrapper_driver_sycl"],
+        sycl_defines,
+    )
+
+def _sycl_autoconf_imp(repository_ctx):
+    """Implementation of the sycl_autoconf rule."""
+    if not enable_sycl(repository_ctx):
+        _create_dummy_repository(repository_ctx)
+    else:
+        _create_local_sycl_repository(repository_ctx)
+
+sycl_configure = repository_rule(
+    implementation = _sycl_autoconf_imp,
+    local = True,
+    attrs = {
+        "_find_sycl_config": attr.label(
+            default = Label("//third_party/gpus:find_sycl_config.py"),
+        ),
+    },
+)
+"""Detects and configures the local SYCL toolchain.
+
+Add the following to your WORKSPACE FILE:
+
+```python
+sycl_configure(name = "local_config_sycl")
+```
+
+Args:
+  name: A unique name for this workspace rule.
+"""

--- a/third_party/tsl/third_party/gpus/sycl_configure.bzl
+++ b/third_party/tsl/third_party/gpus/sycl_configure.bzl
@@ -348,7 +348,19 @@ error_gpu_disabled()
 def _create_dummy_repository(repository_ctx):
     # Set up BUILD file for sycl/.
     _tpl(repository_ctx, "sycl:build_defs.bzl")
-    _tpl(repository_ctx, "sycl:BUILD")
+    _tpl(
+        repository_ctx,
+        "sycl:BUILD",
+        {
+            "%{mkl_intel_ilp64_lib}": _lib_name("mkl_intel_ilp64"),
+            "%{mkl_sequential_lib}": _lib_name("mkl_sequential"),
+            "%{mkl_core_lib}": _lib_name("mkl_core"),
+            "%{mkl_sycl_libs}": "",
+            "%{core_sycl_libs}": "",
+            "%{copy_rules}": "",
+            "%{sycl_headers}": "",
+        },
+    )
 
     # If sycl_configure is not configured to build with SYCL support, and the user
     # attempts to build with --config=sycl, add a dummy build rule to intercept

--- a/third_party/tsl/third_party/spirv_llvm_translator/BUILD
+++ b/third_party/tsl/third_party/spirv_llvm_translator/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/third_party/tsl/third_party/spirv_llvm_translator/spirv_llvm_translator.BUILD
+++ b/third_party/tsl/third_party/spirv_llvm_translator/spirv_llvm_translator.BUILD
@@ -1,0 +1,36 @@
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "spirv_llvm_translator",
+    srcs = glob([
+        "lib/SPIRV/libSPIRV/*.cpp",
+        "lib/SPIRV/libSPIRV/*.hpp",
+        "lib/SPIRV/libSPIRV/*.h",
+        "lib/SPIRV/Mangler/*.cpp",
+        "lib/SPIRV/Mangler/*.h",
+        "lib/SPIRV/*.cpp",
+        "lib/SPIRV/*.hpp",
+        "lib/SPIRV/*.h",
+    ]),
+    hdrs = glob(["include/*"]),
+    includes = [
+        "include/",
+        "lib/SPIRV/",
+        "lib/SPIRV/Mangler/",
+        "lib/SPIRV/libSPIRV/",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@llvm-project//llvm:Analysis",
+        "@llvm-project//llvm:BitWriter",
+        "@llvm-project//llvm:CodeGen",
+        "@llvm-project//llvm:Core",
+        "@llvm-project//llvm:Demangle",
+        "@llvm-project//llvm:IRReader",
+        "@llvm-project//llvm:Linker",
+        "@llvm-project//llvm:Passes",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:TransformUtils",
+        "@spirv_headers//:spirv_cpp_headers",
+    ],
+)

--- a/third_party/tsl/third_party/spirv_llvm_translator/spirv_llvm_translator.patch
+++ b/third_party/tsl/third_party/spirv_llvm_translator/spirv_llvm_translator.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/SPIRV/SPIRVInternal.h b/lib/SPIRV/SPIRVInternal.h
+index a828add8..924e13b4 100644
+--- a/lib/SPIRV/SPIRVInternal.h
++++ b/lib/SPIRV/SPIRVInternal.h
+@@ -179,11 +179,12 @@ typedef SPIRVMap<Op, Op, IntBoolOpMapId> IntBoolOpMap;
+   "-v512:512:512-v1024:1024:1024"
+
+ enum SPIRAddressSpace {
+-  SPIRAS_Private,
++  SPIRAS_Generic,
+   SPIRAS_Global,
+-  SPIRAS_Constant,
++  SPIRAS_Internal,
+   SPIRAS_Local,
+-  SPIRAS_Generic,
++  SPIRAS_Constant,
++  SPIRAS_Private,
+   SPIRAS_GlobalDevice,
+   SPIRAS_GlobalHost,
+   SPIRAS_Input,

--- a/third_party/tsl/workspace2.bzl
+++ b/third_party/tsl/workspace2.bzl
@@ -20,6 +20,7 @@ load("//third_party/gemmlowp:workspace.bzl", gemmlowp = "repo")
 load("//third_party/git:git_configure.bzl", "git_configure")
 load("//third_party/gpus:cuda_configure.bzl", "cuda_configure")
 load("//third_party/gpus:rocm_configure.bzl", "rocm_configure")
+load("//third_party/gpus:sycl_configure.bzl", "sycl_configure")
 load("//third_party/hwloc:workspace.bzl", hwloc = "repo")
 load("//third_party/implib_so:workspace.bzl", implib_so = "repo")
 load("//third_party/llvm:setup.bzl", "llvm_setup")
@@ -77,6 +78,7 @@ def _tf_toolchains():
     python_configure(name = "local_config_python")
     rocm_configure(name = "local_config_rocm")
     remote_execution_configure(name = "local_config_remote_execution")
+    sycl_configure(name = "local_config_sycl")
 
     # For windows bazel build
     # TODO: Remove def file filter when TensorFlow can export symbols properly on Windows.
@@ -601,6 +603,22 @@ def _tf_repositories():
         sha256 = "f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c",
         strip_prefix = "glog-0.4.0",
         urls = tf_mirror_urls("https://github.com/google/glog/archive/refs/tags/v0.4.0.tar.gz"),
+    )
+
+    tf_http_archive(
+        name = "spirv_headers",
+        sha256 = "1a248f4199f4a30b2e7304ed4d62f731765bab12d9fa4c5abb189a5e2d57f1f5",
+        strip_prefix = "SPIRV-Headers-1c6bb2743599e6eb6f37b2969acc0aef812e32e3",
+        urls = tf_mirror_urls("https://github.com/KhronosGroup/SPIRV-Headers/archive/1c6bb2743599e6eb6f37b2969acc0aef812e32e3.tar.gz"),
+    )
+
+    tf_http_archive(
+        name = "spirv_llvm_translator",
+        sha256 = "8d33cb29a480457152ce0166bb823fddfba89dea6ce4e7d4eccef7509951f73d",
+        strip_prefix = "SPIRV-LLVM-Translator-0aab1249acbfb8d206c24988f0974638c290e931",
+        build_file = "//third_party/spirv_llvm_translator:spirv_llvm_translator.BUILD",
+        patch_file = ["//third_party/spirv_llvm_translator:spirv_llvm_translator.patch"],
+        urls = tf_mirror_urls("https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/0aab1249acbfb8d206c24988f0974638c290e931.tar.gz"),
     )
 
 def workspace():

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -2,6 +2,7 @@ load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("//xla:xla.bzl", "xla_cc_test")
 load("//xla/stream_executor:build_defs.bzl", "if_cuda_or_rocm", "if_gpu_is_configured")
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
+load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
 load("@tsl//tsl:tsl.bzl", "internal_visibility")
 load("@tsl//tsl/platform:build_config.bzl", "tf_proto_library")
 load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
@@ -259,6 +260,9 @@ cc_library(
     ]) + if_rocm([
         "@local_config_rocm//rocm:rocm_headers",
         "//xla/service/gpu:amdgpu_compiler_impl",
+    ]) + if_sycl([
+        "@local_config_sycl//sycl:sycl_headers",
+        "//xla/service/gpu:spir_compiler_impl",
     ]),
     alwayslink = True,
 )

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -971,6 +971,8 @@ StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
     const GpuClientOptions& options) {
 #if TENSORFLOW_USE_ROCM
   auto pjrt_platform_name = xla::RocmName();
+#elif TENSORFLOW_USE_SYCL
+  auto pjrt_platform_name = xla::SyclName();
 #else   // TENSORFLOW_USE_ROCM
   auto pjrt_platform_name = xla::CudaName();
 #endif  // TENSORFLOW_USE_ROCM

--- a/xla/pjrt/gpu/se_gpu_pjrt_compiler.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_compiler.cc
@@ -55,7 +55,8 @@ namespace xla {
 namespace {
 
 bool IsGpuClient(const PjRtClient& client) {
-  return client.platform_id() == CudaId() || client.platform_id() == RocmId();
+  return client.platform_id() == CudaId() || client.platform_id() == RocmId() ||
+         client.platform_id() == SyclId();
 }
 
 bool IsSameTopology(const PjRtTopologyDescription& topology1,

--- a/xla/pjrt/pjrt_compiler.h
+++ b/xla/pjrt/pjrt_compiler.h
@@ -44,6 +44,10 @@ inline const char* RocmName() {
   static constexpr char kRocmName[] = "rocm";
   return kRocmName;
 }
+inline const char* SyclName() {
+  static constexpr char kSyclName[] = "sycl";
+  return kSyclName;
+}
 inline const char* TpuName() {
   static constexpr char kTpuName[] = "tpu";
   return kTpuName;
@@ -59,6 +63,10 @@ inline PjRtPlatformId CudaId() {
 inline PjRtPlatformId RocmId() {
   static const PjRtPlatformId kRocmId = tsl::Fingerprint64(RocmName());
   return kRocmId;
+}
+inline PjRtPlatformId SyclId() {
+  static const PjRtPlatformId kSyclId = tsl::Fingerprint64(SyclName());
+  return kSyclId;
 }
 inline PjRtPlatformId TpuId() {
   static const PjRtPlatformId kTpuId = tsl::Fingerprint64(TpuName());

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -20,6 +20,10 @@ load(
     "if_rocm",
     "if_rocm_is_configured",
 )
+load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
 load("@tsl//tsl:tsl.bzl", "if_google", "if_libtpu", "internal_visibility")
 load("@tsl//tsl:tsl.default.bzl", "filegroup", "get_compatible_with_portable", "internal_hlo_deps")
 load(
@@ -1338,6 +1342,9 @@ cc_library(
     ]) + if_rocm_is_configured([
         "//xla/service/gpu:amdgpu_compiler",
         "//xla/stream_executor/rocm:stream_executor_rocm",
+    ]) + if_sycl_is_configured([
+        "//xla/service/gpu:spir_compiler",
+        "//xla/stream_executor/sycl:stream_executor_sycl",
     ]),
 )
 
@@ -3841,6 +3848,7 @@ cc_library(
         "//xla/stream_executor/cuda:cuda_platform_id",
         "//xla/stream_executor/host:host_platform_id",
         "//xla/stream_executor/rocm:rocm_platform_id",
+        "//xla/stream_executor/sycl:sycl_platform_id",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/xla/service/computation_placer.cc
+++ b/xla/service/computation_placer.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
 #include "xla/stream_executor/host/host_platform_id.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
 #include "xla/types.h"
 #include "xla/util.h"
 #include "tsl/platform/errors.h"
@@ -216,6 +217,8 @@ static bool InitModule() {
       stream_executor::cuda::kCudaPlatformId, &CreateComputationPlacer);
   xla::ComputationPlacer::RegisterComputationPlacer(
       stream_executor::rocm::kROCmPlatformId, &CreateComputationPlacer);
+  xla::ComputationPlacer::RegisterComputationPlacer(
+      stream_executor::sycl::kSyclPlatformId, &CreateComputationPlacer);
   return true;
 }
 static bool module_initialized = InitModule();

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -13,6 +13,7 @@ load(
 )
 load(
     "//xla/stream_executor:build_defs.bzl",
+    "if_cuda_or_rocm",
     "if_gpu_is_configured",
 )
 load(
@@ -428,7 +429,7 @@ cc_library(
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/protobuf:dnn_proto_cc",
-    ] + if_gpu_is_configured([
+    ] + if_cuda_or_rocm([
         ":ir_emitter_triton",
         "//xla/service/gpu/runtime:cholesky_thunk",
         "//xla/service/gpu/runtime:cub_sort_thunk",
@@ -965,7 +966,7 @@ alias(
 
 cc_library(
     name = "_nccl_api_impl",
-    srcs = if_gpu_is_configured(
+    srcs = if_cuda_or_rocm(
         ["nccl_api.cc"],
         ["nccl_api_stub.cc"],
     ),
@@ -1324,7 +1325,7 @@ cc_library(
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/profiler/lib:scoped_annotation",
         "@tsl//tsl/profiler/lib:traceme",
-    ] + if_gpu_is_configured([
+    ] + if_cuda_or_rocm([
         ":make_batch_pointers",
     ]) + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cublas_plugin",
@@ -2367,8 +2368,8 @@ xla_test(
 
 cc_library(
     name = "cusolver_context",
-    srcs = if_gpu_is_configured(["cusolver_context.cc"]),
-    hdrs = if_gpu_is_configured(["cusolver_context.h"]),
+    srcs = if_cuda_or_rocm(["cusolver_context.cc"]),
+    hdrs = if_cuda_or_rocm(["cusolver_context.h"]),
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
         "TENSORFLOW_USE_ROCM=1",
     ]),
@@ -3076,6 +3077,7 @@ cc_library(
         "//xla/stream_executor/cuda:cuda_platform_id",
         "//xla/stream_executor/host:host_platform_id",
         "//xla/stream_executor/rocm:rocm_platform_id",
+        "//xla/stream_executor/sycl:sycl_platform_id",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:node_hash_map",
@@ -3915,6 +3917,61 @@ cc_library(
 )
 
 cc_library(
+    name = "spir_compiler",
+    srcs = [
+        "spir_compiler_registration.cc",
+    ],
+    tags = ["manual"],
+    deps = [
+        ":spir_compiler_impl",
+        "//xla/stream_executor/sycl:sycl_platform_id",
+    ],
+    alwayslink = True,  # Contains compiler registration
+)
+
+cc_library(
+    name = "spir_compiler_impl",
+    srcs = [
+        "spir_compiler.cc",
+    ],
+    hdrs = [
+        "spir_compiler.h",
+    ],
+    tags = ["manual"],
+    deps = [
+        ":cublas_pad_for_gemms",
+        ":cublas_padding_requirements",
+        ":cudnn_fused_conv_rewriter",
+        ":gemm_rewriter",
+        ":gpu_compiler",
+        ":gpu_conv_padding_legalization",
+        ":gpu_conv_rewriter",
+        ":gpu_layout_assignment",
+        ":reduction_degenerate_dim_remover",
+        ":reduction_dimension_grouper",
+        ":reduction_layout_normalizer",
+        ":target_constants",
+        ":tree_reduction_rewriter",
+        ":triangular_solve_rewriter",
+        "//xla:statusor",
+        "//xla:xla_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:algebraic_simplifier",
+        "//xla/service:call_inliner",
+        "//xla/service:dot_dimension_merger",
+        "//xla/service:hlo_constant_folding",
+        "//xla/service:hlo_cse",
+        "//xla/service:hlo_pass",
+        "//xla/service:hlo_pass_pipeline",
+        "//xla/service:hlo_verifier",
+        "//xla/service:tuple_simplifier",
+        "//xla/service/gpu/llvm_gpu_backend",
+        "//xla/service/llvm_ir:llvm_util",
+        "//xla/stream_executor/sycl:sycl_platform_id",
+    ],
+)
+
+cc_library(
     name = "all_reduce_blueconnect",
     srcs = ["all_reduce_blueconnect.cc"],
     hdrs = ["all_reduce_blueconnect.h"],
@@ -4276,12 +4333,12 @@ xla_cc_test(
 
 cc_library(
     name = "buffer_comparator",
-    srcs = if_gpu_is_configured(["buffer_comparator.cc"]),
-    hdrs = if_gpu_is_configured(["buffer_comparator.h"]),
+    srcs = if_cuda_or_rocm(["buffer_comparator.cc"]),
+    hdrs = if_cuda_or_rocm(["buffer_comparator.h"]),
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
         "TENSORFLOW_USE_ROCM=1",
     ]),
-    deps = if_gpu_is_configured([
+    deps = if_cuda_or_rocm([
         ":buffer_comparator_kernel",
         ":gpu_asm_opts_util",
         ":launch_dimensions",

--- a/xla/service/gpu/fusions/fusion_emitter.cc
+++ b/xla/service/gpu/fusions/fusion_emitter.cc
@@ -235,7 +235,7 @@ BuildKernelPrototype(IrEmitterContext& ir_emitter_context,
   llvm::LLVMContext& context = llvm_module->getContext();
   llvm::FunctionType* kernel_type = llvm::FunctionType::get(
       /*Result=*/llvm::Type::getVoidTy(context),
-      std::vector<llvm::Type*>(kNumLlvmArgs, builder->getPtrTy()),
+      std::vector<llvm::Type*>(kNumLlvmArgs, builder->getPtrTy(1)),
       /*isVarArg=*/false);
   llvm::Function* kernel =
       llvm::Function::Create(kernel_type, llvm::GlobalValue::ExternalLinkage,

--- a/xla/service/gpu/fusions/reduction.cc
+++ b/xla/service/gpu/fusions/reduction.cc
@@ -1260,7 +1260,8 @@ absl::Status ReductionFusion::ReductionEmitter::EmitKernel(
   llvm::Value* block_id_y = gpu::EmitCallToTargetIntrinsic(
       gpu::TargetIntrinsicID::kBlockIdy, {}, {}, builder_);
   llvm_ir::AddRangeMetadata(0, instr_index_groups.size(),
-                            llvm::cast<llvm::Instruction>(block_id_y));
+                            llvm::cast<llvm::Instruction>(block_id_y),
+                            builder_);
   block_id_y = builder_->CreateZExtOrTrunc(block_id_y, builder_->getInt32Ty());
   block_id_y->setName("block.id.y");
   for (int i = 0; i < instr_index_groups.size(); ++i) {

--- a/xla/service/gpu/fusions/tiling_util.cc
+++ b/xla/service/gpu/fusions/tiling_util.cc
@@ -131,7 +131,7 @@ llvm::Value* EmitBlockId(llvm::IRBuilder<>* builder, int32_t num_blocks,
       EmitCallToTargetIntrinsic(TargetIntrinsicID::kBlockIdx, {}, {}, builder);
   if (num_blocks != 0) {
     llvm_ir::AddRangeMetadata(0, num_blocks,
-                              llvm::cast<llvm::Instruction>(block_id));
+                              llvm::cast<llvm::Instruction>(block_id), builder);
   }
   auto ret = builder->CreateIntCast(block_id, index_ty, /*isSigned=*/true);
   ret->setName("block.id.x");
@@ -147,7 +147,7 @@ llvm::Value* EmitThreadId(llvm::IRBuilder<>* builder, int64_t threads_per_block,
   // defined by (num_thread_y, num_thread_x) from thread_id.
   llvm::CallInst* thread_id =
       EmitCallToTargetIntrinsic(TargetIntrinsicID::kThreadIdx, {}, {}, builder);
-  llvm_ir::AddRangeMetadata(0, threads_per_block, thread_id);
+  llvm_ir::AddRangeMetadata(0, threads_per_block, thread_id, builder);
   auto ret = builder->CreateIntCast(thread_id, index_ty, /*isSigned=*/true);
   ret->setName("thread.id.x");
   return ret;

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2096,8 +2096,10 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
     auto driver_version = se::gpu::GpuDriver::GetDriverVersion();
 #if GOOGLE_CUDA
     constexpr int toolkit_version = CUDA_VERSION;
-#else
+#elif TENSORFLOW_USE_ROCM
     constexpr int toolkit_version = TF_ROCM_VERSION;
+#else
+    constexpr int toolkit_version = -1;
 #endif
     pipeline.AddPass<CommandBufferScheduling>(
         gpu_device_info, toolkit_version,

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -67,6 +67,7 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
 #include "xla/util.h"
 #include "tsl/platform/env.h"
 #include "tsl/platform/errors.h"
@@ -209,6 +210,8 @@ absl::Status GpuExecutable::CheckCompatibilityWithServiceExecutableRunOptions(
         << std::get<se::CudaComputeCapability>(gpu_version_).ToString()
         << "}, but was {" << std::get<se::CudaComputeCapability>(cc).ToString()
         << "}";
+  } else if (platform_id == stream_executor::sycl::kSyclPlatformId) {
+    // TODO: Add check.
   } else {
     return Internal("Unknown platform");
   }

--- a/xla/service/gpu/gpu_transfer_manager.cc
+++ b/xla/service/gpu/gpu_transfer_manager.cc
@@ -46,6 +46,7 @@ limitations under the License.
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/util.h"
 #include "tsl/platform/errors.h"
@@ -337,11 +338,20 @@ static std::unique_ptr<xla::TransferManager> CreateAMDGPUTransferManager() {
           .getPointerSize(0 /* default address space */));
 }
 
+static std::unique_ptr<xla::TransferManager> CreateSPIRTransferManager() {
+  return std::make_unique<xla::gpu::GpuTransferManager>(
+      /*id=*/stream_executor::sycl::kSyclPlatformId,
+      /*pointer_size=*/llvm::DataLayout(xla::gpu::spir::DataLayout())
+          .getPointerSize(0 /* default address space */));
+}
+
 static bool InitModule() {
   xla::TransferManager::RegisterTransferManager(
       stream_executor::cuda::kCudaPlatformId, &CreateNVPTXTransferManager);
   xla::TransferManager::RegisterTransferManager(
       stream_executor::rocm::kROCmPlatformId, &CreateAMDGPUTransferManager);
+  xla::TransferManager::RegisterTransferManager(
+      stream_executor::sycl::kSyclPlatformId, &CreateSPIRTransferManager);
   return true;
 }
 

--- a/xla/service/gpu/ir_emitter_context.cc
+++ b/xla/service/gpu/ir_emitter_context.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "llvm/ADT/ArrayRef.h"
 #include "xla/service/gpu/gpu_constants.h"
 #include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/service/llvm_ir/llvm_util.h"
 
 namespace xla {
 namespace gpu {
@@ -79,7 +80,7 @@ void IrEmitterContext::emit_constant(int64_t num_elements,
       llvm::GlobalValue::ExternalLinkage,
       /*Initializer=*/initializer, symbol_name,
       /*TLMode=*/llvm::GlobalValue::NotThreadLocal,
-      /*AddressSpace=*/0,
+      /*AddressSpace=*/llvm_ir::GetGlobalMemoryAddressSpace(),
       /*isExternallyInitialized=*/false);
   global_for_const->setAlignment(llvm::Align(kConstantBufferAlignBytes));
   llvm_module_->insertGlobalVariable(global_for_const);

--- a/xla/service/gpu/kernels/BUILD
+++ b/xla/service/gpu/kernels/BUILD
@@ -1,7 +1,7 @@
 load("//xla/tests:build_defs.bzl", "xla_test")
 load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library")
 load("//xla:xla.bzl", "xla_cc_test")
-load("//xla/stream_executor:build_defs.bzl", "if_gpu_is_configured")
+load("//xla/stream_executor:build_defs.bzl", "if_cuda_or_rocm", "if_gpu_is_configured")
 load("//xla/service/gpu:build_defs.bzl", "gpu_kernel_library")
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
 load("@tsl//tsl/platform:build_config_root.bzl", "tf_gpu_tests_tags")
@@ -212,7 +212,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@tsl//tsl/platform:statusor",
-    ] + if_gpu_is_configured([
+    ] + if_cuda_or_rocm([
         ":topk_kernel_gpu",
     ]),
 )

--- a/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -4,6 +4,10 @@ load(
     "@local_config_rocm//rocm:build_defs.bzl",
     "if_rocm_is_configured",
 )
+load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -69,6 +73,8 @@ cc_library(
     ] + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",
         "@llvm-project//llvm:AMDGPUCodeGen",
+    ]) + if_sycl_is_configured([
+        "@spirv_llvm_translator//:spirv_llvm_translator",
     ]),
 )
 

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -76,6 +76,11 @@ limitations under the License.
 #include "rocm/rocm_config.h"
 #endif
 
+#if TENSORFLOW_USE_SYCL
+#include "LLVMSPIRVLib.h"
+#include "LLVMSPIRVOpts.h"
+#endif  // TENSORFLOW_USE_SYCL
+
 namespace xla {
 namespace gpu {
 namespace {
@@ -368,7 +373,9 @@ absl::Status LinkAndOptimizeModule(
   llvm::CGSCCAnalysisManager cgam;
   llvm::ModuleAnalysisManager mam;
 
-  fam.registerPass([&] { return target_machine->getTargetIRAnalysis(); });
+  if (target_machine) {
+    fam.registerPass([&] { return target_machine->getTargetIRAnalysis(); });
+  }
 
   llvm::PipelineTuningOptions pto;
   pto.SLPVectorization = true;
@@ -1033,6 +1040,94 @@ absl::StatusOr<std::vector<uint8_t>> CompileToHsaco(
 }
 
 }  // namespace amdgpu
+
+namespace {
+std::unique_ptr<llvm::TargetMachine> SPIRGetTargetMachine(
+    llvm::Triple target_triple, se::GpuComputeCapability gpu_version,
+    const DebugOptions& debug_options) {
+  return nullptr;
+}
+
+absl::Status SPIRTargetModuleLinker(llvm::Module* module,
+                                    se::GpuComputeCapability gpu_version,
+                                    const DebugOptions& debug_options,
+                                    const std::string& device_bitcode_dir_path) {
+  return OkStatus();
+}
+
+StatusOr<std::string> EmitModuleToSpir(llvm::Module* module,
+                                       se::GpuComputeCapability gpu_version,
+                                       const DebugOptions& debug_options) {
+#if TENSORFLOW_USE_SYCL
+  SPIRV::TranslatorOpts::ExtensionsStatusMap ExtensionsStatus;
+  SPIRV::TranslatorOpts opts(SPIRV::VersionNumber::MaximumVersion,
+                             ExtensionsStatus);
+  opts.enableAllExtensions();  // enable all SPIR-V extension first
+
+  std::ostringstream oss;
+  std::string err;
+  bool success = llvm::writeSpirv(module, opts, oss, err);
+  if (!success) {
+    return xla::Internal("Fails to convert LLVM as SPIR-V: %s", err);
+  }
+  return oss.str();
+#else
+  return absl::UnimplementedError("Not implemented for SYCL");
+#endif
+}
+
+void SPIRBackendInit(const DebugOptions& debug_options) {
+
+  FeedLLVMWithFlags({"-slp-vectorize-hor=false"});
+
+  FeedLLVMWithFlags({
+      "-slp-min-reg-size=64",
+      "-slp-max-reg-size=64",
+  });
+
+  llvm_ir::InitializeLLVMCommandLineOptions(
+      debug_options.xla_backend_extra_options());
+
+  llvm::PassRegistry* registry = llvm::PassRegistry::getPassRegistry();
+  InitializePasses(registry);
+}
+}  // namespace
+
+namespace spir {
+absl::StatusOr<std::vector<uint8_t>> CompileToSpir(
+    llvm::Module* module, se::GpuComputeCapability gpu_version,
+    const DebugOptions& debug_options) {
+  std::string libdevice_dir_path;
+  static absl::once_flag backend_init_flag;
+  absl::call_once(backend_init_flag, SPIRBackendInit, debug_options);
+
+  std::string spir;
+  {
+    XLA_SCOPED_LOGGING_TIMER("Compile module " + module->getName().str());
+
+    // If the module has no functions or globals, there's nothing to compile.
+    if (module->empty() && module->global_empty()) {
+      VLOG(2) << "Module '" << module->getName().str()
+              << "' is empty. Skipping compilation.";
+      return std::vector<uint8_t>();
+    }
+
+    llvm::Triple default_target_triple("spir64-unknown-unknown");
+    std::unique_ptr<llvm::TargetMachine> target_machine =
+        SPIRGetTargetMachine(default_target_triple, gpu_version, debug_options);
+
+    TF_RETURN_IF_ERROR(LinkAndOptimizeModule(
+        module, gpu_version, debug_options, libdevice_dir_path,
+        SPIRTargetModuleLinker, default_target_triple, target_machine.get(),
+        kDefaultInlineThreshold));
+
+    // Lower optimized LLVM module to SPIR.
+    TF_ASSIGN_OR_RETURN(spir,
+                        EmitModuleToSpir(module, gpu_version, debug_options));
+  }
+  return std::vector<uint8_t>(spir.begin(), spir.end());
+}
+}  // namespace spir
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h
@@ -66,6 +66,13 @@ absl::StatusOr<std::vector<uint8_t>> CompileToHsaco(
     const std::string& module_config_cache_key);
 }  // namespace amdgpu
 
+namespace spir {
+// Compiles the argument module and returns it.
+StatusOr<std::vector<uint8_t>> CompileToSpir(
+    llvm::Module* module, se::GpuComputeCapability gpu_version,
+    const DebugOptions& debug_options);
+}  // namespace spir
+
 }  // namespace gpu
 }  // namespace xla
 

--- a/xla/service/gpu/parallel_loop_emitter.cc
+++ b/xla/service/gpu/parallel_loop_emitter.cc
@@ -66,7 +66,7 @@ ParallelLoopEmitter::EmitLinearBaseAndThreadIdx(llvm::Type* index_type,
   llvm::Value* block_id =
       EmitCallToTargetIntrinsic(TargetIntrinsicID::kBlockIdx, {}, {}, b_);
   llvm_ir::AddRangeMetadata(0, launch_dimensions_.block_counts().x,
-                            static_cast<llvm::Instruction*>(block_id));
+                            static_cast<llvm::Instruction*>(block_id), b_);
   block_id = b_->CreateZExtOrTrunc(block_id, index_type, "block_id");
 
   // Per the PTX documentation:
@@ -74,7 +74,7 @@ ParallelLoopEmitter::EmitLinearBaseAndThreadIdx(llvm::Type* index_type,
   llvm::Value* thread_id_x =
       EmitCallToTargetIntrinsic(TargetIntrinsicID::kThreadIdx, {}, {}, b_);
   llvm_ir::AddRangeMetadata(0, launch_dimensions_.thread_counts_per_block().x,
-                            static_cast<llvm::Instruction*>(thread_id_x));
+                            static_cast<llvm::Instruction*>(thread_id_x), b_);
   thread_id_x = b_->CreateZExtOrTrunc(thread_id_x, index_type, "thread_id_x");
 
   llvm::Value* linear_index_base =
@@ -88,7 +88,7 @@ ParallelLoopEmitter::EmitLinearBaseAndThreadIdx(llvm::Type* index_type,
     llvm::Value* thread_id_y =
         EmitCallToTargetIntrinsic(TargetIntrinsicID::kThreadIdy, {}, {}, b_);
     llvm_ir::AddRangeMetadata(0, launch_dimensions_.thread_counts_per_block().y,
-                              static_cast<llvm::Instruction*>(thread_id_y));
+                              static_cast<llvm::Instruction*>(thread_id_y), b_);
     thread_id_y = b_->CreateZExtOrTrunc(thread_id_y, index_type, "thread_id_y");
     linear_index_base = b_->CreateAdd(
         linear_index_base,

--- a/xla/service/gpu/spir_compiler.cc
+++ b/xla/service/gpu/spir_compiler.cc
@@ -1,0 +1,219 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/spir_compiler.h"
+
+#include <stdlib.h>
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tsl/platform/path.h"
+#include "tsl/platform/status.h"
+#include "tsl/util/env_var.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/algebraic_simplifier.h"
+#include "xla/service/call_inliner.h"
+#include "xla/service/convert_mover.h"
+#include "xla/service/dot_dimension_merger.h"
+#include "xla/service/dump.h"
+#include "xla/service/float_normalization.h"
+#include "xla/service/float_support.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/buffer_sharing.h"
+#include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/service/gpu/cudnn_fused_conv_rewriter.h"
+#include "xla/service/gpu/gpu_conv_padding_legalization.h"
+#include "xla/service/gpu/gpu_conv_rewriter.h"
+#include "xla/service/gpu/gpu_layout_assignment.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
+#include "xla/service/gpu/target_constants.h"
+#include "xla/service/gpu/triangular_solve_rewriter.h"
+#include "xla/service/hlo_constant_folding.h"
+#include "xla/service/hlo_cse.h"
+#include "xla/service/hlo_dce.h"
+#include "xla/service/hlo_pass_fix.h"
+#include "xla/service/hlo_pass_pipeline.h"
+#include "xla/service/hlo_verifier.h"
+#include "xla/service/layout_normalization.h"
+#include "xla/service/llvm_ir/llvm_util.h"
+#include "xla/service/reshape_decomposer.h"
+#include "xla/service/reshape_mover.h"
+#include "xla/service/tuple_simplifier.h"
+#include "xla/status_macros.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+#include "xla/types.h"
+#include "xla/util.h"
+
+namespace xla {
+namespace gpu {
+
+class ConvBfloat16Support : public FloatSupport {
+ public:
+  explicit ConvBfloat16Support()
+      : FloatSupport(BF16), is_conv_bf16_supported_(true) {}
+
+  bool SupportsLowPrecisionOperand(const HloInstruction& hlo,
+                                   int64_t operand_index) const override {
+    return (hlo.opcode() != HloOpcode::kConvolution) || is_conv_bf16_supported_;
+  }
+
+  bool SupportsLowPrecisionOutput(const HloInstruction& hlo) const override {
+    return (hlo.opcode() != HloOpcode::kConvolution) || is_conv_bf16_supported_;
+  }
+
+  bool SupportsMixedPrecisions(const HloInstruction& hlo) const override {
+    // Skip all HLOs other than convolutions.
+    return (hlo.opcode() != HloOpcode::kConvolution);
+  }
+
+ private:
+  bool is_conv_bf16_supported_;
+};
+
+absl::Status SPIRCompiler::OptimizeHloConvolutionCanonicalization(
+    HloModule* hlo_module, se::GpuComputeCapability gpu_version,
+    se::dnn::VersionInfo dnn_version,
+    se::DeviceMemoryAllocator* device_allocator) {
+  auto cuda_compute_capability =
+      std::get<se::CudaComputeCapability>(gpu_version);
+  // Convert convolutions into CustomCalls to onednn, then canonicalize them
+  // (GpuConvPaddingLegalization).
+  HloPassPipeline pipeline("conv_canonicalization");
+  pipeline.AddInvariantCheckerDebug<HloVerifier>(
+      /*layout_sensitive=*/false,
+      /*allow_mixed_precision=*/false);
+
+  // Convert upsupported bf16 convolutions to f32.
+  ConvBfloat16Support conv_bf16_support;
+  pipeline.AddPass<FloatNormalization>(&conv_bf16_support);
+
+  pipeline.AddPass<GpuConvRewriter>();
+  pipeline.AddPass<CudnnFusedConvRewriter>(cuda_compute_capability);
+  pipeline.AddPass<GpuConvPaddingLegalization>();
+
+  // The conv padding/vectorization passes which we need to get rid of.  They
+  // also leave behind unnecessary tuple/get-tuple-element pairs that
+  // TupleSimplifier fixes.
+  pipeline.AddPass<CallInliner>();
+  pipeline.AddPass<TupleSimplifier>();
+
+  AlgebraicSimplifierOptions algsimp_options;
+  algsimp_options.set_enable_conv_operand_swap(false);
+  algsimp_options.set_enable_unconditional_reduce_of_concat_replacement(false);
+  pipeline.AddPass<HloPassFix<AlgebraicSimplifier>>(algsimp_options);
+
+  // tf2xla bridge, GpuConvRewriter, and introduce reshapes and transposes. Run
+  // ReshapeMover to a fixed point.  Include algsimp because ReshapeMover relies
+  // on it.
+  [&, &pipeline = pipeline.AddPass<HloPassFix<HloPassPipeline>>(
+          "reshape_mover_after_conv_canonicalization")] {
+    ReshapeMoverOptions reshape_mover_options;
+    reshape_mover_options.reshape_of_1d_broadcast_is_cheap = true;
+    pipeline.AddPass<HloPassFix<ReshapeMover>>(reshape_mover_options);
+    pipeline.AddPass<AlgebraicSimplifier>(algsimp_options);
+  }();
+
+  // The reshapes and transposes can possibly be eliminated using
+  // AlgebraicSimplifier. ConvertMover and ReshapeMover fight with each other.
+  // ConvertMover wants to move some converts down the graph, but ReshapeMover
+  // wants to move them up the graph. We run ConvertMover and algsimp to a fixed
+  // point.
+  [&, &pipeline = pipeline.AddPass<HloPassFix<HloPassPipeline>>(
+          "simplify_after_conv_canonicalization")] {
+    pipeline.AddPass<ConvertMover>();
+    pipeline.AddPass<AlgebraicSimplifier>(algsimp_options);
+  }();
+
+  // GpuConvRewriter, GpuConvPaddingLegalization and may add instructions which
+  // can be simplified by constant folding.
+  pipeline.AddPass<HloConstantFolding>();
+  TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
+
+  return absl::OkStatus();
+}
+
+absl::Status SPIRCompiler::OptimizeHloPostLayoutAssignment(
+    HloModule* hlo_module, se::StreamExecutor* stream_exec,
+    const CompileOptions& options, const TargetConfig& gpu_target_config,
+    tsl::thread::ThreadPool* thread_pool) {
+  HloPassPipeline pre_pipeline("spir post-layout_assignment part 1");
+
+  // This needs to run before GemmRewriter, which is part of
+  // OptimizeHloPostLayoutAssignment().
+  auto cuda_compute_capability = std::get<se::CudaComputeCapability>(
+      gpu_target_config.device_description.gpu_compute_capability());
+
+  pre_pipeline.AddPass<DotDimensionMerger>();
+
+  // Padding a gemm operand that's a constant results in pad(constant).  Run
+  // constant-folding to simplify this into a new constant.
+  pre_pipeline.AddPass<HloConstantFolding>();
+  TF_RETURN_IF_ERROR(pre_pipeline.Run(hlo_module).status());
+
+  TF_RETURN_IF_ERROR(GpuCompiler::OptimizeHloPostLayoutAssignment(
+      hlo_module, stream_exec, options, gpu_target_config, thread_pool));
+
+  HloPassPipeline post_pipeline("spir post-layout_assignment part 2");
+
+  // Transform TriangularSolve ops into custom-calls, so we can add temp
+  // memory.
+  post_pipeline.AddPass<TriangularSolveRewriter>();
+
+  TF_RETURN_IF_ERROR(post_pipeline.Run(hlo_module).status());
+
+  return absl::OkStatus();
+}
+
+SPIRCompiler::SPIRCompiler()
+    : GpuCompiler(stream_executor::sycl::kSyclPlatformId, spir::TargetTriple(),
+                  spir::DataLayout()) {}
+
+HloDataflowAnalysis::CanShareBuffer SPIRCompiler::GetCanShareBuffer() const {
+  return &CanShareBufferHint;
+}
+
+absl::StatusOr<GpuCompiler::BackendCompileResult>
+SPIRCompiler::CompileTargetBinary(const HloModuleConfig& module_config,
+                                  llvm::Module* llvm_module,
+                                  se::GpuComputeCapability gpu_version,
+                                  bool relocatable,
+                                  const HloModule* debug_module,
+                                  const CompileOptions& options) {
+  if (relocatable) {
+    return Unimplemented("relocatable target binary is not implemented");
+  }
+
+  std::vector<uint8_t> spir;
+  {
+    // This may print multiple lines per HLO compilation because of the
+    // parallelized compilation of LLVM modules.
+    XLA_SCOPED_LOGGING_TIMER_IF(
+        "SPIRCompiler::CompileTargetBinary - CompileToSpir",
+        !options.is_autotuning_compilation);
+    TF_ASSIGN_OR_RETURN(spir,
+                        spir::CompileToSpir(llvm_module, gpu_version,
+                                            module_config.debug_options()));
+  }
+
+  return BackendCompileResult{"", std::move(spir)};
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/spir_compiler.h
+++ b/xla/service/gpu/spir_compiler.h
@@ -1,0 +1,63 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_SPIR_COMPILER_H_
+#define XLA_SERVICE_GPU_SPIR_COMPILER_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/base/call_once.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/SourceMgr.h"
+#include "xla/service/gpu/gpu_compiler.h"
+#include "xla/statusor.h"
+
+namespace xla {
+namespace gpu {
+
+// SPIRCompiler generates efficient GPU executables for SPIR target.
+class SPIRCompiler : public GpuCompiler {
+ public:
+  SPIRCompiler();
+  ~SPIRCompiler() override {}
+
+  absl::Status OptimizeHloConvolutionCanonicalization(
+      HloModule* hlo_module, se::GpuComputeCapability gpu_version,
+      se::dnn::VersionInfo dnn_version,
+      se::DeviceMemoryAllocator* device_allocator) override;
+
+  absl::Status OptimizeHloPostLayoutAssignment(
+      HloModule* hlo_module, se::StreamExecutor* stream_exec,
+      const CompileOptions& options, const TargetConfig& gpu_target_config,
+      tsl::thread::ThreadPool* thread_pool) override;
+
+  HloDataflowAnalysis::CanShareBuffer GetCanShareBuffer() const override;
+
+  absl::StatusOr<BackendCompileResult> CompileTargetBinary(
+      const HloModuleConfig& module_config, llvm::Module* llvm_module,
+      se::GpuComputeCapability gpu_version, bool relocatable,
+      const HloModule* debug_module, const CompileOptions& options) override;
+
+ private:
+  SPIRCompiler(const SPIRCompiler&) = delete;
+  SPIRCompiler& operator=(const SPIRCompiler&) = delete;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_SPIR_COMPILER_H_

--- a/xla/service/gpu/spir_compiler_registration.cc
+++ b/xla/service/gpu/spir_compiler_registration.cc
@@ -1,0 +1,25 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/spir_compiler.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+
+static bool InitModule() {
+  xla::Compiler::RegisterCompilerFactory(
+      stream_executor::sycl::kSyclPlatformId,
+      []() { return std::make_unique<xla::gpu::SPIRCompiler>(); });
+  return true;
+}
+static bool module_initialized = InitModule();

--- a/xla/service/gpu/stream_executor_util.cc
+++ b/xla/service/gpu/stream_executor_util.cc
@@ -334,7 +334,8 @@ absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
 
   if (!cubin_data.empty()) {
     loader_spec.AddCudaCubinInMemory(
-        reinterpret_cast<const char*>(cubin_data.data()), kernel_name);
+        reinterpret_cast<const char*>(cubin_data.data()), cubin_data.size(),
+        kernel_name);
   }
 
   TF_ASSIGN_OR_RETURN(std::unique_ptr<se::Kernel> kernel,

--- a/xla/service/llvm_ir/fused_ir_emitter.cc
+++ b/xla/service/llvm_ir/fused_ir_emitter.cc
@@ -104,7 +104,7 @@ FusedIrEmitter::IndexedGenerator FusedIrEmitter::HandleConstant(
       /*Initializer=*/initializer,
       /*Name=*/"", /*InsertBefore=*/nullptr,
       /*TLMode=*/llvm::GlobalValue::NotThreadLocal,
-      /*AddressSpace=*/0,
+      /*AddressSpace=*/llvm_ir::GetGlobalMemoryAddressSpace(),
       /*isExternallyInitialized=*/false);
   global->setUnnamedAddr(llvm::GlobalVariable::UnnamedAddr::Global);
 

--- a/xla/service/llvm_ir/llvm_util.h
+++ b/xla/service/llvm_ir/llvm_util.h
@@ -273,7 +273,8 @@ void SetDereferenceableMetadataForLoad(llvm::LoadInst* load,
 
 // Tells LLVM `inst >= lower && inst < upper`. Returns `inst` for convenience.
 llvm::Instruction* AddRangeMetadata(int32_t lower, int32_t upper,
-                                    llvm::Instruction* inst);
+                                    llvm::Instruction* inst,
+                                    llvm::IRBuilder<>* b);
 
 void SetToFirstInsertPoint(llvm::BasicBlock* blk, llvm::IRBuilder<>* builder);
 

--- a/xla/service/llvm_ir/sort_util.cc
+++ b/xla/service/llvm_ir/sort_util.cc
@@ -165,7 +165,7 @@ Status EmitTiledCompareLoop(
   llvm::Value* thread_id = gpu::EmitCallToTargetIntrinsic(
       gpu::TargetIntrinsicID::kThreadIdx, {}, {}, b);
   llvm_ir::AddRangeMetadata(0, tile_size / 2,
-                            llvm::cast<llvm::Instruction>(thread_id));
+                            llvm::cast<llvm::Instruction>(thread_id), b);
   thread_id = b->CreateIntCast(thread_id, tiled_keys_index.GetType(),
                                /*isSigned=*/true, "thread.id.x");
 

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -698,6 +698,11 @@ alias(
     actual = "//xla/stream_executor/rocm:all_runtime",
 )
 
+alias(
+    name = "sycl_platform",
+    actual = "//xla/stream_executor/sycl:all_runtime",
+)
+
 # TODO(ezhulenev): This should be removed.
 cc_library(
     name = "stream_executor_bundle",

--- a/xla/stream_executor/build_defs.bzl
+++ b/xla/stream_executor/build_defs.bzl
@@ -1,7 +1,11 @@
 """Configurations for StreamExecutor builds"""
 
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda_is_configured")
-load("@local_config_rocm//rocm:build_defs.bzl", _if_gpu_is_configured = "if_gpu_is_configured")
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    _if_gpu_is_configured = "if_gpu_is_configured",
+    _if_cuda_or_rocm = "if_cuda_or_rocm",
+)
 load(
     "@tsl//tsl/platform:rules_cc.bzl",
     "cc_library",
@@ -23,8 +27,8 @@ def tf_additional_cudnn_plugin_copts():
 def if_gpu_is_configured(if_true, if_false = []):
     return _if_gpu_is_configured(if_true, if_false)
 
-def if_cuda_or_rocm(x):
-    return if_gpu_is_configured(x)
+def if_cuda_or_rocm(if_true, if_false = []):
+    return _if_cuda_or_rocm(if_true, if_false)
 
 # nvlink is not available via the pip wheels, disable it since it will create
 # unnecessary dependency

--- a/xla/stream_executor/cuda/cuda_driver.cc
+++ b/xla/stream_executor/cuda/cuda_driver.cc
@@ -1400,6 +1400,14 @@ struct BitPatternToValue {
       "Feature not supported on CUDA platform (LoadHsaco)");
 }
 
+/* static */ absl::Status GpuDriver::LoadSpirv(GpuContext* context,
+                                               const char* spir_contents,
+                                               const size_t size,
+                                               CUmodule* module) {
+  return absl::InternalError(
+      "Feature not supported on CUDA platform (LoadSpirv)");
+}
+
 /* static */ absl::Status GpuDriver::SynchronousMemsetUint8(
     GpuContext* context, CUdeviceptr location, uint8_t value, size_t size) {
   ScopedActivateContext activation(context);

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -190,6 +190,12 @@ absl::Status GpuExecutor::LoadModuleFromHsaco(const char* hsaco,
       "Feature not supported on CUDA platform (LoadModuleFromHsaco)");
 }
 
+absl::Status GpuExecutor::LoadModuleFromSpir(const char* spir, const size_t size,
+                                            CUmodule* module) {
+  return absl::InternalError(
+      "Feature not supported on CUDA platform (LoadModuleFromSpir)");
+}
+
 absl::Status GpuExecutor::GetKernel(const MultiKernelLoaderSpec& spec,
                                     Kernel* kernel) {
   GpuKernel* cuda_kernel = AsGpuKernel(kernel);

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -28,6 +28,10 @@ load(
     "if_rocm_is_configured",
 )
 load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
+load(
     "@tsl//tsl:tsl.bzl",
     "if_libtpu",
     "internal_visibility",
@@ -365,6 +369,8 @@ gpu_only_cc_library(
         "@local_config_cuda//cuda:cuda_headers",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",
+    ]) + if_sycl_is_configured([
+        "@local_config_sycl//sycl:sycl_headers",
     ]),
 )
 

--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -629,6 +629,13 @@ class GpuDriver {
   static absl::Status LoadHsaco(GpuContext* context, const char* hsaco_contents,
                                 GpuModuleHandle* module);
 
+  // Loads SPIR with the SYCL runtime and stores the resulting handle in
+  // "module". Any error logs that are produced are logged internally.
+  // (supported on SYCL only)
+  static absl::Status LoadSpirv(GpuContext* context,
+                                   const char* spir_contents, const size_t size,
+                                   GpuModuleHandle* module);
+
   // Retrieves a named kernel from a loaded module, and places the resulting
   // handle into function (outparam) on success. Neither kernel_name nor
   // function may be null. No ownership is taken of kernel_name.

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -343,6 +343,11 @@ class GpuExecutor : public internal::StreamExecutorInterface {
   absl::Status LoadModuleFromHsaco(const char* hsaco, GpuModuleHandle* module)
       TF_EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
 
+  // (supported on SYCL only)
+  absl::Status LoadModuleFromSpir(const char* spir, const size_t size,
+                                 GpuModuleHandle* module)
+      TF_EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
+
   absl::Status Launch(Stream* stream, const ThreadDim& thread_dims,
                       const BlockDim& block_dims,
                       const std::optional<ClusterDim>& cluster_dims,

--- a/xla/stream_executor/gpu/gpu_types.h
+++ b/xla/stream_executor/gpu/gpu_types.h
@@ -13,12 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// GPU (ROCm / CUDA) specific type handle resolution
+// GPU (SYCL / ROCm / CUDA) specific type handle resolution
 
 #ifndef XLA_STREAM_EXECUTOR_GPU_GPU_TYPES_H_
 #define XLA_STREAM_EXECUTOR_GPU_GPU_TYPES_H_
 
-#if TENSORFLOW_USE_ROCM
+#if TENSORFLOW_USE_SYCL
+
+#include <sycl/sycl.hpp>
+
+#elif TENSORFLOW_USE_ROCM
 
 #define __HIP_DISABLE_CPP_FUNCTIONS__
 
@@ -40,7 +44,34 @@ namespace gpu {
 // current CUDA/HIP version.
 struct UnsupportedGpuFeature {};
 
-#if TENSORFLOW_USE_ROCM
+#if TENSORFLOW_USE_SYCL
+typedef struct SYCLEventWrapper {
+  ::sycl::event* event;
+  ::sycl::queue* queue;
+} EventWrapper;
+
+using GpuContextHandle = ::sycl::context*;
+using GpuStreamHandle = ::sycl::queue*;
+using GpuEventHandle = EventWrapper*;
+using GpuFunctionHandle = ::sycl::kernel*;
+using GpuFunctionAttribute = const void*;
+using GpuDeviceHandle = ::sycl::device*;
+using GpuDevicePtr = void*;
+using GpuDeviceAttribute = const void*;
+using GpuDeviceProperty = const void*;
+using GpuModuleHandle = ze_module_handle_t;
+using GpuStatus = const void*;
+using GpuFuncCachePreference = const void*;
+using GpuSharedMemConfig = const void*;
+using GpuComplexType = std::complex<float>;
+using GpuDoubleComplexType = std::complex<double>;
+using GpuRngHandle = const void*;
+using GpuGraphHandle = const void*;
+using GpuGraphExecHandle = const void*;
+using GpuGraphNodeHandle = const void*;
+using GpuGraphConditionalHandle = UnsupportedGpuFeature;
+
+#elif TENSORFLOW_USE_ROCM
 
 using GpuContextHandle = hipCtx_t;
 using GpuStreamHandle = hipStream_t;

--- a/xla/stream_executor/gpu/redzone_allocator.cc
+++ b/xla/stream_executor/gpu/redzone_allocator.cc
@@ -305,6 +305,7 @@ static absl::StatusOr<RedzoneCheckStatus> CheckRedzonesForBuffer(
   return RedzoneCheckStatus::OK();
 }
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 absl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
   StreamExecutor* executor = stream_->parent();
 
@@ -356,6 +357,7 @@ absl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
 
   return RedzoneCheckStatus::OK();
 }
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 std::string RedzoneCheckStatus::RedzoneFailureMsg() const {
   return absl::StrFormat(

--- a/xla/stream_executor/kernel_spec.cc
+++ b/xla/stream_executor/kernel_spec.cc
@@ -35,9 +35,9 @@ KernelLoaderSpec::KernelLoaderSpec(absl::string_view kernel_name)
 InProcessSymbol::InProcessSymbol(void *symbol, std::string kernel_name)
     : KernelLoaderSpec(std::move(kernel_name)), symbol_(symbol) {}
 
-CudaCubinInMemory::CudaCubinInMemory(const char *bytes,
+CudaCubinInMemory::CudaCubinInMemory(const char *bytes, int size,
                                      absl::string_view kernel_name)
-    : KernelLoaderSpec(kernel_name), bytes_(bytes) {}
+    : KernelLoaderSpec(kernel_name), bytes_(bytes), size_(size) {}
 
 bool CompareComputeCapability(const std::tuple<int, int> &lhs,
                               const std::tuple<int, int> &rhs) {
@@ -167,9 +167,9 @@ MultiKernelLoaderSpec *MultiKernelLoaderSpec::AddInProcessSymbol(
 }
 
 MultiKernelLoaderSpec *MultiKernelLoaderSpec::AddCudaCubinInMemory(
-    const char *bytes, absl::string_view kernel_name) {
+    const char *bytes, int size, absl::string_view kernel_name) {
   CHECK(cuda_cubin_in_memory_ == nullptr);
-  cuda_cubin_in_memory_.reset(new CudaCubinInMemory{bytes, kernel_name});
+  cuda_cubin_in_memory_.reset(new CudaCubinInMemory{bytes, size, kernel_name});
   return this;
 }
 

--- a/xla/stream_executor/kernel_spec.h
+++ b/xla/stream_executor/kernel_spec.h
@@ -186,13 +186,16 @@ class CudaPtxInMemory : public KernelLoaderSpec {
 // Kernel loader specification for a CUBIN blob that resides in memory.
 class CudaCubinInMemory : public KernelLoaderSpec {
  public:
-  CudaCubinInMemory(const char *bytes, absl::string_view kernel_name);
+  CudaCubinInMemory(const char *bytes, int size, absl::string_view kernel_name);
   ~CudaCubinInMemory() override {}
 
   const char *bytes() const { return bytes_; }
+  const int size() const { return size_; }
 
  private:
   const char *bytes_;
+  // Size is required for SPIRV
+  int size_;
 
   CudaCubinInMemory(const CudaCubinInMemory &) = delete;
   void operator=(const CudaCubinInMemory &) = delete;
@@ -246,7 +249,7 @@ class MultiKernelLoaderSpec {
   // mangled by the compiler if it is not declared in an extern "C" scope.
   MultiKernelLoaderSpec *AddInProcessSymbol(void *symbol,
                                             absl::string_view kernel_name);
-  MultiKernelLoaderSpec *AddCudaCubinInMemory(const char *cubin_bytes,
+  MultiKernelLoaderSpec *AddCudaCubinInMemory(const char *cubin_bytes, int size,
                                               absl::string_view kernel_name);
   MultiKernelLoaderSpec *AddCudaPtxInMemory(absl::string_view ptx,
                                             absl::string_view kernel_name);

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -1164,6 +1164,14 @@ struct BitPatternToValue {
 
   return ret;
 }
+ 
+/* static */ tsl::Status GpuDriver::LoadSpirv(GpuContext* context,
+                                              const char* spir_contents,
+                                              const size_t size,
+                                              hipModule_t* module) {
+  return absl::Status{absl::StatusCode::kInternal,
+                      "Feature not supported on ROCm platform (LoadSpirv)"};
+}
 
 /* static */ absl::Status GpuDriver::SynchronousMemsetUint8(
     GpuContext* context, hipDeviceptr_t location, uint8 value, size_t size) {

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -461,6 +461,11 @@ absl::Status GpuExecutor::LoadModuleFromHsaco(const char* hsaco,
   return absl::OkStatus();
 }
 
+absl::Status GpuExecutor::LoadModuleFromSpir(const char* spir, const size_t size,
+                                             hipModule_t* module) {
+  LOG(FATAL) << "Feature not supported on ROCM platform (LoadModuleFromSpir)";
+}
+
 // This is a non-essential operation; if there's a failure, proceed without
 // logging an error. It's nearly certain that in case of failures, we'd never
 // get here in the first place; these are very low-impact routines.

--- a/xla/stream_executor/stream_executor_pimpl.h
+++ b/xla/stream_executor/stream_executor_pimpl.h
@@ -556,7 +556,7 @@ inline absl::StatusOr<TypedKernel<Args...>> StreamExecutor::CreateTypedKernel(
 
   if (!cubin_data.empty()) {
     loader_spec.AddCudaCubinInMemory(
-        reinterpret_cast<const char*>(cubin_data.data()), kernel_name);
+        reinterpret_cast<const char*>(cubin_data.data()), cubin_data.size(), kernel_name);
   }
 
   return TypedKernel<Args...>::Create(this, loader_spec);

--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -1,0 +1,214 @@
+# Description:
+#   SYCL-platform specific StreamExecutor support code.
+
+load(
+    "//xla/stream_executor:build_defs.bzl",
+    "stream_executor_friends",
+)
+load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
+load("@tsl//tsl:tsl.bzl", "internal_visibility", "tsl_copts")
+load("@tsl//tsl/platform:build_config_root.bzl", "if_static")
+load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = internal_visibility([":friends"]),
+    licenses = ["notice"],
+)
+
+package_group(
+    name = "friends",
+    packages = stream_executor_friends(),
+)
+
+cc_library(
+    name = "onednn_plugin",
+    srcs = ["sycl_dnn.cc"],
+    hdrs = ["sycl_dnn.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":sycl_driver",
+        ":sycl_executor",
+        ":sycl_platform_id",
+        "//xla/stream_executor",
+        "//xla/stream_executor:dnn",
+        "//xla/stream_executor:plugin_registry",
+        "//xla/stream_executor:stream_executor_internal",
+        "//xla/stream_executor/gpu:gpu_executor_header",
+        "//xla/stream_executor/gpu:gpu_timer_header",
+        "//xla/stream_executor/platform",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "sycl_gpu_runtime",
+    srcs = ["sycl_gpu_runtime.cc"],
+    hdrs = ["sycl_gpu_runtime.h"],
+    deps = [
+        "//xla/stream_executor/gpu:gpu_types_header",
+        "@com_google_absl//absl/strings",
+        "@local_config_sycl//sycl",
+        "@local_config_sycl//sycl:sycl_headers",
+        "@tsl//tsl/util:env_var",
+    ],
+)
+
+cc_library(
+    name = "sycl_driver",
+    srcs = ["sycl_driver.cc"],
+    deps = [
+        ":sycl_gpu_runtime",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/debugging:leak_check",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:stacktrace",
+        "@tsl//tsl/platform:status",
+        "//xla/stream_executor:device_options",
+        "//xla/stream_executor:stream_executor_headers",
+        "//xla/stream_executor/gpu:gpu_driver_header",
+        "//xla/stream_executor/platform",
+        "//xla/stream_executor/platform:dso_loader",
+    ] + if_sycl_is_configured([
+        "@local_config_sycl//sycl:mkl",
+    ]),
+)
+
+cc_library(
+    name = "sycl_collectives",
+    srcs = ["sycl_collectives.cc"],
+    deps = [
+        "//xla/stream_executor/gpu:gpu_collectives_header",
+        "//xla/stream_executor/gpu:gpu_driver_header",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "sycl_platform_id",
+    srcs = ["sycl_platform_id.cc"],
+    hdrs = ["sycl_platform_id.h"],
+    deps = ["//xla/stream_executor:platform"],
+)
+
+cc_library(
+    name = "sycl_platform",
+    srcs = ["sycl_platform.cc"],
+    hdrs = ["sycl_platform.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":sycl_executor",
+        ":sycl_platform_id",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "//xla/stream_executor",  # buildcleaner: keep
+        "//xla/stream_executor:executor_cache",
+        "//xla/stream_executor:multi_platform_manager",
+        "//xla/stream_executor:stream_executor_headers",
+        "//xla/stream_executor/gpu:gpu_executor_header",
+        "//xla/stream_executor/platform",
+    ],
+    alwayslink = True,  # Registers itself with the MultiPlatformManager.
+)
+
+cc_library(
+    name = "sycl_kernel",
+    srcs = ["sycl_kernel.cc"],
+    deps = [
+        ":sycl_gpu_runtime",
+        "//xla/stream_executor:stream_executor_headers",
+        "//xla/stream_executor/gpu:gpu_kernel_header",
+        "//xla/stream_executor/platform",
+    ],
+)
+
+cc_library(
+    name = "sycl_event",
+    srcs = ["sycl_event.cc"],
+    deps = [
+        ":sycl_driver",
+        "//xla/stream_executor:stream_executor_headers",
+        "//xla/stream_executor/gpu:gpu_event",
+        "//xla/stream_executor/gpu:gpu_stream_header",
+    ],
+)
+
+cc_library(
+    name = "sycl_executor",
+    srcs = ["sycl_executor.cc"],
+    deps = [
+        ":sycl_collectives",
+        ":sycl_driver",
+        ":sycl_event",
+        ":sycl_kernel",
+        ":sycl_platform_id",
+        "//xla/stream_executor:plugin_registry",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "//xla/stream_executor:event",
+        "//xla/stream_executor:stream_executor_headers",
+        "//xla/stream_executor:stream_executor_internal",
+        "//xla/stream_executor/gpu:gpu_command_buffer",
+        "//xla/stream_executor/platform",
+        "//xla/stream_executor/platform:dso_loader",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "all_runtime",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":onednn_plugin",
+        ":sycl_platform",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "sycl_rpath",
+    data = [],
+    linkopts = select({
+        "//conditions:default": [
+            "-Wl,-rpath,../local_config_sycl/sycl/sycl/lib",
+        ],
+    }),
+    deps = [],
+)
+
+cc_library(
+    name = "stream_executor_sycl",
+    deps = [
+        ":sycl_rpath",
+        "//xla/stream_executor:stream_executor_bundle",
+    ] + if_static(
+        [":all_runtime"],
+    ),
+)

--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -26,10 +26,10 @@ package_group(
 
 cc_library(
     name = "onednn_plugin",
-    srcs = ["sycl_dnn.cc"],
-    hdrs = ["sycl_dnn.h"],
+    srcs = if_sycl_is_configured(["sycl_dnn.cc"]),
+    hdrs = if_sycl_is_configured(["sycl_dnn.h"]),
     visibility = ["//visibility:public"],
-    deps = [
+    deps = if_sycl_is_configured([
         ":sycl_driver",
         ":sycl_executor",
         ":sycl_platform_id",
@@ -50,27 +50,27 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
-    ],
+    ]),
     alwayslink = True,
 )
 
 cc_library(
     name = "sycl_gpu_runtime",
-    srcs = ["sycl_gpu_runtime.cc"],
-    hdrs = ["sycl_gpu_runtime.h"],
-    deps = [
+    srcs = if_sycl_is_configured(["sycl_gpu_runtime.cc"]),
+    hdrs = if_sycl_is_configured(["sycl_gpu_runtime.h"]),
+    deps = if_sycl_is_configured([
         "//xla/stream_executor/gpu:gpu_types_header",
         "@com_google_absl//absl/strings",
         "@local_config_sycl//sycl",
         "@local_config_sycl//sycl:sycl_headers",
         "@tsl//tsl/util:env_var",
-    ],
+    ]),
 )
 
 cc_library(
     name = "sycl_driver",
-    srcs = ["sycl_driver.cc"],
-    deps = [
+    srcs = if_sycl_is_configured(["sycl_driver.cc"]),
+    deps = if_sycl_is_configured([
         ":sycl_gpu_runtime",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
@@ -91,20 +91,19 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_driver_header",
         "//xla/stream_executor/platform",
         "//xla/stream_executor/platform:dso_loader",
-    ] + if_sycl_is_configured([
         "@local_config_sycl//sycl:mkl",
     ]),
 )
 
 cc_library(
     name = "sycl_collectives",
-    srcs = ["sycl_collectives.cc"],
-    deps = [
+    srcs = if_sycl_is_configured(["sycl_collectives.cc"]),
+    deps = if_sycl_is_configured([
         "//xla/stream_executor/gpu:gpu_collectives_header",
         "//xla/stream_executor/gpu:gpu_driver_header",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
-    ],
+    ]),
 )
 
 cc_library(
@@ -116,10 +115,10 @@ cc_library(
 
 cc_library(
     name = "sycl_platform",
-    srcs = ["sycl_platform.cc"],
-    hdrs = ["sycl_platform.h"],
+    srcs = if_sycl_is_configured(["sycl_platform.cc"]),
+    hdrs = if_sycl_is_configured(["sycl_platform.h"]),
     visibility = ["//visibility:public"],
-    deps = [
+    deps = if_sycl_is_configured([
         ":sycl_executor",
         ":sycl_platform_id",
         "@com_google_absl//absl/base",
@@ -134,36 +133,36 @@ cc_library(
         "//xla/stream_executor:stream_executor_headers",
         "//xla/stream_executor/gpu:gpu_executor_header",
         "//xla/stream_executor/platform",
-    ],
+    ]),
     alwayslink = True,  # Registers itself with the MultiPlatformManager.
 )
 
 cc_library(
     name = "sycl_kernel",
-    srcs = ["sycl_kernel.cc"],
-    deps = [
+    srcs = if_sycl_is_configured(["sycl_kernel.cc"]),
+    deps = if_sycl_is_configured([
         ":sycl_gpu_runtime",
         "//xla/stream_executor:stream_executor_headers",
         "//xla/stream_executor/gpu:gpu_kernel_header",
         "//xla/stream_executor/platform",
-    ],
+    ]),
 )
 
 cc_library(
     name = "sycl_event",
-    srcs = ["sycl_event.cc"],
-    deps = [
+    srcs = if_sycl_is_configured(["sycl_event.cc"]),
+    deps = if_sycl_is_configured([
         ":sycl_driver",
         "//xla/stream_executor:stream_executor_headers",
         "//xla/stream_executor/gpu:gpu_event",
         "//xla/stream_executor/gpu:gpu_stream_header",
-    ],
+    ]),
 )
 
 cc_library(
     name = "sycl_executor",
-    srcs = ["sycl_executor.cc"],
-    deps = [
+    srcs = if_sycl_is_configured(["sycl_executor.cc"]),
+    deps = if_sycl_is_configured([
         ":sycl_collectives",
         ":sycl_driver",
         ":sycl_event",
@@ -178,17 +177,17 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_command_buffer",
         "//xla/stream_executor/platform",
         "//xla/stream_executor/platform:dso_loader",
-    ],
+    ]),
     alwayslink = True,
 )
 
 cc_library(
     name = "all_runtime",
     visibility = ["//visibility:public"],
-    deps = [
+    deps = if_sycl_is_configured([
         ":onednn_plugin",
         ":sycl_platform",
-    ],
+    ]),
     alwayslink = 1,
 )
 

--- a/xla/stream_executor/sycl/sycl_collectives.cc
+++ b/xla/stream_executor/sycl/sycl_collectives.cc
@@ -1,0 +1,37 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/gpu/gpu_driver.h"
+#include "xla/stream_executor/gpu/gpu_collectives.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<void*> GpuCollectives::CollectiveMemoryAllocate(
+    GpuContext* context, uint64_t bytes) {
+  return absl::UnimplementedError(
+      "Feature not supported on SYCL platform (CollectiveMemoryAllocate)");
+}
+
+absl::Status GpuCollectives::CollectiveMemoryDeallocate(GpuContext* context,
+                                                        void* location) {
+  return absl::UnimplementedError(
+      "Feature not supported on SYCL platform (CollectiveMemoryDeallocate)");
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/sycl/sycl_dnn.cc
+++ b/xla/stream_executor/sycl/sycl_dnn.cc
@@ -1,0 +1,100 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/sycl/sycl_dnn.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "absl/base/optimization.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+#include "xla/stream_executor/dnn.h"
+#include "xla/stream_executor/gpu/gpu_executor.h"
+#include "xla/stream_executor/gpu/gpu_timer.h"
+#include "xla/stream_executor/numeric_options.h"
+#include "xla/stream_executor/platform/initialize.h"
+#include "xla/stream_executor/plugin_registry.h"
+#include "xla/stream_executor/scratch_allocator.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/stream_executor_internal.h"
+#include "absl/strings/string_view.h"
+
+
+namespace stream_executor {
+namespace gpu {
+
+OnednnSupport::OnednnSupport(GpuExecutor* parent) : parent_(parent) {}
+
+absl::Status OnednnSupport::Init() {
+  return absl::OkStatus();
+}
+
+absl::StatusOr<stream_executor::dnn::VersionInfo> OnednnSupport::GetVersion() {
+  return dnn::VersionInfo(0, 0, 0);
+}
+
+}  // namespace gpu
+
+void initialize_onednn() {
+  absl::Status status =
+      PluginRegistry::Instance()->RegisterFactory<PluginRegistry::DnnFactory>(
+          sycl::kSyclPlatformId, "oneDNN",
+          [](internal::StreamExecutorInterface* parent) -> dnn::DnnSupport* {
+            gpu::GpuExecutor* sycl_executor =
+                dynamic_cast<gpu::GpuExecutor*>(parent);
+            if (sycl_executor == nullptr) {
+              LOG(ERROR) << "Attempting to initialize an instance of the oneDNN "
+                         << "support library with a non-SYCL StreamExecutor";
+              return nullptr;
+            }
+
+            gpu::OnednnSupport* dnn = new gpu::OnednnSupport(sycl_executor);
+            if (!dnn->Init().ok()) {
+              // Note: Init() will log a more specific error.
+              delete dnn;
+              return nullptr;
+            }
+            return dnn;
+          });
+
+  if (!status.ok()) {
+    LOG(ERROR) << "Unable to register oneDNN factory: " << status.message();
+  }
+}
+
+}  // namespace stream_executor
+
+STREAM_EXECUTOR_REGISTER_MODULE_INITIALIZER(register_onednn, {
+  stream_executor::initialize_onednn();
+});

--- a/xla/stream_executor/sycl/sycl_dnn.h
+++ b/xla/stream_executor/sycl/sycl_dnn.h
@@ -1,0 +1,95 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// oneDNN library support, implementing the general DnnSupport interface.
+
+#ifndef XLA_STREAM_EXECUTOR_SYCL_SYCL_DNN_H_
+#define XLA_STREAM_EXECUTOR_SYCL_SYCL_DNN_H_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/dnn.h"
+#include "xla/stream_executor/plugin_registry.h"
+
+namespace stream_executor {
+namespace gpu {
+
+class GpuExecutor;
+
+// onednn-library based DNN support. For details on overridden interface
+// functions, see dnn.h.
+class OnednnSupport : public dnn::DnnSupport {
+ public:
+  explicit OnednnSupport(GpuExecutor* parent);
+
+  absl::Status Init() override;
+  absl::StatusOr<stream_executor::dnn::VersionInfo> GetVersion() override;
+
+  absl::Status DoConvolve(
+      dnn::ConvolutionKind kind, dnn::DataType element_type,
+      dnn::DataType output_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      dnn::AlgorithmDesc algorithm_desc, DeviceMemory<uint8_t> scratch_memory,
+      dnn::ProfileResult* output_profile_result) override {
+    return absl::UnimplementedError(
+        "DnnSupport::DoConvolve not implemented on this platform.");
+  }
+
+  absl::Status DoPoolForward(dnn::DataType element_type, Stream* stream,
+                             const dnn::PoolingDescriptor& pooling_dimensions,
+                             const dnn::BatchDescriptor& input_dimensions,
+                             DeviceMemoryBase input_data,
+                             const dnn::BatchDescriptor& output_dimensions,
+                             DeviceMemoryBase output_data,
+                             ScratchAllocator* workspace_allocator) override {
+    return absl::UnimplementedError(
+        "DnnSupport::DoPoolForward not implemented on this platform.");
+  }
+
+  absl::Status DoPoolBackward(dnn::DataType element_type, Stream* stream,
+                              const dnn::PoolingDescriptor& pooling_dimensions,
+                              const dnn::BatchDescriptor& input_dimensions,
+                              DeviceMemoryBase input_data,
+                              const dnn::BatchDescriptor& output_dimensions,
+                              DeviceMemoryBase output_data,
+                              DeviceMemoryBase input_diff_data,
+                              DeviceMemoryBase output_diff_data,
+                              ScratchAllocator* workspace_allocator) override {
+    return absl::UnimplementedError(
+        "DnnSupport::DoPoolBackward not implemented on this platform.");
+  }
+
+ private:
+  GpuExecutor* parent_;  // Parent executor object. Not owned.
+
+  OnednnSupport(const OnednnSupport&) = delete;
+  void operator=(const OnednnSupport&) = delete;
+};
+
+}  // namespace gpu
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_SYCL_SYCL_DNN_H_

--- a/xla/stream_executor/sycl/sycl_driver.cc
+++ b/xla/stream_executor/sycl/sycl_driver.cc
@@ -1,0 +1,674 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "absl/base/casts.h"
+#include "absl/base/const_init.h"
+#include "absl/base/optimization.h"
+#include "absl/container/inlined_vector.h"
+#include "absl/debugging/leak_check.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
+#include "tsl/platform/env.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"
+#include "tsl/platform/stacktrace.h"
+#include "tsl/platform/threadpool.h"
+#include "xla/stream_executor/gpu/gpu_driver.h"
+#include "xla/stream_executor/platform/port.h"
+#include "xla/stream_executor/sycl/sycl_gpu_runtime.h"
+
+#include <level_zero/ze_api.h>
+
+#define RETURN_IF_SYCL_RES_ERROR(expr, ...)                            \
+  do {                                                                 \
+    SYCLError_t _res = (expr);                                         \
+    if (ABSL_PREDICT_FALSE(_res != SYCL_SUCCESS)) {                    \
+      return absl::InternalError(absl::StrCat(                         \
+          __VA_ARGS__, ": ", ToString(_res))); \
+    }                                                                  \
+  } while (0)
+
+namespace stream_executor {
+namespace gpu {
+
+class GpuContext {
+ public:
+  GpuContext(GpuDeviceHandle d, GpuContextHandle c) : device_(d), context_(c) {}
+
+  GpuDeviceHandle device() const { return device_; }
+  GpuContextHandle context() const { return context_; }
+
+  // Disallow copying and moving.
+  GpuContext(GpuContext&&) = delete;
+  GpuContext(const GpuContext&) = delete;
+  GpuContext& operator=(GpuContext&&) = delete;
+  GpuContext& operator=(const GpuContext&) = delete;
+
+ private:
+  GpuDeviceHandle device_;
+  GpuContextHandle context_;
+};
+
+namespace {
+
+static absl::Status InternalInit() { return ::absl::OkStatus(); }
+
+}  // namespace
+/* static */ absl::Status GpuDriver::Init() {
+  // Cached return value from calling InternalInit()
+  static absl::Status* init_retval = [] {
+    return new absl::Status(InternalInit());
+  }();
+  return *init_retval;
+}
+
+/* static */ absl::Status GpuDriver::GetDevice(int device_ordinal,
+                                              GpuDeviceHandle* device) {
+  auto res = SYCLGetDevice(device, device_ordinal);
+  if (res == SYCL_SUCCESS) {
+    return absl::OkStatus();
+  }
+
+  return absl::Status{
+      absl::StatusCode::kInternal,
+      absl::StrCat("failed call to syclDeviceGet: ", ToString(res))};
+}
+
+/* static */ absl::Status GpuDriver::GetDeviceName(GpuDeviceHandle device,
+                                                  std::string* device_name) {
+  *device_name = device->get_info<sycl::info::device::name>();
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::CreateContext(
+    int device_ordinal, GpuDeviceHandle device,
+    const DeviceOptions& device_options, GpuContext** context) {
+  GpuContextHandle sycl_context;
+  SYCLGetContext(&sycl_context);
+  *context = new GpuContext(device, sycl_context);
+  return absl::OkStatus();
+}
+
+/* static */ void GpuDriver::DestroyContext(GpuContext* context) {
+  if (context == nullptr) {
+    return;
+  }
+  delete context;
+}
+
+/* static */ absl::Status GpuDriver::LaunchKernel(
+    GpuContext* context, absl::string_view kernel_name, GpuFunctionHandle function,
+    unsigned int grid_dim_x, unsigned int grid_dim_y, unsigned int grid_dim_z,
+    unsigned int block_dim_x, unsigned int block_dim_y,
+    unsigned int block_dim_z, unsigned int shared_mem_bytes,
+    GpuStreamHandle stream, void** kernel_params, void** extra) {
+  VLOG(2) << "launching kernel: " << kernel_name << "; gdx: " << grid_dim_x
+          << " gdy: " << grid_dim_y << " gdz: " << grid_dim_z
+          << " bdx: " << block_dim_x << " bdy: " << block_dim_y
+          << " bdz: " << block_dim_z;
+  auto sycl_global_range =
+      sycl::range<3>(block_dim_z * grid_dim_z, block_dim_y * grid_dim_y,
+                     block_dim_x * grid_dim_x);
+  auto sycl_local_range = sycl::range<3>(block_dim_z, block_dim_y, block_dim_x);
+  sycl::nd_range<3> sycl_nd_range(
+      sycl::nd_range<3>(sycl_global_range, sycl_local_range));
+
+  stream->submit([&](auto& cgh) {
+    for (uint32_t i = 0; i < static_cast<size_t*>(extra[1])[0]; i++) {
+      cgh.set_arg(i, static_cast<void**>(extra[0])[i]);
+    }
+    cgh.parallel_for(sycl_nd_range, *function);
+  });
+
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::LoadPtx(GpuContext* context,
+                                            const char* ptx_contents,
+                                            ze_module_handle_t* module) {
+  return absl::Status{absl::StatusCode::kInternal,
+                     "Feature not supported on Levelzero platform (LoadPtx)"};
+}
+
+/* static */ absl::Status GpuDriver::LoadCubin(GpuContext* context,
+                                              const char* cubin_bytes,
+                                              ze_module_handle_t* module) {
+  return absl::Status{absl::StatusCode::kInternal,
+                     "Feature not supported on Levelzero platform (LoadCubin)"};
+}
+
+/* static */ absl::Status GpuDriver::LoadHsaco(GpuContext* context,
+                                              const char* hsaco_contents,
+                                              ze_module_handle_t* module) {
+  return absl::Status{absl::StatusCode::kInternal,
+                     "Feature not supported on Levelzero platform (LoadHsaco)"};
+}
+
+#define ZE_SAFE_CALL(call)                 \
+  {                                        \
+    ze_result_t status = (call);           \
+    if (status != 0) {                     \
+      LOG(FATAL) << "Error " << status; \
+      exit(1);                             \
+    }                                      \
+  }
+/* static */ absl::Status GpuDriver::LoadSpirv(
+    GpuContext* context, const char* spir_contents, const size_t size,
+    ze_module_handle_t* ze_module) {
+  const GpuContextHandle sycl_context = context->context();
+  const GpuDeviceHandle sycl_device = context->device();
+  auto ze_device =
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(*sycl_device);
+  auto ze_context =
+      sycl::get_native<sycl::backend::ext_oneapi_level_zero>(*sycl_context);
+
+  ze_module_desc_t moduleDesc = {ZE_STRUCTURE_TYPE_MODULE_DESC,
+                                 nullptr,
+                                 ZE_MODULE_FORMAT_IL_SPIRV,
+                                 size,
+                                 (const uint8_t*)spir_contents,
+                                 nullptr,
+                                 nullptr};
+
+  ze_module_build_log_handle_t buildlog;
+  ze_result_t status =
+      zeModuleCreate(ze_context, ze_device, &moduleDesc, ze_module, &buildlog);
+  if (status != 0) {
+    size_t szLog = 0;
+    zeModuleBuildLogGetString(buildlog, &szLog, nullptr);
+
+    std::unique_ptr<char> PLogs(new char[szLog]);
+    zeModuleBuildLogGetString(buildlog, &szLog, PLogs.get());
+    std::string PLog(PLogs.get());
+    LOG(FATAL) << "Error " << status << ": " << PLog;
+  }
+
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::GetModuleFunction(
+    GpuContext* context, ze_module_handle_t module, const char* kernel_name,
+    GpuFunctionHandle* sycl_kernel) {
+  const GpuContextHandle sycl_context = context->context();
+  CHECK(module != nullptr && kernel_name != nullptr);
+  ze_kernel_handle_t ze_kernel;
+  std::string kernel_name_fix = std::string(kernel_name);
+  ze_kernel_desc_t kernelDesc = {ZE_STRUCTURE_TYPE_KERNEL_DESC, nullptr, 0,
+                                 kernel_name_fix.c_str()};
+
+  if (VLOG_IS_ON(2)) {
+    bool First = true;
+    std::string PINames{""};
+    uint32_t Count = 0;
+    ZE_SAFE_CALL(zeModuleGetKernelNames(module, &Count, nullptr));
+    std::unique_ptr<const char*[]> PNames(new const char*[Count]);
+    ZE_SAFE_CALL(zeModuleGetKernelNames(module, &Count, PNames.get()));
+    for (uint32_t I = 0; I < Count; ++I) {
+      PINames += (!First ? ";" : "");
+      PINames += PNames[I];
+      First = false;
+    }
+    VLOG(2) << "Required kernel name: " << kernel_name;
+    VLOG(2) << "Module has kernel: " << PINames;
+  }
+  ZE_SAFE_CALL(zeKernelCreate(module, &kernelDesc, &ze_kernel));
+
+  sycl::kernel_bundle<sycl::bundle_state::executable> kernel_bundle =
+      sycl::make_kernel_bundle<sycl::backend::ext_oneapi_level_zero,
+                               sycl::bundle_state::executable>({module},
+                                                               *sycl_context);
+  auto kernel = sycl::make_kernel<sycl::backend::ext_oneapi_level_zero>(
+      {kernel_bundle, ze_kernel}, *sycl_context);
+  *sycl_kernel = new sycl::kernel(kernel);
+  return absl::OkStatus();
+}
+
+/* static */ bool GpuDriver::GetModuleSymbol(GpuContext* context,
+                                             ze_module_handle_t module,
+                                             const char* symbol_name,
+                                             void** dptr, size_t* bytes) {
+  CHECK(module != nullptr && symbol_name != nullptr &&
+        (*dptr != nullptr || bytes != nullptr));
+  ze_result_t status =
+      zeModuleGetGlobalPointer(module, symbol_name, bytes, dptr);
+  if (status != ZE_RESULT_SUCCESS) {
+    // symbol may not be found in the current module, but it may reside in
+    // another module.
+    VLOG(2) << "failed to get symbol \"" << symbol_name
+            << "\" from module. Error: " << status;
+    return false;
+  }
+  return true;
+}
+
+/* static */ void GpuDriver::UnloadModule(GpuContext* context,
+                                          ze_module_handle_t module) {
+  if (module) ZE_SAFE_CALL(zeModuleDestroy(module));
+}
+
+#undef ZE_SAFE_CALL
+
+/* static */ absl::Status GpuDriver::SynchronousMemsetUint8(GpuContext* context,
+                                                           void* location,
+                                                           uint8_t value,
+                                                           size_t size) {
+  RETURN_IF_SYCL_RES_ERROR(
+      SYCLMemsetD8(location, value, size, context->device()),
+      "Failed to memset memory");
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::SynchronousMemsetUint32(
+    GpuContext* context, void* location, uint32_t value, size_t uint32_count) {
+  RETURN_IF_SYCL_RES_ERROR(
+      SYCLMemsetD32(location, value, uint32_count, context->device()),
+      "Failed to memset memory");
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::AsynchronousMemsetUint8(
+    GpuContext* context, void* location, uint8_t value, size_t uint32_count,
+    GpuStreamHandle stream) {
+  RETURN_IF_SYCL_RES_ERROR(
+      SYCLMemsetD8Async(location, value, uint32_count, stream),
+      "Failed to enqueue async memset operation");
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::AsynchronousMemsetUint32(
+    GpuContext* context, void* location, uint32_t value, size_t uint32_count,
+    GpuStreamHandle stream) {
+  RETURN_IF_SYCL_RES_ERROR(
+      SYCLMemsetD32Async(location, value, uint32_count, stream),
+      "Failed to enqueue async memset operation");
+  return ::absl::OkStatus();
+}
+
+/* static */ bool GpuDriver::CreateStream(GpuContext* context,
+                                          GpuStreamHandle* stream, int priority) {
+  SYCLError_t res;
+  if (priority == 0) {
+    res = SYCLCreateStream(context->device(), stream);
+  } else {
+    LOG(ERROR)
+        << "CreateStream with priority is not supported on SYCL platform";
+  }
+
+  if (res != SYCL_SUCCESS) {
+    LOG(ERROR) << "could not allocate SYCL stream for context "
+               << context->context() << ": " << ToString(res);
+    return false;
+  }
+
+  VLOG(2) << "successfully created stream " << *stream << " for context "
+          << context->context() << " on thread";
+  return true;
+}
+
+/* static */ void GpuDriver::DestroyStream(GpuContext* context,
+                                           GpuStreamHandle* stream) {
+  if (*stream == nullptr) {
+    return;
+  }
+  SYCLError_t res = SYCLDestroyStream(context->device(), *stream);
+
+  if (res != SYCL_SUCCESS) {
+    LOG(ERROR) << "failed to destroy SYCL stream for context "
+               << context->context() << ": " << ToString(res);
+  } else {
+    VLOG(2) << "successfully destroyed stream " << *stream << " for context "
+            << context->context();
+    *stream = nullptr;
+  }
+}
+
+/* static */ void* GpuDriver::DeviceAllocate(GpuContext* context,
+                                             uint64_t bytes) {
+  if (bytes == 0) {
+    return nullptr;
+  }
+
+  void* ptr = SYCLMalloc(context->device(), bytes);
+  VLOG(2) << "allocated " << ptr << " for context " << context->context()
+          << " of " << bytes << " bytes";
+  return ptr;
+}
+
+/* static */ void GpuDriver::DeviceDeallocate(GpuContext* context,
+                                              void* location) {
+  SYCLFree(context->device(), location);
+  VLOG(2) << "deallocated device memory at " << location << " for context "
+          << context->context();
+}
+
+/* static */ void* GpuDriver::UnifiedMemoryAllocate(GpuContext* context,
+                                                    uint64_t bytes) {
+  if (bytes == 0) {
+    return nullptr;
+  }
+
+  void* ptr = SYCLMallocShared(context->device(), bytes);
+  VLOG(2) << "allocated " << ptr << " for context " << context->context()
+          << " of " << bytes << " bytes in unified memory";
+  return ptr;
+}
+
+/* static */ void GpuDriver::UnifiedMemoryDeallocate(GpuContext* context,
+                                                     void* location) {
+  SYCLFree(context->device(), location);
+  VLOG(2) << "deallocated unified memory at " << location << " for context "
+          << context->context();
+}
+
+/* static */ void* GpuDriver::HostAllocate(GpuContext* context,
+                                           uint64_t bytes) {
+  if (bytes == 0) {
+    return nullptr;
+  }
+
+  void* ptr = SYCLMallocHost(context->device(), bytes);
+  VLOG(2) << "allocated " << ptr << " for context " << context->context()
+          << " of " << bytes << " bytes";
+  return ptr;
+}
+
+/* static */ void GpuDriver::HostDeallocate(GpuContext* context,
+                                            void* location) {
+  SYCLFree(context->device(), location);
+  VLOG(2) << "deallocated host memory at " << location << " for context "
+          << context->context();
+}
+
+/* static */ int GpuDriver::GetGpuStreamPriority(
+    GpuContext* context, stream_executor::StreamPriority stream_priority) {
+  if (stream_priority == stream_executor::StreamPriority::Default) {
+    return 0;
+  }
+  LOG(FATAL) << "GetGpuStreamPriority not implemented on SYCL platform";
+  return 0;
+}
+
+/* static */ absl::Status GpuDriver::InitEvent(GpuContext* context,
+                                              GpuEventHandle* event_handle,
+                                              EventFlags flags) {
+  if (*event_handle != nullptr) {
+    LOG(FATAL) << "Event is wrongly initialized before using";
+  }
+
+  *event_handle = new EventWrapper();
+  (*event_handle)->event = new sycl::event;
+  (*event_handle)->queue = nullptr;
+
+  return absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::DestroyEvent(GpuContext* context,
+                                                 GpuEventHandle* event_handle) {
+  if (*event_handle == nullptr) {
+    return absl::Status{absl::StatusCode::kInvalidArgument,
+                       "input event cannot be null"};
+  }
+
+  delete (*event_handle)->event;
+  delete (*event_handle);
+  *event_handle = nullptr;
+
+  return absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::RecordEvent(GpuContext* context,
+                                                GpuEventHandle event_handle,
+                                                GpuStreamHandle stream) {
+  event_handle->queue = stream;
+  *(event_handle->event) = stream->ext_oneapi_submit_barrier();
+
+  return absl::OkStatus();
+}
+
+/* static */ bool GpuDriver::WaitStreamOnEvent(GpuContext* context,
+                                               GpuStreamHandle stream,
+                                               GpuEventHandle event_handle) {
+  if (stream != event_handle->queue) {
+    const std::vector<sycl::event> event_list{*(event_handle->event)};
+    stream->ext_oneapi_submit_barrier(event_list);
+  }
+
+  return true;
+}
+
+/* static */ bool GpuDriver::SynchronizeContext(GpuContext* context) {
+  SYCLError_t res = SYCLCtxSynchronize(context->device());
+  if (res != SYCL_SUCCESS) {
+    LOG(ERROR) << "could not synchronize on SYCL context: " << ToString(res)
+               << " :: " << tsl::CurrentStackTrace();
+    return false;
+  }
+
+  return true;
+}
+
+/* static */ absl::Status GpuDriver::SynchronizeStream(GpuContext* context,
+                                                      GpuStreamHandle stream) {
+  CHECK(stream != nullptr);
+  stream->wait();
+  return ::absl::OkStatus();
+}
+
+/* static */ bool GpuDriver::IsStreamIdle(GpuContext* context,
+                                          GpuStreamHandle stream) {
+  return true;
+}
+
+/* static */ absl::Status GpuDriver::SynchronousMemcpyD2H(GpuContext* context,
+                                                         void* host_dst,
+                                                         void* gpu_src,
+                                                         uint64_t size) {
+  RETURN_IF_SYCL_RES_ERROR(
+      SYCLMemcpyDtoH(host_dst, gpu_src, size, context->device()),
+      absl::StrFormat("failed to synchronous memcpy from device to host "
+                      "host dst: %p; GPU src: %p; size: %u=0x%x",
+                      host_dst, absl::bit_cast<void*>(gpu_src), size, size));
+  VLOG(2) << "successfully sync memcpy'd d2h of " << size << " bytes to "
+          << host_dst;
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::SynchronousMemcpyH2D(GpuContext* context,
+                                                         void* gpu_dst,
+                                                         const void* host_src,
+                                                         uint64_t size) {
+  RETURN_IF_SYCL_RES_ERROR(
+      SYCLMemcpyHtoD(gpu_dst, host_src, size, context->device()),
+      absl::StrFormat(
+          "failed to synchronous memcpy from host to device: GPU dst: %p;"
+          " host src: %p; size: %u=0x%x",
+          absl::bit_cast<void*>(gpu_dst), host_src, size, size));
+  VLOG(2) << "successfully enqueued sync memcpy h2d of " << size << " bytes";
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::Status GpuDriver::SynchronousMemcpyD2D(GpuContext* context,
+                                                         void* gpu_dst,
+                                                         void* gpu_src,
+                                                         uint64_t size) {
+  RETURN_IF_SYCL_RES_ERROR(
+      SYCLMemcpyDtoD(gpu_dst, gpu_src, size, context->device()),
+      absl::StrFormat(
+          "failed to synchronous memcpy from device to device: GPU dst: %p; "
+          "GPU src: %p; size: %u=0x%x",
+          absl::bit_cast<void*>(gpu_dst), absl::bit_cast<void*>(gpu_src), size,
+          size));
+  VLOG(2) << "successfully sync memcpy'd d2d of " << size << " bytes";
+  return ::absl::OkStatus();
+}
+
+/* static */ bool GpuDriver::AsynchronousMemcpyD2H(GpuContext* context,
+                                                   void* host_dst,
+                                                   void* gpu_src, uint64_t size,
+                                                   GpuStreamHandle stream) {
+  SYCLError_t res = SYCLMemcpyDtoHAsync(host_dst, gpu_src, size, stream);
+  if (res != SYCL_SUCCESS) {
+    LOG(ERROR) << absl::StrFormat(
+        "failed to enqueue async memcpy from device to host: %s; host dst: %p; "
+        "GPU src: %p; size: %u=0x%x",
+        ToString(res), host_dst, absl::bit_cast<void*>(gpu_src), size, size);
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memcpy d2h of " << size
+          << " bytes from " << absl::bit_cast<void*>(gpu_src) << " to "
+          << host_dst << " on stream " << stream;
+  return true;
+}
+
+/* static */ bool GpuDriver::AsynchronousMemcpyH2D(GpuContext* context,
+                                                   void* gpu_dst,
+                                                   const void* host_src,
+                                                   uint64_t size,
+                                                   GpuStreamHandle stream) {
+  SYCLError_t res = SYCLMemcpyHtoDAsync(gpu_dst, host_src, size, stream);
+  if (res != SYCL_SUCCESS) {
+    LOG(ERROR) << absl::StrFormat(
+        "failed to enqueue async memcpy from host to device: %s; GPU dst: %p; "
+        "host src: %p; size: %u=0x%x",
+        ToString(res), absl::bit_cast<void*>(gpu_dst), host_src, size, size);
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memcpy h2d of " << size << " bytes"
+          << " from " << host_src << " to " << absl::bit_cast<void*>(gpu_dst)
+          << " on stream " << stream;
+  return true;
+}
+
+/* static */ bool GpuDriver::AsynchronousMemcpyD2D(GpuContext* context,
+                                                   void* gpu_dst, void* gpu_src,
+                                                   uint64_t size,
+                                                   GpuStreamHandle stream) {
+  SYCLError_t res = SYCLMemcpyDtoDAsync(gpu_dst, gpu_src, size, stream);
+  if (res != SYCL_SUCCESS) {
+    LOG(ERROR) << absl::StrFormat(
+        "failed to enqueue async memcpy from device to device: %s; GPU dst: "
+        "%p; "
+        "GPU src: %p; size: %u=0x%x",
+        ToString(res), absl::bit_cast<void*>(gpu_dst), gpu_src, size, size);
+    return false;
+  }
+  VLOG(2) << "successfully enqueued async memcpy d2d of " << size << " bytes"
+          << " from " << gpu_src << " to " << absl::bit_cast<void*>(gpu_dst)
+          << " on stream " << stream;
+  return true;
+}
+
+/* static */ int GpuDriver::GetDeviceCount() {
+  int device_count = 0;
+  SYCLError_t res = SYCLGetDeviceCount(&device_count);
+  if (res != SYCL_SUCCESS) {
+    LOG(ERROR) << "could not retrieve SYCL device count: " << ToString(res);
+    return 0;
+  }
+
+  return device_count;
+}
+
+/* static */ absl::Status GpuDriver::GetComputeCapability(int* cc_major,
+                                                         int* cc_minor,
+                                                         GpuDeviceHandle device) {
+  *cc_major = 100;
+  *cc_minor = 100;
+  return ::absl::OkStatus();
+}
+
+/* static */ absl::StatusOr<int> GpuDriver::GetMultiprocessorCount(
+    GpuDeviceHandle device) {
+  return device->template get_info<
+             sycl::ext::intel::info::device::gpu_subslices_per_slice>() *
+         device
+             ->template get_info<sycl::ext::intel::info::device::gpu_slices>();
+}
+
+/* static */ absl::StatusOr<int64_t> GpuDriver::GetMaxSharedMemoryPerCore(
+    GpuDeviceHandle device) {
+  return device->template get_info<sycl::info::device::local_mem_size>();
+}
+
+/* static */ absl::StatusOr<int64_t> GpuDriver::GetMaxSharedMemoryPerBlock(
+    GpuDeviceHandle device) {
+  return device->template get_info<sycl::info::device::local_mem_size>();
+}
+
+/* static */ absl::Status GpuDriver::GetGridLimits(int* x, int* y, int* z,
+                                                  GpuDeviceHandle device) {
+  BlockDim block_dim_limit;
+  *x = device->template get_info<
+      sycl::ext::oneapi::experimental::info::device::max_work_groups<1>>();
+  *y = device->template get_info<
+      sycl::ext::oneapi::experimental::info::device::max_work_groups<1>>();
+  *z = device->template get_info<
+      sycl::ext::oneapi::experimental::info::device::max_work_groups<1>>();
+  return absl::OkStatus();
+}
+
+/* static */ absl::StatusOr<int32_t> GpuDriver::GetDriverVersion() {
+  int32_t version = 0;
+  // TODO: Implement it for SYCL platform.
+  return version;
+}
+
+/* static */ bool GpuDriver::GetDeviceMemoryInfo(GpuContext* context,
+                                                 int64_t* free_out,
+                                                 int64_t* total_out) {
+  *free_out = -1;
+  *total_out = context->device()
+                   ->template get_info<sycl::info::device::global_mem_size>();
+  return true;
+}
+
+/* static */ bool GpuDriver::GetDeviceTotalMemory(GpuDeviceHandle device,
+                                                  uint64_t* result) {
+  *result = device->get_info<sycl::info::device::global_mem_size>();
+  return true;
+}
+
+/* static */ absl::StatusOr<int> GpuDriver::GetMaxOccupiedBlocksPerCore(
+    GpuContext* context, GpuFunctionHandle kernel, int threads_per_block,
+    size_t dynamic_shared_memory_bytes) {
+  int max_blocks = 0;
+
+  SYCLError_t result = SYCL_SUCCESS;
+  // TODO(SYCL) implement this feature in HIP
+  if (result != SYCL_SUCCESS) {
+    return absl::Status{
+        absl::StatusCode::kInternal,
+        absl::StrFormat("failed to calculate occupancy of kernel %p: %s",
+                        kernel, ToString(result))};
+  }
+
+  return max_blocks;
+}
+
+}  // namespace gpu
+}  // namespace stream_executor

--- a/xla/stream_executor/sycl/sycl_event.cc
+++ b/xla/stream_executor/sycl/sycl_event.cc
@@ -1,0 +1,43 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tsl/platform/statusor.h"
+#include "xla/stream_executor/sycl/sycl_gpu_runtime.h"
+#include "xla/stream_executor/gpu/gpu_stream.h"
+#include "xla/stream_executor/gpu/gpu_event.h"
+
+namespace stream_executor {
+namespace gpu {
+
+namespace sycl = ::sycl;
+
+Event::Status GpuEvent::PollForStatus() {
+  auto* event = gpu_event_->event;
+  auto event_status =
+      event->get_info<sycl::info::event::command_execution_status>();
+
+  switch (event_status) {
+    case sycl::info::event_command_status::submitted:
+    case sycl::info::event_command_status::running:
+      return Event::Status::kPending;
+    case sycl::info::event_command_status::complete:
+      return Event::Status::kComplete;
+    default:
+      return Event::Status::kUnknown;
+  }
+}
+
+}  // namespace gpu
+}  // namespace stream_executor

--- a/xla/stream_executor/sycl/sycl_executor.cc
+++ b/xla/stream_executor/sycl/sycl_executor.cc
@@ -1,0 +1,706 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <unistd.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "tsl/platform/env.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/numbers.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/util/env_var.h"
+#include "tsl/platform/fingerprint.h"
+#include "xla/stream_executor/gpu/gpu_command_buffer.h"
+#include "xla/stream_executor/gpu/gpu_driver.h"
+#include "xla/stream_executor/gpu/gpu_event.h"
+#include "xla/stream_executor/gpu/gpu_executor.h"
+#include "xla/stream_executor/gpu/gpu_kernel.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform/initialize.h"
+#include "xla/stream_executor/platform/port.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor_internal.h"
+#include "xla/stream_executor/stream_executor_pimpl.h"
+#include "xla/stream_executor/plugin_registry.h"
+#include "xla/stream_executor/sycl/sycl_gpu_runtime.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+
+namespace stream_executor {
+namespace gpu {
+
+static GpuEvent* AsGpuEvent(Event* event) {
+  DCHECK(event != nullptr);
+  return static_cast<GpuEvent*>(event->implementation());
+}
+
+static void* AsSyclDevicePtr(const DeviceMemoryBase& gpu_mem) {
+  return const_cast<void*>(gpu_mem.opaque());
+}
+
+// See description on const version above.
+static void* AsSyclDevicePtr(DeviceMemoryBase* gpu_mem) {
+  return AsSyclDevicePtr(*gpu_mem);
+}
+
+GpuExecutor::~GpuExecutor() {
+  CHECK(kernel_to_gpu_binary_.empty()) << "GpuExecutor has live kernels.";
+  CHECK(gpu_binary_to_module_.empty()) << "GpuExecutor has loaded modules.";
+  if (context_ != nullptr) {
+    GpuDriver::DestroyContext(context_);
+  }
+}
+
+absl::Status GpuExecutor::Init(int device_ordinal,
+                              DeviceOptions device_options) {
+  device_ordinal_ = device_ordinal;
+  auto status = GpuDriver::GetDevice(device_ordinal_, &device_);
+  if (!status.ok()) {
+    return status;
+  }
+
+  return GpuDriver::CreateContext(device_ordinal_, device_, device_options,
+                                  &context_);
+}
+
+absl::Status GpuExecutor::LoadModuleFromCuBin(const char* cubin,
+                                             ze_module_handle_t* module) {
+  LOG(FATAL) << "Feature not supported on SYCL platform (LoadModuleFromCuBin)";
+}
+
+absl::Status GpuExecutor::LoadModuleFromPtx(const char* ptx,
+                                           ze_module_handle_t* module) {
+  LOG(FATAL) << "Feature not supported on SYCL platform (LoadModuleFromPtx)";
+}
+
+absl::Status GpuExecutor::LoadModuleFromHsaco(const char* hsaco,
+                                             ze_module_handle_t* module) {
+  LOG(FATAL) << "Feature not supported on SYCL platform (LoadModuleFromHsaco)";
+}
+
+absl::Status GpuExecutor::LoadModuleFromSpir(const char* spirv,
+                                            const size_t size,
+                                            ze_module_handle_t* module) {
+  uint64_t module_refcount;
+  std::tie(*module, module_refcount) = gpu_binary_to_module_[spirv];
+
+  if (*module == nullptr) {
+    TF_RETURN_IF_ERROR(GpuDriver::LoadSpirv(context_, spirv, size, module));
+
+    module_refcount = 1;
+    VLOG(3) << "Loaded SPIRV " << static_cast<const void*>(spirv)
+            << " as module " << *module;
+  } else {
+    ++module_refcount;
+    VLOG(3) << "SPIRV " << static_cast<const void*>(spirv)
+            << " is already loaded as module " << *module;
+  }
+  gpu_binary_to_module_[spirv] = {*module, module_refcount};
+  return absl::OkStatus();
+}
+
+absl::Status GpuExecutor::GetKernel(const MultiKernelLoaderSpec& spec,
+                                    Kernel* kernel) {
+  GpuKernel* spir_kernel = AsGpuKernel(kernel);
+  ze_module_handle_t module = nullptr;
+  string kernel_name;
+
+  if (spec.has_cuda_cubin_in_memory()) {
+    kernel_name = spec.cuda_cubin_in_memory().kernel_name();
+    const char* spirv = spec.cuda_cubin_in_memory().bytes();
+    int size = spec.cuda_cubin_in_memory().size();
+    absl::MutexLock lock{&in_memory_modules_mu_};
+    TF_RETURN_IF_ERROR(LoadModuleFromSpir(spirv, size, &module));
+    kernel_to_gpu_binary_[kernel] = spirv;
+  } else {
+    return absl::InternalError("No method of loading SPIR kernel provided");
+  }
+
+  VLOG(2) << "getting function " << kernel_name << " from module " << module;
+  TF_RETURN_IF_ERROR(GpuDriver::GetModuleFunction(
+      context_, module, kernel_name.c_str(), spir_kernel->gpu_function_ptr()));
+
+  // We have to trust the kernel loader spec arity because there doesn't
+  // appear to be a way to reflect on the number of expected arguments w/the
+  // SPIR API.
+  spir_kernel->set_arity(spec.arity());
+
+  KernelMetadata kernel_metadata;
+  TF_RETURN_IF_ERROR(GetKernelMetadata(spir_kernel, &kernel_metadata));
+  kernel->set_metadata(kernel_metadata);
+  kernel->set_name(kernel_name);
+  return absl::OkStatus();
+}
+
+bool GpuExecutor::UnloadGpuBinary(const void* gpu_binary) {
+  auto module_it = gpu_binary_to_module_.find(gpu_binary);
+  if (gpu_binary_to_module_.end() == module_it) {
+    VLOG(3) << "No loaded  SPIR module for " << gpu_binary;
+    return false;
+  }
+  auto& module = module_it->second.first;
+  auto& refcount = module_it->second.second;
+  VLOG(3) << "Found SPIR module " << module << " with refcount " << refcount;
+  if (--refcount == 0) {
+    VLOG(3) << "Unloading  SPIR module " << module;
+    GpuDriver::UnloadModule(context_, module);
+    gpu_binary_to_module_.erase(module_it);
+  }
+  return true;
+}
+
+void GpuExecutor::UnloadKernel(const Kernel* kernel) {
+  VLOG(3) << "Unloading kernel " << kernel << " : " << kernel->name();
+
+  absl::MutexLock lock{&in_memory_modules_mu_};
+  auto gpu_binary_it = kernel_to_gpu_binary_.find(kernel);
+  if (kernel_to_gpu_binary_.end() == gpu_binary_it) {
+    VLOG(3) << "Kernel " << kernel << " : " << kernel->name()
+            << " has never been loaded.";
+    return;  // We've never seen this kernel.
+  }
+  VLOG(3) << "Kernel " << kernel << " : " << kernel->name()
+          << " has loaded GPU code " << gpu_binary_it->second;
+  UnloadGpuBinary(gpu_binary_it->second);
+  kernel_to_gpu_binary_.erase(gpu_binary_it);
+}
+
+absl::Status GpuExecutor::LoadModule(const MultiModuleLoaderSpec& spec,
+                                    ModuleHandle* module_handle) {
+  ze_module_handle_t ze_module = nullptr;
+  if (spec.has_cuda_cubin_in_memory()) {
+    absl::MutexLock lock{&in_memory_modules_mu_};
+
+    TF_RETURN_IF_ERROR(LoadModuleFromSpir(
+        reinterpret_cast<const char*>(spec.cuda_cubin_in_memory().data()),
+        spec.cuda_cubin_in_memory().size(), &ze_module));
+    *module_handle = ModuleHandle(const_cast<void*>(
+        static_cast<const void*>(spec.cuda_cubin_in_memory().data())));
+    return absl::OkStatus();
+  } else {
+    return absl::InternalError("No SPIR binary found");
+  }
+}
+
+bool GpuExecutor::UnloadModule(ModuleHandle module_handle) {
+  const char* gpu_binary = reinterpret_cast<const char*>(module_handle.id());
+  absl::MutexLock lock{&in_memory_modules_mu_};
+  return UnloadGpuBinary(gpu_binary);
+}
+
+namespace {
+absl::uint128 Fingerprint128(const absl::string_view s) {
+  auto fp = tsl::Fingerprint128(s);
+  return absl::MakeUint128(fp.high64, fp.low64);
+}
+}  // namespace
+
+absl::StatusOr<std::shared_ptr<DeviceMemoryBase>>
+GpuExecutor::CreateOrShareConstant(Stream* stream,
+                                   absl::Span<const uint8_t> content) {
+  absl::MutexLock lock{&shared_constants_mu_};
+  // We assume all constants are uniquely identified by this hash. In the
+  // (highly unlikely) event of a hash collision, the program will likely crash
+  // (because the cached constant that will be returned by mistake is unlikely
+  // to have the correct size).
+  absl::uint128 fingerprint = Fingerprint128(absl::string_view(
+      reinterpret_cast<const char*>(content.data()), content.size()));
+  // Must insert nullptr first to get an iterator to the insertion point.
+  auto insert_result = shared_constants_.insert(
+      {fingerprint, std::weak_ptr<DeviceMemoryBase>()});
+  auto it = insert_result.first;
+  bool was_already_in_cache = !insert_result.second;
+  std::shared_ptr<DeviceMemoryBase> shared_constant;
+
+  if (was_already_in_cache) {
+    shared_constant = it->second.lock();
+  }
+
+  if (shared_constant == nullptr) {
+    // Either the constant wasn't found in the cache, or it was but its
+    // weak_ptr had expired.
+    DeviceMemoryBase* new_constant =
+        new DeviceMemoryBase(Allocate(content.size(), /*memory_space=*/0));
+    if (new_constant->opaque() == nullptr) {
+      return absl::InternalError(absl::StrFormat("Failed to allocate %d bytes for new constant",
+                          content.size()));
+    }
+
+    absl::Status status =
+        stream->ThenMemcpy(new_constant, content.data(), content.size())
+            .BlockHostUntilDone();
+    if (!status.ok()) {
+      Deallocate(new_constant);
+      return absl::InternalError(absl::StrFormat("Memcpy to device address %p failed",
+                                         new_constant->opaque()));
+    }
+
+    // Capturing 'this' in the custom deleter means this executor must
+    // outlive all shared uses of this constant.
+    shared_constant = std::shared_ptr<DeviceMemoryBase>(
+        new_constant, [this](DeviceMemoryBase* p) {
+          Deallocate(p);
+          delete p;
+        });
+    it->second = std::weak_ptr<DeviceMemoryBase>(shared_constant);
+  }
+
+  return shared_constant;
+}
+
+absl::Status GpuExecutor::GetKernelMetadata(GpuKernel* spir_kernel,
+                                           KernelMetadata* kernel_metadata) {
+  int value = 0;
+  // TODO: implement this feature in SPIR
+  kernel_metadata->set_registers_per_thread(value);
+  kernel_metadata->set_shared_memory_bytes(value);
+  return absl::OkStatus();
+}
+
+absl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
+                                 const BlockDim& block_dims,
+                                 const ClusterDim& cluster_dims,
+                                 const Kernel& kernel, const KernelArgs& args) {
+  if (cluster_dims.x != 1 || cluster_dims.y != 1 || cluster_dims.z != 1)
+    return absl::UnimplementedError("Not implemented for SYCL");
+  return Launch(stream, thread_dims, block_dims, kernel, args);
+}
+
+absl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
+                                const BlockDim& block_dims,
+                                 const Kernel& kernel, const KernelArgs& args) {
+  CHECK_EQ(kernel.Arity() + (args.number_of_shared_bytes() > 0),
+           args.number_of_arguments());
+  GpuStreamHandle gpu_stream = AsGpuStreamValue(stream);
+  const GpuKernel* spir_kernel = AsGpuKernel(&kernel);
+  GpuFunctionHandle sycl_kernel = spir_kernel->AsGpuFunctionHandle();
+
+  // Only perform/print the occupancy check once.  Even just checking to see
+  // whether we've done an occupancy check on this kernel before isn't free
+  // (because we have to synchronize), so we only do this at -v 2+.
+  if (VLOG_IS_ON(2)) {
+    absl::MutexLock lock(&launched_kernels_mu_);
+    if (launched_kernels_.count(sycl_kernel) == 0) {
+      launched_kernels_.insert(sycl_kernel);
+    }
+  }
+
+  auto* packed_args = DynCast<KernelArgsPackedArrayBase>(&args);
+  if (!packed_args)
+    return absl::InternalError("Unsupported kernel arguments type");
+
+  std::vector<void*> kernargs;
+  for (const void *const arg: packed_args->argument_addresses()) {
+    kernargs.push_back(reinterpret_cast<void*>(*static_cast<const uint64_t*>(arg)));
+  }
+  size_t size = kernargs.size();
+  void* config[] = {kernargs.data(), &size};
+
+  return GpuDriver::LaunchKernel(
+      context_, kernel.name(), sycl_kernel, block_dims.x, block_dims.y,
+      block_dims.z, thread_dims.x, thread_dims.y, thread_dims.z,
+      args.number_of_shared_bytes(), gpu_stream, nullptr, (void**)&config);
+}
+
+absl::Status GpuExecutor::Submit(Stream* stream,
+                                const CommandBuffer& command_buffer) {
+  LOG(FATAL) << "Submit is not implemented in sycl_executor";
+}
+
+DeviceMemoryBase GpuExecutor::Allocate(uint64_t size, int64_t memory_space) {
+  CHECK_EQ(memory_space, 0);
+  return DeviceMemoryBase(GpuDriver::DeviceAllocate(context_, size), size);
+}
+
+void GpuExecutor::Deallocate(DeviceMemoryBase* mem) {
+  GpuDriver::DeviceDeallocate(context_, mem->opaque());
+}
+
+bool GpuExecutor::HostMemoryRegister(void* location, uint64_t size) {
+  return false;
+}
+
+bool GpuExecutor::HostMemoryUnregister(void* location) { return false; }
+
+bool GpuExecutor::SynchronizeAllActivity() {
+  return GpuDriver::SynchronizeContext(context_);
+}
+
+absl::Status GpuExecutor::SynchronousMemZero(DeviceMemoryBase* location,
+                                            uint64_t size) {
+  if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+      size % 4 == 0) {
+    return GpuDriver::SynchronousMemsetUint32(
+        context_, AsSyclDevicePtr(location), 0x0, size / 4);
+  }
+  return GpuDriver::SynchronousMemsetUint8(context_, AsSyclDevicePtr(location),
+                                           0x0, size);
+}
+
+absl::Status GpuExecutor::SynchronousMemSet(DeviceMemoryBase* location,
+                                           int value, uint64_t size) {
+  if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+      size % 4 == 0) {
+    uint8_t byte_value = static_cast<uint8_t>(value);
+    uint32_t pattern = (byte_value << 24) | (byte_value << 16) |
+                       (byte_value << 8) | byte_value;
+    return GpuDriver::SynchronousMemsetUint32(
+        context_, AsSyclDevicePtr(location), pattern, size / 4);
+  }
+  return GpuDriver::SynchronousMemsetUint8(context_, AsSyclDevicePtr(location),
+                                           value, size);
+}
+
+absl::Status GpuExecutor::SynchronousMemcpy(DeviceMemoryBase* gpu_dst,
+                                           const void* host_src,
+                                           uint64_t size) {
+  return GpuDriver::SynchronousMemcpyH2D(context_, AsSyclDevicePtr(gpu_dst),
+                                         host_src, size);
+}
+
+absl::Status GpuExecutor::SynchronousMemcpy(void* host_dst,
+                                           const DeviceMemoryBase& gpu_src,
+                                           uint64_t size) {
+  return GpuDriver::SynchronousMemcpyD2H(context_, host_dst,
+                                         AsSyclDevicePtr(gpu_src), size);
+}
+
+absl::Status GpuExecutor::SynchronousMemcpyDeviceToDevice(
+    DeviceMemoryBase* gpu_dst, const DeviceMemoryBase& gpu_src, uint64_t size) {
+  return GpuDriver::SynchronousMemcpyD2D(context_, AsSyclDevicePtr(gpu_dst),
+                                         AsSyclDevicePtr(gpu_src), size);
+}
+
+absl::Status GpuExecutor::MemZero(Stream* stream, DeviceMemoryBase* location,
+                                 uint64_t size) {
+  if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+      size % 4 == 0) {
+    return Memset32(stream, location, 0x0, size);
+  } else {
+    return Memset(stream, location, 0x0, size);
+  }
+}
+
+absl::Status GpuExecutor::Memset(Stream* stream, DeviceMemoryBase* location,
+                                uint8_t pattern, uint64_t size) {
+  VLOG(2) << "enqueueing memset8 operation onto stream " << stream
+          << " at location " << location << " with size " << size
+          << " and pattern " << std::hex << pattern;
+  return GpuDriver::AsynchronousMemsetUint8(context_, AsSyclDevicePtr(location),
+                                            pattern, size,
+                                            AsGpuStreamValue(stream));
+}
+
+absl::Status GpuExecutor::Memset32(Stream* stream, DeviceMemoryBase* location,
+                                  uint32_t pattern, uint64_t size) {
+  VLOG(2) << "enqueueing memset32 operation onto stream " << stream
+          << " at location " << location << " with size " << size
+          << " and pattern " << std::hex << pattern;
+  CHECK(reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
+        size % 4 == 0);
+  return GpuDriver::AsynchronousMemsetUint32(
+      context_, AsSyclDevicePtr(location), pattern, size / 4,
+      AsGpuStreamValue(stream));
+}
+
+bool GpuExecutor::Memcpy(Stream* stream, void* host_dst,
+                         const DeviceMemoryBase& gpu_src, uint64_t size) {
+  return GpuDriver::AsynchronousMemcpyD2H(context_, host_dst,
+                                          AsSyclDevicePtr(gpu_src), size,
+                                          AsGpuStreamValue(stream));
+}
+
+bool GpuExecutor::Memcpy(Stream* stream, DeviceMemoryBase* gpu_dst,
+                         const void* host_src, uint64_t size) {
+  return GpuDriver::AsynchronousMemcpyH2D(context_, AsSyclDevicePtr(gpu_dst),
+                                          host_src, size,
+                                          AsGpuStreamValue(stream));
+}
+
+bool GpuExecutor::MemcpyDeviceToDevice(Stream* stream,
+                                       DeviceMemoryBase* gpu_dst,
+                                       const DeviceMemoryBase& gpu_src,
+                                       uint64_t size) {
+  return GpuDriver::AsynchronousMemcpyD2D(context_, AsSyclDevicePtr(gpu_dst),
+                                          AsSyclDevicePtr(gpu_src), size,
+                                          AsGpuStreamValue(stream));
+}
+
+bool GpuExecutor::HostCallback(Stream* stream,
+                               absl::AnyInvocable<absl::Status() &&> callback) {
+  auto callback_ptr_new =
+      new absl::AnyInvocable<void() &&>([cb = std::move(callback)]() mutable {
+        absl::Status s = std::move(cb)();
+        if (!s.ok()) {
+          LOG(WARNING) << "Host callback failed: " << s;
+        }
+      });
+  auto ptr_new = reinterpret_cast<void*>(callback_ptr_new);
+  auto callback_function = std::function<void()>([ptr_new]() {
+    auto* callback_ptr =
+        reinterpret_cast<absl::AnyInvocable<void() &&>*>(ptr_new);
+    std::move (*callback_ptr)();
+    delete callback_ptr;
+  });
+
+  GpuStreamHandle stream_handle = AsGpuStreamValue(stream);
+  stream_handle->submit(
+      [&](auto& cgh) { cgh.host_task(std::move(callback_function)); });
+  return true;
+}
+
+absl::Status GpuExecutor::AllocateEvent(Event* event) {
+  return AsGpuEvent(event)->Init();
+}
+
+absl::Status GpuExecutor::DeallocateEvent(Event* event) {
+  return AsGpuEvent(event)->Destroy();
+}
+
+absl::Status GpuExecutor::RecordEvent(Stream* stream, Event* event) {
+  return AsGpuEvent(event)->Record(AsGpuStream(stream));
+}
+
+absl::Status GpuExecutor::WaitForEvent(Stream* stream, Event* event) {
+  if (GpuDriver::WaitStreamOnEvent(context_, AsGpuStream(stream)->gpu_stream(),
+                                   AsGpuEvent(event)->gpu_event())) {
+    return absl::OkStatus();
+  } else {
+    return absl::InternalError(absl::StrFormat("error recording waiting for SYCL event on stream %p",
+                        stream));
+  }
+}
+
+absl::Status GpuExecutor::WaitForEventOnExternalStream(std::intptr_t stream,
+                                                      Event* event) {
+  if (GpuDriver::WaitStreamOnEvent(context_,
+                                   absl::bit_cast<GpuStreamHandle>(stream),
+                                   AsGpuEvent(event)->gpu_event())) {
+    return absl::OkStatus();
+  } else {
+    return absl::InternalError("error waiting for SYCL event on external stream");
+  }
+}
+
+Event::Status GpuExecutor::PollForEventStatus(Event* event) {
+  return AsGpuEvent(event)->PollForStatus();
+}
+
+bool GpuExecutor::AllocateStream(Stream* stream) {
+  absl::MutexLock l(&alive_gpu_streams_mu_);
+  bool out = AsGpuStream(stream)->Init();
+  alive_gpu_streams_[stream->platform_specific_handle().stream] = stream;
+  return out;
+}
+
+void GpuExecutor::DeallocateStream(Stream* stream) {
+  GpuStream* gpu_stream = AsGpuStream(stream);
+  absl::MutexLock l(&alive_gpu_streams_mu_);
+  alive_gpu_streams_.erase(gpu_stream->platform_specific_stream());
+  gpu_stream->Destroy();
+}
+
+bool GpuExecutor::CreateStreamDependency(Stream* dependent, Stream* other) {
+  // For thread safe, event should be thread local.
+  auto* other_queue = AsGpuStreamValue(other);
+  auto event = other_queue->ext_oneapi_submit_barrier();
+
+  EventWrapper event_wrapper;
+  event_wrapper.event = &event;
+  event_wrapper.queue = AsGpuStreamValue(other);
+
+  return GpuDriver::WaitStreamOnEvent(context_, AsGpuStreamValue(dependent),
+                                      &event_wrapper);
+}
+
+absl::Status GpuExecutor::BlockHostUntilDone(Stream* stream) {
+  GpuStreamHandle stream_handle = AsGpuStreamValue(stream);
+  stream_handle->wait();
+  return absl::OkStatus();
+}
+
+blas::BlasSupport* GpuExecutor::CreateBlas() { return nullptr; }
+
+dnn::DnnSupport* GpuExecutor::CreateDnn() {
+  PluginRegistry* registry = PluginRegistry::Instance();
+  absl::StatusOr<PluginRegistry::DnnFactory> status =
+      registry->GetFactory<PluginRegistry::DnnFactory>(sycl::kSyclPlatformId);
+  if (!status.ok()) {
+    LOG(ERROR) << "Unable to retrieve DNN factory: "
+               << status.status().message();
+    return nullptr;
+  }
+
+  return status.value()(this);
+}
+
+fft::FftSupport* GpuExecutor::CreateFft() { return nullptr; }
+
+bool GpuExecutor::CanEnablePeerAccessTo(StreamExecutorInterface* other) {
+  return false;
+}
+
+absl::Status GpuExecutor::EnablePeerAccessTo(StreamExecutorInterface* other) {
+  LOG(FATAL) << "Peer access is not supported on SYCL platform";
+}
+
+bool GpuExecutor::DeviceMemoryUsage(int64_t* free, int64_t* total) const {
+  return GpuDriver::GetDeviceMemoryInfo(context_, free, total);
+}
+
+bool GpuExecutor::GetSymbol(const std::string& symbol_name,
+                            ModuleHandle module_handle, void** mem,
+                            size_t* bytes) {
+  CHECK(static_cast<bool>(module_handle));
+
+  auto lookup_in_module = [&](ze_module_handle_t module) {
+    CHECK(module != nullptr);
+    return GpuDriver::GetModuleSymbol(context_, module, symbol_name.c_str(),
+                                      mem, bytes);
+  };
+
+  {  // give limited scope to mutex_lock
+    absl::MutexLock lock{&in_memory_modules_mu_};
+    auto it = gpu_binary_to_module_.find(module_handle.id());
+    CHECK(it != gpu_binary_to_module_.end());
+    return lookup_in_module(it->second.first);
+  }
+
+  LOG(INFO) << "Failed to find symbol: " << symbol_name;
+  return false;
+}
+
+absl::Status FillBlockDimLimit(GpuDeviceHandle device,
+                              BlockDim* block_dim_limit) {
+  // The BlockDim name is a mismatch against these GRID_DIM_* queries because
+  // we use BlockDims to express the dimensions of blocks within a grid
+  // (as opposed to ThreadDim which expresses the dimensions of threads
+  // within a block).
+  int x, y, z;
+  TF_RETURN_IF_ERROR(GpuDriver::GetGridLimits(&x, &y, &z, device));
+  block_dim_limit->x = x;
+  block_dim_limit->y = y;
+  block_dim_limit->z = z;
+  return absl::OkStatus();
+}
+
+std::unique_ptr<internal::EventInterface>
+GpuExecutor::CreateEventImplementation() {
+  return std::unique_ptr<internal::EventInterface>(new GpuEvent(this));
+}
+
+std::unique_ptr<internal::StreamInterface>
+GpuExecutor::GetStreamImplementation() {
+  return std::unique_ptr<internal::StreamInterface>(new GpuStream(this));
+}
+
+absl::StatusOr<std::unique_ptr<Kernel>> GpuExecutor::CreateKernel() {
+  return std::make_unique<GpuKernel>(this);
+}
+
+absl::StatusOr<std::unique_ptr<CommandBuffer>> GpuExecutor::CreateCommandBuffer(
+    CommandBuffer::Mode mode) {
+  return absl::UnimplementedError("Not implemented for SYCL");
+}
+
+std::unique_ptr<GpuCommandBuffer> GpuExecutor::CreateCommandBuffer(
+    CommandBuffer::Mode mode, GpuGraphHandle graph, bool is_owned_graph) {
+  VLOG(2) << "Create HIP command buffer (HIP graph) from existing graph "
+          << graph << "; is_owned_graph=" << is_owned_graph;
+  return std::make_unique<GpuCommandBuffer>(mode, /*parent=*/this, graph,
+                                            is_owned_graph);
+}
+
+void* GpuExecutor::platform_specific_context() { return context_; }
+
+GpuContext* GpuExecutor::gpu_context() { return context_; }
+
+absl::StatusOr<std::unique_ptr<DeviceDescription>>
+GpuExecutor::CreateDeviceDescription(int device_ordinal) {
+  GpuDeviceHandle device;
+  TF_RETURN_IF_ERROR(GpuDriver::GetDevice(device_ordinal, &device));
+
+  internal::DeviceDescriptionBuilder builder;
+
+  int32_t max_workgroup_size =
+      device->template get_info<::sycl::info::device::max_work_group_size>();
+  builder.set_threads_per_block_limit(max_workgroup_size);
+
+  int clock_ghz =
+      device->template get_info<::sycl::info::device::max_clock_frequency>() /
+      1000.;
+  builder.set_clock_rate_ghz(clock_ghz);
+
+  uint64_t device_memory_size = static_cast<uint64_t>(-1);
+  (void)GpuDriver::GetDeviceTotalMemory(device, &device_memory_size);
+  builder.set_device_memory_size(device_memory_size);
+
+  int global_mem_cache_size =
+      device->template get_info<::sycl::info::device::global_mem_cache_size>();
+  builder.set_l2_cache_size(global_mem_cache_size);
+
+  int32_t memory_clock_khz = device->template get_info<
+      ::sycl::ext::intel::info::device::memory_clock_rate>();
+  int32_t memory_bus_width = device->template get_info<
+      ::sycl::ext::intel::info::device::memory_bus_width>();
+  builder.set_memory_bandwidth(2 * memory_clock_khz * 1e6 * memory_bus_width /
+                               8);
+
+  {
+    BlockDim block_dim_limit;
+    TF_RETURN_IF_ERROR(FillBlockDimLimit(device, &block_dim_limit));
+    builder.set_block_dim_limit(block_dim_limit);
+  }
+
+  {
+    std::string device_name;
+    TF_RETURN_IF_ERROR(GpuDriver::GetDeviceName(device, &device_name));
+    builder.set_name(device_name);
+  }
+
+  builder.set_device_vendor("INTEL Corporation");
+  // This means AMPERE.
+  builder.set_cuda_compute_capability(8, 0);
+  builder.set_shared_memory_per_core(
+      GpuDriver::GetMaxSharedMemoryPerCore(device).value());
+  builder.set_shared_memory_per_block(
+      GpuDriver::GetMaxSharedMemoryPerBlock(device).value());
+  int core_count = GpuDriver::GetMultiprocessorCount(device).value();
+  builder.set_core_count(core_count);
+  int eu_count =
+      device->template get_info<::sycl::ext::intel::info::device::gpu_eu_count>();
+  builder.set_fpus_per_core(eu_count);
+  builder.set_threads_per_core_limit(max_workgroup_size);
+  builder.set_threads_per_warp(32);
+
+  return builder.Build();
+}
+
+}  // namespace gpu
+
+}  // namespace stream_executor
+
+STREAM_EXECUTOR_REGISTER_MODULE_INITIALIZER(sycl_executor, {});

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.cc
@@ -1,0 +1,382 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/sycl/sycl_gpu_runtime.h"
+
+#include <cassert>
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+
+#include "absl/base/call_once.h"
+#include "absl/synchronization/mutex.h"
+#include "tsl/util/env_var.h"
+
+namespace {
+class DevicePool {
+ public:
+  static sycl::context& getDeviceContext() {
+    static sycl::context context(GetDevicesPool());
+    return context;
+  }
+
+  static SYCLError_t getDeviceCount(int* count) {
+    *count = GetDevicesPool().size();
+    return SYCL_SUCCESS;
+  }
+
+  static SYCLError_t getDevice(sycl::device** device, int device_ordinal) {
+    if (device_ordinal >= GetDevicesPool().size()) {
+      return SYCL_ERROR_INVALID_DEVICE;
+    } else {
+      *device = &GetDevicesPool()[device_ordinal];
+      return SYCL_SUCCESS;
+    }
+  }
+
+ private:
+  static std::vector<sycl::device>& GetDevicesPool() {
+    static absl::once_flag init_device_flag;
+    static std::vector<sycl::device> devices;
+
+    absl::call_once(init_device_flag, []() {
+      for (const auto& platform : sycl::platform::get_platforms()) {
+        auto platform_name = platform.get_info<sycl::info::platform::name>();
+        bool is_level_zero =
+            platform_name.find("Level-Zero") != std::string::npos;
+        if (is_level_zero) {
+          LOG(INFO) << "Selected platform: " << platform_name;
+          for (const auto& device : platform.get_devices()) {
+            if (device.is_gpu()) {
+              devices.push_back(device);
+            }
+          }
+        }
+      }
+      if (devices.size() <= 0) {
+        LOG(ERROR) << "Can not found any devices.";
+      }
+    });
+
+    return devices;
+  }
+};
+
+}  // namespace
+
+bool IsMultipleStreamEnabled() {
+  static absl::once_flag init_flag;
+  static bool is_multiple_stream_enabled = false;
+
+  absl::call_once(init_flag, [&]() {
+    const char* env = std::getenv("XLA_SYCL_ENABLE_MULTIPLE_STREAM");
+
+    if (env != nullptr) {
+      std::string str_value = absl::AsciiStrToLower(env);
+      if (str_value == "1" || str_value == "true") {
+        is_multiple_stream_enabled = true;
+      }
+    }
+  });
+
+  return is_multiple_stream_enabled;
+}
+
+/******************* SYCL context management**************************/
+static sycl::async_handler SYCLAsyncHandler = [](sycl::exception_list eL) {
+  for (auto& e : eL) {
+    try {
+      std::rethrow_exception(e);
+    } catch (sycl::exception& e) {
+      LOG(ERROR) << "SYCL Exception: " << e.what() << ", file = " << __FILE__
+                 << ", line = " << __LINE__ << ".";
+    }
+  }
+};
+
+class SYCLStreamPool {
+ public:
+  static SYCLError_t getDefaultStream(sycl::device* device_handle,
+                                      sycl::queue** stream_p) {
+    *stream_p = SYCLStreamPool::GetStreamsPool(device_handle)[0].get();
+    return SYCL_SUCCESS;
+  }
+
+  static SYCLError_t createStream(sycl::device* device_handle,
+                                  sycl::queue** stream_p) {
+    if (IsMultipleStreamEnabled()) {
+      sycl::property_list propList{sycl::property::queue::in_order()};
+      SYCLStreamPool::GetStreamsPool(device_handle)
+          .push_back(std::make_shared<sycl::queue>(
+              DevicePool::getDeviceContext(), *device_handle, SYCLAsyncHandler,
+              propList));
+    }
+    *stream_p = SYCLStreamPool::GetStreamsPool(device_handle).back().get();
+    return SYCL_SUCCESS;
+  }
+
+  static SYCLError_t syncContext(sycl::device* device_handle) {
+    for (auto stream : SYCLStreamPool::GetStreamsPool(device_handle)) {
+      stream->wait();
+    }
+    return SYCL_SUCCESS;
+  }
+
+  static SYCLError_t destroyStream(sycl::device* device_handle,
+                                   sycl::queue* stream_handle) {
+    if (stream_handle == nullptr) return SYCL_ERROR_INVALID_STREAM;
+    auto stream_pool = SYCLStreamPool::GetStreamsPool(device_handle);
+    for (int i = 0; i < stream_pool.size(); i++) {
+      if (stream_pool[i].get() == stream_handle) {
+        stream_pool.erase(stream_pool.begin() + i);
+        return SYCL_SUCCESS;
+      }
+    }
+    return SYCL_ERROR_INVALID_STREAM;
+  }
+
+ private:
+  static std::vector<std::shared_ptr<sycl::queue>>& GetStreamsPool(
+      sycl::device* device_handle) {
+    static std::unordered_map<sycl::device*,
+                              std::vector<std::shared_ptr<sycl::queue>>>
+        stream_pool_map;
+    auto iter = stream_pool_map.find(device_handle);
+    if (iter != stream_pool_map.end()) return iter->second;
+    sycl::property_list propList{sycl::property::queue::in_order()};
+    std::vector<std::shared_ptr<sycl::queue>> stream_pool = {
+        std::make_shared<sycl::queue>(DevicePool::getDeviceContext(),
+                                      *device_handle, SYCLAsyncHandler,
+                                      propList)};
+    stream_pool_map.insert(std::make_pair(device_handle, stream_pool));
+    return stream_pool_map[device_handle];
+  }
+};
+
+SYCLError_t SYCLGetContext(sycl::context** context) {
+  *context = &DevicePool::getDeviceContext();
+  return SYCL_SUCCESS;
+}
+
+SYCLError_t SYCLGetDeviceCount(int* count) {
+  return DevicePool::getDeviceCount(count);
+}
+
+SYCLError_t SYCLGetDevice(sycl::device** device, int device_ordinal) {
+  return DevicePool::getDevice(device, device_ordinal);
+}
+
+SYCLError_t SYCLCreateStream(sycl::device* device_handle,
+                             sycl::queue** stream_p) {
+  return SYCLStreamPool::createStream(device_handle, stream_p);
+}
+
+SYCLError_t SYCLDestroyStream(sycl::device* device_handle,
+                              sycl::queue* stream_handle) {
+  return SYCLStreamPool::destroyStream(device_handle, stream_handle);
+}
+
+SYCLError_t SYCLCtxSynchronize(sycl::device* device_handle) {
+  return SYCLStreamPool::syncContext(device_handle);
+}
+
+/************************* SYCL memory management
+ * ***************************/
+
+static void memcpyHostToDevice(void* dstDevice, const void* srcHost,
+                               size_t ByteCount, bool async,
+                               sycl::queue* stream) {
+  if (ByteCount == 0) return;
+
+  auto event = stream->memcpy(dstDevice, srcHost, ByteCount);
+  if (!async) {
+    event.wait();
+  }
+}
+
+static void memcpyDeviceToHost(void* dstHost, const void* srcDevice,
+                               size_t ByteCount, bool async,
+                               sycl::queue* stream) {
+  if (ByteCount == 0) return;
+
+  auto event = stream->memcpy(dstHost, srcDevice, ByteCount);
+
+  if (!async) {
+    event.wait();
+  }
+}
+
+static void memcpyDeviceToDevice(void* dstDevice, const void* srcDevice,
+                                 size_t ByteCount, bool async,
+                                 sycl::queue* stream) {
+  if (ByteCount == 0) return;
+
+  auto event = stream->memcpy(dstDevice, srcDevice, ByteCount);
+
+  if (!async) {
+    event.wait();
+  }
+}
+
+static void memsetDeviceD8(void* dstDevice, unsigned char value, size_t n,
+                           bool async, sycl::queue* stream) {
+  if (n == 0) return;
+
+  auto event = stream->memset(dstDevice, value, n * sizeof(uint8_t));
+  if (!async) {
+    event.wait();
+  }
+}
+
+static void memsetDeviceD32(void* dstDevice, int value, size_t n, bool async,
+                            sycl::queue* stream) {
+  if (n == 0) return;
+
+  auto event = stream->fill(dstDevice, value, n);
+
+  if (!async) {
+    event.wait();
+  }
+}
+
+SYCLError_t SYCLMemcpyDtoH(void* dstHost, const void* srcDevice,
+                           size_t ByteCount, sycl::device* device) {
+  sycl::queue* stream;
+  auto res = SYCLStreamPool::getDefaultStream(device, &stream);
+  memcpyDeviceToHost(dstHost, srcDevice, ByteCount, false, stream);
+  return res;
+}
+
+SYCLError_t SYCLMemcpyHtoD(void* dstDevice, const void* srcHost,
+                           size_t ByteCount, sycl::device* device) {
+  sycl::queue* stream;
+  auto res = SYCLStreamPool::getDefaultStream(device, &stream);
+  memcpyHostToDevice(dstDevice, srcHost, ByteCount, false, stream);
+  return res;
+}
+
+SYCLError_t SYCLMemcpyDtoD(void* dstDevice, const void* srcDevice,
+                           size_t ByteCount, sycl::device* device) {
+  sycl::queue* stream;
+  auto res = SYCLStreamPool::getDefaultStream(device, &stream);
+  memcpyDeviceToDevice(dstDevice, srcDevice, ByteCount, false, stream);
+  return res;
+}
+
+SYCLError_t SYCLMemcpyDtoHAsync(void* dstHost, const void* srcDevice,
+                                size_t ByteCount, sycl::queue* stream) {
+  sycl::usm::alloc DstAllocType =
+      get_pointer_type(dstHost, stream->get_context());
+  memcpyDeviceToHost(dstHost, srcDevice, ByteCount,
+                     DstAllocType == sycl::usm::alloc::host, stream);
+  return SYCL_SUCCESS;
+}
+
+SYCLError_t SYCLMemcpyHtoDAsync(void* dstDevice, const void* srcHost,
+                                size_t ByteCount, sycl::queue* stream) {
+  sycl::usm::alloc SrcAllocType =
+      get_pointer_type(srcHost, stream->get_context());
+  memcpyHostToDevice(dstDevice, srcHost, ByteCount,
+                     SrcAllocType == sycl::usm::alloc::host, stream);
+  return SYCL_SUCCESS;
+}
+
+SYCLError_t SYCLMemcpyDtoDAsync(void* dstDevice, const void* srcDevice,
+                                size_t ByteCount, sycl::queue* stream) {
+  memcpyDeviceToDevice(dstDevice, srcDevice, ByteCount, true, stream);
+  return SYCL_SUCCESS;
+}
+
+SYCLError_t SYCLMemsetD8(void* dstDevice, unsigned char uc, size_t N,
+                         sycl::device* device) {
+  sycl::queue* stream;
+  auto res = SYCLStreamPool::getDefaultStream(device, &stream);
+  memsetDeviceD8(dstDevice, uc, N, false, stream);
+  return res;
+}
+
+SYCLError_t SYCLMemsetD8Async(void* dstDevice, unsigned char uc, size_t N,
+                              sycl::queue* stream) {
+  memsetDeviceD8(dstDevice, uc, N, true, stream);
+  return SYCL_SUCCESS;
+}
+
+SYCLError_t SYCLMemsetD32(void* dstDevice, unsigned int ui, size_t N,
+                          sycl::device* device) {
+  sycl::queue* stream;
+  auto res = SYCLStreamPool::getDefaultStream(device, &stream);
+  memsetDeviceD32(dstDevice, ui, N, false, stream);
+  return res;
+}
+
+SYCLError_t SYCLMemsetD32Async(void* dstDevice, unsigned int ui, size_t N,
+                               sycl::queue* stream) {
+  memsetDeviceD32(dstDevice, ui, N, true, stream);
+  return SYCL_SUCCESS;
+}
+
+void* SYCLMalloc(sycl::device* device, size_t ByteCount) {
+  sycl::queue* stream;
+  SYCLStreamPool::getDefaultStream(device, &stream);
+
+  // Always use default 0 stream to allocate mem
+  auto ptr = aligned_alloc_device(/*alignment=*/64, ByteCount, *stream);
+  return static_cast<void*>(ptr);
+}
+
+void* SYCLMallocHost(sycl::device* device, size_t ByteCount) {
+  sycl::queue* stream;
+  SYCLStreamPool::getDefaultStream(device, &stream);
+
+  // Always use default 0 stream to allocate mem
+  auto ptr = aligned_alloc_host(/*alignment=*/64, ByteCount, *stream);
+  return static_cast<void*>(ptr);
+}
+
+void* SYCLMallocShared(sycl::device* device, size_t ByteCount) {
+  sycl::queue* stream;
+  SYCLStreamPool::getDefaultStream(device, &stream);
+
+  // Always use default 0 stream to allocate mem
+  auto ptr = aligned_alloc_shared(/*alignment=*/64, ByteCount, *stream);
+  return static_cast<void*>(ptr);
+}
+
+void SYCLFree(sycl::device* device, void* ptr) {
+  sycl::queue* stream;
+  SYCLStreamPool::getDefaultStream(device, &stream);
+
+  // Always use default 0 stream to free mem
+  sycl::free(ptr, *stream);
+}
+
+const char* ToString(SYCLError_t error) {
+  switch (error) {
+    case SYCL_SUCCESS:
+      return "SYCL succeed.";
+    case SYCL_ERROR_NO_DEVICE:
+      return "SYCL did not find the device.";
+    case SYCL_ERROR_INVALID_DEVICE:
+      return "SYCL got invalid device id.";
+    case SYCL_ERROR_INVALID_POINTER:
+      return "SYCL got invalid pointer.";
+    case SYCL_ERROR_INVALID_STREAM:
+      return "SYCL got invalid stream.";
+    case SYCL_ERROR_DESTROY_DEFAULT_STREAM:
+      return "SYCL cannot destroy default stream.";
+    default:
+      return "SYCL got invalid error code.";
+  }
+}

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.h
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.h
@@ -1,0 +1,89 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_SYCL_SYCL_GPU_RUNTIME_H_
+#define XLA_STREAM_EXECUTOR_SYCL_SYCL_GPU_RUNTIME_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/strings/ascii.h"
+#include "xla/stream_executor/gpu/gpu_types.h"
+
+enum SYCLError_t {
+  SYCL_SUCCESS,
+  SYCL_ERROR_NO_DEVICE,
+  SYCL_ERROR_NOT_READY,
+  SYCL_ERROR_INVALID_DEVICE,
+  SYCL_ERROR_INVALID_POINTER,
+  SYCL_ERROR_INVALID_STREAM,
+  SYCL_ERROR_DESTROY_DEFAULT_STREAM,
+};
+
+bool IsMultipleStreamEnabled();
+
+const char* ToString(SYCLError_t error);
+
+SYCLError_t SYCLGetContext(sycl::context** context);
+
+SYCLError_t SYCLGetDeviceCount(int* count);
+
+SYCLError_t SYCLGetDevice(sycl::device** device, int device_ordinal);
+
+SYCLError_t SYCLCreateStream(sycl::device* device_handle, sycl::queue** stream);
+
+SYCLError_t SYCLDestroyStream(sycl::device* device_handle, sycl::queue* stream);
+
+SYCLError_t SYCLCtxSynchronize(sycl::device* device_handle);
+
+SYCLError_t SYCLMemcpyDtoH(void* dstHost, const void* srcDevice,
+                           size_t ByteCount, sycl::device* device);
+
+SYCLError_t SYCLMemcpyHtoD(void* dstDevice, const void* srcHost,
+                           size_t ByteCount, sycl::device* device);
+
+SYCLError_t SYCLMemcpyDtoD(void* dstDevice, const void* srcDevice,
+                           size_t ByteCount, sycl::device* device);
+
+SYCLError_t SYCLMemcpyDtoHAsync(void* dstHost, const void* srcDevice,
+                                size_t ByteCount, sycl::queue* stream);
+
+SYCLError_t SYCLMemcpyHtoDAsync(void* dstDevice, const void* srcHost,
+                                size_t ByteCount, sycl::queue* stream);
+
+SYCLError_t SYCLMemcpyDtoDAsync(void* dstDevice, const void* srcDevice,
+                                size_t ByteCount, sycl::queue* stream);
+
+SYCLError_t SYCLMemsetD8(void* dstDevice, unsigned char uc, size_t N,
+                         sycl::device* device);
+
+SYCLError_t SYCLMemsetD8Async(void* dstDevice, unsigned char uc, size_t N,
+                              sycl::queue* stream);
+
+SYCLError_t SYCLMemsetD32(void* dstDevice, unsigned int ui, size_t N,
+                          sycl::device* device);
+
+SYCLError_t SYCLMemsetD32Async(void* dstDevice, unsigned int ui, size_t N,
+                               sycl::queue* stream);
+
+void* SYCLMalloc(sycl::device* device, size_t ByteCount);
+
+void* SYCLMallocHost(sycl::device* device, size_t ByteCount);
+
+void* SYCLMallocShared(sycl::device* device, size_t ByteCount);
+
+void SYCLFree(sycl::device* device, void* ptr);
+
+#endif  // XLA_STREAM_EXECUTOR_SYCL_SYCL_GPU_RUNTIME_H_

--- a/xla/stream_executor/sycl/sycl_kernel.cc
+++ b/xla/stream_executor/sycl/sycl_kernel.cc
@@ -1,0 +1,34 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/gpu/gpu_kernel.h"
+
+namespace stream_executor {
+namespace gpu {
+
+absl::StatusOr<int32_t> GpuKernel::GetMaxOccupiedBlocksPerCore(
+    ThreadDim threads, size_t dynamic_shared_memory_bytes) const {
+  int32_t threads_per_block = threads.x * threads.y * threads.z;
+  VLOG(3) << "Get kernel block occupancy: " << name_
+          << "; threads_per_block: " << threads_per_block
+          << "; dynamic_shared_memory_bytes: " << dynamic_shared_memory_bytes;
+
+  return GpuDriver::GetMaxOccupiedBlocksPerCore(gpu_context_, gpu_function_,
+                                                threads_per_block,
+                                                dynamic_shared_memory_bytes);
+}
+
+}  // namespace gpu
+}  // namespace stream_executor

--- a/xla/stream_executor/sycl/sycl_platform.cc
+++ b/xla/stream_executor/sycl/sycl_platform.cc
@@ -1,0 +1,146 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/sycl/sycl_platform.h"
+
+#include "absl/base/call_once.h"
+#include "absl/base/const_init.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+#include "xla/stream_executor/gpu/gpu_executor.h"
+#include "xla/stream_executor/platform/initialize.h"
+
+namespace stream_executor {
+namespace gpu {
+
+SyclPlatform::SyclPlatform()
+    : name_("SYCL"), min_numa_node_(0), limit_numa_node_(0) {}
+
+SyclPlatform::~SyclPlatform() {}
+
+// Due to legacy issues in user code, we can't currently call InpectNumaNodes
+// at module initialization time, because non-GPU programs still include this
+// plugin via various methods, so instead, it has to be init-on-reference.
+void SyclPlatform::InspectNumaNodes() {
+  // To get NUMA node information, we need to create all executors, so we can
+  // examine their device descriptions to see their bus assignments.
+  static absl::once_flag once;
+  absl::call_once(once, [&] {
+    for (int i = 0; i < VisibleDeviceCount(); i++) {
+      StreamExecutor* exec = *ExecutorForDevice(i);
+      if (i == 0) {
+        // NUMA nodes may not start at 0, so set the minimum node  based on the
+        // first executor we see.
+        min_numa_node_ = exec->GetDeviceDescription().numa_node();
+        limit_numa_node_ = min_numa_node_ + 1;
+      } else {
+        min_numa_node_ =
+            std::min(min_numa_node_, exec->GetDeviceDescription().numa_node());
+        limit_numa_node_ = std::max(
+            limit_numa_node_, exec->GetDeviceDescription().numa_node() + 1);
+      }
+    }
+  });
+}
+
+int SyclPlatform::BusCount() {
+  InspectNumaNodes();
+  return limit_numa_node_ - min_numa_node_;
+}
+
+int SyclPlatform::DeviceToBus(int device_ordinal) {
+  StreamExecutor* exec = *ExecutorForDevice(device_ordinal);
+  return exec->GetDeviceDescription().numa_node() - min_numa_node_;
+}
+
+absl::StatusOr<StreamExecutor*> SyclPlatform::FirstExecutorForBus(
+    int bus_ordinal) {
+  InspectNumaNodes();
+  CHECK_LT(bus_ordinal, BusCount()) << "bus ordinal out of available range";
+  for (int i = 0; i < VisibleDeviceCount(); i++) {
+    if (DeviceToBus(i) == bus_ordinal) {
+      return *ExecutorForDevice(i);
+    }
+  }
+
+  return absl::NotFoundError(
+      absl::StrFormat("Executor for bus %d not found.", bus_ordinal));
+}
+
+Platform::Id SyclPlatform::id() const { return sycl::kSyclPlatformId; }
+
+int SyclPlatform::VisibleDeviceCount() const {
+  // Initialized in a thread-safe manner the first time this is run.
+  static const int num_devices = [] {
+    if (!GpuDriver::Init().ok()) return -1;
+    return GpuDriver::GetDeviceCount();
+  }();
+  return num_devices;
+}
+
+const std::string& SyclPlatform::Name() const { return name_; }
+
+absl::StatusOr<std::unique_ptr<DeviceDescription>>
+SyclPlatform::DescriptionForDevice(int ordinal) const {
+  return GpuExecutor::CreateDeviceDescription(ordinal);
+}
+
+absl::StatusOr<StreamExecutor*> SyclPlatform::ExecutorForDevice(int ordinal) {
+  StreamExecutorConfig config;
+  config.ordinal = ordinal;
+  config.device_options = DeviceOptions::Default();
+  return GetExecutor(config);
+}
+
+absl::StatusOr<StreamExecutor*> SyclPlatform::GetExecutor(
+    const StreamExecutorConfig& config) {
+  if (config.gpu_stream) {
+    // If the GPU stream was provided, it's not possible to get-or-create a
+    // stream with a required pointer: so we are looking for previously
+    // allocated streams.
+    return executor_cache_.Get(config);
+  }
+  return executor_cache_.GetOrCreate(
+      config, [&]() { return GetUncachedExecutor(config); });
+}
+
+absl::StatusOr<std::unique_ptr<StreamExecutor>>
+SyclPlatform::GetUncachedExecutor(const StreamExecutorConfig& config) {
+  auto executor = std::make_unique<StreamExecutor>(
+      this, std::make_unique<GpuExecutor>(), config.ordinal);
+  auto init_status = executor->Init(config.device_options);
+  if (!init_status.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "failed initializing StreamExecutor for SYCL device ordinal %d: %s",
+        config.ordinal, init_status.ToString()));
+  }
+  return std::move(executor);
+}
+
+}  // namespace gpu
+
+static void InitializeSyclPlatform() {
+  // Disabling leak checking, MultiPlatformManager does not destroy its
+  // registered platforms.
+  std::unique_ptr<gpu::SyclPlatform> platform(new gpu::SyclPlatform);
+  TF_CHECK_OK(MultiPlatformManager::RegisterPlatform(std::move(platform)));
+}
+
+}  // namespace stream_executor
+
+STREAM_EXECUTOR_REGISTER_MODULE_INITIALIZER(
+    sycl_platform, stream_executor::InitializeSyclPlatform());

--- a/xla/stream_executor/sycl/sycl_platform.h
+++ b/xla/stream_executor/sycl/sycl_platform.h
@@ -1,0 +1,104 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_SYCL_SYCL_PLATFORM_H_
+#define XLA_STREAM_EXECUTOR_SYCL_SYCL_PLATFORM_H_
+
+#include <memory>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/executor_cache.h"
+#include "xla/stream_executor/multi_platform_manager.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform/port.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/stream_executor_internal.h"
+
+namespace stream_executor {
+namespace sycl {
+// Opaque and unique identifier for the SYCL platform plugin.
+// This is needed so that plugins can refer to/identify this platform without
+// instantiating a SyclPlatform object.
+extern const Platform::Id kSyclPlatformId;
+}  // namespace sycl
+
+namespace gpu {
+// Sycl-specific platform plugin, registered as a singleton value via module
+// initializer.
+class SyclPlatform : public Platform {
+ public:
+  SyclPlatform();
+  ~SyclPlatform() override;
+
+  // SyclPlatform-specific functionality
+  // Returns the number of distinct buses / NUMA nodes on the machine.
+  int BusCount();
+
+  // Returns the bus/NUMA node for the specified device ordinal.
+  int DeviceToBus(int device_ordinal);
+
+  // Returns the lowest-ordinal-number StreamExecutor on the specified bus.
+  absl::StatusOr<StreamExecutor*> FirstExecutorForBus(int bus_ordinal);
+
+  // Platform interface implementation:
+  // Returns the same value as kSyclPlatform above.
+  Platform::Id id() const override;
+
+  // Returns -1 as a sentinel on internal failure (and logs the error).
+  int VisibleDeviceCount() const override;
+
+  const std::string& Name() const override;
+
+  absl::StatusOr<std::unique_ptr<DeviceDescription>> DescriptionForDevice(
+      int ordinal) const override;
+
+  absl::StatusOr<StreamExecutor*> ExecutorForDevice(int ordinal) override;
+
+  absl::StatusOr<StreamExecutor*> GetExecutor(
+      const StreamExecutorConfig& config) override;
+
+  absl::StatusOr<std::unique_ptr<StreamExecutor>> GetUncachedExecutor(
+      const StreamExecutorConfig& config) override;
+
+ private:
+  // Determines the number of NUMA nodes and the assignment of executor to each.
+  void InspectNumaNodes();
+
+  // This platform's name.
+  std::string name_;
+
+  // Cache of created executors.
+  ExecutorCache executor_cache_;
+
+  // The smallest NUMA node value for any device managed by this machine
+  // manager. Used, along with limit_numa_node_, to convert NUMA nodes into bus
+  // ordinals. The NUMA node space occupied by GPUs is assumed to be dense./
+  int min_numa_node_;
+
+  // Larger than the NUMA node value for any device managed by this machine
+  // manager.
+  int limit_numa_node_;
+
+  SyclPlatform(const SyclPlatform&) = delete;
+  void operator=(const SyclPlatform&) = delete;
+};
+
+}  // namespace gpu
+
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_SYCL_SYCL_PLATFORM_H_

--- a/xla/stream_executor/sycl/sycl_platform_id.cc
+++ b/xla/stream_executor/sycl/sycl_platform_id.cc
@@ -1,0 +1,24 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+
+namespace stream_executor {
+namespace sycl {
+
+PLATFORM_DEFINE_ID(kSyclPlatformId);
+
+}  // namespace sycl
+}  // namespace stream_executor

--- a/xla/stream_executor/sycl/sycl_platform_id.h
+++ b/xla/stream_executor/sycl/sycl_platform_id.h
@@ -1,0 +1,34 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_SYCL_SYCL_PLATFORM_ID_H_
+#define XLA_STREAM_EXECUTOR_SYCL_SYCL_PLATFORM_ID_H_
+
+#include "xla/stream_executor/platform.h"
+
+namespace stream_executor {
+namespace sycl {
+
+// Opaque and unique identifier for the sycl platform.
+// This is needed so that plugins can refer to/identify this platform without
+// instantiating a SyclPlatform object.
+// This is broken out here to avoid a circular dependency between SyclPlatform
+// and SyclExecutor.
+extern const Platform::Id kSyclPlatformId;
+
+}  // namespace sycl
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_SYCL_SYCL_PLATFORM_ID_H_


### PR DESCRIPTION
This PR aims to add sycl runtime support, we can run basic JAX GPU UTs with it. It includes:
1. sycl runtime crosstool build
2. sycl stream executor
3. spirv-llvm-translator
4. registration of spir_compiler/computation placer/transfer manager
5. refine build file to remove cuda specific changes(especially those cuda kernels)
6. fix CudaCubin to load spirv binary
7. fix metadata

This is a draft PR to show what is needed to run JAX on sycl runtime.