### PR TITLE
[XLA:GPU] Fix the bug of thread conflicts for running command buffer cublasLtCmd

### DIFF
--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -1189,15 +1189,20 @@ absl::Status CublasLtCmd::Initialize(const Thunk::InitializeParams& params,
   if (!params.stream->parent()->AsBlas()) {
     return absl::InternalError("Failed to initialize BLAS support for GemmCmd");
   }
-  TF_ASSIGN_OR_RETURN(plan_, GetMatmulPlan(params.stream));
-  TF_ASSIGN_OR_RETURN(algorithm_,
-                      GetMatmulAlgorithm(plan_, workspace_buffer_.size()));
+  // Populate plan and algorithm cache;
+  TF_ASSIGN_OR_RETURN(auto plan, GetMatmulPlan(params.stream));
+  TF_RETURN_IF_ERROR(
+      GetMatmulAlgorithm(plan, workspace_buffer_.size()).status());
   return absl::OkStatus();
 }
 
 absl::Status CublasLtCmd::Record(const Thunk::ExecuteParams& execute_params,
                                  const RecordParams& record_params,
                                  se::CommandBuffer* command_buffer) {
+  TF_ASSIGN_OR_RETURN(auto plan, GetMatmulPlan(execute_params.stream));
+  TF_ASSIGN_OR_RETURN(auto algorithm,
+                      GetMatmulAlgorithm(plan, workspace_buffer_.size()));
+
   const BufferAllocations& allocs = *execute_params.buffer_allocations;
 
   se::DeviceMemoryBase bias, a_scale, b_scale, c_scale, d_scale, aux, d_amax;
@@ -1242,12 +1247,12 @@ absl::Status CublasLtCmd::Record(const Thunk::ExecuteParams& execute_params,
 
   return AddTracedCommandBuffer(
       execute_params, record_params, command_buffer, [&](se::Stream* stream) {
-        return plan_->ExecuteOnStream(
+        return plan->ExecuteOnStream(
             stream, allocs.GetDeviceAddress(a_buffer_),
             allocs.GetDeviceAddress(b_buffer_),
             allocs.GetDeviceAddress(c_buffer_),
             allocs.GetDeviceAddress(d_buffer_), bias, aux, a_scale, b_scale,
-            c_scale, d_scale, d_amax, algorithm_,
+            c_scale, d_scale, d_amax, algorithm,
             allocs.GetDeviceAddress(workspace_buffer_));
       });
 }

--- a/xla/service/gpu/runtime/command_buffer_cmd.h
+++ b/xla/service/gpu/runtime/command_buffer_cmd.h
@@ -781,9 +781,6 @@ class CublasLtCmd : public TracedCommandBufferCmd {
                       se::gpu::BlasLt::MatmulAlgorithm>
       matmul_algorithm_cache_;
 
-  se::gpu::BlasLt::MatmulPlan* plan_;
-  se::gpu::BlasLt::MatmulAlgorithm algorithm_;
-
   const GemmConfig gemm_config_;
   const se::gpu::BlasLt::Epilogue epilogue_;
   const int64_t algorithm_idx_;

--- a/xla/service/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/service/gpu/runtime/command_buffer_thunk_test.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <optional>
 #include <utility>
 #include <vector>
+#include <thread>
 
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
@@ -70,11 +71,11 @@ static se::StreamExecutor* GpuExecutor() {
 static Thunk::ExecutableSource ExecutableSource() {
   Thunk::ExecutableSource source = {
 #if defined(GOOGLE_CUDA)
-      /*text=*/se::gpu::internal::kAddI32Kernel,
-      /*binary=*/{}
+    /*text=*/se::gpu::internal::kAddI32Kernel,
+    /*binary=*/{}
 #elif defined(TENSORFLOW_USE_ROCM)
-      /*text=*/{},
-      /*binary=*/se::gpu::internal::kAddI32KernelModule
+    /*text=*/{},
+    /*binary=*/se::gpu::internal::kAddI32KernelModule
 #endif
   };
   return source;
@@ -594,7 +595,8 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
 
   se::StreamExecutor* executor = GpuExecutor();
 
-  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  TF_ASSERT_OK_AND_ASSIGN(auto stream1, executor->CreateStream());
+  TF_ASSERT_OK_AND_ASSIGN(auto stream2, executor->CreateStream());
 
   // CublasLt formula: D = alpha*(A*B) + beta*(C),
 
@@ -602,35 +604,6 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
   int64_t b_length = sizeof(float) * 4 * 3;
   int64_t c_length = sizeof(float) * 2 * 3;
   int64_t d_length = sizeof(float) * 2 * 3;
-
-  // Prepare arguments:
-  // a = [1.0, 2.0, 3.0, 4.0
-  //      5.0, 6.0, 7.0, 8.0]
-  // b = [1.0, 1.0, 1.0
-  //      1.0, 1.0, 1.0
-  //      1.0, 1.0, 1.0
-  //      1.0, 1.0, 1.0]
-  // c = [1.0, 1.0, 1.0
-  //       1.0, 1.0, 1.0]
-
-  se::DeviceMemory<float> a = executor->AllocateArray<float>(2 * 4);
-  std::vector<float> a_arr{1, 2, 3, 4, 5, 6, 7, 8};
-  TF_ASSERT_OK(stream->Memcpy(&a, a_arr.data(), a_length));
-
-  se::DeviceMemory<float> b = executor->AllocateArray<float>(4 * 3);
-  std::vector<float> b_arr(12, 1);
-  TF_ASSERT_OK(stream->Memcpy(&b, b_arr.data(), b_length));
-
-  se::DeviceMemory<float> c = executor->AllocateArray<float>(2 * 3);
-  std::vector<float> c_arr(6, 1);
-  TF_ASSERT_OK(stream->Memcpy(&c, c_arr.data(), c_length));
-
-  se::DeviceMemory<float> d = executor->AllocateArray<float>(2 * 3);
-  TF_ASSERT_OK(stream->MemZero(&d, d_length));
-
-  se::DeviceMemory<float> workspace =
-      executor->AllocateArray<float>(1024 * 1024);
-  TF_ASSERT_OK(stream->MemZero(&workspace, 1024 * 1024));
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, a_length, /*color=*/0);
@@ -673,57 +646,88 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
   // Construct a thunk with command sequence.
   CommandBufferThunk thunk(std::move(commands), Thunk::ThunkInfo());
 
-  ServiceExecutableRunOptions run_options;
-  se::StreamExecutorMemoryAllocator allocator(executor);
-  BufferAllocations allocations({a, b, c, d, workspace}, 0, &allocator);
+  std::vector<float> a_arr_1{1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<float> a_arr_2{2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<float> result_1{11, 11, 11, 27, 27, 27};
+  std::vector<float> result_2{15, 15, 15, 31, 31, 31};
 
-  Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
-      run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
+  auto run_cublaslt_test = [&](std::unique_ptr<se::Stream>& stream, std::vector<float> a_arr, std::vector<float> result) {
+    se::DeviceMemory<float> a = executor->AllocateArray<float>(2 * 4);
+    TF_ASSERT_OK(stream->Memcpy(&a, a_arr.data(), a_length));
 
-  Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  TF_ASSERT_OK(thunk.Initialize(
-      {executor, source, &allocations, stream.get(), stream.get()}));
+    se::DeviceMemory<float> b = executor->AllocateArray<float>(4 * 3);
+    std::vector<float> b_arr(12, 1);
+    TF_ASSERT_OK(stream->Memcpy(&b, b_arr.data(), b_length));
 
-  // Execute command buffer thunk and verify that it executed a GEMM.
-  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
-  TF_ASSERT_OK(stream->BlockHostUntilDone());
+    se::DeviceMemory<float> c = executor->AllocateArray<float>(2 * 3);
+    std::vector<float> c_arr(6, 1);
+    TF_ASSERT_OK(stream->Memcpy(&c, c_arr.data(), c_length));
 
-  // Copy `out` data back to host.
-  std::vector<float> dst(6, 0);
-  TF_ASSERT_OK(stream->Memcpy(dst.data(), d, d_length));
+    se::DeviceMemory<float> d = executor->AllocateArray<float>(2 * 3);
+    TF_ASSERT_OK(stream->MemZero(&d, d_length));
 
-  ASSERT_EQ(dst, std::vector<float>({11, 11, 11, 27, 27, 27}));
+    se::DeviceMemory<float> workspace =
+        executor->AllocateArray<float>(1024 * 1024);
+    TF_ASSERT_OK(stream->MemZero(&workspace, 1024 * 1024));
 
-  // Prepare buffer allocation for updating command buffer.
-  se::DeviceMemory<float> updated_d = executor->AllocateArray<float>(2 * 3);
-  TF_ASSERT_OK(stream->MemZero(&updated_d, d_length));
+    ServiceExecutableRunOptions run_options;
+    se::StreamExecutorMemoryAllocator allocator(executor);
+    BufferAllocations allocations({a, b, c, d, workspace}, 0, &allocator);
 
-  // Update buffer allocation to updated `d` buffer.
-  allocations =
-      BufferAllocations({a, b, c, updated_d, workspace}, 0, &allocator);
+    Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
+        run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
 
-  // Thunk execution should automatically update underlying command buffer.
-  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
-  TF_ASSERT_OK(stream->BlockHostUntilDone());
+    Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
+    TF_ASSERT_OK(thunk.Initialize(
+        {executor, source, &allocations, stream.get(), stream.get()}));
 
-  // Copy `updated_out` data back to host.
-  std::fill(dst.begin(), dst.end(), 0);
-  TF_ASSERT_OK(stream->Memcpy(dst.data(), updated_d, d_length));
+    // Execute command buffer thunk and verify that it executed a GEMM.
+    TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+    TF_ASSERT_OK(stream->BlockHostUntilDone());
 
-  ASSERT_EQ(dst, std::vector<float>({11, 11, 11, 27, 27, 27}));
+    // Copy `out` data back to host.
+    std::vector<float> dst(6, 0);
+    TF_ASSERT_OK(stream->Memcpy(dst.data(), d, d_length));
 
-  // Try to update the command buffer with the same buffers.
-  TF_ASSERT_OK(stream->MemZero(&updated_d, d_length));
+    ASSERT_EQ(dst, result);
 
-  // Thunk execution should automatically update underlying command buffer.
-  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
-  TF_ASSERT_OK(stream->BlockHostUntilDone());
+    // Prepare buffer allocation for updating command buffer.
+    se::DeviceMemory<float> updated_d = executor->AllocateArray<float>(2 * 3);
+    TF_ASSERT_OK(stream->MemZero(&updated_d, d_length));
 
-  // Copy `updated_out` data back to host.
-  std::fill(dst.begin(), dst.end(), 0);
-  TF_ASSERT_OK(stream->Memcpy(dst.data(), updated_d, d_length));
+    // Update buffer allocation to updated `d` buffer.
+    allocations =
+        BufferAllocations({a, b, c, updated_d, workspace}, 0, &allocator);
 
-  ASSERT_EQ(dst, std::vector<float>({11, 11, 11, 27, 27, 27}));
+    // Thunk execution should automatically update underlying command
+    // buffer.
+    TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+    TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+    // Copy `updated_out` data back to host.
+    std::fill(dst.begin(), dst.end(), 0);
+    TF_ASSERT_OK(stream->Memcpy(dst.data(), updated_d, d_length));
+
+    ASSERT_EQ(dst, result);
+
+    // Try to update the command buffer with the same buffers.
+    TF_ASSERT_OK(stream->MemZero(&updated_d, d_length));
+
+    // Thunk execution should automatically update underlying command
+    // buffer.
+    TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+    TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+    // Copy `updated_out` data back to host.
+    std::fill(dst.begin(), dst.end(), 0);
+    TF_ASSERT_OK(stream->Memcpy(dst.data(), updated_d, d_length));
+
+    ASSERT_EQ(dst, result);
+  };
+  std::thread t1(run_cublaslt_test, std::ref(stream1), a_arr_1, result_1);
+  std::thread t2(run_cublaslt_test, std::ref(stream2), a_arr_2, result_2);
+  t1.join();
+  t2.join();
 }
 
 TEST(CommandBufferThunkTest, MultipleLaunchCmd) {


### PR DESCRIPTION
It is a bug that CublasLtCmd's save the gemm plan and algorithm across Initialize and Execute.