### PR TITLE
[NVIDIA] Added a flag to control the total number of collective resource in LHS

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -297,7 +297,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_experimental_ignore_channel_id(false);
   opts.set_xla_gpu_dot_merger_threshold_mb(32);
   opts.set_xla_enable_fast_math(false);
-  opts.set_xla_gpu_scheduler_parallel_collective_resource(1);
+  opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
   return opts;
 }
 
@@ -2011,10 +2011,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 debug_options->xla_enable_fast_math(),
                 "Enable optimizations that assume finite math, i.e., no NaN."));
   flag_list->push_back(tsl::Flag(
-      "xla_gpu_scheduler_parallel_collective_resource",
+      "xla_gpu_experimental_parallel_collective_overlap_limit",
       int32_setter_for(
-          &DebugOptions::set_xla_gpu_scheduler_parallel_collective_resource),
-      debug_options->xla_gpu_scheduler_parallel_collective_resource(),
+          &DebugOptions::
+              set_xla_gpu_experimental_parallel_collective_overlap_limit),
+      debug_options->xla_gpu_experimental_parallel_collective_overlap_limit(),
       "This controls how many in-flight collectives "
       "latency hiding scheduler can schedule."));
 }  // NOLINT(readability/fn_size)

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -297,6 +297,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_experimental_ignore_channel_id(false);
   opts.set_xla_gpu_dot_merger_threshold_mb(32);
   opts.set_xla_enable_fast_math(false);
+  opts.set_xla_gpu_scheduler_parallel_collective_resource(1);
   return opts;
 }
 
@@ -2004,12 +2005,18 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       int32_setter_for(&DebugOptions::set_xla_gpu_dot_merger_threshold_mb),
       debug_options->xla_gpu_dot_merger_threshold_mb(),
       "Dot merger pass threshold to be set in MB."));
