### PR TITLE
[GPU] Fix use of DfsHloRewriteVisitor by cuDNN fusion compiler.

### DIFF
--- a/xla/service/gpu/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/cudnn_fusion_compiler.cc
@@ -609,9 +609,6 @@ absl::StatusOr<se::gpu::CudnnGraph> PrepareGraph(
 
 absl::StatusOr<HloInstruction*> AddWorkspace(HloInstruction& fusion,
                                              const int64_t workspace_size) {
-  if (workspace_size == 0 || fusion.shape().IsTuple()) {
-    return &fusion;
-  }
   HloComputation* computation = fusion.fused_instructions_computation();
   HloInstruction* custom_call =
       computation->AddInstruction(HloInstruction::CreateCustomCall(
@@ -650,6 +647,13 @@ class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
     VLOG(4) << "Processing " << hlo->ToString();
     VLOG(4) << "Plan ID: " << plan_id;
 
+    auto add_workspace = [&](const int64_t workspace_size) {
+      if (workspace_size > 0) {
+        TF_ASSIGN_OR_RETURN(hlo, AddWorkspace(*hlo, workspace_size));
+        SetVisited(*hlo);
+      }
+      return absl::OkStatus();
+    };
     const std::string fingerprint_without_workspace =
         GetComputationFingerprint(hlo->fused_instructions_computation(), {});
     auto workspace_size_it =
@@ -683,7 +687,7 @@ class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
       const int64_t workspace_size = graph.Graph().get_workspace_size();
       workspace_sizes_.insert(workspace_size_it,
                               {fingerprint_without_workspace, workspace_size});
-      TF_ASSIGN_OR_RETURN(hlo, AddWorkspace(*hlo, workspace_size));
+      TF_RETURN_IF_ERROR(add_workspace(workspace_size));
 
       std::vector<uint8_t> serialized_graph;
       RETURN_IF_CUDNN_FRONTEND_ERROR(graph.Graph().serialize(serialized_graph));
@@ -695,7 +699,7 @@ class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
                       serialized_graph.size());
     } else {
       VLOG(4) << "Cache hit.";
-      TF_ASSIGN_OR_RETURN(hlo, AddWorkspace(*hlo, workspace_size_it->second));
+      TF_RETURN_IF_ERROR(add_workspace(workspace_size_it->second));
     }
     auto cudnn_config = gpu_config.mutable_fusion_backend_config()
                             ->mutable_cudnn_fusion_config();


### PR DESCRIPTION
DfsHloVisitor visits replaced instructions again. This used to happen here on addition of workspace, HandleFusion() was called again. SetVisited() prevents that.