### PR TITLE
[XLA:GPU] Adding an option that allocates temp buffer through separate memory allocator. 

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -148,6 +148,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_nccl_comm_splitting(false);
   opts.set_xla_gpu_enable_nccl_per_stream_comms(false);
 
+  opts.set_xla_gpu_temp_buffer_use_separate_color(false);
+
   // Set 4GB space limit for redzone scratch allocator.
   opts.set_xla_gpu_redzone_scratch_max_megabytes(1LL << 12);
   opts.set_xla_gpu_redzone_padding_bytes(8 * 1024 * 1024);
@@ -1274,6 +1276,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "Enables NCCL User Buffer Registration. collective_memory_size in the "
       "allocator config must also be set to a non-zero value that is large "
       "enough to meet peak collective memory usage."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_temp_buffer_use_separate_color",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_temp_buffer_use_separate_color),
+      debug_options->xla_gpu_temp_buffer_use_separate_color(),
+      "Enables temp User Buffer Registration. Enable this flag will use a "
+      "separate cuda async memory allocator to allocate temp buffer, this will "
+      "allocate temp buffer to the fixed address on every iteration"));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_enable_nccl_comm_splitting",
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_nccl_comm_splitting),

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -122,6 +122,8 @@ cc_library(
     ]) + if_cuda([
         "@local_config_cuda//cuda:cuda_headers",
         "//xla/stream_executor/gpu:gpu_cudamallocasync_allocator",
+        "//xla/service/gpu:gpu_memory_space_assignment",
+        "//xla:debug_options_flags",
     ]) + if_rocm([
         "@local_config_rocm//rocm:rocm_headers",
     ]),

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -96,7 +96,9 @@ limitations under the License.
 #include "xla/pjrt/gpu/nccl_id_store.h"
 #include "xla/pjrt/stream_executor_executable.pb.h"
 #include "xla/service/gpu/gpu_compiler.h"
+#include "xla/service/gpu/gpu_memory_space_assignment.h"
 #include "xla/xla.pb.h"
