### PR TITLE
Add `-Wno-c23-extensions` flag with Clang >= 19

### DIFF
--- a/build_tools/configure/configure.py
+++ b/build_tools/configure/configure.py
@@ -412,8 +412,13 @@ class XLAConfigOptions:
     if dpav.ld_library_path:
       rc.append(f"build --action_env LD_LIBRARY_PATH={dpav.ld_library_path}")
 
+    # Needed due to error in @upb//:upb which is a dep of @com_github_grpc_grpc
+    # error: defining a type within 'offsetof' is a Clang extension
     if dpav.clang_major_version in (16, 17, 18):
       self.compiler_options.append("-Wno-gnu-offsetof-extensions")
+    # error: defining a type within 'offsetof' is a C23 extension
+    if dpav.clang_major_version and dpav.clang_major_version >= 19:
+      self.compiler_options.append("-Wno-c23-extensions")
 
     # Avoid XNNPACK using `-mavxvnniint8` (needs clang-16+/gcc-13+)
     if (


### PR DESCRIPTION
XLA's version of gRPC depends on an ancient version of upb which is unable to compile on Clang >= 19 without this flag. Also, added clarification for why the `-Wno-gnu-offsetof-extensions` is used for Clang 16 -> 18.

To test this change, run the following locally:

```sh
$ docker run --rm -it \
    --name xla \
    -v $PWD:/xla \
    -w /tmp \
    silkeh/clang:19
$ wget https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-amd64.deb
$ dpkg -i bazelisk-amd64.deb
$ cd /xla
$ ./configure.py --backend=CPU
$ bazel \
    build \
    --repo_env=HERMETIC_PYTHON_VERSION=3.11 \
    --spawn_strategy=sandboxed \
    @upb//:upb
```