### PR TITLE
Fix const qualifier on status prevents automatic move semantics

### DIFF
--- a/xla/status_macros.cc
+++ b/xla/status_macros.cc
@@ -77,7 +77,7 @@ static absl::Status MakeError(const char* filename, int line,
     LOG(ERROR) << "Cannot create error with status OK";
     code = absl::StatusCode::kUnknown;
   }
-  const absl::Status status = absl::Status(code, message);
+  absl::Status status = absl::Status(code, message);
   if (ABSL_PREDICT_TRUE(should_log)) {
     LogError(status, filename, line, log_severity, should_log_stack_trace);
   }


### PR DESCRIPTION
reason for change - const qualifier on `status` prevents automatic move semantics in return.

When return status; is executed, the compiler cannot invoke the move constructor of `absl::Status` because status is const.