### PR TITLE
[NVIDIA GPU] Add a new option to enable windowed einsum based on total flops of the gemm

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -230,7 +230,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_cub_radix_sort(true);
   opts.set_xla_gpu_enable_cudnn_layer_norm(false);
   opts.set_xla_gpu_threshold_for_windowed_einsum_mib(100000);
-  opts.set_xla_gpu_total_bytes_threshold_for_windowed_einsum(-1);
+  opts.set_xla_gpu_operand_bytes_threshold_for_windowed_einsum(-1);
 
   opts.set_xla_gpu_enable_triton_hopper(false);
   opts.set_xla_gpu_experimental_enable_fusion_block_level_rewriter(false);
@@ -1800,12 +1800,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "larger than this threshold will be transformed to use windowed einsums."
       "Default is 100000"));
   flag_list->push_back(tsl::Flag(
-      "xla_gpu_total_bytes_threshold_for_windowed_einsum",
+      "xla_gpu_operand_bytes_threshold_for_windowed_einsum",
       int64_setter_for(
-          &DebugOptions::set_xla_gpu_total_bytes_threshold_for_windowed_einsum),
-      debug_options->xla_gpu_total_bytes_threshold_for_windowed_einsum(),
+          &DebugOptions::
+              set_xla_gpu_operand_bytes_threshold_for_windowed_einsum),
+      debug_options->xla_gpu_operand_bytes_threshold_for_windowed_einsum(),
       "This controls whether to enable windowed einsum (collective matmul) "
-      "based on the total flops(combined sizes of both operands) if set >= 0."
+      "based on the sum of sizes of 2 operands if set >= 0."
       "If set >= 0, xla_gpu_threshold_for_windowed_einsum_mib is ignored."
       "Default is -1"));
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -230,7 +230,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_cub_radix_sort(true);
   opts.set_xla_gpu_enable_cudnn_layer_norm(false);
   opts.set_xla_gpu_threshold_for_windowed_einsum_mib(100000);
-  opts.set_xla_gpu_total_flops_threshold_for_windowed_einsum(-1);
+  opts.set_xla_gpu_total_bytes_threshold_for_windowed_einsum(-1);
 
   opts.set_xla_gpu_enable_triton_hopper(false);
   opts.set_xla_gpu_experimental_enable_fusion_block_level_rewriter(false);
@@ -1800,13 +1800,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "larger than this threshold will be transformed to use windowed einsums."
       "Default is 100000"));
   flag_list->push_back(tsl::Flag(
-      "xla_gpu_total_flops_threshold_for_windowed_einsum",
+      "xla_gpu_total_bytes_threshold_for_windowed_einsum",
       int64_setter_for(
-          &DebugOptions::set_xla_gpu_total_flops_threshold_for_windowed_einsum),
-      debug_options->xla_gpu_total_flops_threshold_for_windowed_einsum(),
+          &DebugOptions::set_xla_gpu_total_bytes_threshold_for_windowed_einsum),
+      debug_options->xla_gpu_total_bytes_threshold_for_windowed_einsum(),
       "This controls whether to enable windowed einsum (collective matmul) "
       "based on the total flops(combined sizes of both operands) if set >= 0."
-      "This flag overrides xla_gpu_threshold_for_windowed_einsum_mib."
+      "If set >= 0, xla_gpu_threshold_for_windowed_einsum_mib is ignored."
       "Default is -1"));
 
   flag_list->push_back(tsl::Flag(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -230,6 +230,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_cub_radix_sort(true);
   opts.set_xla_gpu_enable_cudnn_layer_norm(false);
   opts.set_xla_gpu_threshold_for_windowed_einsum_mib(100000);
+  opts.set_xla_gpu_total_flops_threshold_for_windowed_einsum(-1);
 
   opts.set_xla_gpu_enable_triton_hopper(false);
   opts.set_xla_gpu_experimental_enable_fusion_block_level_rewriter(false);
@@ -1798,6 +1799,16 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "Einsums that have partitioned operand(can be either LHS or RHS) that's "
       "larger than this threshold will be transformed to use windowed einsums."
       "Default is 100000"));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_total_flops_threshold_for_windowed_einsum",
