### PR TITLE
[NVIDIA] Update Cudnn Frontend to 1.8.0

### DIFF
--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,5 +1,5 @@
 diff --git a/include/cudnn_frontend.h b/include/cudnn_frontend.h
-index 7bca425..cd74e3a 100644
+index e3f1ec8..373e52d 100644
 --- a/include/cudnn_frontend.h
 +++ b/include/cudnn_frontend.h
 @@ -97,7 +97,7 @@
@@ -12,13 +12,13 @@ index 7bca425..cd74e3a 100644
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_Heuristics.h"
 diff --git a/include/cudnn_frontend/backend/backend_descriptor.h b/include/cudnn_frontend/backend/backend_descriptor.h
-index dc7ad25..ade164a 100644
+index 47387a1..3864c1d 100644
 --- a/include/cudnn_frontend/backend/backend_descriptor.h
 +++ b/include/cudnn_frontend/backend/backend_descriptor.h
-@@ -2,7 +2,7 @@
- 
+@@ -3,7 +3,7 @@
  #include <memory>
  
+ #include "../graph_helpers.h"
 -#include "cudnn.h"
 +#include "third_party/gpus/cudnn/cudnn.h"
  

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -52,9 +52,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "bd1037f8e7218d0d44ff2ff11d0c95175a5a27a82d8ea92879e23eafd6d5df02",
-        strip_prefix = "cudnn-frontend-1.6.1",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.6.1.zip"),
+        sha256 = "5f77784dc3ccbca7aca5ea0b5a6e31b95aa85023c5942d22be5fa8dd6c339d81",
+        strip_prefix = "cudnn-frontend-1.8.0",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.8.0.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
This PR bumps up the cudnn frontend version to 1.8.0.