### PR TITLE
Code dedup in execution_trace_utils LiteralToValue

### DIFF
--- a/xla/mlir/tools/mlir_replay/public/execution_trace_utils.cc
+++ b/xla/mlir/tools/mlir_replay/public/execution_trace_utils.cc
@@ -43,6 +43,7 @@ limitations under the License.
 #include "xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.h"
 #include "xla/mlir/tools/mlir_replay/public/execution_trace.pb.h"
 #include "tsl/platform/statusor.h"
+#include "xla/primitive_util.h"
 
 namespace mlir {
 namespace interpreter {
@@ -251,7 +252,13 @@ absl::StatusOr<InterpreterValue> LiteralToValue(const xla::Literal& literal) {
   }
 
   if (literal.shape().IsArray()) {
-    switch (literal.shape().element_type()) {
+    auto type = literal.shape().element_type();
+    if (xla::primitive_util::IsF8Type(type)) {
+      return absl::UnimplementedError(
+          absl::StrCat(xla::primitive_util::LowercasePrimitiveTypeName(type),
+                       " not implemented"));
+    }
+    switch (type) {
       case xla::PRED:
         return {{ArrayLiteralToTensor<bool>(literal)}};
       case xla::S8:
@@ -278,16 +285,6 @@ absl::StatusOr<InterpreterValue> LiteralToValue(const xla::Literal& literal) {
         return absl::UnimplementedError("BF16 not implemented");
       case xla::F64:
         return {{ArrayLiteralToTensor<double>(literal)}};
-      case xla::F8E5M2:
-        return absl::UnimplementedError("F8E5M2 not implemented");
-      case xla::F8E4M3FN:
-        return absl::UnimplementedError("F8E4M3FN not implemented");
-      case xla::F8E4M3B11FNUZ:
-        return absl::UnimplementedError("F8E4M3B11FNUZ not implemented");
-      case xla::F8E5M2FNUZ:
-        return absl::UnimplementedError("F8E5M2FNUZ not implemented");
-      case xla::F8E4M3FNUZ:
-        return absl::UnimplementedError("F8E4M3FNUZ not implemented");
       case xla::C64:
         return {{ArrayLiteralToTensor<std::complex<float>>(literal)}};
       case xla::C128:


### PR DESCRIPTION
Code dedup in execution_trace_utils LiteralToValue

### Issue descr:
To avoid having to modify this every time a new FP8 type is added, remove all these FP8 cases and check if IsF8Type(literal.shape().element_type() before the switch statement.

