### PR TITLE
[NVIDIA GPU] Fix fabric info test

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1165,7 +1165,7 @@ TEST(StreamExecutorGpuClientTest, GetDeviceFabricInfo) {
                   &executor->GetDeviceDescription())) == 9) {
             auto fabric_info = GetDeviceFabricInfo(executor->device_ordinal());
             if (fabric_info.ok()) {
-              ADD_FAILURE();
+              CHECK_EQ(*fabric_info, "00000000-0000-0000-0000-000000000000/0");
             }
           }
         }


### PR DESCRIPTION
https://github.com/openxla/xla/pull/24142 was merged, reverted, and re-landed. The test somehow diverged from [the original logic](https://github.com/openxla/xla/pull/24142/files#diff-ce4a6f9e304d9bac11e6cacffa07b57f584ad705009e41aded11b4146ae536fdR1155) and failed on H100. Fixing it here.