### PR TITLE
Partially Replicated Instructions in Replication Analysis

### DIFF
--- a/xla/hlo/transforms/BUILD
+++ b/xla/hlo/transforms/BUILD
@@ -361,6 +361,8 @@ cc_library(
         "//xla/hlo/analysis:hlo_replication_analysis",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
+        "//xla/service:collective_ops_utils",
+        "//xla/service:hlo_replication_analysis",
         "//xla/service:pattern_matcher",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status:statusor",

--- a/xla/hlo/transforms/collectives/collective_quantizer_test.cc
+++ b/xla/hlo/transforms/collectives/collective_quantizer_test.cc
@@ -88,7 +88,7 @@ TEST_F(CollectiveQuantizerTest, AllGatherQuantize) {
   HloModule module
   ENTRY entry {
     param = bf16[8,4,8,128] parameter(0)
-    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1, use_global_device_ids=true
     scale = bf16[] parameter(1), sharding={replicated}
     scale_bcast = bf16[8,32,8,128] broadcast(scale), dimensions={}
     divide = bf16[8,32,8,128] divide(all-gather, scale_bcast)
@@ -206,7 +206,7 @@ TEST_F(CollectiveQuantizerTest, AllGatherQuantizeUnary) {
   HloModule module
   ENTRY entry {
     param = bf16[8,4,8,128] parameter(0)
-    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1, use_global_device_ids=true
     reshape = bf16[8,32,1024] reshape(all-gather)
     slice = bf16[8,32,512] slice(reshape), slice={[0:8], [0:32], [256:768]}
     scale = bf16[] parameter(1), sharding={replicated}
@@ -279,6 +279,211 @@ TEST_F(CollectiveQuantizerTest, AllGatherQuantizeNonReplicatedScale) {
   EXPECT_FALSE(changed);
 }
 
+TEST_F(CollectiveQuantizerTest, AllGatherQuantizePartialReplication) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  ENTRY entry {
+    param = bf16[8,4,8,128] parameter(0)
+    all-gather = bf16[8,16,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1, use_global_device_ids=true
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] all-reduce(scalar_scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2, use_global_device_ids=true
+    scale_bcast = bf16[8,16,8,128] broadcast(all_reduced_scale), dimensions={}
+    divide = bf16[8,16,8,128] divide(all-gather, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,16,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,16,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,16,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,16,8,128] convert(clamp)
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))));
+  HloInstruction* all_gather = module->entry_computation()->root_instruction();
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, AllToAllQuantizePartialReplication) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  ENTRY entry {
+    param = bf16[8,32,8,128] parameter(0)
+    all-to-all = bf16[8,32,8,128] all-to-all(param), dimensions={1}, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] all-reduce(scalar_scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2, use_global_device_ids=true
+    scale_bcast = bf16[8,32,8,128] broadcast(all_reduced_scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(all-to-all, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllToAll(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))));
+  HloInstruction* all_to_all = module->entry_computation()->root_instruction();
+  EXPECT_THAT(all_to_all->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest,
+       AllToAllQuantizePartialReplicationSeparateComputation) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  all_reduce {
+    scale = bf16[] parameter(0)
+    ROOT all_reduced_scale = bf16[] all-reduce(scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2, use_global_device_ids=true
+  }
+
+  ENTRY entry {
+    param = bf16[8,32,8,128] parameter(0)
+    all-to-all = bf16[8,32,8,128] all-to-all(param), dimensions={1}, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] call(scalar_scale), to_apply=all_reduce
+    scale_bcast = bf16[8,32,8,128] broadcast(all_reduced_scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(all-to-all, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllToAll(op::Convert(op::Clamp(
+                  op::Broadcast(), op::Divide(op::Parameter(), op::Broadcast()),
+                  op::Broadcast()))));
+  HloInstruction* all_to_all = module->entry_computation()->root_instruction();
+  EXPECT_THAT(all_to_all->shape().element_type(), F8E4M3FN);
+}
+
+// Expecting no change as the all-reduced scale is not replicated identically to
+// the all-gather.
+TEST_F(CollectiveQuantizerTest,
+       AllGatherQuantizePartialReplicationGroupMismatch) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  ENTRY entry {
+    param = bf16[8,4,8,128] parameter(0)
+    all-gather = bf16[8,32,8,128] all-gather(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1, use_global_device_ids=true
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] all-reduce(scalar_scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2, use_global_device_ids=true
+    scale_bcast = bf16[8,32,8,128] broadcast(all_reduced_scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(all-gather, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+// Expecting no change as the all-reduced scale is not replicated identically to
+// the all-gather.
+TEST_F(CollectiveQuantizerTest,
+       AllToAllQuantizePartialReplicationGroupMismatchSeparateComputation) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  all_reduce {
+    scale = bf16[] parameter(0)
+    ROOT all_reduced_scale = bf16[] all-reduce(scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2, use_global_device_ids=true
+  }
+
+  ENTRY entry {
+    param = bf16[8,32,8,128] parameter(0)
+    all-to-all = bf16[8,32,8,128] all-to-all(param), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] call(scalar_scale), to_apply=all_reduce
+    scale_bcast = bf16[8,32,8,128] broadcast(all_reduced_scale), dimensions={}
+    divide = bf16[8,32,8,128] divide(all-to-all, scale_bcast)
+    clamp_lower = bf16[] constant(-448.0)
+    clamp_lower_bcast = bf16[8,32,8,128] broadcast(clamp_lower), dimensions={}
+    clamp_upper = bf16[] constant(448.0)
+    clamp_upper_bcast = bf16[8,32,8,128] broadcast(clamp_upper), dimensions={}
+    clamp = bf16[8,32,8,128] clamp(clamp_lower_bcast, divide, clamp_upper_bcast)
+    ROOT convert = f8e4m3fn[8,32,8,128] convert(clamp)
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_FALSE(changed);
+}
+
 TEST_F(CollectiveQuantizerTest, ConvertAllGather) {
   absl::string_view hlo_string = R"(
   HloModule module
@@ -331,7 +536,7 @@ TEST_F(CollectiveQuantizerTest, DequantizeAllGather) {
     scale = bf16[] parameter(1), sharding={replicated}
     scale_bcast = bf16[8,4,8,128] broadcast(scale), dimensions={}
     multiply = bf16[8,4,8,128] multiply(convert, scale_bcast)
-    ROOT all-gather = bf16[8,32,8,128] all-gather(multiply), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    ROOT all-gather = bf16[8,32,8,128] all-gather(multiply), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1, use_global_device_ids=true
     }
   )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
@@ -430,7 +635,7 @@ TEST_F(CollectiveQuantizerTest, DequantizeAllGatherUnary) {
     multiply = bf16[8,4,8,128] multiply(convert, scale_bcast)
     reshape = bf16[8,4,1024] reshape(multiply)
     slice = bf16[8,4,512] slice(reshape), slice={[0:8], [0:4], [256:768]}
-    ROOT all-gather = bf16[8,32,512] all-gather(slice), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1
+    ROOT all-gather = bf16[8,32,512] all-gather(slice), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=1, use_global_device_ids=true
     }
   )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
@@ -447,6 +652,186 @@ TEST_F(CollectiveQuantizerTest, DequantizeAllGatherUnary) {
                                    ->mutable_operand(0)
                                    ->mutable_operand(0);
   EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, DequantizeAllGatherPartialReplication) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  ENTRY entry {
+    param = f8e4m3fn[8,4,8,128] parameter(0)
+    convert = bf16[8,4,8,128] convert(param)
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] all-reduce(scalar_scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1, use_global_device_ids=true
+    scale_bcast = bf16[8,4,8,128] broadcast(all_reduced_scale), dimensions={}
+    multiply = bf16[8,4,8,128] multiply(convert, scale_bcast)
+    ROOT all-gather = bf16[8,16,8,128] all-gather(multiply), dimensions={1}, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2, use_global_device_ids=true
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Multiply(op::Convert(op::AllGather(op::Parameter())),
+                           op::Broadcast()));
+  const HloInstruction* all_gather =
+      module->entry_computation()->root_instruction()->operand(0)->operand(0);
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest, DequantizeAllToAllPartialReplication) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  ENTRY entry {
+    param = f8e4m3fn[8,32,8,128] parameter(0)
+    convert = bf16[8,32,8,128] convert(param)
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] all-reduce(scalar_scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1, use_global_device_ids=true
+    scale_bcast = bf16[8,32,8,128] broadcast(all_reduced_scale), dimensions={}
+    multiply = bf16[8,32,8,128] multiply(convert, scale_bcast)
+    ROOT all-to-all = bf16[8,32,8,128] all-to-all(multiply), dimensions={1}, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Multiply(op::Convert(op::AllToAll(op::Parameter())),
+                           op::Broadcast()));
+  const HloInstruction* all_gather =
+      module->entry_computation()->root_instruction()->operand(0)->operand(0);
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+TEST_F(CollectiveQuantizerTest,
+       DequantizeAllToAllPartialReplicationSeparateComputation) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  all_reduce {
+    scale = bf16[] parameter(0)
+    ROOT all_reduced_scale = bf16[] all-reduce(scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1, use_global_device_ids=true
+  }
+
+  ENTRY entry {
+    param = f8e4m3fn[8,32,8,128] parameter(0)
+    convert = bf16[8,32,8,128] convert(param)
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] call(scalar_scale), to_apply=all_reduce
+    scale_bcast = bf16[8,32,8,128] broadcast(all_reduced_scale), dimensions={}
+    multiply = bf16[8,32,8,128] multiply(convert, scale_bcast)
+    ROOT all-to-all = bf16[8,32,8,128] all-to-all(multiply), dimensions={1}, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=2
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Multiply(op::Convert(op::AllToAll(op::Parameter())),
+                           op::Broadcast()));
+  const HloInstruction* all_gather =
+      module->entry_computation()->root_instruction()->operand(0)->operand(0);
+  EXPECT_THAT(all_gather->shape().element_type(), F8E4M3FN);
+}
+
+// Expecting no change as the all-reduced scale is not replicated identically to
+// the all-gather.
+TEST_F(CollectiveQuantizerTest,
+       DequantizeAllGatherPartialReplicationGroupMismatch) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  ENTRY entry {
+    param = f8e4m3fn[8,4,8,128] parameter(0)
+    convert = bf16[8,4,8,128] convert(param)
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] all-reduce(scalar_scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1, use_global_device_ids=true
+    scale_bcast = bf16[8,4,8,128] broadcast(all_reduced_scale), dimensions={}
+    multiply = bf16[8,4,8,128] multiply(convert, scale_bcast)
+    ROOT all-gather = bf16[8,32,8,128] all-gather(multiply), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=2, use_global_device_ids=true
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+// Expecting no change as the all-reduced scale is not replicated identically to
+// the all-gather.
+TEST_F(CollectiveQuantizerTest,
+       DequantizeAllToAllPartialReplicationGroupMismatchSeparateComputation) {
+  absl::string_view hlo_string = R"(
+  HloModule module
+  max {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT max = f32[] maximum(a, b)
+  }
+
+  all_reduce {
+    scale = bf16[] parameter(0)
+    ROOT all_reduced_scale = bf16[] all-reduce(scale), to_apply=max, replica_groups={{0,1,2,3},{4,5,6,7}}, channel_id=1, use_global_device_ids=true
+  }
+
+  ENTRY entry {
+    param = f8e4m3fn[8,32,8,128] parameter(0)
+    convert = bf16[8,32,8,128] convert(param)
+    scale = bf16[1] parameter(1), sharding={devices=[8]<=[8]}
+    scalar_scale = bf16[] reshape(scale)
+    all_reduced_scale = bf16[] call(scalar_scale), to_apply=all_reduce
+    scale_bcast = bf16[8,32,8,128] broadcast(all_reduced_scale), dimensions={}
+    multiply = bf16[8,32,8,128] multiply(convert, scale_bcast)
+    ROOT all-to-all = bf16[8,32,8,128] all-to-all(multiply), dimensions={1}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=2
+    }
+  )";
+
+  HloModuleConfig config;
+  config.set_num_partitions(8);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunCollectiveQuantizer(module.get()));
+  EXPECT_FALSE(changed);
 }
 
 }  // namespace

--- a/xla/service/collective_ops_utils.h
+++ b/xla/service/collective_ops_utils.h
@@ -118,6 +118,13 @@ absl::StatusOr<std::vector<int>> GetParticipatingIDs(
 absl::string_view CollectiveOpGroupModeToString(
     CollectiveOpGroupMode group_mode);
 
+// Returns the group formation mode of instr, assuming that instr is, or is
+// dervied from, an HloAllGatherInstruction, HloAllReduceInstructionBase,
+// HloAllToAllInstruction, HloCollectiveBroadcastInstruction or
+// HloCollectivePermuteInstruction.
+absl::StatusOr<CollectiveOpGroupMode> GetCollectiveOpGroupMode(
+    HloInstruction* instr);
+
 // Returns the group formation mode implied by (a) whether the operation has
 // channel_id and (b) if it has use_global_device_ids and if yes, its value.
 absl::StatusOr<CollectiveOpGroupMode> GetCollectiveOpGroupMode(

--- a/xla/service/collective_ops_utils_test.cc
+++ b/xla/service/collective_ops_utils_test.cc
@@ -307,6 +307,130 @@ TEST_P(GetCollectOpGroupModeTest, Test) {
 
 INSTANTIATE_TEST_SUITE_P(GetCollectOpGroupMode, GetCollectOpGroupModeTest,
                          testing::ValuesIn(GetTestCases()));
+
+// Tests for GetCollectiveOpGroupMode(HloInstruction*)
+struct TestCaseForInstruction {
+  HloOpcode op_code;
+  bool has_channel_id;
+  std::optional<bool> use_global_device_ids;
+  xla::CollectiveOpGroupMode expected_group_mode;
+};
+
+std::vector<TestCaseForInstruction> GetTestCasesForInstruction() {
+  return std::vector<TestCaseForInstruction>{
+      //  opcode, has_channel_id, use_global_device_ids, expected_group_mode
+      {HloOpcode::kAllGather, true, true, CollectiveOpGroupMode::kFlattenedID},
+      {HloOpcode::kAllGather, true, false,
+       CollectiveOpGroupMode::kCrossReplicaAndPartition},
+      {HloOpcode::kAllGather, false, false,
+       CollectiveOpGroupMode::kCrossReplica},
+      {HloOpcode::kAllReduce, true, true, CollectiveOpGroupMode::kFlattenedID},
+      {HloOpcode::kAllReduce, true, false,
+       CollectiveOpGroupMode::kCrossReplicaAndPartition},
+      {HloOpcode::kAllReduce, false, false,
+       CollectiveOpGroupMode::kCrossReplica},
+      {HloOpcode::kAllToAll, true, std::nullopt,
+       CollectiveOpGroupMode::kCrossPartition},
+      {HloOpcode::kAllToAll, false, std::nullopt,
+       CollectiveOpGroupMode::kCrossReplica},
+      {HloOpcode::kCollectiveBroadcast, true, std::nullopt,
+       CollectiveOpGroupMode::kCrossPartition},
+      {HloOpcode::kCollectiveBroadcast, false, std::nullopt,
+       CollectiveOpGroupMode::kCrossReplica},
+      {HloOpcode::kCollectivePermute, true, std::nullopt,
+       CollectiveOpGroupMode::kCrossPartition},
+      {HloOpcode::kCollectivePermute, false, std::nullopt,
+       CollectiveOpGroupMode::kCrossReplica}};
+}
+
+class GetCollectOpGroupModeTestForInstruction
+    : public testing::TestWithParam<TestCaseForInstruction> {};
+
+absl::StatusOr<std::unique_ptr<HloComputation>> CreateMaxComputation() {
+  Shape scalar = ShapeUtil::MakeScalarShape(F32);
+  auto builder_max = HloComputation::Builder("max");
+  TF_ASSIGN_OR_RETURN(HloInstruction * a,
+                      builder_max.AddParameter(
+                          HloInstruction::CreateParameter(0, scalar, "a")));
+  TF_ASSIGN_OR_RETURN(HloInstruction * b,
+                      builder_max.AddParameter(
+                          HloInstruction::CreateParameter(1, scalar, "b")));
+  HloInstruction *max = builder_max.AddInstruction(
+      HloInstruction::CreateBinary(scalar, HloOpcode::kMaximum, a, b), "max");
+  return builder_max.Build(max);
+}
+
+TEST_P(GetCollectOpGroupModeTestForInstruction, Test) {
+  const TestCaseForInstruction &test_case = GetParam();
+  ReplicaGroup group;
+  for (int k = 0; k < 4; ++k) {
+    group.add_replica_ids(k);
+  }
+  std::vector<std::pair<int64_t, int64_t>> source_target_pairs{{0, 1}, {2, 3}};
+
+  Shape two_elements = ShapeUtil::MakeShape(F32, {2});
+  Shape eight_elements = ShapeUtil::MakeShape(F32, {8});
+
+  auto channel_id = [&test_case]() -> std::optional<int64_t> {
+    return test_case.has_channel_id ? std::make_optional<int64_t>(1)
+                                    : std::nullopt;
+  };
+
+  auto use_global_device_ids = [&test_case]() -> bool {
+    return test_case.use_global_device_ids.value();
+  };
+
+  // Create the entry computation for testing the group mode of the collectives.
+  auto builder = HloComputation::Builder("entry");
+  TF_ASSERT_OK_AND_ASSIGN(HloInstruction * parameter,
+                          builder.AddParameter(HloInstruction::CreateParameter(
+                              0, two_elements, "parameter")));
+
+  HloInstruction *collective;
+  switch (test_case.op_code) {
+    case HloOpcode::kAllGather:
+      collective = builder.AddInstruction(HloInstruction::CreateAllGather(
+          eight_elements, {parameter}, 1, {group}, /*constrain_layout=*/true,
+          channel_id(), use_global_device_ids()));
+      break;
+    case HloOpcode::kAllReduce: {
+      // Create a computation to be applied by the all-reduce instruction.
+      TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloComputation> max_computation,
+                              CreateMaxComputation());
+
+      collective = builder.AddInstruction(HloInstruction::CreateAllReduce(
+          two_elements, {parameter}, max_computation.get(), {group},
+          /*constrain_layout=*/true, channel_id(), use_global_device_ids()));
+      break;
+    }
+    case HloOpcode::kAllToAll:
+      collective = builder.AddInstruction(HloInstruction::CreateAllToAll(
+          eight_elements, {parameter}, {group}, /*constrain_layout=*/true,
+          channel_id(), std::nullopt));
+      break;
+    case HloOpcode::kCollectiveBroadcast:
+      collective =
+          builder.AddInstruction(HloInstruction::CreateCollectiveBroadcast(
+              two_elements, {parameter}, {group}, /*constrain_layout=*/true,
+              channel_id()));
+      break;
+    case HloOpcode::kCollectivePermute:
+      collective =
+          builder.AddInstruction(HloInstruction::CreateCollectivePermute(
+              two_elements, parameter, source_target_pairs, channel_id()));
+      break;
+    default:
+      LOG(FATAL) << "Unexpected opcode.";
+  }
+  TF_ASSIGN_OR_RETURN(auto collective_group_mode,
+                      GetCollectiveOpGroupMode(collective));
+  EXPECT_EQ(collective_group_mode, test_case.expected_group_mode);
+}
+
+INSTANTIATE_TEST_SUITE_P(GetCollectOpGroupModeForInstruction,
+                         GetCollectOpGroupModeTestForInstruction,
+                         testing::ValuesIn(GetTestCasesForInstruction()));
+
 }  // namespace GetCollectiveOpGroupModeTest
 
 // Tests for GetParticipatingDevices


### PR DESCRIPTION
Extends the HLO replication analysis to identify partially replicated instructions when the group mode of the collective is flattened ID.

Also enables the exchange of collectives and quantizations or dequantizations with partially replicated scaling factors in the collective quantizer pass.