### PR TITLE
[PJRT:GPU] Respect auto layout modes in MLIR compilation

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1307,6 +1307,64 @@ TEST(StreamExecutorGpuClientTest, MlirResultHostMemorySpaceIsSetInHlo) {
   EXPECT_EQ(result_layout.memory_space(), Layout::kHostMemorySpace);
 }
 
+TEST(StreamExecutorGpuClientTest, MlirAutoResultLayoutIsSet) {
+  constexpr char kMlirWithParameterLayout[] =
+      R"(
+    func.func public @main(%arg0: tensor<2x4x2xi32> {
+            mhlo.layout_mode = "{2, 1, 0}"
+        }) -> (tensor<2x2x4xi32> {
+            jax.result_info = "",
+            mhlo.layout_mode = "auto"}) {
+      %0 = stablehlo.transpose %arg0, dims = [0, 2, 1]
+          : (tensor<2x4x2xi32>) -> tensor<2x2x4xi32>
+      return %0 : tensor<2x2x4xi32>
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(auto module, xla::ParseMlirModuleString(
+                                           kMlirWithParameterLayout, context));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, {}));
+  TF_ASSERT_OK_AND_ASSIGN(auto modules, executable->GetHloModules());
+
+  auto result_layout =
+      modules[0]->entry_computation_layout().result_layout().layout();
+  EXPECT_EQ(result_layout, Layout({1, 2, 0}));
+}
+
+TEST(StreamExecutorGpuClientTest, MlirAutoParameterLayoutIsSet) {
+  constexpr char kMlirWithParameterLayout[] =
+      R"(
+    func.func public @main(%arg0: tensor<2x4x2xi32> {
+            mhlo.layout_mode = "auto"
+        }) -> (tensor<2x2x4xi32> {
+            jax.result_info = "",
+            mhlo.layout_mode = "{2, 1, 0}"}) {
+      %0 = stablehlo.transpose %arg0, dims = [0, 2, 1]
+          : (tensor<2x4x2xi32>) -> tensor<2x2x4xi32>
+      return %0 : tensor<2x2x4xi32>
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(auto module, xla::ParseMlirModuleString(
+                                           kMlirWithParameterLayout, context));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable, client->Compile(*module, {}));
+  TF_ASSERT_OK_AND_ASSIGN(auto modules, executable->GetHloModules());
+
+  auto first_param_layout =
+      modules[0]->entry_computation_layout().parameter_layout(0).layout();
+  EXPECT_EQ(first_param_layout, Layout({1, 2, 0}));
+}
+
 TEST(StreamExecutorGpuClientTest, MlirParameterLayoutIsSetInHlo) {
   constexpr char kMlirWithParameterLayout[] =
       R"(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1478,6 +1478,13 @@ TEST(StreamExecutorGpuClientTest,
       modules[0]->entry_computation_layout().result_layout().layout();
   EXPECT_EQ(result_layout,
             Layout({0, 1}).set_memory_space(Layout::kHostMemorySpace));
+
+  // Verify that the executable's layout callback is null.
+  // This is necessary for the executable to be serializable.
+  EXPECT_EQ(executable->GetCompileOptions()
+                .value()
+                .executable_build_options.layout_canonicalization_callback(),
+            nullptr);
 }
 
 }  // namespace

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -3497,6 +3497,11 @@ PjRtStreamExecutorClient::CompileInternal(
       client()->Compile(computation, argument_layout_pointers,
                         options.executable_build_options));
 
+  // Make sure that the options that are embedded in the executable
+  // do not have the layout canonicalization callback set
+  // (the executable's options must be serializable).
+  input_options.executable_build_options.set_layout_canonicalization_callback(
+      nullptr);
   auto executable = std::make_unique<PjRtStreamExecutorLoadedExecutable>(
       std::move(local_executables), options.parameter_is_tupled_arguments,
       std::move(device_assignment), std::move(input_options),

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -479,6 +479,11 @@ class PjRtStreamExecutorClient : public PjRtClient {
   };
   absl::StatusOr<ExecutableExtras> GetExecutableExtras(CompileOptions* options);
 
+  absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> CompileInternal(
+      const XlaComputation& computation,
+      const std::vector<const Shape*>& argument_layout_pointers,
+      CompileOptions options);
+
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> BufferFromHostBufferInternal(
       const void* data, PrimitiveType type, absl::Span<int64_t const> dims,
       std::optional<absl::Span<int64_t const>> byte_strides,

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -482,6 +482,7 @@ class PjRtStreamExecutorClient : public PjRtClient {
   absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> CompileInternal(
       const XlaComputation& computation,
       const std::vector<const Shape*>& argument_layout_pointers,
+      LayoutCanonicalizationCallback layout_canonicalization_callback,
       CompileOptions options);
 
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> BufferFromHostBufferInternal(


### PR DESCRIPTION
Without this patch, auto layouts for arguments and results turn into default layouts (in the
DetermineArgumentLayoutsFromCompileOptions function). This patch avoids calling
DetermineArgumentLayoutsFromCompileOptions from the MLIR compilation method
so that empty layouts on shapes are preserved.

With this patch we should be able to enable four more layout tests in JAX on GPUs.