### PR TITLE
[XLA:CPU][oneDNN] Scratch allocations for oneDNN Convolutions

### DIFF
--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -2466,7 +2466,7 @@ std::vector<StackAlloca> IrEmitter::EmitOneDnnOperandsAlloca(
 }
 
 std::pair<llvm::Value*, StackAlloca> IrEmitter::GetPtrAndAllocaFromBufferSlice(
-    const BufferAllocation::Slice slice, const Shape shape) {
+    const BufferAllocation::Slice& slice, const Shape& shape) {
   llvm::Value* slice_ptr = EmitBufferPointer(slice, shape);
   llvm::Type* type = IrShapeType(shape);
   llvm_ir::IrArray ir_array = llvm_ir::IrArray(slice_ptr, type, shape);
@@ -2678,7 +2678,7 @@ absl::Status IrEmitter::HandleOneDnnConvolution(HloInstruction* custom_call) {
   // Lifetime ends for all stack allocations.
   b()->CreateLifetimeEnd(nargs_ptr, b()->getInt64(-1));
   b()->CreateLifetimeEnd(args_ptr, b()->getInt64(-1));
-  for (auto& alloca : operands_stack_alloca) {
+  for (StackAlloca& alloca : operands_stack_alloca) {
     alloca.EmitLifetimeEnd();
   }
   result_stack_alloca.EmitLifetimeEnd();

--- a/xla/service/cpu/ir_emitter.h
+++ b/xla/service/cpu/ir_emitter.h
@@ -338,7 +338,7 @@ class IrEmitter : public DfsHloVisitorWithDefault,
                                                     llvm::Value*& args_val,
                                                     int& arg_indx);
   std::pair<llvm::Value*, StackAlloca> GetPtrAndAllocaFromBufferSlice(
-      const BufferAllocation::Slice slice, const Shape shape);
+      const BufferAllocation::Slice& slice, const Shape& shape);
   absl::Status HandleOneDnnMatMulCalls(HloInstruction* hlo,
                                        std::string runtime_symbol_name);
   absl::Status HandleOneDnnSoftmax(HloInstruction* hlo);

--- a/xla/service/cpu/ir_emitter.h
+++ b/xla/service/cpu/ir_emitter.h
@@ -337,6 +337,8 @@ class IrEmitter : public DfsHloVisitorWithDefault,
   std::vector<StackAlloca> EmitOneDnnOperandsAlloca(HloInstruction* custom_call,
                                                     llvm::Value*& args_val,
                                                     int& arg_indx);
+  std::pair<llvm::Value*, StackAlloca> GetPtrAndAllocaFromBufferSlice(
+      const BufferAllocation::Slice slice, const Shape shape);
   absl::Status HandleOneDnnMatMulCalls(HloInstruction* hlo,
                                        std::string runtime_symbol_name);
   absl::Status HandleOneDnnSoftmax(HloInstruction* hlo);

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -1153,7 +1153,7 @@ class OneDnnPostRewriteVisitor : public DfsHloRewriteVisitor {
     }
     // TODO(intel-tf): Remove this condition after enabling weights prepacking
     // for convolutions
-    if constexpr (std::is_same<PrimDesc, dnnl::matmul::primitive_desc>::value) {
+    if constexpr (std::is_same_v<PrimDesc, dnnl::matmul::primitive_desc>) {
       auto weights_prepack = PrepackWeights<PrimDesc>(custom_call);
       if (!weights_prepack.ok()) {
         VLOG(2) << weights_prepack.status();

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -1132,12 +1132,14 @@ class OneDnnPostRewriteVisitor : public DfsHloRewriteVisitor {
   }
 
   absl::Status HandleCustomCall(HloInstruction* custom_call) override {
-    HloInstruction* matmul;
-    if (Match(custom_call, OneDnnMatmulInstr(&matmul))) {
+    HloInstruction* contraction;
+    if (Match(custom_call, OneDnnMatmulInstr(&contraction))) {
       return HandleCustomCallInternal<dnnl::matmul::primitive_desc>(
           custom_call);
+    } else if (Match(custom_call, OneDnnConvolutionInstr(&contraction))) {
+      return HandleCustomCallInternal<
+          dnnl::convolution_forward::primitive_desc>(custom_call);
     }
-
     return DefaultAction(custom_call);
   }
 
@@ -1149,9 +1151,13 @@ class OneDnnPostRewriteVisitor : public DfsHloRewriteVisitor {
     } else {
       VLOG(2) << scratch_add.status();
     }
-    auto weights_prepack = PrepackWeights<PrimDesc>(custom_call);
-    if (!weights_prepack.ok()) {
-      VLOG(2) << weights_prepack.status();
+    // TODO(intel-tf): Remove this condition after enabling weights prepacking
+    // for convolutions
+    if constexpr (std::is_same<PrimDesc, dnnl::matmul::primitive_desc>::value) {
+      auto weights_prepack = PrepackWeights<PrimDesc>(custom_call);
+      if (!weights_prepack.ok()) {
+        VLOG(2) << weights_prepack.status();
+      }
     }
     return absl::OkStatus();
   }
@@ -1168,8 +1174,8 @@ class OneDnnPostRewriteVisitor : public DfsHloRewriteVisitor {
   template <typename>
   bool GetUserScratch(HloInstruction*);
 
-  // Add scratch for matmul by changing the result of custom-call to
-  // tuple(result, scratch)
+  // Add scratch for matmul and convolution by changing the result of
+  // custom-call to tuple(result, scratch)
   template <typename PrimDesc>
   absl::StatusOr<HloInstruction*> AddScratch(HloInstruction* custom_call) {
     if (GetUserScratch<PrimDesc>(custom_call)) {
@@ -1272,6 +1278,9 @@ EMIT_GET_BACKEND_CONFIG_SPECIALIZATION(GetWeightsPrepack,
                                        dnnl::matmul::primitive_desc,
                                        onednn_matmul_config,
                                        optimization_config, weights_prepacked);
+EMIT_GET_BACKEND_CONFIG_SPECIALIZATION(
+    GetUserScratch, dnnl::convolution_forward::primitive_desc,
+    onednn_conv_config, optimization_config, user_scratchpad);
 
 #define EMIT_SET_BACKEND_CONFIG_SPECIALIZATION(SETTER, PRIM_DESC, CONFIG_TYPE, \
                                                CONFIG, SUB_CONFIG, FIELD)      \
@@ -1293,6 +1302,10 @@ EMIT_SET_BACKEND_CONFIG_SPECIALIZATION(SetUserScratch,
                                        dnnl::matmul::primitive_desc,
                                        OneDnnMatMulConfig, onednn_matmul_config,
                                        optimization_config, user_scratchpad);
+EMIT_SET_BACKEND_CONFIG_SPECIALIZATION(
+    SetUserScratch, dnnl::convolution_forward::primitive_desc,
+    OneDnnConvolutionConfig, onednn_conv_config, optimization_config,
+    user_scratchpad);
 
 absl::StatusOr<bool> OneDnnContractionRewriter::Run(
     HloModule* module,

--- a/xla/service/cpu/onednn_convolution.cc
+++ b/xla/service/cpu/onednn_convolution.cc
@@ -166,11 +166,11 @@ CreateOneDnnPrimDesc<dnnl::convolution_forward::primitive_desc>(
 
   uint64_t groups = conv_config.feature_groups();
 
-  auto new_inp_md =
+  memory::desc new_inp_md =
       input_md.permute_axes(ComputeInputPermutations(&conv_config));
-  auto new_ker_md =
+  memory::desc new_ker_md =
       weights_md.permute_axes(ComputeKernelPermutations(&conv_config));
-  auto new_out_md =
+  memory::desc new_out_md =
       output_md.permute_axes(ComputeOutputPermutations(&conv_config));
 
   if (groups > 1) {

--- a/xla/service/cpu/onednn_convolution.cc
+++ b/xla/service/cpu/onednn_convolution.cc
@@ -21,21 +21,28 @@ limitations under the License.
 #include <cmath>
 #include <cstring>
 #include <initializer_list>
+#include <iterator>
 #include <utility>
 #include <vector>
-
-#define EIGEN_USE_THREADS
 
 #include "absl/base/dynamic_annotations.h"
 #include "unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
 #include "xla/executable_run_options.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_config.pb.h"
 #include "xla/service/cpu/onednn_memory_util.h"
+#include "xla/service/cpu/onednn_util.h"
 #include "xla/service/cpu/runtime_lightweight_check.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
 #include "xla/tsl/util/onednn_threadpool.h"
+#include "tsl/platform/cpu_info.h"
 #include "tsl/platform/logging.h"
+
+#define EIGEN_USE_THREADS
 
 namespace xla {
 namespace cpu {
@@ -70,8 +77,149 @@ GetKernelConfig<kOnednnConvConfig>(
   return (*backend_config)->mutable_onednn_conv_config();
 }
 
+template <>
+std::unique_ptr<dnnl::convolution_forward::primitive_desc>
+CreateOneDnnPrimDesc<dnnl::convolution_forward::primitive_desc>(
+    HloInstruction* instr) {
+  if (instr->opcode() != HloOpcode::kCustomCall) {
+    return nullptr;
+  }
+  auto custom_call = Cast<xla::HloCustomCallInstruction>(instr);
+  auto backend_config = custom_call->backend_config<BackendConfig>();
+  if (!backend_config.ok()) {
+    return nullptr;
+  }
+  auto& conv_config = backend_config.value().onednn_conv_config();
+  auto operands = custom_call->operands();
+  auto input = operands[0];
+  auto weight = operands[1];  // assuming weights is the second operand
+  auto input_shape = input->shape();
+  auto weight_shape = weight->shape();
+  auto output_shape = custom_call->shape().IsTuple()
+                          ? custom_call->shape().tuple_shapes(0)
+                          : custom_call->shape();
+
+  auto fused_operands =
+      HloInstruction::InstructionVector(operands.begin() + 2, operands.end());
+  std::vector<Shape> fused_shapes;
+  std::transform(fused_operands.begin(), fused_operands.end(),
+                 std::back_inserter(fused_shapes),
+                 [](const HloInstruction* instr) { return instr->shape(); });
+
+  auto input_md = ShapeToMemDesc(input_shape);
+  auto weights_md = ShapeToMemDesc(weight_shape);
+  auto output_md = ShapeToMemDesc(output_shape);
+
+  std::vector<int64_t> inp_perm_axes(conv_config.dims());
+  std::vector<int64_t> ker_perm_axes(conv_config.dims());
+  std::vector<int64_t> out_perm_axes(conv_config.dims());
+
+  int index_i = 0;
+  int index_o = 0;
+  int index_k = 0;
+
+  inp_perm_axes[conv_config.input().data().batch_dim()] = index_i++;
+  out_perm_axes[conv_config.output().data().batch_dim()] = index_o++;
+  ker_perm_axes[conv_config.kernel().filter().output_feature_dim()] = index_k++;
+
+  inp_perm_axes[conv_config.input().data().feature_dim()] = index_i++;
+  out_perm_axes[conv_config.output().data().feature_dim()] = index_o++;
+  ker_perm_axes[conv_config.kernel().filter().input_feature_dim()] = index_k++;
+
+  std::vector<int64_t> inp_dim_axes(
+      conv_config.input().data().spatial_dims().begin(),
+      conv_config.input().data().spatial_dims().end());
+  std::vector<int64_t> ker_dim_axes(
+      conv_config.kernel().filter().spatial_dims().begin(),
+      conv_config.kernel().filter().spatial_dims().end());
+  std::vector<int64_t> out_dim_axes(
+      conv_config.output().data().spatial_dims().begin(),
+      conv_config.output().data().spatial_dims().end());
+
+  std::for_each(inp_dim_axes.begin(), inp_dim_axes.end(),
+                [&inp_perm_axes, &index_i](int64_t& n) {
+                  inp_perm_axes[--n] = index_i++;
+                });
+  std::for_each(ker_dim_axes.begin(), ker_dim_axes.end(),
+                [&ker_perm_axes, &index_k](int64_t& n) {
+                  ker_perm_axes[--n] = index_k++;
+                });
+  std::for_each(out_dim_axes.begin(), out_dim_axes.end(),
+                [&out_perm_axes, &index_o](int64_t& n) {
+                  out_perm_axes[--n] = index_o++;
+                });
+
+  memory::dims strides(conv_config.window().strides().begin(),
+                       conv_config.window().strides().end());
+  memory::dims pad_left(conv_config.window().pad_left().begin(),
+                        conv_config.window().pad_left().end());
+  memory::dims pad_right(conv_config.window().pad_right().begin(),
+                         conv_config.window().pad_right().end());
+  memory::dims rhs_dilations(conv_config.window().window_dilations().begin(),
+                             conv_config.window().window_dilations().end());
+
+  std::for_each(strides.begin(), strides.end(), [](int64_t& n) { n -= 1; });
+  std::for_each(pad_left.begin(), pad_left.end(), [](int64_t& n) { n -= 1; });
+  std::for_each(pad_right.begin(), pad_right.end(), [](int64_t& n) { n -= 1; });
+  std::for_each(rhs_dilations.begin(), rhs_dilations.end(),
+                [](int64_t& n) { n -= 2; });
+
+  auto groups = conv_config.feature_groups();
+
+  std::vector<int> inp_axes(inp_perm_axes.begin(), inp_perm_axes.end());
+  std::vector<int> ker_axes(ker_perm_axes.begin(), ker_perm_axes.end());
+  std::vector<int> out_axes(out_perm_axes.begin(), out_perm_axes.end());
+
+  auto new_inp_md = input_md.permute_axes(inp_axes);
+  auto new_ker_md = weights_md.permute_axes(ker_axes);
+  auto new_res_md = output_md.permute_axes(out_axes);
+
+  if (groups > 1) {
+    auto corr_dims = new_ker_md.get_dims();
+    corr_dims.insert(corr_dims.begin(), 1, groups);
+    corr_dims[1] = corr_dims[1] / groups;
+    new_ker_md = new_ker_md.reshape(corr_dims);
+  }
+
+  std::vector<memory::desc> fused_mds;
+  std::transform(fused_shapes.begin(), fused_shapes.end(),
+                 std::back_inserter(fused_mds),
+                 [](const Shape& shape) { return ShapeToMemDesc(shape); });
+
+  auto bias_md = memory::desc();
+
+  dnnl::post_ops post_ops =
+      PopulateOneDnnPostOps(dnnl::engine(dnnl::engine::kind::cpu, 0), fused_mds,
+                            &conv_config.fusions(), nullptr, &bias_md);
+
+  auto any_ker_md =
+      memory::desc(new_ker_md.get_dims(), new_ker_md.get_data_type(),
+                   dnnl::memory::format_tag::any);
+  auto any_inp_md =
+      memory::desc(new_inp_md.get_dims(), new_inp_md.get_data_type(),
+                   GetFormatTag(new_inp_md.get_ndims()));
+  auto any_res_md =
+      memory::desc(new_res_md.get_dims(), new_res_md.get_data_type(),
+                   GetFormatTag(new_res_md.get_ndims()));
+
+  dnnl::primitive_attr attrs;
+
+  if (conv_config.optimization_config().user_scratchpad()) {
+    attrs.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+  }
+
+  if (post_ops.len() > 0) {
+    attrs.set_post_ops(post_ops);
+  }
+
+  return std::make_unique<convolution_forward::primitive_desc>(
+      dnnl::engine(dnnl::engine::kind::cpu, 0), prop_kind::forward_inference,
+      algorithm::convolution_direct, any_inp_md, any_ker_md, bias_md,
+      any_res_md, strides, rhs_dilations, pad_left, pad_right, attrs);
+}
+
 ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnConvolution(
-    void* result, void** args) {
+    void* result, void* scratch, void** args) {
   // args[0]: ptr to nargs
   // args[1]: ptr to ExecutableRunOptions
   // args[2]: ptr to OneDnnConvolutionConfig
@@ -215,6 +363,11 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnConvolution(
   XLA_LIGHTWEIGHT_CHECK(num_args == arg_indx);
 
   dnnl::primitive_attr attrs;
+
+  if (conv_config.optimization_config().user_scratchpad()) {
+    attrs.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+  }
+
   if (post_ops.len() > 0) {
     attrs.set_post_ops(post_ops);
   }
@@ -245,6 +398,14 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnConvolution(
   std::unordered_map<int, memory> conv_args{{DNNL_ARG_SRC, new_inp_mem},
                                             {DNNL_ARG_WEIGHTS, new_ker_mem},
                                             {DNNL_ARG_DST, new_res_mem}};
+
+  if (conv_config.optimization_config().user_scratchpad()) {
+    XLA_LIGHTWEIGHT_CHECK(scratch != nullptr);
+    MemrefInfo scratch_minfo(scratch);
+    auto scratchpad_md = conv_pd->scratchpad_desc();
+    auto scratch_mem = memory(scratchpad_md, cpu_engine, scratch_minfo.Data());
+    conv_args.insert({DNNL_ARG_SCRATCHPAD, scratch_mem});
+  }
 
   conv_args.insert(postop_args.begin(), postop_args.end());
   conv_prim.execute(onednn_stream, conv_args);

--- a/xla/service/cpu/onednn_convolution.h
+++ b/xla/service/cpu/onednn_convolution.h
@@ -25,7 +25,8 @@ namespace cpu {
 constexpr auto kOnednnConvConfig = BackendConfigOneofCase::kOnednnConvConfig;
 
 extern "C" {
-extern void __xla_cpu_runtime_OneDnnConvolution(void* result, void** args);
+extern void __xla_cpu_runtime_OneDnnConvolution(void* result, void* scratch,
+                                                void** args);
 }  // extern "C"
 
 template <>

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -72,9 +72,7 @@ class ConvolutionTest : public HloTestBase,
   ConvolutionTest() {
     dtype_ = GetParam();
     atol_ = rtol_ = (dtype_ == F32) ? 1e-4 : 1e-2;
-    // TODO(intel-tf): Set default value of user_scratchpad to true after
-    // enabling feature
-    user_scratchpad_ = false;
+    user_scratchpad_ = true;
     weights_prepacked_ = false;
     dtypeString_ = primitive_util::LowercasePrimitiveTypeName(dtype_);
   }


### PR DESCRIPTION
This PR allocates scratch buffers for oneDNN convolution computations. It also updates the existing tests to verify that the feature is enabled by default.