### PR TITLE
[DOC] Add HLO passes unit testing guidelines

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -35,6 +35,8 @@ toc:
     path: /xla/persisted_autotuning
   - title: Shapes and layout
     path: /xla/shapes
+  - title: Testing HLO passes
+    path: /xla/test_hlo_passes
   - title: Tiled layout
     path: /xla/tiled_layout
   - title: Using LSP autocompletion

--- a/docs/test_hlo_passes.md
+++ b/docs/test_hlo_passes.md
@@ -1,0 +1,59 @@
+# Writing unit tests for HLO passes
+
+There are different ways to write unit test for HLO passes.
+This page describes the preferred method to ensure consistency and readability.
+
+## `FileCheck` with `CHECK` lines interleaved
+
+Most HLO passes can be tested using [`FileCheck`](https://llvm.org/docs/CommandGuide/FileCheck.html) tests.
+Interleave  `CHECK`  lines in input HLO module texts, and make sure to use `// CHECK` instead of `; CHECK` uniformly as the `FileCheck` delimiter.
+
+For example, you can re-write the [`fusion cc_test` for a `priotity_fusion` pass](https://github.com/openxla/xla/blob/fe30942a406659bff75399a2a10585bbd1287e07/xla/service/gpu/transforms/priority_fusion_test.cc#L133-L149) as follows:
+
+```
+TEST_F(PriorityFusionTest, FuseBroadcastIntoBitcastConsumers) {
+  absl::string_view kHlo = R"(
+    HloModule test_module
+
+    // CHECK: ENTRY main
+    ENTRY main {
+      // CHECK-NEXT: %[[PARAM:.*]] = f32[96]{0} parameter(0)
+      param_0 = f32[96]{0} parameter(0)
+      broadcast = f32[8,96,128,7]{3,2,1,0} broadcast(param_0), dimensions={1}
+      bitcast.6079.2 = f32[8,24,4,128,7]{4,3,2,1,0} bitcast(broadcast)
+      // CHECK-NEXT: ROOT %{{.*}} fusion(%[[PARAM]]) {{.*}}
+      ROOT transpose.1990.2 = f32[8,24,128,7,4]{4,3,2,1,0} transpose(bitcast.6079.2), dimensions={0,1,3,4,2}
+    }
+  )";
+  RunAndFilecheckHloRewrite(kHlo, std::move(priority_fusion_));
+}
+```
+
+Note: Currently, the codebase has some tests where input HLO module and expected module are written separately. Inlining the `CHECK` lines is the preferred method for future tests. It enables better readability and a similar signature as MLIR based tests [like in `stablehlo_aggressive_folder.mlir`](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir#L31-L39).
+
+## `LIT` runner with
+
+Where feasible, use [`LIT`](https://llvm.org/docs/CommandGuide/lit.html) runner and `hlo-opt`, and place `CHECK` lines locally next to the input IR they correspond to.
+Again, make sure to use `// CHECK` instead of `; CHECK` as the delimiter.
+
+For example, some [GPU tests](https://github.com/openxla/xla/tree/main/xla/service/gpu/tests) can be written as follows:
+
+```
+// RUN: hlo-opt %s --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/%{GPU}.txtpb | FileCheck --check-prefixes=CHECK-%{PTX} %s
+
+HloModule Test, is_scheduled=true
+fused_computation {
+  param_0 = f32[100,200]{1,0} parameter(0)
+  ROOT b.1 = f32[200,100]{1,0} transpose(f32[100,200]{1,0} param_0), dimensions={1,0}
+}
+ENTRY main {
+  a = f32[100, 200]{1,0} parameter(0)
+  // CHECK-PTX:         call void @llvm.nvvm.barrier0
+  // CHECK-GCN:         call void @llvm.amdgcn.s.barrier
+  ROOT wrapped_b = f32[200,100]{1,0} fusion(f32[100,200]{1,0} a), kind=kInput, calls=fused_computation
+}
+```
+
+## (Don't) Graph traversal
+
+Refrain from writing tests that travel leaf nodes of the result graph and match with expected op. These tests are tedious to write, difficult to quickly read, and more difficult to debug and fix. Use one of the above options instead.

--- a/docs/test_hlo_passes.md
+++ b/docs/test_hlo_passes.md
@@ -31,7 +31,7 @@ TEST_F(PriorityFusionTest, FuseBroadcastIntoBitcastConsumers) {
 
 Note: Currently, the codebase has some tests where input HLO module and expected module are written separately. Inlining the `CHECK` lines is the preferred method for future tests. It enables better readability and a similar signature as MLIR based tests [like in `stablehlo_aggressive_folder.mlir`](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir#L31-L39).
 
-## `LIT` runner with
+## `LIT` runner and `hlo-opt`
 
 Where feasible, use [`LIT`](https://llvm.org/docs/CommandGuide/lit.html) runner and `hlo-opt`, and place `CHECK` lines locally next to the input IR they correspond to.
 Again, make sure to use `// CHECK` instead of `; CHECK` as the delimiter.


### PR DESCRIPTION
This PR adds a new developer guide page with notes for writing unit tests for HLO passes.

The content is derived from "Standardize HLO Pass Tools and Testing" proposal docs. 