### PR TITLE
[XLA:GPU] Replace "gpu_b100" with "gpu_b200" test backend name

### DIFF
--- a/build_tools/lint/tags.py
+++ b/build_tools/lint/tags.py
@@ -81,7 +81,7 @@ _TAGS_TO_DOCUMENTATION_MAP = {
     "xla_gpu_v100": "Runs on a v100.",
     "xla_gpu_a100": "Runs on an a100.",
     "xla_gpu_h100": "Runs on an h100.",
-    "xla_gpu_b100": "Runs on an b100.",
+    "xla_gpu_b200": "Runs on an b200.",
     # Below tags are consumed by `xla_test`.
     "test_xla_cpu_no_thunks": (
         "Internally, `xla_test` sets `--xla_cpu_use_thunk_runtime` to false."

--- a/xla/backends/gpu/codegen/BUILD
+++ b/xla/backends/gpu/codegen/BUILD
@@ -61,7 +61,7 @@ xla_test(
     srcs = if_cuda_is_configured(["cudnn_test.cc"]),
     backends = [
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     deps = [
         "//xla:comparison_util",

--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -625,7 +625,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     shard_count = 20,
@@ -680,7 +680,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     tags = [
@@ -718,7 +718,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     shard_count = 30,
@@ -763,7 +763,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     tags = [
@@ -908,7 +908,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     tags = [
@@ -936,7 +936,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     shard_count = 10,
@@ -1023,7 +1023,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     tags = ["no_mac"],

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -229,7 +229,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_v100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
@@ -343,7 +343,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_v100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     deps = [

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1869,7 +1869,7 @@ xla_test(
     backends = [
         "gpu_v100",
         "gpu_a100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     tags = [
         "cuda-only",
@@ -2616,7 +2616,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     deps = [
         ":variant_visitor",
@@ -2863,7 +2863,7 @@ xla_test(
         "gpu_v100",
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     tags = [
@@ -2947,7 +2947,7 @@ xla_test(
     srcs = ["determinism_test.cc"],
     backends = [
         "gpu_a100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     deps = [

--- a/xla/service/gpu/autotuning/BUILD
+++ b/xla/service/gpu/autotuning/BUILD
@@ -197,7 +197,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     tags = [
         "cuda-only",

--- a/xla/service/gpu/model/BUILD
+++ b/xla/service/gpu/model/BUILD
@@ -118,7 +118,7 @@ xla_test(
         "gpu_v100",
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     deps = [
         ":analytical_latency_estimator",

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -320,7 +320,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_v100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     deps = [
@@ -685,7 +685,7 @@ xla_test(
     srcs = ["tensor_float_32_global_var_test.cc"],
     backends = [
         "gpu_a100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ] + if_oss([
         "gpu_any",
@@ -704,7 +704,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     tags = ["cuda-only"],
     deps = if_cuda_is_configured(
@@ -748,7 +748,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     shard_count = 2,
     deps = [

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1390,7 +1390,7 @@ xla_test(
         "gpu_a100",
         "gpu_p100",
         "gpu_v100",
-        "gpu_b100",
+        "gpu_b200",
         "gpu_amd_any",
     ],
     deps = if_gpu_is_configured(
@@ -3206,7 +3206,7 @@ xla_test(
     backends = [
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     deps = [
         ":triton_fusion_numerics_verifier",

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -1670,7 +1670,7 @@ xla_test(
         "gpu_v100",
         "gpu_a100",
         "gpu_h100",
-        "gpu_b100",
+        "gpu_b200",
     ],
     data = ["data/cudnn_reproducer.hlo"],
     deps = [

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -14,7 +14,7 @@ NVIDIA_GPU_BACKENDS = [
     "gpu_v100",
     "gpu_a100",
     "gpu_h100",
-    "gpu_b100",
+    "gpu_b200",
 ]
 
 # The generic "gpu" backend includes the actual backends in this list.
@@ -22,7 +22,7 @@ NVIDIA_GPU_DEFAULT_BACKENDS = [
     "gpu_any",
     "gpu_a100",
     "gpu_h100",
-    "gpu_b100",
+    "gpu_b200",
 ]
 
 AMD_GPU_DEFAULT_BACKENDS = ["gpu_amd_any"]
@@ -65,7 +65,7 @@ def prepare_nvidia_gpu_backend_data(backends, disabled_backends, backend_tags, b
         "gpu_v100": (7, 0),
         "gpu_a100": (8, 0),
         "gpu_h100": (9, 0),
-        "gpu_b100": (10, 0),
+        "gpu_b200": (10, 0),
     }
     for gpu_backend in NVIDIA_GPU_BACKENDS:
         all_tags = new_backend_tags[gpu_backend]


### PR DESCRIPTION
B200 is the name of the released chip.
https://www.nvidia.com/en-us/data-center/dgx-b200/