### PR TITLE
[ROCm] fix kernel tiling test

### DIFF
--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -404,7 +404,7 @@ TEST_F(GpuKernelTilingTest, ReductionInputTooLarge) {
     EXPECT_THAT(status.message(),
                 ::testing::ContainsRegex(
                     "Kernel '.*' launch needs more blocks [(]2147483648, 1[)] "
-                    "than allowed by hardware [(]2147483647, 65535[)]"));
+                    "than allowed by hardware [(]2147483647, 65536[)]"));
   } else {
     EXPECT_THAT(status.message(),
                 ::testing::ContainsRegex(


### PR DESCRIPTION
In ROCm, the limit should be 65536.