### PR TITLE
Enable dynamic-(update-)slice memcpy optimization.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1267,6 +1267,7 @@ cc_library(
         "//xla:xla_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass_pipeline",
+        "//xla/service/gpu/transforms:fusion_dynamic_memcpy_rewriter",
         "//xla/service:hlo_cost_analysis",
         "//xla/service:pattern_matcher",
         "//xla/service/gpu/transforms:fusion_block_level_rewriter",

--- a/xla/service/gpu/fusion_dispatch_pipeline.cc
+++ b/xla/service/gpu/fusion_dispatch_pipeline.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/hlo/pass/hlo_pass_pipeline.h"
 #include "xla/layout_util.h"
 #include "xla/service/gpu/transforms/fusion_block_level_rewriter.h"
+#include "xla/service/gpu/transforms/fusion_dynamic_memcpy_rewriter.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/stream_executor/device_description.h"
@@ -131,6 +132,7 @@ HloPassPipeline FusionDispatchPipeline(
   HloPassPipeline pipeline("fusion-dispatch-pipeline");
   pipeline.AddPass<FusionBlockLevelRewriter>(device_description, shape_size_fn,
                                              std::move(try_rewrite_fusion_if));
+  pipeline.AddPass<FusionDynamicMemcpyRewriter>();
   return pipeline;
 }
 

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -469,7 +469,7 @@ TEST_F(GpuCopyTest, UseMemcpyIntegrationTest) {
 }
 
 TEST_F(GpuCopyTest, UseMemcpyIntegrationTestControl) {
-  // Control for  UseMemcpyIntegrationTest. Verify that without
+  // Control for UseMemcpyIntegrationTest. Verify that without
   // fusion-dynamic-memcpy-rewriter, we have a third fusion.
   HloModuleConfig config;
   DebugOptions options;

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -399,17 +399,17 @@ TEST_F(GpuCopyTest, UseMemcpyForDynamicUpdateSliceWithBitcasts) {
 
 constexpr char kSliceMemcpyModuleUnfused[] = R"(
     body {
-      p0 = (s32[], s32[4,8,100000000], s32[1,1,100000000]) parameter(0)
+      p0 = (s32[], s32[4,8,1000000], s32[1,1,1000000]) parameter(0)
       ivar = s32[] get-tuple-element(p0), index=0
-      input = s32[4,8,100000000] get-tuple-element(p0), index=1
+      input = s32[4,8,1000000] get-tuple-element(p0), index=1
 
       ivar_copy = s32[] copy(ivar)
       c1 = s32[] constant(1)
-      slice = s32[1,1,100000000] dynamic-slice(input, ivar_copy, c1, c1),
-          dynamic_slice_sizes={1,1,100000000}
+      slice = s32[1,1,1000000] dynamic-slice(input, ivar_copy, c1, c1),
+          dynamic_slice_sizes={1,1,1000000}
 
       next_ivar = s32[] add(ivar_copy, c1)
-      ROOT result = (s32[], s32[4,8,100000000], s32[1,1,100000000])
+      ROOT result = (s32[], s32[4,8,1000000], s32[1,1,1000000])
           tuple(next_ivar, input, slice)
     }
 
@@ -420,18 +420,18 @@ constexpr char kSliceMemcpyModuleUnfused[] = R"(
     }
 
     condition {
-      p0 = (s32[], s32[4,8,100000000], s32[1,1,100000000]) parameter(0)
+      p0 = (s32[], s32[4,8,1000000], s32[1,1,1000000]) parameter(0)
       ivar = s32[] get-tuple-element(p0), index=0
       c6 = s32[] constant(6)
       ROOT cmp = pred[] compare(ivar, c6), direction=LT
     }
 
     ENTRY main {
-      p0 = s32[4,8,100000000] parameter(0)
-      p1 = s32[1,1,100000000] parameter(1)
+      p0 = s32[4,8,1000000] parameter(0)
+      p1 = s32[1,1,1000000] parameter(1)
       c0 = s32[] constant(0)
-      tuple = (s32[], s32[4,8,100000000], s32[1,1,100000000]) tuple(c0, p0, p1)
-      ROOT while = (s32[], s32[4,8,100000000], s32[1,1,100000000]) while(tuple),
+      tuple = (s32[], s32[4,8,1000000], s32[1,1,1000000]) tuple(c0, p0, p1)
+      ROOT while = (s32[], s32[4,8,1000000], s32[1,1,1000000]) while(tuple),
           condition=condition, body=body
     })";
 

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -442,6 +442,10 @@ TEST_F(GpuCopyTest, UseDynamicMemcpyIntegrationTest) {
   TF_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<VerifiedHloModule> hlo_module,
       ParseAndReturnVerifiedModule(kSliceMemcpyModuleUnfused));
+  DebugOptions debug_options = hlo_module->config().debug_options();
+  debug_options.set_xla_dump_to("sponge");
+  debug_options.set_xla_dump_hlo_pass_re(".*");
+  hlo_module->mutable_config().set_debug_options(debug_options);
 
   // Check that there are exactly two fusions:
   // 1. A `compare` fusion for the loop condition.

--- a/xla/service/gpu/tests/gpu_copy_test.cc
+++ b/xla/service/gpu/tests/gpu_copy_test.cc
@@ -435,8 +435,10 @@ constexpr char kSliceMemcpyModuleUnfused[] = R"(
           condition=condition, body=body
     })";
 
-TEST_F(GpuCopyTest, UseMemcpyIntegrationTest) {
-  // This is an integration test to verify that the pipeline works as a whole.
+TEST_F(GpuCopyTest, UseDynamicMemcpyIntegrationTest) {
+  // This is an integration test to verify that the pipeline for replacing
+  // dynamic-slices that depend on while loop iteration variables with memcpy
+  // works as a whole.
   TF_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<VerifiedHloModule> hlo_module,
       ParseAndReturnVerifiedModule(kSliceMemcpyModuleUnfused));
@@ -468,8 +470,8 @@ TEST_F(GpuCopyTest, UseMemcpyIntegrationTest) {
                      /*run_optimization_passes=*/true);
 }
 
-TEST_F(GpuCopyTest, UseMemcpyIntegrationTestControl) {
-  // Control for UseMemcpyIntegrationTest. Verify that without
+TEST_F(GpuCopyTest, UseDynamicMemcpyIntegrationTestControl) {
+  // Control for UseDynamicMemcpyIntegrationTest. Verify that without
   // fusion-dynamic-memcpy-rewriter, we have a third fusion.
   HloModuleConfig config;
   DebugOptions options;


### PR DESCRIPTION
This optimization replaces dynamic-slice and dynamic-update slice fusions with
memcpy, when possible. This mainly triggers inside while loops (scans) when
using offloading with parameter streaming.

If this causes any unexpected issues, set
XLA_FLAGS=--xla_disable_hlo_passes=fusion-dynamic-memcpy-rewriter. This will
disable the optimization completely.

Keywords: DynamicMemcpyThunk, DynamicMemcpyFusion, HloEvaluator.