### PR TITLE
Fix deterministic scatter expander pass and re-enable it by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -293,7 +293,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_enable_fast_math(false);
   opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
   opts.set_xla_pjrt_allow_auto_layout_in_hlo(false);
-  opts.set_xla_gpu_enable_scatter_determinism_expander(false);
+  opts.set_xla_gpu_enable_scatter_determinism_expander(true);
   return opts;
 }
 

--- a/xla/service/scatter_determinism_expander.cc
+++ b/xla/service/scatter_determinism_expander.cc
@@ -793,7 +793,6 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
     // Create a new dimension numbers for the new scatter operation
     // As we have scalar updates, there is no update_window_dims
     new_dim_numbers.clear_update_window_dims();
-    new_dim_numbers.set_index_vector_dim(1);
     // Mitigate the missed dimensions
     for (int i = 0; i < operand_shape.dimensions_size() -
                             dim_numbers.input_batching_dims_size();
@@ -807,6 +806,9 @@ absl::StatusOr<HloInstruction*> ScatterDeterminismExpander::ExpandInstruction(
   } else {
     new_dim_numbers = dim_numbers;
   }
+
+  // `CanonicalizeScatterIndices` collapses index dimensions.
+  new_dim_numbers.set_index_vector_dim(1);
 
   // Sort the scatter indices and updates together based on the scatter indices.
   int64_t num_indices = ShapeUtil::ElementsIn(scatter_updates[0]->shape());


### PR DESCRIPTION
The pass implementation branches on `non_scalar_update` and (previously) only updated `index_vector_dim` in one branch, whereas the indices tensor is canonicalized unconditionally.

This PR fixes the bug, adds the regression test and re-enables the pass by default.