### PR TITLE
Enable gpu latency hiding for copy-start/copy-done

### DIFF
--- a/xla/service/gpu/gpu_hlo_schedule_test.cc
+++ b/xla/service/gpu/gpu_hlo_schedule_test.cc
@@ -1670,17 +1670,13 @@ TEST_F(GpuHloScheduleTest, CopyStartDoneScheduled) {
   constexpr absl::string_view kHloCopyStartDone = R"(
     HloModule offloading
       ENTRY main {
-      param_1 = f32[512,1024]{1,0} parameter(1)
-      param_0 = f32[512,1024]{1,0} parameter(0)
-      add.31 = f32[512,1024]{1,0} add(param_0, param_1)
-      tanh.14 = f32[512,1024]{1,0} tanh(add.31)
-      copy-start.1 = (f32[512,1024]{1,0:S(5)}, f32[512,1024]{1,0}, u32[]) copy-start(add.31)
+      param.0 = f32[512,1024]{1,0} parameter(0)
+      tanh.14 = f32[512,1024]{1,0} tanh(param.0)
+      copy-start.1 = (f32[512,1024]{1,0:S(5)}, f32[512,1024]{1,0}, u32[]) copy-start(param.0)
       copy-done.1 = f32[512,1024]{1,0:S(5)} copy-done(copy-start.1)
-      tanh.15 = f32[512,1024]{1,0} tanh(tanh.14)
-      reduce-precision.2 = f32[512,1024]{1,0} reduce-precision(tanh.15), exponent_bits=8, mantissa_bits=23
       copy-start.3 = (f32[512,1024]{1,0}, f32[512,1024]{1,0:S(5)}, u32[]) copy-start(copy-done.1)
       copy-done.3 = f32[512,1024]{1,0} copy-done(copy-start.3)
-      ROOT add.0 = f32[512,1024]{1,0} add(copy-done.3, reduce-precision.2)
+      ROOT add.0 = f32[512,1024]{1,0} add(copy-done.3, tanh.14)
   })";
 
   TF_ASSERT_OK_AND_ASSIGN(
@@ -1692,13 +1688,10 @@ TEST_F(GpuHloScheduleTest, CopyStartDoneScheduled) {
                   module.get(), /*pointer_size=*/8,
                   backend().default_stream_executor()->GetDeviceDescription())
                   .status());
