### PR TITLE
[XLA:GPU] Fix dropout state in cuDNN FMHA

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -1230,7 +1230,6 @@ cc_library(
     name = "cudnn_thunk",
     srcs = ["cudnn_thunk.cc"],
     hdrs = ["cudnn_thunk.h"],
-    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":thunk",
         "//xla/service:buffer_assignment",
@@ -1241,7 +1240,5 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:errors",
-    ] + if_cuda_is_configured([
-        "//xla/stream_executor/cuda:cudnn_plugin",
-    ]),
+    ],
 )

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -1235,7 +1235,7 @@ cc_library(
         "//xla/service:buffer_assignment",
         "//xla/service/gpu:kernel_arguments",
         "//xla/stream_executor",
-        "//xla/stream_executor:dnn",
+        "//xla/stream_executor/cuda:cudnn_plugin",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/types:span",

--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -1230,15 +1230,18 @@ cc_library(
     name = "cudnn_thunk",
     srcs = ["cudnn_thunk.cc"],
     hdrs = ["cudnn_thunk.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     deps = [
         ":thunk",
         "//xla/service:buffer_assignment",
         "//xla/service/gpu:kernel_arguments",
         "//xla/stream_executor",
-        "//xla/stream_executor/cuda:cudnn_plugin",
+        "//xla/stream_executor:dnn",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:errors",
-    ],
+    ] + if_cuda_is_configured([
+        "//xla/stream_executor/cuda:cudnn_plugin",
+    ]),
 )

--- a/xla/service/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/service/gpu/runtime/command_buffer_cmd.cc
@@ -1369,7 +1369,8 @@ absl::Status CuDnnCmd::Record(const Thunk::ExecuteParams& execute_params,
   return AddTracedCommandBuffer(
       execute_params, record_params, command_buffer, [&](se::Stream* stream) {
         return graph_->get()->Execute(
-            *stream, absl::Span<se::DeviceMemoryBase>(operands));
+            *stream, absl::Span<se::DeviceMemoryBase>(operands),
+            execute_params.collective_params->local_device_ordinal);
       });
 }
 

--- a/xla/service/gpu/runtime/cudnn_thunk.cc
+++ b/xla/service/gpu/runtime/cudnn_thunk.cc
@@ -23,12 +23,16 @@ limitations under the License.
 #include "absl/base/call_once.h"
 #include "absl/status/status.h"
 #include "absl/types/span.h"
-#include "tsl/platform/errors.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/kernel_arguments.h"
 #include "xla/service/gpu/runtime/thunk.h"
-#include "xla/stream_executor/cuda/cuda_dnn.h"
 #include "xla/stream_executor/device_memory.h"
