### PR TITLE
Don't clone instructions in HloEvaluator. 

### DIFF
--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -3243,7 +3243,7 @@ absl::Status HloEvaluator::HandleGetTupleElement(
   const Literal& operand_tuple_literal = GetEvaluatedLiteralFor(operand);
 
   Literal literal =
-      CreateLiteral(ShapeUtil::GetTupleElementShape(operand->shape(), index));
+      Literal(ShapeUtil::GetTupleElementShape(operand->shape(), index));
   TF_RETURN_IF_ERROR(literal.CopyFrom(operand_tuple_literal,
                                       /*dest_shape_index=*/{},
                                       /*src_shape_index=*/{index}));
@@ -3286,7 +3286,7 @@ absl::Status HloEvaluator::HandleAsyncStart(const HloInstruction* async_start) {
       embedded_evaluator->Evaluate(*async_start->async_wrapped_computation(),
                                    arg_literals));
 
-  Literal literal = CreateLiteral(async_start->shape());
+  Literal literal = Literal(async_start->shape());
 
   // Copy the operand values to the index {0, i} of the output.
   for (int i = 0; i < arg_literals.size(); ++i) {
@@ -3307,7 +3307,7 @@ absl::Status HloEvaluator::HandleAsyncUpdate(
     const HloInstruction* async_update) {
   const Literal& operand_tuple_literal =
       GetEvaluatedLiteralFor(async_update->operand(0));
-  Literal literal = CreateLiteral(async_update->shape());
+  Literal literal = Literal(async_update->shape());
   TF_RETURN_IF_ERROR(literal.CopyFrom(operand_tuple_literal,
                                       /*dest_shape_index=*/{},
                                       /*src_shape_index=*/{}));
@@ -3318,7 +3318,7 @@ absl::Status HloEvaluator::HandleAsyncUpdate(
 absl::Status HloEvaluator::HandleAsyncDone(const HloInstruction* async_done) {
   const Literal& operand_tuple_literal =
       GetEvaluatedLiteralFor(async_done->operand(0));
-  Literal literal = CreateLiteral(async_done->shape());
+  Literal literal = Literal(async_done->shape());
   TF_RETURN_IF_ERROR(literal.CopyFrom(operand_tuple_literal,
                                       /*dest_shape_index=*/{},
                                       /*src_shape_index=*/{1}));
@@ -3358,8 +3358,8 @@ absl::Status HloEvaluator::HandleCopyDone(const HloInstruction* copy_done) {
   }
 
   const Literal& operand_tuple_literal = GetEvaluatedLiteralFor(operand);
-  Literal literal = CreateLiteral(
-      ShapeUtil::GetTupleElementShape(operand->shape(), /*index=*/0));
+  Literal literal =
+      Literal(ShapeUtil::GetTupleElementShape(operand->shape(), /*index=*/0));
   TF_RETURN_IF_ERROR(literal.CopyFrom(operand_tuple_literal,
                                       /*dest_shape_index=*/{},
                                       /*src_shape_index=*/{0}));
@@ -4544,8 +4544,7 @@ absl::Status HloEvaluator::HandleReduce(const HloInstruction* hlo) {
 
   absl::InlinedVector<Literal, 1> results(num_args);
   for (int64_t i = 0; i < num_args; ++i) {
-    results[i] =
-        CreateLiteral(is_tuple ? out_shape.tuple_shapes(i) : out_shape);
+    results[i] = Literal(is_tuple ? out_shape.tuple_shapes(i) : out_shape);
   }
 
   TF_RETURN_IF_ERROR(ShapeUtil::ForEachIndexParallelWithStatus(
@@ -4648,7 +4647,7 @@ absl::Status HloEvaluator::HandleReduceWindow(const HloInstruction* hlo) {
           curr_val_literal_vec.reserve(input_literal_vec.size());
           for (const auto* input_literal : input_literal_vec) {
             // Evaluate computation with specified literal operands.
-            curr_val_literal_vec.push_back(CreateLiteral(ShapeUtil::MakeShape(
+            curr_val_literal_vec.push_back(Literal(ShapeUtil::MakeShape(
                 input_literal->shape().element_type(), {})));
             curr_val_literal_vec.back().CopyElementFrom(*input_literal,
                                                         operand_index, {});
@@ -4682,7 +4681,7 @@ absl::Status HloEvaluator::HandleReduceWindow(const HloInstruction* hlo) {
   if (inferred_return_shape.IsTuple()) {
     absl::InlinedVector<Literal, 1> results(num_args);
     for (int64_t i = 0; i < num_args; ++i) {
-      results[i] = CreateLiteral(inferred_return_shape.tuple_shapes(i));
+      results[i] = Literal(inferred_return_shape.tuple_shapes(i));
     }
     ShapeUtil::ForEachIndexParallel(
         inferred_return_shape.tuple_shapes(0),

--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -3392,13 +3392,13 @@ absl::Status HloEvaluator::HandleCall(const HloInstruction* call) {
 absl::Status HloEvaluator::HandleFusion(const HloInstruction* fusion) {
   auto* computation = fusion->fused_instructions_computation();
 
-  const auto& operands = fusion->operands();
   std::unique_ptr<HloEvaluator> embedded_evaluator =
       CreateEmbedded(max_loop_iterations_);
   embedded_evaluator->set_dynamic_dimension_inference(
       dynamic_dimension_inference_);
 
   absl::flat_hash_map<const HloInstruction*, const LiteralBase*> substitutions;
+  const auto& operands = fusion->operands();
   for (int i = 0; i < operands.size(); ++i) {
     substitutions[computation->parameter_instruction(i)] =
         &GetEvaluatedLiteralFor(operands[i]);

--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -1006,7 +1006,6 @@ bool HloEvaluator::TryEvaluate(const HloInstruction* instruction,
   return true;
 }
 
-
 absl::StatusOr<Literal> HloEvaluator::EvaluateElementwiseBinaryOp(
     HloOpcode opcode, const Literal& lhs, const Literal& rhs) {
   std::unique_ptr<HloInstruction> lhs_instr =
@@ -3386,39 +3385,26 @@ absl::Status HloEvaluator::HandleCall(const HloInstruction* call) {
 }
 
 absl::Status HloEvaluator::HandleFusion(const HloInstruction* fusion) {
-  HloModuleConfig config;
-  // Attach cloned computation to an empty HLO module so the existing ones are
-  // not modified.
-  HloModule empty_hlo_module("EmptyModuleForFusion", config,
-                             std::make_unique<CompilationEnvironments>(
-                                 fusion->GetModule()->comp_envs()));
-  HloCloneContext context(&empty_hlo_module);
-  auto cloned_fused_computation =
-      fusion->fused_instructions_computation()->Clone(
-          /*suffix=*/"clone_with_layout", &context);
-  for (auto* instruction : cloned_fused_computation->instructions()) {
-    if (!LayoutUtil::HasLayout(instruction->shape())) {
-      LayoutUtil::SetToDefaultLayout(instruction->mutable_shape());
-    }
-  }
-  auto readded_computation =
-      empty_hlo_module.AddEntryComputation(std::move(cloned_fused_computation));
+  auto* computation = fusion->fused_instructions_computation();
 
-  auto operands = fusion->operands();
-  std::vector<const Literal*> arg_literals;
-  arg_literals.reserve(operands.size());
-  for (auto operand : operands) {
-    const Literal& arg_literal = GetEvaluatedLiteralFor(operand);
-    arg_literals.push_back(&arg_literal);
-  }
-
+  const auto& operands = fusion->operands();
   std::unique_ptr<HloEvaluator> embedded_evaluator =
       CreateEmbedded(max_loop_iterations_);
   embedded_evaluator->set_dynamic_dimension_inference(
       dynamic_dimension_inference_);
-  TF_ASSIGN_OR_RETURN(Literal result, embedded_evaluator->Evaluate(
-                                          *readded_computation, arg_literals));
 
+  absl::flat_hash_map<const HloInstruction*, const LiteralBase*> substitutions;
+  for (int i = 0; i < operands.size(); ++i) {
+    substitutions[computation->parameter_instruction(i)] =
+        &GetEvaluatedLiteralFor(operands[i]);
+  }
+
+  TF_ASSIGN_OR_RETURN(Literal result,
+                      embedded_evaluator->Evaluate(
+                          fusion->fused_expression_root(),
+                          /*precomputed_analyses=*/{},
+                          /*recursively_evaluate_nonconstant_operands=*/true,
+                          substitutions));
   SetEvaluatedLiteralFor(fusion, std::move(result));
   return absl::OkStatus();
 }

--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -3404,12 +3404,12 @@ absl::Status HloEvaluator::HandleFusion(const HloInstruction* fusion) {
         &GetEvaluatedLiteralFor(operands[i]);
   }
 
-  TF_ASSIGN_OR_RETURN(Literal result,
-                      embedded_evaluator->Evaluate(
-                          fusion->fused_expression_root(),
-                          /*precomputed_analyses=*/{},
-                          /*recursively_evaluate_nonconstant_operands=*/true,
-                          substitutions));
+  TF_ASSIGN_OR_RETURN(
+      Literal result,
+      embedded_evaluator->Evaluate(
+          fusion->fused_expression_root(),
+          /*precomputed_analyses=*/{},
+          /*recursively_evaluate_nonconstant_operands=*/true, substitutions));
   SetEvaluatedLiteralFor(fusion, std::move(result));
   return absl::OkStatus();
 }

--- a/xla/hlo/evaluator/hlo_evaluator.h
+++ b/xla/hlo/evaluator/hlo_evaluator.h
@@ -554,7 +554,7 @@ class HloEvaluator : public ConstDfsHloVisitorWithDefault {
     const auto* operand = instruction->operand(0);
     TF_RET_CHECK(ShapeUtil::SameDimensions(shape, operand->shape()));
 
-    Literal result = Literal(shape);
+    Literal result(shape);
     TF_RETURN_IF_ERROR(
         result.PopulateLinearParallel<ReturnT>([&](int64_t linear_index, int) {
           return unary_op(operand_literal.GetLinear<NativeT>(linear_index));

--- a/xla/hlo/evaluator/hlo_evaluator.h
+++ b/xla/hlo/evaluator/hlo_evaluator.h
@@ -413,6 +413,9 @@ class HloEvaluator : public ConstDfsHloVisitorWithDefault {
   // Returns the already-evaluated literal result for the instruction and
   // removes it from internal evaluate state.
   Literal ExtractEvaluatedLiteralFor(const HloInstruction* hlo) {
+    if (state_.has_evaluated(hlo)) {
+      return state_.extract_evaluated(hlo);
+    }
     if (hlo->IsConstant()) {
       return hlo->literal().Clone();
     }
@@ -420,9 +423,7 @@ class HloEvaluator : public ConstDfsHloVisitorWithDefault {
       return state_.arg(hlo->parameter_number())->Clone();
     }
 
-    CHECK(state_.has_evaluated(hlo))
-        << "could not find evaluated value for: " << hlo->ToString();
-    return state_.extract_evaluated(hlo);
+    LOG(FATAL) << "could not find evaluated value for: " << hlo->ToString();
   }
 
   // Returns true if the given hlo has been evaluated and cached.

--- a/xla/hlo/evaluator/hlo_evaluator_test.cc
+++ b/xla/hlo/evaluator/hlo_evaluator_test.cc
@@ -4470,6 +4470,31 @@ ENTRY main {
   EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
 }
 
+TEST_F(HloEvaluatorTest, Reduction2D) {
+  const std::string hlo_text = R"(
+HloModule Reduction2D
+
+add_f32 {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT add = f32[] add(lhs, rhs)
+}
+
+ENTRY main {
+  arg0 = f32[2,4] parameter(0)
+  init = f32[] constant(0)
+  ROOT %reduce = f32[2] reduce(arg0, init), dimensions={1}, to_apply=add_f32
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(m_, ParseAndReturnVerifiedModule(hlo_text));
+
+  Literal arg = LiteralUtil::CreateR2<float>(
+      {{1.0f, 3.0f, -2.0f, 42.0f}, {4.0f, 5.0f, 6.0f, 7.0f}});
+  Literal expected = LiteralUtil::CreateR1<float>({44.0f, 22.0f});
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Evaluate({&arg}));
+  EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
+}
+
 TEST_F(HloEvaluatorTest, DontFailOnCallUnimplementedOps) {
   // Outfeed triggers unimplemented error within HandleCall, and we verify that
   // the Evaluator does fail in such case.

--- a/xla/hlo/evaluator/hlo_evaluator_test.cc
+++ b/xla/hlo/evaluator/hlo_evaluator_test.cc
@@ -3322,9 +3322,9 @@ TEST_P(HloEvaluatorBf16Test, EvaluateWithSubstitutions) {
   // Evaluate again, with a different substitution. This verifies we don't
   // accidentally cache anything.
   Literal param0_literal2 = LiteralUtil::CreateR1<float>({5, 6, 7, 8});
-  TF_ASSERT_OK_AND_ASSIGN(Literal result2,
-                          evaluator.Evaluate(add, {}, true,
-                                             {{param0, &param0_literal2}}));
+  TF_ASSERT_OK_AND_ASSIGN(
+      Literal result2,
+      evaluator.Evaluate(add, {}, true, {{param0, &param0_literal2}}));
   EXPECT_TRUE(LiteralTestUtil::Equal(
       LiteralUtil::CreateR1<float>({30, 42, 56, 72}), result2));
 }
@@ -5026,7 +5026,6 @@ TEST_F(HloEvaluatorTest, AsyncOps) {
       Literal result, HloEvaluator().Evaluate(*m_->entry_computation(), {}));
   EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
 }
-
 
 TEST_F(HloEvaluatorTest, AsyncOpsWithLayout) {
   const absl::string_view hlo_text = R"(

--- a/xla/hlo/evaluator/hlo_evaluator_test.cc
+++ b/xla/hlo/evaluator/hlo_evaluator_test.cc
@@ -3318,6 +3318,15 @@ TEST_P(HloEvaluatorBf16Test, EvaluateWithSubstitutions) {
                                               {square, &square_literal}}));
   EXPECT_TRUE(LiteralTestUtil::Equal(
       LiteralUtil::CreateR1<float>({11, 22, 33, 44}), result));
+
+  // Evaluate again, with a different substitution. This verifies we don't
+  // accidentally cache anything.
+  Literal param0_literal2 = LiteralUtil::CreateR1<float>({5, 6, 7, 8});
+  TF_ASSERT_OK_AND_ASSIGN(Literal result2,
+                          evaluator.Evaluate(add, {}, true,
+                                             {{param0, &param0_literal2}}));
+  EXPECT_TRUE(LiteralTestUtil::Equal(
+      LiteralUtil::CreateR1<float>({30, 42, 56, 72}), result2));
 }
 
 TEST_F(HloEvaluatorTest, EvaluateWithSubstitutionsRecursive) {

--- a/xla/hlo/evaluator/hlo_evaluator_typed_visitor.h
+++ b/xla/hlo/evaluator/hlo_evaluator_typed_visitor.h
@@ -1119,8 +1119,8 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
 
     auto is_default_layout = [](const HloInstruction* op) {
       return !op->shape().has_layout() ||
-             !LayoutUtil::Equal(op->shape().layout(),
-                                LayoutUtil::GetDefaultLayoutForR2());
+             LayoutUtil::Equal(op->shape().layout(),
+                               LayoutUtil::GetDefaultLayoutForR2());
     };
 
     // The fast path is for a simple rank 2 dot with default layout operands.

--- a/xla/hlo/evaluator/hlo_evaluator_typed_visitor.h
+++ b/xla/hlo/evaluator/hlo_evaluator_typed_visitor.h
@@ -138,6 +138,18 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
         PrimitiveType_Name(instruction->shape().element_type()));
   }
 
+  // Returns `shape`, if it has a layout, or a copy of `shape` with the default
+  // layout if it doesn't. Some functions require shapes to have layouts, so we
+  // simply always set one.
+  Shape GetShapeWithLayout(const Shape& shape) {
+    CHECK(shape.IsArray());
+    Shape shape_copy = shape;
+    if (!shape.has_layout()) {
+      LayoutUtil::SetToDefaultLayout(&shape_copy);
+    }
+    return shape_copy;
+  }
+
  public:
   explicit HloEvaluatorTypedVisitor(HloEvaluator* p) : parent_(p) {}
 
@@ -813,7 +825,7 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
                                              const Literal& lhs_literal,
                                              const Literal& rhs_literal) {
     const auto& window = conv->window();
-    const Shape& result_shape = conv->shape();
+    Shape result_shape = GetShapeWithLayout(conv->shape());
     const Shape& lhs_shape = lhs_literal.shape();
     const Shape& rhs_shape = rhs_literal.shape();
 
@@ -1010,7 +1022,7 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
     auto lhs = conv->operand(0);
     auto rhs = conv->operand(1);
     const auto& window = conv->window();
-    const Shape& result_shape = conv->shape();
+    Shape result_shape = GetShapeWithLayout(conv->shape());
     const Shape& lhs_shape = lhs->shape();
     const Shape& rhs_shape = rhs->shape();
 
@@ -1105,15 +1117,16 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
         << " rhs contracted dimension: "
         << rhs->shape().dimensions(rhs_contracting_dimension);
 
+    auto is_default_layout = [](const HloInstruction* op) {
+      return !op->shape().has_layout() ||
+             !LayoutUtil::Equal(op->shape().layout(),
+                                LayoutUtil::GetDefaultLayoutForR2());
+    };
+
     // The fast path is for a simple rank 2 dot with default layout operands.
     if (lhs_rank != 2 || rhs_rank != 2 || lhs_contracting_dimension != 1 ||
-        rhs_contracting_dimension != 0 ||
-        !LayoutUtil::Equal(lhs->shape().layout(),
-                           LayoutUtil::GetDefaultLayoutForR2()) ||
-        !LayoutUtil::Equal(rhs->shape().layout(),
-                           LayoutUtil::GetDefaultLayoutForR2()) ||
-        !LayoutUtil::Equal(dot->shape().layout(),
-                           LayoutUtil::GetDefaultLayoutForR2())) {
+        rhs_contracting_dimension != 0 || !is_default_layout(lhs) ||
+        !is_default_layout(rhs) || !is_default_layout(dot)) {
       return HandleDotSlowPath(dot);
     }
 
@@ -1180,7 +1193,8 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
       contracting_dim_sizes.push_back(dim_size);
     }
     const int64_t total_contraction_size = Product(contracting_dim_sizes);
-    Literal result(dot->shape());
+    Shape dot_shape = GetShapeWithLayout(dot->shape());
+    Literal result(dot_shape);
     TF_RETURN_IF_ERROR(result.PopulateParallel<ReturnT>(
         [&](absl::Span<const int64_t> result_index, int /*thread_id*/) {
           // Locations in LHS and RHS that we read from.
@@ -1214,7 +1228,7 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
 
             if (parent_->trace_mac_handler_ != nullptr) {
               const int64_t result_linear_index =
-                  IndexUtil::MultidimensionalIndexToLinearIndex(dot->shape(),
+                  IndexUtil::MultidimensionalIndexToLinearIndex(dot_shape,
                                                                 result_index);
               const int64_t lhs_linear_index =
                   IndexUtil::MultidimensionalIndexToLinearIndex(
@@ -1314,7 +1328,7 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
     }
 
     // Create new HLO of padded shape with padding value.
-    Literal result(pad->shape());
+    Literal result(GetShapeWithLayout(pad->shape()));
     TF_RETURN_IF_ERROR(result.PopulateLinearParallel<ReturnT>(
         [&scalar](int64_t linear_index, int) { return scalar; }));
 
@@ -1550,9 +1564,10 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
     if constexpr (std::is_integral_v<ElementwiseT> ||
                   is_complex_v<ElementwiseT> ||
                   std::is_floating_point_v<ElementwiseT>) {
-      Literal result(iota->shape());
+      auto iota_shape = GetShapeWithLayout(iota->shape());
+      Literal result(iota_shape);
       ShapeUtil::ForEachIndexNoStatus(
-          iota->shape(), [&](absl::Span<const int64_t> idx) {
+          iota_shape, [&](absl::Span<const int64_t> idx) {
             result.Set(idx, static_cast<ReturnT>(idx[iota->iota_dimension()]));
             return true;
           });
@@ -1564,7 +1579,7 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
 
   absl::Status HandleRng(const HloInstruction* random) override {
     RandomDistribution distribution = random->random_distribution();
-    const Shape& result_shape = random->shape();
+    Shape result_shape = GetShapeWithLayout(random->shape());
     Literal result(result_shape);
 
     if constexpr (std::is_floating_point_v<ElementwiseT>) {
@@ -1684,7 +1699,7 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
                                         ElementwiseT>,
                   "Invalid BinaryOp signature");
 
-    const auto& shape = instruction->shape();
+    Shape shape = GetShapeWithLayout(instruction->shape());
     const auto* lhs = instruction->operand(0);
     const auto* rhs = instruction->operand(1);
     TF_RET_CHECK(ShapeUtil::SameDimensions(shape, rhs->shape()));
@@ -1727,7 +1742,7 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
         std::is_invocable_r_v<ReturnT, TernaryOp, LhsType, RhsType, EhsType>,
         "Invalid TernaryOp signature");
 
-    const auto& shape = instruction->shape();
+    Shape shape = GetShapeWithLayout(instruction->shape());
     const auto* lhs = instruction->operand(0);
     const auto* rhs = instruction->operand(1);
     const auto* ehs = instruction->operand(2);

--- a/xla/hlo/evaluator/hlo_evaluator_typed_visitor.h
+++ b/xla/hlo/evaluator/hlo_evaluator_typed_visitor.h
@@ -1023,8 +1023,8 @@ class HloEvaluatorTypedVisitor : public ConstDfsHloVisitorWithDefault {
     auto rhs = conv->operand(1);
     const auto& window = conv->window();
     Shape result_shape = GetShapeWithLayout(conv->shape());
-    const Shape& lhs_shape = lhs->shape();
-    const Shape& rhs_shape = rhs->shape();
+    Shape lhs_shape = GetShapeWithLayout(lhs->shape());
+    Shape rhs_shape = GetShapeWithLayout(rhs->shape());
 
     TF_CHECK_OK(ShapeUtil::ValidateShape(lhs_shape));
     TF_CHECK_OK(ShapeUtil::ValidateShape(rhs_shape));


### PR DESCRIPTION
There doesn't appear to be any good reason to do this, but it makes
HloEvaluator very dangerous to use - any use from a multi-threaded
context will eventually cause memory corruptions due to concurrent 
modifications of the HloModule. With this PR, it should be possible to
use multiple HloEvaluators concurrently.
