### PR TITLE
[GPU] Remove uses of absl::Status from CUB sort kernel.

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -2010,9 +2010,6 @@ cuda_library(
         "gpu",
     ],
     deps = [
-        "//xla/stream_executor/cuda:cuda_status",
-        "@com_google_absl//absl/base",
-        "@com_google_absl//absl/status",
         "@local_config_cuda//cuda:cub_headers",
         "@local_config_cuda//cuda:cuda_headers",
     ],
@@ -2034,6 +2031,7 @@ cuda_library(
         ":cub_sort_kernel_cuda_impl_{}".format(typename),
         "//xla/ffi",
         "//xla/ffi:ffi_api",
+        "//xla/stream_executor/cuda:cuda_status",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
         "@local_config_cuda//cuda:cuda_headers",

--- a/xla/stream_executor/cuda/cub_sort_kernel_cuda.cc
+++ b/xla/stream_executor/cuda/cub_sort_kernel_cuda.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cuda_fp16.h"  // IWYU pragma: keep
 #include "xla/ffi/ffi.h"
 #include "xla/ffi/ffi_api.h"  // IWYU pragma: keep
+#include "xla/stream_executor/cuda/cuda_status.h"
 
 namespace stream_executor {
 namespace cuda {
@@ -34,16 +35,16 @@ absl::Status CubSortKeysExecute(
     xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out, size_t num_items,
     bool descending, size_t batch_size, CUstream stream) {
   size_t temp_bytes = d_temp_storage.size_bytes();
-  return CubSortKeys<KeyT>(d_temp_storage.untyped_data(), temp_bytes,
-                           d_keys_in.untyped_data(), d_keys_out->untyped_data(),
-                           num_items, descending, batch_size, stream);
+  return ToStatus(CubSortKeys<KeyT>(
+      d_temp_storage.untyped_data(), temp_bytes, d_keys_in.untyped_data(),
+      d_keys_out->untyped_data(), num_items, descending, batch_size, stream));
 }
 
 template <typename KeyT>
 absl::Status CubSortKeysGetScratchSize(size_t* temp_bytes, size_t num_items,
                                        size_t batch_size) {
-  return CubSortKeys<KeyT>(nullptr, *temp_bytes, nullptr, nullptr, num_items,
-                           false, batch_size, nullptr);
+  return ToStatus(CubSortKeys<KeyT>(nullptr, *temp_bytes, nullptr, nullptr,
+                                    num_items, false, batch_size, nullptr));
 }
 
 template <typename KeyT, typename ValT>
@@ -54,18 +55,18 @@ absl::Status CubSortPairsExecute(
     xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out, size_t num_items,
     bool descending, size_t batch_size, CUstream stream) {
   size_t temp_bytes = d_temp_storage.size_bytes();
-  return CubSortPairs<KeyT, ValT>(
+  return ToStatus(CubSortPairs<KeyT, ValT>(
       d_temp_storage.untyped_data(), temp_bytes, d_keys_in.untyped_data(),
       d_keys_out->untyped_data(), d_values_in.untyped_data(),
-      d_values_out->untyped_data(), num_items, descending, batch_size, stream);
+      d_values_out->untyped_data(), num_items, descending, batch_size, stream));
 }
 
 template <typename KeyT, typename ValT>
 absl::Status CubSortPairsGetScratchSize(size_t* temp_bytes, size_t num_items,
                                         size_t batch_size) {
-  return CubSortPairs<KeyT, ValT>(nullptr, *temp_bytes, nullptr, nullptr,
-                                  nullptr, nullptr, num_items, false,
-                                  batch_size, nullptr);
+  return ToStatus(CubSortPairs<KeyT, ValT>(nullptr, *temp_bytes, nullptr,
+                                           nullptr, nullptr, nullptr, num_items,
+                                           false, batch_size, nullptr));
 }
 
 }  // namespace

--- a/xla/stream_executor/cuda/cub_sort_kernel_cuda.h
+++ b/xla/stream_executor/cuda/cub_sort_kernel_cuda.h
@@ -18,8 +18,8 @@ limitations under the License.
 
 #include <cstddef>
 
-#include "absl/status/status.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 
 namespace stream_executor::cuda {
 
@@ -32,17 +32,17 @@ namespace stream_executor::cuda {
 // units.
 
 template <typename KeyT>
-absl::Status CubSortKeys(void* d_temp_storage, size_t& temp_bytes,
-                         const void* d_keys_in, void* d_keys_out,
-                         size_t num_items, bool descending, size_t batch_size,
-                         CUstream stream);
+cudaError_t CubSortKeys(void* d_temp_storage, size_t& temp_bytes,
+                        const void* d_keys_in, void* d_keys_out,
+                        size_t num_items, bool descending, size_t batch_size,
+                        CUstream stream);
 
 template <typename KeyT, typename ValT>
-absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
-                          const void* d_keys_in, void* d_keys_out,
-                          const void* d_values_in, void* d_values_out,
-                          size_t num_items, bool descending, size_t batch_size,
-                          CUstream stream);
+cudaError_t CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
+                         const void* d_keys_in, void* d_keys_out,
+                         const void* d_values_in, void* d_values_out,
+                         size_t num_items, bool descending, size_t batch_size,
+                         CUstream stream);
 
 }  // namespace stream_executor::cuda
 


### PR DESCRIPTION
This enables compilation with ASan.