+#include "xla/stream_executor/dnn.h"
+#include "tsl/platform/errors.h"
+
+#if GOOGLE_CUDA
+#include "xla/stream_executor/cuda/cuda_dnn.h"
+#endif
 
 namespace xla {
 namespace gpu {
@@ -54,11 +58,13 @@ absl::Status CuDnnThunk::Initialize(const InitializeParams& params) {
     std::string().swap(fingerprint_);
     if (result.ok()) {
       graph_->swap(*result);
+#if GOOGLE_CUDA
       if (sdpa_dropout_seed_.has_value()) {
         dynamic_cast<stream_executor::gpu::CudnnGraph*>(graph_->get())
             ->InitDropoutState(params.local_device_count, *sdpa_dropout_seed_,
                                16);
       }
+#endif
     }
     ret = result.status();
   });

--- a/xla/service/gpu/runtime/cudnn_thunk.cc
+++ b/xla/service/gpu/runtime/cudnn_thunk.cc
@@ -30,10 +30,6 @@ limitations under the License.
 #include "xla/stream_executor/dnn.h"
 #include "tsl/platform/errors.h"
 
-#if GOOGLE_CUDA
-#include "xla/stream_executor/cuda/cuda_dnn.h"
-#endif
-
 namespace xla {
 namespace gpu {
 
@@ -58,13 +54,10 @@ absl::Status CuDnnThunk::Initialize(const InitializeParams& params) {
     std::string().swap(fingerprint_);
     if (result.ok()) {
       graph_->swap(*result);
-#if GOOGLE_CUDA
       if (sdpa_dropout_seed_.has_value()) {
-        dynamic_cast<stream_executor::gpu::CudnnGraph*>(graph_->get())
-            ->InitDropoutState(params.local_device_count, *sdpa_dropout_seed_,
-                               16);
+        graph_->get()->InitDropoutState(params.local_device_count,
+                                        *sdpa_dropout_seed_, 16);
       }
-#endif
     }
     ret = result.status();
   });

--- a/xla/service/gpu/runtime/cudnn_thunk.h
+++ b/xla/service/gpu/runtime/cudnn_thunk.h
@@ -35,7 +35,8 @@ namespace gpu {
 class CuDnnThunk : public Thunk {
  public:
   CuDnnThunk(std::string fingerprint, ThunkInfo,
-             absl::Span<const KernelArgument>);
+             absl::Span<const KernelArgument>,
+             std::optional<int64_t> sdpa_dropout_seed = std::nullopt);
   CuDnnThunk(const CuDnnThunk&) = delete;
   CuDnnThunk& operator=(const CuDnnThunk&) = delete;
   ~CuDnnThunk() override = default;
@@ -53,6 +54,8 @@ class CuDnnThunk : public Thunk {
   std::string fingerprint_;
   std::shared_ptr<se::dnn::LazyDnnGraph> graph_;
   std::vector<BufferAllocation::Slice> args_;
+  // Sdpa dropout seed
+  std::optional<int64_t> sdpa_dropout_seed_;
 };
 
 }  // namespace gpu

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -1352,9 +1352,8 @@ class FlashAttentionBMMScalePaddingMaskSoftmaxBMMF8
 class FlashAttentionBMMScaleSoftmaxDropoutBMM
     : public MultiHeadedAttentionTest {
  protected:
-  const std::string  // NOLINT
-  GetModuleFlash_Attention_Training_BMM1_Softmax_Dropout_BMM2_HloString_BF16() {  // NOLINT
-    const std::string hlo_text = R"(
+  static constexpr absl::string_view
+      kModuleFlashAttentionTrainingBMM1SoftmaxDropoutBMM2HloStringBF16 = R"(
     HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})->(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})}, allow_spmd_sharding_propagation_to_parameters={true,true,true,true}, allow_spmd_sharding_propagation_to_output={true,true,true,true}
 
     ENTRY main.21 {
@@ -1380,8 +1379,6 @@ class FlashAttentionBMMScaleSoftmaxDropoutBMM
       ROOT tuple.20 = (bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}) tuple(transpose.11, transpose.17, transpose.18, transpose.19)
     } // main.21
     )";
-    return hlo_text;
-  }
 
   void TestImpl_Flash_Attention_Training_BMM1_Softmax_Dropout_BMM2() {
     if (skip_reason_) GTEST_SKIP() << *skip_reason_;
@@ -1390,9 +1387,6 @@ class FlashAttentionBMMScaleSoftmaxDropoutBMM
       GTEST_SKIP() << "Flash Attention requires cuDNN >= 9.0.0.";
     }
     XlaBuilder builder(TestName());
-    //
-    std::string hlo_string =
-        GetModuleFlash_Attention_Training_BMM1_Softmax_Dropout_BMM2_HloString_BF16();  // NOLINT
 
     auto lhs_bmm1_literal =
         GetInput4DLiteral<bfloat16>({4, 1024, 4, 64}, {3, 2, 1, 0});
@@ -1403,8 +1397,10 @@ class FlashAttentionBMMScaleSoftmaxDropoutBMM
     auto do_literal =
         GetInput4DLiteral<bfloat16>({4, 1024, 4, 64}, {3, 2, 1, 0});
 
-    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                            ParseAndReturnVerifiedModule(hlo_string));
+    TF_ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<HloModule> module,
+        ParseAndReturnVerifiedModule(
+            kModuleFlashAttentionTrainingBMM1SoftmaxDropoutBMM2HloStringBF16));
     ExecuteAndTransfer(std::move(module), {&lhs_bmm1_literal, &rhs_bmm1_literal,
                                            &rhs_bmm2_literal, &do_literal});
   }

--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -1349,6 +1349,67 @@ class FlashAttentionBMMScalePaddingMaskSoftmaxBMMF8
   }
 };
 
