### PR TITLE
[XLA:CPU] Increase minimum alignment of buffers for CPU

### DIFF
--- a/xla/cpu_function_runtime.h
+++ b/xla/cpu_function_runtime.h
@@ -179,7 +179,8 @@ class BufferInfo {
 inline constexpr size_t Align() { return 64; }
 
 // The minimum alignment of buffers passed to XLA:CPU.
-inline constexpr size_t MinAlign() { return 16; }
+// Aligning to 64 byte cacheline.
+inline constexpr size_t MinAlign() { return 64; }
 
 // When declaring variables that will be passed to an XLA instance as input via
 // set_arg_data(), be it a regular input or a resource variable in the graph,

--- a/xla/pjrt/cpu/abstract_tfrt_cpu_buffer.cc
+++ b/xla/pjrt/cpu/abstract_tfrt_cpu_buffer.cc
@@ -723,9 +723,7 @@ AbstractTfrtCpuBuffer::BufferFromHostBufferHelper(
   bool is_packed = primitive_util::IsSubByteNonPredType(type);
 
   // If the input buffer has a default layout and is sufficiently aligned, we
-  // can simply point to the input array's data without any further copies. At
-  // the time of writing we require a 16-byte alignment because XLA may generate
-  // code which requires it.
+  // can simply point to the input array's data without any further copies.
   bool is_aligned_data = ((absl::bit_cast<std::uintptr_t>(data) &
                            (cpu_function_runtime::MinAlign() - 1)) == 0);
 

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -882,7 +882,7 @@ absl::Status CpuCompiler::RunHloPasses(HloModule* module, bool is_aot_compile,
 
 namespace {
 
-// Align buffers to XLA:CPU minimal alignment.
+// Align buffers to XLA:CPU minimal alignment of 64 bytes.
 int64_t memory_alignment(LogicalBuffer::Color) {
   return cpu_function_runtime::MinAlign();
 }


### PR DESCRIPTION
Change minimum alignment of buffers passed to XLA:CPU from 16 to 64. This improves performance for many workloads including ViT, Bert, gemma by upto 30%