### PR TITLE
Treat arrays and tuples equally in Literal construction.

### DIFF
--- a/xla/literal.cc
+++ b/xla/literal.cc
@@ -257,9 +257,13 @@ void Literal::SetShape(const Shape& shape) {
     return;
   }
   auto owning_shape_ptr = std::make_unique<Shape>(shape);
-  if (owning_shape_ptr->IsArray() && !owning_shape_ptr->has_layout()) {
-    *owning_shape_ptr->mutable_layout() =
-        LayoutUtil::GetDefaultLayoutForShape(*owning_shape_ptr);
+  if (!LayoutUtil::HasLayout(*owning_shape_ptr)) {
+    ShapeUtil::ForEachMutableLeafShape(
+        owning_shape_ptr.get(), [](Shape* subshape, const ShapeIndex& index) {
+          if (!subshape->has_layout()) {
+            LayoutUtil::SetToDefaultLayout(subshape);
+          }
+        });
   }
   if (owning_shape_ptr->IsArray() &&
       LayoutUtil::HasCustomElementSizeInBits(*owning_shape_ptr)) {

--- a/xla/literal_test.cc
+++ b/xla/literal_test.cc
@@ -551,6 +551,27 @@ TEST_F(LiteralUtilTest, DifferentLayoutInEquality) {
   EXPECT_FALSE(colmajor.Equal(rowmajor, true));
 }
 
+TEST_F(LiteralUtilTest, CreateWithoutLayout) {
+  Shape default_layout_shape = ShapeUtil::MakeShape(F32, {2, 1});
+  Shape no_layout_shape = default_layout_shape;
+  no_layout_shape.clear_layout();
+  auto literal =
+      LiteralBase::CreateFromShapeWithUndeterminedLeafArrays(no_layout_shape);
+  // The default Layout should have been added back.
+  EXPECT_EQ(literal.shape(), default_layout_shape);
+}
+
+TEST_F(LiteralUtilTest, CreateWithoutLayout_Tuple) {
+  Shape default_layout_shape = ShapeUtil::MakeShape(F32, {2, 1});
+  Shape no_layout_shape = default_layout_shape;
+  no_layout_shape.clear_layout();
+  Shape literal_shape = ShapeUtil::MakeTupleShape({no_layout_shape});
+  auto literal =
+      LiteralBase::CreateFromShapeWithUndeterminedLeafArrays(literal_shape);
+  // The default Layout should have been added back.
+  EXPECT_EQ(literal.shape().tuple_shapes(0), default_layout_shape);
+}
+
 TEST_F(LiteralUtilTest, TupleEquality) {
   // Test equality with tuples.
   auto scalar = LiteralUtil::CreateR0<float>(1.0);


### PR DESCRIPTION
Currently, arrays without a layout are treated as having an implicit default layout (see the first added test, which passes at HEAD). For tuples, this does not apply, so it is possible to have Literals whose shape does not have a layout. After this change, Literals should always have a set layout.

This should hopefully make landing
https://github.com/openxla/xla/pull/24744/files easier. I'm sending this separately because the other PR affects a lot of tests that I have no access to. I'm guessing this change solves some of the issues we're seeing there.