### PR TITLE
Revert "PR #15989: [GPU] Upgrade cuDNN frontend to 1.6.0."

### DIFF
--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -50,9 +50,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "313f4a38a54e578ed668809697c96754497141ba62332bdcc019faaeb1e3c6f6",
-        strip_prefix = "cudnn-frontend-1.6.0",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.6.0.zip"),
+        sha256 = "281789777ac296f5f8215a7c4bd066de8816d240eb44c760788beebf8d25a99f",
+        strip_prefix = "cudnn-frontend-1.5.1",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.5.1.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
This reverts commit 8ea0da691de62f78dbf5d131b9e193b00f81d130.

We see failures in jax/tests/nn_test.py caused by this commit.