### PR TITLE
[ROCm] Add rocm deps for ragged_all_to_all_kernel

### DIFF
--- a/xla/service/gpu/kernels/BUILD
+++ b/xla/service/gpu/kernels/BUILD
@@ -288,13 +288,15 @@ cc_library(
     ],
 )
 
-cuda_library(
+gpu_kernel_library(
     name = "ragged_all_to_all_kernel_gpu",
     srcs = ["ragged_all_to_all_kernel.cu.cc"],
     hdrs = ["ragged_all_to_all_kernel_common.h"],
-    deps = [
+    deps = if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",  # build_cleaner: keep
-    ],
+    ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
 )
 
 xla_test(


### PR DESCRIPTION
Kernel added in https://github.com/openxla/xla/commit/be68e80894862fe97757ea2b6110958ef4244c21. For ROCm build is currently failing with:
```
[2025-03-09T01:01:48.040Z] ERROR: /tf/xla/xla/service/gpu/kernels/BUILD:291:13: Compiling xla/service/gpu/kernels/ragged_all_to_all_kernel.cu.cc failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing CppCompile command (from target //xla/service/gpu/kernels:ragged_all_to_all_kernel_gpu) external/local_config_rocm/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer ... (remaining 148 arguments skipped)
[2025-03-09T01:01:48.040Z] /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/external/local_config_rocm/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc:23: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
[2025-03-09T01:01:48.040Z]   import pipes
[2025-03-09T01:01:48.040Z] xla/service/gpu/kernels/ragged_all_to_all_kernel.cu.cc:52:1: error: ‘__global__’ does not name a type
[2025-03-09T01:01:48.040Z]    52 | __global__ void __launch_bounds__(128) RaggedAllToAllKernel(
[2025-03-09T01:01:48.040Z]       | ^~~~~~~~~~
[2025-03-09T01:01:48.040Z] xla/service/gpu/kernels/ragged_all_to_all_kernel.cu.cc: In function ‘void* xla::gpu::GetRaggedAllToAllKernel()’:
[2025-03-09T01:01:48.040Z] xla/service/gpu/kernels/ragged_all_to_all_kernel.cu.cc:83:35: error: ‘RaggedAllToAllKernel’ was not declared in this scope; did you mean ‘GetRaggedAllToAllKernel’?
[2025-03-09T01:01:48.040Z]    83 |   return reinterpret_cast<void*>(&RaggedAllToAllKernel<T>);
[2025-03-09T01:01:48.040Z]       |                                   ^~~~~~~~~~~~~~~~~~~~
[2025-03-09T01:01:48.040Z]       |                                   GetRaggedAllToAllKernel
[2025-03-09T01:01:48.040Z] xla/service/gpu/kernels/ragged_all_to_all_kernel.cu.cc:83:57: error: expected primary-expression before ‘>’ token
[2025-03-09T01:01:48.040Z]    83 |   return reinterpret_cast<void*>(&RaggedAllToAllKernel<T>);
[2025-03-09T01:01:48.040Z]       |                                                         ^
[2025-03-09T01:01:48.040Z] xla/service/gpu/kernels/ragged_all_to_all_kernel.cu.cc:83:58: error: expected primary-expression before ‘)’ token
[2025-03-09T01:01:48.040Z]    83 |   return reinterpret_cast<void*>(&RaggedAllToAllKernel<T>);
[2025-03-09T01:01:48.040Z]       |   
```

This PR just adds necessary deps for rocm 