### PR TITLE
[ROCm] Fix failing dot tests

### DIFF
--- a/xla/tests/dot_operation_test.cc
+++ b/xla/tests/dot_operation_test.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "xla/array3d.h"
 #include "xla/client/local_client.h"
 #include "xla/error_spec.h"
+#include "xla/hlo/builder/lib/arithmetic.h"
 #include "xla/hlo/builder/lib/matrix.h"
 #include "xla/hlo/builder/xla_builder.h"
 #include "xla/hlo/parser/hlo_parser.h"


### PR DESCRIPTION
Issue introduced here https://github.com/openxla/xla/commit/d1f63e2f60ee4ccb73a5e06484f4783eae79420a

The following tests failed to build:
```
//xla/tests:dot_operation_single_threaded_runtime_test_gpu_amd_any FAILED TO BUILD
//xla/tests:dot_operation_test_autotune_disabled_gpu_amd_any    FAILED TO BUILD
//xla/tests:dot_operation_test_gpu_amd_any                      FAILED TO BUILD
```

...with:
```
[2025-01-09T01:19:37.573Z] xla/tests/dot_operation_test.cc:1014:24: error: there are no arguments to ‘CreateScalarMaxComputation’ that depend on a template parameter, so a declaration of ‘CreateScalarMaxComputation’ must be available [-fpermissive]
[2025-01-09T01:19:37.573Z]  1014 |   XlaComputation max = CreateScalarMaxComputation(F32, &builder);
[2025-01-09T01:19:37.573Z]       |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
[2025-01-09T01:19:37.573Z] xla/tests/dot_operation_test.cc:1014:24: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
[2025-01-09T01:19:37.573Z] xla/tests/dot_operation_test.cc: In instantiation of ‘void xla::{anonymous}::DotOperationTestWithCublasLt_F8_ScaledABScaledDWithDAmaxF8_Test<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = ml_dtypes::float8_internal::float8_e4m3fnuz]’:
[2025-01-09T01:19:37.573Z] xla/tests/dot_operation_test.cc:986:1:   required from here
[2025-01-09T01:19:37.573Z] xla/tests/dot_operation_test.cc:1014:50: error: ‘CreateScalarMaxComputation’ was not declared in this scope
[2025-01-09T01:19:37.573Z]  1014 |   XlaComputation max = CreateScalarMaxComputation(F32, &builder);
```

Returning `"xla/hlo/builder/lib/arithmetic.h"` include fixed the problem.

