### PR TITLE
[ROCm] Fix transpose related tests which breaks due to 6fabf59

### DIFF
--- a/xla/service/gpu/tests/gpu_fusion_test.cc
+++ b/xla/service/gpu/tests/gpu_fusion_test.cc
@@ -127,7 +127,7 @@ ENTRY main {
 // CHECK-NEXT:   [[s_1_1:%[^ ]+]] = f32[16,32]{1,0} sqrt([[param_0_1_0]])
 // CHECK-NEXT:   ROOT [[c_1_2:%[^ ]+]] = f32[32,16]{1,0} transpose([[s_1_1]]), dimensions={1,0}
 // CHECK-NEXT: }
-// CHECK: ROOT [[fusion_0:%[^ ]+]] = f32[32,16]{1,0} fusion([[p_1:%[^ ]+]]), kind=kInput, calls=[[fused_computation_2:%[^ ]+]]
+// CHECK: ROOT [[fusion_0:%[^ ]+]] = f32[32,16]{1,0} fusion([[p_1:%[^ ]+]]), kind=kLoop, calls=[[fused_computation_2:%[^ ]+]]
 )");
 }
 

--- a/xla/service/gpu/tests/transpose_emitter_test.cc
+++ b/xla/service/gpu/tests/transpose_emitter_test.cc
@@ -140,11 +140,6 @@ ENTRY main {
 }
   )";
 
-  CompileAndVerifyIr(hlo, MakePlatformSpecificLlvm(R"(
-// CHECK: call void BARRIER()
-  )"),
-                     /*match_optimized_ir=*/true,
-                     /*run_optimization_passes=*/false);
   EXPECT_TRUE(RunAndCompareNoHloPasses(hlo, ErrorSpec{1e-3}));
 }
 
@@ -197,11 +192,6 @@ ENTRY %main (p: f16[16,32]) -> (f32[32,16], f16[32,16]) {
 }
   )";
 
-  CompileAndVerifyIr(hlo, MakePlatformSpecificLlvm(R"(
-// CHECK: call void BARRIER()
-  )"),
-                     /*match_optimized_ir=*/true,
-                     /*run_optimization_passes=*/false);
   EXPECT_TRUE(RunAndCompareNoHloPasses(hlo, ErrorSpec{1e-3}));
 }
 
@@ -223,11 +213,6 @@ ENTRY entry {
 }
   )";
 
-  CompileAndVerifyIr(hlo, MakePlatformSpecificLlvm(R"(
-// CHECK: call void BARRIER()
-  )"),
-                     /*match_optimized_ir=*/true,
-                     /*run_optimization_passes=*/false);
   EXPECT_TRUE(RunAndCompareNoHloPasses(hlo, ErrorSpec{1e-3}));
 }
 


### PR DESCRIPTION
Failure is due to https://github.com/openxla/xla/pull/16336