### PR TITLE
Fix deps for //xla/service/gpu/model:gpu_indexing_performance_model_test in OSS

### DIFF
--- a/xla/service/gpu/model/BUILD
+++ b/xla/service/gpu/model/BUILD
@@ -552,6 +552,7 @@ xla_cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@llvm-project//mlir:IR",
+        "@tsl//tsl/platform:status_matchers",
         "@tsl//tsl/platform:test",
     ],
 )

--- a/xla/service/gpu/model/gpu_indexing_performance_model_test.cc
+++ b/xla/service/gpu/model/gpu_indexing_performance_model_test.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "xla/shape_util.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/tests/hlo_test_base.h"
+#include "tsl/platform/status_matchers.h"
 #include "tsl/platform/statusor.h"
 
 namespace xla {
@@ -46,7 +47,7 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
-using ::testing::status::StatusIs;
+using ::tsl::testing::StatusIs;
 
 class GpuIndexingPerformanceModelTest : public HloTestBase {
   GpuHloCostAnalysis::ShapeSizeFunction ShapeSizeBytesFunction() const {


### PR DESCRIPTION
Currently fails with:
xla/service/gpu/model/gpu_indexing_performance_model_test.cc:49:18: error: no member named 'status' in namespace 'testing'                                                                                          
   49 | using ::testing::status::StatusIs;                                                                                                                                                                          
