### PR TITLE
Disable dynamic memcpy fusion annotation.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1304,7 +1304,6 @@ cc_library(
         "//xla/service:hlo_cost_analysis",
         "//xla/service:pattern_matcher",
         "//xla/service/gpu/transforms:fusion_block_level_rewriter",
-        "//xla/service/gpu/transforms:fusion_dynamic_memcpy_rewriter",
         "//xla/stream_executor:device_description",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",

--- a/xla/service/gpu/fusion_dispatch_pipeline.cc
+++ b/xla/service/gpu/fusion_dispatch_pipeline.cc
@@ -29,7 +29,6 @@ limitations under the License.
 #include "xla/hlo/pass/hlo_pass_pipeline.h"
 #include "xla/layout_util.h"
 #include "xla/service/gpu/transforms/fusion_block_level_rewriter.h"
-#include "xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/stream_executor/device_description.h"
@@ -132,7 +131,6 @@ HloPassPipeline FusionDispatchPipeline(
   HloPassPipeline pipeline("fusion-dispatch-pipeline");
   pipeline.AddPass<FusionBlockLevelRewriter>(device_description, shape_size_fn,
                                              std::move(try_rewrite_fusion_if));
-  pipeline.AddPass<FusionDynamicMemcpyRewriter>();
   return pipeline;
 }
 


### PR DESCRIPTION
This was reported to cause segfaults in the dynamic copy thunk. Disabling the annotation disables the creation of any such thunks.

Note: there are no test cases because the tests I wrote before are incomplete (which I hadn't noticed). In `GpuCopyTest`, I intended to test this functionality end-to-end, but I accidentally left out triggering. I'll fix this when re-enabling this.