### PR TITLE
[ROCm] Fixed gcc build errors

### DIFF
--- a/xla/service/cpu/runtime/thunk_executor.cc
+++ b/xla/service/cpu/runtime/thunk_executor.cc
@@ -292,7 +292,7 @@ void ThunkExecutor::Execute(ExecuteState* state,
   }
 }
 
-void ABSL_ATTRIBUTE_ALWAYS_INLINE ThunkExecutor::SplitReadyQueue(
+inline ABSL_ATTRIBUTE_ALWAYS_INLINE void ThunkExecutor::SplitReadyQueue(
     ExecuteState* state, const Thunk::ExecuteParams& params,
     int64_t start_index, ReadyQueue& ready_queue) {
   DCHECK(state->runner) << "TaskRunner must be set";

--- a/xla/tests/array_elementwise_ops_test.cc
+++ b/xla/tests/array_elementwise_ops_test.cc
@@ -788,8 +788,7 @@ XLA_TEST_F(ArrayElementwiseOpTest, MulTwoConstantF64s) {
   static_assert(kScaledMax * kScaleFactor == kMax);
   constexpr float kUlpOfScaledMax = GoldbergUlp(kScaledMax);
   constexpr float kNextAfterScaledMax = kScaledMax + kUlpOfScaledMax;
-  static_assert(kNextAfterScaledMax * kScaleFactor ==
-                std::numeric_limits<float>::infinity());
+  static_assert(kNextAfterScaledMax * static_cast<double>(kScaleFactor) > std::numeric_limits<float>::max());
   static_assert(kNextAfterScaledMax * 2 <
                 std::numeric_limits<float>::infinity());
   XlaBuilder builder(TestName());


### PR DESCRIPTION
Declared `ThunkExecutor::SplitReadyQueue` inline. 
Also changed the test introduced here https://github.com/openxla/xla/commit/114cab2b5f76df86ba325a8537ddd0f279f6e088 in order to avoid UB.