### PR TITLE
[WIP] [ROCm] Moving blas::CallContext into NumericOptions

### DIFF
--- a/xla/BUILD
+++ b/xla/BUILD
@@ -366,6 +366,7 @@ cc_library(
         "@tsl//tsl/platform:ml_dtypes",
         "@tsl//tsl/platform:numbers",
         "@tsl//tsl/platform:stacktrace",
+        "//xla/stream_executor:numeric_options"
     ],
 )
 

--- a/xla/client/lib/matrix.h
+++ b/xla/client/lib/matrix.h
@@ -92,13 +92,29 @@ XlaOp Symmetrize(XlaOp x, bool lower);
 //     output[..., :, :] = matrix(x[..., :, :]) * matrix(y[..., :, :])
 xla::XlaOp BatchDot(
     xla::XlaOp x, xla::XlaOp y,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
+    xla::PrecisionConfig precision = xla::PrecisionConfigDEFAULT(),
     std::optional<PrimitiveType> preferred_element_type = std::nullopt);
 xla::XlaOp BatchDot(
     xla::XlaOp x, bool transpose_x, xla::XlaOp y, bool transpose_y,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
-    std::optional<PrimitiveType> preferred_element_type = std::nullopt,
-    bool grad_x = false, bool grad_y = false);
+    xla::PrecisionConfig precision = xla::PrecisionConfigDEFAULT(),
+    std::optional<PrimitiveType> preferred_element_type = std::nullopt);
+
+inline xla::XlaOp BatchDot(
+    xla::XlaOp x, xla::XlaOp y,
+    xla::PrecisionConfig::Precision precision,
+    std::optional<PrimitiveType> preferred_element_type = std::nullopt) {
+  return BatchDot(x, y, PrecisionToPrecisionConfig(precision), 
+    preferred_element_type);
+}
+
+inline xla::XlaOp BatchDot(
+    xla::XlaOp x, bool transpose_x, xla::XlaOp y, bool transpose_y,
+    xla::PrecisionConfig::Precision precision,
+    std::optional<PrimitiveType> preferred_element_type = std::nullopt) {
+  return BatchDot(x, transpose_x, y, transpose_y,
+    PrecisionToPrecisionConfig(precision), 
+    preferred_element_type);
+}
 
 // Parse an einsum string into dimension numbers:
 //   "ab,cb->ac"
@@ -128,12 +144,11 @@ std::string NormalizeEinsumString(absl::string_view einsum_config);
 // Supports two operand einsum notation like "ab,cb->ac".
 xla::XlaOp Einsum(
     xla::XlaOp x, xla::XlaOp y, absl::string_view einsum_config,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
-    std::optional<PrimitiveType> preferred_element_type = std::nullopt,
-    bool grad_x = false, bool grad_y = false);
+    xla::PrecisionConfig precision = xla::PrecisionConfigDEFAULT(),
+    std::optional<PrimitiveType> preferred_element_type = std::nullopt);
 xla::XlaOp Einsum(
     xla::XlaOp x, absl::string_view einsum_config,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT);
+    xla::PrecisionConfig precision = xla::PrecisionConfigDEFAULT());
 
 // Same as above but supporting numeric labels on dimensions. So "ab,cb->ac"
 // becomes:
@@ -143,9 +158,8 @@ xla::XlaOp Einsum(
 xla::XlaOp Einsum(
     xla::XlaOp x, absl::Span<const int64_t> x_config, xla::XlaOp y,
     absl::Span<const int64_t> y_config, absl::Span<const int64_t> output_config,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
-    std::optional<PrimitiveType> preferred_element_type = std::nullopt,
-    bool grad_x = false, bool grad_y = false);
+    xla::PrecisionConfig precision,
+    std::optional<PrimitiveType> preferred_element_type = std::nullopt);
 
 // Transposes a stack of matrices `x` by swapping the last two dimensions.
 xla::XlaOp TransposeInMinorDims(xla::XlaOp x);

--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -893,6 +893,7 @@ StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
       TF_RET_CHECK(proto.has_convolution_dimension_numbers());
       TF_RET_CHECK(absl::c_all_of(proto.precision_config().operand_precision(),
                                   PrecisionConfig::Precision_IsValid));
+
       PrecisionConfig precision_config = proto.precision_config();
       precision_config.mutable_operand_precision()->Resize(
           proto.operand_ids_size(), PrecisionConfig::DEFAULT);

--- a/xla/mlir_hlo/mhlo/IR/hlo_ops_enums.td
+++ b/xla/mlir_hlo/mhlo/IR/hlo_ops_enums.td
@@ -18,6 +18,7 @@ limitations under the License.
 
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/PatternBase.td"
+include "mlir/IR/AttrTypeBase.td"
 
 //===----------------------------------------------------------------------===//
 // Precision Config enum definitions.
@@ -28,10 +29,15 @@ def MHLO_PRECISION_DEFAULT : I32EnumAttrCase<"DEFAULT", 0>;
 def MHLO_PRECISION_HIGH    : I32EnumAttrCase<"HIGH", 1>;
 def MHLO_PRECISION_HIGHEST : I32EnumAttrCase<"HIGHEST", 2>;
 def MHLO_PRECISION_PACKED_NIBBLE : I32EnumAttrCase<"PACKED_NIBBLE", 3>;
+def MHLO_PRECISION_E4B8 : I32EnumAttrCase<"E4B8", 4>;
+def MHLO_PRECISION_E4B10 : I32EnumAttrCase<"E4B10", 5>;
+def MHLO_PRECISION_E4B12 : I32EnumAttrCase<"E4B12", 6>;
+def MHLO_PRECISION_E5 : I32EnumAttrCase<"E5", 7>;
 
 def MHLO_Precision : I32EnumAttr<"Precision",
     "XLA precision for an operand. Has backend specific meaning.",
