### PR TITLE
Offloading 1/3: Add annotation for copy-start/copy-done

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -6117,6 +6117,7 @@ cc_library(
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/service:hlo_pass",
+        "//xla/hlo/utils:hlo_query",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status:statusor",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2194,7 +2194,7 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
         /*host_memory_offload_config=*/std::nullopt);
     HloRematerialization::RematerializationSizes sizes;
     pipeline.AddPass<HloRematerialization>(options, sizes);
-    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start_done=*/true);
+    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start=*/true);
     pipeline.AddPass<OptimizationBarrierExpander>();
 
     TF_ASSIGN_OR_RETURN(bool changed, pipeline.Run(module));

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2193,8 +2193,8 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
         /*min_remat_size=*/0, /*compact_shape_function=*/nullptr,
         /*host_memory_offload_config=*/std::nullopt);
     HloRematerialization::RematerializationSizes sizes;
-    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start_done=*/true);
     pipeline.AddPass<HloRematerialization>(options, sizes);
+    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start_done=*/true);
     pipeline.AddPass<OptimizationBarrierExpander>();
 
     TF_ASSIGN_OR_RETURN(bool changed, pipeline.Run(module));

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2193,6 +2193,7 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
         /*min_remat_size=*/0, /*compact_shape_function=*/nullptr,
         /*host_memory_offload_config=*/std::nullopt);
     HloRematerialization::RematerializationSizes sizes;
+    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start_done=*/true);
     pipeline.AddPass<HloRematerialization>(options, sizes);
     pipeline.AddPass<OptimizationBarrierExpander>();
 

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2194,7 +2194,7 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
         /*host_memory_offload_config=*/std::nullopt);
     HloRematerialization::RematerializationSizes sizes;
     pipeline.AddPass<HloRematerialization>(options, sizes);
-    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start=*/true);
+    pipeline.AddPass<StreamAttributeAnnotator>();
     pipeline.AddPass<OptimizationBarrierExpander>();
 
     TF_ASSIGN_OR_RETURN(bool changed, pipeline.Run(module));

