### PR TITLE
Introduce env var to filter trace entries in Python profiling

### DIFF
--- a/xla/backends/profiler/cpu/python_tracer.cc
+++ b/xla/backends/profiler/cpu/python_tracer.cc
@@ -94,6 +94,7 @@ std::unique_ptr<tsl::profiler::ProfilerInterface> CreatePythonTracer(
       options.enable_trace_python_function;
   pyhooks_options.enable_python_traceme = options.enable_python_traceme;
   pyhooks_options.end_to_end_mode = options.end_to_end_mode;
+  pyhooks_options.min_entry_duration_ns = options.min_entry_duration_ns;
   return std::make_unique<PythonTracer>(pyhooks_options);
 }
 

--- a/xla/backends/profiler/cpu/python_tracer.h
+++ b/xla/backends/profiler/cpu/python_tracer.h
@@ -15,9 +15,11 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_CPU_PYTHON_TRACER_H_
 #define XLA_BACKENDS_PROFILER_CPU_PYTHON_TRACER_H_
 
+#include <cstdint>
 #include <memory>
 
 #include "tsl/profiler/lib/profiler_interface.h"
+#include "tsl/platform/types.h"
 
 namespace xla {
 namespace profiler {
@@ -32,6 +34,8 @@ struct PythonTracerOptions {
 
   // Whether profiling stops within an atexit handler.
   bool end_to_end_mode = false;
+
+  uint64_t min_entry_duration_ns = 0;
 };
 
 std::unique_ptr<tsl::profiler::ProfilerInterface> CreatePythonTracer(

--- a/xla/backends/profiler/cpu/python_tracer_factory.cc
+++ b/xla/backends/profiler/cpu/python_tracer_factory.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include <memory>
+#include <string>
+#include <stdlib.h>
 
 #include "xla/backends/profiler/cpu/python_tracer.h"
 #include "tsl/profiler/lib/profiler_factory.h"
@@ -28,6 +30,14 @@ std::unique_ptr<tsl::profiler::ProfilerInterface> CreatePythonTracer(
   PythonTracerOptions options;
   options.enable_trace_python_function = profile_options.python_tracer_level();
   options.enable_python_traceme = profile_options.host_tracer_level();
+
+  char* min_entry_duration_ns = getenv("XLA_PYTHON_TRACER_MIN_EVENT_DURATION_NS");
+  if (min_entry_duration_ns != nullptr) {
+    options.min_entry_duration_ns = std::stoull(min_entry_duration_ns, nullptr, 10);
+  } else {
+    options.min_entry_duration_ns = 0;
+  }
+
   return CreatePythonTracer(options);
 }
 

--- a/xla/python/profiler/internal/python_hooks.cc
+++ b/xla/python/profiler/internal/python_hooks.cc
@@ -304,7 +304,9 @@ void PythonHookContext::ProfileFast(PyFrameObject* frame, int what,
       if (!thread_traces.active.empty()) {
         auto& entry = thread_traces.active.top();
         entry.end_time_ns = now;
-        thread_traces.completed.emplace_back(std::move(entry));
+        if (entry.end_time_ns-entry.start_time_ns >= options_.min_entry_duration_ns) {
+          thread_traces.completed.emplace_back(std::move(entry));
+        }
         thread_traces.active.pop();
       } else if (options_.include_incomplete_events) {
 #if PY_VERSION_HEX < 0x030b0000
@@ -332,7 +334,9 @@ void PythonHookContext::ProfileFast(PyFrameObject* frame, int what,
         if (!thread_traces.active.empty()) {
           auto& entry = thread_traces.active.top();
           entry.end_time_ns = now;
-          thread_traces.completed.emplace_back(std::move(entry));
+          if (entry.end_time_ns-entry.start_time_ns >= options_.min_entry_duration_ns) {
+            thread_traces.completed.emplace_back(std::move(entry));
+          }
           thread_traces.active.pop();
         } else if (options_.include_incomplete_events) {
           // Only the end of the events is recorded, use profiler start as

--- a/xla/python/profiler/internal/python_hooks.h
+++ b/xla/python/profiler/internal/python_hooks.h
@@ -15,6 +15,7 @@ limitations under the License.
 #ifndef XLA_PYTHON_PROFILER_INTERNAL_PYTHON_HOOKS_H_
 #define XLA_PYTHON_PROFILER_INTERNAL_PYTHON_HOOKS_H_
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <optional>
@@ -46,6 +47,8 @@ struct PythonHooksOptions {
   // result, profiler start, end time are used respectively to the absent
   // timestamps.
   bool include_incomplete_events = true;
+
+  uint64_t min_entry_duration_ns = 0;
 };
 
 struct PythonTraceEntry {


### PR DESCRIPTION
**The problem:** As described in https://github.com/jax-ml/jax/issues/21295, by default, the profiler will stop collecting trace events when there's more than 1 million events. This can be overridden by `TF_PROFILER_TRACE_VIEWER_MAX_EVENTS`, but effectively this will quickly result in trace files of multiple GBs in size. Perfetto handles them very slowly or can't handle them at all.

**Proposed solution:** This commit introduces `XLA_PYTHON_TRACER_MIN_EVENT_DURATION_NS`. Setting it e.g. to 1000000 will ignore all Python-level entries that are shorter than 1ms. This reduces the number of Python-level entries significantly, so that trace file sizes can be kept at manageable sizes.