### PR TITLE
Add more checks for multiplication results

### DIFF
--- a/xla/service/algebraic_simplifier.h
+++ b/xla/service/algebraic_simplifier.h
@@ -496,6 +496,11 @@ class AlgebraicSimplifierVisitor : public DfsHloRewriteVisitor {
   static bool IsNonNegative(const HloInstruction* hlo,
                             const AlgebraicSimplifierOptions& options);
 
+  // Checks if the output of a given instruction is guaranteed to be
+  // postive. e.g. power
+  static bool IsPositive(const HloInstruction* hlo,
+                         const AlgebraicSimplifierOptions& options);
+
   // Check if the opcode of a given instruction is a non-decreasing function
   // asymptotically satisfying |f(x)| <= |x|
   static bool IsNondecreasingSublinear(const HloInstruction* hlo);


### PR DESCRIPTION
Add positive checks for multiplication results

This commit introduces a new function that determines if the result of a multiplication is a positive number. It handles the cases where both operands are negative or both are positive, ensuring that the result is treated as a positive number if the product of two negatives is involved.

The function checks the sign of the operands and applies the mathematical rule that the product of two negative numbers is positive. This is crucial for ensuring the correctness of calculations in various scenarios, such as financial calculations or scientific computations where the sign of the result is significant.