### PR TITLE
[ROCM][NFC] Refactoring GemmAlgorithmPicker: added GemmAutotuner class

### DIFF
--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -53,134 +53,6 @@ limitations under the License.
 
 namespace xla {
 namespace gpu {
-
-// Returns the index (into `algorithms`) of the fastest algorithm.
-template <typename AlgoT>
-absl::StatusOr<AutotuneResult> GetBestAlgorithm(
-    se::Stream* stream, se::RedzoneAllocator& allocator,
-    std::optional<std::string_view> gemm_str,
-    const AutotuneConfig& autotune_config, se::DeviceMemoryBase lhs_buffer,
-    se::DeviceMemoryBase rhs_buffer, se::DeviceMemoryBase output_buffer,
-    absl::Span<const AlgoT> algorithms, const Shape& output_shape,
-    const HloModuleConfig& hlo_module_config, double beta,
-    const std::function<absl::StatusOr<se::blas::ProfileResult>(const AlgoT&)>&
-        run_benchmark) {
-  if (!stream->parent()->SynchronizeAllActivity()) {
-    return Internal("Failed to synchronize GPU for autotuning.");
-  }
-
-  se::DeviceMemoryBase reference_buffer;
-  if (autotune_config.should_check_correctness()) {
-    TF_ASSIGN_OR_RETURN(
-        reference_buffer,
-        allocator.AllocateBytes(ShapeUtil::ByteSizeOf(output_shape)));
-  }
-
-  BufferComparator comparator(output_shape, hlo_module_config);
-
-  std::vector<AutotuneResult> results;
-  std::optional<int64_t> reference_algorithm;
-
-  for (const AlgoT& algorithm : algorithms) {
-    // Make sure the output buffer always has the same value if we use
-    // the bias parameter.
-    if (autotune_config.should_reinit_output_buffer() && beta != 0) {
-      int64_t rng_state = 0;
-      InitializeBuffer(stream, output_shape.element_type(), &rng_state,
-                       output_buffer);
-    }
-
-    TF_ASSIGN_OR_RETURN(auto profile_result, run_benchmark(algorithm));
-
-    results.emplace_back();
-    AutotuneResult& result = results.back();
-    result.mutable_gemm()->set_algorithm(profile_result.algorithm());
-
-    if (!profile_result.is_valid()) {  // Unsupported algorithm.
-      result.mutable_failure()->set_kind(AutotuneResult::DISQUALIFIED);
-      continue;
-    }
-
-    VLOG(2) << "gemm algorithm " << profile_result.algorithm() << " took "
-            << profile_result.elapsed_time_in_ms() << "ms";
-
-    *result.mutable_run_time() = tsl::proto_utils::ToDurationProto(
-        absl::Milliseconds(profile_result.elapsed_time_in_ms()));
-
-    if (!autotune_config.should_check_correctness()) {
-      continue;
-    }
-    TF_ASSIGN_OR_RETURN(
-        se::RedzoneAllocator::RedzoneCheckStatus rz_check_status,
-        allocator.CheckRedzones());
-
-    if (!rz_check_status.ok()) {
-      result.mutable_failure()->set_kind(AutotuneResult::REDZONE_MODIFIED);
-      *result.mutable_failure()->mutable_msg() =
-          rz_check_status.RedzoneFailureMsg();
-      LOG(ERROR) << "Detected out-of-bounds write in gemm buffer";
-      CHECK(!autotune_config.should_crash_on_check_failure());
-      continue;
-    }
-
-    if (!reference_algorithm) {
-      TF_RETURN_IF_ERROR(stream->Memcpy(&reference_buffer, output_buffer,
-                                        output_buffer.size()));
-      reference_algorithm = profile_result.algorithm();
-    } else {
-      // Perform the comparison.
-      TF_ASSIGN_OR_RETURN(
-          bool outputs_match,
-          comparator.CompareEqual(stream, /*current=*/output_buffer,
-                                  /*expected=*/reference_buffer));
-      if (!outputs_match) {
-        LOG(ERROR) << "Results mismatch between different GEMM algorithms. "
-                   << "This is likely a bug/unexpected loss of precision.";
-        CHECK(!autotune_config.should_crash_on_check_failure());
-
-        result.mutable_failure()->set_kind(AutotuneResult::WRONG_RESULT);
-        result.mutable_failure()->mutable_reference_gemm()->set_algorithm(
-            *reference_algorithm);
-      }
-    }
-  }
-
-  absl::StatusOr<AutotuneResult> best =
-      PickBestResult(results, gemm_str, hlo_module_config);
-  if (best.ok()) {
-    for (size_t i = 0; i < results.size(); ++i) {
-      if (best->gemm().algorithm() == results[i].gemm().algorithm()) {
-        best->mutable_gemm()->set_algorithm(i);
-        return best;
-      }
-    }
-    return Internal("unknown best algorithm");
-  }
-
-  LOG(WARNING) << "Failed to find best cuBLAS algorithm, GEMM performance "
-                  "might be suboptimal: "
-               << best.status();
-  return AutotuneResult{};
-}
-
-// Select the best algorithm using information from a Blas instruction.
-// Returns the index (into `algorithms`) of the fastest algorithm.
-absl::StatusOr<AutotuneResult> GetBestBlasAlgorithm(
-    se::Stream* stream, se::RedzoneAllocator& allocator,
-    std::optional<std::string_view> gemm_str,
-    const AutotuneConfig& autotune_config, se::DeviceMemoryBase lhs_buffer,
-    se::DeviceMemoryBase rhs_buffer, se::DeviceMemoryBase output_buffer,
-    absl::Span<const se::blas::AlgorithmType> algorithms,
-    const Shape& output_shape, const HloModuleConfig& hlo_module_config,
-    double beta,
-    const std::function<absl::StatusOr<se::blas::ProfileResult>(
-        const se::blas::AlgorithmType&)>& run_benchmark) {
-  return GetBestAlgorithm<se::blas::AlgorithmType>(
-      stream, allocator, gemm_str, autotune_config, lhs_buffer, rhs_buffer,
-      output_buffer, algorithms, output_shape, hlo_module_config, beta,
-      run_benchmark);
-}
-
 namespace {
 
 using se::gpu::BlasLt;
@@ -211,70 +83,68 @@ absl::StatusOr<BlasLt::Epilogue> AsBlasLtEpilogue(
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-absl::StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
-    const HloInstruction* gemm, const AutotuneCacheKey& key,
-    const AutotuneConfig& autotune_config) {
-  if (autotune_config.IsDeviceless()) {
-    // Return empty result, will tune at runtime.
-    return AutotuneResult{};
+class GemmAutotuner {
+
+  const AutotuneConfig& autotune_config_;
+  se::DeviceMemoryBase lhs_buffer_, rhs_buffer_, output_buffer_;
+  std::unique_ptr< se::RedzoneAllocator > redzone_allocator_;
+  se::Stream *stream_ = nullptr;
+  bool deterministic_ops_ = false;
+  int64_t rng_state_ = 0;
+
+public:
+
+  explicit GemmAutotuner(const AutotuneConfig& autotune_config) : 
+        autotune_config_(autotune_config) { }
+
+  StatusOr<AutotuneResult> operator()(const HloInstruction* gemm, 
+                                        const AutotuneCacheKey& key) {
+    if (autotune_config_.IsDeviceless()) {
+      // Return empty result, will tune at runtime.
+      return AutotuneResult{};
+    }
+    VLOG(3) << "Starting autotune of GemmThunk " << gemm->ToString();
+
+    TF_ASSIGN_OR_RETURN(stream_, autotune_config_.GetStream());
+    const DebugOptions& debug_options =
+                       gemm->GetModule()->config().debug_options();
+    deterministic_ops_ = debug_options.xla_gpu_deterministic_ops();
+
+    TF_ASSIGN_OR_RETURN(auto gemm_config, GemmConfig::For(gemm));
+
+    // Don't run autotuning concurrently on the same GPU.
+    absl::MutexLock gpu_lock(&GetGpuMutex(stream_->parent()));
+
+    TF_ASSIGN_OR_RETURN(auto buf_alloc,
+        AutotunerUtil::CreateRedzoneAllocator(autotune_config_, debug_options));
+    redzone_allocator_ = std::make_unique< se::RedzoneAllocator >
+                                                        (std::move(buf_alloc));
+
+    TF_ASSIGN_OR_RETURN(lhs_buffer_, CreateBuffer(gemm->operand(0)->shape()));
+    TF_ASSIGN_OR_RETURN(rhs_buffer_, CreateBuffer(gemm->operand(1)->shape()));
+    TF_ASSIGN_OR_RETURN(output_buffer_, CreateBuffer(GetOutputShape(gemm)));
+
+    return IsCublasLtMatmul(*gemm) ? TuneGpuBlasLt(gemm, gemm_config) :
+                                     TuneGpuBlas(gemm, gemm_config);
   }
 
-  VLOG(3) << "Starting autotune of GemmThunk " << gemm->ToString();
-  se::DeviceMemoryAllocator* allocator = autotune_config.GetAllocator();
-  TF_ASSIGN_OR_RETURN(se::Stream* const stream, autotune_config.GetStream());
-  GpuBackendConfig gpu_config =
+private:
+  const Shape& GetOutputShape(const HloInstruction* gemm) {
+    return gemm->shape().IsTuple() ? gemm->shape().tuple_shapes(0) : gemm->shape();
+  }
+
+  StatusOr<se::DeviceMemoryBase> CreateBuffer(const Shape& shape) {
+    return AutotunerUtil::CreateBuffer(*redzone_allocator_, shape,
+                                      autotune_config_, rng_state_);
+  }
+  
+  StatusOr<AutotuneResult> TuneGpuBlasLt(const HloInstruction* gemm, 
+        const GemmConfig& gemm_config) {
+
+    GpuBackendConfig gpu_config =
       gemm->backend_config<GpuBackendConfig>().value();
-  const GemmBackendConfig& backend_config = gpu_config.gemm_backend_config();
-  const DebugOptions& debug_options =
-      gemm->GetModule()->config().debug_options();
-  const bool deterministic_ops = debug_options.xla_gpu_deterministic_ops();
+    const GemmBackendConfig& backend_config = gpu_config.gemm_backend_config();
 
-  TF_ASSIGN_OR_RETURN(GemmConfig gemm_config, GemmConfig::For(gemm));
-  // Don't run autotuning concurrently on the same GPU.
-  absl::MutexLock gpu_lock(&GetGpuMutex(stream->parent()));
-
-  TF_ASSIGN_OR_RETURN(
-      se::RedzoneAllocator buffer_allocator,
-      AutotunerUtil::CreateRedzoneAllocator(autotune_config, debug_options));
-
-  int64_t rng_state = 0;
-  TF_ASSIGN_OR_RETURN(
-      se::DeviceMemoryBase lhs_buffer,
-      AutotunerUtil::CreateBuffer(buffer_allocator, gemm->operand(0)->shape(),
-                                  autotune_config, rng_state));
-  TF_ASSIGN_OR_RETURN(
-      se::DeviceMemoryBase rhs_buffer,
-      AutotunerUtil::CreateBuffer(buffer_allocator, gemm->operand(1)->shape(),
-                                  autotune_config, rng_state));
-
-  const Shape& output_shape =
-      gemm->shape().IsTuple() ? gemm->shape().tuple_shapes(0) : gemm->shape();
-
-  TF_ASSIGN_OR_RETURN(
-      se::DeviceMemoryBase output_buffer,
-      AutotunerUtil::CreateBuffer(buffer_allocator, output_shape,
-                                  autotune_config, rng_state));
-
-  int64_t workspace_size =
-      std::visit(VariantVisitor{[](const se::CudaComputeCapability& cc) {
-                                  return cc.IsAtLeastHopper()
-                                             ? GemmConfig::kHopperWorkspace
-                                             : GemmConfig::kDefaultWorkspace;
-                                },
-                                [](const se::RocmComputeCapability&) {
-                                  return GemmConfig::kDefaultWorkspace;
-                                }},
-                 autotune_config.GetGpuComputeCapability());
-
-  TF_ASSIGN_OR_RETURN(
-      se::DeviceMemoryBase workspace_buffer,
-      AutotunerUtil::CreateBuffer(buffer_allocator,
-                                  ShapeUtil::MakeShape(S8, {workspace_size}),
-                                  autotune_config, rng_state));
-
-  HloModuleConfig& hlo_module_config = gemm->GetModule()->mutable_config();
-  AutotuneResult best_algorithm;
-  if (IsCublasLtMatmul(*gemm)) {
     bool has_matrix_bias = gemm_config.beta != 0.;
 
     TF_ASSIGN_OR_RETURN(
@@ -288,62 +158,71 @@ absl::StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
     TF_ASSIGN_OR_RETURN(auto epilogue,
                         AsBlasLtEpilogue(backend_config.epilogue()));
 
-    se::DeviceMemoryBase bias_buffer;
-    if (has_vector_bias) {
-      TF_ASSIGN_OR_RETURN(
-          bias_buffer,
-          AutotunerUtil::CreateBuffer(
-              buffer_allocator, gemm->operand(has_matrix_bias ? 3 : 2)->shape(),
-              autotune_config, rng_state));
-    }
     se::DeviceMemoryBase a_scale_buffer, b_scale_buffer, c_scale_buffer,
-        d_scale_buffer, d_amax_buffer;
+        d_scale_buffer, d_amax_buffer, bias_buffer, aux_buffer;
 
-    se::DeviceMemoryBase aux_buffer;
+    if (has_vector_bias) {
+      TF_ASSIGN_OR_RETURN(bias_buffer,
+          CreateBuffer(gemm->operand(has_matrix_bias ? 3 : 2)->shape()));
+    }
     if (has_aux_output) {
-      TF_ASSIGN_OR_RETURN(
-          aux_buffer, AutotunerUtil::CreateBuffer(buffer_allocator,
-                                                  gemm->shape().tuple_shapes(1),
-                                                  autotune_config, rng_state));
+      TF_ASSIGN_OR_RETURN(aux_buffer, 
+          CreateBuffer(gemm->shape().tuple_shapes(1)));
     }
 
     TF_ASSIGN_OR_RETURN(auto plan,
-                        BlasLt::GetMatmulPlan(stream, gemm_config, epilogue));
+                        BlasLt::GetMatmulPlan(stream_, gemm_config, epilogue));
 
     TF_ASSIGN_OR_RETURN(auto algorithms, plan->GetAlgorithms());
 
+    auto tuned_func = [&](const BlasLt::MatmulAlgorithm& algorithm)
+                -> StatusOr<se::blas::ProfileResult> {
+
+      se::OwningScratchAllocator<> scratch_allocator(
+          stream_->parent()->device_ordinal(), autotune_config_.GetAllocator());
+      se::blas::ProfileResult profile_result;
+      TF_RETURN_IF_ERROR(plan->ExecuteOnStream(stream_, lhs_buffer_, rhs_buffer_, 
+          output_buffer_, output_buffer_, bias_buffer, aux_buffer, 
+          a_scale_buffer, b_scale_buffer, c_scale_buffer, d_scale_buffer, 
+          d_amax_buffer, algorithm, scratch_allocator, &profile_result));
+      return std::move(profile_result);
+    };
+
+    return GetBestAlgorithm<BlasLt::MatmulAlgorithm>(gemm, algorithms, 
+          gemm_config.beta, tuned_func);
+  }
+
+  StatusOr<AutotuneResult> TuneGpuBlas(const HloInstruction* gemm,
+         const GemmConfig& gemm_config) {
+
+    int64_t workspace_size =
+      std::visit(VariantVisitor{[](const se::CudaComputeCapability& cc) {
+                                  return cc.IsAtLeastHopper()
+                                             ? GemmConfig::kHopperWorkspace
+                                             : GemmConfig::kDefaultWorkspace;
+                                },
+                                [](const se::RocmComputeCapability&) {
+                                  return GemmConfig::kDefaultWorkspace;
+                                }},
+                 autotune_config_.GetGpuComputeCapability());
+
     TF_ASSIGN_OR_RETURN(
-        best_algorithm,
-        GetBestAlgorithm<BlasLt::MatmulAlgorithm>(
-            stream, buffer_allocator, gemm->ToString(), autotune_config,
-            lhs_buffer, rhs_buffer, output_buffer, algorithms, output_shape,
-            hlo_module_config, backend_config.beta(),
-            [&](const BlasLt::MatmulAlgorithm& algorithm)
-                -> absl::StatusOr<se::blas::ProfileResult> {
-              se::OwningScratchAllocator<> scratch_allocator(
-                  stream->parent()->device_ordinal(), allocator);
-              se::blas::ProfileResult profile_result;
-              TF_RETURN_IF_ERROR(plan->ExecuteOnStream(
-                  stream, lhs_buffer, rhs_buffer, output_buffer, output_buffer,
-                  bias_buffer, aux_buffer, a_scale_buffer, b_scale_buffer,
-                  c_scale_buffer, d_scale_buffer, d_amax_buffer, algorithm,
-                  scratch_allocator, &profile_result));
-              return std::move(profile_result);
-            }));
-  } else {
+      auto workspace_buffer,
+      CreateBuffer(ShapeUtil::MakeShape(S8, {workspace_size})));
+
     std::vector<se::blas::AlgorithmType> algorithms;
     TF_ASSIGN_OR_RETURN(GemmConfig::DescriptorsTuple desc,
-                        gemm_config.GetMatrixDescriptors(lhs_buffer, rhs_buffer,
-                                                         output_buffer));
+        gemm_config.GetMatrixDescriptors(lhs_buffer_, rhs_buffer_, 
+                output_buffer_));
 
-    auto blas = stream->parent()->AsBlas();
+    auto blas = stream_->parent()->AsBlas();
     if (blas == nullptr) {
       return absl::InternalError("No BLAS support for stream");
     }
-    blas->GetBlasGemmAlgorithms(stream, desc.lhs, desc.rhs, &desc.output,
-                                &gemm_config.alpha, &gemm_config.beta,
-                                &algorithms);
+    blas->GetBlasGemmAlgorithms(stream_, desc.lhs, desc.rhs, &desc.output,
+                        &gemm_config.alpha, &gemm_config.beta, &algorithms);
 
+    AutotuneResult best_algorithm;
 #if TENSORFLOW_USE_ROCM        // Blas gemm algorithms can be empty for ROCM
     if (algorithms.empty()) {  // nothing to autotune
       LOG(WARNING) << "No solutions found: skipping autotuning for ROCM..";
@@ -352,35 +231,136 @@ absl::StatusOr<AutotuneResult> DoGemmAutotuneNoCache(
     }
 #endif
 
-    TF_ASSIGN_OR_RETURN(
-        best_algorithm,
-        GetBestBlasAlgorithm(
-            stream, buffer_allocator, gemm->ToString(), autotune_config,
-            lhs_buffer, rhs_buffer, output_buffer, algorithms, output_shape,
-            hlo_module_config, backend_config.beta(),
-            [&](const se::blas::AlgorithmType& algorithm)
-                -> absl::StatusOr<se::blas::ProfileResult> {
-              se::blas::ProfileResult profile_result;
-              // We expect GemmWithAlgorithm to fail sometimes
-              // -- in fact, it will fail for all algorithms if
-              // we're targeting < sm_50.  But because we pass a
-              // non-null ProfileResult, DoGemmWithAlgorithm
-              // should always return true, and the actual
-              // success-ness is returned in
-              // ProfileResult::is_valid.
-              TF_RETURN_IF_ERROR(RunGemm(gemm_config, lhs_buffer, rhs_buffer,
-                                         output_buffer, workspace_buffer,
-                                         deterministic_ops, stream, algorithm,
-                                         &profile_result));
-              return std::move(profile_result);
-            }));
+    auto tuned_func = [&](const se::blas::AlgorithmType& algorithm)
+                -> StatusOr<se::blas::ProfileResult> {
+      se::blas::ProfileResult profile_result;
+      // We expect GemmWithAlgorithm to fail sometimes -- in fact, it will fail 
+      // for all algorithms if we're targeting < sm_50. But because we pass a
+      // non-null ProfileResult, DoGemmWithAlgorithm should always return true, 
+      // and the actual success-ness is returned in ProfileResult::is_valid.
+      TF_RETURN_IF_ERROR(RunGemm(gemm_config, lhs_buffer_, rhs_buffer_,
+           output_buffer_, workspace_buffer, deterministic_ops_, stream_, 
+           algorithm, &profile_result));
+      return std::move(profile_result);
+    };
+
+    TF_ASSIGN_OR_RETURN(best_algorithm,
+       GetBestAlgorithm<se::blas::AlgorithmType>(gemm, algorithms, 
+              gemm_config.beta, tuned_func));
     if (best_algorithm.has_gemm()) {
       int alg_idx = best_algorithm.gemm().algorithm();
       best_algorithm.mutable_gemm()->set_algorithm(algorithms[alg_idx]);
     }
+    return best_algorithm;
   }
-  return best_algorithm;
-}
+
+  // Returns the index (into `algorithms`) of the fastest algorithm.
+  template <typename AlgoT, typename TunedFunc>
+  StatusOr<AutotuneResult> GetBestAlgorithm(const HloInstruction* gemm, 
+      absl::Span<const AlgoT> algorithms, double beta, 
+      TunedFunc&& run_benchmark) {
+
+    static_assert(std::is_invocable_r_v<StatusOr<se::blas::ProfileResult>,
+          TunedFunc, const AlgoT&>,
+          "Tuned function has incorrect prototype!");
+
+    if (!stream_->parent()->SynchronizeAllActivity()) {
+      return Internal("Failed to synchronize GPU for autotuning.");
+    }
+
+    auto& hlo_module_config = gemm->GetModule()->mutable_config();
+    const auto& output_shape = GetOutputShape(gemm);
+
+    se::DeviceMemoryBase reference_buffer;
+    if (autotune_config_.should_check_correctness()) {
+      TF_ASSIGN_OR_RETURN(reference_buffer,
+        redzone_allocator_->AllocateBytes(ShapeUtil::ByteSizeOf(output_shape)));
+    }
+
+    BufferComparator comparator(output_shape, hlo_module_config);
+    std::vector<AutotuneResult> results;
+    results.reserve(algorithms.size());
+    std::optional<int64_t> reference_algorithm;
+
+    for (const AlgoT& algorithm : algorithms) {
+      // Make sure the output buffer always has the same value if we use
+      // the bias parameter.
+      if (autotune_config_.should_reinit_output_buffer() && beta != 0) {
+        int64_t rng_state = 0;
+        InitializeBuffer(stream_, output_shape.element_type(), &rng_state,
+                       output_buffer_);
+      }
+      TF_ASSIGN_OR_RETURN(auto profile_result, run_benchmark(algorithm));
+
+      AutotuneResult& result = results.emplace_back();
+      result.mutable_gemm()->set_algorithm(profile_result.algorithm());
+
+      if (!profile_result.is_valid()) {  // Unsupported algorithm.
+        result.mutable_failure()->set_kind(AutotuneResult::DISQUALIFIED);
+        continue;
+      }
+
+      VLOG(2) << "gemm algorithm " << profile_result.algorithm() << " took "
+            << profile_result.elapsed_time_in_ms() << "ms";
+
+      *result.mutable_run_time() = tsl::proto_utils::ToDurationProto(
+          absl::Milliseconds(profile_result.elapsed_time_in_ms()));
+
+      if (!autotune_config_.should_check_correctness()) {
+        continue;
+      }
+      TF_ASSIGN_OR_RETURN(
+        se::RedzoneAllocator::RedzoneCheckStatus rz_check_status,
+        redzone_allocator_->CheckRedzones());
+
+      if (!rz_check_status.ok()) {
+        result.mutable_failure()->set_kind(AutotuneResult::REDZONE_MODIFIED);
+        *result.mutable_failure()->mutable_msg() =
+            rz_check_status.RedzoneFailureMsg();
+        LOG(ERROR) << "Detected out-of-bounds write in gemm buffer";
+        CHECK(!autotune_config_.should_crash_on_check_failure());
+        continue;
+      }
+
+      if (!reference_algorithm) {
+        TF_RETURN_IF_ERROR(stream_->Memcpy(&reference_buffer, output_buffer_,
+                         output_buffer_.size()));
+        reference_algorithm = profile_result.algorithm();
+      } else {
+        // Perform the comparison.
+        TF_ASSIGN_OR_RETURN(bool outputs_match,
+          comparator.CompareEqual(stream_, /*current=*/output_buffer_,
+                                  /*expected=*/reference_buffer));
+        if (!outputs_match) {
+          LOG(ERROR) << "Results mismatch between different GEMM algorithms. "
+                   << "This is likely a bug/unexpected loss of precision.";
+          CHECK(!autotune_config_.should_crash_on_check_failure());
+
+          result.mutable_failure()->set_kind(AutotuneResult::WRONG_RESULT);
+          result.mutable_failure()->mutable_reference_gemm()->set_algorithm(
+            *reference_algorithm);
+        }
+      }
+    } // for algorithms
+
+    absl::StatusOr<AutotuneResult> best =
+      PickBestResult(results, gemm->ToString(), hlo_module_config);
+    if (best.ok()) {
+      for (size_t i = 0; i < results.size(); ++i) {
+        if (best->gemm().algorithm() == results[i].gemm().algorithm()) {
+          best->mutable_gemm()->set_algorithm(i);
+          return best;
+        }
+      }
+      return Internal("unknown best algorithm");
+    }
+    LOG(WARNING) << "Failed to find best cuBLAS algorithm, GEMM performance "
+                  "might be suboptimal: "
+               << best.status();
+    return AutotuneResult{};
+  } // GetBestAlgorithm
+
+}; // GemmAutotuner
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
@@ -392,7 +372,7 @@ absl::StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
 
   GpuBackendConfig gpu_config =
       gemm->backend_config<GpuBackendConfig>().value();
-  GemmBackendConfig backend_config = gpu_config.gemm_backend_config();
+  GemmBackendConfig& backend_config = *gpu_config.mutable_gemm_backend_config();
 
   // Degenerate gemms replaced with memzero operation, no need to auto tune it.
   if (backend_config.alpha_real() == 0.0 &&
@@ -402,14 +382,13 @@ absl::StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
   }
 
   AutotuneCacheKey key(config.GetModelStr(), *gemm);
-
+  GemmAutotuner autotuner(config);
   TF_ASSIGN_OR_RETURN(AutotuneResult algorithm,
                       AutotunerUtil::Autotune(gemm, config, [&] {
-                        return DoGemmAutotuneNoCache(gemm, key, config);
+                        return autotuner(gemm, key);
                       }));
 
-  GemmBackendConfig updated_config = backend_config;
-
+  auto old_algorithm = backend_config.selected_algorithm();
   bool update_algorithm = std::visit(
       VariantVisitor{[](const se::CudaComputeCapability& cc) {
                        // We only set the 'algorithm' field on
@@ -424,16 +403,14 @@ absl::StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
 
   if (update_algorithm) {
     if (algorithm.has_gemm()) {
-      updated_config.set_selected_algorithm(algorithm.gemm().algorithm());
+      backend_config.set_selected_algorithm(algorithm.gemm().algorithm());
     } else {
-      // TODO: autotuning is NOT available for gpublas-lt (blas gemm only) !
-      updated_config.set_selected_algorithm(se::blas::kRuntimeAutotuning);
+      // NOTE: runtime autotuning is no longer available => set to default
+      backend_config.set_selected_algorithm(se::blas::kDefaultAlgorithm);
     }
   }
-  *gpu_config.mutable_gemm_backend_config() = updated_config;
   TF_RETURN_IF_ERROR(gemm->set_backend_config(gpu_config));
-  return updated_config.SerializeAsString() !=
-         backend_config.SerializeAsString();
+  return old_algorithm != backend_config.selected_algorithm();
 }
 
 absl::StatusOr<bool> RunOnComputation(HloComputation* computation,


### PR DESCRIPTION
In this PR, I refactored GemmAlgorithmPicker by adding a new class GemmAutotuner and also moved repeated pieces of code into member functions. Improving code readability. 
The intention is to integrate later some improvements on GemmAlgorithmPicker, and this is a preparation step.

- converted GetBestAlgorithm with large number params to a member function
- the forwarding function GetBestBlasAlgorithm is no longer needed and can be deleted since kRuntimeAutotuning is no longer available in XLA
- added separate functions TuneBlas() and TuneBlasLt(), respectively
- added CreateBuffer() and GetOutputShape() helper functions

@xla-rotation: would you please have a look ?