### PR TITLE
Multihost HLO runner: fix --while_execution_count behavior.

### DIFF
--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -151,6 +151,7 @@ cc_library(
         "//xla/hlo/ir:hlo",
         "//xla/hlo/parser:hlo_parser",
         "//xla/hlo/pass:hlo_pass_pipeline",
+        "//xla/hlo/transforms:while_loop_trip_count_annotator",
         "//xla/hlo/translate:stablehlo",
         "//xla/hlo/translate/hlo_to_mhlo:translate",
         "//xla/pjrt:host_memory_spaces",
@@ -216,6 +217,7 @@ xla_test(
         "data/single_device.hlo",
         "data/single_device_tupled.hlo",
         "data/single_gemm_fusion.hlo",
+        "data/while_with_known_trip_count.hlo",
     ],
     tags = ["no_mac"],
     deps = [

--- a/xla/tools/multihost_hlo_runner/data/while_with_known_trip_count.hlo
+++ b/xla/tools/multihost_hlo_runner/data/while_with_known_trip_count.hlo
@@ -1,0 +1,21 @@
+condition {
+  p = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(p), index=0
+  trip_count = s32[] constant(7)
+  done = pred[] compare(cond, trip_count), direction=LT
+}
+
+body {
+  p = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(p), index=0
+  one = s32[] constant(1)
+  cond_plus_1 = s32[] add(cond, one)
+  t = (s32[]) tuple(cond_plus_1)
+}
+
+main {
+  p = s32[] constant(0)
+  t = (s32[]) tuple(p)
+  w = (s32[]) while(t), condition=condition,
+    body=body, backend_config={"known_trip_count":{"n":"7"}}
+}

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
@@ -45,6 +45,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_sharding.h"
 #include "xla/hlo/parser/hlo_parser.h"
 #include "xla/hlo/pass/hlo_pass_pipeline.h"
+#include "xla/hlo/transforms/while_loop_trip_count_annotator.h"
 #include "xla/hlo/translate/hlo_to_mhlo/translate.h"
 #include "xla/hlo/translate/stablehlo.h"
 #include "xla/layout.h"
@@ -782,6 +783,7 @@ absl::Status FunctionalHloRunner::PrepareHloModuleForCompilation(
             preproc_options.flatten_conditional,
             /*conditional_value=*/
             preproc_options.conditional_value});
+    pipeline.AddPass<WhileLoopTripCountAnnotator>();
     TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
   }
   return absl::OkStatus();

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
@@ -783,7 +783,9 @@ absl::Status FunctionalHloRunner::PrepareHloModuleForCompilation(
             preproc_options.flatten_conditional,
             /*conditional_value=*/
             preproc_options.conditional_value});
-    pipeline.AddPass<WhileLoopTripCountAnnotator>();
+    if (preproc_options.annotate_while_loop_trip_count) {
+      pipeline.AddPass<WhileLoopTripCountAnnotator>();
+    }
     TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
   }
   return absl::OkStatus();

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
@@ -243,6 +243,9 @@ class FunctionalHloRunner {
       return while_execution_count.has_value();
     }
 
+    // Set / update known_trip_count in while loop backend config.
+    bool annotate_while_loop_trip_count = false;
+
     // Is the module the partitioned result of SPMD?
     bool is_spmd_partitioned_module() const {
       return spmd_partitioned_mode ==

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -393,6 +393,16 @@ TEST_F(FunctionalHloRunnerTest, CanCompileWithoutHavingEnoughGpus) {
                         /*num_partitions=*/16);
 }
 
+TEST_F(FunctionalHloRunnerTest, WhileKnownTripCountGetsCapped) {
+  compile_and_filecheck(
+      GetHloPath("while_with_known_trip_count.hlo"),
+      R"(
+      // CHECK: constant(5)
+      // CHECK: "known_trip_count":{"n":"5"}
+    )",
+      FunctionalHloRunner::PreprocessingOptions{.while_execution_count = 5});
+}
+
 // Name of the test binary.
 static const char* binary_name;
 constexpr int kNumNodes = 2;

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -58,6 +58,7 @@ namespace xla {
 namespace {
 
 using ::testing::SizeIs;
+using ::tsl::testing::IsOkAndHolds;
 using ::tsl::testing::StatusIs;
 using HloModuleAndArguments = ::xla::FunctionalHloRunner::HloModuleAndArguments;
 
@@ -343,31 +344,23 @@ TEST_F(FunctionalHloRunnerTest, UseUninitializedInputsWithTupledArguments) {
       InputFormat::kText));
 }
 
