### PR TITLE
[XLA:GPU] Add cuDNN Flash Attention Padding Mask Generation & Skipping computation on padded tokens in XLA

### DIFF
--- a/xla/service/gpu/cudnn_workspace_rewriter.cc
+++ b/xla/service/gpu/cudnn_workspace_rewriter.cc
@@ -150,6 +150,12 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
 
     std::optional<Shape> fwd_output_shape =
         custom_call->operand(input_index++)->shape();
+    if (config.mask_type() == xla::gpu::CudnnfMHABackendConfig::PADDING ||
+        config.mask_type() ==
+            xla::gpu::CudnnfMHABackendConfig::PADDING_CAUSAL) {
+      // skip q_seqlen and kv_seqlen
+      input_index += 2;
+    }
     TF_RET_CHECK(input_index == custom_call->operand_count());
 
     int output_index = 0;

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -773,6 +773,157 @@ class FlashAttentionBMMScaleSoftmaxBMM : public MultiHeadedAttentionTest {
   }
 };
 
+class FlashAttentionBMMScalePaddingMaskSoftmaxBMM
+    : public MultiHeadedAttentionTest {
+ protected:
+  const std::string  // NOLINT
+  GetModuleFlash_Attention_Training_BMM1_PaddingMask_As_Bias_Softmax_BMM2_HloString_BF16() {  // NOLINT
+    const std::string hlo_text = R"(
+    HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})->(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})}, allow_spmd_sharding_propagation_to_parameters={true,true,true,true}, allow_spmd_sharding_propagation_to_output={true,true,true,true}
+
+    region_0.32 {
+      Arg_0.33 = bf16[] parameter(0)
+      Arg_1.34 = bf16[] parameter(1)
+      ROOT maximum = bf16[] maximum(Arg_0.33, Arg_1.34)
+    }
+
+    region_1.45 {
+      Arg_0.46 = f32[] parameter(0)
+      Arg_1.47 = f32[] parameter(1)
+      ROOT add = f32[] add(Arg_0.46, Arg_1.47)
+    }
+
+    region_2.80 {
+      Arg_0.81 = bf16[] parameter(0)
+      Arg_1.82 = bf16[] parameter(1)
+      ROOT add.1 = bf16[] add(Arg_0.81, Arg_1.82)
+    }
+
+    ENTRY main.106 {
+      Arg_2.3 = bf16[4,1024,4,64]{3,2,1,0} parameter(2)
+      transpose.16 = bf16[4,4,64,1024]{3,2,1,0} transpose(Arg_2.3), dimensions={0,2,3,1}
+      Arg_0.1 = bf16[4,1024,4,64]{3,2,1,0} parameter(0)
+      transpose.17 = bf16[4,4,1024,64]{3,2,1,0} transpose(Arg_0.1), dimensions={0,2,1,3}
+      Arg_1.2 = bf16[4,1024,4,64]{3,2,1,0} parameter(1)
+      transpose.19 = bf16[4,4,64,1024]{3,2,1,0} transpose(Arg_1.2), dimensions={0,2,3,1}
+      dot = bf16[4,4,1024,1024]{3,2,1,0} dot(transpose.17, transpose.19), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+      iota = s32[1024]{0} iota(), iota_dimension=0
+      constant.9 = s32[] constant(512)
+      broadcast.15 = s32[1024]{0} broadcast(constant.9), dimensions={}
+      compare = pred[1024]{0} compare(iota, broadcast.15), direction=GE
+      broadcast.16 = pred[1024,1024]{1,0} broadcast(compare), dimensions={0}
+      broadcast.17 = pred[1024,1024]{1,0} broadcast(compare), dimensions={1}
+      or = pred[1024,1024]{1,0} or(broadcast.16, broadcast.17)
+      constant.7 = bf16[] constant(-2.199e+12)
+      broadcast.18 = bf16[1024,1024]{1,0} broadcast(constant.7), dimensions={}
+      constant.11 = bf16[] constant(0)
+      broadcast.19 = bf16[1024,1024]{1,0} broadcast(constant.11), dimensions={}
+      select.1 = bf16[1024,1024]{1,0} select(or, broadcast.18, broadcast.19)
+      broadcast.20 = bf16[4,4,1024,1024]{3,2,1,0} broadcast(select.1), dimensions={2,3}
+      add.2 = bf16[4,4,1024,1024]{3,2,1,0} add(dot, broadcast.20)
+      constant.13 = bf16[] constant(-inf)
+      reduce.36 = bf16[4,4,1024]{2,1,0} reduce(add.2, constant.13), dimensions={3}, to_apply=region_0.32
+      broadcast.22 = bf16[4,4,1024,1024]{3,2,1,0} broadcast(reduce.36), dimensions={0,1,2}
+      subtract = bf16[4,4,1024,1024]{3,2,1,0} subtract(add.2, broadcast.22)
+      exponential = bf16[4,4,1024,1024]{3,2,1,0} exponential(subtract)
+      convert.5 = f32[4,4,1024,1024]{3,2,1,0} convert(exponential)
+      constant.12 = f32[] constant(0)
+      reduce.49 = f32[4,4,1024]{2,1,0} reduce(convert.5, constant.12), dimensions={3}, to_apply=region_1.45
+      convert.6 = bf16[4,4,1024]{2,1,0} convert(reduce.49)
+      broadcast.25 = bf16[4,4,1024,1024]{3,2,1,0} broadcast(convert.6), dimensions={0,1,2}
+      divide.2 = bf16[4,4,1024,1024]{3,2,1,0} divide(exponential, broadcast.25)
+      dot.1 = bf16[4,4,64,1024]{3,2,1,0} dot(transpose.16, divide.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}
+      iota.1 = s32[1024]{0} iota(), iota_dimension=0
+      compare.1 = pred[1024]{0} compare(iota.1, broadcast.15), direction=LT
+      convert.7 = bf16[1024]{0} convert(compare.1)
+      broadcast.27 = bf16[4,4,64,1024]{3,2,1,0} broadcast(convert.7), dimensions={3}
+      multiply.3 = bf16[4,4,64,1024]{3,2,1,0} multiply(dot.1, broadcast.27)
+      transpose.26 = bf16[4,1024,4,64]{3,2,1,0} transpose(multiply.3), dimensions={0,3,1,2}
+      Arg_3.4 = bf16[4,1024,4,64]{3,2,1,0} parameter(3)
+      transpose.21 = bf16[4,4,1024,64]{3,2,1,0} transpose(Arg_3.4), dimensions={0,2,1,3}
+      broadcast.28 = bf16[4,4,1024,64]{3,2,1,0} broadcast(convert.7), dimensions={2}
+      multiply.4 = bf16[4,4,1024,64]{3,2,1,0} multiply(transpose.21, broadcast.28)
+      dot.2 = bf16[4,4,1024,1024]{3,2,1,0} dot(multiply.4, transpose.16), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+      divide.3 = bf16[4,4,1024,1024]{3,2,1,0} divide(dot.2, broadcast.25)
+      constant.0 = bf16[] constant(1)
+      broadcast.29 = bf16[4,4,1024]{2,1,0} broadcast(constant.0), dimensions={}
+      multiply.5 = bf16[4,4,1024]{2,1,0} multiply(convert.6, convert.6)
+      divide.4 = bf16[4,4,1024]{2,1,0} divide(broadcast.29, multiply.5)
+      broadcast.31 = bf16[4,4,1024,1024]{3,2,1,0} broadcast(divide.4), dimensions={0,1,2}
+      multiply.6 = bf16[4,4,1024,1024]{3,2,1,0} multiply(dot.2, broadcast.31)
+      multiply.7 = bf16[4,4,1024,1024]{3,2,1,0} multiply(multiply.6, exponential)
+      reduce.84 = bf16[4,4,1024]{2,1,0} reduce(multiply.7, constant.11), dimensions={3}, to_apply=region_2.80
+      negate.1 = bf16[4,4,1024]{2,1,0} negate(reduce.84)
+      broadcast.32 = bf16[4,4,1024,1024]{3,2,1,0} broadcast(negate.1), dimensions={0,1,2}
+      add.3 = bf16[4,4,1024,1024]{3,2,1,0} add(divide.3, broadcast.32)
+      multiply.8 = bf16[4,4,1024,1024]{3,2,1,0} multiply(add.3, exponential)
+      transpose.22 = bf16[4,4,1024,64]{3,2,1,0} transpose(Arg_1.2), dimensions={0,2,1,3}
+      dot.4 = bf16[4,4,1024,64]{3,2,1,0} dot(multiply.8, transpose.22), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+      transpose.27 = bf16[4,1024,4,64]{3,2,1,0} transpose(dot.4), dimensions={0,2,1,3}
+      dot.3 = bf16[4,4,1024,64]{3,2,1,0} dot(multiply.8, transpose.17), lhs_batch_dims={0,1}, lhs_contracting_dims={2}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+      transpose.28 = bf16[4,1024,4,64]{3,2,1,0} transpose(dot.3), dimensions={0,2,1,3}
+      transpose.24 = bf16[4,4,64,1024]{3,2,1,0} transpose(multiply.4), dimensions={0,1,3,2}
+      dot.73 = bf16[4,4,64,1024]{3,2,1,0} dot(transpose.24, divide.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+      transpose.29 = bf16[4,1024,4,64]{3,2,1,0} transpose(dot.73), dimensions={0,3,1,2}
+      ROOT tuple = (bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}) tuple(transpose.26, transpose.27, transpose.28, transpose.29)
+    } // main.106
+  )";
+    return hlo_text;
+  }
+
+  const std::string  // NOLINT
+  GetModuleFlash_Attention_Training_BMM1_PaddingMask_Generation_Softmax_BMM2_HloString_BF16() {  // NOLINT
+    const std::string hlo_text = R"(
+    HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})->(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})}, allow_spmd_sharding_propagation_to_parameters={true,true,true,true}, allow_spmd_sharding_propagation_to_output={true,true,true,true}
+
+    ENTRY main.21 {
+      Arg_0.1 = bf16[4,1024,4,64]{3,2,1,0} parameter(0)
+      Arg_1.2 = bf16[4,1024,4,64]{3,2,1,0} parameter(1)
+      Arg_2.3 = bf16[4,1024,4,64]{3,2,1,0} parameter(2)
+      constant.5 = s32[] constant(512)
+      broadcast.6 = s32[4]{0} broadcast(constant.5), dimensions={}
+      custom-call.7 = (bf16[4,4,1024,64]{3,1,2,0}, u8[0]{0}, f32[4,4,1024]{2,1,0}) custom-call(Arg_0.1, Arg_1.2, Arg_2.3, broadcast.6, broadcast.6), custom_call_target="__cudnn$fmhaSoftmax", operand_layout_constraints={bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, s32[4]{0}, s32[4]{0}}, api_version=API_VERSION_STATUS_RETURNING, backend_config={"operation_queue_id": "0", "wait_on_operation_queues": [], "cudnn_fmha_backend_config": {"algorithm": {"algo_id": "0", "math_type": "TENSOR_OP_MATH", "tuning_knobs": {"17": "1", "24": "0"}, "is_cudnn_frontend": true, "workspace_size": "0"}, "fmha_scale": 1.0, "dropout_rate": 0, "intermediate_tensor_shape": {"element_type": "BF16", "dimensions": ["4", "4", "1024", "1024"], "tuple_shapes": [], "layout": {"dim_level_types": [], "dim_unique": [], "dim_ordered": [], "minor_to_major": ["3", "2", "1", "0"], "tiles": [], "element_size_in_bits": "0", "memory_space": "0", "index_primitive_type": "PRIMITIVE_TYPE_INVALID", "pointer_primitive_type": "PRIMITIVE_TYPE_INVALID", "dynamic_shape_metadata_prefix_bytes": "0"}, "is_dynamic_dimension": [false, false, false, false]}, "seed": 42, "is_flash_attention": true, "mask_type": "PADDING", "bmm1_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["3"], "lhs_batch_dimensions": ["0", "2"], "rhs_batch_dimensions": ["0", "2"]}, "bmm2_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}}}
+      get-tuple-element.9 = u8[0]{0} get-tuple-element(custom-call.7), index=1
+      get-tuple-element.10 = f32[4,4,1024]{2,1,0} get-tuple-element(custom-call.7), index=2
+      Arg_3.4 = bf16[4,1024,4,64]{3,2,1,0} parameter(3)
+      get-tuple-element.8 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.7), index=0
+      transpose.11 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.8), dimensions={0,2,1,3}
+      custom-call.12 = (bf16[4,4,1024,64]{3,1,2,0}, bf16[4,4,1024,64]{3,1,2,0}, bf16[4,4,1024,64]{3,1,2,0}, u8[0]{0}) custom-call(Arg_0.1, Arg_1.2, Arg_2.3, get-tuple-element.10, Arg_3.4, /*index=5*/transpose.11, broadcast.6, broadcast.6), custom_call_target="__cudnn$fmhaSoftmaxBackward", operand_layout_constraints={bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, f32[4,4,1024]{2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, s32[4]{0}, s32[4]{0}}, api_version=API_VERSION_STATUS_RETURNING, backend_config={"operation_queue_id": "0", "wait_on_operation_queues": [], "cudnn_fmha_backend_config": {"algorithm": {"algo_id": "0", "math_type": "TENSOR_OP_MATH", "tuning_knobs": {"17": "1", "24": "0"}, "is_cudnn_frontend": true, "workspace_size": "0"}, "fmha_scale": 1.0, "dropout_rate": 0, "intermediate_tensor_shape": {"element_type": "BF16", "dimensions": ["4", "4", "1024", "1024"], "tuple_shapes": [], "layout": {"dim_level_types": [], "dim_unique": [], "dim_ordered": [], "minor_to_major": ["3", "2", "1", "0"], "tiles": [], "element_size_in_bits": "0", "memory_space": "0", "index_primitive_type": "PRIMITIVE_TYPE_INVALID", "pointer_primitive_type": "PRIMITIVE_TYPE_INVALID", "dynamic_shape_metadata_prefix_bytes": "0"}, "is_dynamic_dimension": [false, false, false, false]}, "seed": 42, "is_flash_attention": true, "mask_type": "PADDING", "bmm1_grad_gemm1_dot_dimension_numbers": {"lhs_contracting_dimensions": ["2"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}, "bmm1_grad_gemm2_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}, "bmm2_grad_gemm1_dot_dimension_numbers": {"lhs_contracting_dimensions": ["2"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}, "bmm2_grad_gemm2_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["3"], "lhs_batch_dimensions": ["0", "2"], "rhs_batch_dimensions": ["0", "2"]}}}
+      get-tuple-element.16 = u8[0]{0} get-tuple-element(custom-call.12), index=3
+      get-tuple-element.13 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.12), index=0
+      transpose.17 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.13), dimensions={0,2,1,3}
+      get-tuple-element.14 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.12), index=1
+      transpose.18 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.14), dimensions={0,2,1,3}
+      get-tuple-element.15 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.12), index=2
+      transpose.19 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.15), dimensions={0,2,1,3}
+      ROOT tuple.20 = (bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}) tuple(transpose.11, transpose.17, transpose.18, transpose.19)
+    } // main.21
+    )";
+    return hlo_text;
+  }
+
+  template <typename T>
+  void TestImpl_Flash_Attention_Training_BMM1_PaddingMask_Softmax_BMM2() {
+    if (skip_reason_) GTEST_SKIP() << *skip_reason_;
+    if (GetDnnVersionInfo(backend().default_stream_executor()) <
+        se::dnn::VersionInfo(8, 9, 3)) {
+      GTEST_SKIP() << "Flash Attention requires cuDNN >= 8.9.3.";
+    }
+    XlaBuilder builder(TestName());
+    // pass padding mask as bias
+    std::string hlo_string =
+        GetModuleFlash_Attention_Training_BMM1_PaddingMask_As_Bias_Softmax_BMM2_HloString_BF16();  // NOLINT
+    // generate padding mask in cuDNN directly
+    // XLA pattern match does not support pattern matching padding mask
+    // so directly lower to custom call instead for reference
+    std::string hlo_string_ref =
+        GetModuleFlash_Attention_Training_BMM1_PaddingMask_Generation_Softmax_BMM2_HloString_BF16();  // NOLINT
+    HloModuleConfig config{};
+    EXPECT_TRUE(RunAndCompareTwoModules(hlo_string, hlo_string_ref, config,
+                                        config, ErrorSpec{1e-5, 1e-5}));
+  }
+};
+
 // BMM1 - Scale - CausalMask - Softmax - BMM2
 XLA_TEST_F(FlashAttentionBMMScaleCausalMaskSoftmaxBMM,
            Flash_Attention_BMM1_CausalMask_Softmax_BMM2_BF16) {
@@ -804,6 +955,12 @@ XLA_TEST_F(FlashAttentionBMMScaleBiasSoftmaxBMM,
 XLA_TEST_F(FlashAttentionBMMScaleSoftmaxBMM,
            Flash_Attention_Training_BMM1_Softmax_BMM2_BF16) {
   TestImpl_Flash_Attention_Training_BMM1_Softmax_BMM2<bfloat16>();
+}
+
+// BMM1 - Scale - PaddingMask - Softmax - BMM2
+XLA_TEST_F(FlashAttentionBMMScalePaddingMaskSoftmaxBMM,
+           Flash_Attention_Training_BMM1_PaddingMask_Softmax_BMM2_BF16) {
+  TestImpl_Flash_Attention_Training_BMM1_PaddingMask_Softmax_BMM2<bfloat16>();
 }
 }  // namespace
 }  // namespace gpu

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -7209,8 +7209,7 @@ CudnnSupport::FusedMHARunnerFromDesc(
   int64_t dropout_rng_seed = seed.has_value() ? *seed : 0;
   std::vector<std::optional<int64_t>> uids = {
       CudnnfMHAUid::Q_ID, CudnnfMHAUid::K_ID, CudnnfMHAUid::V_ID,
-      CudnnfMHAUid::O_ID,
-      /*mask=*/std::nullopt};
+      CudnnfMHAUid::O_ID};
   uids.emplace_back(bias_descriptor.has_value()
                         ? std::optional<CudnnfMHAUid>(CudnnfMHAUid::BIAS_ID)
                         : std::nullopt);

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5144,12 +5144,14 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
                          .set_name("seq_q")
                          .set_dim({b, 1, 1, 1})
                          .set_stride({1, 1, 1, 1})
