### PR TITLE
memcmp is not valid for comparing 4 bit types

### DIFF
--- a/xla/literal.cc
+++ b/xla/literal.cc
@@ -1844,6 +1844,15 @@ bool LiteralBase::Piece::EqualElements(const LiteralBase::Piece& other) const {
     CHECK(LayoutUtil::IsDenseArray(subshape()))
         << __func__ << " is only supported for dense arrays: " << subshape();
     CHECK_EQ(size_bytes_dense(), other.size_bytes_dense());
+    if (primitive_util::Is4BitType(subshape().element_type())) {
+      auto one_array = buffer();
+      auto two_array = other.buffer();
+      for (int64_t i = 0; i < size_bytes_dense(); ++i) {
+        if ((one_array[i] & uint8_t{0xf}) != (two_array[i] & uint8_t{0xf}))
+          return false;
+      }
+      return true;
+    }
     return memcmp(buffer(), other.buffer(), size_bytes_dense()) == 0;
   }
 

--- a/xla/literal_test.cc
+++ b/xla/literal_test.cc
@@ -2796,6 +2796,19 @@ TEST_F(LiteralUtilTest, PopulateR3FromArray3DDynamicDim2) {
   EXPECT_EQ(expected, literal.ToString());
 }
 
+TEST_F(LiteralUtilTest, Compare4BitType) {
+  Literal literal1 = Literal(ShapeUtil::MakeShape(S4, {}));
+  Literal literal2 = Literal(ShapeUtil::MakeShape(S4, {}));
+  void *p = literal1.untyped_data();
+  void *q = literal2.untyped_data();
+  *((uint8_t *)p) = 0x44;
+  *((uint8_t *)q) = 0xc4;
+  std::string expected = R"(s4[] 4)";
+  EXPECT_EQ(expected, literal1.ToString());
+  EXPECT_EQ(literal1.ToString(), literal2.ToString());
+  EXPECT_EQ(literal1, literal2);
+}
+
 class LiteralSerializationTest : public ::testing::Test,
                                  public ::testing::WithParamInterface<Shape> {
  public:


### PR DESCRIPTION
To compare the subshape of a literal that is a 4 bit type it is not valid to compare the memory with memcmp as the upper nibble of each byte may not be initialised and result in a false failure of the comparison. Instead detect this situation and compare each nibble that will hold the 4 bit type.