### PR TITLE
[ROCm] Fix build issue caused by unnecessary hip_runtime.h include

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -246,6 +246,7 @@ cc_library(
     ]),
     visibility = ["//visibility:public"],
     deps = [
+        ":rocm_driver",
         "//xla/stream_executor:launch_dim",
         "//xla/stream_executor/gpu:gpu_driver_header",
         "//xla/stream_executor/gpu:gpu_executor_header",

--- a/xla/stream_executor/rocm/rocm_kernel.h
+++ b/xla/stream_executor/rocm/rocm_kernel.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_executor.h"
 #include "xla/stream_executor/gpu/gpu_kernel.h"
 #include "xla/stream_executor/launch_dim.h"
+#include "xla/stream_executor/rocm/rocm_driver_wrapper.h"
 #include "tsl/platform/logging.h"
 
 namespace stream_executor::gpu {

--- a/xla/stream_executor/rocm/rocm_kernel.h
+++ b/xla/stream_executor/rocm/rocm_kernel.h
@@ -26,7 +26,6 @@ limitations under the License.
 #include <cstdint>
 
 #include "absl/status/statusor.h"
-#include "rocm/include/hip/hip_runtime.h"
 #include "xla/stream_executor/gpu/gpu_executor.h"
 #include "xla/stream_executor/gpu/gpu_kernel.h"
 #include "xla/stream_executor/launch_dim.h"


### PR DESCRIPTION
Issue was introduced here: https://github.com/openxla/xla/commit/7e2ff2b1405155d7d6db6bdbca14b09165c122db