### PR TITLE
[NVIDIA GPU] Remove control knobs for each individual async collective and use the global xla_gpu_disable_async_collectives

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -126,12 +126,6 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_reduce_scatter_combine_by_dim(true);
 
   opts.set_xla_gpu_enable_async_collectives(true);
-  opts.set_xla_gpu_enable_async_all_reduce(true);
-  opts.set_xla_gpu_enable_async_all_gather(false);
-  opts.set_xla_gpu_enable_async_collective_broadcast(true);
-  opts.set_xla_gpu_enable_async_collective_permute(false);
-  opts.set_xla_gpu_enable_async_all_to_all(false);
-  opts.set_xla_gpu_enable_async_reduce_scatter(false);
 
   opts.set_xla_gpu_enable_reassociation_for_converted_ar(true);
 
@@ -986,38 +980,6 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_async_collectives),
       debug_options->xla_gpu_enable_async_collectives(),
       "Converts synchronous collective ops into asynchronous."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_async_all_reduce",
-      bool_setter_for(&DebugOptions::set_xla_gpu_enable_async_all_reduce),
-      debug_options->xla_gpu_enable_async_all_reduce(),
-      "Converts synchronous all-reduce ops into asynchronous."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_async_collective_broadcast",
-      bool_setter_for(
-          &DebugOptions::set_xla_gpu_enable_async_collective_broadcast),
-      debug_options->xla_gpu_enable_async_collective_broadcast(),
-      "Converts synchronous collective-broadcast ops into asynchronous."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_async_collective_permute",
-      bool_setter_for(
-          &DebugOptions::set_xla_gpu_enable_async_collective_permute),
-      debug_options->xla_gpu_enable_async_collective_permute(),
-      "Converts synchronous collective-permute ops into asynchronous."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_async_all_gather",
-      bool_setter_for(&DebugOptions::set_xla_gpu_enable_async_all_gather),
-      debug_options->xla_gpu_enable_async_all_gather(),
-      "Converts synchronous all-gather ops into asynchronous."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_async_reduce_scatter",
-      bool_setter_for(&DebugOptions::set_xla_gpu_enable_async_reduce_scatter),
-      debug_options->xla_gpu_enable_async_reduce_scatter(),
-      "Converts synchronous reduce-scatter ops into asynchronous."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_async_all_to_all",
-      bool_setter_for(&DebugOptions::set_xla_gpu_enable_async_all_to_all),
-      debug_options->xla_gpu_enable_async_all_to_all(),
-      "Converts synchronous all-to-all ops into asynchronous."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_all_reduce_combine_threshold_bytes",
       int64_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -125,8 +125,6 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_all_gather_combine_by_dim(true);
   opts.set_xla_gpu_enable_reduce_scatter_combine_by_dim(true);
 
-  opts.set_xla_gpu_enable_async_collectives(true);
-
   opts.set_xla_gpu_enable_reassociation_for_converted_ar(true);
 
   opts.set_xla_cpu_enable_xprof_traceme(false);
@@ -547,6 +545,48 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
     return true;
   };
 
+  auto collective_op_types_to_string =
+      [](tsl::protobuf::RepeatedField<int> collective_ops) -> std::string {
+    struct Formatter {
+      void operator()(std::string* out, int type) const {
+        absl::StrAppend(out, DebugOptions::CollectiveOpType_Name(type));
+      }
+    };
+    return absl::StrJoin(collective_ops, ", ", Formatter());
+  };
+
+  // Custom parser for xla_gpu_disable_async_collectives.
+  auto setter_for_xla_gpu_disable_async_collectives =
+      [debug_options](const std::string& input) {
+        auto is_collective_type = [](absl::string_view value) {
+          DebugOptions::CollectiveOpType op_type;
+          return DebugOptions::CollectiveOpType_Parse(
+              absl::AsciiStrToUpper(value), &op_type);
+        };
+
+        auto parse_collective_type = [](absl::string_view value) {
+          DebugOptions::CollectiveOpType op_type;
+          DebugOptions::CollectiveOpType_Parse(absl::AsciiStrToUpper(value),
+                                               &op_type);
+          return op_type;
+        };
+
+        std::vector<absl::string_view> values = absl::StrSplit(input, ',');
+
+        // Overwrite a set of supported commands with a flag.
+        if (absl::c_all_of(values, is_collective_type)) {
+          debug_options->clear_xla_gpu_disable_async_collectives();
+          for (const absl::string_view value : values) {
+            debug_options->add_xla_gpu_disable_async_collectives(
+                parse_collective_type(value));
+          }
+          return true;
+        }
+
+        // Return an error if flag value was not recognized as one of the
+        // supported modes.
+        return false;
+      };
   // Don't use an initializer list for initializing the vector; this would
   // create a temporary copy, and exceeds the stack space when compiling with
   // certain configurations.
