### PR TITLE
Replace dynamic-slice fusions with memcpy.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1313,6 +1313,7 @@ cc_library(
         "//xla/service:hlo_cost_analysis",
         "//xla/service:pattern_matcher",
         "//xla/service/gpu/transforms:fusion_block_level_rewriter",
+        "//xla/service/gpu/transforms:fusion_dynamic_memcpy_rewriter",
         "//xla/stream_executor:device_description",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",

--- a/xla/service/gpu/fusion_dispatch_pipeline.cc
+++ b/xla/service/gpu/fusion_dispatch_pipeline.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/hlo/pass/hlo_pass_pipeline.h"
 #include "xla/layout_util.h"
 #include "xla/service/gpu/transforms/fusion_block_level_rewriter.h"
+#include "xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/stream_executor/device_description.h"
@@ -131,6 +132,7 @@ HloPassPipeline FusionDispatchPipeline(
   HloPassPipeline pipeline("fusion-dispatch-pipeline");
   pipeline.AddPass<FusionBlockLevelRewriter>(device_description, shape_size_fn,
                                              std::move(try_rewrite_fusion_if));
+  pipeline.AddPass<FusionDynamicMemcpyRewriter>();
   return pipeline;
 }
 

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1511,7 +1511,7 @@ class PassOrderTest : public GpuCompilerTest {
     for (const HloPassMetadata& pass_metadata :
          optimized_module_->metadata()->proto().pass_metadata()) {
       std::string name = pass_metadata.pass_name();
-      if (match_pipeline_name) {
+      if (include_pipeline_name) {
         name = absl::StrCat(pass_metadata.pipeline_name(), ".",
                             pass_metadata.pass_name());
       }

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "xla/autotune_results.pb.h"
@@ -1495,9 +1496,12 @@ class PassOrderTest : public GpuCompilerTest {
   // or if none of the executed passes matches `first_pass_regex` or
   // `last_pass_regex`. Returns a PassRange with the latest run index of any
   // passes with names matching `first_pass_regex` and the earliest run index of
-  // any passes with names matching 'last_pass_regex'.
+  // any passes with names matching 'last_pass_regex'. Passes matching both
+  // regexes will be counted towards last_pass (i.e., overlap of the two ranges
+  // is allowed).
   PassRange VerifyPassOrder(absl::string_view first_pass_regex,
-                            absl::string_view last_pass_regex) {
+                            absl::string_view last_pass_regex,
+                            bool include_pipeline_name = false) {
     if (!optimized_module_) {
       CompileModule(GetModuleConfigForTest());
     }
@@ -1506,15 +1510,19 @@ class PassOrderTest : public GpuCompilerTest {
     int run_index = 0;
     for (const HloPassMetadata& pass_metadata :
          optimized_module_->metadata()->proto().pass_metadata()) {
-      if (RE2::FullMatch(pass_metadata.pass_name(), first_pass_regex)) {
-        VLOG(2) << "Pass " << pass_metadata.pass_name()
-                << " matches first_pass_regex." << std::endl;
-        first_pass_latest_run = std::max(first_pass_latest_run, run_index);
+      std::string name = pass_metadata.pass_name();
+      if (match_pipeline_name) {
+        name = absl::StrCat(pass_metadata.pipeline_name(), ".",
+                            pass_metadata.pass_name());
       }
-      if (RE2::FullMatch(pass_metadata.pass_name(), last_pass_regex)) {
+      if (RE2::FullMatch(name, last_pass_regex)) {
         VLOG(2) << "Pass " << pass_metadata.pass_name()
                 << " matches last_pass_regex." << std::endl;
         last_pass_earliest_run = std::min(last_pass_earliest_run, run_index);
+      } else if (RE2::FullMatch(name, first_pass_regex)) {
+        VLOG(2) << "Pass " << pass_metadata.pass_name()
+                << " matches first_pass_regex." << std::endl;
+        first_pass_latest_run = std::max(first_pass_latest_run, run_index);
       }
       ++run_index;
     }
@@ -1523,7 +1531,7 @@ class PassOrderTest : public GpuCompilerTest {
         << "Did not run a pass matching " << first_pass_regex;
     EXPECT_LT(last_pass_earliest_run, std::numeric_limits<int>::max())
         << "Did not run a pass matching " << last_pass_regex;
-    EXPECT_LE(first_pass_latest_run, last_pass_earliest_run)
+    EXPECT_LT(first_pass_latest_run, last_pass_earliest_run)
         << "One or more passes matching " << first_pass_regex
         << " ran after passes matching " << last_pass_regex;
     return {first_pass_latest_run, last_pass_earliest_run};
@@ -1590,13 +1598,13 @@ TEST_F(PassOrderTest, OffloadingPassesAreRunInCorrectOrder) {
   VerifyNotRunInBetween(pass_range, /*pass_regex=*/"cse");
 }
 
-TEST_F(PassOrderTest, FusionBlockLevelRewriterRunsAfterAllFusionPasses) {
+TEST_F(PassOrderTest, FusionDispatchRunsAfterAllFusionPasses) {
   auto cc = backend()
                 .default_stream_executor()
                 ->GetDeviceDescription()
                 .cuda_compute_capability();
   if (!cc.IsAtLeastAmpere()) {
-    GTEST_SKIP() << "FusionBlockLevelRewriter requires Ampere+ to run.";
+    GTEST_SKIP() << "fusion-dispatch requires Ampere+ to run.";
   }
 
   DebugOptions debug_options = GetDebugOptionsForTest();
@@ -1605,7 +1613,8 @@ TEST_F(PassOrderTest, FusionBlockLevelRewriterRunsAfterAllFusionPasses) {
   SetDebugOptions(debug_options);
 
   VerifyPassOrder(/*first_pass_regex=*/".*fusion.*",
-                  /*last_pass_regex=*/"fusion-block-level-rewriter");
+                  /*last_pass_regex=*/"fusion-dispatch-pipeline.*",
+                  /*include_pipeline_name=*/true);
 }
 
 TEST_F(PassOrderTest, CollectivePipelinerRunsAfterCollectiveQuantizer) {

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -282,6 +282,7 @@ xla_test(
         "//xla:literal_util",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:verified_hlo_module",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -73,5 +73,130 @@ TEST_F(GpuCopyTest, CopyTranspose) {
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
+constexpr char kSliceMemcpyModule[] = R"(
+    dynamic_slice {
+      p0 = s32[4,8,8] parameter(0)
+      p1 = s32[] parameter(1)
+      c1 = s32[] constant(1)
+      p2 = s32[] parameter(2)
+
+      // Test all supported kinds of offsets: derived from the while loop's
+      // induction variable (p1), constant (c1) and always clamped to 0, so
+      // the value is irrelevant (p2).
+      ROOT slice = s32[1,1,8] dynamic-slice(p0, p1, c1, p2),
+          dynamic_slice_sizes={1,1,8}
+    }
+
+    remainder {
+      p0 = s32[] parameter(0)
+      c5 = s32[] constant(5)
+      // We take the value modulo 5 to test for correct clamping (the offset 4
+      // must get clamped to 3, since it's greater or equal than the dimension
+      // size).
+      ROOT remainder = s32[] remainder(p0, c5)
+    }
+
+    add {
+      p0 = s32[] parameter(0)
+      c1 = s32[] constant(1)
+      ROOT sum = s32[] add(p0, c1)
+    }
+
+    add_slices {
+      p0 = s32[1,1,8] parameter(0)
+      p1 = s32[1,1,8] parameter(1)
+      ROOT sum = s32[1,1,8] add(p0, p1)
+    }
+
+    times_two {
+      p0 = s32[] parameter(0)
+      ROOT sum = s32[] add(p0, p0)
+    }
+
+    body {
+      p0 = (s32[], s32[4,8,8], s32[1,1,8], s32[]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+
+      ivar_copy = s32[] copy(ivar)
+      acc = s32[1,1,8] get-tuple-element(p0), index=2
+      acc_copy = s32[1,1,8] copy(acc)
+
+      offset1 = s32[] fusion(ivar_copy), kind=kLoop, calls=remainder
+      offset2 = s32[] get-tuple-element(p0), index=3
+
+      slice = s32[1,1,8] fusion(input, offset1, offset2), kind=kLoop, calls=dynamic_slice,
+          backend_config={"fusion_backend_config":{"kind":"__dynamic_memcpy"}}
+      next_ivar = s32[] fusion(ivar_copy), kind=kLoop, calls=add
+      next_offset_2 = s32[] fusion(offset2), kind=kLoop, calls=times_two
+
+      next_acc = s32[1,1,8] fusion(acc_copy, slice), kind=kLoop, calls=add_slices
+      ROOT result = (s32[], s32[4,8,8], s32[1,1,8], s32[])
+          tuple(next_ivar, input, next_acc, next_offset_2)
+    }
+
+    compare {
+      p0 = s32[] parameter(0)
+      c6 = s32[] constant(6)
+      ROOT cmp = pred[] compare(p0, c6), direction=LT
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8], s32[1,1,8], s32[]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      ROOT cmp = pred[] fusion(ivar), kind=kLoop, calls=compare
+    }
+
+    zero {
+      c0 = s32[] constant(0)
+      ROOT bc = s32[1,1,8] broadcast(c0), dimensions={}
+    }
+
+    input {
+      iota = s32[256] iota(), iota_dimension=0
+      ROOT bc = s32[4,8,8] bitcast(iota)
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] fusion(), kind=kLoop, calls=input
+      init_acc = s32[1,1,8] fusion(), kind=kLoop, calls=zero
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      tuple = (s32[], s32[4,8,8], s32[1,1,8], s32[]) tuple(c0, input, init_acc, c1)
+      ROOT while = (s32[], s32[4,8,8], s32[1,1,8], s32[]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"6"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+TEST_F(GpuCopyTest, UseMemcpyForDynamicSlice) {
+  // This verifies that dynamic slices can be implemented using memcpy in
+  // certain conditions.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> hlo_module,
+                          ParseAndReturnVerifiedModule(kSliceMemcpyModule));
+
+  // There should not be a kernel for `dynamic_slice`.
+  CompileAndVerifyIr(std::move(hlo_module), "; CHECK-NOT: void @slice",
+                     /*match_optimized_ir=*/false,
+                     /*run_optimization_passes=*/false);
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kSliceMemcpyModule, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(GpuCopyTest, DoNotUseMemcpyForDynamicSlice) {
+  // This is a test for the CompileAndVerifyIr statement in
+  // UseMemcpyForDynamicSlice. When the conditions are not met, there should be
+  // a fusion for the slice.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> hlo_module,
+                          ParseAndReturnVerifiedModule(kSliceMemcpyModule));
+
+  // This prevents the memcpy fusion logic from triggering.
+  hlo_module->entry_computation()->root_instruction()->clear_backend_config();
+
+  CompileAndVerifyIr(std::move(hlo_module), "; CHECK: void @slice",
+                     /*match_optimized_ir=*/false,
+                     /*run_optimization_passes=*/false);
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -432,6 +432,46 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "fusion_dynamic_memcpy_rewriter",
+    srcs = ["fusion_dynamic_memcpy_rewriter.cc"],
+    hdrs = ["fusion_dynamic_memcpy_rewriter.h"],
+    deps = [
+        "//xla/backends/gpu/codegen:copy",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service:call_graph",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:ir_emission_utils",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "fusion_dynamic_memcpy_rewriter_test",
+    srcs = ["fusion_dynamic_memcpy_rewriter_test.cc"],
+    deps = [
+        ":fusion_dynamic_memcpy_rewriter",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:ir_emission_utils",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:xla_internal_test_main",  # fixdeps: keep
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest",
+        "@tsl//tsl/platform:status_matchers",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
     name = "block_scaling_rewriter",
     srcs = ["block_scaling_rewriter.cc"],
     hdrs = ["block_scaling_rewriter.h"],

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -458,9 +458,9 @@ xla_cc_test(
     deps = [
         ":fusion_dynamic_memcpy_rewriter",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/service/gpu:backend_configs_cc",
         "//xla/service/gpu:ir_emission_utils",
-        "//xla/tests:hlo_test_base",
         "//xla/tests:xla_internal_test_main",  # fixdeps: keep
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status:statusor",

--- a/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.cc
+++ b/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.cc
@@ -1,0 +1,78 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.h"
+
+#include <string>
+#include <utility>
+
+#include "xla/backends/gpu/codegen/copy.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace xla {
+namespace gpu {
+
+absl::StatusOr<bool> FusionDynamicMemcpyRewriter::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool has_changed = false;
+
+  std::unique_ptr<CallGraph> call_graph = nullptr;
+
+  for (HloComputation* computation : module->computations(execution_threads)) {
+    if (!computation->IsFusionComputation()) {
+      continue;
+    }
+
+    HloFusionInstruction* fusion =
+        ::xla::Cast<HloFusionInstruction>(computation->FusionInstruction());
+    if (!DynamicMemcpyFusion::IsCandidateFusion(*fusion)) {
+      continue;
+    }
+
+    // Lazily build the call graph if we find a candidate fusion.
+    if (!call_graph) {
+      call_graph = CallGraph::Build(module, execution_threads);
+    }
+
+    if (DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(*fusion,
+                                                          *call_graph)) {
+      TF_ASSIGN_OR_RETURN(auto backend_config,
+                          fusion->backend_config<GpuBackendConfig>());
+      backend_config.mutable_fusion_backend_config()->set_kind(
+          std::string(kDynamicMemcpyFusionKind));
+      TF_RETURN_IF_ERROR(fusion->set_backend_config(backend_config));
+      has_changed = true;
+    }
+  }
+
+  return has_changed;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.h
+++ b/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.h
@@ -1,0 +1,48 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_FUSION_DYNAMIC_MEMCPY_REWRITER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_FUSION_DYNAMIC_MEMCPY_REWRITER_H_
+
+#include <utility>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla {
+namespace gpu {
+
+// Detects fusions that can be emitted using DynamicMemcpyFusion and annotates
+// them accordingly.
+class FusionDynamicMemcpyRewriter : public HloModulePass {
+ public:
+  absl::string_view name() const override {
+    return "fusion-dynamic-memcpy-rewriter";
+  }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_FUSION_DYNAMIC_MEMCPY_REWRITER_H_

--- a/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter_test.cc
+++ b/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter_test.cc
@@ -1,0 +1,96 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/log/check.h"
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/tests/hlo_test_base.h"
+#include "tsl/platform/status_matchers.h"
+#include "tsl/platform/statusor.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+using ::tsl::testing::IsOkAndHolds;
+
+using FusionDynamicMemcpyRewriterTest = HloTestBase;
+
+bool IsMemcpyFusion(const HloInstruction* instr) {
+  const auto& config = instr->backend_config<GpuBackendConfig>();
+  return config.ok() &&
+         config->fusion_backend_config().kind() == kDynamicMemcpyFusionKind;
+}
+
+constexpr char kSliceMemcpyModule[] = R"(
+    // This fusion is technically not a dynamic memcpy. Tests for that are in
+    // the unit tests for DynamicMemcpyFusion::GetMemcpyDescriptorForFusion,
+    // in copy_test.cc. Here, we just test that the logic triggers as expected.
+    dynamic_slice {
+      p0 = s32[4] parameter(0)
+      c1 = s32[] constant(1)
+
+      ROOT slice = s32[1] dynamic-slice(p0, c1), dynamic_slice_sizes={1}
+    }
+
+    ENTRY main {
+      p0 = s32[4] parameter(0)
+      ROOT fusion = s32[1] fusion(p0), kind=kLoop, calls=dynamic_slice
+    })";
+
+TEST_F(FusionDynamicMemcpyRewriterTest, AnnotatesMemcpyFusion) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kSliceMemcpyModule));
+  EXPECT_THAT(FusionDynamicMemcpyRewriter().Run(module.get()),
+              IsOkAndHolds(true));
+  EXPECT_TRUE(IsMemcpyFusion(module->entry_computation()->root_instruction()))
+      << module->ToString();
+}
+
+constexpr char kSliceCallModule[] = R"(
+    dynamic_slice {
+      p0 = s32[4] parameter(0)
+      c1 = s32[] constant(1)
+
+      ROOT slice = s32[1] dynamic-slice(p0, c1), dynamic_slice_sizes={1}
+    }
+
+    ENTRY main {
+      p0 = s32[4] parameter(0)
+      ROOT call = s32[1] call(p0), to_apply=dynamic_slice
+    })";
+
+TEST_F(FusionDynamicMemcpyRewriterTest, DoesNotAnnotateCall) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kSliceCallModule));
+  EXPECT_THAT(FusionDynamicMemcpyRewriter().Run(module.get()),
+              IsOkAndHolds(false))
+      << module->ToString();
+  EXPECT_FALSE(IsMemcpyFusion(module->entry_computation()->root_instruction()))
+      << module->ToString();
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter_test.cc
+++ b/xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter_test.cc
@@ -23,9 +23,9 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/ir_emission_utils.h"
-#include "xla/tests/hlo_test_base.h"
 #include "tsl/platform/status_matchers.h"
 #include "tsl/platform/statusor.h"
 
@@ -35,7 +35,7 @@ namespace {
 
 using ::tsl::testing::IsOkAndHolds;
 
-using FusionDynamicMemcpyRewriterTest = HloTestBase;
+using FusionDynamicMemcpyRewriterTest = HloHardwareIndependentTestBase;
 
 bool IsMemcpyFusion(const HloInstruction* instr) {
   const auto& config = instr->backend_config<GpuBackendConfig>();


### PR DESCRIPTION
Fusion-dispatch pattern matches these fusions, after which fusions.cc
will emit the correct fusion/thunk type. This also adds an integration
test.