+                         .set_uid(CudnnfMHAUid::Q_SEQLEN_ID)
                          .set_data_type(cudnn_frontend::DataType_t::INT32));
     auto seq_kv_tensor =
         graph.tensor(Tensor_attributes()
                          .set_name("seq_kv")
                          .set_dim({b, 1, 1, 1})
                          .set_stride({1, 1, 1, 1})
+                         .set_uid(CudnnfMHAUid::K_SEQLEN_ID)
                          .set_data_type(cudnn_frontend::DataType_t::INT32));
     sdpa_options.set_padding_mask(true);
     sdpa_options.set_seq_len_q(seq_q_tensor);
@@ -5341,12 +5343,14 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
                          .set_name("seq_q")
                          .set_dim({b, 1, 1, 1})
                          .set_stride({1, 1, 1, 1})
+                         .set_uid(CudnnfMHAUid::Q_SEQLEN_ID)
                          .set_data_type(cudnn_frontend::DataType_t::INT32));
     auto seq_kv_tensor =
         graph.tensor(Tensor_attributes()
                          .set_name("seq_kv")
                          .set_dim({b, 1, 1, 1})
                          .set_stride({1, 1, 1, 1})
+                         .set_uid(CudnnfMHAUid::K_SEQLEN_ID)
                          .set_data_type(cudnn_frontend::DataType_t::INT32));
     sdpa_backward_options.set_padding_mask(true);
     sdpa_backward_options.set_seq_len_q(seq_q_tensor);

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5133,6 +5133,28 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
                          .set_uid(CudnnfMHAUid::BIAS_ID));
     sdpa_options.set_bias(bias_tensor);
   }
