### PR TITLE
[Nvidia GPU] Add mechanism to detect nccl timeout and return error status

### DIFF
--- a/xla/python/pjit.cc
+++ b/xla/python/pjit.cc
@@ -46,11 +46,11 @@ limitations under the License.
 #include "absl/synchronization/notification.h"
 #include "absl/types/span.h"
 #include "nanobind/nanobind.h"
-#include "nanobind/stl/optional.h"  // IWYU pragma: keep
-#include "nanobind/stl/shared_ptr.h"  // IWYU pragma: keep
-#include "nanobind/stl/string.h"  // IWYU pragma: keep
+#include "nanobind/stl/optional.h"     // IWYU pragma: keep
+#include "nanobind/stl/shared_ptr.h"   // IWYU pragma: keep
+#include "nanobind/stl/string.h"       // IWYU pragma: keep
 #include "nanobind/stl/string_view.h"  // IWYU pragma: keep
-#include "nanobind/stl/vector.h"  // IWYU pragma: keep
+#include "nanobind/stl/vector.h"       // IWYU pragma: keep
 #include "xla/layout.h"
 #include "xla/pjrt/exceptions.h"
 #include "xla/pjrt/lru_cache.h"

--- a/xla/python/pjit.cc
+++ b/xla/python/pjit.cc
@@ -952,7 +952,11 @@ PyObject* PjitFunction_tp_vectorcall(PyObject* callable, PyObject* const* args,
     absl::StatusOr<nb::object> out =
         o->fun.Call(callable, args, nargs, kwnames);
     if (!out.ok()) {
-      PyErr_SetString(PyExc_ValueError, out.status().ToString().c_str());
+      if(out.status().code() == absl::StatusCode::kDeadlineExceeded) {
+        PyErr_SetString(PyExc_TimeoutError, out.status().ToString().c_str());
+      } else {
+        PyErr_SetString(PyExc_ValueError, out.status().ToString().c_str());
+      }
       return nullptr;
     }
     return out.value().release().ptr();

--- a/xla/python/pjit.cc
+++ b/xla/python/pjit.cc
@@ -46,9 +46,9 @@ limitations under the License.
 #include "absl/synchronization/notification.h"
 #include "absl/types/span.h"
 #include "nanobind/nanobind.h"
-#include "nanobind/stl/optional.h"  // IWYU pragma: keep
-#include "nanobind/stl/shared_ptr.h"  // IWYU pragma: keep
-#include "nanobind/stl/string.h"  // IWYU pragma: keep
+#include "nanobind/stl/optional.h"     // IWYU pragma: keep
+#include "nanobind/stl/shared_ptr.h"   // IWYU pragma: keep
+#include "nanobind/stl/string.h"       // IWYU pragma: keep
 #include "nanobind/stl/string_view.h"  // IWYU pragma: keep
 #include "nanobind/stl/vector.h"  // IWYU pragma: keep
 #include "xla/layout.h"
@@ -952,7 +952,7 @@ PyObject* PjitFunction_tp_vectorcall(PyObject* callable, PyObject* const* args,
     absl::StatusOr<nb::object> out =
         o->fun.Call(callable, args, nargs, kwnames);
     if (!out.ok()) {
-      if(out.status().code() == absl::StatusCode::kDeadlineExceeded) {
+      if (out.status().code() == absl::StatusCode::kDeadlineExceeded) {
         PyErr_SetString(PyExc_TimeoutError, out.status().ToString().c_str());
       } else {
         PyErr_SetString(PyExc_ValueError, out.status().ToString().c_str());
@@ -1184,24 +1184,24 @@ void BuildPjitSubmodule(nb::module_& m) {
       absl::StrCat(nb::cast<std::string>(m.attr("__name__")), ".PjitFunction");
   PyType_Spec PjitFunction_spec = {
 #if PY_VERSION_HEX < 0x030B0000
-      // Work around for https://github.com/python/cpython/issues/89478
-      // CPython 3.10 and earlier assume that the .name value remains alive
-      // forever.
-      /*.name=*/strdup(name.c_str()),
+    // Work around for https://github.com/python/cpython/issues/89478
+    // CPython 3.10 and earlier assume that the .name value remains alive
+    // forever.
+    /*.name=*/strdup(name.c_str()),
 #else
-      /*.name=*/name.c_str(),
+    /*.name=*/name.c_str(),
 #endif  // PY_VERSION_HEX < 0x030B0000
-      /*.basicsize=*/static_cast<int>(sizeof(PjitFunctionObject)),
-      /*.itemsize=*/0,
+    /*.basicsize=*/static_cast<int>(sizeof(PjitFunctionObject)),
+    /*.itemsize=*/0,
 #if PY_VERSION_HEX < 0x030C0000
-      /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-          Py_TPFLAGS_HAVE_VECTORCALL,
+    /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_HAVE_VECTORCALL,
 #else   // PY_VERSION_HEX < 0x030C0000
-      /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-          Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_MANAGED_DICT |
-          Py_TPFLAGS_MANAGED_WEAKREF,
+    /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_MANAGED_DICT |
+        Py_TPFLAGS_MANAGED_WEAKREF,
 #endif  // PY_VERSION_HEX < 0x030C0000
-      /*.slots=*/PjitFunction_slots,
+    /*.slots=*/PjitFunction_slots,
   };
   PjitFunction_Type = PyType_FromSpec(&PjitFunction_spec);
   if (!PjitFunction_Type) {

--- a/xla/python/pjit.cc
+++ b/xla/python/pjit.cc
@@ -46,9 +46,9 @@ limitations under the License.
 #include "absl/synchronization/notification.h"
 #include "absl/types/span.h"
 #include "nanobind/nanobind.h"
-#include "nanobind/stl/optional.h"     // IWYU pragma: keep
-#include "nanobind/stl/shared_ptr.h"   // IWYU pragma: keep
-#include "nanobind/stl/string.h"       // IWYU pragma: keep
+#include "nanobind/stl/optional.h"  // IWYU pragma: keep
+#include "nanobind/stl/shared_ptr.h"  // IWYU pragma: keep
+#include "nanobind/stl/string.h"  // IWYU pragma: keep
 #include "nanobind/stl/string_view.h"  // IWYU pragma: keep
 #include "nanobind/stl/vector.h"  // IWYU pragma: keep
 #include "xla/layout.h"
@@ -952,10 +952,11 @@ PyObject* PjitFunction_tp_vectorcall(PyObject* callable, PyObject* const* args,
     absl::StatusOr<nb::object> out =
         o->fun.Call(callable, args, nargs, kwnames);
     if (!out.ok()) {
+      const char* error_string = out.status().ToString().c_str();
       if (out.status().code() == absl::StatusCode::kDeadlineExceeded) {
-        PyErr_SetString(PyExc_TimeoutError, out.status().ToString().c_str());
+        PyErr_SetString(PyExc_TimeoutError, error_string);
       } else {
-        PyErr_SetString(PyExc_ValueError, out.status().ToString().c_str());
+        PyErr_SetString(PyExc_ValueError, error_string);
       }
       return nullptr;
     }

--- a/xla/python/pjit.cc
+++ b/xla/python/pjit.cc
@@ -46,11 +46,11 @@ limitations under the License.
 #include "absl/synchronization/notification.h"
 #include "absl/types/span.h"
 #include "nanobind/nanobind.h"
-#include "nanobind/stl/optional.h"     // IWYU pragma: keep
-#include "nanobind/stl/shared_ptr.h"   // IWYU pragma: keep
-#include "nanobind/stl/string.h"       // IWYU pragma: keep
+#include "nanobind/stl/optional.h"  // IWYU pragma: keep
+#include "nanobind/stl/shared_ptr.h"  // IWYU pragma: keep
+#include "nanobind/stl/string.h"  // IWYU pragma: keep
 #include "nanobind/stl/string_view.h"  // IWYU pragma: keep
-#include "nanobind/stl/vector.h"       // IWYU pragma: keep
+#include "nanobind/stl/vector.h"  // IWYU pragma: keep
 #include "xla/layout.h"
 #include "xla/pjrt/exceptions.h"
 #include "xla/pjrt/lru_cache.h"
@@ -1185,24 +1185,24 @@ void BuildPjitSubmodule(nb::module_& m) {
       absl::StrCat(nb::cast<std::string>(m.attr("__name__")), ".PjitFunction");
   PyType_Spec PjitFunction_spec = {
 #if PY_VERSION_HEX < 0x030B0000
-    // Work around for https://github.com/python/cpython/issues/89478
-    // CPython 3.10 and earlier assume that the .name value remains alive
-    // forever.
-    /*.name=*/strdup(name.c_str()),
+      // Work around for https://github.com/python/cpython/issues/89478
+      // CPython 3.10 and earlier assume that the .name value remains alive
+      // forever.
+      /*.name=*/strdup(name.c_str()),
 #else
-    /*.name=*/name.c_str(),
+      /*.name=*/name.c_str(),
 #endif  // PY_VERSION_HEX < 0x030B0000
-    /*.basicsize=*/static_cast<int>(sizeof(PjitFunctionObject)),
-    /*.itemsize=*/0,
+      /*.basicsize=*/static_cast<int>(sizeof(PjitFunctionObject)),
+      /*.itemsize=*/0,
 #if PY_VERSION_HEX < 0x030C0000
-    /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_HAVE_VECTORCALL,
+      /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+          Py_TPFLAGS_HAVE_VECTORCALL,
 #else   // PY_VERSION_HEX < 0x030C0000
-    /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_MANAGED_DICT |
-        Py_TPFLAGS_MANAGED_WEAKREF,
+      /*.flags=*/Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+          Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_MANAGED_DICT |
+          Py_TPFLAGS_MANAGED_WEAKREF,
 #endif  // PY_VERSION_HEX < 0x030C0000
-    /*.slots=*/PjitFunction_slots,
+      /*.slots=*/PjitFunction_slots,
   };
   PjitFunction_Type = PyType_FromSpec(&PjitFunction_spec);
   if (!PjitFunction_Type) {

--- a/xla/python/pjit.cc
+++ b/xla/python/pjit.cc
@@ -952,7 +952,8 @@ PyObject* PjitFunction_tp_vectorcall(PyObject* callable, PyObject* const* args,
     absl::StatusOr<nb::object> out =
         o->fun.Call(callable, args, nargs, kwnames);
     if (!out.ok()) {
-      const char* error_string = out.status().ToString().c_str();
+      std::string status_str = out.status().ToString();
+      const char* error_string = status_str.c_str();
       if (out.status().code() == absl::StatusCode::kDeadlineExceeded) {
         PyErr_SetString(PyExc_TimeoutError, error_string);
       } else {

--- a/xla/service/executable.cc
+++ b/xla/service/executable.cc
@@ -82,8 +82,8 @@ absl::StatusOr<ScopedShapedBuffer> Executable::ExecuteOnStream(
     HloExecutionProfile* hlo_execution_profile) {
   absl::StatusOr<ScopedShapedBuffer> result =
       ExecuteAsyncOnStream(run_options, arguments, hlo_execution_profile);
-  absl::Status blocking_status = run_options->stream()->BlockHostUntilDone();
   TF_RETURN_IF_ERROR(result.status());
+  absl::Status blocking_status = run_options->stream()->BlockHostUntilDone();
   TF_RETURN_IF_ERROR(blocking_status);
   return result;
 }
@@ -119,8 +119,8 @@ absl::StatusOr<ExecutionOutput> Executable::ExecuteOnStream(
     HloExecutionProfile* hlo_execution_profile) {
   absl::StatusOr<ExecutionOutput> result = ExecuteAsyncOnStream(
       run_options, std::move(arguments), hlo_execution_profile);
-  absl::Status blocking_status = run_options->stream()->BlockHostUntilDone();
   TF_RETURN_IF_ERROR(result.status());
+  absl::Status blocking_status = run_options->stream()->BlockHostUntilDone();
   TF_RETURN_IF_ERROR(blocking_status);
   return result;
 }

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -596,11 +596,8 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor/cuda:cuda_platform_id",
-<<<<<<< HEAD
-=======
         "//xla/stream_executor/gpu:gpu_executor_header",
         "//xla/stream_executor/gpu:gpu_stream",
->>>>>>> 4a72ac01ce (Added missing include in bazel rule)
         "//xla/stream_executor/rocm:rocm_platform_id",
         "//xla/stream_executor/sycl:sycl_platform_id",
         "@com_google_absl//absl/algorithm:container",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -596,6 +596,11 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor/cuda:cuda_platform_id",
+<<<<<<< HEAD
+=======
+        "//xla/stream_executor/gpu:gpu_executor_header",
+        "//xla/stream_executor/gpu:gpu_stream",
+>>>>>>> 4a72ac01ce (Added missing include in bazel rule)
         "//xla/stream_executor/rocm:rocm_platform_id",
         "//xla/stream_executor/sycl:sycl_platform_id",
         "@com_google_absl//absl/algorithm:container",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -599,6 +599,9 @@ absl::Status MaybeSyncAndProfile(const ServiceExecutableRunOptions* run_options,
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     while (!se::gpu::AsGpuStream(stream_to_sync)->IsIdle()) {
       if (!async_status.ok()) {
+        // NCCL error has occurred, allow some time for NCCL
+        // to completely tear down before exiting the executable.
+        absl::SleepFor(absl::Seconds(15));
         return async_status;
       }
     }

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -596,11 +596,13 @@ absl::Status MaybeSyncAndProfile(const ServiceExecutableRunOptions* run_options,
   // TODO(b/30100571): we could potentially postpone deallocating the temp
   // buffers until a different computation is executed.
   if (stream_to_sync) {
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     while (!se::gpu::AsGpuStream(stream_to_sync)->IsIdle()) {
       if (!async_status.ok()) {
         return async_status;
       }
     }
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     absl::Status block_status = stream_to_sync->BlockHostUntilDone();
     if (!block_status.ok()) {
       return Internal(

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -239,6 +239,17 @@ class GpuExecutable : public Executable {
 
   xla::Shape output_shape_;
 
+  // This indicates the status of all async operations
+  // associated with this executable instance.
+  // The status will be set to failure status the first time
+  // an async error or timeout has occurred.
+  absl::Status async_status_ = absl::OkStatus();
+
+  // This queue captures all async events created by this executable.
+  // Any thunk that records an async event will push the se::Event to
+  // this queue. The statuses of events are monitored in a separate thread.
+  std::vector<std::unique_ptr<se::Event>> async_events_queue_;
+
   // The allocations_ object contains allocations that **may** be used to
   // provide information for allocating memory for every output/temp buffer.
   // See the comment on GetAllocations().

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -243,7 +243,7 @@ class GpuExecutable : public Executable {
   // associated with this executable instance.
   // The status will be set to failure status the first time
   // an async error or timeout has occurred.
-  absl::Status async_status_ = absl::OkStatus();
+  AsyncStatus async_status_ = {absl::OkStatus(), false};
 
   // This queue captures all async events created by this executable.
   // Any thunk that records an async event will push the se::Event to

--- a/xla/service/gpu/runtime/nccl_clique.h
+++ b/xla/service/gpu/runtime/nccl_clique.h
@@ -87,7 +87,7 @@ class NcclCliqueCommunicators {
  public:
   class AsyncErrorChecker {
    public:
-    absl::Status Check();
+    absl::Status Check(const absl::Status& current_executable_status);
 
    private:
     friend class NcclCliqueCommunicators;
@@ -158,7 +158,7 @@ class NcclClique : public Lockable<NcclCliqueCommunicators, NcclCliqueName> {
   // Checks for async errors for all the communicators in the clique without
   // taking the lock. If at least one of the communicators has an async error,
   // it returns one of the errors.
-  absl::Status CheckAsyncErrors();
+  absl::Status CheckAsyncErrors(const absl::Status& current_status);
 
  private:
   NcclCliqueCommunicators::AsyncErrorChecker async_error_checker_;

--- a/xla/service/gpu/runtime/nccl_clique.h
+++ b/xla/service/gpu/runtime/nccl_clique.h
@@ -37,6 +37,13 @@ limitations under the License.
 
 namespace xla::gpu {
 
+inline constexpr absl::string_view kNcclAsyncErrorPrefix = "Nccl Async Error";
+
+inline constexpr absl::string_view kNcclAsyncTimeout = "Async event timeout";
+
+inline constexpr absl::string_view kAsyncEventInvalidStatus =
+    "Unexpected async event status";
+
 // NCCL clique (collective clique) is a set of devices that execute collective
 // operations (e.g. all-reduce). It is notoriously easy to misuse NCCL
 // communicators (see link below) and get a dead lock at run time, so in XLA we
@@ -169,7 +176,8 @@ absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
     const NcclCliqueIdCallback& clique_id_callback, int32_t rank,
     size_t num_local_participants,
     const NcclClique::AcquiredCliquesMap& acquired_cliques,
-    int64_t max_nchannels = 0);
+    const std::vector<se::Event*> async_events_queue,
+    absl::Status& async_status, int64_t max_nchannels = 0);
 
 }  // namespace xla::gpu
 

--- a/xla/service/gpu/runtime/nccl_clique.h
+++ b/xla/service/gpu/runtime/nccl_clique.h
@@ -37,7 +37,7 @@ limitations under the License.
 
 namespace xla::gpu {
 
-inline constexpr absl::string_view kNcclAsyncErrorPrefix = "Nccl Async Error";
+inline constexpr absl::string_view kNcclAsyncErrorPrefix = "Nccl async error";
 
 inline constexpr absl::string_view kNcclAsyncTimeout = "Async event timeout";
 

--- a/xla/service/gpu/runtime/nccl_clique.h
+++ b/xla/service/gpu/runtime/nccl_clique.h
@@ -176,7 +176,7 @@ absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
     const NcclCliqueIdCallback& clique_id_callback, int32_t rank,
     size_t num_local_participants,
     const NcclClique::AcquiredCliquesMap& acquired_cliques,
-    const std::vector<se::Event*> async_events_queue,
+    const std::vector<std::unique_ptr<se::Event>>& async_events_queue,
     absl::Status& async_status, int64_t max_nchannels = 0);
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/runtime/nccl_clique.h
+++ b/xla/service/gpu/runtime/nccl_clique.h
@@ -76,6 +76,19 @@ absl::StatusOr<const NcclCliqueIdCallback*> GetNcclCliqueIdCallback(
     bool is_local);
 
 //===----------------------------------------------------------------------===//
+// AsyncStatus
+//===----------------------------------------------------------------------===//
+
+// A convenient wrapper of status of async events.
+struct AsyncStatus {
+  // The status of async operations
+  absl::Status async_op_status;
+
+  // The flag to indicate that all communicators have been aborted.
+  bool is_all_comms_aborted;
+};
+
+//===----------------------------------------------------------------------===//
 // NcclClique
 //===----------------------------------------------------------------------===//
 
@@ -87,7 +100,7 @@ class NcclCliqueCommunicators {
  public:
   class AsyncErrorChecker {
    public:
-    absl::Status Check(const absl::Status& current_executable_status);
+    absl::Status Check(AsyncStatus& current_executable_status);
 
    private:
     friend class NcclCliqueCommunicators;
@@ -158,7 +171,7 @@ class NcclClique : public Lockable<NcclCliqueCommunicators, NcclCliqueName> {
   // Checks for async errors for all the communicators in the clique without
   // taking the lock. If at least one of the communicators has an async error,
   // it returns one of the errors.
-  absl::Status CheckAsyncErrors(const absl::Status& current_status);
+  absl::Status CheckAsyncErrors(AsyncStatus& current_status);
 
  private:
   NcclCliqueCommunicators::AsyncErrorChecker async_error_checker_;
@@ -177,7 +190,7 @@ absl::StatusOr<std::shared_ptr<NcclClique::Lock>> AcquireNcclClique(
     size_t num_local_participants,
     const NcclClique::AcquiredCliquesMap& acquired_cliques,
     const std::vector<std::unique_ptr<se::Event>>& async_events_queue,
-    absl::Status& async_status, int64_t max_nchannels = 0);
+    AsyncStatus& async_status, int64_t max_nchannels = 0);
 
 }  // namespace xla::gpu
 

--- a/xla/service/gpu/runtime/nccl_collective_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.cc
@@ -422,9 +422,10 @@ bool operator==(const FirstCallRendezvousKey& a,
 }  // namespace
 
 absl::Status NcclCollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
-  if ((*params.collective_params->async_status) != absl::OkStatus()) {
+  if (params.collective_params->async_status->async_op_status !=
+      absl::OkStatus()) {
     LOG(ERROR) << "Async status is not ok. Returning status.";
-    return (*params.collective_params->async_status);
+    return params.collective_params->async_status->async_op_status;
   }
 
   VLOG(1) << absl::StreamFormat("Starting %s %s.", IsAsync() ? "async" : "sync",

--- a/xla/service/gpu/runtime/nccl_collective_thunk.h
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.h
@@ -149,12 +149,12 @@ class NcclCollectiveThunk : public Thunk {
     friend class NcclCollectiveThunk;
     friend class NcclCollectiveDoneThunk;
 
-    absl::Status Initialize(se::StreamExecutor* executor);
+    absl::Status Initialize(const InitializeParams& params);
     absl::StatusOr<se::Event*> GetEvent(se::StreamExecutor* executor);
 
    private:
     absl::Mutex mu_;
-    absl::flat_hash_map<se::StreamExecutor*, std::unique_ptr<se::Event>> events_
+    absl::flat_hash_map<se::StreamExecutor*, se::Event*> events_
         ABSL_GUARDED_BY(mu_);
   };
 

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -268,6 +268,10 @@ class Thunk {
     int64_t collective_max_nchannels;
     int64_t p2p_max_nchannels;
 
+    absl::Status async_status = absl::OkStatus();
+
+    std::vector<se::Event*> async_events_queue;
+
    private:
     CollectiveExecuteParams(se::StreamExecutor* executor, RunId run_id,
                             absl::Span<se::Stream* const> async_streams,

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -268,9 +268,11 @@ class Thunk {
     int64_t collective_max_nchannels;
     int64_t p2p_max_nchannels;
 
-    absl::Status async_status = absl::OkStatus();
+    // Global async status.
+    absl::Status* async_status = nullptr;
 
-    std::vector<se::Event*> async_events_queue;
+    // Global queue of async events.
+    std::vector<std::unique_ptr<se::Event>>* async_events_queue = nullptr;
 
    private:
     CollectiveExecuteParams(se::StreamExecutor* executor, RunId run_id,

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -269,7 +269,7 @@ class Thunk {
     int64_t p2p_max_nchannels;
 
     // Global async status.
-    absl::Status* async_status = nullptr;
+    AsyncStatus* async_status = nullptr;
 
     // Global queue of async events.
     std::vector<std::unique_ptr<se::Event>>* async_events_queue = nullptr;

--- a/xla/stream_executor/cuda/cuda_stream.h
+++ b/xla/stream_executor/cuda/cuda_stream.h
@@ -60,6 +60,7 @@ class CudaStream : public StreamCommon {
   absl::Status BlockHostUntilDone() override;
 
   void SetName(std::string name) override;
+  absl::StatusOr<bool> IsIdle() override;
 
   Stream::PlatformSpecificHandle platform_specific_handle() const override {
     return {stream_handle_};

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -306,6 +306,11 @@ class Stream {
         "This stream does not support EventBasedTimers.");
   }
 
+  // Checks to see if the stream is idling.
+  virtual absl::StatusOr<bool> IsIdle() {
+    return absl::UnimplementedError("Not implemented");
+  };
+
  private:
   // Helper method to launch a kernel with optional cluster dimensions.
   virtual absl::Status Launch(const ThreadDim &thread_dims,

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -1325,7 +1325,6 @@ ENTRY test_computation {
   HloModuleConfig config =
       GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
   auto opts = GetDebugOptionsForTest();
-  opts.set_xla_gpu_nccl_termination_timeout_seconds(5);
   config.set_debug_options(opts);
   config.set_num_partitions(kNumPartitions);
   TF_ASSERT_OK_AND_ASSIGN(

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -1305,8 +1305,7 @@ ENTRY test_computation {
         _xla_send_recv_pipeline="1"
       }
 
-    after-all.1 = token[] after-all()
-    recv.1 = (u32[2], u32[], token[]) recv(after-all.1), channel_id=2,
+    recv.1 = (u32[2], u32[], token[]) recv(after-all.0), channel_id=2,
       frontend_attributes={
         _xla_send_recv_source_target_pairs="{{0,1}}"
       }
@@ -1316,14 +1315,7 @@ ENTRY test_computation {
     recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=2
     recv-data.1 = u32[2] get-tuple-element(recv-done.1), index=0
 
-    replica = u32[] replica-id()
-    constant0 = u32[] constant(0)
-    compare0 = pred[] compare(replica, constant0), direction=EQ
-    compare = pred[2] broadcast(compare0), dimensions={}
-    recv-data = u32[2] select(compare, recv-data.0, recv-data.1)
-
-    r = u32[2] broadcast(replica), dimensions={}
-    ROOT s = u32[2] add(r, recv-data)
+    ROOT result = (u32[2], u32[2]) tuple(recv-data.0, recv-data.1)
 }
 )";
 

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -1295,5 +1295,68 @@ ENTRY entry {
   EXPECT_TRUE(executable->has_module());
 }
 
+TEST_F(CollectiveOpsTestE2E, NcclErrorPropagation) {
+  absl::string_view kModuleReplicatedStr = R"(
+ENTRY test_computation {
+    after-all.0 = token[] after-all()
+    recv.0 = (u32[2], u32[], token[]) recv(after-all.0), channel_id=1,
+      frontend_attributes={
+        _xla_send_recv_source_target_pairs="{{1,0}}",
+        _xla_send_recv_pipeline="1"
+      }
+
+    after-all.1 = token[] after-all()
+    recv.1 = (u32[2], u32[], token[]) recv(after-all.1), channel_id=2,
+      frontend_attributes={
+        _xla_send_recv_source_target_pairs="{{0,1}}"
+      }
+    recv-done.0 = (u32[2], token[]) recv-done(recv.0), channel_id=1
+    recv-data.0 = u32[2] get-tuple-element(recv-done.0), index=0
+
+    recv-done.1 = (u32[2], token[]) recv-done(recv.1), channel_id=2
+    recv-data.1 = u32[2] get-tuple-element(recv-done.1), index=0
+
+    replica = u32[] replica-id()
+    constant0 = u32[] constant(0)
+    compare0 = pred[] compare(replica, constant0), direction=EQ
+    compare = pred[2] broadcast(compare0), dimensions={}
+    recv-data = u32[2] select(compare, recv-data.0, recv-data.1)
+
+    r = u32[2] broadcast(replica), dimensions={}
+    ROOT s = u32[2] add(r, recv-data)
+}
+)";
+
+  const int64_t kNumReplicas = 1;
+  const int64_t kNumPartitions = 2;
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  auto opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_nccl_termination_timeout_seconds(5);
+  config.set_debug_options(opts);
+  config.set_num_partitions(kNumPartitions);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleReplicatedStr, config));
+  DeviceAssignment assn(/*replica_count=*/kNumReplicas,
+                        /*computation_count=*/kNumPartitions);
+  config.set_replica_count(kNumReplicas);
+  for (int64_t i = 0; i < kNumPartitions; ++i) {
+    assn(0, i) = i;
+  }
+
+  auto fake_arguments = xla::MakeFakeArguments(module.get()).value();
+  std::vector<Literal*> fake_ptrs(fake_arguments.size());
+  for (int i = 0; i < fake_arguments.size(); i++) {
+    fake_ptrs[i] = &fake_arguments[i];
+  }
+
+  auto result = HloTestBase::ExecuteReplicated(
+      std::move(module), fake_ptrs, kNumPartitions, &assn,
+      false /*run_hlo_passes*/, true /*use-threads*/);
+  ASSERT_FALSE(result.status().ok());
+  ASSERT_EQ(result.status().code(), absl::StatusCode::kDeadlineExceeded);
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
The current behavior crashes the program whenever a nccl async error has occured, timeout errors are also not detected for async events. This pr adds a mechanism to do:
1. poll statuses of async events and return timeout if status is pending for too long
2. return nccl async event status as xla status so a proper python exception can be thrown.