### PR TITLE
Add kPower case to algsimp IsNonNegative

### DIFF
--- a/xla/service/algebraic_simplifier.cc
+++ b/xla/service/algebraic_simplifier.cc
@@ -497,6 +497,9 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
       return IsNonNegative(hlo->operand(0), options) ||
              IsNonNegative(hlo->operand(1), options);
     }
+    case HloOpcode::kPower: {
+      return IsNonNegative(hlo->operand(0), options);
+    }
     case HloOpcode::kSelect: {
       return IsNonNegative(hlo->operand(1), options) &&
              IsNonNegative(hlo->operand(2), options);

--- a/xla/service/algebraic_simplifier_test.cc
+++ b/xla/service/algebraic_simplifier_test.cc
@@ -80,6 +80,7 @@ const char* non_neg_ops[] = {"abs(p0)",
                              "maximum(p0, a1)",
                              "maximum(a1, p0)",
                              "multiply(p0, p0)",
+                             "power(a0, p1)",
                              "select(pred0, a0, a1)",
                              "select(pred0, a1, a0)"};
 
@@ -93,6 +94,7 @@ const char* arb_sing_ops[] = {"constant(-0.1)",
                               "multiply(p0, a1)",
                               "multiply(a1, p0)",
                               "negate(p0)",
+                              "power(p0, p1)",
                               "select(pred0, a1, p0)",
                               "select(pred0, p0, a1)"};
 // clang-format on


### PR DESCRIPTION
if `kPower` op lhs (The bases) IsNonNegative the result is also non-negative

Test
```python
import jax.numpy as jnp

x = jnp.array([0.0, -0.0, jnp.inf, -jnp.inf, 0.1, -0.1, 1.0, -1.0, 3, -3])
bases = [0.0, 0.1, 1.0, 1.1, 3, jnp.inf]

for base in bases:
  print("base:", base, ", isAllResultsNonNegative:", jnp.all(jnp.pow(base, x) >= 0.0))

base: 0.0 , isAllResultsNonNegative: True
base: 0.1 , isAllResultsNonNegative: True
base: 1.0 , isAllResultsNonNegative: True
base: 1.1 , isAllResultsNonNegative: True
base: 3 , isAllResultsNonNegative: True
base: inf , isAllResultsNonNegative: True
```