### PR TITLE
Fix link error in for_all_thunks_test

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -1139,7 +1139,7 @@ cc_library(
     ],
 )
 
-cc_test(
+xla_cc_test(
     name = "for_all_thunks_test",
     srcs = ["for_all_thunks_test.cc"],
     deps = [


### PR DESCRIPTION
Use xla_cc_test instead of cc_test to ensure that all shared objects are available for linking.