### PR TITLE
Do not fail for dot ops with E5M2 inputs and BF16 output

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2722,11 +2722,7 @@ cc_library(
 xla_test(
     name = "dot_algorithm_support_test",
     srcs = if_gpu_is_configured(["dot_algorithm_support_test.cc"]),
-    backends = [
-        "gpu_v100",
-        "gpu_a100",
-        "gpu_amd_any",
-    ],
+    backends = ["gpu"],
     tags = [
         "nomac",
     ],


### PR DESCRIPTION
Prior to this PR, the following HLO fails to run:

```
HloModule test
ENTRY test {
  x = f8e5m2[32,32] parameter(0)
  y = f8e5m2[32,32] parameter(1)
  ROOT dot = bf16[32,32] dot(x, y),
    lhs_contracting_dims={1}, rhs_contracting_dims={0}, algorithm=dot_any_f8_any_f8_f32
}
```

This works as (f16 f16 bf16) GEMM config is not supported by cuBLASlt, but (bf16 bf16 bf16) is.