### PR TITLE
[XLA:GPU] use separte command buffer cmd flag for conditional and loop

### DIFF
--- a/xla/service/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/service/gpu/runtime/command_buffer_thunk_test.cc
@@ -1481,7 +1481,7 @@ class CmdBufferTest : public HloTestBase {
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CUSTOM_CALL);
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CUDNN);
     debug_options.add_xla_gpu_enable_command_buffer(
-        DebugOptions::DYNAMIC_SLICE);
+        DebugOptions::DYNAMIC_SLICE_FUSION);
     return debug_options;
   }
 };

--- a/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
@@ -46,7 +46,8 @@ class CommandBufferSchedulingTest : public HloTestBase {
   DebugOptions GetDebugOptionsForTest() const override {
     auto debug_options = HloTestBase::GetDebugOptionsForTest();
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
-    debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CONDITIONALS);
+    debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CONDITIONAL);
+    debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::WHILE);
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::COLLECTIVES);
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CUDNN);
     debug_options.add_xla_gpu_enable_command_buffer(DebugOptions::CUBLASLT);

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -604,10 +604,11 @@ message DebugOptions {
     CUBLAS = 2;
     CUDNN = 3;
     COLLECTIVES = 4;
-    CONDITIONALS = 5;
-    CUSTOM_CALL = 6;
-    CUBLASLT = 7;
-    DYNAMIC_SLICE = 8;
+    CONDITIONAL = 5;
+    WHILE = 6;
+    CUSTOM_CALL = 7;
+    CUBLASLT = 8;
+    DYNAMIC_SLICE_FUSION = 9;
   }
 
   // Determine the types of commands that are recorded into command buffers.


### PR DESCRIPTION
Observed in saxml workload that sharing the same command buffer cmd type (CONDITIONALS) for WHILE and CONDITIONAL command over kill the lowering opportunities.  

Many cases could allow CONDITIONAL instruction to lower into command buffer, while WHILE is not possible. 

This PR uses separate command buffer cmd type flag for CONDITIONAL and WHILE instructions when user specifies the type to lowering.   