### PR TITLE
Fix xla-mlir failures on Windows

### DIFF
--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -22,8 +22,8 @@ cc_library(
         ],
         exclude = ["util.cc"],
     ),
+    hdrs= ["symbol_finder.h"],
     deps = [
-        ":find_symbol",
         ":dialect_utils",
         "//xla/mlir/tools/mlir_interpreter/framework",
         "//xla/mlir_hlo",
@@ -65,15 +65,15 @@ cc_library(
 )
 
 cc_library(
-  name = "find_symbol_posix",
-  srcs = ["symbol_finder_windows.cc"],
+  name = "find_symbol_linux",
+  srcs = ["symbol_finder_linux.cc"],
   deps = ["@com_google_absl//absl/status:statusor"],
   tags = ["manual"]
 )
 
 cc_library(
   name = "find_symbol_windows",
-  srcs = ["symbol_finder_linux.cc"],
+  srcs = ["symbol_finder_windows.cc"],
   deps = ["@com_google_absl//absl/status:statusor"],
   tags = ["manual"]
 )
@@ -81,6 +81,6 @@ cc_library(
 cc_library(
   name = "find_symbol",
   hdrs = ["symbol_finder.h"],
-  deps = if_windows([":find_symbol_windows"], [":find_symbol_posix"])
+  deps = if_windows([":find_symbol_windows"], [":find_symbol_linux"])
 )
 

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -21,6 +21,7 @@ cc_library(
         ],
         exclude = ["util.cc"],
     ),
+    hdrs=["symbol_finder.h"],
     deps = [
         ":dialect_utils",
         "//xla/mlir/tools/mlir_interpreter/framework",

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -76,31 +76,25 @@ cc_library(
 )
 
 cc_library(
-    name = "symbol_finder_header",
-    hdrs = ["symbol_finder.h"],
-)
-
-cc_library(
     name = "symbol_finder_linux",
-    srcs = ["symbol_finder_linux.cc"],
+    srcs = ["symbol_finder.h","symbol_finder_linux.cc"],
     deps = [
-        "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header",
+        "@com_google_absl//absl/status:statusor"
     ],
     tags = ["manual"],
 )
 
 cc_library(
     name = "symbol_finder_windows",
-    srcs = ["symbol_finder_windows.cc"],
+    srcs = ["symbol_finder.h","symbol_finder_windows.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header",
     ],
     tags = ["manual"],
 )
 
 cc_library(
     name = "find_symbol",
+    hdrs = ["symbol_finder.h"],
     deps = if_windows([":symbol_finder_windows"], [":symbol_finder_linux"]),
 )

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -1,4 +1,5 @@
 load("@tsl//tsl/platform:rules_cc.bzl", "cc_library")
+load("//xla/tsl:tsl.bzl", "if_windows")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -21,8 +22,8 @@ cc_library(
         ],
         exclude = ["util.cc"],
     ),
-    hdrs=["symbol_finder.h"],
     deps = [
+        ":find_symbol",
         ":dialect_utils",
         "//xla/mlir/tools/mlir_interpreter/framework",
         "//xla/mlir_hlo",
@@ -62,3 +63,24 @@ cc_library(
         "@llvm-project//mlir:ViewLikeInterface",
     ],
 )
+
+cc_library(
+  name = "find_symbol_posix",
+  srcs = ["symbol_finder_windows.cc"],
+  deps = ["@com_google_absl//absl/status:statusor"],
+  tags = ["manual"]
+)
+
+cc_library(
+  name = "find_symbol_windows",
+  srcs = ["symbol_finder_linux.cc"],
+  deps = ["@com_google_absl//absl/status:statusor"],
+  tags = ["manual"]
+)
+
+cc_library(
+  name = "find_symbol",
+  hdrs = ["symbol_finder.h"],
+  deps = if_windows([":find_symbol_windows"], [":find_symbol_posix"])
+)
+

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -64,7 +64,6 @@ cc_library(
     ],
 )
 
