### PR TITLE
Bump ml_dtypes version to include MX floating point types

### DIFF
--- a/third_party/tsl/third_party/py/ml_dtypes/ml_dtypes.BUILD
+++ b/third_party/tsl/third_party/py/ml_dtypes/ml_dtypes.BUILD
@@ -32,6 +32,18 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "mxfloat",
+    hdrs = ["include/mxfloat.h"],
+    include_prefix = "ml_dtypes",
+    # Internal headers are all relative to . but other packages
+    # include these headers with the  prefix.
+    includes = [
+        ".",
+        "ml_dtypes",
+    ],
+)
+
 pybind_extension(
     name = "_ml_dtypes_ext",
     srcs = [
@@ -48,6 +60,7 @@ pybind_extension(
     deps = [
         ":float8",
         ":intn",
+        ":mxfloat",
         "@eigen_archive//:eigen3",
         "@tsl//third_party/py/numpy:headers",
     ],

--- a/third_party/tsl/third_party/py/ml_dtypes/workspace.bzl
+++ b/third_party/tsl/third_party/py/ml_dtypes/workspace.bzl
@@ -7,8 +7,8 @@ float8 varieties, and int4.
 load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 
 def repo():
-    ML_DTYPES_COMMIT = "6f02f77c4fa624d8b467c36d1d959a9b49b07900"
-    ML_DTYPES_SHA256 = "c5b421a3b8549c020582b9be5e9edf8bb6e9d4284cbd44b0babe6640b4af18da"
+    ML_DTYPES_COMMIT = "c12281a501469d553483eb4d68065826b9c2fcb5"
+    ML_DTYPES_SHA256 = "cee11c4bed5147bece9e385a88c20887344ad9b89b3acb09bf3d7c9c21fb9715"
     tf_http_archive(
         name = "ml_dtypes",
         build_file = "//third_party/py/ml_dtypes:ml_dtypes.BUILD",

--- a/third_party/tsl/tsl/platform/BUILD
+++ b/third_party/tsl/tsl/platform/BUILD
@@ -1065,6 +1065,7 @@ cc_library(
     deps = [
         "@ml_dtypes//:float8",
         "@ml_dtypes//:intn",
+        "@ml_dtypes//:mxfloat",
     ],
 )
 

--- a/third_party/tsl/tsl/platform/ml_dtypes.h
+++ b/third_party/tsl/tsl/platform/ml_dtypes.h
@@ -16,10 +16,14 @@ limitations under the License.
 #ifndef TENSORFLOW_TSL_PLATFORM_ML_DTYPES_H_
 #define TENSORFLOW_TSL_PLATFORM_ML_DTYPES_H_
 
-#include "ml_dtypes/include/float8.h"  // from @ml_dtypes
-#include "ml_dtypes/include/intn.h"  // from @ml_dtypes
+#include "ml_dtypes/include/float8.h"   // from @ml_dtypes
+#include "ml_dtypes/include/intn.h"     // from @ml_dtypes
+#include "ml_dtypes/include/mxfloat.h"  // from @ml_dtypes
 
 namespace tsl {
+using float4_e2m1fn = ::ml_dtypes::float4_e2m1fn;
+using float6_e2m3fn = ::ml_dtypes::float6_e2m3fn;
+using float6_e3m2fn = ::ml_dtypes::float6_e3m2fn;
 using float8_e3m4 = ::ml_dtypes::float8_e3m4;
 using float8_e4m3 = ::ml_dtypes::float8_e4m3;
 using float8_e4m3fn = ::ml_dtypes::float8_e4m3fn;
@@ -27,6 +31,7 @@ using float8_e4m3fnuz = ::ml_dtypes::float8_e4m3fnuz;
 using float8_e4m3b11fnuz = ::ml_dtypes::float8_e4m3b11fnuz;
 using float8_e5m2 = ::ml_dtypes::float8_e5m2;
 using float8_e5m2fnuz = ::ml_dtypes::float8_e5m2fnuz;
+using float8_e8m0fnu = ::ml_dtypes::float8_e8m0fnu;
 
 using int2 = ::ml_dtypes::int2;
 using uint2 = ::ml_dtypes::uint2;


### PR DESCRIPTION
Bumping the jax-ml/ml_dtypes version:
1. Unblocks the implementation of MX floating point types in XLA ([RFC](https://github.com/openxla/xla/discussions/18085))
2. Allows enabling E3M4/E4M3 dtypes in XLA python client ([example](https://github.com/openxla/xla/blob/main/xla/python/xla_client.py#L279))