### PR TITLE
[ROCM][NFC] gpublas-lt refactoring after adding workspace and scratch allocator

### DIFF
--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -404,33 +404,6 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     DeviceMemoryBase aux, DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
     DeviceMemoryBase c_scale, DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
     std::optional<DeviceMemoryBase> workspace,
-    blas::ProfileResult* profile_result) const {
-  return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux,
-                  a_scale, b_scale, c_scale, d_scale, d_amax, workspace,
-                  std::nullopt, profile_result);
-}
-
-// Tensorflow use this API
-absl::Status BlasLt::MatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, DeviceMemoryBase a, DeviceMemoryBase b,
-    const void* beta, DeviceMemoryBase c, DeviceMemoryBase d,
-    const MatmulAlgorithm& algorithm, ScratchAllocator& scratch_allocator,
-    DeviceMemoryBase bias, DeviceMemoryBase aux, DeviceMemoryBase a_scale,
-    DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
-    DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
-    blas::ProfileResult* profile_result) const {
-  return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux,
-                  a_scale, b_scale, c_scale, d_scale, d_amax, std::nullopt,
-                  &scratch_allocator, profile_result);
-}
-
-absl::Status BlasLt::MatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, DeviceMemoryBase a, DeviceMemoryBase b,
-    const void* beta, DeviceMemoryBase c, DeviceMemoryBase d,
-    const MatmulAlgorithm& algorithm, DeviceMemoryBase bias,
-    DeviceMemoryBase aux, DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
-    DeviceMemoryBase c_scale, DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
-    std::optional<DeviceMemoryBase> workspace,
     std::optional<ScratchAllocator*> scratch_allocator,
     blas::ProfileResult* profile_result = nullptr) const {
   TF_ASSIGN_OR_RETURN(
@@ -609,190 +582,73 @@ absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
   std::tuple operand_types{a_desc_.type(), b_desc_.type(), c_desc_.type(),
                            d_desc_.type()};
 
-#define TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(SCALENTYPE, ATYPE, BTYPE, CTYPE, \
-                                            DTYPE)                           \
-  if (operand_types == std::make_tuple(ATYPE, BTYPE, CTYPE, DTYPE)) {        \
+#define TYPED_MATMUL(SCALENTYPE, ATYPE, BTYPE, CTYPE, DTYPE)                 \
+  if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) {             \
     return gpu::BlasLt::MatmulPlan::DoMatmul<                                \
         SCALENTYPE, CudaToNativeT<ATYPE>::type, CudaToNativeT<BTYPE>::type,  \
         CudaToNativeT<CTYPE>::type, CudaToNativeT<DTYPE>::type>(             \
         stream, alpha_, a, b, beta_, c, d, bias, aux, a_scale, b_scale,      \
-        c_scale, d_scale, d_amax, algorithm, *scratch_allocator.value(),     \
+        c_scale, d_scale, d_amax, algorithm, workspace, scratch_allocator,   \
         profile_result);                                                     \
   }
 
-#define TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(SCALENTYPE, ATYPE, BTYPE,   \
-                                                CTYPE, DTYPE)               \
-  if (operand_types == std::make_tuple(ATYPE, BTYPE, CTYPE, DTYPE)) {       \
-    return gpu::BlasLt::MatmulPlan::DoMatmul<                               \
-        SCALENTYPE, CudaToNativeT<ATYPE>::type, CudaToNativeT<BTYPE>::type, \
-        CudaToNativeT<CTYPE>::type, CudaToNativeT<DTYPE>::type>(            \
-        stream, alpha_, a, b, beta_, c, d, bias, aux, a_scale, b_scale,     \
-        c_scale, d_scale, d_amax, algorithm, workspace, profile_result);    \
-  }
-
-  if (workspace.has_value()) {
 #if CUDA_VERSION >= 11080
-    // FP8 compatible type combinations (see cuBLASLt documentation):
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  // FP8 compatible type combinations (see cuBLASLt documentation):
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
 
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_32F, CUDA_R_32F)
 
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
 #endif
 
