### PR TITLE
[ROCm] Fix ragged_all_to_all_kernel_test

### DIFF
--- a/xla/service/gpu/kernels/ragged_all_to_all_kernel_test.cc
+++ b/xla/service/gpu/kernels/ragged_all_to_all_kernel_test.cc
@@ -90,6 +90,7 @@ TEST_F(RaggedAllToAllKernelTest, SimpleKernelTest) {
   for (int64_t i = 0; i < num_outputs; ++i) {
     output_buffers.emplace_back(executor, executor->AllocateArray<T>(n));
     ASSERT_TRUE(!output_buffers[i].memory().is_null());
+    TF_ASSERT_OK(stream->MemZero(output_buffers[i].memory_ptr(), n * sizeof(T)));
   }
 
   stream_executor::DeviceMemoryHandle input_offsets_buffer(


### PR DESCRIPTION
Test was failing with mismatch error:
```
xla/service/gpu/kernels/ragged_all_to_all_kernel_test.cc:153: Failure
Expected equality of these values:
  output_results
    Which is: { { 2, 3, 4, 5, -0.372549, -0.372549, -0.372549, -0.372549, 8, 9, 10, 11, 12, 13, -0.372549, -0.372549 }, { -0.372549, -0.372549, 0, 1, -0.372549, -0.372549, -0.372549, -0.372549, -0.372549, -0.372549, 6, 7, 8, 9, -0.372549, -0.372549 } }
  expected_output_results
    Which is: { { 2, 3, 4, 5, 0, 0, 0, 0, 8, 9, 10, 11, 12, 13, 0, 0 }, { 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 6, 7, 8, 9, 0, 0 } }
```

This PR initializes output_buffers to 0 before `RunRaggedAllToAllKernel` 