### PR TITLE
[SPMD] Introduce an option to limit communication around gradient accumulation in Jax scan ops.

### DIFF
--- a/xla/hlo/utils/hlo_sharding_util.h
+++ b/xla/hlo/utils/hlo_sharding_util.h
@@ -119,9 +119,10 @@ HloSharding TransposeSharding(const HloSharding& sharding,
 // shape or std::nullopt if the resulting reshape would create an invalid
 // sharding (non continuous or non uniformly sized tiles). In case of a tile
 // maximal sharding returns the original sharding.
-std::optional<HloSharding> ReshapeSharding(const Shape& source_shape,
-                                           const Shape& target_shape,
-                                           const HloSharding& source_sharding);
+std::optional<HloSharding> ReshapeSharding(
+    const Shape& source_shape, const Shape& target_shape,
+    const HloSharding& source_sharding,
+    const bool enable_sharding_replication_grad_accum = false);
 
 // Propagates sharding through reshape. It tries to find partial matches on
 // subsets of dimensions that could satisfy ReshapeSharding() constraints, then

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -122,6 +122,12 @@ struct SpmdPartitionerOptions {
   // This combines sizes in bytes of both operands.
   // When it's set, it will override threshold_for_windowed_einsum_mib.
   std::optional<int64_t> total_bytes_windowed_einsum_threshold = std::nullopt;
+
+  // Whether to enable sharding replication for gradient accumulation pattern.
+  // Pattern is a Jax scan op over the accumulation dimension.
+  // This option can prevent all-to-alls around the scan op at the expense of
+  // higher memory.
+  bool enable_sharding_replication_grad_accum = false;
 };
 
 // Class to wrap the computation builder to capture information during SPMD


### PR DESCRIPTION
In Jax scan ops used in gradient accumulation, the reshape of the accumulation axis often triggers all-to-alls and collective-permutes. 

Example
The partitioner is hardcoded to split the sharding so it becomes

x=bf16[8,2048] sharding(4,1,8)
reshape(x, (2, 4, 2048)) sharding(2,2,1,8)
Which triggers all-to-alls and collective permute. What we want is sharding

x=bf16[8,2048] sharding(4,1,8)
reshape(x, (2, 4, 2048)) sharding(1,4,1,8)
Gradient accumulation batches are replicated. Batch itself is split and then sequence dimension is also replicated.
This is more optimal for certain hardware and the cost of replication is also quite low.

I have put this option behind an SPMD partitioner config option - 
```
  // Whether to enable sharding replication for gradient accumulation pattern.
  // Pattern is a Jax scan op over the accumulation dimension.
  // This option can prevent all-to-alls around the scan op at the expense of
  // higher memory.
  bool enable_sharding_replication_grad_accum = false;
  ```
This fixes Issue #13306 