### PR TITLE
[ROCM] fixing collective ops tests

### DIFF
--- a/xla/tests/collective_ops_test.cc
+++ b/xla/tests/collective_ops_test.cc
@@ -480,7 +480,7 @@ XLA_TEST_F(CollectiveOpsTest, AllReduce_ThreeReplicaGroups) {
   TF_ASSERT_OK_AND_ASSIGN(
       std::vector<Literal> results,
       ExecuteReplicated(std::move(module), {&input_literal}, /*num_replicas=*/4,
-                        /*use_threads=*/true));
+                        /*use_threads=*/true, /*run_hlo_passes=*/true));
 
   ASSERT_EQ(results.size(), 4);
 
@@ -522,7 +522,7 @@ XLA_TEST_F(CollectiveOpsTest, AllReduce_Degenerate) {
   TF_ASSERT_OK_AND_ASSIGN(
       std::vector<Literal> results,
       ExecuteReplicated(std::move(module), {}, /*num_replicas=*/kNumReplicas,
-                        /*use_threads=*/true));
+                        /*use_threads=*/true, /*run_hlo_passes=*/true));
 
   ASSERT_EQ(results.size(), kNumReplicas);
   for (int i = 0; i < kNumReplicas; ++i) {
@@ -619,8 +619,8 @@ XLA_TEST_F(CollectiveOpsTest, ReplicaId) {
                           ParseAndReturnVerifiedModule(kModuleStr));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, num_devices_,
-                                            /*use_threads=*/true));
+            ExecuteReplicated(std::move(module), {}, num_devices_,
+                        /*use_threads=*/true, /*run_hlo_passes=*/true));
 
   ASSERT_EQ(results.size(), num_devices_);
   for (uint32_t i = 0; i < num_devices_; ++i) {
@@ -689,8 +689,8 @@ XLA_TEST_F(CollectiveOpsTest, CollectivePermute_Simple) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+               ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                            /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({11, 11}),
                                      results[0]));
@@ -724,8 +724,8 @@ XLA_TEST_F(CollectiveOpsTest, CollectivePermute_Degenerate) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+                   ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                                /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({10, 10}),
                                      results[0]));
@@ -758,8 +758,8 @@ XLA_TEST_F(CollectiveOpsTest, CollectivePermute_NotDegenerate) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+              ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                              /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({10, 10}),
                                      results[0]));
@@ -793,8 +793,8 @@ XLA_TEST_F(CollectiveOpsTest, CollectivePermute_Rotate) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+                 ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                               /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({13, 13}),
                                      results[0]));
@@ -870,8 +870,8 @@ XLA_TEST_F(CollectiveOpsTest, AllToAll_EmptyReplicaGroups) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+              ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                             /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({10, 15, 11, 16, 12, 17, 13, 18},
                                            results[0]);
@@ -914,8 +914,8 @@ XLA_TEST_F(CollectiveOpsTest, AllToAll_OrderedReplicaGroups) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+             ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                              /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({43, 48, 42, 47, 41, 46, 40, 45},
                                            results[0]);
@@ -952,8 +952,8 @@ XLA_TEST_F(CollectiveOpsTest, AllToAll_TwoReplicaGroups) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+              ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                              /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({23, 28, 20, 25}, results[0]);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({22, 27, 21, 26}, results[1]);
@@ -982,8 +982,8 @@ XLA_TEST_F(CollectiveOpsTest, DISABLED_ON_CPU(AllToAll_SplitDimension)) {
                           ParseAndReturnVerifiedModule(kModuleStr, config));
 
   TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
-                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
-                                            /*use_threads=*/true));
+            ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                           /*use_threads=*/true, /*run_hlo_passes=*/true));
   ASSERT_EQ(results.size(), kNumReplicas);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({10, 15, 11, 16, 12, 17, 13, 18},
                                            results[0]);

--- a/xla/tests/collective_ops_test_e2e.cc
+++ b/xla/tests/collective_ops_test_e2e.cc
@@ -78,6 +78,7 @@ class AsyncCollectiveOps : public CollectiveOpsTestE2E,
 
     // Enable or disable all async collectives based on test parameter.
     const bool enable_async = GetParam();
+    debug_options.set_xla_gpu_enable_async_collectives(false);
     debug_options.set_xla_gpu_enable_async_all_reduce(enable_async);
     debug_options.set_xla_gpu_enable_async_collective_broadcast(enable_async);
     debug_options.set_xla_gpu_enable_async_collective_permute(enable_async);


### PR DESCRIPTION
Here I fix collectives ops tests which were not taken care of for quite a some time.
- xla/tests/collective_ops_test_e2e: failed because collectives were made async by default in https://github.com/openxla/xla/commit/79ff5de7601d27e78fc1760b4ca20baded1f9139 while this test checks for sync/async collectives
- xla/tests/collective_ops_test: failed with errors like:
```
INTERNAL: Unsupported instruction opcode: collective-permute
``` 
because HLO passes were not run for a number of subtests. The point is we need [AsyncCollectiveCreator](https://github.com/ROCm/xla/blob/7ab393fc384651f367fdff4c3b1d5b1c4cbd9342/xla/service/gpu/gpu_compiler.cc#L1103) call in order to rewrite sync collectives into "start" and "done" pairs: e.g., collective-permute gets rewritten into 'collective-permute-start' and 'collective-permute-done'.

@xla-rotation: could you have a look, please ?
