### PR TITLE
Spmd partitioning for host memory offloading ops

### DIFF
--- a/xla/service/spmd/BUILD
+++ b/xla/service/spmd/BUILD
@@ -66,6 +66,7 @@ cc_library(
         "//xla/service:hlo_module_config",
         "//xla/service:hlo_pass",
         "//xla/service:hlo_pass_pipeline",
+        "//xla/service:host_memory_offload_annotations_hdr",
         "//xla/service:pattern_matcher",
         "//xla/service:shape_inference",
         "//xla/service:sharding_propagation",


### PR DESCRIPTION
This partitions MoveToHost and MoveToDevice custom calls in a way that
tries to avoid resharding on the host. That is, MoveToHost reshards input,
MoveToDevice reshards output.