### PR TITLE
[XLA:GPU] Remove gpu_performance_model_cache mutex locks in Priority fusion

### DIFF
--- a/xla/service/gpu/model/gpu_performance_model.cc
+++ b/xla/service/gpu/model/gpu_performance_model.cc
@@ -113,8 +113,7 @@ GpuPerformanceModel::EstimateRunTimeForInstructionCached(
       return *cached_result;
     }
   }
-  CHECK(!config.gpu_performance_model_cache_read_only)
-      << "cache hit failed for read only cache.";
+
   auto runtime_data =
       EstimateRunTimeForInstruction(instr, device_info, cost_analysis, config);
 
@@ -346,8 +345,9 @@ GpuPerformanceModel::EstimateRunTimesForPriorityFusion(
     const GpuPerformanceModelOptions& config,
     absl::Span<const HloInstruction* const> fused_consumers,
     bool multi_output) {
-  EstimateRunTimeData producer_runtime = EstimateRunTimeForInstructionCached(
-      producer, device_info, cost_analysis, config);
+  auto cache_result = config.gpu_performance_model_cache->Get(*producer);
+  CHECK(cache_result.has_value());
+  EstimateRunTimeData producer_runtime = *cache_result;
 
   absl::Duration time_unfused =
       kKernelLaunchOverhead * (fused_consumers.size() + 1) +
@@ -358,8 +358,9 @@ GpuPerformanceModel::EstimateRunTimesForPriorityFusion(
   for (auto fused_consumer : fused_consumers) {
     VLOG(8) << "Fused consumer: " << fused_consumer->name();
 
-    EstimateRunTimeData consumer_runtime = EstimateRunTimeForInstructionCached(
-        fused_consumer, device_info, cost_analysis, config);
+    auto cache_result = config.gpu_performance_model_cache->Get(*producer);
+    CHECK(cache_result.has_value());
+    EstimateRunTimeData consumer_runtime = *cache_result;
 
     time_unfused += consumer_runtime.exec_time;
 

--- a/xla/service/gpu/model/gpu_performance_model.cc
+++ b/xla/service/gpu/model/gpu_performance_model.cc
@@ -113,7 +113,8 @@ GpuPerformanceModel::EstimateRunTimeForInstructionCached(
       return *cached_result;
     }
   }
-
+  CHECK(!config.gpu_performance_model_cache_read_only)
+      << "cache hit failed for read only cache.";
   auto runtime_data =
       EstimateRunTimeForInstruction(instr, device_info, cost_analysis, config);
 
@@ -266,6 +267,9 @@ absl::Duration GpuPerformanceModel::EstimateRunTimeForFusionCached(
       return *fusion_runtime;
     }
   }
+
+  CHECK(!config.gpu_performance_model_cache_read_only)
+      << "cache hit failed for read only cache.";
 
   auto fusion_runtime = EstimateRunTimeForFusion(
       producer, consumer, producer_runtime, consumer_runtime, device_info,

--- a/xla/service/gpu/model/gpu_performance_model.cc
+++ b/xla/service/gpu/model/gpu_performance_model.cc
@@ -268,9 +268,6 @@ absl::Duration GpuPerformanceModel::EstimateRunTimeForFusionCached(
     }
   }
 
-  CHECK(!config.gpu_performance_model_cache_read_only)
-      << "cache hit failed for read only cache.";
-
   auto fusion_runtime = EstimateRunTimeForFusion(
       producer, consumer, producer_runtime, consumer_runtime, device_info,
       cost_analysis, config);

--- a/xla/service/gpu/model/gpu_performance_model.cc
+++ b/xla/service/gpu/model/gpu_performance_model.cc
@@ -358,7 +358,8 @@ GpuPerformanceModel::EstimateRunTimesForPriorityFusion(
   for (auto fused_consumer : fused_consumers) {
     VLOG(8) << "Fused consumer: " << fused_consumer->name();
 
-    auto cache_result = config.gpu_performance_model_cache->Get(*producer);
+    auto cache_result =
+        config.gpu_performance_model_cache->Get(*fused_consumer);
     CHECK(cache_result.has_value());
     EstimateRunTimeData consumer_runtime = *cache_result;
 

--- a/xla/service/gpu/model/gpu_performance_model_base.cc
+++ b/xla/service/gpu/model/gpu_performance_model_base.cc
@@ -97,6 +97,8 @@ std::optional<EstimateRunTimeData> GpuPerformanceModelCache::Get(
 
 std::optional<absl::Duration> GpuPerformanceModelCache::Get(
     const HloInstruction& producer, const HloInstruction& consumer) {
+  absl::MutexLock lock(&mutex_);
+
   auto it = fusion_runtime_data_.find(&producer);
   if (it != fusion_runtime_data_.end()) {
     auto jt = it->second.find(&consumer);
@@ -115,6 +117,7 @@ void GpuPerformanceModelCache::Set(const HloInstruction& instruction,
 void GpuPerformanceModelCache::Set(const HloInstruction& producer,
                                    const HloInstruction& consumer,
                                    absl::Duration runtime) {
+  absl::MutexLock lock(&mutex_);
   fusion_runtime_data_[&producer][&consumer] = runtime;
 }
 

--- a/xla/service/gpu/model/gpu_performance_model_base.cc
+++ b/xla/service/gpu/model/gpu_performance_model_base.cc
@@ -88,8 +88,6 @@ float AdjustBandwidth(const se::DeviceDescription& gpu_device_info,
 
 std::optional<EstimateRunTimeData> GpuPerformanceModelCache::Get(
     const HloInstruction& instruction) {
-  absl::MutexLock lock(&mutex_);
-
   auto it = instruction_runtime_data_.find(&instruction);
   if (it != instruction_runtime_data_.end()) {
     return it->second;
@@ -99,8 +97,6 @@ std::optional<EstimateRunTimeData> GpuPerformanceModelCache::Get(
 
 std::optional<absl::Duration> GpuPerformanceModelCache::Get(
     const HloInstruction& producer, const HloInstruction& consumer) {
-  absl::MutexLock lock(&mutex_);
-
   auto it = fusion_runtime_data_.find(&producer);
   if (it != fusion_runtime_data_.end()) {
     auto jt = it->second.find(&consumer);
@@ -113,21 +109,16 @@ std::optional<absl::Duration> GpuPerformanceModelCache::Get(
 
 void GpuPerformanceModelCache::Set(const HloInstruction& instruction,
                                    const EstimateRunTimeData& runtime_data) {
-  absl::MutexLock lock(&mutex_);
-
   instruction_runtime_data_[&instruction] = runtime_data;
 }
 
 void GpuPerformanceModelCache::Set(const HloInstruction& producer,
                                    const HloInstruction& consumer,
                                    absl::Duration runtime) {
-  absl::MutexLock lock(&mutex_);
   fusion_runtime_data_[&producer][&consumer] = runtime;
 }
 
 void GpuPerformanceModelCache::Invalidate(const HloInstruction& instruction) {
-  absl::MutexLock lock(&mutex_);
-
   // Remove runtime data for the instruction.
   instruction_runtime_data_.erase(&instruction);
 

--- a/xla/service/gpu/model/gpu_performance_model_base.h
+++ b/xla/service/gpu/model/gpu_performance_model_base.h
@@ -105,16 +105,13 @@ struct GpuPerformanceModelOptions {
 
   GpuPerformanceModelCache* gpu_performance_model_cache = nullptr;
 
-  bool gpu_performance_model_cache_read_only;
-
   static GpuPerformanceModelOptions Default() {
     return GpuPerformanceModelOptions();
   }
 
   static GpuPerformanceModelOptions PriorityFusion(
       HloFusionAnalysisCache* fusion_analysis_cache = nullptr,
-      GpuPerformanceModelCache* gpu_performance_model_cache = nullptr,
-      bool gpu_performance_model_cache_read_only = false) {
+      GpuPerformanceModelCache* gpu_performance_model_cache = nullptr) {
     GpuPerformanceModelOptions config;
     config.fusion_analysis_cache = fusion_analysis_cache;
     config.gpu_performance_model_cache = gpu_performance_model_cache;
@@ -124,8 +121,6 @@ struct GpuPerformanceModelOptions {
     // or memory accesses will be stalled waiting for the other, but usually
     // they won't).
     config.memory_compute_parallelism = 0.95;
-    config.gpu_performance_model_cache_read_only =
-        gpu_performance_model_cache_read_only;
     return config;
   }
 

--- a/xla/service/gpu/model/gpu_performance_model_base.h
+++ b/xla/service/gpu/model/gpu_performance_model_base.h
@@ -80,8 +80,6 @@ class GpuPerformanceModelCache {
   void Invalidate(const HloInstruction& instruction);
 
  private:
-  absl::Mutex mutex_;
-
   // Stores unfused runtime data for individual instructions.
   absl::flat_hash_map<const HloInstruction*, EstimateRunTimeData>
       instruction_runtime_data_;
@@ -105,13 +103,16 @@ struct GpuPerformanceModelOptions {
 
   GpuPerformanceModelCache* gpu_performance_model_cache = nullptr;
 
+  bool gpu_performance_model_cache_read_only;
+
   static GpuPerformanceModelOptions Default() {
     return GpuPerformanceModelOptions();
   }
 
   static GpuPerformanceModelOptions PriorityFusion(
       HloFusionAnalysisCache* fusion_analysis_cache = nullptr,
-      GpuPerformanceModelCache* gpu_performance_model_cache = nullptr) {
+      GpuPerformanceModelCache* gpu_performance_model_cache = nullptr,
+      bool gpu_performance_model_cache_read_only = false) {
     GpuPerformanceModelOptions config;
     config.fusion_analysis_cache = fusion_analysis_cache;
     config.gpu_performance_model_cache = gpu_performance_model_cache;
@@ -121,6 +122,8 @@ struct GpuPerformanceModelOptions {
     // or memory accesses will be stalled waiting for the other, but usually
     // they won't).
     config.memory_compute_parallelism = 0.95;
+    config.gpu_performance_model_cache_read_only =
+        gpu_performance_model_cache_read_only;
     return config;
   }
 

--- a/xla/service/gpu/model/gpu_performance_model_base.h
+++ b/xla/service/gpu/model/gpu_performance_model_base.h
@@ -80,6 +80,8 @@ class GpuPerformanceModelCache {
   void Invalidate(const HloInstruction& instruction);
 
  private:
+  absl::Mutex mutex_;
+
   // Stores unfused runtime data for individual instructions.
   absl::flat_hash_map<const HloInstruction*, EstimateRunTimeData>
       instruction_runtime_data_;

--- a/xla/service/gpu/model/gpu_performance_model_test.cc
+++ b/xla/service/gpu/model/gpu_performance_model_test.cc
@@ -68,9 +68,19 @@ class GpuPerformanceModelTest : public HloTestBase {
   GpuPerformanceModel::RunTimes EstimateRunTimesForPriorityFusion(
       const HloInstruction* producer,
       std::vector<HloInstruction*> fused_consumers = {}) {
+    auto config = GpuPerformanceModelOptions::PriorityFusion(
+        &fusion_analysis_cache_, &gpu_performance_model_cache_);
+
+    auto runtime_data = GpuPerformanceModel::EstimateRunTimeForInstruction(
+        producer, device_info_, &analysis_, config);
+    gpu_performance_model_cache_.Set(*producer, runtime_data);
+    for (auto consumer : fused_consumers) {
+      auto runtime_data = GpuPerformanceModel::EstimateRunTimeForInstruction(
+          consumer, device_info_, &analysis_, config);
+      gpu_performance_model_cache_.Set(*consumer, runtime_data);
+    }
     return GpuPerformanceModel::EstimateRunTimesForPriorityFusion(
-        producer, device_info_, &analysis_,
-        GpuPerformanceModelOptions::PriorityFusion(), fused_consumers);
+        producer, device_info_, &analysis_, config, fused_consumers);
   }
 
   mlir::MLIRContext mlir_context_;
@@ -82,6 +92,7 @@ class GpuPerformanceModelTest : public HloTestBase {
   se::DeviceDescription device_info_{TestGpuDeviceInfo::RTXA6000DeviceInfo()};
   HloFusionAnalysisCache fusion_analysis_cache_{device_info_};
   GpuHloCostAnalysis analysis_{options_, device_info_};
+  GpuPerformanceModelCache gpu_performance_model_cache_;
 
   GpuPerformanceModelWithIndexingAnalysis indexing_cost_model_{
       &device_info_, &fusion_analysis_cache_, ShapeSizeBytesFunction(),

--- a/xla/service/gpu/priority_fusion.cc
+++ b/xla/service/gpu/priority_fusion.cc
@@ -252,8 +252,7 @@ class GpuPriorityFusionQueue {
 
   void UpdatePerformanceModelCache(HloInstruction* producer) {
     if (producer->opcode() == HloOpcode::kBitcast ||
-        producer->opcode() == HloOpcode::kConstant ||
-        !IsFusible(*producer)) {
+        producer->opcode() == HloOpcode::kConstant || !IsFusible(*producer)) {
       return;
     }
 

--- a/xla/service/gpu/priority_fusion.cc
+++ b/xla/service/gpu/priority_fusion.cc
@@ -248,7 +248,7 @@ class GpuPriorityFusionQueue {
   }
 
   void UpdatePerformanceModelCache(HloInstruction* producer) {
-    if (!IsFusible(*producer)) {
+    if (!IsFusible(*producer) && !IsGenericTritonFusion(*producer)) {
       return;
     }
 

--- a/xla/service/gpu/priority_fusion.cc
+++ b/xla/service/gpu/priority_fusion.cc
@@ -418,7 +418,6 @@ class GpuPriorityFusionQueue {
       return std::numeric_limits<Priority>::min();
     }
 
-    // everything should already be in performance model cache
     // never write cache here as we dont have locks anymore
     GpuPerformanceModel::RunTimes run_times =
         GpuPerformanceModel::EstimateRunTimesForPriorityFusion(


### PR DESCRIPTION
* remove mutex for gpu_performance_model_cache. let cache rewrites only happen in sequential order in main thread and make sure only read in worker threads.
* fix cache invalidation to only invalidate producer if it doesn't have any consumers after fusion.

some of the benchmarks using this PR: https://docs.google.com/spreadsheets/d/1EL35JeY9jouqTNvaF9J5jvoaRX9jEIMexNqM-Rk0fss/edit?usp=sharing. Check column B and G.