### PR TITLE
Enable Relu epilogue fusion for cublasLt matmul for training

### DIFF
--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -95,6 +95,10 @@ message GemmBackendConfig {
     GELU_AUX = 5;
     BIAS_GELU = 6;
     BIAS_GELU_AUX = 7;
+    RELU_AUX = 8;
+    BIAS_RELU_AUX = 9;
+    D_RELU = 10;
+    D_RELU_BGRAD = 11;
   }
 
   Epilogue epilogue = 13;

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -173,7 +173,7 @@ class GemmAutotuner {
     TF_ASSIGN_OR_RETURN(bool has_aux_input,
                         xla::gpu::gpublas_lt::EpilogueHasAuxiliaryInput(
                             backend_config.epilogue()));
-
+    CHECK(!(has_aux_input && has_aux_output));
     TF_ASSIGN_OR_RETURN(auto epilogue,
                         AsBlasLtEpilogue(backend_config.epilogue()));
 

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -900,19 +900,17 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
   // Attempt to match the prescribed patterns associated with ReLU and its
   // gradient:
-  // y1 = matmul1(x1, weight1)
+  // y1 = fwd_gemm(x1, weight1)
   // y2 = relu(y1)
-  // y3 = matmul2(y2, weight2)
+  // y3 = matmul(y2, weight2)
   // and its corresponding backward pass
-  // dy1 = grad_matmul2(dy, weight2)
+  // dy1 = bwd_gemm(dy, weight2)
   // dy2 = drelu(dy1)
-  // dy3 = grad_matmul1(dy2, weight1)
-  // In the forward pass, fuse ReLU into matmul1 as an epilogue and generate a
-  // bitmask for subsequent use in grad_matmul2. For the backward pass,
-  // streamline and combine the ReLU gradient computation with grad_matmul2 as
-  // an epilogue.
+  // dy3 = grad_matmul(dy2, weight1)
+  // In the forward pass, fuse ReLU into fwd_gemm as an epilogue and generate a
+  // bitmask for subsequent use in backward pass where the ReLU gradient
+  // computation is fused with bwd_gemm as an epilogue.
   absl::Status HandleSelect(HloInstruction *instr) override {
-    // fwd_gemm refers to matmul1 and bwd_gemm refers to grad_matmul2 above.
     HloInstruction *fwd_gemm = nullptr;
     HloInstruction *bwd_gemm = nullptr;
     HloInstruction *maximum = nullptr;

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -751,13 +751,17 @@ absl::StatusOr<bool> EpilogueAddsVectorBias(
   switch (epilogue) {
     case GemmBackendConfig::DEFAULT:
     case GemmBackendConfig::RELU:
+    case GemmBackendConfig::RELU_AUX:
     case GemmBackendConfig::GELU:
     case GemmBackendConfig::GELU_AUX:
+    case GemmBackendConfig::D_RELU:
       return false;
     case GemmBackendConfig::BIAS:
     case GemmBackendConfig::BIAS_RELU:
     case GemmBackendConfig::BIAS_GELU:
+    case GemmBackendConfig::BIAS_RELU_AUX:
     case GemmBackendConfig::BIAS_GELU_AUX:
+    case GemmBackendConfig::D_RELU_BGRAD:
       return true;
     default:
       return Internal("Unknown Epilogue.");
@@ -773,10 +777,57 @@ absl::StatusOr<bool> EpilogueHasAuxiliaryOutput(
     case GemmBackendConfig::BIAS:
     case GemmBackendConfig::BIAS_RELU:
     case GemmBackendConfig::BIAS_GELU:
+    case GemmBackendConfig::D_RELU:
+    case GemmBackendConfig::D_RELU_BGRAD:
       return false;
+    case GemmBackendConfig::RELU_AUX:
+    case GemmBackendConfig::BIAS_RELU_AUX:
     case GemmBackendConfig::GELU_AUX:
     case GemmBackendConfig::BIAS_GELU_AUX:
       return true;
+    default:
+      return Internal("Unknown Epilogue.");
+  }
+}
+
+absl::StatusOr<bool> EpilogueHasAuxiliaryInput(
+    GemmBackendConfig_Epilogue epilogue) {
+  switch (epilogue) {
+    case GemmBackendConfig::DEFAULT:
+    case GemmBackendConfig::RELU:
+    case GemmBackendConfig::GELU:
+    case GemmBackendConfig::BIAS:
+    case GemmBackendConfig::BIAS_RELU:
+    case GemmBackendConfig::BIAS_GELU:
+    case GemmBackendConfig::RELU_AUX:
+    case GemmBackendConfig::BIAS_RELU_AUX:
+    case GemmBackendConfig::GELU_AUX:
+    case GemmBackendConfig::BIAS_GELU_AUX:
+      return false;
+    case GemmBackendConfig::D_RELU:
+    case GemmBackendConfig::D_RELU_BGRAD:
+      return true;
+    default:
+      return Internal("Unknown Epilogue.");
+  }
+}
+
+absl::StatusOr<bool> EpilogueForForward(GemmBackendConfig_Epilogue epilogue) {
+  switch (epilogue) {
+    case GemmBackendConfig::DEFAULT:
+    case GemmBackendConfig::RELU:
+    case GemmBackendConfig::GELU:
+    case GemmBackendConfig::BIAS:
+    case GemmBackendConfig::BIAS_RELU:
+    case GemmBackendConfig::BIAS_GELU:
+    case GemmBackendConfig::RELU_AUX:
+    case GemmBackendConfig::BIAS_RELU_AUX:
+    case GemmBackendConfig::GELU_AUX:
+    case GemmBackendConfig::BIAS_GELU_AUX:
+      return true;
+    case GemmBackendConfig::D_RELU:
+    case GemmBackendConfig::D_RELU_BGRAD:
+      return false;
     default:
       return Internal("Unknown Epilogue.");
   }
@@ -791,6 +842,8 @@ absl::StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
       return se::gpu::BlasLt::Epilogue::kReLU;
     case GemmBackendConfig::GELU:
       return se::gpu::BlasLt::Epilogue::kGELU;
+    case GemmBackendConfig::RELU_AUX:
+      return se::gpu::BlasLt::Epilogue::kReLUWithAux;
     case GemmBackendConfig::GELU_AUX:
       return se::gpu::BlasLt::Epilogue::kGELUWithAux;
     case GemmBackendConfig::BIAS:
@@ -799,8 +852,14 @@ absl::StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
       return se::gpu::BlasLt::Epilogue::kBiasThenReLU;
     case GemmBackendConfig::BIAS_GELU:
       return se::gpu::BlasLt::Epilogue::kBiasThenGELU;
+    case GemmBackendConfig::BIAS_RELU_AUX:
+      return se::gpu::BlasLt::Epilogue::kBiasThenReLUWithAux;
     case GemmBackendConfig::BIAS_GELU_AUX:
       return se::gpu::BlasLt::Epilogue::kBiasThenGELUWithAux;
+    case GemmBackendConfig::D_RELU:
+      return se::gpu::BlasLt::Epilogue::kDReLU;
+    case GemmBackendConfig::D_RELU_BGRAD:
+      return se::gpu::BlasLt::Epilogue::kDReLUBGrad;      
     default:
       return Internal("unexpected epilogue value");
   }

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -160,7 +160,9 @@ absl::StatusOr<bool> EpilogueAddsVectorBias(
     GemmBackendConfig_Epilogue epilogue);
 absl::StatusOr<bool> EpilogueHasAuxiliaryOutput(
     GemmBackendConfig_Epilogue epilogue);
-
+absl::StatusOr<bool> EpilogueHasAuxiliaryInput(
+    GemmBackendConfig_Epilogue epilogue);
+absl::StatusOr<bool> EpilogueForForward(GemmBackendConfig_Epilogue epilogue);
 absl::StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
     GemmBackendConfig_Epilogue epilogue);
 

--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -134,6 +134,14 @@ absl::StatusOr<cublasLtEpilogue_t> AsCublasLtEpilogue(
       return CUBLASLT_EPILOGUE_GELU_BIAS;
     case gpu::BlasLt::Epilogue::kBiasThenGELUWithAux:
       return CUBLASLT_EPILOGUE_GELU_AUX_BIAS;
+    case gpu::BlasLt::Epilogue::kReLUWithAux:
+      return CUBLASLT_EPILOGUE_RELU_AUX;
+    case gpu::BlasLt::Epilogue::kBiasThenReLUWithAux:
+      return CUBLASLT_EPILOGUE_RELU_AUX_BIAS;
+    case gpu::BlasLt::Epilogue::kDReLU:
+      return CUBLASLT_EPILOGUE_DRELU;
+    case gpu::BlasLt::Epilogue::kDReLUBGrad:
+      return CUBLASLT_EPILOGUE_DRELU_BGRAD;      
 #else
     case gpu::BlasLt::Epilogue::kGELU:
     case gpu::BlasLt::Epilogue::kGELUWithAux:
@@ -219,6 +227,11 @@ cudaDataType_t BlasLt::MatrixLayout::type() const {
   return std::move(desc);
 }
 
+cublasLtEpilogue_t BlasLt::MatmulDesc::epilogue_type() const {
+  return static_cast<cublasLtEpilogue_t>(
+      GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_EPILOGUE).value());
+}
+
 cublasComputeType_t BlasLt::MatmulDesc::compute_type() const {
   return static_cast<cublasComputeType_t>(
       GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_COMPUTE_TYPE)
@@ -257,6 +270,18 @@ auto BlasLt::MatmulPlan::GetAlgorithms(size_t max_algorithm_count,
         max_workspace_size));
 
     gpu::ScopedActivateExecutorContext sac{blas_lt_ref_.parent_};
+
+    auto epilogue = op_desc_.epilogue_type();
+    if (epilogue == CUBLASLT_EPILOGUE_RELU_AUX ||
+        epilogue == CUBLASLT_EPILOGUE_RELU_AUX_BIAS) {
+      TF_ASSIGN_OR_RETURN(
+          int64_t output_leading_dim,
+          GetAttr<int64_t>(d_desc_.get(), CUBLASLT_MATRIX_LAYOUT_LD));
+
+      TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                                 CUBLASLT_MATMUL_DESC_EPILOGUE_AUX_LD,
+                                 output_leading_dim));
+    }
 
     int found_algorithm_count = 0;
     SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulAlgoGetHeuristic(

--- a/xla/stream_executor/cuda/cuda_blas_lt.h
+++ b/xla/stream_executor/cuda/cuda_blas_lt.h
@@ -75,6 +75,7 @@ class BlasLt : public gpu::BlasLt {
         PointerMode pointer_mode = PointerMode::kHost);
 
     cublasComputeType_t compute_type() const;
+    cublasLtEpilogue_t epilogue_type() const;
     cudaDataType_t scale_type() const;
     cublasLtPointerMode_t pointer_mode() const;
     cublasLtMatmulDesc_t get() const { return handle_.get(); }

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -131,6 +131,10 @@ struct BlasLt {
     kGELUWithAux = 32 | 1024,  // Apply GELU with auxiliary output.
     kBiasThenGELU = kBias | kGELU,  // Apply bias and then approximate GELU.
     kBiasThenGELUWithAux = kBiasThenGELU | 1024,
+    kReLUWithAux = 2 | 1024,  // Apply ReLU with auxiliary output.
+    kBiasThenReLUWithAux = kBiasThenReLU | 1024,
+    kDReLU = 8 | 128,
+    kDReLUBGrad = kDReLU | 16,
   };
 
   // Describes the location of pointers for the scaling factors alpha and beta.


### PR DESCRIPTION
To enable ReLU epilogue fusion for CublasLt matmul for training, 2 pair of epilogues: (RELU_AUX, DRELU) and (BIAS_RELU_AUX, DRELU_BGRAD) are added. The RELU_AUX(or BIAS_RELU_AUX) epilogue for the forward matmul outputs a bitmask in the auxiliary buffer for the backward matmul to use. This PR only targets both non-fp8 and fp8 matmuls. @kaixih @philipphack @reedwm 

This PR aims to pattern match the following forward pass:
```
y = matmul1(x1, weight1)
y = relu(y)
y = matmul2(y, weight2)
```
and its corresponding backward pass
```
dy = grad_matmul2(dy, weight1)
dy = drelu(dy)
dy = grad_matmul1(dy, weight2)
```
Here matmul1, matmul2, grad_matmul1 and grad_matmul2 could also be fp8 matmuls and vector bias could be present. In the forward pass, ReLU is fused into matmul1 and in the backward pass, drelu is fused into grad_matmul2.
For the matmul operation with the first matrix having dimensions m=16384, k=n=12288, the performance comparison yields:

With Optimization:
Execution Time: 32.98 ms

Without Optimization:
Execution Time: 33.52 ms