### PR TITLE
Offloading 2/3: generate multi-stream async copies using events on GPUs

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3642,11 +3642,12 @@ xla_test(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "gpu_offloading_test",
     srcs = ["gpu_offloading_test.cc"],
-    tags = tf_cuda_tests_tags(),
+    backends = ["gpu"],
     deps = [
+        ":backend_configs_cc",
         ":horizontal_loop_fusion",
         ":metrics",
         "//xla:autotune_results_proto_cc",
@@ -3657,7 +3658,7 @@ xla_cc_test(
         "//xla/hlo/utils:hlo_matchers",
         "//xla/service:buffer_assignment",
         "//xla/service:buffer_value",
-        "//xla/service:gpu_plugin",
+        "//xla/service/gpu:stream_attribute_annotator",
         "//xla/service:hlo_cost_analysis",
         "//xla/service:hlo_memory_scheduler",
         "//xla/service:hlo_rematerialization",
@@ -3666,6 +3667,7 @@ xla_cc_test(
         "//xla/service:pattern_matcher_gmock",
         "//xla/service:xla_debug_info_manager",
         "//xla/tests:hlo_test_base",
+        "//xla/tests:test_macros_header",
         "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/base:log_severity",
         "@com_google_absl//absl/log:scoped_mock_log",

--- a/xla/service/gpu/gpu_offloading_test.cc
+++ b/xla/service/gpu/gpu_offloading_test.cc
@@ -30,6 +30,8 @@ limitations under the License.
 #include "xla/layout.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/buffer_value.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/stream_attribute_annotator.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/hlo_memory_scheduler.h"
 #include "xla/service/hlo_rematerialization.h"
@@ -38,6 +40,7 @@ limitations under the License.
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/tests/hlo_test_base.h"
+#include "xla/tests/test_macros.h"
 #include "xla/util.h"
 #include "tsl/lib/core/status_test_util.h"
 #include "tsl/platform/statusor.h"
@@ -53,7 +56,8 @@ using ::testing::IsEmpty;
 using ::testing::Not;
 using ::testing::TempDir;
 
-class GpuCompilerTest : public HloTestBase {
+class GpuOffloadingTest : public HloTestBase {
+
  protected:
   absl::StatusOr<bool> RunHloRematerialization(int64_t memory_limit_bytes,
                                                HloModule* module,
@@ -106,7 +110,7 @@ class GpuCompilerTest : public HloTestBase {
   float transcendentals_per_second_{1.0f};
 };
 
-TEST_F(GpuCompilerTest, OriginalTest) {
+TEST_F(GpuOffloadingTest, CopyStartDoneHloStringTest) {
   const char* hlo_text = R"(
   HloModule test
 
@@ -132,10 +136,51 @@ ENTRY %main (param_0: f32[1024], param_1: f32[1024]) -> f32[1024] {
   ROOT %res_11 = f32[1024]{0} tanh(f32[1024]{0} %res_10)
 }
 )";
-  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{/*aabs=*/1e-6, /*arel=*/1e-6}));
+  EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{1e-3}));
 }
 
-TEST_F(GpuCompilerTest, CompiledProgramsCount) {
+TEST_F(GpuOffloadingTest, FusedComputationOffloadingTest) {
+  const char* hlo_text = R"(
+  HloModule test
+
+  mul {
+    %param_1 = f32[1024]{0} parameter(1)
+    %param_0 = f32[1024]{0} parameter(0)
+    ROOT m = f32[1024]{0} multiply(%param_0, %param_1)
+  }
+
+  exp {
+    %param_0 = f32[1024]{0} parameter(0)
+    e = f32[1024]{0} exponential(%param_0)
+    ROOT t = f32[1024]{0} tanh(e)
+  }
+
+  ENTRY %main (param_0: f32[1024], param_1: f32[1024]) -> f32[1024] {
+  %param_1 = f32[1024]{0} parameter(1)
+  %param_0 = f32[1024]{0} parameter(0)
+  %res_3 = f32[1024]{0} fusion(%param_1, %param_0), kind=kInput, calls=mul
+  %copy-start = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_3)
+  %res_4 = f32[1024]{0} fusion(%res_3), kind=kInput, calls=exp
+  %copy-start.2 = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_4)
+  %res_5 = f32[1024]{0} tanh(f32[1024]{0} %res_4)
+  %copy-done = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start)
+  %res_6 = f32[1024]{0} tanh(f32[1024]{0} %res_5)
+  %copy-done.2 = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start.2)
+  %copy-start.3 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done.2)
+  %res_7 = f32[1024]{0} add(f32[1024]{0} %res_6, f32[1024]{0} %res_6)
+  %copy-start.1 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done)
+  %res_8 = f32[1024]{0} add(f32[1024]{0} %res_7, f32[1024]{0} %res_5)
+  %copy-done.3 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.3)
+  %res_9 = f32[1024]{0} add(f32[1024]{0} %res_8, f32[1024]{0} %copy-done.3)
+  %copy-done.1 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.1)
+  %res_10 = f32[1024]{0} add(f32[1024]{0} %res_9, f32[1024]{0} %copy-done.1)
+  ROOT %res_11 = f32[1024]{0} tanh(f32[1024]{0} %res_10)
+}
+)";
+  EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{1e-3}));
+}
+
+TEST_F(GpuOffloadingTest, CopyIRCreationTest) {
   const char* hlo_text = R"(
   HloModule test
 
@@ -168,6 +213,18 @@ TEST_F(GpuCompilerTest, CompiledProgramsCount) {
                           RunHloRematerialization(
                               /*memory_limit_bytes=*/10 * 1024, module.get()));
   ASSERT_TRUE(changed);
+  StreamAttributeAnnotator attr_annotator;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed_attr, attr_annotator.Run(module.get()));
+  EXPECT_TRUE(changed_attr);
+  // Verify that the stream attribute for a copy-start is annotated
+  for (std::string i : {"", ".1", ".2", ".3"}) {
+    const HloInstruction* cp_start =
+        FindInstruction(module.get(), "copy-start" + i);
+    EXPECT_TRUE(cp_start->has_backend_config());
+    TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig gpu_config,
+                            cp_start->backend_config<GpuBackendConfig>());
+    EXPECT_GT(gpu_config.operation_queue_id(), 0);
+  }
 
   // The module should still have a schedule.
   ASSERT_TRUE(module->has_schedule());

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -191,6 +191,7 @@ inline std::pair<bool, int64_t> GetSendRecvAsyncEventsKey(Thunk::Kind kind,
 IrEmitterUnnested::IrEmitterUnnested(IrEmitterContext* ir_emitter_context)
     : IrEmitter(ir_emitter_context, /*is_nested=*/false),
       send_recv_events_(std::make_shared<SendRecvAsyncEvents>()),
+      copy_events_(std::make_shared<CopyThunk::AsyncEvents>()),
       elemental_emitter_(*ir_emitter_context, &b_) {}
 
 std::unique_ptr<IrEmitterUnnested> IrEmitterUnnested::Create(
@@ -2559,60 +2560,71 @@ static std::optional<GlobalDeviceId> DeviceConstraint(
   return std::nullopt;
 }
 
+absl::StatusOr<bool> ShapeHasHostMemorySpace(Shape shape, int index,
+                                             int host_memory_space) {
+  return shape.tuple_shapes(index).has_layout() &&
+      shape.tuple_shapes(index).layout().memory_space() == host_memory_space;
+}
+
 absl::Status IrEmitterUnnested::EmitCopyStartThunk(
-    const HloCopyStartInstruction* instr) {
+    const HloCopyStartInstruction* copy_start_instr) {
   // copy-start has a tuple shape: {host, device, context},
   // or {device, host, context}.
   // Only the destination shape is needed to get the output buffer.
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst_buffer,
-                      GetAllocationSliceForHlo(instr,
+                      GetAllocationSliceForHlo(copy_start_instr,
                                                /*ShapeIndex=*/{0}));
 
-  const HloInstruction* src = instr->operand(0);
+  const HloInstruction* src = copy_start_instr->operand(0);
   const Shape& input_shape = src->shape();
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice src_buffer,
                       GetAllocationSliceForHlo(src, {}));
-  Shape shape = instr->shape();
+  Shape shape = copy_start_instr->shape();
   CHECK(shape.IsTuple());
-
-  if (shape.mutable_tuple_shapes(0)->has_layout() &&
-      shape.mutable_tuple_shapes(0)->mutable_layout()->memory_space() ==
-          static_cast<int>(stream_executor::MemoryType::kHost)) {
-    VLOG(3) << "Device to Host: host memory space "
-            << static_cast<int>(stream_executor::MemoryType::kHost);
+  int host_memory_space = static_cast<int>(stream_executor::MemoryType::kHost);
+  TF_ASSIGN_OR_RETURN(bool is_dst_host_memory,
+                      ShapeHasHostMemorySpace(shape, 0, host_memory_space));
+  TF_ASSIGN_OR_RETURN(bool is_src_host_memory,
+                      ShapeHasHostMemorySpace(shape, 1, host_memory_space));
+  if (is_dst_host_memory == is_src_host_memory) {
+    return absl::InternalError(absl::StrFormat(
+        "Copy-start %s doesn't have correct host memory space color S(%d)",
+        copy_start_instr->ToString(),
+        static_cast<int>(stream_executor::MemoryType::kHost)));
+  }
+  if (is_dst_host_memory ) {
     auto thunk = std::make_unique<DeviceToHostCopyThunk>(
-        Thunk::ThunkInfo::WithProfileAnnotation(instr),
+        Thunk::ThunkInfo::WithProfileAnnotation(copy_start_instr),
         /*source_buffer=*/src_buffer,
         /*destination_buffer=*/dst_buffer,
-        /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape));
+        /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
+        /*copy_events=*/copy_events_,
+        /*copy_start_instr=*/copy_start_instr);
     AddThunkToThunkSequence(std::move(thunk));
-    return absl::OkStatus();
-  }
-  if (shape.mutable_tuple_shapes(1)->has_layout() &&
-      shape.mutable_tuple_shapes(1)->mutable_layout()->memory_space() ==
-          static_cast<int>(stream_executor::MemoryType::kHost)) {
-    VLOG(3) << "Host to Device from the host memory space "
-            << static_cast<int>(stream_executor::MemoryType::kHost);
-    ;
+  } else {
     auto thunk = std::make_unique<HostToDeviceCopyThunk>(
-        Thunk::ThunkInfo::WithProfileAnnotation(instr),
+        Thunk::ThunkInfo::WithProfileAnnotation(copy_start_instr),
         /*source_buffer=*/src_buffer,
         /*destination_buffer=*/dst_buffer,
-        /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape));
+        /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
+        /*copy_events=*/copy_events_,
+        /*copy_start_instr=*/copy_start_instr);
     AddThunkToThunkSequence(std::move(thunk));
