### PR TITLE
feat: add runtime_version field to target_config

### DIFF
--- a/xla/service/compiler.cc
+++ b/xla/service/compiler.cc
@@ -46,13 +46,25 @@ Compiler::TargetConfig::TargetConfig(const se::GpuTargetConfigProto& proto)
     : device_description({proto.gpu_device_info()}),
       platform_name(proto.platform_name()),
       dnn_version_info(proto.dnn_version_info()),
-      device_description_str(proto.device_description_str()) {}
+      device_description_str(proto.device_description_str()) {
+        se::SemanticVersion runtime_version(
+          proto.runtime_version().major(),
+          proto.runtime_version().minor(),
+          proto.runtime_version().patch()
+        );
+        device_description.set_runtime_version(runtime_version);
+      }
 
 se::GpuTargetConfigProto Compiler::TargetConfig::ToProto() const {
   stream_executor::GpuTargetConfigProto proto;
   *proto.mutable_gpu_device_info() = device_description.ToGpuProto();
   proto.set_platform_name(platform_name);
   *proto.mutable_dnn_version_info() = dnn_version_info.ToProto();
+  se::RuntimeVersionProto runtime_version_proto;  
+  runtime_version_proto.set_major(device_description.runtime_version().major());
+  runtime_version_proto.set_minor(device_description.runtime_version().minor());
+  runtime_version_proto.set_patch(device_description.runtime_version().patch());
+  *proto.mutable_runtime_version() = runtime_version_proto;
   proto.set_device_description_str(device_description_str);
   return proto;
 }

