### PR TITLE
[GPU] Horizontal loop fusion: remove layout check.

### DIFF
--- a/xla/service/gpu/transforms/horizontal_loop_fusion.cc
+++ b/xla/service/gpu/transforms/horizontal_loop_fusion.cc
@@ -519,6 +519,13 @@ absl::Status HorizontalLoopFusionImpl::CreateFusedComputation(
         if (new_output->shape().dimensions_size() == 1) {
           instr_outputs[j] = new_output;
         } else {
+          if (!LayoutUtil::IsMonotonicWithDim0Major(
+                  new_output->shape().layout())) {
+            new_output = comp->AddInstruction(HloInstruction::CreateBitcast(
+                ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(
+                    new_output->shape()),
+                new_output));
+          }
           Shape new_shape = ShapeUtil::MakeShapeWithDenseLayout(
               new_output->shape().element_type(),
               {ShapeUtil::ElementsIn(new_output->shape())},

--- a/xla/service/gpu/transforms/horizontal_loop_fusion_test.cc
+++ b/xla/service/gpu/transforms/horizontal_loop_fusion_test.cc
@@ -905,7 +905,7 @@ e {
   EXPECT_TRUE(HorizontalLoopFusion().Run(module.get()).value());
 }
 
-TEST_F(HorizontalLoopFusionTest, FuseNonDefaultLayouts) {
+TEST_F(HorizontalLoopFusionTest, FuseNonDefaultLayoutsUsingTuple) {
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
 f {
   p = s8[2,2]{0,1} parameter(0)
@@ -928,8 +928,39 @@ e {
 })"));
 
   EXPECT_TRUE(HorizontalLoopFusion().Run(module.get()).value());
+  EXPECT_THAT(module->entry_computation()
+                  ->parameter_instruction(0)
+                  ->users()[0]
+                  ->fused_instructions_computation()
+                  ->root_instruction(),
+              GmockMatch(m::Tuple(m::Negate(), m::Add())));
 }
 
+TEST_F(HorizontalLoopFusionTest, FuseNonDefaultLayoutsUsingConcatenation) {
+  const std::string kHloText = R"(
+HloModule m, entry_computation_layout={()->(s32[2,3]{0,1}, s32[2,3]{1,0})}
+
+e {
+  a = s32[2,3]{1,0} constant({ { 1, 2, 3 }, { 4, 5, 6 } })
+  b = s32[2,3]{1,0} constant({ { 10, 20, 30 }, { 40, 50, 60 } })
+  t = tuple(a, b)
+})";
+
+  MatchOptimizedHlo(kHloText, R"(
+CHECK: copy_horizontally_fused_computation
+CHECK: %[[p0:.+]] = s32[2,3]{0,1} parameter(0)
+CHECK: %[[c0:.+]] = s32[2,3]{0,1} copy(%[[p0]])
+CHECK: %[[b0:.+]] = s32[3,2]{1,0} bitcast(%[[c0]])
+CHECK: %[[r0:.+]] = s32[6]{0} reshape(%[[b0]])
+CHECK: %[[p1:.+]] = s32[2,3]{1,0} parameter(1)
+CHECK: %[[c1:.+]] = s32[2,3]{1,0} copy(%[[p1]])
+CHECK: %[[r1:.+]] = s32[6]{0} reshape(%[[c1]])
+CHECK: s32[12]{0} concatenate(%[[r0]], %[[r1]]), dimensions={0}
+)");
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+  EXPECT_TRUE(RunAndCompare(std::move(module), ErrorSpec{0}));
+}
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
The check as it's written doesn't prevent uncoalesced access as it intends but does prevent some reasonable fusions.