### PR TITLE
Create overloads of cub::ThreadLoadVolatilePointer instead of template specializations

### DIFF
--- a/xla/service/gpu/gpu_prim.h
+++ b/xla/service/gpu/gpu_prim.h
@@ -44,10 +44,9 @@ __device__ __forceinline__ void ThreadStoreVolatilePtr<Eigen::half>(
       Eigen::numext::bit_cast<uint16_t>(val);
 }
 
-template <>
-__device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer<Eigen::half>(
-    Eigen::half *ptr, Int2Type<true> /*is_primitive*/) {
-  uint16_t result = *reinterpret_cast<volatile uint16_t *>(ptr);
+__device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer(
+    const Eigen::half *ptr, Int2Type<true> /*is_primitive*/) {
+  uint16_t result = *reinterpret_cast<volatile const uint16_t *>(ptr);
   return Eigen::numext::bit_cast<Eigen::half>(result);
 }
 
@@ -58,10 +57,8 @@ __device__ __forceinline__ void ThreadStoreVolatilePtr<tsl::bfloat16>(
       Eigen::numext::bit_cast<uint16_t>(val);
 }
 
-template <>
-__device__ __forceinline__ tsl::bfloat16
-ThreadLoadVolatilePointer<tsl::bfloat16>(tsl::bfloat16 *ptr,
-                                         Int2Type<true> /*is_primitive*/) {
+__device__ __forceinline__ tsl::bfloat16 ThreadLoadVolatilePointer(
+    tsl::bfloat16 *ptr, Int2Type<true> /*is_primitive*/) {
   uint16_t result = *reinterpret_cast<volatile uint16_t *>(ptr);
   return Eigen::numext::bit_cast<tsl::bfloat16>(result);
 }


### PR DESCRIPTION
This avoids a build failure with an upcoming CUDA change.
Commit https://github.com/NVIDIA/cccl/commit/6dfc8dddaef5f01adeb683790bf0c8ec05302460 changed the method signature and breaks our specializations.
Specializing cub:: templates is against the CCCL guidelines: https://github.com/NVIDIA/cccl?tab=readme-ov-file#compatibility-guidelines

The workaround here was suggested by someone on the CUDA team.
It is also against the guidelines, since it is adding to the cub:: namespace, but it fixes the compilation failure.
The more futureproof solution is to open a feature request with them (https://github.com/NVIDIA/cccl/issues) to support loading of `Eigen::half` and `tsl::bfloat16` in CUB directly.