### PR TITLE
[XLA:GPU] add force inline option to get better llvm splits

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -193,6 +193,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_while_loop_reduce_scatter_code_motion(false);
 
   opts.set_xla_gpu_collective_inflation_factor(1);
+  opts.set_xla_llvm_split_module_level(0);
 
   opts.set_xla_gpu_exhaustive_tiling_search(false);
 
@@ -1095,6 +1096,15 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_collective_inflation_factor(),
       "Inflation factor for collectives. If set to > 1, each XLA/GPU "
       "collective will execute multiple times (will yield incorrect results)"));
+
+  flag_list->push_back(tsl::Flag(
+      "xla_llvm_split_module_level",
+      int32_setter_for(&DebugOptions::set_xla_llvm_split_module_level),
+      debug_options->xla_llvm_split_module_level(),
+      "Decide how llvm modules are split: Whether to force inline or preserve "
+      "locals. 0 = no inline, 1 = force inline before split, 2 = no line and "
+      "PreserveLocals=False during split, default is 0"));
+
   flag_list->push_back(tsl::Flag(
       "xla_gpu_enable_reassociation_for_converted_ar",
       bool_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -193,7 +193,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_while_loop_reduce_scatter_code_motion(false);
 
   opts.set_xla_gpu_collective_inflation_factor(1);
-  opts.set_xla_llvm_split_module_level(0);
+  opts.set_xla_llvm_force_inline_before_split(true);
 
   opts.set_xla_gpu_exhaustive_tiling_search(false);
 
@@ -1098,12 +1098,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "collective will execute multiple times (will yield incorrect results)"));
 
   flag_list->push_back(tsl::Flag(
-      "xla_llvm_split_module_level",
-      int32_setter_for(&DebugOptions::set_xla_llvm_split_module_level),
-      debug_options->xla_llvm_split_module_level(),
-      "Decide how llvm modules are split: Whether to force inline or preserve "
-      "locals. 0 = no inline, 1 = force inline before split, 2 = no line and "
-      "PreserveLocals=False during split, default is 0"));
+      "xla_llvm_force_inline_before_split",
+      bool_setter_for(&DebugOptions::set_xla_llvm_force_inline_before_split),
+      debug_options->xla_llvm_force_inline_before_split(),
+      "Decide whether to force inline before llvm module split to get a more "
+      "balanced splits for parallel compilation"));
 
   flag_list->push_back(tsl::Flag(
       "xla_gpu_enable_reassociation_for_converted_ar",

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -430,6 +430,10 @@ message DebugOptions {
   // Inflate collective cost by running each collective multiple times.
   int32 xla_gpu_collective_inflation_factor = 205;
 
+  // Whether to force inline or preserve locals
+  // 0 = no inline, 1 = inline, 2 = no preserve locals, default is 0
+  int32 xla_llvm_split_module_level = 300;
+
   // Whether to use the cuDNN frontend API for convolutions when possible.
   bool xla_gpu_enable_cudnn_frontend = 160;
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -430,9 +430,9 @@ message DebugOptions {
   // Inflate collective cost by running each collective multiple times.
   int32 xla_gpu_collective_inflation_factor = 205;
 
-  // Whether to force inline or preserve locals
-  // 0 = no inline, 1 = inline, 2 = no preserve locals, default is 0
-  int32 xla_llvm_split_module_level = 300;
+  // Whether to force inline before llvm module split to get a more balanced
+  // splits for parallel compilation.
+  bool xla_llvm_force_inline_before_split = 300;
 
   // Whether to use the cuDNN frontend API for convolutions when possible.
   bool xla_gpu_enable_cudnn_frontend = 160;


### PR DESCRIPTION
Add option to XLA to enforce inlining before llvm splitModule or set preserveLocals=False to get more balanced splits in parallel compilation case.

Some data of GPT3 5B model with different setting:
```
Compilation: TSL:XlaCompile:#module=pjit__wrapped_step_fn,program_id=24#: 3.754429084s (parallel + inline) runtime: 1.0s
Compilation: TSL:XlaCompile:#module=pjit__wrapped_step_fn,program_id=24#: 4.676450341s (parallel + no inline) runtime: 1.0s
Compilation: TSL:XlaCompile:#module=pjit__wrapped_step_fn,program_id=24#: 3.051018704s (parallel + perserve_local=False) runtime: 1.4s
Compilation: TSL:XlaCompile:#module=pjit__wrapped_step_fn,program_id=24#: 4.862938161s (serial) runtime: 1.0s
```

However, the runtime per step of perserve_locals=False vs other three setup is 1.4s vs 1.0s.