### PR TITLE
Changing the default value of the flag xla_dump_hlo_as_long_text

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -76,7 +76,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_dump_include_timestamp(false);
   opts.set_xla_dump_max_hlo_modules(-1);
   opts.set_xla_dump_module_metadata(false);
-  opts.set_xla_dump_hlo_as_long_text(false);
+  opts.set_xla_dump_hlo_as_long_text(true);
   opts.set_xla_dump_large_constants(false);
   opts.set_xla_dump_enable_mlir_pretty_form(true);
   opts.set_xla_gpu_unsupported_annotate_with_emitter_loc(false);


### PR DESCRIPTION
This stems from the difference in HLO dumps from tools like hlo-opt, multihost_hlo_runner, and hlo_runner_main. Although the options related to printing HLO are tied to the HLO via DebugOptions, these tools have different behaviors because the tool hlo-opt uses `ToString()` function from `HloModule` while `functional_hlo_runner` uses a separate dumping utility from `xla/service/dump.cc`. To standardize this behavior, we first are making the default behavior uniform by setting the default value of long text HLO dumps to be true. This ensures that the HLO dumps will be functional by default (for example, backend_config will be printed).