### PR TITLE
[GPU] Optimize zero-clamping of index operands known to be non-negative.

### DIFF
--- a/xla/service/gpu/fusions/transforms/tests/simplify_arith.mlir
+++ b/xla/service/gpu/fusions/transforms/tests/simplify_arith.mlir
@@ -367,3 +367,41 @@ module {
 // CHECK-SAME: xla.range = [0 : index, 2147483647 : index]
 // CHECK-NEXT: arith.index_cast
 // CHECK-SAME: xla.range = [0 : index, 2147483647 : index]
+
+// -----
+
+module {
+  func.func @annotate_range_abs_index(%v: i32 {xla.range = [-31 : i32, 17 : i32]}) -> index {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi sge, %v, %c0_i32 : i32
+    %1 = arith.subi %c0_i32, %v : i32
+    %2 = arith.select %0, %v, %1 : i32
+    %3 = arith.index_cast %2 : i32 to index
+    return %3: index
+  }
+}
+
+// CHECK-LABEL: @annotate_range_abs
+// CHECK: arith.select
+// CHECK-SAME: xla.range = [0 : index, 31 : index]
+// CHECK-NEXT: arith.index_cast
+// CHECK-SAME: xla.range = [0 : index, 31 : index]
+
+// -----
+
+module {
+  func.func @annotate_range_abs_index(%v: i32 {xla.range = [-5 : i32, 3 : i32]}) -> index {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi sge, %v, %c0_i32 : i32
+    %1 = arith.subi %c0_i32, %v : i32
+    %2 = arith.select %0, %v, %1 : i32
+    %3 = arith.index_cast %2 : i32 to index
+    return %3: index
+  }
+}
+
+// CHECK-LABEL: @annotate_range_abs
+// CHECK: arith.select
+// CHECK-SAME: xla.range = [0 : index, 5 : index]
+// CHECK-NEXT: arith.index_cast
+// CHECK-SAME: xla.range = [0 : index, 5 : index]

--- a/xla/service/gpu/fusions/transforms/tests/simplify_arith.mlir
+++ b/xla/service/gpu/fusions/transforms/tests/simplify_arith.mlir
@@ -348,3 +348,22 @@ func.func @dus(%arg0: tensor<20x30xf32>, %arg1: tensor<5x6xf32>, %arg2: i32, %ar
 // CHECK-SAME: xla.range = [0 : index, 19 : index]
 // CHECK: arith.addi
 // CHECK-SAME: xla.range = [0 : index, 29 : index]
+
+// -----
+
+module {
+  func.func @annotate_range_abs_index(%v: i32) -> index {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = arith.cmpi sge, %v, %c0_i32 : i32
+    %1 = arith.subi %c0_i32, %v : i32
+    %2 = arith.select %0, %v, %1 : i32
+    %3 = arith.index_cast %2 : i32 to index
+    return %3: index
+  }
+}
+
+// CHECK-LABEL: @annotate_range_abs
+// CHECK: arith.select
+// CHECK-SAME: xla.range = [0 : index, 2147483647 : index]
+// CHECK-NEXT: arith.index_cast
+// CHECK-SAME: xla.range = [0 : index, 2147483647 : index]

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -650,6 +650,7 @@ lit_test_suite(
             "transpose_210.hlo",
             "transpose_210_extra_output.hlo",
             "triton_naming.hlo",
+            "zero_clamp_abs_index.hlo",
         ],
         include = [
             "*.hlo",

--- a/xla/service/gpu/tests/zero_clamp_abs_index.hlo
+++ b/xla/service/gpu/tests/zero_clamp_abs_index.hlo
@@ -1,0 +1,13 @@
+// RUN: hlo-opt %s --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/%{GPU}.txtpb | FileCheck %s
+
+e {
+  p0 = s32[8,9] parameter(0)
+  p1 = s32[5] parameter(1)
+  a = s32[5] abs(p1)
+  ROOT r = s32[5,2,3] gather(p0, a),
+    offset_dims={1,2}, collapsed_slice_dims={}, start_index_map={0},
+    index_vector_dim=1, slice_sizes={2,3}
+}
+
+// CHECK: llvm.smin.i32
+// CHECK-NOT: llvm.smax.i32


### PR DESCRIPTION
This is a minor optimization and fixes
LaxBackedScipyTests.testSphHarmAccuracy from JAX lax_scipy_test on H100 with CUDA 12.5.0 which has incorrect handling of max(min(abs(x), y), z) in ptxas.