### PR TITLE
Remove std::move for trivially copyable types

### DIFF
--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -318,11 +318,11 @@ std::optional<ParamIndexAndValue> TryParsingInstructionAsParameterAndInteger(
   }
   std::optional<DynamicOrStaticInteger> integer_value =
       GetInstructionValueAsInteger(instruction, precomputed_analyses);
-  result.value = std::move(integer_value);
+  result.value = integer_value;
   if (!result.IsValid()) {
     return std::nullopt;
   }
-  return std::optional<ParamIndexAndValue>(std::move(result));
+  return result;
 }
 
 // Represents the while loop condition comparison.
@@ -377,8 +377,7 @@ std::optional<WhileCondComparisonOrNoOp> PatternMatchLoopCondComparison(
   if (!lhs.has_value() || !rhs.has_value()) {
     return std::nullopt;
   }
-  return WhileCondComparison{comparison->comparison_direction(),
-                             *std::move(lhs), *std::move(rhs)};
+  return WhileCondComparison{comparison->comparison_direction(), *lhs, *rhs};
 }
 // Finds the while loop condition comparison by matching the loop condition root
 // with known patterns.
@@ -1707,7 +1706,7 @@ absl::Status HloEvaluator::HandleTuple(const HloInstruction* tuple) {
     CHECK(new_result.IsDetermined(visitor_shape_index_));
     Literal literal;
     TF_RETURN_IF_ERROR(
-        literal.CopyFrom(std::move(new_result),
+        literal.CopyFrom(new_result,
                          /*dest_shape_index=*/visitor_shape_index_,
                          /*src_shape_index=*/visitor_shape_index_));
     SetEvaluatedLiteralFor(tuple, std::move(literal));

--- a/xla/stream_executor/kernel.h
+++ b/xla/stream_executor/kernel.h
@@ -220,9 +220,7 @@ class Kernel {
       ThreadDim threads, size_t dynamic_shared_memory_bytes) const = 0;
 
   const KernelMetadata &metadata() const { return metadata_; }
-  void set_metadata(KernelMetadata metadata) {
-    metadata_ = std::move(metadata);
-  }
+  void set_metadata(KernelMetadata metadata) { metadata_ = metadata; }
 
   const KernelArgsPacking &args_packing() const { return args_packing_; }
   void set_args_packing(KernelArgsPacking args_packing) {


### PR DESCRIPTION
Changes:
- Removed unnecessary std::move calls for some trivially_copyable classes
- Literal::CopyFrom expects a reference (&), not an r-value reference (&&). Removed std::move on the first parameter.
