### PR TITLE
Add replicated testing utility functions to hlo_test_base

### DIFF
--- a/xla/tests/hlo_test_base.cc
+++ b/xla/tests/hlo_test_base.cc
@@ -325,6 +325,48 @@ Literal HloTestBase::ExecuteAndTransfer(std::unique_ptr<HloModule> module,
   return runner_->Execute(std::move(module), arguments, true, nullptr).value();
 }
 
+std::vector<int> HloTestBase::CompareInputs(const HloModule& module_0,
+                                            const HloModule& module_1) {
+  const auto params_0 = module_0.entry_computation()->parameter_instructions();
+  const auto params_1 = module_1.entry_computation()->parameter_instructions();
+  std::vector<int> mismatches;
+  int64_t min = std::min(params_0.size(), params_1.size());
+  int64_t max = std::max(params_0.size(), params_1.size());
+  for (int64_t i = 0; i < min; ++i) {
+    const HloModuleConfig& module_config_0 = module_0.config();
+    const Shape& param_shape_0 =
+        (module_config_0.has_entry_computation_layout() &&
+         module_config_0.entry_computation_layout()
+             .parameter_layout(i)
+             .shape()
+             .is_static())
+            ? module_config_0.entry_computation_layout()
+                  .parameter_layout(i)
+                  .shape()
+            : params_0[i]->shape();
+
+    const HloModuleConfig& module_config_1 = module_1.config();
+    const Shape& param_shape_1 =
+        (module_config_1.has_entry_computation_layout() &&
+         module_config_1.entry_computation_layout()
+             .parameter_layout(i)
+             .shape()
+             .is_static())
+            ? module_config_1.entry_computation_layout()
+                  .parameter_layout(i)
+                  .shape()
+            : params_1[i]->shape();
+
+    if (!Shape::Equal().IgnoreTilesInLayout()(param_shape_0, param_shape_1)) {
+      mismatches.push_back(i);
+    }
+  }
+  for (int64_t i = min; i < max; i++) {
+    mismatches.push_back(i);
+  }
+  return mismatches;
+}
+
 absl::StatusOr<std::vector<Literal>> HloTestBase::ExecuteReplicated(
     std::unique_ptr<HloModule> module, absl::Span<Literal* const> arguments,
     int64_t num_replicas, bool use_threads, bool run_hlo_passes) {
@@ -501,6 +543,120 @@ absl::StatusOr<::testing::AssertionResult> HloTestBase::RunAndCompareInternal(
 }
 
 absl::StatusOr<::testing::AssertionResult>
+HloTestBase::RunAndCompareTwoModulesInternalReplicated(
+    std::unique_ptr<HloModule> module_0, std::unique_ptr<HloModule> module_1,
+    HloRunner::ReplicatedExecuteOptions options,
+    const std::optional<ErrorSpec>& error) {
+  TF_RETURN_IF_ERROR(hlo_verifier_->Run(module_0.get()).status());
+  TF_RETURN_IF_ERROR(hlo_verifier_->Run(module_1.get()).status());
+
+  // Execute the two modules.
+  TF_ASSIGN_OR_RETURN(auto test_0,
+                      runner_->ExecuteReplicated(std::move(module_0), options));
+  TF_ASSIGN_OR_RETURN(auto test_1,
+                      runner_->ExecuteReplicated(std::move(module_1), options));
+
+  for (auto [expected, actual] : llvm::zip_equal(test_0, test_1)) {
+    auto compare_result = LiteralTestUtil::NearOrEqual(expected, actual, error);
+    if (!compare_result) {
+      return compare_result;
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult HloTestBase::RunAndCompareTwoModulesReplicated(
+    std::unique_ptr<HloModule> module_0, std::unique_ptr<HloModule> module_1,
+    HloRunner::ReplicatedExecuteOptions options,
+    const optional<ErrorSpec>& error) {
+  int replica_count = module_0->config().replica_count();
+  if (replica_count != module_1->config().replica_count()) {
+    return ::testing::AssertionFailure()
+           << "Number of replicas is not the same: " << replica_count << " Vs "
+           << module_1->config().replica_count();
+  }
+  if (options.num_replicas != replica_count) {
+    return ::testing::AssertionFailure()
+           << "Number of execution replicas is different from number of "
+              "replicas in the module: requested number of replicas = "
+           << options.num_replicas
+           << ", number of replicas in hlo = " << replica_count;
+  }
+
+  std::vector<int> mismatches = CompareInputs(*module_0, *module_1);
+  if (!mismatches.empty()) {
+    return ::testing::AssertionFailure()
+           << "Error: parameter mismatch at indices: "
+           << absl::StrJoin(mismatches, ",");
+  }
+  auto num_args = module_0->entry_computation()->num_parameters();
+  if (num_args != options.arguments.size()) {
+    return ::testing::AssertionFailure()
+           << "Mismatch in number of arguments passed while running replicated "
+              "hlo module. Expected: "
+           << num_args << ", actual: " << options.arguments.size();
+  }
+  auto result = RunAndCompareTwoModulesInternalReplicated(
+      std::move(module_0), std::move(module_1), options, error);
+  if (!result.ok()) {
+    return ::testing::AssertionFailure() << result.status();
+  }
+  return result.value();
+}
+
+::testing::AssertionResult HloTestBase::RunAndCompareTwoModulesReplicated(
+    std::unique_ptr<HloModule> module_0, std::unique_ptr<HloModule> module_1,
+    bool run_hlo_passes, bool use_threads,
+    const std::optional<ErrorSpec>& error) {
+  absl::StatusOr<std::vector<Literal>> fake_arguments = MakeFakeArguments(
+      /*module=*/module_0.get(), /*pseudo_random=*/true,
+      /*use_large_range=*/false,
+      /*treat_gte_as_data_formatting=*/false,
+      /*max_bits_of_precision=*/std::nullopt);
+  CHECK_OK(fake_arguments);
+  std::vector<const Literal*> fake_argument_ptrs;
+  absl::c_transform(
+      /*input=*/*fake_arguments,
+      /*output=*/std::back_inserter(fake_argument_ptrs),
+      /*unary_op=*/[](const Literal& literal) -> Literal* {
+        return const_cast<Literal*>(&literal);
+      });
+  HloRunner::ReplicatedExecuteOptions options{
+      /*num_replicas=*/ module_0->config().replica_count(),
+      /*arguments=*/ fake_argument_ptrs,
+      /*infeed_values=*/ {},
+      /*infeed_steps=*/ -1,
+      /*outfeed_shape=*/ {},
+      /*outfeed_values=*/ nullptr,
+      /*run_hlo_passes=*/ run_hlo_passes,
+      /*use_threads=*/ use_threads};
+  return RunAndCompareTwoModulesReplicated(std::move(module_0),
+                                           std::move(module_1), options, error);
+}
+
+::testing::AssertionResult HloTestBase::RunAndCompareTwoModulesReplicated(
+    absl::string_view module_0, absl::string_view module_1, bool run_hlo_passes,
+    bool use_threads, const std::optional<ErrorSpec>& error) {
+  auto module_0_or_status = ParseAndReturnVerifiedModule(module_0);
+  if (!module_0_or_status.ok()) {
+    return ::testing::AssertionFailure()
+           << "Error while parsing HLO text format: "
+           << module_0_or_status.status().ToString();
+  }
+
+  auto module_1_or_status = ParseAndReturnVerifiedModule(module_1);
+  if (!module_1_or_status.ok()) {
+    return ::testing::AssertionFailure()
+           << "Error while parsing HLO text format: "
+           << module_1_or_status.status().ToString();
+  }
+  return RunAndCompareTwoModulesReplicated(
+      std::move(module_0_or_status).value(),
+      std::move(module_1_or_status).value(), run_hlo_passes, use_threads,
+      error);
+}
+
+absl::StatusOr<::testing::AssertionResult>
 HloTestBase::RunAndCompareTwoModulesInternal(
     std::unique_ptr<HloModule> module_0, std::unique_ptr<HloModule> module_1,
     const absl::Span<Literal* const> arguments,
@@ -535,39 +691,11 @@ HloTestBase::RunAndCompareTwoModulesInternal(
     std::unique_ptr<HloModule> module_0, std::unique_ptr<HloModule> module_1,
     const optional<ErrorSpec>& error, bool run_hlo_passes,
     std::optional<int64_t> args_max_bits_of_precision) {
-  const auto params_0 = module_0->entry_computation()->parameter_instructions();
-  const auto params_1 = module_1->entry_computation()->parameter_instructions();
-  for (int i = 0; i < params_0.size(); ++i) {
-    const HloModuleConfig& module_config_0 = module_0->config();
-    const Shape& param_shape_0 =
-        (module_config_0.has_entry_computation_layout() &&
-         module_config_0.entry_computation_layout()
-             .parameter_layout(i)
-             .shape()
-             .is_static())
-            ? module_config_0.entry_computation_layout()
-                  .parameter_layout(i)
-                  .shape()
-            : params_0[i]->shape();
-
-    const HloModuleConfig& module_config_1 = module_1->config();
-    const Shape& param_shape_1 =
-        (module_config_1.has_entry_computation_layout() &&
-         module_config_1.entry_computation_layout()
-             .parameter_layout(i)
-             .shape()
-             .is_static())
-            ? module_config_1.entry_computation_layout()
-                  .parameter_layout(i)
-                  .shape()
-            : params_1[i]->shape();
-
-    if (!Shape::Equal().IgnoreTilesInLayout()(param_shape_0, param_shape_1)) {
-      return ::testing::AssertionFailure()
-             << "Error : mismatching parameter shapes: "
-             << param_shape_0.ToString(true) << " Vs. "
-             << param_shape_1.ToString(true);
-    }
+  std::vector<int> mismatches = CompareInputs(*module_0, *module_1);
+  if (!mismatches.empty()) {
+    return ::testing::AssertionFailure()
+           << "Error : mismatching parameter shapes for parameters "
+           << absl::StrJoin(mismatches, ", ");
   }
 
   absl::StatusOr<std::vector<Literal>> fake_arguments = MakeFakeArguments(


### PR DESCRIPTION
This patch adds the functions `RunAndCompareTwoModulesReplicated` and `CompareInputs` to `HloTestBase`. These functions can now be used in testing replicated HLO modules.