### PR TITLE
[XLA:GPU] Upgrade cuDNN frontend to 1.5

### DIFF
--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,5 +1,5 @@
 diff --git a/include/cudnn_frontend.h b/include/cudnn_frontend.h
-index 0f0d5a6..802bcbb 100644
+index 7bca425..cd74e3a 100644
 --- a/include/cudnn_frontend.h
 +++ b/include/cudnn_frontend.h
 @@ -97,7 +97,7 @@
@@ -11,3 +11,42 @@ index 0f0d5a6..802bcbb 100644
  
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_Heuristics.h"
+diff --git a/include/cudnn_frontend/backend/backend_descriptor.h b/include/cudnn_frontend/backend/backend_descriptor.h
+index dc7ad25..ade164a 100644
+--- a/include/cudnn_frontend/backend/backend_descriptor.h
++++ b/include/cudnn_frontend/backend/backend_descriptor.h
+@@ -2,7 +2,7 @@
+ 
+ #include <memory>
+ 
+-#include "cudnn.h"
++#include "third_party/gpus/cudnn/cudnn.h"
+ 
+ namespace cudnn_frontend::detail {
+ 
+diff --git a/include/cudnn_frontend/backend/execution_helpers.h b/include/cudnn_frontend/backend/execution_helpers.h
+index 334ffde..d2ca694 100644
+--- a/include/cudnn_frontend/backend/execution_helpers.h
++++ b/include/cudnn_frontend/backend/execution_helpers.h
+@@ -2,7 +2,7 @@
+ 
+ #include <vector>
+ 
+-#include "cudnn.h"
++#include "third_party/gpus/cudnn/cudnn.h"
+ 
+ #include "backend_descriptor.h"
+ 
+diff --git a/include/cudnn_frontend/backend/plan_helpers.h b/include/cudnn_frontend/backend/plan_helpers.h
+index 1fa458d..8c37d10 100644
+--- a/include/cudnn_frontend/backend/plan_helpers.h
++++ b/include/cudnn_frontend/backend/plan_helpers.h
+@@ -2,7 +2,7 @@
+ 
+ #include <vector>
+ 
+-#include "cudnn.h"
++#include "third_party/gpus/cudnn/cudnn.h"
+ 
+ #include "backend_descriptor.h"
+ 

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -48,9 +48,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "5727ed189a17fe888f1729ba09b2afd8df3e71192a27e9fa87e14a60f7b9d367",
-        strip_prefix = "cudnn-frontend-1.3.0",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.3.0.zip"),
+        sha256 = "f00f8cc2a80858b59b736aeeaaaea46a38cb25560c2b5b9e2482c812c0432d02",
+        strip_prefix = "cudnn-frontend-1.5.0",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.5.0.zip"),
     )
 
     tf_http_archive(

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -48,9 +48,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "f00f8cc2a80858b59b736aeeaaaea46a38cb25560c2b5b9e2482c812c0432d02",
-        strip_prefix = "cudnn-frontend-1.5.0",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.5.0.zip"),
+        sha256 = "281789777ac296f5f8215a7c4bd066de8816d240eb44c760788beebf8d25a99f",
+        strip_prefix = "cudnn-frontend-1.5.1",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.5.1.zip"),
     )
 
     tf_http_archive(

--- a/xla/tsl/cuda/cudnn.symbols
+++ b/xla/tsl/cuda/cudnn.symbols
@@ -270,3 +270,4 @@ cudnnSpatialTfSamplerForward
 cudnnTransformFilter
 cudnnTransformTensor
 cudnnTransformTensorEx
+cudnnGetLastErrorString


### PR DESCRIPTION
release note: https://github.com/NVIDIA/cudnn-frontend/releases/tag/v1.5.0