### PR TITLE
[GPU] Expose caching DebugOptions to python

### DIFF
--- a/xla/python/xla_client_test.py
+++ b/xla/python/xla_client_test.py
@@ -3154,7 +3154,10 @@ module @jit__lambda_ attributes {mhlo.num_partitions = 1 : i32,
                          getattr(restored.executable_build_options, name),
                          msg=name)
 
-      for name in ("xla_cpu_enable_fast_math", "xla_test_all_input_layouts"):
+      for name in ("xla_cpu_enable_fast_math", "xla_test_all_input_layouts",
+                   "xla_gpu_kernel_cache_file",
+                   "xla_gpu_enable_llvm_module_compilation_parallelism",
+                   "xla_gpu_per_fusion_autotune_cache_dir"):
         self.assertEqual(
             getattr(options.executable_build_options.debug_options, name),
             getattr(restored.executable_build_options.debug_options, name),

--- a/xla/python/xla_client_test.py
+++ b/xla/python/xla_client_test.py
@@ -3137,6 +3137,9 @@ module @jit__lambda_ attributes {mhlo.num_partitions = 1 : i32,
       executable_build_options.num_partitions = 2
       executable_build_options.debug_options.xla_cpu_enable_fast_math = True
       executable_build_options.debug_options.xla_test_all_input_layouts = True
+      executable_build_options.debug_options.xla_gpu_kernel_cache_file = "/foo/bar"
+      executable_build_options.debug_options.xla_gpu_enable_llvm_module_compilation_parallelism = True
+      executable_build_options.debug_options.xla_gpu_per_fusion_autotune_cache_dir = "/bar/foo/"
 
       b = options.SerializeAsString()
       restored = xla_client.CompileOptions.ParseFromString(b)

--- a/xla/python/xla_compiler.cc
+++ b/xla/python/xla_compiler.cc
@@ -1199,6 +1199,20 @@ void BuildXlaCompilerSubmodule(nb::module_& m) {
                    &DebugOptions::xla_gpu_dump_autotune_logs_to,
                    [](DebugOptions* self, std::string value) {
                      self->set_xla_gpu_dump_autotune_logs_to(value);
+                   })
+      .def_prop_rw("xla_gpu_kernel_cache_file",
+                   &DebugOptions::xla_gpu_kernel_cache_file,
+                   [](DebugOptions* self, std::string value) {
+                     self->set_xla_gpu_kernel_cache_file(value);
+                   })
+      .def_prop_rw(
+          "xla_gpu_enable_llvm_module_compilation_parallelism",
+          &DebugOptions::xla_gpu_enable_llvm_module_compilation_parallelism,
+          &DebugOptions::set_xla_gpu_enable_llvm_module_compilation_parallelism)
+      .def_prop_rw("xla_gpu_per_fusion_autotune_cache_dir",
+                   &DebugOptions::xla_gpu_per_fusion_autotune_cache_dir,
+                   [](DebugOptions* self, std::string value) {
+                     self->set_xla_gpu_per_fusion_autotune_cache_dir(value);
                    });
 
   nb::class_<ExecutableBuildOptions>(m, "ExecutableBuildOptions")

--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -318,6 +318,9 @@ class DebugOptions:
   xla_gpu_dump_autotune_results_to: str
   xla_gpu_load_autotune_results_from: str
   xla_gpu_dump_autotune_logs_to: str
+  xla_gpu_kernel_cache_file: str
+  xla_gpu_enable_llvm_module_compilation_parallelism: bool
+  xla_gpu_per_fusion_autotune_cache_dir: str
 
 class CompiledMemoryStats:
   generated_code_size_in_bytes: int


### PR DESCRIPTION
Adds python bindings for `xla_gpu_kernel_cache_file`, `xla_gpu_enable_llvm_module_compilation_parallelism` and `xla_gpu_per_fusion_autotune_cache_dir`.

We would like to add some convenience  features to JAX which will enable all caches with one flag/option (will open PR for that soon). This change is necessary for that.