### PR TITLE
[ROCM] fixing hipblas-lt large startup overhead

### DIFF
--- a/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -90,32 +90,38 @@ absl::Status CublasLtMatmulThunk::ExecuteOnStream(const ExecuteParams& params) {
       params.stream, allocs.GetDeviceAddress(a_buffer_),
       allocs.GetDeviceAddress(b_buffer_), allocs.GetDeviceAddress(c_buffer_),
       allocs.GetDeviceAddress(d_buffer_), bias, aux, a_scale, b_scale, c_scale,
-      d_scale, d_amax, *algorithm, scratch_allocator);
+      d_scale, d_amax, algorithm, scratch_allocator);
 }
 
 absl::StatusOr<se::gpu::BlasLt::MatmulPlan*> CublasLtMatmulThunk::GetMatmulPlan(
     const stream_executor::Stream* stream) {
-  absl::MutexLock lock(&matmul_plans_cache_mutex_);
-  auto it = matmul_plans_cache_.find(stream);
-  if (it == matmul_plans_cache_.end()) {
-    TF_ASSIGN_OR_RETURN(auto plan, se::gpu::BlasLt::GetMatmulPlan(
-                                       stream, gemm_config_, epilogue_));
-    it = matmul_plans_cache_.emplace(stream, std::move(plan)).first;
+ {
+    absl::MutexLock lock(&matmul_plans_cache_mutex_);
+    auto it = matmul_plans_cache_.find(stream);
+    if (it != matmul_plans_cache_.end()) return it->second.get();
   }
+  TF_ASSIGN_OR_RETURN(auto plan, se::gpu::BlasLt::GetMatmulPlan(
+                                       stream, gemm_config_, epilogue_));
+  
+  absl::MutexLock lock(&matmul_plans_cache_mutex_);
+  auto [it, _] = matmul_plans_cache_.emplace(stream, std::move(plan));
   return it->second.get();
 }
 
-absl::StatusOr<std::optional<se::gpu::BlasLt::MatmulAlgorithm> >
+absl::StatusOr< se::gpu::BlasLt::MatmulAlgorithm >
 CublasLtMatmulThunk::GetMatmulAlgorithm(
     const se::gpu::BlasLt::MatmulPlan* plan) {
-  absl::MutexLock lock(&matmul_algorithm_cache_mutex_);
-  auto it = matmul_algorithm_cache_.find(plan);
-  if (it == matmul_algorithm_cache_.end()) {
-    TF_ASSIGN_OR_RETURN(auto algorithms, plan->GetAlgorithms());
-    TF_RET_CHECK(algorithm_idx_ >= 0 && algorithm_idx_ < algorithms.size());
-    auto algorithm = algorithms[algorithm_idx_];
-    it = matmul_algorithm_cache_.emplace(plan, algorithm).first;
+  {
+    absl::MutexLock lock(&matmul_algorithm_cache_mutex_);
+    auto it = matmul_algorithm_cache_.find(plan);
+    if (it != matmul_algorithm_cache_.end()) return it->second;
   }
+  TF_ASSIGN_OR_RETURN(auto algorithms, plan->GetAlgorithms());
+  TF_RET_CHECK(algorithm_idx_ >= 0 && algorithm_idx_ < algorithms.size());
+  
+  absl::MutexLock lock(&matmul_algorithm_cache_mutex_);
+  auto [it, _] = matmul_algorithm_cache_.emplace(plan, 
+                        algorithms[algorithm_idx_]);
   return it->second;
 }
 

--- a/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.h
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.h
@@ -53,7 +53,7 @@ class CublasLtMatmulThunk : public Thunk {
  private:
   absl::StatusOr<se::gpu::BlasLt::MatmulPlan*> GetMatmulPlan(
       const stream_executor::Stream* stream);
-  absl::StatusOr<std::optional<se::gpu::BlasLt::MatmulAlgorithm> >
+  absl::StatusOr< se::gpu::BlasLt::MatmulAlgorithm >
   GetMatmulAlgorithm(const se::gpu::BlasLt::MatmulPlan* plan);
 
   absl::Mutex matmul_plans_cache_mutex_;

--- a/xla/tests/collective_ops_test_e2e.cc
+++ b/xla/tests/collective_ops_test_e2e.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "xla/tests/hlo_test_base.h"
 #include "xla/tests/literal_test_util.h"
 #include "xla/tests/test_macros.h"
+#include "xla/tests/test_utils.h"
 
 namespace xla {
 namespace {
@@ -379,6 +380,82 @@ XLA_TEST_P(AsyncCollectiveOps, AsyncAllToAllWithoutSplitDim) {
   ASSERT_EQ(results.size(), kNumReplicas);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({10, 15, 11, 16}, results[0]);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({40, 60, 44, 64}, results[1]);
+}
+
+TEST_P(AsyncCollectiveOps, MatmulReplicated) {
+
+      // collective_permute = f32[16,32]{1,0} collective-permute(x_unscaled), source_target_pairs={{0,1}, {1,2}, {2,3}, {3,0}}
+  absl::string_view kModuleReplicatedStr = R"(
+    HloModule test
+
+    ENTRY test {
+      x_f32 = f32[16,32] parameter(0)
+      y_f32 = f32[16,32] parameter(1)
+      replica_id = u32[] replica-id()
+      addend = f32[] convert(replica_id)
+      addend_bcast = f32[16,32] broadcast(addend), dimensions={}
+      x_add = f32[16,32] add(addend_bcast, x_f32)
+      ROOT dot_a = f32[16,16] dot(x_add, y_f32), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+   }
+  )";
+
+  absl::string_view kModuleSingleStr = R"(
+    HloModule test
+
+    ENTRY test {
+      x_f32 = f32[16,32] parameter(0)
+      y_f32 = f32[16,32] parameter(1)
+      replica_id = u32[] parameter(2)
+      addend = f32[] convert(replica_id)
+      addend_bcast = f32[16,32] broadcast(addend), dimensions={}
+      x_add = f32[16,32] add(addend_bcast, x_f32)
+      ROOT dot_a = f32[16,16] dot(x_add, y_f32), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+   }
+  )";
+  const int64_t kNumReplicas = 4;
+
+  HloModuleConfig config =
+        GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  auto opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_enable_cublaslt(GetParam());
+  VLOG(0) << "Running with CUBLAS enabled: " << 
+        opts.xla_gpu_enable_cublaslt();
+  config.set_debug_options(opts);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                        ParseAndReturnVerifiedModule(kModuleReplicatedStr, config));
+  DeviceAssignment assn(/*replica_count=*/kNumReplicas,
+                        /*computation_count=*/1);
+  for (int64_t i = 0; i < kNumReplicas; ++i) {
+    assn(i, 0) = i;
+  }
+
+  auto fake_arguments = xla::MakeFakeArguments(module.get()).value();
+  std::vector<Literal*> fake_ptrs(fake_arguments.size());
+  for(int i = 0; i < fake_arguments.size(); i++) {
+    fake_ptrs[i] = &fake_arguments[i];
+  }
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
+                          HloTestBase::ExecuteReplicated(
+          std::move(module), fake_ptrs, kNumReplicas, &assn, 
+          true /*run_hlo_passes*/, true /*use-threads*/));
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  auto& ref_runner = HloTestBase::reference_runner_;
+  TF_ASSERT_OK_AND_ASSIGN(auto ref_module,
+                        ParseAndReturnVerifiedModule(kModuleSingleStr, config));
+  TF_ASSERT_OK_AND_ASSIGN(auto ref_exec,
+        ref_runner.CreateExecutable(std::move(ref_module), true));
+
+  ErrorSpec error_spec{1e-5, 1e-5};
+  fake_ptrs.push_back(nullptr);
+  for(int i = 0; i < kNumReplicas; i++) {
+    auto replica_id = LiteralUtil::CreateFullWithDescendingLayout<uint32_t>({}, i);
+    fake_ptrs.back() = &replica_id;
+    TF_ASSERT_OK_AND_ASSIGN(auto res, 
+                  ref_runner.ExecuteWithExecutable(ref_exec.get(), fake_ptrs));
+    EXPECT_TRUE(LiteralTestUtil::Near(res, results[i], error_spec));
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(AsyncCollectiveOps, AsyncCollectiveOps,


### PR DESCRIPTION

This PR https://github.com/openxla/xla/pull/6595 introduced **matmul_algorithm_cache_** which calls MatmulPlan::GetAlgorithms while holding a mutex. This is not bad on CUDA side but on ROCM, hipblas-lt has a large startup overhead, and when running this code with multiple GPUs, this startup overhead increases linearly with the number of GPUs.
However, **MatmulPlan::GetAlgorithms** can be run in parallel across different StreamExecutorsL anyway library functions are called under [per-instance mutex](https://github.com/ROCm/xla/blob/43c67a4d135b5e1e023c3e67b9062b9aa88d6ab8/xla/stream_executor/cuda/cuda_blas_lt.cc#L244).

I also did the same for **matmul_plans_cache_**, besides I added a multi-GPU matmul test which runs with cublas and cublas-lt libraries.

@xla-rotation: could you please have a look ?