+      int64_setter_for(
+          &DebugOptions::set_xla_gpu_total_flops_threshold_for_windowed_einsum),
+      debug_options->xla_gpu_total_flops_threshold_for_windowed_einsum(),
+      "This controls whether to enable windowed einsum (collective matmul) "
+      "based on the total flops(combined sizes of both operands) if set >= 0."
+      "This flag overrides xla_gpu_threshold_for_windowed_einsum_mib."
+      "Default is -1"));
+
   flag_list->push_back(tsl::Flag(
       "xla_gpu_enable_triton_hopper",
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_triton_hopper),

--- a/xla/service/gpu/gpu_spmd_pipeline.cc
+++ b/xla/service/gpu/gpu_spmd_pipeline.cc
@@ -102,13 +102,14 @@ void AddSPMDPasses(
         /*is_spmd=*/true, /*propagate_metadata=*/false,
         config.allow_spmd_sharding_propagation_to_output());
   }
-  std::optional<int64_t> flops_threshold = std::nullopt;
+  std::optional<int64_t> oper_size_threshold = std::nullopt;
   if (hlo_module->config()
           .debug_options()
-          .xla_gpu_total_bytes_threshold_for_windowed_einsum() >= 0) {
-    flops_threshold = hlo_module->config()
-                          .debug_options()
-                          .xla_gpu_total_bytes_threshold_for_windowed_einsum();
+          .xla_gpu_operand_bytes_threshold_for_windowed_einsum() >= 0) {
+    oper_size_threshold =
+        hlo_module->config()
+            .debug_options()
+            .xla_gpu_operand_bytes_threshold_for_windowed_einsum();
   }
   spmd_pipeline.AddPass<spmd::StatefulRngSpmdPartitioner>(
       num_partitions, hlo_module->config().replica_count(),
@@ -119,7 +120,7 @@ void AddSPMDPasses(
           .debug_options()
           .xla_gpu_multi_streamed_windowed_einsum(),
       /*skip_checking_windowed_einsum_users=*/true,
-      /*disable_ag_rewrite_for_multiple_consumers=*/true, flops_threshold);
+      /*disable_ag_rewrite_for_multiple_consumers=*/true, oper_size_threshold);
   spmd_pipeline.AddPass<CollectivePermuteMotion>();
 }
 

--- a/xla/service/gpu/gpu_spmd_pipeline.cc
+++ b/xla/service/gpu/gpu_spmd_pipeline.cc
@@ -111,7 +111,14 @@ void AddSPMDPasses(
           .debug_options()
           .xla_gpu_multi_streamed_windowed_einsum(),
       /*skip_checking_windowed_einsum_users=*/true,
-      /*disable_ag_rewrite_for_multiple_consumers=*/true);
+      /*disable_ag_rewrite_for_multiple_consumers=*/true,
+      hlo_module->config()
+                  .debug_options()
+                  .xla_gpu_total_flops_threshold_for_windowed_einsum() >= 0
+          ? hlo_module->config()
+                .debug_options()
+                .xla_gpu_total_flops_threshold_for_windowed_einsum()
+          : std::nullopt);
   spmd_pipeline.AddPass<CollectivePermuteMotion>();
 }
 

--- a/xla/service/spmd/dot_handler.cc
+++ b/xla/service/spmd/dot_handler.cc
@@ -454,6 +454,19 @@ bool RequiresTransposeSharding(
          has_different_lhs_rhs_dim_sharding;
 }
 
+bool should_enable_windowed_einsum_with_threshold(
+    const SpmdPartitionerOptions& options, int64_t total_flops,
+    int64_t operand_or_output_shape_size) {
+  if (options.total_flops_windowed_einsum_threshold != std::nullopt) {
+    int64_t total_flops_threshold =
+        options.total_flops_windowed_einsum_threshold.value();
+    return total_flops >= total_flops_threshold;
+  } else {
+    return operand_or_output_shape_size * 1024 * 1024 >=
+           options.threshold_for_windowed_einsum_mib;
+  }
+}
+
 std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
     int64_t num_partitions, int64_t output_lhs_non_contracting_partitions,
     int64_t output_rhs_non_contracting_partitions,
