### PR TITLE
Add xla_experimental_ignore_channel_id flag to CSE pass

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -4160,6 +4160,7 @@ cc_library(
         "//xla:shape_util",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
+        "//xla/service:collective_ops_utils",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status:statusor",


### PR DESCRIPTION
When sequence parallelism is enabled, we are seeing duplicated all-gather ops in some models. 

Currently, CSE removes duplicate collectives if no `channel_id` is set. However, it considers them as unique ops if `channel_id` is set and does not replace them. 


To eliminate duplicates and improve performance, this PR:
- adds logic to use `IdenticalIgnoringChannelIdValues` to check op equality in CSE
- checks `xla_experimental_ignore_channel_id` flag along with HasSideEffects() in CSE
