### PR TITLE
[XLA:CPU][oneDNN] Refactor and parameterize oneDNN convolution tests

### DIFF
--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -402,6 +402,7 @@ xla_cc_test(
         "//xla/tests:hlo_test_base",
         "//xla/tests:test_macros_header",
         "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/strings",
         "@tsl//tsl/platform:platform_port",
     ],
 )

--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -396,12 +396,12 @@ xla_cc_test(
         "//xla:test_helpers",
         "//xla/hlo/utils:hlo_matchers",
         "//xla/service:cpu_plugin",
+        "//xla/service/cpu:onednn_contraction_rewriter",
         "//xla/service/cpu:onednn_util",
         "//xla/tests:filecheck",
         "//xla/tests:hlo_test_base",
         "//xla/tests:test_macros_header",
         "//xla/tests:xla_internal_test_main",
-        "//xla/service/cpu:onednn_contraction_rewriter",
         "@tsl//tsl/platform:platform_port",
     ],
 )

--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -396,12 +396,12 @@ xla_cc_test(
         "//xla:test_helpers",
         "//xla/hlo/utils:hlo_matchers",
         "//xla/service:cpu_plugin",
-        "//xla/service/cpu:onednn_contraction_rewriter",
         "//xla/service/cpu:onednn_util",
         "//xla/tests:filecheck",
         "//xla/tests:hlo_test_base",
         "//xla/tests:test_macros_header",
         "//xla/tests:xla_internal_test_main",
+        "//xla/service/cpu:onednn_contraction_rewriter",
         "@tsl//tsl/platform:platform_port",
     ],
 )

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <utility>
 
+#include "absl/strings/substitute.h"
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/literal.h"
 #include "xla/service/cpu/onednn_contraction_rewriter.h"
