### PR TITLE
Add recursive parameter to EvaluateWithSubstitutions

### DIFF
--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -980,12 +980,26 @@ bool HloEvaluator::TryEvaluate(const HloInstruction* instruction,
 absl::StatusOr<Literal> HloEvaluator::EvaluateWithSubstitutions(
     const HloInstruction* instruction,
     const absl::flat_hash_map<const HloInstruction*, const LiteralBase*>&
-        substitutions) {
+        substitutions,
+    bool recursively_evaluate_nonconstant_operands) {
   std::vector<std::unique_ptr<HloInstruction>> owned_operands;
   for (const HloInstruction* operand : instruction->operands()) {
     auto it = substitutions.find(operand);
     if (it == substitutions.end()) {
-      owned_operands.push_back(operand->Clone());
+      if (recursively_evaluate_nonconstant_operands) {
+        TF_ASSIGN_OR_RETURN(Literal value,
+                            EvaluateWithSubstitutions(
+                                operand, substitutions,
+                                recursively_evaluate_nonconstant_operands));
+        owned_operands.push_back(HloInstruction::CreateConstant(value.Clone()));
+      } else {
+        if (!operand->IsConstant()) {
+          VLOG(2) << "EvaluateWithSubstitutions called when not all operands "
+                     "are constant. Consider calling it with "
+                     "`recursively_evaluate_non_constant_operands` true.";
+        }
+        owned_operands.push_back(operand->Clone());
+      }
     } else {
       owned_operands.push_back(
           HloInstruction::CreateConstant(it->second->Clone()));

--- a/xla/hlo/evaluator/hlo_evaluator.h
+++ b/xla/hlo/evaluator/hlo_evaluator.h
@@ -164,7 +164,8 @@ class HloEvaluator : public ConstDfsHloVisitorWithDefault {
   absl::StatusOr<Literal> EvaluateWithSubstitutions(
       const HloInstruction* instruction,
       const absl::flat_hash_map<const HloInstruction*, const LiteralBase*>&
-          substitutions);
+          substitutions,
+      bool recursively_evaluate_nonconstant_operands = false);
 
   absl::StatusOr<Literal> EvaluateElementwiseBinaryOp(HloOpcode opcode,
                                                       const Literal& lhs,

--- a/xla/hlo/evaluator/hlo_evaluator_test.cc
+++ b/xla/hlo/evaluator/hlo_evaluator_test.cc
@@ -3357,6 +3357,55 @@ TEST_P(HloEvaluatorBf16Test, EvaluateWithSubstitutions) {
       LiteralUtil::CreateR1<float>({11, 22, 33, 44}), result));
 }
 
+TEST_F(HloEvaluatorTest, EvaluateWithSubstitutionsRecursive) {
+  const char* hlo = R"(
+  HloModule test
+
+  ENTRY main {
+    param = s32[] parameter(0)
+    c1 = s32[] constant(1)
+    c2 = s32[] constant(2)
+    add.1 = s32[] add(c1, c2)
+    ROOT add.2 = s32[] add(param, add.1)
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  Literal param_value = LiteralUtil::CreateR0(PrimitiveType::S32, 3);
+  HloInstruction* param = module->entry_computation()->parameter_instruction(0);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto result,
+      evaluator_.EvaluateWithSubstitutions(
+          /*instruction=*/module->entry_computation()->root_instruction(),
+          /*substitutions=*/{{param, &param_value}},
+          /*recursively_evaluate_nonconstant_operands=*/true));
+  EXPECT_EQ(result, LiteralUtil::CreateR0(PrimitiveType::S32, 1 + 2 + 3));
+}
+
+TEST_F(HloEvaluatorTest,
+       EvaluateWithSubstitutionsRecursiveWithDeepSubstitutions) {
+  const char* hlo = R"(
+  HloModule test
+  ENTRY main {
+    param = s32[] parameter(0)
+    c1 = s32[] constant(1)
+    c2 = s32[] constant(2)
+    add.1 = s32[] add(param, c1)
+    add.2 = s32[] add(add.1, c2)
+    ROOT add.3 = s32[] add(add.2, c1)
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          ParseAndReturnVerifiedModule(hlo));
+  Literal param_value = LiteralUtil::CreateR0(PrimitiveType::S32, 4);
+  HloInstruction* param = module->entry_computation()->parameter_instruction(0);
+  TF_ASSERT_OK_AND_ASSIGN(
+      Literal result,
+      evaluator_.EvaluateWithSubstitutions(
+          /*instruction=*/module->entry_computation()->root_instruction(),
+          /*substitutions=*/{{param, &param_value}},
+          /*recursively_evaluate_nonconstant_operands=*/true));
+  EXPECT_EQ(result, LiteralUtil::CreateR0(PrimitiveType::S32, 4 + 1 + 2 + 1));
+}
+
 // Check that EvaluateWithSubstitutions works if one of the operands to the op
 // we're evaluating is a constant.
 TEST_P(HloEvaluatorBf16Test, EvaluateWithSubstitutionsWithConstantOperand) {


### PR DESCRIPTION
This patch adds support for recursive evaluation for constant operands and expressions with EvaluateWithSubstitutions. This is added as a parameter to the function call.