### PR TITLE
[NVIDIA GPU] Improve GPU collective matmul to support all-gather having multiple users

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -5957,6 +5957,8 @@ xla_cc_test(
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
+        "//xla/service:pattern_matcher",
+        "//xla/service:pattern_matcher_gmock",
         "//xla/tests:hlo_test_base",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings:string_view",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -708,7 +708,9 @@ absl::Status RunSPMDPasses(
             .xla_gpu_threshold_for_windowed_einsum_mib(),
         hlo_module->config()
             .debug_options()
-            .xla_gpu_multi_streamed_windowed_einsum());
+            .xla_gpu_multi_streamed_windowed_einsum(),
+        /*skip_checking_windowed_einsum_users=*/true,
+        /*disable_ag_rewrite_for_multiple_consumers=*/true);
     spmd_pipeline.AddPass<CollectivePermuteMotion>();
     return spmd_pipeline.Run(hlo_module).status();
   } else {

--- a/xla/service/gpu/gpu_windowed_einsum_handler.cc
+++ b/xla/service/gpu/gpu_windowed_einsum_handler.cc
@@ -143,6 +143,83 @@ absl::StatusOr<bool> HandleAgWindowedEinsumLoop(HloComputation* comp,
   return changed;
 }
 
+absl::Status ProcessWindowedEinsumLoopForActivationCaching(
+    GpuWindowedEinsumHandler::WindowedEinsumAgLoops& ag_loop) {
+  HloInstruction* loop = ag_loop.loop;
+  // Transform the while body to cache the allgathered result in the
+  // output buffer to be consumed by the dot
+  HloComputation* while_body = loop->while_body();
+  HloInstruction* input_gte;
+  for (HloInstruction* gte : while_body->parameter_instruction(0)->users()) {
+    if (gte->tuple_index() == 0) {
+      input_gte = gte;
+    }
+  }
+  // Get the output operand of the full buffer.
+  HloInstruction* root = while_body->root_instruction();
+  // The full buffer that we will use to cache the accumulated activation
+  // is the 4th operand in the output tuple.
+  int64_t full_cache_buffer_index = 3;
+  HloInstruction* full_buffer_output_gte =
+      root->mutable_operand(full_cache_buffer_index);
+  HloInstruction* new_full_buffer_output;
+  // Find the DUS in the loop body and re-use the slice indices
+  // This should just be a constant(0)
+  HloInstruction* dus_boundary_constant;
+  for (HloInstruction* inst : while_body->MakeInstructionPostOrder()) {
+    HloInstruction* slice_indices;
+    // If we have a DUS(PARAM,DS) pattern, we need to update the output
+    // buffer with the first slice.
+    if (Match(inst,
+              m::DynamicUpdateSlice(
+                  m::GetTupleElement(m::Parameter()), m::Op(),
+                  m::Constant(&dus_boundary_constant),
+                  m::Reshape(m::DynamicSlice(&slice_indices, m::Op(), m::Op())),
+                  m::Op()))) {
+      slice_indices = while_body->AddInstruction(HloInstruction::CreateReshape(
+          dus_boundary_constant->shape(), slice_indices));
+      VLOG(5) << "Created slice op for first slice: "
+              << slice_indices->ToString();
+      full_buffer_output_gte =
+          while_body->AddInstruction(HloInstruction::CreateDynamicUpdateSlice(
+              full_buffer_output_gte->shape(), full_buffer_output_gte,
+              input_gte,
+              {dus_boundary_constant, slice_indices, dus_boundary_constant}));
+    }
+    // If we have a DUS(DUS,DS) pattern, then the einsum loop is
+    // unrolled, we need to update the output buffer again with the
+    // second slice. Since the second slice will have different indices,
+    // we need to re-capture slice_indices.
+    if (Match(inst,
+              m::DynamicUpdateSlice(
+                  m::DynamicUpdateSlice(), m::Op(), m::Constant(),
+                  m::Reshape(m::DynamicSlice(&slice_indices, m::Op(), m::Op())),
+                  m::Op()))) {
+      slice_indices = while_body->AddInstruction(HloInstruction::CreateReshape(
+          dus_boundary_constant->shape(), slice_indices));
+      VLOG(5) << "Created slice op for second slice: "
+              << slice_indices->ToString();
+      // The slice we need this time is the output of the first
+      // collective-permute
+      HloInstruction* cp_output;
+      for (HloInstruction* gte_user : input_gte->users()) {
+        if (gte_user->opcode() == HloOpcode::kCollectivePermute) {
+          cp_output = gte_user;
+          break;
+        }
+      }
+      new_full_buffer_output =
+          while_body->AddInstruction(HloInstruction::CreateDynamicUpdateSlice(
+              full_buffer_output_gte->shape(), full_buffer_output_gte,
+              cp_output,
+              {dus_boundary_constant, slice_indices, dus_boundary_constant}));
+    }
+  }
+  TF_RETURN_IF_ERROR(root->ReplaceOperandWith(full_cache_buffer_index,
+                                              new_full_buffer_output));
+  return OkStatus();
+}
+
 class WindowedEinsumVisitor : public DfsHloRewriteVisitor {
  public:
   explicit WindowedEinsumVisitor(
@@ -157,30 +234,25 @@ class WindowedEinsumVisitor : public DfsHloRewriteVisitor {
     for (GpuWindowedEinsumHandler::WindowedEinsumAgLoops ag_loop :
          all_ag_loops_) {
       HloInstruction* loop = ag_loop.loop;
-      HloInstruction* lhs_ag = nullptr;
-      HloInstruction* rhs_ag = nullptr;
+      HloInstruction* ag_operand = nullptr;
 
-      if (Match(dot, m::Dot(m::AllGather(&lhs_ag), m::Op())) ||
-          Match(dot, m::Dot(m::Op(), m::AllGather(&rhs_ag)))) {
+      if (Match(dot, m::Dot(m::AllGather(&ag_operand), m::Op())) ||
+          Match(dot, m::Dot(m::Op(), m::AllGather(&ag_operand)))) {
         HloInstruction* windowed_lhs =
             loop->mutable_operand(0)->mutable_operand(0);
         HloInstruction* ag_with_shared_operand = nullptr;
-        if (lhs_ag && lhs_ag->mutable_operand(0) == windowed_lhs) {
-          ag_with_shared_operand = lhs_ag;
-        }
-
-        if (rhs_ag && rhs_ag->mutable_operand(0) == windowed_lhs) {
-          ag_with_shared_operand = rhs_ag;
+        if (ag_operand && ag_operand->mutable_operand(0) == windowed_lhs) {
+          ag_with_shared_operand = ag_operand;
         }
 
         if (!ag_with_shared_operand) {
-          return absl::OkStatus();
+          continue;
         }
 
         VLOG(5) << "Found all-gather that shares the same operand with a "
-                      "windowed einsum loop : "
-                   << loop->ToString();
-        int64_t cache_output_index = ag_with_shared_operand == lhs_ag ? 0 : 1;
+                   "windowed einsum loop : "
+                << loop->ToString();
+        int64_t cache_output_index = dot->operand_index(ag_with_shared_operand);
         HloComputation* comp = dot->parent();
         HloInstruction* new_gte = comp->AddInstruction(
             HloInstruction::CreateGetTupleElement(loop, 3));
@@ -188,78 +260,8 @@ class WindowedEinsumVisitor : public DfsHloRewriteVisitor {
             dot->ReplaceOperandWith(cache_output_index, new_gte));
         TF_RETURN_IF_ERROR(comp->RemoveInstruction(ag_with_shared_operand));
         if (!ag_loop.consumed) {
-          // Transform the while body to cache the allgathered result in the
-          // output buffer to be consumed by the dot
-          HloComputation* while_body = loop->while_body();
-          HloInstruction* input_gte;
-          for (HloInstruction* gte :
-               while_body->parameter_instruction(0)->users()) {
-            if (gte->tuple_index() == 0) {
-              input_gte = gte;
-            }
-          }
-          // Get the output operand of the full buffer.
-          HloInstruction* root = while_body->root_instruction();
-          HloInstruction* full_buffer_output_gte = root->mutable_operand(3);
-          HloInstruction* new_full_buffer_output;
-          // Find the DUS in the loop body and re-use the slice indices
-          // This should just be a constant(0)
-          HloInstruction* dus_boundary_constant;
-          for (HloInstruction* inst : while_body->MakeInstructionPostOrder()) {
-            HloInstruction* slice_indices;
-            // If we have a DUS(PARAM,DS) pattern, we need to update the output
-            // buffer with the first slice.
-            if (Match(inst, m::DynamicUpdateSlice(
-                                m::GetTupleElement(m::Parameter()), m::Op(),
-                                m::Constant(&dus_boundary_constant),
-                                m::Reshape(m::DynamicSlice(&slice_indices,
-                                                           m::Op(), m::Op())),
-                                m::Op()))) {
-              slice_indices =
-                  while_body->AddInstruction(HloInstruction::CreateReshape(
-                      dus_boundary_constant->shape(), slice_indices));
-              VLOG(5) << "Created slice op for first slice: "
-                         << slice_indices->ToString();
-              full_buffer_output_gte = while_body->AddInstruction(
-                  HloInstruction::CreateDynamicUpdateSlice(
-                      full_buffer_output_gte->shape(), full_buffer_output_gte,
-                      input_gte,
-                      {dus_boundary_constant, slice_indices,
-                       dus_boundary_constant}));
-            }
-            // If we have a DUS(DUS,DS) pattern, then the einsum loop is
-            // unrolled, we need to update the output buffer again with the
-            // second slice. Since the second slice will have different indices,
-            // we need to re-capture slice_indices.
-            if (Match(inst, m::DynamicUpdateSlice(
-                                m::DynamicUpdateSlice(), m::Op(), m::Constant(),
-                                m::Reshape(m::DynamicSlice(&slice_indices,
-                                                           m::Op(), m::Op())),
-                                m::Op()))) {
-              slice_indices =
-                  while_body->AddInstruction(HloInstruction::CreateReshape(
-                      dus_boundary_constant->shape(), slice_indices));
-              VLOG(5) << "Created slice op for second slice: "
-                         << slice_indices->ToString();
-              // The slice we need this time is the output of the first
-              // collective-permute
-              HloInstruction* cp_output;
-              for (HloInstruction* gte_user : input_gte->users()) {
-                if (gte_user->opcode() == HloOpcode::kCollectivePermute) {
-                  cp_output = gte_user;
-                  break;
-                }
-              }
-              new_full_buffer_output = while_body->AddInstruction(
-                  HloInstruction::CreateDynamicUpdateSlice(
-                      full_buffer_output_gte->shape(), full_buffer_output_gte,
-                      cp_output,
-                      {dus_boundary_constant, slice_indices,
-                       dus_boundary_constant}));
-            }
-          }
           TF_RETURN_IF_ERROR(
-              root->ReplaceOperandWith(3, new_full_buffer_output));
+              ProcessWindowedEinsumLoopForActivationCaching(ag_loop));
           ag_loop.consumed = true;
         }
       }
@@ -311,11 +313,14 @@ absl::StatusOr<bool> GpuWindowedEinsumHandler::Run(
   //                       |
   //                       |
   //                     windowed loop
-  //                       | 
+  //                       |
   //                       |
   //                      dot
-  // The windowed einsum loop will also be rewritten to output the full input to be consumed
-  // by the dot.
+  // The windowed einsum loop will also be rewritten to output the full input to
+  // be consumed by the dot.
+  // This is advantageous since the chained dot can fully utilize all the
+  // resources on the GPU while comm is hidden by the first collective matmul
+  // loop.
   for (HloComputation* comp :
        module->MakeNonfusionComputations(execution_threads)) {
     WindowedEinsumVisitor visitor(all_ag_loops_);

--- a/xla/service/gpu/gpu_windowed_einsum_handler.h
+++ b/xla/service/gpu/gpu_windowed_einsum_handler.h
@@ -38,16 +38,24 @@ class GpuWindowedEinsumHandler : public HloModulePass {
     return "gpu-windowed-einsum-handler";
   }
 
+  struct WindowedEinsumAgLoops {
+    WindowedEinsumAgLoops(HloInstruction* loop) :
+    loop(loop) {}
+    HloInstruction* loop;
+    bool consumed = false;
+  };
+
   using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
 
- private:
   constexpr static const char* kWindowedEinsumRsLoopName =
       "windowed_dot_general_body_rs";
   constexpr static const char* kWindowedEinsumAgLoopName =
       "windowed_dot_general_body_ag";
+ private:
+  std::vector<WindowedEinsumAgLoops> all_ag_loops_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/gpu_windowed_einsum_handler_test.cc
+++ b/xla/service/gpu/gpu_windowed_einsum_handler_test.cc
@@ -23,11 +23,15 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/pattern_matcher.h"
+#include "xla/service/pattern_matcher_gmock.h"
 #include "xla/tests/hlo_test_base.h"
 #include "tsl/platform/statusor.h"
 
 namespace xla::gpu {
 namespace {
+
+namespace m = ::xla::match;
 
 using GpuWindowedEinsumHanlderTest = HloTestBase;
 
@@ -191,6 +195,147 @@ ENTRY main.9_spmd {
       FindInstructionByName(rs_loop_body, "collective-permute.1");
   EXPECT_TRUE(
       cp1->backend_config<GpuBackendConfig>()->force_earliest_schedule());
+}
+
+TEST_F(GpuWindowedEinsumHanlderTest, AgLoopsMultipleConsumersAreChained) {
+  constexpr absl::string_view kHloString = R"(
+HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(bf16[2,512,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[24576,24576]{1,0}, bf16[24576,24576]{1,0})->bf16[2,512,24576]{2,1,0}}, num_partitions=4
+
+windowed_dot_general_body_ag {
+  param.1 = (bf16[2,512,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,2048,24576]{2,1,0}, bf16[2,2048,24576]{2,1,0}, u32[]) parameter(0)
+  get-tuple-element.1 = bf16[2,512,24576]{2,1,0} get-tuple-element(param.1), index=0
+  collective-permute = bf16[2,512,24576]{2,1,0} collective-permute(get-tuple-element.1), channel_id=2, source_target_pairs={{0,3},{1,0},{2,1},{3,2}}
+  collective-permute.1 = bf16[2,512,24576]{2,1,0} collective-permute(collective-permute), channel_id=3, source_target_pairs={{0,3},{1,0},{2,1},{3,2}}
+  get-tuple-element.2 = bf16[24576,24576]{1,0} get-tuple-element(param.1), index=1
+  get-tuple-element.3 = bf16[2,2048,24576]{2,1,0} get-tuple-element(param.1), index=2
+  dot = bf16[2,512,24576]{2,1,0} dot(get-tuple-element.1, get-tuple-element.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  constant.2 = s32[] constant(0)
+  constant.3 = s32[4]{0} constant({0, 512, 1024, 1536})
+  get-tuple-element.5 = u32[] get-tuple-element(param.1), index=4
+  partition-id = u32[] partition-id()
+  add = u32[] add(get-tuple-element.5, partition-id)
+  constant.1 = u32[] constant(4)
+  remainder = u32[] remainder(add, constant.1)
+  dynamic-slice = s32[1]{0} dynamic-slice(constant.3, remainder), dynamic_slice_sizes={1}
+  reshape = s32[] reshape(dynamic-slice)
+  dynamic-update-slice = bf16[2,2048,24576]{2,1,0} dynamic-update-slice(get-tuple-element.3, dot, constant.2, reshape, constant.2)
+  dot.1 = bf16[2,512,24576]{2,1,0} dot(collective-permute, get-tuple-element.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  constant.5 = u32[] constant(1)
+  add.1 = u32[] add(get-tuple-element.5, constant.5)
+  add.2 = u32[] add(add.1, partition-id)
+  remainder.1 = u32[] remainder(add.2, constant.1)
+  dynamic-slice.1 = s32[1]{0} dynamic-slice(constant.3, remainder.1), dynamic_slice_sizes={1}
+  reshape.1 = s32[] reshape(dynamic-slice.1)
+  dynamic-update-slice.1 = bf16[2,2048,24576]{2,1,0} dynamic-update-slice(dynamic-update-slice, dot.1, constant.2, reshape.1, constant.2)
+  get-tuple-element.4 = bf16[2,2048,24576]{2,1,0} get-tuple-element(param.1), index=3
+  add.3 = u32[] add(add.1, constant.5)
+  ROOT tuple = (bf16[2,512,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,2048,24576]{2,1,0}, bf16[2,2048,24576]{2,1,0}, u32[]) tuple(collective-permute.1, get-tuple-element.2, dynamic-update-slice.1, get-tuple-element.4, add.3)
+} // windowed_dot_general_body_ag
+
+windowed_dot_general_cond_ag {
+  param = (bf16[2,512,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,2048,24576]{2,1,0}, bf16[2,2048,24576]{2,1,0}, u32[]) parameter(0)
+  get-tuple-element = u32[] get-tuple-element(param), index=4
+  constant = u32[] constant(4)
+  ROOT compare = pred[] compare(get-tuple-element, constant), direction=LT
+}
+
+windowed_dot_general_body_rs {
+  param.3 = (bf16[2,2048,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,512,24576]{2,1,0}, bf16[2,512,24576]{2,1,0}, u32[]) parameter(0)
+  get-tuple-element.7 = bf16[2,2048,24576]{2,1,0} get-tuple-element(param.3), index=0
+  get-tuple-element.8 = bf16[24576,24576]{1,0} get-tuple-element(param.3), index=1
+  get-tuple-element.9 = bf16[2,512,24576]{2,1,0} get-tuple-element(param.3), index=2
+  collective-permute.2 = bf16[2,512,24576]{2,1,0} collective-permute(get-tuple-element.9), channel_id=5, source_target_pairs={{0,2},{1,3},{2,0},{3,1}}
+  constant.13 = s32[] constant(0)
+  constant.14 = s32[4]{0} constant({0, 512, 1024, 1536})
+  get-tuple-element.12 = u32[] get-tuple-element(param.3), index=4
+  constant.16 = u32[] constant(2)
+  add.9 = u32[] add(get-tuple-element.12, constant.16)
+  constant.17 = u32[] constant(1)
+  add.10 = u32[] add(add.9, constant.17)
+  partition-id.3 = u32[] partition-id()
+  add.11 = u32[] add(add.10, partition-id.3)
+  constant.12 = u32[] constant(4)
+  remainder.3 = u32[] remainder(add.11, constant.12)
+  dynamic-slice.4 = s32[1]{0} dynamic-slice(constant.14, remainder.3), dynamic_slice_sizes={1}
+  reshape.3 = s32[] reshape(dynamic-slice.4)
+  dynamic-slice.5 = bf16[2,512,24576]{2,1,0} dynamic-slice(get-tuple-element.7, constant.13, reshape.3, constant.13), dynamic_slice_sizes={2,512,24576}
+  dot.3 = bf16[2,512,24576]{2,1,0} dot(dynamic-slice.5, get-tuple-element.8), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  add.12 = bf16[2,512,24576]{2,1,0} add(collective-permute.2, dot.3)
+  get-tuple-element.10 = bf16[2,512,24576]{2,1,0} get-tuple-element(param.3), index=3
+  add.6 = u32[] add(get-tuple-element.12, partition-id.3)
+  remainder.2 = u32[] remainder(add.6, constant.12)
+  dynamic-slice.2 = s32[1]{0} dynamic-slice(constant.14, remainder.2), dynamic_slice_sizes={1}
+  reshape.2 = s32[] reshape(dynamic-slice.2)
+  dynamic-slice.3 = bf16[2,512,24576]{2,1,0} dynamic-slice(get-tuple-element.7, constant.13, reshape.2, constant.13), dynamic_slice_sizes={2,512,24576}
+  dot.2 = bf16[2,512,24576]{2,1,0} dot(dynamic-slice.3, get-tuple-element.8), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  add.7 = bf16[2,512,24576]{2,1,0} add(get-tuple-element.10, dot.2)
+  collective-permute.3 = bf16[2,512,24576]{2,1,0} collective-permute(add.7), channel_id=6, source_target_pairs={{0,2},{1,3},{2,0},{3,1}}
+  ROOT tuple.1 = (bf16[2,2048,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,512,24576]{2,1,0}, bf16[2,512,24576]{2,1,0}, u32[]) tuple(get-tuple-element.7, get-tuple-element.8, add.12, collective-permute.3, add.9)
+} // windowed_dot_general_body_rs
+
+windowed_dot_general_cond_rs {
+  param.2 = (bf16[2,2048,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,512,24576]{2,1,0}, bf16[2,512,24576]{2,1,0}, u32[]) parameter(0)
+  get-tuple-element.6 = u32[] get-tuple-element(param.2), index=4
+  constant.11 = u32[] constant(4)
+  ROOT compare.1 = pred[] compare(get-tuple-element.6, constant.11), direction=LT
+}
+
+ENTRY main.12_spmd {
+  param.4 = bf16[2,512,24576]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  param.5 = bf16[24576,24576]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  constant.22 = bf16[] constant(0)
+  broadcast = bf16[2,2048,24576]{2,1,0} broadcast(constant.22), dimensions={}
+  constant.24 = u32[] constant(0)
+  tuple.2 = (bf16[2,512,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,2048,24576]{2,1,0}, bf16[2,2048,24576]{2,1,0}, u32[]) tuple(param.4, param.5, broadcast, broadcast, constant.24)
+  while = (bf16[2,512,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,2048,24576]{2,1,0}, bf16[2,2048,24576]{2,1,0}, u32[]) while(tuple.2), condition=windowed_dot_general_cond_ag, body=windowed_dot_general_body_ag
+  get-tuple-element.13 = bf16[2,2048,24576]{2,1,0} get-tuple-element(while), index=2
+  copy.1 = bf16[2,2048,24576]{2,1,0} copy(get-tuple-element.13)
+  all-gather = bf16[2,2048,24576]{2,1,0} all-gather(param.4), channel_id=1, replica_groups={{0,1,2,3}}, dimensions={1}, use_global_device_ids=true
+  param.6 = bf16[24576,24576]{1,0} parameter(2), sharding={devices=[1,4]<=[4]}
+  dot.7 = bf16[2,2048,24576]{2,1,0} dot(all-gather, param.6), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  add.13 = bf16[2,2048,24576]{2,1,0} add(copy.1, dot.7)
+  param.7 = bf16[24576,24576]{1,0} parameter(3), sharding={devices=[4,1]<=[4]}
+  broadcast.2 = bf16[2,512,24576]{2,1,0} broadcast(constant.22), dimensions={}
+  tuple.3 = (bf16[2,2048,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,512,24576]{2,1,0}, bf16[2,512,24576]{2,1,0}, u32[]) tuple(add.13, param.7, broadcast.2, broadcast.2, constant.24)
+  while.1 = (bf16[2,2048,24576]{2,1,0}, bf16[24576,24576]{1,0}, bf16[2,512,24576]{2,1,0}, bf16[2,512,24576]{2,1,0}, u32[]) while(tuple.3), condition=windowed_dot_general_cond_rs, body=windowed_dot_general_body_rs
+  get-tuple-element.14 = bf16[2,512,24576]{2,1,0} get-tuple-element(while.1), index=2
+  collective-permute.4 = bf16[2,512,24576]{2,1,0} collective-permute(get-tuple-element.14), channel_id=7, source_target_pairs={{0,1},{1,2},{2,3},{3,0}}
+  get-tuple-element.15 = bf16[2,512,24576]{2,1,0} get-tuple-element(while.1), index=3
+  ROOT add.14 = bf16[2,512,24576]{2,1,0} add(collective-permute.4, get-tuple-element.15)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloString));
+
+  GpuWindowedEinsumHandler gpu_handler;
+  bool changed;
+  TF_ASSERT_OK_AND_ASSIGN(changed, gpu_handler.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  HloInstruction* ag_loop =
+      FindInstructionByName(module->entry_computation(), "while");
+  HloInstruction* inst =
+      FindInstructionByName(module->entry_computation(), "dot.7");
+  // dot.7 should now consume output of the windowed einsum while loop.
+  EXPECT_TRUE(inst->operand(0)->opcode() == HloOpcode::kGetTupleElement);
+  EXPECT_TRUE(inst->operand(0)->tuple_index() == 3);
+  EXPECT_TRUE(inst->operand(0)->operand(0) == ag_loop);
+
+  // while loop's root should now have a chain of DUS.
+  HloInstruction* ag_while_root = ag_loop->while_body()->root_instruction();
+  EXPECT_THAT(ag_while_root,
+              GmockMatch(m::Tuple(
+                  m::Op(), m::Op(), m::Op(),
+                  m::DynamicUpdateSlice(
+                      m::DynamicUpdateSlice(
+                          m::GetTupleElement(m::Parameter())
+                              .WithPredicate([](const HloInstruction* instr) {
+                                return instr->tuple_index() == 3;
+                              }),
+                          m::Op(), m::Op(), m::Op(), m::Op()),
+                      m::Op(), m::Op(), m::Op(), m::Op()),
+                  m::Op())));
 }
 
 }  // namespace

--- a/xla/service/spmd/dot_handler.cc
+++ b/xla/service/spmd/dot_handler.cc
@@ -1909,22 +1909,56 @@ absl::StatusOr<HloInstruction*> PartitionBaseCase(
     }
   }
 
+  // If we see a dot that shares the same operand with a windowed einsum ag loop
+  // and disable_ag_rewrite_for_multiple_consumers is true. We skip rewriting
+  // the current dot.
+  bool should_skip_windowed_einsum = false;
+  if (options.disable_ag_rewrite_for_multiple_consumers) {
+    auto lhs_operand = lhs.hlo()->opcode() == HloOpcode::kReshape ||
+                               lhs.hlo()->opcode() == HloOpcode::kBitcast ||
+                               lhs.hlo()->opcode() == HloOpcode::kTranspose
+                           ? lhs.hlo()->operand(0)
+                           : lhs.hlo();
+    auto rhs_operand = rhs.hlo()->opcode() == HloOpcode::kReshape ||
+                               rhs.hlo()->opcode() == HloOpcode::kBitcast ||
+                               rhs.hlo()->opcode() == HloOpcode::kTranspose
+                           ? rhs.hlo()->operand(0)
+                           : rhs.hlo();
+    for (auto loop : *windowed_dot_general_loops) {
+      if (loop.while_loop->while_body()->name().find(
+              "windowed_dot_general_body_ag") == 0) {
+        auto cm_lhs = loop.while_loop->operand(0)->operand(0);
+        if (cm_lhs == lhs_operand || cm_lhs == rhs_operand) {
+          VLOG(2) << "Skip processing: " << original_hlo->ToString();
+          VLOG(2) << "It shares the same operand with "
+                  << loop.while_loop->ToString()
+                  << " and disable_ag_rewrite_for_multiple_consumers is set to "
+                     "true.";
+          should_skip_windowed_einsum = true;
+        }
+      }
+    }
+  }
+
   // Hard limit on iteration count based on empirical data (above this amount
   // there's pretty significant overhead).
   constexpr int64_t kMaxIterations = 32;
-  std::optional<WindowedEinsumConfig> e_config = GetWindowedEinsumConfiguration(
-      num_partitions, output_lhs_non_contracting_partitions,
-      output_rhs_non_contracting_partitions, rhs_contracting_partitions,
-      rhs_non_contracting_partitions, rhs_batch_partitions,
-      lhs_contracting_partitions, lhs_non_contracting_partitions,
-      lhs_batch_partitions, ShapeSizeInBytes(rhs.base_shape()),
-      ShapeSizeInBytes(lhs.base_shape()), ShapeSizeInBytes(output_base_shape),
-      options, output_sharding_transposed_to_match_lhs,
-      output_sharding_transposed_to_match_rhs,
-      lhs_sharding_transposed_to_match_rhs,
-      rhs_sharding_transposed_to_match_lhs, lhs_sharding, rhs_sharding,
-      conv_window, dims_mapping, visitor->call_graph(), kMaxIterations,
-      original_hlo, &lhs, &rhs, create_sharded_dot, b, module, visitor);
+  std::optional<WindowedEinsumConfig> e_config = std::nullopt;
+  if (!should_skip_windowed_einsum) {
+    e_config = GetWindowedEinsumConfiguration(
+        num_partitions, output_lhs_non_contracting_partitions,
+        output_rhs_non_contracting_partitions, rhs_contracting_partitions,
+        rhs_non_contracting_partitions, rhs_batch_partitions,
+        lhs_contracting_partitions, lhs_non_contracting_partitions,
+        lhs_batch_partitions, ShapeSizeInBytes(rhs.base_shape()),
+        ShapeSizeInBytes(lhs.base_shape()), ShapeSizeInBytes(output_base_shape),
+        options, output_sharding_transposed_to_match_lhs,
+        output_sharding_transposed_to_match_rhs,
+        lhs_sharding_transposed_to_match_rhs,
+        rhs_sharding_transposed_to_match_lhs, lhs_sharding, rhs_sharding,
+        conv_window, dims_mapping, visitor->call_graph(), kMaxIterations,
+        original_hlo, &lhs, &rhs, create_sharded_dot, b, module, visitor);
+  }
   if (e_config) {
     VLOG(2) << "Emit windowed dot.";
     return EmitWindowedDotGeneral(

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -87,6 +87,10 @@ struct SpmdPartitionerOptions {
   bool enable_windowed_einsum_for_all_gather = true;
   // Enables windowed einsum for result reduce-scatter.
   bool enable_windowed_einsum_for_reduce_scatter = true;
+
+  // Whether disable rewrite for dots that share the same
+  // operand as an already rewritten windowed einsum loop.
+  bool disable_ag_rewrite_for_multiple_consumers = false;
 };
 
 // Class to wrap the computation builder to capture information during SPMD

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -53,7 +53,9 @@ class SpmdPartitioningTest
       bool choose_faster_windowed_einsum = false,
       bool unroll_windowed_einsum = false,
       bool bidirectional_windowed_einsum = false,
-      int64_t threshold_for_windowed_einsum_mib = -1) {
+      int64_t threshold_for_windowed_einsum_mib = -1,
+      bool skip_checking_windowed_einsum_users = false,
+      bool disable_ag_rewrite_for_multiple_consumers = false) {
     // Some tests (BackpropFilter convs) set this flag false to test two
     // different paths of the implementation.
     SpmdPartitionerOptions options;
@@ -63,6 +65,10 @@ class SpmdPartitioningTest
         choose_faster_windowed_einsum;
     options.unroll_windowed_einsum = unroll_windowed_einsum;
     options.bidirectional_windowed_einsum = bidirectional_windowed_einsum;
+    options.skip_checking_windowed_einsum_users =
+        skip_checking_windowed_einsum_users;
+    options.disable_ag_rewrite_for_multiple_consumers =
+        disable_ag_rewrite_for_multiple_consumers;
     if (threshold_for_windowed_einsum_mib >= 0) {
       options.threshold_for_windowed_einsum_mib =
           threshold_for_windowed_einsum_mib;
@@ -127,6 +133,16 @@ std::string TestParamToString(
     case ShardingFormatPicker::ShardingType::kBestEffortV2:
       return "BestEffortV2";
   }
+}
+
+int64_t CountInstructions(const HloComputation& computation, HloOpcode opcode) {
+  int64_t count = 0;
+  for (const auto& instruction : computation.instructions()) {
+    if (instruction->opcode() == opcode) {
+      count++;
+    }
+  }
+  return count;
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -5220,6 +5236,39 @@ ENTRY entry {
               op::CollectivePermute(op::Parameter(0)));
   EXPECT_THAT(cp_conditional->false_computation()->root_instruction(),
               op::Parameter(0));
+}
+
+TEST_P(SpmdPartitioningTest, EinsumDisableRewriteForAgWithMultipleConsumers) {
+  absl::string_view hlo_string = R"(
+HloModule test, entry_computation_layout={(bf16[2,2048,24576]{2,1,0}, bf16[24576,98304]{1,0}, bf16[24576,98304]{1,0})->bf16[2,2048,98304]{2,1,0}}, num_partitions=4
+
+ENTRY main {
+  Arg_0.1 = bf16[2,2048,24576]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  Arg_1.2 = bf16[24576,98304]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  dot.5 = bf16[2,2048,98304]{2,1,0} dot(Arg_0.1, Arg_1.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}, sharding={devices=[1,1,4]<=[4]}
+  copy = bf16[2,2048,98304]{2,1,0} copy(dot.5), sharding={devices=[1,1,4]<=[4]}
+  Arg_2.3 = bf16[24576,98304]{1,0} parameter(2), sharding={devices=[1,4]<=[4]}
+  dot.6 = bf16[2,2048,98304]{2,1,0} dot(Arg_0.1, Arg_2.3), lhs_contracting_dims={2}, rhs_contracting_dims={0}, sharding={devices=[1,1,4]<=[4]}
+  ROOT add.8 = bf16[2,2048,98304]{2,1,0} add(copy, dot.6), sharding={devices=[1,1,4]<=[4]}
+}
+
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      PartitionComputation(hlo_string,
+                           /*num_devices=*/4,
+                           /*conv_halo_exchange_always_on_lhs =*/true,
+                           /*choose_faster_windowed_einsum =*/false,
+                           /*unroll_windowed_einsum =*/false,
+                           /*bidirectional_windowed_einsum=*/false,
+                           /*threshold_for_windowed_einsum_mib=*/0,
+                           /*skip_checking_windowed_einsum_users=*/true,
+                           /*disable_ag_rewrite_for_multiple_consumers=*/true));
+  EXPECT_EQ(CountInstructions(*module->entry_computation(), HloOpcode::kWhile),
+            1);
+  EXPECT_EQ(CountInstructions(*module->entry_computation(), HloOpcode::kDot),
+            1);
 }
 
 TEST_P(SpmdPartitioningTest,

--- a/xla/service/spmd/stateful_rng_spmd_partitioner.h
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner.h
@@ -45,13 +45,18 @@ class StatefulRngSpmdPartitioningVisitor
 
 class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
  public:
-  StatefulRngSpmdPartitioner(int64_t num_partitions, int64_t num_replicas,
-                             int64_t threshold_for_windowed_einsum_mib = 100000,
-                             bool windowed_einsum_use_multiple_streams = false)
-      : spmd::SpmdPartitioner(
-            num_partitions, num_replicas,
-            GetSpmdPartitionerOptions(threshold_for_windowed_einsum_mib,
-                                      windowed_einsum_use_multiple_streams)) {}
+  StatefulRngSpmdPartitioner(
+      int64_t num_partitions, int64_t num_replicas,
+      int64_t threshold_for_windowed_einsum_mib = 100000,
+      bool windowed_einsum_use_multiple_streams = false,
+      bool skip_checking_windowed_einsum_users = false,
+      bool disable_ag_rewrite_for_multiple_consumers = false)
+      : spmd::SpmdPartitioner(num_partitions, num_replicas,
+                              GetSpmdPartitionerOptions(
+                                  threshold_for_windowed_einsum_mib,
+                                  windowed_einsum_use_multiple_streams,
+                                  skip_checking_windowed_einsum_users,
+                                  disable_ag_rewrite_for_multiple_consumers)) {}
 
  protected:
   std::unique_ptr<spmd::SpmdPartitioningVisitor> CreateVisitor(
@@ -70,12 +75,18 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
  private:
   static spmd::SpmdPartitionerOptions GetSpmdPartitionerOptions(
       int64_t threshold_for_windowed_einsum_mib,
-      bool windowed_einsum_use_multiple_streams = false) {
+      bool windowed_einsum_use_multiple_streams = false,
+      bool skip_checking_windowed_einsum_users = false,
+      bool disable_ag_rewrite_for_multiple_consumers = false) {
     spmd::SpmdPartitionerOptions options;
     options.allow_module_signature_change = true;
     options.threshold_for_windowed_einsum_mib =
         threshold_for_windowed_einsum_mib;
     options.unroll_windowed_einsum = windowed_einsum_use_multiple_streams;
+    options.skip_checking_windowed_einsum_users =
+        skip_checking_windowed_einsum_users;
+    options.disable_ag_rewrite_for_multiple_consumers =
+        disable_ag_rewrite_for_multiple_consumers;
     return options;
   }
 };

--- a/xla/tests/collective_ops_test_e2e.cc
+++ b/xla/tests/collective_ops_test_e2e.cc
@@ -647,18 +647,22 @@ TEST_F(CollectiveOpsTestE2E, NoAllToAllDecomposition) {
 
 TEST_F(CollectiveOpsTestE2E, WindowedEinsumE2EAllgatherMultiConsumer) {
   absl::string_view kModuleReplicatedStr = R"(
-HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(bf16[2,2048,24576]{2,1,0}, bf16[24576,98304]{1,0}, bf16[24576,98304]{1,0})->bf16[2,2048,98304]{2,1,0}}, num_partitions=4
+HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(bf16[2,16,48]{2,1,0}, bf16[48,192]{1,0}, bf16[48,192]{1,0}, bf16[192,48]{1,0})->bf16[2,16,48]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
 
 ENTRY main.12 {
-  Arg_0.1 = bf16[2,2048,24576]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
-  Arg_1.2 = bf16[24576,98304]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
-  dot.5 = bf16[2,2048,98304]{2,1,0} dot(Arg_0.1, Arg_1.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}
-  custom-call.7 = bf16[2,2048,98304]{2,1,0} custom-call(dot.5), custom_call_target="Sharding", sharding={devices=[1,1,4]<=[4]}
-  Arg_2.3 = bf16[24576,98304]{1,0} parameter(2), sharding={devices=[1,4]<=[4]}
-  ROOT dot.6 = bf16[2,2048,98304]{2,1,0} dot(Arg_0.1, Arg_2.3), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  Arg_0.1 = bf16[2,16,48]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  Arg_1.2 = bf16[48,192]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  dot.5 = bf16[2,16,192]{2,1,0} dot(Arg_0.1, Arg_1.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  custom-call.7 = bf16[2,16,192]{2,1,0} custom-call(dot.5), custom_call_target="Sharding", sharding={devices=[1,1,4]<=[4]}
+  Arg_2.3 = bf16[48,192]{1,0} parameter(2), sharding={devices=[1,4]<=[4]}
+  dot.6 = bf16[2,16,192]{2,1,0} dot(Arg_0.1, Arg_2.3), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  add.8 = bf16[2,16,192]{2,1,0} add(custom-call.7, dot.6)
+  Arg_3.4 = bf16[192,48]{1,0} parameter(3), sharding={devices=[4,1]<=[4]}
+  dot.9 = bf16[2,16,48]{2,1,0} dot(add.8, Arg_3.4), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  tuple.10 = (bf16[2,16,48]{2,1,0}) tuple(dot.9)
+  ROOT get-tuple-element.11 = bf16[2,16,48]{2,1,0} get-tuple-element(tuple.10), index=0, sharding={devices=[1,4,1]<=[4]}
 } // main.12
-
-  )";
+)";
 
   const int64_t kNumReplicas = 1;
   const int64_t kNumPartitions = 4;
@@ -669,6 +673,7 @@ ENTRY main.12 {
   opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
   opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
   opts.set_xla_gpu_graph_min_graph_size(200);
+  opts.set_xla_gpu_enable_triton_gemm(false);
   config.set_debug_options(opts);
   config.set_num_partitions(kNumPartitions);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -692,11 +697,11 @@ ENTRY main.12 {
           std::move(module), fake_ptrs, kNumPartitions, &assn,
           true /*run_hlo_passes*/, true /*use-threads*/));
   ASSERT_EQ(results.size(), kNumPartitions);
-
   HloModuleConfig ref_config =
       GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
   auto ref_opts = GetDebugOptionsForTest();
   ref_opts.set_xla_gpu_graph_min_graph_size(200);
+  ref_opts.set_xla_gpu_enable_triton_gemm(false);
   ref_config.set_debug_options(ref_opts);
   ref_config.set_num_partitions(kNumPartitions);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -714,12 +719,11 @@ ENTRY main.12 {
           std::move(ref_module), ref_fake_ptrs, kNumPartitions, &assn,
           true /*run_hlo_passes*/, true /*use-threads*/));
   ASSERT_EQ(ref_results.size(), kNumPartitions);
-  ErrorSpec error_spec{1e-5, 1e-5};
+  ErrorSpec error_spec{1e-2, 1e-2};
   // Results should be the same between windowed einsum and non-windowed cases
   for (int i = 0; i < kNumPartitions; i++) {
     EXPECT_TRUE(LiteralTestUtil::Near(ref_results[i], results[i], error_spec));
   }
 }
-
 }  // namespace
 }  // namespace xla

--- a/xla/tests/collective_ops_test_e2e.cc
+++ b/xla/tests/collective_ops_test_e2e.cc
@@ -645,5 +645,81 @@ TEST_F(CollectiveOpsTestE2E, NoAllToAllDecomposition) {
   LiteralTestUtil::ExpectR1Equal<uint32_t>({20, 25, 21, 26}, results[1]);
 }
 
+TEST_F(CollectiveOpsTestE2E, WindowedEinsumE2EAllgatherMultiConsumer) {
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(bf16[2,2048,24576]{2,1,0}, bf16[24576,98304]{1,0}, bf16[24576,98304]{1,0})->bf16[2,2048,98304]{2,1,0}}, num_partitions=4
+
+ENTRY main.12 {
+  Arg_0.1 = bf16[2,2048,24576]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  Arg_1.2 = bf16[24576,98304]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  dot.5 = bf16[2,2048,98304]{2,1,0} dot(Arg_0.1, Arg_1.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  custom-call.7 = bf16[2,2048,98304]{2,1,0} custom-call(dot.5), custom_call_target="Sharding", sharding={devices=[1,1,4]<=[4]}
+  Arg_2.3 = bf16[24576,98304]{1,0} parameter(2), sharding={devices=[1,4]<=[4]}
+  ROOT dot.6 = bf16[2,2048,98304]{2,1,0} dot(Arg_0.1, Arg_2.3), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+} // main.12
+
+  )";
+
+  const int64_t kNumReplicas = 1;
+  const int64_t kNumPartitions = 4;
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  auto opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
+  opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  opts.set_xla_gpu_graph_min_graph_size(200);
+  config.set_debug_options(opts);
+  config.set_num_partitions(kNumPartitions);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleReplicatedStr, config));
+  DeviceAssignment assn(/*replica_count=*/kNumReplicas,
+                        /*computation_count=*/kNumPartitions);
+  config.set_replica_count(kNumReplicas);
+  for (int64_t i = 0; i < kNumPartitions; ++i) {
+    assn(0, i) = i;
+  }
+
+  auto fake_arguments = xla::MakeFakeArguments(module.get()).value();
+  std::vector<Literal*> fake_ptrs(fake_arguments.size());
+  for (int i = 0; i < fake_arguments.size(); i++) {
+    fake_ptrs[i] = &fake_arguments[i];
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::vector<Literal> results,
+      HloTestBase::ExecuteReplicated(
+          std::move(module), fake_ptrs, kNumPartitions, &assn,
+          true /*run_hlo_passes*/, true /*use-threads*/));
+  ASSERT_EQ(results.size(), kNumPartitions);
+
+  HloModuleConfig ref_config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  auto ref_opts = GetDebugOptionsForTest();
+  ref_opts.set_xla_gpu_graph_min_graph_size(200);
+  ref_config.set_debug_options(ref_opts);
+  ref_config.set_num_partitions(kNumPartitions);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto ref_module,
+      ParseAndReturnVerifiedModule(kModuleReplicatedStr, ref_config));
+  auto fake_ref_arguments = xla::MakeFakeArguments(ref_module.get()).value();
+  std::vector<Literal*> ref_fake_ptrs(fake_ref_arguments.size());
+  for (int i = 0; i < fake_ref_arguments.size(); i++) {
+    ref_fake_ptrs[i] = &fake_ref_arguments[i];
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::vector<Literal> ref_results,
+      HloTestBase::ExecuteReplicated(
+          std::move(ref_module), ref_fake_ptrs, kNumPartitions, &assn,
+          true /*run_hlo_passes*/, true /*use-threads*/));
+  ASSERT_EQ(ref_results.size(), kNumPartitions);
+  ErrorSpec error_spec{1e-5, 1e-5};
+  // Results should be the same between windowed einsum and non-windowed cases
+  for (int i = 0; i < kNumPartitions; i++) {
+    EXPECT_TRUE(LiteralTestUtil::Near(ref_results[i], results[i], error_spec));
+  }
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
We have identified another optimization opportunity for gpt-3 using collective matmul, in the backward pass, the all-gather has multiple dot users but current spmd will duplicate multiple collective matmul loops. We'd like this transformation:
before:
```
  //                       input
  //                       /    |
  //                      /     |
  //                     AG    windowed loop
  //                     /
  //                    /
  //                   dot

```
after:
```
  //                       input
  //                       |
  //                       |
  //                     windowed loop
  //                       | 
  //                       |
  //                      dot
```
This is advantageous since the chained dot can fully utilize all the resource on the GPU while comm is hidden by the first collective matmul loop.

We introduced an option to turn off CM loop duplication in SPMD and rewrite the graph to desired pattern in the gpu_windowed_einsum_handler pass.