### PR TITLE
Pass CC 10.0 to Triton for sm_120.

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter.cc
@@ -1234,9 +1234,9 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
   const auto& cc = device_info.gpu_compute_capability();
   std::string arch_name =
       std::visit([](auto& cc) { return cc.ToString(); }, cc);
-  // Pass CC 10.0 to Triton to avoid spurious "unsupported conversion" errors,
-  // until Triton supports sm_120.
   if (arch_name == "12.0") {
+    LOG(WARNING) << "Triton does not support sm_120 yet. Passing CC 10.0 to "
+                    "avoid spurious \"unsupported conversion\" errors";
     arch_name = "10.0";
   }
   if (std::holds_alternative<se::CudaComputeCapability>(cc)) {

--- a/xla/backends/gpu/codegen/triton/fusion_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter.cc
@@ -1232,8 +1232,13 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
     mlir::ModuleOp triton_module, llvm::Module* llvm_module,
     mlir::MLIRContext& mlir_context, bool is_xla_fusion, bool emit_kernel) {
   const auto& cc = device_info.gpu_compute_capability();
-  const std::string arch_name =
+  std::string arch_name =
       std::visit([](auto& cc) { return cc.ToString(); }, cc);
+  // Pass CC 10.0 to Triton to avoid spurious "unsupported conversion" errors,
+  // until Triton supports sm_120.
+  if (arch_name == "12.0") {
+    arch_name = "10.0";
+  }
   if (std::holds_alternative<se::CudaComputeCapability>(cc)) {
     auto ccCuda = std::get<se::CudaComputeCapability>(cc);
     if (!ccCuda.IsAtLeastAmpere()) {


### PR DESCRIPTION
Workaround to avoid spurious failures in Triton when compiling for sm_120.