### PR TITLE
[ROCM] Ci fix mem leak in rocm dnn

### DIFF
--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -872,7 +872,7 @@ struct ScopedDescriptor {
   }
 
   ~ScopedDescriptor() {
-    if (handle_ != nullptr) return;
+    if (handle_ == nullptr) return;
 
     auto status = miDestroyObject(
         handle_);  // wrap::miopenDestroyTensorDescriptor(handle_);


### PR DESCRIPTION
Fix memory leak detected by asan. 
Early return on a wrong condition in destructor.