### PR TITLE
[XLA:GPU] Fix triton: do not use MMA v3 on Blackwell

### DIFF
--- a/third_party/triton/temporary/series.bzl
+++ b/third_party/triton/temporary/series.bzl
@@ -18,5 +18,7 @@ temporary_patch_list = [
     # but not merged into llvm_head branch nor Google's fork yet.
     # Without this XLA fails to build on macos crosscompile and other targets.
     "//third_party/triton:temporary/header.patch",
+    # Force MMA v2 layout for Blackwell until MMA v5 support is integrated.
+    "//third_party/triton:temporary/sm100_mmav2.patch",
     # Add new patches just above this line
 ]

--- a/third_party/triton/temporary/sm100_mmav2.patch
+++ b/third_party/triton/temporary/sm100_mmav2.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+index 89e854108..0bd46f022 100644
+--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
++++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+@@ -26,7 +26,7 @@ static int getMMAVersionSafe(int computeCapability, DotOp op) {
+   SmallVector<int> versionsSupported;
+   if (computeCapability < 75) {
+     versionsSupported = {1};
+-  } else if (computeCapability < 90) {
++  } else if (computeCapability < 90 || computeCapability >= 100) {
+     versionsSupported = {2};
+   } else if (computeCapability < 100) {
+     versionsSupported = {3, 2};


### PR DESCRIPTION
Triton commit https://github.com/triton-lang/triton/commit/b39c1e14b8f2029bc6a8798e4914d2692edf97d8 enables MMA v5 support for Blackwell.

Until it is integrated into OpenXLA, Triton generates unsupported PTX instructions for SM100 - this PR fixes the issue by falling back to MMA v2 for SM100+. Without it, the compilation of Triton GEMM kernels fails on Blackwell.