### PR TITLE
Exclude FP8 Conversions in DotOperandConverter

### DIFF
--- a/xla/service/gpu/dot_operand_converter_test.cc
+++ b/xla/service/gpu/dot_operand_converter_test.cc
@@ -106,6 +106,23 @@ TEST_F(DotOperandConverterTest, NoConvertHappensWithSameTypes) {
   EXPECT_FALSE(upcasted);
 }
 
+TEST_F(DotOperandConverterTest, NoConvertFromF8toF8) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    p0 = f8e4m3fn[2,3]{1,0} parameter(0)
+    p1 = f8e5m2[3,2]{1,0} parameter(1)
+    ROOT dot = bf16[2,2]{1,0} dot(p0, p1), lhs_contracting_dims={1},
+                                         rhs_contracting_dims={0}
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(module_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool upcasted,
+                          DotOperandConverter().Run(module.get()));
+  EXPECT_FALSE(upcasted);
+}
+
 TEST_F(DotOperandConverterTest, CompilerOptimizesUsingDotOperandConverter) {
   absl::string_view module_string = R"(
   HloModule module


### PR DESCRIPTION
Excludes conversions of dot operands between F8E4M3FN and F8E5M2 types in the DotOperandConverter pass.