### PR TITLE
[NVIDIA] Don't use c_scale when the operand c is non-fp8

### DIFF
--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -448,12 +448,15 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
                                  CUBLASLT_MATMUL_DESC_B_SCALE_POINTER,
                                  b_scale.opaque()));
     }
-    if (c_scale != nullptr) {
+    auto isF8Input = [](const auto& desc) {
+        return desc.type() == CUDA_R_8F_E4M3 || desc.type() == CUDA_R_8F_E5M2;
+    };
+    if (c_scale != nullptr && isF8Input(c_desc_)) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  CUBLASLT_MATMUL_DESC_C_SCALE_POINTER,
                                  c_scale.opaque()));
     }
-    if (d_scale != nullptr) {
+    if (d_scale != nullptr && isF8Input(d_desc_)) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  CUBLASLT_MATMUL_DESC_D_SCALE_POINTER,
                                  d_scale.opaque()));


### PR DESCRIPTION
For current fp8 gemm, we set the c_scale to one, though it is effectively never used. Newer cublaslt, however, has a stricter requirement that c_scale can be set only when the operand c is fp8. So, this PR fixes this issue by removing the c_scale. This shouldn't affect the current fp8 gemm, as it is not used anyway.

cc. @philipphack @reedwm 