### PR TITLE
[GPU] Fix missing cuDNN symbols.

### DIFF
--- a/xla/tsl/cuda/cudnn.symbols
+++ b/xla/tsl/cuda/cudnn.symbols
@@ -10,7 +10,9 @@ cudnnBackendExecute
 cudnnBackendFinalize
 cudnnBackendGetAttribute
 cudnnBackendInitialize
+cudnnBackendPopulateCudaGraph
 cudnnBackendSetAttribute
+cudnnBackendUpdateCudaGraph
 cudnnBatchNormalizationBackward
 cudnnBatchNormalizationBackwardEx
 cudnnBatchNormalizationForwardInference


### PR DESCRIPTION
This fixes JAX builds with cuDNN 9.5.0+ after https://github.com/openxla/xla/commit/65b4b8874b659d7f11523f7b1d6df1613cfc8984.