### PR TITLE
Pass the compile options for deserialization via PJRT C API

### DIFF
--- a/xla/pjrt/c/CHANGELOG.md
+++ b/xla/pjrt/c/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PJRT C API changelog
 
+## 0.56
+* Added `overridden_serialized_compile_options` and
+  `overridden_serialized_compile_options_size` fields to
+  `PJRT_Executable_DeserializeAndLoad_Args`.
+
 ## 0.55
 * Added types F8E4M3 and F8E3M4.
 

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -1580,8 +1580,8 @@ struct PJRT_Executable_DeserializeAndLoad_Args {
   // Serialized CompileOptionsProto or null (to use the options
   // from the serialized executable).
   // (https://github.com/openxla/xla/blob/main/xla/pjrt/compile_options.proto)
-  const char* compile_options;
-  size_t compile_options_size;
+  const char* overridden_serialized_compile_options;
+  size_t overridden_serialized_compile_options_size;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_DeserializeAndLoad_Args,
                           loaded_executable);

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -1576,6 +1576,8 @@ struct PJRT_Executable_DeserializeAndLoad_Args {
   PJRT_Client* client;
   const char* serialized_executable;
   size_t serialized_executable_size;
+  const char* compile_options;
+  size_t compile_options_size;
   PJRT_LoadedExecutable* loaded_executable;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_DeserializeAndLoad_Args,

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -1576,9 +1576,12 @@ struct PJRT_Executable_DeserializeAndLoad_Args {
   PJRT_Client* client;
   const char* serialized_executable;
   size_t serialized_executable_size;
+  PJRT_LoadedExecutable* loaded_executable;  // out
+  // Serialized CompileOptionsProto or null (to use the options
+  // from the serialized executable).
+  // (https://github.com/openxla/xla/blob/main/xla/pjrt/compile_options.proto)
   const char* compile_options;
   size_t compile_options_size;
-  PJRT_LoadedExecutable* loaded_executable;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_DeserializeAndLoad_Args,
                           loaded_executable);

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -79,7 +79,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 55
+#define PJRT_API_MINOR 56
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
@@ -1570,17 +1570,20 @@ PJRT_Error* PJRT_Executable_DeserializeAndLoad(
   absl::string_view serialized(args->serialized_executable,
                                args->serialized_executable_size);
 
-  std::optional<xla::CompileOptions> options;
+  std::optional<xla::CompileOptions> overriden_options;
 
-  if (args->compile_options && args->compile_options_size > 0) {
+  if (args->overridden_serialized_compile_options &&
+      args->overridden_serialized_compile_options_size > 0) {
     PJRT_ASSIGN_OR_RETURN(
-        options, ParseCompileOptions(absl::string_view(
-                     args->compile_options, args->compile_options_size)));
+        overriden_options,
+        ParseCompileOptions(absl::string_view(
+            args->overridden_serialized_compile_options,
+            args->overridden_serialized_compile_options_size)));
   }
 
-  PJRT_ASSIGN_OR_RETURN(
-      std::unique_ptr<xla::PjRtLoadedExecutable> executable,
-      args->client->client->DeserializeExecutable(serialized, options));
+  PJRT_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtLoadedExecutable> executable,
+                        args->client->client->DeserializeExecutable(
+                            serialized, overriden_options));
 
   args->loaded_executable =
       new PJRT_LoadedExecutable(std::move(executable), args->client);

--- a/xla/pjrt/pjrt_c_api_client.cc
+++ b/xla/pjrt/pjrt_c_api_client.cc
@@ -422,6 +422,16 @@ PjRtCApiClient::DeserializeExecutable(absl::string_view serialized,
   des_args.client = c_client_.get();
   des_args.serialized_executable = serialized.data();
   des_args.serialized_executable_size = serialized.length();
+  des_args.compile_options = nullptr;
+  des_args.compile_options_size = 0;
+
+  if (options) {
+    TF_ASSIGN_OR_RETURN(const CompileOptionsProto options_proto,
+                        options->ToProto());
+    std::string options_str = options_proto.SerializeAsString();
+    des_args.compile_options = options_str.c_str();
+    des_args.compile_options_size = options_str.size();
+  }
 
   const PJRT_Api* api = pjrt_c_api();
 

--- a/xla/pjrt/pjrt_c_api_client.cc
+++ b/xla/pjrt/pjrt_c_api_client.cc
@@ -425,10 +425,11 @@ PjRtCApiClient::DeserializeExecutable(absl::string_view serialized,
   des_args.compile_options = nullptr;
   des_args.compile_options_size = 0;
 
+  std::string options_str;
   if (options) {
     TF_ASSIGN_OR_RETURN(const CompileOptionsProto options_proto,
                         options->ToProto());
-    std::string options_str = options_proto.SerializeAsString();
+    options_str = options_proto.SerializeAsString();
     des_args.compile_options = options_str.c_str();
     des_args.compile_options_size = options_str.size();
   }

--- a/xla/pjrt/pjrt_c_api_client.cc
+++ b/xla/pjrt/pjrt_c_api_client.cc
@@ -422,16 +422,16 @@ PjRtCApiClient::DeserializeExecutable(absl::string_view serialized,
   des_args.client = c_client_.get();
   des_args.serialized_executable = serialized.data();
   des_args.serialized_executable_size = serialized.length();
-  des_args.compile_options = nullptr;
-  des_args.compile_options_size = 0;
+  des_args.overridden_serialized_compile_options = nullptr;
+  des_args.overridden_serialized_compile_options_size = 0;
 
   std::string options_str;
   if (options) {
     TF_ASSIGN_OR_RETURN(const CompileOptionsProto options_proto,
                         options->ToProto());
     options_str = options_proto.SerializeAsString();
-    des_args.compile_options = options_str.c_str();
-    des_args.compile_options_size = options_str.size();
+    des_args.overridden_serialized_compile_options = options_str.c_str();
+    des_args.overridden_serialized_compile_options_size = options_str.size();
   }
 
   const PJRT_Api* api = pjrt_c_api();

--- a/xla/pjrt/pjrt_c_api_client_test.cc
+++ b/xla/pjrt/pjrt_c_api_client_test.cc
@@ -196,5 +196,41 @@ TEST(PjRtClientTest, CompileUsesStableHloVersion) {
   const_cast<PJRT_Api*>(c_api)->PJRT_Client_Compile = PJRT_Client_Compile_Orig;
 }
 
+TEST(PjRtClientTest, DeserializeExecutableWithDifferentDeviceAssignment) {
+  SetUpCpuPjRtApi();
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetCApiClient("cpu"));
+  ASSERT_GT(client->addressable_devices().size(), 1);
+
+  XlaBuilder builder("Identity");
+  Shape shape = ShapeUtil::MakeShape(S32, {2, 3});
+  auto input = Parameter(&builder, 0, shape, "input");
+  auto computation = builder.Build(input).value();
+
+  auto compile_options_for_device = [](int id) -> xla::CompileOptions {
+    xla::DeviceAssignment device_assignment(1, 1);
+    device_assignment(0, 0) = id;
+    xla::CompileOptions options;
+    options.executable_build_options.set_device_assignment(device_assignment);
+    return options;
+  };
+
+  // Compile the executable for device 0 and serialize it.
+  std::unique_ptr<PjRtLoadedExecutable> executable =
+      client->Compile(computation, compile_options_for_device(0)).value();
+  TF_ASSERT_OK_AND_ASSIGN(std::string serialized_executable,
+                          executable->SerializeExecutable());
+
+  // Deserialize the executable for device 1.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto deserialized_executable,
+      client->DeserializeExecutable(serialized_executable,
+                                    compile_options_for_device(1)));
+
+  // Check that the executable was indeed serialized for device 1.
+  EXPECT_EQ(
+      deserialized_executable->addressable_devices()[0]->global_device_id(), 1);
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/pjrt/pjrt_c_api_client_test.cc
+++ b/xla/pjrt/pjrt_c_api_client_test.cc
@@ -227,7 +227,8 @@ TEST(PjRtClientTest, DeserializeExecutableWithDifferentDeviceAssignment) {
       client->DeserializeExecutable(serialized_executable,
                                     compile_options_for_device(1)));
 
-  // Check that the executable was indeed serialized for device 1.
+  // Check that the executable's compile options were overridden
+  // with device id 1.
   EXPECT_EQ(
       deserialized_executable->addressable_devices()[0]->global_device_id(), 1);
 }

--- a/xla/pjrt/pjrt_client.h
+++ b/xla/pjrt/pjrt_client.h
@@ -605,6 +605,9 @@ class PjRtClient {
   // Pending completion of b/237720161, `options` is a mandatory argument in
   // most implementations of this interface. They _are_ optional for
   // implementations related to the PJRT C API.
+  //
+  // If `options` are provided, then they override the compile options
+  // from the serialized executable (`serialized`).
   virtual absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
   DeserializeExecutable(absl::string_view serialized,
                         std::optional<CompileOptions> options) {


### PR DESCRIPTION
This enables JAX to supply different device assignment when deserializing single-device executables from compilation cache.

Fixes https://github.com/openxla/xla/issues/18286.