### PR TITLE
[hlo-opt] Add parsing debug options support

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
+#include <fstream>
 #include <limits>
 #include <memory>
 #include <string>
@@ -2378,13 +2379,15 @@ bool ParseFlagsFromDebugOptionsFile(absl::string_view filename) {
   VLOG(2) << "Parsing flags from file: " << filename;
   // Read the file content
   std::string file_content;
-  absl::Status status = tsl::ReadFileToString(
-      tsl::Env::Default(), std::string(filename), &file_content);
-  if (!status.ok()) {
-    LOG(ERROR) << "Failed to read file: " << filename
-               << ", error: " << status.ToString();
+  std::ifstream file{std::string(filename)};
+  if (!file.is_open()) {
+    LOG(ERROR) << "Failed to open file: " << filename;
     return false;
   }
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  file_content = buffer.str();
+  file.close();
   DebugOptions new_debug_options;
   tsl::protobuf::TextFormat::Parser parser;
   tsl::protobuf::TextFormat::ParseInfoTree tree;

--- a/xla/hlo/tools/hlo_opt/opt_main.cc
+++ b/xla/hlo/tools/hlo_opt/opt_main.cc
@@ -220,6 +220,27 @@ absl::Status RunOpt(int argc, char** argv, const HloOptConfig& opts) {
   return absl::OkStatus();
 }
 
+// This function is parsing only the debug options file, because we cannot wait
+// till all the flags are parsed. If the debug_options file exists, then we have
+// to first consider the debug_options from that file, then XLA_FLAGS, and then
+// the command line flags. Hence, we parse the debug_options file first.
+std::optional<absl::string_view> GetDebugOptionsFileName(int argc,
+                                                         char* argv[]) {
+  for (int i = 1; i < argc; ++i) {
+    absl::string_view arg = argv[i];
+    if (absl::StrContains(arg, "--debug_options_file")) {
+      auto eq_idx = arg.find('=');
+      if (eq_idx != absl::string_view::npos) {
+        return arg.substr(eq_idx + 1);
+      } else {
+        LOG(QFATAL) << "No value provided for --debug_options_file. Expected "
+                    << "--debug_options_file=<filename>";
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace
 }  // namespace xla
 
@@ -227,6 +248,7 @@ absl::Status RunOpt(int argc, char** argv, const HloOptConfig& opts) {
 // Use `--xla_gpu_target_config_filename` to specify the target config.
 int main(int argc, char** argv) {
   HloOptConfig opts;
+  std::string unused_debug_options_filename;
   std::vector<tsl::Flag> flag_list = {
       tsl::Flag("o", &opts.output_file,
                 "Output filename, or '-' for stdout (default)."),
@@ -258,11 +280,27 @@ int main(int argc, char** argv) {
                 "Print all supported passes for a given platform and exit"),
       tsl::Flag("emit-proto", &opts.emit_proto,
                 "Emit HLO in `textproto` format, "
-                "no optimization passes are applied.")};
+                "no optimization passes are applied."),
+      // This flag is parsed separately, not as part of the HloOptConfig
+      // options. `unused_debug_options_filename` is introduced for a
+      // documentation, not used by the tool.
+      tsl::Flag("debug_options_file", &unused_debug_options_filename,
+                "A file containing debug options to be passed to the HLO "
+                "module. The file should contain a serialized DebugOptions "
+                "proto message. The order of precedence: command line flags > "
+                "XLA_FLAGS > debug_options_file > default flags.")};
 
   // Modifies global DebugOptions, populates flags with every flag available
   // from xla.proto.
   xla::AppendDebugOptionsFlags(&flag_list);
+
+  std::optional<absl::string_view> debugOptionsFilename =
+      xla::GetDebugOptionsFileName(argc, argv);
+  if (debugOptionsFilename.has_value()) {
+    xla::ParseFlagsFromDebugOptionsFile(debugOptionsFilename.value());
+  }
+  xla::ParseDebugOptionFlagsFromEnv(true);
+
   // The usage string includes the message at the top of the file, the
   // DebugOptions flags and the flags defined above.
   const std::string kUsageString =

--- a/xla/hlo/tools/hlo_opt/opt_main.cc
+++ b/xla/hlo/tools/hlo_opt/opt_main.cc
@@ -294,6 +294,11 @@ int main(int argc, char** argv) {
   // from xla.proto.
   xla::AppendDebugOptionsFlags(&flag_list);
 
+  // The usage string includes the message at the top of the file, the
+  // DebugOptions flags and the flags defined above.
+  const std::string kUsageString =
+      absl::StrCat(kUsage, "\n\n", tsl::Flags::Usage(argv[0], flag_list));
+
   std::optional<absl::string_view> debugOptionsFilename =
       xla::GetDebugOptionsFileName(argc, argv);
   if (debugOptionsFilename.has_value()) {
@@ -301,16 +306,11 @@ int main(int argc, char** argv) {
   }
   xla::ParseDebugOptionFlagsFromEnv(true);
 
-  // The usage string includes the message at the top of the file, the
-  // DebugOptions flags and the flags defined above.
-  const std::string kUsageString =
-      absl::StrCat(kUsage, "\n\n", tsl::Flags::Usage(argv[0], flag_list));
   bool parse_ok = tsl::Flags::Parse(&argc, argv, flag_list);
-  tsl::port::InitMain(kUsageString.c_str(), &argc, &argv);
-
   if (!parse_ok) {
     LOG(QFATAL) << kUsageString;
   }
+  tsl::port::InitMain(kUsageString.c_str(), &argc, &argv);
 
   absl::Status s = xla::RunOpt(argc, argv, opts);
   if (!s.ok()) {

--- a/xla/hlo/tools/tests/BUILD
+++ b/xla/hlo/tools/tests/BUILD
@@ -25,6 +25,7 @@ lit_test_suite(
         [
             # go/keep-sorted start
             "hlo_opt_all_passes_smoke_test.hlo",
+            "hlo_opt_debug_options_parse_test.hlo",
             "hlo_opt_dump.hlo",
             "hlo_opt_emit_proto.hlo",
             "hlo_opt_hlo_protobinary_to_hlotext.hlo",

--- a/xla/hlo/tools/tests/hlo_opt_debug_options_parse_test.hlo
+++ b/xla/hlo/tools/tests/hlo_opt_debug_options_parse_test.hlo
@@ -2,24 +2,24 @@
 // RUN: hlo-opt --xla_dump_to=%t_dump_dir --xla_dump_hlo_pass_re=".*" --xla_gpu_dot_merger_threshold_mb=3253 --xla_dump_large_constants=true --passes=dce,algsimp %s 
 
 // === Then, we parse the debug options from the temporary directory ===
-// RUN: hlo-opt --xla_dump_to=%t_dump_dir2 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --passes="dce,algsimp" %s
-// RUN: cat %t_dump_dir2/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
-// RUN: cat %t_dump_dir2/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP"
+// RUN: hlo-opt --xla_dump_to=%t_dump_dir2 --debug_options_file=$(echo %t_dump_dir/module_0000.m.*debug_options) --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir2/module_0000.m.*after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir2/module_0000.m.*debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP"
 
 // === Then, we override the debug options with the command line ===
-// RUN: hlo-opt --xla_dump_to=%t_dump_dir3 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --xla_gpu_dot_merger_threshold_mb=1000 --passes="dce,algsimp" %s
-// RUN: cat %t_dump_dir3/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
-// RUN: cat %t_dump_dir3/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES"
+// RUN: hlo-opt --xla_dump_to=%t_dump_dir3 --debug_options_file=$(echo %t_dump_dir/module_0000.m.*debug_options) --xla_gpu_dot_merger_threshold_mb=1000 --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir3/module_0000.m.*after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir3/module_0000.m.*debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES"
 
 // === Then, we override the debug options via XLA_FLAGS ===
-// RUN: XLA_FLAGS="--xla_gpu_dot_merger_threshold_mb=1000" hlo-opt --xla_dump_to=%t_dump_dir4 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --passes="dce,algsimp" %s
-// RUN: cat %t_dump_dir4/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
-// RUN: cat %t_dump_dir4/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES"
+// RUN: XLA_FLAGS="--xla_gpu_dot_merger_threshold_mb=1000" hlo-opt --xla_dump_to=%t_dump_dir4 --debug_options_file=$(echo %t_dump_dir/module_0000.m.*debug_options) --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir4/module_0000.m.*after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir4/module_0000.m.*debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES"
 
 // === We also test that command line flags override XLA_FLAGS ===
-// RUN: XLA_FLAGS="--xla_gpu_dot_merger_threshold_mb=1000" hlo-opt --xla_dump_to=%t_dump_dir5 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --xla_gpu_dot_merger_threshold_mb=4578 --passes="dce,algsimp" %s
-// RUN: cat %t_dump_dir5/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
-// RUN: cat %t_dump_dir5/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES_XLA_FLAGS"
+// RUN: XLA_FLAGS="--xla_gpu_dot_merger_threshold_mb=1000" hlo-opt --xla_dump_to=%t_dump_dir5 --debug_options_file=$(echo %t_dump_dir/module_0000.m.*debug_options) --xla_gpu_dot_merger_threshold_mb=4578 --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir5/module_0000.m.*after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir5/module_0000.m.*debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES_XLA_FLAGS"
 
 // MODULE_WITH_LARGE_CONSTANTS: %c2 = s32[12]{0} constant({10, 6, 3, 2, 5, 3, 7, 4, 2, 3, 1, 0})
 

--- a/xla/hlo/tools/tests/hlo_opt_debug_options_parse_test.hlo
+++ b/xla/hlo/tools/tests/hlo_opt_debug_options_parse_test.hlo
@@ -1,0 +1,48 @@
+// === First, we dump the debug options to a temporary directory ===
+// RUN: hlo-opt --xla_dump_to=%t_dump_dir --xla_dump_hlo_pass_re=".*" --xla_gpu_dot_merger_threshold_mb=3253 --xla_dump_large_constants=true --passes=dce,algsimp %s 
+
+// === Then, we parse the debug options from the temporary directory ===
+// RUN: hlo-opt --xla_dump_to=%t_dump_dir2 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir2/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir2/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP"
+
+// === Then, we override the debug options with the command line ===
+// RUN: hlo-opt --xla_dump_to=%t_dump_dir3 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --xla_gpu_dot_merger_threshold_mb=1000 --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir3/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir3/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES"
+
+// === Then, we override the debug options via XLA_FLAGS ===
+// RUN: XLA_FLAGS="--xla_gpu_dot_merger_threshold_mb=1000" hlo-opt --xla_dump_to=%t_dump_dir4 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir4/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir4/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES"
+
+// === We also test that command line flags override XLA_FLAGS ===
+// RUN: XLA_FLAGS="--xla_gpu_dot_merger_threshold_mb=1000" hlo-opt --xla_dump_to=%t_dump_dir5 --debug_options_file=%t_dump_dir/module_0000.m.debug_options --xla_gpu_dot_merger_threshold_mb=4578 --passes="dce,algsimp" %s
+// RUN: cat %t_dump_dir5/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir5/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP_OVERRIDES_XLA_FLAGS"
+
+// MODULE_WITH_LARGE_CONSTANTS: %c2 = s32[12]{0} constant({10, 6, 3, 2, 5, 3, 7, 4, 2, 3, 1, 0})
+
+// DEBUG_OPTIONS_DUMP: xla_gpu_dot_merger_threshold_mb: 3253
+// DEBUG_OPTIONS_DUMP-NEXT: xla_dump_to:
+// DEBUG_OPTIONS_DUMP-NEXT: xla_dump_hlo_pass_re:
+// DEBUG_OPTIONS_DUMP-NEXT: xla_dump_large_constants: true
+
+// DEBUG_OPTIONS_DUMP_OVERRIDES: xla_gpu_dot_merger_threshold_mb: 1000
+// DEBUG_OPTIONS_DUMP_OVERRIDES-NEXT: xla_dump_to:
+// DEBUG_OPTIONS_DUMP_OVERRIDES-NEXT: xla_dump_hlo_pass_re:
+// DEBUG_OPTIONS_DUMP_OVERRIDES-NEXT: xla_dump_large_constants: true
+
+// DEBUG_OPTIONS_DUMP_OVERRIDES_XLA_FLAGS: xla_gpu_dot_merger_threshold_mb: 4578
+// DEBUG_OPTIONS_DUMP_OVERRIDES_XLA_FLAGS-NEXT: xla_dump_to:
+// DEBUG_OPTIONS_DUMP_OVERRIDES_XLA_FLAGS-NEXT: xla_dump_hlo_pass_re:
+// DEBUG_OPTIONS_DUMP_OVERRIDES_XLA_FLAGS-NEXT: xla_dump_large_constants: true
+
+HloModule m
+test {
+    p0 = s32[12] parameter(0)
+    c1 = s32[12] constant({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
+    c2 = s32[12] constant({10, 6, 3, 2, 5, 3, 7, 4, 2, 3, 1, 0})
+    x = s32[12] multiply(p0, c1)
+    ROOT y = s32[12] add(x, c2)
+}

--- a/xla/hlo/tools/tests/hlo_opt_dump.hlo
+++ b/xla/hlo/tools/tests/hlo_opt_dump.hlo
@@ -1,7 +1,13 @@
+// === Checking dump with dump for passes disabled ===
 // RUN: hlo-opt %s --xla_dump_to=%t_dump_dir --passes=dce,algsimp
 // RUN: ls %t_dump_dir | sort | FileCheck %s --check-prefix="DUMP"
-// RUN: hlo-opt --xla_dump_to=%t_dump_dir_with_passes --xla_dump_hlo_pass_re=".*" --passes=dce,algsimp %s
+// RUN: cat %t_dump_dir/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITHOUT_LARGE_CONSTANTS"
+
+// === Checking dumping with dump for passes enabled ===
+// RUN: hlo-opt --xla_dump_to=%t_dump_dir_with_passes --xla_dump_hlo_pass_re=".*" --xla_gpu_dot_merger_threshold_mb=3253 --xla_dump_large_constants=true --passes=dce,algsimp %s 
 // RUN: ls %t_dump_dir_with_passes | sort | FileCheck %s --check-prefix="DUMP_WITH_PASSES"
+// RUN: cat %t_dump_dir_with_passes/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP"
+// RUN: cat %t_dump_dir_with_passes/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
 
 // DUMP: module_0000.m.{{.*}}after_optimization.txt
 // DUMP-NEXT: module_0000.m.{{.*}}before_optimization.txt
@@ -13,9 +19,19 @@
 // DUMP_WITH_PASSES-NEXT: module_0000.m.{{.*}}before_optimization.txt
 // DUMP_WITH_PASSES-NEXT: module_0000.m.{{.*}}debug_options
 
+// DEBUG_OPTIONS_DUMP: xla_gpu_dot_merger_threshold_mb: 3253
+// DEBUG_OPTIONS_DUMP-NEXT: xla_dump_to:
+// DEBUG_OPTIONS_DUMP-NEXT: xla_dump_hlo_pass_re:
+// DEBUG_OPTIONS_DUMP-NEXT: xla_dump_large_constants: true
+
+// MODULE_WITHOUT_LARGE_CONSTANTS: %c2 = s32[12]{0} constant({...})
+// MODULE_WITH_LARGE_CONSTANTS: %c2 = s32[12]{0} constant({10, 6, 3, 2, 5, 3, 7, 4, 2, 3, 1, 0})
+
 HloModule m
 test {
-    p0 = s32[11] parameter(0)
-    c = s32[11] constant({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
-    ROOT x = s32[11] multiply(p0, c)
+    p0 = s32[12] parameter(0)
+    c1 = s32[12] constant({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
+    c2 = s32[12] constant({10, 6, 3, 2, 5, 3, 7, 4, 2, 3, 1, 0})
+    x = s32[12] multiply(p0, c1)
+    ROOT y = s32[12] add(x, c2)
 }

--- a/xla/hlo/tools/tests/hlo_opt_dump.hlo
+++ b/xla/hlo/tools/tests/hlo_opt_dump.hlo
@@ -1,13 +1,13 @@
 // === Checking dump with dump for passes disabled ===
 // RUN: hlo-opt %s --xla_dump_to=%t_dump_dir --passes=dce,algsimp
 // RUN: ls %t_dump_dir | sort | FileCheck %s --check-prefix="DUMP"
-// RUN: cat %t_dump_dir/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITHOUT_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir/module_0000.m.*after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITHOUT_LARGE_CONSTANTS"
 
 // === Checking dumping with dump for passes enabled ===
 // RUN: hlo-opt --xla_dump_to=%t_dump_dir_with_passes --xla_dump_hlo_pass_re=".*" --xla_gpu_dot_merger_threshold_mb=3253 --xla_dump_large_constants=true --passes=dce,algsimp %s 
 // RUN: ls %t_dump_dir_with_passes | sort | FileCheck %s --check-prefix="DUMP_WITH_PASSES"
-// RUN: cat %t_dump_dir_with_passes/module_0000.m.debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP"
-// RUN: cat %t_dump_dir_with_passes/module_0000.m.after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
+// RUN: cat %t_dump_dir_with_passes/module_0000.m.*debug_options | FileCheck %s --check-prefix="DEBUG_OPTIONS_DUMP"
+// RUN: cat %t_dump_dir_with_passes/module_0000.m.*after_optimization.txt | FileCheck %s --check-prefix="MODULE_WITH_LARGE_CONSTANTS"
 
 // DUMP: module_0000.m.{{.*}}after_optimization.txt
 // DUMP-NEXT: module_0000.m.{{.*}}before_optimization.txt


### PR DESCRIPTION
These can be parsed with command line option: `--debug_options_file="path_to_debug_options_file"`.