### PR TITLE
[GPU] Shard GEMM fusion autotuning across multiple compilation processes.

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -259,6 +259,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   opts.set_xla_use_shardonnay(false);
 
+  opts.set_xla_gpu_shard_autotuning(false);
+
   return opts;
 }
 
@@ -1706,6 +1708,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "xla_use_shardonnay",
       bool_setter_for(&DebugOptions::set_xla_use_shardonnay),
       debug_options->xla_use_shardonnay(), "Whether to use Shardonnay."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_shard_autotuning",
+      bool_setter_for(&DebugOptions::set_xla_gpu_shard_autotuning),
+      debug_options->xla_gpu_shard_autotuning(),
+      "Shard autotuning between participating compiler processes (typically in "
+      "multi-host setups) and join the results when it's done."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/pjrt/distributed/key_value_store_interface.h
+++ b/xla/pjrt/distributed/key_value_store_interface.h
@@ -45,6 +45,12 @@ class KeyValueStoreInterface {
   virtual absl::Status Set(std::string_view key, std::string_view value) = 0;
 };
 
+struct MultiProcessKeyValueStore {
+  std::shared_ptr<KeyValueStoreInterface> key_value_store;
+  int process_index = 0;
+  int process_count = 1;
+};
+
 }  // namespace xla
 
 #endif  // XLA_PJRT_DISTRIBUTED_KEY_VALUE_STORE_INTERFACE_H_

