### PR TITLE
Delete Operand Transposes of FP8 GEMMs on Blackwell

### DIFF
--- a/xla/service/gpu/transforms/gemm_rewriter_fp8_test.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_fp8_test.cc
@@ -2991,6 +2991,49 @@ TEST_P(ParameterizedFp8GemmRewriteTest, FnuzTypeF8) {
   }
 }
 
+TEST_P(ParameterizedFp8GemmRewriteTest, NoTransposeOnBlackwellF8) {
+  if (!IsBlackwell()) {
+    GTEST_SKIP() << "Test requires a Blackwell GPU.";
+  }
+  const char* hlo_text = R"(
+    HloModule test
+
+    ENTRY test {
+      x = <<F8E4M3>>[16,32] parameter(0)
+      y = <<F8E4M3>>[32,16] parameter(1)
+      ROOT out = <<F8E4M3>>[16,16] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+          }
+
+)";
+
+  EXPECT_TRUE(RunAndCompare(absl::StrReplaceAll(hlo_text, replacements_),
+                            ErrorSpec{1e-2, 1e-2}));
+  MatchOptimizedHlo(hlo_text,
+                    R"(
+; CHECK-LABEL: ENTRY %test ({{.*}}: <<F8E4M3>>[16,32], {{.*}}: <<F8E4M3>>[32,16]) -> <<F8E4M3>>[16,16] {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = <<F8E4M3>>[16,32]{1,0} parameter(0)
+; CHECK-NEXT:    [[P1:%[^ ]+]] = <<F8E4M3>>[32,16]{1,0} parameter(1)
+; CHECK-NEXT:    [[C1:[^ ]+]] = f32[] constant(1)
+; CHECK-NEXT:    [[OUT:%[^ ]+]] = (<<F8E4M3>>[16,16]{1,0}, s8[{{[0-9]+}}]{0}) custom-call([[P0]], [[P1]], [[C1]], [[C1]]),
+; CHECK:           custom_call_target="__cublas$lt$matmul$f8",
+; CHECK:           backend_config={
+; CHECK-DAG:         "alpha_real":1
+; CHECK-DAG:         "alpha_imag":0
+; CHECK-DAG:         "beta":0
+; CHECK-DAG:         "dot_dimension_numbers":{
+; CHECK-DAG:           "lhs_contracting_dimensions":["1"]
+; CHECK-DAG:           "rhs_contracting_dimensions":["0"]
+; CHECK-DAG:           "lhs_batch_dimensions":[]
+; CHECK-DAG:           "rhs_batch_dimensions":[]
+; CHECK-DAG:         }
+; CHECK-DAG:         "precision_config":{
+; CHECK-DAG:           "operand_precision":["DEFAULT","DEFAULT"]
+; CHECK-DAG:         }
+; CHECK-DAG:         "epilogue":"DEFAULT"
+; CHECK:           }
+          )");
+}
+
 INSTANTIATE_TEST_SUITE_P(Fp8CublasTestsBothLegacyAndLt,
                          ParameterizedFp8GemmRewriteTest, ::testing::Bool());
 

--- a/xla/service/gpu/transforms/gemm_rewriter_fp8_test.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_fp8_test.cc
@@ -2999,9 +2999,9 @@ TEST_P(ParameterizedFp8GemmRewriteTest, NoTransposeOnBlackwellF8) {
     HloModule test
 
     ENTRY test {
-      x = <<F8E4M3>>[16,32] parameter(0)
+      x = <<F8E4M3>>[32,16] parameter(0)
       y = <<F8E4M3>>[32,16] parameter(1)
-      ROOT out = <<F8E4M3>>[16,16] dot(x, y), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      ROOT out = <<F8E4M3>>[16,16] dot(x, y), lhs_contracting_dims={0}, rhs_contracting_dims={0}
           }
 
 )";
