### PR TITLE
[XLA:GPU] Only allow horizontal loop fusion for default memory space

### DIFF
--- a/xla/service/gpu/transforms/horizontal_loop_fusion_test.cc
+++ b/xla/service/gpu/transforms/horizontal_loop_fusion_test.cc
@@ -189,6 +189,23 @@ TEST_F(HorizontalLoopFusionTest, NegativeTestForIncompatibleTypes) {
       HorizontalLoopFusion{device_description_}.Run(module.get()).value());
 }
 
+TEST_F(HorizontalLoopFusionTest, NegativeTestForDifferentMemorySpace) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+ HloModule NegativeTestForIncompatibleSpaces
+ ENTRY main {
+   arg0 = f32[1]{0} parameter(0)
+   arg1 = f32[1]{0:S(5)} parameter(1)
+   cp1 = f32[1]{0} copy(arg0)
+   cp2 = f32[1]{0:S(5)} copy(arg1)
+   ROOT tuple_out = (f32[1]{0}, f32[1]{0:S(5)}) tuple(cp1, cp2)
+ }
+)")
+                    .value();
+
+  EXPECT_FALSE(
+      HorizontalLoopFusion{device_description_}.Run(module.get()).value());
+}
+
 TEST_F(HorizontalLoopFusionTest, FusingIntoKLoopAndKInputTogether) {
   auto module = ParseAndReturnVerifiedModule(R"(
  HloModule FusingIntoKLoopAndKInputTogether


### PR DESCRIPTION
Horizontal loop fusion currently breaks weight offloading in JAX if it fuses a host-memory copy and device-memory copy because such a fusion results in a same-space buffer, triggering memory space assertions in JAX.

This PR avoids any horizontal loop fusions for host-memory (even though in practice, some fusions would work even in host space).