@@ -32,7 +33,8 @@ limitations under the License.
 namespace xla {
 namespace cpu {
 
-class ConvolutionTest : public HloTestBase {
+class ConvolutionTest : public HloTestBase,
+                        public ::testing::WithParamInterface<PrimitiveType> {
  protected:
   DebugOptions GetDebugOptionsForTest() override {
     DebugOptions debug_options = HloTestBase::GetDebugOptionsForTest();
@@ -40,150 +42,211 @@ class ConvolutionTest : public HloTestBase {
     return debug_options;
   }
 
-  const char* conv_rewrite_str_ = R"(
-    ; CHECK:     custom_call_target="__onednn$convolution",
+  PrimitiveType dtype;
+  std::string dtypeString;
+  bool user_scratchpad;
+  bool weights_prepacked;
+  float atol;
+  float rtol;
+
+  constexpr static char* conv_rewrite_str_ = R"(
+    ; CHECK:     custom_call_target="__onednn$$convolution",
     ; CHECK:       backend_config={
     ; CHECK-DAG:     "outer_dimension_partitions":[],
-    ; CHECK-DAG:       "onednn_conv_config":{
-    ; CHECK-DAG:   }
-    ; CHECK:     }
+    ; CHECK-DAG:       "onednn_conv_config":{$0$1
+    ; CHECK-DAG:    }
+    ; CHECK:      }
     )";
 
-  const char* conv_rewrite_bias_str_ = R"(
-    ; CHECK:     custom_call_target="__onednn$convolution",
-    ; CHECK:       backend_config={
-    ; CHECK-DAG:     "outer_dimension_partitions":[],
-    ; CHECK-DAG:       "onednn_conv_config":{
-    ; CHECK-DAG:       "fusions":{
-    ; CHECK-DAG:         "ops":["BIAS"]
-    ; CHECK-DAG:     }
-    ; CHECK-DAG:   }
-    ; CHECK:     }
-    )";
+  constexpr static char* conv_rewrite_fusions_str_ = R"(
+    ; CHECK-DAG:          "fusions":{
+    ; CHECK-DAG:            "ops":[$0]
+    ; CHECK-DAG:      },)";
 
-  const char* fused_convolution_binary_add_ = R"(
-    ; CHECK:     custom_call_target="__onednn$convolution",
-    ; CHECK:       backend_config={
-    ; CHECK-DAG:     "outer_dimension_partitions":[],
-    ; CHECK-DAG:       "onednn_conv_config":{
-    ; CHECK-DAG:       "fusions":{
-    ; CHECK-DAG:         "ops":["BINARY_ADD"]
-    ; CHECK-DAG:     }
-    ; CHECK-DAG:   }
-    ; CHECK:     }
-    )";
+  constexpr static char* conv_rewrite_optimizations_str_ = R"(
+    ; CHECK-DAG:          "optimization_config":{
+    ; CHECK-DAG:            "weights_prepacked":$0,
+    ; CHECK-DAG:            "user_scratchpad":$1,
+    ; CHECK-DAG:      })";
+
+  ConvolutionTest() {
+    dtype = GetParam();
+    atol = rtol = (dtype == F32) ? 1e-4 : 1e-2;
+    // TODO(intel-tf): Set default value of user_scratchpad to true after
+    // enabling feature
+    user_scratchpad = false;
+    weights_prepacked = false;
+    dtypeString = primitive_util::LowercasePrimitiveTypeName(dtype);
+  }
+
+  void SetUp() override {
+    if (!IsSupportedType(dtype)) {
+      GTEST_SKIP() << "CPU does not support " << dtypeString;
+    }
+  }
+
+  void SetWeightsPrepacked(bool value) { weights_prepacked = value; }
+
+  void SetUserScratchpad(bool value) { user_scratchpad = value; }
+
+  std::string GetOptimizationsString() {
+    return (user_scratchpad || weights_prepacked)
+               ? absl::Substitute(conv_rewrite_optimizations_str_,
+                                  weights_prepacked, user_scratchpad)
+               : "";
+  }
+
+  std::string ConvStringWithOptimizations(
+      const std::vector<absl::string_view> fused_ops) {
+    std::ostringstream stream;
+    std::for_each(
+        fused_ops.begin(), fused_ops.end(),
+        [&](const absl::string_view& arg) { stream << "\"" << arg << "\","; });
+    std::string fusions = stream.str();
+    if (fused_ops.size() > 0) {
+      fusions.pop_back();
+      return absl::Substitute(
+          conv_rewrite_str_,
+          absl::Substitute(conv_rewrite_fusions_str_, fusions),
+          GetOptimizationsString());
+    }
+    return absl::Substitute(conv_rewrite_str_, "", GetOptimizationsString());
+  }
+
+  // TODO(intel-tf): Remove this and simplify patterns when Elemental BF16 is
+  // fully supported.
+  PrimitiveType PromotedDtype() {
+    // BF16 is promoted to F32 because not all HLO Instructions currently
+    // support BF16 computations. Meanwhile, FP32 and FP16 elementwise
+    // instructions are not promoted and remain unchanged.
+    switch (dtype) {
+      case F16:
+        return F16;
+      case F32:
+      case BF16:
+      default:
+        return F32;
+    }
+  }
+
+  void AdjustToleranceForDtype(PrimitiveType for_type, float atol_arg,
+                               float rtol_arg) {
+    if (dtype == for_type) {
+      atol = atol_arg;
+      rtol = rtol_arg;
+    }
+  }
+
+  std::string PromotedDtypeToString() {
+    auto promoted_type = PromotedDtype();
+    return primitive_util::LowercasePrimitiveTypeName(promoted_type);
+  }
+
+  void RunCompareAndMatchOptimizedHlo(
+      const absl::string_view outline,
+      const std::vector<absl::string_view> fused_ops) {
+    const std::string convolution_module_str =
+        absl::Substitute(outline, dtypeString, PromotedDtypeToString());
+    EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{atol, rtol}));
+    MatchOptimizedHlo(convolution_module_str,
+                      ConvStringWithOptimizations(fused_ops));
+  }
 };
 
