### PR TITLE
Do not dump autotuner PTX to stdout when --xla_dump_hlo_as_* are set

### DIFF
--- a/xla/service/gpu/autotuner_compile_util.cc
+++ b/xla/service/gpu/autotuner_compile_util.cc
@@ -84,7 +84,7 @@ AutotunerCompileUtil::AutotunerCompileUtil(const AutotuneConfig& config,
       allocator_(allocator),
       opts_(opts) {
   // Avoid dumping compilation steps.
-  opts_.set_xla_dump_to("");
+  opts_.set_xla_enable_dumping(false);
   opts_.set_xla_gpu_dump_autotune_results_to("");
   opts_.set_xla_gpu_load_autotune_results_from("");
   opts_.set_xla_gpu_dump_llvmir(false);


### PR DESCRIPTION
Without this change then when `--xla_dump_hlo_as_proto=true --xla_dump_to=/some/real/path` is set, the autotuner dumps PTX to stdout.