### PR TITLE
[Proposal] Open source some simple custom call annotation handling.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1373,6 +1373,7 @@ cc_library(
         ":compile_module_to_llvm_ir",
         ":conv_layout_normalization",
         ":cublas_cudnn",
+        ":custom_call_partitioners",
         ":executable_proto_cc",
         ":execution_stream_assignment",
         ":flag_utils",
@@ -1551,8 +1552,10 @@ cc_library(
         "//xla/service/gpu/transforms:gemm_rewriter",
         "//xla/service/gpu/transforms:gemv_rewriter",
         "//xla/service/gpu/transforms:layout_assignment",
+        "//xla/service/gpu/transforms:memory_space_propagation",
         "//xla/service/gpu/transforms:move_copy_to_users",
         "//xla/service/gpu/transforms:nest_gemm_fusion",
+        "//xla/service/gpu/transforms:post_layout_custom_call_rewriter",
         "//xla/service/gpu/transforms:ragged_all_to_all_canonicalizer",
         "//xla/service/gpu/transforms:ragged_all_to_all_decomposer",
         "//xla/service/gpu/transforms:reduce_scatter_creator",
@@ -3031,5 +3034,15 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@tsl//tsl/profiler/lib:traceme",
         "@tsl//tsl/profiler/lib:traceme_encode",
+    ],
+)
+
+cc_library(
+    name = "custom_call_partitioners",
+    hdrs = ["custom_call_partitioners.h"],
+    deps = [
+        "//xla/hlo/ir:hlo",
+        "//xla/service:custom_call_sharding_helper",
+        "//xla/service/spmd:spmd_partitioner",
     ],
 )

