### PR TITLE
Support cuDNN frontend scaled dot product attention for FP8. Part- 1(forward)

### DIFF
--- a/xla/service/gpu/cublas_cudnn.cc
+++ b/xla/service/gpu/cublas_cudnn.cc
@@ -223,13 +223,12 @@ absl::StatusOr<CudnnfMHAKind> GetCudnnfMHAKind(
     return CudnnfMHAKind::kScaleBiasSoftmax;
   if (target == kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget)
     return CudnnfMHAKind::kScaleBiasSoftmaxDropout;
-  if (target == kCudnnfMHASoftmaxF8CallTarget)
-    return CudnnfMHAKind::kSoftmaxF8;  
+  if (target == kCudnnfMHASoftmaxF8CallTarget) return CudnnfMHAKind::kSoftmaxF8;
   // backward
   if (target == kCudnnfMHASoftmaxDropoutBackwardCallTarget)
     return CudnnfMHAKind::kBackwardSoftmaxDropout;
   if (target == kCudnnfMHASoftmaxBackwardF8CallTarget)
-    return CudnnfMHAKind::kBackwardSoftmaxF8;  
+    return CudnnfMHAKind::kBackwardSoftmaxF8;
   if (target == kCudnnfMHASoftmaxBackwardCallTarget)
     return CudnnfMHAKind::kBackwardSoftmax;
   if (target == kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget)
@@ -242,7 +241,7 @@ absl::StatusOr<CudnnfMHAKind> GetCudnnfMHAKind(
 std::string CudnnfMHAKindToString(CudnnfMHAKind kind) {
   switch (kind) {
     case CudnnfMHAKind::kSoftmaxF8:
-      return "fmha_softmax_f8";    
+      return "fmha_softmax_f8";
     case CudnnfMHAKind::kSoftmax:
       return "fmha_softmax";
     case CudnnfMHAKind::kSoftmaxDropout:
@@ -253,7 +252,7 @@ std::string CudnnfMHAKindToString(CudnnfMHAKind kind) {
       return "fmha_bias_softmax";
     // backward
     case CudnnfMHAKind::kBackwardSoftmaxF8:
-      return "fmha_softmax_backward_f8";    
+      return "fmha_softmax_backward_f8";
     case CudnnfMHAKind::kBackwardSoftmax:
       return "fmha_softmax_backward";
     case CudnnfMHAKind::kBackwardSoftmaxDropout:

--- a/xla/service/gpu/cublas_cudnn.cc
+++ b/xla/service/gpu/cublas_cudnn.cc
@@ -75,6 +75,7 @@ const absl::string_view kCudnnConvReorderFilterAndBiasCallTarget =
 const absl::string_view kCudnnNormCallTarget = "__cudnn$norm";
 
 // fMHA forward call targets.
+const absl::string_view kCudnnfMHASoftmaxF8CallTarget = "__cudnn$fmhaSoftmaxF8";
 const absl::string_view kCudnnfMHASoftmaxCallTarget = "__cudnn$fmhaSoftmax";
 const absl::string_view kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget =
     "__cudnn$fmhaScaleBiasSoftmaxDropout";
@@ -84,6 +85,8 @@ const absl::string_view kCudnnfMHASoftmaxDropoutCallTarget =
     "__cudnn$fmhaSoftmaxDropout";
 
 // fMHA backward call targets.
+const absl::string_view kCudnnfMHASoftmaxBackwardF8CallTarget =
+    "__cudnn$fmhaSoftmaxBackwardF8";
 const absl::string_view kCudnnfMHASoftmaxBackwardCallTarget =
     "__cudnn$fmhaSoftmaxBackward";
 const absl::string_view kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget =
@@ -124,6 +127,14 @@ bool IsCustomCallToDnnNorm(const HloInstruction& hlo) {
   return target == kCudnnNormCallTarget;
 }
 
+bool IsFwdCustomCallTofMHAF8(const HloInstruction& hlo) {
+  if (hlo.opcode() != HloOpcode::kCustomCall) {
+    return false;
+  }
+  const auto& target = hlo.custom_call_target();
+  return target == kCudnnfMHASoftmaxF8CallTarget;
+}
+
 bool IsFwdCustomCallTofMHA(const HloInstruction& hlo) {
   if (hlo.opcode() != HloOpcode::kCustomCall) {
     return false;
@@ -155,6 +166,10 @@ bool MHACallHasDropout(const absl::string_view fmha_call_name) {
 
 bool IsCustomCallTofMHA(const HloInstruction& hlo) {
   return (IsFwdCustomCallTofMHA(hlo) || IsBwdCustomCallTofMHA(hlo));
+}
+
+bool IsCustomCallTofMHAF8(const HloInstruction& hlo) {
+  return IsFwdCustomCallTofMHAF8(hlo);
 }
 
 bool IsCubDeviceRadixSort(const HloInstruction& hlo) {
@@ -208,9 +223,13 @@ absl::StatusOr<CudnnfMHAKind> GetCudnnfMHAKind(
     return CudnnfMHAKind::kScaleBiasSoftmax;
   if (target == kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget)
     return CudnnfMHAKind::kScaleBiasSoftmaxDropout;
+  if (target == kCudnnfMHASoftmaxF8CallTarget)
+    return CudnnfMHAKind::kSoftmaxF8;  
   // backward
   if (target == kCudnnfMHASoftmaxDropoutBackwardCallTarget)
     return CudnnfMHAKind::kBackwardSoftmaxDropout;
+  if (target == kCudnnfMHASoftmaxBackwardF8CallTarget)
+    return CudnnfMHAKind::kBackwardSoftmaxF8;  
   if (target == kCudnnfMHASoftmaxBackwardCallTarget)
     return CudnnfMHAKind::kBackwardSoftmax;
   if (target == kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget)
@@ -222,6 +241,8 @@ absl::StatusOr<CudnnfMHAKind> GetCudnnfMHAKind(
 
 std::string CudnnfMHAKindToString(CudnnfMHAKind kind) {
   switch (kind) {
+    case CudnnfMHAKind::kSoftmaxF8:
+      return "fmha_softmax_f8";    
     case CudnnfMHAKind::kSoftmax:
       return "fmha_softmax";
     case CudnnfMHAKind::kSoftmaxDropout:
@@ -231,6 +252,8 @@ std::string CudnnfMHAKindToString(CudnnfMHAKind kind) {
     case CudnnfMHAKind::kScaleBiasSoftmax:
       return "fmha_bias_softmax";
     // backward
+    case CudnnfMHAKind::kBackwardSoftmaxF8:
+      return "fmha_softmax_backward_f8";    
     case CudnnfMHAKind::kBackwardSoftmax:
       return "fmha_softmax_backward";
     case CudnnfMHAKind::kBackwardSoftmaxDropout:

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -68,7 +68,7 @@ enum class CudnnfMHAKind {
   kBackwardScaleBiasSoftmax,
   kBackwardScaleBiasSoftmaxDropout,
   kSoftmaxF8,
-  kBackwardSoftmaxF8,  
+  kBackwardSoftmaxF8,
 };
 
 enum class CudnnfMHAMaskKind {

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -67,6 +67,8 @@ enum class CudnnfMHAKind {
   kBackwardSoftmax,
   kBackwardScaleBiasSoftmax,
   kBackwardScaleBiasSoftmaxDropout,
+  kSoftmaxF8,
+  kBackwardSoftmaxF8,  
 };
 
 enum class CudnnfMHAMaskKind {
@@ -180,6 +182,7 @@ bool IsCustomCallToDnnNorm(const HloInstruction& hlo);
 // 3. BMM1 - scale - Bias - Softmax - BMM2
 // 4. BMM1 - scale - Bias - Softmax - Dropout - BMM2
 // Forward calls
+extern const absl::string_view kCudnnfMHASoftmaxF8CallTarget;
 extern const absl::string_view kCudnnfMHASoftmaxCallTarget;
 extern const absl::string_view kCudnnfMHASoftmaxDropoutCallTarget;
 extern const absl::string_view kCudnnfMHAScaleBiasSoftmaxDropoutCallTarget;
@@ -191,6 +194,8 @@ extern const absl::string_view
     kCudnnfMHAScaleBiasSoftmaxDropoutBackwardCallTarget;
 extern const absl::string_view kCudnnfMHAScaleBiasSoftmaxBackwardCallTarget;
 
+bool IsFwdCustomCallTofMHAF8(const HloInstruction& hlo);
+bool IsCustomCallTofMHAF8(const HloInstruction& hlo);
 bool IsFwdCustomCallTofMHA(const HloInstruction& hlo);
 bool IsBwdCustomCallTofMHA(const HloInstruction& hlo);
 bool IsCustomCallTofMHA(const HloInstruction& hlo);

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2715,7 +2715,7 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       if (IsCustomCallToDnnNorm(*instr)) {
         return EmitNormThunk(custom_call);
       }
-      if (IsCustomCallTofMHA(*instr)) {
+      if (IsCustomCallTofMHA(*instr) || IsCustomCallTofMHAF8(*instr)) {
         return EmitCuDnnThunk(custom_call);
       }
 #endif  // GOOGLE_CUDA

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -1181,7 +1181,7 @@ class FlashAttentionBMMScalePaddingMaskSoftmaxBMMF8
       call.41 = bf16[4,16,4,16]{3,2,1,0} call(divide.32, constant.5, constant.4), to_apply=clip.33
       convert.42 = f8e4m3fn[4,16,4,16]{3,2,1,0} convert(call.41)
       convert.43 = bf16[4,16,4,16]{3,2,1,0} convert(convert.42)
-      custom-call.21.0 = (f8e4m3fn[4,4,16,16]{3,1,2,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, u8[16]{0}) custom-call(convert.18, convert.30, convert.42, broadcast.99, broadcast.99, /*index=5*/broadcast.99, broadcast.99, broadcast.99, broadcast.99), custom_call_target="__cudnn$fmhaSoftmax$f8", operand_layout_constraints={f8e4m3fn[4,16,4,16]{3,2,1,0}, f8e4m3fn[4,16,4,16]{3,2,1,0}, f8e4m3fn[4,16,4,16]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}}
+      custom-call.21.0 = (f8e4m3fn[4,4,16,16]{3,1,2,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, u8[16]{0}) custom-call(convert.18, convert.30, convert.42, broadcast.99, broadcast.99, /*index=5*/broadcast.99, broadcast.99, broadcast.99, broadcast.99), custom_call_target="__cudnn$fmhaSoftmaxF8", operand_layout_constraints={f8e4m3fn[4,16,4,16]{3,2,1,0}, f8e4m3fn[4,16,4,16]{3,2,1,0}, f8e4m3fn[4,16,4,16]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}}
       get-tuple-element.5.0 = f8e4m3fn[4,4,16,16]{3,1,2,0} get-tuple-element(custom-call.21.0), index=0
       ROOT out = bf16[4,4,16,16]{3,1,2,0} convert(get-tuple-element.5.0)
     } // main.106

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -1108,8 +1108,8 @@ class FlashAttentionBMMScalePaddingMaskSoftmaxBMMF8
   void TestImpl_Flash_Attention_Inference_BMM1_NoMask_Softmax_BMM2_F8() {
     if (skip_reason_) GTEST_SKIP() << *skip_reason_;
     if (GetDnnVersionInfoOrDefault(backend().default_stream_executor()) <
-        se::dnn::VersionInfo(9, 0, 0)) {
-      GTEST_SKIP() << "Flash Attention requires cuDNN >= 9.0.0.";
+        se::dnn::VersionInfo(9, 1, 0)) {
+      GTEST_SKIP() << "Flash Attention requires cuDNN >= 9.1.0.";
     }
     XlaBuilder builder(TestName());
     std::string hlo_string_ref =

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -1102,6 +1102,95 @@ class FlashAttentionBMMScalePaddingMaskSoftmaxBMM
   }
 };
 
+class FlashAttentionBMMScalePaddingMaskSoftmaxBMMF8
+    : public MultiHeadedAttentionTest {
+ protected:
+  void TestImpl_Flash_Attention_Inference_BMM1_NoMask_Softmax_BMM2_F8() {
+    if (skip_reason_) GTEST_SKIP() << *skip_reason_;
+    if (GetDnnVersionInfoOrDefault(backend().default_stream_executor()) <
+        se::dnn::VersionInfo(9, 0, 0)) {
+      GTEST_SKIP() << "Flash Attention requires cuDNN >= 9.0.0.";
+    }
+    XlaBuilder builder(TestName());
+    std::string hlo_string_ref =
+        R"(
+    HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(bf16[4,16,4,16]{3,2,1,0}, bf16[4,16,4,16]{3,2,1,0}, bf16[4,16,4,16]{3,2,1,0})->bf16[4,4,16,16]{3,1,2,0}}, allow_spmd_sharding_propagation_to_parameters={true,true,true}, allow_spmd_sharding_propagation_to_output={true}
+    clip.33 {
+      Arg_2.36 = bf16[] parameter(2)
+      broadcast.39 = bf16[4,16,4,16]{3,2,1,0} broadcast(Arg_2.36), dimensions={}
+      Arg_1.35 = bf16[] parameter(1)
+      broadcast.37 = bf16[4,16,4,16]{3,2,1,0} broadcast(Arg_1.35), dimensions={}
+      Arg_0.34 = bf16[4,16,4,16]{3,2,1,0} parameter(0)
+      maximum.38 = bf16[4,16,4,16]{3,2,1,0} maximum(broadcast.37, Arg_0.34)
+      ROOT minimum.40 = bf16[4,16,4,16]{3,2,1,0} minimum(broadcast.39, maximum.38)
+    } // clip.33
+    ENTRY main.106 {
+      Arg_0.1 = bf16[4,16,4,16]{3,2,1,0} parameter(0)
+      constant.6 = bf16[] constant(1)
+      broadcast.7 = bf16[4,16,4,16]{3,2,1,0} broadcast(constant.6), dimensions={}
+      divide.8 = bf16[4,16,4,16]{3,2,1,0} divide(Arg_0.1, broadcast.7)
+      constant.5 = bf16[] constant(-448)
+      constant.4 = bf16[] constant(448)
+      call.17 = bf16[4,16,4,16]{3,2,1,0} call(divide.8, constant.5, constant.4), to_apply=clip.33
+      convert.18 = f8e4m3fn[4,16,4,16]{3,2,1,0} convert(call.17)
+      convert.19 = bf16[4,16,4,16]{3,2,1,0} convert(convert.18)
+      Arg_1.2 = bf16[4,16,4,16]{3,2,1,0} parameter(1)
+      divide.20 = bf16[4,16,4,16]{3,2,1,0} divide(Arg_1.2, broadcast.7)
+      call.29 = bf16[4,16,4,16]{3,2,1,0} call(divide.20, constant.5, constant.4), to_apply=clip.33
+      convert.30 = f8e4m3fn[4,16,4,16]{3,2,1,0} convert(call.29)
+      convert.31 = bf16[4,16,4,16]{3,2,1,0} convert(convert.30)
+      Arg_2.3 = bf16[4,16,4,16]{3,2,1,0} parameter(2)
+      divide.32 = bf16[4,16,4,16]{3,2,1,0} divide(Arg_2.3, broadcast.7)
+      call.41 = bf16[4,16,4,16]{3,2,1,0} call(divide.32, constant.5, constant.4), to_apply=clip.33
+      convert.42 = f8e4m3fn[4,16,4,16]{3,2,1,0} convert(call.41)
+      convert.43 = bf16[4,16,4,16]{3,2,1,0} convert(convert.42)
+      custom-call.4.0 = (bf16[4,4,16,16]{3,1,2,0}, u8[16]{0}) custom-call(convert.19, convert.31, convert.43), custom_call_target="__cudnn$fmhaSoftmax", operand_layout_constraints={bf16[4,16,4,16]{3,2,1,0}, bf16[4,16,4,16]{3,2,1,0}, bf16[4,16,4,16]{3,2,1,0}}, api_version=API_VERSION_STATUS_RETURNING, backend_config={"operation_queue_id": "0", "wait_on_operation_queues": [], "cudnn_fmha_backend_config": {"algorithm": {"algo_id": "0", "math_type": "TENSOR_OP_MATH", "tuning_knobs": {"17": "1", "24": "0"}, "is_cudnn_frontend": true, "workspace_size": "0"}, "fmha_scale": 1.0, "dropout_rate": 0.0, "intermediate_tensor_shape": {"element_type": "BF16", "dimensions": ["4", "4", "16", "16"], "tuple_shapes": [], "layout": {"dim_level_types": [], "dim_unique": [], "dim_ordered": [], "minor_to_major": ["3", "2", "1", "0"], "tiles": [], "element_size_in_bits": "0", "memory_space": "0", "index_primitive_type": "PRIMITIVE_TYPE_INVALID", "pointer_primitive_type": "PRIMITIVE_TYPE_INVALID", "dynamic_shape_metadata_prefix_bytes": "0"}, "is_dynamic_dimension": [false, false, false, false]}, "seed": 42, "is_flash_attention": true, "mask_type": "NO_MASK", "bmm1_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["3"], "lhs_batch_dimensions": ["0", "2"], "rhs_batch_dimensions": ["0", "2"]}, "bmm2_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}}}
+      ROOT get-tuple-element.5.0 = bf16[4,4,16,16]{3,1,2,0} get-tuple-element(custom-call.4.0), index=0
+    } // main.106
+  )";  // NOLINT
+    std::string hlo_string = R"(
+    HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(bf16[4,16,4,16]{3,2,1,0}, bf16[4,16,4,16]{3,2,1,0}, bf16[4,16,4,16]{3,2,1,0})->bf16[4,4,16,16]{3,1,2,0}}, allow_spmd_sharding_propagation_to_parameters={true,true,true}, allow_spmd_sharding_propagation_to_output={true}
+    clip.33 {
+      Arg_2.36 = bf16[] parameter(2)
+      broadcast.39 = bf16[4,16,4,16]{3,2,1,0} broadcast(Arg_2.36), dimensions={}
+      Arg_1.35 = bf16[] parameter(1)
+      broadcast.37 = bf16[4,16,4,16]{3,2,1,0} broadcast(Arg_1.35), dimensions={}
+      Arg_0.34 = bf16[4,16,4,16]{3,2,1,0} parameter(0)
+      maximum.38 = bf16[4,16,4,16]{3,2,1,0} maximum(broadcast.37, Arg_0.34)
+      ROOT minimum.40 = bf16[4,16,4,16]{3,2,1,0} minimum(broadcast.39, maximum.38)
+    } // clip.33
+    ENTRY main.106 {
+      constant.99 = f32[] constant(1)
+      broadcast.99 = f32[1,1,1,1]{3,2,1,0} broadcast(constant.99), dimensions={}
+      Arg_0.1 = bf16[4,16,4,16]{3,2,1,0} parameter(0)
+      constant.6 = bf16[] constant(1)
+      broadcast.7 = bf16[4,16,4,16]{3,2,1,0} broadcast(constant.6), dimensions={}
+      divide.8 = bf16[4,16,4,16]{3,2,1,0} divide(Arg_0.1, broadcast.7)
+      constant.5 = bf16[] constant(-448)
+      constant.4 = bf16[] constant(448)
+      call.17 = bf16[4,16,4,16]{3,2,1,0} call(divide.8, constant.5, constant.4), to_apply=clip.33
+      convert.18 = f8e4m3fn[4,16,4,16]{3,2,1,0} convert(call.17)
+      convert.19 = bf16[4,16,4,16]{3,2,1,0} convert(convert.18)
+      Arg_1.2 = bf16[4,16,4,16]{3,2,1,0} parameter(1)
+      divide.20 = bf16[4,16,4,16]{3,2,1,0} divide(Arg_1.2, broadcast.7)
+      call.29 = bf16[4,16,4,16]{3,2,1,0} call(divide.20, constant.5, constant.4), to_apply=clip.33
+      convert.30 = f8e4m3fn[4,16,4,16]{3,2,1,0} convert(call.29)
+      convert.31 = bf16[4,16,4,16]{3,2,1,0} convert(convert.30)
+      Arg_2.3 = bf16[4,16,4,16]{3,2,1,0} parameter(2)
+      divide.32 = bf16[4,16,4,16]{3,2,1,0} divide(Arg_2.3, broadcast.7)
+      call.41 = bf16[4,16,4,16]{3,2,1,0} call(divide.32, constant.5, constant.4), to_apply=clip.33
+      convert.42 = f8e4m3fn[4,16,4,16]{3,2,1,0} convert(call.41)
+      convert.43 = bf16[4,16,4,16]{3,2,1,0} convert(convert.42)
+      custom-call.21.0 = (f8e4m3fn[4,4,16,16]{3,1,2,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, u8[16]{0}) custom-call(convert.18, convert.30, convert.42, broadcast.99, broadcast.99, /*index=5*/broadcast.99, broadcast.99, broadcast.99, broadcast.99), custom_call_target="__cudnn$fmhaSoftmax$f8", operand_layout_constraints={f8e4m3fn[4,16,4,16]{3,2,1,0}, f8e4m3fn[4,16,4,16]{3,2,1,0}, f8e4m3fn[4,16,4,16]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}, f32[1,1,1,1]{3,2,1,0}}
+      get-tuple-element.5.0 = f8e4m3fn[4,4,16,16]{3,1,2,0} get-tuple-element(custom-call.21.0), index=0
+      ROOT out = bf16[4,4,16,16]{3,1,2,0} convert(get-tuple-element.5.0)
+    } // main.106
+  )";  // NOLINT
+    EXPECT_TRUE(RunAndCompareTwoModules(hlo_string, hlo_string_ref,
+                                        ErrorSpec{1e-2, 1e-2}));
+  }
+};
+
 // BMM1 - Scale - CausalMask - Softmax - BMM2
 XLA_TEST_F(FlashAttentionBMMScaleCausalMaskSoftmaxBMM,
            Flash_Attention_BMM1_CausalMask_Softmax_BMM2_BF16) {
@@ -1149,6 +1238,12 @@ XLA_TEST_F(FlashAttentionBMMScaleSoftmaxBMM,
 XLA_TEST_F(FlashAttentionBMMScalePaddingMaskSoftmaxBMM,
            Flash_Attention_Training_BMM1_PaddingMask_Softmax_BMM2_BF16) {
   TestImpl_Flash_Attention_Training_BMM1_PaddingMask_Softmax_BMM2<bfloat16>();
+}
+
+// BMM1 - Scale - Softmax - BMM2 fp8
+XLA_TEST_F(FlashAttentionBMMScalePaddingMaskSoftmaxBMMF8,
+           Flash_Attention_Inference_BMM1_NoMask_Softmax_BMM2_F8) {
+  TestImpl_Flash_Attention_Inference_BMM1_NoMask_Softmax_BMM2_F8();
 }
 }  // namespace
 }  // namespace gpu

--- a/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
@@ -165,7 +165,7 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     TF_ASSIGN_OR_RETURN(
         const auto gpu_config,
         custom_call->backend_config<xla::gpu::GpuBackendConfig>());
-    const xla::gpu::CudnnfMHABackendConfig& config =
+    const xla::gpu::CudnnfMHABackendConfig &config =
         gpu_config.cudnn_fmha_backend_config();
     Shape intermediate_tensor_shape(config.intermediate_tensor_shape());
 
@@ -186,23 +186,22 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
         MatmulTensorDescriptor rhs_bmm2,
         MatmulTensorDescriptorFor(custom_call->operand(2)->shape(),
                                   config.bmm2_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(TensorDescriptor output,
-                        TensorDescriptorFor(
-                            ShapeUtil::GetSubshape(custom_call->shape(), {0})));
-                                        
+    TF_ASSIGN_OR_RETURN(
+        TensorDescriptor output,
+        TensorDescriptorFor(ShapeUtil::GetSubshape(custom_call->shape(), {0})));
+
     std::optional<se::dnn::TensorDescriptor> activation;
     bool has_activation =
-        xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 5;    
+        xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 5;
     if (has_activation) {
       TF_ASSIGN_OR_RETURN(
-          activation,TensorDescriptorFor(
-                         ShapeUtil::GetSubshape(custom_call->shape(), {3})));
+          activation, TensorDescriptorFor(
+                          ShapeUtil::GetSubshape(custom_call->shape(), {3})));
     }
     TF_ASSIGN_OR_RETURN(
         se::gpu::CudnnGraph graph,
         se::gpu::GetCudnnFlashAttentionF8OperationGraph(
-            dnn_support, lhs_bmm1, rhs_bmm1,
-            rhs_bmm2, output, activation,
+            dnn_support, lhs_bmm1, rhs_bmm1, rhs_bmm2, output, activation,
             static_cast<float>(config.fmha_scale()), dnn_mask_type));
     return std::move(graph);
   } else {
@@ -342,7 +341,7 @@ class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
   }
 
   absl::Status HandleCustomCall(HloInstruction *hlo) override {
-    if (!IsCustomCallTofMHA(*hlo) && !IsCustomCallTofMHAF8(*hlo)) {      
+    if (!IsCustomCallTofMHA(*hlo) && !IsCustomCallTofMHAF8(*hlo)) {
       return absl::OkStatus();
     }
 

--- a/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
@@ -159,6 +159,57 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
             static_cast<float>(config.fmha_scale()), dropout_rate > 0.0,
             dropout_rate, dnn_mask_type));
     return std::move(graph);
+  } else if (IsFwdCustomCallTofMHAF8(*custom_call)) {
+    TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
+                        xla::gpu::GetCudnnfMHAKind(custom_call));
+    TF_ASSIGN_OR_RETURN(
+        const auto gpu_config,
+        custom_call->backend_config<xla::gpu::GpuBackendConfig>());
+    const xla::gpu::CudnnfMHABackendConfig& config =
+        gpu_config.cudnn_fmha_backend_config();
+    Shape intermediate_tensor_shape(config.intermediate_tensor_shape());
+    // output_shapes only holds output and activation but not amax_s or amax_o.
+    absl::InlinedVector<Shape, 2> output_shapes = {
+        ShapeUtil::GetSubshape(custom_call->shape(), {0})};
+
+    bool has_activation =
+        xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 5;
+    if (has_activation) {
+      output_shapes.push_back(
+          ShapeUtil::GetSubshape(custom_call->shape(), {3}));
+    }
+    TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
+                        AsCudnnFmhaMaskKind(config.mask_type()));
+    TF_ASSIGN_OR_RETURN(
+        se::dnn::FMHAMaskKind dnn_mask_type,
+        GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
+    TF_ASSIGN_OR_RETURN(
+        MatmulTensorDescriptor lhs_bmm1,
+        MatmulTensorDescriptorFor(custom_call->operand(0)->shape(),
+                                  config.bmm1_dot_dimension_numbers(), LHS));
+    TF_ASSIGN_OR_RETURN(
+        MatmulTensorDescriptor rhs_bmm1,
+        MatmulTensorDescriptorFor(custom_call->operand(1)->shape(),
+                                  config.bmm1_dot_dimension_numbers(), RHS));
+    TF_ASSIGN_OR_RETURN(
+        MatmulTensorDescriptor rhs_bmm2,
+        MatmulTensorDescriptorFor(custom_call->operand(2)->shape(),
+                                  config.bmm2_dot_dimension_numbers(), RHS));
+    TF_ASSIGN_OR_RETURN(TensorDescriptor output,
+                        TensorDescriptorFor(output_shapes[0]));
+                                        
+    std::optional<se::dnn::TensorDescriptor> activation;
+    if (output_shapes.size() > 1) {
+      const Shape &activation_shape = output_shapes.back();
+      TF_ASSIGN_OR_RETURN(activation, TensorDescriptorFor(activation_shape));
+    }
+    TF_ASSIGN_OR_RETURN(
+        se::gpu::CudnnGraph graph,
+        se::gpu::GetCudnnFlashAttentionF8OperationGraph(
+            dnn_support, lhs_bmm1, rhs_bmm1,
+            rhs_bmm2, output, activation,
+            static_cast<float>(config.fmha_scale()), dnn_mask_type));
+    return std::move(graph);
   } else {
     TF_ASSIGN_OR_RETURN(
         auto gpu_config,
@@ -296,7 +347,7 @@ class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
   }
 
   absl::Status HandleCustomCall(HloInstruction *hlo) override {
-    if (!IsCustomCallTofMHA(*hlo)) {
+    if (!IsCustomCallTofMHA(*hlo) && !IsCustomCallTofMHAF8(*hlo)) {      
       return absl::OkStatus();
     }
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -4972,7 +4972,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     const dnn::TensorDescriptor& o_descriptor,
     const std::optional<dnn::TensorDescriptor> bias_descriptor,
     const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    const float scale, const bool use_dropout,
+    double scale, const bool use_dropout,
     const std::optional<double> dropout_rate,
     const dnn::FMHAMaskKind mask_type) {
   using cudnn_frontend::graph::Tensor_attributes;
@@ -5013,7 +5013,6 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
                        .set_dim(q_descriptor.GetCudnnCompatibleDimensions(true))
                        .set_stride(q_descriptor.GetCudnnCompatibleStrides(true))
                        .set_uid(next_uid()));
-  auto dim = k_descriptor.GetCudnnCompatibleDimensions(true);
 
   std::shared_ptr<Tensor_attributes> k_tensor =
       graph.tensor(Tensor_attributes()
@@ -5147,7 +5146,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
     const dnn::MatmulTensorDescriptor& v_descriptor,
     const dnn::TensorDescriptor& o_descriptor,
     const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    const float scale, const dnn::FMHAMaskKind mask_type) {
+    double scale, const dnn::FMHAMaskKind mask_type) {
   using cudnn_frontend::graph::Tensor_attributes;
 
 #if CUDNN_VERSION >= 90000
@@ -5185,7 +5184,6 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
                        .set_dim(q_descriptor.GetCudnnCompatibleDimensions(true))
                        .set_stride(q_descriptor.GetCudnnCompatibleStrides(true))
                        .set_uid(next_uid()));
-  auto dim = k_descriptor.GetCudnnCompatibleDimensions(true);
 
   std::shared_ptr<Tensor_attributes> k_tensor =
       graph.tensor(Tensor_attributes()

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5140,6 +5140,144 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
 #endif
 }
 
+absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
+    dnn::DnnSupport& dnn_support,
+    const dnn::MatmulTensorDescriptor& q_descriptor,
+    const dnn::MatmulTensorDescriptor& k_descriptor,
+    const dnn::MatmulTensorDescriptor& v_descriptor,
+    const dnn::TensorDescriptor& o_descriptor,
+    const std::optional<dnn::TensorDescriptor> stats_descriptor,
+    const float scale, const dnn::FMHAMaskKind mask_type) {
+  using cudnn_frontend::graph::Tensor_attributes;
+
+#if CUDNN_VERSION >= 90000
+  if (VLOG_IS_ON(4)) {
+    VLOG(4) << "\n bmm1_lhs(q): " << q_descriptor.ToString()
+            << "\n bmm1_rhs(k): " << k_descriptor.ToString()
+            << "\n bmm2_rhs(v): " << v_descriptor.ToString()
+            << "\n out(o): " << o_descriptor.ToString()
+            << "\n scale: " << scale;
+
+    if (stats_descriptor) {
+      VLOG(4) << "\n activation(s): " << stats_descriptor->ToString();
+    }
+  }
+
+  cudnn_frontend::graph::Graph graph;
+  dnn::DataType q_type = q_descriptor.type();
+  dnn::DataType k_type = k_descriptor.type();
+  dnn::DataType v_type = v_descriptor.type();
+  dnn::DataType o_type = o_descriptor.type();
+  if (!(q_type == k_type && k_type == v_type && v_type == o_type)) {
+    return absl::InternalError("Input datatypes do not match");
+  }
+  cudnn_frontend::DataType_t ioDataType = ToCudnnFrontendDataType(q_type);
+
+  graph.set_intermediate_data_type(cudnn_frontend::DataType_t::FLOAT)
+      .set_io_data_type(ioDataType)
+      .set_compute_data_type(cudnn_frontend::DataType_t::FLOAT);
+
+  auto next_uid = [uid = 0]() mutable -> int { return CuDnnTensorUID(uid++); };
+
+  std::shared_ptr<Tensor_attributes> q_tensor =
+      graph.tensor(Tensor_attributes()
+                       .set_name("Q")
+                       .set_dim(q_descriptor.GetCudnnCompatibleDimensions(true))
+                       .set_stride(q_descriptor.GetCudnnCompatibleStrides(true))
+                       .set_uid(next_uid()));
+  auto dim = k_descriptor.GetCudnnCompatibleDimensions(true);
+
+  std::shared_ptr<Tensor_attributes> k_tensor =
+      graph.tensor(Tensor_attributes()
+                       .set_name("K")
+                       .set_dim(k_descriptor.GetCudnnCompatibleDimensions(true))
+                       .set_stride(k_descriptor.GetCudnnCompatibleStrides(true))
+                       .set_uid(next_uid()));
+  std::shared_ptr<Tensor_attributes> v_tensor = graph.tensor(
+      Tensor_attributes()
+          .set_name("V")
+          .set_dim(v_descriptor.GetCudnnCompatibleDimensions(false))
+          .set_stride(v_descriptor.GetCudnnCompatibleStrides(false))
+          .set_uid(next_uid()));
+
+  auto descale_q =
+      graph.tensor(Tensor_attributes()
+                       .set_name("Descale_Q")
+                       .set_dim({1, 1, 1, 1})
+                       .set_stride({1, 1, 1, 1})
+                       .set_data_type(cudnn_frontend::DataType_t::FLOAT)
+                       .set_uid(next_uid()));
+  auto descale_k = graph.tensor_like(descale_q, "Descale_K");
+  auto descale_v = graph.tensor_like(descale_q, "Descale_V");
+  auto descale_s = graph.tensor_like(descale_q, "Descale_S");
+  auto scale_s = graph.tensor_like(descale_q, "Scale_S");
+  auto scale_o = graph.tensor_like(descale_q, "Scale_O");
+
+  descale_k->set_uid(next_uid());
+  descale_v->set_uid(next_uid());
+  descale_s->set_uid(next_uid());
+  scale_s->set_uid(next_uid());
+  scale_o->set_uid(next_uid());
+
+  // Setting sdpa, and is_inference
+  bool is_causal = mask_type == dnn::FMHAMaskKind::CAUSAL;
+  cudnn_frontend::graph::SDPA_fp8_attributes sdpa_fp8_options;
+  sdpa_fp8_options.set_name("sdpa_fp8")
+      .set_is_inference(stats_descriptor == std::nullopt)
+      .set_causal_mask(is_causal)
+      .set_attn_scale(scale);
+
+  // Add SDPA to the graph.
+  auto [o_tensor, stats_tensor, amax_s, amax_o] =
+      graph.sdpa_fp8(q_tensor, k_tensor, v_tensor, descale_q, descale_k,
+                     descale_v, descale_s, scale_s, scale_o, sdpa_fp8_options);
+
+  // Set output attributes.
+  o_tensor->set_name("O")
+      .set_output(true)
+      .set_dim(o_descriptor.dimensions())
+      .set_stride(o_descriptor.GetLogicalStrides())
+      .set_uid(next_uid());
+  amax_s->set_output(true)
+      .set_dim({1, 1, 1, 1})
+      .set_data_type(cudnn_frontend::DataType_t::FLOAT)
+      .set_uid(next_uid());
+  amax_o->set_output(true)
+      .set_dim({1, 1, 1, 1})
+      .set_data_type(cudnn_frontend::DataType_t::FLOAT)
+      .set_uid(next_uid());
+
+  if (stats_descriptor.has_value()) {
+    cudnn_frontend::DataType_t statsType =
+        ToCudnnFrontendDataType(stats_descriptor->type());
+    auto stat_dims = stats_descriptor->dimensions();
+    auto stat_strides = stats_descriptor->GetLogicalStrides();
+    stat_dims.push_back(1);
+    stat_strides.push_back(1);
+    stats_tensor->set_name("stats")
+        .set_output(true)
+        .set_data_type(statsType)
+        .set_dim(stat_dims)
+        .set_stride(stat_strides)
+        .set_uid(next_uid());
+  }
+  CudnnGraph cudnnGraph(std::move(graph));
+  TF_RETURN_IF_ERROR(cudnnGraph.Prepare(
+      dnn_support, NumericOptions{/*require_determinism=*/false,
+                                  /*allow_tf32=*/true}));
+  TF_RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/std::nullopt));
+
+  if (VLOG_IS_ON(4)) {
+    VLOG(4) << "\b workspace size:" << cudnnGraph.Graph().get_workspace_size();
+    VLOG(4) << "\b flash attention operation graph: " << graph;
+  }
+  return cudnnGraph;
+#else
+  return absl::UnimplementedError(
+      "Cudnn flash attention only supported with Cudnn >= 9.0.0");
+#endif
+}
+
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
     const dnn::MatmulTensorDescriptor& k_desc,

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5148,7 +5148,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
     const dnn::FMHAMaskKind mask_type) {
   using cudnn_frontend::graph::Tensor_attributes;
 
-#if CUDNN_VERSION >= 90000
+#if CUDNN_VERSION >= 90100
   if (VLOG_IS_ON(4)) {
     VLOG(4) << "\n bmm1_lhs(q): " << q_descriptor.ToString()
             << "\n bmm1_rhs(k): " << k_descriptor.ToString()
@@ -5271,7 +5271,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
   return cudnnGraph;
 #else
   return absl::UnimplementedError(
-      "Cudnn flash attention only supported with Cudnn >= 9.0.0");
+      "Cudnn flash attention only supported with Cudnn >= 9.1.0");
 #endif
 }
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -4971,9 +4971,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     const dnn::MatmulTensorDescriptor& v_descriptor,
     const dnn::TensorDescriptor& o_descriptor,
     const std::optional<dnn::TensorDescriptor> bias_descriptor,
-    const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    double scale, const bool use_dropout,
-    const std::optional<double> dropout_rate,
+    const std::optional<dnn::TensorDescriptor> stats_descriptor, double scale,
+    const bool use_dropout, const std::optional<double> dropout_rate,
     const dnn::FMHAMaskKind mask_type) {
   using cudnn_frontend::graph::Tensor_attributes;
 
@@ -5145,8 +5144,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
     const dnn::MatmulTensorDescriptor& k_descriptor,
     const dnn::MatmulTensorDescriptor& v_descriptor,
     const dnn::TensorDescriptor& o_descriptor,
-    const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    double scale, const dnn::FMHAMaskKind mask_type) {
+    const std::optional<dnn::TensorDescriptor> stats_descriptor, double scale,
+    const dnn::FMHAMaskKind mask_type) {
   using cudnn_frontend::graph::Tensor_attributes;
 
 #if CUDNN_VERSION >= 90000

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -696,7 +696,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     const dnn::TensorDescriptor& o_descriptor,
     const std::optional<dnn::TensorDescriptor> bias_descriptor,
     const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    const float scale, const bool use_dropout,
+    double scale, const bool use_dropout,
     const std::optional<double> dropout_rate,
     const dnn::FMHAMaskKind mask_type);
 
@@ -707,7 +707,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
     const dnn::MatmulTensorDescriptor& v_descriptor,
     const dnn::TensorDescriptor& o_descriptor,
     const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    const float scale, const dnn::FMHAMaskKind mask_type);
+    double scale, const dnn::FMHAMaskKind mask_type);
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -700,6 +700,15 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     const std::optional<double> dropout_rate,
     const dnn::FMHAMaskKind mask_type);
 
+absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
+    dnn::DnnSupport& dnn_support,
+    const dnn::MatmulTensorDescriptor& q_descriptor,
+    const dnn::MatmulTensorDescriptor& k_descriptor,
+    const dnn::MatmulTensorDescriptor& v_descriptor,
+    const dnn::TensorDescriptor& o_descriptor,
+    const std::optional<dnn::TensorDescriptor> stats_descriptor,
+    const float scale, const dnn::FMHAMaskKind mask_type);
+
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
     const dnn::MatmulTensorDescriptor& k_desc,

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -695,9 +695,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     const dnn::MatmulTensorDescriptor& v_descriptor,
     const dnn::TensorDescriptor& o_descriptor,
     const std::optional<dnn::TensorDescriptor> bias_descriptor,
-    const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    double scale, const bool use_dropout,
-    const std::optional<double> dropout_rate,
+    const std::optional<dnn::TensorDescriptor> stats_descriptor, double scale,
+    const bool use_dropout, const std::optional<double> dropout_rate,
     const dnn::FMHAMaskKind mask_type);
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
@@ -706,8 +705,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
     const dnn::MatmulTensorDescriptor& k_descriptor,
     const dnn::MatmulTensorDescriptor& v_descriptor,
     const dnn::TensorDescriptor& o_descriptor,
-    const std::optional<dnn::TensorDescriptor> stats_descriptor,
-    double scale, const dnn::FMHAMaskKind mask_type);
+    const std::optional<dnn::TensorDescriptor> stats_descriptor, double scale,
+    const dnn::FMHAMaskKind mask_type);
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,


### PR DESCRIPTION
Add cudnn frontend support of scaled dot product attention for FP8 forward. doc [here](https://github.com/NVIDIA/cudnn-frontend/blob/98ca4e1941fe3263f128f74f10063a3ea35c7019/docs/operations/Attention.md).

NOTE: this feature relies on cudnn-frontend v1.6.1 which is not in XLA yet.