### PR TITLE
[XLA:GPU][AutoSharding] Replace hashmap with btree map to determine the iteration order

### DIFF
--- a/xla/hlo/experimental/auto_sharding/auto_sharding_solver_test.cc
+++ b/xla/hlo/experimental/auto_sharding/auto_sharding_solver_test.cc
@@ -846,6 +846,20 @@ TEST(ScaleRequest, SkipsScaling) {
   EXPECT_THAT(request, ::testing::EqualsProto(expected_request));
 }
 
+TEST(StableHashMap, IterationOrderDeterminism){
+    StableHashMap<int, int> map;
+    std::vector<int> insertion_order = {6, 3, 1, 2, 4, 5, 10, 0, 7, 9, 8};
+    for (int key : insertion_order){
+        map[key] = key;
+    }
+
+    std::vector<int> iteration_order;
+    for (const auto& [key, value] : map){
+        iteration_order.push_back(key);   
+    }
+    EXPECT_THAT(iteration_order, ::testing::ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+}
+
 TEST(ValidateRequest, AcceptsAutoShardingSolverRequest) {
   CHECK_OK(ValidateRequest(DefaultAutoShardingSolverRequest()));
 }

--- a/xla/hlo/experimental/auto_sharding/auto_sharding_strategy.h
+++ b/xla/hlo/experimental/auto_sharding/auto_sharding_strategy.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include "xla/service/hlo_value.h"
 #include "xla/shape_util.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_set.h"
 
 namespace xla {
@@ -42,7 +43,7 @@ constexpr double kInfinityCost = 1e20;
 
 // Type alias
 template <typename Key, typename Value>
-using StableHashMap = ::absl::flat_hash_map<Key, Value>;
+using StableHashMap = ::absl::btree_map<Key, Value>;
 template <typename Key>
 using StableHashSet = ::absl::flat_hash_set<Key>;
 


### PR DESCRIPTION
This PR addresses one of the problems mentioned in #7248, regarding the non-deterministic iteration order of `StableHashMap`.

To resolve this, this PR proposes the following changes:

- Replaced `::absl::flat_hash_map` with `::absl::btree_map` within the `StableHashMap` implementation.
- Added new tests to validate the deterministic iteration order of the `StableHashMap`.
