### PR TITLE
[ROCM] fixing build brake and temporarily disable delayed kernel for rocm

### DIFF
--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -330,6 +330,9 @@ gpu_only_cc_library(
     name = "gpu_timer",
     srcs = ["gpu_timer.cc"],
     hdrs = ["gpu_timer.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
     deps = [
         ":gpu_driver_header",
         ":gpu_executor_header",


### PR DESCRIPTION
This PR fixes the ongoing build brake after https://github.com/openxla/xla/commit/28cfdcd27859e79cf10bd92779bc29f6404c79a0

and also I temporarily disable delayed kernel for ROCM since it significantly increases running times (to be investigated).

@xla-rotation: would you please have a look ?