### PR TITLE
[gpu] Make collective permute decomposer accept no channel ids

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -282,6 +282,7 @@ xla_cc_test(
         ":collective_permute_decomposer",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/parser:hlo_parser",
+        "//xla/hlo/testlib:filecheck",
         "//xla/hlo/utils:hlo_matchers",
         "//xla/hlo/utils:hlo_query",
         "//xla/service/gpu:backend_configs_cc",

--- a/xla/service/collective_permute_decomposer_test.cc
+++ b/xla/service/collective_permute_decomposer_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/parser/hlo_parser.h"
+#include "xla/hlo/testlib/filecheck.h"
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/service/collective_ops_utils.h"
@@ -128,23 +129,6 @@ TEST_F(CollectivePermuteDecomposerTest, TransformedExplicitChannelId) {
   EXPECT_THAT(root, op::GetTupleElement(recv_done, 0));
 }
 
-TEST_F(CollectivePermuteDecomposerTest, NotTransformedDefaultChannelId) {
-  const char* const kModuleStr = R"(
-  HloModule test
-  ENTRY test_computation {
-    p = u32[] replica-id()
-    ROOT cp = u32[] collective-permute(p),
-      source_target_pairs={{0,1}, {1,2}, {2,3}, {3,4}}
-  }
-  )";
-
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnUnverifiedModule((kModuleStr)));
-  CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
-  EXPECT_FALSE(changed);
-}
-
 TEST_F(CollectivePermuteDecomposerTest, ThresholdNotTransformed) {
   const char* const kModuleStr = R"(
   HloModule test
@@ -178,7 +162,7 @@ TEST_F(CollectivePermuteDecomposerTest, Pipeline1) {
     count = get-tuple-element(param), index=0
     send-data = get-tuple-element(param), index=1
 
-    recv-data = u32[2] collective-permute(send-data), channel_id=1,
+    recv-data = u32[2] collective-permute(send-data), {{CHANNEL_ID}}
       source_target_pairs={{0,1}, {1,2}, {2,3}, {3,4}},
       frontend_attributes={_xla_other_attribute="xyz"}
 
@@ -202,37 +186,53 @@ TEST_F(CollectivePermuteDecomposerTest, Pipeline1) {
     ROOT result = u32[2] get-tuple-element(while_result), index=1
   })";
 
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnUnverifiedModule((kModuleStr)));
-  CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
-  EXPECT_TRUE(changed);
-  HloInstruction* recv = FindInstruction(module.get(), "recv");
-  EXPECT_EQ(recv->channel_id().value(), 1);
-  EXPECT_THAT(
-      recv->ToString(),
-      HasSubstr(
-          "_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3},{3,4}}"));
-  EXPECT_THAT(recv->ToString(), HasSubstr("_xla_send_recv_pipeline=\"0\""));
-  EXPECT_THAT(recv->ToString(), HasSubstr("_xla_other_attribute=\"xyz\""));
-  HloInstruction* recv_done = FindInstruction(module.get(), "recv-done");
-  EXPECT_THAT(recv_done->ToString(),
-              HasSubstr("_xla_send_recv_pipeline=\"0\""));
+  const char* kFileCheckStr = R"(
+  // CHECK-LABEL: %body
+  // CHECK-DAG:     %[[P1:.+]] = parameter(0)
+  // CHECK-DAG:     %[[COUNT:.+]] = get-tuple-element(%[[P1]]), index=0
+  // CHECK-DAG:     %[[C1:.+]] = constant(1)
+  // CHECK-DAG:     %[[NEW_COUNT:.+]] = add(%[[COUNT]], %[[C1]])
+  // CHECK-DAG:     %[[R:.+]] = broadcast(%[[C1]]), dimensions={}
+  // CHECK-DAG:     %[[SEND_DATA:.+]] = get-tuple-element(%[[P1]]), index=1
+  // CHECK-DAG:     %[[AFTER_ALL:.+]] = after-all()
+  // CHECK:         %[[SEND:.+]] = send(%[[SEND_DATA]], %[[AFTER_ALL]]), {{CHANNEL_ID}} 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_other_attribute="xyz",_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3},{3,4}}}
+  // CHECK:         %[[RECV:.+]] = recv(%[[AFTER_ALL]]), {{CHANNEL_ID}} 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_other_attribute="xyz",_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3},{3,4}}}
+  // CHECK-DAG:     %[[RECV_DONE:.+]] = recv-done(%[[RECV]]), {{CHANNEL_ID}} frontend_attributes={_xla_send_recv_pipeline="0"}, control-predecessors={%[[SEND]]}
+  // CHECK-DAG:     %[[GTE:.+]] = get-tuple-element(%[[RECV_DONE]]), index=0
+  // CHECK-DAG:     %[[S:.+]] = add(%[[R]], %[[GTE]])
+  // CHECK-DAG:     ROOT %{{.+}} = tuple(%[[NEW_COUNT]], %[[S]])
+  // CHECK-DAG:     %{{.+}} = send-done(%[[SEND]]), {{CHANNEL_ID}} frontend_attributes={_xla_send_recv_pipeline="0"}
+  })";
 
