### PR TITLE
Do not use Span for transient objects

### DIFF
--- a/xla/client/xla_builder_test.cc
+++ b/xla/client/xla_builder_test.cc
@@ -1743,6 +1743,7 @@ struct BinaryOpTestCase {
 constexpr absl::string_view kBroadcastDimensionMismatch =
     "Broadcast dimension 0 mismatch: 2 != -9223372036854775808; f32[2] and "
     "f32[?,10].";
+std::array<const int64_t, 1> zero_array = {0};
 
 class XlaBuilderUnboundedUnaryOpTest
     : public ::testing::TestWithParam<UnaryOpTestCase> {};
@@ -2381,28 +2382,28 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn<BinaryOpTestCase>({
         {"f32[1, ?, 2, ?, <=2, ?, ?]", "f32[?, 1, ?, 2, ?, <=2, ?]",
          /*broadcast_dimensions=*/{}, "f32[?, ?, 2, 2, <=2, <=2, ?]", &Add},
-        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/{0}, "f32[?, 10]",
-         &Add},
+        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/zero_array,
+         "f32[?, 10]", &Add},
         {"f32[1, ?, 2, ?, <=2, ?, ?]", "f32[?, 1, ?, 2, ?, <=2, ?]",
          /*broadcast_dimensions=*/{}, "f32[?, ?, 2, 2, <=2, <=2, ?]", &Div},
-        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/{0}, "f32[?, 10]",
-         &Div},
+        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/zero_array,
+         "f32[?, 10]", &Div},
         {"f32[1, ?, 2, ?, <=2, ?, ?]", "f32[?, 1, ?, 2, ?, <=2, ?]",
          /*broadcast_dimensions=*/{}, "f32[?, ?, 2, 2, <=2, <=2, ?]", &Max},
-        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/{0}, "f32[?, 10]",
-         &Max},
+        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/zero_array,
+         "f32[?, 10]", &Max},
         {"f32[1, ?, 2, ?, <=2, ?, ?]", "f32[?, 1, ?, 2, ?, <=2, ?]",
          /*broadcast_dimensions=*/{}, "f32[?, ?, 2, 2, <=2, <=2, ?]", &Mul},
-        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/{0}, "f32[?, 10]",
-         &Mul},
+        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/zero_array,
+         "f32[?, 10]", &Mul},
         {"f32[1, ?, 2, ?, <=2, ?, ?]", "f32[?, 1, ?, 2, ?, <=2, ?]",
          /*broadcast_dimensions=*/{}, "f32[?, ?, 2, 2, <=2, <=2, ?]", &Pow},
-        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/{0}, "f32[?, 10]",
-         &Pow},
+        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/zero_array,
+         "f32[?, 10]", &Pow},
         {"f32[1, ?, 2, ?, <=2, ?, ?]", "f32[?, 1, ?, 2, ?, <=2, ?]",
          /*broadcast_dimensions=*/{}, "f32[?, ?, 2, 2, <=2, <=2, ?]", &Sub},
-        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/{0}, "f32[?, 10]",
-         &Sub},
+        {"f32[?, 10]", "f32[1]", /*broadcast_dimensions=*/zero_array,
+         "f32[?, 10]", &Sub},
     }));
 
 }  // namespace

--- a/xla/service/shape_inference_test.cc
+++ b/xla/service/shape_inference_test.cc
@@ -49,6 +49,7 @@ constexpr absl::string_view kBroadcastDimensionMismatchErrorMessage =
     "Broadcast dimension 0 mismatch";
 constexpr absl::string_view kIncompatibleBinaryOpShapeErrorMessage =
     "Binary op with incompatible shapes";
+std::array<const int64_t, 1> zero_array = {0};
 
 class ShapeInferenceTest : public ::testing::Test {
  protected:
@@ -4540,12 +4541,9 @@ INSTANTIATE_TEST_SUITE_P(UnboundedDynamism, UnboundedAndOpShapeInferenceTest,
                               // ?   | ?   | []    | ?
                               {"s32[?]", "s32[?]", {}, "s32[?]"},
                               // 1   | ?,3 | [0]   | ?,3
-                              {"s32[1]", "s32[?,3]", {0}, "s32[?,3]"},
+                              {"s32[1]", "s32[?,3]", zero_array, "s32[?,3]"},
                               // 2   | ?,3 | [0]   | err
-                              {"s32[2]",
-                               "s32[?,3]",
-                               {0},
-                               "",
+                              {"s32[2]", "s32[?,3]", zero_array, "",
                                kBroadcastDimensionMismatchErrorMessage},
                               // ?,2 | ?,3 | []    | err
                               {"s32[?,2]",
@@ -4572,12 +4570,9 @@ INSTANTIATE_TEST_SUITE_P(UnboundedDynamism, UnboundedBinaryOpShapeInferenceTest,
                               // ?   | ?   | []    | ?
                               {"f32[?]", "f32[?]", {}, "f32[?]"},
                               // 1   | ?,3 | [0]   | ?,3
-                              {"f32[1]", "f32[?,3]", {0}, "f32[?,3]"},
+                              {"f32[1]", "f32[?,3]", zero_array, "f32[?,3]"},
                               // 2   | ?,3 | [0]   | err
-                              {"f32[2]",
-                               "f32[?,3]",
-                               {0},
-                               "",
+                              {"f32[2]", "f32[?,3]", zero_array, "",
                                kBroadcastDimensionMismatchErrorMessage},
                               // ?,2 | ?,3 | []    | err
                               {"f32[?,2]",
@@ -4605,12 +4600,9 @@ INSTANTIATE_TEST_SUITE_P(UnboundedDynamism,
                               // ?   | ?   | []    | ?
                               {"f32[?]", "f32[?]", {}, "pred[?]"},
                               // 1   | ?,3 | [0]   | ?,3
-                              {"f32[1]", "f32[?,3]", {0}, "pred[?,3]"},
+                              {"f32[1]", "f32[?,3]", zero_array, "pred[?,3]"},
                               // 2   | ?,3 | [0]   | err
-                              {"f32[2]",
-                               "f32[?,3]",
-                               {0},
-                               "",
+                              {"f32[2]", "f32[?,3]", zero_array, "",
                                kBroadcastDimensionMismatchErrorMessage},
                               // ?,2 | ?,3 | []    | err
                               {"f32[?,2]",


### PR DESCRIPTION
absl::Span does not extend the lifetime of an object so it cannot be used for transient objects, instead create the object first before using it.

Fixes issues caused by https://github.com/openxla/xla/commit/79c10a641dda6a6af0a44a112efa41ecb681c738