### PR TITLE
[debug_options] Printing all the fields in debug options

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -521,10 +521,23 @@ void CheckNotScheduled(HloModule* hlo_module) {
 void LogDebugOptions(HloModule* hlo_module) {
   // LOG_LINES is used instead of LOG since the message can exceed the
   // maximum line length, which results in the message being truncated.
-  XLA_VLOG_LINES(
-      1, absl::StrFormat("GpuCompilationEnvironment of hlo_module %s:\n%s",
-                         hlo_module->name(),
-                         hlo_module->config().debug_options().DebugString()));
+  //
+  // We are also printing all the fields, instead of the DebugString() because
+  // DebugString() does not print the default values of the fields. For example
+  // for all boolean fields, the default value is false, it will not be printed
+  // by DebugString() if the value is false. We however need that value to be
+  // printed, because our "default" values (defined in
+  // xla/debug_options_flags.cc) override the default values of the fields. If
+  // we set the "default" value of a field to be true in
+  // `debug_option_flags.cc`, and it is overridden by XLA_FLAGS to false, we
+  // will not see it in the DebugString(). So, we print all the fields.
+  if (VLOG_IS_ON(1)) {
+    XLA_VLOG_LINES(
+        1,
+        absl::StrFormat("GpuCompilationEnvironment of hlo_module %s:\n%s",
+                        hlo_module->name(),
+                        PrintAllFields(hlo_module->config().debug_options())));
+  }
 }
 
 AlgebraicSimplifierOptions LayoutInsensitiveAlgebraicSimplifierOptions(

--- a/xla/util.cc
+++ b/xla/util.cc
@@ -515,4 +515,31 @@ bool DistinctNumbersAreConsecutiveIfSorted(absl::Span<const int64_t> seq) {
          seq.size() - 1;
 }
 
+std::string PrintAllFields(const google::protobuf::Message& message) {
+  tsl::protobuf::TextFormat::Printer tsl_printer;
+  const google::protobuf::Reflection* reflection = message.GetReflection();
+  std::stringstream result;
+  std::string buffer;
+  const google::protobuf::Descriptor* descriptor = message.GetDescriptor();
+  for (int i = 0; i < descriptor->field_count(); ++i) {
+    const google::protobuf::FieldDescriptor* field = descriptor->field(i);
+    if (field->is_repeated()) {
+      result << field->name() << ": [";
+      for (int j = 0; j < reflection->FieldSize(message, field); ++j) {
+        if (j > 0) {
+          result << ", ";
+        }
+        tsl_printer.PrintFieldValueToString(message, field, j, &buffer);
+        result << buffer;
+      }
+      result << "]\n";
+    } else {
+      result << field->name() << ": ";
+      tsl_printer.PrintFieldValueToString(message, field, -1, &buffer);
+      result << buffer << "\n";
+    }
+  }
+  return result.str();
+}
+
 }  // namespace xla

--- a/xla/util.h
+++ b/xla/util.h
@@ -950,6 +950,8 @@ inline bool HloPredicateFalse(const HloInstruction*) { return false; }
 using Vector2 = std::array<int64_t, 2>;
 using Vector3 = std::array<int64_t, 3>;
 
+std::string PrintAllFields(const google::protobuf::Message& message);
+
 }  // namespace xla
 
 // Note that STRING is evaluated regardless of whether it will be logged.

--- a/xla/util_test.cc
+++ b/xla/util_test.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "absl/base/log_severity.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/log/check.h"
+#include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "ml_dtypes/include/float8.h"
@@ -37,6 +38,7 @@ limitations under the License.
 #include "xla/maybe_owning.h"
 #include "xla/tsl/platform/logging.h"
 #include "xla/types.h"
+#include "xla/xla_data.pb.h"
 #include "tsl/platform/ml_dtypes.h"
 
 namespace xla {
@@ -407,6 +409,18 @@ TEST(UtilTest, MaybeOwningTestShared) {
   EXPECT_EQ(*c1, 'x');
   EXPECT_EQ(*c2, 'x');
   EXPECT_EQ(c1.get(), c2.get());
+}
+
+TEST(UtilTest, PrintAllFields) {
+  // Here we are using one of the bool fields that has the default value to
+  // false and ensuring that it is always printed.
+  ExecutionProfile execution_profile;
+  execution_profile.set_compilation_cache_hit(true);
+  std::string result = PrintAllFields(execution_profile);
+  EXPECT_TRUE(absl::StrContains(result, "compilation_cache_hit: true"));
+  execution_profile.set_compilation_cache_hit(false);
+  result = PrintAllFields(execution_profile);
+  EXPECT_TRUE(absl::StrContains(result, "compilation_cache_hit: false"));
 }
 
 }  // namespace


### PR DESCRIPTION
This patch prints all the values of the debug options while dumping it under VLOG. This is specifically required for boolean fields which have the default value set to true in `xla/debug_options_flags.cc`. These values will not be printed in `DebugString()` if `XLA_FLAGS` overrides it to `false`.