### PR TITLE
[ds-fusion] Avoid dynamic-slice-fusion when reduce-scatter has tuple output

### DIFF
--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
@@ -525,7 +525,8 @@ absl::StatusOr<bool> DynamicSliceFusionRewriter::Run(
         sliced_operand_paths = GetSlicedOperandPaths(instr);
         has_sliced_operand_paths = sliced_operand_paths.size() > 1;
       }
-      if (instr->opcode() == HloOpcode::kReduceScatter ||
+      if ((instr->opcode() == HloOpcode::kReduceScatter &&
+           instr->shape().IsArray()) ||
           IsLegacyCublasMatmul(*instr) || IsCustomCall(instr, platform_name_)) {
         DefUseDataflowPaths sliced_user_paths = GetSlicedUserPaths(instr);
         bool has_sliced_user_paths = absl::c_any_of(


### PR DESCRIPTION
Tuple outputs are not handled while emitting thunks for dynamic-slice fusion. This patch avoids fusing them altogether while the support for multiple outputs is implemented.