### PR TITLE
[Hermetic CUDA] Skip arch if not in redistrib json

### DIFF
--- a/third_party/gpus/cuda/hermetic/cuda_redist_init_repositories.bzl
+++ b/third_party/gpus/cuda/hermetic/cuda_redist_init_repositories.bzl
@@ -489,6 +489,8 @@ def _get_redistribution_urls(dist_info):
         arch_key = arch
         if arch_key == "linux-aarch64" and arch_key not in dist_info:
             arch_key = "linux-sbsa"
+        if arch_key not in dist_info:
+            continue
         if "relative_path" in dist_info[arch_key]:
             url_dict[_REDIST_ARCH_DICT[arch]] = [
                 dist_info[arch_key]["relative_path"],


### PR DESCRIPTION
Given a custom CUDA redistribution which only specifies a distribution for `linux-x86_64` and not `linux-sbsa` nor `linux-aarch64`, a key error occurs due to `_get_redistribution_urls` expecting all architectures to be present for each subproject.

```json
// fragment of the custom CUDA redistribution JSON
{
    "cuda_cccl": {
        "linux-x86_64": {
            "relative_path": "...",
            "sha256": "..."
        },
    },
}
```

This can be resolved by adding a key for each arch mapping to an empty dict if there is no artifact for that arch. However, this solution is awkward and adds clutter to the custom CUDA redistribution.

```json
{
  "cuda_cccl": {
      "linux-x86_64": {
          "relative_path": "...",
          "sha256": "..."
      },
      "linux-aarch64": {},
      "linux-sbsa": {},
  },
```

Instead, allow for `_get_redistribution_urls` to skip the arch if it is not present in the redistribution.