### PR TITLE
[ds-fusion] Enable GpuReduceScatterCombiner before ds-fusion

### DIFF
--- a/xla/backends/gpu/codegen/dynamic_slice_fusion_test.cc
+++ b/xla/backends/gpu/codegen/dynamic_slice_fusion_test.cc
@@ -3632,7 +3632,8 @@ TEST_F(DynamicSliceFusionTest, MultipleOffsetsAsFunctionOfInductionVariable) {
       /*run_hlo_passes=*/false, /*use_threads=*/true, std::nullopt));
 }
 
-TEST_F(DynamicSliceFusionTest, ReduceScatterDynamicSliceMultipleBuffers) {
+TEST_F(DynamicSliceFusionTest,
+       ReduceScatterDynamicSliceMultipleBuffersShouldFuseAndExecuteCorrectly) {
   const char* hlo = R"(
     HloModule test, replica_count=2
     add {
@@ -3697,10 +3698,9 @@ TEST_F(DynamicSliceFusionTest, ReduceScatterDynamicSliceMultipleBuffers) {
       GetDynamicSliceFusions(*m);
   ASSERT_EQ(unfused_dynamic_slice_fusions.size(), 0);
 
-  ErrorSpec error_spec = ErrorSpec(1e-6, 1e-6);
   EXPECT_TRUE(RunAndCompareTwoModulesReplicated(
       std::move(m_fused), std::move(m),
-      /*run_hlo_passes=*/false, /*use_threads=*/true, error_spec));
+      /*run_hlo_passes=*/false, /*use_threads=*/true, std::nullopt));
 }
 
 }  // namespace

--- a/xla/backends/gpu/codegen/dynamic_slice_fusion_test.cc
+++ b/xla/backends/gpu/codegen/dynamic_slice_fusion_test.cc
@@ -3632,6 +3632,77 @@ TEST_F(DynamicSliceFusionTest, MultipleOffsetsAsFunctionOfInductionVariable) {
       /*run_hlo_passes=*/false, /*use_threads=*/true, std::nullopt));
 }
 
