### PR TITLE
Remove unused legalize_sparse_ops param from MlirToXlaComputation

### DIFF
--- a/xla/pjrt/cpu/cpu_client.cc
+++ b/xla/pjrt/cpu/cpu_client.cc
@@ -800,7 +800,7 @@ absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> TfrtCpuClient::Compile(
   TF_RETURN_IF_ERROR(MlirToXlaComputation(
       module, xla_computation,
       /*use_tuple_args=*/options.parameter_is_tupled_arguments,
-      /*return_tuple=*/false, /*legalize_sparse_ops=*/true));
+      /*return_tuple=*/false));
   return Compile(xla_computation, options);
 }
 

--- a/xla/pjrt/mlir_to_hlo.cc
+++ b/xla/pjrt/mlir_to_hlo.cc
@@ -181,8 +181,7 @@ void UpgradeStablehlo(mlir::ModuleOp module) {
 
 Status MlirToXlaComputation(mlir::ModuleOp module,
                             XlaComputation& xla_computation,
-                            bool use_tuple_args, bool return_tuple,
-                            bool legalize_sparse_ops) {
+                            bool use_tuple_args, bool return_tuple) {
   mlir::BaseScopedDiagnosticHandler diagnostic_handler(module->getContext());
   {
     mlir::PassManager pm(module->getContext());
@@ -208,9 +207,8 @@ Status MlirToXlaComputation(mlir::ModuleOp module,
   }
 
   HloProto proto;
-  mlir::MlirToHloConversionOptions options;
   TF_RETURN_IF_ERROR(ConvertMlirHloToHlo(module, &proto, use_tuple_args,
-                                         return_tuple, options));
+                                         return_tuple));
 
   xla_computation = XlaComputation(std::move(*proto.mutable_hlo_module()));
   return OkStatus();

--- a/xla/pjrt/mlir_to_hlo.h
+++ b/xla/pjrt/mlir_to_hlo.h
@@ -30,8 +30,7 @@ StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> ParseMlirModuleString(
 // Converts an CHLO/MHLO module to XLA HLO.
 Status MlirToXlaComputation(mlir::ModuleOp module,
                             XlaComputation& xla_computation,
-                            bool use_tuple_args, bool return_tuple,
-                            bool legalize_sparse_ops = false);
+                            bool use_tuple_args, bool return_tuple);
 
 // Converts an MHLO/CHLO module string to an XLA computation.
 Status ParseMlirModuleStringAndConvertToXlaComputation(

--- a/xla/pjrt/pjrt_c_api_client.cc
+++ b/xla/pjrt/pjrt_c_api_client.cc
@@ -1080,12 +1080,11 @@ PjRtCApiExecutable::GetHloModules() const {
     pm.addPass(mlir::mhlo::createStablehloLegalizeToHloPass());
     if (mlir::failed(pm.run(module.get())))
       return xla::Internal("failed to convert to MHLO");
-    mlir::MlirToHloConversionOptions options;
     // TODO(jieying): Tuple args should really come from GetCompileOptions (or
     // equivalent) once implemented.
     TF_RETURN_IF_ERROR(mlir::ConvertMlirHloToHlo(
         module.get(), &hlo_proto, /*use_tuple_args=*/false,
-        /*return_tuple=*/false, options));
+        /*return_tuple=*/false));
     xla::DebugOptions debug_options;
     TF_ASSIGN_OR_RETURN(xla::HloModuleConfig module_config,
                         xla::HloModule::CreateModuleConfigFromProto(


### PR DESCRIPTION
`xla::ParseMlirModuleStringAndConvertToXlaComputation` uses the same params as `xla::MlirToXlaComputation`.

New param `legalize_sparse_ops` was added to `xla::MlirToXlaComputation` on Sep 14, 2023. But this param is unused now.

1. It was decided to remove `legalize_sparse_ops` param from `xla::MlirToXlaComputation`.

2. `options` param has default value `{}` in `MlirToXlaComputation` decl and it is passed by value. In case func caller uses empty options we can simply omit passing `options` param to remove unnecessary obj copy.