### PR TITLE
[TSL] Bump ml_dtypes to version 0.5.0

### DIFF
--- a/third_party/py/ml_dtypes/ml_dtypes.BUILD
+++ b/third_party/py/ml_dtypes/ml_dtypes.BUILD
@@ -38,7 +38,7 @@ pybind_extension(
         "_src/common.h",
         "_src/custom_float.h",
         "_src/dtypes.cc",
-        "_src/int4_numpy.h",
+        "_src/intn_numpy.h",
         "_src/numpy.cc",
         "_src/numpy.h",
         "_src/ufuncs.h",

--- a/third_party/py/ml_dtypes/workspace.bzl
+++ b/third_party/py/ml_dtypes/workspace.bzl
@@ -7,8 +7,8 @@ float8 varieties, and int4.
 load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 
 def repo():
-    ML_DTYPES_COMMIT = "24084d9ed2c3d45bf83b7a9bff833aa185bf9172"
-    ML_DTYPES_SHA256 = "c916a3e6b3d9bdcb476f506fdbbecb6d5e9f21f82f221dfcb42b320b4e85e55a"
+    ML_DTYPES_COMMIT = "f802a63d5ef65e33978eece14464c8b02a7c269d"
+    ML_DTYPES_SHA256 = "f789d68472cf02f548f0881255438708ed734f1ffcd6c64cd3e9ffe23478a9c5"
     tf_http_archive(
         name = "ml_dtypes",
         build_file = "//third_party/py/ml_dtypes:ml_dtypes.BUILD",

--- a/third_party/tsl/third_party/py/ml_dtypes/ml_dtypes.BUILD
+++ b/third_party/tsl/third_party/py/ml_dtypes/ml_dtypes.BUILD
@@ -38,7 +38,7 @@ pybind_extension(
         "_src/common.h",
         "_src/custom_float.h",
         "_src/dtypes.cc",
-        "_src/int4_numpy.h",
+        "_src/intn_numpy.h",
         "_src/numpy.cc",
         "_src/numpy.h",
         "_src/ufuncs.h",

--- a/third_party/tsl/third_party/py/ml_dtypes/workspace.bzl
+++ b/third_party/tsl/third_party/py/ml_dtypes/workspace.bzl
@@ -7,8 +7,8 @@ float8 varieties, and int4.
 load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 
 def repo():
-    ML_DTYPES_COMMIT = "24084d9ed2c3d45bf83b7a9bff833aa185bf9172"
-    ML_DTYPES_SHA256 = "c916a3e6b3d9bdcb476f506fdbbecb6d5e9f21f82f221dfcb42b320b4e85e55a"
+    ML_DTYPES_COMMIT = "f802a63d5ef65e33978eece14464c8b02a7c269d"
+    ML_DTYPES_SHA256 = "f789d68472cf02f548f0881255438708ed734f1ffcd6c64cd3e9ffe23478a9c5"
     tf_http_archive(
         name = "ml_dtypes",
         build_file = "//third_party/py/ml_dtypes:ml_dtypes.BUILD",


### PR DESCRIPTION
### ml_dtypes 0.5.0. updates:

- Added new 8-bit float types following IEEE 754 convention: ml_dtypes.float8_e4m3, ml_dtypes.float8_e3m4
- Added the 8-bit floating point type ml_dtypes.float8_e8m0fnu, which is the OpenCompute MX scale format.
- Added new 4-bit and 6-bit float types: ml_dtypes.float4_e2m1fn, ml_dtypes.float6_e2m3fn and ml_dtypes.float6_e3m2fn.
- Fix outputs of float divmod and floor_divide when denominator is zero.

[ml_dtypes/releases](https://github.com/jax-ml/ml_dtypes/releases)

### Related PRs
- ml_dtypes PR https://github.com/jax-ml/ml_dtypes/pull/161 Add float8_e4m3 (Merged)
- XLA PR https://github.com/openxla/xla/pull/16585 (In Review)