### PR TITLE
Fix //xla/service/gpu:ir_emitter_triton_mem_utils_test in OSS

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -705,7 +705,7 @@ cc_library(
     ],
 )
 
-cc_test(
+xla_cc_test(
     name = "ir_emitter_triton_mem_utils_test",
     srcs = if_cuda_is_configured(["ir_emitter_triton_mem_utils_test.cc"]),
     deps = [

--- a/xla/service/gpu/ir_emitter_triton_mem_utils_test.cc
+++ b/xla/service/gpu/ir_emitter_triton_mem_utils_test.cc
@@ -43,10 +43,10 @@ limitations under the License.
 #include "xla/service/llvm_ir/llvm_util.h"
 #include "xla/shape_util.h"
 #include "xla/tests/hlo_test_base.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
 #include "tsl/lib/core/status_test_util.h"
 #include "tsl/platform/logging.h"  // IWYU pragma: keep
-#include "third_party/triton/include/triton/Dialect/Triton/IR/Dialect.h"
-#include "third_party/triton/include/triton/Dialect/Triton/IR/Types.h"
 
 namespace xla::gpu::ir_emitter_triton_internal {
 namespace {


### PR DESCRIPTION
Currently the test fails with:

xla/service/gpu/ir_emitter_triton_mem_utils_test.cc:48:10: fatal error: 'third_party/triton/include/triton/Dialect/Triton/IR/Dialect.h' file not found
   48 | #include "third_party/triton/include/triton/Dialect/Triton/IR/Dialect.h"

Also, using `cc_test` instead of `xla_cc_test` results in linker errors