### PR TITLE
Fixed failing NCCL Group test on internal CI

### DIFF
--- a/xla/tests/nccl_group_execution_test.cc
+++ b/xla/tests/nccl_group_execution_test.cc
@@ -127,7 +127,7 @@ XLA_TEST_F(NcclGroupExecutionTest, NcclGroupSendRecvNoWhileLoop) {
 
 XLA_TEST_F(NcclGroupExecutionTest, BidirectionalCommunication) {
   const absl::string_view kModuleStr = R"(
-  HloModule module_main, entry_computation_layout={()->(u32[], u32[])}, replica_count=4
+  HloModule module_main, entry_computation_layout={()->(u32[], u32[])}, num_partitions=4
 
   bidirectional_ring {
     a = u32[] parameter(0)

--- a/xla/tests/nccl_group_execution_test.cc
+++ b/xla/tests/nccl_group_execution_test.cc
@@ -127,13 +127,13 @@ XLA_TEST_F(NcclGroupExecutionTest, NcclGroupSendRecvNoWhileLoop) {
 
 XLA_TEST_F(NcclGroupExecutionTest, BidirectionalCommunication) {
   const absl::string_view kModuleStr = R"(
-  HloModule module_main, entry_computation_layout={()->(u32[], u32[])}
+  HloModule module_main, entry_computation_layout={()->(u32[], u32[])}, replica_count=4
 
   bidirectional_ring {
     a = u32[] parameter(0)
-    start = (u32[], u32[]) collective-permute-start(a), channel_id=2, source_target_pairs={{0,1},{1,2},{2,3},{3,0}}
+    start = (u32[], u32[]) collective-permute-start(a), source_target_pairs={{0,1},{1,2},{2,3},{3,0}}
     done = u32[] collective-permute-done(start)
-    start.1 = (u32[], u32[]) collective-permute-start(a), channel_id=1, source_target_pairs={{0,3},{1,0},{2,1},{3,2}}
+    start.1 = (u32[], u32[]) collective-permute-start(a), source_target_pairs={{0,3},{1,0},{2,1},{3,2}}
     done.1 = u32[] collective-permute-done(start.1)
     ROOT tuple = (u32[], u32[]) tuple(done, done.1)
   }


### PR DESCRIPTION
Previously, this test was failing with 

```
INTERNAL: NCCL operation ncclRecv( recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype, source_rank->value(), comm_, se::gpu::AsGpuStreamValue(stream)) failed: invalid argument (run with NCCL_DEBUG=WARN for details). Last NCCL warning(error) log entry (may be unrelated) 'Recv : invalid root 3 (root should be in the 0..1 range)'.
```

This was because of a mix of the bad channel ids and this missing `replica_count` attribute.
