### PR TITLE
[XLA:GPU] add cuDNN FMHA variable sequence length support in thunk lowering

### DIFF
--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -48,7 +48,9 @@ absl::Status RunFusedMHA(GpufMHAParams params, se::Stream *stream,
                          DeviceMemoryBase mask_buffer,
                          DeviceMemoryBase bias_buffer,
                          DeviceMemoryBase scratch_memory,
-                         DeviceMemoryBase activation_output) {
+                         DeviceMemoryBase activation_output,
+                         DeviceMemoryBase seqlen_q,
+                         DeviceMemoryBase seqlen_k) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHAOp> *lazy_runner =
       options.runner_cache->AsFusedMHARunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHAOp>> local_runner;
@@ -91,7 +93,8 @@ absl::Status RunFusedMHA(GpufMHAParams params, se::Stream *stream,
                       lazy_runner->GetOrCreateRunner(config, stream));
   return (*runner)(stream, options.profile_result, scratch_memory,
                    lhs_bmm1_buffer, rhs_bmm1_buffer, rhs_bmm2_buffer,
-                   output_buffer, mask_buffer, bias_buffer, activation_output);
+                   output_buffer, mask_buffer, bias_buffer, activation_output,
+                   seqlen_q, seqlen_k);
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -112,6 +115,12 @@ absl::Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
   auto bias_buffer = params.bias_buffer.has_value()
                          ? se::DeviceMemory<BiasType>(*params.bias_buffer)
                          : se::DeviceMemoryBase();
+  auto seqlen_q_buffer = params.seqlen_q_buffer.has_value()
+                         ? se::DeviceMemory<BiasType>(*params.seqlen_q_buffer)
+                         : se::DeviceMemoryBase();
+  auto seqlen_k_buffer = params.seqlen_k_buffer.has_value()
+                         ? se::DeviceMemory<BiasType>(*params.seqlen_k_buffer)
+                         : se::DeviceMemoryBase();
   se::dnn::AlgorithmDesc algorithm = params.config->algorithm;
   if (options.runner_cache) {
     algorithm = options.runner_cache->ToAlgorithmDesc();
@@ -131,7 +140,8 @@ absl::Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
       run_status = RunFusedMHA<ElementType, BiasType, OutputType>(
           params, stream, options, lhs_bmm1_buffer, rhs_bmm1_buffer,
           rhs_bmm2_buffer, output_buffer, mask_buffer, bias_buffer,
-          scratch_memory, activation_buffer);
+          scratch_memory, activation_buffer, seqlen_q_buffer,
+          seqlen_k_buffer);
       break;
     default:
       return Internal("Invalid cuDNN fMHA kind");
@@ -217,7 +227,8 @@ absl::Status RunFusedMHABackward(
     DeviceMemoryBase softmax_buffer, DeviceMemoryBase d_Q_accum_buffer,
     DeviceMemoryBase mask_buffer, DeviceMemoryBase d_bias_buffer,
     DeviceMemoryBase fwd_output_buffer, DeviceMemoryBase bias_buffer,
-    DeviceMemoryBase scratch_memory) {
+    DeviceMemoryBase scratch_memory, DeviceMemoryBase seqlen_q,
+    DeviceMemoryBase seqlen_k) {
   se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp> *lazy_runner =
       options.runner_cache->AsFusedMHABackwardRunner();
   std::optional<se::dnn::LazyOpRunner<se::dnn::FusedMHABackwardOp>>
@@ -271,7 +282,8 @@ absl::Status RunFusedMHABackward(
                    d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
                    d_bmm2_rhs_buffer, d_s_buffer, softmax_buffer,
                    d_Q_accum_buffer, mask_buffer, d_bias_buffer,
-                   fwd_output_buffer, bias_buffer);
+                   fwd_output_buffer, bias_buffer, seqlen_q,
+                   seqlen_k);
   return absl::OkStatus();
 }
 
@@ -327,6 +339,14 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
                          ? se::DeviceMemory<BiasType>(*params.bias_buffer)
                          : se::DeviceMemoryBase();
 
