### PR TITLE
Remove redundant HloPassFix in OptimizeHloConvolutionCanonicalization

### DIFF
--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -132,7 +132,7 @@ absl::Status AMDGPUCompiler::OptimizeHloConvolutionCanonicalization(
           "reshape_mover_after_conv_canonicalization")] {
     ReshapeMoverOptions reshape_mover_options;
     reshape_mover_options.reshape_of_1d_broadcast_is_cheap = true;
-    pipeline.AddPass<HloPassFix<ReshapeMover>>(reshape_mover_options);
+    pipeline.AddPass<ReshapeMover>(reshape_mover_options);
     pipeline.AddPass<AlgebraicSimplifier>(options);
   }();
 

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -200,7 +200,7 @@ absl::Status NVPTXCompiler::OptimizeHloConvolutionCanonicalization(
           "reshape_mover_after_conv_canonicalization")] {
     ReshapeMoverOptions reshape_mover_options;
     reshape_mover_options.reshape_of_1d_broadcast_is_cheap = true;
-    pipeline.AddPass<HloPassFix<ReshapeMover>>(reshape_mover_options);
+    pipeline.AddPass<ReshapeMover>(reshape_mover_options);
     pipeline.AddPass<AlgebraicSimplifier>(algsimp_options);
   }();
 


### PR DESCRIPTION
I do not think `ReshapeMover` pass should be wrapped with `HloPassFix` twice

currently:
```c
  [&, &pipeline = pipeline.AddPass<HloPassFix<HloPassPipeline>>()] {
    pipeline.AddPass<HloPassFix<ReshapeMover>>(reshape_mover_options);
    pipeline.AddPass<AlgebraicSimplifier>(options);
  }();
```

I think it should be wrapped only once:

```c
  [&, &pipeline = pipeline.AddPass<HloPassFix<HloPassPipeline>>()] {
    pipeline.AddPass<ReshapeMover>(reshape_mover_options);
    pipeline.AddPass<AlgebraicSimplifier>(options);
  }();
```