### PR TITLE
Remove gpu_a100 and gpu_h100 from default nvidia gpu backends list

### DIFF
--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -17,11 +17,7 @@ NVIDIA_GPU_BACKENDS = [
 ]
 
 # The generic "gpu" backend includes the actual backends in this list.
-NVIDIA_GPU_DEFAULT_BACKENDS = [
-    "gpu_any",
-    "gpu_a100",
-    "gpu_h100",
-]
+NVIDIA_GPU_DEFAULT_BACKENDS = ["gpu_any"]
 
 AMD_GPU_DEFAULT_BACKENDS = ["gpu_amd_any"]
 


### PR DESCRIPTION
For the xla_test targets  (e.g. test1 ) without backend field the targets are generated as test1_gpu_any, test1_gpu_a100, test1_gpu_h100, test1_gpu_amd_any, test1_cpu, and for test targets with just "gpu" backend fields, the targets are generated as test1_gpu_any, test1_gpu_a100, test1_gpu_h100. This causes repetitive tests execution in the CI job. This can be controlled with using test tags e.g. -xla_gpu_a100/-requires-sm-80/-requries-sm90-only,etc as in OSS CI but to run the tests on ampere gpu as default, we need to provide requires-gpu-nvidia (to include tests that have this tag mentioned in the target) and requires-sm-80, requires-sm-80-only for a100 test targets hence each test without backend field gets executed twice. 
Changing the default backend target to gpu_any and including the requires-sm-80,requires-sm-80-only tags ensures the test targets are executed once and a100/h100 specific tests are included using the tags (either xla_gpu_a100/xla_gpu_h100 or requires-sm-80/90/-only)