### PR TITLE
[ROCM] rocBLAS: default algorithm fallback

### DIFF
--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -692,17 +692,15 @@ bool ROCMBlas::GetBlasGemmAlgorithms(
   auto blas_lambda = [this, out_algorithms](auto handle, auto &&blas_func,
                                             auto &&...rest) {
     rocblas_int num_sols = 0;
-
+    // If get_solutions call fails, we still can use the default (fallback) 
+    // algorithm which is available for almost all number types.
     if (auto ret = blas_func(handle, std::forward<decltype(rest)>(rest)...,
-                             nullptr, &num_sols);
-        ret != rocblas_status_success) {
-      return ret;
-    }
-    solutions_.resize(num_sols);
-    if (auto ret = blas_func(handle, std::forward<decltype(rest)>(rest)...,
-                             solutions_.data(), &num_sols);
-        ret != rocblas_status_success) {
-      return ret;
+                         nullptr, &num_sols); ret == rocblas_status_success) {
+      solutions_.resize(num_sols);
+      if(ret = blas_func(handle, std::forward<decltype(rest)>(rest)...,
+                solutions_.data(), &num_sols); ret != rocblas_status_success) {
+        num_sols = 0;
+      }
     }
     out_algorithms->resize(num_sols + 1);
     (*out_algorithms)[0] = blas::kDefaultAlgorithm;

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -697,7 +697,7 @@ bool ROCMBlas::GetBlasGemmAlgorithms(
     if (auto ret = blas_func(handle, std::forward<decltype(rest)>(rest)...,
                          nullptr, &num_sols); ret == rocblas_status_success) {
       solutions_.resize(num_sols);
-      if(ret = blas_func(handle, std::forward<decltype(rest)>(rest)...,
+      if (ret = blas_func(handle, std::forward<decltype(rest)>(rest)...,
                 solutions_.data(), &num_sols); ret != rocblas_status_success) {
         num_sols = 0;
       }


### PR DESCRIPTION
Some number types (like complex64) are generally supported by rocBLAS but the library does not provide any solutions for autotuning. In that case, we shall fallback to use the default solution (kDefaultAlgorithm).

Besides, I have also added workspace buffer provided by XLA runtime which previously was ignored by rocBLAS.

@xla-rotation: would you please have a look ?