### PR TITLE
Fix build failure for //xla/service/gpu:gpu_latency_hiding_scheduler_test in OSS

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -6319,8 +6319,8 @@ cc_library(
     ],
 )
 
-cc_test(
+xla_cc_test(
     name = "gpu_latency_hiding_scheduler_test",
     srcs = ["gpu_latency_hiding_scheduler_test.cc"],
-    deps = ["@com_google_googletest//:gtest_main"],
+    deps = ["//xla/tests:xla_internal_test_main"],
 )


### PR DESCRIPTION
Currently fails with:

ERROR: /home/skozub/xla/xla/service/gpu/BUILD:6322:8: Linking xla/service/gpu/gpu_latency_hiding_scheduler_test failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing command (from
 target //xla/service/gpu:gpu_latency_hiding_scheduler_test) external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc @bazel-out/k8-opt/bin/xla/service/gpu/gpu_latency_hiding_scheduler_test
-2.params                                                                                                                                                                                                              
ld.lld: error: undefined reference due to --no-allow-shlib-undefined: nextafter                                                                                                                                        
>>> referenced by bazel-out/k8-opt/bin/_solib_local/libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so                                                                                                                  
clang: error: linker command failed with exit code 1 (use -v to see invocation)                            

BTW, why do we even have empty test files?