### PR TITLE
Skip emitting Triton kernel when deserializing from cache

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3577,6 +3577,7 @@ xla_cc_test(
         "//xla/service:executable",
         "//xla/service:gpu_plugin",
         "//xla/service:platform_util",
+        "//xla/service/gpu/fusions/triton:triton_support",
         "//xla/stream_executor",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",

--- a/xla/service/gpu/fusions/fusion_emitter.cc
+++ b/xla/service/gpu/fusions/fusion_emitter.cc
@@ -193,6 +193,12 @@ IndexingMap KernelFusionInterface::GetDefaultThreadIdIndexingMap(
   return indexing_map;
 }
 
+std::string GetSanitizedUniqueName(IrEmitterContext& ir_emitter_context,
+                                   const std::string& suggested_name) {
+  return ir_emitter_context.name_uniquer()->GetUniqueName(
+      llvm_ir::SanitizeFunctionName(suggested_name));
+}
+
 absl::StatusOr<std::tuple<llvm::Function*, std::vector<llvm_ir::IrArray>,
                           std::vector<llvm_ir::IrArray>>>
 BuildKernelPrototype(IrEmitterContext& ir_emitter_context,
@@ -201,6 +207,20 @@ BuildKernelPrototype(IrEmitterContext& ir_emitter_context,
                      size_t num_inputs,
                      const LaunchDimensions& launch_dimensions,
                      llvm::IRBuilder<>* builder) {
+  return BuildKernelPrototypeFromUniqueName(
+      ir_emitter_context,
+      GetSanitizedUniqueName(ir_emitter_context, suggested_name), arguments,
+      num_inputs, launch_dimensions, builder);
+}
+
+absl::StatusOr<std::tuple<llvm::Function*, std::vector<llvm_ir::IrArray>,
+                          std::vector<llvm_ir::IrArray>>>
+BuildKernelPrototypeFromUniqueName(IrEmitterContext& ir_emitter_context,
+                                   const std::string& unique_kernel_name,
+                                   absl::Span<const KernelArgument> arguments,
+                                   size_t num_inputs,
+                                   const LaunchDimensions& launch_dimensions,
+                                   llvm::IRBuilder<>* builder) {
   // If some arguments have the same buffer, we will pass them only once.
   llvm::SmallVector<int> to_llvm_arg_no(arguments.size());
   llvm::SmallVector<int> to_arg_no;
@@ -217,11 +237,6 @@ BuildKernelPrototype(IrEmitterContext& ir_emitter_context,
   }
   const int kNumLlvmArgs = to_arg_no.size();
 
-  // Compute the kernel name. The opcode string may contain "-" which cannot be
-  // in a PTX function name, so sanitize the name before uniquifying it.
-  std::string kernel_name = ir_emitter_context.name_uniquer()->GetUniqueName(
-      llvm_ir::SanitizeFunctionName(suggested_name));
-
   // Create the kernel and add it to the module.
   auto* llvm_module = ir_emitter_context.llvm_module();
   llvm::LLVMContext& context = llvm_module->getContext();
@@ -233,12 +248,12 @@ BuildKernelPrototype(IrEmitterContext& ir_emitter_context,
       /*isVarArg=*/false);
   llvm::Function* kernel =
       llvm::Function::Create(kernel_type, llvm::GlobalValue::ExternalLinkage,
-                             kernel_name, llvm_module);
+                             unique_kernel_name, llvm_module);
 
   AnnotateFunctionAsGpuKernel(llvm_module, kernel, builder);
   TF_RETURN_IF_ERROR(AnnotateKernelLaunchDimensions(
-      ir_emitter_context.gpu_device_info(), launch_dimensions, kernel_name,
-      llvm_module));
+      ir_emitter_context.gpu_device_info(), launch_dimensions,
+      unique_kernel_name, llvm_module));
 
   // TODO(b/65380986): Investigate if adding fast math flags for generated
   // kernels makes sense.

