### PR TITLE
Perform elementwise BF16 math natively in platforms that support it.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3225,6 +3225,7 @@ cc_library(
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/service:float_support",
+        "//xla/stream_executor:device_description",
         "@com_google_absl//absl/log:check",
     ],
 )

--- a/xla/service/gpu/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/gemm_fusion_autotuner.cc
@@ -475,7 +475,8 @@ absl::StatusOr<std::unique_ptr<HloModule>> TritonGemmAutotuneExtractor(
 
   if (config.split_k > 1) {
     TF_RETURN_IF_ERROR(MakeDotSplitKBatch(cloned_dot_fusion, config));
-    GpuFloatSupport bf16_support(BF16);
+    GpuFloatSupport bf16_support(gpu_device_info.gpu_compute_capability(),
+                                 BF16);
     FloatNormalization float_normalization(&bf16_support);
     TF_RETURN_IF_ERROR(float_normalization.Run(new_module.get()).status());
     GpuInstructionFusion instruction_fusion(/*may_duplicate=*/false,

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1323,9 +1323,9 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
                       GetAutotuneConfig(stream_exec, debug_options, options,
                                         gpu_target_config));
   // Lambdas and related constants:
-  const GpuFloatSupport bf16_support(BF16);
-  const GpuFloatSupport f8e5m2_support(F8E5M2, F16);
-  const GpuFloatSupport f8e4m3fn_support(F8E4M3FN, F16);
+  const GpuFloatSupport bf16_support(gpu_version, BF16);
+  const GpuFloatSupport f8e5m2_support(gpu_version, F8E5M2, F16);
+  const GpuFloatSupport f8e4m3fn_support(gpu_version, F8E4M3FN, F16);
   const FloatSupport f8e4m3b11fnuz_support(F8E4M3B11FNUZ, F16);
   const FloatSupport f8e5m2fnuz_support(F8E5M2FNUZ, F16);
   const FloatSupport f8e4m3fnuz_support(F8E4M3FNUZ, F16);

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -73,6 +73,18 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     // Other special ops.
     case HloOpcode::kBitcast:
       return true;
+    // Elementwise ops.
+    case HloOpcode::kAdd:
+    case HloOpcode::kSubtract:
+    case HloOpcode::kMultiply: {
+      if (LowPrecisionType() == BF16) {
+        auto* cuda_compute_capability =
+            std::get_if<se::CudaComputeCapability>(&compute_capability_);
+        return cuda_compute_capability != nullptr &&
+               cuda_compute_capability->IsAtLeastHopper();
+      }
+      return false;
+    }
     default:
       return false;
   }

--- a/xla/service/gpu/gpu_float_support.h
+++ b/xla/service/gpu/gpu_float_support.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/float_support.h"
+#include "xla/stream_executor/device_description.h"
 #include "xla/xla_data.pb.h"
 
 namespace xla {
@@ -27,9 +28,11 @@ namespace gpu {
 
 class GpuFloatSupport : public FloatSupport {
  public:
-  explicit GpuFloatSupport(PrimitiveType low_precision_type,
+  explicit GpuFloatSupport(se::GpuComputeCapability cc,
+                           PrimitiveType low_precision_type,
                            PrimitiveType high_precision_type = F32)
-      : FloatSupport(low_precision_type, high_precision_type) {}
+      : FloatSupport(low_precision_type, high_precision_type),
+        compute_capability_(cc) {}
 
   bool SupportsLowPrecisionOperand(const HloInstruction& hlo,
                                    int64_t operand_index) const override {
@@ -45,6 +48,8 @@ class GpuFloatSupport : public FloatSupport {
 
  private:
   bool IsSupported(const HloInstruction& hlo) const;
+
+  const se::GpuComputeCapability compute_capability_;
 };
 
 }  // namespace gpu


### PR DESCRIPTION
Perform elementwise BF16 math natively in platforms that support it, e.g., Hopper GPUs.

In xla/service/gpu, we check the platform using Cuda compute capability. We don't have access to that in llvm_ir, so we pass an optional bool to say whether native BF16 support is there. We make it optional with default to false, to avoid a very large refactoring that would touch most functions in llvm_ir.