### PR TITLE
[ROCM] hipblas-lt: bias pointer workaround

### DIFF
--- a/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -4111,7 +4111,7 @@ ENTRY test {
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
 
-  if (IsCuda() ||
+  if (IsCuda() &&
       !HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {
     GTEST_SKIP() << "Pre-Ampere casts up bf16 to fp32";
   }

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -176,8 +176,10 @@ absl::Status BlasLt::Init() {
   auto hip_compute_type = AsHipblasComputeType(compute_type);
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatmulDescCreate(
       &hip_desc, hip_compute_type, hip_scale_type));
+
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
-  BlasLt::MatmulDesc desc(hip_desc, hip_compute_type, hip_scale_type);
+  BlasLt::MatmulDesc desc(hip_desc, hip_compute_type, hip_scale_type,
+        int32_t(epilogue) & int32_t(Epilogue::kBias));
   if (pointer_mode != PointerMode::kHost) {
     return absl::InternalError("hipblaslt does not support device pointers");
   }
@@ -215,17 +217,10 @@ auto BlasLt::MatmulPlan::GetAlgorithms(size_t max_algorithm_count,
 
     gpu::ScopedActivateExecutorContext sac{blas_lt_ref_.parent_};
 
-    // Right now, hipBlasLt would require setting the bias pointer (even a dummy
-    // one) before finding the algorithms for
-    // HIPBLASLT_MATMUL_DESC_BIAS_POINTER. Can remove this later once this
-    // restriction is gone.
-    static int dummy_pointer = 0;
-    TF_ASSIGN_OR_RETURN(auto epilogue,
-                        GetAttr<hipblasLtEpilogue_t>(
-                            op_desc_.get(), HIPBLASLT_MATMUL_DESC_EPILOGUE));
-    if (epilogue == HIPBLASLT_EPILOGUE_BIAS) {
-      TF_RETURN_IF_ERROR(SetAttr(
-          op_desc_.get(), HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &dummy_pointer));
+    if (op_desc_.has_bias_epilogue()) {
+      static int64_t dummyPointer = 0xACEBALL;
+      TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(), 
+            HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &dummyPointer));
     }
 
     int found_algorithm_count = 0;
@@ -450,7 +445,7 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     TF_RET_CHECK(blas_lt_ref_.blas_lt_ != nullptr);
     // We must set the bias and aux pointers while holding the mutex, to avoid a
     // potential race condition from multiple threads sharing the same plan.
-    if (bias != nullptr) {
+    if (op_desc_.has_bias_epilogue() && bias != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(
           op_desc_.get(), HIPBLASLT_MATMUL_DESC_BIAS_POINTER, bias.opaque()));
     }

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -177,9 +177,11 @@ absl::Status BlasLt::Init() {
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatmulDescCreate(
       &hip_desc, hip_compute_type, hip_scale_type));
 
+  int32_t bias_flag = static_cast<int32_t>(epilogue) & 
+                                      static_cast<int32_t>(Epilogue::kBias);
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
   BlasLt::MatmulDesc desc(hip_desc, hip_compute_type, hip_scale_type,
-        int32_t(epilogue) & int32_t(Epilogue::kBias));
+        bias_flag != 0);
   if (pointer_mode != PointerMode::kHost) {
     return absl::InternalError("hipblaslt does not support device pointers");
   }

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -217,6 +217,9 @@ auto BlasLt::MatmulPlan::GetAlgorithms(size_t max_algorithm_count,
 
     gpu::ScopedActivateExecutorContext sac{blas_lt_ref_.parent_};
 
+    // hipBlasLt requires setting the bias pointer (even a dummy one), otherwise
+    // no algorithms can be found for "bias epilogues". This is to be removed
+    // later when this limitation is gone.
     if (op_desc_.has_bias_epilogue()) {
       static int64_t dummyPointer = 0xACEBALL;
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(), 

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -65,6 +65,7 @@ class BlasLt : public gpu::BlasLt {
 
     hipblasComputeType_t compute_type() const { return compute_type_; }
     hipDataType scale_type() const { return datatype_; }
+    bool has_bias_epilogue() const { return has_bias_epilogue_; }
     hipblasPointerMode_t pointer_mode() const {
       return HIPBLAS_POINTER_MODE_HOST;
     }
@@ -72,14 +73,16 @@ class BlasLt : public gpu::BlasLt {
 
    private:
     MatmulDesc(hipblasLtMatmulDesc_t handle, hipblasComputeType_t compute_type,
-               hipDataType datatype)
+               hipDataType datatype, bool bias_epilogue)
         : handle_(handle, wrap::hipblasLtMatmulDescDestroy),
-          compute_type_(compute_type),
-          datatype_(datatype) {}
+          compute_type_(compute_type), 
+          datatype_(datatype),
+          has_bias_epilogue_(bias_epilogue) {}
 
     Owned<hipblasLtMatmulDesc_t> handle_;
     hipblasComputeType_t compute_type_;
     hipDataType datatype_;
+    bool has_bias_epilogue_;
   };
 
   struct MatmulPlan : public gpu::BlasLt::MatmulPlan {


### PR DESCRIPTION
This is a workaround for ROCM-6.2 version where the behaviour of bias pointer was changed. New version shall work fine both for old and new rocm versions

@xla-rotation: could you have a look please ?