-# New target for the header file
 cc_library(
     name = "symbol_finder_header",
     hdrs = ["symbol_finder.h"],
@@ -75,7 +74,7 @@ cc_library(
     srcs = ["symbol_finder_linux.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header",  # Depend on the header-only target
+        ":symbol_finder_header", 
     ],
     tags = ["manual"]
 )
@@ -85,7 +84,7 @@ cc_library(
     srcs = ["symbol_finder_windows.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header",  # Depend on the header-only target
+        ":symbol_finder_header", 
     ],
     tags = ["manual"]
 )
@@ -94,4 +93,3 @@ cc_library(
     name = "find_symbol",
     deps = if_windows([":symbol_finder_windows"], [":symbol_finder_linux"])
 )
-

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -74,9 +74,9 @@ cc_library(
     srcs = ["symbol_finder_linux.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header", 
+        ":symbol_finder_header",
     ],
-    tags = ["manual"]
+    tags = ["manual"],
 )
 
 cc_library(
@@ -84,12 +84,12 @@ cc_library(
     srcs = ["symbol_finder_windows.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header", 
+        ":symbol_finder_header",
     ],
-    tags = ["manual"]
+    tags = ["manual"],
 )
 
 cc_library(
     name = "find_symbol",
-    deps = if_windows([":symbol_finder_windows"], [":symbol_finder_linux"])
+    deps = if_windows([":symbol_finder_windows"], [":symbol_finder_linux"]),
 )

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -22,8 +22,8 @@ cc_library(
         ],
         exclude = ["util.cc"],
     ),
-    hdrs= ["symbol_finder.h"],
     deps = [
+        ":find_symbol",
         ":dialect_utils",
         "//xla/mlir/tools/mlir_interpreter/framework",
         "//xla/mlir_hlo",
@@ -64,23 +64,34 @@ cc_library(
     ],
 )
 
+# New target for the header file
 cc_library(
-  name = "find_symbol_linux",
-  srcs = ["symbol_finder_linux.cc"],
-  deps = ["@com_google_absl//absl/status:statusor"],
-  tags = ["manual"]
+    name = "symbol_finder_header",
+    hdrs = ["symbol_finder.h"],
 )
 
 cc_library(
-  name = "find_symbol_windows",
-  srcs = ["symbol_finder_windows.cc"],
-  deps = ["@com_google_absl//absl/status:statusor"],
-  tags = ["manual"]
+    name = "symbol_finder_linux",
+    srcs = ["symbol_finder_linux.cc"],
+    deps = [
+        "@com_google_absl//absl/status:statusor",
+        ":symbol_finder_header",  # Depend on the header-only target
+    ],
+    tags = ["manual"]
 )
 
 cc_library(
-  name = "find_symbol",
-  hdrs = ["symbol_finder.h"],
-  deps = if_windows([":find_symbol_windows"], [":find_symbol_linux"])
+    name = "symbol_finder_windows",
+    srcs = ["symbol_finder_windows.cc"],
+    deps = [
+        "@com_google_absl//absl/status:statusor",
+        ":symbol_finder_header",  # Depend on the header-only target
+    ],
+    tags = ["manual"]
+)
+
+cc_library(
+    name = "find_symbol",
+    deps = if_windows([":symbol_finder_windows"], [":symbol_finder_linux"])
 )
 

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -65,31 +65,25 @@ cc_library(
 )
 
 cc_library(
-    name = "symbol_finder_header",
-    hdrs = ["symbol_finder.h"],
-)
-
-cc_library(
     name = "symbol_finder_linux",
-    srcs = ["symbol_finder_linux.cc"],
+    srcs = ["symbol_finder.h","symbol_finder_linux.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header",
     ],
     tags = ["manual"],
 )
 
 cc_library(
     name = "symbol_finder_windows",
-    srcs = ["symbol_finder_windows.cc"],
+    srcs = ["symbol_finder.h","symbol_finder_windows.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
-        ":symbol_finder_header",
     ],
     tags = ["manual"],
 )
 
 cc_library(
     name = "find_symbol",
+    hdrs = ["symbol_finder.h"],
     deps = if_windows([":symbol_finder_windows"], [":symbol_finder_linux"]),
 )

--- a/xla/mlir/tools/mlir_interpreter/dialects/BUILD
+++ b/xla/mlir/tools/mlir_interpreter/dialects/BUILD
@@ -16,12 +16,23 @@ package_group(
 
 cc_library(
     name = "dialects",
-    srcs = glob(
-        [
-            "*.cc",
+    srcs = [
+            "affine.cc",
+            "arith.cc",
+            "bufferization.cc",
+            "builtin.cc",
+            "complex.cc",
+            "func.cc",
+            "linalg.cc",
+            "math.cc",
+            "memref.cc",
+            "mhlo.cc",
+            "mhlo_binary_cwise.cc",
+            "mhlo_unary_cwise.cc",
+            "scf.cc",
+            "tensor.cc",
+            "vector.cc",
         ],
-        exclude = ["util.cc"],
-    ),
     deps = [
         ":find_symbol",
         ":dialect_utils",
@@ -65,25 +76,31 @@ cc_library(
 )
 
 cc_library(
+    name = "symbol_finder_header",
+    hdrs = ["symbol_finder.h"],
+)
+
+cc_library(
     name = "symbol_finder_linux",
-    srcs = ["symbol_finder.h","symbol_finder_linux.cc"],
+    srcs = ["symbol_finder_linux.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
+        ":symbol_finder_header",
     ],
     tags = ["manual"],
 )
 
 cc_library(
     name = "symbol_finder_windows",
-    srcs = ["symbol_finder.h","symbol_finder_windows.cc"],
+    srcs = ["symbol_finder_windows.cc"],
     deps = [
         "@com_google_absl//absl/status:statusor",
+        ":symbol_finder_header",
     ],
     tags = ["manual"],
 )
 
 cc_library(
     name = "find_symbol",
-    hdrs = ["symbol_finder.h"],
     deps = if_windows([":symbol_finder_windows"], [":symbol_finder_linux"]),
 )

--- a/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
@@ -44,20 +44,22 @@ struct FloatCompare : CwiseAll {
     }
   }
 
-  // Template type for non-floating point and non-complex
-  template <typename T>
+  // Overload for floating-point types only
+  template <typename T, typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
   static bool isnan(T a) {
-    return false;
+    return std::isnan(a);
   }
+
+  // Overload for non-floating point types (integral types)
+  template <typename T, typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
+  static bool isnan(T a) {
+    return false;  // Integral types can't be NaN
+  }
+
   // Handling complex types
   template <typename T>
   static bool isnan(std::complex<T> a) {
     return std::isnan(std::real(a)) || std::isnan(std::imag(a));
-  }
-  // Template for isnan (Floating numbers)
-  template <typename T>
-  static bool isnan(std::is_floating_point<T> a) {
-    return std::isnan(a);
   }
 };
 

--- a/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
@@ -1,4 +1,3 @@
-
 /* Copyright 2022 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <complex>
 #include <cstdint>
 #include <type_traits>
+#include <cmath>
 
 #include "llvm/Support/ErrorHandling.h"
 #include "xla/mlir/tools/mlir_interpreter/framework/interpreter_value_util.h"
@@ -43,13 +44,20 @@ struct FloatCompare : CwiseAll {
     }
   }
 
+  // Template type for non-floating point and non-complex
   template <typename T>
   static bool isnan(T a) {
-    return std::isnan(a);
+    return false;
   }
+  // Handling complex types
   template <typename T>
   static bool isnan(std::complex<T> a) {
     return std::isnan(std::real(a)) || std::isnan(std::imag(a));
+  }
+  // Template for isnan (Floating numbers)
+  template <typename T>
+  static bool isnan(std::is_floating_point<T> a) {
+    return std::isnan(a);
   }
 };
 

--- a/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/comparators.h
@@ -1,3 +1,4 @@
+
 /* Copyright 2022 The OpenXLA Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +20,6 @@ limitations under the License.
 #include <complex>
 #include <cstdint>
 #include <type_traits>
-#include <cmath>
 
 #include "llvm/Support/ErrorHandling.h"
 #include "xla/mlir/tools/mlir_interpreter/framework/interpreter_value_util.h"
@@ -44,19 +44,10 @@ struct FloatCompare : CwiseAll {
     }
   }
 
-  // Overload for floating-point types only
-  template <typename T, typename std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
+  template <typename T>
   static bool isnan(T a) {
     return std::isnan(a);
   }
-
-  // Overload for non-floating point types (integral types)
-  template <typename T, typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
-  static bool isnan(T a) {
-    return false;  // Integral types can't be NaN
-  }
-
-  // Handling complex types
   template <typename T>
   static bool isnan(std::complex<T> a) {
     return std::isnan(std::real(a)) || std::isnan(std::imag(a));

--- a/xla/mlir/tools/mlir_interpreter/dialects/func.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/func.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "symbol_finder.h"
+#include "xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h"
 #include "absl/status/statusor.h"
 
 #include <tuple>
@@ -96,14 +96,14 @@ llvm::SmallVector<InterpreterValue> Call(MutableArrayRef<InterpreterValue> args,
   if (callee->getRegion(0).hasOneBlock()) {
     return Interpret(state, callee.getRegion(), args);
   }
-  
+
   // Use the new FindSymbolInProcess function
   absl::StatusOr<void*> symbol_status = FindSymbolInProcess(callee.getSymName().str());
   if (!symbol_status.ok()) {
-     state.AddFailure(symbol_status.status().message());
+    state.AddFailure(symbol_status.status().message());
     return {};
-    }
-    void* sym = *symbol_status;  // Retrieve the symbol pointer
+  }
+  void* sym = *symbol_status;  // Retrieve the symbol pointer
 
   InterpreterValue result;
   if (TryCall<float, float>(sym, callee, args, result) ||
@@ -112,6 +112,9 @@ llvm::SmallVector<InterpreterValue> Call(MutableArrayRef<InterpreterValue> args,
       TryCall<double, double, double>(sym, callee, args, result)) {
     return {result};
   }
+}
+
+
 
   state.AddFailure("unsupported call target");
   return {};

--- a/xla/mlir/tools/mlir_interpreter/dialects/func.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/func.cc
@@ -112,10 +112,6 @@ llvm::SmallVector<InterpreterValue> Call(MutableArrayRef<InterpreterValue> args,
       TryCall<double, double, double>(sym, callee, args, result)) {
     return {result};
   }
-}
-
-
-
   state.AddFailure("unsupported call target");
   return {};
 }

--- a/xla/mlir/tools/mlir_interpreter/dialects/func.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/func.cc
@@ -13,11 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifdef __linux__
-#include <dlfcn.h>
-#elif defined(_WIN32)
-#include <windows.h>
-#endif
+#include "symbol_finder.h"
+#include "absl/status/statusor.h"
 
 #include <tuple>
 #include <type_traits>
@@ -100,30 +97,13 @@ llvm::SmallVector<InterpreterValue> Call(MutableArrayRef<InterpreterValue> args,
     return Interpret(state, callee.getRegion(), args);
   }
   
-  /*GetModuleHandle gets the handle for the module of the current process
-  GetProcAddress uses the module handle to look for the address
-  of the function/variable named by callee.getSymName().str().c_str()*/
-  void* sym =nullptr;
-  #ifdef _WIN32
-  HMODULE handle =GetModuleHandle(NULL);
-  if (handle){
-      sym =GetProcAddress(handle, callee.getSymName().str().c_str());
-      if (!sym) {
-          state.AddFailure("Callee not found");
-          return {};
-      }
-  }
-  else {
-       state.AddFailure("Failed to get module handle");
-       return {};
-  }
-  #else
-  sym = dlsym(RTLD_DEFAULT, callee.getSymName().str().c_str());
-  if (sym == nullptr) {
-    state.AddFailure("callee not found");
+  // Use the new FindSymbolInProcess function
+  absl::StatusOr<void*> symbol_status = FindSymbolInProcess(callee.getSymName().str());
+  if (!symbol_status.ok()) {
+     state.AddFailure(symbol_status.status().message());
     return {};
-  }
-  #endif
+    }
+    void* sym = *symbol_status;  // Retrieve the symbol pointer
 
   InterpreterValue result;
   if (TryCall<float, float>(sym, callee, args, result) ||

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
@@ -8,5 +8,4 @@ input and returns either the symbol's address or an error status, encapsulated i
 #include "absl/status/statusor.h"
 
 absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name);
-
 #endif  // SYMBOL_FINDER_H_

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
@@ -1,0 +1,9 @@
+#ifndef SYMBOL_FINDER_H_
+#define SYMBOL_FINDER_H_
+
+#include <string>
+#include "absl/status/statusor.h"
+
+absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name);
+
+#endif  // SYMBOL_FINDER_H_

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
@@ -1,3 +1,6 @@
+/* This header file declares the FindSymbolInProcess function, which takes a symbol name as 
+input and returns either the symbol's address or an error status, encapsulated in absl::StatusOr<void*> */
+
 #ifndef SYMBOL_FINDER_H_
 #define SYMBOL_FINDER_H_
 

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h
@@ -1,11 +1,19 @@
 /* This header file declares the FindSymbolInProcess function, which takes a symbol name as 
 input and returns either the symbol's address or an error status, encapsulated in absl::StatusOr<void*> */
 
-#ifndef SYMBOL_FINDER_H_
-#define SYMBOL_FINDER_H_
+#ifndef XLA_MLIR_TOOLS_MLIR_INTERPRETER_DIALECTS_SYMBOL_FINDER_H_
+#define XLA_MLIR_TOOLS_MLIR_INTERPRETER_DIALECTS_SYMBOL_FINDER_H_
 
 #include <string>
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
+namespace mlir {
+namespace interpreter {
+
 absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name);
-#endif  // SYMBOL_FINDER_H_
+
+}  // namespace interpreter
+}  // namespace mlir
+
+#endif  // XLA_MLIR_TOOLS_MLIR_INTERPRETER_DIALECTS_SYMBOL_FINDER_H_

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
@@ -2,13 +2,13 @@
    which uses dlsym to locate a function or variable symbol (symbol_name) in the current process;
    it returns the symbol's address if found or an error if not */
    
-#ifndef _WIN32
-
 #include "xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h"
 #include <dlfcn.h>
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
+namespace mlir {
+namespace interpreter {
 absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
   void* sym = dlsym(RTLD_DEFAULT, symbol_name.c_str());
   if (sym == nullptr) {
@@ -16,4 +16,5 @@ absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
   }
   return sym;
 }
-#endif  // !_WIN32
+}  // namespace interpreter
+}  // namespace mlir

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
@@ -1,3 +1,7 @@
+/* This code defines a POSIX-compatible function, FindSymbolInProcess, 
+   which uses dlsym to locate a function or variable symbol (symbol_name) in the current process;
+   it returns the symbol's address if found or an error if not */
+   
 #ifndef _WIN32
 
 #include "symbol_finder.h"

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
@@ -1,0 +1,16 @@
+#ifndef _WIN32
+
+#include "symbol_finder.h"
+#include <dlfcn.h>
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
+  void* sym = dlsym(RTLD_DEFAULT, symbol_name.c_str());
+  if (sym == nullptr) {
+    return absl::NotFoundError("Callee not found");
+  }
+  return sym;
+}
+
+#endif  // !_WIN32

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
@@ -4,7 +4,7 @@
    
 #ifndef _WIN32
 
