### PR TITLE
Add helper to analyze induction var dependencies.

### DIFF
--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -664,5 +664,118 @@ bool IsDynamicSliceFusion(const HloInstruction* instr) {
          name == kDynamicSliceFusionWithDynamicAddressComputationConfigName;
 }
 
+std::optional<InductionVariableFunctionalDependency>
+ResolveFunctionalDependencyOnInductionVariable(
+    absl::Span<const HloInstruction* const> call_stack,
+    const HloInstruction* parameter) {
+  if (call_stack.empty()) {
+    return std::nullopt;
+  }
+
+  VLOG(5) << "Looking for defining while loop of " << parameter->name();
+
+  // Walk up the call stack, tracking the origin of `parameter`.
+  const HloInstruction* argument = parameter;
+  auto call_stack_it = call_stack.rbegin();
+  auto call_stack_end = call_stack.rend();
+  for (; call_stack_it != call_stack_end &&
+         argument->opcode() == HloOpcode::kParameter &&
+         ((*call_stack_it)->opcode() == HloOpcode::kFusion ||
+          (*call_stack_it)->opcode() == HloOpcode::kAsyncStart ||
+          (*call_stack_it)->opcode() == HloOpcode::kCall);
+       ++call_stack_it) {
+    argument = (*call_stack_it)->operand(argument->parameter_number());
+  }
+
+  if (call_stack_it == call_stack_end) {
+    return std::nullopt;
+  }
+
+  VLOG(5) << "Arrived at " << argument->name() << " in "
+          << (*call_stack_it)->name();
+
+  // Find a unique parameter and a gte in the transitive dependencies of
+  // `argument`.
+  const HloInstruction* unique_param = nullptr;
+  const HloInstruction* unique_gte = nullptr;
+  absl::flat_hash_set<const HloInstruction*> seen{argument};
+  std::queue<const HloInstruction*> queue;
+  queue.push(argument);
+  while (!queue.empty()) {
+    const auto* instruction = queue.front();
+    queue.pop();
+
+    if (instruction->opcode() == HloOpcode::kCustomCall ||
+        instruction->HasSideEffect()) {
+      VLOG(5) << "Found an unsafe operation.";
+      return std::nullopt;
+    }
+
+    if (instruction->opcode() == HloOpcode::kParameter) {
+      if (unique_param || !instruction->shape().IsTuple()) {
+        VLOG(5) << "Failed to match parameters.";
+        return std::nullopt;
+      }
+      unique_param = instruction;
+    }
+
+    if (instruction->opcode() == HloOpcode::kGetTupleElement) {
+      if (unique_gte) {
+        VLOG(5) << "Found non-unique GTEs.";
+        return std::nullopt;
+      }
+      unique_gte = instruction;
+    }
+
+    for (auto* operand : instruction->operands()) {
+      if (seen.insert(operand).second) {
+        queue.push(operand);
+      }
+    }
+  }
+
+  if (!unique_param || !unique_gte || unique_gte->operand(0) != unique_param) {
+    VLOG(5) << "Did not find a parameter or GTE or they don't match.";
+    return std::nullopt;
+  }
+
+  VLOG(5) << "Parameter and GTE: " << unique_param->name() << ", "
+          << unique_gte->name();
+
+  // Continue walking up through call instructions.
+  while (call_stack_it != call_stack_end &&
+         (*call_stack_it)->opcode() == HloOpcode::kCall &&
+         unique_param->opcode() == HloOpcode::kParameter) {
+    unique_param = (*call_stack_it)->operand(unique_param->parameter_number());
+    ++call_stack_it;
+  }
+
+  // Find the while loop for 'unique_param'.
+  auto while_instr_it = std::find_if(
+      call_stack_it, call_stack_end, [&](const HloInstruction* instr) {
+        return instr->opcode() == HloOpcode::kWhile &&
+               unique_param == instr->while_body()->parameter_instruction(0);
+      });
+
+  if (while_instr_it == call_stack_end) {
+    VLOG(5) << "Did not find a while loop.";
+    return std::nullopt;
+  }
+
+  auto config = (*while_instr_it)->backend_config<xla::WhileLoopBackendConfig>();
+  if (!config.ok() || !config->has_known_induction_variable() ||
+      unique_gte->tuple_index() !=
+          config->known_induction_variable().tuple_index()) {
+    VLOG(5) << "Failed to verify that the offset depends on the induction "
+               "variable.";
+    return std::nullopt;
+  }
+
+  VLOG(5) << "While loop for " << parameter->name() << ": "
+          << (*while_instr_it)->name();
+  return InductionVariableFunctionalDependency{argument, *while_instr_it,
+                                               unique_gte};
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -272,6 +272,22 @@ absl::StatusOr<std::string> FingerprintWithBackendConfig(
                       ", backend_config_fingerprint=", fingerprint);
 }
 
+struct InductionVariableFunctionalDependency {
+  // The value that is derived from the induction variable. This is guaranteed
+  // to have no other transitive dependencies (except constants).
+  const HloInstruction* derived_value;
+
+  // The loop and its induction variable that the value depends on.
+  const HloInstruction* loop;
+  const HloInstruction* induction_var;
+};
+
+// Checks if `parameter`'s value is a pure function of a while loop's induction
+// variable.
+std::optional<InductionVariableFunctionalDependency>
+ResolveFunctionalDependencyOnInductionVariable(
+    absl::Span<const HloInstruction* const> call_stack, const HloInstruction* parameter);
+
 }  // namespace gpu
 }  // namespace xla
 

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -283,10 +283,18 @@ struct InductionVariableFunctionalDependency {
 };
 
 // Checks if `parameter`'s value is a pure function of a while loop's induction
-// variable.
+// variable. This supports parameters that are inside call, async or fusion
+// instructions. The dependency can be through arbitrary non-side-effecting
+// instructions.
+// `call_stack` should contain the nested instructions that are ancestor of
+// `parameter`. For example, if it is a parameter of a fusion in a while loop,
+// it should contain the while loop as the first element and the fusion as the
+// second element.
+// Requires `while_loop_trip_count_annotator` to have been run on the loop.
 std::optional<InductionVariableFunctionalDependency>
 ResolveFunctionalDependencyOnInductionVariable(
-    absl::Span<const HloInstruction* const> call_stack, const HloInstruction* parameter);
+    absl::Span<const HloInstruction* const> call_stack,
+    const HloInstruction* parameter);
 
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
This adds a helper function that checks if an HLO instruction is a pure functional dependency of a  while loop's induction variable. See the comment on `ResolveFunctionalDependencyOnInductionVariable` in `ir_emission_utils.h` for more details.

For additional context, see
https://github.com/openxla/xla/compare/main...jreiffers:xla:memcpy and the companion document
https://docs.google.com/document/d/1E2_Jt_Dw4VbPXPVktNWhtsDEtIpN-kurCMGGyvMV4JA.