### PR TITLE
Add support for emitting DUS as memcpy.

### DIFF
--- a/xla/backends/gpu/codegen/copy.cc
+++ b/xla/backends/gpu/codegen/copy.cc
@@ -83,28 +83,57 @@ absl::StatusOr<FusionEmissionResult> DynamicMemcpyFusion::Emit(
     const HloFusionInstruction& fusion) const {
   CHECK_EQ(analysis_.fusion_roots().size(), 1);
 
-  const auto* src_instr = &analysis_.fusion_root(0).GetOperand(0).instruction();
+  auto root = analysis_.fusion_roots().front();
+
+  int source_operand_index;
+  const Shape* copy_shape;
+
+  if (root.opcode() == HloOpcode::kDynamicUpdateSlice) {
+    // We only handle in-place DUS operations (where the source and the
+    // destination are the same). This could be extended to out-of-place DUSes,
+    // but we would either have to issue two memcpys (one of the full original
+    // buffer, one for the updated slice), or three (one for the unchanged
+    // prefix, one for the updated slice, one for the unchanged suffix). The
+    // first option is inefficient, the second option is currently not
+    // implemented: we only support dynamic offsets, no dynamic sizes.
+    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice input,
+                        buffer_assignment_->GetUniqueSlice(
+                            &root.GetOperand(0).instruction(), {}));
+    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst,
+                        buffer_assignment_->GetUniqueSlice(&fusion, {}));
+    CHECK_EQ(input, dst);
+
+    source_operand_index = 1;
+    copy_shape = &root.GetOperand(source_operand_index).shape();
+  } else {
+    source_operand_index = 0;
+    copy_shape = &root.shape();
+  }
+
+  const auto* src_instr = &root.GetOperand(source_operand_index).instruction();
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice src_buffer,
                       buffer_assignment_->GetUniqueSlice(src_instr, {}));
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst_buffer,
                       buffer_assignment_->GetUniqueSlice(&fusion, {}));
 
   FusionEmissionResult result;
