### PR TITLE
[AllGatherCSE] Add a pass that CSEs all-gathers on parameters.

### DIFF
--- a/xla/hlo/transforms/collectives/BUILD
+++ b/xla/hlo/transforms/collectives/BUILD
@@ -18,6 +18,31 @@ package_group(
 )
 
 cc_library(
+    name = "all_gather_cse",
+    hdrs = ["all_gather_cse.h"],
+    srcs = ["all_gather_cse.cc"],
+    deps = [
+        "//xla/hlo/pass:hlo_pass",
+        "@com_google_absl//absl/container:flat_hash_map",
+    ],
+)
+
+xla_cc_test(
+    name = "all_gather_cse_test",
+    srcs = ["all_gather_cse_test.cc"],
+    deps = [
+        ":all_gather_cse",
+        "//xla:test",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/transforms:hlo_dce",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/hlo/utils:hlo_matchers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test_main",  # fixdeps: keep
+    ],
+)
+
+cc_library(
     name = "async_collective_creator",
     srcs = ["async_collective_creator.cc"],
     hdrs = ["async_collective_creator.h"],

--- a/xla/hlo/transforms/collectives/all_gather_cse.cc
+++ b/xla/hlo/transforms/collectives/all_gather_cse.cc
@@ -1,0 +1,114 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/hlo/transforms/collectives/all_gather_cse.h"
+
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+
+namespace xla {
+
+absl::StatusOr<bool> AllGatherCSE::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  VLOG(2) << "Running AllGatherCSE pass";
+  bool changed = false;
+
+  for (HloComputation* computation : module->computations(execution_threads)) {
+    VLOG(2) << "Processing computation: " << computation->name();
+    absl::flat_hash_map<std::tuple<HloInstruction*, int64_t, PrimitiveType>,
+                        HloInstruction*>
+        all_gather_map;  // Every region has its own all gather map
+    for (HloInstruction* instruction : computation->instructions()) {
+      if (instruction->opcode() == HloOpcode::kAllGather) {
+        VLOG(2) << "Found all-gather instruction: " << instruction->ToString();
+        auto raw_parameter_tuple =
+            FindRawParameter(instruction->mutable_operand(0));
+        HloInstruction* raw_parameter = std::get<0>(raw_parameter_tuple);
+        if (raw_parameter != nullptr &&
+            raw_parameter->opcode() == HloOpcode::kParameter) {
+          auto it = all_gather_map.find(raw_parameter_tuple);
+          if (it != all_gather_map.end()) {
+            VLOG(2) << "Replacing all-gather with previous result: "
+                    << it->second->ToString();
+            TF_RETURN_IF_ERROR(instruction->ReplaceAllUsesWith(it->second));
+            changed = true;
+          } else {
+            VLOG(2) << "Storing all-gather result for future use";
+            all_gather_map[raw_parameter_tuple] = instruction;
+          }
+        }
+      }
+    }
+  }
+
+  VLOG(2) << "AllGatherCSE pass complete";
+  return changed;
+}
+
+std::tuple<HloInstruction*, int64_t, PrimitiveType>
+AllGatherCSE::FindRawParameter(HloInstruction* instruction) {
+  VLOG(2) << "Finding raw parameter for instruction: "
+          << instruction->ToString();
+  HloInstruction* current = instruction;
+  int64_t tuple_index = -1;
+  PrimitiveType dtype = instruction->shape().element_type();
+  while (current != nullptr) {
+    if (current->opcode() == HloOpcode::kParameter) {
+      VLOG(2) << "Found parameter: " << current->ToString();
+      return std::make_tuple(current, tuple_index, dtype);
+    } else if (current->opcode() == HloOpcode::kGetTupleElement) {
+      tuple_index = current->tuple_index();
+      VLOG(2) << "Found get-tuple-element at index: " << tuple_index;
+      current = current->mutable_operand(0);
+    } else if (current->opcode() == HloOpcode::kTuple) {
+      if (tuple_index >= 0 && tuple_index < current->operand_count()) {
+        VLOG(2) << "Found tuple, moving to element at index: " << tuple_index;
+        current = current->mutable_operand(tuple_index);
+        tuple_index = -1;  // Reset tuple index
+      } else {
+        VLOG(2) << "Invalid tuple index: " << tuple_index;
+        return std::make_tuple(nullptr, -1, PRIMITIVE_TYPE_INVALID);
+      }
+    } else if (current->opcode() == HloOpcode::kOptimizationBarrier) {
+      VLOG(2) << "Found optimization barrier, moving to its input";
+      current = current->mutable_operand(0);
+    } else if (current->opcode() == HloOpcode::kConvert) {
+      VLOG(2) << "Found convert operation, moving to its input";
+      current = current->mutable_operand(0);
+    } else if (current->opcode() == HloOpcode::kAllGather) {
+      // When you code motion AllGathers out of nested while loops you may end
+      // up with two all gathers trying to all gather each other as they are the
+      // same parameter. We check the shape of whats being all gathered is the
+      // same as the all gather shape. Then it is safe to traverse.
+      if (current->shape() == current->mutable_operand(0)->shape()) {
+        VLOG(2) << "Found all-gather operation, moving to its input";
+        current = current->mutable_operand(0);
+      }
+      VLOG(2) << "All gather of an all gather but we did not match shape. "
+              << current->ToString();
+      return std::make_tuple(nullptr, -1, PRIMITIVE_TYPE_INVALID);
+    } else {
+      VLOG(2) << "Unsupported instruction: " << current->ToString();
+      return std::make_tuple(nullptr, -1, PRIMITIVE_TYPE_INVALID);
+    }
+  }
+  VLOG(2) << "Raw parameter not found";
+  return std::make_tuple(nullptr, -1, PRIMITIVE_TYPE_INVALID);
+}
+
+}  // namespace xla

