### PR TITLE
GpuTimer: take Stream not GpuStream

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -424,9 +424,8 @@ absl::Status ExecuteThunks(
   if (ExecutionProfile* profile =
           run_options->run_options().execution_profile();
       profile) {
-    TF_ASSIGN_OR_RETURN(
-        execution_timer,
-        se::gpu::GpuTimer::Create(se::gpu::AsGpuStream(main_stream)));
+    TF_ASSIGN_OR_RETURN(execution_timer,
+                        se::gpu::GpuTimer::Create(main_stream));
   }
 #endif
 

--- a/xla/service/gpu/kernels/topk_kernel_test.cc
+++ b/xla/service/gpu/kernels/topk_kernel_test.cc
@@ -212,7 +212,7 @@ void BM_SmallTopk(benchmark::State& state) {
   }
 
   for (auto _ : state) {
-    auto timer = se::gpu::GpuTimer::Create(se::gpu::AsGpuStream(&stream));
+    auto timer = se::gpu::GpuTimer::Create(&stream);
     CHECK_OK(timer.status());
     CHECK_OK(RunTopk(&stream, Get(T()), *input_buffer, n, *output_values,
                      *output_indices, k, batch_size));

--- a/xla/stream_executor/cuda/cuda_blas.cc
+++ b/xla/stream_executor/cuda/cuda_blas.cc
@@ -750,8 +750,7 @@ absl::Status CUDABlas::DoBlasGemmWithAlgorithm(
 
   TF_ASSIGN_OR_RETURN(
       std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream),
-                               output_profile_result != nullptr));
+      GpuTimer::CreateIfNeeded(stream, output_profile_result != nullptr));
 
   // Since we are converting 'algorithm' to cublasGemmAlgo_t by static_cast,
   // we do the following compile-time check on the default value:
@@ -783,8 +782,7 @@ absl::Status CUDABlas::DoBlasGemmStridedBatchedWithAlgorithm(
       GetMathTypeForGemmEx(stream, algorithm, type_a, type_b, numeric_options));
   TF_ASSIGN_OR_RETURN(
       std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream),
-                               output_profile_result != nullptr));
+      GpuTimer::CreateIfNeeded(stream, output_profile_result != nullptr));
   cudaDataType_t cuda_in_type = AsCudaDataType(type_a);
 
 #if CUDA_VERSION >= 11000

--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -387,9 +387,8 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
     DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
     blas::ProfileResult* profile_result) const {
-  TF_ASSIGN_OR_RETURN(
-      std::optional<gpu::GpuTimer> timer,
-      gpu::GpuTimer::CreateIfNeeded(gpu::AsGpuStream(stream), profile_result));
+  TF_ASSIGN_OR_RETURN(std::optional<gpu::GpuTimer> timer,
+                      gpu::GpuTimer::CreateIfNeeded(stream, profile_result));
 
   void* workspace = nullptr;
   if (algorithm.workspace_size > 0) {

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -2294,9 +2294,8 @@ absl::Status CudnnSupport::DoRnnForwardImpl(
       reserve_space_allocator, is_training, &workspace, &reserve_space));
 
   const bool is_profiling = output_profile_result != nullptr;
-  TF_ASSIGN_OR_RETURN(
-      std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_profiling));
+  TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
+                      GpuTimer::CreateIfNeeded(stream, is_profiling));
 
   if (input_desc.is_var_seq_lengths()) {
     // In CUDNN v8, the cudnnRNNForward*** and cudnnRNNForward***Ex have been
@@ -2445,9 +2444,8 @@ absl::Status CudnnSupport::DoRnnBackwardImpl(
                                         nullptr, true, &workspace, nullptr));
 
   const bool is_profiling = output_profile_result != nullptr;
