### PR TITLE
Add the hlo verifier before host offloader to check host memory space

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1593,6 +1593,12 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   // also have unsorted update_window_dims.
   pipeline.AddPass<ScatterSimplifier>();
 
+  // Verify the host memory space before the host offloader pass
+  std::unique_ptr<TargetVerifierMetadata> verifier_metadata =
+      std::make_unique<CpuGpuVerifierMetadata>(
+          std::move(HloVerifierOpts{}.VerifyNoHostMemorySpace()));
+  pipeline.AddPass<HloVerifier>(std::move(verifier_metadata));
+
   pipeline.AddPass<HostOffloader>();
 
   TF_RETURN_IF_ERROR(

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1596,7 +1596,7 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   // Verify the host memory space before the host offloader pass
   std::unique_ptr<TargetVerifierMetadata> verifier_metadata =
       std::make_unique<CpuGpuVerifierMetadata>(
-          std::move(HloVerifierOpts{}.VerifyNoHostMemorySpace()));
+          HloVerifierOpts{}.VerifyNoHostMemorySpace());
   pipeline.AddPass<HloVerifier>(std::move(verifier_metadata));
 
   pipeline.AddPass<HostOffloader>();

--- a/xla/service/hlo_verifier.cc
+++ b/xla/service/hlo_verifier.cc
@@ -3112,9 +3112,10 @@ class InstructionVerifier : public DfsHloVisitorWithDefault {
       const Shape& result_shape = instruction->shape();
       const Layout& result_layout = result_shape.layout();
       if (result_layout.memory_space() == Layout::kHostMemorySpace) {
-        return absl::InvalidArgumentError(absl::StrCat(
-            "Instruction shouldn't have the layout of host memory ",
-            "space: ", instruction->ToString()));
+        return Internal(
+            "Instruction shouldn't have the layout of host memory "
+            "space: %s",
+            instruction->ToString());
       }
     }
 

--- a/xla/service/hlo_verifier.h
+++ b/xla/service/hlo_verifier.h
@@ -107,6 +107,11 @@ struct HloVerifierOpts {
     return std::move(*this);
   }
 
+  HloVerifierOpts&& VerifyNoHostMemorySpace() {
+    verify_no_host_memory_space = true;
+    return std::move(*this);
+  }
+
   bool IsLayoutSensitive() const { return layout_sensitive; }
 
   bool AllowMixedPrecision() const { return allow_mixed_precision; }
@@ -157,6 +162,9 @@ struct HloVerifierOpts {
 
   // Check if channel instructions all have unique channel ids.
   bool verify_unique_channel_ids = true;
+
+  // Check if a shape has a host memory space color
+  bool verify_no_host_memory_space = false;
 
   HloPredicate instruction_can_change_layout;
 

--- a/xla/service/hlo_verifier_test.cc
+++ b/xla/service/hlo_verifier_test.cc
@@ -3750,6 +3750,43 @@ TEST_F(HloVerifierTest, RaggedAllToAllWithRank2OffsetsShapes) {
   EXPECT_FALSE(status.ok()) << status;
   EXPECT_THAT(status.message(),
               HasSubstr("RaggedAllToAll operands have different shapes"));
+TEST_F(HloVerifierTest, NoHostMemorySpaceShape) {
+  constexpr absl::string_view hlo_no_host_memory_space_shape = R"(
+HloModule hlo_no_host_memory_space
+ENTRY main {
+  x = f32[] parameter(0)
+  y = f32[] parameter(1)
+  ROOT z = f32[] add(f32[] x, f32[] y)
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnUnverifiedModule(
+                                           hlo_no_host_memory_space_shape));
+
+  auto status = HloVerifier{HloVerifierOpts{}.VerifyNoHostMemorySpace()}
+                    .Run(module.get())
+                    .status();
+  ASSERT_TRUE(status.ok());
+}
+
+TEST_F(HloVerifierTest, NegativeHostMemorySpaceShape) {
+  constexpr absl::string_view hlo_with_host_memory_space_shape = R"(
+HloModule custom_call_bitcast_module
+ENTRY main {
+  param.1 = bf16[8,1,64]{2,0,1} parameter(0)
+  custom-call.2 = bf16[8,1,64]{2,0,1} custom-call(param.1), custom_call_target="MoveToHost"
+  ROOT bitcast.3 = bf16[8,1,64]{2,1,0:S(5)} bitcast(custom-call.2)
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnUnverifiedModule(
+                                           hlo_with_host_memory_space_shape));
+
+  auto status = HloVerifier{HloVerifierOpts{}.VerifyNoHostMemorySpace()}
+                    .Run(module.get())
+                    .status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(
+      status.message(),
+      HasSubstr("Instruction shouldn't have the layout of host memory space"));
 }
 
 }  // namespace

--- a/xla/service/hlo_verifier_test.cc
+++ b/xla/service/hlo_verifier_test.cc
@@ -3750,6 +3750,8 @@ TEST_F(HloVerifierTest, RaggedAllToAllWithRank2OffsetsShapes) {
   EXPECT_FALSE(status.ok()) << status;
   EXPECT_THAT(status.message(),
               HasSubstr("RaggedAllToAll operands have different shapes"));
+}
+
 TEST_F(HloVerifierTest, NoHostMemorySpaceShape) {
   constexpr absl::string_view hlo_no_host_memory_space_shape = R"(
 HloModule hlo_no_host_memory_space


### PR DESCRIPTION
Ensure No Instructions Have Host Memory Space S(5) Before Host Offloader

This change verifies that no instruction possesses host memory space S(5) prior to the host offloader pass. It addresses an issue where the HLO passes before the host offloader could inadvertently leak memory space annotations from the entry computation layout to the graph.

In PR https://github.com/openxla/xla/pull/20426, the layout assignment pass was corrected to prevent instructions from inheriting memory space S(5) from the entry computation layout. This commit further ensures that such annotations are not propagated, keeping host memory space not changed until the host offloader pass.