### PR TITLE
Fix pylint C0301: Line too long in xla_client_test.py

### DIFF
--- a/xla/python/xla_client_test.py
+++ b/xla/python/xla_client_test.py
@@ -3169,17 +3169,12 @@ module @jit__lambda_ attributes {mhlo.num_partitions = 1 : i32,
       options.compile_portable_executable = True
       executable_build_options.num_replicas = 3
       executable_build_options.num_partitions = 2
-      executable_build_options.debug_options.xla_cpu_enable_fast_math = True
-      executable_build_options.debug_options.xla_test_all_input_layouts = True
-      executable_build_options.debug_options.xla_gpu_kernel_cache_file = (
-          "/foo/bar"
-      )
-      executable_build_options.debug_options.xla_gpu_enable_llvm_module_compilation_parallelism = (
-          True
-      )
-      executable_build_options.debug_options.xla_gpu_per_fusion_autotune_cache_dir = (
-          "/bar/foo/"
-      )
+      deb_opt = executable_build_options.debug_options
+      deb_opt.xla_cpu_enable_fast_math = True
+      deb_opt.xla_test_all_input_layouts = True
+      deb_opt.xla_gpu_kernel_cache_file = "/foo/bar"
+      deb_opt.xla_gpu_enable_llvm_module_compilation_parallelism = True
+      deb_opt.xla_gpu_per_fusion_autotune_cache_dir = "/bar/foo/"
 
       b = options.SerializeAsString()
       restored = xla_client.CompileOptions.ParseFromString(b)
@@ -3352,8 +3347,9 @@ module @jit__lambda_ attributes {mhlo.num_partitions = 1 : i32,
       options.num_replicas = num_replicas
       compiled_c = self.backend.compile(
           xla_computation_to_mlir_module(c.build()), compile_options=options)
-      results, sharded_token = compiled_c.execute_sharded_on_local_devices_with_tokens(
-          [])
+      results, sharded_token = (
+        compiled_c.execute_sharded_on_local_devices_with_tokens([])
+      )
       sharded_token.block_until_ready()
       self.assertLen(results, 1)
       self.assertLen(results[0], 1)


### PR DESCRIPTION
Currently Tensorflow CI build (triggered by XLA copybara-service bot) fails with the following pylint errors:
```bash
************* Module python.xla_client_test
third_party/xla/xla/python/xla_client_test.py:3182:0: C0301: Line too long (99/80) (line-too-long)
third_party/xla/xla/python/xla_client_test.py:3185:0: C0301: Line too long (86/80) (line-too-long)
third_party/xla/xla/python/xla_client_test.py:3360:0: C0301: Line too long (87/80) (line-too-long)
```

links:
- https://github.com/tensorflow/tensorflow/commit/dd2c1e9d94cfe5c471b5788917a2f74140d9b144
- https://github.com/tensorflow/tensorflow/actions/runs/11130353052/job/30929504884

This PR fixes the issue