### PR TITLE
[XlA:GPU] Fix GpuCommandBuffer NotifyExecDestroyed assert failure

### DIFF
--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -717,9 +717,9 @@ std::unique_ptr<ScopedUpdateMode> CudaCommandBuffer::ActivateUpdateMode(
 
 CudaCommandBuffer::~CudaCommandBuffer() {
   if (exec_ != nullptr && is_owned_graph_exec_) {
+    auto exec_num = NotifyExecDestroyed();
     VLOG(5) << "Destroy GPU command buffer executable graph " << exec_ << " "
-            << "(remaining alive executable graphs: " << NotifyExecDestroyed()
-            << ")";
+            << "(remaining alive executable graphs: " << exec_num << ")";
     if (auto status = cuda::ToStatus(cuGraphExecDestroy(exec_),
                                      "Failed to destroy CUDA executable graph");
         !status.ok()) {

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -808,8 +808,8 @@ absl::Status GpuCommandBuffer::Finalize() {
     uint64_t end_nanos = tsl::Env::Default()->NowNanos();
 
     auto exec_num = NotifyExecCreated();
-    VLOG(5) << "Instantiated executable graph #" << exec_num
-            << " in " << (end_nanos - start_nanos) / 1000 << " μs"
+    VLOG(5) << "Instantiated executable graph #" << exec_num << " in "
+            << (end_nanos - start_nanos) / 1000 << " μs"
             << "; execution_scopes: " << execution_scopes_.size()
             << "; nodes: " << num_nodes
             << "; conditionals: " << num_cond_cmd_buffers

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -807,7 +807,8 @@ absl::Status GpuCommandBuffer::Finalize() {
 
     uint64_t end_nanos = tsl::Env::Default()->NowNanos();
 
-    VLOG(5) << "Instantiated executable graph #" << NotifyExecCreated()
+    auto exec_num = NotifyExecCreated();
+    VLOG(5) << "Instantiated executable graph #" << exec_num
             << " in " << (end_nanos - start_nanos) / 1000 << " μs"
             << "; execution_scopes: " << execution_scopes_.size()
             << "; nodes: " << num_nodes

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -468,9 +468,9 @@ std::unique_ptr<ScopedUpdateMode> RocmCommandBuffer::ActivateUpdateMode(
 
 RocmCommandBuffer::~RocmCommandBuffer() {
   if (exec_ != nullptr && is_owned_graph_exec_) {
+    auto exec_num = NotifyExecDestroyed();
     VLOG(5) << "Destroy GPU command buffer executable graph " << exec_ << " "
-            << "(remaining alive executable graphs: " << NotifyExecDestroyed()
-            << ")";
+            << "(remaining alive executable graphs: " << exec_num << ")";
     if (auto status = ToStatus(hipGraphExecDestroy(exec_),
                                "Failed to destroy HIP executable graph");
         !status.ok()) {


### PR DESCRIPTION
This PR fixes the NotifyExecDestroy assertion failure, due to NotifyExecCreate is not called due to not enabling VLOG dump for the matching file.