### PR TITLE
[NVIDIA GPU] Optimize collective matmul loops when contracting dim is sharded

### DIFF
--- a/xla/service/gpu/transforms/windowed_einsum_handler.cc
+++ b/xla/service/gpu/transforms/windowed_einsum_handler.cc
@@ -467,6 +467,24 @@ bool ShouldAddToChain(const HloInstruction* inst) {
       return false;
   }
 }
+
+HloComputation* MakeSumComputation(PrimitiveType type, HloModule* module) {
+  HloComputation::Builder sum_b("add");
+  auto x = sum_b.AddInstruction(HloInstruction::CreateParameter(
+      /*parameter_number=*/0, ShapeUtil::MakeShape(type, {}), "x"));
+  auto y = sum_b.AddInstruction(HloInstruction::CreateParameter(
+      /*parameter_number=*/1, ShapeUtil::MakeShape(type, {}), "y"));
+  if (type == PRED) {
+    sum_b.AddInstruction(HloInstruction::CreateBinary(
+        ShapeUtil::MakeShape(type, {}), HloOpcode::kOr, x, y));
+  } else {
+    sum_b.AddInstruction(HloInstruction::CreateBinary(
+        ShapeUtil::MakeShape(type, {}), HloOpcode::kAdd, x, y));
+  }
+  HloComputation* reduction = module->AddEmbeddedComputation(sum_b.Build());
+  return reduction;
+}
+
 absl::Status PostProcessUnrolledLoop(HloInstruction* loop, int64_t stream_id) {
   HloComputation* while_body = loop->while_body();
   // This is to set force delay for the first collective permute so it can
@@ -477,6 +495,7 @@ absl::Status PostProcessUnrolledLoop(HloInstruction* loop, int64_t stream_id) {
           WindowedEinsumHandler::kWindowedEinsumRsLoopName) == 0
           ? 2
           : 0;
+  std::vector<HloInstruction*> partial_accumulations;
   for (HloInstruction* inst : while_body->MakeInstructionPostOrder()) {
     HloInstruction* matched_cp;
     if (Match(inst,
@@ -491,6 +510,125 @@ absl::Status PostProcessUnrolledLoop(HloInstruction* loop, int64_t stream_id) {
       // Dispatch the dot to additional compute stream.
       TF_RETURN_IF_ERROR(UpdateDotAndConsumerConfig(inst, stream_id));
       ++stream_id;
+    }
+    // If dot's result is accumulated, this means we found a loop with
+    // contracting dim sharded.
+    HloInstruction* partial_dot;
+    if (Match(inst, m::AddAnyOrder(m::Op(),
+                                   m::Dot(&partial_dot, m::Op(), m::Op())))) {
+      partial_accumulations.push_back(partial_dot);
+    }
+  }
+
+  // Transform partial accumulations into a reduction on a contiguous buffer.
+  // Partial accumulations will impact the overlap between dots because the
+  // dot+add pattern will be fused into a single gemm later in gemm rewriter
+  // which adds data dependencies between gemms. Instead we write all
+  // intermediate results into a larger buffer and perform a one-shot reduction.
+  // The high-level transformation is:
+  // shape(x,y) cp   shape(x,y) dot0
+  //          \         /
+  //           \       /
+  //     shape(x,y) add0    shape(x,y) dot1
+  //             \                /
+  //              \              /
+  //             shape(x,y) add1
+  //                     |
+  //        shape(x,y) loop output
+  //
+  // transformed into:
+  // shape(x,y) cp         shape(x,y) dot0    shape(x,y) dot1
+  //    \                     /                   /
+  //     \                   /                   /
+  //     shape(n,x,y) concatenate on first axis, n is the number of partitions
+  //                        |
+  //             shape(n,x,y) loop output
+  //                        |
+  //             shape(x,y) reduction on first axis
+  //
+  // The final reduction is pulled outside of the loop to overlap with other
+  // collectives.
+  if (partial_accumulations.size() > 0 &&
+      while_body->name().find(
+          WindowedEinsumHandler::kWindowedEinsumAgLoopName) !=
+          std::string::npos) {
+    std::vector<HloInstruction*> partials_to_concat;
+
+    // We reshape it to a N+1 dimensioned tensor with left-most dim being 1.
+    Shape shape = partial_accumulations[0]->shape();
+    shape = ShapeUtil::PrependMajorDimension(1, shape);
+
+    for (auto& inst : partial_accumulations) {
+      CHECK(inst->user_count() == 1);
+      HloInstruction* reshaped_partial = while_body->AddInstruction(
+          HloInstruction::CreateReshape(shape, inst));
+      partials_to_concat.push_back(reshaped_partial);
+    }
+    Shape concat_shape = partial_accumulations[0]->shape();
+    concat_shape = ShapeUtil::PrependMajorDimension(
+        partial_accumulations.size(), concat_shape);
+
+    HloInstruction* concat = while_body->AddInstruction(
+        HloInstruction::CreateConcatenate(concat_shape, partials_to_concat, 0));
+
+    HloComputation* comp = loop->parent();
+    HloInstruction* windowed_lhs = loop->mutable_operand(0)->mutable_operand(0);
+    // Add a broadcasted zero of the same type as windowed_lhs. This holds all
+    // the partial accumulations and will be fed to a global reduction after
+    // this windowed einsum loop. We move the reduction outside of the loop so
+    // it can be fused or overlap with other instructions in the main
+    // computation.
+    Literal zero_literal =
+        LiteralUtil::Zero(windowed_lhs->shape().element_type());
+    HloInstruction* zero = comp->AddInstruction(
+        HloInstruction::CreateConstant(std::move(zero_literal)));
+    Shape zero_bcast_shape = ShapeUtil::ChangeElementType(
+        concat_shape, windowed_lhs->shape().element_type());
+    HloInstruction* zero_bcast = MakeBroadcastHlo(zero, {}, zero_bcast_shape);
+    loop->mutable_operand(0)->AppendOperand(zero_bcast);
+    ShapeUtil::AppendShapeToTuple(zero_bcast->shape(),
+                                  loop->mutable_operand(0)->mutable_shape());
+
+    // Update the parameter tuples of while's body and condition
+    // computations.
+    for (HloComputation* while_comp : {while_body, loop->while_condition()}) {
+      while_comp->ReplaceParameter(
+          0, HloInstruction::CreateParameter(
+                 0, loop->mutable_operand(0)->shape(),
+                 while_comp->parameter_instruction(0)->name()));
+    }
+    HloInstruction* root = while_body->root_instruction();
+    std::vector<HloInstruction*> original_operands(root->operands().begin(),
+                                                   root->operands().end());
+    original_operands.push_back(concat);
+    HloInstruction* new_output_tuple = while_body->AddInstruction(
+        HloInstruction::CreateTuple(original_operands));
+    TF_RETURN_IF_ERROR(while_body->ReplaceInstructionWithDifferentShape(
+        root, new_output_tuple));
+
+    // Update the shape of the while loop instruction.
+    *loop->mutable_shape() = loop->operand(0)->shape();
+
+    // The final reduction
+    HloInstruction* concat_result_gte =
+        comp->AddInstruction(HloInstruction::CreateGetTupleElement(
+            loop, (loop->operand(0)->shape().tuple_shapes_size() - 1)));
+    HloInstruction* reduced_result =
+        comp->AddInstruction(HloInstruction::CreateReduce(
+            partial_accumulations[0]->shape(), concat_result_gte, {zero}, {0},
+            MakeSumComputation(shape.element_type(), loop->GetModule())));
+
+    // Replace the original output if present.
+    HloInstruction* original_output_gte;
+    auto it = absl::c_find_if(loop->users(), [&](HloInstruction* instr) {
+      // Index of the original output. It's fixed to be the third element in the
+      // tuple.
+      return instr->tuple_index() == 2;
+    });
+    if (it != loop->users().end()) {
+      original_output_gte = *it;
+      TF_RETURN_IF_ERROR(
+          original_output_gte->ReplaceAllUsesWith(reduced_result));
     }
   }
   return absl::OkStatus();

--- a/xla/service/gpu/transforms/windowed_einsum_handler.cc
+++ b/xla/service/gpu/transforms/windowed_einsum_handler.cc
@@ -474,17 +474,129 @@ HloComputation* MakeSumComputation(PrimitiveType type, HloModule* module) {
       /*parameter_number=*/0, ShapeUtil::MakeShape(type, {}), "x"));
   auto y = sum_b.AddInstruction(HloInstruction::CreateParameter(
       /*parameter_number=*/1, ShapeUtil::MakeShape(type, {}), "y"));
-  if (type == PRED) {
-    sum_b.AddInstruction(HloInstruction::CreateBinary(
-        ShapeUtil::MakeShape(type, {}), HloOpcode::kOr, x, y));
-  } else {
-    sum_b.AddInstruction(HloInstruction::CreateBinary(
-        ShapeUtil::MakeShape(type, {}), HloOpcode::kAdd, x, y));
-  }
+  sum_b.AddInstruction(HloInstruction::CreateBinary(
+      ShapeUtil::MakeShape(type, {}), HloOpcode::kAdd, x, y));
   HloComputation* reduction = module->AddEmbeddedComputation(sum_b.Build());
   return reduction;
 }
 
+// Transform partial accumulations into a reduction on a contiguous buffer.
+// Partial accumulations will impact the overlap between dots because the
+// dot+add pattern will be fused into a single gemm later in gemm rewriter
+// which adds data dependencies between gemms. Instead we write all
+// intermediate results into a larger buffer and perform a one-shot reduction.
+// The high-level transformation is:
+//
+// 'prev_res' is previously partially accumulated result.
+//
+// shape(x,y) prev_res   shape(x,y) dot0
+//          \            /
+//           \         /
+//     shape(x,y) add0    shape(x,y) dot1
+//             \                /
+//              \              /
+//             shape(x,y) add1
+//                     |
+//        shape(x,y) loop output
+//
+// transformed into:
+// shape(x,y) prev_res         shape(x,y) dot0    shape(x,y) dot1
+//    \                        /                   /
+//     \                      /                   /
+//     shape(n,x,y) concatenate on first axis, n is the number of partitions
+//                        |
+//             shape(n,x,y) loop output
+//                        |
+//             shape(x,y) reduction on first axis
+//
+// The final reduction is pulled outside of the loop to overlap with other
+// collectives.
+absl::Status MoveAccumulationOutsideLoop(
+    std::vector<HloInstruction*>& partial_accumulations,
+    HloComputation* while_body, HloInstruction* loop) {
+  // The input of the while loop will be modified and must have no other users.
+  if (!loop || loop->operand(0)->user_count() != 1) {
+    return absl::OkStatus();
+  }
+
+  std::vector<HloInstruction*> partials_to_concat;
+
+  // We reshape it to a N+1 dimensioned tensor with left-most dim being 1.
+  Shape shape = partial_accumulations[0]->shape();
+  shape = ShapeUtil::PrependMajorDimension(1, shape);
+
+  for (auto& inst : partial_accumulations) {
+    HloInstruction* reshaped_partial =
+        while_body->AddInstruction(HloInstruction::CreateReshape(shape, inst));
+    partials_to_concat.push_back(reshaped_partial);
+  }
+  Shape concat_shape = partial_accumulations[0]->shape();
+  concat_shape = ShapeUtil::PrependMajorDimension(partial_accumulations.size(),
+                                                  concat_shape);
+
+  HloInstruction* concat = while_body->AddInstruction(
+      HloInstruction::CreateConcatenate(concat_shape, partials_to_concat, 0));
+
+  HloComputation* comp = loop->parent();
+  HloInstruction* windowed_lhs = loop->mutable_operand(0)->mutable_operand(0);
+  // Add a broadcasted zero of the same type as windowed_lhs. This holds all
+  // the partial accumulations and will be fed to a global reduction after
+  // this windowed einsum loop. We move the reduction outside of the loop so
+  // it can be fused or overlap with other instructions in the main
+  // computation.
+  Literal zero_literal =
+      LiteralUtil::Zero(windowed_lhs->shape().element_type());
+  HloInstruction* zero = comp->AddInstruction(
+      HloInstruction::CreateConstant(std::move(zero_literal)));
+  Shape zero_bcast_shape = ShapeUtil::ChangeElementType(
+      concat_shape, windowed_lhs->shape().element_type());
+  HloInstruction* zero_bcast = MakeBroadcastHlo(zero, {}, zero_bcast_shape);
+  loop->mutable_operand(0)->AppendOperand(zero_bcast);
+  ShapeUtil::AppendShapeToTuple(zero_bcast->shape(),
+                                loop->mutable_operand(0)->mutable_shape());
+
+  // Update the parameter tuples of while's body and condition
+  // computations.
+  for (HloComputation* while_comp : {while_body, loop->while_condition()}) {
+    while_comp->ReplaceParameter(
+        0, HloInstruction::CreateParameter(
+               0, loop->mutable_operand(0)->shape(),
+               while_comp->parameter_instruction(0)->name()));
+  }
+  HloInstruction* root = while_body->root_instruction();
+  std::vector<HloInstruction*> original_operands(root->operands().begin(),
+                                                 root->operands().end());
+  original_operands.push_back(concat);
+  HloInstruction* new_output_tuple = while_body->AddInstruction(
+      HloInstruction::CreateTuple(original_operands));
+  TF_RETURN_IF_ERROR(
+      while_body->ReplaceInstructionWithDifferentShape(root, new_output_tuple));
+
+  // Update the shape of the while loop instruction.
+  *loop->mutable_shape() = loop->operand(0)->shape();
+
+  // The final reduction
+  HloInstruction* concat_result_gte =
+      comp->AddInstruction(HloInstruction::CreateGetTupleElement(
+          loop, (loop->operand(0)->shape().tuple_shapes_size() - 1)));
+  HloInstruction* reduced_result =
+      comp->AddInstruction(HloInstruction::CreateReduce(
+          partial_accumulations[0]->shape(), concat_result_gte, {zero}, {0},
+          MakeSumComputation(shape.element_type(), loop->GetModule())));
+
+  // Replace the original output if present.
+  HloInstruction* original_output_gte;
+  auto it = absl::c_find_if(loop->users(), [&](HloInstruction* instr) {
+    // Index of the original output. It's fixed to be the third element in the
+    // tuple.
+    return instr->tuple_index() == 2;
+  });
+  if (it != loop->users().end()) {
+    original_output_gte = *it;
+    TF_RETURN_IF_ERROR(original_output_gte->ReplaceAllUsesWith(reduced_result));
+  }
+  return absl::OkStatus();
+}
 absl::Status PostProcessUnrolledLoop(HloInstruction* loop, int64_t stream_id) {
   HloComputation* while_body = loop->while_body();
   // This is to set force delay for the first collective permute so it can
@@ -519,117 +631,12 @@ absl::Status PostProcessUnrolledLoop(HloInstruction* loop, int64_t stream_id) {
       partial_accumulations.push_back(partial_dot);
     }
   }
-
-  // Transform partial accumulations into a reduction on a contiguous buffer.
-  // Partial accumulations will impact the overlap between dots because the
-  // dot+add pattern will be fused into a single gemm later in gemm rewriter
-  // which adds data dependencies between gemms. Instead we write all
-  // intermediate results into a larger buffer and perform a one-shot reduction.
-  // The high-level transformation is:
-  // shape(x,y) cp   shape(x,y) dot0
-  //          \         /
-  //           \       /
-  //     shape(x,y) add0    shape(x,y) dot1
-  //             \                /
-  //              \              /
-  //             shape(x,y) add1
-  //                     |
-  //        shape(x,y) loop output
-  //
-  // transformed into:
-  // shape(x,y) cp         shape(x,y) dot0    shape(x,y) dot1
-  //    \                     /                   /
-  //     \                   /                   /
-  //     shape(n,x,y) concatenate on first axis, n is the number of partitions
-  //                        |
-  //             shape(n,x,y) loop output
-  //                        |
-  //             shape(x,y) reduction on first axis
-  //
-  // The final reduction is pulled outside of the loop to overlap with other
-  // collectives.
   if (partial_accumulations.size() > 0 &&
       while_body->name().find(
           WindowedEinsumHandler::kWindowedEinsumAgLoopName) !=
           std::string::npos) {
-    std::vector<HloInstruction*> partials_to_concat;
-
-    // We reshape it to a N+1 dimensioned tensor with left-most dim being 1.
-    Shape shape = partial_accumulations[0]->shape();
-    shape = ShapeUtil::PrependMajorDimension(1, shape);
-
-    for (auto& inst : partial_accumulations) {
-      CHECK(inst->user_count() == 1);
-      HloInstruction* reshaped_partial = while_body->AddInstruction(
-          HloInstruction::CreateReshape(shape, inst));
-      partials_to_concat.push_back(reshaped_partial);
-    }
-    Shape concat_shape = partial_accumulations[0]->shape();
-    concat_shape = ShapeUtil::PrependMajorDimension(
-        partial_accumulations.size(), concat_shape);
-
-    HloInstruction* concat = while_body->AddInstruction(
-        HloInstruction::CreateConcatenate(concat_shape, partials_to_concat, 0));
-
-    HloComputation* comp = loop->parent();
-    HloInstruction* windowed_lhs = loop->mutable_operand(0)->mutable_operand(0);
-    // Add a broadcasted zero of the same type as windowed_lhs. This holds all
-    // the partial accumulations and will be fed to a global reduction after
-    // this windowed einsum loop. We move the reduction outside of the loop so
-    // it can be fused or overlap with other instructions in the main
-    // computation.
-    Literal zero_literal =
-        LiteralUtil::Zero(windowed_lhs->shape().element_type());
-    HloInstruction* zero = comp->AddInstruction(
-        HloInstruction::CreateConstant(std::move(zero_literal)));
-    Shape zero_bcast_shape = ShapeUtil::ChangeElementType(
-        concat_shape, windowed_lhs->shape().element_type());
-    HloInstruction* zero_bcast = MakeBroadcastHlo(zero, {}, zero_bcast_shape);
-    loop->mutable_operand(0)->AppendOperand(zero_bcast);
-    ShapeUtil::AppendShapeToTuple(zero_bcast->shape(),
-                                  loop->mutable_operand(0)->mutable_shape());
-
-    // Update the parameter tuples of while's body and condition
-    // computations.
-    for (HloComputation* while_comp : {while_body, loop->while_condition()}) {
-      while_comp->ReplaceParameter(
-          0, HloInstruction::CreateParameter(
-                 0, loop->mutable_operand(0)->shape(),
-                 while_comp->parameter_instruction(0)->name()));
-    }
-    HloInstruction* root = while_body->root_instruction();
-    std::vector<HloInstruction*> original_operands(root->operands().begin(),
-                                                   root->operands().end());
-    original_operands.push_back(concat);
-    HloInstruction* new_output_tuple = while_body->AddInstruction(
-        HloInstruction::CreateTuple(original_operands));
-    TF_RETURN_IF_ERROR(while_body->ReplaceInstructionWithDifferentShape(
-        root, new_output_tuple));
-
-    // Update the shape of the while loop instruction.
-    *loop->mutable_shape() = loop->operand(0)->shape();
-
-    // The final reduction
-    HloInstruction* concat_result_gte =
-        comp->AddInstruction(HloInstruction::CreateGetTupleElement(
-            loop, (loop->operand(0)->shape().tuple_shapes_size() - 1)));
-    HloInstruction* reduced_result =
-        comp->AddInstruction(HloInstruction::CreateReduce(
-            partial_accumulations[0]->shape(), concat_result_gte, {zero}, {0},
-            MakeSumComputation(shape.element_type(), loop->GetModule())));
-
-    // Replace the original output if present.
-    HloInstruction* original_output_gte;
-    auto it = absl::c_find_if(loop->users(), [&](HloInstruction* instr) {
-      // Index of the original output. It's fixed to be the third element in the
-      // tuple.
-      return instr->tuple_index() == 2;
-    });
-    if (it != loop->users().end()) {
-      original_output_gte = *it;
-      TF_RETURN_IF_ERROR(
-          original_output_gte->ReplaceAllUsesWith(reduced_result));
-    }
+    TF_RETURN_IF_ERROR(
+        MoveAccumulationOutsideLoop(partial_accumulations, while_body, loop));
   }
   return absl::OkStatus();
 }

