### PR TITLE
Add kCall to GetFusibleComputations

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2567,6 +2567,7 @@ cc_library(
         ":reduction_utils",
         "//xla:permutation_util",
         "//xla:shape_util",
+        "//xla:side_effect_util",
         "//xla:util",
         "//xla/hlo/analysis:hlo_dataflow_analysis",
         "//xla/hlo/ir:hlo",

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "xla/service/instruction_fusion.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
+#include "xla/side_effect_util.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/util.h"
 
@@ -847,6 +848,11 @@ bool MayPreventVectorization(const HloFusionAdaptor& fusion) {
   });
 }
 
+bool IsStreamAnnotatedComputation(const HloInstruction* instr) {
+  return instr->opcode() == HloOpcode::kCall &&
+         instr->frontend_attributes().map().contains(kXlaStreamAnnotationAttr);
+}
+
 std::vector<HloComputation*> GetFusibleComputations(
     const HloModule& module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
@@ -857,8 +863,8 @@ std::vector<HloComputation*> GetFusibleComputations(
       // Don't fuse within called computations, unless they are for control
       // flow. See also fusion_wrapper.cc, which does the same.
       if (HloInstruction::MightHaveCalledComputations(instr->opcode()) &&
+          !IsStreamAnnotatedComputation(instr) &&
           instr->opcode() != HloOpcode::kWhile &&
-          instr->opcode() != HloOpcode::kCall &&
           instr->opcode() != HloOpcode::kConditional &&
           // No need to add fusion computations, just check the flag.
           instr->opcode() != HloOpcode::kFusion) {

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -858,6 +858,7 @@ std::vector<HloComputation*> GetFusibleComputations(
       // flow. See also fusion_wrapper.cc, which does the same.
       if (HloInstruction::MightHaveCalledComputations(instr->opcode()) &&
           instr->opcode() != HloOpcode::kWhile &&
+          instr->opcode() != HloOpcode::kCall &&
           instr->opcode() != HloOpcode::kConditional &&
           // No need to add fusion computations, just check the flag.
           instr->opcode() != HloOpcode::kFusion) {

--- a/xla/service/gpu/gpu_fusible_test.cc
+++ b/xla/service/gpu/gpu_fusible_test.cc
@@ -1518,7 +1518,8 @@ TEST_F(GpuFusibleTest, GetFusibleComputations) {
     ENTRY main {
       p0 = s32[] parameter(0)
       p1 = f32[128,1024] parameter(1)
-      called = f32[128] call(p1), to_apply=body_c
+      called = f32[128] call(p1), to_apply=body_c,
+        frontend_attributes={_xla_stream_annotation="1"}
       ROOT conditional = f32[128] conditional(p0, p1, p1),
         branch_computations={body_a, body_b}
     })"))


### PR DESCRIPTION
Previously, we had issues with the stream annotation being applied to non-Gemm operations, and having the compilation fail at IR emitter stage. Operations that normally should've been fused weren't getting fused inside the async computation. This PR is intended to fix this issue by including the call computations when searching for fusible computations.

This was suggested by @jreiffers 