### PR TITLE
[XLA:GPU] Update cuDNN flash attention backward to use new cuDNN frontend (>1.0)

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3096,6 +3096,33 @@ cc_library(
     ]),
 )
 
+cc_library(
+    name = "cudnn_workspace_rewriter",
+    srcs = if_cuda_is_configured(["cudnn_workspace_rewriter.cc"]),
+    hdrs = if_cuda_is_configured(["cudnn_workspace_rewriter.h"]),
+    deps = if_cuda_is_configured([
+        ":backend_configs_cc",
+        ":ir_emission_utils",
+        ":gpu_fused_mha_runner",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@local_config_cuda//cuda:cudnn_header",
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:hlo_pass",
+        "//xla/stream_executor:stream_executor_headers",
+        "//xla/stream_executor/cuda:cudnn_frontend_helpers",
+        "//xla/stream_executor/cuda:cudnn_plugin",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+        "@com_google_absl//absl/container:flat_hash_set",
+    ]),
+)
+
 tf_proto_library(
     name = "executable_proto",
     srcs = ["executable.proto"],
@@ -3824,6 +3851,7 @@ cc_library(
         ":cudnn_fused_conv_rewriter",
         ":cudnn_fused_mha_rewriter",
         ":cudnn_fused_mha_transpose_fusion",
+        ":cudnn_workspace_rewriter",
         ":cudnn_fusion_compiler",
         ":cudnn_norm_rewriter",
         ":cudnn_pad_for_convolutions",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3104,6 +3104,7 @@ cc_library(
         ":backend_configs_cc",
         ":ir_emission_utils",
         ":gpu_fused_mha_runner",
+        ":cublas_cudnn",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",

--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -1384,12 +1384,10 @@ int div_up(int a, int b) { return ((a + b - 1) / b) * b; }
 int get_fa_fwd_workspace() { return 32; }
 
 int get_fa_bwd_workspace(int b, int h, int s_q, int s_kv, int d) {
-  int workspace = 16;
+  int workspace = 32;
   // softmax sum in float
   workspace += div_up(b * h * s_q * 4, 16);
-  workspace += div_up(b * h * div_up(s_q, 128) * div_up(s_kv, 128), 16);
-  // dq_accum in float
-  workspace += div_up(b * h * s_q * d * 4, 16);
+  workspace += div_up(b * h * div_up(s_q, 128) * div_up(s_kv, 128) * 2, 16);
   return workspace;
 }
 

--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -1470,7 +1470,7 @@ absl::StatusOr<HloInstruction*> FuseFwdMultiHeadedAttentionBlock(
       output_shape,
       ShapeUtil::MakeShape(
           U8, {is_flash_attention
-                   ? 16
+                   ? 3194896
                    : 0})};  // reserved 2 int64 for dropout seed and offset
   if (is_training) {
     activation_output = bmm_2->mutable_operand(0);
@@ -1734,24 +1734,16 @@ absl::StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
 
   // Output order:
   // {dQ(bmm_1_grad_2), dK(bmm_1_grad_1), dV(bmm_2_grad_1),
-  // d_intermediate_tensor*, softmax_sum*, d_Q_accum*, scratch, dbias*}
+  // d_intermediate_tensor*, scratch, dbias*}
   std::vector<Shape> output_shapes = {
       bmm_1_grad_2->shape(), bmm_1_grad_1->shape(), bmm_2_grad_1->shape()};
   if (!fwd_config.is_flash_attention()) {
     output_shapes.push_back(lhs_bmm2_grad_gemm1->shape());
-  } else {
-    // softmax_sum, d_Q_accum
-    // add softmax sum here and change the data type
-    // softmax sum and d_Q_accum should both be fp32 datatype
-    output_shapes.push_back(
-        ShapeUtil::MakeShape(F32, fwd_act->shape().dimensions()));
-    output_shapes.push_back(
-        ShapeUtil::MakeShape(F32, bmm_1_grad_2->shape().dimensions()));
   }
   // Reserved placeholder for workspace
   output_shapes.push_back(ShapeUtil::MakeShape(
       U8, {is_flash_attention
-               ? 16
+               ? 3194896
                : 0}));  // reserved 2 int64 for dropout seed and offset
 
   if (dbias) {

--- a/xla/service/gpu/cudnn_fused_mha_rewriter.cc
+++ b/xla/service/gpu/cudnn_fused_mha_rewriter.cc
@@ -1212,7 +1212,7 @@ absl::StatusOr<bool> IsMHABlockSupported(
     bool is_training, bool is_causal_mask, bool& is_flash_attention,
     std::string& custom_call_name, const DebugOptions& debug_options,
     stream_executor::CudaComputeCapability cc,
-    stream_executor::dnn::VersionInfo cudnn_version, QKVLayout& qkv_layout) {
+    stream_executor::dnn::VersionInfo cudnn_version) {
   if (MHACallHasDropout(custom_call_name) &&
       !debug_options.xla_gpu_fused_attention_use_cudnn_rng()) {
     VLOG(3) << "Using CUDNN RNG for fused attention dropout is not enabled.\n";
@@ -1248,18 +1248,17 @@ absl::StatusOr<bool> IsMHABlockSupported(
 
   // get batch/num heads/sequence length/hidden dim from bmm1 and bmm2
   // also make sure they are the same between bmm1 and bmm2
-  TF_ASSIGN_OR_RETURN(std::optional<QKVLayout> qkv_layout_res,
+  TF_ASSIGN_OR_RETURN(std::optional<QKVLayout> qkv_layout,
                       GetQKVLayout(bmm_1, bmm_2, need_canonicalization));
-  if (!qkv_layout_res.has_value()) {
+  if (!qkv_layout.has_value()) {
     VLOG(2) << "bmm1 and bmm2 have different qkv layout.";
     return false;
   }
 
-  qkv_layout = qkv_layout_res.value();
   // check if matched attention block is supported by cuDNN flash attention.
   TF_ASSIGN_OR_RETURN(
       is_flash_attention,
-      IsFlashAttention(qkv_layout, is_training, cc, cudnn_version));
+      IsFlashAttention(qkv_layout.value(), is_training, cc, cudnn_version));
   if (is_flash_attention) {
     if (is_causal_mask) {
       // if bias is causal mask, needs to remove bias from name
@@ -1279,7 +1278,7 @@ absl::StatusOr<bool> IsMHABlockSupported(
   // check if matched attention block is supported by cuDNN fused attention.
   TF_ASSIGN_OR_RETURN(
       bool is_fused_attention,
-      IsFusedAttention(qkv_layout, is_training, cc, cudnn_version));
+      IsFusedAttention(qkv_layout.value(), is_training, cc, cudnn_version));
   return is_fused_attention;
 }
 
@@ -1379,26 +1378,13 @@ absl::StatusOr<HloInstruction*> ChangeCheckedDimToFastest(
   return operand_bmm;
 }
 
-int div_up(int a, int b) { return ((a + b - 1) / b) * b; }
-
-int get_fa_fwd_workspace() { return 32; }
-
-int get_fa_bwd_workspace(int b, int h, int s_q, int s_kv, int d) {
-  int workspace = 32;
-  // softmax sum in float
-  workspace += div_up(b * h * s_q * 4, 16);
-  workspace += div_up(b * h * div_up(s_q, 128) * div_up(s_kv, 128) * 2, 16);
-  return workspace;
-}
-
 absl::StatusOr<HloInstruction*> FuseFwdMultiHeadedAttentionBlock(
     HloComputation* comp, HloInstruction* bmm_1, HloInstruction* bmm_2,
     HloInstruction* bias, HloInstruction* mask, HloInstruction* scale,
     HloInstruction* reduce_sum, HloInstruction* softmax_input,
     double dropout_rate, std::string& custom_call_name,
     stream_executor::CudaComputeCapability cc, bool is_training, bool& changed,
-    bool& v_transposed, bool is_causal_mask, bool is_flash_attention,
-    QKVLayout& qkv_layout) {
+    bool& v_transposed, bool is_causal_mask, bool is_flash_attention) {
   double scale_value = 1.0;
   HloInstruction* lhs_bmm1;
   HloInstruction* rhs_bmm1;
@@ -1480,12 +1466,8 @@ absl::StatusOr<HloInstruction*> FuseFwdMultiHeadedAttentionBlock(
   // Activation output is used by backward gemm.
   HloInstruction* activation_output = nullptr;
 
-  std::vector<Shape> output_shapes = {
-      output_shape,
-      ShapeUtil::MakeShape(
-          U8, {is_flash_attention
-                   ? get_fa_fwd_workspace()
-                   : 0})};  // reserved 2 int64 for dropout seed and offset
+  std::vector<Shape> output_shapes = {output_shape,
+                                      ShapeUtil::MakeShape(U8, {0})};
   if (is_training) {
     activation_output = bmm_2->mutable_operand(0);
     // Sometimes activation output is bitcast, the actual activation is the
@@ -1599,7 +1581,7 @@ absl::StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
     HloInstruction* bmm_1_grad_2, HloInstruction* bmm_2_grad_1,
     HloInstruction* bmm_2_grad_2, HloInstruction* fwd_fmha_call,
     HloInstruction* dbias, HloInstruction* mask, HloInstruction* bias,
-    std::string& bwd_custom_call_name, QKVLayout& qkv_layout) {
+    std::string& bwd_custom_call_name) {
   HloInstruction* rhs_bmm1_grad_gemm1;
   HloInstruction* lhs_bmm1_grad_gemm2;
   HloInstruction* lhs_bmm2_grad_gemm1;
@@ -1756,12 +1738,7 @@ absl::StatusOr<bool> FuseBwdMultiHeadedAttentionBlock(
   }
 
   // Reserved placeholder for workspace
-  output_shapes.push_back(ShapeUtil::MakeShape(
-      U8, {is_flash_attention
-               ? get_fa_bwd_workspace(qkv_layout.batch, qkv_layout.num_heads,
-                                      qkv_layout.seqlen_q, qkv_layout.seqlen_kv,
-                                      qkv_layout.hidden_dim)
-               : 0}));
+  output_shapes.push_back(ShapeUtil::MakeShape(U8, {0}));
 
   if (dbias) {
     // Cudnn kernel only outputs dbias in this shape [1, num_heads, seq, seq],
@@ -1891,7 +1868,6 @@ absl::StatusOr<bool> CudnnFusedMHARewriter::Run(
       // We check the validity of bmms here before canonicalization so we don't
       // modify the graph if mha fusion is not possible
       // Relax 512 constraint if it is flash attention
-      QKVLayout qkv_layout;
       TF_ASSIGN_OR_RETURN(
           bool is_mha_module_supported,
           IsMHABlockSupported(
@@ -1899,7 +1875,7 @@ absl::StatusOr<bool> CudnnFusedMHARewriter::Run(
               matched_result.need_canonicalization, matched_result.is_training,
               matched_result.is_causal_mask, matched_result.is_flash_attention,
               matched_result.matched_custom_call_name, debug_options,
-              compute_capability_, cudnn_version, qkv_layout));
+              compute_capability_, cudnn_version));
 
       if (!is_mha_module_supported) continue;
       // If we have an activation with more than 1 users in non-training mode,
@@ -1948,8 +1924,8 @@ absl::StatusOr<bool> CudnnFusedMHARewriter::Run(
               matched_result.matched_dropout_rate,
               matched_result.matched_custom_call_name, compute_capability_,
               matched_result.is_training, changed, v_transposed,
-              matched_result.is_causal_mask, matched_result.is_flash_attention,
-              qkv_layout));
+              matched_result.is_causal_mask,
+              matched_result.is_flash_attention));
       any_changed |= changed;
       if (matched_result.is_training) {
         MatchBwdResult matched_bwd_result =
@@ -2031,7 +2007,7 @@ absl::StatusOr<bool> CudnnFusedMHARewriter::Run(
                 matched_bwd_result.matched_bmm_2_grad_2, fwd_fmha_call,
                 matched_bwd_result.matched_dbias, matched_result.matched_mask,
                 matched_result.matched_bias,
-                matched_bwd_result.matched_custom_call_name, qkv_layout));
+                matched_bwd_result.matched_custom_call_name));
         any_changed |= changed;
       }
     }

--- a/xla/service/gpu/cudnn_workspace_rewriter.cc
+++ b/xla/service/gpu/cudnn_workspace_rewriter.cc
@@ -124,7 +124,7 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
         se::gpu::GetCudnnFlashAttentionOperationGraph(
             dnn_support, fmha_config.lhs_bmm1, fmha_config.rhs_bmm1,
             fmha_config.rhs_bmm2, fmha_config.output, fmha_config.bias,
-            fmha_config.mask, fmha_config.mask,
+            fmha_config.mask, fmha_config.activation,
             static_cast<float>(*fmha_config.fmha_scale),
             fmha_config.dropout_rate && *fmha_config.dropout_rate > 0.0,
             fmha_config.dropout_rate, fmha_config.is_causal_mask));

--- a/xla/service/gpu/cudnn_workspace_rewriter.cc
+++ b/xla/service/gpu/cudnn_workspace_rewriter.cc
@@ -1,0 +1,288 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/cudnn_workspace_rewriter.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "third_party/gpus/cudnn/cudnn_version.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_clone_context.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/service/gpu/gpu_fused_mha_runner.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/stream_executor/cuda/cuda_dnn.h"
+#include "xla/stream_executor/cuda/cudnn_frontend_helpers.h"
+#include "xla/util.h"
+
+namespace xla {
+namespace gpu {
+
+namespace {
+
+namespace fe = cudnn_frontend;
+namespace graph = fe::graph;
+
+// create cuDNN graphs from HloCustomCall
+absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
+    se::dnn::DnnSupport& dnn_support,
+    const HloCustomCallInstruction* custom_call) {
+  if (IsFwdCustomCallTofMHA(*custom_call)) {
+    const HloInstruction* q = custom_call->operand(0);
+    const HloInstruction* k = custom_call->operand(1);
+    const HloInstruction* v = custom_call->operand(2);
+
+    bool has_activation =
+        xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
+    TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
+                        xla::gpu::GetCudnnfMHAKind(custom_call));
+    std::optional<Shape> mask_shape, bias_shape;
+    {
+      bool has_mask = kind == CudnnfMHAKind::kScaleMaskSoftmax ||
+                      kind == CudnnfMHAKind::kScaleMaskSoftmaxDropout ||
+                      kind == CudnnfMHAKind::kScaleBiasMaskSoftmax ||
+                      kind == CudnnfMHAKind::kScaleBiasMaskSoftmaxDropout;
+      bool has_bias = kind == CudnnfMHAKind::kScaleBiasMaskSoftmax ||
+                      kind == CudnnfMHAKind::kScaleBiasSoftmaxDropout ||
+                      kind == CudnnfMHAKind::kScaleBiasSoftmax ||
+                      kind == CudnnfMHAKind::kScaleBiasSoftmaxDropout;
+
+      if (has_mask) {
+        const HloInstruction* mask = custom_call->operand(3);
+        mask_shape = mask->shape();
+        if (has_bias) {
+          const HloInstruction* bias = custom_call->operand(4);
+          bias_shape = bias->shape();
+        }
+      } else if (has_bias) {
+        const HloInstruction* bias = custom_call->operand(3);
+        bias_shape = bias->shape();
+      }
+    }
+
+    TF_ASSIGN_OR_RETURN(
+        const auto gpu_config,
+        custom_call->backend_config<xla::gpu::GpuBackendConfig>());
+    const xla::gpu::CudnnfMHABackendConfig& config =
+        gpu_config.cudnn_fmha_backend_config();
+    Shape intermediate_tensor_shape(config.intermediate_tensor_shape());
+    absl::InlinedVector<Shape, 2> output_shapes = {
+        ShapeUtil::GetSubshape(custom_call->shape(), {0})};
+    if (has_activation) {
+      output_shapes.push_back(
+          ShapeUtil::GetSubshape(custom_call->shape(), {2}));
+    }
+
+    GpufMHADescriptor descriptor = {kind,
+                                    config,
+                                    config.is_flash_attention(),
+                                    config.is_causal_mask(),
+                                    q->shape(),
+                                    k->shape(),
+                                    v->shape(),
+                                    intermediate_tensor_shape,
+                                    output_shapes,
+                                    config.bmm1_dot_dimension_numbers(),
+                                    config.bmm2_dot_dimension_numbers(),
+                                    mask_shape,
+                                    bias_shape};
+
+    TF_ASSIGN_OR_RETURN(GpufMHAConfig fmha_config,
+                        GpufMHAConfig::For(descriptor));
+    TF_ASSIGN_OR_RETURN(
+        se::gpu::CudnnGraph graph,
+        se::gpu::GetCudnnFlashAttentionOperationGraph(
+            dnn_support, fmha_config.lhs_bmm1, fmha_config.rhs_bmm1,
+            fmha_config.rhs_bmm2, fmha_config.output, fmha_config.bias,
+            fmha_config.mask, fmha_config.mask,
+            static_cast<float>(*fmha_config.fmha_scale),
+            fmha_config.dropout_rate && *fmha_config.dropout_rate > 0.0,
+            fmha_config.dropout_rate, fmha_config.is_causal_mask));
+    return std::move(graph);
+  } else {
+    TF_ASSIGN_OR_RETURN(
+        const auto gpu_config,
+        custom_call->backend_config<xla::gpu::GpuBackendConfig>());
+    const xla::gpu::CudnnfMHABackendConfig& config =
+        gpu_config.cudnn_fmha_backend_config();
+    bool is_flash_attention = config.is_flash_attention();
+
+    int input_index = 0;
+    Shape bmm1_grad_gemm1_rhs_shape =
+        custom_call->operand(input_index++)->shape();
+    Shape bmm1_grad_gemm2_rhs_shape =
+        custom_call->operand(input_index++)->shape();
+    Shape bmm2_grad_gemm2_rhs_shape =
+        custom_call->operand(input_index++)->shape();
+    Shape bmm2_grad_gemm1_lhs_shape(config.intermediate_tensor_shape());
+    input_index++;
+    Shape d_output_shape = custom_call->operand(input_index++)->shape();
+
+    TF_ASSIGN_OR_RETURN(const CudnnfMHAKind kind,
+                        GetCudnnfMHAKind(custom_call));
+    bool has_mask = kind == CudnnfMHAKind::kBackwardScaleMaskSoftmax ||
+                    kind == CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax ||
+                    kind == CudnnfMHAKind::kBackwardScaleMaskSoftmaxDropout ||
+                    kind == CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout;
+    std::optional<Shape> mask_shape;
+    if (has_mask) {
+      mask_shape = custom_call->operand(input_index++)->shape();
+    }
+
+    bool has_bias =
+        (kind == CudnnfMHAKind::kBackwardScaleBiasSoftmax ||
+         kind == CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout ||
+         kind == CudnnfMHAKind::kBackwardScaleBiasMaskSoftmax ||
+         kind == CudnnfMHAKind::kBackwardScaleBiasMaskSoftmaxDropout);
+    std::optional<Shape> bias_shape;
+    if (has_bias) {
+      bias_shape = custom_call->operand(input_index++)->shape();
+    }
+
+    std::optional<Shape> fwd_output_shape =
+        custom_call->operand(input_index++)->shape();
+    TF_RET_CHECK(input_index == custom_call->operand_count());
+
+    int output_index = 0;
+    Shape d_bmm1_lhs_shape =
+        ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
+    Shape d_bmm1_rhs_shape =
+        ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
+    Shape d_bmm2_rhs_shape =
+        ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
+    output_index++;
+    std::optional<Shape> d_s_shape;
+    std::optional<Shape> d_bias_shape;
+    TF_RET_CHECK(output_index == custom_call->shape().tuple_shapes().size());
+
+    GpufMHABackwardDescriptor descriptor = {
+        kind,
+        config,
+        is_flash_attention,
+        config.is_causal_mask(),
+        bmm1_grad_gemm1_rhs_shape,
+        bmm1_grad_gemm2_rhs_shape,
+        bmm2_grad_gemm1_lhs_shape,
+        bmm2_grad_gemm2_rhs_shape,
+        d_output_shape,
+        d_bmm1_lhs_shape,
+        d_bmm1_rhs_shape,
+        d_bmm2_rhs_shape,
+        config.bmm1_grad_gemm1_dot_dimension_numbers(),
+        config.bmm1_grad_gemm2_dot_dimension_numbers(),
+        config.bmm2_grad_gemm1_dot_dimension_numbers(),
+        config.bmm2_grad_gemm2_dot_dimension_numbers(),
+        d_s_shape,
+        fwd_output_shape,
+        mask_shape,
+        d_bias_shape,
+        bias_shape};
+
+    TF_ASSIGN_OR_RETURN(GpufMHABackwardConfig fmha_config,
+                        GpufMHABackwardConfig::For(descriptor));
+    TF_ASSIGN_OR_RETURN(
+        se::gpu::CudnnGraph graph,
+        se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(
+            dnn_support, fmha_config.bmm1_grad_gemm1_rhs,
+            fmha_config.bmm1_grad_gemm2_rhs, fmha_config.bmm2_grad_gemm1_lhs,
+            fmha_config.bmm2_grad_gemm2_rhs, fmha_config.d_output,
+            fmha_config.d_bmm1_lhs, fmha_config.d_bmm1_rhs,
+            fmha_config.d_bmm2_rhs, fmha_config.bias, fmha_config.dropout_rate,
+            fmha_config.seed, *fmha_config.fmha_scale,
+            fmha_config.dropout_rate && *fmha_config.dropout_rate > 0.0,
+            fmha_config.mask != std::nullopt, fmha_config.bias != std::nullopt,
+            fmha_config.is_causal_mask));
+    return std::move(graph);
+  }
+}
+
+class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
+ public:
+  explicit CuDnnCustomCallVisitor(se::dnn::DnnSupport& dnn_support)
+      : dnn_support_(dnn_support) {}
+
+  absl::Status HandleCustomCall(HloInstruction* hlo) override {
+    if (!IsCustomCallTofMHA(*hlo)) {
+      // don't do anything about other cuDNN custom calls
+      return absl::OkStatus();
+    }
+    TF_ASSIGN_OR_RETURN(auto gpu_config,
+                        hlo->backend_config<GpuBackendConfig>());
+    const CudnnfMHABackendConfig& config =
+        gpu_config.cudnn_fmha_backend_config();
+    if (!config.is_flash_attention()) {
+      // only flash attention is supported in new cudnn frontend
+      return absl::OkStatus();
+    }
+
+    TF_ASSIGN_OR_RETURN(
+        se::gpu::CudnnGraph graph,
+        HloCustomCallToCuDnnGraph(dnn_support_,
+                                  DynCast<HloCustomCallInstruction>(hlo)));
+    auto workspace = graph.Graph().get_workspace_size();
+    if (workspace != 0) {
+      // rewrite custom call to have correct scratch spaces
+      VLOG(4) << "Rewriting: " << hlo->ToString();
+      Shape* shape = hlo->mutable_shape();
+      if (IsFwdCustomCallTofMHA(*hlo)) {
+        shape->mutable_tuple_shapes(1)->set_dimensions(0, workspace);
+      } else {
+        shape->mutable_tuple_shapes(3)->set_dimensions(0, workspace);
+      }
+    }
+    MarkAsChanged();
+    return absl::OkStatus();
+  }
+
+ private:
+  se::dnn::DnnSupport& dnn_support_;
+};
+
+}  // namespace
+
+absl::StatusOr<bool> CuDnnWorkspaceRewriter::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  XLA_SCOPED_LOGGING_TIMER("cuDNN workspace rewriter");
+  return CuDnnCustomCallVisitor(dnn_support_)
+      .RunOnModule(module, execution_threads);
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/cudnn_workspace_rewriter.cc
+++ b/xla/service/gpu/cudnn_workspace_rewriter.cc
@@ -57,10 +57,6 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     se::dnn::DnnSupport& dnn_support,
     const HloCustomCallInstruction* custom_call) {
   if (IsFwdCustomCallTofMHA(*custom_call)) {
-    Shape q_shape = custom_call->operand(0)->shape();
-    Shape k_shape = custom_call->operand(1)->shape();
-    Shape v_shape = custom_call->operand(2)->shape();
-
     TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
                         xla::gpu::GetCudnnfMHAKind(custom_call));
     std::optional<Shape> mask_shape, bias_shape;
@@ -102,6 +98,10 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
       output_shapes.push_back(
           ShapeUtil::GetSubshape(custom_call->shape(), {2}));
     }
+
+    Shape q_shape = custom_call->operand(0)->shape();
+    Shape k_shape = custom_call->operand(1)->shape();
+    Shape v_shape = custom_call->operand(2)->shape();
 
     GpufMHADescriptor descriptor = {kind,
                                     config,

--- a/xla/service/gpu/cudnn_workspace_rewriter.h
+++ b/xla/service/gpu/cudnn_workspace_rewriter.h
@@ -1,0 +1,54 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_CUDNN_WORKSPACE_REWRITER_H_
+#define XLA_SERVICE_GPU_CUDNN_WORKSPACE_REWRITER_H_
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/hlo_pass_interface.h"
+#include "xla/stream_executor/dnn.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla {
+namespace gpu {
+
+// Rewrite cuDNN custom call to have correct workspace size by build graph
+// and serialize so we can use it later
+class CuDnnWorkspaceRewriter : public HloModulePass {
+ public:
+  // <HLO computation fingerprint, serialized compiled cuDNN graph>.
+  using BinaryMap = absl::flat_hash_map<std::string, std::string>;
+
+  explicit CuDnnWorkspaceRewriter(se::StreamExecutor& stream_exec)
+      : dnn_support_(*stream_exec.AsDnn()) {}
+
+  absl::string_view name() const override { return "cudnn-workspace-rewriter"; }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  se::dnn::DnnSupport& dnn_support_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_CUDNN_WORKSPACE_REWRITER_H_

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -179,7 +179,6 @@ absl::Status RunFusedMHABackward(
     DeviceMemory<OutputType> d_bmm1_lhs_buffer,
     DeviceMemory<OutputType> d_bmm1_rhs_buffer,
     DeviceMemory<OutputType> d_bmm2_rhs_buffer, DeviceMemoryBase d_s_buffer,
-    DeviceMemoryBase softmax_buffer, DeviceMemoryBase d_Q_accum_buffer,
     DeviceMemoryBase mask_buffer, DeviceMemoryBase d_bias_buffer,
     DeviceMemoryBase fwd_output_buffer, DeviceMemoryBase bias_buffer,
     DeviceMemoryBase scratch_memory, DeviceMemoryBase seqlen_q,
@@ -235,8 +234,7 @@ absl::Status RunFusedMHABackward(
                    bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
                    bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
                    d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
-                   d_bmm2_rhs_buffer, d_s_buffer, softmax_buffer,
-                   d_Q_accum_buffer, mask_buffer, d_bias_buffer,
+                   d_bmm2_rhs_buffer, d_s_buffer, mask_buffer, d_bias_buffer,
                    fwd_output_buffer, bias_buffer, seqlen_q, seqlen_k);
   return absl::OkStatus();
 }
@@ -266,15 +264,6 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   auto d_s_buffer = params.d_s_buffer.has_value()
                         ? se::DeviceMemory<OutputType>(*params.d_s_buffer)
                         : se::DeviceMemoryBase();
-  auto softmax_sum_buffer =
-      params.softmax_sum_buffer.has_value()
-          ? se::DeviceMemory<float>(*params.softmax_sum_buffer)
-          : se::DeviceMemoryBase();
-
-  auto d_Q_accum_buffer =
-      params.d_Q_accum_buffer.has_value()
-          ? se::DeviceMemory<float>(*params.d_Q_accum_buffer)
-          : se::DeviceMemoryBase();
 
   auto mask_buffer = params.mask_buffer.has_value()
                          ? se::DeviceMemory<ElementType>(*params.mask_buffer)
@@ -323,8 +312,8 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
           params, stream, options, bmm1_grad_gemm1_rhs_buffer,
           bmm1_grad_gemm2_rhs_buffer, bmm2_grad_gemm1_lhs_buffer,
           bmm2_grad_gemm2_rhs_buffer, d_output_buffer, d_bmm1_lhs_buffer,
-          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_s_buffer, softmax_sum_buffer,
-          d_Q_accum_buffer, mask_buffer, d_bias_buffer, fwd_output_buffer,
+          d_bmm1_rhs_buffer, d_bmm2_rhs_buffer, d_s_buffer,
+          mask_buffer, d_bias_buffer, fwd_output_buffer,
           bias_buffer, scratch_memory, seqlen_q_buffer, seqlen_k_buffer);
       break;
     default:
@@ -617,8 +606,6 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
     se::DeviceMemoryBase d_bmm1_rhs_buffer,
     se::DeviceMemoryBase d_bmm2_rhs_buffer,
     std::optional<se::DeviceMemoryBase> d_s_buffer,
-    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
-    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
     std::optional<se::DeviceMemoryBase> mask_buffer,
     std::optional<se::DeviceMemoryBase> d_bias_buffer,
     std::optional<se::DeviceMemoryBase> fwd_output_buffer,
@@ -636,8 +623,6 @@ absl::Status RunGpuFMHABackwardImpl(const GpufMHABackwardParams &params,
   params.d_bmm1_rhs_buffer = d_bmm1_rhs_buffer;
   params.d_bmm2_rhs_buffer = d_bmm2_rhs_buffer;
   params.d_s_buffer = d_s_buffer;
-  params.softmax_sum_buffer = softmax_sum_buffer;
-  params.d_Q_accum_buffer = d_Q_accum_buffer;
   params.mask_buffer = mask_buffer;
   params.d_bias_buffer = d_bias_buffer;
   params.fwd_output_buffer = fwd_output_buffer;
@@ -691,8 +676,6 @@ absl::Status RunGpuFMHABackward(
     se::DeviceMemoryBase d_bmm1_rhs_buffer,
     se::DeviceMemoryBase d_bmm2_rhs_buffer,
     std::optional<se::DeviceMemoryBase> d_s_buffer,
-    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
-    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
     std::optional<se::DeviceMemoryBase> mask_buffer,
     std::optional<se::DeviceMemoryBase> d_bias_buffer,
     std::optional<se::DeviceMemoryBase> fwd_output_buffer,
@@ -706,7 +689,7 @@ absl::Status RunGpuFMHABackward(
           fmha_config, bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
           bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer,
           d_output_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer,
-          d_bmm2_rhs_buffer, d_s_buffer, softmax_sum_buffer, d_Q_accum_buffer,
+          d_bmm2_rhs_buffer, d_s_buffer,
           mask_buffer, d_bias_buffer, fwd_output_buffer, bias_buffer,
           seqlen_q_buffer, seqlen_k_buffer));
   PrimitiveType input_primitive_type = fmha_config.input_type;

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -182,8 +182,6 @@ struct GpufMHABackwardParams {
       se::DeviceMemoryBase d_bmm1_rhs_buffer,
       se::DeviceMemoryBase d_bmm2_rhs_buffer,
       std::optional<se::DeviceMemoryBase> d_s_buffer,
-      std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
-      std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
       std::optional<se::DeviceMemoryBase> mask_buffer,
       std::optional<se::DeviceMemoryBase> d_bias_buffer,
       std::optional<se::DeviceMemoryBase> fwd_output_buffer,
@@ -201,8 +199,6 @@ struct GpufMHABackwardParams {
   se::DeviceMemoryBase d_bmm1_rhs_buffer;
   se::DeviceMemoryBase d_bmm2_rhs_buffer;
   std::optional<se::DeviceMemoryBase> d_s_buffer;
-  std::optional<se::DeviceMemoryBase> softmax_sum_buffer;
-  std::optional<se::DeviceMemoryBase> d_Q_accum_buffer;
   std::optional<se::DeviceMemoryBase> mask_buffer;
   std::optional<se::DeviceMemoryBase> d_bias_buffer;
   std::optional<se::DeviceMemoryBase> fwd_output_buffer;
@@ -412,8 +408,6 @@ absl::Status RunGpuFMHABackward(
     se::DeviceMemoryBase d_bmm1_rhs_buffer,
     se::DeviceMemoryBase d_bmm2_rhs_buffer,
     std::optional<se::DeviceMemoryBase> d_s_buffer,
-    std::optional<se::DeviceMemoryBase> softmax_sum_buffer,
-    std::optional<se::DeviceMemoryBase> d_Q_accum_buffer,
     std::optional<se::DeviceMemoryBase> mask_buffer,
     std::optional<se::DeviceMemoryBase> d_bias_buffer,
     std::optional<se::DeviceMemoryBase> fwd_output_buffer,

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1136,17 +1136,12 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
   Shape d_bmm2_rhs_shape =
       ShapeUtil::GetSubshape(instr->shape(), {output_index++});
 
-  BufferAllocation::Slice d_s_slice, softmax_sum_slice, d_Q_accum_slice;
+  BufferAllocation::Slice d_s_slice;
   std::optional<Shape> d_s_shape;
   if (!is_flash_attention) {
     TF_ASSIGN_OR_RETURN(d_s_slice,
                         GetAllocationSliceForHlo(instr, {output_index}));
     d_s_shape = ShapeUtil::GetSubshape(instr->shape(), {output_index++});
-  } else {
-    TF_ASSIGN_OR_RETURN(softmax_sum_slice,
-                        GetAllocationSliceForHlo(instr, {output_index++}));
-    TF_ASSIGN_OR_RETURN(d_Q_accum_slice,
-                        GetAllocationSliceForHlo(instr, {output_index++}));
   }
 
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice scratch_slice,
@@ -1161,7 +1156,6 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
                         GetAllocationSliceForHlo(instr, {output_index}));
     d_bias_shape = ShapeUtil::GetSubshape(instr->shape(), {output_index++});
   }
-
   TF_RET_CHECK(output_index == instr->shape().tuple_shapes().size());
 
   GpufMHABackwardDescriptor descriptor = {
@@ -1196,7 +1190,7 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
       bmm1_grad_gemm2_rhs_slice, bmm2_grad_gemm1_lhs_slice,
       bmm2_grad_gemm2_rhs_slice, d_output_slice, scratch_slice,
       d_bmm1_lhs_slice, d_bmm1_rhs_slice, d_bmm2_rhs_slice, d_s_slice,
-      softmax_sum_slice, d_Q_accum_slice, mask_slice, d_bias_slice,
+      mask_slice, d_bias_slice,
       fwd_output_slice, bias_slice, seqlen_q_slice, seqlen_k_slice));
 
   return absl::OkStatus();

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -39,13 +39,6 @@ limitations under the License.
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
-#include "tsl/platform/env.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/path.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/statusor.h"
-#include "tsl/platform/threadpool.h"
-#include "tsl/profiler/lib/traceme.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/algebraic_simplifier.h"
@@ -112,6 +105,13 @@ limitations under the License.
 #include "xla/tsl/util/env_var.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
+#include "tsl/platform/env.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/path.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/threadpool.h"
+#include "tsl/profiler/lib/traceme.h"
 
 namespace xla {
 namespace gpu {

--- a/xla/service/gpu/runtime/fused_mha_thunk.cc
+++ b/xla/service/gpu/runtime/fused_mha_thunk.cc
@@ -110,7 +110,6 @@ FusedMHABackwardThunk::FusedMHABackwardThunk(
     BufferAllocation::Slice d_output, BufferAllocation::Slice scratch,
     BufferAllocation::Slice d_bmm1_lhs, BufferAllocation::Slice d_bmm1_rhs,
     BufferAllocation::Slice d_bmm2_rhs, BufferAllocation::Slice d_s,
-    BufferAllocation::Slice softmax_sum, BufferAllocation::Slice d_Q_accum,
     BufferAllocation::Slice mask, BufferAllocation::Slice d_bias,
     BufferAllocation::Slice fwd_output, BufferAllocation::Slice bias,
     BufferAllocation::Slice seqlen_q, BufferAllocation::Slice seqlen_k)
@@ -125,8 +124,6 @@ FusedMHABackwardThunk::FusedMHABackwardThunk(
       d_bmm1_rhs_buffer_(d_bmm1_rhs),
       d_bmm2_rhs_buffer_(d_bmm2_rhs),
       d_s_buffer_(d_s),
-      softmax_sum_buffer_(softmax_sum),
-      d_Q_accum_buffer_(d_Q_accum),
       mask_buffer_(mask),
       d_bias_buffer_(d_bias),
       fwd_output_buffer_(fwd_output),
@@ -182,10 +179,6 @@ absl::Status FusedMHABackwardThunk::ExecuteOnStream(
 
   std::optional<se::DeviceMemoryBase> d_s_buffer =
       AssignBufferIfNotNull(buffer_allocations, d_s_buffer_);
-  std::optional<se::DeviceMemoryBase> softmax_sum_buffer =
-      AssignBufferIfNotNull(buffer_allocations, softmax_sum_buffer_);
-  std::optional<se::DeviceMemoryBase> d_Q_accum_buffer =
-      AssignBufferIfNotNull(buffer_allocations, d_Q_accum_buffer_);
   std::optional<se::DeviceMemoryBase> mask_buffer =
       AssignBufferIfNotNull(buffer_allocations, mask_buffer_);
   std::optional<se::DeviceMemoryBase> d_bias_buffer =
@@ -206,7 +199,7 @@ absl::Status FusedMHABackwardThunk::ExecuteOnStream(
       config_, bmm1_grad_gemm1_rhs_buffer, bmm1_grad_gemm2_rhs_buffer,
       bmm2_grad_gemm1_lhs_buffer, bmm2_grad_gemm2_rhs_buffer, d_output_buffer,
       scratch_buffer, d_bmm1_lhs_buffer, d_bmm1_rhs_buffer, d_bmm2_rhs_buffer,
-      d_s_buffer, softmax_sum_buffer, d_Q_accum_buffer, mask_buffer,
+      d_s_buffer, mask_buffer,
       d_bias_buffer, fwd_output_buffer, bias_buffer, seqlen_q_buffer,
       seqlen_k_buffer, params.stream, opts));
   if (!params.stream->ok()) {

--- a/xla/service/gpu/runtime/fused_mha_thunk.h
+++ b/xla/service/gpu/runtime/fused_mha_thunk.h
@@ -92,8 +92,6 @@ class FusedMHABackwardThunk : public Thunk {
                         BufferAllocation::Slice d_bmm1_rhs_slice,
                         BufferAllocation::Slice d_bmm2_rhs_slice,
                         BufferAllocation::Slice d_s_slice,
-                        BufferAllocation::Slice softmax_sum_slice,
-                        BufferAllocation::Slice d_Q_accum_slice,
                         BufferAllocation::Slice mask_slice,
                         BufferAllocation::Slice d_bias_slice,
                         BufferAllocation::Slice fwd_output_slice,
@@ -117,8 +115,6 @@ class FusedMHABackwardThunk : public Thunk {
   BufferAllocation::Slice d_bmm1_rhs_buffer_;
   BufferAllocation::Slice d_bmm2_rhs_buffer_;
   BufferAllocation::Slice d_s_buffer_;
-  BufferAllocation::Slice softmax_sum_buffer_;
-  BufferAllocation::Slice d_Q_accum_buffer_;
   BufferAllocation::Slice mask_buffer_;
   BufferAllocation::Slice d_bias_buffer_;
   BufferAllocation::Slice fwd_output_buffer_;

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6231,147 +6231,6 @@ GetCudnnFusedMHABackwardOperationGraph(
   return std::make_unique<cudnn_frontend::OperationGraph>(std::move(op_graph));
 }
 
-// Returns a cudnn tensor that's the output of the bias addition op
-absl::StatusOr<cudnn_frontend::Tensor> CreateCudnnFlashAttentionBiasFwdTensor(
-    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
-    absl::Span<const int64_t> strides, dnn::DataType dtype,
-    cudnn_frontend::Tensor& input_tensor) {
-  // Create the bias tensor.
-  TF_ASSIGN_OR_RETURN(
-      auto bias_tensor,
-      CreateCudnnTensor(dims, strides, CudnnfMHAUid::BIAS_ID, dtype, 1, -1));
-
-  // Create the bias output tensor
-  TF_ASSIGN_OR_RETURN(
-      auto bias_out_tensor,
-      CreateCudnnTensor(dims, strides, CudnnfMHAUid::VIRTUAL_ID + 300,
-                        dnn::DataType::kFloat, 1, -1, /*is_virtual=*/true));
-
-  // Define the bias descriptor
-  auto bias_desc = cudnn_frontend::PointWiseDescBuilder()
-                       .setMode(CUDNN_POINTWISE_ADD)
-                       .setComputeType(CUDNN_DATA_FLOAT)
-                       .build();
-  // Create the bias op.
-  auto bias_op = cudnn_frontend::OperationBuilder(
-                     CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                     .setxDesc(input_tensor)
-                     .setbDesc(bias_tensor)
-                     .setyDesc(bias_out_tensor)
-                     .setpwDesc(bias_desc)
-                     .build();
-
-  RETURN_MSG_IF_CUDNN_ERROR(bias_op);
-  // Add bias to op list
-  ops.push_back(std::move(bias_op));
-
-  return bias_out_tensor;
-}
-
-absl::StatusOr<cudnn_frontend::Tensor>
-CreateCudnnFlashAttentionCausalMaskTensor(
-    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
-    absl::Span<const int64_t> strides, dnn::DataType dtype,
-    cudnn_frontend::Tensor& input_tensor) {
-  std::vector<int64_t> mask_dim(dims.size(), 1);
-  std::vector<int64_t> mask_stride(strides.size(), 1);
-
-  // Create the masked out value tensor.
-  TF_ASSIGN_OR_RETURN(
-      auto masked_val_tensor,
-      CreateCudnnTensor(
-          mask_dim, mask_stride, CudnnfMHAUid::NEG_INFINITY_ID,
-          dnn::DataType::kFloat, 1, -1,
-          /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
-          /*is_value*/ true));
-
-  // Create the row index tensor
-  TF_ASSIGN_OR_RETURN(
-      auto row_index_tensor,
-      CreateCudnnTensor(dims, strides, CudnnfMHAUid::VIRTUAL_ID + 401,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual=*/true));
-
-  // Create the column index tensor
-  TF_ASSIGN_OR_RETURN(
-      auto column_index_tensor,
-      CreateCudnnTensor(dims, strides, CudnnfMHAUid::VIRTUAL_ID + 402,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual=*/true));
-
-  // Create the causal mask tensor
-  auto causal_mask_tensor = cudnn_frontend::TensorBuilder()
-                                .setDim(dims.size(), dims.data())
-                                .setStride(strides.size(), strides.data())
-                                .setId(CudnnfMHAUid::VIRTUAL_ID + 403)
-                                .setAlignment(16)
-                                .setDataType(CUDNN_DATA_BOOLEAN)
-                                .setVectorCountAndDimension(1, -1)
-                                .setVirtual(true)
-                                .setReorderType(CUDNN_TENSOR_REORDERING_NONE)
-                                .setByValue(false)
-                                .build();
-
-  // Create the mask output tensor
-  TF_ASSIGN_OR_RETURN(
-      auto mask_out_tensor,
-      CreateCudnnTensor(dims, strides, CudnnfMHAUid::VIRTUAL_ID + 400,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual=*/true));
-
-  auto gen_index_row_desc = cudnn_frontend::PointWiseDescBuilder()
-                                .setMode(CUDNN_POINTWISE_GEN_INDEX)
-                                .setAxis(2)
-                                .setComputeType(CUDNN_DATA_FLOAT)
-                                .build();
-  RETURN_MSG_IF_CUDNN_ERROR(gen_index_row_desc);
-
-  TF_ASSIGN_OR_RETURN(
-      auto gen_index_row_op,
-      CreateUnaryPwOp(input_tensor, row_index_tensor, gen_index_row_desc));
-
-  auto gen_index_column_desc = cudnn_frontend::PointWiseDescBuilder()
-                                   .setMode(CUDNN_POINTWISE_GEN_INDEX)
-                                   .setAxis(3)
-                                   .setComputeType(CUDNN_DATA_FLOAT)
-                                   .build();
-  RETURN_MSG_IF_CUDNN_ERROR(gen_index_column_desc);
-
-  TF_ASSIGN_OR_RETURN(auto gen_index_column_op,
-                      CreateUnaryPwOp(input_tensor, column_index_tensor,
-                                      gen_index_column_desc));
-
-  auto row_greater_than_column_desc = cudnn_frontend::PointWiseDescBuilder()
-                                          .setMode(CUDNN_POINTWISE_CMP_GE)
-                                          .setComputeType(CUDNN_DATA_BOOLEAN)
-                                          .build();
-  RETURN_MSG_IF_CUDNN_ERROR(row_greater_than_column_desc);
-
-  TF_ASSIGN_OR_RETURN(
-      auto row_greater_than_column_op,
-      CreateBinaryPwOp(row_index_tensor, column_index_tensor,
-                       causal_mask_tensor, row_greater_than_column_desc));
-
-  TF_ASSIGN_OR_RETURN(
-      auto mask_desc,
-      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_BINARY_SELECT));
-
-  // Create the mask op.
-  TF_ASSIGN_OR_RETURN(
-      auto mask_op,
-      CreateTernaryPwOp(input_tensor, masked_val_tensor, causal_mask_tensor,
-                        mask_out_tensor, mask_desc));
-
-  // Add mask to op list
-  ops.push_back(std::move(gen_index_row_op));
-  ops.push_back(std::move(gen_index_column_op));
-  ops.push_back(std::move(row_greater_than_column_op));
-  ops.push_back(std::move(mask_op));
-
-  return mask_out_tensor;
-}
-
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     dnn::DnnSupport& dnn_support,
     const dnn::MatmulTensorDescriptor& q_descriptor,
@@ -6494,11 +6353,11 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
   }
 
   CudnnGraph cudnnGraph(std::move(graph));
-  TF_ASSIGN_OR_RETURN(bool supported, cudnnGraph.Prepare(dnn_support));
+  TF_ASSIGN_OR_RETURN(bool supported, cudnnGraph.Prepare());
   if (!supported) {
     return absl::InternalError("cuDNN graph is not supported.");
   }
-  TF_RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/0));
+  TF_RETURN_IF_ERROR(cudnnGraph.Build(/*plan_id=*/0));
 
   if (VLOG_IS_ON(4)) {
     VLOG(4) << "\b flash attention operation graph: " << graph;
@@ -6506,407 +6365,79 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
   return cudnnGraph;
 }
 
-absl::StatusOr<cudnn_frontend::Tensor>
-CreateCudnnFlashAttentionDropoutBwdTensor(
-    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
-    absl::Span<const int64_t> strides, dnn::DataType dtype,
-    cudnn_frontend::Tensor& input_tensor, cudnn_frontend::Tensor& mask_tensor,
-    double dropout_rate) {
-  // Create scale tensor
-  std::vector<int64_t> scale_dims(dims.size(), 1);
-  std::vector<int64_t> scale_strides(strides.size(), 1);
-
-  // Create output tensor of dropout node
-  // it is different from regular attention, the dropout output is always
-  // virtual we compute mask in the bwd instead of storing the mask
-
-  TF_ASSIGN_OR_RETURN(
-      auto dropout_out_tensor,
-      CreateCudnnTensor(
-          dims, strides, CudnnfMHAUid::VIRTUAL_ID + 601, dtype, 1, -1,
-          /*is_virtual*/ true,
-          /*cudnn_tensor_order_type*/
-          cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16));
-
-  // flash attention TODO: set byValue to true if host pointer is supported
-  // Create offset tensor of dropout node
-  TF_ASSIGN_OR_RETURN(
-      auto dropout_offset_tensor,
-      CreateCudnnTensor(
-          scale_dims, scale_strides, CudnnfMHAUid::D_OFFSET_ID,
-          dnn::DataType::kInt64, 1, -1, /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/
-          cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_NONE,
-          /*is_value*/ CUDNN_VERSION < 8903 ? false : true));
-
-  // Create seed tensor of dropout node
-  TF_ASSIGN_OR_RETURN(
-      auto dropout_seed_tensor,
-      CreateCudnnTensor(
-          scale_dims, scale_strides, CudnnfMHAUid::D_SEED_ID,
-          dnn::DataType::kInt64, 1, -1, /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/
-          cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_NONE,
-          /*is_value*/ CUDNN_VERSION < 8903 ? false : true));
-
-  // Create description for rng node
-  auto rng_desc = cudnn_frontend::RngDescBuilder()
-                      .setRngDistribution(CUDNN_RNG_DISTRIBUTION_BERNOULLI)
-                      .setBernoulliDistProbability(1.0 - dropout_rate)
-                      .build();
-
-  // Create the rng Node.
-  auto rng_op =
-      cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
-          .setyDesc(mask_tensor)
-          .setSeedDesc(dropout_seed_tensor)
-          .setOffsetDesc(dropout_offset_tensor)
-          .setRngDesc(rng_desc)
-          .build();
-  RETURN_MSG_IF_CUDNN_ERROR(rng_op);
-
-  // Create the masking node desc after mask tensor
-  TF_ASSIGN_OR_RETURN(auto masking_desc,
-                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
-
-  // Create the scaling op
-  TF_ASSIGN_OR_RETURN(auto masking_op,
-                      CreateBinaryPwOp(input_tensor, mask_tensor,
-                                       dropout_out_tensor, masking_desc));
-
-  TF_ASSIGN_OR_RETURN(
-      auto dropout_scale_tensor,
-      CreateCudnnTensor(
-          scale_dims, scale_strides, CudnnfMHAUid::DROPOUT_SCALE_ID,
-          dnn::DataType::kFloat, 1, -1,
-          /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
-          /*is_value*/ true));
-
-  // Create output of scale node
-  TF_ASSIGN_OR_RETURN(
-      auto dropout_scale_out_tensor,
-      CreateCudnnTensor(dims, strides, CudnnfMHAUid::VIRTUAL_ID + 602, dtype, 1,
-                        -1, /*is_virtual*/ true));
-  // Create the scaling desc
-  TF_ASSIGN_OR_RETURN(auto scale_desc,
-                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
-
-  // Create the scaling op
-  TF_ASSIGN_OR_RETURN(auto scale_op,
-                      CreateBinaryPwOp(dropout_out_tensor, dropout_scale_tensor,
-                                       dropout_scale_out_tensor, scale_desc));
-  // Add rng op to op list
-  ops.push_back(std::move(rng_op));
-  // Add masking op to op list
-  ops.push_back(std::move(masking_op));
-  // Add scaling op to op list
-  ops.push_back(std::move(scale_op));
-
-  return dropout_scale_out_tensor;
-}
-
-absl::StatusOr<std::unique_ptr<cudnn_frontend::OperationGraph>>
-GetCudnnFlashAttentionBackwardOperationGraph(
-    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm1_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm1_grad_gemm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm1_lhs_descriptor,
-    const dnn::MatmulTensorDescriptor& bmm2_grad_gemm2_rhs_descriptor,
-    const dnn::MatmulTensorDescriptor& d_output_descriptor,
-    const dnn::TensorDescriptor& d_bmm1_lhs_descriptor,
-    const dnn::TensorDescriptor& d_bmm1_rhs_descriptor,
-    const dnn::TensorDescriptor& d_bmm2_rhs_descriptor, dnn::FusedMHAKind kind,
+absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
+    const dnn::MatmulTensorDescriptor& q_desc,
+    const dnn::MatmulTensorDescriptor& k_desc,
+    const dnn::MatmulTensorDescriptor& p_desc,
+    const dnn::MatmulTensorDescriptor& v_desc,
+    const dnn::MatmulTensorDescriptor& do_desc,
+    const dnn::TensorDescriptor& dq_desc, const dnn::TensorDescriptor& dk_desc,
+    const dnn::TensorDescriptor& dv_desc, dnn::FusedMHAKind kind,
     std::optional<double> dropout_rate, std::optional<int64_t> seed,
     CudnnHandle& cudnn, double scale, std::vector<int64_t>& intermediate_shape,
     bool use_dropout = false, bool use_mask = false, bool use_bias = false,
     bool use_causal_mask = false) {
   if (VLOG_IS_ON(4)) {
-    VLOG(4) << "\n bmm1_grad_gemm1_rhs(q): "
-            << bmm1_grad_gemm1_rhs_descriptor.ToString()
-            << "\n bmm1_grad_gemm2_rhs(k): "
-            << bmm1_grad_gemm2_rhs_descriptor.ToString()
-            << "\n bmm2_grad_gemm1_lhs(p): "
-            << bmm2_grad_gemm1_lhs_descriptor.ToString()
-            << "\n bmm2_grad_gemm2_rhs(v^t): "
-            << bmm2_grad_gemm2_rhs_descriptor.ToString()
-            << "\n d_output(do): " << d_output_descriptor.ToString()
-            << "\n d_bmm1_lhs(dq): " << d_bmm1_lhs_descriptor.ToString()
-            << "\n d_bmm1_rhs(dk): " << d_bmm1_rhs_descriptor.ToString()
-            << "\n d_bmm2_rhs(dv): " << d_bmm2_rhs_descriptor.ToString();
+    VLOG(4) << "\n bmm1_grad_gemm1_rhs(q): " << q_desc.ToString()
+            << "\n bmm1_grad_gemm2_rhs(k): " << k_desc.ToString()
+            << "\n bmm2_grad_gemm1_lhs(p): " << p_desc.ToString()
+            << "\n bmm2_grad_gemm2_rhs(v^t): " << v_desc.ToString()
+            << "\n d_output(do): " << do_desc.ToString()
+            << "\n d_bmm1_lhs(dq): " << dq_desc.ToString()
+            << "\n d_bmm1_rhs(dk): " << dk_desc.ToString()
+            << "\n d_bmm2_rhs(dv): " << dv_desc.ToString();
   }
-  // cnn_infer needs to be preloaded for fMHA as well. Reusing the function
-  // created for convolution for fMHA.
-  PreloadCudnnSubLibsHelper(dnn::ConvolutionKind::FORWARD);
-
-  std::vector<cudnn_frontend::Operation const*> ops;
-  std::vector<cudnn_frontend::Operation> intermediate_ops;
-
-  // fp16 or bf16 is required
-  auto dtype = bmm1_grad_gemm1_rhs_descriptor.type();
-  // create input tensor Q
-  std::vector<int64_t> q_dims =
-      bmm1_grad_gemm1_rhs_descriptor.GetCudnnCompatibleDimensions(false);
-  std::vector<int64_t> q_strides =
-      bmm1_grad_gemm1_rhs_descriptor.GetCudnnCompatibleStrides(false);
-
-  // used for create scale tensor or zero tensor
-  std::vector<int64_t> scale_dims(q_dims.size(), 1);
-  std::vector<int64_t> scale_strides(q_strides.size(), 1);
-
-  VLOG(2) << "\n cuDNN compatible bmm1_grad_gemm1_rhs_dims: "
-          << absl::StrJoin(q_dims, ",")
-          << "\n cuDNN compatible bmm1_grad_gemm1_rhs_strides: "
-          << absl::StrJoin(q_strides, ",");
-
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_q,
-      CreateCudnnTensor(q_dims, q_strides, CudnnfMHAUid::Q_ID, dtype, 1, -1));
-
-  // create input tensor K^T
-  std::vector<int64_t> k_transpose_dims =
-      bmm1_grad_gemm2_rhs_descriptor.GetCudnnCompatibleDimensions(true);
-  std::vector<int64_t> k_transpose_strides =
-      bmm1_grad_gemm2_rhs_descriptor.GetCudnnCompatibleStrides(true);
-
-  VLOG(2) << "\n cuDNN compatible bmm1_grad_gemm2_rhs_dims: "
-          << absl::StrJoin(k_transpose_dims, ",")
-          << "\n cuDNN compatible bmm1_grad_gemm2_rhs_strides: "
-          << absl::StrJoin(k_transpose_strides, ",");
-
-  TF_ASSIGN_OR_RETURN(auto tensor_kt,
-                      CreateCudnnTensor(k_transpose_dims, k_transpose_strides,
-                                        CudnnfMHAUid::K_ID, dtype, 1, -1));
-
-  // P^T is lhs of bmm2grad1 dV = dot(P^T, dO) so we set is_lhs = false here to
-  // get correct P dim and stride
-  std::vector<int64_t> p_dims =
-      bmm2_grad_gemm1_lhs_descriptor.GetCudnnCompatibleDimensions(false);
-  std::vector<int64_t> p_strides =
-      bmm2_grad_gemm1_lhs_descriptor.GetCudnnCompatibleStrides(false);
-
-  // used for calculate offset increment
-  intermediate_shape = p_dims;
-  VLOG(2) << "\n cuDNN compatible bmm2_grad_gemm1_lhs_dims: "
-          << absl::StrJoin(p_dims, ",")
-          << "\n cuDNN compatible bmm2_grad_gemm1_lhs_strides: "
-          << absl::StrJoin(p_strides, ",");
-
-  // create input tensor V^T
-  std::vector<int64_t> v_transpose_dims =
-      bmm2_grad_gemm2_rhs_descriptor.GetCudnnCompatibleDimensions(false);
-  std::vector<int64_t> v_transpose_strides =
-      bmm2_grad_gemm2_rhs_descriptor.GetCudnnCompatibleStrides(false);
-
-  VLOG(2) << "\n cuDNN compatible bmm2_grad_gemm2_rhs_dims: "
-          << absl::StrJoin(v_transpose_dims, ",")
-          << "\n cuDNN compatible bmm2_grad_gemm2_rhs_strides: "
-          << absl::StrJoin(v_transpose_strides, ",");
-
-  TF_ASSIGN_OR_RETURN(auto tensor_vt,
-                      CreateCudnnTensor(v_transpose_dims, v_transpose_strides,
-                                        CudnnfMHAUid::V_ID, dtype, 1, -1));
-
-  // create input tensor dO
-  // FLASH ATTENTION TODO: be really careful here about dim
-  std::vector<int64_t> do_dims =
-      d_output_descriptor.GetCudnnCompatibleDimensions(false);
-  std::vector<int64_t> do_strides =
-      d_output_descriptor.GetCudnnCompatibleStrides(false);
-
-  VLOG(2) << "\n cuDNN compatible d_output_dims: "
-          << absl::StrJoin(do_dims, ",")
-          << "\n cuDNN compatible d_output_strides: "
-          << absl::StrJoin(do_strides, ",");
-
-  TF_ASSIGN_OR_RETURN(auto tensor_do,
-                      CreateCudnnTensor(do_dims, do_strides,
-                                        CudnnfMHAUid::dO_ID, dtype, 1, -1));
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_o,
-      CreateCudnnTensor(do_dims, do_strides, CudnnfMHAUid::O_ID, dtype, 1, -1));
-
-  // create output tensor dQ
-  std::vector<int64_t> dq_dims = d_bmm1_lhs_descriptor.dimensions();
-  std::vector<int64_t> dq_strides = d_bmm1_lhs_descriptor.GetLogicalStrides();
-
-  VLOG(2) << "\n cuDNN compatible d_bmm1_lhs_dims: "
-          << absl::StrJoin(dq_dims, ",")
-          << "\n cuDNN compatible d_bmm1_lhs_strides: "
-          << absl::StrJoin(dq_strides, ",");
-
-  TF_ASSIGN_OR_RETURN(auto tensor_dq,
-                      CreateCudnnTensor(dq_dims, dq_strides,
-                                        CudnnfMHAUid::dQ_ID, dtype, 1, -1));
-
-  // create output tensor dK
-  std::vector<int64_t> dk_dims = d_bmm1_rhs_descriptor.dimensions();
-  std::vector<int64_t> dk_strides = d_bmm1_rhs_descriptor.GetLogicalStrides();
-
-  VLOG(2) << "\n cuDNN compatible d_bmm1_rhs_dims: "
-          << absl::StrJoin(dk_dims, ",")
-          << "\n cuDNN compatible d_bmm1_rhs_strides: "
-          << absl::StrJoin(dk_strides, ",");
-
-  TF_ASSIGN_OR_RETURN(auto tensor_dk,
-                      CreateCudnnTensor(dk_dims, dk_strides,
-                                        CudnnfMHAUid::dK_ID, dtype, 1, -1));
-
-  // create output tensor dV
-  std::vector<int64_t> dv_dims = d_bmm2_rhs_descriptor.dimensions();
-  std::vector<int64_t> dv_strides = d_bmm2_rhs_descriptor.GetLogicalStrides();
-
-  VLOG(2) << "\n cuDNN compatible d_bmm2_rhs_dims: "
-          << absl::StrJoin(dv_dims, ",")
-          << "\n cuDNN compatible d_bmm2_rhs_strides: "
-          << absl::StrJoin(dv_strides, ",");
-
-  TF_ASSIGN_OR_RETURN(auto tensor_dv,
-                      CreateCudnnTensor(dv_dims, dv_strides,
-                                        CudnnfMHAUid::dV_ID, dtype, 1, -1));
-
-  // Begin backward graph creation
-  // dO * O
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dot_product,
-      CreateCudnnTensor(do_dims, do_strides, CudnnfMHAUid::VIRTUAL_ID + 100,
-                        dnn::DataType::kFloat, 1, -1, /*is_virtual*/ true));
-
-  TF_ASSIGN_OR_RETURN(auto mul_desc,
-                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_MUL));
-
-  TF_ASSIGN_OR_RETURN(
-      auto mul_op,
-      CreateBinaryPwOp(tensor_do, tensor_o, tensor_dot_product, mul_desc));
-
-  intermediate_ops.push_back(std::move(mul_op));
-
-  // reduction(dO * O)
-  std::vector<int64_t> do_reduction_dims(do_dims.begin(), do_dims.end() - 1);
-  do_reduction_dims.push_back(1);
-
-  // Divide every stride by the last dim value.
-  std::vector<int64_t> do_reduction_strides;
-  do_reduction_strides.reserve(do_strides.size());
-  int64_t reduced_dim_len = do_dims.back();
-  for (auto stride : do_strides) {
-    do_reduction_strides.push_back(stride / reduced_dim_len);
+  using cudnn_frontend::graph::Tensor_attributes;
+  cudnn_frontend::graph::Graph graph;
+  if (!(q_desc.type() == k_desc.type() && k_desc.type() == p_desc.type() &&
+        p_desc.type() == v_desc.type() && v_desc.type() == do_desc.type() &&
+        do_desc.type() == dq_desc.type() && dq_desc.type() == dk_desc.type() &&
+        dk_desc.type() == dv_desc.type())) {
+    return absl::InternalError("Input datatypes do not match.");
   }
 
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dot_product_reduction,
-      CreateCudnnTensor(do_reduction_dims, do_reduction_strides,
-                        CudnnfMHAUid::VIRTUAL_ID + 101, dnn::DataType::kFloat,
-                        1, -1, /*is_virtual*/ true));
+  auto ioDataType = ToCudnnFrontendDataType(q_desc.type());
+  graph.set_compute_data_type(cudnn_frontend::DataType_t::FLOAT)
+      .set_intermediate_data_type(cudnn_frontend::DataType_t::FLOAT)
+      .set_io_data_type(ioDataType);
 
-  auto reduction_add_desc = cudnn_frontend::ReductionDescBuilder()
-                                .setComputeType(CUDNN_DATA_FLOAT)
-                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
-                                .build();
-  RETURN_MSG_IF_CUDNN_ERROR(reduction_add_desc);
-  auto reduction_add_op = cudnn_frontend::OperationBuilder(
-                              CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
-                              .setxDesc(tensor_dot_product)
-                              .setyDesc(tensor_dot_product_reduction)
-                              .setreductionDesc(reduction_add_desc)
-                              .build();
-  RETURN_MSG_IF_CUDNN_ERROR(reduction_add_op);
-  intermediate_ops.push_back(std::move(reduction_add_op));
-
-  // reduction(dO * O) * scale prob -> softmax_sum
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_scale_prob,
-      CreateCudnnTensor(
-          scale_dims, scale_strides, CudnnfMHAUid::SCALE_PROB_ID,
-          dnn::DataType::kFloat, 1, -1,
-          /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
-          /*is_value*/ true));
-
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_softmax_sum,
-      CreateCudnnTensor(do_reduction_dims, do_reduction_strides,
-                        CudnnfMHAUid::S_SUM_ID, dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ false));
-
-  TF_ASSIGN_OR_RETURN(
-      auto mul_0_op,
-      CreateBinaryPwOp(tensor_dot_product_reduction, tensor_scale_prob,
-                       tensor_softmax_sum, mul_desc));
-  intermediate_ops.push_back(std::move(mul_0_op));
-
-  // Q @ K.T -> P
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_p,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 102,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-
-  auto bmm1_desc = cudnn_frontend::MatMulDescBuilder()
-                       .setComputeType(CUDNN_DATA_FLOAT)
-                       .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm1_desc);
-  auto bmm1_op = cudnn_frontend::OperationBuilder(
-                     CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
-                     .setaMatDesc(tensor_q)
-                     .setbMatDesc(tensor_kt)
-                     .setcMatDesc(tensor_p)
-                     .setmatmulDesc(bmm1_desc)
-                     .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm1_op);
-  intermediate_ops.push_back(std::move(bmm1_op));
-
-  // P * alpha_scale -> p_after_alpha_scale
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_alpha_scale,
-      CreateCudnnTensor(
-          scale_dims, scale_strides, CudnnfMHAUid::ALPHA_SCALE_ID,
-          dnn::DataType::kFloat, 1, -1,
-          /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
-          /*is_value*/ true));
-
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_p_after_alpha_scale,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 103,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-  TF_ASSIGN_OR_RETURN(auto mul_1_op,
-                      CreateBinaryPwOp(tensor_p, tensor_alpha_scale,
-                                       tensor_p_after_alpha_scale, mul_desc));
-  intermediate_ops.push_back(std::move(mul_1_op));
-
-  if (use_bias) {
-    // bias -> p_after_bias
-    TF_ASSIGN_OR_RETURN(auto tensor_p_after_bias,
-                        CreateCudnnFlashAttentionBiasFwdTensor(
-                            intermediate_ops, p_dims, p_strides, dtype,
-                            tensor_p_after_alpha_scale));
-    tensor_p_after_alpha_scale = std::move(tensor_p_after_bias);
-  }
-
-  if (use_mask) {
-    // masking -> p_after_mask
-    TF_ASSIGN_OR_RETURN(
-        auto tensor_p_after_mask,
-        CreateCudnnMaskFwdTensor(intermediate_ops, p_dims, p_strides, dtype,
-                                 tensor_p_after_alpha_scale));
-    tensor_p_after_alpha_scale = std::move(tensor_p_after_mask);
-  } else if (use_causal_mask) {
-    // Causal masking -> p_after_mask
-    TF_ASSIGN_OR_RETURN(auto tensor_p_after_causal_mask,
-                        CreateCudnnFlashAttentionCausalMaskTensor(
-                            intermediate_ops, p_dims, p_strides, dtype,
-                            tensor_p_after_alpha_scale));
-    tensor_p_after_alpha_scale = std::move(tensor_p_after_causal_mask);
-  }
-  auto tensor_p_after_bias_or_mask = std::move(tensor_p_after_alpha_scale);
-  // p_after_mask - softmax_stats -> p_after_sub
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_p_after_sub,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 104,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-
+  std::shared_ptr<Tensor_attributes> q =
+      graph.tensor(Tensor_attributes()
+                       .set_name("Q")
+                       .set_dim(q_desc.GetCudnnCompatibleDimensions(false))
+                       .set_stride(q_desc.GetCudnnCompatibleStrides(false))
+                       .set_uid(CudnnfMHAUid::Q_ID)
+                       .set_data_type(ioDataType));
+  std::shared_ptr<Tensor_attributes> k =
+      graph.tensor(Tensor_attributes()
+                       .set_name("K")
+                       .set_dim(k_desc.GetCudnnCompatibleDimensions(false))
+                       .set_stride(k_desc.GetCudnnCompatibleStrides(false))
+                       .set_uid(CudnnfMHAUid::K_ID)
+                       .set_data_type(ioDataType));
+  std::shared_ptr<Tensor_attributes> v =
+      graph.tensor(Tensor_attributes()
+                       .set_name("V")
+                       .set_dim(v_desc.GetCudnnCompatibleDimensions(true))
+                       .set_stride(v_desc.GetCudnnCompatibleStrides(true))
+                       .set_uid(CudnnfMHAUid::V_ID)
+                       .set_data_type(ioDataType));
+  std::shared_ptr<Tensor_attributes> o =
+      graph.tensor(Tensor_attributes()
+                       .set_name("O")
+                       .set_dim(do_desc.GetCudnnCompatibleDimensions(false))
+                       .set_stride(do_desc.GetCudnnCompatibleStrides(false))
+                       .set_uid(CudnnfMHAUid::O_ID)
+                       .set_data_type(ioDataType));
+  std::shared_ptr<Tensor_attributes> dO =
+      graph.tensor(Tensor_attributes()
+                       .set_name("dO")
+                       .set_dim(do_desc.GetCudnnCompatibleDimensions(false))
+                       .set_stride(do_desc.GetCudnnCompatibleStrides(false))
+                       .set_uid(CudnnfMHAUid::dO_ID)
+                       .set_data_type(ioDataType));
+  auto p_dims = p_desc.GetCudnnCompatibleDimensions(false);
+  auto p_strides = p_desc.GetCudnnCompatibleStrides(false);
   std::vector<int64_t> p_reduction_dims(p_dims.begin(), p_dims.end() - 1);
   p_reduction_dims.push_back(1);
 
@@ -6917,284 +6448,60 @@ GetCudnnFlashAttentionBackwardOperationGraph(
   for (auto stride : p_strides) {
     p_reduction_strides.push_back(stride / p_reduced_dim_len);
   }
+  p_reduction_strides[3] = 1;
+  std::shared_ptr<Tensor_attributes> stats =
+      graph.tensor(Tensor_attributes()
+                       .set_name("stats")
+                       .set_dim(p_reduction_dims)
+                       .set_stride(p_reduction_strides)
+                       .set_uid(CudnnfMHAUid::P_ID)
+                       .set_data_type(ioDataType));
 
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_softmax_stats,
-      CreateCudnnTensor(p_reduction_dims, p_reduction_strides,
-                        CudnnfMHAUid::P_ID, dnn::DataType::kFloat, 1, -1));
+  auto sdpa_backward_options =
+      cudnn_frontend::graph::SDPA_backward_attributes()
+          .set_name("flash_attention_backward")
+          .set_causal_mask(true)
+          .set_attn_scale(scale)
+          .set_compute_data_type(cudnn_frontend::DataType_t::FLOAT);
 
-  TF_ASSIGN_OR_RETURN(auto sub_desc,
-                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_SUB));
-  TF_ASSIGN_OR_RETURN(
-      auto sub_0_op,
-      CreateBinaryPwOp(tensor_p_after_bias_or_mask, tensor_softmax_stats,
-                       tensor_p_after_sub, sub_desc));
-  intermediate_ops.push_back(std::move(sub_0_op));
+  auto [dQ, dK, dV] =
+      graph.sdpa_backward(q, k, v, o, dO, stats, sdpa_backward_options);
 
-  // e^(p_after_sub) -> p_after_softmax
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_p_after_softmax,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 105,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
+  dQ->set_output(true)
+      .set_dim(dq_desc.dimensions())
+      .set_stride(dq_desc.GetLogicalStrides())
+      .set_name("dQ")
+      .set_uid(CudnnfMHAUid::dQ_ID)
+      .set_data_type(ioDataType);
+  dK->set_output(true)
+      .set_dim(dk_desc.dimensions())
+      .set_stride(dk_desc.GetLogicalStrides())
+      .set_name("dK")
+      .set_uid(CudnnfMHAUid::dK_ID)
+      .set_data_type(ioDataType);
+  dV->set_output(true)
+      .set_dim(dv_desc.dimensions())
+      .set_stride(dv_desc.GetLogicalStrides())
+      .set_name("dV")
+      .set_uid(CudnnfMHAUid::dV_ID)
+      .set_data_type(ioDataType);
 
-  TF_ASSIGN_OR_RETURN(auto exp_0_desc,
-                      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_EXP));
-  TF_ASSIGN_OR_RETURN(
-      auto exp_0_op,
-      CreateUnaryPwOp(tensor_p_after_sub, tensor_p_after_softmax, exp_0_desc));
-  intermediate_ops.push_back(std::move(exp_0_op));
+  std::cerr << graph << "\n";
 
-  // Dropout -> p_after_scale_dropout
-  // Create tensor for dropout's mask
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dropout_mask,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 106,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_p_after_scale_dropout,
-      CreateCudnnFlashAttentionDropoutBwdTensor(
-          intermediate_ops, p_dims, p_strides, dtype, tensor_p_after_softmax,
-          tensor_dropout_mask, use_dropout ? *dropout_rate : 0));
+  CudnnGraph cudnnGraph(std::move(graph));
+  TF_ASSIGN_OR_RETURN(bool supported, cudnnGraph.Prepare());
+  if (!supported) {
+    return absl::InternalError("cuDNN graph is not supported.");
+  }
+  TF_RETURN_IF_ERROR(cudnnGraph.Build(/*plan_id=*/0));
 
-  // after_scale_dropout -> s_transpose
-  auto p_transpose_dims = p_dims;
-  auto p_transpose_strides = p_strides;
-  auto p_rank = p_transpose_dims.size();
-  std::swap(p_transpose_dims[p_rank - 1], p_transpose_dims[p_rank - 2]);
-  std::swap(p_transpose_strides[p_rank - 1], p_transpose_strides[p_rank - 2]);
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_s_transpose,
-      CreateCudnnTensor(p_transpose_dims, p_transpose_strides,
-                        CudnnfMHAUid::VIRTUAL_ID + 107, dtype, 1, -1,
-                        /*is_virtual*/ true));
-  auto reshape_op = cudnn_frontend::OperationBuilder(
-                        CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
-                        .setxDesc(tensor_p_after_scale_dropout)
-                        .setyDesc(tensor_s_transpose)
-                        .build();
-  RETURN_MSG_IF_CUDNN_ERROR(reshape_op);
-  intermediate_ops.push_back(std::move(reshape_op));
-
-  // s_transpose @ dO -> dV
-  auto bmm2_grad_gemm1_desc = cudnn_frontend::MatMulDescBuilder()
-                                  .setComputeType(CUDNN_DATA_FLOAT)
-                                  .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm1_desc);
-  auto bmm2_grad_gemm1_op = cudnn_frontend::OperationBuilder(
-                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
-                                .setaMatDesc(tensor_s_transpose)
-                                .setbMatDesc(tensor_do)
-                                .setcMatDesc(tensor_dv)
-                                .setmatmulDesc(bmm2_grad_gemm1_desc)
-                                .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm1_op);
-  intermediate_ops.push_back(std::move(bmm2_grad_gemm1_op));
-
-  // dO @ V^t -> dS
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_ds,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 108,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-
-  auto bmm2_grad_gemm2_desc = cudnn_frontend::MatMulDescBuilder()
-                                  .setComputeType(CUDNN_DATA_FLOAT)
-                                  .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm2_desc);
-  auto bmm2_grad_gemm2_op = cudnn_frontend::OperationBuilder(
-                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
-                                .setaMatDesc(tensor_do)
-                                .setbMatDesc(tensor_vt)
-                                .setcMatDesc(tensor_ds)
-                                .setmatmulDesc(bmm2_grad_gemm2_desc)
-                                .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm2_grad_gemm2_op);
-  intermediate_ops.push_back(std::move(bmm2_grad_gemm2_op));
-
-  // dS * dropout -> dS_after_dropout
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_ds_after_dropout,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 109,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-
-  TF_ASSIGN_OR_RETURN(auto mul_2_op,
-                      CreateBinaryPwOp(tensor_ds, tensor_dropout_mask,
-                                       tensor_ds_after_dropout, mul_desc));
-  intermediate_ops.push_back(std::move(mul_2_op));
-
-  // dS_after_dropout - softmax_sum -> dS_after_sub
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_ds_after_sub,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 110,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-
-  TF_ASSIGN_OR_RETURN(
-      auto sub_1_op,
-      CreateBinaryPwOp(tensor_ds_after_dropout, tensor_softmax_sum,
-                       tensor_ds_after_sub, sub_desc));
-  intermediate_ops.push_back(std::move(sub_1_op));
-
-  // dS_after_sub * p_after_softmax -> dP
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dp,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 111,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-
-  TF_ASSIGN_OR_RETURN(auto mul_3_op, CreateBinaryPwOp(tensor_ds_after_sub,
-                                                      tensor_p_after_softmax,
-                                                      tensor_dp, mul_desc));
-  intermediate_ops.push_back(std::move(mul_3_op));
-
-  // dP * dropout_scale -> dP_after_dropout_scale
-  // flash attention TODO: make sure the data type is correct here
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dp_after_dropout_scale,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 112,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dropout_scale,
-      CreateCudnnTensor(
-          scale_dims, scale_strides, CudnnfMHAUid::DROPOUT_SCALE_ID,
-          dnn::DataType::kFloat, 1, -1,
-          /*is_virtual*/ false,
-          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
-          /*is_value*/ true));
-
-  TF_ASSIGN_OR_RETURN(
-      auto mul_4_op, CreateBinaryPwOp(tensor_dp, tensor_dropout_scale,
-                                      tensor_dp_after_dropout_scale, mul_desc));
-  intermediate_ops.push_back(std::move(mul_4_op));
-
-  // dP_after_dropout_scale * alpha_scale -> dP_scaled
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dp_scaled,
-      CreateCudnnTensor(p_dims, p_strides, CudnnfMHAUid::VIRTUAL_ID + 113,
-                        dnn::DataType::kFloat, 1, -1,
-                        /*is_virtual*/ true));
-  TF_ASSIGN_OR_RETURN(
-      auto mul_5_op,
-      CreateBinaryPwOp(tensor_dp_after_dropout_scale, tensor_alpha_scale,
-                       tensor_dp_scaled, mul_desc));
-  intermediate_ops.push_back(std::move(mul_5_op));
-
-  // K^T -> K
-  auto k_dims = k_transpose_dims;
-  auto k_strides = k_transpose_strides;
-  auto k_rank = k_dims.size();
-  std::swap(k_dims[k_rank - 1], k_dims[k_rank - 2]);
-  std::swap(k_strides[k_rank - 1], k_strides[k_rank - 2]);
-
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_k,
-      CreateCudnnTensor(k_dims, k_strides, CudnnfMHAUid::VIRTUAL_ID + 114,
-                        dtype, 1, -1, /*is_virtual*/ true));
-  auto reshape_1_op = cudnn_frontend::OperationBuilder(
-                          CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
-                          .setxDesc(tensor_kt)
-                          .setyDesc(tensor_k)
-                          .build();
-  RETURN_MSG_IF_CUDNN_ERROR(reshape_1_op);
-  intermediate_ops.push_back(std::move(reshape_1_op));
-
-  // dP_scaled @ K -> d_Q_accum
-  auto tensor_d_Q_accum =
-      cudnn_frontend::TensorBuilder()
-          .setDim(dq_dims.size(), dq_dims.data())
-          .setStride(dq_strides.size(), dq_strides.data())
-          .setId(CudnnfMHAUid::d_Q_accum_ID)
-          .setAlignment(16)
-          .setDataType(ToCudnnDataType(dnn::DataType::kFloat))
-          .setVectorCountAndDimension(1, -1)
-          .setVirtual(false)
-          .setReorderType(CUDNN_TENSOR_REORDERING_F16x16)
-          .setByValue(false)
-          .build();
-  RETURN_MSG_IF_CUDNN_ERROR(tensor_d_Q_accum);
-
-  auto bmm1_grad_gemm1_desc = cudnn_frontend::MatMulDescBuilder()
-                                  .setComputeType(CUDNN_DATA_FLOAT)
-                                  .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm1_desc);
-  auto bmm1_grad_gemm1_op = cudnn_frontend::OperationBuilder(
-                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
-                                .setaMatDesc(tensor_dp_scaled)
-                                .setbMatDesc(tensor_k)
-                                .setcMatDesc(tensor_d_Q_accum)
-                                .setmatmulDesc(bmm1_grad_gemm1_desc)
-                                .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm1_op);
-  intermediate_ops.push_back(std::move(bmm1_grad_gemm1_op));
-
-  // dP_scaled.T @ Q -> dK
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_dp_scaled_transpose,
-      CreateCudnnTensor(p_transpose_dims, p_transpose_strides,
-                        CudnnfMHAUid::VIRTUAL_ID + 115, dnn::DataType::kFloat,
-                        1, -1, /*is_virtual*/ true));
-  auto reshape_2_op = cudnn_frontend::OperationBuilder(
-                          CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
-                          .setxDesc(tensor_dp_scaled)
-                          .setyDesc(tensor_dp_scaled_transpose)
-                          .build();
-  RETURN_MSG_IF_CUDNN_ERROR(reshape_2_op);
-  intermediate_ops.push_back(std::move(reshape_2_op));
-
-  auto bmm1_grad_gemm2_desc = cudnn_frontend::MatMulDescBuilder()
-                                  .setComputeType(CUDNN_DATA_FLOAT)
-                                  .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm2_desc);
-  auto bmm1_grad_gemm2_op = cudnn_frontend::OperationBuilder(
-                                CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
-                                .setaMatDesc(tensor_dp_scaled_transpose)
-                                .setbMatDesc(tensor_q)
-                                .setcMatDesc(tensor_dk)
-                                .setmatmulDesc(bmm1_grad_gemm2_desc)
-                                .build();
-  RETURN_MSG_IF_CUDNN_ERROR(bmm1_grad_gemm2_op);
-  intermediate_ops.push_back(std::move(bmm1_grad_gemm2_op));
-
-  // d_Q_accum @ identity -> dQ
-  TF_ASSIGN_OR_RETURN(
-      auto identity_desc,
-      CreatePwDesc(dnn::DataType::kFloat, CUDNN_POINTWISE_IDENTITY));
-  TF_ASSIGN_OR_RETURN(
-      auto identity_op,
-      CreateUnaryPwOp(tensor_d_Q_accum, tensor_dq, identity_desc));
-  intermediate_ops.push_back(std::move(identity_op));
-
-  ops.reserve(intermediate_ops.size());
-  for (auto& intermediate_op : intermediate_ops) {
-    ops.emplace_back(&intermediate_op);
+  if (VLOG_IS_ON(4)) {
+    VLOG(4) << "\b flash attention operation backward graph: " << graph;
   }
 
-  auto op_graph = cudnn_frontend::OperationGraphBuilder()
-                      .setHandle(cudnn.handle())
-                      .setOperationGraph(ops.size(), ops.data())
-                      .build();
-  RETURN_MSG_IF_CUDNN_ERROR(op_graph);
+  std::cerr << "Graph building successful\n";
 
-  VLOG(4) << "\nTensor_q: " << tensor_q.describe()
-          << "\nTensor_kt: " << tensor_kt.describe()
-          << "\nTensor_p: " << tensor_p.describe()
-          << "\nTensor_vt: " << tensor_vt.describe()
-          << "\nTensor_do: " << tensor_do.describe()
-          << "\nTensor_o: " << tensor_o.describe()
-          << "\nTensor_dq: " << tensor_dq.describe()
-          << "\nTensor_dk: " << tensor_dk.describe()
-          << "\nTensor_dv: " << tensor_dv.describe()
-          << "\nBMM2_grad_gemm1: " << bmm2_grad_gemm1_desc.describe()
-          << "\nBMM2_grad_gemm2: " << bmm2_grad_gemm2_desc.describe()
-          << "\nBMM1_grad_gemm1: " << bmm1_grad_gemm1_desc.describe()
-          << "\nBMM1_grad_gemm2: " << bmm1_grad_gemm2_desc.describe()
-          << "\nOpGraph: " << op_graph.describe();
-  return std::make_unique<cudnn_frontend::OperationGraph>(std::move(op_graph));
+  return cudnnGraph;
 }
 
 #endif  // CUDNN_VERSION >= 8800
@@ -8066,9 +7373,10 @@ class CudnnGraphRunner<void(Args...)> : public dnn::OpRunner<void(Args...)> {
 
     if (dropout_rng_offset_increment_ > 0) {
 #if CUDNN_VERSION >= 8800
-      variant_pack[D_SEED_ID] = (void*)&dropout_rng_seed_;
+      variant_pack[CudnnfMHAUid::D_SEED_ID] = (void*)&dropout_rng_seed_;
       current_dropout_rng_offset_ += dropout_rng_offset_increment_;
-      variant_pack[D_OFFSET_ID] = (void*)&current_dropout_rng_offset_;
+      variant_pack[CudnnfMHAUid::D_OFFSET_ID] =
+          (void*)&current_dropout_rng_offset_;
 #else
       return absl::UnimplementedError(
           "Cudnn dropout offset and seed are only supported with Cudnn >= "
@@ -8085,14 +7393,16 @@ class CudnnGraphRunner<void(Args...)> : public dnn::OpRunner<void(Args...)> {
   static absl::StatusOr<CudnnGraphRunner> Create(
       GpuExecutor* parent, CudnnAccess* cudnn, CudnnGraph graph,
       int64_t dropout_rng_seed, int64_t dropout_rng_offset,
+      std::unordered_map<int64_t, ScalingParam> scalars,
       std::vector<std::optional<int64_t>> uids) {
     return CudnnGraphRunner(parent, cudnn, std::move(graph), dropout_rng_seed,
-                            dropout_rng_offset, uids);
+                            dropout_rng_offset, scalars, uids);
   }
 
  private:
   CudnnGraphRunner(GpuExecutor* parent, CudnnAccess* cudnn, CudnnGraph graph,
                    int64_t dropout_rng_seed, int64_t dropout_rng_offset,
+                   std::unordered_map<int64_t, ScalingParam> scalars,
                    std::vector<std::optional<int64_t>> uids)
       : parent_(parent),
         cudnn_(cudnn),
@@ -8100,6 +7410,7 @@ class CudnnGraphRunner<void(Args...)> : public dnn::OpRunner<void(Args...)> {
         dropout_rng_seed_(dropout_rng_seed),
         current_dropout_rng_offset_(0),
         dropout_rng_offset_increment_(dropout_rng_offset),
+        scalars_(scalars),
         uids_(uids) {}
   GpuExecutor* parent_;
   CudnnAccess* cudnn_;
@@ -8108,6 +7419,7 @@ class CudnnGraphRunner<void(Args...)> : public dnn::OpRunner<void(Args...)> {
   int64_t dropout_rng_seed_;
   mutable int64_t current_dropout_rng_offset_;
   int64_t dropout_rng_offset_increment_;
+  std::unordered_map<int64_t, ScalingParam> scalars_;
   std::vector<std::optional<int64_t>> uids_;
 };
 
@@ -9148,10 +8460,11 @@ CudnnSupport::FusedMHARunnerFromDesc(
     uids.emplace_back(activation_descriptor.has_value()
                           ? std::optional<CudnnfMHAUid>(CudnnfMHAUid::P_ID)
                           : std::nullopt);
-    TF_ASSIGN_OR_RETURN(auto runner,
-                        CudnnGraphRunner<dnn::FusedMHASignature>::Create(
-                            parent_, cudnn_.get(), std::move(graph),
-                            dropout_rng_seed, dropout_rng_offset, uids));
+    std::unordered_map<int64_t, ScalingParam> scalars;
+    TF_ASSIGN_OR_RETURN(
+        auto runner, CudnnGraphRunner<dnn::FusedMHASignature>::Create(
+                         parent_, cudnn_.get(), std::move(graph),
+                         dropout_rng_seed, dropout_rng_offset, scalars, uids));
 
     return {std::make_unique<CudnnGraphRunner<dnn::FusedMHASignature>>(
         std::move(runner))};
@@ -9239,27 +8552,52 @@ CudnnSupport::FusedMHABackwardRunnerFromDesc(
 
   bool use_dropout = dropout_rate && *dropout_rate > 0.0;
   std::vector<int64_t> intermediate_shape;
+
+  if (is_flash_attention) {
+    TF_ASSIGN_OR_RETURN(
+        auto graph,
+        GetCudnnFlashAttentionBackwardOperationGraph(
+            bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
+            bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
+            d_output_descriptor, d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor,
+            d_bmm2_rhs_descriptor, kind, dropout_rate, seed, cudnn, scale,
+            intermediate_shape, use_dropout,
+            /*use_mask*/ mask_descriptor != std::nullopt,
+            /*use_bias*/ bias_descriptor != std::nullopt, is_causal_mask));
+    std::cerr << "Plans built: " << graph.Graph().get_execution_plan_count()
+              << "\n";
+
+    std::vector<int64_t> p_dims =
+        bmm2_grad_gemm1_lhs_descriptor.GetCudnnCompatibleDimensions(false);
+    intermediate_shape = p_dims;
+    int64_t dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
+    int64_t dropout_rng_seed = seed.has_value() ? *seed : 0;
+
+    std::unordered_map<int64_t, ScalingParam> scalars;
+    std::vector<std::optional<int64_t>> uids;
+    uids = {CudnnfMHAUid::Q_ID,  CudnnfMHAUid::K_ID,  CudnnfMHAUid::P_ID,
+            CudnnfMHAUid::V_ID,  CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
+            CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, std::nullopt,
+            std::nullopt,        std::nullopt,        std::nullopt,
+            std::nullopt,        CudnnfMHAUid::O_ID,  std::nullopt};
+    TF_ASSIGN_OR_RETURN(
+        auto runner, CudnnGraphRunner<dnn::FusedMHABackwardSignature>::Create(
+                         parent_, cudnn_.get(), graph, dropout_rng_seed,
+                         dropout_rng_offset, scalars, uids));
+    return {std::make_unique<CudnnGraphRunner<dnn::FusedMHABackwardSignature>>(
+        std::move(runner))};
+  }
+
   TF_ASSIGN_OR_RETURN(
       auto op_graph,
-      is_flash_attention
-          ? GetCudnnFlashAttentionBackwardOperationGraph(
-                bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
-                bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
-                d_output_descriptor, d_bmm1_lhs_descriptor,
-                d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor, kind,
-                dropout_rate, seed, cudnn, scale, intermediate_shape,
-                use_dropout,
-                /*use_mask*/ mask_descriptor != std::nullopt,
-                /*use_bias*/ bias_descriptor != std::nullopt, is_causal_mask)
-          : GetCudnnFusedMHABackwardOperationGraph(
-                bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
-                bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
-                d_output_descriptor, d_bmm1_lhs_descriptor,
-                d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor, kind,
-                dropout_rate, seed, cudnn, scale, intermediate_shape,
-                use_dropout,
-                /*use_mask*/ mask_descriptor != std::nullopt,
-                /*use_bias*/ d_bias_descriptor != std::nullopt));
+      GetCudnnFusedMHABackwardOperationGraph(
+          bmm1_grad_gemm1_rhs_descriptor, bmm1_grad_gemm2_rhs_descriptor,
+          bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
+          d_output_descriptor, d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor,
+          d_bmm2_rhs_descriptor, kind, dropout_rate, seed, cudnn, scale,
+          intermediate_shape, use_dropout,
+          /*use_mask*/ mask_descriptor != std::nullopt,
+          /*use_bias*/ d_bias_descriptor != std::nullopt));
   // The function  GetExecPlanFromHeuristics uses
   // cudnn_frontend::cudnnException which is currently not recommended for
   // use by Google. Hence commenting out the call.
@@ -9277,67 +8615,30 @@ CudnnSupport::FusedMHABackwardRunnerFromDesc(
   std::vector<ScalingParam> scalar_values;
   std::vector<int64_t> uids;
 
-  if (is_flash_attention) {
-    scalar_uids = {CudnnfMHAUid::ALPHA_SCALE_ID, CudnnfMHAUid::DROPOUT_SCALE_ID,
-                   CudnnfMHAUid::SCALE_PROB_ID};
-    // alpha scale
-    ScalingParam alpha_scale(scale, dnn::DataType::kFloat);
-    // dropout scale
-    double dropout_scale_value =
-        use_dropout ? (1.0f / (1.0f - *dropout_rate)) : 1.0f;
-    ScalingParam dropout_scale(dropout_scale_value, dnn::DataType::kFloat);
-    // scale prob
-    double scale_prob_value = use_dropout ? 1.0 - *dropout_rate : 1.0f;
-    ScalingParam scale_prob(scale_prob_value, dnn::DataType::kFloat);
-    scalar_values = {alpha_scale, dropout_scale, scale_prob};
-    // push dropout seed and offset here
-    dropout_rng_offset = GetDropoutRngOffset(intermediate_shape);
-    uids = {CudnnfMHAUid::Q_ID,     CudnnfMHAUid::K_ID,
-            CudnnfMHAUid::P_ID,     CudnnfMHAUid::V_ID,
-            CudnnfMHAUid::dO_ID,    CudnnfMHAUid::dQ_ID,
-            CudnnfMHAUid::dK_ID,    CudnnfMHAUid::dV_ID,
-            CudnnfMHAUid::S_SUM_ID, CudnnfMHAUid::d_Q_accum_ID};
-    if (mask_descriptor != std::nullopt) {
-      uids.push_back(CudnnfMHAUid::MASK_ID);
-    }
-    uids.push_back(CudnnfMHAUid::O_ID);
-    if (bias_descriptor != std::nullopt) {
-      uids.push_back(CudnnfMHAUid::BIAS_ID);
-    }
-    if (is_causal_mask) {
-      // is causal mask
-      // negative infinity
-      double negative_infinity_value = -std::numeric_limits<float>::infinity();
-      ScalingParam negative_infinity(negative_infinity_value,
-                                     dnn::DataType::kFloat);
-      scalar_values.push_back(negative_infinity);
-      scalar_uids.push_back(CudnnfMHAUid::NEG_INFINITY_ID);
-    }
-  } else {
-    // TODO cudnn doesn't support no dropout, so setting dropout rate to 0 here
-    // to mimic no dropout. Change this when cudnn graph is more flexible.
-    scalar_uids = {CudnnfMHAUid::ALPHA_SCALE_ID, CudnnfMHAUid::ZERO_VAL_ID,
-                   CudnnfMHAUid::ONE_VAL_ID, CudnnfMHAUid::DROPOUT_SCALE_ID};
-    ScalingParam alpha_scale(scale, dnn::DataType::kFloat);
-    double zero_value = 0.0f;
-    ScalingParam zero(zero_value, dnn::DataType::kFloat);
-    double one_value = 1.0f;
-    ScalingParam one(one_value, dnn::DataType::kFloat);
-    double dropout_scale_value =
-        use_dropout ? (1.0 / (1.0 - *dropout_rate)) : 1.0;
-    ScalingParam dropout_scale(dropout_scale_value, dnn::DataType::kFloat);
-    scalar_values = {alpha_scale, zero, one, dropout_scale};
+  // TODO cudnn doesn't support no dropout, so setting dropout rate to 0 here
+  // to mimic no dropout. Change this when cudnn graph is more flexible.
+  scalar_uids = {CudnnfMHAUid::ALPHA_SCALE_ID, CudnnfMHAUid::ZERO_VAL_ID,
+                 CudnnfMHAUid::ONE_VAL_ID, CudnnfMHAUid::DROPOUT_SCALE_ID};
+  ScalingParam alpha_scale(scale, dnn::DataType::kFloat);
+  double zero_value = 0.0f;
+  ScalingParam zero(zero_value, dnn::DataType::kFloat);
+  double one_value = 1.0f;
+  ScalingParam one(one_value, dnn::DataType::kFloat);
+  double dropout_scale_value =
+      use_dropout ? (1.0 / (1.0 - *dropout_rate)) : 1.0;
+  ScalingParam dropout_scale(dropout_scale_value, dnn::DataType::kFloat);
+  scalar_values = {alpha_scale, zero, one, dropout_scale};
 
-    uids = {CudnnfMHAUid::Q_ID,  CudnnfMHAUid::K_ID,  CudnnfMHAUid::P_ID,
-            CudnnfMHAUid::V_ID,  CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
-            CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID};
-    if (mask_descriptor != std::nullopt) {
-      uids.push_back(CudnnfMHAUid::MASK_ID);
-    }
-    if (d_bias_descriptor != std::nullopt) {
-      uids.push_back(CudnnfMHAUid::dBIAS_ID);
-    }
+  uids = {CudnnfMHAUid::Q_ID,  CudnnfMHAUid::K_ID,  CudnnfMHAUid::P_ID,
+          CudnnfMHAUid::V_ID,  CudnnfMHAUid::dO_ID, CudnnfMHAUid::dQ_ID,
+          CudnnfMHAUid::dK_ID, CudnnfMHAUid::dV_ID, CudnnfMHAUid::dS_ID};
+  if (mask_descriptor != std::nullopt) {
+    uids.push_back(CudnnfMHAUid::MASK_ID);
   }
+  if (d_bias_descriptor != std::nullopt) {
+    uids.push_back(CudnnfMHAUid::dBIAS_ID);
+  }
+
   TF_ASSIGN_OR_RETURN(
       auto runner,
       CudnnExecutionPlanRunner<dnn::FusedMHABackwardSignature>::Create(
@@ -10425,6 +9726,7 @@ absl::Status CudnnGraph::Build(dnn::DnnSupport& dnn_support,
   TF_ASSIGN_OR_RETURN(auto cudnn, cudnn_support.cudnn_->GetLocalHandle());
   RETURN_IF_CUDNN_FRONTEND_ERROR(
       graph_.build_plan_at_index(cudnn->handle(), plan_id));
+  // RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.build_plans(cudnn->handle()));
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6377,10 +6377,9 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     const dnn::TensorDescriptor& dq_desc, const dnn::TensorDescriptor& dk_desc,
     const dnn::TensorDescriptor& dv_desc,
     const std::optional<dnn::TensorDescriptor> bias_descriptor,
-    dnn::FusedMHAKind kind, std::optional<double> dropout_rate,
-    std::optional<int64_t> seed, CudnnHandle& cudnn, double scale,
-    bool use_dropout = false, bool use_mask = false, bool use_bias = false,
-    bool use_causal_mask = false) {
+    std::optional<double> dropout_rate, std::optional<int64_t> seed,
+    double scale, bool use_dropout = false, bool use_mask = false,
+    bool use_bias = false, bool use_causal_mask = false) {
   if (VLOG_IS_ON(4)) {
     VLOG(4) << "\n bmm1_grad_gemm1_rhs(q): " << q_desc.ToString()
             << "\n bmm1_grad_gemm2_rhs(k): " << k_desc.ToString()
@@ -8608,8 +8607,7 @@ CudnnSupport::FusedMHABackwardRunnerFromDesc(
             bmm1_grad_gemm2_rhs_descriptor, bmm2_grad_gemm1_lhs_descriptor,
             bmm2_grad_gemm2_rhs_descriptor, d_output_descriptor,
             d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor, d_bmm2_rhs_descriptor,
-            bias_descriptor, kind, dropout_rate, seed, cudnn, scale,
-            use_dropout,
+            bias_descriptor, dropout_rate, seed, scale, use_dropout,
             /*use_mask*/ mask_descriptor != std::nullopt,
             /*use_bias*/ bias_descriptor != std::nullopt, is_causal_mask));
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -7408,8 +7408,6 @@ class CudnnGraphRunner<void(Args...)> : public dnn::OpRunner<void(Args...)> {
     }
     if (dropout_rng_offset_increment_ > 0) {
 #if CUDNN_VERSION >= 8800
-      // variant_pack[CudnnfMHAUid::D_SEED_ID] = scratch_memory.opaque();
-      // variant_pack[CudnnfMHAUid::D_OFFSET_ID] = static_cast<void*>(static_cast<int64_t*>(scratch_memory.opaque()) + 1);
       variant_pack[CudnnfMHAUid::D_SEED_ID] = (void*)&dropout_rng_seed_;
       current_dropout_rng_offset_ += dropout_rng_offset_increment_;
       variant_pack[CudnnfMHAUid::D_OFFSET_ID] =

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -9760,7 +9760,6 @@ absl::Status CudnnGraph::Build(dnn::DnnSupport& dnn_support,
   TF_ASSIGN_OR_RETURN(auto cudnn, cudnn_support.cudnn_->GetLocalHandle());
   RETURN_IF_CUDNN_FRONTEND_ERROR(
       graph_.build_plan_at_index(cudnn->handle(), plan_id));
-  // RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.build_plans(cudnn->handle()));
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -369,6 +369,7 @@ class CudnnSupport : public dnn::DnnSupport {
       std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed,
       bool is_flash_attention, bool is_causal_mask);
+
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
@@ -718,6 +719,31 @@ class CudnnSupport : public dnn::DnnSupport {
   CudnnSupport(const CudnnSupport&) = delete;
   void operator=(const CudnnSupport&) = delete;
 };
+
+absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
+    dnn::DnnSupport& dnn_support,
+    const dnn::MatmulTensorDescriptor& q_descriptor,
+    const dnn::MatmulTensorDescriptor& k_descriptor,
+    const dnn::MatmulTensorDescriptor& v_descriptor,
+    const dnn::TensorDescriptor& o_descriptor,
+    const std::optional<dnn::TensorDescriptor> bias_descriptor,
+    const std::optional<dnn::TensorDescriptor> mask_descriptor,
+    const std::optional<dnn::TensorDescriptor> stats_descriptor,
+    const float scale, const bool use_dropout,
+    const std::optional<double> dropout_rate, const bool is_causal_mask);
+
+absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
+    dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
+    const dnn::MatmulTensorDescriptor& k_desc,
+    const dnn::MatmulTensorDescriptor& p_desc,
+    const dnn::MatmulTensorDescriptor& v_desc,
+    const dnn::MatmulTensorDescriptor& do_desc,
+    const dnn::TensorDescriptor& dq_desc, const dnn::TensorDescriptor& dk_desc,
+    const dnn::TensorDescriptor& dv_desc,
+    const std::optional<dnn::TensorDescriptor> bias_descriptor,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed,
+    double scale, bool use_dropout, bool use_mask, bool use_bias,
+    bool use_causal_mask);
 
 }  // namespace gpu
 }  // namespace stream_executor

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1013,8 +1013,7 @@ using FusedMHABackwardSignature = void(
     DeviceMemoryBase /* d_BMM1_inputA_data */,
     DeviceMemoryBase /* d_BMM1_inputB_data */,
     DeviceMemoryBase /* d_BMM2_inputB_data */, DeviceMemoryBase /* d_S_data */,
-    DeviceMemoryBase /* softmax_sum_data */,
-    DeviceMemoryBase /* d_Q_accum_data */, DeviceMemoryBase /* mask_data */,
+    DeviceMemoryBase /* mask_data */,
     DeviceMemoryBase /* d_bias_data */, DeviceMemoryBase /* fwd_output_data */,
     DeviceMemoryBase /* bias_data */, DeviceMemoryBase /* seqlen_q_data */,
     DeviceMemoryBase /* seqlen_k_data */);


### PR DESCRIPTION
* Replace complicated node by node flash attention cuDNN graph construction with simple cudnn sdpa call provided in new cuDNN frontend (>1.0).
* Remove softmax_sum/dq_accum tensors from the custom call outputs since it is not required anymore in new cuDNN frontend.
* Add a pass to query workspace from cuDNN graph instead of manual calculation as workspace size is subject to change.