### PR TITLE
[GPU] Let constants be emitted into a separate LLVM module.

### DIFF
--- a/xla/service/gpu/compile_module_to_llvm_ir.cc
+++ b/xla/service/gpu/compile_module_to_llvm_ir.cc
@@ -36,10 +36,10 @@ limitations under the License.
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Transforms/Utils/SplitModule.h"
-#include "mlir/IR/Diagnostics.h"  // from @llvm-project
-#include "mlir/IR/DialectRegistry.h"  // from @llvm-project
-#include "mlir/Pass/PassManager.h"  // from @llvm-project
-#include "mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/IR/Diagnostics.h"         // from @llvm-project
+#include "mlir/IR/DialectRegistry.h"     // from @llvm-project
+#include "mlir/Pass/PassManager.h"       // from @llvm-project
+#include "mlir/Support/LLVM.h"           // from @llvm-project
 #include "mlir/Support/LogicalResult.h"  // from @llvm-project
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
@@ -109,12 +109,21 @@ absl::StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
     const std::string& platform_name, se::Platform::Id platform_id,
     const se::DeviceDescription& gpu_device_info,
     const HloDataflowAnalysis::CanShareBuffer& can_share_buffer_function,
-    const BufferValue::SizeFunction& buffer_size_bytes_function) {
+    const BufferValue::SizeFunction& buffer_size_bytes_function,
+    bool split_constants_module) {
   CompileModuleResults results;
   results.llvm_module =
       std::make_unique<llvm::Module>(hlo_module->name(), *llvm_context);
   results.llvm_module->setTargetTriple(target_triple);
   results.llvm_module->setDataLayout(data_layout);
+
+  if (split_constants_module) {
+    // Constants are emitted into a separate module to avoid caching them.
+    results.llvm_module_constants = std::make_unique<llvm::Module>(
+        absl::StrCat(hlo_module->name(), "_consts"), *llvm_context);
+    results.llvm_module_constants->setTargetTriple(target_triple);
+    results.llvm_module_constants->setDataLayout(data_layout);
+  }
 
   {
     tsl::profiler::ScopedAnnotation annotation([&] {
@@ -179,7 +188,8 @@ absl::StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
   IrEmitterContext ir_emitter_context(
       hlo_module, results.buffer_assignment.get(),
       results.execution_stream_assignment.get(), platform_name, gpu_device_info,
-      mlir_context.get(), results.llvm_module.get(), /*emit_kernels=*/true);
+      mlir_context.get(), results.llvm_module.get(),
+      results.llvm_module_constants.get(), /*emit_kernels=*/true);
 
   std::vector<BufferAllocation*> allocations;
   results.output_shape = hlo_module->result_shape();
@@ -203,8 +213,9 @@ absl::StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
     if (supports_runtime_managed_constants) {
       // Remove these globals from the generated code to indicate that XLA is
       // responsible for allocating and initializing them.
-      RemoveUnusedAndUninitializedGlobals(ir_emitter_context.llvm_module(),
-                                          ir_emitter_context.constants());
+      RemoveUnusedAndUninitializedGlobals(
+          ir_emitter_context.llvm_module_constants(),
+          ir_emitter_context.constants());
     }
 
     results.constants = std::move(ir_emitter_context.constants());

--- a/xla/service/gpu/compile_module_to_llvm_ir.h
+++ b/xla/service/gpu/compile_module_to_llvm_ir.h
@@ -45,6 +45,7 @@ namespace gpu {
 
 struct CompileModuleResults {
   std::unique_ptr<llvm::Module> llvm_module;
+  std::unique_ptr<llvm::Module> llvm_module_constants;
   std::unique_ptr<BufferAssignment> buffer_assignment;
   std::unique_ptr<ExecutionStreamAssignment> execution_stream_assignment;
   std::vector<BufferAllocation> allocations;
@@ -69,7 +70,8 @@ absl::StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
     const std::string& platform_name, se::Platform::Id platform_id,
     const se::DeviceDescription& gpu_device_info,
     const HloDataflowAnalysis::CanShareBuffer& can_share_buffer_function,
-    const BufferValue::SizeFunction& buffer_size_bytes_function);
+    const BufferValue::SizeFunction& buffer_size_bytes_function,
+    bool split_constants_module = false);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -394,16 +394,17 @@ GpuThunkAotCompilationResult::LoadExecutable(
   mlir::DialectRegistry registry;
   auto mlir_context = std::make_unique<mlir::MLIRContext>(registry);
   llvm::LLVMContext llvm_context;
-  auto llvm_module = std::make_unique<llvm::Module>("", llvm_context);
   auto* gpu_compiler = dynamic_cast<GpuCompiler*>(compiler);
   if (gpu_compiler == nullptr) {
     return Internal("Compiler is not a GpuCompiler.");
   }
+  auto llvm_module = std::make_unique<llvm::Module>("", llvm_context);
   llvm_module->setTargetTriple(gpu_compiler->target_triple());
   llvm_module->setDataLayout(gpu_compiler->data_layout());
   IrEmitterContext ir_emitter_context(
       hlo_module.get(), buffer_assignment.get(), &execution_stream_assignment,
       platform_name, gpu_device_info, mlir_context.get(), llvm_module.get(),
+      /*llvm_module_constants=*/nullptr,
       /*emit_kernels=*/false);
   auto ir_emitter = IrEmitterUnnested::Create(&ir_emitter_context);
   TF_RETURN_IF_ERROR(
@@ -1770,7 +1771,7 @@ GpuCompiler::CompileSingleModule(const HloModuleConfig& module_config,
 
 absl::StatusOr<GpuCompiler::BackendCompileResult>
 GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
-                                   llvm::Module* llvm_module,
+                                   CompileModuleResults& compile_module_results,
                                    se::GpuComputeCapability gpu_version,
                                    se::StreamExecutor* stream_exec,
                                    const CompileOptions& options,
@@ -1784,6 +1785,7 @@ GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
                 /*default_thread_pool=*/options.thread_pool,
                 /*default_parallelism=*/1)
           : MaybeOwningThreadPool(nullptr);
+  llvm::Module* llvm_module = &*compile_module_results.llvm_module;
 
   // Test whether LinkModules is supported.
   TF_ASSIGN_OR_RETURN(bool can_use_link_modules,
@@ -1837,7 +1839,11 @@ GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
   // We'll change the linkage type of these variables from external to internal
   // to ensure constant-folding works properly after calling llvm::SplitModule.
   llvm::DenseMap<llvm::StringRef, llvm::Constant*> const_initializer_map;
-  for (llvm::GlobalVariable& gv : llvm_module->globals()) {
+  llvm::Module& module_with_constants =
+      (compile_module_results.llvm_module_constants == nullptr)
+          ? *llvm_module
+          : *compile_module_results.llvm_module_constants;
+  for (llvm::GlobalVariable& gv : module_with_constants.globals()) {
     if (gv.hasName() && gv.isConstant() && gv.hasInitializer() &&
         gv.hasExternalLinkage()) {
       llvm::Constant* initializer = gv.getInitializer();
@@ -1855,6 +1861,10 @@ GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
     }
   }
 
+  if (compile_module_results.llvm_module_constants != nullptr) {
+    llvm_modules.push_back(
+        std::move(compile_module_results.llvm_module_constants));
+  }
   llvm::SplitModule(
       *llvm_module,
       std::max<unsigned>(
@@ -1941,16 +1951,26 @@ GpuCompiler::CompileToBackendResult(
 
   if (user_pre_optimization_hook_) {
     user_pre_optimization_hook_(*compile_module_results.llvm_module);
+    if (compile_module_results.llvm_module_constants != nullptr) {
+      user_pre_optimization_hook_(
+          *compile_module_results.llvm_module_constants);
+    }
   }
 
   llvm_ir::DumpIrIfEnabled(*module, *compile_module_results.llvm_module,
                            /*optimized=*/false);
 
+  if (compile_module_results.llvm_module_constants != nullptr) {
+    llvm_ir::DumpIrIfEnabled(*module,
+                             *compile_module_results.llvm_module_constants,
+                             /*optimized=*/false, "constants");
+  }
+
   TF_ASSIGN_OR_RETURN(
       BackendCompileResult backend_result,
-      CompileToTargetBinary(
-          module->config(), compile_module_results.llvm_module.get(),
-          gpu_device_info.gpu_compute_capability(), executor, options, module));
+      CompileToTargetBinary(module->config(), compile_module_results,
+                            gpu_device_info.gpu_compute_capability(), executor,
+                            options, module));
   RecordXlaDeviceBinarySize(backend_result.binary.size());
   if (DumpingEnabledForHloModule(*module)) {
     DumpToFileInDirOrStdout(*module, "", "thunk_sequence.txt",

--- a/xla/service/gpu/gpu_compiler.h
+++ b/xla/service/gpu/gpu_compiler.h
@@ -187,7 +187,8 @@ class GpuCompiler : public LLVMCompiler {
       const se::DeviceDescription& gpu_device_info);
 
   absl::StatusOr<BackendCompileResult> CompileToTargetBinary(
-      const HloModuleConfig& module_config, llvm::Module* llvm_module,
+      const HloModuleConfig& module_config,
+      CompileModuleResults& compile_module_results,
       se::GpuComputeCapability gpu_version, se::StreamExecutor* stream_exec,
       const CompileOptions& options, const HloModule* debug_module);
 

--- a/xla/service/gpu/ir_emitter_context.cc
+++ b/xla/service/gpu/ir_emitter_context.cc
@@ -70,7 +70,7 @@ void IrEmitterContext::emit_constant(int64_t num_elements,
     std::vector<uint8_t> padded(kMinConstAllocationInBytes, 0);
     absl::c_copy(content.span(), padded.begin());
     return llvm::ConstantDataArray::get<uint8_t>(
-        llvm_module_->getContext(),
+        llvm_module_constants()->getContext(),
         needs_padding ? llvm::ArrayRef<uint8_t>(padded)
                       : llvm::ArrayRef<uint8_t>(content.span().data(),
                                                 content.span().size()));
@@ -78,7 +78,7 @@ void IrEmitterContext::emit_constant(int64_t num_elements,
 
   // Explicitly set global addrspace for SPIR backend.
   int addrspace =
-      llvm::Triple(llvm_module_->getTargetTriple()).isSPIR() ? 1 : 0;
+      llvm::Triple(llvm_module_constants()->getTargetTriple()).isSPIR() ? 1 : 0;
   // These globals will be looked up by name by GpuExecutable so we need to
   // give them an external linkage.  Not all of their uses are visible in
   // the LLVM IR so we can't give then a linkage that merely preserves their
@@ -95,7 +95,7 @@ void IrEmitterContext::emit_constant(int64_t num_elements,
       /*AddressSpace=*/addrspace,
       /*isExternallyInitialized=*/false);
   global_for_const->setAlignment(llvm::Align(kConstantBufferAlignBytes));
-  llvm_module_->insertGlobalVariable(global_for_const);
+  llvm_module_constants()->insertGlobalVariable(global_for_const);
 
   info.symbol_name.assign(symbol_name);
   info.allocation_index = allocation_idx;

--- a/xla/service/gpu/ir_emitter_context.h
+++ b/xla/service/gpu/ir_emitter_context.h
@@ -28,7 +28,7 @@ limitations under the License.
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
 #include "mlir/IR/MLIRContext.h"  // from @llvm-project
-#include "mlir/IR/Operation.h"  // from @llvm-project
+#include "mlir/IR/Operation.h"    // from @llvm-project
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/buffer_assignment.h"
@@ -65,7 +65,7 @@ class IrEmitterContext {
                    std::string platform_name,
                    const se::DeviceDescription& gpu_device_info,
                    mlir::MLIRContext* mlir_context, llvm::Module* llvm_module,
-                   bool emit_kernels)
+                   llvm::Module* llvm_module_constants, bool emit_kernels)
       : hlo_module_(hlo_module),
         buffer_assignment_(buffer_assignment),
         execution_stream_assignment_(execution_stream_assignment),
@@ -73,6 +73,7 @@ class IrEmitterContext {
         gpu_device_info_(gpu_device_info),
         mlir_context_(mlir_context),
         llvm_module_(llvm_module),
+        llvm_module_constants_(llvm_module_constants),
         emit_kernels_(emit_kernels) {}
   // Disallow copy and assign.
   IrEmitterContext(const IrEmitterContext&) = delete;
@@ -105,6 +106,11 @@ class IrEmitterContext {
   }
   mlir::MLIRContext* mlir_context() { return mlir_context_; }
   llvm::Module* llvm_module() { return llvm_module_; }
+  // A separate module can optionally be used to emit constants.
+  llvm::Module* llvm_module_constants() {
+    return (llvm_module_constants_ == nullptr) ? llvm_module_
+                                               : llvm_module_constants_;
+  }
   NameUniquer* name_uniquer() { return &name_uniquer_; }
 
   std::vector<GpuExecutable::ConstantInfo>& constants() { return constants_; }
@@ -134,6 +140,7 @@ class IrEmitterContext {
   const se::DeviceDescription& gpu_device_info_;
   mlir::MLIRContext* mlir_context_;
   llvm::Module* llvm_module_;
+  llvm::Module* llvm_module_constants_;
   NameUniquer name_uniquer_;
   std::vector<GpuExecutable::ConstantInfo> constants_;
   KernelReuseCache kernel_cache_;


### PR DESCRIPTION
Will not change the behavior of the compiler for now - the use of separate constant modules will be added in the next PR with on-disk kernel compilation cache: https://github.com/openxla/xla/pull/13569.