### PR TITLE
[ROCM] Increase memory limit for parallel test execution

### DIFF
--- a/build_tools/ci/parallel_gpu_execute.sh
+++ b/build_tools/ci/parallel_gpu_execute.sh
@@ -29,7 +29,7 @@ function is_absolute {
   [[ "$1" = /* ]] || [[ "$1" =~ ^[a-zA-Z]:[/\\].* ]]
 }
 
-export TF_PER_DEVICE_MEMORY_LIMIT_MB=${TF_PER_DEVICE_MEMORY_LIMIT_MB:-2048}
+export TF_PER_DEVICE_MEMORY_LIMIT_MB=${TF_PER_DEVICE_MEMORY_LIMIT_MB:-4096}
 
 # *******************************************************************
 #         This section of the script is needed to


### PR DESCRIPTION
This PR fixes this test in ROCM build:
//xla/tests:conv_depthwise_backprop_filter_test_gpu_amd_any
