### PR TITLE
[ds-fusion] Fix algebraic simplifier error in debug mode.

### DIFF
--- a/xla/hlo/ir/dfs_hlo_visitor_with_default.h
+++ b/xla/hlo/ir/dfs_hlo_visitor_with_default.h
@@ -352,16 +352,16 @@ class DfsHloRewriteVisitor : public DfsHloVisitorWithDefault {
   // Replaces the existing HLO instruction old_instruction, with
   // new_instruction, and marks the optimizer status as changed.
   // Returns the absl::Status representing the result of the replace operation.
-  absl::StatusOr<bool> ReplaceInstruction(
-      HloInstruction* old_instruction, HloInstruction* new_instruction,
-      bool preserve_sharding, bool relay_control_dependency = false) {
+  absl::StatusOr<bool> ReplaceInstruction(HloInstruction* old_instruction,
+                                          HloInstruction* new_instruction,
+                                          bool preserve_sharding) {
     VLOG(3) << "Replacing instruction:" << "\n  old: "
             << old_instruction->ToString()
             << "\n  new: " << new_instruction->ToString();
     absl::StatusOr<bool> changed_or =
         old_instruction->parent()->ReplaceInstruction(
             old_instruction, new_instruction, preserve_sharding,
-            relay_control_dependency);
+            /*relay_control_dependency=*/true);
     if (ABSL_PREDICT_TRUE(changed_or.ok())) {
       changed_ |= changed_or.value();
     }

--- a/xla/hlo/ir/dfs_hlo_visitor_with_default.h
+++ b/xla/hlo/ir/dfs_hlo_visitor_with_default.h
@@ -352,15 +352,16 @@ class DfsHloRewriteVisitor : public DfsHloVisitorWithDefault {
   // Replaces the existing HLO instruction old_instruction, with
   // new_instruction, and marks the optimizer status as changed.
   // Returns the absl::Status representing the result of the replace operation.
-  absl::StatusOr<bool> ReplaceInstruction(HloInstruction* old_instruction,
-                                          HloInstruction* new_instruction,
-                                          bool preserve_sharding) {
+  absl::StatusOr<bool> ReplaceInstruction(
+      HloInstruction* old_instruction, HloInstruction* new_instruction,
+      bool preserve_sharding, bool relay_control_dependency = false) {
     VLOG(3) << "Replacing instruction:" << "\n  old: "
             << old_instruction->ToString()
             << "\n  new: " << new_instruction->ToString();
     absl::StatusOr<bool> changed_or =
         old_instruction->parent()->ReplaceInstruction(
-            old_instruction, new_instruction, preserve_sharding);
+            old_instruction, new_instruction, preserve_sharding,
+            relay_control_dependency);
     if (ABSL_PREDICT_TRUE(changed_or.ok())) {
       changed_ |= changed_or.value();
     }

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -2089,9 +2089,11 @@ absl::Status AlgebraicSimplifierVisitor::HandleConstant(
         LiteralUtil::GetFirstScalarLiteral(constant->literal()));
     HloInstruction* scalar = constant->AddInstruction(
         simplifier_->CreateConstantWithLayoutUpdated(std::move(unique_scalar)));
-    return ReplaceWithNewInstruction(
-        constant,
+    HloInstruction* broadcast = constant->AddInstruction(
         HloInstruction::CreateBroadcast(constant->shape(), scalar, {}));
+    return ReplaceInstruction(constant, broadcast, /*preserve_sharding=*/false,
+                              /*relay_control_dependency=*/true)
+        .status();
   }
 
   // If a literal is an increasing sequence from zero, replace it with an iota.

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -2091,9 +2091,7 @@ absl::Status AlgebraicSimplifierVisitor::HandleConstant(
         simplifier_->CreateConstantWithLayoutUpdated(std::move(unique_scalar)));
     HloInstruction* broadcast = constant->AddInstruction(
         HloInstruction::CreateBroadcast(constant->shape(), scalar, {}));
-    return ReplaceInstruction(constant, broadcast, /*preserve_sharding=*/false,
-                              /*relay_control_dependency=*/true)
-        .status();
+    return ReplaceInstruction(constant, broadcast);
   }
 
   // If a literal is an increasing sequence from zero, replace it with an iota.


### PR DESCRIPTION
This error was observed while trying to land #21375 (which is needed for the ds-fusion work).

This error occurs when there is a constant operation that can be converted into a scalar broadcast, but some other operation is a successor for the constant operation (via control dependency). Such a dependency is not relayed and so the operation is not converted even after the
`ReplaceWithNewInstruction` function call. This causes a runtime error in debug mode testing. Fixing this by relaying this control dependency.