### PR TITLE
[ROCm] switch rocm build to clang

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -283,7 +283,6 @@ build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm --define=using_rocm_hipcc=true
 build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
 build:rocm --repo_env TF_NEED_ROCM=1
-build:rocm --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
 build:rocm --action_env=TF_ROCM_CLANG="1"
 build:rocm --linkopt="-fuse-ld=lld"
 build:rocm --host_linkopt="-fuse-ld=lld"

--- a/.bazelrc
+++ b/.bazelrc
@@ -283,6 +283,10 @@ build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm --define=using_rocm_hipcc=true
 build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
 build:rocm --repo_env TF_NEED_ROCM=1
+build:rocm --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
+build:rocm --action_env=TF_ROCM_CLANG="1"
+build:rocm --linkopt="-fuse-ld=lld"
+build:rocm --host_linkopt="-fuse-ld=lld"
 
 build:sycl --crosstool_top=@local_config_sycl//crosstool:toolchain
 build:sycl --define=using_sycl=true

--- a/.bazelrc
+++ b/.bazelrc
@@ -283,9 +283,14 @@ build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm --define=using_rocm_hipcc=true
 build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
 build:rocm --repo_env TF_NEED_ROCM=1
-build:rocm --action_env=TF_ROCM_CLANG="1"
-build:rocm --linkopt="-fuse-ld=lld"
-build:rocm --host_linkopt="-fuse-ld=lld"
+
+build:rocm_clang_official --config=rocm
+build:rocm_clang_official --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
+build:rocm_clang_official --action_env=TF_ROCM_CLANG="1"
+build:rocm_clang_official --linkopt="-fuse-ld=lld"
+build:rocm_clang_official --host_linkopt="-fuse-ld=lld"
+
+build:rocm_ci --config=rocm_clang_official
 
 build:sycl --crosstool_top=@local_config_sycl//crosstool:toolchain
 build:sycl --define=using_sycl=true


### PR DESCRIPTION
This PR switches the default rocm build to clang as the gcc config is broken at the moment.
