### PR TITLE
Verifier: Allow dynamic-slice and dynamic-update-slice change spaces

### DIFF
--- a/xla/service/hlo_verifier.cc
+++ b/xla/service/hlo_verifier.cc
@@ -2776,6 +2776,11 @@ class InstructionVerifier : public DfsHloVisitorWithDefault {
           if (instruction->opcode() == HloOpcode::kConvert) {
             // Convert instructions can change element_size_in_bits
             equal_predicate.IgnoreElementSize();
+          } else if (instruction->opcode() == HloOpcode::kDynamicSlice ||
+                     instruction->opcode() == HloOpcode::kDynamicUpdateSlice) {
+            // DynamicSlice and DynamicUpdateSlice can be used to
+            // copy between memory spaces.
+            equal_predicate.IgnoreMemorySpace();
           }
           TF_RET_CHECK(equal_predicate(result_layout, operand_layout))
               << "Instruction shouldn't change layouts "


### PR DESCRIPTION
In preparation for host offloading with partial copies (using dynamic-update-slice and dynamic-slice instructions), this patch relaxes the verifier to allow different memory spaces for dynamic-update-slice and dynamic-slice instructions.