### PR TITLE
[PJRT:GPU] Propagate arg and result info from MLIR to XLA Compile method

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -157,6 +157,7 @@ xla_cc_test(
         "//xla/ffi",
         "//xla/ffi:ffi_api",
         "//xla/pjrt:host_memory_spaces",
+        "//xla/pjrt:mlir_to_hlo",
         "//xla/pjrt:pjrt_client",
         "//xla/pjrt:pjrt_executable",
         "//xla/pjrt:pjrt_future",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1283,5 +1283,63 @@ TEST(StreamExecutorGpuClientTest, MlirParameterLayoutFromOptionsIsSetInHlo) {
   EXPECT_EQ(first_param_layout, Layout({0, 2, 1}));
 }
 
+TEST(StreamExecutorGpuClientTest,
+     MlirResultHostMemorySpaceIsSetInHloWithShardingPropagation) {
+  constexpr absl::string_view mlir_mul_explicit_sharding_layout_and_memory =
+      R"mlir(
+  module @jit_f attributes {
+      mhlo.num_partitions = 4 : i32,
+      mhlo.num_replicas = 1 : i32
+  } {
+    func.func public @main(%arg0: tensor<8x2xi32> {
+            mhlo.layout_mode = "{1,0}",
+            mhlo.memory_kind = "device",
+            mhlo.sharding = "{devices=[2,2]<=[4]}"
+        }) -> (tensor<8x2xi32> {
+            jax.result_info = "",
+            mhlo.layout_mode = "{0,1}",
+            mhlo.memory_kind = "pinned_host"
+        }) {
+      %c = stablehlo.constant dense<2> : tensor<i32>
+      %0 = stablehlo.broadcast_in_dim %c, dims = []
+          : (tensor<i32>) -> tensor<8x2xi32>
+      %1 = stablehlo.multiply %arg0, %0 : tensor<8x2xi32>
+      %2 = stablehlo.custom_call @Sharding(%1) {
+              mhlo.sharding = "{devices=[2,2]<=[4]}"
+          } : (tensor<8x2xi32>) -> tensor<8x2xi32>
+      %3 = stablehlo.custom_call @annotate_device_placement(%2) {
+              has_side_effect = true,
+              mhlo.frontend_attributes = {
+                  _xla_buffer_placement = "pinned_host"
+              }
+          } : (tensor<8x2xi32>) -> tensor<8x2xi32>
+      return %3 : tensor<8x2xi32>
+    }
+  })mlir";
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, xla::ParseMlirModuleString(
+                       mlir_mul_explicit_sharding_layout_and_memory, context));
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+
+  xla::CompileOptions options;
+  options.executable_build_options.set_num_partitions(4)
+      .set_use_spmd_partitioning(true)
+      .set_allow_spmd_sharding_propagation_to_output({true});
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, options));
+  TF_ASSERT_OK_AND_ASSIGN(auto modules, executable->GetHloModules());
+
+  auto first_param_layout =
+      modules[0]->entry_computation_layout().parameter_layout(0).layout();
+  EXPECT_EQ(first_param_layout.memory_space(), Layout::kDefaultMemorySpace);
+  auto result_layout =
+      modules[0]->entry_computation_layout().result_layout().layout();
+  EXPECT_EQ(result_layout,
+            Layout({0, 1}).set_memory_space(Layout::kHostMemorySpace));
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1288,13 +1288,13 @@ TEST(StreamExecutorGpuClientTest,
   constexpr absl::string_view mlir_mul_explicit_sharding_layout_and_memory =
       R"mlir(
   module @jit_f attributes {
-      mhlo.num_partitions = 4 : i32,
+      mhlo.num_partitions = 2 : i32,
       mhlo.num_replicas = 1 : i32
   } {
     func.func public @main(%arg0: tensor<8x2xi32> {
             mhlo.layout_mode = "{1,0}",
             mhlo.memory_kind = "device",
-            mhlo.sharding = "{devices=[2,2]<=[4]}"
+            mhlo.sharding = "{devices=[1,2]<=[2]}"
         }) -> (tensor<8x2xi32> {
             jax.result_info = "",
             mhlo.layout_mode = "{0,1}",
@@ -1305,7 +1305,7 @@ TEST(StreamExecutorGpuClientTest,
           : (tensor<i32>) -> tensor<8x2xi32>
       %1 = stablehlo.multiply %arg0, %0 : tensor<8x2xi32>
       %2 = stablehlo.custom_call @Sharding(%1) {
-              mhlo.sharding = "{devices=[2,2]<=[4]}"
+              mhlo.sharding = "{devices=[1,2]<=[2]}"
           } : (tensor<8x2xi32>) -> tensor<8x2xi32>
       %3 = stablehlo.custom_call @annotate_device_placement(%2) {
               has_side_effect = true,
@@ -1325,7 +1325,7 @@ TEST(StreamExecutorGpuClientTest,
                           GetStreamExecutorGpuClient(GpuClientOptions()));
 
   xla::CompileOptions options;
-  options.executable_build_options.set_num_partitions(4)
+  options.executable_build_options.set_num_partitions(2)
       .set_use_spmd_partitioning(true)
       .set_allow_spmd_sharding_propagation_to_output({true});
 

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -43,6 +43,7 @@ limitations under the License.
 #include "xla/pjrt/distributed/in_memory_key_value_store.h"
 #include "xla/pjrt/gpu/gpu_topology.h"
 #include "xla/pjrt/host_memory_spaces.h"
+#include "xla/pjrt/mlir_to_hlo.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/pjrt/pjrt_executable.h"
 #include "xla/pjrt/pjrt_future.h"
@@ -1147,6 +1148,139 @@ TEST(StreamExecutorGpuClientTest,
   EXPECT_EQ(memory_kinds[0].size(), 2);
   EXPECT_EQ(memory_kinds[0][0], "device");
   EXPECT_EQ(memory_kinds[0][1], "pinned_host");
+}
+
+TEST(StreamExecutorGpuClientTest, MlirParameterHostMemorySpaceIsSetInHlo) {
+  constexpr char kMlirH2D[] =
+      R"(
+    func.func public @main(%arg0: tensor<8x2xi32> {
+            mhlo.layout_mode = "{1,0}",
+            mhlo.memory_kind = "pinned_host",
+            mhlo.sharding = "{devices=[2,2]<=[4]}"
+        }) -> (tensor<8x2xi32> {
+            jax.result_info = "",
+            mhlo.layout_mode = "default",
+            mhlo.memory_kind = "device",
+            mhlo.sharding = "{devices=[2,2]<=[4]}"}) {
+      %0 = stablehlo.custom_call @annotate_device_placement(%arg0) {
+              has_side_effect = true,
+              mhlo.frontend_attributes = {_xla_buffer_placement = "device"}
+          } : (tensor<8x2xi32>) -> tensor<8x2xi32>
+      return %0 : tensor<8x2xi32>
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          xla::ParseMlirModuleString(kMlirH2D, context));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, {}));
+  TF_ASSERT_OK_AND_ASSIGN(auto modules, executable->GetHloModules());
+
+  auto first_param_layout =
+      modules[0]->entry_computation_layout().parameter_layout(0).layout();
+  EXPECT_EQ(first_param_layout.memory_space(), Layout::kHostMemorySpace);
+  auto result_layout =
+      modules[0]->entry_computation_layout().result_layout().layout();
+  EXPECT_EQ(result_layout.memory_space(), Layout::kDefaultMemorySpace);
+}
+
+TEST(StreamExecutorGpuClientTest, MlirResultHostMemorySpaceIsSetInHlo) {
+  constexpr char kMlirD2H[] =
+      R"(
+    func.func public @main(%arg0: tensor<8x2xi32> {
+            mhlo.layout_mode = "{1,0}",
+            mhlo.memory_kind = "device",
+            mhlo.sharding = "{devices=[2,2]<=[4]}"
+        }) -> (tensor<8x2xi32> {
+            jax.result_info = "",
+            mhlo.layout_mode = "default",
+            mhlo.memory_kind = "pinned_host",
+            mhlo.sharding = "{devices=[2,2]<=[4]}"}) {
+      %0 = stablehlo.custom_call @annotate_device_placement(%arg0) {
+              has_side_effect = true,
+              mhlo.frontend_attributes = {_xla_buffer_placement = "pinned_host"}
+          } : (tensor<8x2xi32>) -> tensor<8x2xi32>
+      return %0 : tensor<8x2xi32>
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          xla::ParseMlirModuleString(kMlirD2H, context));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, {}));
+  TF_ASSERT_OK_AND_ASSIGN(auto modules, executable->GetHloModules());
+
+  auto first_param_layout =
+      modules[0]->entry_computation_layout().parameter_layout(0).layout();
+  EXPECT_EQ(first_param_layout.memory_space(), Layout::kDefaultMemorySpace);
+  auto result_layout =
+      modules[0]->entry_computation_layout().result_layout().layout();
+  EXPECT_EQ(result_layout.memory_space(), Layout::kHostMemorySpace);
+}
+
+TEST(StreamExecutorGpuClientTest, MlirParameterLayoutIsSetInHlo) {
+  constexpr char kMlirWithParameterLayout[] =
+      R"(
+    func.func public @main(%arg0: tensor<2x2x2xi32> {
+            mhlo.layout_mode = "{0, 2, 1}"
+        }) -> (tensor<2x2x2xi32> {
+            jax.result_info = "",
+            mhlo.layout_mode = "default"}) {
+      return %arg0 : tensor<2x2x2xi32>
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(auto module, xla::ParseMlirModuleString(
+                                           kMlirWithParameterLayout, context));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, {}));
+  TF_ASSERT_OK_AND_ASSIGN(auto modules, executable->GetHloModules());
+
+  auto first_param_layout =
+      modules[0]->entry_computation_layout().parameter_layout(0).layout();
+  EXPECT_EQ(first_param_layout, Layout({0, 2, 1}));
+}
+
+TEST(StreamExecutorGpuClientTest, MlirParameterLayoutFromOptionsIsSetInHlo) {
+  constexpr char kMlirCopy[] =
+      R"(
+    func.func public @main(%arg0: tensor<2x2x2xi32> {
+            mhlo.layout_mode = "default"
+        }) -> (tensor<2x2x2xi32> {
+            jax.result_info = "",
+            mhlo.layout_mode = "default"}) {
+      return %arg0 : tensor<2x2x2xi32>
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          xla::ParseMlirModuleString(kMlirCopy, context));
+
+  xla::CompileOptions options;
+  options.argument_layouts = {
+      {ShapeUtil::MakeShapeWithDenseLayout(S32, {2, 2, 2}, {0, 2, 1})}};
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, options));
+  TF_ASSERT_OK_AND_ASSIGN(auto modules, executable->GetHloModules());
+
+  auto first_param_layout =
+      modules[0]->entry_computation_layout().parameter_layout(0).layout();
+  EXPECT_EQ(first_param_layout, Layout({0, 2, 1}));
 }
 
 }  // namespace

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -3397,12 +3397,11 @@ PjRtStreamExecutorClient::GetExecutableExtras(CompileOptions* options) {
     build_options.set_device_allocator(allocator());
   }
 
