### PR TITLE
[GPU] Sharded autotuning: exchange only results of the latest compilation.

### DIFF
--- a/xla/service/gpu/autotuning/autotuner_util.cc
+++ b/xla/service/gpu/autotuning/autotuner_util.cc
@@ -262,10 +262,12 @@ void SerializeAutotuneEntry(AutotuneResults* results, const AutotuneCacheKey& k,
 }  // namespace
 
 /*static*/ absl::Status AutotunerUtil::SerializeAutotuneResults(
-    AutotuneResults* results) {
+    AutotuneResults* results, std::optional<const AutotuneCacheKeySet*> keys) {
   absl::MutexLock lock(&autotune_cache_mu);
   for (const auto& [k, result] : autotune_cache) {
-    SerializeAutotuneEntry(results, k, &result);
+    if (!keys.has_value() || keys.value()->contains(k)) {
+      SerializeAutotuneEntry(results, k, &result);
+    }
   }
 
   results->set_version(kVersion);

--- a/xla/service/gpu/autotuning/autotuner_util.h
+++ b/xla/service/gpu/autotuning/autotuner_util.h
@@ -97,6 +97,8 @@ class AutotuneCacheKey {
   std::string hlo_canonical_;
 };
 
+using AutotuneCacheKeySet = absl::flat_hash_set<AutotuneCacheKey>;
+
 class AutotuneConfig {
  public:
   bool should_init_buffers() const { return autotune_level_ >= 2; }
@@ -279,8 +281,11 @@ struct AutotunerUtil {
   static absl::StatusOr<std::string> SerializeAutotuneResults(
       bool as_textproto = false);
 
-  // Serializes autotune results into the given proto.
-  static absl::Status SerializeAutotuneResults(AutotuneResults* results);
+  // Serializes autotune results into the given proto. If optional keys are
+  // provided, serializes results only for these keys.
+  static absl::Status SerializeAutotuneResults(
+      AutotuneResults* results,
+      std::optional<const AutotuneCacheKeySet*> keys = {});
 
   // Loads autotune results from the given string of bytes.
   //

--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner.h
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner.h
@@ -148,7 +148,7 @@ class GemmFusionAutotunerImpl {
       absl::Span<const ExecutableCandidate> candidates);
 
   // Autotune and save the results to the autotuning cache.
-  absl::Status Autotune(
+  absl::StatusOr<AutotuneCacheKeySet> Autotune(
       AutotunerCompileUtil& compile_util,
       const BackendConfigs& gemm_config_sets,
       absl::flat_hash_map<AutotuneCacheKey, uint64_t> fusion_count_map);

--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -185,6 +185,7 @@ xla_test(
     data = [
         "data/multiple_gemm_fusions_1.hlo",
         "data/multiple_gemm_fusions_2.hlo",
+        "data/single_gemm_fusion.hlo",
         "data/sharded_16_devices.hlo",
         "data/sharded_2_devices.hlo",
         "data/single_device.hlo",

--- a/xla/tools/multihost_hlo_runner/data/single_gemm_fusion.hlo
+++ b/xla/tools/multihost_hlo_runner/data/single_gemm_fusion.hlo
@@ -1,0 +1,14 @@
+f {
+  a = f32[70,70,70] parameter(0)
+  b = f32[70,70,70] parameter(1)
+  d = f32[70,70,70] dot(a, b),
+    lhs_batch_dims={0}, lhs_contracting_dims={1},
+    rhs_batch_dims={0}, rhs_contracting_dims={2}
+}
+
+e {
+  a = f32[70,70,70] parameter(0)
+  b = f32[70,70,70] parameter(1)
+  f = f32[70,70,70] fusion(a, b), kind=kCustom, calls=f,
+    backend_config={"fusion_backend_config":{"kind":"__triton_gemm"}}
+}

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -326,6 +326,13 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id) {
     // The nodes autotune different fusions.
     CHECK_NE(results0, results1);
   }
+  // Compile another module to test that the autotuner doesn't fail trying to
+  // exchange again cached results for the previous module.
+  TF_RETURN_IF_ERROR(FunctionalHloRunner::LoadAndCompile(
+      *env.client, GetDebugOptionsFromFlags(),
+      FunctionalHloRunner::PreprocessingOptions{},
+      FunctionalHloRunner::RawCompileOptions{},
+      GetHloPath("single_gemm_fusion.hlo"), InputFormat::kText));
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
Exchanging the cached results of previous compilation of other modules isn't necessary and leads to conflicts.