### PR TITLE
[RematerializeLargeAllGather] Add pass to rematerialize large tensor parallel all-gathers. Allow configurable bytes.

### DIFF
--- a/xla/hlo/transforms/collectives/BUILD
+++ b/xla/hlo/transforms/collectives/BUILD
@@ -398,6 +398,36 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "rematerialize_large_all_gather",
+    hdrs = ["rematerialize_large_all_gather.h"],
+    srcs = ["rematerialize_large_all_gather.cc"],
+    deps = [
+        "//xla/hlo/utils:hlo_query",
+        "//xla:shape_util",
+        "//xla/service:hlo_creation_utils",
+        "//xla/service:hlo_pass",
+        "//xla/service:pattern_matcher",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rematerialize_large_all_gather_test",
+    srcs = ["rematerialize_large_all_gather_test.cc"],
+    deps = [
+        ":rematerialize_large_all_gather",
+        "//xla:test",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/transforms:hlo_dce",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/hlo/utils:hlo_matchers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test_main",  # fixdeps: keep
+    ],
+)
+
+cc_library(
     name = "while_loop_all_reduce_code_motion_setup",
     srcs = ["while_loop_all_reduce_code_motion_setup.cc"],
     hdrs = ["while_loop_all_reduce_code_motion_setup.h"],

--- a/xla/hlo/transforms/collectives/rematerialize_large_all_gather.cc
+++ b/xla/hlo/transforms/collectives/rematerialize_large_all_gather.cc
@@ -1,0 +1,166 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/hlo/transforms/collectives/rematerialize_large_all_gather.h"
+
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_query.h"
+#include "xla/service/pattern_matcher.h"
+#include "xla/shape_util.h"
+
+namespace xla {
+
+std::pair<bool, std::vector<ReplicaGroup>>
+RematerializeLargeAllGather::GetTpReplicaGroup(HloComputation* computation) {
+  //   Use pattern matcher to find TP replica group pattern. It finds
+  //  reduce-scatter that matches either reduce-scatter(dot) or
+  // reduce-scatter(any(dot)) patterns. The replica group is used to determine
+  // whether to combine a all-gather or not.
+
+  bool tp_replica_group_found = false;
+  std::vector<ReplicaGroup> tp_replica_group;
+  for (HloInstruction* instruction : computation->MakeInstructionPostOrder()) {
+    if (Match(instruction,
+              match::ReduceScatter().WithOperand(
+                  0, match::AnyOf<HloInstruction>(
+                         match::Op().WithOpcode(HloOpcode::kDot),
+                         match::Op()
+                             .WithOpcode(HloOpcode::kReshape)
+                             .WithOperand(0, match::Op().WithOpcode(
+                                                 HloOpcode::kDot)))))) {
+      tp_replica_group = instruction->replica_groups();
+      tp_replica_group_found = true;
+    }
+    if (tp_replica_group_found) break;
+  }
+  return std::make_pair(tp_replica_group_found, tp_replica_group);
+}
+
+std::pair<bool, std::vector<ReplicaGroup>>
+RematerializeLargeAllGather::GetTpReplicaGroup(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  std::vector<ReplicaGroup> tp_replica_group;
+  bool tp_replica_group_found = false;
+  for (HloComputation* computation : module->computations(execution_threads)) {
+    auto rval = GetTpReplicaGroup(computation);
+    if (rval.first) {
+      tp_replica_group = rval.second;
+      tp_replica_group_found = true;
+      break;
+    }
+  }
+  return std::make_pair(tp_replica_group_found, tp_replica_group);
+}
+
+bool RematerializeLargeAllGather::IsRemattableAllGather(
+    std::vector<ReplicaGroup> tp_replica_group, HloInstruction* input_inst) {
+  if (disable_pattern_match_ && !tp_replica_group.empty()) {
+    VLOG(2) << "Matched all-gather with replica group "
+            << input_inst->ToString();
+    return hlo_query::HasMatchingReplicaGroups(input_inst, tp_replica_group);
+  } else {
+    int64_t ag_numel = 1;
+    for (int64_t dim : input_inst->shape().dimensions()) {
+      ag_numel *= dim;
+    }
+    const int64_t ag_size = ag_numel * ShapeUtil::ByteSizeOfPrimitiveType(
+                                           input_inst->shape().element_type());
+    VLOG(2) << "Matched all-gather based on size " << ag_size;
+    return ag_size >= remat_size_in_bytes_;
+  }
+}
+absl::StatusOr<bool> RematerializeLargeAllGather::RematAllGather(
+    HloInstruction* all_gather_inst, HloInstruction* gte,
+    HloInstruction* opt_barrier) {
+  VLOG(2) << "Will remat all-gather: " << all_gather_inst->ToString();
+  int64_t tuple_index = gte->tuple_index();
+  HloComputation* computation = all_gather_inst->parent();
+  // Replace the operand of the optimization barrier's tuple with the
+  // AllGather input
+  TF_RETURN_IF_ERROR(
+      opt_barrier->mutable_operand(0)->ReplaceOperandWithDifferentShape(
+          tuple_index, all_gather_inst->mutable_operand(0)));
+  // Update the shape of the optimization barrier's tuple to match the
+  // new operand shape
+  Shape new_tuple_shape = opt_barrier->operand(0)->shape();
+  *new_tuple_shape.mutable_tuple_shapes(tuple_index) =
+      all_gather_inst->mutable_operand(0)->shape();
+  *opt_barrier->mutable_operand(0)->mutable_shape() = new_tuple_shape;
+  // Update the shape of the optimization barrier to match the new
+  // tuple shape
+  *opt_barrier->mutable_shape() = new_tuple_shape;
+  // Replace the GetTupleElement with a new GetTupleElement from the
+  // updated OptimizationBarrier
+  HloInstruction* new_gte =
+      computation->AddInstruction(HloInstruction::CreateGetTupleElement(
+          all_gather_inst->mutable_operand(0)->shape(), opt_barrier,
+          tuple_index));
+
+  HloAllGatherInstruction* all_gather =
+      Cast<HloAllGatherInstruction>(all_gather_inst);
+  // Launch the AllGather on the new GetTupleElement
+  HloInstruction* new_allgather =
+      computation->AddInstruction(HloInstruction::CreateAllGather(
+          all_gather->shape(), {new_gte}, all_gather->all_gather_dimension(),
+          all_gather->replica_groups(), all_gather->constrain_layout(),
+          all_gather->channel_id(), all_gather->use_global_device_ids()));
+  // Replace the original GetTupleElement with the new AllGather
+  TF_RETURN_IF_ERROR(gte->ReplaceAllUsesWith(new_allgather));
+  return true;
+}
+
+absl::StatusOr<bool> RematerializeLargeAllGather::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+  bool tp_replica_group_found = false;
+  std::vector<ReplicaGroup> tp_replica_group;
+  if (!disable_pattern_match_) {
+    auto rval = GetTpReplicaGroup(module, execution_threads);
+    if (rval.first) {
+      tp_replica_group_found = true;
+      tp_replica_group = rval.second;
+    }
+  }
+
+  for (HloComputation* computation : module->computations(execution_threads)) {
+    for (HloInstruction* inst : computation->instructions()) {
+      if (inst->opcode() == HloOpcode::kGetTupleElement) {
+        HloInstruction* opt_barrier = inst->mutable_operand(0);
+        if (opt_barrier->opcode() == HloOpcode::kOptimizationBarrier) {
+          int64_t tuple_index = inst->tuple_index();
+          HloInstruction* input_inst =
+              opt_barrier->mutable_operand(0)->mutable_operand(tuple_index);
+          if (input_inst->opcode() == HloOpcode::kAllGather &&
+              IsRemattableAllGather(tp_replica_group, input_inst)) {
+            absl::StatusOr<bool> result =
+                RematAllGather(input_inst, inst, opt_barrier);
+            CHECK(result.ok())
+                << "Failed to remat all-gather " << input_inst->ToString();
+            changed |= *result;
+          }
+        }
+      }
+    }
+  }
+
+  return changed;
+}
+
+}  // namespace xla

