### PR TITLE
[GPU] Add flag to monitor GPU memory usage

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -234,6 +234,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_p2p_max_nchannels(0);
 
   opts.set_xla_gpu_enable_mlir_emitters(false);
+  opts.set_xla_gpu_enable_memory_monitoring(false);
   return opts;
 }
 
@@ -1590,6 +1591,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_mlir_emitters),
       debug_options->xla_gpu_enable_mlir_emitters(),
       "Enable new MLIR-based emitters."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_memory_monitoring",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_memory_monitoring),
+      debug_options->xla_gpu_enable_memory_monitoring(),
+      "Enable GPU memory monitoring, which will log when the GPU memory usage "
+      "increases during runtime."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -80,6 +80,7 @@ cc_library(
         "//xla/service:shaped_buffer",
         "//xla/service:transfer_manager",
         "//xla/service/gpu:gpu_executable_run_options",
+        "//xla/service/gpu:memory_monitor",
         "//xla/stream_executor",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:device_memory",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -277,6 +277,20 @@ cc_library(
 )
 
 cc_library(
+    name = "memory_monitor",
+    srcs = ["memory_monitor.cc"],
+    hdrs = ["memory_monitor.h"],
+    deps = [
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "//xla/stream_executor",
+        "//xla:debug_options_flags",
+        "@tsl//tsl/platform:env",
+        "@tsl//tsl/util:env_var",
+    ],
+)
+
+cc_library(
     name = "ir_emitter_context",
     srcs = ["ir_emitter_context.cc"],
     hdrs = ["ir_emitter_context.h"],

--- a/xla/service/gpu/memory_monitor.cc
+++ b/xla/service/gpu/memory_monitor.cc
@@ -1,0 +1,72 @@
+/* Copyright 2019 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/memory_monitor.h"
+#include "xla/debug_options_flags.h"
+
+#include "absl/base/call_once.h"
+#include "tsl/platform/env.h"
+#include "tsl/util/env_var.h"
+
+namespace xla::gpu {
+
+static int UseMemoryMonitoring() {
+  return xla::GetDebugOptionsFromFlags().xla_gpu_enable_memory_monitoring();
+}
+
+static int64_t GetPollingFrequency() {
+  int64_t polling_frequency;
+  TF_CHECK_OK(
+      tsl::ReadInt64FromEnvVar("TF_GPU_MEM_MONITOR_POLL_FREQ_SECS", 10, &polling_frequency));
+  return polling_frequency;
+}
+
+void MemoryMonitorThread(const std::vector<se::StreamExecutor*> executors) {
+  if (!UseMemoryMonitoring()) return;
+  absl::once_flag log_failure_once;
+  std::vector<int64_t> peak_memory(executors.size(), 0);
+  int64_t polling_frequency = GetPollingFrequency();
+
+  while (true) {
+    absl::SleepFor(absl::Seconds(polling_frequency));
+    for (int i = 0; i < executors.size(); ++i) {
+      int device_ordinal = executors[i]->device_ordinal();
+      int64_t free_memory, total_memory;
+      if (!executors[i]->DeviceMemoryUsage(&free_memory, &total_memory)) {
+        absl::call_once(log_failure_once, [&] {
+          LOG(ERROR) << "Failed to query available memory for GPU "
+                     << device_ordinal;
+        });
+        continue;
+      }
+      int64_t used_memory = total_memory - free_memory;
+      if (used_memory > peak_memory[i]) {
+        peak_memory[i] = used_memory;
+        LOG(INFO) << "GPU Device " << device_ordinal << ": ("
+                  << (used_memory >> 20) << " MiB in-use / "
+                  << (total_memory >> 20) << " MiB total)";
+      }
+    }
+  }
+}
+
+void StartMemoryMonitor(const std::vector<se::StreamExecutor*> executors) {
+  static auto* monitor_thread = tsl::Env::Default()->StartThread(
+      tsl::ThreadOptions(), "gpu_memory_monitoring",
+      [executors]() { MemoryMonitorThread(executors); });
+  (void)monitor_thread;  // suppress unused variable warning
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/memory_monitor.h
+++ b/xla/service/gpu/memory_monitor.h
@@ -1,0 +1,29 @@
+/* Copyright 2019 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_MEMORY_MONITOR_H_
+#define XLA_SERVICE_GPU_MEMORY_MONITOR_H_
+
+#include <vector>
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/types.h"
+
+namespace xla::gpu {
+
+void StartMemoryMonitor(const std::vector<se::StreamExecutor*> executors);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_MEMORY_MONITOR_H_

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -704,7 +704,11 @@ message DebugOptions {
   // Let GEMM fusion autotuning probe cuDNN as a backend.
   bool xla_gpu_cudnn_gemm_fusion = 277;
 
-  // Next id: 279
+  // Enable GPU memory monitoring, which will log when the GPU memory usage
+  // increases during runtime.
+  bool xla_gpu_enable_memory_monitoring = 279;
+
+  // Next id: 280
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR adds the flag `--xla_gpu_memory_monitoring_level`. The default value is 0, which disables the feature.
A value of 1 will add warnings when GPU memory usage crosses 95% of the total available memory.
A value of 2 will additionally report the memory usage every 10 seconds.

Currently, the monitoring thread is created when the PJRT client is created. However if there is a better place to do this then any advice would be appreciated.