### PR TITLE
Fix build error for LogicalIdThunk::buffer_uses()

### DIFF
--- a/xla/service/cpu/runtime/logical_id_thunk.cc
+++ b/xla/service/cpu/runtime/logical_id_thunk.cc
@@ -109,11 +109,7 @@ LogicalIdThunk<logical_id_kind>::Execute(const ExecuteParams& params) {
 }
 
 template <LogicalIdKind logical_id_kind>
-using BufferUses = typename LogicalIdThunk<logical_id_kind>::BufferUses;
-
-template <LogicalIdKind logical_id_kind>
-BufferUses<logical_id_kind> LogicalIdThunk<logical_id_kind>::buffer_uses()
-    const {
+Thunk::BufferUses LogicalIdThunk<logical_id_kind>::buffer_uses() const {
   return {BufferUse::Write(logical_id_buffer_)};
 }
 


### PR DESCRIPTION
I tried to build `run_hlo_module` using GCC-13
```bash
bazel build //xla/tools:run_hlo_module
```
and faced build error
```bash
xla/service/cpu/runtime/logical_id_thunk.cc:113:18: error: no declaration matches 'xla::cpu::BufferUses<type> xla::cpu::LogicalIdThunk<type>::buffer_uses() const'
  113 | BufferUses<type> LogicalIdThunk<type>::buffer_uses() const {
      |                  ^~~~~~~~~~~~~~~~~~~~
```

This PR fixes it by using `Thunk::BufferUses` for the output type of `LogicalIdThunk<type>::buffer_uses()` impl.

`BufferUses` alias is declared in `class Thunk`

Related issue: https://github.com/openxla/xla/issues/14172
David, Pawel,  Can you review the fix? @ddunl @pparuzel