### PR TITLE
[ROCm] Disable some tests on ROCM

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -4556,6 +4556,7 @@ xla_test(
             "requires-gpu-sm80-only",
             "noasan",
             "nomsan",
+            "no_rocm",
         ],
     },
     backends = [
@@ -4717,6 +4718,7 @@ xla_test(
     srcs = ["cudnn_fused_mha_rewriter_test.cc"],
     backend_tags = {"gpu": [
         "requires-gpu-nvidia",
+        "no_rocm",
     ]},
     backends = [
         "gpu",

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -195,6 +195,7 @@ xla_cc_test(
     size = "small",
     srcs = ["stream_search_test.cc"],
     tags = tf_cuda_tests_tags() + [
+        "no_rocm",
         "requires-gpu-nvidia",
     ],
     deps = [
@@ -228,6 +229,7 @@ xla_cc_test(
     name = "memcpy_test",
     srcs = ["memcpy_test.cc"],
     tags = tf_cuda_tests_tags() + [
+        "no_rocm",
         "requires-gpu-nvidia",
     ],
     deps = [


### PR DESCRIPTION
The stream_executor/cuda could me moved to stream_executor/gpu, but disable them for now.