### PR TITLE
Move HostOffloadLegalize before LayoutNormalization for GPUs

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -996,6 +996,9 @@ absl::Status RunLayoutAssignmentPasses(HloModule* hlo_module,
   pipeline.AddPass<SubByteNormalization>(
       SubByteNormalization::SET_ELEMENT_SIZE);
   pipeline.AddPass<OptimizeInputOutputBufferAlias>(true);
+  // Run HostOffloadLegalize before LayoutNormalization to prevent
+  // the creation of invalid transpose/bitcast operations within
+  // host memory offloading segments.
   pipeline.AddPass<HostOffloadLegalize>(
       static_cast<int64_t>(stream_executor::MemoryType::kHost),
       /* after_layout= */ true);

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -996,6 +996,9 @@ absl::Status RunLayoutAssignmentPasses(HloModule* hlo_module,
   pipeline.AddPass<SubByteNormalization>(
       SubByteNormalization::SET_ELEMENT_SIZE);
   pipeline.AddPass<OptimizeInputOutputBufferAlias>(true);
+  pipeline.AddPass<HostOffloadLegalize>(
+      static_cast<int64_t>(stream_executor::MemoryType::kHost),
+      /* after_layout= */ true);
   return pipeline.Run(hlo_module).status();
 }
 
@@ -1570,9 +1573,6 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   // Rewrite GEMMs with broadcasted inputs as strided GEMMs.
   pipeline.AddPass<GemmBroadcastFoldingRewriter>();
 
-  pipeline.AddPass<HostOffloadLegalize>(
-      static_cast<int64_t>(stream_executor::MemoryType::kHost),
-      /* after_layout= */ true);
   pipeline.AddPass<HostOffloader>(
       static_cast<int64_t>(stream_executor::MemoryType::kHost));
 

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1097,6 +1097,7 @@ ENTRY main {
   // This test captures known dependencies between passes.
   VerifyPassOrder(passes, "layout-assignment", "priority-fusion");
   VerifyPassOrder(passes, "layout-assignment", "layout_normalization");
+  VerifyPassOrder(passes, "host-offload-legalize", "layout_normalization");
 }
 
 }  // namespace


### PR DESCRIPTION
Fix ActivationOffloadingTest.test_remat_scan_layout_change_offloadable in JAX.
The test in memories_test.py failed with an INVALID_ARGUMENT error:
- A tensor moved to host (from "dynamic-update-slice.13") was used by an 
  instruction ("transpose.32") not acceptable during pure memory offload.

Root cause:
- LayoutNormalization inserts a transpose
- AlgebraicSimplifier replaces certain transposes with bitcast transposes
- These transposes/bitcasts are invalid in host memory offloading segments

Solution:
Move HostOffloadLegalize before LayoutNormalization to prevent this issue.