### PR TITLE
[ds-fusion] Add handling for general dynamic slice fusion while emitting thunks

### DIFF
--- a/xla/service/gpu/fusions/custom.cc
+++ b/xla/service/gpu/fusions/custom.cc
@@ -220,6 +220,15 @@ static bool IsLoopIterationOffset(const HloInstruction* offset) {
   return true;
 }
 
+// Returns the constant literal, if the offset is from an offset array. Returns
+// `std::nullopt` otherwise.
+std::optional<const Literal*> GetOffsetArray(const HloInstruction* inst) {
+  if (Match(inst, m::Reshape(m::DynamicSlice(m::Constant(), m::Parameter())))) {
+    return &inst->operand(0)->operand(0)->literal();
+  }
+  return std::nullopt;
+}
+
 absl::Status CollectSliceInfo(
     const BufferAssignment& buffer_assignment,
     const HloInstruction& fusion_instr,
@@ -236,6 +245,12 @@ absl::Status CollectSliceInfo(
 
   std::vector<DynamicSliceThunk::Offset> arg_offsets;
   for (auto idx_op : arg_slice_instr->index_operands()) {
+    if (auto offset_array_literal = GetOffsetArray(idx_op);
+        offset_array_literal != std::nullopt) {
+      arg_offsets.emplace_back(
+          DynamicSliceThunk::OffsetArray(**offset_array_literal));
+      continue;
+    }
     const auto* param = Cast<HloParameterInstruction>(idx_op);
     const auto* offset_value = fusion_instr.operand(param->parameter_number());
 

--- a/xla/service/gpu/fusions/dynamic_slice_fusion_test.cc
+++ b/xla/service/gpu/fusions/dynamic_slice_fusion_test.cc
@@ -2996,6 +2996,417 @@ TEST_F(DynamicSliceFusionTest, ReduceScatterDUSLoopIterationOffset) {
       false, true, error));
 }
 
+TEST_F(DynamicSliceFusionTest, OffsetArrayTestS32) {
+  // When the offset is s32, then this checks that the offset values can be out
+  // of bounds on both directions but they should be clamped during execution.
+  const char* hlo = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    dynamic-slice-fusion {
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      loop_iter = s32[] parameter(2)
+      offset_values = s32[4] constant({-4,4,12,20})
+      offset_as_array = s32[1] dynamic-slice(offset_values, loop_iter), dynamic_slice_sizes={1}
+      offset = s32[] reshape(offset_as_array)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      zero = s32[] parameter(3)
+      ROOT dus = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      zero = s32[] constant(0)
+      fusion = s32[16,4] fusion(dest, src, loop_iter, zero), kind=kCustom, calls=dynamic-slice-fusion, backend_config={"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}}}
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+
+  const char* normal = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      eight = s32[] constant(8)
+      four = s32[] constant(4)
+      mul = s32[] multiply(eight, i)
+      offset = s32[] subtract(mul, four)
+      zero = s32[] constant(0)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      fusion = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+  ErrorSpec error_spec{/*aabs=*/1e-3, /*arel=*/1e-3};
+  EXPECT_TRUE(
+      RunAndCompareTwoModulesReplicated(hlo, normal, true, true, error_spec));
+}
+
+TEST_F(DynamicSliceFusionTest, OffsetArrayTestS64) {
+  // This test makes sure that the offsets are not parsed as `int32_t` all the
+  // time. If the offset is INT64_MAX, and it is parsed as int32_t, it will be
+  // clamped to the zero (parsed as -1) instead of being clamped to the upper
+  // bound. The offsets in the example here should be clamped to {0,4,8,12} but
+  // if they are parsed as int32_t, then they will be clamped to {12, 4, 8, 0}.
+  const char* hlo = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    dynamic-slice-fusion {
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      loop_iter = s32[] parameter(2)
+      offset_values = s64[4] constant({-2147483649,4,8,9223372036854775807})
+      offset_as_array = s64[1] dynamic-slice(offset_values, loop_iter), dynamic_slice_sizes={1}
+      offset = s64[] reshape(offset_as_array)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      zero = s64[] parameter(3)
+      ROOT dus = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      zero = s64[] constant(0)
+      fusion = s32[16,4] fusion(dest, src, loop_iter, zero), kind=kCustom, calls=dynamic-slice-fusion, backend_config={"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}}}
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+
+  const char* normal = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      offset_values = s64[4] constant({-2147483649,4,8,9223372036854775807})
+      offset_as_array = s64[1] dynamic-slice(offset_values, i), dynamic_slice_sizes={1}
+      offset = s64[] reshape(offset_as_array)
+      zero = s64[] constant(0)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      fusion = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+  ErrorSpec error_spec{/*aabs=*/1e-3, /*arel=*/1e-3};
+  EXPECT_TRUE(
+      RunAndCompareTwoModulesReplicated(hlo, normal, true, true, error_spec));
+}
+
+// Same as above for uint32_t
+TEST_F(DynamicSliceFusionTest, OffsetArrayTestU32) {
+  const char* hlo = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    dynamic-slice-fusion {
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      loop_iter = s32[] parameter(2)
+      offset_values = u32[4] constant({0,4,8,4294967295})
+      offset_as_array = u32[1] dynamic-slice(offset_values, loop_iter), dynamic_slice_sizes={1}
+      offset = u32[] reshape(offset_as_array)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      zero = u32[] parameter(3)
+      ROOT dus = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      zero = u32[] constant(0)
+      fusion = s32[16,4] fusion(dest, src, loop_iter, zero), kind=kCustom, calls=dynamic-slice-fusion, backend_config={"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}}}
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+
+  const char* normal = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      offset_values = u32[4] constant({0,4,8,4294967295})
+      offset_as_array = u32[1] dynamic-slice(offset_values, i), dynamic_slice_sizes={1}
+      offset = u32[] reshape(offset_as_array)
+      zero = u32[] constant(0)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      fusion = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+
+  ErrorSpec error_spec{/*aabs=*/1e-3, /*arel=*/1e-3};
+  EXPECT_TRUE(
+      RunAndCompareTwoModulesReplicated(hlo, normal, true, true, error_spec));
+}
+
+// Same as above for uint64_t. It is expected to produce an error if the offset
+// is outside the range of int64_t.
+TEST_F(DynamicSliceFusionTest, OffsetArrayTestU64) {
+  const char* hlo = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    dynamic-slice-fusion {
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      loop_iter = s32[] parameter(2)
+      offset_values = u64[4] constant({0,4,8,18446744073709551615})
+      offset_as_array = u64[1] dynamic-slice(offset_values, loop_iter), dynamic_slice_sizes={1}
+      offset = u64[] reshape(offset_as_array)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      zero = u64[] parameter(3)
+      ROOT dus = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      zero = u64[] constant(0)
+      fusion = s32[16,4] fusion(dest, src, loop_iter, zero), kind=kCustom, calls=dynamic-slice-fusion, backend_config={"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}}}
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+
+  const char* normal = R"(
+    HloModule test_module, replica_count=2
+
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+
+    Body {
+      param = (s32[], s32[16, 4], s32[8, 4], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      dest = s32[16,4] get-tuple-element(param), index=1
+      src = s32[8,4] get-tuple-element(param), index=2
+      loop_iter = s32[] get-tuple-element(param), index=3
+      offset_values = u64[4] constant({0,4,8,18446744073709551615})
+      offset_as_array = u64[1] dynamic-slice(offset_values, i), dynamic_slice_sizes={1}
+      offset = u64[] reshape(offset_as_array)
+      zero = u64[] constant(0)
+      rs = s32[4,4] reduce-scatter(src), channel_id=0, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+      fusion = s32[16,4] dynamic-update-slice(dest, rs, offset, zero)
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      loop_iter_plus_one = s32[] add(loop_iter, one)
+      ROOT tuple = tuple(i_plus_one, fusion, src, loop_iter)
+    }
+
+    Cond {
+      param = (s32[], s32[16,4], s32[8,4], s32[]) parameter(0)
+      loop_iter = s32[] get-tuple-element(param), index=0
+      four = s32[] constant(4)
+      ROOT compare = pred[] compare(loop_iter, four), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      dest = s32[16,4] parameter(0)
+      src = s32[8,4] parameter(1)
+      tuple = tuple(zero, dest, src, zero)
+      ROOT while = (s32[], s32[16,4], s32[8,4], s32[]) while(tuple), body=Body, condition=Cond
+    }
+  )";
+
+  ErrorSpec error_spec{/*aabs=*/1e-3, /*arel=*/1e-3};
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  EXPECT_DEATH(auto status = RunAndCompareTwoModulesReplicated(
+                   hlo, normal, true, true, error_spec),
+               ".*");
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -329,6 +329,7 @@ cc_library(
         ":sequential_thunk",
         ":thunk",
         ":while_thunk",
+        "//xla:literal",
         "//xla:shape_util",
         "//xla:status_macros",
         "//xla/service:buffer_assignment",

--- a/xla/service/gpu/runtime/dynamic_slice_thunk.cc
+++ b/xla/service/gpu/runtime/dynamic_slice_thunk.cc
@@ -81,6 +81,34 @@ DynamicSliceThunk::DynamicSliceThunk(
   }
 }
 
+DynamicSliceThunk::OffsetArray::OffsetArray(const Literal& l) {
+  CHECK(l.shape().IsArray()) << "Expected array literal, got " << l.ToString();
+  for (int i = 0; i < l.element_count(); i++) {
+    switch (l.shape().element_type()) {
+      case S32:
+        values.push_back(l.data<int32_t>()[i]);
+        break;
+      case S64:
+        values.push_back(l.data<int64_t>()[i]);
+        break;
+      case U32:
+        values.push_back(l.data<uint32_t>()[i]);
+        break;
+      case U64:
+        CHECK(l.data<uint64_t>()[i] <
+              uint64_t(std::numeric_limits<int64_t>::max()))
+            << "Offset value: " << l.data<uint64_t>()[i]
+            << " cannot fit in int64_t";
+        values.push_back(l.data<uint64_t>()[i]);
+        break;
+      default:
+        CHECK(false) << "Offset array must be of a supported integer type "
+                        "(S32, S64, U32, U64), found: "
+                     << l.shape().element_type();
+    }
+  }
+}
+
 absl::Status DynamicSliceThunk::Prepare(const PrepareParams& params,
                                         ResourceRequests& resource_requests) {
   for (SliceDef& slice : slices_) {
@@ -182,6 +210,13 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
         VLOG(2) << "  - arg " << argument_idx << "[" << offset_idx
                 << "]: loop iteration offset = " << iter;
         offset_value(argument_idx, offset_idx) = iter;
+
+      } else if (OffsetArray* offset_array =
+                     std::get_if<OffsetArray>(&offset)) {
+        TF_ASSIGN_OR_RETURN(int64_t iter, WhileThunk::CurrentLoopIteration());
+        VLOG(2) << "  - arg " << argument_idx << "[" << offset_idx
+                << "]: offset array offset = " << offset_array->values[iter];
+        offset_value(argument_idx, offset_idx) = offset_array->values[iter];
 
       } else {
         // Transfer slice offset value from device to host.

--- a/xla/service/gpu/runtime/dynamic_slice_thunk.h
+++ b/xla/service/gpu/runtime/dynamic_slice_thunk.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include "xla/shape.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/literal.h"
 
 namespace xla {
 namespace gpu {
@@ -43,12 +44,25 @@ namespace gpu {
 // DynamicSliceThunk assumes that the slices are contiguous.
 class DynamicSliceThunk : public Thunk {
  public:
+  // When the offset value holds an object of type LoopIter, then that offset is
+  // equal to the loop iteration number.
   struct LoopIter {};
+
+  // This struct is used to wrap an array of offset values, where `values[i]`
+  // denotes the value of offset at loop iteration `i`.
+  // For example, if the loop iteration goes [0,5), and a particular offset for
+  // a slicing operation is `4-i`, then values will contain `{4,3,2,1,0}`
+  struct OffsetArray {
+    std::vector<int64_t> values;
+    explicit OffsetArray(const Literal& l);
+    OffsetArray(const OffsetArray& other) { values = other.values; }
+  };
 
   // Dynamic slice offset can be either: (1) a statically known constant value,
   // (2) a loop iteration number, or (3) a truly dynamic offset that is
   // computed on device and have to be transferred to host.
-  using Offset = std::variant<uint64_t, LoopIter, BufferAllocation::Slice>;
+  using Offset =
+      std::variant<uint64_t, LoopIter, BufferAllocation::Slice, OffsetArray>;
 
   DynamicSliceThunk(
       ThunkInfo thunk_info, std::unique_ptr<ThunkSequence> embedded_thunk,


### PR DESCRIPTION
In the current implementation of dynamic slice fusion, we rely on constants or very specific loop offset patterns. This is an effort to generalize this by computing the offset values during compilation and using the constant array as source of offset while emitting thunks.

This patch adds support for this in thunks. Next, support for this will be added in the dynamic-slice-fusion-rewriter.