### PR TITLE
[XLA:GPU] Allow user to change command buffer trace cache capacity

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -115,6 +115,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUDNN);
   opts.set_xla_gpu_graph_min_graph_size(5);
   opts.set_xla_gpu_graph_enable_concurrent_region(false);
+  opts.set_xla_cmd_buffer_trace_cache_size(16);
+
 
   // Despite the name, fast min/max on GPUs does not seem to be any faster, and
   // adds very counter-intuitive "NaN-swallowing" behavior.
@@ -1217,7 +1219,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 debug_options->xla_gpu_graph_enable_concurrent_region(),
                 "Identify concurrent regions in gpu graphs and execute them "
                 "concurrently."));
-
+  flag_list->push_back(tsl::Flag(
+      "xla_cmd_buffer_trace_cache_size",
+      int64_setter_for(&DebugOptions::set_xla_cmd_buffer_trace_cache_size),
+      debug_options->xla_cmd_buffer_trace_cache_size(),
+      "Set the command buffer trace cache size, increasing the cache size may "
+      "sometimes reduces the chances of doing command buffer tracing for "
+      "updating command buffer instance."));
   flag_list->push_back(
       tsl::Flag("xla_dump_disable_metadata",
                 bool_setter_for(&DebugOptions::set_xla_dump_disable_metadata),

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -63,6 +63,7 @@ cc_library(
         ":nccl_collective_broadcast_thunk",
         ":nccl_collective_thunk",
         ":thunk",
+        "//xla:debug_options_flags",
         "//xla:executable_run_options",
         "//xla:types",
         "//xla:util",

--- a/xla/service/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd_test.cc
@@ -398,81 +398,89 @@ TEST(CommandBufferCmdStateManageTest, GetOrCreateState) {
 }
 
 TEST(TracedCommandBuffer, GetOrUpdateCommandBuffer) {
-  se::StreamExecutor* executor = GpuExecutor();
+  auto run_traced_test = [](int trace_cache_size) {
+    se::StreamExecutor* executor = GpuExecutor();
 
-  auto stream = executor->CreateStream().value();
-  BufferAllocation alloc0(/*index=*/0, /*size=*/1024, /*color=*/0);
-  BufferAllocation alloc1(/*index=*/1, /*size=*/1024, /*color=*/0);
+    auto stream = executor->CreateStream().value();
+    BufferAllocation alloc0(/*index=*/0, /*size=*/1024, /*color=*/0);
+    BufferAllocation alloc1(/*index=*/1, /*size=*/1024, /*color=*/0);
 
-  CommandBufferCmd::BufferUsageVector buffers = {
-      {BufferAllocation::Slice(&alloc0, 0, 1024), MemoryAccess::kRead},
-      {BufferAllocation::Slice(&alloc1, 0, 1024), MemoryAccess::kWrite}};
+    CommandBufferCmd::BufferUsageVector buffers = {
+        {BufferAllocation::Slice(&alloc0, 0, 1024), MemoryAccess::kRead},
+        {BufferAllocation::Slice(&alloc1, 0, 1024), MemoryAccess::kWrite}};
 
-  TracedCommandBuffer traced_cmd_buffer(buffers, /*capacity=*/2);
+    TracedCommandBuffer traced_cmd_buffer(buffers,
+                                          /*capacity=*/trace_cache_size);
 
-  se::DeviceMemoryBase mem0(reinterpret_cast<void*>(0x01234567));
-  se::DeviceMemoryBase mem1(reinterpret_cast<void*>(0x12345670));
+    se::DeviceMemoryBase mem0(reinterpret_cast<void*>(0x01234567));
+    se::DeviceMemoryBase mem1(reinterpret_cast<void*>(0x12345670));
 
-  se::StreamExecutorMemoryAllocator allocator(executor);
-  BufferAllocations allocations({mem0, mem1}, 0, &allocator);
+    se::StreamExecutorMemoryAllocator allocator(executor);
+    BufferAllocations allocations({mem0, mem1}, 0, &allocator);
 
-  // No-op trace callback to count how many times it was called.
-  int64_t num_calls = 0;
-  auto trace = [&](se::Stream*) {
-    num_calls++;
-    return absl::OkStatus();
+    // No-op trace callback to count how many times it was called.
+    int64_t num_calls = 0;
+    auto trace = [&](se::Stream*) {
+      num_calls++;
+      return absl::OkStatus();
+    };
+
+    TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer0,
+                            traced_cmd_buffer.GetOrTraceCommandBuffer(
+                                &allocations, executor, stream.get(), trace));
+
+    TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer1,
+                            traced_cmd_buffer.GetOrTraceCommandBuffer(
+                                &allocations, executor, stream.get(), trace));
+
+    // Check that command buffer was reused as buffer allocations didn't
+    // change.
+    ASSERT_EQ(command_buffer0, command_buffer1);
+    EXPECT_EQ(num_calls, 1);
+
+    // Check that when memory address changes we re-trace the command
+    // buffer.
+    se::DeviceMemoryBase mem2(reinterpret_cast<void*>(0x23456701));
+    allocations = BufferAllocations({mem0, mem2}, 0, &allocator);
+
+    TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer2,
+                            traced_cmd_buffer.GetOrTraceCommandBuffer(
+                                &allocations, executor, stream.get(), trace));
+
+    ASSERT_NE(command_buffer0, command_buffer2);
+    EXPECT_EQ(num_calls, 2);
+
+    // Check that we keep first command buffer in cache.
+    allocations = BufferAllocations({mem0, mem1}, 0, &allocator);
+
+    TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer3,
+                            traced_cmd_buffer.GetOrTraceCommandBuffer(
+                                &allocations, executor, stream.get(), trace));
+    ASSERT_EQ(command_buffer0, command_buffer3);
+    EXPECT_EQ(num_calls, 2);
+
+    // Check that we trace a new graph when buffer allocation pattern is
+    // new.
+    allocations = BufferAllocations({mem0, mem0}, 0, &allocator);
+
+    TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer4,
+                            traced_cmd_buffer.GetOrTraceCommandBuffer(
+                                &allocations, executor, stream.get(), trace));
+    ASSERT_NE(command_buffer4, command_buffer3);
+    ASSERT_NE(command_buffer4, command_buffer2);
+    EXPECT_EQ(num_calls, 3);
+
+    // Check that we still keep the previous graph in cache.
+    allocations = BufferAllocations({mem0, mem1}, 0, &allocator);
+
+    TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer5,
+                            traced_cmd_buffer.GetOrTraceCommandBuffer(
+                                &allocations, executor, stream.get(), trace));
+    ASSERT_EQ(command_buffer0, command_buffer5);
+    EXPECT_EQ(num_calls, 3);
   };
