### PR TITLE
Removing spurious `option go_package` from autotuning.proto

### DIFF
--- a/xla/autotuning.proto
+++ b/xla/autotuning.proto
@@ -11,8 +11,6 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "tsl/protobuf/dnn.proto";
 
-option go_package = "github.com/google/tsl/tsl/go/protobuf/for_core_protos_go_proto";
-
 message CudnnVersion {
   int32 major = 1;
   int32 minor = 2;


### PR DESCRIPTION
Generally, **bazel** uses the `M` option for the Go proto generator -- see https://protobuf.dev/reference/go/go-generated/#invocation

Unfortunately, hard-coding `option go_package` here prevents other libraries from using the `.proto` file by compiling the Go bindings in their own package structure.

Removing it makes it friendlier for downstream Go users of the XLA library.

Plus I don't see it used anywhere in the library, so better remove things not used -- and it's not defined in any of the other `.proto` files.