### PR TITLE
Add a TritonFusionAnalysis util to query an op's scope.

### DIFF
--- a/xla/service/gpu/triton_fusion_analysis.cc
+++ b/xla/service/gpu/triton_fusion_analysis.cc
@@ -320,6 +320,17 @@ absl::Status TritonFusionAnalysis::ExecuteForDotFusion(
   return absl::OkStatus();
 }
 
+std::optional<TritonFusionAnalysis::Scope>
+TritonFusionAnalysis::QueryInstructionScope(const HloInstruction& hlo) const {
+  for (const Scope& scope : {Scope::LHS, Scope::RHS, Scope::OUTPUT}) {
+    if (iter_specs_.at(scope).count(&hlo) > 0) {
+      return scope;
+    }
+  }
+  LOG(WARNING) << "No scope for hlo: " << hlo.ToString();
+  return std::nullopt;
+}
+
 const TensorIterationSpec::DimIterationSpec* TritonFusionAnalysis::IterSpec(
     const TritonFusionAnalysis::Scope scope, const HloInstruction* hlo,
     const int dimension) const {

--- a/xla/service/gpu/triton_fusion_analysis.h
+++ b/xla/service/gpu/triton_fusion_analysis.h
@@ -79,6 +79,10 @@ class TritonFusionAnalysis {
     return parameters_.at(scope);
   }
 
+  // Returns the given instruction's scope, if there is no scope, returns
+  // nullopt instead.
+  std::optional<Scope> QueryInstructionScope(const HloInstruction& hlo) const;
+
   std::string ToString() const;
 
  private:


### PR DESCRIPTION
Add a TritonFusionAnalysis util to query an op's scope.
This will be used in cuDNN compiler for deciding an op's dimensions in the followup PR. 