+TEST_F(DynamicSliceFusionTest, ReduceScatterDynamicSliceMultipleBuffers) {
+  const char* hlo = R"(
+    HloModule test, replica_count=2
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+    body {
+      param.1 = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) parameter(0)
+      iter.1 = s32[] get-tuple-element(param.1), index=0
+      c1 = s32[] constant(1)
+      c0 = s32[] constant(0)
+      src1 = s32[8,8,8] get-tuple-element(param.1), index=1
+      src2 = s32[8,8,8] get-tuple-element(param.1), index=2
+      dst1 = s32[8,4,8] get-tuple-element(param.1), index=3
+      dst2 = s32[8,4,8] get-tuple-element(param.1), index=4
+      ds1 = s32[1,8,8]{2,1,0} dynamic-slice(src1, iter.1, c0, c0), dynamic_slice_sizes={1,8,8}
+      ds2 = s32[1,8,8]{2,1,0} dynamic-slice(src2, iter.1, c0, c0), dynamic_slice_sizes={1,8,8}
+      rs1 = s32[8,8] reshape(ds1)
+      rs2 = s32[8,8] reshape(ds2)
+      rs = (s32[4,8], s32[4,8]) reduce-scatter(rs1, rs2), dimensions={0}, replica_groups={{0,1}}, to_apply=add
+      reduce-scatter1 = s32[4,8] get-tuple-element(rs), index=0
+      reduce-scatter2 = s32[4,8] get-tuple-element(rs), index=1
+      reshape1 = s32[1,4,8] reshape(reduce-scatter1)
+      reshape2 = s32[1,4,8] reshape(reduce-scatter2)
+      dus1 = s32[8,4,8] dynamic-update-slice(dst1, reshape1, iter.1, c0, c0)
+      dus2 = s32[8,4,8] dynamic-update-slice(dst2, reshape2, iter.1, c0, c0)
+      add = s32[] add(iter.1, c1)
+      ROOT tuple = tuple(add, src1, src2, dus1, dus2)
+    }
+    condition {
+      param.2 = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) parameter(0)
+      iter.2 = s32[] get-tuple-element(param.2), index=0
+      c8 = s32[] constant(8)
+      ROOT compare = pred[] compare(iter.2, c8), direction=LT
+    }
+    ENTRY main {
+      c0 = s32[] constant(0)
+      p1 = s32[8,8,8] parameter(0)
+      p2 = s32[8,8,8] parameter(1)
+      p3 = s32[8,4,8] parameter(2)
+      p4 = s32[8,4,8] parameter(3)
+      tuple = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) tuple(c0, p1, p2, p3, p4)
+      ROOT while = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) while(tuple), body=body, condition=condition
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
+                          ParseAndReturnVerifiedModule(hlo));
+  std::unique_ptr<HloModule> m_fused = m->Clone();
+  m_fused->mutable_config()
+      .mutable_debug_options()
+      .set_xla_gpu_enable_dynamic_slice_fusion(true);
+  TF_ASSERT_OK_AND_ASSIGN(m_fused, GetOptimizedModule(std::move(m_fused)));
+  TF_ASSERT_OK_AND_ASSIGN(m, GetOptimizedModule(std::move(m)));
+
+  // Check that the fused module has a dynamic address computation.
+  std::vector<HloComputation*> fused_dynamic_slice_fusions =
+      GetDynamicSliceFusions(*m_fused);
+  ASSERT_EQ(fused_dynamic_slice_fusions.size(), 1);
+  // Check that the unfused module does not have a dynamic address computation.
+  std::vector<HloComputation*> unfused_dynamic_slice_fusions =
+      GetDynamicSliceFusions(*m);
+  ASSERT_EQ(unfused_dynamic_slice_fusions.size(), 0);
+
+  ErrorSpec error_spec = ErrorSpec(1e-6, 1e-6);
+  EXPECT_TRUE(RunAndCompareTwoModulesReplicated(
+      std::move(m_fused), std::move(m),
+      /*run_hlo_passes=*/false, /*use_threads=*/true, error_spec));
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1098,7 +1098,7 @@ void AddDoubleBufferingPasses(const HloModule& module,
 
 absl::Status RunPostFusionPasses(
     HloModule* hlo_module, const se::DeviceDescription& device_description,
-    int pointer_size) {
+    int pointer_size, const int combine_threshold_count) {
   const DebugOptions& opts = hlo_module->config().debug_options();
 
   HloPassPipeline pipeline("post-fusion optimization");
@@ -1108,19 +1108,19 @@ absl::Status RunPostFusionPasses(
       /*default_combine_threshold_in_bytes=*/kDefaultAllGatherCombineThreshold,
       /*combine_threshold_in_bytes=*/
       opts.xla_gpu_all_gather_combine_threshold_bytes(),
-      /*combine_threshold_count=*/256,
+      combine_threshold_count,
       /*combine_by_dim=*/opts.xla_gpu_enable_all_gather_combine_by_dim(),
       /*combine_different_dtypes=*/true, /*pointer_size=*/pointer_size);
   pipeline.AddPass<GpuAllReduceCombiner>(
       device_description, kDefaultAllReduceCombineThreshold,
       opts.xla_gpu_all_reduce_combine_threshold_bytes(),
-      /*combine_threshold_count=*/256, /*pointer_size=*/pointer_size);
+      combine_threshold_count, /*pointer_size=*/pointer_size);
   pipeline.AddPass<GpuReduceScatterCombiner>(
       device_description, /*default_combine_threshold_in_bytes=*/
       kDefaultReduceScatterCombineThreshold,
       /*combine_threshold_in_bytes=*/
       opts.xla_gpu_reduce_scatter_combine_threshold_bytes(),
-      /*combine_threshold_count=*/256,
+      combine_threshold_count,
       /*combine_by_dim=*/opts.xla_gpu_enable_reduce_scatter_combine_by_dim(),
       /*pointer_size=*/pointer_size);
 
@@ -1241,14 +1241,23 @@ absl::Status RunAsyncDotPasses(HloModule* hlo_module) {
   return pipeline.Run(hlo_module).status();
 }
 
-absl::Status RunDynamicSliceFusionPasses(HloModule* hlo_module,
-                                         se::Platform::Id platform_id) {
-  if (hlo_module->config()
-          .debug_options()
-          .xla_gpu_enable_dynamic_slice_fusion()) {
+
+absl::Status RunDynamicSliceFusionPasses(
+    HloModule* hlo_module, se::Platform::Id platform_id,
+    const se::DeviceDescription& device_description, int64_t pointer_size, const int combine_threshold_count) {
+  const DebugOptions& opts = hlo_module->config().debug_options();
+  if (opts.xla_gpu_enable_dynamic_slice_fusion()) {
     HloPassPipeline pipeline("dynamic-slice");
     TF_ASSIGN_OR_RETURN(se::Platform * platform,
                         se::PlatformManager::PlatformWithId(platform_id));
+    pipeline.AddPass<GpuReduceScatterCombiner>(
+        device_description, /*default_combine_threshold_in_bytes=*/
+        kDefaultReduceScatterCombineThreshold,
+        /*combine_threshold_in_bytes=*/
+        opts.xla_gpu_reduce_scatter_combine_threshold_bytes(),
+        /*combine_threshold_count=*/combine_threshold_count,
+        /*combine_by_dim=*/opts.xla_gpu_enable_reduce_scatter_combine_by_dim(),
+        /*pointer_size=*/pointer_size);
     pipeline.AddPass<DynamicSliceFusionRewriter>(platform->Name());
     pipeline.AddPass<AsyncWrapper>([](const HloInstruction* instr) {
       if (!IsDynamicSliceFusion(instr)) {
@@ -1266,7 +1275,6 @@ absl::Status RunDynamicSliceFusionPasses(HloModule* hlo_module,
 
   return absl::OkStatus();
 }
-
 }  // namespace
 
 absl::Status GpuCompiler::RunCollectiveScheduleLinearizerPasses(
@@ -1333,15 +1341,20 @@ absl::Status GpuCompiler::OptimizeHloModule(
   TF_RETURN_IF_ERROR(OptimizeHloPostLayoutAssignment(
       hlo_module, stream_exec, options, gpu_target_config,
       thread_pool.get_mutable()));
+  
+  const int combine_threshold_count = 256;
 
   // This is a "low effort, high impact" fusion that should be run first.
-  TF_RETURN_IF_ERROR(RunDynamicSliceFusionPasses(hlo_module, PlatformId()));
+  TF_RETURN_IF_ERROR(RunDynamicSliceFusionPasses(
+      hlo_module, /*platform_id=*/PlatformId(),
+      /*device_description=*/gpu_target_config.device_description,
+      /*pointer_size=*/pointer_size_, combine_threshold_count));
 
   TF_RETURN_IF_ERROR(RunFusionPasses(hlo_module, gpu_target_config,
                                      thread_pool.get_mutable(),
                                      ShapeSizeBytesFunction()));
   TF_RETURN_IF_ERROR(
-      RunPostFusionPasses(hlo_module, device_description, pointer_size_));
+      RunPostFusionPasses(hlo_module, device_description, pointer_size_, combine_threshold_count));
   TF_RETURN_IF_ERROR(RunAsyncCollectivesConversionPasses(hlo_module));
   TF_RETURN_IF_ERROR(RunPostFusionSimplificationPasses(
       hlo_module, layout_insensitive_algsimp_opts, gpu_version,

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter.cc
@@ -533,8 +533,7 @@ absl::StatusOr<bool> DynamicSliceFusionRewriter::Run(
   for (HloComputation* computation : module->computations()) {
     if (computation->IsFusionComputation()) continue;
     for (HloInstruction* instr : computation->instructions()) {
-      if ((HloPredicateIsOp<HloOpcode::kReduceScatter>(instr) &&
-           instr->shape().IsArray()) ||
+      if ((HloPredicateIsOp<HloOpcode::kReduceScatter>(instr)) ||
           IsLegacyCublasMatmul(*instr) || IsCustomCall(instr, platform_name_)) {
         UseDefDataflowPaths sliced_operand_paths =
             GetSlicedOperandPaths(instr, call_graph.get());

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
@@ -2060,31 +2060,6 @@ TEST_F(DynamicSliceFusionRewriterTest, DUSSimpleGemmLaxScan) {
   RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"), expected);
 }
 
-// Remove this when tuple support is added to dynamic slice fusion
-TEST_F(DynamicSliceFusionRewriterTest, DUSReduceScatterTupleNoTransform) {
-  const char* hlo = R"(
-  HloModule test, replica_count=2
-
-  add {
-    param_0 = f16[] parameter(0)
-    param_1 = f16[] parameter(1)
-    ROOT add.1 = f16[] add(param_0, param_1)
-  }
-
-  ENTRY main.9 {
-    param_0 = f16[128,128]{1,0} parameter(0)
-    param_1 = f16[128,128]{1,0} parameter(1)
-    param_2 = f16[128,128]{1,0} parameter(2)
-    constant_20 = u32[] constant(20)
-    constant_0 = u32[] constant(0)
-    reduce-scatter = (f16[64,128]{1,0}, f16[64,128]{1,0}) reduce-scatter(param_0, param_2), channel_id=64, replica_groups={{0,1}}, use_global_device_ids=true, dimensions={0}, to_apply=add
-    rs1 = get-tuple-element(reduce-scatter), index=0
-    ROOT loop_dynamic_update_slice_fusion = f16[128,128]{1,0} dynamic-update-slice(param_1, rs1, constant_20, constant_0)
-  })";
-  RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"),
-                            std::nullopt);
-}
-
 TEST_F(DynamicSliceFusionRewriterTest, ReduceScatterSlice) {
   const char* hlo = R"(
   HloModule jit_slice, replica_count=2
@@ -2193,6 +2168,73 @@ TEST_F(DynamicSliceFusionRewriterTest,
     // CHECK: body
     // CHECK:   %[[fusion:.+]] = {{.+}} fusion({{.+}}), kind=kCustom, calls=%dynamic-slice-fusion,
     // CHECK-SAME:  "fusion_backend_config":{"kind":"__custom_fusion","custom_fusion_config":{"name":"dynamic_address_computation"
+  )");
+}
+
+TEST_F(DynamicSliceFusionRewriterTest,
+       ReduceScatterDynamicSliceMultipleBuffers) {
+  const char* hlo = R"(
+    HloModule test, replica_count=2
+    add {
+      a = s32[] parameter(0)
+      b = s32[] parameter(1)
+      ROOT add = s32[] add(a, b)
+    }
+    body {
+      param.1 = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) parameter(0)
+      iter.1 = s32[] get-tuple-element(param.1), index=0
+      c1 = s32[] constant(1)
+      c0 = s32[] constant(0)
+      src1 = s32[8,8,8] get-tuple-element(param.1), index=1
+      src2 = s32[8,8,8] get-tuple-element(param.1), index=2
+      dst1 = s32[8,4,8] get-tuple-element(param.1), index=3
+      dst2 = s32[8,4,8] get-tuple-element(param.1), index=4
+      ds1 = s32[1,8,8]{2,1,0} dynamic-slice(src1, iter.1, c0, c0), dynamic_slice_sizes={1,8,8}
+      ds2 = s32[1,8,8]{2,1,0} dynamic-slice(src2, iter.1, c0, c0), dynamic_slice_sizes={1,8,8}
+      rs1 = s32[8,8] bitcast(ds1)
+      rs2 = s32[8,8] bitcast(ds2)
+      rs = (s32[4,8], s32[4,8]) reduce-scatter(rs1, rs2), dimensions={0}, replica_groups={{0,1}}, to_apply=add
+      reduce-scatter1 = s32[4,8] get-tuple-element(rs), index=0
+      reduce-scatter2 = s32[4,8] get-tuple-element(rs), index=1
+      bitcast1 = s32[1,4,8] bitcast(reduce-scatter1)
+      bitcast2 = s32[1,4,8] bitcast(reduce-scatter2)
+      dus1 = s32[8,4,8] dynamic-update-slice(dst1, bitcast1, iter.1, c0, c0)
+      dus2 = s32[8,4,8] dynamic-update-slice(dst2, bitcast2, iter.1, c0, c0)
+      add = s32[] add(iter.1, c1)
+      ROOT tuple = tuple(add, src1, src2, dus1, dus2)
+    }
+    condition {
+      param.2 = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) parameter(0)
+      iter.2 = s32[] get-tuple-element(param.2), index=0
+      c8 = s32[] constant(8)
+      ROOT compare = pred[] compare(iter.2, c8), direction=LT
+    }
+    ENTRY main {
+      c0 = s32[] constant(0)
+      p1 = s32[8,8,8] parameter(0)
+      p2 = s32[8,8,8] parameter(1)
+      p3 = s32[8,4,8] parameter(2)
+      p4 = s32[8,4,8] parameter(3)
+      tuple = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) tuple(c0, p1, p2, p3, p4)
+      ROOT while = (s32[], s32[8,8,8], s32[8,8,8], s32[8,4,8], s32[8,4,8]) while(tuple), body=body, condition=condition
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"), R"(
+    // CHECK: dynamic-slice-fusion
+    // CHECK-DAG:   %[[ds1:.+]] = {{.+}} dynamic-slice({{.+}})
+    // CHECK-DAG:   %[[ds2:.+]] = {{.+}} dynamic-slice({{.+}})
+    // CHECK-DAG:   %[[bc1:.+]] = {{.+}} bitcast(%[[ds1]])
+    // CHECK-DAG:   %[[bc2:.+]] = {{.+}} bitcast(%[[ds2]])
+    // CHECK-DAG:   %[[rs:.+]] = {{.+}} reduce-scatter(%[[bc1]], %[[bc2]])
+    // CHECK-DAG:   %[[rs1:.+]] = {{.+}} get-tuple-element(%[[rs]]), index=0
+    // CHECK-DAG:   %[[rs2:.+]] = {{.+}} get-tuple-element(%[[rs]]), index=1
+    // CHECK-DAG:   %[[bc3:.+]] = {{.+}} bitcast(%[[rs1]])
+    // CHECK-DAG:   %[[bc4:.+]] = {{.+}} bitcast(%[[rs2]])
+    // CHECK-DAG:   %[[dus1:.+]] = {{.+}} dynamic-update-slice({{.+}}, %[[bc3]], {{.+}})
+    // CHECK-DAG:   %[[dus2:.+]] = {{.+}} dynamic-update-slice({{.+}}, %[[bc4]], {{.+}})
+
+    // CHECK: body
   )");
 }
 

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
@@ -2220,6 +2220,8 @@ TEST_F(DynamicSliceFusionRewriterTest,
     }
   )";
 
+  // Checking for 2 dynamic-slices, their uses in reduce-scatter and their
+  // update via dus inside the fusion.
   RunAndFilecheckHloRewrite(hlo, DynamicSliceFusionRewriter("gpu"), R"(
     // CHECK: dynamic-slice-fusion
     // CHECK-DAG:   %[[ds1:.+]] = {{.+}} dynamic-slice({{.+}})

--- a/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
+++ b/xla/service/gpu/transforms/dynamic_slice_fusion_rewriter_test.cc
@@ -2172,7 +2172,7 @@ TEST_F(DynamicSliceFusionRewriterTest,
 }
 
 TEST_F(DynamicSliceFusionRewriterTest,
-       ReduceScatterDynamicSliceMultipleBuffers) {
+       ReduceScatterDynamicSliceAndDUSMultipleBuffersGetsFused) {
   const char* hlo = R"(
     HloModule test, replica_count=2
     add {


### PR DESCRIPTION
This PR depends on #22799. This patch runs GpuReduceScatterCombiner before ds-fusion so that the overhead of multiple nccl thunks is avoided in `gpu_compiler`.