### PR TITLE
Force CB to use global device ids

### DIFF
--- a/xla/client/xla_builder.cc
+++ b/xla/client/xla_builder.cc
@@ -3916,13 +3916,13 @@ XlaOp XlaBuilder::AllToAllTuple(
 
 XlaOp XlaBuilder::CollectiveBroadcast(
     XlaOp operand, absl::Span<const ReplicaGroup> replica_groups,
-    const std::optional<ChannelHandle>& channel_id) {
-  return CollectiveBroadcastImpl(operand, replica_groups, channel_id);
+    const std::optional<ChannelHandle>& channel_id, const std::optional<bool> use_global_device_ids) {
+  return CollectiveBroadcastImpl(operand, replica_groups, channel_id, use_global_device_ids);
 }
 
 XlaOp XlaBuilder::CollectiveBroadcastImpl(
     XlaOp operand, absl::Span<const ReplicaGroup> replica_groups,
-    const std::optional<ChannelHandle>& channel_id) {
+    const std::optional<ChannelHandle>& channel_id, const std::optional<bool> use_global_device_ids) {
   return ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     TF_ASSIGN_OR_RETURN(const Shape* operand_shape, GetShapePtr(operand));
     HloInstructionProto instr;
@@ -3935,6 +3935,9 @@ XlaOp XlaBuilder::CollectiveBroadcastImpl(
     }
     if (channel_id.has_value()) {
       instr.set_channel_id(channel_id->handle());
+    }
+    if (use_global_device_ids.has_value()) {
+      instr.set_use_global_device_ids(*use_global_device_ids);
     }
 
     return AddInstruction(std::move(instr), HloOpcode::kCollectiveBroadcast,

--- a/xla/client/xla_builder.h
+++ b/xla/client/xla_builder.h
@@ -865,7 +865,8 @@ class XlaBuilder {
 
   XlaOp CollectiveBroadcast(
       XlaOp operand, absl::Span<const ReplicaGroup> replica_groups,
-      const std::optional<ChannelHandle>& channel_id = std::nullopt);
+      const std::optional<ChannelHandle>& channel_id = std::nullopt, 
+      const std::optional<bool> use_global_device_ids=std::nullopt);
 
   XlaOp CollectivePermute(
       XlaOp operand,
@@ -1681,7 +1682,7 @@ class XlaBuilder {
 
   XlaOp CollectiveBroadcastImpl(XlaOp operand,
                                 absl::Span<const ReplicaGroup> replica_groups,
-                                const std::optional<ChannelHandle>& channel_id);
+                                const std::optional<ChannelHandle>& channel_id,std::optional<bool> use_global_device_ids);
 
   XlaOp CollectivePermuteImpl(
       XlaOp operand,

--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -763,7 +763,7 @@ absl::StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
           proto.replica_groups().begin(), proto.replica_groups().end());
       instruction = CreateCollectiveBroadcast(
           shape, all_operands(), CollectiveDeviceList(replica_groups), false,
-          channel_id);
+          channel_id, proto.use_global_device_ids());
       break;
     }
     case HloOpcode::kCollectivePermute:
@@ -1624,20 +1624,20 @@ HloInstruction::CreateAllReduceStart(
 HloInstruction::CreateCollectiveBroadcast(
     const Shape& shape, absl::Span<HloInstruction* const> operands,
     const CollectiveDeviceList& device_list, bool constrain_layout,
-    const std::optional<int64_t>& channel_id) {
+    const std::optional<int64_t>& channel_id, bool use_global_device_ids) {
   return std::make_unique<HloCollectiveBroadcastInstruction>(
       HloOpcode::kCollectiveBroadcast, shape, operands, device_list,
-      constrain_layout, channel_id);
+      constrain_layout, channel_id, use_global_device_ids);
 }
 
 /* static */ std::unique_ptr<HloInstruction>
 HloInstruction::CreateCollectiveBroadcast(
     const Shape& shape, absl::Span<HloInstruction* const> operands,
     absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-    const std::optional<int64_t>& channel_id) {
+    const std::optional<int64_t>& channel_id, bool use_global_device_ids) {
   return CreateCollectiveBroadcast(shape, operands,
                                    CollectiveDeviceList(replica_groups),
-                                   constrain_layout, channel_id);
+                                   constrain_layout, channel_id, use_global_device_ids);
 }
 
 /* static */ std::unique_ptr<HloInstruction>

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -1003,13 +1003,13 @@ class HloInstruction {
   static std::unique_ptr<HloInstruction> CreateCollectiveBroadcast(
       const Shape& shape, absl::Span<HloInstruction* const> operand,
       const CollectiveDeviceList& device_list, bool constrain_layout,
-      const std::optional<int64_t>& channel_id);
+      const std::optional<int64_t>& channel_id, bool use_global_device_ids);
 
   ABSL_DEPRECATED("Use CollectiveDeviceList instead of list of ReplicaGroup.")
   static std::unique_ptr<HloInstruction> CreateCollectiveBroadcast(
       const Shape& shape, absl::Span<HloInstruction* const> operand,
       absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-      const std::optional<int64_t>& channel_id);
+      const std::optional<int64_t>& channel_id, bool use_global_device_ids);
 
   // Creates a communication instruction that permutes data cross replicas.
   // Data is sent/received according to the (source_replica_id,

