### PR TITLE
[NVIDIA GPU] Annotate syntactic sugar op name in nsys profile

### DIFF
--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2323,9 +2323,11 @@ absl::Status IrEmitterUnnested::EmitNcclThunk(
   }
 
   if (should_use_nccl_thunk) {
+    auto thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(inst);
+    // when op is wrapped by syntactic sugar, use the wrapper name
+    thunk_info.profile_annotation = async_start->name();
     auto thunk = std::make_unique<NcclThunkType>(
-        Thunk::ThunkInfo::WithProfileAnnotation(inst), NcclApi::Default(), inst,
-        /*buffers=*/std::move(buffers));
+        thunk_info, NcclApi::Default(), inst, /*buffers=*/std::move(buffers));
     GetCollectivesAsyncEvents().insert({async_start, thunk->async_events()});
     AddThunkToThunkSequence(std::move(thunk));
     return absl::OkStatus();

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2324,7 +2324,7 @@ absl::Status IrEmitterUnnested::EmitNcclThunk(
 
   if (should_use_nccl_thunk) {
     auto thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(inst);
-    // when op is wrapped by syntactic sugar, use the wrapper name
+    // The wrapper name is used when an op is wrapped by syntactic sugar.
     thunk_info.profile_annotation = async_start->name();
     auto thunk = std::make_unique<NcclThunkType>(
         thunk_info, NcclApi::Default(), inst, /*buffers=*/std::move(buffers));


### PR DESCRIPTION
**Problem:** Currently in HLO dumping the syntactic sugar for async ops are turned on by default, while in nsys profile the op names are the actual op names, which is causing inefficiency when trying to correspond them.

**Solution:** Annotate syntactic sugar op name in nsys profile.