### PR TITLE
Increase the default thread stack size to 8MB

### DIFF
--- a/xla/backends/cpu/nanort/nanort_client.cc
+++ b/xla/backends/cpu/nanort/nanort_client.cc
@@ -45,7 +45,7 @@ using ::tsl::profiler::TraceMeEncode;
 
 NanoRtClient::NanoRtClient()
     : intra_op_thread_pool_(
-          new tsl::thread::ThreadPool(tsl::Env::Default(), tsl::ThreadOptions(),
+          new tsl::thread::ThreadPool(tsl::Env::Default(),
                                       "nanort", DefaultThreadPoolSize())) {}
 
 absl::StatusOr<std::unique_ptr<NanoRtExecutable>> NanoRtClient::Compile(

--- a/xla/backends/cpu/nanort/nanort_client.cc
+++ b/xla/backends/cpu/nanort/nanort_client.cc
@@ -44,9 +44,8 @@ using ::tsl::profiler::TraceMe;
 using ::tsl::profiler::TraceMeEncode;
 
 NanoRtClient::NanoRtClient()
-    : intra_op_thread_pool_(
-          new tsl::thread::ThreadPool(tsl::Env::Default(),
-                                      "nanort", DefaultThreadPoolSize())) {}
+    : intra_op_thread_pool_(new tsl::thread::ThreadPool(
+          tsl::Env::Default(), "nanort", DefaultThreadPoolSize())) {}
 
 absl::StatusOr<std::unique_ptr<NanoRtExecutable>> NanoRtClient::Compile(
     const XlaComputation& computation) {

--- a/xla/pjrt/cpu/cpu_client.cc
+++ b/xla/pjrt/cpu/cpu_client.cc
@@ -335,9 +335,8 @@ TfrtCpuClient::TfrtCpuClient(
       eigen_intraop_device_(
           new Eigen::ThreadPoolDevice(eigen_intraop_pool_->AsEigenThreadPool(),
                                       eigen_intraop_pool_->NumThreads())),
-      pjrt_client_thread_pool_(
-          new tsl::thread::ThreadPool(tsl::Env::Default(),
-                                      "XLATfrtCpuClient", num_threads)),
+      pjrt_client_thread_pool_(new tsl::thread::ThreadPool(
+          tsl::Env::Default(), "XLATfrtCpuClient", num_threads)),
       async_work_runner_(std::make_unique<ThreadPoolAsyncWorkRunner>(
           pjrt_client_thread_pool_.get())),
       last_collective_launch_event_(

--- a/xla/python/ifrt/ir/transforms/multi_threaded_atom_program_compiler.cc
+++ b/xla/python/ifrt/ir/transforms/multi_threaded_atom_program_compiler.cc
@@ -66,7 +66,6 @@ tsl::thread::ThreadPool* thread_pool() {
   static tsl::thread::ThreadPool* thread_pool = []() {
     constexpr int kMaxParallelism = 32;
     return new tsl::thread::ThreadPool(tsl::Env::Default(),
-                                       tsl::ThreadOptions(),
                                        "CompileAtomPrograms", kMaxParallelism);
   }();
   return thread_pool;

--- a/xla/python/ifrt_proxy/client/executable.cc
+++ b/xla/python/ifrt_proxy/client/executable.cc
@@ -608,17 +608,6 @@ absl::Span<xla::ifrt::Device* const> LoadedExecutable::addressable_devices()
   return addressable_devices_;
 }
 
-namespace {
-
-static tsl::ThreadOptions GetThreadOptions() {
-  tsl::ThreadOptions thread_options;
-  // Ensure the threads' stack is large enough for arbitrary Python code.
-  thread_options.stack_size = 2 * 1024 * 1024;  // 2 MiB
-  return thread_options;
-}
-
-}  // namespace
-
 void LoadedExecutable::PollLoadedHostCallback(
     uint64_t handle,
     tsl::RCReference<xla::ifrt::LoadedHostCallback> loaded_host_callback) {
@@ -674,7 +663,7 @@ void LoadedExecutable::PollLoadedHostCallback(
   };
 
   static auto* global_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), GetThreadOptions(), "XLAIFRTProxy",
+      tsl::Env::Default(), "XLAIFRTProxy",
       std::min(16, tsl::port::MaxParallelism()));
   global_pool->Schedule(std::move(f));
 }

--- a/xla/python/ifrt_proxy/client/executable.cc
+++ b/xla/python/ifrt_proxy/client/executable.cc
@@ -662,9 +662,9 @@ void LoadedExecutable::PollLoadedHostCallback(
     }
   };
 
-  static auto* global_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), "XLAIFRTProxy",
-      std::min(16, tsl::port::MaxParallelism()));
+  static auto* global_pool =
+      new tsl::thread::ThreadPool(tsl::Env::Default(), "XLAIFRTProxy",
+                                  std::min(16, tsl::port::MaxParallelism()));
   global_pool->Schedule(std::move(f));
 }
 

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -250,7 +250,8 @@ static tsl::thread::ThreadPool* GetCompilationThreadPool() {
   // to be enough to achieve maximum parallel compilation speedup.
   static constexpr int kMaxCompilationThreads = 32;
   static auto* thread_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), "xla-cpu-llvm-codegen",
