### PR TITLE
[oneDNN][BugFix] Fix dtype utility function for F16 AVX2 DL extension

### DIFF
--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -41,10 +41,10 @@ inline bool IsSupportedType(xla::PrimitiveType dtype) {
              TestCPUFeature(CPUFeature::AVX_NE_CONVERT) ||
              TestCPUFeature(CPUFeature::AMX_BF16);
     case F16:
-      return TestCPUFeature(CPUFeature::AVX512BW) &&
-             (TestCPUFeature(CPUFeature::AVX512_FP16) ||
-              TestCPUFeature(CPUFeature::AMX_FP16) ||
-              TestCPUFeature(CPUFeature::AVX_NE_CONVERT));
+      return (TestCPUFeature(CPUFeature::AVX512BW) &&
+              (TestCPUFeature(CPUFeature::AVX512_FP16) ||
+               TestCPUFeature(CPUFeature::AMX_FP16))) ||
+             TestCPUFeature(CPUFeature::AVX_NE_CONVERT);
     default:
       return false;
   }


### PR DESCRIPTION
Intel's Efficiency cores do not support AVX512 instructions. However, some of them do support lower precisions (BF16/FP16) by converting to and from FP32. Due to the lack of Byte and Word instruction set support, the current condition check always returns False, even on supporting E-cores. This PR fixes the condition to correctly return True on all compatible hardware.