### PR TITLE
[XLA:CPU][oneDNN][Bugfix] Fix BF16 oneDNN Layernorm

### DIFF
--- a/xla/tests/onednn_layer_norm_test.cc
+++ b/xla/tests/onednn_layer_norm_test.cc
@@ -141,6 +141,75 @@ TEST_F(LayerNormTest, LayerNormTest0_F16) {
   MatchOptimizedHlo(layer_norm_module_str, onednn_layer_norm_);
 }
 
+// Test case encountered in models like TFViTForImageClassification in
+// HuggingFace
+// (https://huggingface.co/docs/transformers/model_doc/vit#transformers.TFViTForImageClassification)
+TEST_F(LayerNormTest, LayerNormTest1_BF16) {
+  const char* layer_norm_module_str = R"(
+  HloModule layer_norm.test, entry_computation_layout={(bf16[160,197,768]{2,1,0}, bf16[768]{0}, bf16[768]{0})->bf16[160,197,768]{2,1,0}}
+  region_add {
+    Arg_0.7555 = f32[] parameter(0)
+    Arg_1.7556 = f32[] parameter(1)
+    ROOT add.7557 = f32[] add(Arg_0.7555, Arg_1.7556)
+  }
+  ENTRY main {
+    Arg_0.1 = bf16[160,197,768]{2,1,0} parameter(0), sharding={replicated}
+    Arg_0.2 = bf16[768]{0} parameter(1), sharding={replicated}
+    Arg_0.3 = bf16[768]{0} parameter(2), sharding={replicated}
+    convert.80 = f32[160,197,768]{2,1,0} convert(Arg_0.1)
+    constant.81 = f32[] constant(0)
+    convert.82 = f32[] convert(constant.81)
+    reduce.87 = f32[160,197]{1,0} reduce(convert.80, convert.82), dimensions={2}, to_apply=region_add
+    constant.88 = s32[] constant(768)
+    convert.89 = f32[] convert(constant.88)
+    broadcast.90 = f32[160,197]{1,0} broadcast(convert.89), dimensions={}
+    divide.91 = f32[160,197]{1,0} divide(reduce.87, broadcast.90)
+    convert.92 = bf16[160,197]{1,0} convert(divide.91)
+    reshape.93 = bf16[160,197,1]{2,1,0} reshape(convert.92)
+    reshape.94 = bf16[160,197]{1,0} reshape(reshape.93)
+    broadcast.95 = bf16[160,197,768]{2,1,0} broadcast(reshape.94), dimensions={0,1}
+    subtract.96 = bf16[160,197,768]{2,1,0} subtract(Arg_0.1, broadcast.95)
+    multiply.97 = bf16[160,197,768]{2,1,0} multiply(subtract.96, subtract.96)
+    convert.98 = f32[160,197,768]{2,1,0} convert(multiply.97)
+    constant.99 = f32[] constant(0)
+    convert.100 = f32[] convert(constant.99)
+    reduce.105 = f32[160,197]{1,0} reduce(convert.98, convert.100), dimensions={2}, to_apply=region_add
+    constant.106 = s32[] constant(768)
+    convert.107 = f32[] convert(constant.106)
+    broadcast.108 = f32[160,197]{1,0} broadcast(convert.107), dimensions={}
+    divide.109 = f32[160,197]{1,0} divide(reduce.105, broadcast.108)
+    convert.110 = bf16[160,197]{1,0} convert(divide.109)
+    reshape.111 = bf16[160,197,1]{2,1,0} reshape(convert.110)
+    constant.112 = bf16[] constant(1.002e-12)
+    broadcast.113 = bf16[160,197,1]{2,1,0} broadcast(constant.112), dimensions={}
+    add.114 = bf16[160,197,1]{2,1,0} add(reshape.111, broadcast.113)
+    rsqrt.115 = bf16[160,197,1]{2,1,0} rsqrt(add.114)
+    reshape.118 = bf16[160,197]{1,0} reshape(rsqrt.115)
+    broadcast.119 = bf16[160,197,768]{2,1,0} broadcast(reshape.118), dimensions={0,1}
+    broadcast.117 = bf16[160,197,768]{2,1,0} broadcast(Arg_0.2), dimensions={2}
+    multiply.120 = bf16[160,197,768]{2,1,0} multiply(broadcast.119, broadcast.117)
+    multiply.121 = bf16[160,197,768]{2,1,0} multiply(Arg_0.1, multiply.120)
+    broadcast.126 = bf16[160,197,768]{2,1,0} broadcast(Arg_0.3), dimensions={2}
+    reshape.122 = bf16[160,197]{1,0} reshape(reshape.93)
+    broadcast.123 = bf16[160,197,768]{2,1,0} broadcast(reshape.122), dimensions={0,1}
+    multiply.124 = bf16[160,197,768]{2,1,0} multiply(multiply.120, broadcast.123)
+    subtract.127 = bf16[160,197,768]{2,1,0} subtract(broadcast.126, multiply.124)
+    ROOT add.128 = bf16[160,197,768]{2,1,0} add(multiply.121, subtract.127)
+  }
+)";
+
+  EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-2, 1e-2}));
+  MatchOptimizedHlo(layer_norm_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$layernorm",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "onednn_layer_norm_config":{
+  ; CHECK-DAG:       "fused_ops":"SCALE_AND_SHIFT"
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
 }  // namespace
 }  // namespace xla
 

