### PR TITLE
Exclude the usage of CPU memory from the GPU memory scheduler

### DIFF
--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -714,14 +714,14 @@ absl::StatusOr<ScheduleMetadata> ScheduleGpuModule(
 absl::StatusOr<HloSchedule> ScheduleGpuModuleWithMemoryScheduler(
     const HloModule* module, int64_t pointer_size, int64_t* peak_memory_bytes) {
   BufferValue::SizeFunction size_func =
-      [pointer_size](const BufferValue& buffer) {
-        const Shape& shape = buffer.shape();
-        if (shape.has_layout() &&
-            shape.layout().memory_space() == Layout::kHostMemorySpace) {
-          return static_cast<int64_t>(0);
-        }
-        return ShapeUtil::ByteSizeOf(shape, pointer_size);
-      };
+      [pointer_size](const BufferValue& buffer) -> int64_t {
+    const Shape& shape = buffer.shape();
+    if (shape.has_layout() &&
+        shape.layout().memory_space() == Layout::kHostMemorySpace) {
+      return static_cast<int64_t>(0);
+    }
+    return ShapeUtil::ByteSizeOf(shape, pointer_size);
+  };
   ModuleSchedulerAlgorithm algorithm = ComputationSchedulerToModuleScheduler(
       DefaultMemoryScheduler, PostProcessSchedule);
   return ScheduleModule(module, size_func, algorithm,

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -715,7 +715,12 @@ absl::StatusOr<HloSchedule> ScheduleGpuModuleWithMemoryScheduler(
     const HloModule* module, int64_t pointer_size, int64_t* peak_memory_bytes) {
   BufferValue::SizeFunction size_func =
       [pointer_size](const BufferValue& buffer) {
-        return ShapeUtil::ByteSizeOf(buffer.shape(), pointer_size);
+        const Shape& shape = buffer.shape();
+        if (shape.has_layout() &&
+            shape.layout().memory_space() == Layout::kHostMemorySpace) {
+          return static_cast<int64_t>(0);
+        }
+        return ShapeUtil::ByteSizeOf(shape, pointer_size);
       };
   ModuleSchedulerAlgorithm algorithm = ComputationSchedulerToModuleScheduler(
       DefaultMemoryScheduler, PostProcessSchedule);


### PR DESCRIPTION
In the MaxText optimizer state offloading, we observed no memory savings when switching from f16 to f32. The root cause is that the GPU memory scheduler does not distinguish between CPU memory and GPU memory. This commit modifies the scheduler to exclude CPU memory.