### PR TITLE
Add move assignment operator to Shape and ProgramShape

### DIFF
--- a/xla/shape.cc
+++ b/xla/shape.cc
@@ -38,6 +38,7 @@ Shape::~Shape() = default;
 Shape::Shape(const Shape&) = default;
 Shape::Shape(Shape&&) = default;
 Shape& Shape::operator=(const Shape&) = default;
+Shape& Shape::operator=(Shape&&) = default;
 
 Shape::Shape(const ShapeProto& shape_proto) {
   set_element_type(shape_proto.element_type());
@@ -260,6 +261,7 @@ ProgramShape::~ProgramShape() = default;
 ProgramShape::ProgramShape(const ProgramShape&) = default;
 ProgramShape::ProgramShape(ProgramShape&&) = default;
 ProgramShape& ProgramShape::operator=(const ProgramShape&) = default;
+ProgramShape& ProgramShape::operator=(ProgramShape&&) = default;
 
 ProgramShape::ProgramShape(const ProgramShapeProto& program_shape_proto) {
   for (const ShapeProto& shape_proto : program_shape_proto.parameters()) {

--- a/xla/shape.h
+++ b/xla/shape.h
@@ -44,6 +44,7 @@ class Shape {
   Shape(const Shape&);
   Shape(Shape&&);
   Shape& operator=(const Shape&);
+  Shape& operator=(Shape&&);
 
   // Construct a shape from a ShapeProto.
   explicit Shape(const ShapeProto& shape_proto);
@@ -375,6 +376,7 @@ class ProgramShape {
   ProgramShape(const ProgramShape&);
   ProgramShape(ProgramShape&&);
   ProgramShape& operator=(const ProgramShape&);
+  ProgramShape& operator=(ProgramShape&&);
 
   // Creates a ProgramShape from a ProgramShapeProto protobuf.
   explicit ProgramShape(const ProgramShapeProto& program_shape_proto);

--- a/xla/shape_util.h
+++ b/xla/shape_util.h
@@ -1130,7 +1130,7 @@ inline ShapeUtil::ForEachState::ForEachState(const Shape& s,
       minor_to_major(shape.layout().minor_to_major().data()),
       rank(LayoutUtil::MinorToMajor(shape).size()),
       indexes(b.begin(), b.end()),
-      indexes_ptr((rank == 0) ? nullptr : &indexes[0]),
+      indexes_ptr((rank == 0) ? nullptr : indexes.data()),
       indexes_span(indexes) {
   CHECK_EQ(shape.rank(), b.size());
   CHECK_EQ(i.size(), b.size());


### PR DESCRIPTION
The attempt to use `Shape` move assignment operator is found in [ShapeUtil::MakeProgramShape](https://github.com/openxla/xla/blob/main/xla/shape_util.cc#L278)
```
Shape result) {
  ...
  ProgramShape program_shape;
   ...
  *program_shape.mutable_result() = std::move(result);
  ...
```
Because `Shape` move assignment operator is currently not declared, C++ uses copy assignment operator which copies all Shape internal fields from src Shape (`result`) to dest Shape (`program_shape.result_`).