### PR TITLE
[XLA][CPU] Ensure correct scale is used when there are multiple linear fusion ops

### DIFF
--- a/xla/service/cpu/onednn_config.proto
+++ b/xla/service/cpu/onednn_config.proto
@@ -55,7 +55,7 @@ message OneDnnFusionConfig {
   repeated FusionKind ops = 1;
   // To avoid protobuf failures for specific decimal values,
   // the original float value alpha is type-casted to int32.
-  int32 alpha_typecast = 2;
+  repeated int32 alpha_typecast = 2;
 }
 
 message OneDnnTensorLayoutProto {

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -938,7 +938,7 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
       fusions_config->add_ops(OneDnnFusionConfig::LINEAR);
       // Casting to int32 because of issues in proto config for decimal types
       // handling.
-      fusions_config->set_alpha_typecast(
+      fusions_config->add_alpha_typecast(
           *(reinterpret_cast<int32_t*>(&constant_value.value())));
       TF_RETURN_IF_ERROR(custom_call->set_backend_config(*backend_config));
       HloInstruction* new_instr;

--- a/xla/service/cpu/onednn_util.cc
+++ b/xla/service/cpu/onednn_util.cc
@@ -47,6 +47,7 @@ dnnl::post_ops PopulateOneDnnPostOps(
     FusedOperandsRef* fused_operands_ref, dnnl::memory::desc* bias_md) {
   dnnl::post_ops post_ops;
   int fused_operand_idx = 0;
+  int linear_scale_idx = 0;
   for (auto& fused_op : fusion_config->ops()) {
     switch (fused_op) {
       case OneDnnFusionConfig::RELU:
@@ -99,9 +100,10 @@ dnnl::post_ops PopulateOneDnnPostOps(
       case OneDnnFusionConfig::LINEAR: {
         float const_float;
         *(reinterpret_cast<int32_t*>(&const_float)) =
-            fusion_config->alpha_typecast();
+            fusion_config->alpha_typecast()[linear_scale_idx];
         post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, const_float,
                                 0.f);
+        linear_scale_idx++;
       } break;
       default:
         LOG(FATAL) << __FILE__ << ":" << __LINE__

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -1629,6 +1629,36 @@ TEST_F(MatmulTest, BroadcastedAddAfterFusion) {
   )");
 }
 
+TEST_F(MatmulTest, MulTanhMul) {
+  const char* matmul_module_str = R"(
+  ENTRY matmul.multanhmul.test.f32 {
+    arg.0 = f32[16,400,500] parameter(0)
+    arg.1 = f32[16,500,3] parameter(1)
+    dot.0 = f32[16,400,3] dot(arg.0, arg.1), lhs_batch_dims={0}, lhs_contracting_dims={2}, rhs_batch_dims={0}, rhs_contracting_dims={1}
+    constant.0 = f32[] constant(0.02)
+    broadcast.0 = f32[16,400,3] broadcast(constant.0), dimensions={}
+    multiply.0 = f32[16,400,3] multiply(dot.0, broadcast.0)
+    tanh.0 = f32[16,400,3] tanh(multiply.0)
+    constant.1 = f32[] constant(50)
+    broadcast.1 = f32[16,400,3] broadcast(constant.1), dimensions={}
+    ROOT multiply.1 = f32[16,400,3] multiply(tanh.0, broadcast.1)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec(1e-4, 1e-4)));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+  ; CHECK:     custom_call_target="__onednn$matmul",
+  ; CHECK:       backend_config={
+  ; CHECK-DAG:     "outer_dimension_partitions":[],
+  ; CHECK-DAG:     "onednn_matmul_config":{
+  ; CHECK-DAG:       "fusions":{
+  ; CHECK-DAG:         "ops":["LINEAR","TANH","LINEAR"]
+  ; CHECK-DAG:     }
+  ; CHECK-DAG:   }
+  ; CHECK:     }
+  )");
+}
+
 }  // namespace cpu
 }  // namespace xla
 


### PR DESCRIPTION
When a pattern like MM + Mul + Tanh + Mul, with two Mul ops and each has it's unique multiplier, we need to ensure the multiplier scales are applied crrectly.
Without this change, the 2nd scale factor was overwriting the first scale factor. Changes in this PR fix the issue.