### PR TITLE
[GPU] Redefine the flag xla_gpu_cudnn_gemm_fusion_level.

### DIFF
--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner_cuda.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner_cuda.cc
@@ -52,10 +52,13 @@ bool GemmFusionAutotunerImpl::AddLibConfigs(
     std::vector<BackendConfig>& configs) {
   // Add cuDNN plans, if available.
   auto cc = std::get<se::CudaComputeCapability>(GetComputeCapability());
-  bool is_hopper = !config_.IsDeviceless() && cc.IsAtLeastHopper();
   bool is_cudnn_enabled =
-      debug_options_.xla_gpu_cudnn_gemm_fusion_level() > 0 && is_hopper &&
-      GetDnnVersionInfoOrDefault(config_.GetExecutor()).major_version() >= 9;
+      !config_.IsDeviceless() &&
+      GetDnnVersionInfoOrDefault(config_.GetExecutor()).major_version() >= 9 &&
+      ((cc.IsAtLeastAmpere() &&
+        debug_options_.xla_gpu_cudnn_gemm_fusion_level() > 1) ||
+       (cc.IsAtLeastBlackwell() &&
+        debug_options_.xla_gpu_cudnn_gemm_fusion_level() > 0));
   if ((IsFusionKind(fusion, kCuDnnFusionKind) && IsAutotuningEnabled()) ||
       (IsFusionKind(fusion, kTritonGemmFusionKind) && is_cudnn_enabled &&
        algorithm_util::IsSupportedByCudnn(

--- a/xla/service/gpu/fusions/BUILD
+++ b/xla/service/gpu/fusions/BUILD
@@ -475,6 +475,7 @@ xla_test(
         "//xla/service/gpu/runtime:thunk",
         "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/service/gpu/transforms:cudnn_fusion_compiler",
+        "//xla/stream_executor:device_description",
         "//xla/stream_executor:dnn",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor:stream_executor_memory_allocator",

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -899,9 +899,8 @@ message DebugOptions {
   // Let GEMM fusion autotuning probe cuDNN as a backend.
   // Current levels:
   // 0: Disabled.
-  // 1: Fusions of GEMM, elementwise, transpose/reshape operations.
-  // 2: + Broadcasts, slicing.
-  // 3: + Nontrivial noncontracting dimension reshapes/transposes.
+  // 1: Enabled on Blackwell+ GPUs.
+  // 2: Enabled on all supported GPUs (Ampere+).
   int32 xla_gpu_cudnn_gemm_fusion_level = 285;
 
   // This instructs the runtime whether to use


### PR DESCRIPTION
The levels defined so far were used for testing/benchmarking. The new definitions will help the architecture-targeted deployment of the feature.

This change also lets the relevant tests run manually on Ampere+ GPUs - previously they were skipped before Hopper.