### PR TITLE
bug: perf regression over 10%

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -818,6 +818,7 @@ absl::Status RunOptimizationPasses(
     pipeline.AddPass<HloConstantFolding>();
     pipeline.AddPass<ConditionalSimplifier>();
     pipeline.AddPass<RealImagExpander>();
+    pipeline.AddPass<TransposeFolding>(CanFoldTransposeOperandIntoDot);
     pipeline.AddPass<HloCSE>(/*is_layout_sensitive=*/false);
     pipeline.AddPass<HloDCE>();
   }();
@@ -831,7 +832,6 @@ absl::Status RunOptimizationPasses(
     pipeline.AddPass<ConvertMover>();
     pipeline.AddPass<GpuAlgebraicSimplifier>(layout_insensitive_algsimp_opts,
                                              gpu_version);
-    pipeline.AddPass<TransposeFolding>(CanFoldTransposeOperandIntoDot);
   }();
 
   pipeline.AddPass<HloComputationDeduplicator>(


### PR DESCRIPTION
Hi, We found out that https://github.com/openxla/xla/commit/961e5c25fbd4082a1ac4f2e0865ad28163d12f7d caused a significant drop of performances in our LLM server (over 10%) on Cuda and Rocm. 

Either re-adding `pipeline.AddPass<TransposeFolding>(CanFoldTransposeOperandIntoDot);` at its previous place without removing the new one, or going back to the previous state is fixing the issue.

If you need anything from us for testing, please do not hesitate to ping. Thanks!

