### PR TITLE
Fix the build issue after commit df841fe

### DIFF
--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -7,6 +7,14 @@ load(
     "//xla/tsl/platform:build_config_root.bzl",
     "tf_gpu_tests_tags",
 )
+load(
+    "@local_config_cuda//cuda:build_defs.bzl",
+    "is_cuda_configured",
+)
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "is_rocm_configured",
+)
 load("//xla/tsl/platform/default:build_config.bzl", "strict_cc_test")
 
 visibility(DEFAULT_LOAD_VISIBILITY)
@@ -169,7 +177,9 @@ def prepare_gpu_backend_data(backends, disabled_backends, backend_tags, backend_
 
     new_backends = [
         backend
-        for backend in nvidia_backends + amd_backends + other_backends
+        for backend in (nvidia_backends if (not is_rocm_configured()) else []) 
+            + (amd_backends if (not is_cuda_configured()) else []) 
+            + other_backends
     ]
 
     disabled_backends = nvidia_disabled_backends + amd_disabled_backends

--- a/xla/tests/build_defs.bzl
+++ b/xla/tests/build_defs.bzl
@@ -177,9 +177,7 @@ def prepare_gpu_backend_data(backends, disabled_backends, backend_tags, backend_
 
     new_backends = [
         backend
-        for backend in (nvidia_backends if (not is_rocm_configured()) else []) 
-            + (amd_backends if (not is_cuda_configured()) else []) 
-            + other_backends
+        for backend in nvidia_backends + amd_backends + other_backends
     ]
 
     disabled_backends = nvidia_disabled_backends + amd_disabled_backends
@@ -372,8 +370,9 @@ def xla_test(
             fail_if_no_test_linked = fail_if_no_test_linked,
             **this_backend_kwargs
         )
-
-        test_names.append(test_name)
+        if ((backend in NVIDIA_GPU_BACKENDS and is_cuda_configured()) or 
+           (backend in AMD_GPU_DEFAULT_BACKENDS and is_rocm_configured())):
+            test_names.append(test_name)
 
     # Notably, a test_suite with `tests = []` is not empty:
     # https://bazel.build/reference/be/general#test_suite_args and the default
@@ -408,7 +407,6 @@ def xla_test(
             # --build_tag_filters (see above). Therefore we don't want to fail
             # if no test case is linked in.
             fail_if_no_test_linked = False,
-            **kwargs
         )
 
 def xla_test_library(


### PR DESCRIPTION
When running tests, like `bazel test //xla/service/gpu/model:hlo_op_profiler_test`, on a machine with only CUDA configured, the build system will try to build ROCm tests and fail.

Before this change:
```
ERROR: xla/xla/stream_executor/rocm/BUILD:791:13: Compiling xla/stream_executor/rocm/rocm_helpers.cu.cc failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing CppCompile command (from target //xla/stream_executor/rocm:rocm_helpers) external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -MD -MF bazel-out/k8-opt/bin/xla/stream_executor/rocm/_objs/rocm_helpers/rocm_helpers.cu.pic.d ... (remaining 37 arguments skipped)
/home/svaishay/.cache/bazel/_bazel_svaishay/3b9a2c84bcbdad9b9781b5eb1069603a/execroot/xla/external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc:227: SyntaxWarning: invalid escape sequence '\.'
  re.search('\.cpp$|\.cc$|\.c$|\.cxx$|\.C$', f)]
clang: warning: argument unused during compilation: '--cuda-path=external/cuda_nvcc' [-Wunused-command-line-argument]
xla/stream_executor/rocm/rocm_helpers.cu.cc:16:10: fatal error: 'hip/hip_bfloat16.h' file not found
   16 | #include <hip/hip_bfloat16.h>
      |          ^~~~~~~~~~~~~~~~~~~~
1 error generated.
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 3.333s, Critical Path: 0.18s
INFO: 28 processes: 28 internal.
ERROR: Build did NOT complete successfully
//xla/service/gpu/model:hlo_op_profiler_test_gpu_a100                 NO STATUS
//xla/service/gpu/model:hlo_op_profiler_test_gpu_any                  NO STATUS
//xla/service/gpu/model:hlo_op_profiler_test_gpu_b200                 NO STATUS
//xla/service/gpu/model:hlo_op_profiler_test_gpu_h100                 NO STATUS
```

After this change:
```
INFO: Build completed successfully, 5 total actions
//xla/service/gpu/model:hlo_op_profiler_test_gpu_a100                    PASSED in 14.9s
//xla/service/gpu/model:hlo_op_profiler_test_gpu_any                     PASSED in 15.4s
//xla/service/gpu/model:hlo_op_profiler_test_gpu_b200                    PASSED in 16.2s
//xla/service/gpu/model:hlo_op_profiler_test_gpu_h100                    PASSED in 14.3s
```