### PR TITLE
[NVIDIA GPU] Flatten call graph after collective pipeliner pass

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -869,6 +869,8 @@ absl::Status RunPostLayoutCollectivePipelinerPasses(HloModule* hlo_module) {
     // We call WhileLoopTripCountAnnotator at the end of the collective
     // pipeline, which might have changed the loop trip count.
     collectives_pipeline.AddPass<WhileLoopTripCountAnnotator>();
+    // Flatten call graph after loop peeling.
+    collectives_pipeline.AddPass<FlattenCallGraph>();
   }
   return collectives_pipeline.Run(hlo_module).status();
 }

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -981,5 +981,98 @@ ENTRY entry {
   EXPECT_THAT(gemm_op, NotNull());
   EXPECT_EQ(gemm_op->custom_call_target(), "__cublas$lt$matmul$f8");
 }
+
+TEST_F(CollectiveOpsTestE2E, PostLayoutCollectivePipelinerShouldFlattenCallGraph) {
+// The allgather in the loop has a nested while loop as its operand,
+// when the pipelining happens, the nested while loop will be peeled outside.
+// However, when a while is cloned, its callsites are still preserved which will
+// error out in alias analysis. When the graph is flattened, the error should not
+// happen.
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule module
+
+while_cond {
+  param = (s32[], f32[2,128], f32[8,128], f32[8,128]) parameter(0)
+  gte = s32[] get-tuple-element(param), index=0
+  constant.1 = s32[] constant(3)
+  ROOT cmp = pred[] compare(gte, constant.1), direction=LT
+}
+
+while_nested_cond {
+  param.nested = (s32[], f32[2,128]) parameter(0)
+  gte.nested = s32[] get-tuple-element(param.nested), index=0
+  constant.nested = s32[] constant(3)
+  ROOT cmp.nested = pred[] compare(gte.nested, constant.nested), direction=LT
+}
+while_nested_body {
+  param.body_nested = (s32[], f32[2,128]) parameter(0)
+  gte.body_nested = s32[] get-tuple-element(param.body_nested), index=0
+  gte.2.body_nested = f32[2,128] get-tuple-element(param.body_nested), index=1
+
+  constant.body_nested = s32[] constant(1)
+  add.body_nested = s32[] add(gte.body_nested, constant.body_nested)
+  rsqrt.body_nested = f32[2,128] rsqrt(gte.2.body_nested)
+  ROOT tuple.body_nested = (s32[], f32[2,128]) tuple(add.body_nested, rsqrt.body_nested)
+}
+
+while_body {
+  param = (s32[], f32[2,128], f32[8,128], f32[8,128]) parameter(0)
+  get-tuple-element.394 = s32[] get-tuple-element(param), index=0
+  get-tuple-element.395 = f32[2,128] get-tuple-element(param), index=1
+  get-tuple-element.35 = f32[8,128] get-tuple-element(param), index=2
+  get-tuple-element.36 = f32[8,128] get-tuple-element(param), index=3
+
+  constant.2557 = s32[] constant(1)
+  add.230 = s32[] add(get-tuple-element.394, constant.2557)
+  mul = f32[2,128] multiply(get-tuple-element.395, get-tuple-element.395)
+  constant.while = s32[] constant(0)
+  tuple.1 = (s32[], f32[2,128]) tuple(constant.while, mul)
+  while.1 = (s32[], f32[2,128]) while(tuple.1), condition=while_nested_cond, body=while_nested_body
+  gte.while = f32[2,128] get-tuple-element(while.1), index=1
+  add.while = f32[2,128] add(gte.while, get-tuple-element.395)
+
+  ag.1 = f32[8,128] all-gather(add.while), replica_groups={}, dimensions={0}
+  add.ag = f32[8,128] add(ag.1, get-tuple-element.36)
+
+  ROOT tuple = (s32[], f32[2,128], f32[8,128], f32[8,128]) tuple(add.230, get-tuple-element.395, get-tuple-element.35, ag.1)
+}
+
+ENTRY entry {
+  c0 = s32[] constant(0)
+  p0 = f32[2,128] parameter(0)
+  p1 = f32[8,128] parameter(1)
+
+  tuple = (s32[], f32[2,128], f32[8,128], f32[8,128]) tuple(c0, p0, p1, p1)
+  while = (s32[], f32[2,128], f32[8,128], f32[8,128]) while(tuple), condition=while_cond, body=while_body
+  gte1 = f32[2,128] get-tuple-element(while), index=1
+  gte2 = f32[8,128] get-tuple-element(while), index=3
+  ROOT tuple.result = (f32[2,128], f32[8,128]) tuple(gte1, gte2)
+}
+)";
+
+  const int64_t kNumReplicas = 1;
+  const int64_t kNumPartitions = 4;
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  auto opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_run_post_layout_collective_pipeliner(true);
+  opts.set_xla_gpu_enable_pipelined_all_reduce(true);
+  opts.set_xla_gpu_enable_pipelined_all_gather(true);
+  opts.set_xla_gpu_enable_pipelined_reduce_scatter(true);
+
+  opts.set_xla_gpu_enable_triton_gemm(false);
+  config.set_debug_options(opts);
+  config.set_use_spmd_partitioning(false);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleReplicatedStr, config));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable,
+                          CreateExecutable(std::move(module),
+                                           /*run_hlo_passes=*/true));
+  EXPECT_TRUE(executable->has_module());
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
After moving the collective pipeliner pass after post layout optimization passes, we need to call flatten call graph after pipeliners have run so call sites are unique. We didnt need to do this before because layout assignment(which is after previous location of collective pipeline) runs flattenCallGraph.