### PR TITLE
[XLA:CPU] Bug fix for enabling F16 support

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -20,8 +20,7 @@ load(
     "if_rocm",
     "if_rocm_is_configured",
 )
-load("@tsl//tsl:tsl.bzl", "tsl_copts")
-load("@tsl//tsl:tsl.bzl", "if_google", "if_libtpu", "internal_visibility")
+load("@tsl//tsl:tsl.bzl", "tsl_copts", "if_google", "if_libtpu", "internal_visibility")
 load("@tsl//tsl:tsl.default.bzl", "filegroup", "get_compatible_with_portable", "internal_hlo_deps")
 load(
     "@tsl//tsl/platform:build_config.bzl",

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -20,6 +20,7 @@ load(
     "if_rocm",
     "if_rocm_is_configured",
 )
+load("@tsl//tsl:tsl.bzl", "tsl_copts")
 load("@tsl//tsl:tsl.bzl", "if_google", "if_libtpu", "internal_visibility")
 load("@tsl//tsl:tsl.default.bzl", "filegroup", "get_compatible_with_portable", "internal_hlo_deps")
 load(
@@ -7278,6 +7279,7 @@ cc_library(
     name = "change_op_data_type",
     srcs = ["change_op_data_type.cc"],
     hdrs = ["change_op_data_type.h"],
+    copts = tsl_copts(),
     deps = [
         ":hlo_creation_utils",
         ":hlo_pass",

--- a/xla/service/change_op_data_type.cc
+++ b/xla/service/change_op_data_type.cc
@@ -63,8 +63,8 @@ absl::StatusOr<bool> ChangeOpDataType::Run(
         continue;
       }
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
-      if (instr->opcode == HloOpcode::kDot &&
-          OneDnnMatMulRewriter::ShouldRewrite(instr)) {
+      if (instr->opcode() == HloOpcode::kDot &&
+          cpu::OneDnnMatMulRewriter::ShouldRewrite(instr)) {
         continue;
       }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -19,6 +19,8 @@ limitations under the License.
 
 #include "xla/service/cpu/onednn_matmul_rewriter.h"
 
+#include "tsl/platform/logging.h"  // IWYU pragma: keep
+#include "tsl/util/onednn_threadpool.h"
 #include "xla/executable_run_options.h"
 #include "xla/hlo/evaluator/hlo_evaluator.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
@@ -32,8 +34,6 @@ limitations under the License.
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
-#include "tsl/platform/logging.h"  // IWYU pragma: keep
-#include "tsl/util/onednn_threadpool.h"
 
 namespace xla {
 namespace cpu {
@@ -246,11 +246,6 @@ inline bool IsRowMajor(const Shape& shape) {
 inline bool CompatibleElementType(const HloInstruction* instr) {
   PrimitiveType element_type = instr->shape().element_type();
   return element_type == BF16 || element_type == F32 || element_type == F16;
-}
-
-inline bool LowPrecisionType(const HloInstruction* instr) {
-  PrimitiveType element_type = instr->shape().element_type();
-  return element_type == BF16 || element_type == F16;
 }
 
 // Type conversion from and to any of BF16, F16 and FP32.
@@ -520,7 +515,8 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
       // for bf16 case to avoid datatype mismatch.
       if (optional_dot_bitcast != nullptr &&
           optional_dot_bitcast->opcode() == HloOpcode::kBitcast) {
-        if (LowPrecisionType(matmul_call)) {
+        if (optional_dot_convert != nullptr &&
+            optional_dot_convert->opcode() == HloOpcode::kConvert) {
           auto bitcast_call =
               matmul_call->AddInstruction(HloInstruction::CreateBitcast(
                   ShapeUtil::ChangeElementType(
@@ -528,18 +524,21 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
                   matmul_call));
           new_instr =
               bitcast_call->AddInstruction(HloInstruction::CreateConvert(
-                  ShapeUtil::ChangeElementType(bitcast_call->shape(),
-                                               PrimitiveType::F32),
+                  ShapeUtil::ChangeElementType(
+                      bitcast_call->shape(),
+                      optional_dot_convert->shape().element_type()),
                   bitcast_call));
         } else {
           new_instr = matmul_call->AddInstruction(
               HloInstruction::CreateBitcast(instr->shape(), matmul_call));
         }
       } else {
-        if (LowPrecisionType(matmul_call)) {
+        if (optional_dot_convert != nullptr &&
+            optional_dot_convert->opcode() == HloOpcode::kConvert) {
           new_instr = matmul_call->AddInstruction(HloInstruction::CreateConvert(
-              ShapeUtil::ChangeElementType(matmul_call->shape(),
-                                           PrimitiveType::F32),
+              ShapeUtil::ChangeElementType(
+                  matmul_call->shape(),
+                  optional_dot_convert->shape().element_type()),
               matmul_call));
         } else {
           new_instr = matmul_call;

--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -511,8 +511,8 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
       HloInstruction* new_instr;
       // If matched pattern has custom-call -> bitcast -> add, then we need to
       // insert bitcast after the new fusion to maintain the correct shape
-      // (new-custom-call -> bitcast). Also, this will be followed by -> convert
-      // for bf16 case to avoid datatype mismatch.
+      // (new-custom-call -> bitcast). Also, this will optionally be followed
+      // by -> convert for bf16 case to avoid datatype mismatch.
       if (optional_dot_bitcast != nullptr &&
           optional_dot_bitcast->opcode() == HloOpcode::kBitcast) {
         if (optional_dot_convert != nullptr &&

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <utility>
 
+#include "tsl/platform/cpu_info.h"
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/literal.h"
 #include "xla/service/cpu/onednn_matmul_rewriter.h"
@@ -27,7 +28,6 @@ limitations under the License.
 #include "xla/tests/filecheck.h"
 #include "xla/tests/hlo_test_base.h"
 #include "xla/tests/test_macros.h"
-#include "tsl/platform/cpu_info.h"
 
 namespace op = xla::testing::opcode_matchers;
 
@@ -511,7 +511,7 @@ TEST_F(MatmulTest, DivisionByConstantWithEltwiseLinearF32) {
   )");
 }
 
-TEST_F(MatmulTest, SimpleBiasTestFP16_PARAM_F32) {
+TEST_F(MatmulTest, SimpleBiasTestF16_PARAM_F32) {
   if (!IsSupportedType(PrimitiveType::F16)) {
     GTEST_SKIP() << "CPU does not support F16.";
   }
@@ -537,7 +537,7 @@ TEST_F(MatmulTest, SimpleBiasTestFP16_PARAM_F32) {
   MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_);
 }
 
-TEST_F(MatmulTest, SimpleBiasTestFP16_PARAM_FP16) {
+TEST_F(MatmulTest, SimpleBiasTestF16_PARAM_F16) {
   if (!IsSupportedType(PrimitiveType::F16)) {
     GTEST_SKIP() << "CPU does not support F16.";
   }


### PR DESCRIPTION
This PR fixes a bug for f16 matmul enabling.
Since dot is supported in f16, there is no need for adding an extra convert instruction after fusion similar to the bf16 case.
Also add missed changes in build file.