### PR TITLE
[ROCm] fixed build due to https://github.com/openxla/xla/commit/19c11…

### DIFF
--- a/xla/service/gpu/ir_emitter_triton_rocm.cc
+++ b/xla/service/gpu/ir_emitter_triton_rocm.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "mlir/Transforms/Passes.h"  // from @llvm-project
 #include "xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
 #include "xla/service/gpu/matmul_utils.h"
+#include "xla/service/gpu/model/tiled_hlo_computation.h"
 #include "xla/service/hlo_module_config.h"
 #include "tsl/platform/rocm_rocdl_path.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"


### PR DESCRIPTION
…baa83f31e25a3f841cf41fa47a53e8ca161

@xla-rotation 
https://github.com/openxla/xla/blob/main/xla/service/gpu/ir_emitter_triton_rocm.cc was partially updated according to the change, but there was missing include directive in it (because of which ROCm build is broken).