### PR TITLE
[XLA:GPU] Enable cuDNN kernel for block scaled dot on Blackwell

### DIFF
--- a/xla/literal_util.cc
+++ b/xla/literal_util.cc
@@ -115,6 +115,16 @@ struct ZeroProvider {
   NativeT<kType> operator()() const { return static_cast<NativeT<kType>>(0); }
 };
 
+// Use template specialization for the E8M0 type, as it has no zero
+// representation, so static_cast<> returns NaN. The actual zero-like value
+// is 2^-127.
+template <>
+struct ZeroProvider<F8E8M0FNU> {
+  NativeT<F8E8M0FNU> operator()() const {
+    return Eigen::numext::bit_cast<NativeT<F8E8M0FNU>>('\0');
+  }
+};
+
 template <PrimitiveType kType>
 struct OneProvider {
   NativeT<kType> operator()() const { return static_cast<NativeT<kType>>(1); }

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1807,6 +1807,7 @@ cc_library(
         "//xla/service/gpu/llvm_gpu_backend:nvptx_backend",
         "//xla/service/gpu/llvm_gpu_backend:nvptx_utils",
         "//xla/service/gpu/transforms:algebraic_simplifier",
+        "//xla/service/gpu/transforms:block_scaling_rewriter",
         "//xla/service/gpu/transforms:conv_padding_legalization",
         "//xla/service/gpu/transforms:conv_rewriter",
         "//xla/service/gpu/transforms:cublas_pad_for_gemms",

--- a/xla/service/gpu/cublas_cudnn.cc
+++ b/xla/service/gpu/cublas_cudnn.cc
@@ -73,6 +73,8 @@ const absl::string_view kCudnnConvReorderFilterAndBiasCallTarget =
     "__cudnn$convReorderFilterAndBias";
 
 const absl::string_view kCudnnNormCallTarget = "__cudnn$norm";
+const absl::string_view kCudnnBlockScaledDotCallTarget =
+    "__cudnn$blockScaledDot";
 
 // fMHA forward call targets.
 const absl::string_view kCudnnfMHASoftmaxF8CallTarget = "__cudnn$fmhaSoftmaxF8";
@@ -172,6 +174,11 @@ bool IsCustomCallTofMHA(const HloInstruction& hlo) {
 
 bool IsCustomCallTofMHAF8(const HloInstruction& hlo) {
   return IsFwdCustomCallTofMHAF8(hlo) || IsBwdCustomCallTofMHAF8(hlo);
+}
+
+bool IsCustomCallToBlockScaledDot(const HloInstruction& hlo) {
+  return hlo.opcode() == HloOpcode::kCustomCall &&
+         hlo.custom_call_target() == kCudnnBlockScaledDotCallTarget;
 }
 
 bool IsCubDeviceRadixSort(const HloInstruction& hlo) {

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -210,6 +210,11 @@ absl::Status SetFMHAInstructionName(HloModule* module, HloInstruction* fmha);
 
 bool MHACallHasDropout(absl::string_view fmha_call_name);
 
+// A call to cuDNN for a block scaled dot.
+extern const absl::string_view kCudnnBlockScaledDotCallTarget;
+
+bool IsCustomCallToBlockScaledDot(const HloInstruction& hlo);
+
 // CUB library calls.
 // Reference: https://nvlabs.github.io/cub/
 extern const absl::string_view kCubDeviceRadixSortTarget;

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2721,7 +2721,8 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       if (IsCustomCallToDnnNorm(*instr)) {
         return EmitNormThunk(custom_call);
       }
-      if (IsCustomCallTofMHA(*instr) || IsCustomCallTofMHAF8(*instr)) {
+      if (IsCustomCallTofMHA(*instr) || IsCustomCallTofMHAF8(*instr) ||
+          IsCustomCallToBlockScaledDot(*instr)) {
         return EmitCuDnnThunk(custom_call);
       }
       if (IsCustomCallToTopK(*instr)) {

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -71,6 +71,7 @@ limitations under the License.
 #include "xla/service/gpu/ptx_compile_options_from_debug_options.h"
 #include "xla/service/gpu/target_constants.h"
 #include "xla/service/gpu/transforms/algebraic_simplifier.h"
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
 #include "xla/service/gpu/transforms/conv_padding_legalization.h"
 #include "xla/service/gpu/transforms/conv_rewriter.h"
 #include "xla/service/gpu/transforms/cublas_pad_for_gemms.h"
@@ -326,6 +327,9 @@ absl::Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
     pre_pipeline.AddPass<CudnnNormRewriter>(cuda_compute_capability);
   }
 
+  pre_pipeline.AddPass<BlockScalingRewriter>(
+      /*allow_cudnn=*/cuda_compute_capability.IsAtLeastBlackwell() &&
+      gpu_target_config.dnn_version_info >= se::dnn::VersionInfo(9, 7));
   pre_pipeline.AddPass<DotDimensionMerger>();
   pre_pipeline.AddPass<DotSparsityRewriter>();
 

--- a/xla/service/gpu/stream_executor_util.cc
+++ b/xla/service/gpu/stream_executor_util.cc
@@ -613,6 +613,10 @@ absl::StatusOr<se::dnn::DataType> GetDNNDataTypeFromPrimitiveType(
       return se::dnn::ToDataType<tsl::float8_e4m3fn>::value;
     case F8E5M2:
       return se::dnn::ToDataType<tsl::float8_e5m2>::value;
+    case F4E2M1FN:
+      return se::dnn::ToDataType<tsl::float4_e2m1fn>::value;
+    case F8E8M0FNU:
+      return se::dnn::ToDataType<tsl::float8_e8m0fnu>::value;
     default:
       break;
   }

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -442,10 +442,12 @@ cc_library(
         "//xla:util",
         "//xla/hlo/builder:xla_builder",
         "//xla/hlo/builder:xla_computation",
+        "//xla/hlo/builder/lib:constants",
         "//xla/hlo/ir:hlo",
         "//xla/service:hlo_creation_utils",
         "//xla/service:op_expander_pass",
         "//xla/service:shape_inference",
+        "//xla/service/gpu:cublas_cudnn",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
@@ -467,6 +469,20 @@ xla_cc_test(
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
+    ],
+)
+
+xla_test(
+    name = "block_scaling_rewriter_cudnn_test",
+    srcs = ["block_scaling_rewriter_cudnn_test.cc"],
+    backends = ["gpu_b100"],
+    deps = [
+        ":block_scaling_rewriter",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest",
+        "@tsl//tsl/platform:status_matchers",
     ],
 )
 
@@ -1349,6 +1365,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@local_config_cuda//cuda:cudnn_header",
+        ":block_scaling_rewriter",
         "//xla:shape_util",
         "//xla:status_macros",
         "//xla:util",

--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -64,7 +64,7 @@ namespace xla::gpu {
 //
 class BlockScalingRewriter : public OpExpanderPass {
  public:
-  BlockScalingRewriter() = default;
+  explicit BlockScalingRewriter(bool allow_cudnn) : allow_cudnn_(allow_cudnn){};
 
   absl::string_view name() const override { return "block-scaling-rewriter"; }
 
@@ -80,6 +80,12 @@ class BlockScalingRewriter : public OpExpanderPass {
       "__op$dequantize";
   static constexpr absl::string_view kBlockScaledDotCustomCallTarget =
       "__op$block_scaled_dot";
+
+  // Common block size constants.
+  static constexpr int kBlockSizeMXFP8 = 32;
+
+ private:
+  bool allow_cudnn_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
@@ -1,0 +1,84 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
+
+#include <gtest/gtest.h>
+#include "absl/strings/string_view.h"
+#include "xla/tests/hlo_test_base.h"
+#include "tsl/platform/status_matchers.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::tsl::testing::IsOkAndHolds;
+using BlockScalingRewriterCudnnTest = HloTestBase;
+
+TEST_F(BlockScalingRewriterCudnnTest, Mxfp8) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[256,256] parameter(0)
+  %rhs = f8e4m3fn[256,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[256,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[256,8] parameter(3)
+  ROOT %result = f32[256,256] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [](HloModule* reference_module) {
+        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [](HloModule* test_module) {
+        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+}
+
+TEST_F(BlockScalingRewriterCudnnTest, Mxfp8_MixedTypes) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[4,128,224] parameter(0)
+  %rhs = f8e5m2[4,120,224] parameter(1)
+  %lhs_scale = f8e8m0fnu[4,128,7] parameter(2)
+  %rhs_scale = f8e8m0fnu[4,120,7] parameter(3)
+  ROOT %result = f32[4,128,120] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [](HloModule* reference_module) {
+        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [](HloModule* test_module) {
+        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
@@ -39,6 +39,7 @@ limitations under the License.
 #include "xla/service/gpu/cublas_cudnn.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/stream_executor_util.h"
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/status_macros.h"
@@ -97,302 +98,347 @@ absl::StatusOr<MatmulTensorDescriptor> MatmulTensorDescriptorFor(
                     : dnums.rhs_contracting_dimensions());
 }
 
+absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToForwardFMHA(
+    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+  TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
+                      xla::gpu::GetCudnnfMHAKind(custom_call));
+  TF_ASSIGN_OR_RETURN(
+      const auto gpu_config,
+      custom_call->backend_config<xla::gpu::GpuBackendConfig>());
+  const xla::gpu::CudnnfMHABackendConfig &config =
+      gpu_config.cudnn_fmha_backend_config();
+
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor lhs_bmm1,
+      MatmulTensorDescriptorFor(custom_call->operand(0)->shape(),
+                                config.bmm1_dot_dimension_numbers(), LHS));
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor rhs_bmm1,
+      MatmulTensorDescriptorFor(custom_call->operand(1)->shape(),
+                                config.bmm1_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor rhs_bmm2,
+      MatmulTensorDescriptorFor(custom_call->operand(2)->shape(),
+                                config.bmm2_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(
+      TensorDescriptor output,
+      TensorDescriptorFor(ShapeUtil::GetSubshape(custom_call->shape(), {0})));
+
+  std::optional<se::dnn::TensorDescriptor> activation;
+  const bool has_activation =
+      xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
+  if (has_activation) {
+    TF_ASSIGN_OR_RETURN(activation, TensorDescriptorFor(ShapeUtil::GetSubshape(
+                                        custom_call->shape(), {1})));
+  }
+
+  std::optional<se::dnn::TensorDescriptor> bias;
+  if (kind == CudnnfMHAKind::kScaleBiasSoftmax ||
+      kind == CudnnfMHAKind::kScaleBiasSoftmaxDropout) {
+    const HloInstruction &bias_hlo = *custom_call->operand(3);
+    TF_ASSIGN_OR_RETURN(bias, TensorDescriptorFor(bias_hlo.shape()));
+  }
+
+  const double dropout_rate = config.dropout_rate();
+
+  TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
+                      AsCudnnFmhaMaskKind(config.mask_type()));
+  TF_ASSIGN_OR_RETURN(se::dnn::FMHAMaskKind dnn_mask_type,
+                      GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
+
+  const int sliding_window_length = config.sliding_window_length();
+  const int max_seg_per_batch = config.max_seg_per_batch();
+  TF_ASSIGN_OR_RETURN(
+      se::gpu::CudnnGraph graph,
+      se::gpu::GetCudnnFlashAttentionOperationGraph(
+          dnn_support, lhs_bmm1, rhs_bmm1, rhs_bmm2, output, bias, activation,
+          static_cast<float>(config.fmha_scale()), dropout_rate > 0.0,
+          dropout_rate, dnn_mask_type, sliding_window_length,
+          max_seg_per_batch));
+  return graph;
+}
+
+absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToForwardFMHAF8(
+    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+  TF_ASSIGN_OR_RETURN(
+      const auto gpu_config,
+      custom_call->backend_config<xla::gpu::GpuBackendConfig>());
+  const xla::gpu::CudnnfMHABackendConfig &config =
+      gpu_config.cudnn_fmha_backend_config();
+  Shape intermediate_tensor_shape(config.intermediate_tensor_shape());
+
+  TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
+                      AsCudnnFmhaMaskKind(config.mask_type()));
+  TF_ASSIGN_OR_RETURN(se::dnn::FMHAMaskKind dnn_mask_type,
+                      GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor lhs_bmm1,
+      MatmulTensorDescriptorFor(custom_call->operand(0)->shape(),
+                                config.bmm1_dot_dimension_numbers(), LHS));
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor rhs_bmm1,
+      MatmulTensorDescriptorFor(custom_call->operand(1)->shape(),
+                                config.bmm1_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor rhs_bmm2,
+      MatmulTensorDescriptorFor(custom_call->operand(2)->shape(),
+                                config.bmm2_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(
+      TensorDescriptor output,
+      TensorDescriptorFor(ShapeUtil::GetSubshape(custom_call->shape(), {0})));
+
+  std::optional<se::dnn::TensorDescriptor> activation;
+  bool has_activation =
+      xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 5;
+  if (has_activation) {
+    TF_ASSIGN_OR_RETURN(activation, TensorDescriptorFor(ShapeUtil::GetSubshape(
+                                        custom_call->shape(), {3})));
+  }
+  TF_ASSIGN_OR_RETURN(
+      se::gpu::CudnnGraph graph,
+      se::gpu::GetCudnnFlashAttentionF8OperationGraph(
+          dnn_support, lhs_bmm1, rhs_bmm1, rhs_bmm2, output, activation,
+          static_cast<float>(config.fmha_scale()), dnn_mask_type));
+  return graph;
+}
+
+absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHA(
+    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+  TF_ASSIGN_OR_RETURN(
+      auto gpu_config,
+      custom_call->backend_config<xla::gpu::GpuBackendConfig>());
+  xla::gpu::CudnnfMHABackendConfig &config =
+      *gpu_config.mutable_cudnn_fmha_backend_config();
+
+  int input_index = 0;
+  const Shape &bmm1_grad_gemm1_rhs_shape =
+      custom_call->operand(input_index++)->shape();
+  const Shape &bmm1_grad_gemm2_rhs_shape =
+      custom_call->operand(input_index++)->shape();
+  const Shape &bmm2_grad_gemm2_rhs_shape =
+      custom_call->operand(input_index++)->shape();
+  const Shape bmm2_grad_gemm1_lhs_shape(config.intermediate_tensor_shape());
+  ++input_index;
+  const Shape &d_output_shape = custom_call->operand(input_index++)->shape();
+
+  TF_ASSIGN_OR_RETURN(const CudnnfMHAKind kind, GetCudnnfMHAKind(custom_call));
+
+  bool has_bias = (kind == CudnnfMHAKind::kBackwardScaleBiasSoftmax ||
+                   kind == CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout);
+  std::optional<Shape> bias_shape;
+  if (has_bias) {
+    bias_shape = custom_call->operand(input_index++)->shape();
+  }
+
+  // Unused fwd_output_shape
+  ++input_index;
+
+  const int max_seg_per_batch = config.max_seg_per_batch();
+  if (config.mask_type() == xla::gpu::CudnnfMHABackendConfig::PADDING ||
+      config.mask_type() == xla::gpu::CudnnfMHABackendConfig::PADDING_CAUSAL ||
+      max_seg_per_batch > 1) {
+    // skip q_seqlen and kv_seqlen
+    input_index += 2;
+  }
+
+  if (max_seg_per_batch > 1) {
+    // skip q_offsets and kv_offsets
+    input_index += 2;
+  }
+  TF_RET_CHECK(input_index == custom_call->operand_count());
+
+  int output_index = 0;
+  const Shape &d_bmm1_lhs_shape =
+      ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
+  const Shape &d_bmm1_rhs_shape =
+      ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
+  const Shape &d_bmm2_rhs_shape =
+      ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
+  bool has_dbias = custom_call->shape().tuple_shapes().size() == 5;
+  if (has_dbias) {
+    ++output_index;
+  }
+  // The last one is the workspace.
+  TF_RET_CHECK(output_index == custom_call->shape().tuple_shapes().size() - 1);
+
+  const bool force_deterministic =
+      RequireDeterminism(custom_call->GetModule()->config());
+  config.set_force_deterministic(force_deterministic);
+  TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));
+
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm1_grad_gemm1_rhs,
+                      MatmulTensorDescriptorFor(
+                          bmm1_grad_gemm1_rhs_shape,
+                          config.bmm1_grad_gemm1_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm1_grad_gemm2_rhs,
+                      MatmulTensorDescriptorFor(
+                          bmm1_grad_gemm2_rhs_shape,
+                          config.bmm1_grad_gemm2_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm2_grad_gemm1_lhs,
+                      MatmulTensorDescriptorFor(
+                          bmm2_grad_gemm1_lhs_shape,
+                          config.bmm2_grad_gemm1_dot_dimension_numbers(), LHS));
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm2_grad_gemm2_rhs,
+                      MatmulTensorDescriptorFor(
+                          bmm2_grad_gemm2_rhs_shape,
+                          config.bmm2_grad_gemm2_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor d_output,
+      MatmulTensorDescriptorFor(
+          d_output_shape, config.bmm2_grad_gemm1_dot_dimension_numbers(), RHS));
+
+  TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_lhs,
+                      TensorDescriptorFor(d_bmm1_lhs_shape));
+  TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_rhs,
+                      TensorDescriptorFor(d_bmm1_rhs_shape));
+  TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm2_rhs,
+                      TensorDescriptorFor(d_bmm2_rhs_shape));
+
+  std::optional<se::dnn::TensorDescriptor> bias;
+  if (bias_shape.has_value()) {
+    TF_ASSIGN_OR_RETURN(bias, TensorDescriptorFor(*bias_shape));
+  }
+
+  const double dropout_rate = config.dropout_rate();
+
+  TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
+                      AsCudnnFmhaMaskKind(config.mask_type()));
+  TF_ASSIGN_OR_RETURN(se::dnn::FMHAMaskKind dnn_mask_type,
+                      GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
+
+  const int sliding_window_length = config.sliding_window_length();
+  TF_ASSIGN_OR_RETURN(
+      se::gpu::CudnnGraph graph,
+      se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(
+          dnn_support, bmm1_grad_gemm1_rhs, bmm1_grad_gemm2_rhs,
+          bmm2_grad_gemm1_lhs, bmm2_grad_gemm2_rhs, d_output, d_bmm1_lhs,
+          d_bmm1_rhs, d_bmm2_rhs, bias, dropout_rate, config.seed(),
+          config.fmha_scale(), dropout_rate > 0.0, bias != std::nullopt,
+          dnn_mask_type, force_deterministic, sliding_window_length,
+          max_seg_per_batch));
+  return graph;
+}
+
+absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHAF8(
+    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+  TF_ASSIGN_OR_RETURN(
+      auto gpu_config,
+      custom_call->backend_config<xla::gpu::GpuBackendConfig>());
+  xla::gpu::CudnnfMHABackendConfig &config =
+      *gpu_config.mutable_cudnn_fmha_backend_config();
+
+  Shape bmm1_grad_gemm1_rhs_shape = custom_call->operand(0)->shape();
+  Shape bmm1_grad_gemm2_rhs_shape = custom_call->operand(1)->shape();
+  Shape bmm2_grad_gemm2_rhs_shape = custom_call->operand(2)->shape();
+
+  Shape fwd_output_shape = custom_call->operand(3)->shape();
+  Shape d_output_shape = custom_call->operand(4)->shape();
+
+  Shape bmm2_grad_gemm1_lhs_shape(config.intermediate_tensor_shape());
+
+  Shape d_bmm1_lhs_shape = ShapeUtil::GetSubshape(custom_call->shape(), {0});
+  Shape d_bmm1_rhs_shape = ShapeUtil::GetSubshape(custom_call->shape(), {1});
+  Shape d_bmm2_rhs_shape = ShapeUtil::GetSubshape(custom_call->shape(), {2});
+
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm1_grad_gemm1_rhs,
+                      MatmulTensorDescriptorFor(
+                          bmm1_grad_gemm1_rhs_shape,
+                          config.bmm1_grad_gemm1_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm1_grad_gemm2_rhs,
+                      MatmulTensorDescriptorFor(
+                          bmm1_grad_gemm2_rhs_shape,
+                          config.bmm1_grad_gemm2_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm2_grad_gemm1_lhs,
+                      MatmulTensorDescriptorFor(
+                          bmm2_grad_gemm1_lhs_shape,
+                          config.bmm2_grad_gemm1_dot_dimension_numbers(), LHS));
+  TF_ASSIGN_OR_RETURN(MatmulTensorDescriptor bmm2_grad_gemm2_rhs,
+                      MatmulTensorDescriptorFor(
+                          bmm2_grad_gemm2_rhs_shape,
+                          config.bmm2_grad_gemm2_dot_dimension_numbers(), RHS));
+  TF_ASSIGN_OR_RETURN(
+      MatmulTensorDescriptor d_output,
+      MatmulTensorDescriptorFor(
+          d_output_shape, config.bmm2_grad_gemm1_dot_dimension_numbers(), RHS));
+
+  TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_lhs,
+                      TensorDescriptorFor(d_bmm1_lhs_shape));
+  TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_rhs,
+                      TensorDescriptorFor(d_bmm1_rhs_shape));
+  TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm2_rhs,
+                      TensorDescriptorFor(d_bmm2_rhs_shape));
+  // 3 gradients, 4 amaxs and one workspace
+  TF_RET_CHECK(8 == custom_call->shape().tuple_shapes().size());
+
+  TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));
+
+  TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
+                      AsCudnnFmhaMaskKind(config.mask_type()));
+  TF_ASSIGN_OR_RETURN(se::dnn::FMHAMaskKind dnn_mask_type,
+                      GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
+  TF_ASSIGN_OR_RETURN(
+      se::gpu::CudnnGraph graph,
+      se::gpu::GetCudnnFlashAttentionBackwardF8OperationGraph(
+          dnn_support, bmm1_grad_gemm1_rhs, bmm1_grad_gemm2_rhs,
+          bmm2_grad_gemm1_lhs, bmm2_grad_gemm2_rhs, d_output, d_bmm1_lhs,
+          d_bmm1_rhs, d_bmm2_rhs, config.fmha_scale(), dnn_mask_type));
+  return graph;
+}
+
+absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBlockScaledDot(
+    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+  TF_RET_CHECK(custom_call->operand_count() == 4);
+  TF_RET_CHECK(custom_call->shape().tuple_shapes_size() == 2);
+
+  TF_ASSIGN_OR_RETURN(TensorDescriptor lhs_data,
+                      TensorDescriptorFor(custom_call->operand(0)->shape()));
+  TF_ASSIGN_OR_RETURN(TensorDescriptor rhs_data,
+                      TensorDescriptorFor(custom_call->operand(1)->shape()));
+  TF_ASSIGN_OR_RETURN(TensorDescriptor lhs_scale,
+                      TensorDescriptorFor(custom_call->operand(2)->shape()));
+  TF_ASSIGN_OR_RETURN(TensorDescriptor rhs_scale,
+                      TensorDescriptorFor(custom_call->operand(3)->shape()));
+
+  DataType result_type;
+  switch (custom_call->shape().tuple_shapes(0).element_type()) {
+    case PrimitiveType::F32:
+      result_type = DataType::kFloat;
+      break;
+    case PrimitiveType::F16:
+      result_type = DataType::kHalf;
+      break;
+    case PrimitiveType::BF16:
+      result_type = DataType::kBF16;
+      break;
+    default:
+      return absl::InternalError("Unsupported data type for block scaled dot");
+  }
+
+  // cuDNN supports MXFP8 (block size 32, E8M0 scales).
+  TF_RET_CHECK(lhs_scale.type() == DataType::kF8E8M0FNU &&
+               rhs_scale.type() == DataType::kF8E8M0FNU);
+  const int block_size = BlockScalingRewriter::kBlockSizeMXFP8;
+
+  TF_ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph,
+                      se::gpu::GetCudnnBlockScaledDotOperationGraph(
+                          dnn_support, lhs_data, lhs_scale, rhs_data, rhs_scale,
+                          result_type, block_size));
+  return graph;
+}
+
 absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
     se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
   if (IsFwdCustomCallTofMHA(*custom_call)) {
-    TF_ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
-                        xla::gpu::GetCudnnfMHAKind(custom_call));
-    TF_ASSIGN_OR_RETURN(
-        const auto gpu_config,
-        custom_call->backend_config<xla::gpu::GpuBackendConfig>());
-    const xla::gpu::CudnnfMHABackendConfig &config =
-        gpu_config.cudnn_fmha_backend_config();
-
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor lhs_bmm1,
-        MatmulTensorDescriptorFor(custom_call->operand(0)->shape(),
-                                  config.bmm1_dot_dimension_numbers(), LHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor rhs_bmm1,
-        MatmulTensorDescriptorFor(custom_call->operand(1)->shape(),
-                                  config.bmm1_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor rhs_bmm2,
-        MatmulTensorDescriptorFor(custom_call->operand(2)->shape(),
-                                  config.bmm2_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        TensorDescriptor output,
-        TensorDescriptorFor(ShapeUtil::GetSubshape(custom_call->shape(), {0})));
-
-    std::optional<se::dnn::TensorDescriptor> activation;
-    const bool has_activation =
-        xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 3;
-    if (has_activation) {
-      TF_ASSIGN_OR_RETURN(
-          activation, TensorDescriptorFor(
-                          ShapeUtil::GetSubshape(custom_call->shape(), {1})));
-    }
-
-    std::optional<se::dnn::TensorDescriptor> bias;
-    if (kind == CudnnfMHAKind::kScaleBiasSoftmax ||
-        kind == CudnnfMHAKind::kScaleBiasSoftmaxDropout) {
-      const HloInstruction &bias_hlo = *custom_call->operand(3);
-      TF_ASSIGN_OR_RETURN(bias, TensorDescriptorFor(bias_hlo.shape()));
-    }
-
-    const double dropout_rate = config.dropout_rate();
-
-    TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
-                        AsCudnnFmhaMaskKind(config.mask_type()));
-    TF_ASSIGN_OR_RETURN(
-        se::dnn::FMHAMaskKind dnn_mask_type,
-        GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
-
-    const int sliding_window_length = config.sliding_window_length();
-    const int max_seg_per_batch = config.max_seg_per_batch();
-    TF_ASSIGN_OR_RETURN(
-        se::gpu::CudnnGraph graph,
-        se::gpu::GetCudnnFlashAttentionOperationGraph(
-            dnn_support, lhs_bmm1, rhs_bmm1, rhs_bmm2, output, bias, activation,
-            static_cast<float>(config.fmha_scale()), dropout_rate > 0.0,
-            dropout_rate, dnn_mask_type, sliding_window_length,
-            max_seg_per_batch));
-    return graph;
+    return BuildGraphForCustomCallToForwardFMHA(dnn_support, custom_call);
   } else if (IsFwdCustomCallTofMHAF8(*custom_call)) {
-    TF_ASSIGN_OR_RETURN(
-        const auto gpu_config,
-        custom_call->backend_config<xla::gpu::GpuBackendConfig>());
-    const xla::gpu::CudnnfMHABackendConfig &config =
-        gpu_config.cudnn_fmha_backend_config();
-    Shape intermediate_tensor_shape(config.intermediate_tensor_shape());
-
-    TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
-                        AsCudnnFmhaMaskKind(config.mask_type()));
-    TF_ASSIGN_OR_RETURN(
-        se::dnn::FMHAMaskKind dnn_mask_type,
-        GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor lhs_bmm1,
-        MatmulTensorDescriptorFor(custom_call->operand(0)->shape(),
-                                  config.bmm1_dot_dimension_numbers(), LHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor rhs_bmm1,
-        MatmulTensorDescriptorFor(custom_call->operand(1)->shape(),
-                                  config.bmm1_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor rhs_bmm2,
-        MatmulTensorDescriptorFor(custom_call->operand(2)->shape(),
-                                  config.bmm2_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        TensorDescriptor output,
-        TensorDescriptorFor(ShapeUtil::GetSubshape(custom_call->shape(), {0})));
-
-    std::optional<se::dnn::TensorDescriptor> activation;
-    bool has_activation =
-        xla::ShapeUtil::TupleElementCount(custom_call->shape()) == 5;
-    if (has_activation) {
-      TF_ASSIGN_OR_RETURN(
-          activation, TensorDescriptorFor(
-                          ShapeUtil::GetSubshape(custom_call->shape(), {3})));
-    }
-    TF_ASSIGN_OR_RETURN(
-        se::gpu::CudnnGraph graph,
-        se::gpu::GetCudnnFlashAttentionF8OperationGraph(
-            dnn_support, lhs_bmm1, rhs_bmm1, rhs_bmm2, output, activation,
-            static_cast<float>(config.fmha_scale()), dnn_mask_type));
-    return graph;
+    return BuildGraphForCustomCallToForwardFMHAF8(dnn_support, custom_call);
   } else if (IsBwdCustomCallTofMHA(*custom_call)) {
-    TF_ASSIGN_OR_RETURN(
-        auto gpu_config,
-        custom_call->backend_config<xla::gpu::GpuBackendConfig>());
-    xla::gpu::CudnnfMHABackendConfig &config =
-        *gpu_config.mutable_cudnn_fmha_backend_config();
-
-    int input_index = 0;
-    const Shape &bmm1_grad_gemm1_rhs_shape =
-        custom_call->operand(input_index++)->shape();
-    const Shape &bmm1_grad_gemm2_rhs_shape =
-        custom_call->operand(input_index++)->shape();
-    const Shape &bmm2_grad_gemm2_rhs_shape =
-        custom_call->operand(input_index++)->shape();
-    const Shape bmm2_grad_gemm1_lhs_shape(config.intermediate_tensor_shape());
-    ++input_index;
-    const Shape &d_output_shape = custom_call->operand(input_index++)->shape();
-
-    TF_ASSIGN_OR_RETURN(const CudnnfMHAKind kind,
-                        GetCudnnfMHAKind(custom_call));
-
-    bool has_bias = (kind == CudnnfMHAKind::kBackwardScaleBiasSoftmax ||
-                     kind == CudnnfMHAKind::kBackwardScaleBiasSoftmaxDropout);
-    std::optional<Shape> bias_shape;
-    if (has_bias) {
-      bias_shape = custom_call->operand(input_index++)->shape();
-    }
-
-    // Unused fwd_output_shape
-    ++input_index;
-
-    const int max_seg_per_batch = config.max_seg_per_batch();
-    if (config.mask_type() == xla::gpu::CudnnfMHABackendConfig::PADDING ||
-        config.mask_type() ==
-            xla::gpu::CudnnfMHABackendConfig::PADDING_CAUSAL ||
-        max_seg_per_batch > 1) {
-      // skip q_seqlen and kv_seqlen
-      input_index += 2;
-    }
-
-    if (max_seg_per_batch > 1) {
-      // skip q_offsets and kv_offsets
-      input_index += 2;
-    }
-    TF_RET_CHECK(input_index == custom_call->operand_count());
-
-    int output_index = 0;
-    const Shape &d_bmm1_lhs_shape =
-        ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
-    const Shape &d_bmm1_rhs_shape =
-        ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
-    const Shape &d_bmm2_rhs_shape =
-        ShapeUtil::GetSubshape(custom_call->shape(), {output_index++});
-    bool has_dbias = custom_call->shape().tuple_shapes().size() == 5;
-    if (has_dbias) {
-      ++output_index;
-    }
-    // The last one is the workspace.
-    TF_RET_CHECK(output_index ==
-                 custom_call->shape().tuple_shapes().size() - 1);
-
-    const bool force_deterministic =
-        RequireDeterminism(custom_call->GetModule()->config());
-    config.set_force_deterministic(force_deterministic);
-    TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));
-
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm1_grad_gemm1_rhs,
-        MatmulTensorDescriptorFor(
-            bmm1_grad_gemm1_rhs_shape,
-            config.bmm1_grad_gemm1_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm1_grad_gemm2_rhs,
-        MatmulTensorDescriptorFor(
-            bmm1_grad_gemm2_rhs_shape,
-            config.bmm1_grad_gemm2_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm2_grad_gemm1_lhs,
-        MatmulTensorDescriptorFor(
-            bmm2_grad_gemm1_lhs_shape,
-            config.bmm2_grad_gemm1_dot_dimension_numbers(), LHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm2_grad_gemm2_rhs,
-        MatmulTensorDescriptorFor(
-            bmm2_grad_gemm2_rhs_shape,
-            config.bmm2_grad_gemm2_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor d_output,
-        MatmulTensorDescriptorFor(
-            d_output_shape, config.bmm2_grad_gemm1_dot_dimension_numbers(),
-            RHS));
-
-    TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_lhs,
-                        TensorDescriptorFor(d_bmm1_lhs_shape));
-    TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_rhs,
-                        TensorDescriptorFor(d_bmm1_rhs_shape));
-    TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm2_rhs,
-                        TensorDescriptorFor(d_bmm2_rhs_shape));
-
-    std::optional<se::dnn::TensorDescriptor> bias;
-    if (bias_shape.has_value()) {
-      TF_ASSIGN_OR_RETURN(bias, TensorDescriptorFor(*bias_shape));
-    }
-
-    const double dropout_rate = config.dropout_rate();
-
-    TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
-                        AsCudnnFmhaMaskKind(config.mask_type()));
-    TF_ASSIGN_OR_RETURN(
-        se::dnn::FMHAMaskKind dnn_mask_type,
-        GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
-
-    const int sliding_window_length = config.sliding_window_length();
-    TF_ASSIGN_OR_RETURN(
-        se::gpu::CudnnGraph graph,
-        se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(
-            dnn_support, bmm1_grad_gemm1_rhs, bmm1_grad_gemm2_rhs,
-            bmm2_grad_gemm1_lhs, bmm2_grad_gemm2_rhs, d_output, d_bmm1_lhs,
-            d_bmm1_rhs, d_bmm2_rhs, bias, dropout_rate, config.seed(),
-            config.fmha_scale(), dropout_rate > 0.0, bias != std::nullopt,
-            dnn_mask_type, force_deterministic, sliding_window_length,
-            max_seg_per_batch));
-    return graph;
+    return BuildGraphForCustomCallToBackwardFMHA(dnn_support, custom_call);
+  } else if (IsBwdCustomCallTofMHAF8(*custom_call)) {
+    return BuildGraphForCustomCallToBackwardFMHAF8(dnn_support, custom_call);
   } else {
-    TF_ASSIGN_OR_RETURN(
-        auto gpu_config,
-        custom_call->backend_config<xla::gpu::GpuBackendConfig>());
-    xla::gpu::CudnnfMHABackendConfig &config =
-        *gpu_config.mutable_cudnn_fmha_backend_config();
-
-    Shape bmm1_grad_gemm1_rhs_shape = custom_call->operand(0)->shape();
-    Shape bmm1_grad_gemm2_rhs_shape = custom_call->operand(1)->shape();
-    Shape bmm2_grad_gemm2_rhs_shape = custom_call->operand(2)->shape();
-
-    Shape fwd_output_shape = custom_call->operand(3)->shape();
-    Shape d_output_shape = custom_call->operand(4)->shape();
-
-    Shape bmm2_grad_gemm1_lhs_shape(config.intermediate_tensor_shape());
-
-    Shape d_bmm1_lhs_shape = ShapeUtil::GetSubshape(custom_call->shape(), {0});
-    Shape d_bmm1_rhs_shape = ShapeUtil::GetSubshape(custom_call->shape(), {1});
-    Shape d_bmm2_rhs_shape = ShapeUtil::GetSubshape(custom_call->shape(), {2});
-
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm1_grad_gemm1_rhs,
-        MatmulTensorDescriptorFor(
-            bmm1_grad_gemm1_rhs_shape,
-            config.bmm1_grad_gemm1_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm1_grad_gemm2_rhs,
-        MatmulTensorDescriptorFor(
-            bmm1_grad_gemm2_rhs_shape,
-            config.bmm1_grad_gemm2_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm2_grad_gemm1_lhs,
-        MatmulTensorDescriptorFor(
-            bmm2_grad_gemm1_lhs_shape,
-            config.bmm2_grad_gemm1_dot_dimension_numbers(), LHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor bmm2_grad_gemm2_rhs,
-        MatmulTensorDescriptorFor(
-            bmm2_grad_gemm2_rhs_shape,
-            config.bmm2_grad_gemm2_dot_dimension_numbers(), RHS));
-    TF_ASSIGN_OR_RETURN(
-        MatmulTensorDescriptor d_output,
-        MatmulTensorDescriptorFor(
-            d_output_shape, config.bmm2_grad_gemm1_dot_dimension_numbers(),
-            RHS));
-
-    TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_lhs,
-                        TensorDescriptorFor(d_bmm1_lhs_shape));
-    TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm1_rhs,
-                        TensorDescriptorFor(d_bmm1_rhs_shape));
-    TF_ASSIGN_OR_RETURN(TensorDescriptor d_bmm2_rhs,
-                        TensorDescriptorFor(d_bmm2_rhs_shape));
-    // 3 gradients, 4 amaxs and one workspace
-    TF_RET_CHECK(8 == custom_call->shape().tuple_shapes().size());
-
-    TF_RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));
-
-    TF_ASSIGN_OR_RETURN(CudnnfMHAMaskKind cudnn_mask_type,
-                        AsCudnnFmhaMaskKind(config.mask_type()));
-    TF_ASSIGN_OR_RETURN(
-        se::dnn::FMHAMaskKind dnn_mask_type,
-        GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
-    TF_ASSIGN_OR_RETURN(
-        se::gpu::CudnnGraph graph,
-        se::gpu::GetCudnnFlashAttentionBackwardF8OperationGraph(
-            dnn_support, bmm1_grad_gemm1_rhs, bmm1_grad_gemm2_rhs,
-            bmm2_grad_gemm1_lhs, bmm2_grad_gemm2_rhs, d_output, d_bmm1_lhs,
-            d_bmm1_rhs, d_bmm2_rhs, config.fmha_scale(), dnn_mask_type));
-    return graph;
+    TF_RET_CHECK(IsCustomCallToBlockScaledDot(*custom_call));
+    return BuildGraphForCustomCallToBlockScaledDot(dnn_support, custom_call);
   }
 }
 
@@ -413,7 +459,8 @@ class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
   }
 
   absl::Status HandleCustomCall(HloInstruction *hlo) override {
-    if (!IsCustomCallTofMHA(*hlo) && !IsCustomCallTofMHAF8(*hlo)) {
+    if (!IsCustomCallTofMHA(*hlo) && !IsCustomCallTofMHAF8(*hlo) &&
+        !IsCustomCallToBlockScaledDot(*hlo)) {
       return absl::OkStatus();
     }
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -1223,6 +1223,12 @@ cudnn_frontend::DataType_t ToCudnnFrontendDataType(
     case dnn::DataType::kF8E5M2:
       return cudnn_frontend::DataType_t::FP8_E5M2;
 #endif
+#if CUDNN_VERSION >= 90700
+    case dnn::DataType::kF4E2M1FN:
+      return cudnn_frontend::DataType_t::FP4_E2M1;
+    case dnn::DataType::kF8E8M0FNU:
+      return cudnn_frontend::DataType_t::FP8_E8M0;
+#endif
     default:
       LOG(FATAL) << "Invalid DNN data type: " << static_cast<int>(data_type);
   }
@@ -5520,6 +5526,91 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardF8OperationGraph(
 #else
   return absl::UnimplementedError(
       "Cudnn flash attention only supported with Cudnn >= 9.1.0");
+#endif
+}
+
+absl::StatusOr<CudnnGraph> GetCudnnBlockScaledDotOperationGraph(
+    dnn::DnnSupport& dnn_support, const dnn::TensorDescriptor& lhs_data,
+    const dnn::TensorDescriptor& lhs_scale,
+    const dnn::TensorDescriptor& rhs_data,
+    const dnn::TensorDescriptor& rhs_scale, dnn::DataType result_type,
+    int block_size) {
+#if CUDNN_VERSION >= 90700
+  using cudnn_frontend::graph::Block_scale_dequantize_attributes;
+  using cudnn_frontend::graph::Matmul_attributes;
+  using cudnn_frontend::graph::Tensor_attributes;
+
+  VLOG(4) << "\n lhs_data: " << lhs_data.ToString()
+          << "\n lhs_scale: " << lhs_scale.ToString()
+          << "\n rhs_data: " << rhs_data.ToString()
+          << "\n rhs_scale: " << rhs_scale.ToString()
+          << "\n result_type: " << dnn::DataType_Name(result_type)
+          << "\n block_size: " << block_size;
+
+  cudnn_frontend::graph::Graph graph;
+  auto compute_type = cudnn_frontend::DataType_t::FLOAT;
+  graph.set_compute_data_type(compute_type);
+  graph.set_intermediate_data_type(compute_type);
+
+  auto next_uid = [uid = 0]() mutable -> int { return CuDnnTensorUID(uid++); };
+  auto get_tensor_attr = [&](const dnn::TensorDescriptor& desc,
+                             bool is_rhs) -> absl::StatusOr<Tensor_attributes> {
+    TF_ASSIGN_OR_RETURN(std::vector<int64_t> dimensions,
+                        desc.GetPhysicalDimensionsMajorToMinor());
+    std::vector<int64_t> strides = desc.GetPhysicalStridesMajorToMinor();
+    if (dimensions.size() == 2) {
+      dimensions.insert(dimensions.begin(), 1);
+      strides.insert(strides.begin(), dimensions[1] * dimensions[2]);
+    }
+    CHECK_EQ(dimensions.size(), 3);
+    if (is_rhs) {
+      std::swap(dimensions[1], dimensions[2]);
+      std::swap(strides[1], strides[2]);
+    }
+    return Tensor_attributes()
+        .set_uid(next_uid())
+        .set_dim(dimensions)
+        .set_stride(strides)
+        .set_data_type(ToCudnnFrontendDataType(desc.type()));
+  };
+  TF_ASSIGN_OR_RETURN(auto a_data_attr, get_tensor_attr(lhs_data, false));
+  TF_ASSIGN_OR_RETURN(auto b_data_attr, get_tensor_attr(rhs_data, true));
+  TF_ASSIGN_OR_RETURN(auto a_scale_attr, get_tensor_attr(lhs_scale, false));
+  TF_ASSIGN_OR_RETURN(auto b_scale_attr, get_tensor_attr(rhs_scale, true));
+
+  a_scale_attr.set_reordering_type(
+      cudnn_frontend::TensorReordering_t::F8_128x4);
+  b_scale_attr.set_reordering_type(
+      cudnn_frontend::TensorReordering_t::F8_128x4);
+
+  auto a_data = graph.tensor(a_data_attr.set_name("a_data"));
+  auto b_data = graph.tensor(b_data_attr.set_name("b_data"));
+  auto a_scale = graph.tensor(a_scale_attr.set_name("a_scale"));
+  auto b_scale = graph.tensor(b_scale_attr.set_name("b_scale"));
+
+  auto dq_attr = Block_scale_dequantize_attributes().set_block_size(block_size);
+  auto a_dq = graph.block_scale_dequantize(a_data, a_scale, dq_attr);
+  auto b_dq = graph.block_scale_dequantize(b_data, b_scale, dq_attr);
+
+  auto matmul_attr = Matmul_attributes().set_compute_data_type(compute_type);
+  auto d_tensor = graph.matmul(a_dq, b_dq, matmul_attr);
+  d_tensor->set_uid(next_uid());
+  d_tensor->set_data_type(ToCudnnFrontendDataType(result_type));
+  d_tensor->set_is_virtual(false);
+
+  CudnnGraph cudnnGraph(std::move(graph));
+  TF_RETURN_IF_ERROR(cudnnGraph.Prepare(
+      dnn_support, NumericOptions{/*require_determinism=*/false,
+                                  /*allow_tf32=*/true}));
+  TF_RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/std::nullopt));
+
+  VLOG(4) << "\b workspace size:" << cudnnGraph.Graph().get_workspace_size();
+  VLOG(4) << "\b block scaled dot graph: " << cudnnGraph.Graph();
+
+  return cudnnGraph;
+#else
+  return absl::UnimplementedError(
+      "Cudnn block scaled dot only supported with Cudnn >= 9.7.0");
 #endif
 }
 

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -743,6 +743,13 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardF8OperationGraph(
     const dnn::TensorDescriptor& dv_desc, double scale,
     dnn::FMHAMaskKind mask_type);
 
+absl::StatusOr<CudnnGraph> GetCudnnBlockScaledDotOperationGraph(
+    dnn::DnnSupport& dnn_support, const dnn::TensorDescriptor& lhs_data,
+    const dnn::TensorDescriptor& lhs_scale,
+    const dnn::TensorDescriptor& rhs_data,
+    const dnn::TensorDescriptor& rhs_scale, dnn::DataType result_type,
+    int block_size);
+
 }  // namespace gpu
 }  // namespace stream_executor
 


### PR DESCRIPTION
Update the `BlockScalingRewriter` pass to allow lowering the "__op$block_scaled_dot" to a cuDNN graph (instead of HLO graph) - this lowers to a block scaled dot kernel via cuDNN frontend (since v1.10).

The only format supported currently is MXFP8 (both dot inputs are quantized to E4M3FN/E5M2 tensors with E8M0 scales using block size 32).
MXFP8 docs: https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf

The cuDNN kernel has some requirements for the input shapes, so some padding may be needed. Also, the scale tensor must be swizzled (transposed in a specific manner). The tests are added that verify both the pass transformations and the runtime correctness.

The pass is also enabled in the same PR.