--- a/xla/hlo/ir/hlo_instructions.cc
+++ b/xla/hlo/ir/hlo_instructions.cc
@@ -1217,18 +1217,19 @@ HloCollectiveBroadcastInstruction::HloCollectiveBroadcastInstruction(
     HloOpcode opcode, const Shape& shape,
     absl::Span<HloInstruction* const> operands,
     const CollectiveDeviceList& device_list, bool constrain_layout,
-    const std::optional<int64_t>& channel_id)
+    const std::optional<int64_t>& channel_id, bool use_global_device_ids)
     : HloCollectiveInstruction(opcode, shape, operands, device_list,
-                               constrain_layout, channel_id) {}
+                               constrain_layout, channel_id),
+      use_global_device_ids_(use_global_device_ids) {}
 
 HloCollectiveBroadcastInstruction::HloCollectiveBroadcastInstruction(
     HloOpcode opcode, const Shape& shape,
     absl::Span<HloInstruction* const> operands,
     absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-    const std::optional<int64_t>& channel_id)
+    const std::optional<int64_t>& channel_id, bool use_global_device_ids)
     : HloCollectiveBroadcastInstruction(opcode, shape, operands,
                                         CollectiveDeviceList(replica_groups),
-                                        constrain_layout, channel_id) {}
+                                        constrain_layout, channel_id, use_global_device_ids) {}
 
 HloInstructionProto HloCollectiveBroadcastInstruction::ToProto() const {
   return HloCollectiveInstruction::ToProto();
@@ -1240,7 +1241,7 @@ HloCollectiveBroadcastInstruction::CloneWithNewOperandsImpl(
     HloCloneContext* /*context*/) const {
   return std::make_unique<HloCollectiveBroadcastInstruction>(
       opcode(), shape, new_operands, device_list(), constrain_layout(),
-      channel_id());
+      channel_id(), use_global_device_ids());
 }
 
 HloCollectivePermuteInstruction::HloCollectivePermuteInstruction(

--- a/xla/hlo/ir/hlo_instructions.h
+++ b/xla/hlo/ir/hlo_instructions.h
@@ -910,14 +910,14 @@ class HloCollectiveBroadcastInstruction : public HloCollectiveInstruction {
       HloOpcode opcode, const Shape& shape,
       absl::Span<HloInstruction* const> operands,
       const CollectiveDeviceList& device_list, bool constrain_layout,
-      const std::optional<int64_t>& channel_id);
+      const std::optional<int64_t>& channel_id, bool use_global_device_ids);
 
   ABSL_DEPRECATED("Use CollectiveDeviceList instead of list of ReplicaGroup.")
   explicit HloCollectiveBroadcastInstruction(
       HloOpcode opcode, const Shape& shape,
       absl::Span<HloInstruction* const> operands,
       absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-      const std::optional<int64_t>& channel_id);
+      const std::optional<int64_t>& channel_id, bool use_global_device_ids);
 
   // Returns a serialized representation of this instruction.
   HloInstructionProto ToProto() const override;
