### PR TITLE
[GPU] Horizontal loop fusion: improve shared operand check.

### DIFF
--- a/xla/service/gpu/transforms/horizontal_loop_fusion.cc
+++ b/xla/service/gpu/transforms/horizontal_loop_fusion.cc
@@ -299,7 +299,8 @@ void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
       VLOG(2) << "sliced_input_fusion=" << sliced_input_fusion_
               << " rejects non-row-major fusion instr " << instr->ToString();
       continue;
-    } else if (AnyOpndIsParamSharedAmongFusions(instr, fusible_candidates)) {
+    } else if (sliced_input_fusion_ &&
+               AnyOpndIsParamSharedAmongFusions(instr, fusible_candidates)) {
       // Don't fuse fusions whose operands are parameter instructions that are
       // shared among fusions because we cannot i/o alias the produced
       // horizontal fusion due to the concat insertion.

--- a/xla/service/gpu/transforms/horizontal_loop_fusion_test.cc
+++ b/xla/service/gpu/transforms/horizontal_loop_fusion_test.cc
@@ -555,10 +555,9 @@ TEST_F(HorizontalLoopFusionTest, DynamicUpdateSlice) {
   EXPECT_TRUE(RunAndCompareNoHloPasses(std::move(module), ErrorSpec{0, 0}));
 }
 
-TEST_F(HorizontalLoopFusionTest, NegativeTestForSharedParam) {
+TEST_F(HorizontalLoopFusionTest,
+       AllowSharedParametersWhenNotUsingConcatenation) {
   auto module = ParseAndReturnVerifiedModule(R"(
- HloModule BasicTest
-
  fused_computation.1 {
    arg.1 = f16[123]{0} parameter(0)
    arg.2 = f16[123]{0} parameter(1)
@@ -582,10 +581,40 @@ TEST_F(HorizontalLoopFusionTest, NegativeTestForSharedParam) {
        fusion(arg.3, arg.2), kind=kLoop, calls=fused_computation.2
    ROOT tuple.1 = (f16[123]{0}, f16[123]{0})
        tuple(fusion.1, fusion.2)
- }
-)")
+ })")
                     .value();
 
+  EXPECT_TRUE(HorizontalLoopFusion().Run(module.get()).value());
+  EXPECT_THAT(module->entry_computation()
+                  ->parameter_instruction(0)
+                  ->users()[0]
+                  ->fused_instructions_computation()
+                  ->root_instruction(),
+              GmockMatch(m::Tuple(m::Multiply(), m::Add())));
+}
+
+TEST_F(HorizontalLoopFusionTest, ForbidSharedParametersWhenUsingConcatenation) {
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
+f {
+  p = f16[] parameter(0)
+}
+
+g {
+  p = f16[] parameter(0)
+  b = f16[1] bitcast(p)
+}
+
+e {
+  p = f16[] parameter(0)
+  a = f16[] fusion(p), kind=kLoop, calls=f
+  b = f16[1] fusion(p), kind=kLoop, calls=g
+  t = tuple(a, b)
+})"));
+
+  // As fusions f and g have different output shapes, the horizontal fusion
+  // algorithm would only consider merging them using concatenation/slicing.
+  // The horizontal fusion is not supposed to happen in this
+  // example though because f and g share an input parameter.
   EXPECT_FALSE(HorizontalLoopFusion().Run(module.get()).value());
 }
 


### PR DESCRIPTION
The argument for this check about aliasing and concatenation does not apply to fusions constructed just using a root tuple.