### PR TITLE
[XLA:CPU][oneDNN] Perf regression fix on matmul weight prepacking.

### DIFF
--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -839,14 +839,10 @@ class OneDnnPostRewriteVisitor : public DfsHloRewriteVisitor {
       return custom_call;
     }
     auto weights = custom_call->operand(1);
-    if (weights->user_count() > 1) {
-      return absl::FailedPreconditionError(
-          "Cannot prepack weights. There is more than one consumer.");
-    }
     auto weights_shape = weights->shape();
     Literal weights_literal;
     if (!(weights_shape.rank() == 2 &&
-          evaluator_.TryEvaluate(weights, &weights_literal))) {
+          evaluator_.TryEvaluate(weights, &weights_literal, true))) {
       return absl::CancelledError(
           "Cannot prepack weights. Not constant 2D weights.");
     }


### PR DESCRIPTION
This PR fixes a regression caused by refactoring of weight prepacking. Essentially, the current PR restores the conditions for weight prepacking as before.
(1) Restores weights to have multiple users. Since weights are prepacked only when it can be evaluated as constant it is safe.
(2) Restores the HloEvaluator to evaluate constants recursively.