### PR TITLE
Fix clang build error.

### DIFF
--- a/xla/runtime/execution_graph.cc
+++ b/xla/runtime/execution_graph.cc
@@ -243,7 +243,7 @@ int64_t ExecutionGraph::EraseEdge(NodeDefBuilder& from, NodeDefBuilder& to,
       in_edges_it != to.in_edges.end() && in_edges_it->id == from.id;
 
   DCHECK(has_in_edge) << "In-edge must exist if out-edge exists";
-  DCHECK_EQ(in_edges_it->kind, out_edges_it->kind) << "Edges kind must match";
+  DCHECK(in_edges_it->kind == out_edges_it->kind) << "Edges kind must match";
 
   // At this point we must have exactly one edge between `from` and `to` nodes.
   DCHECK_EQ(absl::c_count_if(from.out_edges, EdgePredicate(to.id)), 1)


### PR DESCRIPTION
Fix clang build error: 

external/xla/xla/tsl/platform/default/logging.h:329:9: error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'const xla::ExecutionGraph::NodeEdge::Kind')
  329 |   (*os) << v;
      |   ~~~~~ ^  ~
external/xla/xla/tsl/platform/default/logging.h:388:3: note: in instantiation of function template specialization 'tsl::internal::MakeCheckOpValueString<xla::ExecutionGraph::NodeEdge::Kind>' requested here
  388 |   MakeCheckOpValueString(comb.ForVar1(), v1);
      |   ^
external/xla/xla/tsl/platform/default/logging.h:417:1: note: in instantiation of function template specialization 'tsl::internal::MakeCheckOpString<xla::ExecutionGraph::NodeEdge::Kind, xla::ExecutionGraph::NodeEdge::Kind>' requested here
  417 | TF_DEFINE_CHECK_OP_IMPL(Check_EQ, ==)
      | ^
external/xla/xla/tsl/platform/default/logging.h:408:31: note: expanded from macro 'TF_DEFINE_CHECK_OP_IMPL'
  408 |       return ::tsl::internal::MakeCheckOpString(v1, v2, exprtext);  \
      |                               ^
external/xla/xla/runtime/execution_graph.cc:246:3: note: in instantiation of function template specialization 'tsl::internal::Check_EQImpl<xla::ExecutionGraph::NodeEdge::Kind, xla::ExecutionGraph::NodeEdge::Kind>' requested here
  246 |   DCHECK_EQ(in_edges_it->kind, out_edges_it->kind) << "Edges kind must match";