### PR TITLE
[GPU] Add flag to enable/disable per-stream NCCL communicators

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -144,6 +144,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_shared_constants(true);
   opts.set_xla_gpu_enable_nccl_user_buffers(false);
   opts.set_xla_gpu_enable_nccl_comm_splitting(false);
+  opts.set_xla_gpu_enable_nccl_per_stream_comms(true);
 
   // Set 4GB space limit for redzone scratch allocator.
   opts.set_xla_gpu_redzone_scratch_max_megabytes(1LL << 12);
@@ -1192,6 +1193,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_enable_nccl_comm_splitting(),
       "Enables NCCL communicator splitting which allows sharing NCCL resources "
       "between different NCCL cliques."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_nccl_per_stream_comms",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_nccl_per_stream_comms),
+      debug_options->xla_gpu_enable_nccl_per_stream_comms(),
+      "A separate NCCL communicator will be created for each stream that a "
+      "NCCL collective is executed on. This can lead to higher performance if "
+      "NCCL collectives are issued concurrently at the cost of more GPU memory"
+      " usage."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_redzone_scratch_max_megabytes",
       int64_setter_for(

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -679,6 +679,9 @@ message DebugOptions {
   // Enable NCCL communicator splitting.
   bool xla_gpu_enable_nccl_comm_splitting = 272;
 
+  // Enable NCCL per stream communicators.
+  bool xla_gpu_enable_nccl_per_stream_comms = 276;
+
   // If enabled, uses the libnvptxcompiler library to compile PTX to cuBIN.
   bool xla_gpu_enable_libnvptxcompiler = 269;
 
@@ -697,7 +700,7 @@ message DebugOptions {
 
   bool xla_gpu_enable_mlir_emitters = 275;
 
-  // Next id: 276
+  // Next id: 277
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR adds a flag `--xla_gpu_enable_nccl_per_stream_comms` to allow us to disable per-stream communicators (it is enabled by default to retain current behavior).
Per-stream communicators can increase performance ~~if NCCL collectives are scheduled in parallel~~ by avoiding synchronization between streams. However, it costs a lot of GPU memory to create the extra communicators, and [using multiple communicators simultaneously can lead to hangs](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#using-multiple-nccl-communicators-concurrently).

Because of these drawbacks, we would like to add this flag to disable the feature in certain cases.

## Results with Pax GPT5B-PP on 2xH100 (NVLS enabled)

| enable_nccl_per_stream_comms | # Comms Created | Total Memory (MiB) | NCCL Memory (MiB) | Steps/sec |
| --- | --- |  --- |  --- |  --- |
| true (default, existing behavior) | 13 | 78366 | 21022 | 0.1254 |
| false (new with this PR) | 8 | 71830 | 14486 | 0.1285 |

In this case by disabling per-stream comms the memory used by NCCL decreased by 31% and the steps/sec actually increased by 2.47%.





















