### PR TITLE
[XLA:GPU] Enable cuDNN kernel for NVFP4 block scaled dot

### DIFF
--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -64,8 +64,7 @@ namespace xla::gpu {
 //
 class BlockScalingRewriter : public OpExpanderPass {
  public:
-  explicit BlockScalingRewriter(bool allow_cudnn)
-      : allow_cudnn_(allow_cudnn) {};
+  explicit BlockScalingRewriter(bool allow_cudnn) : allow_cudnn_(allow_cudnn){};
 
   absl::string_view name() const override { return "block-scaling-rewriter"; }
 
@@ -84,6 +83,7 @@ class BlockScalingRewriter : public OpExpanderPass {
 
   // Common block size constants.
   static constexpr int kBlockSizeMXFP8 = 32;
+  static constexpr int kBlockSizeNVFP4 = 16;
 
  private:
   bool allow_cudnn_;


### PR DESCRIPTION
Support NVFP4 in addition to MXFP8 hardware acceleration for the "__op$block_scaled_dot" custom call.

This PR also addresses some nits from the internal review (like renaming a generic `CompositeType` to a more specific `CudnnMxType`).