### PR TITLE
[XLA:FFI][BugFix] Add Token Args and Rets for typed FFI on CPU backend

### DIFF
--- a/xla/service/cpu/ir_emitter.cc
+++ b/xla/service/cpu/ir_emitter.cc
@@ -2847,7 +2847,7 @@ absl::Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
       // Emit nested tuples as flat buffer pointers
       TF_RETURN_IF_ERROR(ShapeUtil::ForEachSubshapeWithStatus(
           operand->shape(), [&](const Shape& shape, const ShapeIndex& index) {
-            if (!shape.IsArray()) {
+            if (!shape.IsArray() && !shape.IsToken()) {
               return absl::OkStatus();
             }
             TF_ASSIGN_OR_RETURN(BufferAllocation::Slice slice,
@@ -2931,7 +2931,7 @@ absl::Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
       TF_RETURN_IF_ERROR(ShapeUtil::ForEachSubshapeWithStatus(
           custom_call->shape(),
           [&](const Shape& shape, const ShapeIndex& index) {
-            if (!shape.IsArray()) {
+            if (!shape.IsArray() && !shape.IsToken()) {
               return absl::OkStatus();
             }
             TF_ASSIGN_OR_RETURN(BufferAllocation::Slice slice,

--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -152,6 +152,28 @@ xla_cc_test(
 )
 
 xla_cc_test(
+    name = "cpu_ffi_test",
+    srcs = ["cpu_ffi_test.cc"],
+    deps = [
+        "//xla:debug_options_flags",
+        "//xla:shape_util",
+        "//xla:status_macros",
+        "//xla/ffi",
+        "//xla/ffi:execution_context",
+        "//xla/ffi:ffi_api",
+        "//xla/hlo/builder:xla_builder",
+        "//xla/pjrt/interpreter:interpreter_client",
+        "//xla/service:hlo_runner_pjrt",
+        "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
+        "//xla/tests:hlo_pjrt_test_base",
+        "//xla/tests:pjrt_cpu_client_registry",
+        "//xla/tests:test_macros_cpu",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/lib/core:status_test_util",
+    ],
+)
+
+xla_cc_test(
     name = "cpu_intrinsic_test",
     srcs = ["cpu_intrinsic_test.cc"],
     deps = [

--- a/xla/service/cpu/tests/cpu_ffi_test.cc
+++ b/xla/service/cpu/tests/cpu_ffi_test.cc
@@ -1,0 +1,84 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "absl/status/status.h"
+#include "xla/ffi/execution_context.h"
+#include "xla/ffi/ffi.h"
+#include "xla/ffi/ffi_api.h"
+#include "xla/hlo/builder/xla_builder.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_pjrt_test_base.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+
+namespace xla {
+namespace {
+
+static absl::Status HostIOCallback(ffi::Token, ffi::Result<ffi::Token>,
+                                   ffi::Result<ffi::AnyBuffer>) {
+  return absl::OkStatus();
+}
+
+XLA_FFI_DEFINE_HANDLER(
+    kIOCallback, HostIOCallback,
+    ffi::Ffi::Bind().Arg<ffi::Token>().Ret<ffi::Token>().Ret<ffi::AnyBuffer>());
+
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "__xla_test$$io_callback", "Host",
+                         kIOCallback);
+
+class CpuFFITest : public HloPjRtTestBase,
+                   public ::testing::WithParamInterface<bool> {
+ protected:
+  bool thunk_rt_val_;
+
+  CpuFFITest() { thunk_rt_val_ = GetParam(); }
+
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions debug_options = GetDebugOptionsFromFlags();
+    debug_options.set_xla_cpu_use_thunk_runtime(thunk_rt_val_);
+    return debug_options;
+  }
+};
+
+TEST_P(CpuFFITest, EmulateImpureCallbackWithTokens) {
+  auto module = CreateNewVerifiedModule();
+  auto builder = HloComputation::Builder(TestName());
+
+  HloInstruction* p0 = builder.AddInstruction(HloInstruction::CreateToken());
+  auto instr = Cast<HloCustomCallInstruction>(
+      builder.AddInstruction(HloInstruction::CreateCustomCall(
+          ShapeUtil::MakeTupleShape(
+              {ShapeUtil::MakeTokenShape(), ShapeUtil::MakeShape(S32, {})}),
+          {p0}, "__xla_test$$io_callback", "",
+          CustomCallApiVersion::API_VERSION_TYPED_FFI)));
+
+  instr->set_custom_call_has_side_effect(true);
+  module->AddEntryComputation(builder.Build());
+
+  TF_EXPECT_OK(Execute(std::move(module), {}).status());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    FFITest, CpuFFITest, ::testing::Values(true, false),
+    [](const ::testing::TestParamInfo<CpuFFITest::ParamType>& info) {
+      return info.param ? "ThunkRuntime" : "LegacyRuntime";
+    });
+
+}  // namespace
+}  // namespace xla


### PR DESCRIPTION
This PR adds support for token args and rets in the typed FFI for legacy (non-thunk) runtime. It also adds code to initialize the handler execution state when an instantiation callback is provided. These changes resolve crashes occurring in certain custom calls that use the typed FFI API. 