+class FlashAttentionBMMScaleSoftmaxDropoutBMM
+    : public MultiHeadedAttentionTest {
+ protected:
+  const std::string  // NOLINT
+  GetModuleFlash_Attention_Training_BMM1_Softmax_Dropout_BMM2_HloString_BF16() {  // NOLINT
+    const std::string hlo_text = R"(
+    HloModule jit__unnamed_wrapped_function_, entry_computation_layout={(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})->(bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0})}, allow_spmd_sharding_propagation_to_parameters={true,true,true,true}, allow_spmd_sharding_propagation_to_output={true,true,true,true}
+
+    ENTRY main.21 {
+      Arg_0.1 = bf16[4,1024,4,64]{3,2,1,0} parameter(0)
+      Arg_1.2 = bf16[4,1024,4,64]{3,2,1,0} parameter(1)
+      Arg_2.3 = bf16[4,1024,4,64]{3,2,1,0} parameter(2)
+      constant.5 = s32[] constant(512)
+      broadcast.6 = s32[4]{0} broadcast(constant.5), dimensions={}
+      custom-call.7 = (bf16[4,4,1024,64]{3,1,2,0}, f32[4,4,1024]{2,1,0}, u8[0]{0}) custom-call(Arg_0.1, Arg_1.2, Arg_2.3, broadcast.6, broadcast.6), custom_call_target="__cudnn$fmhaSoftmaxDropout", operand_layout_constraints={bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, s32[4]{0}, s32[4]{0}}, api_version=API_VERSION_STATUS_RETURNING, backend_config={"operation_queue_id": "0", "wait_on_operation_queues": [], "cudnn_fmha_backend_config": {"algorithm": {"algo_id": "0", "math_type": "TENSOR_OP_MATH", "tuning_knobs": {"17": "1", "24": "0"}, "is_cudnn_frontend": true, "workspace_size": "0"}, "fmha_scale": 1.0, "dropout_rate": 0.5, "intermediate_tensor_shape": {"element_type": "BF16", "dimensions": ["4", "4", "1024", "1024"], "tuple_shapes": [], "layout": {"dim_level_types": [], "dim_unique": [], "dim_ordered": [], "minor_to_major": ["3", "2", "1", "0"], "tiles": [], "element_size_in_bits": "0", "memory_space": "0", "index_primitive_type": "PRIMITIVE_TYPE_INVALID", "pointer_primitive_type": "PRIMITIVE_TYPE_INVALID", "dynamic_shape_metadata_prefix_bytes": "0"}, "is_dynamic_dimension": [false, false, false, false]}, "seed": 42, "is_flash_attention": true, "mask_type": "PADDING", "bmm1_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["3"], "lhs_batch_dimensions": ["0", "2"], "rhs_batch_dimensions": ["0", "2"]}, "bmm2_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}}}
+      get-tuple-element.9 = u8[0]{0} get-tuple-element(custom-call.7), index=2
+      get-tuple-element.10 = f32[4,4,1024]{2,1,0} get-tuple-element(custom-call.7), index=1
+      Arg_3.4 = bf16[4,1024,4,64]{3,2,1,0} parameter(3)
+      get-tuple-element.8 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.7), index=0
+      transpose.11 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.8), dimensions={0,2,1,3}
+      custom-call.12 = (bf16[4,4,1024,64]{3,1,2,0}, bf16[4,4,1024,64]{3,1,2,0}, bf16[4,4,1024,64]{3,1,2,0}, u8[0]{0}) custom-call(Arg_0.1, Arg_1.2, Arg_2.3, get-tuple-element.10, Arg_3.4, /*index=5*/transpose.11, broadcast.6, broadcast.6), custom_call_target="__cudnn$fmhaSoftmaxDropoutBackward", operand_layout_constraints={bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, f32[4,4,1024]{2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, s32[4]{0}, s32[4]{0}}, api_version=API_VERSION_STATUS_RETURNING, backend_config={"operation_queue_id": "0", "wait_on_operation_queues": [], "cudnn_fmha_backend_config": {"algorithm": {"algo_id": "0", "math_type": "TENSOR_OP_MATH", "tuning_knobs": {"17": "1", "24": "0"}, "is_cudnn_frontend": true, "workspace_size": "0"}, "fmha_scale": 1.0, "dropout_rate": 0.5, "intermediate_tensor_shape": {"element_type": "BF16", "dimensions": ["4", "4", "1024", "1024"], "tuple_shapes": [], "layout": {"dim_level_types": [], "dim_unique": [], "dim_ordered": [], "minor_to_major": ["3", "2", "1", "0"], "tiles": [], "element_size_in_bits": "0", "memory_space": "0", "index_primitive_type": "PRIMITIVE_TYPE_INVALID", "pointer_primitive_type": "PRIMITIVE_TYPE_INVALID", "dynamic_shape_metadata_prefix_bytes": "0"}, "is_dynamic_dimension": [false, false, false, false]}, "seed": 42, "is_flash_attention": true, "mask_type": "PADDING", "bmm1_grad_gemm1_dot_dimension_numbers": {"lhs_contracting_dimensions": ["2"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}, "bmm1_grad_gemm2_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}, "bmm2_grad_gemm1_dot_dimension_numbers": {"lhs_contracting_dimensions": ["2"], "rhs_contracting_dimensions": ["1"], "lhs_batch_dimensions": ["0", "1"], "rhs_batch_dimensions": ["0", "2"]}, "bmm2_grad_gemm2_dot_dimension_numbers": {"lhs_contracting_dimensions": ["3"], "rhs_contracting_dimensions": ["3"], "lhs_batch_dimensions": ["0", "2"], "rhs_batch_dimensions": ["0", "2"]}}}
+      get-tuple-element.16 = u8[0]{0} get-tuple-element(custom-call.12), index=3
+      get-tuple-element.13 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.12), index=0
+      transpose.17 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.13), dimensions={0,2,1,3}
+      get-tuple-element.14 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.12), index=1
+      transpose.18 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.14), dimensions={0,2,1,3}
+      get-tuple-element.15 = bf16[4,4,1024,64]{3,1,2,0} get-tuple-element(custom-call.12), index=2
+      transpose.19 = bf16[4,1024,4,64]{3,2,1,0} transpose(get-tuple-element.15), dimensions={0,2,1,3}
+      ROOT tuple.20 = (bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}, bf16[4,1024,4,64]{3,2,1,0}) tuple(transpose.11, transpose.17, transpose.18, transpose.19)
+    } // main.21
+    )";
+    return hlo_text;
+  }
+
+  void TestImpl_Flash_Attention_Training_BMM1_Softmax_Dropout_BMM2() {
+    if (skip_reason_) GTEST_SKIP() << *skip_reason_;
+    if (GetDnnVersionInfoOrDefault(backend().default_stream_executor()) <
+        se::dnn::VersionInfo(9, 0, 0)) {
+      GTEST_SKIP() << "Flash Attention requires cuDNN >= 9.0.0.";
+    }
+    XlaBuilder builder(TestName());
+    //
+    std::string hlo_string =
+        GetModuleFlash_Attention_Training_BMM1_Softmax_Dropout_BMM2_HloString_BF16();  // NOLINT
+
+    auto lhs_bmm1_literal =
+        GetInput4DLiteral<bfloat16>({4, 1024, 4, 64}, {3, 2, 1, 0});
+    auto rhs_bmm1_literal =
+        GetInput4DLiteral<bfloat16>({4, 1024, 4, 64}, {3, 2, 1, 0});
+    auto rhs_bmm2_literal =
+        GetInput4DLiteral<bfloat16>({4, 1024, 4, 64}, {3, 2, 1, 0});
+    auto do_literal =
+        GetInput4DLiteral<bfloat16>({4, 1024, 4, 64}, {3, 2, 1, 0});
+
+    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                            ParseAndReturnVerifiedModule(hlo_string));
+    ExecuteAndTransfer(std::move(module), {&lhs_bmm1_literal, &rhs_bmm1_literal,
+                                           &rhs_bmm2_literal, &do_literal});
+  }
+};
+
 // BMM1 - Scale - CausalMask - Softmax - BMM2
 XLA_TEST_F(FlashAttentionBMMScaleCausalMaskSoftmaxBMM,
            Flash_Attention_BMM1_CausalMask_Softmax_BMM2_BF16) {
@@ -1409,6 +1470,12 @@ XLA_TEST_F(FlashAttentionBMMScaleSlidingWindowMaskSoftmaxBMM,
 XLA_TEST_F(FlashAttentionBMMScalePaddingMaskSoftmaxBMMF8,
            Flash_Attention_Inference_BMM1_NoMask_Softmax_BMM2_F8) {
   TestImpl_Flash_Attention_Inference_BMM1_NoMask_Softmax_BMM2_F8();
+}
+
+// BMM1 - Scale - Softmax - BMM2 fp8
+XLA_TEST_F(FlashAttentionBMMScaleSoftmaxDropoutBMM,
+           Flash_Attention_Training_BMM1_Softmax_Dropout_BMM2) {
+  TestImpl_Flash_Attention_Training_BMM1_Softmax_Dropout_BMM2();
 }
 }  // namespace
 }  // namespace gpu

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5127,7 +5127,6 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     offset_tensor->set_uid(next_uid());
   }
   CudnnGraph cudnnGraph(std::move(graph));
