### PR TITLE
[XLA:GPU] Add deterministic flash attention backward implementation in XLA

### DIFF
--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -253,6 +253,9 @@ message CudnnfMHABackendConfig {
     ALIBI = 4;
   }
   MaskType mask_type = 22;
+
+  // Whether force deterministic for bwd
+  bool force_deterministic = 23;
 }
 
 // Generic backend config for XLA:GPU

--- a/xla/service/gpu/cudnn_workspace_rewriter.cc
+++ b/xla/service/gpu/cudnn_workspace_rewriter.cc
@@ -53,7 +53,7 @@ namespace {
 // create cuDNN graphs from HloCustomCall
 absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     se::dnn::DnnSupport& dnn_support,
-    const HloCustomCallInstruction* custom_call) {
+    HloCustomCallInstruction* custom_call) {
   if (IsFwdCustomCallTofMHA(*custom_call)) {
     TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
                         xla::gpu::GetCudnnfMHAKind(custom_call));
@@ -118,10 +118,10 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     return std::move(graph);
   } else {
     TF_ASSIGN_OR_RETURN(
-        const auto gpu_config,
+        auto gpu_config,
         custom_call->backend_config<xla::gpu::GpuBackendConfig>());
-    const xla::gpu::CudnnfMHABackendConfig& config =
-        gpu_config.cudnn_fmha_backend_config();
+    xla::gpu::CudnnfMHABackendConfig& config =
+        *gpu_config.mutable_cudnn_fmha_backend_config();
 
     int input_index = 0;
     Shape bmm1_grad_gemm1_rhs_shape =
@@ -174,6 +174,15 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
                  custom_call->shape().tuple_shapes().size() - 1);
     TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
                         AsCudnnFmhaMaskKind(config.mask_type()));
+
+    bool force_deterministic = custom_call->GetModule()
+                                   ->config()
+                                   .debug_options()
+                                   .xla_gpu_deterministic_ops();
+    // set the correct force_deterministic attribute here
+    config.set_force_deterministic(force_deterministic);
+    TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));
+
     GpufMHABackwardDescriptor descriptor = {
         kind,
         config,
@@ -194,13 +203,15 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
         fwd_output_shape,
         mask_shape,
         d_bias_shape,
-        bias_shape};
+        bias_shape,
+        force_deterministic};
 
     TF_ASSIGN_OR_RETURN(GpufMHABackwardConfig fmha_config,
                         GpufMHABackwardConfig::For(descriptor));
     TF_ASSIGN_OR_RETURN(
         se::dnn::FMHAMaskKind dnn_mask_type,
         GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(fmha_config.mask_type));
+
     TF_ASSIGN_OR_RETURN(
         se::gpu::CudnnGraph graph,
         se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(
@@ -211,7 +222,8 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
             fmha_config.d_bmm2_rhs, fmha_config.bias, fmha_config.dropout_rate,
             fmha_config.seed, *fmha_config.fmha_scale,
             fmha_config.dropout_rate && *fmha_config.dropout_rate > 0.0,
-            fmha_config.bias != std::nullopt, dnn_mask_type));
+            fmha_config.bias != std::nullopt, dnn_mask_type,
+            force_deterministic));
     return std::move(graph);
   }
 }

--- a/xla/service/gpu/cudnn_workspace_rewriter.cc
+++ b/xla/service/gpu/cudnn_workspace_rewriter.cc
@@ -175,10 +175,11 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
                         AsCudnnFmhaMaskKind(config.mask_type()));
 
-    bool force_deterministic = custom_call->GetModule()
-                                   ->config()
-                                   .debug_options()
-                                   .xla_gpu_deterministic_ops();
+    const DebugOptions& debug_options =
+        custom_call->GetModule()->config().debug_options();
+    bool force_deterministic =
+        debug_options.xla_gpu_deterministic_ops() ||
+        debug_options.xla_gpu_exclude_nondeterministic_ops();
     // set the correct force_deterministic attribute here
     config.set_force_deterministic(force_deterministic);
     TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));

