### PR TITLE
Fixes type annotation overload of `dlpack_managed_tensor_to_buffer` in `python/xla_extension` 

### DIFF
--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -696,8 +696,15 @@ class DeviceTopology:
 def buffer_to_dlpack_managed_tensor(
     buffer: ArrayImpl, stream: int | None = None
 ) -> Any: ...
+@overload
 def dlpack_managed_tensor_to_buffer(
     tensor: Any, device: Device, stream: int | None
+) -> ArrayImpl: ...
+@overload
+def dlpack_managed_tensor_to_buffer( # Legacy overload
+    tensor: Any,
+    cpu_backend: Optional[Client] = ...,
+    gpu_backend: Optional[Client] = ...,
 ) -> ArrayImpl: ...
 
 def cuda_array_interface_to_buffer(
@@ -710,12 +717,6 @@ def cuda_array_interface_to_buffer(
     gpu_backend: Optional[Client] = ...,
 ) -> ArrayImpl: ...
 
-# Legacy overload
-def dlpack_managed_tensor_to_buffer(
-    tensor: Any,
-    cpu_backend: Optional[Client] = ...,
-    gpu_backend: Optional[Client] = ...,
-) -> ArrayImpl: ...
 
 # === BEGIN py_traceback.cc
 


### PR DESCRIPTION
Encountered bug in https://github.com/google/jax/pull/20175 (see this [comment](https://github.com/google/jax/pull/20175#issuecomment-1989572870)).

This adjusts the stub file to properly overload `dlpack_managed_tensor_to_buffer` so that both signatures can be checked against.