### PR TITLE
[ROCm ] fixed build due to https://github.com/openxla/xla/commit/e2a86549996ae6ac57f6eae31c1ed9aee4975bab

### DIFF
--- a/xla/service/gpu/ir_emitter_triton_rocm.cc
+++ b/xla/service/gpu/ir_emitter_triton_rocm.cc
@@ -74,13 +74,12 @@ absl::Status CreateTritonPipeline(
   pm.addPass(mt::gpu::createTritonGPUCoalesce());
   pm.addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   pm.addPass(mt::gpu::createTritonGPUOptimizeThreadLocality());
-  pm.addPass(mt::gpu::createTritonGPUAccelerateMatmul({ccAsInt}));
+  pm.addPass(mt::gpu::createTritonGPUAccelerateMatmul());
   pm.addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   // TODO ROCm Check if we want to compare MI100 and greater
   pm.addPass(mt::gpu::createTritonGPUOptimizeDotOperands({true}));
   pm.addPass(mlir::createCSEPass());
-  pm.addPass(mt::gpu::createTritonGPUPipeline(
-      {config.num_stages, config.num_warps, config.num_ctas, ccAsInt}));
+  pm.addPass(mt::gpu::createTritonGPUPipeline({config.num_stages}));
   pm.addPass(mt::gpu::createTritonGPUPrefetch());
 
   // TODO ROCm Check if we want to compare MI100 and greater


### PR DESCRIPTION
this fixed ROCm build due to https://github.com/openxla/xla/commit/e2a86549996ae6ac57f6eae31c1ed9aee4975bab#diff-1390f748feeae091b1bf422c47df533aba570c7a50a6f3fafda65a5159908cc3R72-R86


@ddunl @xla-rotation 

this is already a couple of times, e.g., https://github.com/openxla/xla/pull/13194 , please change related [ir_emitter_triton_rocm.cc](https://github.com/openxla/xla/blob/main/xla/service/gpu/ir_emitter_triton_rocm.cc) next time. 

Thanks in advance!