### PR TITLE
Fix build issue in xla/ffi XLA_FFI_REGISTER_ENUM_ATTR_DECODING

### DIFF
--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -1637,7 +1637,7 @@ auto DictionaryDecoder(Members... m) {
 // type to decode the attribute as a scalar value and cast it to the enum type.
 #define XLA_FFI_REGISTER_ENUM_ATTR_DECODING(T)                                \
   template <>                                                                 \
-  struct ::xla::ffi::AttrDecoding<T> {                                        \
+  struct AttrDecoding<T> {                                                    \
     using Type = T;                                                           \
     using U = std::underlying_type_t<Type>;                                   \
     static_assert(std::is_enum<Type>::value, "Expected enum class");          \

--- a/xla/ffi/api/ffi_test.cc
+++ b/xla/ffi/api/ffi_test.cc
@@ -54,12 +54,8 @@ enum class Int64BasedEnum : int64_t {
   kTwo = kI32MaxValue + 2,
 };
 
-}  // namespace xla::ffi
-
 XLA_FFI_REGISTER_ENUM_ATTR_DECODING(::xla::ffi::Int32BasedEnum);
 XLA_FFI_REGISTER_ENUM_ATTR_DECODING(::xla::ffi::Int64BasedEnum);
-
-namespace xla::ffi {
 
 using ::testing::HasSubstr;
 using ::tsl::testing::StatusIs;


### PR DESCRIPTION
Currently gcc11 shows the following build error:
```bash
./xla/ffi/api/api.h:1640:38: error: global qualification of class name is invalid before '{' token
 1640 |   struct ::xla::ffi::AttrDecoding<T> {                                        \
      |                                      ^
xla/ffi/api/ffi_test.cc:59:1: note: in expansion of macro 'XLA_FFI_REGISTER_ENUM_ATTR_DECODING'
   59 | XLA_FFI_REGISTER_ENUM_ATTR_DECODING(::xla::ffi::Int32BasedEnum);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes it.