### PR TITLE
[XLA:CPU][oneDNN] Refactor population of oneDNN post-ops

### DIFF
--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -104,11 +104,6 @@ Shape OneDnnMatMulOptWeightsShape(const Shape& input_shape,
   return MemDescToXlaShapeFlattened(optimized_weights_md);
 }
 
-struct FusedOperandsRef {
-  const std::vector<void*>& bufs;
-  std::vector<std::pair<int, dnnl::memory>>& postop_args;
-};
-
 std::unique_ptr<matmul::primitive_desc> CreateMatMulPrimDesc(
     const engine& cpu_engine, const memory::desc& input_md,
     const memory::desc& plain_weights_md, const memory::desc& output_md,
@@ -123,84 +118,9 @@ std::unique_ptr<matmul::primitive_desc> CreateMatMulPrimDesc(
                               memory::format_tag::any);
   }
 
-  dnnl::post_ops post_ops;
-  int fused_operand_idx = 0;
-  for (auto& fused_op : matmul_config.fusions().ops()) {
-    switch (fused_op) {
-      case OneDnnFusionConfig::RELU:
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_relu, 0.f, 0.f);
-        break;
-      case OneDnnFusionConfig::TANH:
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_tanh, 0.f, 0.f);
-        break;
-      case OneDnnFusionConfig::GELU_TANH:
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_gelu_tanh, 0.f, 0.f);
-        break;
-      case OneDnnFusionConfig::GELU_ERF:
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_gelu_erf, 0.f, 0.f);
-        break;
-      case OneDnnFusionConfig::RELU6:
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_clip_v2, 0.f, 6.0f);
-        break;
-      case OneDnnFusionConfig::SIGMOID:
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_logistic, 0.f, 0.f);
-        break;
-      case OneDnnFusionConfig::BIAS: {
-        bias_md = fused_mds.at(fused_operand_idx);
-        // Extend bias rank to match result rank.
-        auto missed_rank = output_md.get_ndims() - bias_md.get_ndims();
-        XLA_LIGHTWEIGHT_CHECK(missed_rank >= 0);
-        if (missed_rank > 0) {
-          auto bias_dims = bias_md.get_dims();
-          bias_dims.insert(bias_dims.begin(), missed_rank, 1);
-          bias_md = bias_md.reshape(bias_dims);
-        }
-        if (fused_operands_ref) {
-          fused_operands_ref->postop_args.emplace_back(
-              DNNL_ARG_BIAS,
-              dnnl::memory(bias_md, cpu_engine,
-                           fused_operands_ref->bufs[fused_operand_idx]));
-        }
-        fused_operand_idx++;
-      } break;
-      case OneDnnFusionConfig::ELU:
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_elu, 1.0f, 0.0f);
-        break;
-      case OneDnnFusionConfig::BINARY_ADD: {
-        auto binary_md = fused_mds.at(fused_operand_idx);
-        // Extend addend rank to match result rank.
-        auto missed_rank = output_md.get_ndims() - binary_md.get_ndims();
-        XLA_LIGHTWEIGHT_CHECK(missed_rank >= 0);
-        if (missed_rank > 0) {
-          auto binary_dims = binary_md.get_dims();
-          binary_dims.insert(binary_dims.begin(), missed_rank, 1);
-          binary_md = binary_md.reshape(binary_dims);
-        }
-        if (fused_operands_ref) {
-          auto arg_idx =
-              DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops.len()) | DNNL_ARG_SRC_1;
-          fused_operands_ref->postop_args.emplace_back(
-              arg_idx,
-              dnnl::memory(binary_md, cpu_engine,
-                           fused_operands_ref->bufs[fused_operand_idx]));
-        }
-        post_ops.append_binary(dnnl::algorithm::binary_add, binary_md);
-        fused_operand_idx++;
-      } break;
-      case OneDnnFusionConfig::LINEAR: {
-        float const_float;
-        *(reinterpret_cast<int32_t*>(&const_float)) =
-            matmul_config.fusions().alpha_typecast();
-        post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, const_float,
-                                0.f);
-      } break;
-      default:
-        LOG(FATAL) << __FILE__ << ":" << __LINE__
-                   << " Attempt to call OneDNN MatMul runtime library with "
-                      "unsupported post op."
-                   << std::endl;
-    }
-  }
+  dnnl::post_ops post_ops = PopulateOneDnnPostOps(
+      cpu_engine, fused_mds, &matmul_config.fusions(), output_md.get_ndims(),
+      fused_operands_ref, &bias_md);
 
   dnnl::primitive_attr attrs;
   if (matmul_config.optimization_config().user_scratchpad()) {

--- a/xla/service/cpu/onednn_util.cc
+++ b/xla/service/cpu/onednn_util.cc
@@ -40,6 +40,92 @@ dnnl::stream MakeOneDnnStream(
              : dnnl::stream(cpu_engine);
 }
 
+dnnl::post_ops PopulateOneDnnPostOps(
+    const dnnl::engine& cpu_engine,
+    const std::vector<dnnl::memory::desc>& fused_mds,
+    const OneDnnFusionConfig* fusion_config, const int output_ndims,
+    FusedOperandsRef* fused_operands_ref, dnnl::memory::desc* bias_md) {
+  dnnl::post_ops post_ops;
+  int fused_operand_idx = 0;
+  for (auto& fused_op : fusion_config->ops()) {
+    switch (fused_op) {
+      case OneDnnFusionConfig::RELU:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_relu, 0.f, 0.f);
+        break;
+      case OneDnnFusionConfig::TANH:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_tanh, 0.f, 0.f);
+        break;
+      case OneDnnFusionConfig::GELU_TANH:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_gelu_tanh, 0.f, 0.f);
+        break;
+      case OneDnnFusionConfig::GELU_ERF:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_gelu_erf, 0.f, 0.f);
+        break;
+      case OneDnnFusionConfig::RELU6:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_clip_v2, 0.f, 6.0f);
+        break;
+      case OneDnnFusionConfig::SIGMOID:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_logistic, 0.f, 0.f);
+        break;
+      case OneDnnFusionConfig::BIAS: {
+        *bias_md = fused_mds.at(fused_operand_idx);
+        // TODO(intel-tf): Move this check to the rewriter file
+        // Extend bias rank to match result rank.
+        auto missed_rank = output_ndims - bias_md->get_ndims();
+        if (missed_rank > 0) {
+          auto bias_dims = bias_md->get_dims();
+          bias_dims.insert(bias_dims.begin(), missed_rank, 1);
+          *bias_md = bias_md->reshape(bias_dims);
+        }
+        if (fused_operands_ref) {
+          fused_operands_ref->postop_args.emplace_back(
+              DNNL_ARG_BIAS,
+              dnnl::memory(*bias_md, cpu_engine,
+                           fused_operands_ref->bufs[fused_operand_idx]));
+        }
+        fused_operand_idx++;
+      } break;
+      case OneDnnFusionConfig::ELU:
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_elu, 1.0f, 0.0f);
+        break;
+      case OneDnnFusionConfig::BINARY_ADD: {
+        auto binary_md = fused_mds.at(fused_operand_idx);
+        // TODO(intel-tf): Move this check to the rewriter file
+        // Extend addend rank to match result rank.
+        auto missed_rank = output_ndims - binary_md.get_ndims();
+        if (missed_rank > 0) {
+          auto binary_dims = binary_md.get_dims();
+          binary_dims.insert(binary_dims.begin(), missed_rank, 1);
+          binary_md = binary_md.reshape(binary_dims);
+        }
+        if (fused_operands_ref) {
+          auto arg_idx =
+              DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops.len()) | DNNL_ARG_SRC_1;
+          fused_operands_ref->postop_args.emplace_back(
+              arg_idx,
+              dnnl::memory(binary_md, cpu_engine,
+                           fused_operands_ref->bufs[fused_operand_idx]));
+        }
+        post_ops.append_binary(dnnl::algorithm::binary_add, binary_md);
+        fused_operand_idx++;
+      } break;
+      case OneDnnFusionConfig::LINEAR: {
+        float const_float;
+        *(reinterpret_cast<int32_t*>(&const_float)) =
+            fusion_config->alpha_typecast();
+        post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, const_float,
+                                0.f);
+      } break;
+      default:
+        LOG(FATAL) << __FILE__ << ":" << __LINE__
+                   << " Attempt to call OneDNN runtime library with "
+                      "unsupported post op."
+                   << std::endl;
+    }
+  }
+  return post_ops;
+}
+
 }  // namespace cpu
 }  // namespace xla
 

