### PR TITLE
Make GpuExecutor::HostMemoryAllocate NUMA aware

### DIFF
--- a/third_party/tsl/third_party/hwloc/hwloc.BUILD
+++ b/third_party/tsl/third_party/hwloc/hwloc.BUILD
@@ -110,7 +110,7 @@ _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
     "#undef HAVE_SYS_MMAN_H": "#define HAVE_SYS_MMAN_H 1",
     "#undef HAVE_SYS_PARAM_H": "#define HAVE_SYS_PARAM_H 1",
     "#undef HAVE_SYS_STAT_H": "#define HAVE_SYS_STAT_H 1",
-    "#undef HAVE_SYS_SYSCTL_H": "#define HAVE_SYS_SYSCTL_H 1",
+    #"#undef HAVE_SYS_SYSCTL_H": "#define HAVE_SYS_SYSCTL_H 1",
     "#undef HAVE_SYS_TYPES_H": "#define HAVE_SYS_TYPES_H 1",
     "#undef HAVE_SYS_UTSNAME_H": "#define HAVE_SYS_UTSNAME_H 1",
     "#undef HAVE_TIME_H": "#define HAVE_TIME_H 1",

--- a/third_party/tsl/tsl/platform/default/BUILD
+++ b/third_party/tsl/tsl/platform/default/BUILD
@@ -342,11 +342,8 @@ cc_library(
         "//tsl/platform/profile_utils:cpu_utils.h",
     ],
     copts = tsl_copts(),
