### PR TITLE
Add while loop config options and support custom-call root instruction in while loop unroll.

### DIFF
--- a/xla/service/while_loop_analysis.cc
+++ b/xla/service/while_loop_analysis.cc
@@ -60,7 +60,7 @@ static const HloInstruction* NonConstantOperand(const HloInstruction* instr) {
 // for the same value N, returns N.  Otherwise, returns nullopt.
 static optional<int64_t> GetGTEOperandIndex(const HloInstruction* instr,
                                             const HloInstruction* gte_operand) {
-  VLOG(2) << "GetGTEOperandIndex(" << instr->ToString() << ", "
+  VLOG(2) << "GetGTEOperandIndex(" << instr->ToString() << ", GTE Operand: "
           << gte_operand->ToString() << ")";
 
   // All operands of `instr` must be either constants or of the form
@@ -83,7 +83,8 @@ static optional<int64_t> GetGTEOperandIndex(const HloInstruction* instr,
     }
 
     if (!Match(possibly_gte_operand,
-               m::GetTupleElement(m::Op().Is(gte_operand)))) {
+               m::GetTupleElement(m::Op().Is(gte_operand))) &&
+        !Match(possibly_gte_operand, m::GetTupleElement(m::CustomCall(m::Op().Is(gte_operand))))) {
       return nullopt;
     }
 
@@ -280,22 +281,64 @@ optional<int64_t> GetLoopInductionVarTupleIdx(const HloInstruction* while_op) {
     return nullopt;
   }
 
-  // The while_body computation should have the form
+  // The while_body computation should have one of the following forms:
   //
+  // Form 1:
   //   while_body_inc =
   //       op(constants, get-tuple-elem(while_body_param, N), constants)
   //   while_body_root = tuple(..., while_body_inc, ...)
   //
   // where while_body_inc is operand N of while_body_root.
+  //
+  // Form 2:
+  //   while_body_inc =
+  //       op(constants, get-tuple-elem(while_body_param, N), constants)
+  //   tuple = tuple(..., while_body_inc, ...)
+  //   while_body_root = custom-call(tuple)
+  //
+  // where while_body_inc is operand N of the tuple, and the tuple is the operand
+  // of the while_body_root custom-call instruction.
+  //
+  // Form 3:
+  //   while_body_inc =
+  //       op(constants, get-tuple-elem(while_body_param, N), constants)
+  //   while_body_root = custom-call(input1, ..., while_body_inc, ...)
+  //
+  // where while_body_inc is an operand of the while_body_root custom-call
+  // instruction, and the custom-call instruction does not have a tuple operand.
   auto* while_body = while_op->while_body();
   auto* while_body_root = while_body->root_instruction();
-  if (while_body_root->opcode() != HloOpcode::kTuple) {
-    VLOG(2) << "While body's root is not a tuple instruction: "
+  if (while_body_root->opcode() != HloOpcode::kTuple && while_body_root->opcode() != HloOpcode::kCustomCall) {
+    VLOG(2) << "While body's root is not a tuple or custom-call instruction: "
             << while_body_root->ToString();
     return nullopt;
   }
-
-  auto* while_body_inc = while_body_root->operand(*indvar_tuple_idx);
+  const HloInstruction* while_body_inc; 
+  if (while_body_root->opcode() == HloOpcode::kTuple) {
+    while_body_inc = while_body_root->operand(*indvar_tuple_idx);
+  }
+  else {
+    // Custom-call cases
+    if (while_body_root->operand_count() == 1 && while_body_root->operand(0)->opcode() == HloOpcode::kTuple) {
+      // Custom-call case
+      // Single tuple operand.
+      auto* while_body_root_input_tuple = while_body_root->operand(0);
+      if (*indvar_tuple_idx >= while_body_root_input_tuple->operand_count()) {
+        VLOG(2) << "Cannot find the induction variable in the output root custom-call " << while_body_root->ToString();
+        return std::nullopt;
+      }
+      while_body_inc = while_body_root_input_tuple->operand(*indvar_tuple_idx);
+      }
+    else {
+      // Custom-call case
+      // Operand is not single tuple.
+      if (*indvar_tuple_idx >= while_body_root->operand_count()) {
+        VLOG(2) << "Cannot find the induction variable in the output root custom-call " << while_body_root->ToString();
+        return std::nullopt;
+      }
+      while_body_inc = while_body_root->operand(*indvar_tuple_idx);
+    }
+  }
   auto* while_body_param = while_body->parameter_instruction(0);
   optional<int64_t> while_body_indvar_tuple_idx =
       GetGTEOperandIndex(while_body_inc, while_body_param);
@@ -367,8 +410,26 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
   // Check that `i` goes as `i += k` in the while body where k is a natural
   // number.
   auto* while_body = while_op->while_body();
-  auto* while_body_indvar_update =
-      while_body->root_instruction()->mutable_operand(indvar_tuple_idx);
+  auto* while_body_root = while_body->root_instruction();
+  HloInstruction* while_body_indvar_update;
+
+  if (while_body_root->opcode() == HloOpcode::kCustomCall) {
+      // We know it must be a custom-call.
+      if (while_body_root->operand_count() == 1 && while_body_root->operand(0)->opcode() == HloOpcode::kTuple) {
+      // Custom-call case
+      // Single tuple operand.
+      auto* while_body_root_input_tuple = while_body_root->mutable_operand(0);
+      while_body_indvar_update = while_body_root_input_tuple->mutable_operand(indvar_tuple_idx);
+      }
+    else {
+      // Custom-call case
+      // Operand is not single tuple.
+      while_body_indvar_update = while_body_root->mutable_operand(indvar_tuple_idx);
+    }
+  }
+  else { 
+    while_body_indvar_update = while_body_root->mutable_operand(indvar_tuple_idx);
+  }
   auto* while_body_indvar = NonConstantOperand(while_body_indvar_update);
   HloInstruction* trip_count_increase_step_instr = nullptr;
   int64_t trip_count_step = 0;

--- a/xla/service/while_loop_analysis_test.cc
+++ b/xla/service/while_loop_analysis_test.cc
@@ -130,6 +130,71 @@ TEST_F(WhileLoopAnalysisTest, SingleIterationUpperBound) {
   EXPECT_EQ(*ComputeWhileLoopTripCountUpperBound(while_op), 1);
 }
 
+TEST_F(WhileLoopAnalysisTest, SimpleLoopWithCustomCallNonTuple){
+  std::string hlo_string = R"(
+  HloModule SimpleLoop
+  SimpleLoop.body {
+    loop_var.1 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    custom-call.1 = (s32[]{:T(128)}, s32[3]{0}) custom-call(loop_var.1), custom_call_target="CustomCallStart"
+    get-tuple-element.1 = s32[]{:T(128)} get-tuple-element(custom-call.1), index=0
+    constant.1 = s32[]{:T(128)} constant(1)
+    idx = s32[]{:T(128)} add(get-tuple-element.1, constant.1)
+    get-tuple-element.2 = s32[3]{0} get-tuple-element(custom-call.1), index=1
+    output = s32[3]{0} add(get-tuple-element.2, get-tuple-element.2)
+    ROOT custom-call.2 = (s32[]{:T(128)}, s32[3]{0}) custom-call(idx, output), custom_call_target="CustomCallEnd"
+  }
+  SimpleLoop.condition {
+    loop_var.2 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    get-tuple-element.5 = s32[] get-tuple-element(loop_var.2), index=0
+    constant.2 = s32[]{:T(128)} constant(5)
+    ROOT less-than = pred[] compare(get-tuple-element.5, constant.2), direction=LT
+  }
+  ENTRY SimpleLoop {
+    constant.3 = s32[]{:T(128)} constant(0)
+    constant.4 = s32[3]{0} constant({0, 1, 2})
+    tuple.1 = (s32[]{:T(128)}, s32[3]{0}) tuple(constant.3, constant.4)
+    ROOT while = (s32[]{:T(128)}, s32[3]{0}) while(tuple.1), condition=
+      SimpleLoop.condition, body=SimpleLoop.body
+  }
+  )";
+  auto m = ParseAndReturnVerifiedModule(hlo_string).value();
+  HloInstruction* while_op = m->entry_computation()->root_instruction();
+  EXPECT_EQ(*ComputeWhileLoopTripCountUpperBound(while_op), 5);
+}
+
+TEST_F(WhileLoopAnalysisTest, SimpleLoopWithCustomCall){
+  std::string hlo_string = R"(
+  HloModule SimpleLoop
+  SimpleLoop.body {
+    loop_var.1 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    custom-call.1 = (s32[]{:T(128)}, s32[3]{0}) custom-call(loop_var.1), custom_call_target="CustomCallStart"
+    get-tuple-element.1 = s32[]{:T(128)} get-tuple-element(custom-call.1), index=0
+    constant.1 = s32[]{:T(128)} constant(1)
+    idx = s32[]{:T(128)} add(get-tuple-element.1, constant.1)
+    get-tuple-element.2 = s32[3]{0} get-tuple-element(custom-call.1), index=1
+    output = s32[3]{0} add(get-tuple-element.2, get-tuple-element.2)
+    tuple = (s32[]{:T(128)}, s32[3]{0}) tuple(idx, output)
+    ROOT custom-call.2 = (s32[]{:T(128)}, s32[3]{0}) custom-call(tuple), custom_call_target="CustomCallEnd"
+  }
+  SimpleLoop.condition {
+    loop_var.2 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    get-tuple-element.3 = s32[] get-tuple-element(loop_var.2), index=0
+    constant.2 = s32[]{:T(128)} constant(5)
+    ROOT less-than = pred[] compare(get-tuple-element.3, constant.2), direction=LT
+  }
+  ENTRY SimpleLoop {
+    constant.3 = s32[]{:T(128)} constant(0)
+    constant.4 = s32[3]{0} constant({0, 1, 2})
+    tuple.1 = (s32[]{:T(128)}, s32[3]{0}) tuple(constant.3, constant.4)
+    ROOT while = (s32[]{:T(128)}, s32[3]{0}) while(tuple.1), condition=
+      SimpleLoop.condition, body=SimpleLoop.body
+  }
+  )";
+  auto m = ParseAndReturnVerifiedModule(hlo_string).value();
+  HloInstruction* while_op = m->entry_computation()->root_instruction();
+  EXPECT_EQ(*ComputeWhileLoopTripCountUpperBound(while_op), 5);
+}
+
 TEST_F(WhileLoopAnalysisTest, NoUpperBound) {
   const char* const kHloModule = R"(
     HloModule ModuleWithWhile

--- a/xla/service/while_loop_unroller.cc
+++ b/xla/service/while_loop_unroller.cc
@@ -64,11 +64,6 @@ namespace {
 
 using hlo_query::ContainsInstrWithOpcode;
 
-// Parameters for the unroller that can be adjusted.
-const int kUnrollTripCountThreshold = 64;
-const int kUnrollInstructionCountThreshold = 800;
-const int kUnrollExpandFactorThreshold = 10000;
-
 // Helper function to create a condition for a single iteration while loop in
 // the form of 'i <= init_value' where i is the induction variable.
 std::unique_ptr<HloComputation> MakeTrivialLoopCondition(
@@ -232,42 +227,39 @@ UnrollSingleIterationOfTrivialLoop(HloInstruction* while_op,
 // 2. trip count.
 // 3. unroll expansion limit (#_body_instructions * trip_count).
 // These conditions can be changed per usecase.
-bool InitialFeasibilityCheck(HloInstruction* while_op, WhileLoopConfig config) {
+bool InitialFeasibilityCheck(const HloInstruction* while_op, const WhileLoopConfig config, const UnrollConfig unroll_config) {
   CHECK_EQ(while_op->opcode(), HloOpcode::kWhile);
 
   VLOG(5) << "Trying to unroll " << while_op->ToShortString();
 
-  // TODO(b/291628533): Extract this parameter to the unroller config. We don't
-  // attempt to unroll loops where the body has more than
+  // We don't attempt to unroll loops where the body has more than
   // kUnrollInstructionCountThreshold instructions.
   if (while_op->while_body()->instruction_count() >
-      kUnrollInstructionCountThreshold) {
+      unroll_config.instruction_count_threshold) {
     VLOG(5) << absl::StrCat(
         "Cannot unroll while loop. Too many instructions in the body: ",
         while_op->while_body()->instruction_count());
     return false;
   }
 
-  // TODO(b/291628533): Extract this parameter to the an unroller config. We
-  // only unroll loops up to a threshold.
-  if (config.trip_count > kUnrollTripCountThreshold) {
+  // We only unroll loops up to a threshold.
+  if (config.trip_count > unroll_config.trip_count_threshold) {
     VLOG(5) << absl::StrCat(
-        "Cannot unroll while loop. The tip count is greater "
+        "Cannot unroll while loop. The trip count is greater "
         "than the threshold: ",
-        config.trip_count, " vs ", kUnrollTripCountThreshold);
+        config.trip_count, " vs ", unroll_config.trip_count_threshold);
     return false;
   }
 
-  // TODO(b/291628533): Extract this parameter to the unroller config. We don't
-  // unroll loops that increase the instruction count by more than
+  // We don't unroll loops that increase the instruction count by more than
   // kUnrollExpandFactorThreshold.
   if (config.trip_count * while_op->while_body()->instruction_count() >
-      kUnrollExpandFactorThreshold) {
+      unroll_config.expand_factor_threshold) {
     VLOG(5) << absl::StrCat(
         "Not attempting to unroll due to instruction count "
         "increase explosion. New instruction count: ",
         config.trip_count * while_op->while_body()->instruction_count(), " vs ",
-        kUnrollExpandFactorThreshold);
+        unroll_config.expand_factor_threshold);
     return false;
   }
   return true;
@@ -278,7 +270,6 @@ absl::StatusOr<bool> UnrollInternal(HloInstruction* while_op,
   VLOG(3) << "Unrolling while instruction " << while_op->ToShortString()
           << " with body instruction count "
           << while_op->while_body()->instruction_count();
-
   HloModule* module = while_op->GetModule();
   HloComputation* computation = while_op->parent();
   HloInstruction* unrolled_body_call_op;
@@ -599,7 +590,6 @@ std::optional<int64_t> MatchShapeCoveringDynamicIndexInstruction(
             << while_op->ToShortString();
     return std::nullopt;
   }
-
   std::optional<int64_t> indvar_tuple_idx =
       GetLoopInductionVarTupleIdx(while_op);
   if (!indvar_tuple_idx.has_value()) {
@@ -618,7 +608,6 @@ std::optional<int64_t> MatchShapeCoveringDynamicIndexInstruction(
     return std::nullopt;
   }
   Literal indvar_iter_val = std::move(indvar_init_result).value();
-
   std::optional<int64_t> trip_count =
       MatchTrivialLoopTripCount(while_op, *indvar_tuple_idx, indvar_iter_val);
   if (!trip_count.has_value()) {
@@ -673,7 +662,7 @@ std::optional<int64_t> MatchShapeCoveringDynamicIndexInstruction(
 /*static*/ std::vector<std::pair<HloInstruction*, WhileLoopConfig>>
 WhileLoopUnroller::GetUnrollableLoops(
     HloModule* module,
-    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+    const absl::flat_hash_set<absl::string_view>& execution_threads, const UnrollConfig& unroll_config) {
   // Processing the while loops in the reverse topological order. If the body
   // of while loop A calls while loop B, B comes before A.
   std::vector<HloInstruction*> all_while_ops;
@@ -681,12 +670,11 @@ WhileLoopUnroller::GetUnrollableLoops(
     absl::c_copy_if(comp->instructions(), std::back_inserter(all_while_ops),
                     HloPredicateIsOp<HloOpcode::kWhile>);
   }
-
   std::vector<std::pair<HloInstruction*, WhileLoopConfig>> while_loop_configs;
   for (HloInstruction* instr : all_while_ops) {
     std::optional<WhileLoopConfig> config = IsLoopUnrollable(instr);
     if (config.has_value()) {
-      if (!InitialFeasibilityCheck(instr, config.value())) {
+      if (!InitialFeasibilityCheck(instr, config.value(), unroll_config)) {
         VLOG(3) << "Initial feasibility check failed for " << instr->name();
         continue;
       }
@@ -700,7 +688,7 @@ WhileLoopUnroller::GetUnrollableLoops(
 WhileLoopUnroller::UnrollAndReturnReplacement(HloInstruction* while_op,
                                               int64_t unroll_factor,
                                               bool wrap_in_trivial_loop,
-                                              bool force_unroll, bool prepare) {
+                                              bool force_unroll, bool prepare, const UnrollConfig& unroll_config) {
   UnrollResult result;
 
   HloModule* module = while_op->GetModule();
@@ -728,7 +716,7 @@ WhileLoopUnroller::UnrollAndReturnReplacement(HloInstruction* while_op,
     return result;
   }
 
-  if (!force_unroll && !InitialFeasibilityCheck(while_op, config.value())) {
+  if (!force_unroll && !InitialFeasibilityCheck(while_op, config.value(), unroll_config)) {
     return result;
   }
   if (wrap_in_trivial_loop) {
@@ -758,12 +746,10 @@ absl::StatusOr<bool> WhileLoopUnroller::Run(
   }
   XLA_VLOG_LINES(3, "WhileLoopUnroller::Run(), before:\n" + module->ToString());
   bool changed = false;
-
   // Make sure all the necessary passes are executed before unrolling in order
   // to unroll every possible loop.
   TF_ASSIGN_OR_RETURN(changed,
                       PrepareModuleForUnrolling(module, execution_threads));
-
   // Processing the while loops in the reverse of topological order. If the body
   // of while loop A calls while loop B, B comes before A.
   std::vector<HloInstruction*> all_while_ops;
@@ -771,13 +757,11 @@ absl::StatusOr<bool> WhileLoopUnroller::Run(
     absl::c_copy_if(comp->instructions(), std::back_inserter(all_while_ops),
                     HloPredicateIsOp<HloOpcode::kWhile>);
   }
-
   // Gather a preliminary vector of all the while ops that we think we can
   // unroll. We do this ahead of time so we don't have to worry about mutating
   // the lists of computations or instructions while we iterate.
   std::vector<std::pair<HloInstruction*, WhileLoopConfig>>
-      unrollable_while_ops = GetUnrollableLoops(module, execution_threads);
-
+      unrollable_while_ops = GetUnrollableLoops(module, execution_threads, unroll_config_);
   VLOG(3) << "Number of while instructions in the module to unroll: "
           << unrollable_while_ops.size();
 

--- a/xla/service/while_loop_unroller.h
+++ b/xla/service/while_loop_unroller.h
@@ -31,6 +31,13 @@ limitations under the License.
 
 namespace xla {
 
+// Config for unroll thresholds.
+struct UnrollConfig {
+  int64_t trip_count_threshold = 64;
+  int64_t instruction_count_threshold = 800;
+  int64_t expand_factor_threshold = 10000;
+};
+
 // Config for unrollable while loops.
 struct WhileLoopConfig {
   const HloInstruction* while_instr;
@@ -88,9 +95,11 @@ class WhileLoopUnroller : public HloModulePass {
 
   // Default unroll_factor of -1 indicates full unrolling
   explicit WhileLoopUnroller(int64_t unroll_factor = -1,
-                             bool wrap_in_trivial_loop = false)
+                             bool wrap_in_trivial_loop = false,
+                             UnrollConfig config = UnrollConfig())
       : unroll_factor_(unroll_factor),
-        wrap_in_trivial_loop_(wrap_in_trivial_loop) {}
+        wrap_in_trivial_loop_(wrap_in_trivial_loop),
+        unroll_config_(config) {}
 
   absl::string_view name() const override { return "while_loop_unroller"; }
 
@@ -115,7 +124,7 @@ class WhileLoopUnroller : public HloModulePass {
   static std::vector<std::pair<HloInstruction*, WhileLoopConfig>>
   GetUnrollableLoops(
       HloModule* module,
-      const absl::flat_hash_set<absl::string_view>& execution_threads);
+      const absl::flat_hash_set<absl::string_view>& execution_threads, const UnrollConfig& unroll_config= UnrollConfig());
 
   // Unrolls the given while loop with the default behaviour set to full unroll.
   // If wrap_in_trivial_loop is set, the unrolled body of the loop will be
@@ -126,12 +135,13 @@ class WhileLoopUnroller : public HloModulePass {
   static absl::StatusOr<UnrollResult> UnrollAndReturnReplacement(
       HloInstruction* while_op, int64_t unroll_factor = -1,
       bool wrap_in_trivial_loop = false, bool force_unroll = false,
-      bool prepare = true);
+      bool prepare = true, const UnrollConfig& unroll_config = UnrollConfig());
 
  private:
   int64_t unroll_factor_;
   // Whether to wrap the unrolled computation in a loop with trip count of one.
   bool wrap_in_trivial_loop_;
+  UnrollConfig unroll_config_;
 };
 
 }  // namespace xla

--- a/xla/service/while_loop_unroller_test.cc
+++ b/xla/service/while_loop_unroller_test.cc
@@ -691,6 +691,13 @@ TEST_F(WhileLoopUnrollerTest, SimpleLoopPartialUnroll) {
   EXPECT_FALSE(WhileLoopUnroller(/*unroll_factor=*/3).Run(m.get()).value());
 }
 
+TEST_F(WhileLoopUnrollerTest, SimpleLoopNoUnrollDueToTripCountThreshold) {
+  auto m = MakeModuleWithSimpleLoop(/*num_iters=*/5);
+  UnrollConfig config;
+  config.trip_count_threshold = 0;  // Set the trip count threshold to 0.
+  EXPECT_FALSE(WhileLoopUnroller(/*unroll_factor=*/-1, /*wrap_in_trivial_loop=*/false, config).Run(m.get()).value());
+}
+
 TEST_F(WhileLoopUnrollerTest, IndirectBodyInc) {
   std::unique_ptr<HloModule> module =
       MakeModuleWithLoopBodyIndirectInc(/*num_iters=*/5);
@@ -1192,6 +1199,107 @@ TEST_F(WhileLoopUnrollerTest, IsEffectivelyStaticDynamicSlice) {
     }
   }
 }
+// We do not support case where there is no tuple for input.
+TEST_F(WhileLoopUnrollerTest, SimpleLoopWithCustomCallNoTuple) {
+  std::string hlo_string = R"(
+  HloModule SimpleLoop
+  SimpleLoop.body {
+    loop_var.1 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    get-tuple-element.1 = s32[]{:T(128)} get-tuple-element(loop_var.1), index=0
+    get-tuple-element.2 = s32[3]{0} get-tuple-element(loop_var.1), index=1
+    custom-call.1 = (s32[]{:T(128)}, s32[3]{0}) custom-call(get-tuple-element.1, get-tuple-element.2), custom_call_target="CustomCallStart"
+    get-tuple-element.3 = s32[]{:T(128)} get-tuple-element(custom-call.1), index=0
+    constant.1 = s32[]{:T(128)} constant(1)
+    idx = s32[]{:T(128)} add(get-tuple-element.3, constant.1)
+    get-tuple-element.4 = s32[3]{0} get-tuple-element(custom-call.1), index=1
+    output = s32[3]{0} add(get-tuple-element.4, get-tuple-element.4)
+    tuple = (s32[]{:T(128)}, s32[3]{0}) tuple(idx, output)
+    ROOT custom-call.2 = (s32[]{:T(128)}, s32[3]{0}) custom-call(idx, output), custom_call_target="CustomCallEnd"
+  }
+  SimpleLoop.condition {
+    loop_var.2 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    get-tuple-element.5 = s32[] get-tuple-element(loop_var.2), index=0
+    constant.2 = s32[]{:T(128)} constant(5)
+    ROOT less-than = pred[] compare(get-tuple-element.5, constant.2), direction=LT
+  }
+  ENTRY SimpleLoop {
+    constant.3 = s32[]{:T(128)} constant(0)
+    constant.4 = s32[3]{0} constant({0, 1, 2})
+    tuple.1 = (s32[]{:T(128)}, s32[3]{0}) tuple(constant.3, constant.4)
+    ROOT while = (s32[]{:T(128)}, s32[3]{0}) while(tuple.1), condition=
+      SimpleLoop.condition, body=SimpleLoop.body
+  }
+  )";
+  auto m = ParseAndReturnVerifiedModule(hlo_string).value();
+  UnrollConfig config;
+  EXPECT_FALSE(WhileLoopUnroller(/*unroll_factor=*/-1, /*wrap_in_trivial_loop=*/false, config).Run(m.get()).value());
+}
+
+TEST_F(WhileLoopUnrollerTest, SimpleLoopWithCustomCallNonTupleForRoot) {
+  std::string hlo_string = R"(
+  HloModule SimpleLoop
+  SimpleLoop.body {
+    loop_var.1 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    custom-call.1 = (s32[]{:T(128)}, s32[3]{0}) custom-call(loop_var.1), custom_call_target="CustomCallStart"
+    get-tuple-element.1 = s32[]{:T(128)} get-tuple-element(custom-call.1), index=0
+    constant.1 = s32[]{:T(128)} constant(1)
+    idx = s32[]{:T(128)} add(get-tuple-element.1, constant.1)
+    get-tuple-element.2 = s32[3]{0} get-tuple-element(custom-call.1), index=1
+    output = s32[3]{0} add(get-tuple-element.2, get-tuple-element.2)
+    ROOT custom-call.2 = (s32[]{:T(128)}, s32[3]{0}) custom-call(idx, output), custom_call_target="CustomCallEnd"
+  }
+  SimpleLoop.condition {
+    loop_var.2 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    get-tuple-element.5 = s32[] get-tuple-element(loop_var.2), index=0
+    constant.2 = s32[]{:T(128)} constant(5)
+    ROOT less-than = pred[] compare(get-tuple-element.5, constant.2), direction=LT
+  }
+  ENTRY SimpleLoop {
+    constant.3 = s32[]{:T(128)} constant(0)
+    constant.4 = s32[3]{0} constant({0, 1, 2})
+    tuple.1 = (s32[]{:T(128)}, s32[3]{0}) tuple(constant.3, constant.4)
+    ROOT while = (s32[]{:T(128)}, s32[3]{0}) while(tuple.1), condition=
+      SimpleLoop.condition, body=SimpleLoop.body
+  }
+  )";
+  auto m = ParseAndReturnVerifiedModule(hlo_string).value();
+  UnrollConfig config;
+  EXPECT_TRUE(WhileLoopUnroller(/*unroll_factor=*/-1, /*wrap_in_trivial_loop=*/false, config).Run(m.get()).value());
+}
+
+TEST_F(WhileLoopUnrollerTest, SimpleLoopWithCustomCall){
+  std::string hlo_string = R"(
+  HloModule SimpleLoop
+  SimpleLoop.body {
+    loop_var.1 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    custom-call.1 = (s32[]{:T(128)}, s32[3]{0}) custom-call(loop_var.1), custom_call_target="CustomCallStart"
+    get-tuple-element.1 = s32[]{:T(128)} get-tuple-element(custom-call.1), index=0
+    constant.1 = s32[]{:T(128)} constant(1)
+    idx = s32[]{:T(128)} add(get-tuple-element.1, constant.1)
+    get-tuple-element.2 = s32[3]{0} get-tuple-element(custom-call.1), index=1
+    output = s32[3]{0} add(get-tuple-element.2, get-tuple-element.2)
+    tuple = (s32[]{:T(128)}, s32[3]{0}) tuple(idx, output)
+    ROOT custom-call.2 = (s32[]{:T(128)}, s32[3]{0}) custom-call(tuple), custom_call_target="CustomCallEnd"
+  }
+  SimpleLoop.condition {
+    loop_var.2 = (s32[]{:T(128)}, s32[3]{0}) parameter(0)
+    get-tuple-element.3 = s32[] get-tuple-element(loop_var.2), index=0
+    constant.2 = s32[]{:T(128)} constant(5)
+    ROOT less-than = pred[] compare(get-tuple-element.3, constant.2), direction=LT
+  }
+  ENTRY SimpleLoop {
+    constant.3 = s32[]{:T(128)} constant(0)
+    constant.4 = s32[3]{0} constant({0, 1, 2})
+    tuple.1 = (s32[]{:T(128)}, s32[3]{0}) tuple(constant.3, constant.4)
+    ROOT while = (s32[]{:T(128)}, s32[3]{0}) while(tuple.1), condition=
+      SimpleLoop.condition, body=SimpleLoop.body
+  }
+  )";
+  auto m = ParseAndReturnVerifiedModule(hlo_string).value();
+  UnrollConfig config;
+  EXPECT_TRUE(WhileLoopUnroller(/*unroll_factor=*/-1, /*wrap_in_trivial_loop=*/false, config).Run(m.get()).value());
+}
+
 
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
This PR adds the availability to configure while loop unroll thresholds. Existing defaults are maintained. This PR also adds the option for the user to specify an HloPassPipeline that will be run immediately before unroll. This is very important and by design. Some proprietary passes need to be run immediately before the unroll as the last step. The pipeline is defaulted to nullptr.