@@ -663,8 +676,8 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
 
   if (output_lhs_non_contracting_partitions == num_partitions &&
       output_sharding_transposed_to_match_lhs == lhs_sharding &&
-      rhs_shape_size >=
-          options.threshold_for_windowed_einsum_mib * 1024 * 1024 &&
+      should_enable_windowed_einsum_with_threshold(
+          options, (rhs_shape_size + lhs_shape_size), rhs_shape_size) &&
       (!rhs || check_users_sharding(rhs)) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/false, /*rhs_needs_ag=*/true) &&
       options.enable_windowed_einsum_for_all_gather) {
@@ -695,8 +708,8 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
   }
   if (output_rhs_non_contracting_partitions == num_partitions &&
       output_sharding_transposed_to_match_rhs == rhs_sharding &&
-      lhs_shape_size >=
-          options.threshold_for_windowed_einsum_mib * 1024 * 1024 &&
+      should_enable_windowed_einsum_with_threshold(
+          options, (rhs_shape_size + lhs_shape_size), lhs_shape_size) &&
       (!lhs || check_users_sharding(lhs)) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/true, /*rhs_needs_ag=*/false) &&
       options.enable_windowed_einsum_for_all_gather) {
@@ -729,8 +742,8 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
       lhs_contracting_partitions == num_partitions &&
       (output_lhs_non_contracting_partitions == num_partitions ||
        output_rhs_non_contracting_partitions == num_partitions) &&
-      output_shape_size >=
-          options.threshold_for_windowed_einsum_mib * 1024 * 1024 &&
+      should_enable_windowed_einsum_with_threshold(
+          options, (rhs_shape_size + lhs_shape_size), output_shape_size) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/false,
                                /*rhs_needs_ag=*/false) &&
       options.enable_windowed_einsum_for_reduce_scatter) {

--- a/xla/service/spmd/dot_handler.cc
+++ b/xla/service/spmd/dot_handler.cc
@@ -455,15 +455,15 @@ bool RequiresTransposeSharding(
 }
 
 bool should_enable_windowed_einsum_with_threshold(
-    const SpmdPartitionerOptions& options, int64_t total_flops,
+    const SpmdPartitionerOptions& options, int64_t total_operand_bytes,
     int64_t operand_or_output_shape_size) {
   if (options.total_bytes_windowed_einsum_threshold != std::nullopt) {
-    int64_t total_flops_threshold =
+    int64_t operand_bytes_threshold =
         options.total_bytes_windowed_einsum_threshold.value();
-    return total_flops >= total_flops_threshold;
+    return total_operand_bytes >= operand_bytes_threshold;
   } else {
-    return operand_or_output_shape_size * 1024 * 1024 >=
-           options.threshold_for_windowed_einsum_mib;
+    return operand_or_output_shape_size >=
+           options.threshold_for_windowed_einsum_mib * 1024 * 1024;
   }
 }
 

--- a/xla/service/spmd/dot_handler.cc
+++ b/xla/service/spmd/dot_handler.cc
@@ -460,6 +460,9 @@ bool should_enable_windowed_einsum_with_threshold(
   if (options.total_flops_windowed_einsum_threshold != std::nullopt) {
     int64_t total_flops_threshold =
         options.total_flops_windowed_einsum_threshold.value();
+    LOG(ERROR) << "TOTAL FLOPS: " << total_flops;
+    LOG(ERROR) << "TOTAL total_flops_threshold: " << total_flops_threshold;
+
     return total_flops >= total_flops_threshold;
   } else {
     return operand_or_output_shape_size * 1024 * 1024 >=
@@ -677,7 +680,10 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
   if (output_lhs_non_contracting_partitions == num_partitions &&
       output_sharding_transposed_to_match_lhs == lhs_sharding &&
       should_enable_windowed_einsum_with_threshold(
-          options, (rhs_shape_size + lhs_shape_size), rhs_shape_size) &&
+          options,
+          (ShapeUtil::ByteSizeOf(rhs->shape()) +
+           ShapeUtil::ByteSizeOf(lhs->shape())),
+          rhs_shape_size) &&
       (!rhs || check_users_sharding(rhs)) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/false, /*rhs_needs_ag=*/true) &&
       options.enable_windowed_einsum_for_all_gather) {
@@ -709,7 +715,10 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
   if (output_rhs_non_contracting_partitions == num_partitions &&
       output_sharding_transposed_to_match_rhs == rhs_sharding &&
       should_enable_windowed_einsum_with_threshold(
-          options, (rhs_shape_size + lhs_shape_size), lhs_shape_size) &&
+          options,
+          (ShapeUtil::ByteSizeOf(rhs->shape()) +
+           ShapeUtil::ByteSizeOf(lhs->shape())),
+          lhs_shape_size) &&
       (!lhs || check_users_sharding(lhs)) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/true, /*rhs_needs_ag=*/false) &&
       options.enable_windowed_einsum_for_all_gather) {
@@ -743,7 +752,10 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
       (output_lhs_non_contracting_partitions == num_partitions ||
        output_rhs_non_contracting_partitions == num_partitions) &&
       should_enable_windowed_einsum_with_threshold(
-          options, (rhs_shape_size + lhs_shape_size), output_shape_size) &&
+          options,
+          (ShapeUtil::ByteSizeOf(rhs->shape()) +
+           ShapeUtil::ByteSizeOf(lhs->shape())),
+          output_shape_size) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/false,
                                /*rhs_needs_ag=*/false) &&
       options.enable_windowed_einsum_for_reduce_scatter) {

--- a/xla/service/spmd/dot_handler.cc
+++ b/xla/service/spmd/dot_handler.cc
@@ -455,9 +455,14 @@ bool RequiresTransposeSharding(
 }
 
 bool should_enable_windowed_einsum_with_threshold(
-    const SpmdPartitionerOptions& options, int64_t total_operand_bytes,
-    int64_t operand_or_output_shape_size) {
+    const SpmdPartitionerOptions& options, const HloInstruction* lhs,
+    const HloInstruction* rhs, int64_t operand_or_output_shape_size) {
   if (options.total_bytes_windowed_einsum_threshold != std::nullopt) {
+    if (lhs == nullptr || rhs == nullptr) {
+      return false;
+    }
+    int64_t total_operand_bytes = (ShapeUtil::ByteSizeOf(rhs->shape()) +
+                                   ShapeUtil::ByteSizeOf(lhs->shape()));
     int64_t operand_bytes_threshold =
         options.total_bytes_windowed_einsum_threshold.value();
     return total_operand_bytes >= operand_bytes_threshold;
@@ -676,11 +681,8 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
 
   if (output_lhs_non_contracting_partitions == num_partitions &&
       output_sharding_transposed_to_match_lhs == lhs_sharding &&
-      should_enable_windowed_einsum_with_threshold(
-          options,
-          (ShapeUtil::ByteSizeOf(rhs->shape()) +
-           ShapeUtil::ByteSizeOf(lhs->shape())),
-          rhs_shape_size) &&
+      should_enable_windowed_einsum_with_threshold(options, lhs, rhs,
+                                                   rhs_shape_size) &&
       (!rhs || check_users_sharding(rhs)) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/false, /*rhs_needs_ag=*/true) &&
       options.enable_windowed_einsum_for_all_gather) {
@@ -711,11 +713,8 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
   }
   if (output_rhs_non_contracting_partitions == num_partitions &&
       output_sharding_transposed_to_match_rhs == rhs_sharding &&
-      should_enable_windowed_einsum_with_threshold(
-          options,
-          (ShapeUtil::ByteSizeOf(rhs->shape()) +
-           ShapeUtil::ByteSizeOf(lhs->shape())),
-          lhs_shape_size) &&
+      should_enable_windowed_einsum_with_threshold(options, lhs, rhs,
+                                                   lhs_shape_size) &&
       (!lhs || check_users_sharding(lhs)) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/true, /*rhs_needs_ag=*/false) &&
       options.enable_windowed_einsum_for_all_gather) {
@@ -748,11 +747,8 @@ std::optional<WindowedEinsumConfig> GetWindowedEinsumConfiguration(
       lhs_contracting_partitions == num_partitions &&
       (output_lhs_non_contracting_partitions == num_partitions ||
        output_rhs_non_contracting_partitions == num_partitions) &&
-      should_enable_windowed_einsum_with_threshold(
-          options,
-          (ShapeUtil::ByteSizeOf(rhs->shape()) +
-           ShapeUtil::ByteSizeOf(lhs->shape())),
-          output_shape_size) &&
+      should_enable_windowed_einsum_with_threshold(options, lhs, rhs,
+                                                   output_shape_size) &&
       !disable_windowed_einsum(/*lhs_needs_ag=*/false,
                                /*rhs_needs_ag=*/false) &&
       options.enable_windowed_einsum_for_reduce_scatter) {

--- a/xla/service/spmd/dot_handler.cc
+++ b/xla/service/spmd/dot_handler.cc
@@ -457,12 +457,9 @@ bool RequiresTransposeSharding(
 bool should_enable_windowed_einsum_with_threshold(
     const SpmdPartitionerOptions& options, int64_t total_flops,
     int64_t operand_or_output_shape_size) {
-  if (options.total_flops_windowed_einsum_threshold != std::nullopt) {
+  if (options.total_bytes_windowed_einsum_threshold != std::nullopt) {
     int64_t total_flops_threshold =
-        options.total_flops_windowed_einsum_threshold.value();
-    LOG(ERROR) << "TOTAL FLOPS: " << total_flops;
-    LOG(ERROR) << "TOTAL total_flops_threshold: " << total_flops_threshold;
-
+        options.total_bytes_windowed_einsum_threshold.value();
     return total_flops >= total_flops_threshold;
   } else {
     return operand_or_output_shape_size * 1024 * 1024 >=

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -117,6 +117,11 @@ struct SpmdPartitionerOptions {
   // Partitioning method to prioritize for scatter operations.
   PartitioningMethod scatter_partition_method =
       PartitioningMethod::kIndexParallel;
+
+  // The minimum size to enable windowed einsum in total flops.
+  // This combines sizes in bytes of both operands.
+  // When it's set, it will override threshold_for_windowed_einsum_mib.
+  std::optional<int64_t> total_flops_windowed_einsum_threshold = std::nullopt;
 };
 
 // Class to wrap the computation builder to capture information during SPMD

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -118,10 +118,10 @@ struct SpmdPartitionerOptions {
   PartitioningMethod scatter_partition_method =
       PartitioningMethod::kIndexParallel;
 
-  // The minimum size to enable windowed einsum in total flops.
+  // The minimum size to enable windowed einsum in total bytes.
   // This combines sizes in bytes of both operands.
   // When it's set, it will override threshold_for_windowed_einsum_mib.
-  std::optional<int64_t> total_flops_windowed_einsum_threshold = std::nullopt;
+  std::optional<int64_t> total_bytes_windowed_einsum_threshold = std::nullopt;
 };
 
 // Class to wrap the computation builder to capture information during SPMD

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -76,7 +76,9 @@ class SpmdPartitioningTest
       bool bidirectional_windowed_einsum = false,
       int64_t threshold_for_windowed_einsum_mib = -1,
       PartitioningMethod gather_method = PartitioningMethod::kIndexParallel,
-      PartitioningMethod scatter_method = PartitioningMethod::kIndexParallel) {
+      PartitioningMethod scatter_method = PartitioningMethod::kIndexParallel,
+      std::optional<int64_t> total_bytes_windowed_einsum_threshold =
+          std::nullopt) {
     // Some tests (BackpropFilter convs) set this flag false to test two
     // different paths of the implementation.
     SpmdPartitionerOptions options;
@@ -86,6 +88,8 @@ class SpmdPartitioningTest
         choose_faster_windowed_einsum;
     options.unroll_windowed_einsum = unroll_windowed_einsum;
     options.bidirectional_windowed_einsum = bidirectional_windowed_einsum;
+    options.total_bytes_windowed_einsum_threshold =
+        total_bytes_windowed_einsum_threshold;
     if (threshold_for_windowed_einsum_mib >= 0) {
       options.threshold_for_windowed_einsum_mib =
           threshold_for_windowed_einsum_mib;
@@ -4903,6 +4907,34 @@ ENTRY entry {
       CHECK_EQ(rhs_batch_dims[1], 1);
     }
   }
+}
+
+TEST_P(SpmdPartitioningTest, WindowedEinsumNoRewriteWithTotalBytesThreshold) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  %p0 = f32[2048,2,3264]{2,1,0} parameter(0), sharding={devices=[1,1,2]0,1}
+  %p1 = f32[2,3264,2176]{2,1,0} parameter(1), sharding={devices=[2,1,1]0,1}
+  ROOT %dot.224 = f32[2048,2176]{1,0} dot(f32[2048,2,3264]{2,1,0} %p0, f32[2,3264,2176]{2,1,0} %p1), lhs_contracting_dims={1,2}, rhs_contracting_dims={0,1}, sharding={devices=[1,2]0,1}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      PartitionComputation(hlo_string, /*num_devices=*/2,
+                           /*conv_halo_exchange_always_on_lhs=*/true,
+                           /*choose_faster_windowed_einsum=*/false,
+                           /*unroll_windowed_einsum=*/false,
+                           /*bidirectional_windowed_einsum=*/false,
+                           /*threshold_for_windowed_einsum_mib=*/5,
+                           PartitioningMethod::kIndexParallel,
+                           PartitioningMethod::kIndexParallel,
+                           /*total_bytes_windowed_einsum_threshold=*/1 << 30));
+  VLOG(1) << module->ToString();
+  // Total bytes threshold overrides threshold_for_windowed_einsum_mib,
+  // there shouldn't be any while loop after partitioner.
+  HloInstruction* while_inst = FindInstruction(module.get(), HloOpcode::kWhile);
+  EXPECT_EQ(while_inst, nullptr);
 }
 
 TEST_P(SpmdPartitioningTest, DotPartialDeviceOrder) {

--- a/xla/service/spmd/stateful_rng_spmd_partitioner.h
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner.h
@@ -55,7 +55,7 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
       bool windowed_einsum_use_multiple_streams = false,
       bool skip_checking_windowed_einsum_users = false,
       bool disable_ag_rewrite_for_multiple_consumers = false,
-      std::optional<int64_t> total_flops_windowed_einsum_threshold =
+      std::optional<int64_t> total_bytes_windowed_einsum_threshold =
           std::nullopt)
       : spmd::SpmdPartitioner(
             num_partitions, num_replicas,
@@ -63,7 +63,7 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
                                       windowed_einsum_use_multiple_streams,
                                       skip_checking_windowed_einsum_users,
                                       disable_ag_rewrite_for_multiple_consumers,
-                                      total_flops_windowed_einsum_threshold)) {}
+                                      total_bytes_windowed_einsum_threshold)) {}
 
  protected:
   std::unique_ptr<spmd::SpmdPartitioningVisitor> CreateVisitor(
@@ -91,7 +91,7 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
       bool windowed_einsum_use_multiple_streams = false,
       bool skip_checking_windowed_einsum_users = false,
       bool disable_ag_rewrite_for_multiple_consumers = false,
-      std::optional<int64_t> total_flops_windowed_einsum_threshold =
+      std::optional<int64_t> total_bytes_windowed_einsum_threshold =
           std::nullopt) {
     spmd::SpmdPartitionerOptions options;
     options.allow_module_signature_change = true;
@@ -102,8 +102,8 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
         skip_checking_windowed_einsum_users;
     options.disable_ag_rewrite_for_multiple_consumers =
         disable_ag_rewrite_for_multiple_consumers;
-    options.total_flops_windowed_einsum_threshold =
-        total_flops_windowed_einsum_threshold;
+    options.total_bytes_windowed_einsum_threshold =
+        total_bytes_windowed_einsum_threshold;
     return options;
   }
 };

