### PR TITLE
Make UNKNOWN the default XLA FFI error code

### DIFF
--- a/xla/ffi/api/c_api.h
+++ b/xla/ffi/api/c_api.h
@@ -100,8 +100,8 @@ typedef struct XLA_FFI_Error XLA_FFI_Error;
 // Codes are based on https://abseil.io/docs/cpp/guides/status-codes
 typedef enum {
   XLA_FFI_Error_Code_OK = 0,
-  XLA_FFI_Error_Code_CANCELLED = 1,
-  XLA_FFI_Error_Code_UNKNOWN = 2,
+  XLA_FFI_Error_Code_UNKNOWN = 1,
+  XLA_FFI_Error_Code_CANCELLED = 2,
   XLA_FFI_Error_Code_INVALID_ARGUMENT = 3,
   XLA_FFI_Error_Code_DEADLINE_EXCEEDED = 4,
   XLA_FFI_Error_Code_NOT_FOUND = 5,


### PR DESCRIPTION
Default error is defined as !success(), where success is communicated using XLA_FFI_Error_Code_OK with an integer value of 0. The value of !success() then is 1, corresponding to "CANCELLED" before this commit.

This commit swaps the values of CANCELLED and UNKNOWN since UNKNOWN is a better default/generic error type.