### PR TITLE
Split FP8 And Non-FP8 GEMM Rewriters

### DIFF
--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -475,8 +475,9 @@ auto OptionalBitcast(HloInstruction **optional_bitcast, Pattern pattern) {
 // when the output of the GEMM is requested in FP8 format.
 class GemmRewriterVisitor : public DfsHloRewriteVisitor {
  public:
-  explicit GemmRewriterVisitor(const se::GpuComputeCapability &gpu_version)
-      : gpu_version_(gpu_version) {}
+  explicit GemmRewriterVisitor(const se::GpuComputeCapability &gpu_version,
+                               const bool f8_rewrite)
+      : gpu_version_(gpu_version), f8_rewrite_(f8_rewrite) {}
 
   absl::Status HandleDot(HloInstruction *instr) override {
     if (!IsMatrixMultiplication(*instr) &&
@@ -523,17 +524,21 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     gemm_backend_config.set_lhs_stride(lhs_stride);
     gemm_backend_config.set_rhs_stride(rhs_stride);
 
-    // First try to match the fp8 gemm pattern.
-    TF_ASSIGN_OR_RETURN(bool supported_by_cublaslt,
-                        GemmIsSupportedByCublasLt(*instr, gemm_backend_config));
-    HloInstruction *a, *b, *a_scale = nullptr, *b_scale = nullptr;
-    // Sequence of ops between dequantization and GEMM which are mathematically
-    // commutative with dequantization. The second element of the pair gives the
-    // index of the operand identifying the next op in the sequence.
-    std::vector<std::pair<HloInstruction *, int>> a_ops, b_ops;
-    bool a_mult_scale{}, b_mult_scale{};
-    if (supported_by_cublaslt &&
-        Match(instr,
+    if (f8_rewrite_) {
+      // Rewrite FP8 GEMMs into a type-specific cublasLT Custom Call.
+      TF_ASSIGN_OR_RETURN(
+          bool supported_by_cublaslt,
+          GemmIsSupportedByCublasLt(*instr, gemm_backend_config));
+      HloInstruction *a, *b, *a_scale = nullptr, *b_scale = nullptr;
+      // Sequence of ops between dequantization and GEMM which are
+      // mathematically commutative with dequantization. The second element of
+      // the pair gives the index of the operand identifying the next op in the
+      // sequence.
+      std::vector<std::pair<HloInstruction *, int>> a_ops, b_ops;
+      bool a_mult_scale{}, b_mult_scale{};
+      if (supported_by_cublaslt &&
+          Match(
+              instr,
               m::Dot(m::Op().WithPredicate([&](const HloInstruction *instr) {
                 return IsSupportedF8Pattern(const_cast<HloInstruction *>(instr),
                                             a, a_scale, a_mult_scale, a_ops);
@@ -543,34 +548,31 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
                            const_cast<HloInstruction *>(instr), b, b_scale,
                            b_mult_scale, b_ops);
                      })))) {
-      TF_ASSIGN_OR_RETURN(
-          bool created_call,
-          CreateF8CustomCall(instr, gpu_backend_config, a, b, a_scale, b_scale,
-                             a_mult_scale, b_mult_scale, a_ops, b_ops));
-      if (created_call) {
-        return absl::OkStatus();
+        TF_RETURN_IF_ERROR(CreateF8CustomCall(instr, gpu_backend_config, a, b,
+                                              a_scale, b_scale, a_mult_scale,
+                                              b_mult_scale, a_ops, b_ops));
       }
-    }
+    } else {
+      // Rewrite non-FP8 GEMMs into a cublas or cublasLT Custom Call.
+      if (IsF8Type(instr->operand(0))) {
+        // FP8 rewriter couldn't rewrite dot with FP8 inputs into cublasLt
+        // custom call, so turn into an FP16 dot and below it will be rewritten
+        // as an FP16 cublas or cublasLt call.
+        TF_ASSIGN_OR_RETURN(instr, TurnF8DotIntoF16Dot(instr));
+      }
 
-    if (IsF8Type(instr->operand(0))) {
-      // Couldn't rewrite as an FP8 cublasLt custom call, so turn into an FP16
-      // dot and below it will be rewritten as an FP16 cublas or cublasLt call.
-      TF_ASSIGN_OR_RETURN(instr, TurnF8DotIntoF16Dot(instr));
+      TF_ASSIGN_OR_RETURN(
+          absl::string_view gemm_custom_call_target,
+          GetNonFp8GemmCustomCallTarget(*instr, gemm_backend_config));
+      const Shape &output_shape = instr->shape();
+      HloInstruction *gemm_call =
+          instr->AddInstruction(HloInstruction::CreateCustomCall(
+              output_shape,
+              {instr->mutable_operand(0), instr->mutable_operand(1)},
+              gemm_custom_call_target));
+      TF_RETURN_IF_ERROR(gemm_call->set_backend_config(gpu_backend_config));
+      TF_RETURN_IF_ERROR(ReplaceInstruction(instr, gemm_call));
     }
-
-    // Couldn't rewrite as an FP8 cublasLt custom call, rewrite as a cublas or
-    // cublasLt call.
-    TF_ASSIGN_OR_RETURN(
-        absl::string_view gemm_custom_call_target,
-        GetNonFp8GemmCustomCallTarget(*instr, gemm_backend_config));
-    const Shape &output_shape = instr->shape();
-    HloInstruction *gemm_call =
-        instr->AddInstruction(HloInstruction::CreateCustomCall(
-            output_shape,
-            {instr->mutable_operand(0), instr->mutable_operand(1)},
-            gemm_custom_call_target));
-    TF_RETURN_IF_ERROR(gemm_call->set_backend_config(gpu_backend_config));
-    TF_RETURN_IF_ERROR(ReplaceInstruction(instr, gemm_call));
     return absl::OkStatus();
   }
 
@@ -843,7 +845,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     return absl::OkStatus();
   }
 
-  absl::StatusOr<bool> CreateF8CustomCall(
+  absl::Status CreateF8CustomCall(
       HloInstruction *instr, GpuBackendConfig &gpu_backend_config,
       HloInstruction *a, HloInstruction *b, HloInstruction *a_scale,
       HloInstruction *b_scale, bool a_mult_scale, bool b_mult_scale,
@@ -859,12 +861,12 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     if (!cuda_compute_capability_.IsAtLeast(8, 9)) {
       VLOG(1)
           << "FP8 Custom Calls require Ada, Hopper, or later architectures.";
-      return false;
+      return absl::OkStatus();
     }
 #if CUDA_VERSION < 12000
     // FP8 GEMM kernels are only available with CUDA 12.0 and above
     VLOG(1) << "FP8 Custom Calls require CUDA 12.0 or newer.";
-    return false;
+    return absl::OkStatus();
 #endif  // CUDA_VERSION < 12000
 
     PrimitiveType a_type = a->shape().element_type();
@@ -877,7 +879,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
           << "Failed to rewrite " << instr->ToShortString()
           << " into FP8 Custom Call. The element type of one of the operands "
              "must be F8E4M3FN.";
-      return false;
+      return absl::OkStatus();
     }
     if ((a_type != F8E5M2 && a_type != F8E4M3FN) ||
         (b_type != F8E5M2 && b_type != F8E4M3FN)) {
@@ -886,7 +888,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
                  "F8E4M3FN, but got "
               << PrimitiveType_Name(a_type) << " and "
               << PrimitiveType_Name(b_type);
-      return false;
+      return absl::OkStatus();
     }
 
     absl::Span<const int64_t> batch_dims =
@@ -906,7 +908,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
           VLOG(1) << "Failed to rewrite " << instr->ToShortString()
                   << " into FP8 Custom Call. The scaling factors must be "
                      "scalars.";
-          return false;
+          return absl::OkStatus();
         }
         if (!mult_scale[i]) {
           inv_scales[i] = instr->AddInstruction(HloInstruction::CreateBinary(
@@ -934,7 +936,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
                 << " into FP8 Custom Call. Output element type must be "
                    "F8E4M3FN, F8E5M2, BF16, F16 or F32. Actual element type is "
                 << PrimitiveType_Name(instr->shape().element_type());
-        return false;
+        return absl::OkStatus();
     }
 
     // Each operand must have exactly one contracting and one non-contracting
@@ -949,7 +951,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       VLOG(1) << "Failed to rewrite " << instr->ToShortString()
               << " into FP8 Custom Call. A and B must have one contracting "
                  "dimension.";
-      return false;
+      return absl::OkStatus();
     }
     if ((a_ops.empty() ? a : a_ops.back().first)->shape().dimensions_size() -
                 batch_dims.size() !=
@@ -960,7 +962,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       VLOG(1) << "Failed to rewrite " << instr->ToShortString()
               << "into FP8 Custom Call. A and B must have one non-contracting "
                  "dimension.";
-      return false;
+      return absl::OkStatus();
     }
 
     // Sequentially apply the collected unary, dynamic-slice, pad and select ops
@@ -1077,9 +1079,9 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     TF_RETURN_IF_ERROR(
         ReplaceInstruction(instr, slice ? slice : new_custom_call));
     VLOG(1) << instr->ToString() << " rewritten into FP8 Custom Call.";
-    return true;
+    return absl::OkStatus();
 #else  // TENSORFLOW_USE_ROCM
-    return false;
+    return absl::OkStatus();
 #endif
   }
 
@@ -1580,6 +1582,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
  private:
   se::GpuComputeCapability gpu_version_;
+  bool f8_rewrite_;
 
   // Choose cublas or cublasLt for the target of the custom call that instr will
   // be rewritten into.
@@ -2051,8 +2054,9 @@ class GemmWorkspaceRewriteVisitor : public DfsHloRewriteVisitor {
 };
 
 absl::StatusOr<bool> RunOnComputation(HloComputation *computation,
-                                      se::GpuComputeCapability gpu_version) {
-  GemmRewriterVisitor visitor(gpu_version);
+                                      se::GpuComputeCapability gpu_version,
+                                      bool f8_rewrite) {
+  GemmRewriterVisitor visitor(gpu_version, f8_rewrite);
   TF_RETURN_IF_ERROR(computation->Accept(&visitor));
   GemmWorkspaceRewriteVisitor workspace_visitor(gpu_version);
   TF_RETURN_IF_ERROR(computation->Accept(&workspace_visitor));
@@ -2061,8 +2065,9 @@ absl::StatusOr<bool> RunOnComputation(HloComputation *computation,
 
 }  // anonymous namespace
 
-GemmRewriter::GemmRewriter(se::GpuComputeCapability gpu_version)
-    : gpu_version_(gpu_version) {}
+GemmRewriter::GemmRewriter(se::GpuComputeCapability gpu_version,
+                           bool f8_rewrite)
+    : gpu_version_(gpu_version), f8_rewrite_(f8_rewrite) {}
 
 absl::StatusOr<bool> GemmRewriter::Run(
     HloModule *module,
@@ -2070,8 +2075,8 @@ absl::StatusOr<bool> GemmRewriter::Run(
   bool changed = false;
   for (HloComputation *computation :
        module->MakeNonfusionComputations(execution_threads)) {
-    TF_ASSIGN_OR_RETURN(bool result,
-                        RunOnComputation(computation, gpu_version_));
+    TF_ASSIGN_OR_RETURN(
+        bool result, RunOnComputation(computation, gpu_version_, f8_rewrite_));
     changed |= result;
   }
   return changed;

--- a/xla/service/gpu/gemm_rewriter.h
+++ b/xla/service/gpu/gemm_rewriter.h
@@ -45,6 +45,8 @@ namespace gpu {
 // stored in the backend config.
 class GemmRewriter : public HloModulePass {
  public:
+  // When f8_rewrite is true, only FP8 GEMMs are rewritten. Otherwise, non-FP8
+  // GEMMs are rewritten.
   explicit GemmRewriter(se::GpuComputeCapability gpu_version,
                         bool f8_rewrite = false);
   absl::string_view name() const override { return "cublas-gemm-rewriter"; }

--- a/xla/service/gpu/gemm_rewriter.h
+++ b/xla/service/gpu/gemm_rewriter.h
@@ -45,7 +45,8 @@ namespace gpu {
 // stored in the backend config.
 class GemmRewriter : public HloModulePass {
  public:
-  explicit GemmRewriter(se::GpuComputeCapability gpu_version);
+  explicit GemmRewriter(se::GpuComputeCapability gpu_version,
+                        bool f8_rewrite = false);
   absl::string_view name() const override { return "cublas-gemm-rewriter"; }
 
   using HloPassInterface::Run;
@@ -55,6 +56,7 @@ class GemmRewriter : public HloModulePass {
 
  private:
   se::GpuComputeCapability gpu_version_;
+  bool f8_rewrite_;
 };
 
 }  // namespace gpu

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1380,7 +1380,8 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
         gpu_target_config.device_description.gpu_compute_capability();
     const auto* cuda_cc = std::get_if<se::CudaComputeCapability>(&gpu_version);
 
-    // Rewrite FP8 GEMMs ahead of Triton.
+    // Rewrite FP8 GEMMs ahead of Triton which currently lacks support for FP8
+    // and may rewrite quantized FP8 GEMMs as higher-precision GEMMs.
     pipeline.AddPass<GemmRewriter>(gpu_version, /*f8_rewrite=*/true);
     if (debug_options.xla_gpu_enable_triton_gemm() && cuda_cc != nullptr &&
         cuda_cc->IsAtLeast(se::CudaComputeCapability::VOLTA)) {

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1379,11 +1379,15 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
     se::GpuComputeCapability gpu_version =
         gpu_target_config.device_description.gpu_compute_capability();
     const auto* cuda_cc = std::get_if<se::CudaComputeCapability>(&gpu_version);
+
+    // Rewrite FP8 GEMMs ahead of Triton.
+    pipeline.AddPass<GemmRewriter>(gpu_version, /*f8_rewrite=*/true);
     if (debug_options.xla_gpu_enable_triton_gemm() && cuda_cc != nullptr &&
         cuda_cc->IsAtLeast(se::CudaComputeCapability::VOLTA)) {
       pipeline.AddPass<GemmRewriterTriton>(gpu_version);
     }
-    pipeline.AddPass<GemmRewriter>(gpu_version);
+    // Rewrite non-FP8 GEMMs.
+    pipeline.AddPass<GemmRewriter>(gpu_version, /*f8_rewrite=*/false);
 
     // Rewrite GEMMs with broadcasted inputs as strided GEMMs.
     pipeline.AddPass<GemmBroadcastFoldingRewriter>();


### PR DESCRIPTION
Separates the rewriters for FP8 and non-FP8 GEMMs and moves the rewrite of FP8 GEMMs ahead of the Triton GEMM rewriter.