### PR TITLE
Fix hlo_opt printing of Hlo module

### DIFF
--- a/xla/hlo/ir/BUILD
+++ b/xla/hlo/ir/BUILD
@@ -177,6 +177,7 @@ xla_cc_test(
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/parser:hlo_parser",
+        "//xla/hlo/testlib:filecheck",
         "//xla/service:hlo_module_config",
         "//xla/tsl/platform:status",
         "//xla/tsl/platform:statusor",

--- a/xla/hlo/ir/hlo_module.cc
+++ b/xla/hlo/ir/hlo_module.cc
@@ -436,6 +436,19 @@ void HloModule::Print(Printer* printer, const HloPrintOptions& options) const {
   }
 }
 
+std::string HloModule::ToString() const {
+  const DebugOptions& db_options = config().debug_options();
+  HloPrintOptions print_options = db_options.xla_dump_hlo_as_long_text()
+                                      ? HloPrintOptions::Default()
+                                      : HloPrintOptions::ShortParsable();
+  print_options.set_print_large_constants(
+      db_options.xla_dump_large_constants());
+  print_options.set_print_metadata(!db_options.xla_dump_disable_metadata());
+  print_options.set_syntax_sugar_async_ops(
+      db_options.xla_syntax_sugar_async_ops());
+  return ToString(print_options);
+}
+
 std::string HloModule::ToString(const HloPrintOptions& options) const {
   StringPrinter printer;
   Print(&printer, options);

--- a/xla/hlo/ir/hlo_module.h
+++ b/xla/hlo/ir/hlo_module.h
@@ -405,7 +405,8 @@ class HloModule {
 
   // Return a string representation of the module.
   //
-  // By default, we honor the debug options to determine the HloPrintOptions.
+  // By default, we take the default print options but adjust them based on
+  // debug options flags.
   std::string ToString() const;
   std::string ToString(const HloPrintOptions& options) const;
 

--- a/xla/hlo/ir/hlo_module.h
+++ b/xla/hlo/ir/hlo_module.h
@@ -405,9 +405,8 @@ class HloModule {
 
   // Return a string representation of the module.
   //
-  // (We express the default options using an overload rather than a default
-  // param because gdb ignores default params, but does resolve overloads.)
-  std::string ToString() const { return ToString(HloPrintOptions::Default()); }
+  // By default, we honor the debug options to determine the HloPrintOptions.
+  std::string ToString() const;
   std::string ToString(const HloPrintOptions& options) const;
 
   // Returns a Cord representation of the module.

--- a/xla/hlo/ir/hlo_module_test.cc
+++ b/xla/hlo/ir/hlo_module_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_schedule.h"
 #include "xla/hlo/parser/hlo_parser.h"
+#include "xla/hlo/testlib/filecheck.h"
 #include "xla/service/hlo_module_config.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -425,6 +426,47 @@ TEST(HloModuleTest, AbslHashConstantValues) {
       )"));
 
   EXPECT_NE(absl::HashOf(*module1), absl::HashOf(*module2));
+}
+
+TEST(HloModuleTest, CheckToStringHonorsDebugOptions) {
+  // Check that the debug options xla_dump_large_constants,
+  // xla_syntax_sugar_async_ops are honored.
+  const char* hlo = R"(
+  HloModule test
+
+  async_computation {
+    a = f32[32,32] parameter(0)
+    b = f32[32,32] parameter(1)
+    ROOT result = f32[32,32] subtract(a, b)
+  }
+
+  ENTRY main {
+    a = f32[32,32] parameter(0)
+    b = f32[32,32] parameter(1)
+    c = f32[32,32] parameter(2)
+    add = f32[32,32] add(a, b), metadata={op_type="add", op_name="my_add", source_file="my_file.cc", source_line=123}
+    large_constant = f32[16]{0} constant({42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42})
+    async_start = ((f32[32,32], f32[32,32]), f32[32,32]) async-start(add, c), calls=async_computation
+    async_done = f32[32,32] async-done(async_start)
+    ROOT result = tuple(async_done, large_constant)
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnUnverifiedModule(hlo));
+  DebugOptions& db_options = module->mutable_config().mutable_debug_options();
+  // Setting non-default values for these w.r.t the PrintOptions class.
+  db_options.set_xla_dump_large_constants(true);
+  db_options.set_xla_dump_disable_metadata(true);
+  db_options.set_xla_syntax_sugar_async_ops(false);
+  TF_ASSERT_OK_AND_ASSIGN(bool filecheck_matched,
+                          RunFileCheck(module->ToString(), R"(
+    // CHECK:     {{.+}} = f32[32,32]{1,0} add({{.+}}){{$}}
+    // CHECK-NOT: subtract-start
+    // CHECK-DAG: {{.+}} = f32[16]{0} constant({42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42})
+    // CHECK-DAG: {{.+}} = ((f32[32,32]{1,0}, f32[32,32]{1,0}), f32[32,32]{1,0}) async-start({{.+}})
+    // CHECK-NOT: subtract-done
+  )"));
+  EXPECT_TRUE(filecheck_matched);
 }
 
 }  // namespace

--- a/xla/hlo/tools/tests/convert_to_text.hlo
+++ b/xla/hlo/tools/tests/convert_to_text.hlo
@@ -3,7 +3,7 @@
 
 // CHECK: ENTRY
 // CHECK-SAME: mod1
-// CHECK-SAME: s8
+// CHECK-NEXT: ROOT {{.*}} = s8[] constant(0)
 
 mod1 {
   a = s8[] constant(0)

--- a/xla/service/gpu/tests/dot_bf16.hlo
+++ b/xla/service/gpu/tests/dot_bf16.hlo
@@ -1,6 +1,6 @@
-// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/v100.txtpb --split-input-file | FileCheck %s --check-prefixes=CHECK-SM70 %}
-// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/a100_pcie_80.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
-// RUN: %if IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/mi200.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
+// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_dump_hlo_as_long_text --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/v100.txtpb --split-input-file | FileCheck %s --check-prefixes=CHECK-SM70 %}
+// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_dump_hlo_as_long_text --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/a100_pcie_80.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
+// RUN: %if IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_dump_hlo_as_long_text --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/mi200.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
 
 
 // CHECK-SM70: custom-call(f32

--- a/xla/service/gpu/tests/dot_bf16.hlo
+++ b/xla/service/gpu/tests/dot_bf16.hlo
@@ -1,6 +1,6 @@
-// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_dump_hlo_as_long_text --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/v100.txtpb --split-input-file | FileCheck %s --check-prefixes=CHECK-SM70 %}
-// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_dump_hlo_as_long_text --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/a100_pcie_80.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
-// RUN: %if IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_dump_hlo_as_long_text --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/mi200.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
+// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/v100.txtpb --split-input-file | FileCheck %s --check-prefixes=CHECK-SM70 %}
+// RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/a100_pcie_80.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
+// RUN: %if IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/mi200.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
 
 
 // CHECK-SM70: custom-call(f32

--- a/xla/service/hlo_instruction_test.cc
+++ b/xla/service/hlo_instruction_test.cc
@@ -2023,6 +2023,9 @@ ENTRY %Entry (p0: f32[10]) -> f32[20] {
 }
 
 )";
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_syntax_sugar_async_ops(true);
   EXPECT_EQ(module->ToString(), expected_with_syntax_sugar);
   const std::string expected_without_syntax_sugar =
       R"(HloModule StringifyAsyncOps, entry_computation_layout={(f32[10]{0})->f32[20]{0}}
@@ -2109,6 +2112,9 @@ ENTRY %Entry (pentry: f32[20]) -> f32[10] {
 }
 
 )";
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_syntax_sugar_async_ops(true);
   EXPECT_EQ(module->ToString(), expected_with_syntax_sugar);
 
   const std::string expected_without_syntax_sugar =


### PR DESCRIPTION
The tool `hlo-opt` was not honoring the debug options within the HloModule while printing the HloModule.

These options should be honored by the default printing of the HloModule as they are a part of the same HloModule. Fixed the print method to do this. This should now be reflected in all the tools using these debug options.