### PR TITLE
compute_library: set openmp runtime off by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -214,6 +214,7 @@ build:mkl_aarch64 -c opt
 # Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
 # with Eigen threadpool support
 build:mkl_aarch64_threadpool --define=build_with_mkl_aarch64=true
+build:mkl_aarch64_threadpool --@compute_library//:openmp=false
 build:mkl_aarch64_threadpool -c opt
 
 # CUDA: This config refers to building CUDA op kernels with nvcc.


### PR DESCRIPTION
The official wheel binary is using Eigen thread pool runtime and there is no dependency on OpenMP. Having openmp ON by default in compute library bazel config causing an unnecessary dependency on libgomp/libomp for aarch64 linux wheel. This PR is to remove the dependency. There is no impact on the performance because openmp runtime is not being used anyway.