### PR TITLE
[xla:cpu] Add XLA_VLOG_LINES to oneDNN rewriter passes

### DIFF
--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -1276,6 +1276,8 @@ EMIT_SET_BACKEND_CONFIG_SPECIALIZATION(SetUserScratch,
 absl::StatusOr<bool> OneDnnContractionRewriter::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  XLA_VLOG_LINES(
+      3, "OneDnnContractionRewriter::Run(), before:\n" + module->ToString());    
   OneDnnContractionRewriteVisitor visitor;
   TF_ASSIGN_OR_RETURN(auto result,
                       visitor.RunOnModule(module, execution_threads));
@@ -1284,7 +1286,8 @@ absl::StatusOr<bool> OneDnnContractionRewriter::Run(
                                            compile_threadpool_);
   TF_ASSIGN_OR_RETURN(auto result2,
                       reorder_visitor.RunOnModule(module, execution_threads));
-
+  XLA_VLOG_LINES(3,
+                 "OneDnnContractionRewriter::Run(), after:\n" + module->ToString());
   return {result || result2};
 }
 

--- a/xla/service/cpu/onednn_ops_rewriter.cc
+++ b/xla/service/cpu/onednn_ops_rewriter.cc
@@ -576,8 +576,14 @@ class OneDnnOpsRewriterVisitor : public DfsHloRewriteVisitor {
 absl::StatusOr<bool> OneDnnOpsRewriter::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  XLA_VLOG_LINES(
+      3, "OneDnnOpsRewriter::Run(), before:\n" + module->ToString());
   OneDnnOpsRewriterVisitor visitor;
-  return visitor.RunOnModule(module, execution_threads);
+  TF_ASSIGN_OR_RETURN(auto result,
+                      visitor.RunOnModule(module, execution_threads));
+  XLA_VLOG_LINES(3,
+                 "OneDnnOpsRewriter::Run(), after:\n" + module->ToString());                   
+  return result;
 }
 
 }  // namespace cpu


### PR DESCRIPTION
Enables logging when we set TF_CPP_MAX_VLOG_LEVEL and TF_CPP_MIN_LOG_LEVEL
