### PR TITLE
Cleanup passes names

### DIFF
--- a/xla/service/batch_dot_simplification.cc
+++ b/xla/service/batch_dot_simplification.cc
@@ -111,10 +111,6 @@ BatchDotSimplification::ElideDegenerateBatchDimensionFromBatchDot(
   return true;
 }
 
-absl::string_view BatchDotSimplification::name() const {
-  return "batch-dot-simplification";
-}
-
 absl::StatusOr<bool> BatchDotSimplification::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {

--- a/xla/service/batch_dot_simplification.h
+++ b/xla/service/batch_dot_simplification.h
@@ -31,7 +31,7 @@ class BatchDotSimplification : public HloModulePass {
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
-  absl::string_view name() const override;
+  absl::string_view name() const override { return "batch-dot-simplification"; }
 
  private:
   absl::StatusOr<bool> ElideDegenerateBatchDimensionFromBatchDot(

--- a/xla/service/collective_transformation_reorderer.h
+++ b/xla/service/collective_transformation_reorderer.h
@@ -56,9 +56,7 @@ class CollectiveTransformationReorder : public HloModulePass {
   CollectiveTransformationReorder() = default;
   ~CollectiveTransformationReorder() override = default;
   absl::string_view name() const override {
-    static constexpr absl::string_view kName =
-        "collective-transformation-reorderer";
-    return kName;
+    return "collective-transformation-reorderer";
   }
   using HloPassInterface::Run;
   absl::StatusOr<bool> Run(

--- a/xla/service/indexed_array_analysis.cc
+++ b/xla/service/indexed_array_analysis.cc
@@ -1146,10 +1146,6 @@ absl::StatusOr<Analysis::Array*> IndexedArrayAnalysis::ComputeArrayForDot(
   return nullptr;
 }
 
-absl::string_view IndexedArrayAnalysisPrinterPass::name() const {
-  return "indexed-array-analysis-printer-pass";
-}
-
 absl::StatusOr<bool> IndexedArrayAnalysisPrinterPass::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {

--- a/xla/service/indexed_array_analysis.h
+++ b/xla/service/indexed_array_analysis.h
@@ -370,7 +370,9 @@ class IndexedArrayAnalysis {
 // unconditionally add to the regular HLO pass pipeline.
 class IndexedArrayAnalysisPrinterPass : public HloModulePass {
  public:
-  absl::string_view name() const override;
+  absl::string_view name() const override {
+    return "indexed-array-analysis-printer-pass";
+  }
   using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,

--- a/xla/service/while_loop_concat_code_motion.h
+++ b/xla/service/while_loop_concat_code_motion.h
@@ -64,9 +64,9 @@ class WhileLoopConcatCodeMotion : public HloModulePass {
   ~WhileLoopConcatCodeMotion() override = default;
 
   absl::string_view name() const override {
-    static constexpr absl::string_view kName = "while-loop-concat-code-motion";
-    return kName;
+    return "while-loop-concat-code-motion";
   }
+
   using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,


### PR DESCRIPTION
I found couple passes with simple `absl::string_view name()` implementation which were defined in cc files.
All other passes define `name()` in header file. (Unless name() impl requires if/switch block)

This PR makes simple `absl::string_view name()` implementation consistent across all passes.