-  TF_ASSIGN_OR_RETURN(
-      std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_profiling));
+  TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
+                      GpuTimer::CreateIfNeeded(stream, is_profiling));
 
   if (input_desc.is_var_seq_lengths()) {
     // In CUDNN v8, the cudnnRNNBackward*** and cudnnRNNBackward***Ex have
@@ -7791,9 +7789,8 @@ class CudnnLegacyConvRunner : public dnn::ConvRunner {
                      : static_cast<void*>(&fbeta);
 
     const bool is_profiling = profile_result != nullptr;
-    TF_ASSIGN_OR_RETURN(
-        std::optional<GpuTimer> timer,
-        GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_profiling));
+    TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
+                        GpuTimer::CreateIfNeeded(stream, is_profiling));
 
     const auto get_fwd_bugs = [&]() -> absl::Status {
 #if CUDNN_VERSION < 8000
@@ -8270,9 +8267,8 @@ class CudnnExecutionPlanRunner<void(Args...)>
             << "\nVariantPack: " << variantPack.describe();
 
     const bool is_profiling = profile_result != nullptr;
-    TF_ASSIGN_OR_RETURN(
-        std::optional<GpuTimer> timer,
-        GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_profiling));
+    TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
+                        GpuTimer::CreateIfNeeded(stream, is_profiling));
 
     if (sizeof...(Args) == 15) {
       // is training
@@ -8787,9 +8783,9 @@ class CudnnLegacyFusedConvRunner : public dnn::FusedConvRunner {
 
     auto algo = MakeAlgorithmDesc();
 
-    TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
-                        GpuTimer::CreateIfNeeded(AsGpuStream(stream),
-                                                 profile_result != nullptr));
+    TF_ASSIGN_OR_RETURN(
+        std::optional<GpuTimer> timer,
+        GpuTimer::CreateIfNeeded(stream, profile_result != nullptr));
     auto side_input_data_ptr = (side_input_scale_ == 0)
                                    ? output_data.opaque()
                                    : side_input_data.opaque();

--- a/xla/stream_executor/gpu/gpu_timer.cc
+++ b/xla/stream_executor/gpu/gpu_timer.cc
@@ -53,7 +53,8 @@ absl::Duration RandomDuration() {
 
 }  // namespace
 
-/*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(GpuStream* stream) {
+/*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(Stream* real_stream) {
+  GpuStream* stream = AsGpuStream(real_stream);
   GpuExecutor* parent = stream->parent();
   GpuContext* context = parent->gpu_context();
   GpuEventHandle start_event;
@@ -70,7 +71,7 @@ absl::Duration RandomDuration() {
 }
 
 /*static*/ absl::StatusOr<std::optional<GpuTimer>> GpuTimer::CreateIfNeeded(
-    GpuStream* stream, bool is_needed) {
+    Stream* stream, bool is_needed) {
   if (is_needed) {
     TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream));
     return {std::make_optional(std::move(t))};

--- a/xla/stream_executor/gpu/gpu_timer.cc
+++ b/xla/stream_executor/gpu/gpu_timer.cc
@@ -53,8 +53,8 @@ absl::Duration RandomDuration() {
 
 }  // namespace
 
-/*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(Stream* real_stream) {
-  GpuStream* stream = AsGpuStream(real_stream);
+/*deprecated*/ /*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(
+    GpuStream* stream) {
   GpuExecutor* parent = stream->parent();
   GpuContext* context = parent->gpu_context();
   GpuEventHandle start_event;
@@ -70,13 +70,25 @@ absl::Duration RandomDuration() {
                                   stop_event, stream};
 }
 
-/*static*/ absl::StatusOr<std::optional<GpuTimer>> GpuTimer::CreateIfNeeded(
-    Stream* stream, bool is_needed) {
+/*deprecated*/ /*static*/ absl::StatusOr<std::optional<GpuTimer>>
+GpuTimer::CreateIfNeeded(GpuStream* stream, bool is_needed) {
   if (is_needed) {
     TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream));
     return {std::make_optional(std::move(t))};
   }
   return std::nullopt;
+}
+
+[[deprecated("So it can quietly call a deprecated method")]] /*static*/ absl::
+    StatusOr<GpuTimer>
+    GpuTimer::Create(Stream* stream) {
+  return GpuTimer::Create(AsGpuStream(stream));
+}
+
+[[deprecated("So it can quietly call a deprecated method")]] /*static*/ absl::
+    StatusOr<std::optional<GpuTimer>>
+    GpuTimer::CreateIfNeeded(Stream* stream, bool is_needed) {
+  return GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_needed);
 }
 
 /*static*/ void GpuTimer::ReturnRandomDurationsForTesting() {

--- a/xla/stream_executor/gpu/gpu_timer.h
+++ b/xla/stream_executor/gpu/gpu_timer.h
@@ -40,12 +40,17 @@ class GpuStream;
 class GpuTimer {
  public:
   static absl::StatusOr<GpuTimer> Create(Stream* stream);
+  [[deprecated("Pass Stream* not GpuStream*")]] static absl::StatusOr<GpuTimer>
+  Create(GpuStream* stream);
 
   // An ugly but a very convenient helper: creates a timer only when we need
   // one, but always returns an object. If `is_needed` is false, returns an
   // empty optional, acts like `Create` otherwise.
   static absl::StatusOr<std::optional<GpuTimer>> CreateIfNeeded(Stream* stream,
                                                                 bool is_needed);
+  [[deprecated("Pass Stream* not GpuStream*")]] static absl::StatusOr<
+      std::optional<GpuTimer>>
+  CreateIfNeeded(GpuStream* stream, bool is_needed);
 
   explicit GpuTimer(GpuExecutor* parent, GpuEventHandle start_event,
                     GpuEventHandle stop_event, GpuStream* stream)

--- a/xla/stream_executor/gpu/gpu_timer.h
+++ b/xla/stream_executor/gpu/gpu_timer.h
@@ -39,13 +39,13 @@ class GpuStream;
 // Timer is started once it's created, and is stopped once read.
 class GpuTimer {
  public:
-  static absl::StatusOr<GpuTimer> Create(GpuStream* stream);
+  static absl::StatusOr<GpuTimer> Create(Stream* stream);
 
   // An ugly but a very convenient helper: creates a timer only when we need
   // one, but always returns an object. If `is_needed` is false, returns an
   // empty optional, acts like `Create` otherwise.
-  static absl::StatusOr<std::optional<GpuTimer>> CreateIfNeeded(
-      GpuStream* stream, bool is_needed);
+  static absl::StatusOr<std::optional<GpuTimer>> CreateIfNeeded(Stream* stream,
+                                                                bool is_needed);
 
   explicit GpuTimer(GpuExecutor* parent, GpuEventHandle start_event,
                     GpuEventHandle stop_event, GpuStream* stream)

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -365,9 +365,8 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
     DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
     blas::ProfileResult* profile_result) const {
-  TF_ASSIGN_OR_RETURN(
-      std::optional<gpu::GpuTimer> timer,
-      gpu::GpuTimer::CreateIfNeeded(gpu::AsGpuStream(stream), profile_result));
+  TF_ASSIGN_OR_RETURN(std::optional<gpu::GpuTimer> timer,
+                      gpu::GpuTimer::CreateIfNeeded(stream, profile_result));
 
   void* workspace = nullptr;
   if (algorithm.workspace_size > 0) {

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -530,8 +530,7 @@ absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
         static_cast<int>(type_a), static_cast<int>(type_b)));
   }
   TF_ASSIGN_OR_RETURN(
-      auto timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream), profile_result != nullptr));
+      auto timer, GpuTimer::CreateIfNeeded(stream, profile_result != nullptr));
 
   // fall back to the default implementation
   if (algorithm == blas::kDefaultAlgorithm && type_a == type_c) {
@@ -587,8 +586,7 @@ absl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
         static_cast<int>(type_a), static_cast<int>(type_b)));
   }
   TF_ASSIGN_OR_RETURN(
-      auto timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream), profile_result != nullptr));
+      auto timer, GpuTimer::CreateIfNeeded(stream, profile_result != nullptr));
 
   // fall back to the default implementation
   if (algorithm == blas::kDefaultAlgorithm && type_a == type_c) {

--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -2379,9 +2379,8 @@ absl::Status MIOpenSupport::DoRnnForwardImpl(
 
   const bool is_profiling = output_profile_result != nullptr;
 
-  TF_ASSIGN_OR_RETURN(
-      std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_profiling));
+  TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
+                      GpuTimer::CreateIfNeeded(stream, is_profiling));
 
   // make the forward call
   if (!is_training) {
@@ -2508,9 +2507,8 @@ absl::Status MIOpenSupport::DoRnnBackwardImpl(
 
   const bool is_profiling = output_profile_result != nullptr;
 
-  TF_ASSIGN_OR_RETURN(
-      std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_profiling));
+  TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
+                      GpuTimer::CreateIfNeeded(stream, is_profiling));
 
   // make the backward data call
   auto status = wrap::miopenRNNBackwardData(
@@ -3202,9 +3200,8 @@ class RocmConvRunner : public dnn::ConvRunner {
     float beta = 0.0;
 
     const bool is_profiling = profile_result != nullptr;
-    TF_ASSIGN_OR_RETURN(
-        std::optional<GpuTimer> timer,
-        GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_profiling));
+    TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
+                        GpuTimer::CreateIfNeeded(stream, is_profiling));
 
     miopenStatus_t status = miopenStatusSuccess;
     switch (kind_) {


### PR DESCRIPTION
This is split out from https://github.com/openxla/xla/pull/9757 on request from @cheshire.

It deprecates the `GpuTimer::Create*` factory functions that take `GpuStream*` and adds new alternatives that take `Stream*`. All call sites were converting `Stream*` to `GpuStream*` anyway, so updating them to use the non-deprecated factories is trivial.

This allows the other changes in https://github.com/openxla/xla/pull/9757 to take advantage of some higher-level helpers (`CreateTypedKernel`, `ThenLaunch`) in the implementation of `GpuTimer`.