### PR TITLE
[ROCm] Fix int4_test

### DIFF
--- a/third_party/llvm/slpvectorizer.patch
+++ b/third_party/llvm/slpvectorizer.patch
@@ -1,0 +1,21 @@
+diff --git a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+index d28210513556..3aa4e7de71d5 100644
+--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
++++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+@@ -21388,14 +21388,14 @@ public:
+         ReduxWidth =
+             getFloorFullVectorNumberOfElements(TTI, ScalarTy, ReduxWidth);
+         VectorType *Tp = getWidenedType(ScalarTy, ReduxWidth);
+-        NumParts = ::getNumberOfParts(TTI, Tp);
++        NumParts = TTI.getNumberOfParts(Tp);
+         NumRegs =
+             TTI.getNumberOfRegisters(TTI.getRegisterClassForType(true, Tp));
+         while (NumParts > NumRegs) {
+           assert(ReduxWidth > 0 && "ReduxWidth is unexpectedly 0.");
+           ReduxWidth = bit_floor(ReduxWidth - 1);
+           VectorType *Tp = getWidenedType(ScalarTy, ReduxWidth);
+-          NumParts = ::getNumberOfParts(TTI, Tp);
++          NumParts = TTI.getNumberOfParts(Tp);
+           NumRegs =
+               TTI.getNumberOfRegisters(TTI.getRegisterClassForType(true, Tp));
+         }

--- a/third_party/llvm/workspace.bzl
+++ b/third_party/llvm/workspace.bzl
@@ -22,6 +22,7 @@ def repo(name):
             "//third_party/llvm:mathextras.patch",
             "//third_party/llvm:toolchains.patch",
             "//third_party/llvm:zstd.patch",
+            "//third_party/llvm:slpvectorizer.patch",
         ],
         link_files = {"//third_party/llvm:run_lit.sh": "mlir/run_lit.sh"},
     )


### PR DESCRIPTION
Test started failing with https://github.com/llvm/llvm-project/pull/124774 
Log:
```
[ RUN      ] HloTestBase.TransposeDot
...
/root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/_tmp/2abb88b04f834ec5bb68543d8d7bed99/
int4_test_gpu_amd_any: external/llvm-project/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp:6335: llvm::SDValue llvm::SelectionDAG::getNode(unsigned int, const llvm::SDLoc&, llvm::EVT, llvm::SDValue, llvm::SDNodeFlags): Assertion `VT.isVector() == N1.getValueType().isVector() && "TRUNCATE result type type should be vector iff the operand " "type is vector!"' failed.
/root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/bazel-out/k8-dbg/bin/xla/tests/int4_test_gpu_amd_any.runfiles/xla/tools/ci_build/gpu_build/parallel_gpu_execute: line 74: 3336020 Aborted                 (core dumped) "$TEST_BINARY" $@
```
