### PR TITLE
Add a missing dependency on EventInterface

### DIFF
--- a/xla/backends/interpreter/BUILD
+++ b/xla/backends/interpreter/BUILD
@@ -151,6 +151,7 @@ cc_library(
         "//xla:xla_data_proto_cc",
         "//xla/stream_executor",
         "//xla/stream_executor:stream_executor_interface",
+        "//xla/stream_executor:event_interface",
         "//xla/stream_executor/host:host_stream",
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",

--- a/xla/backends/interpreter/executor.h
+++ b/xla/backends/interpreter/executor.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/device_memory.h"
 #include "xla/stream_executor/event.h"
+#include "xla/stream_executor/event_interface.h"
 #include "xla/stream_executor/host/host_stream.h"
 #include "xla/stream_executor/host_memory_allocation.h"
 #include "xla/stream_executor/kernel.h"


### PR DESCRIPTION
This adds a missing dependency of xla/backends/interpreter/executor.h. Without it, I am seeing the following compiler error:
```
/usr/include/c++/9/bits/unique_ptr.h: In instantiation of _void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = stream_executor::EventInterface]_:             
/usr/include/c++/9/bits/unique_ptr.h:292:17:   required from _std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = stream_executor::EventInterface; _Dp = std::default_delete<stream_executor::EventInterface>]_                                                                                                                                        
./xla/backends/interpreter/executor.h:161:12:   required from here
/usr/include/c++/9/bits/unique_ptr.h:79:16: error: invalid application of _sizeof_ to incomplete type _stream_executor::EventInterface_ 
```
I assume this is due to a difference in behavior between compilers (some compilers allow construction of a std::unique_ptr to an incomplete type, and some don't.)