### PR TITLE
Fix while loop analysis

### DIFF
--- a/xla/hlo/analysis/while_loop_analysis.cc
+++ b/xla/hlo/analysis/while_loop_analysis.cc
@@ -83,9 +83,7 @@ static optional<int64_t> GetGTEOperandIndex(const HloInstruction* instr,
     }
 
     if (!Match(possibly_gte_operand,
-               m::GetTupleElement(m::Op().Is(gte_operand))) &&
-        !Match(possibly_gte_operand,
-               m::GetTupleElement(m::CustomCall(m::Op().Is(gte_operand))))) {
+               m::GetTupleElement(m::Op().Is(gte_operand)))) {
       return nullopt;
     }
 
@@ -282,7 +280,7 @@ optional<int64_t> GetLoopInductionVarTupleIdx(const HloInstruction* while_op) {
     return nullopt;
   }
 
-  // The while_body computation should have one of the following forms:
+  // The while_body computation should have the form:
   //
   // Form 1:
   //   while_body_inc =
@@ -290,60 +288,15 @@ optional<int64_t> GetLoopInductionVarTupleIdx(const HloInstruction* while_op) {
   //   while_body_root = tuple(..., while_body_inc, ...)
   //
   // where while_body_inc is operand N of while_body_root.
-  //
-  // Form 2:
-  //   while_body_inc =
-  //       op(constants, get-tuple-elem(while_body_param, N), constants)
-  //   tuple = tuple(..., while_body_inc, ...)
-  //   while_body_root = custom-call(tuple)
-  //
-  // where while_body_inc is operand N of the tuple, and the tuple is the
-  // operand of the while_body_root custom-call instruction.
-  //
-  // Form 3:
-  //   while_body_inc =
-  //       op(constants, get-tuple-elem(while_body_param, N), constants)
-  //   while_body_root = custom-call(input1, ..., while_body_inc, ...)
-  //
-  // where while_body_inc is an operand of the while_body_root custom-call
-  // instruction, and the custom-call instruction does not have a tuple operand.
   auto* while_body = while_op->while_body();
   auto* while_body_root = while_body->root_instruction();
-  if (while_body_root->opcode() != HloOpcode::kTuple &&
-      while_body_root->opcode() != HloOpcode::kCustomCall) {
-    VLOG(2) << "While body's root is not a tuple or custom-call instruction: "
+  if (while_body_root->opcode() != HloOpcode::kTuple) {
+    VLOG(2) << "While body's root is not a tuple instruction: "
             << while_body_root->ToString();
     return nullopt;
   }
   const HloInstruction* while_body_inc;
-  if (while_body_root->opcode() == HloOpcode::kTuple) {
-    while_body_inc = while_body_root->operand(*indvar_tuple_idx);
-  } else {
-    // Custom-call cases
-    if (while_body_root->operand_count() == 1 &&
-        while_body_root->operand(0)->opcode() == HloOpcode::kTuple) {
-      // Custom-call case
-      // Single tuple operand.
-      auto* while_body_root_input_tuple = while_body_root->operand(0);
-      if (*indvar_tuple_idx >= while_body_root_input_tuple->operand_count()) {
-        VLOG(2) << "Cannot find the induction variable in the output root "
-                   "custom-call "
-                << while_body_root->ToString();
-        return std::nullopt;
-      }
-      while_body_inc = while_body_root_input_tuple->operand(*indvar_tuple_idx);
-    } else {
-      // Custom-call case
-      // Operand is not single tuple.
-      if (*indvar_tuple_idx >= while_body_root->operand_count()) {
-        VLOG(2) << "Cannot find the induction variable in the output root "
-                   "custom-call "
-                << while_body_root->ToString();
-        return std::nullopt;
-      }
-      while_body_inc = while_body_root->operand(*indvar_tuple_idx);
-    }
-  }
+  while_body_inc = while_body_root->operand(*indvar_tuple_idx);
   auto* while_body_param = while_body->parameter_instruction(0);
   optional<int64_t> while_body_indvar_tuple_idx =
       GetGTEOperandIndex(while_body_inc, while_body_param);
@@ -415,28 +368,8 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
   // Check that `i` goes as `i += k` in the while body where k is a natural
   // number.
   auto* while_body = while_op->while_body();
-  auto* while_body_root = while_body->root_instruction();
-  HloInstruction* while_body_indvar_update;
-
-  if (while_body_root->opcode() == HloOpcode::kCustomCall) {
-    // We know it must be a custom-call.
-    if (while_body_root->operand_count() == 1 &&
-        while_body_root->operand(0)->opcode() == HloOpcode::kTuple) {
-      // Custom-call case
-      // Single tuple operand.
-      auto* while_body_root_input_tuple = while_body_root->mutable_operand(0);
-      while_body_indvar_update =
-          while_body_root_input_tuple->mutable_operand(indvar_tuple_idx);
-    } else {
-      // Custom-call case
-      // Operand is not single tuple.
-      while_body_indvar_update =
-          while_body_root->mutable_operand(indvar_tuple_idx);
-    }
-  } else {
-    while_body_indvar_update =
-        while_body_root->mutable_operand(indvar_tuple_idx);
-  }
+  auto* while_body_indvar_update =
+      while_body->root_instruction()->mutable_operand(indvar_tuple_idx);
   auto* while_body_indvar = NonConstantOperand(while_body_indvar_update);
   HloInstruction* trip_count_increase_step_instr = nullptr;
   int64_t trip_count_step = 0;

--- a/xla/hlo/analysis/while_loop_analysis_test.cc
+++ b/xla/hlo/analysis/while_loop_analysis_test.cc
@@ -159,7 +159,7 @@ TEST_F(WhileLoopAnalysisTest, SimpleLoopWithCustomCallNonTuple) {
   )";
   auto m = ParseAndReturnVerifiedModule(hlo_string).value();
   HloInstruction* while_op = m->entry_computation()->root_instruction();
-  EXPECT_EQ(*ComputeWhileLoopTripCountUpperBound(while_op), 5);
+  EXPECT_EQ(ComputeWhileLoopTripCountUpperBound(while_op), std::nullopt);
 }
 
 TEST_F(WhileLoopAnalysisTest, SimpleLoopWithCustomCall) {
@@ -192,7 +192,7 @@ TEST_F(WhileLoopAnalysisTest, SimpleLoopWithCustomCall) {
   )";
   auto m = ParseAndReturnVerifiedModule(hlo_string).value();
   HloInstruction* while_op = m->entry_computation()->root_instruction();
-  EXPECT_EQ(*ComputeWhileLoopTripCountUpperBound(while_op), 5);
+  EXPECT_EQ(ComputeWhileLoopTripCountUpperBound(while_op), std::nullopt);
 }
 
 TEST_F(WhileLoopAnalysisTest, NoUpperBound) {

--- a/xla/service/while_loop_unroller_test.cc
+++ b/xla/service/while_loop_unroller_test.cc
@@ -1270,10 +1270,10 @@ TEST_F(WhileLoopUnrollerTest, SimpleLoopWithCustomCallNonTupleForRoot) {
   )";
   auto m = ParseAndReturnVerifiedModule(hlo_string).value();
   UnrollConfig config;
-  EXPECT_TRUE(WhileLoopUnroller(/*unroll_factor=*/-1,
-                                /*wrap_in_trivial_loop=*/false, config)
-                  .Run(m.get())
-                  .value());
+  EXPECT_FALSE(WhileLoopUnroller(/*unroll_factor=*/-1,
+                                 /*wrap_in_trivial_loop=*/false, config)
+                   .Run(m.get())
+                   .value());
 }
 
 TEST_F(WhileLoopUnrollerTest, SimpleLoopWithCustomCall) {
@@ -1306,10 +1306,10 @@ TEST_F(WhileLoopUnrollerTest, SimpleLoopWithCustomCall) {
   )";
   auto m = ParseAndReturnVerifiedModule(hlo_string).value();
   UnrollConfig config;
-  EXPECT_TRUE(WhileLoopUnroller(/*unroll_factor=*/-1,
-                                /*wrap_in_trivial_loop=*/false, config)
-                  .Run(m.get())
-                  .value());
+  EXPECT_FALSE(WhileLoopUnroller(/*unroll_factor=*/-1,
+                                 /*wrap_in_trivial_loop=*/false, config)
+                   .Run(m.get())
+                   .value());
 }
 
 }  // namespace


### PR DESCRIPTION
This PR reverts the unsafe changes to while loop analysis in PR #15417. If the loop induction variable is passed to a custom-call and the output of that custom-call is used as the loop induction variable, we cannot safely assume that the custom-call returns the loop induction variable unchanged. This PR removes this unsafe relaxation.