### PR TITLE
[GPU] Enable copy engine for intra-node communications by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -272,7 +272,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   const int64_t kDefaultMinGemmRewriteSize = 100;
   opts.set_xla_gpu_gemm_rewrite_size_threshold(kDefaultMinGemmRewriteSize);
 
-  opts.set_xla_gpu_use_memcpy_local_p2p(false);
+  opts.set_xla_gpu_use_memcpy_local_p2p(true);
 
   opts.set_xla_reduce_window_rewrite_base_length(16);
 


### PR DESCRIPTION
Copy engine has better performance than NCCL kernels when available, plus it doesn't occupy SMs. This PR enables copy engine for local communications by default.