-  HloInstruction* send = FindInstruction(module.get(), "send");
-  EXPECT_EQ(send->channel_id().value(), 1);
-  EXPECT_THAT(
-      send->ToString(),
-      HasSubstr(
-          "_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3},{3,4}}"));
-  EXPECT_THAT(send->ToString(), HasSubstr("_xla_send_recv_pipeline=\"0\""));
-  EXPECT_THAT(send->ToString(), HasSubstr("_xla_other_attribute=\"xyz\""));
-  HloInstruction* send_done = FindInstruction(module.get(), "send-done");
-  EXPECT_THAT(send_done->ToString(),
-              HasSubstr("_xla_send_recv_pipeline=\"0\""));
+  std::string channel_id_hlo =
+      absl::StrReplaceAll(kModuleStr, {{"{{CHANNEL_ID}}", "channel_id=1, "}});
+  std::string channel_id_filecheck = absl::StrReplaceAll(
+      kFileCheckStr, {{"{{CHANNEL_ID}}", "channel_id=1, "}});
+  std::string no_channel_id_hlo =
+      absl::StrReplaceAll(kModuleStr, {{"{{CHANNEL_ID}}", ""}});
+  std::string no_channel_id_filecheck = absl::StrReplaceAll(
+      kFileCheckStr, {{"{{CHANNEL_ID}}", "channel_id=0, "}});
 
