### PR TITLE
Add GCC Version Detection and Enforce XNNPACK Compatibility Flags

### DIFF
--- a/build_tools/configure/configure.py
+++ b/build_tools/configure/configure.py
@@ -139,6 +139,29 @@ def _get_clang_major_version(path_to_clang: str) -> int:
   return major_version
 
 
+def _get_gcc_major_version(path_to_gcc: str) -> int:
+  """Gets the major version of the gcc at `path_to_gcc`.
+
+  Args:
+    path_to_gcc: Path to a gcc executable
+
+  Returns:
+    The major version.
+  """
+  logging.info("Running echo __GNUC__ | %s -E -P -", path_to_gcc)
+  gcc_version_proc = subprocess.run(
+    [path_to_gcc, "-E", "-P", "-"],
+    input="__GNUC__",
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  major_version = int(gcc_version_proc.stdout)
+  logging.info("%s reports major version %s.", path_to_gcc, major_version)
+
+  return major_version
+
+
 class ArgparseableEnum(enum.Enum):
   """Enum base class with helper methods for working with argparse.
 
@@ -212,6 +235,7 @@ class DiscoverablePathsAndVersions:
   clang_path: Optional[str] = None
   clang_major_version: Optional[int] = None
   gcc_path: Optional[str] = None
+  gcc_major_version: Optional[int] = None
   lld_path: Optional[str] = None
   ld_library_path: Optional[str] = None
 
@@ -246,6 +270,9 @@ class DiscoverablePathsAndVersions:
       self.lld_path = self.lld_path or shutil.which("ld.lld")
     elif config.host_compiler == HostCompiler.GCC:
       self.gcc_path = _find_executable_or_die("gcc", self.gcc_path)
+      self.gcc_major_version = (
+          self.gcc_major_version or _get_gcc_major_version(self.gcc_path)
+      )
 
     if config.backend == Backend.CUDA:
       if config.cuda_compiler == CudaCompiler.CLANG:
@@ -388,6 +415,18 @@ class XLAConfigOptions:
     if dpav.clang_major_version in (16, 17, 18):
       self.compiler_options.append("-Wno-gnu-offsetof-extensions")
 
+    # Avoid XNNPACK using `-mavxvnniint8` (needs clang-16+/gcc-13+)
+    if (
+      dpav.clang_major_version is not None and dpav.clang_major_version < 16
+    ) or (dpav.gcc_major_version is not None and dpav.gcc_major_version < 13):
+      rc.append("build --define=xnn_enable_avxvnniint8=false")
+
+    # Avoid XNNPACK using `-mavx512fp16` (needs clang-14+/gcc-12+).
+    if (
+      dpav.clang_major_version is not None and dpav.clang_major_version < 14
+    ) or (dpav.gcc_major_version is not None and dpav.gcc_major_version < 12):
+      rc.append("build --define=xnn_enable_avx512fp16=false")
+
     rc.append(f"build --action_env PYTHON_BIN_PATH={self.python_bin_path}")
     rc.append(f"build --python_path {self.python_bin_path}")
     rc.append("test --test_env LD_LIBRARY_PATH")
@@ -410,6 +449,7 @@ class XLAConfigOptions:
 
 def _parse_args():
   """Creates an argparse.ArgumentParser and parses arguments."""
+  # pylint: disable=C3001
   comma_separated_list = lambda l: [s.strip() for s in l.split(",")]
 
   parser = argparse.ArgumentParser(allow_abbrev=False)

--- a/build_tools/configure/testdata/gcc.bazelrc
+++ b/build_tools/configure/testdata/gcc.bazelrc
@@ -1,4 +1,6 @@
 build --action_env GCC_HOST_COMPILER_PATH=/usr/bin/gcc
+build --define=xnn_enable_avxvnniint8=false
+build --define=xnn_enable_avx512fp16=false
 build --action_env PYTHON_BIN_PATH=/usr/bin/python3
 build --python_path /usr/bin/python3
 test --test_env LD_LIBRARY_PATH

--- a/build_tools/configure/testdata/nvcc_gcc.bazelrc
+++ b/build_tools/configure/testdata/nvcc_gcc.bazelrc
@@ -5,6 +5,8 @@ build:cuda --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES=7.5
 build:cuda --repo_env HERMETIC_CUDNN_VERSION="8.6"
 build --config nonccl
 build --action_env LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+build --define=xnn_enable_avxvnniint8=false
+build --define=xnn_enable_avx512fp16=false
 build --action_env PYTHON_BIN_PATH=/usr/bin/python3
 build --python_path /usr/bin/python3
 test --test_env LD_LIBRARY_PATH


### PR DESCRIPTION
### Description:  
- Added `_get_gcc_major_version` function to `configure.py` to determine the major version of GCC.  
- Adjusted XNNPACK build flags dynamically based on detected Clang and GCC versions:  
  - Disabled `-mavxvnniint8` for Clang <16 and GCC <13.  
  - Disabled `-mavx512fp16` for Clang <14 and GCC <12.
- Updated testdata used by `//build_tools/configure:configure_test`
  - build_tools/configure/testdata/gcc.bazelrc
  - build_tools/configure/testdata/nvcc_gcc.bazelrc 

CI builds report the following gcc major version
```
XLA Linux x86 CPU - gcc-11
XLA Linux ARM64 CPU - gcc-9
```

This ensures proper compiler compatibility and avoids build issues with unsupported instruction sets.

### Next step - Improve CI Build by Generating XNN Options Dynamically

I suggest updating `build_tools/ci/build.py` to output the `python configure.py --platform ...` command, which will generate the `xla_configure.bazelrc` file with the correct XNN options based on the detected Clang/GCC version.

This would allow us to remove the hardcoded XNN options from `.bazelrc`, making the configuration more dynamic and maintainable.