-    [MHLO_PRECISION_DEFAULT, MHLO_PRECISION_HIGH, MHLO_PRECISION_HIGHEST, MHLO_PRECISION_PACKED_NIBBLE]> {
+    [MHLO_PRECISION_DEFAULT, MHLO_PRECISION_HIGH, MHLO_PRECISION_HIGHEST, MHLO_PRECISION_PACKED_NIBBLE,
+    MHLO_PRECISION_E4B8, MHLO_PRECISION_E4B10, MHLO_PRECISION_E4B12, MHLO_PRECISION_E5]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::mhlo";
 }
@@ -42,6 +48,7 @@ def MHLO_PrecisionAttr : EnumAttr<MHLO_Dialect, MHLO_Precision, "precision">;
 def MHLO_PrecisionConfigAttr:
     OptionalAttr<
           TypedArrayAttrBase<MHLO_PrecisionAttr, "Precision Config attribute">>;
+
 
 //===----------------------------------------------------------------------===//
 // Custom call schedule hints

--- a/xla/reference_util.cc
+++ b/xla/reference_util.cc
@@ -482,9 +482,7 @@ ReferenceUtil::ConvArray4DGeneralDimensionsDilated(
   HloInstruction* rhs_instruction =
       b.AddInstruction(HloInstruction::CreateConstant(std::move(rhs_literal)));
 
-  PrecisionConfig precision_config;
-  precision_config.mutable_operand_precision()->Resize(
-      /*new_size=*/2, PrecisionConfig::DEFAULT);
+  PrecisionConfig precision_config = PrecisionConfigDEFAULT();
   b.AddInstruction(HloInstruction::CreateConvolve(
       shape, lhs_instruction, rhs_instruction, /*feature_group_count=*/1,
       /*batch_group_count=*/1, window, dnums, precision_config));

--- a/xla/service/algebraic_simplifier.cc
+++ b/xla/service/algebraic_simplifier.cc
@@ -3307,9 +3307,7 @@ Status AlgebraicSimplifierVisitor::HandleDot(HloInstruction* dot) {
         dot, HloInstruction::CreateBroadcast(dot->shape(), zero, {}));
   }
 
-  const bool is_packed_nibble =
-      absl::c_linear_search(dot->precision_config().operand_precision(),
-                            PrecisionConfig::PACKED_NIBBLE);
+  const bool is_packed_nibble = count_packed_nibbles(dot->precision_config());
   // If there are no contracting dimensions, a dot can be rewritten as
   // mul(broadcast(transpose(x)),broadcast(transpose(y)))
   if (!is_packed_nibble && options_.enable_dot_to_multiply_rewrite() &&
@@ -8622,9 +8620,8 @@ absl::StatusOr<bool> AlgebraicSimplifierVisitor::SimplifyConvToDot(
 
 absl::StatusOr<bool> AlgebraicSimplifierVisitor::SimplifyConvToMultiply(
     HloInstruction* convolution) {
-  if (options_.is_layout_sensitive() ||
-      absl::c_linear_search(convolution->precision_config().operand_precision(),
-                            PrecisionConfig::PACKED_NIBBLE)) {
+  if (options_.is_layout_sensitive() 
+    || count_packed_nibbles(convolution->precision_config())) {
     return false;
   }
 

--- a/xla/service/dot_merger.cc
+++ b/xla/service/dot_merger.cc
@@ -120,8 +120,7 @@ absl::StatusOr<HloInstruction*> TryMergeSameOperand(HloInstruction* a,
     return nullptr;
   }
 
-  if (!absl::c_equal(a->precision_config().operand_precision(),
-                     b->precision_config().operand_precision())) {
+  if (!equal_configs(a->precision_config(), b->precision_config())) {
     VLOG(3) << "Can't merge dots because they have mismatching operand "
                "precisions:\n"
             << "\t" << a->ToString() << "\n"

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -101,9 +101,6 @@ message GemmBackendConfig {
 
   optional int64 lhs_stride = 14;
   optional int64 rhs_stride = 15;
-
-  optional bool grad_x = 16;
-  optional bool grad_y = 17;
 }
 
 // Backend config for bitcast operation generated from MLIR MHLO dialect.

--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -827,7 +827,10 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
         instr->precision_config().operand_precision(),
         [](int precision) { return precision <= PrecisionConfig::HIGH; });
   }
-  const se::NumericOptions numeric_options{deterministic_ops, allow_tf32};
+  const se::NumericOptions numeric_options{deterministic_ops, allow_tf32,
+    instr->precision_config().operand_precision(0),
+    instr->precision_config().operand_precision(1)
+  };
 
   // Use the first algorithm that's supported as reference. There isn't a
   // particular reason to use it, as any algorithm suffices. It doesn't make
@@ -962,7 +965,10 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
   const bool allow_tf32 = absl::c_all_of(
       instr->precision_config().operand_precision(),
       [](int precision) { return precision <= PrecisionConfig::HIGH; });
-  const se::NumericOptions numeric_options{deterministic_ops, allow_tf32};
+  const se::NumericOptions numeric_options{deterministic_ops, allow_tf32,
+    instr->precision_config().operand_precision(0),
+    instr->precision_config().operand_precision(1)
+  };
 
   se::StreamExecutor* stream_exec = config_.GetExecutor();
   const auto device_ordinal = stream_exec->device_ordinal();

--- a/xla/service/gpu/fusions/address_computation_fusion_test.cc
+++ b/xla/service/gpu/fusions/address_computation_fusion_test.cc
@@ -108,9 +108,7 @@ TEST_F(AddressComputationFusionTest, CublasGemmSimple) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   })";
 
@@ -140,9 +138,7 @@ TEST_F(AddressComputationFusionTest, CublasGemmSimple) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   }
 
@@ -186,9 +182,7 @@ TEST_F(AddressComputationFusionTest, CublasGemmWithWorkspace) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   })";
 
