### PR TITLE
[PTX] Use the correct ptx version (8.5) for CUDA 12.6

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -295,30 +295,6 @@ absl::Status NVPTXTargetModuleLinker(llvm::Module* module,
   return absl::OkStatus();
 }
 
-#ifdef GOOGLE_CUDA
-namespace {
-constexpr int kFallbackPtxVersion = 65;
-
-int DetermineHighestSupportedPtxVersionFromCudaVersion(
-    stream_executor::ToolVersion cuda_version) {
-  if (cuda_version[0] < 11) {
-    // For everything below CUDA 11 we just fall back to PTX 6.5.
-    // We don't support CUDA below 11 anymore.
-    return kFallbackPtxVersion;
-  }
-
-  // Mapping determined from
-  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#release-notes
-  // Examples:
-  // CUDA 11.0 -> PTX 7.0
-  // CUDA 11.1 -> PTX 7.1
-  // CUDA 12.0 -> PTX 8.0
-  // CUDA 12.4 -> PTX 8.4 etc.
-  return (cuda_version[0] - 4) * 10 + cuda_version[1];
-}
-}  // namespace
-#endif
-
 std::unique_ptr<llvm::TargetMachine> NVPTXGetTargetMachine(
     llvm::Triple target_triple, se::CudaComputeCapability compute_capability,
     const DebugOptions& debug_options) {
@@ -338,9 +314,12 @@ std::unique_ptr<llvm::TargetMachine> NVPTXGetTargetMachine(
     return kCompileTimeCudaVersion;
   }();
 
-  auto highest_supported_ptx_version =
-      DetermineHighestSupportedPtxVersionFromCudaVersion(
-          highest_supported_cuda_version);
+  nvptx::Version cuda_version{highest_supported_cuda_version[0],
+                              highest_supported_cuda_version[1]};
+  nvptx::Version ptx_version =
+      nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(cuda_version);
+  int highest_supported_ptx_version =
+      ptx_version.first * 10 + ptx_version.second;
 
   VLOG(1) << "Targeting PTX version: " << highest_supported_ptx_version;
   std::string feature_str =
@@ -708,6 +687,34 @@ absl::StatusOr<std::string> CompileToPtx(
   return ptx;
 }
 
+namespace {
+constexpr nvptx::Version kFallbackPtxVersion{6, 5};
+constexpr nvptx::Version kMaxPtxVersion{8, 5};
+}  // namespace
+
+Version DetermineHighestSupportedPtxVersionFromCudaVersion(
+    Version cuda_version) {
+  if (cuda_version < Version{11, 0}) {
+    // For everything below CUDA 11 we just fall back to PTX 6.5.
+    // We don't support CUDA below 11 anymore.
+    return kFallbackPtxVersion;
+  }
+
+  // Mapping determined from
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#release-notes
+  // Examples:
+  // CUDA 11.0 -> PTX 7.0
+  // CUDA 11.1 -> PTX 7.1
+  // CUDA 12.0 -> PTX 8.0
+  // CUDA 12.4 -> PTX 8.4
+  // This versioning scheme is valid until CUDA 12.6
+  if (cuda_version < Version{12, 6}) {
+    return {cuda_version.first - 4, cuda_version.second};
+  }
+
+  // Return maximum known PTX version.
+  return kMaxPtxVersion;
+}
 }  // namespace nvptx
 
 namespace {

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h
@@ -63,6 +63,12 @@ absl::StatusOr<std::string> CompileToPtx(
     llvm::Module* module, se::GpuComputeCapability gpu_version,
     const DebugOptions& debug_options,
     std::function<void(llvm::TargetMachine*)> configure_target = nullptr);
+
+// Determine PTX version from CUDA version.
+using Version = std::pair<int, int>;
+Version DetermineHighestSupportedPtxVersionFromCudaVersion(
+    Version cuda_version);
+
 }  // namespace nvptx
 
 namespace amdgpu {

--- a/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib_test.cc
@@ -33,6 +33,42 @@ TEST(UtilsTest, TestGetSmName) {
   ASSERT_EQ(nvptx::GetSmName(cc_next), "sm_90");
 }
 
+using VersionPair = std::pair<nvptx::Version, nvptx::Version>;
+using PtxVersionFromCudaVersionTest = ::testing::TestWithParam<VersionPair>;
+
+TEST_P(PtxVersionFromCudaVersionTest, VerifyMapping) {
+  EXPECT_EQ(nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
+                GetParam().first),
+            GetParam().second);
+}
+
+INSTANTIATE_TEST_SUITE_P(VersionTest, PtxVersionFromCudaVersionTest,
+                         ::testing::ValuesIn<VersionPair>({
+                             // CUDA 11
+                             {{11, 0}, {7, 0}},
+                             {{11, 1}, {7, 1}},
+                             {{11, 2}, {7, 2}},
+                             {{11, 3}, {7, 3}},
+                             {{11, 4}, {7, 4}},
+                             {{11, 5}, {7, 5}},
+                             {{11, 6}, {7, 6}},
+                             {{11, 7}, {7, 7}},
+                             {{11, 8}, {7, 8}},
+                             // CUDA 12
+                             {{12, 0}, {8, 0}},
+                             {{12, 1}, {8, 1}},
+                             {{12, 2}, {8, 2}},
+                             {{12, 3}, {8, 3}},
+                             {{12, 4}, {8, 4}},
+                             {{12, 5}, {8, 5}},
+                             {{12, 6}, {8, 5}},
+                         }),
+                         [](::testing::TestParamInfo<VersionPair> data) {
+                           nvptx::Version cuda_version = data.param.first;
+                           return absl::StrCat("cuda", cuda_version.first,
+                                               cuda_version.second);
+                         });
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
For CUDA 12.6, PTX version is 8.5 (simple versioning rule heuristic used previously no longer works):
https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#release-notes

For CUDA 12.6 and above, use the highest known PTX version (8.5).
Without this change, the following error is observed:
'+ptx86' is not a recognized feature for this target (ignoring feature)
See: https://github.com/openxla/xla/issues/16431

This PR also adds a basic test.
