### PR TITLE
Improve warning message for high execution overhead with sharded arrays

### DIFF
--- a/xla/hlo/transforms/host_offloader.cc
+++ b/xla/hlo/transforms/host_offloader.cc
@@ -264,8 +264,8 @@ absl::StatusOr<bool> HostOffloader::WalkDownHostMemoryOffloadPaths(
           "Found an instruction (\"%s\") which does device compute in host "
           "memory space. Converting into host compute. This is likely to have "
           "a very slow execution time. If you're using JAX, use device_put() "
-          "on the inputs to move the computation to the "
-          "accelerator.",
+          "to move the inputs to the device so that computation happens on the "
+          "device.",
           instruction->name());
       host_offload_utils::SetHostComputeFrontendAttribute(*instruction);
     }

--- a/xla/hlo/transforms/host_offloader.cc
+++ b/xla/hlo/transforms/host_offloader.cc
@@ -263,7 +263,9 @@ absl::StatusOr<bool> HostOffloader::WalkDownHostMemoryOffloadPaths(
       LOG(WARNING) << absl::StreamFormat(
           "Found an instruction (\"%s\") which does device compute in host "
           "memory space. Converting into host compute. This is likely to have "
-          "a very high overhead.",
+          "a very slow execution time. If you're using JAX, use device_put() "
+          "on the inputs to move the computation to the "
+          "accelerator.",
           instruction->name());
       host_offload_utils::SetHostComputeFrontendAttribute(*instruction);
     }

--- a/xla/hlo/transforms/host_offloader.cc
+++ b/xla/hlo/transforms/host_offloader.cc
@@ -922,33 +922,33 @@ absl::StatusOr<bool> UpdateMemorySpaceForHostOffloadedOutputs(
   HloInstruction* root = called_computation->root_instruction();
   Shape* root_shape = root->mutable_shape();
 
-  host_instrs_tree.ForEachMutableElement([&](ShapeIndex output_index,
-                                             std::vector<
-                                                 InstructionAndShapeIndex>*
-                                                 instruction_and_shape_indexes)
-                                             -> void {
-    for (InstructionAndShapeIndex& instr_and_shape :
-         *instruction_and_shape_indexes) {
-      // If instruction is MoveToHost, we will replace usage.
-      if (instr_and_shape.instruction->IsCustomCall(
-              memory_annotations::kMoveToHostCustomCallTarget)) {
-        to_replace.push_back(instr_and_shape);
-        continue;
-      }
+  host_instrs_tree.ForEachMutableElement(
+      [&](ShapeIndex output_index,
+          std::vector<InstructionAndShapeIndex>* instruction_and_shape_indexes)
+          -> void {
+        for (InstructionAndShapeIndex& instr_and_shape :
+             *instruction_and_shape_indexes) {
+          // If instruction is MoveToHost, we will replace usage.
+          if (instr_and_shape.instruction->IsCustomCall(
+                  memory_annotations::kMoveToHostCustomCallTarget)) {
+            to_replace.push_back(instr_and_shape);
+            continue;
+          }
 
-      SetMemorySpace(ShapeUtil::GetMutableSubshape(
-                         instr_and_shape.instruction->mutable_shape(),
-                         instr_and_shape.shape_index),
-                     Layout::kHostMemorySpace);
-    }
+          SetMemorySpace(ShapeUtil::GetMutableSubshape(
+                             instr_and_shape.instruction->mutable_shape(),
+                             instr_and_shape.shape_index),
+                         Layout::kHostMemorySpace);
+        }
 
-    if (!instruction_and_shape_indexes->empty()) {
-      // Update the memory space for the output of the computation call
-      // itself.
-      SetMemorySpace(ShapeUtil::GetMutableSubshape(root_shape, output_index),
-                     Layout::kHostMemorySpace);
-    }
-  });
+        if (!instruction_and_shape_indexes->empty()) {
+          // Update the memory space for the output of the computation call
+          // itself.
+          SetMemorySpace(
+              ShapeUtil::GetMutableSubshape(root_shape, output_index),
+              Layout::kHostMemorySpace);
+        }
+      });
   bool modified = false;
   // Remove MoveToHost usage.
   for (InstructionAndShapeIndex& instr_and_shape : to_replace) {


### PR DESCRIPTION
When performing computations on a JAX array that has sharding and  pinned_host memory kind, users may experience high execution overhead. Add guidance in the warning message to suggest using device_put() to transfer the array to the device for better performance.
