### PR TITLE
[NVIDIA] Fix the segfault in scatter_determinism_expander when running Transformer Engine

### DIFF
--- a/xla/service/scatter_utils.cc
+++ b/xla/service/scatter_utils.cc
@@ -194,8 +194,7 @@ absl::StatusOr<HloComputation*> CallComputationAndGetIthOutputWithBinaryParams(
 }
 
 int64_t ScatterIndicesCount(const HloScatterInstruction* scatter) {
-  // Compute the trip count for the while loop to be used for scatter. This
-  // should be the number of indices we should scatter into the operand.
+  // Compute the number of indices we should scatter into the operand.
   const HloInstruction* scatter_indices = scatter->scatter_indices();
   const Shape& scatter_indices_shape = scatter_indices->shape();
   const ScatterDimensionNumbers& dim_numbers =
@@ -235,6 +234,9 @@ bool IsScatterDeterministic(const HloScatterInstruction* scatter) {
     return true;
   }
   if (IsScatterCombinerAssociative(scatter->to_apply())) {
+    return true;
+  }
+  if (ScatterIndicesCount(scatter) == 1) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Issue:
When running TE using XLA with xla_gpu_determinisitc_ops=true, the prefix scan inside the scatter determinism expander caused segfault when then there is only one update in the scatter operation. 
### Steps to reproduce:
```
docker run -it --rm --ipc=host --gpus=all ghcr.io/nvidia/jax:pax-2024-10-18
cd /opt/transformer-engine
pip install -r ./examples/jax/encoder/requirements.txt
XLA_FLAGS="${XLA_FLAGS} --xla_gpu_deterministic_ops" pytest examples/jax/encoder/test_single_gpu_encoder.py
```

The scatter determinism expander assumed the original scatter operation is not deterministic, meaning the case where there is only one index-update pair is not possible. However, if the creator of the scatter operation did not mark the scatter operation to have unique_indices, the scatter determinism expander pass will still match and be applied. In this case, the prefix scan implementation will have a segfault because the log2ceiling of num_indices=1 is 0, leading to direct return in the prefix scan without getting into the loop body, and hence a nullptr update will be returned.

## Changes:
1. Modified the implementation of pattern matching of scatter_determinism_expander, so that even if the unique_indices flag of the scatter operation is not set properly, we will still check the number of indices to make sure the pass is not applied on the scatter with one index.
2. Modified the implementation of prefix scan so that even if the loop body is not entered, the correct update will be returned.
3. Added checks before final CreateScatter operation to explicitly check if any args of the new scatter operation is nullptr. After this, even if any args is nullptr, the pass will fail explicitly instead of having a segfault.
4. Added a test for the case where there is only one index-update pair, and make sure the scatter_determinism_expander pass does not match in this case.