### PR TITLE
Allow bitcasts in dynamic memcpy fusions.

### DIFF
--- a/xla/backends/gpu/codegen/copy.cc
+++ b/xla/backends/gpu/codegen/copy.cc
@@ -43,6 +43,7 @@ limitations under the License.
 
 namespace xla {
 namespace gpu {
+namespace {
 
 HloInstructionAdaptor SkipOptionalBitcast(HloInstructionAdaptor adaptor) {
   return adaptor.opcode() == HloOpcode::kBitcast ? adaptor.GetOperand(0)
@@ -52,6 +53,8 @@ HloInstructionAdaptor SkipOptionalBitcast(HloInstructionAdaptor adaptor) {
 const HloInstruction* SkipOptionalBitcast(const HloInstruction* instr) {
   return instr->opcode() == HloOpcode::kBitcast ? instr->operand(0) : instr;
 }
+
+}  // namespace
 
 absl::StatusOr<FusionEmissionResult> MemcpyFusion::Emit(
     IrEmitterContext& ir_emitter_context,

--- a/xla/backends/gpu/codegen/copy.cc
+++ b/xla/backends/gpu/codegen/copy.cc
@@ -44,6 +44,11 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
+HloInstructionAdaptor SkipBitcast(HloInstructionAdaptor adaptor) {
+  return adaptor.opcode() == HloOpcode::kBitcast ? adaptor.GetOperand(0)
+                                                 : adaptor;
+}
+
 absl::StatusOr<FusionEmissionResult> MemcpyFusion::Emit(
     IrEmitterContext& ir_emitter_context,
     const HloFusionInstruction& fusion) const {
@@ -87,7 +92,7 @@ absl::StatusOr<FusionEmissionResult> DynamicMemcpyFusion::Emit(
     const HloFusionInstruction& fusion) const {
   CHECK_EQ(analysis_.fusion_roots().size(), 1);
 
-  auto root = analysis_.fusion_roots().front();
+  auto root = SkipBitcast(analysis_.fusion_roots().front());
 
   int source_operand_index;
   const Shape* copy_shape;
@@ -100,12 +105,15 @@ absl::StatusOr<FusionEmissionResult> DynamicMemcpyFusion::Emit(
     // prefix, one for the updated slice, one for the unchanged suffix). The
     // first option is inefficient, the second option is currently not
     // implemented: we only support dynamic offsets, no dynamic sizes.
-    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice input,
-                        buffer_assignment_->GetUniqueSlice(
-                            &root.GetOperand(0).instruction(), {}));
-    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst,
+    auto input = root.GetOperand(0);
+
+    TF_ASSIGN_OR_RETURN(
+        BufferAllocation::Slice input_slice,
+        buffer_assignment_->GetUniqueSlice(
+            &SkipBitcast(root.GetOperand(0)).instruction(), {}));
+    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst_slice,
                         buffer_assignment_->GetUniqueSlice(&fusion, {}));
-    CHECK_EQ(input, dst);
+    CHECK_EQ(input_slice, dst_slice);
 
     source_operand_index = 1;
     copy_shape = &root.GetOperand(source_operand_index).shape();
@@ -115,7 +123,8 @@ absl::StatusOr<FusionEmissionResult> DynamicMemcpyFusion::Emit(
     copy_shape = &root.shape();
   }
 
-  const auto* src_instr = &root.GetOperand(source_operand_index).instruction();
+  const auto* src_instr =
+      &SkipBitcast(root.GetOperand(source_operand_index)).instruction();
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice src_buffer,
                       buffer_assignment_->GetUniqueSlice(src_instr, {}));
   TF_ASSIGN_OR_RETURN(BufferAllocation::Slice dst_buffer,
@@ -132,6 +141,15 @@ absl::StatusOr<FusionEmissionResult> DynamicMemcpyFusion::Emit(
 }
 
 namespace {
+
+// Returns the fusion's root, skipping an optional bitcast.
+const HloInstruction* GetRealRoot(const HloFusionInstruction& fusion) {
+  const HloInstruction* root = fusion.fused_expression_root();
+  if (root->opcode() == HloOpcode::kBitcast) {
+    root = root->operand(0);
+  }
+  return root;
+}
 
 // Returns the slice size in the given dimension for a dynamic-(update-)slice
 // instruction.
@@ -163,7 +181,7 @@ int GetFirstOffsetOperandIndex(const HloInstruction* slice) {
 
 bool DynamicMemcpyFusion::IsCandidateFusion(
     const HloFusionInstruction& instruction) {
-  const HloInstruction* root = instruction.fused_expression_root();
+  const HloInstruction* root = GetRealRoot(instruction);
   if (root->opcode() != HloOpcode::kDynamicSlice &&
       root->opcode() != HloOpcode::kDynamicUpdateSlice) {
     return false;
@@ -184,7 +202,11 @@ bool DynamicMemcpyFusion::IsCandidateFusion(
 
   int first_offset_index = GetFirstOffsetOperandIndex(root);
   for (int i = 0; i < first_offset_index; ++i) {
-    if (root->operand(i)->opcode() != HloOpcode::kParameter) {
+    auto* operand = root->operand(i);
+    if (operand->opcode() == HloOpcode::kBitcast) {
+      operand = operand->operand(0);
+    }
+    if (operand->opcode() != HloOpcode::kParameter) {
       VLOG(5) << "Not a slice of a parameter.";
       return false;
     }
@@ -202,7 +224,7 @@ DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(
     return std::nullopt;
   }
 
-  const HloInstruction* slice = fusion.fused_expression_root();
+  const HloInstruction* slice = GetRealRoot(fusion);
   const Shape& slice_input_shape = slice->operand(0)->shape();
   std::optional<absl::InlinedVector<int64_t, 4>> strides =
       ShapeUtil::ByteStrides(slice_input_shape);

--- a/xla/backends/gpu/codegen/copy.cc
+++ b/xla/backends/gpu/codegen/copy.cc
@@ -109,8 +109,6 @@ absl::StatusOr<FusionEmissionResult> DynamicMemcpyFusion::Emit(
     // prefix, one for the updated slice, one for the unchanged suffix). The
     // first option is inefficient, the second option is currently not
     // implemented: we only support dynamic offsets, no dynamic sizes.
-    auto input = root.GetOperand(0);
-
     TF_ASSIGN_OR_RETURN(
         BufferAllocation::Slice input_slice,
         buffer_assignment_->GetUniqueSlice(


### PR DESCRIPTION
Both before and after the dynamic-(update-)slice.

This is in line with other copy fusions. I just missed this case previously.