### PR TITLE
Adds a convenient python binding for obtaining instruction costs.

### DIFF
--- a/xla/python/profiler.cc
+++ b/xla/python/profiler.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
 #include "nanobind/nanobind.h"
+#include "nanobind/stl/pair.h"  // IWYU pragma: keep
 #include "nanobind/stl/string.h"  // IWYU pragma: keep
 #include "nanobind/stl/string_view.h"  // IWYU pragma: keep
 #include "nanobind/stl/unique_ptr.h"  // IWYU pragma: keep
@@ -266,6 +267,23 @@ void BuildProfilerSubmodule(nb::module_& m) {
                 tensorboard_dir, &profile_proto));
         std::string profile_proto_str = profile_proto.SerializeAsString();
         return nb::bytes(profile_proto_str.data(), profile_proto_str.size());
+      },
+      nb::arg("tensorboard_dir"));
+
+  profiler.def(
+      "get_instructions_profile",
+      [](const std::string& tensorboard_dir)
+          -> std::vector<std::pair<std::string, double>> {
+        tensorflow::profiler::ProfiledInstructionsProto profile_proto;
+        xla::ThrowIfError(
+            xla::ConvertXplaneUnderLogdirToProfiledInstructionsProto(
+                tensorboard_dir, &profile_proto));
+        std::vector<std::pair<std::string, double>> results;
+        results.reserve(profile_proto.costs().size());
+        for (const auto& c : profile_proto.costs()) {
+          results.emplace_back(c.name(), c.cost_us());
+        }
+        return results;
       },
       nb::arg("tensorboard_dir"));
 


### PR DESCRIPTION
The python binding being added in this PR can help quick analysis on the cost of the HLO instructions with easy python code.

The binding is tested with a real tensorboard dir:

```
import jax.lib.xla_bridge as xb
client = xb.xla_client
costs = client.profiler.get_instructions_profile(tensorboard_dir)
for name, cost in costs:
  print(name, cost)
```

works.