--- a/xla/hlo/transforms/collectives/all_gather_cse.h
+++ b/xla/hlo/transforms/collectives/all_gather_cse.h
@@ -1,0 +1,59 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_HLO_TRANSFORMS_COLLECTIVES_ALL_GATHER_CSE_H_
+#define XLA_HLO_TRANSFORMS_COLLECTIVES_ALL_GATHER_CSE_H_
+
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla {
+
+//  This pass performs common subexpression elimination (CSE) on all-gathers
+//  of parameters. It serves as a setup pass for more advanced collective
+//  transformation strategies by ensuring there is only one all-gather per
+//  parameter. This enables subsequent passes to perform operations like
+//  reinserting all-gathers or all-gather code motion. Example:
+//
+//  Before the pass:
+//  while_loop {
+//      all-gather.1 = all-gather(param_0)
+//      some_computation.1 = compute(all-gather.1)
+//      all-gather.2 = all-gather(param_0)
+//      some_computation.2 = compute(all-gather.2)
+//  }
+//
+//  After the pass:
+//  while_loop {
+//      all-gather.0 = all-gather(param_0)
+//      some_computation.1 = compute(all-gather.0)
+//      some_computation.2 = compute(all-gather.0)
+//  }
+class AllGatherCSE : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "all-gather-cse"; }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  std::tuple<HloInstruction*, int64_t, PrimitiveType> FindRawParameter(
+      HloInstruction* instruction);
+};
+
+}  // namespace xla
+
+#endif  // XLA_HLO_TRANSFORMS_COLLECTIVES_ALL_GATHER_CSE_H_

