### PR TITLE
Check all F8 dtype combinations in //xla/tests:convert_test

### DIFF
--- a/xla/service/elemental_ir_emitter.cc
+++ b/xla/service/elemental_ir_emitter.cc
@@ -471,8 +471,8 @@ llvm::Value* EmitF16ToF8e4m3b11fnuz(llvm::Value* f16_value,
   auto type = f16_value->getType();
   auto f16_abs_value = llvm_ir::EmitCallToIntrinsic(llvm::Intrinsic::fabs,
                                                     {f16_value}, {type}, b);
-  auto f16_zero = llvm::ConstantFP::getZero(type);
-  auto is_zero = b->CreateFCmpOEQ(f16_abs_value, f16_zero);
+  auto f16_zero_or_underflow = llvm::ConstantFP::get(type, 0x1.004p-14);
+  auto is_zero = b->CreateFCmpOLT(f16_abs_value, f16_zero_or_underflow);
   auto f8_overflow_threshold = llvm::ConstantFP::get(type, 0x1.fp+4);
   auto no_overflow = b->CreateFCmpOLT(f16_abs_value, f8_overflow_threshold);
 


### PR DESCRIPTION
This PR parametrizes float8 conversion tests to make sure all combinations are covered.
All 5 supported float8 types' tests now follow the same pattern in the test file.

Previously, the following tests were missing:
- Conversion from F8e4m3b11fn to PRED;
- Denormal and negative zero tests from F16 to F8e5m2;
- `ConvertF32F8e5m2Roundtrip` was missing (test conversion from F32 to F8e5m2);
- The complete set of exhaustive tests (vs other types) was only present for FNUZ types;
- ...probably more

Also merged the "Exhaustive4" and "Exhaustive5" suffixed tests that followed a similar pattern.
Removed unnecessary saving/restoring of the debug options.