### PR TITLE
Explicit stream annotation: Set ExecutionStreamId based on frontend attribute

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -2070,6 +2070,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 bool_setter_for(&DebugOptions::set_xla_enable_fast_math),
                 debug_options->xla_enable_fast_math(),
                 "Enable optimizations that assume finite math, i.e., no NaN."));
+  flag_list->push_back(
+      tsl::Flag("xla_gpu_experimental_stream_annotation",
+                bool_setter_for(
+                    &DebugOptions::set_xla_gpu_experimental_stream_annotation),
+                debug_options->xla_gpu_experimental_stream_annotation(),
+                "Enable the experimental explicit stream annotation support. "
+                "If false, the annotations are ignored."));
   flag_list->push_back(tsl::Flag(
       "xla_experimental_exec_time_optimization_effort",
       float_setter_for(

--- a/xla/service/gpu/execution_stream_assignment.cc
+++ b/xla/service/gpu/execution_stream_assignment.cc
@@ -17,12 +17,16 @@ limitations under the License.
 
 #include <deque>
 #include <memory>
+#include <optional>
+#include <string>
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
+#include "absl/strings/numbers.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "xla/side_effect_util.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -73,16 +77,18 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
   // Assigns source and destination streams to an instruction and records it in
   // async_instructions_.
   auto assign_async_execution_streams =
-      [&](HloInstruction* instruction, ExecutionStreamId source_stream_id) {
+      [&](HloInstruction* instruction, ExecutionStreamId source_stream_id,
+          std::optional<ExecutionStreamId> dest_stream_id) {
         AsyncExecutionStreamIds streams;
         streams.source_stream_id = source_stream_id;
-        streams.destination_stream_id = next_stream_id;
+        streams.destination_stream_id = dest_stream_id.value_or(next_stream_id);
 
         CHECK(async_instructions_.try_emplace(instruction, streams).second);
-
-        next_stream_id++;
-        if (next_stream_id.value() > options.number_of_execution_streams) {
-          next_stream_id = ExecutionStreamId(1);
+        if (!dest_stream_id.has_value()) {
+          next_stream_id++;
+          if (next_stream_id.value() > options.number_of_execution_streams) {
+            next_stream_id = ExecutionStreamId(1);
+          }
         }
       };
 
@@ -97,7 +103,8 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
       if (instruction->opcode() == HloOpcode::kCopyStart) {
         // CopyStart is morally an async instruction, let us treat it
         // as an async instruction.
-        assign_async_execution_streams(instruction, pending.stream_id);
+        assign_async_execution_streams(instruction, pending.stream_id,
+                                       std::nullopt);
       } else {
         CHECK(sync_instructions_.try_emplace(instruction, pending.stream_id)
                   .second);
@@ -110,10 +117,20 @@ ExecutionStreamAssignment::ExecutionStreamAssignment(
       if (callsite.instruction()->IsAsynchronous()) {
         // Asynchronous calls will result in a new `ExecutionStreamId` being
         // dispensed for the called computations.
-        CHECK_EQ(callsite.instruction()->opcode(), HloOpcode::kAsyncStart);
-        enqueue_called_computations(callsite, next_stream_id);
+        // Special logic for explicit stream annotations.
+        std::optional<ExecutionStreamId> optional_stream_id = std::nullopt;
+        auto instruction = callsite.instruction();
+        auto it = instruction->frontend_attributes().map().find(
+            kXlaStreamAnnotationAttr);
+        if (it != instruction->frontend_attributes().map().end()) {
+          int stream_id;
+          CHECK(absl::SimpleAtoi(it->second, &stream_id));
+          optional_stream_id = ExecutionStreamId(stream_id);
+        }
+        enqueue_called_computations(
+            callsite, optional_stream_id.value_or(next_stream_id));
         assign_async_execution_streams(callsite.instruction(),
-                                       pending.stream_id);
+                                       pending.stream_id, optional_stream_id);
       } else {
         // Synchronous calls will result in the called computations being
         // invoked using the same `ExecutionStreamId`.


### PR DESCRIPTION
This PR picks up the stream annotation frontend attribute on async methods and assigns the matching ExecutionStreamId.

This PR is another part of breaking up PR #17982.