### PR TITLE
Add ReducePrecision handler to algebraic_simplifier

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
@@ -431,6 +431,8 @@ class AlgebraicSimplifierVisitor : public DfsHloRewriteVisitor {
 
   absl::Status HandleConvert(HloInstruction* convert) override;
 
+  absl::Status HandleReducePrecision(HloInstruction* reduce_precision) override;
+
   absl::Status HandleComplex(HloInstruction* complex) override;
 
   absl::Status HandleCustomCall(HloInstruction* custom_call) override;


### PR DESCRIPTION
```
ReducePrecision(operand, mantissa_bits, exponent_bits)

Arguments        Type     Semantics
---------------------------------------------------------------------------
operand          XlaOp    array of floating-point type T.
exponent_bits    int32    number of exponent bits in lower-precision format
mantissa_bits    int32    number of mantissa bits in lower-precision format
```

If the target exponent bits and mantissa bits are equal to or greater than those of the operation's data type, the operation is a no-op and can be removed.

https://openxla.org/xla/operation_semantics#reduceprecision

_The number of exponent or mantissa bits may exceed the corresponding value for type T; the corresponding portion of the conversion is then simply a no-op._