--- a/xla/hlo/transforms/collectives/rematerialize_large_all_gather.h
+++ b/xla/hlo/transforms/collectives/rematerialize_large_all_gather.h
@@ -1,0 +1,76 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef REMATERIALIZE_LARGE_ALLGATHER_H_
+#define REMATERIALIZE_LARGE_ALLGATHER_H_
+
+#include "xla/service/hlo_pass_interface.h"
+
+namespace xla {
+
+//    A pass that attempts to rematerialize large SPMD partitioner inserted
+//    tensor
+//  parallel all-gathers. The pass has two options for use:
+//  1. The pass can look for the reduce-scatter(dot(a,b)) pattern to find the
+//     tensor parallel replica group and remat all matching all-gathers.
+// 2. The pass accepts a threshold in bytes in which it will remat all
+//  all-gathers greater than or equal.
+//
+//  The pass also assumes the opt-barrier for activation checkpointing is
+//  already
+// present by Jax.
+//
+//  By default, it will use the pattern matcher.
+
+class RematerializeLargeAllGather : public HloModulePass {
+ public:
+  explicit RematerializeLargeAllGather(int64_t remat_size_in_bytes = 4096 *
+                                                                     4096 * 2,
+                                       bool disable_pattern_match = false)
+      : remat_size_in_bytes_(remat_size_in_bytes),
+        disable_pattern_match_(disable_pattern_match) {}
+
+  absl::string_view name() const override {
+    return "rematerialize-large-allgather";
+  }
+
+  using HloPassInterface::Run;
+
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+  bool IsRemattableAllGather(std::vector<ReplicaGroup> tp_replica_group,
+                             HloInstruction* input_inst);
+
+  std::pair<bool, std::vector<ReplicaGroup>> GetTpReplicaGroup(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads);
+
+  std::pair<bool, std::vector<ReplicaGroup>> GetTpReplicaGroup(
+      HloComputation* computation);
+
+  absl::StatusOr<bool> RematAllGather(HloInstruction* all_gather,
+                                      HloInstruction* gte,
+                                      HloInstruction* opt_barrier);
+
+ private:
+  const int64_t remat_size_in_bytes_;
+  const bool disable_pattern_match_;
+};
+
+}  // namespace xla
+
+#endif  // REMATERIALIZE_LARGE_ALLGATHER_H_

