### PR TITLE
Add support for emitting a kCall from an async instruction

### DIFF
--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1295,18 +1295,19 @@ ENTRY entry {
 TEST_F(GpuCompilerTest, StreamAnnotationThunkTest) {
   const absl::string_view hlo_text = R"(
   HloModule composite
-%f.3 (Arg_0.4: f32[32,32], Arg_1.5: f32[32,32]) -> f32[32,32] {
-  %Arg_1.5 = f32[32,32]{1,0} parameter(1), metadata={op_name="jit(h)/jit(main)/pjit" scheduling_name="Arg_1.5"}
-  %Arg_0.4 = f32[32,32]{1,0} parameter(0), metadata={op_name="jit(h)/jit(main)/pjit" scheduling_name="Arg_0.4"}
-  %custom-call.1 = (f32[32,32]{1,0}, s8[8192]{0}) custom-call(f32[32,32]{1,0} %Arg_0.4, f32[32,32]{1,0} %Arg_1.5), custom_call_target="__cublas$gemm", metadata={op_name="jit(h)/jit(main)/jit(f)/dot_general" source_file="/mounted/scheduling-example/tiny.py" source_line=17 scheduling_name="custom-call.1"}, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"gemm_backend_config":{"alpha_real":1,"alpha_imag":0,"beta":0,"dot_dimension_numbers":{"lhs_contracting_dimensions":["1"],"rhs_contracting_dimensions":["0"],"lhs_batch_dimensions":[],"rhs_batch_dimensions":[]},"precision_config":{"operand_precision":["DEFAULT","DEFAULT"],"algorithm":"ALG_UNSET"},"epilogue":"DEFAULT","damax_output":false,"lhs_stride":"1024","rhs_stride":"1024","grad_x":false,"grad_y":false},"force_earliest_schedule":false}
-  ROOT %get-tuple-element = f32[32,32]{1,0} get-tuple-element((f32[32,32]{1,0}, s8[8192]{0}) %custom-call.1), index=0, metadata={op_name="jit(h)/jit(main)/jit(f)/dot_general" source_file="/mounted/scheduling-example/tiny.py" source_line=17 scheduling_name="get-tuple-element"}
+gemm () -> f32[32,32] {
+  a = f32[32,32]{1,0} parameter(0)
+  b = f32[32,32]{1,0} parameter(1)
+  c = (f32[32,32]{1,0}, s8[8192]{0}) custom-call(b, a), custom_call_target="__cublas$gemm",
+    backend_config={"gemm_backend_config":{"dot_dimension_numbers":{"lhs_contracting_dimensions":["1"],"rhs_contracting_dimensions":["0"]}}}
+  ROOT %get-tuple-element = f32[32,32]{1,0} get-tuple-element(c), index=0
 }, execution_thread="explicit"
 
-ENTRY %main.8 (Arg_0.1.0: f32[32,32], Arg_1.2.0: f32[32,32]) -> f32[32,32] {
-  %Arg_1.2.0 = f32[32,32]{1,0} parameter(1), metadata={op_name="b" scheduling_name="Arg_1.2.0"}
-  %Arg_0.1.0 = f32[32,32]{1,0} parameter(0), metadata={op_name="a" scheduling_name="Arg_0.1.0"}
-  %call-start = ((f32[32,32]{1,0}, f32[32,32]{1,0}), f32[32,32]{1,0}) call-start(f32[32,32]{1,0} %Arg_0.1.0, f32[32,32]{1,0} %Arg_1.2.0), async_execution_thread="explicit", to_apply=%f.3, frontend_attributes={_xla_stream_annotation="1"}, metadata={scheduling_name="call-start"}
-  ROOT %call-done = f32[32,32]{1,0} call-done(((f32[32,32]{1,0}, f32[32,32]{1,0}), f32[32,32]{1,0}) %call-start), frontend_attributes={_xla_stream_annotation="1"}, metadata={scheduling_name="call-done"}, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false}
+ENTRY main () -> f32[32,32] {
+  a = f32[32,32]{1,0} parameter(1)
+  b = f32[32,32]{1,0} parameter(0)
+  %call-start = ((f32[32,32]{1,0}, f32[32,32]{1,0}), f32[32,32]{1,0}) call-start(b, a), to_apply=gemm, frontend_attributes={_xla_stream_annotation="1"}
+  ROOT %call-done = f32[32,32]{1,0} call-done(%call-start), frontend_attributes={_xla_stream_annotation="1"}
 })";
   auto module = ParseAndReturnVerifiedModule(hlo_text).value();
 
@@ -1324,6 +1325,10 @@ ENTRY %main.8 (Arg_0.1.0: f32[32,32], Arg_1.2.0: f32[32,32]) -> f32[32,32] {
   // We expect there to be only 3 thunks:
   // 1) wait 2) a sequential thunk and 3) another wait.
   EXPECT_EQ(gpu_exec->GetThunk().thunks().size(), 3);
+
+  // Check that the waits exist.
+  EXPECT_EQ(gpu_exec->GetThunk().thunks()[0]->kind(), Thunk::kWaitForStreams);
+  EXPECT_EQ(gpu_exec->GetThunk().thunks()[2]->kind(), Thunk::kWaitForStreams);
 
   // The second operation should be a custom call with a specified execution
   // stream id == 1

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1292,22 +1292,36 @@ ENTRY entry {
   }
 }
 
+MATCHER_P(ThunkKindIs, kind, "") {
+  return ExplainMatchResult(::testing::Eq(kind), arg->kind(), result_listener);
+}
+
 TEST_F(GpuCompilerTest, StreamAnnotationThunkTest) {
   const absl::string_view hlo_text = R"(
-  HloModule composite
-gemm () -> f32[32,32] {
-  a = f32[32,32]{1,0} parameter(0)
-  b = f32[32,32]{1,0} parameter(1)
-  c = (f32[32,32]{1,0}, s8[8192]{0}) custom-call(b, a), custom_call_target="__cublas$gemm",
-    backend_config={"gemm_backend_config":{"dot_dimension_numbers":{"lhs_contracting_dimensions":["1"],"rhs_contracting_dimensions":["0"]}}}
-  ROOT %get-tuple-element = f32[32,32]{1,0} get-tuple-element(c), index=0
+HloModule composite
+
+async_call {
+  p0 = f32[32,32] parameter(0)
+  p1 = f32[32,32] parameter(1)
+  gemm = (f32[32,32], s8[8192]) custom-call(p0, p1), custom_call_target="__cublas$gemm",
+    backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],
+      "gemm_backend_config":{"alpha_real":1,"alpha_imag":0,"beta":0,
+      "dot_dimension_numbers":
+        {"lhs_contracting_dimensions":["1"],"rhs_contracting_dimensions":["0"]},
+      "precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},
+      "lhs_stride":"1024","rhs_stride":"1024"}}
+  ROOT get-tuple-element = f32[32,32] get-tuple-element(gemm), index=0
 }, execution_thread="explicit"
 
-ENTRY main () -> f32[32,32] {
-  a = f32[32,32]{1,0} parameter(1)
-  b = f32[32,32]{1,0} parameter(0)
-  %call-start = ((f32[32,32]{1,0}, f32[32,32]{1,0}), f32[32,32]{1,0}) call-start(b, a), to_apply=gemm, frontend_attributes={_xla_stream_annotation="1"}
-  ROOT %call-done = f32[32,32]{1,0} call-done(%call-start), frontend_attributes={_xla_stream_annotation="1"}
+ENTRY main {
+  p0 = f32[32,32] parameter(0)
+  p1 = f32[32,32] parameter(1)
+  call-start = ((f32[32,32], f32[32,32]), f32[32,32]) call-start(p0, p1),
+    async_execution_thread="explicit", to_apply=async_call,
+    frontend_attributes={_xla_stream_annotation="1"}
+  ROOT call-done = f32[32,32]{1,0} call-done(call-start),
+    frontend_attributes={_xla_stream_annotation="1"},
+    backend_config={"operation_queue_id":"0"}
 })";
   auto module = ParseAndReturnVerifiedModule(hlo_text).value();
 
@@ -1322,24 +1336,21 @@ ENTRY main () -> f32[32,32] {
           .value();
   std::unique_ptr<GpuExecutable> gpu_exec(
       static_cast<GpuExecutable*>(executable.release()));
-  // We expect there to be only 3 thunks:
-  // 1) wait 2) a sequential thunk and 3) another wait.
+
   EXPECT_EQ(gpu_exec->GetThunk().thunks().size(), 3);
+  EXPECT_THAT(gpu_exec->GetThunk().thunks(),
+              ::testing::ElementsAre(ThunkKindIs(Thunk::kWaitForStreams),
+                                     ThunkKindIs(Thunk::kSequential),
+                                     ThunkKindIs(Thunk::kWaitForStreams)));
 
-  // Check that the waits exist.
-  EXPECT_EQ(gpu_exec->GetThunk().thunks()[0]->kind(), Thunk::kWaitForStreams);
-  EXPECT_EQ(gpu_exec->GetThunk().thunks()[2]->kind(), Thunk::kWaitForStreams);
-
-  // The second operation should be a custom call with a specified execution
-  // stream id == 1
-  EXPECT_EQ(gpu_exec->GetThunk().thunks()[1]->kind(), Thunk::kSequential);
-  EXPECT_EQ(gpu_exec->GetThunk().thunks()[1]->execution_stream_id(), 1);
-
-  // Within the sequential thunk, there should only be a single custom call
-  // thunk with the same execution stream id.
+  // Within the sequential thunk, there should only be a single gemm
+  // thunk with an explicitly set execution stream id.
   auto sequential_thunk =
       static_cast<SequentialThunk*>(gpu_exec->GetThunk().thunks()[1].get());
-  EXPECT_EQ(sequential_thunk->thunks()[0]->kind(), Thunk::kGemm);
+  EXPECT_EQ(sequential_thunk->thunks().size(), 1);
+  EXPECT_THAT(sequential_thunk->thunks(),
+              ::testing::ElementsAre(ThunkKindIs(Thunk::kGemm)));
+  // Ensure the gemm is run on the explicitly set stream.
   EXPECT_EQ(sequential_thunk->thunks()[0]->execution_stream_id(), 1);
 }
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1511,7 +1511,7 @@ absl::Status IrEmitterUnnested::EmitAsyncComputation(
       ir_emitter_context_->execution_stream_assignment();
   TF_ASSIGN_OR_RETURN(auto stream,
                       stream_assignment.GetSyncExecutionStreamId(wrapped));
-  CHECK(wrapped->called_computations().size() == 1);
+  TF_RET_CHECK(wrapped->called_computations().size() == 1);
   auto computation = wrapped->called_computations().front();
   auto ir_emitter = IrEmitterUnnested::Create(ir_emitter_context_);
   TF_RETURN_IF_ERROR(ir_emitter->EmitHloComputation(computation));
@@ -1520,7 +1520,6 @@ absl::Status IrEmitterUnnested::EmitAsyncComputation(
   for (auto& thunk : thunk_sequence->thunks()) {
     thunk->set_execution_stream_id(stream);
   }
-  thunk_sequence->set_execution_stream_id(stream);
   auto* async_start = Cast<HloAsyncInstruction>(instr);
   TF_ASSIGN_OR_RETURN(
       ExecutionStreamAssignment::AsyncExecutionStreamIds async_streams,

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2578,6 +2578,7 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
         case HloOpcode::kCollectiveBroadcast:
           return EmitNcclAsyncDone(Thunk::kNcclCollectiveBroadcastDone, instr);
         case HloOpcode::kFusion:
+        case HloOpcode::kCall:
         case HloOpcode::kCustomCall: {
           // Wait until the concurrent stream has finished.
           auto* async_done = Cast<HloAsyncInstruction>(instr);
@@ -2647,6 +2648,24 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
               Thunk::ThunkInfo::WithProfileAnnotation(instr),
               streams.destination_stream_id, streams.source_stream_id));
           return EmitFusion(Cast<HloFusionInstruction>(wrapped));
+        }
+        case HloOpcode::kCall: {
+          const ExecutionStreamAssignment& stream_assignment =
+              ir_emitter_context_->execution_stream_assignment();
+          TF_ASSIGN_OR_RETURN(
+              auto stream, stream_assignment.GetSyncExecutionStreamId(wrapped));
+          auto ir_emitter = IrEmitterUnnested::Create(ir_emitter_context_);
+          DCHECK_EQ(wrapped->called_computations().size(), 1);
+          auto computation = wrapped->called_computations().front();
+          TF_RETURN_IF_ERROR(ir_emitter->EmitHloComputation(computation));
+          std::unique_ptr<SequentialThunk> thunk_sequence =
+              ir_emitter->ConsumeThunkSequence();
+          for (auto& thunk : thunk_sequence->thunks()) {
+            thunk->set_execution_stream_id(stream);
+          }
+          thunk_sequence->set_execution_stream_id(stream);
+          AddThunkToThunkSequence(std::move(thunk_sequence));
+          return absl::OkStatus();
         }
         case HloOpcode::kCustomCall: {
           return EmitAsyncCustomCallStart(instr);

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1504,6 +1504,39 @@ absl::Status IrEmitterUnnested::EmitTritonCustomCall(
   return absl::OkStatus();
 }
 
+absl::Status IrEmitterUnnested::EmitAsyncComputation(
+    const HloInstruction* instr) {
+  const HloInstruction* wrapped = instr->async_wrapped_instruction();
+  const ExecutionStreamAssignment& stream_assignment =
+      ir_emitter_context_->execution_stream_assignment();
+  TF_ASSIGN_OR_RETURN(auto stream,
+                      stream_assignment.GetSyncExecutionStreamId(wrapped));
+  CHECK(wrapped->called_computations().size() == 1);
+  auto computation = wrapped->called_computations().front();
+  auto ir_emitter = IrEmitterUnnested::Create(ir_emitter_context_);
+  TF_RETURN_IF_ERROR(ir_emitter->EmitHloComputation(computation));
+  std::unique_ptr<SequentialThunk> thunk_sequence =
+      ir_emitter->ConsumeThunkSequence();
+  for (auto& thunk : thunk_sequence->thunks()) {
+    thunk->set_execution_stream_id(stream);
+  }
+  thunk_sequence->set_execution_stream_id(stream);
+  auto* async_start = Cast<HloAsyncInstruction>(instr);
+  TF_ASSIGN_OR_RETURN(
+      ExecutionStreamAssignment::AsyncExecutionStreamIds async_streams,
+      stream_assignment.GetAsyncExecutionStreamIds(async_start));
+  // We launch the thunk sequence computation on a concurrent stream.
+  // The concurrent stream needs to first wait until the main stream has
+  // finished calculating any values that may be used as input.
+  // We enforce this by inlining a `WaitForStreams` thunk on the main
+  // stream.
+  AddThunkToThunkSequence(std::make_unique<WaitForStreamsThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(instr),
+      async_streams.destination_stream_id, async_streams.source_stream_id));
+  AddThunkToThunkSequence(std::move(thunk_sequence));
+  return absl::OkStatus();
+}
+
 absl::Status IrEmitterUnnested::EmitFusion(const HloFusionInstruction* instr) {
   const se::DeviceDescription& device_info =
       ir_emitter_context_->gpu_device_info();
@@ -2650,35 +2683,7 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
           return EmitFusion(Cast<HloFusionInstruction>(wrapped));
         }
         case HloOpcode::kCall: {
-          const ExecutionStreamAssignment& stream_assignment =
-              ir_emitter_context_->execution_stream_assignment();
-          TF_ASSIGN_OR_RETURN(
-              auto stream, stream_assignment.GetSyncExecutionStreamId(wrapped));
-          auto ir_emitter = IrEmitterUnnested::Create(ir_emitter_context_);
-          DCHECK_EQ(wrapped->called_computations().size(), 1);
-          auto computation = wrapped->called_computations().front();
-          TF_RETURN_IF_ERROR(ir_emitter->EmitHloComputation(computation));
-          std::unique_ptr<SequentialThunk> thunk_sequence =
-              ir_emitter->ConsumeThunkSequence();
-          for (auto& thunk : thunk_sequence->thunks()) {
-            thunk->set_execution_stream_id(stream);
-          }
-          thunk_sequence->set_execution_stream_id(stream);
-          auto* async_start = Cast<HloAsyncInstruction>(instr);
-          TF_ASSIGN_OR_RETURN(
-              ExecutionStreamAssignment::AsyncExecutionStreamIds async_streams,
-              stream_assignment.GetAsyncExecutionStreamIds(async_start));
-          // We launch the thunk sequence computation on a concurrent stream.
-          // The concurrent stream needs to first wait until the main stream has
-          // finished calculating any values that may be used as input.
-          // We enforce this by inlining a `WaitForStreams` thunk on the main
-          // stream.
-          AddThunkToThunkSequence(std::make_unique<WaitForStreamsThunk>(
-              Thunk::ThunkInfo::WithProfileAnnotation(instr),
-              async_streams.destination_stream_id,
-              async_streams.source_stream_id));
-          AddThunkToThunkSequence(std::move(thunk_sequence));
-          return absl::OkStatus();
+          return EmitAsyncComputation(instr);
         }
         case HloOpcode::kCustomCall: {
           return EmitAsyncCustomCallStart(instr);

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -126,6 +126,7 @@ class IrEmitterUnnested : public IrEmitter {
   absl::Status EmitCholeskyThunk(const HloInstruction* instr);
   absl::Status EmitCustomCallThunk(const HloCustomCallInstruction* instr);
   absl::Status EmitFftThunk(const HloFftInstruction* instr);
+  absl::Status EmitAsyncComputation(const HloInstruction* instr);
   absl::Status EmitFusion(const HloFusionInstruction* instr);
   absl::Status EmitCopy(const HloInstruction* instr);
   absl::Status EmitAsyncCustomCallStart(const HloInstruction* instr);


### PR DESCRIPTION
This is the last PR needed to enable the explicit stream annotation feature.

This PR enables the IR emitter for kCall subroutines that are wrapped in async-{start,done} pairs. For start, the instructions in the kCall are converted to a `SequentialThunk`. This thunk and the inner thunks are then annotated with their respective `execution_stream_ids`. (These ids come from #19699) 