### PR TITLE
Fix the EmitSort checking after enabling NVLS and user buffer

### DIFF
--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1672,10 +1672,12 @@ absl::Status IrEmitterUnnested::EmitSort(const HloSortInstruction* sort) {
         sort->operand_count() > 1 ? ShapeIndex({i}) : ShapeIndex({});
     // We assume that the layout of all involved operands and outputs is the
     // same.
-    TF_RET_CHECK(LayoutUtil::LayoutsInShapesEqual(keys_shape,
-                                                  sort->operand(i)->shape()));
+    TF_RET_CHECK(
+        LayoutUtil::LayoutsInShapesEqual(keys_shape, sort->operand(i)->shape(),
+                                         Layout::Equal().IgnoreMemorySpace()));
     TF_RET_CHECK(LayoutUtil::LayoutsInShapesEqual(
-        keys_shape, ShapeUtil::GetSubshape(sort->shape(), shape_index)));
+        keys_shape, ShapeUtil::GetSubshape(sort->shape(), shape_index),
+        Layout::Equal().IgnoreMemorySpace()));
 
     BufferAllocation::Slice destination_buffer;
     BufferAllocation::Slice source_address;

--- a/xla/service/gpu/tests/sorting_test.cc
+++ b/xla/service/gpu/tests/sorting_test.cc
@@ -69,6 +69,56 @@ ENTRY TestComputation {
   EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
+// Test that verifies the IgnoreMemorySpace option works correctly
+TEST_F(SortingTest, LayoutsInShapesEqualWithIgnoreMemorySpace) {
+  const char* hlo_text = R"(
+HloModule TestModule
+
+compare {
+  p.0.lhs = f32[] parameter(0)
+  p.0.rhs = f32[] parameter(1)
+  p.1.lhs = f32[] parameter(2)
+  p.1.rhs = f32[] parameter(3)
+  ROOT lt = pred[] compare(p.0.lhs, p.0.rhs), direction=LT
+}
+
+ENTRY TestComputation {
+  data = f32[6] parameter(0)
+  
+  // Create two copies in different memory spaces
+  keys = f32[6] copy(data)
+  values = f32[6] copy(data)
+  
+  // Sort operation with operands in different memory spaces
+  ROOT sort = (f32[6], f32[6]) sort(keys, values), dimensions={0}, to_apply=compare
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+
+  HloInstruction* values =
+      module->entry_computation()->GetInstructionWithName("values");
+  Shape values_shape = values->shape();
+  values_shape.mutable_layout()->set_memory_space(1);
+  *values->mutable_shape() = values_shape;
+
+  const HloInstruction* sort = module->entry_computation()->root_instruction();
+  EXPECT_EQ(sort->opcode(), HloOpcode::kSort);
+
+  const HloInstruction* keys = sort->operand(0);
+  const HloInstruction* values_const = sort->operand(1);
+
+  EXPECT_FALSE(
+      LayoutUtil::LayoutsInShapesEqual(keys->shape(), values->shape()));
+  EXPECT_TRUE(LayoutUtil::LayoutsInShapesEqual(
+      keys->shape(), values->shape(), Layout::Equal().IgnoreMemorySpace()));
+
+  auto literal = LiteralUtil::CreateR1<float>({1.0, 6.0, 7.0, 0.0, 2.0, 5.0});
+  absl::StatusOr<Literal> executed = Execute(std::move(module), {&literal});
+  EXPECT_TRUE(executed.ok()) << executed.status().message();
+}
+
 // Size of the radix sort tests.
 static constexpr int kRadixSortTestSize = 100000;
 


### PR DESCRIPTION
There is a reported bug from NVIDIA that running Midjourney model triggers XLA error after enabling NVLS and user buffer by setting NCCL_NVLS_ENABLE=1 and --xla_gpu_enable_nccl_user_buffers=true:
```
jaxlib.xla_extension.XlaRuntimeError: INTERNAL: RET_CHECK failure (external/xla/xla/service/gpu/ir_emitter_unnested.cc:1676) LayoutUtil::LayoutsInShapesEqual(keys_shape, sort->operand(i)->shape()).
```
This is because after enabling NVLS and user buffer, one of the operand of `sort` operation is from a different memory space (user buffer), and the previous `LayoutsInShapesEqual` check is too strong to pass as it also checks if operands are from the same memory space.

This MR makes the sort layout check weaker as operands do not have to be in the same memory space as long as they all on the device.