### PR TITLE
Generalize dynamic memcpy support.

### DIFF
--- a/xla/backends/gpu/codegen/copy.cc
+++ b/xla/backends/gpu/codegen/copy.cc
@@ -150,27 +150,6 @@ bool IsZeroOffset(const HloInstruction* slice, int dim) {
   return GetSliceSize(slice, dim) == slice->operand(0)->shape().dimensions(dim);
 }
 
-std::vector<const HloInstruction*> GetCallStack(
-    const HloInstruction& instruction) {
-  const HloInstruction* current = &instruction;
-  std::vector<const HloInstruction*> stack;
-  while (current) {
-    stack.push_back(current);
-
-    auto callers = current->parent()->caller_instructions();
-    if (callers.size() == 1) {
-      current = callers[0];
-    } else {
-      // Failed to determine a unique caller, so we stop here. The rest of the
-      // call stack (if there is one, we can also be in the entry computation)
-      // will be missing.
-      current = nullptr;
-    }
-  }
-  std::reverse(stack.begin(), stack.end());
-  return stack;
-}
-
 int GetFirstOffsetOperandIndex(const HloInstruction* slice) {
   // dynamic-slice takes the full array, then the offsets.
   // dynamic-update-slice takes the full array, then the update slice, then the
@@ -211,16 +190,6 @@ bool DynamicMemcpyFusion::IsCandidateFusion(
     }
   }
 
-  int rank = root->operand(0)->shape().dimensions().size();
-  for (int i = 0; i < rank; ++i) {
-    auto* operand = root->operand(i + first_offset_index);
-    if (!IsZeroOffset(root, i) && operand->opcode() != HloOpcode::kConstant &&
-        operand->opcode() != HloOpcode::kParameter) {
-      VLOG(5) << "Dimension " << i << " is not a constant or a parameter.";
-      return false;
-    }
-  }
-
   // This might be a dynamic memcpy fusion. We need to actually analyze the data
   // dependencies of the parameters to know for sure.
   return true;
@@ -243,7 +212,6 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
 
   int first_offset_index = GetFirstOffsetOperandIndex(slice);
   int rank = slice_input_shape.dimensions().size();
-  auto stack = GetCallStack(fusion);
 
   VLOG(5) << "Preconditions passed, trying to build a memcpy descriptor.";
   DynamicMemcpyThunk::MemcpyDescriptor descriptor;
@@ -279,7 +247,7 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
     }
 
     auto functional_dependency =
-        ResolveFunctionalDependencyOnInductionVariable(stack, operand);
+        ResolveFunctionalDependencyOnInductionVariable(operand);
     if (!functional_dependency) {
       VLOG(5) << "Offset for dimension " << i << " is not statically known.";
       return std::nullopt;
@@ -297,7 +265,9 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
 
     VLOG(5) << "Offset for dimension " << i << " is dynamic.";
     dynamic_offsets.emplace_back() = {
-        functional_dependency->loop, functional_dependency->induction_var,
+        functional_dependency->loop,
+        functional_dependency->induction_var,
+        std::move(functional_dependency->required_parameters),
         functional_dependency->derived_value,
         /*dimension_size=*/slice_input_shape.dimensions(i),
         /*byte_stride=*/(*strides)[i]};

--- a/xla/backends/gpu/codegen/copy.cc
+++ b/xla/backends/gpu/codegen/copy.cc
@@ -268,7 +268,7 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
         functional_dependency->loop,
         functional_dependency->induction_var,
         std::move(functional_dependency->required_parameters),
-        functional_dependency->derived_value,
+        operand,
         /*dimension_size=*/slice_input_shape.dimensions(i),
         /*byte_stride=*/(*strides)[i]};
   }

--- a/xla/backends/gpu/codegen/copy_test.cc
+++ b/xla/backends/gpu/codegen/copy_test.cc
@@ -52,27 +52,6 @@ TEST_F(CopyFusionTest, ValidCandidate) {
   EXPECT_TRUE(DynamicMemcpyFusion::IsCandidateFusion(GetFusion(module.get())));
 }
 