+  auto seqlen_q_buffer = params.seqlen_q_buffer.has_value()
+                         ? se::DeviceMemory<BiasType>(*params.seqlen_q_buffer)
+                         : se::DeviceMemoryBase();
+
+  auto seqlen_k_buffer = params.seqlen_k_buffer.has_value()
+                         ? se::DeviceMemory<BiasType>(*params.seqlen_k_buffer)
+                         : se::DeviceMemoryBase();
+
   se::dnn::AlgorithmDesc algorithm = params.config->algorithm;
   if (options.runner_cache) {
     algorithm = options.runner_cache->ToAlgorithmDesc();
@@ -349,7 +369,7 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
           bmm2_grad_gemm2_rhs_buffer, d_output_buffer, d_bmm1_lhs_buffer,
           d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_s_buffer, softmax_sum_buffer,
           d_Q_accum_buffer, mask_buffer, d_bias_buffer, fwd_output_buffer,
-          bias_buffer, scratch_memory);
+          bias_buffer, scratch_memory, seqlen_q_buffer, seqlen_k_buffer);
       break;
     default:
       return Internal("Invalid cuDNN fMHA kind");
@@ -624,7 +644,9 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
     se::DeviceMemoryBase output_buffer,
     std::optional<se::DeviceMemoryBase> mask_buffer,
     std::optional<se::DeviceMemoryBase> bias_buffer,
-    std::optional<se::DeviceMemoryBase> activation_buffer) {
+    std::optional<se::DeviceMemoryBase> activation_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_k_buffer) {
   GpufMHAParams params;
   params.config = &config;
   params.lhs_bmm1_buffer = lhs_bmm1_buffer;
@@ -634,7 +656,8 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   params.activation_buffer = activation_buffer;
   params.mask_buffer = mask_buffer;
   params.bias_buffer = bias_buffer;
-
+  params.seqlen_q_buffer = seqlen_q_buffer;
+  params.seqlen_k_buffer = seqlen_k_buffer;
   return params;
 }
 
@@ -654,7 +677,9 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
     std::optional<se::DeviceMemoryBase> mask_buffer,
     std::optional<se::DeviceMemoryBase> d_bias_buffer,
     std::optional<se::DeviceMemoryBase> fwd_output_buffer,
-    std::optional<se::DeviceMemoryBase> bias_buffer) {
+    std::optional<se::DeviceMemoryBase> bias_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_k_buffer) {
   GpufMHABackwardParams params;
   params.config = &config;
   params.bmm1_grad_gemm1_rhs_buffer = bmm1_grad_gemm1_rhs_buffer;
@@ -672,6 +697,8 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   params.d_bias_buffer = d_bias_buffer;
   params.fwd_output_buffer = fwd_output_buffer;
   params.bias_buffer = bias_buffer;
+  params.seqlen_q_buffer = seqlen_q_buffer;
+  params.seqlen_k_buffer = seqlen_k_buffer;
   return params;
 }
 
