### PR TITLE
[XLA:CPU][oneDNN] Variant patterns of GELU tanh approximation

### DIFF
--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -56,13 +56,41 @@ inline Status ValidateDotDimensionNumbers(
   return OkStatus();
 }
 
+// Whether the element type of instr is compatible with oneDNN kernels.
+// TODO(intel-tf): Restict compatible types based on instruction kind.
+inline bool CompatibleElementType(const HloInstruction* instr) {
+  PrimitiveType element_type = instr->shape().element_type();
+  return element_type == BF16 || element_type == F32 || element_type == F16;
+}
+
+// Type conversion from and to any of BF16 and FP32.
+// TODO(intel-tf): Support more types when enabled.
+template <typename Pattern>
+inline auto SupportedConvert(Pattern pattern) {
+  auto supported_convert = [](const HloInstruction* instr) -> bool {
+    return CompatibleElementType(instr) &&
+           CompatibleElementType(instr->operand(0));
+  };
+  return m::Convert(pattern).WithPredicate(supported_convert);
+}
+
+template <typename Pattern>
+inline auto SupportedConvert(HloInstruction** convert, Pattern pattern) {
+  auto supported_convert = [](const HloInstruction* instr) -> bool {
+    return CompatibleElementType(instr) &&
+           CompatibleElementType(instr->operand(0));
+  };
+  return m::Convert(convert, pattern).WithPredicate(supported_convert);
+}
+
 template <typename Pattern>
 auto ElementwiseSafeIntermediate(HloInstruction** instr, Pattern pattern) {
-  return m::AnyOf<HloInstruction>(m::Broadcast(instr, pattern.WithOneUser()),
-                                  m::Slice(instr, pattern.WithOneUser()),
-                                  m::Bitcast(instr, pattern.WithOneUser()),
-                                  m::Reshape(instr, pattern.WithOneUser()),
-                                  pattern);
+  return m::AnyOf<HloInstruction>(
+      m::Broadcast(instr, pattern.WithOneUser()),
+      m::Slice(instr, pattern.WithOneUser()),
+      m::Bitcast(instr, pattern.WithOneUser()),
+      m::Reshape(instr, pattern.WithOneUser()),
+      SupportedConvert(instr, pattern.WithOneUser()), pattern);
 }
 
 inline auto OneDnnMatmulInstr(HloInstruction** instr) {
@@ -137,35 +165,64 @@ inline auto BcastConstScalarNear(double value) {
   return m::Broadcast(ConstScalarNear(value));
 }
 
-auto GELUActivation(HloInstruction* instr, HloInstruction** src) {
+// Associativity and commutativity properties of multiply results in various
+// patterns for an equivalent computation. This function tries to capture most
+// of the variations for a computation a * b * c. For example, patterns could be
+// any of (a * b) * c or a * (b * c), alongwith the variations resulting from
+// commutative patterns.
+template <typename PatternA, typename PatternB, typename PatternC>
+inline auto MultiplyMultiplyAnyOrder(PatternA a, PatternB b, PatternC c) {
+  return m::AnyOf<HloInstruction>(
+      m::MultiplyAnyOrder(a, m::MultiplyAnyOrder(b, c)),
+      m::MultiplyAnyOrder(b, m::MultiplyAnyOrder(a, c)),
+      m::MultiplyAnyOrder(c, m::MultiplyAnyOrder(a, b)));
+}
+
+bool GELUActivation(HloInstruction* instr, HloInstruction** src) {
   // Attempt to match GELU_TANH activation
   // (https://arxiv.org/abs/1606.08415), where:
   // gelu_tanh(x) = x * cdf(x)
   // cdf(x) = 0.5 * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x**3))
+  //                     -------------errf_approximate------------
+
   HloInstruction* errf;
-  return Match(instr, m::MultiplyAnyOrder(
-                          m::Op(src),
-                          m::MultiplyAnyOrder(
-                              BcastConstScalar(0.5),
-                              m::AddAnyOrder(BcastConstScalar(1.0),
-                                             m::Op(&errf).WithOneUser())))) &&
-         Match(errf,
-               m::Tanh(m::MultiplyAnyOrder(
-                           BcastConstScalarNear(sqrt(M_2_PI)),
-                           m::AddAnyOrder(
-                               m::Op().Is(*src),
-                               m::MultiplyAnyOrder(
-                                   BcastConstScalarNear(0.044715),
-                                   m::MultiplyAnyOrder(
-                                       m::Op().Is(*src),
-                                       m::MultiplyAnyOrder(m::Op().Is(*src),
-                                                           m::Op().Is(*src))
-                                           .WithOneUser())
-                                       .WithOneUser())
-                                   .WithOneUser())
-                               .WithOneUser())
-                           .WithOneUser())
-                   .WithOneUser());
+
+  // The expression 0.5 * x * (1 + errf) as common pattern for GELU exact and
+  // approximate activations.
+  auto common_pattrn = MultiplyMultiplyAnyOrder(
+      BcastConstScalar(0.5), m::Op(src),
+      m::AddAnyOrder(BcastConstScalar(1.0), m::Op(&errf).WithOneUser()));
+
+  bool matched = Match(instr, common_pattrn);
+  if (matched) {
+    // The subexpression 0.044715 * x**3 appears in GELU approximate activation.
+    // However, it is often optimized by other HLO passes into an expression of
+    // 0.044715 * x * (x * x). Since there are three consecutive multiplies,
+    // there could be a large number of patterns. We try capture some of those:
+    //
+    //      1. (0.044715 * x) * x * x
+    //      2. 0.044715 * (x * x) * x
+    //
+    // Note each of the above could in turn have various patterns due to
+    // associtivity and commutativity properties of mulitply.
+    auto subexpr_pattrn = m::AnyOf<HloInstruction>(
+        MultiplyMultiplyAnyOrder(
+            m::MultiplyAnyOrder(BcastConstScalarNear(0.044715),
+                                m::Op().Is(*src)),
+            m::Op().Is(*src), m::Op().Is(*src)),
+        MultiplyMultiplyAnyOrder(
+            BcastConstScalarNear(0.044715),
+            m::Multiply(m::Op().Is(*src), m::Op().Is(*src)), m::Op().Is(*src)));
+
+    auto errf_apprx_pattrn =
+        m::Tanh(
+            m::MultiplyAnyOrder(
+                BcastConstScalarNear(sqrt(M_2_PI)),
+                m::AddAnyOrder(m::Op().Is(*src), subexpr_pattrn).WithOneUser()))
+            .WithOneUser();
+    matched = Match(errf, errf_apprx_pattrn);
+  }
+  return matched;
 }
 
 // OneDNN matmul can fuse add operation with automatic broadcasting along the
@@ -239,33 +296,6 @@ inline bool IsOperandFusible(HloInstruction* operand, HloInstruction* dot) {
 
 inline bool IsRowMajor(const Shape& shape) {
   return LayoutUtil::IsMonotonicWithDim0Major(shape.layout());
-}
-
-// Whether the element type of instr is compatible with oneDNN kernels.
-// TODO(intel-tf): Restict compatible types based on instruction kind.
-inline bool CompatibleElementType(const HloInstruction* instr) {
-  PrimitiveType element_type = instr->shape().element_type();
-  return element_type == BF16 || element_type == F32 || element_type == F16;
-}
-
-// Type conversion from and to any of BF16, F16 and FP32.
-// TODO(intel-tf): Support more types when enabled.
-template <typename Pattern>
-inline auto SupportedConvert(Pattern pattern) {
-  auto supported_convert = [](const HloInstruction* instr) -> bool {
-    return CompatibleElementType(instr) &&
-           CompatibleElementType(instr->operand(0));
-  };
-  return m::Convert(pattern).WithPredicate(supported_convert);
-}
-
-template <typename Pattern>
-inline auto SupportedConvert(HloInstruction** convert, Pattern pattern) {
-  auto supported_convert = [](const HloInstruction* instr) -> bool {
-    return CompatibleElementType(instr) &&
-           CompatibleElementType(instr->operand(0));
-  };
-  return m::Convert(convert, pattern).WithPredicate(supported_convert);
 }
 
 template <typename Pattern>

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -63,6 +63,15 @@ class MatmulTest : public HloTestBase {
     ; CHECK-DAG:   }
     ; CHECK:     }
     )";
+  const char* fused_matmul_bias_gelu_tanh_ = R"(
+    ; CHECK:     custom_call_target="__onednn$matmul",
+    ; CHECK:       backend_config={
+    ; CHECK-DAG:     "outer_dimension_partitions":[],
+    ; CHECK-DAG:     "onednn_matmul_config":{
+    ; CHECK-DAG:       "fused_ops":["BIAS","GELU_TANH"]
+    ; CHECK-DAG:   }
+    ; CHECK:     }
+    )";
 };
 
 TEST_F(MatmulTest, SimpleTestF32) {
@@ -393,16 +402,126 @@ TEST_F(MatmulTest, BiasAndApproxGELUTestF32) {
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
-  MatchOptimizedHlo(matmul_module_str,
-                    R"(
-  ; CHECK:     custom_call_target="__onednn$matmul",
-  ; CHECK:       backend_config={
-  ; CHECK-DAG:     "outer_dimension_partitions":[],
-  ; CHECK-DAG:     "onednn_matmul_config":{
-  ; CHECK-DAG:       "fused_ops":["BIAS","GELU_TANH"]
-  ; CHECK-DAG:   }
-  ; CHECK:     }
-  )");
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_gelu_tanh_);
+}
+
+// Tests GELU approximate pattern from tf.nn.gelu(approximate=True).
+TEST_F(MatmulTest, BiasAndApproxTFGELUTestF32) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32
+
+  ENTRY matmul.test.f32 {
+  arg0.1 = f32[1024,512] parameter(0), parameter_replication={false}
+  arg1.2 = f32[256,512] parameter(1), parameter_replication={false}
+  dot.7 = f32[1024,256] dot(arg0.1, arg1.2), lhs_contracting_dims={1}, rhs_contracting_dims={1}, frontend_attributes={grad_x="false",grad_y="false"}
+  arg2.3 = f32[256] parameter(2), parameter_replication={false}
+  broadcast.9 = f32[1024,256] broadcast(arg2.3), dimensions={1}
+  add.10 = f32[1024,256] add(dot.7, broadcast.9)
+  constant.12 = f32[] constant(0.044715)
+  broadcast.13 = f32[1024,256] broadcast(constant.12), dimensions={}
+  multiply.14 = f32[1024,256] multiply(broadcast.13, add.10)
+  multiply.11 = f32[1024,256] multiply(add.10, add.10)
+  multiply.15 = f32[1024,256] multiply(multiply.14, multiply.11)
+  add.16 = f32[1024,256] add(add.10, multiply.15)
+  constant.17 = f32[] constant(0.797884583)
+  broadcast.18 = f32[1024,256] broadcast(constant.17), dimensions={}
+  multiply.19 = f32[1024,256] multiply(add.16, broadcast.18)
+  tanh.20 = f32[1024,256] tanh(multiply.19)
+  constant.21 = f32[] constant(1)
+  broadcast.22 = f32[1024,256] broadcast(constant.21), dimensions={}
+  add.23 = f32[1024,256] add(tanh.20, broadcast.22)
+  constant.24 = f32[] constant(0.5)
+  broadcast.25 = f32[1024,256] broadcast(constant.24), dimensions={}
+  multiply.26 = f32[1024,256] multiply(add.23, broadcast.25)
+  ROOT multiply.27 = f32[1024,256] multiply(add.10, multiply.26)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_gelu_tanh_);
+}
+
+// Tests GELU approximate pattern from tf.nn.gelu(approximate=True) with
+// auto_mixed_precision_onednn_bfloat16.
+TEST_F(MatmulTest, BiasAndApproxTFGELUTestBF16) {
+  if (!IsSupportedType(PrimitiveType::BF16)) {
+    GTEST_SKIP() << "CPU does not support BF16.";
+  }
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32
+
+  ENTRY matmul.test.f32 {
+  arg0.1 = f32[1024,512] parameter(0), parameter_replication={false}
+  convert.8 = bf16[1024,512] convert(arg0.1)
+  arg1.2 = f32[256,512] parameter(1), parameter_replication={false}
+  convert.9 = bf16[256,512] convert(arg1.2)
+  dot.10 = bf16[1024,256] dot(convert.8, convert.9), lhs_contracting_dims={1}, rhs_contracting_dims={1}, frontend_attributes={grad_x="false",grad_y="false"}
+  convert = f32[1024,256] convert(dot.10)
+  arg2.3 = f32[256] parameter(2), parameter_replication={false}
+  broadcast = f32[1024,256] broadcast(arg2.3), dimensions={1}
+  add.13 = f32[1024,256] add(convert, broadcast)
+  constant.16 = f32[] constant(0.044715)
+  broadcast.17 = f32[1024,256] broadcast(constant.16), dimensions={}
+  multiply.18 = f32[1024,256] multiply(broadcast.17, add.13)
+  multiply.15 = f32[1024,256] multiply(add.13, add.13)
+  multiply.19 = f32[1024,256] multiply(multiply.18, multiply.15)
+  add.20 = f32[1024,256] add(add.13, multiply.19)
+  constant.21 = f32[] constant(0.797884583)
+  broadcast.22 = f32[1024,256] broadcast(constant.21), dimensions={}
+  multiply.23 = f32[1024,256] multiply(add.20, broadcast.22)
+  tanh.24 = f32[1024,256] tanh(multiply.23)
+  constant.25 = f32[] constant(1)
+  broadcast.26 = f32[1024,256] broadcast(constant.25), dimensions={}
+  add.27 = f32[1024,256] add(tanh.24, broadcast.26)
+  constant.1 = f32[] constant(0.5)
+  broadcast.2 = f32[1024,256] broadcast(constant.1), dimensions={}
+  multiply.30 = f32[1024,256] multiply(add.13, broadcast.2)
+  ROOT multiply.32 = f32[1024,256] multiply(add.27, multiply.30)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-2}));
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_gelu_tanh_);
+}
+
+// Tests GELU approximate pattern from tf.nn.gelu(approximate=True)
+TEST_F(MatmulTest, BiasAndApproxTFGELUTestF16) {
+  if (!IsSupportedType(PrimitiveType::F16)) {
+    GTEST_SKIP() << "CPU does not support F16.";
+  }
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32
+
+  ENTRY matmul.test.f32 {
+  arg0.1 = f16[1024,512] parameter(0), parameter_replication={false}
+  reshape.4 = f16[1024,512] reshape(arg0.1)
+  arg1.2 = f16[256,512] parameter(1), parameter_replication={false}
+  reshape.5 = f16[256,512] reshape(arg1.2)
+  dot.7 = f16[1024,256] dot(reshape.4, reshape.5), lhs_contracting_dims={1}, rhs_contracting_dims={1}, frontend_attributes={grad_x="false",grad_y="false"}
+  transpose.8 = f16[1024,256] transpose(dot.7), dimensions={0,1}
+  arg2.3 = f16[256] parameter(2), parameter_replication={false}
+  reshape.6 = f16[256] reshape(arg2.3)
+  broadcast.9 = f16[1024,256] broadcast(reshape.6), dimensions={1}
+  add.10 = f16[1024,256] add(transpose.8, broadcast.9)
+  constant.12 = f16[] constant(0.044708)
+  broadcast.13 = f16[1024,256] broadcast(constant.12), dimensions={}
+  multiply.14 = f16[1024,256] multiply(broadcast.13, add.10)
+  multiply.11 = f16[1024,256] multiply(add.10, add.10)
+  multiply.15 = f16[1024,256] multiply(multiply.14, multiply.11)
+  add.16 = f16[1024,256] add(add.10, multiply.15)
+  constant.17 = f16[] constant(0.79785)
+  broadcast.18 = f16[1024,256] broadcast(constant.17), dimensions={}
+  multiply.19 = f16[1024,256] multiply(add.16, broadcast.18)
+  tanh.20 = f16[1024,256] tanh(multiply.19)
+  constant.21 = f16[] constant(1)
+  broadcast.22 = f16[1024,256] broadcast(constant.21), dimensions={}
+  add.23 = f16[1024,256] add(tanh.20, broadcast.22)
+  constant.24 = f16[] constant(0.5)
+  broadcast.25 = f16[1024,256] broadcast(constant.24), dimensions={}
+  multiply.26 = f16[1024,256] multiply(add.23, broadcast.25)
+  ROOT multiply.27 = f16[1024,256] multiply(add.10, multiply.26)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_gelu_tanh_);
 }
 
 TEST_F(MatmulTest, ReLUTestF32) {


### PR DESCRIPTION
This PR supports more patterns from TF->XLA GELU Approximate. It was found that the variations were resulting from associativity of multiply instructions like in the expression a * b * c. An utility function is added in this PR that captures patterns from two consecutive multiplies.