### PR TITLE
Add xla flag for fp8 gemm-gelu fusion

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -86,7 +86,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   // TODO(AyanmoI): Remove this flag when cuDNN FMHA is fully supported.
   opts.set_xla_gpu_enable_cudnn_fmha(false);
-
+  opts.set_xla_gpu_enable_fp8_gelu_fusion(true);
   opts.set_xla_gpu_fused_attention_use_cudnn_rng(false);
 
   // By default, copy TF's Eigen style min_max behavior with nans.
@@ -1002,6 +1002,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "that dropout support and the developement of this feature as a whole is "
       "in progress. Attention with dropout may cause results to diverge with "
       "and without this  flag turned on."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_fp8_gelu_fusion",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_fp8_gelu_fusion),
+      debug_options->xla_gpu_enable_fp8_gelu_fusion(),
+      "Use the FP8 cublasLt gelu epilogue fusion when possible."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_fused_attention_use_cudnn_rng",
       bool_setter_for(&DebugOptions::set_xla_gpu_fused_attention_use_cudnn_rng),

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -677,7 +677,8 @@ message DebugOptions {
 
   bool xla_gpu_enable_dot_strength_reduction = 270;
 
-  // Next id: 271
+  // Next id: 272
+  bool xla_gpu_enable_fp8_gelu_fusion = 271;
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
For most cases, FP8 cublasLt gemm-gelu fusion is faster than non-fused cases but not all. Adding a switching flag.