-#include "symbol_finder.h"
+#include "xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h"
 #include <dlfcn.h>
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_linux.cc
@@ -16,5 +16,4 @@ absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
   }
   return sym;
 }
-
 #endif  // !_WIN32

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
@@ -1,12 +1,13 @@
 /* Implemented Function FindSymbolInProcess locate a function or variable
  symbol in the current process's address space */
 
-#ifdef _WIN32
-
 #include "xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h"
 #include <windows.h>
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+
+namespace mlir {
+namespace interpreter {
 
 absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
   HMODULE handle = GetModuleHandle(NULL);
@@ -20,4 +21,5 @@ absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
     return absl::InternalError("Failed to get module handle");
   }
 }
-#endif  // _WIN32
+}  // namespace interpreter
+}  // namespace mlir

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
@@ -3,7 +3,7 @@
 
 #ifdef _WIN32
 
-#include "symbol_finder.h"
+#include "xla/mlir/tools/mlir_interpreter/dialects/symbol_finder.h"
 #include <windows.h>
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
@@ -20,5 +20,4 @@ absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
     return absl::InternalError("Failed to get module handle");
   }
 }
-
 #endif  // _WIN32

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
@@ -1,3 +1,6 @@
+/* Implemented Function FindSymbolInProcess locate a function or variable
+ symbol in the current process's address space */
+
 #ifdef _WIN32
 
 #include "symbol_finder.h"

