### PR TITLE
Parameterize Float tests in literal_test

### DIFF
--- a/xla/literal_test.cc
+++ b/xla/literal_test.cc
@@ -121,6 +121,16 @@ class LiteralUtilTest : public ::testing::Test {
   Literal literal_r4_2x2x3x3_dim0minor_;
 };
 
+template <typename T>
+class LiteralUtilFloatTest : public LiteralUtilTest {};
+
+using FloatTypes =
+    ::testing::Types<float, half, bfloat16, tsl::float8_e4m3fn,
+                     tsl::float8_e4m3fnuz, tsl::float8_e4m3b11fnuz,
+                     tsl::float8_e5m2, tsl::float8_e5m2fnuz>;
+
+TYPED_TEST_SUITE(LiteralUtilFloatTest, FloatTypes);
+
 TEST_F(LiteralUtilTest, LiteralScalarToString) {
   auto true_lit = LiteralUtil::CreateR0<bool>(true);
   EXPECT_EQ("pred[] true", true_lit.ToString());
@@ -1140,34 +1150,30 @@ TEST_F(LiteralUtilTest, PopulateR2C64) {
   EXPECT_EQ(output, expected);
 }
 
-TEST_F(LiteralUtilTest, PopulateWithValueR0BF16) {
-  Literal output(ShapeUtil::MakeShape(BF16, {}));
-  bfloat16 h(0.25f);
-  output.PopulateWithValue<bfloat16>(h);
-  auto expected = LiteralUtil::CreateR0<bfloat16>(h);
+TYPED_TEST(LiteralUtilFloatTest, PopulateWithValueR0Float) {
+  Literal output(ShapeUtil::MakeShape(
+      primitive_util::NativeToPrimitiveType<TypeParam>(), {}));
+  TypeParam h(0.25f);
+  output.PopulateWithValue<TypeParam>(h);
+  auto expected = LiteralUtil::CreateR0<TypeParam>(h);
   EXPECT_EQ(output, expected);
 }
 
-TEST_F(LiteralUtilTest, PopulateWithValueR1BF16) {
-  Literal output(ShapeUtil::MakeShape(BF16, {3}));
-  bfloat16 h(0.5f);
-  output.PopulateWithValue<bfloat16>(h);
-  auto expected = LiteralUtil::CreateR1<bfloat16>({h, h, h});
+TYPED_TEST(LiteralUtilFloatTest, PopulateWithValueR1Float) {
+  Literal output(ShapeUtil::MakeShape(
+      primitive_util::NativeToPrimitiveType<TypeParam>(), {3}));
+  TypeParam h(0.5f);
+  output.PopulateWithValue<TypeParam>(h);
+  auto expected = LiteralUtil::CreateR1<TypeParam>({h, h, h});
   EXPECT_EQ(output, expected);
 }
 
-TEST_F(LiteralUtilTest, PopulateWithValueR2BF16) {
-  Literal output(ShapeUtil::MakeShape(BF16, {2, 2}));
-  bfloat16 h(2.0f);
-  output.PopulateWithValue<bfloat16>(h);
-  auto expected = LiteralUtil::CreateR2<bfloat16>({{h, h}, {h, h}});
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR0F32) {
-  Literal output(ShapeUtil::MakeShape(F32, {}));
-  output.PopulateWithValue<float>(2.5f);
-  auto expected = LiteralUtil::CreateR0<float>(2.5f);
+TYPED_TEST(LiteralUtilFloatTest, PopulateWithValueR2Float) {
+  Literal output(ShapeUtil::MakeShape(
+      primitive_util::NativeToPrimitiveType<TypeParam>(), {2, 2}));
+  TypeParam h(2.0f);
+  output.PopulateWithValue<TypeParam>(h);
+  auto expected = LiteralUtil::CreateR2<TypeParam>({{h, h}, {h, h}});
   EXPECT_EQ(output, expected);
 }
 
@@ -1198,70 +1204,6 @@ TEST_F(LiteralUtilTest, PopulateWithValueR2C128) {
   output.PopulateWithValue<complex128>({4, 2});
   auto expected =
       LiteralUtil::CreateR2<complex128>({{{4, 2}, {4, 2}}, {{4, 2}, {4, 2}}});
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR0F16) {
-  Literal output(ShapeUtil::MakeShape(F16, {}));
-  half h(0.25f);
-  output.PopulateWithValue<half>(h);
-  auto expected = LiteralUtil::CreateR0<half>(h);
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR1F16) {
-  Literal output(ShapeUtil::MakeShape(F16, {3}));
-  half h(0.5f);
-  output.PopulateWithValue<half>(h);
-  auto expected = LiteralUtil::CreateR1<half>({h, h, h});
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR2F16) {
-  Literal output(ShapeUtil::MakeShape(F16, {2, 2}));
-  half h(2.0f);
-  output.PopulateWithValue<half>(h);
-  auto expected = LiteralUtil::CreateR2<half>({{h, h}, {h, h}});
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR0F8e5m2) {
-  Literal output(ShapeUtil::MakeShape(F8E5M2, {}));
-  tsl::float8_e5m2 x(0.25f);
-  output.PopulateWithValue<tsl::float8_e5m2>(x);
-  auto expected = LiteralUtil::CreateR0<tsl::float8_e5m2>(x);
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR1F8e4m3) {
-  Literal output(ShapeUtil::MakeShape(F8E4M3FN, {3}));
-  tsl::float8_e4m3fn x(0.5f);
-  output.PopulateWithValue<tsl::float8_e4m3fn>(x);
-  auto expected = LiteralUtil::CreateR1<tsl::float8_e4m3fn>({x, x, x});
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR1F8e4m3b11) {
-  Literal output(ShapeUtil::MakeShape(F8E4M3B11FNUZ, {3}));
-  tsl::float8_e4m3b11fnuz x(0.5f);
-  output.PopulateWithValue<tsl::float8_e4m3b11fnuz>(x);
-  auto expected = LiteralUtil::CreateR1<tsl::float8_e4m3b11fnuz>({x, x, x});
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR1F8e4m3fnuz) {
-  Literal output(ShapeUtil::MakeShape(F8E4M3FNUZ, {3}));
-  tsl::float8_e4m3fnuz x(0.5f);
-  output.PopulateWithValue<tsl::float8_e4m3fnuz>(x);
-  auto expected = LiteralUtil::CreateR1<tsl::float8_e4m3fnuz>({x, x, x});
-  EXPECT_EQ(output, expected);
-}
-
-TEST_F(LiteralUtilTest, PopulateWithValueR1F8e5m2fnuz) {
-  Literal output(ShapeUtil::MakeShape(F8E5M2FNUZ, {3}));
-  tsl::float8_e5m2fnuz x(0.5f);
-  output.PopulateWithValue<tsl::float8_e5m2fnuz>(x);
-  auto expected = LiteralUtil::CreateR1<tsl::float8_e5m2fnuz>({x, x, x});
   EXPECT_EQ(output, expected);
 }
 
@@ -1745,92 +1687,70 @@ TEST_F(LiteralUtilTest, ConvertIfTypesMatch) {
   EXPECT_EQ(c128.Convert(S32).status().code(), tsl::error::UNIMPLEMENTED);
 }
 
-TEST_F(LiteralUtilTest, ConvertIfTypesMatchF8) {
-  auto s8 = LiteralUtil::CreateR2WithLayout<int8_t>({{0, 1}, {2, 3}},
-                                                    layout_r2_dim0major_);
-  auto f32 = LiteralUtil::CreateR2WithLayout<float>({{0., 1.}, {2., 3.}},
-                                                    layout_r2_dim0major_);
-  auto c128 = LiteralUtil::CreateR2WithLayout<complex128>({{0., 1.}, {2., 3.}},
-                                                          layout_r2_dim0major_);
-  using e5 = tsl::float8_e5m2;
-  auto f8e5m2 = LiteralUtil::CreateR2WithLayout<e5>(
-      {{e5{0.}, e5{1.}}, {e5{2.}, e5{3.}}}, layout_r2_dim0major_);
-  using e4 = tsl::float8_e4m3fn;
-  auto f8e4m3 = LiteralUtil::CreateR2WithLayout<e4>(
-      {{e4{0.}, e4{1.}}, {e4{2.}, e4{3.}}}, layout_r2_dim0major_);
-  using b11 = tsl::float8_e4m3b11fnuz;
-  auto f8e4m3b11 = LiteralUtil::CreateR2WithLayout<b11>(
-      {{b11{0.}, b11{1.}}, {b11{2.}, b11{3.}}}, layout_r2_dim0major_);
-  using e5f = tsl::float8_e5m2fnuz;
-  auto f8e5m2fnuz = LiteralUtil::CreateR2WithLayout<e5f>(
-      {{e5f{0.}, e5f{1.}}, {e5f{2.}, e5f{3.}}}, layout_r2_dim0major_);
-  using e4f = tsl::float8_e4m3fnuz;
-  auto f8e4m3fnuz = LiteralUtil::CreateR2WithLayout<e4f>(
-      {{e4f{0.}, e4f{1.}}, {e4f{2.}, e4f{3.}}}, layout_r2_dim0major_);
+TYPED_TEST(LiteralUtilFloatTest, ConvertIfTypesMatchF8) {
+  constexpr auto ptype = primitive_util::NativeToPrimitiveType<TypeParam>();
+  if (!primitive_util::IsF8Type(ptype)) {
+    GTEST_SKIP() << "Skipping test for non F8 types";
+  }
+  auto s8 = LiteralUtil::CreateR2WithLayout<int8_t>(
+      {{0, 1}, {2, 3}}, LiteralUtilTest::layout_r2_dim0major_);
+  auto bf16 = LiteralUtil::CreateR2WithLayout<bfloat16>(
+      {{bfloat16(0.), bfloat16(1.)}, {bfloat16(2.), bfloat16(3.)}},
+      LiteralUtilTest::layout_r2_dim0major_);
+  auto f32 = LiteralUtil::CreateR2WithLayout<float>(
+      {{0., 1.}, {2., 3.}}, LiteralUtilTest::layout_r2_dim0major_);
+  auto c128 = LiteralUtil::CreateR2WithLayout<complex128>(
+      {{0., 1.}, {2., 3.}}, LiteralUtilTest::layout_r2_dim0major_);
+  // Let's also use a couple of popular F8 types as sources for conversion
+  using f8e5m2_t = tsl::float8_e5m2;
+  auto f8e5m2 = LiteralUtil::CreateR2WithLayout<f8e5m2_t>(
+      {{f8e5m2_t{0.}, f8e5m2_t{1.}}, {f8e5m2_t{2.}, f8e5m2_t{3.}}},
+      LiteralUtilTest::layout_r2_dim0major_);
+  using e4m3fn_t = tsl::float8_e4m3fn;
+  auto f8e4m3fn = LiteralUtil::CreateR2WithLayout<e4m3fn_t>(
+      {{e4m3fn_t{0.}, e4m3fn_t{1.}}, {e4m3fn_t{2.}, e4m3fn_t{3.}}},
+      LiteralUtilTest::layout_r2_dim0major_);
+
+  auto f8 = LiteralUtil::CreateR2WithLayout<TypeParam>(
+      {{TypeParam{0.}, TypeParam{1.}}, {TypeParam{2.}, TypeParam{3.}}},
+      LiteralUtilTest::layout_r2_dim0major_);
+
   Literal conv;
 
-  conv = s8.Convert(F8E5M2).value();
+  // Convert to f8
+  conv = s8.Convert(ptype).value();
+  EXPECT_EQ(conv, f8);
+
+  conv = bf16.Convert(ptype).value();
+  EXPECT_EQ(conv, f8);
+
+  conv = f32.Convert(ptype).value();
+  EXPECT_EQ(conv, f8);
+
+  conv = f8e5m2.Convert(ptype).value();
+  EXPECT_EQ(conv, f8);
+
+  conv = f8e4m3fn.Convert(ptype).value();
+  EXPECT_EQ(conv, f8);
+
+  // Convert from f8
+  conv = f8.Convert(S8).value();
+  EXPECT_EQ(conv, s8);
+
+  conv = f8.Convert(BF16).value();
+  EXPECT_EQ(conv, bf16);
+
+  conv = f8.Convert(F32).value();
+  EXPECT_EQ(conv, f32);
+
+  conv = f8.Convert(C128).value();
+  EXPECT_EQ(conv, c128);
+
+  conv = f8.Convert(F8E5M2).value();
   EXPECT_EQ(conv, f8e5m2);
 
-  conv = f32.Convert(F8E5M2).value();
-  EXPECT_EQ(conv, f8e5m2);
-
-  conv = f8e4m3.Convert(F8E5M2).value();
-  EXPECT_EQ(conv, f8e5m2);
-
-  conv = s8.Convert(F8E4M3FN).value();
-  EXPECT_EQ(conv, f8e4m3);
-
-  conv = f32.Convert(F8E4M3FN).value();
-  EXPECT_EQ(conv, f8e4m3);
-
-  conv = f8e5m2.Convert(F8E4M3FN).value();
-  EXPECT_EQ(conv, f8e4m3);
-
-  conv = f8e5m2.Convert(S8).value();
-  EXPECT_EQ(conv, s8);
-
-  conv = f8e5m2.Convert(F32).value();
-  EXPECT_EQ(conv, f32);
-
-  conv = f8e5m2.Convert(C128).value();
-  EXPECT_EQ(conv, c128);
-
-  conv = f8e4m3.Convert(S8).value();
-  EXPECT_EQ(conv, s8);
-
-  conv = f8e4m3.Convert(F32).value();
-  EXPECT_EQ(conv, f32);
-
-  conv = f8e4m3.Convert(C128).value();
-  EXPECT_EQ(conv, c128);
-
-  conv = f8e4m3b11.Convert(S8).value();
-  EXPECT_EQ(conv, s8);
-
-  conv = f8e4m3b11.Convert(F32).value();
-  EXPECT_EQ(conv, f32);
-
-  conv = f8e4m3b11.Convert(C128).value();
-  EXPECT_EQ(conv, c128);
-
-  conv = f8e5m2fnuz.Convert(S8).value();
-  EXPECT_EQ(conv, s8);
-
-  conv = f8e5m2fnuz.Convert(F32).value();
-  EXPECT_EQ(conv, f32);
-
-  conv = f8e5m2fnuz.Convert(C128).value();
-  EXPECT_EQ(conv, c128);
-
-  conv = f8e4m3fnuz.Convert(S8).value();
-  EXPECT_EQ(conv, s8);
-
-  conv = f8e4m3fnuz.Convert(F32).value();
-  EXPECT_EQ(conv, f32);
-
-  conv = f8e4m3fnuz.Convert(C128).value();
-  EXPECT_EQ(conv, c128);
+  conv = f8.Convert(F8E4M3FN).value();
+  EXPECT_EQ(conv, f8e4m3fn);
 }
 
 TEST_F(LiteralUtilTest, BitcastConvert) {


### PR DESCRIPTION
`literal_test.cc` contains multiple similar tests for Float types

Changes:
- Parameterize the float tests in literal_test.cc