+      tsl::Env::Default(),
+      "xla-cpu-llvm-codegen",
       std::min(kMaxCompilationThreads, tsl::port::MaxParallelism()));
   return thread_pool;
 }

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -250,8 +250,7 @@ static tsl::thread::ThreadPool* GetCompilationThreadPool() {
   // to be enough to achieve maximum parallel compilation speedup.
   static constexpr int kMaxCompilationThreads = 32;
   static auto* thread_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(),
-      "xla-cpu-llvm-codegen",
+      tsl::Env::Default(), "xla-cpu-llvm-codegen",
       std::min(kMaxCompilationThreads, tsl::port::MaxParallelism()));
   return thread_pool;
 }

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -112,7 +112,7 @@ bool ShouldLaunchDelayKernel() {
 // and wait for completion.
 tsl::thread::ThreadPool* GetDriverExecutor() {
   static tsl::thread::ThreadPool* thread_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), tsl::ThreadOptions(), "cuda_driver", 1);
+      tsl::Env::Default(), "cuda_driver", 1);
   return thread_pool;
 }
 

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -111,8 +111,8 @@ bool ShouldLaunchDelayKernel() {
 // thread::ThreadPool on some platforms), we run certain routines in this pool
 // and wait for completion.
 tsl::thread::ThreadPool* GetDriverExecutor() {
-  static tsl::thread::ThreadPool* thread_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), "cuda_driver", 1);
+  static tsl::thread::ThreadPool* thread_pool =
+      new tsl::thread::ThreadPool(tsl::Env::Default(), "cuda_driver", 1);
   return thread_pool;
 }
 

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -132,7 +132,7 @@ int fpus_per_core(std::string gcn_arch_name) {
 // and wait for completion.
 tsl::thread::ThreadPool* GetDriverExecutor() {
   static tsl::thread::ThreadPool* thread_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), tsl::ThreadOptions(), "rocm_driver", 1);
+      tsl::Env::Default(), "rocm_driver", 1);
   return thread_pool;
 }
 

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -131,8 +131,8 @@ int fpus_per_core(std::string gcn_arch_name) {
 // thread::ThreadPool on some platforms), we run certain routines in this pool
 // and wait for completion.
 tsl::thread::ThreadPool* GetDriverExecutor() {
-  static tsl::thread::ThreadPool* thread_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), "rocm_driver", 1);
+  static tsl::thread::ThreadPool* thread_pool =
+      new tsl::thread::ThreadPool(tsl::Env::Default(), "rocm_driver", 1);
   return thread_pool;
 }
 

--- a/xla/tsl/platform/env.h
+++ b/xla/tsl/platform/env.h
@@ -624,7 +624,11 @@ int unsetenv(const char* name);
 /// underlying implementation may choose to ignore it.
 struct ThreadOptions {
   /// Thread stack size to use (in bytes).
-  size_t stack_size = 0;  // 0: use system default value
+  // On Mac OS the default stack size is 512KiB, which is too small for some
+  // BLAS and LAPACK functions (https://github.com/google/jax/issues/20428).
+  // On Linux we also observed that 2MB wasn't enough to run some OpenBLAS
+  // functions.
+  size_t stack_size = 8 * 1024 * 1024;  // 8 MB
   /// Guard area size to use near thread stacks to use (in bytes)
   size_t guard_size = 0;  // 0: use system default value
   int numa_node = port::kNUMANoAffinity;


### PR DESCRIPTION
**CAUTION**: This PR proposes changing the default thread stack size for spawned threads using `tsl::thread::ThreadPool`. I do not have the prerequisites to evaluate if this is likely to cause problems for others.

When JIT compiling modules using a process runner, the default stack size on OS X is too low. Fx [this StableHLO module](https://gist.github.com/kasper0406/6e73ebd7c2e2475c69d4043d8c9e7465) will fail to compile with a stack overflow error using this command:
```
bazel run --spawn_strategy=sandboxed //xla/tools:run_hlo_module -- --platform=CPU --input_format=stablehlo stack_overflow.mlir
```

Looking through the codebase, this looks to be a common theme when using `tsl::thread::ThreadPool`, which currently uses the OS default stack size when spinning up threads.

This PR proposes using 8MB as the default thread stack size no matter the platform used.

A less invasive alternative, is to increase the thread stack size for just the compilation thread pool. Given this adjustment has had to be put in place in multiple areas, suggests that the default value is not great.