### PR TITLE
[XLA:GPU} Enable DeviceToDeviceMemCpy lowering to command buffer

### DIFF
--- a/xla/service/gpu/transforms/command_buffer_scheduling.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling.cc
@@ -271,6 +271,9 @@ static bool IsCommand(const HloInstruction* hlo,
   if (auto* sort = DynCast<HloSortInstruction>(hlo))
     return config.enabled_commands.contains(DebugOptions::FUSION);
 
+  if (hlo->opcode() == HloOpcode::kCopy)
+    return config.enabled_commands.contains(DebugOptions::FUSION);
+
   if (hlo->opcode() == HloOpcode::kPartitionId ||
       hlo->opcode() == HloOpcode::kReplicaId) {
     return config.enabled_commands.contains(DebugOptions::FUSION);


### PR DESCRIPTION
MemoryCopy command testing is covered by existing test: https://github.com/openxla/xla/blob/main/xla/service/gpu/runtime/command_buffer_cmd_test.cc#L285-L292 