-TEST_F(ConvolutionTest, Simple2DTestF32) {
-  const char* convolution_module_str = R"(
-  HloModule convolution.test.f32
+TEST_P(ConvolutionTest, Simple2DTest1) {
+  const absl::string_view outline = R"(
+  HloModule convolution.test
 
-  ENTRY convolution.test.f32 {
-    arg.0 = f32[1,22,22,1] parameter(0)
-    reshape.0 = f32[1,22,22,1] reshape(arg.0)
-    arg.1 = f32[8,8,1,1] parameter(1)
-    reshape.1 = f32[8,8,1,1] reshape(arg.1)
-    convolution.0 = f32[1,11,11,1] convolution(reshape.0, reshape.1), window={size=8x8 stride=2x2 pad=3_3x3_3}, dim_labels=b01f_01io->b01f
-    reshape.2 = f32[1,11,11,1] reshape(convolution.0)
-    tuple.0 = (f32[1,11,11,1]) tuple(reshape.2)
-    ROOT get-tuple-element.0 = f32[1,11,11,1] get-tuple-element(tuple.0), index=0
+  ENTRY convolution.test {
+    arg.0 = $0[1,22,22,1] parameter(0)
+    reshape.0 = $0[1,22,22,1] reshape(arg.0)
+    arg.1 = $0[8,8,1,1] parameter(1)
+    reshape.1 = $0[8,8,1,1] reshape(arg.1)
+    convolution.0 = $0[1,11,11,1] convolution(reshape.0, reshape.1), window={size=8x8 stride=2x2 pad=3_3x3_3}, dim_labels=b01f_01io->b01f
+    reshape.2 = $0[1,11,11,1] reshape(convolution.0)
+    tuple.0 = ($0[1,11,11,1]) tuple(reshape.2)
+    ROOT get-tuple-element.0 = $0[1,11,11,1] get-tuple-element(tuple.0), index=0
   })";
 
-  EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{1e-4, 1e-4}));
-  MatchOptimizedHlo(convolution_module_str, conv_rewrite_str_);
+  RunCompareAndMatchOptimizedHlo(outline, {});
 }
 
-TEST_F(ConvolutionTest, Simple3DTestBF16) {
-  if (!IsSupportedType(PrimitiveType::BF16)) {
-    GTEST_SKIP() << "CPU does not support BF16.";
-  }
+TEST_P(ConvolutionTest, Simple3DTest1) {
+  const absl::string_view outline = R"(
+  HloModule convolution.test
 
-  const char* convolution_module_str = R"(
-  HloModule convolution.test.bf16
-
-  ENTRY convolution.test.bf16 {
-    p0 = bf16[8,4,5,5,1] parameter(0)
-    p1 = bf16[3,3,3,1,32] parameter(1)
-    ROOT conv = bf16[8,4,5,5,32] convolution(p0, p1), window={size=3x3x3 pad=1_1x1_1x1_1}, dim_labels=b012f_012io->b012f
+  ENTRY convolution.test {
+    p0 = $0[8,4,5,5,1] parameter(0)
+    p1 = $0[3,3,3,1,32] parameter(1)
+    ROOT conv = $0[8,4,5,5,32] convolution(p0, p1), window={size=3x3x3 pad=1_1x1_1x1_1}, dim_labels=b012f_012io->b012f
 })";
 
-  EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{1e-4, 1e-4}));
-  MatchOptimizedHlo(convolution_module_str, conv_rewrite_str_);
+  RunCompareAndMatchOptimizedHlo(outline, {});
 }
 
-TEST_F(ConvolutionTest, Simple2DTestF16) {
-  if (!IsSupportedType(PrimitiveType::F16)) {
-    GTEST_SKIP() << "CPU does not support F16.";
-  }
+TEST_P(ConvolutionTest, Conv3DWithBiasTest) {
+  const absl::string_view outline = R"(
+  HloModule convolution.test.with.bias
 
-  const char* convolution_module_str = R"(
-  HloModule convolution.test.f16
-
-  ENTRY convolution.test.bf16 {
-    p0 = f16[8,4,5,5,1] parameter(0)
-    p1 = f16[3,3,3,1,32] parameter(1)
-    ROOT conv = f16[8,4,5,5,32] convolution(p0, p1), window={size=3x3x3 pad=1_1x1_1x1_1}, dim_labels=b012f_012io->b012f
+  ENTRY convolution.test.with.bias {
+    arg.0 = $0[15,4,5,5,28] parameter(0)
+    arg.1 = $0[3,3,3,28,64] parameter(1)
+    conv = $0[15,4,5,5,64] convolution(arg.0, arg.1), window={size=3x3x3 pad=1_1x1_1x1_1}, dim_labels=b012f_012io->b012f
+    bias = $0[64] parameter(2)
+    broadcasted_bias = $0[15,4,5,5,64] broadcast(bias), dimensions={4}
+    ROOT add = $0[15,4,5,5,64] add(conv, broadcasted_bias)
 })";
 
-  EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{1e-4, 1e-4}));
-  MatchOptimizedHlo(convolution_module_str, conv_rewrite_str_);
+  RunCompareAndMatchOptimizedHlo(outline, {"BIAS"});
 }
 
