### PR TITLE
Define SO_ZEROCOPY, SO_EE_ORIGIN_ZEROCOPY when missing (e.g. in conda sysroot)

### DIFF
--- a/xla/python/transfer/event_loop.h
+++ b/xla/python/transfer/event_loop.h
@@ -24,6 +24,17 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
+// socket.h in conda sysroot include directory does not define
+// SO_ZEROCOPY and SO_EE_ORIGIN_ZEROCOPY that were introduced in a
+// newer kernel version compared to one used by the conda sysroot, see
+// openxla/xla#22083.
+#ifndef SO_ZEROCOPY
+#define SO_ZEROCOPY 60
+#endif
+#ifndef SO_EE_ORIGIN_ZEROCOPY
+#define SO_EE_ORIGIN_ZEROCOPY 5
+#endif
+
 namespace aux {
 
 // Basic event loop using poll().


### PR DESCRIPTION
As in the title.

Conda sysroot includes headers from an old version of linux kernel that does not define SO_ZEROCOPY nor SO_EE_ORIGIN_ZEROCOPY but are required by the feature implemented in https://github.com/openxla/xla/pull/21496 .

Fixes https://github.com/openxla/xla/issues/22083