### PR TITLE
Remove HloComputation::WhileCallInstruction.

### DIFF
--- a/xla/hlo/ir/hlo_computation.cc
+++ b/xla/hlo/ir/hlo_computation.cc
@@ -293,7 +293,7 @@ static void DecrementCount(
   }
 }
 
-void HloComputation::AddCallee(const HloInstruction* caller,
+void HloComputation::AddCallee(HloInstruction* caller,
                                HloComputation* callee) {
   IncrementCount(callee_computations_, callee);
   IncrementCount(callee->caller_computations_, this);
@@ -318,7 +318,7 @@ void HloComputation::AddCallee(const HloInstruction* caller,
   }
 }
 
-void HloComputation::RemoveCallee(const HloInstruction* caller,
+void HloComputation::RemoveCallee(HloInstruction* caller,
                                   HloComputation* callee) {
   CHECK(caller);
   CHECK(callee);
@@ -343,22 +343,21 @@ void HloComputation::RemoveCallee(const HloInstruction* caller,
   }
 }
 
-absl::flat_hash_map<const HloInstruction*, int>*
-HloComputation::GetCallersMap() {
+absl::flat_hash_map<HloInstruction*, int>* HloComputation::GetCallersMap() {
   if (static_cast<CallersType>(callers_ & kCallerTypeMask) ==
       CallersType::kCallerCountHashMap) {
-    return reinterpret_cast<absl::flat_hash_map<const HloInstruction*, int>*>(
+    return reinterpret_cast<absl::flat_hash_map< HloInstruction*, int>*>(
         callers_ & ~kCallerTypeMask);
   }
   return nullptr;
 }
 
-absl::flat_hash_map<const HloInstruction*, int>* const
-HloComputation::GetCallersMap() const {
+absl::flat_hash_map<HloInstruction*, int>* const HloComputation::GetCallersMap()
+    const {
   if (static_cast<CallersType>(callers_ & kCallerTypeMask) ==
       CallersType::kCallerCountHashMap) {
     return reinterpret_cast<
-        absl::flat_hash_map<const HloInstruction*, int>* const>(
+        absl::flat_hash_map< HloInstruction*, int>* const>(
         callers_ & ~kCallerTypeMask);
   }
   return nullptr;

--- a/xla/hlo/ir/hlo_computation.h
+++ b/xla/hlo/ir/hlo_computation.h
@@ -219,8 +219,6 @@ class HloComputation {
     kCustomCall,
     // This computation is a collective computation.
     kCollective,
-    // This computation is a while body computation.
-    kWhile,
     // This computation is a conditional branch computation.
     kConditional,
     // Last Value for range checking.
@@ -841,30 +839,6 @@ class HloComputation {
     SetInstruction(collective_call_instruction, InstructionType::kCollective);
   }
 
-  // Returns if this computation is a body computation of a while.
-  [[deprecated(
-      "This is broken. Use CallGraph::GetComputationCallers() instead")]]
-  bool IsWhileBodyComputation() const {
-    return instruction_type() == InstructionType::kWhile;
-  }
-
-  // Returns the owning while call instruction, or nullptr if this is not a
-  // while call body computation.
-  [[deprecated(
-      "This is broken. Use CallGraph::GetComputationCallers() instead")]]
-  HloInstruction* WhileCallInstruction() const {
-    return instruction_type() == InstructionType::kWhile ? instruction()
-                                                         : nullptr;
-  }
-
-  [[deprecated(
-      "This is broken. Use CallGraph::GetComputationCallers() instead")]]
-  void SetWhileCallInstruction(HloInstruction* while_call_instruction) {
-    CHECK(while_call_instruction != nullptr);
-    CHECK(while_call_instruction->opcode() == HloOpcode::kWhile);
-    SetInstruction(while_call_instruction, InstructionType::kWhile);
-  }
-
   // Returns if this computation is a branch computation of a conditional.
   [[deprecated(
       "This is broken. Use CallGraph::GetComputationCallers() instead")]]
@@ -983,11 +957,15 @@ class HloComputation {
   }
 
   // The returned callers are in no particular order.
-  absl::InlinedVector<const HloInstruction*, 1> caller_instructions() const {
+  absl::InlinedVector<HloInstruction*, 1> caller_instructions(
+      std::optional<HloOpcode> caller_opcode = std::nullopt) const {
     if (const auto* map = GetCallersMap()) {
-      absl::InlinedVector<const HloInstruction*, 1> result;
-      for (const auto& [instr, _] : *map) {
-        result.push_back(instr);
+      absl::InlinedVector<HloInstruction*, 1> result;
+      for (auto [instr, _] : *map) {
+        if (caller_opcode == std::nullopt ||
+            instr->opcode() == *caller_opcode) {
+          result.push_back(instr);
+        }
       }
       return result;
     }
@@ -995,8 +973,23 @@ class HloComputation {
     if (callers_ == 0) {
       return {};
     }
-    return {
-        reinterpret_cast<const HloInstruction*>(callers_ & ~kCallerTypeMask)};
+
+    auto* instr =
+        reinterpret_cast<HloInstruction*>(callers_ & ~kCallerTypeMask);
+    if (caller_opcode == std::nullopt || instr->opcode() == *caller_opcode) {
+      return {instr};
+    }
+
+    return {};
+  }
+
+  // Returns the only caller with the given opcode, if there is exactly one.
+  std::optional<HloInstruction*> GetUniqueCaller(HloOpcode opcode) {
+    auto callers = caller_instructions(opcode);
+    if (callers.size() == 1) {
+      return callers.front();
+    }
+    return std::nullopt;
   }
 
   void ClearCalledComputations();
@@ -1076,12 +1069,12 @@ class HloComputation {
   friend class HloInstruction;
   // Add/remove call from `caller`, which must be in this computation, to
   // `callee`.
-  void AddCallee(const HloInstruction* caller, HloComputation* callee);
-  void RemoveCallee(const HloInstruction* caller, HloComputation* callee);
+  void AddCallee(HloInstruction* caller, HloComputation* callee);
+  void RemoveCallee(HloInstruction* caller, HloComputation* callee);
 
   // Returns nullptr if `callers_` is not a map.
-  absl::flat_hash_map<const HloInstruction*, int>* GetCallersMap();
-  absl::flat_hash_map<const HloInstruction*, int>* const GetCallersMap() const;
+  absl::flat_hash_map<HloInstruction*, int>* GetCallersMap();
+  absl::flat_hash_map<HloInstruction*, int>* const GetCallersMap() const;
 
   // Unique ID of this computation.
   // This is set to -1 if the computation is not in a module. Should only be

--- a/xla/hlo/ir/hlo_computation.h
+++ b/xla/hlo/ir/hlo_computation.h
@@ -984,7 +984,7 @@ class HloComputation {
   }
 
   // Returns the only caller with the given opcode, if there is exactly one.
-  std::optional<HloInstruction*> GetUniqueCaller(HloOpcode opcode) {
+  std::optional<HloInstruction*> GetUniqueCaller(HloOpcode opcode) const {
     auto callers = caller_instructions(opcode);
     if (callers.size() == 1) {
       return callers.front();

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -2862,8 +2862,7 @@ class HloParameterizedParserTest
     for (HloComputation* computation : module->computations()) {
       for (HloInstruction* instr : computation->instructions()) {
         if (instr->opcode() == HloOpcode::kWhile) {
-          EXPECT_EQ(instr->while_body()->WhileCallInstruction(), instr);
-          EXPECT_TRUE(instr->while_body()->IsWhileBodyComputation());
+          EXPECT_EQ(instr->while_body()->GetUniqueCaller(HloOpcode::kWhile), instr);
         }
       }
     }

--- a/xla/hlo/transforms/collectives/all_gather_combiner.cc
+++ b/xla/hlo/transforms/collectives/all_gather_combiner.cc
@@ -239,7 +239,7 @@ absl::StatusOr<bool> AllGatherCombiner::RunWithKeyCombiner(
   bool changed = false;
   for (HloComputation* computation :
        module->MakeNonfusionComputations(execution_threads)) {
-    if (!combine_while_loops_ && computation->IsWhileBodyComputation()) {
+    if (!combine_while_loops_ && computation->GetUniqueCaller(HloOpcode::kWhile)) {
       VLOG(2) << "Skipping this computation because the computation is a while "
                  "loop body: "
               << computation->ToString();

--- a/xla/hlo/transforms/collectives/while_loop_all_reduce_code_motion_setup.cc
+++ b/xla/hlo/transforms/collectives/while_loop_all_reduce_code_motion_setup.cc
@@ -34,7 +34,7 @@ namespace xla {
 bool ReorderReduceTranspose::InstructionMatchesPattern(
     HloInstruction* instruction) {
   // Instruction must be in while loop body.
-  if (!instruction->parent()->IsWhileBodyComputation()) {
+  if (!instruction->parent()->GetUniqueCaller(HloOpcode::kWhile)) {
     return false;
   }
   // Search for Reduce Scatter Transpose pairs with optional convert in between
@@ -159,7 +159,7 @@ absl::StatusOr<HloInstruction*> ReorderReduceTranspose::ExpandInstruction(
 bool ReorderConvertReduceAdd::InstructionMatchesPattern(
     HloInstruction* instruction) {
   // Instruction must be in while loop body.
-  if (!instruction->parent()->IsWhileBodyComputation()) {
+  if (!instruction->parent()->GetUniqueCaller(HloOpcode::kWhile)) {
     return false;
   }
   // Check if the instruction is an add operation

--- a/xla/hlo/transforms/simplifiers/flatten_call_graph.cc
+++ b/xla/hlo/transforms/simplifiers/flatten_call_graph.cc
@@ -148,9 +148,6 @@ absl::Status AnnotateNode(const CallGraphNode& node) {
         computation->SetCollectiveCallInstruction(instruction);
       }
 
-    } else if (instruction->opcode() == HloOpcode::kWhile) {
-      instruction->while_body()->SetWhileCallInstruction(instruction);
-
     } else if (instruction->opcode() == HloOpcode::kConditional) {
       for (HloComputation* branch : instruction->branch_computations()) {
         branch->SetConditionalCallInstruction(instruction);

--- a/xla/service/copy_insertion.cc
+++ b/xla/service/copy_insertion.cc
@@ -2114,7 +2114,7 @@ absl::Status CopyInsertion::AddCopiesForAsyncSendRecv(
 
   // For other cases that send/recv are outside of the while loop, live times
   // are disjoint. No copies are needed.
-  if (!parent->IsWhileBodyComputation()) {
+  if (!parent->GetUniqueCaller(HloOpcode::kWhile)) {
     return absl::OkStatus();
   }
 

--- a/xla/service/copy_insertion.cc
+++ b/xla/service/copy_insertion.cc
@@ -2114,7 +2114,7 @@ absl::Status CopyInsertion::AddCopiesForAsyncSendRecv(
 
   // For other cases that send/recv are outside of the while loop, live times
   // are disjoint. No copies are needed.
-  if (!parent->caller_instructions(HloOpcode::kWhile).empty()) {
+  if (parent->caller_instructions(HloOpcode::kWhile).empty()) {
     return absl::OkStatus();
   }
 

--- a/xla/service/copy_insertion.cc
+++ b/xla/service/copy_insertion.cc
@@ -2114,7 +2114,7 @@ absl::Status CopyInsertion::AddCopiesForAsyncSendRecv(
 
   // For other cases that send/recv are outside of the while loop, live times
   // are disjoint. No copies are needed.
-  if (!parent->GetUniqueCaller(HloOpcode::kWhile)) {
+  if (!parent->caller_instructions(HloOpcode::kWhile).empty()) {
     return absl::OkStatus();
   }
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -1029,7 +1029,7 @@ absl::Status IrEmitterUnnested::EmitCholeskyThunk(const HloInstruction* instr) {
   TF_ASSIGN_OR_RETURN(CholeskyOptions options,
                       instr->backend_config<CholeskyOptions>());
   const Shape& shape = instr->operand(0)->shape();
-  int ndim = shape.rank();
+  int ndim = shape.dimensions_size();
   CHECK_GE(ndim, 2);
   int64_t n = shape.dimensions(ndim - 1);
 
@@ -1863,7 +1863,7 @@ absl::Status IrEmitterUnnested::EmitCollectivePermute(
   const int64_t partition_count = hlo_config.num_partitions();
 
   auto operands = instr->operands();
-  std::vector<CollectiveThunk::Buffer> buffers;
+  std::vector<NcclCollectiveThunk::Buffer> buffers;
   for (int oprd_idx = 0; oprd_idx < operands.size(); ++oprd_idx) {
     const auto operand = operands.at(oprd_idx);
     const ShapeIndex nested_shape_idx = {1, oprd_idx}, normal_shape_idx = {1};
@@ -1893,7 +1893,7 @@ absl::Status IrEmitterUnnested::EmitCollectivePermute(
       // Signal that start thunk not created with nullptr.
       GetCollectivesAsyncEvents().try_emplace(instr, nullptr);
     } else {
-      const CollectiveThunk::Buffer buffer = {
+      const NcclCollectiveThunk::Buffer buffer = {
           /*element_count=*/ShapeUtil::ElementsIn(operand_shape),
           /*source_buffer=*/source_slice,
           /*destination_buffer=*/result_slice,
@@ -1944,9 +1944,9 @@ absl::Status IrEmitterUnnested::EmitCollectiveThunk(
       inst, replica_count, partition_count);
   bool should_use_nccl_thunk = !is_degenerate && implementable_status.ok();
 
-  // Stash relevant information in CollectiveThunk::Buffer even if we may
-  // not generate an CollectiveThunk.
-  std::vector<CollectiveThunk::Buffer> buffers;
+  // Stash relevant information in NcclCollectiveThunk::Buffer even if we may
+  // not generate an NcclCollectiveThunk.
+  std::vector<NcclCollectiveThunk::Buffer> buffers;
 
   int64_t operand_count = inst->operand_count();
   buffers.reserve(operand_count);
@@ -1955,14 +1955,14 @@ absl::Status IrEmitterUnnested::EmitCollectiveThunk(
   auto add_buffer = [&](int64_t element_count, BufferAllocation::Slice src,
                         int64_t src_memory_space, BufferAllocation::Slice dst,
                         int64_t dst_memory_space) {
-    buffers.push_back(
-        CollectiveThunk::Buffer{/*element_count=*/element_count,
-                                /*source_buffer=*/src,
-                                /*destination_buffer=*/dst,
-                                /*source_memory_space=*/src_memory_space,
-                                /*destination_memory_space=*/dst_memory_space,
-                                /*source_value=*/nullptr,
-                                /*destination_value=*/nullptr});
+    buffers.push_back(NcclCollectiveThunk::Buffer{
+        /*element_count=*/element_count,
+        /*source_buffer=*/src,
+        /*destination_buffer=*/dst,
+        /*source_memory_space=*/src_memory_space,
+        /*destination_memory_space=*/dst_memory_space,
+        /*source_value=*/nullptr,
+        /*destination_value=*/nullptr});
   };
 
   if (kind == Thunk::Kind::kAllGatherStart) {
@@ -2115,8 +2115,9 @@ static const HloInstruction* FindCanonicalSendRecvStartOp(
           unique_user->opcode() == HloOpcode::kWhile);
     if (unique_user->IsRoot()) {
       // send/recv op in the loop body.
-      CHECK(unique_user->parent()->IsWhileBodyComputation());
-      while_op = unique_user->parent()->WhileCallInstruction();
+      auto maybe_while_op = unique_user->parent()->GetUniqueCaller(HloOpcode::kWhile);
+      CHECK(maybe_while_op);
+      while_op = *maybe_while_op;
       i = unique_user->operand_index(inst);
     } else {
       // send/recv leading into the loop.
@@ -2146,8 +2147,9 @@ static const HloInstruction* FindCanonicalSendRecvStartOp(
     if (iter_tuple->opcode() == HloOpcode::kParameter) {
       // send-done/recv-done in the loop body.
       CHECK(Cast<HloParameterInstruction>(iter_tuple)->parameter_number() == 0);
-      CHECK(operand->parent()->IsWhileBodyComputation());
-      while_op = iter_tuple->parent()->WhileCallInstruction();
+      auto maybe_while = iter_tuple->parent()->GetUniqueCaller(HloOpcode::kWhile);
+      CHECK(maybe_while);
+      while_op = *maybe_while;
       i = gte->tuple_index();
     } else {
       // send-done/recv-done proceeding the loop.
@@ -2215,7 +2217,7 @@ absl::Status IrEmitterUnnested::EmitCollectiveAsyncDone(
   if (is_send_recv) {
     stream_kind = GetStreamKindForP2P(start);
   }
-  AddThunkToThunkSequence(std::make_unique<CollectiveDoneThunk>(
+  AddThunkToThunkSequence(std::make_unique<NcclCollectiveDoneThunk>(
       kind, Thunk::ThunkInfo::WithProfileAnnotation(inst),
       async_events_it->second, stream_kind));
   return absl::OkStatus();
@@ -2451,7 +2453,7 @@ absl::Status IrEmitterUnnested::EmitSendThunk(const HloSendInstruction* instr) {
         instr->shape().IsTuple()
             ? instr->shape().tuple_shapes(0).layout().memory_space()
             : instr->shape().layout().memory_space();
-    const CollectiveThunk::Buffer nccl_buffer = {
+    const NcclCollectiveThunk::Buffer nccl_buffer = {
         /*element_count=*/ShapeUtil::ElementsIn(src->shape()),
         /*source_buffer=*/buffer,
         /*destination_buffer=*/buffer,
@@ -2525,7 +2527,7 @@ absl::Status IrEmitterUnnested::EmitRecvThunk(const HloRecvInstruction* instr) {
             ? instr->shape().tuple_shapes(0).layout().memory_space()
             : instr->shape().layout().memory_space();
 
-    const CollectiveThunk::Buffer nccl_buffer = {
+    const NcclCollectiveThunk::Buffer nccl_buffer = {
         /*element_count=*/ShapeUtil::ElementsIn(instr->shape().tuple_shapes(0)),
         /*source_buffer=*/buffer,
         /*destination_buffer=*/buffer,

--- a/xla/service/gpu/transforms/collective_permute_valid_iteration_annotator.cc
+++ b/xla/service/gpu/transforms/collective_permute_valid_iteration_annotator.cc
@@ -102,60 +102,55 @@ absl::StatusOr<bool> CollectivePermuteValidIterationAnnotator::Run(
         continue;
       }
 
-      auto maybe_while = inst->parent()->GetUniqueCaller(HloOpcode::kWhile);
-      if (!maybe_while.has_value()) {
-        VLOG(2) << "No surrounding while op found. Ignoring " << inst->name();
-        continue;
-      }
+      for (auto* while_op : inst->parent()->caller_instructions(HloOpcode::kWhile)) {
+        if (!while_op->frontend_attributes().map().contains(
+                "is_pipelined_while_loop")) {
+          continue;
+        }
 
-      auto* while_op = *maybe_while;
-      if (!while_op->frontend_attributes().map().contains(
-              "is_pipelined_while_loop")) {
-        continue;
-      }
+        TF_ASSIGN_OR_RETURN(WhileLoopBackendConfig config,
+                            while_op->backend_config<WhileLoopBackendConfig>());
+        if (!config.has_known_trip_count()) {
+          VLOG(2) << "Trip count for while loop (" << while_op->name()
+                  << "): unknown";
+          continue;
+        }
 
-      TF_ASSIGN_OR_RETURN(WhileLoopBackendConfig config,
-                          while_op->backend_config<WhileLoopBackendConfig>());
-      if (!config.has_known_trip_count()) {
+        int64_t trip_count = config.known_trip_count().n();
+        std::optional<int64_t> step = GetStep(while_op);
         VLOG(2) << "Trip count for while loop (" << while_op->name()
-                << "): unknown";
-        continue;
-      }
+                << "): " << trip_count;
+        if (!step) {
+          VLOG(2) << "Could not find step for while operation";
+          continue;
+        }
+        VLOG(2) << "Step for while loop (" << while_op->name() << "): " << *step;
+        if (*step != 1) {
+          VLOG(2) << "Step is not 1. Skipping...";
+          continue;
+        }
 
-      int64_t trip_count = config.known_trip_count().n();
-      std::optional<int64_t> step = GetStep(while_op);
-      VLOG(2) << "Trip count for while loop (" << while_op->name()
-              << "): " << trip_count;
-      if (!step) {
-        VLOG(2) << "Could not find step for while operation";
-        continue;
-      }
-      VLOG(2) << "Step for while loop (" << while_op->name() << "): " << *step;
-      if (*step != 1) {
-        VLOG(2) << "Step is not 1. Skipping...";
-        continue;
-      }
+        // For each source i, the send/recv iteration instances are {i, i+offset}
+        // where offset is `number of microbatches * CR - 1`. We know that
+        // `trip_count = number_of_microbatches * CR + num_devices - 1` So, offset
+        // = number_of_microbatches * CR - 1 = trip_count - num_devices.
+        SourceTargetPairs sourceTargetPairs(inst->source_target_pairs());
+        int64_t num_devices = sourceTargetPairs.GetMaxDeviceNum() + 1;
+        int64_t offset = trip_count - num_devices;
+        SourceTargetPairs sendRecvValidation;
+        for (int64_t currIdx = 0; currIdx < sourceTargetPairs.size(); currIdx++) {
+          sendRecvValidation.emplace_back(currIdx, currIdx + offset);
+        }
 
-      // For each source i, the send/recv iteration instances are {i, i+offset}
-      // where offset is `number of microbatches * CR - 1`. We know that
-      // `trip_count = number_of_microbatches * CR + num_devices - 1` So, offset
-      // = number_of_microbatches * CR - 1 = trip_count - num_devices.
-      SourceTargetPairs sourceTargetPairs(inst->source_target_pairs());
-      int64_t num_devices = sourceTargetPairs.GetMaxDeviceNum() + 1;
-      int64_t offset = trip_count - num_devices;
-      SourceTargetPairs sendRecvValidation;
-      for (int64_t currIdx = 0; currIdx < sourceTargetPairs.size(); currIdx++) {
-        sendRecvValidation.emplace_back(currIdx, currIdx + offset);
-      }
+        if (cycleType == CycleType::kBackward) {
+          std::reverse(sendRecvValidation.data().begin(),
+                      sendRecvValidation.data().end());
+        }
 
-      if (cycleType == CycleType::kBackward) {
-        std::reverse(sendRecvValidation.data().begin(),
-                     sendRecvValidation.data().end());
+        inst->set_frontend_attribute(kSendRecvValidationAttr,
+                                    sendRecvValidation.ToString());
+        changed = true;
       }
-
-      inst->set_frontend_attribute(kSendRecvValidationAttr,
-                                   sendRecvValidation.ToString());
-      changed = true;
     }
   }
   return changed;

--- a/xla/service/hlo_graph_dumper.cc
+++ b/xla/service/hlo_graph_dumper.cc
@@ -679,7 +679,7 @@ bool HloDotDumper::ShouldShowSubcomputation(const HloComputation* subcomp) {
     return false;
   }
 
-  if (subcomp->WhileCallInstruction() != nullptr &&
+  if (!subcomp->caller_instructions(HloOpcode::kWhile).empty() &&
       !hlo_render_options_.show_while_subcomputations) {
     return false;
   }

--- a/xla/service/hlo_instruction_test.cc
+++ b/xla/service/hlo_instruction_test.cc
@@ -2712,25 +2712,16 @@ TEST_F(HloInstructionTest, VerifyBodyComputationPointsToWhile) {
   module->AddEntryComputation(main_builder.Build());
   // Should find one while body computation in the graph and it should point to
   // the while instruction.
-  int num_while_body_comp = 0;
-  for (HloComputation* comp : module->MakeComputationPostOrder()) {
-    if (comp->IsWhileBodyComputation()) {
-      num_while_body_comp += 1;
-      EXPECT_EQ(comp->WhileCallInstruction(),
-                module->entry_computation()->root_instruction());
-    }
-  }
-  EXPECT_EQ(num_while_body_comp, 1);
-
+  int num_whiles = 0;
   for (HloInstruction* instruction :
        module->entry_computation()->instructions()) {
     if (instruction->opcode() == HloOpcode::kWhile) {
-      HloComputation* while_body = instruction->while_body();
-      EXPECT_TRUE(while_body->IsWhileBodyComputation());
-      HloInstruction* while_back_ref = while_body->WhileCallInstruction();
-      EXPECT_EQ(while_back_ref->while_body(), while_body);
+      ++num_whiles;
+      EXPECT_EQ(instruction->GetUniqueCaller(HloOpcode::kWhile),
+                module->entry_computation()->root_instruction());
     }
   }
+  EXPECT_EQ(num_whiles, 1);
 }
 
 TEST_F(HloInstructionTest,

--- a/xla/service/profile_guided_latency_estimator.cc
+++ b/xla/service/profile_guided_latency_estimator.cc
@@ -173,7 +173,7 @@ absl::Status ProfileGuidedLatencyEstimator::CheckAccuracy(
     // to avoid fine-grained exclusion of fusion computations, wrapped async
     // computations, trivial to_apply computations (present in e.g. reductions)
     // etc.
-    if (!comp->IsEntryComputation() && !comp->IsWhileBodyComputation()) {
+    if (!comp->IsEntryComputation() && !comp->GetUniqueCaller(HloOpcode::kWhile)) {
       continue;
     }
     for (const HloInstruction* instr : comp->MakeInstructionPostOrder()) {

--- a/xla/service/reduce_scatter_combiner.cc
+++ b/xla/service/reduce_scatter_combiner.cc
@@ -222,7 +222,7 @@ absl::StatusOr<bool> ReduceScatterCombiner::RunWithKeyCombiner(
   bool changed = false;
   for (HloComputation* computation :
        module->MakeNonfusionComputations(execution_threads)) {
-    if (!combine_while_loops_ && computation->IsWhileBodyComputation()) {
+    if (!combine_while_loops_ && computation->GetUniqueCaller(HloOpcode::kWhile)) {
       VLOG(2) << "Skipping this computation because the computation is a while "
                  "loop body: "
               << computation->ToString();

--- a/xla/service/scan_loop_accumulator_input_unification.cc
+++ b/xla/service/scan_loop_accumulator_input_unification.cc
@@ -33,7 +33,6 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/transforms/simplifiers/tuple_simplifier.h"
 #include "xla/literal_util.h"
-#include "xla/service/call_graph.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/service/while_loop_simplifier.h"
 #include "xla/service/while_loop_unroller.h"
@@ -210,16 +209,8 @@ FindAccumulatorInputPairs(const HloAliasAnalysis& alias_analysis,
 absl::StatusOr<bool> UnifyAccumulatorWithInput(
     const HloAliasAnalysis& alias_analysis,
     std::vector<std::pair<HloInstruction*, WhileLoopConfig>> unrollable_loops) {
-  // TODO(b/333521102): Helper function to check if a computation is a body of a
-  // while call. Currently, IsWhileBodyComputation api call does not work
-  // properly so we check it ourself. We should switch to IsWhileBodyComputation
-  // when it's fixed.
-  std::unique_ptr<CallGraph> call_graph =
-      CallGraph::Build(&alias_analysis.dataflow_analysis().module());
   auto is_while_body = [&](HloComputation* comp) {
-    std::vector<HloInstruction*> callers =
-        call_graph->GetComputationCallers(comp);
-    return !callers.empty() && callers.at(0)->opcode() == HloOpcode::kWhile;
+    return comp->GetUniqueCaller(HloOpcode::kWhile).has_value();
   };
 
   std::vector<HloInstruction*> changed_loops;

--- a/xla/service/spmd/stateful_rng_spmd_partitioner.cc
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner.cc
@@ -90,11 +90,11 @@ bool StatefulRngSpmdPartitioner::CanSideEffectingHaveReplicatedSharding(
 
 absl::Status StatefulRngSpmdPartitioner::HandleRotateRightWhilePreprocessing(
     HloComputation* computation) {
-  if (!computation->IsWhileBodyComputation()) {
+  auto maybe_while = computation->GetUniqueCaller(HloOpcode::kWhile);
+  if (!maybe_while) {
     return absl::OkStatus();
   }
-  HloInstruction* while_loop = computation->WhileCallInstruction();
-  TF_RET_CHECK(while_loop);
+  HloInstruction* while_loop = *maybe_while;
   if (computation->parent()
           ->config()
           .debug_options()

--- a/xla/service/while_loop_all_reduce_code_motion.cc
+++ b/xla/service/while_loop_all_reduce_code_motion.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/literal_util.h"
 #include "xla/map_util.h"
+#include "xla/service/call_graph.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/statusor.h"
@@ -979,6 +980,7 @@ absl::StatusOr<bool> WhileLoopAllReduceCodeMotion::Run(
   // loop. We recursively sink the all-reduce through nested while loops if
   // applicable by repeating this process.
   uint32_t count_all_reduce = 0, count_reduce_scatter = 0;
+  std::unique_ptr<CallGraph> call_graph = CallGraph::Build(module);
   // We process all callees of a computation before processing the computation,
   // so that when we process a computation, the all-reduce instructions that
   // need to be hoisted to the computation from its callees have been hoisted.
@@ -987,8 +989,18 @@ absl::StatusOr<bool> WhileLoopAllReduceCodeMotion::Run(
     // A computation could be the while body of multiple while instructions,
     // so we start from the computation and find all of its callers that is a
     // kWhile if there is any.
-    auto while_caller_instructions =
-        computation->caller_instructions(HloOpcode::kWhile);
+    std::vector<HloInstruction*> computation_callers =
+        call_graph->GetComputationCallers(computation);
+    std::vector<HloInstruction*> while_caller_instructions;
+    for (HloInstruction* caller_instruction : computation_callers) {
+      // For simplicity, we only support while instructions whose shape is
+      // tuple.
+      if (caller_instruction->opcode() == HloOpcode::kWhile &&
+          caller_instruction->shape().IsTuple() &&
+          caller_instruction->while_body() == computation) {
+        while_caller_instructions.push_back(caller_instruction);
+      }
+    }
     // Skip to next computation if this computation is not the while body of
     // any while instruction.
     if (while_caller_instructions.empty()) {
@@ -1052,6 +1064,11 @@ absl::StatusOr<bool> WhileLoopAllReduceCodeMotion::Run(
       }
       TF_RETURN_IF_ERROR(computation->ReplaceInstructionWithDifferentShape(
           all_reduce, all_reduce->mutable_operand(0)));
+    }
+    // Needs to rebuild the call graph after we remove instructions to avoid
+    // accessing removed instructions.
+    if (!all_reduce_to_accumulations.empty()) {
+      call_graph = CallGraph::Build(module);
     }
   }
   VLOG(2) << "Hoisted " << count_all_reduce << " all-reduce and "

--- a/xla/service/while_loop_all_reduce_code_motion.cc
+++ b/xla/service/while_loop_all_reduce_code_motion.cc
@@ -37,7 +37,6 @@ limitations under the License.
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/literal_util.h"
 #include "xla/map_util.h"
-#include "xla/service/call_graph.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/statusor.h"
@@ -980,7 +979,6 @@ absl::StatusOr<bool> WhileLoopAllReduceCodeMotion::Run(
   // loop. We recursively sink the all-reduce through nested while loops if
   // applicable by repeating this process.
   uint32_t count_all_reduce = 0, count_reduce_scatter = 0;
-  std::unique_ptr<CallGraph> call_graph = CallGraph::Build(module);
   // We process all callees of a computation before processing the computation,
   // so that when we process a computation, the all-reduce instructions that
   // need to be hoisted to the computation from its callees have been hoisted.
@@ -989,18 +987,8 @@ absl::StatusOr<bool> WhileLoopAllReduceCodeMotion::Run(
     // A computation could be the while body of multiple while instructions,
     // so we start from the computation and find all of its callers that is a
     // kWhile if there is any.
-    std::vector<HloInstruction*> computation_callers =
-        call_graph->GetComputationCallers(computation);
-    std::vector<HloInstruction*> while_caller_instructions;
-    for (HloInstruction* caller_instruction : computation_callers) {
-      // For simplicity, we only support while instructions whose shape is
-      // tuple.
-      if (caller_instruction->opcode() == HloOpcode::kWhile &&
-          caller_instruction->shape().IsTuple() &&
-          caller_instruction->while_body() == computation) {
-        while_caller_instructions.push_back(caller_instruction);
-      }
-    }
+    auto while_caller_instructions =
+        computation->caller_instructions(HloOpcode::kWhile);
     // Skip to next computation if this computation is not the while body of
     // any while instruction.
     if (while_caller_instructions.empty()) {
@@ -1064,11 +1052,6 @@ absl::StatusOr<bool> WhileLoopAllReduceCodeMotion::Run(
       }
       TF_RETURN_IF_ERROR(computation->ReplaceInstructionWithDifferentShape(
           all_reduce, all_reduce->mutable_operand(0)));
-    }
-    // Needs to rebuild the call graph after we remove instructions to avoid
-    // accessing removed instructions.
-    if (!all_reduce_to_accumulations.empty()) {
-      call_graph = CallGraph::Build(module);
     }
   }
   VLOG(2) << "Hoisted " << count_all_reduce << " all-reduce and "


### PR DESCRIPTION
The function is deprecated and broken. I'll remove the remaining similar functions one by one. The caller API I added in the previous PR was too `const`, fixed that as well.