### PR TITLE
Fix build issues caused by wrong type in GetRangeVarNames

### DIFF
--- a/xla/service/gpu/model/indexing_map_serialization.cc
+++ b/xla/service/gpu/model/indexing_map_serialization.cc
@@ -897,7 +897,7 @@ std::ostream& operator<<(std::ostream& out, const IndexingMap& indexing_map) {
 }
 
 SmallVector<std::string> GetRangeVarNames(const IndexingMap& map) {
-  SmallVector<std::string, 3> range_names;
+  SmallVector<std::string> range_names;
   range_names.reserve(map.GetRangeVarsCount());
   for (const auto& [index, range_var] : llvm::enumerate(map.GetRangeVars())) {
     range_names.push_back(GetRangeVarName(index, range_var.name));


### PR DESCRIPTION
Introduced here: https://github.com/openxla/xla/commit/c613ee7284114b9eb0dccb6cbae24bfa6f10f244?diff=split&w=1

Error log:
```
[2024-11-06T06:12:26.615Z] xla/service/gpu/model/indexing_map_serialization.cc:905:10: error: could not convert ‘range_names’ from ‘SmallVector<[...],3>’ to ‘SmallVector<[...],1>’
[2024-11-06T06:12:26.615Z]   905 |   return range_names;
[2024-11-06T06:12:26.615Z]       |          ^~~~~~~~~~~
[2024-11-06T06:12:26.615Z]       |          |
[2024-11-06T06:12:26.615Z]       |          SmallVector<[...],3>
```