-  EXPECT_FALSE(recv_done->control_predecessors().empty());
-  EXPECT_EQ(recv_done->control_predecessors()[0], send);
+  auto check_module = [](std::string module_str, std::string filecheck_str) {
+    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                            ParseAndReturnUnverifiedModule((module_str)));
+    CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
+    TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
+    EXPECT_TRUE(changed);
+
+    TF_ASSERT_OK_AND_ASSIGN(
+        bool filecheck_status,
+        RunFileCheck(/*input=*/module->ToString(
+                         /*options=*/HloPrintOptions{}
+                             .set_print_operand_shape(false)
+                             .set_print_result_shape(false)),
+                     /*pattern=*/filecheck_str));
+    EXPECT_TRUE(filecheck_status);
+  };
+  check_module(channel_id_hlo, channel_id_filecheck);
+  check_module(no_channel_id_hlo, no_channel_id_filecheck);
 }
 
 TEST_F(CollectivePermuteDecomposerTest, ForwardPipeline2) {
@@ -250,10 +250,10 @@ TEST_F(CollectivePermuteDecomposerTest, ForwardPipeline2) {
     count = get-tuple-element(param), index=0
     send-data = get-tuple-element(param), index=1
 
-    recv-data.0 = u32[2] collective-permute(send-data), channel_id=1,
+    recv-data.0 = u32[2] collective-permute(send-data), {{CHANNEL_ID_1}}
       source_target_pairs={{3,0}}
 
-    recv-data.1 = u32[2] collective-permute(send-data), channel_id=2,
+    recv-data.1 = u32[2] collective-permute(send-data), {{CHANNEL_ID_2}}
       source_target_pairs={{0,1}, {1,2}, {2,3}}
 
     replica = u32[] replica-id()
@@ -282,38 +282,70 @@ TEST_F(CollectivePermuteDecomposerTest, ForwardPipeline2) {
     ROOT result = u32[2] get-tuple-element(while_result), index=1
   })";
 
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnUnverifiedModule((kModuleStr)));
-  CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
-  EXPECT_TRUE(changed);
-  HloInstruction* recv = FindInstruction(module.get(), "recv");
-  EXPECT_EQ(recv->channel_id().value(), 1);
-  EXPECT_THAT(recv->ToString(),
-              HasSubstr("_xla_send_recv_source_target_pairs={{3,0}}"));
-  EXPECT_THAT(recv->ToString(), HasSubstr("_xla_send_recv_pipeline=\"0\""));
-  HloInstruction* send = FindInstruction(module.get(), "send");
-  EXPECT_THAT(send->ToString(),
-              HasSubstr("_xla_send_recv_source_target_pairs={{3,0}}"));
-  EXPECT_THAT(send->ToString(), HasSubstr("_xla_send_recv_pipeline=\"0\""));
+  const char* kFilecheckStr = R"(
+  // CHECK-LABEL: %body
+  // CHECK-DAG:     %[[p1:.+]] = parameter(0)
+  // CHECK-DAG:     %[[count:.+]] = get-tuple-element(%[[p1]]), index=0
+  // CHECK-DAG:     %[[c1:.+]] = constant(1)
+  // CHECK-DAG:     %[[new_count:.+]] = add(%[[count]], %[[c1]])
+  // CHECK-DAG:     %[[r:.+]] = broadcast(%[[c1]]), dimensions={}
+  // CHECK-DAG:     %[[replica:.+]] = replica-id()
+  // CHECK-DAG:     %[[c0:.+]] = constant(0)
+  // CHECK-DAG:     %[[compare0:.+]] = compare(%[[replica]], %[[c0]]), direction=EQ
+  // CHECK-DAG:     %[[compare:.+]] = broadcast(%[[compare0]]), dimensions={}
+  // CHECK-DAG:     %[[send_data:.+]] = get-tuple-element(%[[p1]]), index=1
+  // CHECK-DAG:     %[[after_all:.+]] = after-all()
+  // CHECK:         %[[send:.+]] = send(%[[send_data]], %[[after_all]]), {{CHANNEL_ID_1}} 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{3,0}}}
+  // CHECK:         %[[recv:.+]] = recv(%[[after_all]]), {{CHANNEL_ID_1}} 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{3,0}}}
+  // CHECK-DAG:     %[[recv_done:.+]] = recv-done(%[[recv]]), {{CHANNEL_ID_1}} frontend_attributes={_xla_send_recv_pipeline="0"}, control-predecessors={%[[send]]}
+  // CHECK-DAG:     %[[gte:.+]] = get-tuple-element(%[[recv_done]]), index=0
+  // CHECK-DAG:     %[[after_all1:.+]] = after-all()
+  // CHECK:         %[[send1:.+]] = send(%[[send_data]], %[[after_all1]]), {{CHANNEL_ID_2}} 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="1",_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}}
+  // CHECK:         %[[recv1:.+]] = recv(%[[after_all1]]), {{CHANNEL_ID_2}} 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="1",_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}}
+  // CHECK-DAG:     %[[recv_done1:.+]] = recv-done(%[[recv1]]), {{CHANNEL_ID_2}} frontend_attributes={_xla_send_recv_pipeline="1"}, control-predecessors={%[[send1]]}
+  // CHECK-DAG:     %[[gte1:.+]] = get-tuple-element(%[[recv_done1]]), index=0
+  // CHECK-DAG:     %[[recv_data2:.+]] = select(%[[compare]], %[[gte]], %[[gte1]])
+  // CHECK-DAG:     %[[s:.+]] = add(%[[r]], %[[recv_data2]])
+  // CHECK-DAG:     ROOT %{{.+}} = tuple(%[[new_count]], %[[s]])
+  // CHECK-DAG:     %{{.+}} = send-done(%[[send]]), {{CHANNEL_ID_1}} frontend_attributes={_xla_send_recv_pipeline="0"}
+  // CHECK-DAG:     %{{.+}} = send-done(%[[send1]]), {{CHANNEL_ID_2}} frontend_attributes={_xla_send_recv_pipeline="1"}
+  })";
 
