### PR TITLE
[GPU] Enable nccl comm split by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -147,7 +147,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_termination_timeout_seconds(-1);
   opts.set_xla_gpu_enable_shared_constants(true);
   opts.set_xla_gpu_enable_nccl_user_buffers(false);
-  opts.set_xla_gpu_enable_nccl_comm_splitting(false);
+  opts.set_xla_gpu_enable_nccl_comm_splitting(true);
   opts.set_xla_gpu_enable_nccl_per_stream_comms(false);
 
   // Set 4GB space limit for redzone scratch allocator.


### PR DESCRIPTION
With https://github.com/openxla/xla/pull/11761 NCCL comm split will be available for multiprocess applications. Using that change, I tested a variety of PAXML and T5X workloads. I found no crashes, hangs, or performance regressions and a good amount of memory savings depending on the model. I tested many more workloads aside from these four, but there was no interesting results since they only used a single communicator.

| Workload                                                                 | Mem diff (MiB) | Speedup |
| ------------------------------------------------------------------------ | ------------- | --------- |
| paxml llama70b evaluate 16xh100 bfloat16 bs-4 ici--1-8-1 dcn--1-2-1      | 0 | 0.9915 |
| paxml GPT3 train 8xh100 bfl16 bs-4 ici--4-1-2                            | \-320 | 1.0029 |
| paxml GPT3 train 8xh100 bfl16 bs-8 ici--1-4-2                            | \-1252 |  1.0026 |
| paxml GPT3pp train 16xh100 bf16 bs-8 ici--2-2-1-2                        | \-2990 | 0.9947 |

