### PR TITLE
[NVIDIA] Support pipelining collectives in backward direction with loop invariant instructions in chain

### DIFF
--- a/xla/service/collective_pipeliner.h
+++ b/xla/service/collective_pipeliner.h
@@ -99,6 +99,9 @@ class CollectivePipeliner : public HloModulePass {
     bool should_allow_control_dependencies = false;
     HloPostprocessor postprocess_backward_peeled_op = std::nullopt;
     HloPostprocessor postprocess_backward_rotated_op = std::nullopt;
+    // Determines whether a loop invariant instruction can be considered
+    // in the pipelining chain.
+    bool should_add_loop_invariant_op_in_chain = false;
   };
   static const char* const kInsertedByPreviousStep;
   static const char* const kSunkByPreviousStep;

--- a/xla/service/collective_pipeliner_test.cc
+++ b/xla/service/collective_pipeliner_test.cc
@@ -2229,55 +2229,45 @@ ENTRY main.3813_spmd {
   ASSERT_IS_OK(verifier.Run(module.get()).status());
 }
 
-TEST_F(CollectivePipelinerTest, PipelineBackwardIncludeInvariantInChain) {
+TEST_F(CollectivePipelinerTest,
+       PipelineBackwardIncludeInvariantMultiConsumerInChain) {
   constexpr absl::string_view hlo_string = R"(
 HloModule module
 
 while_cond {
-  param = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) parameter(0)
+  param = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}) parameter(0)
   gte = s32[] get-tuple-element(param), index=0
   constant.1 = s32[] constant(3)
   ROOT cmp = pred[] compare(gte, constant.1), direction=LT
 }
 
 while_body {
-  param = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) parameter(0)
+  param = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}) parameter(0)
   get-tuple-element.394 = s32[] get-tuple-element(param), index=0
   get-tuple-element.395 = bf16[1,8,2048,32768]{3,2,1,0} get-tuple-element(param), index=1
   get-tuple-element.397 = bf16[1,8,2048,32768]{3,2,1,0} get-tuple-element(param), index=2
-  get-tuple-element.398 = bf16[1,64,2048,32768]{3,2,1,0} get-tuple-element(param), index=3
-  get-tuple-element.399 = bf16[1,64,2048,32768]{3,2,1,0} get-tuple-element(param), index=4
 
   constant.1 = bf16[] constant(2)
   broadcast.3593 = bf16[1,8,2048,32768]{3,2,1,0} broadcast(constant.1), dimensions={}
 
   add.2 = bf16[1,8,2048,32768]{3,2,1,0} add(broadcast.3593, get-tuple-element.395)
-  add.3 = bf16[1,8,2048,32768]{3,2,1,0} add(broadcast.3593, get-tuple-element.397)
 
-  all-gather.1 = bf16[1,64,2048,32768]{3,2,1,0} all-gather(add.2), channel_id=1, dimensions={1}, replica_groups={}
-  all-gather.2 = bf16[1,64,2048,32768]{3,2,1,0} all-gather(add.3), channel_id=2, dimensions={1}, replica_groups={}
+  all-gather.1 = bf16[1,64,2048,32768]{3,2,1,0} all-gather(broadcast.3593), channel_id=1, dimensions={1}, replica_groups={}
 
-  mul.1 = bf16[1,64,2048,32768]{3,2,1,0} multiply(all-gather.1, get-tuple-element.398)
-  mul.2 = bf16[1,64,2048,32768]{3,2,1,0} multiply(all-gather.2, get-tuple-element.399)
-  add.4 = bf16[1,64,2048,32768]{3,2,1,0} add(mul.1, mul.2)
-
-  slice.1 = bf16[1,8,2048,32768]{3,2,1,0} slice(add.4), slice={[0:1], [0:8], [0:2048], [0:32768]}
-  slice.2 = bf16[1,8,2048,32768]{3,2,1,0} slice(add.4), slice={[0:1], [8:16], [0:2048], [0:32768]}
+  slice.2 = bf16[1,8,2048,32768]{3,2,1,0} slice(all-gather.1), slice={[0:1], [8:16], [0:2048], [0:32768]}
   constant.2 = s32[] constant(1)
   add.230 = s32[] add(get-tuple-element.394, constant.2)
 
