### PR TITLE
GpuTimer: improve kernel execution time measurement accuracy

### DIFF
--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -609,7 +609,6 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
   // Use assignment instead of brace-list to make GCC 4.9 happy.
   RunConvOptions options;
   options.runner_cache = runner;
-  options.profile_result = &profile_result;
   // The following plan timing code is based on
   // https://github.com/NVIDIA/cudnn-frontend/blob/60496f42fdc7a4ccc059f5934e306e728a756755/include/cudnn_frontend_find_plan.h
   float max_time = 0;
@@ -622,15 +621,20 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
   // Dry-run to warmup the plan.
   launch_status = RunGpuConv(config, operand_buffers, result_buffers,
                              scratch_memory, stream, options);
+  // It is intentional that the warm-up run does not have a profile result.
+  // This avoids a timeout and error message if lazy module loading is enabled
+  // by ensuring that lazy loading happens outside the GpuTimer region.
+  options.profile_result = &profile_result;
   constexpr int kMaxIter = 10;
   // Iterate until the new measurement is within kThreshold of the current
   // minimum.
   int num_iters = 0;
-  for (;
-       num_iters < kMaxIter && launch_status.ok() && profile_result.is_valid();
-       num_iters++) {
+  for (; num_iters < kMaxIter && launch_status.ok(); ++num_iters) {
     launch_status = RunGpuConv(config, operand_buffers, result_buffers,
                                scratch_memory, stream, options);
+    if (!profile_result.is_valid()) {
+      break;
+    }
     float old_min_time = min_time;
     min_time = std::min(min_time, profile_result.elapsed_time_in_ms());
     max_time = std::max(max_time, profile_result.elapsed_time_in_ms());

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -236,6 +236,15 @@ class GemmAutotuner {
 
     auto tuned_func = [&](const se::blas::AlgorithmType& algorithm)
         -> absl::StatusOr<se::blas::ProfileResult> {
+      // Do a warm-up run first, without a profile result. This avoids a timeout
+      // and error message if lazy module loading is enabled by ensuring that
+      // lazy loading happens outside the GpuTimer. RunGemm swallows error codes
+      // when profile_result is passed, as it is in the measurement below, but
+      // not otherwise. It is, therefore, consistent to ignore the error code
+      // here.
+      static_cast<void>(RunGemm(gemm_config, lhs_buffer_, rhs_buffer_,
+                                output_buffer_, workspace_buffer,
+                                deterministic_ops_, stream_, algorithm));
       se::blas::ProfileResult profile_result;
       // We expect GemmWithAlgorithm to fail sometimes -- in fact, it will fail
       // for all algorithms if we're targeting < sm_50. But because we pass a
@@ -364,7 +373,7 @@ class GemmAutotuner {
                  << best.status();
     return AutotuneResult{};
   }  // GetBestAlgorithm
-};  // GemmAutotuner
+};   // GemmAutotuner
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -343,6 +343,7 @@ gpu_only_cc_library(
         ":gpu_driver_header",
         ":gpu_executor_header",
         ":gpu_stream",
+        ":gpu_timer_kernel",
         ":gpu_types_header",
         "//xla/stream_executor",
         "//xla/stream_executor:stream_executor_internal",
@@ -357,9 +358,7 @@ gpu_only_cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
-    ] + if_gpu_is_configured([
-        ":gpu_timer_kernel",
-    ]) + if_cuda_is_configured([
+    ] + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_driver",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:rocm_driver",

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -317,11 +317,18 @@ gpu_only_cc_library(
     ],
 )
 
+gpu_kernel_library(
+    name = "gpu_timer_kernel",
+    hdrs = ["gpu_timer_kernel.h"],
+    srcs = if_gpu_is_configured(["gpu_timer_kernel.cu.cc"]),
+)
+
 gpu_only_cc_library(
     name = "gpu_timer_header",
     hdrs = ["gpu_timer.h"],
     deps = [
         ":gpu_executor_header",
+        ":gpu_timer_kernel",
         ":gpu_types_header",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/time",
@@ -350,7 +357,9 @@ gpu_only_cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
-    ] + if_cuda_is_configured([
+    ] + if_gpu_is_configured([
+        ":gpu_timer_kernel",
+    ]) + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_driver",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:rocm_driver",

--- a/xla/stream_executor/gpu/gpu_timer.cc
+++ b/xla/stream_executor/gpu/gpu_timer.cc
@@ -51,10 +51,21 @@ absl::Duration RandomDuration() {
   return absl::Microseconds(distribution(rng));
 }
 
+bool ShouldLaunchDelayKernel() {
+  // Only launch the delay kernel if CUDA_LAUNCH_BLOCKING is not set to 1.
+  static bool value = [] {
+    const char* blocking = std::getenv("CUDA_LAUNCH_BLOCKING");
+    return !blocking || std::string_view{blocking} != "1";
+  }();
+  return value;
+}
+
 }  // namespace
 
 /*deprecated*/ /*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(
     GpuStream* stream) {
+  // This deprecated factory does not launch the delay kernel and may lead to
+  // reduced measurement accuracy.
   GpuExecutor* parent = stream->parent();
   GpuContext* context = parent->gpu_context();
   GpuEventHandle start_event;
@@ -72,6 +83,8 @@ absl::Duration RandomDuration() {
 
 /*deprecated*/ /*static*/ absl::StatusOr<std::optional<GpuTimer>>
 GpuTimer::CreateIfNeeded(GpuStream* stream, bool is_needed) {
+  // This deprecated factory does not launch the delay kernel and may lead to
+  // reduced measurement accuracy.
   if (is_needed) {
     TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream));
     return {std::make_optional(std::move(t))};
@@ -79,16 +92,78 @@ GpuTimer::CreateIfNeeded(GpuStream* stream, bool is_needed) {
   return std::nullopt;
 }
 
-[[deprecated("So it can quietly call a deprecated method")]] /*static*/ absl::
-    StatusOr<GpuTimer>
-    GpuTimer::Create(Stream* stream) {
-  return GpuTimer::Create(AsGpuStream(stream));
+/*static*/ absl::StatusOr<GpuTimer::GpuSemaphore>
+GpuTimer::GpuSemaphore::Create(StreamExecutor* executor) {
+  // Allocate the value in pinned host memory that can be read from both
+  // host and device.
+  TF_ASSIGN_OR_RETURN(auto alloc,
+                      executor->HostMemoryAllocate(sizeof(GpuSemaphoreState)));
+  return GpuSemaphore{std::move(alloc)};
 }
 
-[[deprecated("So it can quietly call a deprecated method")]] /*static*/ absl::
-    StatusOr<std::optional<GpuTimer>>
-    GpuTimer::CreateIfNeeded(Stream* stream, bool is_needed) {
-  return GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_needed);
+DeviceMemory<GpuSemaphoreState> GpuTimer::GpuSemaphore::device() {
+  // This assumes unified addressing, as we do not explicitly translate the
+  // host pointer into a device pointer.
+  return DeviceMemory<GpuSemaphoreState>::MakeFromByteSize(
+      ptr_->opaque(), sizeof(GpuSemaphoreState));
+}
+
+/*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(Stream* real_stream) {
+  StreamExecutor* executor = real_stream->parent();
+  GpuStream* stream = AsGpuStream(real_stream);
+  GpuExecutor* parent = stream->parent();
+  GpuContext* context = parent->gpu_context();
+  GpuEventHandle start_event;
+  TF_RETURN_IF_ERROR(GpuDriver::InitEvent(context, &start_event,
+                                          GpuDriver::EventFlags::kDefault));
+  GpuEventHandle stop_event;
+  TF_RETURN_IF_ERROR(GpuDriver::InitEvent(context, &stop_event,
+                                          GpuDriver::EventFlags::kDefault));
+  CHECK(start_event != nullptr && stop_event != nullptr);
+  GpuSemaphore semaphore{};
+  if (ShouldLaunchDelayKernel()) {
+    // Check the assumption that this device supports unified addressing,
+    // otherwise skip the delay kernel
+    TF_ASSIGN_OR_RETURN(int status, GpuDriver::GetDeviceAttribute(
+                                        CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING,
+                                        parent->device()));
+    if (!status) {
+      LOG(WARNING) << "Skipping the delay kernel because the device does not "
+                      "support unified addressing";
+    } else {
+      // Allocate a semaphore value that will be used to signal to the delay
+      // kernel that it may exit.
+      TF_ASSIGN_OR_RETURN(semaphore, GpuSemaphore::Create(executor));
+      *semaphore = GpuSemaphoreState::Hold;
+      // In principle the kernel could be loaded lazily and shared across
+      // multiple GpuTimer objects.
+      TF_ASSIGN_OR_RETURN(
+          auto kernel,
+          (TypedKernel<DeviceMemory<GpuSemaphoreState>,
+                       GpuSemaphoreState>::Create(executor, "DelayKernel",
+                                                  delay_kernel::kernel())));
+      // Launch a delay kernel into this stream, which will spin until
+      // GetElapsedDuration() is called, the timer is destroyed, or the timeout
+      // in the kernel is reached.
+      TF_RETURN_IF_ERROR(real_stream->ThenLaunch(
+          ThreadDim(1, 1, 1), BlockDim(1, 1, 1), kernel, semaphore.device(),
+          GpuSemaphoreState::Release));
+    }
+  }
+  // The start event goes after the delay kernel in the stream
+  TF_RETURN_IF_ERROR(GpuDriver::RecordEvent(parent->gpu_context(), start_event,
+                                            stream->gpu_stream()));
+  return absl::StatusOr<GpuTimer>{absl::in_place, parent, start_event,
+                                  stop_event,     stream, std::move(semaphore)};
+}
+
+/*static*/ absl::StatusOr<std::optional<GpuTimer>> GpuTimer::CreateIfNeeded(
+    Stream* stream, bool is_needed) {
+  if (is_needed) {
+    TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream));
+    return {std::make_optional(std::move(t))};
+  }
+  return std::nullopt;
 }
 
 /*static*/ void GpuTimer::ReturnRandomDurationsForTesting() {
@@ -97,6 +172,17 @@ GpuTimer::CreateIfNeeded(GpuStream* stream, bool is_needed) {
 
 GpuTimer::~GpuTimer() {
   GpuContext* context = parent_->gpu_context();
+  if (semaphore_ && !is_stopped_) {
+    // Signal the delay kernel that it can exit
+    *semaphore_ = GpuSemaphoreState::Release;
+    // Wait for the delay kernel to exit before destroying the value that it is
+    // watching.
+    absl::Status status =
+        GpuDriver::SynchronizeStream(context, stream_->gpu_stream());
+    if (!status.ok()) {
+      LOG(ERROR) << status;
+    }
+  }
   if (start_event_ != nullptr) {
     absl::Status status = GpuDriver::DestroyEvent(context, &start_event_);
     if (!status.ok()) {
@@ -117,6 +203,18 @@ absl::StatusOr<absl::Duration> GpuTimer::GetElapsedDuration() {
   }
   TF_RETURN_IF_ERROR(GpuDriver::RecordEvent(parent_->gpu_context(), stop_event_,
                                             stream_->gpu_stream()));
+  // If we launched the delay kernel then check if it already timed out.
+  if (semaphore_) {
+    if (*semaphore_ == GpuSemaphoreState::TimedOut) {
+      // The delay kernel did not achieve the intended result.
+      LOG(ERROR) << "Delay kernel timed out: measured time has sub-optimal "
+                    "accuracy. There may be a missing warmup execution, please "
+                    "investigate in Nsight Systems.";
+    } else {
+      // Signal that the kernel can exit
+      *semaphore_ = GpuSemaphoreState::Release;
+    }
+  }
   float elapsed_milliseconds = NAN;
   if (!GpuDriver::GetEventElapsedTime(parent_->gpu_context(),
                                       &elapsed_milliseconds, start_event_,

--- a/xla/stream_executor/gpu/gpu_timer.h
+++ b/xla/stream_executor/gpu/gpu_timer.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "xla/stream_executor/gpu/gpu_executor.h"
+#include "xla/stream_executor/gpu/gpu_timer_kernel.h"
 #include "xla/stream_executor/gpu/gpu_types.h"
 
 namespace xla {
@@ -36,9 +37,29 @@ namespace gpu {
 class GpuExecutor;
 class GpuStream;
 
-// Timer is started once it's created, and is stopped once read.
+// When a timer is created it launches a delay kernel into the given stream and
+// queues a start event immediately afterwards. This delay kernel blocks
+// execution on the stream until GetElapsedDuration() is called, at which point
+// an end event is queued and the delay kernel exits. This allows the device
+// execution time of the tasks queued to the stream while the timer is active
+// to be measured more accurately.
 class GpuTimer {
  public:
+  class GpuSemaphore {
+   public:
+    GpuSemaphore() = default;
+    static absl::StatusOr<GpuSemaphore> Create(StreamExecutor* executor);
+    explicit operator bool() const { return bool{ptr_}; }
+    GpuSemaphoreState& operator*() {
+      return *static_cast<GpuSemaphoreState*>(ptr_->opaque());
+    }
+    DeviceMemory<GpuSemaphoreState> device();
+
+   private:
+    GpuSemaphore(std::unique_ptr<HostMemoryAllocation> alloc)
+        : ptr_{std::move(alloc)} {}
+    std::unique_ptr<HostMemoryAllocation> ptr_;
+  };
   static absl::StatusOr<GpuTimer> Create(Stream* stream);
   [[deprecated("Pass Stream* not GpuStream*")]] static absl::StatusOr<GpuTimer>
   Create(GpuStream* stream);
@@ -53,17 +74,20 @@ class GpuTimer {
   CreateIfNeeded(GpuStream* stream, bool is_needed);
 
   explicit GpuTimer(GpuExecutor* parent, GpuEventHandle start_event,
-                    GpuEventHandle stop_event, GpuStream* stream)
+                    GpuEventHandle stop_event, GpuStream* stream,
+                    GpuSemaphore semaphore = {})
       : parent_(parent),
         start_event_(start_event),
         stop_event_(stop_event),
-        stream_(stream) {}
+        stream_(stream),
+        semaphore_(std::move(semaphore)) {}
 
   GpuTimer(GpuTimer&& other)
       : parent_(other.parent_),
         start_event_(std::exchange(other.start_event_, nullptr)),
         stop_event_(std::exchange(other.stop_event_, nullptr)),
-        stream_(other.stream_) {}
+        stream_(other.stream_),
+        semaphore_(std::move(other.semaphore_)) {}
 
   GpuTimer& operator=(GpuTimer&& other) {
     if (this != &other) {
@@ -71,6 +95,7 @@ class GpuTimer {
       start_event_ = std::exchange(other.start_event_, nullptr);
       stop_event_ = std::exchange(other.stop_event_, nullptr);
       stream_ = other.stream_;
+      semaphore_ = std::move(other.semaphore_);
     }
     return *this;
   }
@@ -86,6 +111,7 @@ class GpuTimer {
   GpuEventHandle start_event_ = nullptr;
   GpuEventHandle stop_event_ = nullptr;
   GpuStream* stream_;
+  GpuSemaphore semaphore_;
   bool is_stopped_ = false;
 
   GpuTimer(const GpuTimer&) = delete;

--- a/xla/stream_executor/gpu/gpu_timer_kernel.cu.cc
+++ b/xla/stream_executor/gpu/gpu_timer_kernel.cu.cc
@@ -1,0 +1,52 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "xla/stream_executor/gpu/gpu_timer_kernel.h"
+
+#include <cstddef>
+
+namespace stream_executor::gpu {
+namespace {
+// Wait for the value pointed to by `semaphore` to have value `target`, timing
+// out after approximately `APPROX_TIMEOUT_SECONDS` seconds if that value is
+// not reached. This can happen if, for example, blocking launches are enabled
+// via CUDA_LAUNCH_BLOCKING=1. It can also happen if launching a kernel after
+// this delay kernel causes synchronisation, e.g. because of lazy loading.
+__global__ void DelayKernel(volatile GpuSemaphoreState* semaphore,
+                            GpuSemaphoreState target) {
+  constexpr int64_t WAIT_CYCLES{1024};
+  constexpr int64_t TIMEOUT_CYCLES{200000000};  // 100ms at 2GHz
+  const int64_t tstart{clock64()};
+  bool target_not_reached;
+  while ((target_not_reached = (*semaphore != target)) &&
+         (clock64() - tstart) < TIMEOUT_CYCLES) {
+    int64_t elapsed{};
+    const int64_t t0{clock64()};
+    do {
+      elapsed = clock64() - t0;
+    } while (elapsed < WAIT_CYCLES);
+  }
+  if (target_not_reached) {
+    // We are exiting due to the timeout. Signal this back to the host so that
+    // we can emit a warning, as it probably indicates suboptimal usage.
+    *semaphore = GpuSemaphoreState::TimedOut;
+  }
+}
+}  // namespace
+
+namespace delay_kernel {
+void* kernel() { return reinterpret_cast<void*>(DelayKernel); }
+}  // namespace delay_kernel
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/gpu/gpu_timer_kernel.h
+++ b/xla/stream_executor/gpu/gpu_timer_kernel.h
@@ -23,4 +23,4 @@ void* kernel();  // returns a pointer to a CUDA C++ device function
 }  // namespace delay_kernel
 }  // namespace stream_executor::gpu
 
-#endif
+#endif  // XLA_STREAM_EXECUTOR_GPU_GPU_TIMER_KERNEL_H_

--- a/xla/stream_executor/gpu/gpu_timer_kernel.h
+++ b/xla/stream_executor/gpu/gpu_timer_kernel.h
@@ -1,0 +1,26 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_GPU_GPU_TIMER_KERNEL_H_
+#define XLA_STREAM_EXECUTOR_GPU_GPU_TIMER_KERNEL_H_
+
+namespace stream_executor::gpu {
+enum struct GpuSemaphoreState { Hold, Release, TimedOut };
+namespace delay_kernel {
+void* kernel();  // returns a pointer to a CUDA C++ device function
+}  // namespace delay_kernel
+}  // namespace stream_executor::gpu
+
+#endif


### PR DESCRIPTION
This PR changes how `GpuTimer` measures execution time, which should improve the measurement accuracy.
Quoting my comment in the code:
```c++
// When a timer is created it launches a delay kernel into the given stream and
// queues a start event immediately afterwards. This delay kernel blocks
// execution on the stream until GetElapsedDuration() is called, at which point
// an end event is queued and the delay kernel exits. This allows the device
// execution time of the tasks queued to the stream while the timer is active
// to be measured more accurately.
```
this should improve the accuracy of the measurements that are used to make auto-tuning decisions, especially for small kernels.

There are a couple of edge cases that have special treatment:
- if `CUDA_LAUNCH_BLOCKING=1` then the delay kernel will not achieve anything, so we don't launch it
- if any code in the timed region synchronises the device then the host will wait for the delay kernel to time out before actually launching the kernels to be measured. This will lead to a poor quality measurement, and an error message is printed. This condition can be met if one of the kernels being measured is lazily loaded, as lazy loading can trigger synchronisation. Best practice is to execute a warmup run (without timing enabled) before the timed execution.

Two parts of the autotuning code are updated to follow this best practice.

The `GpuTimer::Create*` signatures that were deprecated in https://github.com/openxla/xla/pull/9841 do not benefit from these accuracy improvements.

cc: @sergachev @nouiz 