### PR TITLE
[NVIDIA GPU] Enforce first collective permute of collective matmul to always run at the top of loop.

### DIFF
--- a/xla/service/gpu/gpu_windowed_einsum_handler_test.cc
+++ b/xla/service/gpu/gpu_windowed_einsum_handler_test.cc
@@ -106,8 +106,14 @@ ENTRY test_main {
       module->entry_computation()->root_instruction()->mutable_operand(0);
   HloComputation* ag_loop_body = ag_loop->while_body();
   HloInstruction* inst = FindInstructionByName(ag_loop_body, "dot.2");
-  EXPECT_TRUE(inst->backend_config<GpuBackendConfig>()->operation_queue_id() >
-              0);
+  EXPECT_GT(inst->backend_config<GpuBackendConfig>()->operation_queue_id(), 0);
+  EXPECT_TRUE(
+      inst->backend_config<GpuBackendConfig>()->force_earliest_schedule());
+
+  HloInstruction* cp1 =
+      FindInstructionByName(ag_loop_body, "collective-permute");
+  EXPECT_TRUE(
+      cp1->backend_config<GpuBackendConfig>()->force_earliest_schedule());
 }
 
 TEST_F(GpuWindowedEinsumHanlderTest, RsLoopsHaveStreamIds) {
@@ -180,6 +186,11 @@ ENTRY main.9_spmd {
   HloInstruction* inst = FindInstructionByName(rs_loop_body, "dot.7");
   EXPECT_TRUE(inst->backend_config<GpuBackendConfig>()->operation_queue_id() >
               0);
+
+  HloInstruction* cp1 =
+      FindInstructionByName(rs_loop_body, "collective-permute.1");
+  EXPECT_TRUE(
+      cp1->backend_config<GpuBackendConfig>()->force_earliest_schedule());
 }
 
 }  // namespace

--- a/xla/service/gpu/stream_attribute_async_wrapper.cc
+++ b/xla/service/gpu/stream_attribute_async_wrapper.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/service/gpu/stream_attribute_async_wrapper.h"
 
-
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/string_view.h"
 #include "xla/hlo/ir/hlo_computation.h"
@@ -43,6 +42,12 @@ static absl::StatusOr<bool> AsynchronizeInstruction(HloInstruction* instr) {
       computation->CreateAsyncInstructions(
           instr, {}, StreamAttributeAsyncWrapper::kParallelExecutionThread,
           /*replace=*/true));
+  TF_ASSIGN_OR_RETURN(GpuBackendConfig gpu_config,
+                      done->backend_config<GpuBackendConfig>());
+  // Set the false delay of done op to be false so it can be scheduled
+  // far apart from start.
+  gpu_config.set_force_earliest_schedule(false);
+  TF_RETURN_IF_ERROR(done->set_backend_config(gpu_config));
   VLOG(5) << "Created async instruction: " << done->ToString();
   return true;
 }

--- a/xla/service/gpu/stream_attribute_async_wrapper_test.cc
+++ b/xla/service/gpu/stream_attribute_async_wrapper_test.cc
@@ -40,7 +40,7 @@ TEST_F(StreamAttributeAsyncWrapperTest, NonDefaultOpIsWrapped) {
   ENTRY entry {
     p1_32 = f32[1] parameter(0)
     p2_32 = f32[1] parameter(1)
-    add_32 = f32[1] add(p1_32, p2_32), backend_config={"operation_queue_id":"1", "wait_on_operation_queues":[]}
+    add_32 = f32[1] add(p1_32, p2_32), backend_config={"operation_queue_id":"1", "wait_on_operation_queues":[], "force_earliest_schedule":true}
     ROOT exp_32 = f32[1] exponential(add_32), backend_config={"operation_queue_id":"0", "wait_on_operation_queues":[1]}
   }
   )";
@@ -55,6 +55,11 @@ TEST_F(StreamAttributeAsyncWrapperTest, NonDefaultOpIsWrapped) {
   const HloInstruction* producer =
       module->entry_computation()->root_instruction()->operand(0);
   EXPECT_EQ(producer->opcode(), HloOpcode::kAsyncDone);
+  // Verify that the force_earliest_schedule is set to false for the done op.
+  TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig done_gpu_config,
+                          producer->backend_config<GpuBackendConfig>());
+  EXPECT_EQ(done_gpu_config.force_earliest_schedule(), false);
+
   const HloInstruction* producer_start = producer->operand(0);
   EXPECT_EQ(producer_start->opcode(), HloOpcode::kAsyncStart);
 
@@ -65,6 +70,7 @@ TEST_F(StreamAttributeAsyncWrapperTest, NonDefaultOpIsWrapped) {
   TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig gpu_config,
                           async->backend_config<GpuBackendConfig>());
   EXPECT_EQ(gpu_config.operation_queue_id(), 1);
+  EXPECT_EQ(gpu_config.force_earliest_schedule(), true);
   EXPECT_EQ(async->async_execution_thread(), "parallel");
 }
 }  // namespace


### PR DESCRIPTION
This is to port collective matmul related changes from this pr(https://github.com/openxla/xla/pull/10316).
We'd need the first collective permute of a collective matmul loop always run at the beginning of the loop.
We set the force_earliest_schedule flag  for that instruction to achieve so.
Force this schedule order would give about additional 3% speedup on top of existing collective matmul for GPT-3 530B model.