### PR TITLE
Fix build issue in xla/hlo/utils/hlo_sharding_util_test.cc

### DIFF
--- a/xla/hlo/ir/tile_assignment.h
+++ b/xla/hlo/ir/tile_assignment.h
@@ -173,6 +173,8 @@ class TileAssignment {
       : TileAssignment(std::make_shared<const Array<int64_t>>(
             std::initializer_list<int64_t>{1}, device_id)) {}
   explicit TileAssignment(IotaTileAssignment iota) : iota_(std::move(iota)) {}
+  explicit TileAssignment(std::initializer_list<int64_t> dims)
+      : iota_(IotaTileAssignment::Create(dims)) {}
   explicit TileAssignment(absl::Span<const int64_t> dims)
       : iota_(IotaTileAssignment::Create(dims)) {}
   explicit TileAssignment(absl::Span<const int64_t> dims,

--- a/xla/hlo/utils/hlo_sharding_util_test.cc
+++ b/xla/hlo/utils/hlo_sharding_util_test.cc
@@ -376,7 +376,7 @@ TEST(HloShardingUtilTest, ReshapeToTileDimension2D) {
   for (const HloSharding& sharding : shardings) {
     EXPECT_EQ(ReshapeToTileDimension(sharding, /*dim=*/0, /*dims=*/{0, 1})
                   .tile_assignment(),
-              TileAssignment((absl::Span<const int64_t>){4, 1}));
+              TileAssignment({4, 1}));
     EXPECT_EQ(ReshapeToTileDimension(sharding, /*dim=*/1, /*dims=*/{0, 1})
                   .tile_assignment(),
               TileAssignment({1, 4}, {2, 2}, {1, 0}));
@@ -554,8 +554,7 @@ TEST(HloShardingUtilTest, GetManualSubgroupSharding_ManualOnly) {
   GroupedSharding group_sharding = GetManualSubgroupSharding(sharding);
 
   // Expect group_sharding.sharding to be {devices=[1,2]0,1}
-  EXPECT_EQ(group_sharding.sharding.tile_assignment(),
-            TileAssignment((absl::Span<const int64_t>){1, 2}));
+  EXPECT_EQ(group_sharding.sharding.tile_assignment(), TileAssignment({1, 2}));
 
   // Expect the device groups are: {0, 2} and {1, 3}
   EXPECT_THAT(group_sharding.device_groups[0],
@@ -734,8 +733,7 @@ TEST(HloShardingUtilTest, UngroupShardingWithUnsortedGroupDims) {
 }
 
 TEST(HloShardingUtilTest, DeviceGroupsDoesNotMatch) {
-  HloSharding sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   DimensionVector group_dim_sizes = {2};
 
   std::vector<std::vector<int64_t>> lhs_device_groups = {{0, 2, 4, 6},
@@ -770,8 +768,7 @@ TEST(HloShardingUtilTest, DeviceGroupsMatch) {
       group_dim_sizes, 2, lhs_sharding,
       /*subgroup_manual=*/true);
 
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   auto rhs = GroupedSharding(
       device_groups, DimensionVector(group_dims.begin(), group_dims.end()),
       group_dim_sizes, 2, rhs_sharding,
@@ -796,23 +793,20 @@ TEST(HloShardingUtilTest, IsSubShardingReplicatedTiled) {
 
 TEST(HloShardingUtilTest, IsSubShardingTiledPartialReplicated) {
   HloSharding rhs_sharding = HloSharding::Replicate();
-  HloSharding lhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding lhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_TRUE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
 }
 
 TEST(HloShardingUtilTest, IsSubShardingReplicatedTiledPartial) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   HloSharding lhs_sharding = HloSharding::Replicate();
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_FALSE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
 }
 
 TEST(HloShardingUtilTest, IsSubShardingPartialTiledTiled) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   HloSharding lhs_sharding = HloSharding::IotaTile({4, 1});
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_FALSE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
@@ -826,8 +820,7 @@ TEST(HloShardingUtilTest, IsSubShardingIncompatibleTiled) {
 }
 
 TEST(HloShardingUtilTest, IsSubShardingIncompatibleShapeTiledPartialTiled) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   HloSharding lhs_sharding = HloSharding::IotaTile({4, 1});
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_FALSE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
@@ -842,8 +835,7 @@ TEST(HloShardingUtilTest, IsSubShardingCompatibleShapeTiledPartialTiled) {
 }
 
 TEST(HloShardingUtilTest, IsSubTilingOrEqualShardingNoShortcut) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   HloSharding lhs_sharding = HloSharding::IotaTile({4});
   std::vector<int64_t> success = {1, 3, 4, 7, 8, 11, 12, 15, 16, 19, 20};
   std::vector<int64_t> fail = {2, 5, 6, 9, 10, 13, 14, 17, 18};
@@ -858,16 +850,14 @@ TEST(HloShardingUtilTest, IsSubTilingOrEqualShardingNoShortcut) {
 }
 
 TEST(HloShardingUtilTest, IsSubTilingOrEqualShardingShortcut1) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   HloSharding lhs_sharding = HloSharding::IotaTile({4});
   Shape shape = ShapeUtil::MakeShape(F32, {8});
   EXPECT_TRUE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
 }
 
 TEST(HloShardingUtilTest, IsSubTilingOrEqualShardingShortcut2) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   Array<int64_t> lhs_array({4});
   lhs_array.SetValues({1, 0, 2, 3});
   HloSharding lhs_sharding = HloSharding::Tile(lhs_array);
@@ -876,8 +866,7 @@ TEST(HloShardingUtilTest, IsSubTilingOrEqualShardingShortcut2) {
 }
 
 TEST(HloShardingUtilTest, IsSubTilingOrEqualShardingShortcut3) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(
-      TileAssignment((absl::Span<const int64_t>){2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
   HloSharding lhs_sharding = HloSharding::IotaTile({4}, {2, 2}, {1, 0});
   Shape shape = ShapeUtil::MakeShape(F32, {8});
   EXPECT_FALSE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));

--- a/xla/python/pjrt_ifrt/xla_sharding_serdes_test.cc
+++ b/xla/python/pjrt_ifrt/xla_sharding_serdes_test.cc
@@ -39,8 +39,7 @@ class XlaShardingSerDesTest : public test_util::ShardingTest {};
 
 TEST_P(XlaShardingSerDesTest, HloShardingRoundTrip) {
   auto device_list = GetDevices({0, 1});
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
   auto sharding = HloSharding::Create(device_list, MemoryKind("abc"),
                                       /*xla_hlo_sharding=*/xla_hlo_sharding);
 

--- a/xla/python/pjrt_ifrt/xla_sharding_test.cc
+++ b/xla/python/pjrt_ifrt/xla_sharding_test.cc
@@ -186,8 +186,7 @@ TEST_P(HloShardingTest, DisassembleWithReplication) {
 TEST_P(HloShardingTest, IndexDomainsWithTile) {
   auto device_list = GetDevices({0, 1});
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, MemoryKind(), xla_hlo_sharding);
 
@@ -205,8 +204,7 @@ TEST_P(HloShardingTest, IndexDomainsWithTile) {
 TEST_P(HloShardingTest, DisassembleWithTile) {
   auto device_list = GetDevices({0, 1});
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, MemoryKind(), xla_hlo_sharding);
 
@@ -225,8 +223,7 @@ TEST_P(HloShardingTest, DisassembleWithTile) {
 TEST_P(HloShardingTest, IndexDomainsWithUnevenTile) {
   auto device_list = GetDevices({0, 1});
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, MemoryKind(), xla_hlo_sharding);
 
@@ -244,8 +241,7 @@ TEST_P(HloShardingTest, IndexDomainsWithUnevenTile) {
 TEST_P(HloShardingTest, DisassembleWithUnevenTile) {
   auto device_list = GetDevices({0, 1});
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, MemoryKind(), xla_hlo_sharding);
 
@@ -403,8 +399,7 @@ TEST_P(HloShardingTest, DisassembleWithSubgroupMaximalSlowPath) {
 TEST_P(HloShardingTest, DisassembleFailsWithInvalidDeviceCount) {
   auto device_list = GetDevices({0});
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, MemoryKind(), xla_hlo_sharding);
 
@@ -418,8 +413,7 @@ TEST_P(HloShardingTest, DisassembleFailsWithInvalidDeviceCount) {
 TEST_P(HloShardingTest, DisassembleFailsWithMismatchingShapeDimsSize) {
   auto device_list = GetDevices({0, 1});
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, MemoryKind(), xla_hlo_sharding);
 
@@ -433,8 +427,7 @@ TEST_P(HloShardingTest, DisassembleFailsWithMismatchingShapeDimsSize) {
 
 TEST_P(HloShardingTest, DisassembleFailsWithDynamicShape) {
   auto device_list = GetDevices({0, 1});
-  auto xla_hlo_sharding = xla::HloSharding::Tile(
-      xla::TileAssignment((absl::Span<const int64_t>){2}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, MemoryKind(), xla_hlo_sharding);
 

--- a/xla/service/hlo_dce_test.cc
+++ b/xla/service/hlo_dce_test.cc
@@ -193,8 +193,7 @@ TEST_F(HloDceTest, ShardingCustomCallInstruction) {
       HloInstruction::CreateCustomCall(p0->shape(),
                                        /*operands=*/{add},
                                        /*custom_call_target=*/"Sharding"));
-  dangling_sharding->set_sharding(
-      HloSharding::Tile(TileAssignment((absl::Span<const int64_t>){2, 1})));
+  dangling_sharding->set_sharding(HloSharding::Tile(TileAssignment({2, 1})));
   builder.AddInstruction(HloInstruction::CreateBinary(
       p0->shape(), HloOpcode::kMultiply, add, add));
   auto module = CreateNewVerifiedModule();
@@ -219,8 +218,7 @@ TEST_F(HloDceTest, ShardingCustomCallInstructionWithDeadOperand) {
       HloInstruction::CreateCustomCall(p0->shape(),
                                        /*operands=*/{add},
                                        /*custom_call_target=*/"Sharding"));
-  dangling_sharding->set_sharding(
-      HloSharding::Tile(TileAssignment((absl::Span<const int64_t>){2, 1})));
+  dangling_sharding->set_sharding(HloSharding::Tile(TileAssignment({2, 1})));
   builder.AddInstruction(
       HloInstruction::CreateBinary(p0->shape(), HloOpcode::kMultiply, p0, p0));
   auto module = CreateNewVerifiedModule();

--- a/xla/service/hlo_sharding_test.cc
+++ b/xla/service/hlo_sharding_test.cc
@@ -205,8 +205,7 @@ TEST_F(HloShardingTest, V1V2TileEquivalence) {
 TEST_F(HloShardingTest, V1V2PartialTileEquivalence) {
   {
     HloSharding v1 = HloSharding::PartialTile(MakeArray({2, 2}, {0, 1, 2, 3}));
-    HloSharding v2 = HloSharding::PartialTile(
-        TileAssignment((absl::Span<const int64_t>){2, 2}));
+    HloSharding v2 = HloSharding::PartialTile(TileAssignment({2, 2}));
     EXPECT_EQ(v1, v2);
     EXPECT_EQ(absl::HashOf(v1), absl::HashOf(v2));
   }
@@ -232,9 +231,8 @@ TEST_F(HloShardingTest, V1V2SubgroupEquivalence) {
     HloSharding v1 =
         HloSharding::Subgroup(MakeArray({2, 2}, {0, 1, 2, 3}),
                               {OpSharding::MANUAL, OpSharding::REPLICATED});
-    HloSharding v2 =
-        HloSharding::Subgroup(TileAssignment((absl::Span<const int64_t>){2, 2}),
-                              {OpSharding::MANUAL, OpSharding::REPLICATED});
+    HloSharding v2 = HloSharding::Subgroup(
+        TileAssignment({2, 2}), {OpSharding::MANUAL, OpSharding::REPLICATED});
     EXPECT_EQ(v1, v2);
     EXPECT_EQ(absl::HashOf(v1), absl::HashOf(v2));
   }


### PR DESCRIPTION
This PR fixes the following build error in `xla/hlo/utils/hlo_sharding_util_test.cc` (used GCC-13):
```bash
xla/hlo/utils/hlo_sharding_util_test.cc:538:41: error: call of overloaded 'TileAssignment(<brace-enclosed initializer list>)' is ambiguous
  538 |   TileAssignment tile_assignment({16, 4});
```
Reed, can you look at this build fix too? @reedwm 