### PR TITLE
[XLA:GPU] Add an option to disable GPU multi thread sharing

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -157,6 +157,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_nccl_per_stream_comms(false);
 
   opts.set_xla_gpu_temp_buffer_use_separate_color(false);
+  opts.set_xla_gpu_require_exclusive_lock(false);
 
   // Set 4GB space limit for redzone scratch allocator.
   opts.set_xla_gpu_redzone_scratch_max_megabytes(1LL << 12);
@@ -1440,6 +1441,18 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "Enables temp User Buffer Registration. Enable this flag will use a "
       "separate cuda async memory allocator to allocate temp buffer, this will "
       "allocate temp buffer to the fixed address on every iteration"));
+
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_require_exclusive_lock",
+      bool_setter_for(&DebugOptions::set_xla_gpu_require_exclusive_lock),
+      debug_options->xla_gpu_require_exclusive_lock(),
+      "if true, running gpu executable will require exclusive lock on gpu, so "
+      "there is no multi thread conlicts on gpu. this can enable some "
+      "optimizations that reduce the cost of resource management, e.g, "
+      "command "
+      "buffer update to ensure correctness when running in multi thread "
+      "mode."));
+
   flag_list->push_back(tsl::Flag(
       "xla_gpu_enable_nccl_comm_splitting",
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_nccl_comm_splitting),

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1274,6 +1274,13 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
   if (options.enable_mock_nccl) {
     gpu_run_options->set_enable_mock_nccl_collectives();
   }
+
+  static const bool xla_gpu_require_exclusive_lock =
+      xla::GetDebugOptionsFromFlags().xla_gpu_require_exclusive_lock();
+  if (xla_gpu_require_exclusive_lock) {
+    gpu_run_options->set_requires_exclusive_lock_on_gpu();
+  }
+
   std::shared_ptr<KeyValueStoreInterface> kv_store = options.kv_store;
   if (options.enable_mock_nccl) {
     kv_store = std::make_shared<InMemoryKeyValueStore>();

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -4555,6 +4555,7 @@ cc_library(
         "//xla/hlo/ir:hlo",
         "//xla/hlo/ir:hlo_module_group",
         "//xla/hlo/parser:hlo_parser",
+        "//xla/service/gpu:gpu_executable_run_options",
         "//xla/stream_executor:device_memory_allocator",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor:stream_executor_memory_allocator",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -361,6 +361,13 @@ absl::Status ExecuteThunks(
           ? debug_options->xla_gpu_enable_highest_priority_async_stream()
           : false;
 
+  bool requires_exclusive_lock_on_gpu =
+      run_options->run_options().gpu_executable_run_options()
+          ? run_options->run_options()
+                .gpu_executable_run_options()
+                ->requires_exclusive_lock_on_gpu()
+          : false;
+
   se::Stream* main_stream = run_options->stream();
   se::StreamExecutor* executor = main_stream->parent();
   stream_executor::StreamPriority stream_priority =
@@ -453,7 +460,8 @@ absl::Status ExecuteThunks(
         &collective_params,
         &collective_cliques,
         run_options->run_options().ffi_execution_context(),
-        run_options->local_device_count()};
+        run_options->local_device_count(),
+        requires_exclusive_lock_on_gpu};
 
     tsl::profiler::TraceMe trace([&] { return "Thunks::Initialize"; });
     TF_RETURN_IF_ERROR(thunk_sequence.Initialize(initialize_params));

--- a/xla/service/gpu/runtime/thunk.cc
+++ b/xla/service/gpu/runtime/thunk.cc
@@ -191,6 +191,11 @@ Thunk::ExecuteParams Thunk::ExecuteParams::Create(
                            ? run_options.run_options()
                                  .gpu_executable_run_options()
                                  ->enable_mock_nccl_collectives()
+                           : false,
+                       run_options.run_options().gpu_executable_run_options()
+                           ? run_options.run_options()
+                                 .gpu_executable_run_options()
+                                 ->requires_exclusive_lock_on_gpu()
                            : false);
 }
 
@@ -214,7 +219,8 @@ Thunk::ExecuteParams::ExecuteParams(
     SendDeviceMemoryFunction* send_device_memory_function,
     RecvDeviceMemoryFunction* recv_device_memory_function,
     const ffi::ExecutionContext* ffi_execution_context,
-    ExecutionStreamIdMap additional_compute_streams, bool mock_collectives)
+    ExecutionStreamIdMap additional_compute_streams, bool mock_collectives,
+    bool requires_exclusive_lock_on_gpu)
     : buffer_allocations(buffer_allocations),
       stream(stream),
       command_buffer_trace_stream(command_buffer_trace_stream),
