### PR TITLE
Handle missing collective_permute in collective-permute-motion

### DIFF
--- a/xla/service/spmd/collective_permute_motion.cc
+++ b/xla/service/spmd/collective_permute_motion.cc
@@ -129,6 +129,9 @@ std::optional<MovableCluster> FindMovableClusterAtBodyRoot(
       }
     }
   }
+  if (cluster.collective_permute == nullptr) {
+    return std::nullopt;
+  }
   return cluster;
 }
 


### PR DESCRIPTION
Currently, the `MoveCollectivePermutes` function expects that if `FindMovableClusterAtBodyRoot` function returns a cluster, then the cluster's `collective_permute` field is not null. However, if `FindMovableClusterAtBodyRoot` does not find a collective_permute on when traversing an input, it happily returns cluster with `collective_permute == null`. This patch just returns `nullopt` for a 'cluster' without collective-permute.

Fixes #10394.