@@ -684,12 +711,15 @@ absl::Status RunGpuFMHA(const GpufMHAConfig &fmha_config,
                         std::optional<se::DeviceMemoryBase> mask_buffer,
                         std::optional<se::DeviceMemoryBase> bias_buffer,
                         std::optional<se::DeviceMemoryBase> activation_buffer,
+                        std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+                        std::optional<se::DeviceMemoryBase> seqlen_k_buffer,
                         se::Stream *stream, RunFusedMHAOptions options) {
   TF_ASSIGN_OR_RETURN(
       GpufMHAParams params,
       GpufMHAParams::For(fmha_config, lhs_bmm1_buffer, rhs_bmm1_buffer,
                          rhs_bmm2_buffer, output_buffer, mask_buffer,
-                         bias_buffer, activation_buffer));
+                         bias_buffer, activation_buffer, seqlen_q_buffer,
+                         seqlen_k_buffer));
   PrimitiveType input_primitive_type = fmha_config.input_type;
   switch (input_primitive_type) {
     case F16:
@@ -721,8 +751,10 @@ absl::Status RunGpuFMHABackward(
     std::optional<se::DeviceMemoryBase> mask_buffer,
     std::optional<se::DeviceMemoryBase> d_bias_buffer,
     std::optional<se::DeviceMemoryBase> fwd_output_buffer,
-    std::optional<se::DeviceMemoryBase> bias_buffer, se::Stream *stream,
-    RunFusedMHABackwardOptions options) {
+    std::optional<se::DeviceMemoryBase> bias_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_k_buffer,
+    se::Stream *stream, RunFusedMHABackwardOptions options) {
   TF_ASSIGN_OR_RETURN(
       GpufMHABackwardParams params,
       GpufMHABackwardParams::For(
@@ -730,7 +762,8 @@ absl::Status RunGpuFMHABackward(
           bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
           d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
           d_bmm2_rhs_buffer, d_s_buffer, softmax_sum_buffer, d_Q_accum_buffer,
-          mask_buffer, d_bias_buffer, fwd_output_buffer, bias_buffer));
+          mask_buffer, d_bias_buffer, fwd_output_buffer, bias_buffer,
+          seqlen_q_buffer, seqlen_k_buffer));
   PrimitiveType input_primitive_type = fmha_config.input_type;
   switch (input_primitive_type) {
     case F16:

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -156,8 +156,7 @@ struct GpufMHAParams {
       std::optional<se::DeviceMemoryBase> bias_buffer,
       std::optional<se::DeviceMemoryBase> activation_buffer,
       std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
-      std::optional<se::DeviceMemoryBase> seqlen_k_buffer
-      );
+      std::optional<se::DeviceMemoryBase> seqlen_k_buffer);
 
   const GpufMHAConfig* config;  // Not owned
   se::DeviceMemoryBase lhs_bmm1_buffer;
@@ -420,8 +419,8 @@ absl::Status RunGpuFMHABackward(
     std::optional<se::DeviceMemoryBase> fwd_output_buffer,
     std::optional<se::DeviceMemoryBase> bias_buffer,
     std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
-    std::optional<se::DeviceMemoryBase> seqlen_k_buffer,
-    se::Stream* stream, RunFusedMHABackwardOptions = {});
+    std::optional<se::DeviceMemoryBase> seqlen_k_buffer, se::Stream* stream,
+    RunFusedMHABackwardOptions = {});
 
 std::string ToString(const GpufMHAConfig& config);
 

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -154,7 +154,10 @@ struct GpufMHAParams {
       se::DeviceMemoryBase rhs_bmm2_buffer, se::DeviceMemoryBase output_buffer,
       std::optional<se::DeviceMemoryBase> mask_buffer,
       std::optional<se::DeviceMemoryBase> bias_buffer,
-      std::optional<se::DeviceMemoryBase> activation_buffer);
+      std::optional<se::DeviceMemoryBase> activation_buffer,
+      std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+      std::optional<se::DeviceMemoryBase> seqlen_k_buffer
+      );
 
   const GpufMHAConfig* config;  // Not owned
   se::DeviceMemoryBase lhs_bmm1_buffer;
@@ -164,6 +167,8 @@ struct GpufMHAParams {
   std::optional<se::DeviceMemoryBase> activation_buffer;
   std::optional<se::DeviceMemoryBase> mask_buffer;
   std::optional<se::DeviceMemoryBase> bias_buffer;
+  std::optional<se::DeviceMemoryBase> seqlen_q_buffer;
+  std::optional<se::DeviceMemoryBase> seqlen_k_buffer;
 };
 
 struct GpufMHABackwardParams {
@@ -183,7 +188,9 @@ struct GpufMHABackwardParams {
       std::optional<se::DeviceMemoryBase> mask_buffer,
       std::optional<se::DeviceMemoryBase> d_bias_buffer,
       std::optional<se::DeviceMemoryBase> fwd_output_buffer,
-      std::optional<se::DeviceMemoryBase> bias_buffer);
+      std::optional<se::DeviceMemoryBase> bias_buffer,
+      std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+      std::optional<se::DeviceMemoryBase> seqlen_k_buffer);
 
   const GpufMHABackwardConfig* config;  // Not owned
   se::DeviceMemoryBase bmm1_grad_gemm1_rhs_buffer;
