### PR TITLE
[PJRT:GPU] Handle sub-byte allocations in pinned host memory

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -957,6 +957,36 @@ TEST(StreamExecutorGpuClientTest, CopyToPinnedHostMemorySpace) {
                                      *literal));
 }
 
+TEST(StreamExecutorGpuClientTest, CopyToPinnedHostMemorySpaceInt4) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+  std::vector<int8_t> data{1, 2, 3, 4};
+  Shape shape = ShapeUtil::MakeShape(S4, {4});
+  auto device = client->addressable_devices()[0];
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto buffer,
+      client->BufferFromHostBuffer(
+          data.data(), shape.element_type(), shape.dimensions(),
+          /*byte_strides=*/std::nullopt,
+          PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall, nullptr,
+          device));
+
+  EXPECT_EQ(buffer->memory_space()->kind(), "device");
+
+  auto* pinned_memory_space = device->memory_spaces()[1];
+  EXPECT_EQ(pinned_memory_space->kind_id(), PinnedHostMemorySpace::kKindId);
+  TF_ASSERT_OK_AND_ASSIGN(auto result,
+                          buffer->CopyToMemorySpace(pinned_memory_space));
+
+  EXPECT_EQ(result->memory_space()->kind(), "pinned_host");
+  EXPECT_TRUE(result->IsOnCpu());
+
+  TF_ASSERT_OK_AND_ASSIGN(auto literal, result->ToLiteralSync());
+  std::vector<xla::s4> expected{xla::s4(1), xla::s4(2), xla::s4(3), xla::s4(4)};
+  EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR1<xla::s4>(expected),
+                                     *literal));
+}
+
 TEST(StreamExecutorGpuClientTest, OpaqueDeviceMemoryDataPointer) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
                           GetStreamExecutorGpuClient(GpuClientOptions()));

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -458,11 +458,9 @@ AllocateDestinationBuffer(
   // callback.
   auto memory_space_shape_fn = [is_pinned_host_memory,
                                 transfer_manager](const Shape& shape) {
-    Shape result = shape;
+    Shape result = transfer_manager->HostShapeToDeviceShape(shape);
     if (is_pinned_host_memory) {
       result.mutable_layout()->set_memory_space(Layout::kHostMemorySpace);
-    } else {
-      result = transfer_manager->HostShapeToDeviceShape(result);
     }
     return result;
   };


### PR DESCRIPTION
Let us not skip calling transfer manager's HostShapeToDeviceShape method for pinned memory allocations. With this patch, the [test_deserialization_with_int4 JAX test](https://github.com/google/jax/blob/23effba503081b176673bd4d5284f1b70584f2df/jax/experimental/array_serialization/serialization_test.py#L581) passes on GPU.

Without this patch, we do not pack sub-byte types in the layout (implemented in GenericTransferManager::HostShapeToDeviceShape).