### PR TITLE
Larger timeouts for first call rendezvous

### DIFF
--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -58,6 +58,10 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 
+// TODO: These timeouts should really be configurable via debug options.
+extern "C" int XLA_FIRST_CALL_RENDEZVOUS_WARN = 20;
+extern "C" int XLA_FIRST_CALL_RENDEZVOUS_TERMINATE = 40;
+
 namespace xla::gpu {
 namespace {
 
@@ -482,8 +486,8 @@ absl::Status CollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
 
     Rendezvous(first_call_rendezvous_flag_, rendezvous_name, rendezvous_key,
                num_local_participants,
-               /*warn_stuck_timeout=*/absl::Seconds(20),
-               /*terminate_timeout=*/absl::Seconds(40));
+               /*warn_stuck_timeout=*/absl::Seconds(XLA_FIRST_CALL_RENDEZVOUS_WARN),
+               /*terminate_timeout=*/absl::Seconds(XLA_FIRST_CALL_RENDEZVOUS_TERMINATE));
   }
 
   return absl::OkStatus();


### PR DESCRIPTION
Probably not the best design, but these timeouts should really be configurable like [others are](https://github.com/openxla/xla/blob/ea7226c6def0ada11fd4635be19a288c7c66f874/xla/service/gpu/gpu_executable.cc#L429-L438) and this is a quick and dirty way to do it