### PR TITLE
[ROCM] disabling setting workspace for rocblas

### DIFF
--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -359,24 +359,27 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
 
   // set the atomics mode, leaving default to library
   bool allow_atomics = !OpDeterminismRequired();
-  rocblas_status ret;
   if (!allow_atomics) {
-    ret = wrap::rocblas_set_atomics_mode(blas_, rocblas_atomics_not_allowed);
+    auto ret = wrap::rocblas_set_atomics_mode(blas_, rocblas_atomics_not_allowed);
     if (err_on_failure && ret != rocblas_status_success) {
-      LOG(ERROR) << "failed to to set atomics mode before " << FuncT::kName
+      LOG(ERROR) << "Failed to set atomics mode before " << FuncT::kName
                  << ": " << ToString(ret);
     }
   }
 #if TF_ROCM_VERSION >= 60000
-  if (auto *workspace = GetWorkspace(); workspace != nullptr &&
-                                        workspace->opaque() != nullptr &&
-                                        workspace->size() > 0) {
-    (void)wrap::rocblas_set_workspace(blas_, workspace->opaque(),
-                                      workspace->size());
+  {
+    auto *workspace = GetWorkspace();
+    auto *wptr = workspace != nullptr ? workspace->opaque() : nullptr;
+    size_t wsize = workspace != nullptr ? workspace->size() : 0;
+    auto ret = wrap::rocblas_set_workspace(blas_, wptr, wsize); 
+    if (err_on_failure && ret != rocblas_status_success) {
+      LOG(ERROR) << "Failed to set workspace before " << FuncT::kName
+                 << ": " << ToString(ret);
+    }
   }
 #endif
 
-  ret = rocblas_func(blas_, std::forward<Args>(args)...);
+  auto ret = rocblas_func(blas_, std::forward<Args>(args)...);
   if (ret != rocblas_status_success) {
     auto err_str =
         absl::StrFormat("%s failed with: %s", FuncT::kName, ToString(ret));

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -356,13 +356,13 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
   }
 
   gpu::ScopedActivateExecutorContext sac{parent_};
-
+  rocblas_status ret;
   // set the atomics mode, leaving default to library
   bool allow_atomics = !OpDeterminismRequired();
   if (!allow_atomics) {
-    auto ret = wrap::rocblas_set_atomics_mode(blas_, rocblas_atomics_not_allowed);
+    ret = wrap::rocblas_set_atomics_mode(blas_, rocblas_atomics_not_allowed);
     if (err_on_failure && ret != rocblas_status_success) {
-      LOG(ERROR) << "Failed to set atomics mode before " << FuncT::kName
+      LOG(ERROR) << "failed to set atomics mode before " << FuncT::kName
                  << ": " << ToString(ret);
     }
   }
@@ -371,15 +371,15 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
     auto *workspace = GetWorkspace();
     auto *wptr = workspace != nullptr ? workspace->opaque() : nullptr;
     size_t wsize = workspace != nullptr ? workspace->size() : 0;
-    auto ret = wrap::rocblas_set_workspace(blas_, wptr, wsize); 
+    ret = wrap::rocblas_set_workspace(blas_, wptr, wsize); 
     if (err_on_failure && ret != rocblas_status_success) {
-      LOG(ERROR) << "Failed to set workspace before " << FuncT::kName
+      LOG(ERROR) << "failed to set workspace before " << FuncT::kName
                  << ": " << ToString(ret);
     }
   }
 #endif
 
-  auto ret = rocblas_func(blas_, std::forward<Args>(args)...);
+  ret = rocblas_func(blas_, std::forward<Args>(args)...);
   if (ret != rocblas_status_success) {
     auto err_str =
         absl::StrFormat("%s failed with: %s", FuncT::kName, ToString(ret));

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -366,7 +366,10 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
                  << ": " << ToString(ret);
     }
   }
-#if TF_ROCM_VERSION >= 60000
+#if 0
+// pemeliya: the feature is disabled since rocblas does not perform well under
+// graph capture. rocblas_set_workspace seems to use blocking memory functions
+// like hipFree/hipMalloc which result in HIP_ERROR_StreamCaptureUnsupported 
   {
     auto *workspace = GetWorkspace();
     auto *wptr = workspace != nullptr ? workspace->opaque() : nullptr;


### PR DESCRIPTION
After enabling workspaces on ROCM in https://github.com/openxla/xla/pull/13779, we have a problem with **//xla/tests:triangular_solve_test**. Note that, [triangular_solve_thunk](https://github.com/openxla/xla/blob/4cfd0f84e1fbd5e92c7b961d59650474e7f310a4/xla/service/gpu/runtime/triangular_solve_thunk.cc#L151) does **not** set a workspace while calling DoBlasTrsmBatched functions which is probably not needed on CUDA side.

Apparently, rocblas has a different behaviour: since rocblas_set_workspace was not called before TRSM routine, rocblas will try to reuse **previously set** workspace which might not be enough for that triangular solve. I fix it by setting workspace to **nullptr** if it is not explicitly provided (thereby forcing rocblas to use its internal scratch buffer). 

**UPDATE:** this feature seems to produce sporadic errors since rocblas_set_workspace uses blocking memory functions to manipulate scratch memory (which do not work under stream capture). **Disabled** until we have a clear idea on how to make it working on ROCM.

@xla-rotation: could you have a look please ?