### PR TITLE
[GPU] Fix sharded autotuning compatibility with result caching.

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "gtest/gtest.h"
 #include "mlir/IR/MLIRContext.h"
 #include "xla/ffi/ffi.h"
 #include "xla/ffi/ffi_api.h"
@@ -1869,8 +1870,21 @@ TEST(StreamExecutorGpuClientTest, AutoLayoutIsSupported) {
   EXPECT_NE(layouts[1]->ToString(), "{2,1,0}");
 }
 
+struct ShardedAutotuningTestInfo {
+  bool use_xla_computation;
+  int num_active_nodes;
+  int num_nodes_using_cache;
+
+  static std::string Name(
+      const ::testing::TestParamInfo<ShardedAutotuningTestInfo>& info) {
+    return absl::StrFormat(
+        "computation_%d_active_%d_cache_%d", info.param.use_xla_computation,
+        info.param.num_active_nodes, info.param.num_nodes_using_cache);
+  }
+};
+
 class ShardedAutotuningTest
-    : public ::testing::TestWithParam<std::tuple<bool, int>> {
+    : public ::testing::TestWithParam<ShardedAutotuningTestInfo> {
  public:
   static constexpr int kNumNodes = 2;
 };
@@ -1878,51 +1892,66 @@ class ShardedAutotuningTest
 static const char* test_binary_name;
 
 TEST_P(ShardedAutotuningTest, ShardedAutotuningWorks) {
-  bool use_xla_computation;
-  int num_active_nodes;
-  std::tie(use_xla_computation, num_active_nodes) = GetParam();
+  ShardedAutotuningTestInfo param = GetParam();
+
+  std::string cache_dir;
+  CHECK(tsl::Env::Default()->LocalTempFilename(&cache_dir));
 
   tsl::setenv("TF_CPP_VMODULE", "gemm_fusion_autotuner=1", /*overwrite=*/true);
-  tsl::SubProcess child[kNumNodes];
-  for (int node_id = 0; node_id < kNumNodes; ++node_id) {
-    std::vector<std::string> argv;
-    argv.reserve(4);
-    argv.push_back(test_binary_name);
-    argv.push_back(absl::StrFormat("--node_id=%d", node_id));
-    argv.push_back(
-        absl::StrFormat("--use_xla_computation=%d", use_xla_computation));
-    argv.push_back(absl::StrFormat("--num_active_nodes=%d", num_active_nodes));
-    child[node_id].SetProgram(test_binary_name, argv);
-    child[node_id].SetChannelAction(tsl::CHAN_STDOUT, tsl::ACTION_PIPE);
-    child[node_id].SetChannelAction(tsl::CHAN_STDERR, tsl::ACTION_PIPE);
-    ASSERT_TRUE(child[node_id].Start()) << "node " << node_id;
-  }
-  for (int node_id = 0; node_id < kNumNodes; ++node_id) {
-    std::string stdout_str;
-    std::string stderr_str;
-    int child_status =
-        child[node_id].Communicate(nullptr, &stdout_str, &stderr_str);
-    if (WIFEXITED(child_status) &&
-        WEXITSTATUS(child_status) ==
-            static_cast<int>(absl::StatusCode::kFailedPrecondition)) {
-      GTEST_SKIP() << "Requires Ampere+ GPU.";
+
+  // Compile twice to test both empty and non-empty disk cache.
+  for (int iteration = 0; iteration < 2; ++iteration) {
+    tsl::SubProcess child[kNumNodes];
+    for (int node_id = 0; node_id < kNumNodes; ++node_id) {
+      std::vector<std::string> argv;
+      argv.reserve(6);
+      argv.push_back(test_binary_name);
+      argv.push_back(absl::StrFormat("--node_id=%d", node_id));
+      argv.push_back(absl::StrFormat("--use_xla_computation=%d",
+                                     param.use_xla_computation));
+      argv.push_back(
+          absl::StrFormat("--num_active_nodes=%d", param.num_active_nodes));
+      argv.push_back(absl::StrFormat("--num_nodes_using_cache=%d",
+                                     param.num_nodes_using_cache));
+      argv.push_back(absl::StrFormat("--cache_dir=%s", cache_dir));
+      child[node_id].SetProgram(test_binary_name, argv);
+      child[node_id].SetChannelAction(tsl::CHAN_STDOUT, tsl::ACTION_PIPE);
+      child[node_id].SetChannelAction(tsl::CHAN_STDERR, tsl::ACTION_PIPE);
+      ASSERT_TRUE(child[node_id].Start()) << "node " << node_id;
     }
-    EXPECT_EQ(child_status, 0) << " node " << node_id << "\nstdout:\n"
-                               << stdout_str << "\nstderr:\n"
-                               << stderr_str;
-    if (node_id < num_active_nodes) {
-      EXPECT_THAT(stderr_str,
-                  HasSubstr(absl::StrFormat(
-                      "Shard %d / %d: autotuning %d / 1 fusions", node_id + 1,
-                      num_active_nodes, (node_id == 0) ? 1 : 0)));
-    } else {
-      EXPECT_THAT(stderr_str, Not(HasSubstr("autotuning")));
+    for (int node_id = 0; node_id < kNumNodes; ++node_id) {
+      std::string stdout_str;
+      std::string stderr_str;
+      int child_status =
+          child[node_id].Communicate(nullptr, &stdout_str, &stderr_str);
+      if (WIFEXITED(child_status) &&
+          WEXITSTATUS(child_status) ==
+              static_cast<int>(absl::StatusCode::kFailedPrecondition)) {
+        GTEST_SKIP() << "Requires Ampere+ GPU.";
+      }
+      EXPECT_EQ(child_status, 0) << " node " << node_id << "\nstdout:\n"
+                                 << stdout_str << "\nstderr:\n"
+                                 << stderr_str;
+      if (node_id < param.num_active_nodes) {
+        int num_fusions_to_autotune = (node_id == 0) ? 1 : 0;
+        if (iteration > 0 && node_id < param.num_nodes_using_cache) {
+          num_fusions_to_autotune = 0;
+        }
+        EXPECT_THAT(stderr_str,
+                    HasSubstr(absl::StrFormat(
+                        "Rank %d / %d: autotuning %d / 1 fusions", node_id,
+                        param.num_active_nodes, num_fusions_to_autotune)));
+      } else {
+        EXPECT_THAT(stderr_str, Not(HasSubstr("autotuning")));
+      }
     }
   }
 }
 
 absl::Status ShardedAutotuningWorksTestBody(const int node_id,
                                             const int num_active_nodes,
+                                            const int num_nodes_using_cache,
+                                            absl::string_view cache_dir,
                                             bool use_xla_computation) {
   std::unique_ptr<xla::DistributedRuntimeService> service;
   if (node_id == 0) {
@@ -1966,22 +1995,27 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id,
 
   CompileOptions compile_options;
   compile_options.executable_build_options.set_num_replicas(num_active_nodes);
-  DebugOptions* debug_options =
-      compile_options.executable_build_options.mutable_debug_options();
-  debug_options->set_xla_gpu_shard_autotuning(true);
-  debug_options->set_xla_gpu_triton_gemm_any(true);
-  debug_options->set_xla_gpu_cublas_fallback(false);
+  DebugOptions& debug_options =
+      *compile_options.executable_build_options.mutable_debug_options();
+  debug_options.set_xla_gpu_shard_autotuning(true);
+  debug_options.set_xla_gpu_triton_gemm_any(true);
+  debug_options.set_xla_gpu_cublas_fallback(false);
+
+  if (node_id < num_nodes_using_cache) {
+    debug_options.set_xla_gpu_per_fusion_autotune_cache_dir(
+        std::string(cache_dir));
+  }
 
   mlir::MLIRContext context;
   TF_ASSIGN_OR_RETURN(mlir::OwningOpRef<mlir::ModuleOp> module,
                       ParseMlirModuleString(R"mlir(
-      func.func public @main(%arg0: tensor<2x2048x2048xf32>) ->
-      (tensor<2x2048x2048xf32> {jax.result_info = ""}) {
+      func.func public @main(%arg0: tensor<2x32x32xf16>) ->
+      (tensor<2x32x32xf16> {jax.result_info = ""}) {
         %0 = stablehlo.dot_general %arg0, %arg0, batching_dims = [0] x [0],
         contracting_dims = [2] x [1]
-          : (tensor<2x2048x2048xf32>, tensor<2x2048x2048xf32>) ->
-          tensor<2x2048x2048xf32>
-        return %0 : tensor<2x2048x2048xf32>
+          : (tensor<2x32x32xf16>, tensor<2x32x32xf16>) ->
+          tensor<2x32x32xf16>
+        return %0 : tensor<2x32x32xf16>
       })mlir",
                                             context));
   std::unique_ptr<PjRtLoadedExecutable> executable;
@@ -2007,10 +2041,12 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id,
 
 INSTANTIATE_TEST_SUITE_P(
     ShardedAutotuningTest, ShardedAutotuningTest,
-    ::testing::Combine(::testing::Bool(),
-                       ::testing::Range(1,
-                                        ShardedAutotuningTest::kNumNodes + 1)));
-
+    ::testing::ValuesIn(std::vector<ShardedAutotuningTestInfo>{{true, 2, 0},
+                                                               {false, 2, 0},
+                                                               {false, 1, 0},
+                                                               {false, 2, 1},
+                                                               {false, 2, 2}}),
+    ShardedAutotuningTestInfo::Name);
 }  // namespace
 }  // namespace xla
 
@@ -2019,11 +2055,17 @@ int main(int argc, char* argv[]) {
   xla::test_binary_name = argv[0];
   int node_id = -1;
   int num_active_nodes = -1;
+  int num_nodes_using_cache = -1;
+  std::string cache_dir;
   bool use_xla_computation = false;
   std::vector<tsl::Flag> flag_list = {
       tsl::Flag("node_id", &node_id,
                 "Node ID for ShardedAutotuningWorks test."),
       tsl::Flag("num_active_nodes", &num_active_nodes,
+                "Test parameter for ShardedAutotuningWorks."),
+      tsl::Flag("num_nodes_using_cache", &num_nodes_using_cache,
+                "Test parameter for ShardedAutotuningWorks."),
+      tsl::Flag("cache_dir", &cache_dir,
                 "Test parameter for ShardedAutotuningWorks."),
       tsl::Flag("use_xla_computation", &use_xla_computation,
                 "Test parameter for ShardedAutotuningWorks."),
@@ -2033,9 +2075,13 @@ int main(int argc, char* argv[]) {
   tsl::Flags::Parse(&argc, argv, flag_list);
   testing::InitGoogleTest(&argc, argv);
   if (node_id >= 0) {
-    return xla::ShardedAutotuningWorksTestBody(node_id, num_active_nodes,
-                                               use_xla_computation)
-        .raw_code();
+    absl::Status result = xla::ShardedAutotuningWorksTestBody(
+        node_id, num_active_nodes, num_nodes_using_cache, cache_dir,
+        use_xla_computation);
+    if (!result.ok()) {
+      LOG(ERROR) << result.ToString();
+    }
+    return result.raw_code();
   }
   return RUN_ALL_TESTS();
 }

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -38,7 +38,6 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
-#include "gtest/gtest.h"
 #include "mlir/IR/MLIRContext.h"
 #include "xla/ffi/ffi.h"
 #include "xla/ffi/ffi_api.h"

--- a/xla/service/gpu/autotuning/autotuner_util.cc
+++ b/xla/service/gpu/autotuning/autotuner_util.cc
@@ -269,14 +269,18 @@ void SerializeAutotuneEntry(AutotuneResults* results, const AutotuneCacheKey& k,
 }
 
 /*static*/ absl::Status AutotunerUtil::LoadAutotuneResults(
-    const AutotuneResults& results) {
+    const AutotuneResults& results, bool allow_override) {
   absl::MutexLock lock(&autotune_cache_mu);
   for (const AutotuneResults::Entry& result : results.results()) {
-    if (auto [it, inserted] = autotune_cache.emplace(
-            AutotuneCacheKey(result.device(), result.hlo()), result.result());
-        !inserted) {
-      return absl::InternalError(absl::StrCat(
-          "Duplicate autotuning result for ", it->first.ToString()));
+    AutotuneCacheKey key(result.device(), result.hlo());
+    if (allow_override) {
+      autotune_cache.insert_or_assign(key, result.result());
+    } else {
+      if (auto [it, inserted] = autotune_cache.emplace(key, result.result());
+          !inserted) {
+        return absl::InternalError(absl::StrCat(
+            "Duplicate autotuning result for ", it->first.ToString()));
+      }
     }
   }
   return absl::OkStatus();
@@ -292,7 +296,6 @@ void SerializeAutotuneEntry(AutotuneResults* results, const AutotuneCacheKey& k,
   return autotune_cache.empty();
 }
 
-namespace {
 std::string ToCanonicalString(const HloInstruction* instr) {
   auto options = HloPrintOptions::Canonical();
   if (instr->opcode() != HloOpcode::kFusion) {
@@ -312,8 +315,6 @@ std::string ToCanonicalString(const HloInstruction* instr) {
   // of the HLO computation proto instead.
   return instr->called_computations()[0]->ToString(options);
 }
-
-}  // namespace
 
 AutotuneCacheKey::AutotuneCacheKey(absl::string_view model_str,
                                    const HloInstruction& instr)
@@ -476,7 +477,7 @@ bool IsTextProtoPath(absl::string_view file_path) {
 }  // anonymous namespace
 
 /*static*/ absl::Status AutotunerUtil::LoadAutotuneResults(
-    absl::string_view data, bool as_textproto) {
+    absl::string_view data, bool as_textproto, bool allow_override) {
   AutotuneResults results;
   // The cast here is necessary for MacOS builds.
   bool parse_success =
@@ -493,7 +494,7 @@ bool IsTextProtoPath(absl::string_view file_path) {
         kVersion, results.version()));
   }
 
-  TF_RETURN_IF_ERROR(LoadAutotuneResults(results));
+  TF_RETURN_IF_ERROR(LoadAutotuneResults(results, allow_override));
   return absl::OkStatus();
 }
 

--- a/xla/service/gpu/autotuning/autotuner_util.h
+++ b/xla/service/gpu/autotuning/autotuner_util.h
@@ -277,12 +277,14 @@ struct AutotunerUtil {
   //
   // Warning: The results are only loaded to the in-memory cache.
   static absl::Status LoadAutotuneResults(absl::string_view data,
-                                          bool as_textproto = false);
+                                          bool as_textproto = false,
+                                          bool allow_override = false);
 
   // Loads autotune results from the given proto.
   //
   // Warning: The results are only loaded to the in-memory cache.
-  static absl::Status LoadAutotuneResults(const AutotuneResults& results);
+  static absl::Status LoadAutotuneResults(const AutotuneResults& results,
+                                          bool allow_override = false);
 
   // Serializes autotune results into a file.
   //
@@ -344,6 +346,8 @@ absl::StatusOr<std::string> AutotuneResultsToString(
 // Git is also transitioning to SHA-256. This is probably better than
 // tsl::Fingerprint128.
 absl::StatusOr<std::string> GetBase64EncodedSha256Hash(absl::string_view s);
+
+std::string ToCanonicalString(const HloInstruction* instr);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
@@ -145,73 +145,115 @@ constexpr std::array<int, 5> kNumCtas = {1, 2, 4, 8, 16};
 
 using AutoTuneCacheKeyCount = absl::flat_hash_map<AutotuneCacheKey, uint64_t>;
 
-class GemmConfigSetCollector : public ConstDfsHloVisitorWithDefault {
- public:
-  explicit GemmConfigSetCollector(GemmFusionAutotunerImpl* impl)
-      : impl_(impl) {}
+using KeysAndInstructions =
+    std::vector<std::pair<AutotuneCacheKey, const HloFusionInstruction*>>;
 
-  // Find configurations to tune.
-  absl::StatusOr<BackendConfigs> CollectGemmConfigSets(
-      const HloModule* module,
+struct GemmFusionCollectorResult {
+  KeysAndInstructions keys_and_instructions;
+  // Counts unique fusions in the module.
+  AutoTuneCacheKeyCount fusion_count_map;
+  // Fingerprints the module by all its unique GEMM fusions.
+  std::string fingerprint;
+};
+
+class GemmFusionCollector : public ConstDfsHloVisitorWithDefault {
+ public:
+  explicit GemmFusionCollector(GemmFusionAutotunerImpl* impl) : impl_(impl) {}
+
+  // Find fusions to tune.
+  absl::StatusOr<GemmFusionCollectorResult> CollectGemmFusions(
+      const HloModule& module,
       const absl::flat_hash_set<absl::string_view>& execution_threads = {}) {
     error_out_on_cache_miss_ =
-        module->config()
+        module.config()
             .debug_options()
             .xla_gpu_require_complete_aot_autotune_results();
-    gemm_config_sets_.clear();
+    result_ = {};
+    handled_fusions_.clear();
     for (HloComputation* computation :
-         module->MakeNonfusionComputations(execution_threads)) {
+         module.MakeNonfusionComputations(execution_threads)) {
       TF_RETURN_IF_ERROR(computation->Accept(this));
     }
-    return std::move(gemm_config_sets_);
-  }
-
-  AutoTuneCacheKeyCount GetFusionsCount() {
-    return std::move(fusion_count_map_);
+    TF_ASSIGN_OR_RETURN(result_.fingerprint,
+                        GetBase64EncodedSha256Hash(result_.fingerprint));
+    return std::move(result_);
   }
 
   absl::Status HandleFusion(const HloInstruction* hlo) override {
-    const HloFusionInstruction* fusion = Cast<HloFusionInstruction>(hlo);
-
     TF_ASSIGN_OR_RETURN(auto gpu_config,
                         hlo->backend_config<GpuBackendConfig>());
     const FusionBackendConfig& backend_config =
         gpu_config.fusion_backend_config();
-
-    AutotuneCacheKey key = AutotunerUtil::GetKey(hlo, impl_->GetConfig());
-
-    auto [iterator, inserted] = fusion_count_map_.insert({key, 1});
-    if (!inserted) {
-      ++(iterator->second);
-    }
-
-    TF_ASSIGN_OR_RETURN(bool is_in_cache,
-                        AutotunerUtil::IsInCache(key, impl_->GetConfig()));
-    if (is_in_cache || handled_fusions_.contains(key)) {
+    if (backend_config.kind() != kTritonGemmFusionKind &&
+        backend_config.kind() != kCuDnnFusionKind &&
+        backend_config.kind() != kCustomFusionKind) {
       return absl::OkStatus();
     }
 
-    bool missing_config = (backend_config.kind() == kTritonGemmFusionKind &&
-                           !backend_config.has_triton_gemm_config()) ||
-                          (backend_config.kind() == kCuDnnFusionKind &&
-                           !backend_config.has_cudnn_fusion_config()) ||
-                          (backend_config.kind() == kCustomFusionKind &&
-                           !backend_config.has_custom_fusion_config());
-    if (missing_config) {
+    AutotuneCacheKey key = AutotunerUtil::GetKey(hlo, impl_->GetConfig());
+    auto [iterator, inserted] = result_.fusion_count_map.insert({key, 1});
+    if (inserted) {
+      result_.fingerprint += ToCanonicalString(hlo);
+    } else {
+      ++(iterator->second);
+    }
+
+    bool missing_config = !backend_config.has_triton_gemm_config() &&
+                          !backend_config.has_cudnn_fusion_config() &&
+                          !backend_config.has_custom_fusion_config();
+    if (missing_config && handled_fusions_.insert(key).second) {
+      result_.keys_and_instructions.push_back(
+          {key, Cast<HloFusionInstruction>(hlo)});
+    }
+
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<KeysAndInstructions> RemoveCached(
+      const KeysAndInstructions& entries) const {
+    KeysAndInstructions result;
+    for (const auto& [key, fusion] : entries) {
+      TF_ASSIGN_OR_RETURN(bool is_in_cache,
+                          AutotunerUtil::IsInCache(key, impl_->GetConfig()));
+      if (is_in_cache) {
+        continue;
+      }
       if (error_out_on_cache_miss_) {
         return absl::NotFoundError(absl::StrCat(
             "Complete autotuning results are required, but no cache result "
             "found for key: ",
             key.ToString()));
       }
+      result.push_back({key, fusion});
+    }
+    return result;
+  }
 
+  // Trim the set of entries to what one rank has to run.
+  static KeysAndInstructions Shard(const KeysAndInstructions& entries,
+                                   const int shard_index,
+                                   const int shard_count) {
+    const uint64_t bucket_size =
+        (entries.size() + shard_count - 1) / shard_count;
+    const uint64_t start = bucket_size * shard_index;
+    const uint64_t end = std::min(start + bucket_size, entries.size());
+    if (start >= end) {
+      return {};
+    }
+    return KeysAndInstructions(entries.cbegin() + start,
+                               entries.cbegin() + end);
+  }
+
+  absl::StatusOr<BackendConfigs> GenerateConfigs(
+      const KeysAndInstructions& keys_and_instructions) const {
+    BackendConfigs result;
+    result.reserve(keys_and_instructions.size());
+    for (const auto& [_, fusion] : keys_and_instructions) {
       TF_ASSIGN_OR_RETURN(std::vector<BackendConfig> configs,
                           impl_->GenerateConfigs(*fusion));
-      gemm_config_sets_.push_back({fusion, std::move(configs)});
+      result.push_back({fusion, std::move(configs)});
     }
-
-    handled_fusions_.insert(key);
-    return absl::OkStatus();
+    return result;
   }
 
   absl::Status DefaultAction(const HloInstruction* hlo) override {
@@ -221,8 +263,7 @@ class GemmConfigSetCollector : public ConstDfsHloVisitorWithDefault {
  private:
   bool error_out_on_cache_miss_;
   GemmFusionAutotunerImpl* impl_;
-  BackendConfigs gemm_config_sets_;
-  AutoTuneCacheKeyCount fusion_count_map_;
+  GemmFusionCollectorResult result_;
   AutotuneCacheKeySet handled_fusions_;
 };
 
@@ -1276,7 +1317,7 @@ static absl::Status DumpAutotuningLogs(const DebugOptions& debug_opts,
   return absl::OkStatus();
 }
 
-absl::StatusOr<AutotuneCacheKeySet> GemmFusionAutotunerImpl::Autotune(
+absl::Status GemmFusionAutotunerImpl::Autotune(
     AutotunerCompileUtil& compile_util, const BackendConfigs& gemm_config_sets,
     AutoTuneCacheKeyCount fusion_count_map) {
   TF_ASSIGN_OR_RETURN(auto executable_sets,
@@ -1291,7 +1332,6 @@ absl::StatusOr<AutotuneCacheKeySet> GemmFusionAutotunerImpl::Autotune(
   }
 
   AutotuningLogs autotuning_logs;
-  AutotuneCacheKeySet added_keys;
   int fusion_id = 0;
   for (const auto& [fusion, candidates] : executable_sets) {
     TF_ASSIGN_OR_RETURN(std::vector<AutotuneResult> results,
@@ -1320,9 +1360,7 @@ absl::StatusOr<AutotuneCacheKeySet> GemmFusionAutotunerImpl::Autotune(
     const AutotuneCacheKey key = AutotunerUtil::GetKey(fusion, config_);
     TF_ASSIGN_OR_RETURN(
         bool added, AutotunerUtil::AddResult(key, std::move(best), config_));
-    if (added) {
-      added_keys.insert(key);
-    } else {
+    if (!added) {
       // In the context of model server, concurrent autotuning is expected and
       // insertion of identical autotuning keys is accepted.
       LOG(WARNING) << "AutotunerUtil::AddResult already existed: "
@@ -1347,24 +1385,7 @@ absl::StatusOr<AutotuneCacheKeySet> GemmFusionAutotunerImpl::Autotune(
     }
   }
 
-  TF_RETURN_IF_ERROR(DumpAutotuningLogs(debug_options_, autotuning_logs));
-
-  return added_keys;
-}
-
-// Trim the set of configs to what one rank has to run.
-static BackendConfigs TrimConfigs(const BackendConfigs& gemm_config_sets,
-                                  const int shard_index,
-                                  const int shard_count) {
-  const uint64_t bucket_size =
-      (gemm_config_sets.size() + shard_count - 1) / shard_count;
-  const uint64_t start = bucket_size * shard_index;
-  const uint64_t end = std::min(start + bucket_size, gemm_config_sets.size());
-  if (start >= end) {
-    return {};
-  }
-  return BackendConfigs(gemm_config_sets.cbegin() + start,
-                        gemm_config_sets.cbegin() + end);
+  return DumpAutotuningLogs(debug_options_, autotuning_logs);
 }
 
 // Exchange the results with the other ranks.
@@ -1400,8 +1421,8 @@ static absl::Status ExchangeResults(KeyValueStoreInterface& key_value_store,
             // Using an infinite duration here leads to issues with MPI, see
             // https://github.com/google/jax/issues/22995.
             absl::Hours(24)));
-    TF_RETURN_IF_ERROR(
-        AutotunerUtil::LoadAutotuneResults(autotune_results_str, true));
+    TF_RETURN_IF_ERROR(AutotunerUtil::LoadAutotuneResults(
+        autotune_results_str, /*as_textproto=*/true, /*allow_override=*/true));
   }
   return absl::OkStatus();
 }
@@ -1412,20 +1433,37 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
   XLA_SCOPED_LOGGING_TIMER("GEMM fusion autotuner");
 
   const DebugOptions& debug_options = module->config().debug_options();
+  const bool shard_autotuning = debug_options.xla_gpu_shard_autotuning() &&
+                                key_value_store_.process_count > 1;
   GemmFusionAutotunerImpl autotuner(config_, toolkit_version_, debug_options,
                                     thread_pool_);
-  GemmConfigSetCollector gemm_config_set_collector(&autotuner);
-  TF_ASSIGN_OR_RETURN(BackendConfigs gemm_config_sets,
-                      gemm_config_set_collector.CollectGemmConfigSets(
-                          module, execution_threads));
-  const int total_fusion_count = gemm_config_sets.size();
-
-  AutoTuneCacheKeyCount fusion_count_map =
-      gemm_config_set_collector.GetFusionsCount();
+  GemmFusionCollector fusion_collector(&autotuner);
+  TF_ASSIGN_OR_RETURN(
+      GemmFusionCollectorResult fusions,
+      fusion_collector.CollectGemmFusions(*module, execution_threads));
+  AutotuneCacheKeySet keys_of_this_rank;
+  if (shard_autotuning) {
+    if (key_value_store_.key_value_store == nullptr) {
+      return absl::FailedPreconditionError(
+          "Sharded autotuning requested but key-value store is missing.");
+    }
+    fusions.keys_and_instructions = fusion_collector.Shard(
+        fusions.keys_and_instructions, key_value_store_.process_index,
+        key_value_store_.process_count);
+    for (const auto& [key, _] : fusions.keys_and_instructions) {
+      CHECK(keys_of_this_rank.insert(key).second);
+    }
+  }
+  TF_ASSIGN_OR_RETURN(
+      fusions.keys_and_instructions,
+      fusion_collector.RemoveCached(fusions.keys_and_instructions));
+  TF_ASSIGN_OR_RETURN(
+      const BackendConfigs config_sets,
+      fusion_collector.GenerateConfigs(fusions.keys_and_instructions));
 
   if (!autotuner.IsAutotuningEnabled()) {
     // Pick the first option for each gemm instead of autotuning.
-    for (const auto& [fusion, tilings] : gemm_config_sets) {
+    for (const auto& [fusion, tilings] : config_sets) {
       const AutotuneCacheKey key = AutotunerUtil::GetKey(fusion, config_);
       AutotuneResult res = FromConfig(tilings[0]);
       *res.mutable_run_time() =
@@ -1439,7 +1477,7 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
         debug_options.xla_gpu_override_gemm_autotuner(), &gemm_key));
     VLOG(1) << "Overriding GEMM autotuner with the following config: "
             << gemm_key.DebugString();
-    for (const auto& [fusion, unused] : gemm_config_sets) {
+    for (const auto& [fusion, unused] : config_sets) {
       const AutotuneCacheKey key = AutotunerUtil::GetKey(fusion, config_);
       AutotuneResult res;
       *res.mutable_triton() = gemm_key;
@@ -1454,41 +1492,22 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
                                             ? "(with correctness check)"
                                             : "(without correctness check)";
 
-    const bool shard_autotuning = debug_options.xla_gpu_shard_autotuning() &&
-                                  key_value_store_.process_count > 1 &&
-                                  total_fusion_count > 0;
-    std::string fusion_set_fingerprint;
-    if (shard_autotuning) {
-      if (key_value_store_.key_value_store == nullptr) {
-        return absl::FailedPreconditionError(
-            "Sharded autotuning requested but key-value store is missing.");
-      }
-
-      for (const auto& [fusion, _] : gemm_config_sets) {
-        fusion_set_fingerprint += fusion->ToString();
-      }
-      TF_ASSIGN_OR_RETURN(fusion_set_fingerprint,
-                          GetBase64EncodedSha256Hash(fusion_set_fingerprint));
-
-      gemm_config_sets =
-          TrimConfigs(gemm_config_sets, key_value_store_.process_index,
-                      key_value_store_.process_count);
-    }
+    const int number_of_fusions_in_module = fusions.fusion_count_map.size();
 
     VLOG(1) << absl::StrFormat(
-        "Shard %d / %d: autotuning %d / %d fusions for %s %s.",
-        key_value_store_.process_index + 1, key_value_store_.process_count,
-        gemm_config_sets.size(), total_fusion_count, module->name(),
+        "Rank %d / %d: autotuning %d / %d fusions for %s %s.",
+        key_value_store_.process_index, key_value_store_.process_count,
+        config_sets.size(), number_of_fusions_in_module, module->name(),
         correctness_check_str);
-    TF_ASSIGN_OR_RETURN(const AutotuneCacheKeySet added_keys,
-                        autotuner.Autotune(compile_util, gemm_config_sets,
-                                           std::move(fusion_count_map)));
+    TF_RETURN_IF_ERROR(autotuner.Autotune(compile_util, config_sets,
+                                          std::move(fusions.fusion_count_map)));
     VLOG(1) << "Done autotuning.";
 
-    if (shard_autotuning) {
-      TF_RETURN_IF_ERROR(ExchangeResults(
-          *key_value_store_.key_value_store, added_keys, fusion_set_fingerprint,
-          key_value_store_.process_index, key_value_store_.process_count));
+    if (shard_autotuning && number_of_fusions_in_module > 0) {
+      TF_RETURN_IF_ERROR(ExchangeResults(*key_value_store_.key_value_store,
+                                         keys_of_this_rank, fusions.fingerprint,
+                                         key_value_store_.process_index,
+                                         key_value_store_.process_count));
     }
   }
 

--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner.h
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner.h
@@ -148,7 +148,7 @@ class GemmFusionAutotunerImpl {
       absl::Span<const ExecutableCandidate> candidates);
 
   // Autotune and save the results to the autotuning cache.
-  absl::StatusOr<AutotuneCacheKeySet> Autotune(
+  absl::Status Autotune(
       AutotunerCompileUtil& compile_util,
       const BackendConfigs& gemm_config_sets,
       absl::flat_hash_map<AutotuneCacheKey, uint64_t> fusion_count_map);

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -414,6 +414,7 @@ TEST_F(FunctionalHloRunnerTest, ShardedAutotuningWorks) {
     GTEST_SKIP() << "GPU-only test.";
   }
 
+  tsl::setenv("TF_CPP_VMODULE", "gemm_fusion_autotuner=2", /*overwrite=*/true);
   tsl::SubProcess child[kNumNodes];
   for (int node_id = 0; node_id < kNumNodes; ++node_id) {
     std::vector<std::string> argv;
@@ -469,13 +470,13 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id) {
     TF_ASSIGN_OR_RETURN(
         std::string results0,
         env.kv_store->Get("gemm_fusion_autotuning_results_"
-                          "3rICV5olU4JYmrEsiWSstWM0ew6jr1f60ikmjvPhwUc_0",
+                          "iuhMRX2JY-YpaUJD3Pw0h3H3HNGWEzN4xA0s9Q3CoK8_0",
                           absl::Seconds(1)));
     CHECK(absl::StrContains(results0, "run_time"));
     TF_ASSIGN_OR_RETURN(
         std::string results1,
         env.kv_store->Get("gemm_fusion_autotuning_results_"
-                          "3rICV5olU4JYmrEsiWSstWM0ew6jr1f60ikmjvPhwUc_1",
+                          "iuhMRX2JY-YpaUJD3Pw0h3H3HNGWEzN4xA0s9Q3CoK8_1",
                           absl::Seconds(1)));
     CHECK(absl::StrContains(results1, "run_time"));
     // The nodes autotune different fusions.


### PR DESCRIPTION
The algorithm before this change was:
 - collect unique non-cached fusions
 - shard them
 - autotune the shard
 - publish the shard
 - read the other shards
 - merge them into the local cache

This did not work when the ranks observed the cache(s) in different states - sharding requires the set of autotuned fusions to be exactly the same.

The new algorithm is:
 - collect unique fusions ignoring the caches
 - shard them
 - skip fusions present in the local caches of the rank
 - autotune the remainder
 - publish cached + new autotuned results comprising the shard
 - read the other shards
 - merge them into the local cache overwriting on conflicts