### PR TITLE
[gpu] Change the implementation of GetFusionRoots to a simpler one

### DIFF
--- a/xla/service/gpu/gpu_fusible.h
+++ b/xla/service/gpu/gpu_fusible.h
@@ -187,19 +187,19 @@ absl::InlinedVector<const HloInstruction*, 2> GetOutputsOfFusible(
 size_t GetOutputSizeOfFusible(const HloInstruction& instr);
 
 // Returns instructions which are roots of the fusion, following the operands of
-// GTE instructions in the root tuple. Groups multiple subsequent instructions
-// with the same root. CHECKs that the fusion never outputs the same instruction
-// twice, as well as that there are no explicitly created tuples or nested gtes
-// in fusion output.
+// GTE instructions in the root tuple that extract from a tuple.
 //
-// For input: (tuple (gte R1) (gte R1) O2)
-// Expected output: [R1, O2]
+// For input: (tuple (gte tuple(R1)) (gte tuple(R1)) O2)
+// Expected output: [R1, R1, O2]
 //
 // For input: (tuple R1 R2 O2)
 // Expected output: [R1, R2, O2]
 //
-// For input: (tuple (gte R1) (gte R1) R2 O3)
-// Expected output: [R1, R2, O3]
+// For input: (tuple (gte tuple(R1)) R2 (gte tuple(R1)) O3)
+// Expected output: [R1, R2, R1, O3]
+//
+// For input: (tuple (gte R1) R2 (gte R1) O3)
+// Expected output: [R1, R2, R1, O3]
 //
 // For input: R1
 // Expected output: [R1]

--- a/xla/service/gpu/multi_output_fusion_test.cc
+++ b/xla/service/gpu/multi_output_fusion_test.cc
@@ -2175,5 +2175,32 @@ ENTRY computation {
   )");
 }
 
+TEST_F(ReduceMultiOutputFusionTest, GetTupleElementMakeTupleSequence) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+    HloModule test_module
+
+    fusion {
+      p0 = s32[] parameter(0)
+      p1 = s32[32] parameter(1)
+      custom-call = (bf16[], s32[], u32[]) custom-call(p1), custom_call_target="my_custom_call"
+      get-tuple-element.0 = bf16[] get-tuple-element(custom-call), index=0
+      get-tuple-element.1 = s32[] get-tuple-element(custom-call), index=1
+      bitcast = s32[1] bitcast(get-tuple-element.1)
+      dynamic-update-slice = s32[32] dynamic-update-slice(p1, bitcast, p0)
+      get-tuple-element.2 = u32[] get-tuple-element(custom-call), index=2
+      ROOT tuple.30 = (bf16[], s32[32], u32[]) tuple(get-tuple-element.0, dynamic-update-slice, get-tuple-element.2)
+    }
+
+    ENTRY entry{
+      p0 = s32[] parameter(0)
+      bitcast = s32[32] bitcast(p0)
+      ROOT address_computation.7.0 = (bf16[], s32[32], u32[]) fusion(p0, bitcast), kind=kCustom, calls=fusion
+    }
+  )")
+                    .value();
+
+  ASSERT_FALSE(mof_.Run(module.get()).value());
+}
+
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
Following the tuple -> get-tuple-element sequence for getting roots and remove allowing a duplicate root in case it is encountered twice in a row in the recursive search.