### PR TITLE
[XLA:CPU] [oneDNN] Fix accuracy issue with layernorm fusion

### DIFF
--- a/xla/tests/onednn_layer_norm_test.cc
+++ b/xla/tests/onednn_layer_norm_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "xla/test.h"
 #include "xla/tests/hlo_test_base.h"
+#include "xla/service/cpu/onednn_util.h"
 
 namespace xla {
 namespace {
@@ -106,6 +107,9 @@ TEST_F(LayerNormTest, LayerNormTest0_FP32) {
 }
 
 TEST_F(LayerNormTest, LayerNormTest0_BF16) {
+  if (!xla::cpu::IsSupportedType(PrimitiveType::BF16)) {
+    GTEST_SKIP() << "CPU does not support BF16.";
+  }
   std::string layer_norm_module_str =
       R"(HloModule layer_norm.test, entry_computation_layout={(bf16[84,197,768]{2,1,0}, f32[768]{0}, f32[768]{0})->bf16[84,197,768]{2,1,0}})" +
       common_hlo_region_ + R"(
@@ -124,6 +128,9 @@ TEST_F(LayerNormTest, LayerNormTest0_BF16) {
 }
 
 TEST_F(LayerNormTest, LayerNormTest0_F16) {
+  if (!xla::cpu::IsSupportedType(PrimitiveType::F16)) {
+    GTEST_SKIP() << "CPU does not support F16.";
+  }
   std::string layer_norm_module_str =
       R"(HloModule layer_norm.test, entry_computation_layout={(f16[84,197,768]{2,1,0}, f32[768]{0}, f32[768]{0})->f16[84,197,768]{2,1,0}})" +
       common_hlo_region_ + R"(
@@ -141,10 +148,130 @@ TEST_F(LayerNormTest, LayerNormTest0_F16) {
   MatchOptimizedHlo(layer_norm_module_str, onednn_layer_norm_);
 }
 
+TEST_F(LayerNormTest, LayerNormTest1_F16) {
+  if (!xla::cpu::IsSupportedType(PrimitiveType::F16)) {
+    GTEST_SKIP() << "CPU does not support F16.";
+  }
+  const char* layer_norm_module_str = R"(
+  HloModule layer_norm.test
+  region_add {
+    Arg_0 = f32[] parameter(0)
+    Arg_1 = f32[] parameter(1)
+    ROOT add_0 = f32[] add(Arg_0, Arg_1)
+  }
+  ENTRY main {
+    Arg_2 = f16[2,4,8] parameter(0), sharding={replicated}
+    convert_0 = f32[2,4,8] convert(Arg_2)
+    constant_0 = f32[] constant(0)
+    convert_1 = f32[] convert(constant_0)
+    reduce_0 = f32[2,4] reduce(convert_0, convert_1), dimensions={2}, to_apply=region_add
+    constant_1 = s32[] constant(8)
+    convert_2 = f32[] convert(constant_1)
+    broadcast_0 = f32[2,4] broadcast(convert_2), dimensions={}
+    divide_0 = f32[2,4] divide(reduce_0, broadcast_0)
+    convert_3 = f16[2,4] convert(divide_0)
+    reshape_0 = f16[2,4,1] reshape(convert_3)
+    reshape_1 = f16[2,4] reshape(reshape_0)
+    broadcast_1 = f16[2,4,8] broadcast(reshape_1), dimensions={0,1}
+    subtract_0 = f16[2,4,8] subtract(Arg_2, broadcast_1)
+    multiply_0 = f16[2,4,8] multiply(subtract_0, subtract_0)
+    convert_4 = f32[2,4,8] convert(multiply_0)
+    constant_2 = f32[] constant(0)
+    convert_5 = f32[] convert(constant_2)
+    reduce_2 = f32[2,4] reduce(convert_4, convert_5), dimensions={2}, to_apply=region_add
+    constant_3 = s32[] constant(8)
+    convert_6 = f32[] convert(constant_3)
+    broadcast_2 = f32[2,4] broadcast(convert_6), dimensions={}
+    divide_1 = f32[2,4] divide(reduce_2, broadcast_2)
+    convert_7 = f16[2,4] convert(divide_1)
+    reshape_2 = f16[2,4,1] reshape(convert_7)
+    rsqrt_0 = f16[2,4,1] rsqrt(reshape_2)
+    reshape_3 = f16[2,4] reshape(rsqrt_0)
+    broadcast_3 = f16[2,4,8] broadcast(reshape_3), dimensions={0,1}
+    constant_4 = f16[8]{0} constant({1,1,1,1,1,1,1,1})
+    broadcast_4 = f16[2,4,8] broadcast(constant_4), dimensions={2}
+    multiply_1 = f16[2,4,8] multiply(broadcast_3, broadcast_4)
+    multiply_2 = f16[2,4,8] multiply(Arg_2, multiply_1)
+    constant_5 = f16[8]{0} constant({1,1,1,1,1,1,1,1})
+    broadcast_5 = f16[2,4,8] broadcast(constant_5), dimensions={2}
+    reshape_4 = f16[2,4] reshape(reshape_0)
+    broadcast_6 = f16[2,4,8] broadcast(reshape_4), dimensions={0,1}
+    multiply_3 = f16[2,4,8] multiply(multiply_1, broadcast_6)
+    subtract_1 = f16[2,4,8] subtract(broadcast_5, multiply_3)
+    ROOT add_1 = f16[2,4,8] add(multiply_2, subtract_1)
+  }
+ )";
+
+  EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-2, 1e-2}));
+  MatchOptimizedHlo(layer_norm_module_str, onednn_layer_norm_);
+}
+
+// Test for reversed inputs
+TEST_F(LayerNormTest, LayerNormTest2_F16) {
+  if (!xla::cpu::IsSupportedType(PrimitiveType::F16)) {
+    GTEST_SKIP() << "CPU does not support F16.";
+  }
+  const char* layer_norm_module_str = R"(
+  HloModule layer_norm.test
+  region_add {
+    Arg_0 = f32[] parameter(0)
+    Arg_1 = f32[] parameter(1)
+    ROOT add_0 = f32[] add(Arg_0, Arg_1)
+  }
+  ENTRY main {
+    Arg_2= f16[2,4,8] parameter(0), sharding={replicated}
+    convert_0 = f32[2,4,8] convert(Arg_2)
+    constant_0 = f32[] constant(0)
+    convert_1 = f32[] convert(constant_0)
+    reduce_0 = f32[2,4] reduce(convert_0, convert_1), dimensions={2}, to_apply=region_add
+    constant_1 = s32[] constant(8)
+    convert_2 = f32[] convert(constant_1)
+    broadcast_0 = f32[2,4] broadcast(convert_2), dimensions={}
+    divide_0 = f32[2,4] divide(reduce_0, broadcast_0)
+    convert_3 = f16[2,4] convert(divide_0)
+    reshape_0 = f16[2,4,1] reshape(convert_3)
+    reshape_1 = f16[2,4] reshape(reshape_0)
+    broadcast_1 = f16[2,4,8] broadcast(reshape_1), dimensions={0,1}
+    subtract_0 = f16[2,4,8] subtract(broadcast_1, Arg_2)
+    multiply_0 = f16[2,4,8] multiply(subtract_0, subtract_0)
+    convert_4 = f32[2,4,8] convert(multiply_0)
+    constant_2 = f32[] constant(0)
+    convert_5 = f32[] convert(constant_2)
+    reduce_1 = f32[2,4] reduce(convert_4, convert_5), dimensions={2}, to_apply=region_add
+    constant_3 = s32[] constant(8)
+    convert_6 = f32[] convert(constant_3)
+    broadcast_2 = f32[2,4] broadcast(convert_6), dimensions={}
+    divide_1= f32[2,4] divide(reduce_1, broadcast_2)
+    convert_7 = f16[2,4] convert(divide_1)
+    reshape_2 = f16[2,4,1] reshape(convert_7)
+    rsqrt_0 = f16[2,4,1] rsqrt(reshape_2)
+    reshape_3 = f16[2,4] reshape(rsqrt_0)
+    broadcast_3 = f16[2,4,8] broadcast(reshape_3), dimensions={0,1}
+    constant_4 = f16[8] constant({1,1,1,1,1,1,1,1})
+    broadcast_4 = f16[2,4,8] broadcast(constant_4), dimensions={2}
+    multiply_1 = f16[2,4,8] multiply(broadcast3, broadcast_4)
+    multiply_2 = f16[2,4,8] multiply(multiply_1, Arg_2)
+    constant_5 = f16[8] constant({1,1,1,1,1,1,1,1})
+    broadcast_5 = f16[2,4,8] broadcast(constant_5), dimensions={2}
+    reshape_4 = f16[2,4] reshape(reshape_0)
+    broadcast_5 = f16[2,4,8] broadcast(reshape_4), dimensions={0,1}
+    multiply_3 = f16[2,4,8] multiply(multiply_1, broadcast_5)
+    subtract_1 = f16[2,4,8] subtract(broadcast_5, multiply_3)
+    ROOT add_1 = f16[2,4,8] add(multiply_2, subtract_1)
+  }
+ )";
+
+  EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-2, 1e-2}));
+  MatchOptimizedHlo(layer_norm_module_str, onednn_layer_norm_);
+}
+
 // Test case encountered in models like TFViTForImageClassification in
 // HuggingFace
 // (https://huggingface.co/docs/transformers/model_doc/vit#transformers.TFViTForImageClassification)
 TEST_F(LayerNormTest, LayerNormTest1_BF16) {
+  if (!xla::cpu::IsSupportedType(PrimitiveType::BF16)) {
+    GTEST_SKIP() << "CPU does not support BF16.";
+  }
   const char* layer_norm_module_str = R"(
   HloModule layer_norm.test
   region_add {
@@ -196,18 +323,10 @@ TEST_F(LayerNormTest, LayerNormTest1_BF16) {
     subtract.127 = bf16[160,197,768] subtract(broadcast.126, multiply.124)
     ROOT add.128 = bf16[160,197,768] add(multiply.121, subtract.127)
   }
-)";
+ )";
 
   EXPECT_TRUE(RunAndCompare(layer_norm_module_str, ErrorSpec{1e-2, 1e-2}));
-  MatchOptimizedHlo(layer_norm_module_str,
-                    R"(
-  ; CHECK:     custom_call_target="__onednn$layernorm",
-  ; CHECK:       backend_config={
-  ; CHECK-DAG:     "onednn_layer_norm_config":{
-  ; CHECK-DAG:       "fused_ops":"SCALE_AND_SHIFT"
-  ; CHECK-DAG:   }
-  ; CHECK:     }
-  )");
+  MatchOptimizedHlo(layer_norm_module_str, onednn_layer_norm_);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR fixes the accuracy issue seen with F16 ViT model by adding a default value for epsilon. It also adds a slight variation seen for TF layernorm pattern in XLA for F32,BF16,F16.
