### PR TITLE
[XLA:GPU] Fix cuDNN FMHA rewriter sequence length checks and Bump up minimum flash attn cuDNN version to 8.9.4

### DIFF
--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -315,19 +315,6 @@ bool IsSupportedPrimitiveType(const HloInstruction* bmm) {
   return dtype == BF16 || dtype == F16;
 }
 
-bool IsContractingDimSupported(absl::Span<const int64_t> contracting_dims) {
-  return absl::c_all_of(contracting_dims,
-                        [](int64_t dim) { return dim == 64; });
-}
-
-bool IsNonContractingDimSupported(
-    const std::vector<int64_t>& non_contracting_dims, bool is_training) {
-  // For training, cuDNN require non_contracting_dim to be Divisible by 64
-  return absl::c_all_of(non_contracting_dims, [&](int64_t dim) {
-    return dim <= 512 && (!is_training || dim % 64 == 0);
-  });
-}
-
 std::vector<int64_t> GetDimensionVector(absl::Span<const int64_t> dimensions,
                                         absl::Span<const int64_t> dim_nums) {
   std::vector<int64_t> vec(dim_nums.size());
@@ -337,150 +324,127 @@ std::vector<int64_t> GetDimensionVector(absl::Span<const int64_t> dimensions,
   return vec;
 }
 
-absl::StatusOr<bool> IsSupportedBMM1(const HloInstruction* bmm_1,
-                                     bool is_training) {
-  const DotDimensionNumbers& dot_dims_bmm1 = bmm_1->dot_dimension_numbers();
+absl::StatusOr<bool> GetBHSD(HloInstruction* bmm_1, HloInstruction* bmm_2,
+                             bool need_canonicalization,
+                             std::vector<int64_t>& bhsd) {
+  // get bhsd from bmm1
+  const DotDimensionNumbers& bmm1_dnums = bmm_1->dot_dimension_numbers();
   TF_ASSIGN_OR_RETURN(
-      std::vector<int64_t> lhs_non_contracting_dim_nums_bmm1,
+      std::vector<int64_t> bmm1_s_q_dims,
       GetNonContractingDims(bmm_1->operand(0)->shape(),
-                            dot_dims_bmm1.lhs_batch_dimensions(),
-                            dot_dims_bmm1.lhs_contracting_dimensions()));
+                            bmm1_dnums.lhs_batch_dimensions(),
+                            bmm1_dnums.lhs_contracting_dimensions()));
+
   TF_ASSIGN_OR_RETURN(
-      std::vector<int64_t> rhs_non_contracting_dim_nums_bmm1,
+      std::vector<int64_t> bmm1_s_kv_dims,
       GetNonContractingDims(bmm_1->operand(1)->shape(),
-                            dot_dims_bmm1.rhs_batch_dimensions(),
-                            dot_dims_bmm1.rhs_contracting_dimensions()));
-  std::vector<int64_t> lhs_non_contracting_dims_bmm1 =
+                            bmm1_dnums.rhs_batch_dimensions(),
+                            bmm1_dnums.rhs_contracting_dimensions()));
+
+  std::vector<int64_t> bmm1_bh =
       GetDimensionVector(bmm_1->operand(0)->shape().dimensions(),
-                         lhs_non_contracting_dim_nums_bmm1);
-  std::vector<int64_t> rhs_non_contracting_dims_bmm1 =
-      GetDimensionVector(bmm_1->operand(1)->shape().dimensions(),
-                         rhs_non_contracting_dim_nums_bmm1);
-  // The non contracting dimensions for BMM1 need to be less than or equal to
-  // 512.
-  if (!IsNonContractingDimSupported(lhs_non_contracting_dims_bmm1,
-                                    is_training) ||
-      !IsNonContractingDimSupported(rhs_non_contracting_dims_bmm1,
-                                    is_training)) {
-    if (VLOG_IS_ON(2)) {
-      VLOG(2) << "BMM1 lhs_non_contracting_dims: "
-              << absl::StrJoin(lhs_non_contracting_dims_bmm1, ",")
-              << " BMM1 rhs_non_contracting_dims: "
-              << absl::StrJoin(rhs_non_contracting_dims_bmm1, ",")
-              << " are not supported. The non-contracting dims should be less "
-                 "than 512. This is a criteria for current cuDNN 8.8 support.";
-    }
+                         bmm1_dnums.lhs_batch_dimensions());
+
+  std::vector<int64_t> bmm1_s_q = GetDimensionVector(
+      bmm_1->operand(0)->shape().dimensions(), bmm1_s_q_dims);
+
+  std::vector<int64_t> bmm1_s_kv = GetDimensionVector(
+      bmm_1->operand(1)->shape().dimensions(), bmm1_s_kv_dims);
+
+  std::vector<int64_t> bmm1_d =
+      GetDimensionVector(bmm_1->operand(0)->shape().dimensions(),
+                         bmm1_dnums.lhs_contracting_dimensions());
+
+  TF_RET_CHECK(bmm1_bh.size() == 2);
+  TF_RET_CHECK(bmm1_s_q.size() == 1);
+  TF_RET_CHECK(bmm1_s_kv.size() == 1);
+  TF_RET_CHECK(bmm1_d.size() == 1);
+
+  // get bhsd from bmm2
+  const DotDimensionNumbers& bmm2_dnums = bmm_2->dot_dimension_numbers();
+  TF_ASSIGN_OR_RETURN(
+      std::vector<int64_t> bmm2_lhs_non_contracting_dims,
+      GetNonContractingDims(bmm_2->operand(0)->shape(),
+                            bmm2_dnums.lhs_batch_dimensions(),
+                            bmm2_dnums.lhs_contracting_dimensions()));
+
+  TF_ASSIGN_OR_RETURN(
+      std::vector<int64_t> bmm2_rhs_non_contracting_dims,
+      GetNonContractingDims(bmm_2->operand(1)->shape(),
+                            bmm2_dnums.rhs_batch_dimensions(),
+                            bmm2_dnums.rhs_contracting_dimensions()));
+
+  std::vector<int64_t> bmm2_bh =
+      GetDimensionVector(bmm_2->operand(0)->shape().dimensions(),
+                         bmm2_dnums.lhs_batch_dimensions());
+
+  std::vector<int64_t> bmm2_s_kv =
+      GetDimensionVector(bmm_2->operand(0)->shape().dimensions(),
+                         bmm2_dnums.lhs_contracting_dimensions());
+
+  std::vector<int64_t> bmm2_s_q =
+      need_canonicalization
+          ? GetDimensionVector(bmm_2->operand(1)->shape().dimensions(),
+                               bmm2_rhs_non_contracting_dims)
+          : GetDimensionVector(bmm_2->operand(0)->shape().dimensions(),
+                               bmm2_lhs_non_contracting_dims);
+
+  std::vector<int64_t> bmm2_d =
+      need_canonicalization
+          ? GetDimensionVector(bmm_2->operand(0)->shape().dimensions(),
+                               bmm2_lhs_non_contracting_dims)
+          : GetDimensionVector(bmm_2->operand(1)->shape().dimensions(),
+                               bmm2_rhs_non_contracting_dims);
+
+  TF_RET_CHECK(bmm2_bh.size() == 2);
+  TF_RET_CHECK(bmm2_s_q.size() == 1);
+  TF_RET_CHECK(bmm2_s_kv.size() == 1);
+  TF_RET_CHECK(bmm2_d.size() == 1);
+
+  // check if bhsd is correct between bmm1 and bmm2
+  if (bmm1_bh[0] != bmm2_bh[0] || bmm1_bh[1] != bmm2_bh[1] ||
+      bmm1_s_q[0] != bmm2_s_q[0] || bmm1_s_kv[0] != bmm2_s_kv[0] ||
+      bmm1_d[0] != bmm2_d[0]) {
     return false;
   }
 
