### PR TITLE
[ROCM] gemm precision settings for autotuner

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -279,6 +279,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   opts.set_xla_gpu_per_fusion_autotune_cache_dir("");
 
+  opts.set_xla_gpu_autotune_gemm_rtol(0.1f);
+
   return opts;
 }
 
@@ -835,13 +837,24 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       int32_setter_for(&DebugOptions::set_xla_gpu_autotune_level),
       debug_options->xla_gpu_autotune_level(),
       "Set GEMM and Convolution auto-tuning level. 0 = off; 1 = on; 2 = "
-      "on+init; 3 = on+init+reinit; 4 = on+init+reinit+check."));
+      "on+init; 3 = on+init+reinit; 4 = on+init+reinit+check; "
+      "5 = on+init+reinit+check and skip WRONG_RESULT solutions. See also "
+      "the related flag xla_gpu_autotune_gemm_rtol. Remark that, setting the "
+      "level to 5 only makes sense if you are sure that the reference (first "
+      "in the list) solution is numerically CORRECT. Otherwise, the autotuner "
+      "might discard many other correct solutions based on the failed "
+      "BufferComparator test."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_autotune_max_solutions",
       int64_setter_for(&DebugOptions::set_xla_gpu_autotune_max_solutions),
       debug_options->xla_gpu_autotune_max_solutions(),
       "Maximal number of GEMM solutions to consider for autotuning: 0 means "
       "consider all solutions returned by the GEMM library."));
