### PR TITLE
[XLA:GPU] fix case command buffer operator data corruption issue when index is bool type

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -929,6 +929,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "4D shape, the computation will run 2! * 4! times for every possible "
       "layouts"));
   flag_list->push_back(tsl::Flag(
+      "xla_test_add_command_buffer_mode",
+      bool_setter_for(&DebugOptions::set_xla_test_add_command_buffer_mode),
+      debug_options->xla_test_add_command_buffer_mode(),
+      "If true, the test launched with ClientLibraryTestBase will use command "
+      "buffer to execute the computation."));
+  flag_list->push_back(tsl::Flag(
       "xla_hlo_profile", bool_setter_for(&DebugOptions::set_xla_hlo_profile),
       debug_options->xla_hlo_profile(),
       "Instrument the computation to collect per-HLO cycle counts"));

--- a/xla/tests/client_library_test_base.h
+++ b/xla/tests/client_library_test_base.h
@@ -427,6 +427,12 @@ class ClientLibraryTestBase : public ::testing::Test {
           verify_output,
       const Shape* output_with_layout = nullptr);
 
+  absl::Status ComputeAndCompareLiteralWithCmdBuffer(
+      const xla::XlaComputation& computation, const Literal& expected,
+      absl::Span<GlobalData* const> arguments,
+      const std::function<void(const Literal& actual,
+                               const std::string& error_message)>&
+          verify_output);
   // Converts an f32 shape to test_type_.
   Shape MaybeConvertShapeToTestType(const Shape& shape);
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1168,9 +1168,13 @@ message DebugOptions {
   // its use indicates an error in test setup.
   bool xla_allow_get_default_platform = 371;
 
+  // If true, the test launched with ClientLibraryTestBase will also try to
+  // use command buffer mode to run.
+  bool xla_test_add_command_buffer_mode = 373;
+
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
-  // Next id: 373
+  // Next id: 374
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
XLA mis-interprets that the first branch in conditional_thunk's branch vector is true branch, while the 2nd branch is false branch. 