--- a/xla/hlo/transforms/collectives/rematerialize_large_all_gather_test.cc
+++ b/xla/hlo/transforms/collectives/rematerialize_large_all_gather_test.cc
@@ -1,0 +1,210 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/hlo/transforms/collectives/rematerialize_large_all_gather.h"
+
+#include <string_view>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/transforms/simplifiers/hlo_dce.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/hlo/utils/hlo_matchers.h"
+#include "tsl/platform/statusor.h"
+
+namespace op = xla::testing::opcode_matchers;
+
+namespace xla {
+namespace {
+
+class RematerializeLargeAllGatherTest : public HloHardwareIndependentTestBase {
+ protected:
+  RematerializeLargeAllGatherTest() = default;
+};
+
+TEST_F(RematerializeLargeAllGatherTest, ReduceScatterDotPatternWithOptBarrier) {
+  constexpr std::string_view hlo = R"(
+HloModule main
+%reduction {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add = f32[] add(f32[] %x, f32[] %y)
+}
+ENTRY main {
+  %param0 = f32[4096,4096] parameter(0)
+  %param1 = f32[4096,4096] parameter(1)
+  %dot = f32[4096,4096] dot(%param0, %param1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %reduce-scatter = f32[2048,4096] reduce-scatter(%dot), dimensions={0}, replica_groups={{0,1}}, to_apply=%reduction
+  %multiply = f32[2048,4096] multiply(%reduce-scatter, %reduce-scatter)
+  %all-gather = f32[4096,4096] all-gather(%multiply), replica_groups={{0,1}}, dimensions={0}
+  %tuple = (f32[4096,4096]) tuple(%all-gather)
+  %opt-barrier = (f32[4096,4096]) opt-barrier(%tuple)
+  ROOT %gte = f32[4096,4096] get-tuple-element(%opt-barrier), index=0
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  RematerializeLargeAllGather pass;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+  EXPECT_TRUE(changed);
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::GetTupleElement(op::OptimizationBarrier())));
+}
+
+TEST_F(RematerializeLargeAllGatherTest,
+       ReduceScatterDotPatternWithOptBarrierAndDisablePatternMatch) {
+  constexpr std::string_view hlo = R"(
+HloModule main
+%reduction {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add = f32[] add(f32[] %x, f32[] %y)
+}
+ENTRY main {
+  %param0 = f32[4096,4096] parameter(0)
+  %param1 = f32[4096,4096] parameter(1)
+  %dot = f32[4096,4096] dot(%param0, %param1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %reduce-scatter = f32[2048,4096] reduce-scatter(%dot), dimensions={0}, replica_groups={{0,1}}, to_apply=%reduction
+  %multiply = f32[2048,4096] multiply(%reduce-scatter, %reduce-scatter)
+  %all-gather = f32[4096,4096] all-gather(%multiply), dimensions={0}
+  %tuple = (f32[4096,4096]) tuple(%all-gather)
+  %opt-barrier = (f32[4096,4096]) opt-barrier(%tuple)
+  ROOT %gte = f32[4096,4096] get-tuple-element(%opt-barrier), index=0
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  RematerializeLargeAllGather pass(/*remat_size_in_bytes=*/4096 * 4096 * 2,
+                                   /*disable_pattern_match=*/true);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+  EXPECT_TRUE(changed);
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::GetTupleElement(op::OptimizationBarrier())));
+}
+
+TEST_F(RematerializeLargeAllGatherTest,
+       ReduceScatterDotPatternWithOptBarrierAndHighBytes) {
+  constexpr std::string_view hlo = R"(
+HloModule main
+%reduction {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add = f32[] add(f32[] %x, f32[] %y)
+}
+ENTRY main {
+  %param0 = f32[4096,4096] parameter(0)
+  %param1 = f32[4096,4096] parameter(1)
+  %dot = f32[4096,4096] dot(%param0, %param1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %reduce-scatter = f32[2048,4096] reduce-scatter(%dot), dimensions={0}, replica_groups={{0,1}}, to_apply=%reduction
+  %multiply = f32[2048,4096] multiply(%reduce-scatter, %reduce-scatter)
+  %all-gather = f32[4096,4096] all-gather(%multiply), dimensions={0}
+  %tuple = (f32[4096,4096]) tuple(%all-gather)
+  %opt-barrier = (f32[4096,4096]) opt-barrier(%tuple)
+  ROOT %gte = f32[4096,4096] get-tuple-element(%opt-barrier), index=0
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  RematerializeLargeAllGather pass(/*remat_size_in_bytes=*/(8192 * 8192 * 2),
+                                   /*disable_pattern_match=*/true);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(RematerializeLargeAllGatherTest,
+       ReduceScatterDotPatternWithOptBarrierAndLowBytes) {
+  constexpr std::string_view hlo = R"(
+HloModule main
+%reduction {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add = f32[] add(f32[] %x, f32[] %y)
+}
+ENTRY main {
+  %param0 = f32[4096,4096] parameter(0)
+  %param1 = f32[4096,4096] parameter(1)
+  %dot = f32[4096,4096] dot(%param0, %param1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %reduce-scatter = f32[2048,4096] reduce-scatter(%dot), dimensions={0}, replica_groups={{0,1}}, to_apply=%reduction
+  %multiply = f32[2048,4096] multiply(%reduce-scatter, %reduce-scatter)
+  %all-gather = f32[4096,4096] all-gather(%multiply), dimensions={0}
+  %tuple = (f32[4096,4096]) tuple(%all-gather)
+  %opt-barrier = (f32[4096,4096]) opt-barrier(%tuple)
+  ROOT %gte = f32[4096,4096] get-tuple-element(%opt-barrier), index=0
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  RematerializeLargeAllGather pass(/*remat_size_in_bytes=*/1024,
+                                   /*disable_pattern_match=*/true);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::GetTupleElement(op::OptimizationBarrier())));
+}
+
+TEST_F(RematerializeLargeAllGatherTest, NoOptBarrier) {
+  constexpr std::string_view hlo = R"(
+HloModule main
+%reduction {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add = f32[] add(f32[] %x, f32[] %y)
+}
+ENTRY main {
+  %param0 = f32[4096,4096] parameter(0)
+  %param1 = f32[4096,4096] parameter(1)
+  %dot = f32[4096,4096] dot(%param0, %param1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %reduce-scatter = f32[2048,4096] reduce-scatter(%dot), dimensions={0}, replica_groups={{0,1}}, to_apply=%reduction
+  %multiply = f32[2048,4096] multiply(%reduce-scatter, %reduce-scatter)
+  ROOT %all-gather = f32[4096,4096] all-gather(%multiply), dimensions={0}
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  RematerializeLargeAllGather pass;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(RematerializeLargeAllGatherTest,
+       NoReduceScatterDotPatternFallbackToDefaultRematSize) {
+  constexpr std::string_view hlo = R"(
+HloModule main
+ENTRY main {
+  %param0 = f32[4096,4096] parameter(0)
+  %all-gather = f32[8192,4096] all-gather(%param0), dimensions={0}
+  %tuple = (f32[8192,4096]) tuple(%all-gather)
+  %opt-barrier = (f32[8192,4096]) opt-barrier(%tuple)
+  ROOT %gte = f32[8192,4096] get-tuple-element(%opt-barrier), index=0
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  RematerializeLargeAllGather pass;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  HloDCE dce;
+  TF_RETURN_IF_ERROR(dce.Run(module.get()).status());
+  EXPECT_TRUE(changed);
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::AllGather(op::GetTupleElement(op::OptimizationBarrier())));
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/hlo/utils/hlo_query.cc
+++ b/xla/hlo/utils/hlo_query.cc
@@ -304,5 +304,29 @@ HloInstruction* FindInstruction(const HloComputation* computation,
   return nullptr;
 }
 
+bool HasMatchingReplicaGroups(
+    const xla::HloInstruction* instruction,
+    const std::vector<xla::ReplicaGroup> replica_groups) {
+  bool match = true;
+  if (instruction->replica_groups().size() == replica_groups.size() &&
+      instruction->replica_groups()[0].replica_ids().size() ==
+          replica_groups[0].replica_ids().size()) {
+    for (int i = 0; i < instruction->replica_groups().size(); i++) {
+      for (int j = 0; j < instruction->replica_groups()[0].replica_ids().size();
+           j++) {
+        if (instruction->replica_groups()[i].replica_ids()[j] !=
+            replica_groups[i].replica_ids()[j]) {
+          match = false;
+          break;
+        }
+      }
+      if (!match) break;
+    }
+  } else {
+    match = false;
+  }
+  return match;
+}
+
 }  // namespace hlo_query
 }  // namespace xla

--- a/xla/hlo/utils/hlo_query.h
+++ b/xla/hlo/utils/hlo_query.h
@@ -203,6 +203,12 @@ HloInstruction* FindInstruction(const HloComputation* computation,
 HloInstruction* FindInstruction(const HloComputation* computation,
                                 HloOpcode opcode);
 
+// Checks if the instruction has replica groups that matches the given replica
+// group.
+bool HasMatchingReplicaGroups(
+    const xla::HloInstruction* instruction,
+    const std::vector<xla::ReplicaGroup> replica_groups);
+
 }  // namespace hlo_query
 }  // namespace xla
 


### PR DESCRIPTION
This PR adds a pass that rematerializes large all-gathers for activation checkpointing in Jax models. The pass by default will try and remat tensor parallel all-gathers, but the pass also allows specifying the bytes threshold in which to remat. 