### PR TITLE
Fix use of bitwise and with boolean operands

### DIFF
--- a/xla/hlo/utils/hlo_sharding_util.cc
+++ b/xla/hlo/utils/hlo_sharding_util.cc
@@ -216,7 +216,7 @@ static bool IsLeafShardingMoreSpecific(const HloSharding& lhs,
   DCHECK(!lhs.IsTuple());
   DCHECK(!rhs.IsTuple());
   // Manual sharding is more specific than tile maximal sharding.
-  if (lhs.IsManualLeaf() & rhs.IsTileMaximalLeaf()) {
+  if (lhs.IsManualLeaf() && rhs.IsTileMaximalLeaf()) {
     return true;
   }
   if (lhs.IsManualLeaf() || rhs.IsManualLeaf()) {

--- a/xla/service/sharding_propagation.cc
+++ b/xla/service/sharding_propagation.cc
@@ -98,10 +98,10 @@ int MaskTupleShardingStrictlyBetter(const HloSharding& lhs,
     if (lhs_shard.IsTuple()) {
       mask |= MaskTupleShardingStrictlyBetter(lhs_shard, rhs_shard);
     } else {
-      if (lhs_shard.IsManualLeaf() & rhs_shard.IsTileMaximalLeaf()) {
+      if (lhs_shard.IsManualLeaf() && rhs_shard.IsTileMaximalLeaf()) {
         mask |= 1;
       }
-      if (rhs_shard.IsManualLeaf() & lhs_shard.IsTileMaximalLeaf()) {
+      if (rhs_shard.IsManualLeaf() && lhs_shard.IsTileMaximalLeaf()) {
         mask |= 2;
       }
     }
@@ -115,7 +115,7 @@ bool IsShardingStrictlyBetter(const HloSharding& lhs, const HloSharding& rhs) {
   if (lhs.IsTuple()) {
     return MaskTupleShardingStrictlyBetter(lhs, rhs) == 1;
   }
-  return lhs.IsManualLeaf() & rhs.IsTileMaximalLeaf();
+  return lhs.IsManualLeaf() && rhs.IsTileMaximalLeaf();
 }
 
 // Implementation for returning a improved sharding from another sharding.


### PR DESCRIPTION
Clang diagnostics reported `use of bitwise '&' with boolean operands` issue

[-Wbitwise-instead-of-logical](https://clang.llvm.org/docs/DiagnosticsReference.html#id82)

Diagnostic text: warning: use of bitwise '&' with boolean operands

