### PR TITLE
[ROCm] Upstreaming old changes

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -4141,9 +4141,6 @@ cc_library(
     name = "gpu_layout_assignment",
     srcs = ["gpu_layout_assignment.cc"],
     hdrs = ["gpu_layout_assignment.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
     deps = [
         ":backend_configs_cc",
         ":cublas_cudnn",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -4141,6 +4141,9 @@ cc_library(
     name = "gpu_layout_assignment",
     srcs = ["gpu_layout_assignment.cc"],
     hdrs = ["gpu_layout_assignment.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
     deps = [
         ":backend_configs_cc",
         ":cublas_cudnn",

--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -71,6 +71,7 @@ limitations under the License.
 #include "tsl/platform/logging.h"
 #include "tsl/platform/numbers.h"
 #include "tsl/platform/statusor.h"
+#include "xla/tsl/util/env_var.h"
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
 #include "third_party/gpus/cudnn/cudnn.h"  // IWYU pragma: keep
@@ -99,9 +100,16 @@ class ScratchAllocator : public se::ScratchAllocator {
       : device_ordinal_(device_ordinal), memory_allocator_(memory_allocator) {}
 
   int64_t GetMemoryLimitInBytes() override {
-    return 1LL << 32;  // 4GB.  TODO(jlebar): Tune this?
+    return ScratchAllocator::GetDefaultMemoryLimitInBytes();
   }
   int64_t TotalAllocatedBytes() { return total_allocated_bytes_; }
+
+  static int64_t GetDefaultMemoryLimitInBytes() {
+      int64_t value;
+      TF_CHECK_OK(tsl::ReadInt64FromEnvVar("TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 
+                1LL << 12, &value));
+      return value * (1LL << 20);
+  }
 
   absl::StatusOr<se::DeviceMemory<uint8_t>> AllocateBytes(
       int64_t byte_size) override;

--- a/xla/service/gpu/gpu_layout_assignment.cc
+++ b/xla/service/gpu/gpu_layout_assignment.cc
@@ -128,50 +128,48 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
   }
 
   const bool isFloat16 = (input_ty == F16) || (input_ty == BF16);
-#if GOOGLE_CUDA
-  // If we're not Volta or not fp16/bfloat16, or not conv2D, the decision is
-  // easy: Use NCHW.
-  const auto* cuda_compute_capability =
-      std::get_if<se::CudaComputeCapability>(&gpu_version);
-  bool is_volta =
-      cuda_compute_capability &&
-      cuda_compute_capability->IsAtLeast(se::CudaComputeCapability::VOLTA);
-  if (!isFloat16 || !is_volta ||
-      instr->shape().tuple_shapes(0).dimensions_size() != 4) {
-    return kAllNCHW;
+  if(std::holds_alternative<se::CudaComputeCapability>(gpu_version)) {
+    // If we're not Volta or not fp16/bfloat16, or not conv2D, the decision is
+    // easy: Use NCHW.
+    const auto* cuda_compute_capability =
+        std::get_if<se::CudaComputeCapability>(&gpu_version);
+    bool is_volta =
+        cuda_compute_capability &&
+        cuda_compute_capability->IsAtLeast(se::CudaComputeCapability::VOLTA);
+    if (!isFloat16 || !is_volta ||
+        instr->shape().tuple_shapes(0).dimensions_size() != 4) {
+      return kAllNCHW;
+    }
+
+    // Empirically we've found with Volta and cudnn <= 7.3 that backward-input
+    // convs with stride are significantly faster with NCHW layouts.
+    //
+    // We could have used a mixed layout combination, e.g. (NHWC, NCHW, NCHW),
+    // which on paper gives good performance. However, there are two observations:
+    // * a mixed layout combination is more cuDNN-bug prone, based on empirical
+    //   evidence.
+    // * we've also observed that for mixed layouts, cuDNN transposes data back
+    //   and forth from a different layout combination. If we end up with
+    //   transposes anyway, we prefer to have them in XLA, as they can be fused.
+    if (std::make_tuple(dnn_version.major_version(),
+                        dnn_version.minor_version()) <= std::make_tuple(7, 3) &&
+        instr->custom_call_target() == kCudnnConvBackwardInputCallTarget &&
+        window_util::HasStride(instr->window())) {
+      return kAllNCHW;
+    }
+  } else if (std::holds_alternative<se::RocmComputeCapability>(gpu_version)) {
+    bool is_enabled = false;
+    TF_CHECK_OK(tsl::ReadBoolFromEnvVar(
+        "TF_USE_ROCM_NHWC",
+        /*default_val=*/false, &is_enabled));
+    auto rocm_compute_capability = std::get<se::RocmComputeCapability>(gpu_version);
+    if (!isFloat16 || (!rocm_compute_capability.has_nhwc_layout_support()) ||
+        instr->shape().tuple_shapes(0).dimensions_size() != 4 || !is_enabled) {
+      return kAllNCHW;
+    }
   }
-#elif TENSORFLOW_USE_ROCM
-  bool is_enabled = false;
-  TF_CHECK_OK(tsl::ReadBoolFromEnvVar(
-      "TF_USE_ROCM_NHWC",
-      /*default_val=*/false, &is_enabled));
-  auto rocm_compute_capability = std::get<se::RocmComputeCapability>(gpu_version);
-  if (!isFloat16 || (!rocm_compute_capability.has_nhwc_layout_support()) ||
-      instr->shape().tuple_shapes(0).dimensions_size() != 4 || !is_enabled) {
-    return kAllNCHW;
-  }
-#endif
 
   VLOG(2) << "Using heuristic to figure out layouts for " << instr->ToString();
-
-#if GOOGLE_CUDA
-  // Empirically we've found with Volta and cudnn <= 7.3 that backward-input
-  // convs with stride are significantly faster with NCHW layouts.
-  //
-  // We could have used a mixed layout combination, e.g. (NHWC, NCHW, NCHW),
-  // which on paper gives good performance. However, there are two observations:
-  // * a mixed layout combination is more cuDNN-bug prone, based on empirical
-  //   evidence.
-  // * we've also observed that for mixed layouts, cuDNN transposes data back
-  //   and forth from a different layout combination. If we end up with
-  //   transposes anyway, we prefer to have them in XLA, as they can be fused.
-  if (std::make_tuple(dnn_version.major_version(),
-                      dnn_version.minor_version()) <= std::make_tuple(7, 3) &&
-      instr->custom_call_target() == kCudnnConvBackwardInputCallTarget &&
-      window_util::HasStride(instr->window())) {
-    return kAllNCHW;
-  }
-#endif
 
   // For other Volta f16 convolutions, use NHWC.
   return kAllNHWC;


### PR DESCRIPTION
This PR upstreams changes from [#2467](https://github.com/ROCm/tensorflow-upstream/pull/2467/commits/c3d966e559ffd13f6a473d1b57e606314a456ce8) and also upstreams changes to `gpu_layout_assignment.cc` introduced [here](https://github.com/ROCm/tensorflow-upstream/commit/b34b1eb35c095a16208356913a956256cc419e99) and [here](https://github.com/ROCm/tensorflow-upstream/commit/dfb7dd0b2f7e6c6bbcd3f1dbc9e299be9554b4a7).