### PR TITLE
Fix the driver version parsing in the diagnostics.

### DIFF
--- a/xla/stream_executor/cuda/cuda_diagnostics.cc
+++ b/xla/stream_executor/cuda/cuda_diagnostics.cc
@@ -225,7 +225,7 @@ absl::StatusOr<DriverVersion> Diagnostician::FindDsoVersion() {
 
 absl::StatusOr<DriverVersion> Diagnostician::FindKernelModuleVersion(
     const std::string &driver_version_file_contents) {
-  static const char *kDriverFilePrelude = "Kernel Module  ";
+  static const char *kDriverFilePrelude = "Kernel Module";
   size_t offset = driver_version_file_contents.find(kDriverFilePrelude);
   if (offset == std::string::npos) {
     return absl::NotFoundError(
@@ -233,9 +233,17 @@ absl::StatusOr<DriverVersion> Diagnostician::FindKernelModuleVersion(
                      "driver version file contents: \"",
                      driver_version_file_contents, "\""));
   }
+  static const char *kDriverVersionPrelude = "  ";
+  offset = driver_version_file_contents.find(kDriverVersionPrelude, offset);
+  if (offset == std::string::npos) {
+    return absl::NotFoundError(
+        absl::StrCat("driver version not preceded by two spaces in "
+                     "driver version file contents: \"",
+                     driver_version_file_contents, "\""));
+  }
 
   std::string version_and_rest = driver_version_file_contents.substr(
-      offset + strlen(kDriverFilePrelude), std::string::npos);
+      offset + strlen(kDriverVersionPrelude), std::string::npos);
   size_t space_index = version_and_rest.find(' ');
   auto kernel_version = version_and_rest.substr(0, space_index);
   // TODO(b/22689637): Eliminate the explicit namespace if possible.

--- a/xla/stream_executor/cuda/cuda_driver_test.cc
+++ b/xla/stream_executor/cuda/cuda_driver_test.cc
@@ -19,10 +19,12 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/driver_types.h"
-#include "xla/stream_executor/cuda/cuda_status.h"
-#include "xla/stream_executor/gpu/gpu_driver.h"
 #include "tsl/platform/status.h"
 #include "tsl/platform/test.h"
+#include "xla/stream_executor/cuda/cuda_diagnostics.h"
+#include "xla/stream_executor/cuda/cuda_status.h"
+#include "xla/stream_executor/gpu/gpu_diagnostics.h"
+#include "xla/stream_executor/gpu/gpu_driver.h"
 
 namespace stream_executor {
 namespace gpu {
@@ -68,4 +70,25 @@ TEST(CudaDriverTest, ScopedActivateContextTest) {
 }
 
 }  // namespace gpu
+
+namespace cuda {
+
+TEST(CudaDriverTest, DriverVersionParsingTest) {
+  // Tests that the driver version can be right after 'Kernel Module',
+  // or later as well.
+  auto driver_version = Diagnostician::FindKernelModuleVersion(
+      "... NVIDIA UNIX Open Kernel Module for x86_64  570.00  Release Build  "
+      "...  Mon Aug 12 04:17:20 UTC 2024");
+  TF_CHECK_OK(driver_version.status());
+  EXPECT_EQ("570.0.0", cuda::DriverVersionToString(driver_version.value()));
+
+  driver_version = Diagnostician::FindKernelModuleVersion(
+      "... NVIDIA UNIX Open Kernel Module  571.00  Release Build  "
+      "...  Mon Aug 12 04:17:20 UTC 2024");
+  TF_CHECK_OK(driver_version.status());
+  EXPECT_EQ("571.0.0", cuda::DriverVersionToString(driver_version.value()));
+}
+
+}  // namespace cuda
+
 }  // namespace stream_executor


### PR DESCRIPTION
The version number doesn't always follow "Kernel Module" immediately. Two spaces somewhere after "Kernel Module" are the signifier that the driver version follows.