### PR TITLE
Fix while loop parsing in in protobuf format

### DIFF
--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -1184,6 +1184,8 @@ absl::StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
         TF_RET_CHECK(proto.called_computation_ids_size() == 2)
             << "While should have 2 called computation but has "
             << proto.called_computation_ids_size();
+        computation_map.at(proto.called_computation_ids(0))
+            ->SetWhileCallInstruction(instruction.get());
       }
 
       for (const int64_t operand_id : proto.operand_ids()) {

--- a/xla/service/hlo_parser_test.cc
+++ b/xla/service/hlo_parser_test.cc
@@ -2541,6 +2541,14 @@ class HloParameterizedParserTest
           original,
           module->ToString(HloPrintOptions().set_print_large_constants(true)));
     }
+    for (HloComputation* computation : module->computations()) {
+      for (HloInstruction* instr : computation->instructions()) {
+        if (instr->opcode() == HloOpcode::kWhile) {
+          EXPECT_EQ(instr->while_body()->WhileCallInstruction(), instr);
+          EXPECT_TRUE(instr->while_body()->IsWhileBodyComputation());
+        }
+      }
+    }
   }
 };
 


### PR DESCRIPTION
While loop computations were not being linked to the while operation. This patch fixes that and connects them.