-    defines = ["TF_USE_SNAPPY"] + select({
-        # TF Additional NUMA defines
-        "@xla//xla/tsl:with_numa_support": ["TENSORFLOW_USE_NUMA"],
-        "//conditions:default": [],
-    }),
+    # FIXME: keep the option?
+    defines = ["TF_USE_SNAPPY", "TENSORFLOW_USE_NUMA"],
     tags = [
         "manual",
         "no_oss",
@@ -361,15 +358,9 @@ cc_library(
         "//tsl/platform:types",
         "//tsl/platform/profile_utils:profile_utils_cpu_utils",
         "@com_google_absl//absl/base",
+        "@hwloc",
         "@snappy",
-    ] + select({
-        # TF Additional NUMA dependencies
-        "@xla//xla/tsl:with_numa_support": [
-            # Don't merge in a single line
-            "@hwloc",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )
 
 cc_library(

--- a/xla/backends/interpreter/executor.h
+++ b/xla/backends/interpreter/executor.h
@@ -103,7 +103,7 @@ class XlaInterpreterExecutor : public StreamExecutorCommon {
       uint64_t size) override {
     return std::make_unique<HostMemoryAllocation>(new char[size], size, this);
   }
-  void HostMemoryDeallocate(void *mem) override {
+  void HostMemoryDeallocate(void *mem, uint64_t size) override {
     delete[] static_cast<char *>(mem);
   }
 

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -824,6 +824,7 @@ cuda_only_cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:fingerprint",
         "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:statusor",
     ] + if_cuda_is_configured([":delay_kernel_cuda"]),
     alwayslink = True,

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -798,6 +798,7 @@ xla_test(
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:test",
     ] + if_cuda([
         "//xla/stream_executor/cuda:cuda_platform",

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -235,6 +235,7 @@ gpu_only_cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:thread_annotations",
     ],
 )

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -58,6 +58,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/stream_executor/stream_executor_common.h"
+#include "tsl/platform/numa.h"
 #include "tsl/platform/thread_annotations.h"
 
 namespace stream_executor {
@@ -112,7 +113,7 @@ class GpuExecutor : public StreamExecutorCommon {
         cc_major_(0),
         cc_minor_(0),
         version_(0),
-        numa_node_(-1) {}
+        numa_node_(tsl::port::kNUMANoAffinity) {}
 
   // See the corresponding StreamExecutor methods for method comments on the
   // following overrides.

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -183,7 +183,7 @@ class GpuExecutor : public StreamExecutorCommon {
     return std::make_unique<HostMemoryAllocation>(buffer, size, this);
   }
 
-  void HostMemoryDeallocate(void* location) override {
+  void HostMemoryDeallocate(void* location, uint64_t size) override {
     return GpuDriver::HostDeallocate(context_, location);
   }
 

--- a/xla/stream_executor/gpu/gpu_executor_test.cc
+++ b/xla/stream_executor/gpu/gpu_executor_test.cc
@@ -72,8 +72,14 @@ TEST_F(HostMemoryAllocateTest, Numa) {
     ASSERT_TRUE(host_ptr);
     EXPECT_NE(host_ptr->opaque(), nullptr);
     const int numa_node = tsl::port::NUMAGetMemAffinity(host_ptr->opaque());
-    EXPECT_NE(numa_node, tsl::port::kNUMANoAffinity);
-    EXPECT_EQ(device_desc->numa_node(), numa_node);
+    if (numa_node == tsl::port::kNUMANoAffinity) {
+      // Could be because `executor` could not determine its own NUMA node, in
+      // which case numa_node() will be -1 or 0, depending on the failure mode.
+      EXPECT_LE(device_desc->numa_node(), 0);
+      EXPECT_GE(device_desc->numa_node(), -1);
+    } else {
+      EXPECT_EQ(device_desc->numa_node(), numa_node);
+    }
   }
 }
 

--- a/xla/stream_executor/gpu/gpu_executor_test.cc
+++ b/xla/stream_executor/gpu/gpu_executor_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "tsl/platform/numa.h"
 #include "tsl/platform/statusor.h"
 #include "tsl/platform/test.h"
 
@@ -52,6 +53,28 @@ TEST_F(GetPointerMemorySpaceTest, Device) {
                           executor->GetPointerMemorySpace(mem.opaque()))
   EXPECT_EQ(memory_space, MemoryType::kDevice);
   executor->Deallocate(&mem);
+}
+
+using HostMemoryAllocateTest = GpuExecutorTest;
+
+TEST_F(HostMemoryAllocateTest, Numa) {
+  Platform* platform = GetPlatform();
+  const uint64_t kSize = 1024;
+  const int num_devices = platform->VisibleDeviceCount();
+  for (int device = 0; device < num_devices; ++device) {
+    TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                            platform->ExecutorForDevice(device));
+    ASSERT_TRUE(executor);
+    TF_ASSERT_OK_AND_ASSIGN(auto device_desc,
+                            executor->CreateDeviceDescription());
+    ASSERT_TRUE(device_desc);
+    TF_ASSERT_OK_AND_ASSIGN(auto host_ptr, executor->HostMemoryAllocate(kSize));
+    ASSERT_TRUE(host_ptr);
+    EXPECT_NE(host_ptr->opaque(), nullptr);
+    const int numa_node = tsl::port::NUMAGetMemAffinity(host_ptr->opaque());
+    EXPECT_NE(numa_node, tsl::port::kNUMANoAffinity);
+    EXPECT_EQ(device_desc->numa_node(), numa_node);
+  }
 }
 
 }  // namespace stream_executor

--- a/xla/stream_executor/host/host_executor.h
+++ b/xla/stream_executor/host/host_executor.h
@@ -84,7 +84,7 @@ class HostExecutor : public StreamExecutorCommon {
       uint64_t size) override {
     return std::make_unique<HostMemoryAllocation>(new char[size], size, this);
   }
-  void HostMemoryDeallocate(void* mem) override {
+  void HostMemoryDeallocate(void* mem, uint64_t size) override {
     delete[] static_cast<char*>(mem);
   }
 

--- a/xla/stream_executor/host_memory_allocation.cc
+++ b/xla/stream_executor/host_memory_allocation.cc
@@ -27,7 +27,7 @@ HostMemoryAllocation::HostMemoryAllocation(void* ptr, uint64_t size,
 
 HostMemoryAllocation::~HostMemoryAllocation() {
   if (ptr_ != nullptr && executor_ != nullptr) {
-    executor_->HostMemoryDeallocate(ptr_);
+    executor_->HostMemoryDeallocate(ptr_, size_);
   }
 }
 

--- a/xla/stream_executor/integrations/device_mem_allocator.h
+++ b/xla/stream_executor/integrations/device_mem_allocator.h
@@ -82,7 +82,7 @@ class DeviceMemAllocator : public tsl::SubAllocator {
         auto status = stream_exec_->CollectiveMemoryDeallocate(ptr);
         CHECK(status.ok()) << status.message();
       } else if (memory_type_ == MemoryType::kHost) {
-        stream_exec_->HostMemoryDeallocate(ptr);
+        stream_exec_->HostMemoryDeallocate(ptr, num_bytes);
       } else {
         DeviceMemoryBase device_ptr(ptr);
         stream_exec_->Deallocate(&device_ptr);

--- a/xla/stream_executor/mock_stream_executor.h
+++ b/xla/stream_executor/mock_stream_executor.h
@@ -92,6 +92,7 @@ class MockStreamExecutor : public StreamExecutor {
               (override));
   MOCK_METHOD(absl::StatusOr<std::unique_ptr<MemoryAllocation>>,
               HostMemoryAllocate, (uint64_t size), (override));
+  MOCK_METHOD(void, HostMemoryDeallocate, (void* mem), (override));
   MOCK_METHOD(void, HostMemoryDeallocate, (void* mem, uint64_t size),
               (override));
   MOCK_METHOD(bool, SynchronizeAllActivity, (), (override));

--- a/xla/stream_executor/mock_stream_executor.h
+++ b/xla/stream_executor/mock_stream_executor.h
@@ -92,7 +92,8 @@ class MockStreamExecutor : public StreamExecutor {
               (override));
   MOCK_METHOD(absl::StatusOr<std::unique_ptr<MemoryAllocation>>,
               HostMemoryAllocate, (uint64_t size), (override));
-  MOCK_METHOD(void, HostMemoryDeallocate, (void* mem), (override));
+  MOCK_METHOD(void, HostMemoryDeallocate, (void* mem, uint64_t size),
+              (override));
   MOCK_METHOD(bool, SynchronizeAllActivity, (), (override));
   MOCK_METHOD(absl::Status, SynchronousMemZero,
               (DeviceMemoryBase * location, uint64_t size), (override));

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -459,6 +459,20 @@ void GpuExecutor::Deallocate(DeviceMemoryBase* mem) {
   GpuDriver::DeviceDeallocate(context_, mem->opaque());
 }
 
+absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+GpuExecutor::HostMemoryAllocate(uint64_t size) {
+  auto* buffer = GpuDriver::HostAllocate(context_, size);
+  if (buffer == nullptr && size > 0) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to allocate HostMemory of size %d", size));
+  }
+  return std::make_unique<HostMemoryAllocation>(buffer, size, this);
+}
+
+void GpuExecutor::HostMemoryDeallocate(void* location, uint64_t size) {
+  return GpuDriver::HostDeallocate(context_, location);
+}
+
 bool GpuExecutor::SynchronizeAllActivity() {
   return GpuDriver::SynchronizeContext(context_);
 }

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -207,6 +207,9 @@ class StreamExecutor {
       uint64_t size) = 0;
 
   // Deallocates a region of host memory allocated by HostMemoryAllocate().
+  [[deprecated(
+      "Use HostMemoryDeallocate(void*, uint64_t) instead")]] virtual void
+  HostMemoryDeallocate(void* mem) = 0;
   virtual void HostMemoryDeallocate(void* mem, uint64_t size) = 0;
 
   // Returns the memory space of the given pointer.

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -207,7 +207,7 @@ class StreamExecutor {
       uint64_t size) = 0;
 
   // Deallocates a region of host memory allocated by HostMemoryAllocate().
-  virtual void HostMemoryDeallocate(void* mem) = 0;
+  virtual void HostMemoryDeallocate(void* mem, uint64_t size) = 0;
 
   // Returns the memory space of the given pointer.
   virtual absl::StatusOr<MemoryType> GetPointerMemorySpace(const void* ptr) {

--- a/xla/stream_executor/stream_executor_common.cc
+++ b/xla/stream_executor/stream_executor_common.cc
@@ -52,4 +52,13 @@ const DeviceDescription& StreamExecutorCommon::GetDeviceDescription() const {
   return *device_description_;
 }
 
+/* deprecated */ void StreamExecutorCommon::HostMemoryDeallocate(void* mem) {
+  LOG(ERROR) << "deprecated compatibility stub called";
+}
+
+[[deprecated("so it can quietly call deprecated methods")]] void
+StreamExecutorCommon::HostMemoryDeallocate(void* mem, uint64_t size) {
+  HostMemoryDeallocate(mem);
+}
+
 }  // namespace stream_executor

--- a/xla/stream_executor/stream_executor_common.h
+++ b/xla/stream_executor/stream_executor_common.h
@@ -46,6 +46,12 @@ class StreamExecutorCommon : public StreamExecutor {
   const DeviceDescription& GetDeviceDescription() const override;
   int64_t GetMemoryLimitBytes() const override { return memory_limit_bytes_; }
 
+  // Default implementation for modern derived classes; logs an error
+  /* deprecated */ void HostMemoryDeallocate(void* mem) override;
+  // Default implementation for obsolete derived classes; calls the deprecated
+  // signature (above) that should be implemented by the obsolete derived class
+  void HostMemoryDeallocate(void* mem, uint64_t size) override;
+
  private:
   // Reader/writer lock for mutable data structures on this StreamExecutor.
   //

--- a/xla/stream_executor/tpu/tpu_executor.h
+++ b/xla/stream_executor/tpu/tpu_executor.h
@@ -137,7 +137,7 @@ class TpuExecutor : public tensorflow::tpu::TpuExecutorInterface {
       uint64_t size) override {
     LOG(FATAL) << "not yet implemented";
   }
-  void HostMemoryDeallocate(void* mem) override {
+  void HostMemoryDeallocate(void* mem, uint64_t size) override {
     LOG(FATAL) << "not yet implemented";
   }
   absl::Status SynchronousMemZero(DeviceMemoryBase* location,


### PR DESCRIPTION
This improves the achieved throughput of D2H transfers, for example when checkpointing. For example, there is a ~2x improvement in throughput of overlapped D2H copies from 8xH100 on a DGX node.

Notes:
- `TENSORFLOW_USE_NUMA` is set unconditionally instead of being hidden behind an option; it's not clear from OSS-world if this is an important handle for Google internally.
- `stream_executor::StreamExecutor::HostMemoryDeallocate` now takes the allocation size; all call sites updated. This is required by the `tsl::port::NUMAFree` API.