-TEST_F(ConvolutionTest, Conv3DWithBiasBF16) {
-  const char* convolution_module_str = R"(
-  HloModule convolution.test.with.bias.relu.bf16.3D
+TEST_P(ConvolutionTest, Conv2DWithBinaryAddTest) {
+  const absl::string_view outline = R"(
+  HloModule convolution.test.with.binaryadd
 
-  ENTRY TestComputation {
-    arg.0 = bf16[15,4,5,5,28] parameter(0)
-    arg.1 = bf16[3,3,3,28,64] parameter(1)
-    conv = bf16[15,4,5,5,64] convolution(arg.0, arg.1), window={size=3x3x3 pad=1_1x1_1x1_1}, dim_labels=b012f_012io->b012f
-    bias = bf16[64] parameter(2)
-    broadcasted_bias = bf16[15,4,5,5,64] broadcast(bias), dimensions={4}
-    ROOT add = bf16[15,4,5,5,64] add(conv, broadcasted_bias)
-})";
-  EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{0.01, 0.01}));
-  MatchOptimizedHlo(convolution_module_str, conv_rewrite_bias_str_);
-}
-
-TEST_F(ConvolutionTest, SimpleTestF32WithBinaryAddFusion1) {
-  const char* convolution_module_str = R"(
-  HloModule conv.binaryadd.test.f32
-
-  ENTRY matmul.biasadd.test.f32 {
-    arg0.1 = f32[1,22,22,1] parameter(0)
-    constant.3 = f32[] constant(1)
-    broadcast.4 = f32[8,8,1,1] broadcast(constant.3), dimensions={}
-    convolution.0 = f32[1,11,11,1] convolution(arg0.1, broadcast.4), window={size=8x8 stride=2x2 pad=3_3x3_3}, dim_labels=b01f_01io->b01f
-    constant.5 = f32[] constant(15)
-    broadcast.6 = f32[1] broadcast(constant.5), dimensions={}
-    broadcast.9 = f32[1,11,11,1] broadcast(broadcast.6), dimensions={3}
-    ROOT add.10 = f32[1,11,11,1] add(convolution.0, broadcast.9)
+  ENTRY convolution.test.with.binaryadd {
+    arg0.1 = $0[1,22,22,1] parameter(0)
+    constant.3 = $0[] constant(1)
+    broadcast.4 = $0[8,8,1,1] broadcast(constant.3), dimensions={}
+    convolution.0 = $0[1,11,11,1] convolution(arg0.1, broadcast.4), window={size=8x8 stride=2x2 pad=3_3x3_3}, dim_labels=b01f_01io->b01f
+    constant.5 = $0[] constant(15)
+    broadcast.6 = $0[1] broadcast(constant.5), dimensions={}
+    broadcast.9 = $0[1,11,11,1] broadcast(broadcast.6), dimensions={3}
+    ROOT add.10 = $0[1,11,11,1] add(convolution.0, broadcast.9)
   })";
 
-  EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{1e-4, 1e-4}));
-  MatchOptimizedHlo(convolution_module_str, fused_convolution_binary_add_);
+  RunCompareAndMatchOptimizedHlo(outline, {"BINARY_ADD"});
 }
 
-// This test should match BIAS + Residual Add when the residual add fusion is
+// This test should match BIAS + RESIDUAL ADD when the residual add fusion is
 // re-enabled.
