### PR TITLE
[PATCH] [PJRT C API] Ensure C compliance for Profiler Extension

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_profiler_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_profiler_extension.h
@@ -16,8 +16,10 @@ limitations under the License.
 #ifndef XLA_PJRT_C_PJRT_C_API_PROFILER_EXTENSION_H_
 #define XLA_PJRT_C_PJRT_C_API_PROFILER_EXTENSION_H_
 
+#ifdef __cplusplus
 #include <cstddef>
 #include <cstdint>
+#endif
 
 #include "xla/backends/profiler/plugin/profiler_c_api.h"
 #include "xla/pjrt/c/pjrt_c_api.h"


### PR DESCRIPTION
Wraps `<cstddef>` and `<cstdint>` includes with `#ifdef __cplusplus` to maintain C compatibility. No functional changes.