### PR TITLE
Add ReduceScatter and CollectiveBroadcast to IsCollectiveWithChannelId

### DIFF
--- a/xla/service/collective_ops_utils.cc
+++ b/xla/service/collective_ops_utils.cc
@@ -615,8 +615,10 @@ bool IsCollectiveWithChannelId(const HloInstruction* instruction) {
     case HloOpcode::kAllGather:
     case HloOpcode::kAllGatherStart:
     case HloOpcode::kAllToAll:
+    case HloOpcode::kCollectiveBroadcast:
     case HloOpcode::kCollectivePermute:
     case HloOpcode::kCollectivePermuteStart:
+    case HloOpcode::kReduceScatter:
       return instruction->channel_id().has_value();
     case HloOpcode::kFusion:
       for (const auto* inner_inst : instruction->fused_instructions()) {


### PR DESCRIPTION
Add `ReduceScatter` and `CollectiveBroadcast` to `IsCollectiveWithChannelId()` util method defined in `xla/service/collective_ops_utils.cc`.

Both instructions derive from `HloChannelInstruction` class which declares public `channel_id()` method.

```
class HloChannelInstruction : public HloInstruction {
    std::optional<int64_t> channel_id() const { return channel_id_; }

class HloCollectiveInstruction : public HloChannelInstruction

class HloCollectiveBroadcastInstruction : public HloCollectiveInstruction

class HloAllReduceInstructionBase : public HloCollectiveInstruction

class HloReduceScatterInstruction : public HloAllReduceInstructionBase 
```

Related Issue: https://github.com/openxla/xla/issues/11742