-    // Other data types:
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, CUDA_R_16BF, CUDA_R_16BF,
-                                            CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, CUDA_R_16F, CUDA_R_16F,
-                                            CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, CUDA_R_16BF, CUDA_R_16BF,
-                                            CUDA_R_32F, CUDA_R_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, CUDA_R_16F, CUDA_R_16F,
-                                            CUDA_R_32F, CUDA_R_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, CUDA_R_32F, CUDA_R_32F,
-                                            CUDA_R_32F, CUDA_R_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(double, CUDA_R_64F, CUDA_R_64F,
-                                            CUDA_R_64F, CUDA_R_64F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(xla::complex64, CUDA_C_32F,
-                                            CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(xla::complex128, CUDA_C_64F,
-                                            CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
-  } else if (scratch_allocator.has_value()) {
-#if CUDA_VERSION >= 11080
-    // FP8 compatible type combinations (see cuBLASLt documentation):
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3,
-                                        CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3,
-                                        CUDA_R_16BF, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3,
-                                        CUDA_R_16F, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3,
-                                        CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3,
-                                        CUDA_R_32F, CUDA_R_32F)
+  // Other data types:
+  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(float, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(double, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F)
+  TYPED_MATMUL(xla::complex64, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
+  TYPED_MATMUL(xla::complex128, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
 
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2,
-                                        CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2,
-                                        CUDA_R_16BF, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2,
-                                        CUDA_R_16BF, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2,
-                                        CUDA_R_16F, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2,
-                                        CUDA_R_16F, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2,
-                                        CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2,
-                                        CUDA_R_32F, CUDA_R_32F)
-
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3,
-                                        CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3,
-                                        CUDA_R_16BF, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3,
-                                        CUDA_R_16BF, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3,
-                                        CUDA_R_16F, CUDA_R_8F_E4M3)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3,
-                                        CUDA_R_16F, CUDA_R_8F_E5M2)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3,
-                                        CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3,
-                                        CUDA_R_32F, CUDA_R_32F)
-#endif
-
-    // Other data types:
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_16BF, CUDA_R_16BF,
-                                        CUDA_R_16BF, CUDA_R_16BF)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_16F, CUDA_R_16F,
-                                        CUDA_R_16F, CUDA_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_16BF, CUDA_R_16BF,
-                                        CUDA_R_32F, CUDA_R_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_16F, CUDA_R_16F,
-                                        CUDA_R_32F, CUDA_R_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, CUDA_R_32F, CUDA_R_32F,
-                                        CUDA_R_32F, CUDA_R_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(double, CUDA_R_64F, CUDA_R_64F,
-                                        CUDA_R_64F, CUDA_R_64F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(xla::complex64, CUDA_C_32F, CUDA_C_32F,
-                                        CUDA_C_32F, CUDA_C_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(xla::complex128, CUDA_C_64F, CUDA_C_64F,
-                                        CUDA_C_64F, CUDA_C_64F)
-  }
-
-#undef TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR
-#undef TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE
+#undef TYPED_MATMUL
 
   return xla::Internal("Unexpected dtype");
-}
-
-absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
-    Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-    DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-    DeviceMemoryBase bias_buffer,  // may be null
-    DeviceMemoryBase aux_buffer,   // may be null
-    DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-    DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-    DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-    ScratchAllocator& scratch_allocator,
-    blas::ProfileResult* profile_result) const {
-  return ExecuteOnStream(stream, a_buffer, b_buffer, c_buffer, d_buffer,
-                         bias_buffer, aux_buffer, a_scale_buffer,
-                         b_scale_buffer, c_scale_buffer, d_scale_buffer,
-                         d_amax_buffer, algorithm, std::nullopt,
-                         &scratch_allocator, profile_result);
-}
-
-absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
-    Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-    DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-    DeviceMemoryBase bias_buffer,  // may be null
-    DeviceMemoryBase aux_buffer,   // may be null
-    DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-    DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-    DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-    std::optional<DeviceMemoryBase> workspace,
-    blas::ProfileResult* profile_result) const {
-  return ExecuteOnStream(
-      stream, a_buffer, b_buffer, c_buffer, d_buffer, bias_buffer, aux_buffer,
-      a_scale_buffer, b_scale_buffer, c_scale_buffer, d_scale_buffer,
-      d_amax_buffer, algorithm, workspace, std::nullopt, profile_result);
 }
 
 }  // namespace cuda

--- a/xla/stream_executor/cuda/cuda_blas_lt.h
+++ b/xla/stream_executor/cuda/cuda_blas_lt.h
@@ -113,31 +113,9 @@ class BlasLt : public gpu::BlasLt {
         DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
         DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
         DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-        ScratchAllocator& scratch_allocator,
-        blas::ProfileResult* profile_result = nullptr) const override;
-
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-        DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-        DeviceMemoryBase bias_buffer,  // may be null
-        DeviceMemoryBase aux_buffer,   // may be null
-        DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-        DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-        DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-        std::optional<DeviceMemoryBase> workspace,
-        blas::ProfileResult* profile_result = nullptr) const override;
-
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-        DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-        DeviceMemoryBase bias_buffer,  // may be null
-        DeviceMemoryBase aux_buffer,   // may be null
-        DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-        DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-        DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
         std::optional<DeviceMemoryBase> workspace,
         std::optional<ScratchAllocator*> scratch_allocator,
-        blas::ProfileResult* profile_result = nullptr) const;
+        blas::ProfileResult* profile_result = nullptr) const override;
 
     absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
         size_t max_algorithm_count, size_t max_workspace_size) const override;
