### PR TITLE
Add Tirton support for XLA clamp

### DIFF
--- a/xla/service/gpu/ir_emitter_triton.cc
+++ b/xla/service/gpu/ir_emitter_triton.cc
@@ -475,6 +475,10 @@ absl::StatusOr<Value> EmitElementwise(ImplicitLocOpBuilder& b,
       return Maximum(b, device_info, inputs);
     case HloOpcode::kMinimum:
       return Minimum(b, device_info, inputs);
+    case HloOpcode::kClamp:
+      return Maximum(
+          b, device_info,
+          {Minimum(b, device_info, {inputs[1], inputs[2]}), inputs[0]});
     case HloOpcode::kAnd:
       return b.create<ma::AndIOp>(inputs[0], inputs[1]);
     case HloOpcode::kOr:

--- a/xla/service/gpu/ir_emitter_triton_test.cc
+++ b/xla/service/gpu/ir_emitter_triton_test.cc
@@ -4452,7 +4452,12 @@ triton_gemm_dot_computation {
   tmp_19 = f32[3,57]{1,0} multiply(tmp_17, tmp_18)
   tmp_20 = f32[3,57]{1,0} negate(tmp_19)
   tmp_21 = f32[3,57]{1,0} add(tmp_13, tmp_20)
-  ROOT tmp_22 = f32[32,57]{0,1} dot(tmp_8, tmp_21), lhs_contracting_dims={0}, rhs_contracting_dims={0}
+  const_1 = f32[] constant(-3e-3)
+  const_2 = f32[] constant(3e-2)
+  broadcast_1 = f32[3,57]{1,0} broadcast(const_1), dimensions={}
+  broadcast_2 = f32[3,57]{1,0} broadcast(const_2), dimensions={}
+  tmp_22 = f32[3,57]{1,0} clamp(broadcast_1, tmp_21, broadcast_2)
+  ROOT tmp_23 = f32[32,57]{0,1} dot(tmp_8, tmp_22), lhs_contracting_dims={0}, rhs_contracting_dims={0}
 }
 
 ENTRY e {
@@ -4493,7 +4498,12 @@ fused_computation {
   param_0.1 = f32[3,57]{1,0} parameter(0)
   multiply.3 = f32[3,57]{1,0} multiply(select.2, param_0.1)
   negate.1 = f32[3,57]{1,0} negate(multiply.3)
-  ROOT add.2 = f32[3,57]{1,0} add(add.3, negate.1)
+  add.2 = f32[3,57]{1,0} add(add.3, negate.1)
+  const.1 = f32[] constant(-3e-3)
+  const.2 = f32[] constant(3e-2)
+  broadcast.1 = f32[3,57]{1,0} broadcast(const.1), dimensions={}
+  broadcast.2 = f32[3,57]{1,0} broadcast(const.2), dimensions={}
+  ROOT clamp = f32[3,57]{1,0} clamp(broadcast.1, add.2, broadcast.2)
 }
 
 fused_computation.1 {

--- a/xla/service/gpu/triton_support.cc
+++ b/xla/service/gpu/triton_support.cc
@@ -123,7 +123,7 @@ std::vector<HloOpcode> TritonSupportedBinaryElementwise(
 
 std::vector<HloOpcode> TritonSupportedTernaryElementwise(
     PrimitiveType element_type) {
-  return {HloOpcode::kSelect};
+  return {HloOpcode::kSelect, HloOpcode::kClamp};
 }
 
 bool IsTritonSupportedElementwise(HloOpcode opcode,


### PR DESCRIPTION
Add Triton support for XLA clamp instruction. Clamp is a common instruction found in FP8 fusions, and will be used in cuDNN fusions: 

This is a fix for perviously rolled-back PR due to internal ir_emitter_triton test failure: https://github.com/openxla/xla/commit/d114eceb0afa4289e1ba4468a0474d2c1ffe4123

cc @sergeykozub @sergachev 