### PR TITLE
Fix //xla/service/gpu:triton_support_test in OSS

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1285,7 +1285,7 @@ xla_cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:protobuf",
-        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:status_matchers",
     ],
 )
 

--- a/xla/service/gpu/triton_support_test.cc
+++ b/xla/service/gpu/triton_support_test.cc
@@ -39,14 +39,14 @@ limitations under the License.
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/protobuf.h"
-#include "tsl/platform/statusor.h"
+#include "tsl/platform/status_matchers.h"
 
 namespace xla {
 namespace gpu {
 namespace {
 
 using ::testing::Not;
-using ::testing::status::IsOk;
+using ::tsl::testing::IsOk;
 
 std::vector<xla::PrimitiveType> AllXlaDataTypes() {
   std::vector<xla::PrimitiveType> xla_data_types;


### PR DESCRIPTION
Currently the test fails with:

xla/service/gpu/triton_support_test.cc:49:18: error: no member named 'status' in namespace 'testing'                                                                                                                
   49 | using ::testing::status::IsOk;                                                                                                                                                                              
