### PR TITLE
Add flag `xla_gpu_enable_pgle_accuracy_checker` to enable accuracy checker

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -287,6 +287,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_cudnn_gemm_max_plans(5);
 
   opts.set_xla_gpu_enable_triton_gemm_int4(false);
+
+  opts.set_xla_gpu_enable_pgle_accuracy_checker(false);
   return opts;
 }
 

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -487,7 +487,11 @@ absl::StatusOr<ScheduleMetadata> ScheduleGpuModule(
         std::move(aggregator));
     LOG(INFO) << "Found profile, using profile guided latency estimator";
     VLOG(1) << "Profile:\n" << profile->DebugString();
-    pipeline.AddPass<PGLEAccuracyChecker>(*pg_latency_estimator);
+    if (module->config()
+            .debug_options()
+            .xla_gpu_enable_pgle_accuracy_checker()) {
+      pipeline.AddPass<PGLEAccuracyChecker>(*pg_latency_estimator);
+    }
     latency_estimator = std::move(pg_latency_estimator);
   } else if (enable_analytical_latency_estimator) {
     latency_estimator = std::make_unique<AnalyticalLatencyEstimator>(

--- a/xla/service/gpu/gpu_hlo_schedule_test.cc
+++ b/xla/service/gpu/gpu_hlo_schedule_test.cc
@@ -537,6 +537,12 @@ TEST_F(GpuHloScheduleTest, ProfileGuidedCostModelFailsWithIncompleteProfile) {
                                       /*enable_gpu_async_tracker=*/true,
                                       /*fdo_profile=*/kProfile)));
 
+  HloModuleConfig config(module->config());
+  DebugOptions dboptions(config.debug_options());
+  dboptions.set_xla_gpu_enable_pgle_accuracy_checker(true);
+  config.set_debug_options(dboptions);
+  module->set_config(config);
+
   // `dot1` and `ar-start1` are missing from the profile.
   EXPECT_THAT(ScheduleGpuModule(
                   module.get(), /*pointer_size=*/8,

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -49,6 +49,11 @@ class GpuLatencyHidingSchedulerBaseTest : public HloTestBase {
     auto& test_backend = backend();
     const auto& gpu_device_info =
         test_backend.default_stream_executor()->GetDeviceDescription();
+    HloModuleConfig config(module->config());
+    DebugOptions dboptions(config.debug_options());
+    dboptions.set_xla_gpu_enable_pgle_accuracy_checker(true);
+    config.set_debug_options(dboptions);
+    module->set_config(config);
     TF_RETURN_IF_ERROR(
         ScheduleGpuModule(module, /*pointer_size=*/8, gpu_device_info)
             .status());

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -962,7 +962,9 @@ message DebugOptions {
     AUTOTUNE_CACHE_MODE_READ = 2;
   }
 
-  // Next id: 326
+  bool xla_gpu_enable_pgle_accuracy_checker = 326;
+
+  // Next id: 327
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
To enable the strict pgle accuracy checker, set `--xla_gpu_enable_pgle_accuracy_checker` in XLA_FLAGS
