### PR TITLE
Implement async dynamic slicing

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -5942,6 +5942,7 @@ cc_library(
     hdrs = ["stream_attribute_annotator.h"],
     deps = [
         ":backend_configs_cc",
+        ":gpu_fusible",
         "//xla:comparison_util",
         "//xla:status",
         "//xla:statusor",


### PR DESCRIPTION
This implements async dynamic-slice and dynamic-update-slice for host memory offloading on GPU.

Since the emitter does not understand dynamic slicing instructions in async computation, we wrap them in a fusion node and mark them for execution on a different stream. This is all we need to execute the offloading of slices asynchronously.