### PR TITLE
[ds-fusion] Add slicing -> reduce-scatter for dynamic-slice-fusion

### DIFF
--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -413,15 +413,17 @@ cc_library(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "command_buffer_scheduling_test",
     srcs = ["command_buffer_scheduling_test.cc"],
+    backends = ["cpu", "gpu"],
     deps = [
         ":command_buffer_scheduling",
         "//xla/hlo/ir:hlo",
         "//xla/service:hlo_parser",
         "//xla/service/gpu:gpu_device_info_for_tests",
         "//xla/stream_executor:device_description",
+        "//xla/service/gpu:gpu_executable",
         "//xla/tests:filecheck",
         "//xla/tests:hlo_test_base",
         "//xla/tests:verified_hlo_module",

--- a/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/ir/hlo_schedule.h"
 #include "xla/service/gpu/gpu_device_info_for_tests.h"
+#include "xla/service/gpu/gpu_executable.h"
 #include "xla/service/hlo_parser.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/tests/filecheck.h"
@@ -1069,6 +1070,162 @@ TEST_F(CommandBufferSchedulingTest, AsyncFusion) {
                               EXPECT_TRUE(module->has_schedule());
                               TF_CHECK_OK(module->schedule().Verify());
                             });
+}
+
+TEST_F(CommandBufferSchedulingTest, DynamicSliceFusionDynamicSlicing) {
+  if (backend().platform()->Name() == "Host") {
+    GTEST_SKIP() << "GPU support required for this test";
+  }
+  const char* hlo = R"(
+  HloModule jit_slice, replica_count=2
+
+  add {
+    a = s32[] parameter(0)
+    b = s32[] parameter(1)
+    ROOT add = add(a,b)
+  }
+
+  ENTRY main.9 {
+    p0 = s32[2,8,32]{2,1,0} parameter(0)
+    p1 = s32[8,32]{1,0} parameter(1)
+    c0 = s32[] constant(0)
+    c1 = s32[] constant(1)
+    slice = s32[1,8,32]{2,1,0} dynamic-slice(p0, c1, c0, c0), dynamic_slice_sizes={1,8,32}
+    input = s32[8,32]{1,0} reshape(slice)
+    rs = s32[4,32] reduce-scatter(input), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+    ROOT dus = s32[8,32] dynamic-update-slice(p1, rs, c0, c0)
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto m, GetOptimizedModule(hlo));
+
+  HloModuleConfig config(m->config());
+  DebugOptions options(config.debug_options());
+  options.set_xla_gpu_graph_min_graph_size(0);
+
+  auto check = [&m, this](DebugOptions options) -> absl::Status {
+    auto m_clone = m->Clone();
+    HloModuleConfig config(m_clone->config());
+    config.set_debug_options(options);
+    m_clone->set_config(config);
+    TF_ASSIGN_OR_RETURN(auto exec, CreateExecutable(std::move(m_clone), false));
+    auto gpu_exec = std::unique_ptr<GpuExecutable>(
+        static_cast<GpuExecutable*>(exec.release()));
+    TF_RET_CHECK(llvm::any_of(gpu_exec->GetThunk().thunks(),
+                              [](const std::unique_ptr<Thunk>& thunk) {
+                                return thunk->kind() == Thunk::kDynamicSlice;
+                              }));
+    return absl::OkStatus();
+  };
+
+  // With dynamic slicing, no matter what, there should be no command buffer.
+  // Case 1: FUSION on, COLLECTIVES on
+  options.clear_xla_gpu_enable_command_buffer();
+  options.add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
+  options.add_xla_gpu_enable_command_buffer(DebugOptions::COLLECTIVES);
+  TF_ASSERT_OK(check(options));
+
+  // Case 2: FUSION off, COLLECTIVES off
+  options.clear_xla_gpu_enable_command_buffer();
+  TF_ASSERT_OK(check(options));
+
+  // Case 3: FUSION off, COLLECTIVES on
+  options.clear_xla_gpu_enable_command_buffer();
+  options.add_xla_gpu_enable_command_buffer(DebugOptions::COLLECTIVES);
+  TF_ASSERT_OK(check(options));
+
+  // Case 4: FUSION on, COLLECTIVES off
+  options.clear_xla_gpu_enable_command_buffer();
+  options.add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
+  TF_ASSERT_OK(check(options));
+}
+
+TEST_F(CommandBufferSchedulingTest, DynamicSliceFusionStaticSlicing) {
+  if (backend().platform()->Name() == "Host" || backend().device_count() < 2) {
+    GTEST_SKIP() << "Atleast two GPUs required for this test";
+  }
+  const char* hlo = R"(
+  HloModule jit_slice, replica_count=2
+
+  add {
+    a = s32[] parameter(0)
+    b = s32[] parameter(1)
+    ROOT add = add(a,b)
+  }
+
+  ENTRY main.9 {
+    p0 = s32[2,8,32]{2,1,0} parameter(0)
+    p1 = s32[8,32]{1,0} parameter(1)
+    c0 = s32[] constant(0)
+    c1 = s32[] constant(1)
+    slice = s32[1,8,32]{2,1,0} slice(p0), slice={[1:2], [0:8], [0:32]}
+    input = s32[8,32]{1,0} reshape(slice)
+    ROOT rs = s32[4,32] reduce-scatter(input), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto m, GetOptimizedModule(hlo));
+
+  HloModuleConfig config(m->config());
+  DebugOptions options(config.debug_options());
+
+  options.set_xla_gpu_graph_min_graph_size(0);
+
+  auto get_exec = [&m, this](DebugOptions options)
+      -> absl::StatusOr<std::unique_ptr<GpuExecutable>> {
+    auto m_clone = m->Clone();
+    HloModuleConfig config(m_clone->config());
+    config.set_debug_options(options);
+    m_clone->set_config(config);
+    TF_ASSIGN_OR_RETURN(auto exec, CreateExecutable(std::move(m_clone), false));
+    return std::unique_ptr<GpuExecutable>(
+        static_cast<GpuExecutable*>(exec.release()));
+  };
+
+  // FUSION on, COLLECTIVES on -> command buffer
+  {
+    options.clear_xla_gpu_enable_command_buffer();
+    options.add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
+    options.add_xla_gpu_enable_command_buffer(DebugOptions::COLLECTIVES);
+    TF_ASSERT_OK_AND_ASSIGN(auto gpu_exec, get_exec(options));
+    Thunk* child = gpu_exec->GetThunk().thunks()[0].get();
+    ASSERT_EQ(child->kind(), Thunk::kCommandBuffer);
+  }
+
+  // FUSION off, COLLECTIVES off -> no command buffer because collective hero.
+  {
+    options.clear_xla_gpu_enable_command_buffer();
+    TF_ASSERT_OK_AND_ASSIGN(auto gpu_exec, get_exec(options));
+    Thunk* child = gpu_exec->GetThunk().thunks()[0].get();
+    ASSERT_NE(child->kind(), Thunk::kCommandBuffer);
+  }
+
+  // FUSION off, COLLECTIVES on -> command buffer because static slices.
+  {
+    options.clear_xla_gpu_enable_command_buffer();
+    options.add_xla_gpu_enable_command_buffer(DebugOptions::COLLECTIVES);
+    TF_ASSERT_OK_AND_ASSIGN(auto gpu_exec, get_exec(options));
+    Thunk* child = gpu_exec->GetThunk().thunks()[0].get();
+    ASSERT_EQ(child->kind(), Thunk::kCommandBuffer);
+  }
+
+  // FUSION on, COLLECTIVES off -> no command buffer because collective hero.
+  {
+    options.clear_xla_gpu_enable_command_buffer();
+    options.add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
+    TF_ASSERT_OK_AND_ASSIGN(auto gpu_exec, get_exec(options));
+    Thunk* child = gpu_exec->GetThunk().thunks()[0].get();
+    ASSERT_NE(child->kind(), Thunk::kCommandBuffer);
+  }
+
+  // Finally compare with/without command buffer.
+  options.clear_xla_gpu_enable_command_buffer();
+  auto m_ref = m->Clone();
+  config.set_debug_options(options);
+  m_ref->set_config(config);
+
+  config.set_debug_options(GetDebugOptionsForTest());
+  m->set_config(config);
+  ASSERT_TRUE(RunAndCompareTwoModulesReplicated(std::move(m_ref), std::move(m),
+                                                false, true, std::nullopt));
 }
 
 }  // namespace

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
@@ -251,8 +251,12 @@ UseDefDataflowPaths GetSlicedOperandPaths(const HloInstruction* instr) {
   // the matched instructions that we have seen so far.
   InstructionSet processed_instrs;
 
-  const auto& aliasing_pairs =
-      Cast<HloCustomCallInstruction>(instr)->output_to_operand_aliasing();
+  std::vector<std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
+      aliasing_pairs;
+  if (instr->opcode() == HloOpcode::kCustomCall) {
+    aliasing_pairs =
+        Cast<HloCustomCallInstruction>(instr)->output_to_operand_aliasing();
+  }
   absl::flat_hash_set<int64_t> aliased_operands;
   for (const auto& pair : aliasing_pairs) {
     aliased_operands.insert(pair.second.first);
@@ -519,15 +523,11 @@ absl::StatusOr<bool> DynamicSliceFusionRewriter::Run(
   for (HloComputation* computation : module->computations()) {
     if (computation->IsFusionComputation()) continue;
     for (HloInstruction* instr : computation->instructions()) {
-      UseDefDataflowPaths sliced_operand_paths = {instr};
-      bool has_sliced_operand_paths = false;
-      if (IsLegacyCublasMatmul(*instr) || IsCustomCall(instr, platform_name_)) {
-        sliced_operand_paths = GetSlicedOperandPaths(instr);
-        has_sliced_operand_paths = sliced_operand_paths.size() > 1;
-      }
       if ((instr->opcode() == HloOpcode::kReduceScatter &&
            instr->shape().IsArray()) ||
           IsLegacyCublasMatmul(*instr) || IsCustomCall(instr, platform_name_)) {
+        UseDefDataflowPaths sliced_operand_paths = GetSlicedOperandPaths(instr);
+        bool has_sliced_operand_paths = sliced_operand_paths.size() > 1;
         DefUseDataflowPaths sliced_user_paths = GetSlicedUserPaths(instr);
         bool has_sliced_user_paths = absl::c_any_of(
             sliced_user_paths,

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
@@ -2086,4 +2086,62 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSReduceScatterTupleNoTransform) {
                             std::nullopt);
 }
 
+TEST_F(DynamicSliceFusionRewriterTest, ReduceScatterSlice) {
+  const char* hlo = R"(
+  HloModule jit_slice, replica_count=2
+
+  add {
+    a = s32[] parameter(0)
+    b = s32[] parameter(1)
+    ROOT add = add(a,b)
+  }
+
+  ENTRY %main.9 {
+    p0 = s32[2,8,32]{2,1,0} parameter(0)
+    slice = s32[1,8,32]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:32]}
+    bc = s32[8,32]{1,0} bitcast(%slice)
+    ROOT rs = s32[4,32] reduce-scatter(bc), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+  })";
+  const char* expected = R"(
+  // CHECK: dynamic-slice-fusion{{.*}} {
+  // CHECK:   %[[p0:.+]] = {{.+}} parameter(0)
+  // CHECK:   %[[slice:.+]] = {{.+}} slice(%[[p0]]), slice={[1:2], [0:8], [0:32]}
+  // CHECK:   %[[bc:.+]] = {{.+}} bitcast(%[[slice]])
+  // CHECK:   ROOT {{.+}} = {{.+}} reduce-scatter(%[[bc]])
+  // CHECK: }
+  )";
+  RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"), expected);
+}
+
+TEST_F(DynamicSliceFusionRewriterTest, ReduceScatterDynamicSlice) {
+  const char* hlo = R"(
+  HloModule jit_slice, replica_count=2
+
+  add {
+    a = s32[] parameter(0)
+    b = s32[] parameter(1)
+    ROOT add = add(a,b)
+  }
+
+  ENTRY %main.9 {
+    p0 = s32[2,8,32]{2,1,0} parameter(0)
+    c0 = s32[] constant(0)
+    c1 = s32[] constant(1)
+    slice = s32[1,8,32]{2,1,0} dynamic-slice(p0, c1, c0, c0), dynamic_slice_sizes={1,8,32}
+    bc = s32[8,32]{1,0} bitcast(%slice)
+    ROOT rs = s32[4,32] reduce-scatter(bc), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
+  })";
+  const char* expected = R"(
+  // CHECK: add
+  // CHECK: dynamic-slice-fusion{{.*}} {
+  // CHECK:   %[[p0:.+]] = {{.+}} parameter(0)
+  // CHECK:   %[[slice:.+]] = {{.+}} dynamic-slice(%[[p0]], {{.+}}), dynamic_slice_sizes={1,8,32}
+  // CHECK:   %[[bc:.+]] = {{.+}} bitcast(%[[slice]])
+  // CHECK:   ROOT {{.+}} = {{.+}} reduce-scatter(%[[bc]])
+  // CHECK: }
+  // CHECK: ENTRY
+  )";
+  RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"), expected);
+}
+
 }  // namespace xla::gpu


### PR DESCRIPTION
This patch adds support for slicing operations (`dynamic-slice` and `slice`) on operands of reduce-scatter in dynamic-slice-fusion.

When the operands have static slicing, then this fusion gets merged into the command buffer.