-  HloInstruction* recv1 = FindInstruction(module.get(), "recv.1");
-  EXPECT_EQ(recv1->channel_id().value(), 2);
-  EXPECT_THAT(
-      recv1->ToString(),
-      HasSubstr("_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}"));
-  EXPECT_THAT(recv1->ToString(), HasSubstr("_xla_send_recv_pipeline=\"1\""));
-  HloInstruction* recv_done1 = FindInstruction(module.get(), "recv-done.1");
-  EXPECT_THAT(recv_done1->ToString(),
-              HasSubstr("_xla_send_recv_pipeline=\"1\""));
-  HloInstruction* send1 = FindInstruction(module.get(), "send.1");
-  EXPECT_THAT(
-      send1->ToString(),
-      HasSubstr("_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}"));
-  EXPECT_THAT(send1->ToString(), HasSubstr("_xla_send_recv_pipeline=\"1\""));
-  HloInstruction* send_done1 = FindInstruction(module.get(), "send-done.1");
-  EXPECT_THAT(send_done1->ToString(),
-              HasSubstr("_xla_send_recv_pipeline=\"1\""));
+  std::string channel_id_hlo =
+      absl::StrReplaceAll(kModuleStr, {{"{{CHANNEL_ID_1}}", "channel_id=1, "},
+                                       {"{{CHANNEL_ID_2}}", "channel_id=2, "}});
+  std::string channel_id_filecheck = absl::StrReplaceAll(
+      kFilecheckStr, {{"{{CHANNEL_ID_1}}", "channel_id=1, "},
+                      {"{{CHANNEL_ID_2}}", "channel_id=2, "}});
+  std::string no_channel_id_hlo = absl::StrReplaceAll(
+      kModuleStr, {{"{{CHANNEL_ID_1}}", ""}, {"{{CHANNEL_ID_2}}", ""}});
+  std::string no_channel_id_filecheck = absl::StrReplaceAll(
+      kFilecheckStr, {{"{{CHANNEL_ID_1}}", "channel_id=0, "},
+                      {"{{CHANNEL_ID_2}}", "channel_id=0, "}});
+
+  auto check_module = [](const std::string module_str,
+                         std::string filecheck_str) {
+    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                            ParseAndReturnUnverifiedModule((module_str)));
+    CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
+    TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
+    EXPECT_TRUE(changed);
+    TF_ASSERT_OK_AND_ASSIGN(
+        bool filecheck_status,
+        RunFileCheck(/*input=*/module->ToString(
+                         /*options=*/HloPrintOptions{}
+                             .set_print_operand_shape(false)
+                             .set_print_result_shape(false)),
+                     /*pattern=*/filecheck_str));
+    EXPECT_TRUE(filecheck_status);
+  };
+
+  check_module(channel_id_hlo, channel_id_filecheck);
+  check_module(no_channel_id_hlo, no_channel_id_filecheck);
 }
 
 TEST_F(CollectivePermuteDecomposerTest, ForwardPipelineWithMatmul) {
@@ -336,10 +368,10 @@ TEST_F(CollectivePermuteDecomposerTest, ForwardPipelineWithMatmul) {
     weights = f32[2,2] get-tuple-element(inputs), index=2
     data = f32[2,2] get-tuple-element(inputs), index=1
 
-    cp_back = f32[2,2] collective-permute(data), channel_id=1,
+    cp_back = f32[2,2] collective-permute(data), {{CHANNEL_ID_1}}
       source_target_pairs={{3,0}},
       frontend_attributes={_xla_send_recv_validation="{{3,10}}"}
-    cp_forward = f32[2,2] collective-permute(data), channel_id=2,
+    cp_forward = f32[2,2] collective-permute(data), {{CHANNEL_ID_2}}
       source_target_pairs={{0,1},{1,2},{2,3}},
       frontend_attributes={_xla_send_recv_validation="{{0,7},{1,8},{2,9}}"}
 
@@ -367,62 +399,79 @@ TEST_F(CollectivePermuteDecomposerTest, ForwardPipelineWithMatmul) {
     while_result = (u32[], f32[2,2], f32[2,2]) while(input),
         condition=while_cond, body=while_body
     ROOT data_out = f32[2,2] get-tuple-element(while_result), index=1
-  }
-  )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnUnverifiedModule((kModuleStr)));
-  CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
-  EXPECT_TRUE(changed);
-  HloModule* transformed_module = module.get();
-  // Check the annotations and ordering of the decomposed send-recv pairs.
-  // We expect the recv to come before the send in the while body, both for the
-  // forward edge ({0,1},{1,2},{2,3}}) and the backward edge ({3,0}). This is
-  // an XLA invariant that shouldn't be broken (see
-  // https://openxla.org/xla/operation_semantics#send for details of the
-  // semantics).
-  HloComputation* while_body =
-      FindComputation(transformed_module, "while_body");
-  HloInstruction* recv_bwd = hlo_query::FindInstruction(while_body, "recv");
-  EXPECT_EQ(recv_bwd->channel_id().value(), 1);
-  auto recv_bwd_frontend_attributes = recv_bwd->frontend_attributes().map();
-  EXPECT_EQ(recv_bwd_frontend_attributes.size(), 3);
-  EXPECT_EQ(recv_bwd_frontend_attributes.at(kSendRecvValidationAttr),
-            "{{3,10}}");
-  EXPECT_EQ(recv_bwd_frontend_attributes.at(kSendRecvPipelineAttr), "0");
-  EXPECT_EQ(recv_bwd_frontend_attributes.at(kSendRecvSourceTargetPairsAttr),
-            "{{3,0}}");
+  })";
 
