### PR TITLE
[NVIDIA XLA GPU] Fix gcc build failure

### DIFF
--- a/xla/service/gpu/model/indexing_analysis.cc
+++ b/xla/service/gpu/model/indexing_analysis.cc
@@ -684,7 +684,7 @@ std::vector<int64_t> ToTransposeDimensions(const Layout& l) {
   return out;
 }
 
-llvm::SmallVector<AffineExpr, 4> DelinearizeInBoundsIndex(
+llvm::SmallVector<AffineExpr> DelinearizeInBoundsIndex(
     mlir::AffineExpr linear, absl::Span<const int64_t> sizes,
     absl::Span<const int64_t> strides) {
   llvm::SmallVector<AffineExpr> result;


### PR DESCRIPTION
`DelinearizeInBoundsIndex` right now returns `llvm::SmallVector<AffineExpr, 4>`. The number of elements in the returned vector really depends on how many elements are in sizes and strides so it doesn't make much sense to put a fixed number, change it to return just an array with no constant size specified.
It looks like this only fails with gcc not clang. 