### PR TITLE
Experimental Explicit Stream Annotation

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -253,7 +253,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 #endif
 
   opts.set_xla_gpu_multi_streamed_windowed_einsum(false);
-
+  opts.set_xla_gpu_experimental_stream_annotation(false);
   // Minimum combined size of matrices in matrix multiplication to
   // be rewritten to cuBLAS or Triton kernel call.
   // This threshold is a conservative estimate and has been measured
@@ -1852,6 +1852,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
           &DebugOptions::set_xla_gpu_multi_streamed_windowed_einsum),
       debug_options->xla_gpu_multi_streamed_windowed_einsum(),
       "Whether to run windowed einsum using multiple compute streams."));
+  flag_list->push_back(
+      tsl::Flag("xla_gpu_experimental_stream_annotation",
+                bool_setter_for(
+                    &DebugOptions::set_xla_gpu_experimental_stream_annotation),
+                debug_options->xla_gpu_experimental_stream_annotation(),
+                "Whether to respect explicit stream annotation tags."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_gemm_rewrite_size_threshold",
       int64_setter_for(&DebugOptions::set_xla_gpu_gemm_rewrite_size_threshold),

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -1219,6 +1219,7 @@ cc_library(
         ":call_graph",
         ":hlo_dce",
         ":hlo_domain_isolator",
+        "//xla:side_effect_util",
         "//xla:status_macros",
         "//xla:util",
         "//xla:xla_data_proto_cc",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1680,6 +1680,7 @@ xla_test(
         "//xla:autotune_results_proto_cc",
         "//xla:error_spec",
         "//xla:shape_util",
+        "//xla:side_effect_util",
         "//xla:util",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/utils:hlo_matchers",
@@ -2942,6 +2943,7 @@ cc_library(
     srcs = ["execution_stream_assignment.cc"],
     hdrs = ["execution_stream_assignment.h"],
     deps = [
+        "//xla:side_effect_util",
         "//xla/hlo/ir:hlo",
         "//xla/service:call_graph",
         "//xla/service/gpu/runtime:thunk",

--- a/xla/service/gpu/execution_stream_assignment.cc
+++ b/xla/service/gpu/execution_stream_assignment.cc
@@ -18,11 +18,15 @@ limitations under the License.
 #include <deque>
 #include <memory>
 #include <utility>
+#include <optional>
+#include <string>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
+#include "absl/strings/numbers.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "xla/side_effect_util.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -73,16 +77,18 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
   // Assigns source and destination streams to an instruction and records it in
   // async_instructions_.
   auto assign_async_execution_streams =
-      [&](HloInstruction* instruction, ExecutionStreamId source_stream_id) {
+      [&](HloInstruction* instruction, ExecutionStreamId source_stream_id,
+          std::optional<ExecutionStreamId> dest_stream_id) {
         AsyncExecutionStreamIds streams;
         streams.source_stream_id = source_stream_id;
-        streams.destination_stream_id = next_stream_id;
+        streams.destination_stream_id = dest_stream_id.value_or(next_stream_id);
 
         CHECK(async_instructions_.try_emplace(instruction, streams).second);
-
-        next_stream_id++;
-        if (next_stream_id.value() > options.number_of_execution_streams) {
-          next_stream_id = ExecutionStreamId(1);
+        if (!dest_stream_id.has_value()) {
+          next_stream_id++;
+          if (next_stream_id.value() > options.number_of_execution_streams) {
+            next_stream_id = ExecutionStreamId(1);
+          }
         }
       };
 
@@ -97,7 +103,8 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
       if (instruction->opcode() == HloOpcode::kCopyStart) {
         // CopyStart is morally an async instruction, let us treat it
         // as an async instruction.
-        assign_async_execution_streams(instruction, pending.stream_id);
+        assign_async_execution_streams(instruction, pending.stream_id,
+                                       std::nullopt);
       } else {
         CHECK(sync_instructions_.try_emplace(instruction, pending.stream_id)
                   .second);
@@ -109,11 +116,24 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
          call_graph->GetNode(pending.node).callsites()) {
       if (callsite.instruction()->IsAsynchronous()) {
         // Asynchronous calls will result in a new `ExecutionStreamId` being
-        // dispensed for the called computations.
+        // dispensed for the called computations
         CHECK_EQ(callsite.instruction()->opcode(), HloOpcode::kAsyncStart);
-        enqueue_called_computations(callsite, next_stream_id);
+        // Special logic for explicit stream annotations.
+        std::optional<ExecutionStreamId> optional_stream_id = std::nullopt;
+        auto instr_opcode =
+            callsite.instruction()->async_wrapped_instruction()->opcode();
+        auto instruction = callsite.instruction()->async_wrapped_instruction();
+        auto it = instruction->frontend_attributes().map().find(
+            kXlaStreamAnnotationAttr);
+        if (it != instruction->frontend_attributes().map().end()) {
+          int stream_id;
+          absl::SimpleAtoi(it->second, &stream_id);
+          optional_stream_id = ExecutionStreamId(stream_id);
+        }
+        enqueue_called_computations(
+            callsite, optional_stream_id.value_or(next_stream_id));
         assign_async_execution_streams(callsite.instruction(),
-                                       pending.stream_id);
+                                       pending.stream_id, optional_stream_id);
       } else {
         // Synchronous calls will result in the called computations being
         // invoked using the same `ExecutionStreamId`.

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1171,7 +1171,10 @@ absl::Status RunPostFusionSimplificationPasses(
 
   if (hlo_module->config()
           .debug_options()
-          .xla_gpu_multi_streamed_windowed_einsum()) {
+          .xla_gpu_multi_streamed_windowed_einsum() ||
+      hlo_module->config()
+          .debug_options()
+          .xla_gpu_experimental_stream_annotation()) {
     pipeline.AddPass<StreamAttributeAnnotator>();
     pipeline.AddPass<StreamAttributeAsyncWrapper>();
   }

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -2848,6 +2848,7 @@ cc_library(
     srcs = ["stream_attribute_annotator.cc"],
     hdrs = ["stream_attribute_annotator.h"],
     deps = [
+        "//xla:side_effect_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
@@ -2862,6 +2863,7 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:numbers",
         "@tsl//tsl/platform:statusor",
     ],
 )

--- a/xla/side_effect_util.cc
+++ b/xla/side_effect_util.cc
@@ -55,6 +55,8 @@ const char kXlaQuantizationNumBucketsValueAttr[] =
 
 const char kXlaTableId[] = "_xla_table_id";
 
+const char kXlaStreamAnnotationAttr[] = "_xla_stream_annotation";
+
 const char kXlaBufferPlacementAttr[] = "_xla_buffer_placement";
 
 const char kXlaBufferPlacementParam[] = "arg";

--- a/xla/side_effect_util.h
+++ b/xla/side_effect_util.h
@@ -63,6 +63,9 @@ extern const char kXlaQuantizationNumBucketsValueAttr[];
 // XLA frontend attribute for table id.
 extern const char kXlaTableId[];
 
+// XLA frontend attribute for stream annotation.
+extern const char kXlaStreamAnnotationAttr[];
+
 // XLA frontend attribute for buffer placement.
 extern const char kXlaBufferPlacementAttr[];
 extern const char kXlaBufferPlacementParam[];

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -805,6 +805,9 @@ message DebugOptions {
   // Whether to use multiple compute streams to run windowed einsum.
   bool xla_gpu_multi_streamed_windowed_einsum = 280;
 
+  // Whether to support explicit stream annotations.
+  bool xla_gpu_experimental_stream_annotation = 336;
+
   // If enabled, uses bf16_6way gemm to compute F32 gemm.
   bool xla_gpu_enable_bf16_6way_gemm = 271;
 
@@ -1006,7 +1009,7 @@ message DebugOptions {
   // loop by a factor of two if a collective op is present.
   bool xla_gpu_enable_heuristic_pass_configuration = 332;
 
-  // Next id: 336
+  // Next id: 337
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This is the first PR that is intended to support explicit stream annotations for GPU runtimes.

## Why do we want/need this?

There are a few optimizations that are possible with existing hardware, but they are difficult to generate from XLA. The intention is that by allowing explicit annotation of what stream a subcomputation should run with, we can allow users to define their own stream assignment strategies

1) Communication-Communication overlap 

Certain configurations of parallelization that would allow for overlapping `all-gather` and `all-reduce` operations on independent networking hardware (i.e., one operation is running on NVLinks and the other exclusively using IB). Right now there is no way to do this explicitly in JAX.

2) Compute-Compute overlap

Certain kernels do not utilize all of the SMs for the full duration of their computation, leaving some idling. Other independent compute kernels could utilize these SMs for better e2e performance. We do this already for some of our collective matmul implementations, but there is currently no way to do this explicitly in JAX.

## What are the code changes?

* Added new experimental flag `xla_gpu_experimental_stream_annotation`
* Adding an exception to `CallInliner`.
* Set `operation_queue_id` and add wrapped async operations
* At runtime, the execution stream assignment will use the stream annotation and queue kernels accordingly.


## Current known limitations

* Non-inlined calls aren't well supported by all passes. For example, a single `Add` will not correctly lower to a fusion.
