### PR TITLE
[ROCm] Fix collective ops test

### DIFF
--- a/xla/tests/collective_ops_test.cc
+++ b/xla/tests/collective_ops_test.cc
@@ -1985,18 +1985,30 @@ XLA_TEST_F(CollectiveOpsTest, DISABLED_ON_CPU(SendRecv_TwoConcurrentChains)) {
       channel_id=0, frontend_attributes={
         _xla_send_recv_source_target_pairs="{{0,1}}"
       }
-    recv-done.0 = (u32[2], token[]) recv-done(recv.0), channel_id=0
+
+    recv-done.0 = (u32[2], token[]) recv-done(recv.0), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="1"
+      }
     recv-data.0 = u32[2] get-tuple-element(recv-done.0), index=0
-    recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=0
+    recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
     recv-data.1 = u32[2] get-tuple-element(recv-done.1), index=0
 
     compare0 = pred[] compare(replica, c0), direction=EQ
     compare = pred[2] broadcast(compare0), dimensions={}
     recv-data = u32[2] select(compare, recv-data.0, recv-data.1)
 
-    send-done.0 = token[] send-done(send.0), channel_id=0
-    send-done.1 = token[] send-done(send.1), channel_id=0
-
+    send-done.0 = token[] send-done(send.0), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="1"
+      }
+    send-done.1 = token[] send-done(send.1), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
     c1b = u32[2] broadcast(c1), dimensions={}
     ROOT result = u32[2] add(c1b, recv-data)
   })";
@@ -2042,9 +2054,15 @@ XLA_TEST_F(CollectiveOpsTest, DISABLED_ON_CPU(SendRecv_ValidationAttr1)) {
         _xla_send_recv_source_target_pairs="{{1,0}}",
         _xla_send_recv_validation="invalid"
       }
-    recv-done.0 = (u32[2], token[]) recv-done(recv.0), channel_id=0
+    recv-done.0 = (u32[2], token[]) recv-done(recv.0), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
     recv-data.0 = u32[2] get-tuple-element(recv-done.0), index=0
-    send-done.0 = token[] send-done(send.0), channel_id=0
+    send-done.0 = token[] send-done(send.0), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
 
     after-all.1 = token[] after-all()
     recv.1 = (u32[2], u32[], token[]) recv(after-all.1), channel_id=0,
@@ -2055,13 +2073,19 @@ XLA_TEST_F(CollectiveOpsTest, DISABLED_ON_CPU(SendRecv_ValidationAttr1)) {
       channel_id=0, frontend_attributes={
         _xla_send_recv_source_target_pairs="{{0,1}}"
       }
-    recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=0
+    recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
     recv-data.1 = u32[2] get-tuple-element(recv-done.1), index=0
 
     compare0 = pred[] compare(replica, c0), direction=EQ
     compare = pred[2] broadcast(compare0), dimensions={}
     recv-data = u32[2] select(compare, recv-data.0, recv-data.1)
-    send-done.1 = token[] send-done(send.1), channel_id=0
+    send-done.1 = token[] send-done(send.1), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
 
     c1b = u32[2] broadcast(c1), dimensions={}
     ROOT result = u32[2] add(c1b, recv-data)
@@ -2113,9 +2137,15 @@ body {
         _xla_send_recv_source_target_pairs="{{1,0}}",
         _xla_send_recv_validation="{{0,1}}"
       }
-    recv-done.0 = (u32[2], token[]) recv-done(recv.0), channel_id=0
+    recv-done.0 = (u32[2], token[]) recv-done(recv.0), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
     recv-data.0 = u32[2] get-tuple-element(recv-done.0), index=0
-    send-done.0 = token[] send-done(send.0), channel_id=0
+    send-done.0 = token[] send-done(send.0), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
 
     after-all.1 = token[] after-all()
     recv.1 = (u32[2], u32[], token[]) recv(after-all.1), channel_id=0,
@@ -2127,7 +2157,10 @@ body {
       frontend_attributes={
         _xla_send_recv_source_target_pairs="{{0,1}}"
       }
-    recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=0
+    recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
     recv-data.1 = u32[2] get-tuple-element(recv-done.1), index=0
 
     replica = u32[] replica-id()
@@ -2142,7 +2175,10 @@ body {
     r = u32[2] broadcast(c1), dimensions={}
     s = u32[2] add(r, recv-data)
 
-    send-done.1 = token[] send-done(send.1), channel_id=0
+    send-done.1 = token[] send-done(send.1), channel_id=0,
+    frontend_attributes={
+        _xla_send_recv_pipeline="0"
+      }
     ROOT result = (u32[], u32[2]) tuple(new_count, s)
   }
 


### PR DESCRIPTION
After https://github.com/openxla/xla/commit/2431013a04ffa3526906bdea49e3423ccc2596dd VerifyChannels would, in the event of multiple Send/Recv instructions in the same channel, check for frontend attributes of SendDone/RecvDone instructions as well. This caused multiple subtests to fail, so I added the needed attributes.