### PR TITLE
[ROCm] Do not use fast approximation for exp and log

### DIFF
--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -99,7 +99,12 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     // Elementwise ops.
     case HloOpcode::kExp:
     case HloOpcode::kLog:
-      return LowPrecisionType() == BF16;
+      if (LowPrecisionType() == BF16) {
+        auto* cuda_compute_capability =
+            std::get_if<se::CudaComputeCapability>(&compute_capability_);
+        return cuda_compute_capability != nullptr;
+      }
+      return false;
     case HloOpcode::kAdd:
     case HloOpcode::kMultiply:
     case HloOpcode::kSubtract: {

--- a/xla/service/gpu/gpu_float_support_test.cc
+++ b/xla/service/gpu/gpu_float_support_test.cc
@@ -332,5 +332,26 @@ ENTRY main {
   EXPECT_TRUE(Normalize(module_with_unsupported_reducer.get(), cc, BF16, F32));
 }
 
+TEST_F(FloatSupportTest, BF16LogAndExpOnRocmIsNormalized) {
+  auto cc = se::RocmComputeCapability();
+  constexpr absl::string_view kHloModule = R"(
+HloModule module
+
+ENTRY main {
+      p0 = bf16[4] parameter(0)
+      ROOT r = bf16[4] $0(p0)
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_log,
+                          ParseAndReturnVerifiedModule(
+                              absl::Substitute(kHloModule, "log")));
+  EXPECT_TRUE(Normalize(module_log.get(), cc, BF16, F32));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_exp,
+                          ParseAndReturnVerifiedModule(
+                              absl::Substitute(kHloModule, "exponential")));
+  EXPECT_TRUE(Normalize(module_exp.get(), cc, BF16, F32));
+}
+
 }  // namespace
 }  // namespace xla::gpu


### PR DESCRIPTION
Error started occurring from this commit for exp https://github.com/openxla/xla/commit/6e9eefeec077f49c2b22bfeee8da537ed8517b22 (originally introduced here https://github.com/openxla/xla/commit/9b19353a30821fb990afa456a2a5e7fae71e9afc#diff-61ab646c9c3b8b0fc5ed1e9a62f535e9df5843adddd071250343f3bec48eacb6) and from this one https://github.com/openxla/xla/commit/53d533845f3c97d08a49e3d8589ec98c745ac09e for log.

Trying to compile following MLIR code:
```
HloModule module

ENTRY main {
      p0 = bf16[4] parameter(0)
      ROOT exp = bf16[4] exp(p0)
}
```
would result in:
```
UNKNOWN: <unknown>:0: error: loc(callsite("wrapped_exponential" at "wrapped_exponential")): failed to legalize operation 'math.exp'
<unknown>:0: note: loc("wrapped_exponential"): called from
<unknown>:0: note: loc(callsite("wrapped_exponential" at "wrapped_exponential")): see current operation: %7 = "math.exp"(%6) <{fastmath = #arith.fastmath<afn>}> : (bf16) -> bf16
```

