### PR TITLE
[NVIDIA XLA] Support initializing communicators with custom configurations

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -226,6 +226,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_dot_strength_reduction(true);
 
   opts.set_xla_gpu_enable_bf16_6way_gemm(false);
+  opts.set_xla_gpu_nccl_collective_max_nchannels(0);
+  opts.set_xla_gpu_nccl_p2p_max_nchannels(0);
 
   return opts;
 }
@@ -1536,6 +1538,20 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_dot_strength_reduction),
       debug_options->xla_gpu_enable_dot_strength_reduction(),
       "Enable rewriting matmuls with a vector into reductions."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_nccl_collective_max_nchannels",
+      int64_setter_for(&DebugOptions::set_xla_gpu_nccl_collective_max_nchannels),
+      debug_options->xla_gpu_nccl_collective_max_nchannels(),
+      "Specify the maximum number of channels(SMs) NCCL will use "
+      "for collective operations. Default is 0 which is to let "
+      "NCCL decide."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_nccl_p2p_max_nchannels",
+      int64_setter_for(&DebugOptions::set_xla_gpu_nccl_p2p_max_nchannels),
+      debug_options->xla_gpu_nccl_p2p_max_nchannels(),
+      "Specify the maximum number of channels(SMs) NCCL will use "
+      "for p2p operations. Default is 0 which is to let "
+      "NCCL decide."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/gpu/nccl_api.h
+++ b/xla/service/gpu/nccl_api.h
@@ -52,6 +52,7 @@ class NcclApi {
   // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html#ncclconfig
   struct Config {
     bool split_share = false;
+    int64_t max_nchannels = 0;
   };
 
   // Returns a default NcclApi for a current process. Can be a real one based on
@@ -162,7 +163,7 @@ class NcclApi {
   // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommsplit
   virtual absl::StatusOr<std::vector<OwnedNcclComm>> CommSplit(
       absl::Span<const NcclCommHandle> comms, int32_t color,
-      absl::Span<const int32_t> keys) = 0;
+      absl::Span<const int32_t> keys, const Config& config) = 0;
 
   // Abort any uncompleted operations and destroys the communicator. Frees
   // resources that are allocated to a communicator object comm.

--- a/xla/service/gpu/nccl_api.h
+++ b/xla/service/gpu/nccl_api.h
@@ -163,7 +163,7 @@ class NcclApi {
   // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcommsplit
   virtual absl::StatusOr<std::vector<OwnedNcclComm>> CommSplit(
       absl::Span<const NcclCommHandle> comms, int32_t color,
-      absl::Span<const int32_t> keys, const Config& config) = 0;
+      absl::Span<const int32_t> keys, std::optional<Config> config) = 0;
 
   // Abort any uncompleted operations and destroys the communicator. Frees
   // resources that are allocated to a communicator object comm.

--- a/xla/service/gpu/nccl_api_stub.cc
+++ b/xla/service/gpu/nccl_api_stub.cc
@@ -93,8 +93,8 @@ class NcclApiStub final : public NcclApi {
   }
 
   absl::StatusOr<std::vector<OwnedNcclComm>> CommSplit(
-      absl::Span<const NcclCommHandle>, int32_t,
-      absl::Span<const int32_t>, const Config&) final {
+      absl::Span<const NcclCommHandle>, int32_t, absl::Span<const int32_t>,
+      std::optional<Config>) final {
     return UnimplementedError();
   }
 

--- a/xla/service/gpu/nccl_api_stub.cc
+++ b/xla/service/gpu/nccl_api_stub.cc
@@ -94,7 +94,7 @@ class NcclApiStub final : public NcclApi {
 
   absl::StatusOr<std::vector<OwnedNcclComm>> CommSplit(
       absl::Span<const NcclCommHandle>, int32_t,
-      absl::Span<const int32_t>) final {
+      absl::Span<const int32_t>, const Config&) final {
     return UnimplementedError();
   }
 

--- a/xla/service/gpu/nccl_clique.cc
+++ b/xla/service/gpu/nccl_clique.cc
@@ -240,7 +240,8 @@ static auto DeviceRanksToString(absl::Span<const NcclApi::DeviceRank> ranks) {
 static absl::StatusOr<std::shared_ptr<NcclClique::Lock>> InitializeNcclClique(
     se::StreamExecutor* device, RunId run_id, NcclCliqueKey clique_key,
     const NcclCliqueIdCallback& clique_id_callback,
-    int32_t num_local_participants, int32_t rank) {
+    int32_t num_local_participants, int32_t rank,
+    NcclApi::Config &config) {
   int nranks = clique_key.devices().size();
   VLOG(3) << "Initialize NCCL clique " << clique_key.ToString() << " rank #"
           << rank << "; num_local_participants=" << num_local_participants;
@@ -266,11 +267,6 @@ static absl::StatusOr<std::shared_ptr<NcclClique::Lock>> InitializeNcclClique(
         "Create NCCL communicators for clique %s; ranks=[%s]; hash(id)=%d",
         clique_key.ToString(), DeviceRanksToString(ranks),
         absl::HashOf(clique_id));
-
-    // We enable resource sharing between parent and split communicators by
-    // default because that's the only reason why we use comm splitting.
-    NcclApi::Config config;
-    config.split_share = true;
 
     TF_ASSIGN_OR_RETURN(
         std::vector<NcclApi::OwnedNcclComm> created_comms,
@@ -344,7 +340,7 @@ static int32_t GetCommSplitColor(const NcclCliqueKey& clique_key) {
 static absl::StatusOr<std::shared_ptr<NcclClique::Lock>> InitializeNcclClique(
     se::StreamExecutor* device, RunId run_id, NcclCliqueKey clique_key,
     std::shared_ptr<NcclClique::Lock> parent_clique,
-    int32_t num_local_participants, int32_t rank) {
+    int32_t num_local_participants, int32_t rank, NcclApi::Config& config) {
   // Find our rank in the parent clique.
   const NcclCliqueKey& parent_clique_key = (*parent_clique)->clique_key();
   int32_t parent_rank = *parent_clique_key.rank(clique_key.devices()[rank]);
@@ -407,7 +403,8 @@ static absl::StatusOr<std::shared_ptr<NcclClique::Lock>> InitializeNcclClique(
         absl::StrJoin(rank_mapping, ",", rank_mapping_formatter));
 
     TF_ASSIGN_OR_RETURN(auto splitted_comms, NcclApi::Default()->CommSplit(
-                                                 parent_comms, color, keys));
+                                                 parent_comms, color, keys,
+                                                 config));
 
     absl::btree_map<int32_t, NcclApi::OwnedNcclComm> comms;
     for (size_t i = 0; i < splitted_comms.size(); ++i) {
@@ -459,7 +456,8 @@ using AcquiredCliquesMap = NcclClique::AcquiredCliquesMap;
 absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
     se::StreamExecutor* device, RunId run_id, NcclCliqueKey clique_key,
     const NcclCliqueIdCallback& clique_id_callback, int32_t rank,
-    size_t num_local_participants, const AcquiredCliquesMap& acquired_cliques) {
+    size_t num_local_participants, const AcquiredCliquesMap& acquired_cliques,
+    int64_t max_nchannels) {
   VLOG(2) << "Acquire NCCL clique " << clique_key.ToString() << "; run"
           << run_id.ToString() << "; rank " << rank
           << "; num_local_participants=" << num_local_participants
@@ -493,6 +491,12 @@ absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
   static const int64_t enable_nccl_comm_splitting =
       xla::GetDebugOptionsFromFlags().xla_gpu_enable_nccl_comm_splitting();
 
+  // We enable resource sharing between parent and split communicators by
+  // default because that's the only reason why we use comm splitting.
+  NcclApi::Config config;
+  config.split_share = true;
+  config.max_nchannels = max_nchannels;
+
   if (enable_nccl_comm_splitting) {
     for (auto& [acquired_clique_key, acquired_clique] : acquired_cliques) {
       // We don't support splitting non-local cliques as it requires careful
@@ -501,14 +505,14 @@ absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
 
       if (clique_key.IsSubsetOf(acquired_clique_key)) {
         return InitializeNcclClique(device, run_id, clique_key, acquired_clique,
-                                    num_local_participants, rank);
+                                    num_local_participants, rank, config);
       }
     }
   }
 
   // If we can't split any of the acquired cliques, create a new one.
   return InitializeNcclClique(device, run_id, clique_key, clique_id_callback,
-                              num_local_participants, rank);
+                              num_local_participants, rank, config);
 }
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/nccl_clique.h
+++ b/xla/service/gpu/nccl_clique.h
@@ -137,7 +137,8 @@ absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
     se::StreamExecutor* device, RunId run_id, NcclCliqueKey clique_key,
     const NcclCliqueIdCallback& clique_id_callback, int32_t rank,
     size_t num_local_participants,
-    const NcclClique::AcquiredCliquesMap& acquired_cliques);
+    const NcclClique::AcquiredCliquesMap& acquired_cliques,
+    int64_t max_nchannels = 0);
 
 }  // namespace xla::gpu
 

