### PR TITLE
Fix while loop analysis when the increment is not a constant

### DIFF
--- a/xla/hlo/analysis/while_loop_analysis.cc
+++ b/xla/hlo/analysis/while_loop_analysis.cc
@@ -699,7 +699,7 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
   int64_t trip_count_step = 0;
   if (!Match(while_body_indvar_update,
              m::AddAnyOrder(m::Op().Is(while_body_indvar),
-                            m::Op(&trip_count_increase_step_instr)))) {
+                            m::Constant(&trip_count_increase_step_instr)))) {
     if (trip_count_increase_step_instr == nullptr) {
       VLOG(2) << "Pattern-match failed: induction variable is not getting "
                  "updated by an add operation: "


### PR DESCRIPTION
Currently this fails with an assert because the checks (matcher) does not look for constants.