### PR TITLE
[ROCM] gemm_rewriter: bugfixing supported datatypes combinations

### DIFF
--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -2040,7 +2040,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         {ComputationType::kF64, DataType::kComplexDouble, PrimitiveType::C128,
          PrimitiveType::C128, DataType::kComplexDouble},
     };
-    if (IsCuda(gpu_version_) &&
+    if (/*IsCuda(gpu_version_) &&*/
         absl::c_linear_search(supported_cublas_type_combinations,
                               std::tuple{compute_type, scale_type, a_dtype,
                                               b_dtype, output_dtype})) {

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -2040,9 +2040,10 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         {ComputationType::kF64, DataType::kComplexDouble, PrimitiveType::C128,
          PrimitiveType::C128, DataType::kComplexDouble},
     };
-    if (absl::c_linear_search(supported_cublas_type_combinations,
-                              std::make_tuple(compute_type, scale_type, a_dtype,
-                                              b_dtype, output_dtype))) {
+    if (IsCuda(gpu_version_) &&
+        absl::c_linear_search(supported_cublas_type_combinations,
+                              std::tuple{compute_type, scale_type, a_dtype,
+                                              b_dtype, output_dtype})) {
       return true;
     }
     const TypeCombinations supported_hipblas_type_combinations = {
@@ -2078,9 +2079,10 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         {ComputationType::kF32, DataType::kFloat, PrimitiveType::F8E5M2FNUZ,
          PrimitiveType::F8E4M3FNUZ, DataType::kFloat},
     };
-    if (absl::c_linear_search(supported_hipblas_type_combinations,
-                              std::make_tuple(compute_type, scale_type, a_dtype,
-                                              b_dtype, output_dtype))) {
+    if (IsRocm(gpu_version_) && 
+          absl::c_linear_search(supported_hipblas_type_combinations,
+                              std::tuple{compute_type, scale_type, a_dtype,
+                                              b_dtype, output_dtype})) {
       return true;
     }
     const TypeCombinations supported_type_combinations = {

--- a/xla/service/gpu/gemm_rewriter.cc
+++ b/xla/service/gpu/gemm_rewriter.cc
@@ -2040,7 +2040,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         {ComputationType::kF64, DataType::kComplexDouble, PrimitiveType::C128,
          PrimitiveType::C128, DataType::kComplexDouble},
     };
-    if (/*IsCuda(gpu_version_) &&*/
+    if (IsCuda(gpu_version_) &&
         absl::c_linear_search(supported_cublas_type_combinations,
                               std::tuple{compute_type, scale_type, a_dtype,
                                               b_dtype, output_dtype})) {

--- a/xla/tests/matmul_test.cc
+++ b/xla/tests/matmul_test.cc
@@ -51,6 +51,24 @@ class MatmulTestWithCublas : public HloTestBase,
   const bool use_cublas_lt_{GetParam()};
 };
 
+TEST_P(MatmulTestWithCublas, GemmRewriter_RegressionTestF64) {
+
+  const char* module_str = R"(
+HloModule GeneralMatMulActivation.7, entry_computation_layout={(f64[2,2,2]{2,1,0}, f64[2,2,2]{2,1,0})->f64[2,2,2]{2,1,0}}
+
+ENTRY GeneralMatMulActivation.7 {
+  x.1 = f64[2,2,2]{2,1,0} parameter(0)
+  y.2 = f64[2,2,2]{2,1,0} parameter(1)
+  dot.3 = f64[2,2,2]{2,1,0} dot(x.1, y.2), lhs_batch_dims={0}, lhs_contracting_dims={2}, rhs_batch_dims={0}, rhs_contracting_dims={1}
+  constant.4 = f64[] constant(0)
+  broadcast.5 = f64[2,2,2]{2,1,0} broadcast(constant.4), dimensions={}
+  ROOT maximum.6 = f64[2,2,2]{2,1,0} maximum(dot.3, broadcast.5)
+})";
+
+  EXPECT_TRUE(RunAndCompare(module_str, ErrorSpec{1e-4, 1e-4}));
+
+}
+
 // There was an issue where the compilation process of an Inverse operation was
 // resulting in a cached cuBLASLt matmul plan which was incorrectly fetched at
 // the time of the Matmul operation


### PR DESCRIPTION
This PR https://github.com/openxla/xla/pull/12553 introduced some a regression bug by enabling CUDA-specific and ROCM-specific datatype combinations on both platforms.

@xla-rotation: could you please have a look ? 