### PR TITLE
Enable the use of ACL operations in an mkl_aarch64 build

### DIFF
--- a/xla/python/xla_compiler.cc
+++ b/xla/python/xla_compiler.cc
@@ -1213,7 +1213,9 @@ void BuildXlaCompilerSubmodule(nb::module_& m) {
                    &DebugOptions::xla_gpu_per_fusion_autotune_cache_dir,
                    [](DebugOptions* self, std::string value) {
                      self->set_xla_gpu_per_fusion_autotune_cache_dir(value);
-                   });
+                   })
+      .def_prop_rw("xla_cpu_use_acl", &DebugOptions::xla_cpu_use_acl,
+                   &DebugOptions::set_xla_cpu_use_acl);
 
   nb::class_<ExecutableBuildOptions>(m, "ExecutableBuildOptions")
       .def(nb::init<>())

--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -321,6 +321,7 @@ class DebugOptions:
   xla_gpu_kernel_cache_file: str
   xla_gpu_enable_llvm_module_compilation_parallelism: bool
   xla_gpu_per_fusion_autotune_cache_dir: str
+  xla_cpu_use_acl: bool
 
 class CompiledMemoryStats:
   generated_code_size_in_bytes: int

--- a/xla/service/cpu/runtime_matmul_acl.cc
+++ b/xla/service/cpu/runtime_matmul_acl.cc
@@ -174,7 +174,7 @@ int32_t MatMulF32(const void* run_options_ptr, float* out, float* lhs,
   acl_obj.out_tensor.allocator()->free();
   if (acl_conf.is_trans_lhs) acl_obj.lhs_acc_tensor.allocator()->free();
   if (acl_conf.is_trans_rhs) acl_obj.rhs_acc_tensor.allocator()->free();
-
+  VLOG(1) << "ACL matmul succeeded";
   return 0;
 }
 

--- a/xla/tsl/mkl/build_defs.bzl
+++ b/xla/tsl/mkl/build_defs.bzl
@@ -35,7 +35,7 @@ def if_mkl(if_true, if_false = []):
       may need it. It may be deleted in future with refactoring.
     """
     return select({
-        "@xla//xla/tsl/mkl:build_with_mkl_aarch64": if_true,
+        # "@xla//xla/tsl/mkl:build_with_mkl_aarch64": if_true,
         "@xla//xla/tsl:linux_x86_64": if_true,
         "@xla//xla/tsl:windows": if_true,
         "//conditions:default": if_false,


### PR DESCRIPTION
1. Enables the `xla_cpu_use_acl` option when built with config: `mkl_aarch64` 
Without this change, the following line evaluates to false everytime
https://github.com/openxla/xla/blob/9d8668f0eb7773905d4047692f481e277dd5ba09/xla/service/cpu/dot_op_emitter.cc#L770

2. This PR also enables a VLOG for a successful ACL matmul operation.
Tested by using `TF_CPP_MAX_VLOG_LEVEL=2 TF_CPP_MIN_LOG_LEVEL=0` 