-
   EXPECT_TRUE(*RunFileCheck(module->ToString(), R"(
 // CHECK: ENTRY
 // CHECK: copy-start.3 = (f32[512,1024]{1,0}, f32[512,1024]{1,0:S(5)}, u32[]) copy-start
 // CHECK: tanh.14 = f32[512,1024]{1,0} tanh
-// CHECK: tanh.15 = f32[512,1024]{1,0} tanh
-// CHECK: reduce-precision.2 = f32[512,1024]{1,0} reduce-precision
 // CHECK: copy-done.3 = f32[512,1024]{1,0} copy-done
 )"));
 }

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -95,14 +95,14 @@ bool IsGpuAsyncStart(const HloInstruction& hlo) {
   return (hlo_query::IsAsyncCollectiveStartOp(&hlo,
                                               /*include_send_recv=*/true) &&
           !IsSyncCollective(&hlo)) ||
-         IsAsyncComputeOp(hlo);
+         IsAsyncComputeOp(hlo) || hlo.opcode() == HloOpcode::kCopyStart;
 }
 
 bool IsGpuAsyncDone(const HloInstruction& hlo) {
   return (hlo_query::IsAsyncCollectiveDoneOp(&hlo,
                                              /*include_send_recv=*/true) &&
           !IsSyncCollective(hlo.operand(0))) ||
-         IsAsyncComputeOp(hlo);
+         IsAsyncComputeOp(hlo) || hlo.opcode() == HloOpcode::kCopyDone;
 }
 
 bool IsAsyncPair(const HloInstruction& from, const HloInstruction& target) {

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -91,6 +91,10 @@ std::pair<GpuResourceType, ResourceUsageType> GetP2PResourceAndUsage(
   return {resource, usage};
 }
 
+// Marks async start operations to be scheduled as early as possible.
+// It allows maximum overlap of operations while respecting dependencies.
+// Besides async collectives, copy-start is async memcpy D2H/H2D, the beginning
+// of a host offloading segment.
 bool IsGpuAsyncStart(const HloInstruction& hlo) {
   return (hlo_query::IsAsyncCollectiveStartOp(&hlo,
                                               /*include_send_recv=*/true) &&
@@ -98,6 +102,7 @@ bool IsGpuAsyncStart(const HloInstruction& hlo) {
          IsAsyncComputeOp(hlo) || hlo.opcode() == HloOpcode::kCopyStart;
 }
 
+// Marks async done operations to be scheduled as late as possible.
 bool IsGpuAsyncDone(const HloInstruction& hlo) {
   return (hlo_query::IsAsyncCollectiveDoneOp(&hlo,
                                              /*include_send_recv=*/true) &&

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -214,61 +214,6 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
           Property(&HloInstruction::opcode, HloOpcode::kAllGatherStart)));
 }
 
-// This test verifies that the GPUProfileStatisticsAggregator correctly handles
-// copy-start/copy-done async pairs in the profiling data.
-TEST_F(GpuLatencyHidingSchedulerBaseTest,
-       GPUProfileStatisticsAggregatorCountsMissingAsyncCopyStart) {
-  GPUProfileStatisticsAggregator aggregator;
-  ProfileStatisticsAggregator::Statistics before_stats = aggregator.GetStats();
-
-  ASSERT_EQ(before_stats.missing_instructions.size(), 0);
-  ASSERT_EQ(before_stats.found_instructions_count, 0);
-
-  absl::string_view kFdoProfile = "";
-  absl::string_view kModuleWithCopyStartDone = R"(
-    HloModule m
-
-    ENTRY main {
-      %param_1 = f32[1024]{0} parameter(1)
-      %param_0 = f32[1024]{0} parameter(0)
-      %res_3 = f32[1024]{0} add(f32[1024]{0} %param_0, f32[1024]{0} %param_1)
-      %res_4 = f32[1024]{0} tanh(f32[1024]{0} %res_3)
-      %res_5 = f32[1024]{0} tanh(f32[1024]{0} %res_4)
-      %copy-start = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_3)
-      %copy-done = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start)
-      %res_6 = f32[1024]{0} tanh(f32[1024]{0} %res_5)
-      %copy-start.2 = (f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) copy-start(f32[1024]{0} %res_4)
-      %copy-done.2 = f32[1024]{0:S(5)} copy-done((f32[1024]{0:S(5)}, f32[1024]{0}, u32[]) %copy-start.2)
-      %res_7 = f32[1024]{0} add(f32[1024]{0} %res_6, f32[1024]{0} %res_6)
-      %res_8 = f32[1024]{0} add(f32[1024]{0} %res_7, f32[1024]{0} %res_5)
-      %copy-start.3 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done.2)
-      %copy-done.3 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.3)
-      %res_9 = f32[1024]{0} add(f32[1024]{0} %res_8, f32[1024]{0} %copy-done.3)
-      %copy-start.1 = (f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) copy-start(f32[1024]{0:S(5)} %copy-done)
-      %copy-done.1 = f32[1024]{0} copy-done((f32[1024]{0}, f32[1024]{0:S(5)}, u32[]) %copy-start.1)
-      %res_10 = f32[1024]{0} add(f32[1024]{0} %res_9, f32[1024]{0} %copy-done.1)
-      ROOT %res_11 = f32[1024]{0} tanh(f32[1024]{0} %res_10)
-    }
-  )";
-
-  auto config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
-                                           kModuleWithCopyStartDone, config));
-
-  for (const HloInstruction* instr :
-       module->entry_computation()->instructions()) {
-    for (const HloInstruction* user : instr->users()) {
-      aggregator.HandleMissingInstructionLatency(*instr, *user);
-    }
-  }
-  ProfileStatisticsAggregator::Statistics after_stats = aggregator.GetStats();
-  for (const HloInstruction* instr : after_stats.missing_instructions) {
-    EXPECT_EQ(instr->opcode(), HloOpcode::kCopyStart);
-  }
-  EXPECT_EQ(after_stats.found_instructions_count, 0);
-  EXPECT_EQ(after_stats.missing_instructions.size(), 4);
-}
-
 TEST_F(GpuLatencyHidingSchedulerBaseTest,
        ScheduleGpuModuleErrorsOutOnMissingInstrucitonsForAWhileLoopBody) {
   absl::string_view kFdoProfile = R"pb(


### PR DESCRIPTION
This CL adds copy-start and copy-done instructions to the missing pairs in GPUProfileStatisticsAggregator, enabling correct handling of host memory offloading segments in profiling data. The scheduler optimizes instruction placement by moving copy-start instructions earlier and adjusting copy-done instructions to maximize overlap with computation while ensuring program correctness.
This helps MaxText latency hiding when enabling offloading and scan_layers=false.