### PR TITLE
Add kExp op to algsimp IsNonNegative

### DIFF
--- a/xla/service/algebraic_simplifier.h
+++ b/xla/service/algebraic_simplifier.h
@@ -445,6 +445,11 @@ class AlgebraicSimplifierVisitor : public DfsHloRewriteVisitor {
       const Shape& original_shape, const Shape& bitcast_shape,
       const std::vector<std::vector<int64_t>>& original_map);
 
+  // Checks if the output of a given instruction is guaranteed to be
+  // non-negative. e.g. abs
+  static bool IsNonNegative(const HloInstruction* hlo,
+                            const AlgebraicSimplifierOptions& options);
+
   // Modify the layout dimensions of result_shape, so that it becomes the
   // re-shaped result of applying bitcast to the original_shape, by using
   // dim_map to re-shape layout dimensions of original_shape. Returns the

--- a/xla/service/algebraic_simplifier_test.cc
+++ b/xla/service/algebraic_simplifier_test.cc
@@ -71,6 +71,171 @@ class AlgebraicSimplifierTest : public HloTestBase {
   AlgebraicSimplifierOptions default_options_;
 };
 
+// clang-format off
+const char* non_neg_ops[] = {"abs(p0)",
+                             "constant(0.0)",
+                             "constant(0.1)",
+                             "constant(inf)",
+                             "exponential(p0)",
+                             "maximum(p0, a1)",
+                             "maximum(a1, p0)",
+                             "multiply(p0, p0)",
+                             "select(pred0, a0, a1)",
+                             "select(pred0, a1, a0)"};
+
+const char* arb_sing_ops[] = {"constant(-0.1)",
+                              "constant(-inf)",
+                              "constant(nan)",
+                              "cosine(p0)",
+                              "custom-call(a1), custom_call_target=\"foobar\"",
+                              "maximum(p0, p1)",
+                              "maximum(p1, p0)",
+                              "multiply(p0, a1)",
+                              "multiply(a1, p0)",
+                              "negate(p0)",
+                              "select(pred0, a1, p0)",
+                              "select(pred0, p0, a1)"};
+// clang-format on
+
+// Test that the result of particular oprations is always non-negative
+TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op) {
+  for (const auto* op : non_neg_ops) {
+    const auto kModuleStr = absl::StrFormat(R"(
+      HloModule m
+      test {
+        p0 = f32[] parameter(0)
+        a0 = f32[] abs(p0)
+        p1 = f32[] parameter(1)
+        a1 = f32[] abs(p1)
+        pred0 = pred[] parameter(2)
+        ROOT y = f32[] %s
+      }
+    )",
+                                            op);
+    TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    ASSERT_TRUE(AlgebraicSimplifierVisitor::IsNonNegative(
+        m->entry_computation()->root_instruction(), default_options_));
+  }
+}
+
+// Test that the result of particular oprations might be negative
+TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op_NegativeTestCase) {
+  for (const auto op : arb_sing_ops) {
+    const auto kModuleStr = absl::StrFormat(R"(
+      HloModule m
+      test {
+        p0 = f32[] parameter(0)
+        a0 = f32[] abs(p0)
+        p1 = f32[] parameter(1)
+        a1 = f32[] abs(p1)
+        pred0 = pred[] parameter(2)
+        ROOT y = f32[] %s
+      }
+    )",
+                                            op);
+    TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+        m->entry_computation()->root_instruction(), default_options_));
+  }
+}
+
+// Test that the result of Broadcast is non-negative if its operand is
+// non-negative
+TEST_F(AlgebraicSimplifierTest, IsNonNegative_Broadcast) {
+  for (const auto op : non_neg_ops) {
+    const auto kModuleStr = absl::StrFormat(R"(
+      HloModule m
+      test {
+        p0 = f32[] parameter(0)
+        a0 = f32[] abs(p0)
+        p1 = f32[] parameter(1)
+        a1 = f32[] abs(p1)
+        pred0 = pred[] parameter(2)
+        y = f32[] %s
+        ROOT b = f32[4,8] broadcast(y), dimensions={}
+      }
+    )",
+                                            op);
+    TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    ASSERT_TRUE(AlgebraicSimplifierVisitor::IsNonNegative(
+        m->entry_computation()->root_instruction(), default_options_));
+  }
+}
+
+// Test that the result of Broadcast might be negative if its oprand is
+// not non-negative
+TEST_F(AlgebraicSimplifierTest, IsNonNegative_Broadcast_NegativeTestCase) {
+  for (const auto op : arb_sing_ops) {
+    const auto kModuleStr = absl::StrFormat(R"(
+      HloModule m
+      test {
+        p0 = f32[] parameter(0)
+        a0 = f32[] abs(p0)
+        p1 = f32[] parameter(1)
+        a1 = f32[] abs(p1)
+        pred0 = pred[] parameter(2)
+        y = f32[] %s
+        ROOT b = f32[4,8] broadcast(y), dimensions={}
+      }
+    )",
+                                            op);
+    TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+        m->entry_computation()->root_instruction(), default_options_));
+  }
+}
+
+// Test that the result #2 of custom-call batchNormalizationForwardTraining is
+// non-negative
+TEST_F(AlgebraicSimplifierTest,
+       IsNonNegative_CustomCall_BatchNormalizationForwardTraining) {
+  const auto kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = f32[128,32,2,112] parameter(0)
+      p1 = f32[32] parameter(1)
+      p2 = f32[32] parameter(2)
+      c0 = f32[] constant(0.001)
+      c1 = s64[] constant(1)
+      cc0 = (f32[128,32,2,112], f32[32], f32[32]) custom-call(p0, p1, p2, c0, c1), custom_call_target="__cudnn$batchNormalizationForwardTraining"
+      ROOT t2 = f32[32] get-tuple-element(cc0), index=2
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  default_options_.set_cudnn_batchnorm_forward_training_metadata(
+      "__cudnn$batchNormalizationForwardTraining");
+  ASSERT_TRUE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
+}
+
+// Test that the results #0 and #1 of custom-call
+// batchNormalizationForwardTraining can have arbitrary sign
+TEST_F(
+    AlgebraicSimplifierTest,
+    IsNonNegative_CustomCall_BatchNormalizationForwardTraining_NegativeTestCase_index1) {
+  for (const auto op : {"f32[128,32,2,112] get-tuple-element(cc0), index=0",
+                        "f32[32] get-tuple-element(cc0), index=1"}) {
+    const auto kModuleStr = absl::StrFormat(R"(
+      HloModule m
+      test {
+        p0 = f32[128,32,2,112] parameter(0)
+        p1 = f32[32] parameter(1)
+        p2 = f32[32] parameter(2)
+        c0 = f32[] constant(0.001)
+        c1 = s64[] constant(1)
+        cc0 = (f32[128,32,2,112], f32[32], f32[32]) custom-call(p0, p1, p2, c0, c1), custom_call_target="__cudnn$batchNormalizationForwardTraining"
+        ROOT t1 = %s
+      }
+    )",
+                                            op);
+    TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    default_options_.set_cudnn_batchnorm_forward_training_metadata(
+        "__cudnn$batchNormalizationForwardTraining");
+    ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+        m->entry_computation()->root_instruction(), default_options_));
+  }
+}
+
 // Test that A + 0 is simplified to A
 TEST_F(AlgebraicSimplifierTest, AddZero) {
   auto m = CreateNewVerifiedModule();


### PR DESCRIPTION
`kExp` result is always non-negative (similar to `kAbs`).
We can add `kExp` to `IsNonNegative()` util function in algsimp

Test:
```python
import jax.numpy as jnp                                                                                                                                                                                                                 
x = jnp.array([0.0, -0.0, jnp.inf, -jnp.inf, jnp.nan, 0.1, -0.1, 3, -3]) 

jnp.abs(x)
# Array([0. , 0. , inf, inf, nan, 0.1, 0.1, 3. , 3. ], dtype=float32)

jnp.exp(x)
# Array([ 1. , 1. , inf, 0. , nan, 1.105171, 0.9048374, 20.085537, 0.04978707], dtype=float32)
```
Adrian, what you think? @akuegel 