### PR TITLE
Add PassesIncGen to ChloPasses in xla/mlir_hlo/mhlo/transforms/CMakeL…

### DIFF
--- a/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
+++ b/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
@@ -175,6 +175,7 @@ add_mlir_library(ChloPasses
   MLIRhlo_opsIncGen
   MLIRChloLegalizeToHloIncGen
   MLIRMhloPassIncGen
+  PassesIncGen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
Hello!

We're updating jax version (v0.4.28) in our [MLIR based compiler](https://github.com/PennyLaneAI/catalyst/). However, our CI/CD process failed when building `mlir-hlo-opt` (please see [this Github Action](https://github.com/PennyLaneAI/catalyst/actions/runs/10113602669/job/27970370343?pr=931)). We’ve tested the build both locally and on an AWS instance without encountering the error. The main difference is that local and aws environments build `mlir-hlo-opt` in parallel, while the CI/CD runner only uses a single core. We believe this issue is similar to a previous PR ([#61071](https://github.com/openxla/xla/pull/3857)), where building with a single core fails to resolve a missing dependency. Thank you very much.

**Description of the Change:** This patch adds `PassesIncGen` as a dependency to `ChloPasses`. Otherwise, single-core build would fail because it cannot find `stablehlo/transforms/Passes.h.inc`.

**Related GitHub Issues:** Similar to https://github.com/tensorflow/mlir-hlo/issues/68.