### PR TITLE
Fix for fusion wrapper on async computations

### DIFF
--- a/xla/codegen/emitters/fusion_wrapper_base.cc
+++ b/xla/codegen/emitters/fusion_wrapper_base.cc
@@ -37,7 +37,8 @@ absl::StatusOr<bool> FusionWrapperBase::Run(
   std::function<absl::Status(HloInstruction*)> handle_instruction;
   handle_instruction = [&](HloInstruction* instruction) -> absl::Status {
     const HloOpcode opcode = instruction->opcode();
-    if (opcode == HloOpcode::kConditional || opcode == HloOpcode::kWhile) {
+    if (opcode == HloOpcode::kConditional || opcode == HloOpcode::kWhile ||
+        opcode == HloOpcode::kCall || opcode == HloOpcode::kAsyncStart) {
       for (auto* computation : instruction->called_computations()) {
         for (auto* inner_instruction :
              computation->MakeInstructionPostOrder()) {

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -115,17 +115,17 @@ xla_test(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "async_kernel_launch_test",
     srcs = ["async_kernel_launch_test.cc"],
     # "requires-net:external" tag allows uploading `xprof` results.
     tags = if_google(["requires-net:external"]) + tf_cuda_tests_tags(),
+    backends = ["gpu"],
     deps = [
         "//xla:debug_options_flags",
         "//xla:literal",
         "//xla:literal_util",
         "//xla:xla_proto_cc",
-        "//xla/service:gpu_plugin",
         "//xla/service:hlo_module_config",
         "//xla/tests:hlo_test_base",
         "//xla/tests:literal_test_util",

--- a/xla/service/gpu/tests/async_kernel_launch_test.cc
+++ b/xla/service/gpu/tests/async_kernel_launch_test.cc
@@ -77,5 +77,58 @@ TEST_F(AsyncKernelLaunchTest, BasicFusion) {
   EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
 }
 
+TEST_F(AsyncKernelLaunchTest, BasicAsyncComputation) {
+  const char* hlo_text = R"(
+    HloModule Test1
+
+    add_F32 {
+      lhs = f32[2] parameter(0)
+      rhs = f32[2] parameter(1)
+      ROOT add = f32[2] add(lhs, rhs)
+    }
+
+    ENTRY Test1 {
+      a = f32[2] parameter(0)
+      b = f32[2] parameter(1)
+      start = ((f32[2], f32[2]), f32[2]) call-start(a, b), to_apply=add_F32
+      ROOT done = f32[2] call-done(start)
+    }
+  )";
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(AsyncKernelLaunchTest, ScheduledOverlappingAsyncComputations) {
+  const char* hlo_text = R"(
+    HloModule Test1
+
+    add {
+      lhs = f32[2] parameter(0)
+      rhs = f32[2] parameter(1)
+      ROOT add = f32[2] add(lhs, rhs)
+    }
+    
+    mul {
+      lhs = f32[2] parameter(0)
+      rhs = f32[2] parameter(1)
+      ROOT mul = f32[2] multiply(lhs, rhs)
+    }
+
+    ENTRY Test1 {
+      a = f32[2] parameter(0)
+      b = f32[2] parameter(1)
+      start = ((f32[2], f32[2]), f32[2]) call-start(a, b), to_apply=add,
+        frontend_attributes={_xla_stream_annotation="1", _scheduling_group_id="0"}
+      start.1 = ((f32[2], f32[2]), f32[2]) call-start(a, b), to_apply=mul,
+        frontend_attributes={_xla_stream_annotation="2", _scheduling_group_id="0"}
+      done = f32[2] call-done(start)
+      done.1 = f32[2] call-done(start.1)
+      ROOT result = f32[2] add(done, done.1)
+    }
+  )";
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/service/gpu/tests/async_kernel_launch_test.cc
+++ b/xla/service/gpu/tests/async_kernel_launch_test.cc
@@ -82,16 +82,16 @@ TEST_F(AsyncKernelLaunchTest, BasicAsyncComputation) {
     HloModule Test1
 
     add_F32 {
-      lhs = f32[2] parameter(0)
-      rhs = f32[2] parameter(1)
-      ROOT add = f32[2] add(lhs, rhs)
+      lhs = f32[2]{0} parameter(0)
+      rhs = f32[2]{0} parameter(1)
+      ROOT add = f32[2]{0} add(lhs, rhs)
     }
 
     ENTRY Test1 {
-      a = f32[2] parameter(0)
-      b = f32[2] parameter(1)
-      start = ((f32[2], f32[2]), f32[2]) call-start(a, b), to_apply=add_F32
-      ROOT done = f32[2] call-done(start)
+      a = f32[2]{0} parameter(0)
+      b = f32[2]{0} parameter(1)
+      start = ((f32[2]{0}, f32[2]{0}), f32[2]{0}) call-start(a, b), to_apply=add_F32
+      ROOT done = f32[2]{0} call-done(start)
     }
   )";
 
@@ -103,27 +103,27 @@ TEST_F(AsyncKernelLaunchTest, ScheduledOverlappingAsyncComputations) {
     HloModule Test1
 
     add {
-      lhs = f32[2] parameter(0)
-      rhs = f32[2] parameter(1)
-      ROOT add = f32[2] add(lhs, rhs)
+      lhs = f32[2]{0} parameter(0)
+      rhs = f32[2]{0} parameter(1)
+      ROOT add = f32[2]{0} add(lhs, rhs)
     }
     
     mul {
-      lhs = f32[2] parameter(0)
-      rhs = f32[2] parameter(1)
+      lhs = f32[2]{0} parameter(0)
+      rhs = f32[2]{0} parameter(1)
       ROOT mul = f32[2] multiply(lhs, rhs)
     }
 
     ENTRY Test1 {
-      a = f32[2] parameter(0)
-      b = f32[2] parameter(1)
-      start = ((f32[2], f32[2]), f32[2]) call-start(a, b), to_apply=add,
+      a = f32[2]{0} parameter(0)
+      b = f32[2]{0} parameter(1)
+      start = ((f32[2]{0}, f32[2]{0}), f32[2]{0}) call-start(a, b), to_apply=add,
         frontend_attributes={_xla_stream_annotation="1", _scheduling_group_id="0"}
-      start.1 = ((f32[2], f32[2]), f32[2]) call-start(a, b), to_apply=mul,
+      start.1 = ((f32[2]{0}, f32[2]{0}), f32[2]{0}) call-start(a, b), to_apply=mul,
         frontend_attributes={_xla_stream_annotation="2", _scheduling_group_id="0"}
-      done = f32[2] call-done(start)
-      done.1 = f32[2] call-done(start.1)
-      ROOT result = f32[2] add(done, done.1)
+      done = f32[2]{0} call-done(start)
+      done.1 = f32[2]{0} call-done(start.1)
+      ROOT result = f32[2]{0} add(done, done.1)
     }
   )";
 

--- a/xla/service/gpu/tests/async_kernel_launch_test.cc
+++ b/xla/service/gpu/tests/async_kernel_launch_test.cc
@@ -95,7 +95,7 @@ TEST_F(AsyncKernelLaunchTest, BasicAsyncComputation) {
     }
   )";
 
-  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+  EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
 TEST_F(AsyncKernelLaunchTest, ScheduledOverlappingAsyncComputations) {
@@ -127,7 +127,7 @@ TEST_F(AsyncKernelLaunchTest, ScheduledOverlappingAsyncComputations) {
     }
   )";
 
-  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+  EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
 }  // namespace

--- a/xla/service/gpu/transforms/fusion_wrapper_test.cc
+++ b/xla/service/gpu/transforms/fusion_wrapper_test.cc
@@ -241,29 +241,28 @@ TEST_F(FusionWrapperTest, AsyncComputationFusion) {
       HloModule AsyncComputation
 
       mul {
-      a = f32[5]{0} parameter(0)
-      ROOT b = f32[5]{0} multiply(a, a)
+        a = f32[5] parameter(0)
+        ROOT b = f32[5] multiply(a, a)
       }
 
-      ENTRY %main (parameter.1: f32[5]) -> f32[5] {
-      parameter = f32[5]{0} parameter(0)
-      start = ((f32[5]), f32[5]) call-start(parameter), to_apply=mul
-      ROOT done = f32[5] call-done(start)
-})",
+      ENTRY %main {
+        parameter = f32[5] parameter(0)
+        start = ((f32[5]), f32[5]) call-start(parameter), to_apply=mul
+        ROOT done = f32[5] call-done(start)
+      })",
                             FusionWrapper(device_description()), R"(
-//CHECK: %wrapped_multiply_computation (param_0: f32[5]) -> f32[5] {
-//CHECK:   %param_0 = f32[5]{0} parameter(0)
-//CHECK:   ROOT %b.1 = f32[5]{0} multiply(%param_0, %param_0)
-//CHECK: }
-//CHECK: %mul (a: f32[5]) -> f32[5] {
-//CHECK:  %a = f32[5]{0} parameter(0)
-//CHECK:   ROOT %wrapped_multiply = f32[5]{0} fusion(%a), kind=kLoop, calls=%wrapped_multiply_computation
-//CHECK: }
-//CHECK: ENTRY %main (parameter: f32[5]) -> f32[5] {
-//CHECK:   %parameter = f32[5]{0} parameter(0)
-//CHECK:   %start = ((f32[5]{0}), f32[5]{0}) call-start(%parameter), to_apply=%mul
-//CHECK:   ROOT %done = f32[5]{0} call-done(%start)
-//CHECK: })");
+//CHECK:      %wrapped_multiply_computation {{.*}} {
+//CHECK-NEXT:   %[[P0:.*]] = {{.*}} parameter(0)
+//CHECK-NEXT:   ROOT {{.*}} multiply(%[[P0]], %[[P0]])
+//CHECK-NEXT: }
+//CHECK:      %mul {{.*}} {
+//CHECK-NEXT:   %[[P0:.*]] = {{.*}} parameter(0)
+//CHECK-NEXT:   ROOT {{.*}} fusion(%[[P0]]), kind=kLoop, calls=%wrapped_multiply_computation
+//CHECK-NEXT: }
+//CHECK:     ENTRY %main {{.*}} {
+//CHECK-NEXT:        %[[P0:.*]] = {{.*}} parameter(0)
+//CHECK-NEXT:        {{.*}} call-start(%[[P0]]), to_apply=%mul
+)");
 }
 
 }  // namespace


### PR DESCRIPTION
Previously, in JAX if you do a simple stream annotated computation with just a single instruction, i.e.

```python
@compute_on('gpu_stream:1')
@jax.jit
def h(x, y):
  return x * y
```

Then the XLA compiler would fail with an error like

```
jaxlib.xla_extension.XlaRuntimeError: INTERNAL: Unsupported instruction opcode: multiply
```

This is because the fusion wrapper would not correctly look inside of async computations, leaving the instructions unfused. 

To fix this, we simply add `kCall` and `kAsyncStart` to the set of instructions that are treated recursively in the fusion wrapper.