### PR TITLE
[XLA:GPU] Force nccl command buffer to update even memory pointers do not change

### DIFF
--- a/xla/service/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/service/gpu/runtime/command_buffer_thunk.cc
@@ -80,6 +80,10 @@ CommandBufferThunk::CommandBufferThunk(CommandBufferCmdSequence commands,
 bool CommandBufferThunk::ExecutorCommandBuffer::ShouldUpdateCommandBuffer(
     const CommandBufferCmdSequence& commands,
     const Thunk::ExecuteParams& params) {
+  if (commands.force_update()) {
+    return true;
+  }
+
   bool should_update = false;
   const BufferAllocations* allocs = params.buffer_allocations;
 
@@ -156,6 +160,9 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
   // before execution, because command buffers when instantiated will allocate
   // memory on device and this might lead to deadlocks when we have concurrent
   // NCCL operations in flight.
+  //
+  // If command buffer in any other state we check it is has to be updated, i.e. if captured pointers
+  // changed or command buffer has commands that require update on each call.
   if (cmd_buffer->command_buffer->state() ==
           se::CommandBuffer::State::kCreate &&
       cmd_buffer->ShouldUpdateCommandBuffer(commands_, execute_params)) {
@@ -181,6 +188,7 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
             << params.executor->device_ordinal() << " in "
             << (end_micros - start_micros)
             << " μs; num_commands=" << commands_.size();
+    cmd_buffer->num_executions = 0;
   }
 
   return absl::OkStatus();


### PR DESCRIPTION
This PR force command buffer to do cuda graph update if it contains nccl collective operators, because NCCL requires all devices to make the collective call even in the cuda-graph capturing mode.
