### PR TITLE
[ROCM] disable setting workspace on ROCM

### DIFF
--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -366,15 +366,18 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
                  << ToString(ret);
     }
   }
-#if TF_ROCM_VERSION >= 60000
+#if 0
+// pemeliya: the feature is disabled since rocblas does not perform well under
+// graph capture. rocblas_set_workspace seems to use blocking memory functions
+// like hipFree/hipMalloc which result in HIP_ERROR_StreamCaptureUnsupported 
   {
     auto *workspace = GetWorkspace();
     auto *wptr = workspace != nullptr ? workspace->opaque() : nullptr;
     size_t wsize = workspace != nullptr ? workspace->size() : 0;
-    ret = wrap::rocblas_set_workspace(blas_, wptr, wsize);
+    ret = wrap::rocblas_set_workspace(blas_, wptr, wsize); 
     if (err_on_failure && ret != rocblas_status_success) {
-      LOG(ERROR) << "failed to set workspace before " << FuncT::kName << ": "
-                 << ToString(ret);
+      LOG(ERROR) << "failed to set workspace before " << FuncT::kName
+                 << ": " << ToString(ret);
     }
   }
 #endif


### PR DESCRIPTION
This is a follow-up PR for https://github.com/openxla/xla/pull/16149 which was closed with unmerged commits.

Here I disable setting workspace on ROCM. This feature seems to produce sporadic errors because rocblas_set_workspace uses blocking memory functions (e.g. hipMalloc/hipFree) to manipulate scratch memory (which do not work under stream capture). **Disabled** until we have a clear idea on how to make it working on ROCM.

@xla-rotation: could you have a look please ?