### PR TITLE
[XLA:CPU][oneDNN] Align with oneDNN for supported data types in matmul

### DIFF
--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -25,27 +25,23 @@ namespace cpu {
 
 inline bool IsSupportedType(xla::PrimitiveType dtype) {
   using tsl::port::CPUFeature;
-  bool is_supported = false;
   // TODO(intel-tf): Enable more types.
   switch (dtype) {
     case F32:
-      is_supported = true;
-      break;
+      return true;
     case BF16:
-      is_supported = TestCPUFeature(CPUFeature::AVX512F) ||
-                     TestCPUFeature(CPUFeature::AVX_NE_CONVERT) ||
-                     TestCPUFeature(CPUFeature::AMX_BF16);
-      break;
+      return TestCPUFeature(CPUFeature::AVX512F) ||
+             TestCPUFeature(CPUFeature::AVX_NE_CONVERT) ||
+             TestCPUFeature(CPUFeature::AMX_BF16);
     case F16:
-      is_supported = (TestCPUFeature(CPUFeature::AVX512BW) &&
-                      (TestCPUFeature(CPUFeature::AVX512_FP16) ||
-                       TestCPUFeature(CPUFeature::AMX_FP16) ||
-                       TestCPUFeature(CPUFeature::AVX_NE_CONVERT)));
-      break;
+      return TestCPUFeature(CPUFeature::AVX512BW) &&
+             (TestCPUFeature(CPUFeature::AVX512_FP16) ||
+              TestCPUFeature(CPUFeature::AMX_FP16) ||
+              TestCPUFeature(CPUFeature::AVX_NE_CONVERT));
     default:
-      break;
+      return false;
   }
-  return is_supported;
+  return false;
 }
 
 }  // namespace cpu

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <utility>
 
 #include "xla/literal.h"
+#include "xla/service/cpu/onednn_util.h"
 #include "xla/shape_util.h"
 #include "xla/test.h"
 #include "xla/test_helpers.h"
@@ -76,9 +77,7 @@ TEST_F(MatmulTest, SimpleTestF32) {
 TEST_F(MatmulTest, SimpleTestBF16) {
   // TODO(penporn): Refactor IsBF16SupportedByOneDNNOnThisCPU() from
   // tensorflow/core/graph/mkl_graph_util.h and call the function instead.
-  using tsl::port::TestCPUFeature;
-  if (!TestCPUFeature(tsl::port::CPUFeature::AVX512_BF16) &&
-      !TestCPUFeature(tsl::port::CPUFeature::AMX_BF16)) {
+  if (!IsSupportedType(PrimitiveType::BF16)) {
     GTEST_SKIP() << "CPU does not support BF16.";
   }
 


### PR DESCRIPTION
This PR updates the data type support based on CPU features and aligns with oneDNN.