### PR TITLE
force delay scheduling start to extend overlap interval

### DIFF
--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -585,8 +585,7 @@ absl::Status RunLatencyHidingSchedulerPasses(
   // If overlap limit is set to be greater than 1 and the default t-short size
   // estimator is used we will tell LHS to extend async-done intervals as much
   // as possible to start collectives as early as possible.
-  if (config.parallel_collective_overlap_limit > 1 &&
-      typeid(*estimator) == typeid(GpuLatencyEstimator)) {
+  if (config.parallel_collective_overlap_limit > 1) {
     config.prioritize_compute_over_async_start = true;
   }
   auto async_tracker = std::make_unique<GpuAsyncTracker>(config);

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -582,7 +582,13 @@ absl::Status RunLatencyHidingSchedulerPasses(
     pipeline.AddPass<PGLEAccuracyChecker>(
         dynamic_cast<ProfileGuidedLatencyEstimator&>(*estimator));
   }
-
+  // If overlap limit is set to be greater than 1 and the default t-short size
+  // estimator is used we will tell LHS to extend async-done intervals as much
+  // as possible to start collectives as early as possible.
+  if (config.parallel_collective_overlap_limit > 1 &&
+      typeid(*estimator) == typeid(GpuLatencyEstimator)) {
+    config.prioritize_compute_over_async_start = true;
+  }
   auto async_tracker = std::make_unique<GpuAsyncTracker>(config);
 
   std::shared_ptr<const SchedulingContext> scheduling_context =

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -585,8 +585,9 @@ absl::Status RunLatencyHidingSchedulerPasses(
   // If overlap limit is set to be greater than 1 and the default t-short size
   // estimator is used we will tell LHS to extend async-done intervals as much
   // as possible to start collectives as early as possible.
+  bool prioritize_compute_over_async_start;
   if (config.parallel_collective_overlap_limit > 1) {
-    config.prioritize_compute_over_async_start = true;
+    prioritize_compute_over_async_start = true;
   }
   auto async_tracker = std::make_unique<GpuAsyncTracker>(config);
 
@@ -594,10 +595,55 @@ absl::Status RunLatencyHidingSchedulerPasses(
       std::make_shared<const SchedulingContext>(
           module, std::move(estimator), std::move(async_tracker), alias_info,
           shape_size_in_bytes);
+
+  auto gpu_early_scheduling_rule =
+      [&prioritize_compute_over_async_start, &config](
+          DefaultSchedulerCore::ScheduleCandidate& a,
+          DefaultSchedulerCore::ScheduleCandidate& b)
+      -> std::optional<DefaultSchedulerCore::CandidateResult> {
+    if (config.aggressive_scheduling_policies &&
+        prioritize_compute_over_async_start) {
+      HloGraphNode* a_node = a.node;
+      HloGraphNode* b_node = b.node;
+      // If either one is an asyncDone, we proceed to the subsequent rules in
+      // the base LHS.
+      if (a_node->DoesOccupyAnyResource() || b_node->DoesOccupyAnyResource()) {
+        return std::nullopt;
+      }
+
+      bool a_has_async_resource =
+          a_node->DoesReleaseAnyResource() && !a.resource_constrained;
+      bool b_has_async_resource =
+          b_node->DoesReleaseAnyResource() && !b.resource_constrained;
+
+      if (!a_has_async_resource && b_has_async_resource) {
+        return DefaultSchedulerCore::CandidateResult{
+            a, "kDelayAsyncStartForCompute"};
+      } else if (a_has_async_resource && !b_has_async_resource) {
+        return DefaultSchedulerCore::CandidateResult{
+            b, "kDelayAsyncStartForCompute"};
+      }
+      if (a_has_async_resource && b_has_async_resource) {
+        // If 2 nodes are both async nodes, we prioritize the one
+        // with more depth to free up more computes to overlap
+        // with the one with less depth which can be launched
+        // early
+        if (a_node->GetDepth() > b_node->GetDepth()) {
+          return DefaultSchedulerCore::CandidateResult{
+              a, "kDelayAsyncStartForDepth"};
+        } else if (b_node->GetDepth() > a_node->GetDepth()) {
+          return DefaultSchedulerCore::CandidateResult{
+              b, "kDelayAsyncStartForDepth"};
+        }
+      }
+    }
+    return std::nullopt;
+  };
+
   auto scheduler_core = std::make_unique<DefaultSchedulerCore>(
       scheduling_context, config,
       /*target_scheduling_rule=*/nullptr,
-      /*early_target_scheduling_rule=*/nullptr,
+      /*early_target_scheduling_rule=*/gpu_early_scheduling_rule,
       /*post_processing_fn=*/nullptr);
 
   pipeline.AddPass<LatencyHidingScheduler>(scheduling_context,

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -585,7 +585,7 @@ absl::Status RunLatencyHidingSchedulerPasses(
   // If overlap limit is set to be greater than 1 and the default t-short size
   // estimator is used we will tell LHS to extend async-done intervals as much
   // as possible to start collectives as early as possible.
-  bool prioritize_compute_over_async_start;
+  bool prioritize_compute_over_async_start = false;
   if (config.parallel_collective_overlap_limit > 1) {
     prioritize_compute_over_async_start = true;
   }

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1087,8 +1087,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, ParallelThreadsShouldBeScheduled) {
 }
 
 TEST_F(GpuLatencyHidingSchedulerBaseTest,
-  MultipleParallelAsyncsExtendedOverAllComputes) {
-absl::string_view kHloModule = R"(
+       MultipleParallelAsyncsExtendedOverAllComputes) {
+  absl::string_view kHloModule = R"(
 HloModule m
 reduce {
 x = f32[] parameter(0)
@@ -1116,45 +1116,45 @@ mul_0 = f32[2] multiply(p4, p5)
 ROOT _ = (f32[], f32[2], f32[1], f32[2], f32[2], f32[2]) tuple(ar_1, ar_3, rs_1, add_0, div_0, mul_0)
 }
 )";
-absl::string_view kFdoProfile = "";
+  absl::string_view kFdoProfile = "";
 
-auto config = GetModuleConfig(kFdoProfile);
-TF_ASSERT_OK_AND_ASSIGN(auto module,
-                     ParseAndReturnVerifiedModule(kHloModule, config));
+  auto config = GetModuleConfig(kFdoProfile);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
 
-TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/16));
-auto schedule = module->schedule();
-std::vector<HloInstruction*> instruction_sequence =
- schedule.sequence(module->entry_computation()).instructions();
-// With a lot of parallel resources and default latency estimator,
-// LHS will try to extend all asyncs as much as possible.
-// We expect all computes to be wrapped within all async start-done
-// intervals.
-EXPECT_TRUE(GetIndexByName(instruction_sequence, "add_0") >
-             GetIndexByName(instruction_sequence, "ar_0") &&
-         GetIndexByName(instruction_sequence, "add_0") >
-             GetIndexByName(instruction_sequence, "rs_0") &&
-         GetIndexByName(instruction_sequence, "add_0") <
-             GetIndexByName(instruction_sequence, "ar_1") &&
-         GetIndexByName(instruction_sequence, "add_0") <
-             GetIndexByName(instruction_sequence, "rs_1"));
+  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/16));
+  auto schedule = module->schedule();
+  std::vector<HloInstruction*> instruction_sequence =
+      schedule.sequence(module->entry_computation()).instructions();
+  // With a lot of parallel resources and default latency estimator,
+  // LHS will try to extend all asyncs as much as possible.
+  // We expect all computes to be wrapped within all async start-done
+  // intervals.
+  EXPECT_TRUE(GetIndexByName(instruction_sequence, "add_0") >
+                  GetIndexByName(instruction_sequence, "ar_0") &&
+              GetIndexByName(instruction_sequence, "add_0") >
+                  GetIndexByName(instruction_sequence, "rs_0") &&
+              GetIndexByName(instruction_sequence, "add_0") <
+                  GetIndexByName(instruction_sequence, "ar_1") &&
+              GetIndexByName(instruction_sequence, "add_0") <
+                  GetIndexByName(instruction_sequence, "rs_1"));
 
-EXPECT_TRUE(GetIndexByName(instruction_sequence, "div_0") >
-             GetIndexByName(instruction_sequence, "ar_0") &&
-         GetIndexByName(instruction_sequence, "div_0") >
-             GetIndexByName(instruction_sequence, "rs_0") &&
-         GetIndexByName(instruction_sequence, "div_0") <
-             GetIndexByName(instruction_sequence, "ar_1") &&
-         GetIndexByName(instruction_sequence, "div_0") <
-             GetIndexByName(instruction_sequence, "rs_1"));
-EXPECT_TRUE(GetIndexByName(instruction_sequence, "mul_0") >
-             GetIndexByName(instruction_sequence, "ar_0") &&
-         GetIndexByName(instruction_sequence, "mul_0") >
-             GetIndexByName(instruction_sequence, "rs_0") &&
-         GetIndexByName(instruction_sequence, "mul_0") <
-             GetIndexByName(instruction_sequence, "ar_1") &&
-         GetIndexByName(instruction_sequence, "mul_0") <
-             GetIndexByName(instruction_sequence, "rs_1"));
+  EXPECT_TRUE(GetIndexByName(instruction_sequence, "div_0") >
+                  GetIndexByName(instruction_sequence, "ar_0") &&
+              GetIndexByName(instruction_sequence, "div_0") >
+                  GetIndexByName(instruction_sequence, "rs_0") &&
+              GetIndexByName(instruction_sequence, "div_0") <
+                  GetIndexByName(instruction_sequence, "ar_1") &&
+              GetIndexByName(instruction_sequence, "div_0") <
+                  GetIndexByName(instruction_sequence, "rs_1"));
+  EXPECT_TRUE(GetIndexByName(instruction_sequence, "mul_0") >
+                  GetIndexByName(instruction_sequence, "ar_0") &&
+              GetIndexByName(instruction_sequence, "mul_0") >
+                  GetIndexByName(instruction_sequence, "rs_0") &&
+              GetIndexByName(instruction_sequence, "mul_0") <
+                  GetIndexByName(instruction_sequence, "ar_1") &&
+              GetIndexByName(instruction_sequence, "mul_0") <
+                  GetIndexByName(instruction_sequence, "rs_1"));
 }
 
 }  // namespace

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1086,5 +1086,76 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, ParallelThreadsShouldBeScheduled) {
   TF_EXPECT_OK(ScheduleModule(module.get()));
 }
 
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+  MultipleParallelAsyncsExtendedOverAllComputes) {
+absl::string_view kHloModule = R"(
+HloModule m
+reduce {
+x = f32[] parameter(0)
+y = f32[] parameter(1)
+ROOT _ = f32[] add(x, y)
+}
+ENTRY main {
+p0 = f32[] parameter(0)
+p1 = f32[2] parameter(1)
+p2 = f32[2] parameter(2)
+p3 = f32[2] parameter(3)
+p4 = f32[2] parameter(4)
+p5 = f32[2] parameter(5)
+p6 = f32[2] parameter(6)
+ar_0 = f32[] all-reduce-start(p0), to_apply=reduce
+ar_1 = f32[] all-reduce-done(ar_0)
+ar_2 = f32[2] all-reduce-start(p6), to_apply=reduce
+ar_3 = f32[2] all-reduce-done(ar_2)
+rs_0 = ((f32[2]), f32[1]) reduce-scatter-start(p1), to_apply=reduce,
+dimensions={0}
+rs_1 = f32[1] reduce-scatter-done(rs_0)
+add_0 = f32[2] add(p1, p2)
+div_0 = f32[2] divide(p3, p4)
+mul_0 = f32[2] multiply(p4, p5)
+ROOT _ = (f32[], f32[2], f32[1], f32[2], f32[2], f32[2]) tuple(ar_1, ar_3, rs_1, add_0, div_0, mul_0)
+}
+)";
+absl::string_view kFdoProfile = "";
+
+auto config = GetModuleConfig(kFdoProfile);
+TF_ASSERT_OK_AND_ASSIGN(auto module,
+                     ParseAndReturnVerifiedModule(kHloModule, config));
+
+TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/16));
+auto schedule = module->schedule();
+std::vector<HloInstruction*> instruction_sequence =
+ schedule.sequence(module->entry_computation()).instructions();
+// With a lot of parallel resources and default latency estimator,
+// LHS will try to extend all asyncs as much as possible.
+// We expect all computes to be wrapped within all async start-done
+// intervals.
+EXPECT_TRUE(GetIndexByName(instruction_sequence, "add_0") >
+             GetIndexByName(instruction_sequence, "ar_0") &&
+         GetIndexByName(instruction_sequence, "add_0") >
+             GetIndexByName(instruction_sequence, "rs_0") &&
+         GetIndexByName(instruction_sequence, "add_0") <
+             GetIndexByName(instruction_sequence, "ar_1") &&
+         GetIndexByName(instruction_sequence, "add_0") <
+             GetIndexByName(instruction_sequence, "rs_1"));
+
+EXPECT_TRUE(GetIndexByName(instruction_sequence, "div_0") >
+             GetIndexByName(instruction_sequence, "ar_0") &&
+         GetIndexByName(instruction_sequence, "div_0") >
+             GetIndexByName(instruction_sequence, "rs_0") &&
+         GetIndexByName(instruction_sequence, "div_0") <
+             GetIndexByName(instruction_sequence, "ar_1") &&
+         GetIndexByName(instruction_sequence, "div_0") <
+             GetIndexByName(instruction_sequence, "rs_1"));
+EXPECT_TRUE(GetIndexByName(instruction_sequence, "mul_0") >
+             GetIndexByName(instruction_sequence, "ar_0") &&
+         GetIndexByName(instruction_sequence, "mul_0") >
+             GetIndexByName(instruction_sequence, "rs_0") &&
+         GetIndexByName(instruction_sequence, "mul_0") <
+             GetIndexByName(instruction_sequence, "ar_1") &&
+         GetIndexByName(instruction_sequence, "mul_0") <
+             GetIndexByName(instruction_sequence, "rs_1"));
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -74,6 +74,8 @@ class GpuLatencyHidingSchedulerBaseTest
     DebugOptions& options = module->mutable_config().mutable_debug_options();
     options.set_xla_gpu_experimental_parallel_collective_overlap_limit(
         num_parallel_resources);
