### PR TITLE
Fix bug in post order traversal of computation instructions

### DIFF
--- a/xla/hlo/ir/hlo_computation.cc
+++ b/xla/hlo/ir/hlo_computation.cc
@@ -743,7 +743,12 @@ std::vector<HloInstruction*> HloComputation::MakeInstructionPostOrder(
   dfs_stack_scratch.reserve(instruction_count());
 
   for (const auto& instruction : instructions()) {
-    if (instruction->users().empty()) {
+    // We don't consider users outside any computation as real users. This can
+    // happen when creating new instructions for replacement when cloning
+    // computations.
+    if (absl::c_all_of(instruction->users(), [](const HloInstruction* user) {
+          return user->parent() == nullptr;
+        })) {
       ComputeInstructionPostOrder(instruction, channel_dependencies, visited,
                                   post_order, &dfs_stack_scratch);
     }
@@ -823,7 +828,12 @@ void HloComputation::ForEachInstructionPostOrder(
   dfs_stack_scratch.reserve(instruction_count());
   auto channel_dependencies = ComputeChannelDependencies();
   for (const auto& instruction : instructions()) {
-    if (instruction->users().empty()) {
+    // We don't consider users outside any computation as real users. This can
+    // happen when creating new instructions for replacement when cloning
+    // computations.
+    if (absl::c_all_of(instruction->users(), [](const HloInstruction* user) {
+          return user->parent() == nullptr;
+        })) {
       ForEachInstructionPostOrderImpl(func, instruction, channel_dependencies,
                                       visited, &dfs_stack_scratch);
     }


### PR DESCRIPTION
While creating post order traversal, an instruction may have a user outside the computation. This is the case when we are constructing new instructions to store in replacements for cloning the computation later. This user should be ignored. Added test for the same.

Because of this, functions like `ToString()`, and
`GetUniqueGteInstruction()` encounter errors. They rely on post-order traversal to have all the instructions.