### PR TITLE
[XLA:GPU] Add support for NCCL ncclCommInitRankScalable API

### DIFF
--- a/xla/backends/cpu/collectives/gloo_collectives.cc
+++ b/xla/backends/cpu/collectives/gloo_collectives.cc
@@ -52,7 +52,7 @@ GlooCollectives::~GlooCollectives() = default;
 
 absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
 GlooCollectives::CreateCommunicators(const CliqueKey& clique_key,
-                                     const std::optional<CliqueId>& clique_id,
+                                     const std::optional<CliqueIds>& clique_ids,
                                      absl::Span<const DeviceRank> ranks,
                                      const Config& config) {
   std::vector<std::unique_ptr<Communicator>> communicators;

--- a/xla/backends/cpu/collectives/gloo_collectives.h
+++ b/xla/backends/cpu/collectives/gloo_collectives.h
@@ -42,7 +42,7 @@ class GlooCollectives : public CpuCollectives {
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
   CreateCommunicators(const CliqueKey& clique_key,
-                      const std::optional<CliqueId>& clique_id,
+                      const std::optional<CliqueIds>& clique_ids,
                       absl::Span<const DeviceRank> ranks,
                       const Config& config) final;
 

--- a/xla/backends/cpu/collectives/in_process_collectives.cc
+++ b/xla/backends/cpu/collectives/in_process_collectives.cc
@@ -33,7 +33,7 @@ namespace xla::cpu {
 
 absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
 InProcessCollectives::CreateCommunicators(
-    const CliqueKey& clique_key, const std::optional<CliqueId>& clique_id,
+    const CliqueKey& clique_key, const std::optional<CliqueIds>& clique_ids,
     absl::Span<const DeviceRank> ranks, const Config& config) {
   std::vector<std::unique_ptr<Communicator>> communicators;
   communicators.reserve(ranks.size());

--- a/xla/backends/cpu/collectives/in_process_collectives.h
+++ b/xla/backends/cpu/collectives/in_process_collectives.h
@@ -38,7 +38,7 @@ class InProcessCollectives : public CpuCollectives {
  public:
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
   CreateCommunicators(const CliqueKey& clique_key,
-                      const std::optional<CliqueId>& clique_id,
+                      const std::optional<CliqueIds>& clique_ids,
                       absl::Span<const DeviceRank> ranks,
                       const Config& config) final;
 };

--- a/xla/backends/cpu/collectives/mpi_collectives.cc
+++ b/xla/backends/cpu/collectives/mpi_collectives.cc
@@ -45,7 +45,7 @@ void MpiCollectives::Finalize() { MPI_Finalize(); }
 
 absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
 MpiCollectives::CreateCommunicators(const CliqueKey& clique_key,
-                                    const std::optional<CliqueId>& clique_id,
+                                    const std::optional<CliqueIds>& clique_ids,
                                     absl::Span<const DeviceRank> ranks,
                                     const Config& config) {
   int flag;

--- a/xla/backends/cpu/collectives/mpi_collectives.h
+++ b/xla/backends/cpu/collectives/mpi_collectives.h
@@ -49,7 +49,7 @@ class MpiCollectives : public CpuCollectives {
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
   CreateCommunicators(const CliqueKey& clique_key,
-                      const std::optional<CliqueId>& clique_id,
+                      const std::optional<CliqueIds>& clique_ids,
                       absl::Span<const DeviceRank> ranks,
                       const Config& config) final;
 

--- a/xla/backends/gpu/collectives/gpu_clique.cc
+++ b/xla/backends/gpu/collectives/gpu_clique.cc
@@ -37,14 +37,14 @@ limitations under the License.
 namespace xla::gpu {
 
 GpuClique::GpuClique(
-    GpuCliqueKey key, std::optional<CliqueId> id,
+    GpuCliqueKey key, std::optional<CliqueIds> ids,
     absl::btree_map<RankId, std::unique_ptr<Communicator>> communicators)
-    : Clique(std::move(communicators)), key_(key), id_(id) {}
+    : Clique(std::move(communicators)), key_(key), ids_(ids) {}
 
 std::string GpuClique::DebugString() const {
   std::string out =
       absl::StrFormat("key: %s; fingerprint(id): %d; size: %d; communicators: ",
-                      key_.ToString(), id_.has_value() ? id_->fingerprint() : 0,
+                      key_.ToString(), ids_.has_value() ? ids_->fingerprint() : 0,
                       num_communicators());
   int32_t cnt = 0;
   ForEachComm([&](RankId rank, Communicator* comm) {
@@ -70,9 +70,9 @@ std::string GpuClique::LockableName::ToString(const GpuClique& clique) {
 }
 
 LockableGpuClique::LockableGpuClique(
-    GpuCliqueKey clique_key, std::optional<CliqueId> clique_id,
+    GpuCliqueKey clique_key, std::optional<CliqueIds> clique_ids,
     absl::btree_map<RankId, std::unique_ptr<Communicator>> communicators)
-    : Lockable(std::move(clique_key), clique_id, std::move(communicators)) {}
+    : Lockable(std::move(clique_key), clique_ids, std::move(communicators)) {}
 
 absl::Status LockableGpuClique::HealthCheck() const {
   return value().HealthCheck();

--- a/xla/backends/gpu/collectives/gpu_clique.h
+++ b/xla/backends/gpu/collectives/gpu_clique.h
@@ -40,7 +40,7 @@ class LockableGpuClique;
 class GpuClique : public Clique {
  public:
   GpuClique(
-      GpuCliqueKey key, std::optional<CliqueId> id,
+      GpuCliqueKey key, std::optional<CliqueIds> ids,
       absl::btree_map<RankId, std::unique_ptr<Communicator>> communicators);
 
   // Returns true if clique is local: all communicators belong to current
@@ -48,7 +48,7 @@ class GpuClique : public Clique {
   bool IsLocal() const { return num_communicators() == key_.devices().size(); }
 
   const GpuCliqueKey& key() const { return key_; }
-  const std::optional<CliqueId>& id() const { return id_; }
+  const std::optional<CliqueIds>& ids() const { return ids_; }
 
   std::string DebugString() const final;
   absl::Status HealthCheck() const final;
@@ -62,7 +62,7 @@ class GpuClique : public Clique {
   };
 
   GpuCliqueKey key_;
-  std::optional<CliqueId> id_;
+  std::optional<CliqueIds> ids_;
 };
 
 // A lockable version of GpuClique that guarantees exclusive access to the
@@ -70,7 +70,7 @@ class GpuClique : public Clique {
 class LockableGpuClique : public Lockable<GpuClique, GpuClique::LockableName> {
  public:
   LockableGpuClique(
-      GpuCliqueKey clique_key, std::optional<CliqueId> clique_id,
+      GpuCliqueKey clique_key, std::optional<CliqueIds> clique_ids,
       absl::btree_map<RankId, std::unique_ptr<Communicator>> communicators);
 
   std::string DebugString() const;

--- a/xla/backends/gpu/collectives/gpu_clique_key.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key.cc
@@ -45,12 +45,13 @@ CollectiveStreamId GetCollectiveStreamId(bool is_async,
 GpuCliqueKey::GpuCliqueKey(
     std::vector<GlobalDeviceId> devices, CollectiveStreamId stream_id,
     AsyncStreamKind stream_kind,
-    std::vector<std::vector<GlobalDeviceId>> participant_groups)
+    std::vector<std::vector<GlobalDeviceId>> participant_groups,
+    GlobalDeviceId root_device)
     : CliqueKey(std::move(devices)),
       stream_id_(stream_id),
       stream_kind_(stream_kind),
       participant_groups_(std::move(participant_groups)),
-      root_device_(-1) {
+      root_device_(root_device) {
   for (std::vector<GlobalDeviceId>& group : participant_groups_) {
     absl::c_sort(group);
   }

--- a/xla/backends/gpu/collectives/gpu_clique_key.h
+++ b/xla/backends/gpu/collectives/gpu_clique_key.h
@@ -58,7 +58,8 @@ class GpuCliqueKey : public CliqueKey {
       std::vector<GlobalDeviceId> devices,
       CollectiveStreamId stream_id = CollectiveStreamId(0),
       AsyncStreamKind stream_kind = AsyncStreamKind::kCollective,
-      std::vector<std::vector<GlobalDeviceId>> participant_groups = {});
+      std::vector<std::vector<GlobalDeviceId>> participant_groups = {},
+      GlobalDeviceId root_device = GlobalDeviceId(-1));
 
   GpuCliqueKey(const GpuCliqueKey&) = default;
   GpuCliqueKey& operator=(const GpuCliqueKey&) = default;

--- a/xla/backends/gpu/collectives/gpu_clique_key.h
+++ b/xla/backends/gpu/collectives/gpu_clique_key.h
@@ -68,9 +68,16 @@ class GpuCliqueKey : public CliqueKey {
 
   CollectiveStreamId stream_id() const;
 
+  // Device generating the unique id for this key
+  GlobalDeviceId root_device() const;
+
   // Returns true if this clique is a subset of `other`: both cliques have the
   // same `stream_id` and all clique devices are part of `other` clique.
   bool IsSubsetOf(const CliqueKey& other) const final;
+
+  // Returns a copy of the key (subkey) with the root device properly set given
+  // nroots and root_seq_id. The subkey is used to generate a NcclCliqueId.
+  GpuCliqueKey GetSubKey(int64_t nroots, int64_t root_seq_id) const;
 
   // Returns the stream kind for this clique key, stream kind will be used to
   // specify what configuration to pass for each type of operation.
@@ -105,6 +112,8 @@ class GpuCliqueKey : public CliqueKey {
   // Having the participating groups as part of the cache key will prevent such
   // situations
   std::vector<std::vector<GlobalDeviceId>> participant_groups_;
+
+  GlobalDeviceId root_device_;
 };
 
 bool operator==(const GpuCliqueKey& a, const GpuCliqueKey& b);

--- a/xla/backends/gpu/collectives/gpu_clique_key.h
+++ b/xla/backends/gpu/collectives/gpu_clique_key.h
@@ -75,9 +75,12 @@ class GpuCliqueKey : public CliqueKey {
   // same `stream_id` and all clique devices are part of `other` clique.
   bool IsSubsetOf(const CliqueKey& other) const final;
 
-  // Returns a copy of the key (subkey) with the root device properly set given
-  // nroots and root_seq_id. The subkey is used to generate a NcclCliqueId.
-  GpuCliqueKey GetSubKey(int64_t nroots, int64_t root_seq_id) const;
+
+  // For multi-root initialization, generate `nroots` copies (subkeys) of the
+  // key each with a different root device. Root devices are distributed evenly
+  // accross the ranks. The subkeys are used to exchange the CliqueIds during
+  // clique initialization.
+  std::vector<GpuCliqueKey> GetSubKeys(int64_t nroots) const;
 
   // Returns the stream kind for this clique key, stream kind will be used to
   // specify what configuration to pass for each type of operation.

--- a/xla/backends/gpu/collectives/gpu_clique_key_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key_test.cc
@@ -37,7 +37,8 @@ static GpuCliqueKey GetBaseCliqueKey() {
                       CollectiveStreamId(0), AsyncStreamKind::kCollective,
                       std::vector<std::vector<GlobalDeviceId>>{
                           {GlobalDeviceId(0), GlobalDeviceId(1)},
-                          {GlobalDeviceId(2), GlobalDeviceId(3)}});
+                          {GlobalDeviceId(2), GlobalDeviceId(3)}},
+                      GlobalDeviceId(0));
 }
 TEST(GpuCliqueKeyTest, IsSubsetOf) {
   GlobalDeviceId id0 = GlobalDeviceId(0);
@@ -53,6 +54,33 @@ TEST(GpuCliqueKeyTest, IsSubsetOf) {
   EXPECT_TRUE(key0.IsSubsetOf(key1));
   EXPECT_FALSE(key0.IsSubsetOf(key2));
   EXPECT_FALSE(key0.IsSubsetOf(key3));
+}
+
+TEST(GpuCliqueKeyTest, GetSubKeys) {
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+  GlobalDeviceId id2 = GlobalDeviceId(2);
+  GlobalDeviceId id3 = GlobalDeviceId(3);
+
+  GpuCliqueKey key({id0, id1, id2, id3}, CollectiveStreamId(1));
+  std::array<int64_t, 4> nroots{1, 2, 3, 4};
+  std::vector<std::vector<GlobalDeviceId>> exp_root_devs{{id0},
+                                                         {id0, id2},
+                                                         {id0, id2, id3},
+                                                         {id0, id1, id2, id3}};
+  for (int ridx = 0; ridx < nroots.size(); ++ridx) {
+    int64_t n = nroots[ridx];
+    const auto& subkeys = key.GetSubKeys(n);
+    EXPECT_EQ(subkeys.size(), exp_root_devs[ridx].size());
+    for (int kidx = 0; kidx < subkeys.size(); ++kidx) {
+      GpuCliqueKey exp_subkey({id0, id1, id2, id3},
+                              CollectiveStreamId(1),
+                              AsyncStreamKind::kCollective,
+                              {},
+                              exp_root_devs[ridx][kidx]);
+      EXPECT_EQ(subkeys[kidx], exp_subkey);
+    }
+  }
 }
 
 TEST(GpuCliqueKeyTest, Compare) {
@@ -148,7 +176,7 @@ TEST(GpuCliqueKeyGettersTest, StreamId) {
 
 TEST(GpuCliqueKeyGetterTest, ToString) {
   EXPECT_EQ(GetBaseCliqueKey().ToString(),
-            "devices=[0,1]; stream=0; groups=[[0,1],[2,3]]");
+            "devices=[0,1]; stream=0; groups=[[0,1],[2,3]]; root_device=0");
 }
 
 TEST(GpuCliqueIdGettersTest, Data) {

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -205,13 +205,30 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
 
   using RendezvousArg = std::pair<DeviceRank, /*synchronized=*/bool>;
 
+  // Check how many roots are needed to initialize the GpuClique
+  static const int64_t nccl_init_rank_per_root_ratio =
+  xla::GetDebugOptionsFromFlags().xla_gpu_nccl_init_max_rank_per_root_ratio();
+  int64_t nranks = clique_key.num_devices();
+  int64_t nroots = 1;
+  // Ceiling division to get number of roots
+  if (nccl_init_rank_per_root_ratio > 0) {
+    nroots = (nranks + nccl_init_rank_per_root_ratio - 1) / nccl_init_rank_per_root_ratio;
+  }
   // Initializes a GpuClique for given device ranks and returns a lock that
   // gives access to clique communicators.
   auto initialize = [&](absl::Span<const RendezvousArg* const> args)
       -> absl::StatusOr<LockableGpuClique::Lock> {
     tsl::profiler::TraceMe trace("InitializeGpuClique");
 
-    TF_ASSIGN_OR_RETURN(auto clique_id, clique_id_callback(clique_key));
+    CliqueIds clique_ids;
+    for (int64_t i = 0; i < nroots; ++i) {
+      GpuCliqueKey subkey = clique_key.GetSubKey(nroots, i);
+      VLOG(3) << absl::StreamFormat(
+          "Get CliqueId for sub clique key %s; nroots=%lld",
+          subkey.ToString(), nroots);
+      TF_ASSIGN_OR_RETURN(auto clique_id, clique_id_callback(subkey));
+      clique_ids.Add(clique_id);
+    }
 
     // Check that all ranks successfully synchronized device activity before
     // trying to instantiate GPU communicators.
@@ -233,13 +250,13 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
 
     VLOG(3) << absl::StreamFormat(
         "Create GPU communicators for clique %s; ranks=[%s]; "
-        "fingerprint(id)=%d",
+        "nroots=%lld; fingerprint(id)=%d",
         clique_key.ToString(), DeviceRanksToString(ranks),
-        clique_id.fingerprint());
+        nroots, clique_ids.fingerprint());
 
     TF_ASSIGN_OR_RETURN(
         std::vector<std::unique_ptr<Communicator>> created_comms,
-        collectives->CreateCommunicators(clique_key, clique_id, ranks, config));
+        collectives->CreateCommunicators(clique_key, clique_ids, ranks, config));
 
     absl::btree_map<RankId, std::unique_ptr<Communicator>> comms;
     for (size_t i = 0; i < ranks.size(); ++i) {
@@ -248,15 +265,15 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
 
     VLOG(3) << absl::StreamFormat(
         "Created GPU communicators for clique %s; ranks=[%s]; "
-        "fingerprint(id)=%d",
+        "nroots=%lld; fingerprint(id)=%d",
         clique_key.ToString(), DeviceRanksToString(ranks),
-        clique_id.fingerprint());
+        nroots, clique_ids.fingerprint());
 
     ProcessGpuCliques& cliques = GetProcessGpuCliques();
     absl::MutexLock lock(&cliques.mu);
 
     // Create a new clique with given clique key and communicators.
-    auto emplaced = cliques.map.try_emplace(clique_key, clique_key, clique_id,
+    auto emplaced = cliques.map.try_emplace(clique_key, clique_key, clique_ids,
                                             std::move(comms));
 
     // We can have a race to create a clique for a given key, the winner

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -221,8 +221,8 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
     tsl::profiler::TraceMe trace("InitializeGpuClique");
 
     CliqueIds clique_ids;
-    for (int64_t i = 0; i < nroots; ++i) {
-      GpuCliqueKey subkey = clique_key.GetSubKey(nroots, i);
+    const auto& subkeys = clique_key.GetSubKeys(nroots);
+    for (const auto& subkey : subkeys) {
       VLOG(3) << absl::StreamFormat(
           "Get CliqueId for sub clique key %s; nroots=%lld",
           subkey.ToString(), nroots);

--- a/xla/backends/gpu/collectives/gpu_collectives_stub.h
+++ b/xla/backends/gpu/collectives/gpu_collectives_stub.h
@@ -50,7 +50,7 @@ class GpuCollectivesStub : public GpuCollectives {
   }
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
-  CreateCommunicators(const CliqueKey&, const std::optional<CliqueId>&,
+  CreateCommunicators(const CliqueKey&, const std::optional<CliqueIds>&,
                       absl::Span<const DeviceRank>,
                       const Collectives::Config&) final {
     return UnimplementedError();

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -114,18 +114,32 @@ static absl::StatusOr<ncclUniqueId> AsNcclUniqueId(const CliqueId& clique_id) {
   return id;
 }
 
+static absl::StatusOr<std::vector<ncclUniqueId>> AsNcclUniqueIds(const CliqueIds& clique_ids) {
+  std::vector<ncclUniqueId> ids;
+  auto ids_vect = clique_ids.data();
+  ids.reserve(ids_vect.size());
+  for (const auto& clique_id : ids_vect) {
+    auto id = AsNcclUniqueId(clique_id);
+    if (!id.ok()) {
+      return id.status();
+    }
+    ids.push_back(id.value());
+  }
+  return ids;
+}
+
 absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
 NcclCollectives::CreateCommunicators(const CliqueKey& clique_key,
-                                     const std::optional<CliqueId>& clique_id,
+                                     const std::optional<CliqueIds>& clique_ids,
                                      absl::Span<const DeviceRank> ranks,
                                      const Collectives::Config& config) {
   // With NCCL backend we rely on host to exchange unique clique id.
-  if (!clique_id.has_value()) {
+  if (!clique_ids.has_value()) {
     return InvalidArgument("CliqueId is required to create NCCL communicators");
   }
 
   VLOG(1) << "Initialize NCCL communicator for " << ranks.size() << " devices"
-          << "; fingerprint(id)=" << clique_id->fingerprint();
+          << "; fingerprint(id)=" << clique_ids->fingerprint();
 
   TF_ASSIGN_OR_RETURN(auto* gpu_config, TryCast(&config));
   ncclConfig_t comm_config = AsNcclConfig(*gpu_config);
@@ -140,14 +154,15 @@ NcclCollectives::CreateCommunicators(const CliqueKey& clique_key,
   for (size_t i = 0; i < ranks.size(); ++i) {
     VLOG(1) << "Initialize NCCL communicator for rank #" << ranks[i].rank
             << " of " << clique_key.num_devices()
-            << "; fingerprint(id)=" << clique_id->fingerprint();
+            << "; fingerprint(id)=" << clique_ids->fingerprint();
     TF_ASSIGN_OR_RETURN(auto* device, TryCast(ranks[i].device));
     auto activate_context = device->stream_executor()->Activate();
 
-    TF_ASSIGN_OR_RETURN(auto nccl_unique_id, AsNcclUniqueId(*clique_id));
-    XLA_NCCL_RETURN_IF_ERROR(ncclCommInitRankConfig(
-        &comm_handles[i], clique_key.num_devices(), nccl_unique_id,
-        ranks[i].rank.value(), &comm_config));
+    TF_ASSIGN_OR_RETURN(auto nccl_unique_ids, AsNcclUniqueIds(*clique_ids));
+    XLA_NCCL_RETURN_IF_ERROR(
+        ncclCommInitRankScalable(&comm_handles[i], clique_key.num_devices(),
+                                 ranks[i].rank.value(), nccl_unique_ids.size(),
+                                 nccl_unique_ids.data(), &comm_config));
   }
   TF_RETURN_IF_ERROR(GroupEnd());
 

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -133,8 +133,8 @@ NcclCollectives::CreateCommunicators(const CliqueKey& clique_key,
                                      const std::optional<CliqueIds>& clique_ids,
                                      absl::Span<const DeviceRank> ranks,
                                      const Collectives::Config& config) {
-  // With NCCL backend we rely on host to exchange unique clique id.
-  if (!clique_ids.has_value()) {
+  // With NCCL backend we rely on host to exchange unique clique ids.
+  if (!clique_ids.has_value() || clique_ids->data().empty()) {
     return InvalidArgument("CliqueId is required to create NCCL communicators");
   }
 
@@ -154,7 +154,8 @@ NcclCollectives::CreateCommunicators(const CliqueKey& clique_key,
   for (size_t i = 0; i < ranks.size(); ++i) {
     VLOG(1) << "Initialize NCCL communicator for rank #" << ranks[i].rank
             << " of " << clique_key.num_devices()
-            << "; fingerprint(id)=" << clique_ids->fingerprint();
+            << "; fingerprint(id)=" << clique_ids->fingerprint()
+            << "; size(id)=" << clique_ids->data().size();
     TF_ASSIGN_OR_RETURN(auto* device, TryCast(ranks[i].device));
     auto activate_context = device->stream_executor()->Activate();
 

--- a/xla/backends/gpu/collectives/nccl_collectives.h
+++ b/xla/backends/gpu/collectives/nccl_collectives.h
@@ -50,7 +50,7 @@ class NcclCollectives : public GpuCollectives {
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
   CreateCommunicators(const CliqueKey& clique_key,
-                      const std::optional<CliqueId>& clique_id,
+                      const std::optional<CliqueIds>& clique_ids,
                       absl::Span<const DeviceRank> ranks,
                       const Collectives::Config& config) final;
 

--- a/xla/core/collectives/clique_id.cc
+++ b/xla/core/collectives/clique_id.cc
@@ -40,4 +40,20 @@ uint32_t CliqueId::fingerprint() const {
 
 size_t CliqueId::size() const { return data_.size(); }
 
+CliqueIds::CliqueIds(const CliqueId& id) { Add(id); }
+
+void CliqueIds::Add(const CliqueId& id) { ids_.push_back(id); }
+
+std::vector<CliqueId> CliqueIds::data() const { return ids_; }
+
+uint32_t CliqueIds::fingerprint() const {
+  absl::crc32c_t crc(0);
+  for (const auto& clique_id : ids_) {
+    crc = absl::ExtendCrc32c(crc, absl::string_view(clique_id.data().data(),
+                                                    clique_id.data().size()));
+  }
+  return static_cast<uint32_t>(crc);
+}
+
+
 }  // namespace xla

--- a/xla/core/collectives/clique_id.cc
+++ b/xla/core/collectives/clique_id.cc
@@ -44,7 +44,7 @@ CliqueIds::CliqueIds(const CliqueId& id) { Add(id); }
 
 void CliqueIds::Add(const CliqueId& id) { ids_.push_back(id); }
 
-std::vector<CliqueId> CliqueIds::data() const { return ids_; }
+absl::Span<const CliqueId> CliqueIds::data() const { return ids_; }
 
 uint32_t CliqueIds::fingerprint() const {
   absl::crc32c_t crc(0);

--- a/xla/core/collectives/clique_id.h
+++ b/xla/core/collectives/clique_id.h
@@ -59,7 +59,8 @@ H AbslHashValue(H h, const CliqueId& id) {
   return H::combine(std::move(h), id.data());
 }
 
-// Collection of CliqueIds
+// An evenly distributed list of root ranks (cliqueIds) to spread communication
+// during clique setup.
 class CliqueIds {
  public:
   CliqueIds() = default;
@@ -68,7 +69,7 @@ class CliqueIds {
 
   void Add(const CliqueId& id);
 
-  std::vector<CliqueId> data() const;
+  absl::Span<const CliqueId> data() const;
 
   uint32_t fingerprint() const;
 

--- a/xla/core/collectives/clique_id.h
+++ b/xla/core/collectives/clique_id.h
@@ -59,6 +59,31 @@ H AbslHashValue(H h, const CliqueId& id) {
   return H::combine(std::move(h), id.data());
 }
 
+// Collection of CliqueIds
+class CliqueIds {
+ public:
+  CliqueIds() = default;
+
+  CliqueIds(const CliqueId& id);
+
+  void Add(const CliqueId& id);
+
+  std::vector<CliqueId> data() const;
+
+  uint32_t fingerprint() const;
+
+  template <typename H>
+  friend H AbslHashValue(H h, const CliqueIds& ids);
+
+ private:
+  std::vector<CliqueId> ids_;
+};
+
+template <typename H>
+H AbslHashValue(H h, const CliqueIds& ids) {
+  return H::combine(std::move(h), ids.data());
+}
+
 }  // namespace xla
 
 #endif  // XLA_CORE_COLLECTIVES_CLIQUE_ID_H_

--- a/xla/core/collectives/collectives.h
+++ b/xla/core/collectives/collectives.h
@@ -71,7 +71,7 @@ class Collectives {
   // Creates communicators for given clique key and id.
   virtual absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
   CreateCommunicators(const CliqueKey& clique_key,
-                      const std::optional<CliqueId>& clique_id,
+                      const std::optional<CliqueIds>& clique_ids,
                       absl::Span<const DeviceRank> ranks,
                       const Config& config) = 0;
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -161,6 +161,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_nccl_user_buffers(false);
   opts.set_xla_gpu_enable_nccl_comm_splitting(true);
   opts.set_xla_gpu_enable_nccl_per_stream_comms(false);
+  opts.set_xla_gpu_nccl_init_max_rank_per_root_ratio(128);
 
   opts.set_xla_gpu_temp_buffer_use_separate_color(false);
   opts.set_xla_gpu_require_exclusive_lock(false);
@@ -1538,6 +1539,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "NCCL collective is executed on. This can lead to higher performance if "
       "NCCL collectives are issued concurrently at the cost of more GPU memory"
       " usage."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_nccl_init_max_rank_per_root_ratio",
+      int64_setter_for(
+          &DebugOptions::set_xla_gpu_nccl_init_max_rank_per_root_ratio),
+      debug_options->xla_gpu_nccl_init_max_rank_per_root_ratio(),
+      "Maximum number of ranks associated with a root rank to initialize a "
+      "NCCL communicator via ncclCommInitRankScalable. "
+      "A value of zero will lead to a single root."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_redzone_scratch_max_megabytes",
       int64_setter_for(

--- a/xla/pjrt/gpu/nccl_id_store.cc
+++ b/xla/pjrt/gpu/nccl_id_store.cc
@@ -49,7 +49,7 @@ absl::StatusOr<CliqueId> NcclIdStore::GetNcclUniqueId(const CliqueKey& key) {
     }
   }
   CliqueId clique_id;
-  int primary_node_id = device_to_node_.at(gpu_key->devices()[0]);
+  int primary_node_id = device_to_node_.at(gpu_key->root_device());
   if (node_id_ == primary_node_id) {
     TF_ASSIGN_OR_RETURN(clique_id,
                         gpu::GpuCollectives::Default()->CreateUniqueCliqueId());

--- a/xla/tsl/cuda/nccl.symbols
+++ b/xla/tsl/cuda/nccl.symbols
@@ -11,6 +11,7 @@ ncclCommGetAsyncError
 ncclCommInitAll
 ncclCommInitRank
 ncclCommInitRankConfig
+ncclCommInitRankScalable
 ncclCommDeregister
 ncclCommRegister
 ncclCommSplit
@@ -42,6 +43,7 @@ pncclCommGetAsyncError
 pncclCommInitAll
 pncclCommInitRank
 pncclCommInitRankConfig
+pncclCommInitRankScalable
 pncclCommDeregister
 pncclCommRegister
 pncclCommSplit

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -863,6 +863,9 @@ message DebugOptions {
   // Enable NCCL per stream communicators.
   bool xla_gpu_enable_nccl_per_stream_comms = 276;
 
+  // Set number of ranks per root rank for NCCL init.
+  int64 xla_gpu_nccl_init_max_rank_per_root_ratio = 277;
+
   // If enabled, uses the libnvptxcompiler library to compile PTX to cuBIN.
   bool xla_gpu_enable_libnvptxcompiler = 269;
 


### PR DESCRIPTION
`ncclCommInitRankScalable` enables the initialization of communicators via multiple roots which improves the init performance at large scale.
The maximum number of ranks associated with a root rank to initialize a NCCL communicator can be tuned via `--xla_gpu_nccl_init_max_rank_per_root_ratio`. Default is 128 ranks per root.
