### PR TITLE
Run algebraic simplifier after layout normalization

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1424,6 +1424,10 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
 
     if (debug_options.xla_gpu_normalize_layouts()) {
       pipeline.AddPass<LayoutNormalization>(&NormalizeLayoutForGpuCustomCalls);
+      // Remove any redundant operations (such as bitcasts) introduced by layout
+      // normalization.
+      pipeline.AddPass<HloPassFix<AlgebraicSimplifier>>(
+          simplifier_options);
     }
     pipeline.AddPass<BroadcastCanonicalizer>();
 


### PR DESCRIPTION
The newly introduced layout normalization pass (https://github.com/openxla/xla/pull/10811) leaves redundant bitcasts in the HLO graph. In particular, the bitcasts for the host buffer intializations confuse HostOffloadLegalize pass. The legalization pass tries to ensure that host-offloader’s alias analysis can treat dynamic-update-slice instructions as in-place by duplicating (for each use) the broadcast instructions that will be treated as buffer initializations. However, the layout normalization pass l introduces a single bitcast as a user of the broadcast instruction, so the broadcast does not get duplicated.

This patch runs algebraic simplifier after layout normalization to get rid of the redundant bitcasts.