### PR TITLE
[ROCm] Pin amdhip64 soversion in dso loader

### DIFF
--- a/third_party/tsl/third_party/gpus/rocm/rocm_config.h.tpl
+++ b/third_party/tsl/third_party/gpus/rocm/rocm_config.h.tpl
@@ -22,5 +22,7 @@ limitations under the License.
 #define TF_MIOPEN_VERSION %{miopen_version_number}
 #define TF_HIPRUNTIME_VERSION %{hipruntime_version_number}
 #define TF_HIPBLASLT %{hipblaslt_flag}
+#define TF_HIPRUNTIME_SOVERSION "%{hip_soversion_number}"
+#define TF_ROCBLAS_SOVERSION "%{rocblas_soversion_number}"
 
 #endif  // ROCM_ROCM_CONFIG_H_

--- a/third_party/tsl/third_party/gpus/rocm_configure.bzl
+++ b/third_party/tsl/third_party/gpus/rocm_configure.bzl
@@ -761,6 +761,8 @@ def _create_local_rocm_repository(repository_ctx):
             "%{miopen_version_number}": rocm_config.miopen_version_number,
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
             "%{hipblaslt_flag}": have_hipblaslt,
+            "%{hip_soversion_number}": "6" if int(rocm_config.rocm_version_number) >= 60000 else "5",
+            "%{rocblas_soversion_number}": "4" if int(rocm_config.rocm_version_number) >= 60000 else "3",
         },
     )
 

--- a/third_party/tsl/tsl/platform/default/dso_loader.cc
+++ b/third_party/tsl/tsl/platform/default/dso_loader.cc
@@ -48,6 +48,8 @@ std::string GetCufftVersion() { return TF_CUFFT_VERSION; }
 std::string GetCusparseVersion() { return TF_CUSPARSE_VERSION; }
 std::string GetNcclVersion() { return TF_NCCL_VERSION; }
 std::string GetTensorRTVersion() { return TF_TENSORRT_VERSION; }
+std::string GetHipVersion() { return TF_HIPRUNTIME_SOVERSION; }
+std::string GetRocBlasVersion() { return TF_ROCBLAS_SOVERSION; }
 
 absl::StatusOr<void*> GetDsoHandle(const std::string& name,
                                    const std::string& version) {
@@ -144,7 +146,7 @@ absl::StatusOr<void*> GetNvInferPluginDsoHandle() {
 }
 
 absl::StatusOr<void*> GetRocblasDsoHandle() {
-  return GetDsoHandle("rocblas", "");
+  return GetDsoHandle("rocblas", GetRocBlasVersion());
 }
 
 absl::StatusOr<void*> GetMiopenDsoHandle() {
@@ -181,7 +183,9 @@ absl::StatusOr<void*> GetHipblasltDsoHandle() {
   return GetDsoHandle("hipblaslt", "");
 }
 
-absl::StatusOr<void*> GetHipDsoHandle() { return GetDsoHandle("amdhip64", ""); }
+absl::StatusOr<void*> GetHipDsoHandle() {
+  return GetDsoHandle("amdhip64", GetHipVersion());
+}
 
 }  // namespace DsoLoader
 


### PR DESCRIPTION
This prevents us accidentally loading a second copy of HIP runtime in local_config_rocm. Do similar for rocblas to guard against ABI break in rocm 6.0.