### PR TITLE
[ROCM] adding new ROCM-6.2 features: hipGetFuncBySymbol and error codes

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1737,6 +1737,9 @@ xla_test(
 xla_test(
     name = "gemm_algorithm_picker_test",
     srcs = if_gpu_is_configured(["gemm_algorithm_picker_test.cc"]),
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
+        "TENSORFLOW_USE_ROCM=1",
+    ]),
     backends = [
         "gpu_v100",
         "gpu_amd_any",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1737,9 +1737,6 @@ xla_test(
 xla_test(
     name = "gemm_algorithm_picker_test",
     srcs = if_gpu_is_configured(["gemm_algorithm_picker_test.cc"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
     backends = [
         "gpu_v100",
         "gpu_amd_any",

--- a/xla/stream_executor/rocm/rocblas_wrapper.h
+++ b/xla/stream_executor/rocm/rocblas_wrapper.h
@@ -275,9 +275,7 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
   __macro(rocblas_destroy_handle)                        \
   __macro(rocblas_get_stream)                            \
   __macro(rocblas_set_stream)                            \
-  __macro(rocblas_set_atomics_mode)                      \
-  __macro(rocblas_get_version_string)                    \
-  __macro(rocblas_get_version_string_size)
+  __macro(rocblas_set_atomics_mode)
 
 // clang-format on
 

--- a/xla/stream_executor/rocm/rocblas_wrapper.h
+++ b/xla/stream_executor/rocm/rocblas_wrapper.h
@@ -22,6 +22,8 @@ limitations under the License.
 
 // needed for rocblas_gemm_ex_get_solutions* functionality
 #define ROCBLAS_BETA_FEATURES_API
+
+#include "rocm/rocm_config.h"
 #include "rocm/include/rocblas/rocblas.h"
 #include "xla/stream_executor/gpu/gpu_activation.h"
 #include "xla/stream_executor/platform/dso_loader.h"
@@ -280,6 +282,18 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
 // clang-format on
 
 FOREACH_ROCBLAS_API(ROCBLAS_API_WRAPPER)
+
+#if TF_ROCM_VERSION >= 60200
+
+// clang-format off
+#define FOREACH_ROCBLAS_API_62(__macro)            \
+  __macro(rocblas_get_version_string_size)         \
+  __macro(rocblas_get_version_string)
+// clang-format on
+
+FOREACH_ROCBLAS_API_62(ROCBLAS_API_WRAPPER)
+
+#endif // TF_ROCM_VERSION >= 60200
 
 }  // namespace wrap
 }  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -1259,7 +1259,7 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
 }
 
 absl::Status ROCMBlas::GetVersion(std::string *version) {
-#if TF_ROCM_VERSION > 60100  // Not available in ROCM-6.1
+#if TF_ROCM_VERSION >= 60200  // Not available in ROCM-6.1
   absl::MutexLock lock{&mu_};
   size_t len = 0;
   if (auto res = wrap::rocblas_get_version_string_size(&len);

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -1273,7 +1273,7 @@ absl::Status ROCMBlas::GetVersion(std::string *version) {
     return absl::InternalError(
         absl::StrCat("GetVersion failed with: ", ToString(res)));
   }
-  *version = string(buf.begin(), buf.end());
+  *version = std::string(buf.begin(), buf.end());
   return absl::OkStatus();
 #else
   return absl::UnimplementedError("");

--- a/xla/stream_executor/rocm/rocm_driver.cc
+++ b/xla/stream_executor/rocm/rocm_driver.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/synchronization/notification.h"
+
 #include "xla/stream_executor/gpu/gpu_diagnostics.h"
 #include "xla/stream_executor/gpu/gpu_driver.h"
 #include "xla/stream_executor/platform/port.h"
@@ -110,6 +111,31 @@ std::string ToString(hipError_t result) {
       OSTREAM_ROCM_ERROR(ContextAlreadyInUse)
       OSTREAM_ROCM_ERROR(PeerAccessUnsupported)
       OSTREAM_ROCM_ERROR(Unknown)  // Unknown internal error to ROCM.
+#if TF_ROCM_VERSION >= 60200
+    OSTREAM_ROCM_ERROR(LaunchTimeOut)
+    OSTREAM_ROCM_ERROR(PeerAccessAlreadyEnabled)
+    OSTREAM_ROCM_ERROR(PeerAccessNotEnabled)
+    OSTREAM_ROCM_ERROR(SetOnActiveProcess)
+    OSTREAM_ROCM_ERROR(ContextIsDestroyed)
+    OSTREAM_ROCM_ERROR(Assert)
+    OSTREAM_ROCM_ERROR(HostMemoryAlreadyRegistered)
+    OSTREAM_ROCM_ERROR(HostMemoryNotRegistered)
+    OSTREAM_ROCM_ERROR(LaunchFailure)
+    OSTREAM_ROCM_ERROR(CooperativeLaunchTooLarge)
+    OSTREAM_ROCM_ERROR(NotSupported)
+    OSTREAM_ROCM_ERROR(StreamCaptureUnsupported)
+    OSTREAM_ROCM_ERROR(StreamCaptureInvalidated)
+    OSTREAM_ROCM_ERROR(StreamCaptureMerge)
+    OSTREAM_ROCM_ERROR(StreamCaptureUnmatched)
+    OSTREAM_ROCM_ERROR(StreamCaptureUnjoined)
+    OSTREAM_ROCM_ERROR(StreamCaptureIsolation)
+    OSTREAM_ROCM_ERROR(StreamCaptureImplicit)
+    OSTREAM_ROCM_ERROR(CapturedEvent)
+    OSTREAM_ROCM_ERROR(StreamCaptureWrongThread)
+    OSTREAM_ROCM_ERROR(GraphExecUpdateFailure)
+    OSTREAM_ROCM_ERROR(RuntimeMemory)
+    OSTREAM_ROCM_ERROR(RuntimeOther)
+#endif // TF_ROCM_VERSION >= 60200
     default:
       return absl::StrCat("hipError_t(", static_cast<int>(result), ")");
   }
@@ -1106,19 +1132,22 @@ struct BitPatternToValue {
   VLOG(2) << "launching kernel: " << kernel_name << "; gdx: " << grid_dim_x
           << " gdy: " << grid_dim_y << " gdz: " << grid_dim_z
           << " bdx: " << block_dim_x << " bdy: " << block_dim_y
-          << " bdz: " << block_dim_z << " smem: " << shared_mem_bytes;
+          << " bdz: " << block_dim_z << " smem: " << shared_mem_bytes 
+          <<" func: " << (const void*)function;
 
+  auto res = hipSuccess;
+#if TF_ROCM_VERSION < 60200
   // for in-process kernel this function returns mangled kernel function name,
   // and null otherwise
   auto name = wrap::hipKernelNameRefByPtr((const void*)function, stream);
-
-  auto res = hipSuccess;
   if (name != nullptr) {
     res = wrap::hipLaunchKernel((const void*)function,
                                 dim3(grid_dim_x, grid_dim_y, grid_dim_z),
                                 dim3(block_dim_x, block_dim_y, block_dim_z),
                                 kernel_params, shared_mem_bytes, stream);
-  } else {
+  } else 
+#endif // TF_ROCM_VERSION < 60200
+  {
     res = wrap::hipModuleLaunchKernel(
         function, grid_dim_x, grid_dim_y, grid_dim_z, block_dim_x, block_dim_y,
         block_dim_z, shared_mem_bytes, stream, kernel_params, extra);

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #define __HIP_DISABLE_CPP_FUNCTIONS__
 
+#include "rocm/rocm_config.h"
 #include "rocm/include/hip/hip_runtime.h"
 #include "xla/stream_executor/platform/dso_loader.h"
 #include "xla/stream_executor/platform/port.h"
@@ -173,6 +174,19 @@ namespace wrap {
   __macro(hipStreamWaitEvent)  // clang-format on
 
 HIP_ROUTINE_EACH(STREAM_EXECUTOR_HIP_WRAP)
+
+#if TF_ROCM_VERSION >= 60200
+
+// clang-format off
+#define HIP_ROUTINE_EACH_62(__macro)            \
+  __macro(hipGetFuncBySymbol)                   \
+  __macro(hipStreamBeginCaptureToGraph)
+// clang-format on
+
+HIP_ROUTINE_EACH_62(STREAM_EXECUTOR_HIP_WRAP)
+
+#undef HIP_ROUTINE_EACH_62
+#endif // TF_ROCM_VERSION >= 60200
 
 #undef HIP_ROUTINE_EACH
 #undef STREAM_EXECUTOR_HIP_WRAP

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -856,6 +856,7 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
       GpuDriver::GetMaxRegistersPerBlock(device).value());
   builder.set_threads_per_warp(GpuDriver::GetThreadsPerWarp(device).value());
   builder.set_registers_per_core_limit(64 * 1024);
+  builder.set_runtime_version(std::to_string(TF_ROCM_VERSION));
 
   int cc_major = 0;
   int cc_minor = 0;

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "rocm/rocm_config.h"
 #include "xla/stream_executor/gpu/gpu_collectives.h"
 #include "xla/stream_executor/gpu/gpu_command_buffer.h"
 #include "xla/stream_executor/gpu/gpu_driver.h"
@@ -265,8 +266,16 @@ absl::Status GpuExecutor::GetKernel(const MultiKernelLoaderSpec& spec,
     VLOG(1) << "Resolve ROCM kernel " << *kernel_name
             << " from symbol pointer: " << symbol;
 
+#if TF_ROCM_VERSION >= 60200
+    TF_ASSIGN_OR_RETURN(
+        GpuFunctionHandle function,
+        GpuRuntime::GetFuncBySymbol(spec.in_process_symbol().symbol()));
+    *rocm_kernel->gpu_function_ptr() = function;
+#else
     *rocm_kernel->gpu_function_ptr() =
         static_cast<hipFunction_t>(spec.in_process_symbol().symbol());
+#endif // TF_ROCM_VERSION >= 60200
+
   } else {
     return absl::InternalError("No method of loading ROCM kernel provided");
   }

--- a/xla/stream_executor/rocm/rocm_runtime.cc
+++ b/xla/stream_executor/rocm/rocm_runtime.cc
@@ -36,7 +36,14 @@ namespace gpu {
 
 absl::StatusOr<GpuFunctionHandle> GpuRuntime::GetFuncBySymbol(void* symbol) {
   VLOG(2) << "Get ROCM function from a symbol: " << symbol;
+#if TF_ROCM_VERSION >= 60200
+  hipFunction_t func;
+  RETURN_IF_ROCM_ERROR(wrap::hipGetFuncBySymbol(&func, symbol),
+                           "Failed call to hipGetFuncBySymbol");
+  return func; 
+#else
   return absl::UnimplementedError("GetFuncBySymbol is not implemented");
+#endif // TF_ROCM_VERSION >= 60200
 }
 
 absl::StatusOr<int32_t> GpuRuntime::GetRuntimeVersion() {


### PR DESCRIPTION
In this PR we enable some new rocm-6.2 features: mainly the missing **hipGetFuncBySymbol** in rocm_runtime, so that we had to the workaround. This affects only rocm-specific files.

@xla-rotation: could you have a look please ?