--- a/xla/service/gpu/gpu_fused_mha_runner.cc
+++ b/xla/service/gpu/gpu_fused_mha_runner.cc
@@ -515,6 +515,7 @@ GpufMHAConfig::AsDnnFusedMHAOpConfig() const {
 
   config.kind = desc.kind;
   config.mask_type = desc.mask_type;
+  config.force_deterministic = desc.force_deterministic;
   const CudnnfMHABackendConfig &backend_config = desc.backend_config;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
   config.fmha_scale.emplace(backend_config.fmha_scale());
@@ -531,6 +532,7 @@ GpufMHABackwardConfig::AsDnnFusedMHABackwardOpConfig() const {
   }
   TF_ASSIGN_OR_RETURN(se::dnn::FMHAMaskKind mask_type,
                       GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(mask_type));
+
   return se::dnn::FusedMHABackwardOp::Config{scale,
                                              bmm1_grad_gemm1_rhs,
                                              bmm1_grad_gemm2_rhs,
@@ -546,7 +548,8 @@ GpufMHABackwardConfig::AsDnnFusedMHABackwardOpConfig() const {
                                              bias,
                                              dropout_rate,
                                              seed,
-                                             mask_type};
+                                             mask_type,
+                                             force_deterministic};
 }
 
 /*static*/ absl::StatusOr<GpufMHAParams> GpufMHAParams::For(

--- a/xla/service/gpu/gpu_fused_mha_runner.h
+++ b/xla/service/gpu/gpu_fused_mha_runner.h
@@ -100,6 +100,7 @@ struct GpufMHABackwardDescriptor {
   std::optional<Shape> mask_shape;
   std::optional<Shape> d_bias_shape;
   std::optional<Shape> bias_shape;
+  bool force_deterministic;
 };
 
 // Structure to describe static properties of a GPU fused Multi-Headed
@@ -166,6 +167,7 @@ struct GpufMHABackwardConfig {
   std::optional<se::dnn::TensorDescriptor> d_bias;
   std::optional<se::dnn::TensorDescriptor> fwd_output;
   std::optional<se::dnn::TensorDescriptor> bias;
+  bool force_deterministic;
 };
 
 // Implementation struct exposed for debugging and log analysis.

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1138,6 +1138,7 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
   TF_RET_CHECK(output_index == instr->shape().tuple_shapes().size());
   TF_ASSIGN_OR_RETURN(const auto mask_type,
                       AsCudnnFmhaMaskKind(config.mask_type()));
+  bool force_deterministic = config.force_deterministic();
   GpufMHABackwardDescriptor descriptor = {
       kind,
       config,
@@ -1158,7 +1159,8 @@ absl::Status IrEmitterUnnested::EmitFusedMHABackwardThunk(
       fwd_output_shape,
       mask_shape,
       d_bias_shape,
-      bias_shape};
+      bias_shape,
+      force_deterministic};
 
   TF_ASSIGN_OR_RETURN(GpufMHABackwardConfig fmha_backward_config,
                       GpufMHABackwardConfig::For(descriptor));

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -134,6 +134,31 @@ class MultiHeadedAttentionTest : public GpuCodegenTest {
         LiteralTestUtil::Near(expected_result, actual_result, mha_error_spec_));
   }
 
+  void VerifyBackwardDeterminism(absl::string_view hlo_string,
+                                 const std::vector<Literal *> &literals,
+                                 bool force_deterministic = false) {
+    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> reference_module,
+                            ParseAndReturnVerifiedModule(hlo_string));
+    DebugOptions debug_options = GetDebugOptionsForTest();
+    debug_options.set_xla_gpu_enable_cudnn_fmha(true);
+    if (force_deterministic) {
+      debug_options.set_xla_gpu_deterministic_ops(true);
+    }
+    reference_module->mutable_config().set_debug_options(debug_options);
+    const Literal first_run_result =
+        ExecuteAndTransfer(reference_module->Clone(), literals);
+
+    const Literal second_run_result =
+        ExecuteAndTransfer(std::move(reference_module), literals);
+
+    ErrorSpec error_spec{1E-8, 1e-8};
+    if (force_deterministic) {
+      EXPECT_TRUE(LiteralTestUtil::Near(first_run_result, second_run_result, error_spec));
+    } else {
+      EXPECT_FALSE(LiteralTestUtil::Near(first_run_result, second_run_result, error_spec));
+    }
+  }
+
   template <typename T>
   Literal GetInput4DLiteral(std::vector<int64_t> dimensions,
                             std::vector<int64_t> minor_to_major) {
@@ -879,6 +904,37 @@ class FlashAttentionBMMScaleSoftmaxBMM : public MultiHeadedAttentionTest {
         {&lhs_bmm1_literal, &rhs_bmm1_literal, &rhs_bmm2_literal, &do_literal},
         /*expected_num_fmha_calls=*/2);
   }
