### PR TITLE
[ROCm] Add support for the collective memory allocator type

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -776,6 +776,33 @@ RocmExecutor::CreateMemoryAllocator(MemoryType type) {
                 }
               });
         });
+  } else if (type == MemoryType::kCollective) {
+    return std::make_unique<GenericMemoryAllocator>(
+        [this](uint64_t size)
+            -> absl::StatusOr<std::unique_ptr<MemoryAllocation>> {
+          void* ptr = nullptr;
+          auto hipResult = wrap::hipMalloc(&ptr, size);
+          if (hipResult != hipSuccess) {
+            return absl::InternalError(absl::StrFormat(
+                "failed to allocate %s (%llu bytes) from device collective "
+                "memory: %s, "
+                "Last NCCL warning(error)",
+                tsl::strings::HumanReadableNumBytes(size), size,
+                hipGetErrorString(hipResult)));
+          }
+          VLOG(2) << "allocated " << ptr << " of " << size
+                  << " bytes of collective memory";
+          return std::make_unique<GenericMemoryAllocation>(
+              ptr, size, [this](void* location, uint64_t size) {
+                auto status = wrap::hipFree(location);
+                if (status != hipSuccess) {
+                  LOG(ERROR) << "failed to free collective memory at "
+                             << location << "; result: " << status;
+                } else {
+                  VLOG(2) << "deallocated collective memory at " << location;
+                }
+              });
+        });
   } else if (type == MemoryType::kHost) {
     return std::make_unique<GenericMemoryAllocator>(
         [this](uint64_t size)

--- a/xla/stream_executor/rocm/rocm_executor_test.cc
+++ b/xla/stream_executor/rocm/rocm_executor_test.cc
@@ -111,14 +111,27 @@ TEST(RocmExecutorTest, CreateHostMemoryAllocatorWorks) {
   allocation.reset();
 }
 
+TEST(RocmExecutorTest, CreateCollectiveMemoryAllocatorWorks) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("ROCM"));
+  TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                          platform->ExecutorForDevice(0));
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<MemoryAllocator> allocator,
+      executor->CreateMemoryAllocator(MemoryType::kCollective));
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                          allocator->Allocate(1024));
+  EXPECT_NE(allocation->opaque(), nullptr);
+  EXPECT_EQ(allocation->size(), 1024);
+  allocation.reset();
+}
+
 TEST(RocmExecutorTest, CreateUnsupportedMemoryAllocatorsFail) {
   TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
                           PlatformManager::PlatformWithName("ROCM"));
   TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
                           platform->ExecutorForDevice(0));
   EXPECT_THAT(executor->CreateMemoryAllocator(MemoryType::kDevice),
-              Not(IsOk()));
-  EXPECT_THAT(executor->CreateMemoryAllocator(MemoryType::kCollective),
               Not(IsOk()));
 }
 


### PR DESCRIPTION
This pr introduces support for the collective memory allocator in rocm. Fixing the failing test due to the missing support.