### PR TITLE
[PJRT:GPU] Add setting for mocked number of hosts per slice

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -83,8 +83,7 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
           {"node_id", PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
           {"num_nodes", PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
           {"enable_mock_nccl", PJRT_NamedValue_Type::PJRT_NamedValue_kBool},
-          {"mock_num_hosts_per_slice",
-           PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
+          {"mock_gpu_topology", PJRT_NamedValue_Type::PJRT_NamedValue_kString},
       });
   PJRT_RETURN_IF_ERROR(
       ValidateCreateOptions(create_options, kExpectedOptionNameAndTypes));
@@ -143,10 +142,10 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
       it != create_options.end()) {
     enable_mock_nccl = std::get<bool>(it->second);
   }
-  int mock_num_hosts_per_slice = 1;
-  if (auto it = create_options.find("mock_num_hosts_per_slice");
+  std::string mock_gpu_topology;
+  if (auto it = create_options.find("mock_gpu_topology");
       it != create_options.end()) {
-    mock_num_hosts_per_slice = std::get<int64_t>(it->second);
+    mock_gpu_topology = std::get<std::string>(it->second);
   }
 
   xla::GpuClientOptions options;
@@ -159,7 +158,7 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
       pjrt::ToCppKeyValueStore(args->kv_get_callback, args->kv_get_user_arg,
                                args->kv_put_callback, args->kv_put_user_arg);
   options.enable_mock_nccl = enable_mock_nccl;
-  options.mock_num_hosts_per_slice = mock_num_hosts_per_slice;
+  options.mock_gpu_topology = mock_gpu_topology;
   PJRT_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtClient> client,
                         xla::GetStreamExecutorGpuClient(options));
   args->client = pjrt::CreateWrapperClient(std::move(client));

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -142,7 +142,7 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
       it != create_options.end()) {
     enable_mock_nccl = std::get<bool>(it->second);
   }
-  std::string mock_gpu_topology;
+  std::optional<std::string> mock_gpu_topology;
   if (auto it = create_options.find("mock_gpu_topology");
       it != create_options.end()) {
     mock_gpu_topology = std::get<std::string>(it->second);
@@ -215,33 +215,6 @@ absl::StatusOr<TargetConfigAndDevices> GetTargetConfigFromOptions(
   return {{gpu_target_config.ToProto(), device_ids}};
 }
 
-struct TopologySizes {
-  int num_slices = 0;
-  int num_hosts_per_slice = 0;
-  int num_devices_per_host = 0;
-
-  int GetDeviceCount() {
-    return num_slices * num_hosts_per_slice * num_devices_per_host;
-  }
-
-  static absl::StatusOr<TopologySizes> FromString(
-      std::string_view topology_string) {
-    TopologySizes sizes;
-    std::vector<std::string> topology_components =
-        absl::StrSplit(topology_string, 'x');
-    if (topology_components.size() != 3 ||
-        !absl::SimpleAtoi(topology_components[0], &sizes.num_slices) ||
-        !absl::SimpleAtoi(topology_components[1], &sizes.num_hosts_per_slice) ||
-        !absl::SimpleAtoi(topology_components[2],
-                          &sizes.num_devices_per_host)) {
-      return absl::InternalError(
-          "topology must be of shape "
-          "\"<num-slices>x<num-hosts-per-slice>x<num-devices-per-host>\"");
-    }
-    return sizes;
-  }
-};
-
 }  // namespace
 
 PJRT_Error* PJRT_GpuDeviceTopology_Create(
@@ -268,12 +241,13 @@ PJRT_Error* PJRT_GpuDeviceTopology_Create(
   std::vector<int>& device_ids = target_config_and_devices.device_ids;
   stream_executor::GpuTargetConfigProto& target_config_proto =
       target_config_and_devices.target_config_proto;
-  TopologySizes sizes{1, 1, static_cast<int>(device_ids.size())};
+  xla::TopologySizes sizes{1, 1, static_cast<int>(device_ids.size())};
 
   if (auto topology_it = create_options.find("topology");
       topology_it != create_options.end()) {
     std::string topology_string = std::get<std::string>(topology_it->second);
-    PJRT_ASSIGN_OR_RETURN(sizes, TopologySizes::FromString(topology_string));
+    PJRT_ASSIGN_OR_RETURN(sizes,
+                          xla::TopologySizes::FromString(topology_string));
   }
 
   if (sizes.GetDeviceCount() == 0) {

--- a/xla/pjrt/gpu/gpu_helpers.cc
+++ b/xla/pjrt/gpu/gpu_helpers.cc
@@ -215,4 +215,25 @@ std::unique_ptr<tsl::BFCAllocator> GetGpuHostAllocator(
                                              /*name=*/"xla_gpu_host_bfc", opts);
 }
 
+int TopologySizes::GetDeviceCount() {
+  return num_slices * num_hosts_per_slice * num_devices_per_host;
+}
+
+// static
+absl::StatusOr<TopologySizes> TopologySizes::FromString(
+    std::string_view topology_string) {
+  TopologySizes sizes;
+  std::vector<std::string> topology_components =
+      absl::StrSplit(topology_string, 'x');
+  if (topology_components.size() != 3 ||
+      !absl::SimpleAtoi(topology_components[0], &sizes.num_slices) ||
+      !absl::SimpleAtoi(topology_components[1], &sizes.num_hosts_per_slice) ||
+      !absl::SimpleAtoi(topology_components[2], &sizes.num_devices_per_host)) {
+    return absl::InternalError(
+        "topology must be of shape "
+        "\"<num-slices>x<num-hosts-per-slice>x<num-devices-per-host>\"");
+  }
+  return sizes;
+}
+
 }  // namespace xla

--- a/xla/pjrt/gpu/gpu_helpers.h
+++ b/xla/pjrt/gpu/gpu_helpers.h
@@ -89,6 +89,21 @@ absl::StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
     se::StreamExecutor* executor, double memory_fraction,
     size_t collective_memory_size);
 
