### PR TITLE
Pass process index and count from PJRT client.

### DIFF
--- a/xla/client/executable_build_options.cc
+++ b/xla/client/executable_build_options.cc
@@ -198,6 +198,8 @@ absl::StatusOr<ExecutableBuildOptionsProto> ExecutableBuildOptions::ToProto()
     output.mutable_auto_spmd_partitioning_mesh_ids()->Add(s);
   }
   output.set_use_shardy_partitioner(use_shardy_partitioner());
+  output.set_process_index(process_index());
+  output.set_process_count(process_count());
   return output;
 }
 
@@ -248,6 +250,8 @@ absl::StatusOr<ExecutableBuildOptions> ExecutableBuildOptionsFromProto(
       std::vector<int64_t>(input.auto_spmd_partitioning_mesh_ids().begin(),
                            input.auto_spmd_partitioning_mesh_ids().end()));
   output.set_use_shardy_partitioner(input.use_shardy_partitioner());
+  output.set_process_index(input.process_index());
+  output.set_process_count(input.process_count());
   return output;
 }
 

--- a/xla/pjrt/compile_options.proto
+++ b/xla/pjrt/compile_options.proto
@@ -125,6 +125,9 @@ message ExecutableBuildOptionsProto {
   // ShardingPropagation and SpmdPartitioner. See go/xla-sdy-pipeline for
   // details.
   bool use_shardy_partitioner = 19;
+
+  int64 process_index = 22;
+  int64 process_count = 23;
 }
 
 message OptionOverrideProto {

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -3514,11 +3514,6 @@ PjRtStreamExecutorClient::CompileInternal(
     CompileOptions options) {
   tsl::profiler::TraceMe traceme("PjRtStreamExecutorClient::Compile");
   VLOG(1) << "PjRtStreamExecutorClient::Compile";
-  options.executable_build_options.set_process_index(process_index());
-  TF_RET_CHECK(device_count() % addressable_device_count() == 0)
-      << "Each process is expected to have the same number of devices";
-  options.executable_build_options.set_process_count(
-      device_count() / addressable_device_count());
   auto input_options = options;
 
   TF_RETURN_IF_ERROR(options.ApplyAllOptionOverrides());

--- a/xla/python/xla_compiler.cc
+++ b/xla/python/xla_compiler.cc
@@ -36,13 +36,13 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "nanobind/nanobind.h"
 #include "nanobind/ndarray.h"
-#include "nanobind/stl/optional.h"  // IWYU pragma: keep
-#include "nanobind/stl/pair.h"  // IWYU pragma: keep
-#include "nanobind/stl/shared_ptr.h"  // IWYU pragma: keep
-#include "nanobind/stl/string.h"  // IWYU pragma: keep
+#include "nanobind/stl/optional.h"     // IWYU pragma: keep
+#include "nanobind/stl/pair.h"         // IWYU pragma: keep
+#include "nanobind/stl/shared_ptr.h"   // IWYU pragma: keep
+#include "nanobind/stl/string.h"       // IWYU pragma: keep
 #include "nanobind/stl/string_view.h"  // IWYU pragma: keep
-#include "nanobind/stl/variant.h"  // IWYU pragma: keep
-#include "nanobind/stl/vector.h"  // IWYU pragma: keep
+#include "nanobind/stl/variant.h"      // IWYU pragma: keep
+#include "nanobind/stl/vector.h"       // IWYU pragma: keep
 #include "xla/array.h"
 #include "xla/client/executable_build_options.h"
 #include "xla/debug_options_flags.h"
@@ -1330,7 +1330,11 @@ void BuildXlaCompilerSubmodule(nb::module_& m) {
           })
       .def_prop_rw("use_shardy_partitioner",
                    &ExecutableBuildOptions::use_shardy_partitioner,
-                   &ExecutableBuildOptions::set_use_shardy_partitioner);
+                   &ExecutableBuildOptions::set_use_shardy_partitioner)
+      .def_prop_rw("process_index", &ExecutableBuildOptions::process_index,
+                   &ExecutableBuildOptions::set_process_index)
+      .def_prop_rw("process_count", &ExecutableBuildOptions::process_count,
+                   &ExecutableBuildOptions::set_process_count);
 
   nb::enum_<OpSharding::Type> op_sharding_type(m, "OpSharding_Type",
                                                nb::is_arithmetic());

--- a/xla/python/xla_extension/__init__.pyi
+++ b/xla/python/xla_extension/__init__.pyi
@@ -364,6 +364,8 @@ class ExecutableBuildOptions:
   auto_spmd_partitioning_mesh_shape: List[int]
   auto_spmd_partitioning_mesh_ids: List[int]
   use_shardy_partitioner: bool
+  process_index: int
+  process_count: int
 
 class PrecisionConfig_Precision(enum.IntEnum):
   DEFAULT: int


### PR DESCRIPTION
Process index and count are used in sharded autotuning in the GPU compiler. To make this work also in MPMD programs they have to be set at the higher level which knows which of the connected processes are participating in compilation of an HLO module.

I didn't find an easy way to run tests from xla/python in OSS so I'll add a test for this to JAX.
