### PR TITLE
Fix build issue for ir_emitter_triton_test 

### DIFF
--- a/xla/service/gpu/ir_emitter_triton_test.cc
+++ b/xla/service/gpu/ir_emitter_triton_test.cc
@@ -1425,7 +1425,7 @@ ENTRY entry {
 
   auto backend_config_or =
       triton_dot_fusion->backend_config<GpuBackendConfig>();
-  ASSERT_OK(backend_config_or);
+  TF_ASSERT_OK(backend_config_or);
   GpuBackendConfig& backend_config = *backend_config_or;
 
   FusionBackendConfig& fusion_backend_config =
@@ -1439,7 +1439,7 @@ ENTRY entry {
   config.set_num_warps(8);
   config.set_num_stages(4);
 
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   BlockLevelParameters block_level_parameters;
   block_level_parameters.num_ctas = 1;
@@ -1457,7 +1457,7 @@ ENTRY entry {
   config.set_block_n(128);
   config.set_block_k(128);
   block_level_parameters.num_stages = 1;
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   TF_ASSERT_OK_AND_ASSIGN(
       const auto result,
@@ -1972,7 +1972,7 @@ ENTRY entry {
 
   auto backend_config_or =
       triton_dot_fusion->backend_config<GpuBackendConfig>();
-  ASSERT_OK(backend_config_or);
+  TF_ASSERT_OK(backend_config_or);
   GpuBackendConfig& backend_config = *backend_config_or;
 
   FusionBackendConfig& fusion_backend_config =
@@ -1986,7 +1986,7 @@ ENTRY entry {
   config.set_num_ctas(1);
   config.set_num_stages(1);
   config.set_num_warps(2);
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   BlockLevelParameters block_level_parameters;
   block_level_parameters.num_ctas = 1;
@@ -2003,7 +2003,7 @@ ENTRY entry {
   config.set_block_m(32);
   config.set_block_n(32);
   config.set_block_k(32);
-  ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
+  TF_ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
 
   TF_CHECK_OK(TritonWrapper("test_fn", triton_dot_fusion, CudaAmpereOrRocm(),
                             dev_info, block_level_parameters, &llvm_module,


### PR DESCRIPTION
Build error is encountered in OSS for target ir_emitter_triton_test:
#10 283.3 ./xla/service/memory_space_assignment/cost_analysis.h:118:28: note: replace 'default' with 'delete'
#10 283.3   118 |   HloCostAnalysisCosts() = default;
#10 283.3       |                            ^~~~~~~
#10 283.3       |                            delete
#10 283.3 xla/service/gpu/ir_emitter_triton_test.cc:1428:3: error: use of undeclared identifier 'ASSERT_OK'
#10 283.3  1428 |   ASSERT_OK(backend_config_or);
#10 283.3       |   ^
#10 283.3 xla/service/gpu/ir_emitter_triton_test.cc:1442:3: error: use of undeclared identifier 'ASSERT_OK'
#10 283.3  1442 |   ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
#10 283.3       |   ^
#10 283.3 xla/service/gpu/ir_emitter_triton_test.cc:1460:3: error: use of undeclared identifier 'ASSERT_OK'
#10 283.3  1460 |   ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
#10 283.3       |   ^
#10 283.3 xla/service/gpu/ir_emitter_triton_test.cc:1975:3: error: use of undeclared identifier 'ASSERT_OK'
#10 283.3  1975 |   ASSERT_OK(backend_config_or);
#10 283.3       |   ^
#10 283.3 xla/service/gpu/ir_emitter_triton_test.cc:1989:3: error: use of undeclared identifier 'ASSERT_OK'
#10 283.3  1989 |   ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));
#10 283.3       |   ^
#10 283.3 xla/service/gpu/ir_emitter_triton_test.cc:2006:3: error: use of undeclared identifier 'ASSERT_OK'
#10 283.3  2006 |   ASSERT_OK(triton_dot_fusion->set_backend_config(backend_config));



Fix: Replaced ASSERT_OK with TF_ASSERT_OK