### PR TITLE
[XLA:CPU] Enable XLA on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -437,8 +437,8 @@ build:avx_win --copt=/arch:AVX
 # Use Clang-cl compiler on Windows
 build:win_clang --copt=/clang:-Weverything
 build:win_clang --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
-build:win_clang --extra_execution_platforms=//tools/toolchains/win:x64_windows-clang-cl
-build:win_clang --host_platform=//tools/toolchains/win:x64_windows-clang-cl
+build:win_clang --extra_execution_platforms=//tensorflow/tools/toolchains/win:x64_windows-clang-cl
+build:win_clang --host_platform=//tensorflow/tools/toolchains/win:x64_windows-clang-cl
 build:win_clang --compiler=clang-cl
 build:win_clang --linkopt=/FORCE:MULTIPLE
 build:win_clang --host_linkopt=/FORCE:MULTIPLE

--- a/.bazelrc
+++ b/.bazelrc
@@ -437,8 +437,8 @@ build:avx_win --copt=/arch:AVX
 # Use Clang-cl compiler on Windows
 build:win_clang --copt=/clang:-Weverything
 build:win_clang --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
-build:win_clang --extra_execution_platforms=//tensorflow/tools/toolchains/win:x64_windows-clang-cl
-build:win_clang --host_platform=//tensorflow/tools/toolchains/win:x64_windows-clang-cl
+build:win_clang --extra_execution_platforms=//tools/toolchains/win:x64_windows-clang-cl
+build:win_clang --host_platform=//tools/toolchains/win:x64_windows-clang-cl
 build:win_clang --compiler=clang-cl
 build:win_clang --linkopt=/FORCE:MULTIPLE
 build:win_clang --host_linkopt=/FORCE:MULTIPLE

--- a/xla/tools/interactive_graphviz_bin_test.cc
+++ b/xla/tools/interactive_graphviz_bin_test.cc
@@ -60,6 +60,7 @@ TEST(InteractiveGraphviz, CPU) {
   #if defined (_WIN32) || defined (_WIN64)
   EXPECT_EQ(0, status);
   #else
+  EXPECT_TRUE(WIFEXITED(status));
   EXPECT_EQ(0, WEXITSTATUS(status));
   #endif  // defined(_WIN32) || defined(_WIN64)
   ASSERT_THAT(err, testing::HasSubstr("Compiling module for Host"));

--- a/xla/tools/interactive_graphviz_bin_test.cc
+++ b/xla/tools/interactive_graphviz_bin_test.cc
@@ -62,7 +62,7 @@ TEST(InteractiveGraphviz, CPU) {
   #else
   EXPECT_EQ(0, WEXITSTATUS(status));
   ASSERT_THAT(err, testing::HasSubstr("Compiling module for Host"));
-  #endif
+  #endif  // defined(_WIN32) || defined(_WIN64)
 }
 
 }  // namespace

--- a/xla/tools/interactive_graphviz_bin_test.cc
+++ b/xla/tools/interactive_graphviz_bin_test.cc
@@ -61,8 +61,8 @@ TEST(InteractiveGraphviz, CPU) {
   EXPECT_EQ(0, status);
   #else
   EXPECT_EQ(0, WEXITSTATUS(status));
-  ASSERT_THAT(err, testing::HasSubstr("Compiling module for Host"));
   #endif  // defined(_WIN32) || defined(_WIN64)
+  ASSERT_THAT(err, testing::HasSubstr("Compiling module for Host"));
 }
 
 }  // namespace

--- a/xla/tools/interactive_graphviz_bin_test.cc
+++ b/xla/tools/interactive_graphviz_bin_test.cc
@@ -58,8 +58,13 @@ TEST(InteractiveGraphviz, CPU) {
 
   int status = proc.Communicate(&in, &out, &err);
   EXPECT_TRUE(WIFEXITED(status));
+  #if defined (_WIN32) || defined (_WIN64)
+  EXPECT_TRUE(status==0);
+  EXPECT_EQ(0, status);
+  #else
   EXPECT_EQ(0, WEXITSTATUS(status));
   ASSERT_THAT(err, testing::HasSubstr("Compiling module for Host"));
+  #endif
 }
 
 }  // namespace