--- a/xla/service/gpu/nccl_clique_key.cc
+++ b/xla/service/gpu/nccl_clique_key.cc
@@ -37,8 +37,10 @@ namespace xla::gpu {
 //===----------------------------------------------------------------------===//
 
 NcclCliqueKey::NcclCliqueKey(std::vector<GlobalDeviceId> devices,
-                             int64_t stream_id)
-    : devices_(std::move(devices)), stream_id_(stream_id) {}
+                             int64_t stream_id, AsyncStreamKind stream_kind)
+    : devices_(std::move(devices)),
+      stream_id_(stream_id),
+      stream_kind_(stream_kind) {}
 
 absl::Span<const GlobalDeviceId> NcclCliqueKey::devices() const {
   return devices_;

--- a/xla/service/gpu/nccl_clique_key.h
+++ b/xla/service/gpu/nccl_clique_key.h
@@ -73,8 +73,9 @@ inline uint64_t GetStreamId(
 // executable.
 class NcclCliqueKey {
  public:
-  explicit NcclCliqueKey(std::vector<GlobalDeviceId> devices,
-                         int64_t stream_id = 0);
+  explicit NcclCliqueKey(
+      std::vector<GlobalDeviceId> devices, int64_t stream_id = 0,
+      AsyncStreamKind stream_kind = AsyncStreamKind::kCollective);
 
   absl::Span<const GlobalDeviceId> devices() const;
 
@@ -84,6 +85,11 @@ class NcclCliqueKey {
   // Returns true if this clique is a subset of `other`: both cliques have the
   // same `stream_id` and all clique devices are part of `other` clique.
   bool IsSubsetOf(const NcclCliqueKey& other) const;
+
+  // Returns the stream kind for this clique key,
+  // stream kind will be used to specify what configuration
+  // to pass for each type of operation.
+  AsyncStreamKind stream_kind() const { return stream_kind_; }
 
   std::string ToString() const;
 
@@ -97,6 +103,7 @@ class NcclCliqueKey {
  private:
   const std::vector<GlobalDeviceId> devices_;
   const int64_t stream_id_;
+  AsyncStreamKind stream_kind_;
 };
 
 template <typename H>

--- a/xla/service/gpu/nccl_collective_thunk.h
+++ b/xla/service/gpu/nccl_collective_thunk.h
@@ -261,7 +261,8 @@ absl::StatusOr<NcclApi::NcclCommHandle> GetNcclComm(
     const Thunk::CollectiveExecuteParams& params,
     const Thunk::CollectiveCliques& collective_cliques,
     const std::vector<ReplicaGroup>& replica_groups,
-    CollectiveOpGroupMode group_mode, int64_t stream_id);
+    CollectiveOpGroupMode group_mode, int64_t stream_id,
+    AsyncStreamKind stream_kind);
 
 struct DeviceBufferPair {
   PrimitiveType element_type;

--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -1111,7 +1111,8 @@ absl::Status CollectiveCmd::Prepare(
       collectives->global_device_id_map ? &local_devices : nullptr);
 
   return resource_requests.AddClique(
-      NcclCliqueKey(std::move(participants), /*stream_id=*/0),
+      NcclCliqueKey(std::move(participants), /*stream_id=*/0,
+                    GetAsyncStreamKind()),
       num_local_participants);
 }
 
@@ -1155,7 +1156,7 @@ absl::Status AllReduceCmd::Record(const Thunk::ExecuteParams& params,
       NcclApi::NcclCommHandle comm,
       GetNcclComm(*params.collective_params, *params.collective_cliques,
                   config().replica_groups, config().group_mode,
-                  /*stream_id=*/0));
+                  /*stream_id=*/0, GetAsyncStreamKind()));
 
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1220,7 +1221,7 @@ absl::Status ReduceScatterCmd::Record(const Thunk::ExecuteParams& params,
       NcclApi::NcclCommHandle comm,
       GetNcclComm(*params.collective_params, *params.collective_cliques,
                   config().replica_groups, config().group_mode,
-                  /*stream_id=*/0));
+                  /*stream_id=*/0, GetAsyncStreamKind()));
 
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1282,7 +1283,7 @@ absl::Status AllGatherCmd::Record(const Thunk::ExecuteParams& params,
       NcclApi::NcclCommHandle comm,
       GetNcclComm(*params.collective_params, *params.collective_cliques,
                   config().replica_groups, config().group_mode,
-                  /*stream_id=*/0));
+                  /*stream_id=*/0, GetAsyncStreamKind()));
 
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(

--- a/xla/service/gpu/runtime/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime/command_buffer_cmd.h
@@ -698,6 +698,8 @@ class CollectiveCmd : public TracedCommandBufferCmd {
 
   bool IsNestedCommandBuffer() const final { return true; }
 
+  virtual AsyncStreamKind GetAsyncStreamKind() = 0;
+
  protected:
   NcclApi* nccl_api() const { return nccl_api_; }
   const NcclCollectiveConfig& config() const { return config_; }
@@ -722,6 +724,10 @@ class AllReduceCmd : public CollectiveCmd {
 
   BufferUsageVector buffers() override;
 
+  AsyncStreamKind GetAsyncStreamKind() override {
+    return AsyncStreamKind::kCollective;
+  };
+
  private:
   ReductionKind reduction_kind_;
   std::vector<NcclCollectiveThunk::Buffer> buffers_;
@@ -742,6 +748,10 @@ class ReduceScatterCmd : public CollectiveCmd {
 
   BufferUsageVector buffers() override;
 
+  AsyncStreamKind GetAsyncStreamKind() override {
+    return AsyncStreamKind::kCollective;
+  };
+
  private:
   ReductionKind reduction_kind_;
   std::vector<NcclCollectiveThunk::Buffer> buffers_;
@@ -760,6 +770,10 @@ class AllGatherCmd : public CollectiveCmd {
                       se::CommandBuffer* command_buffer) override;
 
   BufferUsageVector buffers() override;
+
+  AsyncStreamKind GetAsyncStreamKind() override {
+    return AsyncStreamKind::kCollective;
+  };
 
  private:
   std::vector<NcclCollectiveThunk::Buffer> buffers_;

--- a/xla/service/gpu/thunk.cc
+++ b/xla/service/gpu/thunk.cc
@@ -114,7 +114,8 @@ static absl::StatusOr<GlobalDeviceId> GetGlobalDeviceId(
 absl::StatusOr<Thunk::CollectiveExecuteParams>
 Thunk::CollectiveExecuteParams::Create(
     const ServiceExecutableRunOptions& run_options,
-    int64_t local_device_ordinal) {
+    int64_t local_device_ordinal, int64_t collective_max_nchannels,
+    int64_t p2p_max_nchannels) {
   const GpuExecutableRunOptions* gpu_options =
       run_options.run_options().gpu_executable_run_options();
 
@@ -133,21 +134,26 @@ Thunk::CollectiveExecuteParams::Create(
                                  run_options.run_options().run_id(),
                                  local_device_ordinal, global_device_id,
                                  run_options.run_options().device_assignment(),
-                                 device_id_map, nccl_callback);
+                                 device_id_map, nccl_callback,
+                                 collective_max_nchannels, p2p_max_nchannels);
 }
 
 Thunk::CollectiveExecuteParams::CollectiveExecuteParams(
     se::StreamExecutor* executor, RunId run_id, int64_t local_device_ordinal,
     GlobalDeviceId global_device_id, const DeviceAssignment* device_assn,
     const GlobalDeviceIdMap* global_device_id_map,
-    const NcclCliqueIdCallback* nccl_clique_id_callback)
+    const NcclCliqueIdCallback* nccl_clique_id_callback,
+    int64_t collective_max_nchannels,
+    int64_t p2p_max_nchannels)
     : executor(executor),
       run_id(run_id),
       local_device_ordinal(local_device_ordinal),
       global_device_id(global_device_id),
       device_assn(device_assn),
       global_device_id_map(global_device_id_map),
-      nccl_clique_id_callback(nccl_clique_id_callback) {}
+      nccl_clique_id_callback(nccl_clique_id_callback),
+      collective_max_nchannels(collective_max_nchannels),
+      p2p_max_nchannels(p2p_max_nchannels) {}
 
 //===----------------------------------------------------------------------===//
 // Thunk::ExecuteParams

--- a/xla/service/gpu/thunk.h
+++ b/xla/service/gpu/thunk.h
@@ -206,7 +206,8 @@ class Thunk {
     // missing a global device mapping for a local device ordinal).
     static absl::StatusOr<CollectiveExecuteParams> Create(
         const ServiceExecutableRunOptions& run_options,
-        int64_t local_device_ordinal);
+        int64_t local_device_ordinal, int64_t collective_max_nchannels = 0,
+        int64_t p2p_max_nchannels = 0);
 
     // A mapping from local device ordinals to global device IDs.
     using GlobalDeviceIdMap = std::map<int32_t, GlobalDeviceId>;
@@ -224,13 +225,17 @@ class Thunk {
     const GlobalDeviceIdMap* global_device_id_map;
     const NcclCliqueIdCallback* nccl_clique_id_callback;
 
+    int64_t collective_max_nchannels;
+    int64_t p2p_max_nchannels;
+
    private:
     CollectiveExecuteParams(
         se::StreamExecutor* executor, RunId run_id,
         int64_t local_device_ordinal, GlobalDeviceId global_device_id,
         const DeviceAssignment* device_assn,
         const GlobalDeviceIdMap* global_device_id_map,
-        const NcclCliqueIdCallback* nccl_clique_id_callback);
+        const NcclCliqueIdCallback* nccl_clique_id_callback,
+        int64_t collective_max_nchannels, int64_t p2p_max_nchannels);
   };
 
   //===--------------------------------------------------------------------===//

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -687,7 +687,15 @@ message DebugOptions {
   // If enabled, uses bf16_6way gemm to compute F32 gemm.
   bool xla_gpu_enable_bf16_6way_gemm = 271;
 
-  // Next id: 273
+  // Specify the maximum number of channels(SMs) NCCL
+  // will use for collective operations.
+  int64 xla_gpu_nccl_collective_max_nchannels = 273;
+
+  // Specify the maximum number of channels(SMs) NCCL
+  // will use for p2p operations.
+  int64 xla_gpu_nccl_p2p_max_nchannels = 274;
+
+  // Next id: 275
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
NCCL added support for giving custom configurations to communicators upon creation. [Here's](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcomminitrankconfig) the documentation for that.

We should utilize this feature to give flexibility for tuning in xla. This PR only exposes ways to configure maximum number of channels used by NCCL for different communicators, while it sets up the infra for exposing more configs in the future. 