### PR TITLE
Fix build issue of gpu_sparse_dot_test 

### DIFF
--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -940,7 +940,9 @@ xla_test(
             "//xla:literal_util",
             "//xla/tests:xla_internal_test_main",
         ],
-        ["@tsl//tsl/platform:test_main"],  # b/317293391
+        ["@tsl//tsl/platform:test_main"  # b/317293391
+	 "@tsl//tsl/lib/core:status_test_util",
+	],
     ),
 )
 

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -939,10 +939,9 @@ xla_test(
             "//xla:literal",
             "//xla:literal_util",
             "//xla/tests:xla_internal_test_main",
+	    "@tsl//tsl/lib/core:status_test_util",
         ],
-        ["@tsl//tsl/platform:test_main",  # b/317293391
-	 "@tsl//tsl/lib/core:status_test_util",
-	],
+        ["@tsl//tsl/platform:test_main"],  # b/317293391
     ),
 )
 

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -940,7 +940,7 @@ xla_test(
             "//xla:literal_util",
             "//xla/tests:xla_internal_test_main",
         ],
-        ["@tsl//tsl/platform:test_main"  # b/317293391
+        ["@tsl//tsl/platform:test_main",  # b/317293391
 	 "@tsl//tsl/lib/core:status_test_util",
 	],
     ),

--- a/xla/service/gpu/tests/gpu_sparse_dot_test.cc
+++ b/xla/service/gpu/tests/gpu_sparse_dot_test.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/literal.h"
 #include "xla/literal_util.h"
+#include "tsl/lib/core/status_test_util.h"
 #include "xla/service/gpu/tests/gpu_codegen_test.h"
 
 namespace xla {
@@ -131,10 +132,10 @@ ENTRY main {
   Literal dense_rhs = LiteralUtil::CreateR1<uint16_t>(absl::MakeSpan(in2));
 
   auto dense_module = ParseAndReturnVerifiedModule(dense_hlo);
-  EXPECT_OK(dense_module);
+  TF_EXPECT_OK(dense_module);
   auto dense_result =
       Execute(std::move(*dense_module), {&dense_lhs, &dense_rhs});
-  EXPECT_OK(dense_result);
+  TF_EXPECT_OK(dense_result);
 
   // Execute sparse dot.
   const char* kSparseTpl = R"(
@@ -155,10 +156,10 @@ ENTRY main {
   Literal sparse_meta = LiteralUtil::CreateR1<uint16_t>(absl::MakeSpan(meta));
 
   auto sparse_module = ParseAndReturnVerifiedModule(sparse_hlo);
-  EXPECT_OK(sparse_module);
+  TF_EXPECT_OK(sparse_module);
   auto sparse_result = Execute(std::move(*sparse_module),
                                {&sparse_lhs, &sparse_rhs, &sparse_meta});
-  EXPECT_OK(sparse_result);
+  TF_EXPECT_OK(sparse_result);
 
   // Compare the results.
   EXPECT_EQ(*dense_result, *sparse_result);


### PR DESCRIPTION
replaces EXPECT_OK with TF_EXPECT_OK and added relevant header file and dependency.

Error:
#10 1431.9 xla/service/gpu/tests/gpu_sparse_dot_test.cc:134:3: error: use of undeclared identifier 'EXPECT_OK'
[1792](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1792)#10 1431.9   134 |   EXPECT_OK(dense_module);
[1793](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1793)#10 1431.9       |   ^
[1794](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1794)#10 1431.9 xla/service/gpu/tests/gpu_sparse_dot_test.cc:137:3: error: use of undeclared identifier 'EXPECT_OK'
[1795](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1795)#10 1431.9   137 |   EXPECT_OK(dense_result);
[1796](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1796)#10 1431.9       |   ^
[1797](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1797)#10 1431.9 xla/service/gpu/tests/gpu_sparse_dot_test.cc:158:3: error: use of undeclared identifier 'EXPECT_OK'
[1798](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1798)#10 1431.9   158 |   EXPECT_OK(sparse_module);
[1799](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1799)#10 1431.9       |   ^
[1800](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1800)#10 1431.9 xla/service/gpu/tests/gpu_sparse_dot_test.cc:161:3: error: use of undeclared identifier 'EXPECT_OK'
[1801](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1801)#10 1431.9   161 |   EXPECT_OK(sparse_result);
[1802](https://gitlab-master.nvidia.com/dl/openxla/ci/-/jobs/94442414#L1802)#10 1431.9       |   ^