@@ -3010,8 +3010,8 @@ TEST_P(ParameterizedFp8GemmRewriteTest, NoTransposeOnBlackwellF8) {
                             ErrorSpec{1e-2, 1e-2}));
   MatchOptimizedHlo(hlo_text,
                     R"(
-; CHECK-LABEL: ENTRY %test ({{.*}}: <<F8E4M3>>[16,32], {{.*}}: <<F8E4M3>>[32,16]) -> <<F8E4M3>>[16,16] {
-; CHECK-NEXT:    [[P0:%[^ ]+]] = <<F8E4M3>>[16,32]{1,0} parameter(0)
+; CHECK-LABEL: ENTRY %test ({{.*}}: <<F8E4M3>>[32,16], {{.*}}: <<F8E4M3>>[32,16]) -> <<F8E4M3>>[16,16] {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = <<F8E4M3>>[32,16]{1,0} parameter(0)
 ; CHECK-NEXT:    [[P1:%[^ ]+]] = <<F8E4M3>>[32,16]{1,0} parameter(1)
 ; CHECK-NEXT:    [[C1:[^ ]+]] = f32[] constant(1)
 ; CHECK-NEXT:    [[OUT:%[^ ]+]] = (<<F8E4M3>>[16,16]{1,0}, s8[{{[0-9]+}}]{0}) custom-call([[P0]], [[P1]], [[C1]], [[C1]]),
@@ -3021,7 +3021,7 @@ TEST_P(ParameterizedFp8GemmRewriteTest, NoTransposeOnBlackwellF8) {
 ; CHECK-DAG:         "alpha_imag":0
 ; CHECK-DAG:         "beta":0
 ; CHECK-DAG:         "dot_dimension_numbers":{
-; CHECK-DAG:           "lhs_contracting_dimensions":["1"]
+; CHECK-DAG:           "lhs_contracting_dimensions":["0"]
 ; CHECK-DAG:           "rhs_contracting_dimensions":["0"]
 ; CHECK-DAG:           "lhs_batch_dimensions":[]
 ; CHECK-DAG:           "rhs_batch_dimensions":[]

--- a/xla/service/gpu/transforms/gemm_rewriter_test_lib.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_test_lib.cc
@@ -59,6 +59,13 @@ bool GemmRewriteTestBase::IsRocm() const {
       Capability());
 }
 
+bool GemmRewriteTestBase::IsBlackwell() const {
+  if (IsCuda()) {
+    return std::get<se::CudaComputeCapability>(Capability()).IsBlackwell();
+  }
+  return false;
+}
+
 stream_executor::GpuComputeCapability
 GemmRewriteTestBase::CudaHopperOrRocmMI300() {
   if (IsCuda()) {

--- a/xla/service/gpu/transforms/gemm_rewriter_test_lib.h
+++ b/xla/service/gpu/transforms/gemm_rewriter_test_lib.h
@@ -37,6 +37,8 @@ class GemmRewriteTestBase : public GpuCodegenTest {
 
   bool IsRocm() const;
 
+  bool IsBlackwell() const;
+
   stream_executor::GpuComputeCapability CudaHopperOrRocmMI300();
 
   DebugOptions GetDebugOptionsForTest() const override;

--- a/xla/service/gpu/transforms/layout_assignment.cc
+++ b/xla/service/gpu/transforms/layout_assignment.cc
@@ -396,13 +396,17 @@ absl::Status GpuLayoutAssignment::AddDotBackendConstraints(
   const bool is_s8_to_s32 = output_type == PrimitiveType::S32 &&
                             lhs.type == PrimitiveType::S8 &&
                             rhs.type == PrimitiveType::S8;
-  const bool is_fp8_to_fp8 = (lhs.type == PrimitiveType::F8E4M3FN ||
-                              lhs.type == PrimitiveType::F8E5M2FNUZ) &&
-                             (rhs.type == PrimitiveType::F8E4M3FN ||
-                              rhs.type == PrimitiveType::F8E5M2FNUZ);
+  const bool is_fp8 = (lhs.type == PrimitiveType::F8E4M3FN ||
+                       lhs.type == PrimitiveType::F8E5M2FNUZ) &&
+                      (rhs.type == PrimitiveType::F8E4M3FN ||
+                       rhs.type == PrimitiveType::F8E5M2FNUZ);
+
+  // Blackwell does not require the transposing of FP8 dot operands.
+  const se::CudaComputeCapability* cc =
+      std::get_if<se::CudaComputeCapability>(&gpu_version_);
   const bool both_operands_require_minor_contraction_dims =
       (is_bf16_to_bf16 && xla_gpu_ensure_minor_dot_contraction_dims) ||
-      is_s8_to_s32 || is_fp8_to_fp8;
+      is_s8_to_s32 || (is_fp8 && !(cc && cc->IsBlackwell()));
 
   for (const Side& side : {lhs, rhs}) {
     if ((IsPackedInstruction(side.operand) && pack_along_contracting_dims) ||

--- a/xla/service/gpu/transforms/layout_assignment.cc
+++ b/xla/service/gpu/transforms/layout_assignment.cc
@@ -401,7 +401,6 @@ absl::Status GpuLayoutAssignment::AddDotBackendConstraints(
                       (rhs.type == PrimitiveType::F8E4M3FN ||
                        rhs.type == PrimitiveType::F8E5M2FNUZ);
 
-  // Blackwell does not require the transposing of FP8 dot operands.
   const se::CudaComputeCapability* cc =
       std::get_if<se::CudaComputeCapability>(&gpu_version_);
   const bool both_operands_require_minor_contraction_dims =

--- a/xla/stream_executor/cuda/cuda_compute_capability.h
+++ b/xla/stream_executor/cuda/cuda_compute_capability.h
@@ -96,6 +96,8 @@ struct CudaComputeCapability {
     return major >= CudaComputeCapabilities::BLACKWELL;
   }
 
+  bool IsBlackwell() const { return *this == Blackwell(); }
+
   bool operator<(const CudaComputeCapability &other) const {
     return ToPair() < other.ToPair();
   }


### PR DESCRIPTION
Skips the insertion of transposes of the operands of FP8 GEMMs not required on Blackwell systems.