### PR TITLE
[NVIDIA GPU] Added a predicate function to dot merger to determine eligibility

### DIFF
--- a/xla/service/dot_merger.cc
+++ b/xla/service/dot_merger.cc
@@ -278,10 +278,10 @@ absl::StatusOr<HloInstruction*> TryMergeSameOperand(HloInstruction* a,
   return new_dot;
 }
 
-absl::StatusOr<bool> MergeDots(
-    HloComputation* comp, int64_t max_size_to_merge,
-    std::function<bool(const HloInstruction* a, const HloInstruction* b)>
-        is_compatible) {
+absl::StatusOr<bool> MergeDots(HloComputation* comp, int64_t max_size_to_merge,
+                               std::function<bool(const HloInstruction* dot_a,
+                                                  const HloInstruction* dot_b)>
+                                   can_merge) {
   auto is_merge_candidate = [&](HloInstruction* instr) {
     int64_t bytes = ShapeUtil::ByteSizeOfElements(instr->shape());
     for (const HloInstruction* operand : instr->operands()) {
@@ -397,7 +397,7 @@ absl::StatusOr<bool> MergeDots(
             (!is_merge_candidate(a) && !is_merge_candidate(b)) ||
             // Perform reachability checks last since they can be expensive.
             graph.IsReachableNonConst(a_id, b_id) ||
-            graph.IsReachableNonConst(b_id, a_id) || !is_compatible(a, b)) {
+            graph.IsReachableNonConst(b_id, a_id) || !can_merge(a, b)) {
           continue;
         }
 
@@ -439,7 +439,7 @@ absl::StatusOr<bool> DotMerger::Run(
   for (HloComputation* comp :
        module->MakeNonfusionComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool changed_computation,
-                        MergeDots(comp, max_size_to_merge_, is_compatible_));
+                        MergeDots(comp, max_size_to_merge_, can_merge_));
     changed |= changed_computation;
   }
   return changed;

--- a/xla/service/dot_merger.cc
+++ b/xla/service/dot_merger.cc
@@ -278,8 +278,10 @@ absl::StatusOr<HloInstruction*> TryMergeSameOperand(HloInstruction* a,
   return new_dot;
 }
 
-absl::StatusOr<bool> MergeDots(HloComputation* comp,
-                               int64_t max_size_to_merge) {
+absl::StatusOr<bool> MergeDots(
+    HloComputation* comp, int64_t max_size_to_merge,
+    std::function<bool(const HloInstruction* a, const HloInstruction* b)>
+        is_compatible) {
   auto is_merge_candidate = [&](HloInstruction* instr) {
     int64_t bytes = ShapeUtil::ByteSizeOfElements(instr->shape());
     for (const HloInstruction* operand : instr->operands()) {
@@ -395,7 +397,7 @@ absl::StatusOr<bool> MergeDots(HloComputation* comp,
             (!is_merge_candidate(a) && !is_merge_candidate(b)) ||
             // Perform reachability checks last since they can be expensive.
             graph.IsReachableNonConst(a_id, b_id) ||
-            graph.IsReachableNonConst(b_id, a_id)) {
+            graph.IsReachableNonConst(b_id, a_id) || !is_compatible(a, b)) {
           continue;
         }
 
@@ -437,7 +439,7 @@ absl::StatusOr<bool> DotMerger::Run(
   for (HloComputation* comp :
        module->MakeNonfusionComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool changed_computation,
-                        MergeDots(comp, max_size_to_merge_));
+                        MergeDots(comp, max_size_to_merge_, is_compatible_));
     changed |= changed_computation;
   }
   return changed;

--- a/xla/service/dot_merger.h
+++ b/xla/service/dot_merger.h
@@ -56,8 +56,12 @@ namespace xla {
 // operands to be concatenated.
 class DotMerger : public HloModulePass {
  public:
-  explicit DotMerger(int64_t max_size_to_merge)
-      : max_size_to_merge_(max_size_to_merge) {}
+  explicit DotMerger(
+      int64_t max_size_to_merge,
+      std::function<bool(const HloInstruction* a, const HloInstruction* b)>
+          is_compatible = [](const HloInstruction* a,
+                             const HloInstruction* b) -> bool { return true; })
+      : max_size_to_merge_(max_size_to_merge), is_compatible_(is_compatible) {}
 
   absl::string_view name() const override { return "dot-merger"; }
   using HloPassInterface::Run;
@@ -67,6 +71,9 @@ class DotMerger : public HloModulePass {
 
  private:
   int64_t max_size_to_merge_;
+  // Predicate function for backend-specific compatibility check.
+  std::function<bool(const HloInstruction* a, const HloInstruction* b)>
+      is_compatible_;
 };
 
 }  // namespace xla

--- a/xla/service/dot_merger.h
+++ b/xla/service/dot_merger.h
@@ -59,9 +59,9 @@ class DotMerger : public HloModulePass {
   explicit DotMerger(
       int64_t max_size_to_merge,
       std::function<bool(const HloInstruction* a, const HloInstruction* b)>
-          is_compatible = [](const HloInstruction* a,
-                             const HloInstruction* b) -> bool { return true; })
-      : max_size_to_merge_(max_size_to_merge), is_compatible_(is_compatible) {}
+          can_merge = [](const HloInstruction* dot_a,
+                         const HloInstruction* dot_b) -> bool { return true; })
+      : max_size_to_merge_(max_size_to_merge), can_merge_(can_merge) {}
 
   absl::string_view name() const override { return "dot-merger"; }
   using HloPassInterface::Run;
@@ -72,8 +72,8 @@ class DotMerger : public HloModulePass {
  private:
   int64_t max_size_to_merge_;
   // Predicate function for backend-specific compatibility check.
-  std::function<bool(const HloInstruction* a, const HloInstruction* b)>
-      is_compatible_;
+  std::function<bool(const HloInstruction* dot_a, const HloInstruction* dot_b)>
+      can_merge_;
 };
 
 }  // namespace xla

--- a/xla/service/dot_merger_test.cc
+++ b/xla/service/dot_merger_test.cc
@@ -813,5 +813,30 @@ TEST_F(DotMergerTest, MergeSparseDotsDifferentMetadata) {
   EXPECT_FALSE(changed);
 }
 
+TEST_F(DotMergerTest, NoMergeWithFalseCompatibility) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    lhs0 = f32[2,4,100,200] parameter(0)
+    lhs1 = f32[2,4,300,200] parameter(1)
+    rhs  = f32[2,4,200, 50] parameter(2)
+    dot0 = f32[2,4,100, 50] dot(lhs0, rhs), lhs_batch_dims={0,1}, rhs_batch_dims={0,1},
+                                            lhs_contracting_dims={3}, rhs_contracting_dims={2}
+    dot1 = f32[2,4,300, 50] dot(lhs1, rhs), lhs_batch_dims={0,1}, rhs_batch_dims={0,1},
+                                            lhs_contracting_dims={3}, rhs_contracting_dims={2}
+    ROOT tuple = (f32[2,4,100,50], f32[2,4,300,50]) tuple(dot0, dot1)
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(module_string));
+  std::function<bool(const HloInstruction* a, const HloInstruction* b)>
+      is_compatible = [&](const HloInstruction* a,
+                          const HloInstruction* b) -> bool { return false; };
+  DotMerger pass(/*max_size_to_merge=*/std::numeric_limits<int64_t>::max(),
+                 is_compatible);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, this->RunHloPass(&pass, module.get()));
+  EXPECT_FALSE(changed);
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/dot_merger_test.cc
+++ b/xla/service/dot_merger_test.cc
@@ -829,11 +829,11 @@ TEST_F(DotMergerTest, NoMergeWithFalseCompatibility) {
   })";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(module_string));
-  std::function<bool(const HloInstruction* a, const HloInstruction* b)>
-      is_compatible = [&](const HloInstruction* a,
-                          const HloInstruction* b) -> bool { return false; };
+  std::function<bool(const HloInstruction* dot_a, const HloInstruction* dot_b)>
+      can_merge = [&](const HloInstruction* dot_a,
+                      const HloInstruction* dot_b) -> bool { return false; };
   DotMerger pass(/*max_size_to_merge=*/std::numeric_limits<int64_t>::max(),
-                 is_compatible);
+                 can_merge);
   TF_ASSERT_OK_AND_ASSIGN(bool changed, this->RunHloPass(&pass, module.get()));
   EXPECT_FALSE(changed);
 }

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -798,17 +798,18 @@ absl::Status RunOptimizationPasses(
     // Only merge "smallish" dots.  This threshold defaults to 32MB today, with
     // a flag to override.
     // Do not merge dots when they are assigned different stream ids.
-    std::function<bool(const HloInstruction* a, const HloInstruction* b)>
-        is_compatible =
-            [&](const HloInstruction* a, const HloInstruction* b) -> bool {
-      return a->backend_config<GpuBackendConfig>()->operation_queue_id() ==
-             b->backend_config<GpuBackendConfig>()->operation_queue_id();
+    std::function<bool(const HloInstruction* dot_a,
+                       const HloInstruction* dot_b)>
+        can_merge = [&](const HloInstruction* dot_a,
+                        const HloInstruction* dot_b) -> bool {
+      return dot_a->backend_config<GpuBackendConfig>()->operation_queue_id() ==
+             dot_b->backend_config<GpuBackendConfig>()->operation_queue_id();
     };
     pipeline.AddPass<DotMerger>(
         /*max_size_to_merge=*/int64_t{debug_options
                                           .xla_gpu_dot_merger_threshold_mb()}
             << 20,
-        is_compatible);
+        can_merge);
     pipeline.AddPass<SortSimplifier>();
     pipeline.AddPass<TupleSimplifier>();
     pipeline.AddPass<WhileLoopConstantSinking>();


### PR DESCRIPTION
Expose a predicate function interface through dot merger to pass in backend-specific compatibility check.
This is used in gpu compiler to avoid merging dots that are assigned with 2 different non-default stream ids as they will be optimized separately.