-
   TF_RETURN_IF_ERROR(cudnnGraph.Prepare(
       dnn_support, NumericOptions{/*require_determinism=*/false,
                                   /*allow_tf32=*/true}));
@@ -5500,7 +5499,6 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
   }
 
   CudnnGraph cudnnGraph(std::move(graph));
-
   TF_RETURN_IF_ERROR(
       cudnnGraph.Prepare(dnn_support, NumericOptions{force_deterministic,
                                                      /*allow_tf32=*/true}));

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -5127,6 +5127,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     offset_tensor->set_uid(next_uid());
   }
   CudnnGraph cudnnGraph(std::move(graph));
+
   TF_RETURN_IF_ERROR(cudnnGraph.Prepare(
       dnn_support, NumericOptions{/*require_determinism=*/false,
                                   /*allow_tf32=*/true}));
@@ -5499,6 +5500,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
   }
 
   CudnnGraph cudnnGraph(std::move(graph));
+
   TF_RETURN_IF_ERROR(
       cudnnGraph.Prepare(dnn_support, NumericOptions{force_deterministic,
                                                      /*allow_tf32=*/true}));
@@ -7162,19 +7164,6 @@ CudnnSupport::NormRunnerFromDesc(
 #endif  // CUDNN_VERSION >= 8905
 }
 
