### PR TITLE
Fix kernel_thunk_test compilation error

### DIFF
--- a/xla/backends/cpu/runtime/kernel_thunk_test.cc
+++ b/xla/backends/cpu/runtime/kernel_thunk_test.cc
@@ -97,9 +97,9 @@ TEST(KernelThunkTest, AddF32Inline) {
   BufferAllocation::Slice slice = CreateBufferAllocationSlice(alloc);
 
   TF_ASSERT_OK_AND_ASSIGN(
-      auto thunk,
-      KernelThunk::Create({"add_f32"}, {slice}, {slice}, "add_f32",
-                          se::ThreadDim(4), /*invariant_arguments=*/{{}}));
+      auto thunk, KernelThunk::Create({"add_f32"}, {slice}, {slice}, "add_f32",
+                                      se::ThreadDim(4),
+                                      /*invariant_arguments=*/std::nullopt));
 
   AddF32HostKernel host_kernels;
   Thunk::ExecuteParams params = {&host_kernels, &allocations};
@@ -126,9 +126,9 @@ TEST(KernelThunkInvariantBuffersTest, MissingBufferSlice) {
 
   // Invariant buffer set is incorrect - should include in_slice, but is empty.
   TF_ASSERT_OK_AND_ASSIGN(
-      auto thunk,
-      KernelThunk::Create({"add_f32"}, {in_slice}, {out_slice}, "add_f32",
-                          se::ThreadDim(4), /*invariant_arguments=*/{{}}));
+      auto thunk, KernelThunk::Create({"add_f32"}, {in_slice}, {out_slice},
+                                      "add_f32", se::ThreadDim(4),
+                                      /*invariant_arguments=*/std::nullopt));
 
   AddF32HostKernel host_kernels;
   Thunk::ExecuteParams params = {&host_kernels, &allocations};


### PR DESCRIPTION
### Description

GCC 13 compilation error (Ubuntu 24.04)
```
Error:
kernel_thunk_test.cc:101:26: error: converting to 'std::optional<absl::lts_20230802::flat_hash_set<long int> >' from initializer list would use explicit constructor 'constexpr std::optional<_Tp>::optional(std::in_place_t, _Args&& ...) [with _Args = {}; typename std::enable_if<__and_v<std::is_constructible<_Tp, _Args ...> >, bool>::type <anonymous> = false; _Tp = absl::lts_20230802::flat_hash_set<long int>]'
  101 |       KernelThunk::Create({"add_f32"}, {slice}, {slice}, "add_f32",
      |       ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  102 |                           se::ThreadDim(4), /*invariant_arguments=*/{{}}));
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The compilation error occurs because {} (invariant_arguments) is being used to initialize `std::optional<absl::flat_hash_set<int64_t>>`, but `std::optional` has an explicit constructor that takes an `in_place_t` argument, which prevents `{}` from being implicitly converted.

I think we can use `std::nullopt` here instead of `{{}}`


### Testing
```
//xla/backends/cpu/runtime:kernel_thunk_test                             PASSED in 0.0s
```