### PR TITLE
[NVIDIA] Disable the bias reuse for fp8 dot

### DIFF
--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -1377,8 +1377,9 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
     // The F8ConvertD may change the output dtype. We need to turn off the
     // output to operand aliasing when it happens.
-    const auto& maybe_bias = existing_gemm->operand(2);
-    if (!ShapeUtil::Equal(maybe_bias->shape(), new_gemm->shape())) {
+    if (gemm_backend_config.beta() != 0.0 &&
+        !ShapeUtil::Equal(existing_gemm->operand(2)->shape(),
+                          new_gemm->shape())) {
       xla::Cast<HloCustomCallInstruction>(new_gemm.get())
           ->set_output_to_operand_aliasing({});
     }

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -1526,7 +1526,8 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     // true if those uses all come before this operation.  But copy-insertion
     // runs before scheduling, so it can't know and has to conservatively insert
     // copies.)
-    if (IsLegacyCublasMatmul(*fused_op) || can_overwrite_bias) {
+    if (!IsCublasLtMatmulF8(*fused_op) &&
+        (IsLegacyCublasMatmul(*fused_op) || can_overwrite_bias)) {
       xla::Cast<HloCustomCallInstruction>(fused_op.get())
           ->set_output_to_operand_aliasing({{{}, {2, {}}}});
     }

--- a/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -4967,53 +4967,6 @@ TEST_P(ParameterizedFp8GemmRewriteTest, UnscaledABUnscaledDMatrixBiasF8) {
       )");
 }
 
-// Do not reuse matrix bias for fp8 matmul output.
-TEST_P(ParameterizedFp8GemmRewriteTest,
-       UnscaledABScaledDMatrixBiasNoAliasingF8) {
-#if GOOGLE_CUDA && CUDA_VERSION < 12000
-  GTEST_SKIP() << "F8 gemm rewrite is only supported in CUDA 12 and above.";
-#endif  // CUDA_VERSION < 12000
-
-#if TENSORFLOW_USE_ROCM && TF_ROCM_VERSION < 60000
-  GTEST_SKIP() << "F8 gemm rewrite is only supported in ROCm 6.0 and above.";
-#endif  // TF_ROCM_VERSION < 60000
-
-  const char* hlo_text = R"(
-    HloModule test
-
-    ENTRY test {
-      x = f8e4m3fn[16,32] parameter(0)
-      w = f8e4m3fn[32,64] parameter(1)
-      y = bf16[16,64] dot(x, w), lhs_contracting_dims={1}, rhs_contracting_dims={0}
-      b = bf16[16,64] parameter(2)
-      one = bf16[] constant(1)
-      ones = bf16[16,64] broadcast(one), dimensions={}
-      fake_b = bf16[16,64] add(b, ones)
-      bias_add = bf16[16,64] add(y, fake_b)
-      y_scale = bf16[] parameter(3)
-      y_scales = bf16[16,64] broadcast(y_scale), dimensions={}
-      y_scaled = bf16[16,64] divide(bias_add, y_scales)
-      lo = bf16[] constant(-448.)
-      los = bf16[16,64] broadcast(lo), dimensions={}
-      hi = bf16[] constant(448.)
-      his = bf16[16,64] broadcast(hi), dimensions={}
-      y_clamped = bf16[16,64] clamp(los, y_scaled, his)
-      ROOT y_f8 = <<F8E4M3>>[16,64] convert(y_clamped)
-    } // test
-)";
-
-  RunAndFilecheckHloRewrite(
-      hlo_text,
-      GemmRewriter(CudaHopperOrRocmMI300(), GetToolkitVersion(),
-                   /*f8_rewrite=*/true),
-      R"(
-; CHECK-LABEL: ENTRY %test ({{.*}}) -> <<F8E4M3>>[16,64] {
-; CHECK:           custom_call_target="__cublas$lt$matmul$f8",
-; CHECK-NOT:       output_to_operand_aliasing
-      )"
-  );
-}
-
 TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF8) {
 #if GOOGLE_CUDA && CUDA_VERSION < 12000
   GTEST_SKIP() << "F8 gemm rewrite is only supported in CUDA 12 and above.";
@@ -5868,7 +5821,7 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDMatrixBiasF8) {
       b = f32[16,16] parameter(2)
       one = f32[] constant(1)
       ones = f32[16,16] broadcast(one), dimensions={}
-      fake_b = f32[16,16] add(b, ones)
+      b_ones = f32[16,16] add(b, ones)
       x_f32 = f32[16,32] convert(x)
       y_f32 = f32[32,16] convert(y)
       x_scale = f32[] parameter(3)
@@ -5878,7 +5831,7 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDMatrixBiasF8) {
       x_unscaled = f32[16,32] multiply(x_f32, x_scale_bcast)
       y_unscaled = f32[32,16] multiply(y_f32, y_scale_bcast)
       dot_a = f32[16,16] dot(x_unscaled, y_unscaled), lhs_contracting_dims={1}, rhs_contracting_dims={0}
-      ROOT out = add(dot_a, fake_b)
+      ROOT out = add(dot_a, b_ones)
           }
 
 )";
