### PR TITLE
Increase the compilation thread stack size to 4MB

### DIFF
--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -249,8 +249,14 @@ static tsl::thread::ThreadPool* GetCompilationThreadPool() {
   // so much CPU-bound work. Based on profiling a few examples, 32 threads seems
   // to be enough to achieve maximum parallel compilation speedup.
   static constexpr int kMaxCompilationThreads = 32;
+
+  // On Mac OS the default stack size is 512KiB, this is too small for compiling
+  // reasonably sized programs
+  tsl::ThreadOptions thread_options;
+  thread_options.stack_size = 4 * 1024 * 1024;  // 4 MB
+
   static auto* thread_pool = new tsl::thread::ThreadPool(
-      tsl::Env::Default(), "xla-cpu-llvm-codegen",
+      tsl::Env::Default(), thread_options, "xla-cpu-llvm-codegen",
       std::min(kMaxCompilationThreads, tsl::port::MaxParallelism()));
   return thread_pool;
 }


### PR DESCRIPTION
When JIT compiling modules using a process runner, the default stack size on OS X is too low. Fx [this StableHLO module](https://gist.github.com/kasper0406/6e73ebd7c2e2475c69d4043d8c9e7465) will fail to compile with a stack overflow error using this command:
```
bazel run --spawn_strategy=sandboxed //xla/tools:run_hlo_module -- --platform=CPU --input_format=stablehlo stack_overflow.mlir
```

This PR will increase the thread stack size for the compilation thread pool to 4MB per thread.
