### PR TITLE
[ROCm] Fix build break in `xla/service/gpu/runtime/convolution_thunk.cc`

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -526,7 +526,7 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:errors",
-    ],
+	] + if_rocm_is_configured(["//xla/service/gpu:stream_executor_util"]),
 )
 
 cc_library(

--- a/xla/service/gpu/runtime/convolution_thunk.cc
+++ b/xla/service/gpu/runtime/convolution_thunk.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/service/buffer_assignment.h"
+#include "xla/service/gpu/stream_executor_util.h"
 #include "xla/service/gpu/gpu_conv_runner.h"
 #include "xla/service/gpu/runtime/thunk.h"
 #include "xla/stream_executor/device_memory.h"

--- a/xla/service/gpu/runtime/convolution_thunk.cc
+++ b/xla/service/gpu/runtime/convolution_thunk.cc
@@ -27,7 +27,9 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/service/buffer_assignment.h"
+#if TENSORFLOW_USE_ROCM
 #include "xla/service/gpu/stream_executor_util.h"
+#endif //TENSORFLOW_USE_ROCM
 #include "xla/service/gpu/gpu_conv_runner.h"
 #include "xla/service/gpu/runtime/thunk.h"
 #include "xla/stream_executor/device_memory.h"


### PR DESCRIPTION
Fix build break introduced in db8f9c0cf2bf08b171aec2cbe3da2fcb074a6207