-  ROOT tuple = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) tuple(add.230, slice.1, slice.2, mul.1, mul.2)
+  ROOT tuple = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}) tuple(add.230, add.2, slice.2)
 }
 
 ENTRY entry {
   c0 = s32[] constant(0)
   p0 = bf16[1,8,2048,32768]{3,2,1,0} parameter(0)
   p1 = bf16[1,8,2048,32768]{3,2,1,0} parameter(1)
-  p2 = bf16[1,64,2048,32768]{3,2,1,0} parameter(2)
-  p3 = bf16[1,64,2048,32768]{3,2,1,0} parameter(3)
 
-  tuple = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) tuple(c0, p0, p1, p2, p3)
-  while = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) while(tuple), condition=while_cond, body=while_body
+  tuple = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}) tuple(c0, p0, p1)
+  while = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}) while(tuple), condition=while_cond, body=while_body
   ROOT gte1 = bf16[1,8,2048,32768]{3,2,1,0} get-tuple-element(while), index=1
 }
 )";
@@ -2301,17 +2291,33 @@ ENTRY entry {
   XLA_VLOG_LINES(1, module->ToString());
   HloInstruction* while_instr =
       FindInstruction(module.get(), HloOpcode::kWhile);
-  // Expect the while instruction input tuple to have 8 operands instead of 5
-  // operands. 6th and 7th operands should be peeled allgather in the main
+  // Expect the while instruction input tuple to have 5 operands instead of 3
+  // operands. 4th operand should be the peeled allgather in the main
   // computation.
-  EXPECT_THAT(while_instr, op::While(op::Tuple(_, _, _, _, _, op::AllGather(),
-                                               op::AllGather(), _)));
+  EXPECT_THAT(while_instr, op::While(op::Tuple(_, _, _, op::AllGather(), _)));
 
   HloInstruction* root = while_instr->while_body()->root_instruction();
-  // Expect the while loop now to have 8 operands at the root instead of 5
-  // operands. 6th and 7th operands should be pipelined allgather.
-  EXPECT_THAT(root,
-              op::Tuple(_, _, _, _, _, op::AllGather(), op::AllGather(), _));
+  // Expect the while loop now to have 5 operands at the root instead of 3
+  // operands. 4th operands should be the pipelined allgather.
+  EXPECT_THAT(root, op::Tuple(_, _, _, op::AllGather(), _));
+
+  // Now we turn should_add_loop_invariant_op_in_chain off, the hlo shouldn't
+  // change at all.
+  auto ref_module = ParseAndReturnUnverifiedModule(hlo_string, config_).value();
+  EXPECT_FALSE(
+      RunOptimizer(
+          ref_module.get(), /*last_run=*/true, 0,
+          /*pipeline_use_tree=*/false,
+          /*process_different_sized_ops=*/false,
+          /*direction=*/CollectivePipeliner::PipeliningDirection::kBackward,
+          /*should_process=*/IsAllGather,
+          /*acceptable_formatting=*/HloPredicateTrue,
+          /*reuse_pipelined_op_buffer=*/HloPredicateTrue,
+          /*should_allow_loop_variant_parameter_in_chain=*/HloPredicateTrue,
+          /*postprocess_backward_peeled=*/std::nullopt,
+          /*postprocess_backward_rotated=*/std::nullopt,
+          /*should_add_loop_invariant_op_in_chain=*/false)
+          .value());
 }
 
 }  // namespace

