### PR TITLE
[XLA:GPU] Large dynamic update slice fusion due to inability to identify in place fusion

### DIFF
--- a/xla/hlo/analysis/hlo_dataflow_analysis.cc
+++ b/xla/hlo/analysis/hlo_dataflow_analysis.cc
@@ -1895,7 +1895,11 @@ GetFusionInstructionInPlaceInputOutputPairs(const HloInstruction* instruction) {
             }
           }
         }
-
+        // Skip bitcast
+        if (in_place_input_source != nullptr &&
+            in_place_input_source->opcode() == HloOpcode::kBitcast) {
+          in_place_input_source = in_place_input_source->operand(0);
+        }
         if (in_place_input_source != nullptr &&
             in_place_input_source->opcode() == HloOpcode::kParameter) {
           in_place_input_output_pairs.emplace_back(


### PR DESCRIPTION
```
fused_dynamic_update_slice {
  param_1.133 = bf16[32,1,4096,18432]{2,3,1,0} parameter(1)
  bitcast.8539.1 = bf16[32,1,18432,4096]{3,2,1,0} bitcast(param_1.133)
  param_0.168 = bf16[1,4096,18432]{1,0,2} parameter(0)
  bitcast.8543.1 = bf16[1,1,18432,4096]{3,2,1,0} bitcast(param_0.168)
  param_2.98 = s32[] parameter(2)
  constant_2153_8 = s32[] constant(0)
  compare.753.6 = pred[] compare(param_2.98, constant_2153_8), direction=LT
  constant_2154_12 = s32[] constant(96)
  add.950.6 = s32[] add(param_2.98, constant_2154_12)
  select.883.5 = s32[] select(compare.753.6, add.950.6, param_2.98)
  ROOT dynamic-update-slice.178.1 = bf16[32,1,18432,4096]{3,2,1,0} dynamic-update-slice(bitcast.8539.1, bitcast.8543.1, select.883.5, constant_2153_8, constant_2153_8, /*index=5*/constant_2153_8)
} // fused_dynamic_update_slice
```
`GetFusionInstructionInPlaceInputOutputPairs` isn't able to identify `param_1.133` to be aliased with `dynamic-update-slice.178.1` because there is a bitcast in between. Therefore, dus fusion happens out of place, resulting in large runtime overhead.

Could potentially be implemented in `FollowTupleIndirection`? I'm not sure if this beaks other things if done so.