+// Represents topology of devices.
+struct TopologySizes {
+  int num_slices = 0;
+  int num_hosts_per_slice = 0;
+  int num_devices_per_host = 0;
+
+  // Returns number of devices in the topology.
+  int GetDeviceCount();
+  // Parses the topology description of the form
+  // "<num_slices> x <num_hosts_per_slice> x <num_devices_per_host>"
+  // and returns the parsed components on success.
+  static absl::StatusOr<TopologySizes> FromString(
+      std::string_view topology_string);
+};
+
 }  // namespace xla
 
 #endif  // XLA_PJRT_GPU_GPU_HELPERS_H_

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1038,7 +1038,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     int node_id, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
-    std::string_view mock_gpu_topology,
+    std::optional<std::string_view> mock_gpu_topology,
     absl::Duration get_local_topology_timeout,
     absl::Duration get_global_topology_timeout) {
   std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> devices;
@@ -1070,29 +1070,34 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
 
   GlobalTopologyProto global_topology;
   if (enable_mock_nccl) {
-    int num_slices = num_nodes;
-    int num_hosts_per_slice = 1;
-    if (!mock_gpu_topology.empty()) {
-      std::vector<std::string> topology_components =
-          absl::StrSplit(mock_gpu_topology, 'x');
-      if (topology_components.size() != 2 ||
-          !absl::SimpleAtoi(topology_components[0], &num_slices) ||
-          !absl::SimpleAtoi(topology_components[1], &num_hosts_per_slice)) {
-        return absl::InternalError(
-            "mock_gpu_topology must be of shape "
-            "\"<num-slices>x<num-hosts-per-slice>\"");
-      }
+    TopologySizes sizes;
+    if (mock_gpu_topology.has_value()) {
+      TF_ASSIGN_OR_RETURN(sizes, TopologySizes::FromString(*mock_gpu_topology));
+    } else {
+      // If there is no topology spec, we assume that each node is a slice,
+      // there is one process (host) on each slice and each host
+      // has all the local devices.
+      sizes.num_slices = num_nodes;
+      sizes.num_hosts_per_slice = 1;
+      sizes.num_devices_per_host = local_topology.devices().size();
     }
 
-    if (num_slices * num_hosts_per_slice != num_nodes) {
+    if (sizes.num_devices_per_host != local_topology.devices().size()) {
       return absl::InternalError(
-          "The size of mock_gpu_topology must by the same as num_nodes");
+          "The number of devices per host in 'mock_gpu_topology' "
+          "must be the same as the number of devices in the local topology");
+    }
+
+    if (sizes.num_slices * sizes.num_hosts_per_slice != num_nodes) {
+      return absl::InternalError(
+          "The number of hosts in 'mock_gpu_topology' "
+          "must be the same as 'num_nodes'");
     }
 
     std::vector<LocalTopologyProto> local_topologies(num_nodes, local_topology);
-    for (int i = 0; i < num_slices; ++i) {
-      for (int j = 0; j < num_hosts_per_slice; j++) {
-        int node_id = i * num_hosts_per_slice + j;
+    for (int i = 0; i < sizes.num_slices; ++i) {
+      for (int j = 0; j < sizes.num_hosts_per_slice; j++) {
+        int node_id = i * sizes.num_hosts_per_slice + j;
         local_topologies[node_id].set_node_id(node_id);
         local_topologies[node_id].set_boot_id(absl::StrCat(i));
       }

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1038,7 +1038,8 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     int node_id, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
-    int mock_num_hosts_per_slice, absl::Duration get_local_topology_timeout,
+    std::string_view mock_gpu_topology,
+    absl::Duration get_local_topology_timeout,
     absl::Duration get_global_topology_timeout) {
   std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> devices;
   LocalTopologyProto local_topology;
@@ -1069,18 +1070,32 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
 
   GlobalTopologyProto global_topology;
   if (enable_mock_nccl) {
-    std::vector<LocalTopologyProto> local_topologies(num_nodes, local_topology);
-    if (num_nodes % mock_num_hosts_per_slice != 0) {
-      return absl::InternalError(
-          "Mocked num_nodes must be divisible "
-          "by mock_num_hosts_per_slice");
+    int num_slices = num_nodes;
+    int num_hosts_per_slice = 1;
+    if (!mock_gpu_topology.empty()) {
+      std::vector<std::string> topology_components =
+          absl::StrSplit(mock_gpu_topology, 'x');
+      if (topology_components.size() != 2 ||
+          !absl::SimpleAtoi(topology_components[0], &num_slices) ||
+          !absl::SimpleAtoi(topology_components[1], &num_hosts_per_slice)) {
+        return absl::InternalError(
+            "mock_gpu_topology must be of shape "
+            "\"<num-slices>x<num-hosts-per-slice>\"");
+      }
     }
-    for (int i = 0; i < num_nodes; ++i) {
-      local_topologies[i].set_node_id(i);
-      // Set a distinct boot_id for each local topology to change slice_index
-      // for each node.
-      local_topologies[i].set_boot_id(
-          absl::StrCat(i / mock_num_hosts_per_slice));
+
+    if (num_slices * num_hosts_per_slice != num_nodes) {
+      return absl::InternalError(
+          "The size of mock_gpu_topology must by the same as num_nodes");
+    }
+
+    std::vector<LocalTopologyProto> local_topologies(num_nodes, local_topology);
+    for (int i = 0; i < num_slices; ++i) {
+      for (int j = 0; j < num_hosts_per_slice; j++) {
+        int node_id = i * num_hosts_per_slice + j;
+        local_topologies[node_id].set_node_id(node_id);
+        local_topologies[node_id].set_boot_id(absl::StrCat(i));
+      }
     }
     global_topology = BuildGlobalTopology(absl::MakeSpan(local_topologies),
                                           /*assign_global_device_ids=*/true);
@@ -1263,7 +1278,7 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
       BuildDistributedDevices(
           pjrt_platform_name, std::move(local_device_states), options.node_id,
           options.num_nodes, gpu_run_options.get(), kv_store,
-          options.enable_mock_nccl, options.mock_num_hosts_per_slice));
+          options.enable_mock_nccl, options.mock_gpu_topology));
 
   auto gpu_topology = std::shared_ptr<const GpuTopology>(
       GpuTopology::FromProto(device_topology_pair.second));

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -273,6 +273,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     int node_id, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
+    int num_hosts_per_slice,
     absl::Duration get_local_topology_timeout = absl::Minutes(2),
     absl::Duration get_global_topology_timeout = absl::Minutes(5));
 
@@ -293,6 +294,8 @@ struct GpuClientOptions {
   std::shared_ptr<KeyValueStoreInterface> kv_store = nullptr;
 
   bool enable_mock_nccl = false;
+
+  int mock_num_hosts_per_slice = 1;
 };
 
 absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -273,7 +273,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     int node_id, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
-    std::string_view mock_gpu_topology,
+    std::optional<std::string_view> mock_gpu_topology,
     absl::Duration get_local_topology_timeout = absl::Minutes(2),
     absl::Duration get_global_topology_timeout = absl::Minutes(5));
 
@@ -295,7 +295,7 @@ struct GpuClientOptions {
 
   bool enable_mock_nccl = false;
 
-  std::string mock_gpu_topology;
+  std::optional<std::string> mock_gpu_topology;
 };
 
 absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -273,7 +273,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     int node_id, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
-    std::optional<std::string_view> mock_gpu_topology,
+    std::optional<std::string_view> mock_gpu_topology = std::nullopt,
     absl::Duration get_local_topology_timeout = absl::Minutes(2),
     absl::Duration get_global_topology_timeout = absl::Minutes(5));
 

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -273,7 +273,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     int node_id, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
-    int num_hosts_per_slice,
+    std::string_view mock_gpu_topology,
     absl::Duration get_local_topology_timeout = absl::Minutes(2),
     absl::Duration get_global_topology_timeout = absl::Minutes(5));
 
@@ -295,7 +295,7 @@ struct GpuClientOptions {
 
   bool enable_mock_nccl = false;
 
-  int mock_num_hosts_per_slice = 1;
+  std::string mock_gpu_topology;
 };
 
 absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -992,12 +992,11 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientTest) {
   }
 }
 
