### PR TITLE
[GPU] Improve compiled kernel caching with new SplitModule mode.

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -55,9 +55,9 @@ limitations under the License.
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/SplitModule.h"
-#include "mlir/IR/Diagnostics.h"  // from @llvm-project
+#include "mlir/IR/Diagnostics.h"      // from @llvm-project
 #include "mlir/IR/DialectRegistry.h"  // from @llvm-project
-#include "mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/Support/LLVM.h"        // from @llvm-project
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
@@ -1909,7 +1909,7 @@ absl::StatusOr<GpuCompiler::BackendCompileResult> GpuCompiler::CompileAndLink(
         }
         llvm_modules.push_back({name, std::move(module)});
       },
-      /*PreserveLocals=*/true);
+      /*PreserveLocals=*/true, /*RoundRobin=*/true);
   VLOG(2) << "Single-function cacheable modules: "
           << single_function_module_count << " / " << llvm_modules.size();
 

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -642,6 +642,20 @@ TEST_F(KernelCacheTest, CacheGrowsWithNewKernels) {
   EXPECT_EQ(CacheEntryCount(), 2);
 }
 
+TEST_F(KernelCacheTest, AllKernelsAreCachedBecauseSplitModuleUsesRoundRobin) {
+  EXPECT_FALSE(CacheFileExists());
+  EXPECT_TRUE(Run(R"(
+  ENTRY e {
+    p = s8[] parameter(0)
+    n = s8[] negate(p)
+    a = s8[] add(n, n)
+    s = s8[] subtract(p, a)
+    ROOT _ = s8[] multiply(s, p)
+  })",
+                  /*run_hlo_passes=*/false));
+  EXPECT_EQ(CacheEntryCount(), 4);
+}
+
 class KernelCacheTestSingleThreaded : public KernelCacheTest {
  public:
   DebugOptions GetDebugOptionsForTest() override {


### PR DESCRIPTION
The new RoundRobin mode distributes functions to modules more evenly, therefore there are more single-function cacheable modules. Without this the example in the added test would have only 2 kernels cached.

This needs https://github.com/llvm/llvm-project/commit/c02e8f762a410e55581866c43636efcd6504c1bd to get integrated before it can be submitted.
