### PR TITLE
[ROCm] Fix rocm_executor_test

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -584,6 +584,7 @@ void RocmExecutor::UnloadKernel(const Kernel* kernel) {
   VLOG(3) << "Unloading kernel " << kernel << " : " << kernel->name();
 
   absl::MutexLock lock{&in_memory_modules_mu_};
+  loaded_kernels_.erase(kernel);
   auto gpu_binary_it = kernel_to_gpu_binary_.find(kernel);
   if (kernel_to_gpu_binary_.end() == gpu_binary_it) {
     VLOG(3) << "Kernel " << kernel << " : " << kernel->name()
@@ -650,6 +651,9 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
     return absl::InternalError("No method of loading ROCM kernel provided");
   }
 
+  absl::MutexLock lock{&in_memory_modules_mu_};
+  loaded_kernels_.insert(rocm_kernel.get());
+  
   // We have to trust the kernel loader spec arity because there doesn't appear
   // to be a way to reflect on the number of expected arguments w/the ROCM API.
   rocm_kernel->set_arity(spec.arity());


### PR DESCRIPTION
The issue was introduced here https://github.com/openxla/xla/commit/7c468b089a5fb467f7ea9104d3bf6218ffb37d5d
Error log:
```
[ RUN      ] RocmExecutorTest.GetRocmKernel
xla/stream_executor/rocm/rocm_executor_test.cc:70: Failure
Value of: rocm_executor->GetRocmKernel(kernel.get())
Expected: is OK and has a value that is equal to 0x55c94b2c7730
Actual: 16-byte object <01-28 2F-4B C9-55 00-00 00-00 00-00 00-00 00-00>, which has status NOT_FOUND: Kernel not loaded in this executor.
[  FAILED  ] RocmExecutorTest.GetRocmKernel (5 ms)
```