### PR TITLE
[XLA:GPU] Reduce CUDA plugin registration messages to info

### DIFF
--- a/xla/stream_executor/cuda/cuda_blas.cc
+++ b/xla/stream_executor/cuda/cuda_blas.cc
@@ -1404,7 +1404,7 @@ void initialize_cublas() {
           });
 
   if (!status.ok()) {
-    LOG(ERROR) << "Unable to register cuBLAS factory: " << status.message();
+    LOG(INFO) << "Unable to register cuBLAS factory: " << status.message();
   }
 }
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -8667,7 +8667,7 @@ void initialize_cudnn() {
           });
 
   if (!status.ok()) {
-    LOG(ERROR) << "Unable to register cuDNN factory: " << status.message();
+    LOG(INFO) << "Unable to register cuDNN factory: " << status.message();
   }
 }
 

--- a/xla/stream_executor/cuda/cuda_fft.cc
+++ b/xla/stream_executor/cuda/cuda_fft.cc
@@ -464,7 +464,7 @@ void initialize_cufft() {
             return new gpu::CUDAFft(parent);
           });
   if (!status.ok()) {
-    LOG(ERROR) << "Unable to register cuFFT factory: " << status.message();
+    LOG(INFO) << "Unable to register cuFFT factory: " << status.message();
   }
 }
 


### PR DESCRIPTION
This pull request is to reduce the CUDA plugin registration log level to avoid user confusing confusion in https://github.com/openxla/xla/issues/20803. Actually, no functionality errors happened with CUDA plugin registration.