### PR TITLE
[XLA:GPU] Add participating groups to NCCL  clique key to fix split hang

### DIFF
--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -1919,30 +1919,16 @@ absl::Status CollectiveCmd::BarrierIfAsync(
 absl::Status CollectiveCmd::Prepare(
     const Thunk::PrepareParams& params,
     Thunk::ResourceRequests& resource_requests) {
-  const Thunk::CollectiveExecuteParams* collectives = params.collective_params;
-
   TF_ASSIGN_OR_RETURN(
-      std::vector<GlobalDeviceId> participants,
-      GetParticipatingDevices(collectives->global_device_id,
-                              *collectives->device_assn,
+      NcclCliqueKey clique_key,
+      GetNcclCliqueKey(*params.collective_params, config().replica_groups,
+                       config().group_mode, nccl_stream_id(),
+                       GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(
+      size_t num_local_participants,
+      GetNumLocalParticipants(*params.collective_params,
                               config().replica_groups, config().group_mode));
-
-  std::vector<GlobalDeviceId> local_devices;
-  if (collectives->global_device_id_map) {
-    local_devices.reserve(collectives->global_device_id_map->size());
-    for (const auto& entry : *collectives->global_device_id_map) {
-      local_devices.push_back(entry.second);
-    }
-  }
-
-  size_t num_local_participants = GetNumLocalParticipants(
-      participants,
-      collectives->global_device_id_map ? &local_devices : nullptr);
-
-  return resource_requests.AddClique(
-      NcclCliqueKey(std::move(participants), nccl_stream_id(),
-                    GetAsyncStreamKind()),
-      num_local_participants);
+  return resource_requests.AddClique(clique_key, num_local_participants);
 }
 
 absl::Status CollectiveCmd::AddTracedCommandBuffer(

--- a/xla/service/gpu/runtime/nccl_clique_key.cc
+++ b/xla/service/gpu/runtime/nccl_clique_key.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
 #include "absl/types/span.h"
 #include "xla/service/global_device_id.h"
 
@@ -36,12 +37,14 @@ namespace xla::gpu {
 // NcclCliqueKey
 //===----------------------------------------------------------------------===//
 
-NcclCliqueKey::NcclCliqueKey(std::vector<GlobalDeviceId> devices,
-                             NcclStreamId stream_id,
-                             AsyncStreamKind stream_kind)
+NcclCliqueKey::NcclCliqueKey(
+    std::vector<GlobalDeviceId> devices, NcclStreamId stream_id,
+    AsyncStreamKind stream_kind,
+    std::vector<std::vector<GlobalDeviceId>> participant_groups)
     : devices_(std::move(devices)),
       stream_id_(stream_id),
-      stream_kind_(stream_kind) {}
+      stream_kind_(stream_kind),
+      participant_groups_(std::move(participant_groups)) {}
 
 absl::Span<const GlobalDeviceId> NcclCliqueKey::devices() const {
   return devices_;
@@ -64,12 +67,23 @@ bool NcclCliqueKey::IsSubsetOf(const NcclCliqueKey& other) const {
 }
 
 std::string NcclCliqueKey::ToString() const {
-  return absl::StrFormat("devices=[%s]; stream=%d",
-                         GlobalDeviceIdsToString(devices_), stream_id_.value());
+  std::string group_string = "";
+  if (!participant_groups_.empty()) {
+    std::vector<std::string> values;
+    values.reserve(participant_groups_.size());
+    for (auto group : participant_groups_) {
+      values.push_back("[" + GlobalDeviceIdsToString(group) + "]");
+    }
+    group_string = absl::StrFormat("; groups=[%s]", absl::StrJoin(values, ","));
+  }
+  return absl::StrFormat("devices=[%s]; stream=%d%s",
+                         GlobalDeviceIdsToString(devices_), stream_id_.value(),
+                         group_string);
 }
 
 bool operator==(const NcclCliqueKey& a, const NcclCliqueKey& b) {
-  return a.devices_ == b.devices_ && a.stream_id_ == b.stream_id_;
+  return a.devices_ == b.devices_ && a.stream_id_ == b.stream_id_ &&
+         a.participant_groups_ == b.participant_groups_;
 }
 
 bool operator<(const NcclCliqueKey& a, const NcclCliqueKey& b) {

--- a/xla/service/gpu/runtime/nccl_clique_key.h
+++ b/xla/service/gpu/runtime/nccl_clique_key.h
@@ -82,7 +82,8 @@ class NcclCliqueKey {
   explicit NcclCliqueKey(
       std::vector<GlobalDeviceId> devices,
       NcclStreamId stream_id = NcclStreamId(0),
-      AsyncStreamKind stream_kind = AsyncStreamKind::kCollective);
+      AsyncStreamKind stream_kind = AsyncStreamKind::kCollective,
+      std::vector<std::vector<GlobalDeviceId>> participant_groups = {});
 
   absl::Span<const GlobalDeviceId> devices() const;
 
@@ -111,13 +112,25 @@ class NcclCliqueKey {
 
  private:
   std::vector<GlobalDeviceId> devices_;
+  // The full list of groups across all devices which this clique is a part of.
+  // When enable_nccl_comm_splitting is enabled, this is used to distinguish
+  // which cliques can be reused from the cache or must be split in order to
+  // prevent a deadlock situation.
+  // For example, imagine we have a communicator with devices = [0,1] and groups
+  // = [0, 1] Later on, we may want to create communicators [0, 1] and [2, 3] by
+  // splitting [0, 1, 2, 3] If ranks 0 and 1 reuse the exisiting [0, 1] clique
+  // but ranks 2 and 3 initiate a split, there will be a deadlock since ranks 2,
+  // 3 and will be waiting forever for 0, 1 to join the split. Having the
+  // particating groups as part of the cache key will prevent such situations
+  std::vector<std::vector<GlobalDeviceId>> participant_groups_;
   NcclStreamId stream_id_;
   AsyncStreamKind stream_kind_;
 };
 
 template <typename H>
 H AbslHashValue(H h, const NcclCliqueKey& k) {
-  return H::combine(std::move(h), k.devices_, k.stream_id_);
+  return H::combine(std::move(h), k.devices_, k.stream_id_,
+                    k.participant_groups_);
 }
 
 bool operator==(const NcclCliqueKey& a, const NcclCliqueKey& b);

--- a/xla/service/gpu/runtime/nccl_clique_key_test.cc
+++ b/xla/service/gpu/runtime/nccl_clique_key_test.cc
@@ -53,6 +53,26 @@ TEST(NcclCliqueKeyTest, Compare) {
   EXPECT_GT(key1, key0);
 }
 
+TEST(NcclCliqueKeyTest, CompareWithParticipantGroups) {
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+  GlobalDeviceId id2 = GlobalDeviceId(2);
+  GlobalDeviceId id3 = GlobalDeviceId(3);
+
+  // The keys are not equal because the replica groups are different.
+  NcclCliqueKey key0({id0, id1}, NcclStreamId(0), AsyncStreamKind::kCollective,
+                     std::vector<std::vector<GlobalDeviceId>>{{id0, id1}});
+  NcclCliqueKey key1(
+      {id0, id1}, NcclStreamId(0), AsyncStreamKind::kCollective,
+      std::vector<std::vector<GlobalDeviceId>>{{id0, id1}, {id2, id3}});
+  EXPECT_FALSE(key0 == key1);
+
+  // With no replica groups, the keys are equal
+  NcclCliqueKey key0_nogroups({id0, id1}, NcclStreamId(0));
+  NcclCliqueKey key1_nogroups({id0, id1}, NcclStreamId(0));
+  EXPECT_EQ(key0_nogroups, key1_nogroups);
+}
+
 TEST(NcclCliqueKeyTest, BtreeIterationOrder) {
   GlobalDeviceId id0 = GlobalDeviceId(0);
   GlobalDeviceId id1 = GlobalDeviceId(1);

--- a/xla/service/gpu/runtime/nccl_collective_thunk.h
+++ b/xla/service/gpu/runtime/nccl_collective_thunk.h
@@ -283,9 +283,16 @@ absl::Status AddOpDescription(absl::Status status, OpT op,
 
 //===----------------------------------------------------------------------===//
 
-size_t GetNumLocalParticipants(
-    const std::vector<GlobalDeviceId>& participants,
-    const std::vector<GlobalDeviceId>* local_devices);  // may be null
+absl::StatusOr<NcclCliqueKey> GetNcclCliqueKey(
+    const Thunk::CollectiveExecuteParams& params,
+    const std::vector<ReplicaGroup>& replica_groups,
+    CollectiveOpGroupMode group_mode, NcclStreamId stream_id,
+    AsyncStreamKind stream_kind);
+
+absl::StatusOr<size_t> GetNumLocalParticipants(
+    const Thunk::CollectiveExecuteParams& params,
+    const std::vector<ReplicaGroup>& replica_groups,
+    CollectiveOpGroupMode group_mode);
 
 // Returns a nccl comm handle and a flag indicating if
 // it's a local communicator.


### PR DESCRIPTION
When using `--xla_gpu_enable_nccl_comm_splitting=true`, it is possible for a deadlock to occur if one or more subgroups of a split was already created and those devices reuse it from the clique map, while the other subgroups initiate a split and will wait forver for the rest of the devices to join. This was occuring in the JAX pmap_test as reported by @hawkinsp.

The code below reproduces the issue by first creating a ccommunicator with all devices [0, 1, 2, 3].
Next, we created a communicator [0, 1].
Then, we try to split [0, 1, 2, 3] ->[0, 1] and [2, 3].
On ranks 0 and 1, XLA will reuse the [0, 1] comm that was created earlier. However, ranks 2 and 3 will begin a NcclCommSplit. They will be stuck forever since ranks 0 and 1 don't also join the split.

To fix this, the key for the clique map now also includes the full set of groups across all devices. This ensures that the clique map lookup behavior will be consistent across all ranks and in this situations would prevent ranks 0 and 1 from reusing the earlier [0, 1] communicator.

```
import jax
import jax.numpy as jnp
from jax import lax

def create_comm_0_1():
    x = jnp.arange(2*2).reshape(2, 2)
    ans = jax.pmap(lambda x: jax.lax.psum(jax.lax.psum(x, 'i'), 'i'), in_axes=0, out_axes=None, axis_name='i')(x)
    print(ans)

def create_comms_0_1_and_2_3():
    x = jnp.arange(4*2).reshape(4, 2)
    ans = jax.pmap(lambda x: jax.lax.psum(jax.lax.psum(x, 'i'), 'i', axis_index_groups=[[0, 1], [2, 3]]), in_axes=0, out_axes=None, axis_name='i')(x)
    print(ans)

create_comm_0_1()
create_comms_0_1_and_2_3() # <--- Hangs without this PR!
```

I've also refactored a little so that `GetNcclCliqueKey` is always used when creating the nccl clique key to avoid some duplicated code.