### PR TITLE
PJRT_Executable_DeserializeAndLoad: plumb compile options

### DIFF
--- a/xla/pjrt/c/CHANGELOG.md
+++ b/xla/pjrt/c/CHANGELOG.md
@@ -1,11 +1,14 @@
 # PJRT C API changelog
 
-## 0.69
+## 0.70
+* Added `overridden_serialized_compile_options` and
+  `overridden_serialized_compile_options_size` fields to
+  `PJRT_Executable_DeserializeAndLoad_Args`.
 
+## 0.69
 * Implemented PjRtClient::CreateUninitializedBuffer
 
 ## 0.68
-
 * Changed the type of ``topology`` in
   ``PJRT_TopologyDescription_PlatformName_Args`` and
   ``PJRT_TopologyDescription_GetDeviceDescriptions_Args`` from

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -82,7 +82,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 69
+#define PJRT_API_MINOR 70
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in
@@ -1803,6 +1803,11 @@ struct PJRT_Executable_DeserializeAndLoad_Args {
   const char* serialized_executable;
   size_t serialized_executable_size;
   PJRT_LoadedExecutable* loaded_executable;  // out
+  // Serialized CompileOptionsProto or null (to use the options
+  // from the serialized executable).
+  // (https://github.com/openxla/xla/blob/main/xla/pjrt/compile_options.proto)
+  const char* overridden_serialized_compile_options;
+  size_t overridden_serialized_compile_options_size;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_DeserializeAndLoad_Args,
                           loaded_executable);

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
@@ -1876,10 +1876,21 @@ PJRT_Error* PJRT_Executable_DeserializeAndLoad(
   absl::string_view serialized(args->serialized_executable,
                                args->serialized_executable_size);
 
+  std::optional<xla::CompileOptions> overridden_options;
+
+  if (args->overridden_serialized_compile_options &&
+      args->overridden_serialized_compile_options_size > 0) {
+    PJRT_ASSIGN_OR_RETURN(
+        overridden_options,
+        ParseCompileOptions(absl::string_view(
+            args->overridden_serialized_compile_options,
+            args->overridden_serialized_compile_options_size)));
+  }
+
   PJRT_ASSIGN_OR_RETURN(
       std::unique_ptr<xla::PjRtLoadedExecutable> executable,
       args->client->client->LoadSerializedExecutable(
-          serialized, /*options=*/std::nullopt, xla::LoadOptions()));
+          serialized, overridden_options, xla::LoadOptions()));
 
   args->loaded_executable =
       new PJRT_LoadedExecutable(std::move(executable), args->client);

--- a/xla/pjrt/pjrt_c_api_client.cc
+++ b/xla/pjrt/pjrt_c_api_client.cc
@@ -425,6 +425,17 @@ PjRtCApiClient::LoadSerializedExecutable(absl::string_view serialized,
   des_args.client = c_client_.get();
   des_args.serialized_executable = serialized.data();
   des_args.serialized_executable_size = serialized.length();
+  des_args.overridden_serialized_compile_options = nullptr;
+  des_args.overridden_serialized_compile_options_size = 0;
+
+  std::string options_str;
+  if (options) {
+    TF_ASSIGN_OR_RETURN(const CompileOptionsProto options_proto,
+                        options->ToProto());
+    options_str = options_proto.SerializeAsString();
+    des_args.overridden_serialized_compile_options = options_str.c_str();
+    des_args.overridden_serialized_compile_options_size = options_str.size();
+  }
 
   const PJRT_Api* api = pjrt_c_api();
 

--- a/xla/pjrt/pjrt_c_api_client.h
+++ b/xla/pjrt/pjrt_c_api_client.h
@@ -315,7 +315,7 @@ class PjRtCApiClient : public PjRtClient {
   absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> CompileAndLoad(
       mlir::ModuleOp module, CompileOptions options) override;
 
-  // `PjRtCApiClient::LoadSerializedExecutable()` ignores `CompileOptions` arg
+  // `PjRtCApiClient::LoadSerializedExecutable()` ignores `LoadOptions` arg
   absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
   LoadSerializedExecutable(absl::string_view serialized,
                            std::optional<CompileOptions> options,

--- a/xla/pjrt/pjrt_c_api_client_test.cc
+++ b/xla/pjrt/pjrt_c_api_client_test.cc
@@ -327,5 +327,43 @@ TEST(PjRtCApiClientTest, ForwardExecuteContext) {
       *result_literal));
 }
 
+TEST(PjRtClientTest, DeserializeExecutableWithDifferentDeviceAssignment) {
+  SetUpCpuPjRtApi();
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetCApiClient("cpu"));
+  ASSERT_GT(client->addressable_devices().size(), 1);
+
+  XlaBuilder builder("Identity");
+  Shape shape = ShapeUtil::MakeShape(S32, {2, 3});
+  auto input = Parameter(&builder, 0, shape, "input");
+  auto computation = builder.Build(input).value();
+
+  auto compile_options_for_device = [](int id) -> xla::CompileOptions {
+    xla::DeviceAssignment device_assignment(1, 1);
+    device_assignment(0, 0) = id;
+    xla::CompileOptions options;
+    options.executable_build_options.set_device_assignment(device_assignment);
+    return options;
+  };
+
+  // Compile the executable for device 0 and serialize it.
+  std::unique_ptr<PjRtLoadedExecutable> executable =
+      client->CompileAndLoad(computation, compile_options_for_device(0))
+          .value();
+  TF_ASSERT_OK_AND_ASSIGN(std::string serialized_executable,
+                          executable->SerializeExecutable());
+
+  // Deserialize the executable for device 1.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto deserialized_executable,
+      client->LoadSerializedExecutable(
+          serialized_executable, compile_options_for_device(1), LoadOptions{}));
+
+  // Check that the executable's compile options were overridden
+  // with device id 1.
+  EXPECT_EQ(
+      deserialized_executable->addressable_devices()[0]->global_device_id(), 1);
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/pjrt/pjrt_client.h
+++ b/xla/pjrt/pjrt_client.h
@@ -629,6 +629,9 @@ class PjRtClient {
   // LoadSerializedExecutable takes the serialized output of PjRtExecutable. The
   // returned executable is loaded by this client. The same checks are made as
   // in Load that the serialized executable is compatible with the client.
+  //
+  // If `options` are provided, then they override the compile options
+  // from the serialized executable (`serialized`).
   virtual absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
   LoadSerializedExecutable(absl::string_view serialized,
                            std::optional<CompileOptions> options,


### PR DESCRIPTION
This plumbs overriden compilation options through `PJRT_Executable_DeserializeAndLoad` in protobuf format and into `LoadSerializedExecutable`. Previously these were dropped.

This should close https://github.com/openxla/xla/issues/18286 and address more recent flakes with the JAX compilation cache with the same root cause but a different error `jaxlib._jax.XlaRuntimeError: INVALID_ARGUMENT: Expected args to execute_sharded_on_local_devices to have 0 shards, got: ...`.