### PR TITLE
Dumping non-default debug options in a new file under xla_dump_to

### DIFF
--- a/xla/service/dump.cc
+++ b/xla/service/dump.cc
@@ -753,12 +753,171 @@ std::vector<std::string> DumpHloModuleIfEnabled(const HloModule& module,
   return {};
 }
 
+std::string GetRepeatedValueAsString(
+    const tsl::protobuf::Reflection* reflection,
+    const DebugOptions& debug_options,
+    const tsl::protobuf::FieldDescriptor* field, int index) {
+  switch (field->type()) {
+    case tsl::protobuf::FieldDescriptor::TYPE_INT32:
+      return std::to_string(
+          reflection->GetRepeatedInt32(debug_options, field, index));
+    case tsl::protobuf::FieldDescriptor::TYPE_INT64:
+      return std::to_string(
+          reflection->GetRepeatedInt64(debug_options, field, index));
+    case tsl::protobuf::FieldDescriptor::TYPE_UINT32:
+      return std::to_string(
+          reflection->GetRepeatedUInt32(debug_options, field, index));
+    case tsl::protobuf::FieldDescriptor::TYPE_UINT64:
+      return std::to_string(
+          reflection->GetRepeatedUInt64(debug_options, field, index));
+    case tsl::protobuf::FieldDescriptor::TYPE_DOUBLE:
+      return std::to_string(
+          reflection->GetRepeatedDouble(debug_options, field, index));
+    case tsl::protobuf::FieldDescriptor::TYPE_FLOAT:
+      return std::to_string(
+          reflection->GetRepeatedFloat(debug_options, field, index));
+    case tsl::protobuf::FieldDescriptor::TYPE_BOOL:
+      return reflection->GetRepeatedBool(debug_options, field, index) ? "true"
+                                                                      : "false";
+    case tsl::protobuf::FieldDescriptor::TYPE_ENUM:
+      return reflection->GetRepeatedEnum(debug_options, field, index)->name();
+    case tsl::protobuf::FieldDescriptor::TYPE_STRING:
+      return reflection->GetRepeatedString(debug_options, field, index);
+    case tsl::protobuf::FieldDescriptor::TYPE_MESSAGE: {
+      tsl::protobuf::TextFormat::Printer tsl_printer;
+      tsl_printer.SetInitialIndentLevel(1);
+      std::string result;
+      tsl_printer.PrintToString(
+          reflection->GetRepeatedMessage(debug_options, field, index), &result);
+      return "{\n" + result + "}";
+    }
+    default:
+      return "Unsupported field type";
+  }
+}
+
+std::string GetValueAsString(const tsl::protobuf::Reflection* reflection,
+                             const DebugOptions& debug_options,
+                             const tsl::protobuf::FieldDescriptor* field) {
+  // Based on the field type, get the value and convert it to a string
+  switch (field->type()) {
+    case tsl::protobuf::FieldDescriptor::TYPE_INT32:
+      return std::to_string(reflection->GetInt32(debug_options, field));
+    case tsl::protobuf::FieldDescriptor::TYPE_INT64:
+      return std::to_string(reflection->GetInt64(debug_options, field));
+    case tsl::protobuf::FieldDescriptor::TYPE_UINT32:
+      return std::to_string(reflection->GetUInt32(debug_options, field));
+    case tsl::protobuf::FieldDescriptor::TYPE_UINT64:
+      return std::to_string(reflection->GetUInt64(debug_options, field));
+    case tsl::protobuf::FieldDescriptor::TYPE_DOUBLE:
+      return std::to_string(reflection->GetDouble(debug_options, field));
+    case tsl::protobuf::FieldDescriptor::TYPE_FLOAT:
+      return std::to_string(reflection->GetFloat(debug_options, field));
+    case tsl::protobuf::FieldDescriptor::TYPE_BOOL:
+      return reflection->GetBool(debug_options, field) ? "true" : "false";
+    case tsl::protobuf::FieldDescriptor::TYPE_ENUM:
+      return reflection->GetEnum(debug_options, field)->name();
+    case tsl::protobuf::FieldDescriptor::TYPE_STRING:
+      return "\"" + reflection->GetString(debug_options, field) + "\"";
+    case tsl::protobuf::FieldDescriptor::TYPE_MESSAGE: {
+      tsl::protobuf::TextFormat::Printer tsl_printer;
+      tsl_printer.SetSingleLineMode(false);
+      std::string result;
+      tsl_printer.PrintToString(reflection->GetMessage(debug_options, field),
+                                &result);
+      return "{\n" + result + "}";
+    }
+    default:
+      return "Unsupported field type";
+  }
+}
+
+std::string GetNonDefaultDebugOptions(const DebugOptions& debug_options) {
+  // Create a default DebugOptions to compare against
+  DebugOptions default_options = DefaultDebugOptionsIgnoringFlags();
+  std::string non_default_options;
+
+  // Use protobuf reflection to compare fields
+  const tsl::protobuf::Descriptor* descriptor = debug_options.GetDescriptor();
+  const tsl::protobuf::Reflection* reflection = debug_options.GetReflection();
+
+  // Iterate through all fields
+  for (int i = 0; i < descriptor->field_count(); i++) {
+    const tsl::protobuf::FieldDescriptor* field = descriptor->field(i);
+
+    if (field->is_repeated()) {
+      // Handle repeated fields by comparing the values
+      int repeated_count = reflection->FieldSize(debug_options, field);
+      int default_count = reflection->FieldSize(default_options, field);
+
+      // Only process if the repeated field has values
+      if (repeated_count > 0) {
+        std::vector<std::string> debug_values(repeated_count);
+        std::vector<std::string> default_values(default_count);
+
+        // Collect all values from debug_options
+        for (int j = 0; j < repeated_count; j++) {
+          debug_values[j] =
+              GetRepeatedValueAsString(reflection, debug_options, field, j);
+        }
+
+        // Collect all values from default_options
+        for (int j = 0; j < default_count; j++) {
+          default_values[j] =
+              GetRepeatedValueAsString(reflection, default_options, field, j);
+        }
+
+        // Sort both vectors for comparison
+        std::sort(debug_values.begin(), debug_values.end());
+        std::sort(default_values.begin(), default_values.end());
+
+        // Compare the sorted vectors
+        if (debug_values != default_values) {
+          // Values differ, append all debug values to output
+          for (const auto& value : debug_values) {
+            absl::StrAppend(&non_default_options, field->name(), ": ", value,
+                            "\n");
+          }
+        }
+      }
+      continue;
+    }
+
+    // Check if this field differs from default
+    if (reflection->HasField(debug_options, field) &&
+        !reflection->HasField(default_options, field)) {
+      // Field exists in debug_options but not defaults
+      absl::StrAppend(&non_default_options, field->name(), ": ",
+                      GetValueAsString(reflection, debug_options, field), "\n");
+    } else if (reflection->HasField(debug_options, field)) {
+      // Field exists in both, compare values
+      if (GetValueAsString(reflection, debug_options, field) !=
+          GetValueAsString(reflection, default_options, field)) {
+        absl::StrAppend(&non_default_options, field->name(), ": ",
+                        GetValueAsString(reflection, debug_options, field),
+                        "\n");
+      }
+    }
+  }
+
+  return non_default_options;
+}
+
+void DumpNonDefaultDebugOptions(const HloModule& module,
+                                absl::string_view suffix) {
+  const DebugOptions& debug_options = module.config().debug_options();
+  auto filename = FilenameFor(module, "", suffix);
+  auto nonDefaultDebugOptions = GetNonDefaultDebugOptions(debug_options);
+  DumpToFileInDir(debug_options, filename, nonDefaultDebugOptions);
+}
+
 std::vector<std::string> DumpHloModuleIfEnabled(
     const HloModule& module, const BufferAssignment& buffer_assn,
     string_view name) {
   CanonicalDebugOptions opts(module.config().debug_options());
   if (opts.should_dump_module(module.name())) {
     DumpHloModuleImpl(module, &buffer_assn, TimestampFor(module), name, opts);
+    DumpNonDefaultDebugOptions(module, kNonDefaultDebugOptionsDumpSuffix);
   }
   return {};
 }

