### PR TITLE
[ROCm] Skip Parametric/TestF16/MajorToMinor tests as it requires trit…

### DIFF
--- a/xla/tests/dot_operation_test.cc
+++ b/xla/tests/dot_operation_test.cc
@@ -312,6 +312,7 @@ class ParametricDotTest : public DotOperationTest,
       std::string_view name(
           ::testing::UnitTest::GetInstance()->current_test_info()->name());
       if (name.find("TestF16/270x270x520_MajorToMinor") != std::string::npos) {
+        GTEST_SKIP() << "Not supported on ROCm until Triton is re-enabled.";
         execution_options_.mutable_debug_options()->set_xla_gpu_autotune_level(
             0);
         DotTestParam param = GetParam();


### PR DESCRIPTION
…on gemm

This fails due to cce3b37b6 which disables triton gemm on ROCm.