### PR TITLE
[XLA:GPU] Avoid fusion-wrapping copies

### DIFF
--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1515,6 +1515,21 @@ absl::Status IrEmitterUnnested::EmitFusion(const HloFusionInstruction* instr) {
   return absl::OkStatus();
 }
 
+absl::Status IrEmitterUnnested::EmitCopy(const HloInstruction* instr) {
+  TF_RET_CHECK(LayoutUtil::LayoutsInShapesEqual(instr->operand(0)->shape(),
+                                                instr->shape()));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice src_buffer,
+                      GetAllocationSliceForHlo(instr->operand(0)));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst_buffer,
+                      GetAllocationSliceForHlo(instr));
+  AddThunkToThunkSequence(std::make_unique<DeviceToDeviceCopyThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(instr),
+      /*source_buffer=*/src_buffer,
+      /*destination_buffer=*/dst_buffer,
+      /*mem_size=*/src_buffer.size()));
+  return absl::OkStatus();
+}
+
 absl::Status IrEmitterUnnested::EmitAsyncCustomCallStart(
     const HloInstruction* instr) {
   const HloInstruction* wrapped = instr->async_wrapped_instruction();
@@ -2773,9 +2788,10 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       }
       return EmitCustomCallThunk(custom_call);
     }
-    case HloOpcode::kFusion: {
+    case HloOpcode::kFusion:
       return EmitFusion(Cast<HloFusionInstruction>(instr));
-    }
+    case HloOpcode::kCopy:
+      return EmitCopy(instr);
     case HloOpcode::kInfeed:
       return EmitInfeed(Cast<HloInfeedInstruction>(instr));
     case HloOpcode::kOutfeed:

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -156,6 +156,7 @@ class IrEmitterUnnested : public IrEmitter {
   absl::Status EmitCustomCallThunk(const HloCustomCallInstruction* instr);
   absl::Status EmitFftThunk(const HloFftInstruction* instr);
   absl::Status EmitFusion(const HloFusionInstruction* instr);
+  absl::Status EmitCopy(const HloInstruction* instr);
   absl::Status EmitAsyncCustomCallStart(const HloInstruction* instr);
   absl::Status EmitSelectAndScatter(
       const HloSelectAndScatterInstruction* instr);

--- a/xla/service/gpu/transforms/fusion_wrapper.cc
+++ b/xla/service/gpu/transforms/fusion_wrapper.cc
@@ -62,7 +62,6 @@ absl::StatusOr<bool> FusionWrapper::Run(
       case HloOpcode::kConcatenate:
       case HloOpcode::kConvolution:
       case HloOpcode::kConvert:
-      case HloOpcode::kCopy:
       case HloOpcode::kCos:
       case HloOpcode::kDivide:
       case HloOpcode::kDot:


### PR DESCRIPTION
Fusion wrapping copies breaks the logic for detecting copies from copy-insertion in rematerialization pass.

This patch avoids wrapping copy instructions and instead emits them directly in IrEmitterUnnested.

This should fix https://github.com/openxla/xla/issues/17922