-  HloInstruction* send_bwd = hlo_query::FindInstruction(while_body, "send");
-  auto send_bwd_frontend_attributes = send_bwd->frontend_attributes().map();
-  EXPECT_THAT(send_bwd_frontend_attributes.at(kSendRecvSourceTargetPairsAttr),
-              "{{3,0}}");
+  const char* kFilecheckStr = R"(
+  // CHECK-LABEL: %while_body
+  // CHECK-DAG:     %[[p:.+]] = parameter(0)
+  // CHECK-DAG:     %[[iter:.+]] = get-tuple-element(%[[p]]), index=0
+  // CHECK-DAG:     %[[c1:.+]] = constant(1)
+  // CHECK-DAG:     %[[next_iter:.+]] = add(%[[iter]], %[[c1]])
+  // CHECK-DAG:     %[[weights:.+]] = get-tuple-element(%[[p]]), index=2
+  // CHECK-DAG:     %[[partition:.+]] = partition-id()
+  // CHECK-DAG:     %[[c0:.+]] = constant(0)
+  // CHECK-DAG:     %[[compare:.+]] = compare(%[[partition]], %[[c0]]), direction=EQ
+  // CHECK-DAG:     %[[broadcast:.+]] = broadcast(%[[compare]]), dimensions={}
+  // CHECK-DAG:     %[[data:.+]] = get-tuple-element(%[[p]]), index=1
+  // CHECK-DAG:     %[[after_all:.+]] = after-all()
+  // CHECK:         %[[send:.+]] = send(%[[data]], %[[after_all]]), {{CHANNEL_ID_1}}
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{3,0}},_xla_send_recv_validation={{3,10}}}
+  // CHECK:         %[[recv:.+]] = recv(%[[after_all]]), {{CHANNEL_ID_1}}
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{3,0}},_xla_send_recv_validation={{3,10}}}
+  // CHECK-DAG:     %[[recv_done:.+]] = recv-done(%[[recv]]), {{CHANNEL_ID_1}}frontend_attributes={_xla_send_recv_pipeline="0"}, control-predecessors={%[[send]]}
+  // CHECK-DAG:     %[[gte:.+]] = get-tuple-element(%[[recv_done]]), index=0
+  // CHECK-DAG:     %[[after_all1:.+]] = after-all()
+  // CHECK:         %[[send1:.+]] = send(%[[data]], %[[after_all1]]), {{CHANNEL_ID_2}}
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="1",_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_validation={{0,7},{1,8},{2,9}}}
+  // CHECK:         %[[recv1:.+]] = recv(%[[after_all1]]), {{CHANNEL_ID_2}}
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="1",_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_validation={{0,7},{1,8},{2,9}}}
+  // CHECK-DAG:     %[[recv_done1:.+]] = recv-done(%[[recv1]]), {{CHANNEL_ID_2}} frontend_attributes={_xla_send_recv_pipeline="1"}, control-predecessors={%[[send1]]}
+  // CHECK-DAG:     %[[gte1:.+]] = get-tuple-element(%[[recv_done1]]), index=0
+  // CHECK-DAG:     %[[select:.+]] = select(%[[broadcast]], %[[gte]], %[[gte1]])
+  // CHECK-DAG:     %[[matmul:.+]] = dot(%[[weights]], %[[select]]), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  // CHECK-DAG:     ROOT %{{.+}} = tuple(%[[next_iter]], %[[matmul]], %[[weights]])
+  // CHECK-DAG:     %{{.+}} = send-done(%[[send]]), {{CHANNEL_ID_1}} frontend_attributes={_xla_send_recv_pipeline="0"}
+  // CHECK-DAG:     %{{.+}} = send-done(%[[send1]]), {{CHANNEL_ID_2}} frontend_attributes={_xla_send_recv_pipeline="1"}
+  })";
+  std::string channel_id_hlo =
+      absl::StrReplaceAll(kModuleStr, {{"{{CHANNEL_ID_1}}", "channel_id=1, "},
+                                       {"{{CHANNEL_ID_2}}", "channel_id=2, "}});
+  std::string channel_id_filecheck = absl::StrReplaceAll(
+      kFilecheckStr, {{"{{CHANNEL_ID_1}}", "channel_id=1, "},
+                      {"{{CHANNEL_ID_2}}", "channel_id=2, "}});
+  std::string no_channel_id_hlo = absl::StrReplaceAll(
+      kModuleStr, {{"{{CHANNEL_ID_1}}", ""}, {"{{CHANNEL_ID_2}}", ""}});
+  std::string no_channel_id_filecheck = absl::StrReplaceAll(
+      kFilecheckStr, {{"{{CHANNEL_ID_1}}", "channel_id=0, "},
+                      {"{{CHANNEL_ID_2}}", "channel_id=0, "}});
 
