### PR TITLE
InitializeBuffer: use maximum 2 h2d copies

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -4283,6 +4283,11 @@ xla_cc_test(
     ],
 )
 
+cuda_library(
+    name = "stream_executor_util_kernel",
+    srcs = if_cuda_is_configured(["stream_executor_util_kernel.cu.cc"]),
+)
+
 cc_library(
     name = "stream_executor_util",
     srcs = ["stream_executor_util.cc"],
@@ -4291,6 +4296,7 @@ cc_library(
     deps = [
         ":cublas_cudnn",
         ":launch_dimensions",
+        ":stream_executor_util_kernel",
         "//xla:autotuning_proto_cc",
         "//xla:shape_util",
         "//xla:statusor",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -4293,6 +4293,7 @@ cc_library(
     srcs = ["stream_executor_util.cc"],
     hdrs = ["stream_executor_util.h"],
     copts = tsl_copts(),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":cublas_cudnn",
         ":launch_dimensions",

--- a/xla/service/gpu/stream_executor_util.cc
+++ b/xla/service/gpu/stream_executor_util.cc
@@ -416,15 +416,21 @@ typename std::enable_if<std::is_floating_point<T>::value,
   return std::uniform_real_distribution<T>(lhs, rhs)(*gen);
 }
 
+namespace repeat_buffer_kernel {
+void* kernel();
+}
+
 template <typename T>
 static void InitializeTypedBuffer(se::Stream* stream,
                                   se::DeviceMemoryBase buffer,
                                   int64_t* rng_state) {
   // Accesses to static variables are not locked, since the caller is already
   // in a critical section.
+
+  // Use a large prime number to fragment the accesses.
+  constexpr int host_buffer_size = 10069;
   static std::vector<T>* host_buffer = [] {
-    // Use a large prime number to fragment the accesses.
-    auto* ret = new std::vector<T>(10069);
+    auto* ret = new std::vector<T>(host_buffer_size);
     // Default-seeded random numbers.
     std::mt19937 gen;
     for (auto& element : *ret) {
@@ -447,26 +453,56 @@ static void InitializeTypedBuffer(se::Stream* stream,
     }
     return ret;
   }();
-
-  int64_t& host_index = *rng_state;
-
-  char* current_addr = static_cast<char*>(buffer.opaque());
+  // The buffer of random numbers is treated as being circular, and the seed in
+  // *rng_state is the offset in host_buffer that is copied to the zeroth index
+  // on the device. For large buffers then repeatedly copying the data from the
+  // host is expensive, so we just copy it once and use a kernel to repeat the
+  // data as needed.
   CHECK_EQ(0, buffer.size() % sizeof(T));
-  int64_t elements_left = buffer.size() / sizeof(T);
-  while (elements_left > 0) {
-    CHECK_LE(host_index, host_buffer->size());
-    if (host_buffer->size() == host_index) {
-      host_index = 0;
-    }
-    int64_t elements_copied =
-        std::min<int64_t>(host_buffer->size() - host_index, elements_left);
-    se::DeviceMemoryBase mem(current_addr, elements_copied * sizeof(T));
-    TF_CHECK_OK(stream->Memcpy(&mem, host_buffer->data() + host_index,
-                               elements_copied * sizeof(T)));
-    current_addr += elements_copied * sizeof(T);
-    elements_left -= elements_copied;
-    host_index += elements_copied;
+  int64_t elements_to_fill = buffer.size() / sizeof(T);
+  int64_t host_index = *rng_state;
+  CHECK_LT(host_index, host_buffer_size);
+  *rng_state = (*rng_state + elements_to_fill) % host_buffer_size;
+  // Copy the last part of `host_buffer` to the start of `buf` on the device
+  int64_t first_size =
+      std::min<int64_t>(host_buffer_size - host_index, elements_to_fill);
+  TF_CHECK_OK(stream->Memcpy(&buffer, host_buffer->data() + host_index,
+                             first_size * sizeof(T)));
+  elements_to_fill -= first_size;
+  if (elements_to_fill == 0) {
+    // Nothing more to do
+    return;
   }
+  // Issue a second host->device copy to transfer the rest of host_buffer
+  int64_t second_size = std::min<int64_t>(host_index, elements_to_fill);
+  CHECK_LE(first_size + second_size, host_buffer_size);
+  se::DeviceMemoryBase mem =
+      buffer.GetByteSlice(first_size * sizeof(T), second_size * sizeof(T));
+  TF_CHECK_OK(stream->Memcpy(&mem, host_buffer->data(), mem.size()));
+  elements_to_fill -= second_size;
+  if (elements_to_fill == 0) {
+    // Nothing more to do
+    return;
+  }
+  // Repeat the host_buffer_size elements at the start of `buf` to the end
+  CHECK_EQ(elements_to_fill, buffer.size() / sizeof(T) - host_buffer_size);
+  se::StreamExecutor* executor = stream->parent();
+  auto kernel = se::TypedKernel<se::DeviceMemoryBase, int64_t, int64_t>::Create(
+      executor, "RepeatBufferKernel", repeat_buffer_kernel::kernel());
+  if (!kernel.ok()) {
+    LOG(FATAL) << "Could not create RepeatBufferKernel";
+  }
+  // Launch the kernel with at least host_buffer_bytes threads. Each thread
+  // will read one byte of `host_buffer` from the start of `buffer`, where the
+  // Memcpy call(s) above put it, and scatter it through the rest of `buffer`.
+  constexpr int64_t host_buffer_bytes = host_buffer_size * sizeof(T);
+  constexpr int threads_per_block = 256;
+  constexpr int blocks_per_grid =
+      (host_buffer_bytes + threads_per_block - 1) / threads_per_block;
+  TF_CHECK_OK(stream->ThenLaunch(se::ThreadDim(threads_per_block, 1, 1),
+                                 se::BlockDim(blocks_per_grid, 1, 1), *kernel,
+                                 buffer, host_buffer_bytes,
+                                 static_cast<int64_t>(buffer.size())));
 }
 
 void InitializeBuffer(se::Stream* stream, PrimitiveType buffer_type,

--- a/xla/service/gpu/stream_executor_util.cc
+++ b/xla/service/gpu/stream_executor_util.cc
@@ -484,6 +484,7 @@ static void InitializeTypedBuffer(se::Stream* stream,
     // Nothing more to do
     return;
   }
+#ifdef GOOGLE_CUDA
   // Repeat the host_buffer_size elements at the start of `buf` to the end
   CHECK_EQ(elements_to_fill, buffer.size() / sizeof(T) - host_buffer_size);
   se::StreamExecutor* executor = stream->parent();
@@ -503,6 +504,7 @@ static void InitializeTypedBuffer(se::Stream* stream,
                                  se::BlockDim(blocks_per_grid, 1, 1), *kernel,
                                  buffer, host_buffer_bytes,
                                  static_cast<int64_t>(buffer.size())));
+#endif
 }
 
 void InitializeBuffer(se::Stream* stream, PrimitiveType buffer_type,

--- a/xla/service/gpu/stream_executor_util_kernel.cu.cc
+++ b/xla/service/gpu/stream_executor_util_kernel.cu.cc
@@ -1,0 +1,37 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+
+namespace xla::gpu::repeat_buffer_kernel {
+namespace {
+// Populate the last `buffer_size - repeat_size` bytes of `buffer` by repeating
+// the first `repeat_size` bytes. This should be launched with at least
+// `repeat_size` threads in total.
+__global__ void RepeatBufferKernel(char* buffer, int64_t repeat_size,
+                                   int64_t buffer_size) {
+  int64_t global_index = blockDim.x * blockIdx.x + threadIdx.x;
+  if (global_index >= repeat_size) {
+    return;
+  }
+  const char src_value = buffer[global_index];
+  for (int64_t dst_index = global_index + repeat_size; dst_index < buffer_size;
+       dst_index += repeat_size) {
+    buffer[dst_index] = src_value;
+  }
+}
+}  // namespace
+void* kernel() { return reinterpret_cast<void*>(RepeatBufferKernel); }
+}  // namespace xla::gpu::repeat_buffer_kernel


### PR DESCRIPTION
This provides a significant speedup when autotuning, where buffers are repeatedly initialized.
Instead of repeatedly copying the same data to different locations on the device, it is copied once (using up to two host to device copies) and then replicated on the device using a custom kernel.

Using the paxml container from JAX-Toolbox and the 5B configuration on H100, the total runtime of the `gemm-algorithm-picker` pass for the main JITed function decreased from around 4.8s to 0.16s. With the same model and `--xla_gpu_triton_gemm_any=true` to make sure the Triton autotuner does a lot of work, that pass speeds up from 17.2s to 14.2s with this change.