### PR TITLE
Verify device compatibility for execution early

### DIFF
--- a/xla/client/local_client.h
+++ b/xla/client/local_client.h
@@ -81,6 +81,10 @@ class LocalExecutable {
   // Return the built executable.
   Executable* executable() const { return executable_.get(); }
 
+  // Verifies that the a device is compatible with the executable's
+  // build device.
+  absl::Status VerifyRunDeviceCompatible(int run_device_ordinal) const;
+
  private:
   absl::StatusOr<ExecutionOutput> RunAsync(
       absl::Span<Shape const* const> argument_host_shapes,

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -3148,6 +3148,24 @@ PjRtStreamExecutorLoadedExecutable::ExecuteHelper(
   return Result({/*future=*/std::move(future), /*buffers=*/std::move(outputs)});
 }
 
+absl::Status PjRtStreamExecutorLoadedExecutable::VerifyCompatibleDevices()
+    const {
+  const int num_addressable_devices = addressable_devices_.size();
+  for (int i = 0; i < num_addressable_devices; ++i) {
+    PjRtDevice* device = addressable_devices_[i];
+    const int device_ordinal =
+        tensorflow::down_cast<PjRtStreamExecutorDevice*>(device)
+            ->local_device_state()
+            ->local_device_id()
+            .value();
+    const int partition = addressable_device_logical_ids_[i].partition;
+    const int executable_idx = executables_.size() > 1 ? partition : 0;
+    TF_RETURN_IF_ERROR(executables_[executable_idx]->VerifyRunDeviceCompatible(
+        device_ordinal));
+  }
+  return absl::OkStatus();
+}
+
 absl::StatusOr<std::vector<std::vector<std::unique_ptr<PjRtBuffer>>>>
 PjRtStreamExecutorLoadedExecutable::Execute(
     absl::Span<const std::vector<PjRtBuffer*>> argument_handles,
@@ -3172,6 +3190,7 @@ PjRtStreamExecutorLoadedExecutable::Execute(
         num_partitions());
   }
 
+  TF_RETURN_IF_ERROR(VerifyCompatibleDevices());
   VLOG(1) << "Executing computation " << name()
           << "; num_replicas=" << num_replicas()
           << " num_partitions=" << num_partitions()

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -1061,6 +1061,8 @@ class PjRtStreamExecutorLoadedExecutable : public PjRtLoadedExecutable {
       int partition, const RunId& run_id, const ExecuteOptions& options,
       bool fill_future, PjRtDevice* device = nullptr) const;
 
+  absl::Status VerifyCompatibleDevices() const;
+
   // Create shared pointers so we can free them after the execution: with
   // asynchronous execution, the process being executed can outlive the
   // executable itself.

--- a/xla/service/backend.cc
+++ b/xla/service/backend.cc
@@ -208,7 +208,7 @@ absl::StatusOr<se::StreamExecutor*> Backend::stream_executor(
 }
 
 absl::StatusOr<bool> Backend::devices_equivalent(int device_ordinal_a,
-                                                 int device_ordinal_b) {
+                                                 int device_ordinal_b) const {
   // Use the name from device description to determine equivalence. This is a
   // bit crude but works for GPUs which is the important case where we compile
   // an executable for one GPU and want to know if it will run (well) on

--- a/xla/service/backend.h
+++ b/xla/service/backend.h
@@ -167,7 +167,7 @@ class Backend {
   // XLA's perspective. That is, an executable compiled for one device would
   // be equivalent to an executable compiled for the other.
   absl::StatusOr<bool> devices_equivalent(int device_ordinal_a,
-                                          int device_ordinal_b);
+                                          int device_ordinal_b) const;
 
   // For the host platform, returns the configured eigen threadpool device to be
   // used for scheduling work. For other platforms, returns NULL.


### PR DESCRIPTION
Let us verify that all the devices to run a PJRT executable are compatible with the device that was used to build the executable. Currently we only verify the compatibility on each device separately, just before running the executable on the device.

This fixes a problem where running an executable with a collective on two different devices crashes on NCCL timeout. When only one of the device will not pass the compatibility check while the other device (the one passes the check) runs, the running device will hang on the NCCL collective (since the incompatible device program has not been executed).