-  HloInstruction* recv_fwd = hlo_query::FindInstruction(while_body, "recv.1");
-  EXPECT_EQ(recv_fwd->channel_id().value(), 2);
-  auto recv_fwd_frontend_attributes = recv_fwd->frontend_attributes().map();
-  EXPECT_EQ(recv_fwd_frontend_attributes.size(), 3);
-  EXPECT_EQ(recv_fwd_frontend_attributes.at(kSendRecvPipelineAttr), "1");
-  EXPECT_EQ(recv_fwd_frontend_attributes.at(kSendRecvSourceTargetPairsAttr),
-            "{{0,1},{1,2},{2,3}}");
+  auto check_module = [](std::string module_str, std::string filecheck_str) {
+    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                            ParseAndReturnUnverifiedModule((module_str)));
+    CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
+    TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
+    EXPECT_TRUE(changed);
+    // TODO: b/356201477 - Investigate potential NCCL deadlock in
+    // collective_permute_decomposer because of control_predecessor checks
+    // (recv->send->recv_done)
+    // Check the annotations and ordering of the decomposed send-recv pairs.
+    // We expect the recv to come before the send in the while body, both for
+    // the forward edge ({0,1},{1,2},{2,3}}) and the backward edge ({3,0}). This
+    // is an XLA invariant that shouldn't be broken (see
+    // https://openxla.org/xla/operation_semantics#send for details of the
+    // semantics).
+    TF_ASSERT_OK_AND_ASSIGN(
+        bool filecheck_status,
+        RunFileCheck(/*input=*/module->ToString(
+                         /*options=*/HloPrintOptions{}
+                             .set_print_operand_shape(false)
+                             .set_print_result_shape(false)),
+                     /*pattern=*/filecheck_str));
+    EXPECT_TRUE(filecheck_status);
+  };
 
