### PR TITLE
[ROCM] Try targeting cuBLAS if it's not profitable to fuse dot

### DIFF
--- a/xla/service/gpu/transforms/gemm_fusion.cc
+++ b/xla/service/gpu/transforms/gemm_fusion.cc
@@ -805,14 +805,9 @@ class GemmFusionVisitor : public DfsHloRewriteVisitor {
     // If a GEMM requiring padding for cuBLAS is encountered here this
     // happened because earlier ShouldTritonHandleGEMM() accepted it and padding
     // was skipped. Accept it ignoring profitability checks.
-    // TODO(rocm): check ROCM padding requirements.
-    if (std::holds_alternative<se::CudaComputeCapability>(gpu_version_)) {
-      if (!CublasRequiresPadding(
-              *Cast<HloDotInstruction>(dot),
-              std::get<se::CudaComputeCapability>(gpu_version_)) &&
-          !decision.WantToFuse()) {
-        return absl::OkStatus();
-      }
+    if (!CublasRequiresPadding(*Cast<HloDotInstruction>(dot), gpu_version_) &&
+        !decision.WantToFuse()) {
+      return absl::OkStatus();
     }
 
     HloComputation* computation =

--- a/xla/service/gpu/transforms/gemm_fusion_test.cc
+++ b/xla/service/gpu/transforms/gemm_fusion_test.cc
@@ -1247,6 +1247,22 @@ e {
                                     m::GetTupleElement()))));
 }
 
+TEST_F(GemmFusionTest, DoNotFuseNonProfitableDot) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+HloModule m
+
+ENTRY e {
+  p0 = bf16[1024] parameter(0)
+  b0 = bf16[16,64] bitcast(p0)
+  p1 = bf16[1024] parameter(1)
+  b1 = bf16[64,16] bitcast(p1)
+  ROOT d = bf16[16,16] dot(b0, b1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0}
+})")
+                    .value();
+  EXPECT_FALSE(GemmFusion(gpu_version_).Run(module.get()).value());
+}
+
 // A test fixture class for testing the threshold for small matrices.
 class SmallDotGemmFusionTest : public GemmFusionTest {
  public:


### PR DESCRIPTION
TritonTest.NonstandardLayoutWithManyNonContractingDims
TritonTest.NonstandardLayoutWithManyNonContractingDimsReversedLayout

If it's not profitable to fuse dot and cuBLAS is not requiring extra padding then targeting custom call would be optimal. Align this check for both ROCm and CUDA here.
 
@xla-rotation would you please have a look?