-  if (src_buffer != dst_buffer) {
-    result.thunks.emplace_back(std::make_unique<DynamicMemcpyThunk>(
-        Thunk::ThunkInfo::WithProfileAnnotation(&fusion),
-        /*source_buffer=*/src_buffer,
-        /*destination_buffer=*/dst_buffer,
-        /*mem_size=*/dst_buffer.size(),
-        /*descriptor=*/descriptor_));
-  }
+  result.thunks.emplace_back(std::make_unique<DynamicMemcpyThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(&fusion),
+      /*source_buffer=*/src_buffer,
+      /*destination_buffer=*/dst_buffer,
+      /*mem_size=*/ShapeUtil::ByteSizeOfElements(*copy_shape),
+      /*descriptor=*/descriptor_));
   return result;
 }
 
 namespace {
 
 bool IsZeroOffset(const HloInstruction* slice, int dim) {
-  return slice->dynamic_slice_sizes()[dim] ==
+  if (slice->opcode() == HloOpcode::kDynamicSlice) {
+    return slice->dynamic_slice_sizes()[dim] ==
+           slice->operand(0)->shape().dimensions(dim);
+  }
+  return slice->operand(1)->shape().dimensions(dim) ==
          slice->operand(0)->shape().dimensions(dim);
 }
 
@@ -129,12 +158,22 @@ std::vector<const HloInstruction*> GetCallStack(
   return stack;
 }
 
+int GetFirstOffset(const HloInstruction* slice) {
+  // dynamic-slice takes the full array, then the offsets.
+  // dynamic-update-slice takes the full array, then the update slice, then the
+  // offsets.
+  CHECK(slice->opcode() == HloOpcode::kDynamicSlice ||
+        slice->opcode() == HloOpcode::kDynamicUpdateSlice);
+  return slice->opcode() == HloOpcode::kDynamicSlice ? 1 : 2;
+}
+
 }  // namespace
 
 bool DynamicMemcpyFusion::IsCandidateFusion(
     const HloFusionInstruction& instruction) {
   const HloInstruction* root = instruction.fused_expression_root();
-  if (root->opcode() != HloOpcode::kDynamicSlice) {
+  if (root->opcode() != HloOpcode::kDynamicSlice &&
+      root->opcode() != HloOpcode::kDynamicUpdateSlice) {
     return false;
   }
 
@@ -151,14 +190,17 @@ bool DynamicMemcpyFusion::IsCandidateFusion(
     return false;
   }
 
-  if (root->operand(0)->opcode() != HloOpcode::kParameter) {
-    VLOG(5) << "Not a slice of a parameter.";
-    return false;
+  int first_offset = GetFirstOffset(root);
+  for (int i = 0; i < first_offset; ++i) {
+    if (root->operand(i)->opcode() != HloOpcode::kParameter) {
+      VLOG(5) << "Not a slice of a parameter.";
+      return false;
+    }
   }
 
   int rank = root->operand(0)->shape().rank();
   for (int i = 0; i < rank; ++i) {
-    auto* operand = root->operand(i + 1);
+    auto* operand = root->operand(i + first_offset);
     if (!IsZeroOffset(root, i) && operand->opcode() != HloOpcode::kConstant &&
         operand->opcode() != HloOpcode::kParameter) {
       VLOG(5) << "Dimension " << i << " is not a constant or a parameter.";
@@ -186,13 +228,20 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
     return std::nullopt;
   }
 
+  int first_offset = GetFirstOffset(slice);
   int rank = slice_input_shape.rank();
   auto stack = GetCallStack(fusion, call_graph);
 
   VLOG(5) << "Preconditions passed, trying to build a memcpy descriptor.";
   DynamicMemcpyThunk::MemcpyDescriptor descriptor;
+  auto& dynamic_offsets = slice->opcode() == HloOpcode::kDynamicSlice
+                              ? descriptor.src_dynamic_offsets
+                              : descriptor.dst_dynamic_offsets;
+  auto& static_offset = slice->opcode() == HloOpcode::kDynamicSlice
+                            ? descriptor.src_byte_static_offset
+                            : descriptor.dst_byte_static_offset;
   for (int i = 0; i < rank; ++i) {
-    auto* operand = slice->operand(i + 1);
+    auto* operand = slice->operand(i + first_offset);
     // If this dimension's offset is always clamped to 0, we can skip it.
     if (IsZeroOffset(slice, i)) {
       VLOG(5) << "Offset for dimension " << i << " is clamped to 0.";
@@ -208,7 +257,7 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
 
       VLOG(5) << "Offset for dimension " << i << " is constant: " << *value
               << ".";
-      descriptor.src_byte_static_offset += *value * (*strides)[i];
+      static_offset += *value * (*strides)[i];
       continue;
     }
 
@@ -230,7 +279,7 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
     }
 
     VLOG(5) << "Offset for dimension " << i << " is dynamic.";
-    descriptor.src_dynamic_offsets.emplace_back() = {
+    dynamic_offsets.emplace_back() = {
         functional_dependency->loop, functional_dependency->induction_var,
         functional_dependency->derived_value,
         /*dimension_size=*/slice_input_shape.dimensions(i),

--- a/xla/backends/gpu/codegen/copy_test.cc
+++ b/xla/backends/gpu/codegen/copy_test.cc
@@ -144,7 +144,7 @@ constexpr char kSliceMemcpyModule[] = R"(
                           "known_induction_variable":{"tuple_index":"0"}}
     })";
 
-TEST_F(CopyFusionTest, BuildDescriptor) {
+TEST_F(CopyFusionTest, BuildSliceDescriptor) {
   TF_ASSERT_OK_AND_ASSIGN(auto module,
                           ParseAndReturnVerifiedModule(kSliceMemcpyModule));
 
@@ -160,6 +160,74 @@ TEST_F(CopyFusionTest, BuildDescriptor) {
   EXPECT_EQ(offset.while_loop->name(), "while");
   EXPECT_EQ(offset.induction_variable->name(), "ivar");
   EXPECT_EQ(offset.offset->name(), "offset1");
+  EXPECT_EQ(offset.dimension_size, 4);
+  EXPECT_EQ(offset.byte_stride, 8 * 8 * sizeof(float));
+
+  EXPECT_THAT(descriptor->dst_dynamic_offsets, ::testing::IsEmpty());
+  EXPECT_EQ(descriptor->dst_byte_static_offset, 0);
+}
+
+constexpr char kUpdateSliceMemcpyModule[] = R"(
+    dynamic_slice {
+      p0 = s32[4,8,8] parameter(0)
+      p1 = s32[1,1,8] parameter(1)
+      p2 = s32[] parameter(2)
+      c1 = s32[] constant(1)
+
+      ROOT update-slice = s32[4,8,8] dynamic-update-slice(p0, p1, p2, c1, c1)
+    }
+
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      val = s32[1,1,8] constant({{{1,2,3,4,5,6,7,8}}})
+
+      updated = s32[4,8,8] fusion(input, val, ivar), kind=kLoop, calls=dynamic_slice,
+          backend_config={"fusion_backend_config":{"kind":"__dynamic_memcpy"}}
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+
+      ROOT result = (s32[], s32[4,8,8])
+          tuple(next_ivar, updated)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c6 = s32[] constant(6)
+      ROOT cmp = pred[] compare(ivar, c6), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"6"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+TEST_F(CopyFusionTest, BuildUpdateSliceDescriptor) {
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kUpdateSliceMemcpyModule));
+
+  auto call_graph = CallGraph::Build(module.get(), /*execution_threads=*/{});
+  auto descriptor = DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
+      GetFusion(module.get()), *call_graph);
+
+  ASSERT_TRUE(descriptor.has_value());
+  EXPECT_THAT(descriptor->src_dynamic_offsets, ::testing::IsEmpty());
+  EXPECT_EQ(descriptor->src_byte_static_offset, 0);
+
+  ASSERT_THAT(descriptor->dst_dynamic_offsets, ::testing::SizeIs(1));
+  const auto& offset = descriptor->dst_dynamic_offsets[0];
+  EXPECT_EQ(descriptor->dst_byte_static_offset, 32);
+  EXPECT_EQ(offset.while_loop->name(), "while");
+  EXPECT_EQ(offset.induction_variable->name(), "ivar");
+  EXPECT_EQ(offset.offset->name(), "ivar");
   EXPECT_EQ(offset.dimension_size, 4);
   EXPECT_EQ(offset.byte_stride, 8 * 8 * sizeof(float));
 }

--- a/xla/backends/gpu/runtime/copy_thunk.h
+++ b/xla/backends/gpu/runtime/copy_thunk.h
@@ -195,6 +195,9 @@ class DynamicMemcpyThunk : public Thunk {
 
     std::vector<DynamicOffset> src_dynamic_offsets;
     int64_t src_byte_static_offset = 0;
+
+    std::vector<DynamicOffset> dst_dynamic_offsets;
+    int64_t dst_byte_static_offset = 0;
   };
 
   DynamicMemcpyThunk(ThunkInfo thunk_info,

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -214,5 +214,99 @@ TEST_F(GpuCopyTest, DoNotUseMemcpyWithLayoutChange) {
       RunAndCompareNoHloPasses(kSliceMemcpyModule, ErrorSpec{1e-5, 1e-5}));
 }
 
+constexpr char kDynamicUpdateSliceModule[] = R"(
+    dynamic_update_slice {
+      p0 = s32[4,8,8] parameter(0)
+      p1 = s32[1,1,8] parameter(1)
+      p2 = s32[] parameter(2)
+      c0 = s32[] constant(0)
+
+      ROOT update-slice = s32[4,8,8] dynamic-update-slice(p0, p1, p2, c0, c0)
+    }
+
+    add {
+      p0 = s32[] parameter(0)
+      c1 = s32[] constant(1)
+      ROOT sum = s32[] add(p0, c1)
+    }
+
+    add_slices {
+      p0 = s32[1,1,8] parameter(0)
+      ROOT sum = s32[1,1,8] add(p0, p0)
+    }
+
+    body {
+      p0 = (s32[], s32[4,8,8], s32[1,1,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      input-copy = s32[4,8,8] copy(input)
+
+      ivar_copy = s32[] copy(ivar)
+      acc = s32[1,1,8] get-tuple-element(p0), index=2
+      acc_copy = s32[1,1,8] copy(acc)
+
+      updated = s32[4,8,8] fusion(input-copy, acc_copy, ivar_copy), kind=kLoop,
+          calls=dynamic_update_slice,
+          backend_config={"fusion_backend_config":{"kind":"__dynamic_memcpy"}}
+      next_ivar = s32[] fusion(ivar_copy), kind=kLoop, calls=add
+
+      next_acc = s32[1,1,8] fusion(acc_copy), kind=kLoop, calls=add_slices
+      ROOT result = (s32[], s32[4,8,8], s32[1,1,8])
+          tuple(next_ivar, updated, next_acc)
+    }
+
+    compare {
+      p0 = s32[] parameter(0)
+      c6 = s32[] constant(6)
+      ROOT cmp = pred[] compare(p0, c6), direction=LT
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8], s32[1,1,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      ROOT cmp = pred[] fusion(ivar), kind=kLoop, calls=compare
+    }
+
+    input {
+      iota = s32[256] iota(), iota_dimension=0
+      ROOT bc = s32[4,8,8] bitcast(iota)
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] fusion(), kind=kLoop, calls=input
+      init_acc = s32[1,1,8] constant({{{7,6,5,4,3,2,1,0}}})
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8], s32[1,1,8]) tuple(c0, input, init_acc)
+      ROOT while = (s32[], s32[4,8,8], s32[1,1,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"6"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+TEST_F(GpuCopyTest, UseMemcpyForDynamicUpdateSlice) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<VerifiedHloModule> hlo_module,
+      ParseAndReturnVerifiedModule(kDynamicUpdateSliceModule));
+
+  CompileAndVerifyIr(std::move(hlo_module), "; CHECK-NOT: void @updated",
+                     /*match_optimized_ir=*/false,
+                     /*run_optimization_passes=*/false);
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kDynamicUpdateSliceModule,
+                                       ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(GpuCopyTest, DoNotUseMemcpyForDynamicUpdateSlice) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<VerifiedHloModule> hlo_module,
+      ParseAndReturnVerifiedModule(kDynamicUpdateSliceModule));
+
+  // This prevents the memcpy fusion logic from triggering.
+  hlo_module->entry_computation()->root_instruction()->clear_backend_config();
+  CompileAndVerifyIr(std::move(hlo_module), "; CHECK: void @updated",
+                     /*match_optimized_ir=*/false,
+                     /*run_optimization_passes=*/false);
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -211,7 +211,7 @@ TEST_F(GpuCopyTest, DoNotUseMemcpyWithLayoutChange) {
                      /*match_optimized_ir=*/false,
                      /*run_optimization_passes=*/false);
   EXPECT_TRUE(
-      RunAndCompareNoHloPasses(kSliceMemcpyModule, ErrorSpec{1e-5, 1e-5}));
+      RunAndCompareNoHloPasses(kSliceMemcpyModule, ErrorSpec{0, 0}));
 }
 
 constexpr char kDynamicUpdateSliceModule[] = R"(
@@ -293,10 +293,13 @@ TEST_F(GpuCopyTest, UseMemcpyForDynamicUpdateSlice) {
                      /*match_optimized_ir=*/false,
                      /*run_optimization_passes=*/false);
   EXPECT_TRUE(RunAndCompareNoHloPasses(kDynamicUpdateSliceModule,
-                                       ErrorSpec{1e-5, 1e-5}));
+                                       ErrorSpec{0, 0}));
 }
 
 TEST_F(GpuCopyTest, DoNotUseMemcpyForDynamicUpdateSlice) {
+  // This is a test for the CompileAndVerifyIr statement in
+  // UseMemcpyForDynamicUpdateSlice. When the conditions are not met, there
+  // should be a fusion for the slice.
   TF_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<VerifiedHloModule> hlo_module,
       ParseAndReturnVerifiedModule(kDynamicUpdateSliceModule));


### PR DESCRIPTION
This extends the dynamic memcpy support for dynamic-slice to dynamic-update-slice. The logic is largely the same (except this time, the destination offset is dynamic, not the source offset).

For now, only in-place DUSes are handled. We could handle out-of-place DUSes as well, but I don't think it's needed.