-  std::vector<int64_t> lhs_contracting_dims_bmm1 =
-      GetDimensionVector(bmm_1->operand(0)->shape().dimensions(),
-                         dot_dims_bmm1.lhs_contracting_dimensions());
-  std::vector<int64_t> rhs_contracting_dims_bmm1 =
-      GetDimensionVector(bmm_1->operand(1)->shape().dimensions(),
-                         dot_dims_bmm1.rhs_contracting_dimensions());
-
-  // The contracting dimensions for BMM1 need to be 64.
-  if (!IsContractingDimSupported(lhs_contracting_dims_bmm1) ||
-      !IsContractingDimSupported(rhs_contracting_dims_bmm1)) {
-    if (VLOG_IS_ON(2)) {
-      VLOG(2) << "BMM1 lhs_contracting_dims: "
-              << absl::StrJoin(lhs_contracting_dims_bmm1, ",")
-              << " BMM1 rhs_contracting_dims: "
-              << absl::StrJoin(rhs_contracting_dims_bmm1, ",")
-              << " are not supported.";
-    }
-    return false;
-  }
+  bhsd = {bmm1_bh[0], bmm1_bh[1], bmm1_s_q[0], bmm1_s_kv[0], bmm1_d[0]};
   return true;
 }
 
-absl::StatusOr<bool> IsSupportedBMM2(const HloInstruction* bmm_2,
-                                     bool need_canonicalization) {
-  const DotDimensionNumbers& dot_dims_bmm2 = bmm_2->dot_dimension_numbers();
-  // need swap lhs and rhs for bmm2 if canonicalization is needed
-  int operand_index = need_canonicalization ? 0 : 1;
-  auto batch_dim = need_canonicalization ? dot_dims_bmm2.lhs_batch_dimensions()
-                                         : dot_dims_bmm2.rhs_batch_dimensions();
-  auto contracting_dim = need_canonicalization
-                             ? dot_dims_bmm2.lhs_contracting_dimensions()
-                             : dot_dims_bmm2.rhs_contracting_dimensions();
-
-  TF_ASSIGN_OR_RETURN(
-      std::vector<int64_t> non_contracting_dim_nums_bmm2,
-      GetNonContractingDims(bmm_2->operand(operand_index)->shape(), batch_dim,
-                            contracting_dim));
-
-  std::vector<int64_t> non_contracting_dims_bmm2 =
-      GetDimensionVector(bmm_2->operand(operand_index)->shape().dimensions(),
-                         non_contracting_dim_nums_bmm2);
-  // The non contracting dimension for BMM2 needs to be 64 for the input matrix.
-  // The input matrix is the second argument to BMM2 i.e, rhs.
-  if (!absl::c_all_of(non_contracting_dims_bmm2,
-                      [](int64_t dim) { return dim == 64; })) {
-    if (VLOG_IS_ON(2)) {
-      VLOG(2) << " BMM2 rhs_non_contracting_dims: "
-              << absl::StrJoin(non_contracting_dims_bmm2, ",")
-              << " are not supported.";
-    }
-    return false;
-  }
-  return true;
+absl::StatusOr<bool> IsFusedAttention(
+    std::vector<int64_t>& bhsd, bool is_training,
+    stream_executor::CudaComputeCapability cc,
+    stream_executor::dnn::VersionInfo cudnn_version) {
+  // otherwise check if it is supported by regular attention
+  int64_t s_q = bhsd[2];
+  int64_t s_kv = bhsd[3];
+  int64_t hidden_dim = bhsd[4];
+  bool is_seqlen_supported = (s_q <= 512 && s_kv <= 512) &&
+                             (!is_training || s_q % 64 == 0 && s_kv % 64 == 0);
+  bool is_hidden_dim_supported = hidden_dim == 64;
+  bool is_fused_attention = is_seqlen_supported && is_hidden_dim_supported;
+  return is_fused_attention;
 }
 
 absl::StatusOr<bool> IsFlashAttention(
-    HloInstruction* bmm_1, bool is_causal_mask,
-    absl::string_view custom_call_name,
+    std::vector<int64_t>& bhsd, bool is_training,
     stream_executor::CudaComputeCapability cc,
     stream_executor::dnn::VersionInfo cudnn_version) {
-  const DotDimensionNumbers& dnums = bmm_1->dot_dimension_numbers();
-  TF_ASSIGN_OR_RETURN(
-      std::vector<int64_t> seq_q_dims,
-      GetNonContractingDims(bmm_1->operand(0)->shape(),
-                            dnums.lhs_batch_dimensions(),
-                            dnums.lhs_contracting_dimensions()));
+  int64_t s_q = bhsd[2];
+  int64_t s_kv = bhsd[3];
+  int64_t hidden_dim = bhsd[4];
+  bool is_seqlen_supported = (s_q > 512 || s_kv > 512) &&
+                             (!is_training || s_q % 2 == 0 && s_kv % 2 == 0);
+  bool is_hidden_dim_supported = hidden_dim <= 128 && hidden_dim % 8 == 0;
+  bool is_flash_attention = is_seqlen_supported && is_hidden_dim_supported;
 
-  TF_ASSIGN_OR_RETURN(
-      std::vector<int64_t> seq_k_dims,
-      GetNonContractingDims(bmm_1->operand(1)->shape(),
-                            dnums.rhs_batch_dimensions(),
-                            dnums.rhs_contracting_dimensions()));
-
-  std::vector<int64_t> seq_q =
-      GetDimensionVector(bmm_1->operand(0)->shape().dimensions(), seq_q_dims);
-
-  std::vector<int64_t> seq_k =
-      GetDimensionVector(bmm_1->operand(1)->shape().dimensions(), seq_k_dims);
-
-  std::vector<int64_t> hidden_dim =
-      GetDimensionVector(bmm_1->operand(0)->shape().dimensions(),
-                         dnums.lhs_contracting_dimensions());
-  // for now, seq_q and seq_k should be equal for flash attention to work
-  // flash attention only supports fixed topology so we check if custom call is
-  // such topology by checking custom_call_name
-  TF_RET_CHECK(seq_q.size() == 1);
-  TF_RET_CHECK(seq_k.size() == 1);
-  TF_RET_CHECK(hidden_dim.size() == 1);
-
-  auto is_seqlen_supported = seq_q[0] > 512 && seq_k[0] > 512 &&
-                             seq_q[0] % 64 == 0 && seq_k[0] % 64 == 0;
-  auto is_hidden_dim_supported = hidden_dim[0] == 64 || hidden_dim[0] == 128;
-  auto is_flash_attention = is_seqlen_supported && is_hidden_dim_supported;
-  auto is_cross_attention = seq_q[0] != seq_k[0];
-
-  // flash attention requires cuDNN 8.9.3 to run non-fused QKV
+  // flash attention requires cuDNN 8.9.4 to run non-fused QKV
   // once we have fused QKV support, we can relax this contraint
   if (is_flash_attention &&
       !IsComputeCapabilityAndCudnnSupported(
-          cc, cudnn_version, stream_executor::dnn::VersionInfo(8, 9, 3))) {
-    VLOG(2) << "Require cuDNN 8.9.3 to run flash attention.";
-    return false;
-  }
-  // flash attention cross attention requires cuDNN 8.9.4 to run
-  if (is_cross_attention &&
-      !IsComputeCapabilityAndCudnnSupported(
           cc, cudnn_version, stream_executor::dnn::VersionInfo(8, 9, 4))) {
-    VLOG(2) << "Require cuDNN 8.9.4 to run flash cross attention.";
+    VLOG(2) << "Require cuDNN 8.9.4 to run flash attention.";
     return false;
   }
   return is_flash_attention;
@@ -1239,10 +1203,19 @@ absl::StatusOr<bool> IsMHABlockSupported(
     return false;
   }
 
+  // get batch/num heads/sequence length/hidden dim from bmm1 and bmm2
+  // also make sure they are the same between bmm1 and bmm2
+  std::vector<int64_t> bhsd;
+  TF_ASSIGN_OR_RETURN(bool success,
+                      GetBHSD(bmm_1, bmm_2, need_canonicalization, bhsd));
+  if (!success) {
+    VLOG(2) << "bmm1 and bmm2 have different bhsd length.";
+    return false;
+  }
+
   // check if matched attention block is supported by cuDNN flash attention.
   TF_ASSIGN_OR_RETURN(is_flash_attention,
-                      IsFlashAttention(bmm_1, is_causal_mask, custom_call_name,
-                                       cc, cudnn_version));
+                      IsFlashAttention(bhsd, is_training, cc, cudnn_version));
   if (is_flash_attention) {
     if (is_causal_mask) {
       // if bias is causal mask, needs to remove bias from name
@@ -1259,14 +1232,10 @@ absl::StatusOr<bool> IsMHABlockSupported(
     }
     return true;
   }
-  // otherwise check if it is supported by regular attention
-  TF_ASSIGN_OR_RETURN(bool is_bmm1_supported,
-                      IsSupportedBMM1(bmm_1, is_training));
-  if (!is_bmm1_supported) return false;
-  TF_ASSIGN_OR_RETURN(bool is_bmm2_supported,
-                      IsSupportedBMM2(bmm_2, need_canonicalization));
-  if (!is_bmm2_supported) return false;
-  return true;
+  // check if matched attention block is supported by cuDNN fused attention.
+  TF_ASSIGN_OR_RETURN(bool is_fused_attention,
+                      IsFusedAttention(bhsd, is_training, cc, cudnn_version));
+  return is_fused_attention;
 }
 
 absl::StatusOr<HloInstruction*> CanonicalizeBatchedGemmForcuDNNFMHA(

--- a/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter_test.cc
@@ -93,13 +93,6 @@ class CudnnFusedMhaRewriterTestHloTest : public HloTestBase {
     // Fake a supported compute capability to run tests,
     // we don't run any kernels in these tests so they should be safe
     // to run anywhere.
-    return se::dnn::VersionInfo(8, 9, 3);
-  }
-
-  se::dnn::VersionInfo GetCudnnVersionWithFlashCrossAttentionSupport() {
-    // Fake a supported compute capability to run tests,
-    // we don't run any kernels in these tests so they should be safe
-    // to run anywhere.
     return se::dnn::VersionInfo(8, 9, 4);
   }
 
@@ -4361,73 +4354,6 @@ ENTRY main.82 {
   EXPECT_EQ(config.is_causal_mask(), false);
 }
 
-TEST_F(CudnnFusedMhaRewriterTestHloTest,
-       FlashAttentionF16Bmm1BiasSoftmaxBmm2PatternCrossAttention) {
-  if (skip_reason_) GTEST_SKIP() << *skip_reason_;
-  const char* module_str = R"(
-HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(f16[2,6,2048,64]{3,2,1,0},f16[2,6,64,1024]{3,2,1,0},f16[2,6,1024,64]{3,2,1,0},f16[2,6,2048,1024]{3,2,1,0})->f16[2,6,2048,64]{3,2,1,0}}
-
-region_0.7 {
-  Arg_0.8 = f16[] parameter(0)
-  Arg_1.9 = f16[] parameter(1)
-  ROOT maximum = f16[] maximum(Arg_0.8, Arg_1.9)
-}
-
-region_1.19 {
-  Arg_0.20 = f32[] parameter(0)
-  Arg_1.21 = f32[] parameter(1)
-  ROOT add = f32[] add(Arg_0.20, Arg_1.21)
-}
-
-ENTRY main.31 {
-  Arg_0.1 = f16[2,6,2048,64]{3,2,1,0} parameter(0), sharding={replicated}
-  Arg_1.2 = f16[2,6,64,1024]{3,2,1,0} parameter(1), sharding={replicated}
-  dot = f16[2,6,2048,1024]{3,2,1,0} dot(Arg_0.1, Arg_1.2), lhs_contracting_dims={3}, rhs_contracting_dims={2}, lhs_batch_dims={0,1}, rhs_batch_dims={0,1}
-  Arg_3.4 = f16[2,6,2048,1024]{3,2,1,0} parameter(3), sharding={replicated}
-  add.1 = f16[2,6,2048,1024]{3,2,1,0} add(dot, Arg_3.4)
-  constant = f16[] constant(-inf)
-  reduce.11 = f16[2,6,2048]{2,1,0} reduce(add.1, constant), dimensions={3}, to_apply=region_0.7
-  broadcast.3 = f16[2,6,2048,1024]{3,2,1,0} broadcast(reduce.11), dimensions={0,1,2}
-  subtract.1 = f16[2,6,2048,1024]{3,2,1,0} subtract(add.1, broadcast.3)
-  exponential.1 = f16[2,6,2048,1024]{3,2,1,0} exponential(subtract.1)
-  convert.1 = f32[2,6,2048,1024]{3,2,1,0} convert(exponential.1)
-  constant.1 = f32[] constant(0)
-  reduce.23 = f32[2,6,2048]{2,1,0} reduce(convert.1, constant.1), dimensions={3}, to_apply=region_1.19
-  convert.2 = f16[2,6,2048]{2,1,0} convert(reduce.23)
-  broadcast.4 = f16[2,6,2048,1024]{3,2,1,0} broadcast(convert.2), dimensions={0,1,2}
-  divide = f16[2,6,2048,1024]{3,2,1,0} divide(exponential.1, broadcast.4)
-  Arg_2.3 = f16[2,6,1024,64]{3,2,1,0} parameter(2), sharding={replicated}
-  ROOT dot.1 = f16[2,6,2048,64]{3,2,1,0} dot(divide, Arg_2.3), lhs_contracting_dims={3}, rhs_contracting_dims={2}, lhs_batch_dims={0,1}, rhs_batch_dims={0,1}
-})";
-
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
-  CudnnFusedMHARewriter fusedMhaRewriter{
-      GetCudaComputeCapability(), GetCudnnVersionWithFlashAttentionSupport()};
-  TF_ASSERT_OK(RunHloPass(&fusedMhaRewriter, m.get()).status());
-
-  SCOPED_TRACE(m->ToString());
-  EXPECT_THAT(m->entry_computation()->root_instruction(), GmockMatch(m::Dot()));
-
-  CudnnFusedMHARewriter fusedMhaRewriterWithCrossAttention{
-      GetCudaComputeCapability(),
-      GetCudnnVersionWithFlashCrossAttentionSupport()};
-  TF_ASSERT_OK(
-      RunHloPass(&fusedMhaRewriterWithCrossAttention, m.get()).status());
-  SCOPED_TRACE(m->ToString());
-  const HloInstruction* fmha;
-  EXPECT_THAT(
-      m->entry_computation()->root_instruction(),
-      GmockMatch(
-          m::GetTupleElement(
-              m::CustomCall(&fmha, {kCudnnfMHAScaleBiasSoftmaxCallTarget}), 0)
-              .WithShape(F16, {2, 6, 2048, 64})));
-  TF_ASSERT_OK_AND_ASSIGN(auto gpu_config,
-                          fmha->backend_config<GpuBackendConfig>());
-  const CudnnfMHABackendConfig& config = gpu_config.cudnn_fmha_backend_config();
-  EXPECT_EQ(config.is_flash_attention(), true);
-  EXPECT_EQ(config.is_causal_mask(), false);
-}
-
 // GPT3 pattern
 TEST_F(CudnnFusedMhaRewriterTestHloTest, FlashAttentionBF16TrainingGPT3_5B) {
   if (skip_reason_) GTEST_SKIP() << *skip_reason_;
@@ -5192,6 +5118,40 @@ ENTRY main.164_spmd {
               m::Op(), m::Op().WithPredicate([](const HloInstruction* instr) {
                 return instr->name() == "multiply.39.fmha_no_match_clone";
               }))))));
