### PR TITLE
Fix clamp test.

### DIFF
--- a/xla/service/gpu/fusions/cudnn_test.cc
+++ b/xla/service/gpu/fusions/cudnn_test.cc
@@ -557,6 +557,10 @@ ENTRY e {
 }
 
 TEST_F(CuDnnFusionLevel2Test, ClampExecutesCorrectly) {
+  if (!IsAtLeastCuDnn91()) {
+    GTEST_SKIP() << "Clamp test requires cuDNN 9.1+.";
+  }
+
   EXPECT_TRUE(RunAndCompare(R"(
 fusion1 {
   x = bf16[16,32] parameter(0)


### PR DESCRIPTION
Only test cuDNN clamp for versions above 9.1 due to constant fusing capability. 