### PR TITLE
Activation offloading dependency fix: insert a wait

### DIFF
--- a/xla/service/gpu/execution_stream_assignment.cc
+++ b/xla/service/gpu/execution_stream_assignment.cc
@@ -43,6 +43,7 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
   // each invocation of `async-start` will result in the target computation
   // being assigned a new `ExecutionStreamId`.
   ExecutionStreamId next_stream_id = ExecutionStreamId(1);
+  ExecutionStreamId copy_start_stream_id = ExecutionStreamId(0);
 
   // Each `Pending` item represents an `HloComputation` that needs to be
   // processed. We start with the entrypoint and add callees as we discover
@@ -70,6 +71,18 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
     }
   };
 
+  // Assigns source and destination streams to an instruction and records it in
+  // async_instructions_.
+  auto assign_async_execution_streams =
+      [&](HloInstruction* instruction, ExecutionStreamId source_stream_id,
+          ExecutionStreamId destination_stream_id) {
+        AsyncExecutionStreamIds streams;
+        streams.source_stream_id = source_stream_id;
+        streams.destination_stream_id = destination_stream_id;
+
+        CHECK(async_instructions_.try_emplace(instruction, streams).second);
+      };
+
   while (!queue.empty()) {
     Pending pending = queue.front();
     queue.pop_front();
@@ -78,8 +91,24 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
     // instructions. Asynchronous instructions will be handled afterwards.
     for (HloInstruction* instruction : pending.node->instructions()) {
       if (instruction->IsAsynchronous()) continue;
-      CHECK(sync_instructions_.try_emplace(instruction, pending.stream_id)
-                .second);
+      // The copy-start operation can only be in the main stream (stream 0).
+      if (instruction->opcode() == HloOpcode::kCopyStart) {
+        ExecutionStreamId destination_stream_id = pending.stream_id;
+        CHECK_EQ(pending.stream_id, ExecutionStreamId(0));
+        if (copy_start_stream_id == ExecutionStreamId(0)) {
+          copy_start_stream_id = next_stream_id;
+          next_stream_id++;
+          if (next_stream_id.value() > options.number_of_execution_streams) {
+            next_stream_id = ExecutionStreamId(1);
+          }
+        }
+        destination_stream_id = copy_start_stream_id;
+        assign_async_execution_streams(instruction, pending.stream_id,
+                                       destination_stream_id);
+      } else {
+        CHECK(sync_instructions_.try_emplace(instruction, pending.stream_id)
+                  .second);
+      }
     }
 
     // Next, we'll process all callsites in the current computation.
@@ -90,13 +119,8 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
         // dispensed for the called computations.
         CHECK_EQ(callsite.instruction()->opcode(), HloOpcode::kAsyncStart);
         enqueue_called_computations(callsite, next_stream_id);
-
-        AsyncExecutionStreamIds streams;
-        streams.source_stream_id = pending.stream_id;
-        streams.destination_stream_id = next_stream_id;
-        CHECK(async_instructions_.try_emplace(callsite.instruction(), streams)
-                  .second);
-
+        assign_async_execution_streams(callsite.instruction(),
+                                       pending.stream_id, next_stream_id);
         next_stream_id++;
         if (next_stream_id.value() > options.number_of_execution_streams) {
           next_stream_id = ExecutionStreamId(1);
@@ -151,7 +175,9 @@ ExecutionStreamAssignment::GetSyncExecutionStreamId(
 
 absl::StatusOr<ExecutionStreamAssignment::AsyncExecutionStreamIds>
 ExecutionStreamAssignment::GetAsyncExecutionStreamIds(
-    const HloAsyncInstruction* instruction) const {
+    const HloInstruction* instruction) const {
+  CHECK(instruction->IsAsynchronous() ||
+        instruction->opcode() == HloOpcode::kCopyStart);
   auto streams = async_instructions_.find(instruction);
   if (streams == async_instructions_.end()) {
     return StreamNotFoundError(instruction);

--- a/xla/service/gpu/execution_stream_assignment.h
+++ b/xla/service/gpu/execution_stream_assignment.h
@@ -65,7 +65,7 @@ class ExecutionStreamAssignment {
     ExecutionStreamId destination_stream_id;
   };
   absl::StatusOr<AsyncExecutionStreamIds> GetAsyncExecutionStreamIds(
-      const HloAsyncInstruction* instruction) const;
+      const HloInstruction* instruction) const;
 
  private:
   // Maps from `HloInstructions` to `ExecutionStreamIds` for synchronous and

--- a/xla/service/gpu/gpu_offloading_test.cc
+++ b/xla/service/gpu/gpu_offloading_test.cc
@@ -171,6 +171,20 @@ TEST_F(GpuOffloadingTest, FusedComputationOffloadingTest) {
   EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{1e-3}));
 }
 
+TEST_F(GpuOffloadingTest, WeightOffloadingD2HWithWaitTest) {
+  const char* hlo_offloading_d2h = R"(
+  HloModule jit__lambda_, is_scheduled=true,
+      entry_computation_layout={(s32[4,1]{1,0})->s32[4,1]{1,0:S(5)}}
+
+  ENTRY main.5_spmd {
+    param.1 = s32[4,1]{1,0} parameter(0), sharding={devices=[2,2]<=[4]}
+    copy-start.1 = (s32[4,1]{1,0:S(5)}, s32[4,1]{1,0}, u32[]) copy-start(param.1)
+    ROOT copy-done.1 = s32[4,1]{1,0:S(5)} copy-done(copy-start.1)
+  }
+)";
+  EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_offloading_d2h, ErrorSpec{1e-3}));
+}
+
 TEST_F(GpuOffloadingTest, CopyIRCreationTest) {
   const char* hlo_text = R"(
   HloModule test

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2404,20 +2404,20 @@ absl::Status IrEmitterUnnested::EmitCopyStartThunk(
         copy_start_instr->ToString(),
         static_cast<int>(stream_executor::MemoryType::kHost)));
   }