-  HloInstruction* send_fwd = hlo_query::FindInstruction(while_body, "send.1");
-  auto send_fwd_frontend_attributes = send_fwd->frontend_attributes().map();
-  EXPECT_EQ(send_fwd_frontend_attributes.size(), 3);
-  EXPECT_EQ(send_fwd_frontend_attributes.at(kSendRecvPipelineAttr), "1");
-  EXPECT_EQ(send_fwd_frontend_attributes.at(kSendRecvSourceTargetPairsAttr),
-            "{{0,1},{1,2},{2,3}}");
-
-  EXPECT_NE(while_body, nullptr);
-  HloInstruction* recv_done_fwd =
-      hlo_query::FindInstruction(while_body, "recv-done");
-  HloInstruction* recv_done_bwd =
-      hlo_query::FindInstruction(while_body, "recv-done.1");
-
-  // TODO: b/356201477 - Investigate potential NCCL deadlock in
-  // collective_permute_decomposer
-  EXPECT_EQ(recv_done_fwd->control_predecessors()[0], send_bwd);
-  EXPECT_EQ(recv_done_bwd->control_predecessors()[0], send_fwd);
+  check_module(channel_id_hlo, channel_id_filecheck);
+  check_module(no_channel_id_hlo, no_channel_id_filecheck);
 }
 
 TEST_F(CollectivePermuteDecomposerTest, BackwardPipeline2) {
@@ -440,10 +489,10 @@ TEST_F(CollectivePermuteDecomposerTest, BackwardPipeline2) {
     count = get-tuple-element(param), index=0
     send-data = get-tuple-element(param), index=1
 
-    recv-data.0 = u32[2] collective-permute(send-data), channel_id=1,
+    recv-data.0 = u32[2] collective-permute(send-data), {{CHANNEL_ID_1}}
       source_target_pairs={{1,0},{2,1},{3,2}}
 
-    recv-data.1 = u32[2] collective-permute(send-data), channel_id=2,
+    recv-data.1 = u32[2] collective-permute(send-data), {{CHANNEL_ID_2}}
       source_target_pairs={{0,3}}
 
     replica = u32[] replica-id()
@@ -472,32 +521,103 @@ TEST_F(CollectivePermuteDecomposerTest, BackwardPipeline2) {
     ROOT result = u32[2] get-tuple-element(while_result), index=1
   })";
 
+  const char* kFilecheckStr = R"(
+  // CHECK-LABEL: %body
+  // CHECK-DAG:  %[[p:.+]] = parameter(0)
+  // CHECK-DAG:  %[[iter:.+]] = get-tuple-element(%[[p]]), index=0
+  // CHECK-DAG:  %[[c1:.+]] = constant(1)
+  // CHECK-DAG:  %[[new_count:.+]] = add(%[[iter]], %[[c1]])
+  // CHECK-DAG:  %[[r:.+]] = broadcast(%[[c1]]), dimensions={}
+  // CHECK-DAG:  %[[replica:.+]] = replica-id()
+  // CHECK-DAG:  %[[c0:.+]] = constant(0)
+  // CHECK-DAG:  %[[compare0:.+]] = compare(%[[replica]], %[[c0]]), direction=NE
+  // CHECK-DAG:  %[[compare:.+]] = broadcast(%[[compare0]]), dimensions={}
+  // CHECK-DAG:  %[[send_data:.+]] = get-tuple-element(%[[p]]), index=1
+  // CHECK-DAG:  %[[after_all:.+]] = after-all()
+  // CHECK:      %[[send:.+]] = send(%[[send_data]], %[[after_all]]), {{CHANNEL_ID_1}} 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="1",_xla_send_recv_source_target_pairs={{1,0},{2,1},{3,2}}}
+  // CHECK:      %[[recv:.+]] = recv(%[[after_all]]), {{CHANNEL_ID_1}}
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="1",_xla_send_recv_source_target_pairs={{1,0},{2,1},{3,2}}}
+  // CHECK-DAG:  %[[recv_done:.+]] = recv-done(%[[recv]]), {{CHANNEL_ID_1}} frontend_attributes={_xla_send_recv_pipeline="1"}, control-predecessors={%[[send]]}
+  // CHECK-DAG:  %[[gte:.+]] = get-tuple-element(%[[recv_done]]), index=0
+  // CHECK-DAG:  %[[after_all1:.+]] = after-all()
+  // CHECK:      %[[send1:.+]] = send(%[[send_data]], %[[after_all1]]), {{CHANNEL_ID_2}}
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{0,3}}}
+  // CHECK:      %[[recv1:.+]] = recv(%[[after_all1]]), {{CHANNEL_ID_2}}
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_pipeline="0",_xla_send_recv_source_target_pairs={{0,3}}}
+  // CHECK-DAG:  %[[recv_done_1:.+]] = recv-done(%[[recv1]]), {{CHANNEL_ID_2}} frontend_attributes={_xla_send_recv_pipeline="0"}, control-predecessors={%[[send1]]}
+  // CHECK-DAG:  %[[gte1:.+]] = get-tuple-element(%[[recv_done_1]]), index=0
+  // CHECK-DAG:  %[[recv_data2:.+]] = select(%[[compare]], %[[gte]], %[[gte1]])
+  // CHECK-DAG:  %[[s:.+]] = add(%[[r]], %[[recv_data2]])
+  // CHECK-DAG:  ROOT %{{.+}} = tuple(%[[new_count]], %[[s]])
+  // CHECK-DAG:  %{{.+}} = send-done(%[[send]]), {{CHANNEL_ID_1}} frontend_attributes={_xla_send_recv_pipeline="1"}
+  // CHECK-DAG:  %{{.+}} = send-done(%[[send1]]), {{CHANNEL_ID_2}} frontend_attributes={_xla_send_recv_pipeline="0"}
+  })";
+
+  std::string channel_id_hlo =
+      absl::StrReplaceAll(kModuleStr, {{"{{CHANNEL_ID_1}}", "channel_id=1, "},
+                                       {"{{CHANNEL_ID_2}}", "channel_id=2, "}});
+  std::string channel_id_filecheck = absl::StrReplaceAll(
+      kFilecheckStr, {{"{{CHANNEL_ID_1}}", "channel_id=1, "},
+                      {"{{CHANNEL_ID_2}}", "channel_id=2, "}});
+  std::string no_channel_id_hlo = absl::StrReplaceAll(
+      kModuleStr, {{"{{CHANNEL_ID_1}}", ""}, {"{{CHANNEL_ID_2}}", ""}});
+  std::string no_channel_id_filecheck = absl::StrReplaceAll(
+      kFilecheckStr, {{"{{CHANNEL_ID_1}}", "channel_id=0, "},
+                      {"{{CHANNEL_ID_2}}", "channel_id=0, "}});
+  auto check_module = [](std::string module_str, std::string filecheck_str) {
+    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                            ParseAndReturnUnverifiedModule((module_str)));
+    CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
+    TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
+    EXPECT_TRUE(changed);
+    TF_ASSERT_OK_AND_ASSIGN(
+        bool filecheck_status,
+        RunFileCheck(/*input=*/module->ToString(
+                         /*options=*/HloPrintOptions{}
+                             .set_print_operand_shape(false)
+                             .set_print_result_shape(false)),
+                     /*pattern=*/filecheck_str));
+    EXPECT_TRUE(filecheck_status);
+  };
+
+  check_module(channel_id_hlo, channel_id_filecheck);
+  check_module(no_channel_id_hlo, no_channel_id_filecheck);
+}
+
+TEST_F(CollectivePermuteDecomposerTest, DefaultChannelIdNoCycle) {
+  const char* const kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    p = u32[] replica-id()
+    ROOT cp = u32[] collective-permute(p),
+      source_target_pairs={{0,1}, {1,2}, {2,3}, {3,4}}
+  }
+  )";
+
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnUnverifiedModule((kModuleStr)));
   CollectivePermuteDecomposer decomposer(/*threshold_in_bytes=*/0);
   TF_ASSERT_OK_AND_ASSIGN(bool changed, decomposer.Run(module.get()));
   EXPECT_TRUE(changed);