+  // Setting actual seqlen
+  bool is_padding = mask_type == dnn::FMHAMaskKind::PADDING ||
+                    mask_type == dnn::FMHAMaskKind::PADDING_CAUSAL;
+  if (is_padding) {
+    auto q_dim = q_descriptor.GetCudnnCompatibleDimensions(true);
+    auto b = q_dim[0];
+    auto seq_q_tensor =
+        graph.tensor(Tensor_attributes()
+                         .set_name("seq_q")
+                         .set_dim({b, 1, 1, 1})
+                         .set_stride({1, 1, 1, 1})
+                         .set_data_type(cudnn_frontend::DataType_t::INT32));
+    auto seq_kv_tensor =
+        graph.tensor(Tensor_attributes()
+                         .set_name("seq_kv")
+                         .set_dim({b, 1, 1, 1})
+                         .set_stride({1, 1, 1, 1})
+                         .set_data_type(cudnn_frontend::DataType_t::INT32));
+    sdpa_options.set_padding_mask(true);
+    sdpa_options.set_seq_len_q(seq_q_tensor);
+    sdpa_options.set_seq_len_kv(seq_kv_tensor);
+  }
   // Setting seed and offset
   if (use_dropout) {
     auto seed_tensor =
@@ -5307,6 +5329,28 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
                          .set_stride(bias_descriptor->GetLogicalStrides())
                          .set_uid(CudnnfMHAUid::BIAS_ID));
     sdpa_backward_options.set_bias(bias_tensor);
