### PR TITLE
[XLA:CPU][oneDNN] Reduce the threshold for element count in oneDNN ma…

### DIFF
--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -372,7 +372,7 @@ bool OneDnnMatMulRewriter::ShouldRewrite(const HloInstruction* dot_instr) {
   auto rank = lhs_shape.rank();
   auto rhs_dims = rhs_shape.dimensions();
   int64_t num_mac_ops = ShapeUtil::ElementsIn(lhs_shape) * rhs_dims.back();
-  int mac_ops_threshold = (rank == 2) ? (1 << 23) : (1 << 18);
+  int mac_ops_threshold = (rank == 2) ? (1 << 20) : (1 << 18);
   return (num_mac_ops >= mac_ops_threshold);
 }
 


### PR DESCRIPTION
…tmul rewriter
The "onednn-matmul-rewriter" pass has threshold to avoid rewriting dot operator on smaller shape' operands. This PR reduce the threshold limit for 2D matrix, which enables additional dot operators executed through oneDNN.  