### PR TITLE
[GPU] Fix cuDNN fusion compiler support of control predecessors.

### DIFF
--- a/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
@@ -181,7 +181,7 @@ inline std::optional<fe::DataType_t> GetComputeDataType(
 class GemmDimensionAdapter {
   explicit GemmDimensionAdapter(const HloDotInstruction& dot,
                                 TritonFusionAnalysis analysis)
-      : analysis_(std::move(analysis)), dot_(dot) {};
+      : analysis_(std::move(analysis)), dot_(dot){};
 
  public:
   const TritonFusionAnalysis analysis_;
@@ -642,6 +642,8 @@ absl::StatusOr<HloInstruction*> AddWorkspace(HloInstruction& fusion,
   computation->set_root_instruction(output_tuple, true);
   HloInstruction* new_fusion = fusion.parent()->AddInstruction(
       fusion.CloneWithNewShape(output_tuple->shape()));
+  TF_RETURN_IF_ERROR(new_fusion->CopyAllControlDepsFrom(&fusion));
+  TF_RETURN_IF_ERROR(fusion.DropAllControlDeps());
   TF_RETURN_IF_ERROR(fusion.ReplaceAllUsesWith(fusion.parent()->AddInstruction(
       HloInstruction::CreateGetTupleElement(new_fusion, 0))));
   TF_RETURN_IF_ERROR(fusion.parent()->RemoveInstruction(&fusion));


### PR DESCRIPTION
Control predecessors have to be handled like in https://github.com/openxla/xla/blob/28887817aa29aef860211b131e4f6901ef590d4c/xla/service/gpu/transforms/fusion_wrapper.cc#L133-L137 to make the removal of the original instruction safe.