--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -52,6 +52,11 @@ inline bool IsSupportedType(xla::PrimitiveType dtype) {
   return false;
 }
 
+struct FusedOperandsRef {
+  const std::vector<void*>& bufs;
+  std::vector<std::pair<int, dnnl::memory>>& postop_args;
+};
+
 std::unique_ptr<tsl::OneDnnThreadPool> CreateOneDnnThreadPool(
     const Eigen::ThreadPoolDevice* threadpool_device);
 
@@ -72,6 +77,13 @@ struct PrimitiveTrait;
 template <BackendConfigOneofCase config>
 typename PrimitiveTrait<config>::pointer_type GetKernelConfig(
     absl::StatusOr<BackendConfig>*);
+
+dnnl::post_ops PopulateOneDnnPostOps(
+    const dnnl::engine& cpu_engine,
+    const std::vector<dnnl::memory::desc>& fused_mds,
+    const OneDnnFusionConfig* fusion_config, const int output_ndims,
+    FusedOperandsRef* fused_operands_ref = nullptr,
+    dnnl::memory::desc* bias_md = nullptr);
 
 }  // namespace cpu
 }  // namespace xla


### PR DESCRIPTION
This PR refactors the code that populates post-ops for oneDNN primitive and moves it to onednn_util so that it can be re-used by other primitive kinds in the future.