### PR TITLE
[Bug-fix][XLA:CPU][oneDNN] Fix BINARY_ADD fusion to Dot

### DIFF
--- a/xla/tests/onednn_matmul_test.cc
+++ b/xla/tests/onednn_matmul_test.cc
@@ -1442,6 +1442,52 @@ TEST_F(MatmulTest, WeightsPrepackAndScratch) {
   )");
 }
 
+TEST_F(MatmulTest, ConsecutiveBinaryAdd) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32
+    region_0.22 {
+    Arg_0.23 = f32[] parameter(0)
+    Arg_1.24 = f32[] parameter(1)
+  ROOT add.25 = f32[] add(Arg_0.23, Arg_1.24)
+  }
+
+  region_1.29 {
+    Arg_0.30 = f32[] parameter(0)
+    Arg_1.31 = f32[] parameter(1)
+    ROOT add.32 = f32[] add(Arg_0.30, Arg_1.31)
+  }
+
+  ENTRY main {
+    constant.2 = f32[] constant(1e-06)
+    broadcast.3 = f32[1000000] broadcast(constant.2), dimensions={}
+    constant.7 = f32[] constant(1)
+    broadcast.8 = f32[1000000,3] broadcast(constant.7), dimensions={}
+    Arg_0.1 = f32[3] parameter(0)
+    reshape.10 = f32[1,3] reshape(Arg_0.1)
+    broadcast.11 = f32[1,3] broadcast(reshape.10), dimensions={0,1}
+    reshape.12 = f32[3] reshape(broadcast.11)
+    broadcast.13 = f32[1000000,3] broadcast(reshape.12), dimensions={1}
+    subtract.14 = f32[1000000,3] subtract(broadcast.8, broadcast.13)
+    constant.4 = f32[] constant(0)
+    broadcast.5 = f32[3,3] broadcast(constant.4), dimensions={}
+    dot.15 = f32[1000000,3] dot(subtract.14, broadcast.5), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    dot.16 = f32[1000000,3] dot(broadcast.3, dot.15), lhs_batch_dims={0}, lhs_contracting_dims={}, rhs_batch_dims={0}, rhs_contracting_dims={}
+    dot.17 = f32[1000000,3] dot(broadcast.3, subtract.14), lhs_batch_dims={0}, lhs_contracting_dims={}, rhs_batch_dims={0}, rhs_contracting_dims={}
+    dot.18 = f32[1000000,3] dot(dot.17, broadcast.5), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+    add.19 = f32[1000000,3] add(dot.16, dot.18)
+    constant.9 = f32[3] constant({1, 2, 3})
+    dot.20 = f32[1000000,3] dot(broadcast.3, constant.9), lhs_contracting_dims={}, rhs_contracting_dims={}
+    add.21 = f32[1000000,3] add(add.19, dot.20)
+    constant.6 = f32[] constant(0)
+    reduce.26 = f32[3] reduce(add.21, constant.6), dimensions={0}, to_apply=region_0.22
+    reshape.27 = f32[1,3] reshape(reduce.26)
+    negate.28 = f32[1,3] negate(reshape.27)
+    ROOT reduce.33 = f32[3] reduce(negate.28, constant.6), dimensions={0}, to_apply=region_1.29
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+}
+
 }  // namespace cpu
 }  // namespace xla
 


### PR DESCRIPTION
This PR fixes a bug reported for JAX (https://github.com/openxla/xla/issues/13054)