### PR TITLE
Fix separator detection in name uniquer.

### DIFF
--- a/xla/service/name_uniquer.cc
+++ b/xla/service/name_uniquer.cc
@@ -83,8 +83,8 @@ std::string NameUniquer::GetUniqueName(absl::string_view prefix) {
   int64_t numeric_suffix = 0;
   size_t separator_index = root.rfind(separator_);
   if (separator_index != std::string::npos && (separator_index > 0) &&
-      (separator_index < root.size() - 1)) {
-    std::string after_suffix = root.substr(separator_index + 1);
+      (separator_index < root.size() - separator_.size())) {
+    std::string after_suffix = root.substr(separator_index + separator_.size());
     if (absl::SimpleAtoi(after_suffix, &numeric_suffix)) {
       has_numeric_suffix = true;
       // Remove numeric suffix from root.

--- a/xla/service/name_uniquer_test.cc
+++ b/xla/service/name_uniquer_test.cc
@@ -14,17 +14,12 @@ limitations under the License.
 ==============================================================================*/
 
 #include "xla/service/name_uniquer.h"
-
-#include <memory>
-#include <utility>
-#include <vector>
-
 #include "tsl/platform/test.h"
 
 namespace xla {
 namespace {
 
-class NameUniquerTest : public ::testing::Test {};
+using NameUniquerTest = ::testing::Test;
 
 TEST_F(NameUniquerTest, SimpleUniquer) {
   NameUniquer uniquer;
@@ -124,6 +119,14 @@ TEST_F(NameUniquerTest, AvoidKeywords) {
   EXPECT_EQ("F32", uniquer.GetUniqueName("F32"));
   EXPECT_EQ("S32", uniquer.GetUniqueName("S32"));
   EXPECT_EQ("Pred", uniquer.GetUniqueName("Pred"));
+}
+
+TEST_F(NameUniquerTest, DetectSeparator) {
+  NameUniquer uniquer;
+
+  EXPECT_EQ(uniquer.GetUniqueName("a__1"), "a__1");
+  EXPECT_EQ(uniquer.GetUniqueName("a"), "a");
+  EXPECT_EQ(uniquer.GetUniqueName("a"), "a__2");
 }
 
 }  // namespace


### PR DESCRIPTION
Name uniquer [guarantees](https://github.com/openxla/xla/blob/4228782cc8ecaa8411e988bae08aa9251507e8e9/xla/service/name_uniquer.h#L30) to return distinct names but currently does not. For the sequence of inputs like the one added in the test (a__1, a, a) it will currently return a__1, a, a__1, the last output being a duplicate of the first one. This breaks GPU kernel binary caching.

[This](https://github.com/openxla/xla/blob/4228782cc8ecaa8411e988bae08aa9251507e8e9/xla/service/name_uniquer.cc#L80-L96) code tries to detect the separator, which by default is "__", double underscore, in the input string and split the input string into root and suffix, for a__1 that should be a and 1. But because the code assumes the separator length to be 1, and even the default separator has length 2, this probably almost never works. As a result in a__1 further [atoi](https://github.com/openxla/xla/blob/4228782cc8ecaa8411e988bae08aa9251507e8e9/xla/service/name_uniquer.cc#L88) tries to parse "_1" instead of "1" and fails. This leads to incorrect [registration of names](https://github.com/openxla/xla/blob/4228782cc8ecaa8411e988bae08aa9251507e8e9/xla/service/name_uniquer.cc#L98-L99) in the end.

The fix is to simply take the actual separator string length instead of 1.