### PR TITLE
Remove transpose from reshape builder

### DIFF
--- a/docs/operation_semantics.md
+++ b/docs/operation_semantics.md
@@ -2241,30 +2241,24 @@ and the [`Collapse`](#collapse) operation.
 
 Reshapes the dimensions of an array into a new configuration.
 
-<b> `Reshape(operand, new_sizes)` </b>
-<b> `Reshape(operand, dimensions, new_sizes)` </b>
+<b> `Reshape(operand, dimensions)` </b>
 
 Arguments    | Type           | Semantics
 ------------ | -------------- | ---------------------------------------
 `operand`    | `XlaOp`        | array of type T
-`dimensions` | `int64` vector | order in which dimensions are collapsed
-`new_sizes`  | `int64` vector | vector of sizes of new dimensions
+`dimensions` | `int64` vector | vector of sizes of new dimensions
 
 Conceptually, reshape first flattens an array into a one-dimensional vector of
 data values, and then refines this vector into a new shape. The input arguments
 are an arbitrary array of type T, a compile-time-constant vector of dimension
 indices, and a compile-time-constant vector of dimension sizes for the result.
-The values in the `dimension` vector, if given, must be a permutation of all of
-T's dimensions; the default if not given is `{0, ..., rank - 1}`. The order of
-the dimensions in `dimensions` is from slowest-varying dimension (most major) to
-fastest-varying dimension (most minor) in the loop nest which collapses the
-input array into a single dimension. The `new_sizes` vector determines the size
-of the output array. The value at index 0 in `new_sizes` is the size of
-dimension 0, the value at index 1 is the size of dimension 1, and so on. The
-product of the `new_size` dimensions must equal the product of the operand's
-dimension sizes. When refining the collapsed array into the multidimensional
-array defined by `new_sizes`, the dimensions in `new_sizes` are ordered from
-slowest varying (most major) and to fastest varying (most minor).
+The `dimensions` vector determines the size of the output array. The value at
+index 0 in `dimensions` is the size of dimension 0, the value at index 1 is the
+size of dimension 1, and so on. The product of the `dimensions` dimensions must
+equal the product of the operand's dimension sizes. When refining the collapsed
+array into the multidimensional array defined by `dimensions`, the dimensions
+in `dimensions` are ordered from slowest varying (most major) and to fastest
+varying (most minor).
 
 For example, let v be an array of 24 elements:
 
@@ -2274,44 +2268,23 @@ let v = f32[4x2x3] {{{10, 11, 12}, {15, 16, 17}},
                     {{30, 31, 32}, {35, 36, 37}},
                     {{40, 41, 42}, {45, 46, 47}}};
 
-In-order collapse:
-let v012_24 = Reshape(v, {0,1,2}, {24});
+let v012_24 = Reshape(v, {24});
 then v012_24 == f32[24] {10, 11, 12, 15, 16, 17, 20, 21, 22, 25, 26, 27,
                          30, 31, 32, 35, 36, 37, 40, 41, 42, 45, 46, 47};
 
-let v012_83 = Reshape(v, {0,1,2}, {8,3});
+let v012_83 = Reshape(v, {8,3});
 then v012_83 == f32[8x3] {{10, 11, 12}, {15, 16, 17},
                           {20, 21, 22}, {25, 26, 27},
                           {30, 31, 32}, {35, 36, 37},
                           {40, 41, 42}, {45, 46, 47}};
-
-Out-of-order collapse:
-let v021_24 = Reshape(v, {1,2,0}, {24});
-then v012_24 == f32[24]  {10, 20, 30, 40, 11, 21, 31, 41, 12, 22, 32, 42,
-                          15, 25, 35, 45, 16, 26, 36, 46, 17, 27, 37, 47};
-
-let v021_83 = Reshape(v, {1,2,0}, {8,3});
-then v021_83 == f32[8x3] {{10, 20, 30}, {40, 11, 21},
-                          {31, 41, 12}, {22, 32, 42},
-                          {15, 25, 35}, {45, 16, 26},
-                          {36, 46, 17}, {27, 37, 47}};
-
-
-let v021_262 = Reshape(v, {1,2,0}, {2,6,2});
-then v021_262 == f32[2x6x2] {{{10, 20}, {30, 40},
-                              {11, 21}, {31, 41},
-                              {12, 22}, {32, 42}},
-                             {{15, 25}, {35, 45},
-                              {16, 26}, {36, 46},
-                              {17, 27}, {37, 47}}};
 ```
 
 As a special case, reshape can transform a single-element array to a scalar and
 vice versa. For example,
 
 ```cpp
-Reshape(f32[1x1] {{5}}, {0,1}, {}) == 5;
-Reshape(5, {}, {1,1}) == f32[1x1] {{5}};
+Reshape(f32[1x1] {{5}}, {}) == 5;
+Reshape(5, {1,1}) == f32[1x1] {{5}};
 ```
 
 ## Rev (reverse)

--- a/xla/hlo/builder/xla_builder.h
+++ b/xla/hlo/builder/xla_builder.h
@@ -543,10 +543,6 @@ class XlaBuilder {
       const PaddingConfig& padding_config);
 
   XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> dimensions,
-                absl::Span<const int64_t> new_sizes,
-                int64_t inferred_dimension = -1);
-
-  XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> new_sizes,
                 int64_t inferred_dimension = -1);
 
   XlaOp Reshape(const Shape& shape, XlaOp operand,
@@ -1269,10 +1265,7 @@ class XlaBuilder {
   friend XlaOp PadInDim(XlaOp operand, XlaOp padding_value, int64_t dimno,
                         int64_t pad_lo, int64_t pad_hi);
 
-  friend XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> dimensions,
-                       absl::Span<const int64_t> new_sizes);
-
-  friend XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> new_sizes);
+  friend XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> dimensions);
 
   friend XlaOp Reshape(const Shape& shape, XlaOp operand);
 
@@ -2032,14 +2025,6 @@ XlaOp Pad(XlaOp operand, XlaOp padding_value,
 XlaOp PadInDim(XlaOp operand, XlaOp padding_value, int64_t dimno,
                int64_t pad_lo, int64_t pad_hi);
 
-// Enqueues an operation onto the computation that flattens the operand based
-// on the dimension order (major/slowest-varying to minor/fastest-varying)
-// given, followed by reshaping it into the shape with the given dimension
-// sizes (also major to minor). Conceptually, this is a limited form of
-// "shape casting".
-XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> dimensions,
-              absl::Span<const int64_t> new_sizes);
-
 // Enqueues a dynamic reshape operation. The dynamic reshape takes additional
 // XlaOps as sizes for the result dimension. The result dim i is a dynamic
 // dimension dimension if dims_are_dynamic[i] is true.
@@ -2055,7 +2040,7 @@ XlaOp MhloDynamicReshape(XlaOp operand, XlaOp output_shape, const Shape& shape);
 // Enqueues an operation onto the computation that collapses the operand,
 // from first to last dimension (C order), then reshapes it to the given
 // dimension sizes. Conceptually, this is a limited form of "shape casting".
-XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> new_sizes);
+XlaOp Reshape(XlaOp operand, absl::Span<const int64_t> dimensions);
 
 // Enqueues a Reshape op that uses an explicit target shape.
 XlaOp Reshape(const Shape& shape, XlaOp operand);

--- a/xla/hlo/builder/xla_builder_test.cc
+++ b/xla/hlo/builder/xla_builder_test.cc
@@ -603,18 +603,9 @@ TEST(XlaBuilderTest, OperandFromWrongBuilder) {
 TEST(XlaBuilderTest, ReshapeDefaultOrder) {
   XlaBuilder b(TestName());
   auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {2, 3, 5, 7}), "x");
-  Reshape(x, /*new_sizes=*/{6, 35});
+  Reshape(x, /*dimensions=*/{6, 35});
   TF_ASSERT_OK_AND_ASSIGN(const auto module, BuildHloModule(b));
   EXPECT_THAT(GetRoot(*module), GmockMatch(m::Reshape(m::Parameter())));
-}
-
-TEST(XlaBuilderTest, ReshapeHasTranspose) {
-  XlaBuilder b(TestName());
-  auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {2, 3, 5, 7}), "x");
-  Reshape(x, /*dimensions=*/{3, 2, 1, 0}, /*new_sizes=*/{6, 35});
-  TF_ASSERT_OK_AND_ASSIGN(const auto module, BuildHloModule(b));
-  EXPECT_THAT(GetRoot(*module),
-              GmockMatch(m::Reshape(m::Transpose(m::Parameter()))));
 }
 
 TEST(XlaBuilderTest, Transpose) {
@@ -3160,8 +3151,7 @@ TEST(XlaBuilderTest, UnboundedReshape) {
   XlaBuilder b(TestName());
   TF_ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[?]"));
   TF_ASSERT_OK_AND_ASSIGN(const Shape expected, ParseShape("f32[2,3]"));
-  Reshape(Parameter(&b, 0, operand, "operand"), /*dimensions=*/{0},
-          /*new_sizes=*/{2, 3});
+  Reshape(Parameter(&b, 0, operand, "operand"), /*dimensions=*/{2, 3});
   TF_ASSERT_OK_AND_ASSIGN(const auto module, BuildHloModule(b));
   EXPECT_THAT(GetRoot(*module),
               GmockMatch(m::Op().WithShapeEqualTo(&expected)));
@@ -3170,8 +3160,8 @@ TEST(XlaBuilderTest, UnboundedReshape) {
 TEST(XlaBuilderTest, UnboundedReshapeUnsupportedOutputShape) {
   XlaBuilder b(TestName());
   TF_ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[6]"));
-  Reshape(Parameter(&b, 0, operand, "operand"), /*dimensions=*/{0},
-          /*new_sizes=*/{Shape::kUnboundedSize, Shape::kUnboundedSize});
+  Reshape(Parameter(&b, 0, operand, "operand"),
+          /*dimensions=*/{Shape::kUnboundedSize, Shape::kUnboundedSize});
   EXPECT_THAT(
       BuildHloModule(b),
       StatusIs(_,

--- a/xla/python/ops.cc
+++ b/xla/python/ops.cc
@@ -649,10 +649,7 @@ void BuildOpsSubmodule(nb::module_& m) {
   ops.def("Reshape",
           static_cast<XlaOp (*)(XlaOp, absl::Span<const int64_t>,
                                 absl::Span<const int64_t>)>(&Reshape),
-          nb::arg("operand"), nb::arg("dimensions"), nb::arg("new_sizes"));
-  ops.def("Reshape",
-          static_cast<XlaOp (*)(XlaOp, absl::Span<const int64_t>)>(&Reshape),
-          nb::arg("operand"), nb::arg("new_sizes"));
+          nb::arg("operand"), nb::arg("dimensions"));
   ops.def("Rev", &Rev, nb::arg("operand"), nb::arg("dimensions"));
   ops.def("RngBitGenerator", &RngBitGenerator, nb::arg("algorithm"),
           nb::arg("initial_state"), nb::arg("shape"));

--- a/xla/python/ops.cc
+++ b/xla/python/ops.cc
@@ -25,12 +25,12 @@ limitations under the License.
 
 #include "absl/types/span.h"
 #include "nanobind/nanobind.h"
-#include "nanobind/stl/optional.h"  // IWYU pragma: keep
-#include "nanobind/stl/pair.h"  // IWYU pragma: keep
+#include "nanobind/stl/optional.h"    // IWYU pragma: keep
+#include "nanobind/stl/pair.h"        // IWYU pragma: keep
 #include "nanobind/stl/shared_ptr.h"  // IWYU pragma: keep
-#include "nanobind/stl/string.h"  // IWYU pragma: keep
-#include "nanobind/stl/tuple.h"  // IWYU pragma: keep
-#include "nanobind/stl/vector.h"  // IWYU pragma: keep
+#include "nanobind/stl/string.h"      // IWYU pragma: keep
+#include "nanobind/stl/tuple.h"       // IWYU pragma: keep
+#include "nanobind/stl/vector.h"      // IWYU pragma: keep
 #include "xla/hlo/builder/lib/approx_topk.h"
 #include "xla/hlo/builder/lib/approx_topk_shape.h"
 #include "xla/hlo/builder/lib/comparators.h"
@@ -647,8 +647,7 @@ void BuildOpsSubmodule(nb::module_& m) {
           nb::arg("dimension"));
   ops.def("ReplicaId", &ReplicaId, nb::arg("builder"));
   ops.def("Reshape",
-          static_cast<XlaOp (*)(XlaOp, absl::Span<const int64_t>,
-                                absl::Span<const int64_t>)>(&Reshape),
+          static_cast<XlaOp (*)(XlaOp, absl::Span<const int64_t>)>(&Reshape),
           nb::arg("operand"), nb::arg("dimensions"));
   ops.def("Rev", &Rev, nb::arg("operand"), nb::arg("dimensions"));
   ops.def("RngBitGenerator", &RngBitGenerator, nb::arg("algorithm"),

--- a/xla/service/shape_inference.h
+++ b/xla/service/shape_inference.h
@@ -295,7 +295,7 @@ class ShapeInference {
   // its operand and the new dimension sizes specified.
   static absl::StatusOr<Shape> InferReshapeShape(
       const Shape& operand, absl::Span<const int64_t> dimensions,
-      absl::Span<const int64_t> new_sizes, int64_t inferred_dimension);
+      int64_t inferred_dimension);
 
   // Infers the shape produced by a dynamic reshape operation from the element
   // type of its operand and the new dimension sizes specified. The result shape

--- a/xla/service/shape_inference_test.cc
+++ b/xla/service/shape_inference_test.cc
@@ -1620,7 +1620,7 @@ TEST_F(ShapeInferenceTest, InferReshapeDegenerateCombine) {
   // Both output dimension can be dynamic, use inferred_dimension to tie-break.
   const Shape operand = ShapeUtil::MakeShape(F32, {1, 1}, {false, true});
   const auto status =
-      ShapeInference::InferReshapeShape(operand, {1, 0}, {1},
+      ShapeInference::InferReshapeShape(operand, {1},
                                         /*inferred_dimension=*/-1);
   ASSERT_EQ(ShapeUtil::MakeShape(F32, {1}, {true}), *status);
 }
@@ -1633,7 +1633,7 @@ TEST_F(ShapeInferenceTest, InferReshapeSplit) {
   // Both output dimension can be dynamic, use inferred_dimension to tie-break.
   const Shape operand = ShapeUtil::MakeShape(F32, {10}, {true});
   const auto status =
-      ShapeInference::InferReshapeShape(operand, {0}, {1, 10},
+      ShapeInference::InferReshapeShape(operand, {1, 10},
                                         /*inferred_dimension=*/0);
   ASSERT_EQ(ShapeUtil::MakeShape(F32, {1, 10}, {true, false}), *status);
 }
@@ -1644,7 +1644,7 @@ TEST_F(ShapeInferenceTest, InferReshapeCombine) {
   // [<=60]
   const Shape operand = ShapeUtil::MakeShape(F32, {6, 10}, {false, true});
   const auto status =
-      ShapeInference::InferReshapeShape(operand, {1, 0}, {60},
+      ShapeInference::InferReshapeShape(operand, {60},
                                         /*inferred_dimension=*/-11);
   ASSERT_EQ(ShapeUtil::MakeShape(F32, {60}, {true}), *status);
 }
@@ -1655,7 +1655,7 @@ TEST_F(ShapeInferenceTest, UnchangedDimension) {
   // [2, 3, <=10]
   const Shape operand = ShapeUtil::MakeShape(F32, {6, 10}, {false, true});
   const auto status =
-      ShapeInference::InferReshapeShape(operand, {1, 0}, {2, 3, 10},
+      ShapeInference::InferReshapeShape(operand, {2, 3, 10},
                                         /*inferred_dimension=*/-11);
   ASSERT_EQ(ShapeUtil::MakeShape(F32, {2, 3, 10}, {false, false, true}),
             *status);
@@ -5559,8 +5559,7 @@ TEST_F(ShapeInferenceTest, UnboundedReshape) {
   TF_ASSERT_OK_AND_ASSIGN(const Shape expected, ParseShape("f32[2,3]"));
   TF_ASSERT_OK_AND_ASSIGN(
       const Shape inferred,
-      ShapeInference::InferReshapeShape(operand, /*dimensions=*/{0},
-                                        /*new_sizes=*/{2, 3}, -1));
+      ShapeInference::InferReshapeShape(operand, /*dimensions=*/{2, 3}, -1));
   ASSERT_TRUE(ShapeUtil::Equal(inferred, expected))
       << "inferred: " << ShapeUtil::HumanString(inferred)
       << " expected: " << ShapeUtil::HumanString(expected);
@@ -5570,8 +5569,8 @@ TEST_F(ShapeInferenceTest, UnboundedReshapeUnsupportedOutputShape) {
   TF_ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[6]"));
   const absl::StatusOr<Shape> inferred_shape =
       ShapeInference::InferReshapeShape(
-          operand, /*dimensions=*/{0},
-          /*new_sizes=*/{Shape::kUnboundedSize, Shape::kUnboundedSize}, -1);
+          operand,
+          /*dimensions=*/{Shape::kUnboundedSize, Shape::kUnboundedSize}, -1);
   EXPECT_THAT(
       inferred_shape.status().message(),
       HasSubstr("Reshaping with unbounded result shape is not supported."));
@@ -5581,8 +5580,7 @@ TEST_F(ShapeInferenceTest, UnboundedReshapeUnsupportedMixOfDynamism) {
   TF_ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[?, <=3]"));
   TF_ASSERT_OK_AND_ASSIGN(const Shape expected, ParseShape("f32[<=3]"));
   const absl::StatusOr<Shape> inferred_shape =
-      ShapeInference::InferReshapeShape(operand, /*dimensions=*/{0},
-                                        /*new_sizes=*/{3}, -1);
+      ShapeInference::InferReshapeShape(operand, /*dimensions=*/{3}, -1);
   ASSERT_THAT(inferred_shape.status().message(),
               HasSubstr("Reshape operand with bounded and unbounded dynamism "
                         "not supported."));

--- a/xla/tests/bitcast_convert_test.cc
+++ b/xla/tests/bitcast_convert_test.cc
@@ -141,7 +141,7 @@ TEST_F(BitcastConvertTest, ConvertMapToF32) {
 TEST_F(BitcastConvertTest, ConvertReshape) {
   XlaBuilder builder(TestName());
   auto input = ConstantR1<int32_t>(&builder, {0x42280000});
-  auto reshape = Reshape(input, /*dimensions=*/{0}, /*new_sizes=*/{});
+  auto reshape = Reshape(input, /*dimensions=*/{});
   BitcastConvertType(reshape, F32);
 
   ComputeAndCompareR0<float>(&builder, 42.0f, {});

--- a/xla/tests/convert_test.cc
+++ b/xla/tests/convert_test.cc
@@ -447,7 +447,7 @@ TEST_F(ConvertTest, ConvertMapToF32) {
 TEST_F(ConvertTest, ConvertReshape) {
   XlaBuilder builder(TestName());
   auto input = ConstantR1<int32_t>(&builder, {42});
-  auto reshape = Reshape(input, /*dimensions=*/{0}, /*new_sizes=*/{});
+  auto reshape = Reshape(input, /*dimensions=*/{});
   ConvertElementType(reshape, F32);
 
   ComputeAndCompareR0<float>(&builder, 42.0f, {}, ErrorSpec(0.0001));

--- a/xla/tests/dot_operation_test.cc
+++ b/xla/tests/dot_operation_test.cc
@@ -688,8 +688,8 @@ XLA_TYPED_TEST(DotOperationTestForBatchMatMul, DISABLED_ON_TPU(Types)) {
   auto y = Parameter(&builder, 1, ShapeUtil::MakeShapeWithType<T>({2, 2, 2, 2}),
                      "y");
 
-  auto x_flat = Reshape(x, {0, 1, 2, 3}, {4, 2, 2});
-  auto y_flat = Reshape(y, {0, 1, 2, 3}, {4, 2, 2});
+  auto x_flat = Reshape(x, {4, 2, 2});
+  auto y_flat = Reshape(y, {4, 2, 2});
 
   // Slice batches into individual matrices and multiply them.
   std::vector<XlaOp> out_slices;
@@ -698,16 +698,16 @@ XLA_TYPED_TEST(DotOperationTestForBatchMatMul, DISABLED_ON_TPU(Types)) {
   for (int i = 0; i < n; ++i) {
     // Slice off individual matrices and reshape to 2D tensors.
     auto x_slice = Slice(x_flat, {i, 0, 0}, {i + 1, 2, 2}, {1, 1, 1});
-    x_slice = Reshape(x_slice, {0, 1, 2}, {2, 2});
+    x_slice = Reshape(x_slice, {2, 2});
     auto y_slice = Slice(y_flat, {i, 0, 0}, {i + 1, 2, 2}, {1, 1, 1});
-    y_slice = Reshape(y_slice, {0, 1, 2}, {2, 2});
+    y_slice = Reshape(y_slice, {2, 2});
 
     auto out = Dot(x_slice, y_slice);
-    out = Reshape(out, {0, 1}, {1, 2, 2});
+    out = Reshape(out, {1, 2, 2});
     out_slices.push_back(out);
   }
   auto out_flat = ConcatInDim(&builder, out_slices, 0);
-  Reshape(out_flat, {0, 1, 2}, {2, 2, 2, 2});
+  Reshape(out_flat, {2, 2, 2, 2});
 
   auto x_data = this->client_
                     ->TransferToServer(LiteralUtil::CreateR4FromArray4D<T>(

--- a/xla/tests/reshape_test.cc
+++ b/xla/tests/reshape_test.cc
@@ -112,8 +112,7 @@ XLA_TEST_P(ReshapeTest, SingleElementArrayToScalar) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(
                       0, input_literal, "parameter", &builder, &parameter));
-  auto reshape = Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1},
-                         /*new_sizes=*/{});
+  auto reshape = Reshape(/*operand=*/parameter, /*dimensions=*/{});
   auto new_shape = builder.GetShape(reshape).value();
 
   auto expected_literal = LiteralUtil::CreateR0<float>(1.0f);
@@ -130,7 +129,7 @@ XLA_TEST_P(ReshapeTest, ScalarToSingleElementArray) {
       auto input, CreateParameterAndTransferLiteral(0, param0_literal, "param0",
                                                     &builder, &parameter));
   auto a = Neg(parameter);
-  Reshape(/*operand=*/a, /*dimensions=*/{}, /*new_sizes=*/{1});
+  Reshape(/*operand=*/a, /*dimensions=*/{1});
 
   auto expected_literal = LiteralUtil::CreateR1<float>({-1.0f});
   ComputeAndCompareLiteral(&builder, expected_literal, {input.get()},
@@ -216,8 +215,7 @@ XLA_TEST_P(ReshapeTest, R1ToR2_0_To_2x0) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0},
-          /*new_sizes=*/{2, 0});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{2, 0});
   auto expected_literal = LiteralUtil::CreateR2<float>({{}, {}});
   ComputeAndCompareLiteral(&builder, expected_literal, {input.get()},
                            zero_error_spec_);
@@ -232,8 +230,7 @@ XLA_TEST_P(ReshapeTest, R1ToR2_6_To_2x3) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0},
-          /*new_sizes=*/{2, 3});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{2, 3});
   auto expected_literal =
       LiteralUtil::CreateR2<float>({{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}});
   ComputeAndCompareLiteral(&builder, expected_literal, {input.get()},
@@ -248,8 +245,7 @@ XLA_TEST_P(ReshapeTest, Reshape0x2To2x0) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1},
-          /*new_sizes=*/{2, 0});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{2, 0});
   auto expected_literal = LiteralUtil::CreateR2<float>({{}, {}});
   ComputeAndCompareLiteral(&builder, expected_literal, {input.get()},
                            zero_error_spec_);
@@ -264,8 +260,7 @@ XLA_TEST_P(ReshapeTest, ReshapeRowToCol) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1},
-          /*new_sizes=*/{3, 1});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{3, 1});
 
   auto expected = ReferenceUtil::TransposeArray2D(*simple);
   auto expected_literal = LiteralUtil::CreateFromArray(*expected);
@@ -282,8 +277,8 @@ XLA_TEST_P(ReshapeTest, TransposeAsReshape) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{1, 0},
-          /*new_sizes=*/{3, 4});
+  Reshape(Transpose(parameter, /*permutation=*/{1, 0}),
+          /*dimensions=*/{3, 4});
 
   auto expected = ReferenceUtil::TransposeArray2D(*a4x3);
   auto expected_literal = LiteralUtil::CreateFromArray(*expected);
@@ -331,8 +326,7 @@ XLA_TEST_P(ReshapeTest, ReshapeSplitNoShuffleZeroElements) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1},
-          /*new_sizes=*/{2, 3, 0, 0});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{2, 3, 0, 0});
   auto expected_literal =
       LiteralUtil::CreateFromArray(Array4D<float>(2, 3, 0, 0));
   ComputeAndCompareLiteral(&builder, expected_literal, {input.get()},
@@ -346,8 +340,7 @@ XLA_TEST_P(ReshapeTest, ReshapeR4ToR2ZeroElements) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1, 2, 3},
-          /*new_sizes=*/{24, 0});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{24, 0});
   auto expected_literal = LiteralUtil::CreateFromArray(Array2D<float>(24, 0));
   ComputeAndCompareLiteral(&builder, expected_literal, {input.get()},
                            zero_error_spec_);
@@ -363,8 +356,7 @@ XLA_TEST_P(ReshapeTest, ReshapeSplitNoShuffle) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1},
-          /*new_sizes=*/{2, 6});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{2, 6});
 
   auto expected = MakeLinspaceArray2D(1.0f, 12.0f, 2, 6);
   auto expected_literal = LiteralUtil::CreateFromArray(*expected);
@@ -379,8 +371,8 @@ XLA_TEST_P(ReshapeTest, ReshapeSplitAndShuffleZeroElements) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{1, 0},
-          /*new_sizes=*/{3, 0});
+  Reshape(Transpose(parameter, /*permutation=*/{1, 0}),
+          /*dimensions=*/{3, 0});
   auto expected_literal = LiteralUtil::CreateFromArray(Array2D<float>(3, 0));
   ComputeAndCompareLiteral(&builder, expected_literal, {input.get()},
                            zero_error_spec_);
@@ -396,8 +388,8 @@ XLA_TEST_P(ReshapeTest, ReshapeSplitAndShuffle) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{1, 0},
-          /*new_sizes=*/{2, 6});
+  Reshape(Transpose(parameter, /*permutation=*/{1, 0}),
+          /*dimensions=*/{2, 6});
   Array2D<float> expected({{1.0f, 4.0f, 7.0f, 10.0f, 2.0f, 5.0f},
                            {8.0f, 11.0f, 3.0f, 6.0f, 9.0f, 12.0f}});
   auto expected_literal = LiteralUtil::CreateFromArray(expected);
@@ -423,8 +415,8 @@ XLA_TEST_P(ReshapeTest, DocR3_R1_Collapse_012) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1, 2},
-          /*new_sizes=*/{24});
+  Reshape(Transpose(parameter, /*permutation=*/{0, 1, 2}),
+          /*dimensions=*/{24});
   auto expected_literal = LiteralUtil::CreateR1<float>(
       {10, 11, 12, 15, 16, 17, 20, 21, 22, 25, 26, 27,
        30, 31, 32, 35, 36, 37, 40, 41, 42, 45, 46, 47});
@@ -439,8 +431,8 @@ XLA_TEST_P(ReshapeTest, DocR3_R2_Collapse_012_Refine_83) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1, 2},
-          /*new_sizes=*/{8, 3});
+  Reshape(Transpose(parameter, /*permutation=*/{0, 1, 2}),
+          /*dimensions=*/{8, 3});
   auto expected_literal = LiteralUtil::CreateR2<float>({{10, 11, 12},
                                                         {15, 16, 17},
                                                         {20, 21, 22},
@@ -460,8 +452,8 @@ XLA_TEST_P(ReshapeTest, DocR3_R1_Collapse_120) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{1, 2, 0},
-          /*new_sizes=*/{24});
+  Reshape(Transpose(parameter, /*permutation=*/{1, 2, 0}),
+          /*dimensions=*/{24});
   auto expected_literal = LiteralUtil::CreateR1<float>(
       {10, 20, 30, 40, 11, 21, 31, 41, 12, 22, 32, 42,
        15, 25, 35, 45, 16, 26, 36, 46, 17, 27, 37, 47});
@@ -476,8 +468,9 @@ XLA_TEST_P(ReshapeTest, DocR3_R2_Collapse_120_Refine_83) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{1, 2, 0},
-          /*new_sizes=*/{8, 3});
+
+  Reshape(Transpose(parameter, /*permutation=*/{1, 2, 0}),
+          /*dimensions=*/{8, 3});
   auto expected_literal = LiteralUtil::CreateR2<float>({{10, 20, 30},
                                                         {40, 11, 21},
                                                         {31, 41, 12},
@@ -497,8 +490,8 @@ XLA_TEST_P(ReshapeTest, DocR3_R3_Collapse_120_Refine_262) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{1, 2, 0},
-          /*new_sizes=*/{2, 6, 2});
+  Reshape(Transpose(parameter, /*permutation=*/{1, 2, 0}),
+          /*dimensions=*/{2, 6, 2});
   auto expected_literal = LiteralUtil::CreateR3<float>(
       {{{10, 20}, {30, 40}, {11, 21}, {31, 41}, {12, 22}, {32, 42}},
        {{15, 25}, {35, 45}, {16, 26}, {36, 46}, {17, 27}, {37, 47}}});
@@ -557,8 +550,7 @@ XLA_TEST_P(ReshapeTest, FullyConnectedCollapseDesugared) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(/*operand=*/parameter, /*dimensions=*/{0, 1, 2, 3},
-          /*new_sizes=*/{2, 4});
+  Reshape(/*operand=*/parameter, /*dimensions=*/{2, 4});
 
   auto expected_literal =
       LiteralUtil::CreateR2<float>({{0, 1, 2, 3}, {4, 5, 6, 7}});
@@ -571,8 +563,6 @@ XLA_TEST_P(ReshapeTest, ToScalar) {
   for (int rank = 0; rank < 8; ++rank) {
     XlaBuilder b(TestName());
     std::vector<int64_t> ones(rank, 1);  // this is {1, ..., 1}.
-    std::vector<int64_t> dimensions(rank);
-    std::iota(dimensions.begin(), dimensions.end(), 0);
     Literal input_literal(ShapeUtil::MakeShape(F32, ones));
     std::vector<int64_t> zeros(rank, 0);  // this is {0, ..., 0}.
     input_literal.Set<float>(zeros, 83.0f);
@@ -581,25 +571,12 @@ XLA_TEST_P(ReshapeTest, ToScalar) {
     TF_ASSERT_OK_AND_ASSIGN(
         auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                       &b, &parameter));
-    Reshape(parameter, dimensions, {});
+    Reshape(parameter, {});
 
     auto expected_literal = LiteralUtil::CreateR0<float>(83.0f);
     ComputeAndCompareLiteral(&b, expected_literal, {input.get()},
                              zero_error_spec_);
   }
-}
-
-XLA_TEST_P(ReshapeTest, BadDimensions) {
-  XlaBuilder b(TestName());
-  auto input_literal = LiteralUtil::CreateR1<float>({1.0f});
-  XlaOp parameter;
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
-                                                    &b, &parameter));
-  Reshape(parameter, {}, {});
-  EXPECT_THAT(
-      ExecuteToString(&b, {}),
-      ::testing::HasSubstr("not a permutation of the operand dimensions"));
 }
 
 XLA_TEST_P(ReshapeTest, BadNewSizes) {
@@ -609,7 +586,7 @@ XLA_TEST_P(ReshapeTest, BadNewSizes) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &b, &parameter));
-  Reshape(parameter, {1}, {});
+  Reshape(parameter, {});
   EXPECT_THAT(ExecuteToString(&b, {}),
               ::testing::HasSubstr("mismatched element counts"));
 }
@@ -647,7 +624,7 @@ XLA_TEST_P(ReshapeTest, R4Dim0MinorLayoutToR2Dim0MajorLayout) {
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
 
-  Reshape(parameter, /*dimensions=*/{0, 1, 2, 3}, /*new_sizes=*/{2, 8});
+  Reshape(parameter, /*dimensions=*/{2, 8});
 
   Array2D<float> expected_array({
       {0, 1, 2, 3, 100, 101, 102, 103},
@@ -681,7 +658,7 @@ XLA_TEST_P(ReshapeTest, R2ToR4_3x8_To_3x2x1x4) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1}, /*new_sizes=*/{3, 2, 1, 4});
+  Reshape(parameter, /*dimensions=*/{3, 2, 1, 4});
 
   // clang-format off
   auto expected_literal = LiteralUtil::CreateR4<float>({
@@ -709,7 +686,8 @@ XLA_TEST_P(ReshapeTest, R2ToR4_3x8_To_3x2x1x4_Dimensions_10) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, input_literal, "input",
                                                     &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{1, 0}, /*new_sizes=*/{3, 2, 1, 4});
+  Reshape(Transpose(parameter, /*permutation=*/{1, 0}),
+          /*dimensions=*/{3, 2, 1, 4});
 
   // clang-format off
   auto expected_literal = LiteralUtil::CreateR4<float>({
@@ -738,7 +716,7 @@ XLA_TEST_P(ReshapeTest, R4ToR2_2x1x1x1_To_2x1) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1, 2, 3}, /*new_sizes=*/{2, 1});
+  Reshape(parameter, /*dimensions=*/{2, 1});
 
   Literal expected = LiteralUtil::ReshapeSlice({2, 1}, {1, 0}, input_literal);
   ComputeAndCompareLiteral(&builder, expected, {input_data.get()},
@@ -758,7 +736,7 @@ XLA_TEST_P(ReshapeTest, R4ToR2_2x1x4x1_To_4x2) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1, 2, 3}, /*new_sizes=*/{4, 2});
+  Reshape(parameter, /*dimensions=*/{4, 2});
 
   Literal expected = LiteralUtil::ReshapeSlice({4, 2}, {1, 0}, input_literal);
   ComputeAndCompareLiteral(&builder, expected, {input_data.get()},
@@ -779,8 +757,9 @@ XLA_TEST_P(ReshapeTest, R4ToR2_5x10x2x3_To_5x60_Dimensions_0213) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 2, 1, 3},
-          /*new_sizes=*/{5, 60});
+  Reshape(Transpose(parameter,
+                    /*permutation=*/{0, 2, 1, 3}),
+          /*dimensions=*/{5, 60});
 
   Array2D<float> expected_array(5, 60);
   input.Each([&](absl::Span<const int64_t> indices, float* cell) {
@@ -806,8 +785,9 @@ XLA_TEST_P(ReshapeTest, NoopReshape) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{3, 0, 1, 2},
-          /*new_sizes=*/{7, 2, 3, 5});
+  Reshape(Transpose(parameter,
+                    /*permutation=*/{3, 0, 1, 2}),
+          /*dimensions=*/{7, 2, 3, 5});
   XlaComputation computation = builder.Build().value();
 
   ExecutionOptions execution_options = execution_options_;
@@ -859,8 +839,7 @@ XLA_TEST_P(ReshapeTest, R4ToR4Reshape_Trivial) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, literal_1x2x3x4, "input",
                                                     &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1, 2, 3},
-          /*new_sizes=*/{1, 2, 3, 4});
+  Reshape(parameter, /*dimensions=*/{1, 2, 3, 4});
 
   ComputeAndCompareLiteral(&builder, literal_1x2x3x4, {input.get()});
 }
@@ -875,8 +854,8 @@ XLA_TEST_P(ReshapeTest, R4ToR4Reshape) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto input, CreateParameterAndTransferLiteral(0, literal_1x2x3x4, "input",
                                                     &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{1, 3, 2, 0},
-          /*new_sizes=*/{2, 4, 3, 1});
+  Reshape(Transpose(parameter, /*permutation=*/{1, 3, 2, 0}),
+          /*dimensions=*/{2, 4, 3, 1});
 
   // clang-format off
   auto expected_2x4x3x1 = LiteralUtil::CreateR4<float>(
@@ -909,8 +888,8 @@ XLA_TEST_P(ReshapeTest, R4TwoMinorTransposeSimple) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1, 3, 2},
-          /*new_sizes=*/new_bounds);
+  Reshape(Transpose(parameter, /*permutation=*/{0, 1, 3, 2}),
+          /*dimensions=*/new_bounds);
 
   Literal expected =
       LiteralUtil::ReshapeSlice(new_bounds, {2, 3, 1, 0}, input_literal)
@@ -938,8 +917,7 @@ XLA_TEST_P(ReshapeTest, R4TwoMinorTransposeMajorFirstEffectiveR2) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1, 3, 2},
-          /*new_sizes=*/new_bounds);
+  Reshape(Transpose(parameter, {0, 1, 3, 2}), /*dimensions=*/new_bounds);
 
   Literal expected =
       LiteralUtil::ReshapeSlice(new_bounds, {2, 3, 1, 0}, input_literal)
@@ -967,8 +945,7 @@ XLA_TEST_P(ReshapeTest, R4TwoMinorTransposeMajorFirstMinorEffectiveR1) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1, 3, 2},
-          /*new_sizes=*/new_bounds);
+  Reshape(Transpose(parameter, {0, 1, 3, 2}), /*dimensions=*/new_bounds);
 
   Literal expected =
       LiteralUtil::ReshapeSlice(new_bounds, {2, 3, 1, 0}, input_literal)
@@ -997,8 +974,7 @@ XLA_TEST_P(ReshapeTest, R4TwoMinorTransposeMajorFirstMinorEffectiveR1InR2) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{0, 1, 3, 2},
-          /*new_sizes=*/new_bounds);
+  Reshape(Transpose(parameter, {0, 1, 3, 2}), /*dimensions=*/new_bounds);
 
   Literal expected =
       LiteralUtil::ReshapeSlice(new_bounds, {2, 3, 1, 0}, input_literal)
@@ -1026,8 +1002,7 @@ XLA_TEST_P(ReshapeTest, R4TwoMinorTransposeTrivialR2) {
   TF_ASSERT_OK_AND_ASSIGN(auto input_data,
                           CreateParameterAndTransferLiteral(
                               0, input_literal, "input", &builder, &parameter));
-  Reshape(parameter, /*dimensions=*/{1, 0, 2, 3},
-          /*new_sizes=*/new_bounds);
+  Reshape(Transpose(parameter, {1, 0, 2, 3}), /*dimensions=*/new_bounds);
 
   Literal expected =
       LiteralUtil::ReshapeSlice(new_bounds, {1, 0, 2, 3}, input_literal)

--- a/xla/tests/select_and_scatter_test.cc
+++ b/xla/tests/select_and_scatter_test.cc
@@ -303,8 +303,8 @@ XLA_TEST_F(SelectAndScatterTest, DISABLED_ON_TPU(R2F32Tie)) {
 XLA_TEST_F(SelectAndScatterTest, DISABLED_ON_TPU(ReshapeR2S32)) {
   const auto operand = ConstantR2<int32_t>(
       &builder_, {{7, 3}, {2, 8}, {5, 9}, {3, 3}, {10, 4}, {2, 2}});
-  const auto reshape =
-      Reshape(operand, /*dimensions=*/{1, 0}, /*new_sizes=*/{2, 6});
+  const auto reshape = Reshape(Transpose(operand, /*permutation=*/{1, 0}),
+                               /*dimensions=*/{2, 6});
   const auto source = ConstantR2<int32_t>(&builder_, {{2, 6}});
   Array2D<int32_t> expected({{0, 0, 0, 0, 6, 0}, {0, 0, 2, 0, 0, 0}});
   SelectAndScatter(reshape, ge_s32_, /*window_dimensions=*/{2, 3},

--- a/xla/tests/while_test.cc
+++ b/xla/tests/while_test.cc
@@ -894,7 +894,7 @@ XLA_TEST_F(WhileTest, WhileWithPrngScalarResult) {
   auto build_condition = [this, v6s32](int count) {
     XlaBuilder builder(TestName());
     auto prev = Reshape(
-        Slice(Parameter(&builder, 0, v6s32, "prev"), {0}, {1}, {1}), {0}, {});
+        Slice(Parameter(&builder, 0, v6s32, "prev"), {0}, {1}, {1}), {});
     Gt(ConstantR0<int32_t>(&builder, count), prev);
     return builder.Build().value();
   };


### PR DESCRIPTION
Reshape builder unnecessarily accepts two arguments:

 1. `dimensions` which permutation of the  layoyt of the shape.
 2. `new_sizes` which are the new dimensions of the shape.

This is confusing, and the we can simply remove the support for permutation of layout - as it is just a transpose and such a transpose can be easily constructed wherever required.