-    return absl::OkStatus();
   }
 
-  // Disabled the generation of memcpy D2D as only H2D and D2H are useful
-  // for memory offload now.
+  return absl::OkStatus();
+}
 
-  auto thunk = std::make_unique<DeviceToDeviceCopyThunk>(
-      Thunk::ThunkInfo::WithProfileAnnotation(instr),
-      /*source_buffer=*/src_buffer,
-      /*destination_buffer=*/dst_buffer,
-      /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape));
+absl::Status IrEmitterUnnested::EmitCopyDoneThunk(const HloInstruction* instr) {
+  const HloInstruction* copy_start_instr = instr->operand(0);
+  CHECK(copy_start_instr->opcode() == HloOpcode::kCopyStart);
+
+  auto thunk = std::make_unique<CopyDoneThunk>(
+      Thunk::kCopyDone,
+      Thunk::ThunkInfo::WithProfileAnnotation(copy_start_instr),
+      /*copy_events=*/copy_events_,
+      /*copy_start_instr=*/copy_start_instr);
   AddThunkToThunkSequence(std::move(thunk));
-
   return absl::OkStatus();
 }
 
@@ -2963,6 +2975,8 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       return EmitWhile(instr);
     case HloOpcode::kCopyStart:
       return EmitCopyStartThunk(Cast<HloCopyStartInstruction>(instr));
