### PR TITLE
[ROCm] Distinguish between AMD and NVIDIA GPUs with relevant tags

### DIFF
--- a/.kokoro/linux/build.sh
+++ b/.kokoro/linux/build.sh
@@ -60,7 +60,7 @@ RBE_FLAGS=""
 TARGET_FILTERS=""
 
 if is_linux_gpu_job ; then
-    TAGS_FILTER="$TAGS_FILTER,requires-gpu-nvidia"
+    TAGS_FILTER="$TAGS_FILTER,requires-gpu-nvidia,-requires-gpu-amd"
 
     # We are currently running XLA presubmits on machines with NVIDIA T4 GPUs,
     # which have a compute compatibility of 7.5. Se we filter out all the tests
@@ -79,7 +79,7 @@ if is_linux_gpu_job ; then
     echo "***NOTE: nvidia-smi lists the highest CUDA version the driver supports, which may be different than the version of CUDA actually used!!***"
     nvidia-smi
 else
-    TAGS_FILTER="$TAGS_FILTER,-gpu,-requires-gpu-nvidia"
+    TAGS_FILTER="$TAGS_FILTER,-gpu,-requires-gpu-nvidia,-requires-gpu-amd"
     ADDITIONAL_FLAGS="$ADDITIONAL_FLAGS --config=nonccl"
     TARGET_FILTERS="$TARGET_FILTERS -//xla/service/gpu/..."
 

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -603,13 +603,14 @@ cc_library(
 
 xla_test(
     name = "ir_emitter_triton_test",
-    srcs = if_cuda_is_configured(["ir_emitter_triton_test.cc"]),
+    srcs = if_gpu_is_configured(["ir_emitter_triton_test.cc"]),
     backends = [
         "gpu_a100",
         "gpu_h100",
+        "amd_gpu_any"
     ],
     shard_count = 20,
-    tags = ["nomac"],
+    tags = ["nomac", "no_rocm"],
     deps = [
         ":backend_configs_cc",
         ":gpu_device_info_for_tests",
@@ -653,10 +654,11 @@ xla_test(
 
 xla_test(
     name = "ir_emitter_triton_large_test",
-    srcs = if_cuda_is_configured(["ir_emitter_triton_large_test.cc"]),
+    srcs = if_gpu_is_configured(["ir_emitter_triton_large_test.cc"]),
     backends = [
         "gpu_a100",
         "gpu_h100",
+        "amd_gpu_any"
     ],
     tags = [
         "large",
@@ -677,10 +679,11 @@ xla_test(
 
 xla_test(
     name = "ir_emitter_triton_parametrized_test",
-    srcs = if_cuda_is_configured(["ir_emitter_triton_parametrized_test.cc"]),
+    srcs = if_gpu_is_configured(["ir_emitter_triton_parametrized_test.cc"]),
     backends = [
         "gpu_a100",
         "gpu_h100",
+        "amd_gpu_any"
     ],
     shard_count = 10,
     tags = ["nomac"],
@@ -1188,9 +1191,10 @@ cc_library(
 
 xla_test(
     name = "triton_support_test",
-    srcs = if_cuda_is_configured(["triton_support_test.cc"]),
+    srcs = if_gpu_is_configured(["triton_support_test.cc"]),
     backends = [
         "gpu_a100",
+        "amd_gpu_any"
     ],
     shard_count = 10,
     tags = ["nomac"],
@@ -1607,6 +1611,7 @@ xla_test(
     srcs = if_gpu_is_configured(["gemm_algorithm_picker_test.cc"]),
     backends = [
         "gpu_v100",
+        "amd_gpu_any"
     ],
     deps = [
         ":autotuner_util",
@@ -1903,6 +1908,7 @@ xla_test(
     srcs = if_gpu_is_configured(["conv_algorithm_picker_test.cc"]),
     backends = [
         "gpu_v100",
+        "amd_gpu_any"
     ],
     tags = [
         "noasan",
@@ -3776,7 +3782,7 @@ cc_library(
 
 xla_test(
     name = "nvptx_compiler_test",
-    srcs = if_gpu_is_configured([
+    srcs = if_cuda_is_configured([
         "nvptx_compiler_test.cc",
     ]),
     backends = [
@@ -4573,6 +4579,7 @@ xla_test(
     },
     backends = [
         "gpu_a100",
+        "amd_gpu_any"
     ] + if_oss(["gpu_any"]),
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     shard_count = 10,
@@ -5230,13 +5237,14 @@ cc_library(
 
 xla_test(
     name = "dot_operand_converter_test",
-    srcs = if_cuda_is_configured(["dot_operand_converter_test.cc"]),
+    srcs = if_gpu_is_configured(["dot_operand_converter_test.cc"]),
     backends = [
         "gpu_a100",
         "gpu_p100",
         "gpu_v100",
+        "amd_gpu_any"
     ],
-    deps = if_cuda_is_configured(
+    deps = if_gpu_is_configured(
         [
             ":dot_operand_converter",
             "@com_google_googletest//:gtest",
@@ -5571,10 +5579,11 @@ cc_library(
 
 xla_test(
     name = "dot_algorithm_support_test",
-    srcs = if_cuda_is_configured(["dot_algorithm_support_test.cc"]),
+    srcs = if_gpu_is_configured(["dot_algorithm_support_test.cc"]),
     backends = [
         "gpu_v100",
         "gpu_a100",
+        "amd_gpu_any"
     ],
     tags = [
         "no_oss",  # Needs fix for `ConvertGenerator`
@@ -5786,6 +5795,7 @@ xla_test(
     srcs = if_gpu_is_configured(["determinism_test.cc"]),
     backends = [
         "gpu_a100",
+        "amd_gpu_any"
     ],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
         "TENSORFLOW_USE_ROCM=1",

--- a/xla/service/gpu/build_defs.bzl
+++ b/xla/service/gpu/build_defs.bzl
@@ -7,7 +7,7 @@ load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//xla/tests:build_defs.bzl",
-    "prepare_gpu_backend_data",
+    "prepare_nvidia_gpu_backend_data",
 )
 
 # buildifier: disable=out-of-order-load
@@ -149,7 +149,7 @@ def gen_gpu_hlo_compile_tests(name, hlo_files, multihost_hlo_runner_binary_path,
 
         # Expand "gpu" backend name to specific GPU backends and update tags.
         backends, disabled_backends, backend_tags, backend_args = \
-            prepare_gpu_backend_data(backends, disabled_backends, backend_tags, backend_args)
+            prepare_nvidia_gpu_backend_data(backends, disabled_backends, backend_tags, backend_args)
 
         backends = [
             backend

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -351,6 +351,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_v100",
+        "amd_gpu_any"
     ],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
@@ -451,6 +452,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_v100",
+        "amd_gpu_any"
     ],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -449,6 +449,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_v100",
+        "amd_gpu_any"
     ],
     deps = [
         ":gpu_codegen_test",
@@ -529,6 +530,7 @@ xla_test(
     srcs = ["gpu_kernel_tiling_test.cc"],
     backends = [
         "gpu_p100",
+        "amd_gpu_any"
     ] + if_oss(["gpu_any"]),
     deps = [
         ":gpu_codegen_test",
@@ -912,6 +914,7 @@ xla_test(
     srcs = ["tensor_float_32_global_var_test.cc"],
     backends = [
         "gpu_a100",
+        "amd_gpu_any"
     ] + if_oss(["gpu_any"]),
     deps = [
         "//xla:error_spec",
@@ -928,6 +931,7 @@ xla_test(
         "gpu_a100",
         "gpu_h100",
     ],
+    tags=["no_rocm"],
     deps = if_cuda_is_configured(
         [
             ":gpu_codegen_test",

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -27,7 +27,7 @@ AMD_GPU_DEFAULT_BACKENDS = ["amd_gpu_any"]
 
 _DEFAULT_BACKENDS = ["cpu"] + NVIDIA_GPU_DEFAULT_BACKENDS + AMD_GPU_DEFAULT_BACKENDS
 
-ALL_GPU_BACKENDS = NVIDIA_GPU_BACKENDS + AMD_GPU_DEFAULT_BACKENDS
+GPU_BACKENDS = NVIDIA_GPU_BACKENDS + AMD_GPU_DEFAULT_BACKENDS
 
 _ALL_BACKENDS = ["cpu", "interpreter"] + NVIDIA_GPU_BACKENDS + AMD_GPU_DEFAULT_BACKENDS + list(plugins.keys())
 
@@ -318,7 +318,7 @@ def xla_test_library(
         this_backend_copts = []
         if backend == "cpu":
             backend_deps = ["//xla/tests:test_macros_cpu"]
-        elif backend in ALL_GPU_BACKENDS:
+        elif backend in GPU_BACKENDS:
             backend_deps = ["//xla/tests:test_macros_%s" % backend]
         elif backend == "interpreter":
             backend_deps = ["//xla/tests:test_macros_interpreter"]

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -5,14 +5,10 @@ load(
     "tf_gpu_tests_tags",
 )
 load("//xla:xla.bzl", "xla_cc_test")
-load(
-    "//xla/stream_executor:build_defs.bzl",
-    "if_gpu_is_configured",
-)
 load("//xla/tests:plugin.bzl", "plugins")
 
 # Possible backend values for the GPU family.
-GPU_BACKENDS = [
+NVIDIA_GPU_BACKENDS = [
     "gpu_any",
     "gpu_p100",
     "gpu_v100",
@@ -21,35 +17,39 @@ GPU_BACKENDS = [
 ]
 
 # The generic "gpu" backend includes the actual backends in this list.
-GPU_DEFAULT_BACKENDS = [
+NVIDIA_GPU_DEFAULT_BACKENDS = [
     "gpu_any",
     "gpu_a100",
     "gpu_h100",
 ]
 
-_DEFAULT_BACKENDS = ["cpu"] + GPU_DEFAULT_BACKENDS
+AMD_GPU_DEFAULT_BACKENDS = ["amd_gpu_any"]
 
-_ALL_BACKENDS = ["cpu", "interpreter"] + GPU_BACKENDS + list(plugins.keys())
+_DEFAULT_BACKENDS = ["cpu"] + NVIDIA_GPU_DEFAULT_BACKENDS + AMD_GPU_DEFAULT_BACKENDS
+
+ALL_GPU_BACKENDS = NVIDIA_GPU_BACKENDS + AMD_GPU_DEFAULT_BACKENDS
+
+_ALL_BACKENDS = ["cpu", "interpreter"] + NVIDIA_GPU_BACKENDS + AMD_GPU_DEFAULT_BACKENDS + list(plugins.keys())
 
 # buildifier: disable=function-docstring
-def prepare_gpu_backend_data(backends, disabled_backends, backend_tags, backend_args):
+def prepare_nvidia_gpu_backend_data(backends, disabled_backends, backend_tags, backend_args):
     # Expand "gpu" backend name into device specific backend names.
     new_backends = [name for name in backends if name != "gpu"]
     if len(new_backends) < len(backends):
-        new_backends.extend(GPU_DEFAULT_BACKENDS)
+        new_backends.extend(NVIDIA_GPU_DEFAULT_BACKENDS)
 
     new_disabled_backends = [name for name in disabled_backends if name != "gpu"]
     if len(new_disabled_backends) < len(disabled_backends):
-        new_disabled_backends.extend(GPU_BACKENDS)
+        new_disabled_backends.extend(NVIDIA_GPU_BACKENDS)
 
     new_backend_tags = {key: value for key, value in backend_tags.items() if key != "gpu"}
     gpu_backend_tags = backend_tags.get("gpu", [])
-    for key in GPU_BACKENDS:
+    for key in NVIDIA_GPU_BACKENDS:
         new_backend_tags.setdefault(key, gpu_backend_tags[:])
 
     new_backend_args = {key: value for key, value in backend_args.items() if key != "gpu"}
     if "gpu" in backend_args:
-        for key in GPU_BACKENDS:
+        for key in NVIDIA_GPU_BACKENDS:
             new_backend_args.setdefault(key, backend_args["gpu"])
 
     # Disable backends that don't meet the device requirements.
@@ -60,7 +60,7 @@ def prepare_gpu_backend_data(backends, disabled_backends, backend_tags, backend_
         "gpu_a100": (8, 0),
         "gpu_h100": (9, 0),
     }
-    for gpu_backend in GPU_BACKENDS:
+    for gpu_backend in NVIDIA_GPU_BACKENDS:
         all_tags = new_backend_tags[gpu_backend]
         requires_gpu = [t for t in all_tags if t.startswith("requires-gpu-")]
         requires_sm, only = None, False
@@ -86,6 +86,13 @@ def prepare_gpu_backend_data(backends, disabled_backends, backend_tags, backend_
             new_backend_tags[gpu_backend].append(sm_tag)
 
     return new_backends, new_disabled_backends, new_backend_tags, new_backend_args
+
+def prepare_amd_gpu_backend_data(backends):
+    new_backends = [name for name in backends if name != "gpu"]
+    if len(new_backends) < len(backends):
+        new_backends.extend(AMD_GPU_DEFAULT_BACKENDS)
+
+    return new_backends
 
 def xla_test(
         name,
@@ -170,13 +177,30 @@ def xla_test(
     if not backends:
         backends = _DEFAULT_BACKENDS
 
+    nvidia_backends = [
+            backend
+            for backend in backends
+            if backend in ['gpu'] + NVIDIA_GPU_BACKENDS
+    ]
+    amd_backends = [
+            backend
+            for backend in backends
+            if backend in ['gpu'] + AMD_GPU_DEFAULT_BACKENDS
+    ]
+    other_backends = [
+            backend
+            for backend in backends
+            if backend not in ['gpu'] + NVIDIA_GPU_BACKENDS + AMD_GPU_DEFAULT_BACKENDS
+    ]
+
     # Expand "gpu" backend name to specific GPU backends and update tags.
-    backends, disabled_backends, backend_tags, backend_args = \
-        prepare_gpu_backend_data(backends, disabled_backends, backend_tags, backend_args)
+    nvidia_backends, disabled_backends, backend_tags, backend_args = \
+        prepare_nvidia_gpu_backend_data(nvidia_backends, disabled_backends, backend_tags, backend_args)
+    amd_backends = prepare_amd_gpu_backend_data(amd_backends)
 
     backends = [
         backend
-        for backend in backends
+        for backend in nvidia_backends + amd_backends + other_backends
         if backend not in disabled_backends
     ]
 
@@ -192,12 +216,16 @@ def xla_test(
                 "//xla/service:cpu_plugin",
                 "//xla/tests:test_macros_cpu",
             ]
-        elif backend in GPU_BACKENDS:
-            backend_deps += if_gpu_is_configured([
+        elif backend in NVIDIA_GPU_BACKENDS:
+            backend_deps += [
                 "//xla/service:gpu_plugin",
                 "//xla/tests:test_macros_%s" % backend,
-            ])
+            ]
             this_backend_tags += tf_gpu_tests_tags()
+            this_backend_copts.append("-DXLA_TEST_BACKEND_GPU=1")
+        elif backend in AMD_GPU_DEFAULT_BACKENDS:
+            backend_deps.append("//xla/tests:test_macros_amd_gpu_any")
+            this_backend_tags.append('requires-gpu-amd')
             this_backend_copts.append("-DXLA_TEST_BACKEND_GPU=1")
         elif backend == "interpreter":
             backend_deps += [
@@ -290,7 +318,7 @@ def xla_test_library(
         this_backend_copts = []
         if backend == "cpu":
             backend_deps = ["//xla/tests:test_macros_cpu"]
-        elif backend in GPU_BACKENDS:
+        elif backend in ALL_GPU_BACKENDS:
             backend_deps = ["//xla/tests:test_macros_%s" % backend]
         elif backend == "interpreter":
             backend_deps = ["//xla/tests:test_macros_interpreter"]


### PR DESCRIPTION
Add `requires-gpu-amd` for AMD gpus and unit tests that require AMD backend. Use `requires-gpu-nvidia` for any nvidia gpu backend.