### PR TITLE
[XLA:GPU] Enable Async nccl collective operators in command buffer

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -381,6 +381,7 @@ cc_library(
         "//xla/service/gpu/runtime:nccl_collective_broadcast_thunk",
         "//xla/service/gpu/runtime:nccl_collective_permute_thunk",
         "//xla/service/gpu/runtime:nccl_collective_thunk",
+        "//xla/service/gpu/runtime:nccl_p2p_thunk_common",
         "//xla/service/gpu/runtime:nccl_recv_thunk",
         "//xla/service/gpu/runtime:nccl_send_thunk",
         "//xla/service/gpu/runtime:norm_thunk",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -137,6 +137,7 @@ cc_library(
         ":gemm_thunk",
         ":kernel_thunk",
         ":memset_thunk",
+        ":nccl_collective_thunk",
         ":nccl_all_gather_thunk",
         ":nccl_all_reduce_thunk",
         ":replica_id_thunk",
@@ -1127,7 +1128,6 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@llvm-project//mlir:IR",
-        "@tsl//tsl/lib/gtl:int_type",
         "@tsl//tsl/platform:statusor",
     ],
 )

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -307,6 +307,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
+        "@tsl//tsl/lib/gtl:int_type",
     ],
 )
 

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -1128,6 +1128,7 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@llvm-project//mlir:IR",
+        "@tsl//tsl/lib/gtl:int_type",
         "@tsl//tsl/platform:statusor",
     ],
 )

--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -312,7 +312,6 @@ absl::Status CommandBufferCmdSequence::Record(
       TF_RETURN_IF_ERROR(command_buffer->Barrier(device, execution_scope_id));
       num_recorded_commands.erase(execution_scope_id);
     }
-
     VLOG(5) << " Record command buffer with scope id "
             << execution_scope_id.value();
 
@@ -1711,11 +1710,11 @@ absl::Status CollectiveBroadcastCmd::Record(
         "CollectiveBroadcastCmd requires collective parameters and cliques");
   }
 
