### PR TITLE
Fix EvaluateWithSubstitutions when the evaluated thing is substituted.

### DIFF
--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -1004,6 +1004,11 @@ absl::StatusOr<Literal> HloEvaluator::EvaluateWithSubstitutions(
     const absl::flat_hash_map<const HloInstruction*, const LiteralBase*>&
         substitutions,
     bool recursively_evaluate_nonconstant_operands) {
+  auto value = substitutions.find(instruction);
+  if (value != substitutions.end()) {
+    return value->second->Clone();
+  }
+
   std::vector<std::unique_ptr<HloInstruction>> owned_operands;
   for (const HloInstruction* operand : instruction->operands()) {
     auto it = substitutions.find(operand);

--- a/xla/hlo/evaluator/hlo_evaluator_test.cc
+++ b/xla/hlo/evaluator/hlo_evaluator_test.cc
@@ -3394,6 +3394,24 @@ TEST_P(HloEvaluatorBf16Test, EvaluateWithSubstitutionsWithConstantOperand) {
       LiteralUtil::CreateR1<float>({11, 22, 33, 44}), result));
 }
 
+// Check that EvaluateWithSubstitutions works if the thing we're evaluating is
+// being substituted.
+TEST_P(HloEvaluatorBf16Test, EvaluateSubstitutedInstruction) {
+  HloComputation::Builder b(TestName());
+  Shape shape = ShapeUtil::MakeShape(F32, {4});
+
+  HloInstruction* param =
+      b.AddInstruction(HloInstruction::CreateParameter(0, shape, "param0"));
+
+  HloEvaluator evaluator;
+  Literal literal = LiteralUtil::CreateR1<float>({10, 20, 30, 40});
+  TF_ASSERT_OK_AND_ASSIGN(
+      Literal result,
+      evaluator.EvaluateWithSubstitutions(param, {{param, &literal}}));
+  EXPECT_TRUE(LiteralTestUtil::Equal(
+      LiteralUtil::CreateR1<float>({10, 20, 30, 40}), result));
+}
+
 TEST_F(HloEvaluatorTest, EvaluateWithSubstitutionsLiteralBase) {
   HloComputation::Builder b(TestName());
   Shape shape = ShapeUtil::MakeShape(S64, {3});


### PR DESCRIPTION
Currently, this results in an error, which is surprising. There seems no benefit to the current behavior, so let's just return the substitued value for this case.