--- a/xla/service/dump.h
+++ b/xla/service/dump.h
@@ -39,6 +39,7 @@ namespace xla {
 // performed on an HloModule.
 constexpr char kBeforeOptimizationsDumpName[] = "before_optimizations";
 constexpr char kAfterOptimizationsDumpName[] = "after_optimizations";
+constexpr char kNonDefaultDebugOptionsDumpSuffix[] = "debug_options";
 
 class BufferAssignment;
 class HloSnapshot;
@@ -198,6 +199,15 @@ absl::Status DumpProtoToDirectory(const tsl::protobuf::Message& message,
                                   std::string* full_path = nullptr);
 
 void DumpHloConfigIfEnabled(const HloModule& module);
+
+// Dumps the non-default debug options to a file in the xla_dump_to directory
+// specified by the module's DebugOptions.
+void DumpNonDefaultDebugOptions(const HloModule& module,
+                                absl::string_view suffix);
+
+// Returns the non-default debug options as a string. The default debug options
+// are received from DefaultDebugOptionsIgnoringFlags().
+std::string GetNonDefaultDebugOptions(const DebugOptions& debug_options);
 
 }  // namespace xla
 

--- a/xla/service/dump_test.cc
+++ b/xla/service/dump_test.cc
@@ -288,5 +288,126 @@ TEST(DumpTest, DumpHloUnoptimizedSnapshotProtoBinary) {
   EXPECT_EQ(hlo_snapshot_loaded.hlo_module().name(), module.name());
 }
 
