### PR TITLE
[ROCm] Build fix

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -792,7 +792,7 @@ dnn::DnnSupport* GpuExecutor::AsDnn() {
   }
   PluginRegistry* registry = PluginRegistry::Instance();
   absl::StatusOr<PluginRegistry::DnnFactory> status =
-      registry->GetFactory<PluginRegistry::DnnFactory>(cuda::kCudaPlatformId);
+      registry->GetFactory<PluginRegistry::DnnFactory>(rocm::kROCmPlatformId);
   if (!status.ok()) {
     LOG(ERROR) << "Unable to retrieve DNN factory: "
                << status.status().message();

--- a/xla/tests/complex_unary_op_samples.h
+++ b/xla/tests/complex_unary_op_samples.h
@@ -29,6 +29,9 @@ limitations under the License.
 
 namespace complex_unary_op_samples {
 
+template<class>
+constexpr bool dependent_false = false;
+
 template <typename T, int default_dps_deficiency = 0>
 struct Log1p {
   typedef std::complex<T> InputType;
@@ -1438,7 +1441,7 @@ struct Log1p {
           /* 288 */ {{inf, inf}, {inf, pi_4}, 1.e+00}};
       return table;
     } else {
-      static_assert(false); /* unreachable */
+      static_assert(dependent_false<T>); /* unreachable */
     }
   }
 };

--- a/xla/tests/complex_unary_op_test.cc
+++ b/xla/tests/complex_unary_op_test.cc
@@ -29,6 +29,9 @@ limitations under the License.
 namespace xla {
 namespace {
 
+template<class>
+constexpr bool dependent_false = false;
+
 class ComplexUnaryOpTest : public ClientLibraryTestBase {
  protected:
   template <typename T, size_t index, typename... Types>
@@ -64,7 +67,7 @@ class ComplexUnaryOpTest : public ClientLibraryTestBase {
     } else if constexpr (std::is_same_v<FloatType, double>) {
       atol = std::ldexp(1e-15f, precision_deficiency);
     } else {
-      static_assert(false);  // unreachable
+      static_assert(dependent_false<FloatType>);
     }
 
     XlaBuilder builder(TestName());


### PR DESCRIPTION
This contains two fixes:
* A compilation fix for stream_executor/rocm/rocm_executor.cc after it got broken by  the commit https://github.com/openxla/xla/commit/3c5cf0ac2adbc0a651d3a2ec822e47927218b153
* A workaround that allows static_assert(false) to be compiled with compilers not implementing https://cplusplus.github.io/CWG/issues/2518.html