+#include "xla/debug_options_flags.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #if GOOGLE_CUDA
@@ -794,59 +796,56 @@ namespace {
 
 #if defined(GOOGLE_CUDA) && CUDA_VERSION >= 11020
 
-absl::StatusOr<std::vector<se::MultiDeviceAdapter::AllocatorInfo>>
-CreateCudaAsyncAllocator(
-    se::Platform* platform,
-    const std::map<int, std::unique_ptr<LocalDeviceState>>& addressable_devices,
-    double memory_fraction, bool preallocate) {
-  CHECK_GT(addressable_devices.size(), 0);
-  std::vector<se::MultiDeviceAdapter::AllocatorInfo> allocators;
+absl::StatusOr<std::unique_ptr<se::GpuCudaMallocAsyncAllocator>>
+CreateCudaAsyncAllocator(const LocalDeviceState& device, double memory_fraction,
+                         bool reserve_memory, bool create_new_pool, bool sync_mode,
+                         bool compute_stats = true) {
+  se::StreamExecutor* executor = device.executor();
+  int device_ordinal = executor->device_ordinal();
 
-  for (auto& ordinal_and_device : addressable_devices) {
-    se::StreamExecutor* executor = ordinal_and_device.second->executor();
-    int device_ordinal = executor->device_ordinal();
-
-    int64_t free_memory;
-    int64_t total_memory;
-    if (!executor->DeviceMemoryUsage(&free_memory, &total_memory)) {
-      return Unavailable("Failed to query available memory from device %i",
-                         device_ordinal);
-    }
-    // To allow full GPU memory to be visible to the Cuda Async allocator
-    // if using unified memory.
-    // When unified memory is enabled, allow GPU memory oversubscription by
-    // setting memory_fraction > 1.
-    size_t allocator_memory = total_memory * memory_fraction;
-    if (preallocate) {
-      LOG(INFO) << "XLA backend allocating " << allocator_memory
-                << " bytes on device " << device_ordinal
-                << " for CudaAsyncAllocator.";
-    } else {
-      LOG(INFO) << "XLA backend will use up to " << allocator_memory
-                << " bytes on device " << device_ordinal
-                << " for CudaAsyncAllocator.";
-    }
-
-    auto allocator = std::make_unique<se::GpuCudaMallocAsyncAllocator>(
-        tsl::PlatformDeviceId(device_ordinal), allocator_memory, preallocate);
-    allocator->SetStreamAndPreallocateMemory(
-        ordinal_and_device.second->compute_stream()
-            ->platform_specific_handle()
-            .stream);
-    allocators.emplace_back(std::move(allocator),
-                            ordinal_and_device.second->compute_stream(),
-                            /*memory_space=*/0);
+  int64_t free_memory;
+  int64_t total_memory;
+  if (!executor->DeviceMemoryUsage(&free_memory, &total_memory)) {
+    return Unavailable("Failed to query available memory from device %i",
+                       device_ordinal);
   }
-  return allocators;
+  // To allow full GPU memory to be visible to the Cuda Async allocator
+  // if using unified memory.
+  // When unified memory is enabled, allow GPU memory oversubscription by
+  // setting memory_fraction > 1.
+  size_t allocator_memory = total_memory * memory_fraction;
+  if (reserve_memory) {
+    LOG(INFO) << "XLA backend allocating " << allocator_memory
+              << " bytes on device " << device_ordinal
+              << " for CudaAsyncAllocator.";
+  } else {
+    LOG(INFO) << "XLA backend will use up to " << allocator_memory
+              << " bytes on device " << device_ordinal
+              << " for CudaAsyncAllocator.";
+  }
+
+  auto allocator = std::make_unique<se::GpuCudaMallocAsyncAllocator>(
+      /*platform_device_id*/ tsl::PlatformDeviceId(device_ordinal),
+      /*create_new_pool*/ create_new_pool,
+      /*new_pool_size*/ allocator_memory,
+      /*reserve_memory*/ reserve_memory,
+      /*reserve_memory_size*/ reserve_memory ? allocator_memory : 0,
+      /*sync_mode*/ sync_mode,
+      /*compute_stats*/ compute_stats);
+
+  allocator->SetStreamAndPreallocateMemory(
+      device.compute_stream()
+          ->platform_specific_handle()
+          .stream);
+
+  return allocator;
 }
 
 #else  // defined(GOOGLE_CUDA) && CUDA_VERSION >= 11020
-
-absl::StatusOr<std::vector<se::MultiDeviceAdapter::AllocatorInfo>>
-CreateCudaAsyncAllocator(
-    se::Platform* platform,
-    const std::map<int, std::unique_ptr<LocalDeviceState>>& addressable_devices,
-    double memory_fraction, bool preallocate) {
+absl::StatusOr<std::unique_ptr<tsl::Allocator>>
+CreateCudaAsyncAllocator(const LocalDeviceState& device, double memory_fraction,
+                         bool reserve_memory, bool create_new_pool, bool sync_mode,
+                         bool compute_stats = true) {
   return FailedPrecondition("CUDA async allocator requires CUDA >= 11.2");
 }
 
@@ -878,17 +877,17 @@ GetStreamExecutorGpuDeviceAllocator(
   std::vector<se::MultiDeviceAdapter::AllocatorInfo> allocators;
   switch (allocator_config.kind) {
     case GpuAllocatorConfig::Kind::kCudaAsync: {
-      auto allocators_or = CreateCudaAsyncAllocator(
-          platform, addressable_devices, allocator_config.memory_fraction,
-          allocator_config.preallocate);
-      if (allocators_or.ok()) {
-        LOG(INFO) << "Using CUDA async allocator.";
-        allocators = std::move(allocators_or.value());
-        break;
+      for (const auto& ordinal_and_device : addressable_devices) {
+        TF_ASSIGN_OR_RETURN(
+            auto async_allocator,
+            CreateCudaAsyncAllocator(
+                *(ordinal_and_device.second), allocator_config.memory_fraction,
+                allocator_config.preallocate, false, false, true));
+        allocators.emplace_back(std::move(async_allocator),
+                                ordinal_and_device.second->compute_stream(),
+                                /*memory_space=*/0);
       }
-      LOG(ERROR) << "Failed to initialize CUDA async allocator: "
-                 << allocators_or.status() << "; falling back to BFC.";
-      [[fallthrough]];
+      break;
     }
 
     case GpuAllocatorConfig::Kind::kDefault:
@@ -942,6 +941,23 @@ GetStreamExecutorGpuDeviceAllocator(
                             static_cast<int>(se::MemoryType::kHost));
   }
 
+#if defined(GOOGLE_CUDA) && CUDA_VERSION >= 11020
+  const auto& debug_options = xla::GetDebugOptionsFromFlags();
+  if (debug_options.xla_gpu_temp_buffer_use_separate_color()) {
+    // Add memory allocator to allocate memory buffers with persistent temp
+    // memory space color.
+    for (const auto& ordinal_and_device : addressable_devices) {
+      TF_ASSIGN_OR_RETURN(
+          auto async_allocator,
+          CreateCudaAsyncAllocator(*(ordinal_and_device.second), 1.0, false,
+                                   true, true, true));
+      allocators.emplace_back(
+          std::move(async_allocator),
+          ordinal_and_device.second->compute_stream(),
+          /*memory_space=*/gpu::kTempBufferMemorySpaceColor);
+    }
+  }
+#endif
   return std::make_unique<se::MultiDeviceAdapter>(platform,
                                                   std::move(allocators));
 }

--- a/xla/service/buffer_assignment.h
+++ b/xla/service/buffer_assignment.h
@@ -163,6 +163,7 @@ class BufferAllocation {
   // color can reside in this allocation.
   LogicalBuffer::Color color() const { return color_; }
 
+  void set_color(LogicalBuffer::Color color) { color_ = color;}
   struct OffsetSize {
     int64_t offset = 0;
     int64_t size = 0;
@@ -579,7 +580,8 @@ class BufferAssignment {
 
   // Combines allocations of temporary buffers into one big BufferAllocation.
   void CombineTempAllocations(
-      const absl::flat_hash_set<BufferValue::Color>& private_stack_colors);
+      const absl::flat_hash_set<BufferValue::Color>& private_stack_colors,
+      std::optional<BufferValue::Color> temp_buffer_color);
 
   // Computes stats for the assignment, to be retrieved by GetStats.
   absl::Status ComputeSummaryStats();
@@ -665,7 +667,8 @@ class BufferAssigner {
       GlobalDecreasingSizeBestFitHeap<HloValue>::BufferIntervalCompare
           heap_buffer_interval_compare = nullptr,
       std::optional<BufferAssignment::BufferIsolationOptions>
-          isolation_options = std::nullopt);
+          isolation_options = std::nullopt,
+      std::optional<BufferValue::Color> temp_buffer_color = std::nullopt);
 
  private:
   BufferAssigner(bool allocate_buffers_for_constants, Colorer colorer,
@@ -687,8 +690,8 @@ class BufferAssigner {
       const PrivateStacks& private_stacks,
       GlobalDecreasingSizeBestFitHeap<HloValue>::BufferIntervalCompare
           heap_buffer_interval_compare,
-      std::optional<BufferAssignment::BufferIsolationOptions>
-          isolation_options);
+      std::optional<BufferAssignment::BufferIsolationOptions> isolation_options,
+      std::optional<BufferValue::Color> temp_buffer_color);
 
   // Assigns buffers to the instructions in the given computations. "assignment"
   // is modified to reflect the new buffer assignments. If is_thread_local is

--- a/xla/service/gpu/compile_module_to_llvm_ir.cc
+++ b/xla/service/gpu/compile_module_to_llvm_ir.cc
@@ -183,7 +183,16 @@ absl::StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
                     .xla_gpu_enable_nccl_user_buffers()
                 ? CollectiveColorer()
                 : BufferAssigner::DefaultColorer(),
-            /*must_not_live_out=*/{}, can_share_buffer_function));
+            /*must_not_live_out=*/{},
+            /*can_share_buffer*/ can_share_buffer_function,
+            /*preset_assignments*/ {},
+            /*private_stack*/ {}, /*heap_buffer_interval_compare*/ nullptr,
+            /*isolation_options*/ std::nullopt,
+            hlo_module->config()
+                    .debug_options()
+                    .xla_gpu_temp_buffer_use_separate_color()
+                ? std::optional<BufferValue::Color>(kTempBufferMemorySpaceColor)
+                : std::nullopt));
   }
   VLOG(1) << "Buffer Assignment Stats for " << hlo_module->name() << "\n"
           << results.buffer_assignment->GetStats().ToString();

--- a/xla/service/gpu/gpu_memory_space_assignment.h
+++ b/xla/service/gpu/gpu_memory_space_assignment.h
@@ -29,6 +29,7 @@ namespace xla {
 namespace gpu {
 
 inline constexpr int64_t kCollectiveMemorySpaceColor = 1;
+inline constexpr int64_t kTempBufferMemorySpaceColor = 2;
 
 // Set memory space to kCollectiveMemorySpaceColor for all allocations used by
 // all-reduce, all-gather, and reduce-scatter. This memory space maps to

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
@@ -88,7 +88,6 @@ TEST(GpuCudaMallocAsyncAllocator, AddressAlignedNewPool) {
       /*compute_stats*/ true);
   allocator.SetStreamAndPreallocateMemory(
       se::gpu::AsGpuStreamValue(stream.get()));
-
   void* addr1 = allocator.AllocateRaw(128, 127);
   void* addr2 = allocator.AllocateRaw(128, 129);
   CHECK_EQ((reinterpret_cast<uintptr_t>(addr1) & 127), 0);
@@ -115,7 +114,6 @@ TEST(GpuCudaMallocAsyncAllocator, SyncAddressAlignedNewPool) {
       /*compute_stats*/ true);
   allocator.SetStreamAndPreallocateMemory(
       se::gpu::AsGpuStreamValue(stream.get()));
-
   void* addr1 = allocator.AllocateRaw(128, 127);
   void* addr2 = allocator.AllocateRaw(128, 129);
   CHECK_EQ((reinterpret_cast<uintptr_t>(addr1) & 127), 0);

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -826,7 +826,14 @@ message DebugOptions {
 
   string xla_gpu_per_fusion_autotune_cache_dir = 310;
 
-  // Next id: 311
+  // Enable this flag will use a separate memory space color for  
+  // temp buffer, and then will use separate memory allocator to allocate it, 
+  // as there is no other memory allocation interference, 
+  // it will allocate temp buffer to some fix address on every iteration, 
+  // which is good for cuda-graph perf.
+  bool xla_gpu_temp_buffer_use_separate_color = 311;
+
+  // Next id: 312
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR will assign XLA temp buffer to a dedicated memory space, and uses a standalone cuda async allocator to allocate temp buffer, as temp buffer is always allocated & deallocated for each step, this will ensure that temp buffer can be allocated to a stable address, which is good for cuda-graph's perf.