### PR TITLE
Fix //xla/service/gpu:autotuner_util_test in OSS

### DIFF
--- a/xla/service/gpu/autotuner_util_test.cc
+++ b/xla/service/gpu/autotuner_util_test.cc
@@ -258,7 +258,7 @@ TEST_F(AutotunerUtilTest, OkIfJitAutotuningDisabledButAlreadyLoadedAOT) {
 
 class FileBasedCacheTest : public AutotunerUtilTest {
  public:
-  static std::string ToString(const proto2::Message& message) {
+  static std::string ToString(const AutotuneResult& message) {
     std::string textproto;
     CHECK(tsl::protobuf::TextFormat::PrintToString(message, &textproto));
     return textproto;


### PR DESCRIPTION
Currently the test fails with:

external/com_google_googletest/googletest/include/gtest/gtest-message.h:103:3: note: candidate constructor not viable: no known conversion from 'const AutotuneResult' to 'const Message &' for 1st argument        
  103 |   Message(const Message& msg) : ss_(new ::std::stringstream) {  // NOLINT                                                                                                                                   