@@ -926,11 +926,16 @@ class HloCollectiveBroadcastInstruction : public HloCollectiveInstruction {
     return hlo->opcode() == HloOpcode::kCollectiveBroadcast;
   }
 
+    bool use_global_device_ids() const { return use_global_device_ids_; }
+
+
  private:
   // Implementation for non-common logic of CloneWithNewOperands.
   std::unique_ptr<HloInstruction> CloneWithNewOperandsImpl(
       const Shape& shape, absl::Span<HloInstruction* const> new_operands,
       HloCloneContext* context) const override;
+      bool use_global_device_ids_;
+
 };
 
 class HloCollectivePermuteInstruction : public HloChannelInstruction {

--- a/xla/mlir_hlo/tests/Dialect/mhlo/hlo-legalize-to-stablehlo.mlir
+++ b/xla/mlir_hlo/tests/Dialect/mhlo/hlo-legalize-to-stablehlo.mlir
@@ -563,10 +563,12 @@ func.func @op_collective_broadcast(%arg0: tensor<1x2xi64>) -> tensor<1x2xi64> {
   //               CHECK: "stablehlo.collective_broadcast"(%arg0) <{
   //          CHECK-SAME:   channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>,
   // CHECK-SAME{LITERAL}:   replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-  //          CHECK-SAME: }> : (tensor<1x2xi64>) -> tensor<1x2xi64>
+  //          CHECK-SAME:   use_global_device_ids
+  //          CHECK-SAME: } : (tensor<1x2xi64>) -> tensor<1x2xi64>
   %0 = "mhlo.collective_broadcast"(%arg0) {
+    channel_handle = #mhlo.channel_handle<handle = 0, type = 0>,
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-    channel_handle = #mhlo.channel_handle<handle = 0, type = 0>
+    use_global_device_ids
   } : (tensor<1x2xi64>) -> tensor<1x2xi64>
   func.return %0 : tensor<1x2xi64>
 }

--- a/xla/mlir_hlo/tests/Dialect/mhlo/stablehlo-legalize-to-hlo.mlir
+++ b/xla/mlir_hlo/tests/Dialect/mhlo/stablehlo-legalize-to-hlo.mlir
@@ -550,10 +550,12 @@ func.func @op_collective_broadcast(%arg0: tensor<1x2xi64>) -> tensor<1x2xi64> {
   //               CHECK: "mhlo.collective_broadcast"(%arg0) <{
   //          CHECK-SAME:   channel_handle = #mhlo.channel_handle<handle = 0, type = 0>,
   // CHECK-SAME{LITERAL}:   replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-  //          CHECK-SAME: }> : (tensor<1x2xi64>) -> tensor<1x2xi64>
+  //          CHECK-SAME:   use_global_device_ids
+  //          CHECK-SAME: } : (tensor<1x2xi64>) -> tensor<1x2xi64>
   %0 = "stablehlo.collective_broadcast"(%arg0) {
+    channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>,
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-    channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
+    use_global_device_ids
   } : (tensor<1x2xi64>) -> tensor<1x2xi64>
   func.return %0 : tensor<1x2xi64>
 }

--- a/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.cc
@@ -40,7 +40,7 @@ NcclCollectiveBroadcastStartThunk::NcclCollectiveBroadcastStartThunk(
     const HloCollectiveBroadcastInstruction* instr, std::vector<Buffer> buffers)
     : NcclCollectiveThunk(Thunk::kNcclCollectiveBroadcastStart, thunk_info,
                           nccl_api, IsSyncCollective(instr)),
-      config_(GetNcclCollectiveConfig(instr, std::nullopt)),
+      config_(GetNcclCollectiveConfig(instr, instr->use_global_device_ids())),
       buffers_(std::move(buffers)) {}
 
 /*static*/ Status NcclCollectiveBroadcastStartThunk::CheckImplementable(

--- a/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.cc
@@ -52,7 +52,7 @@ NcclCollectiveBroadcastStartThunk::NcclCollectiveBroadcastStartThunk(
 /*static*/ CollectiveOpGroupMode
 NcclCollectiveBroadcastStartThunk::GetGroupMode(
     const HloCollectiveBroadcastInstruction* inst) {
-  return GetNcclCollectiveConfig(inst, std::nullopt).group_mode;
+  return GetNcclCollectiveConfig(inst, true).group_mode;
 }
 
 Status NcclCollectiveBroadcastStartThunk::RunNcclCollective(

--- a/xla/service/hlo_parser.cc
+++ b/xla/service/hlo_parser.cc
@@ -1777,6 +1777,9 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
                                  AttrTy::kBracedInt64ListList, &tmp_groups};
       optional<int64_t> channel_id;
       attrs["channel_id"] = {/*required=*/false, AttrTy::kInt64, &channel_id};
+      optional<bool> use_global_device_ids;
+      attrs["use_global_device_ids"] = {/*required=*/false, AttrTy::kBool,
+                                  &use_global_device_ids};
       if ((!preset_operands && !ParseOperands(&operands, builder)) ||
           !ParseAttributes(attrs, allow_attributes)) {
         return nullptr;
@@ -1787,7 +1790,7 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       }
       return builder->AddInstruction(HloInstruction::CreateCollectiveBroadcast(
           *shape, operands, CollectiveDeviceList(replica_groups), false,
-          channel_id));
+          channel_id, use_global_device_ids ? *use_global_device_ids : false));
     }
     case HloOpcode::kCollectivePermute:
     case HloOpcode::kCollectivePermuteStart: {

--- a/xla/tests/collective_ops_test.cc
+++ b/xla/tests/collective_ops_test.cc
@@ -635,7 +635,8 @@ XLA_TEST_F(CollectiveOpsTest, DISABLED_ON_CPU(CollectiveBroadcast_Simple)) {
 
   collective_broadcast {
     p0 = u32[2] parameter(0)
-    ROOT result = u32[2] collective-broadcast(p0), replica_groups={{1, 0, 2, 3}}
+    ROOT result = u32[2] collective-broadcast(p0), replica_groups={{1, 0, 2, 3}}, 
+    use_global_device_ids=true, channel_id=1
   }
 
   ENTRY test_computation {
@@ -664,6 +665,47 @@ XLA_TEST_F(CollectiveOpsTest, DISABLED_ON_CPU(CollectiveBroadcast_Simple)) {
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({11, 11}),
                                      results[1]));
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({11, 11}),
+                                     results[2]));
+  EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({11, 11}),
+                                     results[3]));
+}
+
+XLA_TEST_F(CollectiveOpsTest, DISABLED_ON_CPU(CollectiveBroadcast_Complex2D)) {
+  const char* const kModuleStr = R"(
+  HloModule test
+
+  collective_broadcast {
+    p0 = u32[2] parameter(0)
+    ROOT result = u32[2] collective-broadcast(p0), replica_groups={{2, 0}, {1, 3}}, 
+    use_global_device_ids=true, channel_id=1
+  }
+
+  ENTRY test_computation {
+    replica = u32[] replica-id()
+    ten = u32[] constant(10)
+    sum = u32[] add(replica, ten)
+    p = u32[2] broadcast(sum), dimensions={}
+    cb = ((u32[2]), u32[2]) async-start(u32[2] %p), calls=collective_broadcast
+    ROOT res = u32[2] async-done(cb), calls=collective_broadcast
+  }
+  )";
+  const int64_t kNumReplicas = 4;
+  SKIP_TEST_IF_NUM_DEVICES_LESS_THAN(kNumReplicas)
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr, config));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
+                          ExecuteReplicated(std::move(module), {}, kNumReplicas,
+                                            /*use_threads=*/true));
+  ASSERT_EQ(results.size(), kNumReplicas);
+  EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({12, 12}),
+                                     results[0]));
+  EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({11, 11}),
+                                     results[1]));
+  EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({12, 11}),
                                      results[2]));
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<uint32_t>({11, 11}),
                                      results[3]));

