### PR TITLE
[cuda] Cache the results of slow cuda_asm_compiler functions

### DIFF
--- a/xla/service/gpu/reduction_utils.cc
+++ b/xla/service/gpu/reduction_utils.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <algorithm>
 #include <array>
-#include <atomic>
 #include <cstdint>
 #include <ostream>
 
@@ -81,48 +80,12 @@ Vector3 PartitionShapeByMiddleDimensions(
 
 int64_t MinThreadsXRowReduction(const HloModuleConfig& hlo_module_config) {
 #ifdef GOOGLE_CUDA
-  // The call to `GetAsmCompilerVersion` is expensive, but the result never
-  // changes during one execution and doesn't really depend on
-  // `hlo_module_config`. To avoid repeated calls, we cache the result in a
-  // static variable.
-  static absl::Mutex mutex(absl::kConstInit);
-  static std::atomic<bool*> use_reduced_thread_count_atomic = nullptr;
-
-  bool* use_reduced_thread_count =
-      use_reduced_thread_count_atomic.load(std::memory_order_acquire);
-
-  if (use_reduced_thread_count == nullptr) {
-    absl::MutexLock lock(&mutex);
-    // We might have raced with another thread, so check again!
-    // Note: We can use relaxed memory ordering here because we hold
-    //       the mutex lock and all updates happen under the same lock.
-    //       When unsure, use release and acquire pairs for stores and loads.
-    use_reduced_thread_count =
-        use_reduced_thread_count_atomic.load(std::memory_order_relaxed);
-
-    if (use_reduced_thread_count == nullptr) {
-      auto ptxas_config =
-          PtxOptsFromDebugOptions(hlo_module_config.debug_options());
-      auto ptxas_version_tuple =
-          se::GetAsmCompilerVersion(ptxas_config.preferred_cuda_dir);
-
-      use_reduced_thread_count = new bool(false);
-
-      // ptxas versions prior to 12.2 have a very rare bug when very high
-      // register spilling occurs with some order of instructions, so use less
-      // threads to reduce register pressure.
-      if (!ptxas_version_tuple.ok() ||
-          ptxas_version_tuple.value() <
-              stream_executor::SemanticVersion{12, 2, 0}) {
-        *use_reduced_thread_count = true;
-      }
-
-      use_reduced_thread_count_atomic.store(use_reduced_thread_count,
-                                            std::memory_order_release);
-    }
-  }
-
-  if (*use_reduced_thread_count) {
+  auto ptxas_version_tuple = se::GetAsmCompilerVersion(
+      hlo_module_config.debug_options().xla_gpu_cuda_data_dir());
+  bool use_reduced_thread_count =
+      !ptxas_version_tuple.ok() ||
+      ptxas_version_tuple.value() < stream_executor::SemanticVersion{12, 2, 0};
+  if (use_reduced_thread_count) {
     return 512;
   }
 #endif  // GOOGLE_CUDA

--- a/xla/util_test.cc
+++ b/xla/util_test.cc
@@ -343,5 +343,18 @@ TEST(UtilTest, MaybeOwningTestShared) {
   EXPECT_EQ(c1.get(), c2.get());
 }
 
+TEST(UtilTest, GetOrInitMappedValue) {
+  int call_count = 0;
+  auto get_or_init = [&](int key) {
+    ++call_count;
+    return key + 1;
+  };
+  EXPECT_EQ(SynchronizedGetOrInitMappedValue(1, get_or_init), 2);
+  EXPECT_EQ(SynchronizedGetOrInitMappedValue(1, get_or_init), 2);
+  EXPECT_EQ(call_count, 1);  // Second invocation doesn't call initialization.
+  EXPECT_EQ(SynchronizedGetOrInitMappedValue(10, get_or_init), 11);
+  EXPECT_EQ(call_count, 2);
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
Following the comments in https://github.com/openxla/xla/pull/16734

Implementation of `GetAsmCompilerVersion` and `GetNvLinkVersion` methods is rather slow (they search for an executable and create a process), making it impractical to repeatedly call them during the compilation without caching.

The previous approach implemented in `reduction_utils.cc` is not quite correct, as the cached value doesn't depend on the HloModule options (as Adrian pointed out in PR#16374 it's a hack).

This PR extracts the common code path to `util.h` as a template function, and updates the call sites. Note that there's a separate cache per each init function.