### PR TITLE
[XLA:GPU] Collective Quantizer Fix.

### DIFF
--- a/xla/service/collective_quantizer.cc
+++ b/xla/service/collective_quantizer.cc
@@ -321,7 +321,7 @@ absl::StatusOr<bool> MatchDequantization(HloInstruction* instr) {
 
 absl::StatusOr<bool> MatchQuantization(HloInstruction* instr) {
   if (instr->user_count() != 1) {
-    return absl::OkStatus();
+    return false;
   }
 
   VLOG(5) << "Attempt to quantize collective " << instr->ToShortString();

--- a/xla/service/collective_quantizer_test.cc
+++ b/xla/service/collective_quantizer_test.cc
@@ -276,7 +276,13 @@ TEST_F(CollectiveQuantizerTest, AllGatherQuantizeNonReplicatedScale) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(hlo_string));
   TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
-  EXPECT_FALSE(changed);
+
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::Convert()));
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction()->shape().element_type(),
+      F8E4M3FN);
 }
 
 TEST_F(CollectiveQuantizerTest, ConvertAllGather) {
@@ -346,13 +352,13 @@ TEST_F(CollectiveQuantizerTest, DequantizeAllGather) {
   EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
 }
 
-TEST_F(CollectiveQuantizerTest, DequantizeAllGatherWithEffectiveScalarScale) {
+TEST_F(CollectiveQuantizerTest, DequantizeAllGatherWithNonReplicatedScale) {
   absl::string_view hlo_string = R"(
   HloModule module
   ENTRY entry {
     param = f8e4m3fn[8,4,8,128] parameter(0)
     convert = bf16[8,4,8,128] convert(param)
-    scale = bf16[1] constant({0.1})
+    scale = bf16[] constant(0.1)
     scale_bcast = bf16[8,4,8,128] broadcast(scale), dimensions={}
     multiply = bf16[8,4,8,128] multiply(convert, scale_bcast)
     ROOT all-gather = bf16[8,32,8,128] all-gather(multiply), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
@@ -361,6 +367,31 @@ TEST_F(CollectiveQuantizerTest, DequantizeAllGatherWithEffectiveScalarScale) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(hlo_string));
   TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Multiply(op::Convert(op::AllGather(op::Parameter())),
+                           op::Broadcast()));
+  const HloInstruction* all_gather =
+      module->entry_computation()->root_instruction()->operand(0)->operand(0);
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, DequantizeAllGatherWithEffectiveScalarScale) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = f8e4m3fn[8,1] parameter(0)
+    convert = bf16[8,1] convert(param)
+    scale = bf16[1] constant({0.1})
+    scale_bcast = bf16[8,1] broadcast(scale), dimensions={1}
+    multiply = bf16[8,1] multiply(convert, scale_bcast)
+    ROOT all-gather = bf16[8,8] all-gather(multiply), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+
   EXPECT_TRUE(changed);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Multiply(op::Convert(op::AllGather(op::Parameter())),

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -171,6 +171,7 @@ xla_test(
         ":gpu_codegen_test",
         "//xla:debug_options_flags",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/utils:hlo_matchers",
         "//xla/hlo/utils:hlo_query",
         "//xla/service:executable",
         "//xla/service:hlo_module_config",


### PR DESCRIPTION
This PR fixes the collective quantizer pass.

1. The major dish: Removed the requirement that the scale should have a replicated sharding. It is unknown why it was needed previously. From the cublas documentation, the cublas custom call seems to only need to be run on a single device and it accepts four scalars. It doesn't need the scalars to be replicated across the devices.

Actually in some cases, the scalars can be "fully-sharded" so if there are 4 devices, the user can manually broadcast the scalar to 4 devices and set the sharding to be fully-sharded, then each device gets one effective scalar.

In the actual world, jax shard_map might generate code with this scenario. In my perspective, what is essentially needed here is to have an effective scalar (basically a scalar or a single element array)

2. Fixes inefficient code. For instance, a collective can either be dequantized or quantized but not both? Don't run both.
3. Clean up code a bit.
4. Add debuggability with more VLOG.