### PR TITLE
[XLA:GPU] Use cached cuDNN handle for FMHA thunk

### DIFF
--- a/xla/service/gpu/cudnn_workspace_rewriter.cc
+++ b/xla/service/gpu/cudnn_workspace_rewriter.cc
@@ -113,7 +113,7 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     TF_ASSIGN_OR_RETURN(
         se::gpu::CudnnGraph graph,
         se::gpu::GetCudnnFlashAttentionOperationGraph(
-            dnn_support, fmha_config.lhs_bmm1, fmha_config.rhs_bmm1,
+            dnn_support, nullptr, fmha_config.lhs_bmm1, fmha_config.rhs_bmm1,
             fmha_config.rhs_bmm2, fmha_config.output, fmha_config.bias,
             fmha_config.activation, static_cast<float>(*fmha_config.fmha_scale),
             fmha_config.dropout_rate && *fmha_config.dropout_rate > 0.0,
@@ -201,7 +201,7 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     TF_ASSIGN_OR_RETURN(
         se::gpu::CudnnGraph graph,
         se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(
-            dnn_support, fmha_config.bmm1_grad_gemm1_rhs,
+            dnn_support, nullptr, fmha_config.bmm1_grad_gemm1_rhs,
             fmha_config.bmm1_grad_gemm2_rhs, fmha_config.bmm2_grad_gemm1_lhs,
             fmha_config.bmm2_grad_gemm2_rhs, fmha_config.d_output,
             fmha_config.d_bmm1_lhs, fmha_config.d_bmm1_rhs,

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -61,12 +61,18 @@ class CudnnGraph : public dnn::DnnGraph {
       : graph_(std::move(graph)) {}
   // Prepares a graph and checks whether it is generally supported.
   absl::StatusOr<bool> Prepare(dnn::DnnSupport&) override;
+  absl::StatusOr<bool> Prepare(dnn::DnnSupport&, Stream*);
   // Builds single plan of the graph with given ID.
   absl::Status Build(dnn::DnnSupport&, std::optional<int64_t> plan_id) override;
+  absl::Status Build(dnn::DnnSupport&, Stream*, std::optional<int64_t> plan_id);
   // Builds all the plans
   absl::Status Execute(Stream& stream,
                        absl::Span<DeviceMemoryBase> operands) const override;
   const cudnn_frontend::graph::Graph& Graph() const { return graph_; }
+  // Returns a mutable reference to the internal graph.
+  cudnn_frontend::graph::Graph& MutableGraph() { return graph_; }
+
+  //   absl::Status Validate() {return graph_.validate();}
 
  private:
   cudnn_frontend::graph::Graph graph_;
@@ -717,7 +723,7 @@ class CudnnSupport : public dnn::DnnSupport {
 };
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
-    dnn::DnnSupport& dnn_support,
+    dnn::DnnSupport& dnn_support, Stream* stream,
     const dnn::MatmulTensorDescriptor& q_descriptor,
     const dnn::MatmulTensorDescriptor& k_descriptor,
     const dnn::MatmulTensorDescriptor& v_descriptor,
@@ -729,7 +735,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     const dnn::FMHAMaskKind mask_type);
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
-    dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
+    dnn::DnnSupport& dnn_support, Stream* stream,
+    const dnn::MatmulTensorDescriptor& q_desc,
     const dnn::MatmulTensorDescriptor& k_desc,
     const dnn::MatmulTensorDescriptor& p_desc,
     const dnn::MatmulTensorDescriptor& v_desc,


### PR DESCRIPTION
ExecuteOnStream was calling into cuDNNCreate rather than calling the cached handle. This was causing a hang since handle was being created with a NCCL call in flight.
This fix addresses a hang.