+
+  template <typename T>
+  void TestImpl_Flash_Attention_Training_BMM1_Softmax_BMM2_Deterministic() {
+    if (skip_reason_) GTEST_SKIP() << *skip_reason_;
+    auto cc = GetCudaComputeCapability();
+    if (GetDnnVersionInfoOrDefault(backend().default_stream_executor()) <
+            se::dnn::VersionInfo(8, 9, 4) ||
+        !cc.IsAtLeastHopper() || cc.minor != 0) {
+      GTEST_SKIP() << "Flash Attention deterministic kernels requires cuDNN >= "
+                      "8.9.4 and Hopper arch.";
+    }
+    XlaBuilder builder(TestName());
+    auto lhs_bmm1_literal =
+        GetInput4DLiteral<T>({2, 6, 1024, 64}, {3, 2, 1, 0});
+    auto rhs_bmm1_literal =
+        GetInput4DLiteral<T>({2, 6, 64, 1024}, {3, 2, 1, 0});
+    auto rhs_bmm2_literal =
+        GetInput4DLiteral<T>({2, 6, 1024, 64}, {3, 2, 1, 0});
+    auto do_literal = GetInput4DLiteral<T>({2, 6, 1024, 64}, {3, 2, 1, 0});
+    std::string hlo_string = "";
+    hlo_string =
+        GetModuleFlash_Attention_Training_BMM1_Softmax_BMM2_HloString_BF16();  // NOLINT
+    VerifyBackwardDeterminism(
+        hlo_string,
+        {&lhs_bmm1_literal, &rhs_bmm1_literal, &rhs_bmm2_literal, &do_literal},
+        /*force_deterministic=*/true);
+    VerifyBackwardDeterminism(
+        hlo_string,
+        {&lhs_bmm1_literal, &rhs_bmm1_literal, &rhs_bmm2_literal, &do_literal},
+        /*force_deterministic=*/false);
+  }
 };
 
 class FlashAttentionBMMScalePaddingMaskSoftmaxBMM
@@ -1067,6 +1123,11 @@ XLA_TEST_F(FlashAttentionBMMScaleBiasSoftmaxBMM,
 XLA_TEST_F(FlashAttentionBMMScaleSoftmaxBMM,
            Flash_Attention_Training_BMM1_Softmax_BMM2_BF16) {
   TestImpl_Flash_Attention_Training_BMM1_Softmax_BMM2<bfloat16>();
+}
+
+XLA_TEST_F(FlashAttentionBMMScaleSoftmaxBMM,
+           Flash_Attention_Training_BMM1_Softmax_BMM2_Deterministic_BF16) {
+  TestImpl_Flash_Attention_Training_BMM1_Softmax_BMM2_Deterministic<bfloat16>();
 }
 
 // BMM1 - Scale - PaddingMask - Softmax - BMM2

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5229,8 +5229,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     const dnn::TensorDescriptor& dv_desc,
     const std::optional<dnn::TensorDescriptor> bias_descriptor,
     std::optional<double> dropout_rate, std::optional<int64_t> seed,
-    double scale, bool use_dropout, bool use_bias,
-    dnn::FMHAMaskKind mask_type) {
+    double scale, bool use_dropout, bool use_bias, dnn::FMHAMaskKind mask_type,
+    bool force_deterministic) {
 #if CUDNN_VERSION >= 8904
   if (VLOG_IS_ON(4)) {
     VLOG(4) << "\n bmm1_grad_gemm1_rhs(q): " << q_desc.ToString()
@@ -5393,6 +5393,10 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
                          .set_uid(CudnnfMHAUid::D_OFFSET_ID));
     sdpa_backward_options.set_dropout((float)dropout_rate.value(), seed_tensor,
                                       offset_tensor);
+  }
+
+  if (force_deterministic) {
+    sdpa_backward_options.set_deterministic_algorithm(true);
   }
 
   auto [dQ, dK, dV] =
