### PR TITLE
Verify GPU Peak Memory Usage for Latency Hiding Scheduler Pass

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -1274,6 +1274,7 @@ xla_cc_test(
         "//xla:shape_util",
         "//xla:util",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass_pipeline",
         "//xla/hlo/transforms/collectives:async_collective_creator",
         "//xla/tests:hlo_test_base",
         "//xla/tests:xla_internal_test_main",

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -2760,7 +2760,8 @@ absl::StatusOr<bool> LatencyHidingScheduler::Run(
   LOG(INFO) << "LatencyHidingScheduler current memory usage: "
             << scheduler_core_->GetMemoryPeak()
             << " bytes. Current limit: " << scheduler_core_->GetMemoryLimit();
-  SetKVMetric(module, "peak_memory_usage", scheduler_core_->GetMemoryPeak());
+  SetKVMetric(module, std::string(kPeakMemoryUsage),
+              scheduler_core_->GetMemoryPeak());
   for (HloComputation* computation : computations_to_schedule) {
     VLOG(1) << "Statistics before scheduling:";
     LogScheduleStatistics(computation);

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -2760,6 +2760,7 @@ absl::StatusOr<bool> LatencyHidingScheduler::Run(
   LOG(INFO) << "LatencyHidingScheduler current memory usage: "
             << scheduler_core_->GetMemoryPeak()
             << " bytes. Current limit: " << scheduler_core_->GetMemoryLimit();
+  SetKVMetric(module, "peak_memory_usage", scheduler_core_->GetMemoryPeak());
   for (HloComputation* computation : computations_to_schedule) {
     VLOG(1) << "Statistics before scheduling:";
     LogScheduleStatistics(computation);

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -1164,6 +1164,8 @@ class LatencyHidingScheduler : public HloModulePass {
   absl::flat_hash_set<HloComputation*> computations_to_schedule_;
 };
 
+static constexpr absl::string_view kPeakMemoryUsage = "peak_memory_usage";
+
 }  // namespace xla
 
 #endif  // XLA_SERVICE_LATENCY_HIDING_SCHEDULER_H_

--- a/xla/service/latency_hiding_scheduler_test.cc
+++ b/xla/service/latency_hiding_scheduler_test.cc
@@ -3088,8 +3088,8 @@ ENTRY AddR2 {
 // Function to retrieve the value for a specific key from HloPassMetadata
 // for a given pass_name. Returns 0 if the key or pass_name is not found.
 int64_t GetKeyValueFromHloPassMetadata(const HloModuleMetadataProto& metadata,
-                                       const std::string& pass_name,
-                                       const std::string& target_key) {
+                                       absl::string_view pass_name,
+                                       absl::string_view target_key) {
   for (const auto& pass_metadata : metadata.pass_metadata()) {
     if (pass_metadata.pass_name() == pass_name) {
       for (const auto& kv_metric : pass_metadata.kv_metrics()) {
@@ -3104,7 +3104,7 @@ int64_t GetKeyValueFromHloPassMetadata(const HloModuleMetadataProto& metadata,
 
 TEST_F(LatencyHidingSchedulerTest, GetGPUPeakMemoryUsage) {
   // Retrieve GPU peak memory usage and verify it excludes host memory
-  absl::string_view kPeakMemoryUsageWithCpuOffload = R"(
+  absl::string_view hlo_string = R"(
   HloModule offloading, is_scheduled=true
   ENTRY main {
     param.1 = f32[1024]{0} parameter(1)
@@ -3116,8 +3116,7 @@ TEST_F(LatencyHidingSchedulerTest, GetGPUPeakMemoryUsage) {
     ROOT t = (f32[1024]{0}, f32[1024]{0:S(5)}) tuple(copy-done.h2d, copy-done.d2h)
   })";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto hlo_module,
-                          ParseHloText(kPeakMemoryUsageWithCpuOffload));
+  TF_ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseHloText(hlo_string));
   EXPECT_TRUE(hlo_module->has_entry_computation());
   auto sched_config = GetDefaultSchedConfig();
   TF_EXPECT_OK(RunScheduler(hlo_module.get(), sched_config,

--- a/xla/service/latency_hiding_scheduler_test.cc
+++ b/xla/service/latency_hiding_scheduler_test.cc
@@ -3122,10 +3122,9 @@ TEST_F(LatencyHidingSchedulerTest, GetGPUPeakMemoryUsage) {
   TF_EXPECT_OK(RunScheduler(hlo_module.get(), sched_config,
                             std::make_unique<TestLatencyEstimator>(), nullptr));
   const HloModuleMetadataProto& metadata = hlo_module->metadata()->proto();
-  std::string pass_name = "latency-hiding-scheduler";
   std::string target_key = "peak_memory_usage";
-  int64_t peak_memory_bytes =
-      GetKeyValueFromHloPassMetadata(metadata, pass_name, target_key);
+  int64_t peak_memory_bytes = GetKeyValueFromHloPassMetadata(
+      metadata, LatencyHidingScheduler::kName, target_key);
   EXPECT_LT(peak_memory_bytes, 4200);
 }
 


### PR DESCRIPTION
When working with llama2-7b from MaxText, we encountered an out-of-memory error when enabling optimizer state offloading and latency hiding scheduling. However, it worked fine without latency hiding scheduling. This change list:
- Stores the GPU peak memory usage in the metadata of the latency hiding scheduler pass.
- Adds unit tests to verify the GPU peak memory usage.