### PR TITLE
[GPU] Support nccl comm splitting in multiprocess mode

### DIFF
--- a/xla/service/gpu/runtime/nccl_clique.cc
+++ b/xla/service/gpu/runtime/nccl_clique.cc
@@ -407,7 +407,7 @@ static absl::StatusOr<std::shared_ptr<NcclClique::Lock>> InitializeNcclClique(
 
     absl::btree_map<int32_t, NcclApi::OwnedNcclComm> comms;
     for (size_t i = 0; i < splitted_comms.size(); ++i) {
-      comms[i] = std::move(splitted_comms[i]);
+      comms[keys[i]] = std::move(splitted_comms[i]);
     }
 
     VLOG(3) << absl::StreamFormat(
@@ -498,10 +498,6 @@ absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
 
   if (enable_nccl_comm_splitting) {
     for (auto& [acquired_clique_key, acquired_clique] : acquired_cliques) {
-      // We don't support splitting non-local cliques as it requires careful
-      // synchronization between multiple processes.
-      if (!(*acquired_clique)->IsLocal()) continue;
-
       if (clique_key.IsSubsetOf(acquired_clique_key)) {
         return InitializeNcclClique(device, run_id, clique_key, acquired_clique,
                                     num_local_participants, rank, config);


### PR DESCRIPTION
Currently `--xla_gpu_enable_nccl_comm_splitting` is a no-op unless using single process mode. This PR allows it to work in multiprocess mode by removing the IsLocal check and fixing the key in the rank -> comm map which was causing the following error:
```
7:  Communicator for rank 1 not found in a NCCL clique devices=[3,7]; stream=0
5: E0403 15:37:24.104311 3871038 pjrt_stream_executor_client.cc:2809] Execution of replica 0 failed: INTERNAL: Communicator for rank 1 not found in a NCCL clique devices=[1,5]; stream=0
6: E0403 15:37:24.104477 3870182 pjrt_stream_executor_client.cc:2809] Execution of replica 0 failed: INTERNAL: Communicator for rank 1 not found in a NCCL clique devices=[2,6]; stream=0
4: E0403 15:37:24.105872 3871021 pjrt_stream_executor_client.cc:2809] Execution of replica 0 failed: INTERNAL: Communicator for rank 1 not found in a NCCL clique devices=[0,4]; stream=0
```