### PR TITLE
Update the scheduling name for the created fusion and root instructions

### DIFF
--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -2239,8 +2239,8 @@ class HloInstruction {
   void set_metadata_preserve_layout(bool preserve_layout) {
     metadata_->set_preserve_layout(preserve_layout);
   }
-  void set_metadata_scheduling_name(const std::string& name) {
-    metadata_->set_scheduling_name(name);
+  void set_metadata_scheduling_name(absl::string_view name) {
+    metadata_->set_scheduling_name(std::string(name));
   }
   const OpMetadata& metadata() const { return *metadata_; }
 

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -5384,6 +5384,7 @@ xla_cc_test(
         ":backend_configs_cc",
         ":stream_attribute_annotator",
         "//xla/hlo/ir:hlo",
+        "//xla/tests:filecheck",
         "//xla/tests:hlo_test_base",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings:string_view",

--- a/xla/service/gpu/scheduling_instruction_annotator.cc
+++ b/xla/service/gpu/scheduling_instruction_annotator.cc
@@ -37,7 +37,7 @@ absl::StatusOr<bool> AnnotateSchedulingInstructionNames(
     if (!inst->metadata().scheduling_name().empty()) {
       continue;
     }
-    inst->set_metadata_scheduling_name(std::string(inst->name()));
+    inst->set_metadata_scheduling_name(inst->name());
     changed = true;
   }
   return changed;

--- a/xla/service/gpu/stream_attribute_annotator.cc
+++ b/xla/service/gpu/stream_attribute_annotator.cc
@@ -123,9 +123,9 @@ absl::StatusOr<bool> WrapIntoFusionAndAnnotateStreamAttributes(
     // Update the scheduling names of the fusion and its root instruction
     // to match their newly assigned instruction names during creation.
     fusion_instruction->set_metadata_scheduling_name(
-        std::string(fusion_instruction->name()));
+        fusion_instruction->name());
     HloInstruction* root = fusion_instruction->fused_expression_root();
-    root->set_metadata_scheduling_name(std::string(root->name()));
+    root->set_metadata_scheduling_name(root->name());
     module->schedule().replace_instruction(computation, instruction,
                                            fusion_instruction);
   }

--- a/xla/service/gpu/stream_attribute_annotator.cc
+++ b/xla/service/gpu/stream_attribute_annotator.cc
@@ -120,6 +120,13 @@ absl::StatusOr<bool> WrapIntoFusionAndAnnotateStreamAttributes(
       fusion_instruction->fused_instructions_computation(),
       absl::StrCat("wrapped_", wrapped_opcode, "_computation"));
   if (module->has_schedule()) {
+    // Update the scheduling names of the fusion and its root instruction
+    // to match their newly assigned instruction names during creation.
+    fusion_instruction->set_metadata_scheduling_name(
+        std::string(fusion_instruction->name()));
+    HloInstruction* root =
+        fusion_instruction->called_computations()[0]->root_instruction();
+    root->set_metadata_scheduling_name(std::string(root->name()));
     module->schedule().replace_instruction(computation, instruction,
                                            fusion_instruction);
   }

--- a/xla/service/gpu/stream_attribute_annotator.cc
+++ b/xla/service/gpu/stream_attribute_annotator.cc
@@ -124,8 +124,7 @@ absl::StatusOr<bool> WrapIntoFusionAndAnnotateStreamAttributes(
     // to match their newly assigned instruction names during creation.
     fusion_instruction->set_metadata_scheduling_name(
         std::string(fusion_instruction->name()));
-    HloInstruction* root =
-        fusion_instruction->called_computations()[0]->root_instruction();
+    HloInstruction* root = fusion_instruction->fused_expression_root();
     root->set_metadata_scheduling_name(std::string(root->name()));
     module->schedule().replace_instruction(computation, instruction,
                                            fusion_instruction);


### PR DESCRIPTION
When working on maxtext, there is an error of scheduling name mismatching the instruction name for the remat-policy of minimal_offloaded. This CL fixes the scheduling names for the instructions created by the StreamAttributeAnnotator pass.