### PR TITLE
Lower threshold for F64 in //xla/service/gpu/model:hlo_op_profiler_test

### DIFF
--- a/xla/service/gpu/model/hlo_op_profiler_test.cc
+++ b/xla/service/gpu/model/hlo_op_profiler_test.cc
@@ -39,7 +39,7 @@ TEST_F(HloOpProfilerTest, BasicMeasurementsAreCorrect) {
   EXPECT_GT(profiler.MeasureClockCyclesPerOp(HloOpcode::kDivide, F64)
                 .value()
                 .clock_cycles(),
-            400);
+            300);
   // c128 sqrt is slow.
   EXPECT_GT(profiler.MeasureClockCyclesPerOp(HloOpcode::kSqrt, C128)
                 .value()


### PR DESCRIPTION
When running "bazel test" with "--runs_per_test 100" the target fails sometimes (on A100): //xla/service/gpu/model:hlo_op_profiler_test

Reducing the threshold seems to help.