--- a/xla/service/collective_pipeliner_test.cc
+++ b/xla/service/collective_pipeliner_test.cc
@@ -69,7 +69,8 @@ absl::StatusOr<bool> RunOptimizer(
     CollectivePipeliner::HloPostprocessor postprocess_backward_peeled =
         std::nullopt,
     CollectivePipeliner::HloPostprocessor postprocess_backward_rotated =
-        std::nullopt) {
+        std::nullopt,
+    bool should_add_loop_invariant_op_in_chain = false) {
   CollectivePipeliner::Config config = {
       /*level_to_operate_on=*/level_to_operate_on,
       /*max_pipelining_per_loop=*/INT64_MAX,
@@ -83,7 +84,7 @@ absl::StatusOr<bool> RunOptimizer(
       /*reuse_pipelined_op_buffer=*/reuse_pipelined_op_buffer,
       should_allow_loop_variant_parameter_in_chain,
       /*should_allow_control_dependencies=*/false, postprocess_backward_peeled,
-      postprocess_backward_rotated};
+      postprocess_backward_rotated, should_add_loop_invariant_op_in_chain};
   HloPassPipeline pass("optimizer");
   pass.AddPass<HloVerifier>(/*layout_sensitive=*/false,
                             /*allow_mixed_precision=*/false);
@@ -2226,6 +2227,91 @@ ENTRY main.3813_spmd {
   HloVerifier verifier(/*layout_sensitive=*/false,
                        /*allow_mixed_precision*/ true);
   ASSERT_IS_OK(verifier.Run(module.get()).status());
+}
+
+TEST_F(CollectivePipelinerTest, PipelineBackwardIncludeInvariantInChain) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule module
+
+while_cond {
+  param = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) parameter(0)
+  gte = s32[] get-tuple-element(param), index=0
+  constant.1 = s32[] constant(3)
+  ROOT cmp = pred[] compare(gte, constant.1), direction=LT
+}
+
+while_body {
+  param = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) parameter(0)
+  get-tuple-element.394 = s32[] get-tuple-element(param), index=0
+  get-tuple-element.395 = bf16[1,8,2048,32768]{3,2,1,0} get-tuple-element(param), index=1
+  get-tuple-element.397 = bf16[1,8,2048,32768]{3,2,1,0} get-tuple-element(param), index=2
+  get-tuple-element.398 = bf16[1,64,2048,32768]{3,2,1,0} get-tuple-element(param), index=3
+  get-tuple-element.399 = bf16[1,64,2048,32768]{3,2,1,0} get-tuple-element(param), index=4
+
+  constant.1 = bf16[] constant(2)
+  broadcast.3593 = bf16[1,8,2048,32768]{3,2,1,0} broadcast(constant.1), dimensions={}
+
+  add.2 = bf16[1,8,2048,32768]{3,2,1,0} add(broadcast.3593, get-tuple-element.395)
+  add.3 = bf16[1,8,2048,32768]{3,2,1,0} add(broadcast.3593, get-tuple-element.397)
+
+  all-gather.1 = bf16[1,64,2048,32768]{3,2,1,0} all-gather(add.2), channel_id=1, dimensions={1}, replica_groups={}
+  all-gather.2 = bf16[1,64,2048,32768]{3,2,1,0} all-gather(add.3), channel_id=2, dimensions={1}, replica_groups={}
+
+  mul.1 = bf16[1,64,2048,32768]{3,2,1,0} multiply(all-gather.1, get-tuple-element.398)
+  mul.2 = bf16[1,64,2048,32768]{3,2,1,0} multiply(all-gather.2, get-tuple-element.399)
+  add.4 = bf16[1,64,2048,32768]{3,2,1,0} add(mul.1, mul.2)
+
+  slice.1 = bf16[1,8,2048,32768]{3,2,1,0} slice(add.4), slice={[0:1], [0:8], [0:2048], [0:32768]}
+  slice.2 = bf16[1,8,2048,32768]{3,2,1,0} slice(add.4), slice={[0:1], [8:16], [0:2048], [0:32768]}
+  constant.2 = s32[] constant(1)
+  add.230 = s32[] add(get-tuple-element.394, constant.2)
+
+  ROOT tuple = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) tuple(add.230, slice.1, slice.2, mul.1, mul.2)
+}
+
+ENTRY entry {
+  c0 = s32[] constant(0)
+  p0 = bf16[1,8,2048,32768]{3,2,1,0} parameter(0)
+  p1 = bf16[1,8,2048,32768]{3,2,1,0} parameter(1)
+  p2 = bf16[1,64,2048,32768]{3,2,1,0} parameter(2)
+  p3 = bf16[1,64,2048,32768]{3,2,1,0} parameter(3)
+
+  tuple = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) tuple(c0, p0, p1, p2, p3)
+  while = (s32[], bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,8,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}, bf16[1,64,2048,32768]{3,2,1,0}) while(tuple), condition=while_cond, body=while_body
+  ROOT gte1 = bf16[1,8,2048,32768]{3,2,1,0} get-tuple-element(while), index=1
+}
+)";
+
+  auto module = ParseAndReturnUnverifiedModule(hlo_string, config_).value();
+
+  EXPECT_TRUE(
+      RunOptimizer(
+          module.get(), /*last_run=*/true, 0,
+          /*pipeline_use_tree=*/false,
+          /*process_different_sized_ops=*/false,
+          /*direction=*/CollectivePipeliner::PipeliningDirection::kBackward,
+          /*should_process=*/IsAllGather,
+          /*acceptable_formatting=*/HloPredicateTrue,
+          /*reuse_pipelined_op_buffer=*/HloPredicateTrue,
+          /*should_allow_loop_variant_parameter_in_chain=*/HloPredicateTrue,
+          /*postprocess_backward_peeled=*/std::nullopt,
+          /*postprocess_backward_rotated=*/std::nullopt,
+          /*should_add_loop_invariant_op_in_chain=*/true)
+          .value());
+  XLA_VLOG_LINES(1, module->ToString());
+  HloInstruction* while_instr =
+      FindInstruction(module.get(), HloOpcode::kWhile);
+  // Expect the while instruction input tuple to have 8 operands instead of 5
+  // operands. 6th and 7th operands should be peeled allgather in the main
+  // computation.
+  EXPECT_THAT(while_instr, op::While(op::Tuple(_, _, _, _, _, op::AllGather(),
+                                               op::AllGather(), _)));
+
+  HloInstruction* root = while_instr->while_body()->root_instruction();
+  // Expect the while loop now to have 8 operands at the root instead of 5
+  // operands. 6th and 7th operands should be pipelined allgather.
+  EXPECT_THAT(root,
+              op::Tuple(_, _, _, _, _, op::AllGather(), op::AllGather(), _));
 }
 
 }  // namespace

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -869,7 +869,12 @@ absl::Status RunCollectiveOptimizationPasses(
         CollectivePipeliner::PipeliningDirection::kBackward,
         /*should_process=*/HloPredicateIsOp<HloOpcode::kAllGather>,
         /*acceptable_formatting=*/HloPredicateTrue,
-        /*reuse_pipelined_op_buffer=*/HloPredicateFalse};
+        /*reuse_pipelined_op_buffer=*/HloPredicateFalse,
+        /*should_allow_loop_variant_parameter_in_chain=*/HloPredicateFalse,
+        /*should_allow_control_dependencies=*/false,
+        /*postprocess_backward_peeled_op=*/std::nullopt,
+        /*postprocess_backward_rotated_op=*/std::nullopt,
+        /*acceptable_loop_invariant_op_in_chain=*/true};
     collectives_pipeline.AddPass<CollectivePipeliner>(config);
   }
   if (debug_options.xla_gpu_enable_pipelined_collectives() ||


### PR DESCRIPTION
In some quantization patterns like:
```
                constant
                      |
                broadcast
                  /       \
                /           \
           clamp         clamp
            /                  \
         dot            all-gather
```
The all-gathers cannot be pipelined due to the shared operand broadcast having multiple users and not all users are in all-gather's operand chain. The backward pipelining restricts this situation to avoiding exploding data dependencies across loop iterations.
An exception can be made if such operand chain only contains loop invariant instructions in this case: broadcast and constant.
This pr introduces a config to collective pipeliner backward direction to allow loop invariant instructions to be in the operand chain.