### PR TITLE
[PJRT]  Expose should_stage_host_to_device_transfers as client create option

### DIFF
--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -442,6 +442,7 @@ xla_test(
         "//xla/pjrt:pjrt_common",
         "//xla/pjrt:pjrt_compiler",
         "//xla/pjrt:pjrt_future",
+        "//xla/pjrt/gpu:se_gpu_pjrt_client",
         "//xla/pjrt/distributed:in_memory_key_value_store",
         "//xla/service:custom_call_target_registry",
         "//xla/stream_executor/gpu:gpu_init",

--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -442,7 +442,7 @@ xla_test(
         "//xla/pjrt:pjrt_common",
         "//xla/pjrt:pjrt_compiler",
         "//xla/pjrt:pjrt_future",
-        "//xla/pjrt/gpu:se_gpu_pjrt_client",
+        "//xla/pjrt/plugin/xla_gpu:xla_gpu_pjrt_client",
         "//xla/pjrt/distributed:in_memory_key_value_store",
         "//xla/service:custom_call_target_registry",
         "//xla/stream_executor/gpu:gpu_init",

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -84,6 +84,7 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
           {"visible_devices", PJRT_NamedValue_Type::PJRT_NamedValue_kInt64List},
           {"node_id", PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
           {"num_nodes", PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
+          {"should_stage_host_to_device_transfers", PJRT_NamedValue_Type::PJRT_NamedValue_kBool},
           {"enable_mock_nccl", PJRT_NamedValue_Type::PJRT_NamedValue_kBool},
           {"mock_gpu_topology", PJRT_NamedValue_Type::PJRT_NamedValue_kString},
       });
@@ -139,6 +140,11 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
   if (auto it = create_options.find("num_nodes"); it != create_options.end()) {
     num_nodes = std::get<int64_t>(it->second);
   }
+  bool should_stage_host_to_device_transfers = true;
+  if (auto it = create_options.find("should_stage_host_to_device_transfers");
+      it != create_options.end()) {
+    should_stage_host_to_device_transfers = std::get<bool>(it->second);
+  }
   bool enable_mock_nccl = false;
   if (auto it = create_options.find("enable_mock_nccl");
       it != create_options.end()) {
@@ -159,6 +165,7 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
   options.kv_store = pjrt::ToCppKeyValueStore(
       args->kv_get_callback, args->kv_get_user_arg, args->kv_try_get_callback,
       args->kv_try_get_user_arg, args->kv_put_callback, args->kv_put_user_arg);
+  options.should_stage_host_to_device_transfers = should_stage_host_to_device_transfers;
   options.enable_mock_nccl = enable_mock_nccl;
   options.mock_gpu_topology = mock_gpu_topology;
   PJRT_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtClient> client,

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -690,65 +690,64 @@ TEST(PjrtCApiPlatformNameTest, UnavailablePlatformName) {
   api->PJRT_Error_Destroy(&error_destroy_args);
 }
 
-TEST(PjrtCApiGpuExtensionTest, ShouldStageHostToDeviceTransferOption) {
+TEST(PjrtCApiGpuExtensionTest, ShouldStageHostToDeviceTransferWithOptionSetToTrue) {
   auto api = GetPjrtApi();
-  
-  // Test with option set to true
-  {
-    absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
-        {"should_stage_host_to_device_transfers", true},
-        {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0})},
-    };
-    TF_ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
-                          ::pjrt::ConvertToPjRtNamedValueList(options));
-    PJRT_Client_Create_Args create_arg;
-    create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
-    create_arg.extension_start = nullptr;
-    create_arg.client = nullptr;
-    create_arg.create_options = c_options.data();
-    create_arg.num_options = c_options.size();
-    PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
-    EXPECT_EQ(error, nullptr) << error->status.message();
 
-    xla::PjRtClient* cpp_client = create_arg.client->client.get();
-    auto* gpu_client = tensorflow::down_cast<xla::StreamExecutorGpuClient*>(cpp_client);
-    EXPECT_TRUE(gpu_client->should_stage_host_to_device_transfers());
+  absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
+      {"should_stage_host_to_device_transfers", true},
+      {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0})},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
+                        ::pjrt::ConvertToPjRtNamedValueList(options));
+  PJRT_Client_Create_Args create_arg;
+  create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
+  create_arg.extension_start = nullptr;
+  create_arg.client = nullptr;
+  create_arg.create_options = c_options.data();
+  create_arg.num_options = c_options.size();
+  PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
+  EXPECT_EQ(error, nullptr) << error->status.message();
 
-    PJRT_Client_Destroy_Args destroy_args;
-    destroy_args.struct_size = PJRT_Client_Destroy_Args_STRUCT_SIZE;
-    destroy_args.extension_start = nullptr;
-    destroy_args.client = create_arg.client;
-    PJRT_Error* destroy_error = api->PJRT_Client_Destroy(&destroy_args);
-    CHECK_EQ(destroy_error, nullptr);
-  }
+  xla::PjRtClient* cpp_client = create_arg.client->client.get();
+  auto* gpu_client = tensorflow::down_cast<xla::StreamExecutorGpuClient*>(cpp_client);
+  EXPECT_TRUE(gpu_client->should_stage_host_to_device_transfers());
 
