### PR TITLE
Convert computations to MakeNonfusionComputations in async wrappers

### DIFF
--- a/xla/service/gpu/transforms/explicit_collectives_group_async_wrapper.cc
+++ b/xla/service/gpu/transforms/explicit_collectives_group_async_wrapper.cc
@@ -73,7 +73,8 @@ absl::StatusOr<bool> ExplicitCollectivesGroupAsyncWrapper::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
-  for (const HloComputation* comp : module->computations()) {
+  for (const HloComputation* comp :
+       module->MakeNonfusionComputations(execution_threads)) {
     for (HloInstruction* instr : comp->instructions()) {
       TF_ASSIGN_OR_RETURN(bool result, CreateCollectivesGroupAsyncPair(instr));
       changed |= result;

--- a/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.cc
+++ b/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.cc
@@ -80,7 +80,8 @@ absl::StatusOr<bool> ExplicitStreamAnnotationAsyncWrapper::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
-  for (const HloComputation* comp : module->computations()) {
+  for (const HloComputation* comp :
+       module->MakeNonfusionComputations(execution_threads)) {
     for (HloInstruction* instr : comp->instructions()) {
       TF_ASSIGN_OR_RETURN(bool result, AsynchronizeInstruction(instr));
       changed |= result;


### PR DESCRIPTION
Using `module->computations` was never safe to use when adding new subcomputations (which is required when creating `AsyncStart` instructions), as that method would return a view to the `HloComputation`s, which is not memory safe and could occasionally cause segfaults.  


This change brings it inline with other similar passes. 

Example:
https://github.com/openxla/xla/blob/df11db787a1836f65f277d249f75425a7948a380/xla/service/gpu/transforms/stream_attribute_async_wrapper.cc#L64

See the description of `MakeNonfusionComputations` https://github.com/openxla/xla/blob/7f82d14ffbfdd1e344d1945b62ec91f0c3dff654/xla/hlo/ir/hlo_module.h#L354
