### PR TITLE
add gemm autotune log dump

### DIFF
--- a/xla/autotune_results.proto
+++ b/xla/autotune_results.proto
@@ -44,3 +44,10 @@ message AutotuneResults {
 // LINT.ThenChange(
 //   "service/gpu/autotuner_util.cc:version"
 // )
+
+message AutotuningLogs {
+
+  repeated AutotuningLog logs = 1;
+
+  // Next ID: 2
+}

--- a/xla/autotuning.proto
+++ b/xla/autotuning.proto
@@ -115,5 +115,9 @@ message AutotuningLog {
 
   string blas_version = 6;
 
-  // Next ID: 7
+  string fusion_name = 7;
+
+  int64 fusion_count = 8;
+
+  // Next ID: 9
 }

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -1681,6 +1681,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_use_memcpy_local_p2p),
       debug_options->xla_gpu_use_memcpy_local_p2p(),
       "Whether to use memcpy for local p2p communication."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_dump_autotune_logs_to",
+      string_setter_for(&DebugOptions::set_xla_gpu_dump_autotune_logs_to),
+      debug_options->xla_gpu_dump_autotune_logs_to(),
+      "File to write autotune logs to. It will be a binary file unless the "
+      "name ends with .txt or .textproto."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/python/xla_compiler.cc
+++ b/xla/python/xla_compiler.cc
@@ -1077,6 +1077,12 @@ void BuildXlaCompilerSubmodule(nb::module_& m) {
                    &DebugOptions::xla_dump_hlo_pipeline_re,
                    [](DebugOptions* self, std::string value) {
                      self->set_xla_dump_hlo_pipeline_re(value);
+
+                   })
+      .def_prop_rw("xla_gpu_dump_autotune_logs_to",
+                   &DebugOptions::xla_gpu_dump_autotune_logs_to,
+                   [](DebugOptions* self, std::string value) {
+                     self->set_xla_gpu_dump_autotune_logs_to(value);
                    });
 
   nb::class_<ExecutableBuildOptions>(m, "ExecutableBuildOptions")

--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -308,6 +308,7 @@ class DebugOptions:
   xla_enable_dumping: bool
   xla_gpu_dump_autotune_results_to: str
   xla_gpu_load_autotune_results_from: str
+  xla_gpu_dump_autotune_logs_to: str
 
 class CompiledMemoryStats:
   generated_code_size_in_bytes: int

