### PR TITLE
[ROCm] Suppres offsetof-extensions warning for rocm build

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -291,6 +291,7 @@ build:tpu --define=framework_shared_object=true
 build:tpu --copt=-DLIBTPU_ON_GCE
 build:tpu --define=enable_mlir_bridge=true
 
+build:rocm --copt=-Wno-gnu-offsetof-extensions
 build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm --define=using_rocm_hipcc=true
 build:rocm --define=tensorflow_mkldnn_contraction_kernel=0


### PR DESCRIPTION
Since ROCm hermetic CI job was failing due to a warning in external/upb/upb/upb.c:192:10
We suppress that warning for a rocm config till we use a version of upd with that particular fix. 