### PR TITLE
Remove HloComputation::CustomCallInstruction.

### DIFF
--- a/xla/hlo/ir/hlo_computation.h
+++ b/xla/hlo/ir/hlo_computation.h
@@ -215,8 +215,6 @@ class HloComputation {
     // unreachable, and its instruction is set to null. We still need to regard
     // such computations as fusion computations for HLO scheduling purposes.
     kFusion,
-    // This computation is a custom-call computation.
-    kCustomCall,
     // This computation is a collective computation.
     kCollective,
     // This computation is a conditional branch computation.
@@ -805,21 +803,6 @@ class HloComputation {
   }
   void SetFusionInstruction(HloInstruction* fusion_instruction) {
     SetInstruction(fusion_instruction, InstructionType::kFusion);
-  }
-
-  // Returns if this computation is a custom-call computation.
-  bool IsCustomCallComputation() const {
-    return instruction_type() == InstructionType::kCustomCall;
-  }
-
-  // Returns the owning custom call instruction, or nullptr if this is not a
-  // custom call computation.
-  HloInstruction* CustomCallInstruction() const {
-    return instruction_type() == InstructionType::kCustomCall ? instruction()
-                                                              : nullptr;
-  }
-  void SetCustomCallInstruction(HloInstruction* custom_call_instruction) {
-    SetInstruction(custom_call_instruction, InstructionType::kCustomCall);
   }
 
   // Returns if this computation is a to_apply region of a collective.

--- a/xla/hlo/ir/hlo_instructions.cc
+++ b/xla/hlo/ir/hlo_instructions.cc
@@ -400,7 +400,7 @@ HloAsyncStartInstruction::HloAsyncStartInstruction(
     HloComputation* async_computation, absl::string_view async_execution_thread)
     : HloAsyncInstruction(opcode, shape, operands,
                           async_computation->root_instruction()->opcode()) {
-  CHECK(!async_computation->IsCustomCallComputation());
+  CHECK(async_computation->caller_instructions(HloOpcode::kCustomCall).empty());
   CHECK(!async_computation->IsFusionComputation());
   CHECK(!async_computation->IsAsyncComputation());
   AppendComputation(async_computation);
@@ -3179,7 +3179,6 @@ HloCustomCallInstruction::HloCustomCallInstruction(
       custom_call_schedule_(CustomCallSchedule::SCHEDULE_NONE),
       api_version_(api_version) {
   set_raw_backend_config_string(std::move(opaque));
-  to_apply->SetCustomCallInstruction(this);
 }
 
 HloCustomCallInstruction::HloCustomCallInstruction(
@@ -3198,9 +3197,6 @@ HloCustomCallInstruction::HloCustomCallInstruction(
       custom_call_schedule_(CustomCallSchedule::SCHEDULE_NONE),
       api_version_(api_version) {
   set_raw_backend_config_string(std::move(opaque));
-  for (auto comp : called_computations) {
-    comp->SetCustomCallInstruction(this);
-  }
 }
 
 HloCustomCallInstruction::HloCustomCallInstruction(

--- a/xla/hlo/transforms/simplifiers/flatten_call_graph.cc
+++ b/xla/hlo/transforms/simplifiers/flatten_call_graph.cc
@@ -138,11 +138,6 @@ absl::Status AnnotateNode(const CallGraphNode& node) {
         computation->SetFusionInstruction(instruction);
       }
 
-    } else if (instruction->opcode() == HloOpcode::kCustomCall) {
-      for (HloComputation* computation : instruction->called_computations()) {
-        computation->SetCustomCallInstruction(instruction);
-      }
-
     } else if (hlo_query::IsCollectiveCommunicationOp(instruction->opcode())) {
       for (HloComputation* computation : instruction->called_computations()) {
         computation->SetCollectiveCallInstruction(instruction);

--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -4283,7 +4283,8 @@ bool RecursivelyCheckForCustomCall(
     return itr->second;
   }
 
-  bool contains_custom_call = computation.IsCustomCallComputation();
+  bool contains_custom_call =
+      !computation.caller_instructions(HloOpcode::kCustomCall).empty();
 
   for (const HloInstruction* instruction : computation.instructions()) {
     contains_custom_call |= instruction->opcode() == HloOpcode::kCustomCall;

--- a/xla/service/gpu/transforms/command_buffer_scheduling.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling.cc
@@ -891,7 +891,7 @@ absl::StatusOr<bool> CommandBufferScheduling::Run(
   for (HloComputation* comp : order) {
     // Skip special computations that do not have lowering to thunks.
     if (comp->IsFusionComputation() || comp->IsAsyncComputation() ||
-        comp->IsCustomCallComputation())
+        !comp->caller_instructions(HloOpcode::kCustomCall).empty())
       continue;
 
     // Skip computations that already part of command buffers.

--- a/xla/service/gpu/transforms/softmax_rewriter_triton.cc
+++ b/xla/service/gpu/transforms/softmax_rewriter_triton.cc
@@ -594,7 +594,7 @@ SoftmaxRewriterTriton::FindAllFusibleNormalizationDiamonds(
 
   for (HloComputation* comp :
        module.MakeNonfusionComputations(execution_threads)) {
-    if (comp->IsCustomCallComputation()) {
+    if (!comp->caller_instructions(HloOpcode::kCustomCall).empty()) {
       continue;
     }
     for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {

--- a/xla/service/hlo_module_test.cc
+++ b/xla/service/hlo_module_test.cc
@@ -248,8 +248,8 @@ ENTRY entry () -> s32[] {
   HloInstruction* cloned_custom_call =
       cloned_module->entry_computation()->GetInstructionWithName("custom-call");
 
-  EXPECT_TRUE(cloned_computation->IsCustomCallComputation());
-  EXPECT_EQ(cloned_computation->CustomCallInstruction(), cloned_custom_call);
+  EXPECT_EQ(cloned_computation->GetUniqueCaller(HloOpcode::kCustomCall),
+            cloned_custom_call);
 }
 
 TEST_F(HloModuleTest, CloneCustomCallComputationCalledComputations) {
@@ -288,10 +288,8 @@ ENTRY entry () -> s32[] {
   HloInstruction* cloned_custom_call =
       cloned_module->entry_computation()->GetInstructionWithName("custom-call");
 
-  EXPECT_TRUE(cloned_computation_0->IsCustomCallComputation());
-  EXPECT_EQ(cloned_computation_0->CustomCallInstruction(), cloned_custom_call);
-  EXPECT_TRUE(cloned_computation_1->IsCustomCallComputation());
-  EXPECT_EQ(cloned_computation_1->CustomCallInstruction(), cloned_custom_call);
+  EXPECT_EQ(cloned_computation_0->GetUniqueCaller(HloOpcode::kCustomCall), cloned_custom_call);
+  EXPECT_EQ(cloned_computation_1->GetUniqueCaller(HloOpcode::kCustomCall), cloned_custom_call);
 }
 
 TEST_F(HloModuleTest, CloneFusionComputation) {


### PR DESCRIPTION
Step 2/5 of removing instruction_type. I think kFusion should be last, since it's special (in that it's "sticky", you can't tell from instruction_callers whether it's a fusion computation).