### PR TITLE
[ROCm] hot fix rocm build due to triton update LDS pass 

### DIFF
--- a/xla/service/gpu/fusions/triton/compilation_pipeline_rocm.cc
+++ b/xla/service/gpu/fusions/triton/compilation_pipeline_rocm.cc
@@ -107,7 +107,7 @@ absl::Status CreateTritonPipeline(
   pm.addPass(mlir::triton::AMD::createDecomposeUnsupportedConversionsPass(
       ccRocm.gfx_version()));
   const int custom_lds_size = 0;
-  pm.addPass(mlir::triton::AMD::createOptimizeLdsUsagePass(ccRocm.gfx_version(),
+  pm.addPass(mlir::triton::AMD::createOptimizeLDSUsagePass(ccRocm.gfx_version(),
                                                            custom_lds_size));
   pm.addPass(mlir::createConvertSCFToCFPass());
   pm.addPass(mlir::createConvertIndexToLLVMPass());


### PR DESCRIPTION
This build break is introduced by https://github.com/openxla/xla/pull/15257

and ROcm has a new optimized LDS pass on openai/triton https://github.com/triton-lang/triton/pull/3730

@xla-rotation 