### PR TITLE
Add optimization barrier as no op

### DIFF
--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -49,7 +49,8 @@ bool IsNopInstruction(const HloInstruction& hlo) {
   return op == HloOpcode::kGetTupleElement || op == HloOpcode::kBitcast ||
          op == HloOpcode::kConstant || op == HloOpcode::kParameter ||
          op == HloOpcode::kTuple || op == HloOpcode::kPartitionId ||
-         op == HloOpcode::kReplicaId || hlo.IsEffectiveBitcast();
+         op == HloOpcode::kReplicaId || hlo.IsEffectiveBitcast() ||
+         op == HloOpcode::kOptimizationBarrier;
 }
 
 bool IsAsyncComputeOp(const HloInstruction& hlo) {

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -86,7 +86,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
       partition-id0 = u32[] partition-id()
       replica-id0 = u32[] replica-id()
       tuple0 = (f32[], f32[2,16], u32[], u32[]) tuple(parameter0, bitcast0, partition-id0, replica-id0)
-      ROOT _ = get-tuple-element(tuple0), index=0
+      opt-barrier = (f32[], f32[2,16], u32[], u32[]) opt-barrier(tuple0)
+      ROOT _ = get-tuple-element(opt-barrier), index=0
     }
   )";
 


### PR DESCRIPTION
For PGLE latency hiding scheduler, optimization barrier should be considered a no-op because it is never really executed.