### PR TITLE
[Draft] [ROCm] removing #ifdef CUDA / ROCM macros where possible

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -437,13 +437,10 @@ TEST(PJRTGpuDeviceTopologyTest, CreateGpuTopology) {
       reinterpret_cast<const PJRT_TopologyDescription*>(args.topology);
   ASSERT_NE(pjrt_topology, nullptr);
 
-#ifdef TENSORFLOW_USE_ROCM
-  EXPECT_EQ(pjrt_topology->topology->platform_id(), xla::RocmId());
-  EXPECT_EQ(pjrt_topology->topology->platform_name(), xla::RocmName());
-#else
-  EXPECT_EQ(pjrt_topology->topology->platform_id(), xla::CudaId());
-  EXPECT_EQ(pjrt_topology->topology->platform_name(), xla::CudaName());
-#endif
+  EXPECT_TRUE((pjrt_topology->topology->platform_id() == xla::CudaId() &&
+               pjrt_topology->topology->platform_name() == xla::CudaName()) ||
+              (pjrt_topology->topology->platform_id() == xla::RocmId() &&
+               pjrt_topology->topology->platform_name() == xla::RocmName()));
 
   PJRT_TopologyDescription_Destroy_Args destroy_args;
   destroy_args.struct_size = PJRT_TopologyDescription_Destroy_Args_STRUCT_SIZE;
@@ -507,8 +504,10 @@ TEST(PJRTGpuDeviceTopologyTest, CreateExplicitGpuTopologyAndTargetConfig) {
       reinterpret_cast<const PJRT_TopologyDescription*>(args.topology);
   ASSERT_NE(pjrt_topology, nullptr);
 
-  EXPECT_EQ(pjrt_topology->topology->platform_id(), xla::CudaId());
-  EXPECT_EQ(pjrt_topology->topology->platform_name(), xla::CudaName());
+  EXPECT_TRUE((pjrt_topology->topology->platform_id() == xla::CudaId() &&
+               pjrt_topology->topology->platform_name() == xla::CudaName()) ||
+              (pjrt_topology->topology->platform_id() == xla::RocmId() &&
+               pjrt_topology->topology->platform_name() == xla::RocmName()));
 
   EXPECT_EQ(pjrt_topology->topology->ProcessCount().value(), 16 * 2);
   EXPECT_EQ(pjrt_topology->topology->DeviceDescriptions().size(), 16 * 2 * 4);


### PR DESCRIPTION
Hi @xla-rotation, I'm new to XLA and I intend to work on the ROCm side. I thought I could remove some `#ifdef USE_ROCM` macros as a way to get familiar with the repo. Before I go ahead and make a mess, do you have any general advice or preferences on how to achieve this?

I guess I can start with the tests, and try to replace the compile-time `#if #else` with runtime checks? As an example, see the use of `PlatformUtil::CanonicalPlatformName` below. Internally it still uses macros, but at least those are more localized to a single place now.