### PR TITLE
Add ExplicitStreamAnnotationAsyncWrapper pass

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1541,6 +1541,7 @@ cc_library(
         "//xla/service/gpu/transforms:dot_operand_converter",
         "//xla/service/gpu/transforms:double_buffer_loop_unrolling",
         "//xla/service/gpu/transforms:dynamic_slice_fusion_rewriter",
+        "//xla/service/gpu/transforms:explicit_stream_annotation_async_wrapper",
         "//xla/service/gpu/transforms:fusion_block_level_rewriter",
         "//xla/service/gpu/transforms:fusion_wrapper",
         "//xla/service/gpu/transforms:gemm_broadcast_folding_rewriter",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -200,6 +200,7 @@ limitations under the License.
 #include "xla/service/gpu/transforms/dot_operand_converter.h"
 #include "xla/service/gpu/transforms/double_buffer_loop_unrolling.h"
 #include "xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.h"
+#include "xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.h"
 #include "xla/service/gpu/transforms/fusion_wrapper.h"
 #include "xla/service/gpu/transforms/gemm_broadcast_folding_rewriter.h"
 #include "xla/service/gpu/transforms/gemm_fusion.h"
@@ -1216,7 +1217,11 @@ absl::Status RunPostFusionSimplificationPasses(
         gpu_target_config.device_description);
     pipeline.AddPass<StreamAttributeAsyncWrapper>();
   }