--- a/xla/hlo/transforms/collectives/all_gather_cse_test.cc
+++ b/xla/hlo/transforms/collectives/all_gather_cse_test.cc
@@ -1,0 +1,223 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/hlo/transforms/collectives/all_gather_cse.h"
+
+#include <string_view>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/transforms/simplifiers/hlo_dce.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/hlo/utils/hlo_matchers.h"
+#include "tsl/platform/statusor.h"
+
+namespace op = xla::testing::opcode_matchers;
+
+namespace xla {
+namespace {
+
+class AllGatherCSETest : public HloHardwareIndependentTestBase {
+ protected:
+  AllGatherCSE pass_;
+};
+
+TEST_F(AllGatherCSETest, ReplacesRedundantAllGather) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = s32[4] parameter(0)
+      all-gather.1 = s32[8] all-gather(param0), dimensions={0}, replica_groups={{0,1}}
+      all-gather.2 = s32[8] all-gather(param0), dimensions={0}, replica_groups={{0,1}}
+      ROOT tuple = (s32[8], s32[8]) tuple(all-gather.1, all-gather.2)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  EXPECT_TRUE(changed);
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Tuple(op::AllGather(op::Parameter(0)),
+                        op::AllGather(op::Parameter(0))));
+}
+
+TEST_F(AllGatherCSETest, HandlesRawParameterGetTupleElement) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = (s32[8], s32[8]) parameter(0)
+      gte0 = s32[8] get-tuple-element(param0), index=0
+      gte1 = s32[8] get-tuple-element(param0), index=1
+      all-gather.1 = s32[16] all-gather(gte0), dimensions={0}, replica_groups={{0,1}}
+      all-gather.2 = s32[16] all-gather(gte1), dimensions={0}, replica_groups={{0,1}}
+      ROOT tuple = (s32[16], s32[16]) tuple(all-gather.1, all-gather.2)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(AllGatherCSETest, HandlesRawParameterTuple) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = s32[8] parameter(0)
+      param1 = s32[8] parameter(1)
+      tuple0 = (s32[8], s32[8]) tuple(param0, param1)
+      gte0 = s32[8] get-tuple-element(tuple0), index=0
+      gte1 = s32[8] get-tuple-element(tuple0), index=1
+      all-gather.1 = s32[16] all-gather(gte0), dimensions={0}, replica_groups={{0,1}}
+      all-gather.2 = s32[16] all-gather(gte1), dimensions={0}, replica_groups={{0,1}}
+      ROOT tuple = (s32[16], s32[16]) tuple(all-gather.1, all-gather.2)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(AllGatherCSETest, HandlesRawParameterOptimizationBarrierCSE) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = (s32[8], s32[8]) parameter(0)
+      opt_barrier = (s32[8], s32[8]) opt-barrier(param0)
+      gte0 = s32[8] get-tuple-element(opt_barrier), index=0
+      all-gather.1 = s32[16] all-gather(gte0), dimensions={0}, replica_groups={{0,1}}
+      all-gather.2 = s32[16] all-gather(gte0), dimensions={0}, replica_groups={{0,1}}
+      ROOT tuple = (s32[16], s32[16]) tuple(all-gather.1, all-gather.2)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+  EXPECT_TRUE(changed);
+
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      op::Tuple(op::AllGather(op::GetTupleElement(op::OptimizationBarrier())),
+                op::AllGather(op::GetTupleElement(op::OptimizationBarrier()))));
+}
+
+TEST_F(AllGatherCSETest, HandlesRawParameterConvert) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = f32[8] parameter(0)
+      convert0 = s32[8] convert(param0)
+      all-gather.1 = s32[16] all-gather(convert0), dimensions={0}, replica_groups={{0,1}}
+      all-gather.2 = s32[16] all-gather(convert0), dimensions={0}, replica_groups={{0,1}}
+      ROOT tuple = (s32[16], s32[16]) tuple(all-gather.1, all-gather.2)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+  EXPECT_TRUE(changed);
+
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      op::Tuple(op::AllGather(op::Convert()), op::AllGather(op::Convert())));
+}
+
+TEST_F(AllGatherCSETest, HandlesNoAllGather) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = s32[8] parameter(0)
+      ROOT tuple = (s32[8], s32[8]) tuple(param0, param0)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(AllGatherCSETest, HandlesNonParameterOperand) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = s32[8] parameter(0)
+      negate0 = s32[8] negate(param0)
+      all-gather.1 = s32[16] all-gather(negate0), dimensions={0}, replica_groups={{0,1}}
+      ROOT tuple = (s32[16]) tuple(all-gather.1)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(AllGatherCSETest, RunsHloDCEAfterChanges) {
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = s32[8] parameter(0)
+      all-gather.1 = s32[16] all-gather(param0), dimensions={0}, replica_groups={{0,1}}
+      all-gather.2 = s32[16] all-gather(param0), dimensions={0}, replica_groups={{0,1}}
+      ROOT tuple = (s32[16]) tuple(all-gather.1)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+  EXPECT_TRUE(changed);
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Tuple(op::AllGather(op::Parameter(0))));
+}
+
+}  // namespace
+}  // namespace xla


### PR DESCRIPTION
This PR adds a pass that performs common subexpression elimination on all-gathers of parameters. This is especially useful in strategies where you do not want to run all-gathers in the backward pass. 

```
    Before the pass:
    while_loop {
        all-gather.1 = all-gather(param_0)
        some_computation.1 = compute(all-gather.1)
        all-gather.2 = all-gather(param_0)
        some_computation.2 = compute(all-gather.2)
    }

    After the pass:
    while_loop {
        all-gather.0 = all-gather(param_0)
        some_computation.1 = compute(all-gather.0)
        some_computation.2 = compute(all-gather.0)
    }
    ```