--- a/xla/translate/hlo_to_mhlo/hlo_function_importer.cc
+++ b/xla/translate/hlo_to_mhlo/hlo_function_importer.cc
@@ -998,12 +998,14 @@ absl::StatusOr<mlir::Operation*> HloFunctionImporter::ImportInstructionImpl(
       return new_operation;
     }
     case HloOpcode::kCollectiveBroadcast: {
-      auto collective_broadcast = Cast<HloChannelInstruction>(instruction);
+      auto collective_broadcast = Cast<HloCollectiveBroadcastInstruction>(instruction);
       attributes.push_back(ConvertReplicaGroups(
           collective_broadcast->replica_groups(), builder_));
       if (collective_broadcast->channel_id().has_value())
         attributes.push_back(
             ConvertChannelHandle(collective_broadcast->channel_id().value()));
+      if (collective_broadcast->use_global_device_ids())
+        attributes.push_back(ConvertUseGlobalDeviceIds());
       return func_builder
           ->create<mlir::mhlo::CollectiveBroadcastOp>(loc, result_type,
                                                       operands, attributes)

--- a/xla/translate/hlo_to_mhlo/tests/import.hlotxt
+++ b/xla/translate/hlo_to_mhlo/tests/import.hlotxt
@@ -324,8 +324,9 @@ add {
   // CHECK-NEXT:  "mhlo.collective_broadcast"([[ARG]]) <{
   // CHECK-SAME:    channel_handle = #mhlo.channel_handle<handle = 1, type = 0>,
   // CHECK-SAME{LITERAL}    replica_groups = {{0,1}{2,3}}
-  // CHECK-SAME:  }> : (tensor<128x32xf32>) -> tensor<128x32xf32>
-  ROOT root = f32[128,32]{1,0} collective-broadcast(%input), replica_groups={{0,1},{2,3}}, channel_id=1
+  // CHECK-SAME: use_global_device_ids
+  // CHECK-SAME:  } : (tensor<128x32xf32>) -> tensor<128x32xf32>
+  ROOT root = f32[128,32]{1,0} collective-broadcast(%input), replica_groups={{0,1},{2,3}}, channel_id=1, use_global_device_ids=true
 }
 
 // CHECK-LABEL:  func private @test_collective_permute

--- a/xla/translate/mhlo_to_hlo/tests/export.mlir
+++ b/xla/translate/mhlo_to_hlo/tests/export.mlir
@@ -588,15 +588,18 @@ func.func @callee(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> (tensor<4xi32>,
 // CHECK:  HloModule
 func.func @main(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
   %0 = "mhlo.collective_broadcast"(%arg0) {
+    channel_handle = #mhlo.channel_handle<handle = 1, type = 0>,
     replica_groups = dense<[[0, 1], [2, 3]]> : tensor<2x2xi64>,
-    channel_handle = #mhlo.channel_handle<handle = 1, type = 0>
+    use_global_device_ids
   } : (tensor<128x32xf32>) -> tensor<128x32xf32>
   func.return %0 : tensor<128x32xf32>
 }
 // CHECK:  ENTRY
 // CHECK:  [[ARG:%.*]] = f32[128,32] parameter(0)
-// CHECK:  ROOT [[RESULT:%.*]] = f32[128,32] collective-broadcast(f32[128,32] [[ARG]]), channel_id=1
+// CHECK:  ROOT [[RESULT:%.*]] = f32[128,32] collective-broadcast(f32[128,32] [[ARG]])
+// CHECK: channel_id=1
 // CHECK-SAME{LITERAL}:  replica_groups={{0,1},{2,3}}
+// CHECK-SAME: use_global_device_ids=true
 // -----
 
 // CHECK:  HloModule


### PR DESCRIPTION
Previously, when using `jax.lax.pbroadcast`, it was possible to see errors like

```
E0410 15:07:43.873665 1283339 pjrt_stream_executor_client.cc:2809] Execution of replica 0 failed: INTERNAL: RET_CHECK failure (external/xla/xla/service/collective_ops_utils.cc:409) 0 <= replica_id && replica_id < replica_count 2 1
2024-04-10 15:07:43.873927: E external/xla/xla/status_macros.cc:54] INTERNAL: RET_CHECK failure (external/xla/xla/service/collective_ops_utils.cc:409) 0 <= replica_id && replica_id < replica_count 2 1
```

This was because `use_global_device_id` was set to `std:null:opt` instead of `true`. This fixes it.