### PR TITLE
Increase alignment of Traits::Params to 128

### DIFF
--- a/xla/service/gpu/kernels/cutlass_gemm_adaptor.cu.h
+++ b/xla/service/gpu/kernels/cutlass_gemm_adaptor.cu.h
@@ -283,7 +283,9 @@ static void Initialize(void *params, const Arguments &args, int32_t device_sms,
   // defined by custom gemm kernel.
   static_assert(sizeof(typename Traits<Tag>::Params) <= 1024,
                 "Params struct size is too large");
-  static_assert(alignof(typename Traits<Tag>::Params) <= 64,
+  // The alignment check here needs to be consistent with the definition of
+  // Params in file cutlass_gemm_custom_kernel.cc
+  static_assert(alignof(typename Traits<Tag>::Params) <= 128,
                 "Params struct alignment is too large");
 
   // Convert CUTLASS operation arguments to a device kernel parameters.

--- a/xla/service/gpu/kernels/cutlass_gemm_custom_kernel.cc
+++ b/xla/service/gpu/kernels/cutlass_gemm_custom_kernel.cc
@@ -100,7 +100,7 @@ KernelArgsPacking ArgsPacking(int32_t m, int32_t n, int32_t k,
   // object constructed in the storage. For now we ignore it, and it's textbook
   // definition of UB, but for CUTLASS kernels we use today it's perfectly safe.
   struct Params {
-    alignas(64) std::byte storage[1024];
+    alignas(128) std::byte storage[1024];
   };
 
   return [=](const se::Kernel& kernel, const se::KernelArgs& args) -> Packed {


### PR DESCRIPTION
This fixes a static_assert failure in Nvidia's internal Blackwell testing. Checked with Eugene that bumping up alignment is OK.