### PR TITLE
Remove copy-start from stream attribute annotator

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1655,7 +1655,6 @@ xla_test(
         "//xla/service:hlo_cost_analysis",
         "//xla/service:hlo_memory_scheduler",
         "//xla/service:hlo_rematerialization",
-        "//xla/service/gpu/transforms:stream_attribute_annotator",
         "//xla/tests:hlo_test_base",
         "//xla/tests:xla_internal_test_main",
         "//xla/tsl/lib/core:status_test_util",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2514,7 +2514,6 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
         main_pipeline.AddPass<HloPassPipeline>("remat-pipeline");
 
     pipeline.AddPass<HloRematerialization>(remat_opts, sizes);
-    pipeline.AddPass<StreamAttributeAnnotator>();
     pipeline.AddPass<OptimizationBarrierExpander>();
   }
 

--- a/xla/service/gpu/gpu_offloading_test.cc
+++ b/xla/service/gpu/gpu_offloading_test.cc
@@ -30,8 +30,6 @@ limitations under the License.
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/layout.h"
 #include "xla/service/buffer_value.h"
-#include "xla/service/gpu/backend_configs.pb.h"
-#include "xla/service/gpu/transforms/stream_attribute_annotator.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/hlo_memory_scheduler.h"
 #include "xla/service/hlo_rematerialization.h"
@@ -218,18 +216,6 @@ TEST_F(GpuOffloadingTest, CopyIRCreationTest) {
                           RunHloRematerialization(
                               /*memory_limit_bytes=*/10 * 1024, module.get()));
   ASSERT_TRUE(changed);
-  StreamAttributeAnnotator attr_annotator;
-  TF_ASSERT_OK_AND_ASSIGN(bool changed_attr, attr_annotator.Run(module.get()));
-  EXPECT_TRUE(changed_attr);
-  // Verify that the stream attribute for a copy-start is annotated
-  for (std::string i : {"", ".1", ".2", ".3"}) {
-    const HloInstruction* cp_start =
-        FindInstruction(module.get(), "copy-start" + i);
-    EXPECT_TRUE(cp_start->has_backend_config());
-    TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig gpu_config,
-                            cp_start->backend_config<GpuBackendConfig>());
-    EXPECT_GT(gpu_config.operation_queue_id(), 0);
-  }
 
   // The module should still have a schedule.
   ASSERT_TRUE(module->has_schedule());

--- a/xla/service/gpu/runtime/copy_thunk.cc
+++ b/xla/service/gpu/runtime/copy_thunk.cc
@@ -130,7 +130,8 @@ absl::Status DeviceToHostCopyThunk::ExecuteOnStream(
     VLOG(2) << "Memcpy D2H from the main stream";
     return absl::OkStatus();
   }
-  VLOG(2) << "Memcpy D2H from the other stream";
+  VLOG(2) << absl::StreamFormat("Memcpy D2Hfrom the other stream %d",
+                                Thunk::execution_stream_id().value());
   se::StreamExecutor* executor = params.stream->parent();
   TF_ASSIGN_OR_RETURN(auto event, executor->CreateEvent());
   // Record memcpy operation completion.
@@ -168,7 +169,8 @@ absl::Status HostToDeviceCopyThunk::ExecuteOnStream(
     VLOG(2) << "Memcpy H2D from the main stream";
     return absl::OkStatus();
   }
-  VLOG(2) << "Memcpy H2D from the other stream";
+  VLOG(2) << absl::StreamFormat("Memcpy H2D from the other stream %d",
+                                Thunk::execution_stream_id().value());
   se::StreamExecutor* executor = params.stream->parent();
   TF_ASSIGN_OR_RETURN(auto event, executor->CreateEvent());
   // Record memcpy operation completion.

--- a/xla/service/gpu/transforms/stream_attribute_annotator.cc
+++ b/xla/service/gpu/transforms/stream_attribute_annotator.cc
@@ -89,20 +89,6 @@ absl::StatusOr<bool> AnnotateStreamAttributesForInstruction(
   return true;
 }
 
