### PR TITLE
[XLA:GPU][AutoSharding] Enable autosharding in GPU compiler compilation

### DIFF
--- a/third_party/ortools/ortools.patch
+++ b/third_party/ortools/ortools.patch
@@ -10,3 +10,15 @@ diff --git a/src/ortools/base/file.cc b/src/ortools/base/file.cc
    return absl::Status(absl::StatusCode::kInvalidArgument,
                        absl::StrCat("Could not read from '", filename, "'."));
  }
+diff --git a/ortools/linear_solver/BUILD.bazel b/ortools/linear_solver/BUILD.bazel
+--- a/ortools/linear_solver/BUILD.bazel
++++ b/ortools/linear_solver/BUILD.bazel
+@@ -79,7 +79,7 @@
+         "linear_expr.cc",
+         "linear_solver_callback.cc",
+         "linear_solver.cc",
+-        "lpi_glop.cpp",
++        # "lpi_glop.cpp",
+         "pdlp_interface.cc",
+         "sat_interface.cc",
+         "scip_callback.cc",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3616,6 +3616,7 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "//xla:shape_util",
         "//xla/hlo/ir:hlo_module_group",
+        "//xla/hlo/experimental/auto_sharding",
         "//xla/service:buffer_value",
         "//xla/service:dynamic_dimension_inference",
         "//xla/service:hlo_cost_analysis",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -250,9 +250,7 @@ limitations under the License.
 #include "tsl/platform/threadpool.h"
 #include "tsl/profiler/lib/traceme.h"
 
-#ifdef PLATFORM_GOOGLE
 #include "xla/hlo/experimental/auto_sharding/auto_sharding.h"
-#endif  // PLATFORM_GOOGLE
 
 namespace xla {
 namespace gpu {
@@ -567,7 +565,6 @@ absl::Status RunSPMDPasses(
         hlo_module, layout_insensitive_algsimp_opts,
         gpu_target_config.device_description.gpu_compute_capability(),
         spmd_pipeline,
-#ifdef PLATFORM_GOOGLE
         [&](HloPassPipeline& pipeline) {
           if (auto_sharding) {
             AutoShardingOption option;
@@ -600,9 +597,6 @@ absl::Status RunSPMDPasses(
             spmd_pipeline.AddPass<AutoSharding>(option);
           }
         });
-#else
-        std::nullopt);
-#endif  // PLATFORM_GOOGLE
     return spmd_pipeline.Run(hlo_module).status();
   } else {
     HloPassPipeline sharding_removal_pipeline("sharding-removal");


### PR DESCRIPTION
## Objective:
This pull request aims to resolve compilation issues related to enabling GPU Auto Sharding functionality in the `auto_sharding_gpu_compiler_test.cc` file. fix #13612

## Background
When compiling the `auto_sharding_gpu_compiler_test.cc` using the command:

```shell
TF_CUDA_COMPUTE_CAPABILITIES="8.0" XLA_CUDA=1 bazel build xla/service/gpu:auto_sharding_gpu_compiler_test --config=cuda
```
While the compilation is successful, the unit test subsequently fails. Upon investigation, the failure seems to be linked to the following warning, which suggests that auto sharding is not enabled.

```shell
2024-06-19 17:44:19.985341: E xla/service/gpu/gpu_compiler.cc:552] GPU autosharding is not yet available in open source.
```
## Changes Made

1. To enable GPU Auto Sharding, I removed several conditional macros in `gpu_compiler.cc`. However, this modification led to a compilation error:
    ```shell
    xla/xla/service/gpu/BUILD:3402:11: Compiling xla/service/gpu/gpu_compiler.cc failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing command (from target //xla/service/gpu:gpu_compiler) external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -MD -MF bazel-out/k8-opt/bin/xla/service/gpu/_objs/gpu_compiler/gpu_compiler.pic.d ... (remaining 519 arguments skipped)
    In file included from ./xla/hlo/experimental/auto_sharding/auto_sharding.h:37,
                     from xla/service/gpu/gpu_compiler.cc:253:
    ./xla/hlo/experimental/auto_sharding/auto_sharding_solver.h:25:10: fatal error: xla/hlo/experimental/auto_sharding/auto_sharding.pb.h: No such file or directory
       25 | #include "xla/hlo/experimental/auto_sharding/auto_sharding.pb.h"
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.
    ```

2. Upon reviewing the dependencies listed in the `BUILD` file for the `gpu_compiler` module, I discovered that the auto sharding module was not included. So I added the missing auto sharding module to the dependencies of the GPU compiler in the `BUILD` file.

## Results

Post-modification, the unit test now passes without errors, confirming that the changes fix the related issues.