### PR TITLE
[XLA:GPU] Hermetic Build oneAPI

### DIFF
--- a/build_tools/lint/tags.py
+++ b/build_tools/lint/tags.py
@@ -76,16 +76,16 @@ _TAGS_TO_DOCUMENTATION_MAP = {
     "broken": "Test will be marked with other tags to disable in `xla_test`.",
     "xla_interpreter": "Uses interpreter backend.",
     "xla_cpu": "Uses CPU backend.",
-    "xla_gpu_amd_any": "Uses ROCm backend.",
-    "xla_gpu_any": "Uses NVIDIA GPU backend.",
+    "xla_amdgpu_any": "Uses ROCm backend.",
+    "xla_nvgpu_any": "Uses NVIDIA GPU backend.",
     # Below tags are emitted alongside `requires-gpu-x` tags, which is what the
     # CI actually follows. So we may not execute on an A100, and instead use an
     # L4. These tags are taken literally internally.
-    "xla_gpu_p100": "Runs on a p100.",
-    "xla_gpu_v100": "Runs on a v100.",
-    "xla_gpu_a100": "Runs on an a100.",
-    "xla_gpu_h100": "Runs on an h100.",
-    "xla_gpu_b200": "Runs on a b200.",
+    "xla_p100": "Runs on a p100.",
+    "xla_v100": "Runs on a v100.",
+    "xla_a100": "Runs on an a100.",
+    "xla_h100": "Runs on an h100.",
+    "xla_b200": "Runs on a b200.",
     # Below tags are consumed by `xla_test`.
     "test_xla_cpu_no_thunks": (
         "Internally, `xla_test` sets `--xla_cpu_use_thunk_runtime` to false."

--- a/build_tools/lint/tags.py
+++ b/build_tools/lint/tags.py
@@ -76,16 +76,16 @@ _TAGS_TO_DOCUMENTATION_MAP = {
     "broken": "Test will be marked with other tags to disable in `xla_test`.",
     "xla_interpreter": "Uses interpreter backend.",
     "xla_cpu": "Uses CPU backend.",
-    "xla_amdgpu_any": "Uses ROCm backend.",
-    "xla_nvgpu_any": "Uses NVIDIA GPU backend.",
+    "xla_gpu_amd_any": "Uses ROCm backend.",
+    "xla_gpu_any": "Uses NVIDIA GPU backend.",
     # Below tags are emitted alongside `requires-gpu-x` tags, which is what the
     # CI actually follows. So we may not execute on an A100, and instead use an
     # L4. These tags are taken literally internally.
-    "xla_p100": "Runs on a p100.",
-    "xla_v100": "Runs on a v100.",
-    "xla_a100": "Runs on an a100.",
-    "xla_h100": "Runs on an h100.",
-    "xla_b200": "Runs on a b200.",
+    "xla_gpu_p100": "Runs on a p100.",
+    "xla_gpu_v100": "Runs on a v100.",
+    "xla_gpu_a100": "Runs on an a100.",
+    "xla_gpu_h100": "Runs on an h100.",
+    "xla_gpu_b200": "Runs on a b200.",
     # Below tags are consumed by `xla_test`.
     "test_xla_cpu_no_thunks": (
         "Internally, `xla_test` sets `--xla_cpu_use_thunk_runtime` to false."

--- a/build_tools/sycl/ci_test_xla.sh
+++ b/build_tools/sycl/ci_test_xla.sh
@@ -13,13 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-workspace=$1
-cd $workspace/xla
-
-if [ -z ${SYCL_TOOLKIT_PATH+x} ];
-then
-  export SYCL_TOOLKIT_PATH=$workspace/oneapi/compiler/2024.1/
-fi
-bazel_bin=$(ls $workspace/bazel/)
 ./configure.py --backend=SYCL --host_compiler=GCC
-$workspace/bazel/$bazel_bin build --config=verbose_logs -s --verbose_failures --nocheck_visibility //xla/tools:run_hlo_module
+bazel build \
+      --config=sycl_hermetic \
+      --build_tag_filters=gpu,sycl,requires-intel-gpu,-requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-cuda-only,-rocm-only,-no-sycl \
+      --test_tag_filters=gpu,sycl,requires-intel-gpu,-requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-cuda-only,-rocm-only,-no-sycl \
+      //xla/stream_executor/... 

--- a/build_tools/sycl/ci_test_xla.sh
+++ b/build_tools/sycl/ci_test_xla.sh
@@ -17,6 +17,6 @@
 ./configure.py --backend=SYCL --host_compiler=GCC
 bazel build \
       --config=sycl_hermetic \
-      --build_tag_filters=gpu,sycl,requires-intel-gpu,-requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-cuda-only,-rocm-only,-no-sycl \
-      --test_tag_filters=gpu,sycl,requires-intel-gpu,-requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-cuda-only,-rocm-only,-no-sycl \
-      //xla/stream_executor/... 
+      --build_tag_filters=gpu,sycl,requires-gpu-intel,-requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-cuda-only,-rocm-only,-no-sycl \
+      --test_tag_filters=gpu,sycl,requires-gpu-intel,-requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-cuda-only,-rocm-only,-no-sycl \
+      //xla/stream_executor/sycl:stream_executor_sycl

--- a/build_tools/sycl/ci_test_xla.sh
+++ b/build_tools/sycl/ci_test_xla.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+#set the configuration to select the host compiler
 ./configure.py --backend=SYCL --host_compiler=GCC
 bazel build \
       --config=sycl_hermetic \

--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -260,10 +260,18 @@ build:rocm_ci_hermetic --repo_env="OS=ubuntu_22.04"
 build:rocm_ci_hermetic --repo_env="ROCM_VERSION=6.2.0"
 build:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
+# SYCL Configuration (non-hermetic)
 build:sycl --crosstool_top=@local_config_sycl//crosstool:toolchain
 build:sycl --define=using_sycl=true
 build:sycl --define=tensorflow_mkldnn_contraction_kernel=0
-build:sycl --repo_env TF_NEED_SYCL=1
+build:sycl --repo_env=TF_NEED_SYCL=1
+build:sycl --repo_env=SYCL_BUILD_HERMETIC=0
+
+# Hermetic SYCL Configuration
+build:sycl_hermetic --config=sycl
+build:sycl_hermetic --repo_env=SYCL_BUILD_HERMETIC=1
+build:sycl_hermetic --repo_env=ONEAPI_VERSION=2025.1
+build:sycl_hermetic --repo_env=OS=ubuntu_24.10
 
 # Options to disable default on features
 build:nonccl --define=no_nccl_support=true

--- a/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/gpus/sycl/BUILD.tpl
@@ -1,13 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
 # Intel(R) Software Development Tools Licensed under the Intel End User License Agreement for Developer Tools (Version August 2024)
-# Intel(R) oneAPI DPC++/C++ Compiler, Intel(R) Vtune(TM) Profiler
+# Tools -> Intel(R) oneAPI DPC++/C++ Compiler, Intel(R) Vtune(TM) Profiler
 # Intel(R) Software Development Tools Licensed under the Intel Simplified Software License (Version October 2022)  
-# oneAPI Math Kernel Library (oneMKL)
+# Tools -> oneAPI Math Kernel Library (oneMKL)
 # Intel(R) Software Development Tools Licensed under Open Source Licenses Apache License, Version 2.0 
-# oneAPI Deep Neural Network Library, Intel(R) oneAPI Data Analytics Library (oneDAL)
-# Apache License, Version 2.0 with LLVM Exception --Intel(R) oneAPI DPC++/C++ Compiler,Intel(R) oneAPI DPC++ Library (oneDPL)
-# The GNU General Public License v3.0 ---Intel(R) Distribution for GDB*
+# Tools -> oneAPI Deep Neural Network Library, Intel(R) oneAPI Data Analytics Library (oneDAL)
+# Apache License, Version 2.0 with LLVM Exception -- Tools ->Intel(R) oneAPI DPC++/C++ Compiler,Intel(R) oneAPI DPC++ Library (oneDPL)
+# The GNU General Public License v3.0 -> Tools-- Intel(R) Distribution for GDB*
 licenses(["restricted"])  
 
 config_setting(

--- a/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/gpus/sycl/BUILD.tpl
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+
 # Intel(R) Software Development Tools Licensed under the Intel End User License Agreement for Developer Tools (Version August 2024)
 # Intel(R) Software Development Tools Licensed under the Intel Simplified Software License (Version October 2022)
 # Intel(R) Software Development Tools Licensed under Open Source Licenses Apache License, Version 2.0

--- a/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/gpus/sycl/BUILD.tpl
@@ -1,11 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
 # Intel(R) Software Development Tools Licensed under the Intel End User License Agreement for Developer Tools (Version August 2024)
-# Intel(R) Software Development Tools Licensed under the Intel Simplified Software License (Version October 2022)
-# Intel(R) Software Development Tools Licensed under Open Source Licenses Apache License, Version 2.0
-# Apache License, Version 2.0 with LLVM Exception
-# The GNU General Public License v3.0
-licenses(["restricted"]) 
+# Intel(R) oneAPI DPC++/C++ Compiler, Intel(R) Vtune(TM) Profiler
+# Intel(R) Software Development Tools Licensed under the Intel Simplified Software License (Version October 2022)  
+# oneAPI Math Kernel Library (oneMKL)
+# Intel(R) Software Development Tools Licensed under Open Source Licenses Apache License, Version 2.0 
+# oneAPI Deep Neural Network Library, Intel(R) oneAPI Data Analytics Library (oneDAL)
+# Apache License, Version 2.0 with LLVM Exception --Intel(R) oneAPI DPC++/C++ Compiler,Intel(R) oneAPI DPC++ Library (oneDPL)
+# The GNU General Public License v3.0 ---Intel(R) Distribution for GDB*
+licenses(["restricted"])  
 
 config_setting(
     name = "using_sycl",

--- a/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/gpus/sycl/BUILD.tpl
@@ -1,4 +1,10 @@
 package(default_visibility = ["//visibility:public"])
+# Intel(R) Software Development Tools Licensed under the Intel End User License Agreement for Developer Tools (Version August 2024)
+# Intel(R) Software Development Tools Licensed under the Intel Simplified Software License (Version October 2022)
+# Intel(R) Software Development Tools Licensed under Open Source Licenses Apache License, Version 2.0
+# Apache License, Version 2.0 with LLVM Exception
+# The GNU General Public License v3.0
+licenses(["restricted"]) 
 
 config_setting(
     name = "using_sycl",

--- a/third_party/gpus/sycl/sycl_dl_essential.bzl
+++ b/third_party/gpus/sycl/sycl_dl_essential.bzl
@@ -1,0 +1,41 @@
+sycl_redist = {
+    "ubuntu_24.10": {
+        "2025.1": {
+            "sycl_dl_essential": {
+                "root": "dl_essential_root",
+                "archives": [
+                    {
+                        "url": "https://tensorflow-file-hosting.s3.us-east-1.amazonaws.com/intel-oneapi-base-toolkit-2025.1.3.7.tar.gz",
+                        "sha256": "2213104bd122336551aa144512e7ab99e4a84220e77980b5f346edc14ebd458a",
+                    },
+                ],
+            }
+        }
+    },
+    "ubuntu_24.04": {
+        "2025.1": {
+            "sycl_dl_essential": {
+                "root": "dl_essential_root", 
+                "archives": [
+                    {
+                        "url": "https://tensorflow-file-hosting.s3.us-east-1.amazonaws.com/intel-oneapi-base-toolkit-2025.1.3.7.tar.gz",
+                        "sha256": "2213104bd122336551aa144512e7ab99e4a84220e77980b5f346edc14ebd458a",
+                    },
+                ],
+            }
+        }
+    },
+    "ubuntu_22.04": {
+        "2025.1": {
+            "sycl_dl_essential": {
+                "root": "dl_essential_root",
+                "archives": [
+                    {
+                        "url": "https://tensorflow-file-hosting.s3.us-east-1.amazonaws.com/intel-oneapi-base-toolkit-2025.1.3.7.tar.gz",
+                        "sha256": "2213104bd122336551aa144512e7ab99e4a84220e77980b5f346edc14ebd458a",
+                    },
+                ],
+            }
+        }
+    }
+}

--- a/third_party/gpus/sycl_configure.bzl
+++ b/third_party/gpus/sycl_configure.bzl
@@ -25,6 +25,7 @@ load(
     "make_copy_dir_rule",
     "make_copy_files_rule",
 )
+load("//third_party/gpus/sycl:sycl_dl_essential.bzl", "sycl_redist")
 
 _GCC_HOST_COMPILER_PATH = "GCC_HOST_COMPILER_PATH"
 _GCC_HOST_COMPILER_PREFIX = "GCC_HOST_COMPILER_PREFIX"
@@ -371,6 +372,33 @@ def _create_dummy_repository(repository_ctx):
         },
     )
 
+def _extract_file_name_from_url(url):
+    """Extract the file name from a URL by finding the last slash '/'."""
+    return url[url.rfind("/") + 1:]
+
+def _download_and_extract_archive(repository_ctx, archive_info, distribution_path):
+    """Downloads and extracts a tar.gz ONEAPI redistributable (cached by Bazel)."""
+ 
+    archive_url = archive_info.get("url")
+    archive_sha256 = archive_info.get("sha256")
+    if not archive_url or not archive_sha256:
+        fail("Missing required archive metadata: 'url' or 'sha256'")
+
+    repository_ctx.report_progress("Installing oneAPI Basekit to: %s" % distribution_path)
+
+    archive_override = repository_ctx.os.environ.get("oneAPI_ARCHIVE_OVERRIDE")
+    if archive_override:
+        repository_ctx.report_progress("Using overridden archive: %s" % archive_override)
+        repository_ctx.extract(archive_override, distribution_path)
+    else:
+        repository_ctx.download_and_extract(
+            url = archive_url,
+            sha256 = archive_sha256,
+            output = distribution_path,
+        )
+
+    repository_ctx.report_progress("oneAPI Basekit archive extracted and installed.")
+
 def _create_local_sycl_repository(repository_ctx):
     tpl_paths = {labelname: _tpl_path(repository_ctx, labelname) for labelname in [
         "sycl:build_defs.bzl",
@@ -381,7 +409,33 @@ def _create_local_sycl_repository(repository_ctx):
     ]}
 
     bash_bin = get_bash_bin(repository_ctx)
-    sycl_config = _get_sycl_config(repository_ctx, bash_bin)
+   
+    hermetic = repository_ctx.os.environ.get("SYCL_BUILD_HERMETIC") == "1"
+    if hermetic:
+        oneapi_version = repository_ctx.os.environ.get("ONEAPI_VERSION", "")
+        os_id = repository_ctx.os.environ.get("OS", "")
+        if not oneapi_version or not os_id:
+            fail("ONEAPI_VERSION and OS must be set via --repo_env for hermetic build.")
+        redist_info = sycl_redist.get(os_id, {}).get(oneapi_version, {}).get("sycl_dl_essential")
+        if not redist_info:
+            fail("Missing redistributable definition for %s on %s" % (oneapi_version, os_id))
+        archive_info = redist_info["archives"][0]
+        install_path = str(repository_ctx.path(redist_info["root"]))
+        _download_and_extract_archive(repository_ctx, archive_info, install_path)
+
+        sycl_config =  struct(
+          sycl_basekit_path = install_path + "/oneapi/",
+          sycl_toolkit_path = install_path + "/oneapi/compiler/"+ oneapi_version,
+          # TODO(Intel) 
+          # hard coded for this oneAPI version 2025.1,
+          # change to auto-detect the sycl_version_number
+          sycl_version_number = "80000",
+          sycl_basekit_version_number = oneapi_version,
+        )
+    else:
+        install_path = repository_ctx.os.environ.get("SYCL_TOOLKIT_PATH", "") or "/opt/intel/oneapi/compiler/2025.1"
+        repository_ctx.report_progress("Falling back to default SYCL path: %s" % install_path)
+        sycl_config = _get_sycl_config(repository_ctx, bash_bin)
 
     # Copy header and library files to execroot.
     copy_rules = [

--- a/third_party/gpus/sycl_configure.bzl
+++ b/third_party/gpus/sycl_configure.bzl
@@ -386,7 +386,7 @@ def _download_and_extract_archive(repository_ctx, archive_info, distribution_pat
 
     repository_ctx.report_progress("Installing oneAPI Basekit to: %s" % distribution_path)
 
-    archive_override = repository_ctx.os.environ.get("oneAPI_ARCHIVE_OVERRIDE")
+    archive_override = repository_ctx.getenv("oneAPI_ARCHIVE_OVERRIDE")
     if archive_override:
         repository_ctx.report_progress("Using overridden archive: %s" % archive_override)
         repository_ctx.extract(archive_override, distribution_path)
@@ -410,10 +410,10 @@ def _create_local_sycl_repository(repository_ctx):
 
     bash_bin = get_bash_bin(repository_ctx)
    
-    hermetic = repository_ctx.os.environ.get("SYCL_BUILD_HERMETIC") == "1"
+    hermetic = repository_ctx.getenv("SYCL_BUILD_HERMETIC") == "1"
     if hermetic:
-        oneapi_version = repository_ctx.os.environ.get("ONEAPI_VERSION", "")
-        os_id = repository_ctx.os.environ.get("OS", "")
+        oneapi_version = repository_ctx.getenv("ONEAPI_VERSION") or ""
+        os_id = repository_ctx.getenv("OS") or ""
         if not oneapi_version or not os_id:
             fail("ONEAPI_VERSION and OS must be set via --repo_env for hermetic build.")
         redist_info = sycl_redist.get(os_id, {}).get(oneapi_version, {}).get("sycl_dl_essential")
@@ -433,7 +433,7 @@ def _create_local_sycl_repository(repository_ctx):
           sycl_basekit_version_number = oneapi_version,
         )
     else:
-        install_path = repository_ctx.os.environ.get("SYCL_TOOLKIT_PATH", "") or "/opt/intel/oneapi/compiler/2025.1"
+        install_path = repository_ctx.getenv("SYCL_TOOLKIT_PATH") or "/opt/intel/oneapi/compiler/2025.1"
         repository_ctx.report_progress("Falling back to default SYCL path: %s" % install_path)
         sycl_config = _get_sycl_config(repository_ctx, bash_bin)
 

--- a/third_party/gpus/sycl_configure.bzl
+++ b/third_party/gpus/sycl_configure.bzl
@@ -412,8 +412,8 @@ def _create_local_sycl_repository(repository_ctx):
    
     hermetic = repository_ctx.getenv("SYCL_BUILD_HERMETIC") == "1"
     if hermetic:
-        oneapi_version = repository_ctx.getenv("ONEAPI_VERSION") or ""
-        os_id = repository_ctx.getenv("OS") or ""
+        oneapi_version = repository_ctx.getenv("ONEAPI_VERSION","")
+        os_id = repository_ctx.getenv("OS","")
         if not oneapi_version or not os_id:
             fail("ONEAPI_VERSION and OS must be set via --repo_env for hermetic build.")
         redist_info = sycl_redist.get(os_id, {}).get(oneapi_version, {}).get("sycl_dl_essential")

--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -86,6 +86,10 @@ cc_library(
 
 cc_library(
     name = "stream_executor_sycl",
+    tags = [
+        "gpu",
+        "sycl-only",
+    ],
     deps = [
         ":sycl_platform_id",
         ":sycl_rpath",


### PR DESCRIPTION
This PR introduces support for a hermetic build for XLA using oneAPI toolkit. It enables Bazel to download and extract a prebuilt SYCL basekit automatically during the build process, ensuring consistent, reproducible environments without requiring a system-wide oneAPI installation.
It also adds basic build tests for CI. Execution of tests will be covered in the subsequent PRs