@@ -147,30 +125,6 @@ class BlasLt : public gpu::BlasLt {
                                 bool beta_on_device, blas::DataType A_type,
                                 blas::DataType B_type, blas::DataType C_type,
                                 blas::DataType D_type) const override;
-
-    // API that uses scratch_allocator to allocate workspace
-    absl::Status DoMatmul(Stream* stream, const void* alpha, DeviceMemoryBase a,
-                          DeviceMemoryBase b, const void* beta,
-                          DeviceMemoryBase c, DeviceMemoryBase d,
-                          const MatmulAlgorithm& algorithm,
-                          ScratchAllocator& scratch_allocator,
-                          DeviceMemoryBase bias, DeviceMemoryBase aux,
-                          DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
-                          DeviceMemoryBase c_scale, DeviceMemoryBase d_scale,
-                          DeviceMemoryBase d_amax,
-                          blas::ProfileResult* profile_result) const override;
-
-    // API that uses pre-allocated buffer as workspace
-    absl::Status DoMatmul(Stream* stream, const void* alpha, DeviceMemoryBase a,
-                          DeviceMemoryBase b, const void* beta,
-                          DeviceMemoryBase c, DeviceMemoryBase d,
-                          const MatmulAlgorithm& algorithm,
-                          DeviceMemoryBase bias, DeviceMemoryBase aux,
-                          DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
-                          DeviceMemoryBase c_scale, DeviceMemoryBase d_scale,
-                          DeviceMemoryBase d_amax,
-                          std::optional<DeviceMemoryBase> workspace,
-                          blas::ProfileResult* profile_result) const override;
 
     absl::Status DoMatmul(Stream* stream, const void* alpha, DeviceMemoryBase a,
                           DeviceMemoryBase b, const void* beta,

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -191,7 +191,7 @@ struct BlasLt {
         const HostOrDeviceScalar<Scale>& beta, const DeviceMemory<C>& c,
         DeviceMemory<D>& d, const MatmulAlgorithm& algorithm,
         const DeviceMemory<C>& bias = {},
-        const DeviceMemoryBase& aux = {},
+        const DeviceMemoryBase& aux = DeviceMemoryBase{nullptr, 0},
         const DeviceMemory<Scale>& a_scale = {},
         const DeviceMemory<Scale>& b_scale = {},
         const DeviceMemory<Scale>& c_scale = {},

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -148,34 +148,10 @@ struct BlasLt {
     // DoMatmul provides two sets of API for maintaning compatibility for XLA,
     // and TF. One set API uses scratch_allocator to allocate workspace, and one
     // set API allow uses to provide pre-allocated buffer as workspace.
-    //
-    // API that uses scratch_allocator to allocate workspace
-    template <typename A, typename B, typename C, typename D, typename Scale>
-    absl::Status DoMatmul(Stream* stream,
-                          const HostOrDeviceScalar<Scale>& alpha,
-                          const DeviceMemory<A>& a, const DeviceMemory<B>& b,
-                          const HostOrDeviceScalar<Scale>& beta,
-                          const DeviceMemory<C>& c, DeviceMemory<D>& d,
-                          const MatmulAlgorithm& algorithm,
-                          ScratchAllocator& scratch_allocator,
-                          const DeviceMemory<C>& bias = {},
-                          const DeviceMemoryBase& aux = DeviceMemory<uint8_t>{},
-                          const DeviceMemory<Scale>& a_scale = {},
-                          const DeviceMemory<Scale>& b_scale = {},
-                          const DeviceMemory<Scale>& c_scale = {},
-                          const DeviceMemory<Scale>& d_scale = {},
-                          const DeviceMemory<Scale>& d_amax = {},
-                          blas::ProfileResult* profile_result = nullptr) const {
-      TF_RETURN_IF_ERROR(ValidateInputs(
-          blas::ToDataType<Scale>::value, alpha.on_device(), beta.on_device(),
-          blas::ToDataType<A>::value, blas::ToDataType<B>::value,
-          blas::ToDataType<C>::value, blas::ToDataType<D>::value));
 
-      return DoMatmul(stream, alpha.opaque(), a, b, beta.opaque(), c, d,
-                      algorithm, bias, aux, a_scale, b_scale, c_scale, d_scale,
-                      d_amax, std::nullopt, &scratch_allocator, profile_result);
-    }
-
+    // API that uses scratch_allocator to allocate workspace 
+    // This function is also used by Tensorflow: 
+    // see tensorflow/core/kernels/matmul_util.h.
     template <typename A, typename B, typename C, typename D, typename Scale>
     absl::Status DoMatmul(Stream* stream,
                           const HostOrDeviceScalar<Scale>& alpha,
@@ -187,9 +163,8 @@ struct BlasLt {
                           const DeviceMemory<C>& bias = {},
                           const DeviceMemoryBase& aux = DeviceMemory<uint8_t>{},
                           blas::ProfileResult* profile_result = nullptr) const {
-      return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm,
-                      scratch_allocator, bias, aux, {}, {}, {}, {}, {},
-                      profile_result);
+      return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux, {},
+              {}, {}, {}, {}, std::nullopt, scratch_allocator, profile_result);
     }
 
     // API that uses pre-allocated buffer as workspace
@@ -201,12 +176,29 @@ struct BlasLt {
         DeviceMemory<D>& d, const MatmulAlgorithm& algorithm,
         const DeviceMemory<C>& bias = {},
         const DeviceMemoryBase& aux = DeviceMemory<uint8_t>{},
+        std::optional<DeviceMemoryBase> workspace = std::nullopt,
+        blas::ProfileResult* profile_result = nullptr) const {
+      return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux, {},
+                      {}, {}, {}, {}, workspace, std::nullopt, profile_result);
+    }
+
+    // The most general form: uses pre-allocated buffer workspace or 
+    // provided scratch allocator
+    template <typename A, typename B, typename C, typename D, typename Scale>
+    absl::Status DoMatmul(
+        Stream* stream, const HostOrDeviceScalar<Scale>& alpha,
+        const DeviceMemory<A>& a, const DeviceMemory<B>& b,
+        const HostOrDeviceScalar<Scale>& beta, const DeviceMemory<C>& c,
+        DeviceMemory<D>& d, const MatmulAlgorithm& algorithm,
+        const DeviceMemory<C>& bias = {},
+        const DeviceMemoryBase& aux = {},
         const DeviceMemory<Scale>& a_scale = {},
         const DeviceMemory<Scale>& b_scale = {},
         const DeviceMemory<Scale>& c_scale = {},
         const DeviceMemory<Scale>& d_scale = {},
         const DeviceMemory<Scale>& d_amax = {},
         std::optional<DeviceMemoryBase> workspace = std::nullopt,
+        std::optional<ScratchAllocator*> scratch_allocator = std::nullopt,
         blas::ProfileResult* profile_result = nullptr) const {
       TF_RETURN_IF_ERROR(ValidateInputs(
           blas::ToDataType<Scale>::value, alpha.on_device(), beta.on_device(),
@@ -215,34 +207,47 @@ struct BlasLt {
 
       return DoMatmul(stream, alpha.opaque(), a, b, beta.opaque(), c, d,
                       algorithm, bias, aux, a_scale, b_scale, c_scale, d_scale,
-                      d_amax, workspace, std::nullopt, profile_result);
+                      d_amax, workspace, scratch_allocator, profile_result);
     }
 
-    template <typename A, typename B, typename C, typename D, typename Scale>
-    absl::Status DoMatmul(
-        Stream* stream, const HostOrDeviceScalar<Scale>& alpha,
-        const DeviceMemory<A>& a, const DeviceMemory<B>& b,
-        const HostOrDeviceScalar<Scale>& beta, const DeviceMemory<C>& c,
-        DeviceMemory<D>& d, const MatmulAlgorithm& algorithm,
-        const DeviceMemory<C>& bias = {},
-        const DeviceMemoryBase& aux = DeviceMemory<uint8_t>{},
-        std::optional<DeviceMemoryBase> workspace = std::nullopt,
-        blas::ProfileResult* profile_result = nullptr) const {
-      return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux, {},
-                      {}, {}, {}, {}, workspace, profile_result);
+    // API that uses scratch_allocator to allocate workspace
+    absl::Status ExecuteOnStream(
+      Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
+      DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
+      DeviceMemoryBase bias_buffer,  // may be null
+      DeviceMemoryBase aux_buffer,   // may be null
+      DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
+      DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
+      DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
+      ScratchAllocator& scratch_allocator,
+      blas::ProfileResult* profile_result = nullptr) const {
+
+      return ExecuteOnStream(stream, a_buffer, b_buffer, c_buffer, d_buffer,
+                         bias_buffer, aux_buffer, a_scale_buffer,
+                         b_scale_buffer, c_scale_buffer, d_scale_buffer,
+                         d_amax_buffer, algorithm, std::nullopt,
+                         &scratch_allocator, profile_result);
     }
 
-    virtual absl::Status ExecuteOnStream(
-        Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-        DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-        DeviceMemoryBase bias_buffer,  // may be null
-        DeviceMemoryBase aux_buffer,   // may be null
-        DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-        DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-        DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-        ScratchAllocator& scratch_allocator,
-        blas::ProfileResult* profile_result = nullptr) const = 0;
+    // API that uses pre-allocated buffer as workspace
+    absl::Status ExecuteOnStream(
+      Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
+      DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
+      DeviceMemoryBase bias_buffer,  // may be null
+      DeviceMemoryBase aux_buffer,   // may be null
+      DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
+      DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
+      DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
+      std::optional<DeviceMemoryBase> workspace,
+      blas::ProfileResult* profile_result = nullptr) const {
+  
+      return ExecuteOnStream(
+        stream, a_buffer, b_buffer, c_buffer, d_buffer, bias_buffer, aux_buffer,
+        a_scale_buffer, b_scale_buffer, c_scale_buffer, d_scale_buffer,
+        d_amax_buffer, algorithm, workspace, std::nullopt, profile_result);
+    }
 
+    // The most general form: to be implemented by derived clases.
     virtual absl::Status ExecuteOnStream(
         Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
         DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
@@ -252,7 +257,8 @@ struct BlasLt {
         DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
         DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
         std::optional<DeviceMemoryBase> workspace,
-        blas::ProfileResult* profile_result = nullptr) const = 0;
+        std::optional<ScratchAllocator*> scratch_allocator,
+        blas::ProfileResult* profile_result) const = 0;
 
     // Returns a list of supported algorithms for DoMatmul. The algorithms are
     // returned in the order of increasing estimated compute time according to
@@ -275,39 +281,8 @@ struct BlasLt {
                           DeviceMemoryBase c_scale, DeviceMemoryBase d_scale,
                           DeviceMemoryBase d_amax,
                           const MatmulAlgorithm& algorithm,
-                          ScratchAllocator& scratch_allocator,
-                          blas::ProfileResult* profile_result) const {
-      Scale salpha;
-      if constexpr (std::is_same_v<Scale, xla::complex64> ||
-                    std::is_same_v<Scale, xla::complex128>) {
-        salpha = static_cast<Scale>(alpha);
-      } else {
-        salpha = static_cast<Scale>(alpha.real());
-      }
-      Scale sbeta = static_cast<Scale>(beta);
-
-      DeviceMemory<D> output(d);
-      return DoMatmul<A, B, C, D, Scale>(
-          stream, HostOrDeviceScalar<Scale>(salpha), DeviceMemory<A>(a),
-          DeviceMemory<B>(b), HostOrDeviceScalar<Scale>(sbeta),
-          DeviceMemory<C>(c), output, algorithm, scratch_allocator,
-          DeviceMemory<C>(bias), aux, DeviceMemory<Scale>(a_scale),
-          DeviceMemory<Scale>(b_scale), DeviceMemory<Scale>(c_scale),
-          DeviceMemory<Scale>(d_scale), DeviceMemory<Scale>(d_amax),
-          profile_result);
-    }
-
-    template <typename Scale, typename A, typename B = A, typename C = A,
-              typename D = A>
-    absl::Status DoMatmul(Stream* stream, xla::complex128 alpha,
-                          DeviceMemoryBase a, DeviceMemoryBase b, double beta,
-                          DeviceMemoryBase c, DeviceMemoryBase d,
-                          DeviceMemoryBase bias, DeviceMemoryBase aux,
-                          DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
-                          DeviceMemoryBase c_scale, DeviceMemoryBase d_scale,
-                          DeviceMemoryBase d_amax,
-                          const MatmulAlgorithm& algorithm,
                           std::optional<DeviceMemoryBase> workspace,
+                          std::optional<ScratchAllocator*> scratch_allocator,
                           blas::ProfileResult* profile_result = nullptr) const {
       Scale salpha;
       if constexpr (std::is_same_v<Scale, xla::complex64> ||
@@ -317,43 +292,25 @@ struct BlasLt {
         salpha = static_cast<Scale>(alpha.real());
       }
       Scale sbeta = static_cast<Scale>(beta);
-
       DeviceMemory<D> output(d);
+
       return DoMatmul<A, B, C, D, Scale>(
           stream, HostOrDeviceScalar<Scale>(salpha), DeviceMemory<A>(a),
           DeviceMemory<B>(b), HostOrDeviceScalar<Scale>(sbeta),
           DeviceMemory<C>(c), output, algorithm, DeviceMemory<C>(bias), aux,
           DeviceMemory<Scale>(a_scale), DeviceMemory<Scale>(b_scale),
           DeviceMemory<Scale>(c_scale), DeviceMemory<Scale>(d_scale),
-          DeviceMemory<Scale>(d_amax), workspace, profile_result);
+          DeviceMemory<Scale>(d_amax), workspace, scratch_allocator,
+          profile_result);
     }
 
-    // used internally by template DoMatmul function to validate inputs
+    // This is used internally by template DoMatmul function to validate inputs
     virtual absl::Status ValidateInputs(
         blas::DataType scale_type, bool alpha_on_device, bool beta_on_device,
         blas::DataType A_type, blas::DataType B_type, blas::DataType C_type,
         blas::DataType D_type) const = 0;
 
-    virtual absl::Status DoMatmul(
-        Stream* stream, const void* alpha, DeviceMemoryBase a,
-        DeviceMemoryBase b, const void* beta, DeviceMemoryBase c,
-        DeviceMemoryBase d, const MatmulAlgorithm& algorithm,
-        ScratchAllocator& scratch_allocator, DeviceMemoryBase bias,
-        DeviceMemoryBase aux, DeviceMemoryBase a_scale,
-        DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
-        DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
-        blas::ProfileResult* profile_result = nullptr) const = 0;
-
-    virtual absl::Status DoMatmul(
-        Stream* stream, const void* alpha, DeviceMemoryBase a,
-        DeviceMemoryBase b, const void* beta, DeviceMemoryBase c,
-        DeviceMemoryBase d, const MatmulAlgorithm& algorithm,
-        DeviceMemoryBase bias, DeviceMemoryBase aux, DeviceMemoryBase a_scale,
-        DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
-        DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
-        std::optional<DeviceMemoryBase> workspace,
-        blas::ProfileResult* profile_result = nullptr) const = 0;
-
+    // The most general version to be implemented by derived classes
     virtual absl::Status DoMatmul(
         Stream* stream, const void* alpha, DeviceMemoryBase a,
         DeviceMemoryBase b, const void* beta, DeviceMemoryBase c,

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -191,7 +191,7 @@ struct BlasLt {
         const HostOrDeviceScalar<Scale>& beta, const DeviceMemory<C>& c,
         DeviceMemory<D>& d, const MatmulAlgorithm& algorithm,
         const DeviceMemory<C>& bias = {},
-        const DeviceMemoryBase& aux = DeviceMemoryBase{nullptr, 0},
+        const DeviceMemoryBase& aux = DeviceMemoryBase{},
         const DeviceMemory<Scale>& a_scale = {},
         const DeviceMemory<Scale>& b_scale = {},
         const DeviceMemory<Scale>& c_scale = {},

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -389,33 +389,6 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     DeviceMemoryBase aux, DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
     DeviceMemoryBase c_scale, DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
     std::optional<DeviceMemoryBase> workspace,
-    blas::ProfileResult* profile_result) const {
-  return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux,
-                  a_scale, b_scale, c_scale, d_scale, d_amax, workspace,
-                  std::nullopt, profile_result);
-}
-
-// Tensorflow use this API
-absl::Status BlasLt::MatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, DeviceMemoryBase a, DeviceMemoryBase b,
-    const void* beta, DeviceMemoryBase c, DeviceMemoryBase d,
-    const MatmulAlgorithm& algorithm, ScratchAllocator& scratch_allocator,
-    DeviceMemoryBase bias, DeviceMemoryBase aux, DeviceMemoryBase a_scale,
-    DeviceMemoryBase b_scale, DeviceMemoryBase c_scale,
-    DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
-    blas::ProfileResult* profile_result) const {
-  return DoMatmul(stream, alpha, a, b, beta, c, d, algorithm, bias, aux,
-                  a_scale, b_scale, c_scale, d_scale, d_amax, std::nullopt,
-                  &scratch_allocator, profile_result);
-}
-
-absl::Status BlasLt::MatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, DeviceMemoryBase a, DeviceMemoryBase b,
-    const void* beta, DeviceMemoryBase c, DeviceMemoryBase d,
-    const MatmulAlgorithm& algorithm, DeviceMemoryBase bias,
-    DeviceMemoryBase aux, DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
-    DeviceMemoryBase c_scale, DeviceMemoryBase d_scale, DeviceMemoryBase d_amax,
-    std::optional<DeviceMemoryBase> workspace,
     std::optional<ScratchAllocator*> scratch_allocator,
     blas::ProfileResult* profile_result) const {
   absl::Status status =
@@ -575,134 +548,46 @@ absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
   std::tuple operand_types{a_desc_.type(), b_desc_.type(), c_desc_.type(),
                            d_desc_.type()};
 
-#define TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(SCALENTYPE, ATYPE, BTYPE, CTYPE, \
-                                            DTYPE)                           \
-  if (operand_types == std::make_tuple(ATYPE, BTYPE, CTYPE, DTYPE)) {        \
+#define TYPED_MATMUL(SCALENTYPE, ATYPE, BTYPE, CTYPE, DTYPE)                 \
+  if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) {             \
     return gpu::BlasLt::MatmulPlan::DoMatmul<                                \
         SCALENTYPE, HipToNativeT<ATYPE>::type, HipToNativeT<BTYPE>::type,    \
         HipToNativeT<CTYPE>::type, HipToNativeT<DTYPE>::type>(               \
         stream, alpha_, a, b, beta_, c, d, bias, aux, a_scale, b_scale,      \
-        c_scale, d_scale, d_amax, algorithm, *scratch_allocator.value(),     \
-        profile_result);                                                     \
+        c_scale, d_scale, d_amax, algorithm, workspace,                      \
+        scratch_allocator, profile_result);                                  \
   }
 
