### PR TITLE
Fix mlir_hlo tests on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -455,6 +455,7 @@ build:win_clang_xla --host_platform=//tools/toolchains/win:x64_windows-clang-cl
 build:win_clang_xla --compiler=clang-cl
 build:win_clang_xla --linkopt=/FORCE:MULTIPLE
 build:win_clang_xla --host_linkopt=/FORCE:MULTIPLE
+test:win_clang_xla --action_env=PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY;.PYW
 test:win_clang_xla --linkopt=/FORCE:MULTIPLE
 test:win_clang_xla --host_linkopt=/FORCE:MULTIPLE
 

--- a/xla/mlir_hlo/tests/lit.cfg.py
+++ b/xla/mlir_hlo/tests/lit.cfg.py
@@ -16,6 +16,7 @@
 # pylint: disable=undefined-variable
 
 import os
+import sys
 
 import lit.formats
 from lit.llvm import llvm_config
@@ -39,6 +40,11 @@ config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
 
 llvm_config.with_system_environment(['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+
+# Adjusted the PATH to correctly detect the tools on Windows
+if sys.platform == "win32":
+    llvm_config.config.llvm_tools_dir=r'..\llvm-project\llvm'
+    llvm_config.config.mlir_binary_dir=r'..\llvm-project\mlir'
 
 llvm_config.use_default_substitutions()
 


### PR DESCRIPTION
This PR aims to fix the mlir_hlo tests which are designed to test the implementation of the HLO (High-Level Optimizer) for MLIR (Multi-Level Intermediate Representation).

**Error**
mlir_hlo tests were failing on the Windows platform with an error shown below:

INFO: From Testing //xla/mlir_hlo/tests:Dialect/mhlo/verifier_while_op.mlir.test:

==================== Test output for //xla/mlir_hlo/tests:Dialect/mhlo/verifier_while_op.mlir.test:

lit.py: C:\Users\mraunak\AppData\Local\Temp\Bazel.runfiles_8ccro7s1\runfiles\llvm-project\llvm\utils\lit\lit\llvm\config.py:57: note: using lit tools: C:\Program Files\Git\usr\bin

lit.py: C:\Users\mraunak\AppData\Local\Temp\Bazel.runfiles_8ccro7s1\runfiles\llvm-project\llvm\utils\lit\lit\llvm\subst.py:133: **fatal**: **Did not find FileCheck in external/llvm-project/llvm**

**Solution**
Tweaked the PATH to correctly find the tools required for executing LIT tests on the Windows platform such as FileCheck.