### PR TITLE
FP8 Windowed Einsums

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -5985,6 +5985,7 @@ cc_library(
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/utils:hlo_query",
+        "//xla/service:hlo_creation_utils",
         "//xla/service:hlo_pass",
         "//xla/service:pattern_matcher",
         "@com_google_absl//absl/algorithm:container",

--- a/xla/service/gpu/gpu_windowed_einsum_handler.cc
+++ b/xla/service/gpu/gpu_windowed_einsum_handler.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/hlo_creation_utils.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
@@ -39,6 +40,222 @@ namespace xla::gpu {
 namespace {
 
 namespace m = match;
+
+// Enables the creation of FP8 GEMM Custom Calls for all-gather and
+// reduce-scatter windowed einsums in gemm_rewriter.cc by moving the scalings
+// and type conversions of FP8 operands into the bodies of their while loops,
+// i.e. rewrites
+//
+//   inputs --> dequant --> while loop {dynamic-slice/collective-permute/dot}
+//
+// into
+//
+//   inputs --> while loop {dequant --> dynamic-slice/collective-permute/dot}.
+absl::Status ShiftDequantizationF8(const HloComputation* comp,
+                                   const std::array<HloInstruction*, 2>& gte) {
+  HloInstruction* while_instr = comp->WhileCallInstruction();
+  if (!while_instr) {
+    return absl::OkStatus();
+  }
+
+  // Identify the scalings and type conversions applied to the inputs of the
+  // while loop.
+  HloInstruction* param_tuple = while_instr->mutable_operand(0);
+  std::array<HloInstruction*, 2> binaries, operands, scales;
+  for (int k = 0; k < 2; ++k) {
+    if (!Match(param_tuple->mutable_operand(k),
+               m::AnyOf<HloInstruction>(
+                   m::Divide(&binaries[k], m::Convert(m::Op(&operands[k])),
+                             m::Broadcast(m::Op(&scales[k]))),
+                   m::MultiplyAnyOrder(&binaries[k],
+                                       m::Convert(m::Op(&operands[k])),
+                                       m::Broadcast(m::Op(&scales[k])))))) {
+      VLOG(5) << "Unable to identify FP8 dequantization pattern.";
+      return absl::OkStatus();
+    }
+  }
+
+  // For the dot to be rewritten by gemm_rewriter.cc into an FP8 GEMM, at most
+  // one of the inputs can be F8E5M2.
+  std::array<PrimitiveType, 2> operand_types{
+      operands[0]->shape().element_type(), operands[1]->shape().element_type()};
+  if (!((operand_types[0] == F8E4M3FN && operand_types[1] == F8E4M3FN) ||
+        (operand_types[0] == F8E4M3FN && operand_types[1] == F8E5M2) ||
+        (operand_types[0] == F8E5M2 && operand_types[1] == F8E4M3FN))) {
+    VLOG(5) << "Unsupported types.";
+    return absl::OkStatus();
+  }
+
+  // The dequantized types must be BF16, FP16 or FP32.
+  for (int k = 0; k < 2; ++k) {
+    if (binaries[k]->shape().element_type() != BF16 &&
+        binaries[k]->shape().element_type() != F16 &&
+        binaries[k]->shape().element_type() != F32) {
+      VLOG(5) << "Unsupported types.";
+      return absl::OkStatus();
+    }
+  }
+
+  // The FP8 scaling operands must be scalars.
+  if (!ShapeUtil::IsScalar(scales[0]->shape()) ||
+      !ShapeUtil::IsScalar(scales[1]->shape())) {
+    VLOG(5) << "Scaling factors must be scalars.";
+    return absl::OkStatus();
+  }
+
+  // Identify the dot and collective-permute or dynamic-slice instructions in
+  // the all-gather or reduce-scatter patterns in while's body.
+  HloComputation* while_body = while_instr->while_body();
+  HloComputation* while_condition = while_instr->while_condition();
+  HloInstruction* while_root = while_body->root_instruction();
+  std::array<HloInstruction*, 2> dots, dyn_slices{nullptr, nullptr},
+      coll_perms{nullptr, nullptr};
+  if (Match(
+          while_root,
+          m::Tuple(m::CollectivePermute(
+                       &coll_perms[1], m::CollectivePermute(
+                                           &coll_perms[0], m::Op().Is(gte[0]))),
+                   m::Op().Is(gte[1]),
+                   m::DynamicUpdateSlice(
+                       m::DynamicUpdateSlice().WithOperand(
+                           1, m::Dot(&dots[0], m::Op().Is(gte[0]),
+                                     m::Op().Is(gte[1]))),
+                       m::Dot(&dots[1], m::Op(), m::Op().Is(gte[1])), m::Op(),
+                       m::Op(), m::Op()),
+                   m::Op(), m::Op()))) {
+    VLOG(5) << "Identified all-gather windowed einsum pattern.";
+  } else if (Match(
+                 while_root,
+                 m::Tuple(m::Op().Is(gte[0]), m::Op().Is(gte[1]),
+                          m::AddAnyOrder(
+                              m::Dot(&dots[0], m::DynamicSlice(&dyn_slices[0]),
+                                     m::Op().Is(gte[1])),
+                              m::Op()),
+                          m::CollectivePermute(m::AddAnyOrder(
+                              m::Dot(&dots[1], m::DynamicSlice(&dyn_slices[1]),
+                                     m::Op().Is(gte[1])),
+                              m::Op())),
+                          m::Op()))) {
+    VLOG(5) << "Identified reduce-scatter windowed einsum pattern.";
+  } else {
+    VLOG(5) << "Unable to identify valid windowed einsum pattern.";
+    return absl::OkStatus();
+  }
+
+  // Replace the dequantized dot operands in the parameter tuple used by while
+  // with FP8 operands.
+  for (int k = 0; k < 2; ++k) {
+    TF_RETURN_IF_ERROR(
+        param_tuple->ReplaceOperandWithDifferentShape(k, operands[k]));
+    ShapeUtil::UpdateTupleShape(operands[k]->shape(), k,
+                                param_tuple->mutable_shape());
+    param_tuple->AppendOperand(scales[k]);
+    ShapeUtil::AppendShapeToTuple(scales[k]->shape(),
+                                  param_tuple->mutable_shape());
+  }
+
+  // Update the parameter tuples of while's body and condition computations.
+  for (HloComputation* while_comp : {while_body, while_condition}) {
+    while_comp->ReplaceParameter(
+        0, HloInstruction::CreateParameter(
+               0, param_tuple->shape(),
+               while_comp->parameter_instruction(0)->name()));
+  }
+
+  // In the while body, replace the existing get-tuple-element instructions
+  // retrieving BF16/FP16/FP32 dot operands with dequantized get-tuple-element
+  // instructions retrieving FP8 dot operands from the input tuple.
+  HloInstruction* body_param = while_body->parameter_instruction(0);
+  for (int k = 0; k < 2; ++k) {
+    TF_ASSIGN_OR_RETURN(HloInstruction * operand_f8,
+                        MakeGetTupleElementHlo(body_param, k));
+
+    if (while_root->operand(k) == gte[k]) {
+      TF_RETURN_IF_ERROR(
+          while_root->ReplaceOperandWithDifferentShape(k, operand_f8));
+      ShapeUtil::UpdateTupleShape(operand_f8->shape(), k,
+                                  while_root->mutable_shape());
+    }
+
+    TF_ASSIGN_OR_RETURN(
+        HloInstruction * operand_scale,
+        MakeGetTupleElementHlo(
+            body_param, body_param->shape().tuple_shapes_size() - 2 + k));
+
+    // Also add the scaling factor to the output tuple of the while body.
+    while_root->AppendOperand(operand_scale);
+    ShapeUtil::AppendShapeToTuple(operand_scale->shape(),
+                                  while_root->mutable_shape());
+
+    // Dequantize the operands of the dots and dynamic-slices.
+    HloInstruction* operand_f32 =
+        MakeConvertToHlo(operand_f8, gte[k]->shape().element_type());
+    HloInstruction* broadcast_scale =
+        MakeBroadcastHlo(operand_scale, {}, operand_f32->shape());
+    TF_ASSIGN_OR_RETURN(
+        HloInstruction * operand_scaled,
+        MakeBinaryHlo(binaries[k]->opcode(), operand_f32, broadcast_scale));
+
+    // Replace the original get-tuple-element instructions accessing the
+    // operands of the dots and dynamic-slices with the dequantized FP8
+    // operands. The order of dequantization and dynamic-slices will be
+    // exchanged in gemm_rewriter.cc.
+    for (int l = 0; l < 2; ++l) {
+      if (dots[l]->operand(k) == gte[k]) {
+        TF_RETURN_IF_ERROR(dots[l]->ReplaceOperandWith(k, operand_scaled));
+      }
+      if (dyn_slices[l] && dyn_slices[l]->operand(0) == gte[k]) {
+        TF_RETURN_IF_ERROR(
+            dyn_slices[l]->ReplaceOperandWith(0, operand_scaled));
+      }
+    }
+
+    // In the all-gather case, coll_perms[0] has two users, coll_perms[1] and
+    // dots[1], which prevents it from being exchanged with dequantization in
+    // gemm_rewriter.cc. Instead, directly insert the dequantization before
+    // dots[1] here.
+    if (coll_perms[0] && coll_perms[0]->operand(0) == gte[k]) {
+      std::array<HloInstruction*, 2> coll_perms_f8{nullptr, nullptr};
+      // Change the type of both collective-permutes to FP8.
+      coll_perms_f8[0] =
+          while_body->AddInstruction(coll_perms[0]->CloneWithNewOperands(
+              operand_f8->shape(), {operand_f8}));
+      coll_perms_f8[1] =
+          while_body->AddInstruction(coll_perms[1]->CloneWithNewOperands(
+              coll_perms_f8[0]->shape(), {coll_perms_f8[0]}));
+
+      // Insert the dequantization between coll_perms[0] and dots[1].
+      HloInstruction* coll_perm0_f32 =
+          MakeConvertToHlo(coll_perms_f8[0], gte[k]->shape().element_type());
+      TF_ASSIGN_OR_RETURN(HloInstruction * x_scaled,
+                          MakeBinaryHlo(binaries[k]->opcode(), coll_perm0_f32,
+                                        broadcast_scale));
+      TF_RETURN_IF_ERROR(dots[1]->ReplaceOperandWith(0, x_scaled));
+
+      // Update the output tuple.
+      TF_RETURN_IF_ERROR(
+          while_root->ReplaceOperandWithDifferentShape(0, coll_perms_f8[1]));
+      ShapeUtil::UpdateTupleShape(coll_perms_f8[1]->shape(), 0,
+                                  while_root->mutable_shape());
+    }
+  }
+
+  // Update the shape of the while call in the parent computation.
+  TF_RETURN_IF_ERROR(
+      while_instr->ReplaceAllUsesWithDifferentShape(while_instr->AddInstruction(
+          while_instr->CloneWithNewShape(while_root->shape()))));
+  TF_RETURN_IF_ERROR(while_instr->parent()->RemoveInstruction(while_instr));
+
+  if (coll_perms[0]) {
+    TF_RETURN_IF_ERROR(while_body->RemoveInstruction(coll_perms[1]));
+    TF_RETURN_IF_ERROR(while_body->RemoveInstruction(coll_perms[0]));
+  }
+  TF_RETURN_IF_ERROR(while_body->RemoveInstruction(gte[0]));
+  TF_RETURN_IF_ERROR(while_body->RemoveInstruction(gte[1]));
+
+  VLOG(5) << "FP8 dequantization moved into while loop.";
+  return absl::OkStatus();
+}
 
 int64_t NumberOfInstructionsInComp(const HloComputation* comp, HloOpcode op) {
   int64_t total_count = 0;
@@ -85,10 +302,19 @@ absl::StatusOr<bool> HandleRsWindowedEinsumLoop(HloComputation* comp,
   }
   for (auto inst : comp->MakeInstructionPostOrder()) {
     HloInstruction* matched_dot;
+    std::array<HloInstruction*, 2> gte;
     // The dot we'd like to parallelize is consuming the second loop input
     // as RHS.
-    if (Match(inst, m::Dot(&matched_dot, m::DynamicSlice(),
-                           m::GetTupleElement(m::Parameter(), 1)))) {
+    if (Match(inst,
+              m::Dot(&matched_dot,
+                     m::DynamicSlice().WithOperand(
+                         0, m::GetTupleElement(&gte[0], m::Parameter(), 0)),
+                     m::GetTupleElement(&gte[1], m::Parameter(), 1)))) {
+      // If present, move the dequantization of FP8 operands of the dot into the
+      // while loop to allow gemm_rewriter.cc to rewrite into an FP8 Custom
+      // Call.
+      TF_RETURN_IF_ERROR(ShiftDequantizationF8(comp, gte));
+
       // Dispatch the dot to additional compute stream.
       TF_RETURN_IF_ERROR(UpdateDotAndConsumerConfig(matched_dot, stream_id));
       ++stream_id;
@@ -119,10 +345,17 @@ absl::StatusOr<bool> HandleAgWindowedEinsumLoop(HloComputation* comp,
   }
   for (auto inst : comp->MakeInstructionPostOrder()) {
     HloInstruction* matched_dot;
+    std::array<HloInstruction*, 2> gte;
     // The dot we'd like to parallelize is consuming the second loop input
     // as RHS and first loop input as LHS.
-    if (Match(inst, m::Dot(&matched_dot, m::GetTupleElement(m::Parameter(), 0),
-                           m::GetTupleElement(m::Parameter(), 1)))) {
+    if (Match(inst, m::Dot(&matched_dot,
+                           m::GetTupleElement(&gte[0], m::Parameter(), 0),
+                           m::GetTupleElement(&gte[1], m::Parameter(), 1)))) {
+      // If present, move the dequantization of FP8 operands of the dot into the
+      // while loop to allow gemm_rewriter.cc to rewrite into an FP8 Custom
+      // Call.
+      TF_RETURN_IF_ERROR(ShiftDequantizationF8(comp, gte));
+
       // Dispatch the dot to additional compute stream.
       TF_RETURN_IF_ERROR(UpdateDotAndConsumerConfig(matched_dot, stream_id));
       ++stream_id;

--- a/xla/tests/collective_ops_test_e2e.cc
+++ b/xla/tests/collective_ops_test_e2e.cc
@@ -647,7 +647,75 @@ TEST_F(CollectiveOpsTestE2E, NoAllToAllDecomposition) {
   LiteralTestUtil::ExpectR1Equal<uint32_t>({20, 25, 21, 26}, results[1]);
 }
 
-TEST_F(CollectiveOpsTestE2E, WindowedEinsumE2EAllgatherMultiConsumer) {
+// E2E tests comparing the results of windowed einsum and non-windowed cases.
+class CollectiveOpsTestE2EWindowedNonWindowed : public CollectiveOpsTestE2E {
+ public:
+  void CollectiveOpsCompareWindowedNonWindowed(absl::string_view hlo_text) {
+    const int64_t kNumReplicas = 1;
+    const int64_t kNumPartitions = 4;
+
+    HloModuleConfig config =
+        GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+    auto opts = GetDebugOptionsForTest();
+    opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
+    opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+    opts.set_xla_gpu_graph_min_graph_size(200);
+    opts.set_xla_gpu_enable_triton_gemm(false);
+    config.set_debug_options(opts);
+    config.set_num_partitions(kNumPartitions);
+    TF_ASSERT_OK_AND_ASSIGN(auto module,
+                            ParseAndReturnVerifiedModule(hlo_text, config));
+    DeviceAssignment assn(/*replica_count=*/kNumReplicas,
+                          /*computation_count=*/kNumPartitions);
+    config.set_replica_count(kNumReplicas);
+    for (int64_t i = 0; i < kNumPartitions; ++i) {
+      assn(0, i) = i;
+    }
+
+    auto fake_arguments = xla::MakeFakeArguments(module.get()).value();
+    std::vector<Literal*> fake_ptrs(fake_arguments.size());
+    for (int i = 0; i < fake_arguments.size(); i++) {
+      fake_ptrs[i] = &fake_arguments[i];
+    }
+
+    TF_ASSERT_OK_AND_ASSIGN(
+        std::vector<Literal> results,
+        HloTestBase::ExecuteReplicated(
+            std::move(module), fake_ptrs, kNumPartitions, &assn,
+            true /*run_hlo_passes*/, true /*use-threads*/));
+    ASSERT_EQ(results.size(), kNumPartitions);
+    HloModuleConfig ref_config =
+        GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+    auto ref_opts = GetDebugOptionsForTest();
+    ref_opts.set_xla_gpu_graph_min_graph_size(200);
+    ref_opts.set_xla_gpu_enable_triton_gemm(false);
+    ref_config.set_debug_options(ref_opts);
+    ref_config.set_num_partitions(kNumPartitions);
+    TF_ASSERT_OK_AND_ASSIGN(auto ref_module,
+                            ParseAndReturnVerifiedModule(hlo_text, ref_config));
+    auto fake_ref_arguments = xla::MakeFakeArguments(ref_module.get()).value();
+    std::vector<Literal*> ref_fake_ptrs(fake_ref_arguments.size());
+    for (int i = 0; i < fake_ref_arguments.size(); i++) {
+      ref_fake_ptrs[i] = &fake_ref_arguments[i];
+    }
+
+    TF_ASSERT_OK_AND_ASSIGN(
+        std::vector<Literal> ref_results,
+        HloTestBase::ExecuteReplicated(
+            std::move(ref_module), ref_fake_ptrs, kNumPartitions, &assn,
+            true /*run_hlo_passes*/, true /*use-threads*/));
+    ASSERT_EQ(ref_results.size(), kNumPartitions);
+    ErrorSpec error_spec{1e-2, 1e-2};
+    // Results should be the same between windowed einsum and non-windowed cases
+    for (int i = 0; i < kNumPartitions; i++) {
+      EXPECT_TRUE(
+          LiteralTestUtil::Near(ref_results[i], results[i], error_spec));
+    }
+  }
+};
+
+TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
+       WindowedEinsumE2EAllgatherMultiConsumer) {
   absl::string_view kModuleReplicatedStr = R"(
 HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(bf16[2,16,48]{2,1,0}, bf16[48,192]{1,0}, bf16[48,192]{1,0}, bf16[192,48]{1,0})->bf16[2,16,48]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
 
@@ -666,66 +734,52 @@ ENTRY main.12 {
 } // main.12
 )";
 
-  const int64_t kNumReplicas = 1;
-  const int64_t kNumPartitions = 4;
+  CollectiveOpsCompareWindowedNonWindowed(kModuleReplicatedStr);
+}
 
-  HloModuleConfig config =
-      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
-  auto opts = GetDebugOptionsForTest();
-  opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
-  opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
-  opts.set_xla_gpu_graph_min_graph_size(200);
-  opts.set_xla_gpu_enable_triton_gemm(false);
-  config.set_debug_options(opts);
-  config.set_num_partitions(kNumPartitions);
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto module, ParseAndReturnVerifiedModule(kModuleReplicatedStr, config));
-  DeviceAssignment assn(/*replica_count=*/kNumReplicas,
-                        /*computation_count=*/kNumPartitions);
-  config.set_replica_count(kNumReplicas);
-  for (int64_t i = 0; i < kNumPartitions; ++i) {
-    assn(0, i) = i;
-  }
+TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
+       WindowedEinsumE2EAllGatherAndReduceScatterF8) {
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(f8e4m3fn[2,16,48]{2,1,0}, f8e4m3fn[48,192]{1,0}, f8e4m3fn[192,48]{1,0}, bf16[], bf16[], bf16[], bf16[], bf16[])->bf16[2,16,48]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
 
-  auto fake_arguments = xla::MakeFakeArguments(module.get()).value();
-  std::vector<Literal*> fake_ptrs(fake_arguments.size());
-  for (int i = 0; i < fake_arguments.size(); i++) {
-    fake_ptrs[i] = &fake_arguments[i];
-  }
+ENTRY main.12 {
+  Arg_0.1 = f8e4m3fn[2,16,48]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  Arg_1.2 = f8e4m3fn[48,192]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  Arg_2.3 = bf16[] parameter(3)
+  Arg_3.4 = bf16[] parameter(4)
+  broadcast = bf16[2,16,48]{2,1,0} broadcast(Arg_2.3), dimensions={}
+  broadcast.1 = bf16[48,192]{1,0} broadcast(Arg_3.4), dimensions={}
+  convert = bf16[2,16,48]{2,1,0} convert(Arg_0.1)
+  convert.1 = bf16[48,192]{1,0} convert(Arg_1.2)
+  multiply = bf16[2,16,48]{2,1,0} multiply(broadcast, convert)
+  multiply.1 = bf16[48,192]{1,0} multiply(broadcast.1, convert.1)
+  dot.5 = bf16[2,16,192]{2,1,0} dot(multiply, multiply.1), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  custom-call.7 = bf16[2,16,192]{2,1,0} custom-call(dot.5), custom_call_target="Sharding", sharding={devices=[1,1,4]<=[4]}
+  Arg_4.5 = bf16[] parameter(5)
+  broadcast.2 = bf16[2,16,192]{2,1,0} broadcast(Arg_4.5), dimensions={}
+  divide = bf16[2,16,192]{2,1,0} divide(custom-call.7, broadcast.2)
+  constant = bf16[] constant(-448.)
+  broadcast.3 = bf16[2,16,192]{2,1,0} broadcast(constant), dimensions={}
+  constant.1 = bf16[] constant(448.)
+  broadcast.4 = bf16[2,16,192]{2,1,0} broadcast(constant.1), dimensions={}
+  clamp = bf16[2,16,192]{2,1,0} clamp(broadcast.3, divide, broadcast.4)
+  convert.2 = f8e4m3fn[2,16,192]{2,1,0} convert(clamp)
+  Arg_5.6 = bf16[] parameter(6)
+  broadcast.5 = bf16[2,16,192]{2,1,0} broadcast(Arg_5.6), dimensions={}
+  convert.3 = bf16[2,16,192]{2,1,0} convert(convert.2)
+  multiply.2 = bf16[2,16,192]{2,1,0} multiply(convert.3, broadcast.5)
+  Arg_6.7 = f8e4m3fn[192,48]{1,0} parameter(2), sharding={devices=[4,1]<=[4]}
+  Arg_7.8 = bf16[] parameter(7)
+  broadcast.6 = bf16[192,48]{1,0} broadcast(Arg_7.8), dimensions={}
+  convert.4 = bf16[192,48]{1,0} convert(Arg_6.7)
+  multiply.3 = bf16[192,48]{1,0} multiply(convert.4, broadcast.6)
+  dot.6 = bf16[2,16,48]{2,1,0} dot(multiply.2, multiply.3), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  tuple.10 = (bf16[2,16,48]{2,1,0}) tuple(dot.6)
+  ROOT get-tuple-element.11 = bf16[2,16,48]{2,1,0} get-tuple-element(tuple.10), index=0, sharding={devices=[1,4,1]<=[4]}
+} // main.12
+)";
 
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::vector<Literal> results,
-      HloTestBase::ExecuteReplicated(
-          std::move(module), fake_ptrs, kNumPartitions, &assn,
-          true /*run_hlo_passes*/, true /*use-threads*/));
-  ASSERT_EQ(results.size(), kNumPartitions);
-  HloModuleConfig ref_config =
-      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
-  auto ref_opts = GetDebugOptionsForTest();
-  ref_opts.set_xla_gpu_graph_min_graph_size(200);
-  ref_opts.set_xla_gpu_enable_triton_gemm(false);
-  ref_config.set_debug_options(ref_opts);
-  ref_config.set_num_partitions(kNumPartitions);
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto ref_module,
-      ParseAndReturnVerifiedModule(kModuleReplicatedStr, ref_config));
-  auto fake_ref_arguments = xla::MakeFakeArguments(ref_module.get()).value();
-  std::vector<Literal*> ref_fake_ptrs(fake_ref_arguments.size());
-  for (int i = 0; i < fake_ref_arguments.size(); i++) {
-    ref_fake_ptrs[i] = &fake_ref_arguments[i];
-  }
-
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::vector<Literal> ref_results,
-      HloTestBase::ExecuteReplicated(
-          std::move(ref_module), ref_fake_ptrs, kNumPartitions, &assn,
-          true /*run_hlo_passes*/, true /*use-threads*/));
-  ASSERT_EQ(ref_results.size(), kNumPartitions);
-  ErrorSpec error_spec{1e-2, 1e-2};
-  // Results should be the same between windowed einsum and non-windowed cases
-  for (int i = 0; i < kNumPartitions; i++) {
-    EXPECT_TRUE(LiteralTestUtil::Near(ref_results[i], results[i], error_spec));
-  }
+  CollectiveOpsCompareWindowedNonWindowed(kModuleReplicatedStr);
 }
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
Extends the windowed einsum handler to support collective FP8 GEMMs by shifting the dequantization of dot operands into the body of the while loops of all-gather and reduce-scatter windowed einsums.