### PR TITLE
Document the `input_format` flag for the `run_hlo_module` CLI

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -23,15 +23,25 @@ with many other useful artifacts.
 
 The tool `run_hlo_module` operates on pre-optimization HLO, and by default
 bundles compilation, running and comparison with the reference interpreter
-implementation. For example, the usual invocation to run an input file
-`computation.hlo` on an NVIDIA GPU and to check it for correctness is:
+implementation. The tool can be used as follows:
 
-```
-$ run_hlo_module --platform=CUDA --reference_platform=Interpreter computation.hlo
+```bash
+$ run_hlo_module \
+    --input_format=[hlo|mhlo|pb|pbtxt|stablehlo] \
+    --platform=[CPU|CUDA|Interpreter] \
+    --reference_platform=[CPU|CUDA|Interpreter] \
+    path/to/[hlo|mhlo|pb|pbtxt|stablehlo]_module
 ```
 
-The `--input_format` flag can be used to specify the input type. For example, to
-run a StableHLO module specify `--input_format=stablehlo`.
+A typical usage employs the following flags:
+
+  * `--input_format=<string>` - The format (hlo, mhlo, pb, pbtxt, or
+stablehlo) of the input file.
+  * `--platform=<string>` - The test platform that the input module will be
+executed on (gpu, cpu, etc).
+  * `--reference_platform=<string>` - The reference platform to execute the
+input module on. The result will be compared against the result from the
+test platform. Omitting the flag disables execution on a reference platform.
 
 As with all the tools, `--help` can be used to obtain the full list of options.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -30,6 +30,9 @@ implementation. For example, the usual invocation to run an input file
 $ run_hlo_module --platform=CUDA --reference_platform=Interpreter computation.hlo
 ```
 
+The `--input_format` flag can be used to specify the input type. For example, to
+run a StableHLO module specify `--input_format=stablehlo`.
+
 As with all the tools, `--help` can be used to obtain the full list of options.
 
 ## Running HLO snippets with SPMD support: `multihost_hlo_runner`

--- a/xla/tools/run_hlo_module_main.cc
+++ b/xla/tools/run_hlo_module_main.cc
@@ -297,6 +297,9 @@ int main(int argc, char** argv) {
       } else {
         failure_count++;
         std::cerr << result << "\n";
+        if (result.code() == absl::StatusCode::kInvalidArgument) {
+          std::cerr << "Did you forget to specify the `--input_format` flag?" << "\n";
+        }
       }
     }
 

--- a/xla/tools/run_hlo_module_main.cc
+++ b/xla/tools/run_hlo_module_main.cc
@@ -298,7 +298,7 @@ int main(int argc, char** argv) {
         failure_count++;
         std::cerr << result << "\n";
         if (result.code() == absl::StatusCode::kInvalidArgument) {
-          std::cerr << "Did you forget to specify the `--input_format` flag?" << "\n";
+          std::cerr << "Did you forget to specify the `--input_format` flag in case of StableHLO?" << "\n";
         }
       }
     }


### PR DESCRIPTION
I spent too much time figuring out how to run a StableHLO module. It would be helpful to have this information visible in the docs.

Today, if a StableHLO module is supplied, it errors the following way:
```
➜  xla git:(kn/docs-improvement) ✗ bazel run --spawn_strategy=sandboxed //xla/tools:run_hlo_module -- --platform=CPU /Volumes/git/xla-debug/error_module.mlir

 ** Running /Volumes/git/xla-debug/error_module.mlir**
INVALID_ARGUMENT: Invalid format from file extension: 'mlir'. Expected: hlo, txt, pb, or pbtxt
```

This had me confused for a while, thinking that StableHLO was not supported (enforced because I knew there is a special cli for `hlo-opt` in `//xla/mlir_hlo:mlir-hlo-opt` which works for StableHLO).

Ideally, the CLI would automatically figure out what the input type is, but this is not an easy change with the current structure of the code.
The new output of the CLI is as follows:
```
➜  xla git:(kn/docs-improvement) ✗ bazel run --spawn_strategy=sandboxed //xla/tools:run_hlo_module -- --platform=CPU /Volumes/git/xla-debug/error_module.mlir

 ** Running /Volumes/git/xla-debug/error_module.mlir**
INVALID_ARGUMENT: Invalid format from file extension: 'mlir'. Expected: hlo, txt, pb, or pbtxt
Did you forget to specify the `--input_format` flag in case of StableHLO?
```


I dont' like the way I check for the invalid argument status. If you have a better idea, let me know.