-  auto layout_callback = [local_client = client()](const HloModule& module)
+  auto layout_callback = [&build_options,
+                          local_client = client()](const HloModule& module)
       -> absl::StatusOr<std::pair<std::vector<Shape>, Shape>> {
-    ExecutableBuildOptions build_options;
     std::vector<const Shape*> argument_layout_pointers;
     std::optional<std::vector<Shape>> argument_layouts;
-    Shape result_layout;
     TF_RETURN_IF_ERROR(DetermineArgumentLayoutsFromCompileOptions(
         XlaComputation(module.ToProto()),
         [local_client = local_client](Shape shape) {
@@ -3411,7 +3410,7 @@ PjRtStreamExecutorClient::GetExecutableExtras(CompileOptions* options) {
               ->ChooseCompactLayoutForShape(shape);
         },
         argument_layouts, &build_options, &argument_layout_pointers));
-    result_layout = *build_options.result_layout();
+    const Shape& result_layout = *build_options.result_layout();
     return std::make_pair(*argument_layouts, result_layout);
   };
 

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -3402,6 +3402,8 @@ PjRtStreamExecutorClient::GetExecutableExtras(CompileOptions* options) {
       -> absl::StatusOr<std::pair<std::vector<Shape>, Shape>> {
     std::vector<const Shape*> argument_layout_pointers;
     std::optional<std::vector<Shape>> argument_layouts;
+    ExecutableBuildOptions options = build_options;
+
     TF_RETURN_IF_ERROR(DetermineArgumentLayoutsFromCompileOptions(
         XlaComputation(module.ToProto()),
         [local_client = local_client](Shape shape) {
@@ -3410,8 +3412,7 @@ PjRtStreamExecutorClient::GetExecutableExtras(CompileOptions* options) {
               ->ChooseCompactLayoutForShape(shape);
         },
         argument_layouts, &build_options, &argument_layout_pointers));
-    const Shape& result_layout = *build_options.result_layout();
-    return std::make_pair(*argument_layouts, result_layout);
+    return std::make_pair(*argument_layouts, *options.result_layout());
   };
 
   build_options.set_layout_canonicalization_callback(layout_callback);

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -3465,6 +3465,71 @@ PjRtStreamExecutorClient::GetExecutableExtras(CompileOptions* options) {
 absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
 PjRtStreamExecutorClient::Compile(const XlaComputation& computation,
                                   CompileOptions options) {
+  std::vector<const Shape*> argument_layout_pointers;
+  TF_RETURN_IF_ERROR(DetermineArgumentLayoutsFromCompileOptions(
+      computation,
+      [local_client = client()](Shape shape) {
+        return local_client->backend()
+            .transfer_manager()
+            ->ChooseCompactLayoutForShape(shape);
+      },
+      options.argument_layouts, &options.executable_build_options,
+      &argument_layout_pointers));
+  return CompileInternal(computation, argument_layout_pointers, options);
+}
+
+absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
+PjRtStreamExecutorClient::Compile(mlir::ModuleOp module,
+                                  CompileOptions options) {
+  XlaComputation xla_computation;
+  const ExecutableBuildOptions& exec_build_options =
+      options.executable_build_options;
+  TF_RETURN_IF_ERROR(MlirToXlaComputation(
+      module, xla_computation,
+      /*use_tuple_args=*/options.parameter_is_tupled_arguments,
+      /*return_tuple=*/false,
+      exec_build_options.has_debug_options()
+          ? exec_build_options.debug_options().xla_use_shardy()
+          : false));
+
+  // If the compile options specify argument layout, then let's
+  // fall back to using the options to determine layouts.
+  if (options.argument_layouts) {
+    return Compile(xla_computation, options);
+  }
+
+  TF_ASSIGN_OR_RETURN(std::vector<LayoutMode> arg_layout_modes,
+                      GetArgLayoutModes(module));
+  TF_ASSIGN_OR_RETURN(std::vector<LayoutMode> out_layout_modes,
+                      GetOutputLayoutModes(module));
+  TF_ASSIGN_OR_RETURN(std::vector<MemorySpaceColor> arg_memory_spaces,
+                      GetArgMemoryKinds(module));
+  TF_ASSIGN_OR_RETURN(std::vector<MemorySpaceColor> out_memory_spaces,
+                      GetOutputMemoryKinds(module));
+
+  // This call will update result_layout in options.executable_build_options
+  // (in addition to returning the argument layouts).
+  TF_ASSIGN_OR_RETURN(auto arg_layouts_and_pointers,
+                      LayoutModesToXla(
+                          xla_computation, arg_layout_modes, out_layout_modes,
+                          arg_memory_spaces, out_memory_spaces,
+                          [this](Shape shape) -> absl::StatusOr<Shape> {
+                            return this->client()
+                                ->backend()
+                                .transfer_manager()
+                                ->ChooseCompactLayoutForShape(shape);
+                          },
+                          options.executable_build_options));
+
+  return CompileInternal(xla_computation, arg_layouts_and_pointers.second,
+                         options);
+}
+
+absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
+PjRtStreamExecutorClient::CompileInternal(
+    const XlaComputation& computation,
+    const std::vector<const Shape*>& argument_layout_pointers,
+    CompileOptions options) {
   tsl::profiler::TraceMe traceme("PjRtStreamExecutorClient::Compile");
   VLOG(1) << "PjRtStreamExecutorClient::Compile";
   options.executable_build_options.set_process_index(process_index());
@@ -3483,17 +3548,6 @@ PjRtStreamExecutorClient::Compile(const XlaComputation& computation,
       addressable_device_logical_ids = extras.addressable_device_logical_ids;
   std::vector<PjRtDevice*>& addressable_devices = extras.addressable_devices;
 
-  std::vector<const Shape*> argument_layout_pointers;
-  TF_RETURN_IF_ERROR(DetermineArgumentLayoutsFromCompileOptions(
-      computation,
-      [local_client = client()](Shape shape) {
-        return local_client->backend()
-            .transfer_manager()
-            ->ChooseCompactLayoutForShape(shape);
-      },
-      options.argument_layouts, &options.executable_build_options,
-      &argument_layout_pointers));
-
   TF_ASSIGN_OR_RETURN(
       std::vector<std::unique_ptr<LocalExecutable>> local_executables,
       client()->Compile(computation, argument_layout_pointers,
@@ -3508,22 +3562,6 @@ PjRtStreamExecutorClient::Compile(const XlaComputation& computation,
   TF_RETURN_IF_ERROR(
       executable->SetUpDonation(options.parameter_is_tupled_arguments));
   return std::unique_ptr<PjRtLoadedExecutable>(std::move(executable));
-}
-
-absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
-PjRtStreamExecutorClient::Compile(mlir::ModuleOp module,
-                                  CompileOptions options) {
-  XlaComputation xla_computation;
-  const ExecutableBuildOptions& exec_build_options =
-      options.executable_build_options;
-  TF_RETURN_IF_ERROR(MlirToXlaComputation(
-      module, xla_computation,
-      /*use_tuple_args=*/options.parameter_is_tupled_arguments,
-      /*return_tuple=*/false,
-      exec_build_options.has_debug_options()
-          ? exec_build_options.debug_options().xla_use_shardy()
-          : false));
-  return Compile(xla_computation, options);
 }
 
 absl::StatusOr<std::string> PjRtStreamExecutorClient::SerializeExecutable(

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -478,6 +478,11 @@ class PjRtStreamExecutorClient : public PjRtClient {
   };
   absl::StatusOr<ExecutableExtras> GetExecutableExtras(CompileOptions* options);
 
+  absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> CompileInternal(
+      const XlaComputation& computation,
+      const std::vector<const Shape*>& argument_layout_pointers,
+      CompileOptions options);
+
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> BufferFromHostBufferInternal(
       const void* data, PrimitiveType type, absl::Span<int64_t const> dims,
       std::optional<absl::Span<int64_t const>> byte_strides,

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -478,11 +478,6 @@ class PjRtStreamExecutorClient : public PjRtClient {
   };
   absl::StatusOr<ExecutableExtras> GetExecutableExtras(CompileOptions* options);
 
-  absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> CompileInternal(
-      const XlaComputation& computation,
-      const std::vector<const Shape*>& argument_layout_pointers,
-      CompileOptions options);
-
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> BufferFromHostBufferInternal(
       const void* data, PrimitiveType type, absl::Span<int64_t const> dims,
       std::optional<absl::Span<int64_t const>> byte_strides,


### PR DESCRIPTION
In MLIR flavor of the PjRtStreamExecutorClient::Compile method, we now transfer the argument layouts and result layout from MLIR code to compile options.

If compile options already specified argument layouts, we ignore layouts from MLIR.

We also make sure that the argument/result layouts are preserved when SPMD needs to canonicalize layouts after resharding parameters and/or layouts.