### PR TITLE
Fix pass names with spaces

### DIFF
--- a/xla/service/conditional_canonicalizer.h
+++ b/xla/service/conditional_canonicalizer.h
@@ -28,7 +28,7 @@ namespace xla {
 class ConditionalCanonicalizer : public HloModulePass {
  public:
   absl::string_view name() const override {
-    return "conditional canonicalizer";
+    return "conditional-canonicalizer";
   }
 
   using HloPassInterface::Run;

--- a/xla/service/dynamic_dimension_simplifier.h
+++ b/xla/service/dynamic_dimension_simplifier.h
@@ -27,7 +27,7 @@ namespace xla {
 class DynamicDimensionSimplifier : public HloModulePass {
  public:
   absl::string_view name() const override {
-    return "dynamic dimension simplifier";
+    return "dynamic-dimension-simplifier";
   }
 
   using HloPassInterface::Run;

--- a/xla/service/optimize_input_output_buffer_alias.h
+++ b/xla/service/optimize_input_output_buffer_alias.h
@@ -55,7 +55,7 @@ class OptimizeInputOutputBufferAlias : public HloModulePass {
   ~OptimizeInputOutputBufferAlias() override = default;
 
   absl::string_view name() const override {
-    return "optimize_input_output_buffer_alias.h";
+    return "optimize_input_output_buffer_alias";
   }
 
   using HloPassInterface::Run;


### PR DESCRIPTION
I found two passes which have spaces in their names. Usually passes use - or _ to separate words.

Also noticed that one pass has .h at the end of the name - fixed it too.