### PR TITLE
[GPU] Make cuDNN GEMM fusions respect determinism settings.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2639,6 +2639,7 @@ cc_library(
         ":ir_emission_utils",
         ":kernel_reuse_cache",
         ":matmul_utils",
+        ":stream_executor_util",
         ":triton_fusion_analysis",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/xla/service/gpu/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/cudnn_fusion_compiler.cc
@@ -49,6 +49,7 @@ limitations under the License.
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/kernel_reuse_cache.h"
 #include "xla/service/gpu/matmul_utils.h"
+#include "xla/service/gpu/stream_executor_util.h"
 #include "xla/service/gpu/triton_fusion_analysis.h"
 #include "xla/shape_util.h"
 #include "xla/stream_executor/cuda/cuda_dnn.h"
@@ -187,7 +188,7 @@ int FusionLevel(const HloInstruction& hlo) {
 class GemmDimensionAdapter {
   explicit GemmDimensionAdapter(const HloDotInstruction& dot,
                                 TritonFusionAnalysis analysis)
-      : analysis_(std::move(analysis)), dot_(dot) {};
+      : analysis_(std::move(analysis)), dot_(dot){};
 
  public:
   const TritonFusionAnalysis analysis_;
@@ -596,7 +597,10 @@ absl::StatusOr<se::gpu::CudnnGraph> PrepareGraph(
   if (!graph.has_value()) {
     return absl::InternalError("Construction of cuDNN graph failed.");
   }
-  TF_RETURN_IF_ERROR(graph->Prepare(dnn_support));
+  TF_RETURN_IF_ERROR(graph->Prepare(
+      dnn_support,
+      se::NumericOptions{RequireDeterminism(hlo.GetModule()->config()),
+                         /*allow_tf32=*/true}));
   return *graph;
 }
 

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -60,7 +60,7 @@ class CudnnGraph : public dnn::DnnGraph {
   explicit CudnnGraph(cudnn_frontend::graph::Graph&& graph)
       : graph_(std::move(graph)) {}
   // Prepares a graph and checks whether it is generally supported.
-  absl::Status Prepare(dnn::DnnSupport&) override;
+  absl::Status Prepare(dnn::DnnSupport&, const NumericOptions&) override;
   // Builds single plan of the graph with given ID.
   absl::Status Build(dnn::DnnSupport&, std::optional<int64_t> plan_id) override;
   // Builds all the plans

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1257,11 +1257,7 @@ class DnnGraph {
   DnnGraph() = default;
   virtual ~DnnGraph() = default;
 
-  // Returns non-OK status on hard failures (incorrectly constructed graph,
-  // anything else unexpected),
-  // false on expected ones (graph is valid but not supported),
-  // true on success.
-  virtual absl::Status Prepare(DnnSupport&) = 0;
+  virtual absl::Status Prepare(DnnSupport&, const NumericOptions&) = 0;
   virtual absl::Status Build(DnnSupport&, std::optional<int64_t> plan_id) = 0;
   virtual absl::Status Execute(Stream& stream,
                                absl::Span<DeviceMemoryBase> operands) const = 0;


### PR DESCRIPTION
There is no test because I didn't find a way to trigger nondeterminism with current cuDNN.

No changes are expected in behavior of flash attention, it's only updated here because it uses the common CudnnGraph::Prepare().