### PR TITLE
Fix an error testcase in debug_options_parsers_test

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -2392,6 +2392,11 @@ static void AllocateFlags(DebugOptions* defaults) {
   ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", *flag_objects);
 }
 
+void ParseDebugOptionFlagsFromEnv() {
+  absl::call_once(flags_init, &AllocateFlags, nullptr);
+  ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", *flag_objects);
+}
+
 void AppendDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                              DebugOptions* debug_options) {
   absl::call_once(flags_init, &AllocateFlags, debug_options);

--- a/xla/debug_options_flags.h
+++ b/xla/debug_options_flags.h
@@ -38,6 +38,9 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
 void AppendDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                              DebugOptions* debug_options = nullptr);
 
+// Parses the debug option flags from XLA_FLAGS environment variable.
+void ParseDebugOptionFlagsFromEnv();
+
 // Fetches a DebugOptions proto message from flags provided to the program.
 // Flags must be registered with the flags parser using AppendDebugOptionsFlags
 // first.

--- a/xla/debug_options_parsers_test.cc
+++ b/xla/debug_options_parsers_test.cc
@@ -103,6 +103,7 @@ TEST(FuelTest, FuelPassCountsAreSeparate) {
   int* pargc;
   std::vector<char*>* pargv;
   ResetFlagsFromEnvForTesting("XLA_FLAGS", &pargc, &pargv);
+  ParseDebugOptionFlagsFromEnv();
 
   EXPECT_TRUE(ConsumeFuel("ABC"));
   EXPECT_FALSE(ConsumeFuel("ABC"));
@@ -114,16 +115,16 @@ TEST(FuelTest, FuelPassCountsAreSeparate) {
 
 TEST(FuelTest,
      PassFuelIsSetReturnsTrueOnExplicitlyFueledPassesAndFalseOtherwise) {
-  tsl::setenv("XLA_FLAGS", "--xla_fuel=ABC=1,PQR=2", /*overwrite=*/true);
+  tsl::setenv("XLA_FLAGS", "--xla_fuel=MNO=1,XYZ=2", /*overwrite=*/true);
   // Parse flags from the environment variable.
   int* pargc;
   std::vector<char*>* pargv;
   ResetFlagsFromEnvForTesting("XLA_FLAGS", &pargc, &pargv);
-
-  EXPECT_TRUE(PassFuelIsSet("ABC"));
-  EXPECT_FALSE(PassFuelIsSet("MNO"));
-  EXPECT_TRUE(PassFuelIsSet("PQR"));
-  EXPECT_FALSE(PassFuelIsSet("XYZ"));
+  ParseDebugOptionFlagsFromEnv();
+  EXPECT_FALSE(PassFuelIsSet("ABC"));
+  EXPECT_TRUE(PassFuelIsSet("MNO"));
+  EXPECT_FALSE(PassFuelIsSet("PQR"));
+  EXPECT_TRUE(PassFuelIsSet("XYZ"));
 }
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
The two tests are not independently parsing and testing like they seem to be. It is being parsed on the first call to PassFuelIsSet/ConsumeFuel (whichever executes first in random order of execution of tests). This then parses the XLA_FLAGS from the same test and in the other test, this is not parsed anymore. It seems to be passing because the second test uses the same XLA_FLAGS string. When this string is changed, the test starts failing.