### PR TITLE
[ffi] Support handler bundles in GPU plugin extension

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_gpu_extension.h
@@ -24,17 +24,20 @@ limitations under the License.
 extern "C" {
 #endif
 
-#define PJRT_API_GPU_EXTENSION_VERSION 1
+#define PJRT_API_GPU_EXTENSION_VERSION 2
 
 struct PJRT_Gpu_Register_Custom_Call_Args {
   size_t struct_size;
   const char* function_name;
   size_t function_name_size;
   int api_version;  // 0 for an untyped call, 1 -- for typed
-  void* custom_call_function;
+  void* handler_instantiate;
+  void* handler_prepare;
+  void* handler_initialize;
+  void* handler_execute;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Register_Custom_Call_Args,
-                          custom_call_function);
+                          handler_execute);
 
 // Registers a custom call.
 typedef PJRT_Error* PJRT_Gpu_Register_Custom_Call(

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -293,14 +293,19 @@ PJRT_Error* PJRT_Gpu_Register_Custom_Call(
   switch (args->api_version) {
     case 0:
       xla::CustomCallTargetRegistry::Global()->Register(
-          function_name, args->custom_call_function,
+          function_name, args->handler_execute,
           PJRT_GPU_PLUGIN_PLATFORM_NAME);
       return nullptr;
     case 1:
       xla::ffi::Ffi::RegisterStaticHandler(
           xla::ffi::GetXlaFfiApi(), function_name,
           PJRT_GPU_PLUGIN_PLATFORM_NAME,
-          reinterpret_cast<XLA_FFI_Handler*>(args->custom_call_function));
+          XLA_FFI_Handler_Bundle{
+            reinterpret_cast<XLA_FFI_Handler*>(args->handler_instantiate),
+            reinterpret_cast<XLA_FFI_Handler*>(args->handler_prepare),
+            reinterpret_cast<XLA_FFI_Handler*>(args->handler_initialize),
+            reinterpret_cast<XLA_FFI_Handler*>(args->handler_execute)
+          });
       return nullptr;
     default:
       return new PJRT_Error{absl::UnimplementedError(

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -461,7 +461,10 @@ TEST(PjrtCApiGpuExtensionTest, CustomCallUntyped) {
   args.function_name = function_name.c_str();
   args.function_name_size = function_name.size();
   args.api_version = 0;
-  args.custom_call_function = reinterpret_cast<void*>(&TestCustomCallV2);
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(&TestCustomCallV2);
   auto api = GetPjrtApi();
   const PJRT_Extension_Base* next =
       reinterpret_cast<const PJRT_Extension_Base*>(api->extension_start);
@@ -491,7 +494,10 @@ TEST(PjrtCApiGpuExtensionTest, CustomCallTyped) {
   args.function_name = function_name.c_str();
   args.function_name_size = function_name.size();
   args.api_version = 1;
-  args.custom_call_function = reinterpret_cast<void*>(kNoop);
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(kNoop);
   auto api = GetPjrtApi();
   const PJRT_Extension_Base* next =
       reinterpret_cast<const PJRT_Extension_Base*>(api->extension_start);


### PR DESCRIPTION
Currently only the execute handler is supported. This PR allows all of them to be set, bringing the GPU plugin extensions in sync with https://github.com/openxla/xla/blob/b9fcb2422f5e38ed8aecaec6b604d2fc86755c4d/xla/python/xla_compiler.cc#L306-L308 .

See also the JAX part of this change: https://github.com/jax-ml/jax/pull/23806