-absl::StatusOr<bool> AnnotateStreamAttributesForCopyStart(
-    HloInstruction* instr, int64_t channel_id,
-    GpuBackendConfig& instr_gpu_config) {
-  // Do nothing if copy-start has already been annotated
-  if (instr_gpu_config.operation_queue_id() !=
-      Thunk::kDefaultExecutionStreamId.value()) {
-    return false;
-  }
-  instr_gpu_config.set_operation_queue_id(channel_id);
-  TF_RETURN_IF_ERROR(instr->set_backend_config(instr_gpu_config));
-  VLOG(3) << "Add copy-start's backend config: " << channel_id;
-  return true;
-}
-
 absl::StatusOr<bool> WrapIntoFusionAndAnnotateStreamAttributes(
     HloInstruction* instruction, int64_t channel_id,
     GpuBackendConfig& instr_gpu_config) {
@@ -195,12 +181,6 @@ absl::StatusOr<bool> StreamAttributeAnnotator::Run(
                             AnnotateStreamAttributesForInstruction(
                                 instr, instr_gpu_config.value()));
         changed |= comp_result;
-      } else if (instr->opcode() == HloOpcode::kCopyStart) {
-        TF_ASSIGN_OR_RETURN(bool comp_result,
-                            AnnotateStreamAttributesForCopyStart(
-                                instr, channel_id, instr_gpu_config.value()));
-        changed |= comp_result;
-        continue;
       } else if (comp->IsAsyncComputation() &&
                  (instr->opcode() == HloOpcode::kDynamicSlice ||
                   instr->opcode() == HloOpcode::kDynamicUpdateSlice)) {

--- a/xla/service/gpu/transforms/stream_attribute_annotator_test.cc
+++ b/xla/service/gpu/transforms/stream_attribute_annotator_test.cc
@@ -166,50 +166,6 @@ TEST_F(StreamAttributeAnnotatorTest, FusionIsAnnotated) {
   EXPECT_EQ(gpu_config.operation_queue_id(), 1);
 }
 
-TEST_F(StreamAttributeAnnotatorTest, CopyStartIsAnnotated) {
-  constexpr absl::string_view kHloString = R"(
-  HloModule offloading
-    ENTRY %main (param_0: f32[1024], param_1: f32[1024]) -> f32[1024] {
-    %param_1 = f32[1024]{0} parameter(1)
-    %param_0 = f32[1024]{0} parameter(0)
-    %res_3 = f32[1024]{0} add(f32[1024]{0} %param_0, f32[1024]{0} %param_1)
-    %copy-start = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_3)
-    %res_4 = f32[1024]{0} tanh(f32[1024]{0} %res_3)
-    %copy-start.2 = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_4)
-    %res_5 = f32[1024]{0} tanh(f32[1024]{0} %res_4)
-    %copy-done = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start)
-    %res_6 = f32[1024]{0} tanh(f32[1024]{0} %res_5)
-    %copy-done.2 = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start.2)
-    %copy-start.3 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done.2)
-    %res_7 = f32[1024]{0} add(f32[1024]{0} %res_6, f32[1024]{0} %res_6)
-    %copy-start.1 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done)
-    %res_8 = f32[1024]{0} add(f32[1024]{0} %res_7, f32[1024]{0} %res_5)
-    %copy-done.3 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.3)
-    %res_9 = f32[1024]{0} add(f32[1024]{0} %res_8, f32[1024]{0} %copy-done.3)
-    %copy-done.1 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.1)
-    %res_10 = f32[1024]{0} add(f32[1024]{0} %res_9, f32[1024]{0} %copy-done.1)
-    ROOT %res_11 = f32[1024]{0} tanh(f32[1024]{0} %res_10)
-  }
-  )";
-
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloString));
-
-  StreamAttributeAnnotator attr_annotator;
-  bool changed;
-  TF_ASSERT_OK_AND_ASSIGN(changed, attr_annotator.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  for (std::string i : {"", ".1", ".2", ".3"}) {
-    const HloInstruction* cp_start =
-        FindInstruction(module.get(), "copy-start" + i);
-    EXPECT_TRUE(cp_start->has_backend_config());
-    TF_ASSERT_OK_AND_ASSIGN(GpuBackendConfig gpu_config,
-                            cp_start->backend_config<GpuBackendConfig>());
-    EXPECT_EQ(gpu_config.operation_queue_id(), 1);
-  }
-}
-
 TEST_F(StreamAttributeAnnotatorTest, DynamicUpdateSliceWrappedAndAnnotated) {
   constexpr absl::string_view kHloString = R"(
   HloModule ModuleWithAsyncDynamicUpdateSlice, is_scheduled=true


### PR DESCRIPTION
This change removes the copy-start instruction handling from StreamAttributeAnnotator, which was originally implemented in PR 10636. This removal is a direct consequence of PR 13597, which moved the responsibility of stream assignment for copy-start instructions to ExecutionStreamAssignment.