### PR TITLE
Use vec.data() instead of &vec[0]

### DIFF
--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -4284,7 +4284,7 @@ static absl::StatusOr<bool> GenerateReduceOutputElement(
         // Periodically compute partial sum to avoid linear_indices getting
         // large
         computed_result += *input_arg0->GetSumAsDouble(
-            absl::MakeConstSpan(&linear_indices[0], n_linear_indices));
+            absl::MakeConstSpan(linear_indices, n_linear_indices));
         n_linear_indices = 0;
       }
       return true;
@@ -4294,7 +4294,7 @@ static absl::StatusOr<bool> GenerateReduceOutputElement(
     if (n_linear_indices > 0) {
       // Add in sum over any final indices collected
       computed_result += *input_arg0->GetSumAsDouble(
-          absl::MakeConstSpan(&linear_indices[0], n_linear_indices));
+          absl::MakeConstSpan(linear_indices, n_linear_indices));
     }
     TF_RETURN_IF_ERROR(results[0].SetFromDouble(output_index, computed_result));
     return true;

--- a/xla/parse_flags_from_env.cc
+++ b/xla/parse_flags_from_env.cc
@@ -210,7 +210,7 @@ bool ParseFlagsFromEnvAndIgnoreUnknown(
     }
   }
 
-  return tsl::Flags::Parse(&env_argv->argc, &env_argv->argv[0], flag_list);
+  return tsl::Flags::Parse(&env_argv->argc, env_argv->argv.data(), flag_list);
 }
 
 bool DieIfEnvHasUnknownFlagsLeft(absl::string_view envvar) {

--- a/xla/python/ifrt_proxy/integration_tests/mock_array_test.cc
+++ b/xla/python/ifrt_proxy/integration_tests/mock_array_test.cc
@@ -243,7 +243,7 @@ TEST_F(MockArrayTest, CopyToHostFutureWaitsUntilCopied) {
 
   char data[1000];
   auto copied = arr.proxy_client_array->CopyToHostBuffer(
-      &data[0], /*byte_strides=*/std::nullopt, ArrayCopySemantics::kAlwaysCopy);
+      data, /*byte_strides=*/std::nullopt, ArrayCopySemantics::kAlwaysCopy);
 
   absl::SleepFor(kSomeTime);
   EXPECT_FALSE(copied.IsReady());
@@ -263,7 +263,7 @@ TEST_F(MockArrayTest, CopyToHostFuturePropagatesError) {
 
   char data[1000];
   auto copied = arr.proxy_client_array->CopyToHostBuffer(
-      &data[0], /*byte_strides=*/std::nullopt, ArrayCopySemantics::kAlwaysCopy);
+      data, /*byte_strides=*/std::nullopt, ArrayCopySemantics::kAlwaysCopy);
 
   EXPECT_THAT(copied.Await(), StatusIs(kInternal));
 }

--- a/xla/service/cpu/runtime_fork_join.cc
+++ b/xla/service/cpu/runtime_fork_join.cc
@@ -97,8 +97,8 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_ParallelForkJoin(
   }
 
   // Call first compute function inline.
-  function(result_ptr, run_options_ptr, params, buffer_table, &statuses[0],
-           &partitions[0], prof_counters);
+  function(result_ptr, run_options_ptr, params, buffer_table, statuses.data(),
+           partitions, prof_counters);
   VLOG(3) << "ParallelForkJoin partition 0 done.";
   bc.Wait();
 

