### PR TITLE
[ROCm] hotfix 20240226

### DIFF
--- a/xla/service/gpu/nccl_api.cc
+++ b/xla/service/gpu/nccl_api.cc
@@ -371,6 +371,8 @@ DefaultNcclApi::CommInitRanks(int32_t nranks, const NcclCliqueId& clique_id,
   VLOG(1) << "Initialize NCCL communicator for " << ranks.size()
           << " devices; hash(id)=" << absl::HashOf(clique_id);
 
+#if !defined(TENSORFLOW_USE_ROCM) ||  (defined(TENSORFLOW_USE_ROCM) && 
+                                        TF_ROCM_VERSION > 50700)
   ncclConfig_t comm_config = NCCL_CONFIG_INITIALIZER;
   comm_config.splitShare = config.split_share;
   if (config.max_nchannels > 0) {
@@ -399,6 +401,11 @@ DefaultNcclApi::CommInitRanks(int32_t nranks, const NcclCliqueId& clique_id,
   TF_RETURN_IF_ERROR(GroupEnd());
 
   return comms;
+#else
+  return absl::UnimplementedError(
+      absl::StrFormat("%s:%d: NCCL operation ncclCommInitRankConfig not implemented",
+                      __FILE__, __LINE__));
+#endif  
 }
 
 absl::StatusOr<std::vector<NcclApi::OwnedNcclComm>> DefaultNcclApi::CommSplit(

--- a/xla/service/gpu/nccl_api.cc
+++ b/xla/service/gpu/nccl_api.cc
@@ -371,8 +371,7 @@ DefaultNcclApi::CommInitRanks(int32_t nranks, const NcclCliqueId& clique_id,
   VLOG(1) << "Initialize NCCL communicator for " << ranks.size()
           << " devices; hash(id)=" << absl::HashOf(clique_id);
 
-#if !defined(TENSORFLOW_USE_ROCM) ||  (defined(TENSORFLOW_USE_ROCM) && 
-                                        TF_ROCM_VERSION > 50700)
+#if !defined(TENSORFLOW_USE_ROCM) || (defined(TENSORFLOW_USE_ROCM) && TF_ROCM_VERSION > 50700)
   ncclConfig_t comm_config = NCCL_CONFIG_INITIALIZER;
   comm_config.splitShare = config.split_share;
   if (config.max_nchannels > 0) {

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -643,6 +643,26 @@ static std::string_view StreamCaptureModeToString(
   return absl::OkStatus();
 }
 
+absl::StatusOr<std::vector<GpuGraphNodeHandle>>
+GpuDriver::GraphNodeGetDependencies(GpuGraphNodeHandle node) {
+  VLOG(2) << "Get HIP graph node " << node << " dependencies";
+
+  std::vector<hipGraphNode_t> dependencies;
+
+  size_t num_dependencies = 0;
+  RETURN_IF_ROCM_ERROR(
+      hipGraphNodeGetDependencies(node, nullptr, &num_dependencies),
+      "Failed to get HIP graph node depedencies size");
+
+  dependencies.resize(num_dependencies, nullptr);
+  RETURN_IF_ROCM_ERROR(
+      hipGraphNodeGetDependencies(node, dependencies.data(), &num_dependencies),
+      "Failed to get HIP graph node depedencies");
+
+  return dependencies;
+}
+
+
 /* static */ absl::Status GpuDriver::DestroyGraphExec(hipGraphExec_t exec) {
   VLOG(2) << "Destroying HIP executable graph" << exec;
   RETURN_IF_ROCM_ERROR(wrap::hipGraphExecDestroy(exec),

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -315,7 +315,7 @@ absl::Status GpuExecutor::GetKernel(const MultiKernelLoaderSpec& spec,
     kernel->set_metadata(kernel_metadata);
   }
   kernel->set_name(*kernel_name);
-  kernel->set_kernel_args_packing(spec.kernel_args_packing());
+  kernel->set_args_packing(spec.kernel_args_packing());
   return absl::OkStatus();
 }
 
@@ -354,8 +354,7 @@ absl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
     }
   }
 
-  if (rocm_kernel->GetPreferredCacheConfig() !=
-      KernelCacheConfig::kNoPreference) {
+  if (rocm_kernel->cache_config() != KernelCacheConfig::kNoPreference) {
     TF_RETURN_IF_ERROR(GpuDriver::FuncSetCacheConfig(
         hipfunc, rocm_kernel->GetGpuCacheConfig()));
   }
@@ -377,7 +376,7 @@ absl::Status GpuExecutor::Launch(Stream* stream, const ThreadDim& thread_dims,
   if (packed_args) return launch(*packed_args);
 
   if (auto* device_mem = DynCast<KernelArgsDeviceMemoryArray>(&args)) {
-    auto& pack = kernel.kernel_args_packing();
+    auto& pack = kernel.args_packing();
     if (!pack) {
       return absl::InternalError(
           "Kernel is missing a custom arguments packing function for device "

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -639,7 +639,7 @@ absl::Status GpuExecutor::Memset32(Stream* stream, DeviceMemoryBase* location,
       AsGpuStreamValue(stream));
 }
 
-bool GpuExecutor::Memcpy(Stream* stream, void* host_dst,
+absl::Status GpuExecutor::Memcpy(Stream* stream, void* host_dst,
                          const DeviceMemoryBase& gpu_src, uint64_t size) {
   bool ok = GpuDriver::AsynchronousMemcpyD2H(context_, host_dst,
                                              AsROCmDevicePtr(gpu_src), size,
@@ -652,7 +652,7 @@ bool GpuExecutor::Memcpy(Stream* stream, void* host_dst,
   return absl::OkStatus();
 }
 
-bool GpuExecutor::Memcpy(Stream* stream, DeviceMemoryBase* gpu_dst,
+absl::Status GpuExecutor::Memcpy(Stream* stream, DeviceMemoryBase* gpu_dst,
                          const void* host_src, uint64_t size) {
   bool ok = GpuDriver::AsynchronousMemcpyH2D(context_, AsROCmDevicePtr(gpu_dst),
                                              host_src, size,

--- a/xla/stream_executor/rocm/rocm_kernel.cc
+++ b/xla/stream_executor/rocm/rocm_kernel.cc
@@ -19,7 +19,7 @@ namespace stream_executor {
 namespace gpu {
 
 hipFuncCache_t GpuKernel::GetGpuCacheConfig() const {
-  switch (preferred_cache_config_) {
+  switch (cache_config()) {
     case KernelCacheConfig::kNoPreference:
       return hipFuncCachePreferNone;
     case KernelCacheConfig::kPreferShared:
@@ -30,7 +30,7 @@ hipFuncCache_t GpuKernel::GetGpuCacheConfig() const {
       return hipFuncCachePreferEqual;
     default:
       LOG(FATAL) << "Unknown KernelCacheConfig"
-                 << static_cast<int32>(preferred_cache_config_);
+                 << static_cast<int32>(cache_config());
   }
 }
 


### PR DESCRIPTION
1. add version check for ncclCommSplit
2. fixed https://github.com/openxla/xla/commit/dd7604b8faab933099548452677836b72efdcebf on absl::Status
3. ROCm uses potrf() https://github.com/openxla/xla/commit/dad57bd0d943e08795b3cd55dd27fb4abe0cd9c4
4. fixed https://github.com/openxla/xla/commit/c95205516554a53d0c1c20399c94b9ad456abb4f
5. ROCm graph dependecies https://github.com/openxla/xla/commit/6345b3be9e0e5c94c551e2fec53d2e41f94b7610