### PR TITLE
Clean up special cases for AsyncStart in HloComputation.

### DIFF
--- a/xla/hlo/ir/hlo_computation.cc
+++ b/xla/hlo/ir/hlo_computation.cc
@@ -182,10 +182,6 @@ HloComputation::~HloComputation() {
     CHECK(FusionInstruction()->fused_instructions_computation() == this);
     FusionInstruction()->ClearCalledComputations();
   }
-  if (IsAsyncComputation()) {
-    CHECK(async_start_->async_wrapped_computation() == this);
-    async_start_->ClearCalledComputations();
-  }
   Cleanup();
   ClearCalledComputations();
 

--- a/xla/hlo/ir/hlo_computation.h
+++ b/xla/hlo/ir/hlo_computation.h
@@ -810,7 +810,9 @@ class HloComputation {
   }
 
   // Returns if this computation is an async computation.
-  bool IsAsyncComputation() const { return async_start_ != nullptr; }
+  bool IsAsyncComputation() const {
+    return !caller_instructions(HloOpcode::kAsyncStart).empty();
+  }
 
   // Returns true if this computation only contains send/recv instructions.
   bool OnlyContainsSendRecv() {
@@ -823,19 +825,6 @@ class HloComputation {
     }
     return true;
   }
-
-  // Returns the owning async instruction. It's nullptr if this is not an async
-  // computation.
-  HloInstruction* AsyncStart() const { return async_start_; }
-
-  void AddAsyncStart(HloInstruction* async_instruction) {
-    // TODO: Add instruction type for async instructions.
-    CHECK(instruction_type() == InstructionType::kUnset);
-    CHECK(async_instruction->opcode() == HloOpcode::kAsyncStart);
-    async_start_ = async_instruction;
-  }
-
-  void RemoveAsyncStart() { async_start_ = nullptr; }
 
   // Clear the unique ID of the computation so that it can be re-assigned, such
   // as for the purpose of compacting the unique IDs.