-  TF_ASSIGN_OR_RETURN(NcclCommHandleWrapper comm_handle,
-                      GetNcclComm(*execute_params.collective_params,
-                                  *execute_params.collective_cliques,
-                                  config().replica_groups, config().group_mode,
-                                  nccl_stream_id(), GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(
+      NcclCommHandleWrapper comm_handle,
+      GetNcclComm(*execute_params.collective_params,
+                  *execute_params.collective_cliques, config().replica_groups,
+                  config().group_mode, nccl_stream_id(), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(

--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -313,6 +313,9 @@ absl::Status CommandBufferCmdSequence::Record(
       num_recorded_commands.erase(execution_scope_id);
     }
 
+    VLOG(5) << " Record command buffer with scope id "
+            << execution_scope_id.value();
+
     TF_RETURN_IF_ERROR(
         command.cmd->Record(execute_params, record_params, command_buffer));
     ++num_recorded_commands[execution_scope_id];
@@ -1407,10 +1410,29 @@ BarrierCmd::BufferUsageVector BarrierCmd::buffers() { return {}; }
 //===----------------------------------------------------------------------===//
 
 CollectiveCmd::CollectiveCmd(ExecutionStreamId execution_stream_id,
+                             ExecutionStreamId async_from_stream_id,
                              NcclApi* nccl_api, NcclCollectiveConfig config)
     : TracedCommandBufferCmd(execution_stream_id),
+      async_from_stream_id_(async_from_stream_id),
       nccl_api_(nccl_api),
       config_(std::move(config)) {}
+
+absl::Status CollectiveCmd::BarrierIfAsync(
+    se::CommandBuffer* command_buffer, se::StreamExecutor* executor,
+    const CommandBufferCmd::RecordParams& record_params) {
+  if (IsAsync()) {
+    TF_RETURN_IF_ERROR(
+        command_buffer->Barrier(executor,
+                                CommandBufferCmd::GetExecutionScope(
+                                    record_params, async_from_stream_id_),
+                                CommandBufferCmd::GetExecutionScope(
+                                    record_params, execution_stream_id())));
+    VLOG(5) << "Insert Async barrier from stream "
+            << async_from_stream_id_.value() << " to stream "
+            << execution_stream_id().value();
+  }
+  return absl::OkStatus();
+}
 
 absl::Status CollectiveCmd::Prepare(
     const Thunk::PrepareParams& params,
@@ -1436,7 +1458,7 @@ absl::Status CollectiveCmd::Prepare(
       collectives->global_device_id_map ? &local_devices : nullptr);
 
   return resource_requests.AddClique(
-      NcclCliqueKey(std::move(participants), /*stream_id=*/NcclStreamId(0),
+      NcclCliqueKey(std::move(participants), nccl_stream_id(),
                     GetAsyncStreamKind()),
       num_local_participants);
 }
@@ -1446,16 +1468,21 @@ absl::Status CollectiveCmd::Prepare(
 //===----------------------------------------------------------------------===//
 
 AllReduceCmd::AllReduceCmd(
-    ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+    ExecutionStreamId execution_stream_id,
+    ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
     NcclCollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const NcclCollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(execution_stream_id, nccl_api, std::move(config)),
+    : CollectiveCmd(execution_stream_id, async_from_stream_id, nccl_api,
+                    std::move(config)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::Status AllReduceCmd::Record(const Thunk::ExecuteParams& execute_params,
                                   const RecordParams& record_params,
                                   se::CommandBuffer* command_buffer) {
+  TF_RETURN_IF_ERROR(BarrierIfAsync(
+      command_buffer, execute_params.stream->parent(), record_params));
+
   TF_ASSIGN_OR_RETURN(
       std::vector<DeviceBufferPair> device_buffers,
       ConvertToDeviceBuffers(execute_params.buffer_allocations, buffers_,
@@ -1477,13 +1504,11 @@ absl::Status AllReduceCmd::Record(const Thunk::ExecuteParams& execute_params,
         "AllReduceCmd requires collective parameters and cliques");
   }
 
-  // Today when recording collective operations into command buffers we always
-  // use a sync mode and a stream id `0`.
   TF_ASSIGN_OR_RETURN(
       NcclCommHandleWrapper comm_handle,
       GetNcclComm(*execute_params.collective_params,
                   *execute_params.collective_cliques, config().replica_groups,
-                  config().group_mode, NcclStreamId(0), GetAsyncStreamKind()));
+                  config().group_mode, nccl_stream_id(), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1513,16 +1538,21 @@ CommandBufferCmd::BufferUsageVector AllReduceCmd::buffers() {
 //===----------------------------------------------------------------------===//
 
 ReduceScatterCmd::ReduceScatterCmd(
-    ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+    ExecutionStreamId execution_stream_id,
+    ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
     NcclCollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const NcclCollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(execution_stream_id, nccl_api, std::move(config)),
+    : CollectiveCmd(execution_stream_id, async_from_stream_id, nccl_api,
+                    std::move(config)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::Status ReduceScatterCmd::Record(
     const Thunk::ExecuteParams& execute_params,
     const RecordParams& record_params, se::CommandBuffer* command_buffer) {
+  TF_RETURN_IF_ERROR(BarrierIfAsync(
+      command_buffer, execute_params.stream->parent(), record_params));
+
   TF_ASSIGN_OR_RETURN(
       std::vector<DeviceBufferPair> device_buffers,
       ConvertToDeviceBuffers(execute_params.buffer_allocations, buffers_,
@@ -1545,13 +1575,11 @@ absl::Status ReduceScatterCmd::Record(
         "ReduceScatterCmd requires collective parameters and cliques");
   }
 
-  // Today when recording collective operations into command buffers we always
-  // use a sync mode and a stream id `0`.
   TF_ASSIGN_OR_RETURN(
       NcclCommHandleWrapper comm_handle,
       GetNcclComm(*execute_params.collective_params,
                   *execute_params.collective_cliques, config().replica_groups,
-                  config().group_mode, NcclStreamId(0), GetAsyncStreamKind()));
+                  config().group_mode, nccl_stream_id(), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1581,15 +1609,20 @@ CommandBufferCmd::BufferUsageVector ReduceScatterCmd::buffers() {
 //===----------------------------------------------------------------------===//
 
 AllGatherCmd::AllGatherCmd(
-    ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+    ExecutionStreamId execution_stream_id,
+    ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
     NcclCollectiveConfig config,
     absl::Span<const NcclCollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(execution_stream_id, nccl_api, std::move(config)),
+    : CollectiveCmd(execution_stream_id, async_from_stream_id, nccl_api,
+                    std::move(config)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::Status AllGatherCmd::Record(const Thunk::ExecuteParams& execute_params,
                                   const RecordParams& record_params,
                                   se::CommandBuffer* command_buffer) {
+  TF_RETURN_IF_ERROR(BarrierIfAsync(
+      command_buffer, execute_params.stream->parent(), record_params));
+
   TF_ASSIGN_OR_RETURN(
       std::vector<DeviceBufferPair> device_buffers,
       ConvertToDeviceBuffers(execute_params.buffer_allocations, buffers_,
@@ -1610,13 +1643,11 @@ absl::Status AllGatherCmd::Record(const Thunk::ExecuteParams& execute_params,
         "AllGatherCmd requires collective parameters and cliques");
   }
 
-  // Today when recording collective operations into command buffers we always
-  // use a sync mode and a stream id `0`.
   TF_ASSIGN_OR_RETURN(
       NcclCommHandleWrapper comm_handle,
       GetNcclComm(*execute_params.collective_params,
                   *execute_params.collective_cliques, config().replica_groups,
-                  config().group_mode, NcclStreamId(0), GetAsyncStreamKind()));
+                  config().group_mode, nccl_stream_id(), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1645,15 +1676,20 @@ CommandBufferCmd::BufferUsageVector AllGatherCmd::buffers() {
 //===----------------------------------------------------------------------===//
 
 CollectiveBroadcastCmd::CollectiveBroadcastCmd(
-    ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+    ExecutionStreamId execution_stream_id,
+    ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
     NcclCollectiveConfig config,
     absl::Span<const NcclCollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(execution_stream_id, nccl_api, std::move(config)),
+    : CollectiveCmd(execution_stream_id, async_from_stream_id, nccl_api,
+                    std::move(config)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::Status CollectiveBroadcastCmd::Record(
     const Thunk::ExecuteParams& execute_params,
     const RecordParams& record_params, se::CommandBuffer* command_buffer) {
+  TF_RETURN_IF_ERROR(BarrierIfAsync(
+      command_buffer, execute_params.stream->parent(), record_params));
+
   TF_ASSIGN_OR_RETURN(
       std::vector<DeviceBufferPair> device_buffers,
       ConvertToDeviceBuffers(execute_params.buffer_allocations, buffers_,
@@ -1675,13 +1711,11 @@ absl::Status CollectiveBroadcastCmd::Record(
         "CollectiveBroadcastCmd requires collective parameters and cliques");
   }
 
-  // Today when recording collective operations into command buffers we always
-  // use a sync mode and a stream id `0`.
-  TF_ASSIGN_OR_RETURN(
-      NcclCommHandleWrapper comm_handle,
-      GetNcclComm(*execute_params.collective_params,
-                  *execute_params.collective_cliques, config().replica_groups,
-                  config().group_mode, NcclStreamId(0), GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(NcclCommHandleWrapper comm_handle,
+                      GetNcclComm(*execute_params.collective_params,
+                                  *execute_params.collective_cliques,
+                                  config().replica_groups, config().group_mode,
+                                  nccl_stream_id(), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(

--- a/xla/service/gpu/runtime/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime/command_buffer_cmd.h
@@ -924,7 +924,7 @@ class CollectiveCmd : public TracedCommandBufferCmd {
 class AllReduceCmd : public CollectiveCmd {
  public:
   AllReduceCmd(ExecutionStreamId execution_stream_id,
-               ExecutionStreamId collective_stream_id, NcclApi* nccl_api,
+               ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
                NcclCollectiveConfig config, ReductionKind reduction_kind,
                absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 
@@ -950,7 +950,7 @@ class AllReduceCmd : public CollectiveCmd {
 class ReduceScatterCmd : public CollectiveCmd {
  public:
   ReduceScatterCmd(ExecutionStreamId execution_stream_id,
-                   ExecutionStreamId collective_stream_id, NcclApi* nccl_api,
+                   ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
                    NcclCollectiveConfig config, ReductionKind reduction_kind,
                    absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 
@@ -976,7 +976,7 @@ class ReduceScatterCmd : public CollectiveCmd {
 class AllGatherCmd : public CollectiveCmd {
  public:
   AllGatherCmd(ExecutionStreamId execution_stream_id,
-               ExecutionStreamId collective_stream_id, NcclApi* nccl_api,
+               ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
                NcclCollectiveConfig config,
                absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 
@@ -1001,7 +1001,7 @@ class AllGatherCmd : public CollectiveCmd {
 class CollectiveBroadcastCmd : public CollectiveCmd {
  public:
   CollectiveBroadcastCmd(ExecutionStreamId execution_stream_id,
-                         ExecutionStreamId collective_stream_id,
+                         ExecutionStreamId async_from_stream_id,
                          NcclApi* nccl_api, NcclCollectiveConfig config,
                          absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 

--- a/xla/service/gpu/runtime/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime/command_buffer_cmd.h
@@ -208,8 +208,8 @@ class CommandBufferCmd {
 
   // Return the execution scope created from the execution stream id of the
   // thunk which is lowered to current command.
-  se::CommandBuffer::ExecutionScopeId GetExecutionScope(
-      const RecordParams& record_params) const;
+  virtual se::CommandBuffer::ExecutionScopeId GetExecutionScope(
+      const CommandBufferCmd::RecordParams& record_params) const;
 
   std::string_view profile_annotation() const { return profile_annotation_; }
   void set_profile_annotation(std::string_view profile_annotation) {
@@ -880,7 +880,8 @@ class BarrierCmd : public CommandBufferCmd {
 
 class CollectiveCmd : public TracedCommandBufferCmd {
  public:
-  CollectiveCmd(ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+  CollectiveCmd(ExecutionStreamId execution_stream_id,
+                ExecutionStreamId async_from_stream_id, NcclApi* nccl_api,
                 NcclCollectiveConfig config);
 
   absl::Status Prepare(const Thunk::PrepareParams& params,
@@ -890,11 +891,28 @@ class CollectiveCmd : public TracedCommandBufferCmd {
 
   virtual AsyncStreamKind GetAsyncStreamKind() = 0;
 
+  bool IsAsync() const {
+    return async_from_stream_id_ != execution_stream_id();
+  }
+
+  NcclStreamId nccl_stream_id() {
+    return xla::gpu::GetStreamId(IsAsync(), GetAsyncStreamKind());
+  }
+
+  ExecutionStreamId async_from_stream_id() const {
+    return async_from_stream_id_;
+  }
+
+  absl::Status BarrierIfAsync(
+      se::CommandBuffer* command_buffer, se::StreamExecutor* executor,
+      const CommandBufferCmd::RecordParams& record_params);
+
  protected:
   NcclApi* nccl_api() const { return nccl_api_; }
   const NcclCollectiveConfig& config() const { return config_; }
 
  private:
+  ExecutionStreamId async_from_stream_id_;
   NcclApi* nccl_api_;
   NcclCollectiveConfig config_;
 };
@@ -905,7 +923,8 @@ class CollectiveCmd : public TracedCommandBufferCmd {
 
 class AllReduceCmd : public CollectiveCmd {
  public:
-  AllReduceCmd(ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+  AllReduceCmd(ExecutionStreamId execution_stream_id,
+               ExecutionStreamId collective_stream_id, NcclApi* nccl_api,
                NcclCollectiveConfig config, ReductionKind reduction_kind,
                absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 
@@ -930,7 +949,8 @@ class AllReduceCmd : public CollectiveCmd {
 
 class ReduceScatterCmd : public CollectiveCmd {
  public:
-  ReduceScatterCmd(ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+  ReduceScatterCmd(ExecutionStreamId execution_stream_id,
+                   ExecutionStreamId collective_stream_id, NcclApi* nccl_api,
                    NcclCollectiveConfig config, ReductionKind reduction_kind,
                    absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 
@@ -955,7 +975,8 @@ class ReduceScatterCmd : public CollectiveCmd {
 
 class AllGatherCmd : public CollectiveCmd {
  public:
-  AllGatherCmd(ExecutionStreamId execution_stream_id, NcclApi* nccl_api,
+  AllGatherCmd(ExecutionStreamId execution_stream_id,
+               ExecutionStreamId collective_stream_id, NcclApi* nccl_api,
                NcclCollectiveConfig config,
                absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 
@@ -980,6 +1001,7 @@ class AllGatherCmd : public CollectiveCmd {
 class CollectiveBroadcastCmd : public CollectiveCmd {
  public:
   CollectiveBroadcastCmd(ExecutionStreamId execution_stream_id,
+                         ExecutionStreamId collective_stream_id,
                          NcclApi* nccl_api, NcclCollectiveConfig config,
                          absl::Span<const NcclCollectiveThunk::Buffer> buffers);
 

--- a/xla/service/gpu/runtime/nccl_clique_key.h
+++ b/xla/service/gpu/runtime/nccl_clique_key.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/service/global_device_id.h"
+#include "tsl/lib/gtl/int_type.h"
 
 namespace xla::gpu {
 
@@ -61,11 +62,8 @@ constexpr static int64_t kAsyncStreamTotal =
 // Assigns a unique ID to a stream for asynchronous or synchronous execution.
 // These IDs can be used, for example, to look up the NCCL communicator.
 inline NcclStreamId GetStreamId(
-    uint64_t main_stream_id, bool is_async,
-    AsyncStreamKind stream_kind = AsyncStreamKind::kCollective) {
-  return NcclStreamId(is_async ? (main_stream_id << 3) +
-                                     static_cast<uint64_t>(stream_kind) + 1
-                               : main_stream_id << 3);
+    bool is_async, AsyncStreamKind stream_kind = AsyncStreamKind::kCollective) {
+  return NcclStreamId(is_async ? static_cast<uint64_t>(stream_kind) + 1 : 0);
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/service/gpu/runtime/nccl_collective_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.cc
@@ -402,7 +402,7 @@ absl::Status NcclCollectiveThunk::Prepare(const PrepareParams& params,
       xla::GetDebugOptionsFromFlags().xla_gpu_enable_nccl_per_stream_comms();
   return resource_requests.AddClique(
       NcclCliqueKey(std::move(participants),
-                    enable_per_stream_comms ? GetStreamId() : kNoStreamId,
+                    enable_per_stream_comms ? nccl_stream_id() : kNoStreamId,
                     stream_kind),
       num_local_participants);
 }
@@ -435,7 +435,7 @@ bool operator==(const FirstCallRendezvousKey& a,
 Status NcclCollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(1) << absl::StreamFormat("Starting %s %s.", IsAsync() ? "async" : "sync",
                                 Thunk::KindToString(kind()));
-  const NcclStreamId stream_id = GetStreamId();
+  const NcclStreamId stream_id = nccl_stream_id();
   AsyncStreamKind stream_kind = GetAsyncStreamKind();
   TF_ASSIGN_OR_RETURN(
       NcclCommHandleWrapper comm_handle,
@@ -514,8 +514,11 @@ std::string NcclCollectiveThunk::GetDeviceString(
 
 NcclCollectiveDoneThunk::NcclCollectiveDoneThunk(
     Thunk::Kind kind, ThunkInfo thunk_info,
-    std::shared_ptr<NcclCollectiveThunk::AsyncEvents> async_events)
-    : Thunk(kind, std::move(thunk_info)), async_events_(async_events) {}
+    std::shared_ptr<NcclCollectiveThunk::AsyncEvents> async_events,
+    AsyncStreamKind async_stream_kind)
+    : Thunk(kind, std::move(thunk_info)),
+      async_events_(async_events),
+      async_stream_kind_(async_stream_kind) {}
 
 absl::Status NcclCollectiveDoneThunk::ExecuteOnStream(
     const ExecuteParams& params) {

--- a/xla/service/gpu/runtime/nccl_collective_thunk.h
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.h
@@ -180,15 +180,6 @@ class NcclCollectiveThunk : public Thunk {
     return xla::gpu::GetStreamId(IsAsync(), GetAsyncStreamKind());
   }
 
-  // Left shifting the steam id by 3 bits as to distinguish the async stream
-  // id that is launched from the main stream. i.e.
-  // main_stream_id << 3 :  thunk's execution stream id
-  // main_stream_id << 3 + 1 :  async collective stream id launched from
-  // execution stream
-  // main_stream_id << 3 + 2 :  async P2P0 send/recv stream id launched from
-  // execution stream
-  // main_stream_id << 3 + 3 :  async P2P1 recv/recv stream id launched from
-  // execution stream
   ExecutionStreamId nccl_execution_stream_id() const {
     return ExecutionStreamId(execution_stream_id().value() +
                              nccl_stream_id().value());

--- a/xla/service/gpu/runtime/thunk.cc
+++ b/xla/service/gpu/runtime/thunk.cc
@@ -354,7 +354,7 @@ Thunk::ThunkInfo Thunk::ThunkInfo::WithProfileAnnotation(
   if (gpu_backend_config.ok()) {
     thunk_info.execution_stream_id =
         std::max<uint64_t>(kDefaultExecutionStreamId.value(),
-                           uint64_t(gpu_backend_config->operation_queue_id()));
+                           gpu_backend_config->operation_queue_id());
   }
   return thunk_info;
 }

--- a/xla/service/gpu/runtime/thunk.cc
+++ b/xla/service/gpu/runtime/thunk.cc
@@ -352,18 +352,9 @@ Thunk::ThunkInfo Thunk::ThunkInfo::WithProfileAnnotation(
   thunk_info.profile_annotation = instr->name();
   auto gpu_backend_config = instr->backend_config<GpuBackendConfig>();
   if (gpu_backend_config.ok()) {
-    // Left shifting the steam id by 3 bits as to distinguish the async stream
-    // id that is launched from the main stream. i.e.
-    // main_stream_id << 3 :  thunk's execution stream id
-    // main_stream_id << 3 + 1 :  async collective stream id launched from
-    // execution stream
-    // main_stream_id << 3 + 2 :  async P2P0 send/recv stream id launched from
-    // execution stream
-    // main_stream_id << 3 + 3 :  async P2P1 recv/recv stream id launched from
-    // execution stream
     thunk_info.execution_stream_id =
         std::max<uint64_t>(kDefaultExecutionStreamId.value(),
-                 uint64_t(gpu_backend_config->operation_queue_id())) << 3;
+                           uint64_t(gpu_backend_config->operation_queue_id()));
   }
   return thunk_info;
 }

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -44,7 +44,6 @@ limitations under the License.
 #include "xla/service/service_executable_run_options.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "tsl/lib/gtl/int_type.h"
 
 namespace xla {
 namespace gpu {

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -44,6 +44,7 @@ limitations under the License.
 #include "xla/service/service_executable_run_options.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "tsl/lib/gtl/int_type.h"
 
 namespace xla {
 namespace gpu {


### PR DESCRIPTION
This PR enables async collective operators (AllReduceCmd, ReduceScatterCmd, AllGatherCmd, CollectiveBroadcastCmd) in command buffers. 

The idea is to translate collective-start thunk to command buffer nccl operator with different execution scope id, and insert a barrier from the original execution scope to the nccl execution scope. on collective-done thunk, it translate into command buffer Barrier command that does synchronization from nccl execution scope to main execution scope.