### PR TITLE
[GPU] Fix mutex locking of a cuDNN handle.

### DIFF
--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -8570,9 +8570,9 @@ absl::Status CudnnGraph::Execute(Stream& stream,
 
   const CudnnSupport& dnn_support =
       static_cast<CudnnSupport&>(*stream.parent()->AsDnn());
-  RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.execute(
-      dnn_support.cudnn_->GetHandle(stream.parent(), &stream).handle(),
-      tensor_to_ptr_map, workspace.opaque()));
+  auto cudnn = dnn_support.cudnn_->GetHandle(stream.parent(), &stream);
+  RETURN_IF_CUDNN_FRONTEND_ERROR(
+      graph_.execute(cudnn.handle(), tensor_to_ptr_map, workspace.opaque()));
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
The CudnnHandle object containing a mutex has to stay alive while cudnnHandle_t it guards is in use. This brings the use in sync with the other uses in this file. There is no evidence that this caused failures so far, rather prefetching potential problems, therefore no test added.