### PR TITLE
Allow internal tuples in ResolveFunctionalDependencyOnInductionVariable.

### DIFF
--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -836,10 +836,16 @@ const HloInstruction* GetUniqueCallerOrNull(const HloComputation* callee) {
   return callers.size() == 1 ? callers.front() : nullptr;
 }
 
-// Returns the transitive dependencies of `root`, including those of callers.
-// Returns nullopt if any dependencies have side effects.
-std::optional<absl::flat_hash_set<const HloInstruction*>>
-GetTransitiveFunctionalDependencies(const HloInstruction* root) {
+struct Dependencies {
+  absl::InlinedVector<const HloInstruction*, 2> parameters;
+  absl::InlinedVector<const HloInstruction*, 1> get_tuple_elements;
+};
+
+// Returns the leaf dependencies of `root`, in each frame of the call stack.
+// Here, leaves are parameters and GTEs. Returns nullopt if any dependencies
+// have side effects.
+std::optional<Dependencies>
+GetLeafDependencies(const HloInstruction* root) {
   absl::flat_hash_set<const HloInstruction*> seen{root};
   std::queue<const HloInstruction*> queue;
   queue.push(root);
@@ -850,6 +856,7 @@ GetTransitiveFunctionalDependencies(const HloInstruction* root) {
     }
   };
 
+  Dependencies results;
   while (!queue.empty()) {
     const auto* instruction = queue.front();
     VLOG(5) << "Visiting " << instruction->name() << ".";
@@ -862,6 +869,7 @@ GetTransitiveFunctionalDependencies(const HloInstruction* root) {
     }
 
     if (instruction->opcode() == HloOpcode::kParameter) {
+      results.parameters.push_back(instruction);
       const HloInstruction* caller =
           GetUniqueCallerOrNull(instruction->parent());
       if (!caller) {
@@ -877,40 +885,83 @@ GetTransitiveFunctionalDependencies(const HloInstruction* root) {
       }
     }
 
+    if (instruction->opcode() == HloOpcode::kGetTupleElement) {
+      results.get_tuple_elements.push_back(instruction);
+    }
+
     for (auto* operand : instruction->operands()) {
       enqueue(operand);
     }
   }
-
-  return seen;
+  return results;
 }
 
-// Returns true if `dependency` contains a valid functional dependency: `loop`
-// and `induction_var` are set, and `induction_var` actually points to the
-// loop's induction variable.
-bool VerifyFunctionalDependency(
-    const InductionVariableFunctionalDependency& dependency) {
-  if (!dependency.loop || !dependency.induction_var) {
-    VLOG(5) << "Loop or induction variable not set.";
-    return false;
-  }
+struct VerifiedLoop {
+  const HloInstruction* loop;
+  const HloInstruction* parameter;
+  int64_t induction_variable_index;
+};
 
-  if (dependency.induction_var->opcode() != HloOpcode::kGetTupleElement ||
-      dependency.loop->while_body()->parameter_instruction(0) !=
-          dependency.induction_var->operand(0)) {
-    VLOG(5) << "induction_var does not point to the loop's parameter.";
-    return false;
+// Checks that `loop` is a while loop from which we can derive functional
+// dependencies.
+std::optional<VerifiedLoop> VerifyFunctionalDependencyLoop(
+    const HloInstruction* loop) {
+  if (!loop) {
+    VLOG(5) << "No loop found";
+    return std::nullopt;
   }
-
-  auto config = dependency.loop->backend_config<xla::WhileLoopBackendConfig>();
-  if (!config.ok() || !config->has_known_induction_variable() ||
-      dependency.induction_var->tuple_index() !=
-          config->known_induction_variable().tuple_index()) {
-    VLOG(5) << "induction_var does not access the loop's induction variable.";
-    return false;
+  auto config = loop->backend_config<xla::WhileLoopBackendConfig>();
+  if (!config.ok() || !config->has_known_induction_variable()) {
+    VLOG(5) << "The loop has no known induction variable.";
+    return std::nullopt;
   }
+  return VerifiedLoop{loop, loop->while_body()->parameter_instruction(0),
+                      config->known_induction_variable().tuple_index()};
+}
 
-  return true;
+// Returns true if `hlo` is a GTE for a loop carried variable of `loop`.
+bool IsLoopCarriedVariable(const HloInstruction* hlo,
+                           const VerifiedLoop& loop) {
+  return hlo->opcode() == HloOpcode::kGetTupleElement &&
+         hlo->operand(0) == loop.parameter;
+}
+
+// Returns true if `maybe_variable` is `loop`'s induction variable.
+bool IsInductionVariable(const HloInstruction* maybe_variable,
+                         const VerifiedLoop& loop) {
+  return IsLoopCarriedVariable(maybe_variable, loop) &&
+         maybe_variable->tuple_index() == loop.induction_variable_index;
+}
+
+// Attempts to find the induction variable of `loop` in `dependencies`. If there
+// are any dependencies on non-induction variable loop-carried variables,
+// returns nullopt.
+std::optional<const HloInstruction*> VerifyInductionVariable(
+    const Dependencies& dependencies, const VerifiedLoop& loop) {
+  const HloInstruction* induction_var = nullptr;
+  for (const HloInstruction* gte : dependencies.get_tuple_elements) {
+    if (IsInductionVariable(gte, loop)) {
+      if (induction_var) {
+        // This should never happen.
+        VLOG(5) << "Found non-unique GTEs for the induction variable. Did "
+                   "HloCSE run?";
+        return std::nullopt;
+      }
+      induction_var = gte;
+    } else if (IsLoopCarriedVariable(gte, loop)) {
+      // Other dependencies on loop-carried variables are not allowed.
+      VLOG(5) << "Found illegal dependency on loop-carried variable.";
+      return std::nullopt;
+    }
+    // Other GTEs are OK, as long as their tuples are ultimately just derived
+    // from the loop's induction variable. We already verified that there are no
+    // side-effecting dependencies in GetLeafDependencies.
+  }
+  if (!induction_var) {
+    VLOG(5) << "Did not find an induction variable.";
+    return std::nullopt;
+  }
+  return induction_var;
 }
 
 }  // namespace
@@ -919,7 +970,7 @@ std::optional<InductionVariableFunctionalDependency>
 ResolveFunctionalDependencyOnInductionVariable(const HloInstruction* instr) {
   VLOG(5) << "Looking for defining while loop of " << instr->name();
 
-  auto dependencies = GetTransitiveFunctionalDependencies(instr);
+  auto dependencies = GetLeafDependencies(instr);
   // If there is a side effect in the dependencies, the result will be nullopt.
   if (!dependencies) {
     return std::nullopt;
@@ -929,47 +980,43 @@ ResolveFunctionalDependencyOnInductionVariable(const HloInstruction* instr) {
   // and exactly one GTE for that parameter. We already verified that there are
   // no side-effecting dependencies.
   InductionVariableFunctionalDependency result{};
-  for (const HloInstruction* dep : *dependencies) {
-    if (dep->opcode() == HloOpcode::kParameter) {
-      const HloComputation* callee = dep->parent();
-      const HloInstruction* caller = GetUniqueCallerOrNull(callee);
-      if (caller && IsCallLike(caller)) {
-        // Register the parameter as a required intermediate value.
-        auto& required = result.required_parameters[callee];
-        if (required.empty()) {
-          required.resize(callee->num_parameters());
-        }
-        required[dep->parameter_number()] = true;
-      } else if (caller && caller->opcode() == HloOpcode::kWhile) {
-        if (result.loop) {
-          LOG(WARNING) << "While loop not unique. This should never happen.";
-          return std::nullopt;
-        }
-        result.loop = caller;
-      } else {
-        // We arrived at an unexpected parameter. This likely means we're not in
-        // a while loop, or there's an unsupported instruction between the while
-        // loop and `instr`.
-        VLOG(5) << "Unsupported parameter: " << dep->name() << ".";
+  for (const HloInstruction* param : dependencies->parameters) {
+    const HloComputation* callee = param->parent();
+    const HloInstruction* caller = GetUniqueCallerOrNull(callee);
+    if (caller && IsCallLike(caller)) {
+      // Register the parameter as a required intermediate value.
+      auto& required = result.required_parameters[callee];
+      if (required.empty()) {
+        required.resize(callee->num_parameters());
+      }
+      required[param->parameter_number()] = true;
+    } else if (caller && caller->opcode() == HloOpcode::kWhile) {
+      if (result.loop) {
+        LOG(WARNING) << "While loop not unique. This should never happen.";
         return std::nullopt;
       }
-    }
-
-    if (dep->opcode() == HloOpcode::kGetTupleElement) {
-      // Note that this may not actually be the induction variable. We will
-      // verify this later (in VerifyFunctionalDependency). We can't do it here
-      // because we may not have visited the loop yet.
-      if (result.induction_var) {
-        VLOG(5) << "Found non-unique GTEs.";
-        return std::nullopt;
-      }
-      result.induction_var = dep;
+      result.loop = caller;
+    } else {
+      // We arrived at an unexpected parameter. This likely means we're not in
+      // a while loop, or there's an unsupported instruction between the while
+      // loop and `instr`.
+      VLOG(5) << "Unsupported parameter: " << param->name() << ".";
+      return std::nullopt;
     }
   }
 
-  if (!VerifyFunctionalDependency(result)) {
+  auto verified_loop = VerifyFunctionalDependencyLoop(result.loop);
+  if (!verified_loop) {
     return std::nullopt;
   }
+
+  auto induction_var = VerifyInductionVariable(*dependencies, *verified_loop);
+  if (induction_var) {
+    result.induction_var = *induction_var;
+  } else {
+    return std::nullopt;
+  }
+
   VLOG(5) << "While loop for " << instr->name() << ": " << result.loop->name();
   return result;
 }


### PR DESCRIPTION
While loop double buffering commonly generates patterns like this:

```
ivar = s32[] gte(p0)
tuple = (s32[], s32[]) fusion(ivar), calls=plus_one_and_plus_two
ivar1 = s32[] gte(tuple)
slice = ... dynamic-slice(..., ivar1)
```

Currently, this fails because of the internal GTE - the code bails if there's more than one GTE. To fix this, we can simply look at parameters and GTEs of the while loop and verify that the only dependency on the while loop's parameter is the induction variable.