### PR TITLE
[XLA:GPU] Add cuDNN GEMM fusions.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -690,6 +690,7 @@ cc_library(
         ":matmul_utils",
         ":split_k_gemm_rewriter",
         ":stream_executor_util",
+        ":cudnn_fusion_compiler",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -3030,6 +3031,25 @@ xla_cc_test(
     ],
 )
 
+cc_library(
+    name = "cudnn_fusion_compiler",
+    srcs = if_cuda_is_configured(["cudnn_fusion_compiler.cc"]),
+    hdrs = if_cuda_is_configured(["cudnn_fusion_compiler.h"]),
+    deps = if_cuda_is_configured([
+        ":autotuner_util",
+        ":ir_emission_utils",
+        ":kernel_reuse_cache",
+        "//xla/service/gpu:triton_fusion_analysis",
+        "//xla/service:hlo_pass",
+        "//xla/stream_executor/cuda:cudnn_frontend_helpers",
+        "//xla/stream_executor/cuda:cudnn_plugin",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@cudnn_frontend_archive//:cudnn_frontend",
+        "@local_config_cuda//cuda:cudnn_header",
+    ]),
+)
+
 tf_proto_library(
     name = "executable_proto",
     srcs = ["executable.proto"],
@@ -3718,6 +3738,7 @@ cc_library(
         ":target_constants",
         ":triangular_solve_rewriter",
         ":triton_autotuner",
+        ":cudnn_fusion_compiler",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -149,6 +149,11 @@ message CustomFusionConfig {
   string name = 1;
 }
 
+message CuDnnFusionConfig {
+  int64 plan_id = 1;
+  optional string serialized_graph = 2;
+}
+
 message FusionBackendConfig {
   // kLoop, kInput, or kOutput (from HloInstruction::FusionKind), or your own
   // custom string.
@@ -170,6 +175,8 @@ message FusionBackendConfig {
 
   // Cost model prediction.
   ReificationCost reification_cost = 3;
+
+  CuDnnFusionConfig cudnn_fusion_config = 5;
 }
 
 // Backed config for norm executed by cuDNN.

--- a/xla/service/gpu/command_buffer_scheduling.cc
+++ b/xla/service/gpu/command_buffer_scheduling.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "xla/service/gpu/cublas_cudnn.h"
 #include "xla/service/gpu/hlo_fusion_analysis.h"
 #include "xla/service/gpu/hlo_traversal.h"
+#include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/variant_visitor.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -138,6 +139,9 @@ static bool IsCommand(const HloInstruction* hlo,
     auto gpu_config = fusion->backend_config<GpuBackendConfig>();
     const FusionBackendConfig& backend_config =
         gpu_config->fusion_backend_config();
+    if (backend_config.kind() == kCuDnnFusionKind) {
+      return false;
+    }
     const auto& custom_config = backend_config.custom_fusion_config();
     if (custom_config.name() == "address_computation") {
       auto fusion_analysis =

--- a/xla/service/gpu/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/cudnn_fusion_compiler.cc
@@ -1,0 +1,426 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/cudnn_fusion_compiler.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/string_view.h"
+#include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#include "xla/comparison_util.h"
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_clone_context.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_query.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/service/gpu/kernel_reuse_cache.h"
+#include "xla/service/gpu/matmul_utils.h"
+#include "xla/service/gpu/triton_fusion_analysis.h"
+#include "xla/stream_executor/cuda/cuda_dnn.h"
+#include "xla/stream_executor/cuda/cudnn_frontend_helpers.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+
+namespace xla {
+namespace gpu {
+
+namespace {
+
+namespace fe = cudnn_frontend;
+namespace graph = fe::graph;
+
+inline std::optional<fe::PointwiseMode_t> GetElementwiseMode(
+    const HloInstruction& instruction) {
+  const HloOpcode opcode = instruction.opcode();
+  using m = fe::PointwiseMode_t;
+  switch (opcode) {
+    case HloOpcode::kAdd:
+      return m::ADD;
+    case HloOpcode::kConvert:
+      return m::IDENTITY;
+    case HloOpcode::kDivide:
+      return m::DIV;
+    case HloOpcode::kMultiply:
+      return m::MUL;
+    case HloOpcode::kNegate:
+      return m::NEG;
+    case HloOpcode::kSubtract:
+      return m::SUB;
+    default:
+      return std::nullopt;
+  }
+}
+
+inline std::optional<fe::DataType_t> ToCudnnDataType(const PrimitiveType type) {
+  using t = fe::DataType_t;
+  switch (type) {
+    case PrimitiveType::F32:
+      return t::FLOAT;
+    case PrimitiveType::F16:
+      return t::HALF;
+    case PrimitiveType::BF16:
+      return t::BFLOAT16;
+    case PrimitiveType::S32:
+      return t::INT32;
+    case PrimitiveType::S8:
+      return t::INT8;
+    default:
+      return std::nullopt;
+  }
+}
+
+// Extracts dimensions and strides from HLO tensors in the format expected by
+// cuDNN.
+class GemmDimensionAdapter {
+  explicit GemmDimensionAdapter(const HloDotInstruction& dot,
+                                TritonFusionAnalysis analysis)
+      : analysis_(std::move(analysis)), dot_(dot){};
+
+ public:
+  const TritonFusionAnalysis analysis_;
+
+  static StatusOr<std::optional<GemmDimensionAdapter>> Create(
+      const HloComputation& computation) {
+    const HloInstruction* maybe_dot =
+        hlo_query::GetFirstInstructionWithOpcode(computation, HloOpcode::kDot);
+    if (maybe_dot == nullptr) {
+      VLOG(3) << "Not a GEMM fusion.";
+      return std::nullopt;
+    }
+    const HloDotInstruction* dot = DynCast<HloDotInstruction>(
+        hlo_query::GetFirstInstructionWithOpcode(computation, HloOpcode::kDot));
+    if (absl::c_any_of(dot->precision_config().operand_precision(),
+                       [](int x) { return x != PrecisionConfig::DEFAULT; })) {
+      VLOG(3) << "Non-default precision is not supported.";
+      return std::nullopt;
+    }
+    TF_ASSIGN_OR_RETURN(auto analysis,
+                        TritonFusionAnalysis::Execute(computation));
+    return GemmDimensionAdapter{*dot, std::move(analysis)};
+  }
+
+  bool DimensionsAndStrides(const HloInstruction& hlo,
+                            const TritonFusionAnalysis::Scope scope,
+                            std::vector<int64_t>& dimensions,
+                            std::vector<int64_t>& strides) {
+    const DotDimensionNumbers& dims = dot_.dot_dimension_numbers();
+    // GEMM fusions require a specific canonical order of dimensions.
+    std::vector<int64_t> dim_indices;
+    switch (scope) {
+      case TritonFusionAnalysis::Scope::LHS:
+        dim_indices = {dims.lhs_batch_dimensions().empty()
+                           ? -1
+                           : dims.lhs_batch_dimensions(0),
+                       GetNonContractingDims(dot_.operand(0)->shape(),
+                                             dims.lhs_batch_dimensions(),
+                                             dims.lhs_contracting_dimensions())
+                           .value()[0],
+                       dims.lhs_contracting_dimensions(0)};
+        break;
+      case TritonFusionAnalysis::Scope::RHS:
+        dim_indices = {dims.rhs_batch_dimensions().empty()
+                           ? -1
+                           : dims.rhs_batch_dimensions(0),
+                       dims.rhs_contracting_dimensions(0),
+                       GetNonContractingDims(dot_.operand(1)->shape(),
+                                             dims.rhs_batch_dimensions(),
+                                             dims.rhs_contracting_dimensions())
+                           .value()[0]};
+        break;
+      case TritonFusionAnalysis::Scope::OUTPUT:
+        dim_indices = {dims.lhs_batch_dimensions().empty() ? -1 : 0,
+                       dot_.shape().rank() - 2, dot_.shape().rank() - 1};
+        break;
+    }
+    dimensions.reserve(dim_indices.size());
+    strides.reserve(dim_indices.size());
+    for (const int index : dim_indices) {
+      const auto* spec = analysis_.IterSpec(scope, &hlo, index);
+      if (spec == nullptr) {
+        dimensions.push_back(1);
+        strides.push_back(strides.empty() ? 1 : strides.back());
+        continue;
+      } else {
+        if (spec->size() != 1) {
+          return false;
+        }
+        dimensions.push_back(spec->front().count);
+        strides.push_back(spec->front().stride);
+      }
+    }
+    return true;
+  }
+
+ private:
+  const HloDotInstruction& dot_;
+};
+
+// Traverses fusion computations and creates cuDNN graphs out of them.
+StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
+    const HloFusionInstruction& fusion) {
+  const HloComputation& computation = *fusion.fused_instructions_computation();
+  VLOG(5) << fusion.ToString();
+  VLOG(5) << computation.ToString();
+  graph::Graph graph;
+  std::vector<HloInstruction*> instructions =
+      computation.MakeInstructionPostOrder();
+  absl::flat_hash_map<const HloInstruction*,
+                      std::shared_ptr<graph::Tensor_attributes>>
+      hlo_to_cudnn;
+  TF_ASSIGN_OR_RETURN(std::optional<GemmDimensionAdapter> adapter,
+                      GemmDimensionAdapter::Create(computation));
+  if (!adapter.has_value()) {
+    return std::nullopt;
+  }
+  auto add_parameter = [&](const HloInstruction& parameter,
+                           std::vector<int64_t>& dimensions,
+                           std::vector<int64_t> strides) {
+    const std::optional<fe::DataType_t> data_type =
+        ToCudnnDataType(parameter.shape().element_type());
+    if (!data_type.has_value()) {
+      VLOG(3) << "Unsupported data type.";
+      return false;
+    }
+    hlo_to_cudnn[&parameter] = graph.tensor(
+        graph::Tensor_attributes()
+            .set_dim(dimensions)
+            .set_stride(strides)
+            .set_data_type(*data_type)
+            .set_uid(se::gpu::CuDnnTensorUID(parameter.parameter_number())));
+    return true;
+  };
+  for (const TritonFusionAnalysis::Scope scope :
+       {TritonFusionAnalysis::Scope::LHS, TritonFusionAnalysis::Scope::RHS,
+        TritonFusionAnalysis::Scope::OUTPUT}) {
+    for (const HloInstruction* parameter :
+         adapter->analysis_.ScopeParameters(scope)) {
+      std::vector<int64_t> dimensions;
+      std::vector<int64_t> strides;
+      if (!adapter->DimensionsAndStrides(*parameter, scope, dimensions,
+                                         strides)) {
+        VLOG(3) << "Unsupported dimensions.";
+        return std::nullopt;
+      }
+      if (!add_parameter(*parameter, dimensions, strides)) {
+        return std::nullopt;
+      }
+    }
+  }
+
+  for (const HloInstruction* hlo : instructions) {
+    VLOG(5) << hlo->ToShortString();
+    auto operand = [&hlo_to_cudnn, &hlo](int i) {
+      return hlo_to_cudnn[hlo->operand(i)];
+    };
+    if (hlo->opcode() == HloOpcode::kParameter) {
+      CHECK(hlo_to_cudnn.contains(hlo));
+      continue;
+    } else if (hlo->opcode() == HloOpcode::kReshape ||
+               hlo->opcode() == HloOpcode::kBitcast ||
+               hlo->opcode() == HloOpcode::kTranspose ||
+               hlo->opcode() == HloOpcode::kCopy) {
+      // All these are accounted for separately as transformations of strides.
+      hlo_to_cudnn[hlo] = operand(0);
+    } else if (hlo->IsElementwise()) {
+      const auto mode = GetElementwiseMode(*hlo);
+      if (!mode.has_value()) {
+        VLOG(3) << "Unsupported elementwise operation.";
+        return std::nullopt;
+      }
+      const auto compute_dtype =
+          (primitive_util::IsIntegralType(hlo->shape().element_type()))
+              ? fe::DataType_t::INT32
+              : fe::DataType_t::FLOAT;
+      const auto attrs = graph::Pointwise_attributes()
+                             .set_mode(mode.value())
+                             .set_compute_data_type(compute_dtype);
+      if (hlo->operand_count() == 1) {
+        hlo_to_cudnn[hlo] = graph.pointwise(operand(0), attrs);
+      } else if (hlo->operand_count() == 2) {
+        hlo_to_cudnn[hlo] = graph.pointwise(operand(0), operand(1), attrs);
+      } else if (hlo->operand_count() == 3) {
+        hlo_to_cudnn[hlo] =
+            graph.pointwise(operand(0), operand(1), operand(2), attrs);
+      } else {
+        VLOG(3) << "Unimplemented elementwise operation.";
+        return std::nullopt;
+      }
+    } else if (hlo->opcode() == HloOpcode::kDot) {
+      const auto compute_dtype =
+          (primitive_util::IsIntegralType(hlo->shape().element_type()))
+              ? fe::DataType_t::INT32
+              : fe::DataType_t::FLOAT;
+      hlo_to_cudnn[hlo] = graph.matmul(
+          operand(0), operand(1),
+          graph::Matmul_attributes().set_compute_data_type(compute_dtype));
+    } else {
+      VLOG(3) << "Unimplemented operation.";
+      return std::nullopt;
+    }
+    if (hlo_to_cudnn[hlo] == nullptr) {
+      VLOG(3) << "Creation of the operation failed.";
+      return std::nullopt;
+    }
+    const auto data_type = ToCudnnDataType(hlo->shape().element_type());
+    if (!data_type.has_value()) {
+      VLOG(3) << "Unimplemented data type: " << hlo->shape().element_type();
+      return std::nullopt;
+    }
+    hlo_to_cudnn[hlo]->set_data_type(data_type.value());
+  }
+  const HloInstruction* output = instructions.back();
+  if (instructions.back()->shape().IsTuple()) {
+    output = instructions.back()->operand(0);
+  }
+  std::vector<int64_t> dimensions;
+  std::vector<int64_t> strides;
+  if (!adapter->DimensionsAndStrides(
+          *output, TritonFusionAnalysis::Scope::OUTPUT, dimensions, strides)) {
+    VLOG(3) << "Unsupported dimensions.";
+    return std::nullopt;
+  }
+  hlo_to_cudnn[output]
+      ->set_output(true)
+      .set_dim(dimensions)
+      .set_stride(strides)
+      .set_uid(se::gpu::CuDnnTensorUID(fusion.operand_count()));
+  if (cudnn_frontend::error_t result = graph.validate(); result.is_bad()) {
+    VLOG(3) << result.get_message();
+    return std::nullopt;
+  }
+
+  return se::gpu::CudnnGraph(std::move(graph));
+}
+
+// Creates a cuDNN graph, queries cuDNN whether it is supported.
+StatusOr<se::gpu::CudnnGraph> PrepareGraph(const HloFusionInstruction& hlo,
+                                           se::Stream& stream) {
+  TF_ASSIGN_OR_RETURN(std::optional<se::gpu::CudnnGraph> graph,
+                      HloFusionToCuDnnGraph(hlo));
+  if (!graph.has_value()) {
+    return absl::InternalError("Construction of cuDNN graph failed.");
+  }
+  TF_ASSIGN_OR_RETURN(bool supported, graph->Prepare());
+  if (!supported) {
+    return absl::InternalError("cuDNN graph is not supported.");
+  }
+  return *graph;
+}
+
+class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
+ public:
+  explicit CuDnnFusionVisitor(const AutotuneConfig& config) : config_(config) {}
+
+  absl::Status HandleFusion(HloInstruction* hlo) override {
+    TF_ASSIGN_OR_RETURN(auto gpu_config,
+                        hlo->backend_config<GpuBackendConfig>());
+    const auto& fusion_backend_config = gpu_config.fusion_backend_config();
+    if (fusion_backend_config.kind() != kCuDnnFusionKind) {
+      return absl::OkStatus();
+    }
+    int64_t plan_id = -1;
+    if (fusion_backend_config.has_cudnn_fusion_config()) {
+      if (fusion_backend_config.cudnn_fusion_config().has_serialized_graph()) {
+        VLOG(4) << "Skipping already serialized " << hlo->ToShortString();
+        return absl::OkStatus();
+      }
+      plan_id = fusion_backend_config.cudnn_fusion_config().plan_id();
+    }
+
+    VLOG(4) << "Processing " << hlo->ToString();
+    VLOG(4) << "Plan ID: " << plan_id;
+
+    const std::string cache_key =
+        GetComputationFingerprint(hlo->fused_instructions_computation(), {});
+    std::string& cache_entry = compilation_cache_[cache_key];
+    if (cache_entry.empty()) {
+      TF_ASSIGN_OR_RETURN(se::Stream * stream, config_.GetStream());
+
+      TF_ASSIGN_OR_RETURN(
+          se::gpu::CudnnGraph graph,
+          PrepareGraph(*DynCast<HloFusionInstruction>(hlo), *stream));
+
+      if (plan_id >= 0) {
+        // Build single plan with given ID.
+        if (plan_id >= graph.Graph().get_execution_plan_count()) {
+          return absl::InternalError("cuDNN graph plan does not exist.");
+        }
+        TF_RETURN_IF_ERROR(graph.Build(plan_id));
+      } else {
+        // Build plans one by one till first successful when no plan_id was
+        // provided.
+        for (plan_id = 0; plan_id < graph.Graph().get_execution_plan_count();
+             ++plan_id) {
+          VLOG(7) << "Trying plan ID " << plan_id;
+          if (graph.Build(plan_id).ok()) {
+            VLOG(7) << "Successfully built plan ID " << plan_id;
+            break;
+          }
+        }
+        if (plan_id == graph.Graph().get_execution_plan_count()) {
+          return absl::InternalError("No cuDNN plans can be built.");
+        }
+      }
+
+      if (graph.Graph().get_workspace_size() != 0) {
+        return absl::UnimplementedError(
+            "Support of workspace allocation is not added yet.");
+      }
+
+      std::vector<uint8_t> serialized_graph;
+      RETURN_IF_CUDNN_FRONTEND_ERROR(graph.Graph().serialize(serialized_graph));
+      cache_entry = absl::CEscape(
+          absl::string_view(reinterpret_cast<char*>(serialized_graph.data()),
+                            serialized_graph.size()));
+    } else {
+      VLOG(4) << "Cache hit.";
+    }
+    auto cudnn_config = gpu_config.mutable_fusion_backend_config()
+                            ->mutable_cudnn_fusion_config();
+    cudnn_config->set_plan_id(plan_id);
+    cudnn_config->set_serialized_graph(cache_entry.data());
+    TF_RETURN_IF_ERROR(hlo->set_backend_config(gpu_config));
+
+    MarkAsChanged();
+    return absl::OkStatus();
+  }
+
+ private:
+  AutotuneConfig config_;
+  // <HLO computation fingerprint, serialized compiled cuDNN graph>.
+  absl::flat_hash_map<std::string, std::string> compilation_cache_;
+};
+
+}  // namespace
+
+absl::StatusOr<bool> CuDnnFusionCompiler::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  XLA_SCOPED_LOGGING_TIMER("cuDNN fusion compiler");
+  return CuDnnFusionVisitor(config_).RunOnModule(module, execution_threads);
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/cudnn_fusion_compiler.h
+++ b/xla/service/gpu/cudnn_fusion_compiler.h
@@ -1,0 +1,50 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_CUDNN_FUSION_COMPILER_H_
+#define XLA_SERVICE_GPU_CUDNN_FUSION_COMPILER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/autotuner_util.h"
+#include "xla/service/hlo_pass_interface.h"
+
+namespace xla {
+namespace gpu {
+
+// Converts HLO fusions with cuDNN backend config to cuDNN graphs,
+// compiles them using a cuDNN handle and stores them in the
+// backend config in serialized form.
+class CuDnnFusionCompiler : public HloModulePass {
+ public:
+  explicit CuDnnFusionCompiler(const AutotuneConfig& config)
+      : config_(config) {}
+
+  absl::string_view name() const override { return "cudnn-fusion-compiler"; }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  AutotuneConfig config_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_CUDNN_FUSION_COMPILER_H_

--- a/xla/service/gpu/fusions/BUILD
+++ b/xla/service/gpu/fusions/BUILD
@@ -169,6 +169,7 @@ cc_library(
     deps = [
         ":concatenate",
         ":copy",
+        ":cudnn",
         ":custom",
         ":fusion_emitter",
         ":in_place_dynamic_update_slice",
@@ -416,6 +417,36 @@ xla_cc_test(
         "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
+    name = "cudnn",
+    srcs = ["cudnn.cc"],
+    hdrs = ["cudnn.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    deps = [
+        ":fusion_emitter",
+        "//xla/service/gpu/runtime:cudnn_thunk",
+        "//xla/service/gpu:hlo_fusion_analysis",
+        "@local_config_cuda//cuda:cudnn_header",
+    ],
+)
+
+xla_test(
+    name = "cudnn_test",
+    srcs = if_cuda_is_configured(["cudnn_test.cc"]),
+    backends = [
+        "gpu",
+    ],
+    backend_tags = {"gpu": [
+        "requires-gpu-sm80",
+    ]},
+    deps = [
+        "//xla/service/gpu/tests:gpu_codegen_test",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/platform:test_main",
     ],
 )
 

--- a/xla/service/gpu/fusions/cudnn.cc
+++ b/xla/service/gpu/fusions/cudnn.cc
@@ -1,0 +1,65 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/fusions/cudnn.h"
+
+#include "absl/strings/escaping.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#if GOOGLE_CUDA
+#include "xla/service/gpu/runtime/cudnn_thunk.h"
+#endif
+
+namespace xla {
+namespace gpu {
+
+absl::StatusOr<FusionEmissionResult> CuDnnFusion::Emit(
+    IrEmitterContext& ir_emitter_context,
+    const HloFusionInstruction& fusion) const {
+#if GOOGLE_CUDA
+  VLOG(3) << fusion.ToString();
+
+  TF_ASSIGN_OR_RETURN(auto gpu_config,
+                      fusion.backend_config<GpuBackendConfig>());
+  if (!gpu_config.fusion_backend_config().has_cudnn_fusion_config() ||
+      !gpu_config.fusion_backend_config()
+           .cudnn_fusion_config()
+           .has_serialized_graph()) {
+    return absl::FailedPreconditionError("cuDNN fusion is not compiled.");
+  }
+  std::string unescaped;
+  std::string error;
+  if (!absl::CUnescape(gpu_config.fusion_backend_config()
+                           .cudnn_fusion_config()
+                           .serialized_graph(),
+                       &unescaped, &error)) {
+    return absl::UnknownError(
+        absl::StrCat("Failed unescaping string: ", error));
+  }
+
+  TF_ASSIGN_OR_RETURN(
+      auto kernel_arguments,
+      KernelArguments::Create(ir_emitter_context.buffer_assignment(), &fusion));
+  FusionEmissionResult result;
+  result.thunks.emplace_back(std::make_unique<CuDnnThunk>(
+      std::move(unescaped), Thunk::ThunkInfo::WithProfileAnnotation(&fusion),
+      kernel_arguments.args()));
+  return result;
+#else
+  return absl::UnimplementedError("cuDNN support requires CUDA");
+#endif
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/fusions/cudnn.h
+++ b/xla/service/gpu/fusions/cudnn.h
@@ -1,0 +1,39 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_FUSIONS_CUDNN_H_
+#define XLA_SERVICE_GPU_FUSIONS_CUDNN_H_
+
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/fusions/fusion_emitter.h"
+#include "xla/service/gpu/hlo_fusion_analysis.h"
+
+namespace xla {
+namespace gpu {
+
+// Creates thunks from compiled cuDNN graphs serialized in backend
+// configs of corresponding fusions.
+class CuDnnFusion : public FusionInterface {
+ public:
+  explicit CuDnnFusion(const HloFusionAnalysis&) {}
+
+  absl::StatusOr<FusionEmissionResult> Emit(
+      IrEmitterContext& ir_emitter_context,
+      const HloFusionInstruction& fusion) const final;
+};
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_FUSIONS_CUDNN_H_

--- a/xla/service/gpu/fusions/cudnn_test.cc
+++ b/xla/service/gpu/fusions/cudnn_test.cc
@@ -1,0 +1,218 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class CuDnnFusionExecutionTest : public GpuCodegenTest {
+ public:
+  bool IsAtLeastHopper() {
+    return backend()
+        .default_stream_executor()
+        ->GetDeviceDescription()
+        .cuda_compute_capability()
+        .IsAtLeastHopper();
+  }
+};
+
+TEST_F(CuDnnFusionExecutionTest, DotF32ExecutesCorrectly) {
+  EXPECT_TRUE(RunAndCompare(R"(
+fusion1 {
+  p0 = f32[32,96] parameter(0)
+  p1 = f32[96,64] parameter(1)
+  ROOT r = f32[32,64] dot(p0, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+ENTRY e {
+  p0 = f32[32,96] parameter(0)
+  p1 = f32[96,64] parameter(1)
+  ROOT _ = f32[32,64] fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})",
+                            ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, DotBF16WithCopyExecutesCorrectly) {
+  EXPECT_TRUE(RunAndCompare(R"(
+fusion1 {
+  p0 = bf16[96,512,64]{1,2,0} parameter(0)
+  cp = bf16[96,512,64]{2,1,0} copy(p0)
+  p1 = bf16[96,64,512]{2,1,0} parameter(1)
+  ROOT d = bf16[96,512,512]{2,1,0} dot(cp, p1),
+    lhs_batch_dims={0}, lhs_contracting_dims={2},
+    rhs_batch_dims={0}, rhs_contracting_dims={1}
+}
+
+ENTRY e {
+  p0 = bf16[96,512,64]{1,2,0} parameter(0)
+  p1 = bf16[96,64,512]{2,1,0} parameter(1)
+  ROOT r = bf16[96,512,512]{2,1,0} fusion(p0, p1), kind=kCustom,
+    calls=fusion1,
+    backend_config={"fusion_backend_config": {kind :"__cudnn$fusion"}}
+})",
+                            ErrorSpec{/*aabs=*/1e-2, /*arel=*/1e-3}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, DotBF16BF16F32ExecutesCorrectly) {
+  EXPECT_TRUE(RunAndCompare(R"(
+fusion1 {
+  p0 = bf16[16,32,128] parameter(0)
+  p1 = bf16[16,128,64] parameter(1)
+  ROOT r = f32[16,32,64] dot(p0, p1),
+    lhs_batch_dims={0}, rhs_batch_dims={0},
+    lhs_contracting_dims={2}, rhs_contracting_dims={1}
+}
+
+ENTRY e {
+  p0 = bf16[16,32,128] parameter(0)
+  p1 = bf16[16,128,64] parameter(1)
+  ROOT _ = f32[16,32,64] fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})",
+                            ErrorSpec{/*aabs=*/1e-6, /*arel=*/1e-6}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, DotF32WithOutputSubtractionExecutesCorrectly) {
+  EXPECT_TRUE(RunAndCompare(R"(
+fusion1 {
+  p0 = f32[9,32,96] parameter(0)
+  p1 = f32[9,96,64] parameter(1)
+  d = f32[9,32,64] dot(p0, p1),
+    lhs_batch_dims={0}, rhs_batch_dims={0},
+    lhs_contracting_dims={2}, rhs_contracting_dims={1}
+  p2 = f32[9,32,64] parameter(2)
+  ROOT s = f32[9,32,64] subtract(p2, d)
+}
+
+ENTRY e {
+  p0 = f32[9,32,96] parameter(0)
+  p1 = f32[9,96,64] parameter(1)
+  p2 = f32[9,32,64] parameter(2)
+  ROOT _ = f32[9,32,64] fusion(p0, p1, p2), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})",
+                            ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, DotWithNonDefaultLayoutsExecutesCorrectly) {
+  EXPECT_TRUE(RunAndCompare(R"(
+fusion1 {
+  p0 = bf16[32,32]{0,1} parameter(0)
+  p1 = bf16[32,32]{1,0} parameter(1)
+  ROOT r = bf16[32,32]{0,1} dot(p0, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={1}
+}
+
+ENTRY e {
+  p0 = bf16[32,32]{0,1} parameter(0)
+  p1 = bf16[32,32]{1,0} parameter(1)
+  ROOT _ = bf16[32,32]{0,1} fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})",
+                            ErrorSpec{/*aabs=*/1e-4, /*arel=*/1e-4}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, RHSFusionExecutesCorrectly) {
+  EXPECT_EQ(RunAndCompare(R"(
+fusion1 {
+  p0 = bf16[5,32,96] parameter(0)
+  p1 = s8[5,96,16] parameter(1)
+  p1c = bf16[5,96,16] convert(p1)
+  ROOT r = bf16[5,32,16] dot(p0, p1c),
+    lhs_batch_dims={0}, rhs_batch_dims={0},
+    lhs_contracting_dims={2}, rhs_contracting_dims={1}
+}
+
+ENTRY e {
+  p0 = bf16[5,32,96] parameter(0)
+  p1 = s8[5,96,16] parameter(1)
+  ROOT _ = bf16[5,32,16] fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})",
+                          ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}),
+            IsAtLeastHopper());
+}
+
+TEST_F(CuDnnFusionExecutionTest, SkipNonDefaultPrecision) {
+  EXPECT_FALSE(Run(R"(
+t {
+  p0 = f32[27,23] parameter(0)
+  p0c = s8[27,23] convert(p0)
+  p0cc = f32[27,23] convert(p0c)
+  p1 = f32[23,21] parameter(1)
+  ROOT r = f32[27,21] dot(p0cc, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0},
+    operand_precision={HIGH, HIGH}
+}
+
+ENTRY e {
+  p0 = f32[27,23] parameter(0)
+  p1 = f32[23,21] parameter(1)
+  ROOT r = f32[27,21] fusion(p0, p1), kind=kCustom, calls=t,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})"));
+}
+
+TEST_F(CuDnnFusionExecutionTest,
+       DotF16NegateNonDefaultDimensionsExecutesCorrectly) {
+  EXPECT_TRUE(RunAndCompare(R"(
+fusion1 {
+  p0 = f16[16,32,96] parameter(0)
+  p0n = f16[16,32,96] negate(p0)
+  p1 = f16[16,64,96] parameter(1)
+  ROOT r = f16[16,32,64] dot(p0n, p1),
+    lhs_batch_dims={0}, rhs_batch_dims={0},
+    lhs_contracting_dims={2}, rhs_contracting_dims={2}
+}
+
+ENTRY e {
+  p0 = f16[16,32,96] parameter(0)
+  p1 = f16[16,64,96] parameter(1)
+  ROOT _ = f16[16,32,64] fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})",
+                            ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, DotS8BF16ExecutesCorrectly) {
+  EXPECT_EQ(RunAndCompare(R"(
+fusion1 {
+  p0 = s8[5,32,96] parameter(0)
+  p0c = bf16[5,32,96] convert(p0)
+  p1 = bf16[5,96,16] parameter(1)
+  ROOT r = bf16[5,32,16] dot(p0c, p1),
+    lhs_batch_dims={0}, rhs_batch_dims={0},
+    lhs_contracting_dims={2}, rhs_contracting_dims={1}
+}
+
+ENTRY e {
+  p0 = s8[5,32,96] parameter(0)
+  p1 = bf16[5,96,16] parameter(1)
+  ROOT _ = bf16[5,32,16] fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})",
+                          ErrorSpec{/*aabs=*/1e-5, /*arel=*/1e-5}),
+            IsAtLeastHopper());
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/fusions/fusions.cc
+++ b/xla/service/gpu/fusions/fusions.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/fusions/concatenate.h"
 #include "xla/service/gpu/fusions/copy.h"
+#include "xla/service/gpu/fusions/cudnn.h"
 #include "xla/service/gpu/fusions/custom.h"
 #include "xla/service/gpu/fusions/fusion_emitter.h"
 #include "xla/service/gpu/fusions/in_place_dynamic_update_slice.h"
@@ -206,6 +207,8 @@ absl::StatusOr<std::unique_ptr<FusionInterface>> GetFusionEmitter(
       return std::make_unique<ConcatenateFusion>(analysis);
     case HloFusionAnalysis::EmitterFusionKind::kTriton:
       return std::make_unique<TritonFusion>(analysis);
+    case HloFusionAnalysis::EmitterFusionKind::kCuDnn:
+      return std::make_unique<CuDnnFusion>(analysis);
   }
 }
 

--- a/xla/service/gpu/hlo_fusion_analysis.cc
+++ b/xla/service/gpu/hlo_fusion_analysis.cc
@@ -209,6 +209,10 @@ HloFusionAnalysis::EmitterFusionKind HloFusionAnalysis::GetEmitterFusionKind()
       fusion_backend_config_.kind() == kTritonSoftmaxFusionKind) {
     return EmitterFusionKind::kTriton;
   }
+
+  if (fusion_backend_config_.kind() == kCuDnnFusionKind) {
+    return EmitterFusionKind::kCuDnn;
+  }
 #endif
 
   if (input_output_info_.has_4_bit_input ||

--- a/xla/service/gpu/hlo_fusion_analysis.h
+++ b/xla/service/gpu/hlo_fusion_analysis.h
@@ -44,6 +44,7 @@ class HloFusionAnalysis {
     kConcatenate,
     kInputSlices,
     kScatter,
+    kCuDnn,
   };
 
   // Precomputed information about inputs (arguments) and outputs (roots) of the

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -69,6 +69,8 @@ inline constexpr absl::string_view kTritonGemmFusionKind = "__triton_gemm";
 inline constexpr absl::string_view kTritonSoftmaxFusionKind =
     "__triton_softmax";
 
+inline constexpr absl::string_view kCuDnnFusionKind = "__cudnn$fusion";
+
 inline constexpr absl::string_view kUncompilableFusion =
     "__uncompilable_fusion";
 

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -57,6 +57,7 @@ limitations under the License.
 #include "xla/service/gpu/cudnn_fused_conv_rewriter.h"
 #include "xla/service/gpu/cudnn_fused_mha_rewriter.h"
 #include "xla/service/gpu/cudnn_fused_mha_transpose_fusion.h"
+#include "xla/service/gpu/cudnn_fusion_compiler.h"
 #include "xla/service/gpu/cudnn_norm_rewriter.h"
 #include "xla/service/gpu/cudnn_pad_for_convolutions.h"
 #include "xla/service/gpu/cudnn_simplify_padding.h"
@@ -327,6 +328,7 @@ absl::Status NVPTXCompiler::AddConvAndGemmAutotuningPasses(
     pipeline->AddPass<GpuConvAlgorithmPicker>(autotune_config);
   }
   pipeline->AddPass<GemmAlgorithmPicker>(autotune_config);
+  pipeline->AddPass<CuDnnFusionCompiler>(autotune_config);
   return absl::OkStatus();
 }
 

--- a/xla/service/gpu/priority_fusion.cc
+++ b/xla/service/gpu/priority_fusion.cc
@@ -781,6 +781,7 @@ HloInstruction::FusionKind GpuPriorityFusion::ChooseKind(
       return HloInstruction::FusionKind::kLoop;
     case HloFusionAnalysis::EmitterFusionKind::kTriton:
     case HloFusionAnalysis::EmitterFusionKind::kCustomFusion:
+    case HloFusionAnalysis::EmitterFusionKind::kCuDnn:
       return HloInstruction::FusionKind::kCustom;
     case HloFusionAnalysis::EmitterFusionKind::kConcatenate:
     case HloFusionAnalysis::EmitterFusionKind::kReduction:

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -67,6 +67,7 @@ cc_library(
         "GOOGLE_CUDA=1",
     ]),
     deps = [
+        ":cudnn_thunk",
         ":custom_call_thunk",
         ":nccl_all_gather_thunk",
         ":nccl_all_reduce_thunk",
@@ -733,4 +734,20 @@ cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:statusor",
     ],
+)
+
+cc_library(
+    name = "cudnn_thunk",
+    srcs = if_cuda_is_configured(["cudnn_thunk.cc"]),
+    hdrs = if_cuda_is_configured(["cudnn_thunk.h"]),
+    deps = if_cuda_is_configured([
+        "//xla:status",
+        "//xla/service/gpu:kernel_arguments",
+        "//xla/service/gpu:thunk",
+        "//xla/service:buffer_assignment",
+        "//xla/stream_executor",
+        "//xla/stream_executor:device_memory",
+        "@com_google_absl//absl/strings:string_view",
+        "@tsl//tsl/platform:logging",
+    ]),
 )

--- a/xla/service/gpu/runtime/cudnn_thunk.cc
+++ b/xla/service/gpu/runtime/cudnn_thunk.cc
@@ -1,0 +1,58 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/runtime/cudnn_thunk.h"
+
+#include "absl/status/status.h"
+
+namespace xla {
+namespace gpu {
+
+CuDnnThunk::CuDnnThunk(std::string serialized_graph, ThunkInfo thunk_info,
+                       absl::Span<const KernelArgument> kernel_arguments)
+    : Thunk(Kind::kCuDnn, std::move(thunk_info)),
+      serialized_graph_(std::move(serialized_graph)) {
+  args_.reserve(kernel_arguments.size());
+  for (const KernelArgument& kernel_argument : kernel_arguments) {
+    args_.push_back(kernel_argument.slice());
+  }
+}
+
+absl::Status CuDnnThunk::Initialize(const InitializeParams& params) {
+  absl::Status ret = absl::OkStatus();
+  absl::call_once(once_flag_, [&] {
+    auto result =
+        params.stream->parent()->AsDnn()->DeserializeGraph(serialized_graph_);
+    std::string().swap(serialized_graph_);
+    if (result.ok()) {
+      graph_ = std::move(*result);
+    }
+    ret = result.status();
+  });
+  return ret;
+}
+
+absl::Status CuDnnThunk::ExecuteOnStream(const ExecuteParams& params) {
+  std::vector<se::DeviceMemoryBase> buffer_args;
+  buffer_args.reserve(args_.size());
+  for (const BufferAllocation::Slice& arg : args_) {
+    buffer_args.push_back(params.buffer_allocations->GetDeviceAddress(arg));
+  }
+  return graph_->Execute(*params.stream,
+                         absl::Span<se::DeviceMemoryBase>(buffer_args));
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/runtime/cudnn_thunk.h
+++ b/xla/service/gpu/runtime/cudnn_thunk.h
@@ -1,0 +1,54 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_RUNTIME_CUDNN_THUNK_H_
+#define XLA_SERVICE_GPU_RUNTIME_CUDNN_THUNK_H_
+
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "xla/service/buffer_assignment.h"
+#include "xla/service/gpu/kernel_arguments.h"
+#include "xla/service/gpu/thunk.h"
+#include "xla/stream_executor/dnn.h"
+
+namespace xla {
+namespace gpu {
+
+// Wraps executable cuDNN graph objects.
+class CuDnnThunk : public Thunk {
+ public:
+  CuDnnThunk(std::string serialized_graph, ThunkInfo,
+             absl::Span<const KernelArgument>);
+  CuDnnThunk(const CuDnnThunk&) = delete;
+  CuDnnThunk& operator=(const CuDnnThunk&) = delete;
+  ~CuDnnThunk() override = default;
+
+  absl::Status Initialize(const InitializeParams&) override;
+  absl::Status ExecuteOnStream(const ExecuteParams&) override;
+
+ private:
+  absl::once_flag once_flag_;
+  std::string serialized_graph_;
+  std::unique_ptr<se::dnn::DnnGraph> graph_;
+  std::vector<BufferAllocation::Slice> args_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_RUNTIME_CUDNN_THUNK_H_

--- a/xla/service/gpu/thunk.cc
+++ b/xla/service/gpu/thunk.cc
@@ -252,6 +252,7 @@ Thunk::ExecuteParams::ExecuteParams(
     CASE(kWhile);
     CASE(kFusedMHA);
     CASE(kWaitForStreams);
+    CASE(kCuDnn);
   }
 }
 

--- a/xla/service/gpu/thunk.h
+++ b/xla/service/gpu/thunk.h
@@ -130,7 +130,8 @@ class Thunk {
     kTriangularSolve,
     kWhile,
     kFusedMHA,
-    kWaitForStreams
+    kWaitForStreams,
+    kCuDnn
   };
 
   // TODO(ezhulenev): This should become a part of StreamExecutor library, but

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -419,6 +419,7 @@ cuda_only_cc_library(
         ":cuda_executor",
         ":cuda_platform_id",
         ":cuda_stream",
+        ":cudnn_frontend_helpers",
         "//xla/stream_executor",
         "//xla/stream_executor:dnn",
         "//xla/stream_executor:plugin_registry",
@@ -651,4 +652,10 @@ cc_library(
             "//conditions:default": [],
         }),
     ),
+)
+
+cc_library(
+    name = "cudnn_frontend_helpers",
+    srcs = ["cudnn_frontend_helpers.cc"],
+    hdrs = ["cudnn_frontend_helpers.h"],
 )

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -52,6 +52,7 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_activation.h"
 #include "xla/stream_executor/cuda/cuda_diagnostics.h"
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
+#include "xla/stream_executor/cuda/cudnn_frontend_helpers.h"
 #include "xla/stream_executor/data_type.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/dnn.h"
@@ -10663,6 +10664,85 @@ bool CudnnSupport::DeriveOutputBatchDescriptor(
   return IsStatusOk(status, /*report_error=*/true);
 }
 
+// RAII wrapper for temporary cuDNN handles that are used for multithreaded
+// compilation. Unlike with CudnnAccess these are not associated
+// with GPU devices and are not locked.
+class LocalCuDnnHandle {
+ public:
+  explicit LocalCuDnnHandle(cudnnHandle_t handle) : handle_(handle) {}
+  ~LocalCuDnnHandle() { cudnnDestroy(handle_); }
+  cudnnHandle_t handle() { return handle_; }
+  static absl::StatusOr<std::unique_ptr<LocalCuDnnHandle>> create() {
+    cudnnHandle_t handle = nullptr;
+    if (cudnnCreate(&handle) != CUDNN_STATUS_SUCCESS) {
+      return absl::InternalError("Could not create cudnn handle");
+    }
+    return std::make_unique<LocalCuDnnHandle>(handle);
+  }
+
+ private:
+  cudnnHandle_t handle_;
+};
+
+#if CUDNN_VERSION >= 8100
+
+absl::StatusOr<std::unique_ptr<dnn::DnnGraph>> CudnnSupport::DeserializeGraph(
+    absl::string_view serialized_data) const {
+  TF_ASSIGN_OR_RETURN(auto cudnn, LocalCuDnnHandle::create());
+  cudnn_frontend::graph::Graph graph;
+  RETURN_IF_CUDNN_FRONTEND_ERROR(graph.deserialize(
+      cudnn->handle(),
+      std::vector<uint8_t>(serialized_data.data(),
+                           serialized_data.data() + serialized_data.size())));
+  return std::make_unique<CudnnGraph>(std::move(graph));
+}
+
+absl::StatusOr<bool> CudnnGraph::Prepare() {
+  TF_ASSIGN_OR_RETURN(auto cudnn, LocalCuDnnHandle::create());
+  RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.build_operation_graph(cudnn->handle()));
+  RETURN_IF_CUDNN_FRONTEND_ERROR(
+      graph_.create_execution_plans({cudnn_frontend::HeurMode_t::A}));
+  if (auto result = graph_.check_support(cudnn->handle()); result.is_bad()) {
+    VLOG(3) << result.get_message();
+    return false;
+  }
+  return true;
+}
+
+absl::Status CudnnGraph::Build(const int64_t plan_id) {
+  TF_ASSIGN_OR_RETURN(auto cudnn, LocalCuDnnHandle::create());
+  RETURN_IF_CUDNN_FRONTEND_ERROR(
+      graph_.build_plan_at_index(cudnn->handle(), plan_id));
+  return absl::OkStatus();
+}
+
+absl::Status CudnnGraph::Execute(Stream& stream,
+                                 absl::Span<DeviceMemoryBase> operands) const {
+  std::unordered_map<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>,
+                     void*>
+      tensor_to_ptr_map;
+  int operand_number = 0;
+  CHECK_EQ(graph_.get_workspace_size(), 0);
+  for (DeviceMemoryBase operand : operands) {
+    const cudnn_frontend::graph::Tensor_attributes attr =
+        cudnn_frontend::graph::Tensor_attributes().set_uid(
+            CuDnnTensorUID(operand_number));
+    ++operand_number;
+    tensor_to_ptr_map
+        [std::make_shared<cudnn_frontend::graph::Tensor_attributes>(attr)] =
+            operand.opaque();
+  }
+  const CudnnSupport& dnn_support =
+      static_cast<CudnnSupport&>(*stream.parent()->AsDnn());
+  RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.execute(
+      dnn_support.cudnn_
+          ->GetHandle(ExtractGpuExecutor(stream.parent()), &stream)
+          .handle(),
+      tensor_to_ptr_map, /*workspace=*/nullptr));
+  return absl::OkStatus();
+}
+
+#endif  // CUDNN_VERSION >= 8100
 }  // namespace gpu
 
 void initialize_cudnn() {

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -34,6 +34,11 @@ limitations under the License.
 #include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/numeric_options.h"
 #include "tsl/protobuf/dnn.pb.h"
+#include "third_party/gpus/cudnn/cudnn_version.h"
+
+#if CUDNN_VERSION >= 8100
+#include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#endif  // CUDNN_VERSION >= 8100
 
 namespace stream_executor {
 namespace gpu {
@@ -48,6 +53,24 @@ using BatchDescriptorSlice = absl::Span<const dnn::BatchDescriptor>;
 
 template <typename T>
 using DeviceMemorySlice = absl::Span<const DeviceMemory<T>* const>;
+
+#if CUDNN_VERSION >= 8100
+class CudnnGraph : public dnn::DnnGraph {
+ public:
+  explicit CudnnGraph(cudnn_frontend::graph::Graph&& graph)
+      : graph_(std::move(graph)) {}
+  // Prepares a graph and checks whether it is generally supported.
+  absl::StatusOr<bool> Prepare() override;
+  // Builds single plan of the graph with given ID.
+  absl::Status Build(int64_t plan_id) override;
+  absl::Status Execute(Stream& stream,
+                       absl::Span<DeviceMemoryBase> operands) const override;
+  const cudnn_frontend::graph::Graph& Graph() { return graph_; }
+
+ private:
+  cudnn_frontend::graph::Graph graph_;
+};
+#endif  // CUDNN_VERSION >= 8100
 
 // cudnn-library based DNN support. For details on overridden interface
 // functions, see dnn.h.
@@ -551,7 +574,16 @@ class CudnnSupport : public dnn::DnnSupport {
 
   void NotifyStreamDestroyed(Stream* stream) override;
 
+#if CUDNN_VERSION >= 8100
+  // Loads complete graph from its serialized representation.
+  absl::StatusOr<std::unique_ptr<dnn::DnnGraph>> DeserializeGraph(
+      absl::string_view serialized_data) const override;
+#endif  // CUDNN_VERSION >= 8100
+
  private:
+  // Uses cuDNN handle for execution.
+  friend class CudnnGraph;
+
   GpuExecutor* parent_;  // Parent executor object. Not owned.
 
   // Provides access to the cuDNN handle.

--- a/xla/stream_executor/cuda/cudnn_frontend_helpers.cc
+++ b/xla/stream_executor/cuda/cudnn_frontend_helpers.cc
@@ -1,0 +1,27 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/cuda/cudnn_frontend_helpers.h"
+
+namespace stream_executor {
+namespace gpu {
+
+int CuDnnTensorUID(int offset) {
+  constexpr int kFirstUid = 1;
+  return kFirstUid + offset;
+}
+
+}  // namespace gpu
+}  // namespace stream_executor

--- a/xla/stream_executor/cuda/cudnn_frontend_helpers.h
+++ b/xla/stream_executor/cuda/cudnn_frontend_helpers.h
@@ -1,0 +1,37 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_CUDA_CUDNN_FRONTEND_HELPERS_H_
+#define XLA_STREAM_EXECUTOR_CUDA_CUDNN_FRONTEND_HELPERS_H_
+
+namespace stream_executor {
+namespace gpu {
+
+#define RETURN_IF_CUDNN_FRONTEND_ERROR(expr)                                \
+  do {                                                                      \
+    if (ABSL_PREDICT_TRUE((expr).is_bad())) {                               \
+      std::ostringstream oss;                                               \
+      oss << (expr).get_message() << "\nin " << __FILE__ << "(" << __LINE__ \
+          << "): '" << #expr << "' ";                                       \
+      return absl::InternalError(oss.str());                                \
+    }                                                                       \
+  } while (false)
+
+int CuDnnTensorUID(int offset);
+
+}  // namespace gpu
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_CUDA_CUDNN_FRONTEND_HELPERS_H_


### PR DESCRIPTION
This adds a new fusion compilation and execution path with corresponding tests.
It will not trigger automatically yet, the mechanism constructing such fusions will be added in another commit.
Also capture of CUDA graphs and wider support of fusions will be added in further commits.
Functionality is intentionally limited to minimal testable for now to make reviewing easier.