### PR TITLE
Various macOS QOL enchancements

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -698,7 +698,7 @@ build:release_macos_x86 --config=avx_linux
 build:release_macos_x86 --cpu=darwin
 # Target Catalina as the minimum compatible OS version
 build:release_macos_x86 --macos_minimum_os=10.15
-build:release_macos_x86 --action_env MACOSX_DEPLOYMENT_TARGET=10.15
+build:release_macos_x86 --macos_sdk_version=10.15
 
 # Build configs for macOS Arm64
 build:release_macos_arm64 --config=release_macos_base
@@ -706,7 +706,7 @@ build:release_macos_arm64 --cpu=darwin_arm64
 build:release_macos_arm64 --define=tensorflow_mkldnn_contraction_kernel=0
 # Target Moneterey as the minimum compatible OS version
 build:release_macos_arm64 --macos_minimum_os=12.0
-build:release_macos_arm64 --action_env MACOSX_DEPLOYMENT_TARGET=12.0
+build:release_macos_arm64 --macos_sdk_version=12.0
 
 # Base test configs for macOS
 test:release_macos_base --verbose_failures=true --local_test_jobs=HOST_CPUS

--- a/.bazelrc
+++ b/.bazelrc
@@ -686,7 +686,6 @@ build:unsupported_gpu_linux --crosstool_top=@ubuntu20.04-gcc9_manylinux2014-cuda
 build:release_cpu_macos --config=avx_linux
 
 # Base build configs for macOS
-build:release_macos_base --action_env  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 build:release_macos_base --define=no_nccl_support=true --output_filter=^$
 
 # Ensure release_base is set on mac

--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -227,9 +227,14 @@ cc_library(
 
 # PJRT CPU plugin.
 xla_cc_binary(
-    name = "pjrt_c_api_cpu_plugin.so",
+    name = "pjrt_c_api_cpu_plugin",
+    additional_linker_inputs = if_macos([], [":pjrt_c_api_cpu_version_script.lds"]),
     linkopts = if_macos(
-        [],
+        [
+            "-Wl,-exported_symbol,_GetPjrtApi",
+            "-Wl,-install_name,@rpath/pjrt_c_api_cpu_plugin.dylib",
+            "-Wl,-undefined,error",
+        ],
         [
             "-Wl,--version-script,$(location :pjrt_c_api_cpu_version_script.lds)",
             "-Wl,--no-undefined",
@@ -242,10 +247,7 @@ xla_cc_binary(
         "notsan",
     ],
     visibility = ["//visibility:public"],
-    deps = [
-        ":pjrt_c_api_cpu",
-        ":pjrt_c_api_cpu_version_script.lds",
-    ],
+    deps = [":pjrt_c_api_cpu"],
 )
 
 cc_library(
@@ -311,7 +313,8 @@ cc_library(
 
 # PJRT GPU plugin. Can be configured to be built for CUDA or ROCM.
 xla_cc_binary(
-    name = "pjrt_c_api_gpu_plugin.so",
+    name = "pjrt_c_api_gpu_plugin",
+    additional_linker_inputs = [":pjrt_c_api_gpu_version_script.lds"],
     linkopts = [
         "-Wl,--version-script,$(location :pjrt_c_api_gpu_version_script.lds)",
         "-Wl,--no-undefined",
@@ -325,7 +328,6 @@ xla_cc_binary(
     ],
     deps = [
         ":pjrt_c_api_gpu",
-        ":pjrt_c_api_gpu_version_script.lds",
         "//xla/service:gpu_plugin",
     ] + if_cuda_is_configured([
         "//xla/stream_executor:cuda_platform",


### PR DESCRIPTION
This PR adds various small quality of life improvements to macOS builds:
- drop the `.so` suffix for PjRt plugin targets (`.dylib` on macOS)
- add compatibility with Apple Command Line Tools (no need for Xcode anymore)
- only export the `GetPjrtApi` symbol on macOS
- leverage bazel's `cc_binary.additional_linker_inputs` instead of using `deps`

It is probable the `.so` change my break some other builds, but I couldn't find any use in the XLA repo to patch ?