### PR TITLE
[ROCm] Fix gpu_kernel_tiling_test

### DIFF
--- a/xla/service/gpu/tests/gpu_codegen_test.cc
+++ b/xla/service/gpu/tests/gpu_codegen_test.cc
@@ -71,7 +71,7 @@ std::string GpuCodegenTest::MakePlatformSpecificLlvm(absl::string_view input) {
         is_built_with_rocm_ ? "amdgpu_kernel void" : "void"},
        {"BARRIER",
         is_built_with_rocm_ ? "@llvm.amdgcn.s.barrier" : "@llvm.nvvm.barrier0"},
-       {"SHUFFLE", is_built_with_rocm_ ? "i32 @llvm.amdgcn.ds.bpermute"
+       {"SHUFFLE", is_built_with_rocm_ ? "i32 @llvm.amdgcn.ds.swizzle"
                                        : "float @llvm.nvvm.shfl.sync.down.f32"},
        {"TIDX", is_built_with_rocm_ ? "@llvm.amdgcn.workitem.id.x"
                                     : "@llvm.nvvm.read.ptx.sreg.tid.x"},


### PR DESCRIPTION
Swizzle support was added recently: https://github.com/openxla/xla/pull/13340, which caused some of the subtests to fail