### PR TITLE
Add missing hlo_argument_modes to the error message

### DIFF
--- a/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
+++ b/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
@@ -133,10 +133,10 @@ ArgumentModeFromString(absl::string_view text) {
     return FunctionalHloRunner::ModuleArgumentMode::kUninitialized;
   }
   return absl::InvalidArgumentError(
-      absl::StrCat("Unrecognized module argument mode specified. Expect "
-                   "\"use_device_id_as_input\", \"use_random_inputs\", or "
-                   "\"use_shared_random_inputs\"., got: ",
-                   text));
+      absl::StrCat(R"(Invalid --hlo_argument_mode specified. Expected one of: )"
+                   R"("use_device_id_as_input", "use_random_inputs", )"
+                   R"("use_shared_random_inputs", "use_zeros_as_input", or )",
+                   R"("uninitialized". Got: )", text));
 }
 
 static absl::StatusOr<FunctionalHloRunner::PreprocessingOptions>


### PR DESCRIPTION
The `multihost_hlo_runner` supports five `--hlo_argument_mode` options, but existing error message lists only three modes.
This PR adds missing modes to the error message - specifically "use_zeros_as_input" and "uninitialized"

Additionally, the error message now uses raw string literals (R"()") to simplify the code and avoid unnecessary escape characters.