### PR TITLE
Move-to-memory-space custom calls use default layout

### DIFF
--- a/xla/service/gpu/transforms/layout_assignment.cc
+++ b/xla/service/gpu/transforms/layout_assignment.cc
@@ -340,6 +340,15 @@ bool IsPackedInstruction(const HloInstruction* instruction) {
               instruction->operand(0)->shape().element_type()));
 }
 
+bool IsCustomCallToMemoryPlacement(const HloInstruction* hlo) {
+  if (hlo->opcode() != HloOpcode::kCustomCall) {
+    return false;
+  }
+  const auto& target = hlo->custom_call_target();
+  return target == memory_annotations::kMoveToDeviceCustomCallTarget ||
+         target == memory_annotations::kMoveToHostCustomCallTarget;
+}
+
 }  // namespace
 
 absl::Status GpuLayoutAssignment::AddDotBackendConstraints(
@@ -571,6 +580,13 @@ absl::Status GpuLayoutAssignment::AddBackendConstraints(
             LayoutUtil::SetToDefaultLayout(subshape);
           });
       TF_RETURN_IF_ERROR(SetInstructionLayout(s, instruction));
+    } else if (IsCustomCallToMemoryPlacement(instruction)) {
+      // Make sure that host memory buffers use the default layout so that
+      // the compiler does not insert transposes on host memory buffers.
+      Shape operand_shape = instruction->operand(0)->shape();
+      LayoutUtil::SetToDefaultLayout(&operand_shape);
+      TF_RETURN_IF_ERROR(SetOperandLayout(operand_shape, instruction, 0));
+      TF_RETURN_IF_ERROR(SetInstructionLayout(operand_shape, instruction));
     }
   }
   return absl::OkStatus();
