### PR TITLE
[XLA:CPU][oneDNN] Update oneDNN LayerNorm and Softmax

### DIFF
--- a/xla/service/cpu/backend_config.proto
+++ b/xla/service/cpu/backend_config.proto
@@ -36,6 +36,7 @@ message OneDnnMatMulConfig {
 }
 
 message OneDnnLayerNormConfig {
+  int32 epsilon_typecast = 1;
   // These enum needs to be mapped to oneDNN enum for post_op algorithm.
   // TODO(intel-tf): Add kinds supported by oneDNN.
   enum FusionKind {
@@ -44,5 +45,5 @@ message OneDnnLayerNormConfig {
     SHIFT = 2;
     SCALE_AND_SHIFT = 3;
   }
-  FusionKind fused_ops = 1;
+  FusionKind fused_ops = 2;
 }

--- a/xla/service/cpu/backend_config.proto
+++ b/xla/service/cpu/backend_config.proto
@@ -36,7 +36,6 @@ message OneDnnMatMulConfig {
 }
 
 message OneDnnLayerNormConfig {
-  int32 epsilon_typecast = 1;
   // These enum needs to be mapped to oneDNN enum for post_op algorithm.
   // TODO(intel-tf): Add kinds supported by oneDNN.
   enum FusionKind {
@@ -45,5 +44,6 @@ message OneDnnLayerNormConfig {
     SHIFT = 2;
     SCALE_AND_SHIFT = 3;
   }
-  FusionKind fused_ops = 2;
+  FusionKind fused_ops = 1;
+  int32 epsilon_typecast = 2;
 }

--- a/xla/service/cpu/onednn_layer_norm.cc
+++ b/xla/service/cpu/onednn_layer_norm.cc
@@ -83,7 +83,8 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnLayerNorm(
   auto shift_mem = memory(scaleshift_md, cpu_engine, beta_minfo.Data());
 
   // TODO(intel-tf): Move epsilon to OneDnnLayerNormConfig.
-  const float epsilon = 1.e-5f;
+  float epsilon;
+  *(reinterpret_cast<int32_t*>(&epsilon)) = ln_config.epsilon_typecast();
 
   auto lnorm_pd = layer_normalization_forward::primitive_desc(
       cpu_engine, prop_kind::forward_inference, src_md, dst_md, epsilon,

--- a/xla/service/cpu/onednn_ops_rewriter.cc
+++ b/xla/service/cpu/onednn_ops_rewriter.cc
@@ -29,11 +29,6 @@ namespace cpu {
 namespace {
 namespace m = match;
 
-auto ConvertPattern(HloInstruction** instr) {
-  return m::Convert(m::Op(instr).WithElementType(PrimitiveType::BF16))
-      .WithElementType(PrimitiveType::F32);
-}
-
 template <typename Pattern>
 auto OptionalConvert(Pattern pattern) {
   return m::AnyOf<HloInstruction>(m::Convert(pattern), std::move(pattern));
@@ -98,29 +93,30 @@ std::optional<HloInstruction*> MatchSoftmax(HloInstruction* instr) {
   HloInstruction* right_producer;
 
   // Lower diamond
-  if (!Match(
-          instr,
-          m::Divide(
-              m::Exp(&left_exponential, m::Op()),
-              m::Broadcast(m::Reshape(m::Broadcast(OptionalConvert(m::Reshape(
-                  m::Reduce(
-                      OptionalConvert(m::Exp(&right_exponential, m::Op())),
-                      m::Op())
-                      .WithPredicate([](const HloInstruction* reduce) {
-                        HloComputation* reducer = reduce->to_apply();
-                        return (reducer->root_instruction()->opcode() ==
-                                    HloOpcode::kAdd &&
-                                reduce->dimensions().size() == 1 &&
-                                reduce->dimensions()[0] !=
-                                    reduce->shape().rank() - 1);
-                      })
-                      .WithOneUse())))))))) {
+  if (!Match(instr,
+             m::Divide(
+                 m::Exp(&left_exponential, m::Op()),
+                 m::Broadcast(m::Reshape(
+                     m::Broadcast(OptionalConvert(m::Reshape(OptionalConvert(
+                         m::Reduce(OptionalConvert(
+                                       m::Exp(&right_exponential, m::Op())),
+                                   m::Op())
+                             .WithPredicate([](const HloInstruction* reduce) {
+                               HloComputation* reducer = reduce->to_apply();
+                               return (reducer->root_instruction()->opcode() ==
+                                           HloOpcode::kAdd &&
+                                       reduce->dimensions().size() == 1 &&
+                                       reduce->dimensions()[0] !=
+                                           reduce->shape().rank() - 1);
+                             })
+                             .WithOneUse()))))))))) {
     return std::nullopt;
   }
 
   if (left_exponential != right_exponential ||
-      left_exponential->user_count() != 2)
+      left_exponential->user_count() != 2) {
     return std::nullopt;
+  }
 
   // Upper diamond
   if (!Match(left_exponential->mutable_operand(0),
@@ -143,10 +139,246 @@ std::optional<HloInstruction*> MatchSoftmax(HloInstruction* instr) {
     return std::nullopt;
   }
 
-  if (left_producer != right_producer || left_producer->user_count() != 2)
+  if (left_producer != right_producer || left_producer->user_count() != 2) {
     return std::nullopt;
+  }
 
   return left_producer;
+}
+
+auto MeanPattern(HloInstruction** input) {
+  return m::Reshape(
+      m::Convert(m::Divide(m::Reduce(m::Convert(m::Op(input)), m::Op()),
+                           m::Broadcast(m::Convert()))));
+}
+
+template <typename Pattern>
+auto Square(Pattern pattern) {
+  return m::Multiply()
+      .WithBinaryOperandsAnyOrder(pattern, pattern)
+      .WithPredicate([](const HloInstruction* instr) {
+        return instr->unique_operands().size() == 1;
+      });
+}
+
+std::optional<bool> MatchTFKerasLayerNorm(HloInstruction* instr,
+                                          HloInstruction** src,
+                                          HloInstruction** scale,
+                                          HloInstruction** bias, float* eps) {
+  // variance = Mean((X - Mean(x))^2)
+  // Z = scale / sqrt(variance + eps)
+  // LN(X) = X*Z + Bias - Mean(X)*Z
+
+  HloInstruction *src_a, *src_b, *src_c;
+  HloInstruction *bias_node, *scaled_norm_a, *scaled_norm_b, *mean0_a, *epsilon,
+      *sqrd_diff_mean, *scale_node, *sqrd_diff;
+
+  // First Match X*Z + Bias - Mean(X)*Z
+
+  if (!Match(
+          instr,
+          m::Add().WithBinaryOperandsAnyOrder(
+              m::Multiply()
+                  .WithBinaryOperandsAnyOrder(m::Op(src), m::Op(&scaled_norm_a))
+                  .WithOneUser(),
+              m::Subtract(m::Op(&bias_node),
+                          m::Multiply().WithBinaryOperandsAnyOrder(
+                              m::Broadcast(m::Reshape(m::Op(&mean0_a))),
+                              m::Op(&scaled_norm_b)))
+                  .WithOneUser()))) {
+    return std::nullopt;
+  }
+
+  if (scaled_norm_a != scaled_norm_b) return std::nullopt;
+
+  const Shape& src_shape = (*src)->shape();
+  if (!IsSupportedType(src_shape.element_type())) return std::nullopt;
+
+  // get bias
+  if (!Match(bias_node, m::Broadcast(m::Op(bias)))) return std::nullopt;
+
+  // Match Z = scale / sqrt(variance + eps)
+  if (!Match(scaled_norm_a,
+             m::Multiply().WithBinaryOperandsAnyOrder(
+                 m::Op(&scale_node),
+                 m::Broadcast(
+                     m::Reshape(m::Rsqrt(m::Add().WithBinaryOperandsAnyOrder(
+                         m::Broadcast(m::ConstantScalar(&epsilon)),
+                         m::Op(&sqrd_diff_mean)))))))) {
+    return std::nullopt;
+  }
+
+  // get epsilon
+  *eps = static_cast<float>(epsilon->literal().GetAsDouble({}).value());
+  // get scale
+  if (!Match(scale_node, m::Broadcast(m::Op(scale)))) return std::nullopt;
+
+  // match variance
+  if (!Match(sqrd_diff_mean, MeanPattern(&sqrd_diff))) return std::nullopt;
+
+  if (!Match(sqrd_diff, Square(m::Subtract(
+                            m::Op(&src_a),
+                            m::Broadcast(m::Reshape(MeanPattern(&src_b))))))) {
+    return std::nullopt;
+  }
+
+  if (src_a != src_b && src_a != *src) return std::nullopt;
+
+  // Match mean from Bias - Mean(X)*Z
+  if (!Match(mean0_a, MeanPattern(&src_c))) return std::nullopt;
+
+  if (src_c != *src) return std::nullopt;
+
+  return true;
+}
+
+bool MatchFlaxLayerNorm(HloInstruction* instr, HloInstruction** src,
+                        HloInstruction** scale, HloInstruction** bias,
+                        float* eps, bool* is_bf16orfp16_convert,
+                        bool* is_producer_bf16orfp16,
+                        HloInstruction** convert_instr) {
+  HloInstruction *prod_s, *hinge;
+  HloInstruction *div0, *div1, *div_red;
+  HloInstruction *mul_in0, *mul_in1, *main_pipe_mul_in0;
+  HloInstruction *reduce_in0, *epsilon;
+  HloInstruction *broadcast0, *broadcast1;
+
+  bool scaleFound = false;
+  bool shiftFound = false;
+
+  auto spine = m::Add().WithBinaryOperandsAnyOrder(
+      m::Broadcast(),
+      m::Multiply()
+          .WithBinaryOperandsAnyOrder(
+              m::Op(&hinge).WithOneUser(),
+              m::Subtract(
+                  OptionalConvert(m::Op(&prod_s)),
+                  m::Broadcast(
+                      m::Reshape(
+                          m::Broadcast(m::Reshape(m::Op(&div_red).WithOpcode(
+                                                      HloOpcode::kDivide))
+                                           .WithOneUser())
+                              .WithOneUser())
+                          .WithOneUser())
+                      .WithOneUser())
+                  .WithOneUser())
+          .WithOneUser());
+
+  if (!Match(instr, spine)) return false;
+
+  const Shape& prod_shape = prod_s->shape();
+  if (!IsSupportedType(prod_shape.element_type())) return false;
+
+  HloInstruction* shift = FindLayerNormShift(instr);
+  shiftFound = (shift != nullptr);
+
+  HloInstruction* scale_gamma = FindLayerNormScale(hinge);
+  scaleFound = (scale_gamma != nullptr);
+
+  // Currently patterns without scale and shift are
+  // not supported.
+  // OneDNN only supports 2 <= rank <= 5
+  if (!(prod_shape.rank() >= 2 && prod_shape.rank() <= 5) || !shiftFound ||
+      !scaleFound) {
+    return false;
+  }
+
+  // NOLINTBEGIN
+  auto main_pipeline = m::Multiply().WithBinaryOperandsAnyOrder(
+      m::Op(),
+      m::Broadcast(
+          m::Reshape(
+              m::Broadcast(
+                  m::Rsqrt(
+                      m::Add()
+                          .WithBinaryOperandsAnyOrder(
+                              m::Broadcast(m::ConstantScalar(&epsilon)),
+                              m::Reshape(
+                                  m::Maximum()
+                                      .WithBinaryOperandsAnyOrder(
+                                          m::Broadcast(),
+                                          m::Subtract(
+                                              m::Op(&div0).WithOpcode(
+                                                  HloOpcode::kDivide),
+                                              m::Multiply()
+                                                  .WithBinaryOperandsAnyOrder(
+                                                      m::Op(&main_pipe_mul_in0),
+                                                      m::Op(&div1).WithOpcode(
+                                                          HloOpcode::kDivide))
+                                                  .WithOneUser())
+                                              .WithOneUser())
+                                      .WithOneUser())
+                                  .WithOneUser())
+                          .WithOneUser())
+                      .WithOneUser())
+                  .WithOneUser())
+              .WithOneUser())
+          .WithOneUser());
+  // NOLINTEND
+
+  if (!Match(hinge, main_pipeline)) return false;
+
+  if ((div_red != div1) || (main_pipe_mul_in0 != div1)) return false;
+
+  auto div_red_mul_src =
+      m::Divide()
+          .WithOperand(0, m::Reduce(m::Multiply().WithBinaryOperandsAnyOrder(
+                                        OptionalConvert(m::Op(&mul_in0)),
+                                        OptionalConvert(m::Op(&mul_in1))),
+                                    m::Constant())
+                              .WithPredicate([](const HloInstruction* reduce) {
+                                HloComputation* reducer = reduce->to_apply();
+                                return (reducer->root_instruction()->opcode() ==
+                                            HloOpcode::kAdd &&
+                                        reduce->dimensions().size() == 1 &&
+                                        reduce->dimensions()[0] ==
+                                            reduce->shape().rank());
+                              }))
+          .WithOperand(1, m::Op(&broadcast0).WithOpcode(HloOpcode::kBroadcast))
+          .WithOneUser();
+
+  if (!Match(div0, div_red_mul_src)) return false;
+
+  if (mul_in0 != mul_in1) return false;
+
+  auto div_red_subgraph =
+      m::Divide()
+          .WithOperand(
+              0,
+              m::Reduce(OptionalConvert(m::Op(&reduce_in0)), m::Constant())
+                  .WithPredicate([](const HloInstruction* reduce) {
+                    HloComputation* reducer = reduce->to_apply();
+                    return (reducer->root_instruction()->opcode() ==
+                                HloOpcode::kAdd &&
+                            reduce->dimensions().size() == 1 &&
+                            reduce->dimensions()[0] == reduce->shape().rank());
+                  }))
+          .WithOperand(1, m::Op(&broadcast1).WithOpcode(HloOpcode::kBroadcast));
+
+  if (!Match(div1, div_red_subgraph)) return false;
+
+  if (broadcast1 != broadcast0 || reduce_in0 != mul_in0 || mul_in0 != prod_s) {
+    return false;
+  }
+
+  *is_producer_bf16orfp16 =
+      (prod_s->shape().element_type() == PrimitiveType::F16) ||
+      (prod_s->shape().element_type() == PrimitiveType::BF16);
+  if (instr->user_count() == 1 &&
+      instr->users().at(0)->opcode() == HloOpcode::kConvert) {
+    *convert_instr = instr->users().at(0);
+    *is_bf16orfp16_convert =
+        ((*convert_instr)->shape().element_type() == PrimitiveType::F16 ||
+         (*convert_instr)->shape().element_type() == PrimitiveType::BF16);
+  }
+
+  *src = prod_s;
+  *scale = scale_gamma;
+  *bias = shift;
+  // get epsilon
+  *eps = static_cast<float>(epsilon->literal().GetAsDouble({}).value());
+
+  return true;
 }
 
 }  // namespace
@@ -154,172 +386,41 @@ std::optional<HloInstruction*> MatchSoftmax(HloInstruction* instr) {
 class OneDnnOpsRewriterVisitor : public DfsHloRewriteVisitor {
  public:
   Status HandleAdd(HloInstruction* instr) override {
-    HloInstruction *slicemu1, *slicemu2;
-    HloInstruction *slicesource1, *slicesource2;
-    HloInstruction *musquare1, *musquare2;
-    HloInstruction *prod_c, *prod_l, *prod_s, *prod_r;
-    HloInstruction *slicevar, *hinge;
+    HloInstruction *src, *scale, *bias;
+    float eps;
+    bool found_ln = false;
+    bool is_bf16orfp16_convert = false;
+    bool is_producer_bf16orfp16 = false;
+    HloInstruction* convert_instr;
 
-    bool scaleFound = false;
-    bool shiftFound = false;
-
-    auto spine = m::Add().WithBinaryOperandsAnyOrder(
-        m::Broadcast(),
-        m::Multiply()
-            .WithBinaryOperandsAnyOrder(
-                m::Op(&hinge).WithOneUser(),
-                m::Subtract(
-                    m::Op(&prod_s),
-                    m::Broadcast(
-                        m::Reshape(
-                            m::Broadcast(
-                                m::Reshape(
-                                    m::Op(&slicemu1)
-                                        .WithOpcode(HloOpcode::kSlice)
-                                        .WithOperand(
-                                            0, m::Op(&slicesource1)
-                                                   .WithOpcode(
-                                                       HloOpcode::kDivide)))
-                                    .WithOneUser())
-                                .WithOneUser())
-                            .WithOneUser())
-                        .WithOneUser())
-                    .WithOneUser())
-            .WithOneUser());
-
-    if (!Match(instr, spine)) {
-      return OkStatus();
+    if (MatchTFKerasLayerNorm(instr, &src, &scale, &bias, &eps)) {
+      found_ln = true;
     }
 
-    const Shape& prod_shape = prod_s->shape();
-    if (!IsSupportedType(prod_shape.element_type())) return OkStatus();
-
-    HloInstruction* shift = FindLayerNormShift(instr);
-    shiftFound = (shift != nullptr);
-
-    HloInstruction* scale = FindLayerNormScale(hinge);
-    scaleFound = (scale != nullptr);
-
-    // Currently patterns without scale and shift are
-    // not supported.
-    // OneDNN only supports 2 <= rank <= 5
-    if (!(prod_shape.rank() >= 2 && prod_shape.rank() <= 5) || !shiftFound ||
-        !scaleFound) {
-      return OkStatus();
+    if (!found_ln) {
+      found_ln = MatchFlaxLayerNorm(instr, &src, &scale, &bias, &eps,
+                                    &is_bf16orfp16_convert,
+                                    &is_producer_bf16orfp16, &convert_instr);
     }
 
-    // NOLINTBEGIN
-    auto main_pipeline = m::Multiply().WithBinaryOperandsAnyOrder(
-        m::Op(),
-        m::Broadcast(
-            m::Reshape(
-                m::Broadcast(
-                    m::Rsqrt(
-                        m::Add()
-                            .WithBinaryOperandsAnyOrder(
-                                m::Broadcast(m::Constant()),
-                                m::Reshape(
-                                    m::Maximum()
-                                        .WithBinaryOperandsAnyOrder(
-                                            m::Broadcast(),
-                                            m::Subtract(
-                                                m::Reshape(
-                                                    m::Op(&slicevar)
-                                                        .WithOpcode(
-                                                            HloOpcode::kSlice)
-                                                        .WithOperand(
-                                                            0,
-                                                            m::Op(&slicesource2)
-                                                                .WithOpcode(
-                                                                    HloOpcode::
-                                                                        kDivide)))
-                                                    .WithOneUser(),
-                                                m::Multiply(
-                                                    m::Op(&musquare1),
-                                                    m::Op(&musquare2)
-                                                        .WithOperand(
-                                                            0,
-                                                            m::Op(&slicemu2)
-                                                                .WithOpcode(
-                                                                    HloOpcode::
-                                                                        kSlice)))
-                                                    .WithOneUser())
-                                                .WithOneUser())
-                                        .WithOneUser())
-                                    .WithOneUser())
-                            .WithOneUser())
-                        .WithOneUser())
-                    .WithOneUser())
-                .WithOneUser())
-            .WithOneUser());
-    // NOLINTEND
+    if (!found_ln) return OkStatus();
 
-    if (!Match(hinge, main_pipeline) || slicemu1 != slicemu2 ||
-        musquare1 != musquare2 || slicesource1 != slicesource2) {
-      return OkStatus();
-    }
+    const Shape& src_shape = src->shape();
 
-    // Check if the slices are compatible
-    if (!(absl::c_all_of(slicemu1->slice_starts(),
-                         [](int64_t i) { return i == 0; }) &&
-          absl::c_equal(slicemu1->slice_limits(),
-                        slicemu1->shape().dimensions())) &&
-        !(absl::c_all_of(slicevar->slice_starts(),
-                         [](int64_t i) { return i == 0; }) &&
-          absl::c_equal(slicevar->slice_limits(),
-                        slicevar->shape().dimensions()))) {
-      return OkStatus();
-    }
+    HloInstruction* ln_call =
+        instr->AddInstruction(HloInstruction::CreateCustomCall(
+            src_shape, {src, scale, bias}, "__onednn$layernorm"));
+    BackendConfig backend_config;
+    OneDnnLayerNormConfig* ln_config =
+        backend_config.mutable_onednn_layer_norm_config();
+    ln_config->set_fused_ops(OneDnnLayerNormConfig::SCALE_AND_SHIFT);
+    ln_config->set_epsilon_typecast(*(reinterpret_cast<int32_t*>(&eps)));
+    TF_RETURN_IF_ERROR(ln_call->set_backend_config(backend_config));
 
-    auto empirical_expectations = m::Divide(
-        m::Reduce(m::Concatenate()
-                      .WithBinaryOperandsAnyOrder(
-                          m::Reshape(m::Multiply(m::Op(&prod_l), m::Op(&prod_c))
-                                         .WithOneUser())
-                              .WithOneUser(),
-                          m::Reshape(m::Op(&prod_r)).WithOneUser())
-                      .WithPredicate([](const HloInstruction* comb) {
-                        return (comb->dimensions().size() == 1 &&
-                                comb->dimensions()[0] == 0 &&
-                                comb->shape().dimensions(0) == 2);
-                      })
-                      .WithOneUser(),
-                  m::Constant())
-            .WithPredicate([](const HloInstruction* reduce) {
-              HloComputation* reducer = reduce->to_apply();
-              return (reducer->root_instruction()->opcode() ==
-                          HloOpcode::kAdd &&
-                      reduce->dimensions().size() == 1 &&
-                      reduce->dimensions()[0] == reduce->shape().rank());
-            })
-            .WithOneUser(),
-        m::Broadcast(m::ConstantScalar().WithPredicate(
-            [orig = prod_s](const HloInstruction* divisor) {
-              std::optional<double> actual =
-                  static_cast<const HloConstantInstruction*>(divisor)
-                      ->literal()
-                      .GetAsDouble({});
-              return (actual.has_value() &&
-                      orig->shape().dimensions(orig->shape().rank() - 1) ==
-                          *actual);
-            })));
-
-    HloInstruction *src1, *src2;
-    if (Match(slicesource2, empirical_expectations) &&
-        // Float32 pattern check
-        ((prod_l == prod_c && prod_c == prod_r && prod_l == prod_s) ||
-         // Bfloat16 pattern check
-         (prod_l == prod_c && prod_c == prod_r &&
-          Match(prod_l, ConvertPattern(&src1)) &&
-          Match(prod_s, ConvertPattern(&src2)) && src1 == src2))) {
-      HloInstruction* ln_call =
-          instr->AddInstruction(HloInstruction::CreateCustomCall(
-              prod_shape, {prod_r, scale, shift}, "__onednn$layernorm"));
-      BackendConfig backend_config;
-      OneDnnLayerNormConfig* ln_config =
-          backend_config.mutable_onednn_layer_norm_config();
-      ln_config->set_fused_ops(OneDnnLayerNormConfig::SCALE_AND_SHIFT);
-      TF_RETURN_IF_ERROR(ln_call->set_backend_config(backend_config));
+    if (convert_instr != nullptr && is_bf16orfp16_convert &&
+        is_producer_bf16orfp16) {
+      TF_RETURN_IF_ERROR(ReplaceInstruction(convert_instr, ln_call));
+    } else {
       TF_RETURN_IF_ERROR(ReplaceInstruction(instr, ln_call));
     }
 
@@ -328,15 +429,22 @@ class OneDnnOpsRewriterVisitor : public DfsHloRewriteVisitor {
 
   Status HandleConvert(HloInstruction* instr) override {
     HloInstruction* ln_instr;
-    auto pattern = m::Convert(m::Op(&ln_instr)
-                                  .WithOneUser()
-                                  .WithOpcode(HloOpcode::kCustomCall)
-                                  .WithCustomCallTarget({"__onednn$layernorm"})
-                                  .WithElementType(PrimitiveType::F32))
-                       .WithElementType(PrimitiveType::BF16);
+    HloInstruction* convert_instr;
+    auto pattern =
+        m::Op(&convert_instr)
+            .WithOpcode(HloOpcode::kConvert)
+            .WithOperand(0, m::Op(&ln_instr)
+                                .WithOneUser()
+                                .WithOpcode(HloOpcode::kCustomCall)
+                                .WithCustomCallTarget({"__onednn$layernorm"})
+                                .WithElementType(PrimitiveType::F32));
 
     if (!IsSupportedType(instr->shape().element_type())) return OkStatus();
     if (Match(instr, pattern)) {
+      bool is_bf16orfp16_convert =
+          (convert_instr->shape().element_type() == PrimitiveType::BF16) ||
+          (convert_instr->shape().element_type() == PrimitiveType::F16);
+      if (!is_bf16orfp16_convert) return OkStatus();
       HloInstruction* producer = instr->mutable_operand(0)->mutable_operand(0);
       HloInstruction* newinp =
           producer->AddInstruction(HloInstruction::CreateConvert(

--- a/xla/tests/onednn_layer_norm_test.cc
+++ b/xla/tests/onednn_layer_norm_test.cc
@@ -23,9 +23,9 @@ namespace {
 
 class LayerNormTest : public HloTestBase {};
 
-TEST_F(LayerNormTest, SimpleTest) {
+TEST_F(LayerNormTest, LayerNormTest0_FP32) {
   const char* layer_norm_module_str = R"(
-  HloModule layer_norm.test, entry_computation_layout={(f32[4,1,256]{2,1,0}, f32[1,1,256]{2,1,0}, f32[1,1,256]{2,1,0})->f32[4,1,256]{2,1,0}}
+  HloModule layer_norm.test, entry_computation_layout={(f32[84,197,768]{2,1,0}, f32[768]{0}, f32[768]{0})->f32[84,197,768]{2,1,0}}
 
   region_add {
     Arg_0.7555 = f32[] parameter(0)
@@ -34,49 +34,49 @@ TEST_F(LayerNormTest, SimpleTest) {
   }
 
   ENTRY main {
-    Arg_0.1 = f32[4,1,256]{2,1,0} parameter(0), sharding={replicated}
-    Arg_0.2 = f32[1,1,256]{2,1,0} parameter(1), sharding={replicated}
-    Arg_0.3 = f32[1,1,256]{2,1,0} parameter(2), sharding={replicated}
-    reshape.9744 = f32[1,4,1,256]{3,2,1,0} reshape(Arg_0.1)
-    multiply.9743 = f32[4,1,256]{2,1,0} multiply(Arg_0.1, Arg_0.1)
-    reshape.9745 = f32[1,4,1,256]{3,2,1,0} reshape(multiply.9743)
-    concatenate.9746 = f32[2,4,1,256]{3,2,1,0} concatenate(reshape.9744, reshape.9745), dimensions={0}
-    constant.9731 = f32[] constant(0)
-    reduce.9747 = f32[2,4,1]{2,1,0} reduce(concatenate.9746, constant.9731), dimensions={3}, to_apply=region_add
-    constant.9729 = f32[] constant(256)
-    broadcast.9730 = f32[2,4,1]{2,1,0} broadcast(constant.9729), dimensions={}
-    divide.9748 = f32[2,4,1]{2,1,0} divide(reduce.9747, broadcast.9730)
-    slice.9749 = f32[1,4,1]{2,1,0} slice(divide.9748), slice={[0:1], [0:4], [0:1]}
-    reshape.9756 = f32[4,1,1]{2,1,0} reshape(slice.9749)
-    broadcast.9758 = f32[4,1,1]{2,1,0} broadcast(reshape.9756), dimensions={0,1,2}
-    reshape.9759 = f32[4,1]{1,0} reshape(broadcast.9758)
-    broadcast.9760 = f32[4,1,256]{2,1,0} broadcast(reshape.9759), dimensions={0,1}
-    subtract.9761 = f32[4,1,256]{2,1,0} subtract(Arg_0.1, broadcast.9760)
-    slice.9751 = f32[1,4,1]{2,1,0} slice(divide.9748), slice={[1:2], [0:4], [0:1]}
-    reshape.9752 = f32[4,1]{1,0} reshape(slice.9751)
-    reshape.9750 = f32[4,1]{1,0} reshape(slice.9749)
-    multiply.9753 = f32[4,1]{1,0} multiply(reshape.9750, reshape.9750)
-    subtract.9754 = f32[4,1]{1,0} subtract(reshape.9752, multiply.9753)
-    constant.9727 = f32[] constant(0)
-    broadcast.9728 = f32[4,1]{1,0} broadcast(constant.9727), dimensions={}
-    maximum.9755 = f32[4,1]{1,0} maximum(subtract.9754, broadcast.9728)
-    reshape.9757 = f32[4,1,1]{2,1,0} reshape(maximum.9755)
-    constant.9725 = f32[] constant(1e-05)
-    broadcast.9726 = f32[4,1,1]{2,1,0} broadcast(constant.9725), dimensions={}
-    add.9762 = f32[4,1,1]{2,1,0} add(reshape.9757, broadcast.9726)
-    rsqrt.9763 = f32[4,1,1]{2,1,0} rsqrt(add.9762)
-    broadcast.9764 = f32[4,1,1]{2,1,0} broadcast(rsqrt.9763), dimensions={0,1,2}
-    reshape.9765 = f32[4,1]{1,0} reshape(broadcast.9764)
-    broadcast.9766 = f32[4,1,256]{2,1,0} broadcast(reshape.9765), dimensions={0,1}
-    broadcast.9767 = f32[1,1,256]{2,1,0} broadcast(Arg_0.2), dimensions={0,1,2}
-    reshape.9768 = f32[1,256]{1,0} reshape(broadcast.9767)
-    broadcast.9769 = f32[4,1,256]{2,1,0} broadcast(reshape.9768), dimensions={1,2}
-    multiply.9770 = f32[4,1,256]{2,1,0} multiply(broadcast.9766, broadcast.9769)
-    multiply.9771 = f32[4,1,256]{2,1,0} multiply(subtract.9761, multiply.9770)
-    broadcast.9772 = f32[1,1,256]{2,1,0} broadcast(Arg_0.3), dimensions={0,1,2}
-    reshape.9773 = f32[1,256]{1,0} reshape(broadcast.9772)
-    broadcast.9774 = f32[4,1,256]{2,1,0} broadcast(reshape.9773), dimensions={1,2}
-    ROOT add.9775 = f32[4,1,256]{2,1,0} add(multiply.9771, broadcast.9774)
+    Arg_0.1 = f32[84,197,768]{2,1,0} parameter(0), sharding={replicated}
+    Arg_0.2 = f32[768]{0} parameter(1), sharding={replicated}
+    Arg_0.3 = f32[768]{0} parameter(2), sharding={replicated}
+
+    convert.290 = f32[84,197,768]{2,1,0} convert(Arg_0.1)
+    constant.291 = f32[] constant(0)
+    convert.292 = f32[] convert(constant.291)
+    reduce.297 = f32[84,197]{1,0} reduce(convert.290, convert.292), dimensions={2}, to_apply=region_add
+    constant.298 = s32[] constant(768)
+    convert.299 = f32[] convert(constant.298)
+    broadcast.300 = f32[84,197]{1,0} broadcast(convert.299), dimensions={}
+    divide.301 = f32[84,197]{1,0} divide(reduce.297, broadcast.300)
+    convert.302 = f32[84,197]{1,0} convert(divide.301)
+    reshape.303 = f32[84,197,1]{2,1,0} reshape(convert.302)
+    reshape.304 = f32[84,197]{1,0} reshape(reshape.303)
+    broadcast.305 = f32[84,197,768]{2,1,0} broadcast(reshape.304), dimensions={0,1}
+    subtract.306 = f32[84,197,768]{2,1,0} subtract(Arg_0.1, broadcast.305)
+    multiply.307 = f32[84,197,768]{2,1,0} multiply(subtract.306, subtract.306)
+    convert.308 = f32[84,197,768]{2,1,0} convert(multiply.307)
+    constant.309 = f32[] constant(0)
+    convert.310 = f32[] convert(constant.309)
+    reduce.315 = f32[84,197]{1,0} reduce(convert.308, convert.310), dimensions={2}, to_apply=region_add
+    constant.316 = s32[] constant(768)
+    convert.317 = f32[] convert(constant.316)
+    broadcast.318 = f32[84,197]{1,0} broadcast(convert.317), dimensions={}
+    divide.319 = f32[84,197]{1,0} divide(reduce.315, broadcast.318)
+    convert.320 = f32[84,197]{1,0} convert(divide.319)
+    reshape.321 = f32[84,197,1]{2,1,0} reshape(convert.320)
+    constant.322 = f32[] constant(1e-12)
+    broadcast.323 = f32[84,197,1]{2,1,0} broadcast(constant.322), dimensions={}
+    add.324 = f32[84,197,1]{2,1,0} add(reshape.321, broadcast.323)
+    rsqrt.325 = f32[84,197,1]{2,1,0} rsqrt(add.324)
+    reshape.328 = f32[84,197]{1,0} reshape(rsqrt.325)
+    broadcast.329 = f32[84,197,768]{2,1,0} broadcast(reshape.328), dimensions={0,1}
+    broadcast.327 = f32[84,197,768]{2,1,0} broadcast(Arg_0.2), dimensions={2}
+    multiply.330 = f32[84,197,768]{2,1,0} multiply(broadcast.329, broadcast.327)
+    multiply.331 = f32[84,197,768]{2,1,0} multiply(Arg_0.1, multiply.330)
+    broadcast.336 = f32[84,197,768]{2,1,0} broadcast(Arg_0.3), dimensions={2}
+    reshape.332 = f32[84,197]{1,0} reshape(reshape.303)
+    broadcast.333 = f32[84,197,768]{2,1,0} broadcast(reshape.332), dimensions={0,1}
+    multiply.334 = f32[84,197,768]{2,1,0} multiply(multiply.330, broadcast.333)
+    subtract.337 = f32[84,197,768]{2,1,0} subtract(broadcast.336, multiply.334)
+    ROOT add.338 = f32[84,197,768]{2,1,0} add(multiply.331, subtract.337)
   }  
 )";
 
@@ -92,66 +92,134 @@ TEST_F(LayerNormTest, SimpleTest) {
   )");
 }
 
-TEST_F(LayerNormTest, SimpleTestBF16) {
+TEST_F(LayerNormTest, LayerNormTest0_BF16) {
   const char* layer_norm_module_str = R"(
-  HloModule layer_norm_bf16.test, entry_computation_layout={(f32[768]{0}, f32[768]{0}, bf16[16,128,768]{2,1,0})->bf16[16,128,768]{2,1,0}}, allow_spmd_sharding_propagation_to_output={true}
+  HloModule layer_norm.test, entry_computation_layout={(bf16[84,197,768]{2,1,0}, f32[768]{0}, f32[768]{0})->bf16[84,197,768]{2,1,0}}
 
-  region_0.16 {
-    Arg_0.17 = f32[] parameter(0)
-    Arg_1.18 = f32[] parameter(1)
-    ROOT add.19 = f32[] add(Arg_0.17, Arg_1.18)
+  region_add {
+    Arg_0.7555 = f32[] parameter(0)
+    Arg_1.7556 = f32[] parameter(1)
+    ROOT add.7557 = f32[] add(Arg_0.7555, Arg_1.7556)
   }
 
-  ENTRY main.53 {
-    Arg_2.3 = bf16[16,128,768]{2,1,0} parameter(2), sharding={replicated}
-    convert.31 = f32[16,128,768]{2,1,0} convert(Arg_2.3)
-    convert.11 = f32[16,128,768]{2,1,0} convert(Arg_2.3)
-    reshape.13 = f32[1,16,128,768]{3,2,1,0} reshape(convert.11)
-    multiply.12 = f32[16,128,768]{2,1,0} multiply(convert.11, convert.11)
-    reshape.14 = f32[1,16,128,768]{3,2,1,0} reshape(multiply.12)
-    concatenate.15 = f32[2,16,128,768]{3,2,1,0} concatenate(reshape.13, reshape.14), dimensions={0}
-    constant.10 = f32[] constant(0)
-    reduce.20 = f32[2,16,128]{2,1,0} reduce(concatenate.15, constant.10), dimensions={3}, to_apply=region_0.16
-    constant.8 = f32[] constant(768)
-    broadcast.9 = f32[2,16,128]{2,1,0} broadcast(constant.8), dimensions={}
-    divide.21 = f32[2,16,128]{2,1,0} divide(reduce.20, broadcast.9)
-    slice.22 = f32[1,16,128]{2,1,0} slice(divide.21), slice={[0:1], [0:16], [0:128]}
-    reshape.29 = f32[16,128,1]{2,1,0} reshape(slice.22)
-    broadcast.32 = f32[16,128,1]{2,1,0} broadcast(reshape.29), dimensions={0,1,2}
-    reshape.33 = f32[16,128]{1,0} reshape(broadcast.32)
-    broadcast.34 = f32[16,128,768]{2,1,0} broadcast(reshape.33), dimensions={0,1}
-    subtract.35 = f32[16,128,768]{2,1,0} subtract(convert.31, broadcast.34)
-    slice.24 = f32[1,16,128]{2,1,0} slice(divide.21), slice={[1:2], [0:16], [0:128]}
-    reshape.25 = f32[16,128]{1,0} reshape(slice.24)
-    reshape.23 = f32[16,128]{1,0} reshape(slice.22)
-    multiply.26 = f32[16,128]{1,0} multiply(reshape.23, reshape.23)
-    subtract.27 = f32[16,128]{1,0} subtract(reshape.25, multiply.26)
-    constant.6 = f32[] constant(0)
-    broadcast.7 = f32[16,128]{1,0} broadcast(constant.6), dimensions={}
-    maximum.28 = f32[16,128]{1,0} maximum(subtract.27, broadcast.7)
-    reshape.30 = f32[16,128,1]{2,1,0} reshape(maximum.28)
-    constant.4 = f32[] constant(1e-06)
-    broadcast.5 = f32[16,128,1]{2,1,0} broadcast(constant.4), dimensions={}
-    add.36 = f32[16,128,1]{2,1,0} add(reshape.30, broadcast.5)
-    rsqrt.37 = f32[16,128,1]{2,1,0} rsqrt(add.36)
-    broadcast.39 = f32[16,128,1]{2,1,0} broadcast(rsqrt.37), dimensions={0,1,2}
-    reshape.40 = f32[16,128]{1,0} reshape(broadcast.39)
-    broadcast.41 = f32[16,128,768]{2,1,0} broadcast(reshape.40), dimensions={0,1}
-    Arg_1.2 = f32[768]{0} parameter(1), sharding={replicated}
-    reshape.38 = f32[1,1,768]{2,1,0} reshape(Arg_1.2)
-    broadcast.42 = f32[1,1,768]{2,1,0} broadcast(reshape.38), dimensions={0,1,2}
-    reshape.43 = f32[768]{0} reshape(broadcast.42)
-    broadcast.44 = f32[16,128,768]{2,1,0} broadcast(reshape.43), dimensions={2}
-    multiply.45 = f32[16,128,768]{2,1,0} multiply(broadcast.41, broadcast.44)
-    multiply.46 = f32[16,128,768]{2,1,0} multiply(subtract.35, multiply.45)
-    Arg_0.1 = f32[768]{0} parameter(0), sharding={replicated}
-    reshape.47 = f32[1,1,768]{2,1,0} reshape(Arg_0.1)
-    broadcast.48 = f32[1,1,768]{2,1,0} broadcast(reshape.47), dimensions={0,1,2}
-    reshape.49 = f32[768]{0} reshape(broadcast.48)
-    broadcast.50 = f32[16,128,768]{2,1,0} broadcast(reshape.49), dimensions={2}
-    add.51 = f32[16,128,768]{2,1,0} add(multiply.46, broadcast.50)
-    ROOT convert.52 = bf16[16,128,768]{2,1,0} convert(add.51)
+  ENTRY main {
+    Arg_0.1 = bf16[84,197,768]{2,1,0} parameter(0), sharding={replicated}
+    Arg_0.2 = f32[768]{0} parameter(1), sharding={replicated}
+    Arg_0.3 = f32[768]{0} parameter(2), sharding={replicated}
+
+    convert.289 = f32[84,197,768]{2,1,0} convert(Arg_0.1)
+    convert.290 = f32[84,197,768]{2,1,0} convert(convert.289)
+    constant.291 = f32[] constant(0)
+    convert.292 = f32[] convert(constant.291)
+    reduce.297 = f32[84,197]{1,0} reduce(convert.290, convert.292), dimensions={2}, to_apply=region_add
+    constant.298 = s32[] constant(768)
+    convert.299 = f32[] convert(constant.298)
+    broadcast.300 = f32[84,197]{1,0} broadcast(convert.299), dimensions={}
+    divide.301 = f32[84,197]{1,0} divide(reduce.297, broadcast.300)
+    convert.302 = f32[84,197]{1,0} convert(divide.301)
+    reshape.303 = f32[84,197,1]{2,1,0} reshape(convert.302)
+    reshape.304 = f32[84,197]{1,0} reshape(reshape.303)
+    broadcast.305 = f32[84,197,768]{2,1,0} broadcast(reshape.304), dimensions={0,1}
+    subtract.306 = f32[84,197,768]{2,1,0} subtract(convert.289, broadcast.305)
+    multiply.307 = f32[84,197,768]{2,1,0} multiply(subtract.306, subtract.306)
+    convert.308 = f32[84,197,768]{2,1,0} convert(multiply.307)
+    constant.309 = f32[] constant(0)
+    convert.310 = f32[] convert(constant.309)
+    reduce.315 = f32[84,197]{1,0} reduce(convert.308, convert.310), dimensions={2}, to_apply=region_add
+    constant.316 = s32[] constant(768)
+    convert.317 = f32[] convert(constant.316)
+    broadcast.318 = f32[84,197]{1,0} broadcast(convert.317), dimensions={}
+    divide.319 = f32[84,197]{1,0} divide(reduce.315, broadcast.318)
+    convert.320 = f32[84,197]{1,0} convert(divide.319)
+    reshape.321 = f32[84,197,1]{2,1,0} reshape(convert.320)
+    constant.322 = f32[] constant(1e-12)
+    broadcast.323 = f32[84,197,1]{2,1,0} broadcast(constant.322), dimensions={}
+    add.324 = f32[84,197,1]{2,1,0} add(reshape.321, broadcast.323)
+    rsqrt.325 = f32[84,197,1]{2,1,0} rsqrt(add.324)
+    reshape.328 = f32[84,197]{1,0} reshape(rsqrt.325)
+    broadcast.329 = f32[84,197,768]{2,1,0} broadcast(reshape.328), dimensions={0,1}
+    broadcast.327 = f32[84,197,768]{2,1,0} broadcast(Arg_0.2), dimensions={2}
+    multiply.330 = f32[84,197,768]{2,1,0} multiply(broadcast.329, broadcast.327)
+    multiply.331 = f32[84,197,768]{2,1,0} multiply(convert.289, multiply.330)
+    broadcast.336 = f32[84,197,768]{2,1,0} broadcast(Arg_0.3), dimensions={2}
+    reshape.332 = f32[84,197]{1,0} reshape(reshape.303)
+    broadcast.333 = f32[84,197,768]{2,1,0} broadcast(reshape.332), dimensions={0,1}
+    multiply.334 = f32[84,197,768]{2,1,0} multiply(multiply.330, broadcast.333)
+    subtract.337 = f32[84,197,768]{2,1,0} subtract(broadcast.336, multiply.334)
+    add.338 = f32[84,197,768]{2,1,0} add(multiply.331, subtract.337)
+    ROOT convert.339 = bf16[84,197,768]{2,1,0} convert(add.338)
+  }  
+)";
+
+  EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-2, 1e-2}));
+  MatchOptimizedHlo(layer_norm_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$layernorm",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "onednn_layer_norm_config":{
+  ; CHECK-DAG:       "fused_ops":"SCALE_AND_SHIFT"
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
+TEST_F(LayerNormTest, LayerNormTest0_FP16) {
+  const char* layer_norm_module_str = R"(
+  HloModule layer_norm.test, entry_computation_layout={(f16[84,197,768]{2,1,0}, f32[768]{0}, f32[768]{0})->f16[84,197,768]{2,1,0}}
+
+  region_add {
+    Arg_0.7555 = f32[] parameter(0)
+    Arg_1.7556 = f32[] parameter(1)
+    ROOT add.7557 = f32[] add(Arg_0.7555, Arg_1.7556)
   }
+
+  ENTRY main {
+    Arg_0.1 = f16[84,197,768]{2,1,0} parameter(0), sharding={replicated}
+    Arg_0.2 = f32[768]{0} parameter(1), sharding={replicated}
+    Arg_0.3 = f32[768]{0} parameter(2), sharding={replicated}
+
+    convert.289 = f32[84,197,768]{2,1,0} convert(Arg_0.1)
+    convert.290 = f32[84,197,768]{2,1,0} convert(convert.289)
+    constant.291 = f32[] constant(0)
+    convert.292 = f32[] convert(constant.291)
+    reduce.297 = f32[84,197]{1,0} reduce(convert.290, convert.292), dimensions={2}, to_apply=region_add
+    constant.298 = s32[] constant(768)
+    convert.299 = f32[] convert(constant.298)
+    broadcast.300 = f32[84,197]{1,0} broadcast(convert.299), dimensions={}
+    divide.301 = f32[84,197]{1,0} divide(reduce.297, broadcast.300)
+    convert.302 = f32[84,197]{1,0} convert(divide.301)
+    reshape.303 = f32[84,197,1]{2,1,0} reshape(convert.302)
+    reshape.304 = f32[84,197]{1,0} reshape(reshape.303)
+    broadcast.305 = f32[84,197,768]{2,1,0} broadcast(reshape.304), dimensions={0,1}
+    subtract.306 = f32[84,197,768]{2,1,0} subtract(convert.289, broadcast.305)
+    multiply.307 = f32[84,197,768]{2,1,0} multiply(subtract.306, subtract.306)
+    convert.308 = f32[84,197,768]{2,1,0} convert(multiply.307)
+    constant.309 = f32[] constant(0)
+    convert.310 = f32[] convert(constant.309)
+    reduce.315 = f32[84,197]{1,0} reduce(convert.308, convert.310), dimensions={2}, to_apply=region_add
+    constant.316 = s32[] constant(768)
+    convert.317 = f32[] convert(constant.316)
+    broadcast.318 = f32[84,197]{1,0} broadcast(convert.317), dimensions={}
+    divide.319 = f32[84,197]{1,0} divide(reduce.315, broadcast.318)
+    convert.320 = f32[84,197]{1,0} convert(divide.319)
+    reshape.321 = f32[84,197,1]{2,1,0} reshape(convert.320)
+    constant.322 = f32[] constant(1e-12)
+    broadcast.323 = f32[84,197,1]{2,1,0} broadcast(constant.322), dimensions={}
+    add.324 = f32[84,197,1]{2,1,0} add(reshape.321, broadcast.323)
+    rsqrt.325 = f32[84,197,1]{2,1,0} rsqrt(add.324)
+    reshape.328 = f32[84,197]{1,0} reshape(rsqrt.325)
+    broadcast.329 = f32[84,197,768]{2,1,0} broadcast(reshape.328), dimensions={0,1}
+    broadcast.327 = f32[84,197,768]{2,1,0} broadcast(Arg_0.2), dimensions={2}
+    multiply.330 = f32[84,197,768]{2,1,0} multiply(broadcast.329, broadcast.327)
+    multiply.331 = f32[84,197,768]{2,1,0} multiply(convert.289, multiply.330)
+    broadcast.336 = f32[84,197,768]{2,1,0} broadcast(Arg_0.3), dimensions={2}
+    reshape.332 = f32[84,197]{1,0} reshape(reshape.303)
+    broadcast.333 = f32[84,197,768]{2,1,0} broadcast(reshape.332), dimensions={0,1}
+    multiply.334 = f32[84,197,768]{2,1,0} multiply(multiply.330, broadcast.333)
+    subtract.337 = f32[84,197,768]{2,1,0} subtract(broadcast.336, multiply.334)
+    add.338 = f32[84,197,768]{2,1,0} add(multiply.331, subtract.337)
+    ROOT convert.339 = f16[84,197,768]{2,1,0} convert(add.338)
+  }  
 )";
 
   EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-2, 1e-2}));


### PR DESCRIPTION
This PR addresses following : 
1) Add support for FP16 to oneDNN softmax pattern matching
2) Adds another pattern for oneDNN layernorm based on keras layernorm operation
3) Fixes previous oneDNN layernorm pattern, as it was focused on flax layernorm pattern, which recently wen through an update while moment calculation
4) Adds FP16 support to oneDNN layernorm pattern matching.