### PR TITLE
[gpu][convert-peeling] Add convert peeling

### DIFF
--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -3416,3 +3416,33 @@ xla_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "while_loop_convert_peeler",
+    srcs = ["while_loop_convert_peeler.cc"],
+    hdrs = ["while_loop_convert_peeler.h"],
+    deps = [
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/hlo/analysis:while_loop_analysis",
+        "//xla/hlo/utils:hlo_query",
+        "//xla:literal_util",
+        "//xla/service:value_range",
+        "//xla/tests:test_utils",
+    ],
+)
+
+xla_cc_test(
+    name = "while_loop_convert_peeler_test",
+    srcs = ["while_loop_convert_peeler_test.cc"],
+    deps = [
+        ":while_loop_convert_peeler",
+        "@com_google_googletest//:gtest_main",
+        "//xla/tests:hlo_runner_agnostic_test_base",
+        "//xla/tests:test_utils",
+        "//xla/service:platform_util",
+        "//xla/service:hlo_runner",
+        "//xla/hlo/testlib:pattern_matcher_gmock",
+        "//xla/service:pattern_matcher",
+    ],
+)

--- a/xla/service/gpu/transforms/while_loop_convert_peeler.cc
+++ b/xla/service/gpu/transforms/while_loop_convert_peeler.cc
@@ -130,7 +130,8 @@ WhileLoopConvertPeeler::CollectConvertInfos(
                     buffer->shape().dimensions(idx) ||
                 LiteralUtil::LiteralAsScalarInt64(idx_operand->literal()) !=
                     0) {
-              VLOG(2) << "\tSlice size mismatch.";
+              VLOG(2) << "\tSlice size mismatch. Skipping dynamic-slice "
+                         "instruction.";
               multiple_variable_indices = true;
               break;
             }
@@ -149,7 +150,8 @@ WhileLoopConvertPeeler::CollectConvertInfos(
                 dynamic_slice->slice_sizes(idx) != 1 ||
                 LiteralUtil::LiteralAsScalarInt64(idx_operand->literal()) !=
                     0) {
-              VLOG(2) << "\tSlice size mismatch.";
+              VLOG(2) << "\tSlice size mismatch. Skipping dynamic-slice "
+                         "instruction.";
               multiple_variable_indices = true;
               break;
             }
