### PR TITLE
[XLA:CPU][oneDNN] Scratchpad support to MatMul

### DIFF
--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1568,6 +1568,25 @@ tf_proto_library(
 )
 
 cc_library(
+    name = "onednn_util",
+    srcs = ["onednn_util.cc"],
+    hdrs = [
+        "onednn_util.h",
+        "//xla/tsl/util:onednn_util_hdrs",
+    ],
+    copts = runtime_copts() + tsl_copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "@eigen_archive//:eigen3",
+        "@tsl//tsl/platform:platform_port",
+        "@tsl//tsl/platform:blocking_counter",
+        "@tsl//tsl/platform:env",
+    ] + mkl_deps(),
+)
+
+cc_library(
     name = "onednn_memory_util",
     srcs = ["onednn_memory_util.cc"],
     hdrs = ["onednn_memory_util.h"],
@@ -1602,6 +1621,7 @@ cc_library(
     srcs = ["onednn_matmul.cc"],
     hdrs = [
         "onednn_matmul.h",
+        "onednn_util.h",
         "//xla/tsl/util:onednn_util_hdrs",
     ],
     copts = runtime_copts() + tsl_copts(),
@@ -1609,6 +1629,7 @@ cc_library(
     deps = [
         ":backend_config_proto_cc",
         ":onednn_memory_util",
+        ":onednn_util",
         ":runtime_lightweight_check",
         "//xla:executable_run_options",
         "//xla:shape_util",
@@ -1670,11 +1691,6 @@ cc_library(
 )
 
 cc_library(
-    name = "onednn_util",
-    hdrs = ["onednn_util.h"],
-)
-
-cc_library(
     name = "onednn_matmul_rewriter",
     srcs = ["onednn_matmul_rewriter.cc"],
     hdrs = [
@@ -1711,6 +1727,8 @@ cc_library(
     srcs = ["onednn_ops_rewriter.cc"],
     hdrs = [
         "onednn_ops_rewriter.h",
+        "onednn_util.h",
+        "//xla/tsl/util:onednn_util_hdrs",
     ],
     copts = tsl_copts(),
     deps = [

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1619,11 +1619,7 @@ cc_library(
 cc_library(
     name = "onednn_matmul",
     srcs = ["onednn_matmul.cc"],
-    hdrs = [
-        "onednn_matmul.h",
-        "onednn_util.h",
-        "//xla/tsl/util:onednn_util_hdrs",
-    ],
+    hdrs = ["onednn_matmul.h"],
     copts = runtime_copts() + tsl_copts(),
     visibility = ["//visibility:public"],
     deps = [
@@ -1725,11 +1721,7 @@ cc_library(
 cc_library(
     name = "onednn_ops_rewriter",
     srcs = ["onednn_ops_rewriter.cc"],
-    hdrs = [
-        "onednn_ops_rewriter.h",
-        "onednn_util.h",
-        "//xla/tsl/util:onednn_util_hdrs",
-    ],
+    hdrs = ["onednn_ops_rewriter.h"],
     copts = tsl_copts(),
     deps = [
         ":backend_config_proto_cc",

--- a/xla/service/cpu/backend_config.proto
+++ b/xla/service/cpu/backend_config.proto
@@ -33,6 +33,8 @@ message OneDnnMatMulConfig {
   // To avoid protobuf failures for specific decimal values,
   // the original float value alpha is type-casted to int32.
   int32 alpha_typecast = 5;
+  bool weights_prepacked = 6;
+  bool user_scratch = 7;
 }
 
 message OneDnnLayerNormConfig {

--- a/xla/service/cpu/backend_config.proto
+++ b/xla/service/cpu/backend_config.proto
@@ -34,7 +34,7 @@ message OneDnnMatMulConfig {
   // the original float value alpha is type-casted to int32.
   int32 alpha_typecast = 5;
   bool weights_prepacked = 6;
-  bool user_scratch = 7;
+  bool user_scratchpad = 7;
 }
 
 message OneDnnLayerNormConfig {

--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -2590,58 +2590,57 @@ Status IrEmitter::HandleOneDnnMatMulCalls(HloInstruction* custom_call,
   b_.CreateStore(args_val, args_ptr);
 
   TF_RETURN_IF_ERROR(EmitTargetAddressForOp(custom_call));
-  llvm::Value* result_val;
-  llvm::Value* scratch_val;
+
   StackAlloca result_stack_alloca;
   StackAlloca scratch_stack_alloca;
-  llvm_ir::IrArray result_array;
-  llvm_ir::IrArray scratch_array;
-  llvm::Value* result_value_ptr;
-  llvm::Value* scratch_value_ptr;
-
-  if (custom_call->shape().IsTuple()) {
+  // Custom-call target for matmul has 3 arguments: void* result, void*
+  // scratch and void** args
+  std::vector<llvm::Value*> fn_call_args;
+  fn_call_args.reserve(3);
+  const bool use_scratchpad = custom_call->shape().IsTuple();
+  if (use_scratchpad) {
+    llvm::Value* result_slice_ptr;
+    llvm::Value* scratch_slice_ptr;
+    llvm_ir::IrArray result_array;
+    llvm_ir::IrArray scratch_array;
     TF_ASSIGN_OR_RETURN(const BufferAllocation::Slice result_slice,
                         assignment_.GetUniqueSlice(custom_call, {0}));
     const Shape& result_shape = custom_call->shape().tuple_shapes(0);
-    result_value_ptr = EmitBufferPointer(result_slice, result_shape);
+    result_slice_ptr = EmitBufferPointer(result_slice, result_shape);
     llvm::Type* ir_type = IrShapeType(result_shape);
-    result_array = llvm_ir::IrArray(result_value_ptr, ir_type, result_shape);
+    result_array = llvm_ir::IrArray(result_slice_ptr, ir_type, result_shape);
     result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
-    result_val = result_stack_alloca.value;
+    fn_call_args.push_back(result_stack_alloca.value);
 
     TF_ASSIGN_OR_RETURN(const BufferAllocation::Slice scratch_slice,
                         assignment_.GetUniqueSlice(custom_call, {1}));
     const Shape& scratch_shape = custom_call->shape().tuple_shapes(1);
-    scratch_value_ptr = EmitBufferPointer(scratch_slice, scratch_shape);
+    scratch_slice_ptr = EmitBufferPointer(scratch_slice, scratch_shape);
     llvm::Type* scratch_type = IrShapeType(scratch_shape);
     scratch_array =
-        llvm_ir::IrArray(scratch_value_ptr, scratch_type, scratch_shape);
+        llvm_ir::IrArray(scratch_slice_ptr, scratch_type, scratch_shape);
     scratch_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, scratch_array);
-    scratch_val = scratch_stack_alloca.value;
+    fn_call_args.push_back(scratch_stack_alloca.value);
+    llvm_ir::EmitTuple(GetIrArrayFor(custom_call),
+                       {result_slice_ptr, scratch_slice_ptr}, &b_);
   } else {
+    llvm_ir::IrArray result_array;
     result_array = GetIrArrayFor(custom_call);
     result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
-    result_val = result_stack_alloca.value;
-
-    scratch_val = llvm::ConstantPointerNull::get(b_.getPtrTy());
+    fn_call_args.push_back(result_stack_alloca.value);
+    fn_call_args.push_back(llvm::ConstantPointerNull::get(b_.getPtrTy()));
   }
-
-  EmitCallToFunc(std::move(runtime_symbol_name),
-                 {result_val, scratch_val, args_ptr}, b_.getVoidTy());
-
-  if (custom_call->shape().IsTuple()) {
-    llvm_ir::EmitTuple(GetIrArrayFor(custom_call),
-                       {result_value_ptr, scratch_value_ptr}, &b_);
-  }
+  fn_call_args.push_back(args_ptr);
+  EmitCallToFunc(std::move(runtime_symbol_name), fn_call_args, b_.getVoidTy());
 
   // Lifetime ends for all stack allocations.
   b_.CreateLifetimeEnd(nargs_ptr, b_.getInt64(-1));
-  for (int i = 0; i < num_operands; ++i) {
-    operands_stack_alloca[i].EmitLifetimeEnd();
-  }
   b_.CreateLifetimeEnd(args_ptr, b_.getInt64(-1));
+  for (auto& alloca : operands_stack_alloca) {
+    alloca.EmitLifetimeEnd();
+  }
   result_stack_alloca.EmitLifetimeEnd();
-  if (custom_call->shape().IsTuple()) {
+  if (use_scratchpad) {
     scratch_stack_alloca.EmitLifetimeEnd();
   }
 

--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -12,31 +12,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
-
 #include "xla/service/cpu/onednn_matmul.h"
 
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <initializer_list>
+#include <iterator>
 #include <utility>
 #include <vector>
 
-#define EIGEN_USE_THREADS
-
-#include "dnnl.hpp"
 #include "absl/base/dynamic_annotations.h"
+#include "dnnl.hpp"
+#include "tsl/platform/logging.h"
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "xla/executable_run_options.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_memory_util.h"
+#include "xla/service/cpu/onednn_util.h"
 #include "xla/service/cpu/runtime_lightweight_check.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/tsl/util/onednn_threadpool.h"
-#include "tsl/platform/logging.h"
+
+#define EIGEN_USE_THREADS
 
 namespace xla {
 namespace cpu {
@@ -45,40 +47,6 @@ using dnnl::engine;
 using dnnl::matmul;
 using dnnl::memory;
 using dnnl::stream;
-
-dnnl::memory::desc Transpose(const dnnl::memory::desc& md) {
-  int64_t ndims = md.get_ndims();
-  // Do not transpose 1D
-  if (ndims == 1) {
-    return md;
-  }
-
-  std::vector<int> permutation(ndims);
-  std::iota(permutation.begin(), permutation.end(), 0);
-  std::swap(permutation[ndims - 1], permutation[ndims - 2]);
-  return md.permute_axes(permutation);
-}
-
-dnnl::memory::desc ShapeToMemDesc(const Shape& shape, bool transpose = false) {
-  auto dimensions = shape.dimensions();
-  if (dimensions.size() == 0) {
-    return dnnl::memory::desc{};
-  }
-
-  auto dims = dnnl::memory::dims(dimensions.begin(), dimensions.end());
-
-  dnnl::memory::dims strides(dims.size());
-  dnnl::memory::dim stride = 1;
-  for (auto i : shape.layout().minor_to_major()) {
-    strides.at(i) = stride;
-    stride *= dims.at(i);
-  }
-
-  auto dt = ToOneDnnDataType(static_cast<PrimitiveType>(shape.element_type()));
-
-  return transpose ? Transpose(dnnl::memory::desc(dims, dt, strides))
-                   : dnnl::memory::desc(dims, dt, strides);
-}
 
 dnnl::memory::desc OneDnnMatMulOptWeightsDesc(
     const dnnl::engine& engine, const dnnl::memory::desc& input_md,
@@ -98,8 +66,18 @@ dnnl::memory::desc OneDnnMatMulOptWeightsDesc(
     const dnnl::engine& engine, const Shape& input_shape,
     const Shape& weights_shape, const Shape& bias_shape,
     const Shape& output_shape, const OneDnnMatMulConfig* matmul_config) {
-  auto input_md = ShapeToMemDesc(input_shape, matmul_config->transpose_a());
-  auto weights_md = ShapeToMemDesc(weights_shape, matmul_config->transpose_b());
+  auto input_md = ShapeToMemDesc(input_shape);
+  auto weights_md = ShapeToMemDesc(weights_shape);
+  if (matmul_config->transpose_a()) {
+    auto transpose_input_md = TransposeLastTwoDims(input_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_input_md.ok());
+    input_md = *transpose_input_md;
+  }
+  if (matmul_config->transpose_b()) {
+    auto transpose_weights_md = TransposeLastTwoDims(weights_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_weights_md.ok());
+    weights_md = *transpose_weights_md;
+  }
   auto bias_md =
       absl::c_count(matmul_config->fused_ops(), OneDnnMatMulConfig::BIAS) > 0
           ? ShapeToMemDesc(bias_shape)
@@ -119,40 +97,6 @@ dnnl::memory::desc OneDnnMatMulOptWeightsDesc(
                                     output_md);
 }
 
-Shape MemDescToXlaShape(const dnnl::memory::desc& md) {
-  auto dtype = md.get_data_type();
-  auto element_size = dnnl::memory::data_type_size(dtype);
-  int64_t bytes_num = md.get_size();
-  XLA_LIGHTWEIGHT_CHECK(bytes_num % element_size == 0);
-  int64_t elements_num = static_cast<int64_t>(bytes_num / element_size);
-  return ShapeUtil::MakeShape(ToXlaPrimitiveType(dtype), {elements_num});
-}
-
-std::unique_ptr<tsl::OneDnnThreadPool> CreateOneDnnThreadPool(
-    const xla::ExecutableRunOptions* run_options) {
-#ifndef ENABLE_ONEDNN_OPENMP
-  if (run_options != nullptr &&
-      run_options->intra_op_thread_pool() != nullptr) {
-    return std::make_unique<tsl::OneDnnThreadPool>(
-        run_options->intra_op_thread_pool()->getPool(), false);
-  } else {
-    return nullptr;
-  }
-#else
-  return nullptr;
-#endif  // ENABLE_ONEDNN_OPENMP
-}
-
-dnnl::stream MakeOneDnnStream(
-    const dnnl::engine& cpu_engine,
-    dnnl::threadpool_interop::threadpool_iface* thread_pool) {
-  if (thread_pool != nullptr) {
-    return dnnl::threadpool_interop::make_stream(cpu_engine, thread_pool);
-  } else {
-    return dnnl::stream(cpu_engine);
-  }
-}
-
 }  // namespace
 
 Shape OneDnnMatMulOptWeightsShape(const Shape& input_shape,
@@ -164,53 +108,30 @@ Shape OneDnnMatMulOptWeightsShape(const Shape& input_shape,
   auto optimized_weights_md =
       OneDnnMatMulOptWeightsDesc(cpu_engine, input_shape, weights_shape,
                                  bias_shape, output_shape, matmul_config);
-  return MemDescToXlaShape(optimized_weights_md);
+  return MemDescToXlaShapeFlattened(optimized_weights_md);
 }
 
-ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
-    void* result, void** args) {
-  // args[0]: ptr to nargs
-  // args[1]: ptr to ExecutableRunOptions
-  // args[2]: ptr to OneDnnMatMulConfig
-  // args[3...]: ptrs to operands
-  int arg_indx = 0;
-  const int64_t num_args = *(static_cast<int64_t*>(args[arg_indx++]));
+struct FusedOperandsRef {
+  const std::vector<void*>& bufs;
+  std::vector<std::pair<int, dnnl::memory>>& postop_args;
+};
 
-  const xla::ExecutableRunOptions* run_options =
-      static_cast<const xla::ExecutableRunOptions*>(args[arg_indx++]);
-  XLA_LIGHTWEIGHT_CHECK(run_options != nullptr);
-  XLA_LIGHTWEIGHT_CHECK(run_options->intra_op_thread_pool() != nullptr);
-
-  auto thread_pool = CreateOneDnnThreadPool(run_options);
-  engine cpu_engine(engine::kind::cpu, 0);
-  auto onednn_stream = MakeOneDnnStream(cpu_engine, thread_pool.get());
-
-  std::string config_str(static_cast<const char*>(args[arg_indx++]));
-  OneDnnMatMulConfig matmul_config;
-  matmul_config.ParseFromString(config_str);
-
-  MemrefInfo lhs_minfo(args[arg_indx++]);
-  MemrefInfo rhs_minfo(args[arg_indx++]);
-  MemrefInfo result_minfo(result);
-
-  auto lhs_md = lhs_minfo.GetOneDnnMemDesc();
-  auto rhs_md = rhs_minfo.GetOneDnnMemDesc();
+std::unique_ptr<matmul::primitive_desc> CreateMatMulPrimDesc(
+    const engine& cpu_engine, const memory::desc& input_md,
+    const memory::desc& plain_weights_md, const memory::desc& output_md,
+    const std::vector<memory::desc>& fused_mds,
+    const OneDnnMatMulConfig& matmul_config,
+    FusedOperandsRef* fused_operands_ref = nullptr) {
   auto bias_md = memory::desc();
-  auto result_md = result_minfo.GetOneDnnMemDesc();
-
-  // Update dims and strides for transposed inputs.
-  if (matmul_config.transpose_a()) {
-    lhs_md = Transpose(lhs_md);
+  bool weights_packed = matmul_config.weights_prepacked();
+  auto weights_md = plain_weights_md;
+  if (weights_packed) {
+    weights_md = memory::desc(weights_md.get_dims(), weights_md.get_data_type(),
+                              memory::format_tag::any);
   }
 
-  if (matmul_config.transpose_b()) {
-    rhs_md = Transpose(rhs_md);
-  }
-  auto bias_mem = memory(nullptr);
-  std::vector<std::pair<int, dnnl::memory>> postop_args;
-
-  // Currently, GELU/ReLU only fusion is supported.
   dnnl::post_ops post_ops;
+  int fused_operand_idx = 0;
   for (auto& fused_op : matmul_config.fused_ops()) {
     switch (fused_op) {
       case OneDnnMatMulConfig::RELU:
@@ -226,27 +147,35 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
         post_ops.append_eltwise(dnnl::algorithm::eltwise_gelu_erf, 0.f, 0.f);
         break;
       case OneDnnMatMulConfig::BIAS: {
-        MemrefInfo bias_minfo(args[arg_indx++]);
-        bias_md = bias_minfo.GetOneDnnMemDesc();
-
+        bias_md = fused_mds.at(fused_operand_idx);
         // Extend bias rank to match result rank.
-        auto missed_rank = result_md.get_ndims() - bias_md.get_ndims();
+        auto missed_rank = output_md.get_ndims() - bias_md.get_ndims();
         XLA_LIGHTWEIGHT_CHECK(missed_rank >= 0);
         if (missed_rank > 0) {
           auto bias_dims = bias_md.get_dims();
           bias_dims.insert(bias_dims.begin(), missed_rank, 1);
           bias_md = bias_md.reshape(bias_dims);
         }
-        bias_mem = memory(bias_md, cpu_engine, bias_minfo.Data());
+        if (fused_operands_ref) {
+          fused_operands_ref->postop_args.emplace_back(
+              DNNL_ARG_BIAS,
+              dnnl::memory(bias_md, cpu_engine,
+                           fused_operands_ref->bufs[fused_operand_idx]));
+        }
+        fused_operand_idx++;
       } break;
       case OneDnnMatMulConfig::BINARY_ADD: {
-        MemrefInfo binary_minfo(args[arg_indx++]);
-        auto binary_md = binary_minfo.GetOneDnnMemDesc();
-        auto arg_idx =
-            DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops.len()) | DNNL_ARG_SRC_1;
+        auto binary_md = fused_mds.at(fused_operand_idx);
+        if (fused_operands_ref) {
+          auto arg_idx =
+              DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops.len()) | DNNL_ARG_SRC_1;
+          fused_operands_ref->postop_args.emplace_back(
+              arg_idx,
+              dnnl::memory(binary_md, cpu_engine,
+                           fused_operands_ref->bufs[fused_operand_idx]));
+        }
         post_ops.append_binary(dnnl::algorithm::binary_add, binary_md);
-        postop_args.emplace_back(
-            arg_idx, dnnl::memory(binary_md, cpu_engine, binary_minfo.Data()));
+        fused_operand_idx++;
       } break;
       case OneDnnMatMulConfig::LINEAR: {
         float const_float;
@@ -263,42 +192,162 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
     }
   }
 
-  XLA_LIGHTWEIGHT_CHECK(num_args == arg_indx);
-
   dnnl::primitive_attr attrs;
+  if (matmul_config.user_scratch()) {
+    attrs.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+  }
   if (post_ops.len() > 0) {
     attrs.set_post_ops(post_ops);
   }
+  return std::make_unique<matmul::primitive_desc>(
+      cpu_engine, input_md, weights_md, bias_md, output_md, attrs);
+}
 
-  bool weights_packed = rhs_md.get_ndims() == 1 &&
-                        rhs_md.get_dims().front() != lhs_md.get_dims().back();
-  if (weights_packed) {
-    // expected 2D buffer with last dim of input and last dim of output
-    auto rhs_any_md =
-        memory::desc({lhs_md.get_dims().back(), result_md.get_dims().back()},
-                     rhs_md.get_data_type(), memory::format_tag::any);
+std::unique_ptr<matmul::primitive_desc> CreateMatMulPrimDesc(
+    const Shape& input_shape, const Shape& weights_shape,
+    const Shape& output_shape, const std::vector<Shape>& fused_shapes,
+    const OneDnnMatMulConfig& matmul_config) {
+  auto input_md = ShapeToMemDesc(input_shape);
+  auto weights_md = ShapeToMemDesc(weights_shape);
+  if (matmul_config.transpose_a()) {
+    auto transpose_input_md = TransposeLastTwoDims(input_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_input_md.ok());
+    input_md = *transpose_input_md;
+  }
+  if (matmul_config.transpose_b()) {
+    auto transpose_weights_md = TransposeLastTwoDims(weights_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_weights_md.ok());
+    weights_md = *transpose_weights_md;
+  }
+  auto output_md = ShapeToMemDesc(output_shape);
+  std::vector<memory::desc> fused_mds;
+  std::transform(fused_shapes.begin(), fused_shapes.end(),
+                 std::back_inserter(fused_mds),
+                 [](const Shape& shape) { return ShapeToMemDesc(shape); });
+  return CreateMatMulPrimDesc(engine(engine::kind::cpu, 0), input_md,
+                              weights_md, output_md, fused_mds, matmul_config);
+}
 
-    rhs_md = OneDnnMatMulOptWeightsDesc(cpu_engine, lhs_md, rhs_any_md, bias_md,
-                                        result_md);
+template <>
+std::unique_ptr<dnnl::matmul::primitive_desc>
+CreateOneDnnPrimDesc<dnnl::matmul::primitive_desc>(HloInstruction* instr) {
+  if (instr->opcode() != HloOpcode::kCustomCall) {
+    return nullptr;
+  }
+  auto custom_call = Cast<xla::HloCustomCallInstruction>(instr);
+  auto backend_config = custom_call->backend_config<BackendConfig>();
+  if (!backend_config.ok()) {
+    return nullptr;
+  }
+  auto& matmul_config = backend_config.value().onednn_matmul_config();
+  auto operands = custom_call->operands();
+  auto input = operands[0];
+  auto weight = operands[1];  // assuming weights is the second operand
+  auto input_shape = input->shape();
+  auto weight_shape = weight->shape();
+  auto output_shape = custom_call->shape().IsTuple()
+                          ? custom_call->shape().tuple_shapes(0)
+                          : custom_call->shape();
+
+  auto fused_operands =
+      HloInstruction::InstructionVector(operands.begin() + 2, operands.end());
+  std::vector<Shape> fused_shapes;
+  std::transform(fused_operands.begin(), fused_operands.end(),
+                 std::back_inserter(fused_shapes),
+                 [](const HloInstruction* instr) { return instr->shape(); });
+
+  return CreateMatMulPrimDesc(input_shape, weight_shape, output_shape,
+                              fused_shapes, matmul_config);
+}
+
+ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
+    void* result, void* scratch, void** args) {
+  // args[0]: ptr to nargs
+  // args[1]: ptr to ExecutableRunOptions
+  // args[2]: ptr to OneDnnMatMulConfig
+  // args[3...]: ptrs to operands
+  int arg_indx = 0;
+  const int64_t num_args = *(static_cast<int64_t*>(args[arg_indx++]));
+
+  const xla::ExecutableRunOptions* run_options =
+      static_cast<const xla::ExecutableRunOptions*>(args[arg_indx++]);
+  auto thread_pool = CreateOneDnnThreadPool(
+      run_options ? run_options->intra_op_thread_pool() : nullptr);
+  engine cpu_engine(engine::kind::cpu, 0);
+  auto onednn_stream = MakeOneDnnStream(cpu_engine, thread_pool.get());
+
+  std::string config_str(static_cast<const char*>(args[arg_indx++]));
+  OneDnnMatMulConfig matmul_config;
+  matmul_config.ParseFromString(config_str);
+
+  MemrefInfo input_minfo(args[arg_indx++]);
+  MemrefInfo weights_minfo(args[arg_indx++]);
+  MemrefInfo output_minfo(result);
+
+  auto input_md = input_minfo.GetOneDnnMemDesc();
+  auto weights_md = weights_minfo.GetOneDnnMemDesc();
+  // Input and weights memory::desc need to be in correct layout before matmul
+  // primitive descriptor is created.
+  if (matmul_config.transpose_a() && input_md.get_ndims() > 1) {
+    auto transpose_input_md = TransposeLastTwoDims(input_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_input_md.ok());
+    input_md = *transpose_input_md;
+  }
+  if (matmul_config.transpose_b() && weights_md.get_ndims() > 1) {
+    auto transpose_weights_md = TransposeLastTwoDims(weights_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_weights_md.ok());
+    weights_md = *transpose_weights_md;
+  }
+  auto output_md = output_minfo.GetOneDnnMemDesc();
+  if (matmul_config.weights_prepacked()) {
+    // Weight pre-packing is supported for 2D weights only.
+    // Since prepacked weights array is flattened, try to infer the dims from
+    // input and output.
+    // TODO(intel-tf): Add support for prepacked weights for higher then 2D
+    // array.
+    weights_md =
+        memory::desc({input_md.get_dims().back(), output_md.get_dims().back()},
+                     weights_md.get_data_type(), memory::format_tag::ab);
+  }
+  const int64_t num_fused_operands = num_args - arg_indx;
+  std::vector<memory::desc> fused_mds;
+  std::vector<void*> fused_bufs;
+  for (int64_t i = 0; i < num_fused_operands; ++i) {
+    MemrefInfo operand_minfo(args[arg_indx++]);
+    fused_mds.push_back(operand_minfo.GetOneDnnMemDesc());
+    fused_bufs.push_back(operand_minfo.Data());
   }
 
-  auto lhs_mem = memory(lhs_md, cpu_engine, lhs_minfo.Data());
-  auto rhs_mem = memory(rhs_md, cpu_engine, rhs_minfo.Data());
-  auto result_mem = memory(result_md, cpu_engine, result_minfo.Data());
+  std::vector<std::pair<int, dnnl::memory>> postop_args;
+  FusedOperandsRef fused_operands_ref{fused_bufs, postop_args};
+  auto matmul_pd =
+      CreateMatMulPrimDesc(cpu_engine, input_md, weights_md, output_md,
+                           fused_mds, matmul_config, &fused_operands_ref);
 
-  auto matmul_pd = matmul::primitive_desc(cpu_engine, lhs_md, rhs_md, bias_md,
-                                          result_md, attrs);
+  XLA_LIGHTWEIGHT_CHECK(num_args == arg_indx);
 
-  if (std::strstr(matmul_pd.impl_info_str(), "ref") != nullptr) {
+  auto lhs_mem = memory(input_md, cpu_engine, input_minfo.Data());
+  auto rhs_mem =
+      memory(matmul_pd->weights_desc(), cpu_engine, weights_minfo.Data());
+  auto result_mem = memory(output_md, cpu_engine, output_minfo.Data());
+
+  if (std::strstr(matmul_pd->impl_info_str(), "ref") != nullptr) {
     LOG(WARNING) << "[Perf]: MatMul reference implementation being executed";
   }
 
-  auto matmul_prim = matmul(matmul_pd);
+  auto matmul_prim = matmul(*matmul_pd);
 
   std::unordered_map<int, memory> matmul_args{{DNNL_ARG_SRC, lhs_mem},
                                               {DNNL_ARG_WEIGHTS, rhs_mem},
-                                              {DNNL_ARG_BIAS, bias_mem},
                                               {DNNL_ARG_DST, result_mem}};
+
+  if (matmul_config.user_scratch()) {
+    XLA_LIGHTWEIGHT_CHECK(scratch != nullptr);
+    MemrefInfo scratch_minfo(scratch);
+    auto scratchpad_md = matmul_pd->scratchpad_desc();
+    auto scratch_mem = memory(scratchpad_md, cpu_engine, scratch_minfo.Data());
+    matmul_args.insert({DNNL_ARG_SCRATCHPAD, scratch_mem});
+  }
 
   matmul_args.insert(postop_args.begin(), postop_args.end());
 
@@ -317,7 +366,8 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMulReorder(
   const xla::ExecutableRunOptions* run_options =
       static_cast<const xla::ExecutableRunOptions*>(args[arg_indx++]);
 
-  auto thread_pool = CreateOneDnnThreadPool(run_options);
+  auto thread_pool = CreateOneDnnThreadPool(
+      run_options ? run_options->intra_op_thread_pool() : nullptr);
   engine cpu_engine(engine::kind::cpu, 0);
   auto onednn_stream = MakeOneDnnStream(cpu_engine, thread_pool.get());
 
@@ -345,11 +395,15 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMulReorder(
   // Update dims and strides for transposed inputs.
   bool transpose_a = matmul_config.transpose_a();
   if (transpose_a) {
-    input_md = Transpose(input_md);
+    auto transpose_input_md = TransposeLastTwoDims(input_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_input_md.ok());
+    input_md = *transpose_input_md;
   }
   bool transpose_b = matmul_config.transpose_b();
   if (transpose_b) {
-    weight_md = Transpose(weight_md);
+    auto transpose_weight_md = TransposeLastTwoDims(weight_md);
+    XLA_LIGHTWEIGHT_CHECK(transpose_weight_md.ok());
+    weight_md = *transpose_weight_md;
   }
 
   // extend bias rank to match result rank

--- a/xla/service/cpu/onednn_matmul.h
+++ b/xla/service/cpu/onednn_matmul.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define XLA_SERVICE_CPU_ONEDNN_MATMUL_H_
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
+#include "dnnl.hpp"
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/shape.h"
 
@@ -30,7 +31,8 @@ Shape OneDnnMatMulOptWeightsShape(const Shape& input_shape,
                                   const OneDnnMatMulConfig* matmul_config);
 
 extern "C" {
-extern void __xla_cpu_runtime_OneDnnMatMul(void* result, void** args);
+extern void __xla_cpu_runtime_OneDnnMatMul(void* result, void* scratch,
+                                           void** args);
 extern void __xla_cpu_runtime_OneDnnMatMulReorder(void* result, void** args);
 }  // extern "C"
 

--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -821,14 +821,10 @@ class OneDnnPostRewriteVisitor : public DfsHloRewriteVisitor {
     }
     auto plain_weights_md = ShapeToMemDesc(weights_shape);
     if constexpr (std::is_same<PrimDesc, dnnl::matmul::primitive_desc>::value) {
-      auto backend_config = custom_call->backend_config<BackendConfig>();
-      if (!backend_config.ok()) {
-        return absl::CancelledError(
-            "Cannot prepack weights. Customcall does not have a "
-            "BackendConfig.");
-      }
+      TF_ASSIGN_OR_RETURN(auto backend_config,
+                          custom_call->backend_config<BackendConfig>());
       TRANSPOSE_LAST_TWO_DIMS_IF(
-          backend_config->onednn_matmul_config().transpose_b(),
+          backend_config.onednn_matmul_config().transpose_b(),
           plain_weights_md);
     }
     TF_RETURN_IF_ERROR(SetWeightsPrepack<PrimDesc>(custom_call, true));

--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "xla/service/cpu/onednn_matmul_rewriter.h"
 
+#include "tsl/platform/logging.h"  // IWYU pragma: keep
 #include "xla/executable_run_options.h"
 #include "xla/hlo/evaluator/hlo_evaluator.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
@@ -33,7 +34,6 @@ limitations under the License.
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
 #include "xla/tsl/util/onednn_threadpool.h"
-#include "tsl/platform/logging.h"  // IWYU pragma: keep
 
 namespace xla {
 namespace cpu {
@@ -713,10 +713,10 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
   }
 };
 
-class OneDnnMatMulReorderVisitor : public DfsHloRewriteVisitor {
+class OneDnnPostRewriteVisitor : public DfsHloRewriteVisitor {
  public:
-  OneDnnMatMulReorderVisitor(int intra_op_parallelism,
-                             const tsl::thread::ThreadPool* compile_threadpool)
+  OneDnnPostRewriteVisitor(int intra_op_parallelism,
+                           const tsl::thread::ThreadPool* compile_threadpool)
       : intra_op_parallelism_(intra_op_parallelism > 0
                                   ? intra_op_parallelism
                                   : tsl::port::MaxParallelism()),
@@ -733,108 +733,130 @@ class OneDnnMatMulReorderVisitor : public DfsHloRewriteVisitor {
                                       threadpool_handle_->NumThreads()));
     }
 
-    evaluator_.set_custom_call_handler(
-        [this](const HloInstruction* custom_call_instr,
-               absl::Span<const Literal*> operands) -> StatusOr<Literal> {
-          TF_ASSIGN_OR_RETURN(
-              auto backend_config,
-              custom_call_instr->backend_config<BackendConfig>());
-          auto& matmul_config = backend_config.onednn_matmul_config();
-
-          auto output = Literal::CreateFromShape(custom_call_instr->shape());
-
-          int64_t nargs = operands.size() + 3;
-          std::vector<void*> args;
-          args.push_back(&nargs);
-
-          ExecutableRunOptions run_options;
-          run_options.set_intra_op_thread_pool(threadpool_device_.get());
-          args.push_back(&run_options);  // No ExecutableRunOptions.
-
-          // OneDnnMatMulConfig
-          std::string config;
-          matmul_config.SerializeToString(&config);
-          args.push_back(config.data());
-
-          std::vector<MemrefInfoHandler> minfo_ptrs(operands.size());
-          std::transform(operands.begin(), operands.end(), minfo_ptrs.begin(),
-                         CreateMemrefInfoFromLiteral);
-          for (auto& minfo_ptr : minfo_ptrs) {
-            args.push_back(static_cast<void*>(minfo_ptr.get()));
-          }
-
-          auto result_ptr = CreateMemrefInfoFromLiteral(&output);
-          __xla_cpu_runtime_OneDnnMatMulReorder(result_ptr.get(), args.data());
-
-          return output;
-        });
+#ifndef ENABLE_ONEDNN_OPENMP
+    // set oneDNN cuncurrency settings (which is thread-local)
+    tsl::OneDnnThreadPool::set_onednn_max_threads(intra_op_parallelism_);
+#endif
   }
 
   Status HandleCustomCall(HloInstruction* custom_call) override {
     HloInstruction* matmul;
     if (Match(custom_call, OneDnnMatmulInstr(&matmul))) {
-      TF_ASSIGN_OR_RETURN(auto backend_config,
-                          matmul->backend_config<BackendConfig>());
-      auto& matmul_config = backend_config.onednn_matmul_config();
+      return HandleCustomCallInternal<dnnl::matmul::primitive_desc>(
+          custom_call);
+    }
 
-      auto operands = custom_call->operands();
-      auto input = operands[0];
-      auto weight = operands[1];  // assuming weights is the second operand
+    return DefaultAction(custom_call);
+  }
 
-      auto input_shape = input->shape();
-      auto weight_shape = weight->shape();
-      if (weight_shape.rank() != 2) {
-        // pre-pack only 2D weights
-        return DefaultAction(custom_call);
+  template <typename PrimDesc>
+  Status HandleCustomCallInternal(HloInstruction* custom_call) {
+    auto scratch_add = AddScratch<PrimDesc>(custom_call);
+    if (scratch_add.ok()) {
+      custom_call = *scratch_add;
+    } else {
+      VLOG(2) << scratch_add.status();
+    }
+    auto weights_prepack = PrepackWeights<PrimDesc>(custom_call);
+    if (!weights_prepack.ok()) {
+      VLOG(2) << weights_prepack.status();
+    }
+    return OkStatus();
+  }
+
+  template <typename>
+  Status SetWeightsPrepack(HloInstruction*, bool);
+
+  template <typename>
+  Status SetUserScratch(HloInstruction*, bool);
+
+  template <typename>
+  bool GetWeightsPrepack(HloInstruction*);
+
+  template <typename>
+  bool GetUserScratch(HloInstruction*);
+
+  // Add scratch for matmul by changing the result of custom-call to
+  // tuple(result, scratch)
+  template <typename PrimDesc>
+  StatusOr<HloInstruction*> AddScratch(HloInstruction* custom_call) {
+    if (GetUserScratch<PrimDesc>(custom_call)) {
+      return custom_call;
+    }
+    TF_RETURN_IF_ERROR(SetUserScratch<PrimDesc>(custom_call, true));
+    auto prim_desc = CreateOneDnnPrimDesc<PrimDesc>(custom_call);
+    int64_t scratch_size = prim_desc->scratchpad_desc().get_size();
+    Shape scratch_shape = ShapeUtil::MakeShape(U8, {scratch_size});
+    Shape tuple_shape =
+        ShapeUtil::MakeTupleShape({custom_call->shape(), scratch_shape});
+    auto new_custom_call = custom_call->AddInstruction(
+        custom_call->CloneWithNewShape(tuple_shape));
+    HloInstruction* gte =
+        new_custom_call->AddInstruction(HloInstruction::CreateGetTupleElement(
+            custom_call->shape(), new_custom_call, 0));
+    auto status = ReplaceInstruction(custom_call, gte);
+    if (!status.ok()) {
+      TF_RETURN_IF_ERROR(SetUserScratch<PrimDesc>(custom_call, false));
+      return absl::CancelledError("Adding scratch is unsuccessful.");
+    }
+    return new_custom_call;
+  }
+
+  template <typename PrimDesc>
+  StatusOr<HloInstruction*> PrepackWeights(HloInstruction* custom_call) {
+    if (GetWeightsPrepack<PrimDesc>(custom_call)) {
+      return custom_call;
+    }
+    auto weights = custom_call->operand(1);
+    if (weights->user_count() > 1) {
+      return absl::FailedPreconditionError("Weights could not be prepacked.");
+    }
+    auto weights_shape = weights->shape();
+    Literal weights_literal;
+    if (weights_shape.rank() == 2 &&
+        evaluator_.TryEvaluate(weights, &weights_literal)) {
+      auto plain_weights_md = ShapeToMemDesc(weights_shape);
+      if constexpr (std::is_same<PrimDesc,
+                                 dnnl::matmul::primitive_desc>::value) {
+        auto backend_config = custom_call->backend_config<BackendConfig>();
+        if (!backend_config.ok()) {
+          return absl::CancelledError("Weights could not be prepacked.");
+        }
+        if (backend_config->onednn_matmul_config().transpose_b()) {
+          plain_weights_md = TransposeLastTwoDims(plain_weights_md).value();
+        }
       }
-
-      auto bias_shape =
-          absl::c_count(matmul_config.fused_ops(), OneDnnMatMulConfig::BIAS) > 0
-              ? operands.at(2)->shape()
-              : Shape();
-
-      auto output_shape = custom_call->shape();
-
-#ifndef ENABLE_ONEDNN_OPENMP
-      // set oneDNN cuncurrency settings (which is thread-local)
-      tsl::OneDnnThreadPool::set_onednn_max_threads(intra_op_parallelism_);
-#endif
-      auto new_weight_shape = OneDnnMatMulOptWeightsShape(
-          input_shape, weight_shape, bias_shape, output_shape, &matmul_config);
-
-      auto cmpt = custom_call->parent();
-      std::vector<HloInstruction*> new_operands{
-          cmpt->AddInstruction(
-              HloInstruction::CreateConstant(Literal(input_shape))),
-          weight,
-          cmpt->AddInstruction(
-              HloInstruction::CreateConstant(Literal(output_shape))),
-      };
-
-      if (ShapeUtil::IsInitialized(bias_shape)) {
-        new_operands.push_back(cmpt->AddInstruction(
-            HloInstruction::CreateConstant(Literal(bias_shape))));
-      }
-
-      HloInstruction* reorder_call =
-          custom_call->AddInstruction(HloInstruction::CreateCustomCall(
-              new_weight_shape, new_operands, "__onednn$matmul_reorder"));
-
-      reorder_call->CopyBackendConfigFrom(custom_call);
-
-      Literal result;
-
-      if (evaluator_.TryEvaluate(reorder_call, &result, true)) {
-        HloInstruction* reordered_weight = custom_call->AddInstruction(
-            HloInstruction::CreateConstant(std::move(result)));
-        return custom_call->ReplaceOperandWithDifferentShape(1,
-                                                             reordered_weight);
-
+      TF_RETURN_IF_ERROR(SetWeightsPrepack<PrimDesc>(custom_call, true));
+      auto prim_desc = CreateOneDnnPrimDesc<PrimDesc>(custom_call);
+      auto packed_weights_md = prim_desc->weights_desc();
+      auto packed_weights_shape = MemDescToXlaShapeFlattened(packed_weights_md);
+      auto packed_weights_literal = Literal(packed_weights_shape);
+      ReorderWeight(plain_weights_md, weights_literal.untyped_data(),
+                    packed_weights_md, packed_weights_literal.untyped_data());
+      HloInstruction* reordered_weight = custom_call->AddInstruction(
+          HloInstruction::CreateConstant(std::move(packed_weights_literal)));
+      auto status =
+          custom_call->ReplaceOperandWithDifferentShape(1, reordered_weight);
+      if (!status.ok()) {
+        TF_RETURN_IF_ERROR(SetWeightsPrepack<PrimDesc>(custom_call, false));
+        return absl::CancelledError("Weights could not be prepacked.");
       } else {
-        return DefaultAction(custom_call);
+        return custom_call;
       }
     }
-    return DefaultAction(custom_call);
+    return absl::CancelledError("Weights could not be prepacked.");
+  }
+
+  void ReorderWeight(const dnnl::memory::desc& src_md, void* src_buf,
+                     const dnnl::memory::desc& dst_md, void* dst_buf) {
+    auto onednn_threadpool = CreateOneDnnThreadPool(threadpool_device_.get());
+    dnnl::engine cpu_engine(dnnl::engine::kind::cpu, 0);
+    auto onednn_stream = MakeOneDnnStream(cpu_engine, onednn_threadpool.get());
+    auto src_mem = dnnl::memory(src_md, cpu_engine, src_buf);
+    auto dst_mem = dnnl::memory(dst_md, cpu_engine, dst_buf);
+    dnnl::reorder reorder_prim{src_mem, dst_mem};
+    reorder_prim.execute(onednn_stream, src_mem, dst_mem);
+    onednn_stream.wait();
   }
 
  private:
@@ -844,6 +866,47 @@ class OneDnnMatMulReorderVisitor : public DfsHloRewriteVisitor {
   std::unique_ptr<Eigen::ThreadPoolDevice> threadpool_device_;
 };
 
+#define EMIT_GET_BACKEND_CONFIG_SPECIALIZATION(GETTER, PRIM_DESC, CONFIG,  \
+                                               FIELD)                      \
+  template <>                                                              \
+  inline bool OneDnnPostRewriteVisitor::GETTER<PRIM_DESC>(HloInstruction * \
+                                                          custom_call) {   \
+    auto backend_config = custom_call->backend_config<BackendConfig>();    \
+    if (!backend_config.ok()) {                                            \
+      return false;                                                        \
+    } else {                                                               \
+      return backend_config->CONFIG().FIELD();                             \
+    }                                                                      \
+  }
+
+EMIT_GET_BACKEND_CONFIG_SPECIALIZATION(GetUserScratch,
+                                       dnnl::matmul::primitive_desc,
+                                       onednn_matmul_config, user_scratch);
+EMIT_GET_BACKEND_CONFIG_SPECIALIZATION(GetWeightsPrepack,
+                                       dnnl::matmul::primitive_desc,
+                                       onednn_matmul_config, weights_prepacked);
+
+#define EMIT_SET_BACKEND_CONFIG_SPECIALIZATION(SETTER, PRIM_DESC, CONFIG_TYPE, \
+                                               CONFIG, FIELD)                  \
+  template <>                                                                  \
+  inline Status OneDnnPostRewriteVisitor::SETTER<PRIM_DESC>(                   \
+      HloInstruction * custom_call, bool value) {                              \
+    TF_ASSIGN_OR_RETURN(auto backend_config,                                   \
+                        custom_call->backend_config<BackendConfig>());         \
+    CONFIG_TYPE* config = backend_config.mutable_##CONFIG();                   \
+    config->set_##FIELD(value);                                                \
+    return custom_call->set_backend_config(backend_config);                    \
+  }
+
+EMIT_SET_BACKEND_CONFIG_SPECIALIZATION(SetWeightsPrepack,
+                                       dnnl::matmul::primitive_desc,
+                                       OneDnnMatMulConfig, onednn_matmul_config,
+                                       weights_prepacked);
+EMIT_SET_BACKEND_CONFIG_SPECIALIZATION(SetUserScratch,
+                                       dnnl::matmul::primitive_desc,
+                                       OneDnnMatMulConfig, onednn_matmul_config,
+                                       user_scratch);
+
 StatusOr<bool> OneDnnMatMulRewriter::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
@@ -851,8 +914,8 @@ StatusOr<bool> OneDnnMatMulRewriter::Run(
   TF_ASSIGN_OR_RETURN(auto result,
                       visitor.RunOnModule(module, execution_threads));
 
-  OneDnnMatMulReorderVisitor reorder_visitor(intra_op_parallelism_,
-                                             compile_threadpool_);
+  OneDnnPostRewriteVisitor reorder_visitor(intra_op_parallelism_,
+                                           compile_threadpool_);
   TF_ASSIGN_OR_RETURN(auto result2,
                       reorder_visitor.RunOnModule(module, execution_threads));
 

--- a/xla/service/cpu/onednn_memory_util.cc
+++ b/xla/service/cpu/onednn_memory_util.cc
@@ -186,18 +186,14 @@ dnnl::memory::desc ShapeToMemDesc(const Shape& shape) {
   if (dimensions.empty()) {
     return dnnl::memory::desc{};
   }
-
   auto dims = dnnl::memory::dims(dimensions.begin(), dimensions.end());
-
   dnnl::memory::dims strides(dims.size());
   dnnl::memory::dim stride = 1;
   for (auto i : shape.layout().minor_to_major()) {
     strides.at(i) = stride;
     stride *= dims.at(i);
   }
-
   auto dt = ToOneDnnDataType(static_cast<PrimitiveType>(shape.element_type()));
-
   return dnnl::memory::desc(dims, dt, strides);
 }
 

--- a/xla/service/cpu/onednn_memory_util.cc
+++ b/xla/service/cpu/onednn_memory_util.cc
@@ -169,6 +169,49 @@ int64_t MemrefInfo::GetChannels() const { return pod_->dims[pod_->rank - 1]; }
 
 int64_t MemrefInfo::GetRank() const { return pod_->rank; }
 
+StatusOr<dnnl::memory::desc> TransposeLastTwoDims(
+    const dnnl::memory::desc& md) {
+  int64_t ndims = md.get_ndims();
+  if (ndims < 2) {
+    return absl::InvalidArgumentError("Requires at least 2D shape.");
+  }
+  std::vector<int> permutation(ndims);
+  std::iota(permutation.begin(), permutation.end(), 0);
+  std::swap(permutation[ndims - 1], permutation[ndims - 2]);
+  return md.permute_axes(permutation);
+}
+
+dnnl::memory::desc ShapeToMemDesc(const Shape& shape) {
+  auto dimensions = shape.dimensions();
+  if (dimensions.empty()) {
+    return dnnl::memory::desc{};
+  }
+
+  auto dims = dnnl::memory::dims(dimensions.begin(), dimensions.end());
+
+  dnnl::memory::dims strides(dims.size());
+  dnnl::memory::dim stride = 1;
+  for (auto i : shape.layout().minor_to_major()) {
+    strides.at(i) = stride;
+    stride *= dims.at(i);
+  }
+
+  auto dt = ToOneDnnDataType(static_cast<PrimitiveType>(shape.element_type()));
+
+  return dnnl::memory::desc(dims, dt, strides);
+}
+
+Shape MemDescToXlaShapeFlattened(const dnnl::memory::desc& md) {
+  if (md.is_zero()) {
+    LOG(FATAL) << "Memory descriptor is zero.";
+  }
+  auto dtype = md.get_data_type();
+  auto element_size = dnnl::memory::data_type_size(dtype);
+  int64_t bytes_num = md.get_size();
+  int64_t elements_num = static_cast<int64_t>(bytes_num / element_size);
+  return ShapeUtil::MakeShape(ToXlaPrimitiveType(dtype), {elements_num});
+}
+
 }  // namespace cpu
 }  // namespace xla
 

--- a/xla/service/cpu/onednn_memory_util.h
+++ b/xla/service/cpu/onednn_memory_util.h
@@ -118,6 +118,12 @@ class MemrefInfo {
   MemrefInfoPOD* pod_;
 };
 
+StatusOr<dnnl::memory::desc> TransposeLastTwoDims(const dnnl::memory::desc& md);
+
+dnnl::memory::desc ShapeToMemDesc(const Shape& shape);
+
+Shape MemDescToXlaShapeFlattened(const dnnl::memory::desc& md);
+
 }  // namespace cpu
 }  // namespace xla
 

--- a/xla/service/cpu/onednn_memory_util.h
+++ b/xla/service/cpu/onednn_memory_util.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Value.h"
 #include "xla/literal.h"
+#include "xla/service/cpu/runtime_lightweight_check.h"
 #include "xla/service/llvm_ir/ir_array.h"
 #include "xla/xla_data.pb.h"
 
@@ -119,6 +120,12 @@ class MemrefInfo {
 };
 
 StatusOr<dnnl::memory::desc> TransposeLastTwoDims(const dnnl::memory::desc& md);
+#define TRANSPOSE_LAST_TWO_DIMS_IF(pred, mem_desc)        \
+  if (pred) {                                             \
+    auto trans_mem_desc = TransposeLastTwoDims(mem_desc); \
+    XLA_LIGHTWEIGHT_CHECK(trans_mem_desc.ok());           \
+    mem_desc = *trans_mem_desc;                           \
+  }
 
 dnnl::memory::desc ShapeToMemDesc(const Shape& shape);
 

--- a/xla/service/cpu/onednn_util.cc
+++ b/xla/service/cpu/onednn_util.cc
@@ -1,0 +1,52 @@
+
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "xla/service/cpu/onednn_util.h"
+
+#define EIGEN_USE_THREADS
+
+namespace xla {
+namespace cpu {
+
+std::unique_ptr<tsl::OneDnnThreadPool> CreateOneDnnThreadPool(
+    const Eigen::ThreadPoolDevice* threadpool_device) {
+#ifndef ENABLE_ONEDNN_OPENMP
+  if (threadpool_device != nullptr) {
+    return std::make_unique<tsl::OneDnnThreadPool>(threadpool_device->getPool(),
+                                                   false);
+  } else {
+    return nullptr;
+  }
+#else
+  return nullptr;
+#endif  // ENABLE_ONEDNN_OPENMP
+}
+
+dnnl::stream MakeOneDnnStream(
+    const dnnl::engine& cpu_engine,
+    dnnl::threadpool_interop::threadpool_iface* thread_pool) {
+  if (thread_pool != nullptr) {
+    return dnnl::threadpool_interop::make_stream(cpu_engine, thread_pool);
+  } else {
+    return dnnl::stream(cpu_engine);
+  }
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/xla/service/cpu/onednn_util.cc
+++ b/xla/service/cpu/onednn_util.cc
@@ -1,4 +1,3 @@
-
 /* Copyright 2024 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,22 +27,17 @@ std::unique_ptr<tsl::OneDnnThreadPool> CreateOneDnnThreadPool(
   if (threadpool_device != nullptr) {
     return std::make_unique<tsl::OneDnnThreadPool>(threadpool_device->getPool(),
                                                    false);
-  } else {
-    return nullptr;
   }
-#else
+#endif  // !ENABLE_ONEDNN_OPENMP
   return nullptr;
-#endif  // ENABLE_ONEDNN_OPENMP
 }
 
 dnnl::stream MakeOneDnnStream(
     const dnnl::engine& cpu_engine,
     dnnl::threadpool_interop::threadpool_iface* thread_pool) {
-  if (thread_pool != nullptr) {
-    return dnnl::threadpool_interop::make_stream(cpu_engine, thread_pool);
-  } else {
-    return dnnl::stream(cpu_engine);
-  }
+  return (thread_pool != nullptr)
+             ? dnnl::threadpool_interop::make_stream(cpu_engine, thread_pool)
+             : dnnl::stream(cpu_engine);
 }
 
 }  // namespace cpu

--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -15,10 +15,17 @@ limitations under the License.
 
 #ifndef XLA_SERVICE_CPU_ONEDNN_UTIL_H_
 #define XLA_SERVICE_CPU_ONEDNN_UTIL_H_
+
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
-#include "xla/xla_data.pb.h"
+#define EIGEN_USE_THREADS
+
+#include "dnnl.hpp"
 #include "tsl/platform/cpu_info.h"
+#include "unsupported/Eigen/CXX11/Tensor"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/tsl/util/onednn_threadpool.h"
+#include "xla/xla_data.pb.h"
 
 namespace xla {
 namespace cpu {
@@ -43,6 +50,18 @@ inline bool IsSupportedType(xla::PrimitiveType dtype) {
   }
   return false;
 }
+
+std::unique_ptr<tsl::OneDnnThreadPool> CreateOneDnnThreadPool(
+    const Eigen::ThreadPoolDevice* threadpool_device);
+
+dnnl::stream MakeOneDnnStream(
+    const dnnl::engine& cpu_engine,
+    dnnl::threadpool_interop::threadpool_iface* thread_pool);
+
+// This template function must have explicit specialization at the defintion
+// site.
+template <typename PrimDesc>
+std::unique_ptr<PrimDesc> CreateOneDnnPrimDesc(HloInstruction*);
 
 }  // namespace cpu
 }  // namespace xla

--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -58,7 +58,7 @@ dnnl::stream MakeOneDnnStream(
     const dnnl::engine& cpu_engine,
     dnnl::threadpool_interop::threadpool_iface* thread_pool);
 
-// This template function must have explicit specialization at the defintion
+// This template function must have explicit specialization at the definition
 // site.
 template <typename PrimDesc>
 std::unique_ptr<PrimDesc> CreateOneDnnPrimDesc(HloInstruction*);

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -692,6 +692,30 @@ TEST_F(MatmulTest, SimpleTestF32WithMulAndAddFusion) {
     )");
 }
 
+TEST_F(MatmulTest, WeightsPrepackAndScratch) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[64,256,16] parameter(0), parameter_replication={false}
+    constant = f32[] constant(1)
+    arg.1 = f32[16,32] broadcast(constant), dimensions={}
+    ROOT onednn.matmul.0 = f32[64,256,32] dot(arg.0, arg.1), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:        %matmul.test.f32
+  ; CHECK:        custom_call_target="__onednn$matmul",
+  ; CHECK-SAME:       backend_config={
+  ; CHECK-SAME:           "outer_dimension_partitions":[],
+  ; CHECK-SAME:           "onednn_matmul_config":{
+  ; CHECK-SAME:               "weights_prepacked":true,"user_scratch":true
+  ; CHECK-SAME:           }
+  ; CHECK-SAME:       }
+  )");
+}
+
 }  // namespace cpu
 }  // namespace xla
 

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -710,7 +710,7 @@ TEST_F(MatmulTest, WeightsPrepackAndScratch) {
   ; CHECK-SAME:       backend_config={
   ; CHECK-SAME:           "outer_dimension_partitions":[],
   ; CHECK-SAME:           "onednn_matmul_config":{
-  ; CHECK-SAME:               "weights_prepacked":true,"user_scratch":true
+  ; CHECK-SAME:               "weights_prepacked":true,"user_scratchpad":true
   ; CHECK-SAME:           }
   ; CHECK-SAME:       }
   )");


### PR DESCRIPTION
This PR enables user provided scratch memory to MatMul. It utilizes buffer assigner to allocate scratch buffers. The following is the HLO rewrites.

```
Input HLO:
result = result_shape custom-call(args), custom_call_target="__onednn$matmul", ...

Output HLO:
tuple = (result_shape, scratch_shape) custom-call(args), custom_call_target="__onednn$matmul", ...
result_from_tuple = result_shape get-tuple-element(tuple), index=0
```

Besides enabling scratch memory, this PR refactors the MatMul rewrites and kernel implementation in order to reuse common code. It also introduces the following template function so that similar features can be easily used for other oneDNN primitives.

```
template <typename PrimDesc>
std::unique_ptr<PrimDesc> CreateOneDnnPrimDesc(HloInstruction*);
```