### PR TITLE
[NVIDIA GPU] Use memcpy for intra-node all-to-all

### DIFF
--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2133,7 +2133,9 @@ absl::Status IrEmitterUnnested::EmitNcclThunk(
       thunk_info.profile_annotation = async_start->name();
     }
     auto thunk = std::make_unique<NcclThunkType>(
-        thunk_info, NcclApi::Default(), inst, /*buffers=*/std::move(buffers));
+        thunk_info, NcclApi::Default(), inst,
+        /*buffers=*/std::move(buffers),
+        ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
     GetCollectivesAsyncEvents().insert({async_start, thunk->async_events()});
     AddThunkToThunkSequence(std::move(thunk));
     return absl::OkStatus();

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -823,6 +823,7 @@ cc_library(
         "//xla/service:collective_ops_utils",
         "//xla/service/gpu:ir_emission_utils",
         "//xla/stream_executor",
+        "//xla/tsl/concurrency:async_value",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@llvm-project//mlir:IR",

--- a/xla/service/gpu/runtime/nccl_all_gather_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_all_gather_thunk.cc
@@ -66,7 +66,8 @@ absl::Status CheckImplementableInst(const HloAllGatherInstruction* inst) {
 
 NcclAllGatherStartThunk::NcclAllGatherStartThunk(
     ThunkInfo thunk_info, NcclApi* nccl_api,
-    const HloAllGatherInstruction* inst, std::vector<Buffer> buffers)
+    const HloAllGatherInstruction* inst, std::vector<Buffer> buffers,
+    bool p2p_memcpy_enabled)
     : NcclCollectiveThunk(Thunk::kNcclAllGatherStart, thunk_info, nccl_api,
                           IsSyncCollective(inst)),
       config_(impl::GetNcclAllGatherConfig(inst)),

--- a/xla/service/gpu/runtime/nccl_all_gather_thunk.h
+++ b/xla/service/gpu/runtime/nccl_all_gather_thunk.h
@@ -39,7 +39,8 @@ class NcclAllGatherStartThunk : public NcclCollectiveThunk {
  public:
   NcclAllGatherStartThunk(ThunkInfo thunk_info, NcclApi* nccl_api,
                           const HloAllGatherInstruction* inst,
-                          std::vector<Buffer> buffers);
+                          std::vector<Buffer> buffers,
+                          bool p2p_memcpy_enabled = false);
 
   static const char* GetHloOpName() { return "all-gather-start"; }
 

--- a/xla/service/gpu/runtime/nccl_all_reduce_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_all_reduce_thunk.cc
@@ -156,7 +156,8 @@ NcclAllReduceReduceScatterThunkBase::NcclAllReduceReduceScatterThunkBase(
 
 NcclAllReduceStartThunk::NcclAllReduceStartThunk(
     ThunkInfo thunk_info, NcclApi* nccl_api,
-    const HloAllReduceInstruction* inst, std::vector<Buffer> buffers)
+    const HloAllReduceInstruction* inst, std::vector<Buffer> buffers,
+    bool p2p_memcpy_enabled)
     : NcclAllReduceReduceScatterThunkBase(
           Thunk::kNcclAllReduceStart, thunk_info, nccl_api,
           impl::GetNcclAllReduceConfigInst(inst), std::move(buffers),
@@ -189,7 +190,8 @@ absl::Status NcclAllReduceStartThunk::RunNcclCollective(
 
 NcclReduceScatterStartThunk::NcclReduceScatterStartThunk(
     ThunkInfo thunk_info, NcclApi* nccl_api,
-    const HloReduceScatterInstruction* inst, std::vector<Buffer> buffers)
+    const HloReduceScatterInstruction* inst, std::vector<Buffer> buffers,
+    bool p2p_memcpy_enabled)
     : NcclAllReduceReduceScatterThunkBase(
           Thunk::kNcclReduceScatterStart, thunk_info, nccl_api,
           impl::GetNcclAllReduceConfigInst(inst), std::move(buffers),

--- a/xla/service/gpu/runtime/nccl_all_reduce_thunk.h
+++ b/xla/service/gpu/runtime/nccl_all_reduce_thunk.h
@@ -63,7 +63,8 @@ class NcclAllReduceStartThunk : public NcclAllReduceReduceScatterThunkBase {
  public:
   NcclAllReduceStartThunk(ThunkInfo thunk_info, NcclApi* nccl_api,
                           const HloAllReduceInstruction* inst,
-                          std::vector<Buffer> buffers);
+                          std::vector<Buffer> buffers,
+                          bool p2p_memcpy_enabled = false);
 
   static const char* GetHloOpName() { return "all-reduce-start"; }
 
@@ -87,7 +88,8 @@ class NcclReduceScatterStartThunk : public NcclAllReduceReduceScatterThunkBase {
  public:
   NcclReduceScatterStartThunk(ThunkInfo thunk_info, NcclApi* nccl_api,
                               const HloReduceScatterInstruction* inst,
-                              std::vector<Buffer> buffers);
+                              std::vector<Buffer> buffers,
+                              bool p2p_memcpy_enabled = false);
 
   static const char* GetHloOpName() { return "reduce-scatter-start"; }
 

--- a/xla/service/gpu/runtime/nccl_all_to_all_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_all_to_all_thunk.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/runtime/nccl_api.h"
+#include "xla/service/gpu/runtime/nccl_clique_key.h"
 #include "xla/service/gpu/runtime/nccl_collective_thunk.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -41,7 +42,6 @@ limitations under the License.
 
 namespace xla {
 namespace gpu {
-
 namespace {
 
 NcclAllToAllConfig GetNcclAllToAllConfig(const HloAllToAllInstruction* instr) {
@@ -58,11 +58,12 @@ NcclAllToAllConfig GetNcclAllToAllConfig(const HloAllToAllInstruction* instr) {
 NcclAllToAllStartThunk::NcclAllToAllStartThunk(
     ThunkInfo thunk_info, NcclApi* nccl_api,
     const HloAllToAllInstruction* instr,
-    std::vector<NcclCollectiveThunk::Buffer> buffers)
+    std::vector<NcclCollectiveThunk::Buffer> buffers, bool p2p_memcpy_enabled)
     : NcclCollectiveThunk(Thunk::kNcclAllToAllStart, thunk_info, nccl_api,
                           IsSyncCollective(instr)),
       config_(GetNcclAllToAllConfig(instr)),
-      buffers_(std::move(buffers)) {
+      buffers_(std::move(buffers)),
+      p2p_memcpy_enabled_(p2p_memcpy_enabled) {
   CHECK_EQ(config_.config.operand_count, buffers_.size());
 }
 
@@ -92,6 +93,15 @@ NcclAllToAllStartThunk::NcclAllToAllStartThunk(
   return GetNcclAllToAllConfig(instr).config.group_mode;
 }
 
+absl::Status NcclAllToAllStartThunk::Initialize(
+    const InitializeParams& params) {
+  TF_RETURN_IF_ERROR(NcclCollectiveThunk::Initialize(params));
+  device_count_ = params.local_device_count;
+  CHECK_GT(device_count_, 0);
+  VLOG(5) << "Local device count: " << device_count_;
+  return absl::OkStatus();
+}
+
 absl::Status NcclAllToAllStartThunk::RunNcclCollective(
     const ExecuteParams& params, se::Stream& stream,
     NcclCommHandleWrapper comm_wrapper) {
@@ -99,14 +109,44 @@ absl::Status NcclAllToAllStartThunk::RunNcclCollective(
       std::vector<DeviceBufferPair> device_buffers,
       ConvertToDeviceBuffers(params, buffers_,
                              config_.config.operand_element_type));
+  TF_ASSIGN_OR_RETURN(const int64_t current_id,
+                      GetCurrentId(params.collective_params, config_));
+  TF_ASSIGN_OR_RETURN(int32_t num_participants,
+                      nccl_api()->CommCount(comm_wrapper.comm_handle));
+  for (int64_t id = 0; id < num_participants; ++id) {
+    TF_RETURN_IF_ERROR(recv_ptr_map_.InitializeId(id, current_id));
+    TF_RETURN_IF_ERROR(recv_ptr_map_.InitializeId(current_id, id));
+  }
+
+  bool use_memcpy = is_local() && p2p_memcpy_enabled_;
   return xla::gpu::RunAllToAll(nccl_api(), config_.has_split_dimension,
-                               device_buffers, stream,
-                               comm_wrapper.comm_handle);
+                               device_buffers, stream, comm_wrapper.comm_handle,
+                               current_id, use_memcpy, recv_ptr_map_);
+}
+
+AsyncStreamKind NcclAllToAllStartThunk::GetAsyncStreamKind() const {
+  return (is_local() && p2p_memcpy_enabled_) ? AsyncStreamKind::kMemCpyP2P
+                                             : AsyncStreamKind::kCollective;
+}
+
+bool NcclAllToAllStartThunk::is_local() const {
+  for (const auto& replica_group : config_.config.replica_groups) {
+    const int64_t node_id = replica_group.replica_ids().at(0) / device_count_;
+    if (!absl::c_all_of(replica_group.replica_ids(),
+                        [this, node_id](const int64_t rank) {
+                          return rank / device_count_ == node_id;
+                        })) {
+      return false;
+    }
+  }
+  return true;
 }
 
 absl::Status RunAllToAll(NcclApi* nccl_api, bool has_split_dimension,
                          std::vector<DeviceBufferPair>& buffers,
-                         se::Stream& stream, NcclApi::NcclCommHandle comm) {
+                         se::Stream& stream, NcclApi::NcclCommHandle comm,
+                         int64_t current_id, bool use_memcpy,
+                         NcclAllToAllStartThunk::RecvPtrMap& recv_ptr_map) {
   int device_ordinal = stream.parent()->device_ordinal();
   VLOG(3) << "Performing all-to-all from device ordinal: " << device_ordinal;
   TF_RETURN_IF_ERROR(
@@ -114,7 +154,11 @@ absl::Status RunAllToAll(NcclApi* nccl_api, bool has_split_dimension,
 
   TF_ASSIGN_OR_RETURN(int32_t num_participants, nccl_api->CommCount(comm));
 
-  TF_RETURN_IF_ERROR(nccl_api->GroupStart());
+  if (use_memcpy) {
+    TF_RETURN_IF_ERROR(stream.BlockHostUntilDone());
+  } else {
+    TF_RETURN_IF_ERROR(nccl_api->GroupStart());
+  }
 
   // AllToAll can operate in two modes. Either it specifies a split dimension,
   // in which case inputs are split and outputs concatenated in that dimension
@@ -136,31 +180,80 @@ absl::Status RunAllToAll(NcclApi* nccl_api, bool has_split_dimension,
             NcclApi::Slice(buffer.destination_buffer, buffer.element_type,
                            peer * chunk_elements, chunk_elements);
 
-        TF_RETURN_IF_ERROR(nccl_api->Send(send_slice, buffer.element_type,
-                                          chunk_elements, peer, comm, &stream));
+        if (use_memcpy) {
+          TF_RETURN_IF_ERROR(
+              recv_ptr_map.PutRecvPtr(peer, current_id, recv_slice.opaque()));
+          TF_ASSIGN_OR_RETURN(auto recv_ptr,
+                              recv_ptr_map.GetRecvPtr(current_id, peer));
+          if (recv_ptr.IsUnavailable()) {
+            // TODO make BlockUntilReady support AsyncValueRef directly.
+            BlockUntilReady(recv_ptr.GetAsyncValue());
+          }
+          VLOG(3) << "Using memcpy, received target pointer: " << recv_ptr.get()
+                  << " current_id " << current_id << " target_id: " << peer;
+          VLOG(3) << current_id << " initiating memcpy to " << peer;
+          se::DeviceMemoryBase dst_addr = se::DeviceMemoryBase(recv_ptr.get());
+          TF_RETURN_IF_ERROR(
+              stream.MemcpyD2D(&dst_addr, send_slice, send_slice.size()));
+        } else {
+          TF_RETURN_IF_ERROR(nccl_api->Send(send_slice, buffer.element_type,
+                                            chunk_elements, peer, comm,
+                                            &stream));
 
-        TF_RETURN_IF_ERROR(nccl_api->Recv(recv_slice, buffer.element_type,
-                                          chunk_elements, peer, comm, &stream));
+          TF_RETURN_IF_ERROR(nccl_api->Recv(recv_slice, buffer.element_type,
+                                            chunk_elements, peer, comm,
+                                            &stream));
+        }
       }
     }
   } else {
     TF_RET_CHECK(buffers.size() == num_participants)
         << "Number of inputs didn't match the number of participants.";
 
-    for (size_t i = 0; i < buffers.size(); ++i) {
-      DeviceBufferPair& buffer = buffers[i];
+    for (size_t peer = 0; peer < buffers.size(); ++peer) {
+      DeviceBufferPair& buffer = buffers[peer];
 
-      TF_RETURN_IF_ERROR(
-          nccl_api->Send(buffer.source_buffer, buffer.element_type,
-                         buffer.element_count, i, comm, &stream));
+      if (use_memcpy) {
+        TF_RETURN_IF_ERROR(recv_ptr_map.PutRecvPtr(
+            peer, current_id, buffers[current_id].destination_buffer.opaque()));
+        TF_ASSIGN_OR_RETURN(auto recv_ptr,
+                            recv_ptr_map.GetRecvPtr(current_id, peer));
+        if (recv_ptr.IsUnavailable()) {
+          // TODO make BlockUntilReady support AsyncValueRef directly.
+          BlockUntilReady(recv_ptr.GetAsyncValue());
+        }
+        VLOG(3) << "Using double buffer memcpy, participanting pointers: "
+                << buffer.destination_buffer.opaque() << ", " << recv_ptr.get();
+        VLOG(3) << current_id << " initiating double buffer memcpy to " << peer;
 
-      TF_RETURN_IF_ERROR(
-          nccl_api->Recv(buffer.destination_buffer, buffer.element_type,
-                         buffer.element_count, i, comm, &stream));
+        // double buffer, exchange data with peer
+        se::DeviceMemoryBase dst_addr = se::DeviceMemoryBase(recv_ptr.get());
+        se::DeviceMemoryBase cur_addr =
+            se::DeviceMemoryBase(buffer.destination_buffer);
+        // TODO parallelize below copies on to two streams
+        TF_RETURN_IF_ERROR(stream.MemcpyD2D(&dst_addr, buffer.source_buffer,
+                                            buffer.source_buffer.size()));
+        TF_RETURN_IF_ERROR(
+            stream.MemcpyD2D(&cur_addr, buffers[peer].source_buffer,
+                             buffers[peer].source_buffer.size()));
+      } else {
+        TF_RETURN_IF_ERROR(
+            nccl_api->Send(buffer.source_buffer, buffer.element_type,
+                           buffer.element_count, peer, comm, &stream));
+
+        TF_RETURN_IF_ERROR(
+            nccl_api->Recv(buffer.destination_buffer, buffer.element_type,
+                           buffer.element_count, peer, comm, &stream));
+      }
     }
   }
 
-  return nccl_api->GroupEnd();
+  if (use_memcpy) {
+    TF_RETURN_IF_ERROR(stream.BlockHostUntilDone());
+  } else {
+    return nccl_api->GroupEnd();
+  }
+  return absl::OkStatus();
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/runtime/nccl_all_to_all_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_all_to_all_thunk.cc
@@ -134,19 +134,26 @@ absl::Status NcclAllToAllStartThunk::Initialize(
 
 absl::Status NcclAllToAllStartThunk::Cleanup(const CleanupParams& params) {
   if (p2p_memcpy_enabled_) {
-    TF_ASSIGN_OR_RETURN(const int64_t current_id,
-                        GetCurrentId(params.collective_params, config_));
-    if (send_pointer_maps_.count(current_id)) {
-      for (auto& [id, value] : send_pointer_maps_[current_id]) {
-        if (!value) { continue; }
+    const NcclStreamId stream_id = nccl_stream_id();
+    AsyncStreamKind stream_kind = GetAsyncStreamKind();
+    TF_ASSIGN_OR_RETURN(
+        NcclCommHandleWrapper comm_wrapper,
+        GetNcclComm(*params.collective_params, *params.collective_cliques,
+                    config().replica_groups, config().group_mode, stream_id,
+                    stream_kind));
+    TF_ASSIGN_OR_RETURN(int32_t num_participants,
+                        nccl_api()->CommCount(comm_wrapper.comm_handle));
+
+    int local_id = params.executor->device_ordinal() % num_participants;
+    if (send_pointer_maps_.count(local_id)) {
+      for (auto& [id, value] : send_pointer_maps_[local_id]) {
         if (!params.executor->HostMemoryUnregister((void*)value)) {
           VLOG(5) << "Unregistering host send pointer for memcpy failed.";
         }
       }
     }
-    if (receive_pointer_maps_.count(current_id)) {
-      for (auto& [id, value] : receive_pointer_maps_[current_id]) {
-        if (!value) { continue; }
+    if (receive_pointer_maps_.count(local_id)) {
+      for (auto& [id, value] : receive_pointer_maps_[local_id]) {
         if (!params.executor->HostMemoryUnregister((void*)value)) {
           VLOG(5) << "Unregistering host recv pointer for memcpy failed.";
         }
@@ -163,17 +170,15 @@ absl::Status NcclAllToAllStartThunk::RunNcclCollective(
       std::vector<DeviceBufferPair> device_buffers,
       ConvertToDeviceBuffers(params, buffers_,
                              config_.config.operand_element_type));
-  TF_ASSIGN_OR_RETURN(const int64_t current_id,
-                      GetCurrentId(params.collective_params, config_));
   TF_ASSIGN_OR_RETURN(int32_t num_participants,
                       nccl_api()->CommCount(comm_wrapper.comm_handle));
 
   if (is_local() && p2p_memcpy_enabled_) {
+    int local_id = stream.parent()->device_ordinal() % num_participants;
     return xla::gpu::RunMemCpyAllToAll(
         nccl_api(), config_.has_split_dimension, device_buffers, stream,
-        comm_wrapper.comm_handle, current_id,
-        send_pointer_maps_[current_id],
-        receive_pointer_maps_[current_id]);
+        comm_wrapper.comm_handle, send_pointer_maps_[local_id],
+        receive_pointer_maps_[local_id]);
   }
   return xla::gpu::RunAllToAll(nccl_api(), config_.has_split_dimension,
                                device_buffers, stream,
@@ -260,9 +265,9 @@ absl::Status RunAllToAll(NcclApi* nccl_api, bool has_split_dimension,
 absl::Status RunMemCpyAllToAll(
     NcclApi* nccl_api, bool has_split_dimension,
     std::vector<DeviceBufferPair>& buffers, se::Stream& stream,
-    NcclApi::NcclCommHandle comm, int64_t current_id,
-    std::unordered_map<int64_t, uint64_t>& send_pointer_map,
-    std::unordered_map<int64_t, uint64_t>& receive_pointer_map) {
+    NcclApi::NcclCommHandle comm,
+    absl::node_hash_map<int64_t, uint64_t>& send_pointer_map,
+    absl::node_hash_map<int64_t, uint64_t>& receive_pointer_map) {
   int device_ordinal = stream.parent()->device_ordinal();
   VLOG(3) << "Performing mem-copy-all-to-all from device ordinal: "
           << device_ordinal;

--- a/xla/service/gpu/runtime/nccl_all_to_all_thunk.h
+++ b/xla/service/gpu/runtime/nccl_all_to_all_thunk.h
@@ -19,12 +19,15 @@ limitations under the License.
 #include <cstdint>
 #include <vector>
 
+#include "absl/container/node_hash_map.h"
 #include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/gpu/runtime/nccl_api.h"
 #include "xla/service/gpu/runtime/nccl_collective_thunk.h"
 #include "xla/stream_executor/stream.h"
+#include "xla/tsl/concurrency/async_value_ref.h"
 
 namespace xla {
 namespace gpu {
@@ -37,15 +40,73 @@ struct NcclAllToAllConfig {
 // Thunk that performs a NCCL-based All-to-All among CUDA GPU-based replicas.
 class NcclAllToAllStartThunk : public NcclCollectiveThunk {
  public:
+  class RecvPtrMap {
+   public:
+    bool IsInitialized(int64_t send_id, int64_t receive_id) {
+      absl::MutexLock lock(&mutex_);
+      return recv_ptrs_.find(send_id) != recv_ptrs_.end() &&
+             recv_ptrs_.at(send_id).find(receive_id) !=
+                 recv_ptrs_.at(send_id).end();
+    }
+
+    absl::Status InitializeId(int64_t send_id, int64_t receive_id) {
+      absl::MutexLock lock(&mutex_);
+      if (recv_ptrs_.find(send_id) == recv_ptrs_.end()) {
+        recv_ptrs_[send_id] =
+            absl::node_hash_map<int64_t, tsl::AsyncValueRef<void*>>();
+      }
+      if (recv_ptrs_.at(send_id).find(receive_id) ==
+          recv_ptrs_.at(send_id).end()) {
+        recv_ptrs_.at(send_id)[receive_id] =
+            tsl::MakeUnconstructedAsyncValueRef<void*>();
+      }
+      return absl::OkStatus();
+    }
+
+    absl::Status PutRecvPtr(int64_t send_id, int64_t receive_id, void* ptr) {
+      if (!IsInitialized(send_id, receive_id)) {
+        return absl::InternalError(absl::StrCat("Send-receive pair ", send_id,
+                                                ", ", receive_id,
+                                                " has not been initialized!"));
+      }
+      absl::MutexLock lock(&mutex_);
+      if (recv_ptrs_.at(send_id).at(receive_id).IsUnavailable()) {
+        VLOG(3) << "Putting pointer: " << ptr << " for send_id " << send_id
+                << ", and receive_id " << receive_id;
+        recv_ptrs_.at(send_id).at(receive_id).emplace(ptr);
+      }
+      return absl::OkStatus();
+    }
+
+    absl::StatusOr<tsl::AsyncValueRef<void*>> GetRecvPtr(int64_t send_id,
+                                                         int64_t receive_id) {
+      if (!IsInitialized(send_id, receive_id)) {
+        return absl::InternalError(absl::StrCat("Send-receive pair ", send_id,
+                                                ", ", receive_id,
+                                                " has not been initialized!"));
+      }
+      absl::MutexLock lock(&mutex_);
+      return recv_ptrs_.at(send_id).at(receive_id);
+    }
+
+   private:
+    absl::Mutex mutex_;
+    absl::node_hash_map<int64_t,
+                        absl::node_hash_map<int64_t, tsl::AsyncValueRef<void*>>>
+        recv_ptrs_ ABSL_GUARDED_BY(mutex_);
+  };
+
   NcclAllToAllStartThunk(ThunkInfo thunk_info, NcclApi* nccl_api,
                          const HloAllToAllInstruction* instr,
-                         std::vector<Buffer> buffers);
+                         std::vector<Buffer> buffers, bool p2p_memcpy_enabled);
 
   // Returns whether the given instruction can be lowered to a nccl all-to-all
   // call.
   static absl::Status CheckImplementable(const HloAllToAllInstruction* instr,
                                          int64_t replica_count,
                                          int64_t partition_count);
+
+  absl::Status Initialize(const InitializeParams& params) override;
 
   static const char* GetHloOpName() { return "all-to-all-start"; }
 
@@ -58,14 +119,23 @@ class NcclAllToAllStartThunk : public NcclCollectiveThunk {
                                  se::Stream& stream,
                                  NcclCommHandleWrapper comm_wrapper) override;
 
+  AsyncStreamKind GetAsyncStreamKind() const override;
+
+  bool is_local() const;
+
  private:
   const NcclAllToAllConfig config_;
   const std::vector<Buffer> buffers_;
+  RecvPtrMap recv_ptr_map_;
+  int64_t device_count_ = 1;
+  bool p2p_memcpy_enabled_ = false;
 };
 
 absl::Status RunAllToAll(NcclApi* nccl_api, bool has_split_dimension,
                          std::vector<DeviceBufferPair>& buffers,
-                         se::Stream& stream, NcclApi::NcclCommHandle comm);
+                         se::Stream& stream, NcclApi::NcclCommHandle comm,
+                         int64_t current_id, bool use_memcpy,
+                         NcclAllToAllStartThunk::RecvPtrMap& recv_ptr_map);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/runtime/nccl_all_to_all_thunk.h
+++ b/xla/service/gpu/runtime/nccl_all_to_all_thunk.h
@@ -40,62 +40,6 @@ struct NcclAllToAllConfig {
 // Thunk that performs a NCCL-based All-to-All among CUDA GPU-based replicas.
 class NcclAllToAllStartThunk : public NcclCollectiveThunk {
  public:
-  class RecvPtrMap {
-   public:
-    bool IsInitialized(int64_t send_id, int64_t receive_id) {
-      absl::MutexLock lock(&mutex_);
-      return recv_ptrs_.find(send_id) != recv_ptrs_.end() &&
-             recv_ptrs_.at(send_id).find(receive_id) !=
-                 recv_ptrs_.at(send_id).end();
-    }
-
-    absl::Status InitializeId(int64_t send_id, int64_t receive_id) {
-      absl::MutexLock lock(&mutex_);
-      if (recv_ptrs_.find(send_id) == recv_ptrs_.end()) {
-        recv_ptrs_[send_id] =
-            absl::node_hash_map<int64_t, tsl::AsyncValueRef<void*>>();
-      }
-      if (recv_ptrs_.at(send_id).find(receive_id) ==
-          recv_ptrs_.at(send_id).end()) {
-        recv_ptrs_.at(send_id)[receive_id] =
-            tsl::MakeUnconstructedAsyncValueRef<void*>();
-      }
-      return absl::OkStatus();
-    }
-
-    absl::Status PutRecvPtr(int64_t send_id, int64_t receive_id, void* ptr) {
-      if (!IsInitialized(send_id, receive_id)) {
-        return absl::InternalError(absl::StrCat("Send-receive pair ", send_id,
-                                                ", ", receive_id,
-                                                " has not been initialized!"));
-      }
-      absl::MutexLock lock(&mutex_);
-      if (recv_ptrs_.at(send_id).at(receive_id).IsUnavailable()) {
-        VLOG(3) << "Putting pointer: " << ptr << " for send_id " << send_id
-                << ", and receive_id " << receive_id;
-        recv_ptrs_.at(send_id).at(receive_id).emplace(ptr);
-      }
-      return absl::OkStatus();
-    }
-
-    absl::StatusOr<tsl::AsyncValueRef<void*>> GetRecvPtr(int64_t send_id,
-                                                         int64_t receive_id) {
-      if (!IsInitialized(send_id, receive_id)) {
-        return absl::InternalError(absl::StrCat("Send-receive pair ", send_id,
-                                                ", ", receive_id,
-                                                " has not been initialized!"));
-      }
-      absl::MutexLock lock(&mutex_);
-      return recv_ptrs_.at(send_id).at(receive_id);
-    }
-
-   private:
-    absl::Mutex mutex_;
-    absl::node_hash_map<int64_t,
-                        absl::node_hash_map<int64_t, tsl::AsyncValueRef<void*>>>
-        recv_ptrs_ ABSL_GUARDED_BY(mutex_);
-  };
-
   NcclAllToAllStartThunk(ThunkInfo thunk_info, NcclApi* nccl_api,
                          const HloAllToAllInstruction* instr,
                          std::vector<Buffer> buffers, bool p2p_memcpy_enabled);
@@ -107,6 +51,8 @@ class NcclAllToAllStartThunk : public NcclCollectiveThunk {
                                          int64_t partition_count);
 
   absl::Status Initialize(const InitializeParams& params) override;
+
+  absl::Status Cleanup(const CleanupParams& params) override;
 
   static const char* GetHloOpName() { return "all-to-all-start"; }
 
@@ -126,16 +72,24 @@ class NcclAllToAllStartThunk : public NcclCollectiveThunk {
  private:
   const NcclAllToAllConfig config_;
   const std::vector<Buffer> buffers_;
-  RecvPtrMap recv_ptr_map_;
   int64_t device_count_ = 1;
   bool p2p_memcpy_enabled_ = false;
+  std::unordered_map<int64_t, std::unordered_map<int64_t, uint64_t>>
+      send_pointer_maps_;
+  std::unordered_map<int64_t, std::unordered_map<int64_t, uint64_t>>
+      receive_pointer_maps_;
 };
 
 absl::Status RunAllToAll(NcclApi* nccl_api, bool has_split_dimension,
                          std::vector<DeviceBufferPair>& buffers,
-                         se::Stream& stream, NcclApi::NcclCommHandle comm,
-                         int64_t current_id, bool use_memcpy,
-                         NcclAllToAllStartThunk::RecvPtrMap& recv_ptr_map);
+                         se::Stream& stream, NcclApi::NcclCommHandle comm);
+
+absl::Status RunMemCpyAllToAll(
+    NcclApi* nccl_api, bool has_split_dimension,
+    std::vector<DeviceBufferPair>& buffers, se::Stream& stream,
+    NcclApi::NcclCommHandle comm, int64_t current_id,
+    std::unordered_map<int64_t, uint64_t>& send_pointer_map,
+    std::unordered_map<int64_t, uint64_t>& receive_pointer_map);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/runtime/nccl_all_to_all_thunk.h
+++ b/xla/service/gpu/runtime/nccl_all_to_all_thunk.h
@@ -74,9 +74,9 @@ class NcclAllToAllStartThunk : public NcclCollectiveThunk {
   const std::vector<Buffer> buffers_;
   int64_t device_count_ = 1;
   bool p2p_memcpy_enabled_ = false;
-  std::unordered_map<int64_t, std::unordered_map<int64_t, uint64_t>>
+  absl::node_hash_map<int64_t, absl::node_hash_map<int64_t, uint64_t>>
       send_pointer_maps_;
-  std::unordered_map<int64_t, std::unordered_map<int64_t, uint64_t>>
+  absl::node_hash_map<int64_t, absl::node_hash_map<int64_t, uint64_t>>
       receive_pointer_maps_;
 };
 
@@ -87,9 +87,9 @@ absl::Status RunAllToAll(NcclApi* nccl_api, bool has_split_dimension,
 absl::Status RunMemCpyAllToAll(
     NcclApi* nccl_api, bool has_split_dimension,
     std::vector<DeviceBufferPair>& buffers, se::Stream& stream,
-    NcclApi::NcclCommHandle comm, int64_t current_id,
-    std::unordered_map<int64_t, uint64_t>& send_pointer_map,
-    std::unordered_map<int64_t, uint64_t>& receive_pointer_map);
+    NcclApi::NcclCommHandle comm,
+    absl::node_hash_map<int64_t, uint64_t>& send_pointer_map,
+    absl::node_hash_map<int64_t, uint64_t>& receive_pointer_map);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/runtime/nccl_api.cc
+++ b/xla/service/gpu/runtime/nccl_api.cc
@@ -330,10 +330,14 @@ class DefaultNcclApi final : public NcclApi {
   absl::Status Send(se::DeviceMemoryBase send_buffer, PrimitiveType dtype,
                     size_t count, int32_t peer, NcclCommHandle comm,
                     se::Stream* stream) final;
+  absl::Status SendPtrToPeer(void* ptr, int32_t peer, NcclCommHandle comm,
+                             se::Stream* stream) final;
 
   absl::Status Recv(se::DeviceMemoryBase recv_buffer, PrimitiveType dtype,
                     size_t count, int32_t peer, NcclCommHandle comm,
                     se::Stream* stream) final;
+  absl::Status RecvPtrFromPeer(void* ptr, int32_t peer, NcclCommHandle comm,
+                               se::Stream* stream) final;
 
   absl::StatusOr<NcclRegisteredBufferHandle> RegisterBuffer(
       NcclCommHandle comm, se::DeviceMemoryBase buffer) final;
@@ -609,6 +613,17 @@ absl::Status DefaultNcclApi::Send(se::DeviceMemoryBase send_buffer,
                peer, Cast(comm), se::gpu::AsGpuStreamValue(stream)));
 }
 
+absl::Status DefaultNcclApi::SendPtrToPeer(void* ptr, int32_t peer,
+                                           NcclCommHandle comm,
+                                           se::Stream* stream) {
+  VLOG(3) << absl::StreamFormat(
+      "Launch NCCL RecvPtrFromPeer operation on device #%d;  "
+      "peer=%d; comm=%p; stream=%p",
+      stream->parent()->device_ordinal(), peer, comm, stream);
+  return XLA_NCCL_STATUS(ncclSend(ptr, 1, ncclUint64, peer, Cast(comm),
+                                  se::gpu::AsGpuStreamValue(stream)));
+}
+
 absl::Status DefaultNcclApi::Recv(se::DeviceMemoryBase recv_buffer,
                                   PrimitiveType dtype, size_t count,
                                   int32_t peer, NcclCommHandle comm,
@@ -625,6 +640,18 @@ absl::Status DefaultNcclApi::Recv(se::DeviceMemoryBase recv_buffer,
   return XLA_NCCL_STATUS(
       ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
                peer, Cast(comm), se::gpu::AsGpuStreamValue(stream)));
+}
+
+absl::Status DefaultNcclApi::RecvPtrFromPeer(void* ptr, int32_t peer,
+                                             NcclCommHandle comm,
+                                             se::Stream* stream) {
+  VLOG(3) << absl::StreamFormat(
+      "Launch NCCL RecvPtrFromPeer operation on device #%d; "
+      "peer=%d; comm=%p; stream=%p",
+      stream->parent()->device_ordinal(), peer, comm, stream);
+
+  return XLA_NCCL_STATUS(ncclRecv(ptr, 1, ncclUint64, peer, Cast(comm),
+                                  se::gpu::AsGpuStreamValue(stream)));
 }
 
 absl::StatusOr<NcclApi::NcclRegisteredBufferHandle>

--- a/xla/service/gpu/runtime/nccl_api.h
+++ b/xla/service/gpu/runtime/nccl_api.h
@@ -247,6 +247,10 @@ class NcclApi {
   virtual absl::Status Send(se::DeviceMemoryBase send_buffer,
                             PrimitiveType dtype, size_t count, int32_t peer,
                             NcclCommHandle comm, se::Stream* stream) = 0;
+  // Send a pointer `ptr` to rank `peer`.
+  virtual absl::Status SendPtrToPeer(void* ptr, int32_t peer,
+                                     NcclCommHandle comm,
+                                     se::Stream* stream) = 0;
 
   // Receive data from rank `peer` into `recv_buff`.
   //
@@ -254,6 +258,10 @@ class NcclApi {
   virtual absl::Status Recv(se::DeviceMemoryBase recv_buffer,
                             PrimitiveType dtype, size_t count, int32_t peer,
                             NcclCommHandle comm, se::Stream* stream) = 0;
+  // Receive a pointer from rank `peer` into `ptr`.
+  virtual absl::Status RecvPtrFromPeer(void* ptr, int32_t peer,
+                                       NcclCommHandle comm,
+                                       se::Stream* stream) = 0;
 
   // Register `buffer` with communicator `comm` for zero-copy communication.
   // Returned handle can be used for future unregistration.

--- a/xla/service/gpu/runtime/nccl_clique_key.h
+++ b/xla/service/gpu/runtime/nccl_clique_key.h
@@ -56,10 +56,11 @@ enum class AsyncStreamKind : int64_t {
   kCollective = 0,  // Stream for asynchronous collective ops.
   kP2P0 = 1,        // One Stream for P2P Send and Recv ops.
   kP2P1 = 2,        // Another Stream for P2P Send and Recv ops.
+  kMemCpyP2P = 3,   // Stream for MemCpyP2P
 };
 
 constexpr static int64_t kAsyncStreamTotal =
-    static_cast<int64_t>(AsyncStreamKind::kP2P1) + 1;
+    static_cast<int64_t>(AsyncStreamKind::kMemCpyP2P) + 1;
 
 // Assigns a unique ID to a stream for asynchronous or synchronous execution.
 // These IDs can be used, for example, to look up the NCCL communicator.

--- a/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.cc
+++ b/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.cc
@@ -37,7 +37,8 @@ namespace xla::gpu {
 
 NcclCollectiveBroadcastStartThunk::NcclCollectiveBroadcastStartThunk(
     ThunkInfo thunk_info, NcclApi* nccl_api,
-    const HloCollectiveBroadcastInstruction* instr, std::vector<Buffer> buffers)
+    const HloCollectiveBroadcastInstruction* instr, std::vector<Buffer> buffers,
+    bool p2p_memcpy_enabled)
     : NcclCollectiveThunk(Thunk::kNcclCollectiveBroadcastStart, thunk_info,
                           nccl_api, IsSyncCollective(instr)),
       config_(GetNcclCollectiveConfig(instr, std::nullopt)),

--- a/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.h
+++ b/xla/service/gpu/runtime/nccl_collective_broadcast_thunk.h
@@ -47,7 +47,7 @@ class NcclCollectiveBroadcastStartThunk : public NcclCollectiveThunk {
   NcclCollectiveBroadcastStartThunk(
       ThunkInfo thunk_info, NcclApi* nccl_api,
       const HloCollectiveBroadcastInstruction* instr,
-      std::vector<Buffer> buffers);
+      std::vector<Buffer> buffers, bool p2p_memcpy_enabled = false);
 
  protected:
   absl::Status RunNcclCollective(const ExecuteParams& params,

--- a/xla/service/gpu/runtime/nccl_collective_thunk.h
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.h
@@ -71,20 +71,6 @@ struct NcclCollectiveConfig {
   bool IsDegenerate(int64_t replica_count, int64_t partition_count) const;
 };
 
-template <typename T>
-absl::StatusOr<const int64_t> GetCurrentId(
-    Thunk::CollectiveExecuteParams* collective_params, const T& config) {
-  GlobalDeviceId global_device_id = collective_params->global_device_id;
-  TF_ASSIGN_OR_RETURN(
-      const DeviceAssignment::LogicalID current_logical_id,
-      collective_params->device_assn->LogicalIdForDevice(global_device_id));
-  const int64_t current_id =
-      config.config.group_mode == CollectiveOpGroupMode::kCrossReplica
-          ? current_logical_id.replica_id
-          : current_logical_id.computation_id;
-  return current_id;
-}
-
 template <typename OpT>
 void NcclCollectiveConfig::SetCollectiveOpKindAndID(OpT op) {
   if (op.getChannelId()) {

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -406,11 +406,15 @@ class Thunk {
 
   // Parameters passed to Cleanup. Before returning from executable execution,
   // thunks may need to clean up any resource allocated or registered through
-  // run time APIs.
+  // runtime APIs.
   struct CleanupParams {
     se::StreamExecutor* executor = nullptr;
+
     // Parameters for executing collective operations.
     CollectiveExecuteParams* collective_params = nullptr;
+
+    // Collective cliques acquired based on resource requests.
+    CollectiveCliques* collective_cliques = nullptr;
   };
 
   //===--------------------------------------------------------------------===//

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -401,6 +401,19 @@ class Thunk {
   };
 
   //===--------------------------------------------------------------------===//
+  // CleanupParams
+  //===--------------------------------------------------------------------===//
+
+  // Parameters passed to Cleanup. Before returning from executable execution,
+  // thunks may need to clean up any resource allocated or registered through
+  // run time APIs.
+  struct CleanupParams {
+    se::StreamExecutor* executor = nullptr;
+    // Parameters for executing collective operations.
+    CollectiveExecuteParams* collective_params = nullptr;
+  };
+
+  //===--------------------------------------------------------------------===//
 
   // The hlo_instruction argument is meant to be the instruction this thunk was
   // generated from, but Thunk never uses this argument other than to save it
@@ -443,6 +456,14 @@ class Thunk {
   //
   // Precondition: Initialize(initialize_params) has been called.
   virtual absl::Status ExecuteOnStream(const ExecuteParams& params) = 0;
+
+// Cleans up any resources after thunk execution.
+  //
+  // This may be called multiple times. Its main purpose is to free up
+  // any resources occupied after initialization and execution.
+  virtual absl::Status Cleanup(const CleanupParams& params) {
+    return absl::OkStatus();
+  }
 
   static absl::string_view KindToString(Thunk::Kind kind);
 

--- a/xla/stream_executor/cuda/cuda_driver.cc
+++ b/xla/stream_executor/cuda/cuda_driver.cc
@@ -1272,6 +1272,31 @@ void GpuDriver::HostDeallocate(Context* context, void* location) {
   }
 }
 
+bool GpuDriver::HostRegister(Context* context, void* location,
+                             uint64_t bytes) {
+  ScopedActivateContext activation(context);
+  // "Portable" memory is visible to all CUDA contexts. Safe for our use model.
+  auto status = cuda::ToStatus(
+      cuMemHostRegister(location, bytes, CU_MEMHOSTREGISTER_PORTABLE));
+  if (!status.ok()) {
+    LOG(ERROR) << "error registering host memory at " << location << ": "
+               << status;
+    return false;
+  }
+  return true;
+}
+
+bool GpuDriver::HostUnregister(Context* context, void* location) {
+  ScopedActivateContext activation(context);
+  auto status = cuda::ToStatus(cuMemHostUnregister(location));
+  if (!status.ok()) {
+    LOG(ERROR) << "error unregistering host memory at " << location << ": "
+               << status;
+    return false;
+  }
+  return true;
+}
+
 int GpuDriver::GetGpuStreamPriority(
     Context* context, stream_executor::StreamPriority stream_priority) {
   ScopedActivateContext activation(context);

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -467,6 +467,20 @@ bool CudaExecutor::SynchronizeAllActivity() {
   return GpuDriver::SynchronizeContext(gpu_context()).ok();
 }
 
+bool GpuExecutor::HostMemoryRegister(void* location, uint64_t size) {
+  VLOG(1) << "Called StreamExecutor::HostMemoryRegister(data=" << location
+          << ")";
+
+  return GpuDriver::HostRegister(context_, location, size);
+}
+
+bool GpuExecutor::HostMemoryUnregister(void* location) {
+  VLOG(1) << "Called StreamExecutor::HostUnregister(data=" << location
+          << ")";
+
+  return GpuDriver::HostUnregister(context_, location);
+}
+
 absl::Status CudaExecutor::SynchronousMemZero(DeviceMemoryBase* location,
                                               uint64_t size) {
   if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&

--- a/xla/stream_executor/gpu/gpu_driver.h
+++ b/xla/stream_executor/gpu/gpu_driver.h
@@ -131,6 +131,22 @@ class GpuDriver {
   // https://rocm.docs.amd.com/projects/HIPIFY/en/latest/tables/CUDA_Driver_API_functions_supported_by_HIP.html#memory-management
   static void HostDeallocate(Context* context, void* location);
 
+  // Registers a memory region at location of size bytes via
+  // cuMemHostRegister/hipHostRegister.
+  // http://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1gf0a9fe11544326dabd743b7aa6b54223
+  // https://rocm.docs.amd.com/projects/HIPIFY/en/latest/tables/CUDA_Driver_API_functions_supported_by_HIP.html#memory-management
+  static bool HostRegister(Context* context, void* location, uint64_t bytes);
+
+  // Unregisters a memory region that was previously registered at location via
+  // cuMemHostUnregister/hipHostUnregister.
+  //
+  // http://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1g63f450c8125359be87b7623b1c0b2a14
+  // https://rocm.docs.amd.com/projects/HIPIFY/en/latest/tables/CUDA_Driver_API_functions_supported_by_HIP.html#memory-management
+  //
+  // TODO(leary) verify an error will be returned if the location wasn't
+  // previously registered.
+  static bool HostUnregister(Context* context, void* location);
+
   // Queries the priority range and returns the corresponding integer value via
   // cuCtxGetStreamPriorityRange/hipDeviceGetStreamPriorityRange
   //

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -132,6 +132,9 @@ class GpuExecutor : public StreamExecutorCommon {
 
   uint64_t GetArgumentLoggingMode() const { return argument_logging_mode_; }
 
+  bool HostMemoryRegister(void* location, uint64_t size);
+  bool HostMemoryUnregister(void* location);
+
  protected:
   // Sets the context.
   void set_context(Context* context) { context_ = context; }

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -193,6 +193,9 @@ class StreamExecutor {
   virtual absl::Status SynchronousMemZero(DeviceMemoryBase* location,
                                           uint64_t size) = 0;
 
+  virtual bool HostMemoryUnregister(void* location)  { return false;};
+  virtual bool HostMemoryRegister(void* location, uint64_t size) { return false;};
+
   // Blocks the caller while "size" bytes are copied to the given location in
   // device memory.
   virtual absl::Status SynchronousMemcpy(DeviceMemoryBase* device_dst,

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -434,6 +434,46 @@ XLA_TEST_P(AsyncCollectiveOps, AsyncAllToAllWithSplitDim) {
   LiteralTestUtil::ExpectR1Equal<uint32_t>({15, 16}, results[1]);
 }
 
+TEST_F(CollectiveOpsTestE2E, AsyncAllToAllMemCpy) {
+  const absl::string_view kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    id = u32[] replica-id()
+    id2 = u32[2, 2] broadcast(id), dimensions={}
+    a0 = u32[2, 2] constant({{10, 15}, {20, 25}})
+    a1 = u32[2, 2] add(id2, a0)
+    all2all = u32[2, 2] all-to-all(a1), dimensions={0}
+    ROOT out = u32[4] reshape(all2all)
+  }
+  )";
+  const int64_t kNumReplicas = 2;
+
+  DebugOptions debug_options = GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_use_memcpy_local_p2p(true);
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.set_debug_options(debug_options);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr, config));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executable,
+      CreateExecutable(std::move(module), /*run_hlo_passes=*/true));
+  ASSERT_TRUE(executable->has_module());
+  HloModule* executable_module = &executable->module();
+
+  // Verify that the all-to-all is not decomposed into a tuple all-to-all.
+  const HloInstruction* all_to_all =
+      FindInstruction(executable_module, HloOpcode::kAllToAll);
+  EXPECT_THAT(all_to_all, op::Shape("u32[2, 2]"));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
+                          ExecuteReplicated(executable.get(), kNumReplicas));
+  ASSERT_EQ(results.size(), kNumReplicas);
+  LiteralTestUtil::ExpectR1Equal<uint32_t>({10, 15, 11, 16}, results[0]);
+  LiteralTestUtil::ExpectR1Equal<uint32_t>({20, 25, 21, 26}, results[1]);
+}
+
 XLA_TEST_P(AsyncCollectiveOps, AsyncAllToAllWithoutSplitDim) {
   const absl::string_view kModuleStr = R"(
   HloModule test


### PR DESCRIPTION
The communications of all-to-all rely on NCCL even when it is intra-node. By leveraging memcpy for intra-node communications, all-to-all can have better performance while reducing SM consumption (right now consumed by NCCL). 