### PR TITLE
Fix fp8 tests

### DIFF
--- a/xla/service/gpu/transforms/dot_operand_converter.cc
+++ b/xla/service/gpu/transforms/dot_operand_converter.cc
@@ -39,7 +39,8 @@ bool DotOperandConverter::InstructionMatchesPattern(
   }
 
   // Exclude conversions between FP8 types.
-  absl::flat_hash_set<PrimitiveType> non_converting = {F8E4M3FN, F8E5M2};
+  absl::flat_hash_set<PrimitiveType> non_converting = {F8E4M3FN, F8E5M2,
+    F8E4M3FNUZ, F8E5M2FNUZ};
   if (non_converting.contains(lhs_type) && non_converting.contains(rhs_type)) {
     return false;
   }

--- a/xla/service/gpu/transforms/dot_operand_converter_test.cc
+++ b/xla/service/gpu/transforms/dot_operand_converter_test.cc
@@ -124,6 +124,23 @@ TEST_F(DotOperandConverterTest, NoConvertFromF8toF8) {
   EXPECT_FALSE(upcasted);
 }
 
+TEST_F(DotOperandConverterTest, NoConvertFromF8FNUZtoF8FNUZ) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    p0 = f8e4m3fnuz[2,3]{1,0} parameter(0)
+    p1 = f8e5m2fnuz[3,2]{1,0} parameter(1)
+    ROOT dot = bf16[2,2]{1,0} dot(p0, p1), lhs_contracting_dims={1},
+                                           rhs_contracting_dims={0}
+  })";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(module_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool upcasted,
+                          DotOperandConverter().Run(module.get()));
+  EXPECT_FALSE(upcasted);
+}
+
 TEST_F(DotOperandConverterTest, CompilerOptimizesUsingDotOperandConverter) {
   absl::string_view module_string = R"(
   HloModule module


### PR DESCRIPTION
We observed failures in internal CI for FP8 types `F8E4M3FNUZ` and `F8E5M2FNUZ`. These types should not be implicitly upcast during dot operation operand conversion. This patch extends the existing check that prevents conversions between FP8 types by including these two additional variants.

@xla-rotation @draganmladjenovic can you please take a look?