### PR TITLE
Exclude Circular Dependencies in FP8 Graph Convolutions

### DIFF
--- a/xla/hlo/analysis/hlo_reachability.h
+++ b/xla/hlo/analysis/hlo_reachability.h
@@ -60,7 +60,7 @@ class HloReachabilityMap {
   // Similar to the above Build operation except that it tries to identify
   // paths between instructions that do not contain control instructions
   // and multiple operands, i.e., b is_reachable a == true iff
-  // b = f(f(f(f(f(a), constant), constant), constant).
+  // b = f(f(f(f(f(a), constant), constant), constant), constant).
   // Further, the only ops allowed in a path are basic math operations such
   // as add, sub, mul, div.
   static std::unique_ptr<HloReachabilityMap> BuildWithRestrictions(

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -962,6 +962,7 @@ cc_library(
         "//xla:shape_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
+        "//xla/hlo/analysis:hlo_reachability",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
         "//xla/service:hlo_creation_utils",


### PR DESCRIPTION
Excludes ops with external operands that can be reached from graph outputs of fused ops as well as ops with graph outputs that can reach external operands of fused ops from fusion into graph-based FP8 convolutions. Fusing these ops may lead to circular dependencies between fused and unfused instructions.