### PR TITLE
[XLA:GPU] Enable --xla_gpu_enable_nccl_comm_splitting=true by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -149,7 +149,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_termination_timeout_seconds(-1);
   opts.set_xla_gpu_enable_shared_constants(true);
   opts.set_xla_gpu_enable_nccl_user_buffers(false);
-  opts.set_xla_gpu_enable_nccl_comm_splitting(false);
+  opts.set_xla_gpu_enable_nccl_comm_splitting(true);
   opts.set_xla_gpu_enable_nccl_per_stream_comms(false);
 
   opts.set_xla_gpu_temp_buffer_use_separate_color(false);


### PR DESCRIPTION
Now that the hang with NCCL comm split is fixed #15935, I'm resubmitting #11762 to enable nccl comm split by default which will reduce the amount of memory used by NCCL communicators.