### PR TITLE
[ROCm] Fix build break with gcc due to `53417984`

### DIFF
--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -342,7 +342,9 @@ class DeviceDescription {
   }
 
   // Returns the number of threads per warp/wavefront.
-  const int64_t &threads_per_warp() const { return threads_per_warp_; }
+  constexpr int64_t threads_per_warp() const  {
+      return threads_per_warp_;
+  }
 
   // Returns the limit on the total number of registers per core.
   const int64_t &registers_per_core_limit() const {


### PR DESCRIPTION
@majnemer This fixes build break on gcc due to https://github.com/openxla/xla/commit/53417984a9baf80ac9b677f13e628867298f8eae
