### PR TITLE
Fix dead source code path in XLAFramework dialect

### DIFF
--- a/xla/mlir/framework/ir/xla_framework_ops.td
+++ b/xla/mlir/framework/ir/xla_framework_ops.td
@@ -27,7 +27,7 @@ def XLAFramework_Dialect : Dialect {
   let summary = "Types and operations for xla_framework dialect";
   let description = [{
     This dialect contains operations and types that correspond to XLA compiled C
-    functions in tensorflow/compiler/xla/service/cpu/ir_function.cc.
+    functions in xla/service/cpu/ir_function.cc.
   }];
   let cppNamespace = "::mlir::xla_framework";
 


### PR DESCRIPTION
`tensorflow/compiler/xla/` has already been moved. Seems now we can just use `xla/` since XLA became a standalone project.