### PR TITLE
Added cuDNN 9.5.0 public released version.

### DIFF
--- a/third_party/tsl/third_party/gpus/cuda/hermetic/cuda_redist_versions.bzl
+++ b/third_party/tsl/third_party/gpus/cuda/hermetic/cuda_redist_versions.bzl
@@ -101,6 +101,10 @@ CUDNN_REDIST_JSON_DICT = {
         "https://developer.download.nvidia.com/compute/cudnn/redist/redistrib_9.4.0.json",
         "6eeaafc5cc3d4bb2f283e6298e4c55d4c59d7c83c5d9fd8721a2c0e55aee4e54",
     ],
+    "9.5.0": [
+        "https://developer.download.nvidia.com/compute/cudnn/redist/redistrib_9.5.0.json",
+        "3939f0533fdd0d3aa7edd1ac358d43da18e438e5d8f39c3c15bb72519bad7fb5",
+    ],
 }
 
 # The versions are different for x86 and aarch64 architectures because only


### PR DESCRIPTION
cuDNN public release available at: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/#:~:text=cudnn%2Dlinux%2Dx86_64%2D9.5.0.50_cuda12%2Darchive.tar.xz