### PR TITLE
Support the Execute Device Kernel feature in XLA

### DIFF
--- a/xla/codegen/emitters/kernel_arguments.h
+++ b/xla/codegen/emitters/kernel_arguments.h
@@ -84,6 +84,19 @@ class KernelArguments {
       const BufferAlignment& buffer_alignment,
       const HloInstruction* hlo_instruction);
 
+  // Certain kernels require output arguments to be interleaved with input
+  // arguments. This function creates a KernelArguments object where the output
+  // arguments are interleaved with the input arguments according to the
+  // provided indices.
+  // Example: If hlo_instruction->operands() has 3 elements and hlo_instruction
+  // shape yields 2 output arguments, and interleaved_output_indices = {1, 4}:
+  // - Final argument order will be: input0, output0, input1, input2, output1
+  static absl::StatusOr<KernelArguments> Create(
+      const BufferAssignment& buffer_assignment,
+      const BufferAlignment& buffer_alignment,
+      const HloInstruction* hlo_instruction,
+      absl::Span<const int32_t> interleaved_output_indices);
+
   explicit KernelArguments(std::vector<KernelArgument>&& args)
       : args_(std::move(args)) {}
 

--- a/xla/codegen/emitters/kernel_arguments_test.cc
+++ b/xla/codegen/emitters/kernel_arguments_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "xla/hlo/analysis/alias_info.h"
 #include "xla/hlo/analysis/hlo_ordering.h"
+#include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/testlib/verified_hlo_module.h"
 #include "xla/service/buffer_assignment.h"
@@ -37,6 +38,7 @@ limitations under the License.
 namespace xla::emitters {
 namespace {
 using ::testing::ElementsAre;
+using ::testing::Property;
 using ::testing::SizeIs;
 
 using KernelArgumentsTest = HloHardwareIndependentTestBase;
@@ -92,6 +94,205 @@ TEST_F(KernelArgumentsTest, GetArgumentBufferSlices) {
                                           /*offset=*/0, kExpectedBufferSize)));
   EXPECT_THAT(kernel_arguments.GetArgumentOutputFlags(),
               ElementsAre(false, false, true));
+}
+
+TEST_F(KernelArgumentsTest, InterleavedOutputIndicesTest) {
+  const absl::string_view hlo_string = R"(
+HloModule TestModule
+
+ENTRY main {
+  param0 = f32[10] parameter(0)
+  param1 = f32[20] parameter(1)
+  param2 = f32[30] parameter(2)
+
+  ROOT tuple_result = (f32[10], f32[20]) tuple(param0, param1)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  HloInstruction* root = module->entry_computation()->root_instruction();
+
+  AliasInfo alias_info;
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<BufferAssignment> buffer_assignment,
+      BufferAssigner::Run(
+          module.get(), std::make_unique<DependencyHloOrdering>(module.get()),
+          [](const BufferValue& buffer) {
+            return ShapeUtil::ByteSizeOf(buffer.shape(), sizeof(void*));
+          },
+          &alias_info, [](LogicalBuffer::Color) { return 1; },
+          /*allocate_buffers_for_constants=*/true));
+
+  KernelArguments::BufferAlignment buffer_alignment;
+  buffer_alignment.entry_parameter_align_bytes = 1;
+  buffer_alignment.constant_buffer_align_bytes = 1;
+  buffer_alignment.xla_allocated_buffer_align_bytes = 1;
+
+  // Test 1: Create regular (non-interleaved) arguments for baseline
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelArguments regular_args,
+      KernelArguments::Create(*buffer_assignment, buffer_alignment, root, {}));
+
+  // Test 2: Create interleaved arguments
+  // Expected order: input0, output0, input1, output1
+  std::vector<int32_t> interleaved_indices = {1, 3};
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelArguments interleaved_args,
+      KernelArguments::Create(*buffer_assignment, buffer_alignment, root,
+                              interleaved_indices));
+
+  // Get buffer slices for comparison
+  auto regular_slices = regular_args.GetArgumentBufferSlices();
+  auto interleaved_slices = interleaved_args.GetArgumentBufferSlices();
+
+  // Verify sizes
+  ASSERT_EQ(regular_slices.size(), 4);      // 2 inputs + 2 outputs
+  ASSERT_EQ(interleaved_slices.size(), 4);  // same total count
+
+  // Verify interleaving worked by comparing buffer slices:
+  // Regular order:     [input0, input1, output0, output1]
+  // Interleaved order: [input0, output0, input1, output1]
+  EXPECT_THAT(interleaved_slices,
+              ElementsAre(regular_slices[0], regular_slices[2],
+                          regular_slices[1], regular_slices[3]));
+}
+
+TEST_F(KernelArgumentsTest, InterleavedOutputIndicesEdgeCases) {
+  const absl::string_view hlo_string = R"(
+HloModule TestModule
+
+ENTRY main {
+  param0 = f32[5] parameter(0)
+
+  ROOT tuple_result = (f32[5]) tuple(param0)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  HloInstruction* root = module->entry_computation()->root_instruction();
+
+  AliasInfo alias_info;
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<BufferAssignment> buffer_assignment,
+      BufferAssigner::Run(
+          module.get(), std::make_unique<DependencyHloOrdering>(module.get()),
+          &BufferSizeBytes, &alias_info, [](LogicalBuffer::Color) { return 1; },
+          /*allocate_buffers_for_constants=*/true));
+
+  KernelArguments::BufferAlignment buffer_alignment;
+  buffer_alignment.entry_parameter_align_bytes = 1;
+  buffer_alignment.constant_buffer_align_bytes = 1;
+  buffer_alignment.xla_allocated_buffer_align_bytes = 1;
+
+  // Test 1: Create regular (non-interleaved) arguments for baseline
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelArguments regular_args,
+      KernelArguments::Create(*buffer_assignment, buffer_alignment, root, {}));
+
+  // Test 2: Create interleaved arguments - output at beginning (position 0)
+  // Expected order: output0, input0 (instead of input0, output0)
+  std::vector<int32_t> interleaved_indices = {0};
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelArguments interleaved_args,
+      KernelArguments::Create(*buffer_assignment, buffer_alignment, root,
+                              interleaved_indices));
+
+  // Get buffer slices for comparison
+  auto regular_slices = regular_args.GetArgumentBufferSlices();
+  auto interleaved_slices = interleaved_args.GetArgumentBufferSlices();
+
+  // Verify sizes
+  ASSERT_EQ(regular_slices.size(), 2);      // 1 input + 1 output
+  ASSERT_EQ(interleaved_slices.size(), 2);  // same total count
+
+  // Verify interleaving worked by comparing buffer slices:
+  // Regular order:     [input0, output0]
+  // Interleaved order: [output0, input0]
+  EXPECT_THAT(interleaved_slices,
+              ElementsAre(regular_slices[1], regular_slices[0]));
+}
+
+TEST_F(KernelArgumentsTest, InterleavedOutputIndicesErrorCases) {
+  const absl::string_view hlo_string = R"(
+HloModule TestModule
+
+ENTRY main {
+  param0 = f32[5] parameter(0)
+
+  ROOT result = f32[5] add(param0, param0)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  HloInstruction* root = module->entry_computation()->root_instruction();
+
+  AliasInfo alias_info;
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<BufferAssignment> buffer_assignment,
+      BufferAssigner::Run(
+          module.get(), std::make_unique<DependencyHloOrdering>(module.get()),
+          &BufferSizeBytes, &alias_info, [](LogicalBuffer::Color) { return 1; },
+          /*allocate_buffers_for_constants=*/true));
+
+  KernelArguments::BufferAlignment buffer_alignment;
+  buffer_alignment.entry_parameter_align_bytes = 1;
+  buffer_alignment.constant_buffer_align_bytes = 1;
+  buffer_alignment.xla_allocated_buffer_align_bytes = 1;
+
+  // Test case: Output index out of bounds
+  // root->operands() = {param0, param0} (2 operands, but same parameter used
+  // twice) outputs = {result} (1 output) Total positions = 3, so index 5 is out
+  // of bounds
+  std::vector<int32_t> invalid_indices = {5};
+
+  auto result = KernelArguments::Create(*buffer_assignment, buffer_alignment,
+                                        root, invalid_indices);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              ::testing::HasSubstr("Output index out of bounds"));
+}
+
+TEST_F(KernelArgumentsTest, EmptyInterleavedIndicesFallback) {
+  const absl::string_view hlo_string = R"(
+HloModule TestModule
+
+ENTRY main {
+  param0 = f32[5] parameter(0)
+  ROOT result = f32[5] add(param0, param0)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  HloInstruction* root = module->entry_computation()->root_instruction();
+
+  AliasInfo alias_info;
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<BufferAssignment> buffer_assignment,
+      BufferAssigner::Run(
+          module.get(), std::make_unique<DependencyHloOrdering>(module.get()),
+          &BufferSizeBytes, &alias_info, [](LogicalBuffer::Color) { return 1; },
+          /*allocate_buffers_for_constants=*/true));
+
+  KernelArguments::BufferAlignment buffer_alignment;
+  buffer_alignment.entry_parameter_align_bytes = 1;
+  buffer_alignment.constant_buffer_align_bytes = 1;
+  buffer_alignment.xla_allocated_buffer_align_bytes = 1;
+
+  // Test case: Empty interleaved indices should fall back to regular Create
+  std::vector<int32_t> empty_indices = {};
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelArguments kernel_args,
+      KernelArguments::Create(*buffer_assignment, buffer_alignment, root,
+                              empty_indices));
+
+  // Should succeed and create arguments in regular order: inputs first, then
+  // outputs
+  ASSERT_EQ(kernel_args.args().size(), 3);  // 2 inputs + 1 output
 }
 
 }  // namespace

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -332,6 +332,52 @@ cc_library(
     ],
 )
 