--- a/xla/tests/onednn_layer_norm_test.cc
+++ b/xla/tests/onednn_layer_norm_test.cc
@@ -146,55 +146,55 @@ TEST_F(LayerNormTest, LayerNormTest0_F16) {
 // (https://huggingface.co/docs/transformers/model_doc/vit#transformers.TFViTForImageClassification)
 TEST_F(LayerNormTest, LayerNormTest1_BF16) {
   const char* layer_norm_module_str = R"(
-  HloModule layer_norm.test, entry_computation_layout={(bf16[160,197,768]{2,1,0}, bf16[768]{0}, bf16[768]{0})->bf16[160,197,768]{2,1,0}}
+  HloModule layer_norm.test
   region_add {
     Arg_0.7555 = f32[] parameter(0)
     Arg_1.7556 = f32[] parameter(1)
     ROOT add.7557 = f32[] add(Arg_0.7555, Arg_1.7556)
   }
   ENTRY main {
-    Arg_0.1 = bf16[160,197,768]{2,1,0} parameter(0), sharding={replicated}
-    Arg_0.2 = bf16[768]{0} parameter(1), sharding={replicated}
-    Arg_0.3 = bf16[768]{0} parameter(2), sharding={replicated}
-    convert.80 = f32[160,197,768]{2,1,0} convert(Arg_0.1)
+    Arg_0.1 = bf16[160,197,768] parameter(0), sharding={replicated}
+    Arg_0.2 = bf16[768] parameter(1), sharding={replicated}
+    Arg_0.3 = bf16[768] parameter(2), sharding={replicated}
+    convert.80 = f32[160,197,768] convert(Arg_0.1)
     constant.81 = f32[] constant(0)
     convert.82 = f32[] convert(constant.81)
-    reduce.87 = f32[160,197]{1,0} reduce(convert.80, convert.82), dimensions={2}, to_apply=region_add
+    reduce.87 = f32[160,197] reduce(convert.80, convert.82), dimensions={2}, to_apply=region_add
     constant.88 = s32[] constant(768)
     convert.89 = f32[] convert(constant.88)
-    broadcast.90 = f32[160,197]{1,0} broadcast(convert.89), dimensions={}
-    divide.91 = f32[160,197]{1,0} divide(reduce.87, broadcast.90)
-    convert.92 = bf16[160,197]{1,0} convert(divide.91)
-    reshape.93 = bf16[160,197,1]{2,1,0} reshape(convert.92)
-    reshape.94 = bf16[160,197]{1,0} reshape(reshape.93)
-    broadcast.95 = bf16[160,197,768]{2,1,0} broadcast(reshape.94), dimensions={0,1}
-    subtract.96 = bf16[160,197,768]{2,1,0} subtract(Arg_0.1, broadcast.95)
-    multiply.97 = bf16[160,197,768]{2,1,0} multiply(subtract.96, subtract.96)
-    convert.98 = f32[160,197,768]{2,1,0} convert(multiply.97)
+    broadcast.90 = f32[160,197] broadcast(convert.89), dimensions={}
+    divide.91 = f32[160,197] divide(reduce.87, broadcast.90)
+    convert.92 = bf16[160,197] convert(divide.91)
+    reshape.93 = bf16[160,197,1] reshape(convert.92)
+    reshape.94 = bf16[160,197] reshape(reshape.93)
+    broadcast.95 = bf16[160,197,768] broadcast(reshape.94), dimensions={0,1}
+    subtract.96 = bf16[160,197,768] subtract(Arg_0.1, broadcast.95)
+    multiply.97 = bf16[160,197,768] multiply(subtract.96, subtract.96)
+    convert.98 = f32[160,197,768] convert(multiply.97)
     constant.99 = f32[] constant(0)
     convert.100 = f32[] convert(constant.99)
-    reduce.105 = f32[160,197]{1,0} reduce(convert.98, convert.100), dimensions={2}, to_apply=region_add
+    reduce.105 = f32[160,197] reduce(convert.98, convert.100), dimensions={2}, to_apply=region_add
     constant.106 = s32[] constant(768)
     convert.107 = f32[] convert(constant.106)
-    broadcast.108 = f32[160,197]{1,0} broadcast(convert.107), dimensions={}
-    divide.109 = f32[160,197]{1,0} divide(reduce.105, broadcast.108)
-    convert.110 = bf16[160,197]{1,0} convert(divide.109)
-    reshape.111 = bf16[160,197,1]{2,1,0} reshape(convert.110)
+    broadcast.108 = f32[160,197] broadcast(convert.107), dimensions={}
+    divide.109 = f32[160,197] divide(reduce.105, broadcast.108)
+    convert.110 = bf16[160,197] convert(divide.109)
+    reshape.111 = bf16[160,197,1] reshape(convert.110)
     constant.112 = bf16[] constant(1.002e-12)
-    broadcast.113 = bf16[160,197,1]{2,1,0} broadcast(constant.112), dimensions={}
-    add.114 = bf16[160,197,1]{2,1,0} add(reshape.111, broadcast.113)
-    rsqrt.115 = bf16[160,197,1]{2,1,0} rsqrt(add.114)
-    reshape.118 = bf16[160,197]{1,0} reshape(rsqrt.115)
-    broadcast.119 = bf16[160,197,768]{2,1,0} broadcast(reshape.118), dimensions={0,1}
-    broadcast.117 = bf16[160,197,768]{2,1,0} broadcast(Arg_0.2), dimensions={2}
-    multiply.120 = bf16[160,197,768]{2,1,0} multiply(broadcast.119, broadcast.117)
-    multiply.121 = bf16[160,197,768]{2,1,0} multiply(Arg_0.1, multiply.120)
-    broadcast.126 = bf16[160,197,768]{2,1,0} broadcast(Arg_0.3), dimensions={2}
-    reshape.122 = bf16[160,197]{1,0} reshape(reshape.93)
-    broadcast.123 = bf16[160,197,768]{2,1,0} broadcast(reshape.122), dimensions={0,1}
-    multiply.124 = bf16[160,197,768]{2,1,0} multiply(multiply.120, broadcast.123)
-    subtract.127 = bf16[160,197,768]{2,1,0} subtract(broadcast.126, multiply.124)
-    ROOT add.128 = bf16[160,197,768]{2,1,0} add(multiply.121, subtract.127)
+    broadcast.113 = bf16[160,197,1] broadcast(constant.112), dimensions={}
+    add.114 = bf16[160,197,1] add(reshape.111, broadcast.113)
+    rsqrt.115 = bf16[160,197,1] rsqrt(add.114)
+    reshape.118 = bf16[160,197] reshape(rsqrt.115)
+    broadcast.119 = bf16[160,197,768] broadcast(reshape.118), dimensions={0,1}
+    broadcast.117 = bf16[160,197,768] broadcast(Arg_0.2), dimensions={2}
+    multiply.120 = bf16[160,197,768] multiply(broadcast.119, broadcast.117)
+    multiply.121 = bf16[160,197,768] multiply(Arg_0.1, multiply.120)
+    broadcast.126 = bf16[160,197,768] broadcast(Arg_0.3), dimensions={2}
+    reshape.122 = bf16[160,197] reshape(reshape.93)
+    broadcast.123 = bf16[160,197,768] broadcast(reshape.122), dimensions={0,1}
+    multiply.124 = bf16[160,197,768] multiply(multiply.120, broadcast.123)
+    subtract.127 = bf16[160,197,768] subtract(broadcast.126, multiply.124)
+    ROOT add.128 = bf16[160,197,768] add(multiply.121, subtract.127)
   }
 )";
 


### PR DESCRIPTION
OneDNN expects scale and bias to be in Float32.
This PR will convert BF16/FP16 scale and weights into Float32 (similar to whats done with mkl layernorm in tensorflow [here ](https://github.com/tensorflow/tensorflow/blob/3a5a9ec33c1194f8fdec2a243714055c0118b44a/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc#L138)) , without conversion there is accuracy mismatch with oneDNN layernorm.