-  {
-    absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
-        {"should_stage_host_to_device_transfers", false},
-        {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0})},
-    };
-    TF_ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
-                          ::pjrt::ConvertToPjRtNamedValueList(options));
-    PJRT_Client_Create_Args create_arg;
-    create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
-    create_arg.extension_start = nullptr;
-    create_arg.client = nullptr;
-    create_arg.create_options = c_options.data();
-    create_arg.num_options = c_options.size();
-    PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
-    EXPECT_EQ(error, nullptr) << error->status.message();
+  PJRT_Client_Destroy_Args destroy_args;
+  destroy_args.struct_size = PJRT_Client_Destroy_Args_STRUCT_SIZE;
+  destroy_args.extension_start = nullptr;
+  destroy_args.client = create_arg.client;
+  PJRT_Error* destroy_error = api->PJRT_Client_Destroy(&destroy_args);
+  CHECK_EQ(destroy_error, nullptr);
+}
 
-    xla::PjRtClient* cpp_client = create_arg.client->client.get();
-    auto* gpu_client = tensorflow::down_cast<xla::StreamExecutorGpuClient*>(cpp_client);
-    EXPECT_FALSE(gpu_client->should_stage_host_to_device_transfers());
+TEST(PjrtCApiGpuExtensionTest, ShouldStageHostToDeviceTransferWithOptionSetToFalse) {
+  auto api = GetPjrtApi();
 
-    PJRT_Client_Destroy_Args destroy_args;
-    destroy_args.struct_size = PJRT_Client_Destroy_Args_STRUCT_SIZE;
-    destroy_args.extension_start = nullptr;
-    destroy_args.client = create_arg.client;
-    PJRT_Error* destroy_error = api->PJRT_Client_Destroy(&destroy_args);
-    CHECK_EQ(destroy_error, nullptr);
-  }
+  absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
+      {"should_stage_host_to_device_transfers", false},
+      {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0})},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
+                        ::pjrt::ConvertToPjRtNamedValueList(options));
+  PJRT_Client_Create_Args create_arg;
+  create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
+  create_arg.extension_start = nullptr;
+  create_arg.client = nullptr;
+  create_arg.create_options = c_options.data();
+  create_arg.num_options = c_options.size();
+  PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
+  EXPECT_EQ(error, nullptr) << error->status.message();
+
+  xla::PjRtClient* cpp_client = create_arg.client->client.get();
+  auto* gpu_client = tensorflow::down_cast<xla::StreamExecutorGpuClient*>(cpp_client);
+  EXPECT_FALSE(gpu_client->should_stage_host_to_device_transfers());
+
+  PJRT_Client_Destroy_Args destroy_args;
+  destroy_args.struct_size = PJRT_Client_Destroy_Args_STRUCT_SIZE;
+  destroy_args.extension_start = nullptr;
+  destroy_args.client = create_arg.client;
+  PJRT_Error* destroy_error = api->PJRT_Client_Destroy(&destroy_args);
+  CHECK_EQ(destroy_error, nullptr);
 }
 
 TEST(PJRTGpuDeviceTopologyTest, CreateGpuTopology) {

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -57,6 +57,7 @@ limitations under the License.
 #include "xla/pjrt/pjrt_common.h"
 #include "xla/pjrt/pjrt_compiler.h"
 #include "xla/pjrt/pjrt_future.h"
+#include "xla/pjrt/gpu/se_gpu_pjrt_client.h"
 #include "xla/service/custom_call_target_registry.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -687,6 +688,67 @@ TEST(PjrtCApiPlatformNameTest, UnavailablePlatformName) {
   error_destroy_args.error = error;
 
   api->PJRT_Error_Destroy(&error_destroy_args);
+}
+
+TEST(PjrtCApiGpuExtensionTest, ShouldStageHostToDeviceTransferOption) {
+  auto api = GetPjrtApi();
+  
+  // Test with option set to true
+  {
+    absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
+        {"should_stage_host_to_device_transfers", true},
+        {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0})},
+    };
+    TF_ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
+                          ::pjrt::ConvertToPjRtNamedValueList(options));
+    PJRT_Client_Create_Args create_arg;
+    create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
+    create_arg.extension_start = nullptr;
+    create_arg.client = nullptr;
+    create_arg.create_options = c_options.data();
+    create_arg.num_options = c_options.size();
+    PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
+    EXPECT_EQ(error, nullptr) << error->status.message();
+
+    xla::PjRtClient* cpp_client = create_arg.client->client.get();
+    auto* gpu_client = tensorflow::down_cast<xla::StreamExecutorGpuClient*>(cpp_client);
+    EXPECT_TRUE(gpu_client->should_stage_host_to_device_transfers());
+
+    PJRT_Client_Destroy_Args destroy_args;
+    destroy_args.struct_size = PJRT_Client_Destroy_Args_STRUCT_SIZE;
+    destroy_args.extension_start = nullptr;
+    destroy_args.client = create_arg.client;
+    PJRT_Error* destroy_error = api->PJRT_Client_Destroy(&destroy_args);
+    CHECK_EQ(destroy_error, nullptr);
+  }
+
+  {
+    absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
+        {"should_stage_host_to_device_transfers", false},
+        {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0})},
+    };
+    TF_ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
+                          ::pjrt::ConvertToPjRtNamedValueList(options));
+    PJRT_Client_Create_Args create_arg;
+    create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
+    create_arg.extension_start = nullptr;
+    create_arg.client = nullptr;
+    create_arg.create_options = c_options.data();
+    create_arg.num_options = c_options.size();
+    PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
+    EXPECT_EQ(error, nullptr) << error->status.message();
+
+    xla::PjRtClient* cpp_client = create_arg.client->client.get();
+    auto* gpu_client = tensorflow::down_cast<xla::StreamExecutorGpuClient*>(cpp_client);
+    EXPECT_FALSE(gpu_client->should_stage_host_to_device_transfers());
+
+    PJRT_Client_Destroy_Args destroy_args;
+    destroy_args.struct_size = PJRT_Client_Destroy_Args_STRUCT_SIZE;
+    destroy_args.extension_start = nullptr;
+    destroy_args.client = create_arg.client;
+    PJRT_Error* destroy_error = api->PJRT_Client_Destroy(&destroy_args);
+    CHECK_EQ(destroy_error, nullptr);
+  }
 }
 
 TEST(PJRTGpuDeviceTopologyTest, CreateGpuTopology) {

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1124,6 +1124,61 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientTest) {
   }
 }
 
