### PR TITLE
[ROCm] Add AMD_SERIALIZE_KERNEL environment for gpu_offloading_test

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3626,6 +3626,7 @@ xla_test(
     name = "gpu_offloading_test",
     srcs = ["gpu_offloading_test.cc"],
     backends = ["gpu"],
+    env = if_rocm_is_configured({"AMD_SERIALIZE_KERNEL" : "3"}),
     deps = [
         ":backend_configs_cc",
         ":horizontal_loop_fusion",


### PR DESCRIPTION
This ensures kernel lauch are serialized.