-TEST(StreamExecutorGpuClientTest, MockNcclClientProcessPerGpuTest) {
-  const int num_nodes = 8;
+TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyTest) {
   GpuClientOptions options;
-  options.num_nodes = num_nodes;
   options.enable_mock_nccl = true;
-  options.mock_num_hosts_per_slice = 4;
+  options.num_nodes = 8;
+  options.mock_gpu_topology = "2x4";
   TF_ASSERT_OK_AND_ASSIGN(auto client, GetStreamExecutorGpuClient(options));
 
   TF_ASSERT_OK_AND_ASSIGN(const xla::PjRtTopologyDescription* topology,
@@ -1009,6 +1008,14 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientProcessPerGpuTest) {
   EXPECT_EQ(gpu_topology.gpu_topology().num_slices(), 2);
   EXPECT_EQ(gpu_topology.gpu_topology().num_hosts_per_slice(), 4);
   EXPECT_EQ(gpu_topology.gpu_topology().num_devices_per_host(), 2);
+}
+
+TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyMismatchTest) {
+  GpuClientOptions options;
+  options.enable_mock_nccl = true;
+  options.num_nodes = 16;
+  options.mock_gpu_topology = "2x4";
+  EXPECT_FALSE(GetStreamExecutorGpuClient(options).ok());
 }
 
 TEST(StreamExecutorGpuClientTest, BufferFromHostBufferPinnedMemory) {

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -996,8 +996,11 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyTest) {
   GpuClientOptions options;
   options.enable_mock_nccl = true;
   options.num_nodes = 8;
-  options.mock_gpu_topology = "2x4";
+  options.mock_gpu_topology = "2x4x2";
   TF_ASSERT_OK_AND_ASSIGN(auto client, GetStreamExecutorGpuClient(options));
+
+  auto devices_per_host = client->addressable_device_count();
+  EXPECT_EQ(devices_per_host, 2) << "This test requires 2 local GPUs.";
 
   TF_ASSERT_OK_AND_ASSIGN(const xla::PjRtTopologyDescription* topology,
                           client->GetTopologyDescription());
@@ -1008,6 +1011,65 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyTest) {
   EXPECT_EQ(gpu_topology.gpu_topology().num_slices(), 2);
   EXPECT_EQ(gpu_topology.gpu_topology().num_hosts_per_slice(), 4);
   EXPECT_EQ(gpu_topology.gpu_topology().num_devices_per_host(), 2);
+}
+
+constexpr char kMlirDistributedSum[] = R"(
+module @jit_f attributes {mhlo.num_partitions = 8 : i32,
+                          mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<8xi32> {
+      mhlo.layout_mode = "default",
+      mhlo.sharding = "{devices=[8]0,1,2,3,4,5,6,7}"}) -> (tensor<i32> {
+          jax.result_info = "",
+          mhlo.layout_mode = "default"}) {
+    %c = stablehlo.constant dense<0> : tensor<i32>
+    %0 = stablehlo.reduce(%arg0 init: %c)
+        applies stablehlo.add across dimensions = [0]
+            : (tensor<8xi32>, tensor<i32>) -> tensor<i32>
+    return %0 : tensor<i32>
+  }
+})";
+
+TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyExecuteTest) {
+  GpuClientOptions client_options;
+  client_options.enable_mock_nccl = true;
+  client_options.num_nodes = 4;
+  client_options.mock_gpu_topology = "2x2x2";
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(client_options));
+
+  auto devices_per_host = client->addressable_device_count();
+  EXPECT_EQ(devices_per_host, 2) << "This test requires 2 local GPUs.";
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, xla::ParseMlirModuleString(kMlirDistributedSum, context));
+
+  xla::CompileOptions options;
+  options.executable_build_options.set_num_partitions(8)
+      .set_use_spmd_partitioning(true)
+      .set_allow_spmd_sharding_propagation_to_output({true});
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, options));
+
+  Shape shape = ShapeUtil::MakeShapeWithDenseLayout(S32, {1}, {0});
+  std::vector<std::unique_ptr<PjRtBuffer>> inputs;
+  std::vector<std::vector<PjRtBuffer*>> input_ptrs;
+  for (int i = 0; i < devices_per_host; i++) {
+    auto device = client->addressable_devices()[i];
+    std::vector<int32_t> data{i};
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto input,
+        client->BufferFromHostBuffer(
+            data.data(), shape.element_type(), shape.dimensions(),
+            /*byte_strides=*/std::nullopt,
+            PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall,
+            /*on_done_with_host_buffer=*/nullptr, device));
+    input_ptrs.push_back({input.get()});
+    inputs.push_back(std::move(input));
+  }
+
+  // Test that running the program does not crash/hang.
+  TF_ASSERT_OK(
+      executable->Execute(absl::MakeSpan(input_ptrs), ExecuteOptions()));
 }
 
 TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyMismatchTest) {

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -992,6 +992,25 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientTest) {
   }
 }
 
