### PR TITLE
[XLA:GPU] Fix launch dimension size overflow

### DIFF
--- a/xla/service/gpu/launch_dimensions.cc
+++ b/xla/service/gpu/launch_dimensions.cc
@@ -40,6 +40,9 @@ LaunchDimensions CalculateLaunchDimensions(
   int64_t threads_per_block = std::min<int64_t>(
       gpu_device_info.threads_per_warp() * kWarpSchedulers, num_elements);
   int64_t num_blocks = CeilOfRatio(num_elements, threads_per_block);
+  if (num_blocks > gpu_device_info.block_dim_limit().x) {
+    num_blocks = gpu_device_info.block_dim_limit().x;
+  }
   return LaunchDimensions(se::BlockDim(num_blocks, 1, 1),
                           se::ThreadDim(threads_per_block, 1, 1));
 }


### PR DESCRIPTION
Fix below fusion kernel emitter error on Hopper: 
```
2024-10-30 06:15:46.293278: E xla/status_macros.cc:56] INTERNAL: RET_CHECK failure (xla/service/gpu/fusions/fusion_emitter.cc:95) device_info.block_dim_limit().x == 0 || launch_dims.block_counts().x < device_info.block_dim_limit().x Kernel 'loop_broadcast_fusion' launch needs more blocks (2415919104) than allowed by hardware (2147483647).
```

And the failure can be simply reproduced by replaying an HloModuleHloModule test
```
%fused_broadcast.5 () -> bf16[24,2048,2048,3,4096] {
  %constant_1284_2 = bf16[] constant(0)
  ROOT %broadcast.3862.1 = bf16[24,2048,2048,3,4096]{4,3,2,1,0} broadcast(bf16[] %constant_1284_2), dimensions={}, metadata={scheduling_name="broadcast.3862.1"}
}
```
command: 
```
bazel run \
--action_env TF_CUDA_COMPUTE_CAPABILITIES=compute_90 \
xla/tools/multihost_hlo_runner/hlo_runner_main -- \
example_hlo.txt
```