### PR TITLE
[ds-fusion][nfc] Remove loop iter from dynamic slice thunk

### DIFF
--- a/xla/service/gpu/runtime/dynamic_slice_thunk.cc
+++ b/xla/service/gpu/runtime/dynamic_slice_thunk.cc
@@ -204,13 +204,6 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
                 << "]: constant offset = " << *const_offset;
         offset_value(argument_idx, offset_idx) = *const_offset;
 
-      } else if (std::holds_alternative<LoopIter>(offset)) {
-        // Get slice offset from the current loop iteration.
-        TF_ASSIGN_OR_RETURN(int64_t iter, WhileThunk::CurrentLoopIteration());
-        VLOG(2) << "  - arg " << argument_idx << "[" << offset_idx
-                << "]: loop iteration offset = " << iter;
-        offset_value(argument_idx, offset_idx) = iter;
-
       } else if (OffsetArray* offset_array =
                      std::get_if<OffsetArray>(&offset)) {
         TF_ASSIGN_OR_RETURN(int64_t iter, WhileThunk::CurrentLoopIteration());

--- a/xla/service/gpu/runtime/dynamic_slice_thunk.h
+++ b/xla/service/gpu/runtime/dynamic_slice_thunk.h
@@ -44,10 +44,6 @@ namespace gpu {
 // DynamicSliceThunk assumes that the slices are contiguous.
 class DynamicSliceThunk : public Thunk {
  public:
-  // When the offset value holds an object of type LoopIter, then that offset is
-  // equal to the loop iteration number.
-  struct LoopIter {};
-
   // This struct is used to wrap an array of offset values, where `values[i]`
   // denotes the value of offset at loop iteration `i`.
   // For example, if the loop iteration goes [0,5), and a particular offset for
@@ -61,8 +57,7 @@ class DynamicSliceThunk : public Thunk {
   // Dynamic slice offset can be either: (1) a statically known constant value,
   // (2) a loop iteration number, or (3) a truly dynamic offset that is
   // computed on device and have to be transferred to host.
-  using Offset =
-      std::variant<uint64_t, LoopIter, BufferAllocation::Slice, OffsetArray>;
+  using Offset = std::variant<uint64_t, BufferAllocation::Slice, OffsetArray>;
 
   DynamicSliceThunk(
       ThunkInfo thunk_info, std::unique_ptr<ThunkSequence> embedded_thunk,


### PR DESCRIPTION
Loop iteration offset should now be handled with the offset array implementation.