### PR TITLE
Add missing using HloPassInterface::Run

### DIFF
--- a/xla/service/change_op_data_type.h
+++ b/xla/service/change_op_data_type.h
@@ -63,6 +63,7 @@ class ChangeOpDataType : public HloModulePass {
   }
 
   absl::string_view name() const override { return "change-op-data-type"; }
+  using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;

--- a/xla/service/collective_transformation_reorderer.h
+++ b/xla/service/collective_transformation_reorderer.h
@@ -52,6 +52,7 @@ class CollectiveTransformationReorder : public HloModulePass {
         "collective-transformation-reorderer";
     return kName;
   }
+  using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;

--- a/xla/service/convert_mover.h
+++ b/xla/service/convert_mover.h
@@ -39,6 +39,7 @@ class ConvertMover : public HloModulePass {
   ConvertMover() = default;
 
   absl::string_view name() const override { return "convert-mover"; }
+  using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;

--- a/xla/service/gpu/address_computation_fusion_rewriter.h
+++ b/xla/service/gpu/address_computation_fusion_rewriter.h
@@ -76,6 +76,7 @@ class AddressComputationFusionRewriter : public HloModulePass {
   explicit AddressComputationFusionRewriter(std::string platform_name)
       : platform_name_(std::move(platform_name)) {}
 
+  using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;

--- a/xla/service/gpu/custom_kernel_fusion_rewriter.h
+++ b/xla/service/gpu/custom_kernel_fusion_rewriter.h
@@ -71,6 +71,7 @@ class CustomKernelFusionRewriter : public HloModulePass {
     return "custom-kernel-fusion-rewriter";
   }
 
+  using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;

--- a/xla/service/gpu/rename_fusions.h
+++ b/xla/service/gpu/rename_fusions.h
@@ -35,6 +35,7 @@ namespace gpu {
 
 class RenameFusions : public HloModulePass {
   absl::string_view name() const override { return "rename_fusions"; }
+  using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;

--- a/xla/service/gpu/scatter_slice_simplifier.h
+++ b/xla/service/gpu/scatter_slice_simplifier.h
@@ -47,6 +47,7 @@ class ScatterSliceSimplifier : public HloModulePass {
  public:
   absl::string_view name() const override { return "scatter-slice-simplifier"; }
 
+  using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;


### PR DESCRIPTION
Typical code template for new HLO Pass looks the following
```
class FooBar : public HloModulePass {
 public:
  absl::string_view name() const override { return "foo-bar"; }

  using HloPassInterface::Run;
  absl::StatusOr<bool> Run(
      HloModule* module,
      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
};
```

I found several passes which do not have `using HloPassInterface::Run;` line in its class decl. This PR fixes it.