### PR TITLE
[XLA:GPU] Add synchronized allocation mode for cuda async memory allocator

### DIFF
--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
@@ -77,8 +77,9 @@ class GpuCudaMallocAsyncAllocator : public tsl::Allocator {
   explicit GpuCudaMallocAsyncAllocator(tsl::PlatformDeviceId platform_device_id,
                                        bool create_new_pool,
                                        size_t new_pool_size,
-                                       size_t release_threshold = 0,
                                        bool reserve_memory = false,
+                                       size_t reserve_memory_size = 0,
+                                       bool sync_mode = false,
                                        bool compute_stats = true);
 
   ~GpuCudaMallocAsyncAllocator() override;
@@ -133,6 +134,10 @@ class GpuCudaMallocAsyncAllocator : public tsl::Allocator {
   bool reserve_memory_;
 
   bool create_new_pool_;
+
+  // When the allocator is working in sync mode, the allocator will block host
+  // thread until memory allocation has completed.
+  bool sync_mode_;
 
   GpuCudaMallocAsyncAllocator(const GpuCudaMallocAsyncAllocator&) = delete;
   void operator=(const GpuCudaMallocAsyncAllocator&) = delete;

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
@@ -66,6 +66,9 @@ TEST(GpuCudaMallocAsyncAllocator, AddressAlignedDefaultPool) {
   void* addr2 = allocator.AllocateRaw(128, 129);
   CHECK_EQ((reinterpret_cast<uintptr_t>(addr1) & 127), 0);
   CHECK_EQ((reinterpret_cast<uintptr_t>(addr2) & 127), 0);
+  allocator.DeallocateRaw(addr1);
+  allocator.DeallocateRaw(addr2);
+  EXPECT_TRUE(stream->ok());
 }
 
 TEST(GpuCudaMallocAsyncAllocator, AddressAlignedNewPool) {
@@ -79,8 +82,9 @@ TEST(GpuCudaMallocAsyncAllocator, AddressAlignedNewPool) {
       /*platform_device_id*/ tsl::PlatformDeviceId(executor->device_ordinal()),
       /*create_new_pool*/ true,
       /*new_pool_size*/ 2048,
-      /*release_threshold*/ 0,
       /*reserve_memory*/ true,
+      /*release_threshold*/ 0,
+      /*sync_mode*/ false,
       /*compute_stats*/ true);
   allocator.SetStreamAndPreallocateMemory(
       se::gpu::AsGpuStreamValue(stream.get()));
@@ -89,6 +93,39 @@ TEST(GpuCudaMallocAsyncAllocator, AddressAlignedNewPool) {
   void* addr2 = allocator.AllocateRaw(128, 129);
   CHECK_EQ((reinterpret_cast<uintptr_t>(addr1) & 127), 0);
   CHECK_EQ((reinterpret_cast<uintptr_t>(addr2) & 127), 0);
+  allocator.DeallocateRaw(addr1);
+  allocator.DeallocateRaw(addr2);
+  EXPECT_TRUE(stream->ok());
 }
+
+TEST(GpuCudaMallocAsyncAllocator, SyncAddressAlignedNewPool) {
+#if CUDA_VERSION < 11030
+  GTEST_SKIP() << "Cuda async memory allocator is not supported for CUDA "
+                  "version less than 11030";
+#endif
+  se::StreamExecutor* executor = GpuExecutor();
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  auto allocator = GpuCudaMallocAsyncAllocator(
+      /*platform_device_id*/ tsl::PlatformDeviceId(executor->device_ordinal()),
+      /*create_new_pool*/ true,
+      /*new_pool_size*/ 2048,
+      /*reserve_memory*/ true,
+      /*release_threshold*/ 0,
+      /*sync_mode*/ true,
+      /*compute_stats*/ true);
+  allocator.SetStreamAndPreallocateMemory(
+      se::gpu::AsGpuStreamValue(stream.get()));
+
+  void* addr1 = allocator.AllocateRaw(128, 127);
+  void* addr2 = allocator.AllocateRaw(128, 129);
+  CHECK_EQ((reinterpret_cast<uintptr_t>(addr1) & 127), 0);
+  CHECK_EQ((reinterpret_cast<uintptr_t>(addr2) & 127), 0);
+  allocator.DeallocateRaw(addr1);
+  allocator.DeallocateRaw(addr2);
+  EXPECT_TRUE(stream->ok());
+}
+
+
+
 
 }  // namespace stream_executor

--- a/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
+++ b/xla/stream_executor/gpu/gpu_cudamallocasync_allocator_test.cc
@@ -125,7 +125,4 @@ TEST(GpuCudaMallocAsyncAllocator, SyncAddressAlignedNewPool) {
   EXPECT_TRUE(stream->ok());
 }
 
-
-
-
 }  // namespace stream_executor


### PR DESCRIPTION
This PR adds the synchronized mode to cuda async memory allocator, whose behavior will be the same as BFCAllocator. We are planning to use async allocator to replace BFCAllocator for allocating temp buffer. Later, will try to move to async mode for temp allocation, but first step using sync allocator is more safe.
