### PR TITLE
Offloading 2/3: copy thunk implementation based on stream attribute annotator

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -6101,6 +6101,7 @@ cc_library(
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/utils:hlo_query",
         "//xla/service:hlo_pass",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2193,8 +2193,8 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
         /*min_remat_size=*/0, /*compact_shape_function=*/nullptr,
         /*host_memory_offload_config=*/std::nullopt);
     HloRematerialization::RematerializationSizes sizes;
-    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start_done=*/true);
     pipeline.AddPass<HloRematerialization>(options, sizes);
+    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start_done=*/true);
     pipeline.AddPass<OptimizationBarrierExpander>();
 
     TF_ASSIGN_OR_RETURN(bool changed, pipeline.Run(module));

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2193,6 +2193,7 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
         /*min_remat_size=*/0, /*compact_shape_function=*/nullptr,
         /*host_memory_offload_config=*/std::nullopt);
     HloRematerialization::RematerializationSizes sizes;
+    pipeline.AddPass<StreamAttributeAnnotator>(/*copy_start_done=*/true);
     pipeline.AddPass<HloRematerialization>(options, sizes);
     pipeline.AddPass<OptimizationBarrierExpander>();
 

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -42,6 +42,7 @@ limitations under the License.
 #include "xla/service/gpu/ir_emitter.h"
 #include "xla/service/gpu/ir_emitter_context.h"
 #include "xla/service/gpu/launch_dimensions.h"
+#include "xla/service/gpu/runtime/copy_thunk.h"
 #include "xla/service/gpu/runtime/send_recv_thunk.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/service/llvm_ir/ir_array.h"
@@ -198,6 +199,8 @@ class IrEmitterUnnested : public IrEmitter {
       const HloCollectivePermuteInstruction* instr);
 
   absl::Status EmitCopyStartThunk(const HloCopyStartInstruction* instr);
+
+  absl::Status EmitCopyDoneThunk(const HloInstruction* instr);
 
   absl::Status EmitHloInstruction(const HloInstruction* instr);
 
