### PR TITLE
Add yet another candidate for CUDA root

### DIFF
--- a/xla/tsl/platform/default/cuda_root_path.cc
+++ b/xla/tsl/platform/default/cuda_root_path.cc
@@ -58,6 +58,7 @@ std::vector<std::string> CandidateCudaRoots() {
 
   roots.push_back(TF_CUDA_TOOLKIT_PATH);
   roots.emplace_back(std::string("/usr/local/cuda"));
+  roots.emplace_back(std::string("/opt/cuda"));
 
 #if defined(PLATFORM_POSIX) && !defined(__APPLE__)
   Dl_info info;


### PR DESCRIPTION
@ybaturina Take a look at this pull please. It solves the issue with hermetic CUDA builds and CUDA root at `/opt/cuda` on some distros.

CUDA root is quite commonly located at `/opt/cuda`. 

- Some linux distros like Archlinux installs CUDA to `/opt/cuda` \[[1][1]\].
- Additionally, some build systems like CMake uses this candidate for CUDA home as well \[[2][2]\].

[1]: https://wiki.archlinux.org/title/GPGPU#Development_3
[2]: https://github.com/Kitware/CMake/blob/v3.31.3/Modules/FindCUDA.cmake#L853-L858