--- a/xla/service/gpu/custom_call_partitioners.h
+++ b/xla/service/gpu/custom_call_partitioners.h
@@ -1,0 +1,64 @@
+#ifndef XLA_SERVICE_GPU_CUSTOM_CALL_PARTITIONERS_H_
+#define XLA_SERVICE_GPU_CUSTOM_CALL_PARTITIONERS_H_
+
+#include <optional>
+
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_sharding.h"
+#include "xla/service/custom_call_sharding_helper.h"
+#include "xla/service/spmd/spmd_partitioner.h"
+
+namespace xla::gpu::spmd {
+
+// Partitions custom calls as element-wise ops.
+// Custom calls using this partitioner must follow element-wise op semantics,
+// otherwise there will be undefined behaviors.
+class PassThroughPartitioner : public CustomCallPartitioner {
+ public:
+  bool IsCustomCallShardable(const HloInstruction* instruction) const override {
+    return true;
+  }
+
+  absl::Status Partition(xla::spmd::SpmdPartitioningVisitor* partitioner,
+                         HloInstruction* hlo) const override {
+    // Partitions the custom call just as its operands.
+    return partitioner->HandleElementwise(hlo);
+  }
+
+  // This allows replicated sharding on custom-call op to pass checks at spmd
+  // partitioner preprocess stage.
+  bool CanSideEffectingHaveReplicatedSharding() const override { return true; }
+
+  // Run through this custom call for both forward and backwnard propagation.
+  std::optional<HloSharding> InferShardingFromOperands(
+      const HloInstruction* instruction) const override {
+    if (instruction->operand(0)->has_sharding()) {
+      return instruction->operand(0)->sharding();
+    }
+    return std::nullopt;
+  }
+};
+
+class AllocateBufferPartitioner : public CustomCallPartitioner {
+ public:
+  bool IsCustomCallShardable(const HloInstruction* instruction) const override {
+    return true;
+  }
+
+  absl::Status Partition(xla::spmd::SpmdPartitioningVisitor* partitioner,
+                         HloInstruction* hlo) const override {
+    // Partitions the custom call just as its operands.
+    return partitioner->HandleElementwise(hlo);
+  }
+
+  // Always let backward propagation run through with ShardBarrierFrom.
+  HloSharding PropagateUserSharding(
+      const HloInstruction* instruction, const HloInstruction* user,
+      const HloSharding& sharding) const override {
+    return sharding;
+  }
+};
+
+}  // namespace xla::gpu::spmd
+
+#endif  // XLA_SERVICE_GPU_CUSTOM_CALL_PARTITIONERS_H_

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -3405,3 +3405,65 @@ xla_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "post_layout_custom_call_rewriter",
+    srcs = ["post_layout_custom_call_rewriter.cc"],
+    hdrs = ["post_layout_custom_call_rewriter.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla/ffi:attribute_map",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/hlo/transforms/simplifiers:hlo_dce",
+        "//xla/service:memory_annotations_hdr",
+        "//xla/service/gpu:gpu_memory_space_assignment",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@llvm-project//mlir:AsmParser",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "memory_space_propagation",
+    srcs = ["memory_space_propagation.cc"],
+    hdrs = ["memory_space_propagation.h"],
+    deps = [
+        "//xla/hlo/analysis:hlo_dataflow_analysis",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/ir:hlo_module_group",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "memory_space_propagation_test",
+    srcs = ["memory_space_propagation_test.cc"],
+    deps = [
+        ":memory_space_propagation",
+        "//xla:util",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:filecheck",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service:hlo_verifier",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xla/service/gpu/transforms/layout_assignment.cc
+++ b/xla/service/gpu/transforms/layout_assignment.cc
@@ -354,7 +354,8 @@ bool IsCustomCallToMemoryPlacement(const HloInstruction* hlo) {
   }
   const std::string& target = hlo->custom_call_target();
   return target == memory_annotations::kMoveToDeviceCustomCallTarget ||
-         target == memory_annotations::kMoveToHostCustomCallTarget;
+         target == memory_annotations::kMoveToHostCustomCallTarget ||
+         target == memory_annotations::kAnnotateMemorySpace;
 }
 
 }  // namespace

--- a/xla/service/gpu/transforms/memory_space_propagation.cc
+++ b/xla/service/gpu/transforms/memory_space_propagation.cc
@@ -1,0 +1,95 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/memory_space_propagation.h"
+
+#include <optional>
+#include <utility>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/check.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/analysis/hlo_dataflow_analysis.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/layout.h"
+#include "xla/layout_util.h"
+#include "xla/service/hlo_value.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+
+namespace xla::gpu {
+namespace {
+
+bool Propagate(ShapeIndexView index, HloInstruction* instruction,
+               const Shape& src_shape, const HloDataflowAnalysis* analysis) {
+  bool modified = false;
+
+  const HloValue& value =
+      analysis->GetValueDefinedAt(instruction, ShapeIndex(index));
+  auto memory_space_to_propagate = src_shape.layout().memory_space();
+  for (const HloPosition& position : value.positions()) {
+    auto* instruction = position.instruction;
+    Shape* shape = ShapeUtil::GetMutableSubshape(instruction->mutable_shape(),
+                                                 position.index);
+    if (!shape->has_layout() ||
+        shape->layout().memory_space() == memory_space_to_propagate) {
+      continue;
+    }
+    shape->mutable_layout()->set_memory_space(memory_space_to_propagate);
+    modified = true;
+  }
+
+  // We don't propagate from S(x) operand to S(x) output because it's
+  // pure memory transfer without any computation in S(x). Computations
+  // including transposes should be defined explicitly in JAX.
+  return modified;
+}
+
+}  // namespace
+
+absl::StatusOr<bool> MemorySpacePropagation::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool modified = false;
+  TF_ASSIGN_OR_RETURN(auto dataflow_analysis,
+                      HloDataflowAnalysis::Run(*module, /*ssa_form=*/false,
+                                               /*bitcast_defines_value=*/true));
+
+  absl::flat_hash_set<HloInstruction*> visited_instructions;
+  for (HloComputation* computation :
+       module->MakeNonfusionComputations(execution_threads)) {
+    for (auto* instruction : computation->MakeInstructionPostOrder()) {
+      if (visited_instructions.contains(instruction)) {
+        continue;
+      }
+      visited_instructions.insert(instruction);
+      ShapeUtil::ForEachLeafShape(
+          instruction->shape(),
+          [&, analysis = dataflow_analysis.get()](const Shape& sub_shape,
+                                                  const ShapeIndex& index) {
+            if (sub_shape.has_layout() &&
+                sub_shape.layout().memory_space() !=
+                    xla::Layout::kDefaultMemorySpace &&
+                analysis->ValueIsDefinedAt(instruction, index)) {
+              modified |= Propagate(index, instruction, sub_shape, analysis);
+            }
+          });
+    }
+  }
+  return modified;
+}
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/memory_space_propagation.h
+++ b/xla/service/gpu/transforms/memory_space_propagation.h
@@ -1,0 +1,46 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_MEMORY_SPACE_PROPAGATION_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_MEMORY_SPACE_PROPAGATION_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla::gpu {
+
+// This pass propagates the memory space in the forward direction at best
+// efforts.
+class MemorySpacePropagation : public HloModulePass {
+ public:
+  ~MemorySpacePropagation() override = default;
+  absl::string_view name() const override {
+    return "xai-memory-space-propagation";
+  }
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_XAI_MEMORY_SPACE_PROPAGATION_H_

--- a/xla/service/gpu/transforms/memory_space_propagation_test.cc
+++ b/xla/service/gpu/transforms/memory_space_propagation_test.cc
@@ -1,0 +1,146 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/memory_space_propagation.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/log/check.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/testlib/filecheck.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/hlo_verifier.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace xla::gpu {
+namespace {
+
+using MemorySpacePropagationTest = HloHardwareIndependentTestBase;
+
+TEST_F(MemorySpacePropagationTest, PropagateHostMemorySpace) {
+  constexpr absl::string_view kHlo = R"(
+HloModule jit_loss_fn, entry_computation_layout={(f32[2,2]{1,0})->(f32[], f32[2,2]{1,0})}, allow_spmd_sharding_propagation_to_parameters={true}, allow_spmd_sharding_propagation_to_output={true,true}
+
+%region_3.88.clone.clone (arg_tuple.6: (s32[], f32[2,2], s32[], f32[2,2], f32[2,2,2])) -> (s32[], f32[2,2], s32[], f32[2,2], f32[2,2,2]) {
+  %arg_tuple.6 = (s32[], f32[2,2]{1,0}, s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}) parameter(0)
+  %get-tuple-element.88 = s32[] get-tuple-element(%arg_tuple.6), index=0
+  %constant.35 = s32[] constant(1)
+  %add.36 = s32[] add(%get-tuple-element.88, %constant.35)
+  %get-tuple-element.96 = f32[2,2]{1,0} get-tuple-element(%arg_tuple.6), index=3
+  %get-tuple-element.89 = f32[2,2]{1,0} get-tuple-element(%arg_tuple.6), index=1
+  %tuple.17 = (f32[2,2]{1,0}, f32[2,2]{1,0}) tuple(%get-tuple-element.96, %get-tuple-element.89)
+  %opt-barrier.2 = (f32[2,2]{1,0}, f32[2,2]{1,0}) opt-barrier(%tuple.17)
+  %get-tuple-element.101 = f32[2,2]{1,0} get-tuple-element(%opt-barrier.2), index=1
+  %get-tuple-element.102 = f32[2,2]{1,0} get-tuple-element(%opt-barrier.2), index=0
+  %cosine.2 = f32[2,2]{1,0} cosine(%get-tuple-element.102)
+  %multiply.8 = f32[2,2]{1,0} multiply(%get-tuple-element.101, %cosine.2)
+  %get-tuple-element.111 = s32[] get-tuple-element(%arg_tuple.6), index=2
+  %get-tuple-element.120 = f32[2,2,2]{2,1,0} get-tuple-element(%arg_tuple.6), index=4
+  %constant.39 = s32[] constant(-1)
+  %multiply.9 = s32[] multiply(%get-tuple-element.88, %constant.39)
+  %add.40 = s32[] add(%get-tuple-element.111, %multiply.9)
+  %add.37 = s32[] add(%add.40, %constant.39)
+  %constant.37 = s32[] constant(0)
+  %compare.8 = pred[] compare(%add.37, %constant.37), direction=LT
+  %add.39 = s32[] add(%add.40, %constant.35)
+  %select.6 = s32[] select(%compare.8, %add.39, %add.37)
+  %dynamic-slice.2 = f32[1,2,2]{2,1,0} dynamic-slice(%get-tuple-element.120, %select.6, %constant.37, %constant.37), dynamic_slice_sizes={1,2,2}
+  %bitcast = f32[2,2]{1,0} bitcast(%dynamic-slice.2)
+  ROOT %tuple.16 = (s32[], f32[2,2]{1,0}, s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}) tuple(%add.36, %multiply.8, %get-tuple-element.111, %bitcast, %get-tuple-element.120)
+}
+
+%region_4.102.clone (arg_tuple.5: (s32[], f32[2,2], s32[], f32[2,2], f32[2,2,2])) -> pred[] {
+  %arg_tuple.5 = (s32[], f32[2,2]{1,0}, s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}) parameter(0)
+  %get-tuple-element.81 = s32[] get-tuple-element(%arg_tuple.5), index=0
+  %constant.34 = s32[] constant(2)
+  ROOT %compare.7 = pred[] compare(%get-tuple-element.81, %constant.34), direction=LT
+}
+
+%region_0.29.clone.clone.sunk.clone (arg_tuple.8: (s32[], f32[2,2], f32[2,2,2], f32[2,2])) -> (s32[], f32[2,2], f32[2,2,2], f32[2,2]) {
+  %arg_tuple.8 = (s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}, f32[2,2]{1,0}) parameter(0)
+  %get-tuple-element.139 = s32[] get-tuple-element(%arg_tuple.8), index=0
+  %constant.41 = s32[] constant(1)
+  %add.43 = s32[] add(%get-tuple-element.139, %constant.41)
+  %get-tuple-element.138 = f32[2,2]{1,0} get-tuple-element(%arg_tuple.8), index=1
+  %sine.4 = f32[2,2]{1,0} sine(%get-tuple-element.138)
+  %get-tuple-element.137 = f32[2,2,2]{2,1,0} get-tuple-element(%arg_tuple.8), index=2
+  %get-tuple-element.136 = f32[2,2]{1,0} get-tuple-element(%arg_tuple.8), index=3
+  %bitcast.1 = f32[1,2,2]{2,1,0} bitcast(%get-tuple-element.136)
+  %constant.42 = s32[] constant(0)
+  %compare.10 = pred[] compare(%get-tuple-element.139, %constant.42), direction=LT
+  %constant.48 = s32[] constant(2)
+  %add.47 = s32[] add(%get-tuple-element.139, %constant.48)
+  %select.7 = s32[] select(%compare.10, %add.47, %get-tuple-element.139)
+  %dynamic-update-slice.4 = f32[2,2,2]{2,1,0:S(5)} dynamic-update-slice(%get-tuple-element.137, %bitcast.1, %select.7, %constant.42, %constant.42)
+  ROOT %tuple.20 = (s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}, f32[2,2]{1,0}) tuple(%add.43, %sine.4, %dynamic-update-slice.4, %get-tuple-element.138)
+}
+
+%region_1.44.clone.clone (arg_tuple.7: (s32[], f32[2,2], f32[2,2,2], f32[2,2])) -> pred[] {
+  %arg_tuple.7 = (s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}, f32[2,2]{1,0}) parameter(0)
+  %get-tuple-element.135 = s32[] get-tuple-element(%arg_tuple.7), index=0
+  %constant.40 = s32[] constant(2)
+  ROOT %compare.9 = pred[] compare(%get-tuple-element.135, %constant.40), direction=LT
+}
+
+%region_2.59 (Arg_0.60: f32[], Arg_1.61: f32[]) -> f32[] {
+  %Arg_0.60 = f32[] parameter(0)
+  %Arg_1.61 = f32[] parameter(1)
+  ROOT %add.62 = f32[] add(%Arg_0.60, %Arg_1.61)
+}
+
+ENTRY %main.123 (Arg_0.1: f32[2,2]) -> (f32[], f32[2,2]) {
+  %constant.5 = s32[] constant(0)
+  %Arg_0.1 = f32[2,2]{1,0} parameter(0)
+  %sine.7 = f32[2,2]{1,0} sine(%Arg_0.1)
+  %custom-call.8 = f32[2,2,2]{2,1,0:S(5)} custom-call(), custom_call_target="AllocateBuffer", api_version=API_VERSION_TYPED_FFI
+  %tuple.19 = (s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}, f32[2,2]{1,0}) tuple(%constant.5, %sine.7, %custom-call.8, %Arg_0.1)
+  %while.2 = (s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}, f32[2,2]{1,0}) while(%tuple.19), condition=%region_1.44.clone.clone, body=%region_0.29.clone.clone.sunk.clone, backend_config={"known_trip_count":{"n":"2"},"known_init_step":{"init":"0","step":"1"},"known_induction_variable":{"tuple_index":"0"}}
+  %get-tuple-element.55 = f32[2,2]{1,0} get-tuple-element(%while.2), index=1
+  %bitcast.2 = f32[4]{0} bitcast(%get-tuple-element.55)
+  %constant.4 = f32[] constant(0)
+  %reduce.63 = f32[] reduce(%bitcast.2, %constant.4), dimensions={0}, to_apply=%region_2.59
+  %constant.2 = f32[] constant(1)
+  %broadcast.3 = f32[2,2]{1,0} broadcast(%constant.2), dimensions={}
+  %get-tuple-element.45 = s32[] get-tuple-element(%while.2), index=0
+  %get-tuple-element.58 = f32[2,2]{1,0} get-tuple-element(%while.2), index=3
+  %get-tuple-element.57 = f32[2,2,2]{2,1,0} get-tuple-element(%while.2), index=2
+  %tuple.65 = (s32[], f32[2,2]{1,0}, s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}) tuple(%constant.5, %broadcast.3, %get-tuple-element.45, %get-tuple-element.58, %get-tuple-element.57)
+  %while.1 = (s32[], f32[2,2]{1,0}, s32[], f32[2,2]{1,0}, f32[2,2,2]{2,1,0}) while(%tuple.65), condition=%region_4.102.clone, body=%region_3.88.clone.clone, backend_config={"known_trip_count":{"n":"2"},"known_init_step":{"init":"0","step":"1"},"known_induction_variable":{"tuple_index":"0"}}
+  %get-tuple-element.115 = f32[2,2]{1,0} get-tuple-element(%while.1), index=3
+  %get-tuple-element.113 = f32[2,2]{1,0} get-tuple-element(%while.1), index=1
+  %tuple.116 = (f32[2,2]{1,0}, f32[2,2]{1,0}) tuple(%get-tuple-element.115, %get-tuple-element.113)
+  %opt-barrier.117 = (f32[2,2]{1,0}, f32[2,2]{1,0}) opt-barrier(%tuple.116)
+  %get-tuple-element.119 = f32[2,2]{1,0} get-tuple-element(%opt-barrier.117), index=1
+  %get-tuple-element.118 = f32[2,2]{1,0} get-tuple-element(%opt-barrier.117), index=0
+  %cosine.120 = f32[2,2]{1,0} cosine(%get-tuple-element.118)
+  %multiply.121 = f32[2,2]{1,0} multiply(%get-tuple-element.119, %cosine.120)
+  ROOT %tuple.122 = (f32[], f32[2,2]{1,0}) tuple(%reduce.63, %multiply.121)
+}
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          RunHloPass(MemorySpacePropagation(), module.get()));
+  EXPECT_TRUE(changed);
+  TF_EXPECT_OK(HloVerifier(/*layout_sensitive=*/false,
+                           /*allow_mixed_precision=*/false)
+                   .Run(module.get())
+                   .status());
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/post_layout_custom_call_rewriter.cc
+++ b/xla/service/gpu/transforms/post_layout_custom_call_rewriter.cc
@@ -1,0 +1,104 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/post_layout_custom_call_rewriter.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "mlir/AsmParser/AsmParser.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/LLVM.h"
+#include "xla/ffi/attribute_map.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/transforms/simplifiers/hlo_dce.h"
+#include "xla/service/memory_annotations.h"
+#include "xla/service/gpu/gpu_memory_space_assignment.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/errors.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::xla::ffi::CallFrameBuilder;
+
+absl::StatusOr<bool> RewriteAllocatePersistentBuffer(
+    HloCustomCallInstruction* custom_call) {
+  CHECK(custom_call->api_version() ==
+        CustomCallApiVersion::API_VERSION_TYPED_FFI);
+  CHECK_EQ(custom_call->operand_count(), 1);
+  const auto& backend_config_str = custom_call->raw_backend_config_string();
+
+  mlir::MLIRContext context;
+  mlir::Attribute attr = mlir::parseAttribute(backend_config_str, &context);
+  CallFrameBuilder::AttributesMap attributes;
+  if (auto dict = mlir::dyn_cast_or_null<mlir::DictionaryAttr>(attr)) {
+    // Convert the MLIR dictionary to FFI attributes.
+    TF_ASSIGN_OR_RETURN(attributes, ffi::BuildAttributesMap(dict));
+  } else {
+    return Internal(
+        "Unsupported backend config. Expected a string parsable into "
+        "dictionary attribute");
+  }
+  auto it = attributes.find("memory_space");
+  if (it == attributes.end()) {
+    return Internal("memory_space attribute not found in backend config.");
+  }
+
+  const auto& memory_space_str = std::get<std::string>(it->second);
+  auto* operand = custom_call->mutable_operand(0);
+  if (memory_space_str == "persistent_temp") {
+    operand->mutable_shape()->mutable_layout()->set_memory_space(
+        kTempBufferMemorySpaceColor);
+  } else if (memory_space_str == "host") {
+    operand->mutable_shape()->mutable_layout()->set_memory_space(
+        static_cast<int64_t>(stream_executor::MemoryType::kHost));
+  } else {
+    return Internal("Unsupported memory space.");
+  }
+  TF_RETURN_IF_ERROR(custom_call->ReplaceAllUsesWith(operand));
+  return true;
+}
+}  // namespace
+
+absl::StatusOr<bool> PostLayoutCustomCallRewriter::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+  for (auto* computation :
+       module->MakeComputationPostOrder(execution_threads)) {
+    for (auto* instruction : computation->MakeInstructionPostOrder()) {
+      if (instruction->IsCustomCall(memory_annotations::kAnnotateMemorySpace)) {
+        TF_ASSIGN_OR_RETURN(bool rewrited,
+                            RewriteAllocatePersistentBuffer(
+                                Cast<HloCustomCallInstruction>(instruction)));
+        changed |= rewrited;
+      }
+    }
+  }
+
+  if (changed) {
+    HloDCE hlo_dce;
+    TF_ASSIGN_OR_RETURN(bool dced, hlo_dce.Run(module, execution_threads));
+  }
+
+  return changed;
+}
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/post_layout_custom_call_rewriter.h
+++ b/xla/service/gpu/transforms/post_layout_custom_call_rewriter.h
@@ -1,0 +1,43 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_POST_LAYOUT_CUSTOM_CALL_REWRITER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_POST_LAYOUT_CUSTOM_CALL_REWRITER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla {
+namespace gpu {
+
+// Rewrites custom calls after running layout assignment and normalization.
+class PostLayoutCustomCallRewriter : public HloModulePass {
+ public:
+  absl::string_view name() const override {
+    return "post-layout-custom-call-rewriter";
+  }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_POST_LAYOUT_CUSTOM_CALL_REWRITER_H_

--- a/xla/service/memory_annotations.h
+++ b/xla/service/memory_annotations.h
@@ -35,6 +35,7 @@ inline const absl::string_view kMoveToDeviceCustomCallTarget = "MoveToDevice";
 inline const absl::string_view kPinToDeviceCustomCallTarget = "PinToDevice";
 inline const absl::string_view kPinToDeviceSramCustomCallTarget =
     "PinToDeviceSram";
+inline const absl::string_view kAnnotateMemorySpace = "AnnotateMemorySpace";
 
 }  // namespace memory_annotations
 }  // namespace xla


### PR DESCRIPTION
As mentioned in the 3-way meeting between Google, NVIDIA and xAI, we actually want to upstream some infra features we built internally at xAI to avoid accumulating conflicts between us and upstream.

This can be a first attempt to see how much opinion conflicts we would have and how likely we can upstream our things which will benefit open source community as well.

The overall philosophy we have is to make transforms mostly use-controllable in JAX and treat XLA simply as a lowering/decomposing tool. Thus, we have some internally-used custom call passed into XLA majorly for annotating info that the compiler needs to generate optimized graphs.

In this PR, we have two custom calls:
1) AllocateBuffer, which simply exposes the internal XLA custom op to JAX so that JAX can allocate uninitialized buffer. With this custom call, we don't need to use the delegate jnp.zeros or broadcast to allocate tensors, which often times will be CSEed in JAX. This is quite single responsibility and as it is a custom call, there is no magic compiler optimization on itself.
2) AnnotateMemorySpace, this custom call can annotate the operand buffer to be in any memory space the JAX users want, for instance, the persistent temp, host or in the future SMEM. Unlike `jax.device_put`, this custom call doesn't rely on jax.shardings to take place. It can work with any temp buffers inside a JAX program without knowing the sharding.

A very small memory space propagation pass for propagating the annotated memory space in forward direction was added because our transformations in JAX already makes the semantics clear. We don't rely on any magic XLA pattern matching which can likely lead to unexplained compilation failures for feature dev, such as, activation offload.

We also open source the JAX-side use cases in small, non-production related examples to illustrate the power of this change, for instance, the pipelined scan which essentially works like a drop-in replacement of `jax.lax.scan` but automatically offload `saved` residuals to host:

https://github.com/yliu120/jax_examples/blob/main/magics/transforms/pipelined_scan.py
https://github.com/yliu120/jax_examples/blob/main/tests/pipelined_scan_test.py

The entire code that handles complicated pipelining and host offloading only spans 100+ lines in Python. This pattern can also be used for other use cases.