+    options.set_xla_gpu_enable_analytical_sol_latency_estimator(false);
+
     options.set_xla_gpu_pgle_accuracy_checker(strictness);
 
     TF_RETURN_IF_ERROR(ScheduleGpuModule(module, /*pointer_size=*/8,
@@ -1105,9 +1107,13 @@ p5 = f32[2] parameter(5)
 p6 = f32[2] parameter(6)
 ar_0 = f32[] all-reduce-start(p0), to_apply=reduce
 ar_1 = f32[] all-reduce-done(ar_0)
-ar_2 = f32[2] all-reduce-start(p6), to_apply=reduce
+add_2 = f32[2] add(p1, p6)
+
+ar_2 = f32[2] all-reduce-start(add_2), to_apply=reduce
 ar_3 = f32[2] all-reduce-done(ar_2)
-rs_0 = ((f32[2]), f32[1]) reduce-scatter-start(p1), to_apply=reduce,
+add_3 = f32[2] add(p1, p3)
+
+rs_0 = ((f32[2]), f32[1]) reduce-scatter-start(add_3), to_apply=reduce,
 dimensions={0}
 rs_1 = f32[1] reduce-scatter-done(rs_0)
 add_0 = f32[2] add(p1, p2)
@@ -1130,6 +1136,15 @@ ROOT _ = (f32[], f32[2], f32[1], f32[2], f32[2], f32[2]) tuple(ar_1, ar_3, rs_1,
   // LHS will try to extend all asyncs as much as possible.
   // We expect all computes to be wrapped within all async start-done
   // intervals.
+  EXPECT_TRUE(GetIndexByName(instruction_sequence, "add_2") >
+                  GetIndexByName(instruction_sequence, "ar_0") &&
+              GetIndexByName(instruction_sequence, "add_3") >
+                  GetIndexByName(instruction_sequence, "ar_0") &&
+              GetIndexByName(instruction_sequence, "add_2") <
+                  GetIndexByName(instruction_sequence, "ar_1") &&
+              GetIndexByName(instruction_sequence, "add_3") <
+                  GetIndexByName(instruction_sequence, "ar_1"));
+
   EXPECT_TRUE(GetIndexByName(instruction_sequence, "add_0") >
                   GetIndexByName(instruction_sequence, "ar_0") &&
               GetIndexByName(instruction_sequence, "add_0") >

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -1577,6 +1577,9 @@ class ReadySetLt {
           max_it->second == 0 &&
           res_it != sched_state_.resource_users_in_queue.end() &&
           res_it->second > 0);
+      if (cand.resource_constrained) {
+        return;
+      }
     }
   }
   bool IsResourceConstrained(DefaultSchedulerCore::ScheduleCandidate& cand,

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -150,6 +150,9 @@ struct SchedulerConfig {
   bool use_real_cost_model = false;
   bool aggressive_scheduling_policies = false;
   bool prioritize_async_depth_over_stall = false;
+
+  bool prioritize_compute_over_async_start = false;
+
   bool enable_release_start_policy = false;
   bool resource_sharing = false;
   bool resource_serializing = false;

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -150,9 +150,6 @@ struct SchedulerConfig {
   bool use_real_cost_model = false;
   bool aggressive_scheduling_policies = false;
   bool prioritize_async_depth_over_stall = false;
-
-  bool prioritize_compute_over_async_start = false;
-
   bool enable_release_start_policy = false;
   bool resource_sharing = false;
   bool resource_serializing = false;


### PR DESCRIPTION
📝 Summary of Changes
This pr introduces a new heuristics to delay scheduling start based on the op type when the overlap limit is larger than 1 and default cost model is used.

🎯 Justification
The goal is to extend the overlap interval as much as possible to include more computes and provide the best out of the box scheduling.
🚀 Kind of Contribution
 ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
hlo_llama31_8b_bf16_1x8.hlo -> 1359ms -> 1318.3ms
hlo_llama31_8b_bf16_2x8.hlo -> 1366ms -> 1321.4ms
hlo_llama31_8b_fp8_1x8.hlo -> 1123ms -> 1089ms
hlo_llama31_8b_fp8_2x8.hlo -> 1141ms -> 1.95.5ms
🧪 Unit Tests:
Added unit tests

🧪 Execution Tests:
included
