### PR TITLE
Add while iteration index API for HLOs.

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1232,6 +1232,30 @@ cc_library(
     ],
 )
 
+xla_test(
+    name = "while_thunk_test",
+    srcs = ["while_thunk_test.cc"],
+    backends = ["gpu"],
+    deps = [
+        ":thunk",
+        ":while_thunk",
+        "//xla:executable_run_options",
+        "//xla/service:executable",
+        "//xla/service:platform_util",
+        "//xla/service/gpu:buffer_allocations",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_memory_allocator",
+        "//xla/tests:hlo_test_base",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:status_matchers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
 cc_library(
     name = "wait_for_streams_thunk",
     srcs = ["wait_for_streams_thunk.cc"],

--- a/xla/backends/gpu/runtime/for_all_thunks_test.cc
+++ b/xla/backends/gpu/runtime/for_all_thunks_test.cc
@@ -126,7 +126,7 @@ TEST(ForAllThunksTest, WhileThunk) {
   body_thunk_sequence.push_back(std::move(body_thunk));
 
   WhileThunk while_thunk(
-      Thunk::ThunkInfo(), BufferAllocation::Slice(),
+      Thunk::ThunkInfo(), /*loop=*/nullptr, BufferAllocation::Slice(),
       std::make_unique<SequentialThunk>(Thunk::ThunkInfo(),
                                         std::move(condition_thunk_sequence)),
       std::make_unique<SequentialThunk>(Thunk::ThunkInfo(),

--- a/xla/backends/gpu/runtime/while_thunk.h
+++ b/xla/backends/gpu/runtime/while_thunk.h
@@ -53,7 +53,7 @@ namespace gpu {
 class WhileThunk : public Thunk {
  public:
   // Constructs a WhileThunk to compute while instruction 'hlo'.
-  WhileThunk(ThunkInfo thunk_info,
+  WhileThunk(ThunkInfo thunk_info, const HloInstruction* loop,
              const BufferAllocation::Slice& condition_result_buffer_index,
              std::unique_ptr<SequentialThunk> condition_thunk_sequence,
              std::unique_ptr<SequentialThunk> body_thunk_sequence,
@@ -83,10 +83,15 @@ class WhileThunk : public Thunk {
   // Implementation relies on thread local storage, be careful when call it from
   // code running on multiple threads.
   static absl::StatusOr<int64_t> CurrentLoopIteration(int64_t depth = 0);
+  static absl::StatusOr<int64_t> CurrentLoopIteration(
+      const HloInstruction* while_instr);
 
   void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const override;
 
+  std::string ToString(int indent) const override;
+
  private:
+  const HloInstruction* loop_;
   const BufferAllocation::Slice condition_result_buffer_index_;
   std::unique_ptr<SequentialThunk> condition_thunk_sequence_;
   std::unique_ptr<SequentialThunk> body_thunk_sequence_;

--- a/xla/backends/gpu/runtime/while_thunk_test.cc
+++ b/xla/backends/gpu/runtime/while_thunk_test.cc
@@ -1,0 +1,198 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/while_thunk.h"
+
+#include <optional>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/status/statusor.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/executable_run_options.h"
+#include "xla/service/platform_util.h"
+#include "xla/service/service_executable_run_options.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor_memory_allocator.h"
+#include "xla/tests/hlo_test_base.h"
+#include "tsl/platform/status_matchers.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::testing::ElementsAre;
+using ::tsl::testing::IsOk;
+
+class IterationLoggerThunk : public Thunk {
+ public:
+  explicit IterationLoggerThunk(const HloInstruction* loop)
+      : Thunk(Thunk::Kind::kKernel, Thunk::ThunkInfo()), loop_(loop) {}
+
+  absl::Status ExecuteOnStream(const ExecuteParams& params) override {
+    auto iter = WhileThunk::CurrentLoopIteration(loop_);
+    if (iter.ok()) {
+      iteration_counters_.push_back(*iter);
+    } else {
+      iteration_counters_.push_back(std::nullopt);
+    }
+    return absl::OkStatus();
+  }
+
+  const std::vector<std::optional<int64_t>>& logged_counters() const {
+    return iteration_counters_;
+  }
+
+ private:
+  const HloInstruction* loop_;
+  std::vector<std::optional<int64_t>> iteration_counters_;
+};
+
+// Non-known trip count while thunks are difficult to unit test, so we only have
+// a unit test for the known trip count case.
+class KnownTripCountWhileThunkTest : public HloTestBase {
+ protected:
+  absl::StatusOr<const HloInstruction*> CreateFakeWhileInstruction() {
+    constexpr absl::string_view kDummyModule = R"(
+        body {
+          ROOT r = (pred[]) parameter(0)
+        }
+        cond {
+          param = (pred[]) parameter(0)
+          ROOT r = pred[] get-tuple-element(param), index=0
+        }
+        ENTRY main {
+          p = (pred[]) parameter(0)
+          ROOT while = (pred[]) while(p), condition=cond, body=body
+        })";
+
+    TF_ASSIGN_OR_RETURN(owned_modules_.emplace_back(),
+                        ParseAndReturnVerifiedModule(kDummyModule));
+    return owned_modules_.back()->entry_computation()->root_instruction();
+  }
+
+  absl::Status ExecuteThunk(Thunk& thunk) {
+    TF_ASSIGN_OR_RETURN(auto name, PlatformUtil::CanonicalPlatformName("gpu"));
+    TF_ASSIGN_OR_RETURN(auto* platform,
+                        se::PlatformManager::PlatformWithName(name));
+    TF_ASSIGN_OR_RETURN(auto* executor, platform->ExecutorForDevice(0));
+    TF_ASSIGN_OR_RETURN(std::unique_ptr<se::Stream> stream,
+                        executor->CreateStream());
+    se::StreamExecutorMemoryAllocator allocator(executor);
+    Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
+        ServiceExecutableRunOptions(), BufferAllocations({}, 0, &allocator),
+        stream.get(), stream.get(), nullptr, nullptr);
+    return thunk.ExecuteOnStream(Thunk::ExecuteParams(params));
+  }
+
+  std::pair<std::unique_ptr<SequentialThunk>, IterationLoggerThunk*>
+  CreateLoggingSequentialThunk(const HloInstruction* loop) {
+    auto owned_logger = std::make_unique<IterationLoggerThunk>(loop);
+    auto* logger = owned_logger.get();
+    ThunkSequence sequence;
+    sequence.push_back(std::move(owned_logger));
+    auto thunk = std::make_unique<SequentialThunk>(Thunk::ThunkInfo(),
+                                                   std::move(sequence));
+    return std::make_pair(std::move(thunk), logger);
+  }
+
+ private:
+  std::vector<std::unique_ptr<VerifiedHloModule>> owned_modules_;
+};
+
+TEST_F(KnownTripCountWhileThunkTest, CurrentLoopIterationKnownTripCountTest) {
+  TF_ASSERT_OK_AND_ASSIGN(const HloInstruction* loop,
+                          CreateFakeWhileInstruction());
+
+  auto [body_thunk, logger] = CreateLoggingSequentialThunk(loop);
+  auto condition_thunk =
+      std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), ThunkSequence());
+
+  BufferAllocation::Slice slice;
+  WhileThunk while_thunk(
+      Thunk::ThunkInfo(), loop,
+      /*condition_result_buffer_index=*/slice,
+      /*condition_thunk_sequence=*/std::move(condition_thunk),
+      /*body_thunk_sequence_=*/std::move(body_thunk),
+      /*trip_count=*/5);
+
+  EXPECT_THAT(ExecuteThunk(while_thunk), IsOk());
+  EXPECT_THAT(logger->logged_counters(), ElementsAre(0, 1, 2, 3, 4));
+}
+
+TEST_F(KnownTripCountWhileThunkTest, CurrentLoopIterationNestedTest) {
+  TF_ASSERT_OK_AND_ASSIGN(const HloInstruction* outer_loop,
+                          CreateFakeWhileInstruction());
+  TF_ASSERT_OK_AND_ASSIGN(const HloInstruction* inner_loop,
+                          CreateFakeWhileInstruction());
+
+  auto [body_thunk, logger] = CreateLoggingSequentialThunk(outer_loop);
+  auto inner_condition_thunk =
+      std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), ThunkSequence());
+  auto outer_condition_thunk =
+      std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), ThunkSequence());
+
+  BufferAllocation::Slice slice;
+  auto inner_while_thunk = std::make_unique<WhileThunk>(
+      Thunk::ThunkInfo(), inner_loop,
+      /*condition_result_buffer_index=*/slice,
+      /*condition_thunk_sequence=*/std::move(inner_condition_thunk),
+      /*body_thunk_sequence_=*/std::move(body_thunk),
+      /*trip_count=*/2);
+
+  ThunkSequence outer_body_sequence;
+  outer_body_sequence.push_back(std::move(inner_while_thunk));
+  auto outer_body_thunk = std::make_unique<SequentialThunk>(
+      Thunk::ThunkInfo(), std::move(outer_body_sequence));
+
+  WhileThunk outer_while_thunk(
+      Thunk::ThunkInfo(), outer_loop,
+      /*condition_result_buffer_index=*/slice,
+      /*condition_thunk_sequence=*/std::move(outer_condition_thunk),
+      /*body_thunk_sequence_=*/std::move(outer_body_thunk),
+      /*trip_count=*/3);
+
+  EXPECT_THAT(ExecuteThunk(outer_while_thunk), IsOk());
+  EXPECT_THAT(logger->logged_counters(), ElementsAre(0, 0, 1, 1, 2, 2));
+}
+
+TEST_F(KnownTripCountWhileThunkTest, CurrentLoopIterationUnknownLoopTest) {
+  TF_ASSERT_OK_AND_ASSIGN(const HloInstruction* loop,
+                          CreateFakeWhileInstruction());
+  TF_ASSERT_OK_AND_ASSIGN(const HloInstruction* not_running_loop,
+                          CreateFakeWhileInstruction());
+
+  auto [body_thunk, logger] = CreateLoggingSequentialThunk(not_running_loop);
+  auto condition_thunk =
+      std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), ThunkSequence());
+
+  BufferAllocation::Slice slice;
+  WhileThunk while_thunk(
+      Thunk::ThunkInfo(), loop,
+      /*condition_result_buffer_index=*/slice,
+      /*condition_thunk_sequence=*/std::move(condition_thunk),
+      /*body_thunk_sequence_=*/std::move(body_thunk),
+      /*trip_count=*/3);
+
+  EXPECT_THAT(ExecuteThunk(while_thunk), IsOk());
+  EXPECT_THAT(logger->logged_counters(),
+              ElementsAre(std::nullopt, std::nullopt, std::nullopt));
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -2329,7 +2329,7 @@ absl::StatusOr<std::unique_ptr<Thunk>> IrEmitterUnnested::BuildWhileThunk(
   body_thunk_info.profile_annotation += "_body";
 
   return std::unique_ptr<Thunk>(new WhileThunk(
-      thunk_info, pred,
+      thunk_info, instr, pred,
       ir_emitter_condition->ConsumeThunkSequence(cond_thunk_info),
       ir_emitter_body->ConsumeThunkSequence(body_thunk_info), trip_count));
 }


### PR DESCRIPTION
Currently, we have an API that retrieves a running while loop's iteration number using the depth of the loop in the current call stack. This is hard to use if you only have the HLO instruction of the loop and want to get its index.

For the larger context,  #see
https://github.com/openxla/xla/compare/main...jreiffers:xla:memcpy and the companion document
https://docs.google.com/document/d/1E2_Jt_Dw4VbPXPVktNWhtsDEtIpN-kurCMGGyvMV4JA.