### PR TITLE
[ROCm] adjust hipblaslt workspace size for gfx942

### DIFF
--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -93,6 +93,7 @@ struct GemmConfig : public se::gpu::GemmConfig {
   // Size of the workspace based on NVIDIA recommendation:
   // https://docs.nvidia.com/cuda/cublas/#cublassetworkspace
   static constexpr int64_t kHopperWorkspace = 32 * 1024 * 1024;  // 32 MiB
+  static constexpr int64_t kGFX942Workspace = 76 * 1024 * 1024;  // 76 MiB
   static constexpr int64_t kGFX950Workspace = 64 * 1024 * 1024;  // 64 MiB
   static constexpr int64_t kDefaultWorkspace = 4 * 1024 * 1024;  // 4 MiB
   // the number of algorithms to consider for autotuning by default

--- a/xla/service/gpu/transforms/gemm_rewriter.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter.cc
@@ -2450,8 +2450,12 @@ class GemmWorkspaceRewriteVisitor : public DfsHloRewriteVisitor {
       workspace = GemmConfig::kHopperWorkspace;
     }
     auto *rocm_cc = std::get_if<se::RocmComputeCapability>(&gpu_version_);
-    if (rocm_cc != nullptr && rocm_cc->gfx_version() == "gfx950") {
-      workspace = GemmConfig::kGFX950Workspace;
+    if (rocm_cc != nullptr) {
+      if (rocm_cc->gfx_version() == "gfx942") {
+        workspace = GemmConfig::kGFX942Workspace;
+      } else if (rocm_cc->gfx_version() == "gfx950") {
+        workspace = GemmConfig::kGFX950Workspace;
+      }
     }
 
     // We do not know the workspace size required by cuBLAS, but we can guess


### PR DESCRIPTION
We need to adjust the workspace size for gfx942 as well.

Related PR: https://github.com/openxla/xla/pull/25171