### PR TITLE
[ROCM] Fix run_hlo_module build on ROCm

### DIFF
--- a/xla/tools/BUILD
+++ b/xla/tools/BUILD
@@ -2,7 +2,11 @@
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "if_rocm",
+    "if_rocm_is_configured"
+)
 load("//xla:lit.bzl", "lit_test_suite")
 load(
     "//xla:xla.default.bzl",
@@ -536,6 +540,8 @@ xla_cc_binary(
         "//xla/service:gpu_plugin",
     ]) + if_cuda([
         "//xla/stream_executor:cuda_platform",
+    ]) + if_rocm([
+        "//xla/stream_executor:rocm_platform",
     ]),
 )
 


### PR DESCRIPTION
`run_hlo_module` depends on `rocm_platform` that implements BlasLt. Linking would fail with following complaint without explicitly specifying dependency.

undefined reference to 'stream_executor::rocm::BlasLt::Init()'
undefined reference to 'vtable for stream_executor::rocm::BlasLt'

@xla-rotation Would you help have a look?