-TEST_F(FunctionalHloRunnerTest, CanCompileWithoutHavingEnoughGpus) {
-  // This test corresponds to:
-  // --num_replicas=1 --num_partitions=16
-  // --run=false --xla_dump_to=dump_dir
-
+void compile_and_filecheck(
+    absl::string_view hlo_file, absl::string_view pattern,
+    const FunctionalHloRunner::PreprocessingOptions& preproc_options,
+    const int num_partitions = 1) {
   tsl::Env* env = tsl::Env::Default();
   std::string dump_dir;
   ASSERT_TRUE(env->LocalTempFilename(&dump_dir));
   tsl::FileSystem* fs = nullptr;
   TF_ASSERT_OK(env->GetFileSystemForFile(dump_dir, &fs));
-
-  xla::DebugOptions debug_options;
-  FunctionalHloRunner::PreprocessingOptions preproc_options;
-  FunctionalHloRunner::RawCompileOptions raw_compile_options;
-  raw_compile_options.num_replicas = 1;
-  raw_compile_options.num_partitions = 16;
-  raw_compile_options.xla_dump_to = dump_dir;
-
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::PjRtClient> client,
                           GetPjRtClient());
   TF_EXPECT_OK(FunctionalHloRunner::LoadAndCompile(
-      *client, debug_options, preproc_options, raw_compile_options,
-      GetHloPath("sharded_16_devices.hlo"), InputFormat::kText));
+      *client, xla::DebugOptions{}, preproc_options,
+      FunctionalHloRunner::RawCompileOptions{.num_partitions = num_partitions,
+                                             .xla_dump_to = dump_dir},
+      hlo_file, InputFormat::kText));
 
-  // Check that the sharding was done correctly.
   {
     std::vector<std::string> after_opt_hlo_paths;
     TF_ASSERT_OK(
@@ -377,12 +370,7 @@ TEST_F(FunctionalHloRunnerTest, CanCompileWithoutHavingEnoughGpus) {
     std::string after_opt_hlo;
     TF_ASSERT_OK(
         tsl::ReadFileToString(env, after_opt_hlo_paths[0], &after_opt_hlo));
-    absl::StatusOr<bool> file_check_result = RunFileCheck(after_opt_hlo, R"(
-      // CHECK: param{{.*}} = f32[16,1]{1,0}
-      // CHECK: add{{.*}} = f32[16,1]{1,0}
-    )");
-    TF_ASSERT_OK(file_check_result.status());
-    EXPECT_TRUE(file_check_result.value());
+    EXPECT_THAT(RunFileCheck(after_opt_hlo, pattern), IsOkAndHolds(true));
   }
 
   // Check that the LLVM IR has been generated.
@@ -392,6 +380,17 @@ TEST_F(FunctionalHloRunnerTest, CanCompileWithoutHavingEnoughGpus) {
                                       &ir_paths));
     ASSERT_THAT(ir_paths, SizeIs(1));
   }
+}
+
+TEST_F(FunctionalHloRunnerTest, CanCompileWithoutHavingEnoughGpus) {
+  compile_and_filecheck(GetHloPath("sharded_16_devices.hlo"),
+                        // Check that the sharding was done correctly.
+                        R"(
+      // CHECK: param{{.*}} = f32[16,1]{1,0}
+      // CHECK: add{{.*}} = f32[16,1]{1,0}
+    )",
+                        /*preproc_options=*/{},
+                        /*num_partitions=*/16);
 }
 
 // Name of the test binary.

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -376,7 +376,7 @@ void compile_and_filecheck(
   }
 
   // Check that the LLVM IR has been generated.
-  {
+  if (!IsTestingCpu()) {
     std::vector<std::string> ir_paths;
     TF_ASSERT_OK(fs->GetMatchingPaths(fs->JoinPath(dump_dir, "*ir-no-opt.ll"),
                                       &ir_paths));

--- a/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
+++ b/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
@@ -218,6 +218,7 @@ static absl::Status RunMultihostHloRunner(int argc, char** argv,
   TF_ASSIGN_OR_RETURN(
       xla::FunctionalHloRunner::PreprocessingOptions preproc_options,
       PreprocessingOptionsFromFlags(opts));
+  preproc_options.annotate_while_loop_trip_count = true;
   TF_ASSIGN_OR_RETURN(
       xla::FunctionalHloRunner::RawCompileOptions raw_compile_options,
       RawCompileOptionsFromFlags(opts));


### PR DESCRIPTION
Optimized HLO can have known_trip_count while loop annotation, which has to be updated using WhileLoopTripCountAnnotator after HloControlFlowFlattening to apply the value of while_execution_count at
runtime.