### PR TITLE
Relax the error tolerance of UnaryElementwiseTest.ElementwiseFusionExecutesCorrectly

### DIFF
--- a/xla/service/gpu/fusions/cudnn_test.cc
+++ b/xla/service/gpu/fusions/cudnn_test.cc
@@ -949,7 +949,7 @@ INSTANTIATE_TEST_SUITE_P(
                             HloOpcode::kNegate, HloOpcode::kRsqrt,
                             HloOpcode::kSin, HloOpcode::kSqrt, HloOpcode::kTan,
                             HloOpcode::kTanh}),
-                       ::testing::Values(5e-4)),
+                       ::testing::Values(1e-3)),
     ElementwiseTestParamsToString);
 
 using BinaryElementwiseTest = ElementwiseTest;


### PR DESCRIPTION
To avoid errors like the following on Blackwell:

Value of: RunAndCompare(hlo_test, ErrorSpec{ tolerance, tolerance})
Actual: false (
Mismatch count 199 (19.4336%) in shape f32[32,32] (1024 elements), abs bound 0.0005, rel bound 0.0005
Top relative error mismatches:
  actual             1.43806803, expected             1.43928146, index {8,13}, rel error 0.000843, abs error  0.00121
  actual              1.4577775, expected             1.45898616, index {8,0}, rel error 0.000828, abs error  0.00121
  actual             1.42510152, expected             1.42622399, index {8,20}, rel error 0.000787, abs error  0.00112
  actual             1.31515145, expected             1.31618464, index {22,13}, rel error 0.000785, abs error  0.00103
  actual             1.22491062, expected             1.22583544, index {5,27}, rel error 0.000754, abs error 0.000925
  