### PR TITLE
[ROCM] Fix vector bias add fusion into BLAS call

### DIFF
--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -130,6 +130,13 @@ absl::StatusOr<Shape> GetBatchRowColumnShape(
     case 012:  // (B,R,C) (major-to-minor)
       break;
     case 021:  // (B,C,R)
+      if (num_cols == 1) {
+        // If rhs operand has no non-contracting dims, guarantee bias vector
+        // length will still match matrix D rows with HIPBLASLT_EPILOGUE_BIAS
+        // epilogue
+        // (https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/datatypes.html).
+        break;
+      }
       order = Order::kColumnMajor;
       leading_dim_stride = num_rows;
       break;

--- a/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
@@ -3334,6 +3334,39 @@ ENTRY test {
 )");
 }
 
+TEST_F(CublasLtGemmRewriteTest, CublasLtFullyContractingRhsWithBias) {
+  const char* hlo_text = R"(
+HloModule test
+
+ENTRY test {
+  param_0 = bf16[10240,1024]{1,0} parameter(0)
+  param_1 = bf16[1024,1]{1,0} parameter(1)
+  dot = bf16[10240,1]{1,0} dot(param_0, param_1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  transpose = bf16[10240,1]{1,0} transpose(dot), dimensions={0,1}
+  param_2 = bf16[1]{0} parameter(2)
+  reshape = bf16[1]{0} reshape(param_2)
+  broadcast = bf16[10240,1]{1,0} broadcast(reshape), dimensions={1}
+  ROOT out = bf16[10240,1]{1,0} add(transpose, broadcast)
+}
+)";
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-2, 1e-2}));
+
+  if (IsCuda() &&
+      !HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {
+    GTEST_SKIP() << "Pre-Ampere casts up bf16 to fp32";
+  }
+
+  MatchOptimizedHlo(hlo_text, R"(
+; CHECK-DAG: [[LHS:%[^ ]+]] = bf16[10240,1024]{1,0} parameter(0)
+; CHECK-DAG: [[P_1:%[^ ]+]] = bf16[1024,1]{1,0} parameter(1)
+; CHECK-DAG: [[P_2:%[^ ]+]] = bf16[1]{0} parameter(2)
+; CHECK-DAG: [[RHS:%[^ ]+]] = bf16[1024]{0} {{.+}}([[P_1]])
+; CHECK-DAG: [[BIAS:%[^ ]+]] = bf16[] {{.+}}([[P_2]])
+; CHECK: custom-call([[LHS]], [[RHS]], [[BIAS]]), custom_call_target="__cublas$lt$matmul"
+)");
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
If RHS operand of GEMM has no non-contracting dims, broadcast bias vector to guarantee its length will still match matrix D rows with HIPBLASLT_EPILOGUE_BIAS epilogue required by
(https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/datatypes.html).