### PR TITLE
Terminate on NCCL error by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -270,7 +270,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   opts.set_xla_gpu_enable_host_memory_offloading(false);
 
-  opts.set_xla_gpu_nccl_terminate_on_error(false);
+  opts.set_xla_gpu_nccl_terminate_on_error(true);
 
   opts.set_xla_use_shardonnay(false);
 


### PR DESCRIPTION
Turns the xla_gpu_nccl_terminate_on_error flag on by default.

Since XLA currently hangs on error, this should be strictly better with one caveat: W NCCL error, this exits with LOG(FATAL). On systems with coredumps on, this can take quite a bit of disk space.