--- a/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
+++ b/xla/mlir/tools/mlir_interpreter/dialects/symbol_finder_windows.cc
@@ -1,0 +1,21 @@
+#ifdef _WIN32
+
+#include "symbol_finder.h"
+#include <windows.h>
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+absl::StatusOr<void*> FindSymbolInProcess(const std::string& symbol_name) {
+  HMODULE handle = GetModuleHandle(NULL);
+  if (handle) {
+    void* sym = GetProcAddress(handle, symbol_name.c_str());
+    if (!sym) {
+      return absl::NotFoundError("Callee not found");
+    }
+    return sym;
+  } else {
+    return absl::InternalError("Failed to get module handle");
+  }
+}
+
+#endif  // _WIN32

--- a/xla/mlir/tools/mlir_interpreter/framework/registration.h
+++ b/xla/mlir/tools/mlir_interpreter/framework/registration.h
@@ -163,7 +163,7 @@ void RegisterTypedInterpreterOpImpl(Ret (*fn)(InterpreterState&, Op, T... args),
           return {};
         }
         int64_t used_args = 0;
-        for (auto i : llvm::seq(0ul, sizeof...(T))) {
+        for (auto i : llvm::seq<unsigned long>(0, sizeof...(T))) {
           used_args += cast.getODSOperandIndexAndLength(i).second;
         }
         if (args.size() != used_args) {


### PR DESCRIPTION
This PR aims to enable the XLA/mlir/tool test cases on the Windows Platform.

Error:
//xla/mlir/tools/mlir_bisect/... tests were failing on the Windows platform with the errors shown below:

Errors
Error 1.Error with llvm::seq
no matching function for call to 'seq'
for (auto i : llvm::seq(0ul, sizeof...(T))) {
Solution: change to llvm::seq(0, sizeof...(T))
By explicitly specifying the type (unsigned long) in llvm::seq, the compiler now clearly understands the type of the sequence.

Error 2. Missing dlfcn.h:
Location: xla/mlir/tools/mlir_interpreter/dialects/func.cc
fatal error: 'dlfcn.h' file not found
Solution: include 'windows.h' for Windows platform
Error 3.
Use of Undeclared Identifiers sym and RTLD_DEFAULT:
Location: xla/mlir/tools/mlir_interpreter/dialects/func.cc
use of undeclared identifier 'sym'
sym = dlsym(RTLD_DEFAULT, callee.getSymName().str().c_str());
^
use of undeclared identifier 'RTLD_DEFAULT'
Solution:
On Windows, the approach to obtaining a symbol's address differs from Unix-based systems.
GetModuleHandle function retrieves a handle to the specified module (DLL) that is loaded in the address space of the calling process. This handle is necessary to access the module's symbols.
GetProcAddress function locates the address of an exported function or variable by name.