### PR TITLE
Fix unittest build error

### DIFF
--- a/xla/backends/interpreter/BUILD
+++ b/xla/backends/interpreter/BUILD
@@ -149,6 +149,7 @@ cc_library(
         "//xla:shape_util",
         "//xla:status_macros",
         "//xla:xla_data_proto_cc",
+        "//xla/stream_executor:event_interface",
         "//xla/stream_executor",
         "//xla/stream_executor:stream_executor_interface",
         "//xla/stream_executor/host:host_stream",

--- a/xla/backends/interpreter/executor.h
+++ b/xla/backends/interpreter/executor.h
@@ -36,6 +36,7 @@ limitations under the License.
 #include "xla/stream_executor/kernel.h"
 #include "xla/stream_executor/kernel_spec.h"
 #include "xla/stream_executor/launch_dim.h"
+#include "xla/stream_executor/event_interface.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -376,7 +376,7 @@ cc_library(
 
 #===--------------------------------------------------------------------------------------------===#
 # StreamExecutor internal implementation (visible to StreamExecutor platform implementations)
-#===--------------------------------------------------------------------------------------------===#'
+#===--------------------------------------------------------------------------------------------===#
 
 # This header-only library is an internal implementation detail of StreamExecutor (to break
 # dependency cycles between internal libraries). All StreamExecutor clients should depend on a


### PR DESCRIPTION
This PR fix the build error for tests:

./bazel-6.5.0rc1-linux-x86_64 \
    test \
    --flaky_test_attempts=1 \
    --config=cuda \
    --compilation_mode=dbg \
    --action_env TF_CUDA_COMPUTE_CAPABILITIES=compute_90 \
    --test_summary=detailed \
    --runs_per_test=1 \
    --nocache_test_results \
    --test_output=streamed  \
   //xla/service/gpu/tests:gemm_rewrite_test_gpu  

