### PR TITLE
Including all the gpu versions mentioned in the backends attribute.

### DIFF
--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -111,7 +111,7 @@ def xla_test(
         if backend == "cpu":
             backend_deps = ["//xla/service:cpu_plugin"]
             backend_deps += ["//xla/tests:test_macros_cpu"]  # buildifier: disable=list-append
-        elif backend == "gpu":
+        elif backend == "gpu" or backend == "gpu_a100" or backend == "gpu_v100" or backend == "gpu_p100" or backend == "gpu_h100":
             backend_deps = if_gpu_is_configured(["//xla/service:gpu_plugin"])
             backend_deps += if_gpu_is_configured(["//xla/tests:test_macros_gpu"])  # buildifier: disable=list-append
             this_backend_tags += tf_gpu_tests_tags()

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -11,8 +11,9 @@ load(
 )
 load("//xla/tests:plugin.bzl", "plugins")
 
-gpu_backends = ["gpu", "gpu_p100", "gpu_v100", "gpu_a100", "gpu_h100"]
-all_backends = gpu_backends + ["cpu"] + plugins.keys()
+default_backends = ["cpu", "gpu"]
+gpu_backends = ["gpu_p100", "gpu_v100", "gpu_a100", "gpu_h100"]
+all_backends = default_backends + gpu_backends + plugins.keys()
 
 def xla_test(
         name,
@@ -95,7 +96,7 @@ def xla_test(
 
     test_names = []
     if not backends:
-        backends = all_backends
+        backends = default_backends
 
     backends = [
         backend
@@ -196,9 +197,8 @@ def xla_test_library(
         Supported values: "cpu", "gpu". If this list is empty, the
         library will be generated for all supported backends.
     """
-
     if not backends:
-        backends = all_backends
+        backends = default_backends
 
     for backend in backends:
         this_backend_copts = []
@@ -231,7 +231,7 @@ def generate_backend_suites(backends = []):  # buildifier: disable=unnamed-macro
     """
 
     if not backends:
-        backends = all_backends
+        backends = default_backends
     for backend in backends:
         native.test_suite(
             name = "%s_tests" % backend,
@@ -245,7 +245,7 @@ def generate_backend_test_macros(backends = []):  # buildifier: disable=unnamed-
       backends: The list of backends to generate libraries for.
     """
     if not backends:
-        backends = all_backends
+        backends = default_backends
     for backend in backends:
         manifest = ""
         if backend in plugins:

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -202,8 +202,10 @@ def xla_test_library(
 
     for backend in backends:
         this_backend_copts = []
-        if backend in default_backends + gpu_backends:
-            backend_deps = ["//xla/tests:test_macros_%s" % backend]
+        if backend == "cpu":
+            backend_deps = ["//xla/tests:test_macros_cpu"]
+        elif backend in gpu_backends:
+            backend_deps = ["//xla/tests:test_macros_gpu"]
         elif backend in plugins:
             backend_deps = plugins[backend]["deps"]
             this_backend_copts += plugins[backend]["copts"]

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -114,7 +114,7 @@ def xla_test(
             backend_deps += ["//xla/tests:test_macros_cpu"]  # buildifier: disable=list-append
         elif backend in gpu_backends:
             backend_deps = if_gpu_is_configured(["//xla/service:gpu_plugin"])
-            backend_deps += if_gpu_is_configured(["//xla/tests:test_macros_gpu"])  # buildifier: disable=list-append
+            backend_deps += if_gpu_is_configured(["//xla/tests:test_macros_%s" % backend])  # buildifier: disable=list-append
             this_backend_tags += tf_gpu_tests_tags()
         elif backend in plugins:
             backend_deps = []
@@ -202,7 +202,7 @@ def xla_test_library(
 
     for backend in backends:
         this_backend_copts = []
-        if backend in ["cpu", "gpu"]:
+        if backend in ["cpu"] + gpu_backends:
             backend_deps = ["//xla/tests:test_macros_%s" % backend]
         elif backend in plugins:
             backend_deps = plugins[backend]["deps"]

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -11,7 +11,8 @@ load(
 )
 load("//xla/tests:plugin.bzl", "plugins")
 
-all_backends = ["cpu", "gpu"] + plugins.keys()
+gpu_backends = ["gpu", "gpu_p100", "gpu_v100", "gpu_a100", "gpu_h100"]
+all_backends = gpu_backends + ["cpu"] + plugins.keys()
 
 def xla_test(
         name,
@@ -111,7 +112,7 @@ def xla_test(
         if backend == "cpu":
             backend_deps = ["//xla/service:cpu_plugin"]
             backend_deps += ["//xla/tests:test_macros_cpu"]  # buildifier: disable=list-append
-        elif backend == "gpu" or backend == "gpu_a100" or backend == "gpu_v100" or backend == "gpu_p100" or backend == "gpu_h100":
+        elif backend in gpu_backends:
             backend_deps = if_gpu_is_configured(["//xla/service:gpu_plugin"])
             backend_deps += if_gpu_is_configured(["//xla/tests:test_macros_gpu"])  # buildifier: disable=list-append
             this_backend_tags += tf_gpu_tests_tags()

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -115,7 +115,7 @@ def xla_test(
             backend_deps += ["//xla/tests:test_macros_cpu"]  # buildifier: disable=list-append
         elif backend in gpu_backends:
             backend_deps = if_gpu_is_configured(["//xla/service:gpu_plugin"])
-            backend_deps += if_gpu_is_configured(["//xla/tests:test_macros_%s" % backend])  # buildifier: disable=list-append
+            backend_deps += if_gpu_is_configured(["//xla/tests:test_macros_gpu"])  # buildifier: disable=list-append
             this_backend_tags += tf_gpu_tests_tags()
         elif backend in plugins:
             backend_deps = []

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -12,7 +12,7 @@ load(
 load("//xla/tests:plugin.bzl", "plugins")
 
 default_backends = ["cpu", "gpu"]
-gpu_backends = ["gpu_p100", "gpu_v100", "gpu_a100", "gpu_h100"]
+gpu_backends = ["gpu", "gpu_p100", "gpu_v100", "gpu_a100", "gpu_h100"]
 all_backends = default_backends + gpu_backends + plugins.keys()
 
 def xla_test(
@@ -202,7 +202,7 @@ def xla_test_library(
 
     for backend in backends:
         this_backend_copts = []
-        if backend in ["cpu"] + gpu_backends:
+        if backend in default_backends + gpu_backends:
             backend_deps = ["//xla/tests:test_macros_%s" % backend]
         elif backend in plugins:
             backend_deps = plugins[backend]["deps"]


### PR DESCRIPTION
Added all the gpu version mentioned in the backends field in BUILD files. The tests marked with gpu_v100, gpu_a100, gpu_h100, etc were not getting picked up by bazel during execution. The fix will include the tests and run them on respective gpu nodes.