### PR TITLE
Add "block-scaled-dot" HLO op

### DIFF
--- a/xla/hlo/builder/xla_builder.h
+++ b/xla/hlo/builder/xla_builder.h
@@ -627,6 +627,11 @@ class XlaBuilder {
       const PrecisionConfig* precision_config = nullptr,
       std::optional<PrimitiveType> preferred_element_type = std::nullopt);
 
+  XlaOp BlockScaledDot(
+      XlaOp lhs, XlaOp rhs, XlaOp lhs_scale, XlaOp rhs_scale,
+      const BlockScaledDotConfig& block_scaled_config,
+      std::optional<PrimitiveType> preferred_element_type = std::nullopt);
+
   XlaOp Conv(
       XlaOp lhs, XlaOp rhs, absl::Span<const int64_t> window_strides,
       Padding padding, int64_t feature_group_count = 1,
@@ -1342,6 +1347,10 @@ class XlaBuilder {
                          const RaggedDotDimensionNumbers& dimension_numbers,
                          const PrecisionConfig* precision_config,
                          std::optional<PrimitiveType> preferred_element_type);
+  friend XlaOp BlockScaledDot(
+      XlaOp lhs, XlaOp rhs, XlaOp lhs_scale, XlaOp rhs_scale,
+      const BlockScaledDotConfig& block_scaled_config,
+      std::optional<PrimitiveType> preferred_element_type);
   friend XlaOp Conv(XlaOp lhs, XlaOp rhs,
                     absl::Span<const int64_t> window_strides, Padding padding,
                     int64_t feature_group_count, int64_t batch_group_count,
@@ -2237,6 +2246,12 @@ XlaOp RaggedDot(
     XlaOp lhs, XlaOp rhs, XlaOp group_sizes,
     const RaggedDotDimensionNumbers& dimension_numbers,
     const PrecisionConfig* precision_config = nullptr,
+    std::optional<PrimitiveType> preferred_element_type = std::nullopt);
+
+// Enqueues a block scaled dot instruction onto the computation.
+XlaOp BlockScaledDot(
+    XlaOp lhs, XlaOp rhs, XlaOp lhs_scale, XlaOp rhs_scale,
+    const BlockScaledDotConfig& block_scaled_config,
     std::optional<PrimitiveType> preferred_element_type = std::nullopt);
 
 // Enqueues a convolution instruction onto the computation, which uses the

--- a/xla/hlo/ir/dfs_hlo_visitor.h
+++ b/xla/hlo/ir/dfs_hlo_visitor.h
@@ -110,6 +110,7 @@ class DfsHloVisitorBase {
   }
   virtual absl::Status HandleDot(HloInstructionPtr hlo) = 0;
   virtual absl::Status HandleRaggedDot(HloInstructionPtr hlo) = 0;
+  virtual absl::Status HandleBlockScaledDot(HloInstructionPtr hlo) = 0;
   virtual absl::Status HandlePower(HloInstructionPtr hlo) {
     return HandleElementwiseBinary(hlo);
   }

--- a/xla/hlo/ir/dfs_hlo_visitor_with_default.h
+++ b/xla/hlo/ir/dfs_hlo_visitor_with_default.h
@@ -84,6 +84,9 @@ class DfsHloVisitorWithDefaultBase
   absl::Status HandleRaggedDot(HloInstructionPtr dot) override {
     return DefaultAction(dot);
   }
+  absl::Status HandleBlockScaledDot(HloInstructionPtr dot) override {
+    return DefaultAction(dot);
+  }
   absl::Status HandleConvolution(HloInstructionPtr convolution) override {
     return DefaultAction(convolution);
   }

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -469,6 +469,14 @@ class HloInstruction {
       const RaggedDotDimensionNumbers& dimension_numbers,
       const PrecisionConfig& precision_config);
 
+  // Create a block scaled dot op with operands 'lhs', 'rhs', and optional block
+  // scaling factors. Same arguments as `HloBlockScaledDotInstruction`
+  // constructor, see the comments there.
+  static std::unique_ptr<HloInstruction> CreateBlockScaledDot(
+      const Shape& shape, HloInstruction* lhs, HloInstruction* rhs,
+      const BlockScaledDotConfig& block_scaled_config,
+      absl::Span<HloInstruction* const> scales);
+
   // Creates a reduce-precision op, where operand is the data to reduce in
   // precision, and exponent_bits and mantissa_bits describe the precision to
   // reduce it to.

--- a/xla/hlo/ir/hlo_opcode.h
+++ b/xla/hlo/ir/hlo_opcode.h
@@ -68,6 +68,7 @@ namespace xla {
   V(kBatchNormTraining, "batch-norm-training", 3)                              \
   V(kBitcast, "bitcast", 1)                                                    \
   V(kBitcastConvert, "bitcast-convert", 1)                                     \
+  V(kBlockScaledDot, "block-scaled-dot", kHloOpcodeIsVariadic)                 \
   V(kBroadcast, "broadcast", 1)                                                \
   V(kCall, "call", kHloOpcodeIsVariadic)                                       \
   V(kCbrt, "cbrt", 1)                                                          \

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -1957,6 +1957,50 @@ ENTRY dot {
 
 )"
 },
+// block-scaled-dot
+{
+"BlockScaledDot",
+R"(HloModule block_scaled_dot, entry_computation_layout={(f8e4m3fn[2,16,64]{2,1,0}, f8e4m3fn[2,32,64]{2,1,0}, f8e5m2[2,16,2]{2,1,0}, f8e5m2[2,32,2]{2,1,0})->f32[2,16,32]{2,1,0}}
+
+ENTRY block_scaled_dot {
+  lhs = f8e4m3fn[2,16,64]{2,1,0} parameter(0)
+  rhs = f8e4m3fn[2,32,64]{2,1,0} parameter(1)
+  lhs_scale = f8e5m2[2,16,2]{2,1,0} parameter(2)
+  rhs_scale = f8e5m2[2,32,2]{2,1,0} parameter(3)
+  ROOT res = f32[2,16,32]{2,1,0} block-scaled-dot(lhs, rhs, lhs_scale, rhs_scale), lhs_batch_dims={0}, lhs_contracting_dims={2}, rhs_batch_dims={0}, rhs_contracting_dims={2}, block_size=32, dequantize_type=f16
+}
+
+)"
+},
+// block-scaled-dot (lhs)
+{
+"BlockScaledDotLhs",
+R"(HloModule block_scaled_dot, entry_computation_layout={(f8e4m3fn[16,64]{1,0}, f16[32,64]{1,0}, f16[16,8]{1,0})->f32[16,32]{1,0}}
+
+ENTRY block_scaled_dot {
+  lhs = f8e4m3fn[16,64]{1,0} parameter(0)
+  rhs = f16[32,64]{1,0} parameter(1)
+  lhs_scale = f16[16,8]{1,0} parameter(2)
+  ROOT res = f32[16,32]{1,0} block-scaled-dot(lhs, rhs, lhs_scale), lhs_contracting_dims={1}, rhs_contracting_dims={1}, lhs_block_size=8
+}
+
+)"
+},
+// block-scaled-dot (rhs)
+{
+"BlockScaledDotRhs",
+R"(HloModule block_scaled_dot, entry_computation_layout={(f16[16,64]{1,0}, f8e4m3fn[32,64]{1,0}, f16[32,8]{1,0})->f32[16,32]{1,0}}
+
+ENTRY block_scaled_dot {
+  lhs = f16[16,64]{1,0} parameter(0)
+  rhs = f8e4m3fn[32,64]{1,0} parameter(1)
+  rhs_scale = f16[32,8]{1,0} parameter(2)
+  ROOT res = f32[16,32]{1,0} block-scaled-dot(lhs, rhs, rhs_scale), lhs_contracting_dims={1}, rhs_contracting_dims={1}, rhs_block_size=8
+}
+
+)"
+},
+// gather
 {
 "gather",
 R"(HloModule gather, entry_computation_layout={(f32[50,49,48,47,46]{4,3,2,1,0}, s64[10,9,8,7,5]{4,3,2,1,0})->f32[10,9,8,7,30,29,28,27,26]{8,7,6,5,4,3,2,1,0}}

--- a/xla/service/hlo.proto
+++ b/xla/service/hlo.proto
@@ -113,7 +113,7 @@ enum CustomCallApiVersion {
 }
 
 // Serialization of HloInstruction.
-// Next ID: 92
+// Next ID: 93
 message HloInstructionProto {
   reserved 10;
   reserved "parameter_name";
@@ -226,6 +226,9 @@ message HloInstructionProto {
 
   // Describes the dimension numbers used for a ragged dot operation
   xla.RaggedDotDimensionNumbers ragged_dot_dimension_numbers = 90;
+
+  // Describes the configuration used for a block scaled dot operation.
+  xla.BlockScaledDotConfig block_scaled_dot_config = 92;
 
   // FFT type (FFT, IFFT, etc).
   xla.FftType fft_type = 31;

--- a/xla/service/hlo_cost_analysis.cc
+++ b/xla/service/hlo_cost_analysis.cc
@@ -482,6 +482,14 @@ absl::Status HloCostAnalysis::HandleRaggedDot(
   return absl::OkStatus();
 }
 
+absl::Status HloCostAnalysis::HandleBlockScaledDot(const HloInstruction* hlo) {
+  auto block_scaled_dot = Cast<HloBlockScaledDotInstruction>(hlo);
+  current_properties_[kFlopsKey] =
+      GetDotFlops(hlo->operand(0)->shape(), hlo->shape(),
+                  block_scaled_dot->dot_dimension_numbers());
+  return absl::OkStatus();
+}
+
 absl::Status HloCostAnalysis::HandleInfeed(const HloInstruction* infeed) {
   // Count nested infeed output tuples.
   int64_t size = 0;

--- a/xla/service/hlo_cost_analysis.h
+++ b/xla/service/hlo_cost_analysis.h
@@ -479,6 +479,7 @@ class HloCostAnalysis : public ConstDfsHloVisitor {
   absl::Status HandleDomain(const HloInstruction* domain) override;
   absl::Status HandleDot(const HloInstruction* dot) override;
   absl::Status HandleRaggedDot(const HloInstruction* dot) override;
+  absl::Status HandleBlockScaledDot(const HloInstruction* dot) override;
   absl::Status HandleConvolution(const HloInstruction* convolution) override;
   absl::Status HandleFft(const HloInstruction* fft) override;
   absl::Status HandleTriangularSolve(const HloInstruction* hlo) override;

--- a/xla/service/hlo_creation_utils.h
+++ b/xla/service/hlo_creation_utils.h
@@ -192,6 +192,15 @@ absl::StatusOr<HloInstruction*> MakeRaggedDotHlo(
     const PrecisionConfig& precision_config,
     std::optional<PrimitiveType> preferred_element_type);
 
+// Creates a BlockScaledDot HLO instruction and adds it to the computation
+// containing `lhs`, `rhs`, and optionally `lhs_scale`, `rhs_scale` (all must
+// be in the same computation). An optional `preferred_element_type` can be
+// specified to override the element type.
+absl::StatusOr<HloInstruction*> MakeBlockScaledDotHlo(
+    HloInstruction* lhs, HloInstruction* rhs, HloInstruction* lhs_scale,
+    HloInstruction* rhs_scale, const BlockScaledDotConfig& block_scaled_config,
+    std::optional<PrimitiveType> preferred_element_type);
+
 // Creates a Map HLO instruction and adds it to the computation containing the
 // operands. All operands must be in the same computation.
 absl::StatusOr<HloInstruction*> MakeMapHlo(

--- a/xla/service/hlo_graph_dumper.cc
+++ b/xla/service/hlo_graph_dumper.cc
@@ -1231,6 +1231,7 @@ ColorScheme HloDotDumper::GetInstructionColor(const HloInstruction* instr) {
     case HloOpcode::kConvolution:
     case HloOpcode::kDot:
     case HloOpcode::kRaggedDot:
+    case HloOpcode::kBlockScaledDot:
     case HloOpcode::kFft:
     case HloOpcode::kTriangularSolve:
     case HloOpcode::kCholesky:

--- a/xla/service/hlo_verifier.h
+++ b/xla/service/hlo_verifier.h
@@ -206,6 +206,7 @@ class ShapeVerifier : public DfsHloVisitor {
   absl::Status HandleCollectivePermuteDone(HloInstruction* hlo) override;
   absl::Status HandlePartitionId(HloInstruction* hlo) override;
   absl::Status HandleRaggedDot(HloInstruction* ragged_dot) override;
+  absl::Status HandleBlockScaledDot(HloInstruction* hlo) override;
   absl::Status HandleReplicaId(HloInstruction* hlo) override;
   absl::Status HandleReducePrecision(HloInstruction* reduce_precision) override;
   absl::Status HandleInfeed(HloInstruction*) override;

--- a/xla/service/instruction_fusion.cc
+++ b/xla/service/instruction_fusion.cc
@@ -179,6 +179,7 @@ bool IsAlwaysDuplicable(const HloInstruction& instruction) {
     case HloOpcode::kBatchNormGrad:
     case HloOpcode::kBatchNormInference:
     case HloOpcode::kBatchNormTraining:
+    case HloOpcode::kBlockScaledDot:
     case HloOpcode::kCall:
     case HloOpcode::kCholesky:
     case HloOpcode::kConditional:

--- a/xla/service/layout_assignment.cc
+++ b/xla/service/layout_assignment.cc
@@ -2885,6 +2885,7 @@ bool LayoutAssignment::InstructionCanChangeLayout(
     case HloOpcode::kBatchNormInference:
     case HloOpcode::kBatchNormTraining:
     case HloOpcode::kBitcast:
+    case HloOpcode::kBlockScaledDot:
     case HloOpcode::kBroadcast:
     case HloOpcode::kCall:
     case HloOpcode::kCollectivePermuteStart:

--- a/xla/service/shape_inference.h
+++ b/xla/service/shape_inference.h
@@ -367,6 +367,10 @@ class ShapeInference {
       const Shape& operand_shape, const DotDimensionNumbers& dimension_numbers,
       const SparsityDescriptor& sparsity, PrimitiveType element_type = U16);
 
+  // Helper that infers the scaled dimension of the block scaled dot operand.
+  static absl::StatusOr<int64_t> InferBlockScaledDotDimension(
+      const Shape& operand_shape, const Shape& scale_shape);
+
   // Helper that infers the shape produced by performing a ragged dot operation
   // with the given LHS and RHS shapes. An optional preferred_element_type can
   // be specified to upcast the element type.

--- a/xla/service/shape_inference_test.cc
+++ b/xla/service/shape_inference_test.cc
@@ -2168,6 +2168,23 @@ TEST_F(ShapeInferenceTest, SparseDotMetadata) {
       ShapeUtil::Equal(inferred_shape, ShapeUtil::MakeShape(U16, {5, 10, 2})));
 }
 
+TEST_F(ShapeInferenceTest, BlockScaledDotDimension) {
+  TF_ASSERT_OK_AND_ASSIGN(int64_t inferred_dim,
+                          ShapeInference::InferBlockScaledDotDimension(
+                              ShapeUtil::MakeShape(F8E4M3FN, {1, 8, 64}),
+                              ShapeUtil::MakeShape(F8E8M0FNU, {1, 8, 4})));
+  EXPECT_EQ(inferred_dim, 2);
+
+  EXPECT_FALSE(ShapeInference::InferBlockScaledDotDimension(
+                   ShapeUtil::MakeShape(F8E4M3FN, {1, 8, 63}),
+                   ShapeUtil::MakeShape(F8E8M0FNU, {1, 8, 4}))
+                   .ok());
+  EXPECT_FALSE(ShapeInference::InferBlockScaledDotDimension(
+                   ShapeUtil::MakeShape(F8E4M3FN, {1, 8, 64}),
+                   ShapeUtil::MakeShape(F8E8M0FNU, {1, 2, 4}))
+                   .ok());
+}
+
 // <ragged-dot> : [m,k], [g,k,n], [g] -> [m,n]
 TEST_F(ShapeInferenceTest, RaggedDotRaggedNonContracting) {
   const Shape lhs_shape = ShapeUtil::MakeShape(F32, {11, 5});

--- a/xla/service/sharding_propagation.cc
+++ b/xla/service/sharding_propagation.cc
@@ -301,6 +301,7 @@ const HloInstruction* PickRepresentativeOperand(
     case HloOpcode::kBatchNormInference:
     case HloOpcode::kBatchNormTraining:
     case HloOpcode::kBitcast:
+    case HloOpcode::kBlockScaledDot:
     case HloOpcode::kBroadcast:
     case HloOpcode::kCall:
     case HloOpcode::kCholesky:

--- a/xla/xla_data.proto
+++ b/xla/xla_data.proto
@@ -788,6 +788,20 @@ message RaggedDotDimensionNumbers {
   repeated int64 rhs_group_dimensions = 3;
 }
 
+message BlockScaledDotConfig {
+  // The contracting and batch dimensions of the 'lhs' and 'rhs'.
+  DotDimensionNumbers dot_dimension_numbers = 1;
+
+  // Intermediate type used for dequantization. The input/scale argument pairs
+  // are dequantized to this type, and then used as the inputs to the (implied)
+  // dot op. If omitted, will default to the dot result type.
+  optional PrimitiveType dequantize_type = 2;
+
+  // Block sizes for 'lhs' and 'rhs' scaling factors could be set separately.
+  optional int64 lhs_block_size = 3;
+  optional int64 rhs_block_size = 4;
+}
+
 enum SparsityType {
   SPARSITY_INVALID = 0;
 


### PR DESCRIPTION
This PR adds a new "block-scaled-dot" HLO op, which allows representing a general dot op where one or both inputs have an accompanying scaling factor tensor.

The support for block scaled dot with [MXFP8](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf) inputs is available in Blackwell hardware, and is implemented in [cuDNN](https://github.com/NVIDIA/cudnn-frontend/blob/main/include/cudnn_frontend/node/block_scale_dequantize.h) (requires CUDA 12.8, cuDNN 9.7) and in [Triton](https://github.com/triton-lang/triton/blob/b3dcc32f387d1d54ccd6cbbbc087296c0539e703/include/triton/Dialect/Triton/IR/TritonOps.td#L671) (since 2025-01-28). SOTA models (like [DeepSeekV3](https://arxiv.org/html/2412.19437v1#S3.SS3.SSS2.Px1)) use block scaling. In XLA, there's an equivalent [custom call](https://github.com/openxla/xla/blob/5116f3abf896242a3860707eb8b1cd5cc52dc8f4/xla/service/gpu/transforms/block_scaling_rewriter.h#L44), the intent is to replace it with a first-class HLO op.

This PR only adds the new HLO op (similar to [ragged-dot](https://github.com/openxla/xla/commit/c65b83d1f75b28b07619ea092366801ce1c1a700)), the actual support for lowering this op (via cuDNN and Trtion) will follow. The existing [BlockScalingRewriter](https://github.com/openxla/xla/blob/e816ee557c3025663e0514566423f0eeb77ffb35/xla/service/gpu/transforms/block_scaling_rewriter.h#L65) pass may be used to rewrite this op to an equivalent HLO graph, until the lowering support (to e.g. Triton) is available.

## Syntax

The op has 3 (if one input is quantized) or 4 (if both inputs are quantized) operands. Possible variations:

1. block-scaled-dot(%lhs, %rhs, %lhs_scale), lhs_block_size=L
2. block-scaled-dot(%lhs, %rhs, %rhs_scale), rhs_block_size=R
3. block-scaled-dot(%lhs, %rhs, %lhs_scale, %rhs_scale), lhs_block_size=L, rhs_block_size=R _(block sizes are different)_
4. block-scaled-dot(%lhs, %rhs, %lhs_scale, %rhs_scale), block_size=LR _(block sizes are the same)_

The op has the attributes for describing the dot dimension numbers, same as the general dot op attributes: `lhs_contracting_dims` and `rhs_contracting_dims` are required, `lhs_batch_dims` and `rhs_batch_dims` are optional, and the non-contracting dimensions are implicit.

The op also has an optional attribute, `dequantize_type`. If set, it defines the intermediary dequantization type (e.g. `bf16`), otherwise the dequantization type is implied from the op resulting shape. The user may want to set this explicitly, as this will affect the numerics.

## Semantics

Conceptually, the "block-scaled-dot" op may be substituted with "dequantize -> dot" graph, where "dequantize" is "broadcast -> reshape -> multiply" sequence for each block scaled input (lhs, rhs, or both).

If LHS is quantized (i.e. both %lhs and %lhs_scale operands are present), the operand pair shapes (input/scale) must be the same, except for one dimension `d` (called the block scaled dimension), which has to satisfy "lhs.shape[d] == lhs_scale.shape[d] * lhs_block_size" invariant. Similarly for RHS.

Block scaled LHS/RHS examples:
- ```(f8e5m2[10,128], f8e8m0fnu[10,4])``` for MXFP8 (block size 32);
- ```(f4e2m1fn[12,128], f4e4m3fn[12,8])``` for NVFP4 (block size 16).

HLO op examples:
- Simple MXFP8:
```f32[16,32] block-scaled-dot(f8e5m2[16,128] %lhs, f8e5m2[32,128] %rhs, f8e8m0fnu[16,4] %lhs_scale, f8e8m0fnu[32,4] %rhs_scale), lhs_contracting_dims={1}, rhs_contracting_dims={1}, block_size=32```
- Custom configuration:
```f32[16,4,2,8,32] block-scaled-dot(f8e4m3fn[4,16,256,2,8] %lhs, f8e5m2[4,32,16,256] %rhs, bf16[4,16,32,2,8] %lhs_scale, bf16[4,32,16,16] %rhs_scale), lhs_batch_dims={1,0}, rhs_batch_dims={2,0}, lhs_contracting_dims={2}, rhs_contracting_dims={3}, lhs_block_size=8, rhs_block_size=16, dequantize_type=f32```
