### PR TITLE
Bugfix sharding related logging

### DIFF
--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -1989,7 +1989,7 @@ class HloInstruction {
   // Returns the sharding applied to this operator.
   // REQUIRES: has_sharding() is true.
   const HloSharding& sharding() const {
-    CHECK(has_sharding());
+    CHECK(has_sharding()) << "Sharding instruction expected for: " << ToString() ;
     return *sharding_;
   }
   std::shared_ptr<const HloSharding> sharding_ptr() const { return sharding_; }

--- a/xla/service/sharding_propagation.cc
+++ b/xla/service/sharding_propagation.cc
@@ -2002,7 +2002,9 @@ bool AggressiveConcatOperandShardingCanPassThrough(
 bool InferDynamicUpdateSliceShardingFromOperand1(
     HloInstruction* instruction, bool may_combine_partial_sharding) {
   CHECK(instruction->opcode() == HloOpcode::kDynamicSlice ||
-        instruction->opcode() == HloOpcode::kDynamicUpdateSlice);
+        instruction->opcode() == HloOpcode::kDynamicUpdateSlice)
+        << "Expecting kDynamicSlice or kDynamicUpdateSlice for: "
+        << instruction->ToString();
   const HloInstruction* operand =
       instruction->opcode() == HloOpcode::kDynamicSlice
           ? instruction->operand(0)
@@ -2010,7 +2012,9 @@ bool InferDynamicUpdateSliceShardingFromOperand1(
   if (!hlo_sharding_util::IsSpatiallyPartitioned(operand)) {
     return false;
   }
-  CHECK(!operand->sharding().IsManual());
+  CHECK(!operand->sharding().IsManual())            
+      << "Unexpected manual sharding found for: "
+      << instruction->ToString();
 
   std::vector<int64_t> slice_dims;
   for (int64_t i = 0; i < instruction->shape().rank(); ++i) {

--- a/xla/service/sharding_propagation.cc
+++ b/xla/service/sharding_propagation.cc
@@ -1464,9 +1464,9 @@ absl::StatusOr<bool> ProcessShardingInstruction(
     for (auto it = instructions.rbegin(); it != instructions.rend(); ++it) {
       HloInstruction* instruction = *it;
       if (instruction->IsCustomCall("Sharding")) {
-        TF_RET_CHECK(instruction->has_sharding())
-            << "Sharding instruction must have a sharding attribute";
         VLOG(3) << "ProcessShardingInstruction: " << instruction->ToString();
+        // No check output because has_sharding will block it from showing.
+        TF_RET_CHECK(instruction->has_sharding());
         HloSharding original_sharding = instruction->sharding();
 
         std::vector<int64_t> unspec_dims;

--- a/xla/service/sharding_propagation.cc
+++ b/xla/service/sharding_propagation.cc
@@ -1465,8 +1465,9 @@ absl::StatusOr<bool> ProcessShardingInstruction(
       HloInstruction* instruction = *it;
       if (instruction->IsCustomCall("Sharding")) {
         VLOG(3) << "ProcessShardingInstruction: " << instruction->ToString();
-        // No check output because has_sharding will block it from showing.
-        TF_RET_CHECK(instruction->has_sharding());
+        TF_RET_CHECK(instruction->has_sharding()) 
+            << "Sharding instruction must have a sharding attribute: "
+            << instruction->ToString();
         HloSharding original_sharding = instruction->sharding();
 
         std::vector<int64_t> unspec_dims;


### PR DESCRIPTION
- first bug: check for sharding before actually logging, which instruction is getting processed.
- second bug: CHECK was missing error message to indicate which instruction was failing.