@@ -226,7 +232,8 @@ Thunk::ExecuteParams::ExecuteParams(
       recv_device_memory_function(recv_device_memory_function),
       ffi_execution_context(ffi_execution_context),
       additional_compute_streams(additional_compute_streams),
-      mock_collectives(mock_collectives) {}
+      mock_collectives(mock_collectives),
+      requires_exclusive_lock_on_gpu(requires_exclusive_lock_on_gpu) {}
 
 //===----------------------------------------------------------------------===//
 

--- a/xla/service/gpu/runtime/thunk.h
+++ b/xla/service/gpu/runtime/thunk.h
@@ -329,6 +329,8 @@ class Thunk {
 
     // Total local device count.
     int local_device_count = 0;
+
+    bool requires_exclusive_lock_on_gpu = false;
   };
 
   //===--------------------------------------------------------------------===//
@@ -386,6 +388,8 @@ class Thunk {
 
     bool mock_collectives = false;
 
+    bool requires_exclusive_lock_on_gpu = false;
+
    private:
     friend class CommandBufferThunk;
 
@@ -399,7 +403,8 @@ class Thunk {
                   RecvDeviceMemoryFunction* recv_device_memory_function,
                   const ffi::ExecutionContext* ffi_execution_context,
                   ExecutionStreamIdMap additional_compute_streams = {},
-                  bool mock_collectives = false);
+                  bool mock_collectives = false,
+                  bool requires_exclusive_lock_on_gpu = false);
   };
 
   //===--------------------------------------------------------------------===//

--- a/xla/service/hlo_runner.cc
+++ b/xla/service/hlo_runner.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "xla/service/executable.h"
 #include "xla/service/hlo_module_util.h"
 #include "xla/service/transfer_manager.h"
+#include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/stream_executor/device_memory_allocator.h"
@@ -365,6 +366,15 @@ absl::StatusOr<ExecutionOutput> HloRunner::ExecuteWithExecutionInputs(
                                     stream.get(), nullptr, RunId(),
                                     backend().device_count());
   service_run_options.mutable_run_options()->set_execution_profile(profile);
+
+  auto options = executable->module().config().debug_options();
+  auto gpu_run_options = std::make_unique<gpu::GpuExecutableRunOptions>();
+  if (options.xla_gpu_require_exclusive_lock()) {
+    gpu_run_options->set_requires_exclusive_lock_on_gpu();
+  }
+
+  service_run_options.mutable_run_options()->set_gpu_executable_run_options(
+      gpu_run_options.get());
 
   TF_ASSIGN_OR_RETURN(ExecutionOutput retval,
                       executable->ExecuteOnStreamWrapper(&service_run_options,

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -934,6 +934,12 @@ message DebugOptions {
   // command buffer.
   repeated string legacy_command_buffer_custom_call_targets = 314;
 
+  // If true, XLA runtime will retain exclusive ownership of the GPU when running a module,
+  // so there are no multi-thread conflicts on the GPU. This can enable some
+  // optimizations that reduce the cost of resource management, e.g., command
+  // buffer updates to ensure correctness when running in multi-thread mode.
+  bool xla_gpu_require_exclusive_lock = 347;
+
   // This flag is used for controlling HLO dumping and NVTX marker. If turned
   // on, both HLO dumping and NVTX marker will use syntactic sugar wrappers
   // as op names, while the actual op names will be shown if turned off.
@@ -1059,7 +1065,7 @@ message DebugOptions {
   // be deterministic, although with additional overhead.
   bool xla_gpu_enable_scatter_determinism_expander = 345;
 
-  // Next id: 347
+  // Next id: 348
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
XLA implementation introduces a lot of overhead in handling the case when multi-threads are possibly sharing the GPU device, especially for command buffer.  This PR introduces an option that will disable thread sharing when executing an XLA module, which can benefits the workloads when there are no thread sharing. 
