### PR TITLE
[ROCm] Fix pjrt_c_api_gpu_test

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -276,6 +276,12 @@ TEST(PjrtCApiGpuAllocatorTest, ValidOptionsParsing) {
   std::vector<std::string> allocator_options = {"default", "platform", "bfc",
                                                 "cuda_async"};
   for (const std::string& allocator_option : allocator_options) {
+#ifdef TENSORFLOW_USE_ROCM
+    if (allocator_option == "cuda_async") {
+    VLOG(1) << "cuda_async allocator not available on ROCm!";
+    continue;
+    }
+#endif
     absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
         {"allocator", allocator_option},
         {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0, 1})},

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -278,8 +278,8 @@ TEST(PjrtCApiGpuAllocatorTest, ValidOptionsParsing) {
   for (const std::string& allocator_option : allocator_options) {
 #ifdef TENSORFLOW_USE_ROCM
     if (allocator_option == "cuda_async") {
-    VLOG(1) << "cuda_async allocator not available on ROCm!";
-    continue;
+      VLOG(1) << "cuda_async allocator not available on ROCm!";
+      continue;
     }
 #endif
     absl::flat_hash_map<std::string, xla::PjRtValueType> options = {


### PR DESCRIPTION
After these changes https://github.com/openxla/xla/commit/d86502a8d98f0a7b561281ed5a146d511719772d in cuda async allocator were introduced, `PjrtCApiGpuAllocatorTest.ValidOptionsParsing` started failing on ROCm.