### PR TITLE
[ROCm] Fix build break due to nvtx_with_cuda_kernels_test

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -445,7 +445,10 @@ xla_test(
     srcs = ["nvtx_with_cuda_kernels_test.cc"],
     backends = ["gpu"],
     copts = tf_profiler_copts() + tsl_copts(),
-    tags = ["no_mac"],
+    tags = [
+        "no_mac",
+        "requires-gpu-nvidia",
+    ],
     deps = [
         ":nvtx_with_cuda_kernels",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
Issue introduced here https://github.com/openxla/xla/commit/e94e29fa61bbd1ce28e60b0f6b8875581b3eacd6

This test should be skipped for ROCm so `requires-gpu-nvidia` tag is necessary 