### PR TITLE
[XLA:GPU] Upgrade cuDNN frontend library to v1.10

### DIFF
--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,5 +1,5 @@
 diff --git a/include/cudnn_frontend.h b/include/cudnn_frontend.h
-index e3f1ec8..373e52d 100644
+index c0d6117..cdbe25a 100644
 --- a/include/cudnn_frontend.h
 +++ b/include/cudnn_frontend.h
 @@ -97,7 +97,7 @@
@@ -12,7 +12,7 @@ index e3f1ec8..373e52d 100644
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_Heuristics.h"
 diff --git a/include/cudnn_frontend/backend/backend_descriptor.h b/include/cudnn_frontend/backend/backend_descriptor.h
-index 47387a1..3864c1d 100644
+index a10432c..4c721b7 100644
 --- a/include/cudnn_frontend/backend/backend_descriptor.h
 +++ b/include/cudnn_frontend/backend/backend_descriptor.h
 @@ -3,7 +3,7 @@
@@ -38,7 +38,7 @@ index 334ffde..d2ca694 100644
  #include "backend_descriptor.h"
  
 diff --git a/include/cudnn_frontend/backend/plan_helpers.h b/include/cudnn_frontend/backend/plan_helpers.h
-index 1fa458d..8c37d10 100644
+index 3390969..b9beb32 100644
 --- a/include/cudnn_frontend/backend/plan_helpers.h
 +++ b/include/cudnn_frontend/backend/plan_helpers.h
 @@ -2,7 +2,7 @@
@@ -49,4 +49,4 @@ index 1fa458d..8c37d10 100644
 +#include "third_party/gpus/cudnn/cudnn.h"
  
  #include "backend_descriptor.h"
- 
+ #include "../knobs.h"

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -91,9 +91,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "7be8afebc693f0ef75bbc673ce5c1cf422673e84ea7d53e488201756c046496e",
-        strip_prefix = "cudnn-frontend-1.9.0",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.9.0.zip"),
+        sha256 = "59fb63e273c845cb85996d536194a7e2b22012810983cbbf06c4a46b09d17a32",
+        strip_prefix = "cudnn-frontend-1.10.0",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.10.0.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
The new version of cuDNN will enable using block scaled matmul in cuDNN graphs.

The support of accelerated block scaled matmul (available on Blackwell GPU) in XLA requires this upgrade.