### PR TITLE
[XLA:CPU][oneDNN] Enable F16 convolutions on supported CPU platforms

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -7746,6 +7746,7 @@ cc_library(
         ":hlo_creation_utils",
         ":hlo_pass",
         "//xla/service/cpu:onednn_matmul_rewriter",
+        "//xla/service/cpu:onednn_convolution_rewriter",
     ],
 )
 

--- a/xla/service/change_op_data_type.cc
+++ b/xla/service/change_op_data_type.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "xla/service/hlo_creation_utils.h"
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 #include "xla/service/cpu/onednn_matmul_rewriter.h"
+#include "xla/service/cpu/onednn_convolution_rewriter.h"
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 
 namespace xla {
@@ -65,6 +66,10 @@ absl::StatusOr<bool> ChangeOpDataType::Run(
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
       if (instr->opcode() == HloOpcode::kDot &&
           cpu::OneDnnMatMulRewriter::ShouldRewrite(instr)) {
+        continue;
+      }
+      if (instr->opcode() == HloOpcode::kConvolution &&
+          cpu::OneDnnConvolutionRewriter::ShouldRewrite(instr)) {
         continue;
       }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/xla/tests/onednn_convolution_test.cc
+++ b/xla/tests/onednn_convolution_test.cc
@@ -81,6 +81,23 @@ TEST_F(ConvolutionTest, Simple3DTestBF16) {
   MatchOptimizedHlo(convolution_module_str, conv_rewrite_str_);
 }
 
+TEST_F(ConvolutionTest, Simple2DTestF16) {
+  if (!IsSupportedType(PrimitiveType::F16)) {
+    GTEST_SKIP() << "CPU does not support F16.";
+  }
+
+  const char* convolution_module_str = R"(
+  HloModule convolution.test.f16
+  ENTRY convolution.test.bf16 {
+    p0 = f16[8,4,5,5,1] parameter(0)
+    p1 = f16[3,3,3,1,32] parameter(1)
+    ROOT conv = f16[8,4,5,5,32] convolution(p0, p1), window={size=3x3x3 pad=1_1x1_1x1_1}, dim_labels=b012f_012io->b012f
+})";
+
+  EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(convolution_module_str, conv_rewrite_str_);
+}
+
 }  // namespace cpu
 }  // namespace xla
 


### PR DESCRIPTION
This PR enables F16 convolutions on supported Intel CPUs.