### PR TITLE
Fix build failure for //xla/service/gpu/kernels:cutlass_gemm_custom_kernel_benchmarks in OSS

### DIFF
--- a/xla/service/gpu/kernels/BUILD
+++ b/xla/service/gpu/kernels/BUILD
@@ -5,6 +5,7 @@ load(
     "if_cuda_is_configured",
     "if_cuda_newer_than",
 )
+load("//xla:xla.bzl", "xla_cc_binary")
 load("//xla/service/gpu:build_defs.bzl", "gpu_kernel_library")
 load("//xla/stream_executor:build_defs.bzl", "if_gpu_is_configured")
 load("//xla/tests:build_defs.bzl", "xla_test")
@@ -291,7 +292,7 @@ xla_test(
     ],
 )
 
-cc_binary(
+xla_cc_binary(
     name = "cutlass_gemm_custom_kernel_benchmarks",
     testonly = 1,
     srcs = if_cuda_is_configured(["cutlass_gemm_custom_kernel_benchmarks.cc"]),


### PR DESCRIPTION
Currently the build fails with:

ERROR: /home/skozub/xla/xla/service/gpu/kernels/BUILD:294:10: Linking xla/service/gpu/kernels/cutlass_gemm_custom_kernel_benchmarks failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error exe
cuting command (from target //xla/service/gpu/kernels:cutlass_gemm_custom_kernel_benchmarks) external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc @bazel-out/k8-opt/bin/xla/service/gpu/k
ernels/cutlass_gemm_custom_kernel_benchmarks-2.params                                                                                                                                                                  
ld.lld: error: undefined symbol: xla::AutotuneResult::AutotuneResult(google::protobuf::Arena*, bool)                                                                                                                   