-  HloInstruction* recv = FindInstruction(module.get(), "recv");
-  EXPECT_EQ(recv->channel_id().value(), 1);
-  EXPECT_THAT(
-      recv->ToString(),
-      HasSubstr("_xla_send_recv_source_target_pairs={{1,0},{2,1},{3,2}}"));
-  EXPECT_THAT(recv->ToString(), HasSubstr("_xla_send_recv_pipeline=\"1\""));
-  HloInstruction* send = FindInstruction(module.get(), "send");
-  EXPECT_THAT(
-      send->ToString(),
-      HasSubstr("_xla_send_recv_source_target_pairs={{1,0},{2,1},{3,2}}"));
-  EXPECT_THAT(send->ToString(), HasSubstr("_xla_send_recv_pipeline=\"1\""));
-
-  HloInstruction* recv1 = FindInstruction(module.get(), "recv.1");
-  EXPECT_EQ(recv1->channel_id().value(), 2);
-  EXPECT_THAT(recv1->ToString(),
-              HasSubstr("_xla_send_recv_source_target_pairs={{0,3}}"));
-  EXPECT_THAT(recv1->ToString(), HasSubstr("_xla_send_recv_pipeline=\"0\""));
-  HloInstruction* send1 = FindInstruction(module.get(), "send.1");
-  EXPECT_THAT(send1->ToString(),
-              HasSubstr("_xla_send_recv_source_target_pairs={{0,3}}"));
-  EXPECT_THAT(send1->ToString(), HasSubstr("_xla_send_recv_pipeline=\"0\""));
+  TF_ASSERT_OK_AND_ASSIGN(bool filecheck_status,
+                          RunFileCheck(/*input=*/module->ToString(
+                                           /*options=*/HloPrintOptions{}
+                                               .set_print_operand_shape(false)
+                                               .set_print_result_shape(false)),
+                                       /*pattern=*/R"(
+  // CHECK: ENTRY %test_computation
+  // CHECK:   %[[REPLICA_ID:.+]] = replica-id()
+  // CHECK:   %[[TOKEN:.+]] = after-all()
+  // CHECK:   %[[SEND:.+]] = send(%[[REPLICA_ID]], %[[TOKEN]]), channel_id=0, 
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3},{3,4}}}
+  // CHECK:   %[[SEND_DONE:.+]] = send-done(%[[SEND]]), channel_id=0
+  // CHECK:   %[[RECV:.+]] = recv(%[[TOKEN]]), channel_id=0,
+  // CHECK-SAME{LITERAL}: frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3},{3,4}}}
+  // CHECK:   %[[RECV_DONE:.+]] = recv-done(%[[RECV]]), channel_id=0, control-predecessors={%[[SEND]]}
+  // CHECK:   ROOT {{.+}} = get-tuple-element(%[[RECV_DONE]]), index=0
+  )"));
+  EXPECT_TRUE(filecheck_status);
 }
 
 }  // namespace


### PR DESCRIPTION
When no channel ids are present, this patch creates sends and recvs with channel id 0.