--- a/xla/service/gpu/stream_attribute_annotator.cc
+++ b/xla/service/gpu/stream_attribute_annotator.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_query.h",
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/statusor.h"
@@ -125,20 +126,31 @@ absl::StatusOr<bool> StreamAttributeAnnotator::Run(
   XLA_VLOG_LINES(
       5, "StreamAttributeAnnotator::Run(), before:\n" + module->ToString());
   bool changed = false;
+  int64_t channel_id = hlo_query::NextChannelId(*module);
   for (const HloComputation* comp : module->computations(execution_threads)) {
     for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
       auto instr_gpu_config = instr->backend_config<GpuBackendConfig>();
       if (!instr_gpu_config.ok()) {
         continue;
       }
-      // For fusion instruction, only annotate
-      // when the root of fusion is a single instruction
-      // running on non-default stream.
-      if (instr->opcode() == HloOpcode::kFusion) {
-        TF_ASSIGN_OR_RETURN(bool comp_result,
-                            AnnotateStreamAttributesForInstruction(
-                                instr, instr_gpu_config.value()));
-        changed |= comp_result;
+      if (!copy_start_done_) {
+        // For fusion instruction, only annotate
+        // when the root of fusion is a single instruction
+        // running on non-default stream.
+        if (instr->opcode() == HloOpcode::kFusion) {
+          TF_ASSIGN_OR_RETURN(bool comp_result,
+                              AnnotateStreamAttributesForInstruction(
+                                  instr, instr_gpu_config.value()));
+          changed |= comp_result;
+        }
+      } else {
+        if (instr->opcode() == HloOpcode::kCopyStart) {
+          GpuBackendConfig gpu_backend_config;
+          gpu_backend_config.set_operation_queue_id(channel_id);
+          VLOG(3) << "Add copy-start's backend config: " << channel_id;
+          TF_RETURN_IF_ERROR(instr->set_backend_config(gpu_backend_config));
+          changed = true;
+	    }
       }
 
       TF_ASSIGN_OR_RETURN(

--- a/xla/service/gpu/stream_attribute_annotator.h
+++ b/xla/service/gpu/stream_attribute_annotator.h
@@ -45,11 +45,6 @@ namespace xla::gpu {
 
 class StreamAttributeAnnotator : public HloModulePass {
  public:
-  // copy_start_ is used to differentiate copy-start from
-  // other instructions as it doesn't need the annotations to split into
-  // AsyncStart and AsyncDone: copy-done is available already.
-  explicit StreamAttributeAnnotator(bool copy_start = false)
-      : HloModulePass(), copy_start_(copy_start) {}
   absl::string_view name() const override {
     return "stream-attribute-annotator";
   }
@@ -58,8 +53,6 @@ class StreamAttributeAnnotator : public HloModulePass {
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
- private:
-  bool copy_start_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/stream_attribute_annotator.h
+++ b/xla/service/gpu/stream_attribute_annotator.h
@@ -45,6 +45,8 @@ namespace xla::gpu {
 
 class StreamAttributeAnnotator : public HloModulePass {
  public:
+  explicit StreamAttributeAnnotator(bool copy_start_done = false)
+      : HloModulePass(), copy_start_done_(copy_start_done) {}
   absl::string_view name() const override {
     return "stream-attribute-annotator";
   }
@@ -53,6 +55,8 @@ class StreamAttributeAnnotator : public HloModulePass {
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+ private:
+  bool copy_start_done_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/stream_attribute_annotator.h
+++ b/xla/service/gpu/stream_attribute_annotator.h
@@ -45,8 +45,11 @@ namespace xla::gpu {
 
 class StreamAttributeAnnotator : public HloModulePass {
  public:
-  explicit StreamAttributeAnnotator(bool copy_start_done = false)
-      : HloModulePass(), copy_start_done_(copy_start_done) {}
+  // copy_start_ is used to differentiate copy-start from
+  // other instructions as it doesn't need the annotations to split into
+  // AsyncStart and AsyncDone: copy-done is available already.
+  explicit StreamAttributeAnnotator(bool copy_start = false)
+      : HloModulePass(), copy_start_(copy_start) {}
   absl::string_view name() const override {
     return "stream-attribute-annotator";
   }
@@ -56,7 +59,7 @@ class StreamAttributeAnnotator : public HloModulePass {
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
  private:
-  bool copy_start_done_;
+  bool copy_start_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/stream_attribute_annotator_test.cc
+++ b/xla/service/gpu/stream_attribute_annotator_test.cc
@@ -193,7 +193,7 @@ TEST_F(StreamAttributeAnnotatorTest, CopyStartIsAnnotated) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kHloString));
 
-  StreamAttributeAnnotator attr_annotator(/*copy_start_done=*/true);
+  StreamAttributeAnnotator attr_annotator;
   bool changed;
   TF_ASSERT_OK_AND_ASSIGN(changed, attr_annotator.Run(module.get()));
   EXPECT_TRUE(changed);

--- a/xla/service/gpu/stream_attribute_annotator_test.cc
+++ b/xla/service/gpu/stream_attribute_annotator_test.cc
@@ -164,5 +164,48 @@ TEST_F(StreamAttributeAnnotatorTest, FusionIsAnnotated) {
   EXPECT_EQ(gpu_config.operation_queue_id(), 1);
 }
 
+TEST_F(StreamAttributeAnnotatorTest, CopyStartIsAnnotated) {
+  constexpr absl::string_view kHloString = R"(
+  HloModule offloading
+    ENTRY %main (param_0: f32[1024], param_1: f32[1024]) -> f32[1024] {
+    %param_1 = f32[1024]{0} parameter(1)
+    %param_0 = f32[1024]{0} parameter(0)
+    %res_3 = f32[1024]{0} add(f32[1024]{0} %param_0, f32[1024]{0} %param_1)
+    %copy-start = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_3)
+    %res_4 = f32[1024]{0} tanh(f32[1024]{0} %res_3)
+    %copy-start.2 = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_4)
+    %res_5 = f32[1024]{0} tanh(f32[1024]{0} %res_4)
+    %copy-done = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start)
+    %res_6 = f32[1024]{0} tanh(f32[1024]{0} %res_5)
+    %copy-done.2 = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start.2)
+    %copy-start.3 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done.2)
+    %res_7 = f32[1024]{0} add(f32[1024]{0} %res_6, f32[1024]{0} %res_6)
+    %copy-start.1 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done)
+    %res_8 = f32[1024]{0} add(f32[1024]{0} %res_7, f32[1024]{0} %res_5)
+    %copy-done.3 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.3)
+    %res_9 = f32[1024]{0} add(f32[1024]{0} %res_8, f32[1024]{0} %copy-done.3)
+    %copy-done.1 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.1)
+    %res_10 = f32[1024]{0} add(f32[1024]{0} %res_9, f32[1024]{0} %copy-done.1)
+    ROOT %res_11 = f32[1024]{0} tanh(f32[1024]{0} %res_10)
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloString));
+
+  StreamAttributeAnnotator attr_annotator(/*copy_start_done=*/true);
+  bool changed;
+  TF_ASSERT_OK_AND_ASSIGN(changed, attr_annotator.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  for (std::string i : {"", ".1", ".2", ".3"}) {
+    const HloInstruction* cp_start = FindInstruction(
+        module.get(), "copy-start" + i);
+    EXPECT_TRUE(cp_start->has_backend_config());
+    TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig gpu_config,
+                            cp_start->backend_config<GpuBackendConfig>());
+    EXPECT_EQ(gpu_config.operation_queue_id(), 1);
+  }
+}
 }  // namespace
 }  // namespace xla::gpu


### PR DESCRIPTION
Add stream id in the backend_config of copy-start instruction. The stream id is obtained from hlo_query::NextChannelId(). 
The corresponding copy-done instruction which is the use of copy-start instruction will be traversed and added the stream id in the backend_config too. This part is automatically done by the subsequent AnnotateStreamAttributesForUsers() existing in the function.
The bool data member copy_start_done_ is used to differentiate copy-start/copy-done from other collective instructions and go through two different paths.
https://github.com/openxla/xla/pull/10450 is split and the current PR is the first 1 out of 3 PRs.