### PR TITLE
Avoid rewriting tiny matrices with cublas or triton

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -234,6 +234,9 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   // Minimum combined size of matrices in matrix multiplication to
   // be rewritten to cuBLAS or Triton kernel call.
+  // This threshold is a conservative estimate and has been measured
+  // to be always beneficial (up to generally several times faster)
+  // on V100 and H100 GPUs. See openxla/xla #9319 for details.
   const int64_t kDefaultMinGemmRewriteSize = 100;
   opts.set_xla_gpu_gemm_rewrite_size_threshold(kDefaultMinGemmRewriteSize);
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -231,6 +231,12 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_p2p_max_nchannels(0);
 
   opts.set_xla_gpu_enable_mlir_emitters(false);
+
+  // Minimum combined size of matrices in matrix multiplication to
+  // be rewritten to cuBLAS or Triton kernel call.
+  const int64_t kDefaultMinGemmRewriteSize = 100;
+  opts.set_xla_gpu_gemm_rewrite_size_threshold(kDefaultMinGemmRewriteSize);
+
   return opts;
 }
 
@@ -1568,6 +1574,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_mlir_emitters),
       debug_options->xla_gpu_enable_mlir_emitters(),
       "Enable new MLIR-based emitters."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_gemm_rewrite_size_threshold",
+      int64_setter_for(&DebugOptions::set_xla_gpu_gemm_rewrite_size_threshold),
+      debug_options->xla_gpu_gemm_rewrite_size_threshold(),
+      "Threshold to rewrite matmul to cuBLAS or Triton "
+      "(total number of elements)."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -1579,7 +1579,8 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       int64_setter_for(&DebugOptions::set_xla_gpu_gemm_rewrite_size_threshold),
       debug_options->xla_gpu_gemm_rewrite_size_threshold(),
       "Threshold to rewrite matmul to cuBLAS or Triton "
-      "(total number of elements)."));
+      "(minumum combined number of elements of both matrices "
+      "in non-batch dimensions to be considered for a rewrite)."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -482,8 +482,14 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     if (!IsMatrixMultiplication(*instr)) {
       return absl::OkStatus();
     }
+    int64_t gemm_rewrite_size_threshold =
+        instr->GetModule()
+            ->config()
+            .debug_options()
+            .xla_gpu_gemm_rewrite_size_threshold();
     TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
-                        IsMatrixMultiplicationTooSmallForRewriting(*instr));
+                        IsMatrixMultiplicationTooSmallForRewriting(
+                            *instr, gemm_rewrite_size_threshold));
     if (is_matmul_tiny) {
       return absl::OkStatus();
     }

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -490,7 +490,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
                         IsMatrixMultiplicationTooSmallForRewriting(
                             *instr, gemm_rewrite_size_threshold));
-    if (is_matmul_tiny && IsDotSupportedByBackend(*instr)) {
+    if (is_matmul_tiny && IsDotSupportedByClassicalEmitters(*instr)) {
       return absl::OkStatus();
     }
 

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -490,7 +490,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
                         IsMatrixMultiplicationTooSmallForRewriting(
                             *instr, gemm_rewrite_size_threshold));
-    if (is_matmul_tiny) {
+    if (is_matmul_tiny && IsDotSupportedByBackend(*instr)) {
       return absl::OkStatus();
     }
 

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -482,6 +482,11 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     if (!IsMatrixMultiplication(*instr)) {
       return absl::OkStatus();
     }
+    TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
+                        IsMatrixMultiplicationTooSmallForRewriting(*instr));
+    if (is_matmul_tiny) {
+      return absl::OkStatus();
+    }
 
     CHECK(!instr->IsRank2Transpose());
     CHECK(!instr->mutable_operand(0)->IsRank2Transpose());

