### PR TITLE
[GPU][NFC] Remove duplicate validation of cuDNN graphs.

### DIFF
--- a/xla/service/gpu/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/cudnn_fusion_compiler.cc
@@ -584,10 +584,6 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
         absl::StrCat("cudnn_fusion_", fusion.name(), ".json"),
         /*contents=*/dump.dump(1));
   }
-  if (cudnn_frontend::error_t result = graph.validate(); result.is_bad()) {
-    VLOG(3) << result.get_message();
-    return std::nullopt;
-  }
 
   return se::gpu::CudnnGraph(std::move(graph));
 }


### PR DESCRIPTION
The other time it happens for these graphs in CudnnGraph::Prepare(): https://github.com/openxla/xla/blob/45dca1a0a1d87f3d3c93fa4175e1df971acddb10/xla/stream_executor/cuda/cuda_dnn.cc#L8359