-
-  TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer0,
-                          traced_cmd_buffer.GetOrTraceCommandBuffer(
-                              &allocations, executor, stream.get(), trace));
-
-  TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer1,
-                          traced_cmd_buffer.GetOrTraceCommandBuffer(
-                              &allocations, executor, stream.get(), trace));
-
-  // Check that command buffer was reused as buffer allocations didn't change.
-  ASSERT_EQ(command_buffer0, command_buffer1);
-  EXPECT_EQ(num_calls, 1);
-
-  // Check that when memory address changes we re-trace the command buffer.
-  se::DeviceMemoryBase mem2(reinterpret_cast<void*>(0x23456701));
-  allocations = BufferAllocations({mem0, mem2}, 0, &allocator);
-
-  TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer2,
-                          traced_cmd_buffer.GetOrTraceCommandBuffer(
-                              &allocations, executor, stream.get(), trace));
-
-  ASSERT_NE(command_buffer0, command_buffer2);
-  EXPECT_EQ(num_calls, 2);
-
-  // Check that we keep first command buffer in cache.
-  allocations = BufferAllocations({mem0, mem1}, 0, &allocator);
-
-  TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer3,
-                          traced_cmd_buffer.GetOrTraceCommandBuffer(
-                              &allocations, executor, stream.get(), trace));
-  ASSERT_EQ(command_buffer0, command_buffer3);
-  EXPECT_EQ(num_calls, 2);
-
-  // Check that we trace a new graph when buffer allocation pattern is new.
-  allocations = BufferAllocations({mem0, mem0}, 0, &allocator);
-
-  TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer4,
-                          traced_cmd_buffer.GetOrTraceCommandBuffer(
-                              &allocations, executor, stream.get(), trace));
-  ASSERT_NE(command_buffer4, command_buffer3);
-  ASSERT_NE(command_buffer4, command_buffer2);
-  EXPECT_EQ(num_calls, 3);
-
-  // Check that we still keep the previous graph in cache.
-  allocations = BufferAllocations({mem0, mem1}, 0, &allocator);
-
-  TF_ASSERT_OK_AND_ASSIGN(auto* command_buffer5,
-                          traced_cmd_buffer.GetOrTraceCommandBuffer(
-                              &allocations, executor, stream.get(), trace));
-  ASSERT_EQ(command_buffer0, command_buffer5);
-  EXPECT_EQ(num_calls, 3);
+  run_traced_test(2);
+  run_traced_test(3);
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -826,7 +826,12 @@ message DebugOptions {
 
   string xla_gpu_per_fusion_autotune_cache_dir = 310;
 
-  // Next id: 311
+  // The command buffer trace cache size, increasing the cache size may 
+  // sometimes reduces the chances of doing command buffer tracing for 
+  // updating command buffer instance.
+  int64 xla_cmd_buffer_trace_cache_size = 311;
+
+  // Next id: 312
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
Allow user to set the command buffer trace cache size, increasing the cache size may sometimes reduces the chances of doing command buffer tracing for updating command buffer instance.