### PR TITLE
Improve the error message of the host out-of-memory

### DIFF
--- a/xla/stream_executor/integrations/BUILD
+++ b/xla/stream_executor/integrations/BUILD
@@ -44,6 +44,7 @@ cc_library(
     srcs = ["tf_allocator_adapter.cc"],
     hdrs = ["tf_allocator_adapter.h"],
     deps = [
+        "//xla:shape_util",
         "//xla/stream_executor:device_memory",
         "//xla/stream_executor:device_memory_allocator",
         "//xla/stream_executor:memory_allocation",

--- a/xla/stream_executor/integrations/tf_allocator_adapter.cc
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/strings/cord.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "xla/layout.h"
 #include "xla/stream_executor/device_memory.h"
 #include "xla/stream_executor/device_memory_allocator.h"
 #include "xla/stream_executor/platform.h"
@@ -53,7 +54,8 @@ absl::StatusOr<OwningDeviceMemory> TfAllocatorAdapter::Allocate(
     data =
         wrapped_->AllocateRaw(tsl::Allocator::kAllocatorAlignment, size, attrs);
     if (data == nullptr) {
-      return MemoryAllocationError(size);
+      return MemoryAllocationError(
+          size, memory_space == xla::Layout::kHostMemorySpace);
     }
   }
   return OwningDeviceMemory(DeviceMemoryBase(data, size), device_ordinal, this);
@@ -87,9 +89,16 @@ absl::StatusOr<tsl::Allocator *> TfAllocatorAdapter::GetAllocator(
 static constexpr absl::string_view kMemoryAllocationErrorPayloadKey =
     "tf-allocator-allocation-error";
 
-absl::Status MemoryAllocationError(uint64_t size) {
+absl::Status MemoryAllocationError(uint64_t size, bool is_host_mem) {
+  constexpr absl::string_view kHostMemoryExplanation =
+      " Please set the environment variable "
+      "XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB to allocate larger "
+      "host memory than the default 64 GB.";
+
   absl::Status status = absl::ResourceExhaustedError(
-      absl::StrCat("Out of memory while trying to allocate ", size, " bytes."));
+      absl::StrCat("Out of ", (is_host_mem ? "host " : ""),
+                   "memory while trying to allocate ", size, " bytes.",
+                   (is_host_mem ? kHostMemoryExplanation : "")));
   status.SetPayload(kMemoryAllocationErrorPayloadKey, absl::Cord());
   return status;
 }

--- a/xla/stream_executor/integrations/tf_allocator_adapter.h
+++ b/xla/stream_executor/integrations/tf_allocator_adapter.h
@@ -201,7 +201,7 @@ class MultiDeviceAdapter : public DeviceMemoryAllocator {
 
 // Creates a status with a payload indicating an error while allocating `size`
 // bytes of memory.
-absl::Status MemoryAllocationError(uint64_t size);
+absl::Status MemoryAllocationError(uint64_t size, bool is_host_mem);
 
 // Checks whether the status is a memory allocation error.
 bool IsMemoryAllocationError(absl::Status status);


### PR DESCRIPTION
When working on weight offloading and activation offloading for MaxText Llama2-7B on a GH200, a host memory Out of Memory (OOM) error occurred as a large amount of memory was offloaded from the device to host memory. This CL clarifies that it was a host OOM, not a device OOM, and suggests using the environment variable XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB to increase the host memory limit.