### PR TITLE
Fix some Shape::rank deprecation warnings.

### DIFF
--- a/xla/literal.h
+++ b/xla/literal.h
@@ -415,7 +415,7 @@ class LiteralBase {
           ShapeUtil::ByteSizeOfPrimitiveType(subshape.element_type());
       absl::Span<const int64_t> minor_to_major =
           subshape.layout().minor_to_major();
-      DimensionVector elem_index(subshape.dimensions_size());
+      DimensionVector elem_index(subshape.dimensions().size());
       absl::Span<int64_t> elem_index_span(elem_index.data(), elem_index.size());
       int64_t bytes_hashed = 0;
       while (bytes_hashed < bytes_to_hash) {
@@ -884,7 +884,7 @@ class LiteralBase {
 
     int64_t dynamic_size_buffer_bytes() const {
       DCHECK(LayoutUtil::IsDenseArray(*subshape_));
-      return subshape().dimensions_size() * sizeof(DynamicSizeType);
+      return subshape().dimensions().size() * sizeof(DynamicSizeType);
     }
 
     // Gets or sets the subshape of this piece. This reference points to a
@@ -1692,7 +1692,7 @@ void LiteralBase::Piece::SerializeData(
            primitive_util::NativeToPrimitiveType<NativeT>());
   if (subshape().is_dynamic()) {
     absl::Span<const DynamicSizeType> sizes(dynamic_size_buffer(),
-                                            subshape().dimensions_size());
+                                            subshape().dimensions().size());
     state.WriteDynamicSizes(sizes);
   }
   state.WriteElements(data<NativeT>());
@@ -1704,8 +1704,7 @@ bool LiteralBase::Piece::DeserializeData(
   CHECK_EQ(subshape().element_type(),
            primitive_util::NativeToPrimitiveType<NativeT>());
   if (subshape().is_dynamic()) {
-    absl::Span<DynamicSizeType> sizes(dynamic_size_buffer(),
-                                      subshape().dimensions_size());
+    absl::Span<DynamicSizeType> sizes(dynamic_size_buffer(), subshape().dimensions().size());
     if (!state.ReadDynamicSizes(sizes)) {
       return false;
     }
@@ -1965,10 +1964,10 @@ TF_ATTRIBUTE_NOINLINE void LiteralBase::EachCell(
   if (ShapeUtil::IsZeroElementArray(shape())) {
     return;
   }
-  std::vector<int64_t> indices(shape().dimensions_size(), 0);
+  std::vector<int64_t> indices(shape().dimensions().size(), 0);
 
   Shape shape_dynamic = shape();
-  for (int64_t i = 0; i < shape_dynamic.dimensions_size(); ++i) {
+  for (int64_t i = 0; i < shape_dynamic.dimensions().size(); ++i) {
     shape_dynamic.set_dimensions(i, GetDynamicSize(i));
   }
   do {
@@ -1985,9 +1984,9 @@ TF_ATTRIBUTE_NOINLINE void MutableLiteralBase::MutableEachCell(
   if (ShapeUtil::IsZeroElementArray(shape())) {
     return;
   }
-  std::vector<int64_t> indices(shape().dimensions_size(), 0);
+  std::vector<int64_t> indices(shape().dimensions().size(), 0);
   Shape shape_dynamic = shape();
-  for (int64_t i = 0; i < shape_dynamic.dimensions_size(); ++i) {
+  for (int64_t i = 0; i < shape_dynamic.dimensions().size(); ++i) {
     shape_dynamic.set_dimensions(i, GetDynamicSize(i));
   }
   do {
@@ -2000,7 +1999,7 @@ TF_ATTRIBUTE_NOINLINE void MutableLiteralBase::PopulateR1(
     absl::Span<const NativeT> values) {
   CHECK(LayoutUtil::IsDenseArray(shape()))
       << __func__ << " is only supported for dense arrays: " << shape();
-  CHECK_EQ(shape().dimensions_size(), 1);
+  CHECK_EQ(shape().dimensions().size(), 1);
   if (shape().is_static()) {
     CHECK_EQ(ShapeUtil::ElementsIn(shape()), values.size());
   } else {
@@ -2017,7 +2016,7 @@ TF_ATTRIBUTE_NOINLINE void MutableLiteralBase::PopulateR2(
     std::initializer_list<std::initializer_list<NativeT>> values) {
   CHECK(LayoutUtil::IsDenseArray(shape()))
       << __func__ << " is only supported for dense arrays: " << shape();
-  CHECK_EQ(shape().dimensions_size(), 2);
+  CHECK_EQ(shape().dimensions().size(), 2);
   CHECK_EQ(shape().element_type(),
            primitive_util::NativeToPrimitiveType<NativeT>());
 
@@ -2053,7 +2052,7 @@ TF_ATTRIBUTE_NOINLINE void MutableLiteralBase::PopulateFromArray(
   CHECK(shape().IsArray());
   CHECK_EQ(shape().element_type(),
            primitive_util::NativeToPrimitiveType<NativeT>());
-  CHECK_EQ(shape().dimensions_size(), values.num_dimensions());
+  CHECK_EQ(shape().dimensions().size(), values.num_dimensions());
   for (int dim = 0; dim < values.num_dimensions(); ++dim) {
     int64_t shape_size = shape().is_dynamic_dimension(dim)
                              ? GetDynamicSize(dim)
@@ -2223,7 +2222,7 @@ Literal LiteralBase::Replicate(int64_t times) const {
   CHECK(LayoutUtil::IsDenseArray(shape()))
       << __func__ << " is only supported for dense arrays: " << shape();
   DimensionVector bounds = {times};
-  bounds.reserve(shape().dimensions_size() + 1);
+  bounds.reserve(shape().dimensions().size() + 1);
   for (int64_t bound : shape().dimensions()) {
     bounds.push_back(bound);
   }

--- a/xla/service/pattern_matcher.h
+++ b/xla/service/pattern_matcher.h
@@ -954,7 +954,7 @@ class ShapePatternRankImpl {
   explicit constexpr ShapePatternRankImpl(int64_t rank) : rank_(rank) {}
 
   bool Match(const ::xla::Shape* shape, MatchOption option) const {
-    if (shape->dimensions_size() != rank_) {
+    if (shape->dimensions().size() != rank_) {
       if (rank_ == 0) {
         EXPLAIN << "Shape is not a scalar";
       } else {

--- a/xla/shape_util.h
+++ b/xla/shape_util.h
@@ -114,10 +114,9 @@ class ShapeUtil {
   template <bool kBoundedDynamicOk>
   static inline std::pair<int64_t, bool> ExtentProduct(const Shape& shape) {
     DCHECK(shape.IsArray()) << ShapeUtil::HumanString(shape);
-    DCHECK_EQ(shape.dimensions_size(), shape.dimensions_size());
     int64_t product = 1;
     bool any_overflows = false;
-    for (int dim = 0; dim < shape.dimensions_size(); ++dim) {
+    for (int dim = 0; dim < shape.dimensions().size(); ++dim) {
       if constexpr (kBoundedDynamicOk) {
         if (shape.is_unbounded_dynamic_dimension(dim)) {
           continue;
@@ -304,7 +303,7 @@ class ShapeUtil {
   // Scalar-specific
 
   static bool IsScalar(const Shape& shape) {
-    return shape.IsArray() && shape.dimensions_size() == 0;
+    return shape.IsArray() && shape.dimensions().size() == 0;
   }
   static bool IsEffectiveScalar(const Shape& shape) {
     return shape.IsArray() && TrueRank(shape) == 0;
@@ -961,8 +960,8 @@ class ShapeUtil {
 
   static absl::Status ForEachIndexWithStatus(
       const Shape& shape, const ForEachVisitorFunction& visitor_function) {
-    std::vector<int64_t> base(shape.dimensions_size());
-    std::vector<int64_t> incr(shape.dimensions_size(), 1);
+    std::vector<int64_t> base(shape.dimensions().size());
+    std::vector<int64_t> incr(shape.dimensions().size(), 1);
     return ForEachIndexWithStatus(shape, base,
                                   /*count=*/shape.dimensions(), incr,
                                   visitor_function);
@@ -971,8 +970,8 @@ class ShapeUtil {
   static void ForEachIndexNoStatus(
       const Shape& shape,
       const ForEachVisitorFunctionNoStatus& visitor_function) {
-    std::vector<int64_t> base(shape.dimensions_size());
-    std::vector<int64_t> incr(shape.dimensions_size(), 1);
+    std::vector<int64_t> base(shape.dimensions().size());
+    std::vector<int64_t> incr(shape.dimensions().size(), 1);
     ForEachIndexNoStatus(shape, base,
                          /*count=*/shape.dimensions(), incr, visitor_function);
   }
@@ -1161,7 +1160,7 @@ inline ShapeUtil::ForEachState::ForEachState(const Shape& s,
       indexes(b.begin(), b.end()),
       indexes_ptr((rank == 0) ? nullptr : indexes.data()),
       indexes_span(indexes) {
-  CHECK_EQ(shape.dimensions_size(), b.size());
+  CHECK_EQ(shape.dimensions().size(), b.size());
   CHECK_EQ(i.size(), b.size());
   CHECK_EQ(c.size(), b.size());
 }


### PR DESCRIPTION
These headers are included from absolutely everywhere, and the warning spam can make it quite hard to see the actual problems.