### PR TITLE
[XLA:GPU] Update cudnn frontend version to 1.9

### DIFF
--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -91,9 +91,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "5f77784dc3ccbca7aca5ea0b5a6e31b95aa85023c5942d22be5fa8dd6c339d81",
-        strip_prefix = "cudnn-frontend-1.8.0",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.8.0.zip"),
+        sha256 = "7be8afebc693f0ef75bbc673ce5c1cf422673e84ea7d53e488201756c046496e",
+        strip_prefix = "cudnn-frontend-1.9.0",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.9.0.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
cudnn frontend 1.9 is released, there are some new features that cudnn flash attention will incorporate, hence this PR.
* flex attention with arbitrary pointwise operations after softmax in cudnn flash attention graph.
* [sequence packing](https://github.com/openxla/xla/pull/20861) enhancement with reduced workspace size.

Release note: https://github.com/NVIDIA/cudnn-frontend/releases/tag/v1.9.0