### PR TITLE
[ROCm] Fixing unit tests

### DIFF
--- a/xla/service/gpu/tests/copy_nested.hlo
+++ b/xla/service/gpu/tests/copy_nested.hlo
@@ -14,7 +14,7 @@
 // CHECK:         br i1 %[[VAL_5]], label %[[VAL_6:.*]], label %[[VAL_7:.*]]
 // CHECK:       loop.loop_body:                                   ; preds = %[[VAL_1]]
 // CHECK-PTX:     %[[VAL_8:.*]] = add nuw nsw i32 %[[VAL_4]], 516096
-// CHECK-GCN:     %[[VAL_8:.*]] = add nuw nsw i32 %[[VAL_4]], 851968
+// CHECK-GCN:     %[[VAL_8:.*]] = add nuw nsw i32 %[[VAL_4]], 901120
 // CHECK-PTX:     store i32 %[[VAL_8]], ptr %[[VAL_0]], align 4
 // CHECK-GCN:     store i32 %[[VAL_8]], ptr addrspace(5) %[[VAL_0]], align 4
 // CHECK:         %[[VAL_9:.*]] = icmp eq i32 %[[VAL_4]], 0
@@ -25,7 +25,7 @@
 // CHECK:         %[[VAL_12:.*]] = mul nuw nsw i32 %[[VAL_10]], 128
 // CHECK:         %[[VAL_13:.*]] = add nuw nsw i32 %[[VAL_12]], %[[VAL_11]]
 // CHECK-PTX:     %[[VAL_14:.*]] = icmp ult i32 %[[VAL_13]], 129024
-// CHECK-GCN:     %[[VAL_14:.*]] = icmp ult i32 %[[VAL_13]], 212992
+// CHECK-GCN:     %[[VAL_14:.*]] = icmp ult i32 %[[VAL_13]], 225280
 // CHECK:         call void @llvm.assume(i1 %[[VAL_14]])
 // CHECK:         %[[VAL_15:.*]] = mul nuw nsw i32 %[[VAL_13]], 4
 // CHECK:         %[[VAL_16:.*]] = add nuw nsw i32 %[[VAL_15]], %[[VAL_4]]

--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -634,7 +634,8 @@ TEST_F(GpuKernelTilingTest, RowReductionCorrectShmemUsage) {
   )";
   auto hlo_module = ParseAndReturnVerifiedModule(kHloString).value();
   auto expected_ir = is_built_with_rocm_ ? R"(
-; CHECK: initial_value_addr = internal unnamed_addr addrspace({{[0-9]*}}) global [1024 x float] poison, align 4
+; CHECK: %llvm.amdgcn.kernel.input_reduce_fusion.lds.t = type { [4 x [2 x float]] }
+; CHECK: @llvm.amdgcn.kernel.input_reduce_fusion.lds = internal addrspace(3) global %llvm.amdgcn.kernel.input_reduce_fusion.lds.t poison
   )"
                                          : R"(
 ; CHECK: shared_cache = private unnamed_addr addrspace({{[0-9]*}}) global [4 x [2 x float]]

