### PR TITLE
[XLA:GPU] Re-run the host-offload-legalize pass after CSE

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1023,12 +1023,6 @@ absl::Status RunLayoutAssignmentPasses(
   pipeline.AddPass<SubByteNormalization>(
       SubByteNormalization::SET_ELEMENT_SIZE);
   pipeline.AddPass<OptimizeInputOutputBufferAlias>(true);
-  // Run HostOffloadLegalize before LayoutNormalization to prevent
-  // the creation of invalid transpose/bitcast operations within
-  // host memory offloading segments.
-  pipeline.AddPass<HostOffloadLegalize>(
-      static_cast<int64_t>(stream_executor::MemoryType::kHost),
-      /* after_layout= */ true);
   return pipeline.Run(hlo_module).status();
 }
 
@@ -1652,6 +1646,13 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
 
   // Rewrite GEMMs with broadcasted inputs as strided GEMMs.
   pipeline.AddPass<GemmBroadcastFoldingRewriter>();
+
+  // Run HostOffloadLegalize before LayoutNormalization to prevent
+  // the creation of invalid transpose/bitcast operations within
+  // host memory offloading segments.
+  pipeline.AddPass<HostOffloadLegalize>(
+      static_cast<int64_t>(stream_executor::MemoryType::kHost),
+      /* after_layout= */ true);
 
   pipeline.AddPass<LayoutNormalization>(&NormalizeLayoutForGpuCustomCalls);
 

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1325,6 +1325,40 @@ class PassOrderTest : public GpuCompilerTest {
     CompileModule(config);
   }
 
+  // Fails if any of the passes matching `other_pass_regex` runs before
+  // the first occurence of the pass matching `first_pass_regex`.
+  void VerifyPassRunsBefore(absl::string_view first_pass_regex,
+                            absl::string_view other_pass_regex) {
+    if (!optimized_module_) {
+      CompileModule(GetModuleConfigForTest());
+    }
+    int first_pass_first_run = std::numeric_limits<int>::max();
+    int other_pass_first_run = std::numeric_limits<int>::max();
+    int run_index = 0;
+    for (const HloPassMetadata& pass_metadata :
+         optimized_module_->metadata()->proto().pass_metadata()) {
+      if (RE2::FullMatch(pass_metadata.pass_name(), first_pass_regex)) {
+        VLOG(2) << "Pass " << pass_metadata.pass_name()
+                << " matches first_pass_regex." << std::endl;
+        first_pass_first_run = std::min(first_pass_first_run, run_index);
+      }
+      if (RE2::FullMatch(pass_metadata.pass_name(), other_pass_regex)) {
+        VLOG(2) << "Pass " << pass_metadata.pass_name()
+                << " matches other_pass_regex." << std::endl;
+        other_pass_first_run = std::min(other_pass_first_run, run_index);
+      }
+      ++run_index;
+    }
+
+    EXPECT_NE(first_pass_first_run, std::numeric_limits<int>::max())
+        << "Did not run a pass matching " << first_pass_regex;
+    EXPECT_NE(other_pass_first_run, std::numeric_limits<int>::max())
+        << "Did not run a pass matching " << other_pass_regex;
+    EXPECT_LE(first_pass_first_run, other_pass_first_run)
+        << "A pass matching " << first_pass_regex
+        << " did not run before passes matching " << other_pass_regex;
+  }
+
   // Fails if any of the passes with names matching the regular expression
   // `first_pass_regex` run after any of the passes matching `last_pass_regex`
   // or if none of the executed passes matches `first_pass_regex` or
@@ -1405,6 +1439,15 @@ TEST_F(PassOrderTest, PassesAreRunInCorrectOrder) {
                   /*last_pass_regex=*/"priority-fusion");
   VerifyPassOrder(/*first_pass_regex=*/"layout-assignment",
                   /*last_pass_regex=*/"layout_normalization");
