### PR TITLE
Remove rocdl_path dependency from non rocm builds

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -38,7 +38,6 @@ cc_library(
         "//xla/service/llvm_ir:llvm_type_conversion_util",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:semantic_version",
-        "//xla/tsl/platform:rocm_rocdl_path",
         "//xla/tsl/util:env_var",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",


### PR DESCRIPTION
This PR removes the unwanted dependency to rocm while building for other platforms.