### PR TITLE
[ds-fusion] Add HandleReducePrecision to algebraic simplifier

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -8233,6 +8233,23 @@ absl::Status AlgebraicSimplifierVisitor::HandleReduce(HloInstruction* hlo) {
   return absl::OkStatus();
 }
 
+absl::Status AlgebraicSimplifierVisitor::HandleReducePrecision(
+    HloInstruction* hlo) {
+  HloReducePrecisionInstruction* reduce_precision =
+      Cast<HloReducePrecisionInstruction>(hlo);
+  PrimitiveType element_type =
+      reduce_precision->operand(0)->shape().element_type();
+  if (reduce_precision->exponent_bits() ==
+          primitive_util::ExponentWidth(element_type) &&
+      reduce_precision->mantissa_bits() + 1 ==
+          primitive_util::SignificandWidth(element_type)) {
+    return ReplaceInstruction(
+        /*old_instruction=*/hlo,
+        /*new_instruction=*/reduce_precision->mutable_operand(0));
+  }
+  return absl::OkStatus();
+}
+
 absl::Status AlgebraicSimplifierVisitor::HandleReduceWindow(
     HloInstruction* hlo) {
   auto* reduce_window = Cast<HloReduceWindowInstruction>(hlo);

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -4137,7 +4137,9 @@ GatherOfPadInfo CheckPaddedDimsForGatherOfPad(
   };
 
   int64_t num_padded_batching_dims = 0;
-  struct GatherOfPadInfo skip_transform{false, false};
+  struct GatherOfPadInfo skip_transform {
+    false, false
+  };
   for (int64_t operand_dim : padded_operand_dims) {
     if (padded_operand_dims_to_output_dims.contains(operand_dim)) {
       continue;
@@ -5939,8 +5941,9 @@ AlgebraicSimplifierVisitor::TryToSinkBroadcastAfterOpWithUniqueNonScalarOperand(
         new_operands.push_back(operand);
       }
     }
-    VLOG(4) << "Sinking broadcast after user:" << "\n  old broadcast: "
-            << broadcast->ToString() << "\n  old user: " << user->ToString();
+    VLOG(4) << "Sinking broadcast after user:"
+            << "\n  old broadcast: " << broadcast->ToString()
+            << "\n  old user: " << user->ToString();
     changed_shape = ShapeUtil::ChangeElementType(operand->shape(),
                                                  user->shape().element_type());
     simplifier_->UpdateLayout(&changed_shape);
@@ -6970,7 +6973,7 @@ absl::Status AlgebraicSimplifierVisitor::HandleSlice(HloInstruction* slice) {
     }
   }
 
-  if (HloInstruction* reduce_window;
+  if (HloInstruction * reduce_window;
       options_.enable_window_reduce_to_reduce_replacement() &&
       hlo_instruction_utils::IsUnstridedSlice(slice) &&
       Match(slice, m::Slice(m::ReduceWindow(&reduce_window).WithOneUse()))) {
@@ -8161,7 +8164,7 @@ absl::Status AlgebraicSimplifierVisitor::HandleReduce(HloInstruction* hlo) {
   // For Computation equal to Min, Max, And or Or, replace Reduce(Broadcast(x),
   // a, Computation()) with Computation(x, a) when x is a scalar and the
   // broadcast is reduced to a scalar.
-  if (HloInstruction* broadcast_arg;
+  if (HloInstruction * broadcast_arg;
       Match(arg, m::Broadcast(m::Op(&broadcast_arg))) &&
       (Match(function->root_instruction(),
              m::MaximumAnyOrder(m::Parameter(0), m::Parameter(1))) ||

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -8239,7 +8239,8 @@ absl::Status AlgebraicSimplifierVisitor::HandleReducePrecision(
       Cast<HloReducePrecisionInstruction>(hlo);
   PrimitiveType element_type =
       reduce_precision->operand(0)->shape().element_type();
-  if (reduce_precision->exponent_bits() ==
+  if (options_.enable_remove_no_op_reduce_precision() &&
+      reduce_precision->exponent_bits() ==
           primitive_util::ExponentWidth(element_type) &&
       reduce_precision->mantissa_bits() + 1 ==
           primitive_util::SignificandWidth(element_type)) {

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
@@ -484,6 +484,8 @@ class AlgebraicSimplifierVisitor : public DfsHloRewriteVisitor {
 
   absl::Status HandleReduce(HloInstruction* hlo) override;
 
+  absl::Status HandleReducePrecision(HloInstruction* hlo) override;
+
   absl::Status HandleReduceWindow(HloInstruction* hlo) override;
 
   absl::Status HandleReverse(HloInstruction* reverse) override;

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
@@ -322,6 +322,16 @@ class AlgebraicSimplifierOptions {
     return enable_broadcast_degenerate_dimension_;
   }
 
+  void set_enable_remove_no_op_reduce_precision(
+      bool enable_remove_no_op_reduce_precision) {
+    enable_remove_no_op_reduce_precision_ =
+        enable_remove_no_op_reduce_precision;
+  }
+
+  bool enable_remove_no_op_reduce_precision() const {
+    return enable_remove_no_op_reduce_precision_;
+  }
+
  private:
   // Metadata struct can be used to store any metadata information encapsulated
   // with the AlgebraicSimplifierOptions that can be later used in an
@@ -364,6 +374,7 @@ class AlgebraicSimplifierOptions {
   bool disable_dynamic_slice_to_slice_conversion_{false};
   bool enable_fast_math_{false};
   bool enable_broadcast_degenerate_dimension_{true};
+  bool enable_remove_no_op_reduce_precision_{false};
   Metadata metadata_;
 };
 

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -12698,7 +12698,7 @@ TEST_F(AlgebraicSimplifierTest,
   })";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
                           ParseAndReturnVerifiedModule(hlo));
-
+  default_options_.set_enable_remove_no_op_reduce_precision(true);
   EXPECT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Parameter()));
@@ -12715,6 +12715,7 @@ TEST_F(AlgebraicSimplifierTest,
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
                           ParseAndReturnVerifiedModule(hlo));
 
+  default_options_.set_enable_remove_no_op_reduce_precision(true);
   EXPECT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
 }
 

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -12688,8 +12688,9 @@ TEST_F(AlgebraicSimplifierTest, TestNew123) {
   EXPECT_FALSE(simplifier.Run(module.get()).value());
 }
 
-TEST_F(AlgebraicSimplifierTest,
-       ReducePrecisionWithSamePrecisionAsOperandShouldBeRemoved) {
+TEST_F(
+    AlgebraicSimplifierTest,
+    ReducePrecisionWithSamePrecisionAsOperandShouldBeRemovedWhenRemoveNoOpReducePrecisionIsSet) {
   const char* hlo = R"(
   HloModule test
   ENTRY main {
@@ -12704,8 +12705,9 @@ TEST_F(AlgebraicSimplifierTest,
               GmockMatch(m::Parameter()));
 }
 
-TEST_F(AlgebraicSimplifierTest,
-       ReducePrecisionWithDifferentPrecisionFromOperandShouldNotBeModified) {
+TEST_F(
+    AlgebraicSimplifierTest,
+    ReducePrecisionWithDifferentPrecisionFromOperandShouldNotBeModifiedByDefault) {
   const char* hlo = R"(
   HloModule test
   ENTRY main {

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -7258,13 +7258,14 @@ TEST_F(AlgebraicSimplifierTest, SliceOfReduceWindowTwoReduceDims) {
   auto root = m->entry_computation()->root_instruction();
   EXPECT_THAT(
       root,
-      GmockMatch(m::Reshape(m::Reduce(m::Parameter(0), m::Constant())
-                                .WithShape(S32, {3})
-                                .WithPredicate([](const HloInstruction* instr) {
-                                  return instr->dimensions() ==
-                                         std::vector<int64_t>({1, 2});
-                                }))
-                     .WithShape(S32, {3, 1, 1})));
+      GmockMatch(
+          m::Reshape(
+              m::Reduce(m::Parameter(0), m::Constant())
+                  .WithShape(S32, {3})
+                  .WithPredicate([](const HloInstruction* instr) {
+                    return instr->dimensions() == std::vector<int64_t>({1, 2});
+                  }))
+              .WithShape(S32, {3, 1, 1})));
 }
 
 TEST_F(AlgebraicSimplifierTest, ConcatToBroadcast) {
@@ -11626,12 +11627,13 @@ TEST_F(AlgebraicSimplifierTest, TransposeOfBroadcast) {
   EXPECT_TRUE(
       RunHloPass(AlgebraicSimplifier(default_options_), m.get()).value());
   SCOPED_TRACE(m->ToString());
-  EXPECT_THAT(m->entry_computation()->root_instruction(),
-              GmockMatch(m::Broadcast(m::Parameter(0))
-                             .WithPredicate([](const HloInstruction* instr) {
-                               return instr->dimensions() ==
-                                      std::vector<int64_t>({0, 3});
-                             })));
+  EXPECT_THAT(
+      m->entry_computation()->root_instruction(),
+      GmockMatch(
+          m::Broadcast(m::Parameter(0))
+              .WithPredicate([](const HloInstruction* instr) {
+                return instr->dimensions() == std::vector<int64_t>({0, 3});
+              })));
 }
 
 TEST_F(AlgebraicSimplifierTest, TransposeBitcastOfBroadcast) {
@@ -11647,12 +11649,13 @@ TEST_F(AlgebraicSimplifierTest, TransposeBitcastOfBroadcast) {
   options.set_is_layout_sensitive(true);
   EXPECT_TRUE(RunHloPass(AlgebraicSimplifier(options), m.get()).value());
   SCOPED_TRACE(m->ToString());
-  EXPECT_THAT(m->entry_computation()->root_instruction(),
-              GmockMatch(m::Broadcast(m::Parameter(0))
-                             .WithPredicate([](const HloInstruction* instr) {
-                               return instr->dimensions() ==
-                                      std::vector<int64_t>({0, 3});
-                             })));
+  EXPECT_THAT(
+      m->entry_computation()->root_instruction(),
+      GmockMatch(
+          m::Broadcast(m::Parameter(0))
+              .WithPredicate([](const HloInstruction* instr) {
+                return instr->dimensions() == std::vector<int64_t>({0, 3});
+              })));
 }
 
 TEST_F(AlgebraicSimplifierTest, TransposeOfBroadcastWithLayoutCheckSkipped) {

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -12689,29 +12689,33 @@ TEST_F(AlgebraicSimplifierTest, TestNew123) {
 }
 
 TEST_F(AlgebraicSimplifierTest,
-       ReducePrecisionWithSameDatatypeShouldBeRemoved) {
+       ReducePrecisionWithSamePrecisionAsOperandShouldBeRemoved) {
   const char* hlo = R"(
   HloModule test
   ENTRY main {
-    param.0 = bf16[2,16,64]{2,1,0} parameter(0)
-    param.1 = bf16[32,64]{1,0} parameter(1)
-    reduce-precision.46 = bf16[32,64]{1,0} reduce-precision(param.1), exponent_bits=8, mantissa_bits=7
-    bitcast.7734 = bf16[2,16,64]{2,1,0} bitcast(reduce-precision.46)
-    multiply.1006 = bf16[2,16,64]{2,1,0} multiply(param.0, bitcast.7734)
+    p0 = bf16[64]{0} parameter(0)
+    ROOT reduce-precision = bf16[64] reduce-precision(p0), exponent_bits=8, mantissa_bits=7
   })";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
                           ParseAndReturnVerifiedModule(hlo));
 
-  TF_ASSERT_OK_AND_ASSIGN(
-      bool changed,
-      RunHloPass(AlgebraicSimplifier(default_options_), module.get()));
-  EXPECT_TRUE(changed);
-  EXPECT_EQ(module->entry_computation()
-                ->root_instruction()
-                ->operand(1)
-                ->operand(0)
-                ->opcode(),
-            HloOpcode::kParameter);
+  EXPECT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Parameter()));
+}
+
+TEST_F(AlgebraicSimplifierTest,
+       ReducePrecisionWithDifferentPrecisionFromOperandShouldNotBeModified) {
+  const char* hlo = R"(
+  HloModule test
+  ENTRY main {
+    p0 = bf16[64]{0} parameter(0)
+    ROOT reduce-precision = bf16[64] reduce-precision(p0), exponent_bits=7, mantissa_bits=8
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
+                          ParseAndReturnVerifiedModule(hlo));
+
+  EXPECT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
 }
 
 }  // namespace

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1676,6 +1676,17 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
     pipeline.AddPass<SimplifyFPConversions>();
   }
 
+  {
+    HloPassPipeline& remove_no_op_reduce_precision_pipeline =
+        pipeline.AddPass<HloPassPipeline>(
+            "remove-no-op-reduce-precision-algebraic-simplifier");
+    AlgebraicSimplifierOptions simplifier_options_{simplifier_options};
+    simplifier_options_.set_enable_remove_no_op_reduce_precision(true);
+    remove_no_op_reduce_precision_pipeline
+        .AddPass<HloPassFix<GpuAlgebraicSimplifier>>(simplifier_options_,
+                                                     gpu_version);
+  }
+
   pipeline.AddPass<HloCSE>(/*is_layout_sensitive=*/true);
 
   pipeline.AddPass<HostMemoryTransferAsyncifier>(

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1677,6 +1677,11 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   }
 
   {
+    // Because of an issue with JAX remat and `SimplifyFPConversions` (see PR:
+    // https://github.com/jax-ml/jax/pull/22244), we can only eliminate the
+    // no-op reduce-precision operations after the last call to
+    // `SimplifyFPConversions`. We are creating a sub-pipeline here because that
+    // allows us to test this order in a unit test.
     HloPassPipeline& remove_no_op_reduce_precision_pipeline =
         pipeline.AddPass<HloPassPipeline>(
             "remove-no-op-reduce-precision-algebraic-simplifier");

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1554,6 +1554,12 @@ TEST_F(PassOrderTest, GemmRewriterRunsAfterDotNormalizer) {
   VerifyNotRunInBetween(pass_range, /*pass_regex=*/"algsimp");
 }
 
+TEST_F(PassOrderTest,
+       ReducePrecisionIsRemovedAfterAllCallsToSimplifyFPConversions) {
+  VerifyPassOrder("simplify-fp-conversions",
+                  "remove-no-op-reduce-precision-algebraic-simplifier");
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1556,6 +1556,13 @@ TEST_F(PassOrderTest, GemmRewriterRunsAfterDotNormalizer) {
 
 TEST_F(PassOrderTest,
        ReducePrecisionIsRemovedAfterAllCallsToSimplifyFPConversions) {
+  // Because of an issue with JAX remat and `SimplifyFPConversions` (see PR:
+  // https://github.com/jax-ml/jax/pull/22244), we can only eliminate the
+  // no-op reduce-precision operations after the last call to
+  // `SimplifyFPConversions`. No-op reduce-precisions are removed within
+  // algebraic simplifier, if the option to remove them is set. In the compiler
+  // pipeline, this is done as a subpipeline, which should be after the last
+  // invocation of SimplifyFPConversions.
   VerifyPassOrder("simplify-fp-conversions",
                   "remove-no-op-reduce-precision-algebraic-simplifier");
 }


### PR DESCRIPTION
When the mantissa and exponent of the reduce-precision instruction are the same as the mantissa and exponent of the primitive type of the operand, then the reduce-precision operation is a no-op.