@@ -201,6 +208,8 @@ struct GpufMHABackwardParams {
   std::optional<se::DeviceMemoryBase> d_bias_buffer;
   std::optional<se::DeviceMemoryBase> fwd_output_buffer;
   std::optional<se::DeviceMemoryBase> bias_buffer;
+  std::optional<se::DeviceMemoryBase> seqlen_q_buffer;
+  std::optional<se::DeviceMemoryBase> seqlen_k_buffer;
 };
 
 class FusedMultiHeadedAttentionRunner {
@@ -389,6 +398,8 @@ absl::Status RunGpuFMHA(const GpufMHAConfig& fmha_config,
                         std::optional<se::DeviceMemoryBase> mask_buffer,
                         std::optional<se::DeviceMemoryBase> bias_buffer,
                         std::optional<se::DeviceMemoryBase> activation_buffer,
+                        std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+                        std::optional<se::DeviceMemoryBase> seqlen_k_buffer,
                         se::Stream* stream, RunFusedMHAOptions = {});
 
 absl::Status RunGpuFMHABackward(
@@ -407,8 +418,10 @@ absl::Status RunGpuFMHABackward(
     std::optional<se::DeviceMemoryBase> mask_buffer,
     std::optional<se::DeviceMemoryBase> d_bias_buffer,
     std::optional<se::DeviceMemoryBase> fwd_output_buffer,
-    std::optional<se::DeviceMemoryBase> bias_buffer, se::Stream* stream,
-    RunFusedMHABackwardOptions = {});
+    std::optional<se::DeviceMemoryBase> bias_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_q_buffer,
+    std::optional<se::DeviceMemoryBase> seqlen_k_buffer,
+    se::Stream* stream, RunFusedMHABackwardOptions = {});
 
 std::string ToString(const GpufMHAConfig& config);
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -969,12 +969,14 @@ absl::Status IrEmitterUnnested::EmitFusedMHAThunk(
       bias_shape = bias->shape();
     }
 
-    bool has_seqlen_qk = 2 == (instr->operand_count() - 3 - has_mask - has_bias);
+    bool has_seqlen_qk =
+        2 == (instr->operand_count() - 3 - has_mask - has_bias);
     int64_t seqlen_qk_operand_index = 2 + has_mask + has_bias;
     if (has_seqlen_qk) {
       const HloInstruction* seqlen_q = instr->operand(seqlen_qk_operand_index);
       TF_ASSIGN_OR_RETURN(seqlen_q_slice, GetAllocationSliceForHlo(seqlen_q));
-      const HloInstruction* seqlen_k = instr->operand(seqlen_qk_operand_index + 1);
+      const HloInstruction* seqlen_k =
+          instr->operand(seqlen_qk_operand_index + 1);
       TF_ASSIGN_OR_RETURN(seqlen_k_slice, GetAllocationSliceForHlo(seqlen_k));
     }
   }
@@ -1009,8 +1011,8 @@ absl::Status IrEmitterUnnested::EmitFusedMHAThunk(
   AddThunkToThunkSequence(std::make_unique<FusedMHAThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(instr), std::move(fmha_config),
       lhs_bmm1_slice, rhs_bmm1_slice, rhs_bmm2_slice, output_slice,
-      scratch_slice, mask_slice, bias_slice, activation_slice,
-      seqlen_q_slice, seqlen_k_slice));
+      scratch_slice, mask_slice, bias_slice, activation_slice, seqlen_q_slice,
+      seqlen_k_slice));
   return absl::OkStatus();
 }
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -969,8 +969,7 @@ absl::Status IrEmitterUnnested::EmitFusedMHAThunk(
       bias_shape = bias->shape();
     }
     int64_t seqlen_qk_operand_index = 3 + has_mask + has_bias;
