### PR TITLE
[GPU][NFC] Cleanup horizontal loop fusion.

### DIFF
--- a/xla/service/gpu/transforms/horizontal_loop_fusion.cc
+++ b/xla/service/gpu/transforms/horizontal_loop_fusion.cc
@@ -253,6 +253,8 @@ bool AnyOpndIsParamSharedAmongFusions(
 
 void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
     HloInstruction* consumer) {
+  VLOG(4) << "Considering fusing inputs of " << consumer->ToShortString();
+
   // First, find out all potential target candidates. We will filter out
   // unsupported/non-profitable cases below.
   absl::flat_hash_set<HloInstruction*> fusible_candidates;
@@ -262,6 +264,7 @@ void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
     if (IsFusibleCandidate(*predecessor)) {
       if (fusible_candidates.insert(predecessor).second) {
         // Add unseen fusion to ordered list.
+        VLOG(4) << "Considering " << predecessor->ToShortString();
         ordered_fusible_candidates.push_back(predecessor);
       }
     }
@@ -666,7 +669,7 @@ absl::Status HorizontalLoopFusionImpl::Fuse(
 
 absl::StatusOr<bool> HorizontalLoopFusionImpl::Run() {
   bool changed = false;
-  XLA_VLOG_LINES(3, computation_->ToString());
+  XLA_VLOG_LINES(10, computation_->ToString());
 
   // Traverse from use to def. Bitcasts are placed after h-fusions to resolve
   // shape mismatch but bitcasts could prevent future h-fusion from happening.
@@ -679,9 +682,10 @@ absl::StatusOr<bool> HorizontalLoopFusionImpl::Run() {
     HloInstruction* consumer = to_fuse_candidates.back();
     to_fuse_candidates.pop_back();
 
-    // the consumer may be the operands of previously fused instruction, so
-    // it will no longer valid, skip this instruction.
-    if (consumer->IsDead()) {
+    // The consumer may be an operand of a previously fused instruction, so it
+    // will no longer be valid - skip it. If the consumer has less than two
+    // operands, there is nothing to fuse.
+    if (consumer->IsDead() || consumer->operand_count() < 2) {
       continue;
     }
 


### PR DESCRIPTION
- avoid unnecessary work
- bump log level at which complete computations are printed
- add log statements