### PR TITLE
Safely remove checker in EpiloguePostOrderTransitiveOperands to allow multiple paths to share same nodes.

### DIFF
--- a/xla/service/gpu/fusions/triton/triton_fusion_emitter.cc
+++ b/xla/service/gpu/fusions/triton/triton_fusion_emitter.cc
@@ -1507,7 +1507,7 @@ class MatMulEmitterHelper {
             }
           }
         }
-        CHECK(to_order.insert(current).second);
+        to_order.insert(current);
         to_add.pop();
       }
     }


### PR DESCRIPTION
Remove the checker as it prevents emitting IR for fusions with multiple paths to the same nodes in epilogues. 

cc @sergachev 