+TEST(StreamExecutorGpuClientTest, MockNcclClientProcessPerGpuTest) {
+  const int num_nodes = 8;
+  GpuClientOptions options;
+  options.num_nodes = num_nodes;
+  options.enable_mock_nccl = true;
+  options.mock_num_hosts_per_slice = 4;
+  TF_ASSERT_OK_AND_ASSIGN(auto client, GetStreamExecutorGpuClient(options));
+
+  TF_ASSERT_OK_AND_ASSIGN(const xla::PjRtTopologyDescription* topology,
+                          client->GetTopologyDescription());
+  const StreamExecutorGpuTopologyDescription& gpu_topology =
+      tensorflow::down_cast<const xla::StreamExecutorGpuTopologyDescription&>(
+          *topology);
+
+  EXPECT_EQ(gpu_topology.gpu_topology().num_slices(), 2);
+  EXPECT_EQ(gpu_topology.gpu_topology().num_hosts_per_slice(), 4);
+  EXPECT_EQ(gpu_topology.gpu_topology().num_devices_per_host(), 2);
+}
+
 TEST(StreamExecutorGpuClientTest, BufferFromHostBufferPinnedMemory) {
   TF_ASSERT_OK_AND_ASSIGN(auto client,
                           GetStreamExecutorGpuClient(GpuClientOptions()));

--- a/xla/python/gpu_support.cc
+++ b/xla/python/gpu_support.cc
@@ -83,7 +83,7 @@ void RegisterGpuClientAndDefineGpuAllocatorConfig(nanobind::module_& m_nb) {
           options.platform_name = platform_name;
           options.kv_store = kv_store;
           options.enable_mock_nccl = mock.value_or(false);
-          options.mock_gpu_topology = mock_gpu_topology.value_or("");
+          options.mock_gpu_topology = mock_gpu_topology;
           std::unique_ptr<PjRtClient> pjrt_client =
               xla::ValueOrThrow(GetStreamExecutorGpuClient(options));
           ifrt_client = ifrt::PjRtClient::Create(std::move(pjrt_client));

--- a/xla/python/gpu_support.cc
+++ b/xla/python/gpu_support.cc
@@ -22,10 +22,10 @@ limitations under the License.
 #include <utility>
 
 #include "nanobind/nanobind.h"
-#include "nanobind/stl/optional.h"  // IWYU pragma: keep
-#include "nanobind/stl/set.h"  // IWYU pragma: keep
+#include "nanobind/stl/optional.h"    // IWYU pragma: keep
+#include "nanobind/stl/set.h"         // IWYU pragma: keep
 #include "nanobind/stl/shared_ptr.h"  // IWYU pragma: keep
-#include "nanobind/stl/string.h"  // IWYU pragma: keep
+#include "nanobind/stl/string.h"      // IWYU pragma: keep
 #include "xla/pjrt/distributed/client.h"
 #include "xla/pjrt/distributed/key_value_store_interface.h"
 #include "xla/pjrt/gpu/gpu_helpers.h"
@@ -64,7 +64,9 @@ void RegisterGpuClientAndDefineGpuAllocatorConfig(nanobind::module_& m_nb) {
          int node_id, int num_nodes,
          std::optional<std::set<int>> allowed_devices,
          std::optional<std::string> platform_name,
-         std::optional<bool> mock = false) -> nb_class_ptr<PyClient> {
+         std::optional<bool> mock = false,
+         std::optional<int> mock_num_hosts_per_slice =
+             1) -> nb_class_ptr<PyClient> {
         std::unique_ptr<ifrt::PjRtClient> ifrt_client;
         {
           nb::gil_scoped_release gil_release;
@@ -81,6 +83,8 @@ void RegisterGpuClientAndDefineGpuAllocatorConfig(nanobind::module_& m_nb) {
           options.platform_name = platform_name;
           options.kv_store = kv_store;
           options.enable_mock_nccl = mock.value_or(false);
+          options.mock_num_hosts_per_slice =
+              mock_num_hosts_per_slice.value_or(1);
           std::unique_ptr<PjRtClient> pjrt_client =
               xla::ValueOrThrow(GetStreamExecutorGpuClient(options));
           ifrt_client = ifrt::PjRtClient::Create(std::move(pjrt_client));
@@ -93,7 +97,8 @@ void RegisterGpuClientAndDefineGpuAllocatorConfig(nanobind::module_& m_nb) {
       nb::arg("num_nodes") = 1,
       nb::arg("allowed_devices").none() = std::nullopt,
       nb::arg("platform_name").none() = std::nullopt,
-      nb::arg("mock").none() = std::nullopt);
+      nb::arg("mock").none() = std::nullopt,
+      nb::arg("mock_num_hosts_per_slice").none() = std::nullopt);
 }
 
 }  // namespace xla

--- a/xla/python/gpu_support.cc
+++ b/xla/python/gpu_support.cc
@@ -65,8 +65,8 @@ void RegisterGpuClientAndDefineGpuAllocatorConfig(nanobind::module_& m_nb) {
          std::optional<std::set<int>> allowed_devices,
          std::optional<std::string> platform_name,
          std::optional<bool> mock = false,
-         std::optional<int> mock_num_hosts_per_slice =
-             1) -> nb_class_ptr<PyClient> {
+         std::optional<std::string> mock_gpu_topology =
+             "") -> nb_class_ptr<PyClient> {
         std::unique_ptr<ifrt::PjRtClient> ifrt_client;
         {
           nb::gil_scoped_release gil_release;
@@ -83,8 +83,7 @@ void RegisterGpuClientAndDefineGpuAllocatorConfig(nanobind::module_& m_nb) {
           options.platform_name = platform_name;
           options.kv_store = kv_store;
           options.enable_mock_nccl = mock.value_or(false);
-          options.mock_num_hosts_per_slice =
-              mock_num_hosts_per_slice.value_or(1);
+          options.mock_gpu_topology = mock_gpu_topology.value_or("");
           std::unique_ptr<PjRtClient> pjrt_client =
               xla::ValueOrThrow(GetStreamExecutorGpuClient(options));
           ifrt_client = ifrt::PjRtClient::Create(std::move(pjrt_client));
@@ -98,7 +97,7 @@ void RegisterGpuClientAndDefineGpuAllocatorConfig(nanobind::module_& m_nb) {
       nb::arg("allowed_devices").none() = std::nullopt,
       nb::arg("platform_name").none() = std::nullopt,
       nb::arg("mock").none() = std::nullopt,
-      nb::arg("mock_num_hosts_per_slice").none() = std::nullopt);
+      nb::arg("mock_gpu_topology").none() = std::nullopt);
 }
 
 }  // namespace xla

--- a/xla/python/xla_client.py
+++ b/xla/python/xla_client.py
@@ -89,7 +89,7 @@ def make_gpu_client(
     platform_name=None,
     allowed_devices=None,
     mock=False,
-    mock_num_hosts_per_slice=1,
+    mock_gpu_topology=None,
 ):
   """Returns a GPU client. BFC allocator is used by default."""
   options = generate_pjrt_gpu_plugin_options()
@@ -121,7 +121,7 @@ def make_gpu_client(
       platform_name=platform_name,
       allowed_devices=allowed_devices,
       mock=mock,
-      mock_num_hosts_per_slice=mock_num_hosts_per_slice,
+      mock_gpu_topology=mock_gpu_topology,
   )
 
 

--- a/xla/python/xla_client.py
+++ b/xla/python/xla_client.py
@@ -89,6 +89,7 @@ def make_gpu_client(
     platform_name=None,
     allowed_devices=None,
     mock=False,
+    mock_num_hosts_per_slice=1,
 ):
   """Returns a GPU client. BFC allocator is used by default."""
   options = generate_pjrt_gpu_plugin_options()
@@ -120,6 +121,7 @@ def make_gpu_client(
       platform_name=platform_name,
       allowed_devices=allowed_devices,
       mock=mock,
+      mock_num_hosts_per_slice=mock_num_hosts_per_slice,
   )
 
 

--- a/xla/python/xla_client.pyi
+++ b/xla/python/xla_client.pyi
@@ -101,6 +101,7 @@ def make_gpu_client(
     platform_name: str | None = ...,
     allowed_devices: set[int] | None = ...,
     mock: bool | None = ...,
+    mock_gpu_topology: str | None = ...,
 ) -> Client:
   ...
 


### PR DESCRIPTION
With the existing `enable_mock_nccl` setting it is impossible to warm up compilation cache when there are multiple processes per node. This is because the cache key includes topology and GPU topology contains information about number of slices and number of hosts per slice. The current mocking of topologies always sets num_hosts_per_slice to 1. However, if you have multiple GPUs on a node and run a process-per-GPU then num_hosts_per_slice must be set to the number of GPUs.

This patch allows setting num_hosts_per_slice explicitly when creating the GPU client.