### PR TITLE
[XLA:GPU][Allow cuda async allocator to use non-default pool

### DIFF
--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -590,6 +590,34 @@ xla_test(
     ],
 )
 
+xla_test(
+    name = "gpu_cudamallocasync_allocator_test",
+    srcs = if_gpu_is_configured(["gpu_cudamallocasync_allocator_test.cc"]),
+    backends = ["gpu_any"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    deps = [
+        "//xla:types",
+        "//xla/service:platform_util",
+        "//xla/stream_executor",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor/gpu:gpu_stream",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:status",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+        "@tsl//tsl/platform:test_benchmark",
+        "@tsl//tsl/framework:device_id",
+        "@tsl//tsl/platform:test_main",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+        "//xla/stream_executor/cuda:cuda_platform",
+        ":gpu_cudamallocasync_allocator_header",
+    ]),
+)
+
 # TODO(tlongeri): Remove gpu_cudamallocasync_allocator header/impl split
 tsl_gpu_library(
     name = "gpu_cudamallocasync_allocator_header",

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
@@ -106,10 +106,12 @@ void GpuCudaMallocAsyncAllocator::PrintAllocatorStatisticsNoLock() {
 std::atomic<int> GpuCudaMallocAsyncAllocator::number_instantiated_(0);
 
 GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
-    tsl::PlatformDeviceId platform_device_id, size_t pool_size,
-    bool reserve_memory, bool compute_stats)
+    tsl::PlatformDeviceId platform_device_id, bool create_new_pool,
+    size_t new_pool_size, size_t release_threshold, bool reserve_memory,
+    bool compute_stats)
     : name_(absl::StrCat("gpu_async_", platform_device_id.value())),
-      reserve_memory_(reserve_memory) {
+      reserve_memory_(reserve_memory),
+      create_new_pool_(create_new_pool) {
   ++number_instantiated_;
 
   // Stop clang from complaining about unused private fields when
@@ -172,17 +174,36 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
            "old, "
         << " OS not supported, CUDA version too old(request CUDA11.2+).";
 
-  if (auto status =
-          cuDeviceGetDefaultMemPool(&pool_, platform_device_id.value()))
-    LOG(FATAL) <<  // Crash OK.
-        "Failed to get default CUDA pool: " << GetCudaErrorMessage(status);
+  size_t pool_size;
+  if (create_new_pool_) {
+    pool_size = new_pool_size;
+    CUmemPoolProps pool_props;
+    memset(reinterpret_cast<void*>(&pool_props), 0, sizeof(pool_props));
+    pool_props.allocType = CU_MEM_ALLOCATION_TYPE_PINNED;
+    pool_props.handleTypes = CU_MEM_HANDLE_TYPE_NONE;
+    pool_props.location.id = platform_device_id.value();
+    pool_props.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+#if CUDA_VERSION >= 12030
+    pool_props.maxSize = new_pool_size;
+#endif  // CUDA_VERSION >= 12030
+    if (auto status = cuMemPoolCreate(&pool_, &pool_props))
+      LOG(FATAL) <<  // Crash OK.
+          "Failed to create CUDA pool: " << GetCudaErrorMessage(status);
+  } else {
+    pool_size = release_threshold;
+    if (auto status =
+            cuDeviceGetDefaultMemPool(&pool_, platform_device_id.value()))
+      LOG(FATAL) <<  // Crash OK.
+          "Failed to get default CUDA pool: " << GetCudaErrorMessage(status);
+    VLOG(2) << "using default memory pool " << pool_;
+  }
 
   VLOG(1) << Name() << " CudaMallocAsync initialized on platform: "
           << platform_device_id.value() << " with pool size of: " << pool_size
           << " this ptr: " << this;
-  uint64_t pool_size_64 = pool_size;
+  uint64_t release_threshold_64 = release_threshold;
   if (auto status = cuMemPoolSetAttribute(
-          pool_, CU_MEMPOOL_ATTR_RELEASE_THRESHOLD, &pool_size_64))
+          pool_, CU_MEMPOOL_ATTR_RELEASE_THRESHOLD, &release_threshold_64))
     LOG(FATAL) <<  // Crash OK.
         "Failed to set CUDA pool attribute: " << GetCudaErrorMessage(status);
 
@@ -214,66 +235,86 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
   // Set read/write access to all GPUs.
   static auto* all_pools_ = new std::vector<CUmemoryPool*>();
   static auto* all_ids_ = new std::vector<tsl::PlatformDeviceId>();
