### PR TITLE
[XLA:GPU]  add optimization flag to disable per device multi-threading

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -48,6 +48,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_llvm_enable_noalias_metadata(true);
   opts.set_xla_llvm_enable_invariant_load_metadata(true);
   opts.set_xla_llvm_disable_expensive_passes(false);
+  opts.set_xla_gpu_disable_multi_threading_per_device(false);
   opts.set_xla_backend_optimization_level(3);
   opts.set_xla_gpu_autotune_level(4);
   opts.set_xla_gpu_autotune_max_solutions(0);
@@ -1024,6 +1025,16 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       bool_setter_for(&DebugOptions::set_xla_gpu_exclude_nondeterministic_ops),
       debug_options->xla_gpu_exclude_nondeterministic_ops(),
       "Excludes non-deterministic ops from compiled executables."));
+
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_disable_multi_threading_per_device",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_disable_multi_threading_per_device),
+      debug_options->xla_gpu_disable_multi_threading_per_device(),
+      "If set to true, XLA will assume that there is no multi-threading "
+      "running per GPU device, this enable some optimization to remove the "
+      "overhead introduced by resource sharing"));
+
   flag_list->push_back(tsl::Flag(
       "xla_gpu_disable_async_collectives",
       setter_for_xla_gpu_disable_async_collectives,

--- a/xla/service/gpu/runtime/command_buffer_thunk.h
+++ b/xla/service/gpu/runtime/command_buffer_thunk.h
@@ -130,6 +130,8 @@ class CommandBufferThunk : public Thunk {
   // Command buffer thunk state allocated in heap to allow global (per-process)
   // management of instantiated command buffers.
   std::shared_ptr<State> state_;
+
+  bool disable_multi_threading_per_device_;
 };
 
 }  // namespace xla::gpu

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -783,7 +783,12 @@ message DebugOptions {
   // a deterministic implementation.
   bool xla_gpu_exclude_nondeterministic_ops = 297;
 
-  // Next id: 299
+  // If set to true, XLA will assume that there is no multi-threading 
+  // running per GPU device, this enable some optimization to remove the 
+  // overhead introduced by resource sharing
+  bool xla_gpu_disable_multi_threading_per_device = 299;
+
+  // Next id: 300
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
When the workload type that has multi-thread sharing a single GPU device, this pattern is from some inference workloads, but not from training workloads. If the user tell XLA that the workload does not have multi-thrading sharing of a single GPU device, there is a optimization in cuda-graph update that may reduce the graph update overhead.

The pattern of cuda-graph that can be improved is when it has loop graph nodes.