### PR TITLE
[ROCM] fixing pmap failure on multiple gpus (forward convolution)

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -314,6 +314,9 @@ cc_library(
     name = "convolution_thunk",
     srcs = ["convolution_thunk.cc"],
     hdrs = ["convolution_thunk.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
     deps = [
         "//xla:util",
         "//xla/service:buffer_assignment",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -322,6 +322,7 @@ cc_library(
         "//xla/service:buffer_assignment",
         "//xla/service/gpu:gpu_conv_runner",
         "//xla/service/gpu:thunk",
+        "//xla/service/gpu:stream_executor_util",
         "//xla/stream_executor",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/xla/service/gpu/runtime/convolution_thunk.cc
+++ b/xla/service/gpu/runtime/convolution_thunk.cc
@@ -22,7 +22,9 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/gpu_conv_runner.h"
+#include "xla/service/gpu/stream_executor_util.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/scratch_allocator.h"
 #include "xla/util.h"
 
 namespace xla {
@@ -40,10 +42,11 @@ ConvolutionThunk::ConvolutionThunk(
       config_(std::move(config)) {}
 
 GenericConvRunner& ConvolutionThunk::GetOrCreateRunner(
-    const stream_executor::Stream* stream) {
+    const stream_executor::Stream* stream, bool *runner_created) {
   absl::MutexLock lock(&mu_);
   auto it = runner_cache_.find(stream);
-  if (it == runner_cache_.end()) {
+  *runner_created = (it == runner_cache_.end());
+  if (*runner_created) {
     it = runner_cache_
              .insert({stream, std::make_unique<GenericConvRunner>(config_)})
              .first;
@@ -68,8 +71,38 @@ absl::Status ConvolutionThunk::ExecuteOnStream(const ExecuteParams& params) {
   se::DeviceMemoryBase scratch =
       buffer_allocations.GetDeviceAddress(scratch_buffer_);
 
+  bool runner_created = false;
   RunConvOptions opts;
-  opts.runner_cache = &GetOrCreateRunner(params.stream);
+  opts.runner_cache = &GetOrCreateRunner(params.stream, &runner_created);
+
+#if TENSORFLOW_USE_ROCM
+  if(runner_created) {
+    TF_ASSIGN_OR_RETURN(
+      GpuConvParams conv_params,
+      GetGpuConvParams(config_, operand_se_buffers, result_se_buffers));
+
+    TF_ASSIGN_OR_RETURN(se::dnn::ConvolutionKind kind,
+                      GetDNNConvKindFromCudnnConvKind(config_.kind));
+
+    TF_ASSIGN_OR_RETURN(
+      se::dnn::DataType input_type,
+      GetDNNDataTypeFromPrimitiveType(config_.input_type));
+
+      TF_ASSIGN_OR_RETURN(auto dnn, 
+                      se::dnn::internal::GetDnnFromStream(params.stream));
+      se::OwningScratchAllocator<> scratch_allocator(
+                                   buffer_allocations.device_ordinal(),
+                                   buffer_allocations.memory_allocator());
+
+      std::vector<se::dnn::ProfileResult> profile_results;
+      dnn->GetMIOpenConvolveAlgorithms(
+           kind, input_type, params.stream, config_.input_descriptor, 
+           conv_params.input_buf, config_.filter_descriptor, 
+           conv_params.filter_buf, config_.output_descriptor, 
+           conv_params.output_buf, config_.conv_desc, 
+           &scratch_allocator, &profile_results);
+  }
+#endif // TENSORFLOW_USE_ROCM
 
   TF_RETURN_IF_ERROR(RunGpuConv(config_, absl::MakeSpan(operand_se_buffers),
                                 absl::MakeSpan(result_se_buffers), scratch,

--- a/xla/service/gpu/runtime/convolution_thunk.h
+++ b/xla/service/gpu/runtime/convolution_thunk.h
@@ -58,7 +58,8 @@ class ConvolutionThunk : public Thunk {
   std::vector<BufferAllocation::Slice> operand_buffers_;
   std::vector<BufferAllocation::Slice> result_buffers_;
   BufferAllocation::Slice scratch_buffer_;
-  GenericConvRunner& GetOrCreateRunner(const stream_executor::Stream* stream);
+  GenericConvRunner& GetOrCreateRunner(
+        const stream_executor::Stream* stream, bool *runner_created);
 
   // Convolution config
   const GpuConvConfig config_;


### PR DESCRIPTION
In this PR I fix [this issue](https://github.com/google/jax/issues/14582) for AMD GPUs.

The problem was that, in order to use MIOpen convolutions, previously one needs to call **GetMIOpenConvolveAlgorithms** to populate an intenal MIOpen cache of convolution invokers. So far this was implicitly done by conv_algorithm_picker.cc for **one stream executor** (single GPU). But when one tries to run it on multiple GPU devices, the above problem occurs.\

Note that, the fix applies to AMD GPUs only, hence no changes in behaviuor on CUDA side.

@xla-rotation: could you please take a look ?