### PR TITLE
[XLA:GPU] Simplifies All-Reduce if they can be simplified or are degenerated.

### DIFF
--- a/xla/service/all_reduce_simplifier.h
+++ b/xla/service/all_reduce_simplifier.h
@@ -30,9 +30,6 @@ namespace xla {
 // replaced by a multiply with the replica count.
 class AllReduceSimplifier : public HloModulePass {
  public:
-  explicit AllReduceSimplifier(int64_t replica_count)
-      : replica_count_(replica_count) {}
-  ~AllReduceSimplifier() override = default;
   absl::string_view name() const override { return "all-reduce-simp"; }
 
   // Run all-reduce simplification on the given computation. Returns whether the
@@ -41,9 +38,6 @@ class AllReduceSimplifier : public HloModulePass {
   absl::StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
-
- private:
-  int64_t replica_count_;
 };
 
 }  // namespace xla

--- a/xla/service/all_reduce_simplifier_test.cc
+++ b/xla/service/all_reduce_simplifier_test.cc
@@ -76,7 +76,7 @@ test {
 )";
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
                                            kModuleStr, /*replica_count=*/8));
-  AllReduceSimplifier simplifier(/*replica_count=*/8);
+  AllReduceSimplifier simplifier;
   ASSERT_TRUE(simplifier.Run(module.get()).value());
   EXPECT_THAT(
       module->entry_computation()->root_instruction(),
@@ -112,7 +112,7 @@ test {
 )";
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
                                            kModuleStr, /*replica_count=*/8));
-  AllReduceSimplifier simplifier(/*replica_count=*/8);
+  AllReduceSimplifier simplifier;
   ASSERT_TRUE(simplifier.Run(module.get()).value());
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::MultiplyAnyOrder(
@@ -153,7 +153,7 @@ test {
 )";
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
                                            kModuleStr, /*replica_count=*/8));
-  AllReduceSimplifier simplifier(/*replica_count=*/8);
+  AllReduceSimplifier simplifier;
   ASSERT_TRUE(simplifier.Run(module.get()).value());
   EXPECT_THAT(
       module->entry_computation()->root_instruction(),
@@ -183,7 +183,7 @@ test {
 )";
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
                                            kModuleStr, /*replica_count=*/8));
-  AllReduceSimplifier simplifier(/*replica_count=*/8);
+  AllReduceSimplifier simplifier;
   EXPECT_TRUE(simplifier.Run(module.get()).value());
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::Parameter(0)));
@@ -213,7 +213,7 @@ test {
       auto module, ParseAndReturnVerifiedModule(kModuleStr, /*replica_count=*/1,
                                                 /*num_partitions=*/8));
   module->mutable_config().set_use_spmd_partitioning(true);
-  AllReduceSimplifier simplifier(/*replica_count=*/1);
+  AllReduceSimplifier simplifier;
   EXPECT_TRUE(simplifier.Run(module.get()).value());
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::Parameter(0)));
@@ -248,7 +248,7 @@ test {
       auto module, ParseAndReturnVerifiedModule(kModuleStr, /*replica_count=*/1,
                                                 /*num_partitions=*/8));
   module->mutable_config().set_use_spmd_partitioning(true);
-  AllReduceSimplifier simplifier(/*replica_count=*/1);
+  AllReduceSimplifier simplifier;
   EXPECT_FALSE(simplifier.Run(module.get()).value());
 }
 
@@ -275,7 +275,7 @@ test {
                                                 /*num_partitions=*/1));
   // Mark as MPMD.
   module->mutable_config().set_use_spmd_partitioning(false);