-#define TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(SCALENTYPE, ATYPE, BTYPE, \
-                                                CTYPE, DTYPE)             \
-  if (operand_types == std::make_tuple(ATYPE, BTYPE, CTYPE, DTYPE)) {     \
-    return gpu::BlasLt::MatmulPlan::DoMatmul<                             \
-        SCALENTYPE, HipToNativeT<ATYPE>::type, HipToNativeT<BTYPE>::type, \
-        HipToNativeT<CTYPE>::type, HipToNativeT<DTYPE>::type>(            \
-        stream, alpha_, a, b, beta_, c, d, bias, aux, a_scale, b_scale,   \
-        c_scale, d_scale, d_amax, algorithm, workspace, profile_result);  \
-  }
-
-  if (workspace.has_value()) {
 #if TF_ROCM_VERSION >= 60000
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F, HIP_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F, HIP_R_32F)
 
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E5M2_FNUZ, HIP_R_16F, HIP_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E5M2_FNUZ, HIP_R_32F, HIP_R_32F)
 
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F, HIP_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(
+  TYPED_MATMUL(
         float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F, HIP_R_32F)
 #endif
 
-    // Other data types:
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, HIP_R_16BF, HIP_R_16BF,
-                                            HIP_R_16BF, HIP_R_16BF)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, HIP_R_16F, HIP_R_16F,
-                                            HIP_R_16F, HIP_R_16F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, HIP_R_16BF, HIP_R_16BF,
-                                            HIP_R_32F, HIP_R_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, HIP_R_16F, HIP_R_16F,
-                                            HIP_R_32F, HIP_R_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(float, HIP_R_32F, HIP_R_32F,
-                                            HIP_R_32F, HIP_R_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(double, HIP_R_64F, HIP_R_64F,
-                                            HIP_R_64F, HIP_R_64F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(complex64, HIP_C_32F, HIP_C_32F,
-                                            HIP_C_32F, HIP_C_32F)
-    TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE(complex128, HIP_C_64F, HIP_C_64F,
-                                            HIP_C_64F, HIP_C_64F)
-  } else if (scratch_allocator.has_value()) {
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(
-        float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F, HIP_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(
-        float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F, HIP_R_32F)
+  // Other data types:
+  TYPED_MATMUL(float, HIP_R_16BF, HIP_R_16BF, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_16BF, HIP_R_16BF, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_16F, HIP_R_16F, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_32F, HIP_R_32F, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(double, HIP_R_64F, HIP_R_64F, HIP_R_64F, HIP_R_64F)
+  TYPED_MATMUL(complex64, HIP_C_32F, HIP_C_32F, HIP_C_32F, HIP_C_32F)
+  TYPED_MATMUL(complex128, HIP_C_64F, HIP_C_64F, HIP_C_64F, HIP_C_64F)
 
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(
-        float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E5M2_FNUZ, HIP_R_16F, HIP_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(
-        float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E5M2_FNUZ, HIP_R_32F, HIP_R_32F)
-
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(
-        float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F, HIP_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(
-        float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F, HIP_R_32F)
-
-    // Other data types:
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, HIP_R_16BF, HIP_R_16BF,
-                                        HIP_R_16BF, HIP_R_16BF)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, HIP_R_16F, HIP_R_16F, HIP_R_16F,
-                                        HIP_R_16F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, HIP_R_16BF, HIP_R_16BF,
-                                        HIP_R_32F, HIP_R_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, HIP_R_16F, HIP_R_16F, HIP_R_32F,
-                                        HIP_R_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(float, HIP_R_32F, HIP_R_32F, HIP_R_32F,
-                                        HIP_R_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(double, HIP_R_64F, HIP_R_64F, HIP_R_64F,
-                                        HIP_R_64F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(complex64, HIP_C_32F, HIP_C_32F,
-                                        HIP_C_32F, HIP_C_32F)
-    TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR(complex128, HIP_C_64F, HIP_C_64F,
-                                        HIP_C_64F, HIP_C_64F)
-  }
-
-#undef TYPED_MATMUL_WITH_SCRATCH_ALLOCATOR
-#undef TYPED_MATMUL_WITH_PREALLOCATE_WORKSPACE
+#undef TYPED_MATMUL
 
   return xla::Internal("Unexpected dtype");
-}
-
-absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
-    Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-    DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-    DeviceMemoryBase bias_buffer,  // may be null
-    DeviceMemoryBase aux_buffer,   // may be null
-    DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-    DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-    DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-    ScratchAllocator& scratch_allocator,
-    blas::ProfileResult* profile_result) const {
-  return ExecuteOnStream(stream, a_buffer, b_buffer, c_buffer, d_buffer,
-                         bias_buffer, aux_buffer, a_scale_buffer,
-                         b_scale_buffer, c_scale_buffer, d_scale_buffer,
-                         d_amax_buffer, algorithm, std::nullopt,
-                         &scratch_allocator, profile_result);
-}
-
-absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
-    Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-    DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-    DeviceMemoryBase bias_buffer,  // may be null
-    DeviceMemoryBase aux_buffer,   // may be null
-    DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-    DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-    DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-    std::optional<DeviceMemoryBase> workspace,
-    blas::ProfileResult* profile_result) const {
-  return ExecuteOnStream(
-      stream, a_buffer, b_buffer, c_buffer, d_buffer, bias_buffer, aux_buffer,
-      a_scale_buffer, b_scale_buffer, c_scale_buffer, d_scale_buffer,
-      d_amax_buffer, algorithm, workspace, std::nullopt, profile_result);
 }
 
 }  // namespace rocm

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -110,31 +110,9 @@ class BlasLt : public gpu::BlasLt {
         DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
         DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
         DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-        ScratchAllocator& scratch_allocator,
-        blas::ProfileResult* profile_result = nullptr) const override;
-
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-        DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-        DeviceMemoryBase bias_buffer,  // may be null
-        DeviceMemoryBase aux_buffer,   // may be null
-        DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-        DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-        DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
-        std::optional<DeviceMemoryBase> workspace,
-        blas::ProfileResult* profile_result = nullptr) const override;
-
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceMemoryBase a_buffer, DeviceMemoryBase b_buffer,
-        DeviceMemoryBase c_buffer, DeviceMemoryBase d_buffer,
-        DeviceMemoryBase bias_buffer,  // may be null
-        DeviceMemoryBase aux_buffer,   // may be null
-        DeviceMemoryBase a_scale_buffer, DeviceMemoryBase b_scale_buffer,
-        DeviceMemoryBase c_scale_buffer, DeviceMemoryBase d_scale_buffer,
-        DeviceMemoryBase d_amax_buffer, const MatmulAlgorithm& algorithm,
         std::optional<DeviceMemoryBase> workspace,
         std::optional<ScratchAllocator*> scratch_allocator,
-        blas::ProfileResult* profile_result = nullptr) const;
+        blas::ProfileResult* profile_result) const override;
 
     absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
         size_t max_algorithm_count, size_t max_workspace_size) const override;
