### PR TITLE
[GPU][NFC] Add HLO op profiler build test.

### DIFF
--- a/xla/service/gpu/model/BUILD
+++ b/xla/service/gpu/model/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("@tsl//tsl/platform:build_config.bzl", "tf_proto_library")
 load("@tsl//tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
@@ -966,6 +967,13 @@ cc_library(
         "sm90",
     ]
 ]
+
+build_test(
+    name = "hlo_op_profiler_build_test",
+    targets = [
+        ":hlo_op_profiler_run_sm80",
+    ],
+)
 
 xla_test(
     name = "hlo_op_profiler_test",

--- a/xla/service/gpu/model/BUILD
+++ b/xla/service/gpu/model/BUILD
@@ -957,6 +957,7 @@ cc_library(
             "@tsl//tsl/platform:env",
             "@tsl//tsl/platform:path",
             "@tsl//tsl/platform:platform_port",
+            "@tsl//tsl/platform:protobuf",
             "@tsl//tsl/platform:status",
         ],
     )


### PR DESCRIPTION
hlo_op_profiler_run.cc wasn't compiled regularly and got build failures from time to time.