@@ -7269,7 +7273,7 @@ CudnnSupport::FusedMHABackwardRunnerFromDesc(
     std::optional<dnn::TensorDescriptor> fwd_output_descriptor,
     std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed,
-    dnn::FMHAMaskKind mask_type) {
+    dnn::FMHAMaskKind mask_type, bool force_deterministic) {
 #if CUDNN_VERSION >= 8904
   auto cudnn = cudnn_->GetHandle(parent_, stream);
 
@@ -7283,7 +7287,8 @@ CudnnSupport::FusedMHABackwardRunnerFromDesc(
           bmm2_grad_gemm1_lhs_descriptor, bmm2_grad_gemm2_rhs_descriptor,
           d_output_descriptor, d_bmm1_lhs_descriptor, d_bmm1_rhs_descriptor,
           d_bmm2_rhs_descriptor, bias_descriptor, dropout_rate, seed, scale,
-          use_dropout, bias_descriptor != std::nullopt, mask_type));
+          use_dropout, bias_descriptor != std::nullopt, mask_type,
+          force_deterministic));
 
   std::vector<int64_t> p_dims =
       bmm2_grad_gemm1_lhs_descriptor.GetCudnnCompatibleDimensions(false);

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -364,7 +364,7 @@ class CudnnSupport : public dnn::DnnSupport {
       std::optional<dnn::TensorDescriptor> fwd_output_descriptor,
       std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed,
-      dnn::FMHAMaskKind mask_type);
+      dnn::FMHAMaskKind mask_type, bool force_deterministic);
 
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
@@ -739,7 +739,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     const std::optional<dnn::TensorDescriptor> bias_descriptor,
     std::optional<double> dropout_rate, std::optional<int64_t> seed,
     double scale, bool use_dropout, bool use_bias,
-    const dnn::FMHAMaskKind mask_type);
+    const dnn::FMHAMaskKind mask_type, bool force_deterministic);
 
 }  // namespace gpu
 }  // namespace stream_executor

--- a/xla/stream_executor/dnn.cc
+++ b/xla/stream_executor/dnn.cc
@@ -280,7 +280,7 @@ DnnSupport::FusedMHABackwardRunnerFromDesc(
     std::optional<dnn::TensorDescriptor> fwd_output_descriptor,
     std::optional<dnn::TensorDescriptor> bias_descriptor, double scale,
     std::optional<double> dropout_rate, std::optional<int64_t> seed,
-    dnn::FMHAMaskKind mask_type) {
+    dnn::FMHAMaskKind mask_type, bool force_deterministic) {
   return absl::UnimplementedError(
       "FusedMHABackwardRunnerFromDesc not implemented.");
 }

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1764,7 +1764,7 @@ class DnnSupport {
       std::optional<TensorDescriptor> fwd_output_descriptor,
       std::optional<TensorDescriptor> bias_descriptor, double scale,
       std::optional<double> dropout_rate, std::optional<int64_t> seed,
-      dnn::FMHAMaskKind mask_type);
+      dnn::FMHAMaskKind mask_type, bool force_deterministic);
 
   virtual bool GetMIOpenConvolveAlgorithms(
       ConvolutionKind kind, DataType element_type, DataType output_type,

--- a/xla/stream_executor/lazy_op_runner.h
+++ b/xla/stream_executor/lazy_op_runner.h
@@ -329,6 +329,7 @@ struct FusedMHABackwardOp {
     std::optional<double> dropout_rate;
     std::optional<int64_t> seed;
     FMHAMaskKind mask_type;
+    bool force_deterministic;
   };
 
   static absl::StatusOr<
@@ -345,7 +346,7 @@ struct FusedMHABackwardOp {
         config.d_bmm2_rhs_descriptor, config.d_s_descriptor,
         config.d_bias_descriptor, config.fwd_output_descriptor,
         config.bias_descriptor, config.scale, config.dropout_rate, config.seed,
-        config.mask_type);
+        config.mask_type, config.force_deterministic);
   }
 };
 


### PR DESCRIPTION
* cuDNN frontend 1.5 added an option to enforce deterministic flash attention backward implementation. Guarded by `xla_gpu_deterministic_ops` and `xla_gpu_exclude_nondeterministic_ops`.