### PR TITLE
Convolution Layout Normalization for Parameter Operands

### DIFF
--- a/xla/service/gpu/conv_layout_normalization.cc
+++ b/xla/service/gpu/conv_layout_normalization.cc
@@ -136,15 +136,7 @@ absl::StatusOr<std::optional<HloInstruction*>> UpdateLayoutForCudnnConvolution(
     const Shape& s = op->shape();
     Shape s_reordered =
         ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(s);
-    HloInstruction* normalized_op = op->mutable_operand(0);
-    HloInstruction* new_op;
-    if (normalized_op->shape() == s_reordered) {
-      new_op = normalized_op;
-    } else {
-      new_op = MakeBitcastHlo(op, s_reordered);
-      performed_normalization = true;
-    }
-    normalized_operands.push_back(new_op);
+    normalized_operands.emplace_back(MakeBitcastHlo(op, s_reordered));
   }
 
   // Avoid replacing the Custom Call with an identical copy.

--- a/xla/service/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
@@ -59,6 +59,7 @@ limitations under the License.
 
 #if GOOGLE_CUDA
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cudnn/cudnn.h"  // IWYU pragma: keep
 #elif TENSORFLOW_USE_ROCM
 #include "rocm/rocm_config.h"
 #endif  // GOOGLE_CUDA


### PR DESCRIPTION
Modifies the layout normalization for convolutions to support the direct operation on parameters and constants.

This enables running TestConvAmaxF8 and TestConvReluAmaxF8 in cudnn_fused_conv_rewriter_test.cc.