### PR TITLE
GpuTimer: use delay kernel to improve accuracy

### DIFF
--- a/xla/service/gpu/autotuner_compile_util.cc
+++ b/xla/service/gpu/autotuner_compile_util.cc
@@ -120,6 +120,9 @@ AutotunerCompileUtil::ProfileExecutable(
   std::vector<ExecutionInput> execution_inputs =
       ExecutionInputsFromBuffers(input_buffers, input_shapes);
   ExecutionProfile profile;
+  // Flag that a warm-up run was executed so that GpuTimer can use the, more
+  // accurate, delay kernel implementation.
+  profile.set_warmup_run_executed(true);
   TF_ASSIGN_OR_RETURN(
       ExecutionOutput execution_output,
       Execute(*executable, std::move(execution_inputs), &profile));

--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -625,6 +625,8 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
   launch_status = RunGpuConv(config, operand_buffers, result_buffers,
                              scratch_memory, stream, options);
   // It is intentional that the warm-up run does not have a profile result.
+  // This avoids a timeout and error message if lazy module loading is enabled
+  // by ensuring that lazy loading happens outside the GpuTimer region.
   options.profile_result = &profile_result;
   constexpr int kMaxIter = 10;
   // Iterate until the new measurement is within kThreshold of the current

--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -624,10 +624,11 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
   // Dry-run to warmup the plan.
   launch_status = RunGpuConv(config, operand_buffers, result_buffers,
                              scratch_memory, stream, options);
-  // It is intentional that the warm-up run does not have a profile result.
-  // This avoids a timeout and error message if lazy module loading is enabled
-  // by ensuring that lazy loading happens outside the GpuTimer region.
+  // Flag that a warm-up run has been executed; this allows the GpuTimer for
+  // the main measurement to safely use the delay kernel pattern, even if lazy
+  // module loading is enabled.
   options.profile_result = &profile_result;
+  profile_result.set_warmup_run_executed(true);
   constexpr int kMaxIter = 10;
   // Iterate until the new measurement is within kThreshold of the current
   // minimum.

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -246,10 +246,12 @@ class GemmAutotuner {
 
     auto tuned_func = [&](const se::blas::AlgorithmType& algorithm)
         -> absl::StatusOr<se::blas::ProfileResult> {
-      // Do a warm-up run first, without a profile result. RunGemm swallows
-      // error codes when profile_result is passed, as it is in the measurement
-      // below, but not otherwise. It is, therefore, consistent to ignore the
-      // error code here.
+      // Do a warm-up run first, without a profile result. This avoids a timeout
+      // and error message if lazy module loading is enabled by ensuring that
+      // lazy loading happens outside the GpuTimer. RunGemm swallows error codes
+      // when profile_result is passed, as it is in the measurement below, but
+      // not otherwise. It is, therefore, consistent to ignore the error code
+      // here.
       static_cast<void>(RunGemm(gemm_config, lhs_buffer_, rhs_buffer_,
                                 output_buffer_, workspace_buffer,
                                 deterministic_ops_, stream_, algorithm));

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -193,6 +193,7 @@ class GemmAutotuner {
           c_scale_buffer, d_scale_buffer, d_amax_buffer, algorithm,
           scratch_allocator));
       se::blas::ProfileResult profile_result;
+      profile_result.set_warmup_run_executed(true);
       TF_RETURN_IF_ERROR(plan->ExecuteOnStream(
           stream_, lhs_buffer_, rhs_buffer_, output_buffer_, output_buffer_,
           bias_buffer, aux_buffer, a_scale_buffer, b_scale_buffer,
@@ -246,16 +247,17 @@ class GemmAutotuner {
 
     auto tuned_func = [&](const se::blas::AlgorithmType& algorithm)
         -> absl::StatusOr<se::blas::ProfileResult> {
-      // Do a warm-up run first, without a profile result. This avoids a timeout
-      // and error message if lazy module loading is enabled by ensuring that
-      // lazy loading happens outside the GpuTimer. RunGemm swallows error codes
-      // when profile_result is passed, as it is in the measurement below, but
-      // not otherwise. It is, therefore, consistent to ignore the error code
-      // here.
+      // Do a warm-up run first, without a profile result. RunGemm swallows
+      // error codes when profile_result is passed, as it is in the measurement
+      // below, but not otherwise. It is, therefore, consistent to ignore the
+      // error code here.
       static_cast<void>(RunGemm(gemm_config, lhs_buffer_, rhs_buffer_,
                                 output_buffer_, workspace_buffer,
                                 deterministic_ops_, stream_, algorithm));
       se::blas::ProfileResult profile_result;
+      // Allow GpuTimer to use its delay kernel implementation to improve
+      // accuracy.
+      profile_result.set_warmup_run_executed(true);
       // We expect GemmWithAlgorithm to fail sometimes -- in fact, it will fail
       // for all algorithms if we're targeting < sm_50. But because we pass a
       // non-null ProfileResult, DoGemmWithAlgorithm should always return true,

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -439,8 +439,9 @@ absl::Status ExecuteThunks(
   if (ExecutionProfile* profile =
           run_options->run_options().execution_profile();
       profile) {
-    TF_ASSIGN_OR_RETURN(execution_timer,
-                        se::gpu::GpuTimer::Create(main_stream));
+    TF_ASSIGN_OR_RETURN(
+        execution_timer,
+        se::gpu::GpuTimer::Create(main_stream, profile->warmup_run_executed()));
   }
 #endif
 

--- a/xla/stream_executor/blas.h
+++ b/xla/stream_executor/blas.h
@@ -158,13 +158,15 @@ class ProfileResult {
  public:
   bool is_valid() const { return is_valid_; }
   void set_is_valid(bool val) { is_valid_ = val; }
+  bool warmup_run_executed() const { return warmup_run_executed_; }
+  void set_warmup_run_executed(bool val) { warmup_run_executed_ = val; }
   AlgorithmType algorithm() const { return algorithm_; }
   void set_algorithm(AlgorithmType val) { algorithm_ = val; }
   float elapsed_time_in_ms() const { return elapsed_time_in_ms_; }
   void set_elapsed_time_in_ms(float val) { elapsed_time_in_ms_ = val; }
 
  private:
-  bool is_valid_ = false;
+  bool is_valid_ = false, warmup_run_executed_ = false;
   AlgorithmType algorithm_ = kDefaultAlgorithm;
   float elapsed_time_in_ms_ = std::numeric_limits<float>::max();
 };

--- a/xla/stream_executor/cuda/cuda_blas.cc
+++ b/xla/stream_executor/cuda/cuda_blas.cc
@@ -750,7 +750,10 @@ absl::Status CUDABlas::DoBlasGemmWithAlgorithm(
 
   TF_ASSIGN_OR_RETURN(
       std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(stream, output_profile_result != nullptr));
+      GpuTimer::CreateIfNeeded(
+          stream,
+          output_profile_result && output_profile_result->warmup_run_executed(),
+          output_profile_result != nullptr));
 
   // Since we are converting 'algorithm' to cublasGemmAlgo_t by static_cast,
   // we do the following compile-time check on the default value:
@@ -782,7 +785,10 @@ absl::Status CUDABlas::DoBlasGemmStridedBatchedWithAlgorithm(
       GetMathTypeForGemmEx(stream, algorithm, type_a, type_b, numeric_options));
   TF_ASSIGN_OR_RETURN(
       std::optional<GpuTimer> timer,
-      GpuTimer::CreateIfNeeded(stream, output_profile_result != nullptr));
+      GpuTimer::CreateIfNeeded(
+          stream,
+          output_profile_result && output_profile_result->warmup_run_executed(),
+          output_profile_result != nullptr));
   cudaDataType_t cuda_in_type = AsCudaDataType(type_a);
 
 #if CUDA_VERSION >= 11000

--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -406,8 +406,11 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
     DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
     blas::ProfileResult* profile_result) const {
-  TF_ASSIGN_OR_RETURN(std::optional<gpu::GpuTimer> timer,
-                      gpu::GpuTimer::CreateIfNeeded(stream, profile_result));
+  TF_ASSIGN_OR_RETURN(
+      std::optional<gpu::GpuTimer> timer,
+      gpu::GpuTimer::CreateIfNeeded(
+          stream, profile_result && profile_result->warmup_run_executed(),
+          profile_result != nullptr));
 
   void* workspace = nullptr;
   if (algorithm.workspace_size > 0) {

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -910,6 +910,8 @@ class ProfileResult {
     return algorithm_.has_value() &&
            elapsed_time_in_ms() != std::numeric_limits<float>::max();
   }
+  bool warmup_run_executed() const { return warmup_run_executed_; }
+  void set_warmup_run_executed(bool val) { warmup_run_executed_ = val; }
 
   AlgorithmDesc algorithm() const { return *algorithm_; }
   void set_algorithm(AlgorithmDesc val) { algorithm_ = val; }
@@ -926,6 +928,7 @@ class ProfileResult {
   // The scratch size algorithm_ requires. Currently it's only populated by
   // convolutions.
   size_t scratch_size_ = 0;
+  bool warmup_run_executed_ = false;
 };
 
 // Backend-specific data shared between repeated launches of the same

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -316,10 +316,28 @@ gpu_only_cc_library(
 )
 
 gpu_only_cc_library(
+    name = "gpu_timer_kernel_header",
+    hdrs = ["gpu_timer_kernel.h"],
+)
+
+gpu_kernel_library(
+    name = "gpu_timer_kernel",
+    srcs = if_gpu_is_configured(["gpu_timer_kernel.cu.cc"]),
+    deps = [
+        ":gpu_timer_kernel_header",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
+)
+
+gpu_only_cc_library(
     name = "gpu_timer_header",
     hdrs = ["gpu_timer.h"],
     deps = [
         ":gpu_executor_header",
+        ":gpu_timer_kernel_header",
         ":gpu_types_header",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/time",
@@ -330,10 +348,14 @@ gpu_only_cc_library(
     name = "gpu_timer",
     srcs = ["gpu_timer.cc"],
     hdrs = ["gpu_timer.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
     deps = [
         ":gpu_driver_header",
         ":gpu_executor_header",
         ":gpu_stream",
+        ":gpu_timer_kernel_header",
         ":gpu_types_header",
         "//xla/stream_executor",
         "//xla/stream_executor:stream_executor_internal",
@@ -348,7 +370,9 @@ gpu_only_cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
-    ] + if_cuda_is_configured([
+    ] + if_gpu_is_configured([
+        ":gpu_timer_kernel",
+    ]) + if_cuda_is_configured([
         "//xla/stream_executor/cuda:cuda_driver",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:rocm_driver",

--- a/xla/stream_executor/gpu/gpu_timer.cc
+++ b/xla/stream_executor/gpu/gpu_timer.cc
@@ -51,10 +51,21 @@ absl::Duration RandomDuration() {
   return absl::Microseconds(distribution(rng));
 }
 
+bool ShouldLaunchDelayKernel() {
+  // Only launch the delay kernel if CUDA_LAUNCH_BLOCKING is not set to 1.
+  static bool value = [] {
+    const char* blocking = std::getenv("CUDA_LAUNCH_BLOCKING");
+    return !blocking || std::string_view{blocking} != "1";
+  }();
+  return value;
+}
+
 }  // namespace
 
 /*deprecated*/ /*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(
     GpuStream* stream) {
+  // This deprecated factory does not launch the delay kernel and may lead to
+  // reduced measurement accuracy.
   GpuExecutor* parent = stream->parent();
   GpuContext* context = parent->gpu_context();
   GpuEventHandle start_event;
@@ -72,6 +83,8 @@ absl::Duration RandomDuration() {
 
 /*deprecated*/ /*static*/ absl::StatusOr<std::optional<GpuTimer>>
 GpuTimer::CreateIfNeeded(GpuStream* stream, bool is_needed) {
+  // This deprecated factory does not launch the delay kernel and may lead to
+  // reduced measurement accuracy.
   if (is_needed) {
     TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream));
     return {std::make_optional(std::move(t))};
@@ -79,16 +92,78 @@ GpuTimer::CreateIfNeeded(GpuStream* stream, bool is_needed) {
   return std::nullopt;
 }
 
-[[deprecated("So it can quietly call a deprecated method")]] /*static*/ absl::
-    StatusOr<GpuTimer>
-    GpuTimer::Create(Stream* stream) {
-  return GpuTimer::Create(AsGpuStream(stream));
+/*static*/ absl::StatusOr<GpuTimer::GpuSemaphore>
+GpuTimer::GpuSemaphore::Create(StreamExecutor* executor) {
+  // Allocate the value in pinned host memory that can be read from both
+  // host and device.
+  TF_ASSIGN_OR_RETURN(auto alloc,
+                      executor->HostMemoryAllocate(sizeof(GpuSemaphoreState)));
+  return GpuSemaphore{std::move(alloc)};
 }
 
-[[deprecated("So it can quietly call a deprecated method")]] /*static*/ absl::
-    StatusOr<std::optional<GpuTimer>>
-    GpuTimer::CreateIfNeeded(Stream* stream, bool is_needed) {
-  return GpuTimer::CreateIfNeeded(AsGpuStream(stream), is_needed);
+DeviceMemory<GpuSemaphoreState> GpuTimer::GpuSemaphore::device() {
+  // This assumes unified addressing, as we do not explicitly translate the
+  // host pointer into a device pointer.
+  return DeviceMemory<GpuSemaphoreState>::MakeFromByteSize(
+      ptr_->opaque(), sizeof(GpuSemaphoreState));
+}
+
+/*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(Stream* real_stream) {
+  StreamExecutor* executor = real_stream->parent();
+  GpuStream* stream = AsGpuStream(real_stream);
+  GpuExecutor* parent = stream->parent();
+  GpuContext* context = parent->gpu_context();
+  GpuEventHandle start_event;
+  TF_RETURN_IF_ERROR(GpuDriver::InitEvent(context, &start_event,
+                                          GpuDriver::EventFlags::kDefault));
+  GpuEventHandle stop_event;
+  TF_RETURN_IF_ERROR(GpuDriver::InitEvent(context, &stop_event,
+                                          GpuDriver::EventFlags::kDefault));
+  CHECK(start_event != nullptr && stop_event != nullptr);
+  GpuSemaphore semaphore{};
+  if (ShouldLaunchDelayKernel()) {
+    // Check the assumption that this device supports unified addressing,
+    // otherwise skip the delay kernel
+    TF_ASSIGN_OR_RETURN(int status, GpuDriver::GetDeviceAttribute(
+                                        CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING,
+                                        parent->device()));
+    if (!status) {
+      LOG(WARNING) << "Skipping the delay kernel because the device does not "
+                      "support unified addressing";
+    } else {
+      // Allocate a semaphore value that will be used to signal to the delay
+      // kernel that it may exit.
+      TF_ASSIGN_OR_RETURN(semaphore, GpuSemaphore::Create(executor));
+      *semaphore = GpuSemaphoreState::Hold;
+      // In principle the kernel could be loaded lazily and shared across
+      // multiple GpuTimer objects.
+      TF_ASSIGN_OR_RETURN(
+          auto kernel,
+          (TypedKernel<DeviceMemory<GpuSemaphoreState>,
+                       GpuSemaphoreState>::Create(executor, "DelayKernel",
+                                                  delay_kernel::kernel())));
+      // Launch a delay kernel into this stream, which will spin until
+      // GetElapsedDuration() is called, the timer is destroyed, or the timeout
+      // in the kernel is reached.
+      TF_RETURN_IF_ERROR(real_stream->ThenLaunch(
+          ThreadDim(1, 1, 1), BlockDim(1, 1, 1), kernel, semaphore.device(),
+          GpuSemaphoreState::Release));
+    }
+  }
+  // The start event goes after the delay kernel in the stream
+  TF_RETURN_IF_ERROR(GpuDriver::RecordEvent(parent->gpu_context(), start_event,
+                                            stream->gpu_stream()));
+  return absl::StatusOr<GpuTimer>{absl::in_place, parent, start_event,
+                                  stop_event,     stream, std::move(semaphore)};
+}
+
+/*static*/ absl::StatusOr<std::optional<GpuTimer>> GpuTimer::CreateIfNeeded(
+    Stream* stream, bool is_needed) {
+  if (is_needed) {
+    TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream));
+    return {std::make_optional(std::move(t))};
+  }
+  return std::nullopt;
 }
 
 /*static*/ void GpuTimer::ReturnRandomDurationsForTesting() {
@@ -97,6 +172,17 @@ GpuTimer::CreateIfNeeded(GpuStream* stream, bool is_needed) {
 
 GpuTimer::~GpuTimer() {
   GpuContext* context = parent_->gpu_context();
+  if (semaphore_ && !is_stopped_) {
+    // Signal the delay kernel that it can exit
+    *semaphore_ = GpuSemaphoreState::Release;
+    // Wait for the delay kernel to exit before destroying the value that it is
+    // watching.
+    absl::Status status =
+        GpuDriver::SynchronizeStream(context, stream_->gpu_stream());
+    if (!status.ok()) {
+      LOG(ERROR) << status;
+    }
+  }
   if (start_event_ != nullptr) {
     absl::Status status = GpuDriver::DestroyEvent(context, &start_event_);
     if (!status.ok()) {
@@ -117,6 +203,18 @@ absl::StatusOr<absl::Duration> GpuTimer::GetElapsedDuration() {
   }
   TF_RETURN_IF_ERROR(GpuDriver::RecordEvent(parent_->gpu_context(), stop_event_,
                                             stream_->gpu_stream()));
+  // If we launched the delay kernel then check if it already timed out.
+  if (semaphore_) {
+    if (*semaphore_ == GpuSemaphoreState::TimedOut) {
+      // The delay kernel did not achieve the intended result.
+      LOG(ERROR) << "Delay kernel timed out: measured time has sub-optimal "
+                    "accuracy. There may be a missing warmup execution, please "
+                    "investigate in Nsight Systems.";
+    } else {
+      // Signal that the kernel can exit
+      *semaphore_ = GpuSemaphoreState::Release;
+    }
+  }
   float elapsed_milliseconds = NAN;
   if (!GpuDriver::GetEventElapsedTime(parent_->gpu_context(),
                                       &elapsed_milliseconds, start_event_,

--- a/xla/stream_executor/gpu/gpu_timer.cc
+++ b/xla/stream_executor/gpu/gpu_timer.cc
@@ -108,7 +108,8 @@ DeviceMemory<GpuSemaphoreState> GpuTimer::GpuSemaphore::device() {
       ptr_->opaque(), sizeof(GpuSemaphoreState));
 }
 
-/*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(Stream* real_stream) {
+/*static*/ absl::StatusOr<GpuTimer> GpuTimer::Create(Stream* real_stream,
+                                                     bool use_delay_kernel) {
   StreamExecutor* executor = real_stream->parent();
   GpuStream* stream = AsGpuStream(real_stream);
   GpuExecutor* parent = stream->parent();
@@ -121,7 +122,11 @@ DeviceMemory<GpuSemaphoreState> GpuTimer::GpuSemaphore::device() {
                                           GpuDriver::EventFlags::kDefault));
   CHECK(start_event != nullptr && stop_event != nullptr);
   GpuSemaphore semaphore{};
-  if (ShouldLaunchDelayKernel()) {
+  if (!use_delay_kernel) {
+    LOG(WARNING)
+        << "Skipping the delay kernel, measurement accuracy will be reduced";
+  }
+  if (use_delay_kernel && ShouldLaunchDelayKernel()) {
     // Check the assumption that this device supports unified addressing,
     // otherwise skip the delay kernel
     TF_ASSIGN_OR_RETURN(int status, GpuDriver::GetDeviceAttribute(
@@ -158,9 +163,9 @@ DeviceMemory<GpuSemaphoreState> GpuTimer::GpuSemaphore::device() {
 }
 
 /*static*/ absl::StatusOr<std::optional<GpuTimer>> GpuTimer::CreateIfNeeded(
-    Stream* stream, bool is_needed) {
+    Stream* stream, bool use_delay_kernel, bool is_needed) {
   if (is_needed) {
-    TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream));
+    TF_ASSIGN_OR_RETURN(GpuTimer t, GpuTimer::Create(stream, use_delay_kernel));
     return {std::make_optional(std::move(t))};
   }
   return std::nullopt;

--- a/xla/stream_executor/gpu/gpu_timer.h
+++ b/xla/stream_executor/gpu/gpu_timer.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "xla/stream_executor/gpu/gpu_executor.h"
+#include "xla/stream_executor/gpu/gpu_timer_kernel.h"
 #include "xla/stream_executor/gpu/gpu_types.h"
 
 namespace xla {
@@ -36,9 +37,29 @@ namespace gpu {
 class GpuExecutor;
 class GpuStream;
 
-// Timer is started once it's created, and is stopped once read.
+// When a timer is created it launches a delay kernel into the given stream and
+// queues a start event immediately afterwards. This delay kernel blocks
+// execution on the stream until GetElapsedDuration() is called, at which point
+// an end event is queued and the delay kernel exits. This allows the device
+// execution time of the tasks queued to the stream while the timer is active
+// to be measured more accurately.
 class GpuTimer {
  public:
+  class GpuSemaphore {
+   public:
+    GpuSemaphore() = default;
+    static absl::StatusOr<GpuSemaphore> Create(StreamExecutor* executor);
+    explicit operator bool() const { return bool{ptr_}; }
+    GpuSemaphoreState& operator*() {
+      return *static_cast<GpuSemaphoreState*>(ptr_->opaque());
+    }
+    DeviceMemory<GpuSemaphoreState> device();
+
+   private:
+    explicit GpuSemaphore(std::unique_ptr<HostMemoryAllocation> alloc)
+        : ptr_{std::move(alloc)} {}
+    std::unique_ptr<HostMemoryAllocation> ptr_;
+  };
   static absl::StatusOr<GpuTimer> Create(Stream* stream);
   [[deprecated("Pass Stream* not GpuStream*")]] static absl::StatusOr<GpuTimer>
   Create(GpuStream* stream);
@@ -53,17 +74,20 @@ class GpuTimer {
   CreateIfNeeded(GpuStream* stream, bool is_needed);
 
   explicit GpuTimer(GpuExecutor* parent, GpuEventHandle start_event,
-                    GpuEventHandle stop_event, GpuStream* stream)
+                    GpuEventHandle stop_event, GpuStream* stream,
+                    GpuSemaphore semaphore = {})
       : parent_(parent),
         start_event_(start_event),
         stop_event_(stop_event),
-        stream_(stream) {}
+        stream_(stream),
+        semaphore_(std::move(semaphore)) {}
 
   GpuTimer(GpuTimer&& other)
       : parent_(other.parent_),
         start_event_(std::exchange(other.start_event_, nullptr)),
         stop_event_(std::exchange(other.stop_event_, nullptr)),
-        stream_(other.stream_) {}
+        stream_(other.stream_),
+        semaphore_(std::move(other.semaphore_)) {}
 
   GpuTimer& operator=(GpuTimer&& other) {
     if (this != &other) {
@@ -71,6 +95,7 @@ class GpuTimer {
       start_event_ = std::exchange(other.start_event_, nullptr);
       stop_event_ = std::exchange(other.stop_event_, nullptr);
       stream_ = other.stream_;
+      semaphore_ = std::move(other.semaphore_);
     }
     return *this;
   }
@@ -86,6 +111,7 @@ class GpuTimer {
   GpuEventHandle start_event_ = nullptr;
   GpuEventHandle stop_event_ = nullptr;
   GpuStream* stream_;
+  GpuSemaphore semaphore_;
   bool is_stopped_ = false;
 
   GpuTimer(const GpuTimer&) = delete;

--- a/xla/stream_executor/gpu/gpu_timer.h
+++ b/xla/stream_executor/gpu/gpu_timer.h
@@ -60,15 +60,15 @@ class GpuTimer {
         : ptr_{std::move(alloc)} {}
     std::unique_ptr<HostMemoryAllocation> ptr_;
   };
-  static absl::StatusOr<GpuTimer> Create(Stream* stream);
+  static absl::StatusOr<GpuTimer> Create(Stream* stream, bool use_delay_kernel);
   [[deprecated("Pass Stream* not GpuStream*")]] static absl::StatusOr<GpuTimer>
   Create(GpuStream* stream);
 
   // An ugly but a very convenient helper: creates a timer only when we need
   // one, but always returns an object. If `is_needed` is false, returns an
   // empty optional, acts like `Create` otherwise.
-  static absl::StatusOr<std::optional<GpuTimer>> CreateIfNeeded(Stream* stream,
-                                                                bool is_needed);
+  static absl::StatusOr<std::optional<GpuTimer>> CreateIfNeeded(
+      Stream* stream, bool use_delay_kernel, bool is_needed);
   [[deprecated("Pass Stream* not GpuStream*")]] static absl::StatusOr<
       std::optional<GpuTimer>>
   CreateIfNeeded(GpuStream* stream, bool is_needed);

--- a/xla/stream_executor/gpu/gpu_timer_kernel.cu.cc
+++ b/xla/stream_executor/gpu/gpu_timer_kernel.cu.cc
@@ -1,0 +1,52 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "xla/stream_executor/gpu/gpu_timer_kernel.h"
+
+#include <cstddef>
+
+namespace stream_executor::gpu {
+namespace {
+// Wait for the value pointed to by `semaphore` to have value `target`, timing
+// out after approximately `APPROX_TIMEOUT_SECONDS` seconds if that value is
+// not reached. This can happen if, for example, blocking launches are enabled
+// via CUDA_LAUNCH_BLOCKING=1. It can also happen if launching a kernel after
+// this delay kernel causes synchronisation, e.g. because of lazy loading.
+__global__ void DelayKernel(volatile GpuSemaphoreState* semaphore,
+                            GpuSemaphoreState target) {
+  constexpr int64_t WAIT_CYCLES{1024};
+  constexpr int64_t TIMEOUT_CYCLES{200000000};  // 100ms at 2GHz
+  const int64_t tstart{clock64()};
+  bool target_not_reached;
+  while ((target_not_reached = (*semaphore != target)) &&
+         (clock64() - tstart) < TIMEOUT_CYCLES) {
+    int64_t elapsed{};
+    const int64_t t0{clock64()};
+    do {
+      elapsed = clock64() - t0;
+    } while (elapsed < WAIT_CYCLES);
+  }
+  if (target_not_reached) {
+    // We are exiting due to the timeout. Signal this back to the host so that
+    // we can emit a warning, as it probably indicates suboptimal usage.
+    *semaphore = GpuSemaphoreState::TimedOut;
+  }
+}
+}  // namespace
+
+namespace delay_kernel {
+void* kernel() { return reinterpret_cast<void*>(DelayKernel); }
+}  // namespace delay_kernel
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/gpu/gpu_timer_kernel.h
+++ b/xla/stream_executor/gpu/gpu_timer_kernel.h
@@ -1,0 +1,26 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_GPU_GPU_TIMER_KERNEL_H_
+#define XLA_STREAM_EXECUTOR_GPU_GPU_TIMER_KERNEL_H_
+
+namespace stream_executor::gpu {
+enum struct GpuSemaphoreState { Hold, Release, TimedOut };
+namespace delay_kernel {
+void* kernel();  // returns a pointer to a CUDA C++ device function
+}  // namespace delay_kernel
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_GPU_GPU_TIMER_KERNEL_H_

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -390,8 +390,11 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
     DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
     blas::ProfileResult* profile_result) const {
-  TF_ASSIGN_OR_RETURN(std::optional<gpu::GpuTimer> timer,
-                      gpu::GpuTimer::CreateIfNeeded(stream, profile_result));
+  TF_ASSIGN_OR_RETURN(
+      std::optional<gpu::GpuTimer> timer,
+      gpu::GpuTimer::CreateIfNeeded(
+          stream, profile_result && profile_result->warmup_run_executed(),
+          profile_result));
 
   void* workspace = nullptr;
   if (algorithm.workspace_size > 0) {

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -530,7 +530,10 @@ absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
         static_cast<int>(type_a), static_cast<int>(type_b)));
   }
   TF_ASSIGN_OR_RETURN(
-      auto timer, GpuTimer::CreateIfNeeded(stream, profile_result != nullptr));
+      auto timer,
+      GpuTimer::CreateIfNeeded(
+          stream, profile_result && profile_result->warmup_run_executed(),
+          profile_result != nullptr));
 
   // fall back to the default implementation
   if (algorithm == blas::kDefaultAlgorithm && type_a == type_c) {
@@ -586,7 +589,10 @@ absl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
         static_cast<int>(type_a), static_cast<int>(type_b)));
   }
   TF_ASSIGN_OR_RETURN(
-      auto timer, GpuTimer::CreateIfNeeded(stream, profile_result != nullptr));
+      auto timer,
+      GpuTimer::CreateIfNeeded(
+          stream, profile_result && profile_result->warmup_run_executed(),
+          profile_result != nullptr));
 
   // fall back to the default implementation
   if (algorithm == blas::kDefaultAlgorithm && type_a == type_c) {

--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -2379,8 +2379,12 @@ absl::Status MIOpenSupport::DoRnnForwardImpl(
 
   const bool is_profiling = output_profile_result != nullptr;
 
-  TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
-                      GpuTimer::CreateIfNeeded(stream, is_profiling));
+  TF_ASSIGN_OR_RETURN(
+      std::optional<GpuTimer> timer,
+      GpuTimer::CreateIfNeeded(
+          stream,
+          output_profile_result && output_profile_result->warmup_run_executed(),
+          is_profiling));
 
   // make the forward call
   if (!is_training) {
@@ -2507,8 +2511,12 @@ absl::Status MIOpenSupport::DoRnnBackwardImpl(
 
   const bool is_profiling = output_profile_result != nullptr;
 
-  TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
-                      GpuTimer::CreateIfNeeded(stream, is_profiling));
+  TF_ASSIGN_OR_RETURN(
+      std::optional<GpuTimer> timer,
+      GpuTimer::CreateIfNeeded(
+          stream,
+          output_profile_result && output_profile_result->warmup_run_executed(),
+          is_profiling));
 
   // make the backward data call
   auto status = wrap::miopenRNNBackwardData(
@@ -3201,7 +3209,11 @@ class RocmConvRunner : public dnn::ConvRunner {
 
     const bool is_profiling = profile_result != nullptr;
     TF_ASSIGN_OR_RETURN(std::optional<GpuTimer> timer,
-                        GpuTimer::CreateIfNeeded(stream, is_profiling));
+                        GpuTimer::CreateIfNeeded(
+                            stream,
+                            output_profile_result &&
+                                output_profile_result->warmup_run_executed(),
+                            is_profiling));
 
     miopenStatus_t status = miopenStatusSuccess;
     switch (kind_) {

--- a/xla/xla_data.proto
+++ b/xla/xla_data.proto
@@ -470,6 +470,10 @@ message ExecutionProfile {
   // Whether this profile was drawn from a cache of profiles instead of from
   // execution on the hardware.
   bool profile_cache_hit = 7;
+
+  // Whether a warm-up run of the computation was executed before the
+  // measured execution.
+  bool warmup_run_executed = 8;
 }
 
 // Handle given to a user that represents an execution that the user launched


### PR DESCRIPTION
Originally imported from GitHub PR https://github.com/openxla/xla/pull/9757.

This ensures that all the device operations to be timed are queued to
the relevant stream before any of them are executed, resulting in a more
accurate measurement. This is skipped if CUDA_LAUNCH_BLOCKING=1 or
unified addressing is not available.

Only launch the delay kernel if it has been explicitly flagged that a
warm-up run, which might have triggered lazy kernel loading, has been
executed.

Reproducing information from https://github.com/openxla/xla/pull/9757 below:

Quoting my comment in the code:
```c++
// When a timer is created it launches a delay kernel into the given stream and
// queues a start event immediately afterwards. This delay kernel blocks
// execution on the stream until GetElapsedDuration() is called, at which point
// an end event is queued and the delay kernel exits. This allows the device
// execution time of the tasks queued to the stream while the timer is active
// to be measured more accurately.
```
this should improve the accuracy of the measurements that are used to make
auto-tuning decisions, especially for small kernels.

With the example HLO:
```
  parameter_0 = bf16[128,12,128]{2,1,0} parameter(0)
  parameter_1 = bf16[12,128,128]{2,1,0} parameter(1)
  ROOT dot.26 = bf16[12,128,128]{2,1,0} dot(parameter_0, parameter_1),
    lhs_batch_dims={1}, lhs_contracting_dims={0}, rhs_batch_dims={0},
    rhs_contracting_dims={2}
```
a cuBLAS kernel was selected with a CUPTI/NSys-measured runtime of
3.9µs and before this change, GpuTimer measured a runtime of 17.5µs.
With this change, GpuTimer measures a runtime of 8.1µs.

With the example HLO:
```
  p0 = bf16[128,1536]{0,1} parameter(0)
  p1 = s8[1536,12288]{0,1} parameter(1)
  c = bf16[1536,12288]{0,1} convert(p1)
  ROOT d = bf16[128,12288]{1,0} dot(p0, c), lhs_contracting_dims={1},
    rhs_contracting_dims={0}
```
five cuDNN plans were auto-tuned, with CUPTI/Nsys-measured runtimes of
{34.9, 18.5, 30.9, 32.4, 31.5}µs. Before this change, GpuTimer measured
runtimes of {76.6, 40.0, 52.5, 55.7, 51.8}µs. With this change, GpuTimer
measures runtimes of {39.6, 23.0, 35.4, 35.1, 35.1}µs.

In summary, with this change, GpuTimer gives results that are much
closer to the CUPTI/Nsys measurements, with a ~uniform offset of ~4µs. A
constant offset doesn't matter for auto-tuning.

There are a couple of edge cases that have special treatment:
- if `CUDA_LAUNCH_BLOCKING=1` then the delay kernel will not achieve anything,
  so we don't launch it
- if any code in the timed region synchronises the device then the host will
  wait for the delay kernel to time out before actually launching the kernels
  to be measured. This will lead to a poor quality measurement, and an error
  message is printed. This condition can be met if one of the kernels being
  measured is lazily loaded, as lazy loading can trigger synchronisation. Best
  practice is to execute a warmup run (without timing enabled) before the timed
  execution.

The `GpuTimer::Create*` signatures that were deprecated in https://github.com/openxla/xla/pull/9841 do not benefit
from these accuracy improvements.