### PR TITLE
[ROCm] Disable failing subtests for command_buffer_scheduling_test

### DIFF
--- a/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
@@ -54,6 +54,11 @@ class CommandBufferSchedulingTest : public HloTestBase {
     debug_options.set_xla_gpu_graph_min_graph_size(2);
     return debug_options;
   }
+
+  const se::GpuComputeCapability& GetGpuComputeCapability() {
+    return backend().default_stream_executor()
+        ->GetDeviceDescription().gpu_compute_capability();
+  }
 };
 
 using CommandBuffer = CommandBufferScheduling::CommandBuffer;
@@ -809,6 +814,10 @@ TEST_F(CommandBufferSchedulingTest, WhileNotCommand) {
 }
 
 TEST_F(CommandBufferSchedulingTest, While) {
+  const auto& gpu_desc = GetGpuComputeCapability();
+  if (std::holds_alternative<se::RocmComputeCapability>(gpu_desc)) {
+    GTEST_SKIP() << "Not supported for ROCm!";
+  }
   const char* hlo = R"(
     HloModule TestModule, is_scheduled=true
 
@@ -870,6 +879,10 @@ TEST_F(CommandBufferSchedulingTest, While) {
 }
 
 TEST_F(CommandBufferSchedulingTest, Conditional) {
+  const auto& gpu_desc = GetGpuComputeCapability();
+  if (std::holds_alternative<se::RocmComputeCapability>(gpu_desc)) {
+    GTEST_SKIP() << "Not supported for ROCm!";
+  }
   const char* hlo = R"(
     HloModule TestModule, is_scheduled=true
 


### PR DESCRIPTION
Disabling `Conditional` and `While` subtests in `command_buffer_scheduling_test`  since ROCm does not support conditional nodes in the hip graph