@@ -171,8 +173,8 @@ WhileLoopConvertPeeler::CollectConvertInfos(
             k_range->min().GetSignedValue() != 0 ||
             k_range->max()->GetSignedValue() + 1 !=
                 buffer->shape().dimensions(k)) {
-          VLOG(2) << "Skipping dynamic-slice instruction. Unable to identify "
-                     "the range of the variable index: "
+          VLOG(2) << "Skipping dynamic-slice instruction. The range of the "
+                     "variable index does not cover the full buffer: "
                   << instr->ToString();
           if (k_range.has_value()) {
             VLOG(2) << "Range: " << k_range->ToString();

--- a/xla/service/gpu/transforms/while_loop_convert_peeler.cc
+++ b/xla/service/gpu/transforms/while_loop_convert_peeler.cc
@@ -1,0 +1,444 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/while_loop_convert_peeler.h"
+#include "xla/hlo/analysis/while_loop_analysis.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_clone_context.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_query.h"
+#include "xla/literal_util.h"
+#include "xla/service/value_range.h"
+
+namespace xla::gpu {
+
+std::string WhileLoopConvertPeeler::BufferInfo::ToString(int indent) const {
+  std::stringstream ss;
+  ss << std::string(indent, ' ') << "BufferInfo {\n";
+  ss << std::string(indent + 2, ' ')
+     << "body_buffer: " << (body_buffer ? body_buffer->ToString() : "nullptr")
+     << "\n";
+  ss << std::string(indent + 2, ' ') << "body_convert: "
+     << (body_convert ? body_convert->ToString() : "nullptr") << "\n";
+  ss << std::string(indent + 2, ' ')
+     << "body_root: " << (body_root ? body_root->ToString() : "nullptr")
+     << "\n";
+  ss << std::string(indent + 2, ' ') << "dynamic_index_instruction: "
+     << (dynamic_index_instruction ? dynamic_index_instruction->ToString()
+                                   : "nullptr")
+     << "\n";
+  ss << std::string(indent + 2, ' ')
+     << "while_tuple_buffer_idx: " << while_tuple_buffer_idx << "\n";
+  ss << std::string(indent + 2, ' ') << "while_gte_user_after_loop: "
+     << (while_gte_user_after_loop ? while_gte_user_after_loop->ToString()
+                                   : "nullptr")
+     << "\n";
+  ss << std::string(indent, ' ') << "}";
+  return ss.str();
+}
+
+std::string WhileLoopConvertPeeler::ConvertInfo::ToString(int indent) const {
+  std::stringstream ss;
+  ss << std::string(indent, ' ') << "ConvertInfo {\n";
+  ss << std::string(indent + 2, ' ') << "buffer_infos: "
+     << absl::StrJoin(buffer_infos, ",",
+                      [indent](std::string* s, const BufferInfo& bufferInfo) {
+                        s->append(bufferInfo.ToString(indent + 2));
+                      })
+     << "\n";
+  ss << std::string(indent + 2, ' ')
+     << "new_while_shape: " << new_while_shape.ToString() << "\n";
+  ss << std::string(indent, ' ') << "}";
+  return ss.str();
+}
+
+WhileLoopConvertPeeler::ConvertInfoMap
+WhileLoopConvertPeeler::CollectConvertInfos(
+    HloModule* module,
+    absl::flat_hash_map<const HloInstruction*, Range>& known_ranges,
+    absl::flat_hash_set<HloInstruction*>& while_ops) {
+  ConvertInfoMap convert_infos;
+  for (HloInstruction* while_op : while_ops) {
+    // Find dynamic-slice instructions in the while body.
+    for (HloInstruction* instr : while_op->while_body()->instructions()) {
+      if (instr->opcode() == HloOpcode::kDynamicSlice) {
+        VLOG(2) << "Found dynamic-slice instruction: " << instr->ToString();
+        HloDynamicIndexInstruction* dynamic_slice =
+            Cast<HloDynamicIndexInstruction>(instr);
+
+        // The buffer for dynamic slice must be a get-tuple-element on the while
+        // parameter.
+        HloInstruction* buffer = dynamic_slice->mutable_operand(0);
+        if (buffer->opcode() != HloOpcode::kGetTupleElement) {
+          VLOG(2) << "Skipping dynamic-slice instruction. The buffer is not a "
+                     "get-tuple-element: "
+                  << instr->ToString();
+          continue;
+        }
+        if (buffer->operand(0)->opcode() != HloOpcode::kParameter) {
+          VLOG(2) << "Skipping dynamic-slice instruction. The buffer is not a "
+                     "get-tuple-element of a parameter: "
+                  << instr->ToString();
+          continue;
+        }
+
+        // The dynamic-slice operation must have exactly one variable index
+        // (lets call that index k).
+        bool multiple_variable_indices = false;
+        HloInstruction* dynamic_slice_index = nullptr;
+        int64_t k = -1;
+        VLOG(2) << "Buffer: " << buffer->ToString();
+        for (int idx = 0; idx < dynamic_slice->index_operands().size(); idx++) {
+          HloInstruction* idx_operand = dynamic_slice->index_operands()[idx];
+          VLOG(2) << "Processing index " << idx << " with operand "
+                  << idx_operand->ToString();
+          if (dynamic_slice_index == nullptr &&
+              idx_operand->opcode() != HloOpcode::kConstant) {
+            VLOG(2) << "\tDynamic index found.";
+            dynamic_slice_index = idx_operand;
+            k = idx;
+          } else if (dynamic_slice_index != nullptr &&
+                     idx_operand->opcode() != HloOpcode::kConstant) {
+            VLOG(2) << "\tMore than one variable index found.";
+            // We found more than one variable index.
+            multiple_variable_indices = true;
+            break;
+          } else if (dynamic_slice_index != nullptr &&
+                     idx_operand->opcode() == HloOpcode::kConstant) {
+            // all indices i>k, we should have that
+            // dimension_of_buffer[i]=slice_size[i] and offset[i]=0.
+            VLOG(2) << "\tConstant index i>k found.";
+            VLOG(2) << "\tSlice size: " << dynamic_slice->slice_sizes(idx);
+            VLOG(2) << "\tBuffer dim: " << buffer->shape().dimensions(idx);
+            VLOG(2) << "\tOffset: "
+                    << LiteralUtil::LiteralAsScalarInt64(idx_operand->literal())
+                           .value();
+            if (dynamic_slice->slice_sizes(/*dimension=*/idx) !=
+                    buffer->shape().dimensions(idx) ||
+                LiteralUtil::LiteralAsScalarInt64(idx_operand->literal()) !=
+                    0) {
+              VLOG(2) << "\tSlice size mismatch.";
+              multiple_variable_indices = true;
+              break;
+            }
+          } else if (dynamic_slice_index == nullptr &&
+                     idx_operand->opcode() == HloOpcode::kConstant) {
+            // For all indices i < k, we should have that
+            // dimension[i]=slice_size[i]=1 and offset[i]=0
+            VLOG(2) << "\tConstant index i<k found.";
+            VLOG(2) << "\tSlice size: " << dynamic_slice->slice_sizes(idx);
+            VLOG(2) << "\tBuffer dim: " << buffer->shape().dimensions(idx);
+            VLOG(2) << "\tOffset: "
+                    << LiteralUtil::LiteralAsScalarInt64(idx_operand->literal())
+                           .value();
+            if (dynamic_slice->slice_sizes(idx) !=
+                    buffer->shape().dimensions(idx) ||
+                dynamic_slice->slice_sizes(idx) != 1 ||
+                LiteralUtil::LiteralAsScalarInt64(idx_operand->literal()) !=
+                    0) {
+              VLOG(2) << "\tSlice size mismatch.";
+              multiple_variable_indices = true;
+              break;
+            }
+          }
+        }
+        if (multiple_variable_indices || dynamic_slice_index == nullptr) {
+          VLOG(2) << "Skipping dynamic-slice instruction with multiple "
+                     "variable indices or no variable index: "
+                  << instr->ToString();
+          continue;
+        }
+
+        // The variable index k must have the monotonic range [0, dimension[k])
+        // and each of those values must be taken once (step=1).
+        std::optional<Range> k_range =
+            RecursivelyIdentifyRange(dynamic_slice_index, known_ranges);
+        if (!k_range.has_value() || k_range->IsEmpty() ||
+            k_range->step()->GetSignedValue() != 1 || !k_range->IsLinear() ||
+            k_range->min().GetSignedValue() != 0 ||
+            k_range->max()->GetSignedValue() + 1 !=
+                buffer->shape().dimensions(k)) {
+          VLOG(2) << "Skipping dynamic-slice instruction. Unable to identify "
+                     "the range of the variable index: "
+                  << instr->ToString();
+          if (k_range.has_value()) {
+            VLOG(2) << "Range: " << k_range->ToString();
+            VLOG(2) << "Buffer dim: " << buffer->shape().dimensions(k);
+          }
+          continue;
+        }
+
+        // Pattern: dynamic-slice -> convert
+        if (dynamic_slice->user_count() > 1) {
+          VLOG(2) << "Skipping dynamic-slice instruction. The dynamic-slice "
+                     "has more than 1 user: "
+                  << instr->ToString();
+          continue;
+        }
+
+        if (buffer->user_count() != 2) {
+          VLOG(2) << "Skipping dynamic-slice instruction. The buffer must have "
+                     "exactly 2 users: "
+                  << buffer->ToString();
+          continue;
+        }
+
+        HloInstruction* convert_user = dynamic_slice->users()[0];
+        HloInstruction* root_user = nullptr;
+        root_user = buffer->users()[0]->opcode() == HloOpcode::kTuple
+                        ? buffer->users()[0]
+                        : buffer->users()[1];
+        VLOG(2) << "Root user: " << root_user->ToString();
+        VLOG(2) << "Convert user: " << convert_user->ToString();
+
+        if (root_user->opcode() != HloOpcode::kTuple ||
+            convert_user->opcode() != HloOpcode::kConvert ||
+            !root_user->IsRoot()) {
+          VLOG(2) << "Skipping dynamic-slice instruction. Expected a tuple "
+                     "(root with same index) and a convert user."
+                  << instr->ToString();
+          continue;
+        }
+
+        // Buffer index in input tuple should be same as index of buffer in root
+        // instruction
+        if (buffer->tuple_index() != root_user->operand_index(buffer)) {
+          VLOG(2)
+              << "Skipping dynamic-slice instruction. Buffer index in input "
+                 "tuple should be same as index of buffer in root instruction.";
+          VLOG(2) << "\tBuffer: " << buffer->ToString();
+          VLOG(2) << "\tRoot user: " << root_user->ToString();
+          continue;
+        }
+        convert_infos[while_op].buffer_infos.push_back(
+            {dynamic_slice, buffer, convert_user, root_user,
+             buffer->tuple_index(),
+             hlo_query::GetUniqueGteInstruction(while_op,
+                                                buffer->tuple_index())});
+      }
+    }
+  }
+  return convert_infos;
+}
+
+using Replacements =
+    absl::flat_hash_map<const HloInstruction*, std::unique_ptr<HloInstruction>>;
+
+absl::Status WhileLoopConvertPeeler::CreateTupleGetTupleElementForRoot(
+    HloInstruction* while_op, ConvertInfo& convert_info) {
+  TF_RET_CHECK(while_op->opcode() == HloOpcode::kWhile);
+  TF_RET_CHECK(while_op->IsRoot());
+
+  VLOG(2) << "Creating tuple(get-tuple-element(while_op)) for because while "
+             "operation is root operation : "
+          << while_op->ToString();
+
+  absl::InlinedVector<HloInstruction*, 4> tuple_elements(
+      while_op->shape().tuple_shapes_size());
+
+  absl::flat_hash_set<int64_t> while_tuple_buffer_idxs;
+  for (BufferInfo& buffer_info : convert_info.buffer_infos) {
+    while_tuple_buffer_idxs.insert(buffer_info.while_tuple_buffer_idx);
+  }
+  for (int idx = 0; idx < while_op->shape().tuple_shapes_size(); ++idx) {
+    HloInstruction* get_tuple_element =
+        while_tuple_buffer_idxs.contains(idx)
+            ? while_op->while_init()->mutable_operand(idx)
+            : while_op->AddInstruction(HloInstruction::CreateGetTupleElement(
+                  while_op->shape().tuple_shapes(idx), while_op, idx));
+    tuple_elements[idx] = get_tuple_element;
+  }
+  HloInstruction* tuple =
+      while_op->AddInstruction(HloInstruction::CreateTuple(tuple_elements));
+  while_op->parent()->set_root_instruction(tuple);
+  VLOG(2) << "After creating tuple(get-tuple-element(while_op)): "
+          << while_op->parent()->ToString(HloPrintOptions::ShortParsable());
+  return absl::OkStatus();
+}
+
+void WhileLoopConvertPeeler::DeduceNewWhileShape(HloInstruction* while_op,
+                                                 ConvertInfo& convert_info) {
+  VLOG(2) << "Deducing new while shape.";
+  std::vector<Shape> new_tuple_shapes = while_op->shape().tuple_shapes();
+  for (BufferInfo& buffer_info : convert_info.buffer_infos) {
+    new_tuple_shapes[buffer_info.while_tuple_buffer_idx] = ShapeUtil::MakeShape(
+        buffer_info.body_convert->shape().element_type(),
+        new_tuple_shapes[buffer_info.while_tuple_buffer_idx].dimensions());
+  }
+  Shape new_shape = ShapeUtil::MakeTupleShape(new_tuple_shapes);
+  convert_info.new_while_shape = new_shape;
+  VLOG(2) << "New while shape: " << new_shape.ToString();
+}
+
+void WhileLoopConvertPeeler::FixWhileBody(HloInstruction* while_op,
+                                          ConvertInfo& convert_info) {
+  VLOG(2) << "Fixing while body. Before fix: "
+          << while_op->while_body()->ToString(HloPrintOptions::ShortParsable());
+  HloComputation* while_body = while_op->while_body();
+  HloModule* module = while_body->parent();
+
+  while_body->ReplaceParameter(
+      0, HloInstruction::CreateParameter(0, convert_info.new_while_shape,
+                                         "updated_while_param"));
+
+  absl::flat_hash_map<const HloInstruction*, std::unique_ptr<HloInstruction>>
+      replacements;
+
+  absl::InlinedVector<HloInstruction*, 2> root_tuple_elements =
+      while_body->root_instruction()->operands();
+  for (BufferInfo& buffer_info : convert_info.buffer_infos) {
+    HloInstruction* body_buffer = buffer_info.body_buffer;
+    replacements[body_buffer] = HloInstruction::CreateGetTupleElement(
+        body_buffer->mutable_operand(0), body_buffer->tuple_index());
+    replacements[body_buffer]->SetAndSanitizeName(body_buffer->name());
+
+    HloDynamicIndexInstruction* dynamic_slice =
+        buffer_info.dynamic_index_instruction;
+    replacements[dynamic_slice] = HloInstruction::CreateDynamicSlice(
+        buffer_info.body_convert->shape(),
+        replacements[buffer_info.body_buffer].get(),
+        /*start_indices=*/dynamic_slice->index_operands(),
+        /*slice_sizes=*/dynamic_slice->dynamic_slice_sizes());
+    replacements[dynamic_slice]->SetAndSanitizeName(dynamic_slice->name());
+
+    root_tuple_elements[buffer_info.while_tuple_buffer_idx] =
+        replacements[body_buffer].get();
+  }
+  replacements[while_body->root_instruction()] =
+      HloInstruction::CreateTuple(root_tuple_elements);
+  replacements[while_body->root_instruction()]->SetAndSanitizeName(
+      while_body->root_instruction()->name());
+  HloComputation* new_body = module->AddComputationAndUnifyNamesAndIds(
+      while_body->CloneWithReplacements(&replacements), false);
+  while_op->parent()->parent()->ReplaceComputations({{while_body, new_body}});
+  VLOG(2) << "Fixing while body. After fix: "
+          << new_body->ToString(HloPrintOptions::ShortParsable());
+}
+
+void WhileLoopConvertPeeler::FixWhileCond(HloInstruction* while_op,
+                                          ConvertInfo& convert_info) {
+  VLOG(2) << "Fixing while cond. Before fix: "
+          << while_op->while_condition()->ToString(
+                 HloPrintOptions::ShortParsable());
+  HloComputation* while_cond = while_op->while_condition();
+  while_cond->ReplaceParameter(
+      0, HloInstruction::CreateParameter(0, convert_info.new_while_shape,
+                                         "updated_while_param"));
+  VLOG(2) << "Fixing while cond. After fix: "
+          << while_cond->ToString(HloPrintOptions::ShortParsable());
+}
+
+absl::Status WhileLoopConvertPeeler::FixWhileInit(HloInstruction* while_op,
+                                                  ConvertInfo& convert_info) {
+  VLOG(2) << "Fixing while init. Before fix: "
+          << while_op->parent()->ToString(HloPrintOptions::ShortParsable());
+  HloInstruction* while_init = while_op->while_init();
+  HloComputation* while_init_computation = while_init->parent();
+  HloModule* module = while_init_computation->parent();
+  absl::flat_hash_map<const HloInstruction*, std::unique_ptr<HloInstruction>>
+      replacements;
+
+  // Create the new init tuple.
+  absl::InlinedVector<HloInstruction*, 2> tuple_elements =
+      while_init->operands();
+  for (BufferInfo& buffer_info : convert_info.buffer_infos) {
+    HloInstruction* init_buffer =
+        while_init->mutable_operand(buffer_info.while_tuple_buffer_idx);
+    HloInstruction* convert =
+        while_op->AddInstruction(HloInstruction::CreateConvert(
+            ShapeUtil::MakeShape(
+                buffer_info.body_convert->shape().element_type(),
+                init_buffer->shape().dimensions()),
+            init_buffer));
+    tuple_elements[buffer_info.while_tuple_buffer_idx] = convert;
+  }
+  replacements[while_init] = HloInstruction::CreateTuple(tuple_elements);
+  replacements[while_init]->SetAndSanitizeName(while_init->name());
+
+  replacements[while_op] = HloInstruction::CreateWhile(
+      convert_info.new_while_shape, while_op->while_condition(),
+      while_op->while_body(), replacements[while_init].get());
+  replacements[while_op]->SetAndSanitizeName(while_op->name());
+
+  for (const BufferInfo& buffer_info : convert_info.buffer_infos) {
+    HloInstruction* gte = buffer_info.while_gte_user_after_loop;
+    if (gte != nullptr) {
+      TF_RETURN_IF_ERROR(while_init_computation->ReplaceInstruction(
+          gte,
+          while_init->mutable_operand(buffer_info.while_tuple_buffer_idx)));
+    }
+  }
+
+  HloComputation* new_init_computation =
+      module->AddComputationAndUnifyNamesAndIds(
+          while_init_computation->CloneWithReplacements(&replacements),
+          /*is_entry=*/false);
+  while_op->parent()->parent()->ReplaceComputations(
+      {{while_init_computation, new_init_computation}});
+  VLOG(2) << "Fixing while init. After fix: "
+          << new_init_computation->ToString(HloPrintOptions::ShortParsable());
+  return absl::OkStatus();
+}
+
+absl::StatusOr<bool> WhileLoopConvertPeeler::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  // Find while loops and get their induction variable ranges.
+  absl::flat_hash_map<const HloInstruction*, Range> known_ranges;
+  absl::flat_hash_set<HloInstruction*> while_ops;
+  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+    for (HloInstruction* instruction : computation->instructions()) {
+      if (instruction->opcode() == HloOpcode::kWhile) {
+        std::optional<Range> range = MatchTrivialLoopRange(instruction);
+        std::optional<int64_t> tuple_idx =
+            GetLoopInductionVarTupleIdx(instruction);
+        if (range.has_value() && tuple_idx.has_value()) {
+          HloInstruction* induction_var = hlo_query::GetUniqueGteInstruction(
+              instruction->while_body()->parameter_instruction(0),
+              tuple_idx.value());
+          known_ranges[induction_var] = range.value();
+          while_ops.insert(instruction);
+        }
+      }
+    }
+  }
+
+  ConvertInfoMap convert_infos =
+      CollectConvertInfos(module, known_ranges, while_ops);
+
+  if (convert_infos.empty()) {
+    return false;
+  }
+
+  // Preprocessing: adding the convert operation to while init, and removing
+  // while_op as root if it is the root.
+  for (auto& [while_op, convert_info] : convert_infos) {
+    VLOG(2) << "Processing while loop: " << while_op->ToString();
+    VLOG(2) << "Convert info: \n" << convert_info.ToString();
+    if (while_op->IsRoot()) {
+      TF_RETURN_IF_ERROR(
+          CreateTupleGetTupleElementForRoot(while_op, convert_info));
+    }
+    DeduceNewWhileShape(while_op, convert_info);
+    FixWhileBody(while_op, convert_info);
+    FixWhileCond(while_op, convert_info);
+    TF_RETURN_IF_ERROR(FixWhileInit(while_op, convert_info));
+  }
+
+  return true;
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/while_loop_convert_peeler.h
+++ b/xla/service/gpu/transforms/while_loop_convert_peeler.h
@@ -1,0 +1,177 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_WHILE_LOOP_CONVERT_PEEPER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_WHILE_LOOP_CONVERT_PEEPER_H_
+
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+#include "xla/service/value_range.h"
+namespace xla::gpu {
+
+/*
+
+While loop convert peeler optimization
+
+This pass peels off the convert instructions from the while loop body.
+
+We look for the following pattern in the while body:
+
+```
+data = f32[8, 1024] parameter(0)
+iter = 0
+while (iter < 8):
+  slice = f32[1, 1024] data[iter:iter+1, :]
+  convert = bf16[1, 1024] convert(slice)
+  ...
+  ROOT data
+```
+
+That is, the data is accessed in the while loop, one slice at a time. These
+slices cover the entire data buffer, and they are immediately converted to bf16
+inside the loop body. There are no other uses of the data buffer or the sliced
+operation, except the convert and the root instruction. In this case, we can
+peel the convert outside the while loop:
+
+```
+data = f32[8, 1024] parameter(0)
+converted_data = bf16[8, 1024] convert(data)
+iter = 0
+while (iter < 8):
+  slice = bf16[1, 1024] converted_data[iter:iter+1, :]
+  ...
+  ROOT data
+```
+
+This helps reduce the cost of slicing operations in the while loop.
+
+The conditions for peeling are:
+
+ 1. The dynamic-slice operation must have exactly one variable index (lets call
+that index k).
+
+ 2. The dynamic-slice operation must be a contiguous slice (i.e. for all indices
+i>k, we should have that dimension_of_buffer[i]=slice_size[i] and offset[i]=0.)
+
+ 3. The dynamic-slice operation must cover the entire buffer. This means that
+
+   3a. The variable index k must have the monotonic range [0, dimension[k]) and
+each of those values must be taken once (step=1).
+
+   3b. For all indices i < k, we should have that dimension[i]=slice_size[i]=1
+and offset[i]=0.
+
+ 4. Obviously, the pattern: dynamic-slice followed by a convert operation
+(allowing no-op reshapes).
+
+ 5. The buffer should be from the parameter, unmodified, and the buffer should
+go to the results, unmodified.
+
+ 6. There should be exactly two uses of the buffer inside the while loop:
+convert operation and the root instruction.
+
+If these conditions are met, then we can peel the convert outside the while
+loop:
+
+ 1. We change the while loop body/condition signature to accept the input of
+destination type (from the convert operation).
+
+ 2. We add the convert operation outside the while loop.
+
+ 3. Any user of the previous results of while operation are adjusted.
+
+*/
+
+class WhileLoopConvertPeeler : public HloModulePass {
+ private:
+  // Store metadata about a buffer, for which the convert has to be peeled off.
+  struct BufferInfo {
+    // The dynamic-slice instruction in the while body. Must be non-null.
+    HloDynamicIndexInstruction* dynamic_index_instruction = nullptr;
+    // The buffer of dynamic-slice instruction in the while body. Must be
+    // non-null.
+    HloInstruction* body_buffer = nullptr;
+    // The convert instruction inside while body whose operand is the result of
+    // dynamic-slice instruction. Must be non-null.
+    HloInstruction* body_convert = nullptr;
+    // The root instruction of the while body. Must be non-null.
+    HloInstruction* body_root = nullptr;
+    // The index of the buffer in the parameter tuple of the while instruction.
+    int64_t while_tuple_buffer_idx = -1;
+    // The get-tuple-element instruction that uses the buffer after the while
+    // loop. This could be nullptr, if the buffer is not used after the while
+    // loop.
+    HloInstruction* while_gte_user_after_loop = nullptr;
+
+    // For VLOG and debugging.
+    std::string ToString(int indent = 0) const;
+  };
+
+  // This struct stores the convert peeling information for a while operation.
+  // Each while operation can have multiple buffers that are eligible for
+  // convert peeling, hence it has a vector of `BufferInfos`.
+  struct ConvertInfo {
+    // List of buffer infos to peel the convert of.
+    absl::InlinedVector<BufferInfo, 4> buffer_infos;
+
+    // The new shape of the while operation after peeling the convert. This will
+    // be invalid shape, until the new shape is deduced.
+    Shape new_while_shape;
+
+    // For VLOG and debugging.
+    std::string ToString(int indent = 0) const;
+  };
+
+  // Map of while operation to its convert peeling information.
+  using ConvertInfoMap = absl::flat_hash_map<HloInstruction*, ConvertInfo>;
+
+  // When the while instruction is a root instruction to the computation, just
+  // peeling the convert will change the return datatype of the computation. To
+  // prevent this, we should set the root instruction to a tuple of
+  // get-tuple-elements over the results of while operation.
+  absl::Status CreateTupleGetTupleElementForRoot(HloInstruction* while_op,
+                                                 ConvertInfo& convert_info);
+
+  // Deduce the new shape of the while operation, based on convert info. This
+  // populates the field `new_while_shape`.
+  void DeduceNewWhileShape(HloInstruction* while_op, ConvertInfo& convert_info);
+
+  // Apply fixes to the while body, condition and init computation based on the
+  // convert infos.
+  void FixWhileBody(HloInstruction* while_op, ConvertInfo& convert_info);
+  void FixWhileCond(HloInstruction* while_op, ConvertInfo& convert_info);
+  absl::Status FixWhileInit(HloInstruction* while_op,
+                            ConvertInfo& convert_info);
+
+  // Collect the ConvertInfos. This is a analysis-only function, that does not
+  // modify the HLO.
+  ConvertInfoMap CollectConvertInfos(
+      HloModule* module,
+      absl::flat_hash_map<const HloInstruction*, Range>& known_ranges,
+      absl::flat_hash_set<HloInstruction*>& while_ops);
+
+ public:
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+  absl::string_view name() const override {
+    return "while-loop-convert-peeler";
+  }
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_WHILE_LOOP_CONVERT_PEEPER_H_

--- a/xla/service/gpu/transforms/while_loop_convert_peeler_test.cc
+++ b/xla/service/gpu/transforms/while_loop_convert_peeler_test.cc
@@ -1,0 +1,301 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/while_loop_convert_peeler.h"
+#include "gtest/gtest.h"
+#include "xla/hlo/testlib/pattern_matcher_gmock.h"
+#include "xla/hlo/utils/hlo_query.h"
+#include "xla/service/hlo_runner.h"
+#include "xla/service/platform_util.h"
+#include "xla/tests/hlo_runner_agnostic_test_base.h"
+#include "xla/tests/test_utils.h"
+#include "xla/service/pattern_matcher.h"
+
+namespace xla::gpu {
+
+namespace {
+
+namespace m = ::xla::match;
+
+class WhileLoopConvertPeelerTest : public HloRunnerAgnosticTestBase {
+ public:
+  WhileLoopConvertPeelerTest()
+      : HloRunnerAgnosticTestBase(std::make_unique<HloRunner>(
+            PlatformUtil::GetDefaultPlatform().value())) {}
+};
+
+TEST_F(WhileLoopConvertPeelerTest, DynamicSliceRootWhileOneBuffer) {
+  const std::string hlo = R"(
+  HloModule test
+  body {
+    param = (s32[], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    data = f32[8,8] get-tuple-element(param), index=1
+    bf16_data = bf16[1,8] get-tuple-element(param), index=2
+    c1 = s32[] constant(1)
+    iter_plus_one = s32[] add(iter, c1)
+    c0 = s32[] constant(0)
+    ds = f32[1,8] dynamic-slice(data, iter, c0), dynamic_slice_sizes={1,8}
+    convert = bf16[1,8] convert(ds)
+    add = bf16[1,8] add(convert, bf16_data)
+    ROOT tuple = (s32[], f32[8,8], bf16[1,8]) tuple(iter_plus_one, data, add)
+  }
+  condition {
+    param = (s32[], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    c8 = s32[] constant(8)
+    ROOT lt = pred[] compare(iter, c8), direction=LT
+  }
+  ENTRY main {
+    %c0 = s32[] constant(0)
+    %p0 = f32[8,8] parameter(0)
+    %p1 = bf16[1,8] parameter(1)
+    tuple = (s32[], f32[8,8], bf16[1,8]) tuple(c0, %p0, %p1)
+    ROOT while = (s32[], f32[8,8], bf16[1,8]) while(tuple), body=body, condition=condition
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConvertPeeler().Run(module.get(), {}));
+  EXPECT_TRUE(changed);
+  HloInstruction* while_op = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kWhile);
+
+  // If the convert is peeled, then the while operation type should change from
+  // f32[] to bf16[] at index 1.
+  EXPECT_EQ(while_op->shape().tuple_shapes(1),
+            ShapeUtil::MakeShape(BF16, {8, 8}));
+
+  // We also expect that the while operation is no longer the root, and that the
+  // root operation is a tuple of while results and the original buffer, without
+  // the convert operation.
+  HloInstruction* root = module->entry_computation()->root_instruction();
+  EXPECT_EQ(root->opcode(), HloOpcode::kTuple);
+  ASSERT_EQ(root->operand_count(), 3);
+  EXPECT_EQ(root->operand(0)->opcode(), HloOpcode::kGetTupleElement);
+  EXPECT_EQ(root->operand(1)->opcode(), HloOpcode::kParameter);
+  EXPECT_EQ(root->operand(2)->opcode(), HloOpcode::kGetTupleElement);
+
+  // The while operation should ingest the converted buffer at index 1.
+  const HloInstruction* possible_convert = while_op->while_init()->operand(1);
+  EXPECT_EQ(possible_convert->opcode(), HloOpcode::kConvert);
+  EXPECT_EQ(possible_convert->operand(0),
+            module->entry_computation()->parameter_instruction(0));
+
+  // The changes in while body and condition should be verified by the verifier.
+  TF_CHECK_OK(VerifyHloModule(module.get(), true, false));
+
+  EXPECT_TRUE(
+      RunAndCompareTwoModules(module->ToString(), hlo, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(WhileLoopConvertPeelerTest, DynamicSliceRootWhileTwoBuffers) {
+  const std::string hlo = R"(
+  HloModule test
+  body {
+    param = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    data = f32[8,8] get-tuple-element(param), index=1
+    bf16_data = bf16[1,8] get-tuple-element(param), index=2
+    data2 = f32[8,8] get-tuple-element(param), index=3
+    bf16_data2 = bf16[1,8] get-tuple-element(param), index=4
+    c1 = s32[] constant(1)
+    iter_plus_one = s32[] add(iter, c1)
+    c0 = s32[] constant(0)
+    ds = f32[1,8] dynamic-slice(data, iter, c0), dynamic_slice_sizes={1,8}
+    ds2 = f32[1,8] dynamic-slice(data2, iter, c0), dynamic_slice_sizes={1,8}
+    convert = bf16[1,8] convert(ds)
+    convert2 = bf16[1,8] convert(ds2)
+    add = bf16[1,8] add(convert, bf16_data)
+    add2 = bf16[1,8] add(convert2, bf16_data2)
+    ROOT tuple = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) tuple(iter_plus_one, data, add, data2, add2)
+  }
+  condition {
+    param = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    c8 = s32[] constant(8)
+    ROOT lt = pred[] compare(iter, c8), direction=LT
+  }
+  ENTRY main {
+    %c0 = s32[] constant(0)
+    %p0 = f32[8,8] parameter(0)
+    %p1 = bf16[1,8] parameter(1)
+    %p2 = f32[8,8] parameter(2)
+    %p3 = bf16[1,8] parameter(3)
+    tuple = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) tuple(c0, %p0, %p1, %p2, %p3)
+    ROOT while = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) while(tuple), body=body, condition=condition
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConvertPeeler().Run(module.get(), {}));
+  EXPECT_TRUE(changed);
+
+  // Verify the general structure:
+  //  * root is a tuple of gte from while output, and the original buffers.
+  //  * while operation is accepting the original buffers and the converted
+  //  buffers.
+  //  * the converted buffers are at index 1 and 3 of the while operation.
+  auto while_op_matcher = m::While(
+      m::Tuple(m::Constant(), m::Convert(m::Parameter(0)), m::Parameter(1),
+               m::Convert(m::Parameter(2)), m::Parameter(3)));
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      GmockMatch(m::Tuple(m::GetTupleElement(while_op_matcher), m::Parameter(0),
+                          m::GetTupleElement(while_op_matcher), m::Parameter(2),
+                          m::GetTupleElement(while_op_matcher))));
+
+  // Verify the type of the converted buffers.
+  HloInstruction* while_op = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kWhile);
+  ASSERT_NE(while_op, nullptr);
+  EXPECT_EQ(while_op->shape().tuple_shapes(1),
+            ShapeUtil::MakeShape(BF16, {8, 8}));
+  EXPECT_EQ(while_op->shape().tuple_shapes(3),
+            ShapeUtil::MakeShape(BF16, {8, 8}));
+
+  // The rest of the verification is done by the verifier.
+  TF_CHECK_OK(VerifyHloModule(module.get(), true, false));
+  EXPECT_TRUE(
+      RunAndCompareTwoModules(module->ToString(), hlo, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(WhileLoopConvertPeelerTest, DynamicSliceNonRootWhileOneBuffer) {
+  const char* hlo = R"(  HloModule test
+  body {
+    param = (s32[], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    data = f32[8,8] get-tuple-element(param), index=1
+    bf16_data = bf16[1,8] get-tuple-element(param), index=2
+    c1 = s32[] constant(1)
+    iter_plus_one = s32[] add(iter, c1)
+    c0 = s32[] constant(0)
+    ds = f32[1,8] dynamic-slice(data, iter, c0), dynamic_slice_sizes={1,8}
+    convert = bf16[1,8] convert(ds)
+    add = bf16[1,8] add(convert, bf16_data)
+    ROOT tuple = (s32[], f32[8,8], bf16[1,8]) tuple(iter_plus_one, data, add)
+  }
+  condition {
+    param = (s32[], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    c8 = s32[] constant(8)
+    ROOT lt = pred[] compare(iter, c8), direction=LT
+  }
+  ENTRY main {
+    %c0 = s32[] constant(0)
+    %p0 = f32[8,8] parameter(0)
+    %p1 = bf16[1,8] parameter(1)
+    tuple = (s32[], f32[8,8], bf16[1,8]) tuple(c0, %p0, %p1)
+    while = (s32[], f32[8,8], bf16[1,8]) while(tuple), body=body, condition=condition
+    ROOT res = bf16[1,8] get-tuple-element(while), index=2
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConvertPeeler().Run(module.get(), {}));
+  EXPECT_TRUE(changed);
+
+  auto while_op_matcher = m::While(
+      m::Tuple(m::Constant(), m::Convert(m::Parameter(0)), m::Parameter(1)));
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::GetTupleElement(while_op_matcher)));
+
+  // Verify the type of the converted buffer.
+  HloInstruction* while_op = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kWhile);
+  ASSERT_NE(while_op, nullptr);
+  EXPECT_EQ(while_op->shape().tuple_shapes(1),
+            ShapeUtil::MakeShape(BF16, {8, 8}));
+
+  // The rest of the verification is done by the verifier.
+  TF_CHECK_OK(VerifyHloModule(module.get(), true, false));
+  EXPECT_TRUE(
+      RunAndCompareTwoModules(module->ToString(), hlo, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(WhileLoopConvertPeelerTest, DynamicSliceNonRootWhileTwoBuffers) {
+  const char* hlo = R"(HloModule test
+  body {
+    param = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    data = f32[8,8] get-tuple-element(param), index=1
+    bf16_data = bf16[1,8] get-tuple-element(param), index=2
+    data2 = f32[8,8] get-tuple-element(param), index=3
+    bf16_data2 = bf16[1,8] get-tuple-element(param), index=4
+    c1 = s32[] constant(1)
+    iter_plus_one = s32[] add(iter, c1)
+    c0 = s32[] constant(0)
+    ds = f32[1,8] dynamic-slice(data, iter, c0), dynamic_slice_sizes={1,8}
+    ds2 = f32[1,8] dynamic-slice(data2, iter, c0), dynamic_slice_sizes={1,8}
+    convert = bf16[1,8] convert(ds)
+    convert2 = bf16[1,8] convert(ds2)
+    add = bf16[1,8] add(convert, bf16_data)
+    add2 = bf16[1,8] add(convert2, bf16_data2)
+    ROOT tuple = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) tuple(iter_plus_one, data, add, data2, add2)
+  }
+  condition {
+    param = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) parameter(0)
+    iter = s32[] get-tuple-element(param), index=0
+    c8 = s32[] constant(8)
+    ROOT lt = pred[] compare(iter, c8), direction=LT
+  }
+  ENTRY main {
+    %c0 = s32[] constant(0)
+    %p0 = f32[8,8] parameter(0)
+    %p1 = bf16[1,8] parameter(1)
+    %p2 = f32[8,8] parameter(2)
+    %p3 = bf16[1,8] parameter(3)
+    tuple_init = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) tuple(c0, %p0, %p1, %p2, %p3)
+    while = (s32[], f32[8,8], bf16[1,8], f32[8,8], bf16[1,8]) while(tuple_init), body=body, condition=condition
+    gte0 = s32[] get-tuple-element(while), index=0
+    gte1 = f32[8,8] get-tuple-element(while), index=1
+    gte2 = bf16[1,8] get-tuple-element(while), index=2
+    gte3 = f32[8,8] get-tuple-element(while), index=3
+    gte4 = bf16[1,8] get-tuple-element(while), index=4
+    add1 = f32[8,8] add(gte1, gte3)
+    add2 = bf16[1,8] add(gte2, gte4)
+    ROOT tuple_res = (f32[8,8], bf16[1,8]) tuple(add1, add2)
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConvertPeeler().Run(module.get(), {}));
+  EXPECT_TRUE(changed);
+
+  auto while_op_matcher = m::While(
+      m::Tuple(m::Constant(), m::Convert(m::Parameter(0)), m::Parameter(1),
+               m::Convert(m::Parameter(2)), m::Parameter(3)));
+  HloInstruction* while_op = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kWhile);
+  ASSERT_NE(while_op, nullptr);
+  EXPECT_EQ(while_op->shape().tuple_shapes(1),
+            ShapeUtil::MakeShape(BF16, {8, 8}));
+  EXPECT_EQ(while_op->shape().tuple_shapes(3),
+            ShapeUtil::MakeShape(BF16, {8, 8}));
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      GmockMatch(m::Tuple(m::Add(m::Parameter(0), m::Parameter(2)),
+                          m::Add(m::GetTupleElement(while_op_matcher),
+                                 m::GetTupleElement(while_op_matcher)))));
+
+  // The rest of the verification is done by the verifier.
+  TF_CHECK_OK(VerifyHloModule(module.get(), true, false));
+  EXPECT_TRUE(
+      RunAndCompareTwoModules(module->ToString(), hlo, ErrorSpec{1e-5, 1e-5}));
+}
+
+}  // namespace
+
+}  // namespace xla::gpu


### PR DESCRIPTION
This patch adds convert peeling optimization. If the while loop access a buffer, one slice at a time, and converts it inside the while body, then there is a scope for this optimization.

The conditions are:

 * The dynamic-slice operation must have exactly one variable index (lets call that index k).
 * The dynamic-slice operation must be a contiguous slice (i.e. for all indices i>k, we should have that dimension_of_buffer[i]=slice_size[i] and offset[i]=0.)
 * The dynamic-slice operation must cover the entire buffer. This means that
   * The variable index k must have the monotonic range [0, dimension[k]) and each of those values must be taken once (step=1).
   * For all indices i < k, we should have that dimension[i]=slice_size[i]=1 and offset[i]=0.
 * Obviously, the pattern: dynamic-slice followed by a convert operation (allowing no-op reshapes).
 * The buffer should be from the parameter, unmodified, and the buffer should go to the results, unmodified.
 * There should be exactly two uses of the buffer inside the while loop: convert operation and the root instruction.

If these conditions are met, then we can peel the convert outside the while loop:
 * We change the while loop body/condition signature to accept the input of destination type (from the convert operation).
 * We add the convert operation outside the while loop.
 * Any user of the previous results of while operation are adjusted.