### PR TITLE
[XLA:CPU][oneDNN] Enable Matmul + BiasAdd + Elu / Tanh / Relu6 fusions for onednn

### DIFF
--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1657,6 +1657,15 @@ cc_library(
 )
 
 cc_library(
+    name = "onednn_pattern_utils",
+    hdrs = ["onednn_pattern_utils.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":onednn_util",
+    ] + mkl_deps(),
+)
+
+cc_library(
     name = "onednn_matmul_rewriter",
     srcs = ["onednn_matmul_rewriter.cc"],
     hdrs = [
@@ -1670,6 +1679,7 @@ cc_library(
         ":onednn_matmul",
         ":onednn_memory_util",
         ":onednn_util",
+        ":onednn_pattern_utils",
         "//xla:executable_run_options",
         "//xla:shape_util",
         "//xla:status_macros",
@@ -1698,6 +1708,7 @@ cc_library(
         ":backend_config_proto_cc",
         ":onednn_memory_util",
         ":onednn_util",
+        ":onednn_pattern_utils",
         "//xla:status_macros",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",

--- a/xla/service/cpu/backend_config.proto
+++ b/xla/service/cpu/backend_config.proto
@@ -27,6 +27,8 @@ message OneDnnMatMulConfig {
     GELU_TANH = 5;
     BINARY_ADD = 6;
     LINEAR = 7;
+    ELU = 8;
+    RELU6 = 9;
   }
   repeated FusionKind fused_ops = 3;
   bool bias_broadcast = 4;

--- a/xla/service/cpu/onednn_matmul_rewriter.cc
+++ b/xla/service/cpu/onednn_matmul_rewriter.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "xla/service/cpu/onednn_matmul_rewriter.h"
 
+#include "tsl/platform/logging.h"  // IWYU pragma: keep
 #include "xla/executable_run_options.h"
 #include "xla/hlo/evaluator/hlo_evaluator.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
@@ -28,12 +29,12 @@ limitations under the License.
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_matmul.h"
 #include "xla/service/cpu/onednn_memory_util.h"
+#include "xla/service/cpu/onednn_pattern_utils.h"
 #include "xla/service/cpu/onednn_util.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
 #include "xla/tsl/util/onednn_threadpool.h"
-#include "tsl/platform/logging.h"  // IWYU pragma: keep
 
 namespace xla {
 namespace cpu {
@@ -61,26 +62,6 @@ inline Status ValidateDotDimensionNumbers(
 inline bool CompatibleElementType(const HloInstruction* instr) {
   PrimitiveType element_type = instr->shape().element_type();
   return element_type == BF16 || element_type == F32 || element_type == F16;
-}
-
-// Type conversion from and to any of BF16 and FP32.
-// TODO(intel-tf): Support more types when enabled.
-template <typename Pattern>
-inline auto SupportedConvert(Pattern pattern) {
-  auto supported_convert = [](const HloInstruction* instr) -> bool {
-    return CompatibleElementType(instr) &&
-           CompatibleElementType(instr->operand(0));
-  };
-  return m::Convert(pattern).WithPredicate(supported_convert);
-}
-
-template <typename Pattern>
-inline auto SupportedConvert(HloInstruction** convert, Pattern pattern) {
-  auto supported_convert = [](const HloInstruction* instr) -> bool {
-    return CompatibleElementType(instr) &&
-           CompatibleElementType(instr->operand(0));
-  };
-  return m::Convert(convert, pattern).WithPredicate(supported_convert);
 }
 
 inline bool IsRowMajor(const Shape& shape) {
@@ -138,6 +119,10 @@ inline auto BcastConstScalar(HloInstruction** instr, double value) {
 
 inline auto BcastConstScalar(double value) {
   return BcastConstScalar(nullptr, value);
+}
+
+inline auto BcastConvertConstScalar(double value) {
+  return m::Broadcast(OptionalConvert(m::ConstantScalar(value)));
 }
 
 inline bool IsBatchDot(const HloInstruction& instr) {
@@ -562,7 +547,8 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
       }
 
       // Validate addend for fusion.
-      if (CompatibleElementType(addend) && IsOperandFusible(addend, dot)) {
+      if (IsSupportedType(addend->shape().element_type()) &&
+          IsOperandFusible(addend, dot)) {
         new_operands.push_back(addend);
       } else {
         return OkStatus();
@@ -643,6 +629,73 @@ class OneDnnMatMulRewriteVisitor : public DfsHloRewriteVisitor {
                                  BcastConstScalar(0)))) {
       return FuseActivation(OneDnnMatMulConfig::RELU, instr, matmul_call,
                             intermediate_instr, optional_bitcast);
+    }
+    return OkStatus();
+  }
+
+  auto ELUActivation(HloInstruction* instr, HloInstruction** src) {
+    //  Reference: tensorflow/compiler/tf2xla/kernels/elu_op.cc
+    //  const auto zero = ScalarLike(x, 0);
+    //  const auto pred = Gt(x, zero);
+    //  const auto expm1 = Expm1(x);
+    //  return Select(pred, x, expm1);
+    auto pattern = m::Select(
+        m::Gt(OptionalConvert(m::Op(src)), BcastConvertConstScalar(0)),
+        m::Op(src), OptionalConvert(m::Expm1(OptionalConvert(m::Op(src)))));
+    return Match(instr, pattern);
+  }
+
+  Status HandleSelect(HloInstruction* instr) override {
+    HloInstruction* matmul_call;
+    HloInstruction* intermediate_instr = nullptr;
+    HloInstruction* optional_bitcast = nullptr;
+    HloInstruction* src;
+    // Attempt to elide ELU subgraph and fuse ELU activation into GEMM,
+    // including when slicing or bitcasting is applied to the result.
+    if (ELUActivation(instr, &src)) {
+      if (Match(src,
+                ElementwiseSafeIntermediates(&intermediate_instr,
+                                             &optional_bitcast,
+                                            OneDnnMatmulInstr(&matmul_call)))) {
+        return FuseActivation(OneDnnMatMulConfig::ELU, instr, matmul_call,
+                              intermediate_instr);
+      }
+    }
+    return OkStatus();
+  }
+
+  Status HandleTanh(HloInstruction* instr) override {
+    HloInstruction* matmul_call;
+    HloInstruction* intermediate_instr = nullptr;
+    HloInstruction* optional_bitcast = nullptr;
+    // Attempt to elide Tanh and fuse Tanh activation into GEMM, including
+    // when slicing or bitcasting is applied to the result.
+    if (Match(instr,
+              m::Tanh(ElementwiseSafeIntermediates(
+                          &intermediate_instr,  &optional_bitcast,
+                          OneDnnMatmulInstr(&matmul_call))
+                          .WithOneUser()))) {
+      return FuseActivation(OneDnnMatMulConfig::TANH, instr, matmul_call,
+                            intermediate_instr);
+    }
+    return OkStatus();
+  }
+
+  Status HandleClamp(HloInstruction* instr) override {
+    HloInstruction* matmul_call;
+    HloInstruction* intermediate_instr = nullptr;
+    HloInstruction* optional_bitcast = nullptr;
+    // Attempt to elide RELU6 and fuse RELU6 activation into GEMM, including
+    // when slicing or bitcasting is applied to the result.
+    if (Match(instr,
+              m::Clamp(BcastConstScalar(0),
+                       ElementwiseSafeIntermediates(
+                           &intermediate_instr,  &optional_bitcast,
+                           OneDnnMatmulInstr(&matmul_call))
+                           .WithOneUser(),
+                       BcastConstScalar(6)))) {
+      return FuseActivation(OneDnnMatMulConfig::RELU6, instr, matmul_call,
+                            intermediate_instr);
     }
     return OkStatus();
   }

--- a/xla/service/cpu/onednn_ops_rewriter.cc
+++ b/xla/service/cpu/onednn_ops_rewriter.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_memory_util.h"
+#include "xla/service/cpu/onednn_pattern_utils.h"
 #include "xla/service/cpu/onednn_util.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
@@ -28,11 +29,6 @@ namespace cpu {
 
 namespace {
 namespace m = match;
-
-template <typename Pattern>
-auto OptionalConvert(Pattern pattern) {
-  return m::AnyOf<HloInstruction>(m::Convert(pattern), std::move(pattern));
-}
 
 inline auto OneDnnConvertibleInstr(HloInstruction** instr) {
   return m::AnyOf<HloInstruction>(m::CustomCall(instr, {"__onednn$layernorm"}),

--- a/xla/service/cpu/onednn_pattern_utils.h
+++ b/xla/service/cpu/onednn_pattern_utils.h
@@ -1,0 +1,60 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_CPU_ONEDNN_PATTERN_UTILS_H_
+#define XLA_SERVICE_CPU_ONEDNN_PATTERN_UTILS_H_
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/cpu/onednn_util.h"
+#include "xla/service/pattern_matcher.h"
+
+namespace xla {
+namespace cpu {
+
+namespace {
+namespace m = match;
+
+template <typename Pattern>
+auto OptionalConvert(Pattern pattern) {
+  return m::AnyOf<HloInstruction>(m::Convert(pattern), std::move(pattern));
+}
+
+// Type conversion from and to any of BF16 and FP32.
+// TODO(intel-tf): Support more types when enabled.
+template <typename Pattern>
+inline auto SupportedConvert(Pattern pattern) {
+  auto supported_convert = [](const HloInstruction* instr) -> bool {
+    return IsSupportedType(instr->shape().element_type()) &&
+           IsSupportedType(instr->operand(0)->shape().element_type());
+  };
+  return m::Convert(pattern).WithPredicate(supported_convert);
+}
+
+template <typename Pattern>
+inline auto SupportedConvert(HloInstruction** convert, Pattern pattern) {
+  auto supported_convert = [](const HloInstruction* instr) -> bool {
+    return IsSupportedType(instr->shape().element_type()) &&
+           IsSupportedType(instr->operand(0)->shape().element_type());
+  };
+  return m::Convert(convert, pattern).WithPredicate(supported_convert);
+}
+}  // namespace
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+#endif  // XLA_SERVICE_CPU_ONEDNN_PATTERN_UTILS_H_

--- a/xla/service/pattern_matcher.h
+++ b/xla/service/pattern_matcher.h
@@ -402,8 +402,8 @@ class AllOfPattern {
   void DescribeToImpl(std::ostream* os, std::integral_constant<size_t, index>,
                       int64_t indent) const {
     constexpr bool first_is_trivial =
-        IsTrivialMatcher<typename std::remove_reference<decltype(std::get<0>(
-            patterns_))>::type>::value;
+        IsTrivialMatcher<typename std::remove_reference<decltype(
+            std::get<0>(patterns_))>::type>::value;
     constexpr bool is_last = index == sizeof...(Patterns) - 1;
     const auto& submatcher = std::get<index>(patterns_);
 
@@ -2687,6 +2687,7 @@ XLA_UNOP_PATTERN(CollectivePermuteStart)
 XLA_UNOP_PATTERN(CollectivePermuteDone)
 XLA_UNOP_PATTERN(Domain)
 XLA_UNOP_PATTERN(Exp)
+XLA_UNOP_PATTERN(Expm1)
 XLA_UNOP_PATTERN(Fft)
 XLA_UNOP_PATTERN(Floor)
 XLA_UNOP_PATTERN(GetTupleElement)

--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -957,17 +957,17 @@ TEST_F(MatmulTest, BiasAddELUFusion_F32) {
   HloModule matmul.test.f32
 
   ENTRY matmul.test.f32 {
-    arg1.2 = f32[1024,1024]{1,0} parameter(1), parameter_replication={false}
-    arg0.1 = f32[1024,1024]{1,0} parameter(0), parameter_replication={false}
-    dot.7 = f32[1024,1024]{1,0} dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}, frontend_attributes={grad_x="false",grad_y="false"}
-    arg2.3 = f32[1024]{0} parameter(2), parameter_replication={false}
-    broadcast.9 = f32[1024,1024]{1,0} broadcast(arg2.3), dimensions={1}
-    add.10 = f32[1024,1024]{1,0} add(dot.7, broadcast.9)
-    constant.11 = f32[] constant(0)
-    broadcast.12 = f32[1024,1024]{1,0} broadcast(constant.11), dimensions={}
-    compare.13 = pred[1024,1024]{1,0} compare(add.10, broadcast.12), direction=GT
-    exponential-minus-one.14 = f32[1024,1024]{1,0} exponential-minus-one(add.10)
-    ROOT select.15 = f32[1024,1024]{1,0} select(compare.13, add.10, exponential-minus-one.14)
+    arg0.1 = f32[1024,1024] parameter(0)
+    arg1.2 = f32[1024,1024] parameter(1)
+    dot.3 = f32[1024,1024] dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    arg2.4 = f32[1024] parameter(2)
+    broadcast.5 = f32[1024,1024] broadcast(arg2.4), dimensions={1}
+    add.6 = f32[1024,1024] add(dot.3, broadcast.5)
+    constant.7 = f32[] constant(0)
+    broadcast.8 = f32[1024,1024] broadcast(constant.7), dimensions={}
+    compare.9 = pred[1024,1024] compare(add.6, broadcast.8), direction=GT
+    exponential-minus-one.10 = f32[1024,1024] exponential-minus-one(add.6)
+    ROOT select.11 = f32[1024,1024] select(compare.9, add.6, exponential-minus-one.10)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
@@ -982,23 +982,23 @@ TEST_F(MatmulTest, BiasAddELUFusion_BF16) {
   const char* matmul_module_str = R"(
   HloModule matmul.test.bf16
   ENTRY matmul.test.bf16 {
-    arg0.1 = f32[1024,512] parameter(0), parameter_replication={false}
-    convert.8 = bf16[1024,512] convert(arg0.1)
-    arg1.2 = f32[256,512] parameter(1), parameter_replication={false}
-    convert.9 = bf16[256,512] convert(arg1.2)
-    dot.10 = bf16[1024,256] dot(convert.8, convert.9), lhs_contracting_dims={1}, rhs_contracting_dims={1}, frontend_attributes={grad_x="false",grad_y="false"}
-    convert = f32[1024,256] convert(dot.10)
-    arg2.3 = f32[256] parameter(2), parameter_replication={false}
-    broadcast = f32[1024,256] broadcast(arg2.3), dimensions={1}
-    add.13 = f32[1024,256] add(convert, broadcast)
-    constant.1 = f32[] constant(0)
-    broadcast.2 = f32[1024,256] broadcast(constant.1), dimensions={}
-    compare.16 = pred[1024,256] compare(add.13, broadcast.2), direction=GT
-    convert.2 = bf16[1024,256] convert(add.13)
-    exponential-minus-one.17 = f32[1024,256] exponential-minus-one(add.13)
-    convert.6 = bf16[1024,256] convert(exponential-minus-one.17)
-    select.18 = bf16[1024,256] select(compare.16, convert.2, convert.6)
-    ROOT convert.19 = f32[1024,256] convert(select.18)
+    arg0.1 = f32[1024,512] parameter(0)
+    convert.2 = bf16[1024,512] convert(arg0.1)
+    arg1.3 = f32[256,512] parameter(1)
+    convert.4 = bf16[256,512] convert(arg1.3)
+    dot.5 = bf16[1024,256] dot(convert.2, convert.4), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+    convert.6 = f32[1024,256] convert(dot.5)
+    arg2.7 = f32[256] parameter(2)
+    broadcast.8 = f32[1024,256] broadcast(arg2.7), dimensions={1}
+    add.9 = f32[1024,256] add(convert.6, broadcast.8)
+    constant.10 = f32[] constant(0)
+    broadcast.11 = f32[1024,256] broadcast(constant.10), dimensions={}
+    compare.12 = pred[1024,256] compare(add.9, broadcast.11), direction=GT
+    convert.13 = bf16[1024,256] convert(add.9)
+    exponential-minus-one.14 = f32[1024,256] exponential-minus-one(add.9)
+    convert.15 = bf16[1024,256] convert(exponential-minus-one.14)
+    select.16 = bf16[1024,256] select(compare.12, convert.13, convert.15)
+    ROOT convert.17 = f32[1024,256] convert(select.16)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-2}));
@@ -1014,17 +1014,17 @@ TEST_F(MatmulTest, BiasAddELUFusion_F16) {
   HloModule matmul.test.f16
 
   ENTRY matmul.test.f16 {
-    arg1.2 = f16[1024,1024] parameter(1), parameter_replication={false}
-    arg0.1 = f16[1024,1024] parameter(0), parameter_replication={false}
-    dot.7 = f16[1024,1024] dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}, frontend_attributes={grad_x="false",grad_y="false"}
-    arg2.3 = f16[1024] parameter(2), parameter_replication={false}
-    broadcast.9 = f16[1024,1024] broadcast(arg2.3), dimensions={1}
-    add.10 = f16[1024,1024] add(dot.7, broadcast.9)
-    constant.11 = f16[] constant(0)
-    broadcast.12 = f16[1024,1024] broadcast(constant.11), dimensions={}
-    compare.13 = pred[1024,1024] compare(add.10, broadcast.12), direction=GT
-    exponential-minus-one.14 = f16[1024,1024] exponential-minus-one(add.10)
-    ROOT select.15 = f16[1024,1024] select(compare.13, add.10, exponential-minus-one.14)
+    arg0.1 = f16[1024,1024] parameter(0)
+    arg1.2 = f16[1024,1024] parameter(1)
+    dot.3 = f16[1024,1024] dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    arg2.4 = f16[1024] parameter(2)
+    broadcast.5 = f16[1024,1024] broadcast(arg2.4), dimensions={1}
+    add.6 = f16[1024,1024] add(dot.3, broadcast.5)
+    constant.7 = f16[] constant(0)
+    broadcast.8 = f16[1024,1024] broadcast(constant.7), dimensions={}
+    compare.9 = pred[1024,1024] compare(add.6, broadcast.8), direction=GT
+    exponential-minus-one.10 = f16[1024,1024] exponential-minus-one(add.6)
+    ROOT select.11 = f16[1024,1024] select(compare.9, add.6, exponential-minus-one.10)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-2}));
@@ -1040,22 +1040,22 @@ TEST_F(MatmulTest, BiasAddELUFusion_F16_2) {
   HloModule matmul.test.f16
 
   ENTRY matmul.test.f16 {
-    arg0.1 = f32[1024,1024] parameter(0), parameter_replication={false}
-    convert.8 = f16[1024,1024] convert(arg0.1)
-    arg2.3 = f32[1024,1024] parameter(2), parameter_replication={false}
-    convert.9 = f16[1024,1024] convert(arg2.3)
-    dot.10 = f16[1024,1024] dot(convert.8, convert.9), lhs_contracting_dims={1}, rhs_contracting_dims={0}, frontend_attributes={grad_x="false",grad_y="false"}
-    arg1.2 = f32[1024] parameter(1), parameter_replication={false}
-    convert.7 = f16[1024] convert(arg1.2)
-    broadcast.12 = f16[1024,1024] broadcast(convert.7), dimensions={1}
-    add.13 = f16[1024,1024] add(dot.10, broadcast.12)
-    constant.14 = f16[] constant(0)
-    broadcast.15 = f16[1024,1024] broadcast(constant.14), dimensions={}
-    compare.16 = pred[1024,1024] compare(add.13, broadcast.15), direction=GT
-    exponential-minus-one.17 = f16[1024,1024] exponential-minus-one(add.13)
-    select.18 = f16[1024,1024] select(compare.16, add.13, exponential-minus-one.17)
-    dot.19 = f16[1024,1024] dot(select.18, convert.9), lhs_contracting_dims={1}, rhs_contracting_dims={0}, frontend_attributes={grad_x="false",grad_y="false"}
-    ROOT convert.21 = f32[1024,1024] convert(dot.19)
+    arg0.1 = f32[1024,1024] parameter(0)
+    convert.2 = f16[1024,1024] convert(arg0.1)
+    arg1.3 = f32[1024,1024] parameter(2)
+    convert.4 = f16[1024,1024] convert(arg1.3)
+    dot.5 = f16[1024,1024] dot(convert.2, convert.4), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    arg2.6 = f32[1024] parameter(1)
+    convert.7 = f16[1024] convert(arg2.6)
+    broadcast.8 = f16[1024,1024] broadcast(convert.7), dimensions={1}
+    add.9 = f16[1024,1024] add(dot.5, broadcast.8)
+    constant.10 = f16[] constant(0)
+    broadcast.11 = f16[1024,1024] broadcast(constant.10), dimensions={}
+    compare.12 = pred[1024,1024] compare(add.9, broadcast.11), direction=GT
+    exponential-minus-one.13 = f16[1024,1024] exponential-minus-one(add.9)
+    select.14 = f16[1024,1024] select(compare.12, add.9, exponential-minus-one.13)
+    dot.15 = f16[1024,1024] dot(select.14, convert.4), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    ROOT convert.16 = f32[1024,1024] convert(dot.15)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-2}));
@@ -1153,15 +1153,15 @@ TEST_F(MatmulTest, BiasAddTanhFusionTest_F32) {
   const char* matmul_module_str = R"(
   HloModule matmul.bias.tanh.test.f32
   ENTRY matmul.bias.tanh.test.f32 {
-    arg.0 = f32[32,32,40,30] parameter(0), parameter_replication={false}
-    arg.1 = f32[32,32,30,40] parameter(1), parameter_replication={false}
-    dot.7 = f32[32,32,40,40] dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
-    const.0 = f32[40] constant(15)
-    bcast.1 = f32[32,32,40,40] broadcast(const.0), dimensions={3}
-    add.0 = f32[32,32,40,40] add(dot.7,bcast.1)
-    tanh.1 = f32[32,32,40,40] tanh(add.0)
-    tuple.12 = (f32[32,32,40,40]) tuple(tanh.1)
-    ROOT get-tuple-element.13 = f32[32,32,40,40] get-tuple-element(tuple.12), index=0
+    arg.0 = f32[32,32,40,30] parameter(0)
+    arg.1 = f32[32,32,30,40] parameter(1)
+    dot.2 = f32[32,32,40,40] dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+    const.3 = f32[40] constant(15)
+    bcast.4 = f32[32,32,40,40] broadcast(const.3), dimensions={3}
+    add.5 = f32[32,32,40,40] add(dot.2, bcast.4)
+    tanh.6 = f32[32,32,40,40] tanh(add.5)
+    tuple.7 = (f32[32,32,40,40]) tuple(tanh.6)
+    ROOT get-tuple-element.8 = f32[32,32,40,40] get-tuple-element(tuple.7), index=0
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
@@ -1175,16 +1175,16 @@ TEST_F(MatmulTest, BiasAddTanhFusionTest_BF16) {
   const char* matmul_module_str = R"(
   HloModule matmul.bias.tanh.test.f32
   ENTRY matmul.bias.tanh.test.f32 {
-    arg0.1 = f32[1024,512] parameter(0), parameter_replication={false}
-    convert.8 = bf16[1024,512] convert(arg0.1)
-    arg1.2 = f32[256,512] parameter(1), parameter_replication={false}
-    convert.9 = bf16[256,512] convert(arg1.2)
-    dot.10 = bf16[1024,256] dot(convert.8, convert.9), lhs_contracting_dims={1}, rhs_contracting_dims={1}, frontend_attributes={grad_x="false",grad_y="false"}
-    convert = f32[1024,256] convert(dot.10)
-    arg2.3 = f32[256] parameter(2), parameter_replication={false}
-    broadcast = f32[1024,256] broadcast(arg2.3), dimensions={1}
-    add.13 = f32[1024,256] add(convert, broadcast)
-    ROOT tanh.14 = f32[1024,256] tanh(add.13)
+    arg0.1 = f32[1024,512] parameter(0)
+    convert.2 = bf16[1024,512] convert(arg0.1)
+    arg1.3 = f32[256,512] parameter(1)
+    convert.4 = bf16[256,512] convert(arg1.3)
+    dot.5 = bf16[1024,256] dot(convert.2, convert.4), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+    convert.6 = f32[1024,256] convert(dot.5)
+    arg2.7 = f32[256] parameter(2)
+    broadcast.8 = f32[1024,256] broadcast(arg2.7), dimensions={1}
+    add.9 = f32[1024,256] add(convert.6, broadcast.8)
+    ROOT tanh.10 = f32[1024,256] tanh(add.9)
   })";
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-2}));
   MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_tanh_rewrite_str_);
@@ -1197,13 +1197,13 @@ TEST_F(MatmulTest, BiasAddTanhFusionTest_F16) {
   const char* matmul_module_str = R"(
   HloModule matmul.bias.tanh.test.f16
   ENTRY matmul.bias.tanh.test.f16 {
-    arg1.2 = f16[1024,1024]{1,0} parameter(1), parameter_replication={false}
-    arg0.1 = f16[1024,1024]{1,0} parameter(0), parameter_replication={false}
-    dot.7 = f16[1024,1024]{1,0} dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}, frontend_attributes={grad_x="false",grad_y="false"}
-    arg2.3 = f16[1024]{0} parameter(2), parameter_replication={false}
-    broadcast.9 = f16[1024,1024]{1,0} broadcast(arg2.3), dimensions={1}
-    add.10 = f16[1024,1024]{1,0} add(dot.7, broadcast.9)
-    ROOT tanh.11 = f16[1024,1024]{1,0} tanh(add.10)
+    arg0.1 = f16[1024,1024] parameter(0)
+    arg1.2 = f16[1024,1024] parameter(1)
+    dot.3 = f16[1024,1024] dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    arg2.4 = f16[1024] parameter(2)
+    broadcast.5 = f16[1024,1024] broadcast(arg2.4), dimensions={1}
+    add.6 = f16[1024,1024] add(dot.3, broadcast.5)
+    ROOT tanh.7 = f16[1024,1024] tanh(add.6)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
@@ -1215,17 +1215,17 @@ TEST_F(MatmulTest, BiasAddRelu6Fusion_F32) {
   const char* matmul_module_str = R"(
   HloModule matmul.bias.relu6.test.f32
   ENTRY matmul.bias.relu6.test.f32 {
-    constant.11 = f32[] constant(0)
-    broadcast.13 = f32[1024,1024] broadcast(constant.11), dimensions={}
-    arg1.2 = f32[1024,1024] parameter(1), parameter_replication={false}
-    arg0.1 = f32[1024,1024] parameter(0), parameter_replication={false}
-    dot.7 = f32[1024,1024] dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}, frontend_attributes={grad_x="false",grad_y="false"}
-    arg2.3 = f32[1024] parameter(2), parameter_replication={false}
-    broadcast.9 = f32[1024,1024] broadcast(arg2.3), dimensions={1}
-    add.10 = f32[1024,1024] add(dot.7, broadcast.9)
-    constant.12 = f32[] constant(6)
-    broadcast.14 = f32[1024,1024] broadcast(constant.12), dimensions={}
-    ROOT clamp.15 = f32[1024,1024] clamp(broadcast.13, add.10, broadcast.14)
+    constant.1 = f32[] constant(0)
+    broadcast.2 = f32[1024,1024] broadcast(constant.1), dimensions={}
+    arg1.3 = f32[1024,1024] parameter(1)
+    arg2.4 = f32[1024,1024] parameter(0)
+    dot.5 = f32[1024,1024] dot(arg1.3, arg2.4), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    arg3.6 = f32[1024] parameter(2)
+    broadcast.7 = f32[1024,1024] broadcast(arg3.6), dimensions={1}
+    add.8 = f32[1024,1024] add(dot.5, broadcast.7)
+    constant.9 = f32[] constant(6)
+    broadcast.10 = f32[1024,1024] broadcast(constant.9), dimensions={}
+    ROOT clamp.11 = f32[1024,1024] clamp(broadcast.2, add.8, broadcast.10)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-2}));
@@ -1241,19 +1241,19 @@ TEST_F(MatmulTest, BiasAddRelu6Fusion_BF16) {
   HloModule matmul.bias.relu6.test.bf16
   ENTRY matmul.bias.relu6.test.bf16 {
     constant.1 = f32[] constant(0)
-    broadcast.1 = f32[1024,256] broadcast(constant.1), dimensions={}
-    arg0.1 = f32[1024,512] parameter(0), parameter_replication={false}
-    convert.8 = bf16[1024,512] convert(arg0.1)
-    arg1.2 = f32[256,512] parameter(1), parameter_replication={false}
-    convert.9 = bf16[256,512] convert(arg1.2)
-    dot.10 = bf16[1024,256] dot(convert.8, convert.9), lhs_contracting_dims={1}, rhs_contracting_dims={1}, frontend_attributes={grad_x="false",grad_y="false"}
-    convert = f32[1024,256] convert(dot.10)
-    arg2.3 = f32[256] parameter(2), parameter_replication={false}
-    broadcast.2 = f32[1024,256] broadcast(arg2.3), dimensions={1}
-    add.13 = f32[1024,256] add(convert, broadcast.2)
-    constant.3 = f32[] constant(6)
-    broadcast.4 = f32[1024,256] broadcast(constant.3), dimensions={}
-    ROOT clamp.18 = f32[1024,256] clamp(broadcast.1, add.13, broadcast.4)
+    broadcast.2 = f32[1024,256] broadcast(constant.1), dimensions={}
+    arg0.3 = f32[1024,512] parameter(0)
+    convert.4 = bf16[1024,512] convert(arg0.3)
+    arg1.5 = f32[256,512] parameter(1)
+    convert.6 = bf16[256,512] convert(arg1.5)
+    dot.7 = bf16[1024,256] dot(convert.4, convert.6), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+    convert.8 = f32[1024,256] convert(dot.7)
+    arg2.9 = f32[256] parameter(2)
+    broadcast.10 = f32[1024,256] broadcast(arg2.9), dimensions={1}
+    add.11 = f32[1024,256] add(convert.8, broadcast.10)
+    constant.12 = f32[] constant(6)
+    broadcast.13 = f32[1024,256] broadcast(constant.12), dimensions={}
+    ROOT clamp.14 = f32[1024,256] clamp(broadcast.2, add.11, broadcast.13)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-2}));
@@ -1268,17 +1268,17 @@ TEST_F(MatmulTest, BiasAddRelu6Fusion_F16) {
   const char* matmul_module_str = R"(
   HloModule matmul.bias.relu6.test.f16
   ENTRY matmul.bias.relu6.test.f16 {
-    constant.11 = f16[] constant(0)
-    broadcast.13 = f16[1024,1024]{1,0} broadcast(constant.11), dimensions={}
-    arg1.2 = f16[1024,1024]{1,0} parameter(1), parameter_replication={false}
-    arg0.1 = f16[1024,1024]{1,0} parameter(0), parameter_replication={false}
-    dot.7 = f16[1024,1024]{1,0} dot(arg1.2, arg0.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}, frontend_attributes={grad_x="false",grad_y="false"}
-    arg2.3 = f16[1024]{0} parameter(2), parameter_replication={false}
-    broadcast.9 = f16[1024,1024]{1,0} broadcast(arg2.3), dimensions={1}
-    add.10 = f16[1024,1024]{1,0} add(dot.7, broadcast.9)
-    constant.12 = f16[] constant(6)
-    broadcast.14 = f16[1024,1024]{1,0} broadcast(constant.12), dimensions={}
-    ROOT clamp.15 = f16[1024,1024]{1,0} clamp(broadcast.13, add.10, broadcast.14)
+    constant.1 = f16[] constant(0)
+    broadcast.2 = f16[1024,1024] broadcast(constant.7), dimensions={}
+    arg0.3 = f16[1024,1024] parameter(0)
+    arg1.4 = f16[1024,1024] parameter(1)
+    dot.5 = f16[1024,1024] dot(arg1.4, arg0.3), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    arg2.6 = f16[1024] parameter(2)
+    broadcast.7 = f16[1024,1024] broadcast(arg2.6), dimensions={1}
+    add.8 = f16[1024,1024] add(dot.5, broadcast.7)
+    constant.9 = f16[] constant(6)
+    broadcast.10 = f16[1024,1024] broadcast(constant.9), dimensions={}
+    ROOT clamp.11 = f16[1024,1024] clamp(broadcast.2, add.8, broadcast.10)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));


### PR DESCRIPTION
This PR enables MatMul  fusions with different activations viz. Elu, Tanh and Relu6.