### PR TITLE
[ROCm] Fix gpu_index_test

### DIFF
--- a/xla/service/gpu/tests/gpu_index_test.cc
+++ b/xla/service/gpu/tests/gpu_index_test.cc
@@ -105,7 +105,7 @@ TEST_F(GpuIndexTest, CompatibleUseLinearIndexWithReshapeAndBroadcast) {
                      R"(
 ; CHECK: %[[urem1:.*]] = urem i{{[0-9]*}} %[[linear_index:.*]], 14
 ; CHECK: %[[idx1:.*]] = zext nneg i{{[0-9]*}} %[[urem1]] to i64
-; CHECK: getelementptr inbounds float, ptr{{( addrspace\(1\))?}} %[[alloc:.*]], i64 %[[idx1]]
+; CHECK: getelementptr inbounds{{( nuw)?}} float, ptr{{( addrspace\(1\))?}} %[[alloc:.*]], i64 %[[idx1]]
       )",
                      /*match_optimized_ir=*/true);
 }


### PR DESCRIPTION
For AMDGPUs the expected IR in `CompatibleUseLinearIndexWithReshapeAndBroadcast` test is:
```
%urem = urem i32 %4, 14
%8 = zext nneg i32 %urem to i64
%9 = getelementptr inbounds nuw float, ptr addrspace(1) %.global1, i64 %8
```

Changed the pattern to reflect that.