### PR TITLE
Allow to build multihost_hlo_runner for CPU backend

### DIFF
--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -31,7 +31,7 @@ cc_library(
     compatible_with = None,
     tags = [
         "nomac",
-    ] + tf_gpu_tests_tags(),
+    ],
     deps = [
         ":create_client",
         ":functional_hlo_runner",
@@ -73,7 +73,7 @@ xla_cc_binary(
     testonly = True,
     tags = [
         "nomac",
-    ] + tf_gpu_tests_tags(),
+    ],
     deps = [
         ":hlo_runner_main_lib",
     ],


### PR DESCRIPTION
Currently, Bazel skips building `multihost_hlo_runner:hlo_runner_main` on CPU because the target is tagged with `tf_gpu_tests_tags`.

This tag should only be applied to the dedicated `hlo_runner_main_gpu` target.

The regular `hlo_runner_main` works fine on CPU (when `--xla_force_host_platform_device_count=N` is used)

@bchetioui @ddunl @beckerhe Can you have a look?