### PR TITLE
[ROCM] added flag limiting the number of gemm solutions to be checked & get real IDs for hipblas-lt

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -50,6 +50,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_llvm_disable_expensive_passes(false);
   opts.set_xla_backend_optimization_level(3);
   opts.set_xla_gpu_autotune_level(4);
+  opts.set_xla_gpu_autotune_max_solutions(0);
   opts.set_xla_cpu_multi_thread_eigen(true);
   opts.set_xla_gpu_cuda_data_dir("./cuda_sdk_lib");
   opts.set_xla_gpu_asm_extra_flags("");
@@ -751,6 +752,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_autotune_level(),
       "Set GEMM and Convolution auto-tuning level. 0 = off; 1 = on; 2 = "
       "on+init; 3 = on+init+reinit; 4 = on+init+reinit+check."));
+flag_list->push_back(tsl::Flag(
+      "xla_gpu_autotune_max_solutions",
+      int64_setter_for(&DebugOptions::set_xla_gpu_autotune_max_solutions),
+      debug_options->xla_gpu_autotune_max_solutions(),
+      "Maximal number of GEMM solutions to consider for autotuning: 0 means "
+      "consider all solutions returned by the GEMM library."));
   flag_list->push_back(tsl::Flag(
       "xla_force_host_platform_device_count",
       int32_setter_for(&DebugOptions::set_xla_force_host_platform_device_count),

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -96,6 +96,7 @@ class GemmAutotuner {
   std::unique_ptr<se::RedzoneAllocator> redzone_allocator_;
   se::Stream* stream_ = nullptr;
   bool deterministic_ops_ = false;
+  size_t solutions_limit_ = 0;
   int64_t rng_state_ = 0;
 
  public:
@@ -114,6 +115,7 @@ class GemmAutotuner {
     const DebugOptions& debug_options =
         gemm->GetModule()->config().debug_options();
     deterministic_ops_ = debug_options.xla_gpu_deterministic_ops();
+    solutions_limit_ = debug_options.xla_gpu_autotune_max_solutions();
 
     TF_ASSIGN_OR_RETURN(auto gemm_config, GemmConfig::For(gemm));
 
@@ -237,14 +239,6 @@ class GemmAutotuner {
                                 &algorithms);
 
     AutotuneResult best_algorithm;
-#if TENSORFLOW_USE_ROCM        // Blas gemm algorithms can be empty for ROCM
-    if (algorithms.empty()) {  // nothing to autotune
-      LOG(WARNING) << "No solutions found: skipping autotuning for ROCM..";
-      best_algorithm.mutable_gemm()->set_algorithm(se::blas::kDefaultAlgorithm);
-      return best_algorithm;
-    }
-#endif
-
     auto tuned_func = [&](const se::blas::AlgorithmType& algorithm)
         -> absl::StatusOr<se::blas::ProfileResult> {
       // Do a warm-up run first, without a profile result. RunGemm swallows
@@ -307,7 +301,10 @@ class GemmAutotuner {
     results.reserve(algorithms.size());
     std::optional<int64_t> reference_algorithm;
 
-    for (const AlgoT& algorithm : algorithms) {
+    auto num = algorithms.size();
+    if(solutions_limit_ > 0) num = std::min(num, solutions_limit_);
+    for (size_t i = 0; i < num; i++) {
+      const AlgoT& algorithm = algorithms[i];
       // Make sure the output buffer always has the same value if we use
       // the bias parameter.
       if (autotune_config_.should_reinit_output_buffer() && beta != 0) {

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -459,10 +459,19 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     }
   }
 
+  typedef struct __attribute__((packed, aligned(8))) _rocblaslt_matmul_algo
+  {
+    uint8_t data[8]             = {0};
+    bool    fallback            = false;
+    size_t  max_workspace_bytes = 0;
+  } rocblaslt_matmul_algo;
+  
   if (profile_result != nullptr) {
     TF_ASSIGN_OR_RETURN(absl::Duration elapsed, timer->GetElapsedDuration());
     // set algorithm ID to be unique (otherwise it gets kDefaultAlgorithm ID)
-    profile_result->set_algorithm(reinterpret_cast<blas::AlgorithmType>(palgo));
+    auto roc_algo = (const rocblaslt_matmul_algo *)palgo; 
+    auto pindex = (int *)roc_algo->data;
+    profile_result->set_algorithm(static_cast<blas::AlgorithmType>(*pindex));
     profile_result->set_is_valid(true);
     profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
   }

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -668,10 +668,13 @@ bool ROCMBlas::GetBlasGemmAlgorithms(
         ret != rocblas_status_success) {
       return ret;
     }
-    out_algorithms->resize(num_sols);
+    out_algorithms->resize(num_sols + 1);
+    (*out_algorithms)[0] = blas::kDefaultAlgorithm;
     for (rocblas_int i = 0; i < num_sols; i++) {
-      (*out_algorithms)[i] = solutions_[i];
+      (*out_algorithms)[i + 1] = solutions_[i];
     }
+    // Sort the list solutions by IDs
+    std::sort(out_algorithms->begin() + 1, out_algorithms->end());
     return rocblas_status_success;
   };
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -735,7 +735,12 @@ message DebugOptions {
   // target are located within a node(nvlink).
   bool xla_gpu_use_memcpy_local_p2p = 287;
 
-  // Next id: 288
+  // If non-zero, limits the number of solutions to be used by GEMM autotuner.
+  // This might be useful if underlying math library returns too many GEMM 
+  // solutions.
+  int64 xla_gpu_autotune_max_solutions = 288;
+
+  // Next id: 289
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
In this PR I add a new XLA flag **xla_gpu_autotune_max_solutions** which limits the number of GEMM solutions to be using for GEMM autotuning. This is a temporary measure while rocBLAS returns way too many solutions which can significantly slow-down autotuning for real applications.

Besides, I also added a "workaround" to obtain the real solution IDs for hipblas-lt which might be later used for deterministic autotuning.

@xla-rotation: would you have a look please ?