### PR TITLE
Add the host memory deallocation in GpuExecutor::Deallocate

### DIFF
--- a/xla/service/gpu/gpu_offloading_test.cc
+++ b/xla/service/gpu/gpu_offloading_test.cc
@@ -249,6 +249,19 @@ TEST_F(GpuOffloadingTest, CopyIRCreationTest) {
                                       /*run_hlo_passes=*/false));
 }
 
+// The memory management operations (allocation and deallocation) for the host
+// in unit test below mirror those employed for host offloading in this file.
+TEST_F(GpuOffloadingTest, XLAHostMemoryAllocationDeallocationTest) {
+  stream_executor::StreamExecutor* executor =
+      backend().default_stream_executor();
+  stream_executor::DeviceMemoryBase host_ptr =
+      executor->Allocate(64, (int64_t)(stream_executor::MemoryType::kHost));
+  TF_ASSERT_OK_AND_ASSIGN(auto memory_space,
+                          executor->GetPointerMemorySpace(host_ptr.opaque()));
+  EXPECT_EQ(memory_space, stream_executor::MemoryType::kHost);
+  executor->Deallocate(&host_ptr);
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -486,7 +486,12 @@ DeviceMemoryBase GpuExecutor::Allocate(uint64_t size, int64_t memory_space) {
 }
 
 void GpuExecutor::Deallocate(DeviceMemoryBase* mem) {
-  TF_ASSIGN_OR_RETURN(auto memory_space, GetPointerMemorySpace(mem->opaque()));
+  auto status_or_memory_space = GetPointerMemorySpace(mem->opaque());
+  if (!status_or_memory_space.ok()) {
+    LOG(ERROR) << status_or_memory_space.status();
+    return;
+  }
+  auto memory_space = status_or_memory_space.value();
   if (memory_space == MemoryType::kHost) {
     GpuDriver::HostDeallocate(context_, mem->opaque());
   } else {

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -486,7 +486,12 @@ DeviceMemoryBase GpuExecutor::Allocate(uint64_t size, int64_t memory_space) {
 }
 
 void GpuExecutor::Deallocate(DeviceMemoryBase* mem) {
-  GpuDriver::DeviceDeallocate(context_, mem->opaque());
+  TF_ASSIGN_OR_RETURN(auto memory_space, GetPointerMemorySpace(mem->opaque()));
+  if (memory_space == MemoryType::kHost) {
+    GpuDriver::HostDeallocate(context_, mem->opaque());
+  } else {
+    GpuDriver::DeviceDeallocate(context_, mem->opaque());
+  }
 }
 
 bool GpuExecutor::SynchronizeAllActivity() {


### PR DESCRIPTION
This CL adds the missing host memory deallocation according to the pointer's host memory space allocated by GpuExecutor::Allocate() .