### PR TITLE
[ROCm] Add -Wno-stringop-truncation to build flags

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -227,6 +227,7 @@ build:rocm_base --repo_env TF_NEED_ROCM=1
 build:rocm --config=rocm_base 
 
 build:rocm_gcc --config=rocm_base
+build:rocm_gcc --copt=-Wno-stringop-truncation
 
 build:rocm_clang_official --config=rocm_base
 build:rocm_clang_official --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"


### PR DESCRIPTION
Build error emerged after https://github.com/openxla/xla/commit/bd281e6ecdf5ede173e39f7402e547bbb9e1dc90. Added a workaround until the issue is fixed in upb.
Log:
```
ERROR: /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/external/upb/BUILD:57:11: Compiling upb/upb.c failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing CppCompile command (from target @@upb//:upb) external/local_config_rocm/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer ... (remaining 33 arguments skipped)
In file included from /usr/include/string.h:535,
                 from external/upb/upb/upb.h:16,
                 from external/upb/upb/upb.c:2:
In function ‘strncpy’,
    inlined from ‘upb_status_seterrmsg’ at external/upb/upb/upb.c:40:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin_strncpy’ specified bound 127 equals destination size [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
```

There is a similar workaround in Jax as well -> https://github.com/jax-ml/jax/pull/4974/files