### PR TITLE
[GPU] Add a flag for the number of cuDNN plans per fusion

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -283,6 +283,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   opts.set_xla_enable_command_buffers_during_profiling(false);
 
+  opts.set_xla_gpu_cudnn_gemm_max_plans(5);
+
   return opts;
 }
 
@@ -1840,6 +1842,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "Experimental: Enable command buffers while a profiling active. "
       "By default, enabling profiling switches from command buffers to "
       "op-by-op mode."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_cudnn_gemm_max_plans",
+      int32_setter_for(&DebugOptions::set_xla_gpu_cudnn_gemm_max_plans),
+      debug_options->xla_gpu_cudnn_gemm_max_plans(),
+      "Limit for the number of kernel configurations (plans) to use during "
+      "autotuning of cuDNN GEMM fusions."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/gpu/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/cudnn_fusion_compiler.cc
@@ -187,7 +187,7 @@ int FusionLevel(const HloInstruction& hlo) {
 class GemmDimensionAdapter {
   explicit GemmDimensionAdapter(const HloDotInstruction& dot,
                                 TritonFusionAnalysis analysis)
-      : analysis_(std::move(analysis)), dot_(dot) {};
+      : analysis_(std::move(analysis)), dot_(dot){};
 
  public:
   const TritonFusionAnalysis analysis_;
@@ -726,8 +726,9 @@ int CuDnnFusionCompiler::GetAvailablePlanCount(
   if (!graph.ok()) {
     return 0;
   }
-  constexpr int64_t kMaxPlans = 10;
-  return std::min(graph->Graph().get_execution_plan_count(), kMaxPlans);
+  return std::min(
+      int32_t(graph->Graph().get_execution_plan_count()),
+      hlo.GetModule()->config().debug_options().xla_gpu_cudnn_gemm_max_plans());
 }
 
 }  // namespace gpu

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -878,7 +878,12 @@ message DebugOptions {
   // TODO(b/355487968): Remove this option when validation complete.
   bool xla_enable_command_buffers_during_profiling = 317;
 
-  // Next id: 318
+  // Limit for the number of kernel configurations (plans) to use during
+  // autotuning of cuDNN GEMM fusions. The more - the slower the autotuning
+  // but potentially higher the performance.
+  int32 xla_gpu_cudnn_gemm_max_plans = 318;
+
+  // Next id: 319
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
and lower the default value from 10 to 5 - our benchmarking indicates that this is sufficient.