### PR TITLE
[XLA:GPU] move cublasLt creation to thunk initialization.

### DIFF
--- a/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -125,5 +125,12 @@ CublasLtMatmulThunk::GetMatmulAlgorithm(
   return it->second;
 }
 
+absl::Status CublasLtMatmulThunk::Initialize(const InitializeParams& params) {
+  if (!params.executor->AsBlas()) {
+    return absl::InternalError("Failed to initialize BLASLT support");
+  }
+  return absl::OkStatus();
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.h
+++ b/xla/service/gpu/runtime/gpublas_lt_matmul_thunk.h
@@ -49,6 +49,7 @@ class CublasLtMatmulThunk : public Thunk {
                       BufferAllocation::Slice d_amax_buffer /* may be null */);
 
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+  absl::Status Initialize(const InitializeParams& params) override;
 
  private:
   absl::StatusOr<se::gpu::BlasLt::MatmulPlan*> GetMatmulPlan(


### PR DESCRIPTION
To avoid cublasLt and command buffer deadlock, move cublasLt creation to thunk initialization.