### PR TITLE
Fix build error from PR 10497

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -5966,6 +5966,7 @@ xla_cc_test(
         "//xla/tests:hlo_test_base",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:env",
+	"@tsl//tsl/platform:status_matchers",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:protobuf",
     ]) + [

--- a/xla/service/gpu/autotuner_util_test.cc
+++ b/xla/service/gpu/autotuner_util_test.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "xla/tests/hlo_test_base.h"
 #include "tsl/lib/core/status_test_util.h"
 #include "tsl/platform/env.h"
+#include "tsl/platform/status_matchers.h"
 #include "tsl/platform/logging.h"   // IWYU pragma: keep
 #include "tsl/platform/protobuf.h"  // IWYU pragma: keep
 
@@ -45,7 +46,7 @@ using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::Not;
 using ::testing::TempDir;
-using ::testing::status::StatusIs;
+using ::tsl::testing::StatusIs;
 
 class AutotunerUtilTest : public HloTestBase {
  protected:


### PR DESCRIPTION
Added changes to fix build error that were encountered after merging changes from PR: https://github.com/openxla/xla/pull/10497

Used ::tsl::testing::StatusIs instead of ::testing::status::StatusIs
