### PR TITLE
Fix executable creation in HloRunnerPjRt

### DIFF
--- a/xla/service/hlo_runner_pjrt.cc
+++ b/xla/service/hlo_runner_pjrt.cc
@@ -169,6 +169,13 @@ class PjRtWrappedExecutable : public Executable {
       : Executable(hlo_module),
         pjrt_loaded_executable_(pjrt_loaded_executable) {}
 
+  explicit PjRtWrappedExecutable(std::shared_ptr<HloModule> hlo_module,
+                                 std::unique_ptr<PjRtLoadedExecutable>& pjrt_loaded_executable)
+      : Executable(hlo_module)
+      {
+        pjrt_loaded_executable_ = std::move(pjrt_loaded_executable);
+      }
+
   absl::StatusOr<ExecutionOutput> ExecuteAsyncOnStream(
       const ServiceExecutableRunOptions* run_options,
       std::vector<ExecutionInput> arguments) override;
@@ -399,7 +406,7 @@ absl::StatusOr<std::unique_ptr<Executable>> HloRunnerPjRt::CreateExecutable(
   auto executable = std::make_unique<PjRtWrappedExecutable>(
       std::shared_ptr<HloModule>(
           std::move(pjrt_executable->GetHloModules().value()[0])),
-      pjrt_executable.release());
+      pjrt_executable);
 
   return executable;
 }

--- a/xla/service/hlo_runner_pjrt.cc
+++ b/xla/service/hlo_runner_pjrt.cc
@@ -165,16 +165,9 @@ class PjRtWrappedExecutable : public Executable {
  public:
   // Takes ownership of the provided executable.
   explicit PjRtWrappedExecutable(std::shared_ptr<HloModule> hlo_module,
-                                 PjRtLoadedExecutable* pjrt_loaded_executable)
-      : Executable(hlo_module),
-        pjrt_loaded_executable_(pjrt_loaded_executable) {}
-
-  explicit PjRtWrappedExecutable(std::shared_ptr<HloModule> hlo_module,
-                                 std::unique_ptr<PjRtLoadedExecutable>& pjrt_loaded_executable)
-      : Executable(hlo_module)
-      {
-        pjrt_loaded_executable_ = std::move(pjrt_loaded_executable);
-      }
+                                std::unique_ptr<PjRtLoadedExecutable> pjrt_loaded_executable)
+    : Executable(hlo_module),
+      pjrt_loaded_executable_(std::move(pjrt_loaded_executable)) {}
 
   absl::StatusOr<ExecutionOutput> ExecuteAsyncOnStream(
       const ServiceExecutableRunOptions* run_options,
@@ -404,9 +397,9 @@ absl::StatusOr<std::unique_ptr<Executable>> HloRunnerPjRt::CreateExecutable(
                       CreateExecutable(module.get(), compile_options));
 
   auto executable = std::make_unique<PjRtWrappedExecutable>(
-      std::shared_ptr<HloModule>(
+    std::shared_ptr<HloModule>(
           std::move(pjrt_executable->GetHloModules().value()[0])),
-      pjrt_executable);
+    std::move(pjrt_executable));
 
   return executable;
 }


### PR DESCRIPTION
The order of evaluating function arguments is unspecified ([ref](https://en.cppreference.com/w/cpp/language/eval_order)), so pjrt_executable would get released first, leading to seg faults.

This caused the following test failures:
- all_reduce_test
- broadcast_test
- gather_operation_test
- copy_test
- replicated_io_feed_test