-    bool has_seqlen_qk =
-        seqlen_qk_operand_index == instr->operand_count() - 2;
+    bool has_seqlen_qk = seqlen_qk_operand_index == instr->operand_count() - 2;
     if (has_seqlen_qk) {
       const HloInstruction* seqlen_q = instr->operand(seqlen_qk_operand_index);
       TF_ASSIGN_OR_RETURN(seqlen_q_slice, GetAllocationSliceForHlo(seqlen_q));

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -942,6 +942,7 @@ absl::Status IrEmitterUnnested::EmitFusedMHAThunk(
   TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
                       xla::gpu::GetCudnnfMHAKind(instr));
   BufferAllocation::Slice mask_slice, bias_slice;
+  BufferAllocation::Slice seqlen_q_slice, seqlen_k_slice;
   std::optional<Shape> mask_shape, bias_shape;
   {
     bool has_mask = kind == CudnnfMHAKind::kScaleMaskSoftmax ||
@@ -966,6 +967,15 @@ absl::Status IrEmitterUnnested::EmitFusedMHAThunk(
       const HloInstruction* bias = instr->operand(3);
       TF_ASSIGN_OR_RETURN(bias_slice, GetAllocationSliceForHlo(bias));
       bias_shape = bias->shape();
+    }
+
+    bool has_seqlen_qk = 2 == (instr->operand_count() - 3 - has_mask - has_bias);
+    int64_t seqlen_qk_operand_index = 2 + has_mask + has_bias;
+    if (has_seqlen_qk) {
+      const HloInstruction* seqlen_q = instr->operand(seqlen_qk_operand_index);
+      TF_ASSIGN_OR_RETURN(seqlen_q_slice, GetAllocationSliceForHlo(seqlen_q));
+      const HloInstruction* seqlen_k = instr->operand(seqlen_qk_operand_index + 1);
+      TF_ASSIGN_OR_RETURN(seqlen_k_slice, GetAllocationSliceForHlo(seqlen_k));
     }
   }
 
@@ -999,7 +1009,8 @@ absl::Status IrEmitterUnnested::EmitFusedMHAThunk(
   AddThunkToThunkSequence(std::make_unique<FusedMHAThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(instr), std::move(fmha_config),
       lhs_bmm1_slice, rhs_bmm1_slice, rhs_bmm2_slice, output_slice,
-      scratch_slice, mask_slice, bias_slice, activation_slice));
+      scratch_slice, mask_slice, bias_slice, activation_slice,
+      seqlen_q_slice, seqlen_k_slice));
   return absl::OkStatus();
 }
 
@@ -1079,6 +1090,15 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
     fwd_output_shape = instr->operand(input_index++)->shape();
   }
 
+  BufferAllocation::Slice seqlen_q_slice, seqlen_k_slice;
+  bool has_seqlen_qk = 2 == (instr->operand_count() - input_index);
+  if (has_seqlen_qk) {
+    const HloInstruction* seqlen_q = instr->operand(input_index);
+    TF_ASSIGN_OR_RETURN(seqlen_q_slice, GetAllocationSliceForHlo(seqlen_q));
+    const HloInstruction* seqlen_k = instr->operand(input_index + 1);
+    TF_ASSIGN_OR_RETURN(seqlen_k_slice, GetAllocationSliceForHlo(seqlen_k));
+    input_index += 2;
+  }
   TF_RET_CHECK(input_index == instr->operand_count());
 
   int output_index = 0;
@@ -1158,7 +1178,7 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
       bmm2_grad_gemm2_rhs_slice, d_output_slice, scratch_slice,
       d_bmm1_lhs_slice, d_bmm1_rhs_slice, d_bmm2_rhs_slice, d_s_slice,
       softmax_sum_slice, d_Q_accum_slice, mask_slice, d_bias_slice,
-      fwd_output_slice, bias_slice));
+      fwd_output_slice, bias_slice, seqlen_q_slice, seqlen_k_slice));
 
   return absl::OkStatus();
 }

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -968,10 +968,9 @@ absl::Status IrEmitterUnnested::EmitFusedMHAThunk(
       TF_ASSIGN_OR_RETURN(bias_slice, GetAllocationSliceForHlo(bias));
       bias_shape = bias->shape();
     }
-
+    int64_t seqlen_qk_operand_index = 3 + has_mask + has_bias;
     bool has_seqlen_qk =
-        2 == (instr->operand_count() - 3 - has_mask - has_bias);
-    int64_t seqlen_qk_operand_index = 2 + has_mask + has_bias;
+        seqlen_qk_operand_index == instr->operand_count() - 2;
     if (has_seqlen_qk) {
       const HloInstruction* seqlen_q = instr->operand(seqlen_qk_operand_index);
       TF_ASSIGN_OR_RETURN(seqlen_q_slice, GetAllocationSliceForHlo(seqlen_q));
@@ -1093,7 +1092,7 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
   }
 
   BufferAllocation::Slice seqlen_q_slice, seqlen_k_slice;