@@ -6454,6 +6407,9 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABScaledDMatrixBiasF8) {
       x_f16 = f16[16,32] convert(x)
       y_f16 = f16[32,16] convert(y)
       b = f16[16,16] parameter(2)
+      one = f16[] constant(1)
+      ones = f16[16,16] broadcast(one), dimensions={}
+      b_ones = f16[16,16] add(b, ones)
       x_scale = f16[] parameter(3)
       y_scale = f16[] parameter(4)
       z_scale = f16[] parameter(5)
@@ -6463,7 +6419,7 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABScaledDMatrixBiasF8) {
       x_unscaled = f16[16,32] multiply(x_f16, x_scale_bcast)
       y_unscaled = f16[32,16] multiply(y_f16, y_scale_bcast)
       dot_a = f16[16,16] dot(x_unscaled, y_unscaled), lhs_contracting_dims={1}, rhs_contracting_dims={0}
-      dot_a_bias = f16[16,16] add(dot_a, b)
+      dot_a_bias = f16[16,16] add(dot_a, b_ones)
       dot_a_scaled = f16[16,16] divide(dot_a_bias, z_scale_bcast)
       c1 = f16[] constant(-<<F8E4M3_AMAX>>)
       c1_bcast = f16[16,16] broadcast(c1), dimensions={}
@@ -6486,12 +6442,13 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABScaledDMatrixBiasF8) {
 ; CHECK:    [[P0:%[^ ]+]] = <<F8E4M3>>[16,32]{1,0} parameter(0)
 ; CHECK-NEXT:    [[P1:%[^ ]+]] = <<F8E4M3>>[32,16]{1,0} parameter(1)
 ; CHECK-NEXT:    [[P1_TRANSPOSE:%[^ ]+]] = <<F8E4M3>>[16,32]{1,0} transpose([[P1]]), dimensions={1,0}
-; CHECK-NEXT:    [[C0:%[^ ]+]] = f16[16,16]{1,0} parameter(2)
+; CHECK:         [[C0:%[^ ]+]] = f16[16,16]{1,0} add({{.*}})
 ; CHECK-NEXT:    [[P2:%[^ ]+]] = f16[] parameter(3)
 ; CHECK:         [[P3:%[^ ]+]] = f16[] parameter(4)
 ; CHECK:         [[C1:%[^ ]+]] = f32[] constant(1)
 ; CHECK-PTX:         [[P4:%[^ ]+]] = f16[] parameter(5)
 ; CHECK-PTX:       [[OUT:%[^ ]+]] = (<<F8E4M3>>[16,16]{1,0}, s8[{{[0-9]+}}]{0}) custom-call([[P0]], [[P1_TRANSPOSE]], [[C0]], [[DUMMY0:%[^ ]+]], [[DUMMY1:%[^ ]+]], /*index=5*/[[C1]], [[DUMMY2:%[^ ]+]]),
+; CHECK-NOT:       output_to_operand_aliasing
 ; CHECK-GCN:       [[OUT:%[^ ]+]] = f16[16,16]{1,0} custom-call([[P0]], [[P1_TRANSPOSE]], [[C0]], [[DUMMY0:%[^ ]+]], [[DUMMY1:%[^ ]+]], /*index=5*/[[C1]], [[DUMMY2:%[^ ]+]]),
 ; CHECK:           custom_call_target="__cublas$lt$matmul$f8",
 ; CHECK:           backend_config={


### PR DESCRIPTION
For some operations, we might want to do the `output to operand aliasing` to reuse the memory space. For example, in the dot operation, we can alias the output to the bias operand, when they have the same shape.

However, this aliasing is not always safe especially when the dot outputs fp8 outputs. In this case the bias is 2x larger than expected output and the HLO verifier will complain.

This PR fixes this issue by disabling the `output to operand aliasing`  for fp8 dot.

cc. @philipphack @hx89 @nluehr 