### PR TITLE
[XLA:GPU] use empty cuda-graph node as command buffer barrier node for CUDA_VERSION >= 12040

### DIFF
--- a/xla/service/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd_test.cc
@@ -231,6 +231,8 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
 }
 
 TEST(CommandBufferCmdTest, BarrierCmd) {
+  // This test covers both CUDA version < 12040 (use empty kernel node as
+  // barrier node) and >=12040 (use cuda graph empty node as barrier node).
   se::StreamExecutor* executor = GpuExecutor();
 
   auto stream = executor->CreateStream().value();

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -168,6 +168,7 @@ gpu_only_cc_library(
         "@tsl//tsl/platform:status",
         "@tsl//tsl/platform:statusor",
     ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
         "//xla/stream_executor/cuda:cuda_conditional_kernels",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:hip_conditional_kernels",

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -25,6 +25,9 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#endif
 #include "absl/container/inlined_vector.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"


### PR DESCRIPTION
tested that cuda_12.4 have fixed the cuda graph issue that empty node can not be in conditioanl operator's sub-graph.