### PR TITLE
Fix ambiguous constructor call in SourceTargetPairs initialization

### DIFF
--- a/xla/service/collective_permute_cycle_test.cc
+++ b/xla/service/collective_permute_cycle_test.cc
@@ -127,7 +127,7 @@ TEST_F(CollectivePermuteUtilsTest, GetCycleType) {
   EXPECT_EQ(GetCycleType(fwd4_.cycle), CycleType::kForward);
   EXPECT_EQ(GetCycleType(bwd4_.cycle), CycleType::kBackward);
 
-  EXPECT_EQ(GetCycleType(SourceTargetPairs({{}})), CycleType::kNone);
+  EXPECT_EQ(GetCycleType(SourceTargetPairs()), CycleType::kNone);
   EXPECT_EQ(GetCycleType(SourceTargetPairs({{0, 0}})), CycleType::kNone);
   EXPECT_EQ(GetCycleType(SourceTargetPairs({{0, 1}})), CycleType::kNone);
   EXPECT_EQ(GetCycleType(SourceTargetPairs({{1, 0}})), CycleType::kNone);


### PR DESCRIPTION
### Description
Resolve a build failure (with GCC-11) in `collective_permute_cycle_test` caused by an ambiguous constructor call when initializing `SourceTargetPairs` with an empty list (`{{}}`).  

#### Issue  
When calling `SourceTargetPairs({{}})`, the compiler could not determine whether to use the `std::vector<std::pair<int64_t, int64_t>>` constructor or the default copy/move constructors, leading to an error:  
```
xla/service/collective_permute_cycle_test.cc:130:48: error: call of overloaded 'SourceTargetPairs(<brace-enclosed initializer list>)' is ambiguous
  130 |   EXPECT_EQ(GetCycleType(SourceTargetPairs({{}})), CycleType::kNone);
```

#### Solution
1. Explicitly define an `initializer_list` constructor for `SourceTargetPairs` to properly handle `{}` and `{{src, tgt}}` initializations.  
2. Update the test case to use default ctor `SourceTargetPairs()` instead of `SourceTargetPairs({{}})`, ensuring clarity and correctness.  

This fix ensures proper initialization and eliminates ambiguity

Tested with GCC-11