### PR TITLE
Update kernel args limit for CUDA

### DIFF
--- a/xla/service/gpu/transforms/copy_fusion.cc
+++ b/xla/service/gpu/transforms/copy_fusion.cc
@@ -104,7 +104,8 @@ absl::StatusOr<bool> CopyFusion::DoCopyFusion(HloComputation* computation) {
       if (HloPredicateIsOp<HloOpcode::kCopy>(copy_user) &&
           copy_user->shape() == copy_user->operand(0)->shape() &&
           !copy_user->shape().IsTuple() &&
-          !copy_user->HasControlDependencies()) {
+          !copy_user->HasControlDependencies() &&
+          FusionFitsInBudget(*hlo, *copy_user, device_description_)) {
         copies.push_back(copy_user);
       } else {
         other_users.push_back(user);

--- a/xla/stream_executor/kernel.h
+++ b/xla/stream_executor/kernel.h
@@ -586,8 +586,11 @@ std::unique_ptr<KernelArgsPackedArrayBase> PackKernelArgs(
 template <typename ArgType>
 inline absl::StatusOr<std::unique_ptr<KernelArgsPackedArrayBase>>
 PackKernelArgs(absl::Span<const ArgType> args, uint32_t shared_mem_bytes) {
+#if GOOGLE_CUDA
+  static constexpr int kKernelArgsLimit = 4096;
+#else
   static constexpr int kKernelArgsLimit = 1024;
-
+#endif
   if (args.size() > kKernelArgsLimit)
     return absl::InvalidArgumentError(absl::StrCat(
         "Can't pack device memory arguments array of size ", args.size(),


### PR DESCRIPTION
We ran into two issues during internal testing that this PR addresses: the kernel args limit being too restrictive for CUDA, and copy fusion not respecting the budget limit.