@@ -144,30 +122,6 @@ class BlasLt : public gpu::BlasLt {
                                 bool beta_on_device, blas::DataType A_type,
                                 blas::DataType B_type, blas::DataType C_type,
                                 blas::DataType D_type) const override;
-
-    // API that uses scratch_allocator to allocate workspace
-    absl::Status DoMatmul(Stream* stream, const void* alpha, DeviceMemoryBase a,
-                          DeviceMemoryBase b, const void* beta,
-                          DeviceMemoryBase c, DeviceMemoryBase d,
-                          const MatmulAlgorithm& algorithm,
-                          ScratchAllocator& scratch_allocator,
-                          DeviceMemoryBase bias, DeviceMemoryBase aux,
-                          DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
-                          DeviceMemoryBase c_scale, DeviceMemoryBase d_scale,
-                          DeviceMemoryBase d_amax,
-                          blas::ProfileResult* profile_result) const override;
-
-    // API that uses pre-allocated buffer as workspace
-    absl::Status DoMatmul(Stream* stream, const void* alpha, DeviceMemoryBase a,
-                          DeviceMemoryBase b, const void* beta,
-                          DeviceMemoryBase c, DeviceMemoryBase d,
-                          const MatmulAlgorithm& algorithm,
-                          DeviceMemoryBase bias, DeviceMemoryBase aux,
-                          DeviceMemoryBase a_scale, DeviceMemoryBase b_scale,
-                          DeviceMemoryBase c_scale, DeviceMemoryBase d_scale,
-                          DeviceMemoryBase d_amax,
-                          std::optional<DeviceMemoryBase> workspace,
-                          blas::ProfileResult* profile_result) const override;
 
     absl::Status DoMatmul(Stream* stream, const void* alpha, DeviceMemoryBase a,
                           DeviceMemoryBase b, const void* beta,


### PR DESCRIPTION
This PR https://github.com/openxla/xla/pull/11514 added workspace allocation to cublas-lt. Basically, it doubled the implementation of a number of functions in gpu/cu/hipblas-lt, i.e. now we have:

```
DoMatmul(..., std::optional<DeviceMemoryBase> workspace)
DoMatmul(..., std::optional<ScratchAllocator*> scratch_allocator)
DoMatmul(..., std::optional<DeviceMemoryBase> workspace, std::optional<ScratchAllocator*> scratch_allocator)
```
and the same holds for ```ExecuteOnStream```. This makes gpublas_lt interface barely readable.  The first two functions outlined above are just forwarding calls to the 3rd most generic one. Therefore, I do not see any need to implement these inside the derived classes, i.e. hip_blas_lt.h and cuda_blas_lt.h. Instead, forwarding can be handled in gpu_blas_lt.h interface.

@xla-rotation: could you please have a look?

