### PR TITLE
Quantized Collectives

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -641,6 +641,41 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "collective_quantizer",
+    srcs = ["collective_quantizer.cc"],
+    hdrs = ["collective_quantizer.h"],
+    deps = [
+        ":hlo_pass",
+        "//xla:shape_util",
+        "//xla/hlo/evaluator:hlo_evaluator",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:hlo_parser",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "collective_quantizer_test",
+    srcs = ["collective_quantizer_test.cc"],
+    deps = [
+        ":collective_quantizer",
+        ":hlo_verifier",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/utils:hlo_matchers",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest",
+        "@tsl//tsl/lib/core:status_test_util",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
     name = "dump",
     srcs = ["dump.cc"],
     hdrs = ["dump.h"],

--- a/xla/service/collective_quantizer.cc
+++ b/xla/service/collective_quantizer.cc
@@ -1,0 +1,191 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/collective_quantizer.h"
+
+#include "xla/service/pattern_matcher.h"
+#include "xla/shape_util.h"
+
+namespace xla {
+namespace {
+
+namespace m = match;
+
+// Matches a broadcast of a scalar operand.
+template <typename... Args>
+auto ScalarBroadcast(Args... args) {
+  return m::Broadcast(args...).WithPredicate([](const HloInstruction* instr) {
+    return ShapeUtil::IsScalar(instr->operand(0)->shape());
+  });
+}
+
+// Matches a bitcast that preserves the element type of the operand.
+auto BitcastPreservesElementType() {
+  return m::Bitcast().WithPredicate([](const HloInstruction* instr) {
+    return ShapeUtil::SameElementType(instr->shape(),
+                                      instr->operand(0)->shape());
+  });
+}
+
+// Matches a type conversion to a type with a smaller byte size than that of the
+// operand.
+auto ConvertToNarrowerType() {
+  auto converts_to_narrower_type = [](const HloInstruction* instr) -> bool {
+    return ShapeUtil::ByteSizeOfPrimitiveType(instr->shape().element_type()) <
+           ShapeUtil::ByteSizeOfPrimitiveType(
+               instr->operand(0)->shape().element_type());
+  };
+  return m::Convert().WithPredicate(converts_to_narrower_type);
+}
+
+// Returns true iff instr describes a quantization, i.e. a multiplication or
+// division by a broadcasted scalar followed by a clamp and a type conversion,
+// or a plain type conversion to a narrower type. Unary bitcast, copy, reshape
+// or slice ops with one user may precede the quantization or type conversion.
+bool IsSupportedQuantization(HloInstruction* instr, HloInstruction** convert,
+                             HloInstruction** binary, HloInstruction** clamp,
+                             HloInstruction** scale_bcast,
+                             std::vector<HloInstruction*>& unary_ops) {
+  std::vector<HloInstruction*> ops;
+  while (instr->user_count() <= 1) {
+    if (Match(instr, m::AnyOf<HloInstruction>(
+                         BitcastPreservesElementType(), m::Copy(), m::Reshape(),
+                         m::Slice(), m::Multiply(), m::Divide(), m::Clamp()))) {
+      if (instr->user_count() > 0) {
+        ops.emplace_back(instr);
+        instr = instr->users()[0];
+        continue;
+      }
+      break;
+    }
+
+    if (Match(instr, ConvertToNarrowerType())) {
+      ops.emplace_back(instr);
+      break;
+    }
+    VLOG(5) << "Unsupported instruction.";
+    return false;
+  }
+
+  // In the quantization case, the type conversion is preceded by a
+  // multiplication or division by a broadcasted scalar and a clamp instruction.
+  if (ops.size() > 2 &&
+      (Match(ops.back(),
+             m::Convert(convert, m::Clamp(clamp, ScalarBroadcast(),
+                                          m::MultiplyAnyOrder(
+                                              binary, m::Op(),
+                                              ScalarBroadcast(scale_bcast)),
+                                          ScalarBroadcast()))) ||
+       Match(
+           ops.back(),
+           m::Convert(convert, m::Clamp(clamp, ScalarBroadcast(),
+                                        m::Divide(binary, m::Op(),
+                                                  ScalarBroadcast(scale_bcast)),
+                                        ScalarBroadcast()))))) {
+    unary_ops = {ops.begin(), ops.end() - 3};
+  } else if (ops.size() > 0 && Match(ops.back(), m::Convert(convert))) {
+    unary_ops = {ops.begin(), ops.end() - 1};
+  } else {
+    VLOG(5) << "Did not find type conversion or quantization pattern.";
+    return false;
+  }
+
+  // The collected unary ops between collective and quantization/type conversion
+  // may only include bitcast, copy, reshape and slice instructions.
+  for (HloInstruction* unary_op : unary_ops) {
+    if (!Match(unary_op, m::AnyOf<HloInstruction>(m::Bitcast(), m::Copy(),
+                                                  m::Reshape(), m::Slice()))) {
+      VLOG(5) << "Unexpected instruction in unary ops.";
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsSupportedCollective(HloInstruction* instr) {
+  return instr->opcode() == HloOpcode::kAllGather ||
+         instr->opcode() == HloOpcode::kAllToAll ||
+         instr->opcode() == HloOpcode::kCollectiveBroadcast ||
+         instr->opcode() == HloOpcode::kCollectivePermute;
+}
+
+}  // namespace
+
+absl::StatusOr<bool> CollectiveQuantizer::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+
+  for (HloComputation* comp : module->MakeComputationPostOrder()) {
+    for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
+      HloInstruction *binary = nullptr, *clamp, *convert, *scale_bcast;
+      std::vector<HloInstruction*> unary_ops;
+      if (instr->user_count() == 1 && IsSupportedCollective(instr) &&
+          IsSupportedQuantization(instr->users()[0], &convert, &binary, &clamp,
+                                  &scale_bcast, unary_ops)) {
+        HloInstruction* coll_operand = instr->mutable_operand(0);
+        HloInstruction *new_binary, *new_clamp;
+        // When there is a quantization, insert the scale and clamp ops.
+        if (binary) {
+          HloInstruction* new_scale_bcast = comp->AddInstruction(
+              scale_bcast->CloneWithNewShape(coll_operand->shape()));
+          new_binary = comp->AddInstruction(binary->CloneWithNewOperands(
+              coll_operand->shape(), {coll_operand, new_scale_bcast}));
+          HloInstruction* new_clamp_lower = comp->AddInstruction(
+              clamp->operand(0)->CloneWithNewShape(coll_operand->shape()));
+          HloInstruction* new_clamp_upper = comp->AddInstruction(
+              clamp->operand(2)->CloneWithNewShape(coll_operand->shape()));
+          new_clamp = comp->AddInstruction(clamp->CloneWithNewOperands(
+              coll_operand->shape(),
+              {new_clamp_lower, new_binary, new_clamp_upper}));
+        }
+
+        // Move the collective past the conversion to the narrow type.
+        Shape new_convert_shape = ShapeUtil::ChangeElementType(
+            instr->operand(0)->shape(), convert->shape().element_type());
+        HloInstruction* new_convert =
+            comp->AddInstruction(convert->CloneWithNewOperands(
+                new_convert_shape, {binary ? new_clamp : coll_operand}));
+        Shape new_collective_shape = ShapeUtil::ChangeElementType(
+            instr->shape(), convert->shape().element_type());
+        HloInstruction* new_collective = comp->AddInstruction(
+            instr->CloneWithNewOperands(new_collective_shape, {new_convert}));
+
+        // Sequentially apply the collected unary ops to the output of the
+        // quantized collective.
+        auto shift_unary_ops = [comp, &unary_ops](HloInstruction** x) -> void {
+          for (HloInstruction* unary_op : unary_ops) {
+            *x = comp->AddInstruction(unary_op->CloneWithNewOperands(
+                ShapeUtil::MakeShapeWithDenseLayout(
+                    (*x)->shape().element_type(),
+                    unary_op->shape().dimensions(),
+                    unary_op->shape().layout().minor_to_major()),
+                {*x}));
+          }
+        };
+
+        shift_unary_ops(&new_collective);
+        TF_RETURN_IF_ERROR(convert->ReplaceAllUsesWith(new_collective));
+
+        changed = true;
+        VLOG(5) << "Quantized collective " << new_collective->ToShortString();
+      }
+    }
+  }
+
+  return changed;
+}
+
+}  // namespace xla

--- a/xla/service/collective_quantizer.h
+++ b/xla/service/collective_quantizer.h
@@ -1,0 +1,49 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_COLLECTIVE_QUANTIZER_H_
+#define XLA_SERVICE_COLLECTIVE_QUANTIZER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/hlo_pass_interface.h"
+
+namespace xla {
+
+// Reduces the amount of data transferred in all-gather, all-to-all,
+// collective-broadcast and collective-permute ops by exchanging the collectives
+// with subsequent quantizations or type conversions to a narrower type. When
+// present, unary ops such as bitcasts, copies, reshapes and slices between
+// collective and quantization/type conversion are shifted, i.e. transforms
+//
+//   collective --> unary --> quantization/type conversion
+//
+// into
+//
+//   quantization/type conversion --> collective --> unary.
+class CollectiveQuantizer : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "collective-quantizer"; }
+
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla
+
+#endif  // XLA_SERVICE_COLLECTIVE_QUANTIZER_H_

--- a/xla/service/collective_quantizer_test.cc
+++ b/xla/service/collective_quantizer_test.cc
@@ -1,0 +1,261 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/collective_quantizer.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/utils/hlo_matchers.h"
+#include "xla/service/hlo_verifier.h"
+#include "xla/tests/hlo_test_base.h"
+
+namespace xla {
+namespace {
+
+namespace op = xla::testing::opcode_matchers;
+
+class CollectiveQuantizerTest : public HloTestBase {
+ public:
+  absl::StatusOr<bool> RunCollectiveQuantizer(HloModule* module) {
+    CollectiveQuantizer collective_quantizer;
+    return collective_quantizer.Run(module, {});
+  }
+};
+
+TEST_F(CollectiveQuantizerTest, AllGatherConvert) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,4,8,128] parameter(0)
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(all-gather)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::Convert(op::Parameter())));
+  HloInstruction* all_gather = module->entry_computation()->root_instruction();
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, AllGatherConvertUnary) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,4,8,128] parameter(0)
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    reshape = bf16[8,32,1024] reshape(all-gather)
+    slice = bf16[8,32,512] slice(reshape), slice={[0:8], [0:32], [256:768]}
+    ROOT convert = f8e4m3fn[8,32,512] convert(slice)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      op::Slice(op::Reshape(op::AllGather(op::Convert(op::Parameter())))));
+  HloInstruction* all_gather = module->entry_computation()->root_instruction();
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, AllGatherQuantize) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,4,8,128] parameter(0)
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    scale = bf16[] parameter(1)
+    scale_bcast = bf16[8,32,8,128] broadcast(scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(all-gather, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))));
+  HloInstruction* all_gather = module->entry_computation()->root_instruction();
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, AllToAllQuantize) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,32,8,128] parameter(0)
+    all-to-all = bf16[8,32,8,128] all-to-all(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    scale = bf16[] parameter(1)
+    scale_bcast = bf16[8,32,8,128] broadcast(scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(all-to-all, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllToAll(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))));
+  HloInstruction* all_to_all = module->entry_computation()->root_instruction();
+  EXPECT_THAT(all_to_all->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, CollectiveBroadcastQuantize) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,32,8,128] parameter(0)
+    collective-broadcast = bf16[8,32,8,128] collective-broadcast(param), replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    scale = bf16[] parameter(1)
+    scale_bcast = bf16[8,32,8,128] broadcast(scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(collective-broadcast, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::CollectiveBroadcast(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))));
+  HloInstruction* collective_broadcast =
+      module->entry_computation()->root_instruction();
+  EXPECT_THAT(collective_broadcast->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, CollectivePermuteQuantize) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,32,8,128] parameter(0)
+    collective-permute = bf16[8,32,8,128] collective-permute(param), source_target_pairs={{0,1},{2,3},{4,5},{6,7}}, channel_id=1
+    scale = bf16[] parameter(1)
+    scale_bcast = bf16[8,32,8,128] broadcast(scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(collective-permute, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::CollectivePermute(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))));
+  HloInstruction* collective_permute =
+      module->entry_computation()->root_instruction();
+  EXPECT_THAT(collective_permute->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, AllGatherQuantizeUnary) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,4,8,128] parameter(0)
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    reshape = bf16[8,32,1024] reshape(all-gather)
+    slice = bf16[8,32,512] slice(reshape), slice={[0:8], [0:32], [256:768]}
+    scale = bf16[] parameter(1)
+    scale_bcast = bf16[8,32,512] broadcast(scale), dimensions={}
+    divide = bf16[8,32,512] divide(slice, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,512] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,512] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,512] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,512] convert(clamp)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Slice(op::Reshape(op::AllGather(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))))));
+  HloInstruction* slice = module->entry_computation()->root_instruction();
+  EXPECT_THAT(slice->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, AllGatherQuantizeMultiUser) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[8,4,8,128] parameter(0)
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    scale = bf16[] parameter(1)
+    scale_bcast = bf16[8,32,8,128] broadcast(scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(all-gather, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    add = bf16[8,32,8,128] add(divide, clamp)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(add)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3184,6 +3184,7 @@ cc_library(
         "//xla/service:call_inliner",
         "//xla/service:collective_permute_decomposer",
         "//xla/service:collective_pipeliner",
+        "//xla/service:collective_quantizer",
         "//xla/service:collectives_schedule_linearizer",
         "//xla/service:comparison_expander",
         "//xla/service:compiler",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -83,6 +83,7 @@ limitations under the License.
 #include "xla/service/call_inliner.h"
 #include "xla/service/collective_permute_decomposer.h"
 #include "xla/service/collective_pipeliner.h"
+#include "xla/service/collective_quantizer.h"
 #include "xla/service/collectives_schedule_linearizer.h"
 #include "xla/service/comparison_expander.h"
 #include "xla/service/compiler.h"
@@ -932,6 +933,10 @@ absl::Status RunCollectiveOptimizationPasses(
       {U16, U32}, {S16, S32}};
   collectives_pipeline.AddPass<AllReducePromotion>(ar_promoted_types);
   // Remove dead computations left over after ar/rs promotion.
+  collectives_pipeline.AddPass<HloDCE>();
+
+  collectives_pipeline.AddPass<CollectiveQuantizer>();
+  // Remove dead computations after collective quantization.
   collectives_pipeline.AddPass<HloDCE>();
 
   // Run WhileLoopTripCountAnnotator after collective pipelining and before


### PR DESCRIPTION
Introduces a pass that can reduce the amount of data transferred in all-gather, all-to-all, collective-broadcast and collective-permute ops by exchanging the collective with a subsequent quantization or conversion to a narrower type.