### PR TITLE
Use StableHLO WEEK_4 in GetDefaultStablehloVersion

### DIFF
--- a/xla/pjrt/mlir_to_hlo.cc
+++ b/xla/pjrt/mlir_to_hlo.cc
@@ -245,16 +245,16 @@ absl::Status UpgradeVersionedStablehlo(mlir::ModuleOp mlir_module) {
 }
 
 std::string GetDefaultStablehloVersion(std::optional<int64_t> plugin_version) {
-  // TODO: (b/370803410) Use WEEK_12 in PJRT, some plugins were not up to date,
+  // TODO: (b/370803410) Use WEEK_4 in PJRT, some plugins were not up to date,
   // so temporarily using 1.0.0 to allow them time for a new release.
-  // PJRT v54 released Jun 10, so most plugins should use WEEK_12 by default.
+  // PJRT v54 released Jun 10, so most plugins should use WEEK_4 by default.
   if (plugin_version.has_value() && plugin_version.value() < 54) {
     return "0.19.0";
   }
 
-  // This version must be >=12w old.
+  // This version must be >=4w old.
   return mlir::vhlo::Version::fromCompatibilityRequirement(
-             mlir::vhlo::Version::CompatibilityRequirement::WEEK_12)
+             mlir::vhlo::Version::CompatibilityRequirement::WEEK_4)
       .toString();
 }
 


### PR DESCRIPTION
This is needed to test new Stable HLO types (f8e4m3 and f8e3m8) in JAX on pjrt devices such as GPU.

WEEK_12 currently returns 1.3.0 - too old
f8e4m3 and f8e3m8 dtypes were implemented in Stable HLO 1.7.0 (released on Sep 4, 2024)
WEEK_4 currently returns 1.7.0
Using WEEK_4 in pjrt GetDefaultStablehloVersion() should solve the issue with JAX GPU tests

More details:

- `PjRtCApiCompiler::Compile()` uses `xla::GetDefaultStablehloVersion()` - xla/pjrt/pjrt_c_api_client.cc:2317
- `GetDefaultStablehloVersion` uses mlir::vhlo::Version::CompatibilityRequirement::**WEEK_12** - xla/pjrt/mlir_to_hlo.cc:257
**WEEK_12** returns StableHLO version **1.3.0** instead of 1.7.0

Related JAX PR: https://github.com/jax-ml/jax/pull/23585