### PR TITLE
gemv rewrite pass independent of triton

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1391,11 +1391,12 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
     const auto* cuda_cc = std::get_if<se::CudaComputeCapability>(&gpu_version);
     const auto* rocm_cc = std::get_if<se::RocmComputeCapability>(&gpu_version);
 
+    pipeline.AddPass<GemvRewriter>();
+
     if (debug_options.xla_gpu_enable_triton_gemm() &&
         ((cuda_cc != nullptr &&
           cuda_cc->IsAtLeast(se::CudaComputeCapability::AMPERE)) ||
          rocm_cc != nullptr)) {
-      pipeline.AddPass<GemvRewriter>();
       pipeline.AddPass<GemmFusion>(gpu_version);
     }
 

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1359,6 +1359,7 @@ cc_library(
 xla_cc_test(
     name = "gemv_rewriter_test",
     srcs = ["gemv_rewriter_test.cc"],
+    backends = ["gpu"],
     deps = [
         ":gemv_rewriter",
         "//xla/hlo/ir:hlo",

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1362,6 +1362,9 @@ xla_cc_test(
     deps = [
         ":gemv_rewriter",
         "//xla/hlo/ir:hlo",
+        "//xla/service:pattern_matcher",
+        "//xla/service:pattern_matcher_gmock",
+        "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/tests:hlo_test_base",
         "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/status:statusor",

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1356,9 +1356,10 @@ cc_library(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "gemv_rewriter_test",
     srcs = ["gemv_rewriter_test.cc"],
+    backends = ["gpu"],
     deps = [
         ":gemv_rewriter",
         "//xla/hlo/ir:hlo",

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1359,7 +1359,6 @@ cc_library(
 xla_cc_test(
     name = "gemv_rewriter_test",
     srcs = ["gemv_rewriter_test.cc"],
-    backends = ["gpu"],
     deps = [
         ":gemv_rewriter",
         "//xla/hlo/ir:hlo",

--- a/xla/service/gpu/transforms/gemv_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemv_rewriter_test.cc
@@ -33,7 +33,7 @@ namespace {
 namespace m = ::xla::match;
 
 class GemvRewriterTest : public GpuCodegenTest {
-   const auto& device_desc() {
+  const auto& device_desc() {
     return backend().default_stream_executor()->GetDeviceDescription();
   }
 
@@ -44,7 +44,7 @@ class GemvRewriterTest : public GpuCodegenTest {
 
   bool IsCuda() {
     return std::holds_alternative<se::CudaComputeCapability>(Capability());
-  }  
+  }
 };
 
 TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationToGemmPipeline) {

--- a/xla/service/gpu/transforms/gemv_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemv_rewriter_test.cc
@@ -32,9 +32,26 @@ namespace {
 
 namespace m = ::xla::match;
 
-class GemvRewriterTest : public GpuCodegenTest {};
+class GemvRewriterTest : public GpuCodegenTest {
+   const auto& device_desc() {
+    return backend().default_stream_executor()->GetDeviceDescription();
+  }
+
+ protected:
+  const se::GpuComputeCapability& Capability() {
+    return device_desc().gpu_compute_capability();
+  }
+
+  bool IsCuda() {
+    return std::holds_alternative<se::CudaComputeCapability>(Capability());
+  }  
+};
 
 TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationToGemmPipeline) {
+  if (!IsCuda()) {
+    GTEST_SKIP() << "Only test on NVidia GPUs.";
+  }
+
   const char* hlo = R"(
   HloModule m
 

--- a/xla/service/gpu/transforms/gemv_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemv_rewriter_test.cc
@@ -32,26 +32,9 @@ namespace {
 
 namespace m = ::xla::match;
 
-class GemvRewriterTest : public GpuCodegenTest {
-  const auto& device_desc() {
-    return backend().default_stream_executor()->GetDeviceDescription();
-  }
-
- protected:
-  const se::GpuComputeCapability& Capability() {
-    return device_desc().gpu_compute_capability();
-  }
-
-  bool IsCuda() {
-    return std::holds_alternative<se::CudaComputeCapability>(Capability());
-  }
-};
+class GemvRewriterTest : public GpuCodegenTest {};
 
 TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationToGemmPipeline) {
-  if (!IsCuda()) {
-    GTEST_SKIP() << "Only test on NVidia GPUs.";
-  }
-
   const char* hlo = R"(
   HloModule m
 
@@ -71,7 +54,6 @@ TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationToGemmPipeline) {
   auto result = backend().compiler()->RunHloPasses(
       ParseAndReturnVerifiedModule(hlo, config).value(),
       backend().default_stream_executor(), backend().memory_allocator());
-
   EXPECT_THAT(
       (*result)->entry_computation()->root_instruction(),
       GmockMatch(


### PR DESCRIPTION
In the decoding stage of some MOE model inferences, XLA squeezes dimensions of size 1 when sequence length is 1. For example, it transforms a shape of [1, 4096] into [4096], resulting in a GEMV operation. When Triton GEMM is disabled, the GEMV rewriter is ineffective, which leads to failures in rewriting FP8 GEMM operations.