### PR TITLE
Introduce `xla_gpu_test` macro to avoid common boilerplate in BUILD files

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -27,16 +27,15 @@ load(
     "build_cub_sort_kernels",
     "get_cub_sort_kernel_types",
     "gpu_kernel_library",
+    "xla_gpu_test",
 )
 load(
     "//xla/stream_executor:build_defs.bzl",
     "if_gpu_is_configured",
 )
-load("//xla/tests:build_defs.bzl", "xla_test")
 load(
     "//xla/tsl:tsl.bzl",
     "if_google",
-    "if_oss",
     "internal_visibility",
     "tsl_copts",
     "tsl_gpu_library",
@@ -144,11 +143,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "custom_call_test",
-    srcs = if_gpu_is_configured(["custom_call_test.cc"]),
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    srcs = ["custom_call_test.cc"],
     deps = [
         "//xla:debug_options_flags",
         "//xla:shape_util",
@@ -167,7 +164,6 @@ xla_test(
         "//xla/stream_executor:scratch_allocator",
         "//xla/stream_executor/gpu:gpu_types_header",
         "//xla/tests:client_library_test_base",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
@@ -177,7 +173,8 @@ xla_test(
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",
@@ -610,17 +607,13 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "ir_emitter_triton_test",
-    srcs = if_gpu_is_configured(["ir_emitter_triton_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_h100",
-        "gpu_amd_any",
-    ],
+    srcs = ["ir_emitter_triton_test.cc"],
+    with_cuda = "ampere+",
+    with_rocm = False,
     shard_count = 20,
     tags = [
-        "no_rocm",
         "nomac",
     ],
     deps = [
@@ -643,7 +636,6 @@ xla_test(
         "//xla/stream_executor/cuda:cublas_plugin",
         "//xla/tests:filecheck",
         "//xla/tests:verified_hlo_module",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
@@ -720,14 +712,10 @@ cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "ir_emitter_triton_large_test",
-    srcs = if_gpu_is_configured(["ir_emitter_triton_large_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_h100",
-        "gpu_amd_any",
-    ],
+    srcs = ["ir_emitter_triton_large_test.cc"],
+    with_cuda = "ampere+",
     tags = [
         "large",
         "no_oss",  # requires-mem:16g tag doesn't work in open source
@@ -739,20 +727,15 @@ xla_test(
         "//xla:xla_proto_cc",
         "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/log:check",
         "@com_google_googletest//:gtest",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "ir_emitter_triton_parametrized_test",
-    srcs = if_gpu_is_configured(["ir_emitter_triton_parametrized_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_h100",
-        "gpu_amd_any",
-    ],
+    srcs = ["ir_emitter_triton_parametrized_test.cc"],
+    with_cuda = "ampere+",
     shard_count = 10,
     tags = ["nomac"],
     deps = [
@@ -765,7 +748,6 @@ xla_test(
         "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor/cuda:cublas_plugin",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
@@ -841,15 +823,12 @@ cc_library(
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "gemm_fusion_autotuner_test",
-    srcs = if_cuda_is_configured(["gemm_fusion_autotuner_test.cc"]),
-    backend_tags = {"gpu": [
-        "requires-gpu-sm80",
-    ]},
-    backends = [
-        "gpu",
-    ],
+    srcs = ["gemm_fusion_autotuner_test.cc"],
+    with_cuda = "ampere+",
+    with_rocm = False,
+    disabled_backends = ["gpu_h100"],
     tags = [
         "nomac",
     ],
@@ -876,7 +855,6 @@ xla_test(
         "//xla/tests:hlo_test_base",
         "//xla/tests:test_utils",
         "//xla/tests:verified_hlo_module",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "//xla/tools:hlo_decomposer_lib",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
@@ -889,7 +867,8 @@ xla_test(
         "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:status_matchers",
         "@tsl//tsl/platform:statusor",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
     ]),
 )
@@ -1246,14 +1225,10 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "triton_support_test",
-    srcs = if_gpu_is_configured(["triton_support_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_h100",
-        "gpu_amd_any",
-    ],
+    srcs = ["triton_support_test.cc"],
+    with_cuda = "ampere+",
     deps = [
         ":gpu_device_info_for_tests",
         ":ir_emitter_triton",
@@ -1268,21 +1243,16 @@ xla_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:status_matchers",
         "@tsl//tsl/platform:statusor",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "triton_support_legacy_test",
-    srcs = if_gpu_is_configured(["triton_support_legacy_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_h100",
-        "gpu_amd_any",
-    ],
+    srcs = ["triton_support_legacy_test.cc"],
+    with_cuda = "ampere+",
     tags = ["nomac"],
     deps = [
         ":gpu_device_info_for_tests",
@@ -1301,7 +1271,6 @@ xla_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:status_matchers",
         "@tsl//tsl/platform:statusor",
@@ -1689,36 +1658,26 @@ cc_library(
     ]) + ["@com_google_absl//absl/status"],
 )
 
-xla_test(
+xla_gpu_test(
     name = "autotuner_compile_util_test",
-    srcs = if_gpu_is_configured(["autotuner_compile_util_test.cc"]),
-    backends = ["gpu"],
-    deps = if_gpu_is_configured(
-        [
-            ":autotuner_compile_util",
-            ":autotuner_util",
-            "@com_google_googletest//:gtest_main",
-            "@com_google_absl//absl/strings",
-            "@com_google_absl//absl/strings:string_view",
-            "//xla/hlo/ir:hlo",
-            "//xla/service:platform_util",
-            "//xla/stream_executor:platform",
-            "//xla/tests:hlo_test_base",
-            "@tsl//tsl/platform:statusor",
-        ],
-        if_false = [
-            "@com_google_googletest//:gtest_main",  # b/317293391
-        ],
-    ),
+    srcs = ["autotuner_compile_util_test.cc"],
+    deps = [
+        ":autotuner_compile_util",
+        ":autotuner_util",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:platform_util",
+        "//xla/stream_executor:platform",
+        "//xla/tests:hlo_test_base",
+        "@tsl//tsl/platform:statusor",
+    ]
 )
 
-xla_test(
+xla_gpu_test(
     name = "gemm_algorithm_picker_test",
-    srcs = if_gpu_is_configured(["gemm_algorithm_picker_test.cc"]),
-    backends = [
-        "gpu_v100",
-        "gpu_amd_any",
-    ],
+    srcs = ["gemm_algorithm_picker_test.cc"],
+    with_cuda = "volta+",
     deps = [
         ":autotuner_util",
         ":backend_configs_cc",
@@ -1735,7 +1694,6 @@ xla_test(
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
         "@tsl//tsl/protobuf:dnn_proto_cc",
     ],
 )
@@ -1832,16 +1790,14 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "dot_dimension_sorter_test",
     srcs = ["dot_dimension_sorter_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":dot_dimension_sorter",
         "//xla:error_spec",
         "//xla/hlo/ir:hlo",
         "//xla/service/gpu/tests:gpu_codegen_test",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_googletest//:gtest",
         "@tsl//tsl/platform:statusor",
     ],
@@ -2011,13 +1967,10 @@ cc_library(
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "conv_algorithm_picker_test",
-    srcs = if_gpu_is_configured(["conv_algorithm_picker_test.cc"]),
-    backends = [
-        "gpu_v100",
-        "gpu_amd_any",
-    ],
+    srcs = ["conv_algorithm_picker_test.cc"],
+    with_cuda = "volta+",
     tags = [
         "noasan",
         "nomsan",
@@ -2039,7 +1992,6 @@ xla_test(
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -2233,10 +2185,9 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_sort_rewriter_test",
-    srcs = if_cuda_is_configured(["gpu_sort_rewriter_test.cc"]),
-    backends = ["gpu"],
+    srcs = ["gpu_sort_rewriter_test.cc"],
     tags = ["no_oss"],
     deps = [
         ":cublas_cudnn",
@@ -2247,7 +2198,6 @@ xla_test(
         "//xla/service:pattern_matcher",
         "//xla/service:pattern_matcher_gmock",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_googletest//:gtest",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
@@ -3635,10 +3585,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_compiler_test",
-    srcs = if_gpu_is_configured(["gpu_compiler_test.cc"]),
-    backends = ["gpu"],
+    srcs = ["gpu_compiler_test.cc"],
     data = ["gpu_compiler_test_autotune_db.textproto"],
     deps = [
         ":autotuner_util",
@@ -3656,7 +3605,6 @@ xla_test(
         "//xla/stream_executor:device_description",
         "//xla/tests:filecheck",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status:statusor",
@@ -3673,10 +3621,9 @@ xla_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_offloading_test",
     srcs = ["gpu_offloading_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":backend_configs_cc",
         "//xla:autotune_results_proto_cc",
@@ -3691,7 +3638,6 @@ xla_test(
         "//xla/service:hlo_rematerialization",
         "//xla/service/gpu:stream_attribute_annotator",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
@@ -3700,10 +3646,9 @@ xla_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "auto_sharding_gpu_compiler_test",
     srcs = ["auto_sharding_gpu_compiler_test.cc"],
-    backends = ["gpu"],
     tags = ["no_oss"],  # TODO(b/277355322): Make autosharding work in OSS
     deps = [
         "//xla:shape_util",
@@ -3712,7 +3657,6 @@ xla_test(
         "//xla/service:pattern_matcher",
         "//xla/service:pattern_matcher_gmock",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/platform:logging",
     ],
@@ -3851,17 +3795,12 @@ cc_library(
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "nvptx_compiler_test",
-    srcs = if_cuda_is_configured([
-        "nvptx_compiler_test.cc",
-    ]),
-    backends = [
-        "gpu_v100",
-        "gpu_a100",
-    ],
+    srcs = ["nvptx_compiler_test.cc"],
+    with_cuda = "volta+",
+    with_rocm = False,
     tags = [
-        "no_rocm",
         "nomsan",  # Pulls in precompiled NVIDIA libraries which cause false positives in msan.
     ],
     deps = [
@@ -3879,7 +3818,6 @@ xla_test(
         "//xla/service:logical_buffer",
         "//xla/stream_executor:device_description",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
@@ -4260,12 +4198,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_hlo_schedule_test",
-    srcs = [
-        "gpu_hlo_schedule_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["gpu_hlo_schedule_test.cc"],
     deps = [
         ":gpu_hlo_schedule",
         "//xla:shape_util",
@@ -4278,7 +4213,6 @@ xla_test(
         "//xla/tests:filecheck",
         "//xla/tests:hlo_test_base",
         "//xla/tests:test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings:string_view",
@@ -4564,19 +4498,17 @@ gpu_kernel_library(
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "buffer_comparator_test",
-    srcs = if_gpu_is_configured(["buffer_comparator_test.cc"]),
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    srcs = ["buffer_comparator_test.cc"],
     deps = [
+        ":buffer_comparator",
         ":stream_executor_util",
         "//xla:shape_util",
         "//xla:types",
         "//xla/service:hlo_module_config",
         "//xla/stream_executor",
+        "//xla/stream_executor:device_memory",
         "//xla/stream_executor:device_memory_allocator",
         "//xla/stream_executor:device_memory_handle",
         "//xla/stream_executor:platform_manager",
@@ -4584,10 +4516,7 @@ xla_test(
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:test",
         "@tsl//tsl/platform:test_main",
-    ] + if_gpu_is_configured([
-        ":buffer_comparator",
-        "//xla/stream_executor:device_memory",
-    ]),
+    ],
 )
 
 cc_library(
@@ -4689,23 +4618,14 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "cudnn_fused_conv_rewriter_test",
     srcs = ["cudnn_fused_conv_rewriter_test.cc"],
-    backend_tags = {
-        "gpu_a100": [
-            "noasan",
-            "nomsan",
-            "no_rocm",
-        ],
-    },
-    backends = [
-        "gpu_a100",
-        "gpu_amd_any",
-    ] + if_oss(["gpu_any"]),
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
+    with_cuda = "ampere+",
+    tags = [
+        "noasan",
+        "nomsan",
+    ],
     shard_count = 10,
     deps = [
         ":backend_configs_cc",
@@ -4735,11 +4655,11 @@ xla_test(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
-        "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
         "@local_config_cuda//cuda:cudnn_header",
     ]) + if_rocm_is_configured([
@@ -4784,11 +4704,9 @@ cc_library(
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "cudnn_norm_rewriter_test",
     srcs = ["cudnn_norm_rewriter_test.cc"],
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":cublas_cudnn",
         ":cudnn_norm_rewriter",
@@ -4798,7 +4716,8 @@ xla_test(
         "//xla/tests:filecheck",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
         "@local_config_cuda//cuda:cudnn_header",
     ]),
@@ -4868,17 +4787,10 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "cudnn_fused_mha_rewriter_test",
     srcs = ["cudnn_fused_mha_rewriter_test.cc"],
-    backend_tags = {"gpu": [
-        "requires-gpu-nvidia",
-        "no_rocm",
-    ]},
-    backends = [
-        "gpu",
-    ],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    with_rocm = False,
     deps = [
         ":backend_configs_cc",
         ":cublas_cudnn",
@@ -4908,42 +4820,34 @@ xla_test(
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
         "@local_config_cuda//cuda:cudnn_header",
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "float_support_test",
     srcs = ["float_support_test.cc"],
-    backend_tags = {"gpu": [
-        "requires-gpu-sm80",
-    ]},
-    backends = [
-        "gpu",
-    ],
+    with_cuda = "ampere+",
     deps = [
         ":variant_visitor",
         "//xla:error_spec",
         "//xla:xla_proto_cc",
         "//xla/stream_executor:device_description",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "conv_layout_normalization_test",
     srcs = ["conv_layout_normalization_test.cc"],
-    backends = ["gpu"],
     deps = [
         "//xla:error_spec",
         "//xla/hlo/ir:hlo",
-        "//xla/service/gpu/tests:gpu_codegen_test",  # fixdeps: keep
         "//xla/tests:hlo_test_base",
         "//xla/tests:test_macros_header",
         "@tsl//tsl/platform:test",
@@ -5109,10 +5013,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "horizontal_loop_fusion_test",
     srcs = ["horizontal_loop_fusion_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_device_info_for_tests",
         ":horizontal_loop_fusion",
@@ -5129,7 +5032,6 @@ xla_test(
         "//xla/service:pattern_matcher_gmock",
         "//xla/stream_executor:device_description",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/log",
         "@tsl//tsl/lib/core:status_test_util",
@@ -5157,10 +5059,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "horizontal_input_fusion_test",
     srcs = ["horizontal_input_fusion_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_device_info_for_tests",
         ":horizontal_input_fusion",
@@ -5173,7 +5074,6 @@ xla_test(
         "//xla/service:pattern_matcher_gmock",
         "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/stream_executor:device_description",
-        "//xla/tests:xla_internal_test_main",
     ],
 )
 
@@ -5347,31 +5247,22 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "dot_operand_converter_test",
-    srcs = if_gpu_is_configured(["dot_operand_converter_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_p100",
-        "gpu_v100",
-        "gpu_amd_any",
+    srcs = ["dot_operand_converter_test.cc"],
+    deps = [
+        ":dot_operand_converter",
+        "@com_google_googletest//:gtest",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/utils:hlo_matchers",
+        "//xla/service:pattern_matcher",
+        "//xla/tests:hlo_test_base",
+        "@tsl//tsl/platform:statusor",
     ],
-    deps = if_gpu_is_configured(
-        [
-            ":dot_operand_converter",
-            "@com_google_googletest//:gtest",
-            "@com_google_absl//absl/strings",
-            "@com_google_absl//absl/strings:string_view",
-            "//xla:shape_util",
-            "//xla/hlo/ir:hlo",
-            "//xla/hlo/utils:hlo_matchers",
-            "//xla/service:pattern_matcher",
-            "//xla/tests:hlo_test_base",
-            "//xla/tests:xla_internal_test_main",
-            "@tsl//tsl/platform:statusor",
-        ],
-        ["@tsl//tsl/platform:test_main"],  # b/317293391
-    ) + ["//xla:xla_data_proto_cc"],
 )
 
 cc_library(
@@ -5446,15 +5337,13 @@ tsl_gpu_library(
     alwayslink = 1,
 )
 
-xla_test(
+xla_gpu_test(
     name = "runtime_intrinsics_test",
     srcs = ["runtime_intrinsics_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":runtime_intrinsics",
         "//xla/hlo/ir:hlo",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/platform:statusor",
@@ -5608,10 +5497,9 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "topk_test",
     srcs = ["topk_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":topk_specializer",
         "//xla:shape_util",
@@ -5620,7 +5508,6 @@ xla_test(
         "//xla/service:platform_util",
         "//xla/service:topk_rewriter",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
@@ -5672,14 +5559,11 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "dot_algorithm_support_test",
-    srcs = if_gpu_is_configured(["dot_algorithm_support_test.cc"]),
-    backends = [
-        "gpu_v100",
-        "gpu_a100",
-        "gpu_amd_any",
-    ],
+    srcs = ["dot_algorithm_support_test.cc"],
+    with_cuda = "volta+",
+    disabled_backends = ["gpu_h100"],
     tags = [
         "nomac",
     ],
@@ -5689,7 +5573,6 @@ xla_test(
         "//xla/hlo/ir:hlo",
         "//xla/stream_executor:device_description",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest",
@@ -5892,34 +5775,24 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "determinism_test",
-    srcs = if_gpu_is_configured(["determinism_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_amd_any",
+    srcs = ["determinism_test.cc"],
+    with_cuda = "ampere+",
+    deps = [
+        ":autotuner_util",
+        "@com_google_absl//absl/strings",
+        "//xla:literal",
+        "//xla:xla_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu/tests:gpu_codegen_test",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:gpu_timer",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:literal_test_util",
+        "//xla/tests:test_utils",
+        "@tsl//tsl/platform:statusor",
     ],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
-    deps = if_gpu_is_configured(
-        [
-            ":autotuner_util",
-            "@com_google_googletest//:gtest_main",
-            "@com_google_absl//absl/strings",
-            "//xla:literal",
-            "//xla:xla_proto_cc",
-            "//xla/hlo/ir:hlo",
-            "//xla/service/gpu/tests:gpu_codegen_test",
-            "//xla/stream_executor:device_description",
-            "//xla/stream_executor/gpu:gpu_timer",
-            "//xla/tests:hlo_test_base",
-            "//xla/tests:literal_test_util",
-            "//xla/tests:test_utils",
-            "@tsl//tsl/platform:statusor",
-        ],
-        ["@tsl//tsl/platform:test_main"],  # b/317293391
-    ),
 )
 
 cc_library(
@@ -6142,13 +6015,10 @@ cc_library(
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "triton_fusion_numerics_verifier_test",
-    srcs = if_gpu_is_configured(["triton_fusion_numerics_verifier_test.cc"]),
-    backend_tags = {"gpu": [
-        "requires-gpu-sm80",
-    ]},
-    backends = ["gpu"],
+    srcs = ["triton_fusion_numerics_verifier_test.cc"],
+    with_cuda = "ampere+",
     deps = [
         ":autotuner_compile_util",
         ":autotuner_util",
@@ -6162,7 +6032,6 @@ xla_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
     ],
 )

--- a/xla/service/gpu/fusions/BUILD
+++ b/xla/service/gpu/fusions/BUILD
@@ -1,7 +1,7 @@
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
 load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 load("//xla:xla.bzl", "xla_cc_test")
-load("//xla/tests:build_defs.bzl", "xla_test")
+load("//xla/service/gpu:build_defs.bzl", "xla_gpu_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -76,17 +76,15 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "in_place_dynamic_update_slice_mlir_test",
     srcs = ["in_place_dynamic_update_slice_mlir_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":in_place_dynamic_update_slice_mlir",
         ":mlir_emitter_test_base",
         "//xla:error_spec",
         "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/service/gpu/model:indexing_test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
@@ -163,11 +161,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "dynamic_slice_fusion_test",
-    srcs = if_cuda_is_configured(["dynamic_slice_fusion_test.cc"]),
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    srcs = ["dynamic_slice_fusion_test.cc"],
     deps = [
         "//xla:error_spec",
         "//xla:shape_util",
@@ -193,8 +189,8 @@ xla_test(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",
@@ -374,17 +370,15 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "loop_mlir_test",
     srcs = ["loop_mlir_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":loop_mlir",
         ":mlir_emitter_test_base",
         "//xla:error_spec",
         "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/service/gpu/model:indexing_test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
@@ -423,17 +417,15 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "scatter_mlir_test",
     srcs = ["scatter_mlir_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":mlir_emitter_test_base",
         ":scatter_mlir",
         "//xla:error_spec",
         "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/service/gpu/model:indexing_test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
@@ -475,17 +467,15 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "transpose_mlir_test",
     srcs = ["transpose_mlir_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":mlir_emitter_test_base",
         ":transpose_mlir",
         "//xla:error_spec",
         "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/service/gpu/model:indexing_test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
@@ -661,15 +651,11 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "cudnn_test",
-    srcs = if_cuda_is_configured(["cudnn_test.cc"]),
-    backend_tags = {"gpu": [
-        "requires-gpu-sm90",
-    ]},
-    backends = [
-        "gpu",
-    ],
+    srcs = ["cudnn_test.cc"],
+    with_cuda = "hopper+",
+    with_rocm = False,
     deps = [
         "//xla:comparison_util",
         "//xla:debug_options_flags",
@@ -695,7 +681,6 @@ xla_test(
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -868,16 +853,14 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "reduction_mlir_test",
     srcs = ["reduction_mlir_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":mlir_emitter_test_base",
         ":reduction_mlir",
         "//xla:error_spec",
         "//xla/service/gpu/model:indexing_test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/lib/core:status_test_util",
@@ -954,17 +937,15 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "concatenate_mlir_test",
     srcs = ["concatenate_mlir_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":concatenate_mlir",
         ":mlir_emitter_test_base",
         "//xla:error_spec",
         "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/service/gpu/model:indexing_test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
@@ -1086,16 +1067,14 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "input_slices_mlir_test",
     srcs = ["input_slices_mlir_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":input_slices_mlir",
         ":mlir_emitter_test_base",
         "//xla:error_spec",
         "//xla/service/gpu/model:indexing_test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/xla/service/gpu/ir_emitter_triton_test.cc
+++ b/xla/service/gpu/ir_emitter_triton_test.cc
@@ -1425,7 +1425,7 @@ ENTRY entry {
 
   auto backend_config_or =
       triton_dot_fusion->backend_config<GpuBackendConfig>();
-  ASSERT_OK(backend_config_or);
+  TF_ASSERT_OK(backend_config_or);
   GpuBackendConfig& backend_config = *backend_config_or;
 
   FusionBackendConfig& fusion_backend_config =
@@ -1439,7 +1439,7 @@ ENTRY entry {
   config.set_num_warps(8);
   config.set_num_stages(4);
 
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   BlockLevelParameters block_level_parameters;
   block_level_parameters.num_ctas = 1;
@@ -1457,7 +1457,7 @@ ENTRY entry {
   config.set_block_n(128);
   config.set_block_k(128);
   block_level_parameters.num_stages = 1;
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   TF_ASSERT_OK_AND_ASSIGN(
       const auto result,
@@ -1972,7 +1972,7 @@ ENTRY entry {
 
   auto backend_config_or =
       triton_dot_fusion->backend_config<GpuBackendConfig>();
-  ASSERT_OK(backend_config_or);
+  TF_ASSERT_OK(backend_config_or);
   GpuBackendConfig& backend_config = *backend_config_or;
 
   FusionBackendConfig& fusion_backend_config =
@@ -1986,7 +1986,7 @@ ENTRY entry {
   config.set_num_ctas(1);
   config.set_num_stages(1);
   config.set_num_warps(2);
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   BlockLevelParameters block_level_parameters;
   block_level_parameters.num_ctas = 1;
@@ -2003,7 +2003,7 @@ ENTRY entry {
   config.set_block_m(32);
   config.set_block_n(32);
   config.set_block_k(32);
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   TF_CHECK_OK(TritonWrapper("test_fn", triton_dot_fusion, CudaAmpereOrRocm(),
                             dev_info, block_level_parameters, &llvm_module,

--- a/xla/service/gpu/kernels/BUILD
+++ b/xla/service/gpu/kernels/BUILD
@@ -5,9 +5,8 @@ load(
     "if_cuda_is_configured",
     "if_cuda_newer_than",
 )
-load("//xla/service/gpu:build_defs.bzl", "gpu_kernel_library")
+load("//xla/service/gpu:build_defs.bzl", "gpu_kernel_library", "xla_gpu_test")
 load("//xla/stream_executor:build_defs.bzl", "if_gpu_is_configured")
-load("//xla/tests:build_defs.bzl", "xla_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -100,13 +99,12 @@ cc_library(
     alwayslink = 1,  # static fusion registration
 )
 
-xla_test(
+xla_gpu_test(
     name = "cutlass_gemm_fusion_test",
     srcs = ["cutlass_gemm_fusion_test.cc"],
-    backends = ["gpu"],
+    with_rocm = False,
     # TODO(b/332820384): Enable when it passes on H100.
     disabled_backends = ["gpu_h100"],
-    tags = ["no_rocm"],
     deps = [
         ":custom_kernel_fusion_pattern",
         ":cutlass_gemm_fusion",
@@ -120,7 +118,6 @@ xla_test(
         "//xla/service/gpu:gpu_device_info_for_tests",
         "//xla/tests:hlo_test_base",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -170,10 +167,9 @@ gpu_kernel_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "topk_kernel_test",
-    srcs = if_gpu_is_configured(["topk_kernel_test.cc"]),
-    backends = ["gpu"],
+    srcs = ["topk_kernel_test.cc"],
     deps = [
         ":topk_kernel",
         "//xla:types",
@@ -191,7 +187,6 @@ xla_test(
         "@com_google_absl//absl/time",
         "@tsl//tsl/platform:test",
         "@tsl//tsl/platform:test_benchmark",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -220,10 +215,9 @@ cc_library(
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "topk_custom_kernel_test",
-    srcs = if_gpu_is_configured(["topk_custom_kernel_test.cc"]),
-    backends = ["gpu"],
+    srcs = ["topk_custom_kernel_test.cc"],
     deps = [
         ":topk_custom_kernel",
         "//xla:types",
@@ -241,7 +235,6 @@ xla_test(
         "@tsl//tsl/platform:path",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -272,10 +265,10 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "cutlass_gemm_custom_kernel_test",
-    srcs = if_cuda_is_configured(["cutlass_gemm_custom_kernel_test.cc"]),
-    backends = ["gpu"],
+    srcs = ["cutlass_gemm_custom_kernel_test.cc"],
+    with_rocm = False,
     data = [":cutlass_gemm_kernel_f32xf32_to_f32.so"],
     deps = [
         ":cutlass_gemm_custom_kernel",

--- a/xla/service/gpu/model/BUILD
+++ b/xla/service/gpu/model/BUILD
@@ -4,7 +4,7 @@ load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 load("//xla:xla.bzl", "xla_cc_test", "xla_nvml_deps")
 
 # Libraries for performance modeling of HLO.
-load("//xla/tests:build_defs.bzl", "xla_test")
+load("//xla/service/gpu:build_defs.bzl", "xla_gpu_test")
 load("//xla/tsl:tsl.bzl", "internal_visibility")
 load("//xla/tsl:tsl.default.bzl", "get_compatible_with_portable")
 
@@ -42,15 +42,10 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "analytical_latency_estimator_test",
     srcs = ["analytical_latency_estimator_test.cc"],
-    backend_tags = {"gpu": [
-        "requires-gpu-sm70",
-    ]},
-    backends = [
-        "gpu",
-    ],
+    with_cuda = "volta+",
     deps = [
         ":analytical_latency_estimator",
         "//xla:shape_util",
@@ -59,7 +54,6 @@ xla_test(
         "//xla/service:latency_hiding_scheduler",
         "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/stream_executor:device_description",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
@@ -854,16 +848,13 @@ cc_library(
     ]
 ]
 
-xla_test(
+xla_gpu_test(
     name = "hlo_op_profiler_test",
     srcs = ["hlo_op_profiler_test.cc"],
-    backends = ["gpu"],
-    local_defines = if_cuda(["GOOGLE_CUDA"]),
     deps = [
         ":hlo_op_profiler_lib",
         "//xla/hlo/ir:hlo",
         "//xla/tests:hlo_test_base",
         "@com_google_googletest//:gtest",
-        "@tsl//tsl/platform:test_main",
     ],
 )

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -1,10 +1,9 @@
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
 load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 load("//xla:xla.bzl", "xla_cc_test")
-load("//xla/service/gpu:build_defs.bzl", "get_cub_sort_kernel_types")
+load("//xla/service/gpu:build_defs.bzl", "get_cub_sort_kernel_types", "xla_gpu_test")
 load("//xla/stream_executor:build_defs.bzl", "if_gpu_is_configured")
-load("//xla/tests:build_defs.bzl", "xla_test")
-load("//xla/tsl:tsl.bzl", "if_google", "if_nccl", "internal_visibility", "nvtx_headers")
+load("//xla/tsl:tsl.bzl", "if_nccl", "internal_visibility", "nvtx_headers")
 load("//xla/tsl:tsl.default.bzl", "get_compatible_with_portable")
 
 package(
@@ -140,11 +139,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "command_buffer_cmd_test",
-    srcs = if_gpu_is_configured(["command_buffer_cmd_test.cc"]),
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    srcs = ["command_buffer_cmd_test.cc"],
     deps = [
         ":command_buffer_cmd",
         ":thunk",
@@ -168,7 +165,6 @@ xla_test(
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
         "@tsl//tsl/platform:test_benchmark",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -339,19 +335,10 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "dynamic_slice_thunk_test",
-    srcs = if_gpu_is_configured(["dynamic_slice_thunk_test.cc"]),
-    backend_tags = {
-        "gpu_a100": if_google(["config-cuda-only"]),
-        "gpu_v100": if_google(["config-cuda-only"]),
-    },
-    backends = [
-        "gpu_a100",
-        "gpu_v100",
-        "gpu_amd_any",
-    ],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    srcs = ["dynamic_slice_thunk_test.cc"],
+    with_cuda = "volta+",
     deps = [
         ":custom_call_thunk",
         ":dynamic_slice_thunk",
@@ -380,8 +367,8 @@ xla_test(
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
     ]),
 )
@@ -439,19 +426,10 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "command_buffer_thunk_test",
-    srcs = if_gpu_is_configured(["command_buffer_thunk_test.cc"]),
-    backend_tags = {
-        "gpu_a100": if_google(["config-cuda-only"]),
-        "gpu_v100": if_google(["config-cuda-only"]),
-    },
-    backends = [
-        "gpu_a100",
-        "gpu_v100",
-        "gpu_amd_any",
-    ],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    srcs = ["command_buffer_thunk_test.cc"],
+    with_cuda = "volta+",
     deps = [
         ":command_buffer_cmd",
         ":command_buffer_thunk",
@@ -478,8 +456,8 @@ xla_test(
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
     ]),
 )

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -18,8 +18,7 @@ load(
     "//xla:xla.bzl",
     "xla_cc_test",
 )
-load("//xla/tests:build_defs.bzl", "xla_test")
-load("//xla/tsl:tsl.bzl", "if_oss")
+load("//xla/service/gpu:build_defs.bzl", "xla_gpu_test")
 load("//xla/tsl:tsl.default.bzl", "filegroup")
 
 package(
@@ -66,11 +65,9 @@ cc_library(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "dynamic_slice_fusion_test",
     srcs = ["dynamic_slice_fusion_test.cc"],
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     tags = ["notsan"],  # TODO(b/345034145): Fix tsan error.
     deps = [
         "//xla:error_spec",
@@ -79,33 +76,28 @@ xla_test(
         "//xla/ffi:ffi_api",
         "//xla/stream_executor",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@tsl//tsl/platform:test",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "element_wise_row_vectorization_test",
     srcs = ["element_wise_row_vectorization_test.cc"],
-    backends = ["gpu"],
     deps = [
         "//xla:error_spec",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "pred_arithmetic_test",
     srcs = ["pred_arithmetic_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:literal_util",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -144,16 +136,14 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "float_conversions_test",
     srcs = ["float_conversions_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "@com_google_absl//absl/strings:string_view",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -195,11 +185,10 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_spmd_e2e_compile_test",
     size = "small",
     srcs = ["gpu_spmd_e2e_compile_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:debug_options_flags",
@@ -211,17 +200,12 @@ xla_test(
         "@com_google_absl//absl/status:statusor",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gemm_rewrite_test",
     srcs = ["gemm_rewrite_test.cc"],
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -248,21 +232,17 @@ xla_test(
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/lib/core:status_test_util",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
 
-xla_test(
+xla_gpu_test(
     name = "gemm_broadcast_folding_rewrite_test",
     srcs = ["gemm_broadcast_folding_rewrite_test.cc"],
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -271,16 +251,12 @@ xla_test(
         "//xla/service/gpu:gemm_rewriter",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_too_many_blocks_test",
-    srcs = [
-        "gpu_too_many_blocks_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["gpu_too_many_blocks_test.cc"],
     deps = [
         ":gpu_codegen_test",
         "//xla/hlo/ir:hlo",
@@ -289,7 +265,6 @@ xla_test(
         "@com_google_absl//absl/status:statusor",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -307,19 +282,15 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "reduction_layout_normalizer_test",
-    srcs = [
-        "reduction_layout_normalizer_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["reduction_layout_normalizer_test.cc"],
     deps = [
         "//xla:error_spec",
         "//xla/service/gpu:reduction_layout_normalizer",
         "//xla/tests:hlo_test_base",
         "@com_google_absl//absl/strings:string_view",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -338,27 +309,20 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "swap_conv_operands_test",
-    srcs = [
-        "swap_conv_operands_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["swap_conv_operands_test.cc"],
     tags = ["no_rocm"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "reduction_vectorization_test",
-    srcs = [
-        "reduction_vectorization_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["reduction_vectorization_test.cc"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -367,7 +331,6 @@ xla_test(
         "@com_google_absl//absl/strings",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -385,12 +348,9 @@ xla_cc_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "parallel_reduction_test",
-    srcs = [
-        "parallel_reduction_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["parallel_reduction_test.cc"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -400,29 +360,23 @@ xla_test(
         "//xla/tests:hlo_test_base",
         "//xla/tests:verified_hlo_module",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_compilation_parallelism_test",
-    srcs = [
-        "gpu_compilation_parallelism_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["gpu_compilation_parallelism_test.cc"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "//xla/tests:verified_hlo_module",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_copy_test",
     srcs = ["gpu_copy_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -432,45 +386,34 @@ xla_test(
         "//xla/tests:verified_hlo_module",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_copy_alone_test",
-    srcs = [
-        "gpu_copy_alone_test.cc",
-    ],
-    backends = ["gpu"],
+    srcs = ["gpu_copy_alone_test.cc"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "//xla/tests:verified_hlo_module",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_dyn_shape_test",
     srcs = ["gpu_dyn_shape_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:shape_util",
         "//xla/hlo/ir:hlo",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_triton_custom_call_test",
     srcs = ["gpu_triton_custom_call_test.cc"],
-    backends = [
-        "gpu_a100",
-        "gpu_v100",
-        "gpu_amd_any",
-    ],
+    with_cuda = "ampere+",
     deps = [
         ":gpu_codegen_test",
         "//xla:shape_util",
@@ -485,27 +428,23 @@ xla_test(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
         "@tsl//tsl/platform:status_matchers",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_ftz_test",
     srcs = ["gpu_ftz_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:shape_util",
         "//xla/hlo/ir:hlo",
         "//xla/tests:verified_hlo_module",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_index_test",
     srcs = ["gpu_index_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:comparison_util",
@@ -516,14 +455,12 @@ xla_test(
         "//xla/service:hlo_module_config",
         "//xla/tests:hlo_test_base",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_infeed_test",
     srcs = ["infeed_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",  # build_cleaner: keep
         "//xla:array3d",
@@ -536,17 +473,12 @@ xla_test(
         "//xla/client:xla_builder",
         "//xla/tests:client_library_test_base",
         "@tsl//tsl/platform:env",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_kernel_tiling_test",
     srcs = ["gpu_kernel_tiling_test.cc"],
-    backends = [
-        "gpu_p100",
-        "gpu_amd_any",
-    ] + if_oss(["gpu_any"]),
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -555,50 +487,42 @@ xla_test(
         "//xla/tests:verified_hlo_module",
         "@com_google_absl//absl/status",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "concatenate_emitter_test",
     srcs = ["concatenate_emitter_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "transpose_emitter_test",
     srcs = ["transpose_emitter_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "reduction_emitter_test",
     srcs = ["reduction_emitter_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_ldg_test",
     srcs = ["gpu_ldg_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:literal_util",
@@ -606,28 +530,24 @@ xla_test(
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_noalias_test",
     srcs = ["gpu_noalias_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_fusion_test",
     srcs = ["gpu_fusion_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:shape_util",
@@ -636,14 +556,12 @@ xla_test(
         "//xla/service/gpu:gpu_fusible",
         "//xla/service/gpu:instruction_fusion",
         "@com_google_absl//absl/strings:string_view",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_fusion_pipeline_test",
     srcs = ["gpu_fusion_pipeline_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:shape_util",
@@ -655,68 +573,58 @@ xla_test(
         "//xla/service/gpu:multi_output_fusion",
         "//xla/stream_executor:device_description",
         "@com_google_absl//absl/strings:string_view",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_unrolling_test",
     srcs = ["gpu_unrolling_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:debug_options_flags",
         "//xla/service:hlo_module_config",
         "//xla/tests:hlo_test_base",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_alignment_test",
     srcs = ["gpu_alignment_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_atomic_test",
     srcs = ["gpu_atomic_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_input_fusible_slice_test",
     srcs = ["gpu_input_fusible_slice_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
         "//xla/service:hlo_module_config",
         "//xla/tests:hlo_test_base",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_convolution_regression_test",
     srcs = ["gpu_convolution_regression_test.cc"],
-    backend_args = {"gpu": [
+    args = [
         "--xla_enable_hlo_passes_only=layout-assignment,gpu-conv-algorithm-picker",
         "--xla_gpu_crash_on_verification_failures",
-    ]},
-    backends = ["gpu"],
+    ],
     tags = [
         "manual",
         "no_oss",
@@ -726,15 +634,13 @@ xla_test(
         "//xla:debug_options_flags",
         "//xla/service:hlo_module_config",
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/strings:string_view",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "select_and_scatter_test",
     srcs = ["select_and_scatter_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -742,13 +648,9 @@ xla_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "sorting_test",
     srcs = ["sorting_test.cc"],
-    backends = ["gpu"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
-        "TENSORFLOW_USE_ROCM=1",
-    ]),
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -761,7 +663,6 @@ xla_test(
         "@com_google_absl//absl/strings",
         "@eigen_archive//:eigen3",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
@@ -865,10 +766,9 @@ cc_binary(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "kernel_launch_test",
     srcs = ["kernel_launch_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "//xla:error_spec",
@@ -876,94 +776,78 @@ xla_test(
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "mock_custom_call_test",
     srcs = ["mock_custom_call_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "in_place_op_test",
     srcs = ["in_place_op_test.cc"],
-    backends = ["gpu"],
     deps = [
         "//xla:debug_options_flags",
         "//xla/tests:hlo_test_base",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "dynamic_shared_memory_test",
-    srcs = if_cuda_is_configured(["dynamic_shared_memory_test.cc"]),
-    backends = ["gpu"],
+    srcs = ["dynamic_shared_memory_test.cc"],
+    with_cuda = "all",
+    with_rocm = False,
     deps = [
         "//xla:shape_util",
         "//xla:types",
         "//xla:xla_proto_cc",
+        "//xla/service/gpu:gpu_asm_opts_util",
+        "//xla/service/gpu:stream_executor_util",
+        "//xla/stream_executor",
+        "//xla/stream_executor:device_memory",
         "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor/cuda:cuda_asm_compiler",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
         "@tsl//tsl/platform:test_main",
-    ] + if_cuda_is_configured([
-        "//xla/stream_executor/cuda:cuda_asm_compiler",
-        "//xla/service/gpu:gpu_asm_opts_util",
-        "//xla/stream_executor",
-        "//xla/service/gpu:stream_executor_util",
-        "//xla/stream_executor:device_memory",
-    ]),
+    ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "tensor_float_32_global_var_test",
     srcs = ["tensor_float_32_global_var_test.cc"],
-    backends = [
-        "gpu_a100",
-        "gpu_amd_any",
-    ] + if_oss(["gpu_any"]),
     deps = [
         "//xla:error_spec",
         "//xla/tests:hlo_test_base",
         "@tsl//tsl/platform:tensor_float_32_utils",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_sparse_dot_test",
-    srcs = if_cuda_is_configured(["gpu_sparse_dot_test.cc"]),
-    backends = [
-        "gpu_a100",
-        "gpu_h100",
+    srcs = ["gpu_sparse_dot_test.cc"],
+    with_cuda = "ampere+",
+    with_rocm = False,
+    deps = [
+        ":gpu_codegen_test",
+        "@com_google_googletest//:gtest",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
+        "//xla:literal",
+        "//xla:literal_util",
+        "@tsl//tsl/lib/core:status_test_util",
     ],
-    tags = ["no_rocm"],
-    deps = if_cuda_is_configured(
-        [
-            ":gpu_codegen_test",
-            "@com_google_googletest//:gtest",
-            "@com_google_absl//absl/strings",
-            "@com_google_absl//absl/types:span",
-            "//xla:literal",
-            "//xla:literal_util",
-            "//xla/tests:xla_internal_test_main",
-            "@tsl//tsl/lib/core:status_test_util",
-        ],
-        ["@tsl//tsl/platform:test_main"],  # b/317293391
-    ),
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_cub_sort_test",
     size = "medium",
     srcs = ["gpu_cub_sort_test.cc"],
-    backends = ["gpu"],
     shard_count = 15,
     deps = [
         "//xla:error_spec",
@@ -973,22 +857,14 @@ xla_test(
         "//xla/service/gpu:gpu_sort_rewriter",
         "//xla/tests:hlo_test_base",
         "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:statusor",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_fused_mha_test",
     srcs = ["gpu_fused_mha_test.cc"],
-    backend_tags = {"gpu": [
-        "requires-gpu-sm80",
-    ]},
-    backends = [
-        "gpu",
-    ],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    with_cuda = "ampere+",
     shard_count = 2,
     deps = [
         ":gpu_codegen_test",
@@ -1017,14 +893,14 @@ xla_test(
         "//xla/tests:literal_test_util",
         "//xla/tests:test_macros_header",
         "//xla/tests:test_utils",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
-    ] + if_cuda_is_configured([
+    ],
+    platform_deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
     ]),
 )
@@ -1037,7 +913,6 @@ cc_library(
     tags = tf_cuda_tests_tags(),
     deps = [
         "//xla/tests:hlo_test_base",
-        "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/strings",
         "@tsl//tsl/lib/core:status_test_util",
     ],
@@ -1047,10 +922,9 @@ cc_library(
 #
 # If the GPU used for running the test is different from the one in the cache, then the cache will
 # be loaded, but not used.
-xla_test(
+xla_gpu_test(
     name = "load_autotune_results_using_execpath_test",
     srcs = [],
-    backends = ["gpu"],
     # Data dependency must be declared for the cache.
     data = ["test_autotune_cache.textproto"],
     env = {"XLA_FLAGS": "--xla_gpu_load_autotune_results_from=" +
@@ -1065,10 +939,9 @@ xla_test(
 #
 # If the GPU used for running the test is different from the one in the cache, then the cache will
 # be loaded, but not used.
-xla_test(
+xla_gpu_test(
     name = "load_autotune_results_from_test_workspace_test",
     srcs = [],
-    backends = ["gpu"],
     # Data dependency must be declared for the cache.
     data = ["test_autotune_cache.textproto"],
     env = {"XLA_FLAGS": "--xla_gpu_load_autotune_results_from=TEST_WORKSPACE/" +
@@ -1082,10 +955,9 @@ xla_test(
 # This also works from the command line, by specifying these arguments:
 # --test_env=XLA_FLAGS=--xla_gpu_dump_autotune_results_to=TEST_UNDECLARED_OUTPUTS_DIR/autotune_cache.textproto
 # --test_sharding_strategy=disabled
-xla_test(
+xla_gpu_test(
     name = "dump_autotune_results_to_test_outputs_test",
     srcs = [],
-    backends = ["gpu"],
     env = {"XLA_FLAGS": "--xla_gpu_dump_autotune_results_to=" +
                         "TEST_UNDECLARED_OUTPUTS_DIR/autotune_cache.textproto"},
     # Sharding must be disabled to correctly dump the autotune cache for all test.
@@ -1093,35 +965,29 @@ xla_test(
     deps = [":simple_optimization_test"],
 )
 
-xla_test(
+xla_gpu_test(
     name = "gpu_int4_test",
     srcs = ["gpu_int4_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gpu_codegen_test",
         "@com_google_absl//absl/strings:string_view",
         "@tsl//tsl/platform:test",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "simplify_fp_conversions_test",
     srcs = ["simplify_fp_conversions_test.cc"],
-    backends = ["gpu"],
     deps = [
         "//xla:xla_proto_cc",
         "//xla/tests:hlo_test_base",
-        "@tsl//tsl/platform:test_main",
     ],
 )
 
-xla_test(
+xla_gpu_test(
     name = "nop_custom_call_test",
     srcs = ["nop_custom_call_test.cc"],
-    backends = ["gpu"],
     deps = [
         "//xla/tests:hlo_test_base",
-        "@tsl//tsl/platform:test_main",
     ],
 )


### PR DESCRIPTION
Provides a simpler interface to `xla_test` macro for GPU-only tests.

1) Wraps `srcs` in `if_gpu_is_configured` to avoid compilation on non-GPU backends (e.g. CPU).
Some test targets currently do this, but it's not consistent.

2) Similarly, wraps `deps` in `if_gpu_is_configured` to generate less dependencies on non-GPU backends (e.g. CPU).
Only a few test targets currently do this.

3) Consistently define GOOGLE_CUDA and TENSORFLOW_USE_ROCM We had a few issues due to missing definitions in the past.

4) Do not require listing specific architectures in `backends` Instead, enable shortcut that enables compatible cuda architectures: e.g. with_cuda = "ampere+"

5) Do not generate tests with "gpu_any" suffix.
This means "run on any compatible architecture" in the Google CI, which *will* result in flaky tests for any tests that check for SM version during runtime (e.g. if a test passes on Ampere but fails on Hopper, then "gpu_any" test will be flaky).

6) Hides the complexity of `xla_test` macro.
It is significantly different at Google because of TPU support, so using it is hard in OSS (as the macro source is not visible).

Eventually we should consider removing test suffixes for GPU tests, as "gpu_a100" and "gpu_h100" are essentially the same, and are only needed due to how Google internal CI operates (requires SM-specific tags for a test target).

I propose to use `xla_gpu_test` for all runtime tests (i.e. requiring a GPU to run the test) inside the //xla/service/gpu/... namespace.