### PR TITLE
Draft: [XLA] Control printing of a large GPU backend config field with a flag.

### DIFF
--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -2515,6 +2515,10 @@ class HloInstruction {
 
     const std::string& GetRawString() const;
 
+    // Returns string-formatted proto with a large GPU-specific field removed
+    // if the field is not empty.
+    std::optional<std::string> GetFilteredRawString() const;
+
     BackendConfigRep Clone() const;
 
     bool operator==(const BackendConfigRep& other) const;


### PR DESCRIPTION
In the GPU backend cuDNN graphs can be attached in serialized form to HLO fusion instructions. Printing them by default is not informative and not necessary. In this regard they are similar to large constants, therefore the corresponding flag is reused.

The removal is implemented through protobuf reflection to avoid the dependency of the IR class on the backend-specific GPU proto.