### PR TITLE
[XLA:CPU][BugFix] Verify sufficient scratch allocation for oneDNN convolution execution

### DIFF
--- a/xla/service/cpu/onednn_convolution.cc
+++ b/xla/service/cpu/onednn_convolution.cc
@@ -163,7 +163,10 @@ CreateOneDnnPrimDesc<dnnl::convolution_forward::primitive_desc>(
   for (const Shape& shape : fused_shapes) {
     memory::desc mem_desc = ShapeToMemDesc(shape);
     // The post-op argument must be oriented consistently with the output memory
-    // descriptor
+    // descriptor.
+    // Bias inputs are one-dimensional, as required by oneDNN. The broadcast
+    // dimensions of all binary post-op inputs are expanded in the rewriter.
+    // Hence, this condition should hold for all non-bias inputs.
     if (mem_desc.get_ndims() == new_out_md.get_ndims()) {
       mem_desc = mem_desc.permute_axes(ComputePermutations(
           conv_config.dims(), conv_config.output().data().batch_dim(),

--- a/xla/service/cpu/onednn_convolution.cc
+++ b/xla/service/cpu/onednn_convolution.cc
@@ -161,7 +161,16 @@ CreateOneDnnPrimDesc<dnnl::convolution_forward::primitive_desc>(
 
   std::vector<memory::desc> fused_mds;
   for (const Shape& shape : fused_shapes) {
-    fused_mds.push_back(ShapeToMemDesc(shape));
+    memory::desc mem_desc = ShapeToMemDesc(shape);
+    // The post-op argument must be oriented consistently with the output memory
+    // descriptor
+    if (mem_desc.get_ndims() == new_out_md.get_ndims()) {
+      mem_desc = mem_desc.permute_axes(ComputePermutations(
+          conv_config.dims(), conv_config.output().data().batch_dim(),
+          conv_config.output().data().feature_dim(),
+          conv_config.output().data().spatial_dims()));
+    }
+    fused_mds.push_back(mem_desc);
   }
 
   memory::desc bias_md = memory::desc();
@@ -340,6 +349,8 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnConvolution(
     XLA_LIGHTWEIGHT_CHECK(scratch != nullptr);
     MemrefInfo scratch_minfo(scratch);
     memory::desc scratchpad_md = conv_pd->scratchpad_desc();
+    XLA_LIGHTWEIGHT_CHECK(scratchpad_md.get_size() <=
+                          scratch_minfo.GetOneDnnDims()[0]);
     memory scratch_mem =
         memory(scratchpad_md, cpu_engine, scratch_minfo.Data());
     conv_args.insert({DNNL_ARG_SCRATCHPAD, scratch_mem});

--- a/xla/service/cpu/onednn_util.h
+++ b/xla/service/cpu/onednn_util.h
@@ -53,6 +53,10 @@ inline bool IsSupportedType(xla::PrimitiveType dtype) {
   return false;
 }
 
+inline bool HasAMXTile() {
+  return TestCPUFeature(tsl::port::CPUFeature::AMX_TILE);
+}
+
 struct FusedOperandsRef {
   const std::vector<void*>& bufs;
   std::vector<std::pair<int, dnnl::memory>>& postop_args;

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -295,16 +295,32 @@ TEST_P(ConvolutionTest, ConvInsufficientScratchTest) {
     p0 = $dtype[1,1024,1] parameter(0)
     p1 = $dtype[3,1,3] parameter(1)
     ROOT conv = ($dtype[1,1022,3], u8[128]) custom-call(p0, p1),
-        custom_call_target="__onednn$convolution",
-        backend_config={"outer_dimension_partitions":[],
-        "onednn_conv_config":{"dims":"3","input":{"dims":"0",
-          "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["2"]}},
-          "kernel":{"dims":"0","filter":{"input_feature_dim":"1",
-            "output_feature_dim":"2","spatial_dims":["1"],"shape":[]}},
-          "output":{"dims":"0","data":{"batch_dim":"0","feature_dim":"2",
-            "spatial_dims":["2"]}}, "window":{"size":[],"pad_left":["1"],
-              "pad_right":["1"], "strides":["2"],"window_dilations":["2"]},
-          "feature_groups":"1","optimization_config":{"user_scratchpad":true}}}
+      custom_call_target="__onednn$convolution",
+        backend_config={
+          "outer_dimension_partitions":[],
+          "onednn_conv_config":{
+            "dims":"3",
+            "input":{
+              "dims":"3",
+              "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["2"]}
+            },
+            "kernel":{
+              "dims":"3",
+              "filter":{"input_feature_dim":"1","output_feature_dim":"2",
+                "spatial_dims":["1"],"shape":[]}
+            },
+            "output":{
+              "dims":"3",
+              "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["2"]}
+            },
+            "window":{
+              "size":[],"pad_left":["1"],"pad_right":["1"],
+              "strides":["2"],"window_dilations":["2"]
+            },
+            "feature_groups":"1",
+            "optimization_config":{"user_scratchpad":true}
+          }
+        }
   })";
 
   RunAndExpectExit(outline, SIGABRT);

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -137,6 +137,14 @@ class ConvolutionTest : public HloTestBase,
     return primitive_util::LowercasePrimitiveTypeName(PromotedDtype());
   }
 
+  void RunAndExpectExit(const absl::string_view outline, int signal) {
+    const std::string convolution_module_str = absl::StrReplaceAll(
+        outline,
+        {{"$dtype", dtypeString_}, {"$pdtype", PromotedDtypeToString()}});
+    EXPECT_EXIT(Run(convolution_module_str, true),
+                ::testing::KilledBySignal(signal), "");
+  }
+
   void RunCompareAndMatchOptimizedHlo(
       const absl::string_view outline,
       const std::vector<absl::string_view> fused_ops) {
@@ -269,6 +277,37 @@ TEST_P(ConvolutionTest, Conv2DWithBiasAndReluTest) {
   })";
 
   RunCompareAndMatchOptimizedHlo(outline, {"BIAS", "RELU"});
+}
+
+TEST_P(ConvolutionTest, ConvInsufficientScratchTest) {
+  // Running death tests in a single-threaded environment
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  if (dtype_ == BF16 && !HasAMXTile()) {
+    GTEST_SKIP() << "Skipping test for " << dtypeString_
+                 << " because oneDNN may not request scratch allocations "
+                    "on platforms that emulate "
+                 << dtypeString_;
+  }
+  const absl::string_view outline = R"(
+  HloModule convolution.test.insufficient.scratch
+
+  ENTRY convolution.test.insufficient.scratch {
+    p0 = $dtype[1,1024,1] parameter(0)
+    p1 = $dtype[3,1,3] parameter(1)
+    ROOT conv = ($dtype[1,1022,3], u8[128]) custom-call(p0, p1),
+        custom_call_target="__onednn$convolution",
+        backend_config={"outer_dimension_partitions":[],
+        "onednn_conv_config":{"dims":"3","input":{"dims":"0",
+          "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["2"]}},
+          "kernel":{"dims":"0","filter":{"input_feature_dim":"1",
+            "output_feature_dim":"2","spatial_dims":["1"],"shape":[]}},
+          "output":{"dims":"0","data":{"batch_dim":"0","feature_dim":"2",
+            "spatial_dims":["2"]}}, "window":{"size":[],"pad_left":["1"],
+              "pad_right":["1"], "strides":["2"],"window_dilations":["2"]},
+          "feature_groups":"1","optimization_config":{"user_scratchpad":true}}}
+  })";
+
+  RunAndExpectExit(outline, SIGABRT);
 }
 
 TEST_P(ConvolutionTest, Conv2DWithBinaryAddTest) {

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -141,7 +141,7 @@ class ConvolutionTest : public HloTestBase,
     const std::string convolution_module_str = absl::StrReplaceAll(
         outline,
         {{"$dtype", dtypeString_}, {"$pdtype", PromotedDtypeToString()}});
-    EXPECT_EXIT(Run(convolution_module_str, true),
+    EXPECT_EXIT((void)Run(convolution_module_str, true),
                 ::testing::KilledBySignal(signal), "");
   }
 


### PR DESCRIPTION
In the existing code, the post-op memory descriptors were not permuted to match the orientation of the output during scratch memory allocation. As a result, in some corner cases oneDNN tried to use more scratch memory than what was actually allocated. This PR:
1. Ensures that the orientation of the post-op memory descriptors matches to that of the output, so the scratch memory allocated accurately reflects what is required at runtime.
2. Adds a safeguard check to prevent oneDNN from exceeding the allocated scratch memory, along with a parameterized test (on dtypes) to validate this behavior.