### PR TITLE
[ROCm] Use device allocate for collective memory allocation

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -732,6 +732,9 @@ absl::StatusOr<ModuleHandle> RocmExecutor::LoadModuleFromHsaco(
 }
 
 DeviceMemoryBase RocmExecutor::Allocate(uint64_t size, int64_t memory_space) {
+  if (memory_space == static_cast<int64_t>(MemoryType::kCollective)) {
+    return DeviceMemoryBase(DeviceAllocate(rocm_context_, size), size);
+  }
   if (memory_space ==
       static_cast<int64_t>(stream_executor::MemoryType::kHost)) {
     auto result = HostAllocate(rocm_context_, size);


### PR DESCRIPTION
This extends https://github.com/openxla/xla/pull/22102 and fixes //xla/stream_executor/gpu:gpu_executor_test_gpu_amd_any