### PR TITLE
[GPU] Skip zero-clamping of index operands known to be non-negative.

### DIFF
--- a/xla/service/gpu/fusions/in_place_dynamic_update_slice_mlir.cc
+++ b/xla/service/gpu/fusions/in_place_dynamic_update_slice_mlir.cc
@@ -149,6 +149,8 @@ absl::Status MlirInPlaceDynamicUpdateSliceFusion::EmitEntryFunction(
                         ->operand(i + dus_instr->first_index_operand_number())
                         ->shape()
                         .element_type()),
+                mlir_converter::IsNonNegative(*dus_instr->operand(
+                    i + dus_instr->first_index_operand_number())),
                 dus_instr->shape().dimensions(i) - update_size, b);
 
             update_indices.push_back(

--- a/xla/service/gpu/fusions/mlir/BUILD
+++ b/xla/service/gpu/fusions/mlir/BUILD
@@ -78,6 +78,7 @@ cc_library(
         "//xla/mlir_hlo:map_mhlo_to_scalar_op",
         "//xla/mlir_hlo:type_conversion",
         "//xla/service:algorithm_util",
+        "//xla/service:algebraic_simplifier",
         "//xla/service/gpu:hlo_traversal",
         "//xla/service/gpu/fusions/ir:xla_gpu",
         "//xla/service/gpu/model:indexing_analysis",

--- a/xla/service/gpu/fusions/mlir/elemental_hlo_to_mlir.h
+++ b/xla/service/gpu/fusions/mlir/elemental_hlo_to_mlir.h
@@ -137,8 +137,13 @@ absl::StatusOr<mlir::ValueRange> EmitLoopNestWithStatus(
         create_body);
 
 // Clamps `index` to [0, high] boundaries.
-mlir::Value ClampIndex(mlir::Value index, bool is_unsigned, int64_t high,
+mlir::Value ClampIndex(mlir::Value index, bool is_unsigned,
+                       bool is_non_negative, int64_t high,
                        mlir::ImplicitLocOpBuilder& b);
+
+// Tells that outputs of an instruction or its bitcast / reshape are known
+// to be always non-negative.
+bool IsNonNegative(const HloInstruction&);
 
 // Inlines `src_block` using `mapped_args` to initialize IRMapping from the
 // block arguments of `src_block` to `mapped_args`. Return remapped values of

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1099,6 +1099,19 @@ ENTRY main {
   VerifyPassOrder(passes, "layout-assignment", "layout_normalization");
 }
 
+TEST_F(GpuCompilerTest, IndexZeroClampingWorksCorrectly) {
+  EXPECT_TRUE(RunAndCompare(R"(e {
+  p0 = s32[7] parameter(0)
+  p1 = s32[5] parameter(1)
+  abs = s32[5] abs(p1)
+  r = s32[5,1] reshape(abs)
+  ROOT g = s32[5] gather(p0, r),
+    offset_dims={}, collapsed_slice_dims={0},
+    start_index_map={0}, index_vector_dim=1, slice_sizes={1}
+})",
+                            ErrorSpec{0, 0}));
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
This is a minor optimization and fixes
LaxBackedScipyTests.testSphHarmAccuracy from JAX lax_scipy_test on H100 with CUDA 12.5.0 which has incorrect handling of max(min(abs(x), y), z) in ptxas.