### PR TITLE
Skip CSE for Instructions That Are Not Safely Removable

### DIFF
--- a/xla/service/hlo_cse.cc
+++ b/xla/service/hlo_cse.cc
@@ -298,6 +298,12 @@ absl::StatusOr<bool> HloCSE::RunOnComputation(HloComputation* computation) {
       continue;
     }
 
+    // Skip instructions that cannot be safely removed.
+    if (!computation->IsSafelyRemovable(instruction,
+                                        ignore_control_dependencies_)) {
+      continue;
+    }
+
     if (only_scalars_ && !ShapeUtil::IsScalar(instruction->shape())) {
       continue;
     }


### PR DESCRIPTION
**Description:**  

Currently, CSE performs cleanup on replaced instructions using `computation.RemoveInstructionAndUnusedOperands(instr)`, which internally calls:

```c
TF_RET_CHECK(IsSafelyRemovable(instruction, ignore_control_dependencies))
```

If `IsSafelyRemovable` returns false, this causes a crash.

To prevent this, I've added an `IsSafelyRemovable` check to the existing CSE pre-checks.

#### To Reproduce

model.hlo to reproduce the issue:
```
HloModule m

ENTRY main {
  %p419 = f32[512,768]{1,0} parameter(0)
  %p420 = f32[512,768]{1,0} parameter(1)
  %constant.3834 = f32[] constant(0)
  %broadcast.7223 = f32[512,768]{1,0} broadcast(f32[] %constant.3834), dimensions={}
  %copy.2311 = f32[512,768]{1,0} copy(f32[512,768]{1,0} %broadcast.7223), control-predecessors={%p419}
  %copy.2312 = f32[512,768]{1,0} copy(f32[512,768]{1,0} %broadcast.7223), control-predecessors={%p420}
  ROOT %tuple.17 = (f32[512,768]{1,0}, f32[512,768]{1,0}) tuple(f32[512,768]{1,0} %copy.2311, f32[512,768]{1,0} %copy.2312)
}
```
cmd to repro the crash on CPU
```
xla/tools/run_hlo_module --platform=CPU model.hlo
```
Error:
```
INTERNAL: RET_CHECK failure (xla/hlo/ir/hlo_computation.cc:435) IsSafelyRemovable(instruction, ignore_control_dependencies) Cannot remove instruction: %copy.2312 = f32[512,768]{1,0} copy(f32[512,768]{1,0} %broadcast.7223), control-predecessors={%p420}
	Failed to execute on Host
```

### Unit Tests
I've added both positive and negative test cases:

- CopyOpCSE – Verifies that CSE successfully removes safely removable operations.
- DontCSE_NonSafelyRemovableOp – Ensures that CSE is skipped when copyOp is not safely removable.