### PR TITLE
[XLA:GPU] Fix cuDNN FMHA fwd scale not passed into cuDNN

### DIFF
--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -434,19 +434,9 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   config.is_causal_mask = desc.is_causal_mask;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
-
-  auto assign_scale = [&]() {
-    config.fmha_scale.emplace(backend_config.fmha_scale());
-  };
-
-  auto assign_dropout_rate = [&]() {
-    config.dropout_rate.emplace(backend_config.dropout_rate());
-  };
-
-  auto assign_seed = [&]() { config.seed.emplace(backend_config.seed()); };
-  assign_scale();
-  assign_dropout_rate();
-  assign_seed();
+  config.fmha_scale.emplace(backend_config.fmha_scale());
+  config.dropout_rate.emplace(backend_config.dropout_rate());
+  config.seed.emplace(backend_config.seed());
   return config;
 }
 
@@ -587,19 +577,9 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   config.is_causal_mask = desc.is_causal_mask;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
-
-  auto assign_scale = [&]() {
-    config.fmha_scale.emplace(backend_config.fmha_scale());
-  };
-
-  auto assign_dropout_rate = [&]() {
-    config.dropout_rate.emplace(backend_config.dropout_rate());
-  };
-
-  auto assign_seed = [&]() { config.seed.emplace(backend_config.seed()); };
-  assign_scale();
-  assign_dropout_rate();
-  assign_seed();
+  config.fmha_scale.emplace(backend_config.fmha_scale());
+  config.dropout_rate.emplace(backend_config.dropout_rate());
+  config.seed.emplace(backend_config.seed());
   return config;
 }
 

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -167,58 +167,6 @@ absl::Status RunGpuFMHAImpl(const GpufMHAParams &params, se::Stream *stream,
   return absl::OkStatus();
 }
 
-void AssignScale(GpufMHAConfig &config,
-                 const CudnnfMHABackendConfig &backend_config) {
-  double fmha_scale = 0.0;
-
-  switch (config.kind) {
-    case CudnnfMHAKind::kScaleBiasMaskSoftmax:
-    case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
-    case CudnnfMHAKind::kScaleMaskSoftmax:
-    case CudnnfMHAKind::kScaleMaskSoftmaxDropout:
-    case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
-    case CudnnfMHAKind::kScaleBiasSoftmax:
-      fmha_scale = backend_config.fmha_scale();
-      config.fmha_scale.emplace(fmha_scale);
-      break;
-    default:
-      break;
-  }
-}
-
-void AssignDropoutRate(GpufMHAConfig &config,
-                       const CudnnfMHABackendConfig &backend_config) {
-  double dropout_rate = 0.0;
-  switch (config.kind) {
-    case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
-    case CudnnfMHAKind::kScaleMaskSoftmaxDropout:
-    case CudnnfMHAKind::kSoftmaxDropout:
-    case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
-      dropout_rate = backend_config.dropout_rate();
-      config.dropout_rate.emplace(dropout_rate);
-      break;
-    default:
-      break;
-  }
-}
-
-void AssignSeed(GpufMHAConfig &config,
-                const CudnnfMHABackendConfig &backend_config) {
-  int64_t seed_value = 0;
-
-  switch (config.kind) {
-    case CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout:
-    case CudnnfMHAKind::kScaleMaskSoftmaxDropout:
-    case CudnnfMHAKind::kSoftmaxDropout:
-    case CudnnfMHAKind::kScaleBiasSoftmaxDropout:
-      seed_value = backend_config.seed();
-      config.seed.emplace(seed_value);
-      break;
-    default:
-      break;
-  }
-}
-
 template <typename ElementType, typename OutputType>
 absl::Status RunFusedMHABackward(
     GpufMHABackwardParams params, se::Stream *stream,
@@ -487,9 +435,18 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
 
-  AssignScale(config, backend_config);
-  AssignDropoutRate(config, backend_config);
-  AssignSeed(config, backend_config);
+  auto assign_scale = [&]() {
+    config.fmha_scale.emplace(backend_config.fmha_scale());
+  };
+
+  auto assign_dropout_rate = [&]() {
+    config.dropout_rate.emplace(backend_config.dropout_rate());
+  };
+
+  auto assign_seed = [&]() { config.seed.emplace(backend_config.seed()); };
+  assign_scale();
+  assign_dropout_rate();
+  assign_seed();
   return config;
 }
 

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -2770,7 +2770,7 @@ class FlashAttentionBMMScaleSoftmaxBMM : public MultiHeadedAttentionTest {
       Arg_0.1 = bf16[2,6,1024,64]{3,2,1,0} parameter(0), sharding={replicated}
       Arg_1.2 = bf16[2,6,64,1024]{3,2,1,0} parameter(1), sharding={replicated}
       dot.11 = bf16[2,6,1024,1024]{3,2,1,0} dot(Arg_0.1, Arg_1.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
-      constant.17 = bf16[] constant(2)
+      constant.17 = bf16[] constant(100)
       broadcast.29 = bf16[2,6,1024,1024]{3,2,1,0} broadcast(constant.17), dimensions={}
       multiply.2 = bf16[2,6,1024,1024]{3,2,1,0} multiply(dot.11, broadcast.29)
       constant.9 = bf16[] constant(-inf)

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -2770,7 +2770,7 @@ class FlashAttentionBMMScaleSoftmaxBMM : public MultiHeadedAttentionTest {
       Arg_0.1 = bf16[2,6,1024,64]{3,2,1,0} parameter(0), sharding={replicated}
       Arg_1.2 = bf16[2,6,64,1024]{3,2,1,0} parameter(1), sharding={replicated}
       dot.11 = bf16[2,6,1024,1024]{3,2,1,0} dot(Arg_0.1, Arg_1.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
-      constant.17 = bf16[] constant(100)
+      constant.17 = bf16[] constant(37)
       broadcast.29 = bf16[2,6,1024,1024]{3,2,1,0} broadcast(constant.17), dimensions={}
       multiply.2 = bf16[2,6,1024,1024]{3,2,1,0} multiply(dot.11, broadcast.29)
       constant.9 = bf16[] constant(-inf)


### PR DESCRIPTION
* FMHA fwd scale is not passed into cuDNN in pattern bmm1-scale-softmax-(dropout)-bmm2. Work correctly on other patterns (with bias/mask).
* A quick fix is that I simply copy what works in bwd scale setting.
* Weirdly e2e run does not capture this since we do have cases where fwd scale is not 1.