### PR TITLE
[NVIDIA GPU] Change UB register cache to include size in the key

### DIFF
--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -340,18 +340,17 @@ absl::Status RegisterBufferOnce(GpuCollectives* collectives,
           {executor->device_ordinal(), buffer.size(), comm, buffer.opaque()})) {
     // ncclCommRegister will internally get and use the base address/size of the
     // address we provide.
-    LOG(INFO) << "Registering " << buffer.opaque()
-              << " with size: " << buffer.size()
-              << " and base pointer: " << base_buffer.opaque();
+    VLOG(5) << "Registering " << buffer.opaque()
+            << " with size: " << buffer.size()
+            << " and base pointer: " << base_buffer.opaque();
     TF_ASSIGN_OR_RETURN(auto handle, comm->RegisterBuffer(buffer));
     all_registered.handles.push_back(std::move(handle));
     all_registered.records.insert(
         {executor->device_ordinal(), buffer.size(), comm, buffer.opaque()});
   } else {
-    LOG(INFO) << "Buffer: " << buffer.opaque()
-              << " with size: " << buffer.size()
-              << " and base pointer: " << base_buffer.opaque()
-              << " is already registered.";
+    VLOG(5) << "Buffer: " << buffer.opaque() << " with size: " << buffer.size()
+            << " and base pointer: " << base_buffer.opaque()
+            << " is already registered.";
   }
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -321,7 +321,7 @@ absl::Status RegisterBufferOnce(GpuCollectives* collectives,
   struct RegisteredBuffers {
     absl::Mutex mu;
     // Device ordinal, communicator, and base pointer address.
-    absl::flat_hash_set<std::tuple<int, Communicator*, void*>> records
+    absl::flat_hash_set<std::tuple<int, uint64_t, Communicator*, void*>> records
         ABSL_GUARDED_BY(mu);
     // Buffers could be deregistered with ncclCommDeregister.
     std::vector<std::unique_ptr<Communicator::RegisteredBufferHandle>> handles
@@ -337,13 +337,21 @@ absl::Status RegisterBufferOnce(GpuCollectives* collectives,
 
   absl::MutexLock lock(&all_registered.mu);
   if (!all_registered.records.contains(
-          {executor->device_ordinal(), comm, base_buffer.opaque()})) {
+          {executor->device_ordinal(), buffer.size(), comm, buffer.opaque()})) {
     // ncclCommRegister will internally get and use the base address/size of the
     // address we provide.
+    LOG(INFO) << "Registering " << buffer.opaque()
+              << " with size: " << buffer.size()
+              << " and base pointer: " << base_buffer.opaque();
     TF_ASSIGN_OR_RETURN(auto handle, comm->RegisterBuffer(buffer));
     all_registered.handles.push_back(std::move(handle));
     all_registered.records.insert(
-        {executor->device_ordinal(), comm, base_buffer.opaque()});
+        {executor->device_ordinal(), buffer.size(), comm, buffer.opaque()});
+  } else {
+    LOG(INFO) << "Buffer: " << buffer.opaque()
+              << " with size: " << buffer.size()
+              << " and base pointer: " << base_buffer.opaque()
+              << " is already registered.";
   }
   return absl::OkStatus();
 }


### PR DESCRIPTION
UB registration requires the exact pointer and size. The current cache doesn't use size as part of the key which causes NCCL to skip registration for some buffers.