--- a/xla/service/gpu/transforms/windowed_einsum_handler_test.cc
+++ b/xla/service/gpu/transforms/windowed_einsum_handler_test.cc
@@ -1064,7 +1064,7 @@ ENTRY main {
 TEST_F(WindowedEinsumHandlerTest,
        AgLoopsMultipleConsumersAreChainedWithShardedContratingDim) {
   constexpr absl::string_view kHloString = R"(
-HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(bf16[16,2048,512]{2,1,0}, bf16[4096,6288]{1,0}, bf16[16,2048,6288]{2,1,0})->bf16[4096,6288]{1,0}}, num_partitions=8
+HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(bf16[16,2048,512]{2,1,0}, bf16[4096,6288]{1,0}, bf16[16,2048,6288]{2,1,0})->(bf16[16,2048,6288]{2,1,0}, bf16[4096,6288]{1,0})}, num_partitions=8
 
 windowed_dot_general_body_ag {
   param.195 = (bf16[16,2048,512]{2,1,0}, bf16[4096,6288]{1,0}, bf16[16,2048,6288]{2,1,0}, bf16[16,2048,6288]{2,1,0}, u32[]) parameter(0)
@@ -1114,10 +1114,11 @@ ENTRY main.12_spmd {
   constant.24 = u32[] constant(0)
   tuple.2 = (bf16[16,2048,512]{2,1,0}, bf16[4096,6288]{1,0}, bf16[16,2048,6288]{2,1,0}, bf16[16,2048,6288]{2,1,0}, u32[]) tuple(param.4, param.5, broadcast, broadcast, constant.24)
   while = (bf16[16,2048,512]{2,1,0}, bf16[4096,6288]{1,0}, bf16[16,2048,6288]{2,1,0}, bf16[16,2048,6288]{2,1,0}, u32[]) while(tuple.2), condition=windowed_dot_general_cond_ag, body=windowed_dot_general_body_ag
-  get-tuple-element.13 = bf16[16,2048,6288]{2,1,0} get-tuple-element(while), index=2
+  get-tuple-element.result = bf16[16,2048,6288]{2,1,0} get-tuple-element(while), index=2
   all-gather = bf16[16,2048,4096]{2,1,0} all-gather(param.4), channel_id=1, replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={2}, use_global_device_ids=true
   param.6 = bf16[16,2048,6288]{2,1,0} parameter(2)
-  ROOT dot.7 = bf16[4096,6288]{1,0} dot(all-gather, param.6), lhs_contracting_dims={0,1}, rhs_contracting_dims={0,1}
+  dot.7 = bf16[4096,6288]{1,0} dot(all-gather, param.6), lhs_contracting_dims={0,1}, rhs_contracting_dims={0,1}
+  ROOT tuple.output = (bf16[16,2048,6288]{2,1,0}, bf16[4096,6288]{1,0}) tuple(get-tuple-element.result, dot.7)
 }
 )";
 
@@ -1137,6 +1138,12 @@ ENTRY main.12_spmd {
   EXPECT_EQ(inst->operand(0)->opcode(), HloOpcode::kGetTupleElement);
   EXPECT_EQ(inst->operand(0)->tuple_index(), 5);
   EXPECT_EQ(inst->operand(0)->operand(0), ag_loop);
+
+  EXPECT_EQ(ag_loop->operand(0)->shape().tuple_shapes_size(), 7);
+  // The root instruction's first operand should now be a reduction.
+  EXPECT_EQ(
+      module->entry_computation()->root_instruction()->operand(0)->opcode(),
+      HloOpcode::kReduce);
 }
 
 }  // namespace


### PR DESCRIPTION
When contracting dim is sharded, both LHS and RHS will be sharded and the partial dots' results will be accumulated. However the accumulation is done 1 step at a time which leads to a number of individual add kernels, these add kernels will impact overlap between gemms due to:
1. they each occupy SMs which prevent gemm overlap
2. they might be fused by gemm_rewriter which introduces data dependency between gemms

This pr optimizes it to get rid of partial accumulations, instead all partials will be concatenated into a contiguous buffer and a global reduction is applied on the buffer.