### PR TITLE
[GPU][NFC] Cleanup handling of determinism flags.

### DIFF
--- a/xla/service/gpu/fusions/dynamic_slice_fusion_test.cc
+++ b/xla/service/gpu/fusions/dynamic_slice_fusion_test.cc
@@ -88,7 +88,7 @@ class DynamicSliceFusionTest : public HloTestBase {
 
   HloModuleConfig GetModuleConfigWithDeterministicOps() {
     DebugOptions debug_options = GetDebugOptionsForTest();
-    debug_options.set_xla_gpu_deterministic_ops(true);
+    debug_options.set_xla_gpu_exclude_nondeterministic_ops(true);
     HloModuleConfig config;
     config.set_debug_options(debug_options);
     return config;

--- a/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
@@ -253,11 +253,8 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     TF_RET_CHECK(output_index ==
                  custom_call->shape().tuple_shapes().size() - 1);
 
-    const DebugOptions &debug_options =
-        custom_call->GetModule()->config().debug_options();
-    bool force_deterministic =
-        debug_options.xla_gpu_deterministic_ops() ||
-        debug_options.xla_gpu_exclude_nondeterministic_ops();
+    const bool force_deterministic =
+        RequireDeterminism(custom_call->GetModule()->config());
     config.set_force_deterministic(force_deterministic);
     TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));
 


### PR DESCRIPTION
dynamic_slice_fusion_test does not need to disable autotuning which set_xla_gpu_deterministic_ops does, therefore should use xla_gpu_exclude_nondeterministic_ops. 