### PR TITLE
[ROCm] Fixed build breaks.

### DIFF
--- a/xla/service/gpu/autotuning/BUILD
+++ b/xla/service/gpu/autotuning/BUILD
@@ -433,7 +433,7 @@ cc_library(
     srcs = if_gpu_is_configured(["custom_kernel_fusion_autotuner.cc"]),
     hdrs = if_gpu_is_configured(["custom_kernel_fusion_autotuner.h"]),
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
-    deps = if_cuda_is_configured([
+    deps = if_gpu_is_configured([
         ":autotuner_compile_util",
         ":autotuner_util",
         "@com_google_absl//absl/algorithm:container",

--- a/xla/service/gpu/fusions/triton/compilation_pipeline_rocm.cc
+++ b/xla/service/gpu/fusions/triton/compilation_pipeline_rocm.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
-#include "xla/service/gpu/fusions/triton/sparse_extensions.h"
 #include "xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
 #include "xla/service/gpu/matmul_utils.h"
 #include "xla/service/gpu/model/tiled_hlo_computation.h"


### PR DESCRIPTION
Fixed build breaks caused by:
https://github.com/openxla/xla/commit/e4153a41926ff3d7e4b7f31b59e868145d165a59
https://github.com/openxla/xla/commit/732e7e5eefc21fbba234014a9f05716133de3557

Error messages:
1)
xla/service/gpu/fusions/triton/compilation_pipeline_rocm.cc:25:10: fatal error: xla/service/gpu/fusions/triton/sparse_extensions.h: No such file or directory
[2024-08-06T22:41:10.966Z]    25 | #include "xla/service/gpu/fusions/triton/sparse_extensions.h"
[2024-08-06T22:41:10.966Z]       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2024-08-06T22:41:10.966Z] compilation terminated.

2)
ERROR: /tf/xla/xla/xla/service/gpu/autotuning/BUILD:431:11: Compiling xla/service/gpu/autotuning/custom_kernel_fusion_autotuner.cc failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing command (from target //xla/service/gpu/autotuning:custom_kernel_fusion_autotuner) external/local_config_rocm/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer ... (remaining 45 arguments skipped)
In file included from xla/service/gpu/autotuning/custom_kernel_fusion_autotuner.cc:16:
./xla/service/gpu/autotuning/custom_kernel_fusion_autotuner.h:18:10: fatal error: absl/container/flat_hash_set.h: No such file or directory
   18 | #include "absl/container/flat_hash_set.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

