### PR TITLE
[ROCm] CI hotfix 

### DIFF
--- a/xla/stream_executor/rocm/rocm_platform.cc
+++ b/xla/stream_executor/rocm/rocm_platform.cc
@@ -62,7 +62,7 @@ absl::StatusOr<StreamExecutor*> ROCmPlatform::FindExisting(int ordinal) {
 }
 
 absl::StatusOr<std::unique_ptr<StreamExecutor>>
-ROCmPlatform::GetUncachedExecutor(int ordinal {
+ROCmPlatform::GetUncachedExecutor(int ordinal) {
   auto executor = std::make_unique<GpuExecutor>(this, ordinal);
   TF_RETURN_IF_ERROR(executor->Init());
   return std::move(executor);


### PR DESCRIPTION
Issue was caused by this commit: https://github.com/openxla/xla/commit/05cb60b588d0f0ca13151fc0f5d630d7a26d6b05#diff-09c72ba3125587b3998e45c7a179e18a7df5da72e8c56ec89fcedac1df49f23cR70

Log:
```
[2024-08-16T05:07:42.977Z] xla/stream_executor/rocm/rocm_platform.cc:65:46: error: expected ‘)’ before ‘{’ token
[2024-08-16T05:07:42.977Z]    65 | ROCmPlatform::GetUncachedExecutor(int ordinal {
[2024-08-16T05:07:42.978Z]       |                                  ~           ^~
[2024-08-16T05:07:42.978Z]       |                                              )
```