### PR TITLE
Fix command buffer scheduling for async dynamic memcpy.

### DIFF
--- a/xla/service/gpu/transforms/command_buffer_scheduling.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling.cc
@@ -102,6 +102,42 @@ static bool IsNoOp(const HloInstruction* hlo) {
 // done operation is not part of the same command buffer, we would change the
 // execution semantics and create additional synchronization point.
 
+static bool IsAsyncStartOrDoneCommand(const HloInstruction* hlo,
+                                      const CommandBufferConfig& config) {
+  CHECK(hlo->opcode() == HloOpcode::kAsyncStart ||
+        hlo->opcode() == HloOpcode::kAsyncDone);
+
+  if (IsCublasGemm(*hlo->async_wrapped_instruction())) {
+    return config.enabled_commands.contains(DebugOptions::CUBLAS);
+  }
+
+  if (hlo->async_wrapped_opcode() == HloOpcode::kFusion) {
+    // We don't currently support dynamic memcpy fusions in command buffers.
+    if (IsDynamicMemcpyFusion(hlo->async_wrapped_instruction())) {
+      return false;
+    }
+
+    // We currently only support static address computations in command
+    // buffers.
+    if (IsDynamicSliceFusion(hlo->async_wrapped_instruction())) {
+      bool is_static_ds_fusion =
+          GetCustomFusionConfigName(hlo->async_wrapped_instruction()) ==
+          kDynamicSliceFusionWithStaticAddressComputationConfigName;
+      return is_static_ds_fusion && config.enabled_commands.contains(
+                                        DebugOptions::DYNAMIC_SLICE_FUSION);
+    }
+
+    return config.enabled_commands.contains(DebugOptions::FUSION);
+  }
+
+  if (hlo->async_wrapped_opcode() == HloOpcode::kReduceScatter ||
+      hlo->async_wrapped_opcode() == HloOpcode::kAllToAll) {
+    return config.enabled_commands.contains(DebugOptions::COLLECTIVES);
+  }
+
+  return false;
+}
+
 static bool IsAsyncStartCommand(const HloInstruction* hlo,
                                 const CommandBufferConfig& config) {
   if (HloPredicateIsOp<HloOpcode::kAllReduceStart, HloOpcode::kAllGatherStart>(
@@ -110,26 +146,7 @@ static bool IsAsyncStartCommand(const HloInstruction* hlo,
   }
 
   if (HloPredicateIsOp<HloOpcode::kAsyncStart>(hlo)) {
-    if (IsCublasGemm(*hlo->async_wrapped_instruction())) {
-      return config.enabled_commands.contains(DebugOptions::CUBLAS);
-    }
-    if (hlo->async_wrapped_opcode() == HloOpcode::kFusion) {
-      // We currently only support static address computations in command
-      // buffers.
-      if (IsDynamicSliceFusion(hlo->async_wrapped_instruction())) {
-        bool is_static_ds_fusion =
-            GetCustomFusionConfigName(hlo->async_wrapped_instruction()) ==
-            kDynamicSliceFusionWithStaticAddressComputationConfigName;
-        return is_static_ds_fusion && config.enabled_commands.contains(
-                                          DebugOptions::DYNAMIC_SLICE_FUSION);
-      } else {
-        return config.enabled_commands.contains(DebugOptions::FUSION);
-      }
-    }
-    if (hlo->async_wrapped_opcode() == HloOpcode::kReduceScatter ||
-        hlo->async_wrapped_opcode() == HloOpcode::kAllToAll) {
-      return config.enabled_commands.contains(DebugOptions::COLLECTIVES);
-    }
+    return IsAsyncStartOrDoneCommand(hlo, config);
   }
 
   if (HloPredicateIsOp<HloOpcode::kReduceScatter, HloOpcode::kAllToAll>(hlo)) {
@@ -147,26 +164,7 @@ static bool IsAsyncDoneCommand(const HloInstruction* hlo,
   }
 
   if (HloPredicateIsOp<HloOpcode::kAsyncDone>(hlo)) {
-    if (IsCublasGemm(*hlo->async_wrapped_instruction())) {
-      return config.enabled_commands.contains(DebugOptions::CUBLAS);
-    }
-    if (hlo->async_wrapped_opcode() == HloOpcode::kFusion) {
-      // We currently only support static address computations in command
-      // buffers.
-      if (IsDynamicSliceFusion(hlo->async_wrapped_instruction())) {
-        bool is_static_ds_fusion =
-            GetCustomFusionConfigName(hlo->async_wrapped_instruction()) ==
-            kDynamicSliceFusionWithStaticAddressComputationConfigName;
-        return is_static_ds_fusion && config.enabled_commands.contains(
-                                          DebugOptions::DYNAMIC_SLICE_FUSION);
-      } else {
-        return config.enabled_commands.contains(DebugOptions::FUSION);
-      }
-    }
-    if (hlo->async_wrapped_opcode() == HloOpcode::kReduceScatter ||
-        hlo->async_wrapped_opcode() == HloOpcode::kAllToAll) {
-      return config.enabled_commands.contains(DebugOptions::COLLECTIVES);
-    }
+    return IsAsyncStartOrDoneCommand(hlo, config);
   }
 
   return false;

--- a/xla/service/gpu/transforms/command_buffer_scheduling.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling.cc
@@ -102,8 +102,8 @@ static bool IsNoOp(const HloInstruction* hlo) {
 // done operation is not part of the same command buffer, we would change the
 // execution semantics and create additional synchronization point.
 
-static bool IsAsyncStartOrDoneCommand(const HloInstruction* hlo,
-                                      const CommandBufferConfig& config) {
+static bool AsyncStartOrDoneCommandIsSupported(
+    const HloInstruction* hlo, const CommandBufferConfig& config) {
   CHECK(hlo->opcode() == HloOpcode::kAsyncStart ||
         hlo->opcode() == HloOpcode::kAsyncDone);
 
@@ -146,7 +146,7 @@ static bool IsAsyncStartCommand(const HloInstruction* hlo,
   }
 
   if (HloPredicateIsOp<HloOpcode::kAsyncStart>(hlo)) {
-    return IsAsyncStartOrDoneCommand(hlo, config);
+    return AsyncStartOrDoneCommandIsSupported(hlo, config);
   }
 
   if (HloPredicateIsOp<HloOpcode::kReduceScatter, HloOpcode::kAllToAll>(hlo)) {
@@ -164,7 +164,7 @@ static bool IsAsyncDoneCommand(const HloInstruction* hlo,
   }
 
   if (HloPredicateIsOp<HloOpcode::kAsyncDone>(hlo)) {
-    return IsAsyncStartOrDoneCommand(hlo, config);
+    return AsyncStartOrDoneCommandIsSupported(hlo, config);
   }
 
   return false;

--- a/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
@@ -1205,6 +1205,36 @@ TEST_F(CommandBufferSchedulingTest, DynamicSliceFusionStaticSlicing) {
                                                 false, true, std::nullopt));
 }
 
+TEST_F(CommandBufferSchedulingTest, AsyncDynamicMemcpyFusion) {
+  // Regression test to verify that async memcpy fusions are not commands.
+  const char* hlo = R"(
+      HloModule m, is_scheduled=true
+
+      %fused_computation {
+        p0 = s32[64] parameter(0)
+        c32 = s32[] constant(32)
+        ROOT %slice = s32[32] dynamic-slice(p0, c32), dynamic_slice_sizes={32}
+      }
+
+      %async_computation {
+        p0 = s32[64] parameter(0)
+        ROOT fusion0 = s32[32] fusion(p0), kind=kLoop,
+          calls=%fused_computation,
+          backend_config={"fusion_backend_config":{"kind":"__dynamic_memcpy"}}
+      }
+
+      main {
+        p0 = s32[64] parameter(0)
+        async-start = ((s32[64]), s32[32]) async-start(p0),
+          calls=async_computation
+        ROOT async-done = s32[32] async-done(async-start)
+      })";
+
+  RunAndFilecheckHloRewrite(hlo, CommandBufferScheduling(device_desc()),
+                            std::nullopt /* no change expected*/);
+}
+
+
 TEST_F(CommandBufferSchedulingTest, ReturnFalseWhenNoChange) {
   const char* hlo = R"(
     HloModule module, is_scheduled=true

--- a/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling_test.cc
@@ -1234,7 +1234,6 @@ TEST_F(CommandBufferSchedulingTest, AsyncDynamicMemcpyFusion) {
                             std::nullopt /* no change expected*/);
 }
 
-
 TEST_F(CommandBufferSchedulingTest, ReturnFalseWhenNoChange) {
   const char* hlo = R"(
     HloModule module, is_scheduled=true


### PR DESCRIPTION
Sync dynamic memcpy fusions correctly prevent the creation of commands, but async ones currently do not. For some reason, there's quite a bit of code duplication around this, so I took the opportunity to clean up some of that. There's still some duplication wrt. sync/async, but the behavior is actually slightly different for some fusions. I'll send a followup once I know whether that's intentional or not, for now just fix the bug.