--- a/xla/service/gpu/tests/launch_dimensions.hlo
+++ b/xla/service/gpu/tests/launch_dimensions.hlo
@@ -33,7 +33,7 @@ ENTRY main {
 // CHECK-PTX:   call i32 @llvm.nvvm.read.ptx.sreg.tid.x(), !range ![[tid_range:[0-9]+]]
 // CHECK-GCN:   call i32 @llvm.amdgcn.workitem.id.x(), !range ![[tid_range:[0-9]+]]
 // CHECK-PTX:   ![[ctaid_range]] = !{i32 0, i32 1008}
-// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1664}
+// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1760}
 // CHECK:   ![[tid_range]] = !{i32 0, i32 128}
 
 HloModule Test, is_scheduled=true
@@ -60,7 +60,7 @@ ENTRY main {
 // CHECK-PTX:   ![[tid_range]] = !{i32 0, i32 128}
 // CHECK-GCN:   call i32 @llvm.amdgcn.workgroup.id.x(), !range ![[ctaid_range:[0-9]+]]
 // CHECK-GCN:   call i32 @llvm.amdgcn.workitem.id.x(), !range ![[tid_range:[0-9]+]]
-// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1664}
+// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1760}
 // CHECK-GCN:   ![[tid_range]] = !{i32 0, i32 128}
 
 HloModule ScalarBroadcast, is_scheduled=true
@@ -91,7 +91,7 @@ ENTRY main {
 // CHECK-PTX:   ![[tid_range]] = !{i32 0, i32 128}
 // CHECK-GCN:   call i32 @llvm.amdgcn.workgroup.id.x(), !range ![[ctaid_range:[0-9]+]]
 // CHECK-GCN:   call i32 @llvm.amdgcn.workitem.id.x(), !range ![[tid_range:[0-9]+]]
-// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1664}
+// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1760}
 // CHECK-GCN:   ![[tid_range]] = !{i32 0, i32 128}
 
 HloModule SimpleFusion, is_scheduled=true
@@ -120,7 +120,7 @@ ENTRY main {
 // CHECK-PTX:   ![[tid_range]] = !{i32 0, i32 128}
 // CHECK-GCN:   call i32 @llvm.amdgcn.workgroup.id.x(), !range ![[ctaid_range:[0-9]+]]
 // CHECK-GCN:   call i32 @llvm.amdgcn.workitem.id.x(), !range ![[tid_range:[0-9]+]]
-// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1664}
+// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1760}
 // CHECK-GCN:   ![[tid_range]] = !{i32 0, i32 128}
 
 HloModule LargeConstant, is_scheduled=true
@@ -267,7 +267,7 @@ ENTRY main {
 // CHECK-PTX:   ![[tid_range]] = !{i32 0, i32 128}
 // CHECK-GCN:   call i32 @llvm.amdgcn.workgroup.id.x(), !range ![[ctaid_range:[0-9]+]]
 // CHECK-GCN:   call i32 @llvm.amdgcn.workitem.id.x(), !range ![[tid_range:[0-9]+]]
-// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1664}
+// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1760}
 // CHECK-GCN:   ![[tid_range]] = !{i32 0, i32 128}
 
 HloModule ScalarBroadcastFourInputs, is_scheduled=true
@@ -306,7 +306,7 @@ ENTRY main {
 // CHECK-PTX:   call i32 @llvm.nvvm.read.ptx.sreg.tid.x(), !range ![[tid_range:[0-9]+]]
 // CHECK-GCN:   call i32 @llvm.amdgcn.workitem.id.x(), !range ![[tid_range:[0-9]+]]
 // CHECK-PTX:   ![[ctaid_range]] = !{i32 0, i32 1008}
-// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1664}
+// CHECK-GCN:   ![[ctaid_range]] = !{i32 0, i32 1760}
 // CHECK:   ![[tid_range]] = !{i32 0, i32 128}
 
 HloModule Test, is_scheduled=true

--- a/xla/service/gpu/tests/transpose_021.hlo
+++ b/xla/service/gpu/tests/transpose_021.hlo
@@ -38,69 +38,70 @@ ENTRY main {
 // CHECK:         %tile_origin.0 = mul i32 %[[VAL_9]], 1
 // CHECK:         %tile_origin.1 = mul i32 %[[VAL_8]], 32
 // CHECK:         %tile_origin.2 = mul i32 %[[VAL_6]], 32
-// CHECK:         store i32 %thread.id.1, ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %thread.id.1, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         br label %[[VAL_12:.*]]
 // CHECK:       loop1.loop_header:                                ; preds = %[[VAL_13:.*]], %[[VAL_14:.*]]
-// CHECK:         %[[VAL_15:.*]] = load i32, ptr %[[VAL_3]], align 4
+// CHECK:         %[[VAL_15:.*]] = load i32, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_16:.*]] = icmp uge i32 %[[VAL_15]], %tile_bound.1
 // CHECK:         br i1 %[[VAL_16]], label %[[VAL_17:.*]], label %[[VAL_18:.*]]
 // CHECK:       loop1.loop_body:                                  ; preds = %[[VAL_12]]
 // CHECK:         %[[VAL_19:.*]] = add nuw nsw i32 %[[VAL_15]], 4
-// CHECK:         store i32 %[[VAL_19]], ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %[[VAL_19]], ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_20:.*]] = icmp eq i32 %[[VAL_15]], %thread.id.1
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         br label %[[VAL_21:.*]]
 // CHECK:       loop2.loop_header:                                ; preds = %[[VAL_22:.*]], %[[VAL_18]]
-// CHECK:         %[[VAL_23:.*]] = load i32, ptr %[[VAL_2]], align 4
+// CHECK:         %[[VAL_23:.*]] = load i32, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_24:.*]] = icmp uge i32 %[[VAL_23]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_24]], label %[[VAL_13]], label %[[VAL_22]]
 // CHECK:       loop2.loop_body:                                  ; preds = %[[VAL_21]]
 // CHECK:         %[[VAL_25:.*]] = add nuw nsw i32 %[[VAL_23]], 32
-// CHECK:         store i32 %[[VAL_25]], ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %[[VAL_25]], ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_26:.*]] = icmp eq i32 %[[VAL_23]], %thread.id.2
 // CHECK:         %[[VAL_27:.*]] = add i32 %tile_origin.0, 0
 // CHECK:         %[[VAL_28:.*]] = add i32 %tile_origin.1, %[[VAL_15]]
 // CHECK:         %[[VAL_29:.*]] = add i32 %tile_origin.2, %[[VAL_23]]
-// CHECK:         %[[VAL_30:.*]] = getelementptr inbounds [2 x [16 x [17 x float]]], ptr %[[VAL_31:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         %[[VAL_32:.*]] = load float, ptr %[[VAL_30]], align 4, !invariant.load !4
-// CHECK:         %[[VAL_33:.*]] = getelementptr inbounds [1 x [32 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_15]], i32 %[[VAL_23]]
-// CHECK:         %[[VAL_34:.*]] = addrspacecast ptr addrspace(3) %[[VAL_33]] to ptr
-// CHECK:         store float %[[VAL_32]], ptr %[[VAL_34]], align 4
-// CHECK:         br label %[[VAL_21]], !llvm.loop !5
+// CHECK:         %[[VAL_30:.*]] = getelementptr{{.*}} inbounds [2 x [16 x [17 x float]]], ptr{{.*}} %[[VAL_31:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
+// CHECK:         %[[VAL_32:.*]] = load float, ptr{{.*}} %[[VAL_30]], align 4, !invariant.load !{{[0-9]}}
+// CHECK:         %[[VAL_33:.*]] = getelementptr{{.*}} inbounds [1 x [32 x [33 x float]]], ptr{{.*}} addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_15]], i32 %[[VAL_23]]
+// CHECK:         %[[VAL_34:.*]] = addrspacecast ptr{{.*}} addrspace(3) %[[VAL_33]] to ptr
+// CHECK:         store float %[[VAL_32]], ptr{{.*}} %[[VAL_34]], align 4
+// CHECK:         br label %[[VAL_21]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit:                                  ; preds = %[[VAL_21]]
-// CHECK:         br label %[[VAL_12]], !llvm.loop !7
+// CHECK:         br label %[[VAL_12]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop1.loop_exit:                                  ; preds = %[[VAL_12]]
-// CHECK:         call void @llvm.nvvm.barrier0()
-// CHECK:         store i32 %thread.id.1, ptr %[[VAL_1]], align 4
+// CHECK-PTX:     call void @llvm.nvvm.barrier0()
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier()
+// CHECK:         store i32 %thread.id.1, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         br label %[[VAL_35:.*]]
 // CHECK:       loop1.loop_header4:                               ; preds = %[[VAL_36:.*]], %[[VAL_17]]
-// CHECK:         %[[VAL_37:.*]] = load i32, ptr %[[VAL_1]], align 4
+// CHECK:         %[[VAL_37:.*]] = load i32, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_38:.*]] = icmp uge i32 %[[VAL_37]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_38]], label %[[VAL_39:.*]], label %[[VAL_40:.*]]
 // CHECK:       loop1.loop_body5:                                 ; preds = %[[VAL_35]]
 // CHECK:         %[[VAL_41:.*]] = add nuw nsw i32 %[[VAL_37]], 4
-// CHECK:         store i32 %[[VAL_41]], ptr %[[VAL_1]], align 4
+// CHECK:         store i32 %[[VAL_41]], ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_42:.*]] = icmp eq i32 %[[VAL_37]], %thread.id.1
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         br label %[[VAL_43:.*]]
 // CHECK:       loop2.loop_header10:                              ; preds = %[[VAL_44:.*]], %[[VAL_40]]
-// CHECK:         %[[VAL_45:.*]] = load i32, ptr %[[VAL_0]], align 4
+// CHECK:         %[[VAL_45:.*]] = load i32, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_46:.*]] = icmp uge i32 %[[VAL_45]], %tile_bound.1
 // CHECK:         br i1 %[[VAL_46]], label %[[VAL_36]], label %[[VAL_44]]
 // CHECK:       loop2.loop_body11:                                ; preds = %[[VAL_43]]
 // CHECK:         %[[VAL_47:.*]] = add nuw nsw i32 %[[VAL_45]], 32
-// CHECK:         store i32 %[[VAL_47]], ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %[[VAL_47]], ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_48:.*]] = icmp eq i32 %[[VAL_45]], %thread.id.2
 // CHECK:         %[[VAL_49:.*]] = add i32 %tile_origin.0, 0
 // CHECK:         %[[VAL_50:.*]] = add i32 %tile_origin.2, %[[VAL_37]]
 // CHECK:         %[[VAL_51:.*]] = add i32 %tile_origin.1, %[[VAL_45]]
-// CHECK:         %[[VAL_52:.*]] = getelementptr inbounds [1 x [32 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_45]], i32 %[[VAL_37]]
-// CHECK:         %[[VAL_53:.*]] = addrspacecast ptr addrspace(3) %[[VAL_52]] to ptr
-// CHECK:         %[[VAL_54:.*]] = load float, ptr %[[VAL_53]], align 4
-// CHECK:         %[[VAL_55:.*]] = getelementptr inbounds [2 x [17 x [16 x float]]], ptr %[[VAL_56:.*]], i32 0, i32 %[[VAL_49]], i32 %[[VAL_50]], i32 %[[VAL_51]]
-// CHECK:         store float %[[VAL_54]], ptr %[[VAL_55]], align 4
-// CHECK:         br label %[[VAL_43]], !llvm.loop !8
+// CHECK:         %[[VAL_52:.*]] = getelementptr{{.*}} inbounds [1 x [32 x [33 x float]]], ptr{{.*}} addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_45]], i32 %[[VAL_37]]
+// CHECK:         %[[VAL_53:.*]] = addrspacecast ptr{{.*}} addrspace(3) %[[VAL_52]] to ptr
+// CHECK:         %[[VAL_54:.*]] = load float, ptr{{.*}} %[[VAL_53]], align 4
+// CHECK:         %[[VAL_55:.*]] = getelementptr{{.*}} inbounds [2 x [17 x [16 x float]]], ptr{{.*}} %[[VAL_56:.*]], i32 0, i32 %[[VAL_49]], i32 %[[VAL_50]], i32 %[[VAL_51]]
+// CHECK:         store float %[[VAL_54]], ptr{{.*}} %[[VAL_55]], align 4
+// CHECK:         br label %[[VAL_43]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit9:                                 ; preds = %[[VAL_43]]
-// CHECK:         br label %[[VAL_35]], !llvm.loop !9
+// CHECK:         br label %[[VAL_35]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop1.loop_exit3:                                 ; preds = %[[VAL_35]]
 // CHECK:         ret void

--- a/xla/service/gpu/tests/transpose_021_extra_output.hlo
+++ b/xla/service/gpu/tests/transpose_021_extra_output.hlo
@@ -41,74 +41,75 @@ ENTRY main {
 // CHECK:         %tile_origin.0 = mul i32 %[[VAL_9]], 1
 // CHECK:         %tile_origin.1 = mul i32 %[[VAL_8]], 32
 // CHECK:         %tile_origin.2 = mul i32 %[[VAL_6]], 32
-// CHECK:         store i32 %thread.id.1, ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %thread.id.1, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         br label %[[VAL_12:.*]]
 // CHECK:       loop1.loop_header:                                ; preds = %[[VAL_13:.*]], %[[VAL_14:.*]]
-// CHECK:         %[[VAL_15:.*]] = load i32, ptr %[[VAL_3]], align 4
+// CHECK:         %[[VAL_15:.*]] = load i32, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_16:.*]] = icmp uge i32 %[[VAL_15]], %tile_bound.1
 // CHECK:         br i1 %[[VAL_16]], label %[[VAL_17:.*]], label %[[VAL_18:.*]]
 // CHECK:       loop1.loop_body:                                  ; preds = %[[VAL_12]]
 // CHECK:         %[[VAL_19:.*]] = add nuw nsw i32 %[[VAL_15]], 4
-// CHECK:         store i32 %[[VAL_19]], ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %[[VAL_19]], ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_20:.*]] = icmp eq i32 %[[VAL_15]], %thread.id.1
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         br label %[[VAL_21:.*]]
 // CHECK:       loop2.loop_header:                                ; preds = %[[VAL_22:.*]], %[[VAL_18]]
-// CHECK:         %[[VAL_23:.*]] = load i32, ptr %[[VAL_2]], align 4
+// CHECK:         %[[VAL_23:.*]] = load i32, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_24:.*]] = icmp uge i32 %[[VAL_23]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_24]], label %[[VAL_13]], label %[[VAL_22]]
 // CHECK:       loop2.loop_body:                                  ; preds = %[[VAL_21]]
 // CHECK:         %[[VAL_25:.*]] = add nuw nsw i32 %[[VAL_23]], 32
-// CHECK:         store i32 %[[VAL_25]], ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %[[VAL_25]], ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_26:.*]] = icmp eq i32 %[[VAL_23]], %thread.id.2
 // CHECK:         %[[VAL_27:.*]] = add i32 %tile_origin.0, 0
 // CHECK:         %[[VAL_28:.*]] = add i32 %tile_origin.1, %[[VAL_15]]
 // CHECK:         %[[VAL_29:.*]] = add i32 %tile_origin.2, %[[VAL_23]]
-// CHECK:         %[[VAL_30:.*]] = getelementptr inbounds [2 x [16 x [17 x float]]], ptr %[[VAL_31:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         %[[VAL_32:.*]] = load float, ptr %[[VAL_30]], align 4, !invariant.load !4
-// CHECK:         %[[VAL_33:.*]] = getelementptr inbounds [1 x [32 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_15]], i32 %[[VAL_23]]
-// CHECK:         %[[VAL_34:.*]] = addrspacecast ptr addrspace(3) %[[VAL_33]] to ptr
-// CHECK:         store float %[[VAL_32]], ptr %[[VAL_34]], align 4
-// CHECK:         %[[VAL_35:.*]] = getelementptr inbounds [2 x [16 x [17 x float]]], ptr %[[VAL_31]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         %[[VAL_36:.*]] = load float, ptr %[[VAL_35]], align 4, !invariant.load !4
+// CHECK:         %[[VAL_30:.*]] = getelementptr inbounds [2 x [16 x [17 x float]]], ptr{{.*}} %[[VAL_31:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
+// CHECK:         %[[VAL_32:.*]] = load float, ptr{{.*}} %[[VAL_30]], align 4, !invariant.load !{{[0-9]}}
+// CHECK:         %[[VAL_33:.*]] = getelementptr inbounds [1 x [32 x [33 x float]]], ptr{{.*}} addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_15]], i32 %[[VAL_23]]
+// CHECK:         %[[VAL_34:.*]] = addrspacecast ptr{{.*}} addrspace(3) %[[VAL_33]] to ptr
+// CHECK:         store float %[[VAL_32]], ptr{{.*}} %[[VAL_34]], align 4
+// CHECK:         %[[VAL_35:.*]] = getelementptr inbounds [2 x [16 x [17 x float]]], ptr{{.*}} %[[VAL_31]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
+// CHECK:         %[[VAL_36:.*]] = load float, ptr{{.*}} %[[VAL_35]], align 4, !invariant.load !{{[0-9]}}
 // CHECK:         %[[VAL_37:.*]] = fneg float %[[VAL_36]]
-// CHECK:         %[[VAL_38:.*]] = getelementptr inbounds [2 x [16 x [17 x float]]], ptr %[[VAL_39:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         store float %[[VAL_37]], ptr %[[VAL_38]], align 4
-// CHECK:         br label %[[VAL_21]], !llvm.loop !5
+// CHECK:         %[[VAL_38:.*]] = getelementptr inbounds [2 x [16 x [17 x float]]], ptr{{.*}} %[[VAL_39:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
+// CHECK:         store float %[[VAL_37]], ptr{{.*}} %[[VAL_38]], align 4
+// CHECK:         br label %[[VAL_21]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit:                                  ; preds = %[[VAL_21]]
-// CHECK:         br label %[[VAL_12]], !llvm.loop !7
+// CHECK:         br label %[[VAL_12]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop1.loop_exit:                                  ; preds = %[[VAL_12]]
-// CHECK:         call void @llvm.nvvm.barrier0()
-// CHECK:         store i32 %thread.id.1, ptr %[[VAL_1]], align 4
+// CHECK-PTX:     call void @llvm.nvvm.barrier0()
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier()
+// CHECK:         store i32 %thread.id.1, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         br label %[[VAL_40:.*]]
 // CHECK:       loop1.loop_header6:                               ; preds = %[[VAL_41:.*]], %[[VAL_17]]
-// CHECK:         %[[VAL_42:.*]] = load i32, ptr %[[VAL_1]], align 4
+// CHECK:         %[[VAL_42:.*]] = load i32, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_43:.*]] = icmp uge i32 %[[VAL_42]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_43]], label %[[VAL_44:.*]], label %[[VAL_45:.*]]
 // CHECK:       loop1.loop_body7:                                 ; preds = %[[VAL_40]]
 // CHECK:         %[[VAL_46:.*]] = add nuw nsw i32 %[[VAL_42]], 4
-// CHECK:         store i32 %[[VAL_46]], ptr %[[VAL_1]], align 4
+// CHECK:         store i32 %[[VAL_46]], ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_47:.*]] = icmp eq i32 %[[VAL_42]], %thread.id.1
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         br label %[[VAL_48:.*]]
 // CHECK:       loop2.loop_header12:                              ; preds = %[[VAL_49:.*]], %[[VAL_45]]
-// CHECK:         %[[VAL_50:.*]] = load i32, ptr %[[VAL_0]], align 4
+// CHECK:         %[[VAL_50:.*]] = load i32, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_51:.*]] = icmp uge i32 %[[VAL_50]], %tile_bound.1
 // CHECK:         br i1 %[[VAL_51]], label %[[VAL_41]], label %[[VAL_49]]
 // CHECK:       loop2.loop_body13:                                ; preds = %[[VAL_48]]
 // CHECK:         %[[VAL_52:.*]] = add nuw nsw i32 %[[VAL_50]], 32
-// CHECK:         store i32 %[[VAL_52]], ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %[[VAL_52]], ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_53:.*]] = icmp eq i32 %[[VAL_50]], %thread.id.2
 // CHECK:         %[[VAL_54:.*]] = add i32 %tile_origin.0, 0
 // CHECK:         %[[VAL_55:.*]] = add i32 %tile_origin.2, %[[VAL_42]]
 // CHECK:         %[[VAL_56:.*]] = add i32 %tile_origin.1, %[[VAL_50]]
-// CHECK:         %[[VAL_57:.*]] = getelementptr inbounds [1 x [32 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_50]], i32 %[[VAL_42]]
-// CHECK:         %[[VAL_58:.*]] = addrspacecast ptr addrspace(3) %[[VAL_57]] to ptr
-// CHECK:         %[[VAL_59:.*]] = load float, ptr %[[VAL_58]], align 4
-// CHECK:         %[[VAL_60:.*]] = getelementptr inbounds [2 x [17 x [16 x float]]], ptr %[[VAL_61:.*]], i32 0, i32 %[[VAL_54]], i32 %[[VAL_55]], i32 %[[VAL_56]]
-// CHECK:         store float %[[VAL_59]], ptr %[[VAL_60]], align 4
-// CHECK:         br label %[[VAL_48]], !llvm.loop !8
+// CHECK:         %[[VAL_57:.*]] = getelementptr inbounds [1 x [32 x [33 x float]]], ptr{{.*}} addrspace(3) @tr_tile_0, i32 0, i32 0, i32 %[[VAL_50]], i32 %[[VAL_42]]
+// CHECK:         %[[VAL_58:.*]] = addrspacecast ptr{{.*}} addrspace(3) %[[VAL_57]] to ptr
+// CHECK:         %[[VAL_59:.*]] = load float, ptr{{.*}} %[[VAL_58]], align 4
+// CHECK:         %[[VAL_60:.*]] = getelementptr inbounds [2 x [17 x [16 x float]]], ptr{{.*}} %[[VAL_61:.*]], i32 0, i32 %[[VAL_54]], i32 %[[VAL_55]], i32 %[[VAL_56]]
+// CHECK:         store float %[[VAL_59]], ptr{{.*}} %[[VAL_60]], align 4
+// CHECK:         br label %[[VAL_48]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit11:                                ; preds = %[[VAL_48]]
-// CHECK:         br label %[[VAL_40]], !llvm.loop !9
+// CHECK:         br label %[[VAL_40]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop1.loop_exit5:                                 ; preds = %[[VAL_40]]
 // CHECK:         ret void

--- a/xla/service/gpu/tests/transpose_210.hlo
+++ b/xla/service/gpu/tests/transpose_210.hlo
@@ -37,69 +37,70 @@ ENTRY main {
 // CHECK:         %tile_origin.0 = mul i32 %[[VAL_9]], 32
 // CHECK:         %tile_origin.1 = mul i32 %[[VAL_8]], 1
 // CHECK:         %tile_origin.2 = mul i32 %[[VAL_6]], 32
-// CHECK:         store i32 %thread.id.0, ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %thread.id.0, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         br label %[[VAL_12:.*]]
 // CHECK:       loop0.loop_header:                                ; preds = %[[VAL_13:.*]], %[[VAL_14:.*]]
-// CHECK:         %[[VAL_15:.*]] = load i32, ptr %[[VAL_3]], align 4
+// CHECK:         %[[VAL_15:.*]] = load i32, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_16:.*]] = icmp uge i32 %[[VAL_15]], %tile_bound.0
 // CHECK:         br i1 %[[VAL_16]], label %[[VAL_17:.*]], label %[[VAL_18:.*]]
 // CHECK:       loop0.loop_body:                                  ; preds = %[[VAL_12]]
 // CHECK:         %[[VAL_19:.*]] = add nuw nsw i32 %[[VAL_15]], 4
-// CHECK:         store i32 %[[VAL_19]], ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %[[VAL_19]], ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_20:.*]] = icmp eq i32 %[[VAL_15]], %thread.id.0
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         br label %[[VAL_21:.*]]
 // CHECK:       loop2.loop_header:                                ; preds = %[[VAL_22:.*]], %[[VAL_18]]
-// CHECK:         %[[VAL_23:.*]] = load i32, ptr %[[VAL_2]], align 4
+// CHECK:         %[[VAL_23:.*]] = load i32, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_24:.*]] = icmp uge i32 %[[VAL_23]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_24]], label %[[VAL_13]], label %[[VAL_22]]
 // CHECK:       loop2.loop_body:                                  ; preds = %[[VAL_21]]
 // CHECK:         %[[VAL_25:.*]] = add nuw nsw i32 %[[VAL_23]], 32
-// CHECK:         store i32 %[[VAL_25]], ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %[[VAL_25]], ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_26:.*]] = icmp eq i32 %[[VAL_23]], %thread.id.2
 // CHECK:         %[[VAL_27:.*]] = add i32 %tile_origin.0, %[[VAL_15]]
 // CHECK:         %[[VAL_28:.*]] = add i32 %tile_origin.1, 0
 // CHECK:         %[[VAL_29:.*]] = add i32 %tile_origin.2, %[[VAL_23]]
 // CHECK:         %[[VAL_30:.*]] = getelementptr inbounds [33 x [49 x [65 x float]]], ptr %[[VAL_31:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         %[[VAL_32:.*]] = load float, ptr %[[VAL_30]], align 4, !invariant.load !4
+// CHECK:         %[[VAL_32:.*]] = load float, ptr %[[VAL_30]], align 4, !invariant.load !{{[0-9]}}
 // CHECK:         %[[VAL_33:.*]] = getelementptr inbounds [32 x [1 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 %[[VAL_15]], i32 0, i32 %[[VAL_23]]
 // CHECK:         %[[VAL_34:.*]] = addrspacecast ptr addrspace(3) %[[VAL_33]] to ptr
 // CHECK:         store float %[[VAL_32]], ptr %[[VAL_34]], align 4
-// CHECK:         br label %[[VAL_21]], !llvm.loop !5
+// CHECK:         br label %[[VAL_21]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit:                                  ; preds = %[[VAL_21]]
-// CHECK:         br label %[[VAL_12]], !llvm.loop !7
+// CHECK:         br label %[[VAL_12]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop0.loop_exit:                                  ; preds = %[[VAL_12]]
-// CHECK:         call void @llvm.nvvm.barrier0()
-// CHECK:         store i32 %thread.id.0, ptr %[[VAL_1]], align 4
+// CHECK-PTX:     call void @llvm.nvvm.barrier0()
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier()
+// CHECK:         store i32 %thread.id.0, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         br label %[[VAL_35:.*]]
 // CHECK:       loop0.loop_header4:                               ; preds = %[[VAL_36:.*]], %[[VAL_17]]
-// CHECK:         %[[VAL_37:.*]] = load i32, ptr %[[VAL_1]], align 4
+// CHECK:         %[[VAL_37:.*]] = load i32, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_38:.*]] = icmp uge i32 %[[VAL_37]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_38]], label %[[VAL_39:.*]], label %[[VAL_40:.*]]
 // CHECK:       loop0.loop_body5:                                 ; preds = %[[VAL_35]]
 // CHECK:         %[[VAL_41:.*]] = add nuw nsw i32 %[[VAL_37]], 4
-// CHECK:         store i32 %[[VAL_41]], ptr %[[VAL_1]], align 4
+// CHECK:         store i32 %[[VAL_41]], ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_42:.*]] = icmp eq i32 %[[VAL_37]], %thread.id.0
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         br label %[[VAL_43:.*]]
 // CHECK:       loop2.loop_header10:                              ; preds = %[[VAL_44:.*]], %[[VAL_40]]
-// CHECK:         %[[VAL_45:.*]] = load i32, ptr %[[VAL_0]], align 4
+// CHECK:         %[[VAL_45:.*]] = load i32, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_46:.*]] = icmp uge i32 %[[VAL_45]], %tile_bound.0
 // CHECK:         br i1 %[[VAL_46]], label %[[VAL_36]], label %[[VAL_44]]
 // CHECK:       loop2.loop_body11:                                ; preds = %[[VAL_43]]
 // CHECK:         %[[VAL_47:.*]] = add nuw nsw i32 %[[VAL_45]], 32
-// CHECK:         store i32 %[[VAL_47]], ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %[[VAL_47]], ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_48:.*]] = icmp eq i32 %[[VAL_45]], %thread.id.2
 // CHECK:         %[[VAL_49:.*]] = add i32 %tile_origin.2, %[[VAL_37]]
 // CHECK:         %[[VAL_50:.*]] = add i32 %tile_origin.1, 0
 // CHECK:         %[[VAL_51:.*]] = add i32 %tile_origin.0, %[[VAL_45]]
 // CHECK:         %[[VAL_52:.*]] = getelementptr inbounds [32 x [1 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 %[[VAL_45]], i32 0, i32 %[[VAL_37]]
 // CHECK:         %[[VAL_53:.*]] = addrspacecast ptr addrspace(3) %[[VAL_52]] to ptr
-// CHECK:         %[[VAL_54:.*]] = load float, ptr %[[VAL_53]], align 4
+// CHECK:         %[[VAL_54:.*]] = load float, ptr{{.*}} %[[VAL_53]], align 4
 // CHECK:         %[[VAL_55:.*]] = getelementptr inbounds [65 x [49 x [33 x float]]], ptr %[[VAL_56:.*]], i32 0, i32 %[[VAL_49]], i32 %[[VAL_50]], i32 %[[VAL_51]]
 // CHECK:         store float %[[VAL_54]], ptr %[[VAL_55]], align 4
-// CHECK:         br label %[[VAL_43]], !llvm.loop !8
+// CHECK:         br label %[[VAL_43]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit9:                                 ; preds = %[[VAL_43]]
-// CHECK:         br label %[[VAL_35]], !llvm.loop !9
+// CHECK:         br label %[[VAL_35]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop0.loop_exit3:                                 ; preds = %[[VAL_35]]
 // CHECK:         ret void

--- a/xla/service/gpu/tests/transpose_210_extra_output.hlo
+++ b/xla/service/gpu/tests/transpose_210_extra_output.hlo
@@ -39,74 +39,75 @@ ENTRY main {
 // CHECK:         %tile_origin.0 = mul i32 %[[VAL_9]], 32
 // CHECK:         %tile_origin.1 = mul i32 %[[VAL_8]], 1
 // CHECK:         %tile_origin.2 = mul i32 %[[VAL_6]], 32
-// CHECK:         store i32 %thread.id.0, ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %thread.id.0, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         br label %[[VAL_12:.*]]
 // CHECK:       loop0.loop_header:                                ; preds = %[[VAL_13:.*]], %[[VAL_14:.*]]
-// CHECK:         %[[VAL_15:.*]] = load i32, ptr %[[VAL_3]], align 4
+// CHECK:         %[[VAL_15:.*]] = load i32, ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_16:.*]] = icmp uge i32 %[[VAL_15]], %tile_bound.0
 // CHECK:         br i1 %[[VAL_16]], label %[[VAL_17:.*]], label %[[VAL_18:.*]]
 // CHECK:       loop0.loop_body:                                  ; preds = %[[VAL_12]]
 // CHECK:         %[[VAL_19:.*]] = add nuw nsw i32 %[[VAL_15]], 4
-// CHECK:         store i32 %[[VAL_19]], ptr %[[VAL_3]], align 4
+// CHECK:         store i32 %[[VAL_19]], ptr{{.*}} %[[VAL_3]], align 4
 // CHECK:         %[[VAL_20:.*]] = icmp eq i32 %[[VAL_15]], %thread.id.0
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         br label %[[VAL_21:.*]]
 // CHECK:       loop2.loop_header:                                ; preds = %[[VAL_22:.*]], %[[VAL_18]]
-// CHECK:         %[[VAL_23:.*]] = load i32, ptr %[[VAL_2]], align 4
+// CHECK:         %[[VAL_23:.*]] = load i32, ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_24:.*]] = icmp uge i32 %[[VAL_23]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_24]], label %[[VAL_13]], label %[[VAL_22]]
 // CHECK:       loop2.loop_body:                                  ; preds = %[[VAL_21]]
 // CHECK:         %[[VAL_25:.*]] = add nuw nsw i32 %[[VAL_23]], 32
-// CHECK:         store i32 %[[VAL_25]], ptr %[[VAL_2]], align 4
+// CHECK:         store i32 %[[VAL_25]], ptr{{.*}} %[[VAL_2]], align 4
 // CHECK:         %[[VAL_26:.*]] = icmp eq i32 %[[VAL_23]], %thread.id.2
 // CHECK:         %[[VAL_27:.*]] = add i32 %tile_origin.0, %[[VAL_15]]
 // CHECK:         %[[VAL_28:.*]] = add i32 %tile_origin.1, 0
 // CHECK:         %[[VAL_29:.*]] = add i32 %tile_origin.2, %[[VAL_23]]
-// CHECK:         %[[VAL_30:.*]] = getelementptr inbounds [33 x [49 x [65 x float]]], ptr %[[VAL_31:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         %[[VAL_32:.*]] = load float, ptr %[[VAL_30]], align 4, !invariant.load !4
-// CHECK:         %[[VAL_33:.*]] = getelementptr inbounds [32 x [1 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 %[[VAL_15]], i32 0, i32 %[[VAL_23]]
-// CHECK:         %[[VAL_34:.*]] = addrspacecast ptr addrspace(3) %[[VAL_33]] to ptr
-// CHECK:         store float %[[VAL_32]], ptr %[[VAL_34]], align 4
-// CHECK:         %[[VAL_35:.*]] = getelementptr inbounds [33 x [49 x [65 x float]]], ptr %[[VAL_31]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         %[[VAL_36:.*]] = load float, ptr %[[VAL_35]], align 4, !invariant.load !4
+// CHECK:         %[[VAL_30:.*]] = getelementptr inbounds [33 x [49 x [65 x float]]], ptr{{.*}} %[[VAL_31:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
+// CHECK:         %[[VAL_32:.*]] = load float, ptr{{.*}} %[[VAL_30]], align 4, !invariant.load !{{[0-9]}}
+// CHECK:         %[[VAL_33:.*]] = getelementptr inbounds [32 x [1 x [33 x float]]], ptr{{.*}} addrspace(3) @tr_tile_0, i32 0, i32 %[[VAL_15]], i32 0, i32 %[[VAL_23]]
+// CHECK:         %[[VAL_34:.*]] = addrspacecast ptr{{.*}} addrspace(3) %[[VAL_33]] to ptr
+// CHECK:         store float %[[VAL_32]], ptr{{.*}} %[[VAL_34]], align 4
+// CHECK:         %[[VAL_35:.*]] = getelementptr inbounds [33 x [49 x [65 x float]]], ptr{{.*}} %[[VAL_31]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
+// CHECK:         %[[VAL_36:.*]] = load float, ptr{{.*}} %[[VAL_35]], align 4, !invariant.load !{{[0-9]}}
 // CHECK:         %[[VAL_37:.*]] = fneg float %[[VAL_36]]
-// CHECK:         %[[VAL_38:.*]] = getelementptr inbounds [33 x [49 x [65 x float]]], ptr %[[VAL_39:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
-// CHECK:         store float %[[VAL_37]], ptr %[[VAL_38]], align 4
-// CHECK:         br label %[[VAL_21]], !llvm.loop !5
+// CHECK:         %[[VAL_38:.*]] = getelementptr inbounds [33 x [49 x [65 x float]]], ptr{{.*}} %[[VAL_39:.*]], i32 0, i32 %[[VAL_27]], i32 %[[VAL_28]], i32 %[[VAL_29]]
+// CHECK:         store float %[[VAL_37]], ptr{{.*}} %[[VAL_38]], align 4
+// CHECK:         br label %[[VAL_21]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit:                                  ; preds = %[[VAL_21]]
-// CHECK:         br label %[[VAL_12]], !llvm.loop !7
+// CHECK:         br label %[[VAL_12]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop0.loop_exit:                                  ; preds = %[[VAL_12]]
-// CHECK:         call void @llvm.nvvm.barrier0()
-// CHECK:         store i32 %thread.id.0, ptr %[[VAL_1]], align 4
+// CHECK-PTX:     call void @llvm.nvvm.barrier0()
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier()
+// CHECK:         store i32 %thread.id.0, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         br label %[[VAL_40:.*]]
 // CHECK:       loop0.loop_header6:                               ; preds = %[[VAL_41:.*]], %[[VAL_17]]
-// CHECK:         %[[VAL_42:.*]] = load i32, ptr %[[VAL_1]], align 4
+// CHECK:         %[[VAL_42:.*]] = load i32, ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_43:.*]] = icmp uge i32 %[[VAL_42]], %tile_bound.2
 // CHECK:         br i1 %[[VAL_43]], label %[[VAL_44:.*]], label %[[VAL_45:.*]]
 // CHECK:       loop0.loop_body7:                                 ; preds = %[[VAL_40]]
 // CHECK:         %[[VAL_46:.*]] = add nuw nsw i32 %[[VAL_42]], 4
-// CHECK:         store i32 %[[VAL_46]], ptr %[[VAL_1]], align 4
+// CHECK:         store i32 %[[VAL_46]], ptr{{.*}} %[[VAL_1]], align 4
 // CHECK:         %[[VAL_47:.*]] = icmp eq i32 %[[VAL_42]], %thread.id.0
-// CHECK:         store i32 %thread.id.2, ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %thread.id.2, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         br label %[[VAL_48:.*]]
 // CHECK:       loop2.loop_header12:                              ; preds = %[[VAL_49:.*]], %[[VAL_45]]
-// CHECK:         %[[VAL_50:.*]] = load i32, ptr %[[VAL_0]], align 4
+// CHECK:         %[[VAL_50:.*]] = load i32, ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_51:.*]] = icmp uge i32 %[[VAL_50]], %tile_bound.0
 // CHECK:         br i1 %[[VAL_51]], label %[[VAL_41]], label %[[VAL_49]]
 // CHECK:       loop2.loop_body13:                                ; preds = %[[VAL_48]]
 // CHECK:         %[[VAL_52:.*]] = add nuw nsw i32 %[[VAL_50]], 32
-// CHECK:         store i32 %[[VAL_52]], ptr %[[VAL_0]], align 4
+// CHECK:         store i32 %[[VAL_52]], ptr{{.*}} %[[VAL_0]], align 4
 // CHECK:         %[[VAL_53:.*]] = icmp eq i32 %[[VAL_50]], %thread.id.2
 // CHECK:         %[[VAL_54:.*]] = add i32 %tile_origin.2, %[[VAL_42]]
 // CHECK:         %[[VAL_55:.*]] = add i32 %tile_origin.1, 0
 // CHECK:         %[[VAL_56:.*]] = add i32 %tile_origin.0, %[[VAL_50]]
-// CHECK:         %[[VAL_57:.*]] = getelementptr inbounds [32 x [1 x [33 x float]]], ptr addrspace(3) @tr_tile_0, i32 0, i32 %[[VAL_50]], i32 0, i32 %[[VAL_42]]
-// CHECK:         %[[VAL_58:.*]] = addrspacecast ptr addrspace(3) %[[VAL_57]] to ptr
-// CHECK:         %[[VAL_59:.*]] = load float, ptr %[[VAL_58]], align 4
-// CHECK:         %[[VAL_60:.*]] = getelementptr inbounds [65 x [49 x [33 x float]]], ptr %[[VAL_61:.*]], i32 0, i32 %[[VAL_54]], i32 %[[VAL_55]], i32 %[[VAL_56]]
-// CHECK:         store float %[[VAL_59]], ptr %[[VAL_60]], align 4
-// CHECK:         br label %[[VAL_48]], !llvm.loop !8
+// CHECK:         %[[VAL_57:.*]] = getelementptr inbounds [32 x [1 x [33 x float]]], ptr{{.*}} addrspace(3) @tr_tile_0, i32 0, i32 %[[VAL_50]], i32 0, i32 %[[VAL_42]]
+// CHECK:         %[[VAL_58:.*]] = addrspacecast ptr{{.*}} addrspace(3) %[[VAL_57]] to ptr
+// CHECK:         %[[VAL_59:.*]] = load float, ptr{{.*}} %[[VAL_58]], align 4
+// CHECK:         %[[VAL_60:.*]] = getelementptr inbounds [65 x [49 x [33 x float]]], ptr{{.*}} %[[VAL_61:.*]], i32 0, i32 %[[VAL_54]], i32 %[[VAL_55]], i32 %[[VAL_56]]
+// CHECK:         store float %[[VAL_59]], ptr{{.*}} %[[VAL_60]], align 4
+// CHECK:         br label %[[VAL_48]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop2.loop_exit11:                                ; preds = %[[VAL_48]]
-// CHECK:         br label %[[VAL_40]], !llvm.loop !9
+// CHECK:         br label %[[VAL_40]], !llvm.loop !{{[0-9]}}
 // CHECK:       loop0.loop_exit5:                                 ; preds = %[[VAL_40]]
 // CHECK:         ret void


### PR DESCRIPTION
This updates three hlo unit tests so that they also pass on ROCm. The differences are: 
* the ROCm compiler generates "ptr addrspace(5)" instead of "ptr" in many places 
* some metadata indexes are different
* barrier code is different
