### PR TITLE
[NVIDIA] Fix PGLE for latency estimation of p2p instructions

### DIFF
--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -104,6 +104,14 @@ bool LatencyEstimator::IsAsyncPair(const HloGraphNode& from,
          from_op.inner == target_op.inner;
 }
 
+bool LatencyEstimator::IsP2pPair(const HloGraphNode& from,
+                                 const HloGraphNode& target) const {
+  return (from.GetInstr().opcode() == HloOpcode::kSend &&
+          target.GetInstr().opcode() == HloOpcode::kSendDone) ||
+         (from.GetInstr().opcode() == HloOpcode::kRecv &&
+          target.GetInstr().opcode() == HloOpcode::kRecvDone);
+}
+
 LatencyEstimator::TimeCost ApproximateLatencyEstimator::GetLatencyBetween(
     const HloGraphNode& from, const HloGraphNode& target) const {
   if (IsAsyncPair(from, target)) {

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -106,10 +106,11 @@ bool LatencyEstimator::IsAsyncPair(const HloGraphNode& from,
 
 bool LatencyEstimator::IsP2pPair(const HloGraphNode& from,
                                  const HloGraphNode& target) const {
-  return (from.GetInstr().opcode() == HloOpcode::kSend &&
-          target.GetInstr().opcode() == HloOpcode::kSendDone) ||
-         (from.GetInstr().opcode() == HloOpcode::kRecv &&
-          target.GetInstr().opcode() == HloOpcode::kRecvDone);
+  HloOpcode src_opcode = from.GetInstr().opcode();
+  HloOpcode tgt_opcode = target.GetInstr().opcode();
+  return (src_opcode == HloOpcode::kSend &&
+          tgt_opcode == HloOpcode::kSendDone) ||
+         (src_opcode == HloOpcode::kRecv && tgt_opcode == HloOpcode::kRecvDone);
 }
 
 LatencyEstimator::TimeCost ApproximateLatencyEstimator::GetLatencyBetween(

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -137,6 +137,7 @@ class LatencyEstimator {
     return get_canonical_async_op_(hlo);
   }
   bool IsAsyncPair(const HloGraphNode& from, const HloGraphNode& target) const;
+  bool IsP2pPair(const HloGraphNode& from, const HloGraphNode& target) const;
   explicit LatencyEstimator(
       GetCanonicalAsyncOpFunc func = DefaultGetCanonicalAsyncOp)
       : get_canonical_async_op_(func) {}

--- a/xla/service/profile_guided_latency_estimator.cc
+++ b/xla/service/profile_guided_latency_estimator.cc
@@ -66,7 +66,8 @@ LatencyEstimator::TimeCost ProfileGuidedLatencyEstimator::GetLatencyBetween(
 
   // For async-start/done instructions, if there is no entry in latencies, fall
   // back to using instruction cost as the latency.
-  if (it->second.cost.has_value() && IsAsyncPair(from, target)) {
+  if (it->second.cost.has_value() &&
+      (IsAsyncPair(from, target) || IsP2pPair(from, target))) {
     VLOG(10) << "PGLE found latency for async op " << from.GetInstr().name()
              << " and (assumed)" << target.GetInstr().name()
              << " in instruction costs";

--- a/xla/service/profile_guided_latency_estimator_test.cc
+++ b/xla/service/profile_guided_latency_estimator_test.cc
@@ -228,9 +228,9 @@ ENTRY entry {
   EXPECT_TRUE(hlo_module->has_entry_computation());
 
   std::string profiled_instructions_text_proto = R"pb(
-    costs { name: "send.7.0" cost_us: 110.0 }
-    costs { name: "recv.7.0" cost_us: 100.0 }
-  )pb";
+      costs { name: "send.7.0" cost_us: 110.0 }
+      costs { name: "recv.7.0" cost_us: 100.0 }
+    )pb";
   ;
   tensorflow::profiler::ProfiledInstructionsProto profiled_instructions_proto;
   ASSERT_TRUE(tsl::protobuf::TextFormat::ParseFromString(


### PR DESCRIPTION
PGLE doesn't recognize p2p instruction such as send or recv as async operations.
This adds the utility to check if instruction is a p2p communication instruction.