### PR TITLE
[ROCM][NFC] gemm_algorithm_picker/test: refactoring in preparation for precision settings integration

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1782,6 +1782,7 @@ xla_test(
         ":backend_configs_cc",
         ":gemm_algorithm_picker",
         ":gemm_rewriter",
+        ":variant_visitor",
         "//xla/hlo/ir:hlo",
         "//xla/service:pattern_matcher",
         "//xla/service:pattern_matcher_gmock",

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -345,8 +345,12 @@ class GemmAutotuner {
     absl::StatusOr<AutotuneResult> best =
         PickBestResult(results, gemm->ToString(), hlo_module_config);
     if (best.ok()) {
-      // Return a real algorithm ID if return_algo_index is false: 
-      // e.g., in case of legacy cublas tuning.
+      // Note that, cublas-lt returns an opaque object as an algorithm ID,
+      // therefore we need to convert it to the index from the list algorithms' 
+      // list (otherwise, we cannot store this ID inside a gemm_backend_config).
+      // In contrast, legacy cublas returns a 32-bit integer algorithm ID which
+      // can be readily stored inside an HLO (hence return_algo_index is false
+      // for cublas case).
       if (!return_algo_index) return best; 
       // Otherwise, map a real algorithm ID to its index among the results.
       for (size_t i = 0; i < results.size(); ++i) {

--- a/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/gemm_algorithm_picker.cc
@@ -346,8 +346,8 @@ class GemmAutotuner {
         PickBestResult(results, gemm->ToString(), hlo_module_config);
     if (best.ok()) {
       // Note that, cublas-lt returns an opaque object as an algorithm ID,
-      // therefore we need to convert it to the index from the list algorithms' 
-      // list (otherwise, we cannot store this ID inside a gemm_backend_config).
+      // therefore we need to convert it to the index from the algorithms list 
+      // (otherwise, we cannot store this ID inside a gemm_backend_config).
       // In contrast, legacy cublas returns a 32-bit integer algorithm ID which
       // can be readily stored inside an HLO (hence return_algo_index is false
       // for cublas case).


### PR DESCRIPTION
These is refactoring extracted from the original PR: https://github.com/openxla/xla/pull/13425

I have added **return_algo_index** parameter to GetBestAlgorithm function in order to avoid double conversion: algorithm -> index and then index -> algorithm. This part was quite misleading and hard to follow in the code as to why this was necessary.
The reason for this is because, cu/hipblasLt return an **opaque object** as an algorithm ID which cannot be saved within an HLO. Therefore, we needed an index of the algorithm here. In contrast, cu/hipblas return a 32-bit int algorithm ID which can readily be stoded in HLO (gemm_backend_config). 

Besides, I also simplified the respective test by unifiying some copy-paste stuff.

@xla-rotation: could you have a look please ?