-TEST_F(CopyFusionTest, InvalidCandidateNonParameterOffset) {
-  auto module = ParseAndReturnVerifiedModule(R"(
-    dynamic_slice {
-      p0 = f32[100] parameter(0)
-      p1 = s32[] parameter(1)
-      c1 = s32[] constant(1)
-      sum = s32[] add(p1, c1)
-      ROOT slice = f32[10] dynamic-slice(p0, sum), dynamic_slice_sizes={10}
-    }
-
-    ENTRY main {
-      p0 = f32[100] parameter(0)
-      p1 = s32[] parameter(1)
-      ROOT fusion = f32[10] fusion(p0, p1), kind=kLoop, calls=dynamic_slice
-    }
-  )")
-                    .value();
-
-  EXPECT_FALSE(DynamicMemcpyFusion::IsCandidateFusion(GetFusion(module.get())));
-}
-
 TEST_F(CopyFusionTest, ValidCandidateClamped) {
   auto module = ParseAndReturnVerifiedModule(R"(
     dynamic_slice {
@@ -288,7 +267,7 @@ TEST_F(CopyFusionTest, BuildUpdateSliceDescriptor) {
   EXPECT_EQ(descriptor->dst_byte_static_offset, 32);
   EXPECT_EQ(offset.while_loop->name(), "while");
   EXPECT_EQ(offset.induction_variable->name(), "ivar");
-  EXPECT_EQ(offset.offset->name(), "ivar");
+  EXPECT_EQ(offset.offset->name(), "p2");
   EXPECT_EQ(offset.dimension_size, 4);
   EXPECT_EQ(offset.byte_stride, 8 * 8 * sizeof(float));
 }

--- a/xla/backends/gpu/codegen/copy_test.cc
+++ b/xla/backends/gpu/codegen/copy_test.cc
@@ -146,7 +146,7 @@ TEST_F(CopyFusionTest, ClampedConstantNegative) {
 
 constexpr char kSliceMemcpyModule[] = R"(
     dynamic_slice {
-      p0 = s32[4,8,8] parameter(0)
+      p0 = s32[4,8,8,8] parameter(0)
       p1 = s32[] parameter(1)
       c1 = s32[] constant(1)
       p2 = s32[] parameter(2)
@@ -154,14 +154,16 @@ constexpr char kSliceMemcpyModule[] = R"(
       // Test all supported kinds of offsets: derived from the while loop's
       // induction variable (p1), constant (c1) and always clamped to 0, so
       // the value is irrelevant (p2).
-      ROOT slice = s32[1,1,8] dynamic-slice(p0, p1, c1, p2),
-          dynamic_slice_sizes={1,1,8}
+      // Also test an offset that is computed inside the fusion (o3).
+      o3 = s32[] add(p1, c1)
+      ROOT slice = s32[1,1,1,8] dynamic-slice(p0, p1, c1, o3, p2),
+          dynamic_slice_sizes={1,1,1,8}
     }
 
     body {
-      p0 = (s32[], s32[4,8,8], s32[1,1,8], s32[]) parameter(0)
+      p0 = (s32[], s32[4,8,8,8], s32[1,1,1,8], s32[]) parameter(0)
       ivar = s32[] get-tuple-element(p0), index=0
-      input = s32[4,8,8] get-tuple-element(p0), index=1
+      input = s32[4,8,8,8] get-tuple-element(p0), index=1
 
       c1 = s32[] constant(1)
       c5 = s32[] constant(5)
@@ -169,28 +171,28 @@ constexpr char kSliceMemcpyModule[] = R"(
       offset1 = s32[] remainder(ivar, c5)
       offset2 = s32[] get-tuple-element(p0), index=3
 
-      slice = s32[1,1,8] fusion(input, offset1, offset2), kind=kLoop, calls=dynamic_slice,
+      slice = s32[1,1,1,8] fusion(input, offset1, offset2), kind=kLoop, calls=dynamic_slice,
           backend_config={"fusion_backend_config":{"kind":"__dynamic_memcpy"}}
       next_ivar = s32[] add(ivar, c1)
 
-      ROOT result = (s32[], s32[4,8,8], s32[1,1,8], s32[])
+      ROOT result = (s32[], s32[4,8,8,8], s32[1,1,1,8], s32[])
           tuple(next_ivar, input, slice, offset2)
     }
 
     condition {
-      p0 = (s32[], s32[4,8,8], s32[1,1,8], s32[]) parameter(0)
+      p0 = (s32[], s32[4,8,8,8], s32[1,1,1,8], s32[]) parameter(0)
       ivar = s32[] get-tuple-element(p0), index=0
       c6 = s32[] constant(6)
       ROOT cmp = pred[] compare(ivar, c6), direction=LT
     }
 
     ENTRY main {
-      input = s32[4,8,8] parameter(0)
-      init_acc = s32[1,1,8] parameter(1)
+      input = s32[4,8,8,8] parameter(0)
+      init_acc = s32[1,1,1,8] parameter(1)
       c0 = s32[] constant(0)
       c1 = s32[] constant(1)
-      tuple = (s32[], s32[4,8,8], s32[1,1,8], s32[]) tuple(c0, input, init_acc, c1)
-      ROOT while = (s32[], s32[4,8,8], s32[1,1,8], s32[]) while(tuple),
+      tuple = (s32[], s32[4,8,8,8], s32[1,1,1,8], s32[]) tuple(c0, input, init_acc, c1)
+      ROOT while = (s32[], s32[4,8,8,8], s32[1,1,1,8], s32[]) while(tuple),
           condition=condition, body=body,
           backend_config={"known_trip_count":{"n":"6"},
                           "known_init_step":{"init":"0","step":"1"},
@@ -205,15 +207,23 @@ TEST_F(CopyFusionTest, BuildSliceDescriptor) {
       GetFusion(module.get()));
 
   ASSERT_TRUE(descriptor.has_value());
-  ASSERT_THAT(descriptor->src_dynamic_offsets, ::testing::SizeIs(1));
+  ASSERT_THAT(descriptor->src_dynamic_offsets, ::testing::SizeIs(2));
 
-  const auto& offset = descriptor->src_dynamic_offsets[0];
-  EXPECT_EQ(descriptor->src_byte_static_offset, 32);
-  EXPECT_EQ(offset.while_loop->name(), "while");
-  EXPECT_EQ(offset.induction_variable->name(), "ivar");
-  EXPECT_EQ(offset.offset->name(), "offset1");
-  EXPECT_EQ(offset.dimension_size, 4);
-  EXPECT_EQ(offset.byte_stride, 8 * 8 * sizeof(float));
+  EXPECT_EQ(descriptor->src_byte_static_offset, 8 * 8 * sizeof(float));
+
+  const auto& offset1 = descriptor->src_dynamic_offsets[0];
+  EXPECT_EQ(offset1.while_loop->name(), "while");
+  EXPECT_EQ(offset1.induction_variable->name(), "ivar");
+  EXPECT_EQ(offset1.offset->name(), "p1");
+  EXPECT_EQ(offset1.dimension_size, 4);
+  EXPECT_EQ(offset1.byte_stride, 8 * 8 * 8 * sizeof(float));
+
+  const auto& offset2 = descriptor->src_dynamic_offsets[1];
+  EXPECT_EQ(offset2.while_loop->name(), "while");
+  EXPECT_EQ(offset2.induction_variable->name(), "ivar");
+  EXPECT_EQ(offset2.offset->name(), "o3");
+  EXPECT_EQ(offset2.dimension_size, 8);
+  EXPECT_EQ(offset2.byte_stride, 8 * sizeof(float));
 
   EXPECT_THAT(descriptor->dst_dynamic_offsets, ::testing::IsEmpty());
   EXPECT_EQ(descriptor->dst_byte_static_offset, 0);

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -493,6 +493,7 @@ cc_library(
         "//xla/stream_executor:stream_executor_h",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/xla/backends/gpu/runtime/copy_thunk.h
+++ b/xla/backends/gpu/runtime/copy_thunk.h
@@ -181,6 +181,10 @@ class DynamicMemcpyThunk : public Thunk {
       const HloInstruction* while_loop;
       const HloInstruction* induction_variable;
 
+      // See documentation for ResolveFunctionalDependencyOnInductionVariable.
+      absl::flat_hash_map<const HloComputation*, absl::InlinedVector<bool, 1>>
+          required_parameters;
+
       // All dependencies of `offset` must end in `induction_variable` or
       // constants only.
       const HloInstruction* offset;

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -648,6 +648,7 @@ cc_library(
         "//xla/tsl/lib/strings:proto_serialization",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/log",

--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -904,7 +904,8 @@ ResolveFunctionalDependencyOnInductionVariable(const HloInstruction* instr) {
     }
   }
 
-  if (!unique_param || !unique_gte || unique_gte->operand(0) != unique_param) {
+  if (!while_loop || !unique_param || !unique_gte ||
+      unique_gte->operand(0) != unique_param) {
     VLOG(5) << "Did not find a parameter or GTE or they don't match.";
     return std::nullopt;
   }

--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -879,7 +879,6 @@ ResolveFunctionalDependencyOnInductionVariable(const HloInstruction* instr) {
         }
         while_loop = caller;
         unique_param = instruction;
-        continue;
       } else {
         // Otherwise, we arrived at something we don't support.
         VLOG(5) << "Arrived at unsupported parameter. Caller is "

--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -819,41 +819,29 @@ bool IsDynamicMemcpyFusion(const HloInstruction* instr) {
 
 std::optional<InductionVariableFunctionalDependency>
 ResolveFunctionalDependencyOnInductionVariable(
-    absl::Span<const HloInstruction* const> call_stack,
     const HloInstruction* parameter) {
-  if (call_stack.empty()) {
-    return std::nullopt;
-  }
-
   VLOG(5) << "Looking for defining while loop of " << parameter->name();
 
-  // Walk up the call stack, tracking the origin of `parameter`.
-  const HloInstruction* argument = parameter;
-  auto call_stack_it = call_stack.rbegin();
-  auto call_stack_end = call_stack.rend();
-  for (; call_stack_it != call_stack_end &&
-         argument->opcode() == HloOpcode::kParameter &&
-         ((*call_stack_it)->opcode() == HloOpcode::kFusion ||
-          (*call_stack_it)->opcode() == HloOpcode::kAsyncStart ||
-          (*call_stack_it)->opcode() == HloOpcode::kCall);
-       ++call_stack_it) {
-    argument = (*call_stack_it)->operand(argument->parameter_number());
-  }
-
-  if (call_stack_it == call_stack_end) {
-    return std::nullopt;
-  }
-
-  VLOG(5) << "Arrived at " << argument->name() << " in "
-          << (*call_stack_it)->name();
-
   // Find a unique parameter and a gte in the transitive dependencies of
-  // `argument`.
+  // `parameter`.
   const HloInstruction* unique_param = nullptr;
   const HloInstruction* unique_gte = nullptr;
-  absl::flat_hash_set<const HloInstruction*> seen{argument};
+  const HloInstruction* while_loop = nullptr;
+
+  absl::flat_hash_map<const HloComputation*, absl::InlinedVector<bool, 1>>
+      required_parameters;
+  auto get_required_parameters =
+      [&](const HloComputation* computation) -> absl::InlinedVector<bool, 1>& {
+    auto& result = required_parameters[computation];
+    if (result.empty()) {
+      result.resize(computation->num_parameters());
+    }
+    return result;
+  };
+
+  absl::flat_hash_set<const HloInstruction*> seen{parameter};
   std::queue<const HloInstruction*> queue;
-  queue.push(argument);
+  queue.push(parameter);
   while (!queue.empty()) {
     const auto* instruction = queue.front();
     queue.pop();
@@ -865,11 +853,37 @@ ResolveFunctionalDependencyOnInductionVariable(
     }
 
     if (instruction->opcode() == HloOpcode::kParameter) {
-      if (unique_param || !instruction->shape().IsTuple()) {
-        VLOG(5) << "Failed to match parameters.";
+      auto callers = instruction->parent()->caller_instructions();
+      if (callers.size() != 1) {
+        VLOG(5) << "Failed to determine unique caller.";
         return std::nullopt;
       }
-      unique_param = instruction;
+
+      const HloInstruction* caller = callers.front();
+      // If this is semantically a call, continue the traversal at the call
+      // site. Also register the argument as a required intermediate value.
+      if (caller->opcode() == HloOpcode::kFusion ||
+          caller->opcode() == HloOpcode::kAsyncStart ||
+          caller->opcode() == HloOpcode::kCall) {
+        int64_t index = instruction->parameter_number();
+        get_required_parameters(instruction->parent())[index] = true;
+        queue.push(caller->operand(index));
+      } else if (caller->opcode() == HloOpcode::kWhile) {
+        // We only support dependencies on the inner-most while loop's
+        // induction variable, so we don't need to continue the traversal here.
+        if (unique_param || !instruction->shape().IsTuple()) {
+          VLOG(5) << "Failed to match parameters.";
+          return std::nullopt;
+        }
+        while_loop = caller;
+        unique_param = instruction;
+        continue;
+      } else {
+        // Otherwise, we arrived at something we don't support.
+        VLOG(5) << "Arrived at unsupported parameter. Caller is "
+                << caller->opcode() << ".";
+        return std::nullopt;
+      }
     }
 
     if (instruction->opcode() == HloOpcode::kGetTupleElement) {
@@ -895,28 +909,7 @@ ResolveFunctionalDependencyOnInductionVariable(
   VLOG(5) << "Parameter and GTE: " << unique_param->name() << ", "
           << unique_gte->name();
 
-  // Continue walking up through call instructions.
-  while (call_stack_it != call_stack_end &&
-         (*call_stack_it)->opcode() == HloOpcode::kCall &&
-         unique_param->opcode() == HloOpcode::kParameter) {
-    unique_param = (*call_stack_it)->operand(unique_param->parameter_number());
-    ++call_stack_it;
-  }
-
-  // Find the while loop for 'unique_param'.
-  auto while_instr_it = std::find_if(
-      call_stack_it, call_stack_end, [&](const HloInstruction* instr) {
-        return instr->opcode() == HloOpcode::kWhile &&
-               unique_param == instr->while_body()->parameter_instruction(0);
-      });
-
-  if (while_instr_it == call_stack_end) {
-    VLOG(5) << "Did not find a while loop.";
-    return std::nullopt;
-  }
-
-  auto config =
-      (*while_instr_it)->backend_config<xla::WhileLoopBackendConfig>();
+  auto config = while_loop->backend_config<xla::WhileLoopBackendConfig>();
   if (!config.ok() || !config->has_known_induction_variable() ||
       unique_gte->tuple_index() !=
           config->known_induction_variable().tuple_index()) {
@@ -926,9 +919,9 @@ ResolveFunctionalDependencyOnInductionVariable(
   }
 
   VLOG(5) << "While loop for " << parameter->name() << ": "
-          << (*while_instr_it)->name();
-  return InductionVariableFunctionalDependency{argument, *while_instr_it,
-                                               unique_gte};
+          << while_loop->name();
+  return InductionVariableFunctionalDependency{
+      parameter, std::move(required_parameters), while_loop, unique_gte};
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <variant>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -366,6 +366,17 @@ struct InductionVariableFunctionalDependency {
   // to have no other transitive dependencies (except constants).
   const HloInstruction* derived_value;
 
+  // The dependency may be via multiple levels of intermediate calls. At each
+  // level, we need to know which parameters to evaluate, since not all of them
+  // may be relevant. The while loop's body is not included here, since the
+  // induction variable is implicitly the only dependency that is allowed.
+  // The size of the value is always the same as the number of parameters in the
+  // computation. We request a single element of inlined space, which will
+  // automatically pick the optimum value (16, usually).
+  absl::flat_hash_map<const HloComputation*,
+                      absl::InlinedVector<bool, 1 /* chosen automatically */>>
+      required_parameters;
+
   // The loop and its induction variable that the value depends on.
   const HloInstruction* loop;
   const HloInstruction* induction_var;
@@ -375,15 +386,11 @@ struct InductionVariableFunctionalDependency {
 // variable. This supports parameters that are inside call, async or fusion
 // instructions. The dependency can be through arbitrary non-side-effecting
 // instructions.
-// `call_stack` should contain the nested instructions that are ancestor of
-// `parameter`. For example, if it is a parameter of a fusion in a while loop,
-// it should contain the while loop as the first element and the fusion as the
-// second element.
+// Currently, this does not support nested while loops. Only dependencies on the
+// inner-most while loop will successfully be analyzed.
 // Requires `while_loop_trip_count_annotator` to have been run on the loop.
 std::optional<InductionVariableFunctionalDependency>
-ResolveFunctionalDependencyOnInductionVariable(
-    absl::Span<const HloInstruction* const> call_stack,
-    const HloInstruction* parameter);
+ResolveFunctionalDependencyOnInductionVariable(const HloInstruction* parameter);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -362,10 +362,6 @@ absl::StatusOr<std::string> FingerprintWithBackendConfig(
 }
 
 struct InductionVariableFunctionalDependency {
-  // The value that is derived from the induction variable. This is guaranteed
-  // to have no other transitive dependencies (except constants).
-  const HloInstruction* derived_value;
-
   // The dependency may be via multiple levels of intermediate calls. At each
   // level, we need to know which parameters to evaluate, since not all of them
   // may be relevant. The while loop's body is not included here, since the
@@ -382,15 +378,15 @@ struct InductionVariableFunctionalDependency {
   const HloInstruction* induction_var;
 };
 
-// Checks if `parameter`'s value is a pure function of a while loop's induction
-// variable. This supports parameters that are inside call, async or fusion
+// Checks if `instr`'s value is a pure function of a while loop's induction
+// variable. This supports instructions that are inside call, async or fusion
 // instructions. The dependency can be through arbitrary non-side-effecting
 // instructions.
 // Currently, this does not support nested while loops. Only dependencies on the
 // inner-most while loop will successfully be analyzed.
 // Requires `while_loop_trip_count_annotator` to have been run on the loop.
 std::optional<InductionVariableFunctionalDependency>
-ResolveFunctionalDependencyOnInductionVariable(const HloInstruction* parameter);
+ResolveFunctionalDependencyOnInductionVariable(const HloInstruction* instr);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/ir_emission_utils_test.cc
+++ b/xla/service/gpu/ir_emission_utils_test.cc
@@ -49,8 +49,8 @@ namespace xla {
 namespace gpu {
 
 using ::testing::ElementsAre;
-using ::tsl::testing::IsOkAndHolds;
 using ::testing::SizeIs;
+using ::tsl::testing::IsOkAndHolds;
 
 class IrEmissionUtilsTest : public HloRunnerAgnosticTestBase {
  public:
@@ -1233,10 +1233,6 @@ TEST_F(IrEmissionUtilsTest, ResolveWhileLoopDependency) {
   HloComputation* call_body = module->GetComputationWithName("call_body");
 
   const HloInstruction* loop = module->entry_computation()->root_instruction();
-  const HloInstruction* call = while_body->GetInstructionWithName("call");
-
-  const HloInstruction* called_fusion =
-      call_body->GetInstructionWithName("called_fusion");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
       plus_one->GetInstructionWithName("sum"));
 
@@ -1258,10 +1254,6 @@ TEST_F(IrEmissionUtilsTest,
 
   HloInstruction* loop = module->entry_computation()->root_instruction();
   loop->clear_backend_config();
-  const HloInstruction* call = while_body->GetInstructionWithName("call");
-  const HloInstruction* called_fusion =
-      module->GetComputationWithName("call_body")
-          ->GetInstructionWithName("called_fusion");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
       module->GetComputationWithName("plus_one")->root_instruction());
 
@@ -1275,12 +1267,10 @@ TEST_F(IrEmissionUtilsTest, ResolveWhileLoopDependencySideEffect) {
                           ParseAndReturnVerifiedModule(kWhileLoopTestModule));
 
   auto* while_body = module->GetComputationWithName("while_body");
-
-  const HloInstruction* loop = module->entry_computation()->root_instruction();
   const HloInstruction* called_fusion =
       while_body->GetInstructionWithName("not_functionally_dependent");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
-      module->GetComputationWithName("identity2")->root_instruction());
+      called_fusion->called_computations()[0]->root_instruction());
 
   ASSERT_FALSE(result.has_value());
 }

--- a/xla/service/gpu/ir_emission_utils_test.cc
+++ b/xla/service/gpu/ir_emission_utils_test.cc
@@ -50,6 +50,7 @@ namespace gpu {
 
 using ::testing::ElementsAre;
 using ::tsl::testing::IsOkAndHolds;
+using ::testing::SizeIs;
 
 class IrEmissionUtilsTest : public HloRunnerAgnosticTestBase {
  public:
@@ -1146,8 +1147,12 @@ ENTRY e {
 }
 
 constexpr absl::string_view kWhileLoopTestModule = R"(
-    identity {
-      ROOT p0 = s32[] parameter(0)
+    plus_one {
+      p0 = s32[] parameter(0)
+      p1 = s32[] parameter(1)
+      c1 = s32[] constant(0)
+      sum = s32[] add(p0, c1)
+      ROOT tuple = (s32[], s32[]) tuple(sum, p1)
     }
     identity2 {
       ROOT p0 = s32[] parameter(0)
@@ -1161,7 +1166,11 @@ constexpr absl::string_view kWhileLoopTestModule = R"(
 
     call_body {
       p0 = s32[] parameter(0)
-      ROOT called_fusion = s32[] fusion(p0), kind=kLoop, calls=identity
+      p1 = s32[] parameter(1)
+      p2 = s32[] parameter(2)
+      sum = s32[] add(p0, p2)
+      called_fusion = (s32[], s32[]) fusion(p1, sum), kind=kLoop, calls=plus_one
+      ROOT gte = s32[] get-tuple-element(called_fusion), index=0
     }
 
     add_values {
@@ -1175,11 +1184,10 @@ constexpr absl::string_view kWhileLoopTestModule = R"(
       ivar = s32[] get-tuple-element(p0), index=0
       ivar_copy = s32[] copy(ivar)
 
-      // `derived` and `call` are functionally dependent on the induction variable.
-      derived = s32[] fusion(ivar_copy), kind=kLoop, calls=remainder
-      call = s32[] call(derived), to_apply=call_body
-
       side_effect = s32[] custom-call(), custom_call_target=""
+
+      derived = s32[] fusion(ivar_copy), kind=kLoop, calls=remainder
+      call = s32[] call(side_effect, derived, ivar), to_apply=call_body
 
       // `derived_with_invalid_dep` and `not_functionally_dependent` are not, because
       // they have a custom call in their transitive dependencies.
@@ -1220,28 +1228,32 @@ TEST_F(IrEmissionUtilsTest, ResolveWhileLoopDependency) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kWhileLoopTestModule));
 
-  auto* while_body = module->GetComputationWithName("while_body");
+  HloComputation* while_body = module->GetComputationWithName("while_body");
+  HloComputation* plus_one = module->GetComputationWithName("plus_one");
+  HloComputation* call_body = module->GetComputationWithName("call_body");
 
   const HloInstruction* loop = module->entry_computation()->root_instruction();
   const HloInstruction* call = while_body->GetInstructionWithName("call");
+
   const HloInstruction* called_fusion =
-      module->GetComputationWithName("call_body")
-          ->GetInstructionWithName("called_fusion");
+      call_body->GetInstructionWithName("called_fusion");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
-      module->GetComputationWithName("identity")->root_instruction());
+      plus_one->GetInstructionWithName("sum"));
 
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result->derived_value,
-            while_body->GetInstructionWithName("derived"));
   EXPECT_EQ(result->loop, loop);
   EXPECT_EQ(result->induction_var, while_body->GetInstructionWithName("ivar"));
+
+  EXPECT_THAT(result->required_parameters, SizeIs(2));
+  EXPECT_THAT(result->required_parameters[plus_one], ElementsAre(true, false));
+  EXPECT_THAT(result->required_parameters[call_body],
+              ElementsAre(false, true, false));
 }
 
 TEST_F(IrEmissionUtilsTest,
        ResolveWhileLoopDependencyUnknownInductionVariable) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kWhileLoopTestModule));
-
   auto* while_body = module->GetComputationWithName("while_body");
 
   HloInstruction* loop = module->entry_computation()->root_instruction();
@@ -1251,22 +1263,7 @@ TEST_F(IrEmissionUtilsTest,
       module->GetComputationWithName("call_body")
           ->GetInstructionWithName("called_fusion");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
-      module->GetComputationWithName("identity")->root_instruction());
-
-  ASSERT_FALSE(result.has_value());
-}
-
-TEST_F(IrEmissionUtilsTest, ResolveWhileLoopDependencyWhileLoopNotInCallStack) {
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kWhileLoopTestModule));
-
-  auto* while_body = module->GetComputationWithName("while_body");
-  const HloInstruction* call = while_body->GetInstructionWithName("call");
-  const HloInstruction* called_fusion =
-      module->GetComputationWithName("call_body")
-          ->GetInstructionWithName("called_fusion");
-  auto result = ResolveFunctionalDependencyOnInductionVariable(
-      module->GetComputationWithName("identity")->root_instruction());
+      module->GetComputationWithName("plus_one")->root_instruction());
 
   ASSERT_FALSE(result.has_value());
 }

--- a/xla/service/gpu/ir_emission_utils_test.cc
+++ b/xla/service/gpu/ir_emission_utils_test.cc
@@ -1228,7 +1228,6 @@ TEST_F(IrEmissionUtilsTest, ResolveWhileLoopDependency) {
       module->GetComputationWithName("call_body")
           ->GetInstructionWithName("called_fusion");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
-      /*call_stack=*/{loop, call, called_fusion},
       module->GetComputationWithName("identity")->root_instruction());
 
   ASSERT_TRUE(result.has_value());
@@ -1252,7 +1251,6 @@ TEST_F(IrEmissionUtilsTest,
       module->GetComputationWithName("call_body")
           ->GetInstructionWithName("called_fusion");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
-      /*call_stack=*/{loop, call, called_fusion},
       module->GetComputationWithName("identity")->root_instruction());
 
   ASSERT_FALSE(result.has_value());
@@ -1268,7 +1266,6 @@ TEST_F(IrEmissionUtilsTest, ResolveWhileLoopDependencyWhileLoopNotInCallStack) {
       module->GetComputationWithName("call_body")
           ->GetInstructionWithName("called_fusion");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
-      /*call_stack=*/{call, called_fusion},
       module->GetComputationWithName("identity")->root_instruction());
 
   ASSERT_FALSE(result.has_value());
@@ -1286,7 +1283,6 @@ TEST_F(IrEmissionUtilsTest, ResolveWhileLoopDependencySideEffect) {
   const HloInstruction* called_fusion =
       while_body->GetInstructionWithName("not_functionally_dependent");
   auto result = ResolveFunctionalDependencyOnInductionVariable(
-      /*call_stack=*/{loop, called_fusion},
       module->GetComputationWithName("identity2")->root_instruction());
 
   ASSERT_FALSE(result.has_value());

--- a/xla/service/gpu/ir_emission_utils_test.cc
+++ b/xla/service/gpu/ir_emission_utils_test.cc
@@ -1250,7 +1250,6 @@ TEST_F(IrEmissionUtilsTest,
        ResolveWhileLoopDependencyUnknownInductionVariable) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kWhileLoopTestModule));
-  auto* while_body = module->GetComputationWithName("while_body");
 
   HloInstruction* loop = module->entry_computation()->root_instruction();
   loop->clear_backend_config();

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -81,10 +81,12 @@ constexpr char kSliceMemcpyModule[] = R"(
       c1 = s32[] constant(1)
       p2 = s32[] parameter(2)
 
+      p1p1 = s32[] add(p1, c1)
+
       // Test all supported kinds of offsets: derived from the while loop's
-      // induction variable (p1), constant (c1) and always clamped to 0, so
+      // induction variable (p1p1), constant (c1) and always clamped to 0, so
       // the value is irrelevant (p2).
-      ROOT slice = s32[1,1,8] dynamic-slice(p0, p1, c1, p2),
+      ROOT slice = s32[1,1,8] dynamic-slice(p0, p1p1, c1, p2),
           dynamic_slice_sizes={1,1,8}
     }
 


### PR DESCRIPTION
Note: this optimization is currently not enabled.

Currently, dynamic memcpy fusions only trigger if the innermost fusion contains no offset computations, i.e. all dynamic-(update-)slice offsets are parameters, constants, or values that are clamped to 0. Unfortunately, this is not sufficient in general, since sometimes the offset computations are fused. 

To solve this, we need to generalize ResolveFunctionalDependencyOnInductionVariable. The previous logic traced parameters through the call stack until a while loop is reached, assuming all computations happen directly inside the while loop. The new logic is similar, but does not make the assumption that all computations happen there - for each layer of the stack, it computes the set of required parameters, still verifying that no side-effecting instructions are encountered on the way. Otherwise, arbitrary computations are allowed in each layer.

In the dynamic memcpy thunk, we then start in the while loop body, and for each call we evaluate the previously computed required parameters.

Apologies for the large PR, I didn't see a way to split this up.