### PR TITLE
[XLA:CPU] Modify matmul test cases with constant weights

### DIFF
--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -999,9 +999,9 @@ TEST_F(MatmulTest, TestF32ConstantWeights) {
   HloModule matmul.test.f32
 
   ENTRY matmul.test.f32 {
-    arg.0 = f32[64,256,16] parameter(0), parameter_replication={false}
-    constant = f32[] constant(1)
-    arg.1 = f32[16,32] broadcast(constant), dimensions={}
+    arg.0 = f32[64,256,16] parameter(0)
+    constant = f32[32] constant({...})
+    arg.1 = f32[16,32] broadcast(constant), dimensions={1}
     ROOT onednn.matmul.0 = f32[64,256,32] dot(arg.0, arg.1), lhs_contracting_dims={2}, rhs_contracting_dims={0}
   })";
 


### PR DESCRIPTION
On certain platforms, oneDNN may avoid blocking constant weights for performance reasons. Consequently, these weights remain as tensors of constant values that after further simplification, might get reduced to broadcasted scalar values, messing up the intended `MatchOptimizedHlo` pattern in tests. This PR updates the constant weights in the test file to ensure that even if oneDNN does not block the weights, subsequent simplification passes will not alter them.