### PR TITLE
Fixes XLA build with numpy>=2.1.0

### DIFF
--- a/xla/tsl/python/lib/core/numpy.h
+++ b/xla/tsl/python/lib/core/numpy.h
@@ -29,6 +29,13 @@ limitations under the License.
 #define NO_IMPORT_ARRAY
 #endif
 
+// Prevent linking error with numpy>=2.1.0
+// error: undefined hidden symbol: _xla_numpy_apiPyArray_RUNTIME_VERSION
+// Without this define, Numpy's API symbols will have hidden symbol visibility,
+// which may break things if Bazel chooses to build a cc_library target into
+// its own .so file. Bazel typically does this for debug builds.
+#define NPY_API_SYMBOL_ATTRIBUTE
+
 // clang-format off
 // Place `<locale>` before <Python.h> to avoid build failure in macOS.
 #include <locale>


### PR DESCRIPTION
When building XLA using the command from dev guide: docs/developer_guide.md
```bash
./configure.py --backend=CPU
bazel build --test_output=all --spawn_strategy=sandboxed //xla/...
```

Using numpy==2.1.0 we can have the following linking error:
```
ERROR: /xla/xla/python/BUILD:1453:11: Linking xla/python/libnb_numpy.so failed: (Exit 1): clang failed: error executing command (from target //xla/python:nb_numpy) /usr/lib/llvm-14/bin/clang @bazel-out/k8-opt/bin/xla/python/libnb_numpy.so-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld.lld: error: undefined hidden symbol: _xla_numpy_api
>>> referenced by nb_numpy.cc
>>>               bazel-out/k8-opt/bin/xla/python/_objs/nb_numpy/nb_numpy.pic.o:(xla::nb_dtype::from_args(nanobind::object const&))
>>> referenced by nb_numpy.cc
>>>               bazel-out/k8-opt/bin/xla/python/_objs/nb_numpy/nb_numpy.pic.o:(xla::nb_numpy_ndarray::nb_numpy_ndarray(xla::nb_dtype, absl::lts_20230802::Span<long const>, std::optional<absl::lts_20230802::Span<long const> >, void const*, nanobind::handle))
>>> referenced by nb_numpy.cc
>>>               bazel-out/k8-opt/bin/xla/python/_objs/nb_numpy/nb_numpy.pic.o:(xla::nb_numpy_ndarray::nb_numpy_ndarray(xla::nb_dtype, absl::lts_20230802::Span<long const>, std::optional<absl::lts_20230802::Span<long const> >, void const*, nanobind::handle))
>>> referenced 4 more times

ld.lld: error: undefined hidden symbol: _xla_numpy_apiPyArray_RUNTIME_VERSION
>>> referenced by nb_numpy.cc
>>>               bazel-out/k8-opt/bin/xla/python/_objs/nb_numpy/nb_numpy.pic.o:(xla::nb_numpy_ndarray::itemsize() const)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Which should be related to https://github.com/numpy/numpy/blob/main/doc/source/release/2.1.0-notes.rst#api-symbols-now-hidden-but-customizable

This PR fixes the build issue