### PR TITLE
[XLA:GPU] Add block scaling rewriter pass

### DIFF
--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -432,6 +432,37 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "block_scaling_rewriter",
+    srcs = ["block_scaling_rewriter.cc"],
+    hdrs = ["block_scaling_rewriter.h"],
+    deps = [
+        "//xla:literal",
+        "//xla:shape_util",
+        "//xla/hlo/builder:xla_builder",
+        "//xla/hlo/builder:xla_computation",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:hlo_creation_utils",
+        "//xla/service:op_expander_pass",
+        "//xla/service:shape_inference",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "block_scaling_rewriter_test",
+    srcs = ["block_scaling_rewriter_test.cc"],
+    deps = [
+        ":block_scaling_rewriter",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:xla_internal_test_main",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+cc_library(
     name = "collective_permute_cycle_decomposer",
     srcs = ["collective_permute_cycle_decomposer.cc"],
     hdrs = ["collective_permute_cycle_decomposer.h"],

--- a/xla/service/gpu/transforms/block_scaling_rewriter.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.cc
@@ -1,0 +1,284 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
+
+#include <string>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/hlo/builder/xla_builder.h"
+#include "xla/hlo/builder/xla_computation.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/service/hlo_creation_utils.h"
+#include "xla/service/shape_inference.h"
+#include "xla/literal.h"
+#include "xla/shape_util.h"
+
+namespace xla::gpu {
+namespace {
+
+// Expand builder into a new instruction that will replace the old one.
+absl::StatusOr<HloInstruction*> ExpandInstructionUsingBuilder(
+    XlaBuilder& builder, HloInstruction* old_instruction) {
+  TF_ASSIGN_OR_RETURN(XlaComputation xla_computation, builder.Build());
+  TF_ASSIGN_OR_RETURN(
+      HloComputation * computation,
+      XlaComputationToHloComputation(xla_computation,
+                                     old_instruction->parent()->parent()));
+  return old_instruction->parent()->AddInstruction(HloInstruction::CreateCall(
+      old_instruction->shape(), old_instruction->operands(), computation));
+}
+
+// Determine block size from the shapes.
+absl::StatusOr<int> GetBlockSize(const Shape& quant_shape,
+                                 const Shape& scale_shape) {
+  int rank = quant_shape.rank();
+  TF_RET_CHECK(rank >= 1 && rank == scale_shape.rank());
+  TF_RET_CHECK(quant_shape.dimensions().subspan(0, rank - 1) ==
+               scale_shape.dimensions().subspan(0, rank - 1));
+  int m = quant_shape.dimensions(rank - 1);
+  int n = scale_shape.dimensions(rank - 1);
+  TF_RET_CHECK(m > 0 && n > 0 && m % n == 0);
+  return m / n;
+}
+
+// ----- Quantization
+
+// Build HLO for quantize op.
+absl::StatusOr<XlaOp> BuildQuantize(XlaBuilder& builder,
+                                    const Shape& input_shape,
+                                    const Shape& output_shape) {
+  // Get block size from output shape.
+  const Shape& quant_shape = output_shape.tuple_shapes(0);
+  const Shape& scale_shape = output_shape.tuple_shapes(1);
+  TF_ASSIGN_OR_RETURN(int block_size, GetBlockSize(quant_shape, scale_shape));
+
+  // Reshape input into blocks.
+  std::vector<int64_t> new_dims(scale_shape.dimensions().begin(),
+                                scale_shape.dimensions().end());
+  new_dims.push_back(block_size);
+  XlaOp input = Parameter(&builder, 0, input_shape, "input");
+  XlaOp input_blocks = Reshape(input, new_dims);
+
+  // Calculate AMAX (maximum absolute value per block).
+  XlaBuilder amax_builder("amax");
+  Shape scalar = ShapeUtil::MakeShape(input_shape.element_type(), {});
+  XlaOp out = Max(Abs(Parameter(&amax_builder, 0, scalar, "a")),
+                  Abs(Parameter(&amax_builder, 1, scalar, "b")));
+  TF_ASSIGN_OR_RETURN(XlaComputation amax_comp, amax_builder.Build(out));
+  XlaOp amax = Reduce(input_blocks, ConstantLiteral(&builder, Literal(scalar)),
+                      amax_comp, {scale_shape.rank()});
+
+  // Use EMAX of the quantization type as the denominator.
+  double emax_value =
+      1ll << (primitive_util::OverflowExponent(quant_shape.element_type()) - 1);
+  Literal denominator_literal(scalar);
+  TF_RETURN_IF_ERROR(denominator_literal.SetFromDouble({}, emax_value));
+  XlaOp denominator = ConstantLiteral(&builder, denominator_literal);
+  XlaOp amax_norm = Div(amax, denominator);
+
+  // Calculate scale tensor values and convert back to input type.
+  XlaOp scale = ConvertElementType(amax_norm, scale_shape.element_type());
+  XlaOp scale_cvt = ConvertElementType(scale, scalar.element_type());
+
+  // Broadcast scale to input shape.
+  std::vector<int64_t> broadcast_dims(scale_shape.rank());
+  absl::c_iota(broadcast_dims, 0);
+  XlaOp scale_bc = BroadcastInDim(scale_cvt, new_dims, broadcast_dims);
+  new_dims.pop_back();
+  new_dims.back() *= block_size;
+  XlaOp scale_rs = Reshape(scale_bc, new_dims);
+
+  // Divide input by scale to get quantized result.
+  XlaOp result = Div(input, scale_rs);
+  result = ConvertElementType(result, quant_shape.element_type());
+  return Tuple(&builder, {result, scale});
+}
+
+// Convert quantize custom call to HLO computation.
+absl::StatusOr<HloInstruction*> ExpandQuantizeCustomCall(
+    HloInstruction* instruction) {
+  // Check operand count and output shape.
+  if (instruction->operand_count() != 1) {
+    return InvalidArgument("Incorrect number of operands for quantize op");
+  }
+  if (instruction->shape().tuple_shapes_size() != 2 ||
+      instruction->operand(0)->shape().dimensions() !=
+          instruction->shape().tuple_shapes(0).dimensions()) {
+    return InvalidArgument("Incorrect output shape for quantize op");
+  }
+
+  // Build replacement instruction sequence.
+  XlaBuilder builder(std::string(instruction->name()));
+  TF_RETURN_IF_ERROR(BuildQuantize(builder, instruction->operand(0)->shape(),
+                                   instruction->shape())
+                         .status());
+  return ExpandInstructionUsingBuilder(builder, instruction);
+}
+
+// ----- Dequantization
+
+// Build HLO for dequantize op.
+absl::StatusOr<XlaOp> BuildDequantize(XlaOp input_op, XlaOp scale_op,
+                                      PrimitiveType result_type) {
+  // Get block size from input shapes.
+  XlaBuilder& builder = *input_op.builder();
+  TF_ASSIGN_OR_RETURN(Shape input_shape, builder.GetShape(input_op));
+  TF_ASSIGN_OR_RETURN(Shape scale_shape, builder.GetShape(scale_op));
+  TF_ASSIGN_OR_RETURN(int block_size, GetBlockSize(input_shape, scale_shape));
+
+  // Convert input parameters to the same type.
+  input_op = ConvertElementType(input_op, result_type);
+  scale_op = ConvertElementType(scale_op, result_type);
+
+  // Broadcast scale to input shape.
+  std::vector<int64_t> new_dims(scale_shape.dimensions().begin(),
+                                scale_shape.dimensions().end());
+  new_dims.push_back(block_size);
+  std::vector<int64_t> broadcast_dims(scale_shape.rank());
+  absl::c_iota(broadcast_dims, 0);
+  scale_op = BroadcastInDim(scale_op, new_dims, broadcast_dims);
+  new_dims.pop_back();
+  new_dims.back() *= block_size;
+  scale_op = Reshape(scale_op, new_dims);
+
+  // Multiply input by broadcasted scale.
+  return Mul(input_op, scale_op);
+}
+
+// Convert dequantize custom call to HLO computation.
+absl::StatusOr<HloInstruction*> ExpandDequantizeCustomCall(
+    HloInstruction* instruction) {
+  // Check operand count and output shape.
+  if (instruction->operand_count() != 2) {
+    return InvalidArgument("Incorrect number of operands for dequantize op");
+  }
+  if (instruction->operand(0)->shape().dimensions() !=
+      instruction->shape().dimensions()) {
+    return InvalidArgument("Incorrect output shape for dequantize op");
+  }
+
+  // Build replacement instruction sequence.
+  XlaBuilder builder(std::string(instruction->name()));
+  TF_RETURN_IF_ERROR(
+      BuildDequantize(
+          Parameter(&builder, 0, instruction->operand(0)->shape(), "input"),
+          Parameter(&builder, 1, instruction->operand(1)->shape(), "scale"),
+          instruction->shape().element_type())
+          .status());
+  return ExpandInstructionUsingBuilder(builder, instruction);
+}
+
+// ----- Block scaled dot
+
+// Build HLO for scaled dot op.
+absl::StatusOr<XlaOp> BuildBlockScaledDot(XlaBuilder& builder,
+                                          const HloInstruction* lhs_input,
+                                          const HloInstruction* rhs_input,
+                                          const HloInstruction* lhs_scale,
+                                          const HloInstruction* rhs_scale,
+                                          const DotDimensionNumbers& dnums,
+                                          PrimitiveType result_type) {
+  // Get dot LHS parameter(s).
+  XlaOp lhs_op = Parameter(&builder, 0, lhs_input->shape(), "lhs");
+  XlaOp lhs_scale_op = Parameter(&builder, 2, lhs_scale->shape(), "lhs_scale");
+  TF_ASSIGN_OR_RETURN(lhs_op,
+                      BuildDequantize(lhs_op, lhs_scale_op, result_type));
+
+  // Get dot RHS parameter(s).
+  XlaOp rhs_op = Parameter(&builder, 1, rhs_input->shape(), "rhs");
+  XlaOp rhs_scale_op;
+  if (rhs_scale != nullptr) {
+    rhs_scale_op = Parameter(&builder, 3, rhs_scale->shape(), "rhs_scale");
+    TF_ASSIGN_OR_RETURN(rhs_op,
+                        BuildDequantize(rhs_op, rhs_scale_op, result_type));
+  }
+
+  // Build dot op.
+  return DotGeneral(lhs_op, rhs_op, dnums, /*precision_config=*/nullptr,
+                    /*preferred_element_type=*/result_type);
+}
+
+// Convert scaled dot custom call to HLO computation.
+absl::StatusOr<HloInstruction*> ExpandBlockScaledDotCustomCall(
+    HloInstruction* instruction) {
+  PrimitiveType result_type = instruction->shape().element_type();
+
+  // Check operand count.
+  if (instruction->operand_count() != 3 && instruction->operand_count() != 4) {
+    return InvalidArgument(
+        "Incorrect number of operands for block scaled dot op");
+  }
+
+  // Check output shape.
+  const Shape& lhs_shape = instruction->operand(0)->shape();
+  const Shape& rhs_shape = instruction->operand(1)->shape();
+  DotDimensionNumbers dnums;
+  dnums.add_lhs_contracting_dimensions(lhs_shape.rank() - 1);
+  dnums.add_rhs_contracting_dimensions(rhs_shape.rank() - 1);
+  if (lhs_shape.rank() == 3) {
+    dnums.add_lhs_batch_dimensions(0);
+    dnums.add_rhs_batch_dimensions(0);
+  }
+
+  TF_ASSIGN_OR_RETURN(Shape inferred_shape,
+                      ShapeInference::InferDotOpShape(lhs_shape, rhs_shape,
+                                                      dnums, result_type));
+  if (inferred_shape != instruction->shape()) {
+    return InvalidArgument("Incorrect output shape for block scaled dot op");
+  }
+
+  // Build replacement instruction sequence.
+  XlaBuilder builder(std::string(instruction->name()));
+  auto operands = absl::MakeSpan(instruction->operands());
+  TF_ASSIGN_OR_RETURN(
+      XlaOp block_scaled_dot,
+      BuildBlockScaledDot(builder, operands[0], operands[1], operands[2],
+                          operands.size() == 4 ? operands[3] : nullptr, dnums,
+                          result_type));
+  CHECK(block_scaled_dot.valid());
+  return ExpandInstructionUsingBuilder(builder, instruction);
+}
+
+}  // namespace
+
+bool BlockScalingRewriter::InstructionMatchesPattern(
+    HloInstruction* instruction) {
+  return instruction->opcode() == HloOpcode::kCustomCall &&
+         (instruction->custom_call_target() == kQuantizeCustomCallTarget ||
+          instruction->custom_call_target() == kDequantizeCustomCallTarget ||
+          instruction->custom_call_target() == kBlockScaledDotCustomCallTarget);
+}
+
+absl::StatusOr<HloInstruction*> BlockScalingRewriter::ExpandInstruction(
+    HloInstruction* instruction) {
+  if (instruction->custom_call_target() == kQuantizeCustomCallTarget) {
+    return ExpandQuantizeCustomCall(instruction);
+  }
+  if (instruction->custom_call_target() == kDequantizeCustomCallTarget) {
+    return ExpandDequantizeCustomCall(instruction);
+  }
+  if (instruction->custom_call_target() == kBlockScaledDotCustomCallTarget) {
+    return ExpandBlockScaledDotCustomCall(instruction);
+  }
+  LOG(FATAL) << "Unexpected custom call target: "
+             << instruction->custom_call_target();
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -1,0 +1,87 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_BLOCK_SCALING_REWRITER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_BLOCK_SCALING_REWRITER_H_
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/service/op_expander_pass.h"
+
+namespace xla::gpu {
+
+// This pass converts the block quantize/dequantize operations (represented as
+// custom calls) to XLA graphs or library calls, if available (e.g. cuDNN).
+//
+// Supported operations:
+//
+// 1. "__op$quantize": takes an input tensor of arbitrary size, splits it into
+//    blocks along the minor dimension; for each block calculates the scaling
+//    factor and adjusts the output data, so when these are multiplied together,
+//    the result is roughly equal to the input (minus the rounding error).
+//
+//    Example: f32[8,128] -> (f8e4m3fn[8,128], f8e4m3fn[8,4])
+//
+// 2. "__op$dequantize": takes two tensors as the input - quantized data and
+//    scaling factor (block size is implied). Multiplies them and returns the
+//    result as a wider data type. This is the inverse of the quantize op.
+//
+//    Example: (f8e4m3fn[8,128], f8e4m3fn[8,4]) -> f32[8,128]
+//
+// 3. "__op$block_scaled_dot": performs the dot operation on quantized inputs.
+//    The number of parameters is either 3 (if only LHS input is quantized) or 4
+//    (if both inputs are quantized).
+//    The contracting dimension must be the minor one for both LHS and RHS.
+//    The batch dimension (if present) must be the major one.
+//
+//    Example: (f8e4m3fn[8,128], f8e4m3fn[16,128],
+//              f8e8m0fnu[8,4], f8e8m0fnu[16,4]) -> f32[8,16]
+//
+//    The following HLO:
+//        %res = f32[4,8,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+//               custom_call_target="__op$block_scaled_dot"
+//    is equivalent to:
+//        %lhs_dq = f32[4,8,128] custom-call(%lhs, %lhs_scale),
+//                  custom_call_target="__op$dequantize"
+//        %rhs_dq = f32[4,16,128] custom-call(%rhs, %rhs_scale),
+//                  custom_call_target="__op$dequantize"
+//        %res = f32[4,8,16] dot(%lhs_dq, %rhs_dq),
+//               lhs_batch_dims={0}, lhs_contracting_dims={2},
+//               rhs_batch_dims={0}, rhs_contracting_dims={2}
+//
+class BlockScalingRewriter : public OpExpanderPass {
+ public:
+  BlockScalingRewriter() = default;
+
+  absl::string_view name() const override { return "block-scaling-rewriter"; }
+
+  bool InstructionMatchesPattern(HloInstruction* instruction) override;
+
+  absl::StatusOr<HloInstruction*> ExpandInstruction(
+      HloInstruction* instruction) override;
+
+  // Custom call targets.
+  static constexpr absl::string_view kQuantizeCustomCallTarget =
+      "__op$quantize";
+  static constexpr absl::string_view kDequantizeCustomCallTarget =
+      "__op$dequantize";
+  static constexpr absl::string_view kBlockScaledDotCustomCallTarget =
+      "__op$block_scaled_dot";
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_BLOCK_SCALING_REWRITER_H_

--- a/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
@@ -1,0 +1,175 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
+
+#include "tsl/platform/test.h"
+#include "xla/tests/hlo_test_base.h"
+
+namespace xla::gpu {
+namespace {
+
+using BlockScalingRewriterTest = HloTestBase;
+
+TEST_F(BlockScalingRewriterTest, ExpandQuantizeCustomCall) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %input = f32[10,256] parameter(0)
+  ROOT %result = (f8e4m3fn[10,256], f8e5m2[10,8]) custom-call(%input),
+      custom_call_target="__op$quantize"
+})";
+
+  BlockScalingRewriter pass;
+  RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
+  CHECK: [[input:%.+]] = f32[10,256]{1,0} parameter(0)
+  CHECK: [[blocks:%.+]] = f32[10,8,32]{2,1,0} reshape([[input]])
+  CHECK: [[zero:%.+]] = f32[] constant(0)
+  CHECK: [[amax:%.+]] = f32[10,8]{1,0} reduce([[blocks]], [[zero]]), dimensions={2}, to_apply=%amax
+  CHECK: [[emax:%.+]] = f32[] constant(256)
+  CHECK: [[emax_bc:%.+]] = f32[10,8]{1,0} broadcast([[emax]]), dimensions={}
+  CHECK: [[amax_norm:%.+]] = f32[10,8]{1,0} divide([[amax]], [[emax_bc]])
+  CHECK: [[scale:%.+]] = f8e5m2[10,8]{1,0} convert([[amax_norm]])
+  CHECK: [[scale_cvt:%.+]] = f32[10,8]{1,0} convert([[scale]])
+  CHECK: [[scale_bc:%.+]] = f32[10,8,32]{2,1,0} broadcast([[scale_cvt]]), dimensions={0,1}
+  CHECK: [[scale_rs:%.+]] = f32[10,256]{1,0} reshape([[scale_bc]])
+  CHECK: [[result:%.+]] = f32[10,256]{1,0} divide([[input]], [[scale_rs]])
+  CHECK: [[quantized:%.+]] = f8e4m3fn[10,256]{1,0} convert([[result]])
+  CHECK: ROOT {{.+}} = (f8e4m3fn[10,256]{1,0}, f8e5m2[10,8]{1,0}) tuple([[quantized]], [[scale]])
+})");
+}
+
+TEST_F(BlockScalingRewriterTest, ExpandDequantizeCustomCall) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %input = f8e4m3fn[10,256] parameter(0)
+  %scale = f8e5m2[10,8] parameter(1)
+  ROOT %result = f32[10,256] custom-call(%input, %scale),
+      custom_call_target="__op$dequantize"
+})";
+
+  BlockScalingRewriter pass;
+  RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
+  CHECK: [[input:%.+]] = f8e4m3fn[10,256]{1,0} parameter(0)
+  CHECK: [[input_cvt:%.+]] = f32[10,256]{1,0} convert([[input]])
+  CHECK: [[scale:%.+]] = f8e5m2[10,8]{1,0} parameter(1)
+  CHECK: [[scale_cvt:%.+]] = f32[10,8]{1,0} convert([[scale]])
+  CHECK: [[broadcast:%.+]] = f32[10,8,32]{2,1,0} broadcast([[scale_cvt]]), dimensions={0,1}
+  CHECK: [[reshape:%.+]] = f32[10,256]{1,0} reshape([[broadcast]])
+  CHECK: ROOT {{.+}} = f32[10,256]{1,0} multiply([[input_cvt]], [[reshape]])
+})");
+}
+
+TEST_F(BlockScalingRewriterTest, ExpandBlockScaledDotCustomCall) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[4,16,256] parameter(0)
+  %rhs = f8e4m3fn[4,32,256] parameter(1)
+  %lhs_scale = f8e5m2[4,16,8] parameter(2)
+  %rhs_scale = f8e5m2[4,32,8] parameter(3)
+  ROOT %result = f32[4,16,32] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+
+  BlockScalingRewriter pass;
+  RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
+  CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,1,0} parameter(0)
+  CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,1,0} convert([[lhs_quant]])
+  CHECK: [[lhs_scale:%.+]] = f8e5m2[4,16,8]{2,1,0} parameter(2)
+  CHECK: [[lhs_scale_cvt:%.+]] = f32[4,16,8]{2,1,0} convert([[lhs_scale]])
+  CHECK: [[lhs_scale_bc:%.+]] = f32[4,16,8,32]{3,2,1,0} broadcast([[lhs_scale_cvt]])
+  CHECK: [[lhs_scale_rs:%.+]] = f32[4,16,256]{2,1,0} reshape([[lhs_scale_bc]])
+  CHECK: [[lhs:%.+]] = f32[4,16,256]{2,1,0} multiply([[lhs_quant_cvt]], [[lhs_scale_rs]])
+  CHECK: [[rhs_quant:%.+]] = f8e4m3fn[4,32,256]{2,1,0} parameter(1)
+  CHECK: [[rhs_quant_cvt:%.+]] = f32[4,32,256]{2,1,0} convert([[rhs_quant]])
+  CHECK: [[rhs_scale:%.+]] = f8e5m2[4,32,8]{2,1,0} parameter(3)
+  CHECK: [[rhs_scale_cvt:%.+]] = f32[4,32,8]{2,1,0} convert([[rhs_scale]])
+  CHECK: [[rhs_scale_bc:%.+]] = f32[4,32,8,32]{3,2,1,0} broadcast([[rhs_scale_cvt]])
+  CHECK: [[rhs_scale_rs:%.+]] = f32[4,32,256]{2,1,0} reshape([[rhs_scale_bc]])
+  CHECK: [[rhs:%.+]] = f32[4,32,256]{2,1,0} multiply([[rhs_quant_cvt]], [[rhs_scale_rs]])
+  CHECK: ROOT {{.+}} = f32[4,16,32]{2,1,0} dot([[lhs]], [[rhs]])
+  CHECK-SAME: lhs_batch_dims={0}, lhs_contracting_dims={2}
+  CHECK-SAME: rhs_batch_dims={0}, rhs_contracting_dims={2}
+})");
+}
+
+TEST_F(BlockScalingRewriterTest, ExpandBlockScaledDotQuantizedLhs) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[16,256] parameter(0)
+  %rhs = f16[32,256] parameter(1)
+  %lhs_scale = f8e5m2[16,8] parameter(2)
+  ROOT %result = f16[16,32] custom-call(%lhs, %rhs, %lhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+
+  BlockScalingRewriter pass;
+  RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
+  CHECK: [[lhs_quant:%.+]] = f8e4m3fn[16,256]{1,0} parameter(0)
+  CHECK: [[lhs_quant_cvt:%.+]] = f16[16,256]{1,0} convert([[lhs_quant]])
+  CHECK: [[lhs_scale:%.+]] = f8e5m2[16,8]{1,0} parameter(2)
+  CHECK: [[lhs_scale_cvt:%.+]] = f16[16,8]{1,0} convert([[lhs_scale]])
+  CHECK: [[lhs_scale_bc:%.+]] = f16[16,8,32]{2,1,0} broadcast([[lhs_scale_cvt]])
+  CHECK: [[lhs_scale_rs:%.+]] = f16[16,256]{1,0} reshape([[lhs_scale_bc]])
+  CHECK: [[lhs:%.+]] = f16[16,256]{1,0} multiply([[lhs_quant_cvt]], [[lhs_scale_rs]])
+  CHECK: [[rhs:%.+]] = f16[32,256]{1,0} parameter(1)
+  CHECK: ROOT {{.+}} = f16[16,32]{1,0} dot([[lhs]], [[rhs]])
+  CHECK-SAME: lhs_contracting_dims={1}, rhs_contracting_dims={1}
+})");
+}
+
+TEST_F(BlockScalingRewriterTest, QuantizeDequantizeCompare) {
+  constexpr absl::string_view hlo_test = R"(
+HloModule test
+ENTRY main {
+  %input = f32[256,256] parameter(0)
+  %quantized = (f8e4m3fn[256,256], f8e5m2[256,16]) custom-call(%input),
+      custom_call_target="__op$quantize"
+  %values = f8e4m3fn[256,256] get-tuple-element(%quantized), index=0
+  %scales = f8e5m2[256,16] get-tuple-element(%quantized), index=1
+  ROOT %dequantized = f32[256,256] custom-call(%values, %scales),
+      custom_call_target="__op$dequantize"
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto test_module,
+                          ParseAndReturnUnverifiedModule(hlo_test));
+
+  BlockScalingRewriter pass;
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto changed, pass.Run(test_module.get(), /*execution_threads=*/{}));
+  EXPECT_TRUE(changed);
+
+  constexpr absl::string_view hlo_reference = R"(
+HloModule reference
+ENTRY main {
+  ROOT %input = f32[256,256] parameter(0)
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto reference_module,
+                          ParseAndReturnUnverifiedModule(hlo_reference));
+
+  EXPECT_TRUE(RunAndCompareTwoModules(std::move(test_module),
+                                      std::move(reference_module),
+                                      ErrorSpec(/*aabs=*/0.01, /*arel=*/0.07),
+                                      /*run_hlo_passes=*/false));
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
This PR adds a transformation pass that supports custom calls to block quantize/dequantize/dot ops.
Such calls are replaced by an equivalent sequence of HLO operations.

This pass is supposed to support MX scaling formats, such as MXFP8, but is not limited to those and can be used with any data types and block sizes.
The quantization op sequence matches the one described in the section 6.3 of the MX spec:
https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf

Once cuDNN frontend 1.10 is released, a lowering to a cuDNN graph will be enabled for the hardware that supports block scaled dot natively (i.e. Blackwell). This pass will stay disabled until then.

I also plan on introducing a new HLO op, "block-scaled-dot", which will be more generic than a custom call - for example, will have configurable dimensions numbers akin to the general dot op. This will follow in a separate PR, once that is approved, I'll replace the custom call "__op$block_scaled_dot" with it.

WANT_LGTM=any