### PR TITLE
[ROCm] gcc compiler before 10

### DIFF
--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -73,7 +73,13 @@ limitations under the License.
 #define XLA_FFI_ATTRIBUTE_NEVER_INLINE
 #endif
 
-#if __has_builtin(__builtin_expect)
+#if !defined(__has_builtin) && defined(__GNUC__) && __GNUC__ < 10
+#define HAS_BUILTIN_EXPECT 1
+#else
+#define HAS_BUILTIN_EXPECT __has_builtin(__builtin_expect)
+#endif
+
+#if HAS_BUILTIN_EXPECT
 #define XLA_FFI_PREDICT_FALSE(x) (__builtin_expect(false || (x), false))
 #define XLA_FFI_PREDICT_TRUE(x) (__builtin_expect(false || (x), true))
 #else

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -160,7 +160,8 @@ cc_library(
 xla_cc_test(
     name = "custom_call_test",
     srcs = if_gpu_is_configured(["custom_call_test.cc"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + 
+                    if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     tags = tf_cuda_tests_tags(),
     deps = [
         "//xla:debug_options_flags",


### PR DESCRIPTION
this adds protection before gcc10 for https://github.com/openxla/xla/commit/f2eeace6bd9e19b27c3a121adee18cc7936e0adb#diff-a9034f0822fc31af01d14b2def658853f9e48c342fad205292a878ac25b671a2R76