### PR TITLE
Add guard for scalar operations when brute-forcing while loop analysis

### DIFF
--- a/xla/hlo/analysis/BUILD
+++ b/xla/hlo/analysis/BUILD
@@ -142,6 +142,8 @@ cc_library(
         "//xla/hlo/evaluator:hlo_evaluator",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/ir:hlo_reachability",
+        "//xla/hlo/utils:hlo_query",
+        "//xla/service:collective_ops_utils",
         "//xla/service:pattern_matcher",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:flat_hash_map",


### PR DESCRIPTION
If `MatchTrivialLoopTripCount`, fails we brute force the while loop with `ComputeWhileLoopTripCount`. In this patch we add a guard to ensure that we only brute-force the while loop when the operation is a scalar operation or a collection of scalar operations (via call, or fusion).