@@ -218,9 +212,7 @@ TEST_F(AddressComputationFusionTest, CublasGemmWithWorkspace) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
     %get-tuple-element.0 = f16[8,8]{1,0} get-tuple-element(%custom-call.1), index=0
     %get-tuple-element.1 = s8[256]{0} get-tuple-element(%custom-call.1), index=1
@@ -267,9 +259,7 @@ TEST_F(AddressComputationFusionTest, ContiguousSlice) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   })";
 
@@ -299,9 +289,7 @@ TEST_F(AddressComputationFusionTest, ContiguousSlice) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   }
 
@@ -345,9 +333,7 @@ TEST_F(AddressComputationFusionTest, ContiguousSliceNonDefaultLayout) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   })";
 
@@ -377,9 +363,7 @@ TEST_F(AddressComputationFusionTest, ContiguousSliceNonDefaultLayout) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   }
 
@@ -421,9 +405,7 @@ TEST_F(AddressComputationFusionTest, OperandIsSlicedGetTupleElement) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"20000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
@@ -444,9 +426,7 @@ TEST_F(AddressComputationFusionTest, OperandIsSlicedGetTupleElement) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"10000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
   })";
@@ -474,9 +454,7 @@ TEST_F(AddressComputationFusionTest, OperandIsSlicedGetTupleElement) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"10000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
     %get-tuple-element.221 = f32[100,100]{1,0} get-tuple-element(%cublas-gemm.23), index=0
@@ -505,9 +483,7 @@ TEST_F(AddressComputationFusionTest, OperandIsSlicedGetTupleElement) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"20000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
@@ -554,9 +530,7 @@ TEST_F(AddressComputationFusionTest, ReversedOperandOrder) {
         "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
         "epilogue":"DEFAULT",
         "lhs_stride":"64",
-        "rhs_stride":"64",
-        "grad_x":false,
-        "grad_y":false
+        "rhs_stride":"64"
       }}
   })";
 
@@ -586,9 +560,7 @@ TEST_F(AddressComputationFusionTest, ReversedOperandOrder) {
           "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"64",
-          "rhs_stride":"64",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"64"
         }
       }
   }
@@ -637,9 +609,7 @@ TEST_F(AddressComputationFusionTest, SingleOperandComputation) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"20000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
@@ -660,9 +630,7 @@ TEST_F(AddressComputationFusionTest, SingleOperandComputation) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"10000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
   })";
@@ -689,9 +657,7 @@ TEST_F(AddressComputationFusionTest, SingleOperandComputation) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"10000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
     %get-tuple-element.221 = f32[100,100]{1,0} get-tuple-element(%cublas-gemm.23), index=0
@@ -720,9 +686,7 @@ TEST_F(AddressComputationFusionTest, SingleOperandComputation) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"20000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
@@ -769,9 +733,7 @@ TEST_F(AddressComputationFusionTest, SlicedOperandAliasingOutput) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"10000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }}
   })";
 
@@ -799,9 +761,7 @@ TEST_F(AddressComputationFusionTest, SlicedOperandAliasingOutput) {
           "precision_config":{"operand_precision":["HIGHEST","HIGHEST"]},
           "epilogue":"DEFAULT",
           "lhs_stride":"10000",
-          "rhs_stride":"10000",
-          "grad_x":false,
-          "grad_y":false
+          "rhs_stride":"10000"
         }
       }
     %get-tuple-element = f32[100,100]{1,0} get-tuple-element(%cublas-gemm.0), index=0

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -527,9 +527,6 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
     HloInstruction *lhs = instr->mutable_operand(0);
     HloInstruction *rhs = instr->mutable_operand(1);
-    auto attributes = instr->frontend_attributes().map();
-    gemm_backend_config.set_grad_x(attributes["grad_x"] == "true");
-    gemm_backend_config.set_grad_y(attributes["grad_y"] == "true");
 
     int64_t lhs_batch_dims_size =
         instr->dot_dimension_numbers().lhs_batch_dimensions_size();
@@ -1747,6 +1744,8 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         supported_type_combinations = {{
             {ComputationType::kF16, DataType::kHalf, PrimitiveType::F16,
              PrimitiveType::F16, DataType::kHalf},
+            {ComputationType::kF32, DataType::kHalf, PrimitiveType::F16,
+             PrimitiveType::F16, DataType::kHalf},
 
             {ComputationType::kI32, DataType::kInt32, PrimitiveType::S8,
              PrimitiveType::S8, DataType::kInt32},
@@ -1975,6 +1974,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     // We use ALG_UNSET and kDefaultComputePrecision because we don't care about
     // the precision, just the layout, since we're just checking if the matrix
     // is column-major.
+    PrecisionConfig::Precision input_precisions[2]={PrecisionConfig::DEFAULT, PrecisionConfig::DEFAULT};
     TF_ASSIGN_OR_RETURN(
         GemmConfig gemm_config,
         GemmConfig::For(
@@ -1986,7 +1986,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
             gemm_backend_config.alpha_imag(), gemm_backend_config.beta(),
             /*precision_algorithm=*/PrecisionConfig::ALG_UNSET,
             /*algorithm*/ std::nullopt, se::blas::kDefaultComputePrecision,
-            gemm_backend_config.grad_x(), gemm_backend_config.grad_y()));
+            input_precisions));
 
     if (matrix_name == "lhs" || matrix_name == "a") {
       return gemm_config.lhs_layout.order == MatrixLayout::Order::kColumnMajor;

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -34,6 +34,8 @@ limitations under the License.
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/device_memory.h"
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
+#include "xla/stream_executor/numeric_options.h"
+#include "xla/types.h"
 #include "xla/xla_data.pb.h"
 
 #if TENSORFLOW_USE_ROCM
@@ -115,8 +117,8 @@ struct GemmConfig : public se::gpu::GemmConfig {
       absl::Span<const int64_t> rhs_contracting_dims, const Shape& output_shape,
       double alpha_real, double alpha_imag, double beta,
       PrecisionConfig::Algorithm precision_algorithm,
-      std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-      bool grad_y);
+      std::optional<int64_t> algorithm, int64_t compute_precision,
+      const PrecisionConfig::Precision* input_precisions);
 
   // As above with additional `c_shape` and `bias_shape_ptr` parameter, both
   // which are only necessarily for F8 gemms.
