### PR TITLE
[XLA:GPU] Fix querying parameters in triton fusion analysis.

### DIFF
--- a/xla/service/gpu/triton_fusion_analysis.cc
+++ b/xla/service/gpu/triton_fusion_analysis.cc
@@ -256,6 +256,7 @@ absl::Status TritonFusionAnalysis::ExecuteForDotFusion(
           .insert(
               {output, context.dim_orders().at(output).ToTensorIterationSpec()})
           .second);
+  parameters_[Scope::OUTPUT] = {};
   if (output != &dot) {
     // Propagate back to parameters of the output fusion.
     TF_RETURN_IF_ERROR(context.PropagateDimensionOrdersToParameters(


### PR DESCRIPTION
Without this fix calling `TritonFusionAnalysis::ScopeParameters(TritonFusionAnalysis::Scope::OUTPUT)` on a fusion without output parameters triggers "C++ exception with description "map::at" thrown in the test body.". Existing code using this analysis never reaches this case, so it's just an improvement for the upcoming new code.