### PR TITLE
Fix open file leak

### DIFF
--- a/third_party/tsl/tsl/platform/env.cc
+++ b/third_party/tsl/tsl/platform/env.cc
@@ -402,8 +402,10 @@ string Env::GetExecutablePath() {
   if (strstr(buf, "python") != nullptr) {
     // Discard the path of the python binary, and any flags.
     int fd = open("/proc/self/cmdline", O_RDONLY);
+    CHECK_NE(-1, fd);
     int cmd_length = read(fd, buf, PATH_MAX - 1);
     CHECK_NE(-1, cmd_length);
+    close(fd);
     int token_pos = 0;
     for (bool token_is_first_or_flag = true; token_is_first_or_flag;) {
       // Get token length, including null


### PR DESCRIPTION
The hermetic CUDA changes in https://github.com/openxla/xla/commit/cb1541c5f092807fced9e5e2b261371dba888906 added a new route to this code, which seems to have a long-standing file descriptor leak in it.