--- a/xla/service/compiler.h
+++ b/xla/service/compiler.h
@@ -29,7 +29,6 @@ limitations under the License.
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/span.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_module_group.h"
@@ -162,9 +161,7 @@ class Compiler {
     // If non-null, it will be used to construct relevant MLIR contexts.
     mlir::DialectRegistry* registry = nullptr;
 
-    int process_index = 0;
-    int process_count = 1;
-    std::shared_ptr<KeyValueStoreInterface> key_value_store;
+    MultiProcessKeyValueStore key_value_store;
   };
 
   virtual ~Compiler() = default;

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -795,6 +795,7 @@ cc_library(
         "//xla:xla_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/utils:hlo_query",
+        "//xla/pjrt/distributed:key_value_store_interface",
         "//xla/service:algorithm_util",
         "//xla/service:dump",
         "//xla/service:executable",

--- a/xla/service/gpu/autotuner_util.cc
+++ b/xla/service/gpu/autotuner_util.cc
@@ -80,7 +80,7 @@ static void SortAutotuneResults(AutotuneResults* results) {
 }
 
 // Serialize `results` to string as a proto.
-static absl::StatusOr<std::string> AutotuneResultsToString(
+absl::StatusOr<std::string> AutotuneResultsToString(
     const AutotuneResults& results, bool as_textproto) {
   if (as_textproto) {
     std::string textproto;

--- a/xla/service/gpu/autotuner_util.h
+++ b/xla/service/gpu/autotuner_util.h
@@ -30,9 +30,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "xla/autotune_results.pb.h"
 #include "xla/autotuning.pb.h"
-#include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
-#include "xla/hlo/ir/hlo_module.h"
 #include "xla/shape.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/device_memory.h"
@@ -289,6 +287,9 @@ struct AutotunerUtil {
 
   static bool ResultCacheIsEmpty();
 };
+
+absl::StatusOr<std::string> AutotuneResultsToString(
+    const AutotuneResults& results, bool as_textproto);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/gemm_fusion_autotuner.cc
@@ -1117,6 +1117,47 @@ absl::Status GemmFusionAutotunerImpl::Autotune(
   return absl::OkStatus();
 }
 
+// Trim the set of configs to what one rank has to run.
+static TilingConfigs TrimConfigs(const TilingConfigs& gemm_config_sets,
+                                 const int shard_index, const int shard_count) {
+  const uint64_t bucket_size =
+      (gemm_config_sets.size() + shard_count - 1) / shard_count;
+  const uint64_t start = bucket_size * shard_index;
+  const uint64_t end = std::min(start + bucket_size, gemm_config_sets.size());
+  if (start >= end) {
+    return {};
+  }
+  return TilingConfigs(gemm_config_sets.cbegin() + start,
+                       gemm_config_sets.cbegin() + end);
+}
+
+// Exchange the results with the other ranks.
+absl::Status ExchangeResults(KeyValueStoreInterface& key_value_store,
+                             const int module_id, const int shard_index,
+                             const int shard_count) {
+  AutotuneResults results;
+  TF_RETURN_IF_ERROR(AutotunerUtil::SerializeAutotuneResults(&results));
+  TF_ASSIGN_OR_RETURN(std::string results_str,
+                      AutotuneResultsToString(results, true));
+  constexpr absl::string_view kKeyPrefix = "gemm_fusion_autotuning_results";
+  TF_RETURN_IF_ERROR(key_value_store.Set(
+      absl::StrFormat("%s_%d_%d", kKeyPrefix, module_id, shard_index),
+      results_str));
+  for (int i = 0; i < shard_count; ++i) {
+    if (i == shard_index) {
+      continue;
+    }
+    TF_ASSIGN_OR_RETURN(
+        std::string autotune_results_str,
+        key_value_store.Get(
+            absl::StrFormat("%s_%d_%d", kKeyPrefix, module_id, i),
+            absl::InfiniteDuration()));
+    TF_RETURN_IF_ERROR(
+        AutotunerUtil::LoadAutotuneResults(autotune_results_str, true));
+  }
+  return absl::OkStatus();
+}
+
 absl::StatusOr<bool> GemmFusionAutotuner::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
@@ -1129,6 +1170,7 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
   TF_ASSIGN_OR_RETURN(TilingConfigs gemm_config_sets,
                       gemm_config_set_collector.CollectGemmConfigSets(
                           module, execution_threads));
+  const int total_fusion_count = gemm_config_sets.size();
 
   AutoTuneCacheKeyCount fusion_count_map =
       gemm_config_set_collector.GetFusionsCount();
@@ -1165,11 +1207,33 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
                                             ? "(with correctness check)"
                                             : "(without correctness check)";
 
-    VLOG(1) << "Autotuning " << gemm_config_sets.size() << " fusions "
-            << correctness_check_str << ".";
+    const bool shard_autotuning = debug_options.xla_gpu_shard_autotuning() &&
+                                  key_value_store_.process_count > 1 &&
+                                  total_fusion_count > 0;
+    if (shard_autotuning) {
+      if (key_value_store_.key_value_store == nullptr) {
+        return absl::FailedPreconditionError(
+            "Sharded autotuning requested but key-value store is missing.");
+      }
+      gemm_config_sets =
+          TrimConfigs(gemm_config_sets, key_value_store_.process_index,
+                      key_value_store_.process_count);
+    }
+
+    VLOG(1) << absl::StrFormat(
+        "Shard %d / %d: autotuning %d / %d fusions for %s %s.",
+        key_value_store_.process_index + 1, key_value_store_.process_count,
+        gemm_config_sets.size(), total_fusion_count, module->name(),
+        correctness_check_str);
     TF_RETURN_IF_ERROR(autotuner.Autotune(*opt_compile_util, gemm_config_sets,
                                           std::move(fusion_count_map)));
     VLOG(1) << "Done autotuning.";
+
+    if (shard_autotuning) {
+      TF_RETURN_IF_ERROR(ExchangeResults(
+          *key_value_store_.key_value_store, module->unique_id(),
+          key_value_store_.process_index, key_value_store_.process_count));
+    }
   }
 
   return GemmFusionAutotunerVisitor(config_).RunOnModule(module,

--- a/xla/service/gpu/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/gemm_fusion_autotuner.cc
@@ -1132,9 +1132,9 @@ static TilingConfigs TrimConfigs(const TilingConfigs& gemm_config_sets,
 }
 
 // Exchange the results with the other ranks.
-absl::Status ExchangeResults(KeyValueStoreInterface& key_value_store,
-                             const int module_id, const int shard_index,
-                             const int shard_count) {
+static absl::Status ExchangeResults(KeyValueStoreInterface& key_value_store,
+                                    const int module_id, const int shard_index,
+                                    const int shard_count) {
   AutotuneResults results;
   TF_RETURN_IF_ERROR(AutotunerUtil::SerializeAutotuneResults(&results));
   TF_ASSIGN_OR_RETURN(std::string results_str,

--- a/xla/service/gpu/gemm_fusion_autotuner.h
+++ b/xla/service/gpu/gemm_fusion_autotuner.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
+#include "xla/pjrt/distributed/key_value_store_interface.h"
 #include "xla/service/executable.h"
 #include "xla/service/gpu/autotuner_compile_util.h"
 #include "xla/service/gpu/autotuner_util.h"
@@ -49,10 +50,12 @@ class GemmFusionAutotuner : public HloModulePass {
  public:
   explicit GemmFusionAutotuner(const AutotuneConfig& config,
                                const int32_t toolkit_version,
-                               tsl::thread::ThreadPool* thread_pool)
+                               tsl::thread::ThreadPool* thread_pool,
+                               const MultiProcessKeyValueStore& key_value_store)
       : config_(config),
         toolkit_version_(toolkit_version),
-        thread_pool_(thread_pool) {}
+        thread_pool_(thread_pool),
+        key_value_store_(key_value_store) {}
 
   absl::string_view name() const override { return "triton-autotuner"; }
 
@@ -65,6 +68,7 @@ class GemmFusionAutotuner : public HloModulePass {
   const AutotuneConfig config_;
   const int32_t toolkit_version_;
   tsl::thread::ThreadPool* thread_pool_;
+  MultiProcessKeyValueStore key_value_store_;
 };
 
 // Autotuner implementation.

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -55,9 +55,9 @@ limitations under the License.
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/SplitModule.h"
-#include "mlir/IR/Diagnostics.h"  // from @llvm-project
+#include "mlir/IR/Diagnostics.h"      // from @llvm-project
 #include "mlir/IR/DialectRegistry.h"  // from @llvm-project
-#include "mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/Support/LLVM.h"        // from @llvm-project
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
@@ -297,10 +297,9 @@ absl::StatusOr<AutotuneConfig> GetAutotuneConfig(
     return AutotuneConfig{DeviceConfig{stream_exec, options.device_allocator},
                           debug_options};
   }
-  AutotuneConfig deviceless_config =
-      AutotuneConfig{DevicelessConfig{gpu_target_config.device_description_str},
-                     debug_options};
-  return deviceless_config;
+  return AutotuneConfig{
+      DevicelessConfig{gpu_target_config.device_description_str},
+      debug_options};
 }
 
 se::GpuComputeCapability GetGpuVersion(const se::StreamExecutor* stream_exec) {
@@ -1437,8 +1436,9 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   // f32).
   add_float_normalization(pipeline);
 
-  TF_RETURN_IF_ERROR(AddGemmFusionAutotuningPasses(
-      &pipeline, hlo_module, autotune_config, thread_pool));
+  TF_RETURN_IF_ERROR(AddGemmFusionAutotuningPasses(&pipeline, hlo_module,
+                                                   autotune_config, thread_pool,
+                                                   options.key_value_store));
   // Inline back the calls which have better performance with cuBLAS.
   pipeline.AddPass<CallInliner>();
   // TODO(tdanyluk): Apply CublasPadForGemms to the cuBLAS GEMMs generated

--- a/xla/service/gpu/gpu_compiler.h
+++ b/xla/service/gpu/gpu_compiler.h
@@ -154,7 +154,8 @@ class GpuCompiler : public LLVMCompiler {
   // Add autotuning passes for GEMM fusions.
   virtual absl::Status AddGemmFusionAutotuningPasses(
       HloPassPipeline* pipeline, HloModule* hlo_module,
-      AutotuneConfig& autotune_config, tsl::thread::ThreadPool* thread_pool) {
+      AutotuneConfig& autotune_config, tsl::thread::ThreadPool* thread_pool,
+      const MultiProcessKeyValueStore& key_value_store) {
     return absl::OkStatus();
   }
 

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -372,9 +372,10 @@ absl::Status NVPTXCompiler::AddConvAndGemmAutotuningPasses(
 
 absl::Status NVPTXCompiler::AddGemmFusionAutotuningPasses(
     HloPassPipeline* pipeline, HloModule* hlo_module,
-    AutotuneConfig& autotune_config, tsl::thread::ThreadPool* thread_pool) {
+    AutotuneConfig& autotune_config, tsl::thread::ThreadPool* thread_pool,
+    const MultiProcessKeyValueStore& key_value_store) {
   pipeline->AddPass<GemmFusionAutotuner>(autotune_config, GetToolkitVersion(),
-                                         thread_pool);
+                                         thread_pool, key_value_store);
   return absl::OkStatus();
 }
 

--- a/xla/service/gpu/nvptx_compiler.h
+++ b/xla/service/gpu/nvptx_compiler.h
@@ -74,8 +74,8 @@ class NVPTXCompiler : public GpuCompiler {
 
   absl::Status AddGemmFusionAutotuningPasses(
       HloPassPipeline* pipeline, HloModule* hlo_module,
-      AutotuneConfig& autotune_config,
-      tsl::thread::ThreadPool* thread_pool) override;
+      AutotuneConfig& autotune_config, tsl::thread::ThreadPool* thread_pool,
+      const MultiProcessKeyValueStore& key_value_store) override;
 
   absl::Status AddCustomKernelReplacementPasses(
       HloPassPipeline* pipeline, const DebugOptions& debug_options) override;

--- a/xla/service/local_service.cc
+++ b/xla/service/local_service.cc
@@ -94,9 +94,8 @@ LocalService::CompileExecutables(
       false,
       {},
       nullptr,
-      build_options.process_index(),
-      build_options.process_count(),
-      build_options.key_value_store()};
+      {build_options.key_value_store(), build_options.process_index(),
+       build_options.process_count()}};
   if (build_options.num_partitions() == 1) {
     TF_ASSIGN_OR_RETURN(
         std::unique_ptr<Executable> executable,

--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -172,6 +172,7 @@ xla_test(
         "data/sharded_2_devices.hlo",
         "data/single_device.hlo",
         "data/single_device_tupled.hlo",
+        "data/multiple_gemm_fusions.hlo"
     ],
     tags = ["nomac"],
     deps = [
@@ -179,8 +180,8 @@ xla_test(
         "//xla:statusor",
         "//xla/pjrt:pjrt_client",
         "//xla/tests:filecheck",
-        "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:blocking_counter",
         "@tsl//tsl/platform:env",
         "@tsl//tsl/platform:path",
         "@tsl//tsl/platform:statusor",

--- a/xla/tools/multihost_hlo_runner/data/multiple_gemm_fusions.hlo
+++ b/xla/tools/multihost_hlo_runner/data/multiple_gemm_fusions.hlo
@@ -1,0 +1,35 @@
+f1 {
+  p0 = f16[720,720,720]{2,1,0} parameter(0)
+  p1 = s8[720,720,720]{2,1,0} parameter(1)
+  c = f16[720,720,720]{2,1,0} convert(p1)
+  ROOT d1 = f16[720,720,720]{2,1,0} dot(p0, c),
+    lhs_batch_dims={0}, lhs_contracting_dims={2},
+    rhs_batch_dims={0}, rhs_contracting_dims={1}
+}
+
+f2 {
+  p0 = s8[720,720,720]{2,1,0} parameter(0)
+  c0 = f32[720,720,720]{2,1,0} convert(p0)
+  p1 = f16[720,720,720]{2,1,0} parameter(1)
+  c1 = f32[720,720,720]{2,1,0} convert(p1)
+  ROOT %dot.1 = f32[720,720,720]{2,1,0} dot(c0, c1),
+    lhs_batch_dims={0}, lhs_contracting_dims={2},
+    rhs_batch_dims={0}, rhs_contracting_dims={1}
+}
+
+fa {
+  p1 = f16[720,720,720]{2,1,0} parameter(1)
+  c = f32[720,720,720]{2,1,0} convert(p1)
+  p0 = f32[720,720,720]{2,1,0} parameter(0)
+  ROOT %add.1.1 = f32[720,720,720]{2,1,0} add(c, p0)
+}
+
+ENTRY e {
+  p1 = s8[720,720,720]{2,1,0} parameter(1)
+  p0 = f16[720,720,720]{2,1,0} parameter(0)
+  f1r = f16[720,720,720]{2,1,0} fusion(p0, p1), kind=kCustom, calls=f1,
+    backend_config={"fusion_backend_config":{"kind":"__triton_gemm"}}
+  f2r = f32[720,720,720]{2,1,0} fusion(p1, p0), kind=kCustom, calls=f2,
+    backend_config={"fusion_backend_config":{"kind":"__triton_gemm"}}
+  ROOT _ = f32[720,720,720]{2,1,0} fusion(f2r, f1r), kind=kLoop, calls=fa
+}

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
@@ -94,7 +94,7 @@ absl::StatusOr<std::unique_ptr<xla::PjRtClient>> GetPjRtClient(
     return xla::FunctionalHloRunner::CreateMockGpuClient(num_nodes);
   } else {
     if (num_nodes == 1) {
-      return xla::FunctionalHloRunner::CreateGpuClient();
+      return xla::FunctionalHloRunner::CreateGpuClient({});
     } else {
       CHECK_GT(address.length(), 0);
       // Multinode. Start service on task 0.
@@ -116,8 +116,8 @@ absl::StatusOr<std::unique_ptr<xla::PjRtClient>> GetPjRtClient(
       TF_QCHECK_OK(distributed_client->Connect());
       kv_store = GetDistributedKeyValueStore(distributed_client,
                                              /*key_prefix=*/"gpu:");
-      return xla::FunctionalHloRunner::CreateGpuClient(kv_store, node_id,
-                                                       num_nodes);
+      return xla::FunctionalHloRunner::CreateGpuClient(GpuClientOptions{
+          .node_id = node_id, .num_nodes = num_nodes, .kv_store = kv_store});
     }
   }
 }
@@ -330,8 +330,12 @@ FunctionalHloRunner::CreateHostClient() {
 }
 
 absl::StatusOr<std::unique_ptr<PjRtClient>>
-FunctionalHloRunner::CreateGpuClient() {
-  return GetStreamExecutorGpuClient(GpuClientOptions());
+FunctionalHloRunner::CreateGpuClient(GpuClientOptions options) {
+  if (options.node_id < 0 || options.node_id >= options.num_nodes) {
+    return absl::InvalidArgumentError(
+        "Node id is expected to be in range [0, num_nodes)");
+  }
+  return GetStreamExecutorGpuClient(options);
 }
 
 absl::StatusOr<std::unique_ptr<PjRtClient>>
@@ -339,24 +343,6 @@ FunctionalHloRunner::CreateMockGpuClient(int num_nodes) {
   GpuClientOptions options;
   options.num_nodes = num_nodes;
   options.enable_mock_nccl = true;
-  return GetStreamExecutorGpuClient(options);
-}
-
-absl::StatusOr<std::unique_ptr<PjRtClient>>
-FunctionalHloRunner::CreateGpuClient(
-    std::shared_ptr<xla::KeyValueStoreInterface> kv_store, int node_id,
-    int num_nodes) {
-  if (node_id < 0 || node_id >= num_nodes) {
-    return absl::InvalidArgumentError(
-        "Node id is expected to be in range [0, num_nodes)");
-  }
-
-  TF_RET_CHECK(kv_store != nullptr);
-
-  GpuClientOptions options;
-  options.node_id = node_id;
-  options.num_nodes = num_nodes;
-  options.kv_store = kv_store;
   return GetStreamExecutorGpuClient(options);
 }
 

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/literal.h"
 #include "xla/pjrt/distributed/distributed.h"
+#include "xla/pjrt/gpu/se_gpu_pjrt_client.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/pjrt/pjrt_executable.h"
 #include "xla/statusor.h"
@@ -223,19 +224,12 @@ class FunctionalHloRunner {
   static absl::StatusOr<std::unique_ptr<PjRtClient>> CreateHostClient();
 
   // Create a PjRtClient which can run HLOs on GPU.
-  static absl::StatusOr<std::unique_ptr<PjRtClient>> CreateGpuClient();
+  static absl::StatusOr<std::unique_ptr<PjRtClient>> CreateGpuClient(
+      GpuClientOptions options);
 
   // Create a PjRtClient which mocks multi-hosts GPU run
   static absl::StatusOr<std::unique_ptr<PjRtClient>> CreateMockGpuClient(
       int num_nodes = 1);
-
-  // Create a PjRtClient which can run HLOs on GPUs distributed across several
-  // nodes.
-  // The distributed client pointer passed as a parameter is expected to be
-  // non-null, and 0 <= node_id < num_nodes must hold.
-  static absl::StatusOr<std::unique_ptr<PjRtClient>> CreateGpuClient(
-      std::shared_ptr<xla::KeyValueStoreInterface> kv_store, int node_id,
-      int num_nodes);
 
   // Loads an ExecutionOptions proto (which can be used in RawCompileOptions).
   static absl::StatusOr<ExecutionOptions> LoadExecutionOptions(

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "tsl/platform/subprocess.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/statusor.h"
 #include "xla/tests/filecheck.h"
@@ -42,6 +43,11 @@ bool IsTestingCpu() {
   return false;
 }
 
+std::string GetHloPath(std::string file_name) {
+  return tsl::io::JoinPath(tsl::testing::XlaSrcRoot(), "tools",
+                           "multihost_hlo_runner", "data", file_name);
+}
+
 absl::StatusOr<std::unique_ptr<xla::PjRtClient>> GetPjRtClient() {
   if (IsTestingCpu()) {
     return xla::FunctionalHloRunner::CreateHostClient();
@@ -49,13 +55,7 @@ absl::StatusOr<std::unique_ptr<xla::PjRtClient>> GetPjRtClient() {
   return xla::FunctionalHloRunner::CreateGpuClient();
 }
 
-class FunctionalHloRunnerTest : public ::testing::Test {
- protected:
-  std::string GetHloPath(std::string file_name) {
-    return tsl::io::JoinPath(tsl::testing::XlaSrcRoot(), "tools",
-                             "multihost_hlo_runner", "data", file_name);
-  }
-};
+using FunctionalHloRunnerTest = ::testing::Test;
 
 TEST_F(FunctionalHloRunnerTest, SingleDeviceHlo) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::PjRtClient> client,
@@ -244,5 +244,88 @@ TEST_F(FunctionalHloRunnerTest, CanCompileWithoutHavingEnoughGpus) {
   }
 }
 
+// Name of the test binary.
+static const char* binary_name;
+constexpr int kNumNodes = 3;
+
+TEST_F(FunctionalHloRunnerTest, ShardedAutotuningWorks) {
+  if (IsTestingCpu()) {
+    GTEST_SKIP() << "GPU-only test.";
+  }
+
+  tsl::SubProcess child[kNumNodes];
+  for (int node_id = 0; node_id < kNumNodes; ++node_id) {
+    std::vector<std::string> argv;
+    argv.push_back(binary_name);
+    argv.push_back("--xla_gpu_shard_autotuning");
+    argv.push_back(absl::StrFormat("--node_id=%d", node_id));
+    child[node_id].SetProgram(binary_name, argv);
+    child[node_id].SetChannelAction(tsl::CHAN_STDOUT, tsl::ACTION_PIPE);
+    child[node_id].SetChannelAction(tsl::CHAN_STDERR, tsl::ACTION_PIPE);
+    ASSERT_TRUE(child[node_id].Start()) << "node " << node_id;
+  }
+  for (int node_id = 0; node_id < kNumNodes; ++node_id) {
+    std::string stdout_str;
+    std::string stderr_str;
+    int child_status =
+        child[node_id].Communicate(nullptr, &stdout_str, &stderr_str);
+    ASSERT_EQ(child_status, 0) << " node " << node_id << "\nstdout:\n"
+                               << stdout_str << "\nstderr:\n"
+                               << stderr_str;
+  }
+}
+
+absl::Status ShardedAutotuningWorksTestBody(const int node_id) {
+  tsl::setenv("CUDA_VISIBLE_DEVICES", std::to_string(node_id).data(),
+              /*overwrite=*/true);
+  std::unique_ptr<xla::DistributedRuntimeService> service = nullptr;
+  std::shared_ptr<xla::KeyValueStoreInterface> kv_store = nullptr;
+  TF_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtClient> client,
+                      GetPjRtClient("gpu", "127.0.0.1:12345", node_id,
+                                    kNumNodes, false, service, kv_store));
+  CHECK(kv_store != nullptr);
+  TF_RETURN_IF_ERROR(FunctionalHloRunner::LoadAndCompile(
+      *client, GetDebugOptionsFromFlags(),
+      FunctionalHloRunner::PreprocessingOptions{},
+      FunctionalHloRunner::RawCompileOptions{},
+      GetHloPath("multiple_gemm_fusions.hlo"), InputFormat::kText));
+  if (node_id == 0) {
+    TF_ASSIGN_OR_RETURN(
+        std::string results0,
+        kv_store->Get("gemm_fusion_autotuning_results_1_0", absl::Seconds(1)));
+    CHECK(absl::StrContains(results0, "run_time"));
+    TF_ASSIGN_OR_RETURN(
+        std::string results1,
+        kv_store->Get("gemm_fusion_autotuning_results_1_1", absl::Seconds(1)));
+    CHECK(absl::StrContains(results1, "run_time"));
+    // First two nodes autotune two different fusions.
+    CHECK_NE(results0, results1);
+    TF_ASSIGN_OR_RETURN(
+        std::string results2,
+        kv_store->Get("gemm_fusion_autotuning_results_1_2", absl::Seconds(1)));
+    // Third node has nothing to autotune.
+    CHECK(!absl::StrContains(results2, "run_time"));
+  }
+  return absl::OkStatus();
+}
+
 }  // namespace
 }  // namespace xla
+
+int main(int argc, char* argv[]) {
+  // Save name of binary so that it may invoke itself.
+  xla::binary_name = argv[0];
+  int node_id = -1;
+  std::vector<tsl::Flag> flag_list = {
+      tsl::Flag("node_id", &node_id,
+                "Node ID for ShardedAutotuningWorks test."),
+  };
+  xla::AppendDebugOptionsFlags(&flag_list);
+  std::string usage = tsl::Flags::Usage(argv[0], flag_list);
+  tsl::Flags::Parse(&argc, argv, flag_list);
+  if (node_id >= 0) {
+    return !xla::ShardedAutotuningWorksTestBody(node_id).ok();
+  }
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -52,7 +52,7 @@ absl::StatusOr<std::unique_ptr<xla::PjRtClient>> GetPjRtClient() {
   if (IsTestingCpu()) {
     return xla::FunctionalHloRunner::CreateHostClient();
   }
-  return xla::FunctionalHloRunner::CreateGpuClient();
+  return xla::FunctionalHloRunner::CreateGpuClient({});
 }
 
 using FunctionalHloRunnerTest = ::testing::Test;

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -803,7 +803,9 @@ message DebugOptions {
   // details.
   bool xla_use_shardonnay = 302;
 
-  // Next id: 304
+  bool xla_gpu_shard_autotuning = 304;
+
+  // Next id: 305
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This solves the problem of compiler processes compiling different programs due to fluctuations of measurements during autotuning and in addition makes some cases faster (depending on the number of fusions and the availability of CPU cores).