### PR TITLE
[run_hlo_module] Add parsing debug option support to run_hlo_module

### DIFF
--- a/xla/tools/BUILD
+++ b/xla/tools/BUILD
@@ -553,6 +553,7 @@ xla_cc_test(
         "data/input_literal_f32_2_2.pbtxt",
         "data/must_alias.hlo",
         "data/must_alias_with_sharding.hlo",
+        "data/large_constant.hlo",
         ":run_hlo_module",
     ],
     deps = [

--- a/xla/tools/data/large_constant.hlo
+++ b/xla/tools/data/large_constant.hlo
@@ -1,0 +1,8 @@
+HloModule f
+ENTRY f {
+  p0 = s32[12] parameter(0)
+  c1 = s32[12] constant({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
+  c2 = s32[12] constant({10, 6, 3, 2, 5, 3, 7, 4, 2, 3, 1, 0})
+  x = s32[12] multiply(p0, c1)
+  ROOT y = s32[12] add(x, c2)
+}

--- a/xla/tools/run_hlo_module_bin_test.cc
+++ b/xla/tools/run_hlo_module_bin_test.cc
@@ -204,5 +204,51 @@ f32[2,2] {
 })"));
 }
 
+TEST_F(RunHloModuleTest, DumpAndParseDebugOptions) {
+  tsl::Env* env = tsl::Env::Default();
+  std::string tmp_dir;
+  EXPECT_TRUE(env->LocalTempFilename(&tmp_dir));
+  RunHlo("large_constant.hlo",
+         {"--xla_dump_to=" + tmp_dir, "--xla_dump_large_constants=true",
+          "--xla_gpu_dot_merger_threshold_mb=1234"});
+  std::string data;
+  TF_ASSERT_OK(tsl::ReadFileToString(
+      env, tsl::io::JoinPath(tmp_dir, "module_0000.f.debug_options"), &data));
+  EXPECT_THAT(data, testing::HasSubstr("xla_dump_large_constants: true"));
+  EXPECT_THAT(data,
+              testing::HasSubstr("xla_gpu_dot_merger_threshold_mb: 1234"));
+
+  std::string tmp_dir2;
+  EXPECT_TRUE(env->LocalTempFilename(&tmp_dir2));
+  EXPECT_NE(tmp_dir2, tmp_dir);
+  RunHlo("large_constant.hlo",
+         {"--xla_dump_to=" + tmp_dir2,
+          "--debug_options_file=" +
+              tsl::io::JoinPath(tmp_dir, "module_0000.f.debug_options"),
+          "--xla_gpu_dot_merger_threshold_mb=3253"});
+
+  // Check the new debug options. They should have the dump_large_constants set
+  // to true. This comes from the debug options file.
+  std::vector<std::string> files;
+  TF_ASSERT_OK(tsl::Env::Default()->GetMatchingPaths(
+      absl::StrCat(tmp_dir2, "/module*debug_options"), &files));
+  ASSERT_EQ(files.size(), 1);
+  TF_ASSERT_OK(tsl::ReadFileToString(env, files[0], &data));
+  EXPECT_THAT(data, testing::HasSubstr("xla_dump_large_constants: true"));
+  // Check that the new debug options has xla_gpu_dot_merger_threshold_mb set to
+  // 3253. This comes from the command line (overriding the debug options file).
+  EXPECT_THAT(data,
+              testing::HasSubstr("xla_gpu_dot_merger_threshold_mb: 3253"));
+  EXPECT_THAT(data, testing::Not(testing::HasSubstr(
+                        "xla_gpu_dot_merger_threshold_mb: 1234")));
+  // Read the dumped module and we should see large constant.
+  TF_ASSERT_OK(tsl::ReadFileToString(
+      env,
+      tsl::io::JoinPath(tmp_dir2, "module_0000.f.cpu_after_optimizations.txt"),
+      &data));
+  EXPECT_THAT(data, testing::HasSubstr(
+                        "constant({10, 6, 3, 2, 5, 3, 7, 4, 2, 3, 1, 0})"));
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/tools/run_hlo_module_main.cc
+++ b/xla/tools/run_hlo_module_main.cc
@@ -86,11 +86,34 @@ std::string GetReferencePlatformName(std::string reference_platform) {
   }
   return reference_platform;
 }
+
+// This function is parsing only the debug options file, because we cannot wait
+// till all the flags are parsed. If the debug_options file exists, then we have
+// to first consider the debug_options from that file, then XLA_FLAGS, and then
+// the command line flags. Hence, we parse the debug_options file first.
+std::optional<absl::string_view> GetDebugOptionsFileName(int argc,
+                                                         char* argv[]) {
+  for (int i = 1; i < argc; ++i) {
+    absl::string_view arg = argv[i];
+    if (absl::StrContains(arg, "--debug_options_file")) {
+      auto eq_idx = arg.find('=');
+      if (eq_idx != absl::string_view::npos) {
+        return arg.substr(eq_idx + 1);
+      } else {
+        LOG(QFATAL) << "No value provided for --debug_options_file. Expected "
+                    << "--debug_options_file=<filename>";
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
   xla::RunHloModuleOptions opts;
   bool different_random_seeds = false;
+  std::string unused_debug_options_filename;
   std::vector<tsl::Flag> flag_list = {
       tsl::Flag("platform", &opts.platform,
                 "The test platform that the HLO module will be executed on "
@@ -165,8 +188,24 @@ int main(int argc, char** argv) {
       tsl::Flag("different_random_seeds", &different_random_seeds,
                 "Whether each iteration should use a different random seed for "
                 "the HloModuleConfig."),
-  };
+      // This option is not used during parsing, but it is added here for
+      // documentation, and for ensuring that the parser knows this should be
+      // ignored if present.
+      tsl::Flag("debug_options_file", &unused_debug_options_filename,
+                "A file containing debug options to be passed to the HLO "
+                "module. The file should contain a serialized DebugOptions "
+                "proto message. The order of precedence: command line flags > "
+                "XLA_FLAGS > debug_options_file > default flags.")};
+
   xla::AppendDebugOptionsFlags(&flag_list);
+
+  std::optional<absl::string_view> debug_options_filename =
+      GetDebugOptionsFileName(argc, argv);
+  if (debug_options_filename.has_value()) {
+    xla::ParseFlagsFromDebugOptionsFile(debug_options_filename.value());
+  }
+  xla::ParseDebugOptionFlagsFromEnv(true);
+
   // The usage string includes the message at the top of the file, the
   // DebugOptions flags and the flags defined above.
   const std::string kUsageString =


### PR DESCRIPTION
The debug options dump file can now be passed as a command line arg to run_hlo_module via the flag `--debug_options_file=<path-to-file>`.