+    flag_list->push_back(tsl::Flag(
+      "xla_gpu_autotune_gemm_rtol",
+      float_setter_for(&DebugOptions::set_xla_gpu_autotune_gemm_rtol),
+      debug_options->xla_gpu_autotune_gemm_rtol(),
+      "Relative precision for comparing GEMM solutions vs the reference one"));
   flag_list->push_back(tsl::Flag(
       "xla_force_host_platform_device_count",
       int32_setter_for(&DebugOptions::set_xla_force_host_platform_device_count),

--- a/xla/service/gpu/autotuner_util.h
+++ b/xla/service/gpu/autotuner_util.h
@@ -101,6 +101,7 @@ class AutotuneConfig {
   bool should_init_buffers() const { return autotune_level_ >= 2; }
   bool should_reinit_output_buffer() const { return autotune_level_ >= 3; }
   bool should_check_correctness() const { return autotune_level_ >= 4; }
+  bool should_skip_wrong_results() const { return autotune_level_ >= 5; }
   bool should_crash_on_check_failure() const {
     return should_crash_on_check_failure_;
   }

--- a/xla/service/gpu/buffer_comparator.cc
+++ b/xla/service/gpu/buffer_comparator.cc
@@ -49,7 +49,8 @@ using ComparisonKernelT =
 
 struct ComparisonParams {
   double relative_tol = 0.1;
-  const Shape* shape = nullptr;
+  bool verbose = true;
+  const Shape *shape = nullptr;
   se::Stream* stream = nullptr;
   se::DeviceMemoryBase current{};
   se::DeviceMemoryBase expected{};
@@ -129,6 +130,7 @@ static absl::StatusOr<bool> HostCompare(const ComparisonParams& params) {
     return a;
   };
   int differences_seen = 0;
+
   for (int64_t i = 0; i < n && differences_seen < 10; ++i) {
     auto current_value = static_cast<ComparisonType>(host_current[i]);
     auto expected_value = static_cast<ComparisonType>(host_expected[i]);
@@ -148,11 +150,11 @@ static absl::StatusOr<bool> HostCompare(const ComparisonParams& params) {
         !(std::abs(current_value_canonical - expected_value_canonical) /
               (std::max(std::abs(current_value_canonical),
                         std::abs(expected_value_canonical)) +
-               1) <
-          params.relative_tol)) {
+               1) < params.relative_tol)) {
+      if(!params.verbose) return false; // Return immediately if not verbose.
       ++differences_seen;
       LOG(ERROR) << "Difference at " << i << ": " << current_value
-                 << ", expected " << expected_value;
+                   << ", expected " << expected_value;
     }
   }
   return differences_seen == 0;
@@ -180,7 +182,9 @@ static absl::StatusOr<bool> CompareEqualParameterized(
 absl::StatusOr<bool> BufferComparator::CompareEqual(
     se::Stream* stream, se::DeviceMemoryBase current,
     se::DeviceMemoryBase expected) const {
-  ComparisonParams params{relative_tol_, &shape_, stream, current, expected};
+
+  ComparisonParams params{
+    relative_tol_, verbose_, &shape_, stream, current, expected};
 
   switch (shape_.element_type()) {
 #if GOOGLE_CUDA  // not available for ROCm yet..
@@ -226,10 +230,9 @@ absl::StatusOr<bool> BufferComparator::CompareEqual(
   }
 }
 
-BufferComparator::BufferComparator(const Shape& shape,
-                                   const HloModuleConfig& config,
-                                   double tolerance)
-    : shape_(shape), config_(config), relative_tol_(tolerance) {
+BufferComparator::BufferComparator(const Shape& shape, double tolerance, 
+      bool verbose) : 
+        shape_(shape), relative_tol_(tolerance), verbose_(verbose) {
   // Normalize complex shapes: since we treat the passed array as a contiguous
   // storage it does not matter which dimension are we doubling.
   auto double_dim_size = [&]() {

--- a/xla/service/gpu/buffer_comparator.h
+++ b/xla/service/gpu/buffer_comparator.h
@@ -34,8 +34,8 @@ class BufferComparator {
   BufferComparator(const BufferComparator&) = delete;
   BufferComparator(BufferComparator&&) = default;
 
-  BufferComparator(const Shape& shape, const HloModuleConfig& config,
-                   double tolerance = 0.1);
+  explicit BufferComparator(const Shape& shape, double tolerance = 0.1,
+                   bool verbose = true);
 
   // Returns true if the two buffers compare equal. The definition of "equal"
   // is:
@@ -51,8 +51,8 @@ class BufferComparator {
                                     se::DeviceMemoryBase expected) const;
  private:
   Shape shape_;
-  HloModuleConfig config_;
-  double relative_tol_;
+  double relative_tol_;  // relative tolerance for comparison
+  bool verbose_;          // whether to print out error message on mismatch
 };
 
 namespace buffer_comparator {

--- a/xla/service/gpu/buffer_comparator_test.cc
+++ b/xla/service/gpu/buffer_comparator_test.cc
@@ -75,7 +75,7 @@ class BufferComparatorTest : public testing::Test {
         ShapeUtil::MakeShape(
             primitive_util::NativeToPrimitiveType<ElementType>(),
             {static_cast<int64_t>(current.size())}),
-        HloModuleConfig(), tolerance);
+        tolerance);
     return comparator
         .CompareEqual(stream.get(), current_buffer.memory(),
                       expected_buffer.memory())
@@ -394,8 +394,7 @@ TEST_F(BufferComparatorTest, BF16) {
       stream_exec_->AllocateArray<Eigen::bfloat16>(element_count));
   InitializeBuffer(stream.get(), BF16, &rng_state, rhs.memory());
 
-  BufferComparator comparator(ShapeUtil::MakeShape(BF16, {element_count}),
-                              HloModuleConfig());
+  BufferComparator comparator(ShapeUtil::MakeShape(BF16, {element_count}));
   EXPECT_FALSE(comparator.CompareEqual(stream.get(), lhs.memory(), rhs.memory())
                    .value());
 }

--- a/xla/service/gpu/conv_algorithm_picker.cc
+++ b/xla/service/gpu/conv_algorithm_picker.cc
@@ -732,8 +732,11 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
 
   if (reference_result->has_value()) {
     XLA_SCOPED_LOGGING_TIMER_LEVEL("BufferComparator::CompareEqual", 2);
+    
+    const DebugOptions& debug_options =
+            runtime_arguments.hlo_module_config.debug_options();
     BufferComparator comparator(runtime_arguments.rz_buffers.output_shape(),
-                                runtime_arguments.hlo_module_config);
+                                debug_options.xla_gpu_autotune_gemm_rtol());
     for (int i = 0; i < result_buffers.size(); ++i) {
       absl::StatusOr<bool> compare_result = comparator.CompareEqual(
           stream, (*reference_result)->buffers[i], result_buffers[i]);
@@ -747,8 +750,6 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
           // Possibly OOM. Propagate the error.
           return compare_result.status();
         }
-        const DebugOptions& debug_options =
-            runtime_arguments.hlo_module_config.debug_options();
         CHECK(!debug_options.xla_gpu_crash_on_verification_failures());
       } else if (!compare_result.value()) {
         LOG(ERROR)

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -92,13 +92,18 @@ class GemmAutotuner {
   se::Stream* stream_ = nullptr;
   bool deterministic_ops_ = false;
   size_t solutions_limit_ = 0;
+  size_t num_algorithms_left_ = 0;
 
  public:
   explicit GemmAutotuner(const AutotuneConfig& autotune_config)
       : autotune_config_(autotune_config) {}
 
+  size_t num_algorithms_left() const { return num_algorithms_left_; }
+
   absl::StatusOr<AutotuneResult> operator()(const HloInstruction* gemm,
                                             const AutotuneCacheKey& key) {
+
+    num_algorithms_left_ = 0;
     if (autotune_config_.IsDeviceless()) {
       // Return empty result, will tune at runtime.
       return AutotuneResult{};
@@ -274,7 +279,11 @@ class GemmAutotuner {
                               ShapeUtil::ByteSizeOf(output_shape)));
     }
 
-    BufferComparator comparator(output_shape, hlo_module_config);
+    // Do not print error messages if should_skip_wrong_results() is ON.
+    BufferComparator comparator(output_shape, 
+        hlo_module_config.debug_options().xla_gpu_autotune_gemm_rtol(),
+        /* verbose */!autotune_config_.should_skip_wrong_results()
+    );
     std::vector<AutotuneResult> results;
     results.reserve(algorithms.size());
     std::optional<int64_t> reference_algorithm;
@@ -307,6 +316,7 @@ class GemmAutotuner {
           absl::Milliseconds(profile_result.elapsed_time_in_ms()));
 
       if (!autotune_config_.should_check_correctness()) {
+        num_algorithms_left_++;
         continue;
       }
       TF_ASSIGN_OR_RETURN(
@@ -322,25 +332,35 @@ class GemmAutotuner {
         continue;
       }
 
+      num_algorithms_left_++; 
       if (!reference_algorithm) {
         TF_RETURN_IF_ERROR(stream_->Memcpy(&reference_buffer, OutputBuffer(),
                                            OutputBuffer().size()));
         reference_algorithm = profile_result.algorithm();
-      } else {
-        // Perform the comparison.
-        TF_ASSIGN_OR_RETURN(
-            bool outputs_match,
-            comparator.CompareEqual(stream_, /*current=*/OutputBuffer(),
+        continue;
+      } 
+      // Perform the comparison versus the reference algorithm.
+      TF_ASSIGN_OR_RETURN(
+          bool outputs_match,
+          comparator.CompareEqual(stream_, /*current=*/OutputBuffer(),
                                     /*expected=*/reference_buffer));
-        if (!outputs_match) {
-          LOG(ERROR) << "Results mismatch between different GEMM algorithms. "
-                     << "This is likely a bug/unexpected loss of precision.";
-          CHECK(!autotune_config_.should_crash_on_check_failure());
+      if (!outputs_match) {
+        LOG(ERROR) << "Results mismatch between different GEMM algorithms. "
+                   << "This is likely a bug/unexpected loss of precision.";
+        CHECK(!autotune_config_.should_crash_on_check_failure());
 
-          result.mutable_failure()->set_kind(AutotuneResult::WRONG_RESULT);
-          result.mutable_failure()->mutable_reference_gemm()->set_algorithm(
-              *reference_algorithm);
+        // By default, autotuner does NOT really skip wrong results, but 
+        // merely prints out the above error message: this may lead to a 
+        // great confusion. When should_skip_wrong_results() is set to true,
+        // solutions with accuracy problems will be disqualified.
+        auto kind = AutotuneResult::WRONG_RESULT;
+        if (autotune_config_.should_skip_wrong_results()) {
+          kind = AutotuneResult::DISQUALIFIED;
+          num_algorithms_left_--; // Decrement again since we disqualified it.
         }
+        result.mutable_failure()->set_kind(kind);
+        result.mutable_failure()->mutable_reference_gemm()->set_algorithm(
+              *reference_algorithm);
       }
     }  // for algorithms
 
@@ -373,13 +393,15 @@ class GemmAutotuner {
 // Do Gemm Autotune without stream executor. Use results from autotune cache
 // only.
 absl::StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
-                                      const AutotuneConfig& config) {
+                                const AutotuneConfig& config,
+                                size_t *num_algorithms_left) {
   VLOG(3) << "Loading the autotune result of GemmThunk " << gemm->ToString();
 
   GpuBackendConfig gpu_config =
       gemm->backend_config<GpuBackendConfig>().value();
   GemmBackendConfig& backend_config = *gpu_config.mutable_gemm_backend_config();
 
+  *num_algorithms_left = 0;
   // Degenerate gemms replaced with memzero operation, no need to auto tune it.
   if (backend_config.alpha_real() == 0.0 &&
       backend_config.alpha_imag() == 0.0 && backend_config.beta() == 0.0) {
@@ -393,6 +415,7 @@ absl::StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
                       AutotunerUtil::Autotune(
                           gemm, config, [&] { return autotuner(gemm, key); }));
 
+  *num_algorithms_left = autotuner.num_algorithms_left();
   auto old_algorithm = backend_config.selected_algorithm();
   bool update_algorithm =
       IsCublasLtMatmulF8(*gemm) ||
@@ -434,11 +457,15 @@ absl::StatusOr<bool> RunOnInstruction(HloInstruction* gemm,
 }
 
 absl::StatusOr<bool> RunOnComputation(HloComputation* computation,
-                                      AutotuneConfig config) {
+               AutotuneConfig config, size_t *num_algorithms_left) {
   bool changed = false;
+
   for (HloInstruction* instr : computation->instructions()) {
     if (IsCublasGemm(*instr)) {
-      TF_ASSIGN_OR_RETURN(bool result, RunOnInstruction(instr, config));
+      size_t num_left;
+      TF_ASSIGN_OR_RETURN(bool result, RunOnInstruction(instr, config, &num_left));
+      // Gathering statistics on the algorithms left after tuning (for testing)
+      *num_algorithms_left = std::max(*num_algorithms_left, num_left);
       changed |= result;
     }
   }
@@ -453,6 +480,7 @@ absl::StatusOr<bool> GemmAlgorithmPicker::Run(
   XLA_SCOPED_LOGGING_TIMER(
       absl::StrCat("GemmAlgorithmPicker for ", module->name()));
 
+  num_algorithms_left_ = 0;
   if (module->config().debug_options().xla_gpu_autotune_level() == 0) {
     VLOG(2) << "GEMM auto-tuning disabled, GemmAlgorithmPicker returning early";
     return false;
@@ -461,7 +489,8 @@ absl::StatusOr<bool> GemmAlgorithmPicker::Run(
   bool changed = false;
   for (HloComputation* computation :
        module->MakeNonfusionComputations(execution_threads)) {
-    TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation, config_));
+    TF_ASSIGN_OR_RETURN(bool result, 
+                RunOnComputation(computation, config_, &num_algorithms_left_));
     changed |= result;
   }
   return changed;

--- a/xla/service/gpu/gemm_algorithm_picker.h
+++ b/xla/service/gpu/gemm_algorithm_picker.h
@@ -50,6 +50,10 @@ class GemmAlgorithmPicker : public HloModulePass {
 
   absl::string_view name() const override { return "gemm-algorithm-picker"; }
 
+  size_t num_algorithms_left() const {
+    return num_algorithms_left_;
+  }
+
   using HloPassInterface::Run;
   absl::StatusOr<bool> Run(
       HloModule* module,
@@ -57,6 +61,9 @@ class GemmAlgorithmPicker : public HloModulePass {
 
  private:
   AutotuneConfig config_;
+  // The number of valid algorithms used for autotuning (from the last call),
+  // to be used for testing purposes.
+  size_t num_algorithms_left_ = 0; 
 };
 
 }  // namespace gpu

--- a/xla/service/gpu/gemm_algorithm_picker_test.cc
+++ b/xla/service/gpu/gemm_algorithm_picker_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/gemm_rewriter.h"
 #include "xla/service/gpu/variant_visitor.h"
+#include "xla/service/gpu/variant_visitor.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/service/pattern_matcher_gmock.h"
 #include "xla/service/platform_util.h"
@@ -109,6 +110,70 @@ TEST_P(GemmAlgorithmPickerTest, BlasGetVersion) {
   ASSERT_TRUE(blas->GetVersion(&version).ok());
   VLOG(0) << "Blas version: " << version;
   ASSERT_TRUE(!version.empty());
+}
+
+TEST_P(GemmAlgorithmPickerTest, SkipAlgorithmsWithAccuracyCheck) {
+  constexpr absl::string_view kHlo = R"(
+HloModule module
+
+ENTRY main {
+  %arg0 = f32[100,100]{1,0} parameter(0)
+  %arg1 = f32[100,100]{1,0} parameter(1)
+  ROOT %dot = f32[100,100]{1,0} dot(arg0, arg1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+})";
+
+  auto module_cfg = GetModuleConfigForTest();
+  auto debug_opts = module_cfg.debug_options();
+  size_t num_left1 = 0, num_left2 = 0;
+
+TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHlo, module_cfg));
+
+  {
+    // Run first with default settings (autotune level = 4), keep the number of
+    // algorithms left after autotuning
+    TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RunHloPass(
+          GemmRewriter(gpu_comp(), /*toolkit_version=*/12040),
+          module.get()));
+
+    AutotuneConfig cfg{DeviceConfig{stream_exec(), nullptr}, debug_opts};
+    GemmAlgorithmPicker gpicker(cfg);
+    // Note that, we do not care if the algorithm index has been changed:
+    // the thing matters is the # of algorithms left after sorting out.
+    TF_ASSERT_OK_AND_ASSIGN(changed, RunHloPass(gpicker, module.get()));
+    num_left1 = gpicker.num_algorithms_left();
+    if(num_left1 < 2) {
+      GTEST_SKIP() << "Too few algorithms left after the first step";
+    }
+  }
+
+  // Clear cache before the second run!
+  AutotunerUtil::ClearAutotuneResults();
+  {
+    // Run once again but now with autotune level 5 and embarassingly tight 
+    // rtol which shall disqualify most of the algorithms.
+
+    // Note that, we have "two sources of truth" for GemmAlgorithmPicker: i.e.,
+    // debug_options are used to initialize both 'HloModuleConfig' and also 
+    // 'AutotuneConfig'.
+    debug_opts.set_xla_gpu_autotune_gemm_rtol(1e-12);
+    debug_opts.set_xla_gpu_autotune_level(5);
+    module->mutable_config().set_debug_options(debug_opts);
+    TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RunHloPass(
+          GemmRewriter(gpu_comp(), /*toolkit_version=*/12040),
+          module.get()));
+
+    AutotuneConfig cfg{DeviceConfig{stream_exec(), nullptr}, debug_opts};
+    GemmAlgorithmPicker gpicker(cfg);
+    TF_ASSERT_OK_AND_ASSIGN(changed, RunHloPass(gpicker, module.get()));
+    num_left2 = gpicker.num_algorithms_left();
+  }
+  // Assert that we have fewer algorithms left after the second run.
+  ASSERT_TRUE(num_left1 > num_left2);
 }
 
 TEST_P(GemmAlgorithmPickerTest, SetAlgorithm) {

--- a/xla/service/gpu/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/gemm_fusion_autotuner.cc
@@ -887,7 +887,7 @@ absl::StatusOr<std::vector<AutotuneResult>> GemmFusionAutotunerImpl::Profile(
 
   const HloInstruction& root = *fusion_computation->root_instruction();
   BufferComparator comparator(root.shape(),
-                              fusion_computation->parent()->config());
+                          debug_options_.xla_gpu_autotune_gemm_rtol());
 
   TF_ASSIGN_OR_RETURN(auto rz_buffers,
                       RedzoneBuffers::FromInstruction(

--- a/xla/service/gpu/triton_fusion_numerics_verifier.cc
+++ b/xla/service/gpu/triton_fusion_numerics_verifier.cc
@@ -114,7 +114,8 @@ absl::Status CompareBuffers(const ScopedShapedBuffer& current,
                             const ScopedShapedBuffer& expected,
                             const Shape& shape, const HloModuleConfig& config,
                             se::Stream* stream) {
-  BufferComparator comparator(shape, config);
+  BufferComparator comparator(shape, 
+        config.debug_options().xla_gpu_autotune_gemm_rtol());
   TF_ASSIGN_OR_RETURN(bool outputs_match,
                       comparator.CompareEqual(stream, current.root_buffer(),
                                               expected.root_buffer()));

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -870,7 +870,10 @@ message DebugOptions {
   //  all-to-all-done = f32[1,4,8]{1,0,2} all-to-all-done(all-to-all-start)
   bool xla_syntax_sugar_async_ops = 315;
 
-  // Next id: 316
+  // Relative precision for comparing different GEMM solutions 
+  float xla_gpu_autotune_gemm_rtol = 316;
+
+  // Next id: 317
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
Here we add a new flag **xla_gpu_autotune_gemm_rtol** which controls the relative precision used by the BufferComparator (defaults to **0.1**).

Also I added one more "paranoid" level 5 for **xla_gpu_autotune_level** which forces the autotuner to discard solutions with accuracy problems. Long time I was under impression that the autotuner already does it, however this is not the case as outlined [here](https://github.com/ROCm/xla/blob/6301f04c50c7637a65b3e0c6f40be628aa00947f/xla/service/gpu/stream_executor_util.cc#L640). BufferComparator just prints out the error message but **keeps wrong solutions** as possible candidates which could lead to a great confusion. So, the autotune level 5 is supposed to discard solutions with accuracy problems.

Besides, I also did some small refactoring on BufferComparator to simplify the source code and added **verbose** flag in order to mute error messages if needed.

@xla-rotation: could you please have a look?