### PR TITLE
[ReduceScatterCombiner] Provide option to not combine within while loop bodies. 

### DIFF
--- a/xla/service/reduce_scatter_combiner.cc
+++ b/xla/service/reduce_scatter_combiner.cc
@@ -221,6 +221,12 @@ absl::StatusOr<bool> ReduceScatterCombiner::RunWithKeyCombiner(
   bool changed = false;
   for (HloComputation* computation :
        module->MakeNonfusionComputations(execution_threads)) {
+    if (!combine_while_loops_ && computation->IsWhileBodyComputation()) {
+      VLOG(2) << "Skipping this computation because the computation is a while "
+                 "loop body: "
+              << computation->ToString();
+      continue;
+    }
     TF_ASSIGN_OR_RETURN(auto domain_map, HloDomainMap::Create(computation, ""));
 
     auto key_fn = [&](const HloInstruction* instruction) {
@@ -240,10 +246,12 @@ absl::StatusOr<bool> ReduceScatterCombiner::RunWithKeyCombiner(
 
 ReduceScatterCombiner::ReduceScatterCombiner(int64_t combine_threshold_in_bytes,
                                              int64_t combine_threshold_count,
-                                             bool combine_by_dim)
+                                             bool combine_by_dim,
+                                             bool combine_while_loops)
     : combine_threshold_in_bytes_(combine_threshold_in_bytes),
       combine_threshold_count_(combine_threshold_count),
-      combine_by_dim_(combine_by_dim) {}
+      combine_by_dim_(combine_by_dim),
+      combine_while_loops_(combine_while_loops) {}
 
 absl::StatusOr<bool> ReduceScatterCombiner::Run(
     HloModule* module,

--- a/xla/service/reduce_scatter_combiner.h
+++ b/xla/service/reduce_scatter_combiner.h
@@ -40,7 +40,8 @@ namespace xla {
 class ReduceScatterCombiner : public HloModulePass {
  public:
   ReduceScatterCombiner(int64_t combine_threshold_in_bytes,
-                        int64_t combine_threshold_count, bool combine_by_dim);
+                        int64_t combine_threshold_count, bool combine_by_dim,
+                        bool combine_while_loops = true);
 
   absl::string_view name() const override { return "reduce-scatter-combiner"; }
 
@@ -77,6 +78,9 @@ class ReduceScatterCombiner : public HloModulePass {
 
   // Combine only reduce-scatter ops with the same dimension.
   bool combine_by_dim_;
+
+  // Combine reduce-scatter ops that are inside while loop body computations.
+  bool combine_while_loops_;
 };
 
 }  // namespace xla


### PR DESCRIPTION
Same as #18772 but for reduce-scatters. Copying from #18772 

This PR provides an option to disable combining reduce-scatters inside while loop bodies.
It is set to true, so existing behavior is maintained.

This option is provided as some strategies for FSDP may only want to coalesce collectives that are outside of a while loop. Collectives inside while loop are not coalesced, as we assume there is sufficient compute to overlap.