### PR TITLE
Allow fusing epilogues whose operands are broadcast of scalar instructions.

### DIFF
--- a/xla/service/gpu/fusions/triton/triton_fusion_emitter_device_legacy_test.cc
+++ b/xla/service/gpu/fusions/triton/triton_fusion_emitter_device_legacy_test.cc
@@ -2016,6 +2016,58 @@ ENTRY e {
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 
+TEST_F(TritonGemmTest, BroadcastOfScalarWorksCorrectly) {
+  const std::string kHloText = R"(
+fusion {
+  p0 = f16[2,18] parameter(0)
+  p1 = f16[256,2] parameter(1)
+  d = f16[18,256] dot(p0, p1), lhs_contracting_dims={0}, rhs_contracting_dims={1}
+  p2 = f16[] parameter(2)
+  p3 = f16[] parameter(3)
+  multiply = f16[] multiply(p2, p3)
+  broadcast = f16[18,256] broadcast(multiply), dimensions={}
+  ROOT multiply.3 = f16[18,256] multiply(d, broadcast)
+}
+ENTRY e  {
+  p0 = f16[2,18] parameter(0)
+  p1 = f16[256,2] parameter(1)
+  p2 = f16[] parameter(2)
+  p3 = f16[] parameter(3)
+  ROOT gemm_fusion = f16[18,256]{1,0} fusion(p0, p1, p2, p3), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config":{"kind":"__triton_gemm","triton_gemm_config":{"block_m":"32","block_n":"32","block_k":"16","split_k":"1","num_stages":"1","num_warps":"4","num_ctas":"1"}}}
+})";
+
+  TF_ASSERT_OK(CreateTritonIrAndFileCheckForDot(this, kHloText, "fusion", R"(
+        CHECK:      tt.dot
+        CHECK:      arith.mulf %{{.*}}, %{{.*}} : tensor<f16> 
+        CHECK:      tt.broadcast %{{.*}} : tensor<1x1xf16> -> tensor<32x32xf16>
+        CHECK:      arith.mulf %{{.*}}, %{{.*}} : tensor<32x32xf16>
+    )"));
+  const se::DeviceDescription dev_info =
+      backend().default_stream_executor()->GetDeviceDescription();
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> hlo_module,
+                          ParseAndReturnVerifiedModule(kHloText));
+  const HloFusionInstruction* triton_dot_fusion = Cast<HloFusionInstruction>(
+      hlo_module->entry_computation()->root_instruction());
+  llvm::LLVMContext llvm_ctx;
+  llvm::Module llvm_module("module", llvm_ctx);
+  mlir::MLIRContext mlir_context;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto gpu_config, triton_dot_fusion->backend_config<GpuBackendConfig>());
+  const FusionBackendConfig& config = gpu_config.fusion_backend_config();
+  auto gemm_config = config.triton_gemm_config();
+  BlockLevelParameters block_level_parameters;
+  block_level_parameters.num_ctas = gemm_config.num_ctas();
+  block_level_parameters.num_warps = gemm_config.num_warps();
+  block_level_parameters.num_stages = gemm_config.num_stages();
+
+  TF_CHECK_OK(TritonWrapper("test_fn", triton_dot_fusion, GpuComputeComp(),
+                            dev_info, block_level_parameters, &llvm_module,
+                            mlir_context)
+                  .status());
+}
+
 class TritonGemmLevel2Test : public TritonGemmTest {
  public:
   DebugOptions GetDebugOptionsForTest() override {

--- a/xla/service/gpu/transforms/gemm_fusion_test.cc
+++ b/xla/service/gpu/transforms/gemm_fusion_test.cc
@@ -1216,6 +1216,28 @@ ENTRY e {
       "foo");
 }
 
+TEST_F(GemmFusionTest, FusesBroadcastOfScalarEpilogues) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+HloModule m
+ENTRY e {
+  p0 = f16[2,18] parameter(0)
+  p1 = f16[256,2] parameter(1)
+  d = f16[18,256] dot(p0, p1),
+    lhs_contracting_dims={0}, rhs_contracting_dims={1}
+  p2 = f16[1] parameter(2)
+  p3 = f16[1] parameter(3)
+  m0 = f16[1] multiply(f16[1] p2, f16[1] p3)
+  bc = f16[] bitcast(m0)
+  b = f16[18,256] broadcast(f16[] bc)
+  ROOT m = f16[18,256] multiply(d, b)
+})")
+                    .value();
+  EXPECT_TRUE(GemmFusion(gpu_version_).Run(module.get()).value());
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch((m::Fusion(m::Parameter(), m::Parameter(),
+                                    m::Parameter(), m::Parameter()))));
+}
+
 // A test fixture class for testing the threshold for small matrices.
 class SmallDotGemmFusionTest : public GemmFusionTest {
  public:

--- a/xla/service/gpu/triton_tiling_propagation.cc
+++ b/xla/service/gpu/triton_tiling_propagation.cc
@@ -1075,10 +1075,10 @@ GetPropagatedDimOrdersAndRequirementsIfProfitablyFusible(
       if (i == *src_operand_index) {
         continue;
       }
-      // Currently only broadcasts of scalar constants or parameters
-      // are accepted as other inputs of non-unary operations
-      // in the output fusion.
-      if (hlo_query::IsBroadcastOfScalarConstant(*operand) ||
+      // Currently only broadcasts of scalars or parameters are accepted as
+      // other inputs of non-unary operations in the output fusion.
+      if ((operand->opcode() == HloOpcode::kBroadcast &&
+           ShapeUtil::IsScalar(operand->operand(0)->shape())) ||
           operand->opcode() == HloOpcode::kParameter) {
         continue;
       }


### PR DESCRIPTION
Allow fusing epilogues whose operands are broadcast of scalar instructions. This enables creating fusions for fp8 where the pattern is `mul(dot, scalar_ops)` where scalar ops's shapes are scalar.  This only affects epilogues, the operands of broadcast will still follow the existing fusing rules. Both triton and cuDNN backends support this kind of fusion. 

cc @sergachev 