--- a/xla/service/spmd/stateful_rng_spmd_partitioner.h
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner.h
@@ -54,13 +54,16 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
       int64_t threshold_for_windowed_einsum_mib = 100000,
       bool windowed_einsum_use_multiple_streams = false,
       bool skip_checking_windowed_einsum_users = false,
-      bool disable_ag_rewrite_for_multiple_consumers = false)
-      : spmd::SpmdPartitioner(num_partitions, num_replicas,
-                              GetSpmdPartitionerOptions(
-                                  threshold_for_windowed_einsum_mib,
-                                  windowed_einsum_use_multiple_streams,
-                                  skip_checking_windowed_einsum_users,
-                                  disable_ag_rewrite_for_multiple_consumers)) {}
+      bool disable_ag_rewrite_for_multiple_consumers = false,
+      std::optional<int64_t> total_flops_windowed_einsum_threshold =
+          std::nullopt)
+      : spmd::SpmdPartitioner(
+            num_partitions, num_replicas,
+            GetSpmdPartitionerOptions(threshold_for_windowed_einsum_mib,
+                                      windowed_einsum_use_multiple_streams,
+                                      skip_checking_windowed_einsum_users,
+                                      disable_ag_rewrite_for_multiple_consumers,
+                                      total_flops_windowed_einsum_threshold)) {}
 
  protected:
   std::unique_ptr<spmd::SpmdPartitioningVisitor> CreateVisitor(
@@ -87,7 +90,9 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
       int64_t threshold_for_windowed_einsum_mib,
       bool windowed_einsum_use_multiple_streams = false,
       bool skip_checking_windowed_einsum_users = false,
-      bool disable_ag_rewrite_for_multiple_consumers = false) {
+      bool disable_ag_rewrite_for_multiple_consumers = false,
+      std::optional<int64_t> total_flops_windowed_einsum_threshold =
+          std::nullopt) {
     spmd::SpmdPartitionerOptions options;
     options.allow_module_signature_change = true;
     options.threshold_for_windowed_einsum_mib =
@@ -97,6 +102,8 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
         skip_checking_windowed_einsum_users;
     options.disable_ag_rewrite_for_multiple_consumers =
         disable_ag_rewrite_for_multiple_consumers;
+    options.total_flops_windowed_einsum_threshold =
+        total_flops_windowed_einsum_threshold;
     return options;
   }
 };

