### PR TITLE
[gpu] Fix the pipelined p2p bug

### DIFF
--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -2230,6 +2230,7 @@ xla_cc_test(
     deps = [
         ":pipelined_p2p_rewriter",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/parser:hlo_parser",
         "//xla/hlo/testlib:filecheck",
         "//xla/tests:hlo_test_base",
         "@com_google_absl//absl/strings:string_view",


### PR DESCRIPTION
The PipelinedP2PRewriter had two issues:

 1. For computations that did not have any collectives - the ProcessComputation function did not set the flag `collective_in_computation[computation]` to false. This caused crash on operations like `sort` with a no-collective computation.
 2. For fusion operations, the p2p rewriter assumed that there would be no collective emitted. In case of dynamic-slice-fusion, it may invoke a collective. So, changed this to handle it the same way for both fused and non-fused computations.