@@ -976,10 +1016,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 debug_options->xla_gpu_deterministic_ops(),
                 "Guarantees run-to-run determinism on GPU."));
   flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_async_collectives",
-      bool_setter_for(&DebugOptions::set_xla_gpu_enable_async_collectives),
-      debug_options->xla_gpu_enable_async_collectives(),
-      "Converts synchronous collective ops into asynchronous."));
+      "xla_gpu_disable_async_collectives",
+      setter_for_xla_gpu_disable_async_collectives,
+      collective_op_types_to_string(
+          debug_options->xla_gpu_disable_async_collectives()),
+      "The types of the commands that are recorded into command buffers. It"
+      " can either be a list of command types or a list of command types with"
+      " + and - as prefix, which indicate adding or removing a command type"
+      " to/from the default list."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_all_reduce_combine_threshold_bytes",
       int64_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -557,7 +557,7 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
 
   // Custom parser for xla_gpu_disable_async_collectives.
   auto setter_for_xla_gpu_disable_async_collectives =
-      [debug_options](const std::string& input) {
+      [debug_options](const absl::string_view& input) {
         auto is_collective_type = [](absl::string_view value) {
           DebugOptions::CollectiveOpType op_type;
           return DebugOptions::CollectiveOpType_Parse(
@@ -1020,10 +1020,10 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       setter_for_xla_gpu_disable_async_collectives,
       collective_op_types_to_string(
           debug_options->xla_gpu_disable_async_collectives()),
-      "The types of the commands that are recorded into command buffers. It"
-      " can either be a list of command types or a list of command types with"
-      " + and - as prefix, which indicate adding or removing a command type"
-      " to/from the default list."));
+      "This disables a certain set of async collectives and turn them into"
+      " synchornous ones. By default, this is empty which indicates enabling"
+      " async execution for all collectives. A sample usage is: "
+      " --xla_gpu_disable_async_collectives=ALLREDUCE,REDUCESCATTER"));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_all_reduce_combine_threshold_bytes",
       int64_setter_for(

--- a/xla/python/xla_compiler.cc
+++ b/xla/python/xla_compiler.cc
@@ -1077,25 +1077,7 @@ void BuildXlaCompilerSubmodule(nb::module_& m) {
                    &DebugOptions::xla_dump_hlo_pipeline_re,
                    [](DebugOptions* self, std::string value) {
                      self->set_xla_dump_hlo_pipeline_re(value);
-                   })
-      .def_prop_rw("xla_gpu_enable_async_all_reduce",
-                   &DebugOptions::xla_gpu_enable_async_all_reduce,
-                   &DebugOptions::set_xla_gpu_enable_async_all_reduce)
-      .def_prop_rw("xla_gpu_enable_async_all_gather",
-                   &DebugOptions::xla_gpu_enable_async_all_gather,
-                   &DebugOptions::set_xla_gpu_enable_async_all_gather)
-      .def_prop_rw("xla_gpu_enable_async_collective_broadcast",
-                   &DebugOptions::xla_gpu_enable_async_collective_broadcast,
-                   &DebugOptions::set_xla_gpu_enable_async_collective_broadcast)
-      .def_prop_rw("xla_gpu_enable_async_collective_permute",
-                   &DebugOptions::xla_gpu_enable_async_collective_permute,
-                   &DebugOptions::set_xla_gpu_enable_async_collective_permute)
-      .def_prop_rw("xla_gpu_enable_async_all_to_all",
-                   &DebugOptions::xla_gpu_enable_async_all_to_all,
-                   &DebugOptions::set_xla_gpu_enable_async_all_to_all)
-      .def_prop_rw("xla_gpu_enable_async_reduce_scatter",
-                   &DebugOptions::xla_gpu_enable_async_reduce_scatter,
-                   &DebugOptions::set_xla_gpu_enable_async_reduce_scatter);
+                   });
 
   nb::class_<ExecutableBuildOptions>(m, "ExecutableBuildOptions")
       .def(nb::init<>())

--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -303,12 +303,6 @@ class DebugOptions:
   xla_dump_hlo_as_long_text: bool
   xla_dump_disable_metadata: bool
   xla_dump_hlo_pipeline_re: str
