### PR TITLE
Add set_use_global_device_ids() to AllGather instr

### DIFF
--- a/xla/hlo/ir/hlo_instructions.h
+++ b/xla/hlo/ir/hlo_instructions.h
@@ -708,6 +708,7 @@ class HloAllGatherInstruction : public HloCollectiveInstruction {
 
   // Same as HloAllReduceInstruction::use_global_device_ids.
   bool use_global_device_ids() const { return use_global_device_ids_; }
+  void set_use_global_device_ids(bool value) { use_global_device_ids_ = value; }
 
   // The dimension on which data from different participants are concatenated.
   int64_t all_gather_dimension() const { return all_gather_dimension_; }


### PR DESCRIPTION
`use_global_device_ids` attribute is defined in both `HloAllReduceInstructionBase` and `HloAllGatherInstruction` classes.

But `HloAllGatherInstruction` lacks a setter method - `set_use_global_device_ids`.

This PR fixes it by adding missing `set_use_global_device_ids` to `HloAllGatherInstruction`.

I could not find any existing tests that validate `set_use_global_device_ids` for AllReduce or ReduceScatter. Therefore, this AllGather PR does not include modifications to unit tests too.