### PR TITLE
Opaque types for NVTX domain and string handles

### DIFF
--- a/third_party/tsl/tsl/profiler/lib/BUILD
+++ b/third_party/tsl/tsl/profiler/lib/BUILD
@@ -270,14 +270,9 @@ cc_library(
 cc_library(
     name = "nvtx_utils",
     hdrs = ["nvtx_utils.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    srcs = if_cuda_is_configured(["nvtx_utils.cc"], ["nvtx_utils_stub.cc"]),
     visibility = ["//visibility:public"],
-    deps = [
-        "//tsl/platform:logging",
-        "//tsl/platform:macros",
-        "//tsl/platform:types",
-        "@com_google_absl//absl/strings",
-    ] + if_cuda_is_configured(nvtx_headers()),
+    deps = if_cuda_is_configured(nvtx_headers()),
 )
 
 cc_library(

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
@@ -1,0 +1,80 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tsl/profiler/lib/nvtx_utils.h"
+
+#include <type_traits>
+
+#include "nvtx3/nvToolsExt.h"
+#include "nvtx3/nvToolsExtPayload.h"
+
+namespace tsl::profiler {
+static_assert(std::is_pointer_v<nvtxDomainHandle_t>);
+static_assert(std::is_pointer_v<nvtxStringHandle_t>);
+
+ProfilerDomainHandle DefaultProfilerDomain() {
+  static ProfilerDomainHandle domain =
+      reinterpret_cast<ProfilerDomainHandle>(nvtxDomainCreateA("TSL"));
+  return domain;
+}
+
+void RangePop(ProfilerDomainHandle domain) {
+  nvtxDomainRangePop(reinterpret_cast<nvtxDomainHandle_t>(domain));
+}
+
+void RangePush(ProfilerDomainHandle domain, const char* ascii) {
+  nvtxEventAttributes_t attrs{};
+  attrs.version = NVTX_VERSION;
+  attrs.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  attrs.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  attrs.message.ascii = ascii;
+  nvtxDomainRangePushEx(reinterpret_cast<nvtxDomainHandle_t>(domain), &attrs);
+}
+
+namespace detail {
+void RangePush(ProfilerDomainHandle domain, StringHandle title,
+               uint64_t schema_id, const void* payload, size_t payload_size) {
+  nvtxEventAttributes_t attrs{};
+  attrs.version = NVTX_VERSION;
+  attrs.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  attrs.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
+  attrs.message.registered = reinterpret_cast<nvtxStringHandle_t>(title);
+  NVTX_PAYLOAD_EVTATTR_SET(attrs, schema_id, payload, payload_size);
+  nvtxDomainRangePushEx(reinterpret_cast<nvtxDomainHandle_t>(domain), &attrs);
+}
+}  // namespace detail
+
+uint64_t RegisterSchema(ProfilerDomainHandle domain, const void* schemaAttr) {
+  return nvtxPayloadSchemaRegister(
+      reinterpret_cast<nvtxDomainHandle_t>(domain),
+      static_cast<const nvtxPayloadSchemaAttr_t*>(schemaAttr));
+}
+
+StringHandle RegisterString(ProfilerDomainHandle domain,
+                            const std::string& str) {
+  const auto impl = [domain](const char* c_str) {
+    return reinterpret_cast<StringHandle>(nvtxDomainRegisterStringA(
+        reinterpret_cast<nvtxDomainHandle_t>(domain), c_str));
+  };
+  constexpr auto max_length = 65330;
+  if (str.size() <= max_length) {
+    return impl(str.c_str());
+  }
+  // nvbugs 4340868
+  std::string_view suffix{"\n[truncated]\n"};
+  std::string buffer(str.data(), max_length - suffix.size());
+  buffer.append(suffix);
+  return impl(buffer.c_str());
+}
+}  // namespace tsl::profiler

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
@@ -16,73 +16,51 @@ limitations under the License.
 #ifndef TENSORFLOW_TSL_PROFILER_LIB_NVTX_UTILS_H_
 #define TENSORFLOW_TSL_PROFILER_LIB_NVTX_UTILS_H_
 
-#include <optional>
 #include <string>
 
-#if GOOGLE_CUDA
-#include "nvtx3/nvToolsExt.h"
-#include "nvtx3/nvToolsExtPayload.h"
-#else
-// Some typedef to help build without NVTX.
-typedef void* nvtxDomainHandle_t;
-typedef void* nvtxStringHandle_t;
-#endif
+namespace tsl::profiler {
+struct String;
+// Opaque handle to a string that has been pre-registered with the profiler/NVTX
+// implementation
+using StringHandle = String*;
 
-namespace tsl {
-namespace profiler {
+struct ProfilerDomain;
+// Opaque handle to a domain in the profiler/NVTX implementation
+using ProfilerDomainHandle = ProfilerDomain*;
 
-// A helper function that return the domains to use if NVTX profiling
-// is enabled.
-inline std::optional<nvtxDomainHandle_t> GetNVTXDomain() {
-#if GOOGLE_CUDA
-  static nvtxDomainHandle_t domain = nvtxDomainCreateA("TSL");
-  if (domain != nullptr) return domain;
-#endif
-  return std::nullopt;
-}
+// Get the "TSL" domain if NVTX profiling is enabled, otherwise null
+ProfilerDomainHandle DefaultProfilerDomain();
 
-// A helper function to decide whether to enable CUDA NVTX profiling ranges.
-inline bool RangesEnabled() {
-#if GOOGLE_CUDA
-  return GetNVTXDomain().has_value();
-#else
-  return false;
-#endif
-}
+// Register a string with the profiler/NVTX implementation for faster use
+StringHandle RegisterString(ProfilerDomainHandle, const std::string&);
+
+// End a range that was created on this thread by RangePush
+void RangePop(ProfilerDomainHandle);
 
 // Older/simpler version; NVTX implementation copies a C-style string each time
-inline void RangePush(nvtxDomainHandle_t domain, const char* ascii) {
-#if GOOGLE_CUDA
-  nvtxEventAttributes_t attrs{};
-  attrs.version = NVTX_VERSION;
-  attrs.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-  attrs.messageType = NVTX_MESSAGE_TYPE_ASCII;
-  attrs.message.ascii = ascii;
-  ::nvtxDomainRangePushEx(domain, &attrs);
-#endif
-}
-inline void RangePush(nvtxDomainHandle_t domain, const std::string& str) {
+void RangePush(ProfilerDomainHandle domain, const char*);
+inline void RangePush(ProfilerDomainHandle domain, const std::string& str) {
   RangePush(domain, str.c_str());
 }
 
-// More powerful version: pass a registered string instead of a C-style string,
-// and attach a generic payload. The Annotation type must implement a method
-// called NvtxSchemaId() that allows the NVTX backend to interpret the payload.
-template <typename Annotation>
-void RangePush(nvtxDomainHandle_t domain, nvtxStringHandle_t handle,
-               const Annotation& annotation) {
-#if GOOGLE_CUDA
-  nvtxEventAttributes_t attrs{};
-  attrs.version = NVTX_VERSION;
-  attrs.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-  attrs.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
-  attrs.message.registered = handle;
-  NVTX_PAYLOAD_EVTATTR_SET(attrs, annotation.NvtxSchemaId(), &annotation,
-                           sizeof(Annotation));
-  ::nvtxDomainRangePushEx(domain, &attrs);
-#endif
+namespace detail {
+void RangePush(ProfilerDomainHandle domain, StringHandle title,
+               uint64_t schema_id, const void* payload, size_t payload_size);
 }
 
-}  // namespace profiler
-}  // namespace tsl
+// More powerful version: pass a registered string instead of a C-style
+// string, and attach a generic payload. The Annotation type must implement a
+// method called NvtxSchemaId() that allows the NVTX backend to interpret the
+// payload.
+template <typename Annotation>
+void RangePush(ProfilerDomainHandle domain, StringHandle title,
+               const Annotation& annotation) {
+  return detail::RangePush(domain, title, annotation.NvtxSchemaId(),
+                           &annotation, sizeof(Annotation));
+}
+
+// Register the schema of a custom payload type, for use with the more powerful
+// version of RangePush
+uint64_t RegisterSchema(ProfilerDomainHandle domain, const void* schemaAttr);
+}  // namespace tsl::profiler
 #endif  // TENSORFLOW_TSL_PROFILER_LIB_NVTX_UTILS_H_

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
@@ -1,0 +1,29 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tsl/profiler/lib/nvtx_utils.h"
+
+namespace tsl::profiler {
+ProfilerDomainHandle DefaultProfilerDomain() { return {}; }
+void RangePop(ProfilerDomainHandle) {}
+void RangePush(ProfilerDomainHandle, const char*) {}
+namespace detail {
+void RangePush(ProfilerDomainHandle, StringHandle, uint64_t, const void*,
+               size_t) {}
+}  // namespace detail
+uint64_t RegisterSchema(ProfilerDomainHandle, const void*) { return 0; }
+StringHandle RegisterString(ProfilerDomainHandle, const std::string&) {
+  return {};
+}
+}  // namespace tsl::profiler

--- a/third_party/tsl/tsl/profiler/lib/scoped_annotation.h
+++ b/third_party/tsl/tsl/profiler/lib/scoped_annotation.h
@@ -23,28 +23,23 @@ limitations under the License.
 #include <utility>
 
 #include "tsl/platform/macros.h"
+#include "tsl/profiler/lib/nvtx_utils.h"
 
 #if !defined(IS_MOBILE_PLATFORM)
 #include "tsl/profiler/backends/cpu/annotation_stack.h"
 #endif
 
-#if GOOGLE_CUDA
-#include "tsl/profiler/lib/nvtx_utils.h"
-#endif
-
-namespace tsl {
-namespace profiler {
+namespace tsl::profiler {
 
 // Adds an annotation to all activities through the currently registered
 // TraceCollector until PopAnnotation() is called.
 template <typename T>
-inline void PushAnnotation(const T& generator) {
-#if GOOGLE_CUDA
-  if (auto domain = GetNVTXDomain(); TF_PREDICT_FALSE(domain.has_value())) {
-    return RangePush(*domain, generator());
+void PushAnnotation(const T& generator) {
+  if (auto domain = DefaultProfilerDomain();
+      TF_PREDICT_FALSE(domain != nullptr)) {
+    RangePush(domain, generator());
+    return;
   }
-#endif
-
 #if !defined(IS_MOBILE_PLATFORM)
   if (TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
     AnnotationStack::PushAnnotation(static_cast<std::string_view>(generator()));
@@ -64,12 +59,11 @@ inline void PopAnnotation() {
   // fail probably due to compiler in that presubmit config.
   std::atomic_thread_fence(std::memory_order_acquire);
 
-#if GOOGLE_CUDA
-  if (auto domain = GetNVTXDomain(); TF_PREDICT_FALSE(domain.has_value())) {
-    ::nvtxDomainRangePop(*domain);
+  if (auto domain = DefaultProfilerDomain();
+      TF_PREDICT_FALSE(domain != nullptr)) {
+    RangePop(domain);
     return;
   }
-#endif
 
 #if !defined(IS_MOBILE_PLATFORM)
   if (TF_PREDICT_FALSE(AnnotationStack::IsEnabled())) {
@@ -110,7 +104,6 @@ class ScopedAnnotation {
   ScopedAnnotation& operator=(const ScopedAnnotation&) = delete;
 };
 
-}  // namespace profiler
-}  // namespace tsl
+}  // namespace tsl::profiler
 
 #endif  // TENSORFLOW_TSL_PROFILER_LIB_SCOPED_ANNOTATION_H_

--- a/xla/service/gpu/runtime/annotation.cc
+++ b/xla/service/gpu/runtime/annotation.cc
@@ -42,29 +42,22 @@ limitations under the License.
 #include "tsl/profiler/lib/nvtx_utils.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 
+#if GOOGLE_CUDA
+#include "nvtx3/nvToolsExt.h"
+#include "nvtx3/nvToolsExtPayload.h"
+#endif
+
 namespace xla::gpu {
 
 using ::tsl::profiler::ScopedAnnotation;
+using ::tsl::profiler::StringHandle;
 namespace {
 
-nvtxStringHandle_t RegisterString(const std::string& str) {
-#if GOOGLE_CUDA
-  auto domain = tsl::profiler::GetNVTXDomain();
-  if (!domain) {
-    return {};  // NVTX not enabled, so don't registering strings.
+StringHandle RegisterString(const std::string& str) {
+  if (auto domain = tsl::profiler::DefaultProfilerDomain(); domain) {
+    return tsl::profiler::RegisterString(domain, str);
   }
-  constexpr auto max_length = 65330;
-  if (str.size() <= max_length) {
-    return nvtxDomainRegisterStringA(*domain, str.c_str());
-  }
-  // nvbugs 4340868
-  std::string_view suffix{"\n[truncated]\n"};
-  std::string buffer(str.data(), max_length - suffix.size());
-  buffer.append(suffix);
-  return nvtxDomainRegisterStringA(*domain, buffer.c_str());
-#else
   return {};
-#endif
 }
 
 // Nsight Systems supports some basic HTML markup in annotation strings. This
@@ -202,7 +195,7 @@ class SourceLocationVisitor : public ConstDfsHloVisitorWithDefault {
     return OkStatus();
   }
 
-  std::pair<nvtxStringHandle_t, int32_t> LongestSourceLocationPrefix() const {
+  std::pair<StringHandle, int32_t> LongestSourceLocationPrefix() const {
     // Find the longest common prefix along the members of location_set_ and
     // return a formatted version of that prefix, along with its length. As
     // location_set_ is sorted, that just means looking for the longest common
@@ -275,7 +268,7 @@ std::string_view LongestPrefix(std::string_view a, std::string_view b,
     if (*a_it != *b_it) break;
 
     if (common_prefix_len) ++common_prefix_len;  // account for delimiter
-    common_prefix_len += a_it->size();           // length of a matching token
+    common_prefix_len += a_it->size();  // length of a matching token
   }
 
   return std::string_view(a.data(), common_prefix_len);
@@ -371,7 +364,7 @@ std::string CalledInstructionsAsString(HloInstruction const& inst) {
 
 // Get a string representing the longest common prefix of source locations in
 // this module, and the number of frames that that represents.
-std::pair<nvtxStringHandle_t, int32_t> GetLongestSourceLocationPrefix(
+std::pair<StringHandle, int32_t> GetLongestSourceLocationPrefix(
     const HloModule& mod) {
   // In the presence of (at least) debug callbacks, calling Accept on the root
   // instruction of the module may not reach all instructions in the module.
@@ -417,8 +410,8 @@ auto schema_entry(uint64_t type, const char* name, uint64_t offset) {
 uint64_t ModuleAnnotation::NvtxSchemaId() {
   static std::uint64_t schema_id = []() -> std::uint64_t {
 #if GOOGLE_CUDA
-    auto domain_opt = tsl::profiler::GetNVTXDomain();
-    if (!domain_opt.has_value()) {
+    auto domain = tsl::profiler::DefaultProfilerDomain();
+    if (!domain) {
       return 0;
     }
     const nvtxPayloadSchemaEntry_t schema[] = {
@@ -440,7 +433,7 @@ uint64_t ModuleAnnotation::NvtxSchemaId() {
         /* .entries = */ schema,
         /* .numEntries = */ sizeof(schema) / sizeof(schema[0]),
         /* .payloadStaticSize = */ sizeof(ModuleAnnotation)};
-    return nvtxPayloadSchemaRegister(*domain_opt, &schemaAttr);
+    return RegisterSchema(domain, &schemaAttr);
 #else
     return 0;
 #endif
@@ -491,8 +484,8 @@ ModuleAnnotations::ModuleAnnotations(std::string_view module_name)
 uint64_t KernelAnnotation::NvtxSchemaId() {
   static std::uint64_t schema_id = []() -> std::uint64_t {
 #if GOOGLE_CUDA
-    auto domain_opt = tsl::profiler::GetNVTXDomain();
-    if (!domain_opt.has_value()) {
+    auto domain = tsl::profiler::DefaultProfilerDomain();
+    if (!domain) {
       return 0;
     }
     const nvtxPayloadSchemaEntry_t schema[] = {
@@ -515,7 +508,7 @@ uint64_t KernelAnnotation::NvtxSchemaId() {
         /* .entries = */ schema,
         /* .numEntries = */ sizeof(schema) / sizeof(schema[0]),
         /* .payloadStaticSize = */ sizeof(KernelAnnotation)};
-    return nvtxPayloadSchemaRegister(*domain_opt, &schemaAttr);
+    return RegisterSchema(domain, &schemaAttr);
 #else
     return 0;
 #endif

--- a/xla/service/gpu/runtime/annotation.h
+++ b/xla/service/gpu/runtime/annotation.h
@@ -38,21 +38,21 @@ class ModuleAnnotation {
 
   std::string_view longest_op_name_prefix() const { return longest_prefix_; }
   explicit operator std::string_view() const { return title_str_; }
-  nvtxStringHandle_t title() const { return title_; }
+  tsl::profiler::StringHandle title() const { return title_; }
   static uint64_t NvtxSchemaId();
   int32_t common_stack_frames() const { return common_stack_frames_; }
 
  private:
-  friend void RangePush(nvtxDomainHandle_t domain,
+  friend void RangePush(tsl::profiler::ProfilerDomainHandle domain,
                         const ModuleAnnotation& annotation) {
     tsl::profiler::RangePush(domain, annotation.title(), annotation);
   }
 
   std::string longest_prefix_;
   std::string title_str_;
-  nvtxStringHandle_t title_;
-  nvtxStringHandle_t module_name_;
-  nvtxStringHandle_t common_src_locations_{};
+  tsl::profiler::StringHandle title_;
+  tsl::profiler::StringHandle module_name_;
+  tsl::profiler::StringHandle common_src_locations_{};
   int32_t module_id_{-1};
   int32_t common_stack_frames_{};
 };
@@ -66,16 +66,16 @@ struct KernelAnnotation {
   static uint64_t NvtxSchemaId();
 
  private:
-  friend void RangePush(nvtxDomainHandle_t domain,
+  friend void RangePush(tsl::profiler::ProfilerDomainHandle domain,
                         const KernelAnnotation& annotation) {
     tsl::profiler::RangePush(domain, annotation.title, annotation);
   }
 
   std::string title_str;
-  nvtxStringHandle_t title;
-  nvtxStringHandle_t hlo_dump;
-  nvtxStringHandle_t src_locations;
-  nvtxStringHandle_t called_hlo_dump;
+  tsl::profiler::StringHandle title;
+  tsl::profiler::StringHandle hlo_dump;
+  tsl::profiler::StringHandle src_locations;
+  tsl::profiler::StringHandle called_hlo_dump;
 };
 
 // Parsed/prepared information for an HloModule that gets propagated to NVTX


### PR DESCRIPTION
This avoids having preprocessor checks on `GOOGLE_CUDA` inside some headers, which led to ODR violations.