### PR TITLE
[XLA:CPU][Refactor] Remove config-dependent default value for `enable_onednn_support`  

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
@@ -390,18 +390,7 @@ class AlgebraicSimplifierOptions {
   bool enable_fast_math_{false};
   bool enable_broadcast_degenerate_dimension_{true};
   bool enable_remove_no_op_reduce_precision_{false};
-  bool enable_onednn_support_{
-#ifdef INTEL_MKL
-      // Deprecation warning: This config-dependent default value is a temporary
-      // measure to preserve existing behavior until downstream users can update
-      // their code. The option will default to `false` in a future version;
-      // please explicitly call `set_enable_onednn_support(true)` if you depend
-      // on it being `true`.
-      true
-#else   // INTEL_MKL
-      false
-#endif  // INTEL_MKL
-  };
+  bool enable_onednn_support_{false};
   bool rewrite_reshape_transpose_as_slice_concatenate_{true};
   Metadata metadata_;
 };


### PR DESCRIPTION
This PR removes the config-dependent default value of the AlgebraicSimplifier option `enable_onednn_support_` and explicitly sets the appropriate value while populating the CPU compilation pipeline with optimization passes.