### PR TITLE
Fix dumping non-default debug options

### DIFF
--- a/xla/service/dump.cc
+++ b/xla/service/dump.cc
@@ -886,20 +886,10 @@ std::string GetNonDefaultDebugOptions(const DebugOptions& debug_options) {
       continue;
     }
 
-    // Check if this field differs from default
-    if (reflection->HasField(debug_options, field) &&
-        !reflection->HasField(default_options, field)) {
-      // Field exists in debug_options but not defaults
+    if (GetValueAsString(reflection, debug_options, field) !=
+        GetValueAsString(reflection, default_options, field)) {
       absl::StrAppend(&non_default_options, field->name(), ": ",
                       GetValueAsString(reflection, debug_options, field), "\n");
-    } else if (reflection->HasField(debug_options, field)) {
-      // Field exists in both, compare values
-      if (GetValueAsString(reflection, debug_options, field) !=
-          GetValueAsString(reflection, default_options, field)) {
-        absl::StrAppend(&non_default_options, field->name(), ": ",
-                        GetValueAsString(reflection, debug_options, field),
-                        "\n");
-      }
     }
   }
 

--- a/xla/service/dump_test.cc
+++ b/xla/service/dump_test.cc
@@ -311,6 +311,7 @@ TEST(DumpTest, GetNonDefaultDebugOptions) {
   options.set_xla_gpu_enable_nccl_user_buffers(
       !default_options.xla_gpu_enable_nccl_user_buffers());
   options.set_xla_enable_dumping(true);
+  options.set_xla_gpu_enable_shared_constants(false);
   // Enum field
   options.clear_xla_gpu_enable_command_buffer();
   options.add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
@@ -350,6 +351,8 @@ TEST(DumpTest, GetNonDefaultDebugOptions) {
               100)));
   EXPECT_THAT(non_default_options,
               testing::HasSubstr("xla_gpu_enable_nccl_user_buffers: true"));
+  EXPECT_THAT(non_default_options,
+              testing::HasSubstr("xla_gpu_enable_shared_constants: false"));
   EXPECT_THAT(non_default_options,
               testing::HasSubstr("xla_gpu_enable_command_buffer: CUBLAS"));
   EXPECT_THAT(non_default_options,


### PR DESCRIPTION
When the default value of a flag set in `xla/debug_options_flags.cc` is `true`, and the debug options set it to `false`, this option is not dumped. This patch fixes this issue.