### PR TITLE
[XLA:GPU] Fix default device mesh for auto sharding

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -595,8 +595,7 @@ absl::Status RunSPMDPasses(
                   hlo_module->config().auto_spmd_partitioning_mesh_shape();
             } else {
               // Use a simple mesh shape if not specified.
-              option.device_mesh_shape = {
-                  gpu_target_config.device_description.core_count(), 1};
+              option.device_mesh_shape = {num_partitions, 1};
             }
             if (!hlo_module->config()
                      .auto_spmd_partitioning_mesh_ids()


### PR DESCRIPTION
When the user does not specify the number of GPUs for auto sharding, XLA defaults to using all available GPUs.

The current implementation uses the number of cores (SMs) on the GPU as the default shard count. For example, on an A100, the sharding algorithm will try to shard into 108 devices, which can be confusing for users.

This patch changes the shard count to the number of cards, which has been tested to work correctly on an 8-card A100 machine.