--- a/xla/service/gpu/autotuner_compile_util.cc
+++ b/xla/service/gpu/autotuner_compile_util.cc
@@ -88,6 +88,7 @@ AutotunerCompileUtil::AutotunerCompileUtil(const AutotuneConfig& config,
   opts_.set_xla_gpu_dump_autotune_results_to("");
   opts_.set_xla_gpu_load_autotune_results_from("");
   opts_.set_xla_gpu_dump_llvmir(false);
+  opts_.set_xla_gpu_dump_autotune_logs_to("");
   // Avoid using another thread pool.
   opts_.set_xla_gpu_force_compilation_parallelism(1);
   opts_.set_xla_gpu_enable_llvm_module_compilation_parallelism(false);

--- a/xla/service/gpu/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/gemm_fusion_autotuner.cc
@@ -91,6 +91,7 @@ limitations under the License.
 #include "tsl/platform/status.h"
 #include "tsl/platform/statusor.h"
 #include "tsl/platform/threadpool.h"
+#include "tsl/platform/path.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 
 // Log levels used in this file:
@@ -128,6 +129,8 @@ constexpr std::array<int, 4> kNumStages = {1, 2, 3, 4};
 constexpr std::array<int, 4> kNumWarps = {2, 4, 8, 16};
 constexpr std::array<int, 5> kSplitK = {1, 2, 4, 8, 16};
 constexpr std::array<int, 5> kNumCtas = {1, 2, 4, 8, 16};
+
+using AutoTuneCacheKeyCount = absl::flat_hash_map<AutotuneCacheKey, uint64_t>;
 
 class GemmFusionAutotunerVisitor : public DfsHloRewriteVisitor {
  public:
@@ -217,6 +220,10 @@ class GemmConfigSetCollector : public ConstDfsHloVisitorWithDefault {
     return std::move(gemm_config_sets_);
   }
 
+  AutoTuneCacheKeyCount GetFusionsCount() {
+    return std::move(fusion_count_map_);
+  }
+
   absl::Status HandleFusion(const HloInstruction* hlo) override {
     const HloFusionInstruction* fusion = Cast<HloFusionInstruction>(hlo);
 
@@ -226,6 +233,12 @@ class GemmConfigSetCollector : public ConstDfsHloVisitorWithDefault {
         gpu_config.fusion_backend_config();
 
     AutotuneCacheKey key = AutotunerUtil::GetKey(hlo, impl_->GetConfig());
+
+    auto insertion_result = fusion_count_map_.insert({key, 1});
+    if (!insertion_result.second) {
+      ++(insertion_result.first->second);
+    }
+
     if (AutotunerUtil::IsInCache(key) || handled_fusions_.contains(key)) {
       return absl::OkStatus();
     }
@@ -253,6 +266,7 @@ class GemmConfigSetCollector : public ConstDfsHloVisitorWithDefault {
   GemmFusionAutotunerImpl* impl_;
   absl::flat_hash_map<const HloFusionInstruction*, std::vector<Config>>
       gemm_config_sets_;
+  AutoTuneCacheKeyCount fusion_count_map_;
   absl::flat_hash_set<AutotuneCacheKey> handled_fusions_;
 };
 
@@ -983,10 +997,30 @@ std::vector<TritonGemmConfig> GemmFusionAutotunerImpl::GetDefaultTritonConfigs()
   return configs;
 }
 
+absl::Status DumpAutotuningLogs(const DebugOptions& debug_opts,
+                                const AutotuningLogs& autotuning_logs) {
+  if (absl::string_view file_path = debug_opts.xla_gpu_dump_autotune_logs_to();
+      !file_path.empty()) {
+    std::string resolved_path;
+    if (!tsl::io::ResolveTestPrefixes(file_path, resolved_path)) {
+      return FailedPrecondition("File path can not be resolved: %s", file_path);
+    }
+
+    std::string textproto;
+    tsl::protobuf::TextFormat::PrintToString(autotuning_logs, &textproto);
+
+    TF_RETURN_IF_ERROR(
+        tsl::WriteStringToFile(tsl::Env::Default(), resolved_path, textproto));
+    LOG(INFO) << "Autotune logs serialized to file: " << resolved_path;
+  }
+  return absl::OkStatus();
+}
+
 absl::Status GemmFusionAutotunerImpl::Autotune(
     AutotunerCompileUtil& compile_util,
     const absl::flat_hash_map<const HloFusionInstruction*, std::vector<Config>>&
-        gemm_config_sets) {
+        gemm_config_sets,
+    AutoTuneCacheKeyCount fusion_count_map) {
   TF_ASSIGN_OR_RETURN(auto executable_sets,
                       CompileAll(compile_util, gemm_config_sets));
 
@@ -998,6 +1032,7 @@ absl::Status GemmFusionAutotunerImpl::Autotune(
     });
   }
 
+  AutotuningLogs autotuning_logs;
   int fusion_id = 0;
   for (const auto& key_value : executable_sets) {
     const HloFusionInstruction* fusion = key_value.first;
@@ -1032,7 +1067,26 @@ absl::Status GemmFusionAutotunerImpl::Autotune(
       LOG(WARNING) << "AutotunerUtil::AddResult already existed: "
                    << key.ToString();
     }
+
+    if (!debug_options_.xla_gpu_dump_autotune_logs_to().empty()) {
+      auto autotuning_log = autotuning_logs.add_logs();
+      autotuning_log->set_fusion_name(std::string(fusion->name()));
+
+      for (const auto& autotune_result : results) {
+        auto log_result = autotuning_log->add_results();
+        log_result->CopyFrom(autotune_result);
+      }
+
+      if (auto fusion_key_count = fusion_count_map.find(key);
+          fusion_key_count != fusion_count_map.end()) {
+        auto fusion_key = fusion_key_count->first;
+        auto fusion_count = fusion_key_count->second;
+        autotuning_log->set_fusion_count(fusion_count);
+      }
+    }
   }
+
+  TF_RETURN_IF_ERROR(DumpAutotuningLogs(debug_options_, autotuning_logs));
 
   return absl::OkStatus();
 }
@@ -1050,6 +1104,9 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
   TF_ASSIGN_OR_RETURN(gemm_config_sets,
                       gemm_config_set_collector.CollectGemmConfigSets(
                           module, execution_threads));
+
+  AutoTuneCacheKeyCount fusion_count_map =
+      gemm_config_set_collector.GetFusionsCount();
 
   if (!autotuner.IsAutotuningEnabled()) {
     // Pick the first option for each gemm instead of autotuning.
@@ -1070,7 +1127,8 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
 
     VLOG(1) << "Autotuning " << gemm_config_sets.size() << " fusions "
             << correctness_check_str << ".";
-    TF_RETURN_IF_ERROR(autotuner.Autotune(*opt_compile_util, gemm_config_sets));
+    TF_RETURN_IF_ERROR(autotuner.Autotune(*opt_compile_util, gemm_config_sets,
+                                          std::move(fusion_count_map)));
     VLOG(1) << "Done autotuning.";
   }
 

--- a/xla/service/gpu/gemm_fusion_autotuner.h
+++ b/xla/service/gpu/gemm_fusion_autotuner.h
@@ -108,7 +108,8 @@ class GemmFusionAutotunerImpl {
   absl::Status Autotune(
       AutotunerCompileUtil& compile_util,
       const absl::flat_hash_map<const HloFusionInstruction*,
-                                std::vector<Config>>& gemm_config_sets);
+                                std::vector<Config>>& gemm_config_sets,
+      absl::flat_hash_map<AutotuneCacheKey, uint64_t> fusion_count_map);
 
   // Helper methods.
   const AutotuneConfig& GetConfig() const { return config_; }

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -761,7 +761,10 @@ message DebugOptions {
   // the results of regular emitters.
   bool xla_gpu_verify_triton_fusion_numerics = 291;
 
-  // Next id: 292
+  // File to write autotune logs to. It will stored in txt format.
+  string xla_gpu_dump_autotune_logs_to = 292;
+
+  // Next id: 293
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR adds option to dump all gemm fusion autotune results as AutotuningLogs:
- the dump contains all autotune results for all backends including cublas,cudnn, and triton.
- also add fusion name and count (time of occurrence in a given hlo)