### PR TITLE
[NVIDIA GPU] Unroll all nested loops for double buffering transformer

### DIFF
--- a/xla/service/gpu/loop_double_buffer_transformer.cc
+++ b/xla/service/gpu/loop_double_buffer_transformer.cc
@@ -152,9 +152,10 @@ absl::StatusOr<bool> LoopDoubleBufferTransformer::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   std::vector<HloInstruction*> while_instrs;
-  absl::c_copy_if(module->entry_computation()->instructions(),
-                  std::back_inserter(while_instrs),
-                  HloPredicateIsOp<HloOpcode::kWhile>);
+  for (auto comp : module->MakeNonfusionComputations()) {
+    absl::c_copy_if(comp->instructions(), std::back_inserter(while_instrs),
+                    HloPredicateIsOp<HloOpcode::kWhile>);
+  }
   VLOG(2) << "Processing " << while_instrs.size() << " while loops.";
 
   for (HloInstruction* while_instr : while_instrs) {

--- a/xla/service/gpu/loop_double_buffer_transformer_test.cc
+++ b/xla/service/gpu/loop_double_buffer_transformer_test.cc
@@ -470,6 +470,60 @@ ENTRY main {
   // associated computations.
   EXPECT_EQ(while_loops_callees.size(), 8);
 }
+
+TEST_F(GpuLoopDoubleBufferTransformerTest, NestedWhileLoopAreUnrolled) {
+  const char* const kModuleString = R"(
+HloModule loop_unrolling_nested_are_unrolled
+condition_nested {
+  input_tuple = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(input_tuple), index=0
+  trip_count = s32[] constant(10)
+  ROOT done = pred[] compare(cond, trip_count), direction=LT
+}
+body_nested {
+ input_tuple = (s32[]) parameter(0)
+ cond = s32[] get-tuple-element(input_tuple), index=0
+ one = s32[] constant(1)
+ cond_plus_1 = s32[] add(cond, one)
+ ROOT output = (s32[]) tuple(cond_plus_1)
+}
+condition {
+  input_tuple = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(input_tuple), index=0
+  trip_count = s32[] constant(10)
+  ROOT done = pred[] compare(cond, trip_count), direction=LT
+}
+body {
+  input_tuple = (s32[]) parameter(0)
+  ROOT output = (s32[]) while(input_tuple), condition=condition_nested, body=body_nested, backend_config={"known_trip_count":{"n":"11"}}
+}
+ENTRY main {
+ param_0 = (s32[]) parameter(0)
+ ROOT while = (s32[]) while(param_0), condition=condition, body=body, backend_config={"known_trip_count":{"n":"11"}}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                          ParseAndReturnVerifiedModule(kModuleString));
+  LoopDoubleBufferTransformer double_buffer;
+  EXPECT_THAT(double_buffer.Run(module.get()), IsOkAndHolds(true));
+
+  int64_t num_whiles = 0;
+  for (const HloComputation* computation : module->computations()) {
+    for (const HloInstruction* instr : computation->instructions()) {
+      if (instr->opcode() == HloOpcode::kWhile) {
+        // All loops in the module should be unrolled now and have trip count
+        // of 5.
+        EXPECT_EQ(instr->backend_config<WhileLoopBackendConfig>()
+                      ->known_trip_count()
+                      .n(),
+                  5);
+        ++num_whiles;
+      }
+    }
+  }
+  // We expect the number of while loops to be 4 in total after unrolling.
+  EXPECT_EQ(num_whiles, 4);
+}
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
The loop_double_buffer_transformer pass currently only unrolls the loops in the main computation.
There are some cases where the memcpies(which this pass is designed to eliminate) would exist in nested loops.
This pr changes the pass to look at all loops in the module include the nested ones and unroll them.