### PR TITLE
[XLA:GPU] Sort groups in NCCL clique keys

### DIFF
--- a/xla/service/gpu/runtime/BUILD
+++ b/xla/service/gpu/runtime/BUILD
@@ -300,6 +300,7 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:logging",
     ],
 )
 

--- a/xla/service/gpu/runtime/nccl_clique_key_test.cc
+++ b/xla/service/gpu/runtime/nccl_clique_key_test.cc
@@ -89,6 +89,27 @@ TEST(NcclCliqueKeyTest, CompareWithParticipantGroups) {
   EXPECT_EQ(key0_nogroups, key1_nogroups);
 }
 
+TEST(NcclCliqueKeyTest, CompareWithPermutedParticipantGroups) {
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+  GlobalDeviceId id2 = GlobalDeviceId(2);
+  GlobalDeviceId id3 = GlobalDeviceId(3);
+
+  // The keys are equal because the replica groups are same up to permutation.
+  NcclCliqueKey key0(
+      {id0, id1}, NcclStreamId(0), AsyncStreamKind::kCollective,
+      std::vector<std::vector<GlobalDeviceId>>{{id3, id2}, {id0, id1}});
+  NcclCliqueKey key1(
+      {id0, id1}, NcclStreamId(0), AsyncStreamKind::kCollective,
+      std::vector<std::vector<GlobalDeviceId>>{{id0, id1}, {id2, id3}});
+  EXPECT_EQ(key0, key1);
+
+  NcclCliqueKey key_other(
+      {id0, id1}, NcclStreamId(0), AsyncStreamKind::kCollective,
+      std::vector<std::vector<GlobalDeviceId>>{{id0, id2}, {id1, id3}});
+  EXPECT_FALSE(key0 == key_other);
+}
+
 TEST(NcclCliqueKeyTest, BtreeIterationOrder) {
   GlobalDeviceId id0 = GlobalDeviceId(0);
   GlobalDeviceId id1 = GlobalDeviceId(1);


### PR DESCRIPTION
It turns out that in some cases, we get two calls to GetNcclCliqueKey that only differ by the order of the groups (for instance, one call with groups={{0,1},{2, 3}}, another call with groups={{2,3},{0,1}}. This leads to unnecessary creation of equivalent NCCL communicators.

This patch sorts the groups in NCCL clique key so that we create the same key for the same set of groups (up to permutation).