@@ -128,8 +130,8 @@ struct GemmConfig : public se::gpu::GemmConfig {
       const Shape* bias_shape_ptr, const Shape& output_shape, double alpha_real,
       double alpha_imag, double beta,
       PrecisionConfig::Algorithm precision_algorithm,
-      std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-      bool grad_y);
+      std::optional<int64_t> algorithm, int64_t compute_precision,
+      const PrecisionConfig::Precision* input_precisions);
 
   struct DescriptorsTuple {
     se::gpu::MatrixDescriptor lhs;

--- a/xla/service/gpu/runtime/convolution_thunk.cc
+++ b/xla/service/gpu/runtime/convolution_thunk.cc
@@ -92,6 +92,11 @@ absl::Status ConvolutionThunk::ExecuteOnStream(const ExecuteParams& params) {
     se::OwningScratchAllocator<> scratch_allocator(
         buffer_allocations.device_ordinal(),
         buffer_allocations.memory_allocator());
+    const se::NumericOptions numeric_options{false, false,
+    // FIXME
+      xla::PrecisionConfig::DEFAULT,
+      xla::PrecisionConfig::DEFAULT
+    };
 
     std::vector<se::dnn::ProfileResult> profile_results;
     dnn->GetMIOpenConvolveAlgorithms(
@@ -99,6 +104,7 @@ absl::Status ConvolutionThunk::ExecuteOnStream(const ExecuteParams& params) {
         conv_params.input_buf, config_.filter_descriptor,
         conv_params.filter_buf, config_.output_descriptor,
         conv_params.output_buf, config_.conv_desc, &scratch_allocator,
+        numeric_options,
         &profile_results);
   }
 #endif  // TENSORFLOW_USE_ROCM

--- a/xla/service/hlo_module_config.h
+++ b/xla/service/hlo_module_config.h
@@ -492,8 +492,7 @@ class HloModuleConfig {
   // abstract cost units, before it is considered for early termination.
   absl::flat_hash_map<std::string, int64_t> analysis_allowance_map_;
 
-  PrecisionConfig::Precision matrix_unit_operand_precision_ =
-      PrecisionConfig::DEFAULT;
+  PrecisionConfig::Precision matrix_unit_operand_precision_;
 
   // Profiling data for feedback directed optimizations. Note that this is not
   // the only way to feed FDO data into the compiler and individual backends

--- a/xla/service/hlo_parser.cc
+++ b/xla/service/hlo_parser.cc
@@ -5429,13 +5429,13 @@ bool HloParserImpl::ParseSliceRanges(SliceRanges* result) {
 //   ::= precision_val (delim precision_val)*
 bool HloParserImpl::ParsePrecisionList(
     std::vector<PrecisionConfig::Precision>* result) {
-  auto parse_and_add_item = [&]() {
+    auto parse_and_add_item = [&]() {
     PrecisionConfig::Precision item;
     if (!ParsePrecision(&item)) {
       return false;
     }
     result->push_back(item);
-    return true;
+   return true;
   };
   return ParseList(TokKind::kLbrace, TokKind::kRbrace, TokKind::kComma,
                    parse_and_add_item);

--- a/xla/service/hlo_verifier.cc
+++ b/xla/service/hlo_verifier.cc
@@ -256,9 +256,7 @@ Status ShapeVerifier::HandleConvolution(HloInstruction* convolution) {
           convolution->feature_group_count(), convolution->batch_group_count(),
           convolution->window(), convolution->convolution_dimension_numbers(),
           /*preferred_element_type=*/convolution->shape().element_type()));
-  if (auto nibble_count =
-          absl::c_count(convolution->precision_config().operand_precision(),
-                        PrecisionConfig::PACKED_NIBBLE)) {
+  if (auto nibble_count = count_packed_nibbles(convolution->precision_config())) {
     if (nibble_count == 1) {
       return InvalidArgument(
           "Convolution cannot have a single packed nibble argument");

--- a/xla/service/operand_upcaster.cc
+++ b/xla/service/operand_upcaster.cc
@@ -64,8 +64,7 @@ bool OperandUpcaster::InstructionMatchesPattern(HloInstruction* instruction) {
   }
 
   // Always expand packed nibble precision mode.
-  if (absl::c_count(instruction->precision_config().operand_precision(),
-                    PrecisionConfig::PACKED_NIBBLE) == 2) {
+  if (count_packed_nibbles(instruction->precision_config()) == 2) {
     return true;
   }
 
@@ -81,9 +80,8 @@ bool OperandUpcaster::InstructionMatchesPattern(HloInstruction* instruction) {
 
 absl::StatusOr<HloInstruction*> OperandUpcaster::ExpandInstruction(
     HloInstruction* instruction) {
-  const bool packed_nibble =
-      absl::c_count(instruction->precision_config().operand_precision(),
-                    PrecisionConfig::PACKED_NIBBLE) == 2;
+  const bool packed_nibble = 
+      count_packed_nibbles(instruction->precision_config()) == 2;
   auto type = instruction->shape().element_type();
 
   // If the precision is packed nibble create clone the linear op for each
@@ -121,10 +119,7 @@ absl::StatusOr<HloInstruction*> OperandUpcaster::ExpandInstruction(
     HloInstruction* linear_n0 =
         instruction->parent()->AddInstruction(instruction->CloneWithNewOperands(
             instruction->shape(), {lhs_n0, rhs_n0}));
-    linear_n0->mutable_precision_config()->mutable_operand_precision()->Set(
-        0, PrecisionConfig::DEFAULT);
-    linear_n0->mutable_precision_config()->mutable_operand_precision()->Set(
-        1, PrecisionConfig::DEFAULT);
+    *linear_n0->mutable_precision_config() = PrecisionToPrecisionConfig(PrecisionConfig::DEFAULT);
     HloInstruction* linear_n1 =
         instruction->parent()->AddInstruction(linear_n0->CloneWithNewOperands(
             instruction->shape(), {lhs_n1, rhs_n1}));

--- a/xla/service/spmd/fft_handler.cc
+++ b/xla/service/spmd/fft_handler.cc
@@ -143,9 +143,7 @@ HloInstruction* ShuffleWithinEachPartitionUsingOneHot(HloInstruction* hlo,
   DotDimensionNumbers dot_dnums;
   dot_dnums.add_lhs_contracting_dimensions(hlo->shape().rank() - 1);
   dot_dnums.add_rhs_contracting_dimensions(0);
-  PrecisionConfig precision_config;
-  precision_config.mutable_operand_precision()->Resize(
-      2, PrecisionConfig::DEFAULT);
+  PrecisionConfig precision_config = PrecisionConfigDEFAULT();
   HloInstruction* dot = b->AddInstruction(HloInstruction::CreateDot(
       hlo->shape(), hlo, shuffle_one_hot, dot_dnums, precision_config));
   return dot;

--- a/xla/service/triangular_solve_expander.cc
+++ b/xla/service/triangular_solve_expander.cc
@@ -336,9 +336,7 @@ XlaOp TriangularSolveExpander::InvertDiagonalBlocks(
       dnums.add_rhs_batch_dimensions(0);
       dnums.add_lhs_contracting_dimensions(2);
       dnums.add_rhs_contracting_dimensions(1);
-      PrecisionConfig precision_proto;
-      precision_proto.add_operand_precision(precision);
-      precision_proto.add_operand_precision(precision);
+      PrecisionConfig precision_proto = PrecisionToPrecisionConfig(precision);
       auto update = -DotGeneral(input_row, body_out, dnums, &precision_proto);
 
       body_out = DynamicUpdateSlice(body_out, update, {zero, j, zero});

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -299,6 +299,7 @@ bool DnnSupport::GetMIOpenConvolveAlgorithms(
     DeviceMemoryBase output_data,
     const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
     ScratchAllocator* scratch_allocator,
+    const NumericOptions& numeric_options,
     std::vector<ProfileResult>* /*out_algorithms*/) {
   return false;
 }

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1778,6 +1778,7 @@ class DnnSupport {
       const BatchDescriptor& output_descriptor, DeviceMemoryBase output_data,
       const ConvolutionDescriptor& convolution_descriptor,
       ScratchAllocator* scratch_allocator,
+      const NumericOptions& numeric_options,
       std::vector<ProfileResult>* out_algorithms);
 
   // Returns a list of supported rnn algorithms.

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -112,13 +112,13 @@ struct GemmConfig {  // plain GemmConfig which is extended with create functions
   xla::complex128 alpha;
   double beta;
   int64_t compute_precision;
+  xla::PrecisionConfig::Precision input_precisions[2];
   // PrecisionConfig-level algorithm
   xla::PrecisionConfig::Algorithm precision_algorithm;
   // BLAS-library-level algorithm.
   std::optional<int64_t> algorithm;
-  bool grad_x;
-  bool grad_y;
   std::optional<blas::ComputationType> compute_type;
+  int grad_flags;
 };
 
 struct BlasLt {

--- a/xla/stream_executor/gpu/gpu_timer.cc
+++ b/xla/stream_executor/gpu/gpu_timer.cc
@@ -130,7 +130,11 @@ DeviceMemory<GpuSemaphoreState> GpuTimer::GpuSemaphore::device() {
     // Check the assumption that this device supports unified addressing,
     // otherwise skip the delay kernel
     TF_ASSIGN_OR_RETURN(int status, GpuDriver::GetDeviceAttribute(
+#if GOOGLE_CUDA
                                         CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING,
+#else
+                                        hipDeviceAttributeUnifiedAddressing,
+#endif
                                         parent->device()));
     if (!status) {
       LOG(WARNING) << "Skipping the delay kernel because the device does not "

--- a/xla/stream_executor/numeric_options.h
+++ b/xla/stream_executor/numeric_options.h
@@ -21,8 +21,9 @@ namespace stream_executor {
 // Options that specify the numeric behavior of operations like matrix
 // multiplications and convolutions
 struct NumericOptions {
-  NumericOptions(bool require_determinism, bool allow_tf32)
-      : require_determinism(require_determinism), allow_tf32(allow_tf32) {}
+  NumericOptions(bool require_determinism, bool allow_tf32, int prec1=-1, int prec2=-1)
+      : require_determinism(require_determinism), allow_tf32(allow_tf32), 
+      precision1(DynamicRange(prec1)), precision2(DynamicRange(prec2)) {}
 
   NumericOptions() : require_determinism(false), allow_tf32(true) {}
 
@@ -30,6 +31,24 @@ struct NumericOptions {
   bool require_determinism;
   // If true, float32 inputs can be rounded to TensorFloat-32 precision
   bool allow_tf32;
+
+  // Mirrors xla_data.proto/Precision
+  enum DynamicRange {
+    UNDEFINED = -1,
+
+    DEFAULT = 0,
+    HIGH = 1,
+    HIGHEST = 2,
+    PACKED_NIBBLE = 3,
+    E4B6 = 4,
+    E4B8 = 5,
+    E4B10 = 6,
+    E4B12 = 7,
+    E5 = 8
+  };
+
+  DynamicRange precision1=UNDEFINED;
+  DynamicRange precision2=UNDEFINED;
 };
 
 }  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -222,6 +222,26 @@ rocblas_side ROCMBlasSide(blas::Side side) {
   }
 }
 
+int DtypeSize(blas::DataType type) {
+  switch (type) {
+    case blas::DataType::kHalf:
+    case blas::DataType::kBF16:
+      return 2;
+    case blas::DataType::kFloat:
+      return 4;
+    case blas::DataType::kDouble:
+      return 8;
+    case blas::DataType::kInt8:
+      return 1;
+    case blas::DataType::kComplexFloat:
+      return 8;
+    case blas::DataType::kComplexDouble:
+      return 16;
+    default:
+      return 0;
+  }
+}
+
 absl::StatusOr<rocblas_datatype> AsRocBlasType(blas::DataType type) {
   switch (type) {
     case blas::DataType::kHalf:
@@ -432,6 +452,18 @@ Impl_DoBlasScal(wrap::rocblas_sscal, float,
  *    and ex functions expect the same type as the compute type (i.e. floats.)
  *
  **/
+using sei = internal::StreamExecutorInterface;
+using GemmCallTrace = sei::GemmCallTrace;
+
+void ROCMBlas::MaybeLogGemmOp(GemmCallTrace::GemmType op,
+                              blas::CallContext context, 
+                              uint64_t size1, uint64_t size2) {
+  absl::MutexLock lock{&parent_->LoggerMutex()};
+  if(parent_->GetArgumentLoggingMode() & sei::ArgumentLogging::kGemm) {
+    parent_->ArgumentLogs().emplace_back(
+      GemmCallTrace{op, (int)context, size1, size2});
+  }
+}
 
 absl::Status ROCMBlas::DoBlasGemm(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
@@ -439,6 +471,9 @@ absl::Status ROCMBlas::DoBlasGemm(
     const DeviceMemoryBase &a, int lda, const DeviceMemoryBase &b, int ldb,
     const void *beta, DeviceMemoryBase *c, int ldc,
     const NumericOptions &numeric_options, blas::CallContext context) {
+  MaybeLogGemmOp(GemmCallTrace::GemmType::kPlain, context, m*k*DtypeSize(dtype),
+    n*k*DtypeSize(dtype));
+
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS GEMM: at=%d bt=%d m=%u n=%u "
       "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
@@ -542,6 +577,8 @@ absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
                                   numeric_options, context));
 
   } else {
+    MaybeLogGemmOp(GemmCallTrace::GemmType::kPlain, context, m*k*DtypeSize(type_a),
+      n * k * DtypeSize(type_a));
     CheckPreconditions(transa, transb, m, n, k, type_a, lda, ldb);
     TF_ASSIGN_OR_RETURN(auto roc_type_a, AsRocBlasType(type_a));
     TF_ASSIGN_OR_RETURN(auto roc_type_c, AsRocBlasType(type_c));
@@ -601,6 +638,7 @@ absl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
         ldb, stride_b, beta, c, ldc, stride_c, batch_count, numeric_options,
         context));
   } else {
+    MaybeLogGemmOp(GemmCallTrace::GemmType::kStridedBatched, context, a.size(), b.size());
     VLOG(1) << absl::StreamFormat(
         "doing rocBLAS GEMM strided batched with Algorithm: at=%d bt=%d m=%u "
         "n=%u "
@@ -696,7 +734,6 @@ bool ROCMBlas::GetBlasGemmAlgorithms(
   ASSIGN_OR_FALSE(auto roc_comp_type, AsRocBlasComputeType(c->compute_type));
 
   if (c->batch_size == 1) {
-    // TODO: we should possibly use GemmFloat16Flags(type_a, context) here..
     return DoBlasInternalFailureOK(
         NameWrap{blas_lambda}, stream, true,
         wrap::rocblas_gemm_ex_get_solutions, ROCMBlasTranspose(a.transpose),
@@ -1029,6 +1066,7 @@ bool ROCMBlas::DoBlasGemmBatched(
     DeviceMemorySlice<Eigen::half> c, int ldc, int batch_count,
     const NumericOptions &numeric_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
+  MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a.size(), b.size());
   const Eigen::half alpha_half(alpha);
   const Eigen::half beta_half(beta);
   absl::Status status;
@@ -1063,6 +1101,7 @@ bool ROCMBlas::DoBlasGemmBatched(
     DeviceMemorySlice<Eigen::bfloat16> c_array, int ldc, int batch_count,
     const NumericOptions &numeric_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
+  MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(), b_array.size());
   const Eigen::bfloat16 alpha_bf16(alpha);
   const Eigen::bfloat16 beta_bf16(beta);
 
@@ -1084,6 +1123,8 @@ bool ROCMBlas::DoBlasGemmBatched(
       DeviceMemorySlice<T> c_array, int ldc, int batch_count,                  \
       const NumericOptions &numeric_options,                                   \
       ScratchAllocator *scratch_allocator, blas::CallContext context) {        \
+    MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context,                                          \
+      a_array.size(), b_array.size());                                         \
     absl::Status status = DoBlasGemmBatchedInternal(                           \
         Fun, stream, transa, transb, m, n, k, alpha, a_array, lda, b_array,    \
         ldb, beta, c_array, ldc, batch_count, scratch_allocator);              \
@@ -1150,6 +1191,7 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
       static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
       a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc, stride_a,
       stride_b, stride_c, batch_count);
+  MaybeLogGemmOp(GemmCallTrace::GemmType::kStridedBatched, context, a.size(), b.size());
 
   absl::Status status;
   auto call_gemm = [&](auto func, auto type) {

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -38,6 +38,7 @@ limitations under the License.
 #if TF_HIPBLASLT
 #include "xla/stream_executor/rocm/hip_blas_lt.h"
 #endif
+#include "xla/stream_executor/stream_executor_internal.h"
 
 namespace stream_executor {
 
@@ -198,6 +199,9 @@ class ROCMBlas : public blas::BlasSupport {
 
   // container holding solutions vector (to avoid reallocating it each time)
   std::vector<rocblas_int> solutions_;
+
+  void MaybeLogGemmOp(internal::StreamExecutorInterface::GemmCallTrace::GemmType op, 
+    blas::CallContext context, uint64_t size1, uint64_t size2);
 
 #if TF_HIPBLASLT
   rocm::BlasLt blas_lt_;

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -162,6 +162,21 @@ class ROCMBlas : public blas::BlasSupport {
     return ret.ok();
   }
 
+  absl::Status DoBlasGemmImpl(
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    uint64_t n, uint64_t k, blas::DataType dtype, const void *alpha,
+    const DeviceMemoryBase &a, int lda, const DeviceMemoryBase &b, int ldb,
+    const void *beta, DeviceMemoryBase *c, int ldc,
+    const NumericOptions &numeric_options, blas::ProfileResult* result);
+  absl::Status DoBlasGemmStridedBatchedImpl(
+    Stream *stream, blas::Transpose transa, blas::Transpose transb,
+    uint64_t m, uint64_t n, uint64_t k, blas::DataType dtype,
+    const void *alpha, const DeviceMemoryBase &a, int lda, int64_t stride_a,
+    const DeviceMemoryBase &b, int ldb, int64_t stride_b, const void *beta,
+    DeviceMemoryBase *c, int ldc, int64_t stride_c, int batch_count,
+    const NumericOptions &numeric_options, blas::ProfileResult* result);
+
+
   // A helper function to implement DoBlasGemmBatched interfaces for generic
   // types.
   //
@@ -200,8 +215,8 @@ class ROCMBlas : public blas::BlasSupport {
   // container holding solutions vector (to avoid reallocating it each time)
   std::vector<rocblas_int> solutions_;
 
-  void MaybeLogGemmOp(internal::StreamExecutorInterface::GemmCallTrace::GemmType op, 
-    blas::CallContext context, uint64_t size1, uint64_t size2);
+  void MaybeLogGemmOp(internal::StreamExecutorInterface::GemmCallTrace::GemmType op,
+    bool profiling, NumericOptions numeric_options, uint64_t size1, uint64_t size2);
 
 #if TF_HIPBLASLT
   rocm::BlasLt blas_lt_;

--- a/xla/stream_executor/rocm/rocm_diagnostics.cc
+++ b/xla/stream_executor/rocm/rocm_diagnostics.cc
@@ -38,6 +38,8 @@ limitations under the License.
 #include "tsl/platform/host_info.h"
 #include "tsl/platform/logging.h"
 
+using std::string;
+
 namespace stream_executor {
 namespace rocm {
 

--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -3211,8 +3211,8 @@ class RocmConvRunner : public dnn::ConvRunner {
     TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
                         GpuTimer::CreateIfNeeded(
                             stream,
-                            output_profile_result &&
-                                output_profile_result->warmup_run_executed(),
+                            profile_result &&
+                                profile_result->warmup_run_executed(),
                             is_profiling));
 
     miopenStatus_t status = miopenStatusSuccess;

--- a/xla/stream_executor/rocm/rocm_dnn.h
+++ b/xla/stream_executor/rocm/rocm_dnn.h
@@ -260,6 +260,7 @@ class MIOpenSupport : public dnn::DnnSupport {
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       ScratchAllocator* scratch_allocator,
+      const NumericOptions& numeric_options,
       std::vector<dnn::ProfileResult>* out_algorithms) override;
 
   bool GetRnnAlgorithms(

--- a/xla/stream_executor/stream_executor_internal.h
+++ b/xla/stream_executor/stream_executor_internal.h
@@ -338,7 +338,8 @@ class StreamExecutorInterface {
       kBlasLt = 3
     };
     GemmType op;
-    int flags;
+    bool profiling;
+    int precision1, precision2;
     uint64_t size1, size2;
   };
   // This may be expanded as necessary to trace other calls

--- a/xla/tests/convolution_test.cc
+++ b/xla/tests/convolution_test.cc
@@ -91,11 +91,11 @@ class ForwardPassConvolution_3x3x256_256_OutputZ_Iota : public ConvolutionTest {
     auto lhs = ConstantR4FromArray4D<T>(&builder, *alhs);
     auto rhs = ConstantR4FromArray4D<T>(&builder, *arhs);
     PrecisionConfig precision;
+    precision.add_operand_precision(PrecisionConfig::HIGHEST);
+    precision.add_operand_precision(PrecisionConfig::DEFAULT);
     // The left hand side of the convolution is numbers between 0 and 2304 which
     // requires at least 11 mantissa bits and the DEFAULT precision config is
     // allowed to round to bfloat16 which only has 7 mantissa bits.
-    precision.add_operand_precision(PrecisionConfig::HIGHEST);
-    precision.add_operand_precision(PrecisionConfig::DEFAULT);
     Conv(lhs, rhs, {1, 1}, Padding::kValid, /*feature_group_count=*/1,
          /*batch_group_count=*/1, &precision);
 

--- a/xla/tests/hlo_test_base.cc
+++ b/xla/tests/hlo_test_base.cc
@@ -210,10 +210,7 @@ absl::StatusOr<bool> HloTestBase::RunHloPass(HloPassInterface&& hlo_pass,
 
 /* static */
 PrecisionConfig HloTestBase::DefaultPrecisionConfig(int operands) {
-  PrecisionConfig precision_config;
-  precision_config.mutable_operand_precision()->Resize(
-      operands, PrecisionConfig::DEFAULT);
-  return precision_config;
+  return PrecisionToPrecisionConfig(PrecisionConfig::DEFAULT, operands);
 }
 
 void HloTestBase::SetAotFastMathDebugOptions(DebugOptions* options) {

--- a/xla/tests/test_utils.cc
+++ b/xla/tests/test_utils.cc
@@ -652,9 +652,7 @@ std::unique_ptr<HloDotInstruction> CreateCanonicalDot(const Shape& shape,
                                                       HloInstruction* rhs) {
   CHECK_LE(lhs->shape().rank(), 2);
   CHECK_LE(rhs->shape().rank(), 2);
-  PrecisionConfig precision_config;
-  precision_config.mutable_operand_precision()->Resize(
-      2, PrecisionConfig::DEFAULT);
+  PrecisionConfig precision_config = PrecisionConfigDEFAULT();
   DotDimensionNumbers dot_dimension_numbers;
   dot_dimension_numbers.add_lhs_contracting_dimensions(
       lhs->shape().rank() > 1 ? 1 : 0);

--- a/xla/util.h
+++ b/xla/util.h
@@ -48,6 +48,7 @@ limitations under the License.
 #include "Eigen/Core"  // from @eigen_archive
 #include "xla/status.h"
 #include "xla/status_macros.h"
+#include "xla/stream_executor/numeric_options.h"
 #include "xla/types.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/lib/math/math_util.h"
@@ -820,6 +821,43 @@ void PackInt4(absl::Span<const char> input, absl::Span<char> output);
 // should have num_elements bytes. The high-order 4-bits in each output are
 // zero.
 void UnpackInt4(absl::Span<const char> input, absl::Span<char> output);
+
+inline PrecisionConfig PrecisionToPrecisionConfig(PrecisionConfig::Precision precision, int n = 2)
+{
+  PrecisionConfig cfg;
+  for(int i=0; i<n; i++)
+    cfg.add_operand_precision(precision); 
+  return cfg;
+}
+
+inline PrecisionConfig PrecisionConfigDEFAULT(int n = 2) 
+{ 
+  return PrecisionToPrecisionConfig(PrecisionConfig::DEFAULT, n);
+}
+
+inline PrecisionConfig PrecisionConfigHIGHEST(int n = 2) 
+{ 
+  return PrecisionToPrecisionConfig(PrecisionConfig::HIGHEST, n);
+}
+
+
+inline bool equal_configs(const PrecisionConfig& cfg1, const PrecisionConfig& cfg2) {
+  if(cfg1.operand_precision_size() != cfg2.operand_precision_size())
+    return false;
+  int n = 0;
+  for(int i=0; i<cfg1.operand_precision_size(); i++) {
+    if(cfg1.operand_precision(i) != cfg2.operand_precision(i))
+      return false;
+  }
+  return true;
+}
+
+inline int count_packed_nibbles(const PrecisionConfig& cfg) {
+  int n = 0;
+  for(auto x: cfg.operand_precision())
+    n += (x == PrecisionConfig::PACKED_NIBBLE);
+  return n;
+}
 
 class HloInstruction;
 class HloModule;

--- a/xla/xla_data.proto
+++ b/xla/xla_data.proto
@@ -943,13 +943,34 @@ message SourceTarget {
 // meaning.
 message PrecisionConfig {
   enum Precision {
+    // [ROCm] Equivalent to E4B8
     DEFAULT = 0;
     HIGH = 1;
+
+    // [ROCm] Backend may not downcast into F8 for GEMMs
     HIGHEST = 2;
     // Each U8/S8 value in a tensor actually represents 2 nibble values.
     PACKED_NIBBLE = 3;
 
-    // Next: 4
+    // [ROCm] The following values are only meaningful for F16 and BF16.
+    // If both inputs of a GEMM have one of the following precisions,
+    // backend may downcast internally into F8
+    // (possibly with scaling).
+
+    // Values expected to be almost always within dynamic range of F8_E4M3:
+    // - with bias 6 (maximum amplitude 960.0)
+    E4B6 = 4;
+    // - with bias 8 (maximum amplitude 240.0)
+    E4B8 = 5;
+    // - with bias 10 (maximum amplitude 60.0)
+    E4B10 = 6;
+    // - with bias 12 (maximum amplitude 15.0)
+    E4B12 = 7;
+
+    // Values expected to be within dynamic range of F8_E5M2
+    E5 = 8;
+
+    // Next: 9
   }
 
   // The algorithm used to evaluate the instruction.


### PR DESCRIPTION
OpenXLA currently allows passing gradient flags for GEMM operations through the stack using an argument of type blas::CallContext.

This PR:
* Packs these flags into PrecisionConfig (at the high level) and NumericOptions (at the stream executor level)
* Makes sure that flags are passed correctly (particularly that they are reversed if GEMM operands are swapped)
* Adds unit tests covering the functionality (ROCm only)
* To that end, expands //xla/tests:dot_operation_test (for all backends)

I am somewhat unhappy with the method I am currently using to get data from stream executor back to the unit test, but I don't see a cleaner option - suggestions are welcome.