+}
+
+constexpr absl::string_view hlo_should_lower_to_flash_attention = R"(
+HloModule fmha_test, entry_computation_layout={(bf16[16,16,128,64]{3,2,1,0},bf16[16,16,1024,64]{3,2,1,0},bf16[16,16,1024,64]{3,2,1,0})->bf16[16,16,128,64]{3,2,1,0}}
+ENTRY main.6 {
+  Arg_0.1 = bf16[16,16,128,64]{3,2,1,0} parameter(0)
+  Arg_1.2 = bf16[16,16,1024,64]{3,2,1,0} parameter(1)
+  Arg_2.3 = bf16[16,16,1024,64]{3,2,1,0} parameter(2)
+  dot.0 = bf16[16,16,128,1024]{3,2,1,0} dot(Arg_0.1, Arg_1.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}, metadata={}
+  ROOT dot.1 = bf16[16,16,128,64]{3,2,1,0} dot(dot.0, Arg_2.3), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}, metadata={}
+})";
+
+TEST_F(CudnnFusedMhaRewriterTestHloTest, ShouldLowerToFlashAttention) {
+  if (skip_reason_) GTEST_SKIP() << *skip_reason_;
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto m,
+      ParseAndReturnVerifiedModule(hlo_should_lower_to_flash_attention, GetModuleConfig()));
+  CudnnFusedMHARewriter fusedMhaRewriter{GetCudaComputeCapability(),
+                                         GetCudnnVersionWithFlashAttentionSupport()};
+  TF_ASSERT_OK(RunHloPass(&fusedMhaRewriter, m.get()).status());
+  const HloInstruction* fmha;
+
+  SCOPED_TRACE(m->ToString());
+  EXPECT_THAT(
+      m->entry_computation()->root_instruction(),
+      GmockMatch(m::GetTupleElement(
+                     m::CustomCall(&fmha, {kCudnnfMHABmmBmmCallTarget}), 0)
+                     .WithShape(BF16, {16, 16, 128, 64})));
+  TF_ASSERT_OK_AND_ASSIGN(auto gpu_config,
+                          fmha->backend_config<GpuBackendConfig>());
+  const CudnnfMHABackendConfig& config = gpu_config.cudnn_fmha_backend_config();
+  EXPECT_EQ(config.fmha_scale(), 1.0);
+  EXPECT_EQ(config.dropout_rate(), 0.0);
+  EXPECT_EQ(config.is_flash_attention(), true);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
* If only seqlen_q or seqlen_kv is larger than 512, it will be lowered to fused attn instead of flash attn. This is incorrect as fused attn does not support this case. Add checks to lower to flash attn if one seqlen is larger than 512.
* While fixing the seqlen checks, also relax the seqlen/head dim constraints to support any seqlen % 2 == 0, head_dim <= 128 and head_dim % 8 = 0. (Since 8.9.4).
* Consolidate multiple get seqlen/head dim from fused attn/flash attn checks into one `getBHSD` function and rewrite both fused attn/flash attn checks to make it easier to understand.
* Bump up minimum cuDNN version require for flash attn from 8.9.3 to 8.9.4. (More seqlen/head dim support and cross attn support).
* Remove cross attn checks from rewriter and rewriter test since it is now default supported with 8.9.4.
* Add one testcase to cover the first bullet point.