### PR TITLE
[XLA:CPU][oneDNN] AVX512 vectorization

### DIFF
--- a/xla/service/cpu/simple_orc_jit.cc
+++ b/xla/service/cpu/simple_orc_jit.cc
@@ -298,6 +298,10 @@ SimpleOrcJIT::InferTargetMachineForJIT(
     const llvm::TargetOptions& target_options,
     llvm::CodeGenOptLevel opt_level) {
   std::vector<std::string> attrs = DetectMachineAttributes();
+  // Default preference is 256-bit vectorization because of the attribute
+  // `+prefer-256-bit`. Drop `prefer-256-bit` from the attributes by negation
+  // for higher target machine features, for example, avx-512 vectorization.
+  attrs.push_back("-prefer-256-bit");
   llvm::SmallVector<std::string, 0> llvm_attrs(attrs.begin(), attrs.end());
   std::unique_ptr<llvm::TargetMachine> target_machine(
       llvm::EngineBuilder()


### PR DESCRIPTION
This PR enables AVX512 vectorization on CPUs that have the support. The default target machine features in LLVM include an attribute (`+prefer-256-bit`), as a result LoopVectorization pass produces AVX2 LLVM IR. This PR essentially drops the attribute and this produces AVX512 vectorized code.

Below is the disassembled object code for  **HLO Add** instruction in float32.

### With the PR:
```
Disassembly of section .ltext:

0000000000000000 <parallel_add.3>:
      movq  (%r9), %rax
      movq  0x8(%r9), %rdx
      cmpq  %rdx, %rax
      jae 0xee <parallel_add.3+0xee>
      movq  (%rcx), %rdi
      movq  0x8(%rcx), %rsi
      movq  0x10(%rcx), %r8
      movq  %rax, %r9
      shlq  $0xb, %r9
      leaq  (%rsi,%r9), %rcx
      addq  $0xc0, %rcx
      leaq  (%r8,%r9), %rsi
      addq  $0xc0, %rsi
      addq  %r9, %rdi
      addq  $0xc0, %rdi
      00 00 00 00     nopw  %cs:(%rax,%rax)
      xorl  %r8d, %r8d
      00 00 00        nopw  %cs:(%rax,%rax)
      vmovups -0xc0(%rcx,%r8), %zmm0
      vmovups -0x80(%rcx,%r8), %zmm1
      vmovups -0x40(%rcx,%r8), %zmm2
      vmovups (%rcx,%r8), %zmm3
      vaddps  -0xc0(%rsi,%r8), %zmm0, %zmm0
      vaddps  -0x80(%rsi,%r8), %zmm1, %zmm1
      vaddps  -0x40(%rsi,%r8), %zmm2, %zmm2
      vaddps  (%rsi,%r8), %zmm3, %zmm3
      vmovups %zmm0, -0xc0(%rdi,%r8)
      vmovups %zmm1, -0x80(%rdi,%r8)
      vmovups %zmm2, -0x40(%rdi,%r8)
      vmovups %zmm3, (%rdi,%r8)
      addq  $0x100, %r8             # imm = 0x100
      cmpq  $0x800, %r8             # imm = 0x800
      jne 0x60 <parallel_add.3+0x60>
      incq  %rax
      addq  $0x800, %rcx            # imm = 0x800
      addq  $0x800, %rsi            # imm = 0x800
      addq  $0x800, %rdi            # imm = 0x800
      cmpq  %rdx, %rax
      jne 0x50 <parallel_add.3+0x50>
      vzeroupper
      retq
      00 00 00 00     nopw  %cs:(%rax,%rax)
```

### Without the PR:
```
Disassembly of section .ltext:

0000000000000000 <parallel_add.3>:
      movq  (%r9), %rax
      movq  0x8(%r9), %rdx
      cmpq  %rdx, %rax
      jae 0xcf <parallel_add.3+0xcf>
      movq  (%rcx), %rdi
      movq  0x8(%rcx), %rsi
      movq  0x10(%rcx), %r8
      movq  %rax, %r9
      shlq  $0xb, %r9
      leaq  (%rsi,%r9), %rcx
      addq  $0x60, %rcx
      leaq  (%r8,%r9), %rsi
      addq  $0x60, %rsi
      addq  %r9, %rdi
      addq  $0x60, %rdi
      nopl  (%rax)
      xorl  %r8d, %r8d
      00 00 00        nopw  %cs:(%rax,%rax)
      vmovups -0x60(%rcx,%r8), %ymm0
      vmovups -0x40(%rcx,%r8), %ymm1
      vmovups -0x20(%rcx,%r8), %ymm2
      vmovups (%rcx,%r8), %ymm3
      vaddps  -0x60(%rsi,%r8), %ymm0, %ymm0
      vaddps  -0x40(%rsi,%r8), %ymm1, %ymm1
      vaddps  -0x20(%rsi,%r8), %ymm2, %ymm2
      vaddps  (%rsi,%r8), %ymm3, %ymm3
      vmovups %ymm0, -0x60(%rdi,%r8)
      vmovups %ymm1, -0x40(%rdi,%r8)
      vmovups %ymm2, -0x20(%rdi,%r8)
      vmovups %ymm3, (%rdi,%r8)
      subq  $-0x80, %r8
      cmpq  $0x800, %r8             # imm = 0x800
      jne 0x50 <parallel_add.3+0x50>
      incq  %rax
      addq  $0x800, %rcx            # imm = 0x800
      addq  $0x800, %rsi            # imm = 0x800
      addq  $0x800, %rdi            # imm = 0x800
      cmpq  %rdx, %rax
      jne 0x40 <parallel_add.3+0x40>
      vzeroupper
      retq
      00 00 00        nopw  %cs:(%rax,%rax)
```

