### PR TITLE
Disable VerifyInstructionNameUnchanged() for GPUs due to crashes

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2550,8 +2550,6 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
     pipeline.AddPass<SanitizeConstantNames>();
   }
 
-  AddHloVerifier(&main_pipeline,
-                 HloVerifierOpts{}.VerifyInstructionNameUnchanged());
   return main_pipeline.Run(module).status();
 }
 


### PR DESCRIPTION
After hlo verifier was enabled to check instruction name changes, we saw applications failed.
We disable this option for GPUs for now until all the fixes are in place.