### PR TITLE
Fix build break in convolution_thunk_internal

### DIFF
--- a/xla/backends/cpu/runtime/convolution_thunk_internal.h
+++ b/xla/backends/cpu/runtime/convolution_thunk_internal.h
@@ -338,7 +338,7 @@ void EigenGenericConv2D(
     auto num_tasks = Eigen::numext::div_ceil(feature_group_count, task_size);
 
     if (use_thunk_runtime) {
-      ScheduleAll(&device, num_tasks, [=, &device](Eigen::Index task_index) {
+      ScheduleAll(&device, num_tasks, [=, &device](Eigen::Index task_index) mutable {
         Eigen::Index start = task_index * task_size;
         Eigen::Index end = std::min(start + task_size, feature_group_count);
         for (Eigen::Index i = start; i < end; ++i) {


### PR DESCRIPTION
After this change https://github.com/openxla/xla/commit/8e6b84bd729a1d079ed5035f1ba8afc9d205587e, following build error occurred:

```
In file included from xla/backends/cpu/runtime/convolution_thunk_f16.cc:16:
./xla/backends/cpu/runtime/convolution_thunk_internal.h: In lambda function:
./xla/backends/cpu/runtime/convolution_thunk_internal.h:345:71: error: no matching function for call to ‘tsl::CountDownAsyncValueRef<tsl::Chain>::CountDown() const’
  345 |           auto on_done = [count_down]() mutable { count_down.CountDown(); };
      |                                                   ~~~~~~~~~~~~~~~~~~~~^~
In file included from ./xla/backends/cpu/runtime/convolution_thunk_internal.h:26,
                 from xla/backends/cpu/runtime/convolution_thunk_f16.cc:16:
./xla/tsl/concurrency/async_value_ref.h:867:8: note: candidate: ‘bool tsl::CountDownAsyncValueRef<T>::CountDown(size_t, const absl::lts_20230802::Status&) [with T = tsl::Chain; size_t = long unsigned int]’
  867 |   bool CountDown(size_t count, const absl::Status& status = absl::OkStatus()) {
      |        ^~~~~~~~~
./xla/tsl/concurrency/async_value_ref.h:867:8: note:   candidate expects 2 arguments, 0 provided
./xla/tsl/concurrency/async_value_ref.h:919:8: note: candidate: ‘bool tsl::CountDownAsyncValueRef<T>::CountDown(absl::lts_20230802::Status) [with T = tsl::Chain]’ (near match)
  919 |   bool CountDown(absl::Status status = absl::OkStatus()) {
      |        ^~~~~~~~~
./xla/tsl/concurrency/async_value_ref.h:919:8: note:   passing ‘const tsl::CountDownAsyncValueRef<tsl::Chain>*’ as ‘this’ argument discards qualifiers
```