### PR TITLE
[ROCm] Change logging level for unhandled operators

### DIFF
--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -1561,8 +1561,8 @@ absl::Status RocmTracer::DisableActivityTracing() {
   size_t threshold = 1;
   for (int i = 0; i < 6; i++, duration_ms *= 2, threshold *= 2) {
     if (GetPendingActivityRecordsCount() < threshold) break;
-    VLOG(3) << "Wait for pending activity records :" << " Pending count = "
-            << GetPendingActivityRecordsCount()
+    VLOG(3) << "Wait for pending activity records :"
+            << " Pending count = " << GetPendingActivityRecordsCount()
             << ", Threshold = " << threshold;
     VLOG(3) << "Wait for pending activity records : sleep for " << duration_ms
             << " ms";

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -399,8 +399,8 @@ absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
       default:
         //
         VLOG(1) << "API call "
-                << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API,
-                                                cbid, 0)
+                << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid,
+                                                 0)
                 << ", corr. id=" << data->correlation_id
                 << " dropped. No capturing function was found!";
         // AddGenericEventUponApiExit(cbid, data);

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -399,10 +399,10 @@ absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
       default:
         //
         VLOG(1) << "API call "
-                     << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API,
-                                                      cbid, 0)
-                     << ", corr. id=" << data->correlation_id
-                     << " dropped. No capturing function was found!";
+                << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API,
+                                                cbid, 0)
+                << ", corr. id=" << data->correlation_id
+                << " dropped. No capturing function was found!";
         // AddGenericEventUponApiExit(cbid, data);
         break;
     }

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -398,7 +398,7 @@ absl::Status RocmApiCallbackImpl::operator()(uint32_t domain, uint32_t cbid,
         break;
       default:
         //
-        LOG(WARNING) << "API call "
+        VLOG(1) << "API call "
                      << se::wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API,
                                                       cbid, 0)
                      << ", corr. id=" << data->correlation_id


### PR DESCRIPTION
Previously, when profiling, the profiler would print thousands of messages for operators that the profiler did not handle unless all warning messages were dropped.

This could cause full buffers for stdout, which slowed down computation for at least one workload by 6-7x during profiling (~2s vs ~330ms).

This PR changes the default logging for the unhandled operators, which fixes the problem. Using VLOG(1) was suggested by @pemeliya 