### PR TITLE
Fix thunk_executor.cc build failure caused by ABSL_ATTRIBUTE_ALWAYS_INLINE

### DIFF
--- a/xla/service/cpu/runtime/thunk_executor.cc
+++ b/xla/service/cpu/runtime/thunk_executor.cc
@@ -511,7 +511,7 @@ std::string ThunkExecutor::ToString() const {
   return str;
 }
 
-ABSL_ATTRIBUTE_ALWAYS_INLINE ThunkExecutor::FifoReadyQueue::FifoReadyQueue(
+inline ThunkExecutor::FifoReadyQueue::FifoReadyQueue(
     absl::Span<const NodeId> ready_nodes)
     : queue_(ready_nodes.begin(), ready_nodes.end()) {}
 
@@ -543,8 +543,7 @@ ThunkExecutor::FifoReadyQueue::CreateEmptyReadyQueue() const {
   return FifoReadyQueue(absl::Span<const NodeId>());
 }
 
-ABSL_ATTRIBUTE_ALWAYS_INLINE
-ThunkExecutor::PriorityReadyQueue::PriorityReadyQueue(
+inline ThunkExecutor::PriorityReadyQueue::PriorityReadyQueue(
     absl::Span<const NodeDef> nodes_defs, absl::Span<const NodeId> ready_nodes)
     : nodes_defs_(nodes_defs),
       queue_(ready_nodes.begin(), ready_nodes.end(), Compare{nodes_defs}) {}


### PR DESCRIPTION
Currently thunk_executor.cc compilation fails if gcc11 is used. Error:
```
xla/service/cpu/runtime/thunk_executor.cc:514:30: error: inlining failed in call to 'always_inline' 'xla::cpu::ThunkExecutor::FifoReadyQueue::FifoReadyQueue(absl::lts_20230802::Span<const long int>)': function body can be overwritten at link time
xla/service/cpu/runtime/thunk_executor.cc:543:51: note: called from here
  543 |   return FifoReadyQueue(absl::Span<const NodeId>());
```

This PR fixes it by replacing `ABSL_ATTRIBUTE_ALWAYS_INLINE` with `inline` in couple places.