--- a/xla/service/gpu/gemm_rewriter_triton.cc
+++ b/xla/service/gpu/gemm_rewriter_triton.cc
@@ -674,8 +674,14 @@ class GemmRewriterTritonVisitor : public DfsHloRewriteVisitor {
   absl::Status HandleDot(HloInstruction* dot) override {
     CHECK_EQ(dot->opcode(), HloOpcode::kDot);
 
+    int64_t gemm_rewrite_size_threshold =
+        dot->GetModule()
+            ->config()
+            .debug_options()
+            .xla_gpu_gemm_rewrite_size_threshold();
     TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
-                        IsMatrixMultiplicationTooSmallForRewriting(*dot));
+                        IsMatrixMultiplicationTooSmallForRewriting(
+                            *dot, gemm_rewrite_size_threshold));
     if (is_matmul_tiny) {
       return absl::OkStatus();
     }

--- a/xla/service/gpu/gemm_rewriter_triton.cc
+++ b/xla/service/gpu/gemm_rewriter_triton.cc
@@ -391,8 +391,8 @@ FusionPlanAndRequirements BuildFusionPlanTowardOperands(
 HloInstruction& BuildFusionTowardOperandsImpl(
     AdjacencyList::NodeId node_id, const FusionPlan& fusion_plan,
     absl::flat_hash_map<AdjacencyList::NodeId, HloInstruction*>&
-        fused_hlo_map,                           // read/append
-    HloComputation::Builder& builder,            // append
+        fused_hlo_map,  // read/append
+    HloComputation::Builder& builder,  // append
     std::vector<HloInstruction*>& fusion_params  // append
 ) {
   if (auto it = fused_hlo_map.find(node_id); it != fused_hlo_map.end()) {
@@ -427,7 +427,7 @@ HloInstruction& BuildFusionTowardOperandsImpl(
 // Builds the HLO instructions for the fusion represented by `fusion_plan`.
 HloInstruction& BuildFusionTowardOperands(
     const FusionPlan& fusion_plan,
-    HloComputation::Builder& builder,            // append
+    HloComputation::Builder& builder,  // append
     std::vector<HloInstruction*>& fusion_params  // append
 ) {
   absl::flat_hash_map<AdjacencyList::NodeId, HloInstruction*> fused_hlo_map;
@@ -452,7 +452,7 @@ HlosAndRequirements FuseTowardOperands(
     const std::optional<int>& max_params,
     const se::GpuComputeCapability& gpu_version,
     const HeroProperties& properties, const Requirements& requirements_so_far,
-    HloComputation::Builder& builder,            // append
+    HloComputation::Builder& builder,  // append
     std::vector<HloInstruction*>& fusion_params  // append
 ) {
   FusionPlanAndRequirements fusion_plan_and_reqs =
@@ -480,7 +480,7 @@ HlosAndRequirements FuseTowardOperands(
 HlosAndRequirements FuseDotOperand(
     const HloInstruction& dot, int operand_index,
     const se::GpuComputeCapability& gpu_version,
-    HloComputation::Builder& builder,            // append
+    HloComputation::Builder& builder,  // append
     std::vector<HloInstruction*>& fusion_params  // append
 ) {
   // Direct dot inputs have well defined dimension orders.
@@ -511,7 +511,7 @@ HlosAndRequirements FuseTowardUsers(
     const DimensionOrder& hlo_dim_order,
     const se::GpuComputeCapability& gpu_version,
     const HeroProperties& properties, const Requirements& requirements,
-    HloComputation::Builder& builder,            // append
+    HloComputation::Builder& builder,  // append
     std::vector<HloInstruction*>& fusion_params  // append
 ) {
   const HlosAndRequirements existing_hlos_and_requirements = {&hlo, &fused_hlo,
@@ -593,7 +593,7 @@ HlosAndRequirements FuseDotOutput(
     const HloInstruction& dot, const HloInstruction& fused_dot,
     const se::GpuComputeCapability& gpu_version,
     const DotRequirements& requirements,
-    HloComputation::Builder& builder,            // append
+    HloComputation::Builder& builder,  // append
     std::vector<HloInstruction*>& fusion_params  // append
 ) {
   const auto context =
@@ -682,7 +682,7 @@ class GemmRewriterTritonVisitor : public DfsHloRewriteVisitor {
     TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
                         IsMatrixMultiplicationTooSmallForRewriting(
                             *dot, gemm_rewrite_size_threshold));
-    if (is_matmul_tiny && IsDotSupportedByBackend(*dot)) {
+    if (is_matmul_tiny && IsDotSupportedByClassicalEmitters(*dot)) {
       return absl::OkStatus();
     }
 

--- a/xla/service/gpu/gemm_rewriter_triton.cc
+++ b/xla/service/gpu/gemm_rewriter_triton.cc
@@ -682,7 +682,7 @@ class GemmRewriterTritonVisitor : public DfsHloRewriteVisitor {
     TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
                         IsMatrixMultiplicationTooSmallForRewriting(
                             *dot, gemm_rewrite_size_threshold));
-    if (is_matmul_tiny) {
+    if (is_matmul_tiny && IsDotSupportedByBackend(*dot)) {
       return absl::OkStatus();
     }
 

--- a/xla/service/gpu/gemm_rewriter_triton.cc
+++ b/xla/service/gpu/gemm_rewriter_triton.cc
@@ -674,6 +674,12 @@ class GemmRewriterTritonVisitor : public DfsHloRewriteVisitor {
   absl::Status HandleDot(HloInstruction* dot) override {
     CHECK_EQ(dot->opcode(), HloOpcode::kDot);
 
+    TF_ASSIGN_OR_RETURN(bool is_matmul_tiny,
+                        IsMatrixMultiplicationTooSmallForRewriting(*dot));
+    if (is_matmul_tiny) {
+      return absl::OkStatus();
+    }
+
     std::string fusion_name = absl::StrCat("triton_gemm_", dot->name());
     HloComputation::Builder builder(absl::StrCat(fusion_name, "_computation"));
     std::vector<HloInstruction*> fusion_inputs;

--- a/xla/service/gpu/gemm_rewriter_triton_test.cc
+++ b/xla/service/gpu/gemm_rewriter_triton_test.cc
@@ -57,6 +57,7 @@ class GemmRewriterTritonTest : public HloTestBase {
   DebugOptions GetDebugOptionsForTest() override {
     DebugOptions debug_options = HloTestBase::GetDebugOptionsForTest();
     debug_options.set_xla_gpu_triton_gemm_any(false);
+    debug_options.set_xla_gpu_gemm_rewrite_size_threshold(0);
     return debug_options;
   }
 
@@ -1095,6 +1096,64 @@ ENTRY e {
   EXPECT_EQ(
       module->entry_computation()->root_instruction()->metadata().op_name(),
       "foo");
+}
+
+// A test fixture class for testing the threshold for small matrices.
+class SmallMatrixGemmRewriterTritonTest : public GemmRewriterTritonTest {
+ public:
+  DebugOptions GetDebugOptionsForTest() override {
+    DebugOptions debug_options =
+        GemmRewriterTritonTest::GetDebugOptionsForTest();
+    debug_options.set_xla_gpu_gemm_rewrite_size_threshold(100);
+    return debug_options;
+  }
+};
+
+TEST_F(SmallMatrixGemmRewriterTritonTest, SkipSmallMatrixRewrite) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+HloModule m
+
+ENTRY e {
+  p0 = f16[2,10] parameter(0)
+  p1 = f16[10,2] parameter(1)
+  ROOT d = f16[10,10] dot(p0, p1),
+    lhs_contracting_dims={0}, rhs_contracting_dims={1}, metadata={op_name="foo"}
+})")
+                    .value();
+
+  EXPECT_FALSE(GemmRewriterTriton(gpu_version_).Run(module.get()).value());
+
+  MatchHloModule(*module, R"(
+; CHECK-LABEL: ENTRY %e ({{.*}}: f16[2,10], {{.*}}: f16[10,2]) -> f16[10,10] {
+; CHECK-NEXT: [[P0:%[^ ]+]] = f16[2,10]{1,0} parameter(0)
+; CHECK-NEXT: [[P1:%[^ ]+]] = f16[10,2]{1,0} parameter(1)
+; CHECK:      ROOT {{.*}} = f16[10,10]{1,0} dot(f16[2,10]{1,0} [[P0]], f16[10,2]{1,0} [[P1]])
+})");
+}
+
+TEST_F(SmallMatrixGemmRewriterTritonTest, LargeMatrixRewrite) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+HloModule m
+
+ENTRY e {
+  p0 = f16[2,18] parameter(0)
+  p1 = f16[50,2] parameter(1)
+  ROOT d = f16[18,50] dot(p0, p1),
+    lhs_contracting_dims={0}, rhs_contracting_dims={1}, metadata={op_name="foo"}
+})")
+                    .value();
+
+  EXPECT_TRUE(GemmRewriterTriton(gpu_version_).Run(module.get()).value());
+
+  MatchHloModule(*module, R"(
+; CHECK-LABEL: ENTRY %e ({{.*}}: f16[2,18], {{.*}}: f16[50,2]) -> f16[18,50] {
+; CHECK-NEXT: [[P0:%[^ ]+]] = f16[2,18]{1,0} parameter(0)
+; CHECK-NEXT: [[P1:%[^ ]+]] = f16[50,2]{1,0} parameter(1)
+; CHECK:      ROOT {{.*}} = f16[18,50]{1,0}
+; CHECK:        fusion(f16[2,18]{1,0} [[P0]], f16[50,2]{1,0} [[P1]]),
+; CHECK:        kind=kCustom
+; CHECK:        __triton_gemm
+})");
 }
 
 }  // namespace

--- a/xla/service/gpu/gemm_rewriter_triton_test.cc
+++ b/xla/service/gpu/gemm_rewriter_triton_test.cc
@@ -1099,7 +1099,7 @@ ENTRY e {
 }
 
 // A test fixture class for testing the threshold for small matrices.
-class SmallMatrixGemmRewriterTritonTest : public GemmRewriterTritonTest {
+class SmallDotGemmRewriterTritonTest : public GemmRewriterTritonTest {
  public:
   DebugOptions GetDebugOptionsForTest() override {
     DebugOptions debug_options =
@@ -1109,7 +1109,7 @@ class SmallMatrixGemmRewriterTritonTest : public GemmRewriterTritonTest {
   }
 };
 
-TEST_F(SmallMatrixGemmRewriterTritonTest, SkipSmallMatrixRewrite) {
+TEST_F(SmallDotGemmRewriterTritonTest, SkipSmallMatrixRewrite) {
   auto module = ParseAndReturnVerifiedModule(R"(
 HloModule m
 
@@ -1117,7 +1117,7 @@ ENTRY e {
   p0 = f16[2,10] parameter(0)
   p1 = f16[10,2] parameter(1)
   ROOT d = f16[10,10] dot(p0, p1),
-    lhs_contracting_dims={0}, rhs_contracting_dims={1}, metadata={op_name="foo"}
+    lhs_contracting_dims={0}, rhs_contracting_dims={1}
 })")
                     .value();
 
@@ -1131,7 +1131,7 @@ ENTRY e {
 })");
 }
 
-TEST_F(SmallMatrixGemmRewriterTritonTest, LargeMatrixRewrite) {
+TEST_F(SmallDotGemmRewriterTritonTest, LargeMatrixMultiplicationIsRewritten) {
   auto module = ParseAndReturnVerifiedModule(R"(
 HloModule m
 
@@ -1139,7 +1139,7 @@ ENTRY e {
   p0 = f16[2,18] parameter(0)
   p1 = f16[50,2] parameter(1)
   ROOT d = f16[18,50] dot(p0, p1),
-    lhs_contracting_dims={0}, rhs_contracting_dims={1}, metadata={op_name="foo"}
+    lhs_contracting_dims={0}, rhs_contracting_dims={1}
 })")
                     .value();
 

--- a/xla/service/gpu/gemm_rewriter_triton_test.cc
+++ b/xla/service/gpu/gemm_rewriter_triton_test.cc
@@ -1109,7 +1109,7 @@ class SmallDotGemmRewriterTritonTest : public GemmRewriterTritonTest {
   }
 };
 
-TEST_F(SmallDotGemmRewriterTritonTest, SkipSmallMatrixRewrite) {
+TEST_F(SmallDotGemmRewriterTritonTest, SkipSmallMatrixMultiplicationRewrite) {
   auto module = ParseAndReturnVerifiedModule(R"(
 HloModule m
 

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -30,7 +30,7 @@ limitations under the License.
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Value.h"
 #include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
-#include "mlir/IR/Value.h"              // from @llvm-project
+#include "mlir/IR/Value.h"  // from @llvm-project
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/literal.h"

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -54,9 +54,6 @@ inline constexpr int64_t kMinDimensionToTransposeTiled2 = 8;
 inline constexpr int64_t kMinTotalDimensionsToTransposeTiled = 64 * 128;
 
 // Matrix multiplication before the rewrite.
-//
-// This function should never return "true" on instructions after
-// GemmRewriter pass has finished.
 bool IsMatrixMultiplication(const HloInstruction& dot);
 
 inline constexpr int64_t WarpSize() { return 32; }

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -30,7 +30,7 @@ limitations under the License.
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Value.h"
 #include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
-#include "mlir/IR/Value.h"  // from @llvm-project
+#include "mlir/IR/Value.h"              // from @llvm-project
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/literal.h"

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -823,8 +823,8 @@ absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
          threshold;
 }
 
-bool IsDotSupportedByBackend(const HloInstruction& dot) {
-  // Let us be conservative and only throw float dots at the backend.
+bool IsDotSupportedByClassicalEmitters(const HloInstruction& dot) {
+  // Let us be conservative and only throw float dots at the emitters.
   switch (dot.shape().element_type()) {
     case F16:
     case F32:

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -788,41 +788,39 @@ std::string TritonGemmConfig::ToString() const {
 }
 
 absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
-    const HloInstruction& dot) {
+    const HloInstruction& dot, int64_t threshold) {
   CHECK_EQ(dot.opcode(), HloOpcode::kDot);
 
   const Shape& lhs_shape = dot.operand(0)->shape();
   const Shape& rhs_shape = dot.operand(1)->shape();
   const DotDimensionNumbers& dot_dims = dot.dot_dimension_numbers();
 
-  absl::Span<const int64_t> lhs_contracting_dims =
-      dot_dims.lhs_contracting_dimensions();
-  const int64_t contracting_size = absl::c_accumulate(
-      lhs_contracting_dims, 1, [&](int64_t size, int64_t dim) {
-        return size * lhs_shape.dimensions(dim);
-      });
+  int64_t contracting_size = 1;
+  for (int64_t dim : dot_dims.lhs_contracting_dimensions()) {
+    contracting_size *= lhs_shape.dimensions(dim);
+  }
 
   TF_ASSIGN_OR_RETURN(
       std::vector<int64_t> lhs_non_contracting_dims,
       GetNonContractingDims(lhs_shape, dot_dims.lhs_batch_dimensions(),
                             dot_dims.lhs_contracting_dimensions()));
-  const int64_t lhs_non_contracting_size = absl::c_accumulate(
-      lhs_non_contracting_dims, 1, [&](int64_t size, int64_t dim) {
-        return size * lhs_shape.dimensions(dim);
-      });
+  int64_t lhs_non_contracting_size = 1;
+  for (int64_t dim : lhs_non_contracting_dims) {
+    lhs_non_contracting_size *= lhs_shape.dimensions(dim);
+  }
 
   TF_ASSIGN_OR_RETURN(
       std::vector<int64_t> rhs_non_contracting_dims,
       GetNonContractingDims(rhs_shape, dot_dims.rhs_batch_dimensions(),
-                            dot_dims.lhs_contracting_dimensions()));
-  const int64_t rhs_non_contracting_size = absl::c_accumulate(
-      rhs_non_contracting_dims, 1, [&](int64_t size, int64_t dim) {
-        return size * rhs_shape.dimensions(dim);
-      });
+                            dot_dims.rhs_contracting_dimensions()));
+  int64_t rhs_non_contracting_size = 1;
+  for (int64_t dim : rhs_non_contracting_dims) {
+    rhs_non_contracting_size *= rhs_shape.dimensions(dim);
+  }
 
   return (rhs_non_contracting_size + lhs_non_contracting_size) *
              contracting_size <
-         kMinMatrixSizeForGemmRewriting;
+         threshold;
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -823,5 +823,17 @@ absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
          threshold;
 }
 
+bool IsDotSupportedByBackend(const HloInstruction& dot) {
+  // Let us be conservative and only throw float dots at the backend.
+  switch (dot.shape().element_type()) {
+    case F16:
+    case F32:
+    case BF16:
+      return true;
+    default:
+      return false;
+  }
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -817,7 +817,7 @@ absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
                             dot_dims.lhs_contracting_dimensions()));
   const int64_t rhs_non_contracting_size = absl::c_accumulate(
       rhs_non_contracting_dims, 1, [&](int64_t size, int64_t dim) {
-        return size * lhs_shape.dimensions(dim);
+        return size * rhs_shape.dimensions(dim);
       });
 
   return (rhs_non_contracting_size + lhs_non_contracting_size) *

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -70,11 +70,9 @@ absl::StatusOr<Shape> GetBatchRowColumnShape(
 absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
                                                     int64_t operand_idx);
 
-inline constexpr int64_t kMinMatrixSizeForGemmRewriting = 100;
-
 // Returns true if the matrices are too small to benefit from cublas/triton.
 absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
-    const HloInstruction& dot);
+    const HloInstruction& dot, int64_t threshold);
 
 // extending plain MatrixLayout struct with creator functions
 struct MatrixLayout : public se::gpu::MatrixLayout {

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -75,10 +75,10 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
 absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
     const HloInstruction& dot, int64_t threshold);
 
-// Returns true if the backend can lower the dot. Currently the backend
-// cannot handle some dots, e.g., i8[] x i8[] -> i32[] dots,
+// Returns true if the backend can lower the dot. Currently the classical
+// emitters cannot handle some dots, e.g., i8[] x i8[] -> i32[] dots,
 // so we need to always use cuBLAS or Triton for those.
-bool IsDotSupportedByBackend(const HloInstruction& dot);
+bool IsDotSupportedByClassicalEmitters(const HloInstruction& dot);
 
 // extending plain MatrixLayout struct with creator functions
 struct MatrixLayout : public se::gpu::MatrixLayout {

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -75,6 +75,11 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
 absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
     const HloInstruction& dot, int64_t threshold);
 
+// Returns true if the backend can lower the dot. Currently the backend
+// cannot handle some dots, e.g., i8[] x i8[] -> i32[] dots,
+// so we need to always use cuBLAS or Triton for those.
+bool IsDotSupportedByBackend(const HloInstruction& dot);
+
 // extending plain MatrixLayout struct with creator functions
 struct MatrixLayout : public se::gpu::MatrixLayout {
   // Returns the matrix layout for a logical shape (batch, rows, columns).

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -70,7 +70,8 @@ absl::StatusOr<Shape> GetBatchRowColumnShape(
 absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
                                                     int64_t operand_idx);
 
-// Returns true if the matrices are too small to benefit from cublas/triton.
+// Returns true if the sum of the sizes of the unbatched operand matrices
+// for the dot is smaller than the given threshold.
 absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
     const HloInstruction& dot, int64_t threshold);
 

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -70,6 +70,12 @@ absl::StatusOr<Shape> GetBatchRowColumnShape(
 absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
                                                     int64_t operand_idx);
 
+inline constexpr int64_t kMinMatrixSizeForGemmRewriting = 100;
+
+// Returns true if the matrices are too small to benefit from cublas/triton.
+absl::StatusOr<bool> IsMatrixMultiplicationTooSmallForRewriting(
+    const HloInstruction& dot);
+
 // extending plain MatrixLayout struct with creator functions
 struct MatrixLayout : public se::gpu::MatrixLayout {
   // Returns the matrix layout for a logical shape (batch, rows, columns).

--- a/xla/service/gpu/matmul_utils_test.cc
+++ b/xla/service/gpu/matmul_utils_test.cc
@@ -234,7 +234,7 @@ HloModule DotFuncModule
 ENTRY DotFunc {
   x = f32[100,30,3] parameter(0)
   y = f32[100,3,3] parameter(1)
-  ROOT dot_a = f32[100,30,3] dot(x, y), lhs_contracting_dims={2}, rhs_contracting_dims={1}, lhs_batch_dims={0}, rhs_batch_dims={0}
+  ROOT dot = f32[100,30,3] dot(x, y), lhs_contracting_dims={2}, rhs_contracting_dims={1}, lhs_batch_dims={0}, rhs_batch_dims={0}
 }
 
 )";
@@ -252,7 +252,7 @@ HloModule DotFuncModule
 ENTRY DotFunc {
   x = f32[50,2] parameter(0)
   y = f32[2,2] parameter(1)
-  ROOT dot.1 = f32[50,2] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  ROOT dot = f32[50,2] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
 }
 
 )";
@@ -270,7 +270,7 @@ HloModule DotFuncModule
 ENTRY DotFunc {
   x = f32[2,2] parameter(0)
   y = f32[2,50] parameter(1)
-  ROOT dot.1 = f32[2,50] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  ROOT dot = f32[2,50] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
 }
 
 )";
@@ -288,7 +288,7 @@ HloModule DotFuncModule
 ENTRY DotFunc {
   x = f32[4,16] parameter(0)
   y = f32[16,4] parameter(1)
-  ROOT dot.1 = f32[4,4] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  ROOT dot = f32[4,4] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
 }
 
 )";

--- a/xla/service/gpu/matmul_utils_test.cc
+++ b/xla/service/gpu/matmul_utils_test.cc
@@ -225,6 +225,80 @@ TEST(GetMatrixLayoutTest, BatchInMostMinorPhysicalDimension) {
   EXPECT_FALSE(MatrixLayout::For(shape).ok());
 }
 
+using GetMatrixSizeRewriteThresholdTest = HloTestBase;
+
+TEST_F(GetMatrixSizeRewriteThresholdTest, MatMulTooSmallForRewrite) {
+  const char* hlo_text = R"(
+HloModule DotFuncModule
+
+ENTRY DotFunc {
+  x = f32[100,30,3] parameter(0)
+  y = f32[100,3,3] parameter(1)
+  ROOT dot_a = f32[100,30,3] dot(x, y), lhs_contracting_dims={2}, rhs_contracting_dims={1}, lhs_batch_dims={0}, rhs_batch_dims={0}
+}
+
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  auto dot = module->entry_computation()->root_instruction();
+  EXPECT_THAT(IsMatrixMultiplicationTooSmallForRewriting(*dot, 100),
+              IsOkAndHolds(true));
+}
+
+TEST_F(GetMatrixSizeRewriteThresholdTest, MatMulLeftLargeEnoughForRewrite) {
+  const char* hlo_text = R"(
+HloModule DotFuncModule
+
+ENTRY DotFunc {
+  x = f32[50,2] parameter(0)
+  y = f32[2,2] parameter(1)
+  ROOT dot.1 = f32[50,2] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  auto dot = module->entry_computation()->root_instruction();
+  EXPECT_THAT(IsMatrixMultiplicationTooSmallForRewriting(*dot, 100),
+              IsOkAndHolds(false));
+}
+
+TEST_F(GetMatrixSizeRewriteThresholdTest, MatMulRightLargeEnoughForRewrite) {
+  const char* hlo_text = R"(
+HloModule DotFuncModule
+
+ENTRY DotFunc {
+  x = f32[2,2] parameter(0)
+  y = f32[2,50] parameter(1)
+  ROOT dot.1 = f32[2,50] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  auto dot = module->entry_computation()->root_instruction();
+  EXPECT_THAT(IsMatrixMultiplicationTooSmallForRewriting(*dot, 100),
+              IsOkAndHolds(false));
+}
+
+TEST_F(GetMatrixSizeRewriteThresholdTest, MatMulTogetherLargeEnoughForRewrite) {
+  const char* hlo_text = R"(
+HloModule DotFuncModule
+
+ENTRY DotFunc {
+  x = f32[4,16] parameter(0)
+  y = f32[16,4] parameter(1)
+  ROOT dot.1 = f32[4,4] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  auto dot = module->entry_computation()->root_instruction();
+  EXPECT_THAT(IsMatrixMultiplicationTooSmallForRewriting(*dot, 100),
+              IsOkAndHolds(false));
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/tests/gemm_broadcast_folding_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_broadcast_folding_rewrite_test.cc
@@ -42,6 +42,7 @@ class GemmBroadcastFoldingRewriteTest : public GpuCodegenTest {
     // These tests test the cuBLAS rewriter so we have to make sure that we use
     // cuBLAS for them.
     debug_options.set_xla_gpu_enable_triton_gemm(false);
+    debug_options.set_xla_gpu_gemm_rewrite_size_threshold(0);
     return debug_options;
   }
 };

--- a/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -7163,7 +7163,7 @@ class SmallDotGemmRewriteTest : public GemmRewriteTest {
   }
 };
 
-TEST_F(SmallDotGemmRewriteTest, SkipSmallMatrixRewrite) {
+TEST_F(SmallDotGemmRewriteTest, SkipSmallMatrixMultiplicationRewrite) {
   const char* hlo_text = R"(
 HloModule SkipSmallMatrixRewrite
 

--- a/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -85,7 +85,7 @@ class GemmRewriteTest : public GpuCodegenTest {
 
   enum class Switch : uint32_t {
     False,  // check always fails
-    True,   // check always succeeds
+    True,  // check always succeeds
   };
   // switch based on architecture only
   bool CudaOrRocmCheck(Switch cuda_set, Switch rocm_set) {

--- a/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -7154,8 +7154,7 @@ ENTRY AddDotsFunc {
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
-// A test fixture class for tests which are specific to legacy cublas
-class SmallMatrixGemmRewriteTest : public GemmRewriteTest {
+class SmallDotGemmRewriteTest : public GemmRewriteTest {
  public:
   DebugOptions GetDebugOptionsForTest() override {
     DebugOptions debug_options = GemmRewriteTest::GetDebugOptionsForTest();
@@ -7164,7 +7163,7 @@ class SmallMatrixGemmRewriteTest : public GemmRewriteTest {
   }
 };
 
-TEST_F(SmallMatrixGemmRewriteTest, SkipSmallMatrixRewrite) {
+TEST_F(SmallDotGemmRewriteTest, SkipSmallMatrixRewrite) {
   const char* hlo_text = R"(
 HloModule SkipSmallMatrixRewrite
 
@@ -7175,7 +7174,6 @@ ENTRY DotFunc {
 }
 )";
 
-  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
   MatchOptimizedHlo(hlo_text,
                     R"(
 ; CHECK-LABEL: ENTRY %DotFunc ({{.*}}: f32[3,3], {{.*}}: f32[3,3]) -> f32[3,3] {
@@ -7186,7 +7184,7 @@ ENTRY DotFunc {
 )");
 }
 
-TEST_F(SmallMatrixGemmRewriteTest, LargeMatrixRewrite) {
+TEST_F(SmallDotGemmRewriteTest, LargeMatrixMultiplicationIsRewritten) {
   const char* hlo_text = R"(
 HloModule SkipSmallMatrixRewrite
 
@@ -7197,7 +7195,6 @@ ENTRY DotFunc {
 }
 )";
 
-  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
   MatchOptimizedHlo(hlo_text,
                     R"(
 ; CHECK-LABEL: ENTRY %DotFunc ({{.*}}: f32[8,8], {{.*}}: f32[8,8]) -> f32[8,8] {

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -700,7 +700,9 @@ message DebugOptions {
 
   bool xla_gpu_enable_mlir_emitters = 275;
 
-  // Next id: 277
+  int64 xla_gpu_gemm_rewrite_size_threshold = 277;
+
+  // Next id: 278
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This disables triton/cublas rewriting for matrix multiplication instructions that are too small to benefit from cublas/triton.

In particular, this will avoid triton/cublas if the sum of the sizes of the matrices is <100. This threshold is a conservative estimate and has been measured to be always beneficial (up to generally several times faster) on V100 and H100 GPUs.