-// Returns the offset to increment for the dropout rng.
-// The offset is used by runner to increment by the offset_increment for
-// every call to cudnn fmha kernel to make sure dropout mask is evenly
-// distributed. The recommended offset value by cudnn is max_sequence_length
-// * max_sequence_length / number_of_threads_launched in kernel.
-int64_t GetDropoutRngOffset(std::vector<int64_t>& intermediate_shape) {
-  int64_t kv_seq_len = intermediate_shape[intermediate_shape.size() - 1];
-  int64_t q_seq_len = intermediate_shape[intermediate_shape.size() - 2];
-  int64_t max_seq_len = std::max(q_seq_len, kv_seq_len);
-  int64_t cudnn_mha_num_threads = 256;
-  return max_seq_len * max_seq_len / cudnn_mha_num_threads;
-}
-
 bool CudnnSupport::GetRnnAlgorithms(
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   PreloadCudnnSubLibs(PreloadCudnnType::Rnn);
@@ -8255,7 +8244,8 @@ absl::Status CudnnGraph::Build(dnn::DnnSupport& dnn_support,
 }
 
 absl::Status CudnnGraph::Execute(Stream& stream,
-                                 absl::Span<DeviceMemoryBase> operands) const {
+                                 absl::Span<DeviceMemoryBase> operands,
+                                 int64_t local_device_ordinal) const {
   std::unordered_map<int64_t, void*> tensor_to_ptr_map;
   absl::Span<DeviceMemoryBase> operands_without_workspace = operands;
   DeviceMemoryBase workspace;
@@ -8273,9 +8263,10 @@ absl::Status CudnnGraph::Execute(Stream& stream,
 
   if (dropout_rng_offset_increment_ > 0) {
 #if CUDNN_VERSION >= 8800
+    UpdateDropoutState(local_device_ordinal);
     tensor_to_ptr_map[next_uid()] = (void*)&dropout_rng_seed_;
-    current_dropout_rng_offset_ += dropout_rng_offset_increment_;
-    tensor_to_ptr_map[next_uid()] = (void*)&current_dropout_rng_offset_;
+    tensor_to_ptr_map[next_uid()] =
+        (void*)&current_dropout_rng_offset_[local_device_ordinal];
 #else
     return absl::UnimplementedError(
         "Cudnn dropout offset and seed are only supported with Cudnn >= "

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1236,7 +1236,8 @@ class DnnGraph {
   virtual absl::Status Prepare(DnnSupport&, const NumericOptions&) = 0;
   virtual absl::Status Build(DnnSupport&, std::optional<int64_t> plan_id) = 0;
   virtual absl::Status Execute(Stream& stream,
-                               absl::Span<DeviceMemoryBase> operands) const = 0;
+                               absl::Span<DeviceMemoryBase> operands,
+                               int64_t local_device_ordinal) const = 0;
 };
 
 using LazyDnnGraph = std::unique_ptr<DnnGraph>;

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1238,6 +1238,8 @@ class DnnGraph {
   virtual absl::Status Execute(Stream& stream,
                                absl::Span<DeviceMemoryBase> operands,
                                int64_t local_device_ordinal) const = 0;
+  virtual void InitDropoutState(int64_t local_device_count, int64_t seed,
+                                int64_t increment) = 0;
 };
 
 using LazyDnnGraph = std::unique_ptr<DnnGraph>;


### PR DESCRIPTION
* Fix issue that dropout state is not set after switching to cuDNN thunk in commit: https://github.com/openxla/xla/commit/0aa816e0e4c5c9544237da664eee6ac8e13aabb5.
* Maintain a separate offset copy for each device as thunk can be executed by multiple threads concurrently.
* Add an unit test for the fmha dropout lowering. As it is hard to implement similar philox rng in HLOs, it only guarantees the the fmha custom call with dropout can be lowered correctly.