### PR TITLE
Add unique channel id enforcer pass - V2 handle peer to peer

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -6145,6 +6145,27 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "unique_channel_id_enforcer",
+    hdrs = ["unique_channel_id_enforcer.h"],
+    srcs = ["unique_channel_id_enforcer.cc"],
+    deps = [
+        ":hlo_pass",
+        "//xla/hlo/utils:hlo_query",
+    ],
+)
+
+xla_cc_test(
+    name = "unique_channel_id_enforcer_test",
+    srcs = ["unique_channel_id_enforcer_test.cc"],
+    deps = [
+        ":unique_channel_id_enforcer",
+        "//xla/hlo/utils:hlo_matchers",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:xla_internal_test_main",
+    ],
+)
+
+cc_library(
     name = "root_instruction_sinker",
     srcs = ["root_instruction_sinker.cc"],
     hdrs = ["root_instruction_sinker.h"],

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3669,6 +3669,7 @@ cc_library(
         "//xla/service:topk_rewriter",
         "//xla/service:transpose_folding",
         "//xla/service:tuple_simplifier",
+        "//xla/service:unique_channel_id_enforcer",
         "//xla/service:while_loop_all_reduce_code_motion",
         "//xla/service:while_loop_constant_sinking",
         "//xla/service:while_loop_simplifier",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -220,6 +220,7 @@ limitations under the License.
 #include "xla/service/topk_rewriter.h"
 #include "xla/service/transpose_folding.h"
 #include "xla/service/tuple_simplifier.h"
+#include "xla/service/unique_channel_id_enforcer.h"
 #include "xla/service/while_loop_all_reduce_code_motion.h"
 #include "xla/service/while_loop_constant_sinking.h"
 #include "xla/service/while_loop_simplifier.h"
@@ -2345,6 +2346,7 @@ absl::Status GpuCompiler::RunPreSchedulingPasses(
     HloModule* module, se::StreamExecutor* stream_exec) {
   HloPassPipeline pipeline("pre-scheduling-passes");
   pipeline.AddPass<FusionWrapper>();
+  pipeline.AddPass<UniqueChannelIdEnforcer>();
   return pipeline.Run(module).status();
 }
 

--- a/xla/service/unique_channel_id_enforcer.cc
+++ b/xla/service/unique_channel_id_enforcer.cc
@@ -1,0 +1,62 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/unique_channel_id_enforcer.h"
+
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/utils/hlo_query.h"
+#include "absl/status/statusor.h"
+
+namespace xla {
+
+absl::StatusOr<bool> UniqueChannelIdEnforcer::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  absl::flat_hash_set<std::optional<long int>> used_channel_ids;
+  auto next_channel_id = hlo_query::NextChannelId(*module);
+  bool changed = false;
+  for (HloComputation* computation : module->computations()) {
+    for (HloInstruction* instruction : computation->instructions()) {
+      if (!hlo_query::IsCollectiveCommunicationOp(instruction->opcode()))
+        continue;
+      // Skip send/recv for now, as these allow collisions under certain
+      // circumstances.
+      if (DynCast<HloSendRecvInstruction>(instruction)) continue;
+      auto channel_id = instruction->channel_id();
+      if (used_channel_ids.contains(channel_id)) {
+        if (assert_unique_channel_ids_) {
+          LOG(ERROR) << "Duplicate channel ID " << channel_id.value_or(-1)
+                     << " found on instruction: " << instruction->ToString();
+          return absl::InternalError(
+              absl::StrFormat("Duplicate channel ID %d found on instruction: %s",
+                              channel_id.value_or(-1),
+                              instruction->ToString()));
+        }
+        instruction->set_channel_id(next_channel_id);
+        used_channel_ids.insert(next_channel_id);
+        next_channel_id++;
+        changed = true;
+      } else {
+        used_channel_ids.insert(channel_id);
+      }
+    }
+  }
+
+  return changed;
+}
+
+}  // namespace xla

--- a/xla/service/unique_channel_id_enforcer.h
+++ b/xla/service/unique_channel_id_enforcer.h
@@ -1,0 +1,43 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef UNIQUE_CHANNEL_ID_ENFORCER_H
+#define UNIQUE_CHANNEL_ID_ENFORCER_H
+
+#include "xla/service/hlo_pass_interface.h"
+
+namespace xla {
+// A pass which enforces that every collective
+// must have a unique channel id.
+class UniqueChannelIdEnforcer : public HloModulePass {
+ public:
+  explicit UniqueChannelIdEnforcer(bool assert_unique_channel_ids = false)
+      : assert_unique_channel_ids_(assert_unique_channel_ids) {}
+
+  absl::string_view name() const override {
+    return "unique-channel-id-enforcer";
+  }
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  bool assert_unique_channel_ids_;
+};
+
+}  // namespace xla
+
+#endif  // UNIQUE_CHANNEL_ID_ENFORCER_H

--- a/xla/service/unique_channel_id_enforcer_test.cc
+++ b/xla/service/unique_channel_id_enforcer_test.cc
@@ -1,0 +1,129 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/unique_channel_id_enforcer.h"
+
+#include "xla/service/hlo_parser.h"
+#include "xla/tests/hlo_test_base.h"
+
+namespace xla {
+namespace {
+
+using UniqueChannelIdEnforcerTest = HloTestBase;
+
+TEST_F(UniqueChannelIdEnforcerTest, EnsureUniqueChannelIdsAllGather) {
+  const char* const hlo_string = R"(
+HloModule Module
+
+ENTRY entry {
+  param0 = f32[8] parameter(0)
+  param1 = f32[8] parameter(1)
+  allgather0 = f32[32] all-gather(param0), channel_id=1, replica_groups={}, dimensions={0}
+  allgather1 = f32[32] all-gather(param1), channel_id=1, replica_groups={}, dimensions={0}
+  ROOT tuple = (f32[32], f32[32]) tuple(allgather0, allgather1)
+}
+)";
+  
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  UniqueChannelIdEnforcer enforcer;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, enforcer.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  // Verify that channel IDs are unique for all-gather ops
+  std::optional<int64_t> all_gather1_channel_id;
+  std::optional<int64_t> all_gather2_channel_id;
+  
+  for (HloInstruction* inst : module->entry_computation()->instructions()) {
+    if (inst->opcode() == HloOpcode::kAllGather) {
+      if (!all_gather1_channel_id.has_value()) {
+        all_gather1_channel_id = inst->channel_id();
+      } else {
+        all_gather2_channel_id = inst->channel_id();
+      }
+    }
+  }
+
+  ASSERT_TRUE(all_gather1_channel_id.has_value());
+  ASSERT_TRUE(all_gather2_channel_id.has_value());
+  EXPECT_NE(all_gather1_channel_id.value(), all_gather2_channel_id.value());
+}
+
+TEST_F(UniqueChannelIdEnforcerTest, ChannelIdsAlreadyUnique) {
+  const char* const hlo_string = R"(
+HloModule Module
+
+ENTRY entry {
+  param0 = f32[8] parameter(0)
+  param1 = f32[8] parameter(1)
+  allgather0 = f32[32] all-gather(param0), channel_id=1, replica_groups={}, dimensions={0}
+  allgather1 = f32[32] all-gather(param1), channel_id=2, replica_groups={}, dimensions={0}
+  ROOT tuple = (f32[32], f32[32]) tuple(allgather0, allgather1)
+}
+)";
+  
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  UniqueChannelIdEnforcer enforcer;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, enforcer.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(UniqueChannelIdEnforcerTest, DuplicateChannelIdsAssertTrue) {
+  const char* const hlo_string = R"(
+    HloModule Module
+
+    ENTRY entry {
+      param0 = f32[8] parameter(0)
+      param1 = f32[8] parameter(1)
+      allgather0 = f32[32] all-gather(param0), channel_id=1, replica_groups={}, dimensions={0}
+      allgather1 = f32[32] all-gather(param1), channel_id=1, replica_groups={}, dimensions={0}
+      ROOT tuple = (f32[32], f32[32]) tuple(allgather0, allgather1)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  UniqueChannelIdEnforcer enforcer(/*assert_unique_channel_ids=*/true);
+  auto status_or_changed = enforcer.Run(module.get());
+
+  EXPECT_FALSE(status_or_changed.ok());
+}
+
+TEST_F(UniqueChannelIdEnforcerTest, DuplicateChannelIdsSendReceive) {
+  const char* hlo_string = R"(
+    HloModule module_foo, entry_computation_layout={(s32[], token[])->(s32[], token[])}
+  ENTRY %foo (arg_0: s32[], arg_1: token[]) -> (s32[], token[]) {
+    %arg_0 = s32[] parameter(0)
+    %arg_1 = token[] parameter(1)
+    %send.0 = (s32[], u32[], token[]) send(s32[] %arg_0, token[] %arg_1), channel_id=3, is_host_transfer=true, sharding={{maximal device=0}, {maximal device=0}, {maximal device=0}}
+    %send-done.1 = token[] send-done((s32[], u32[], token[]) %send.0), channel_id=3, is_host_transfer=true, sharding={maximal device=0}
+    %recv.2 = (s32[], u32[], token[]) recv(token[] %send-done.1), channel_id=5, is_host_transfer=true, sharding={{maximal device=0}, {maximal device=0}, {maximal device=0}}
+    %recv-done.3 = (s32[], token[]) recv-done((s32[], u32[], token[]) %recv.2), channel_id=5, is_host_transfer=true, sharding={{maximal device=0}, {maximal device=0}}
+    %get-tuple-element.4 = s32[] get-tuple-element((s32[], token[]) %recv-done.3), index=0, sharding={maximal device=0}
+    %get-tuple-element.5 = token[] get-tuple-element((s32[], token[]) %recv-done.3), index=1, sharding={maximal device=0}
+    ROOT %tuple.6 = (s32[], token[]) tuple(s32[] %get-tuple-element.4, token[] %get-tuple-element.5)
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  UniqueChannelIdEnforcer enforcer;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, enforcer.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+}  // namespace
+}  // namespace xla


### PR DESCRIPTION
Issue #14600

This is same as PR - https://github.com/openxla/xla/pull/15002

but here send/receive ops are not enforced to have unique channel ids. This should fix the rollback of Jax peer to peer failures.