### PR TITLE
Enforce same input/output layout for offloading ops

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -4157,6 +4157,7 @@ cc_library(
         "//xla/service:computation_layout",
         "//xla/service:layout_assignment",
         "//xla/service:logical_buffer",
+        "//xla/service:host_memory_offload_annotations_hdr",
         "//xla/stream_executor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",

--- a/xla/service/gpu/gpu_layout_assignment.cc
+++ b/xla/service/gpu/gpu_layout_assignment.cc
@@ -41,6 +41,7 @@ limitations under the License.
 #include "xla/service/gpu/matmul_utils.h"
 #include "xla/service/gpu/reduction_utils.h"
 #include "xla/service/gpu/stream_executor_util.h"
+#include "xla/service/host_memory_offload_annotations.h"
 #include "xla/service/logical_buffer.h"
 #include "xla/shape.h"
 #include "xla/shape_layout.h"
@@ -538,6 +539,25 @@ bool GpuLayoutAssignment::PropagateReductionLayoutToOperand(
   int64_t kept_dimension_size = ShapeUtil::ElementsIn(user->shape());
   return IsUnnestedReductionFasterThanElemental(
       {/*is_row_reduction=*/true, {1, kept_dimension_size, reduction_size}});
+}
+
+bool GpuLayoutAssignment::InstructionCanChangeLayoutInstance(
+    const HloInstruction* instruction) {
+
+  // The host offloading custom calls will be eventually removed
+  // by the offloader, so we need to make sure that the calls do not change
+  // the layout and thus cause layout mismatches after the removal.
+  const HloCustomCallInstruction* custom_call =
+      DynCast<HloCustomCallInstruction>(instruction);
+  if (custom_call != nullptr &&
+      (custom_call->custom_call_target() ==
+           host_memory_offload_annotations::kMoveToHostCustomCallTarget ||
+       custom_call->custom_call_target() ==
+           host_memory_offload_annotations::kMoveToDeviceCustomCallTarget)) {
+    return false;
+  }
+
+  return LayoutAssignment::InstructionCanChangeLayoutInstance(instruction);
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/gpu_layout_assignment.h
+++ b/xla/service/gpu/gpu_layout_assignment.h
@@ -68,6 +68,9 @@ class GpuLayoutAssignment : public LayoutAssignment {
 
   bool PropagateReductionLayoutToOperand(const HloInstruction* user) override;
 
+  bool InstructionCanChangeLayoutInstance(
+      const HloInstruction* instruction) override;
+
   const se::GpuComputeCapability gpu_version_;
   const se::dnn::VersionInfo dnn_version_;
 };


### PR DESCRIPTION
This patch makes sure that the host offloader will not introduce layout mismatches
after removing the offloading custom calls by constraining the layout assignment
to assign the same layout for the custom call's input and output.