### PR TITLE
Do not reach inside cub:: namespace

### DIFF
--- a/xla/service/gpu/gpu_prim.h
+++ b/xla/service/gpu/gpu_prim.h
@@ -34,46 +34,6 @@ limitations under the license, the license you must see.
 #include "third_party/gpus/cuda/include/cusparse.h"
 
 namespace gpuprim = ::cub;
-
-// Required for sorting Eigen::half and bfloat16.
-namespace cub {
-template <>
-__device__ __forceinline__ void ThreadStoreVolatilePtr<Eigen::half>(
-    Eigen::half *ptr, Eigen::half val, Int2Type<true> /*is_primitive*/) {
-  *reinterpret_cast<volatile uint16_t *>(ptr) =
-      Eigen::numext::bit_cast<uint16_t>(val);
-}
-
-__device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer(
-    const Eigen::half *ptr, Int2Type<true> /*is_primitive*/) {
-  uint16_t result = *reinterpret_cast<volatile const uint16_t *>(ptr);
-  return Eigen::numext::bit_cast<Eigen::half>(result);
-}
-
-template <>
-__device__ __forceinline__ void ThreadStoreVolatilePtr<tsl::bfloat16>(
-    tsl::bfloat16 *ptr, tsl::bfloat16 val, Int2Type<true> /*is_primitive*/) {
-  *reinterpret_cast<volatile uint16_t *>(ptr) =
-      Eigen::numext::bit_cast<uint16_t>(val);
-}
-
-__device__ __forceinline__ tsl::bfloat16 ThreadLoadVolatilePointer(
-    tsl::bfloat16 *ptr, Int2Type<true> /*is_primitive*/) {
-  uint16_t result = *reinterpret_cast<volatile uint16_t *>(ptr);
-  return Eigen::numext::bit_cast<tsl::bfloat16>(result);
-}
-
-template <>
-struct NumericTraits<Eigen::half>
-    : BaseTraits</*_CATEGORY=*/FLOATING_POINT, /*_PRIMITIVE=*/true,
-                 /*_NULL_TYPE=*/false, /*_UnsignedBits=*/uint16_t,
-                 /*T=*/Eigen::half> {};
-template <>
-struct NumericTraits<tsl::bfloat16>
-    : BaseTraits</*_CATEGORY=*/FLOATING_POINT, /*_PRIMITIVE=*/true,
-                 /*_NULL_TYPE=*/false, /*_UnsignedBits=*/uint16_t,
-                 /*T=*/tsl::bfloat16> {};
-}  // namespace cub
 #elif TENSORFLOW_USE_ROCM
 
 #include "rocm/include/hipcub/hipcub.hpp"


### PR DESCRIPTION
https://github.com/NVIDIA/cccl/commit/a4508f6f8c28871db0763c68f61238a3d79470f7 will stop this code compiling, something similar happened before with https://github.com/openxla/xla/pull/16095.

As far as I can see, this code is not actually used [anymore] in OSS.