### PR TITLE
Improve SPMD involuntary full rematerialization logging.

### DIFF
--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -568,12 +568,13 @@ PartitionedHlo PartitionedHlo::ReshardNoCache(
       }
       LOG(ERROR)
           << "[spmd] Involuntary full rematerialization. The compiler was "
-             "not able to go from sharding "
+            "not able to go from sharding "
           << sharding().ToString(/*include_metadata=*/true) << " to "
           << target.ToString(/*include_metadata=*/true)
-          << " without doing a full rematerialization of the tensor. You "
-             "probably want to enrich the sharding annotations to prevent "
-             "this from happening.";
+          << " without doing a full rematerialization of the tensor for HLO operation: "
+          << hlo_->ToString()
+          << ". You probably want to enrich the sharding annotations to prevent "
+            "this from happening.";
     }
     return Replicate().Reshard(target);
   }


### PR DESCRIPTION
When debugging poor SPMD partitioning we sometimes see this warning. This warning implies there was a conflict in shardings so the tensor had to be fully rematerialized to reshard again. 

It is difficult to debug this without knowing which Hlo Instruction the conflict was on. 