### PR TITLE
[ROCm] Disable gpu_too_many_blocks_test for rocm

### DIFF
--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -189,6 +189,7 @@ xla_test(
         "gpu_too_many_blocks_test.cc",
     ],
     backends = ["gpu"],
+    tags = ["cuda-only",],
     deps = [
         ":gpu_codegen_test",
         "//xla/hlo/ir:hlo",


### PR DESCRIPTION
After this change to the test inputs https://github.com/openxla/xla/commit/b10653ff606506dc510d71ddecf6483033b6a6e2 "too many blocks" exception is not getting triggered anymore (shape is not big enough). 

Due to the low importance of the test, it was decided to disable it.