### PR TITLE
[XLA:GPU] fix cuDNN FMHA scale

### DIFF
--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -670,6 +670,7 @@ MatchFwdResult MatchBmm1UnfusedBiasSoftmaxBmm2(MatchFwdResult previous_result,
                 first_bmm_pattern, unfused_scaled_bmm_subpattern))))) {
     // bmm1 - (scale) - softmax
     match_result.matched_bmm_1 = bmm_1;
+    match_result.matched_scale = scale;
     match_result.matched_custom_call_name =
         has_dropout ? kCudnnfMHASoftmaxDropoutCallTarget
                     : kCudnnfMHASoftmaxCallTarget;

--- a/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
@@ -4109,6 +4109,7 @@ ENTRY main.92 {
   const CudnnfMHABackendConfig& config = gpu_config.cudnn_fmha_backend_config();
   EXPECT_EQ(fmha->operands().size(), 6);
   EXPECT_NEAR(config.dropout_rate(), 0, 1e-2);
+  EXPECT_FLOAT_EQ(config.fmha_scale(), 2);
   EXPECT_EQ(config.is_flash_attention(), true);
   EXPECT_EQ(config.is_causal_mask(), false);
 }


### PR DESCRIPTION
* fix bmm1-scale-softmax-(dropout)-bmm2 pattern scale not set in FMHA custom call issue.