### PR TITLE
Align the scheduling name with the instruction name for constants

### DIFF
--- a/xla/service/gpu/transforms/sanitize_constant_names.cc
+++ b/xla/service/gpu/transforms/sanitize_constant_names.cc
@@ -64,6 +64,7 @@ absl::StatusOr<bool> SanitizeConstantNames::Run(
       // Register this new name with the module's instruction_name_uniquer to
       // avoid name collision that might happen in future.
       module->instruction_name_uniquer().GetUniqueName(instr->name());
+      instr->set_metadata_scheduling_name(instr->name());
       changed = true;
     }
   }

--- a/xla/service/gpu/transforms/sanitize_constant_names_test.cc
+++ b/xla/service/gpu/transforms/sanitize_constant_names_test.cc
@@ -104,6 +104,14 @@ TEST_F(SanitizeConstantNamesTest, BufferSanitizedNameCollisionResolved) {
               GmockMatch(m::Constant()));
   EXPECT_THAT(FindInstruction(module.get(), "equal_to_2"),
               GmockMatch(m::Constant()));
+  for (const auto *comp : module->computations()) {
+    for (const auto *instruction : comp->instructions()) {
+      if (!instruction->metadata().scheduling_name().empty()) {
+        EXPECT_EQ(instruction->name(),
+                  instruction->metadata().scheduling_name());
+      }
+    }
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
This commit corrects the scheduling name after it is altered by SanitizeConstantNames, preventing assertion failures in the HLO verifier.