### PR TITLE
[NVIDIA] Support larger head dim for cudnn fmha

### DIFF
--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1009,6 +1009,7 @@ xla_test(
         "//xla/service:pattern_matcher_gmock",
         "//xla/service/gpu:backend_configs_cc",
         "//xla/service/gpu:cublas_cudnn",
+        "//xla/service/gpu:stream_executor_util",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:dnn",
         "//xla/tests:hlo_test_base",

--- a/xla/service/gpu/transforms/cudnn_fused_mha_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cudnn_fused_mha_rewriter_test.cc
@@ -159,8 +159,8 @@ ENTRY main.6 {
 TEST_F(CudnnFusedMhaRewriterTestHloTest,
        BF16Bmm1SoftmaxBmm2Pattern_bmm1_rhs_contracting_dim_not_most_minor) {
   if (skip_reason_) GTEST_SKIP() << *skip_reason_;
-  const std::string hlo = absl::StrReplaceAll(
-      hlo_base_pattern, {{"HEAD_DIM", std::to_string(64)}});
+  const std::string hlo =
+      absl::StrReplaceAll(hlo_base_pattern, {{"HEAD_DIM", std::to_string(64)}});
   TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo));
   CudnnFusedMHARewriter fusedMhaRewriter{GetCudaComputeCapability(),
                                          GetCudnnVersion()};

--- a/xla/service/gpu/transforms/cudnn_fused_mha_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cudnn_fused_mha_rewriter_test.cc
@@ -135,8 +135,7 @@ class CudnnFusedMhaRewriterTestHloTest : public HloTestBase {
   std::optional<absl::string_view> skip_reason_;
 };
 
-constexpr absl::string_view
-    hlo_base_pattern = R"(
+constexpr absl::string_view hlo_base_pattern = R"(
 HloModule fmha_test, entry_computation_layout={(bf16[16,16,256,HEAD_DIM]{3,2,1,0},bf16[16,16,256,HEAD_DIM]{3,2,1,0},bf16[16,16,256,HEAD_DIM]{3,2,1,0})->bf16[16,16,256,HEAD_DIM]{3,2,1,0}}
 
 region_0.7 {
@@ -176,8 +175,8 @@ std::string ReplacePlaceholder(absl::string_view str,
   std::string result(str.begin(), str.end());
   std::string::size_type pos = 0;
   while ((pos = result.find(placeholder, pos)) != std::string::npos) {
-      result.replace(pos, placeholder.size(), value);
-      pos += value.size();
+    result.replace(pos, placeholder.size(), value);
+    pos += value.size();
   }
   return result;
 }
@@ -185,10 +184,9 @@ std::string ReplacePlaceholder(absl::string_view str,
 TEST_F(CudnnFusedMhaRewriterTestHloTest,
        BF16Bmm1SoftmaxBmm2Pattern_bmm1_rhs_contracting_dim_not_most_minor) {
   if (skip_reason_) GTEST_SKIP() << *skip_reason_;
-  bool support_large_head_dim = (
-      GetRealCudaComputeCapability().IsAtLeastHopper() &&
-      GetRealCudnnVersion() >= se::dnn::VersionInfo(9, 5, 0)
-  );
+  bool support_large_head_dim =
+      (GetRealCudaComputeCapability().IsAtLeastHopper() &&
+       GetRealCudnnVersion() >= se::dnn::VersionInfo(9, 5, 0));
   int head_dim = support_large_head_dim ? 256 : 64;
   std::string hlo = ReplacePlaceholder(hlo_base_pattern, "HEAD_DIM",
                                        std::to_string(head_dim));


### PR DESCRIPTION
Since [cudnn v9.5.0](https://docs.nvidia.com/deeplearning/cudnn/latest/release-notes.html#cudnn-9-5-0), the larger head dim of 256 is supported. This PR enables this improvement.

cc @Cjkkkk 