-TEST_F(ConvolutionTest, SimpleTestBF16WithBiasAndAddFusion) {
-  const char* convolution_module_str = R"(
-  HloModule convolution.add.test.bf16
+TEST_P(ConvolutionTest, Conv2DWithBiasAndBinaryAddTest) {
+  const absl::string_view outline = R"(
+  HloModule convolution.add.test
 
-  ENTRY convolution.add.test.bf16 {
-    arg0.1 = bf16[1,22,22,1] parameter(0)
-    arg0.2 = bf16[8,8,1,10] parameter(1)
-    convolution.0 = bf16[1,11,11,10] convolution(arg0.1, arg0.2), window={size=8x8 stride=2x2 pad=3_3x3_3}, dim_labels=b01f_01io->b01f
-    const.0 = bf16[10] constant(15)
-    bcast.1 = bf16[1,11,11,10] broadcast(const.0), dimensions={3}
-    add.0 = bf16[1,11,11,10] add(convolution.0, bcast.1)
-    const.1 = bf16[1,11,11,10] constant({...})
-    ROOT add.1 = bf16[1,11,11,10] add(add.0, const.1)
+  ENTRY convolution.add.test {
+    arg0.1 = $0[1,22,22,1] parameter(0)
+    arg0.2 = $0[8,8,1,10] parameter(1)
+    convolution.0 = $0[1,11,11,10] convolution(arg0.1, arg0.2), window={size=8x8 stride=2x2 pad=3_3x3_3}, dim_labels=b01f_01io->b01f
+    const.0 = $0[10] constant(15)
+    bcast.1 = $0[1,11,11,10] broadcast(const.0), dimensions={3}
+    add.0 = $0[1,11,11,10] add(convolution.0, bcast.1)
+    const.1 = $0[1,11,11,10] constant({...})
+    ROOT add.1 = $0[1,11,11,10] add(add.0, const.1)
   })";
 
-  EXPECT_TRUE(RunAndCompare(convolution_module_str, ErrorSpec{1e-2, 1e-2}));
-  MatchOptimizedHlo(convolution_module_str, conv_rewrite_bias_str_);
+  RunCompareAndMatchOptimizedHlo(outline, {"BIAS"});
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    OneDnnConvolutionTestSuite, ConvolutionTest,
+    ::testing::Values(F32, BF16, F16),
+    [](const ::testing::TestParamInfo<ConvolutionTest::ParamType>& info) {
+      auto infoString = primitive_util::LowercasePrimitiveTypeName(info.param);
+      std::transform(infoString.begin(), infoString.end(), infoString.begin(),
+                     [](auto c) { return std::toupper(c); });
+      return infoString;
+    });
 
 }  // namespace cpu
 }  // namespace xla

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -49,7 +49,7 @@ class ConvolutionTest : public HloTestBase,
   float atol_;
   float rtol_;
 
-  constexpr static char* kConvRewriteStr = R"(
+  constexpr static const char* kConvRewriteStr = R"(
     ; CHECK:     custom_call_target="__onednn$convolution",
     ; CHECK:       backend_config={
     ; CHECK-DAG:     "outer_dimension_partitions":[],
@@ -58,12 +58,12 @@ class ConvolutionTest : public HloTestBase,
     ; CHECK:      }
     )";
 
-  constexpr static char* kConvRewriteFusionsStr = R"(
+  constexpr static const char* kConvRewriteFusionsStr = R"(
     ; CHECK-DAG:          "fusions":{
     ; CHECK-DAG:            "ops":[$fused_ops]
     ; CHECK-DAG:      },)";
 
-  constexpr static char* kConvRewriteOptimizationsStr = R"(
+  constexpr static const char* kConvRewriteOptimizationsStr = R"(
     ; CHECK-DAG:          "optimization_config":{
     ; CHECK-DAG:            "weights_prepacked":$weights_prepacked,
     ; CHECK-DAG:            "user_scratchpad":$user_scratchpad,


### PR DESCRIPTION
This PR refactors and parametrizes the existing tests in the oneDNN convolution test file. Each test now runs with F32, BF16 and F16 precisions on supported hardware.