-  xla_gpu_enable_async_all_reduce: bool
-  xla_gpu_enable_async_all_gather: bool
-  xla_gpu_enable_async_collective_broadcast: bool
-  xla_gpu_enable_async_collective_permute: bool
-  xla_gpu_enable_async_all_to_all: bool
-  xla_gpu_enable_async_reduce_scatter: bool
   xla_gpu_cuda_data_dir: str
   xla_detailed_logging: bool
   xla_enable_dumping: bool

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1137,35 +1137,16 @@ absl::Status RunPostFusionCollectiveOptimizationPasses(HloModule* hlo_module) {
         hlo_module->config().debug_options().xla_gpu_enable_async_collectives();
     switch (inst->opcode()) {
       case HloOpcode::kAllReduceStart:
-        return enable_all_async || hlo_module->config()
-                                       .debug_options()
-                                       .xla_gpu_enable_async_all_reduce();
-      case HloOpcode::kAllGatherStart:
-        return enable_all_async || hlo_module->config()
-                                       .debug_options()
-                                       .xla_gpu_enable_async_all_gather();
       case HloOpcode::kCollectivePermuteStart:
-        return enable_all_async ||
-               hlo_module->config()
-                   .debug_options()
-                   .xla_gpu_enable_async_collective_permute();
+      case HloOpcode::kAllGatherStart:
+        return enable_all_async;
       case HloOpcode::kAsyncStart: {
         auto async_inst = Cast<HloAsyncInstruction>(inst);
         switch (async_inst->async_wrapped_opcode()) {
           case HloOpcode::kCollectiveBroadcast:
-            return enable_all_async ||
-                   hlo_module->config()
-                       .debug_options()
-                       .xla_gpu_enable_async_collective_broadcast();
           case HloOpcode::kReduceScatter:
-            return enable_all_async ||
-                   hlo_module->config()
-                       .debug_options()
-                       .xla_gpu_enable_async_reduce_scatter();
           case HloOpcode::kAllToAll:
-            return enable_all_async || hlo_module->config()
-                                           .debug_options()
-                                           .xla_gpu_enable_async_all_to_all();
+            return enable_all_async;
           default:
             return false;
         }

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1132,21 +1132,32 @@ absl::Status RunPostFusionCollectiveOptimizationPasses(HloModule* hlo_module) {
   config.convert_all_to_all = HloPredicateTrue;
   pipeline.AddPass<AsyncCollectiveCreator>(std::move(config));
 
-  auto convert_to_async = [&hlo_module](const HloInstruction* inst) {
-    const bool enable_all_async =
-        hlo_module->config().debug_options().xla_gpu_enable_async_collectives();
+  absl::flat_hash_set<DebugOptions::CollectiveOpType> disabled_async_ops;
+  for (auto collective_op_type : hlo_module->config()
+                                     .debug_options()
+                                     .xla_gpu_disable_async_collectives()) {
+    disabled_async_ops.insert(
+        static_cast<DebugOptions::CollectiveOpType>(collective_op_type));
+  }
+  auto convert_to_async = [&hlo_module,
+                           &disabled_async_ops](const HloInstruction* inst) {
     switch (inst->opcode()) {
       case HloOpcode::kAllReduceStart:
+        return !disabled_async_ops.contains(DebugOptions::ALLREDUCE);
       case HloOpcode::kCollectivePermuteStart:
+        return !disabled_async_ops.contains(DebugOptions::COLLECTIVEPERMUTE);
       case HloOpcode::kAllGatherStart:
-        return enable_all_async;
+        return !disabled_async_ops.contains(DebugOptions::ALLGATHER);
       case HloOpcode::kAsyncStart: {
         auto async_inst = Cast<HloAsyncInstruction>(inst);
         switch (async_inst->async_wrapped_opcode()) {
           case HloOpcode::kCollectiveBroadcast:
+            return !disabled_async_ops.contains(
+                DebugOptions::COLLECTIVEBROADCAST);
           case HloOpcode::kReduceScatter:
+            return !disabled_async_ops.contains(DebugOptions::REDUCESCATTER);
           case HloOpcode::kAllToAll:
-            return enable_all_async;
+            return !disabled_async_ops.contains(DebugOptions::ALLTOALL);
           default:
             return false;
         }

--- a/xla/tests/collective_ops_test_e2e.cc
+++ b/xla/tests/collective_ops_test_e2e.cc
@@ -79,7 +79,6 @@ class AsyncCollectiveOps : public CollectiveOpsTestE2E,
 
     // Enable or disable all async collectives based on test parameter.
     const bool enable_async = GetParam();
-    debug_options.set_xla_gpu_enable_async_collectives(enable_async);
     debug_options.add_xla_disable_hlo_passes(
         "gpu-convert-async-collectives-to-sync");
     return debug_options;

--- a/xla/tests/collective_ops_test_e2e.cc
+++ b/xla/tests/collective_ops_test_e2e.cc
@@ -79,13 +79,7 @@ class AsyncCollectiveOps : public CollectiveOpsTestE2E,
 
     // Enable or disable all async collectives based on test parameter.
     const bool enable_async = GetParam();
-    debug_options.set_xla_gpu_enable_async_collectives(false);
-    debug_options.set_xla_gpu_enable_async_all_reduce(enable_async);
-    debug_options.set_xla_gpu_enable_async_collective_broadcast(enable_async);
-    debug_options.set_xla_gpu_enable_async_collective_permute(enable_async);
-    debug_options.set_xla_gpu_enable_async_all_gather(enable_async);
-    debug_options.set_xla_gpu_enable_async_reduce_scatter(enable_async);
-    debug_options.set_xla_gpu_enable_async_all_to_all(enable_async);
+    debug_options.set_xla_gpu_enable_async_collectives(enable_async);
     debug_options.add_xla_disable_hlo_passes(
         "gpu-convert-async-collectives-to-sync");
     return debug_options;

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -377,21 +377,28 @@ message DebugOptions {
   // Paths to files with LLVM code.
   repeated string xla_gpu_llvm_ir_file = 150;
 
-  // Convert synchronous collective ops into asynchronous.
-  bool xla_gpu_enable_async_collectives = 238;
+  // Enum to define all collective ops
+  // that xla supports.
+  enum CollectiveOpType {
+    NOOP = 0;
+    ALLREDUCE = 1;
+    ALLGATHER = 2;
+    REDUCESCATTER = 3;
+    COLLECTIVEBROADCAST = 4;
+    ALLTOALL = 5;
+    COLLECTIVEPERMUTE = 6;
+  }
+
+  repeated CollectiveOpType xla_gpu_disable_async_collectives = 289;
 
   // Used to be xla_gpu_enable_async_all_reduce
-  reserved 152;
-  // Used to be xla_gpu_enable_async_collective_broadcast
-  reserved 278;
-  // Used to be xla_gpu_enable_async_collective_permute
-  reserved 183;
-  // Used to be xla_gpu_enable_async_all_gather
-  reserved 199;
-  // Used to be xla_gpu_enable_async_reduce_scatter
-  reserved 200;
-  // Used to be xla_gpu_enable_async_all_to_all
-  reserved 201;
+  // xla_gpu_enable_async_collective_broadcast
+  // xla_gpu_enable_async_collective_permute
+  // xla_gpu_enable_async_all_gather
+  // xla_gpu_enable_async_reduce_scatter
+  // xla_gpu_enable_async_all_to_all
+  // xla_gpu_enable_async_collectives
+  reserved 152, 278, 183, 199 ,200, 201, 238;
 
   // Size threshold (in bytes) for the GPU collective combiners.
   int64 xla_gpu_all_reduce_combine_threshold_bytes = 157;
@@ -747,7 +754,7 @@ message DebugOptions {
   // solutions.
   int64 xla_gpu_autotune_max_solutions = 288;
 
-  // Next id: 289
+  // Next id: 290
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -379,12 +379,19 @@ message DebugOptions {
 
   // Convert synchronous collective ops into asynchronous.
   bool xla_gpu_enable_async_collectives = 238;
-  bool xla_gpu_enable_async_all_reduce = 152;
-  bool xla_gpu_enable_async_collective_broadcast = 278;
-  bool xla_gpu_enable_async_collective_permute = 183;
-  bool xla_gpu_enable_async_all_gather = 199;
-  bool xla_gpu_enable_async_reduce_scatter = 200;
-  bool xla_gpu_enable_async_all_to_all = 201;
+
+  // Used to be xla_gpu_enable_async_all_reduce
+  reserved 152;
+  // Used to be xla_gpu_enable_async_collective_broadcast
+  reserved 278;
+  // Used to be xla_gpu_enable_async_collective_permute
+  reserved 183;
+  // Used to be xla_gpu_enable_async_all_gather
+  reserved 199;
+  // Used to be xla_gpu_enable_async_reduce_scatter
+  reserved 200;
+  // Used to be xla_gpu_enable_async_all_to_all
+  reserved 201;
 
   // Size threshold (in bytes) for the GPU collective combiners.
   int64 xla_gpu_all_reduce_combine_threshold_bytes = 157;


### PR DESCRIPTION
Currently we have 1 global flag(xla_gpu_enable_async_collectives) to control whether we want to asynchronize collectives or not. This flag overrides all other control knobs for each collective. The usage of it is confusing, instead we introduce a new flag xla_gpu_disable_async_collectives which will consolidate all the async flags we have now. We remove xla_gpu_enable_async_collectives and all other individual control knobs.
Sample usage:
xla_gpu_disable_async_collectives=allreduce,reducescatter
disables async allreduce and reducescatter
By default it's empty which indicates enabling async for all collectives.