-
   flag_list->push_back(
       tsl::Flag("xla_enable_fast_math",
                 bool_setter_for(&DebugOptions::set_xla_enable_fast_math),
                 debug_options->xla_enable_fast_math(),
                 "Enable optimizations that assume finite math, i.e., no NaN."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_scheduler_parallel_collective_resource",
+      int32_setter_for(
+          &DebugOptions::set_xla_gpu_scheduler_parallel_collective_resource),
+      debug_options->xla_gpu_scheduler_parallel_collective_resource(),
+      "This controls how many in-flight collectives "
+      "latency hiding scheduler can schedule."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -463,6 +463,16 @@ absl::StatusOr<ScheduleMetadata> ScheduleGpuModule(
       module->config()
           .debug_options()
           .xla_gpu_experimental_parallel_collective_overlap_limit());
+  CHECK((config.collective_broadcast_overlap_limit <=
+         config.parallel_collective_overlap_limit) &&
+        (config.all_to_all_overlap_limit <=
+         config.parallel_collective_overlap_limit) &&
+        (config.all_gather_overlap_limit <=
+         config.parallel_collective_overlap_limit) &&
+        (config.all_reduce_overlap_limit <=
+         config.parallel_collective_overlap_limit) &&
+        (config.reduce_scatter_overlap_limit <=
+         config.parallel_collective_overlap_limit));
   auto gpu_latency_estimator =
       std::make_unique<GpuLatencyEstimator>(pointer_size);
 

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -259,7 +259,7 @@ SchedulerConfig GetSchedulerConfig(int64_t memory_limit,
   config.aggressive_scheduling_policies = true;
   config.schedule_send_recvs = true;
   config.memory_limit = memory_limit;
-  config.global_collective_scheduling_resource = collective_resource;
+  config.parallel_collective_overlap_limit = collective_resource;
   return config;
 }
 
@@ -459,9 +459,10 @@ absl::StatusOr<ScheduleMetadata> ScheduleGpuModule(
   }
 
   SchedulerConfig config = GetSchedulerConfig(
-      memory_limit, module->config()
-                        .debug_options()
-                        .xla_gpu_scheduler_parallel_collective_resource());
+      memory_limit,
+      module->config()
+          .debug_options()
+          .xla_gpu_experimental_parallel_collective_overlap_limit());
   auto gpu_latency_estimator =
       std::make_unique<GpuLatencyEstimator>(pointer_size);
 

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -249,7 +249,8 @@ HloInstructionSequence PostprocessorToScheduleSyncCollectives(
 
 // Latency hiding scheduler support.
 
-SchedulerConfig GetSchedulerConfig(int64_t memory_limit) {
+SchedulerConfig GetSchedulerConfig(int64_t memory_limit,
+                                   int64_t collective_resource) {
   SchedulerConfig config;
   config.all_reduce_overlap_limit = 1;
   config.collective_broadcast_overlap_limit = 1;
@@ -258,6 +259,7 @@ SchedulerConfig GetSchedulerConfig(int64_t memory_limit) {
   config.aggressive_scheduling_policies = true;
   config.schedule_send_recvs = true;
   config.memory_limit = memory_limit;
+  config.global_collective_scheduling_resource = collective_resource;
   return config;
 }
 
@@ -456,7 +458,10 @@ absl::StatusOr<ScheduleMetadata> ScheduleGpuModule(
     return ScheduleMetadata{memory_limit};
   }
 
-  SchedulerConfig config = GetSchedulerConfig(memory_limit);
+  SchedulerConfig config = GetSchedulerConfig(
+      memory_limit, module->config()
+                        .debug_options()
+                        .xla_gpu_scheduler_parallel_collective_resource());
   auto gpu_latency_estimator =
       std::make_unique<GpuLatencyEstimator>(pointer_size);
 

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -241,7 +241,7 @@ int64_t GpuAsyncTracker::GetNumAvailableResources(int64_t resource_type) const {
 
   if ((resource_type - first_target_resource) ==
       static_cast<int64_t>(GpuResourceType::kGpuAsyncStreamCollectives)) {
-    return config_.global_collective_scheduling_resource;
+    return config_.parallel_collective_overlap_limit;
   }
 
   return 1;

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -239,6 +239,11 @@ int64_t GpuAsyncTracker::GetNumAvailableResources(int64_t resource_type) const {
     return 2;
   }
 
+  if ((resource_type - first_target_resource) ==
+      static_cast<int64_t>(GpuResourceType::kGpuAsyncStreamCollectives)) {
+    return config_.global_collective_scheduling_resource;
+  }
+
   return 1;
 }
 

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -139,7 +139,7 @@ struct SchedulerConfig {
   bool enable_selective_resources = false;
   int64_t max_hops_to_closest_selective_overlap = 0;
   int64_t rerun = 0;
-  int64_t global_collective_scheduling_resource = 1;
+  int64_t parallel_collective_overlap_limit = 1;
 };
 
 // Class used estimate latency between instructions and cost of HLOs.

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -139,6 +139,7 @@ struct SchedulerConfig {
   bool enable_selective_resources = false;
   int64_t max_hops_to_closest_selective_overlap = 0;
   int64_t rerun = 0;
+  int64_t global_collective_scheduling_resource = 1;
 };
 
 // Class used estimate latency between instructions and cost of HLOs.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1005,7 +1005,21 @@ message DebugOptions {
   // loop by a factor of two if a collective op is present.
   bool xla_gpu_enable_heuristic_pass_configuration = 332;
 
-  // Next id: 336
+  // This controls how many in-flight collectives latency hiding scheduler
+  // can schedule. Example usage:
+  // With xla_gpu_scheduler_parallel_collective_resource = 1:
+  //   coll.1-start = collective(input)
+  //   coll.1-done = collective(coll.1-start)
+  //   coll.2-start = collective(input2)
+  //   coll.2-done = collective(coll.2-start)
+  // With xla_gpu_scheduler_parallel_collective_resource = 2:
+  //   coll.1-start = collective(input)
+  //   coll.2-start = collective(input2)
+  //   coll.1-done = collective(coll.1-start)
+  //   coll.2-done = collective(coll.2-start)
+  int32 xla_gpu_scheduler_parallel_collective_resource = 336;
+
+  // Next id: 337
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1007,17 +1007,17 @@ message DebugOptions {
 
   // This controls how many in-flight collectives latency hiding scheduler
   // can schedule. Example usage:
-  // With xla_gpu_scheduler_parallel_collective_resource = 1:
+  // With xla_gpu_experimental_parallel_collective_overlap_limit = 1:
   //   coll.1-start = collective(input)
   //   coll.1-done = collective(coll.1-start)
   //   coll.2-start = collective(input2)
   //   coll.2-done = collective(coll.2-start)
-  // With xla_gpu_scheduler_parallel_collective_resource = 2:
+  // With xla_gpu_experimental_parallel_collective_overlap_limit = 2:
   //   coll.1-start = collective(input)
   //   coll.2-start = collective(input2)
   //   coll.1-done = collective(coll.1-start)
   //   coll.2-done = collective(coll.2-start)
-  int32 xla_gpu_scheduler_parallel_collective_resource = 336;
+  int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
 
   // Next id: 337
 


### PR DESCRIPTION
Added a flag to control the total number of collective resource in LHS, the goal is to allow the scheduler to overlap multiple collectives under a large compute:
```
  With xla_gpu_scheduler_parallel_collective_resource = 1:
     coll.1-start = collective(input)
     coll.1-done = collective(coll.1-start)
     coll.2-start = collective(input2)
     large_compute = compute(op)  // because only 1 collective is allowed in-flight, only schedule 1 start-done pair here
     coll.2-done = collective(coll.2-start)
   With xla_gpu_scheduler_parallel_collective_resource = 2:
     coll.1-start = collective(input)
     coll.2-start = collective(input2)
     large_compute = compute(op)  // 2 collectives can be schedule in-flight at once now, much better schedule
     coll.1-done = collective(coll.1-start)
     coll.2-done = collective(coll.2-start)

```

Note that since we only have 1 collective stream, collectives will be serialized anyway, but with more resource, some of them can start much earlier.