### PR TITLE
[GPU] Change the sharded autotuning test to run on 2 GPUs.

### DIFF
--- a/xla/tools/multihost_hlo_runner/data/multiple_gemm_fusions.hlo
+++ b/xla/tools/multihost_hlo_runner/data/multiple_gemm_fusions.hlo
@@ -1,35 +1,46 @@
 f1 {
-  p0 = f16[720,720,720]{2,1,0} parameter(0)
-  p1 = s8[720,720,720]{2,1,0} parameter(1)
-  c = f16[720,720,720]{2,1,0} convert(p1)
-  ROOT d1 = f16[720,720,720]{2,1,0} dot(p0, c),
+  p0 = f16[64,64,64] parameter(0)
+  p1 = s8[64,64,64] parameter(1)
+  c = f16[64,64,64] convert(p1)
+  ROOT d1 = f32[64,64,64] dot(p0, c),
     lhs_batch_dims={0}, lhs_contracting_dims={2},
     rhs_batch_dims={0}, rhs_contracting_dims={1}
 }
 
 f2 {
-  p0 = s8[720,720,720]{2,1,0} parameter(0)
-  c0 = f32[720,720,720]{2,1,0} convert(p0)
-  p1 = f16[720,720,720]{2,1,0} parameter(1)
-  c1 = f32[720,720,720]{2,1,0} convert(p1)
-  ROOT %dot.1 = f32[720,720,720]{2,1,0} dot(c0, c1),
+  p0 = s8[64,64,64] parameter(0)
+  c0 = f32[64,64,64] convert(p0)
+  p1 = f16[64,64,64] parameter(1)
+  c1 = f32[64,64,64] convert(p1)
+  ROOT d2 = f32[64,64,64] dot(c0, c1),
     lhs_batch_dims={0}, lhs_contracting_dims={2},
     rhs_batch_dims={0}, rhs_contracting_dims={1}
 }
 
+f3 {
+  p0 = f16[64,64,64] parameter(0)
+  p1 = f16[64,64,64] parameter(1)
+  ROOT d3 = f32[64,64,64] dot(p0, p1),
+    lhs_batch_dims={0}, lhs_contracting_dims={1},
+    rhs_batch_dims={0}, rhs_contracting_dims={2}
+}
+
 fa {
-  p1 = f16[720,720,720]{2,1,0} parameter(1)
-  c = f32[720,720,720]{2,1,0} convert(p1)
-  p0 = f32[720,720,720]{2,1,0} parameter(0)
-  ROOT %add.1.1 = f32[720,720,720]{2,1,0} add(c, p0)
+  p0 = f32[64,64,64] parameter(0)
+  p1 = f32[64,64,64] parameter(1)
+  p2 = f32[64,64,64] parameter(2)
+  a1 = f32[64,64,64] add(p2, p1)
+  ROOT a = f32[64,64,64] add(p0, a1)
 }
 
 ENTRY e {
-  p1 = s8[720,720,720]{2,1,0} parameter(1)
-  p0 = f16[720,720,720]{2,1,0} parameter(0)
-  f1r = f16[720,720,720]{2,1,0} fusion(p0, p1), kind=kCustom, calls=f1,
+  p0 = f16[64,64,64] parameter(0)
+  p1 = s8[64,64,64] parameter(1)
+  f1r = f32[64,64,64] fusion(p0, p1), kind=kCustom, calls=f1,
     backend_config={"fusion_backend_config":{"kind":"__triton_gemm"}}
-  f2r = f32[720,720,720]{2,1,0} fusion(p1, p0), kind=kCustom, calls=f2,
+  f2r = f32[64,64,64] fusion(p1, p0), kind=kCustom, calls=f2,
     backend_config={"fusion_backend_config":{"kind":"__triton_gemm"}}
-  ROOT _ = f32[720,720,720]{2,1,0} fusion(f2r, f1r), kind=kLoop, calls=fa
+  f3r = f32[64,64,64] fusion(p0, p0), kind=kCustom, calls=f3,
+    backend_config={"fusion_backend_config":{"kind":"__triton_gemm"}}
+  ROOT _ = f32[64,64,64] fusion(f1r, f2r, f3r), kind=kLoop, calls=fa
 }

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -256,7 +256,7 @@ TEST_F(FunctionalHloRunnerTest, CanCompileWithoutHavingEnoughGpus) {
 
 // Name of the test binary.
 static const char* binary_name;
-constexpr int kNumNodes = 3;
+constexpr int kNumNodes = 2;
 
 TEST_F(FunctionalHloRunnerTest, ShardedAutotuningWorks) {
   if (IsTestingCpu()) {
@@ -308,13 +308,8 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id) {
                         env.kv_store->Get("gemm_fusion_autotuning_results_1_1",
                                           absl::Seconds(1)));
     CHECK(absl::StrContains(results1, "run_time"));
-    // First two nodes autotune two different fusions.
+    // The nodes autotune different fusions.
     CHECK_NE(results0, results1);
-    TF_ASSIGN_OR_RETURN(std::string results2,
-                        env.kv_store->Get("gemm_fusion_autotuning_results_1_2",
-                                          absl::Seconds(1)));
-    // Third node has nothing to autotune.
-    CHECK(!absl::StrContains(results2, "run_time"));
   }
   return absl::OkStatus();
 }


### PR DESCRIPTION
3rd fusion was added to the test to keep the distibution of fusions between nodes asymmetric.
Tensor sizes were reduced to let the test run quicker.