@@ -376,6 +379,9 @@ class IrEmitterUnnested : public IrEmitter {
 
   // Container for async send/recv events shared by send/recv thunks.
   std::shared_ptr<SendRecvAsyncEvents> send_recv_events_;
+
+  // Container for async copy-start/copy-done events.
+  std::shared_ptr<CopyAsyncEvents> copy_events_;
 
   // Returns the ShapedSlices for the given operands.
   absl::StatusOr<std::vector<ShapedSlice>> GetShapedSlices(

--- a/xla/service/gpu/runtime/copy_thunk.h
+++ b/xla/service/gpu/runtime/copy_thunk.h
@@ -18,62 +18,111 @@ limitations under the License.
 
 #include <cstdint>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/thunk.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/stream_executor.h"
 
 namespace xla {
 namespace gpu {
 
 // A thunk that copies data from a device buffer to another device buffer.
 class DeviceToDeviceCopyThunk : public Thunk {
- public:
+public:
   // Constructs a CopyThunk that copies host data from `source_buffer` to the
   // device buffer `destination_buffer`. `mem_size` is the size of the data in
   // bytes.
   DeviceToDeviceCopyThunk(ThunkInfo thunk_info,
-                          const BufferAllocation::Slice& source_buffer,
-                          const BufferAllocation::Slice& destination_buffer,
+                          const BufferAllocation::Slice &source_buffer,
+                          const BufferAllocation::Slice &destination_buffer,
                           uint64_t mem_size);
 
-  DeviceToDeviceCopyThunk(const DeviceToDeviceCopyThunk&) = delete;
-  DeviceToDeviceCopyThunk& operator=(const DeviceToDeviceCopyThunk&) = delete;
+  DeviceToDeviceCopyThunk(const DeviceToDeviceCopyThunk &) = delete;
+  DeviceToDeviceCopyThunk &operator=(const DeviceToDeviceCopyThunk &) = delete;
 
-  absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+  absl::Status ExecuteOnStream(const ExecuteParams &params) override;
 
   void ClearCompileTimeInfo() override { Thunk::ClearCompileTimeInfo(); }
 
-  const BufferAllocation::Slice& source() const { return source_buffer_; }
-  const BufferAllocation::Slice& destination() const {
+  const BufferAllocation::Slice &source() const { return source_buffer_; }
+  const BufferAllocation::Slice &destination() const {
     return destination_buffer_;
   }
   uint64_t size_bytes() const { return mem_size_; }
 
- private:
+private:
   const BufferAllocation::Slice source_buffer_;
   const BufferAllocation::Slice destination_buffer_;
   const uint64_t mem_size_;
 };
 
-class DeviceToHostCopyThunk : public DeviceToDeviceCopyThunk {
- public:
-  DeviceToHostCopyThunk(ThunkInfo thunk_info,
-                        const BufferAllocation::Slice& source_buffer,
-                        const BufferAllocation::Slice& destination_buffer,
-                        uint64_t mem_size);
-  absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+//===----------------------------------------------------------------------===//
+// CopyAsyncEvents
+//===----------------------------------------------------------------------===//
+class CopyAsyncEvents {
+public:
+  // Add a new copy-start completion event.
+  // absl::StatusOr<std::shared_ptr<se::Event>> Emplace(
+  absl::Status Emplace(se::StreamExecutor *executor,
+                       const HloInstruction *instr, se::Event &&event);
+
+  // Retrieve a completion event started by copy-start instruction
+  // `instr`, and remove the event from the collection.
+
+  absl::StatusOr<se::Event> Extract(se::StreamExecutor *executor,
+                                    const HloInstruction *instr);
+
+private:
+  using Key = std::pair<se::StreamExecutor *, const HloInstruction *>;
+  absl::Mutex mutex_;
+  absl::flat_hash_map<Key, se::Event> events_ ABSL_GUARDED_BY(mutex_);
 };
 
-class HostToDeviceCopyThunk : public DeviceToDeviceCopyThunk {
- public:
-  HostToDeviceCopyThunk(ThunkInfo thunk_info,
-                        const BufferAllocation::Slice& source_buffer,
-                        const BufferAllocation::Slice& destination_buffer,
-                        uint64_t mem_size);
-  absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+//===----------------------------------------------------------------------===//
+// DeviceHostCopyThunk
+//===----------------------------------------------------------------------===//
+// A thunk that copies data from a device buffer to a host buffer.
+class DeviceHostCopyThunk : public DeviceToDeviceCopyThunk {
+public:
+  // Constructs a CopyThunk that copies host data from `source_buffer` to the
+  // device buffer `destination_buffer`. `mem_size` is the size of the data in
+  // bytes. `instr` is the copy-start instruction. `device_to_host` indicates
+  // whether to generate device-to-host or host-to-device memcpy.
+  DeviceHostCopyThunk(ThunkInfo thunk_info,
+                      const BufferAllocation::Slice &source_buffer,
+                      const BufferAllocation::Slice &destination_buffer,
+                      uint64_t mem_size,
+                      std::shared_ptr<CopyAsyncEvents> events,
+                      const HloInstruction *instr, bool device_to_host);
+  absl::Status ExecuteOnStream(const ExecuteParams &params) override;
+
+private:
+  std::shared_ptr<CopyAsyncEvents> async_events_;
+  const HloInstruction *instr_;
+  bool device_to_host_;
 };
 
-}  // namespace gpu
-}  // namespace xla
+//===----------------------------------------------------------------------===//
+// DeviceHostCopyDoneThunk
+//===----------------------------------------------------------------------===//
 
-#endif  // XLA_SERVICE_GPU_RUNTIME_COPY_THUNK_H_
+class DeviceHostCopyDoneThunk : public Thunk {
+public:
+  DeviceHostCopyDoneThunk(Thunk::Kind kind, ThunkInfo thunk_info,
+                          std::shared_ptr<CopyAsyncEvents> events,
+                          const HloInstruction *copy_start_instr);
+
+  absl::Status ExecuteOnStream(const ExecuteParams &params) override;
+
+private:
+  std::shared_ptr<CopyAsyncEvents> async_events_;
+  const HloInstruction *copy_start_instr_;
+};
+
+} // namespace gpu
+} // namespace xla
+
+#endif // XLA_SERVICE_GPU_RUNTIME_COPY_THUNK_H_

--- a/xla/service/gpu/stream_attribute_annotator.cc
+++ b/xla/service/gpu/stream_attribute_annotator.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_query.h",
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/thunk.h"
 #include "xla/statusor.h"
@@ -125,20 +126,31 @@ absl::StatusOr<bool> StreamAttributeAnnotator::Run(
   XLA_VLOG_LINES(
       5, "StreamAttributeAnnotator::Run(), before:\n" + module->ToString());
   bool changed = false;
+  int64_t channel_id = hlo_query::NextChannelId(*module);
   for (const HloComputation* comp : module->computations(execution_threads)) {
     for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
       auto instr_gpu_config = instr->backend_config<GpuBackendConfig>();
       if (!instr_gpu_config.ok()) {
         continue;
       }
-      // For fusion instruction, only annotate
-      // when the root of fusion is a single instruction
-      // running on non-default stream.
-      if (instr->opcode() == HloOpcode::kFusion) {
-        TF_ASSIGN_OR_RETURN(bool comp_result,
-                            AnnotateStreamAttributesForInstruction(
-                                instr, instr_gpu_config.value()));
-        changed |= comp_result;
+      if (!copy_start_done_) {
+        // For fusion instruction, only annotate
+        // when the root of fusion is a single instruction
+        // running on non-default stream.
+        if (instr->opcode() == HloOpcode::kFusion) {
+          TF_ASSIGN_OR_RETURN(bool comp_result,
+                              AnnotateStreamAttributesForInstruction(
+                                  instr, instr_gpu_config.value()));
+          changed |= comp_result;
+        }
+      } else {
+        if (instr->opcode() == HloOpcode::kCopyStart) {
+          GpuBackendConfig gpu_backend_config;
+          gpu_backend_config.set_operation_queue_id(channel_id);
+          VLOG(3) << "Add copy-start's backend config: " << channel_id;
+          TF_RETURN_IF_ERROR(instr->set_backend_config(gpu_backend_config));
+          changed = true;
+	    }
       }
 
       TF_ASSIGN_OR_RETURN(

--- a/xla/service/gpu/stream_attribute_annotator.h
+++ b/xla/service/gpu/stream_attribute_annotator.h
@@ -45,6 +45,8 @@ namespace xla::gpu {
 
 class StreamAttributeAnnotator : public HloModulePass {
  public:
+  explicit StreamAttributeAnnotator(bool copy_start_done = false)
+      : HloModulePass(), copy_start_done_(copy_start_done) {}
   absl::string_view name() const override {
     return "stream-attribute-annotator";
   }
@@ -53,6 +55,8 @@ class StreamAttributeAnnotator : public HloModulePass {
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+ private:
+  bool copy_start_done_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/thunk.cc
+++ b/xla/service/gpu/thunk.cc
@@ -224,6 +224,7 @@ Thunk::ExecuteParams::ExecuteParams(
     CASE(kConvolution);
     CASE(kConvolutionReorder);
     CASE(kCopy);
+    CASE(kCopyDone);
     CASE(kCubSort);
     CASE(kCublasLtMatmul);
     CASE(kCustomCall);

--- a/xla/service/gpu/thunk.h
+++ b/xla/service/gpu/thunk.h
@@ -93,6 +93,7 @@ class Thunk {
     kConvolution,
     kConvolutionReorder,
     kCopy,
+    kCopyDone,
     kCommandBuffer,
     kCubSort,
     kCublasLtMatmul,


### PR DESCRIPTION
Emit the copy-start and copy-done thunks to generate memcpy H2D and D2H on an additional stream other than the main compute stream. The asynchronous memcpy is guarded by RecordEvent() and WaitForEvent() to ensure the necessary synchronization before using the tensor. To wait for the corresponding event properly, we create a hash table to map the copy-start instruction to the event. And the hash table entry is retrieved and extracted upon copy-done.