### PR TITLE
[GPU] Use single cuDNN handle for graph deserialization.

### DIFF
--- a/xla/backends/gpu/runtime/cudnn_thunk.cc
+++ b/xla/backends/gpu/runtime/cudnn_thunk.cc
@@ -50,7 +50,7 @@ absl::Status CuDnnThunk::Initialize(const InitializeParams& params) {
   absl::Status ret = absl::OkStatus();
   absl::call_once(once_flag_, [&] {
     auto result = params.stream->parent()->AsDnn()->DeserializeGraph(
-        params.src.dnn_compiled_graphs.at(fingerprint_));
+        *params.stream, params.src.dnn_compiled_graphs.at(fingerprint_));
     std::string().swap(fingerprint_);
     if (result.ok()) {
       graph_->swap(*result);

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -8498,11 +8498,11 @@ bool CudnnSupport::DeriveOutputBatchDescriptor(
 #if CUDNN_VERSION >= 8100
 
 absl::StatusOr<std::unique_ptr<dnn::DnnGraph>> CudnnSupport::DeserializeGraph(
-    absl::string_view serialized_data) const {
-  TF_ASSIGN_OR_RETURN(auto cudnn, cudnn_->GetLocalHandle());
+    Stream& stream, absl::string_view serialized_data) const {
+  auto cudnn = cudnn_->GetHandle(stream.parent(), &stream);
   cudnn_frontend::graph::Graph graph;
   RETURN_IF_CUDNN_FRONTEND_ERROR(graph.deserialize(
-      cudnn->handle(),
+      cudnn.handle(),
       std::vector<uint8_t>(serialized_data.data(),
                            serialized_data.data() + serialized_data.size())));
   return std::make_unique<CudnnGraph>(std::move(graph));

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -557,7 +557,7 @@ class CudnnSupport : public dnn::DnnSupport {
 #if CUDNN_VERSION >= 8100
   // Loads complete graph from its serialized representation.
   absl::StatusOr<std::unique_ptr<dnn::DnnGraph>> DeserializeGraph(
-      absl::string_view serialized_data) const override;
+      Stream& stream, absl::string_view serialized_data) const override;
 #endif  // CUDNN_VERSION >= 8100
 
  private:

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1571,7 +1571,7 @@ class DnnSupport {
       std::optional<dnn::TensorDescriptor> dbias_descriptor);
 
   virtual absl::StatusOr<std::unique_ptr<DnnGraph>> DeserializeGraph(
-      absl::string_view) const {
+      Stream& stream, absl::string_view) const {
     return absl::UnimplementedError("Graph support requires cuDNN >= 8.1.");
   };
 


### PR DESCRIPTION
There are two ways to get a cuDNN handle in cuda_dnn.cc. Execution uses a single mutex-locked handle (GetHandle()); compilation uses disposable temporary handles for efficient parallelism (GetLocalHandle()).
Deserialization, which happens during initialization of the GPU executable and is serial, can use either way, but is slightly more efficient when uses the single mutex-locked handle.