### PR TITLE
[XLA:GPU] Fix cuDNN flash attention unit test failure with cuDNN 9.0

### DIFF
--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -62,7 +62,7 @@ class CudnnGraph : public dnn::DnnGraph {
   // Prepares a graph and checks whether it is generally supported.
   absl::StatusOr<bool> Prepare(dnn::DnnSupport&) override;
   // Builds single plan of the graph with given ID.
-  absl::Status Build(dnn::DnnSupport&, int64_t plan_id) override;
+  absl::Status Build(dnn::DnnSupport&, std::optional<int64_t> plan_id) override;
   // Builds all the plans
   absl::Status Execute(Stream& stream,
                        absl::Span<DeviceMemoryBase> operands) const override;

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1262,7 +1262,7 @@ class DnnGraph {
   // false on expected ones (graph is valid but not supported),
   // true on success.
   virtual absl::StatusOr<bool> Prepare(DnnSupport&) = 0;
-  virtual absl::Status Build(DnnSupport&, int64_t plan_id) = 0;
+  virtual absl::Status Build(DnnSupport&, std::optional<int64_t> plan_id) = 0;
   virtual absl::Status Execute(Stream& stream,
                                absl::Span<DeviceMemoryBase> operands) const = 0;
 };


### PR DESCRIPTION
* Use `build_plans` instead of `build_plan_at_index` for flash attention as cuDNN 9.0 could have more than 1 plan and some plans cant be built.