--- a/xla/tools/interactive_graphviz_bin_test.cc
+++ b/xla/tools/interactive_graphviz_bin_test.cc
@@ -57,9 +57,7 @@ TEST(InteractiveGraphviz, CPU) {
   std::string out, err;
 
   int status = proc.Communicate(&in, &out, &err);
-  EXPECT_TRUE(WIFEXITED(status));
   #if defined (_WIN32) || defined (_WIN64)
-  EXPECT_TRUE(status==0);
   EXPECT_EQ(0, status);
   #else
   EXPECT_EQ(0, WEXITSTATUS(status));

--- a/xla/tools/run_hlo_module_bin_test.cc
+++ b/xla/tools/run_hlo_module_bin_test.cc
@@ -40,11 +40,11 @@ class RunHloModuleTest : public ::testing::Test {
 
     stdout_output_ = stderr_output_ = "";
     int status = proc.Communicate(nullptr, &stdout_output_, &stderr_output_);
-    exited_normally_ = WIFEXITED(status);
     #if defined (_WIN32) || defined (_WIN64)
     exited_normally_ = (status == 0);
     exit_status_ = (exited_normally_) ? 0 : status;
     #else
+    exited_normally_ = WIFEXITED(status);
     exit_status_ = exited_normally_ ? WEXITSTATUS(status) : -1;
     #endif
   }

--- a/xla/tools/run_hlo_module_bin_test.cc
+++ b/xla/tools/run_hlo_module_bin_test.cc
@@ -41,7 +41,12 @@ class RunHloModuleTest : public ::testing::Test {
     stdout_output_ = stderr_output_ = "";
     int status = proc.Communicate(nullptr, &stdout_output_, &stderr_output_);
     exited_normally_ = WIFEXITED(status);
+    #if defined (_WIN32) || defined (_WIN64)
+    exited_normally_ = (status == 0);
+    exit_status_ = (exited_normally_) ? 0 : status;
+    #else
     exit_status_ = exited_normally_ ? WEXITSTATUS(status) : -1;
+    #endif
   }
 
   std::string stdout_output_;

--- a/xla/tools/run_hlo_module_bin_test.cc
+++ b/xla/tools/run_hlo_module_bin_test.cc
@@ -42,7 +42,7 @@ class RunHloModuleTest : public ::testing::Test {
     int status = proc.Communicate(nullptr, &stdout_output_, &stderr_output_);
     #if defined (_WIN32) || defined (_WIN64)
     exited_normally_ = (status == 0);
-    exit_status_ = (exited_normally_) ? 0 : status;
+    exit_status_ = status;
     #else
     exited_normally_ = WIFEXITED(status);
     exit_status_ = exited_normally_ ? WEXITSTATUS(status) : -1;

--- a/xla/tools/run_hlo_module_bin_test.cc
+++ b/xla/tools/run_hlo_module_bin_test.cc
@@ -46,7 +46,7 @@ class RunHloModuleTest : public ::testing::Test {
     #else
     exited_normally_ = WIFEXITED(status);
     exit_status_ = exited_normally_ ? WEXITSTATUS(status) : -1;
-    #endif
+    #endif // (_WIN32) || defined (_WIN64)
   }
 
   std::string stdout_output_;

--- a/xla/tools/tests/hlo_expand_test.cc
+++ b/xla/tools/tests/hlo_expand_test.cc
@@ -46,7 +46,7 @@ class HloExpandTest : public ::testing::Test {
     #else
     exited_normally_ = WIFEXITED(status);
     exit_status_ = exited_normally_ ? WEXITSTATUS(status) : -1;
-    #endif
+    #endif  // defined(_WIN32) || defined(_WIN64)
   }
 
   std::string stdout_output_;

--- a/xla/tools/tests/hlo_expand_test.cc
+++ b/xla/tools/tests/hlo_expand_test.cc
@@ -41,8 +41,7 @@ class HloExpandTest : public ::testing::Test {
     stdout_output_ = stderr_output_ = "";
     int status = proc.Communicate(nullptr, &stdout_output_, &stderr_output_);
     #if defined (_WIN32) || defined (_WIN64)
-    exited_normally_ = (status == 0); 
-    exit_status_ = (exited_normally_) ? 0 : status;
+    exit_status_ = status;
     #else
     exited_normally_ = WIFEXITED(status);
     exit_status_ = exited_normally_ ? WEXITSTATUS(status) : -1;

--- a/xla/tools/tests/hlo_expand_test.cc
+++ b/xla/tools/tests/hlo_expand_test.cc
@@ -40,8 +40,13 @@ class HloExpandTest : public ::testing::Test {
 
     stdout_output_ = stderr_output_ = "";
     int status = proc.Communicate(nullptr, &stdout_output_, &stderr_output_);
+    #if defined (_WIN32) || defined (_WIN64)
+    exited_normally_ = (status == 0); 
+    exit_status_ = (exited_normally_) ? 0 : status;
+    #else
     exited_normally_ = WIFEXITED(status);
     exit_status_ = exited_normally_ ? WEXITSTATUS(status) : -1;
+    #endif
   }
 
   std::string stdout_output_;

--- a/xla/tools/tests/hlo_expand_test.cc
+++ b/xla/tools/tests/hlo_expand_test.cc
@@ -41,6 +41,7 @@ class HloExpandTest : public ::testing::Test {
     stdout_output_ = stderr_output_ = "";
     int status = proc.Communicate(nullptr, &stdout_output_, &stderr_output_);
     #if defined (_WIN32) || defined (_WIN64)
+    exited_normally_ = (status == 0);
     exit_status_ = status;
     #else
     exited_normally_ = WIFEXITED(status);


### PR DESCRIPTION
This PR aims to enable the XLA test cases on the Windows Platform. The changes made:

1. Changed the .bazelrc file to use the correct toolchain and platform
This change will allow the user to successfully run XLA tests on the Windows platform using the Clang compiler using '--config=win_clang' in the bazel command

2. Added conditions to a few test cases to successfully run on the Windows platform
These test cases check the exit/termination status of a process
WIFEXITED is typically supported in POSIX-compliant operating systems like Unix and Linux to check if a process has terminated normally. WEXITSTATUS allows examining the termination status of child processes. However, these macros are not Windows compliant, hence the additional condition block was added to check the exit/termination status of process or child process for the Windows platform