### PR TITLE
IsNonNegative(constant(-0.0)) should be false

### DIFF
--- a/xla/service/algebraic_simplifier.cc
+++ b/xla/service/algebraic_simplifier.cc
@@ -534,7 +534,8 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
     }
     case HloOpcode::kConstant: {
       if (std::optional<double> value = GetConstantValue(hlo)) {
-        return *value >= 0.0;
+        // return false for -0.0, -Inf, NaNs and negative values
+        return !std::signbit(*value) && !std::isnan(*value);
       }
       return false;
     }

--- a/xla/service/algebraic_simplifier_test.cc
+++ b/xla/service/algebraic_simplifier_test.cc
@@ -85,7 +85,8 @@ const char* non_neg_ops[] = {"abs(p0)",
                              "select(pred0, a0, a1)",
                              "select(pred0, a1, a0)"};
 
-const char* arb_sing_ops[] = {"constant(-0.1)",
+const char* arb_sign_ops[] = {"constant(-0.0)",
+                              "constant(-0.1)",
                               "constant(-inf)",
                               "constant(nan)",
                               "cosine(p0)",
@@ -126,7 +127,7 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op) {
 
 // Test that the result of particular oprations might be negative
 TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op_NegativeTestCase) {
-  for (const auto op : arb_sing_ops) {
+  for (const auto op : arb_sign_ops) {
     const auto kModuleStr = absl::StrFormat(R"(
       HloModule m
       test {
@@ -171,7 +172,7 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegative_Broadcast) {
 // Test that the result of Broadcast might be negative if its oprand is
 // not non-negative
 TEST_F(AlgebraicSimplifierTest, IsNonNegative_Broadcast_NegativeTestCase) {
-  for (const auto op : arb_sing_ops) {
+  for (const auto op : arb_sign_ops) {
     const auto kModuleStr = absl::StrFormat(R"(
       HloModule m
       test {


### PR DESCRIPTION
Currently `AlgebraicSimplifierVisitor::IsNonNegative` returns true for `Constant(-0.0)`.

Why it is a problem.

Particular optimization patterns should only be applied when IsNonNegative is true.
e.g.
```
y = sqrt(x) * sqrt(x)
can be simplified to 
y = x , when x >=0
```
```
if x is -0.0 the results are different:
sqrt(-0.0) = -0.0 =>
y = sqrt(-0.0) * sqrt(-0.0) = 0.0

After simplification - different result
y = x = -0.0

if later we have smth like 1/y - the results will be completely different +inf and -inf
```

Another example
```
y = power(x, 0.5) can be simplified to y = sqrt(x)
but
power(-0.0, 0.5) = 0.0
sqrt(-0.0) = -0.0
```
Results are different too.

in C++ `0.0` is equal to `-0.0`.
Simple check for non-negativity `x >= 0.0` returns True for `-0.0`

To distinguish between `-0.0` and `0.0` we can use `std::signbit`.

Adrian, what you think? @akuegel 