--- a/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
@@ -78,7 +78,7 @@ class StatefulRngSpmdPartitionerTest : public HloTestBase {
         debug_options.xla_gpu_multi_streamed_windowed_einsum(),
         skip_checking_windowed_einsum_users,
         disable_ag_rewrite_for_multiple_consumers,
-        debug_options.xla_gpu_total_bytes_threshold_for_windowed_einsum());
+        debug_options.xla_gpu_operand_bytes_threshold_for_windowed_einsum());
     pass.AddPass<HloVerifier>(/*layout_sensitive=*/false,
                               /*allow_mixed_precision=*/false);
     TF_RETURN_IF_ERROR(pass.Run(module.get()).status());
@@ -279,9 +279,9 @@ ENTRY main {
   DebugOptions debug_options = GetDefaultDebugOptions();
   debug_options.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
   debug_options.set_xla_gpu_multi_streamed_windowed_einsum(true);
-  int64_t flops_threshold = 1 << 20;
-  debug_options.set_xla_gpu_total_bytes_threshold_for_windowed_einsum(
-      flops_threshold);
+  int64_t oper_bytes_threshold = 1 << 20;
+  debug_options.set_xla_gpu_operand_bytes_threshold_for_windowed_einsum(
+      oper_bytes_threshold);
   TF_ASSERT_OK_AND_ASSIGN(
       auto module,
       PartitionComputation(hlo_string, /*num_partitions=*/4, debug_options,
@@ -313,9 +313,9 @@ ENTRY main {
 )";
   DebugOptions debug_options = GetDefaultDebugOptions();
   debug_options.set_xla_gpu_multi_streamed_windowed_einsum(true);
-  int64_t flops_threshold = 1 << 8;
-  debug_options.set_xla_gpu_total_bytes_threshold_for_windowed_einsum(
-      flops_threshold);
+  int64_t oper_bytes_threshold = 1 << 8;
+  debug_options.set_xla_gpu_operand_bytes_threshold_for_windowed_einsum(
+      oper_bytes_threshold);
   TF_ASSERT_OK_AND_ASSIGN(
       auto module,
       PartitionComputation(hlo_string, /*num_partitions=*/4, debug_options,

--- a/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
@@ -78,7 +78,7 @@ class StatefulRngSpmdPartitionerTest : public HloTestBase {
         debug_options.xla_gpu_multi_streamed_windowed_einsum(),
         skip_checking_windowed_einsum_users,
         disable_ag_rewrite_for_multiple_consumers,
-        debug_options.xla_gpu_total_flops_threshold_for_windowed_einsum());
+        debug_options.xla_gpu_total_bytes_threshold_for_windowed_einsum());
     pass.AddPass<HloVerifier>(/*layout_sensitive=*/false,
                               /*allow_mixed_precision=*/false);
     TF_RETURN_IF_ERROR(pass.Run(module.get()).status());
@@ -280,7 +280,7 @@ ENTRY main {
   debug_options.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
   debug_options.set_xla_gpu_multi_streamed_windowed_einsum(true);
   int64_t flops_threshold = 1 << 20;
-  debug_options.set_xla_gpu_total_flops_threshold_for_windowed_einsum(
+  debug_options.set_xla_gpu_total_bytes_threshold_for_windowed_einsum(
       flops_threshold);
   TF_ASSERT_OK_AND_ASSIGN(
       auto module,
@@ -314,7 +314,7 @@ ENTRY main {
   DebugOptions debug_options = GetDefaultDebugOptions();
   debug_options.set_xla_gpu_multi_streamed_windowed_einsum(true);
   int64_t flops_threshold = 1 << 8;
-  debug_options.set_xla_gpu_total_flops_threshold_for_windowed_einsum(
+  debug_options.set_xla_gpu_total_bytes_threshold_for_windowed_einsum(
       flops_threshold);
   TF_ASSERT_OK_AND_ASSIGN(
       auto module,

--- a/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner_test.cc
@@ -77,7 +77,8 @@ class StatefulRngSpmdPartitionerTest : public HloTestBase {
         debug_options.xla_gpu_threshold_for_windowed_einsum_mib(),
         debug_options.xla_gpu_multi_streamed_windowed_einsum(),
         skip_checking_windowed_einsum_users,
-        disable_ag_rewrite_for_multiple_consumers);
+        disable_ag_rewrite_for_multiple_consumers,
+        debug_options.xla_gpu_total_flops_threshold_for_windowed_einsum());
     pass.AddPass<HloVerifier>(/*layout_sensitive=*/false,
                               /*allow_mixed_precision=*/false);
     TF_RETURN_IF_ERROR(pass.Run(module.get()).status());
@@ -262,6 +263,75 @@ ENTRY %test {
   rotate = op::Concatenate(op::CollectivePermute(op::Slice()), op::Slice());
   EXPECT_THAT(root, AllOf(rotate, op::Shape("f32[3]")));
 }
+
+TEST_F(StatefulRngSpmdPartitionerTest,
+       TotalFlopsThresholdOverrideOperandThreshold) {
+  absl::string_view hlo_string = R"(
+HloModule test, entry_computation_layout={(bf16[2,128,256]{2,1,0}, bf16[256,512]{1,0})->bf16[2,128,512]{2,1,0}}, num_partitions=4
+
+ENTRY main {
+  Arg_0.1 = bf16[2,128,256]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  Arg_1.2 = bf16[256,512]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  ROOT dot.5 = bf16[2,128,512]{2,1,0} dot(Arg_0.1, Arg_1.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}, sharding={devices=[1,1,4]<=[4]}
+}
+
+)";
+  DebugOptions debug_options = GetDefaultDebugOptions();
+  debug_options.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
+  debug_options.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  int64_t flops_threshold = 1 << 20;
+  debug_options.set_xla_gpu_total_flops_threshold_for_windowed_einsum(
+      flops_threshold);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      PartitionComputation(hlo_string, /*num_partitions=*/4, debug_options,
+                           /*add_passes=*/nullptr,
+                           /*skip_checking_windowed_einsum_users=*/true,
+                           /*disable_ag_rewrite_for_multiple_consumers=*/true));
+  XLA_VLOG_LINES(1, module->ToString());
+  // The operand threshold is set to 0 but flops threshold is set to be
+  // larger than the total flops of the gemm. So we don't expect any
+  // windowed einsum loop but rather an all-gather.
+  EXPECT_EQ(CountInstructions(*module->entry_computation(), HloOpcode::kWhile),
+            0);
+  EXPECT_EQ(
+      CountInstructions(*module->entry_computation(), HloOpcode::kAllGather),
+      1);
+}
+
+TEST_F(StatefulRngSpmdPartitionerTest,
+       TotalFlopsThresholdShouldEnableWindowedEinsum) {
+  absl::string_view hlo_string = R"(
+HloModule test, entry_computation_layout={(bf16[2,128,256]{2,1,0}, bf16[256,512]{1,0})->bf16[2,128,512]{2,1,0}}, num_partitions=4
+
+ENTRY main {
+  Arg_0.1 = bf16[2,128,256]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  Arg_1.2 = bf16[256,512]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  ROOT dot.5 = bf16[2,128,512]{2,1,0} dot(Arg_0.1, Arg_1.2), lhs_contracting_dims={2}, rhs_contracting_dims={0}, sharding={devices=[1,1,4]<=[4]}
+}
+
+)";
+  DebugOptions debug_options = GetDefaultDebugOptions();
+  debug_options.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  int64_t flops_threshold = 1 << 8;
+  debug_options.set_xla_gpu_total_flops_threshold_for_windowed_einsum(
+      flops_threshold);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      PartitionComputation(hlo_string, /*num_partitions=*/4, debug_options,
+                           /*add_passes=*/nullptr,
+                           /*skip_checking_windowed_einsum_users=*/true,
+                           /*disable_ag_rewrite_for_multiple_consumers=*/true));
+  XLA_VLOG_LINES(1, module->ToString());
+  // The operand threshold is not set which defaults to 1000000 MB.
+  // But the flops threshold is set, the windowed einsum should still kick in.
+  EXPECT_EQ(CountInstructions(*module->entry_computation(), HloOpcode::kWhile),
+            1);
+  EXPECT_EQ(
+      CountInstructions(*module->entry_computation(), HloOpcode::kAllGather),
+      0);
+}
+
 }  // namespace
 }  // namespace spmd
 }  // namespace xla

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1026,10 +1026,10 @@ message DebugOptions {
   //   coll.2-done = collective(coll.2-start)
   int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
 
-  // If set >= 0, this controls the total flops(combined sizes of both
-  // operands in bytes) to enable windowed einsum.
-  // It overrides xla_gpu_threshold_for_windowed_einsum_mib.
-  int64 xla_gpu_total_flops_threshold_for_windowed_einsum = 339;
+  // If set >= 0, this controls the total bytes(combined sizes of both
+  // operands in bytes) to enable windowed einsum and
+  // xla_gpu_threshold_for_windowed_einsum_mib will be ignored.
+  int64 xla_gpu_operand_bytes_threshold_for_windowed_einsum = 339;
 
   // Next id: 340
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1026,7 +1026,12 @@ message DebugOptions {
   //   coll.2-done = collective(coll.2-start)
   int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
 
-  // Next id: 339
+  // If set >= 0, this controls the total flops(combined sizes of both
+  // operands in bytes) to enable windowed einsum.
+  // It overrides xla_gpu_threshold_for_windowed_einsum_mib.
+  int64 xla_gpu_total_flops_threshold_for_windowed_einsum = 339;
+
+  // Next id: 340
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
The current thresholding mechanism to enable windowed einsum(collective matmul) relies on the total size of the sharded operand, this is not sufficient in some cases as we will need to know the total size of the gemm to see if it's beneficial to split it or not. This pr adds a new option to consider the total sizes of both operands. It will override the current xla_gpu_threshold_for_windowed_einsum_mib.
