### PR TITLE
[NVIDIA] Add fixes for supporting determinism expander for high-dimensional scatter operation and a flag to disable it

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -293,6 +293,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_enable_fast_math(false);
   opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
   opts.set_xla_pjrt_allow_auto_layout_in_hlo(false);
+  opts.set_xla_gpu_enable_scatter_determinism_expander(true);
   return opts;
 }
 
@@ -2064,6 +2065,16 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "Experimental: Make unset entry computation layout mean auto layout "
       "instead of default layout in HLO when run through PjRT. In other cases "
       "(StableHLO or non-PjRT) the auto layout is already used."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_scatter_determinism_expander",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_enable_scatter_determinism_expander),
+      debug_options->xla_gpu_enable_scatter_determinism_expander(),
+      "Enable the scatter determinism expander, an optimized pass that "
+      "rewrites scatter operations to ensure deterministic behavior with high "
+      "performance."
+      "Note that even when this flag is disabled, scatter operations may still "
+      "be deterministic, although with additional overhead."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -2121,6 +2121,7 @@ cc_library(
         "//xla/hlo/transforms:op_expander_pass",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:statusor",
     ],

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -711,7 +711,9 @@ absl::Status RunOptimizationPasses(
   if (RequireDeterminism(hlo_module->config())) {
     // Scatter can be indeterministic if indices are not unique or a non
     // associative combiner function is used. Eliminate these Scatter ops.
-    pipeline.AddPass<ScatterDeterminismExpander>();
+    if (debug_options.xla_gpu_enable_scatter_determinism_expander()) {
+      pipeline.AddPass<ScatterDeterminismExpander>();
+    }
     pipeline.AddPass<ScatterExpander>(
         ScatterExpander::kEliminateIndeterministicScatters);
   }

--- a/xla/service/scatter_determinism_expander.cc
+++ b/xla/service/scatter_determinism_expander.cc
@@ -15,11 +15,14 @@ limitations under the License.
 
 #include "xla/service/scatter_determinism_expander.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_format.h"
+#include "absl/types/span.h"
 #include "xla/array.h"
 #include "xla/array2d.h"
 #include "xla/comparison_util.h"
@@ -62,47 +65,134 @@ static absl::StatusOr<std::vector<HloInstruction*>> CanonicalizeScatterUpdates(
   return adjusted_updates;
 }
 
-// Create the out-of-bound tensor for the scatter operation.
-HloInstruction* CreateOutOfBoundTensor(HloComputation* parent,
-                                       HloInstruction* scatter_indices,
-                                       const Shape& scatter_shape) {
+template <typename T>
+HloInstruction* CreateBoundTensorGeneric(
+    HloComputation* parent, HloInstruction* scatter_indices,
+    absl::Span<const int64_t> operand_dims, bool is_out_of_bound = true,
+    std::optional<absl::Span<const int64_t>> window_sizes = std::nullopt) {
   if (scatter_indices->shape().rank() == 1) {
-    CHECK_EQ(scatter_shape.dimensions_size(), 1);
-    Array<int32_t> out_of_bound_array({scatter_indices->shape().dimensions(0)},
-                                      scatter_shape.dimensions(0));
+    CHECK_EQ(operand_dims.size(), 1);
+    int64_t value = is_out_of_bound ? operand_dims[0]
+                                    : operand_dims[0] - (*window_sizes)[0];
+    // When T is int32_t, value here is implicitly casted to int32_t as we are
+    // dealing with int32_t indices.
+    Array<T> out_of_bound_array({scatter_indices->shape().dimensions(0)},
+                                value);
     return parent->AddInstruction(HloInstruction::CreateConstant(
         LiteralUtil::CreateFromArray(out_of_bound_array)));
   }
   // More than one dimension in scatter_indices
-  Array2D<int32_t> out_of_bound_array(scatter_indices->shape().dimensions(0),
-                                      scatter_indices->shape().dimensions(1));
+  Array2D<T> out_of_bound_array(scatter_indices->shape().dimensions(0),
+                                scatter_indices->shape().dimensions(1));
   for (int i = 0; i < scatter_indices->shape().dimensions(0); ++i) {
     for (int j = 0; j < scatter_indices->shape().dimensions(1); ++j) {
-      out_of_bound_array(i, j) = scatter_shape.dimensions(j);
+      out_of_bound_array(i, j) = is_out_of_bound
+                                     ? operand_dims[j]
+                                     : operand_dims[j] - (*window_sizes)[j];
     }
   }
   return parent->AddInstruction(HloInstruction::CreateConstant(
-      LiteralUtil::CreateR2FromArray2D<int>(out_of_bound_array)));
+      LiteralUtil::CreateR2FromArray2D<T>(out_of_bound_array)));
+}
+
+// Creates a tensor for the scatter operation based on the value of
+// is_out_of_bound.
+//
+// When is_out_of_bound is true, the tensor is filled with values representing
+// the maximum bounds of the scatter shape (out-of-bound values). This is used
+// to simulate out-of-bound conditions in the scatter operation.
+//
+// When is_out_of_bound is false, the tensor is filled with the maximum valid
+// indices (calculated as operand_dimensions - window_dimensions). This is used
+// to check whether indices are within valid bounds for non-scalar updates.
+//
+// This function is reusable for both out-of-bound tensor generation and valid
+// index checks in scatter operations with non-scalar updates.
+absl::StatusOr<HloInstruction*> CreateBoundTensor(
+    HloComputation* parent, HloInstruction* scatter_indices,
+    absl::Span<const int64_t> operand_dims, bool is_out_of_bound = true,
+    std::optional<absl::Span<const int64_t>> window_sizes = std::nullopt) {
+  if (!is_out_of_bound && !window_sizes.has_value()) {
+    return FailedPrecondition(
+        "window_sizes must be provided when is_out_of_bound is false.");
+  }
+
+  PrimitiveType type = scatter_indices->shape().element_type();
+  if (type == S32) {
+    return CreateBoundTensorGeneric<int32_t>(
+        parent, scatter_indices, operand_dims, is_out_of_bound, window_sizes);
+  } else if (type == S64) {
+    return CreateBoundTensorGeneric<int64_t>(
+        parent, scatter_indices, operand_dims, is_out_of_bound, window_sizes);
+  }
+  return FailedPrecondition("Unexpected type for bound tensor: %s",
+                            PrimitiveType_Name(type));
+}
+
+// indices shape: (num_indices, num_dims)
+// updates shape: (num_indices,)
+HloInstruction* FlattenIndices(HloComputation* parent, HloInstruction* indices,
+                               absl::Span<const int64_t> operand_dims) {
+  if (indices->shape().rank() == 1) {
+    return indices;
+  }
+  if (operand_dims.size() == 1) {
+    return parent->AddInstruction(HloInstruction::CreateReshape(
+        ShapeUtil::MakeShape(indices->shape().element_type(),
+                             {indices->shape().dimensions(0)}),
+        indices));
+  }
+  // Step 1: based on the operand_dims, calculate the strides
+  Array2D<int64_t> strides(operand_dims.size(), 1);
+  int64_t stride = 1;
+  for (int i = operand_dims.size() - 1; i >= 0; --i) {
+    strides(i, 0) = stride;
+    stride *= operand_dims[i];
+  }
+  auto strides_tensor = parent->AddInstruction(HloInstruction::CreateConstant(
+      LiteralUtil::CreateR2FromArray2D<int64_t>(strides)));
+
+  // Step 2: calculate the flattened indices
+  auto dot_shape = ShapeUtil::MakeShape(indices->shape().element_type(),
+                                        {indices->shape().dimensions(0), 1});
+  DotDimensionNumbers dim_numbers;
+  dim_numbers.add_lhs_contracting_dimensions(1);
+  dim_numbers.add_rhs_contracting_dimensions(0);
+  PrecisionConfig precision_config;
+  auto flattened_indices = parent->AddInstruction(HloInstruction::CreateDot(
+      dot_shape, indices, strides_tensor, dim_numbers, precision_config));
+  return parent->AddInstruction(HloInstruction::CreateReshape(
+      ShapeUtil::MakeShape(indices->shape().element_type(),
+                           {indices->shape().dimensions(0)}),
+      flattened_indices));
 }
 
 // Computation for sorting the scalar scatter indices and updates together
