### PR TITLE
[NV] Use FP8 conversion intrinsics, when available

### DIFF
--- a/xla/service/gpu/fusions/mlir/mlir_fusion_emitter.cc
+++ b/xla/service/gpu/fusions/mlir/mlir_fusion_emitter.cc
@@ -307,7 +307,7 @@ MlirFusionEmitterBase::CreateLLVMModule(
   mlir::PassManager pm(&mlir_context);
   AddXlaGpuOpsOptimizationPasses(pm);
   AddLoopTransformationPasses(pm);
-  AddLoweringPasses(pm, device);
+  AddLoweringPasses(pm, device, hlo_module->config().debug_options());
   auto pipeline_status = RunPassPipeline(module.get(), pm, trace.get());
   if (trace) {
     DumpPerModuleProtobufToFile(
@@ -566,7 +566,8 @@ void AddLoopTransformationPasses(mlir::OpPassManager& pm) {
 }
 
 void AddLoweringPasses(mlir::OpPassManager& pm,
-                       const se::DeviceDescription& device) {
+                       const se::DeviceDescription& device,
+                       const DebugOptions& debug_options) {
   bool is_amd = std::holds_alternative<se::RocmComputeCapability>(
       device.gpu_compute_capability());
   pm.addNestedPass<FuncOp>(CreateConvertPureCallOpsPass());
@@ -590,6 +591,14 @@ void AddLoweringPasses(mlir::OpPassManager& pm,
   pm.addPass(mlir::createLoopInvariantCodeMotionPass());
   pm.addPass(mlir::createSymbolDCEPass());
   pm.addPass(mlir::createCSEPass());
+
+  // This pass has to run before `ExpandFloatOpsPass`.
+  auto maybe_convert_fp8 = CreateConvertFloatNvidiaPass(
+      device.cuda_compute_capability(), debug_options.xla_gpu_cuda_data_dir());
+  if (maybe_convert_fp8.has_value()) {
+    pm.addPass(std::move(*maybe_convert_fp8));
+  }
+
   pm.addPass(CreateExpandFloatOpsPass());
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(mlir::createConvertSCFToCFPass());

--- a/xla/service/gpu/fusions/mlir/mlir_fusion_emitter.h
+++ b/xla/service/gpu/fusions/mlir/mlir_fusion_emitter.h
@@ -122,7 +122,8 @@ void AddLoopTransformationPasses(mlir::OpPassManager& pm);
 
 // Adds passes that lower transformed loops to LLVM.
 void AddLoweringPasses(mlir::OpPassManager& pm,
-                       const se::DeviceDescription& device);
+                       const se::DeviceDescription& device,
+                       const DebugOptions& debug_options);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/fusions/transforms/BUILD
+++ b/xla/service/gpu/fusions/transforms/BUILD
@@ -1,4 +1,5 @@
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -48,7 +49,9 @@ cc_library(
         "simplify_arith.cc",
         "unswitch_loops.cc",
         "vectorize_loads_stores.cc",
-    ],
+    ] + if_cuda_is_configured([
+        "convert_float_nvidia.cc",
+    ], no_cuda=["cuda_stub.cc"]),
     hdrs = ["passes.h"],
     deps = [
         ":passes_inc_gen",
@@ -104,5 +107,8 @@ cc_library(
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorToLLVM",
         "@llvm-project//mlir:VectorTransforms",
-    ],
+    ] + if_cuda_is_configured([
+        "//xla/stream_executor:semantic_version",
+        "//xla/stream_executor/cuda:cuda_asm_compiler",
+    ]),
 )

--- a/xla/service/gpu/fusions/transforms/convert_float_nvidia.cc
+++ b/xla/service/gpu/fusions/transforms/convert_float_nvidia.cc
@@ -1,0 +1,258 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "llvm/ADT/APFloat.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "tsl/platform/statusor.h"
+#include "xla/service/gpu/fusions/transforms/passes.h"
+#include "xla/stream_executor/cuda/cuda_asm_compiler.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/semantic_version.h"
+
+namespace xla {
+namespace gpu {
+
+namespace ma = ::mlir::arith;
+namespace ml = ::mlir::LLVM;
+using mlir::Value;
+
+#define GEN_PASS_DEF_CONVERTFLOATNVIDIAPASS
+#include "xla/service/gpu/fusions/transforms/passes.h.inc"
+
+namespace {
+
+int GetSignificandBits(mlir::FloatType ty) {
+  return llvm::APFloat::semanticsPrecision(ty.getFloatSemantics()) - 1;
+}
+
+int GetExponentBias(mlir::FloatType ty) {
+  return 1 - llvm::APFloat::semanticsMinExponent(ty.getFloatSemantics());
+}
+
+struct RewriteTruncFPattern : public mlir::OpRewritePattern<ma::TruncFOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      ma::TruncFOp op, mlir::PatternRewriter& rewriter) const override {
+    using FloatValue = mlir::TypedValue<mlir::FloatType>;
+    auto src = mlir::cast<FloatValue>(op.getOperand());
+    auto dst_ty = mlir::cast<mlir::FloatType>(op.getType());
+    if (!dst_ty.isFloat8E4M3FN() && !dst_ty.isFloat8E5M2()) {
+      return rewriter.notifyMatchFailure(op, "unsupported float conversion");
+    }
+
+    mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    rewriter.replaceOp(op, EmitTruncToF8Intrinsic(src, dst_ty, b));
+    return mlir::success();
+  }
+
+  Value EmitTruncToF8Intrinsic(Value value, mlir::FloatType to_ty,
+                               mlir::ImplicitLocOpBuilder& b) const {
+    assert(to_ty.isFloat8E4M3FN() || to_ty.isFloat8E5M2());
+
+    ml::CallIntrinsicOp cvtOp;
+    if (value.getType() == b.getF16Type()) {
+      // Fast path for truncating F16 type.
+      Value vec =
+          b.create<ml::UndefOp>(ml::getFixedVectorType(value.getType(), 2));
+      vec = b.create<ml::InsertElementOp>(vec, value,
+                                          b.create<ma::ConstantIntOp>(0, 8));
+      auto cvtIntr = to_ty.isFloat8E4M3FN() ? "llvm.nvvm.f16x2.to.e4m3x2.rn"
+                                            : "llvm.nvvm.f16x2.to.e5m2x2.rn";
+      cvtOp = b.create<ml::CallIntrinsicOp>(b.getIntegerType(16), cvtIntr,
+                                            mlir::ValueRange{vec});
+    } else {
+      // Other FP types get converted to F32 first.
+      mlir::FloatType f32_ty = b.getF32Type();
+      if (value.getType().getIntOrFloatBitWidth() < f32_ty.getWidth()) {
+        value = b.create<ma::ExtFOp>(f32_ty, value);
+      } else if (value.getType() != f32_ty) {
+        value = b.create<ma::TruncFOp>(f32_ty, value);
+      }
+      auto cvtIntr = to_ty.isFloat8E4M3FN() ? "llvm.nvvm.ff.to.e4m3x2.rn"
+                                            : "llvm.nvvm.ff.to.e5m2x2.rn";
+      cvtOp = b.create<ml::CallIntrinsicOp>(b.getIntegerType(16), cvtIntr,
+                                            mlir::ValueRange{value, value});
+    }
+    Value res = b.create<ml::TruncOp>(b.getIntegerType(8), cvtOp.getResults());
+
+    // Downcasting to float8 saturates the value (uses "satfinite" modifier).
+    // Handle infinity separately to mitigate the issue.
+    mlir::Type src_int_ty =
+        b.getIntegerType(value.getType().getIntOrFloatBitWidth());
+    return FixInfinityConversionValue(
+        b.create<ma::BitcastOp>(src_int_ty, value),
+        mlir::cast<mlir::FloatType>(value.getType()), res, to_ty, b);
+  }
+
+  // If converting the input value would result in an infinity, return infinity
+  // (with sign copied); otherwise return the conversion result.
+  //
+  // The input values have integer types (source is wider than the destination),
+  // and actual floating point types are passed as extra arguments.
+  static Value FixInfinityConversionValue(Value src, mlir::FloatType src_type,
+                                          Value dst, mlir::FloatType dst_type,
+                                          mlir::ImplicitLocOpBuilder& b) {
+    // Extract and discard sign bit.
+    auto make_const = [&](int64_t c) {
+      return b.create<ma::ConstantIntOp>(c, src.getType());
+    };
+    int sign_pos = src.getType().getIntOrFloatBitWidth() - 1;
+    Value sign_bit = b.create<ma::ShRUIOp>(src, make_const(sign_pos));
+    Value input = b.create<ma::AndIOp>(src, make_const((1ull << sign_pos) - 1));
+
+    // Values in the interval that contains all the values above the largest
+    // representable in the destination type, as well as the infinity (source),
+    // result in the infinity (destination).
+    int64_t lower = GetOverflowInputValue(src_type, dst_type);
+    int64_t upper = llvm::APFloat::getInf(src_type.getFloatSemantics())
+                        .bitcastToAPInt()
+                        .getZExtValue();
+    Value is_inf = b.create<ma::AndIOp>(
+        b.create<ma::CmpIOp>(ma::CmpIPredicate::ugt, input, make_const(lower)),
+        b.create<ma::CmpIOp>(ma::CmpIPredicate::ule, input, make_const(upper)));
+
+    // Build signed infinity result value.
+    int64_t inf_val = llvm::APFloat::getInf(dst_type.getFloatSemantics())
+                          .bitcastToAPInt()
+                          .getZExtValue();
+    Value sign_dst =
+        b.create<ma::ShLIOp>(b.create<ml::TruncOp>(dst.getType(), sign_bit),
+                             b.create<ma::ConstantIntOp>(7, dst.getType()));
+    Value inf = b.create<ma::OrIOp>(
+        b.create<ma::ConstantIntOp>(inf_val, dst.getType()), sign_dst);
+
+    // Select result based on the predicate.
+    Value res = b.create<ma::SelectOp>(is_inf, inf, dst);
+    return b.create<ma::BitcastOp>(dst_type, res);
+  }
+
+  // Calculate the minimum raw value (represented as an integer) that would
+  // overflow when converting from `src_type` to `dst_type` (floating point).
+  static int64_t GetOverflowInputValue(mlir::FloatType src_type,
+                                       mlir::FloatType dst_type) {
+    // Get type data from floating point semantics.
+    int src_mantissa = GetSignificandBits(src_type);
+    int src_bias = GetExponentBias(src_type);
+    int dst_mantissa = GetSignificandBits(dst_type);
+    int dst_bias = GetExponentBias(dst_type);
+    assert(src_mantissa > dst_mantissa);
+    assert(src_bias >= dst_bias);
+
+    // Get the largest value, shift to wider type and correct the exponent.
+    int64_t largest = llvm::APFloat::getLargest(dst_type.getFloatSemantics())
+                          .bitcastToAPInt()
+                          .getZExtValue();
+    int64_t threshold = largest << (src_mantissa - dst_mantissa);
+    threshold += int64_t{src_bias - dst_bias} << src_mantissa;
+
+    // Some values above the threshold could still be rounded down, so the
+    // actual threshold that rounds to infinity is higher.
+    threshold |= (1ull << (src_mantissa - dst_mantissa - 1)) - (largest & 1);
+    return threshold;
+  }
+};
+
+struct RewriteExtFPattern : public mlir::OpRewritePattern<ma::ExtFOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      ma::ExtFOp op, mlir::PatternRewriter& rewriter) const override {
+    using FloatValue = mlir::TypedValue<mlir::FloatType>;
+    auto src = mlir::cast<FloatValue>(op.getOperand());
+    auto dst_ty = mlir::cast<mlir::FloatType>(op.getType());
+    if (!src.getType().isFloat8E4M3FN() && !src.getType().isFloat8E5M2()) {
+      return rewriter.notifyMatchFailure(op, "unsupported float conversion");
+    }
+
+    mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+    rewriter.replaceOp(op, EmitExtFromF8Intrinsic(src, dst_ty, b));
+    return mlir::success();
+  }
+
+  Value EmitExtFromF8Intrinsic(Value value, mlir::FloatType to_ty,
+                               mlir::ImplicitLocOpBuilder& b) const {
+    assert(value.getType().isFloat8E4M3FN() || value.getType().isFloat8E5M2());
+
+    // Extend the smaller type to the FP16 type using the intrinsic, and then
+    // to the destination type. In the case of BF16 go through the intermediate
+    // FP32 type (as there's no F2F op for f16->bf16).
+    Value input = b.create<ml::ZExtOp>(
+        b.getIntegerType(16),
+        b.create<ma::BitcastOp>(b.getIntegerType(8), value));
+    auto cvtIntr = value.getType().isFloat8E4M3FN()
+                       ? "llvm.nvvm.e4m3x2.to.f16x2.rn"
+                       : "llvm.nvvm.e5m2x2.to.f16x2.rn";
+    mlir::FloatType f16_ty = b.getF16Type();
+    auto cvtOp = b.create<ml::CallIntrinsicOp>(
+        ml::getFixedVectorType(f16_ty, 2), cvtIntr, mlir::ValueRange{input});
+    Value res = b.create<ml::ExtractElementOp>(
+        cvtOp.getResults(), b.create<ma::ConstantIntOp>(0, 8));
+    if (to_ty.getWidth() > f16_ty.getWidth()) {
+      res = b.create<ma::ExtFOp>(to_ty, res);
+    } else if (to_ty != f16_ty) {
+      if (to_ty == b.getBF16Type()) {
+        res = b.create<ma::ExtFOp>(b.getF32Type(), res);
+      }
+      res = b.create<ma::TruncFOp>(to_ty, res);
+    }
+    return res;
+  }
+};
+
+class ConvertFloatNvidiaPass
+    : public impl::ConvertFloatNvidiaPassBase<ConvertFloatNvidiaPass> {
+ public:
+  using ConvertFloatNvidiaPassBase::ConvertFloatNvidiaPassBase;
+
+  void runOnOperation() override {
+    mlir::RewritePatternSet patterns(&getContext());
+    patterns.add<RewriteTruncFPattern, RewriteExtFPattern>(&getContext());
+    if (mlir::failed(mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                                        std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::optional<std::unique_ptr<mlir::Pass>> CreateConvertFloatNvidiaPass(
+    const se::CudaComputeCapability& cc, const std::string& cuda_data_dir) {
+  absl::StatusOr<se::SemanticVersion> ptx_version =
+      se::GetAsmCompilerVersion(cuda_data_dir);
+  if (ptx_version.ok() &&
+      // FP8 conversion intrinsics are available on sm89 since ptx 8.1
+      ((*ptx_version >= se::SemanticVersion(8, 1, 0) && cc.IsAtLeast(8, 9)) ||
+       // Older ptx versions only support FP8 conversion for sm90
+       (*ptx_version >= se::SemanticVersion(7, 8, 0) && cc.IsAtLeast(9, 0)))) {
+    return std::make_unique<ConvertFloatNvidiaPass>();
+  }
+  return std::nullopt;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/fusions/transforms/cuda_stub.cc
+++ b/xla/service/gpu/fusions/transforms/cuda_stub.cc
@@ -1,0 +1,33 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "mlir/Pass/Pass.h"
+#include "xla/stream_executor/device_description.h"
+
+namespace xla {
+namespace gpu {
+
+std::optional<std::unique_ptr<mlir::Pass>> CreateConvertFloatNvidiaPass(
+    const stream_executor::CudaComputeCapability& cc,
+    const std::string& cuda_data_dir) {
+  return std::nullopt;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/fusions/transforms/passes.h
+++ b/xla/service/gpu/fusions/transforms/passes.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "xla/service/gpu/model/indexing_map.h"
+#include "xla/stream_executor/device_description.h"
 
 namespace xla {
 namespace gpu {
@@ -36,9 +37,11 @@ std::optional<Interval> GetRange(mlir::Value value);
 // determined.
 std::optional<Interval> GetIVRange(mlir::Value iv);
 
+std::optional<std::unique_ptr<mlir::Pass>> CreateConvertFloatNvidiaPass(
+    const se::CudaComputeCapability& cc, const std::string& cuda_data_dir);
+std::unique_ptr<mlir::Pass> CreateConvertPureCallOpsPass();
 std::unique_ptr<mlir::Pass> CreateEraseDeadFunctionsPass();
 std::unique_ptr<mlir::Pass> CreateExpandFloatOpsPass();
-std::unique_ptr<mlir::Pass> CreateConvertPureCallOpsPass();
 std::unique_ptr<mlir::Pass> CreateFlattenTensorsPass();
 std::unique_ptr<mlir::Pass> CreateLowerTensorsPass(
     bool is_amd_gpu = false, const std::string& gpu_arch = "6.0");

--- a/xla/service/gpu/fusions/transforms/passes.td
+++ b/xla/service/gpu/fusions/transforms/passes.td
@@ -154,8 +154,15 @@ def ExpandFloatOpsPass : Pass<"xla-gpu-expand-float-ops", "mlir::ModuleOp"> {
     "mlir::arith::ArithDialect", "mlir::math::MathDialect",
     "mlir::mhlo::MhloDialect"
   ];
+}
 
-  let constructor = "CreateExpandFloatOpsPass()";
+def ConvertFloatNvidiaPass : Pass<"xla-gpu-convert-float-nvidia", "mlir::ModuleOp"> {
+  let summary = "Convert floating point types using NVidia intrinsics.";
+
+  let dependentDialects = [
+    "mlir::LLVM::LLVMDialect",
+    "mlir::arith::ArithDialect",
+  ];
 }
 
 def LowerXlaGpuToScfPass :

--- a/xla/service/gpu/fusions/transforms/tests/convert_float_nvidia.mlir
+++ b/xla/service/gpu/fusions/transforms/tests/convert_float_nvidia.mlir
@@ -1,0 +1,154 @@
+// RUN: mlir_fusions_opt %s -split-input-file -xla-gpu-convert-float-nvidia -canonicalize | FileCheck %s
+
+module {
+  func.func @intr_f16_to_f8(%arg0: f16) -> (f8E4M3FN, f8E5M2) {
+    %a = arith.truncf %arg0 : f16 to f8E4M3FN
+    %b = arith.truncf %arg0 : f16 to f8E5M2
+    return %a, %b : f8E4M3FN, f8E5M2
+  }
+}
+
+// CHECK-LABEL: @intr_f16_to_f8
+// CHECK: llvm.nvvm.f16x2.to.e4m3x2.rn
+// CHECK: llvm.nvvm.f16x2.to.e5m2x2.rn
+
+// -----
+
+module {
+  func.func @intr_bf16_to_f8(%arg0: bf16) -> (f8E4M3FN, f8E5M2) {
+    %a = arith.truncf %arg0 : bf16 to f8E4M3FN
+    %b = arith.truncf %arg0 : bf16 to f8E5M2
+    return %a, %b : f8E4M3FN, f8E5M2
+  }
+}
+
+// CHECK-LABEL: @intr_bf16_to_f8
+// CHECK: arith.extf %{{.+}} : bf16 to f32
+// CHECK: llvm.nvvm.ff.to.e4m3x2.rn
+// CHECK: llvm.nvvm.ff.to.e5m2x2.rn
+
+// -----
+
+module {
+  func.func @intr_f32_to_f8(%arg0: f32) -> (f8E4M3FN, f8E5M2) {
+    %a = arith.truncf %arg0 : f32 to f8E4M3FN
+    %b = arith.truncf %arg0 : f32 to f8E5M2
+    return %a, %b : f8E4M3FN, f8E5M2
+  }
+}
+
+// CHECK-LABEL: @intr_f32_to_f8
+// CHECK: llvm.nvvm.ff.to.e4m3x2.rn
+// CHECK: llvm.nvvm.ff.to.e5m2x2.rn
+
+// -----
+
+module {
+  func.func @intr_f64_to_f8(%arg0: f64) -> (f8E4M3FN, f8E5M2) {
+    %a = arith.truncf %arg0 : f64 to f8E4M3FN
+    %b = arith.truncf %arg0 : f64 to f8E5M2
+    return %a, %b : f8E4M3FN, f8E5M2
+  }
+}
+
+// CHECK-LABEL: @intr_f64_to_f8
+// CHECK: arith.truncf %{{.+}} : f64 to f32
+// CHECK: llvm.nvvm.ff.to.e4m3x2.rn
+// CHECK: llvm.nvvm.ff.to.e5m2x2.rn
+
+// -----
+
+module {
+  func.func @intr_f8_to_f16(%arg0: f8E4M3FN, %arg1: f8E5M2) -> (f16, f16) {
+    %a = arith.extf %arg0 : f8E4M3FN to f16
+    %b = arith.extf %arg1 : f8E5M2 to f16
+    return %a, %b : f16, f16
+  }
+}
+
+// CHECK-LABEL: @intr_f8_to_f16
+// CHECK: llvm.nvvm.e4m3x2.to.f16x2.rn
+// CHECK: llvm.nvvm.e5m2x2.to.f16x2.rn
+
+// -----
+
+module {
+  func.func @intr_f8_to_bf16(%arg0: f8E4M3FN, %arg1: f8E5M2) -> (bf16, bf16) {
+    %a = arith.extf %arg0 : f8E4M3FN to bf16
+    %b = arith.extf %arg1 : f8E5M2 to bf16
+    return %a, %b : bf16, bf16
+  }
+}
+
+// CHECK-LABEL: @intr_f8_to_bf16
+// CHECK: llvm.nvvm.e4m3x2.to.f16x2.rn
+// CHECK: llvm.nvvm.e5m2x2.to.f16x2.rn
+// CHECK: arith.extf %{{.+}} : f16 to f32
+// CHECK: arith.truncf %{{.+}} : f32 to bf16
+
+// -----
+
+module {
+  func.func @intr_f8_to_f32(%arg0: f8E4M3FN, %arg1: f8E5M2) -> (f32, f32) {
+    %a = arith.extf %arg0 : f8E4M3FN to f32
+    %b = arith.extf %arg1 : f8E5M2 to f32
+    return %a, %b : f32, f32
+  }
+}
+
+// CHECK-LABEL: @intr_f8_to_f32
+// CHECK: llvm.nvvm.e4m3x2.to.f16x2.rn
+// CHECK: llvm.nvvm.e5m2x2.to.f16x2.rn
+// CHECK: arith.extf %{{.+}} : f16 to f32
+
+// -----
+
+module {
+  func.func @intr_f8_to_f8(%arg0: f8E4M3FN) -> f8E5M2 {
+    %tmp = arith.extf %arg0 : f8E4M3FN to f16
+    %res = arith.truncf %tmp : f16 to f8E5M2
+    return %res : f8E5M2
+  }
+}
+
+// CHECK-LABEL: @intr_f8_to_f8
+// CHECK: llvm.nvvm.e4m3x2.to.f16x2.rn
+// CHECK: llvm.nvvm.f16x2.to.e5m2x2.rn
+
+// -----
+
+module {
+  func.func @intr_f16_to_f8_fix_infinity(%arg0: f16) -> f8E5M2 {
+    %res = arith.truncf %arg0 : f16 to f8E5M2
+    return %res : f8E5M2
+  }
+}
+
+// CHECK-LABEL: @intr_f16_to_f8_fix_infinity
+// CHECK: %[[PAIR:.*]] = llvm.call_intrinsic "llvm.nvvm.f16x2.to.e5m2x2.rn"
+// CHECK: %[[RES:.*]] = llvm.trunc %[[PAIR]] : i16 to i8
+// CHECK: %[[INT:.*]] = arith.bitcast %arg0 : f16 to i16
+// CHECK: %[[VAL:.*]] = arith.andi %[[INT]], %c32767_i16
+// CHECK: %[[LOWER:.*]] = arith.cmpi ugt, %[[VAL]], %c31615_i16
+// CHECK: %[[UPPER:.*]] = arith.cmpi ule, %[[VAL]], %c31744_i16
+// CHECK: %[[ISINF:.*]] = arith.andi %[[LOWER]], %[[UPPER]]
+// CHECK: arith.select %[[ISINF]], {{.*}}, %[[RES]]
+
+// -----
+
+module {
+  func.func @intr_f32_to_f8_fix_infinity(%arg0: f32) -> f8E4M3FN {
+    %res = arith.truncf %arg0 : f32 to f8E4M3FN
+    return %res : f8E4M3FN
+  }
+}
+
+// CHECK-LABEL: @intr_f32_to_f8_fix_infinity
+// CHECK: %[[PAIR:.*]] = llvm.call_intrinsic "llvm.nvvm.ff.to.e4m3x2.rn"
+// CHECK: %[[RES:.*]] = llvm.trunc %[[PAIR]] : i16 to i8
+// CHECK: %[[INT:.*]] = arith.bitcast %arg0 : f32 to i32
+// CHECK: %[[VAL:.*]] = arith.andi %[[INT]], %c2147483647_i32
+// CHECK: %[[LOWER:.*]] = arith.cmpi ugt, %[[VAL]], %c1139277824_i32
+// CHECK: %[[UPPER:.*]] = arith.cmpi ule, %[[VAL]], %c2139095040_i32
+// CHECK: %[[ISINF:.*]] = arith.andi %[[LOWER]], %[[UPPER]]
+// CHECK: arith.select %[[ISINF]], {{.*}}, %[[RES]]

--- a/xla/service/gpu/fusions/transforms/tests/expand_float_ops.mlir
+++ b/xla/service/gpu/fusions/transforms/tests/expand_float_ops.mlir
@@ -89,9 +89,9 @@ module {
 // -----
 
 module {
-  func.func @double_to_f8(%arg0: f64) -> f8E5M2 {
-    %ret = arith.truncf %arg0 : f64 to f8E5M2
-    return %ret : f8E5M2
+  func.func @double_to_f8(%arg0: f64) -> f8E5M2FNUZ {
+    %ret = arith.truncf %arg0 : f64 to f8E5M2FNUZ
+    return %ret : f8E5M2FNUZ
   }
 }
 

--- a/xla/stream_executor/cuda/cuda_asm_compiler.cc
+++ b/xla/stream_executor/cuda/cuda_asm_compiler.cc
@@ -305,9 +305,11 @@ static absl::StatusOr<std::string> FindPtxAsExecutable(
 
 absl::StatusOr<SemanticVersion> GetAsmCompilerVersion(
     std::string_view preferred_cuda_dir) {
-  TF_ASSIGN_OR_RETURN(std::string ptxas_path,
-                      FindPtxAsExecutable(preferred_cuda_dir));
-  return GetToolVersion(ptxas_path);
+  return ::xla::GetOnce([&]() -> absl::StatusOr<SemanticVersion> {
+    TF_ASSIGN_OR_RETURN(std::string ptxas_path,
+                        FindPtxAsExecutable(preferred_cuda_dir));
+    return GetToolVersion(ptxas_path);
+  });
 }
 
 absl::StatusOr<std::vector<uint8_t>> CompileGpuAsmUsingPtxAs(

--- a/xla/tests/convert_test.cc
+++ b/xla/tests/convert_test.cc
@@ -769,7 +769,9 @@ XLA_TEST_F(ConvertTest, ConvertF16F8e5m2Roundtrip) {
       execution_options_.debug_options().xla_allow_excess_precision();
   execution_options_.mutable_debug_options()->set_xla_allow_excess_precision(
       false);
-  ComputeAndCompareR1<Eigen::half>(&builder, expected_roundtrip, {});
+  // Pass in ErrorSpec, as this causes all NaNs to be treated as equal.
+  ComputeAndCompareR1<Eigen::half>(&builder, expected_roundtrip, {},
+                                   ErrorSpec(0.));
   execution_options_.mutable_debug_options()->set_xla_allow_excess_precision(
       saved);
 }
@@ -929,7 +931,9 @@ XLA_TEST_F(ConvertTest, ConvertF16F8e4m3fnRoundtrip) {
       execution_options_.debug_options().xla_allow_excess_precision();
   execution_options_.mutable_debug_options()->set_xla_allow_excess_precision(
       false);
-  ComputeAndCompareR1<Eigen::half>(&builder, expected_roundtrip, {});
+  // Pass in ErrorSpec, as this causes all NaNs to be treated as equal.
+  ComputeAndCompareR1<Eigen::half>(&builder, expected_roundtrip, {},
+                                   ErrorSpec(0.));
   execution_options_.mutable_debug_options()->set_xla_allow_excess_precision(
       saved);
 }


### PR DESCRIPTION
PTX "cvt" instruction supports converting to/from FP8 types. The NV hardware supports E4M3FN and E5M2 types.
This PR updates the MLIR emitter to use this instruction instead of emitting a long sequence of operations (this matters in compute-bound FP8 kernels).

The NVVM intrinsic allows converting two FP8 values with a single instruction, but as the emitter is elementwise, only one of the inputs is used. This is wasteful, but still much faster than emitting the sequence of instructions.

Before ptx 7.8 (cuda 11.8), the instruction is not supported. Starting with ptx 8.1 (cuda 12.1), the instruction is supported for sm89+. Between those versions, the instruction is supported for sm90+, thas is, if trying to compile on Ada (sm89) with cuda version < 12.1, the ptxas will complain..

Reference:
https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cvt (see "PTX ISA Notes" and "Target ISA Notes").