### PR TITLE
NVTX: name threads, CUDA devices and CUDA streams

### DIFF
--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <sys/syscall.h>
 
 #include "nvtx3/nvToolsExt.h"
+#include "nvtx3/nvToolsExtCuda.h"
 #include "nvtx3/nvToolsExtCudaRt.h"
 #include "nvtx3/nvToolsExtPayload.h"
 
@@ -42,6 +43,7 @@ std::optional<uint32_t> GetCurrentThreadId() {
 }  // namespace
 
 namespace tsl::profiler {
+static_assert(std::is_pointer_v<CUstream>);
 static_assert(std::is_pointer_v<nvtxDomainHandle_t>);
 static_assert(std::is_pointer_v<nvtxStringHandle_t>);
 
@@ -59,6 +61,10 @@ void NameCurrentThread(const std::string& thread_name) {
 
 void NameDevice(int device_id, const std::string& device_name) {
   nvtxNameCudaDeviceA(device_id, device_name.c_str());
+}
+
+void NameStream(StreamHandle stream, const std::string& stream_name) {
+  nvtxNameCuStreamA(reinterpret_cast<CUstream>(stream), stream_name.c_str());
 }
 
 void RangePop(ProfilerDomainHandle domain) {

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
@@ -20,7 +20,10 @@ limitations under the License.
 #include <string_view>
 #include <type_traits>
 
+#include <sys/syscall.h>
+
 #include "nvtx3/nvToolsExt.h"
+#include "nvtx3/nvToolsExtCudaRt.h"
 #include "nvtx3/nvToolsExtPayload.h"
 
 namespace tsl::profiler {
@@ -31,6 +34,14 @@ ProfilerDomainHandle DefaultProfilerDomain() {
   static ProfilerDomainHandle domain =
       reinterpret_cast<ProfilerDomainHandle>(nvtxDomainCreateA("TSL"));
   return domain;
+}
+
+void NameCurrentThread(const char* thread_name) {
+  nvtxNameOsThreadA(syscall(SYS_gettid), thread_name);
+}
+
+void NameDevice(int device_id, const char* device_name) {
+  nvtxNameCudaDeviceA(device_id, device_name);
 }
 
 void RangePop(ProfilerDomainHandle domain) {

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
@@ -34,6 +34,12 @@ using ProfilerDomainHandle = ProfilerDomain*;
 // Get the "TSL" domain if NVTX profiling is enabled, otherwise null
 ProfilerDomainHandle DefaultProfilerDomain();
 
+// Assign a human-readable name to the current thread
+void NameCurrentThread(const char* thread_name);
+
+// Assign a human-readable name to the given local device
+void NameDevice(int device_id, const char* device_name);
+
 // Register a string with the profiler/NVTX implementation for faster use
 StringHandle RegisterString(ProfilerDomainHandle, const std::string&);
 

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
@@ -35,10 +35,10 @@ using ProfilerDomainHandle = ProfilerDomain*;
 ProfilerDomainHandle DefaultProfilerDomain();
 
 // Assign a human-readable name to the current thread
-void NameCurrentThread(const char* thread_name);
+void NameCurrentThread(const std::string&);
 
 // Assign a human-readable name to the given local device
-void NameDevice(int device_id, const char* device_name);
+void NameDevice(int device_id, const std::string& device_name);
 
 // Register a string with the profiler/NVTX implementation for faster use
 StringHandle RegisterString(ProfilerDomainHandle, const std::string&);

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
@@ -40,6 +40,13 @@ void NameCurrentThread(const std::string&);
 // Assign a human-readable name to the given local device
 void NameDevice(int device_id, const std::string& device_name);
 
+struct Stream;
+// Opaque handle to an execution stream
+using StreamHandle = Stream*;
+
+// Assign a human-readable name to the given execution stream
+void NameStream(StreamHandle stream, const std::string& stream_name);
+
 // Register a string with the profiler/NVTX implementation for faster use
 StringHandle RegisterString(ProfilerDomainHandle, const std::string&);
 

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
@@ -16,6 +16,8 @@ limitations under the License.
 
 namespace tsl::profiler {
 ProfilerDomainHandle DefaultProfilerDomain() { return {}; }
+void NameCurrentThread(const char*) {}
+void NameDevice(int, const char*) {}
 void RangePop(ProfilerDomainHandle) {}
 void RangePush(ProfilerDomainHandle, const char*) {}
 namespace detail {

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
@@ -16,8 +16,8 @@ limitations under the License.
 
 namespace tsl::profiler {
 ProfilerDomainHandle DefaultProfilerDomain() { return {}; }
-void NameCurrentThread(const char*) {}
-void NameDevice(int, const char*) {}
+void NameCurrentThread(const std::string&) {}
+void NameDevice(int, const std::string&) {}
 void RangePop(ProfilerDomainHandle) {}
 void RangePush(ProfilerDomainHandle, const char*) {}
 namespace detail {

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
@@ -18,6 +18,7 @@ namespace tsl::profiler {
 ProfilerDomainHandle DefaultProfilerDomain() { return {}; }
 void NameCurrentThread(const std::string&) {}
 void NameDevice(int, const std::string&) {}
+void NameStream(StreamHandle, const std::string&) {}
 void RangePop(ProfilerDomainHandle) {}
 void RangePush(ProfilerDomainHandle, const char*) {}
 namespace detail {

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -116,6 +116,7 @@ cc_library(
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/profiler/lib:connected_traceme",
+        "@tsl//tsl/profiler/lib:nvtx_utils",
         "@tsl//tsl/profiler/lib:traceme",
     ] + if_cuda_or_rocm([
         ":nccl_id_store",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1024,8 +1024,11 @@ absl::Status BuildDistributedDevices(
                             device_proto.slice_index());
         // Name the device.
         tsl::profiler::NameDevice(device_proto.local_device_ordinal(),
-                                  ("Xla" + suffix).c_str());
-        // Name the thread that launches work on this device.
+                                  absl::StrCat("Xla", suffix));
+        // Name the thread that launches work on this device. This is deferred
+        // until after ExchangeTopologies has been called so the global device
+        // id and slice index are known. These are not available when the thread
+        // is created.
         local_device->execute_thread()->Schedule(
             [name = "XlaLauncher" + suffix] {
               tsl::profiler::NameCurrentThread(name.c_str());

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -88,6 +88,7 @@ limitations under the License.
 #include "tsl/platform/statusor.h"
 #include "tsl/platform/threadpool.h"
 #include "tsl/profiler/lib/connected_traceme.h"
+#include "tsl/profiler/lib/nvtx_utils.h"
 #include "tsl/profiler/lib/traceme.h"
 
 #if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
@@ -1015,6 +1016,20 @@ absl::Status BuildDistributedDevices(
         TF_RET_CHECK(it->second != nullptr);
         local_device = std::move(it->second);
         gpu_device_ids[device_proto.local_device_ordinal()] = global_device_id;
+        // Assign some descriptive names for profiling tools.
+        auto suffix =
+            absl::StrFormat(":#global=%d,local=%d,process=%d,slice=%d#",
+                            device_proto.global_device_id(),
+                            device_proto.local_device_ordinal(), node.node_id(),
+                            device_proto.slice_index());
+        // Name the device.
+        tsl::profiler::NameDevice(device_proto.local_device_ordinal(),
+                                  ("Xla" + suffix).c_str());
+        // Name the thread that launches work on this device.
+        local_device->execute_thread()->Schedule(
+            [name = "XlaLauncher" + suffix] {
+              tsl::profiler::NameCurrentThread(name.c_str());
+            });
       }
       auto device = std::make_unique<StreamExecutorGpuDevice>(
           device_proto.global_device_id(), std::move(local_device),

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1030,8 +1030,8 @@ absl::Status BuildDistributedDevices(
         // id and slice index are known. These are not available when the thread
         // is created.
         local_device->execute_thread()->Schedule(
-            [name = "XlaLauncher" + suffix] {
-              tsl::profiler::NameCurrentThread(name.c_str());
+            [name = absl::StrCat("XlaLauncher", suffix)] {
+              tsl::profiler::NameCurrentThread(name);
             });
       }
       auto device = std::make_unique<StreamExecutorGpuDevice>(

--- a/xla/pjrt/local_device_state.cc
+++ b/xla/pjrt/local_device_state.cc
@@ -59,34 +59,43 @@ LocalDeviceState::LocalDeviceState(se::StreamExecutor* executor,
   int num_device_to_device_streams =
       stream_options.has_value() ? stream_options->num_device_to_device_streams
                                  : kNumDeviceToDeviceStreams;
-  auto create_stream = [executor, &stream_options]() {
+  auto create_stream = [executor, &stream_options](std::string const& name) {
+    std::unique_ptr<stream_executor::Stream> stream;
     if (stream_options.has_value()) {
-      return executor->CreateStream(stream_options->priority).value();
+      stream = executor->CreateStream(stream_options->priority).value();
     } else {
-      return executor->CreateStream().value();
+      stream = executor->CreateStream().value();
     }
+    if (stream) {
+      stream->set_name(name);
+    }
+    return stream;
   };
-  compute_stream_ = create_stream();
-  host_to_device_stream_ = create_stream();
+  compute_stream_ = create_stream("Compute");
+  host_to_device_stream_ = create_stream("Host-to-device");
   if (use_callback_stream) {
     callback_stream_map_ =
         absl::flat_hash_map<se::Stream*, std::unique_ptr<se::Stream>>();
   }
   device_to_host_streams_.reserve(num_device_to_host_streams);
   for (int i = 0; i < num_device_to_host_streams; ++i) {
-    device_to_host_streams_.emplace_back(create_stream());
+    device_to_host_streams_.emplace_back(
+        create_stream(absl::StrFormat("Device-to-host #%d", i)));
   }
   device_to_device_streams_.reserve(num_device_to_device_streams);
   for (int i = 0; i < num_device_to_device_streams; ++i) {
-    device_to_device_streams_.emplace_back(create_stream());
+    device_to_device_streams_.emplace_back(
+        create_stream(absl::StrFormat("Device-to-device #%d", i)));
   }
   fixed_size_pool_usage_streams_.reserve(kNumFixedSizePoolUsageStreams);
   for (int i = 0; i < kNumFixedSizePoolUsageStreams; ++i) {
-    fixed_size_pool_usage_streams_.emplace_back(create_stream());
+    fixed_size_pool_usage_streams_.emplace_back(
+        create_stream(absl::StrFormat("Fixed size pool #%d", i)));
   }
   external_ready_event_streams_.reserve(kNumExternalReadyEventStreams);
   for (int i = 0; i < kNumExternalReadyEventStreams; ++i) {
-    external_ready_event_streams_.emplace_back(create_stream());
+    external_ready_event_streams_.emplace_back(
+        create_stream(absl::StrFormat("External ready event #%d", i)));
   }
   execute_thread_ =
       std::make_unique<WorkerThread>(tsl::Env::Default(), "py_xla_execute");
@@ -143,6 +152,7 @@ absl::Status LocalDeviceState::ThenExecuteCallback(
     auto callback_stream = callback_stream_map_->find(stream);
     if (callback_stream == callback_stream_map_->end()) {
       TF_ASSIGN_OR_RETURN(auto new_stream, executor_->CreateStream());
+      new_stream->set_name(absl::StrFormat("Callback for %s", stream->name()));
       callback_stream =
           callback_stream_map_->insert({stream, std::move(new_stream)}).first;
     }
@@ -231,6 +241,7 @@ std::unique_ptr<se::Stream> LocalDeviceState::BorrowStreamFromPool() {
 
   // The stream pool is empty, create a new stream.
   auto stream = compute_stream_->parent()->CreateStream().value();
+  stream->set_name("Pool stream");
   return stream;
 }
 

--- a/xla/service/gpu/infeed_manager.cc
+++ b/xla/service/gpu/infeed_manager.cc
@@ -46,7 +46,9 @@ constexpr int kMaxInfeedsInFlight = 8;
 
 InfeedManager::InfeedManager(se::StreamExecutor* executor)
     : BlockingXfeedQueue(/*max_pending_xfeeds=*/kMaxInfeedsInFlight),
-      stream_(executor->CreateStream().value()) {}
+      stream_(executor->CreateStream().value()) {
+  stream_->set_name("Infeed manager");
+}
 
 static absl::StatusOr<se::DeviceMemoryHandle> CopyBufferToDevice(
     se::Stream* stream, int64_t size, const void* source) {

--- a/xla/service/stream_pool.cc
+++ b/xla/service/stream_pool.cc
@@ -51,6 +51,8 @@ StreamPool::Ptr StreamPool::BorrowStream(se::StreamPriority priority) {
   if (!stream) {
     // Create a new stream.
     stream = executor_->CreateStream(priority).value();
+    stream->set_name(absl::StrFormat("%s pool stream",
+                                     se::StreamPriorityToString(priority)));
     VLOG(1) << absl::StrFormat("Created new stream (%p) with priority = %s",
                                stream.get(),
                                se::StreamPriorityToString(priority));

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -316,6 +316,7 @@ gpu_only_cc_library(
     name = "gpu_stream",
     srcs = ["gpu_stream.cc"],
     hdrs = ["gpu_stream.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":gpu_driver_header",
         ":gpu_event_header",

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -316,7 +316,6 @@ gpu_only_cc_library(
     name = "gpu_stream",
     srcs = ["gpu_stream.cc"],
     hdrs = ["gpu_stream.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":gpu_driver_header",
         ":gpu_event_header",
@@ -331,6 +330,7 @@ gpu_only_cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:str_format",
         "@tsl//tsl/platform:errors",
+        "@tsl//tsl/profiler/lib:nvtx_utils",
     ],
 )
 

--- a/xla/stream_executor/gpu/gpu_stream.cc
+++ b/xla/stream_executor/gpu/gpu_stream.cc
@@ -30,6 +30,9 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "tsl/platform/errors.h"
 
+#if GOOGLE_CUDA
+#include "nvtx3/nvToolsExtCuda.h"
+#endif
 namespace stream_executor {
 namespace gpu {
 
@@ -100,6 +103,13 @@ void GpuStream::Destroy() {
 
 bool GpuStream::IsIdle() const {
   return GpuDriver::IsStreamIdle(parent_->gpu_context(), gpu_stream_);
+}
+
+void GpuStream::set_name(absl::string_view name) {
+  name_ = name;
+#if GOOGLE_CUDA
+  nvtxNameCuStreamA(gpu_stream(), name_.c_str());
+#endif
 }
 
 GpuStream* AsGpuStream(Stream* stream) {

--- a/xla/stream_executor/gpu/gpu_stream.cc
+++ b/xla/stream_executor/gpu/gpu_stream.cc
@@ -29,10 +29,8 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream.h"
 #include "tsl/platform/errors.h"
+#include "tsl/profiler/lib/nvtx_utils.h"
 
-#if GOOGLE_CUDA
-#include "nvtx3/nvToolsExtCuda.h"
-#endif
 namespace stream_executor {
 namespace gpu {
 
@@ -107,9 +105,8 @@ bool GpuStream::IsIdle() const {
 
 void GpuStream::set_name(absl::string_view name) {
   name_ = name;
-#if GOOGLE_CUDA
-  nvtxNameCuStreamA(gpu_stream(), name_.c_str());
-#endif
+  tsl::profiler::NameStream(
+      reinterpret_cast<tsl::profiler::StreamHandle>(gpu_stream()), name_);
 }
 
 GpuStream* AsGpuStream(Stream* stream) {

--- a/xla/stream_executor/gpu/gpu_stream.h
+++ b/xla/stream_executor/gpu/gpu_stream.h
@@ -98,6 +98,8 @@ class GpuStream : public StreamCommon {
   absl::Status WaitFor(Event* event) override;
   absl::Status RecordEvent(Event* event) override;
 
+  void set_name(absl::string_view name) override;
+
  private:
   GpuExecutor* parent_;         // Executor that spawned this stream.
   GpuStreamHandle gpu_stream_;  // Wrapped CUDA stream handle.

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -256,6 +256,10 @@ class Stream {
   virtual absl::Status Launch(const ThreadDim &thread_dims,
                               const BlockDim &block_dims, const Kernel &k,
                               const KernelArgs &args) = 0;
+
+  // Get/set a name for a stream, which can be shown in profiling tools
+  virtual absl::string_view name() const = 0;
+  virtual void set_name(absl::string_view name) = 0;
 };
 
 template <typename... Params, typename... Args>

--- a/xla/stream_executor/stream_common.cc
+++ b/xla/stream_executor/stream_common.cc
@@ -100,6 +100,7 @@ absl::StatusOr<Stream *> StreamCommon::GetOrCreateSubStream() {
   // No streams are reusable; create a new stream.
   TF_ASSIGN_OR_RETURN(auto stream, parent_->CreateStream());
   Stream *sub_stream = stream.get();
+  sub_stream->set_name(absl::StrFormat("Sub-stream of %s", name()));
   sub_streams_.emplace_back(std::move(stream), false);
   VLOG(1) << "stream=" << this << " created new sub_stream=" << sub_stream;
 

--- a/xla/stream_executor/stream_common.h
+++ b/xla/stream_executor/stream_common.h
@@ -102,6 +102,10 @@ class StreamCommon : public Stream {
   absl::Status Launch(const ThreadDim &thread_dims, const BlockDim &block_dims,
                       const Kernel &k, const KernelArgs &args) override;
 
+  // Doesn't do anything interesting by default; GpuStream connects this to NVTX
+  absl::string_view name() const override { return name_; }
+  void set_name(absl::string_view name) override { name_ = name; }
+
  protected:
   bool InErrorState() const TF_LOCKS_EXCLUDED(mu_) {
     absl::ReaderMutexLock lock(&mu_);
@@ -116,6 +120,8 @@ class StreamCommon : public Stream {
   void CheckStatus(absl::Status status) TF_LOCKS_EXCLUDED(mu_);
 
   void SetError() { CheckError(false /* = operation_retcode */); }
+
+  std::string name_;
 
  private:
   // The StreamExecutor that supports the operation of this stream.

--- a/xla/stream_executor/stream_executor_memory_allocator.cc
+++ b/xla/stream_executor/stream_executor_memory_allocator.cc
@@ -105,6 +105,7 @@ absl::StatusOr<Stream*> StreamExecutorMemoryAllocator::GetStream(
   if (!streams_.count(device_ordinal)) {
     TF_ASSIGN_OR_RETURN(auto stream, executor->CreateStream());
     auto stream_ptr = stream.get();
+    stream_ptr->set_name("StreamExecutorMemoryAllocator");
     streams_.emplace(device_ordinal, std::move(stream));
     return stream_ptr;
   }

--- a/xla/stream_executor/trace_command_buffer_factory.cc
+++ b/xla/stream_executor/trace_command_buffer_factory.cc
@@ -34,6 +34,7 @@ TraceCommandBufferFactory::Create(
     absl::AnyInvocable<absl::Status(Stream*)> function,
     CommandBuffer::Mode mode) {
   TF_ASSIGN_OR_RETURN(auto stream, executor->CreateStream());
+  stream->set_name("Command buffer tracer");
   return TraceCommandBufferFactory::Create(executor, stream.get(),
                                            std::move(function), mode);
 }


### PR DESCRIPTION
This aims to improve the profiling experience. These names are shown in the Nsight Systems UI.

Device names:
![Screenshot 2024-06-10 at 14 52 37](https://github.com/openxla/xla/assets/6459623/d889d37e-ca2e-4f5e-b5bd-240bbb625b4c)

Stream names:
![Screenshot 2024-06-10 at 14 53 25](https://github.com/openxla/xla/assets/6459623/4bfc4ffa-8fdf-4b93-b23e-95bf056799f3)

Thread names:
![Screenshot 2024-06-10 at 14 54 04](https://github.com/openxla/xla/assets/6459623/8852ca9e-f2f4-4a45-8334-a18f8ab5ce18)

This also provides a missing link between replica IDs in the HLO and the physical devices in the profile.