### PR TITLE
[ROCm] PJRTGpuDeviceTopologyTest fix with #ifdef ROCM

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -507,8 +507,13 @@ TEST(PJRTGpuDeviceTopologyTest, CreateExplicitGpuTopologyAndTargetConfig) {
       reinterpret_cast<const PJRT_TopologyDescription*>(args.topology);
   ASSERT_NE(pjrt_topology, nullptr);
 
+#ifdef TENSORFLOW_USE_ROCM
+  EXPECT_EQ(pjrt_topology->topology->platform_id(), xla::RocmId());
+  EXPECT_EQ(pjrt_topology->topology->platform_name(), xla::RocmName());
+#else
   EXPECT_EQ(pjrt_topology->topology->platform_id(), xla::CudaId());
   EXPECT_EQ(pjrt_topology->topology->platform_name(), xla::CudaName());
+#endif
 
   EXPECT_EQ(pjrt_topology->topology->ProcessCount().value(), 16 * 2);
   EXPECT_EQ(pjrt_topology->topology->DeviceDescriptions().size(), 16 * 2 * 4);


### PR DESCRIPTION
My first PR to XLA, testing out the workflow...

This is a trivial fix following e.g. https://github.com/ROCm/xla/blob/b8f0c2a7798cb085a650283491cc6d24301a4168/xla/pjrt/c/pjrt_c_api_gpu_test.cc#L440-L446