+
+cc_library(
+    name = "ptx_custom_kernel_emitter_cuda",
+    srcs = ["custom_kernel_emitter_cuda.cc"],
+    hdrs = ["custom_kernel_emitter.h"],
+    tags = ["gpu", "cuda-only"],
+    deps = [
+        ":gpu_constants",
+        ":ir_emitter_context",
+        ":kernel_call",
+        "//xla/backends/gpu/runtime:kernel_thunk",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu/kernels:ptx_custom_kernel",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "ptx_custom_kernel_emitter_rocm",
+    srcs = ["custom_kernel_emitter_rocm.cc"],
+    hdrs = ["custom_kernel_emitter.h"],
+    tags = ["gpu", "rocm-only"],
+    deps = [
+        ":ir_emitter_context",
+        "//xla/hlo/ir:hlo",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "ptx_custom_kernel_emitter",
+    hdrs = ["custom_kernel_emitter.h"],
+    tags = ["gpu"],
+    deps = if_cuda_is_configured([
+        ":ptx_custom_kernel_emitter_cuda",
+    ]) + if_rocm_is_configured([
+        ":ptx_custom_kernel_emitter_rocm",
+    ]) + [
+        "//xla/hlo/ir:hlo",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
 cc_library(
     name = "ir_emitter_context",
     srcs = ["ir_emitter_context.cc"],
@@ -368,8 +414,10 @@ cc_library(
     deps = [
         ":backend_configs_cc",
         ":cublas_cudnn",
+        ":kernel_call",
         ":execution_stream_assignment",
         ":gpu_constants",
+        ":gpu_asm_opts_util",
         ":gpu_conv_runner",
         ":gpu_norm_runner",
         ":hlo_fusion_analysis",
@@ -453,6 +501,7 @@ cc_library(
         "//xla/service:name_uniquer",
         "//xla/service:platform_util",
         "//xla/service/gpu/kernels:custom_kernel",
+        ":ptx_custom_kernel_emitter",
         "//xla/service/gpu/model:block_level_parameters",
         "//xla/service/llvm_ir:buffer_assignment_util",
         "//xla/service/llvm_ir:ir_array",
@@ -502,7 +551,9 @@ cc_library(
         "@tsl//tsl/platform",
         "@tsl//tsl/platform:casts",
         "@tsl//tsl/platform:human_readable_json",
-    ],
+    ] + if_cuda_is_configured([
+        "//xla/service/gpu/kernels:ptx_custom_kernel",
+    ]),
 )
 
 cc_library(
@@ -545,6 +596,30 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
+    name = "kernel_call",
+    srcs = ["kernel_call.cc"],
+    hdrs = ["kernel_call.h"],
+    deps = [
+        ":launch_dimensions",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Parser",
+    ],
+)
+
+xla_cc_test(
+    name = "kernel_call_test",
+    srcs = ["kernel_call_test.cc"],
+    deps = [
+        ":kernel_call",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_googletest//:gtest",
+        "@llvm-project//mlir:IR",
     ],
 )
 

--- a/xla/service/gpu/custom_kernel_emitter.h
+++ b/xla/service/gpu/custom_kernel_emitter.h
@@ -1,0 +1,42 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_CUSTOM_KERNEL_EMITTER_H_
+#define XLA_SERVICE_GPU_CUSTOM_KERNEL_EMITTER_H_
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+
+namespace xla {
+
+// Forward declaration to avoid heavy includes.
+class HloCustomCallInstruction;
+
+namespace gpu {
+
+class Thunk;
+class IrEmitterContext;
+
+// Emit a platform-specific custom kernel thunk for PTX custom calls.
+// This function has separate implementations for CUDA and ROCm backends,
+// selected at build time via conditional compilation in BUILD rules.
+absl::StatusOr<std::unique_ptr<Thunk>> EmitPtxCustomKernelThunk(
+    const HloCustomCallInstruction* instr, IrEmitterContext* context);
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_CUSTOM_KERNEL_EMITTER_H_

--- a/xla/service/gpu/custom_kernel_emitter_cuda.cc
+++ b/xla/service/gpu/custom_kernel_emitter_cuda.cc
@@ -1,0 +1,69 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/custom_kernel_emitter.h"
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/runtime/kernel_thunk.h"
+#include "xla/codegen/emitters/kernel_arguments.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/gpu_constants.h"
+#include "xla/service/gpu/ir_emitter_context.h"
+#include "xla/service/gpu/kernel_call.h"
+#include "xla/service/gpu/kernels/ptx_custom_kernel.h"
+
+namespace xla {
+namespace gpu {
+
+absl::StatusOr<std::unique_ptr<Thunk>> EmitPtxCustomKernelThunk(
+    const HloCustomCallInstruction* instr, IrEmitterContext* context) {
+  absl::string_view backend_config_str = instr->raw_backend_config_string();
+  if (backend_config_str.empty()) {
+    return absl::InvalidArgumentError(
+        "PTX custom call backend config is empty");
+  }
+
+  TF_ASSIGN_OR_RETURN(
+      KernelCall call,
+      KernelCall::Parse(backend_config_str, context->mlir_context()));
+  if (call.kernel_type != KernelCall::KernelType::kPtxSource) {
+    return absl::InvalidArgumentError(
+        "PTX custom call backend config is not a PTX source");
+  }
+
+  emitters::KernelArguments::BufferAlignment buffer_alignment =
+      GetDefaultBufferAlignment();
+  TF_ASSIGN_OR_RETURN(emitters::KernelArguments kernel_arguments,
+                      emitters::KernelArguments::Create(
+                          context->buffer_assignment(), buffer_alignment, instr,
+                          call.output_indices));
+
+  TF_ASSIGN_OR_RETURN(
+      CustomKernel ptx_custom_kernel,
+      kernel::GetOwnedPtxCustomKernel(
+          call.name, call.kernel_data, kernel_arguments.args().size(),
+          call.block_dim, call.thread_dim, call.shared_mem));
+
+  std::unique_ptr<Thunk> thunk = std::make_unique<CustomKernelThunk>(
+      instr, ptx_custom_kernel, kernel_arguments, context->GetNextThunkId());
+  return thunk;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/custom_kernel_emitter_rocm.cc
+++ b/xla/service/gpu/custom_kernel_emitter_rocm.cc
@@ -1,0 +1,35 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/custom_kernel_emitter.h"
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/ir_emitter_context.h"
+
+namespace xla {
+namespace gpu {
+
+absl::StatusOr<std::unique_ptr<Thunk>> EmitPtxCustomKernelThunk(
+    const HloCustomCallInstruction* instr, IrEmitterContext* /*context*/) {
+  return absl::UnimplementedError(
+      "ROCm custom kernel emitter is not yet implemented for PTX custom calls");
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -146,6 +146,11 @@ bool IsCustomCallToTopK(const HloInstruction& hlo) {
          hlo.custom_call_target() == kTopKCustomCallTarget;
 }
 
+bool IsCustomCallToPtxKernel(const HloInstruction& hlo) {
+  return hlo.opcode() == HloOpcode::kCustomCall &&
+         hlo.custom_call_target() == "__gpu$xla.gpu.ptx";
+}
+
 static bool IsContiguousSlice(
     const Shape& orig, const Shape& sliced,
     std::optional<absl::Span<const int64_t>> slice_strides) {

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -155,6 +155,10 @@ bool IsCustomCallToCusolver(const HloInstruction& hlo);
 // Returns true if `hlo` will be implemented as a call to a TopK routine.
 bool IsCustomCallToTopK(const HloInstruction& hlo);
 
+// Returns true if `hlo` will be implmented as a call to a custom PTX kernel
+// implementation.
+bool IsCustomCallToPtxKernel(const HloInstruction& hlo);
+
 // Cholesky decomposition. Takes a (batched) matrix as input, and returns a
 // tuple of (result, workspace, info), where result is the result of the
 // Cholesky decomposition, workspace is scratch space for cuSolver, and info

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -154,11 +154,14 @@ limitations under the License.
 #include "xla/service/gpu/ir_emitter_context.h"
 #include "xla/service/gpu/ir_emitter_nested.h"
 #include "xla/service/gpu/kernel_reuse_cache.h"
+#include "xla/service/gpu/custom_kernel_emitter.h"
 #include "xla/service/gpu/kernels/custom_kernel.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/service/gpu/matmul_utils.h"
 #include "xla/service/gpu/model/block_level_parameters.h"
 #include "xla/service/gpu/parallel_loop_emitter.h"
+#include "xla/service/gpu/gpu_asm_opts_util.h"
+#include "xla/service/gpu/kernel_call.h"
 #include "xla/service/gpu/stream_executor_util.h"
 #include "xla/service/gpu/triton_call.h"
 #include "xla/service/llvm_ir/buffer_assignment_util.h"
@@ -174,6 +177,7 @@ limitations under the License.
 #include "xla/status_macros.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/gpu_asm_opts.h"
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
 #include "xla/stream_executor/gpu/tma_metadata.h"
 #include "xla/stream_executor/gpu_solver_context.h"
@@ -1033,6 +1037,14 @@ absl::Status IrEmitterUnnested::EmitCuDnnThunk(
           instr, ir_emitter_context_->GetNextThunkId()),
       kernel_arguments.GetArgumentBufferSlices(),
       kernel_arguments.GetArgumentOutputFlags(), dropout_seed));
+  return absl::OkStatus();
+}
+
+absl::Status IrEmitterUnnested::EmitPtxCustomCall(
+    const HloCustomCallInstruction* instr) {
+  TF_ASSIGN_OR_RETURN(auto thunk,
+                      EmitPtxCustomKernelThunk(instr, ir_emitter_context_));
+  AddThunkToThunkSequence(std::move(thunk));
   return absl::OkStatus();
 }
 
@@ -3348,6 +3360,9 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       if (IsCustomCallTofMHA(*instr) || IsCustomCallTofMHAF8(*instr) ||
           IsCustomCallToBlockScaledDot(*instr)) {
         return EmitCuDnnThunk(custom_call);
+      }
+      if (IsCustomCallToPtxKernel(*instr)) {
+        return EmitPtxCustomCall(custom_call);
       }
       if (IsCustomCallToTopK(*instr)) {
         return EmitTopKCustomCall(custom_call);

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -124,6 +124,7 @@ class IrEmitterUnnested : public IrEmitter {
       const HloCustomCallInstruction* instr);
   absl::Status EmitNormThunk(const HloCustomCallInstruction* instr);
   absl::Status EmitCuDnnThunk(const HloCustomCallInstruction* instr);
+  absl::Status EmitPtxCustomCall(const HloCustomCallInstruction* instr);
   absl::Status EmitCubDeviceRadixSort(const HloCustomCallInstruction* instr);
   absl::Status EmitCholeskyThunk(const HloInstruction* instr);
   absl::Status EmitCustomCallThunk(const HloCustomCallInstruction* instr);

--- a/xla/service/gpu/kernel_call.cc
+++ b/xla/service/gpu/kernel_call.cc
@@ -1,0 +1,131 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/kernel_call.h"
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "mlir/AsmParser/AsmParser.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Support/LLVM.h"
+#include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace xla::gpu {
+
+// Helper function to parse kernel type string into enum
+absl::StatusOr<KernelCall::KernelType> ParseKernelType(
+    const std::string& kernel_type_str) {
+  if (kernel_type_str == "ptx") {
+    return KernelCall::KernelType::kPtxSource;
+  } else if (kernel_type_str == "cubin") {
+    return KernelCall::KernelType::kCudaBinary;
+  } else {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Unknown kernel type: ", kernel_type_str,
+                     ". Supported types: 'ptx', 'cubin'"));
+  }
+}
+
+absl::StatusOr<KernelCall> KernelCall::Parse(absl::string_view backend_config,
+                                             mlir::MLIRContext* mlir_context) {
+  auto attrs = mlir::cast<mlir::DictionaryAttr>(
+      mlir::parseAttribute(backend_config, mlir_context));
+
+  // Check for required "name" field
+  auto name_attr = attrs.getAs<mlir::StringAttr>("name");
+  if (!name_attr) {
+    return absl::InvalidArgumentError(
+        "Missing required field 'name' in backend_config");
+  }
+  auto name = name_attr.getValue().str();
+
+  // Check for required "kernel_type" field
+  auto kernel_type_attr = attrs.getAs<mlir::StringAttr>("kernel_type");
+  if (!kernel_type_attr) {
+    return absl::InvalidArgumentError(
+        "Missing required field 'kernel_type' in backend_config");
+  }
+  auto kernel_type_str = kernel_type_attr.getValue().str();
+  TF_ASSIGN_OR_RETURN(KernelCall::KernelType kernel_type,
+                      ParseKernelType(kernel_type_str));
+
+  // Check for required "kernel_data" field
+  auto kernel_data_attr = attrs.getAs<mlir::StringAttr>("kernel_data");
+  if (!kernel_data_attr) {
+    return absl::InvalidArgumentError(
+        "Missing required field 'kernel_data' in backend_config");
+  }
+  auto kernel_data = kernel_data_attr.getValue().str();
+
+  VLOG(2) << "Kernel Call backend_config:";
+  for (const auto& namedAttr : attrs) {
+    std::string value_str;
+    llvm::raw_string_ostream os(value_str);
+    namedAttr.getValue().print(os);
+    VLOG(2) << "  " << namedAttr.getName().str() << ": " << value_str;
+  }
+
+  auto get_int32_attr =
+      [&attrs](const char* attr_name) -> absl::StatusOr<int32_t> {
+    auto attr = attrs.getAs<mlir::IntegerAttr>(attr_name);
+    if (!attr) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Missing required field '", attr_name, "' in backend_config"));
+    }
+    return static_cast<int32_t>(attr.getValue().getSExtValue());
+  };
+
+  TF_ASSIGN_OR_RETURN(int32_t grid_x, get_int32_attr("grid_x"));
+  TF_ASSIGN_OR_RETURN(int32_t grid_y, get_int32_attr("grid_y"));
+  TF_ASSIGN_OR_RETURN(int32_t grid_z, get_int32_attr("grid_z"));
+  TF_ASSIGN_OR_RETURN(int32_t block_x, get_int32_attr("block_x"));
+  TF_ASSIGN_OR_RETURN(int32_t block_y, get_int32_attr("block_y"));
+  TF_ASSIGN_OR_RETURN(int32_t block_z, get_int32_attr("block_z"));
+  TF_ASSIGN_OR_RETURN(int32_t shared_mem, get_int32_attr("shared_mem_bytes"));
+
+  // Optional output_indices field
+  mlir::ArrayAttr output_indices =
+      attrs.getAs<mlir::ArrayAttr>("output_indices");
+  std::vector<int32_t> output_indices_vec;
+  if (output_indices) {
+    for (const mlir::Attribute& index : output_indices) {
+      auto int_attr = mlir::dyn_cast<mlir::IntegerAttr>(index);
+      if (!int_attr) {
+        return absl::InvalidArgumentError(
+            "Invalid output_indices: all elements must be integers");
+      }
+      output_indices_vec.push_back(int_attr.getValue().getSExtValue());
+    }
+  }
+
+  stream_executor::BlockDim block_dim(grid_x, grid_y, grid_z);
+  stream_executor::ThreadDim thread_dim(block_x, block_y, block_z);
+
+  return KernelCall{std::move(name),   std::move(kernel_data),
+                    kernel_type,       block_dim,
+                    thread_dim,        static_cast<size_t>(shared_mem),
+                    output_indices_vec};
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/kernel_call.h
+++ b/xla/service/gpu/kernel_call.h
@@ -1,0 +1,50 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_KERNEL_CALL_H_
+#define XLA_SERVICE_GPU_KERNEL_CALL_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "mlir/IR/MLIRContext.h"
+#include "xla/stream_executor/launch_dim.h"
+
+namespace xla::gpu {
+
+struct KernelCall {
+  std::string name;
+  std::string kernel_data;
+  enum class KernelType {
+    kPtxSource,
+    kCudaBinary,
+  } kernel_type;
+
+  stream_executor::BlockDim block_dim;
+  stream_executor::ThreadDim thread_dim;
+  size_t shared_mem;
+  std::vector<int32_t> output_indices;
+
+  // Parse the metadata of a __gpu$xla.gpu.ptx call.
+  static absl::StatusOr<KernelCall> Parse(absl::string_view backend_config,
+                                          mlir::MLIRContext* mlir_context);
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_KERNEL_CALL_H_

--- a/xla/service/gpu/kernel_call_test.cc
+++ b/xla/service/gpu/kernel_call_test.cc
@@ -1,0 +1,245 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/kernel_call.h"
+
+#include <gtest/gtest.h>
+#include "mlir/IR/MLIRContext.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace xla::gpu {
+namespace {
+
+class KernelCallTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mlir_context_ = std::make_unique<mlir::MLIRContext>();
+  }
+
+  std::unique_ptr<mlir::MLIRContext> mlir_context_;
+};
+
+TEST_F(KernelCallTest, ParseBasicConfiguration) {
+  const char* backend_config = R"({
+    name = "test_kernel",
+    kernel_type = "ptx",
+    kernel_data = ".version 7.0\n.target sm_70\n.entry test_kernel() { ret; }",
+    grid_x = 1,
+    grid_y = 2,
+    grid_z = 3,
+    block_x = 4,
+    block_y = 5,
+    block_z = 6,
+    shared_mem_bytes = 1024
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelCall kernel_call,
+      KernelCall::Parse(backend_config, mlir_context_.get()));
+
+  EXPECT_EQ(kernel_call.name, "test_kernel");
+  EXPECT_EQ(kernel_call.kernel_data,
+            ".version 7.0\n.target sm_70\n.entry test_kernel() { ret; }");
+  EXPECT_EQ(kernel_call.block_dim.x, 1);
+  EXPECT_EQ(kernel_call.block_dim.y, 2);
+  EXPECT_EQ(kernel_call.block_dim.z, 3);
+  EXPECT_EQ(kernel_call.thread_dim.x, 4);
+  EXPECT_EQ(kernel_call.thread_dim.y, 5);
+  EXPECT_EQ(kernel_call.thread_dim.z, 6);
+  EXPECT_EQ(kernel_call.shared_mem, 1024);
+  EXPECT_TRUE(kernel_call.output_indices.empty());
+}
+
+TEST_F(KernelCallTest, ParseWithOutputIndices) {
+  const char* backend_config = R"({
+    name = "kernel_with_outputs",
+    kernel_type = "ptx",
+    kernel_data = ".version 7.0\n.target sm_70\n.entry kernel_with_outputs() { ret; }",
+    grid_x = 10,
+    grid_y = 20,
+    grid_z = 1,
+    block_x = 32,
+    block_y = 1,
+    block_z = 1,
+    shared_mem_bytes = 0,
+    output_indices = [1, 3, 5]
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelCall kernel_call,
+      KernelCall::Parse(backend_config, mlir_context_.get()));
+
+  EXPECT_EQ(kernel_call.name, "kernel_with_outputs");
+  EXPECT_EQ(kernel_call.block_dim.x, 10);
+  EXPECT_EQ(kernel_call.block_dim.y, 20);
+  EXPECT_EQ(kernel_call.block_dim.z, 1);
+  EXPECT_EQ(kernel_call.thread_dim.x, 32);
+  EXPECT_EQ(kernel_call.thread_dim.y, 1);
+  EXPECT_EQ(kernel_call.thread_dim.z, 1);
+  EXPECT_EQ(kernel_call.shared_mem, 0);
+
+  ASSERT_EQ(kernel_call.output_indices.size(), 3);
+  EXPECT_EQ(kernel_call.output_indices[0], 1);
+  EXPECT_EQ(kernel_call.output_indices[1], 3);
+  EXPECT_EQ(kernel_call.output_indices[2], 5);
+}
+
+TEST_F(KernelCallTest, ParseMinimalConfiguration) {
+  const char* backend_config = R"({
+    name = "minimal_kernel",
+    kernel_type = "ptx",
+    kernel_data = ".entry minimal_kernel() { ret; }",
+    grid_x = 1,
+    grid_y = 1,
+    grid_z = 1,
+    block_x = 1,
+    block_y = 1,
+    block_z = 1,
+    shared_mem_bytes = 0
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelCall kernel_call,
+      KernelCall::Parse(backend_config, mlir_context_.get()));
+
+  EXPECT_EQ(kernel_call.name, "minimal_kernel");
+  EXPECT_EQ(kernel_call.kernel_data, ".entry minimal_kernel() { ret; }");
+  EXPECT_EQ(kernel_call.block_dim.x, 1);
+  EXPECT_EQ(kernel_call.block_dim.y, 1);
+  EXPECT_EQ(kernel_call.block_dim.z, 1);
+  EXPECT_EQ(kernel_call.thread_dim.x, 1);
+  EXPECT_EQ(kernel_call.thread_dim.y, 1);
+  EXPECT_EQ(kernel_call.thread_dim.z, 1);
+  EXPECT_EQ(kernel_call.shared_mem, 0);
+  EXPECT_TRUE(kernel_call.output_indices.empty());
+}
+
+TEST_F(KernelCallTest, ParseLargeDimensions) {
+  const char* backend_config = R"({
+    name = "large_kernel",
+    kernel_type = "ptx",
+    kernel_data = ".entry large_kernel() { ret; }",
+    grid_x = 65535,
+    grid_y = 65535,
+    grid_z = 65535,
+    block_x = 1024,
+    block_y = 1024,
+    block_z = 64,
+    shared_mem_bytes = 49152
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelCall kernel_call,
+      KernelCall::Parse(backend_config, mlir_context_.get()));
+
+  EXPECT_EQ(kernel_call.name, "large_kernel");
+  EXPECT_EQ(kernel_call.block_dim.x, 65535);
+  EXPECT_EQ(kernel_call.block_dim.y, 65535);
+  EXPECT_EQ(kernel_call.block_dim.z, 65535);
+  EXPECT_EQ(kernel_call.thread_dim.x, 1024);
+  EXPECT_EQ(kernel_call.thread_dim.y, 1024);
+  EXPECT_EQ(kernel_call.thread_dim.z, 64);
+  EXPECT_EQ(kernel_call.shared_mem, 49152);
+}
+
+TEST_F(KernelCallTest, ParseEmptyOutputIndices) {
+  const char* backend_config = R"({
+    name = "no_outputs",
+    kernel_type = "ptx",
+    kernel_data = ".entry no_outputs() { ret; }",
+    grid_x = 1,
+    grid_y = 1,
+    grid_z = 1,
+    block_x = 32,
+    block_y = 1,
+    block_z = 1,
+    shared_mem_bytes = 512,
+    output_indices = []
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelCall kernel_call,
+      KernelCall::Parse(backend_config, mlir_context_.get()));
+
+  EXPECT_EQ(kernel_call.name, "no_outputs");
+  EXPECT_EQ(kernel_call.shared_mem, 512);
+  EXPECT_TRUE(kernel_call.output_indices.empty());
+}
+
+TEST_F(KernelCallTest, ParseSingleOutputIndex) {
+  const char* backend_config = R"({
+    name = "single_output",
+    kernel_type = "ptx",
+    kernel_data = ".entry single_output() { ret; }",
+    grid_x = 2,
+    grid_y = 1,
+    grid_z = 1,
+    block_x = 64,
+    block_y = 1,
+    block_z = 1,
+    shared_mem_bytes = 256,
+    output_indices = [0]
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelCall kernel_call,
+      KernelCall::Parse(backend_config, mlir_context_.get()));
+
+  EXPECT_EQ(kernel_call.name, "single_output");
+  EXPECT_EQ(kernel_call.shared_mem, 256);
+  ASSERT_EQ(kernel_call.output_indices.size(), 1);
+  EXPECT_EQ(kernel_call.output_indices[0], 0);
+}
+
+TEST_F(KernelCallTest, ParseComplexkernel_data) {
+  const char* backend_config = R"({
+    name = "complex_kernel",
+    kernel_type = "ptx",
+    kernel_data = ".version 7.5\n.target sm_80\n.address_size 64\n\n.entry complex_kernel(.param .u64 ptr) {\n  .reg .u64 %r1;\n  ld.param.u64 %r1, [ptr];\n  ret;\n}",
+    grid_x = 100,
+    grid_y = 50,
+    grid_z = 1,
+    block_x = 256,
+    block_y = 1,
+    block_z = 1,
+    shared_mem_bytes = 8192,
+    output_indices = [2, 4, 6, 8]
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      KernelCall kernel_call,
+      KernelCall::Parse(backend_config, mlir_context_.get()));
+
+  EXPECT_EQ(kernel_call.name, "complex_kernel");
+  EXPECT_TRUE(kernel_call.kernel_data.find(".version 7.5") !=
+              std::string::npos);
+  EXPECT_TRUE(kernel_call.kernel_data.find(".target sm_80") !=
+              std::string::npos);
+  EXPECT_TRUE(kernel_call.kernel_data.find("complex_kernel") !=
+              std::string::npos);
+  EXPECT_EQ(kernel_call.block_dim.x, 100);
+  EXPECT_EQ(kernel_call.block_dim.y, 50);
+  EXPECT_EQ(kernel_call.thread_dim.x, 256);
+  EXPECT_EQ(kernel_call.shared_mem, 8192);
+
+  ASSERT_EQ(kernel_call.output_indices.size(), 4);
+  EXPECT_EQ(kernel_call.output_indices[0], 2);
+  EXPECT_EQ(kernel_call.output_indices[1], 4);
+  EXPECT_EQ(kernel_call.output_indices[2], 6);
+  EXPECT_EQ(kernel_call.output_indices[3], 8);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/gpu/kernels/BUILD
+++ b/xla/service/gpu/kernels/BUILD
@@ -375,6 +375,7 @@ cc_library(
         "cuda-only",
         "gpu",
     ],
+    visibility = [":friends"],
     deps = [
         ":custom_kernel",
         "//xla/stream_executor:device_memory",

--- a/xla/service/gpu/kernels/ptx_custom_kernel.cc
+++ b/xla/service/gpu/kernels/ptx_custom_kernel.cc
@@ -33,8 +33,8 @@ namespace xla::gpu::kernel {
 namespace se = ::stream_executor;
 
 absl::StatusOr<std::unique_ptr<se::KernelArgsPackedArrayBase>>
-KernelArgsPacking(const se::Kernel &kernel, const se::KernelArgs &args) {
-  auto *mem_args = se::Cast<se::KernelArgsDeviceMemoryArray>(&args);
+KernelArgsPacking(const se::Kernel& kernel, const se::KernelArgs& args) {
+  auto* mem_args = se::Cast<se::KernelArgsDeviceMemoryArray>(&args);
 
   return se::PackKernelArgs<se::DeviceMemoryBase>(
       mem_args->device_memory_args(), mem_args->number_of_shared_bytes());
@@ -66,6 +66,18 @@ absl::StatusOr<CustomKernel> GetPtxCustomKernel(
           ptx, kernel_name, /*arity=*/num_args, KernelArgsPacking);
   return CustomKernel(std::move(kernel_name), kernel_spec, block_dim,
                       thread_dim, cluster_dim,
+                      /*shared_memory_bytes=*/shared_memory_bytes);
+};
+
+absl::StatusOr<CustomKernel> GetOwnedPtxCustomKernel(
+    std::string kernel_name, std::string ptx, int num_args,
+    se::BlockDim block_dim, se::ThreadDim thread_dim,
+    size_t shared_memory_bytes) {
+  se::KernelLoaderSpec kernel_spec =
+      se::KernelLoaderSpec::CreateOwningCudaPtxInMemorySpec(
+          ptx, kernel_name, /*arity=*/num_args, KernelArgsPacking);
+  return CustomKernel(std::move(kernel_name), kernel_spec, block_dim,
+                      thread_dim,
                       /*shared_memory_bytes=*/shared_memory_bytes);
 };
 

--- a/xla/service/gpu/kernels/ptx_custom_kernel.h
+++ b/xla/service/gpu/kernels/ptx_custom_kernel.h
@@ -37,6 +37,11 @@ absl::StatusOr<CustomKernel> GetPtxCustomKernel(
     std::string kernel_name, absl::string_view ptx, int num_args,
     se::BlockDim block_dim, se::ThreadDim thread_dim,
     se::ClusterDim cluster_dim, size_t shared_memory_bytes = 0);
-}  // namespace xla::gpu::kernel
 
+absl::StatusOr<CustomKernel> GetOwnedPtxCustomKernel(
+    std::string kernel_name, std::string ptx, int num_args,
+    se::BlockDim block_dim, se::ThreadDim thread_dim,
+    size_t shared_memory_bytes = 0);
+
+}  // namespace xla::gpu::kernel
 #endif  // XLA_SERVICE_GPU_KERNELS_PTX_CUSTOM_KERNEL_H_

--- a/xla/service/gpu/kernels/ptx_custom_kernel_test.cc
+++ b/xla/service/gpu/kernels/ptx_custom_kernel_test.cc
@@ -155,4 +155,81 @@ TEST(PtxCustomKernelTest, GetPtxCustomKernelWithClusterDim) {
             "AddI32 grid: [4, 1, 1] threads: [1, 1, 1] cluster: [2, 1, 1] "
             "shared_memory: 16 bytes");
 }
+
+TEST(PtxCustomKernelTest, GetOwnedPtxCustomKernel) {
+  std::string kAddI32KernelPtx = R"(
+.version 4.0
+.target sm_50
+.address_size 64
+
+.visible .entry AddI32(
+        .param .u64 AddI32_param_0,
+        .param .u64 AddI32_param_1,
+        .param .u64 AddI32_param_2
+)
+{
+        .reg .b32       %r<8>;
+        .reg .b64       %rd<11>;
+        .loc    1 1 0
+
+        ld.param.u64    %rd1, [AddI32_param_0];
+        ld.param.u64    %rd2, [AddI32_param_1];
+        ld.param.u64    %rd3, [AddI32_param_2];
+        .loc    1 3 3
+        cvta.to.global.u64      %rd4, %rd3;
+        cvta.to.global.u64      %rd5, %rd2;
+        cvta.to.global.u64      %rd6, %rd1;
+        mov.u32         %r1, %tid.x;
+        mov.u32         %r2, %ctaid.x;
+        mov.u32         %r3, %ntid.x;
+        mad.lo.s32      %r4, %r2, %r3, %r1;
+        .loc    1 4 3
+        mul.wide.s32    %rd7, %r4, 4;
+        add.s64         %rd8, %rd6, %rd7;
+        ld.global.u32   %r5, [%rd8];
+        add.s64         %rd9, %rd5, %rd7;
+        ld.global.u32   %r6, [%rd9];
+        add.s32         %r7, %r6, %r5;
+        add.s64         %rd10, %rd4, %rd7;
+        st.global.u32   [%rd10], %r7;
+        .loc    1 5 1
+        ret;
+
+})";
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+  se::gpu::CudaPlatform platform;
+  TF_ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor,
+                          platform.ExecutorForDevice(0));
+  TF_ASSERT_OK_AND_ASSIGN(
+      CustomKernel custom_kernel,
+      GetOwnedPtxCustomKernel("AddI32", kAddI32KernelPtx, 3, se::BlockDim(4),
+                              se::ThreadDim(1), byte_length));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Kernel> kernel,
+                          executor->LoadKernel(custom_kernel.kernel_spec()));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Stream> stream,
+                          executor->CreateStream());
+  se::DeviceMemory<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
+  se::DeviceMemory<int32_t> b = executor->AllocateArray<int32_t>(length, 0);
+  se::DeviceMemory<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
+  TF_CHECK_OK(stream->Memset32(&a, 1, byte_length));
+  TF_CHECK_OK(stream->Memset32(&b, 2, byte_length));
+  TF_CHECK_OK(stream->MemZero(&c, byte_length));
+
+  se::KernelArgsDeviceMemoryArray args(
+      std::vector<se::DeviceMemoryBase>({a, b, c}),
+      custom_kernel.shared_memory_bytes());
+  TF_CHECK_OK(kernel->Launch(custom_kernel.thread_dims(),
+                             custom_kernel.block_dims(), stream.get(), args));
+
+  TF_CHECK_OK(stream->BlockHostUntilDone());
+
+  std::vector<int32_t> dst(4, 42);
+  TF_CHECK_OK(stream->Memcpy(dst.data(), c, byte_length));
+
+  std::vector<int32_t> expected = {3, 3, 3, 3};
+  ASSERT_EQ(dst, expected);
+}
 }  // namespace xla::gpu::kernel

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -984,3 +984,24 @@ xla_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+xla_test(
+    name = "ptx_kernel_test",
+    srcs = ["ptx_kernel_test.cc"],
+    backends = ["gpu"],
+    tags = [
+        "test_migrated_to_hlo_runner_pjrt",
+        "cuda-only",
+    ],
+    deps = [
+        "//xla/backends/gpu/runtime:kernel_thunk",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:buffer_assignment",
+        "//xla/service/gpu:buffer_allocations",
+        "//xla/service/gpu:launch_dimensions",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:hlo_pjrt_test_base",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_absl//absl/strings",
+    ],
+)

--- a/xla/service/gpu/tests/ptx_kernel_test.cc
+++ b/xla/service/gpu/tests/ptx_kernel_test.cc
@@ -1,0 +1,150 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/service/buffer_assignment.h"
+#include "xla/service/gpu/buffer_allocations.h"
+#include "xla/service/service_executable_run_options.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/tests/hlo_pjrt_test_base.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class PtxKernelE2ETest : public HloPjRtTestBase {};
+
+TEST_F(PtxKernelE2ETest, ScalarAdd) {
+  constexpr char kModuleStr[] = R"(
+    HloModule ptx_test
+    
+    ENTRY main {
+      a = f32[] constant(3.0)
+      b = f32[] constant(4.0)
+      ROOT out = f32[] custom-call(a, b), 
+        custom_call_target="__gpu$xla.gpu.ptx",
+        backend_config="{
+          name = \"add_kernel\",
+          kernel_type = \"ptx\",
+          kernel_data = \".version 7.0\\n.target sm_70\\n.address_size 64\\n\\n.visible .entry add_kernel(\\n    .param .u64 input_a,\\n    .param .u64 input_b,\\n    .param .u64 output)\\n{\\n  .reg .f32 a, b, c;\\n  .reg .u64 addr_a, addr_b, addr_out;\\n  \\n  ld.param.u64 addr_a, [input_a];\\n  ld.param.u64 addr_b, [input_b];\\n  ld.param.u64 addr_out, [output];\\n  \\n  ld.global.f32 a, [addr_a];\\n  ld.global.f32 b, [addr_b];\\n  add.f32 c, a, b;\\n  st.global.f32 [addr_out], c;\\n  \\n  ret;\\n}\",
+          grid_x = 1, grid_y = 1, grid_z = 1,
+          block_x = 1, block_y = 1, block_z = 1,
+          shared_mem_bytes = 0,
+          output_indices = [2]
+        }"
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Execute(std::move(module), {}));
+  EXPECT_EQ(result.Get<float>({}), 7.0f);
+}
+
+TEST_F(PtxKernelE2ETest, TensorAdd) {
+  constexpr char kModuleStr[] = R"(
+    HloModule ptx_tensor_test
+    
+    ENTRY main {
+      a = f32[4] constant({1.0, 2.0, 3.0, 4.0})
+      b = f32[4] constant({5.0, 6.0, 7.0, 8.0})
+      ROOT out = f32[4] custom-call(a, b), 
+        custom_call_target="__gpu$xla.gpu.ptx",
+        backend_config="{
+          name = \"tensor_add_kernel\",
+          kernel_type = \"ptx\",
+          kernel_data = \".version 7.0\\n.target sm_70\\n.address_size 64\\n\\n.visible .entry tensor_add_kernel(\\n    .param .u64 input_a,\\n    .param .u64 input_b,\\n    .param .u64 output)\\n{\\n  // Get base pointers\\n  .reg .u64 a_base, b_base, out_base;\\n  ld.param.u64 a_base, [input_a];\\n  ld.param.u64 b_base, [input_b];\\n  ld.param.u64 out_base, [output];\\n  \\n  // Thread ID calculation - just use thread ID directly for this simple case\\n  .reg .u32 tid;\\n  mov.u32 tid, %tid.x;\\n  \\n  // Hard-coded array size = 4\\n  .reg .pred p;\\n  setp.ge.u32 p, tid, 4;\\n  @p bra done;\\n  \\n  // Calculate byte offset (4 bytes per float)\\n  .reg .u64 offset;\\n  cvt.u64.u32 offset, tid;  // Convert tid to 64-bit\\n  mul.lo.u64 offset, offset, 4;  // Each float is 4 bytes\\n  \\n  // Calculate element addresses\\n  .reg .u64 a_addr, b_addr, out_addr;\\n  add.u64 a_addr, a_base, offset;\\n  add.u64 b_addr, b_base, offset;\\n  add.u64 out_addr, out_base, offset;\\n  \\n  // Load input values\\n  .reg .f32 a_val, b_val, result;\\n  ld.global.f32 a_val, [a_addr];\\n  ld.global.f32 b_val, [b_addr];\\n  \\n  // Perform addition\\n  add.f32 result, a_val, b_val;\\n  \\n  // Store result\\n  st.global.f32 [out_addr], result;\\n  \\ndone:\\n  ret;\\n}\",
+          grid_x = 1, grid_y = 1, grid_z = 1,
+          block_x = 4, block_y = 1, block_z = 1,
+          shared_mem_bytes = 0,
+          output_indices = [2]
+        }"
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Execute(std::move(module), {}));
+
+  EXPECT_EQ(result.Get<float>({0}), 6.0f);
+  EXPECT_EQ(result.Get<float>({1}), 8.0f);
+  EXPECT_EQ(result.Get<float>({2}), 10.0f);
+  EXPECT_EQ(result.Get<float>({3}), 12.0f);
+}
+
+TEST_F(PtxKernelE2ETest, TensorAddWithoutOutputIndices) {
+  constexpr char kModuleStr[] = R"(
+    HloModule ptx_tensor_test
+    
+    ENTRY main {
+      a = f32[4] constant({1.0, 2.0, 3.0, 4.0})
+      b = f32[4] constant({5.0, 6.0, 7.0, 8.0})
+      ROOT out = f32[4] custom-call(a, b), 
+        custom_call_target="__gpu$xla.gpu.ptx",
+        backend_config="{
+          name = \"tensor_add_kernel\",
+          kernel_type = \"ptx\",
+          kernel_data = \".version 7.0\\n.target sm_70\\n.address_size 64\\n\\n.visible .entry tensor_add_kernel(\\n    .param .u64 input_a,\\n    .param .u64 input_b,\\n    .param .u64 output)\\n{\\n  // Get base pointers\\n  .reg .u64 a_base, b_base, out_base;\\n  ld.param.u64 a_base, [input_a];\\n  ld.param.u64 b_base, [input_b];\\n  ld.param.u64 out_base, [output];\\n  \\n  // Thread ID calculation - just use thread ID directly for this simple case\\n  .reg .u32 tid;\\n  mov.u32 tid, %tid.x;\\n  \\n  // Hard-coded array size = 4\\n  .reg .pred p;\\n  setp.ge.u32 p, tid, 4;\\n  @p bra done;\\n  \\n  // Calculate byte offset (4 bytes per float)\\n  .reg .u64 offset;\\n  cvt.u64.u32 offset, tid;  // Convert tid to 64-bit\\n  mul.lo.u64 offset, offset, 4;  // Each float is 4 bytes\\n  \\n  // Calculate element addresses\\n  .reg .u64 a_addr, b_addr, out_addr;\\n  add.u64 a_addr, a_base, offset;\\n  add.u64 b_addr, b_base, offset;\\n  add.u64 out_addr, out_base, offset;\\n  \\n  // Load input values\\n  .reg .f32 a_val, b_val, result;\\n  ld.global.f32 a_val, [a_addr];\\n  ld.global.f32 b_val, [b_addr];\\n  \\n  // Perform addition\\n  add.f32 result, a_val, b_val;\\n  \\n  // Store result\\n  st.global.f32 [out_addr], result;\\n  \\ndone:\\n  ret;\\n}\",
+          grid_x = 1, grid_y = 1, grid_z = 1,
+          block_x = 4, block_y = 1, block_z = 1,
+          shared_mem_bytes = 0
+        }"
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Execute(std::move(module), {}));
+
+  EXPECT_EQ(result.Get<float>({0}), 6.0f);
+  EXPECT_EQ(result.Get<float>({1}), 8.0f);
+  EXPECT_EQ(result.Get<float>({2}), 10.0f);
+  EXPECT_EQ(result.Get<float>({3}), 12.0f);
+}
+
+TEST_F(PtxKernelE2ETest, TensorAddWithNonTrivialOutputIndices) {
+  constexpr char kModuleStr[] = R"(
+    HloModule ptx_tensor_test
+    
+    ENTRY main {
+      a = f32[4] constant({1.0, 2.0, 3.0, 4.0})
+      b = f32[4] constant({5.0, 6.0, 7.0, 8.0})
+      ROOT out = f32[4] custom-call(a, b), 
+        custom_call_target="__gpu$xla.gpu.ptx",
+        backend_config="{
+          name = \"tensor_add_kernel\",
+          kernel_type = \"ptx\",
+          kernel_data = \".version 7.0\\n.target sm_70\\n.address_size 64\\n\\n.visible .entry tensor_add_kernel(\\n    .param .u64 input_a,\\n    .param .u64 output,\\n    .param .u64 input_b\\n    )\\n{\\n  // Get base pointers\\n  .reg .u64 a_base, b_base, out_base;\\n  ld.param.u64 a_base, [input_a];\\n  ld.param.u64 out_base, [output];\\n  ld.param.u64 b_base, [input_b];\\n  \\n  // Thread ID calculation - just use thread ID directly for this simple case\\n  .reg .u32 tid;\\n  mov.u32 tid, %tid.x;\\n  \\n  // Hard-coded array size = 4\\n  .reg .pred p;\\n  setp.ge.u32 p, tid, 4;\\n  @p bra done;\\n  \\n  // Calculate byte offset (4 bytes per float)\\n  .reg .u64 offset;\\n  cvt.u64.u32 offset, tid;  // Convert tid to 64-bit\\n  mul.lo.u64 offset, offset, 4;  // Each float is 4 bytes\\n  \\n  // Calculate element addresses\\n  .reg .u64 a_addr, b_addr, out_addr;\\n  add.u64 a_addr, a_base, offset;\\n  add.u64 b_addr, b_base, offset;\\n  add.u64 out_addr, out_base, offset;\\n  \\n  // Load input values\\n  .reg .f32 a_val, b_val, result;\\n  ld.global.f32 a_val, [a_addr];\\n  ld.global.f32 b_val, [b_addr];\\n  \\n  // Perform addition\\n  add.f32 result, a_val, b_val;\\n  \\n  // Store result\\n  st.global.f32 [out_addr], result;\\n  \\ndone:\\n  ret;\\n}\",
+          grid_x = 1, grid_y = 1, grid_z = 1,
+          block_x = 4, block_y = 1, block_z = 1,
+          shared_mem_bytes = 0,
+          output_indices = [1]
+        }"
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr));
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Execute(std::move(module), {}));
+
+  EXPECT_EQ(result.Get<float>({0}), 6.0f);
+  EXPECT_EQ(result.Get<float>({1}), 8.0f);
+  EXPECT_EQ(result.Get<float>({2}), 10.0f);
+  EXPECT_EQ(result.Get<float>({3}), 12.0f);
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla


### PR DESCRIPTION
 ExecuteDeviceKernel is a proposed enhancement to XLA that enables users to embed and execute device-specific code (starting with PTX, with future support for other formats) directly within JAX programs. It allows users to inject custom kernels with specific launch configurations, streamlining performance optimizations and reducing reliance on external toolchains. By supporting dynamic compilation during JIT, ExecuteDeviceKernel simplifies the integration and reproduction of custom kernels within a stand-alone HLO module.


Design Doc: https://docs.google.com/document/d/1wn75eJEXQ8EkNH0LemVAIqmudpLgcNBqajE8Ml-vkYg/edit?tab=t.0