-HloComputation* ScalarSortingComparison(HloModule* module,
-                                        const Shape key_shape,
-                                        const Shape update_shape,
-                                        int64_t num_updates) {
+static HloComputation* SortingComparison(HloModule* module,
+                                         const PrimitiveType indices_type,
+                                         const PrimitiveType updates_type,
+                                         int64_t num_updates,
+                                         bool has_scalar_indices) {
+  Shape key_shape = ShapeUtil::MakeShape(indices_type, {});
+  Shape update_shape = ShapeUtil::MakeShape(updates_type, {});
   HloComputation::Builder builder("sorting_computation");
   auto param0 = builder.AddInstruction(
       HloInstruction::CreateParameter(0, key_shape, "lhs_key"));
   auto param1 = builder.AddInstruction(
       HloInstruction::CreateParameter(1, key_shape, "rhs_key"));
-  const int kExistingParams = 2;
+  int param_count = 2;
   for (int i = 0; i < num_updates; ++i) {
-    builder.AddInstruction(
-        HloInstruction::CreateParameter(kExistingParams + i, update_shape,
-                                        absl::StrFormat("lhs_update_%d", i)));
-    builder.AddInstruction(
-        HloInstruction::CreateParameter(kExistingParams + 1 + i, update_shape,
-                                        absl::StrFormat("rhs_update_%d", i)));
+    builder.AddInstruction(HloInstruction::CreateParameter(
+        param_count, update_shape, absl::StrFormat("lhs_update_%d", i)));
+    builder.AddInstruction(HloInstruction::CreateParameter(
+        param_count + 1, update_shape, absl::StrFormat("rhs_update_%d", i)));
+    param_count += 2;
+  }
+  if (!has_scalar_indices) {
+    builder.AddInstruction(HloInstruction::CreateParameter(
+        param_count, key_shape, "lhs_permutation"));
+    builder.AddInstruction(HloInstruction::CreateParameter(
+        param_count + 1, key_shape, "rhs_permutation"));
   }
   builder.AddInstruction(
       HloInstruction::CreateCompare(ShapeUtil::MakeShape(PRED, {}), param0,
@@ -113,14 +203,20 @@ HloComputation* ScalarSortingComparison(HloModule* module,
 static std::vector<HloInstruction*> SortIndicesAndUpdates(
     HloInstruction* scatter_indices,
     const std::vector<HloInstruction*>& scatter_updates, int64_t num_indices,
-    HloScatterInstruction* scatter, HloComputation* parent) {
+    HloScatterInstruction* scatter, HloComputation* parent,
+    absl::Span<const int64_t> operand_dims, bool has_scalar_indices) {
   const Shape& indices_shape = scatter_indices->shape();
   const Shape& updates_shape = scatter_updates[0]->shape();
   auto updates_dims = updates_shape.dimensions();
   // Since we canonicalized the scatter updates, the first dim will always be
   // the number of updates and the rest will be the shape of each update
+  HloInstruction* scalar_indices =
+      FlattenIndices(scatter->parent(), scatter_indices, operand_dims);
 
-  HloInstruction* scalar_indices = scatter_indices;
+  // Create the shape for a single index tuple
+  // Create [0...num_indices] tensor for permutation in sorting
+  auto indices_permutation = parent->AddInstruction(HloInstruction::CreateIota(
+      ShapeUtil::MakeShape(indices_shape.element_type(), {num_indices}), 0));
 
   std::vector<int64_t> single_update_dimensions(updates_dims.begin() + 1,
                                                 updates_dims.end());
@@ -130,18 +226,22 @@ static std::vector<HloInstruction*> SortIndicesAndUpdates(
 
   const Shape& scalar_index_shape =
       ShapeUtil::MakeShape(indices_shape.element_type(), {num_indices});
+  auto* comparison = SortingComparison(
+      scatter->GetModule(), indices_shape.element_type(),
+      updates_shape.element_type(), scatter_updates.size(), has_scalar_indices);
 
-  auto* comparison = ScalarSortingComparison(
-      scatter->GetModule(),
-      ShapeUtil::MakeShape(indices_shape.element_type(), {}),
-      ShapeUtil::MakeShape(updates_shape.element_type(), {}),
-      scatter_updates.size());
-
+  // The sorting operation contains the scalar indices and the updates, and if
+  // the scatter indices were not scalar, the sorting operation will also
+  // contain the indices permutation
   std::vector<HloInstruction*> sort_operands = {scalar_indices};
   std::vector<Shape> sort_shapes = {scalar_index_shape};
   for (auto update : scatter_updates) {
     sort_operands.push_back(update);
     sort_shapes.push_back(update->shape());
+  }
+  if (!has_scalar_indices) {
+    sort_operands.push_back(indices_permutation);
+    sort_shapes.push_back(indices_permutation->shape());
   }
 
   auto* sorting = parent->AddInstruction(HloInstruction::CreateSort(
@@ -160,6 +260,34 @@ static std::vector<HloInstruction*> SortIndicesAndUpdates(
   std::vector<HloInstruction*> sorted_tensors = {sorted_scalar_indices};
   sorted_tensors.insert(sorted_tensors.end(), sorted_updates.begin(),
                         sorted_updates.end());
+  if (has_scalar_indices) {
+    return sorted_tensors;
+  }
+  // When the scatter indices were not scalar, need to return the sorted scatter
+  // indices
+  auto* sorted_indices_arg =
+      parent->AddInstruction(HloInstruction::CreateGetTupleElement(
+          indices_permutation->shape(), sorting, sorted_tensors.size()));
+  sorted_indices_arg = parent->AddInstruction(HloInstruction::CreateReshape(
+      ShapeUtil::MakeShape(sorted_indices_arg->shape().element_type(),
+                           {num_indices, 1}),
+      sorted_indices_arg));
+  // Use gather of sorted_indices_arg to get the sorted original indices
+  GatherDimensionNumbers gather_dim_numbers;
+  gather_dim_numbers.add_offset_dims(
+      1);  // Preserving the inner dimension (columns)
+  gather_dim_numbers.add_start_index_map(
+      0);  // Mapping start_indices to the first dimension of the operand
+  gather_dim_numbers.add_collapsed_slice_dims(0);
+  gather_dim_numbers.set_index_vector_dim(1);
+  std::vector<int64_t> slice_sizes = {1,
+                                      scatter_indices->shape().dimensions(1)};
+  auto* sorted_expanded_indices =
+      parent->AddInstruction(HloInstruction::CreateGather(
+          scatter_indices->shape(), scatter_indices, sorted_indices_arg,
+          gather_dim_numbers, slice_sizes,
+          /*indices_are_sorted=*/true));
+  sorted_tensors.push_back(sorted_expanded_indices);
   return sorted_tensors;
 }
 
@@ -273,19 +401,18 @@ absl::StatusOr<std::vector<HloInstruction*>> ComputePrefixScan(
 }
 
 static HloInstruction* FindLastOccurrenceIndices(
-    HloInstruction* scatter_indices, HloInstruction* sorted_scalar_indices,
-    HloInstruction* scatter, HloComputation* parent, int64_t num_indices) {
-  int64_t indices_len = sorted_scalar_indices->shape().dimensions(0);
-  HloInstruction* sorted_indices = sorted_scalar_indices;
+    HloInstruction* sorted_indices, HloInstruction* sorted_scalar_indices,
+    HloInstruction* scatter, HloComputation* parent, int64_t num_indices,
+    HloInstruction* out_of_bound_tensor) {
+  int64_t indices_len = sorted_indices->shape().dimensions(0);
+  const PrimitiveType& indices_type = sorted_indices->shape().element_type();
   auto* sorted_indices_preceding_part =
       parent->AddInstruction(HloInstruction::CreateSlice(
-          ShapeUtil::MakeShape(scatter_indices->shape().element_type(),
-                               {indices_len - 1}),
+          ShapeUtil::MakeShape(indices_type, {indices_len - 1}),
           sorted_scalar_indices, {0}, {indices_len - 1}, {1}));
   auto* sorted_indices_following_part =
       parent->AddInstruction(HloInstruction::CreateSlice(
-          ShapeUtil::MakeShape(scatter_indices->shape().element_type(),
-                               {indices_len - 1}),
+          ShapeUtil::MakeShape(indices_type, {indices_len - 1}),
           sorted_scalar_indices, {1}, {indices_len}, {1}));
   auto* indices_mask_without_padding =
       parent->AddInstruction(HloInstruction::CreateCompare(
@@ -304,16 +431,184 @@ static HloInstruction* FindLastOccurrenceIndices(
 
   // Mask the indices
   indices_mask = parent->AddInstruction(HloInstruction::CreateBroadcast(
-      ShapeUtil::MakeShape(PRED, scatter_indices->shape().dimensions()),
+      ShapeUtil::MakeShape(PRED, sorted_indices->shape().dimensions()),
       indices_mask, {0}));
-
-  auto* out_of_bound_tensor =
-      CreateOutOfBoundTensor(parent, scatter_indices, scatter->shape());
 
   auto* masked_indices = parent->AddInstruction(HloInstruction::CreateTernary(
       sorted_indices->shape(), HloOpcode::kSelect, indices_mask, sorted_indices,
       out_of_bound_tensor));
   return masked_indices;
+}
+
+template <typename T>
+HloInstruction* ExpandIndexOffsetsFromUpdateShape(
+    HloComputation* parent, const Shape& update_shape,
+    const ScatterDimensionNumbers& dim_num, const Shape& operand_shape) {
+  // Calculate the offset tensor for each element of the update tensor.
+  // The offset tensor is represented in (num_elements_in_update, index_dim).
+
+  int64_t num_elements = ShapeUtil::ElementsIn(update_shape);
+  int64_t operand_rank = operand_shape.dimensions_size();
+  Array2D<T> offset_tensor(num_elements, operand_rank);
+
+  std::vector<bool> is_inserted_window_dims(operand_rank, false);
+  for (int64_t dim : dim_num.inserted_window_dims()) {
+    is_inserted_window_dims[dim] = true;
+  }
+
+  for (int64_t linear_index = 0; linear_index < num_elements; ++linear_index) {
+    // Calculate the multi-dimensional index from the linear index
+    int64_t current_index = linear_index;
+    int inserted_window_dim_size = 0;
+    // Handle 0th to (operand_rank-2)th dimensions
+    for (int i = 0; i < operand_rank - 1; ++i) {
+      if (is_inserted_window_dims[i]) {
+        inserted_window_dim_size++;
+        offset_tensor(linear_index, i) = 0;
+      } else {
+        // When computing the multi-dimensional index, we want to divide by the
+        // next dimension size, so we need to add 1. We also want to skip the
+        // inserted window dims.
+        int64_t dim_size =
+            update_shape.dimensions(i + 1 - inserted_window_dim_size);
+        offset_tensor(linear_index, i) = current_index / dim_size;
+        current_index %= dim_size;
+      }
+    }
+    // Handle (operand_rank-1)th dimension
+    if (is_inserted_window_dims[operand_rank - 1]) {
+      offset_tensor(linear_index, operand_rank - 1) = 0;
+    } else {
+      offset_tensor(linear_index, operand_rank - 1) = current_index;
+    }
+  }
+
+  // Return the offset tensor as an HloInstruction
+  return parent->AddInstruction(HloInstruction::CreateConstant(
+      LiteralUtil::CreateR2FromArray2D<T>(offset_tensor)));
+}
+
+// Expand the indices based on index_offset
+HloInstruction* ExpandIndices(HloComputation* parent, HloInstruction* indices,
+                              HloInstruction* index_offsets) {
+  // For each index we need to add the index_offset to the base index
+  // To do that, we first broadcast the indices and index_offsets to the same
+  // shape, then add the index_offset to the base index and flatten the
+  // result Broadcast to be (num_indices, length_of_index_offsets,
+  // length_of_indices).
+  bool is_one_dimensional = indices->shape().dimensions_size() == 1;
+
+  int64_t num_indices = indices->shape().dimensions(0);
+  int64_t num_offsets = index_offsets->shape().dimensions(0);
+  int64_t index_length =
+      is_one_dimensional ? 1 : indices->shape().dimensions(1);
+
+  Shape final_shape =
+      ShapeUtil::MakeShape(indices->shape().element_type(),
+                           {num_indices, num_offsets, index_length});
+  auto broadcasted_indices =
+      parent->AddInstruction(HloInstruction::CreateBroadcast(
+          final_shape, indices,
+          is_one_dimensional ? std::vector<int64_t>{0}
+                             : std::vector<int64_t>{0, 2}));
+  auto broadcasted_offsets = parent->AddInstruction(
+      HloInstruction::CreateBroadcast(final_shape, index_offsets, {1, 2}));
+  auto expanded_indices = parent->AddInstruction(HloInstruction::CreateBinary(
+      final_shape, HloOpcode::kAdd, broadcasted_indices, broadcasted_offsets));
+  // Flatten the result to be (num_indices * num_offsets, index_length)
+  if (is_one_dimensional) {
+    return parent->AddInstruction(HloInstruction::CreateReshape(
+        ShapeUtil::MakeShape(indices->shape().element_type(),
+                             {num_indices * num_offsets}),
+        expanded_indices));
+  }
+  return parent->AddInstruction(HloInstruction::CreateReshape(
+      ShapeUtil::MakeShape(indices->shape().element_type(),
+                           {num_indices * num_offsets, index_length}),
+      expanded_indices));
+}
+
+// Function to create a reduction computation for logical AND
+HloComputation* ReduceAndComputation(HloModule* module) {
+  // Create a computation builder
+  HloComputation::Builder builder("reduce_logical_and");
+
+  // Define the scalar shape for boolean operations
+  const Shape bool_shape = ShapeUtil::MakeShape(PRED, {});
+
+  // Add parameters for the reduction computation.
+  // These represent the elements to be combined (lhs and rhs).
+  HloInstruction* lhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, bool_shape, "lhs"));
+  HloInstruction* rhs = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, bool_shape, "rhs"));
+
+  // Create the logical AND operation between the two parameters
+  builder.AddInstruction(
+      HloInstruction::CreateBinary(bool_shape, HloOpcode::kAnd, lhs, rhs));
+
+  // Build and return the computation object
+  return module->AddEmbeddedComputation(builder.Build());
+}
+
+absl::StatusOr<HloInstruction*> CheckValidIndices(
+    HloComputation* parent, HloInstruction* indices,
+    absl::Span<const int64_t> operand_dims,
+    absl::Span<const int64_t> window_sizes) {
+  // check if indices and indices with the largest offsets are out of bound
+  // Essentially we need to do the following:
+  // 1. Check base indices >= [0, 0, 0, ...]
+  // 2. Check last indices <= [bounds...]
+  // 3. For each check, generate a same size tensor, and then do a reduce across
+  // rows to get a mask of size (n, 1)
+  auto init_reduce_value = parent->AddInstruction(
+      HloInstruction::CreateConstant(LiteralUtil::CreateR0<bool>(true)));
+  auto reduce_computation = ReduceAndComputation(parent->parent());
+
+  // 1. Check base indices >= [0, 0, 0, ...]
+  // first generate a zero tensor of the same size as the indices
+  auto* zero_constant = parent->AddInstruction(
+      HloInstruction::CreateConstant(indices->shape().element_type() == S64
+                                         ? LiteralUtil::CreateR0<int64_t>(0)
+                                         : LiteralUtil::CreateR0<int32_t>(0)));
+  auto* zero_broadcasted = parent->AddInstruction(
+      HloInstruction::CreateBroadcast(indices->shape(), zero_constant, {}));
+  auto* zero_check = parent->AddInstruction(HloInstruction::CreateCompare(
+      ShapeUtil::MakeShape(PRED, indices->shape().dimensions()), indices,
+      zero_broadcasted, ComparisonDirection::kGe));
+  HloInstruction* zero_check_mask;
+  if (indices->shape().rank() == 1) {
+    zero_check_mask = zero_check;
+  } else {
+    // Reduce across rows to get a mask (for multi-dimensional indices).
+    zero_check_mask = parent->AddInstruction(HloInstruction::CreateReduce(
+        ShapeUtil::MakeShape(PRED, {indices->shape().dimensions(0)}),
+        zero_check, init_reduce_value, {1}, reduce_computation));
+  }
+  // 2. Check last indices <= [bounds...]
+  // Check if the index is OOB w.r.t. the operand dimensions and window sizes.
+  TF_ASSIGN_OR_RETURN(
+      HloInstruction * max_valid_index_constant,
+      CreateBoundTensor(parent, indices, operand_dims, false, window_sizes));
+  auto oob_check = parent->AddInstruction(HloInstruction::CreateCompare(
+      ShapeUtil::MakeShape(PRED, indices->shape().dimensions()),
+      max_valid_index_constant, indices, ComparisonDirection::kGe));
+  HloInstruction* oob_check_mask;
+  if (indices->shape().rank() == 1) {
+    oob_check_mask = oob_check;
+  } else {
+    // Reduce across rows to get a mask (for multi-dimensional indices).
+    oob_check_mask = parent->AddInstruction(HloInstruction::CreateReduce(
+        ShapeUtil::MakeShape(PRED, {indices->shape().dimensions(0)}), oob_check,
+        init_reduce_value, {1}, reduce_computation));
+  }
+  // Combine the results of the two checks above.
+  auto* valid_index_mask = parent->AddInstruction(HloInstruction::CreateBinary(
+      ShapeUtil::MakeShape(PRED, {indices->shape().dimensions(0)}),
+      HloOpcode::kAnd, zero_check_mask, oob_check_mask));
+  return parent->AddInstruction(HloInstruction::CreateBroadcast(
+      ShapeUtil::MakeShape(PRED, indices->shape().dimensions()),
+      valid_index_mask, {0}));
 }
 
 absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
@@ -352,7 +647,10 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
   TF_ASSIGN_OR_RETURN(scatter_indices,
                       CanonicalizeScatterIndices(
                           scatter_indices, dim_numbers.index_vector_dim()));
+  CHECK_GE(scatter_indices->shape().dimensions_size(), 1);
   CHECK_EQ(scatter_indices_count, scatter_indices->shape().dimensions(0));
+  bool has_scalar_indices = scatter_indices->shape().dimensions_size() == 1 ||
+                            scatter_indices->shape().dimensions(1) == 1;
 
   // Canonicalize the updates, after which the size of their most-major
   // dimensions must be same as the while loop trip count.
@@ -361,21 +659,124 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
                                            dim_numbers, scatter_indices_count));
 
   HloComputation* parent = scatter->parent();
+  auto updates_shape = scatter_updates[0]->shape();
+  auto updates_dims = scatter_updates[0]->shape().dimensions();
+  // Since we canonicalized the scatter updates, the first dim will always be
+  // the number of updates and the rest will be the shape of each update
+  std::vector<int64_t> one_update_dimensions(updates_dims.begin() + 1,
+                                             updates_dims.end());
+  const Shape& update_shape =
+      ShapeUtil::MakeShape(updates_shape.element_type(), one_update_dimensions);
+
+  ScatterDimensionNumbers new_dim_numbers;
+  // Check if each update is a scalar based on update shape
+  bool non_scalar_update = scatter_updates[0]->shape().dimensions_size() > 1;
+
+  TF_ASSIGN_OR_RETURN(HloInstruction * out_of_bound_tensor,
+                      CreateBoundTensor(parent, scatter_indices,
+                                        scatter->shape().dimensions()));
+
+  if (non_scalar_update) {
+    // Extract operand dimensions
+    const Shape& operand_shape = scatter_operands[0]->shape();
+
+    HloInstruction* index_offsets =
+        scatter_indices->shape().element_type() == S32
+            ? ExpandIndexOffsetsFromUpdateShape<int32_t>(
+                  scatter->parent(), update_shape, dim_numbers, operand_shape)
+            : ExpandIndexOffsetsFromUpdateShape<int64_t>(
+                  scatter->parent(), update_shape, dim_numbers, operand_shape);
+
+    int num_operand_dims = operand_shape.dimensions_size();
+    std::vector<int64_t> actual_update_window_dims(num_operand_dims);
+    int update_dim_index = 0;
+    for (int i = 0; i < num_operand_dims; ++i) {
+      if (std::find(dim_numbers.inserted_window_dims().begin(),
+                    dim_numbers.inserted_window_dims().end(),
+                    i) != dim_numbers.inserted_window_dims().end()) {
+        actual_update_window_dims[i] = 1;
+      } else {
+        actual_update_window_dims[i] =
+            update_shape.dimensions(update_dim_index);
+        update_dim_index++;
+      }
+    }
+
+    // If any updates are out of bound, we change the corresponding indices to
+    // be oob_tensor values
+    TF_ASSIGN_OR_RETURN(
+        HloInstruction * oob_check_mask,
+        CheckValidIndices(scatter->parent(), scatter_indices,
+                          scatter_operands[0]->shape().dimensions(),
+                          actual_update_window_dims));
+
+    scatter_indices = parent->AddInstruction(HloInstruction::CreateTernary(
+        scatter_indices->shape(), HloOpcode::kSelect, oob_check_mask,
+        scatter_indices, out_of_bound_tensor));
+    scatter_indices =
+        ExpandIndices(scatter->parent(), scatter_indices, index_offsets);
+
+    // Check if the number of indices is the same as
+    // (num of indices before expanding * num of offsets)
+    CHECK_EQ(scatter_indices->shape().dimensions(0),
+             scatter_indices_count * ShapeUtil::ElementsIn(update_shape));
+
+    // Expand the updates
+    const int64_t num_elements =
+        ShapeUtil::ElementsIn(scatter_updates[0]->shape());
+    for (int i = 0; i < scatter_updates.size(); i++) {
+      scatter_updates[i] = parent->AddInstruction(HloInstruction::CreateReshape(
+          ShapeUtil::MakeShape(scatter_updates[i]->shape().element_type(),
+                               {num_elements}),
+          scatter_updates[i]));
+    }
+
+    // Create a new dimension numbers for the new scatter operation
+    new_dim_numbers.clear_update_window_dims();
+    new_dim_numbers.set_index_vector_dim(1);
+    // Mitigate the missed dimensions
+    for (int i = 0; i < operand_shape.dimensions_size() -
+                            dim_numbers.input_batching_dims_size();
+         i++) {
+      new_dim_numbers.add_inserted_window_dims(i);
+    }
+    // Set the scatter_dims_to_operand_dims
+    // copy from the original scatter_dims_to_operand_dims
+    for (int i = 0; i < dim_numbers.scatter_dims_to_operand_dims_size(); i++) {
+      new_dim_numbers.add_scatter_dims_to_operand_dims(
+          dim_numbers.scatter_dims_to_operand_dims(i));
+    }
+  } else {
+    new_dim_numbers = dim_numbers;
+  }
 
   // Sort the scatter indices and updates together based on the scatter indices.
   int64_t num_indices = ShapeUtil::ElementsIn(scatter_updates[0]->shape());
   std::vector<HloInstruction*> sorted_tensors = SortIndicesAndUpdates(
-      scatter_indices, scatter_updates, num_indices, scatter, parent);
+      scatter_indices, scatter_updates, num_indices, scatter, parent,
+      scatter_operands[0]->shape().dimensions(), has_scalar_indices);
   HloInstruction* sorted_scalar_indices = sorted_tensors[0];
-  std::vector<HloInstruction*> sorted_updates(sorted_tensors.begin() + 1,
-                                              sorted_tensors.end());
+  std::vector<HloInstruction*> sorted_updates(
+      sorted_tensors.begin() + 1,
+      sorted_tensors.begin() + 1 + scatter_updates.size());
+  HloInstruction* sorted_indices = sorted_scalar_indices;
+  if (!has_scalar_indices) {
+    sorted_indices = sorted_tensors[sorted_tensors.size() - 1];
+  }
 
   TF_ASSIGN_OR_RETURN(std::vector<HloInstruction*> prefix_scan_updates,
                       ComputePrefixScan(sorted_updates, sorted_scalar_indices,
                                         scatter, parent));
-
-  HloInstruction* last_occurrence_indices = FindLastOccurrenceIndices(
-      scatter_indices, sorted_scalar_indices, scatter, parent, num_indices);
+  if (non_scalar_update) {
+    // Need to create another out_of_bound_tensor for expanded indices
+    TF_ASSIGN_OR_RETURN(
+        out_of_bound_tensor,
+        CreateBoundTensor(parent, sorted_indices,
+                          scatter_operands[0]->shape().dimensions()));
+  }
+  HloInstruction* last_occurrence_indices =
+      FindLastOccurrenceIndices(sorted_indices, sorted_scalar_indices, scatter,
+                                parent, num_indices, out_of_bound_tensor);
 
   CHECK(last_occurrence_indices != nullptr)
       << "Last occurrence indices should not be nullptr";
@@ -383,7 +784,7 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
   // Finally, recreate the scatter instruction with unique indices
   return parent->AddInstruction(HloInstruction::CreateScatter(
       scatter->shape(), scatter_operands, last_occurrence_indices,
-      prefix_scan_updates, scatter->to_apply(), dim_numbers,
+      prefix_scan_updates, scatter->to_apply(), new_dim_numbers,
       /*indices_are_sorted=*/true, /*unique_indices=*/true));
 }
 
@@ -437,25 +838,7 @@ bool CheckOutputDependency(HloComputation* to_apply, int operand_size) {
 bool ScatterDeterminismExpander::InstructionMatchesPattern(
     HloInstruction* inst) {
   auto* scatter = DynCast<HloScatterInstruction>(inst);
-  // Need to check if updates and indices are scalar, as the current pass does
-  // not expand scatter with multi-dimensional updates or indices. This is
-  // temporary and will be removed in a future PR soon.
-  if (scatter == nullptr) {
-    return false;
-  }
-
-  const Shape& indices_shape = scatter->scatter_indices()->shape();
-  const Shape& updates_shape = scatter->scatter_updates()[0]->shape();
-
-  // Check if indices and updates are effectively 1D.
-  bool indices_are_1d =
-      (indices_shape.rank() == 1 ||
-       (indices_shape.rank() == 2 && indices_shape.dimensions(1) == 1));
-  bool updates_are_1d =
-      (updates_shape.rank() == 1 ||
-       (updates_shape.rank() == 2 && updates_shape.dimensions(1) == 1));
-
-  return indices_are_1d && updates_are_1d && !IsScatterDeterministic(scatter) &&
+  return (scatter != nullptr) && !IsScatterDeterministic(scatter) &&
          CheckOutputDependency(scatter->to_apply(),
                                scatter->scatter_operands().size());
 }

--- a/xla/service/scatter_determinism_expander.cc
+++ b/xla/service/scatter_determinism_expander.cc
@@ -69,27 +69,20 @@ static absl::StatusOr<std::vector<HloInstruction*>> CanonicalizeScatterUpdates(
 template <typename T>
 HloInstruction* CreateBoundTensorGeneric(
     HloComputation* parent, HloInstruction* scatter_indices,
-    absl::Span<const int64_t> operand_dims, bool is_out_of_bound = true,
+    absl::Span<const int64_t> operand_dims,
+    absl::Span<const int64_t> index_to_operand_map, bool is_out_of_bound = true,
     std::optional<absl::Span<const int64_t>> window_sizes = std::nullopt) {
-  if (scatter_indices->shape().rank() == 1) {
-    CHECK_EQ(operand_dims.size(), 1);
-    int64_t value = is_out_of_bound ? operand_dims[0]
-                                    : operand_dims[0] - (*window_sizes)[0];
-    // When T is int32_t, value here is implicitly casted to int32_t as we are
-    // dealing with int32_t indices.
-    Array<T> out_of_bound_array({scatter_indices->shape().dimensions(0)},
-                                value);
-    return parent->AddInstruction(HloInstruction::CreateConstant(
-        LiteralUtil::CreateFromArray(out_of_bound_array)));
-  }
-  // More than one dimension in scatter_indices
+  CHECK_GT(scatter_indices->shape().dimensions_size(), 1);
   Array2D<T> out_of_bound_array(scatter_indices->shape().dimensions(0),
-                                scatter_indices->shape().dimensions(1));
+                                operand_dims.size());
   for (int i = 0; i < scatter_indices->shape().dimensions(0); ++i) {
-    for (int j = 0; j < scatter_indices->shape().dimensions(1); ++j) {
-      out_of_bound_array(i, j) = is_out_of_bound
-                                     ? operand_dims[j]
-                                     : operand_dims[j] - (*window_sizes)[j];
+    for (int j = 0; j < operand_dims.size(); ++j) {
+      int mapped_index = index_to_operand_map[j];
+      out_of_bound_array(i, j) =
+          is_out_of_bound
+              ? operand_dims[mapped_index]
+              : operand_dims[mapped_index] - (*window_sizes)[mapped_index];
+      // : operand_dims[j] - (*window_sizes)[j] ;
     }
   }
   return parent->AddInstruction(HloInstruction::CreateConstant(
@@ -111,7 +104,8 @@ HloInstruction* CreateBoundTensorGeneric(
 // index checks in scatter operations with non-scalar updates.
 absl::StatusOr<HloInstruction*> CreateBoundTensor(
     HloComputation* parent, HloInstruction* scatter_indices,
-    absl::Span<const int64_t> operand_dims, bool is_out_of_bound = true,
+    absl::Span<const int64_t> operand_dims,
+    absl::Span<const int64_t> index_to_operand_map, bool is_out_of_bound = true,
     std::optional<absl::Span<const int64_t>> window_sizes = std::nullopt) {
   if (!is_out_of_bound && !window_sizes.has_value()) {
     return FailedPrecondition(
@@ -120,11 +114,13 @@ absl::StatusOr<HloInstruction*> CreateBoundTensor(
 
   PrimitiveType type = scatter_indices->shape().element_type();
   if (type == S32) {
-    return CreateBoundTensorGeneric<int32_t>(
-        parent, scatter_indices, operand_dims, is_out_of_bound, window_sizes);
+    return CreateBoundTensorGeneric<int32_t>(parent, scatter_indices,
+                                             operand_dims, index_to_operand_map,
+                                             is_out_of_bound, window_sizes);
   } else if (type == S64) {
-    return CreateBoundTensorGeneric<int64_t>(
-        parent, scatter_indices, operand_dims, is_out_of_bound, window_sizes);
+    return CreateBoundTensorGeneric<int64_t>(parent, scatter_indices,
+                                             operand_dims, index_to_operand_map,
+                                             is_out_of_bound, window_sizes);
   }
   return FailedPrecondition("Unexpected type for bound tensor: %s",
                             PrimitiveType_Name(type));
@@ -134,10 +130,8 @@ absl::StatusOr<HloInstruction*> CreateBoundTensor(
 // updates shape: (num_indices,)
 HloInstruction* FlattenIndices(HloComputation* parent, HloInstruction* indices,
                                absl::Span<const int64_t> operand_dims) {
-  if (indices->shape().rank() == 1) {
-    return indices;
-  }
-  if (operand_dims.size() == 1) {
+  if (indices->shape().dimensions(1) == 1) {
+    // Originally scalar indices
     return parent->AddInstruction(HloInstruction::CreateReshape(
         ShapeUtil::MakeShape(indices->shape().element_type(),
                              {indices->shape().dimensions(0)}),
@@ -388,7 +382,6 @@ absl::StatusOr<std::vector<HloInstruction*>> ComputePrefixScan(
   std::vector<HloInstruction*> prefix_scans(sorted_updates.size());
   HloInstruction* prefix_scan_update = nullptr;
   for (int i = 0; i < sorted_updates.size(); i++) {
-    // TODO(chenhao) change to use the extracted computation
     TF_ASSIGN_OR_RETURN(
         HloComputation * to_apply,
         CallComputationAndGetIthOutputWithBinaryParams(scatter->to_apply(), i));
@@ -445,7 +438,8 @@ template <typename T>
 HloInstruction* ExpandIndexOffsetsFromUpdateShape(
     HloComputation* parent, const Shape& update_shape,
     const ScatterDimensionNumbers& dim_num, const Shape& operand_shape,
-    absl::Span<const int64_t> index_to_operand_map) {
+    absl::Span<const int64_t> index_to_operand_map,
+    absl::Span<const int64_t> actual_update_window_dims) {
   // Calculate the offset tensor for each element of the update tensor.
   // The offset tensor is represented in (num_elements_in_update, index_dim).
 
@@ -455,32 +449,31 @@ HloInstruction* ExpandIndexOffsetsFromUpdateShape(
   Array2D<T> offset_tensor(num_elements, operand_rank);
 
   std::vector<bool> is_inserted_window_dims(operand_rank, false);
+  for (int i = 0; i < dim_num.inserted_window_dims_size(); ++i) {
+    is_inserted_window_dims[dim_num.inserted_window_dims(i)] = true;
+  }
+
+  // Compute the inverse of the index_to_operand_map
+  std::vector<int> operand_to_index_map(operand_rank, -1);
+  for (int i = 0; i < operand_rank; ++i) {
+    operand_to_index_map[index_to_operand_map[i]] = i;
+  }
 
   for (int64_t linear_index = 0; linear_index < num_elements; ++linear_index) {
     // Calculate the multi-dimensional index from the linear index
     int64_t current_index = linear_index;
     int inserted_window_dim_size = 0;
     // Handle 0th to (operand_rank-2)th dimensions
-    for (int i = 0; i < operand_rank - 1; ++i) {
+    for (int i = operand_rank - 1; i >= 0; --i) {
       if (is_inserted_window_dims[i]) {
         inserted_window_dim_size++;
-        offset_tensor(linear_index, i) = 0;
+        offset_tensor(linear_index, operand_to_index_map[i]) = 0;
       } else {
-        // When computing the multi-dimensional index, we want to divide by the
-        // next dimension size, so we need to add 1. We also want to skip the
-        // inserted window dims.
-        int64_t dim_size =
-            update_shape.dimensions(i + 1 - inserted_window_dim_size);
-        offset_tensor(linear_index, index_to_operand_map[i]) =
-            current_index / dim_size;
-        current_index %= dim_size;
+        int64_t dim_size = actual_update_window_dims[i];
+        offset_tensor(linear_index, operand_to_index_map[i]) =
+            current_index % dim_size;
+        current_index /= dim_size;
       }
-    }
-    // Handle (operand_rank-1)th dimension
-    if (is_inserted_window_dims[operand_rank - 1]) {
-      offset_tensor(linear_index, operand_rank - 1) = 0;
-    } else {
-      offset_tensor(linear_index, operand_rank - 1) = current_index;
     }
   }
 
@@ -555,7 +548,8 @@ HloComputation* ReduceAndComputation(HloModule* module) {
 absl::StatusOr<HloInstruction*> CheckValidIndices(
     HloComputation* parent, HloInstruction* indices,
     absl::Span<const int64_t> operand_dims,
-    absl::Span<const int64_t> window_sizes) {
+    absl::Span<const int64_t> window_sizes,
+    absl::Span<const int64_t> full_index_to_operand_dims) {
   // check if indices and indices with the largest offsets are out of bound
   // Essentially we need to do the following:
   // 1. Check base indices >= [0, 0, 0, ...]
@@ -578,19 +572,16 @@ absl::StatusOr<HloInstruction*> CheckValidIndices(
       ShapeUtil::MakeShape(PRED, indices->shape().dimensions()), indices,
       zero_broadcasted, ComparisonDirection::kGe));
   HloInstruction* zero_check_mask;
-  if (indices->shape().rank() == 1) {
-    zero_check_mask = zero_check;
-  } else {
-    // Reduce across rows to get a mask (for multi-dimensional indices).
-    zero_check_mask = parent->AddInstruction(HloInstruction::CreateReduce(
-        ShapeUtil::MakeShape(PRED, {indices->shape().dimensions(0)}),
-        zero_check, init_reduce_value, {1}, reduce_computation));
-  }
+  // Reduce across rows to get a mask (for multi-dimensional indices).
+  zero_check_mask = parent->AddInstruction(HloInstruction::CreateReduce(
+      ShapeUtil::MakeShape(PRED, {indices->shape().dimensions(0)}), zero_check,
+      init_reduce_value, {1}, reduce_computation));
   // 2. Check last indices <= [bounds...]
   // Check if the index is OOB w.r.t. the operand dimensions and window sizes.
   TF_ASSIGN_OR_RETURN(
       HloInstruction * max_valid_index_constant,
-      CreateBoundTensor(parent, indices, operand_dims, false, window_sizes));
+      CreateBoundTensor(parent, indices, operand_dims,
+                        full_index_to_operand_dims, false, window_sizes));
   auto oob_check = parent->AddInstruction(HloInstruction::CreateCompare(
       ShapeUtil::MakeShape(PRED, indices->shape().dimensions()),
       max_valid_index_constant, indices, ComparisonDirection::kGe));
@@ -618,7 +609,6 @@ absl::StatusOr<HloInstruction*> AddImplicitDimensionsToIndices(
     int64_t operand_rank, absl::Span<const int64_t> indices_to_operand_map,
     HloInstruction* indices) {
   const Shape& indices_shape = indices->shape();
-
   HloComputation* computation = indices->parent();
 
   // Get the batch size (N) and S (number of dimensions in index_vector)
@@ -637,6 +627,23 @@ absl::StatusOr<HloInstruction*> AddImplicitDimensionsToIndices(
       computation->AddInstruction(HloInstruction::CreateConcatenate(
           expanded_shape, {indices, zero_filled_tensor}, 1));
   return expanded_indices;
+}
+
+std::vector<int64_t> ComputeFullIndexToOperandDims(
+    const Shape& operand_shape, ScatterDimensionNumbers& dim_numbers) {
+  std::vector<int64_t> full_index_to_operand_dims(
+      dim_numbers.mutable_scatter_dims_to_operand_dims()->begin(),
+      dim_numbers.mutable_scatter_dims_to_operand_dims()->end());
+  // Add the implicit dimensions to the index_to_operand_map
+  absl::flat_hash_set<int64_t> existing_dims(
+      dim_numbers.scatter_dims_to_operand_dims().begin(),
+      dim_numbers.scatter_dims_to_operand_dims().end());
+
+  for (int i = 0; i < operand_shape.dimensions_size(); i++) {
+    if (existing_dims.find(i) == existing_dims.end())
+      full_index_to_operand_dims.push_back(i);
+  }
+  return full_index_to_operand_dims;
 }
 
 absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
@@ -675,12 +682,19 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
   TF_ASSIGN_OR_RETURN(scatter_indices,
                       CanonicalizeScatterIndices(
                           scatter_indices, dim_numbers.index_vector_dim()));
-  // TODO(Chenhao) for the maintainability, we should simplify the code so that
-  // all scatter_indices are always more than 1 D
-  CHECK_GE(scatter_indices->shape().dimensions_size(), 1);
   CHECK_EQ(scatter_indices_count, scatter_indices->shape().dimensions(0));
-  bool has_scalar_indices = scatter_indices->shape().dimensions_size() == 1 ||
-                            scatter_indices->shape().dimensions(1) == 1;
+  // We compromise for maintainability and make the scatter_indices always 2D,
+  // so that the implementation could be easier, as we do not need to maintain
+  // two sets of code for 1D and 2D scatter_indices.
+  if (scatter_indices->shape().dimensions_size() == 1) {
+    scatter_indices =
+        scatter->parent()->AddInstruction(HloInstruction::CreateReshape(
+            ShapeUtil::MakeShape(scatter_indices->shape().element_type(),
+                                 {scatter_indices->shape().dimensions(0), 1}),
+            scatter_indices));
+  }
+  CHECK_GT(scatter_indices->shape().dimensions_size(), 1);
+  bool has_scalar_indices = scatter_indices->shape().dimensions(1) == 1;
 
   // Canonicalize the updates, after which the size of their most-major
   // dimensions must be same as the while loop trip count.
@@ -703,34 +717,17 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
   // Check if each update is a scalar based on update shape
   bool non_scalar_update = scatter_updates[0]->shape().dimensions_size() > 1;
 
-  TF_ASSIGN_OR_RETURN(HloInstruction * out_of_bound_tensor,
-                      CreateBoundTensor(parent, scatter_indices,
-                                        scatter->shape().dimensions()));
+  std::vector<int64_t> full_index_to_operand_dims =
+      ComputeFullIndexToOperandDims(scatter_operands[0]->shape(), dim_numbers);
+
+  TF_ASSIGN_OR_RETURN(
+      HloInstruction * out_of_bound_tensor,
+      CreateBoundTensor(parent, scatter_indices, scatter->shape().dimensions(),
+                        full_index_to_operand_dims));
 
   if (non_scalar_update) {
     // Extract operand dimensions
     const Shape& operand_shape = scatter_operands[0]->shape();
-
-    // Add the implicit dimensions to the index_to_operand_map
-    absl::flat_hash_set<int64_t> existing_dims(
-        dim_numbers.scatter_dims_to_operand_dims().begin(),
-        dim_numbers.scatter_dims_to_operand_dims().end());
-    std::vector<int64_t> full_index_to_operand_dims(
-        dim_numbers.mutable_scatter_dims_to_operand_dims()->begin(),
-        dim_numbers.mutable_scatter_dims_to_operand_dims()->end());
-    for (int i = 0; i < operand_shape.dimensions_size(); i++) {
-      if (existing_dims.find(i) == existing_dims.end())
-        full_index_to_operand_dims.push_back(i);
-    }
-
-    HloInstruction* index_offsets =
-        scatter_indices->shape().element_type() == S32
-            ? ExpandIndexOffsetsFromUpdateShape<int32_t>(
-                  scatter->parent(), update_shape, dim_numbers, operand_shape,
-                  full_index_to_operand_dims)
-            : ExpandIndexOffsetsFromUpdateShape<int64_t>(
-                  scatter->parent(), update_shape, dim_numbers, operand_shape,
-                  full_index_to_operand_dims);
 
     int num_operand_dims = operand_shape.dimensions_size();
     std::vector<int64_t> actual_update_window_dims(num_operand_dims);
@@ -747,21 +744,30 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
       }
     }
 
-    // map scatter_indices into operand space
+    HloInstruction* index_offsets =
+        scatter_indices->shape().element_type() == S32
+            ? ExpandIndexOffsetsFromUpdateShape<int32_t>(
+                  scatter->parent(), update_shape, dim_numbers, operand_shape,
+                  full_index_to_operand_dims, actual_update_window_dims)
+            : ExpandIndexOffsetsFromUpdateShape<int64_t>(
+                  scatter->parent(), update_shape, dim_numbers, operand_shape,
+                  full_index_to_operand_dims, actual_update_window_dims);
+
+    // Map scatter_indices into operand space
     TF_ASSIGN_OR_RETURN(
         scatter_indices,
         AddImplicitDimensionsToIndices(
             scatter_operands[0]->shape().dimensions_size(),
             dim_numbers.scatter_dims_to_operand_dims(), scatter_indices));
     CHECK(scatter_indices->shape().dimensions(0) == scatter_indices_count);
-    // TODO(chenhao) check valid indices with the map!
     // If any updates are out of bound, we change the corresponding indices to
     // be oob_tensor values
     TF_ASSIGN_OR_RETURN(
         HloInstruction * oob_check_mask,
         CheckValidIndices(scatter->parent(), scatter_indices,
                           scatter_operands[0]->shape().dimensions(),
-                          actual_update_window_dims));
+                          actual_update_window_dims,
+                          full_index_to_operand_dims));
 
     scatter_indices = parent->AddInstruction(HloInstruction::CreateTernary(
         scatter_indices->shape(), HloOpcode::kSelect, oob_check_mask,
@@ -785,6 +791,7 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
     }
 
     // Create a new dimension numbers for the new scatter operation
+    // As we have scalar updates, there is no update_window_dims
     new_dim_numbers.clear_update_window_dims();
     new_dim_numbers.set_index_vector_dim(1);
     // Mitigate the missed dimensions
@@ -793,16 +800,9 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
          i++) {
       new_dim_numbers.add_inserted_window_dims(i);
     }
-    // // Set the scatter_dims_to_operand_dims
-    // // copy from the original scatter_dims_to_operand_dims
-    // for (int i = 0; i < dim_numbers.scatter_dims_to_operand_dims_size(); i++)
-    // {
-    //   new_dim_numbers.add_scatter_dims_to_operand_dims(
-    //       dim_numbers.scatter_dims_to_operand_dims(i));
-    // }
-    // Set the scatter_dims_to_operand_dims to be ordered from 0 to operand_rank
     for (int i = 0; i < operand_shape.dimensions_size(); i++) {
-      new_dim_numbers.add_scatter_dims_to_operand_dims(i);
+      new_dim_numbers.add_scatter_dims_to_operand_dims(
+          full_index_to_operand_dims[i]);
     }
   } else {
     new_dim_numbers = dim_numbers;
@@ -817,8 +817,13 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
   std::vector<HloInstruction*> sorted_updates(
       sorted_tensors.begin() + 1,
       sorted_tensors.begin() + 1 + scatter_updates.size());
-  HloInstruction* sorted_indices = sorted_scalar_indices;
-  if (!has_scalar_indices) {
+  HloInstruction* sorted_indices;
+  if (has_scalar_indices) {
+    sorted_indices = parent->AddInstruction(HloInstruction::CreateReshape(
+        ShapeUtil::MakeShape(sorted_scalar_indices->shape().element_type(),
+                             {num_indices, 1}),
+        sorted_scalar_indices));
+  } else {
     sorted_indices = sorted_tensors[sorted_tensors.size() - 1];
   }
 
@@ -826,11 +831,13 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
                       ComputePrefixScan(sorted_updates, sorted_scalar_indices,
                                         scatter, parent));
   if (non_scalar_update) {
-    // Need to create another out_of_bound_tensor for expanded indices
+    // As the indices are expanded, we need to recompute out-of-bound tensor
+    // with the same shape
     TF_ASSIGN_OR_RETURN(
         out_of_bound_tensor,
         CreateBoundTensor(parent, sorted_indices,
-                          scatter_operands[0]->shape().dimensions()));
+                          scatter_operands[0]->shape().dimensions(),
+                          full_index_to_operand_dims));
   }
   HloInstruction* last_occurrence_indices =
       FindLastOccurrenceIndices(sorted_indices, sorted_scalar_indices, scatter,
@@ -897,10 +904,6 @@ bool ScatterDeterminismExpander::InstructionMatchesPattern(
     HloInstruction* inst) {
   auto* scatter = DynCast<HloScatterInstruction>(inst);
 
-  // TODO(chenhao) there are some tricky cases that we need to avoid
-  // 1. some weird batch dims
-  // 2. if the operand rank is not the same as indices rank + inserted window
-  // dimensions
   return (scatter != nullptr) && !IsScatterDeterministic(scatter) &&
          CheckOutputDependency(scatter->to_apply(),
                                scatter->scatter_operands().size());

--- a/xla/service/scatter_determinism_expander_test.cc
+++ b/xla/service/scatter_determinism_expander_test.cc
@@ -90,6 +90,36 @@ TEST_F(ScatterDeterminismExpanderTest,
 }
 
 TEST_F(ScatterDeterminismExpanderTest,
+       EliminateNonScalarScatterWithNonAssociativeCombiner) {
+  const char* const kModuleStr = R"(
+    HloModule scatter_expander
+
+    scatter_computation {
+      arg1.173 = f32[] parameter(1)
+      arg0.172 = f32[] parameter(0)
+      ROOT add.48 = f32[] add(arg0.172, arg1.173)
+    }
+
+    ENTRY fused_computation {
+      bitcast.2335 = f32[1,4096] parameter(0)
+      pad.96 = s32[4096,2] parameter(1)
+     bitcast.2748 = f32[4096,1,1] parameter(2)
+      ROOT scatter.48 = f32[1,4096] scatter(bitcast.2335, pad.96, bitcast.2748),
+        update_window_dims={1,2}, inserted_window_dims={},
+        scatter_dims_to_operand_dims={0,1}, index_vector_dim=1,
+        to_apply=scatter_computation
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+
+  ScatterDeterminismExpander scatter_expander;
+  TF_ASSERT_OK_AND_ASSIGN(bool result,
+                          RunHloPass(&scatter_expander, module.get()));
+  EXPECT_TRUE(result);
+}
+
+TEST_F(ScatterDeterminismExpanderTest,
        DoNotEliminateScatterWithAssociativeFp32Combiner) {
   const char* const kModuleStr = R"(
     HloModule scatter_determinism_expander
@@ -148,7 +178,7 @@ TEST_F(ScatterDeterminismExpanderTest, DoNotEliminateScatterWithOneUpdate) {
   EXPECT_FALSE(result);
 }
 
-TEST_F(ScatterDeterminismExpanderTest, ScatterAddCorrectnessTest) {
+TEST_F(ScatterDeterminismExpanderTest, ScalarScatterAddCorrectnessTest) {
   const char* const kModuleStr = R"(
     HloModule scatter_determinism_expander
 
@@ -178,6 +208,165 @@ TEST_F(ScatterDeterminismExpanderTest, ScatterAddCorrectnessTest) {
   EXPECT_TRUE(result);
 
   std::vector<float> expected_result = {2.0, 16.0, 14.0, 3.0};
+
+  Literal result_literal = ExecuteAndTransfer(std::move(module), {});
+
+  auto result_data = result_literal.data<float>();
+  std::vector<float> actual_result(result_data.begin(), result_data.end());
+
+  EXPECT_EQ(actual_result, expected_result);
+}
+
+TEST_F(ScatterDeterminismExpanderTest,
+       ScalarScatterAddOutOfBoundCorrectnessTest) {
+  const char* const kModuleStr = R"(
+    HloModule scatter_determinism_expander
+
+    scatter_computation {
+      arg1.173 = f32[] parameter(1)
+      arg0.172 = f32[] parameter(0)
+      ROOT add.48 = f32[] add(arg0.172, arg1.173)
+    }
+
+    ENTRY scatter_add_computation {
+      operand = f32[4] constant({0, 0, 0, 0})
+      indices = s32[7,1] constant({{0}, {1}, {5}, {4}, {1}, {1}, {2}})
+      updates = f32[7] constant({2, 1, 5, 3, 8, 7, 9})
+      ROOT scatter.48 = f32[4] scatter(operand, indices, updates),
+        update_window_dims={}, inserted_window_dims={0},
+        scatter_dims_to_operand_dims={0}, index_vector_dim=1,
+        to_apply=scatter_computation
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+
+  ScatterDeterminismExpander scatter_determinism_expander;
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool result, RunHloPass(&scatter_determinism_expander, module.get()));
+
+  EXPECT_TRUE(result);
+
+  std::vector<float> expected_result = {2.0, 16.0, 9.0, 0.0};
+
+  Literal result_literal = ExecuteAndTransfer(std::move(module), {});
+
+  auto result_data = result_literal.data<float>();
+  std::vector<float> actual_result(result_data.begin(), result_data.end());
+
+  EXPECT_EQ(actual_result, expected_result);
+}
+
+TEST_F(ScatterDeterminismExpanderTest,
+       ScatterAddWithNonScalarIndexCorrectnessTest) {
+  const char* const kModuleStr = R"(
+    HloModule scatter_determinism_expander
+
+    scatter_computation {
+      arg1.173 = f32[] parameter(1)
+      arg0.172 = f32[] parameter(0)
+      ROOT add.48 = f32[] add(arg0.172, arg1.173)
+    }
+
+    ENTRY scatter_add_computation {
+      operand = f32[3, 3] constant({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}})
+      indices = s32[3, 2] constant({{0, 0}, {1, 1}, {2,2}})
+      updates = f32[3] constant({2, 1, 3})
+      ROOT scatter.48 = f32[3,3] scatter(operand, indices, updates),
+        update_window_dims={}, inserted_window_dims={0, 1},
+        scatter_dims_to_operand_dims={0, 1}, index_vector_dim=1,
+        to_apply=scatter_computation
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+
+  ScatterDeterminismExpander scatter_determinism_expander;
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool result, RunHloPass(&scatter_determinism_expander, module.get()));
+
+  EXPECT_TRUE(result);
+
+  std::vector<float> expected_result = {2, 0, 0, 0, 1, 0, 0, 0, 3};
+
+  Literal result_literal = ExecuteAndTransfer(std::move(module), {});
+
+  auto result_data = result_literal.data<float>();
+  std::vector<float> actual_result(result_data.begin(), result_data.end());
+
+  EXPECT_EQ(actual_result, expected_result);
+}
+
+TEST_F(ScatterDeterminismExpanderTest, NonScalarScatterAddCorrectnessTest) {
+  const char* const kModuleStr = R"(
+    HloModule scatter_determinism_expander
+
+    scatter_computation {
+      arg1.173 = f32[] parameter(1)
+      arg0.172 = f32[] parameter(0)
+      ROOT add.48 = f32[] add(arg0.172, arg1.173)
+    }
+
+    ENTRY scatter_add_computation {
+      operand = f32[4] constant({0, 0, 0, 0})
+      indices = s32[3, 1] constant({{1}, {2}, {3}})
+      updates = f32[3, 2] constant({{1, 2}, {4, 7}, {10, 13}})
+      ROOT scatter.48 = f32[4] scatter(operand, indices, updates),
+        update_window_dims={1}, inserted_window_dims={},
+        scatter_dims_to_operand_dims={0}, index_vector_dim=1,
+        to_apply=scatter_computation
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+
+  ScatterDeterminismExpander scatter_determinism_expander;
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool result, RunHloPass(&scatter_determinism_expander, module.get()));
+
+  EXPECT_TRUE(result);
+
+  std::vector<float> expected_result = {0, 1, 6, 7};
+
+  Literal result_literal = ExecuteAndTransfer(std::move(module), {});
+
+  auto result_data = result_literal.data<float>();
+  std::vector<float> actual_result(result_data.begin(), result_data.end());
+
+  EXPECT_EQ(actual_result, expected_result);
+}
+
+TEST_F(ScatterDeterminismExpanderTest,
+       ScatterAddWithNonScalarIndexAndUpdateCorrectnessTest) {
+  const char* const kModuleStr = R"(
+    HloModule scatter_determinism_expander
+
+    scatter_computation {
+      arg1.173 = f32[] parameter(1)
+      arg0.172 = f32[] parameter(0)
+      ROOT add.48 = f32[] add(arg0.172, arg1.173)
+    }
+
+    ENTRY scatter_add_computation {
+      operand = f32[3, 3] constant({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}})
+      indices = s32[4, 2] constant({{0, 0}, {0, 1}, {1, 1}, {1, 2}})
+      updates = f32[4, 2] constant({{1, 2}, {4, 7}, {10, 13}, {21, 27}})
+      ROOT scatter.48 = f32[3, 3] scatter(operand, indices, updates),
+        update_window_dims={1}, inserted_window_dims={0},
+        scatter_dims_to_operand_dims={0, 1}, index_vector_dim=1,
+        to_apply=scatter_computation
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+
+  ScatterDeterminismExpander scatter_determinism_expander;
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool result, RunHloPass(&scatter_determinism_expander, module.get()));
+
+  EXPECT_TRUE(result);
+
+  std::vector<float> expected_result = {1, 6, 7, 0, 10, 13, 0, 0, 0};
 
   Literal result_literal = ExecuteAndTransfer(std::move(module), {});
 
@@ -264,7 +453,7 @@ TEST_F(ScatterDeterminismExpanderTest, ScatterAddHloVerificationTest) {
                             kExpectedPattern);
 }
 
-TEST_F(ScatterDeterminismExpanderTest, ScatterAddOutOfBoundCorrectnessTest) {
+TEST_F(ScatterDeterminismExpanderTest, ScalarScatterAddReproducibilityTest) {
   const char* const kModuleStr = R"(
     HloModule scatter_determinism_expander
 
@@ -275,10 +464,30 @@ TEST_F(ScatterDeterminismExpanderTest, ScatterAddOutOfBoundCorrectnessTest) {
     }
 
     ENTRY scatter_add_computation {
-      operand = f32[4] constant({0, 0, 0, 0})
-      indices = s32[7,1] constant({{0}, {1}, {5}, {4}, {1}, {1}, {2}})
-      updates = f32[7] constant({2, 1, 5, 3, 8, 7, 9})
-      ROOT scatter.48 = f32[4] scatter(operand, indices, updates),
+      operand = f32[3] constant({0, 0, 0})
+      indices = s32[100,1] constant({{0}, {3}, {0}, {1}, {0}, {3}, {1}, {2}, {1}, {2}, {2}, {2}, {0}, {2}, {1}, 
+                                    {0}, {1}, {1}, {2}, {0}, {2}, {1}, {2}, {1}, {2}, {2}, {3}, {2}, {2}, {0},
+                                    {3}, {0}, {3}, {2}, {0}, {3}, {3}, {3}, {3}, {3}, {2}, {3}, {3}, {0}, {0},
+                                    {3}, {3}, {3}, {2}, {3}, {2}, {3}, {0}, {0}, {2}, {0}, {1}, {3}, {1}, {3},
+                                    {2}, {2}, {2}, {1}, {0}, {3}, {1}, {1}, {1}, {1}, {1}, {2}, {2}, {3}, {0},
+                                    {2}, {2}, {0}, {2}, {1}, {0}, {2}, {2}, {2}, {0}, {2}, {0}, {1}, {3}, {0},
+                                    {2}, {3}, {3}, {2}, {0}, {3}, {3}, {2}, {3}, {2}})
+      updates = f32[100] constant({0.02379167, 0.8527204, 0.8132185, 0.5140263, 0.17172801, 0.8026866, 0.5124631, 
+                                  0.34838438, 0.50526905, 0.3370521, 0.10868239, 0.10520637, 0.83827364, 0.78986526, 
+                                  0.34059846, 0.8349273, 0.24575627, 0.21387374, 0.02423227, 0.5617423, 0.28066766, 
+                                  0.94366455, 0.61214995, 0.7383388, 0.52419806, 0.65466726, 0.41012764, 0.24028647, 
+                                  0.74443066, 0.03544927, 0.851014, 0.02434528, 0.47239733, 0.72706807, 0.35055435, 
+                                  0.6274171, 0.61077535, 0.06525731, 0.8091929, 0.21307838, 0.6465323, 0.3245015, 
+                                  0.5538883, 0.8849807, 0.9591211, 0.83856845, 0.48919427, 0.11810577, 0.16933143, 
+                                  0.83657074, 0.587505, 0.6867087, 0.95522237, 0.5797727, 0.28024232, 0.34749162, 
+                                  0.5199702, 0.9811766, 0.5645981, 0.2446456, 0.68722725, 0.9616587, 0.480047, 
+                                  0.88953114, 0.7083205, 0.948612, 0.67764974, 0.44131804, 0.36789334, 0.95148766, 
+                                  0.30909216, 0.70908046, 0.8749926, 0.60973287, 0.60751855, 0.22647333, 0.5363518, 
+                                  0.96195626, 0.08158326, 0.5266887, 0.85922587, 0.648262, 0.4657668, 0.31623375, 
+                                  0.43507564, 0.48351157, 0.41285944, 0.73501325, 0.15267539, 0.67055714, 0.08459568, 
+                                  0.04527426, 0.21078384, 0.4654404, 0.7363906, 0.23245859, 0.22119188, 0.99092937, 
+                                  0.878675, 0.4102913})
+      ROOT scatter.48 = f32[3] scatter(operand, indices, updates),
         update_window_dims={}, inserted_window_dims={0},
         scatter_dims_to_operand_dims={0}, index_vector_dim=1,
         to_apply=scatter_computation
@@ -293,17 +502,30 @@ TEST_F(ScatterDeterminismExpanderTest, ScatterAddOutOfBoundCorrectnessTest) {
 
   EXPECT_TRUE(result);
 
-  std::vector<float> expected_result = {2.0, 16.0, 9.0, 0.0};
+  auto cloned_module = module->Clone();
+  Literal first_result_literal =
+      ExecuteAndTransfer(std::move(cloned_module), {});
+  auto first_result_span = first_result_literal.data<float>();
+  std::vector<float> first_result(first_result_span.begin(),
+                                  first_result_span.end());
 
-  Literal result_literal = ExecuteAndTransfer(std::move(module), {});
+  const int num_trials = 20;
+  std::vector<std::vector<float>> results;
 
-  auto result_data = result_literal.data<float>();
-  std::vector<float> actual_result(result_data.begin(), result_data.end());
+  for (int i = 0; i < num_trials; ++i) {
+    auto cloned_module = module->Clone();
 
-  EXPECT_EQ(actual_result, expected_result);
+    Literal result_literal = ExecuteAndTransfer(std::move(cloned_module), {});
+
+    auto result_data = result_literal.data<float>();
+    std::vector<float> actual_result(result_data.begin(), result_data.end());
+
+    EXPECT_EQ(actual_result, first_result)
+        << "Results are not reproducible across trials!";
+  }
 }
 
-TEST_F(ScatterDeterminismExpanderTest, ScatterAddReproducibilityTest) {
+TEST_F(ScatterDeterminismExpanderTest, NonScalarScatterAddReproducibilityTest) {
   const char* const kModuleStr = R"(
     HloModule scatter_determinism_expander
 
@@ -314,12 +536,32 @@ TEST_F(ScatterDeterminismExpanderTest, ScatterAddReproducibilityTest) {
     }
 
     ENTRY scatter_add_computation {
-      operand = f32[3] constant({0, 0, 0})
-      indices = s32[100,1] constant({{0}, {3}, {0}, {1}, {0}, {3}, {1}, {2}, {1}, {2}, {2}, {2}, {0}, {2}, {1}, {0}, {1}, {1}, {2}, {0}, {2}, {1}, {2}, {1}, {2}, {2}, {3}, {2}, {2}, {0}, {3}, {0}, {3}, {2}, {0}, {3}, {3}, {3}, {3}, {3}, {2}, {3}, {3}, {0}, {0}, {3}, {3}, {3}, {2}, {3}, {2}, {3}, {0}, {0}, {2}, {0}, {1}, {3}, {1}, {3}, {2}, {2}, {2}, {1}, {0}, {3}, {1}, {1}, {1}, {1}, {1}, {2}, {2}, {3}, {0}, {2}, {2}, {0}, {2}, {1}, {0}, {2}, {2}, {2}, {0}, {2}, {0}, {1}, {3}, {0}, {2}, {3}, {3}, {2}, {0}, {3}, {3}, {2}, {3}, {2}})
-      updates = f32[100] constant({0.02379167, 0.8527204, 0.8132185, 0.5140263, 0.17172801, 0.8026866, 0.5124631, 0.34838438, 0.50526905, 0.3370521, 0.10868239, 0.10520637, 0.83827364, 0.78986526, 0.34059846, 0.8349273, 0.24575627, 0.21387374, 0.02423227, 0.5617423, 0.28066766, 0.94366455, 0.61214995, 0.7383388, 0.52419806, 0.65466726, 0.41012764, 0.24028647, 0.74443066, 0.03544927, 0.851014, 0.02434528, 0.47239733, 0.72706807, 0.35055435, 0.6274171, 0.61077535, 0.06525731, 0.8091929, 0.21307838, 0.6465323, 0.3245015, 0.5538883, 0.8849807, 0.9591211, 0.83856845, 0.48919427, 0.11810577, 0.16933143, 0.83657074, 0.587505, 0.6867087, 0.95522237, 0.5797727, 0.28024232, 0.34749162, 0.5199702, 0.9811766, 0.5645981, 0.2446456, 0.68722725, 0.9616587, 0.480047, 0.88953114, 0.7083205, 0.948612, 0.67764974, 0.44131804, 0.36789334, 0.95148766, 0.30909216, 0.70908046, 0.8749926, 0.60973287, 0.60751855, 0.22647333, 0.5363518, 0.96195626, 0.08158326, 0.5266887, 0.85922587, 0.648262, 0.4657668, 0.31623375, 0.43507564, 0.48351157, 0.41285944, 0.73501325, 0.15267539, 0.67055714, 0.08459568, 0.04527426, 0.21078384, 0.4654404, 0.7363906, 0.23245859, 0.22119188, 0.99092937, 0.878675, 0.4102913})
-      ROOT scatter.48 = f32[3] scatter(operand, indices, updates),
-        update_window_dims={}, inserted_window_dims={0},
-        scatter_dims_to_operand_dims={0}, index_vector_dim=1,
+      operand = f32[3, 3] constant({{0, 0, 0}, {0, 0, 0}, {0, 0, 0}})
+      indices = s32[50, 2] constant({{0, 0}, {0, 1}, {1, 1}, {2, 2}, {0, 1}, {1, 0}, {2, 1}, {1, 2}, {0, 2}, {2, 0}, 
+                                     {1, 1}, {2, 2}, {0, 0}, {0, 1}, {2, 1}, {1, 2}, {2, 0}, {0, 2}, {1, 0}, {1, 1},
+                                     {1, 2}, {2, 1}, {0, 0}, {1, 1}, {0, 2}, {2, 0}, {1, 0}, {2, 2}, {1, 2}, {0, 1},
+                                     {2, 1}, {1, 0}, {0, 2}, {2, 0}, {0, 1}, {2, 1}, {1, 1}, {1, 0}, {2, 2}, {0, 0},
+                                     {0, 1}, {1, 2}, {2, 0}, {1, 1}, {0, 2}, {2, 1}, {1, 2}, {2, 1}, {1, 1}, {0, 2}})
+      updates = f32[50, 2] constant({{0.02379167, 0.8527204}, {0.8132185, 0.5140263}, {0.17172801, 0.8026866}, 
+                                      {0.5124631, 0.34838438}, {0.50526905, 0.3370521}, {0.10868239, 0.10520637}, 
+                                      {0.83827364, 0.78986526}, {0.34059846, 0.8349273}, {0.24575627, 0.21387374}, 
+                                      {0.02423227, 0.5617423}, {0.28066766, 0.94366455}, {0.61214995, 0.7383388},
+                                      {0.52419806, 0.65466726}, {0.41012764, 0.24028647}, {0.74443066, 0.03544927},
+                                      {0.851014, 0.02434528}, {0.47239733, 0.72706807}, {0.35055435, 0.6274171},
+                                      {0.61077535, 0.06525731}, {0.8091929, 0.21307838}, {0.6465323, 0.3245015},
+                                      {0.5538883, 0.8849807}, {0.9591211, 0.83856845}, {0.48919427, 0.11810577},
+                                      {0.16933143, 0.83657074}, {0.587505, 0.6867087}, {0.95522237, 0.5797727},
+                                      {0.28024232, 0.34749162}, {0.5199702, 0.9811766}, {0.5645981, 0.2446456},
+                                      {0.68722725, 0.9616587}, {0.480047, 0.88953114}, {0.7083205, 0.948612},
+                                      {0.67764974, 0.44131804}, {0.36789334, 0.95148766}, {0.30909216, 0.70908046},
+                                      {0.8749926, 0.60973287}, {0.60751855, 0.22647333}, {0.5363518, 0.96195626},
+                                      {0.08158326, 0.5266887}, {0.85922587, 0.648262}, {0.4657668, 0.31623375},
+                                      {0.43507564, 0.48351157}, {0.41285944, 0.73501325}, {0.15267539, 0.67055714},
+                                      {0.08459568, 0.04527426}, {0.21078384, 0.4654404}, {0.7363906, 0.23245859},
+                                      {0.22119188, 0.99092937}, {0.878675, 0.4102913}})
+      ROOT scatter.48 = f32[3, 3] scatter(operand, indices, updates),
+        update_window_dims={1}, inserted_window_dims={0},
+        scatter_dims_to_operand_dims={0, 1}, index_vector_dim=1,
         to_apply=scatter_computation
     })";
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1044,7 +1044,14 @@ message DebugOptions {
 
   bool xla_pjrt_allow_auto_layout_in_hlo = 344;
 
-  // Next id: 345
+  // Enable the scatter determinism expander, an optimized pass that
+  // rewrites scatter operations to ensure deterministic behavior with high
+  // performance.
+  // Note that even when this flag is disabled, scatter operations may still
+  // be deterministic, although with additional overhead.
+  bool xla_gpu_enable_scatter_determinism_expander = 345;
+
+  // Next id: 346
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR is the 2nd step (out of 2) to improve the performance of deterministic scatter. Originally, the scatter op will be expanded to be deterministic in xla/service/ScatterExpander.cc. However, since it took a while-loop-based approach, the performance is extremely poor. We designed and implemented a prefix-scan-based approach to rewrite the scatter operation to be an efficient deterministic scatter. This PR completes the optimization of deterministic scatter operations with non-scalar indices and updates.

The change of this PR is on top of https://github.com/openxla/xla/pull/17886, and has fixed issues reported in the reverted PR https://github.com/openxla/xla/pull/18326. The issue was that the changes in https://github.com/openxla/xla/pull/18326 were not able to handle different kinds of complicated but realistic scatter dimension numbers. Specifically, this PR unifies the implementation of 1D and multi-dimensional scatter operation to make the code easier to maintain, adds multiple tests for various scatter dimension numbers, and thoroughly handles all cases of different kinds of dimension numbers. 

Moreover, this PR also adds an option `xla_gpu_enable_scatter_determinism_expander`, the default value of which is set to be true. This option could make sure that although unlikely, if anything happens with changes in this PR, the user can easily disable  the `scatter_determinism_expander` pass without getting blocked.


Design doc: https://docs.google.com/document/d/1K204VZR3OP0SUDOPsGUYgIIDf2ucTKEC4yQj8XRG2SA/edit

Bugs resolved: https://github.com/jax-ml/jax/issues/17844