### PR TITLE
[PJRT:GPU] Fix pinned memory space ids

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -509,6 +509,7 @@ StreamExecutorGpuClient::StreamExecutorGpuClient(
           tsl::Fingerprint64(platform_name), platform_name,
           std::move(gpu_topology))),
       kv_store_(std::move(kv_store)) {
+  const int basePinnedId = device_count();
   for (auto* device : addressable_devices()) {
     // Use the device id to construct a globally unique memory space id. We do
     // not promise that memory space ids and device ids are the same.
@@ -518,8 +519,8 @@ StreamExecutorGpuClient::StreamExecutorGpuClient(
     tensorflow::down_cast<PjRtStreamExecutorDevice*>(device)->AttachMemorySpace(
         memory_space.get());
     owned_memory_spaces_.push_back(std::move(memory_space));
-    const size_t basePinnedId = devices.size();
-    auto pinned = std::make_unique<PinnedHostMemorySpace>(basePinnedId, device);
+    auto pinned =
+        std::make_unique<PinnedHostMemorySpace>(basePinnedId + id, device);
     tensorflow::down_cast<PjRtStreamExecutorDevice*>(device)->AttachMemorySpace(
         pinned.get());
     owned_memory_spaces_.push_back(std::move(pinned));

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -161,6 +161,22 @@ TEST(StreamExecutorGpuClientTest, MemorySpace) {
   }
 }
 
+TEST(StreamExecutorGpuClientTest, MemorySpacesUniqueIds) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(GpuClientOptions()));
+  ASSERT_GE(client->devices().size(), 1);
+
+  absl::flat_hash_map<int, std::string> memories;
+  for (auto* device : client->devices()) {
+    for (auto* memory_space : device->memory_spaces()) {
+      std::string debug_string(memory_space->DebugString());
+      auto [it, inserted] = memories.insert({memory_space->id(), debug_string});
+      EXPECT_TRUE(inserted) << "Duplicate ids for memory spaces '" << it->second
+                            << "' and '" << debug_string << "'";
+    }
+  }
+}
+
 TEST(StreamExecutorGpuClientTest, PropagateError) {
   TF_ASSERT_OK_AND_ASSIGN(auto client,
                           GetStreamExecutorGpuClient(GpuClientOptions()));


### PR DESCRIPTION
The memory space ids should be unique.

Duplicated memory space ids cause assertion failures if we try to use GPU client via IFRT proxy server. See https://github.com/openxla/xla/blob/3f6598f7d9d253b364a3316c8a532f7addebc207/xla/python/ifrt_proxy/server/ifrt_backend.cc#L314