+TEST(StreamExecutorGpuClientTest, ShouldStageHostToDeviceTransfers) {
+  GpuClientOptions options_staging;
+  options_staging.should_stage_host_to_device_transfers = true;
+  TF_ASSERT_OK_AND_ASSIGN(auto client_staging, 
+                          GetStreamExecutorGpuClient(options_staging));
+
+  GpuClientOptions options_no_staging;
+  options_no_staging.should_stage_host_to_device_transfers = false; 
+  TF_ASSERT_OK_AND_ASSIGN(auto client_no_staging,
+                          GetStreamExecutorGpuClient(options_no_staging));
+
+  std::vector<float> data(1024, 1.0f);
+  Shape shape = ShapeUtil::MakeShape(F32, {1024});
+
+  auto* staging_client = 
+      tensorflow::down_cast<StreamExecutorGpuClient*>(client_staging.get());
+  auto* no_staging_client = 
+      tensorflow::down_cast<StreamExecutorGpuClient*>(client_no_staging.get());
+
+  EXPECT_TRUE(staging_client->should_stage_host_to_device_transfers());
+  EXPECT_FALSE(no_staging_client->should_stage_host_to_device_transfers());
+
+  {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto buffer,
+        client_staging->BufferFromHostBuffer(
+            data.data(), shape.element_type(), shape.dimensions(),
+            /*byte_strides=*/std::nullopt,
+            PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall,
+            /*on_done_with_host_buffer=*/nullptr,
+            client_staging->addressable_devices()[0]->memory_spaces()[0],
+            /*device_layout=*/nullptr));
+
+    TF_ASSERT_OK_AND_ASSIGN(auto literal, buffer->ToLiteralSync());
+    EXPECT_TRUE(LiteralTestUtil::Equal(*literal,
+                                      LiteralUtil::CreateR1<float>(std::vector<float>(1024, 1.0f))));
+  }
+
+  {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto buffer,
+        client_no_staging->BufferFromHostBuffer(
+            data.data(), shape.element_type(), shape.dimensions(), 
+            /*byte_strides=*/std::nullopt,
+            PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall,
+            /*on_done_with_host_buffer=*/nullptr,
+            client_no_staging->addressable_devices()[0]->memory_spaces()[0],
+            /*device_layout=*/nullptr));
+
+    TF_ASSERT_OK_AND_ASSIGN(auto literal, buffer->ToLiteralSync());
+    EXPECT_TRUE(LiteralTestUtil::Equal(*literal, 
+                                      LiteralUtil::CreateR1<float>(std::vector<float>(1024, 1.0f))));
+  }
+}
+
 TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyTest) {
   GpuClientOptions options;
   options.enable_mock_nccl = true;


### PR DESCRIPTION
Expose GPU option `should_stage_host_to_device_transfers ` as configurable in PJRT client create function.
This allow the end user to override the default value which is `true`.

ref: [openxla@xla/blob/main/xla/pjrt/plugin/xla_gpu/xla_gpu_client_options.h](https://github.com/openxla/xla/blob/main/xla/pjrt/plugin/xla_gpu/xla_gpu_client_options.h)

Since the option is living in a hashmap of type PJRT_NamedValue, it seems that I don't break the C PJRT API interface versioning.