### PR TITLE
[ROCM] Add nanoo fp8 support in type traits

### DIFF
--- a/xla/tsl/framework/type_traits.h
+++ b/xla/tsl/framework/type_traits.h
@@ -73,8 +73,10 @@ struct is_simple_type {
       std::is_same<T, float8_e3m4>::value ||
       std::is_same<T, float8_e4m3>::value ||
       std::is_same<T, float8_e4m3fn>::value ||
+      std::is_same<T, float8_e4m3fnuz>::value ||
       std::is_same<T, float8_e4m3b11fnuz>::value ||
-      std::is_same<T, float8_e5m2>::value || std::is_same<T, int4>::value ||
+      std::is_same<T, float8_e5m2>::value ||
+      std::is_same<T, float8_e5m2fnuz>::value || std::is_same<T, int4>::value ||
       std::is_same<T, uint4>::value;
 };
 


### PR DESCRIPTION
We are trying to add NANOO FP8 support in TensorFlow. To achieve this, a small modification in the `type_traits.h` file on the XLA side is required, where the NANOO FP8 should also be classified as a simple type. This change will be utilized in tensor.cc within TensorFlow. You can find the relevant code here: [TensorFlow tensor.cc](https://github.com/tensorflow/tensorflow/blob/ba7f93b8dc32b64cc0bb5ddb44e75bd344ae67d0/tensorflow/core/framework/tensor.cc#L175).