+  }
+  // Setting actual seqlen
+  bool is_padding = mask_type == dnn::FMHAMaskKind::PADDING ||
+                    mask_type == dnn::FMHAMaskKind::PADDING_CAUSAL;
+  if (is_padding) {
+    auto q_dim = q_desc.GetCudnnCompatibleDimensions(false);
+    auto b = q_dim[0];
+    auto seq_q_tensor =
+        graph.tensor(Tensor_attributes()
+                         .set_name("seq_q")
+                         .set_dim({b, 1, 1, 1})
+                         .set_stride({1, 1, 1, 1})
+                         .set_data_type(cudnn_frontend::DataType_t::INT32));
+    auto seq_kv_tensor =
+        graph.tensor(Tensor_attributes()
+                         .set_name("seq_kv")
+                         .set_dim({b, 1, 1, 1})
+                         .set_stride({1, 1, 1, 1})
+                         .set_data_type(cudnn_frontend::DataType_t::INT32));
+    sdpa_backward_options.set_padding_mask(true);
+    sdpa_backward_options.set_seq_len_q(seq_q_tensor);
+    sdpa_backward_options.set_seq_len_kv(seq_kv_tensor);
   }
   // Setting seed and offset
   if (use_dropout) {
@@ -7161,13 +7205,22 @@ CudnnSupport::FusedMHARunnerFromDesc(
   int64_t dropout_rng_seed = seed.has_value() ? *seed : 0;
   std::vector<std::optional<int64_t>> uids = {
       CudnnfMHAUid::Q_ID, CudnnfMHAUid::K_ID, CudnnfMHAUid::V_ID,
-      CudnnfMHAUid::O_ID};
+      CudnnfMHAUid::O_ID,
+      /*mask=*/std::nullopt};
   uids.emplace_back(bias_descriptor.has_value()
                         ? std::optional<CudnnfMHAUid>(CudnnfMHAUid::BIAS_ID)
                         : std::nullopt);
   uids.emplace_back(activation_descriptor.has_value()
                         ? std::optional<CudnnfMHAUid>(CudnnfMHAUid::P_ID)
                         : std::nullopt);
+  bool is_padding = mask_type == dnn::FMHAMaskKind::PADDING ||
+                    mask_type == dnn::FMHAMaskKind::PADDING_CAUSAL;
+  uids.emplace_back(
+      is_padding ? std::optional<CudnnfMHAUid>(CudnnfMHAUid::Q_SEQLEN_ID)
+                  : std::nullopt);
+  uids.emplace_back(
+      is_padding ? std::optional<CudnnfMHAUid>(CudnnfMHAUid::K_SEQLEN_ID)
+                  : std::nullopt);
   TF_ASSIGN_OR_RETURN(auto runner,
                       CudnnGraphRunner<dnn::FusedMHASignature>::Create(
                           parent_, cudnn_.get(), std::move(graph),


### PR DESCRIPTION
* Follow up PR on https://github.com/openxla/xla/pull/11449 and https://github.com/openxla/xla/pull/10232.
* Add cuDNN flash attention padding mask generation in XLA. cuDNN also supports skip computation at padded tokens.
* Add an e2e test to compare padding mask generation with pass padding mask as bias in cuDNN.