@@ -1041,12 +1030,6 @@ class HloComputation {
   // /*count=*/int> in the high bits and a CallersType in the least significant
   // bit.
   uintptr_t callers_ = 0;
-
-  // If this computation is an async computation, this field points to the
-  // first async instruction (async-start) in the asynchronous op chain that
-  // calls this computation.
-  // Otherwise, this is empty.
-  HloInstruction* async_start_ = nullptr;
 
   HloInstruction::InstructionVector param_instructions_;
 

--- a/xla/hlo/ir/hlo_instructions.cc
+++ b/xla/hlo/ir/hlo_instructions.cc
@@ -402,31 +402,8 @@ HloAsyncStartInstruction::HloAsyncStartInstruction(
                           async_computation->root_instruction()->opcode()) {
   CHECK(async_computation->caller_instructions(HloOpcode::kCustomCall).empty());
   CHECK(!async_computation->IsFusionComputation());
-  CHECK(!async_computation->IsAsyncComputation());
   AppendComputation(async_computation);
-  async_computation->AddAsyncStart(this);
   HloAsyncStartInstruction::set_async_execution_thread(async_execution_thread);
-}
-
-HloAsyncStartInstruction::~HloAsyncStartInstruction() {
-  ClearAsyncComputationInstruction();
-}
-
-void HloAsyncStartInstruction::ClearCalledComputations() {
-  ClearAsyncComputationInstruction();
-  HloInstruction::ClearCalledComputations();
-}
-
-void HloAsyncStartInstruction::ClearAsyncComputationInstruction() {
-  // Each async instruction calls a single computation, but we use
-  // called_computations() instead of async_wrapped_instruction(), because the
-  // order in which things get destructed can vary; the async computation's
-  // back-pointer may already be null, which violates a check in
-  // async_wrapped_instruction.
-  if (!called_computations().empty() &&
-      async_wrapped_computation()->AsyncStart() == this) {
-    async_wrapped_computation()->RemoveAsyncStart();
-  }
 }
 
 void HloAsyncStartInstruction::set_async_execution_thread(

--- a/xla/hlo/ir/hlo_instructions.h
+++ b/xla/hlo/ir/hlo_instructions.h
@@ -302,12 +302,6 @@ class HloAsyncStartInstruction : public HloAsyncInstruction {
       HloComputation* async_computation,
       absl::string_view async_execution_thread = kMainExecutionThread);
 
-  ~HloAsyncStartInstruction() override;
-  void ClearCalledComputations() override;
-  // When an async instruction is being destructed, remove it from the vector of
-  // pointers of its called computation, to avoid referencing freed memory.
-  void ClearAsyncComputationInstruction();
-
   absl::string_view async_execution_thread() const override {
     return async_execution_thread_;
   };

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -5581,11 +5581,11 @@ ENTRY %Entry (p0: f32[10]) -> f32[20] {
   ROOT %async-done.1 = f32[20]{0} async-done(((f32[10]{0}), f32[20]{0}, s32[]) %async-start.1)
 }
   )";
-  EXPECT_THAT(ParseAndReturnUnverifiedModule(hlo_string).status(),
-              tsl::testing::StatusIs(
-                  tsl::error::INVALID_ARGUMENT,
-                  HasSubstr("Computation async_wrapped is already referenced "
-                            "by another async op")));
+  EXPECT_THAT(
+      ParseAndReturnUnverifiedModule(hlo_string).status(),
+      tsl::testing::StatusIs(tsl::error::INVALID_ARGUMENT,
+                             HasSubstr("Computation async_wrapped is called by "
+                                       "more than one async op")));
 }
 
 TEST_F(HloParserTest, AsyncUpdateWrongComputation) {

--- a/xla/hlo/transforms/simplifiers/flatten_call_graph.cc
+++ b/xla/hlo/transforms/simplifiers/flatten_call_graph.cc
@@ -71,10 +71,8 @@ void ReplaceCalledComputation(HloInstruction* instruction,
     }
     case HloOpcode::kAsyncStart: {
       CHECK(computation->IsAsyncComputation());
-      computation->RemoveAsyncStart();
       instruction->ReplaceCalledComputations(
           [&](HloComputation*) { return new_computation; });
-      new_computation->AddAsyncStart(instruction);
       break;
     }
     default:

--- a/xla/hlo/utils/hlo_live_range.cc
+++ b/xla/hlo/utils/hlo_live_range.cc
@@ -219,8 +219,9 @@ void HloLiveRange::CalculateBufferStartEndMap() {
     auto async_context_it = computations_in_async_context_.find(computation);
     if (async_context_it != computations_in_async_context_.end()) {
       const HloComputation* async_context = async_context_it->second;
-      CHECK(async_context->IsAsyncComputation());
-      auto async_done = async_context->AsyncStart()->async_chain_done();
+      auto async_start = async_context->GetUniqueCaller(HloOpcode::kAsyncStart);
+      CHECK(async_start) << "Async computations should have a unique caller.";
+      auto async_done = (*async_start)->async_chain_done();
       auto async_done_it = instruction_schedule_.find(async_done);
       CHECK(async_done_it != instruction_schedule_.end());
       definition_end_time =

--- a/xla/service/gpu/transforms/double_buffer_loop_unrolling.cc
+++ b/xla/service/gpu/transforms/double_buffer_loop_unrolling.cc
@@ -80,8 +80,6 @@ void SetChannelIdForNewCollective(HloInstruction* new_instr,
     if (channel_id_comp_map.find(new_channel_id) == channel_id_comp_map.end()) {
       channel_id_comp_map[new_channel_id] =
           new_instr->async_wrapped_computation();
-    } else {
-      channel_id_comp_map[new_channel_id]->AddAsyncStart(new_instr);
     }
   } else if (hlo_query::IsCollectiveCommunicationOp(new_instr->opcode()) ||
              hlo_query::IsAsyncCollectiveStartOp(new_instr)) {


### PR DESCRIPTION
These are no longer needed, since computations now know their callers. I kept the utility function to check if a computation is async, since it is used from many places.

I had to remove one check from the AsyncStart constructor. Previously, it didn't actually verify that the computation isn't already called by an async-start, just that the special field is unset. I don't see a way to have this check and make the code in CommandBufferScheduling work.

After this, the only remaining special case is kFusion.