### PR TITLE
Added configure_opts to custom_python_interpreter in python_repo.bzl

### DIFF
--- a/third_party/py/python_repo.bzl
+++ b/third_party/py/python_repo.bzl
@@ -280,6 +280,12 @@ def _custom_python_interpreter_impl(ctx):
 
     configure_params.append("--enable-optimizations")
     configure_params.append("--prefix=%s" % install_path.realpath)
+
+    configure_opts = ctx.attr.configure_opts
+    if configure_opts:
+        for param in ctx.attr.configure_opts:
+            configure_params.append(param)
+
     _exec_and_check(
         ctx,
         ["./configure"] + configure_params,
@@ -361,6 +367,7 @@ custom_python_interpreter = repository_rule(
         "strip_prefix": attr.string(),
         "binary_name": attr.string(mandatory = False),
         "version": attr.string(),
+        "configure_opts": attr.string_list(mandatory = False),
     },
 )
 


### PR DESCRIPTION
Description:
- Added configure_opts to custom_python_interpreter in python_repo.bzl



Context: 
Such that I can pass `--disable-gil` param when building python 3.13 interpreter:
```
load("@xla//third_party/py:python_repo.bzl", "custom_python_interpreter")
custom_python_interpreter(
    name = "python_dev",
    urls = ["https://www.python.org/ftp/python/3.13.0/Python-{version}.tgz"],
    strip_prefix = "Python-{version}",
    version = "3.13.0rc1",
    configure_opts = ["--disable-gil"],
)

```

- https://github.com/google/jax/issues/23073
