### PR TITLE
Refactor hlo_text to hlo_file for Consistent Naming in Multihost HLO Runner

### DIFF
--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
@@ -557,7 +557,7 @@ absl::Status FunctionalHloRunner::LoadAndRunAndDump(
     const xla::FunctionalHloRunner::PreprocessingOptions& preproc_options,
     const xla::FunctionalHloRunner::RawCompileOptions& raw_compile_options,
     const xla::FunctionalHloRunner::RunningOptions& running_options,
-    absl::string_view hlo_text, InputFormat input_format,
+    absl::string_view hlo_file, InputFormat input_format,
     std::string dump_output_to, int task_id, int num_nodes,
     std::shared_ptr<xla::KeyValueStoreInterface> kv_store) {
   TF_ASSIGN_OR_RETURN(
@@ -568,7 +568,7 @@ absl::Status FunctionalHloRunner::LoadAndRunAndDump(
       FunctionalHloRunner::PerDeviceLiteralVecType output,
       FunctionalHloRunner::LoadAndRun(client, debug_options, preproc_options,
                                       compile_options, running_options,
-                                      hlo_text, input_format));
+                                      hlo_file, input_format));
   return dump_output_to.empty()
              ? absl::OkStatus()
              : FunctionalHloRunner::DumpOutput(output, dump_output_to, task_id);
@@ -580,7 +580,7 @@ FunctionalHloRunner::LoadAndRun(PjRtClient& client,
                                 const PreprocessingOptions& preproc_options,
                                 const CompileOptions& compile_options,
                                 const RunningOptions& running_options,
-                                absl::string_view hlo_text,
+                                absl::string_view hlo_file,
                                 InputFormat input_format,
                                 const PerDeviceLiteralVecType& arguments,
                                 std::minstd_rand0* engine) {
@@ -590,7 +590,7 @@ FunctionalHloRunner::LoadAndRun(PjRtClient& client,
   // proper device ID, so loading and executing from HLO snapshot might not
   // replay the original execution.
   TF_ASSIGN_OR_RETURN(HloModuleAndArguments hlo_module_and_arguments,
-                      LoadHloModuleAndArguments(hlo_text, input_format));
+                      LoadHloModuleAndArguments(hlo_file, input_format));
   // Arguments from `arguments` take precedence over the arguments from a
   // snapshot.
   if (!arguments.empty()) {

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
@@ -340,7 +340,7 @@ class FunctionalHloRunner {
       const xla::FunctionalHloRunner::PreprocessingOptions& preproc_options,
       const xla::FunctionalHloRunner::RawCompileOptions& raw_compile_options,
       const xla::FunctionalHloRunner::RunningOptions& running_options,
-      absl::string_view hlo_text, InputFormat input_format,
+      absl::string_view hlo_file, InputFormat input_format,
       std::string dump_output_to = "", int task_id = 0, int num_nodes = 1,
       std::shared_ptr<xla::KeyValueStoreInterface> kv_store = nullptr);
 
@@ -353,7 +353,7 @@ class FunctionalHloRunner {
       PjRtClient& client, const DebugOptions& debug_options,
       const PreprocessingOptions& preproc_options,
       const CompileOptions& compile_options,
-      const RunningOptions& running_options, absl::string_view hlo_text,
+      const RunningOptions& running_options, absl::string_view hlo_file,
       InputFormat input_format, const PerDeviceLiteralVecType& arguments = {},
       std::minstd_rand0* engine = nullptr);
 

--- a/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
+++ b/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
@@ -268,22 +268,22 @@ static absl::Status RunMultihostHloRunner(int argc, char** argv,
   }
 
   for (int c = 1; c < argc; c++) {
-    const char* filename = argv[c];
+    const char* hlo_file = argv[c];
     execution_profiles.clear();
     if (opts.should_run) {
-      std::cout << "\n** Running " << filename << " **\n";
+      std::cout << "\n** Running " << hlo_file << " **\n";
       TF_RETURN_IF_ERROR(xla::FunctionalHloRunner::LoadAndRunAndDump(
           *env.client, GetDebugOptionsFromFlags(), preproc_options,
-          raw_compile_options, running_options, filename, opts.input_format,
+          raw_compile_options, running_options, hlo_file, opts.input_format,
           opts.dump_output_literal_to, opts.task_id));
     } else {
-      std::cout << "\n** Compiling " << filename << " **\n";
+      std::cout << "\n** Compiling " << hlo_file << " **\n";
       TF_RETURN_IF_ERROR(FunctionalHloRunner::LoadAndCompile(
           *env.client, GetDebugOptionsFromFlags(), preproc_options,
           raw_compile_options, argv[c], opts.input_format, opts.task_id));
     }
     for (int i = 0; i < execution_profiles.size(); ++i) {
-      std::cout << "## Execution time, file=" << filename << " repeat=" << i
+      std::cout << "## Execution time, file=" << hlo_file << " repeat=" << i
                 << " duration=" << execution_profiles[i].compute_time_ns()
                 << "ns" << std::endl;
     }


### PR DESCRIPTION
FunctionalHloRunner::LoadHloModuleAndArguments takes an string_view parameter named `hlo_file`, representing the file path. The file can be in various formats, such as text, proto, or snapshot.

However, the higher-level API LoadAndRun previously used the variable name `hlo_text` for the same purpose, which could be misleading since it implies content rather than a file path.

This PR updates the variable name from `hlo_text` to `hlo_file` across the relevant functions for better clarity and consistency.

Additionally, hlo_runner_main.cc used the variable name `filename` - this has also been renamed to `hlo_file` to ensure consistent naming across all API levels
