### PR TITLE
Annotate loops: start, step, induction variable.

### DIFF
--- a/xla/hlo/transforms/while_loop_trip_count_annotator.cc
+++ b/xla/hlo/transforms/while_loop_trip_count_annotator.cc
@@ -37,9 +37,34 @@ absl::StatusOr<bool> WhileLoopTripCountAnnotator::Run(
       if (instr->opcode() != HloOpcode::kWhile) {
         continue;
       }
-      if (auto trip_count = ComputeWhileLoopTripCount(instr)) {
+
+      if (auto induction_variable_index = GetLoopInductionVarTupleIdx(instr)) {
+        // The following analyses all need the induction variable index.
         WhileLoopBackendConfig config;
-        config.mutable_known_trip_count()->set_n(*trip_count);
+
+        config.mutable_known_induction_variable()->set_tuple_index(
+            *induction_variable_index);
+        if (auto range = MatchTrivialLoopRange(instr);
+            range.has_value() && range->IsBounded() && range->IsStepKnown() &&
+            // We store the values in signed integers, so we need to verify
+            // they fit.
+            range->max()->GetSignedValue() >= 0 &&
+            range->min().GetSignedValue() >= 0 &&
+            range->step()->GetSignedValue() > 0) {
+          int64_t max = range->max()->GetUnsignedValue();
+          int64_t min = range->min().GetUnsignedValue();
+          int64_t step = range->step()->GetSignedValue();
+          int64_t trip_count = (max - min) / step + 1;
+
+          config.mutable_known_trip_count()->set_n(trip_count);
+          config.mutable_known_init_step()->set_init(min);
+          config.mutable_known_init_step()->set_step(step);
+        } else if (auto trip_count = ComputeWhileLoopTripCount(instr)) {
+          // If this is not a trivial loop, it might still be possible to brute
+          // force the trip count.
+          config.mutable_known_trip_count()->set_n(*trip_count);
+        }
+
         TF_RETURN_IF_ERROR(instr->set_backend_config(config));
         changed = true;
       }

--- a/xla/hlo/transforms/while_loop_trip_count_annotator_test.cc
+++ b/xla/hlo/transforms/while_loop_trip_count_annotator_test.cc
@@ -59,7 +59,12 @@ TEST_F(TripCountAnnotatorTest, KnownSmallTripCount) {
                           m->entry_computation()
                               ->root_instruction()
                               ->backend_config<WhileLoopBackendConfig>());
-  EXPECT_EQ(10, config.known_trip_count().n());
+  EXPECT_TRUE(config.has_known_induction_variable());
+  EXPECT_TRUE(config.has_known_init_step());
+  EXPECT_EQ(config.known_trip_count().n(), 10);
+  EXPECT_EQ(config.known_induction_variable().tuple_index(), 0);
+  EXPECT_EQ(config.known_init_step().init(), 0);
+  EXPECT_EQ(config.known_init_step().step(), 1);
 }
 
 TEST_F(TripCountAnnotatorTest, KnownLargeTripCount) {
@@ -95,25 +100,25 @@ TEST_F(TripCountAnnotatorTest, KnownLargeTripCount) {
                           m->entry_computation()
                               ->root_instruction()
                               ->backend_config<WhileLoopBackendConfig>());
-  EXPECT_EQ(1000000, config.known_trip_count().n());
+  EXPECT_EQ(config.known_trip_count().n(), 1000000);
 }
 
-TEST_F(TripCountAnnotatorTest, NonzeroStart) {
+TEST_F(TripCountAnnotatorTest, NonzeroStartStep) {
   const char* kModuleStr = R"(
     HloModule test
     Body {
       param = (s32[]) parameter(0)
       i = s32[] get-tuple-element(param), index=0
-      one = s32[] constant(1)
-      i_plus_one = s32[] add(i, one)
-      ROOT tuple = (s32[]) tuple(i_plus_one)
+      two = s32[] constant(2)
+      i_plus_two = s32[] add(i, two)
+      ROOT tuple = (s32[]) tuple(i_plus_two)
     }
 
     Cond {
       param = (s32[]) parameter(0)
       i = s32[] get-tuple-element(param), index=0
-      trip_count = s32[] constant(1000000)
-      ROOT done = pred[] compare(i, trip_count), direction=LT
+      max_i = s32[] constant(1000000)
+      ROOT done = pred[] compare(i, max_i), direction=LT
     }
 
     ENTRY test {
@@ -131,7 +136,10 @@ TEST_F(TripCountAnnotatorTest, NonzeroStart) {
                           m->entry_computation()
                               ->root_instruction()
                               ->backend_config<WhileLoopBackendConfig>());
-  EXPECT_EQ(999990, config.known_trip_count().n());
+  EXPECT_EQ(config.known_trip_count().n(), 499995);
+  EXPECT_TRUE(config.has_known_init_step());
+  EXPECT_EQ(config.known_init_step().init(), 10);
+  EXPECT_EQ(config.known_init_step().step(), 2);  
 }
 
 TEST_F(TripCountAnnotatorTest, LessThanOrEqualTo) {
@@ -167,7 +175,7 @@ TEST_F(TripCountAnnotatorTest, LessThanOrEqualTo) {
                           m->entry_computation()
                               ->root_instruction()
                               ->backend_config<WhileLoopBackendConfig>());
-  EXPECT_EQ(999991, config.known_trip_count().n());
+  EXPECT_EQ(config.known_trip_count().n(), 999991);
 }
 
 TEST_F(TripCountAnnotatorTest, Int64Overflow) {
@@ -200,7 +208,52 @@ TEST_F(TripCountAnnotatorTest, Int64Overflow) {
   TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
   WhileLoopTripCountAnnotator pass;
   TF_ASSERT_OK_AND_ASSIGN(bool changed, RunHloPass(&pass, m.get()));
-  EXPECT_FALSE(changed);
+  EXPECT_TRUE(changed);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto config,
+                          m->entry_computation()
+                              ->root_instruction()
+                              ->backend_config<WhileLoopBackendConfig>());
+  EXPECT_FALSE(config.has_known_trip_count());
+  EXPECT_FALSE(config.has_known_init_step());
+  EXPECT_TRUE(config.has_known_induction_variable());
+  EXPECT_EQ(config.known_induction_variable().tuple_index(), 0);
+}
+
+TEST_F(TripCountAnnotatorTest, NonZeroTupleIndex) {
+  const char* kModuleStr = R"(
+    HloModule test
+    Body {
+      param = (s32[], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=1
+      one = s32[] constant(1)
+      i_plus_one = s32[] add(i, one)
+      ROOT tuple = (s32[], s32[]) tuple(one, i_plus_one)
+    }
+
+    Cond {
+      param = (s32[], s32[]) parameter(0)
+      i = s32[] get-tuple-element(param), index=1
+      trip_count = s32[] constant(10)
+      ROOT done = pred[] compare(i, trip_count), direction=LT
+    }
+
+    ENTRY test {
+      i_start = s32[] constant(0)
+      initial_tuple = (s32[], s32[]) tuple(i_start, i_start)
+      ROOT while = (s32[], s32[]) while(initial_tuple), condition=Cond, body=Body
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  WhileLoopTripCountAnnotator pass;
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunHloPass(&pass, m.get()));
+  ASSERT_TRUE(changed);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto config,
+                          m->entry_computation()
+                              ->root_instruction()
+                              ->backend_config<WhileLoopBackendConfig>());
+  EXPECT_EQ(config.known_induction_variable().tuple_index(), 1);
 }
 
 }  // namespace

--- a/xla/xla_data.proto
+++ b/xla/xla_data.proto
@@ -1144,12 +1144,30 @@ message ParameterReplication {
 // whereas implementing a `while` loop requires a host-device sync on each
 // iteration.
 message WhileLoopBackendConfig {
+  message KnownInitStep {
+    int64 init = 1;
+    int64 step = 2;
+  }
+
   message KnownTripCount {
     int64 n = 1;
   }
+
+  message KnownInductionVariable {
+    int64 tuple_index = 1;
+  }
+
   // This indirection lets us distinguish between known-trip-count == 0 and
   // unknown-trip-count.
   KnownTripCount known_trip_count = 1;
+
+  // Independently from the known trip count, we may also know the start and
+  // step of the induction variable.
+  KnownInitStep known_init_step = 2;
+
+  // This lets us distinguish between an unknown induction variable (or none)
+  // and tuple index 0.
+  KnownInductionVariable known_induction_variable = 3;
 }
 
 // Specifies a pair of output/operand buffers that alias each other for


### PR DESCRIPTION
Currently, we annotate while loops with a known trip count accordingly. This PR adds the start, step and induction variable so it's easy to see when a while loop is actually a for loop.

For the larger context see
https://github.com/openxla/xla/compare/main...jreiffers:xla:memcpy and the companion document
https://docs.google.com/document/d/1E2_Jt_Dw4VbPXPVktNWhtsDEtIpN-kurCMGGyvMV4JA/edit?tab=t.0.