+}
+
+TEST_F(PassOrderTest, OffloadingPassesAreRunInCorrectOrder) {
+  VerifyPassRunsBefore(/*first_pass_regex=*/"host-offload-legalize",
+                       /*other_pass_regex=*/"layout_normalization");
+  auto pass_range =
+      VerifyPassOrder(/*first_pass_regex=*/"host-offload-legalize",
+                      /*last_pass_regex=*/"host-offloader");
+  VerifyNotRunInBetween(pass_range, /*pass_regex=*/"cse");
 }
 
 TEST_F(PassOrderTest, FusionBlockLevelRewriterRunsAfterAllFusionPasses) {

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1405,8 +1405,6 @@ TEST_F(PassOrderTest, PassesAreRunInCorrectOrder) {
                   /*last_pass_regex=*/"priority-fusion");
   VerifyPassOrder(/*first_pass_regex=*/"layout-assignment",
                   /*last_pass_regex=*/"layout_normalization");
-  VerifyPassOrder(/*first_pass_regex=*/"host-offload-legalize",
-                  /*last_pass_regex=*/"layout_normalization");
 }
 
 TEST_F(PassOrderTest, FusionBlockLevelRewriterRunsAfterAllFusionPasses) {

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -553,6 +553,7 @@ lit_test_suite(
             "calling_convention.hlo",
             "dot_bf16.hlo",
             "kernel_reuse.hlo",
+            "offload_scan_output.hlo",
             "pad_to_static.hlo",
             "rng_get_and_update_state.hlo",
             "single_instruction.hlo",

--- a/xla/service/gpu/tests/offload_scan_output.hlo
+++ b/xla/service/gpu/tests/offload_scan_output.hlo
@@ -1,0 +1,59 @@
+// RUN: hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/a100_pcie_80.txtpb --split-input-file | FileCheck --check-prefixes=CHECK %s
+
+HloModule jit_f, entry_computation_layout={()->(f32[4]{0:S(5)}, f32[4]{0})}, allow_spmd_sharding_propagation_to_output={true,true}
+
+// # Simplified from the following Python script.
+//
+// import jax
+// import jax.numpy as jnp
+//
+// p = jax.sharding.SingleDeviceSharding(jax.devices()[0], memory_kind="pinned_host")
+//
+// @jax.jit
+// def f():
+//   def g(_1, _2):
+//     return None, (jax.device_put(jnp.array(1.0), p), jnp.array(2.0))
+//   return jax.lax.scan(g, None, length = 4)[1]
+//
+// print(f()[0].sharding)  # doesn't crash
+
+// Verify that the optimized code allocates one pinned-host buffer.
+// CHECK: f32[4]{0:S(5)} custom-call(), custom_call_target="AllocateBuffer"
+// CHECK-NOT: custom-call(), custom_call_target="AllocateBuffer"
+
+body {
+  body-arg.tuple = (s32[], f32[4]{0}, f32[4]{0}) parameter(0)
+  index.s32 = s32[] get-tuple-element(body-arg.tuple), index=0
+  one.s32 = s32[] constant(1)
+  add.32 = s32[] add(index.s32, one.s32)
+  pinned-host-buffer = f32[4]{0} get-tuple-element(body-arg.tuple), index=1
+  one.f32 = f32[] constant(1)
+  custom-call.9 = f32[] custom-call(one.f32), custom_call_target="annotate_device_placement",
+                                              custom_call_has_side_effect=true,
+                                              frontend_attributes={_xla_buffer_placement="pinned_host"}
+  reshape.22 = f32[1]{0} reshape(custom-call.9)
+  new-pinned-host-buffer = f32[4]{0} dynamic-update-slice(pinned-host-buffer, reshape.22, index.s32)
+  device-buffer = f32[4]{0} get-tuple-element(body-arg.tuple), index=2
+  two.f32 = f32[] constant(2)
+  reshape.27 = f32[1]{0} reshape(two.f32)
+  new-device-buffer = f32[4]{0} dynamic-update-slice(device-buffer, reshape.27, index.s32)
+  ROOT new-body-arg.tuple = (s32[], f32[4]{0}, f32[4]{0}) tuple(add.32, new-pinned-host-buffer, new-device-buffer)
+} // body
+
+cond {
+  cond-arg.tuple = (s32[], f32[4]{0}, f32[4]{0}) parameter(0)
+  cond-index.s32 = s32[] get-tuple-element(cond-arg.tuple), index=0
+  four.s32 = s32[] constant(4)
+  ROOT cond-result = pred[] compare(cond-index.s32, four.s32), direction=LT
+} // cond
+
+ENTRY main {
+  zero.s32 = s32[] constant(0)
+  zero.f32 = f32[] constant(0)
+  empty-buffer = f32[4]{0} broadcast(zero.f32), dimensions={}
+  while.tuple = (s32[], f32[4]{0}, f32[4]{0}) tuple(zero.s32, empty-buffer, empty-buffer)
+  while = (s32[], f32[4]{0}, f32[4]{0}) while(while.tuple), condition=cond, body=body
+  output-pinned-host-buffer = f32[4]{0} get-tuple-element(while), index=1
+  output-device-buffer = f32[4]{0} get-tuple-element(while), index=2
+  ROOT result.tuple = (f32[4]{0}, f32[4]{0}) tuple(output-pinned-host-buffer, output-device-buffer)
+} // main


### PR DESCRIPTION
The CSE pass breaks an important invariant of host-offloader for scan -- each "host
buffer" must have an allocation sequence consisting of a zero constant
and a unique single-user broadcast, but CSE merges two broadcasts
if they have the same shape. This invariant is enforced by host-offload-legalize
pass, but a new CSE pass was recently introduced between
the host-offload-legalize and host-offloader passes (as a side effect of https://github.com/openxla/xla/commit/eab45d5da2fab59de8c02678c2b7b9ae69d9fef8).

This patch re-runs the host-offload-legalize after the offending CSE pass.

Fixes https://github.com/openxla/xla/issues/20373