### PR TITLE
Add host memory space to entry_computation_layout

### DIFF
--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -313,6 +313,10 @@ class PjRtStreamExecutorClient : public PjRtClient {
       const XlaComputation& computation, CompileOptions options) override;
   absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> Compile(
       mlir::ModuleOp mlir_module, CompileOptions options) override;
+  absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> Compile(
+      const XlaComputation& computation,
+      const std::vector<const Shape*>& argument_layout_pointers,
+      const Shape& result_layout, CompileOptions options);
 
   virtual absl::StatusOr<std::string> SerializeExecutable(
       const PjRtLoadedExecutable& executable) const;


### PR DESCRIPTION
During the transformation of MLIR to HLO, the host memory space was being dropped. This commit addresses that issue by utilizing utility functions to retrieve the memory space and layout information. It then passes this information to the module's entry computation.
With the input parameters receiving the correct host memory space, the commit enables proper generation of copy-start and copy-done operations for pinned host-to-device memory copies.