### PR TITLE
Clarify that sm_90a should only be used on Hopper

### DIFF
--- a/xla/stream_executor/cuda/cuda_asm_compiler.cc
+++ b/xla/stream_executor/cuda/cuda_asm_compiler.cc
@@ -342,8 +342,9 @@ absl::StatusOr<std::vector<uint8_t>> CompileGpuAsmUsingPtxAs(
     tsl::Env::Default()->DeleteFile(cubin_path).IgnoreError();
   };
   tsl::SubProcess ptxas_info_dumper;
-  // If the target is sm_90, hard code it to sm_90a so that all instructions
-  // can be used. We don't need the portability that sm_90 gives.
+  // On Hopper, default to sm_90a so that all instructions can be used. But
+  // only sm_90 is forward compatible, so don't use sm_90a with newer hardware:
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#ptx-compatibility
   std::string extension = (cc_major == 9 && cc_minor == 0) ? "a" : "";
   std::vector<std::string> ptxas_args = {
       ptxas_path,

--- a/xla/stream_executor/cuda/nvjitlink_impl.cc
+++ b/xla/stream_executor/cuda/nvjitlink_impl.cc
@@ -153,8 +153,9 @@ absl::StatusOr<std::vector<uint8_t>> CompileAndLinkUsingLibNvJitLink(
   }
 
   std::vector<std::string> cli_args;
-  // If the target is sm_90, hard code it to sm_90a so that all instructions
-  // can be used. We don't need the portability that sm_90 gives.
+  // On Hopper, default to sm_90a so that all instructions can be used. But
+  // only sm_90 is forward compatible, so don't use sm_90a with newer hardware:
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#ptx-compatibility
   std::string_view extension = (cc_major == 9 && cc_minor == 0) ? "a" : "";
   std::string architecture = absl::StrCat("sm_", cc_major, cc_minor, extension);
   cli_args.emplace_back(absl::StrCat("-arch=", architecture));

--- a/xla/stream_executor/cuda/ptx_compiler_impl.cc
+++ b/xla/stream_executor/cuda/ptx_compiler_impl.cc
@@ -87,9 +87,9 @@ absl::StatusOr<std::vector<uint8_t>> CompileGpuAsmUsingLibNvPtxCompiler(
   absl::Cleanup compiler_cleaner = [&compiler_handle] {
     nvPTXCompilerDestroy(&compiler_handle);
   };
-
-  // If the target is sm_90, hard code it to sm_90a so that all instructions
-  // can be used. We don't need the portability that sm_90 gives.
+  // On Hopper, default to sm_90a so that all instructions can be used. But
+  // only sm_90 is forward compatible, so don't use sm_90a with newer hardware:
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#ptx-compatibility
   std::string_view extension = (cc_major == 9 && cc_minor == 0) ? "a" : "";
   std::string architecture = absl::StrCat("sm_", cc_major, cc_minor, extension);
 


### PR DESCRIPTION
Same as the comment in xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc, from the original change:
https://github.com/openxla/xla/commit/754b68363d48215baf90f32288d411406761af9f