--- a/xla/service/gpu/fusions/fusion_emitter.h
+++ b/xla/service/gpu/fusions/fusion_emitter.h
@@ -134,6 +134,20 @@ BuildKernelPrototype(IrEmitterContext& ir_emitter_context,
                      size_t num_inputs,
                      const LaunchDimensions& launch_dimensions,
                      llvm::IRBuilder<>* builder);
+absl::StatusOr<
+    std::tuple<llvm::Function*, std::vector<llvm_ir::IrArray /*inputs*/>,
+               std::vector<llvm_ir::IrArray> /*outputs*/>>
+BuildKernelPrototypeFromUniqueName(IrEmitterContext& ir_emitter_context,
+                                   const std::string& unique_name,
+                                   absl::Span<const KernelArgument> arguments,
+                                   size_t num_inputs,
+                                   const LaunchDimensions& launch_dimensions,
+                                   llvm::IRBuilder<>* builder);
+
+// Compute the kernel name. The opcode string may contain "-" which cannot be
+// in a PTX function name, so sanitize the name before uniquifying it.
+std::string GetSanitizedUniqueName(IrEmitterContext& ir_emitter_context,
+                                   const std::string& suggested_name);
 
 absl::Status AnnotateKernelLaunchDimensions(
     const se::DeviceDescription& device_info,

--- a/xla/service/gpu/fusions/triton/triton_fusion_emitter.cc
+++ b/xla/service/gpu/fusions/triton/triton_fusion_emitter.cc
@@ -2831,7 +2831,7 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
     const se::DeviceDescription& device_info,
     const BlockLevelParameters& block_level_parameters,
     mlir::ModuleOp triton_module, llvm::Module* llvm_module,
-    mlir::MLIRContext& mlir_context) {
+    mlir::MLIRContext& mlir_context, bool emit_kernel) {
   if (std::holds_alternative<se::CudaComputeCapability>(cc)) {
     auto ccCuda = std::get<se::CudaComputeCapability>(cc);
     if (!ccCuda.IsAtLeastAmpere()) {
@@ -2926,27 +2926,30 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
         shared_mem_bytes, device_info.shared_memory_per_block_optin()));
   }
 
-  TF_ASSIGN_OR_RETURN(
-      std::unique_ptr<llvm::Module> ll_triton_module,
-      TranslateLLVMToLLVMIR(&llvm_module->getContext(), triton_module,
-                            GetLibdevicePath(hlo_config, device_info)));
-  VLogModule(5, *ll_triton_module);
-  if (should_verify) {
-    VerifyModule(*ll_triton_module);
-  }
+  if (emit_kernel) {
+    TF_ASSIGN_OR_RETURN(
+        std::unique_ptr<llvm::Module> ll_triton_module,
+        TranslateLLVMToLLVMIR(&llvm_module->getContext(), triton_module,
+                              GetLibdevicePath(hlo_config, device_info)));
+    VLogModule(5, *ll_triton_module);
+    if (should_verify) {
+      VerifyModule(*ll_triton_module);
+    }
 
-  // Integrate LLVM matmul kernel into XLA's LLVM module.
-  ll_triton_module->eraseNamedMDNode(
-      ll_triton_module->getNamedMetadata("nvvm.annotations"));
-  ll_triton_module->setDataLayout(llvm_module->getDataLayout());
-  ll_triton_module->setTargetTriple(llvm_module->getTargetTriple());
-  // Use override flag because libdevice functions can be present in both.
-  TF_RET_CHECK(
-      !llvm::Linker::linkModules(*llvm_module, std::move(ll_triton_module),
-                                 llvm::Linker::Flags::OverrideFromSrc));
-  VLogModule(5, *llvm_module);
-  if (should_verify) {
-    VerifyModule(*llvm_module);
+    // Integrate LLVM matmul kernel into XLA's LLVM module.
+    ll_triton_module->eraseNamedMDNode(
+        ll_triton_module->getNamedMetadata("nvvm.annotations"));
+    ll_triton_module->setDataLayout(llvm_module->getDataLayout());
+    ll_triton_module->setTargetTriple(llvm_module->getTargetTriple());
+    // Use override flag because libdevice functions can be present in both.
+    TF_RET_CHECK(
+        !llvm::Linker::linkModules(*llvm_module, std::move(ll_triton_module),
+                                   llvm::Linker::Flags::OverrideFromSrc));
+
+    VLogModule(5, *llvm_module);
+    if (should_verify) {
+      VerifyModule(*llvm_module);
+    }
   }
 
   // `cluster_info` must be read after pm.run().

--- a/xla/service/gpu/fusions/triton/triton_fusion_emitter.h
+++ b/xla/service/gpu/fusions/triton/triton_fusion_emitter.h
@@ -121,6 +121,9 @@ absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> CreateTritonModule(
     mlir::MLIRContext& mlir_context);
 
 // Compiles a given Triton module to LLVM IR.
+// If `emit_kernels` is false, then the function skips emitting
+// the kernels, but it still returns correctly filled TritonWrapperResult.
+// That is useful when deserializing from the compilation cache.
 absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
     const HloModuleConfig& hlo_config, absl::string_view hlo_module_name,
     const se::GpuComputeCapability& cc,

--- a/xla/service/gpu/fusions/triton/triton_fusion_emitter.h
+++ b/xla/service/gpu/fusions/triton/triton_fusion_emitter.h
@@ -127,7 +127,7 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
     const se::DeviceDescription& device_info,
     const BlockLevelParameters& block_level_parameters,
     mlir::ModuleOp triton_module, llvm::Module* llvm_module,
-    mlir::MLIRContext& mlir_context);
+    mlir::MLIRContext& mlir_context, bool emit_kernel = true);
 
 // Create Triton pipeline.
 //

