### PR TITLE
[ROCm] Fix build break due to XNNPACK update and add NCCL_MAX_NCHANNELS to multi gpu tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -295,6 +295,8 @@ build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm --define=using_rocm_hipcc=true
 build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
 build:rocm --repo_env TF_NEED_ROCM=1
+build:rocm --define xnn_enable_avxvnniint8=false
+build:rocm --define xnn_enable_avx512fp16=false
 
 build:rocm_clang_official --config=rocm
 build:rocm_clang_official --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"

--- a/build_tools/rocm/run_xla_multi_gpu.sh
+++ b/build_tools/rocm/run_xla_multi_gpu.sh
@@ -86,6 +86,7 @@ bazel \
     --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
     --action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
     --action_env=XLA_FLAGS=--xla_gpu_enable_llvm_module_compilation_parallelism=true \
+    --action_env=NCCL_MAX_NCHANNELS=1 \
     -- //xla/tests:collective_ops_e2e_test_gpu_amd_any \
        //xla/tests:collective_ops_test_gpu_amd_any \
        //xla/tests:replicated_io_feed_test_gpu_amd_any \

--- a/build_tools/rocm/run_xla_multi_gpu.sh
+++ b/build_tools/rocm/run_xla_multi_gpu.sh
@@ -72,7 +72,8 @@ TAGS_FILTER="${TAGS_FILTER},${UNSUPPORTED_GPU_TAGS// /,}"
 
 bazel \
     test \
-    --define xnn_enable_avxvnniint8=false --define xnn_enable_avx512fp16=false \
+    --define xnn_enable_avxvnniint8=false \
+    --define xnn_enable_avx512fp16=false \
     --config=rocm \
     --build_tag_filters=${TAGS_FILTER} \
     --test_tag_filters=${TAGS_FILTER} \

--- a/build_tools/rocm/run_xla_multi_gpu.sh
+++ b/build_tools/rocm/run_xla_multi_gpu.sh
@@ -72,6 +72,7 @@ TAGS_FILTER="${TAGS_FILTER},${UNSUPPORTED_GPU_TAGS// /,}"
 
 bazel \
     test \
+    --define xnn_enable_avxvnniint8=false --define xnn_enable_avx512fp16=false \
     --config=rocm \
     --build_tag_filters=${TAGS_FILTER} \
     --test_tag_filters=${TAGS_FILTER} \


### PR DESCRIPTION
`NCCL_MAX_NCHANNELS=1`  is necessary for collective ops tests to pass in CI.

As for XNNPACK problem, similar fix has already been done for single-gpu tests -> https://github.com/openxla/xla/pull/20975