### PR TITLE
When a profile is not found for the current device, default to the latest available instead of sm_86.

### DIFF
--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.h
+++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.h
@@ -51,7 +51,7 @@ class GpuHloCostAnalysis : public HloCostAnalysis {
 
   explicit GpuHloCostAnalysis(const Options& options)
       : GpuHloCostAnalysis(options,
-                           HloOpProfiles::Singleton().GetDefaultProfile()) {}
+                           HloOpProfiles::Singleton().GetLatestProfile()) {}
 
   GpuHloCostAnalysis(const Options& options,
                      const se::DeviceDescription& device_info)

--- a/xla/service/gpu/model/hlo_op_profiles.cc
+++ b/xla/service/gpu/model/hlo_op_profiles.cc
@@ -66,7 +66,7 @@ namespace gpu {
   return absl::WrapUnique(new HloOpProfiles(std::move(profiles_map)));
 }
 
-const HloOpProfiles::HloOpProfile& HloOpProfiles::GetLatestProfile() const {
+const HloOpProfiles::HloOpProfile& HloOpProfiles::FindLatestProfile() const {
   auto name_to_version = [](std::string profile_name) {
     int32_t version;
     CHECK(absl::SimpleAtoi(profile_name.substr(/*sm_*/ 3), &version))

--- a/xla/service/gpu/model/hlo_op_profiles.cc
+++ b/xla/service/gpu/model/hlo_op_profiles.cc
@@ -15,11 +15,14 @@ limitations under the License.
 
 #include "xla/service/gpu/model/hlo_op_profiles.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 #include <variant>
 
+#include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"

--- a/xla/service/gpu/model/hlo_op_profiles.h
+++ b/xla/service/gpu/model/hlo_op_profiles.h
@@ -58,7 +58,7 @@ class HloOpProfiles {
   const HloOpProfile& GetLatestProfile() const { return latest_profile_; }
 
  private:
-  HloOpProfiles(ProfilesNestedMap profiles)
+  explicit HloOpProfiles(ProfilesNestedMap profiles)
       : profiles_(std::move(profiles)), latest_profile_(FindLatestProfile()) {}
 
   const HloOpProfile& FindLatestProfile() const;

--- a/xla/service/gpu/model/hlo_op_profiles.h
+++ b/xla/service/gpu/model/hlo_op_profiles.h
@@ -55,12 +55,16 @@ class HloOpProfiles {
   const HloOpProfile& GetProfile(
       const se::DeviceDescription& device_info) const;
 
-  const HloOpProfile& GetLatestProfile() const;
+  const HloOpProfile& GetLatestProfile() const { return latest_profile_; }
 
  private:
-  HloOpProfiles(ProfilesNestedMap profiles) : profiles_(std::move(profiles)) {}
+  HloOpProfiles(ProfilesNestedMap profiles)
+      : profiles_(std::move(profiles)), latest_profile_(FindLatestProfile()) {}
+
+  const HloOpProfile& FindLatestProfile() const;
 
   ProfilesNestedMap profiles_;
+  const HloOpProfile& latest_profile_;
 };
 
 }  // namespace gpu

--- a/xla/service/gpu/model/hlo_op_profiles.h
+++ b/xla/service/gpu/model/hlo_op_profiles.h
@@ -50,22 +50,17 @@ class HloOpProfiles {
 
   // Loads profiles from the given text proto data.
   static std::unique_ptr<HloOpProfiles> Load(
-      absl::string_view profiles_text_proto,
-      absl::string_view default_profile_name);
+      absl::string_view profiles_text_proto);
 
   const HloOpProfile& GetProfile(
       const se::DeviceDescription& device_info) const;
 
-  const HloOpProfile& GetDefaultProfile() const { return default_profile_; }
+  const HloOpProfile& GetLatestProfile() const;
 
  private:
-  HloOpProfiles(ProfilesNestedMap profiles,
-                absl::string_view default_profile_name)
-      : profiles_(std::move(profiles)),
-        default_profile_(profiles_.at(default_profile_name)) {}
+  HloOpProfiles(ProfilesNestedMap profiles) : profiles_(std::move(profiles)) {}
 
   ProfilesNestedMap profiles_;
-  const HloOpProfile& default_profile_;
 };
 
 }  // namespace gpu


### PR DESCRIPTION
Often, when a profile is not available, it is for a new device. So, it makes sense to grab the latest available profile, instead of the somewhat arbitrary sm_86.