### PR TITLE
DRAFT: Add scheduling done group id

### DIFF
--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -359,8 +359,20 @@ class AnnotationTracker {
   std::vector<int64_t> GetAnnotations(const HloComputation* comp) const {
     return comp_annotation_map_.at(comp);
   }
+
+  bool IsAsyncDoneType(HloOpcode opcode) const {
+    return (opcode == HloOpcode::kAsyncDone || 
+            opcode == HloOpcode::kCollectivePermuteDone);
+  }
+  
   std::optional<int64_t> GetAnnotation(const HloInstruction* instr) const {
     const auto& attrs = instr->frontend_attributes().map();
+
+    if (IsAsyncDoneType(instr->opcode())) {
+      if (attrs.contains(kXlaSchedulingDoneGroupIdAttr)) {
+        return std::stoi(attrs.at(kXlaSchedulingDoneGroupIdAttr));
+      }    
+    }
     if (attrs.contains(kXlaSchedulingGroupIdAttr)) {
       return std::stoi(attrs.at(kXlaSchedulingGroupIdAttr));
     }

--- a/xla/side_effect_util.cc
+++ b/xla/side_effect_util.cc
@@ -75,4 +75,6 @@ const char kXlaMultiRecvCountAttr[] = "_xla_multi_recv_count";
 
 const char kXlaSchedulingGroupIdAttr[] = "_scheduling_group_id";
 
+const char kXlaSchedulingDoneGroupIdAttr[] = "_scheduling_done_group_id";
+
 }  // namespace xla

--- a/xla/side_effect_util.h
+++ b/xla/side_effect_util.h
@@ -85,6 +85,8 @@ extern const char kXlaMultiRecvCountAttr[];
 
 // XLA frontend attribute for specifying the scheduling group id annotations.
 extern const char kXlaSchedulingGroupIdAttr[];
+extern const char kXlaSchedulingDoneGroupIdAttr[];
+
 }  // namespace xla
 
 #endif  // XLA_SIDE_EFFECT_UTIL_H_


### PR DESCRIPTION
This is a simple draft patch of how we could implement a `_scheduling_done_group_id`, which would allow done operations to be scheduled in groups separate from their matching start op. 