### PR TITLE
[gpu] Add address computation fusion for RS->DUS pattern

### DIFF
--- a/xla/service/gpu/address_computation_fusion_rewriter.cc
+++ b/xla/service/gpu/address_computation_fusion_rewriter.cc
@@ -409,15 +409,19 @@ absl::StatusOr<bool> AddressComputationFusionRewriter::Run(
                       std::pair<UseDefDataflowPaths, DefUseDataflowPaths>>
       matches;
 
-  // Collect all potential custom call matches in the non-fusion computations.
+  // Collect all potential custom call and reduce-scatter --> dus matches in the
+  // non-fusion computations.
   for (HloComputation* computation : module->computations()) {
     if (computation->IsFusionComputation()) continue;
     for (HloInstruction* instr : computation->instructions()) {
-      if (IsLegacyCublasMatmul(*instr) ||
-          (IsCustomCall(instr, platform_name_))) {
-        UseDefDataflowPaths sliced_operand_paths = GetSlicedOperandPaths(instr);
-        bool has_sliced_operand_paths = sliced_operand_paths.size() > 1;
-
+      UseDefDataflowPaths sliced_operand_paths = {instr};
+      bool has_sliced_operand_paths = false;
+      if (IsLegacyCublasMatmul(*instr) || IsCustomCall(instr, platform_name_)) {
+        sliced_operand_paths = GetSlicedOperandPaths(instr);
+        has_sliced_operand_paths = sliced_operand_paths.size() > 1;
+      }
+      if (instr->opcode() == HloOpcode::kReduceScatter ||
+          IsLegacyCublasMatmul(*instr) || IsCustomCall(instr, platform_name_)) {
         DefUseDataflowPaths sliced_user_paths = GetSlicedUserPaths(instr);
         bool has_sliced_user_paths = absl::c_any_of(
             sliced_user_paths,


### PR DESCRIPTION
This patch recognizes a reduce-scatter operation that is used by a dynamic-update-slice operation. It then fuses this operation to an address-computation fusion.
For example, the following pattern is extracted to a fusion:
```
reduce-scatter = f16[64,128] reduce-scatter(%p0), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
dynamic-update-slice = f16[128,128] dynamic-update-slice(%p1, reduce-scatter, %p3, constant.718)
``` 