-
+  if (hlo_module->config()
+          .debug_options()
+          .xla_gpu_experimental_stream_annotation()) {
+    pipeline.AddPass<ExplicitStreamAnnotationAsyncWrapper>();
+  }
   return pipeline.Run(hlo_module).status();
 }
 

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1641,6 +1641,42 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "explicit_stream_annotation_async_wrapper",
+    srcs = ["explicit_stream_annotation_async_wrapper.cc"],
+    hdrs = ["explicit_stream_annotation_async_wrapper.h"],
+    deps = [
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu/runtime:thunk",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:logging",
+        "@tsl//tsl/platform:statusor",
+    ],
+    )
+    
+xla_cc_test(
+    name = "explicit_stream_annotation_async_wrapper_test",
+    srcs = ["explicit_stream_annotation_async_wrapper_test.cc"],
+    deps = [
+        ":explicit_stream_annotation_async_wrapper",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:filecheck",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/tests:hlo_test_base",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
     name = "fusion_wrapper",
     srcs = ["fusion_wrapper.cc"],
     hdrs = ["fusion_wrapper.h"],

--- a/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.cc
+++ b/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.cc
@@ -1,0 +1,71 @@
+/* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/runtime/thunk.h"
+#include "xla/side_effect_util.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/logging.h"
+#include "tsl/platform/statusor.h"
+
+namespace xla::gpu {
+
+namespace {
+static absl::StatusOr<bool> AsynchronizeInstruction(HloInstruction* instr) {
+  if (instr->opcode() != HloOpcode::kCall ||
+      !instr->frontend_attributes().map().contains(kXlaStreamAnnotationAttr)) {
+    return false;
+  }
+  HloComputation* computation = instr->parent();
+  TF_ASSIGN_OR_RETURN(
+      HloInstruction * done,
+      computation->CreateAsyncInstructions(
+          instr, {},
+          ExplicitStreamAnnotationAsyncWrapper::kExplicitExecutionThread,
+          /*replace=*/true));
+  TF_ASSIGN_OR_RETURN(GpuBackendConfig gpu_config,
+                      done->backend_config<GpuBackendConfig>());
+  // Set the false delay of done op to be false so it can be scheduled
+  // far apart from start.
+  gpu_config.set_force_earliest_schedule(false);
+  TF_RETURN_IF_ERROR(done->set_backend_config(gpu_config));
+  VLOG(5) << "Created async instruction: " << done->ToString();
+  return true;
+}
+}  // namespace
+
+absl::StatusOr<bool> ExplicitStreamAnnotationAsyncWrapper::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+  for (const HloComputation* comp : module->computations()) {
+    for (HloInstruction* instr : comp->instructions()) {
+      TF_ASSIGN_OR_RETURN(bool result, AsynchronizeInstruction(instr));
+      changed |= result;
+    }
+  }
+  return changed;
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.h
+++ b/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.h
@@ -1,0 +1,48 @@
+/* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_EXPLICIT_STREAM_ANNOTATION_ASYNC_WRAPPER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_EXPLICIT_STREAM_ANNOTATION_ASYNC_WRAPPER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla::gpu {
+
+// This pass will find the kCall instructions that
+// are annotated with explicit stream id in their frontend
+// attributes. It then wraps them using AsyncStartDone pairs to achieve
+// asynchronous executions.
+class ExplicitStreamAnnotationAsyncWrapper : public HloModulePass {
+ public:
+  inline static constexpr char kExplicitExecutionThread[] = "explicit";
+
+  absl::string_view name() const override {
+    return "explicit-stream-annotation-async-wrapper";
+  }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_EXPLICIT_STREAM_ANNOTATION_ASYNC_WRAPPER_H_

--- a/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper_test.cc
+++ b/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper_test.cc
@@ -1,0 +1,115 @@
+/* Copyright 2024 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/test.h"
+#include "xla/tests/filecheck.h"
+#include "xla/tests/hlo_test_base.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+
+namespace xla::gpu {
+namespace {
+
+using ExplicitStreamAnnotationAsyncWrapperTest = HloTestBase;
+
+TEST_F(ExplicitStreamAnnotationAsyncWrapperTest, AnnotatedOpIsWrapped) {
+  const absl::string_view hlo_string = R"(
+  HloModule composite
+
+  %sub (lhs: f32[]) -> f32[] {
+    %lhs = f32[] parameter(0)
+    %rhs = f32[] constant(1)
+    ROOT %sub = f32[] subtract(f32[] %lhs, f32[] %rhs)
+  }
+
+  ENTRY %main () -> f32[] {
+    %lhs = f32[] constant(42)
+    %call1 = f32[] call(f32[] %lhs), to_apply=%sub, frontend_attributes={_xla_stream_annotation="1"}
+  })";
+
+  auto debug_options = HloTestBase::GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_experimental_stream_annotation(true);
+  auto module = ParseAndReturnVerifiedModule(hlo_string).value();
+  module->mutable_config().set_debug_options(debug_options);
+  ExplicitStreamAnnotationAsyncWrapper wrapper_pass;
+
+  TF_ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
+  absl::StatusOr<bool> filecheck_result = RunFileCheck(module->ToString({}), R"(
+  // CHECK: %lhs.1 = f32[] constant(42)
+  // CHECK: %call-start = ((f32[]), f32[]) call-start(f32[] %lhs.1), async_execution_thread="explicit", to_apply=%sub, frontend_attributes={_xla_stream_annotation="1"}
+  // CHECK: ROOT %call-done = f32[] call-done(((f32[]), f32[]) %call-start), frontend_attributes={_xla_stream_annotation="1"}, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false}
+  )");
+  TF_ASSERT_OK(filecheck_result.status());
+  EXPECT_TRUE(*filecheck_result);
+
+  ASSERT_TRUE(mutated);
+}
+
+TEST_F(ExplicitStreamAnnotationAsyncWrapperTest, OverlappingGemms) {
+  const absl::string_view hlo_string = R"(
+  HloModule composite
+
+  %gemm1 (z: f32[2048,2048], w: f32[2048,2048]) -> f32[2048,2048] {
+    %w = f32[2048,2048]{1,0} parameter(1)
+    %z = f32[2048,2048]{1,0} parameter(0)
+    %custom-call.1 = (f32[2048,2048]{1,0}, s8[33554432]{0}) custom-call(f32[2048,2048]{1,0} %w, f32[2048,2048]{1,0} %z), custom_call_target="__cublas$gemm"
+    ROOT %get-tuple-element = f32[2048,2048]{1,0} get-tuple-element((f32[2048,2048]{1,0}, s8[33554432]{0}) %custom-call.1), index=0
+  }
+  %gemm2 (a: f32[2048,2048], b: f32[2048,2048]) -> f32[2048,2048] {
+    %a = f32[2048,2048]{1,0} parameter(1)
+    %b = f32[2048,2048]{1,0} parameter(0)
+    %custom-call.2 = (f32[2048,2048]{1,0}, s8[33554432]{0}) custom-call(f32[2048,2048]{1,0} %a, f32[2048,2048]{1,0} %b), custom_call_target="__cublas$gemm"
+    ROOT %get-tuple-element = f32[2048,2048]{1,0} get-tuple-element((f32[2048,2048]{1,0}, s8[33554432]{0}) %custom-call.2), index=0
+  }
+
+  ENTRY %main () -> f32[2048,2048]{1,0} {
+    %x = f32[2048,2048]{1,0} parameter(1), metadata={op_name="b" scheduling_name="x"}
+    %y = f32[2048,2048]{1,0} parameter(0), metadata={op_name="a" scheduling_name="y"}
+    %call1 =  f32[2048,2048]{1,0} call(f32[2048,2048]{1,0} %x, f32[2048,2048]{1,0} %y ), to_apply=%gemm1, frontend_attributes={_xla_stream_annotation="1"}
+    ROOT %call2 =  f32[2048,2048]{1,0} call(f32[2048,2048]{1,0} %x, f32[2048,2048]{1,0} %y), to_apply=%gemm2, frontend_attributes={_xla_stream_annotation="2"}
+  })";
+
+  auto debug_options = HloTestBase::GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_experimental_stream_annotation(true);
+  auto module = ParseAndReturnVerifiedModule(hlo_string).value();
+  module->mutable_config().set_debug_options(debug_options);
+  ExplicitStreamAnnotationAsyncWrapper wrapper_pass;
+
+  TF_ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
+  absl::StatusOr<bool> filecheck_result = RunFileCheck(module->ToString({}), R"(
+  // CHECK: %call-start = ((f32[2048,2048]{1,0}, f32[2048,2048]{1,0}), f32[2048,2048]{1,0}) call-start(f32[2048,2048]{1,0} %x, f32[2048,2048]{1,0} %y), async_execution_thread="explicit", to_apply=%gemm1, frontend_attributes={_xla_stream_annotation="1"} 
+  // CHECK: %call-done = f32[2048,2048]{1,0} call-done(((f32[2048,2048]{1,0}, f32[2048,2048]{1,0}), f32[2048,2048]{1,0}) %call-start), frontend_attributes={_xla_stream_annotation="1"}, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false}
+  // CHECK: %call-start.1 = ((f32[2048,2048]{1,0}, f32[2048,2048]{1,0}), f32[2048,2048]{1,0}) call-start(f32[2048,2048]{1,0} %x, f32[2048,2048]{1,0} %y), async_execution_thread="explicit", to_apply=%gemm2, frontend_attributes={_xla_stream_annotation="2"}
+  // CHECK: ROOT %call-done.1 = f32[2048,2048]{1,0} call-done(((f32[2048,2048]{1,0}, f32[2048,2048]{1,0}), f32[2048,2048]{1,0}) %call-start.1), frontend_attributes={_xla_stream_annotation="2"}, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false}
+  )");
+  TF_ASSERT_OK(filecheck_result.status());
+  EXPECT_TRUE(*filecheck_result);
+
+  ASSERT_TRUE(mutated);
+}
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
This PR introduces a new pass `ExplicitStreamAnnotationAsyncWrapper`. This pass takes `kCall` instructions that are annotated with the frontend attribute `xla_gpu_experimental_stream_annotation`, and wraps the call with an async start-done pair.


Initially, I tried to integrate this with the existing `StreamAttributeAnnotator` and `StreamAttributeAsyncWrapper` passes, but much of that code is specifically just for the `windowedeinsum` logic, and users wont necessarily want both enabled at the same time. Thus, I found it cleaner to instead just make a new pass.