### PR TITLE
[XLA:GPU] bump up minimum PTX ISA to be 8.1 for CUDA >= 12.1

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -76,6 +76,10 @@ limitations under the License.
 #include "rocm/rocm_config.h"
 #endif
 
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#endif
+
 namespace xla {
 namespace gpu {
 namespace {

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -294,6 +294,11 @@ std::unique_ptr<llvm::TargetMachine> NVPTXGetTargetMachine(
     const DebugOptions& debug_options) {
   // Figure out the exact name of the processor as known to the NVPTX backend
   // from the gpu_architecture flag.
+#if defined(GOOGLE_CUDA) && CUDA_VERSION >= 12010
+  // use ptx81 for CUDA >= 12.1
+  return GetTargetMachine(target_triple, GetSmName(compute_capability),
+                          debug_options, /*feature_str=*/"+ptx81");
+#endif
   return GetTargetMachine(target_triple, GetSmName(compute_capability),
                           debug_options, /*feature_str=*/"+ptx74");
 }


### PR DESCRIPTION
NV internal workloads facing an error rn: `error   : Feature 'Kernel parameter size larger than 4352 bytes' requires PTX ISA .version 8.1 or later`. Bumping up to PTX81 solved the issue however it requires minimum CUDA 12.1 to work. So for WAR, I added a check to use PTX81 if CUDA 12.1 is available.