+TEST(DumpTest, GetNonDefaultDebugOptions) {
+  DebugOptions options;
+  DebugOptions default_options = DefaultDebugOptionsIgnoringFlags();
+  std::string dump_folder = tsl::testing::TmpDir();
+
+  // String field
+  options.set_xla_dump_to(dump_folder);
+  // Int32 field
+  options.set_xla_gpu_dot_merger_threshold_mb(
+      default_options.xla_gpu_dot_merger_threshold_mb() + 100);
+  // Int64 field
+  options.set_xla_gpu_experimental_collective_cse_distance_threshold(
+      default_options.xla_gpu_experimental_collective_cse_distance_threshold() +
+      100);
+  // Bool field
+  options.set_xla_gpu_enable_nccl_user_buffers(
+      !default_options.xla_gpu_enable_nccl_user_buffers());
+  options.set_xla_enable_dumping(true);
+  // Enum field
+  options.clear_xla_gpu_enable_command_buffer();
+  options.add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
+  options.add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
+  // Message field
+  int gpus_per_node =
+      std::atoi(default_options.xla_gpu_analytical_latency_estimator_options()
+                    .at("gpus_per_node")
+                    .c_str());
+  int chunk_size_bytes =
+      std::atoi(default_options.xla_gpu_analytical_latency_estimator_options()
+                    .at("chunk_size_bytes")
+                    .c_str());
+  options.mutable_xla_gpu_analytical_latency_estimator_options()->insert(
+      {"gpus_per_node", std::to_string(gpus_per_node + 1)});
+  options.mutable_xla_gpu_analytical_latency_estimator_options()->insert(
+      {"chunk_size_bytes", std::to_string(chunk_size_bytes)});
+
+  auto non_default_options = GetNonDefaultDebugOptions(options);
+  EXPECT_THAT(non_default_options,
+              testing::HasSubstr("xla_dump_to: \"" + dump_folder + "\""));
+  EXPECT_THAT(
+      non_default_options,
+      testing::HasSubstr(
+          "xla_gpu_dot_merger_threshold_mb: " +
+          std::to_string(default_options.xla_gpu_dot_merger_threshold_mb() +
+                         100)));
+  EXPECT_THAT(
+      non_default_options,
+      testing::HasSubstr(
+          "xla_gpu_experimental_collective_cse_distance_threshold: " +
+          std::to_string(
+              default_options
+                  .xla_gpu_experimental_collective_cse_distance_threshold() +
+              100)));
+  EXPECT_THAT(non_default_options,
+              testing::HasSubstr("xla_gpu_enable_nccl_user_buffers: true"));
+  EXPECT_THAT(non_default_options,
+              testing::HasSubstr("xla_gpu_enable_command_buffer: CUBLAS"));
+  EXPECT_THAT(non_default_options,
+              testing::HasSubstr("xla_gpu_enable_command_buffer: FUSION"));
+  EXPECT_THAT(
+      non_default_options,
+      testing::HasSubstr("xla_gpu_analytical_latency_estimator_options: {\n"
+                         "  key: \"gpus_per_node\"\n"
+                         "  value: \"" +
+                         std::to_string(gpus_per_node + 1) +
+                         "\"\n"
+                         "}"));
+  EXPECT_THAT(
+      non_default_options,
+      testing::HasSubstr("xla_gpu_analytical_latency_estimator_options: {\n"
+                         "  key: \"chunk_size_bytes\"\n"
+                         "  value: \"" +
+                         std::to_string(chunk_size_bytes) +
+                         "\"\n"
+                         "}"));
+  tsl::protobuf::TextFormat::Parser parser;
+  DebugOptions parsed_options = DefaultDebugOptionsIgnoringFlags();
+  parser.ParseFromString(non_default_options, &parsed_options);
+  EXPECT_EQ(parsed_options.xla_dump_to(), dump_folder);
+  EXPECT_EQ(parsed_options.xla_gpu_dot_merger_threshold_mb(),
+            default_options.xla_gpu_dot_merger_threshold_mb() + 100);
+  EXPECT_EQ(
+      parsed_options.xla_gpu_experimental_collective_cse_distance_threshold(),
+      default_options.xla_gpu_experimental_collective_cse_distance_threshold() +
+          100);
+  EXPECT_EQ(parsed_options.xla_gpu_enable_nccl_user_buffers(),
+            !default_options.xla_gpu_enable_nccl_user_buffers());
+  EXPECT_EQ(parsed_options.xla_gpu_enable_command_buffer_size(), 2);
+  EXPECT_EQ(parsed_options.xla_gpu_enable_command_buffer(0),
+            DebugOptions::CUBLAS);
+  EXPECT_EQ(parsed_options.xla_gpu_enable_command_buffer(1),
+            DebugOptions::FUSION);
+  EXPECT_EQ(parsed_options.xla_gpu_analytical_latency_estimator_options().at(
+                "gpus_per_node"),
+            std::to_string(gpus_per_node + 1));
+  EXPECT_EQ(parsed_options.xla_gpu_analytical_latency_estimator_options().at(
+                "chunk_size_bytes"),
+            std::to_string(chunk_size_bytes));
+
+  HloModuleConfig config;
+  config.set_debug_options(options);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
+                          ParseAndReturnUnverifiedModule(R"(
+    HloModule test
+    ENTRY test {
+      p0 = s32[11] parameter(0)
+      c = s32[11] constant({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+      ROOT x = s32[11] multiply(p0, c)
+    }
+  )",
+                                                         config));
+  DumpNonDefaultDebugOptions(*m, kNonDefaultDebugOptionsDumpSuffix);
+  std::string real_contents;
+  TF_ASSERT_OK(tsl::ReadFileToString(
+      tsl::Env::Default(),
+      tsl::io::JoinPath(dump_folder,
+                        FilenameFor(*m, "", kNonDefaultDebugOptionsDumpSuffix)),
+      &real_contents));
+  EXPECT_THAT(real_contents, testing::Eq(non_default_options));
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
With this change, the non-default debug options are now dumped in the directory given by `--xla_dump_to` XLA_FLAGS. When dumping the non-default values, the default values are from
`DefaultDebugOptionsIgnoringFlags()`. The dump is in a protobuf parsable format. The file is emitted using the same format as other dumps with a `debug_options` suffix:
for example, `module_0001.test_module.debug_options`

`original debug options = DefaultDebugOptionsIgnoringFlags() + debug_options overwritten from file`