### PR TITLE
Arch specific FP8 SDPA test

### DIFF
--- a/xla/service/gpu/tests/gpu_fused_mha_test.cc
+++ b/xla/service/gpu/tests/gpu_fused_mha_test.cc
@@ -1545,7 +1545,8 @@ XLA_TEST_F(FlashAttentionBMMScaleSoftmaxBMMF8,
     custom-call.21.0 = (
         f8e4m3fn[4,4,16,16]{3,1,2,0},
         f32[1,1,1,1]{3,2,1,0},
-        f32[1,1,1,1]{3,2,1,0}
+        f32[1,1,1,1]{3,2,1,0},
+        u8[0]{0}
     ) custom-call(
         convert.18,
         convert.30,
@@ -1723,7 +1724,8 @@ XLA_TEST_F(FlashAttentionBMMScaleSoftmaxBMMF8,
     custom-call.21.0 = (
         f8e4m3fn[4,16,4,16]{3,2,1,0},
         f32[1,1,1,1]{3,2,1,0},
-        f32[1,1,1,1]{3,2,1,0}
+        f32[1,1,1,1]{3,2,1,0},
+        u8[0]{0}
     ) custom-call(
         convert.18,
         convert.30,


### PR DESCRIPTION
The workspace size required by CuDNN are different on Hopper and Blackwell. To make the HLO string arch agnostic, pin the workspace size to 0.