### PR TITLE
[ROCm] Fix launch dimension triplet for ROCm

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -136,6 +136,7 @@ cc_library(
     deps = [
         "//xla:shape_util",
         "//xla:util",
+        "//xla/service:platform_util",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:launch_dim",
         "@com_google_absl//absl/log",

--- a/xla/service/gpu/launch_dimensions.cc
+++ b/xla/service/gpu/launch_dimensions.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstdint>
 
+#include "xla/service/platform_util.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/stream_executor/device_description.h"
@@ -35,18 +36,36 @@ LaunchDimensions CalculateLaunchDimensions(
     return LaunchDimensions();
   }
   num_elements = CeilOfRatio(num_elements, int64_t{dim_config.unroll_factor});
-
   const int kWarpSchedulers = 4;
-  int64_t threads_per_block = std::min<int64_t>(
+
+  if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm") {
+    int64_t threads_per_block_x = std::min<int64_t>(
       gpu_device_info.threads_per_warp() * kWarpSchedulers, num_elements);
-  int64_t num_blocks_total = CeilOfRatio(num_elements, threads_per_block);
 
-  int64_t num_blocks_y = CeilOfRatio<uint64_t>(
+    int64_t num_blocks = CeilOfRatio(num_elements, threads_per_block_x);
+    CHECK(num_blocks < gpu_device_info.block_dim_limit().x);
+
+    int threads_per_block_y = 1;
+    while ((num_blocks * threads_per_block_x) > std::numeric_limits<uint32_t>::max()) {
+      threads_per_block_x /= 2;
+      threads_per_block_y *= 2;
+    }
+
+    return LaunchDimensions(se::BlockDim(num_blocks, 1, 1),
+                          se::ThreadDim(threads_per_block_x, threads_per_block_y, 1));
+
+  } else {
+    int64_t threads_per_block = std::min<int64_t>(
+      gpu_device_info.threads_per_warp() * kWarpSchedulers, num_elements);
+
+    int64_t num_blocks_total = CeilOfRatio(num_elements, threads_per_block);
+    int64_t num_blocks_y = CeilOfRatio<uint64_t>(
       num_blocks_total, gpu_device_info.block_dim_limit().x);
-  int64_t num_blocks_x = CeilOfRatio(num_blocks_total, num_blocks_y);
+    int64_t num_blocks_x = CeilOfRatio(num_blocks_total, num_blocks_y);
 
-  return LaunchDimensions(se::BlockDim(num_blocks_x, num_blocks_y, 1),
-                          se::ThreadDim(threads_per_block, 1, 1));
+    return LaunchDimensions(se::BlockDim(num_blocks_x, num_blocks_y, 1),
+                          se::ThreadDim(threads_per_block, 1, 1));\
+  }
 }
 
 }  // namespace gpu


### PR DESCRIPTION
Owing to checks in https://github.com/openxla/xla/blob/main/xla/service/gpu/parallel_loop_emitter.cc#L169-L171 launch dimension can be of the form ((block.x, 1, 1), (thread.x, thread.y, 1)). And in ROCm it is expected that (block.x * thread.x) <= 0xFFFFFFFF