### PR TITLE
[XLA:CPU][oneDNN] Prevent F32 fallback for BF16 rewritable dots

### DIFF
--- a/xla/service/change_op_data_type.cc
+++ b/xla/service/change_op_data_type.cc
@@ -64,7 +64,7 @@ absl::StatusOr<bool> ChangeOpDataType::Run(
       }
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
       if (instr->opcode() == HloOpcode::kDot &&
-          cpu::OneDnnContractionRewriter::ShouldRewriteDot(instr)) {
+          cpu::OneDnnContractionRewriter::ShouldRewriteDot(instr, true)) {
         continue;
       }
       if (instr->opcode() == HloOpcode::kConvolution &&

--- a/xla/service/cpu/cpu_float_support.cc
+++ b/xla/service/cpu/cpu_float_support.cc
@@ -27,7 +27,7 @@ bool CpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     // oneDNN rewritable ops
     case HloOpcode::kDot:
       return LowPrecisionType() == BF16 &&
-             OneDnnContractionRewriter::ShouldRewriteDot(&hlo);
+             OneDnnContractionRewriter::ShouldRewriteDot(&hlo, true);
     case HloOpcode::kConvolution:
       return LowPrecisionType() == BF16 &&
              OneDnnContractionRewriter::ShouldRewriteConv(&hlo);

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -366,7 +366,7 @@ inline auto OptionalConvertAndBitcast(HloInstruction** optional_convert,
 }  // namespace
 
 bool OneDnnContractionRewriter::ShouldRewriteDot(
-    const HloInstruction* dot_instr) {
+    const HloInstruction* dot_instr, bool before_layout_assignment) {
   // Currently, blocking control dependencies
   if (dot_instr->HasControlDependencies()) return false;
   if (!IsSupportedType(dot_instr->shape().element_type())) return false;
@@ -400,10 +400,11 @@ bool OneDnnContractionRewriter::ShouldRewriteDot(
   // scenarios in last two dimensions.
   // Col-major layouts are corrected to row-majow for BatchDot operation as
   // part of the layout-pass.
-  if (!IsBatchDot(*dot_instr) &&
-      (!IsRowMajor(lhs_shape) || !IsRowMajor(rhs_shape) ||
-       !IsRowMajor(output_shape))) {
-    return false;
+  // Skip row-major layout check before layout-pass
+  if (!before_layout_assignment) {
+    bool row_major = IsRowMajor(lhs_shape) && IsRowMajor(rhs_shape) &&
+                     IsRowMajor(output_shape);
+    if (!row_major) return false;
   }
 
   auto dot_dim_numbers = dot_instr->dot_dimension_numbers();
@@ -467,8 +468,10 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
 
     TF_RETURN_IF_ERROR(
         ValidateDotDimensionNumbers(dot_instr->dot_dimension_numbers()));
-    if (!OneDnnContractionRewriter::ShouldRewriteDot(dot_instr))
+    if (!OneDnnContractionRewriter::ShouldRewriteDot(dot_instr)) {
+      TF_RETURN_IF_ERROR(UpcastDotToF32(dot_instr));
       return absl::OkStatus();
+    }
     TF_ASSIGN_OR_RETURN(dot_instr, ReconfigureDotDimensions(dot_instr));
     auto dot_dim_numbers = dot_instr->dot_dimension_numbers();
     const Shape& lhs_shape = dot_instr->operand(0)->shape();
@@ -1014,6 +1017,34 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
 
     TF_RETURN_IF_ERROR(ReplaceInstruction(dot_instr, replacement_instr));
     return adjusted_dot;
+  }
+
+  // This function upcasts BF16 dots to F32 if we are unable to rewrite them to
+  // onednn custom calls.
+  absl::Status UpcastDotToF32(HloInstruction* dot_instr) {
+    if (dot_instr->shape().element_type() != BF16) return absl::OkStatus();
+    std::vector<HloInstruction*> new_operands;
+    auto bf16_operands = dot_instr->operands();
+
+    std::for_each(
+        bf16_operands.begin(), bf16_operands.end(),
+        [&new_operands](HloInstruction* instr) {
+          new_operands.push_back(
+              instr->AddInstruction(HloInstruction::CreateConvert(
+                  ShapeUtil::ChangeElementType(instr->shape(), F32), instr)));
+        });
+
+    HloInstruction* f32_dot =
+        dot_instr->AddInstruction(dot_instr->CloneWithNewOperands(
+            ShapeUtil::ChangeElementType(dot_instr->shape(), F32),
+            new_operands));
+
+    HloInstruction* replacement_instr =
+        f32_dot->AddInstruction(HloInstruction::CreateConvert(
+            ShapeUtil::ChangeElementType(f32_dot->shape(), BF16), f32_dot));
+
+    TF_RETURN_IF_ERROR(ReplaceInstruction(dot_instr, replacement_instr));
+    return absl::OkStatus();
   }
 };
 

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -398,9 +398,9 @@ bool OneDnnContractionRewriter::ShouldRewriteDot(
 
   // Layout should be row-major, contraction dimensions captures transpose
   // scenarios in last two dimensions.
-  // Col-major layouts are corrected to row-majow for BatchDot operation as
-  // part of the layout-pass.
-  // Skip row-major layout check before layout-pass
+  // Col-major layouts are corrected to row-major for BatchDot operation as
+  // part of the layout-assignment pass.
+  // Skip row-major layout check before layout-assignment pass
   if (!before_layout_assignment) {
     bool row_major = IsRowMajor(lhs_shape) && IsRowMajor(rhs_shape) &&
                      IsRowMajor(output_shape);
@@ -1020,7 +1020,7 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
   }
 
   // This function upcasts BF16 dots to F32 if we are unable to rewrite them to
-  // onednn custom calls.
+  // oneDNN custom calls.
   absl::Status UpcastDotToF32(HloInstruction* dot_instr) {
     if (dot_instr->shape().element_type() != BF16) return absl::OkStatus();
     std::vector<HloInstruction*> new_operands;

--- a/xla/service/cpu/onednn_contraction_rewriter.h
+++ b/xla/service/cpu/onednn_contraction_rewriter.h
@@ -47,7 +47,8 @@ class OneDnnContractionRewriter : public HloModulePass {
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
 
-  static bool ShouldRewriteDot(const HloInstruction* dot_instr);
+  static bool ShouldRewriteDot(const HloInstruction* dot_instr,
+                               bool before_layout_assignment = false);
   static bool ShouldRewriteConv(const HloInstruction* conv_instr);
 
  private:

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -1501,6 +1501,27 @@ TEST_F(MatmulTest, WeightsPrepackAndScratch) {
   )");
 }
 
+TEST_F(MatmulTest, ColMajorBF16DotBeforeLayoutAssignment) {
+  if (!IsSupportedType(PrimitiveType::BF16)) {
+    GTEST_SKIP() << "CPU does not support BF16.";
+  }
+
+  const char* matmul_module_str = R"(
+  HloModule matmul.colmajor.test
+  ENTRY matmul.colmajor.test.bf16 {
+    arg.0 = bf16[500,500]{0,1} parameter(0)
+    arg.1 = bf16[500,500]{1,0} parameter(1)
+    transpose.0 = bf16[500,500]{0,1} transpose(arg.1), dimensions={1,0}
+    ROOT dot.0 = bf16[500,500]{1,0} dot(arg.0, arg.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec(1e-2, 1e-2)));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:     (bf16[500,500]{1,0}, u8[{{.*}}]{0}) custom-call(%{{[a-z,A-Z,0-9,\.]*}}, %{{[a-z,A-Z,0-9,\.]*}}), custom_call_target="__onednn$matmul",
+  )");
+}
+
 TEST_F(MatmulTest, ConsecutiveBinaryAdd) {
   const char* matmul_module_str = R"(
   HloModule matmul.test.f32

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -1512,13 +1512,15 @@ TEST_F(MatmulTest, ColMajorBF16DotBeforeLayoutAssignment) {
     arg.0 = bf16[500,500]{0,1} parameter(0)
     arg.1 = bf16[500,500]{1,0} parameter(1)
     transpose.0 = bf16[500,500]{0,1} transpose(arg.1), dimensions={1,0}
-    ROOT dot.0 = bf16[500,500]{1,0} dot(arg.0, arg.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    ROOT dot.0 = bf16[500,500]{1,0} dot(arg.0, arg.1), lhs_contracting_dims={1},
+      rhs_contracting_dims={0}
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec(1e-2, 1e-2)));
   MatchOptimizedHlo(matmul_module_str,
                     R"(
-  ; CHECK:     (bf16[500,500]{1,0}, u8[{{.*}}]{0}) custom-call(%{{[a-z,A-Z,0-9,\.]*}}, %{{[a-z,A-Z,0-9,\.]*}}), custom_call_target="__onednn$matmul",
+  ; CHECK: (bf16[500,500]{1,0}, u8[{{.*}}]{0})
+  ; CHECK-SAME: custom_call_target="__onednn$matmul"
   )");
 }
 


### PR DESCRIPTION
This PR prevents some oneDNN rewritable BF16 dots from being converted to F32. In particular:
1. This PR prevents the oneDNN rewriter from performing layout checks before the layout assignment passes, thus avoiding the upcasting of dots with column-major layouts that might later be converted to row-major layouts.
2. In case the BF16 dots are not rewritable to oneDNN custom calls, this PR upcasts the BF16 dots to F32.
3. Currently, the oneDNN rewriter bypasses the layout checks for batch dots. This PR also introduces the layout checks for batch dots during the rewrite process. 