### PR TITLE
[GPU] Support cuDNN explicit CUDA graph construction.

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -1359,7 +1359,14 @@ absl::Status CuDnnCmd::Record(const Thunk::ExecuteParams& execute_params,
     VLOG(5) << "  Arg: " << arg << ": " << buf.opaque();
     operands.push_back(buf);
   }
-
+  TF_ASSIGN_OR_RETURN(
+      const bool supports_explicit,
+      graph_->get()->SupportsExplicitCommandBufferConstruction());
+  if (supports_explicit) {
+    return command_buffer->DnnGraph(GetExecutionScope(record_params),
+                                    *graph_->get(), *execute_params.stream,
+                                    absl::Span<se::DeviceMemoryBase>(operands));
+  }
   return AddTracedCommandBuffer(
       execute_params, record_params, command_buffer, [&](se::Stream* stream) {
         return graph_->get()->Execute(

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -617,6 +617,7 @@ cc_library(
     deps = [
         ":bit_pattern",
         ":device_memory",
+        ":dnn",
         ":kernel",
         ":launch_dim",
         "//xla/tsl/lib/gtl:int_type",

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/stream_executor/bit_pattern.h"
 #include "xla/stream_executor/device_memory.h"
+#include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/kernel.h"
 #include "xla/stream_executor/launch_dim.h"
 #include "xla/tsl/lib/gtl/int_type.h"
@@ -172,9 +173,9 @@ class CommandBuffer {
   // Command buffer API
   //===--------------------------------------------------------------------===//
 
-  // Adds an execution barrier to a given execution scope: all commands added
-  // before a barrier in a the execution scope will complete before any of the
-  // commands added after a barrier in the same execution scope.
+  // Adds an execution barrier to a given execution scope: all commands
+  // added before a barrier in a the execution scope will complete before
+  // any of the commands added after a barrier in the same execution scope.
   virtual absl::Status Barrier(ExecutionScopeId execution_scope_id) = 0;
 
   // Adds an execution barrier that synchronizes commands across multiple
@@ -249,6 +250,10 @@ class CommandBuffer {
                       size_t num_elements) {
     return Memset(kDefaultExecutionScope, dst, bit_pattern, num_elements);
   }
+
+  // Adds a DNN graph launch command.
+  virtual absl::Status DnnGraph(ExecutionScopeId, dnn::DnnGraph&, Stream&,
+                                absl::Span<DeviceMemoryBase> operands) = 0;
 
   //--------------------------------------------------------------------------//
   // Command buffer condtitional commands API

--- a/xla/stream_executor/cuda/cuda_command_buffer.h
+++ b/xla/stream_executor/cuda/cuda_command_buffer.h
@@ -112,6 +112,13 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
                                    DeviceMemoryBase source,
                                    uint64_t size) override;
 
+  absl::Status PopulateDnnGraphNode(
+      dnn::DnnGraph&, Stream&, absl::Span<DeviceMemoryBase> operands) override;
+
+  absl::Status UpdateDnnGraphNode(dnn::DnnGraph&, Stream&,
+                                  absl::Span<DeviceMemoryBase> operands,
+                                  GraphNodeHandle) override;
+
   absl::StatusOr<GraphNodeHandle> CreateChildNode(
       const Dependencies& dependencies, const CommandBuffer& nested) override;
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -8534,12 +8534,11 @@ absl::Status CudnnGraph::Build(dnn::DnnSupport& dnn_support,
   RETURN_CUDNN_FRONTEND_STATUS(graph_.build_plans(cudnn->handle()));
 }
 
-absl::Status CudnnGraph::Execute(Stream& stream,
-                                 absl::Span<DeviceMemoryBase> operands,
-                                 int64_t local_device_ordinal) const {
-  std::unordered_map<int64_t, void*> tensor_to_ptr_map;
+CudnnGraph::VariantPack CudnnGraph::PackOperands(
+    absl::Span<DeviceMemoryBase> operands, DeviceMemoryBase& workspace,
+    std::optional<int64_t> local_device_ordinal) const {
+  CudnnGraph::VariantPack tensor_to_ptr_map;
   absl::Span<DeviceMemoryBase> operands_without_workspace = operands;
-  DeviceMemoryBase workspace;
   if (graph_.get_workspace_size() > 0) {
     workspace = operands.back();
     CHECK_EQ(graph_.get_workspace_size(), workspace.size());
@@ -8554,10 +8553,11 @@ absl::Status CudnnGraph::Execute(Stream& stream,
 
   if (dropout_rng_offset_increment_ > 0) {
 #if CUDNN_VERSION >= 8800
-    UpdateDropoutState(local_device_ordinal);
+    CHECK(local_device_ordinal.has_value());
+    UpdateDropoutState(*local_device_ordinal);
     tensor_to_ptr_map[next_uid()] = (void*)&dropout_rng_seed_;
     tensor_to_ptr_map[next_uid()] =
-        (void*)&current_dropout_rng_offset_[local_device_ordinal];
+        (void*)&current_dropout_rng_offset_[*local_device_ordinal];
 #else
     return absl::UnimplementedError(
         "Cudnn dropout offset and seed are only supported with Cudnn >= "
@@ -8565,11 +8565,53 @@ absl::Status CudnnGraph::Execute(Stream& stream,
 #endif  // CUDNN_VERSION >= 8800
   }
 
+  return tensor_to_ptr_map;
+}
+
+absl::Status CudnnGraph::Execute(Stream& stream,
+                                 absl::Span<DeviceMemoryBase> operands,
+                                 int64_t local_device_ordinal) const {
+  DeviceMemoryBase workspace;
+  VariantPack tensor_to_ptr_map =
+      PackOperands(operands, workspace, local_device_ordinal);
+
   const CudnnSupport& dnn_support =
       static_cast<CudnnSupport&>(*stream.parent()->AsDnn());
-  auto cudnn = dnn_support.cudnn_->GetHandle(stream.parent(), &stream);
+  CudnnHandle cudnn = dnn_support.cudnn_->GetHandle(stream.parent(), &stream);
+
   RETURN_CUDNN_FRONTEND_STATUS(
       graph_.execute(cudnn.handle(), tensor_to_ptr_map, workspace.opaque()));
+}
+
+absl::StatusOr<bool> CudnnGraph::SupportsExplicitCommandBufferConstruction()
+    const {
+  std::vector<cudnn_frontend::BehaviorNote_t> notes;
+  graph_.get_behavior_notes(notes).is_bad();
+  RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.get_behavior_notes(notes));
+  return absl::c_any_of(notes, [](cudnn_frontend::BehaviorNote_t n) {
+    return n == cudnn_frontend::BehaviorNote_t::SUPPORTS_CUDA_GRAPH_NATIVE_API;
+  });
+}
+
+absl::Status CudnnGraph::PopulateOrUpdateRawCommandBuffer(
+    Stream& stream, absl::Span<DeviceMemoryBase> operands,
+    RawCommandBufferHandle cuda_graph, bool do_update) {
+  DeviceMemoryBase workspace;
+  VariantPack tensor_to_ptr_map = PackOperands(operands, workspace);
+
+  const CudnnSupport& dnn_support =
+      static_cast<CudnnSupport&>(*stream.parent()->AsDnn());
+  CudnnHandle cudnn = dnn_support.cudnn_->GetHandle(stream.parent(), &stream);
+
+  if (do_update) {
+    RETURN_CUDNN_FRONTEND_STATUS(
+        graph_.update_cuda_graph(cudnn.handle(), tensor_to_ptr_map,
+                                 workspace.opaque(), (cudaGraph_t)cuda_graph));
+  } else {
+    RETURN_CUDNN_FRONTEND_STATUS(graph_.populate_cuda_graph(
+        cudnn.handle(), tensor_to_ptr_map, workspace.opaque(),
+        (cudaGraph_t)cuda_graph));
+  }
 }
 
 #endif  // CUDNN_VERSION >= 8100

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -77,12 +77,21 @@ class CudnnGraph : public dnn::DnnGraph {
     current_dropout_rng_offset_[local_device_ordinal] +=
         dropout_rng_offset_increment_;
   }
+  absl::StatusOr<bool> SupportsExplicitCommandBufferConstruction()
+      const override;
+  absl::Status PopulateOrUpdateRawCommandBuffer(
+      Stream&, absl::Span<DeviceMemoryBase> operands, RawCommandBufferHandle,
+      bool do_update) override;
 
  private:
   cudnn_frontend::graph::Graph graph_;
   int64_t dropout_rng_seed_;
   mutable std::vector<int64_t> current_dropout_rng_offset_;
   int64_t dropout_rng_offset_increment_ = 0;
+  using VariantPack = std::unordered_map<int64_t, void*>;
+  VariantPack PackOperands(
+      absl::Span<DeviceMemoryBase> operands, DeviceMemoryBase& workspace,
+      std::optional<int64_t> local_device_ordinal = std::nullopt) const;
 };
 #endif  // CUDNN_VERSION >= 8100
 

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1105,6 +1105,12 @@ class DnnGraph {
                                int64_t local_device_ordinal) const = 0;
   virtual void InitDropoutState(int64_t local_device_count, int64_t seed,
                                 int64_t increment) = 0;
+  virtual absl::StatusOr<bool> SupportsExplicitCommandBufferConstruction()
+      const = 0;
+  using RawCommandBufferHandle = void*;
+  virtual absl::Status PopulateOrUpdateRawCommandBuffer(
+      Stream&, absl::Span<DeviceMemoryBase> operands, RawCommandBufferHandle,
+      bool do_update) = 0;
 };
 
 using LazyDnnGraph = std::unique_ptr<DnnGraph>;

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -185,6 +185,7 @@ gpu_only_cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:casts",
         "@tsl//tsl/platform:env",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",
@@ -639,6 +640,7 @@ xla_test(
         "//xla/service:platform_util",
         "//xla/stream_executor:command_buffer",
         "//xla/stream_executor:device_memory",
+        "//xla/stream_executor:dnn",
         "//xla/stream_executor:kernel",
         "//xla/stream_executor:kernel_spec",
         "//xla/stream_executor:launch_dim",
@@ -667,6 +669,7 @@ xla_test(
         "@tsl//tsl/platform:test_benchmark",
     ] + if_cuda([
         "//xla/stream_executor/cuda:cuda_platform",
+        "//xla/stream_executor/cuda:cudnn_plugin",
     ]) + if_rocm([
         "//xla/stream_executor/rocm:rocm_platform",
     ]),

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -34,6 +34,7 @@ limitations under the License.
 #include "xla/stream_executor/gpu/scoped_update_mode.h"
 #include "xla/stream_executor/kernel.h"
 #include "xla/stream_executor/launch_dim.h"
+#include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 
 namespace stream_executor::gpu {
@@ -123,6 +124,9 @@ class GpuCommandBuffer : public CommandBuffer {
   absl::Status Memset(ExecutionScopeId execution_scope_id,
                       DeviceMemoryBase* dst, BitPattern bit_pattern,
                       size_t num_elements) override;
+
+  absl::Status DnnGraph(ExecutionScopeId, dnn::DnnGraph&, Stream&,
+                        absl::Span<DeviceMemoryBase> operands) override;
 
   absl::Status If(ExecutionScopeId execution_scope_id,
                   DeviceMemory<bool> predicate, Builder then_builder) override;
@@ -374,7 +378,7 @@ class GpuCommandBuffer : public CommandBuffer {
       const Dependencies& dependencies, DeviceMemoryBase destination,
       BitPattern bit_pattern, size_t num_elements) = 0;
 
-  // Updates an existing memset node. Note that `node_handle` needs to be refer
+  // Updates an existing memset node. Note that `node_handle` needs to refer
   // to a node created by `CreateMemsetNode`.
   virtual absl::Status UpdateMemsetNode(GraphNodeHandle node_handle,
                                         DeviceMemoryBase destination,
@@ -390,6 +394,13 @@ class GpuCommandBuffer : public CommandBuffer {
                                            DeviceMemoryBase destination,
                                            DeviceMemoryBase source,
                                            uint64_t size) = 0;
+
+  virtual absl::Status PopulateDnnGraphNode(
+      dnn::DnnGraph&, Stream&, absl::Span<DeviceMemoryBase> operands) = 0;
+
+  virtual absl::Status UpdateDnnGraphNode(dnn::DnnGraph&, Stream&,
+                                          absl::Span<DeviceMemoryBase> operands,
+                                          GraphNodeHandle) = 0;
 
   // Adds a new nested command buffer node to the graph.
   virtual absl::StatusOr<GraphNodeHandle> CreateChildNode(

--- a/xla/stream_executor/gpu/gpu_command_buffer_test.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -27,8 +28,10 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/service/platform_util.h"
 #include "xla/stream_executor/command_buffer.h"
+#include "xla/stream_executor/cuda/cuda_dnn.h"
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
 #include "xla/stream_executor/device_memory.h"
+#include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/gpu/gpu_test_kernels.h"
 #include "xla/stream_executor/kernel.h"
 #include "xla/stream_executor/kernel_spec.h"
@@ -1616,6 +1619,100 @@ TEST(GpuCommandBufferTest, ConditionalWhileInExecutionScope) {
 
   EXPECT_EQ(b_dst, 20);
   EXPECT_EQ(c_dst, 43);
+}
+
+TEST(GpuCommandBufferTest, CuDnnExplicitConstructionAndUpdateWork) {
+  Platform* platform = GpuPlatform();
+  StreamExecutor* executor = platform->ExecutorForDevice(0).value();
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  dnn::DnnSupport& dnn_support = *executor->AsDnn();
+
+  constexpr int dim_size = 32;
+  constexpr int total_elements = dim_size * dim_size;
+
+  CudnnGraph graph([]() {
+    cudnn_frontend::graph::Graph graph;
+    graph.set_compute_data_type(cudnn_frontend::DataType_t::INT32);
+    auto lhs = graph.tensor(cudnn_frontend::graph::Tensor_attributes()
+                                .set_dim({1, dim_size, dim_size})
+                                .set_stride({dim_size * dim_size, dim_size, 1})
+                                .set_data_type(cudnn_frontend::DataType_t::INT8)
+                                .set_uid(1));
+    auto rhs = graph.tensor_like(lhs);
+    rhs->set_uid(2);
+    graph.matmul(lhs, rhs, cudnn_frontend::graph::Matmul_attributes())
+        ->set_output(true)
+        .set_data_type(cudnn_frontend::DataType_t::INT32)
+        .set_uid(3);
+    return graph;
+  }());
+  TF_ASSERT_OK(graph.Prepare(dnn_support, NumericOptions{}));
+  TF_ASSERT_OK(graph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  ASSERT_TRUE(graph.SupportsExplicitCommandBufferConstruction().value());
+
+  DeviceMemory<int8_t> input = executor->AllocateArray<int8_t>(total_elements);
+  TF_ASSERT_OK(stream->MemZero(&input, input.size()));
+  DeviceMemory<int32_t> output0 =
+      executor->AllocateArray<int32_t>(total_elements);
+  DeviceMemoryBase workspace;
+  std::vector<DeviceMemoryBase> operands;
+  operands.reserve(4);
+  operands.push_back(input);  // multiplying the input by itself
+  operands.push_back(input);
+  operands.push_back(output0);
+  if (graph.Graph().get_workspace_size() > 0) {
+    workspace = executor->Allocate(graph.Graph().get_workspace_size());
+    operands.push_back(workspace);
+  }
+  TF_ASSERT_OK_AND_ASSIGN(auto cmd_buffer,
+                          executor->CreateCommandBuffer(primary));
+  TF_ASSERT_OK(cmd_buffer->DnnGraph(cmd_buffer->kDefaultExecutionScope, graph,
+                                    *stream,
+                                    absl::Span<DeviceMemoryBase>(operands)));
+  TF_ASSERT_OK(cmd_buffer->Finalize());
+
+  std::vector<int32_t> host_buffer(output0.ElementCount());
+
+  // Initialize and check the output before execution.
+  TF_ASSERT_OK(stream->Memset32(&output0, 123, output0.size()));
+  TF_ASSERT_OK(stream->Memcpy(host_buffer.data(), output0, output0.size()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+  EXPECT_TRUE(absl::c_all_of(host_buffer, [](int32_t x) { return x == 123; }));
+
+  // Run the computation.
+  TF_ASSERT_OK(cmd_buffer->Submit(stream.get()));
+
+  // Check the output after execution.
+  TF_ASSERT_OK(stream->Memcpy(host_buffer.data(), output0, output0.size()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+  EXPECT_TRUE(absl::c_all_of(host_buffer, [](int32_t x) { return x == 0; }));
+
+  // Swap the output buffer.
+  DeviceMemory<int32_t> output1 =
+      executor->AllocateArray<int32_t>(total_elements);
+  operands[2] = output1;
+  executor->Deallocate(&output0);
+
+  // Initialize and check the output before execution.
+  TF_ASSERT_OK(stream->Memset32(&output1, 456, output1.size()));
+  TF_ASSERT_OK(stream->Memcpy(host_buffer.data(), output1, output1.size()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+  EXPECT_TRUE(absl::c_all_of(host_buffer, [](int32_t x) { return x == 456; }));
+
+  // Update the command buffer to write into the new output buffer.
+  TF_ASSERT_OK(cmd_buffer->Update());
+  TF_ASSERT_OK(cmd_buffer->DnnGraph(cmd_buffer->kDefaultExecutionScope, graph,
+                                    *stream,
+                                    absl::Span<DeviceMemoryBase>(operands)));
+  TF_ASSERT_OK(cmd_buffer->Finalize());
+
+  // Run the computation.
+  TF_ASSERT_OK(cmd_buffer->Submit(stream.get()));
+
+  // Check the output after execution.
+  TF_ASSERT_OK(stream->Memcpy(host_buffer.data(), output1, output1.size()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+  EXPECT_TRUE(absl::c_all_of(host_buffer, [](int32_t x) { return x == 0; }));
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Some cuDNN graph engines now support explicit CUDA graph construction instead of stream capture. XLA will now switch between explicit construction and the already implemented stream capture accordingly.