--- a/xla/service/gpu/gpu_aot_compilation_test.cc
+++ b/xla/service/gpu/gpu_aot_compilation_test.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
+#include "mlir/IR/Builders.h"  // from @llvm-project
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_module_group.h"
 #include "xla/service/compiler.h"
@@ -119,6 +120,129 @@ ENTRY main {
   // Load Executable from AOT compilation result.
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Executable> executable,
                           aot_result->LoadExecutable(compiler, stream_exec));
+}
+
+namespace {
+
+using ::mlir::ArrayRef;
+using ::mlir::NamedAttribute;
+
+std::string CreateTritonCustomCallBackendConfig() {
+  mlir::MLIRContext context_;
+  mlir::Builder builder(&context_);
+
+  // Create the backend_config for the triton custom call.
+  const std::string kMLIRText = R"(
+  module {
+    tt.func public @add_one(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 32 : i32}, %arg1: !tt.ptr<f32, 1> {tt.divisibility = 32 : i32}, %arg2: !tt.ptr<f32, 1> {tt.divisibility = 32 : i32}, %arg3: !tt.ptr<f32, 1> {tt.divisibility = 32 : i32}) {
+      %0 = tt.get_program_id x : i32
+      %1 = tt.load %arg0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<f32>
+      %2 = tt.load %arg1 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : !tt.ptr<f32>
+      %cst = arith.constant 1.000000e+00 : f32
+      %3 = arith.addf %1, %cst : f32
+      tt.store %arg2, %3 {cache = 1 : i32, evict = 1 : i32} : !tt.ptr<f32>
+      tt.store %arg3, %2 {cache = 1 : i32, evict = 1 : i32} : !tt.ptr<f32>
+      tt.return
+    }
+  }
+  )";
+
+  NamedAttribute name =
+      builder.getNamedAttr("name", builder.getStringAttr("add_one"));
+  NamedAttribute ir =
+      builder.getNamedAttr("ir", builder.getStringAttr(kMLIRText));
+  NamedAttribute num_stages =
+      builder.getNamedAttr("num_stages", builder.getI32IntegerAttr(3));
+  NamedAttribute num_warps =
+      builder.getNamedAttr("num_warps", builder.getI32IntegerAttr(4));
+  NamedAttribute grid_x =
+      builder.getNamedAttr("grid_x", builder.getI32IntegerAttr(1));
+  NamedAttribute grid_y =
+      builder.getNamedAttr("grid_y", builder.getI32IntegerAttr(1));
+  NamedAttribute grid_z =
+      builder.getNamedAttr("grid_z", builder.getI32IntegerAttr(1));
+  NamedAttribute debug =
+      builder.getNamedAttr("debug", builder.getBoolAttr(false));
+
+  std::vector<NamedAttribute> attributes = {
+      name, ir, num_stages, num_warps, grid_x, grid_y, grid_z, debug};
+  ArrayRef<NamedAttribute> attributesRef(attributes);
+  mlir::DictionaryAttr backend_config =
+      mlir::DictionaryAttr::get(&context_, attributesRef);
+
+  // Parse the backend_config into a string.
+  std::string backend_config_str;
+  llvm::raw_string_ostream(backend_config_str) << backend_config;
+
+  return backend_config_str;
+}
+
+}  // namespace
+
+TEST_F(GpuAotCompilationTest, ExportAndLoadExecutableWithTriton) {
+  if (auto cc = backend()
+                    .default_stream_executor()
+                    ->GetDeviceDescription()
+                    .cuda_compute_capability();
+      !cc.IsAtLeastAmpere()) {
+    GTEST_SKIP() << "Triton support is only enabled for Ampere GPUs and up.";
+  }
+
+  const absl::string_view hlo_string_template = R"(
+    HloModule Test
+
+    ENTRY main {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT c = (f32[],f32[]) custom-call(a, b), custom_call_target="__gpu$xla.gpu.triton", backend_config="%s"
+    }
+    )";
+
+  std::string hlo_string =
+      absl::StrFormat(hlo_string_template,
+                      absl::CEscape(CreateTritonCustomCallBackendConfig()));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  auto compiler = backend().compiler();
+  auto name =
+      absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value());
+  TF_ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                          se::PlatformManager::PlatformWithName(name));
+  TF_ASSERT_OK_AND_ASSIGN(se::StreamExecutor * stream_exec,
+                          platform->ExecutorForDevice(0));
+
+  // Compile AOT.
+  auto module_group = std::make_unique<HloModuleGroup>(std::move(module));
+  AotCompilationOptions aot_options(compiler->PlatformId());
+  aot_options.set_executor(stream_exec);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::vector<std::unique_ptr<AotCompilationResult>> aot_results,
+      compiler->CompileAheadOfTime(std::move(module_group), aot_options));
+
+  // Serialize-deserialize AOT compilation result.
+  TF_ASSERT_OK_AND_ASSIGN(std::string serialized_aot_result,
+                          aot_results[0]->SerializeAsString());
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<AotCompilationResult> aot_result,
+      compiler->LoadAotCompilationResult(serialized_aot_result));
+
+  // Load Executable from AOT compilation result.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Executable> executable,
+                          aot_result->LoadExecutable(compiler, stream_exec));
+
+  const xla::Literal literal_1 = xla::LiteralUtil::CreateR0<float>(1.0f);
+  const xla::Literal literal_2 = xla::LiteralUtil::CreateR0<float>(2.0f);
+  const xla::Literal literal_3 = xla::LiteralUtil::CreateR0<float>(3.0f);
+
+  TF_ASSERT_OK_AND_ASSIGN(Literal result,
+                          GetHloRunner().value()->ExecuteWithExecutable(
+                              executable.get(), {&literal_1, &literal_3}));
+
+  EXPECT_TRUE(LiteralTestUtil::Equal(
+      LiteralUtil::MakeTuple({&literal_2, &literal_3}), result));
 }
 
 }  // namespace gpu


### PR DESCRIPTION
This change avoids running final part of the Triton kernel emission when deserializing form cache. This can make a 0.5-1s difference on larger Pallas kernels (we see ~600ms/2x improvement in deserialization time of a step/update function with Pallas attention kernel).