### PR TITLE
Change the default cuda compiler from nvcc to clang in configure.py

### DIFF
--- a/build_tools/configure/configure.py
+++ b/build_tools/configure/configure.py
@@ -432,7 +432,7 @@ def _parse_args():
       "--cuda_compiler",
       type=CudaCompiler.from_str,
       choices=list(CudaCompiler),
-      default="nvcc",
+      default="clang",
   )
   parser.add_argument(
       "--rocm_compiler",


### PR DESCRIPTION
Changing the default compiler from `configure.py` to use `clang` instead of `nvcc`.