-  DCHECK(all_pools_->size() == all_ids_->size());
-  for (int i = 0; i < all_pools_->size(); ++i) {
-    // Set the current pool access to the previous GPUs.
-    CUmemAccessDesc map;
-    map.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    map.location.id = (*all_ids_)[i].value();
+  if (!create_new_pool_) {
+    DCHECK(all_pools_->size() == all_ids_->size());
+    for (int i = 0; i < all_pools_->size(); ++i) {
+      // Set the current pool access to the previous GPUs.
+      CUmemAccessDesc map;
+      map.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+      map.location.id = (*all_ids_)[i].value();
 
-    map.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    VLOG(2) << "Setting access of the current pool to "
-            << " location id: " << map.location.id;
-    int canAccessPeer;
-    if (auto status = cuDeviceCanAccessPeer(
-            &canAccessPeer, platform_device_id.value(), map.location.id)) {
-      pool_ = nullptr;
-      LOG(FATAL)  // Crash OK.
-          << "cuDeviceCanAccessPeer failed to know if GPU id "
-          << map.location.id << " can access GPU id "
-          << platform_device_id.value() << ": " << GetCudaErrorMessage(status);
-    }
-    if (canAccessPeer == 1) {
-      if (auto status = cuMemPoolSetAccess(pool_, &map, 1)) {
+      map.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+      VLOG(2) << "Setting access of the current pool to "
+              << " location id: " << map.location.id;
+      int canAccessPeer;
+      if (auto status = cuDeviceCanAccessPeer(
+              &canAccessPeer, platform_device_id.value(), map.location.id)) {
         pool_ = nullptr;
         LOG(FATAL)  // Crash OK.
-            << "Error when setting access to the pool id: " << i
-            << " location id: " << map.location.id
-            << " error: " << GetCudaErrorMessage(status);
+            << "cuDeviceCanAccessPeer failed to know if GPU id "
+            << map.location.id << " can access GPU id "
+            << platform_device_id.value() << ": "
+            << GetCudaErrorMessage(status);
       }
-    }
+      if (canAccessPeer == 1) {
+        if (auto status = cuMemPoolSetAccess(pool_, &map, 1)) {
+          pool_ = nullptr;
+          LOG(FATAL)  // Crash OK.
+              << "Error when setting access to the pool id: " << i
+              << " location id: " << map.location.id
+              << " error: " << GetCudaErrorMessage(status);
+        }
+      }
 
-    // Set the previous pools access to the current GPU.
-    map.location.id = platform_device_id.value();
+      // Set the previous pools access to the current GPU.
+      map.location.id = platform_device_id.value();
 
-    VLOG(2) << "Set access to the pool id: " << i
-            << " location id: " << map.location.id;
-    if (auto status = cuDeviceCanAccessPeer(&canAccessPeer, i,
-                                            platform_device_id.value())) {
-      pool_ = nullptr;
-      LOG(FATAL)  // Crash OK.
-          << "cuDeviceCanAccessPeer failed: " << GetCudaErrorMessage(status);
-    }
-    if (canAccessPeer == 1) {
-      if (auto status = cuMemPoolSetAccess(*(*all_pools_)[i], &map, 1)) {
+      VLOG(2) << "Set access to the pool id: " << i
+              << " location id: " << map.location.id;
+      if (auto status = cuDeviceCanAccessPeer(&canAccessPeer, i,
+                                              platform_device_id.value())) {
         pool_ = nullptr;
         LOG(FATAL)  // Crash OK.
-            << "Error when setting access to the pool id: " << i
-            << " location id: " << map.location.id
-            << " error: " << GetCudaErrorMessage(status);
+            << "cuDeviceCanAccessPeer failed: " << GetCudaErrorMessage(status);
+      }
+      if (canAccessPeer == 1) {
+        if (auto status = cuMemPoolSetAccess(*(*all_pools_)[i], &map, 1)) {
+          pool_ = nullptr;
+          LOG(FATAL)  // Crash OK.
+              << "Error when setting access to the pool id: " << i
+              << " location id: " << map.location.id
+              << " error: " << GetCudaErrorMessage(status);
+        }
       }
     }
+    all_pools_->push_back(&pool_);
+    all_ids_->push_back(platform_device_id);
   }
-  all_pools_->push_back(&pool_);
-  all_ids_->push_back(platform_device_id);
 
   VLOG(2) << Name() << " GpuCudaMallocAsyncAllocator PoolSize " << pool_size;
+
 #else   // TF_CUDA_MALLOC_ASYNC_SUPPORTED
   LOG(FATAL) << "GpuCudaMallocAsyncAllocator requires CUDA 11.2+";  // Crash OK.
 #endif  // TF_CUDA_MALLOC_ASYNC_SUPPORTED
 }
 
-GpuCudaMallocAsyncAllocator::~GpuCudaMallocAsyncAllocator() {}
+GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
+    tsl::PlatformDeviceId platform_device_id, size_t release_threshold,
+    bool reserve_memory, bool compute_stats)
+    : GpuCudaMallocAsyncAllocator(platform_device_id, false, 0,
+                                  release_threshold, reserve_memory,
+                                  compute_stats) {}
+
+GpuCudaMallocAsyncAllocator::~GpuCudaMallocAsyncAllocator() {
+#if TF_CUDA_MALLOC_ASYNC_SUPPORTED
+  if (create_new_pool_) {
+    VLOG(2) << "Delete memory pool " << reinterpret_cast<void*>(pool_);
+    if (auto status = cuMemPoolDestroy(pool_))
+      LOG(FATAL) << "Failed to destroy memory pool:"
+                 << GetCudaErrorMessage(status);
+  }
+#endif
+}
 
 void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
                                                size_t num_bytes) {

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
@@ -1,0 +1,97 @@
+/* Copyright 2019 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "xla/service/platform_util.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
+#include "xla/stream_executor/gpu/gpu_stream.h"
+#include "tsl/lib/core/status_test_util.h"
+#include "tsl/platform/status.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+#include "tsl/platform/test_benchmark.h"
+#include "tsl/framework/device_id.h"
+
+#ifdef GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#endif  // GOOGLE_CUDA
+
+namespace se = stream_executor;
+
+namespace {
+static se::StreamExecutor* GpuExecutor() {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
+  auto* platform = se::PlatformManager::PlatformWithName(name).value();
+  return platform->ExecutorForDevice(0).value();
+}
+}  // namespace
+
+namespace stream_executor {
+
+TEST(GpuCudaMallocAsyncAllocator, AddressAlignedDefaultPool) {
+#if CUDA_VERSION < 11030
+  GTEST_SKIP() << "Cuda async memory allocator is not supported for CUDA "
+                  "version less than 11030";
+#endif
+
+  se::StreamExecutor* executor = GpuExecutor();
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  auto allocator = GpuCudaMallocAsyncAllocator(
+      /*platform_device_id*/ tsl::PlatformDeviceId(executor->device_ordinal()),
+      /*pool_size*/ 2048,
+      /*new_pool_size*/ true,
+      /*release_threshold*/ true);
+  allocator.SetStreamAndPreallocateMemory(
+      se::gpu::AsGpuStreamValue(stream.get()));
+  void* addr1 = allocator.AllocateRaw(128, 127);
+  void* addr2 = allocator.AllocateRaw(128, 129);
+  CHECK_EQ((reinterpret_cast<uintptr_t>(addr1) & 127), 0);
+  CHECK_EQ((reinterpret_cast<uintptr_t>(addr2) & 127), 0);
+}
+
+TEST(GpuCudaMallocAsyncAllocator, AddressAlignedNewPool) {
+#if CUDA_VERSION < 11030
+  GTEST_SKIP() << "Cuda async memory allocator is not supported for CUDA "
+                  "version less than 11030";
+#endif
+  se::StreamExecutor* executor = GpuExecutor();
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  auto allocator = GpuCudaMallocAsyncAllocator(
+      /*platform_device_id*/ tsl::PlatformDeviceId(executor->device_ordinal()),
+      /*create_new_pool*/ true,
+      /*new_pool_size*/ 2048,
+      /*release_threshold*/ 0,
+      /*reserve_memory*/ true,
+      /*compute_stats*/ true);
+  allocator.SetStreamAndPreallocateMemory(
+      se::gpu::AsGpuStreamValue(stream.get()));
+
+  void* addr1 = allocator.AllocateRaw(128, 127);
+  void* addr2 = allocator.AllocateRaw(128, 129);
+  CHECK_EQ((reinterpret_cast<uintptr_t>(addr1) & 127), 0);
+  CHECK_EQ((reinterpret_cast<uintptr_t>(addr2) & 127), 0);
+}
+
+}  // namespace stream_executor


### PR DESCRIPTION
This patch allows user to construct the GpuCudaMallocAsyncAllocator to use the non-default memory pool, this is required if we want the allocator to just allocate for a particular memory space allocations, without the interference allocation requests from other memory space.  E.g, using a separate memory pool for XLA temp buffers will make the allocated temp buffer address stabled. 

