### PR TITLE
`FunctionArgTypeConverterFn` under `BufferizationOptions` takes `FunctionOpInterface` instead of `func::FuncOp`

### DIFF
--- a/xla/mlir_hlo/transforms/bufferize_pass.cc
+++ b/xla/mlir_hlo/transforms/bufferize_pass.cc
@@ -66,6 +66,7 @@ limitations under the License.
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -235,7 +236,7 @@ struct OneShotBufferizePass
     opts.allowReturnAllocsFromLoops = true;
     opts.bufferizeFunctionBoundaries = true;
     opts.functionArgTypeConverterFn =
-        [=](TensorType tensorType, Attribute memorySpace, func::FuncOp funcOp,
+        [=](TensorType tensorType, Attribute memorySpace, FunctionOpInterface funcOp,
             const bufferization::BufferizationOptions& /*options*/) {
           // Functions created by fusion outlining should have fully dynamic
           // layout. All other functions (for now only "main") gets static


### PR DESCRIPTION
**Description:** 

Hi! This PR is to synchronize with a recent LLVM/MLIR update (https://github.com/llvm/llvm-project/pull/110322). The update replaces `func::FuncOp` with `FunctionOpInterface` in many bufferization-related methods' signature. Now the signature of `FunctionArgTypeConverterFn` should contain `FunctionOpInterface` instead of `func::FuncOp`. Thank you very much!
```c++
 using FunctionArgTypeConverterFn = std::function<BaseMemRefType(
      TensorType, Attribute memorySpace, FunctionOpInterface,
      const BufferizationOptions &)>;
``` 

**Related Changes in LLVM:** 
https://github.com/llvm/llvm-project/pull/110322/files#diff-0a1a3b3003580d05064692dc58271a17ca2d65ea69a11da1cb92f4102fbb1a20L262-L266

