### PR TITLE
[XLA GPU] Add command buffer BarrierCmd

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -355,8 +355,8 @@ class ResourceRequests : public Thunk::ResourceRequests {
       if (b.key.devices().size() > a.key.devices().size()) return false;
 
       // If cliques have the same size prefer cliques with smaller stream id.
-      if (a.key.stream_id() < b.key.stream_id()) return true;
-      if (b.key.stream_id() < a.key.stream_id()) return false;
+      if (a.key.stream_id().value() < b.key.stream_id().value()) return true;
+      if (b.key.stream_id().value() < a.key.stream_id().value()) return false;
 
       // Prefer cliques with smaller id (comes earlier in execution order).
       return a.id < b.id;

--- a/xla/service/gpu/nccl_clique_key.cc
+++ b/xla/service/gpu/nccl_clique_key.cc
@@ -37,7 +37,7 @@ namespace xla::gpu {
 //===----------------------------------------------------------------------===//
 
 NcclCliqueKey::NcclCliqueKey(std::vector<GlobalDeviceId> devices,
-                             int64_t stream_id, AsyncStreamKind stream_kind)
+                             uint64_t stream_id, AsyncStreamKind stream_kind)
     : devices_(std::move(devices)),
       stream_id_(stream_id),
       stream_kind_(stream_kind) {}
@@ -46,7 +46,7 @@ absl::Span<const GlobalDeviceId> NcclCliqueKey::devices() const {
   return devices_;
 }
 
-int64_t NcclCliqueKey::stream_id() const { return stream_id_; }
+uint64_t NcclCliqueKey::stream_id() const { return stream_id_; }
 
 std::optional<int64_t> NcclCliqueKey::rank(GlobalDeviceId id) const {
   if (auto it = absl::c_find(devices_, id); it != devices_.end()) {

--- a/xla/service/gpu/nccl_clique_key.cc
+++ b/xla/service/gpu/nccl_clique_key.cc
@@ -37,7 +37,7 @@ namespace xla::gpu {
 //===----------------------------------------------------------------------===//
 
 NcclCliqueKey::NcclCliqueKey(std::vector<GlobalDeviceId> devices,
-                             uint64_t stream_id, AsyncStreamKind stream_kind)
+                             NcclStreamId stream_id, AsyncStreamKind stream_kind)
     : devices_(std::move(devices)),
       stream_id_(stream_id),
       stream_kind_(stream_kind) {}
@@ -46,7 +46,7 @@ absl::Span<const GlobalDeviceId> NcclCliqueKey::devices() const {
   return devices_;
 }
 
-uint64_t NcclCliqueKey::stream_id() const { return stream_id_; }
+NcclStreamId NcclCliqueKey::stream_id() const { return stream_id_; }
 
 std::optional<int64_t> NcclCliqueKey::rank(GlobalDeviceId id) const {
   if (auto it = absl::c_find(devices_, id); it != devices_.end()) {
@@ -64,7 +64,7 @@ bool NcclCliqueKey::IsSubsetOf(const NcclCliqueKey& other) const {
 
 std::string NcclCliqueKey::ToString() const {
   return absl::StrFormat("devices=[%s]; stream=%d",
-                         GlobalDeviceIdsToString(devices_), stream_id_);
+                         GlobalDeviceIdsToString(devices_), stream_id_.value());
 }
 
 bool operator==(const NcclCliqueKey& a, const NcclCliqueKey& b) {
@@ -78,7 +78,7 @@ bool operator<(const NcclCliqueKey& a, const NcclCliqueKey& b) {
   if (a.devices_ < b.devices_) return true;
   if (b.devices_ < a.devices_) return false;
 
-  return a.stream_id_ < b.stream_id_;
+  return a.stream_id_.value() < b.stream_id_.value();
 }
 
 bool operator>(const NcclCliqueKey& a, const NcclCliqueKey& b) {
@@ -90,7 +90,7 @@ bool operator>(const NcclCliqueKey& a, const NcclCliqueKey& b) {
 
   // We still use `<` to order by stream id as we want to acquire sync cliques
   // before async ones.
-  return a.stream_id_ < b.stream_id_;
+  return a.stream_id_.value() < b.stream_id_.value();
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/service/gpu/nccl_clique_key.h
+++ b/xla/service/gpu/nccl_clique_key.h
@@ -30,6 +30,8 @@ limitations under the License.
 
 namespace xla::gpu {
 
+TSL_LIB_GTL_DEFINE_INT_TYPE(NcclStreamId, uint64_t);
+
 // A standalone library without any dependencies on NCCL that allows us to
 // include this header in all of XLA without worrying about NCCL availability.
 
@@ -58,12 +60,12 @@ constexpr static int64_t kAsyncStreamTotal =
 
 // Assigns a unique ID to a stream for asynchronous or synchronous execution.
 // These IDs can be used, for example, to look up the NCCL communicator.
-inline uint64_t GetStreamId(
+inline NcclStreamId GetStreamId(
     uint64_t main_stream_id, bool is_async,
     AsyncStreamKind stream_kind = AsyncStreamKind::kCollective) {
-  return is_async
-             ? (main_stream_id << 3) + static_cast<uint64_t>(stream_kind) + 1
-             : main_stream_id << 3;
+  return NcclStreamId(is_async ? (main_stream_id << 3) +
+                                     static_cast<uint64_t>(stream_kind) + 1
+                               : main_stream_id << 3);
 }
 
 //===----------------------------------------------------------------------===//
@@ -78,12 +80,13 @@ inline uint64_t GetStreamId(
 class NcclCliqueKey {
  public:
   explicit NcclCliqueKey(
-      std::vector<GlobalDeviceId> devices, uint64_t stream_id = 0,
+      std::vector<GlobalDeviceId> devices,
+      NcclStreamId stream_id = NcclStreamId(0),
       AsyncStreamKind stream_kind = AsyncStreamKind::kCollective);
 
   absl::Span<const GlobalDeviceId> devices() const;
 
-  uint64_t stream_id() const;
+  NcclStreamId stream_id() const;
 
   // Returns the rank of the global device in the clique.
   std::optional<int64_t> rank(GlobalDeviceId id) const;
@@ -108,7 +111,7 @@ class NcclCliqueKey {
 
  private:
   std::vector<GlobalDeviceId> devices_;
-  uint64_t stream_id_;
+  NcclStreamId stream_id_;
   AsyncStreamKind stream_kind_;
 };
 

--- a/xla/service/gpu/nccl_clique_key_test.cc
+++ b/xla/service/gpu/nccl_clique_key_test.cc
@@ -30,10 +30,10 @@ TEST(NcclCliqueKeyTest, IsSubsetOf) {
   GlobalDeviceId id2 = GlobalDeviceId(2);
   GlobalDeviceId id3 = GlobalDeviceId(3);
 
-  NcclCliqueKey key0({id0, id1}, 0);
-  NcclCliqueKey key1({id0, id1, id2, id3}, 0);
-  NcclCliqueKey key2({id0, id1, id2, id3}, 1);
-  NcclCliqueKey key3({id1, id2, id3}, 0);
+  NcclCliqueKey key0({id0, id1}, NcclStreamId(0));
+  NcclCliqueKey key1({id0, id1, id2, id3}, NcclStreamId(0));
+  NcclCliqueKey key2({id0, id1, id2, id3}, NcclStreamId(1));
+  NcclCliqueKey key3({id1, id2, id3}, NcclStreamId(0));
 
   EXPECT_TRUE(key0.IsSubsetOf(key1));
   EXPECT_FALSE(key0.IsSubsetOf(key2));
@@ -46,8 +46,8 @@ TEST(NcclCliqueKeyTest, Compare) {
   GlobalDeviceId id2 = GlobalDeviceId(2);
   GlobalDeviceId id3 = GlobalDeviceId(3);
 
-  NcclCliqueKey key0({id0, id1}, 0);
-  NcclCliqueKey key1({id1, id2, id3}, 0);
+  NcclCliqueKey key0({id0, id1}, NcclStreamId(0));
+  NcclCliqueKey key1({id1, id2, id3}, NcclStreamId(0));
 
   EXPECT_LT(key0, key1);
   EXPECT_GT(key1, key0);
@@ -59,8 +59,8 @@ TEST(NcclCliqueKeyTest, BtreeIterationOrder) {
   GlobalDeviceId id2 = GlobalDeviceId(2);
   GlobalDeviceId id3 = GlobalDeviceId(3);
 
-  NcclCliqueKey key0({id0, id2}, 0);
-  NcclCliqueKey key1({id0, id1, id2, id3}, 0);
+  NcclCliqueKey key0({id0, id2}, NcclStreamId(0));
+  NcclCliqueKey key1({id0, id1, id2, id3}, NcclStreamId(0));
 
   absl::btree_map<NcclCliqueKey, int64_t, std::greater<NcclCliqueKey>> map;
   map[key0] = 0;

--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -1436,7 +1436,7 @@ absl::Status CollectiveCmd::Prepare(
       collectives->global_device_id_map ? &local_devices : nullptr);
 
   return resource_requests.AddClique(
-      NcclCliqueKey(std::move(participants), /*stream_id=*/0,
+      NcclCliqueKey(std::move(participants), /*stream_id=*/NcclStreamId(0),
                     GetAsyncStreamKind()),
       num_local_participants);
 }
@@ -1483,7 +1483,7 @@ absl::Status AllReduceCmd::Record(const Thunk::ExecuteParams& execute_params,
                       GetNcclComm(*execute_params.collective_params,
                                   *execute_params.collective_cliques,
                                   config().replica_groups, config().group_mode,
-                                  /*stream_id=*/0, GetAsyncStreamKind()));
+                                  NcclStreamId(0), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1551,7 +1551,7 @@ absl::Status ReduceScatterCmd::Record(
                       GetNcclComm(*execute_params.collective_params,
                                   *execute_params.collective_cliques,
                                   config().replica_groups, config().group_mode,
-                                  /*stream_id=*/0, GetAsyncStreamKind()));
+                                  NcclStreamId(0), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1616,7 +1616,7 @@ absl::Status AllGatherCmd::Record(const Thunk::ExecuteParams& execute_params,
                       GetNcclComm(*execute_params.collective_params,
                                   *execute_params.collective_cliques,
                                   config().replica_groups, config().group_mode,
-                                  /*stream_id=*/0, GetAsyncStreamKind()));
+                                  NcclStreamId(0), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(
@@ -1681,7 +1681,7 @@ absl::Status CollectiveBroadcastCmd::Record(
                       GetNcclComm(*execute_params.collective_params,
                                   *execute_params.collective_cliques,
                                   config().replica_groups, config().group_mode,
-                                  /*stream_id=*/0, GetAsyncStreamKind()));
+                                  NcclStreamId(0), GetAsyncStreamKind()));
   NcclApi::NcclCommHandle comm = comm_handle.comm_handle;
   // Use custom allocator for persistent execution plans.
   NcclApi::ScopedPersistentPlanAllocator scoped_allocator(

--- a/xla/service/gpu/runtime/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime/command_buffer_cmd.h
@@ -200,8 +200,14 @@ class CommandBufferCmd {
   // Returns true if command implemented as a nested command buffer.
   virtual bool IsNestedCommandBuffer() const { return false; }
 
-  // Returns a command execution scope computed from the command stream id and
-  // the default command buffer execution scope.
+  // Returns a command execution scope created from the specified
+  // 'execution_stream_id'.
+  se::CommandBuffer::ExecutionScopeId GetExecutionScope(
+      const RecordParams& record_params,
+      ExecutionStreamId execution_stream_id) const;
+
+  // Return the execution scope created from the execution stream id of the
+  // thunk which is lowered to current command.
   se::CommandBuffer::ExecutionScopeId GetExecutionScope(
       const RecordParams& record_params) const;
 
@@ -844,6 +850,28 @@ class CustomCallCmd : public CommandBufferCmd {
 
   std::vector<std::optional<Slice>> operands_;
   std::vector<std::optional<Slice>> results_;
+};
+
+//===----------------------------------------------------------------------===//
+// BarrierCmd
+// BarrierCmd insert a barrier from the execution scope created from the
+// 'from_stream_id' to the execution scope created from the
+// 'execution_stream_id', e.g. Async operator lowered to command buffer requires
+// a barrier from the launching stream to the async operator's execution stream.
+//===----------------------------------------------------------------------===//
+class BarrierCmd : public CommandBufferCmd {
+ public:
+  BarrierCmd(ExecutionStreamId execution_stream_id,
+             ExecutionStreamId from_stream_id);
+
+  absl::Status Record(const Thunk::ExecuteParams& execute_params,
+                      const RecordParams& record_params,
+                      se::CommandBuffer* command_buffer) override;
+
+  BufferUsageVector buffers() override;
+
+ private:
+  ExecutionStreamId from_stream_id_;
 };
 
 //===----------------------------------------------------------------------===//

--- a/xla/service/gpu/runtime/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime/command_buffer_cmd.h
@@ -853,12 +853,12 @@ class CustomCallCmd : public CommandBufferCmd {
 };
 
 //===----------------------------------------------------------------------===//
-// BarrierCmd
 // BarrierCmd insert a barrier from the execution scope created from the
 // 'from_stream_id' to the execution scope created from the
 // 'execution_stream_id', e.g. Async operator lowered to command buffer requires
 // a barrier from the launching stream to the async operator's execution stream.
 //===----------------------------------------------------------------------===//
+
 class BarrierCmd : public CommandBufferCmd {
  public:
   BarrierCmd(ExecutionStreamId execution_stream_id,

--- a/xla/service/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd_test.cc
@@ -227,6 +227,74 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
 }
 
+TEST(CommandBufferCmdTest, BarrierCmd) {
+  se::StreamExecutor* executor = GpuExecutor();
+
+  auto stream = executor->CreateStream().value();
+
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+
+  // Prepare arguments: a=42, b=0
+  se::DeviceMemory<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
+  se::DeviceMemory<int32_t> b = executor->AllocateArray<int32_t>(length, 0);
+  se::DeviceMemory<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
+  se::DeviceMemory<int32_t> d = executor->AllocateArray<int32_t>(length, 0);
+  se::DeviceMemory<int32_t> e = executor->AllocateArray<int32_t>(length, 0);
+
+  TF_ASSERT_OK(stream->Memset32(&a, 42, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&b, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&c, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&d, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&e, byte_length));
+
+  // Prepare buffer allocations for recording command buffer.
+  BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
+  BufferAllocation alloc_b(/*index=*/1, byte_length, /*color=*/0);
+  BufferAllocation alloc_c(/*index=*/2, byte_length, /*color=*/0);
+  BufferAllocation alloc_d(/*index=*/3, byte_length, /*color=*/0);
+  BufferAllocation alloc_e(/*index=*/4, byte_length, /*color=*/0);
+
+  BufferAllocation::Slice slice_a(&alloc_a, 0, byte_length);
+  BufferAllocation::Slice slice_b(&alloc_b, 0, byte_length);
+  BufferAllocation::Slice slice_c(&alloc_c, 0, byte_length);
+  BufferAllocation::Slice slice_d(&alloc_d, 0, byte_length);
+  BufferAllocation::Slice slice_e(&alloc_e, 0, byte_length);
+
+  // Prepare commands sequence for constructing command buffer.
+  CommandBufferCmdSequence commands;
+  commands.Emplace<MemcpyDeviceToDeviceCmd>(s0, slice_b, slice_a, byte_length);
+  commands.Emplace<BarrierCmd>(s1, s0);
+  commands.Emplace<MemcpyDeviceToDeviceCmd>(s1, slice_c, slice_b, byte_length);
+  commands.Emplace<BarrierCmd>(s0, s1);
+  commands.Emplace<MemcpyDeviceToDeviceCmd>(s0, slice_d, slice_c, byte_length);
+  commands.Emplace<BarrierCmd>(s1, s0);
+  commands.Emplace<MemcpyDeviceToDeviceCmd>(s1, slice_e, slice_d, byte_length);
+
+  ServiceExecutableRunOptions run_options;
+  BufferAllocations allocations({a, b, c, d, e}, 0, executor->GetAllocator());
+
+  CommandBufferCmd::StateManager state;
+
+  Thunk::ExecuteParams params =
+      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
+                                   stream.get(), {}, nullptr, nullptr);
+
+  CommandBufferCmd::RecordParams record_params = {state};
+
+  auto command_buffer = se::CommandBuffer::Create(executor).value();
+  TF_ASSERT_OK(commands.Record(params, record_params, command_buffer.get()));
+
+  // Execute command buffer and verify that it copied the memory.
+  TF_ASSERT_OK(executor->Submit(stream.get(), *command_buffer));
+
+  // Copy `b` data back to host.
+  std::vector<int32_t> dst(4, 0);
+  TF_ASSERT_OK(stream->Memcpy(dst.data(), e, byte_length));
+
+  ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
+}
+
 TEST(CommandBufferCmdTest, LaunchCmd) {
   se::StreamExecutor* executor = GpuExecutor();
 

--- a/xla/service/gpu/runtime/nccl_collective_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.cc
@@ -68,7 +68,7 @@ namespace gpu {
 namespace {
 
 static constexpr int64_t kCollectiveMemorySpaceColor = 1;
-static constexpr int64_t kNoStreamId = 0;
+static constexpr uint64_t kNoStreamId = 0;
 
 bool IsTypeSupportedByNccl(PrimitiveType element_type,
                            Thunk::Kind reduction_op) {
@@ -221,7 +221,7 @@ NcclCollectiveThunk::NcclCollectiveThunk(Kind kind, ThunkInfo thunk_info,
 static absl::StatusOr<NcclCliqueKey> GetNcclCliqueKey(
     const Thunk::CollectiveExecuteParams& params,
     const std::vector<ReplicaGroup>& replica_groups,
-    CollectiveOpGroupMode group_mode, int64_t stream_id,
+    CollectiveOpGroupMode group_mode, uint64_t stream_id,
     AsyncStreamKind stream_kind) {
   GlobalDeviceId global_device_id = params.global_device_id;
 
@@ -248,7 +248,7 @@ absl::StatusOr<NcclCommHandleWrapper> GetNcclComm(
     const Thunk::CollectiveExecuteParams& params,
     const Thunk::CollectiveCliques& collective_cliques,
     const std::vector<ReplicaGroup>& replica_groups,
-    CollectiveOpGroupMode group_mode, int64_t stream_id,
+    CollectiveOpGroupMode group_mode, uint64_t stream_id,
     AsyncStreamKind stream_kind) {
   TF_ASSIGN_OR_RETURN(NcclCliqueKey clique_key,
                       GetNcclCliqueKey(params, replica_groups, group_mode,
@@ -435,7 +435,7 @@ bool operator==(const FirstCallRendezvousKey& a,
 Status NcclCollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(1) << absl::StreamFormat("Starting %s %s.", IsAsync() ? "async" : "sync",
                                 Thunk::KindToString(kind()));
-  const int64_t stream_id = GetStreamId();
+  const uint64_t stream_id = GetStreamId();
   AsyncStreamKind stream_kind = GetAsyncStreamKind();
   TF_ASSIGN_OR_RETURN(
       NcclCommHandleWrapper comm_handle,

--- a/xla/service/gpu/runtime/nccl_collective_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.cc
@@ -68,7 +68,7 @@ namespace gpu {
 namespace {
 
 static constexpr int64_t kCollectiveMemorySpaceColor = 1;
-static constexpr uint64_t kNoStreamId = 0;
+static constexpr NcclStreamId kNoStreamId = NcclStreamId(0);
 
 bool IsTypeSupportedByNccl(PrimitiveType element_type,
                            Thunk::Kind reduction_op) {
@@ -221,7 +221,7 @@ NcclCollectiveThunk::NcclCollectiveThunk(Kind kind, ThunkInfo thunk_info,
 static absl::StatusOr<NcclCliqueKey> GetNcclCliqueKey(
     const Thunk::CollectiveExecuteParams& params,
     const std::vector<ReplicaGroup>& replica_groups,
-    CollectiveOpGroupMode group_mode, uint64_t stream_id,
+    CollectiveOpGroupMode group_mode, NcclStreamId stream_id,
     AsyncStreamKind stream_kind) {
   GlobalDeviceId global_device_id = params.global_device_id;
 
@@ -248,7 +248,7 @@ absl::StatusOr<NcclCommHandleWrapper> GetNcclComm(
     const Thunk::CollectiveExecuteParams& params,
     const Thunk::CollectiveCliques& collective_cliques,
     const std::vector<ReplicaGroup>& replica_groups,
-    CollectiveOpGroupMode group_mode, uint64_t stream_id,
+    CollectiveOpGroupMode group_mode, NcclStreamId stream_id,
     AsyncStreamKind stream_kind) {
   TF_ASSIGN_OR_RETURN(NcclCliqueKey clique_key,
                       GetNcclCliqueKey(params, replica_groups, group_mode,
@@ -435,7 +435,7 @@ bool operator==(const FirstCallRendezvousKey& a,
 Status NcclCollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(1) << absl::StreamFormat("Starting %s %s.", IsAsync() ? "async" : "sync",
                                 Thunk::KindToString(kind()));
-  const uint64_t stream_id = GetStreamId();
+  const NcclStreamId stream_id = GetStreamId();
   AsyncStreamKind stream_kind = GetAsyncStreamKind();
   TF_ASSIGN_OR_RETURN(
       NcclCommHandleWrapper comm_handle,

--- a/xla/service/gpu/runtime/nccl_collective_thunk.h
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.h
@@ -197,8 +197,9 @@ class NcclCollectiveThunk : public Thunk {
 
  private:
   bool IsAsync() const { return async_events_ != nullptr; }
-  int64_t GetStreamId() const {
-    return xla::gpu::GetStreamId(IsAsync(), GetAsyncStreamKind());
+  uint64_t GetStreamId() const {
+    return xla::gpu::GetStreamId(execution_stream_id().value(), IsAsync(),
+                                 GetAsyncStreamKind());
   }
 
   NcclApi* nccl_api_;
@@ -279,7 +280,7 @@ absl::StatusOr<NcclCommHandleWrapper> GetNcclComm(
     const Thunk::CollectiveExecuteParams& params,
     const Thunk::CollectiveCliques& collective_cliques,
     const std::vector<ReplicaGroup>& replica_groups,
-    CollectiveOpGroupMode group_mode, int64_t stream_id,
+    CollectiveOpGroupMode group_mode, uint64_t stream_id,
     AsyncStreamKind stream_kind);
 
 struct DeviceBufferPair {

--- a/xla/service/gpu/runtime/nccl_collective_thunk.h
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.h
@@ -197,7 +197,7 @@ class NcclCollectiveThunk : public Thunk {
 
  private:
   bool IsAsync() const { return async_events_ != nullptr; }
-  uint64_t GetStreamId() const {
+  NcclStreamId GetStreamId() const {
     return xla::gpu::GetStreamId(execution_stream_id().value(), IsAsync(),
                                  GetAsyncStreamKind());
   }
@@ -280,7 +280,7 @@ absl::StatusOr<NcclCommHandleWrapper> GetNcclComm(
     const Thunk::CollectiveExecuteParams& params,
     const Thunk::CollectiveCliques& collective_cliques,
     const std::vector<ReplicaGroup>& replica_groups,
-    CollectiveOpGroupMode group_mode, uint64_t stream_id,
+    CollectiveOpGroupMode group_mode, NcclStreamId stream_id,
     AsyncStreamKind stream_kind);
 
 struct DeviceBufferPair {

--- a/xla/service/gpu/runtime/thunk.cc
+++ b/xla/service/gpu/runtime/thunk.cc
@@ -352,8 +352,8 @@ Thunk::ThunkInfo Thunk::ThunkInfo::WithProfileAnnotation(
   auto gpu_backend_config = instr->backend_config<GpuBackendConfig>();
   if (gpu_backend_config.ok()) {
     thunk_info.execution_stream_id =
-        std::max(kDefaultExecutionStreamId.value(),
-                 gpu_backend_config->operation_queue_id());
+        std::max<uint64_t>(kDefaultExecutionStreamId.value(),
+                 uint64_t(gpu_backend_config->operation_queue_id()));
   }
   return thunk_info;
 }

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -49,7 +49,7 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-TSL_LIB_GTL_DEFINE_INT_TYPE(ExecutionStreamId, int64_t);
+TSL_LIB_GTL_DEFINE_INT_TYPE(ExecutionStreamId, uint64_t);
 
 // Thunk acts as the bridge between IrEmitter and GpuExecutable. It stores the
 // metadata IrEmitter generates for GpuExecutable to invoke an HloInstruction.

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -115,7 +115,7 @@ class CommandBuffer {
   //  synchronization in other direction. For CUDA/ROCM backend it has the same
   //  semantics as stream wait operation.
   //
-  TSL_LIB_GTL_DEFINE_INT_TYPE(ExecutionScopeId, int64_t);
+  TSL_LIB_GTL_DEFINE_INT_TYPE(ExecutionScopeId, uint64_t);
   static constexpr auto kDefaulExecutionScope = ExecutionScopeId(0);
 
   // Builder constructs nested command buffers owned by a parent command buffer.


### PR DESCRIPTION
This PR adds barrier command into command buffer. The description for the command: 

//===----------------------------------------------------------------------===//
// BarrierCmd
// BarrierCmd insert a barrier from the execution scope created from the
// 'from_stream_id' to the execution scope created from the
// 'execution_stream_id', e.g. Async operator lowered to command buffer requires
// a barrier from the launching stream to the async operator's execution stream.
//===----------------------------------------------------------------------===//

This PR is a split of PR: https://github.com/openxla/xla/pull/11348