### PR TITLE
Add Support for Custom call with Called Computation and Layout Constraints

### DIFF
--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -5545,10 +5545,10 @@ XlaOp CustomCallWithComputationAndLayouts(
         output_operand_aliasing,
     const Literal* literal, CustomCallSchedule schedule,
     CustomCallApiVersion api_version) {
-  return builder->CustomCall(
-      call_target_name, operands, computation, shape, opaque,
-      operand_shapes_with_layout, has_side_effect,
-      output_operand_aliasing, literal, schedule, api_version);
+  return builder->CustomCall(call_target_name, operands, computation, shape,
+                             opaque, operand_shapes_with_layout,
+                             has_side_effect, output_operand_aliasing, literal,
+                             schedule, api_version);
 }
 
 XlaOp CustomCallWithComputation(

--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -5536,6 +5536,21 @@ XlaOp CustomCall(
                              schedule, api_version);
 }
 
+XlaOp CustomCallWithComputationAndLayouts(
+    XlaBuilder* builder, const std::string& call_target_name,
+    absl::Span<const XlaOp> operands, const XlaComputation& computation,
+    const Shape& shape, absl::Span<const Shape> operand_shapes_with_layout,
+    const std::string& opaque, bool has_side_effect,
+    absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
+        output_operand_aliasing,
+    const Literal* literal, CustomCallSchedule schedule,
+    CustomCallApiVersion api_version) {
+  return builder->CustomCall(
+      call_target_name, operands, computation, shape, opaque,
+      operand_shapes_with_layout, has_side_effect,
+      output_operand_aliasing, literal, schedule, api_version);
+}
+
 XlaOp CustomCallWithComputation(
     XlaBuilder* builder, const std::string& call_target_name,
     absl::Span<const XlaOp> operands, const XlaComputation& computation,

--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -5538,7 +5538,7 @@ XlaOp CustomCall(
 
 XlaOp CustomCallWithComputationAndLayouts(
     XlaBuilder* builder, const std::string& call_target_name,
-    absl::Span<const XlaOp> operands, const XlaComputation& computation,
+    absl::Span<const XlaOp> operands, XlaComputationId computation,
     const Shape& shape, absl::Span<const Shape> operand_shapes_with_layout,
     const std::string& opaque, bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>

--- a/xla/hlo/builder/xla_builder.h
+++ b/xla/hlo/builder/xla_builder.h
@@ -1515,6 +1515,15 @@ class XlaBuilder {
           output_operand_aliasing,
       const Literal* literal, CustomCallSchedule schedule,
       CustomCallApiVersion api_version);
+  friend XlaOp CustomCallWithComputationAndLayouts(
+      XlaBuilder* builder, const std::string& call_target_name,
+      absl::Span<const XlaOp> operands, const XlaComputation& computation,
+      const Shape& shape, absl::Span<const Shape> operand_shapes_with_layout,
+      const std::string& opaque, bool has_side_effect,
+      absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
+          output_operand_aliasing,
+      const Literal* literal, CustomCallSchedule schedule,
+      CustomCallApiVersion api_version);
   friend XlaOp CustomCallWithComputation(
       XlaBuilder* builder, const std::string& call_target_name,
       absl::Span<const XlaOp> operands, XlaComputationId computation,
@@ -2492,6 +2501,19 @@ XlaOp CompositeCall(XlaBuilder* builder, XlaComputationId computation,
 XlaOp CustomCall(
     XlaBuilder* builder, const std::string& call_target_name,
     absl::Span<const XlaOp> operands, const Shape& shape,
+    const std::string& opaque = "", bool has_side_effect = false,
+    absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
+        output_operand_aliasing = {},
+    const Literal* literal = nullptr,
+    CustomCallSchedule schedule = CustomCallSchedule::SCHEDULE_NONE,
+    CustomCallApiVersion api_version = API_VERSION_ORIGINAL);
+
+// Overload which constructs a custom call that applies an Xla computation
+// and fixed layout.
+XlaOp CustomCallWithComputationAndLayouts(
+    XlaBuilder* builder, const std::string& call_target_name,
+    absl::Span<const XlaOp> operands, const XlaComputation& computation,
+    const Shape& shape, absl::Span<const Shape> operand_shapes_with_layout,
     const std::string& opaque = "", bool has_side_effect = false,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
         output_operand_aliasing = {},

--- a/xla/hlo/builder/xla_builder.h
+++ b/xla/hlo/builder/xla_builder.h
@@ -1517,7 +1517,7 @@ class XlaBuilder {
       CustomCallApiVersion api_version);
   friend XlaOp CustomCallWithComputationAndLayouts(
       XlaBuilder* builder, const std::string& call_target_name,
-      absl::Span<const XlaOp> operands, const XlaComputation& computation,
+      absl::Span<const XlaOp> operands, XlaComputationId computation,
       const Shape& shape, absl::Span<const Shape> operand_shapes_with_layout,
       const std::string& opaque, bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
@@ -2512,7 +2512,7 @@ XlaOp CustomCall(
 // and fixed layout.
 XlaOp CustomCallWithComputationAndLayouts(
     XlaBuilder* builder, const std::string& call_target_name,
-    absl::Span<const XlaOp> operands, const XlaComputation& computation,
+    absl::Span<const XlaOp> operands, XlaComputationId computation,
     const Shape& shape, absl::Span<const Shape> operand_shapes_with_layout,
     const std::string& opaque = "", bool has_side_effect = false,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>

--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -1008,9 +1008,16 @@ absl::StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
         for (const ShapeProto& shape_proto : operand_shapes_with_layout) {
           operand_shapes.emplace_back(shape_proto);
         }
-        instruction =
-            CreateCustomCall(shape, all_operands(), proto.custom_call_target(),
-                             operand_shapes, proto.backend_config());
+        if (proto.called_computation_ids_size() == 1) {
+          instruction =
+              CreateCustomCall(shape, all_operands(), computations(0),
+                               proto.custom_call_target(), operand_shapes,
+                               proto.backend_config());
+        } else {
+          instruction = CreateCustomCall(
+              shape, all_operands(), proto.custom_call_target(), operand_shapes,
+              proto.backend_config());
+        }
       } else {
         if (proto.called_computation_ids_size() == 1) {
           instruction = CreateCustomCall(shape, all_operands(), computations(0),
@@ -2500,6 +2507,16 @@ HloInstruction::CreateCompositeCall(const Shape& shape,
     CustomCallApiVersion api_version) {
   return std::make_unique<HloCustomCallInstruction>(
       shape, operands, custom_call_target, std::move(opaque),
+      operand_shapes_with_layout, api_version);
+}
+
+/* static */ std::unique_ptr<HloInstruction> HloInstruction::CreateCustomCall(
+    const Shape& shape, absl::Span<HloInstruction* const> operands,
+    HloComputation* to_apply, absl::string_view custom_call_target,
+    absl::Span<const Shape> operand_shapes_with_layout, std::string opaque,
+    CustomCallApiVersion api_version) {
+  return std::make_unique<HloCustomCallInstruction>(
+      shape, operands, to_apply, custom_call_target, std::move(opaque),
       operand_shapes_with_layout, api_version);
 }
 

--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -1008,6 +1008,7 @@ absl::StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
         for (const ShapeProto& shape_proto : operand_shapes_with_layout) {
           operand_shapes.emplace_back(shape_proto);
         }
+        TF_RET_CHECK(proto.called_computation_ids_size() <= 1);
         if (proto.called_computation_ids_size() == 1) {
           instruction =
               CreateCustomCall(shape, all_operands(), computations(0),

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -1133,6 +1133,15 @@ class HloInstruction {
       std::string opaque = "",
       CustomCallApiVersion api_version = API_VERSION_ORIGINAL);
 
+  // Overload which constrains the layouts of the operand and result and apply a
+  // computation.
+  static std::unique_ptr<HloInstruction> CreateCustomCall(
+      const Shape& shape, absl::Span<HloInstruction* const> operands,
+      HloComputation* to_apply, absl::string_view custom_call_target,
+      absl::Span<const Shape> operand_shapes_with_layout,
+      std::string opaque = "",
+      CustomCallApiVersion api_version = API_VERSION_ORIGINAL);
+
   // Creates a tuple instruction with the given elements. This is a convenience
   // wrapper around CreateVariadic.
   static std::unique_ptr<HloInstruction> CreateTuple(

--- a/xla/hlo/ir/hlo_instructions.cc
+++ b/xla/hlo/ir/hlo_instructions.cc
@@ -3203,6 +3203,25 @@ HloCustomCallInstruction::HloCustomCallInstruction(
   set_raw_backend_config_string(std::move(opaque));
 }
 
+HloCustomCallInstruction::HloCustomCallInstruction(
+    const Shape& shape, absl::Span<HloInstruction* const> operands,
+    HloComputation* to_apply, absl::string_view custom_call_target,
+    std::string opaque, absl::Span<const Shape> operand_shapes_with_layout,
+    CustomCallApiVersion api_version)
+    : HloCallableInstruction(HloOpcode::kCustomCall, shape, operands, to_apply),
+      custom_call_target_(custom_call_target),
+      feature_group_count_(1),
+      batch_group_count_(1),
+      layout_constrained_(true),
+      padding_type_(PaddingType::PADDING_INVALID),
+      operand_shapes_with_layout_(operand_shapes_with_layout.begin(),
+                                  operand_shapes_with_layout.end()),
+      custom_call_has_side_effect_(false),
+      custom_call_schedule_(CustomCallSchedule::SCHEDULE_NONE),
+      api_version_(api_version) {
+  set_raw_backend_config_string(std::move(opaque));
+}
+
 HloInstructionProto HloCustomCallInstruction::ToProto() const {
   HloInstructionProto proto = HloInstruction::ToProto();
   if (window_ != nullptr) {

--- a/xla/hlo/ir/hlo_instructions.h
+++ b/xla/hlo/ir/hlo_instructions.h
@@ -2096,6 +2096,16 @@ class HloCustomCallInstruction : public HloCallableInstruction {
                            absl::Span<const Shape> operand_shapes_with_layout,
                            CustomCallApiVersion api_version);
 
+  // Constructor for a custom call with constrained layout and a to_apply
+  // computation. 'shape' and 'operands_with_layout' must all have layouts.
+  HloCustomCallInstruction(const Shape& shape,
+                           absl::Span<HloInstruction* const> operands,
+                           HloComputation* to_apply,
+                           absl::string_view custom_call_target,
+                           std::string opaque,
+                           absl::Span<const Shape> operand_shapes_with_layout,
+                           CustomCallApiVersion api_version);
+
   // Constructor for a custom call with a to_apply computation.
   HloCustomCallInstruction(const Shape& shape,
                            absl::Span<HloInstruction* const> operands,

--- a/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
+++ b/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
@@ -4265,7 +4265,23 @@ LogicalResult ExportXlaOp(CustomCallOp op, OpLoweringContext ctx) {
   }
 
   xla::XlaOp custom_call;
-  if (op.getCalledComputations().size() == 1) {
+  if (op.getCalledComputations().size() == 1 &&
+      op.getOperandLayouts() && op.getResultLayouts()) {
+    mlir::func::FuncOp callee = ctx.converter->LookUpSymbol(
+        mlir::cast<FlatSymbolRefAttr>(op.getCalledComputations()[0]));
+    if (failed(ctx.converter->RunOnFunction(callee))) return failure();
+    xla::XlaComputation& computation =
+        ctx.converter->GetLoweredComputation(callee);
+    auto operand_shapes_with_layout = ConvertTypesToShapesWithLayout(
+        op.getOperandTypes(), op.getOperandLayouts().value());
+    SetLayout(result_shape, op.getResultLayouts().value());
+
+    custom_call = xla::CustomCallWithComputationAndLayouts(
+        ctx.builder, call_target_name, args, computation, result_shape,
+        operand_shapes_with_layout, backend_config, op.getHasSideEffect(),
+        output_operand_aliasing, literal_ptr, *custom_call_schedule,
+        *xla_api_version);
+  } else if (op.getCalledComputations().size() == 1) {
     mlir::func::FuncOp callee = ctx.converter->LookUpSymbol(
         mlir::cast<FlatSymbolRefAttr>(op.getCalledComputations()[0]));
     if (failed(ctx.converter->RunOnFunction(callee))) return failure();

--- a/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
+++ b/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
@@ -4262,7 +4262,7 @@ LogicalResult ExportXlaOp(CustomCallOp op, OpLoweringContext ctx) {
     mlir::func::FuncOp callee = ctx.converter->LookUpSymbol(
         mlir::cast<FlatSymbolRefAttr>(op.getCalledComputations()[0]));
     if (failed(ctx.converter->RunOnFunction(callee))) return failure();
-    xla::XlaComputation& computation =
+    xla::XlaComputationId computation =
         ctx.converter->GetLoweredComputation(callee);
     auto operand_shapes_with_layout = ConvertTypesToShapesWithLayout(
         op.getOperandTypes(), op.getOperandLayouts().value());

--- a/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
+++ b/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
@@ -4257,8 +4257,8 @@ LogicalResult ExportXlaOp(CustomCallOp op, OpLoweringContext ctx) {
   }
 
   xla::XlaOp custom_call;
-  if (op.getCalledComputations().size() == 1 &&
-      op.getOperandLayouts() && op.getResultLayouts()) {
+  if (op.getCalledComputations().size() == 1 && op.getOperandLayouts() &&
+      op.getResultLayouts()) {
     mlir::func::FuncOp callee = ctx.converter->LookUpSymbol(
         mlir::cast<FlatSymbolRefAttr>(op.getCalledComputations()[0]));
     if (failed(ctx.converter->RunOnFunction(callee))) return failure();

--- a/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
+++ b/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
@@ -4205,14 +4205,6 @@ LogicalResult ExportXlaOp(CustomCallOp op, OpLoweringContext ctx) {
     return op.emitOpError()
            << "cannot export with more than one called computations";
 
-  // Custom call can be exported either with called computation or with layout
-  // attributes. The XlaBuilder API does not allow both.
-  if (!op.getCalledComputations().empty() && op.getOperandLayouts() &&
-      op.getResultLayouts()) {
-    return op.emitOpError() << "cannot export if both called computation and "
-                               "layouts are specified";
-  }
-
   auto xla_api_version = xla::ConvertCustomCallApiVersion(op.getApiVersion());
   if (!xla_api_version.ok()) return failure();
 

--- a/xla/service/gpu/custom_call_test.cc
+++ b/xla/service/gpu/custom_call_test.cc
@@ -623,7 +623,7 @@ TEST_F(CustomCallTest, WithCalledComputationAndLayouts) {
   CustomCallWithComputationAndLayouts(
       &b, "xla.gpu.ext.memcpy_with_called_computation",
       /*operands=*/{Broadcast(ConstantR0WithType(&b, F32, 42.0), {128, 128})},
-      copy_computation, shape, {shape}, /*opaque=*/"",
+      b.AddSubComputation(copy_computation), shape, {shape}, /*opaque=*/"",
       /*has_side_effect=*/false, /*output_operand_aliasing=*/{},
       /*literal=*/nullptr, /*schedule=*/CustomCallSchedule::SCHEDULE_NONE,
       /*api_version=*/CustomCallApiVersion::API_VERSION_TYPED_FFI);

--- a/xla/service/gpu/custom_call_test.cc
+++ b/xla/service/gpu/custom_call_test.cc
@@ -612,7 +612,7 @@ TEST_F(CustomCallTest, WithCalledComputation) {
 }
 
 TEST_F(CustomCallTest, WithCalledComputationAndLayouts) {
-  auto shape = ShapeUtil::MakeShapeWithDenseLayout(F32, {128}, {0});
+  auto shape = ShapeUtil::MakeShapeWithDenseLayout(F32, {128, 128}, {0, 1});
   // Build a called computation which is just a copy instruction.
   XlaBuilder copy("copy");
   auto p0 = Parameter(&copy, 0, shape, "l_val");
@@ -622,7 +622,7 @@ TEST_F(CustomCallTest, WithCalledComputationAndLayouts) {
   XlaBuilder b(TestName());
   CustomCallWithComputationAndLayouts(
       &b, "xla.gpu.ext.memcpy_with_called_computation",
-      /*operands=*/{Broadcast(ConstantR0WithType(&b, F32, 42.0), {128})},
+      /*operands=*/{Broadcast(ConstantR0WithType(&b, F32, 42.0), {128, 128})},
       copy_computation, shape, {shape}, /*opaque=*/"",
       /*has_side_effect=*/false, /*output_operand_aliasing=*/{},
       /*literal=*/nullptr, /*schedule=*/CustomCallSchedule::SCHEDULE_NONE,

--- a/xla/service/gpu/custom_call_test.cc
+++ b/xla/service/gpu/custom_call_test.cc
@@ -620,13 +620,10 @@ TEST_F(CustomCallTest, WithCalledComputationAndLayouts) {
   auto copy_computation = copy.Build().value();
 
   XlaBuilder b(TestName());
-  auto operand = Broadcast(ConstantR0WithType(&b, F32, 42.0), {128});
-  // auto shape_or = b.GetShapePtr(operand);
-  // EXPECT_TRUE(shape_or.ok());
-  // shape_or->mutable_layout()->mutable_minor_to_major() = {0};
   CustomCallWithComputationAndLayouts(
       &b, "xla.gpu.ext.memcpy_with_called_computation",
-      /*operands=*/{operand}, copy_computation, shape, {shape}, /*opaque=*/"",
+      /*operands=*/{Broadcast(ConstantR0WithType(&b, F32, 42.0), {128})},
+      copy_computation, shape, {shape}, /*opaque=*/"",
       /*has_side_effect=*/false, /*output_operand_aliasing=*/{},
       /*literal=*/nullptr, /*schedule=*/CustomCallSchedule::SCHEDULE_NONE,
       /*api_version=*/CustomCallApiVersion::API_VERSION_TYPED_FFI);

--- a/xla/service/gpu/custom_call_test.cc
+++ b/xla/service/gpu/custom_call_test.cc
@@ -611,6 +611,28 @@ TEST_F(CustomCallTest, WithCalledComputation) {
   EXPECT_THAT(result.data<float>(), ::testing::Each(42));
 }
 
+TEST_F(CustomCallTest, WithCalledComputationAndLayouts) {
+  auto shape = ShapeUtil::MakeShapeWithDenseLayout(F32, {128}, {0});
+  // Build a called computation which is just a copy instruction.
+  XlaBuilder copy("copy");
+  auto p0 = Parameter(&copy, 0, shape, "l_val");
+  Copy(p0);
+  auto copy_computation = copy.Build().value();
+
+  XlaBuilder b(TestName());
+  auto operand = Broadcast(ConstantR0WithType(&b, F32, 42.0), {128});
+  // auto shape_or = b.GetShapePtr(operand);
+  // EXPECT_TRUE(shape_or.ok());
+  // shape_or->mutable_layout()->mutable_minor_to_major() = {0};
+  CustomCallWithComputationAndLayouts(
+      &b, "xla.gpu.ext.memcpy_with_called_computation",
+      /*operands=*/{operand}, copy_computation, shape, {shape}, /*opaque=*/"",
+      /*has_side_effect=*/false, /*output_operand_aliasing=*/{},
+      /*literal=*/nullptr, /*schedule=*/CustomCallSchedule::SCHEDULE_NONE,
+      /*api_version=*/CustomCallApiVersion::API_VERSION_TYPED_FFI);
+  TF_ASSERT_OK_AND_ASSIGN(auto result, ExecuteAndTransfer(&b, {}, &shape));
+  EXPECT_THAT(result.data<float>(), ::testing::Each(42));
+}
 //===----------------------------------------------------------------------===//
 // XLA:FFI handler with execution context
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Overload custom call creation to support custom call with both computation attached and layout constraint. Useful for cudnn sdpa custom call where layout constraint is needed and computation is used to extend cudnn functionality to support flex attention. See https://github.com/openxla/xla/pull/25298.