### PR TITLE
[GPU] Improve IsConsumerTheOnlyNonRootUser check.

### DIFF
--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -924,8 +924,9 @@ HloInstruction::FusionKind ChooseFusionKind(const HloInstruction& producer,
 bool IsConsumerTheOnlyNonRootUser(const HloInstruction& instr,
                                   const HloInstruction& consumer) {
   return absl::c_all_of(instr.users(), [&](const HloInstruction* user) {
-    if (user->opcode() == HloOpcode::kGetTupleElement) {
-      // Skip GTE.
+    if (user->opcode() == HloOpcode::kGetTupleElement ||
+        user->opcode() == HloOpcode::kBitcast) {
+      // Skip no-op instructions.
       return IsConsumerTheOnlyNonRootUser(*user, consumer);
     }
     // `user` is `consumer` or consumed by ROOT.

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -801,9 +801,10 @@ FusionDecision FusionFitsInBudget(const HloInstruction& instr1,
       MaxOperandsAndOutputsPerFusion()) {
     return FusionDecision::Allow();
   } else {
-    VLOG(5) << "Operand count of " << "(" << instr1.ToString()
-            << " ) = " << instr1.operand_count() << " and ( "
-            << instr2.ToString() << " ) = " << instr2.operand_count()
+    VLOG(5) << "Operand count of "
+            << "(" << instr1.ToString() << " ) = " << instr1.operand_count()
+            << " and ( " << instr2.ToString()
+            << " ) = " << instr2.operand_count()
             << " and num_output_buffers = " << num_output_buffers
             << " is bigger than the bound of "
             << MaxOperandsAndOutputsPerFusion();

--- a/xla/service/gpu/gpu_fusible_test.cc
+++ b/xla/service/gpu/gpu_fusible_test.cc
@@ -1771,5 +1771,20 @@ TEST_F(GpuFusibleTest, GetSharedMemoryUsage) {
   EXPECT_EQ(cache.GetSharedMemoryUsage(*fusion), 32 * 33 * 2 * 4);
 }
 
+TEST_F(GpuFusibleTest, IsConsumerTheOnlyNonRootUser) {
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
+e {
+  p = s8[] parameter(0)
+  n = s8[] negate(p)
+  b = s8[1] bitcast(p)
+  t = tuple(b, n)
+})"));
+
+  const HloInstruction& p =
+      *module->entry_computation()->parameter_instruction(0);
+  const HloInstruction& n = *p.users().front();
+  EXPECT_TRUE(IsConsumerTheOnlyNonRootUser(p, n));
+}
+
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
The check is used in horizontal fusion passes.