### PR TITLE
Tuple Outputs in Convolution Algorithm Picker

### DIFF
--- a/xla/service/gpu/autotuning/BUILD
+++ b/xla/service/gpu/autotuning/BUILD
@@ -296,6 +296,7 @@ xla_test(
 xla_test(
     name = "gemm_algorithm_picker_test",
     srcs = ["gemm_algorithm_picker_test.cc"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     backends = [
         "gpu_v100",
         "gpu_amd_any",

--- a/xla/service/gpu/autotuning/BUILD
+++ b/xla/service/gpu/autotuning/BUILD
@@ -296,7 +296,6 @@ xla_test(
 xla_test(
     name = "gemm_algorithm_picker_test",
     srcs = ["gemm_algorithm_picker_test.cc"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     backends = [
         "gpu_v100",
         "gpu_amd_any",
@@ -386,6 +385,7 @@ cc_library(
 xla_test(
     name = "conv_algorithm_picker_test",
     srcs = ["conv_algorithm_picker_test.cc"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     backends = [
         "gpu_v100",
         "gpu_amd_any",

--- a/xla/service/gpu/autotuning/BUILD
+++ b/xla/service/gpu/autotuning/BUILD
@@ -405,6 +405,7 @@ xla_test(
         "//xla/service:tuple_simplifier",
         "//xla/service/gpu:stream_executor_util",
         "//xla/service/gpu/transforms:conv_rewriter",
+        "//xla/service/gpu/transforms:cudnn_fused_conv_rewriter",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:platform",
         "//xla/tests:hlo_test_base",
@@ -413,7 +414,9 @@ xla_test(
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
         "@tsl//tsl/platform:test_main",
-    ],
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ]),
 )
 
 cc_library(

--- a/xla/service/gpu/autotuning/conv_algorithm_picker.cc
+++ b/xla/service/gpu/autotuning/conv_algorithm_picker.cc
@@ -97,6 +97,16 @@ using se::DeviceMemoryBase;
 using se::dnn::AlgorithmDesc;
 using std::optional;
 
+// Returns the shape of the element with index tuple_idx from shape when shape
+// is a tuple shape. Returns shape when shape is not a tuple shape.
+Shape MaybeTupleElementShape(Shape shape, int64_t tuple_idx) {
+  if (shape.IsTuple()) {
+    return shape.tuple_shapes(tuple_idx);
+  } else {
+    return shape;
+  }
+}
+
 class ScratchAllocator : public se::ScratchAllocator {
  public:
   ScratchAllocator(int device_ordinal,
@@ -735,9 +745,15 @@ absl::StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
 
     const DebugOptions& debug_options =
         runtime_arguments.hlo_module_config.debug_options();
-    BufferComparator comparator(runtime_arguments.rz_buffers.output_shape(),
-                                debug_options.xla_gpu_autotune_gemm_rtol());
     for (int i = 0; i < result_buffers.size(); ++i) {
+      // If there is one output, the output shape describes the shape of an
+      // array. If there are multiple outputs, the output shape is a tuple, in
+      // which case get the shape of the i-th element.
+      Shape output_shape = MaybeTupleElementShape(
+          runtime_arguments.rz_buffers.output_shape(), i);
+      XLA_SCOPED_LOGGING_TIMER_LEVEL("BufferComparator::CompareEqual", 2);
+      BufferComparator comparator(output_shape,
+                                  debug_options.xla_gpu_autotune_gemm_rtol());
       absl::StatusOr<bool> compare_result = comparator.CompareEqual(
           stream, (*reference_result)->buffers[i], result_buffers[i]);
       if (!compare_result.ok()) {

--- a/xla/service/gpu/autotuning/conv_algorithm_picker_test.cc
+++ b/xla/service/gpu/autotuning/conv_algorithm_picker_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "xla/service/gpu/autotuning/autotuner_util.h"
 #include "xla/service/gpu/stream_executor_util.h"
 #include "xla/service/gpu/transforms/conv_rewriter.h"
+#include "xla/service/gpu/transforms/cudnn_fused_conv_rewriter.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/service/pattern_matcher_gmock.h"
 #include "xla/service/platform_util.h"
@@ -36,6 +37,10 @@ limitations under the License.
 #include "tsl/platform/statusor.h"
 #include "tsl/platform/test.h"
 
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#endif
+
 namespace xla::gpu {
 namespace {
 
@@ -43,6 +48,16 @@ namespace m = ::xla::match;
 
 class GpuConvAlgorithmPickerTest : public HloTestBase {
  public:
+  se::CudaComputeCapability GetCudaComputeCapability() {
+    return backend()
+        .default_stream_executor()
+        ->GetDeviceDescription()
+        .cuda_compute_capability();
+  }
+  stream_executor::dnn::VersionInfo GetDnnVersion() {
+    return GetDnnVersionInfoOrDefault(backend().default_stream_executor());
+  }
+
   GpuConvAlgorithmPickerTest() { AutotunerUtil::ClearAutotuneResults(); }
 };
 
@@ -123,6 +138,69 @@ ENTRY main {
                         .algorithm()
                         .algo_id() != 14);
   }
+}
+
+TEST_F(GpuConvAlgorithmPickerTest, SetAlgorithmGraphConvF8) {
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::HOPPER)) {
+    GTEST_SKIP() << "FP8 convolutions require Hopper or newer architecture.";
+  }
+  constexpr absl::string_view kHlo = R"(
+HloModule module
+apply {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  ROOT c = f32[] maximum(a, b)
+}
+ENTRY main {
+  input = f8e4m3fn[1,6,6,128] parameter(0)
+  filter = f8e4m3fn[16,3,3,128] parameter(1)
+  input_scale = f32[] parameter(2)
+  input_scale_bcast = f32[1,6,6,128] broadcast(input_scale), dimensions={}
+  filter_scale = f32[] parameter(3)
+  filter_scale_bcast = f32[16,3,3,128] broadcast(filter_scale), dimensions={}
+  input_f32 = f32[1,6,6,128] convert(input)
+  input_unscaled = f32[1,6,6,128] multiply(input_f32, input_scale_bcast)
+  filter_f32 = f32[16,3,3,128] convert(filter)
+  filter_unscaled = f32[16,3,3,128] multiply(filter_f32, filter_scale_bcast)
+  conv_a = f32[1,6,6,16] convolution(input_unscaled, filter_unscaled), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, feature_group_count=1
+  z_scale = f32[] parameter(4)
+  z_scale_bcast = f32[1,6,6,16] broadcast(z_scale), dimensions={}
+  conv_a_scaled = f32[1,6,6,16] multiply(conv_a, z_scale_bcast)
+  c1 = f32[] constant(-448.)
+  c1_bcast = f32[1,6,6,16] broadcast(c1), dimensions={}
+  c2 = f32[] constant(448.)
+  c2_bcast = f32[1,6,6,16] broadcast(c2), dimensions={}
+  conv_a_clamped = f32[1,6,6,16] clamp(c1_bcast, conv_a_scaled, c2_bcast)
+  conv_a_clamped_f8 = f8e4m3fn[1,6,6,16] convert(conv_a_clamped)
+  abs_conv_a = f32[1,6,6,16] abs(conv_a)
+  c0 = f32[] constant(-inf)
+  amax = f32[] reduce(abs_conv_a, c0), dimensions={0,1,2,3}, to_apply=apply
+  ROOT conv_f8 = (f8e4m3fn[1,6,6,16], f32[]) tuple(conv_a_clamped_f8, amax)
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kHlo));
+
+  se::Platform* platform = PlatformUtil::GetDefaultPlatform().value();
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                          PlatformUtil::GetStreamExecutors(platform));
+  ASSERT_GT(executors.size(), 0);
+  se::StreamExecutor* stream_exec = executors[0];
+
+  const se::GpuComputeCapability& cc = GetCudaComputeCapability();
+  bool changed;
+  TF_ASSERT_OK_AND_ASSIGN(changed, RunHloPass(GpuConvRewriter(cc), m.get()));
+  ASSERT_TRUE(changed);
+  TF_ASSERT_OK_AND_ASSIGN(
+      changed, RunHloPass(CudnnFusedConvRewriter(GetCudaComputeCapability(),
+                                                 GetDnnVersion(), CUDA_VERSION),
+                          m.get()));
+  ASSERT_TRUE(changed);
+
+  DebugOptions opts = DefaultDebugOptionsIgnoringFlags();
+  AutotuneConfig cfg{DeviceConfig{stream_exec, nullptr}, opts};
+  TF_ASSERT_OK_AND_ASSIGN(changed,
+                          RunHloPass(GpuConvAlgorithmPicker(cfg), m.get()));
+  ASSERT_TRUE(changed);
 }
 
 }  // namespace

--- a/xla/service/gpu/autotuning/conv_algorithm_picker_test.cc
+++ b/xla/service/gpu/autotuning/conv_algorithm_picker_test.cc
@@ -188,7 +188,7 @@ ENTRY main {
 
   const se::GpuComputeCapability& cc = GetCudaComputeCapability();
   bool changed;
-  TF_ASSERT_OK_AND_ASSIGN(changed, RunHloPass(GpuConvRewriter(cc), m.get()));
+  TF_ASSERT_OK_AND_ASSIGN(changed, RunHloPass(ConvRewriter(cc), m.get()));
   ASSERT_TRUE(changed);
   TF_ASSERT_OK_AND_ASSIGN(
       changed, RunHloPass(CudnnFusedConvRewriter(GetCudaComputeCapability(),


### PR DESCRIPTION
Adds support for tuple-shaped outputs in the convolution algorithm picker.

This enables running TestConvAmaxF8 and TestConvReluAmaxF8 in cudnn_fused_conv_rewriter_test.cc.