@@ -691,19 +707,12 @@ bool GpuLayoutAssignment::PropagateReductionLayoutToOperand(
 
 bool GpuLayoutAssignment::InstructionCanChangeLayoutInstance(
     const HloInstruction* instruction) {
-  // The host offloading custom calls will be eventually removed
-  // by the offloader, so we need to make sure that the calls do not change
-  // the layout and thus cause layout mismatches after the removal.
   // The TopK custom call cannot handle the case if the operand has a different
   // layout.
   const HloCustomCallInstruction* custom_call =
       DynCast<HloCustomCallInstruction>(instruction);
   if (custom_call != nullptr &&
-      (custom_call->custom_call_target() ==
-           memory_annotations::kMoveToHostCustomCallTarget ||
-       custom_call->custom_call_target() ==
-           memory_annotations::kMoveToDeviceCustomCallTarget ||
-       custom_call->custom_call_target() == kTopKCustomCallTarget)) {
+      custom_call->custom_call_target() == kTopKCustomCallTarget) {
     return false;
   }
 

--- a/xla/service/gpu/transforms/layout_assignment.cc
+++ b/xla/service/gpu/transforms/layout_assignment.cc
@@ -344,7 +344,7 @@ bool IsCustomCallToMemoryPlacement(const HloInstruction* hlo) {
   if (hlo->opcode() != HloOpcode::kCustomCall) {
     return false;
   }
-  const auto& target = hlo->custom_call_target();
+  const std::string& target = hlo->custom_call_target();
   return target == memory_annotations::kMoveToDeviceCustomCallTarget ||
          target == memory_annotations::kMoveToHostCustomCallTarget;
 }

--- a/xla/service/gpu/transforms/layout_assignment_test.cc
+++ b/xla/service/gpu/transforms/layout_assignment_test.cc
@@ -537,12 +537,8 @@ ENTRY entry {
   const HloInstruction* call_0 = FindInstruction(m.get(), "custom-call.0");
   const Layout input_layout = call_0->operand(0)->shape().layout();
   const Layout output_layout = call_0->shape().layout();
-  EXPECT_TRUE(
-      LayoutUtil::Equal(input_layout, LayoutUtil::MakeLayout({2, 1, 0})))
-      << "Expected default layout for input.  Input: " << input_layout;
-  EXPECT_TRUE(
-      LayoutUtil::Equal(output_layout, LayoutUtil::MakeLayout({2, 1, 0})))
-      << "Expected default layout for output.  Output: " << output_layout;
+  EXPECT_EQ(input_layout, LayoutUtil::GetDefaultLayoutForR3());
+  EXPECT_EQ(output_layout, LayoutUtil::GetDefaultLayoutForR3());
 }
 
 TEST_F(LayoutAssignmentTest, MoveToDeviceCustomCallConstrained) {
@@ -570,12 +566,8 @@ ENTRY entry {
   const HloInstruction* call_0 = FindInstruction(m.get(), "custom-call.0");
   const Layout input_layout = call_0->operand(0)->shape().layout();
   const Layout output_layout = call_0->shape().layout();
-  EXPECT_TRUE(
-      LayoutUtil::Equal(input_layout, LayoutUtil::MakeLayout({2, 1, 0})))
-      << "Expected default layout for input.  Input: " << input_layout;
-  EXPECT_TRUE(
-      LayoutUtil::Equal(output_layout, LayoutUtil::MakeLayout({2, 1, 0})))
-      << "Expected default layout for output.  Output: " << output_layout;
+  EXPECT_EQ(input_layout, LayoutUtil::GetDefaultLayoutForR3());
+  EXPECT_EQ(output_layout, LayoutUtil::GetDefaultLayoutForR3());
 }
 
 TEST_F(LayoutAssignmentTest, CuDNNConvolutionHasNHWCLayoutPostHopper) {

--- a/xla/service/gpu/transforms/layout_assignment_test.cc
+++ b/xla/service/gpu/transforms/layout_assignment_test.cc
@@ -517,9 +517,10 @@ TEST_F(LayoutAssignmentTest, MoveToHostCustomCallConstrained) {
 HloModule TestModule
 
 ENTRY entry {
-  Arg_0 = f32[2,5,5]{2,1,0} parameter(0)
+  Arg_0 = f32[2,5,5]{0,1,2} parameter(0)
   custom-call.0 = f32[2,5,5] custom-call(Arg_0), custom_call_target="MoveToHost"
-  ROOT custom-call.1 = f32[2,5,5]{2, 1, 0} custom-call(custom-call.0), custom_call_target="fixed_call", operand_layout_constraints={f32[2,5,5]{1,2,0}}
+  ROOT custom-call.1 = f32[2,5,5]{2, 1, 0} custom-call(custom-call.0),
+      custom_call_target="fixed_call", operand_layout_constraints={f32[2,5,5]{1,2,0}}
 }
 )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
@@ -536,9 +537,12 @@ ENTRY entry {
   const HloInstruction* call_0 = FindInstruction(m.get(), "custom-call.0");
   const Layout input_layout = call_0->operand(0)->shape().layout();
   const Layout output_layout = call_0->shape().layout();
-  EXPECT_TRUE(LayoutUtil::Equal(input_layout, output_layout))
-      << "Expected the same input/output layouts.  Input: " << input_layout
-      << ". Output: " << output_layout;
+  EXPECT_TRUE(
+      LayoutUtil::Equal(input_layout, LayoutUtil::MakeLayout({2, 1, 0})))
+      << "Expected default layout for input.  Input: " << input_layout;
+  EXPECT_TRUE(
+      LayoutUtil::Equal(output_layout, LayoutUtil::MakeLayout({2, 1, 0})))
+      << "Expected default layout for output.  Output: " << output_layout;
 }
 
 TEST_F(LayoutAssignmentTest, MoveToDeviceCustomCallConstrained) {
@@ -546,9 +550,10 @@ TEST_F(LayoutAssignmentTest, MoveToDeviceCustomCallConstrained) {
 HloModule TestModule
 
 ENTRY entry {
-  Arg_0 = f32[2,5,5]{2,1,0} parameter(0)
+  Arg_0 = f32[2,5,5]{1,2,0} parameter(0)
   custom-call.0 = f32[2,5,5] custom-call(Arg_0), custom_call_target="MoveToDevice"
-  ROOT custom-call.1 = f32[2,5,5]{2, 1, 0} custom-call(custom-call.0), custom_call_target="fixed_call", operand_layout_constraints={f32[2,5,5]{1,2,0}}
+  ROOT custom-call.1 = f32[2,5,5]{2, 1, 0} custom-call(custom-call.0),
+      custom_call_target="fixed_call", operand_layout_constraints={f32[2,5,5]{0,1,2}}
 }
 )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
@@ -565,9 +570,12 @@ ENTRY entry {
   const HloInstruction* call_0 = FindInstruction(m.get(), "custom-call.0");
   const Layout input_layout = call_0->operand(0)->shape().layout();
   const Layout output_layout = call_0->shape().layout();
-  EXPECT_TRUE(LayoutUtil::Equal(input_layout, output_layout))
-      << "Expected the same input/output layouts.  Input: " << input_layout
-      << ". Output: " << output_layout;
+  EXPECT_TRUE(
+      LayoutUtil::Equal(input_layout, LayoutUtil::MakeLayout({2, 1, 0})))
+      << "Expected default layout for input.  Input: " << input_layout;
+  EXPECT_TRUE(
+      LayoutUtil::Equal(output_layout, LayoutUtil::MakeLayout({2, 1, 0})))
+      << "Expected default layout for output.  Output: " << output_layout;
 }
 
 TEST_F(LayoutAssignmentTest, CuDNNConvolutionHasNHWCLayoutPostHopper) {


### PR DESCRIPTION
Using non-default layout for MoveToHost makes the compiler
insert a transpose operation on the host value if that value
flows into the root of the entry computation. Such transposes
cause the host offloader to emit a slow on-host transpose
(and a warning on the console). We see those warnings on 
maxtext llama2-7b with optimizer state offloading with fsdp=2.

This patch enforces default layout for on-host values so that
no transpose is necessary (as long as there is no override
of layout for host values in entry computation).

Note that such transposes cannot be sunk into the uses
by the offloading lagalizer because there is nowhere
to sink to - the value is returned from the computation.