-  AllReduceSimplifier simplifier(/*replica_count=*/2);
+  AllReduceSimplifier simplifier;
   EXPECT_FALSE(simplifier.Run(module.get()).value());
 }
 }  // namespace

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1496,6 +1496,7 @@ cc_library(
         "//xla/service:all_reduce_folder",
         "//xla/service:all_reduce_promotion",
         "//xla/service:all_reduce_reassociate",
+        "//xla/service:all_reduce_simplifier",
         "//xla/service:async_collective_creator",
         "//xla/service:batched_gather_scatter_normalizer",
         "//xla/service:batchnorm_expander",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -79,6 +79,7 @@ limitations under the License.
 #include "xla/service/all_reduce_folder.h"
 #include "xla/service/all_reduce_promotion.h"
 #include "xla/service/all_reduce_reassociate.h"
+#include "xla/service/all_reduce_simplifier.h"
 #include "xla/service/async_collective_creator.h"
 #include "xla/service/batched_gather_scatter_normalizer.h"
 #include "xla/service/batchnorm_expander.h"
@@ -843,6 +844,7 @@ absl::Status RunCollectiveOptimizationPasses(
   const DebugOptions& debug_options = hlo_module->config().debug_options();
 
   HloPassPipeline collectives_pipeline("collective-optimizations");
+  collectives_pipeline.AddPass<AllReduceSimplifier>();
   collectives_pipeline.AddPass<AllReduceFolder>();
   collectives_pipeline.AddPass<AllReduceSplitter>();
   collectives_pipeline.AddPass<AllGatherOptimizer>();

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -882,6 +882,8 @@ cc_library(
     srcs = ["simple_optimization_test.cc"],
     tags = tf_cuda_tests_tags(),
     deps = [
+        "//xla/service:pattern_matcher",
+        "//xla/service:pattern_matcher_gmock",
         "//xla/tests:hlo_test_base",
         "//xla/tests:xla_internal_test_main",
         "//xla/tsl/lib/core:status_test_util",

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -973,3 +973,15 @@ xla_test(
         "@tsl//tsl/platform:test_main",
     ],
 )
+
+xla_test(
+    name = "gpu_compiler_e2e_test",
+    srcs = ["gpu_compiler_e2e_test.cc"],
+    backends = ["gpu"],
+    deps = [
+        "//xla/service:pattern_matcher",
+        "//xla/service:pattern_matcher_gmock",
+        "//xla/tests:hlo_test_base",
+        "@tsl//tsl/platform:test_main",
+    ],
+)

--- a/xla/service/gpu/tests/gpu_compiler_e2e_test.cc
+++ b/xla/service/gpu/tests/gpu_compiler_e2e_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2023 The OpenXLA Authors.
+/* Copyright 2024 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@ limitations under the License.
 ==============================================================================*/
 
 #include "absl/strings/string_view.h"
+#include "xla/service/pattern_matcher.h"
+#include "xla/service/pattern_matcher_gmock.h"
 #include "xla/tests/hlo_test_base.h"
 #include "xla/tsl/lib/core/status_test_util.h"
 
@@ -21,21 +23,33 @@ namespace xla {
 namespace gpu {
 namespace {
 
-class SimpleOptimizationTest : public HloTestBase {};
+namespace m = match;
 
-TEST_F(SimpleOptimizationTest, OptimizeModule) {
+class GpuCompilerE2ETest : public HloTestBase {};
+
+TEST_F(GpuCompilerE2ETest, DegeneratedAllReduceRemoval) {
   constexpr absl::string_view kHloText = R"(
-HloModule t
+HloModule m
 
-ENTRY e {
-  p0 = f16[1,16,17,3] parameter(0)
-  p1 = s8[16,17,3] parameter(1)
-  cp1 = f16[16,17,3] convert(p1)
-  ROOT _ = f16[1,16,16] dot(p0, cp1),
-    lhs_contracting_dims={2,3}, rhs_contracting_dims={1,2}
-})";
+sum {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  ROOT add.2 = f32[] add(a, b)
+}
 
-  TF_EXPECT_OK(GetOptimizedModule(kHloText).status());
+main {
+  p0 = f32[8,16] parameter(0), parameter_replication={false}
+  ROOT all-reduce = f32[8,16] all-reduce(p0),
+    channel_id=1,
+    use_global_device_ids=true,
+    replica_groups={{0},{1},{2},{3},{4},{5},{6},{7}},
+    to_apply=sum
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto optimized_module, GetOptimizedModule(kHloText));
+  EXPECT_THAT(optimized_module->entry_computation()->root_instruction(),
+              GmockMatch(m::Parameter(0)));
 }
 
 }  // namespace

--- a/xla/service/gpu/tests/gpu_compiler_e2e_test.cc
+++ b/xla/service/gpu/tests/gpu_compiler_e2e_test.cc
@@ -47,9 +47,14 @@ main {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto optimized_module, GetOptimizedModule(kHloText));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kHloText, /*replica_count=*/1,
+                                                /*num_partitions=*/8));
+  module->mutable_config().set_use_spmd_partitioning(true);
+  TF_ASSERT_OK_AND_ASSIGN(auto optimized_module,
+                          GetOptimizedModule(std::move(module)));
   EXPECT_THAT(optimized_module->entry_computation()->root_instruction(),
-              GmockMatch(m::Parameter(0)));
+              GmockMatch(m::Copy(m::Parameter(0))));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR adds back the AllReduceSimplifier pass to the GPU compiler as in some cases we see JAX programs will add some degenerated psum to the HLOs,

Code pointer in JAX:
1) https://cs.opensource.google/jax/jax/+/main:jax/experimental/shard_map.py;drc=875f44c63a6c0f082ef3b228559e86e1d0a398d1;l=1674
2) pbroadcast to psum conversions. 

The compiler should generally remove these unnecessary ARs so that it unblocks many optimizations like collective pipeliner. It also emits unncessary runtime thunks as well.