### PR TITLE
Skip constant folding for instructions that cannot be safely removed

### DIFF
--- a/xla/hlo/transforms/simplifiers/hlo_constant_folding.cc
+++ b/xla/hlo/transforms/simplifiers/hlo_constant_folding.cc
@@ -237,6 +237,11 @@ absl::StatusOr<bool> HloConstantFolding::Run(
         continue;
       }
 
+      // Skip constant folding for instructions that cannot be safely removed.
+      if (!computation->IsSafelyRemovable(instruction)) {
+        continue;
+      }
+
       if (instruction->opcode() == HloOpcode::kPad &&
           instruction->operand(0)->opcode() == HloOpcode::kBroadcast &&
           instruction->operand(1)->opcode() == HloOpcode::kConstant) {


### PR DESCRIPTION
**Description:**  

The constant folding pass fails for one of our real models during internal testing.  

`HloConstantFolding` removes replaced instructions using `computation.RemoveInstruction(instr)`. Internally, `RemoveInstruction` calls `RemoveInstructionImpl` without forcing removal (`ignore_safety_check=false`). If the instruction is not **safely removable**, `RemoveInstructionImpl` crashes the application.  

To prevent this crash, I added an `IsSafelyRemovable` check to the existing list of Constant Folding pre-checks.

#### To Reproduce

model.hlo to reproduce the issue
```
HloModule m
%AddComputation.27823 (x.735: f32[], y.735: f32[]) -> f32[] {
  %x.735 = f32[] parameter(0)
  %y.735 = f32[] parameter(1)
  ROOT %add.715 = f32[] add(f32[] %x.735, f32[] %y.735)
}

ENTRY main {
  %p.0 = f32[8,8]{1,0} parameter(0), frontend_attributes={input_name="input0"}
  %p821 = f32[] parameter(1), frontend_attributes={input_name="input821"}
  %copy.1104 = f32[] copy(f32[] %p821)
  %constant.3010 = f32[] constant(0)
  %reduce.734 = f32[] reduce(%p.0, f32[] %constant.3010), dimensions={0,1}, to_apply=%AddComputation.27823
  %add.1649 = f32[] add(f32[] %copy.1104, f32[] %reduce.734)
  %constant.3833 = f32[] constant(0)
  %copy.2310 = f32[] copy(f32[] %constant.3833), control-predecessors={%copy.1104}
  ROOT %tuple.17 = (f32[], f32[]) tuple(f32[] %add.1649, f32[] %copy.2310)
}
```
cmd to repro the crash on CPU
```
xla/tools/run_hlo_module --platform=CPU model.hlo
```
Error:
```
E0000 00:00:1741222471.912307    5276 status_macros.cc:57] INTERNAL: RET_CHECK failure
 (xla/hlo/ir/hlo_computation.cc:503) ignore_safety_check || IsSafelyRemovable(instruction) cannot remove instruction:
 %copy.2310 = f32[] copy(f32[] %constant.3833), control-predecessors={%p821}
```