### PR TITLE
Added `struct` in front of recursive struct PJRT_Extension_Base

### DIFF
--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -53,7 +53,7 @@ typedef enum {
 typedef struct PJRT_Extension_Base {
   size_t struct_size;
   PJRT_Extension_Type type;
-  PJRT_Extension_Base* next;
+  struct PJRT_Extension_Base* next;
 } PJRT_Extension_Base;
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 


### PR DESCRIPTION
In C the type alias of `struct PJRT_Extension_Base` to `PJRT_Extension_Base` (without "struct") is not created yet, and the .h file fails to compile (both in gcc and clang).

C++ compiles that because it does create the alias.

The change won't break C++, and it will allow the C version to work as well.

See #13733

Tested with `bazel test //xla/pjrt/c:pjrt_c_api_cpu_test`