-  bool has_seqlen_qk = 2 == (instr->operand_count() - input_index);
+  bool has_seqlen_qk = input_index == instr->operand_count() - 2;
   if (has_seqlen_qk) {
     const HloInstruction* seqlen_q = instr->operand(input_index);
     TF_ASSIGN_OR_RETURN(seqlen_q_slice, GetAllocationSliceForHlo(seqlen_q));

--- a/xla/service/gpu/runtime/fused_mha_thunk.cc
+++ b/xla/service/gpu/runtime/fused_mha_thunk.cc
@@ -207,8 +207,8 @@ absl::Status FusedMHABackwardThunk::ExecuteOnStream(
       bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer, d_output_buffer,
       scratch_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer, d_bmm2_rhs_buffer,
       d_s_buffer, softmax_sum_buffer, d_Q_accum_buffer, mask_buffer,
-      d_bias_buffer, fwd_output_buffer, bias_buffer, seqlen_q_buffer_,
-      seqlen_k_buffer_, params.stream, opts));
+      d_bias_buffer, fwd_output_buffer, bias_buffer, seqlen_q_buffer,
+      seqlen_k_buffer, params.stream, opts));
   if (!params.stream->ok()) {
     return Internal("FusedMHABackwardThunk::ExecuteOnStream failed.");
   }

--- a/xla/service/gpu/runtime/fused_mha_thunk.cc
+++ b/xla/service/gpu/runtime/fused_mha_thunk.cc
@@ -29,7 +29,8 @@ FusedMHAThunk::FusedMHAThunk(
     BufferAllocation::Slice lhs_bmm1, BufferAllocation::Slice rhs_bmm1,
     BufferAllocation::Slice rhs_bmm2, BufferAllocation::Slice output,
     BufferAllocation::Slice scratch, BufferAllocation::Slice mask,
-    BufferAllocation::Slice bias, BufferAllocation::Slice activation)
+    BufferAllocation::Slice bias, BufferAllocation::Slice activation,
+    BufferAllocation::Slice seqlen_q, BufferAllocation::Slice seqlen_k)
     : Thunk(Kind::kFusedMHA, thunk_info),
       lhs_bmm1_buffer_(lhs_bmm1),
       rhs_bmm1_buffer_(rhs_bmm1),
