### PR TITLE
Enable HLO elementwise ops for int4 types

### DIFF
--- a/xla/service/cpu_gpu_shape_verifier.cc
+++ b/xla/service/cpu_gpu_shape_verifier.cc
@@ -75,6 +75,7 @@ absl::Status VerifyS4U4Usage(HloInstruction* instruction) {
     case HloOpcode::kDynamicUpdateSlice:
     case HloOpcode::kFusion:
     case HloOpcode::kGetTupleElement:
+    case HloOpcode::kOptimizationBarrier:
     case HloOpcode::kParameter:
     case HloOpcode::kSlice:
     case HloOpcode::kTuple:
@@ -86,7 +87,9 @@ absl::Status VerifyS4U4Usage(HloInstruction* instruction) {
       }
       ABSL_FALLTHROUGH_INTENDED;
     default:
-      return verify_subshape(instruction);
+      if (!instruction->IsElementwise()) {
+        return verify_subshape(instruction);
+      }
   }
 
   return absl::OkStatus();

--- a/xla/service/gpu/fusions/triton/triton_fusion_emitter_device_legacy_test.cc
+++ b/xla/service/gpu/fusions/triton/triton_fusion_emitter_device_legacy_test.cc
@@ -162,7 +162,7 @@ TEST_F(TritonGemmTest, RejectDotInt4HLO) {
               StatusIs(tsl::error::INVALID_ARGUMENT));
 }
 
