### PR TITLE
Fix build break due to 21311f23028acfd4bc2c3e4a3f76bad8c9e640e8

### DIFF
--- a/xla/stream_executor/rocm/rocm_platform.h
+++ b/xla/stream_executor/rocm/rocm_platform.h
@@ -63,7 +63,7 @@ class ROCmPlatform : public Platform {
   // looking in or storing to the Platform's executor cache.
   // Ownership IS transferred to the caller.
   absl::StatusOr<std::unique_ptr<StreamExecutor>> GetUncachedExecutor(
-      const StreamExecutorConfig& config) override;
+      const StreamExecutorConfig& config);
 
   // This platform's name.
   std::string name_;


### PR DESCRIPTION
Build break was created by:
https://github.com/openxla/xla/commit/21311f23028acfd4bc2c3e4a3f76bad8c9e640e8