@@ -39,6 +40,8 @@ FusedMHAThunk::FusedMHAThunk(
       mask_buffer_(mask),
       bias_buffer_(bias),
       activation_buffer_(activation),
+      seqlen_q_buffer_(seqlen_q),
+      seqlen_k_buffer_(seqlen_k),
       config_(std::move(config)) {}
 
 FusedMultiHeadedAttentionRunner& FusedMHAThunk::GetOrCreateRunner(
@@ -82,12 +85,16 @@ absl::Status FusedMHAThunk::ExecuteOnStream(const ExecuteParams& params) {
       AssignBufferIfNotNull(buffer_allocations, bias_buffer_);
   std::optional<se::DeviceMemoryBase> activation_buffer =
       AssignBufferIfNotNull(buffer_allocations, activation_buffer_);
-
+  std::optional<se::DeviceMemoryBase> seqlen_q_buffer =
+      AssignBufferIfNotNull(buffer_allocations, seqlen_q_buffer_);
+  std::optional<se::DeviceMemoryBase> seqlen_k_buffer =
+      AssignBufferIfNotNull(buffer_allocations, seqlen_k_buffer_);
   RunFusedMHAOptions opts;
   opts.runner_cache = &GetOrCreateRunner(params.stream);
   TF_RETURN_IF_ERROR(RunGpuFMHA(config_, lhs_bmm1_buffer, rhs_bmm1_buffer,
                                 rhs_bmm2_buffer, output_buffer, scratch_buffer,
                                 mask_buffer, bias_buffer, activation_buffer,
+                                seqlen_q_buffer, seqlen_k_buffer,
                                 params.stream, opts));
 
   if (!params.stream->ok()) {
@@ -106,7 +113,8 @@ FusedMHABackwardThunk::FusedMHABackwardThunk(
     BufferAllocation::Slice d_bmm2_rhs, BufferAllocation::Slice d_s,
     BufferAllocation::Slice softmax_sum, BufferAllocation::Slice d_Q_accum,
     BufferAllocation::Slice mask, BufferAllocation::Slice d_bias,
-    BufferAllocation::Slice fwd_output, BufferAllocation::Slice bias)
+    BufferAllocation::Slice fwd_output, BufferAllocation::Slice bias,
+    BufferAllocation::Slice seqlen_q, BufferAllocation::Slice seqlen_k)
     : Thunk(Kind::kFusedMHA, thunk_info),
       bmm1_grad_gemm1_rhs_buffer_(bmm1_grad_gemm1_rhs),
       bmm1_grad_gemm2_rhs_buffer_(bmm1_grad_gemm2_rhs),
@@ -124,6 +132,8 @@ FusedMHABackwardThunk::FusedMHABackwardThunk(
       d_bias_buffer_(d_bias),
       fwd_output_buffer_(fwd_output),
       bias_buffer_(bias),
+      seqlen_q_buffer_(seqlen_q),
+      seqlen_k_buffer_(seqlen_k),
       config_(std::move(config)) {}
 
 FusedMultiHeadedAttentionBackwardRunner&
@@ -185,7 +195,10 @@ absl::Status FusedMHABackwardThunk::ExecuteOnStream(
       AssignBufferIfNotNull(buffer_allocations, fwd_output_buffer_);
   std::optional<se::DeviceMemoryBase> bias_buffer =
       AssignBufferIfNotNull(buffer_allocations, bias_buffer_);
-
+  std::optional<se::DeviceMemoryBase> seqlen_q_buffer =
+      AssignBufferIfNotNull(buffer_allocations, seqlen_q_buffer_);
+  std::optional<se::DeviceMemoryBase> seqlen_k_buffer =
+      AssignBufferIfNotNull(buffer_allocations, seqlen_k_buffer_);
   RunFusedMHABackwardOptions opts;
 
   opts.runner_cache = &GetOrCreateRunner(params.stream);
@@ -195,7 +208,8 @@ absl::Status FusedMHABackwardThunk::ExecuteOnStream(
       bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer, d_output_buffer,
       scratch_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer, d_bmm2_rhs_buffer,
       d_s_buffer, softmax_sum_buffer, d_Q_accum_buffer, mask_buffer,
-      d_bias_buffer, fwd_output_buffer, bias_buffer, params.stream, opts));
+      d_bias_buffer, fwd_output_buffer, bias_buffer, seqlen_q_buffer_,
+      seqlen_k_buffer_, params.stream, opts));
   if (!params.stream->ok()) {
     return Internal("FusedMHABackwardThunk::ExecuteOnStream failed.");
   }

--- a/xla/service/gpu/runtime/fused_mha_thunk.cc
+++ b/xla/service/gpu/runtime/fused_mha_thunk.cc
@@ -91,11 +91,10 @@ absl::Status FusedMHAThunk::ExecuteOnStream(const ExecuteParams& params) {
       AssignBufferIfNotNull(buffer_allocations, seqlen_k_buffer_);
   RunFusedMHAOptions opts;
   opts.runner_cache = &GetOrCreateRunner(params.stream);
-  TF_RETURN_IF_ERROR(RunGpuFMHA(config_, lhs_bmm1_buffer, rhs_bmm1_buffer,
-                                rhs_bmm2_buffer, output_buffer, scratch_buffer,
-                                mask_buffer, bias_buffer, activation_buffer,
-                                seqlen_q_buffer, seqlen_k_buffer,
-                                params.stream, opts));
+  TF_RETURN_IF_ERROR(RunGpuFMHA(
+      config_, lhs_bmm1_buffer, rhs_bmm1_buffer, rhs_bmm2_buffer, output_buffer,
+      scratch_buffer, mask_buffer, bias_buffer, activation_buffer,
+      seqlen_q_buffer, seqlen_k_buffer, params.stream, opts));
 
   if (!params.stream->ok()) {
     return Internal("FusedMHAThunk::ExecuteOnStream failed.");

--- a/xla/service/gpu/runtime/fused_mha_thunk.h
+++ b/xla/service/gpu/runtime/fused_mha_thunk.h
@@ -46,7 +46,9 @@ class FusedMHAThunk : public Thunk {
                 BufferAllocation::Slice scratch_slice,
                 BufferAllocation::Slice mask_slice, /* may be null */
                 BufferAllocation::Slice bias_slice /* may be null */,
-                BufferAllocation::Slice activation_slice /* may be null */);
+                BufferAllocation::Slice activation_slice /* may be null */,
+                BufferAllocation::Slice seqlen_q_slice /* may be null */,
+                BufferAllocation::Slice seqlen_k_slice /* may be null */);
 
   FusedMHAThunk(const FusedMHAThunk&) = delete;
   FusedMHAThunk& operator=(const FusedMHAThunk&) = delete;
@@ -62,6 +64,8 @@ class FusedMHAThunk : public Thunk {
   BufferAllocation::Slice mask_buffer_;
   BufferAllocation::Slice bias_buffer_;
   BufferAllocation::Slice activation_buffer_;
+  BufferAllocation::Slice seqlen_q_buffer_;
+  BufferAllocation::Slice seqlen_k_buffer_;
 
   FusedMultiHeadedAttentionRunner& GetOrCreateRunner(
       const stream_executor::Stream* stream);
@@ -93,7 +97,9 @@ class FusedMHABackwardThunk : public Thunk {
                         BufferAllocation::Slice mask_slice,
                         BufferAllocation::Slice d_bias_slice,
                         BufferAllocation::Slice fwd_output_slice,
-                        BufferAllocation::Slice bias_slice);
+                        BufferAllocation::Slice bias_slice,
+                        BufferAllocation::Slice seqlen_q_slice,
+                        BufferAllocation::Slice seqlen_k_slice);
 
   FusedMHABackwardThunk(const FusedMHABackwardThunk&) = delete;
   FusedMHABackwardThunk& operator=(const FusedMHABackwardThunk&) = delete;
@@ -117,6 +123,8 @@ class FusedMHABackwardThunk : public Thunk {
   BufferAllocation::Slice d_bias_buffer_;
   BufferAllocation::Slice fwd_output_buffer_;
   BufferAllocation::Slice bias_buffer_;
+  BufferAllocation::Slice seqlen_q_buffer_;
+  BufferAllocation::Slice seqlen_k_buffer_;
 
   FusedMultiHeadedAttentionBackwardRunner& GetOrCreateRunner(
       const stream_executor::Stream* stream);

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -8217,7 +8217,7 @@ class CudnnExecutionPlanRunner<void(Args...)>
       data_ptrs_vec.pop_back();
     }
 
-    if (sizeof...(Args) == 7 || sizeof...(Args) == 15) {
+    if (sizeof...(Args) == 9 || sizeof...(Args) == 17) {
       // is attention fwd or bwd
       data_ptrs_vec.erase(
           std::remove(data_ptrs_vec.begin(), data_ptrs_vec.end(), nullptr),
@@ -8270,7 +8270,7 @@ class CudnnExecutionPlanRunner<void(Args...)>
     TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
                         GpuTimer::CreateIfNeeded(stream, is_profiling));
 
-    if (sizeof...(Args) == 15) {
+    if (sizeof...(Args) == 17) {
       // is training
       if (is_flash_attention_) {
         // should memset dq_accum because it is being atomic added

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -996,7 +996,9 @@ using FusedMHASignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
                                DeviceMemoryBase /* output_data */,
                                DeviceMemoryBase /* mask_data */,
                                DeviceMemoryBase /* bias_data */,
-                               DeviceMemoryBase /* activation_data */);
+                               DeviceMemoryBase /* activation_data */,
+                               DeviceMemoryBase /* seqlen_q_data */,
+                               DeviceMemoryBase /* seqlen_k_data */);
 using FusedMHARunner = OpRunner<FusedMHASignature>;
 
 using FusedMHABackwardSignature = void(
@@ -1011,7 +1013,8 @@ using FusedMHABackwardSignature = void(
     DeviceMemoryBase /* softmax_sum_data */,
     DeviceMemoryBase /* d_Q_accum_data */, DeviceMemoryBase /* mask_data */,
     DeviceMemoryBase /* d_bias_data */, DeviceMemoryBase /* fwd_output_data */,
-    DeviceMemoryBase /* bias_data */);
+    DeviceMemoryBase /* bias_data */, DeviceMemoryBase /* seqlen_q_data */,
+    DeviceMemoryBase /* seqlen_k_data */);
 using FusedMHABackwardRunner = OpRunner<FusedMHABackwardSignature>;
 
 // Describes the configuration for the algorithms that will used.


### PR DESCRIPTION
* cuDNN accepts two tensors seqlen_q and seqlen_k with size [batch, 1] which describes the number of non-padded token in each batch. This allows faster FMHA computation and padding mask generation inside cuDNN if needed.
* Currently not accessible through FMHA rewriter, accessible through JAX SDPA API.