### PR TITLE
Remove Redundant Shape Comparison in Norm Rewriter

### DIFF
--- a/xla/service/gpu/cudnn_norm_rewriter.cc
+++ b/xla/service/gpu/cudnn_norm_rewriter.cc
@@ -970,13 +970,6 @@ class CudnnNormRewriterVisitor : public DfsHloRewriteVisitor {
         VLOG(1) << "Layer norm input dimensions not supported.";
         return absl::OkStatus();
       }
-      for (int i = 0; i < norm_dims.size(); ++i) {
-        if (x.Instr()->shape().dimensions(norm_dims[i]) !=
-            scale->shape().dimensions(i)) {
-          VLOG(1) << "Layer norm input dimensions not supported.";
-          return absl::OkStatus();
-        }
-      }
 
       // Verify the broadcasts of scale and bias.
       if (!ShapeUtil::EqualIgnoringElementType(

--- a/xla/service/gpu/cudnn_norm_rewriter_test.cc
+++ b/xla/service/gpu/cudnn_norm_rewriter_test.cc
@@ -472,10 +472,7 @@ TEST_F(CudnnNormRewriterTest, LayerNorm4D12) {
   TestNorm(hlo_text, optimized_hlo);
 }
 
-// TODO(https://github.com/openxla/xla/issues/13361): re-enable.
 TEST_F(CudnnNormRewriterTest, LayerNorm4D12Degenerate2) {
-  GTEST_SKIP()
-      << "Reenable when https://github.com/openxla/xla/issues/13361 is fixed";
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
@@ -834,10 +831,7 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrain4D12) {
   TestNorm(hlo_text, optimized_hlo);
 }
 
-// TODO(https://github.com/openxla/xla/issues/13361): re-enable.
 TEST_F(CudnnNormRewriterTest, LayerNormTrain4D12Degenerate2) {
-  GTEST_SKIP()
-      << "Reenable when https://github.com/openxla/xla/issues/13361 is fixed";
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif
@@ -1381,10 +1375,7 @@ TEST_F(CudnnNormRewriterTest, LayerNormTrainBackward4D12) {
   TestNorm(hlo_text, optimized_hlo);
 }
 
-// TODO(https://github.com/openxla/xla/issues/13361): re-enable.
 TEST_F(CudnnNormRewriterTest, LayerNormTrainBackward4D12Degenerate2) {
-  GTEST_SKIP()
-      << "Reenable when https://github.com/openxla/xla/issues/13361 is fixed";
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8905)
   GTEST_SKIP() << "Layer norm kernels require CUDA 12 and cuDNN 8.9.5.";
 #endif


### PR DESCRIPTION
Removes a superfluous comparison of the shapes of the input and scale when matching and rewriting layer norm patterns.