+    case HloOpcode::kCopyDone:
+      return EmitCopyDoneThunk(instr);
 
     // HLO module is already scheduled, so instructions for ordering are noops.
     case HloOpcode::kAddDependency:
@@ -2973,7 +2987,6 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
     case HloOpcode::kGetTupleElement:
     case HloOpcode::kParameter:
     case HloOpcode::kTuple:
-    case HloOpcode::kCopyDone:
       return absl::OkStatus();
     default:
       return Internal("Unsupported instruction opcode: %s",

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -42,6 +42,7 @@ limitations under the License.
 #include "xla/service/gpu/ir_emitter.h"
 #include "xla/service/gpu/ir_emitter_context.h"
 #include "xla/service/gpu/launch_dimensions.h"
+#include "xla/service/gpu/runtime/copy_thunk.h"
 #include "xla/service/gpu/runtime/send_recv_thunk.h"
 #include "xla/service/gpu/runtime/thunk.h"
 #include "xla/service/llvm_ir/ir_array.h"
@@ -198,6 +199,8 @@ class IrEmitterUnnested : public IrEmitter {
       const HloCollectivePermuteInstruction* instr);
 
   absl::Status EmitCopyStartThunk(const HloCopyStartInstruction* instr);
+
+  absl::Status EmitCopyDoneThunk(const HloInstruction* instr);
 
   absl::Status EmitHloInstruction(const HloInstruction* instr);
 
@@ -376,6 +379,9 @@ class IrEmitterUnnested : public IrEmitter {
 
   // Container for async send/recv events shared by send/recv thunks.
   std::shared_ptr<SendRecvAsyncEvents> send_recv_events_;
+
+  // Container for async copy-start/copy-done events.
+  std::shared_ptr<CopyThunk::AsyncEvents> copy_events_;
 
   // Returns the ShapedSlices for the given operands.
   absl::StatusOr<std::vector<ShapedSlice>> GetShapedSlices(

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -520,9 +520,10 @@ cc_library(
     srcs = ["copy_thunk.cc"],
     hdrs = ["copy_thunk.h"],
     deps = [
-        "//xla:status",
+        "//xla/hlo/ir:hlo",
         "//xla/service:buffer_assignment",
         "//xla/service/gpu/runtime:thunk",
+        "//xla:status",
         "//xla/stream_executor",
         "@com_google_absl//absl/status",
         "@llvm-project//mlir:IR",

--- a/xla/service/gpu/runtime/copy_thunk.cc
+++ b/xla/service/gpu/runtime/copy_thunk.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstdint>
 
 #include "mlir/IR/Value.h"  // from @llvm-project
+#include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/runtime/thunk.h"
 #include "xla/status.h"
@@ -45,11 +46,67 @@ absl::Status DeviceToDeviceCopyThunk::ExecuteOnStream(
   return params.stream->Memcpy(&destination_data, source_data, mem_size_);
 }
 
-DeviceToHostCopyThunk::DeviceToHostCopyThunk(
+//===----------------------------------------------------------------------===//
+// CopyThunk
+//===----------------------------------------------------------------------===//
+
+CopyThunk::CopyThunk(
     ThunkInfo thunk_info, const BufferAllocation::Slice& source_buffer,
     const BufferAllocation::Slice& destination_buffer, uint64_t mem_size)
-    : DeviceToDeviceCopyThunk(thunk_info, source_buffer, destination_buffer,
-                              mem_size) {}
+    : Thunk(Kind::kCopy, thunk_info),
+      source_buffer_(source_buffer),
+      destination_buffer_(destination_buffer),
+      mem_size_(mem_size) {}
+
+absl::Status CopyThunk::ExecuteOnStream(
+    const ExecuteParams& params) {
+  return absl::OkStatus();
+}
+
+//===----------------------------------------------------------------------===//
+// CopyAsyncEvents
+//===----------------------------------------------------------------------===//
+
+// Emplace() will insert {key, event} pair into the hash map,
+// and return the event in order to do RecordEvent() for async memcpy.
+absl::Status CopyThunk::AsyncEvents::Emplace(se::StreamExecutor* executor,
+                                             const HloInstruction* instr,
+                                             se::Event&& event) {
+  Key key = {executor, instr};
+  absl::MutexLock lock(&mutex_);
+  VLOG(3) << "Emplace event " << event.implementation();
+  if (auto [it, inserted] = events_.try_emplace(key, std::move(event));
+      inserted) {
+    return absl::OkStatus();
+  }
+  return absl::InternalError("Async copy event already exists!");
+}
+
+// Retrieve a completion event started by copy-start instruction
+// `instr`, and remove the event from the collection.
+absl::StatusOr<se::Event>
+CopyThunk::AsyncEvents::Extract(se::StreamExecutor* executor,
+                                const HloInstruction* instr) {
+  Key key = {executor, instr};
+  absl::MutexLock lock(&mutex_);
+  if (auto event = events_.extract(key)) {
+    VLOG(3) << "Extract event " << event.mapped().implementation();
+    return std::move(event.mapped());
+  }
+  return absl::InternalError("Async copy event was not found!");
+}
+
+//===----------------------------------------------------------------------===//
+// DeviceToHostCopyThunk
+//===----------------------------------------------------------------------===//
+DeviceToHostCopyThunk::DeviceToHostCopyThunk(
+    ThunkInfo thunk_info, const BufferAllocation::Slice& source_buffer,
+    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
+    std::shared_ptr<CopyThunk::AsyncEvents> async_events,
+    const HloInstruction* instr)
+    : CopyThunk(thunk_info, source_buffer, destination_buffer, mem_size),
+      async_events_(std::move(async_events)),
+      instr_(instr) {}
 
 absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
     const ExecuteParams& params) {
@@ -58,16 +115,39 @@ absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
   se::DeviceMemoryBase source_data =
       params.buffer_allocations->GetDeviceAddress(source());
   void* cpu_dst = destination_data.opaque();
-  VLOG(3) << "Memcpy D2H for memory offload from " << source_data.opaque()
-          << " to " << cpu_dst;
-  return params.stream->Memcpy(cpu_dst, source_data, size_bytes());
+  TF_ASSIGN_OR_RETURN(
+      se::Stream* stream,
+      GetStreamForExecution(Thunk::execution_stream_id(), params));
+  TF_RETURN_IF_ERROR(stream->Memcpy(cpu_dst, source_data, size_bytes()));
+  if (stream == params.stream) {
+    VLOG(2) << "Memcpy D2H from the main stream";
+    return absl::OkStatus();
+  }
+  VLOG(2) << "Memcpy D2H from the other stream";
+  se::StreamExecutor* executor = params.stream->parent();
+  se::Event event(executor);
+  if (!event.Init()) {
+    return absl::InternalError(
+        "Failed to initialize copy operation async completion event!");
+  }
+  // Record memcpy operation completion.
+  TF_RETURN_IF_ERROR(stream->RecordEvent(&event));
+  VLOG(3) << "Emplace events: " << event.implementation()
+          << " for instr: " << instr_->ToString();
+  return async_events_->Emplace(executor, instr_, std::move(event));
 }
 
+//===----------------------------------------------------------------------===//
+// HostToDeviceCopyThunk
+//===----------------------------------------------------------------------===//
 HostToDeviceCopyThunk::HostToDeviceCopyThunk(
-    ThunkInfo thunk_info, const BufferAllocation::Slice& source_buffer,
-    const BufferAllocation::Slice& destination_buffer, uint64_t mem_size)
-    : DeviceToDeviceCopyThunk(thunk_info, source_buffer, destination_buffer,
-                              mem_size) {}
+    ThunkInfo thunk_info, const BufferAllocation::Slice &source_buffer,
+    const BufferAllocation::Slice &destination_buffer, uint64_t mem_size,
+    std::shared_ptr<CopyThunk::AsyncEvents> async_events,
+    const HloInstruction* instr)
+    : CopyThunk(thunk_info, source_buffer, destination_buffer, mem_size),
+      async_events_(std::move(async_events)),
+      instr_(instr) {}
 
 absl::Status HostToDeviceCopyThunk::ExecuteOnStream(
     const ExecuteParams& params) {
@@ -75,10 +155,49 @@ absl::Status HostToDeviceCopyThunk::ExecuteOnStream(
       params.buffer_allocations->GetDeviceAddress(destination());
   se::DeviceMemoryBase source_data =
       params.buffer_allocations->GetDeviceAddress(source());
-  void* cpu_src = source_data.opaque();
-  VLOG(3) << "Memcpy H2D for memory offload from " << cpu_src << " to "
-          << destination_data.opaque();
-  return params.stream->Memcpy(&destination_data, cpu_src, size_bytes());
+  void *cpu_src = source_data.opaque();
+  TF_ASSIGN_OR_RETURN(
+      se::Stream * stream,
+      GetStreamForExecution(Thunk::execution_stream_id(), params));
+  TF_RETURN_IF_ERROR(
+      stream->Memcpy(&destination_data, cpu_src, size_bytes()));
+  if (stream == params.stream) {
+    VLOG(2) << "Memcpy H2D from the main stream";
+    return absl::OkStatus();
+  }
+  VLOG(2) << "Memcpy H2D from the other stream";
+  se::StreamExecutor *executor = params.stream->parent();
+  se::Event event(executor);
+  if (!event.Init()) {
+    return absl::InternalError(
+        "Failed to initialize copy operation async completion event!");
+  }
+  // Record memcpy operation completion.
+  TF_RETURN_IF_ERROR(stream->RecordEvent(&event));
+  VLOG(3) << "Emplace events: " << event.implementation()
+          << " for instr: " << instr_->ToString();
+  return async_events_->Emplace(executor, instr_, std::move(event));
+}
+
+//===----------------------------------------------------------------------===//
+// CopyDoneThunk
+//===----------------------------------------------------------------------===//
+CopyDoneThunk::CopyDoneThunk(
+    Thunk::Kind kind, ThunkInfo thunk_info,
+    std::shared_ptr<CopyThunk::AsyncEvents> async_events,
+    const HloInstruction *copy_start_instr)
+    : Thunk(kind, std::move(thunk_info)),
+      async_events_(std::move(async_events)),
+      copy_start_instr_(copy_start_instr) {}
+
+absl::Status
+CopyDoneThunk::ExecuteOnStream(const ExecuteParams &params) {
+  VLOG(3) << "CopyDone thunk between a host and a device for: "
+          << copy_start_instr_->ToString();
+  se::StreamExecutor *executor = params.stream->parent();
+  TF_ASSIGN_OR_RETURN(se::Event event,
+                      async_events_->Extract(executor, copy_start_instr_));
+  return params.stream->WaitFor(&event);
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/runtime/copy_thunk.h
+++ b/xla/service/gpu/runtime/copy_thunk.h
@@ -18,9 +18,13 @@ limitations under the License.
 
 #include <cstdint>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/runtime/thunk.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/stream_executor.h"
 
 namespace xla {
 namespace gpu {
@@ -55,22 +59,110 @@ class DeviceToDeviceCopyThunk : public Thunk {
   const uint64_t mem_size_;
 };
 
-class DeviceToHostCopyThunk : public DeviceToDeviceCopyThunk {
- public:
+//===----------------------------------------------------------------------===//
+// CopyThunk
+//===----------------------------------------------------------------------===//
+class CopyThunk : public Thunk {
+public:
+  class AsyncEvents {
+  public:
+    // Add a new copy-start completion event.
+    absl::Status Emplace(se::StreamExecutor* executor,
+                         const HloInstruction* instr, se::Event&& event);
+
+    // Retrieve a completion event started by copy-start instruction
+    // `instr`, and remove the event from the collection.
+    absl::StatusOr<se::Event> Extract(se::StreamExecutor* executor,
+                                      const HloInstruction* instr);
+
+  private:
+    using Key = std::pair<se::StreamExecutor*, const HloInstruction*>;
+    absl::Mutex mutex_;
+    absl::flat_hash_map<Key, se::Event> events_ ABSL_GUARDED_BY(mutex_);
+  };
+  CopyThunk(ThunkInfo thunk_info,
+            const BufferAllocation::Slice &source_buffer,
+            const BufferAllocation::Slice &destination_buffer,
+            uint64_t mem_size);
+  absl::Status ExecuteOnStream(const ExecuteParams &params) override;
+  void ClearCompileTimeInfo() override { Thunk::ClearCompileTimeInfo(); }
+  const BufferAllocation::Slice& source() const { return source_buffer_; }
+  const BufferAllocation::Slice& destination() const {
+    return destination_buffer_;
+  }
+  uint64_t size_bytes() const { return mem_size_; }
+
+  private:
+  const BufferAllocation::Slice source_buffer_;
+  const BufferAllocation::Slice destination_buffer_;
+  const uint64_t mem_size_;
+};
+
+//===----------------------------------------------------------------------===//
+// DeviceToHostCopyThunk
+//===----------------------------------------------------------------------===//
+// The memcpy between a host and a device
+
+// A thunk that copies data from a device buffer to a host buffer.
+class DeviceToHostCopyThunk : public CopyThunk {
+public:
+  // Constructs a DeviceToHostCopyThunk that copies data from `source_buffer` to
+  // the device buffer `destination_buffer`. `mem_size` is the size of the data
+  // in bytes. `events` are the cuda record/wait events.
+  // `instr` is the copy-start instruction.
   DeviceToHostCopyThunk(ThunkInfo thunk_info,
                         const BufferAllocation::Slice& source_buffer,
                         const BufferAllocation::Slice& destination_buffer,
-                        uint64_t mem_size);
+                        uint64_t mem_size,
+                        std::shared_ptr<CopyThunk::AsyncEvents> events,
+                        const HloInstruction* instr);
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+
+private:
+  std::shared_ptr<CopyThunk::AsyncEvents> async_events_;
+  const HloInstruction* instr_;
 };
 
-class HostToDeviceCopyThunk : public DeviceToDeviceCopyThunk {
- public:
+//===----------------------------------------------------------------------===//
+// HostToDeviceCopyThunk
+//===----------------------------------------------------------------------===//
+// The memcpy between a host and a device
+
+// A thunk that copies data from a host buffer to a device buffer.
+class HostToDeviceCopyThunk : public CopyThunk {
+public:
+  // Constructs a HostToDeviceCopyThunk that copies data from `source_buffer` to
+  // the host buffer `destination_buffer`. `mem_size` is the size of the data
+  // in bytes. `events` are the cuda record/wait events.
+  // `instr` is the copy-start instruction.
   HostToDeviceCopyThunk(ThunkInfo thunk_info,
                         const BufferAllocation::Slice& source_buffer,
                         const BufferAllocation::Slice& destination_buffer,
-                        uint64_t mem_size);
+                        uint64_t mem_size,
+                        std::shared_ptr<CopyThunk::AsyncEvents> events,
+                        const HloInstruction* instr);
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+
+private:
+  std::shared_ptr<CopyThunk::AsyncEvents> async_events_;
+  const HloInstruction* instr_;
+};
+
+//===----------------------------------------------------------------------===//
+// CopyDoneThunk
+//===----------------------------------------------------------------------===//
+
+class CopyDoneThunk : public Thunk {
+public:
+  CopyDoneThunk(Thunk::Kind kind, ThunkInfo thunk_info,
+                std::shared_ptr<CopyThunk::AsyncEvents> events,
+                const HloInstruction* copy_start_instr);
+
+  absl::Status ExecuteOnStream(const ExecuteParams &params) override;
+
+private:
+  std::shared_ptr<CopyThunk::AsyncEvents> async_events_;
+  const HloInstruction *copy_start_instr_;
 };
 
 }  // namespace gpu

--- a/xla/service/gpu/runtime/thunk.cc
+++ b/xla/service/gpu/runtime/thunk.cc
@@ -236,6 +236,7 @@ Thunk::ExecuteParams::ExecuteParams(
     CASE(kConvolution);
     CASE(kConvolutionReorder);
     CASE(kCopy);
+    CASE(kCopyDone);
     CASE(kCubSort);
     CASE(kCublasLtMatmul);
     CASE(kCustomCall);

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -118,6 +118,7 @@ class Thunk {
     kConvolution,
     kConvolutionReorder,
     kCopy,
+    kCopyDone,
     kCommandBuffer,
     kCubSort,
     kCublasLtMatmul,


### PR DESCRIPTION
Emit asynchronous memory copies between hosts and devices using additional streams while the main stream does the computation. The async copies are guarded by RecordEvent() and WaitForEvent() created by the copy-start/copy-done thunks respectively. A hash table is utilized to map copy-start instructions to events. The corresponding events will be waited at copy-done and extracted from the hash table.