### PR TITLE
[ds-fusion][nfc] Cleanup for name of dynamic slice fusion

### DIFF
--- a/xla/service/gpu/fusions/dynamic_slice_fusion_test.cc
+++ b/xla/service/gpu/fusions/dynamic_slice_fusion_test.cc
@@ -94,7 +94,7 @@ class DynamicSliceFusionTest : public HloTestBase {
     return config;
   }
 
-  std::vector<HloComputation*> GetAddressComputations(const HloModule& module) {
+  std::vector<HloComputation*> GetDynamicSliceFusions(const HloModule& module) {
     std::vector<HloComputation*> computations;
     for (auto computation : module.computations()) {
       if (!computation->IsFusionComputation()) {
@@ -188,7 +188,7 @@ TEST_F(DynamicSliceFusionTest, CublasGemmSimple) {
     %p0 = bf16[2,8,8]{2,1,0} parameter(0), sharding={replicated}
     %p1 = bf16[2,8,8]{2,1,0} parameter(1), sharding={replicated}
     ROOT %fusion.2 = bf16[8,8]{1,0} fusion(%p0, %p1), kind=kCustom, calls=%fused_computation,
-        backend_config={"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}}}
+        backend_config={"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"address_computation"}}}
   })";
 
   EXPECT_TRUE(RunAndCompareTwoModules(hlo_ref, hlo_opt, error_spec,
@@ -494,7 +494,7 @@ TEST_F(DynamicSliceFusionTest, OperandIsSlicedGetTupleElement) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.3 = f32[200,100]{1,0} parameter(0)
     %p1.3 = f32[100,100]{1,0} parameter(1)
     %slice.56 = f32[100,100]{1,0} slice(%p0.3), slice={[0:100], [0:100]}
@@ -551,9 +551,9 @@ TEST_F(DynamicSliceFusionTest, OperandIsSlicedGetTupleElement) {
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
-    ROOT %address_computation.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97, %get-tuple-element.240),
+    ROOT %dynamic-slice-fusion.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97, %get-tuple-element.240),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       backend_config={
         "fusion_backend_config":{
           "kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}
@@ -603,7 +603,7 @@ TEST_F(DynamicSliceFusionTest, ReversedOperandOrder) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.1 = f16[2,8,8]{2,1,0} parameter(0)
     %slice.1 = f16[1,8,8]{2,1,0} slice(%p0.1), slice={[1:2], [0:8], [0:8]}
     %bitcast.1 = f16[8,8]{1,0} bitcast(%slice.1)
@@ -636,9 +636,9 @@ TEST_F(DynamicSliceFusionTest, ReversedOperandOrder) {
   ENTRY %main {
     %p0 = f16[2,8,8]{2,1,0} parameter(0)
     %p1 = f16[2,8,8]{2,1,0} parameter(1)
-    ROOT %address_computation.6 = f16[8,8]{1,0} fusion(%p1, %p0),
+    ROOT %dynamic-slice-fusion.6 = f16[8,8]{1,0} fusion(%p1, %p0),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       backend_config={
         "fusion_backend_config":{
           "kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}
@@ -710,7 +710,7 @@ TEST_F(DynamicSliceFusionTest, SingleOperandComputation) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.3 = f32[200,100]{1,0} parameter(0)
     %slice.56 = f32[100,100]{1,0} slice(%p0.3), slice={[0:100], [0:100]}
     %cublas-gemm.23 = (f32[100,100]{1,0}, s8[80000]{0}) custom-call(%slice.56, %slice.56),
@@ -766,9 +766,9 @@ TEST_F(DynamicSliceFusionTest, SingleOperandComputation) {
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
-    ROOT %address_computation.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97),
+    ROOT %dynamic-slice-fusion.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       backend_config={
         "fusion_backend_config":{
           "kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}
@@ -818,7 +818,7 @@ TEST_F(DynamicSliceFusionTest, SlicedOperandAliasingOutput) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.1 = f32[100,100]{1,0} parameter(0)
     %p2 = f32[200,100]{1,0} parameter(2)
     %slice.0 = f32[100,100]{1,0} slice(f32[200,100]{1,0} %p2), slice={[20:120], [0:100]}
@@ -855,9 +855,9 @@ TEST_F(DynamicSliceFusionTest, SlicedOperandAliasingOutput) {
     %get-tuple-element.288 = f32[100,100]{1,0} get-tuple-element(%p0), index=1
     %concatenate.12 = f32[200,100]{1,0} concatenate(%get-tuple-element.287, %get-tuple-element.288), dimensions={0}
     %slice.34 = f32[100,100]{1,0} slice(%concatenate.12), slice={[99:199], [0:100]}
-    ROOT %address_computation.6 = (f32[100,100]{1,0}, s8[120000]{0}) fusion(%get-tuple-element.287, %slice.34, %concatenate.12),
+    ROOT %dynamic-slice-fusion.6 = (f32[100,100]{1,0}, s8[120000]{0}) fusion(%get-tuple-element.287, %slice.34, %concatenate.12),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       output_to_operand_aliasing={{0}: (1, {})},
       backend_config={
         "fusion_backend_config":{
@@ -1612,7 +1612,7 @@ TEST_F(DynamicSliceFusionTest, DynamicOperandIsSlicedGetTupleElement) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.3 = f32[200,100]{1,0} parameter(0)
     %p1.3 = f32[100,100]{1,0} parameter(1)
     %c0_s32 = s32[] parameter(2)
@@ -1671,9 +1671,9 @@ TEST_F(DynamicSliceFusionTest, DynamicOperandIsSlicedGetTupleElement) {
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
-    ROOT %address_computation.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97, %get-tuple-element.240, %c0_s32),
+    ROOT %dynamic-slice-fusion.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97, %get-tuple-element.240, %c0_s32),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       backend_config={
         "fusion_backend_config":{
           "kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}
@@ -1725,7 +1725,7 @@ TEST_F(DynamicSliceFusionTest, DynamicReversedOperandOrder) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.1 = f16[2,8,8]{2,1,0} parameter(0)
     %p1.1 = f16[2,8,8]{2,1,0} parameter(1)
     %c0_s32 = s32[] parameter(2)
@@ -1762,9 +1762,9 @@ TEST_F(DynamicSliceFusionTest, DynamicReversedOperandOrder) {
     %p1 = f16[2,8,8]{2,1,0} parameter(1)
     %c0_s32 = s32[] constant(0)
     %c1_s32 = s32[] constant(1)
-    ROOT %address_computation.6 = f16[8,8]{1,0} fusion(%p1, %p0, %c0_s32, %c1_s32),
+    ROOT %dynamic-slice-fusion.6 = f16[8,8]{1,0} fusion(%p1, %p0, %c0_s32, %c1_s32),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       backend_config={
         "fusion_backend_config":{
           "kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}
@@ -1837,7 +1837,7 @@ TEST_F(DynamicSliceFusionTest, DynamicSingleOperandComputation) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.3 = f32[200,100]{1,0} parameter(0)
     %c0_s32 = s32[] parameter(1)
     %slice.56 = f32[100,100]{1,0} dynamic-slice(%p0.3, %c0_s32, %c0_s32), dynamic_slice_sizes={100,100}
@@ -1895,9 +1895,9 @@ TEST_F(DynamicSliceFusionTest, DynamicSingleOperandComputation) {
         }
       }
     %get-tuple-element.97 = f32[200,100]{1,0} get-tuple-element(%custom-call.16), index=0
-    ROOT %address_computation.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97, %c0_s32),
+    ROOT %dynamic-slice-fusion.6 = (f32[100,100]{1,0}, s8[80000]{0}) fusion(%get-tuple-element.97, %c0_s32),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       backend_config={
         "fusion_backend_config":{
           "kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}
@@ -1950,7 +1950,7 @@ TEST_F(DynamicSliceFusionTest, DynamicSlicedOperandAliasingOutput) {
   const char* hlo_opt = R"(
   HloModule jit_slice
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p0.1 = f32[100,100]{1,0} parameter(0)
     %p1 = f32[100,100]{1,0} parameter(1)
     %p2 = f32[200,100]{1,0} parameter(2)
@@ -1992,9 +1992,9 @@ TEST_F(DynamicSliceFusionTest, DynamicSlicedOperandAliasingOutput) {
     %get-tuple-element.288 = f32[100,100]{1,0} get-tuple-element(%p0), index=1
     %concatenate.12 = f32[200,100]{1,0} concatenate(%get-tuple-element.287, %get-tuple-element.288), dimensions={0}
     %slice.34 = f32[100,100]{1,0} dynamic-slice(%concatenate.12, %c99_s32, %c0_s32), dynamic_slice_sizes={100,100}
-    ROOT %address_computation.6 = (f32[100,100]{1,0}, s8[120000]{0}) fusion(%get-tuple-element.287, %slice.34, %concatenate.12, %c0_s32, %c20_s32),
+    ROOT %dynamic-slice-fusion.6 = (f32[100,100]{1,0}, s8[120000]{0}) fusion(%get-tuple-element.287, %slice.34, %concatenate.12, %c0_s32, %c20_s32),
       kind=kCustom,
-      calls=%address-computation,
+      calls=%dynamic-slice-fusion,
       output_to_operand_aliasing={{0}: (1, {})},
       backend_config={
         "fusion_backend_config":{
@@ -2584,7 +2584,7 @@ TEST_F(DynamicSliceFusionTest, DynamicCustomCallWithTuple) {
   TF_ASSERT_OK_AND_ASSIGN(auto changed, this->RunHloPass(&pass, hlo_opt.get()));
   EXPECT_TRUE(changed);
   EXPECT_TRUE(*RunFileCheck(hlo_opt->ToString(), R"(
-    // CHECK: %address-computation{{.+}} {
+    // CHECK: %dynamic-slice-fusion{{.+}} {
     // CHECK:   {{.+}} = {{.+}} slice
     // CHECK:   {{.+}} = {{.+}} dynamic-slice
     // CHECK:   {{.+}} = {{.+}} custom-call
@@ -2830,7 +2830,7 @@ TEST_F(DynamicSliceFusionTest, ReduceScatterDUSConstant) {
     ROOT %add.1 = f16[] add(%param_0, %param_1)
   }
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p1 = f16[128,128]{1,0} parameter(1)
     %p0 = f16[128,128]{1,0} parameter(0)
     %reduce-scatter.1 = f16[64,128]{1,0} reduce-scatter(%p0), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=%add
@@ -2844,7 +2844,7 @@ TEST_F(DynamicSliceFusionTest, ReduceScatterDUSConstant) {
     %param_1.1 = f16[128,128]{1,0} parameter(1)
     %constant_20 = u32[] constant(20)
     %constant_0 = u32[] constant(0)
-    ROOT %address_computation = f16[128,128]{1,0} fusion(%param_0.1, %param_1.1, %constant_20, %constant_0), kind=kCustom, calls=%address-computation, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}},"force_earliest_schedule":false}
+    ROOT %dynamic-slice-fusion = f16[128,128]{1,0} fusion(%param_0.1, %param_1.1, %constant_20, %constant_0), kind=kCustom, calls=%dynamic-slice-fusion, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}},"force_earliest_schedule":false}
   })";
 
   ErrorSpec error_spec{/*aabs=*/1e-3, /*arel=*/1e-3};
@@ -2881,7 +2881,7 @@ TEST_F(DynamicSliceFusionTest, ReduceScatterDUSParameterOffset) {
     ROOT %add.1 = f16[] add(f16[] %param_0, f16[] %param_1)
   }
 
-  %address-computation {
+  %dynamic-slice-fusion {
     %p1 = f16[128,128]{1,0} parameter(1)
     %p0 = f16[128,128]{1,0} parameter(0)
     %reduce-scatter.1 = f16[64,128]{1,0} reduce-scatter(%p0), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=%add
@@ -2895,7 +2895,7 @@ TEST_F(DynamicSliceFusionTest, ReduceScatterDUSParameterOffset) {
     %param_1 = f16[128,128]{1,0} parameter(1)
     %param_2 = u32[] parameter(2)
     %constant_0 = u32[] constant(0)
-    ROOT %address_computation = f16[128,128]{1,0} fusion(%param_0, %param_1, %param_2, %constant_0), kind=kCustom, calls=%address-computation, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}},"force_earliest_schedule":false}
+    ROOT %dynamic-slice-fusion = f16[128,128]{1,0} fusion(%param_0, %param_1, %param_2, %constant_0), kind=kCustom, calls=%dynamic-slice-fusion, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"}},"force_earliest_schedule":false}
   })";
 
   ErrorSpec error_spec{/*aabs=*/1e-3, /*arel=*/1e-3};
@@ -2974,9 +2974,9 @@ TEST_F(DynamicSliceFusionTest, ReduceScatterDUSLoopIterationOffset) {
       GetOptimizedModule(std::move(module_with_adddress_computation_flag)));
 
   std::vector<HloComputation*> address_computations_opt =
-      GetAddressComputations(*module_with_adddress_computation);
+      GetDynamicSliceFusions(*module_with_adddress_computation);
   std::vector<HloComputation*> address_computations_ref =
-      GetAddressComputations(*ref_module_opt);
+      GetDynamicSliceFusions(*ref_module_opt);
   EXPECT_EQ(address_computations_ref.size(), 0);
   ASSERT_EQ(address_computations_opt.size(), 1);
 

--- a/xla/service/gpu/runtime/dynamic_slice_thunk.cc
+++ b/xla/service/gpu/runtime/dynamic_slice_thunk.cc
@@ -54,7 +54,7 @@ DynamicSliceThunk::DynamicSliceThunk(
     std::vector<std::optional<Shape>> orig_shapes,
     std::vector<std::optional<Shape>> sliced_shapes,
     std::vector<std::optional<uint64_t>> offset_byte_sizes)
-    : Thunk(Kind::kAddressComputation, thunk_info),
+    : Thunk(Kind::kDynamicSlice, thunk_info),
       embedded_thunk_(std::make_unique<SequentialThunk>(
           ThunkInfo(), std::move(*embedded_thunk))),
       fake_allocations_(std::move(fake_allocations)) {

--- a/xla/service/gpu/runtime/for_all_thunks.cc
+++ b/xla/service/gpu/runtime/for_all_thunks.cc
@@ -35,7 +35,7 @@ void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn,
   fn(thunk);
   // ... and then handle all nested `Thunks` recursively.
   switch (thunk->kind()) {
-    case Thunk::kAddressComputation:
+    case Thunk::kDynamicSlice:
       ForAllThunks(fn, tensorflow::down_cast<const DynamicSliceThunk*>(thunk)
                            ->embedded_thunk());
       break;

--- a/xla/service/gpu/runtime/thunk.cc
+++ b/xla/service/gpu/runtime/thunk.cc
@@ -235,7 +235,7 @@ Thunk::ExecuteParams::ExecuteParams(
   case Thunk::x: \
     return #x
   switch (kind) {
-    CASE(kAddressComputation);
+    CASE(kDynamicSlice);
     CASE(kCholesky);
     CASE(kCommandBuffer);
     CASE(kConditional);

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -114,7 +114,7 @@ class Thunk {
   static constexpr auto kDefaultExecutionStreamId = ExecutionStreamId(0);
 
   enum Kind {
-    kAddressComputation,
+    kDynamicSlice,
     kCholesky,
     kConditional,
     kConvolution,

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
@@ -429,7 +429,7 @@ absl::Status CreateRootTuple(
 absl::StatusOr<HloComputation*> CreateFusionBody(
     HloModule* module, DataflowPathView sliced_operand_paths,
     DataflowPathsView sliced_user_paths, DataflowPathView captures) {
-  HloComputation::Builder builder("address-computation");
+  HloComputation::Builder builder("dynamic-slice-fusion");
 
   // A mapping from original instructions to instructions in the fusion body.
   absl::flat_hash_map<const HloInstruction*, HloInstruction*> instr_mapping;

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.h
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.h
@@ -70,7 +70,7 @@ namespace gpu {
 class DynamicSliceFusionRewriter : public HloModulePass {
  public:
   absl::string_view name() const override {
-    return "address-computation-fusion-rewriter";
+    return "dynamic-slice-fusion-rewriter";
   }
 
   explicit DynamicSliceFusionRewriter(std::string platform_name)

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
@@ -76,7 +76,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemm) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -89,7 +89,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemm) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -136,7 +136,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmWithWorkspace) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -153,7 +153,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmWithWorkspace) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = (f16[8,8]{1,0}, s8[256]{0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -201,7 +201,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmWorkspaceIgnored) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -218,7 +218,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmWorkspaceIgnored) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = (f16[8,8]{1,0}, s8[256]{0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -267,7 +267,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmNotRoot) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -280,7 +280,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmNotRoot) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -329,7 +329,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandHasMultipleUsers) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[4,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -344,7 +344,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandHasMultipleUsers) {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[4,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion([[P0]], [[P1]])
-    ; CHECK-DAG:     kind=kCustom, calls=%address-computation,
+    ; CHECK-DAG:     kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK-DAG:     backend_config={
     ; CHECK-DAG:       "kind":"__custom_fusion",
     ; CHECK-DAG:       "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -414,7 +414,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandsHaveMultipleUsers) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation{{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -424,7 +424,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandsHaveMultipleUsers) {
     ; CHECK:       ROOT [[CC:%[^ ]+]] = f16[8,8]{1,0} custom-call([[B0]], [[B1]]),
     ; CHECK:              custom_call_target="__cublas$gemm"
     ; CHECK:     }
-    ; CHECK:     %address-computation{{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -477,7 +477,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmSlicingNotParameter) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -493,7 +493,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmSlicingNotParameter) {
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[2,8,8]{2,1,0} slice([[P0]]), slice={[0:2], [0:8], [0:8]}
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK:       [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion([[S0]], [[P1]])
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -644,7 +644,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmDuplicateOperand) {
   })";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK:       [[P0:%[^ ]+]] = f32[200,100]{1,0} parameter(0)
     ; CHECK:       [[S0:%[^ ]+]] = f32[100,100]{1,0} slice([[P0]]), slice={[0:100], [0:100]}
     ; CHECK-NOT:   slice
@@ -654,7 +654,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmDuplicateOperand) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = (f32[100,100]{1,0}, s8[80000]{0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -701,7 +701,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmReverseOperandOrder) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[0:1], [0:8], [0:8]}
@@ -716,7 +716,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmReverseOperandOrder) {
     ; CHECK-DAG:   [[A0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[A1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion([[A0]], [[A1]])
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -763,7 +763,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmReverseOperandOrder2) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[1:2], [0:8], [0:8]}
@@ -778,7 +778,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmReverseOperandOrder2) {
     ; CHECK-DAG:   [[A0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(1)
     ; CHECK-DAG:   [[A1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion([[A0]], [[A1]])
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -825,7 +825,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandAliasingOutput) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P2:%[^ ]+]] = f32[100,100]{1,0} parameter(2)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f32[100,100]{1,0} parameter(1)
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f32[200,100]{1,0} parameter(0)
@@ -841,7 +841,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandAliasingOutput) {
     ; CHECK:       [[CONCAT:%[^ ]+]] = f32[200,100]{1,0} concatenate([[GTE0]], [[GTE1]]), dimensions={0}
     ; CHECK:       [[S:%[^ ]+]] = f32[100,100]{1,0} slice([[CONCAT]]), slice={[99:199], [0:100]}
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = (f32[100,100]{1,0}, s8[120000]{0}) fusion([[CONCAT]], [[GTE0]], [[S]])
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -886,7 +886,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandsFromSameSlice) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f16[1,8,8]{2,1,0} slice([[P0]]), slice={[0:1], [0:8], [0:8]}
     ; CHECK-DAG:   [[B0:%[^ ]+]] = f16[8,8]{1,0} bitcast([[S0]])
@@ -898,7 +898,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleGemmOperandsFromSameSlice) {
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK-DAG:   [[A0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion([[A0]])
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -948,7 +948,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleCustomCall) {
                                         computation.proto(), hlo_config));
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK:       [[P0:%[^ ]+]] = f32[256]{0} parameter(0)
     ; CHECK:       [[S0:%[^ ]+]] = f32[128]{0} slice([[P0]]), slice={[0:128]}
     ; CHECK:       ROOT [[CC:%[^ ]+]] = f32[128]{0} custom-call([[S0]]),
@@ -960,7 +960,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleCustomCall) {
     ; CHECK:       [[C0:%[^ ]+]] = f32[] constant(42)
     ; CHECK:       [[BC:%[^ ]+]] = f32[256]{0} broadcast([[C0]])
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f32[128]{0} fusion([[BC]])
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -1002,7 +1002,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleCustomCallLegacy) {
   // TF_CHECK_OK(hlo->set_schedule(std::move(schedule)));
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK:       [[P0:%[^ ]+]] = f32[256]{0} parameter(0)
     ; CHECK:       [[S0:%[^ ]+]] = f32[128]{0} slice([[P0]]), slice={[0:128]}
     ; CHECK:       ROOT [[CC:%[^ ]+]] = f32[128]{0} custom-call([[S0]]),
@@ -1013,7 +1013,7 @@ TEST_F(DynamicSliceFusionRewriterTest, SimpleCustomCallLegacy) {
     ; CHECK:       [[C0:%[^ ]+]] = f32[] constant(42)
     ; CHECK:       [[BC:%[^ ]+]] = f32[256]{0} broadcast([[C0]])
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f32[128]{0} fusion([[BC]])
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -1062,7 +1062,7 @@ TEST_F(DynamicSliceFusionRewriterTest, TupleSliceCustomCallLegacy) {
   // TF_CHECK_OK(hlo->set_schedule(std::move(schedule)));
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f32[8,8]{1,0} parameter(0)
     ; CHECK-DAG:   [[S0:%[^ ]+]] = f32[4,8]{1,0} slice([[P0]]), slice={[0:4], [0:8]}
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f32[256]{0} parameter(1)
@@ -1074,7 +1074,7 @@ TEST_F(DynamicSliceFusionRewriterTest, TupleSliceCustomCallLegacy) {
 
     ; CHECK:     ENTRY %{{.*}} {
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f32[128]{0} fusion(
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -1134,7 +1134,7 @@ TEST_F(DynamicSliceFusionRewriterTest, TupledOutputCustomCallLegacy) {
   // TF_CHECK_OK(hlo->set_schedule(std::move(schedule)));
 
   const char* expected = R"(
-    ; CHECK:     %address-computation {{.*}} {
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P2:%[^ ]+]] = (f32[1024]{0}, f32[8]{0}) parameter(2)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f32[256]{0} parameter(1)
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f32[8,8]{1,0} parameter(0)
@@ -1154,7 +1154,7 @@ TEST_F(DynamicSliceFusionRewriterTest, TupledOutputCustomCallLegacy) {
 
     ; CHECK:     ENTRY %{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = (f32[8]{0}, (f32[128]{0}, f32[256]{0}), f32[1024]{0}, f32[4,8]{1,0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"address_computation","kernel_index":0}
@@ -1236,7 +1236,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemm) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     address-computation {{.*}} {
+    ; CHECK:     dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(3)
     ; CHECK-DAG:   [[C1:%[^ ]+]] = s32[] parameter(1)
@@ -1251,7 +1251,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemm) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1300,7 +1300,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemmWithWorkspace) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     address-computation {{.*}} {
+    ; CHECK:     dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(3)
     ; CHECK-DAG:   [[C1:%[^ ]+]] = s32[] parameter(1)
@@ -1320,7 +1320,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemmWithWorkspace) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = (f16[8,8]{1,0}, s8[256]{0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1370,7 +1370,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemmWorkspaceIgnored) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     address-computation {{.*}} {
+    ; CHECK:     dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(3)
     ; CHECK-DAG:   [[C1:%[^ ]+]] = s32[] parameter(1)
@@ -1389,7 +1389,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemmWorkspaceIgnored) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = (f16[8,8]{1,0}, s8[256]{0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1440,7 +1440,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemmNotRoot) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     address-computation {{.*}} {
+    ; CHECK:     dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(3)
     ; CHECK-DAG:   [[C1:%[^ ]+]] = s32[] parameter(1)
@@ -1455,7 +1455,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DynamicSimpleGemmNotRoot) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = f16[8,8]{1,0} fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1519,7 +1519,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemm) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       ROOT [[FUSION:%[^ ]+]] = f16[4,8,8]{2,1,0} fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1572,7 +1572,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmNotRoot) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     address-computation {{.*}} {
+    ; CHECK:     dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(3)
     ; CHECK-DAG:   [[P2:%[^ ]+]] = f16[4,8,8]{2,1,0} parameter(4)
@@ -1590,7 +1590,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmNotRoot) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = f16[4,8,8]{2,1,0} fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1647,7 +1647,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmWithWorkspace) {
   )";
 
   const char* expected = R"(
-    ; CHECK:     address-computation {{.*}} {
+    ; CHECK:     dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[2,8,8]{2,1,0} parameter(3)
     ; CHECK-DAG:   [[P2:%[^ ]+]] = f16[4,8,8]{2,1,0} parameter(4)
@@ -1669,7 +1669,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmWithWorkspace) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = (f16[4,8,8]{2,1,0}, s8[256]{0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1721,7 +1721,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmWorkspaceIgnored) {
     })";
 
   const char* expected = R"(
-    ; CHECK:     address-computation {{.*}} {
+    ; CHECK:     dynamic-slice-fusion{{.*}} {
     ; CHECK-DAG:   [[P0:%[^ ]+]] = f16[8,8]{1,0} parameter(0)
     ; CHECK-DAG:   [[P1:%[^ ]+]] = f16[8,8]{1,0} parameter(1)
     ; CHECK-DAG:   [[P2:%[^ ]+]] = f16[4,8,8]{2,1,0} parameter(2)
@@ -1739,7 +1739,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmWorkspaceIgnored) {
 
     ; CHECK:     ENTRY %main{{.*}} {
     ; CHECK:       [[FUSION:%[^ ]+]] = (f16[4,8,8]{2,1,0}, s8[256]{0}) fusion
-    ; CHECK:         kind=kCustom, calls=%address-computation,
+    ; CHECK:         kind=kCustom, calls=%dynamic-slice-fusion,
     ; CHECK:         backend_config={
     ; CHECK:           "kind":"__custom_fusion",
     ; CHECK:           "custom_fusion_config":{"name":"dynamic_address_computation","kernel_index":0}
@@ -1773,13 +1773,13 @@ TEST_F(DynamicSliceFusionRewriterTest, ReduceScatterDUSConstantOffset) {
   )";
 
   const char* expected = R"(
-  // CHECK: %address-computation{{.+}} {
+  // CHECK: %dynamic-slice-fusion{{.+}} {
   // CHECK:   %[[RS:.+]] = f16[64,128]{1,0} reduce-scatter({{.+}})
   // CHECK:   ROOT %{{.+}} = f16[128,128]{1,0} dynamic-update-slice(%{{.+}}, %[[RS]], %{{.+}}, %{{.+}})
   // CHECK: }
   // CHECK: ENTRY {{.+}} {
   // CHECK-NOT: reduce-scatter
-  // CHECK:   ROOT %{{.+}} = {{.+}} fusion(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}), kind=kCustom, calls=%address-computation, {{.+}}"name":"dynamic_address_computation"
+  // CHECK:   ROOT %{{.+}} = {{.+}} fusion(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}), kind=kCustom, calls=%dynamic-slice-fusion, {{.+}}"name":"dynamic_address_computation"
   // CHECK: }
   )";
   RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"), expected);
@@ -1856,13 +1856,13 @@ TEST_F(DynamicSliceFusionRewriterTest, ReduceScatterDUSLoopIterationOffset) {
     ROOT tuple.54 = (f32[128,128]{1,0}, f32[128,128,128]{2,1,0}) tuple(get-tuple-element.50, get-tuple-element.51)
   })";
   const char* expected = R"(
-  // CHECK: %address-computation{{.*}}{
+  // CHECK: %dynamic-slice-fusion{{.*}}{
   // CHECK:   {{.+}} = {{.*}}reduce-scatter({{.+}})
   // CHECK:   {{.+}} = {{.*}}dynamic-update-slice({{.+}})
   // CHECK: }
   // CHECK: Body{{.+}}{
   // CHECK-NOT: {{.+}} = {{.*}}reduce-scatter({{.+}})
-  // CHECK:   {{.+}} = {{.+}}fusion({{.+}}), kind=kCustom, calls=%address-computation{{.*}}"name":"dynamic_address_computation"
+  // CHECK:   {{.+}} = {{.+}}fusion({{.+}}), kind=kCustom, calls=%dynamic-slice-fusion{{.*}}"name":"dynamic_address_computation"
   // CHECK: }
   )";
   RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"), expected);
@@ -1931,7 +1931,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmLoopIteration) {
   // CHECK:   %[[PARAM:.+]] = {{.+}} parameter(0)
   // CHECK:   %[[LOOP_ITER:.+]] = u32[] get-tuple-element(%[[PARAM]]), index=3
   // CHECK:   %[[OFFSET:.+]] = u32[] select({{.+}})
-  // CHECK:   %[[ADDRESS_COMPUTATION:.+]] = {{.+}} fusion({{.+}}, {{.+}}, {{.+}}, %[[OFFSET]], %{{.+}}), kind=kCustom, calls=%address-computation, {{.+}}"name":"dynamic_address_computation"
+  // CHECK:   %[[ADDRESS_COMPUTATION:.+]] = {{.+}} fusion({{.+}}, {{.+}}, {{.+}}, %[[OFFSET]], %{{.+}}), kind=kCustom, calls=%dynamic-slice-fusion, {{.+}}"name":"dynamic_address_computation"
   // CHECK:   ROOT %tuple = {{.+}} tuple(%{{.+}}, %{{.+}}, %[[ADDRESS_COMPUTATION]], %{{.+}})
   // CHECK: }
   // CHECK: ENTRY %test{{.+}}{
@@ -2041,7 +2041,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmLaxScan) {
 )";
   auto device = TestGpuDeviceInfo::RTXA6000DeviceInfo();
   const char* expected = R"(
-  // CHECK: %address-computation{{.*}} {{.+}} {
+  // CHECK: %dynamic-slice-fusion{{.*}} {{.+}} {
   // CHECK:   {{.+}} = {{.+}}dynamic-slice
   // CHECK:   {{.+}} = {{.+}}custom-call
   // CHECK:   {{.+}} = {{.+}}dynamic-update-slice
@@ -2050,7 +2050,7 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmLaxScan) {
   // CHECK:   %[[PARAM:.+]] = {{.+}} parameter(0)
   // CHECK:   %[[LOOP_ITER:.+]] = s32[] get-tuple-element(%[[PARAM]]), index=0
   // CHECK:   %[[OFFSET:.+]] = s32[] select({{.+}})
-  // CHECK:   %[[ADDRESS_COMPUTATION:.+]] = {{.+}} fusion({{.+}}, %[[OFFSET]], %{{.+}}), kind=kCustom, calls=%address-computation{{.+}}"name":"dynamic_address_computation"
+  // CHECK:   %[[ADDRESS_COMPUTATION:.+]] = {{.+}} fusion({{.+}}, %[[OFFSET]], %{{.+}}), kind=kCustom, calls=%dynamic-slice-fusion{{.+}}"name":"dynamic_address_computation"
   // CHECK:   %[[GTE:.+]] = {{.+}} get-tuple-element(%[[ADDRESS_COMPUTATION]]), index=0
   // CHECK:   ROOT %{{.+}} = {{.+}} tuple(%{{.+}}, %[[GTE]], %{{.+}})
   // CHECK: }


### PR DESCRIPTION
At some places, it was still address computation fusion. This patch attempts to clean majority of that.