--- a/xla/service/compiler_test.cc
+++ b/xla/service/compiler_test.cc
@@ -38,13 +38,14 @@ TEST(TargetConfigTest, DISABLED_ON_CPU(ExecutorConstructorFillsAllFields)) {
   // We don't attempt to validate values because doing so would require talking
   // to the driver directly.
   EXPECT_GT(target.dnn_version_info().major(), 0) << target.DebugString();
+  EXPECT_GT(target.runtime_version().major(), 0) << target.DebugString();
   EXPECT_GT(target.gpu_device_info().threads_per_block_limit(), 0)
       << target.DebugString();
   EXPECT_NE(target.device_description_str(), "") << target.DebugString();
   EXPECT_NE(target.platform_name(), "") << target.DebugString();
   EXPECT_EQ(target.autotune_results().version(), 0);
 
-  EXPECT_EQ(5,
+  EXPECT_EQ(6,
             stream_executor::GpuTargetConfigProto::descriptor()->field_count())
       << "Make sure all the fields in GpuTargetConfigProto are set and "
          "validated!";
@@ -54,6 +55,7 @@ TEST(TargetConfigTest, ProtoConstructorFillsAllFields) {
   stream_executor::GpuTargetConfigProto config_proto;
   config_proto.set_platform_name("platform");
   config_proto.mutable_dnn_version_info()->set_major(2);
+  config_proto.mutable_runtime_version()->set_major(12);
   config_proto.mutable_gpu_device_info()->set_threads_per_block_limit(5);
   config_proto.set_device_description_str("foo");
 
@@ -63,13 +65,16 @@ TEST(TargetConfigTest, ProtoConstructorFillsAllFields) {
   EXPECT_EQ(target.dnn_version_info().major(),
             config_proto.dnn_version_info().major())
       << target.DebugString();
+  EXPECT_EQ(target.runtime_version().major(),
+            config_proto.runtime_version().major())
+      << target.DebugString();
   EXPECT_EQ(target.gpu_device_info().threads_per_block_limit(), 5)
       << target.DebugString();
   EXPECT_EQ(target.device_description_str(), "foo") << target.DebugString();
   EXPECT_EQ(target.platform_name(), "platform") << target.DebugString();
   EXPECT_EQ(target.autotune_results().version(), 0);
 
-  EXPECT_EQ(5,
+  EXPECT_EQ(6,
             stream_executor::GpuTargetConfigProto::descriptor()->field_count())
       << "Make sure all the fields in GpuTargetConfigProto are set and "
          "validated!";

--- a/xla/stream_executor/device_description.proto
+++ b/xla/stream_executor/device_description.proto
@@ -54,12 +54,19 @@ message DnnVersionInfoProto {
   int32 patch = 3;
 }
 
+message RuntimeVersionProto {
+  int32 major = 1;
+  int32 minor = 2;
+  int32 patch = 3;
+}
+
 message GpuTargetConfigProto {
   GpuDeviceInfoProto gpu_device_info = 1;
   reserved 2, 3;
   reserved "cuda_compute_capability", "rocm_compute_capability";
   string platform_name = 4;
   DnnVersionInfoProto dnn_version_info = 5;
+  RuntimeVersionProto runtime_version = 8;
 
   // TODO(b/248362914): Autotuning results should be separate from
   // GpuTargetConfig because autotuning can be updated regularly separate from


### PR DESCRIPTION
This CL add the runtime_version to the target config so that it can be configured when doing AOT compilation without any device.
This fixes: #25910 , I just had to add the runtime_version to my target_config so the scripts is now
```
import os

import flax
import flax.linen
import flax.linen as nn
from flax.linen import fp8_ops

import jax
import jax.experimental
import jax.experimental.serialize_executable
import jax.numpy as jnp
from jax.experimental import topologies

h100_gpu_target_config = """
gpu_device_info {
  threads_per_block_limit: 1024
  threads_per_warp: 32
  shared_memory_per_block: 49152
  shared_memory_per_core: 233472
  threads_per_core_limit: 2048
  core_count: 132
  fpus_per_core: 128
  block_dim_limit_x: 2147483647
  block_dim_limit_y: 65535
  block_dim_limit_z: 65535
  memory_bandwidth: 3352320000000
  l2_cache_size: 52428800
  clock_rate_ghz: 1.98
  device_memory_size: 84929347584
  shared_memory_per_block_optin: 232448
  cuda_compute_capability {
    major: 9
  }
  registers_per_core_limit: 65536
  registers_per_block_limit: 65536
}
platform_name: "CUDA"
dnn_version_info {
  major: 9
  minor: 7
}
runtime_version {
  major: 12
  minor: 8
  patch: 0
}
device_description_str: "NVIDIA H100 80GB HBM3"
"""

# Fake not having a GPU on my machine
os.environ["XLA_FLAGS"] = " ".join([
  "--xla_gpu_enable_triton_gemm=false",
  "--xla_dump_to=./dump",
  "--xla_dump_hlo_as_text=true",
])
# os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
os.environ["TF_CPP_VMODULE"] = "gemm_rewriter=10"
# os.environ["TF_CPP_VMODULE"] = "cuda_executor=10,"

topology = topologies.get_topology_desc(
  platform="cuda",
  target_config=h100_gpu_target_config,
  topology="1x1x1",
)


model = nn.Dense(
  1024,
  dot_general_cls=fp8_ops.Fp8DirectDotGeneralOp
)

@jax.jit
def fn(params, x):
    return model.apply(params, x)

mesh = topologies.make_mesh(
  topology,
  (1,),
  ("devices",),
)
replicated_sharding = jax.sharding.NamedSharding(
  mesh,
  jax.sharding.PartitionSpec(
    "devices",
  ),
)
x = jax.ShapeDtypeStruct(
  (16, 2048, 1028),
  jnp.float32,
  sharding=replicated_sharding,
)
params = jax.eval_shape(
  model.init,
  jax.ShapeDtypeStruct((2,), jnp.uint32),
  x
)

inputs = [
  params, x
]

lowered = fn.lower(*inputs)  # <- fail here
compiled = lowered.compile()
print(compiled)
seriazied, in_tree, out_tree = jax.experimental.serialize_executable.serialize(compiled)
```