### PR TITLE
Implement GetCompiledMemoryStats for GPU AOT executables

### DIFF
--- a/xla/pjrt/BUILD
+++ b/xla/pjrt/BUILD
@@ -550,6 +550,7 @@ cc_library(
         "//xla/hlo/ir:hlo",
         "//xla/service:compiler",
         "//xla/service:executable",
+        "//xla/service:hlo_proto_util",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log:check",

--- a/xla/service/compiler.h
+++ b/xla/service/compiler.h
@@ -77,6 +77,11 @@ class AotCompilationResult {
     return Unimplemented("LoadExecutable unimplemented.");
   }
 
+  virtual absl::StatusOr<std::unique_ptr<BufferAssignment>> buffer_assignment()
+      const {
+    return Unimplemented("buffer_assignment unimplemented.");
+  }
+
   // Returns the optimized HLO module if one was computed and the implementation
   // supports it.
   virtual const HloModule* optimized_module() const = 0;

--- a/xla/service/gpu/gpu_compiler.h
+++ b/xla/service/gpu/gpu_compiler.h
@@ -89,10 +89,6 @@ class GpuCompiler : public LLVMCompiler {
   absl::StatusOr<std::unique_ptr<AotCompilationResult>>
   LoadAotCompilationResult(const std::string& serialized_aot_result) override;
 
-  // Stateless version of the same function.
-  static absl::StatusOr<std::unique_ptr<AotCompilationResult>>
-  LoadAotCompilationResultStatic(const std::string& serialized_aot_result);
-
   absl::StatusOr<std::unique_ptr<AotCompilationResult>> Export(
       Executable* executable) const override;
 


### PR DESCRIPTION
This implements `GetCompiledMemoryStats` for ahead-of-time compiled executables. With this patch,
one can estimate memory consumption of a JAX function even without access to a GPU.

Unfortunately, the patch duplicates code between unloaded and loaded GPU executables
and between `GpuThunkAotCompilationResult::GetBufferAssignment()`  and `Compiler::BufferSizeBytesFunction()`+`GpuCompiler::ShapeSizeBytesFunction()`.
This could be perhaps improved by exposing the relevant compiler code as static methods,
but that does not seem worth the extra complexity.

The patch also threads `pointer_size` from `GpuCompiler` to `GpuThunkAotCompilationResult` so that we can
get buffer allocation sizes without direct access to the compiler. Another option would be embedding
`pointer_size` within `CompilationResultProto`.

Also note that this still does not set `generated_code_size_in_bytes` correctly - that would require
duplicating some code from `GpuExecutable::SizeOfGeneratedCodeInBytes()`.