### PR TITLE
Allowing permutations of terms in //xla/service/gpu/fusions:transpose_mlir_test

### DIFF
--- a/xla/service/gpu/fusions/transpose_mlir_test.cc
+++ b/xla/service/gpu/fusions/transpose_mlir_test.cc
@@ -51,8 +51,8 @@ TEST_F(MlirTransposeFusionTest, ThreadIndexing021) {
       MatchIndexingString(R"(
         (d0, d1, d2, d3, d4, d5)[s0, s1, s2] -> (
           d3 floordiv 2,
-          d0 floordiv 32 + s1 * 4,
-          (d3 mod 2) * 32 + d0 mod 32
+          ### d0 floordiv 32 + s1 * 4 ###,
+          ### (d3 mod 2) * 32 + d0 mod 32 ###
         )
         domain:
         d0 in [0, 127]
@@ -71,7 +71,7 @@ TEST_F(MlirTransposeFusionTest, ThreadIndexing021) {
       MatchIndexingString(R"(
         (d0, d1, d2, d3, d4, d5)[s0, s1, s2] -> (
           d3 floordiv 2,
-          d0 floordiv 32 + (d3 mod 2) * 32 + s1 * 4,
+          ### d0 floordiv 32 + (d3 mod 2) * 32 + s1 * 4 ###,
           d0 mod 32
         )
         domain:
@@ -129,9 +129,9 @@ TEST_F(MlirTransposeFusionTest, ThreadIndexing201) {
       fusion.ComputeThreadIdToOutputIndexing(0, &mlir_context_)->ToString(),
       MatchIndexingString(R"(
         (d0, d1, d2, d3, d4, d5)[s0, s1, s2] -> (
-          d0 floordiv 32 + s1 * 4,
+          ### d0 floordiv 32 + s1 * 4 ###,
           d3 floordiv 2,
-          (d3 mod 2) * 32 + d0 mod 32
+          ### (d3 mod 2) * 32 + d0 mod 32 ###
         )
         domain:
         d0 in [0, 127]

--- a/xla/service/gpu/model/indexing_test_utils.cc
+++ b/xla/service/gpu/model/indexing_test_utils.cc
@@ -139,25 +139,79 @@ AffineExpr ParseAffineExpr(absl::string_view serialized_affine_expr,
       .getResult(0);
 }
 
+inline std::vector<std::string> split_string(std::string s, std::string pattern) {
+  std::vector<std::string> result;
+  size_t pos = 0;
+  while ((pos = s.find(pattern)) != std::string::npos) {
+    result.push_back(s.substr(0, pos));
+    s.erase(0, pos + pattern.length());
+  }
+  if (!s.empty())
+    result.push_back(s);
+  return result;
+}
+
+inline bool startswith(const std::string& s, const std::string& pattern) {
+  return s.substr(0, pattern.size()) == pattern;
+}
+
+
 bool ApproximateMatch(std::string_view lhs, std::string_view rhs) {
-  size_t lhs_length = lhs.size();
-  size_t rhs_length = rhs.size();
-  size_t l = 0, r = 0;
-  while (l < lhs_length && r < rhs_length) {
-    while (l < lhs_length && std::isspace(lhs[l])) {
-      ++l;
-    }
-    while (r < rhs_length && std::isspace(rhs[r])) {
-      ++r;
-    }
-    if (l == lhs_length || r == rhs_length) {
-      continue;
-    }
-    if (lhs[l++] != rhs[r++]) {
-      return false;
+  std::string lhs_unspaced, rhs_unspaced;
+  for(auto c : lhs) {
+    if (!std::isspace(c)) {
+      lhs_unspaced+=c;
     }
   }
-  return l == lhs_length && r == rhs_length;
+  for(auto c : rhs) {
+    if (!std::isspace(c)) {
+      rhs_unspaced+=c;
+    }
+  }
+
+  if (lhs_unspaced.find("###") == std::string::npos)
+    return lhs_unspaced == rhs_unspaced;
+
+  std::vector<std::string> frags = split_string(lhs_unspaced, "###");
+
+  while(frags.size() >= 2) {
+    if (!startswith(rhs_unspaced, frags[0])) {
+      return false;
+    }
+
+    rhs_unspaced = rhs_unspaced.substr(frags[0].size());
+
+    auto terms = split_string(frags[1], "+");
+    // iterate through permutations of terms
+    std::vector<int> indexes(terms.size());
+    for(auto i=0; i<terms.size(); i++) {
+      indexes[i] = i;
+    }
+    bool match = false;
+    do {
+      std::string permuted = "";
+      for(auto i : indexes) {
+        permuted += terms[i] + "+";
+      }
+      permuted.pop_back();
+      if (startswith(rhs_unspaced, permuted)) {
+        match = true;
+        break;
+      }
+    } while (std::next_permutation(indexes.begin(), indexes.end()));
+
+    if (!match) {
+      return false;
+    }
+
+    rhs_unspaced = rhs_unspaced.substr(frags[1].size());
+    frags.erase(frags.begin());
+    frags.erase(frags.begin());
+  }
+  if (frags.empty())
+    return rhs_unspaced.empty();
+  else
+    return rhs_unspaced == frags[0];
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/model/indexing_test_utils.h
+++ b/xla/service/gpu/model/indexing_test_utils.h
@@ -33,6 +33,9 @@ namespace xla {
 namespace gpu {
 
 // Matches two strings ignoring whitespaces.
+// 'lhs' may contain regions bounded by the special pattern '###',
+// in which case, each region is parsed as a sequence of terms separated by 
+// '+ signs. The function will try to match all permutations of terms.
 bool ApproximateMatch(std::string_view lhs, std::string_view rhs);
 
 MATCHER(UndefinedMap, "") { return arg.IsUndefined(); }


### PR DESCRIPTION
This expands the pattern matcher used by  //xla/service/gpu/fusions:transpose_mlir_test, so that it reports a match even if some terms are permuted. (Without the change, I see two subtests of this test fail on ROCm. With the change, the test passes there.)