--- a/xla/service/gpu/cudnn_pad_for_convolutions.cc
+++ b/xla/service/gpu/cudnn_pad_for_convolutions.cc
@@ -388,7 +388,7 @@ absl::StatusOr<bool> TryResolvePaddedShapesForIntegerConvolution(
       case CudnnConvKind::kForward:
         CHECK_EQ(new_input_shapes.size(), 2);
         // Input feature maps
-        pad_dim(&new_input_shapes[0], dnums.input_feature_dimension(),
+        pad_dim(new_input_shapes.data(), dnums.input_feature_dimension(),
                 input_vect_size);
         // Kernel for the input feature maps
         pad_dim(&new_input_shapes[1], dnums.kernel_input_feature_dimension(),
@@ -404,7 +404,7 @@ absl::StatusOr<bool> TryResolvePaddedShapesForIntegerConvolution(
       case CudnnConvKind::kForwardActivation:
         CHECK(new_input_shapes.size() == 3 || new_input_shapes.size() == 4);
         // Input feature maps
-        pad_dim(&new_input_shapes[0], dnums.input_feature_dimension(),
+        pad_dim(new_input_shapes.data(), dnums.input_feature_dimension(),
                 input_vect_size);
         // Kernel for the input feature maps
         pad_dim(&new_input_shapes[1], dnums.kernel_input_feature_dimension(),

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -214,7 +214,7 @@ void FeedLLVMWithFlags(const std::vector<std::string>& cl_opts) {
   for (const std::string& cl_opt : cl_opts) {
     fake_argv.push_back(cl_opt.c_str());
   }
-  llvm::cl::ParseCommandLineOptions(fake_argv.size(), &fake_argv[0]);
+  llvm::cl::ParseCommandLineOptions(fake_argv.size(), fake_argv.data());
 }
 
 // Returns whether the module could use any device bitcode library functions.
@@ -794,7 +794,7 @@ absl::StatusOr<std::vector<uint8_t>> EmitModuleToHsaco(
 
   std::vector<uint8_t> hsaco(hsaco_file_size);
   hsaco_file.seekg(0, std::ios::beg);
-  hsaco_file.read(reinterpret_cast<char*>(&hsaco[0]), hsaco_file_size);
+  hsaco_file.read(reinterpret_cast<char*>(hsaco.data()), hsaco_file_size);
   hsaco_file.close();
   if (!keep_tempfiles) {
     remove(ir_path.c_str());

--- a/xla/service/hlo_ordering_test.cc
+++ b/xla/service/hlo_ordering_test.cc
@@ -283,7 +283,7 @@ TEST_F(HloOrderingTest, ValuesInWhileComputations) {
   ASSERT_EQ(dataflow->GetValueDefinedAt(xla_while).GetUses().size(), 1);
 
   const HloUse* while_use =
-      &dataflow->GetValueDefinedAt(xla_while).GetUses()[0];
+      dataflow->GetValueDefinedAt(xla_while).GetUses().data();
   EXPECT_EQ(while_use->instruction, add);
   EXPECT_TRUE(ordering.UsesBeforeValueDefinition(
       {&while_use, 1}, dataflow->GetValueDefinedAt(add), *dataflow));

--- a/xla/service/llvm_ir/llvm_command_line_options.h
+++ b/xla/service/llvm_ir/llvm_command_line_options.h
@@ -51,7 +51,7 @@ void InitializeLLVMCommandLineOptions(const T& options) {
       VLOG(2) << s;
     }
     llvm::cl::ParseCommandLineOptions(static_cast<int>(fake_argv.size()),
-                                      &fake_argv[0]);
+                                      fake_argv.data());
   }
 }
 

--- a/xla/service/service.cc
+++ b/xla/service/service.cc
@@ -470,7 +470,7 @@ absl::StatusOr<GlobalDataHandle> Service::ExecuteAndRegisterResult(
 
   if (options_.number_of_replicas() == 1) {
     TF_ASSIGN_OR_RETURN(auto result, executable->ExecuteOnStreamWrapper(
-                                         &run_options[0], arguments[0]));
+                                         run_options.data(), arguments[0]));
     return allocation_tracker_.Register(std::move(result), result_tag);
   }
 

--- a/xla/stream_executor/stream_executor_pimpl.h
+++ b/xla/stream_executor/stream_executor_pimpl.h
@@ -554,8 +554,7 @@ ScopedDeviceMemory<ElemT>::ScopedDeviceMemory(
     : ScopedDeviceMemory(parent, parent->AllocateArray<ElemT>(values.size())) {
   if (ptr() != nullptr) {
     std::vector<ElemT> local(values);
-    if (!parent->SynchronousMemcpy(ptr(), const_cast<const ElemT*>(&local[0]),
-                                   ptr()->size())) {
+    if (!parent->SynchronousMemcpy(ptr(), local.data(), ptr()->size())) {
       TF_CHECK_OK(Free());
     }
   }

--- a/xla/stream_executor/tpu/c_api_conversions.cc
+++ b/xla/stream_executor/tpu/c_api_conversions.cc
@@ -431,8 +431,8 @@ XLA_ShapeIndex ToC(const xla::ShapeIndex& xla_shape) {
 }
 
 xla::ShapeIndex FromC(XLA_ShapeIndex* c_shape) {
-  return xla::ShapeIndex(&c_shape->indices[0],
-                         &c_shape->indices[c_shape->count]);
+  return xla::ShapeIndex(c_shape->indices,
+                         c_shape->indices + c_shape->count);
 }
 
 void ToC(const xla::LiteralSlice& literal, XLA_Literal* c_literal) {

--- a/xla/stream_executor/tpu/tpu_initialize_util.cc
+++ b/xla/stream_executor/tpu/tpu_initialize_util.cc
@@ -98,7 +98,7 @@ bool IsTpuUsed(int64_t pid) {
     int64_t fd;
     if (!absl::SimpleAtoi(ent->d_name, &fd)) continue;
     path = absl::StrCat("/proc/", pid, "/fd/", fd);
-    if (!readlink(path.c_str(), &line[0], line.size())) continue;
+    if (!readlink(path.c_str(), line.data(), line.size())) continue;
     if (line != tpu_dev_path) continue;
     return true;
   }


### PR DESCRIPTION
I noticed that we use address of the first element of the vector to get pointer of the internal buffer - that is a known style "issue" in CodeChecker / clang-tidy. 

_'data' should be used for accessing the data pointer instead of taking the address of the 0-th element_

## readability-container-data-pointer
Finds cases where code could use data() rather than the address of the element at index 0 in a container. This pattern is commonly used to materialize a pointer to the backing data of a container. std::vector and std::string provide a data() accessor to retrieve the data pointer which should be preferred.

This also ensures that in the case that the container is empty, the data pointer access does not perform an errant memory access.

https://clang.llvm.org/extra/clang-tidy/checks/readability/container-data-pointer.html

