### PR TITLE
Skip TritonGemmTest.TestPreventMMAV3LoopUnrolling on non-Hopper devices

### DIFF
--- a/xla/service/gpu/ir_emitter_triton_test.cc
+++ b/xla/service/gpu/ir_emitter_triton_test.cc
@@ -5607,8 +5607,8 @@ CHECK:          }
 // Test PreventMmaV3LoopUnrolling pass in order to keep compile time low.
 // See b/344841434.
 TEST_F(TritonGemmTest, TestPreventMMAV3LoopUnrolling) {
-  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
-    GTEST_SKIP() << "There are no wgmma instructions pre-Hopper";
+  if (GetCudaComputeCapability().major != se::CudaComputeCapability::HOPPER) {
+    GTEST_SKIP() << "wgmma instruction is only available on Hopper";
   }
   const std::string hlo_text = R"(
 gemm_fusion_dot {


### PR DESCRIPTION
"wgmma" PTX instruction is only available on "sm_90a" target, so will work only on Hopper.
https://docs.nvidia.com/cuda/parallel-thread-execution/#ptx-module-directives-target