### PR TITLE
Move Gt(Max) optimization after all other HandleCompare optimizations

### DIFF
--- a/xla/service/algebraic_simplifier.cc
+++ b/xla/service/algebraic_simplifier.cc
@@ -4640,32 +4640,6 @@ Status AlgebraicSimplifierVisitor::HandleCompare(HloInstruction* compare) {
   HloInstruction* rhs;
   CHECK(Match(compare, m::Compare(m::Op(&lhs), m::Op(&rhs))));
 
-  // Gt(Max(a,b), a) -> Gt(b,a)
-  // Gt(Max(a,b), b) -> Gt(a,b)
-  // Gt(a, Min(a,b)) -> Gt(a,b)
-  // Gt(b, Min(a,b)) -> Gt(b,a)
-  if (compare->comparison_direction() == ComparisonDirection::kGt) {
-    HloInstruction* a;
-    HloInstruction* b;
-    if (Match(lhs, m::Maximum(m::Op(&a), m::Op(&b)))) {
-      if (rhs == a) {  // Gt(Max(a,b), a) -> Gt(b,a)
-        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(0, b));
-        MarkAsChanged();
-      } else if (rhs == b) {  // Gt(Max(a,b), b) -> Gt(a,b)
-        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(0, a));
-        MarkAsChanged();
-      }
-    } else if (Match(rhs, m::Minimum(m::Op(&a), m::Op(&b)))) {
-      if (lhs == a) {  // Gt(a, Min(a,b)) -> Gt(a,b)
-        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(1, b));
-        MarkAsChanged();
-      } else if (lhs == b) {  // Gt(b, Min(a,b)) -> Gt(b,a)
-        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(1, a));
-        MarkAsChanged();
-      }
-    }
-  }
-
   if (Cast<HloCompareInstruction>(compare)->type() ==
       Comparison::Type::kUnsigned) {
     // X u<  0 -> false
@@ -4738,6 +4712,37 @@ Status AlgebraicSimplifierVisitor::HandleCompare(HloInstruction* compare) {
       }
     }
   }
+
+  // Gt(Max(a,b), a) -> Gt(b,a)
+  // Gt(Max(a,b), b) -> Gt(a,b)
+  // Gt(a, Min(a,b)) -> Gt(a,b)
+  // Gt(b, Min(a,b)) -> Gt(b,a)
+  if (compare->comparison_direction() == ComparisonDirection::kGt) {
+    HloInstruction* a;
+    HloInstruction* b;
+    if (Match(lhs, m::Maximum(m::Op(&a), m::Op(&b)))) {
+      if (rhs == a) {  // Gt(Max(a,b), a) -> Gt(b,a)
+        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(0, b));
+        MarkAsChanged();
+        return OkStatus();
+      } else if (rhs == b) {  // Gt(Max(a,b), b) -> Gt(a,b)
+        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(0, a));
+        MarkAsChanged();
+        return OkStatus();
+      }
+    } else if (Match(rhs, m::Minimum(m::Op(&a), m::Op(&b)))) {
+      if (lhs == a) {  // Gt(a, Min(a,b)) -> Gt(a,b)
+        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(1, b));
+        MarkAsChanged();
+        return OkStatus();
+      } else if (lhs == b) {  // Gt(b, Min(a,b)) -> Gt(b,a)
+        TF_RETURN_IF_ERROR(compare->ReplaceOperandWith(1, a));
+        MarkAsChanged();
+        return OkStatus();
+      }
+    }
+  }
+
   return OkStatus();
 }
 


### PR DESCRIPTION
Changes:
1. Move `Gt(Max)` optimization after all other HandleCompare optimizations because other Gt optimizations are more valuable (such as `0 > unsigned  -> False`)
2. If `Gt(Max)` optimization was applied  - `return OkStatus()` instantly. (If `ReplaceInstruction` was called then `lhs/rhs` pointers initialized at the beginning of `HandleCompare` function might point to replaced operand. For consistency, we need to `return OkStatus()` right after `MarkAsChanged`)

@akuegel Could you review it?