### PR TITLE
[ROCm] a patch for C64 and C128 from HLO to MLIR

### DIFF
--- a/xla/codegen/emitters/elemental_hlo_to_mlir.cc
+++ b/xla/codegen/emitters/elemental_hlo_to_mlir.cc
@@ -502,6 +502,11 @@ absl::StatusOr<Value> EmitMulAdd(Value lhs, Value rhs, Value accumulator,
     return b.create<arith::OrIOp>(accumulator,
                                   b.create<arith::AndIOp>(lhs, rhs));
   }
+  if (primitive_util::IsComplexType(result_element_type)) {
+    // Handle complex types (e.g., C64, C128)
+    Value mul = b.create<mlir::complex::MulOp>(accumulator_type, lhs, rhs);
+    return b.create<mlir::complex::AddOp>(accumulator_type, accumulator, mul);
+  }
   return b.create<arith::AddIOp>(accumulator,
                                  b.create<arith::MulIOp>(lhs, rhs));
 }
@@ -518,9 +523,24 @@ absl::StatusOr<SmallVector<Value, 1>> EmitDotLoop(
 
   const mlir::Type accumulator_type =
       result_element_type.isBF16() ? b.getF32Type() : result_element_type;
-  Value accum_init_value =
-      b.create<ConstantOp>(b.getZeroAttr(accumulator_type)).getResult();
+  Value accum_init_value;
+  if (auto complex_ty = accumulator_type.dyn_cast<mlir::ComplexType>()) {
+    // For complex, build real-zero and imag-zero separately:
+    mlir::Type element_ty = complex_ty.getElementType();
 
+    // E.g. float zero
+    auto real_zero = b.create<arith::ConstantOp>(b.getZeroAttr(element_ty));
+    auto imag_zero = b.create<arith::ConstantOp>(b.getZeroAttr(element_ty));
+
+    // Create a complex<element_ty> from these two scalars
+    accum_init_value =
+        b.create<mlir::complex::CreateOp>(complex_ty, real_zero, imag_zero);
+  } else {
+    // For non-complex, just build a float or integer zero directly
+    accum_init_value =
+        b.create<arith::ConstantOp>(b.getZeroAttr(accumulator_type));
+  }
+  
   // For convolutions with `batch_group_count` > 1, there is an additional
   // symbol for LHS (group id) - ignore it for RHS.
   size_t rhs_symbol_count = rhs_indexing_map.GetSymbolCount();

--- a/xla/codegen/emitters/elemental_hlo_to_mlir_test.cc
+++ b/xla/codegen/emitters/elemental_hlo_to_mlir_test.cc
@@ -1765,6 +1765,64 @@ TEST_F(ElementalHloToMlirTest, BroadcastSelect) {
   )"));
 }
 
+TEST_F(ElementalHloToMlirTest, DotC64) {
+  TF_EXPECT_OK(Run(
+      R"(
+HloModule c64_dot_test
+
+ENTRY main {
+  p0 = c64[4] parameter(0)
+  p1 = c64[4] parameter(1)
+  dot = c64[] dot(p0, p1), lhs_contracting_dims={0}, rhs_contracting_dims={0}
+  ROOT out = c64[] add(dot, dot)
+}
+      )",
+      R"(
+      # CHECK: func.func private @main_out(
+      # CHECK-SAME: %[[ARG0:.*]]: tensor<4xcomplex<f32>>,
+      # CHECK-SAME: %[[ARG1:.*]]: tensor<4xcomplex<f32>>
+      # CHECK:   %[[CST0:.*]] = arith.constant 0.000000e+00 : f32
+      # CHECK:   %[[INIT:.*]] = complex.create %[[CST0]], %[[CST0]] : complex<f32>
+      # CHECK:   %[[DOTRESULT:.*]] = scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}} iter_args({{.*}} = %[[INIT]]) -> (complex<f32>) {
+      # CHECK:     %[[EXTRACTED:.*]] = tensor.extract %[[ARG0]][{{.*}}]
+      # CHECK:     %[[EXTRACTED0:.*]] = tensor.extract %[[ARG1]][{{.*}}]
+      # CHECK:     %[[MUL:.*]] = complex.mul %[[EXTRACTED]], %[[EXTRACTED0]]
+      # CHECK:     %[[NEXTACC:.*]] = complex.add {{.*}}, %[[MUL]]
+      # CHECK:     scf.yield %[[NEXTACC]]
+      # CHECK:   %[[OUT:.*]] = complex.add %[[DOTRESULT]], %[[DOTRESULT]]
+      # CHECK:   return %[[OUT]]
+      )"));
+}
+
+TEST_F(ElementalHloToMlirTest, DotC128) {
+  TF_EXPECT_OK(Run(
+      R"(
+HloModule c128_dot_test
+
+ENTRY main {
+  p0 = c128[3] parameter(0)
+  p1 = c128[3] parameter(1)
+  dot = c128[] dot(p0, p1), lhs_contracting_dims={0}, rhs_contracting_dims={0}
+  ROOT out = c128[] add(dot, dot)
+}
+      )",
+      R"(
+      # CHECK: func.func private @main_out(
+      # CHECK-SAME: %[[ARG0:.*]]: tensor<3xcomplex<f64>>,
+      # CHECK-SAME: %[[ARG1:.*]]: tensor<3xcomplex<f64>>
+      # CHECK:   %[[CST0:.*]] = arith.constant 0.000000e+00 : f64
+      # CHECK:   %[[INIT:.*]] = complex.create %[[CST0]], %[[CST0]] : complex<f64>
+      # CHECK:   %[[DOTRESULT:.*]] = scf.for {{.*}} = {{.*}} to {{.*}} step {{.*}} iter_args({{.*}} = %[[INIT]]) -> (complex<f64>) {
+      # CHECK:     %[[EXTRACTED:.*]] = tensor.extract %[[ARG0]][{{.*}}]
+      # CHECK:     %[[EXTRACTED0:.*]] = tensor.extract %[[ARG1]][{{.*}}]
+      # CHECK:     %[[MUL:.*]] = complex.mul %[[EXTRACTED]], %[[EXTRACTED0]]
+      # CHECK:     %[[NEXTACC:.*]] = complex.add {{.*}}, %[[MUL]]
+      # CHECK:     scf.yield %[[NEXTACC]]
+      # CHECK:   %[[OUT:.*]] = complex.add %[[DOTRESULT]], %[[DOTRESULT]]
+      # CHECK:   return %[[OUT]]
+      )"));
+}
+
 }  // namespace
 }  // namespace emitters
 }  // namespace xla


### PR DESCRIPTION
Hi @xla-rotation, would you please kindly help to review this PR?

This PR addresses the following issue related to HLO to MLIR for C64 and C128 as we got
```
[ RUN ] DotTests/ParametricDotTest.TestC64/1x23x1_MajorToMinorTF LLVM ERROR: Failed to infer result type(s): "arith.constant"(...) {} : () -> ( ??? )
[ RUN ] DotTests/ParametricDotTest.TestC128/1x23x1_MajorToMinorTF LLVM ERROR: Failed to infer result type(s): "arith.constant"(...) {} : () -> ( ??? )
```