### PR TITLE
Added use_enabled_free_threading flag to build nanobind with NB_FREE_THREADED=1

### DIFF
--- a/third_party/nanobind/nanobind.BUILD
+++ b/third_party/nanobind/nanobind.BUILD
@@ -1,6 +1,19 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
+
+bool_flag(
+    name = "enabled_free_threading",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "use_enabled_free_threading",
+    flag_values = {
+        ":enabled_free_threading": "True",
+    },
+)
 
 cc_library(
     name = "nanobind",
@@ -11,10 +24,17 @@ cc_library(
         exclude = ["src/nb_combined.cpp"],
     ),
     copts = ["-fexceptions"],
-    defines = [
-        "NB_BUILD=1",
-        "NB_SHARED=1",
-    ],
+    defines = select({
+        ":use_enabled_free_threading": [
+            "NB_FREE_THREADED=1",
+            "NB_BUILD=1",
+            "NB_SHARED=1",
+        ],
+        "//conditions:default": [
+            "NB_BUILD=1",
+            "NB_SHARED=1",
+        ],
+    }),
     includes = ["include"],
     textual_hdrs = glob(
         [

--- a/third_party/nanobind/workspace.bzl
+++ b/third_party/nanobind/workspace.bzl
@@ -5,8 +5,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 def repo():
     tf_http_archive(
         name = "nanobind",
-        strip_prefix = "nanobind-2.1.0",
-        sha256 = "c37c53c60ada5fe1c956e24bd4b83af669a2309bf952bd251f36a7d2fa3bacf0",
-        urls = tf_mirror_urls("https://github.com/wjakob/nanobind/archive/refs/tags/v2.1.0.tar.gz"),
+        strip_prefix = "nanobind-2.2.0",
+        sha256 = "bfbfc7e5759f1669e4ddb48752b1ddc5647d1430e94614d6f8626df1d508e65a",
+        urls = tf_mirror_urls("https://github.com/wjakob/nanobind/archive/refs/tags/v2.2.0.tar.gz"),
         build_file = "//third_party/nanobind:nanobind.BUILD",
     )


### PR DESCRIPTION
Description:
- Added use_enabled_free_threading flag to build nanobind with NB_FREE_THREADED=1 
- Set nanobind version to tag v2.2.0: https://github.com/wjakob/nanobind/releases/tag/v2.2.0

Build command:
```bash
./configure.py --backend=CPU

bazel build --test_output=all --spawn_strategy=sandboxed --define=use_enabled_free_threading=true //xla/...
```