-TEST_F(TritonGemmTest, RejectInt4NegatePlusConvertHLO) {
+TEST_F(TritonGemmTest, Int4NegatePlusConvertHLO) {
   constexpr std::string_view kHloText = R"(
     HloModule t
 
@@ -178,8 +178,8 @@ TEST_F(TritonGemmTest, RejectInt4NegatePlusConvertHLO) {
           rhs_batch_dims={0}
     }
   )";
-  EXPECT_THAT(GetOptimizedModule(kHloText).status(),
-              StatusIs(tsl::error::INVALID_ARGUMENT));
+  EXPECT_TRUE(RunAndCompareNoHloPasses(
+      kHloText, ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 
 TEST_F(TritonGemmTest, RejectTritonFusionForInt4WithMinorBatchDim) {

--- a/xla/shape_util.cc
+++ b/xla/shape_util.cc
@@ -1067,7 +1067,7 @@ Shape ShapeUtil::PrependMajorDimension(int64_t bound, Shape shape) {
   } else {
     Shape new_shape = original;
     new_shape.set_element_type(type);
-    if (new_shape.has_layout() && type == PRED) {
+    if (new_shape.has_layout() && !primitive_util::IsSubByteNonPredType(type)) {
       new_shape.mutable_layout()->set_element_size_in_bits(0);
     }
     return new_shape;

--- a/xla/shape_util_test.cc
+++ b/xla/shape_util_test.cc
@@ -1225,9 +1225,11 @@ TEST(ShapeUtilTest, Int4ShapeSize) {
   EXPECT_EQ(ShapeUtil::ArrayDataSize(int4_shape2), 9216 * 6144 / 2);
   EXPECT_EQ(ShapeUtil::ArraySize(int4_shape2), 9216 * 6144 / 2);
 
-  // Changing the type to PRED should clear element_size_in_bits.
+  // Changing the type should clear element_size_in_bits.
   Shape pred_shape = ShapeUtil::ChangeElementType(int4_shape, PRED);
   EXPECT_EQ(pred_shape.layout().element_size_in_bits(), 0);
+  Shape u8_shape = ShapeUtil::ChangeElementType(int4_shape, U8);
+  EXPECT_EQ(u8_shape.layout().element_size_in_bits(), 0);
   Shape u4_shape = ShapeUtil::ChangeElementType(int4_shape, U4);
   EXPECT_EQ(u4_shape.layout().element_size_in_bits(), 4);
 }

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -1588,6 +1588,8 @@ xla_test(
         ":xla_internal_test_main",
         "//xla:test",
         "//xla/hlo/builder:xla_builder",
+        "//xla/hlo/ir:hlo",
+        "@com_google_absl//absl/strings",
         "@tsl//tsl/platform:errors",
     ],
 )

--- a/xla/tests/int4_test.cc
+++ b/xla/tests/int4_test.cc
@@ -16,6 +16,10 @@ limitations under the License.
 #include <optional>
 #include <string>
 
+#include "absl/strings/str_replace.h"
+#include "absl/strings/substitute.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/test.h"
 #include "xla/tests/hlo_test_base.h"
 #include "xla/tests/test_macros.h"
@@ -186,5 +190,165 @@ XLA_TEST_F(HloTestBaseWithAlgsimpDisabled, TwoDots) {
 )";
   EXPECT_TRUE(RunAndCompare(hlo_text, std::nullopt));
 }
+
+class ElementwiseTest : public HloTestBase,
+                        public ::testing::WithParamInterface<
+                            std::tuple<HloOpcode, PrimitiveType>> {
+ public:
+  static std::vector<HloOpcode> GetElementwiseOpcodesWithIntSupportWithArity(
+      int arity) {
+    std::vector<HloOpcode> opcodes;
+    for (int i = 0; i < HloOpcodeCount(); ++i) {
+      HloOpcode opcode = static_cast<HloOpcode>(i);
+      auto opcode_arity = HloOpcodeArity(opcode);
+      if (HloInstruction::IsOpElementwise(opcode) &&
+          !IsFloatingPointOnly(opcode) && opcode_arity.has_value() &&
+          *opcode_arity == arity) {
+        opcodes.push_back(opcode);
+      }
+    }
+    return opcodes;
+  }
+
+  static std::string FormatTestName(
+      const ::testing::TestParamInfo<std::tuple<HloOpcode, PrimitiveType>>&
+          info) {
+    auto opcode_str = absl::StrReplaceAll(
+        HloOpcodeString(std::get<0>(info.param)), {{"-", "_"}});
+    auto type_str =
+        primitive_util::LowercasePrimitiveTypeName(std::get<1>(info.param));
+    return absl::StrCat(opcode_str, "_", type_str);
+  }
+
+ private:
+  static bool IsFloatingPointOnly(HloOpcode opcode) {
+    switch (opcode) {
+      case HloOpcode::kAtan2:
+      case HloOpcode::kCbrt:
+      case HloOpcode::kCeil:
+      case HloOpcode::kComplex:
+      case HloOpcode::kCos:
+      case HloOpcode::kSin:
+      case HloOpcode::kErf:
+      case HloOpcode::kExp:
+      case HloOpcode::kExpm1:
+      case HloOpcode::kFloor:
+      case HloOpcode::kImag:
+      case HloOpcode::kIsFinite:
+      case HloOpcode::kLog:
+      case HloOpcode::kLog1p:
+      case HloOpcode::kLogistic:
+      case HloOpcode::kPower:
+      case HloOpcode::kReal:
+      case HloOpcode::kReducePrecision:
+      case HloOpcode::kRoundNearestAfz:
+      case HloOpcode::kRoundNearestEven:
+      case HloOpcode::kRsqrt:
+      case HloOpcode::kSqrt:
+      case HloOpcode::kStochasticConvert:
+      case HloOpcode::kTan:
+      case HloOpcode::kTanh:
+        return true;
+      default:
+        return false;
+    }
+  }
+};
+
+using UnaryElementwiseTest = ElementwiseTest;
+using BinaryElementwiseTest = ElementwiseTest;
+using TernaryElementwiseTest = ElementwiseTest;
+
+TEST_P(UnaryElementwiseTest, Unary) {
+  auto [opcode, type] = GetParam();
+  auto opcode_name = HloOpcodeString(opcode);
+
+  if (primitive_util::IsSignedIntegralType(type) &&
+      (opcode == HloOpcode::kClz || opcode == HloOpcode::kPopulationCount)) {
+    GTEST_SKIP() << "Unsupported op on signed type: " << opcode_name;
+  }
+  if (primitive_util::IsUnsignedIntegralType(type) &&
+      (opcode == HloOpcode::kAbs || opcode == HloOpcode::kSign)) {
+    GTEST_SKIP() << "Unsupported op on unsigned type: " << opcode_name;
+  }
+
+  const std::string hlo_text = absl::Substitute(
+      R"(
+  HloModule unary
+
+  ENTRY main {
+    a = $0[100] parameter(0)
+    ROOT r = $0[100] $1(a)
+  }
+)",
+      primitive_util::LowercasePrimitiveTypeName(type),
+      HloOpcodeString(opcode));
+  EXPECT_TRUE(RunAndCompare(hlo_text, std::nullopt));
+}
+
+TEST_P(BinaryElementwiseTest, Binary) {
+  auto [opcode, type] = GetParam();
+  auto type_name = primitive_util::LowercasePrimitiveTypeName(type);
+
+  const std::string hlo_text = absl::Substitute(
+      R"(
+  HloModule binary
+
+  ENTRY main {
+    a = $0[100] parameter(0)
+    b = $0[100] parameter(1)
+    ROOT r = $2[100] $1(a, b) $3
+  }
+)",
+      type_name, HloOpcodeString(opcode),
+      opcode == HloOpcode::kCompare ? "pred" : type_name,
+      opcode == HloOpcode::kCompare ? ", direction=LT" : "");
+  EXPECT_TRUE(RunAndCompare(hlo_text, std::nullopt));
+}
+
+TEST_P(TernaryElementwiseTest, Ternary) {
+  auto [opcode, type] = GetParam();
+  auto type_name = primitive_util::LowercasePrimitiveTypeName(type);
+
+  const std::string hlo_text =
+      absl::Substitute(R"(
+  HloModule ternary
+
+  ENTRY main {
+    a = $2[100] parameter(0)
+    b = $0[100] parameter(1)
+    c = $0[100] parameter(2)
+    ROOT r = $0[100] $1(a, b, c)
+  }
+)",
+                       type_name, HloOpcodeString(opcode),
+                       opcode == HloOpcode::kSelect ? "pred" : type_name);
+  EXPECT_TRUE(RunAndCompare(hlo_text, std::nullopt));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Elementwise, UnaryElementwiseTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(
+            ElementwiseTest::GetElementwiseOpcodesWithIntSupportWithArity(1)),
+        ::testing::Values(U4, S4)),
+    ElementwiseTest::FormatTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    Elementwise, BinaryElementwiseTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(
+            ElementwiseTest::GetElementwiseOpcodesWithIntSupportWithArity(2)),
+        ::testing::Values(U4, S4)),
+    ElementwiseTest::FormatTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    Elementwise, TernaryElementwiseTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(
+            ElementwiseTest::GetElementwiseOpcodesWithIntSupportWithArity(3)),
+        ::testing::Values(U4, S4)),
+    ElementwiseTest::FormatTestName);
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
Allow more HLO ops on sub-byte types: all elementwise ops and opt-barrier.