### PR TITLE
[NVIDIA GPU] Refactor pattern match logic for finding slices of output result buffer

### DIFF
--- a/xla/service/gpu/transforms/windowed_einsum_handler.cc
+++ b/xla/service/gpu/transforms/windowed_einsum_handler.cc
@@ -358,7 +358,7 @@ bool FindDusSliceForCachedActivation(HloInstruction* inst,
                                      HloInstruction** slice_indices,
                                      bool is_first_slice) {
   // We are only interested in DUS in the loop body.
-  if (inst->opcode() != HloOpcode::kDynamicUpdateSlice) {
+  if (HloPredicateIsNotOp<HloOpcode::kDynamicUpdateSlice>(inst)) {
     return false;
   }
   // Check that the first operand of DUS is a:


### PR DESCRIPTION
This is mostly refactoring the pattern matching logic for finding slices to update the output buffer in the case of multiple consumers of allgathers. The logic to find the first output slice and second output slice(for unrolled CM loop) is utterly similar and not generic enough.