### PR TITLE
[XLA:CPU][oneDNN] Relocate Addend Shape Validation to the Contraction Rewriter

### DIFF
--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -118,9 +118,9 @@ std::unique_ptr<matmul::primitive_desc> CreateMatMulPrimDesc(
                               memory::format_tag::any);
   }
 
-  dnnl::post_ops post_ops = PopulateOneDnnPostOps(
-      cpu_engine, fused_mds, &matmul_config.fusions(), output_md.get_ndims(),
-      fused_operands_ref, &bias_md);
+  dnnl::post_ops post_ops =
+      PopulateOneDnnPostOps(cpu_engine, fused_mds, &matmul_config.fusions(),
+                            fused_operands_ref, &bias_md);
 
   dnnl::primitive_attr attrs;
   if (matmul_config.optimization_config().user_scratchpad()) {

--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -82,7 +82,7 @@ typename PrimitiveTrait<config>::pointer_type GetKernelConfig(
 dnnl::post_ops PopulateOneDnnPostOps(
     const dnnl::engine& cpu_engine,
     const std::vector<dnnl::memory::desc>& fused_mds,
-    const OneDnnFusionConfig* fusion_config, const int output_ndims,
+    const OneDnnFusionConfig* fusion_config,
     FusedOperandsRef* fused_operands_ref = nullptr,
     dnnl::memory::desc* bias_md = nullptr);
 


### PR DESCRIPTION
This PR moves the addend shape check to the rewriter so that the code to append oneDNN post-ops can be shared between matmul and convolution kernels.