### PR TITLE
[NVIDIA GPU] Collective-permute combiner ignores channel id when enabled

### DIFF
--- a/xla/hlo/transforms/collectives/collective_permute_combiner_test.cc
+++ b/xla/hlo/transforms/collectives/collective_permute_combiner_test.cc
@@ -341,5 +341,48 @@ ENTRY %CombineCollectivePermutes () -> (f32[256], f32[512], f32[2560], f32[1792]
   EXPECT_TRUE(changed);
 }
 
+TEST_F(CollectivePermuteCombinerTest, IgnoreChannelId) {
+  const char* const hlo_string = R"(
+HloModule CombineCollectivePermutes, entry_computation_layout={()->(f32[256]{0}, f32[512]{0}, f32[2560]{0}, f32[1792]{0}, f32[1536]{0})}
+
+ENTRY %CombineCollectivePermutes () -> (f32[256], f32[512], f32[2560], f32[1792], f32[1536]) {
+  %constant = f64[] constant(42.3)
+  %broadcast = f32[256]{0} broadcast(f64[] %constant), dimensions={}
+  %collective-permute = f32[256]{0} collective-permute(f32[256]{0} %broadcast), source_target_pairs={{0,1},{1,2},{2,3}}, channel_id=1
+
+  %constant.1 = f64[] constant(42.3)
+  %broadcast.1 = f32[512]{0} broadcast(f64[] %constant.1), dimensions={}
+  %collective-permute.1 = f32[512]{0} collective-permute(f32[512]{0} %broadcast.1), source_target_pairs={{0,1},{1,2},{2,3}}, channel_id=1
+
+  %constant.2 = f64[] constant(42.3)
+  %broadcast.2 = f32[2560]{0} broadcast(f64[] %constant.2), dimensions={}
+  %collective-permute.2 = f32[2560]{0} collective-permute(f32[2560]{0} %broadcast.2), source_target_pairs={{0,1},{1,2},{2,3}}, channel_id=2
+
+  %constant.3 = f64[] constant(42.3)
+  %broadcast.3 = f32[1792]{0} broadcast(f64[] %constant.3), dimensions={}
+  %collective-permute.3 = f32[1792]{0} collective-permute(f32[1792]{0} %broadcast.3), source_target_pairs={{0,1},{1,2},{2,3}}, channel_id=2
+
+  %constant.4 = f64[] constant(42.3)
+  %broadcast.4 = f32[1536]{0} broadcast(f64[] %constant.4), dimensions={}
+  %collective-permute.4 = f32[1536]{0} collective-permute(f32[1536]{0} %broadcast.4), source_target_pairs={{0,1},{1,2},{2,3}}, channel_id=1
+  
+  ROOT %tuple = (f32[256]{0}, f32[512]{0}, f32[2560]{0}, f32[1792]{0}, f32[1536]{0}) tuple(f32[256]{0} %collective-permute, f32[512]{0} %collective-permute.1, f32[2560]{0} %collective-permute.2, f32[1792]{0} %collective-permute.3, f32[1536]{0} %collective-permute.4)
+})";
+  HloModuleConfig config = GetModuleConfigForTest();
+  auto opts = GetDebugOptionsForTest();
+  opts.set_xla_ignore_channel_id(true);
+  config.set_debug_options(opts);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+
+  const int64_t total_count = 5;
+  CollectivePermuteCombiner combine(1024 * 1024, kMaxCombineCount);
+  ASSERT_EQ(CollectivePermuteCount(*module), total_count);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, combine.Run(module.get()));
+  // Expect one combined collective permute op since channel_id is ignored
+  EXPECT_EQ(CollectivePermuteCount(*module), 1);
+  EXPECT_TRUE(changed);
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/collective_permute_key.cc
+++ b/xla/service/collective_permute_key.cc
@@ -34,14 +34,7 @@ std::optional<CollectivePermuteKey> GetCollectivePermuteKey(
   }
 
   const auto* cp = Cast<HloCollectivePermuteInstruction>(instruction);
-  return CollectivePermuteKey{cp->source_target_pairs(),
-                              instruction->parent()
-                                      ->parent()
-                                      ->config()
-                                      .debug_options()
-                                      .xla_ignore_channel_id()
-                                  ? std::nullopt
-                                  : cp->channel_id()};
+  return CollectivePermuteKey{cp->source_target_pairs()};
 }
 
 }  // namespace xla

--- a/xla/service/collective_permute_key.cc
+++ b/xla/service/collective_permute_key.cc
@@ -34,7 +34,14 @@ std::optional<CollectivePermuteKey> GetCollectivePermuteKey(
   }
 
   const auto* cp = Cast<HloCollectivePermuteInstruction>(instruction);
-  return CollectivePermuteKey{cp->source_target_pairs(), cp->channel_id()};
+  return CollectivePermuteKey{cp->source_target_pairs(),
+                              instruction->parent()
+                                      ->parent()
+                                      ->config()
+                                      .debug_options()
+                                      .xla_ignore_channel_id()
+                                  ? std::nullopt
+                                  : cp->channel_id()};
 }
 
 }  // namespace xla

--- a/xla/service/collective_permute_key.h
+++ b/xla/service/collective_permute_key.h
@@ -32,8 +32,7 @@ namespace xla {
 // collective-permute instructions to be compatible with each other (and hence
 // be possible to combine the instructions).
 using CollectivePermuteKey = std::tuple<
-    /*source_target_pairs*/ std::vector<std::pair<int64_t, int64_t>>,
-    /*channel_id*/ std::optional<int64_t>>;
+    /*source_target_pairs*/ std::vector<std::pair<int64_t, int64_t>>>;
 
 std::optional<CollectivePermuteKey> GetCollectivePermuteKey(
     const HloInstruction* instruction);


### PR DESCRIPTION
This PR pipes `xla_ignore_channel_id` flag to collective-permute combiner, allowing the combiner to ignore channel id difference when the flag is on.