+  const ExecutionStreamAssignment& stream_assignment =
+      ir_emitter_context_->execution_stream_assignment();
+  TF_ASSIGN_OR_RETURN(
+      ExecutionStreamAssignment::AsyncExecutionStreamIds streams,
+      stream_assignment.GetAsyncExecutionStreamIds(copy_start_instr));
+  // Insert a waitFor() thunk for asynchronous memcpy only when the source
+  // and destination stream IDs differ. If the IDs are the same, the memcpy
+  // operation is synchronous within that stream.
+  if (streams.destination_stream_id != streams.source_stream_id) {
+    AddThunkToThunkSequence(std::make_unique<WaitForStreamsThunk>(
+        Thunk::ThunkInfo::WithProfileAnnotation(copy_start_instr),
+        streams.destination_stream_id, streams.source_stream_id));
+  }
   if (is_dst_host_memory) {
-    const ExecutionStreamAssignment& stream_assignment =
-        ir_emitter_context_->execution_stream_assignment();
-    TF_ASSIGN_OR_RETURN(
-        ExecutionStreamAssignment::AsyncExecutionStreamIds streams,
-        stream_assignment.GetAsyncExecutionStreamIds(copy_start_instr));
-    // Insert a waitFor() thunk for asynchronous memcpy only when the source
-    // and destination stream IDs differ. If the IDs are the same, the memcpy
-    // operation is synchronous within that stream.
-    if (streams.destination_stream_id != streams.source_stream_id) {
-      AddThunkToThunkSequence(std::make_unique<WaitForStreamsThunk>(
-          Thunk::ThunkInfo::WithProfileAnnotation(copy_start_instr),
-          streams.destination_stream_id, streams.source_stream_id));
-    }
     auto thunk = std::make_unique<DeviceToHostCopyThunk>(
         Thunk::ThunkInfo::WithProfileAnnotation(copy_start_instr),
         /*source_buffer=*/src_buffer,
@@ -2425,6 +2425,7 @@ absl::Status IrEmitterUnnested::EmitCopyStartThunk(
         /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
         /*copy_events=*/copy_events_,
         /*copy_start_instr=*/copy_start_instr);
+    thunk->set_execution_stream_id(streams.destination_stream_id);
     AddThunkToThunkSequence(std::move(thunk));
   } else {
     auto thunk = std::make_unique<HostToDeviceCopyThunk>(
@@ -2434,6 +2435,7 @@ absl::Status IrEmitterUnnested::EmitCopyStartThunk(
         /*mem_size=*/ShapeUtil::ByteSizeOf(input_shape),
         /*copy_events=*/copy_events_,
         /*copy_start_instr=*/copy_start_instr);
+    thunk->set_execution_stream_id(streams.destination_stream_id);
     AddThunkToThunkSequence(std::move(thunk));
   }
 

--- a/xla/service/gpu/runtime/copy_thunk.cc
+++ b/xla/service/gpu/runtime/copy_thunk.cc
@@ -125,11 +125,6 @@ absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
   TF_ASSIGN_OR_RETURN(
       se::Stream * stream,
       GetStreamForExecution(Thunk::execution_stream_id(), params));
-  // Wait for the source to be ready on device unless it's an input parameter
-  if (instr_->operand(0)->opcode() != HloOpcode::kParameter) {
-    VLOG(5) << "Waiting for stream: " << params.stream;
-    TF_RETURN_IF_ERROR(stream->WaitFor(params.stream));
-  }
   TF_RETURN_IF_ERROR(stream->Memcpy(cpu_dst, source_data, size_bytes()));
   if (stream == params.stream) {
     VLOG(2) << "Memcpy D2H from the main stream";


### PR DESCRIPTION
To ensure proper synchronization for the asynchronous copy, this CL makes the other stream wait for the completion of the operation (res_3) in the main stream.
  %param_1 = f32[1024]{0} parameter(1)
  %param_0 = f32[1024]{0} parameter(0)
  %res_3 = f32[1024]{0} fusion(%param_1, %param_0), kind=kInput, calls=mul
  %copy-start = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_3)