### PR TITLE
[ROCM] fixing smale build brakes in RedzoneAllocator, rocm_dnn and hip_blas_lt

### DIFF
--- a/xla/stream_executor/gpu/redzone_allocator_kernel_rocm.cu.cc
+++ b/xla/stream_executor/gpu/redzone_allocator_kernel_rocm.cu.cc
@@ -27,7 +27,7 @@ namespace {
 __global__ void redzone_checker_kernel(uint8_t* input_buffer,
                                        uint8_t redzone_pattern,
                                        uint64_t buffer_length,
-                                       int* out_mismatched_ptr) {
+                                       uint32_t* out_mismatched_ptr) {
   uint64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
   if (idx >= buffer_length) return;
   if (input_buffer[idx] != redzone_pattern) atomicAdd(out_mismatched_ptr, 1);
@@ -36,7 +36,7 @@ __global__ void redzone_checker_kernel(uint8_t* input_buffer,
 
 namespace stream_executor {
 
-absl::StatusOr<const RedzoneAllocator::ComparisonKernel*> GetComparisonKernel(
+absl::StatusOr<const ComparisonKernel*> GetComparisonKernel(
     StreamExecutor* executor, GpuAsmOpts /*gpu_asm_opts*/) {
   static auto kernel =
       TypedKernel<DeviceMemory<uint8>, uint8, uint64_t,

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/stream_executor/rocm/hip_blas_lt.h"
 #include "xla/stream_executor/rocm/rocm_blas.h"
 #include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/scratch_allocator.h"
 
 #define SET_ATTR(setter, handle, attr, value) \
   ToStatus(setter(handle, attr, &value, sizeof(decltype(value))), #setter)
@@ -398,11 +399,11 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
 absl::Status BlasLt::MatmulPlan::DoMatmul(
     Stream* stream, const void* alpha, DeviceMemoryBase a, DeviceMemoryBase b,
     const void* beta, DeviceMemoryBase c, DeviceMemoryBase d,
-    const MatmulAlgorithm& algorithm, ScratchAllocator& scratch_allocator,
+    const MatmulAlgorithm& algorithm, 
+    ScratchAllocator& scratch_allocator,
     DeviceMemoryBase bias, DeviceMemoryBase aux, DeviceMemoryBase a_scale,
     DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
     DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
-    ScratchAllocator& scratch_allocator,
     blas::ProfileResult* profile_result) const {
   return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux,
                   a_scale, b_scale, c_scale, d_scale, d_amax, std::nullopt,
@@ -431,7 +432,7 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     workspace_size = workspace.value().size();
     TF_RET_CHECK(workspace_size >= algorithm.workspace_size);
   } else if (algorithm.workspace_size > 0) {
-    TF_RET_CHECK(scratch_allocator.has_value())
+    TF_RET_CHECK(scratch_allocator.has_value());
     TF_ASSIGN_OR_RETURN(
         DeviceMemory<uint8_t> alloc,
         scratch_allocator.value()->AllocateBytes(algorithm.workspace_size));
@@ -577,7 +578,7 @@ absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
         SCALENTYPE, HipToNativeT<ATYPE>::type, HipToNativeT<BTYPE>::type,    \
         HipToNativeT<CTYPE>::type, HipToNativeT<DTYPE>::type>(               \
         stream, alpha_, a, b, beta_, c, d, bias, aux, a_scale, b_scale,      \
-        c_scale, d_scale, d_amax, algorithm, scratch_allocator,              \
+        c_scale, d_scale, d_amax, algorithm, *scratch_allocator.value(),     \
         profile_result);                                                     \
   }
 
@@ -641,7 +642,6 @@ absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
         float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F, HIP_R_16F)
     TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(
         float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F, HIP_R_32F)
-#endif
 
     // Other data types:
     TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, HIP_R_16BF, HIP_R_16BF,

--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -4371,14 +4371,9 @@ absl::Status MIOpenSupport::DoPoolForward(
         // reusing the same buffer
         workspace = reinterpret_cast<uint8*>(pdesc->workspace.ptr()->opaque());
       } else {
-        ScopedDeviceMemory<uint8> wsp_mem(
-            stream->parent(),
-            stream->parent()->AllocateArray<uint8>(workspace_size));
-        workspace = reinterpret_cast<uint8*>(wsp_mem.ptr()->opaque());
-        m_pooling_cache.insert(input_data.opaque(), input_dimensions,
-                               output_dimensions, pooling_dimensions,
-                               miopenFloat, wsp_mem, workspace_size,
-                               AsGpuStreamValue(stream));
+        TF_ASSIGN_OR_RETURN(auto allocated, 
+                        workspace_allocator->AllocateBytes(workspace_size));
+        workspace = reinterpret_cast<uint8*>(allocated.opaque());
       }
     }
   }


### PR DESCRIPTION
Here are fixes after the following PRs:
- rocm_dnn AllocateOwnedArray: https://github.com/openxla/xla/pull/11654
- hipblas_lt: https://github.com/openxla/xla/issues/11514
- and also RedzoneAllocator: https://github.com/openxla/xla/commit/d8f0c1acdb79c18cdce0a050b1d7c6baa8b9f14b


@xla-rotation: could you please have a look ?

