### PR TITLE
[XLA:GPU] Add command buffer custom call targets recording for legacy custom call registry API

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -395,6 +395,16 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
         return true;
       };
 
+  // Custom "sub-parser" lambda for xla_disable_hlo_passes.
+  auto setter_for_legacy_command_buffer_custom_call_targets =
+      [debug_options](std::string comma_separated_values) {
+        for (const auto& target : std::vector<std::string>(
+                 absl::StrSplit(comma_separated_values, ','))) {
+          debug_options->add_legacy_command_buffer_custom_call_targets(target);
+        }
+        return true;
+      };
+
   // Custom "sub-parser" lambda for xla_gpu_ptx_file.
   auto setter_for_xla_gpu_ptx_file = [debug_options](std::string value) {
     debug_options->add_xla_gpu_ptx_file(value);
@@ -1216,6 +1226,15 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       " can either be a list of command types or a list of command types with"
       " + and - as prefix, which indicate adding or removing a command type"
       " to/from the default list."));
+
+  flag_list->push_back(
+      tsl::Flag("legacy_command_buffer_custom_call_targets",
+                setter_for_legacy_command_buffer_custom_call_targets, "",
+                "Comma-separated list of custom call targets with legacy "
+                "registry API (non FFI API), whose targets supports lowering "
+                "to command buffer custom command, i.e, custom call target "
+                "supports cuda-graph capturing for CUDA devices."));
+
   flag_list->push_back(tsl::Flag(
       "xla_gpu_graph_min_graph_size",
       int32_setter_for(&DebugOptions::set_xla_gpu_graph_min_graph_size),

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -395,7 +395,7 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
         return true;
       };
 
-  // Custom "sub-parser" lambda for xla_disable_hlo_passes.
+  // Custom "sub-parser" lambda for legacy_command_buffer_custom_call_targets.
   auto setter_for_legacy_command_buffer_custom_call_targets =
       [debug_options](std::string comma_separated_values) {
         for (const auto& target : std::vector<std::string>(

--- a/xla/service/gpu/command_buffer_scheduling.cc
+++ b/xla/service/gpu/command_buffer_scheduling.cc
@@ -136,6 +136,13 @@ static bool IsCommand(const HloCustomCallInstruction* hlo,
     return false;
   }
 
+  if (config.enabled_legacy_custom_call_targets.contains(
+          hlo->custom_call_target())) {
+    VLOG(3) << "Recording legacy custom call target "
+            << hlo->custom_call_target() << " into command buffer.";
+    return true;
+  }
+
   // A special case for jax-triton kernel while it is not ported to FFI.
   if (hlo->custom_call_target() == "triton_kernel_call" &&
       // TODO(b/327718087): This is an ugly hack to prevent capturing triton
@@ -692,7 +699,16 @@ absl::StatusOr<bool> CommandBufferScheduling::Run(
   for (auto cmd_type : debug_options.xla_gpu_enable_command_buffer()) {
     commands.insert(static_cast<DebugOptions::CommandBufferCmdType>(cmd_type));
   }
-  CommandBufferConfig config{std::move(commands), device_description_};
+
+  absl::flat_hash_set<std::string> legacy_custom_call_targets;
+  for (auto target :
+       debug_options.legacy_command_buffer_custom_call_targets()) {
+    legacy_custom_call_targets.insert(target);
+  }
+
+  CommandBufferConfig config{std::move(commands),
+                             std::move(legacy_custom_call_targets),
+                             device_description_};
 
   // Erase command buffer cmd types that are not supported by the gpu runtime.
   static constexpr auto kRequireConditionals = {DebugOptions::CONDITIONALS};

--- a/xla/service/gpu/command_buffer_scheduling.h
+++ b/xla/service/gpu/command_buffer_scheduling.h
@@ -73,6 +73,7 @@ class CommandBufferScheduling : public HloModulePass {
     // DebugOptions control which commands are enabled. Long term we want to
     // remove that flag and enable all supported commands by default.
     absl::flat_hash_set<DebugOptions::CommandBufferCmdType> enabled_commands;
+    absl::flat_hash_set<std::string> enabled_legacy_custom_call_targets;
     const se::DeviceDescription& device_description;
   };
 

--- a/xla/service/gpu/command_buffer_scheduling_test.cc
+++ b/xla/service/gpu/command_buffer_scheduling_test.cc
@@ -52,6 +52,7 @@ class CommandBufferSchedulingTest : public HloTestBase {
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::COLLECTIVES);
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CUDNN);
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CUBLASLT);
+    debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CUSTOM_CALL);
     debug_options.set_xla_gpu_graph_min_graph_size(2);
     return debug_options;
   }
@@ -503,8 +504,8 @@ TEST_F(CommandBufferSchedulingTest, CollectCommandBufferSequence) {
   }
   EXPECT_EQ(seq.size(), 10);
 
-  CommandBufferScheduling::CommandBufferConfig config{{DebugOptions::FUSION},
-                                                      device_desc()};
+  CommandBufferScheduling::CommandBufferConfig config{
+      {DebugOptions::FUSION}, {}, device_desc()};
 
   std::vector<HloInstructionSequence> command_buffer_sequences =
       CommandBufferScheduling::CollectCommandBufferSequences(seq, config);

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -497,8 +497,8 @@ message DebugOptions {
 
   // Commands are categorized into 5 types:
   // FUSION represents regular fusion kernels.
-  // CUBLAS/CUBLASLT, CUDNN, COLLECTIVES, and TE(Transformer Engine) 
-  // represent library calls. CONDITIONALS represents control flow.
+  // CUBLAS/CUBLASLT, CUDNN, and COLLECTIVES represent library calls.
+  // CONDITIONALS represents control flow.
   enum CommandBufferCmdType {
     INVALID = 0;
     FUSION = 1;
@@ -840,7 +840,7 @@ message DebugOptions {
   bool xla_gpu_temp_buffer_use_separate_color = 312;
 
   // Custom call targets with legacy registry API (non FFI API), 
-  // that support lowering to command buffer custom command, 
+  // that support recording to command buffer custom command, 
   // i.e, custom call target supports cuda-graph capturing for CUDA devices.
   // This flag is read if CUSTOM_CALL command type is recorded into 
   // command buffer.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -497,8 +497,8 @@ message DebugOptions {
 
   // Commands are categorized into 5 types:
   // FUSION represents regular fusion kernels.
-  // CUBLAS/CUBLASLT, CUDNN, and COLLECTIVES represent library calls.
-  // CONDITIONALS represents control flow.
+  // CUBLAS/CUBLASLT, CUDNN, COLLECTIVES, and TE(Transformer Engine) 
+  // represent library calls. CONDITIONALS represents control flow.
   enum CommandBufferCmdType {
     INVALID = 0;
     FUSION = 1;
@@ -839,7 +839,14 @@ message DebugOptions {
   // which is good for cuda-graph perf.
   bool xla_gpu_temp_buffer_use_separate_color = 312;
 
-  // Next id: 314
+  // Custom call targets with legacy registry API (non FFI API), 
+  // that support lowering to command buffer custom command, 
+  // i.e, custom call target supports cuda-graph capturing for CUDA devices.
+  // This flag is read if CUSTOM_CALL command type is recorded into 
+  // command buffer.
+  repeated string legacy_command_buffer_custom_call_targets = 314;
+
+  // Next id: 315
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR enabling lowering TE custom call kernels to command buffer through white list, this is a temporal support as 3rd library call should register command buffer support through FFI API, will remove this temporal support when TE has finished FFI API migration. 