### PR TITLE
Fix symbolic_tile_analysis_test.cc build

### DIFF
--- a/xla/service/gpu/model/symbolic_tile_analysis_test.cc
+++ b/xla/service/gpu/model/symbolic_tile_analysis_test.cc
@@ -55,8 +55,8 @@ using ::testing::IsEmpty;
 using ::testing::Matcher;
 using ::testing::Not;
 using ::testing::SizeIs;
-using ::testing::status::IsOkAndHolds;
-using ::testing::status::StatusIs;
+using ::tsl::testing::IsOkAndHolds;
+using ::tsl::testing::StatusIs;
 using TilingVector = std::vector<SymbolicTileAnalysis::Tiling>;
 
 MATCHER_P3(MatchTiledHloInstructionImpl, tile_sizes, tile_strides,


### PR DESCRIPTION
This PR fixed the following build error in file `symbolic_tile_analysis_test.cc`. (used GCC-13)

```c
xla/service/gpu/model/symbolic_tile_analysis_test.cc:468:7: error: 'IsOkAndHolds' was not declared in this scope; did you mean 'tsl::testing::IsOkAndHolds'?
  468 |       IsOkAndHolds(false));
```

Benjamin, Alexander, can you have a look? @bchetioui @pifon2a 