### PR TITLE
Make the XLA passes skip composite computations (same as fusions)

### DIFF
--- a/xla/backends/gpu/autotuner/fission.cc
+++ b/xla/backends/gpu/autotuner/fission.cc
@@ -149,7 +149,8 @@ absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>> GetCublasConfigs(
     se::StreamExecutor* stream_executor) {
   std::vector<std::unique_ptr<BackendConfig>> configs;
 
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (IsLegacyCublasMatmul(*instruction)) {
         TF_ASSIGN_OR_RETURN(configs, cublas_backend.GetSupportedConfigs(
@@ -167,7 +168,8 @@ absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>> GetCublasLtConfigs(
     se::StreamExecutor* stream_executor) {
   std::vector<std::unique_ptr<BackendConfig>> configs;
 
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (IsCublasLtMatmul(*instruction) || IsCublasLtMatmulF8(*instruction)) {
         TF_ASSIGN_OR_RETURN(configs, cublaslt_backend.GetSupportedConfigs(
@@ -309,7 +311,7 @@ absl::Status FissionBackend::ApplyConfig(HloInstruction& instr,
                                        target_config().device_description,
                                        /*rewrite_to_cublaslt=*/false));
     for (HloComputation* computation :
-         hlo_module->MakeNonfusionComputations()) {
+         hlo_module->MakeNonFusionNonCompositeComputations()) {
       for (HloInstruction* instruction : computation->instructions()) {
         if (IsLegacyCublasMatmul(*instruction)) {
           TF_RETURN_IF_ERROR(cublas_backend_.ApplyConfig(*instruction, config));
@@ -325,7 +327,7 @@ absl::Status FissionBackend::ApplyConfig(HloInstruction& instr,
                                        target_config().device_description,
                                        /*rewrite_to_cublaslt=*/true));
     for (HloComputation* computation :
-         hlo_module->MakeNonfusionComputations()) {
+         hlo_module->MakeNonFusionNonCompositeComputations()) {
       for (HloInstruction* instruction : computation->instructions()) {
         if (IsCublasLtMatmul(*instruction) ||
             IsCublasLtMatmulF8(*instruction)) {

--- a/xla/hlo/analysis/hlo_ordering.cc
+++ b/xla/hlo/analysis/hlo_ordering.cc
@@ -512,7 +512,7 @@ std::string PredecessorHloOrdering::ToStringHelper(
     const std::string& name) const {
   std::vector<std::string> pieces;
   pieces.push_back(name);
-  for (auto* computation : module_->MakeNonfusionComputations()) {
+  for (auto* computation : module_->MakeNonFusionNonCompositeComputations()) {
     pieces.push_back(absl::StrFormat("computation %s:", computation->name()));
     const auto all = computation->MakeInstructionPostOrder();
     for (auto instruction : all) {
@@ -534,7 +534,7 @@ DependencyHloOrdering::DependencyHloOrdering(const HloModule* module)
   // Compute predecessor relationships between all instructions to determine
   // ordering based on dependencies. ExecutesBefore will return true iff there
   // exists a path in the HLO computation graph from 'a' to 'b'.
-  for (auto* computation : module->MakeNonfusionComputations()) {
+  for (auto* computation : module->MakeNonFusionNonCompositeComputations()) {
     predecessors_.emplace(computation, HloReachabilityMap::Build(computation));
   }
 }

--- a/xla/hlo/analysis/hlo_replication_analysis.cc
+++ b/xla/hlo/analysis/hlo_replication_analysis.cc
@@ -543,7 +543,7 @@ absl::Status HloReplicationAnalysis::ComputeHloReplication() {
 void HloReplicationAnalysis::BuildReplicaGroupDedupMap() {
   std::vector<std::vector<const HloInstruction*>> dedupable_instructions;
   for (const HloComputation* computation :
-       module_->MakeNonfusionComputations()) {
+       module_->MakeNonFusionNonCompositeComputations()) {
     for (const HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kAllReduce ||
           instruction->opcode() == HloOpcode::kAllGather) {

--- a/xla/hlo/analysis/indexed_array_analysis.cc
+++ b/xla/hlo/analysis/indexed_array_analysis.cc
@@ -1174,7 +1174,7 @@ absl::StatusOr<bool> IndexedArrayAnalysisPrinterPass::Run(
 
   IndexedArrayAnalysis analysis;
   for (auto* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* instr : computation->instructions()) {
       TF_ASSIGN_OR_RETURN(Analysis::Array * t, analysis.GetArrayFor(instr));
       if (!dynamic_cast<UnknownArray*>(t) && !dynamic_cast<ConstantArray*>(t)) {

--- a/xla/hlo/analysis/logical_buffer_analysis.cc
+++ b/xla/hlo/analysis/logical_buffer_analysis.cc
@@ -72,7 +72,7 @@ absl::Status LogicalBufferAnalysis::Analyze() {
   // instructions. This is because it's possible to have orphaned (unreachable)
   // fusion computations, and we don't want to try to assign buffers to those.
   std::vector<HloInstruction*> fusion_instructions;
-  for (auto* computation : module_->MakeNonfusionComputations()) {
+  for (auto* computation : module_->MakeNonFusionNonCompositeComputations()) {
     TF_RETURN_IF_ERROR(computation->Accept(this));
     for (auto* instruction : computation->instructions()) {
       if (instruction->opcode() != HloOpcode::kFusion) {

--- a/xla/hlo/analysis/tuple_points_to_analysis.cc
+++ b/xla/hlo/analysis/tuple_points_to_analysis.cc
@@ -162,7 +162,7 @@ absl::Status TuplePointsToAnalysis::Analyze() {
       logical_buffer_analysis_->num_logical_buffers());
 
   std::vector<HloInstruction*> fusion_instructions;
-  for (auto* computation : module_->MakeNonfusionComputations()) {
+  for (auto* computation : module_->MakeNonFusionNonCompositeComputations()) {
     TF_RETURN_IF_ERROR(computation->Accept(this));
     TF_RETURN_IF_ERROR(
         PopulateDefinedBuffersAndAliases(computation->instructions()));
@@ -716,7 +716,8 @@ PointsToSet& TuplePointsToAnalysis::CreateCopiedPointsToSet(
 std::string TuplePointsToAnalysis::ToString() const {
   std::string output =
       absl::StrFormat("TuplePointsToSet for module %s:\n", module_->name());
-  for (const auto* computation : module_->MakeNonfusionComputations()) {
+  for (const auto* computation :
+       module_->MakeNonFusionNonCompositeComputations()) {
     const char* entry =
         computation == module_->entry_computation() ? "entry " : "";
     absl::StrAppend(&output, entry, "computation ", computation->name(), ":\n");

--- a/xla/hlo/ir/dfs_hlo_visitor_with_default.h
+++ b/xla/hlo/ir/dfs_hlo_visitor_with_default.h
@@ -317,7 +317,7 @@ class DfsHloRewriteVisitor : public DfsHloVisitorWithDefault {
       const absl::flat_hash_set<absl::string_view>& execution_threads = {}) {
     absl::Status status;
     for (HloComputation* computation :
-         module->MakeNonfusionComputations(execution_threads)) {
+         module->MakeNonFusionNonCompositeComputations(execution_threads)) {
       status = computation->Accept(this);
       if (ABSL_PREDICT_FALSE(!status.ok())) {
         return status;

--- a/xla/hlo/ir/hlo_computation.h
+++ b/xla/hlo/ir/hlo_computation.h
@@ -215,8 +215,10 @@ class HloComputation {
     // unreachable, and its instruction is set to null. We still need to regard
     // such computations as fusion computations for HLO scheduling purposes.
     kFusion,
+    // This computation is a composite body.
+    kComposite,
     // Last Value for range checking.
-    kLast = kFusion,
+    kLast = kComposite,
   };
   static constexpr uintptr_t kInstructionTypeMask = 0b111;
   static_assert(static_cast<int>(InstructionType::kUnset) == 0,
@@ -794,6 +796,11 @@ class HloComputation {
     return instruction_type() == InstructionType::kFusion;
   }
 
+  // Returns if this computation is a composite computation.
+  bool IsCompositeComputation() const {
+    return instruction_type() == InstructionType::kComposite;
+  }
+
   // Returns if this computation is the entry computation of the module.
   bool IsEntryComputation() const;
 
@@ -805,6 +812,16 @@ class HloComputation {
   }
   void SetFusionInstruction(HloInstruction* fusion_instruction) {
     SetInstruction(fusion_instruction, InstructionType::kFusion);
+  }
+
+  // Returns the owning composite call instruction, or nullptr if this is not a
+  // composite computation.
+  HloInstruction* CompositeInstruction() const {
+    return instruction_type() == InstructionType::kComposite ? instruction()
+                                                             : nullptr;
+  }
+  void SetCompositeInstruction(HloInstruction* composite_call) {
+    SetInstruction(composite_call, InstructionType::kComposite);
   }
 
   // Returns if this computation is an async computation.

--- a/xla/hlo/ir/hlo_instructions.h
+++ b/xla/hlo/ir/hlo_instructions.h
@@ -1636,6 +1636,8 @@ class HloCallInstruction : public HloCallableInstruction {
                      HloComputation* decomposition, const std::string& name,
                      const std::string& attributes, int64_t version);
 
+  ~HloCallInstruction() override;
+
   static bool ClassOf(const HloInstruction* hlo) {
     return hlo->opcode() == HloOpcode::kCall;
   }

--- a/xla/hlo/ir/hlo_module.cc
+++ b/xla/hlo/ir/hlo_module.cc
@@ -1194,9 +1194,11 @@ std::vector<HloComputation*> HloModule::MakeNonfusionComputations(
     const absl::flat_hash_set<absl::string_view>& execution_threads) const {
   std::vector<HloComputation*> result =
       MakeComputationPostOrder(execution_threads);
-  result.erase(std::remove_if(
-                   result.begin(), result.end(),
-                   [](HloComputation* c) { return c->IsFusionComputation(); }),
+  result.erase(std::remove_if(result.begin(), result.end(),
+                              [](HloComputation* c) {
+                                return c->IsFusionComputation() ||
+                                       c->IsCompositeComputation();
+                              }),
                result.end());
   return result;
 }

--- a/xla/hlo/ir/hlo_module.cc
+++ b/xla/hlo/ir/hlo_module.cc
@@ -1190,7 +1190,7 @@ std::vector<HloComputation*> HloModule::MakeComputationSorted(
   return result;
 }
 
-std::vector<HloComputation*> HloModule::MakeNonfusionComputations(
+std::vector<HloComputation*> HloModule::MakeNonFusionNonCompositeComputations(
     const absl::flat_hash_set<absl::string_view>& execution_threads) const {
   std::vector<HloComputation*> result =
       MakeComputationPostOrder(execution_threads);
@@ -1203,9 +1203,10 @@ std::vector<HloComputation*> HloModule::MakeNonfusionComputations(
   return result;
 }
 
-std::vector<HloComputation*> HloModule::MakeNonfusionComputationsSorted(
+std::vector<HloComputation*>
+HloModule::MakeNonFusionNonCompositeComputationsSorted(
     const absl::flat_hash_set<absl::string_view>& execution_threads) const {
-  auto result = MakeNonfusionComputations(execution_threads);
+  auto result = MakeNonFusionNonCompositeComputations(execution_threads);
   if (config().content_aware_computation_sorting()) {
     SortComputationsByContent(&result);
   }

--- a/xla/hlo/ir/hlo_module.h
+++ b/xla/hlo/ir/hlo_module.h
@@ -347,10 +347,11 @@ class HloModule {
   std::vector<HloComputation*> MakeComputationSorted(
       const absl::flat_hash_set<absl::string_view>& execution_threads) const;
 
-  // Gets the computations in this module which aren't for fusion nodes.
+  // Gets the computations in this module which are neither for fusion nodes nor
+  // for composite calls.
   //
   // Postcondition: All computations in the returned list have
-  // !IsFusionComputation().
+  // !IsFusionComputation() && !IsCompositeComputation().
   //
   // Note: Callers can and do rely on the return value here being a *snapshot*
   // of the module's non-fusion computations -- that is, it's OK to add or

--- a/xla/hlo/ir/hlo_module.h
+++ b/xla/hlo/ir/hlo_module.h
@@ -356,24 +356,25 @@ class HloModule {
   // Note: Callers can and do rely on the return value here being a *snapshot*
   // of the module's non-fusion computations -- that is, it's OK to add or
   // remove computations from a module while iterating over
-  // MakeNonfusionComputations().
-  std::vector<HloComputation*> MakeNonfusionComputations() const {
-    return MakeNonfusionComputations({});
+  // MakeNonFusionNonCompositeComputations().
+  std::vector<HloComputation*> MakeNonFusionNonCompositeComputations() const {
+    return MakeNonFusionNonCompositeComputations({});
   }
   // Same as above but only for specified `execution_threads`. Empty
   // `execution_threads` list means all execution threads are included.
-  std::vector<HloComputation*> MakeNonfusionComputations(
+  std::vector<HloComputation*> MakeNonFusionNonCompositeComputations(
       const absl::flat_hash_set<absl::string_view>& execution_threads) const;
 
-  // Same as MakeNonfusionComputations() but sorting computations by content.
-  // Note that the sort is potentially expensive, so this should be used only if
-  // a consistent order is required.
-  std::vector<HloComputation*> MakeNonfusionComputationsSorted() const {
-    return MakeNonfusionComputationsSorted({});
+  // Same as MakeNonFusionNonCompositeComputations() but sorting computations by
+  // content. Note that the sort is potentially expensive, so this should be
+  // used only if a consistent order is required.
+  std::vector<HloComputation*> MakeNonFusionNonCompositeComputationsSorted()
+      const {
+    return MakeNonFusionNonCompositeComputationsSorted({});
   }
   // Same as above but only for specified `execution_threads`. Empty
   // `execution_threads` list means all execution threads are included.
-  std::vector<HloComputation*> MakeNonfusionComputationsSorted(
+  std::vector<HloComputation*> MakeNonFusionNonCompositeComputationsSorted(
       const absl::flat_hash_set<absl::string_view>& execution_threads) const;
 
   // Returns a config for modifications in current module. If the config is

--- a/xla/hlo/ir/hlo_schedule.cc
+++ b/xla/hlo/ir/hlo_schedule.cc
@@ -245,7 +245,7 @@ absl::Status HloSchedule::Update(
   // the module for the specified threads, but can have sequences for
   // computations which no longer exist (these are removed).
   std::vector<HloComputation*> nonfusion_computations =
-      module_->MakeNonfusionComputations(execution_threads);
+      module_->MakeNonFusionNonCompositeComputations(execution_threads);
   for (const HloComputation* computation : nonfusion_computations) {
     if (!is_computation_scheduled(computation)) {
       GetOrCreateSequence(computation);
@@ -320,7 +320,7 @@ absl::Status HloSchedule::Verify() const {
   for (const auto& [thread_name, sequence_size] :
        sequence_num_by_execution_threads) {
     std::vector<HloComputation*> nonfusion_computations =
-        module_->MakeNonfusionComputations({thread_name});
+        module_->MakeNonFusionNonCompositeComputations({thread_name});
     TF_RET_CHECK(nonfusion_computations.size() == sequence_size)
         << "For thread " << thread_name << ", schedule has " << sequence_size
         << " sequences, but module has " << nonfusion_computations.size()

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -2356,7 +2356,10 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       }
 
       auto call_op = HloInstruction::CreateCall(*shape, operands, *to_apply);
-      call_op->set_is_composite(is_composite.value());
+      if (is_composite.value()) {
+        call_op->set_is_composite(true);
+        to_apply.value()->SetCompositeInstruction(call_op.get());
+      }
       return builder->AddInstruction(std::move(call_op));
     }
     case HloOpcode::kReduceWindow: {

--- a/xla/hlo/transforms/collectives/all_gather_combiner.cc
+++ b/xla/hlo/transforms/collectives/all_gather_combiner.cc
@@ -239,7 +239,7 @@ absl::StatusOr<bool> AllGatherCombiner::RunWithKeyCombiner(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (!combine_while_loops_ &&
         computation->GetUniqueCaller(HloOpcode::kWhile)) {
       VLOG(2) << "Skipping this computation because the computation is a while "

--- a/xla/hlo/transforms/collectives/all_reduce_combiner.cc
+++ b/xla/hlo/transforms/collectives/all_reduce_combiner.cc
@@ -147,7 +147,7 @@ absl::StatusOr<bool> AllReduceCombiner::RunWithKeyCombiner(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(auto domain_map, HloDomainMap::Create(computation, ""));
 
     auto key_fn = [&domain_map, &combine_key](const HloInstruction* instruction)

--- a/xla/hlo/transforms/collectives/all_reduce_contiguous.cc
+++ b/xla/hlo/transforms/collectives/all_reduce_contiguous.cc
@@ -107,7 +107,7 @@ absl::StatusOr<bool> AllReduceContiguous::Run(
 
   std::vector<HloAllReduceInstruction*> all_reduces;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kAllReduce &&
           instruction->operand_count() > 1) {

--- a/xla/hlo/transforms/collectives/async_collective_creator.cc
+++ b/xla/hlo/transforms/collectives/async_collective_creator.cc
@@ -260,7 +260,7 @@ absl::StatusOr<bool> AsyncCollectiveCreator::Run(
   bool changed = false;
   int64_t collectives_replaced = 0;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     std::vector<HloInstruction*> supported_collectives =
         MatchCollectives(computation);
     if (supported_collectives.empty()) {

--- a/xla/hlo/transforms/collectives/collective_permute_combiner.cc
+++ b/xla/hlo/transforms/collectives/collective_permute_combiner.cc
@@ -107,7 +107,7 @@ absl::StatusOr<bool> CollectivePermuteCombiner::Run(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     auto key_fn = [](const HloInstruction* instruction)
         -> std::optional<CollectivePermuteKey> {
       if (instruction->opcode() != HloOpcode::kCollectivePermute) {

--- a/xla/hlo/transforms/collectives/collectives_schedule_linearizer.cc
+++ b/xla/hlo/transforms/collectives/collectives_schedule_linearizer.cc
@@ -40,7 +40,7 @@ absl::StatusOr<bool> CollectivesScheduleLinearizer::Run(
   }
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     std::unique_ptr<HloReachabilityMap> reachability;
     HloInstruction* prev_done = nullptr;
     for (HloInstruction* inst : computation->MakeInstructionPostOrder()) {

--- a/xla/hlo/transforms/collectives/convert_async_collectives_to_sync.cc
+++ b/xla/hlo/transforms/collectives/convert_async_collectives_to_sync.cc
@@ -211,7 +211,7 @@ absl::StatusOr<bool> ConvertAsyncCollectivesToSync::Run(
   }
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (!module->schedule().is_computation_scheduled(computation)) {
       VLOG(3) << "Skipping computation" << computation->name()
               << " as it is not scheduled";

--- a/xla/hlo/transforms/collectives/infeed_token_propagation.cc
+++ b/xla/hlo/transforms/collectives/infeed_token_propagation.cc
@@ -518,7 +518,7 @@ absl::StatusOr<bool> InfeedTokenPropagation::Run(
   std::vector<HloInstruction*> dangling_infeeds;
   std::vector<HloInstruction*> dangling_outfeeds;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (!computation->IsEntryComputation()) {
       for (HloInstruction* instruction : computation->instructions()) {
         // Bail in the presence of HLO domains.

--- a/xla/hlo/transforms/convert_memory_placement_to_internal_annotations.cc
+++ b/xla/hlo/transforms/convert_memory_placement_to_internal_annotations.cc
@@ -114,7 +114,7 @@ absl::StatusOr<bool> ConvertMemoryPlacementToInternalAnnotations::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
-  for (HloComputation* c : module->MakeNonfusionComputations()) {
+  for (HloComputation* c : module->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : c->MakeInstructionPostOrder()) {
       if (instruction->IsCustomCall(memory_annotations::kDevicePlacement)) {
         TF_ASSIGN_OR_RETURN(

--- a/xla/hlo/transforms/expanders/dot_decomposer.cc
+++ b/xla/hlo/transforms/expanders/dot_decomposer.cc
@@ -277,7 +277,7 @@ absl::StatusOr<bool> DotDecomposer::Run(
   // Gather all Non-canonical Dot operations.
   std::vector<HloInstruction*> non_canonical_dots;
   for (auto* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* instruction : computation->instructions()) {
       if (instruction->opcode() != HloOpcode::kDot) {
         continue;

--- a/xla/hlo/transforms/expanders/dynamic_index_splitter.cc
+++ b/xla/hlo/transforms/expanders/dynamic_index_splitter.cc
@@ -38,7 +38,7 @@ absl::StatusOr<bool> DynamicIndexSplitter::Run(
   bool changed = false;
 
   std::vector<HloComputation*> computations =
-      module->MakeNonfusionComputations(execution_threads);
+      module->MakeNonFusionNonCompositeComputations(execution_threads);
   for (HloComputation* computation : computations) {
     for (HloInstruction* dynamic_op : computation->MakeInstructionPostOrder()) {
       switch (dynamic_op->opcode()) {

--- a/xla/hlo/transforms/expanders/op_expander_pass.cc
+++ b/xla/hlo/transforms/expanders/op_expander_pass.cc
@@ -34,7 +34,7 @@ absl::StatusOr<bool> OpExpanderPass::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   std::vector<HloInstruction*> matching_instructions;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     absl::c_copy_if(computation->MakeInstructionPostOrder(),
                     std::back_inserter(matching_instructions),
                     [&](HloInstruction* inst) {

--- a/xla/hlo/transforms/expanders/optimization_barrier_expander.cc
+++ b/xla/hlo/transforms/expanders/optimization_barrier_expander.cc
@@ -30,7 +30,7 @@ absl::StatusOr<bool> OptimizationBarrierExpander::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   std::vector<HloInstruction*> barriers;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     bool modified = false;
     for (HloInstruction* inst : computation->instructions()) {
       if (inst->opcode() == HloOpcode::kOptimizationBarrier) {

--- a/xla/hlo/transforms/expanders/stochastic_convert_decomposer.cc
+++ b/xla/hlo/transforms/expanders/stochastic_convert_decomposer.cc
@@ -135,8 +135,7 @@ absl::Status DecomposeStochasticConvert(HloComputation* comp,
 
   // TODO(b/232442915): Add support for converting to floats.
   return Internal("Unsupported stochastic convert: from %s to %s",
-                       PrimitiveType_Name(from_type),
-                       PrimitiveType_Name(to_type));
+                  PrimitiveType_Name(from_type), PrimitiveType_Name(to_type));
 }
 
 absl::StatusOr<bool> StochasticConvertDecomposer::Run(
@@ -144,7 +143,7 @@ absl::StatusOr<bool> StochasticConvertDecomposer::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction :
          computation->MakeInstructionPostOrder()) {
       if (instruction->opcode() != HloOpcode::kStochasticConvert) {

--- a/xla/hlo/transforms/host_offload_legalize.cc
+++ b/xla/hlo/transforms/host_offload_legalize.cc
@@ -869,7 +869,7 @@ HostOffloadLegalize::FindStartingInstructionsOfHostMemoryOffload(
   std::vector<HloInstruction*> starting_instructions;
   // Iterate over all instructions and look for XLA host offload annotations.
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (IsEntryComputationParameter(instruction)) {
         Shape param_shape =

--- a/xla/hlo/transforms/host_offloader.cc
+++ b/xla/hlo/transforms/host_offloader.cc
@@ -1192,7 +1192,7 @@ absl::StatusOr<bool> HostOffloader::Run(
   // instructions and look for XLA host offload annotations.
   bool changed_in_loop;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (host_offload_utils::IsHostAsyncStart(instruction)) {
         TF_ASSIGN_OR_RETURN(changed_in_loop, HandleRedundantCopiesBackToHost(

--- a/xla/hlo/transforms/memory_space_propagation.cc
+++ b/xla/hlo/transforms/memory_space_propagation.cc
@@ -46,7 +46,7 @@ absl::StatusOr<bool> MemorySpacePropagation::Run(
   dataflow_analysis_ = std::move(dataflow_analysis);
 
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kFusion) {
         // Propagate the operand subshapes.

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -4148,7 +4148,9 @@ GatherOfPadInfo CheckPaddedDimsForGatherOfPad(
   };
 
   int64_t num_padded_batching_dims = 0;
-  struct GatherOfPadInfo skip_transform{false, false};
+  struct GatherOfPadInfo skip_transform {
+    false, false
+  };
   for (int64_t operand_dim : padded_operand_dims) {
     if (padded_operand_dims_to_output_dims.contains(operand_dim)) {
       continue;
@@ -7031,7 +7033,7 @@ absl::Status AlgebraicSimplifierVisitor::HandleSlice(HloInstruction* slice) {
     }
   }
 
-  if (HloInstruction* reduce_window;
+  if (HloInstruction * reduce_window;
       options_.enable_window_reduce_to_reduce_replacement() &&
       hlo_instruction_utils::IsUnstridedSlice(slice) &&
       Match(slice, m::Slice(m::ReduceWindow(&reduce_window).WithOneUse()))) {
@@ -8281,7 +8283,7 @@ absl::Status AlgebraicSimplifierVisitor::HandleReduce(HloInstruction* hlo) {
   // For Computation equal to Min, Max, And or Or, replace Reduce(Broadcast(x),
   // a, Computation()) with Computation(x, a) when x is a scalar and the
   // broadcast is reduced to a scalar.
-  if (HloInstruction* broadcast_arg;
+  if (HloInstruction * broadcast_arg;
       Match(arg, m::Broadcast(m::Op(&broadcast_arg))) &&
       (Match(function->root_instruction(),
              m::MaximumAnyOrder(m::Parameter(0), m::Parameter(1))) ||
@@ -9946,7 +9948,8 @@ absl::StatusOr<bool> AlgebraicSimplifier::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   AlgebraicSimplifierVisitor visitor(options_, this);
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     bool computation_changed_per_run = false;
     int64_t run_count = 0;
     // Repeatedly run simplification on each computation until it is stable.

--- a/xla/hlo/transforms/simplifiers/ar_crs_combiner.cc
+++ b/xla/hlo/transforms/simplifiers/ar_crs_combiner.cc
@@ -426,7 +426,8 @@ void ArCrsCombiner::GroupAllReducesById(HloModule* module) {
   // to skip processing of short paths when we encounter the other ARs that
   // have the same id as AR2.
   absl::flat_hash_set<int64_t> discarded_ar_ids;
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : computation->instructions()) {
       auto maybe_pair = MatchesArCrsPattern(instruction);
       if (maybe_pair) {

--- a/xla/hlo/transforms/simplifiers/batch_dot_simplification.cc
+++ b/xla/hlo/transforms/simplifiers/batch_dot_simplification.cc
@@ -132,7 +132,7 @@ absl::StatusOr<bool> BatchDotSimplification::Run(
   bool changed = false;
   std::vector<HloInstruction*> dot_instrs;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     absl::c_copy_if(computation->instructions(), std::back_inserter(dot_instrs),
                     [](HloInstruction* instr) {
                       return instr->opcode() == HloOpcode::kDot;

--- a/xla/hlo/transforms/simplifiers/bfloat16_conversion_folding.cc
+++ b/xla/hlo/transforms/simplifiers/bfloat16_conversion_folding.cc
@@ -272,7 +272,8 @@ absl::StatusOr<bool> BFloat16ConversionFolding::Run(
   XLA_VLOG_LINES(
       2, "BFloat16ConversionFolding::Run(), before:\n" + module->ToString());
   bool changed = false;
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (BFloat16ConversionFoldingVisitor::Run(comp, bfloat16_support_, this)) {
       changed = true;
     }

--- a/xla/hlo/transforms/simplifiers/broadcast_canonicalizer.cc
+++ b/xla/hlo/transforms/simplifiers/broadcast_canonicalizer.cc
@@ -42,7 +42,7 @@ absl::StatusOr<bool> BroadcastCanonicalizer::Run(
   // Sort broadcast dims. Then insert a transpose on the broadcast to get the
   // original shape back.
   for (const auto& computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* hlo : computation->MakeInstructionPostOrder()) {
       if (hlo->opcode() != HloOpcode::kBroadcast) {
         continue;

--- a/xla/hlo/transforms/simplifiers/conditional_canonicalizer.cc
+++ b/xla/hlo/transforms/simplifiers/conditional_canonicalizer.cc
@@ -125,7 +125,8 @@ absl::StatusOr<bool> ConditionalCanonicalizer::Run(
   XLA_VLOG_LINES(
       2, "ConditionalCanonicalizer::Run(), before:\n" + module->ToString());
   bool changed = false;
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* inst : comp->MakeInstructionPostOrder()) {
       if (inst->opcode() == HloOpcode::kConditional) {
         TF_ASSIGN_OR_RETURN(changed, CanonicalizeNonTupleConditional(inst));

--- a/xla/hlo/transforms/simplifiers/constant_deferring.cc
+++ b/xla/hlo/transforms/simplifiers/constant_deferring.cc
@@ -92,7 +92,7 @@ absl::StatusOr<bool> ConstantDeferring::Run(
   bool changed = false;
   HloSchedule& schedule = module->schedule();
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     HloInstructionSequence& sequence =
         schedule.GetOrCreateSequence(computation);
     HloInstructionSequence new_sequence = DeferConstants(sequence);

--- a/xla/hlo/transforms/simplifiers/convert_mover.cc
+++ b/xla/hlo/transforms/simplifiers/convert_mover.cc
@@ -216,7 +216,7 @@ absl::StatusOr<bool> ConvertMover::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool changed_computation,
                         MoveConvertPrecisionOps(comp));
     changed |= changed_computation;

--- a/xla/hlo/transforms/simplifiers/convolution_group_converter.cc
+++ b/xla/hlo/transforms/simplifiers/convolution_group_converter.cc
@@ -688,7 +688,8 @@ absl::StatusOr<bool> ConvolutionGroupConverter::Run(
   XLA_VLOG_LINES(
       2, "ConvolutionGroupConverter::Run(), before:\n" + module->ToString());
   bool changed = false;
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (ConvolutionVisitor::Run(comp, should_expand_, is_cost_viable_,
                                 convert_batch_groups_only_,
                                 filter_expansion_)) {

--- a/xla/hlo/transforms/simplifiers/dot_merger.cc
+++ b/xla/hlo/transforms/simplifiers/dot_merger.cc
@@ -119,7 +119,6 @@ absl::StatusOr<HloInstruction*> TryMergeSameOperand(HloInstruction* a,
     return nullptr;
   }
 
-
   VLOG(2) << "Merging dots sharing an operand:\n"
           << "\t" << a->ToString() << "\n"
           << "\t" << b->ToString();
@@ -627,7 +626,7 @@ absl::StatusOr<bool> DotMerger::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool changed_computation,
                         MergeDots(comp, max_size_to_merge_, can_merge_));
     changed |= changed_computation;

--- a/xla/hlo/transforms/simplifiers/dynamic_dimension_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/dynamic_dimension_simplifier.cc
@@ -177,39 +177,45 @@ absl::StatusOr<bool> DynamicDimensionSimplifier::Run(
       2, "DynamicDimensionSimplifier::Run(), before:\n" + module->ToString());
   bool changed = false;
 
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* inst : comp->MakeInstructionPostOrder()) {
       TF_ASSIGN_OR_RETURN(bool local_changed, ConcatForwarding(inst));
       changed |= local_changed;
     }
   }
 
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* inst : comp->MakeInstructionPostOrder()) {
       TF_ASSIGN_OR_RETURN(bool local_changed, SliceConcatForwarding(inst));
       changed |= local_changed;
     }
   }
 
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* inst : comp->MakeInstructionPostOrder()) {
       TF_ASSIGN_OR_RETURN(bool local_changed, ReshapeBroadcastForwarding(inst));
       changed |= local_changed;
     }
   }
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* inst : comp->MakeInstructionPostOrder()) {
       TF_ASSIGN_OR_RETURN(bool local_changed, ReshapeReshapeForwarding(inst));
       changed |= local_changed;
     }
   }
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* inst : comp->MakeInstructionPostOrder()) {
       TF_ASSIGN_OR_RETURN(bool local_changed, IdentityConvertRemoving(inst));
       changed |= local_changed;
     }
   }
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* inst : comp->MakeInstructionPostOrder()) {
       TF_ASSIGN_OR_RETURN(bool local_changed, IdentityReshapeRemoving(inst));
       changed |= local_changed;

--- a/xla/hlo/transforms/simplifiers/fusion_constant_sinking.cc
+++ b/xla/hlo/transforms/simplifiers/fusion_constant_sinking.cc
@@ -102,7 +102,7 @@ absl::StatusOr<bool> FusionConstantSinking::Run(
   XLA_VLOG_LINES(3, module->ToString());
 
   bool changed = false;
-  for (HloComputation* c : module->MakeNonfusionComputations()) {
+  for (HloComputation* c : module->MakeNonFusionNonCompositeComputations()) {
     changed |= ProcessComputation(c);
   }
 

--- a/xla/hlo/transforms/simplifiers/hlo_constant_folding.cc
+++ b/xla/hlo/transforms/simplifiers/hlo_constant_folding.cc
@@ -153,7 +153,7 @@ absl::StatusOr<bool> HloConstantFolding::Run(
   bool changed = false;
 
   for (auto* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* instruction : computation->MakeInstructionPostOrder()) {
       // Skip dead code.
       if (instruction->IsDead()) {

--- a/xla/hlo/transforms/simplifiers/host_memory_transfer_asyncifier.cc
+++ b/xla/hlo/transforms/simplifiers/host_memory_transfer_asyncifier.cc
@@ -201,7 +201,8 @@ absl::StatusOr<bool> HostMemoryTransferAsyncifier::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   HostMemoryTransferAsyncifierVisitor visitor(kHostMemorySpaceColor);
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module->MakeNonFusionNonCompositeComputations()) {
     TF_RETURN_IF_ERROR(computation->Accept(&visitor));
   }
   return visitor.Changed();

--- a/xla/hlo/transforms/simplifiers/instruction_hoister.cc
+++ b/xla/hlo/transforms/simplifiers/instruction_hoister.cc
@@ -41,7 +41,7 @@ bool HoistParameters(
   HloSchedule& schedule = module.schedule();
   bool modified = false;
   for (const HloComputation* computation :
-       module.MakeNonfusionComputations(execution_threads)) {
+       module.MakeNonFusionNonCompositeComputations(execution_threads)) {
     CHECK(schedule.is_computation_scheduled(computation));
     if (computation->num_parameters() == 0) {
       continue;
@@ -95,7 +95,7 @@ bool HoistConstantOperations(
   HloSchedule& schedule = module.schedule();
   bool modified = false;
   for (const HloComputation* computation :
-       module.MakeNonfusionComputations(execution_threads)) {
+       module.MakeNonFusionNonCompositeComputations(execution_threads)) {
     CHECK(schedule.is_computation_scheduled(computation));
     const HloInstructionSequence& sequence = schedule.sequence(computation);
     // Conservatively don't modify the schedule if any instruction has a control

--- a/xla/hlo/transforms/simplifiers/reshape_mover.cc
+++ b/xla/hlo/transforms/simplifiers/reshape_mover.cc
@@ -424,7 +424,8 @@ absl::StatusOr<bool> ReshapeMover::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     HloInstructionSet candidates;
     for (HloInstruction* instruction : comp->instructions()) {
       if (IsReshapeMoveCandidate(instruction)) {

--- a/xla/hlo/transforms/simplifiers/root_instruction_sinker.cc
+++ b/xla/hlo/transforms/simplifiers/root_instruction_sinker.cc
@@ -60,7 +60,7 @@ absl::StatusOr<bool> RootInstructionSinker::Run(
 
   bool modified = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     HloInstructionSequence& sequence =
         module->schedule().GetOrCreateSequence(computation);
     if (computation->root_instruction() ==

--- a/xla/hlo/transforms/simplifiers/sort_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/sort_simplifier.cc
@@ -156,7 +156,8 @@ absl::StatusOr<bool> SortSimplifier::Run(
 
   bool changed = false;
   std::vector<HloInstruction*> sort_instrs;
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     absl::c_copy_if(comp->instructions(), std::back_inserter(sort_instrs),
                     HloPredicateIsOp<HloOpcode::kSort>);
   }

--- a/xla/hlo/transforms/simplifiers/tree_reduction_rewriter.cc
+++ b/xla/hlo/transforms/simplifiers/tree_reduction_rewriter.cc
@@ -120,7 +120,7 @@ absl::StatusOr<bool> TreeReductionRewriter::Run(
   ReductionRewriterVisitor visitor(reduce_window_size_);
   bool changed = false;
   for (const auto &computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_RETURN_IF_ERROR(computation->Accept(&visitor));
     changed |= visitor.changed();
   }

--- a/xla/hlo/transforms/simplifiers/zero_sized_hlo_elimination.cc
+++ b/xla/hlo/transforms/simplifiers/zero_sized_hlo_elimination.cc
@@ -35,7 +35,7 @@ absl::StatusOr<bool> ZeroSizedHloElimination::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : comp->MakeInstructionPostOrder()) {
       if (!ShapeUtil::IsZeroElementArray(instruction->shape())) {
         continue;

--- a/xla/hlo/utils/concurrency/concurrency_utils.h
+++ b/xla/hlo/utils/concurrency/concurrency_utils.h
@@ -202,7 +202,8 @@ absl::StatusOr<FinalReturnT> ForEachNonfusionHloComputation(
         combiner,
     TaskExecutorT& task_executor,
     std::optional<int> parallelism = std::nullopt) {
-  auto computations = module->MakeNonfusionComputations(execution_threads);
+  auto computations =
+      module->MakeNonFusionNonCompositeComputations(execution_threads);
   return ForEachHloComputation(computations, std::move(action),
                                std::move(combiner), task_executor, parallelism);
 }

--- a/xla/service/all_gather_decomposer.cc
+++ b/xla/service/all_gather_decomposer.cc
@@ -116,7 +116,8 @@ absl::StatusOr<bool> AllGatherDecomposer::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
-  for (auto comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto hlo : comp->MakeInstructionPostOrder()) {
       if (hlo->opcode() != HloOpcode::kAllGather) {
         continue;

--- a/xla/service/batchnorm_expander.cc
+++ b/xla/service/batchnorm_expander.cc
@@ -587,7 +587,7 @@ absl::StatusOr<bool> BatchNormExpander::Run(
   XLA_VLOG_LINES(2, "BatchNormExpander::Run(), before:\n" + module->ToString());
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (BatchNormExpanderVisitor::Run(computation, rewrite_training_op_,
                                       rewrite_inference_op_,
                                       rewrite_grad_op_)) {

--- a/xla/service/change_op_data_type.cc
+++ b/xla/service/change_op_data_type.cc
@@ -49,7 +49,7 @@ absl::StatusOr<bool> ChangeOpDataType::Run(
   HloCloner cloner = cloner_ ? cloner_ : default_cloner;
 
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
       std::optional<PrimitiveType> operand_type = GetUniformOperandType(instr);
       if (!op_matcher_(instr) || !operand_type.has_value() ||

--- a/xla/service/copy_insertion.cc
+++ b/xla/service/copy_insertion.cc
@@ -1151,7 +1151,7 @@ absl::Status CopyInsertion::AddCopiesToResolveInterference(
   TF_ASSIGN_OR_RETURN(std::unique_ptr<HloAliasAnalysis> alias_analysis,
                       HloAliasAnalysis::Run(module, can_share_buffer_));
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (computation->IsAsyncComputation()) {
       continue;
     }

--- a/xla/service/copy_removal.cc
+++ b/xla/service/copy_removal.cc
@@ -774,7 +774,8 @@ void CopyRemover::AddValueList(
 void CopyRemover::CreateCopyMap(
     const HloModule& module,
     const absl::flat_hash_map<const HloValue*, ValueNode*>& value_to_node) {
-  for (HloComputation* computation : module.MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module.MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : computation->instructions()) {
       // Add copies with unambiguous source values to the map. Copies with
       // ambiguous sources are not removable.

--- a/xla/service/cpu/parallel_task_assignment.cc
+++ b/xla/service/cpu/parallel_task_assignment.cc
@@ -304,7 +304,7 @@ void ParallelTaskAssigner::ComputeTargetParallelTasks(
                                                   &target_machine_features_);
 
   // Compute parallel task counts for all instructions in 'module'.
-  for (auto* computation : module->MakeNonfusionComputations()) {
+  for (auto* computation : module->MakeNonFusionNonCompositeComputations()) {
     for (auto* instruction : computation->instructions()) {
       // Query ParallelTaskAssignment for target parallel task count.
       const int64_t target_parallel_task_count =

--- a/xla/service/dump.cc
+++ b/xla/service/dump.cc
@@ -514,7 +514,7 @@ static std::vector<std::string> DumpHloModuleImpl(
 
   if (opts.dump_fusion_visualization) {
     for (const HloComputation* computation :
-         module.MakeNonfusionComputations()) {
+         module.MakeNonFusionNonCompositeComputations()) {
       if (IsTrivial(*computation)) {
         VLOG(1) << "Skipping computation " << computation->name()
                 << " as trivial";

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -215,7 +215,8 @@ bool AMDGPUCompiler::RequiresCollectiveScheduleLinearizer(
   if (stream_exec == nullptr || !GpuConvAlgorithmPicker::IsEnabled(module)) {
     return false;
   }
-  for (const HloComputation* comp : module->MakeNonfusionComputations()) {
+  for (const HloComputation* comp :
+       module->MakeNonFusionNonCompositeComputations()) {
     for (const HloInstruction* inst : comp->instructions()) {
       if (GpuConvAlgorithmPicker::IsCandidate(inst)) {
         return true;

--- a/xla/service/gpu/autotuning/autotuner_util_test.cc
+++ b/xla/service/gpu/autotuning/autotuner_util_test.cc
@@ -235,7 +235,8 @@ TEST_F(AutotunerUtilTest, FailIfRequireCompleteAotAutotuning) {
   TF_EXPECT_OK(hlo_module.status());
   std::vector<HloComputation*> computations =
       (*hlo_module)
-          ->MakeNonfusionComputations(absl::flat_hash_set<absl::string_view>());
+          ->MakeNonFusionNonCompositeComputations(
+              absl::flat_hash_set<absl::string_view>());
   EXPECT_THAT(computations, Not(IsEmpty()));
   const HloInstruction* instruction = *computations[0]->instructions().begin();
   stream_executor::StreamExecutor* executor = NewStreamExecutor();
@@ -263,7 +264,8 @@ TEST_F(AutotunerUtilTest, OkIfJitAutotuningDisabledButAlreadyLoadedAOT) {
   auto hlo_module = GetOptimizedModule(kHloText);
   std::vector<HloComputation*> computations =
       (*hlo_module)
-          ->MakeNonfusionComputations(absl::flat_hash_set<absl::string_view>());
+          ->MakeNonFusionNonCompositeComputations(
+              absl::flat_hash_set<absl::string_view>());
   EXPECT_THAT(computations, Not(IsEmpty()));
   const HloInstruction* instruction = *computations[0]->instructions().begin();
   stream_executor::StreamExecutor* executor = NewStreamExecutor();

--- a/xla/service/gpu/autotuning/conv_algorithm_picker.cc
+++ b/xla/service/gpu/autotuning/conv_algorithm_picker.cc
@@ -1171,7 +1171,7 @@ absl::StatusOr<bool> GpuConvAlgorithmPicker::Run(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
     changed |= result;
   }

--- a/xla/service/gpu/autotuning/gemm_algorithm_picker.cc
+++ b/xla/service/gpu/autotuning/gemm_algorithm_picker.cc
@@ -513,7 +513,7 @@ absl::StatusOr<bool> GemmAlgorithmPicker::Run(
   GemmAutotuner autotuner(config_);
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation, autotuner,
                                                       &num_algorithms_left_));
     changed |= result;

--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
@@ -172,7 +172,7 @@ class GemmFusionCollector : public ConstDfsHloVisitorWithDefault {
     result_ = {};
     handled_fusions_.clear();
     for (HloComputation* computation :
-         module.MakeNonfusionComputations(execution_threads)) {
+         module.MakeNonFusionNonCompositeComputations(execution_threads)) {
       TF_RETURN_IF_ERROR(computation->Accept(this));
     }
     TF_ASSIGN_OR_RETURN(result_.fingerprint,

--- a/xla/service/gpu/cudnn_support_utils_test.cc
+++ b/xla/service/gpu/cudnn_support_utils_test.cc
@@ -55,7 +55,8 @@ class CudnnSupportUtilsTest : public HloHardwareIndependentTestBase {
   absl::StatusOr<HloCustomCallInstruction*> GetCustomCall(
       xla::VerifiedHloModule* module, absl::string_view target) {
     HloCustomCallInstruction* call = nullptr;
-    for (HloComputation* comp : module->MakeNonfusionComputations()) {
+    for (HloComputation* comp :
+         module->MakeNonFusionNonCompositeComputations()) {
       for (HloInstruction* inst : comp->instructions()) {
         if (inst->IsCustomCall(target)) {
           VLOG(1) << inst->ToString();

--- a/xla/service/gpu/fusion_process_dump.cc
+++ b/xla/service/gpu/fusion_process_dump.cc
@@ -140,7 +140,8 @@ absl::StatusOr<FusionProcessDump> FusionProcessDump::LoadFromProto(
 
   absl::flat_hash_map<std::string, HloComputation*>
       instruction_name_to_computation_map;
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instr : computation->instructions()) {
       instruction_name_to_computation_map[instr->name()] = computation;
     }

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -325,7 +325,8 @@ bool NVPTXCompiler::RequiresCollectiveScheduleLinearizer(
   if (stream_exec == nullptr || !GpuConvAlgorithmPicker::IsEnabled(module)) {
     return false;
   }
-  for (const HloComputation* comp : module->MakeNonfusionComputations()) {
+  for (const HloComputation* comp :
+       module->MakeNonFusionNonCompositeComputations()) {
     for (const HloInstruction* inst : comp->instructions()) {
       if (GpuConvAlgorithmPicker::IsCandidate(inst)) {
         return true;

--- a/xla/service/gpu/transforms/add_tracking_suffix_to_instruction_names.cc
+++ b/xla/service/gpu/transforms/add_tracking_suffix_to_instruction_names.cc
@@ -33,7 +33,7 @@ absl::StatusOr<bool> AddTrackingSuffixToInstructionNames::Run(
 
   // Only rename instructions in non-fusion computations.
   for (xla::HloComputation* computation :
-       module->MakeNonfusionComputationsSorted(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputationsSorted(execution_threads)) {
     for (auto* instruction : computation->instructions()) {
       // Skip non-fusible instruction to avoid breaking tests that are not
       // related to fusion.

--- a/xla/service/gpu/transforms/algebraic_simplifier.h
+++ b/xla/service/gpu/transforms/algebraic_simplifier.h
@@ -82,7 +82,8 @@ class GpuAlgebraicSimplifier : public AlgebraicSimplifier {
         2, "GpuAlgebraicSimplifier::Run(), before:\n" + module->ToString());
     bool changed = false;
     GpuAlgebraicSimplifierVisitor visitor(options_, compute_capability_, this);
-    for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+    for (auto* comp :
+         module->MakeNonFusionNonCompositeComputations(execution_threads)) {
       if (visitor.Run(comp, options_, this)) {
         changed = true;
       }

--- a/xla/service/gpu/transforms/algorithm_checker.cc
+++ b/xla/service/gpu/transforms/algorithm_checker.cc
@@ -54,7 +54,7 @@ class AlgorithmCheckerVisitor : public ConstDfsHloVisitorWithDefault {
       const HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads = {}) {
     for (HloComputation* computation :
-         module->MakeNonfusionComputations(execution_threads)) {
+         module->MakeNonFusionNonCompositeComputations(execution_threads)) {
       TF_RETURN_IF_ERROR(computation->Accept(this));
     }
     return absl::OkStatus();

--- a/xla/service/gpu/transforms/collectives/all_gather_optimizer.cc
+++ b/xla/service/gpu/transforms/collectives/all_gather_optimizer.cc
@@ -38,7 +38,7 @@ absl::StatusOr<bool> AllGatherOptimizer::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction :
          computation->MakeInstructionPostOrder()) {
       if (!HloOpcodeIsBinaryCommutative(instruction->opcode())) {

--- a/xla/service/gpu/transforms/collectives/all_reduce_blueconnect.cc
+++ b/xla/service/gpu/transforms/collectives/all_reduce_blueconnect.cc
@@ -354,7 +354,7 @@ absl::StatusOr<bool> AllReduceBlueConnect::Run(
 
   std::vector<HloAllReduceInstruction*> all_reduces;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (HloPredicateIsOp<HloOpcode::kAllReduce>(instruction)) {
         all_reduces.push_back(Cast<HloAllReduceInstruction>(instruction));

--- a/xla/service/gpu/transforms/collectives/async_collective_annotator.cc
+++ b/xla/service/gpu/transforms/collectives/async_collective_annotator.cc
@@ -34,7 +34,7 @@ absl::StatusOr<bool> AsyncCollectiveAnnotator::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (!hlo_query::IsAsyncCollectiveStartOp(instruction)) {
         continue;

--- a/xla/service/gpu/transforms/conv_padding_legalization.cc
+++ b/xla/service/gpu/transforms/conv_padding_legalization.cc
@@ -450,7 +450,7 @@ absl::StatusOr<bool> ConvPaddingLegalization::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
     changed |= result;
   }

--- a/xla/service/gpu/transforms/conv_rewriter.cc
+++ b/xla/service/gpu/transforms/conv_rewriter.cc
@@ -867,7 +867,7 @@ absl::StatusOr<bool> ConvRewriter::Run(
   XLA_VLOG_LINES(2, "ConvRewriter::Run(), before:\n" + module->ToString());
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(
         bool result,
         RunOnComputation(computation, compute_capability_, dnn_version_));

--- a/xla/service/gpu/transforms/cublas_pad_for_gemms.cc
+++ b/xla/service/gpu/transforms/cublas_pad_for_gemms.cc
@@ -200,7 +200,7 @@ absl::StatusOr<bool> CublasPadForGemms::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(
         std::vector<HloDotInstruction*> dots,
         GetRelevantDots(gpu_compute_capability_, comp, datatype_));

--- a/xla/service/gpu/transforms/cudnn_fused_conv_rewriter.cc
+++ b/xla/service/gpu/transforms/cudnn_fused_conv_rewriter.cc
@@ -1614,7 +1614,7 @@ void VlogStats(HloModule* module) {
 
   VLOG(1) << "Results of CudnnFusedConvRewriter for " << module->name();
   absl::flat_hash_map<std::string, int> stats;
-  for (HloComputation* comp : module->MakeNonfusionComputations()) {
+  for (HloComputation* comp : module->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instr : comp->instructions()) {
       if (!Match(instr, m::Op().WithPredicate(IsConvCustomCall))) {
         continue;
@@ -1692,7 +1692,7 @@ absl::StatusOr<bool> CudnnFusedConvRewriter::Run(
   bool any_changed = false;
 
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     bool changed = false;
     // Rewrite FP8 convolutions and supported adjacent pointwise ops into a
     // ForwardGraph Custom Call.

--- a/xla/service/gpu/transforms/cudnn_norm_rewriter.cc
+++ b/xla/service/gpu/transforms/cudnn_norm_rewriter.cc
@@ -1567,7 +1567,7 @@ absl::StatusOr<bool> CudnnNormRewriter::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(
         bool result, RunOnComputation(computation, cuda_compute_capability_));
     changed |= result;

--- a/xla/service/gpu/transforms/cudnn_pad_for_convolutions.cc
+++ b/xla/service/gpu/transforms/cudnn_pad_for_convolutions.cc
@@ -495,7 +495,7 @@ absl::StatusOr<bool> CudnnPadForConvolutions::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloCustomCallInstruction* conv : GetRelevantConvs(comp)) {
       // On Turing and later (sm75+), pad to multiples of 32 bytes if possible,
       // because that lets us use the fast int8x32 data type.

--- a/xla/service/gpu/transforms/cudnn_simplify_padding.cc
+++ b/xla/service/gpu/transforms/cudnn_simplify_padding.cc
@@ -474,7 +474,7 @@ absl::StatusOr<bool> CudnnSimplifyPadding::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
       TF_ASSIGN_OR_RETURN(bool c, TrySimplifyPadding(instr));
       changed |= c;

--- a/xla/service/gpu/transforms/cudnn_vectorize_convolutions.cc
+++ b/xla/service/gpu/transforms/cudnn_vectorize_convolutions.cc
@@ -603,7 +603,7 @@ absl::StatusOr<bool> CudnnVectorizeConvolutions::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloCustomCallInstruction* conv : GetRelevantConvs(comp)) {
       // Try to (re)vectorize to int8x32 if this is an sm75+ GPU.  If we can't,
       // fall back to int8x4.

--- a/xla/service/gpu/transforms/dot_dimension_sorter.cc
+++ b/xla/service/gpu/transforms/dot_dimension_sorter.cc
@@ -88,7 +88,7 @@ absl::StatusOr<bool> DotDimensionSorter::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   std::vector<HloInstruction*> dots_to_process;
   for (const HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instr : computation->instructions()) {
       if (HloPredicateIsNotOp<HloOpcode::kDot>(instr)) {
         continue;

--- a/xla/service/gpu/transforms/double_buffer_loop_unrolling.cc
+++ b/xla/service/gpu/transforms/double_buffer_loop_unrolling.cc
@@ -560,7 +560,7 @@ absl::StatusOr<bool> DoubleBufferLoopUnrolling::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   std::vector<HloInstruction*> while_instrs;
-  for (auto comp : module->MakeNonfusionComputations()) {
+  for (auto comp : module->MakeNonFusionNonCompositeComputations()) {
     absl::c_copy_if(comp->instructions(), std::back_inserter(while_instrs),
                     HloPredicateIsOp<HloOpcode::kWhile>);
   }

--- a/xla/service/gpu/transforms/explicit_collectives_group_async_wrapper.cc
+++ b/xla/service/gpu/transforms/explicit_collectives_group_async_wrapper.cc
@@ -74,7 +74,7 @@ absl::StatusOr<bool> ExplicitCollectivesGroupAsyncWrapper::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (const HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instr : comp->instructions()) {
       TF_ASSIGN_OR_RETURN(bool result, CreateCollectivesGroupAsyncPair(instr));
       changed |= result;

--- a/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.cc
+++ b/xla/service/gpu/transforms/explicit_stream_annotation_async_wrapper.cc
@@ -81,7 +81,7 @@ absl::StatusOr<bool> ExplicitStreamAnnotationAsyncWrapper::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (const HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instr : comp->instructions()) {
       TF_ASSIGN_OR_RETURN(bool result, AsynchronizeInstruction(instr));
       changed |= result;

--- a/xla/service/gpu/transforms/gemm_broadcast_folding_rewriter.cc
+++ b/xla/service/gpu/transforms/gemm_broadcast_folding_rewriter.cc
@@ -113,7 +113,7 @@ absl::StatusOr<bool> GemmBroadcastFoldingRewriter::Run(
     const absl::flat_hash_set<absl::string_view> &execution_threads) {
   bool changed = false;
   for (HloComputation *computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
     changed |= result;
   }

--- a/xla/service/gpu/transforms/gemm_fusion.cc
+++ b/xla/service/gpu/transforms/gemm_fusion.cc
@@ -867,7 +867,7 @@ absl::StatusOr<bool> GemmFusion::Run(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result,
                         RunOnComputation(computation, compute_capability_));
     changed |= result;

--- a/xla/service/gpu/transforms/gemm_rewriter.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter.cc
@@ -2535,7 +2535,7 @@ absl::StatusOr<bool> GemmRewriter::Run(
     const absl::flat_hash_set<absl::string_view> &execution_threads) {
   bool changed = false;
   for (HloComputation *computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result,
                         RunOnComputation(computation, gpu_version_,
                                          toolkit_version_, options_));

--- a/xla/service/gpu/transforms/gemv_rewriter.cc
+++ b/xla/service/gpu/transforms/gemv_rewriter.cc
@@ -164,7 +164,7 @@ absl::StatusOr<bool> GemvRewriter::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   GemvRewriterVisitor gemv_rewriter;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_RETURN_IF_ERROR(computation->Accept(&gemv_rewriter));
   }
   return gemv_rewriter.changed();

--- a/xla/service/gpu/transforms/gpusolver_rewriter.cc
+++ b/xla/service/gpu/transforms/gpusolver_rewriter.cc
@@ -198,7 +198,7 @@ absl::StatusOr<bool> GpusolverRewriter::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
     changed |= result;
   }

--- a/xla/service/gpu/transforms/horizontal_input_fusion.cc
+++ b/xla/service/gpu/transforms/horizontal_input_fusion.cc
@@ -91,23 +91,21 @@ std::vector<HloInstruction*> FindAndSortFusionCandidates(
     }
   }
 
-  std::sort(fusion_instrs.begin(), fusion_instrs.end(),
-            [&](const HloInstruction* a, const HloInstruction* b) {
-              Shape shape_a =
-                  GetInputShapeForMultiOutputFusion(*a, device_info);
-              Shape shape_b =
-                  GetInputShapeForMultiOutputFusion(*b, device_info);
-              auto tuple_for_op = [](const Shape& shape,
-                                     const HloInstruction* op) {
-                // Sort shapes according to dimensions, so that the same input
-                // shapes will be placed adjacent each other.
-                // Sort `fusion_instrs` according to instruction counts, because
-                // we'd like to fuse together computations of similar sizes.
-                return std::tuple{shape.dimensions().size(), shape.dimensions(),
-                                  GetInstrCountOfFusible(*op), op->unique_id()};
-              };
-              return tuple_for_op(shape_a, a) < tuple_for_op(shape_b, b);
-            });
+  std::sort(
+      fusion_instrs.begin(), fusion_instrs.end(),
+      [&](const HloInstruction* a, const HloInstruction* b) {
+        Shape shape_a = GetInputShapeForMultiOutputFusion(*a, device_info);
+        Shape shape_b = GetInputShapeForMultiOutputFusion(*b, device_info);
+        auto tuple_for_op = [](const Shape& shape, const HloInstruction* op) {
+          // Sort shapes according to dimensions, so that the same input
+          // shapes will be placed adjacent each other.
+          // Sort `fusion_instrs` according to instruction counts, because
+          // we'd like to fuse together computations of similar sizes.
+          return std::tuple{shape.dimensions().size(), shape.dimensions(),
+                            GetInstrCountOfFusible(*op), op->unique_id()};
+        };
+        return tuple_for_op(shape_a, a) < tuple_for_op(shape_b, b);
+      });
 
   return fusion_instrs;
 }
@@ -174,7 +172,7 @@ absl::StatusOr<bool> HorizontalInputFusion::Run(
   bool any_changed = false;
   VLOG(2) << "Run horizontal input fusion.";
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool changed, RunOnComputation(comp));
     any_changed |= changed;
   }

--- a/xla/service/gpu/transforms/multi_output_fusion_test.cc
+++ b/xla/service/gpu/transforms/multi_output_fusion_test.cc
@@ -72,7 +72,7 @@ const char kModulePrefix[] = R"(
 
 static int64_t CountMultiOutputFusions(const HloModule* module) {
   int multi_output_fusion_count = 0;
-  for (auto* computation : module->MakeNonfusionComputations()) {
+  for (auto* computation : module->MakeNonFusionNonCompositeComputations()) {
     for (auto* instr : computation->instructions()) {
       if (instr->IsMultiOutputFusion()) {
         multi_output_fusion_count++;
@@ -990,7 +990,7 @@ TEST_F(MultiOutputFusionTest, PreferFuseProducerIntoFusionConsumer) {
   ASSERT_TRUE(mof_.Run(module.get()).value());
   SCOPED_TRACE(module->ToString());
   int multi_output_fusion_count = 0;
-  for (auto* computation : module->MakeNonfusionComputations()) {
+  for (auto* computation : module->MakeNonFusionNonCompositeComputations()) {
     for (auto* instr : computation->instructions()) {
       if (instr->IsMultiOutputFusion()) {
         multi_output_fusion_count++;

--- a/xla/service/gpu/transforms/nest_gemm_fusion.cc
+++ b/xla/service/gpu/transforms/nest_gemm_fusion.cc
@@ -1030,7 +1030,7 @@ absl::StatusOr<bool> NestGemmFusion::Run(
   auto call_graph = CallGraph::Build(module, execution_threads);
   mlir::MLIRContext ctx;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     NestGemmFusionVisitor visitor(&ctx, call_graph.get(), compute_capability_);
     TF_RETURN_IF_ERROR(computation->Accept(&visitor));
     changed |= visitor.changed();

--- a/xla/service/gpu/transforms/reduce_scatter_creator.cc
+++ b/xla/service/gpu/transforms/reduce_scatter_creator.cc
@@ -47,7 +47,7 @@ absl::StatusOr<bool> ReduceScatterCreator::Run(
 
   bool changed = false;
   for (HloComputation *computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction *instruction :
          computation->MakeInstructionPostOrder()) {
       if (HloPredicateIsNotOp<HloOpcode::kAllReduce>(instruction)) {

--- a/xla/service/gpu/transforms/rename_fusions.cc
+++ b/xla/service/gpu/transforms/rename_fusions.cc
@@ -76,7 +76,8 @@ void RenameFusion(HloModule* module, HloInstruction* instruction) {
 absl::StatusOr<bool> RenameFusions::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (HloPredicateIsNotOp<HloOpcode::kFusion>(instruction) ||
           instruction->fusion_kind() == HloInstruction::FusionKind::kCustom) {

--- a/xla/service/gpu/transforms/softmax_rewriter_triton.cc
+++ b/xla/service/gpu/transforms/softmax_rewriter_triton.cc
@@ -594,7 +594,7 @@ SoftmaxRewriterTriton::FindAllFusibleNormalizationDiamonds(
   std::vector<DiamondDescriptor> matched_diamonds;
 
   for (HloComputation* comp :
-       module.MakeNonfusionComputations(execution_threads)) {
+       module.MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (!comp->caller_instructions(HloOpcode::kCustomCall).empty()) {
       continue;
     }

--- a/xla/service/gpu/transforms/sort_rewriter.cc
+++ b/xla/service/gpu/transforms/sort_rewriter.cc
@@ -579,7 +579,7 @@ absl::StatusOr<bool> SortRewriter::Run(
   XLA_VLOG_LINES(3, "SortRewriter::Run(), before:\n" + module->ToString());
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
     changed |= result;
   }

--- a/xla/service/gpu/transforms/splitk_rewriter.cc
+++ b/xla/service/gpu/transforms/splitk_rewriter.cc
@@ -344,7 +344,7 @@ absl::StatusOr<bool> SplitkRewriter::Run(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     SplitkRewriterVisitor visitor(device_description_);
     TF_RETURN_IF_ERROR(computation->Accept(&visitor));
     changed |= visitor.changed();

--- a/xla/service/gpu/transforms/stream_attribute_async_wrapper.cc
+++ b/xla/service/gpu/transforms/stream_attribute_async_wrapper.cc
@@ -61,7 +61,7 @@ absl::StatusOr<bool> StreamAttributeAsyncWrapper::Run(
       2, "StreamAttributeAsyncWrapper::Run(), before:\n" + module->ToString());
   bool changed = false;
   for (const HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instr : comp->instructions()) {
       TF_ASSIGN_OR_RETURN(bool result, AsynchronizeInstruction(instr));
       changed |= result;

--- a/xla/service/gpu/transforms/triangular_solve_rewriter.cc
+++ b/xla/service/gpu/transforms/triangular_solve_rewriter.cc
@@ -42,7 +42,7 @@ absl::StatusOr<bool> TriangularSolveRewriter::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     std::vector<HloInstruction*> to_rewrite;
     for (HloInstruction* instr : comp->instructions()) {
       if (HloPredicateIsOp<HloOpcode::kTriangularSolve>(instr)) {

--- a/xla/service/gpu/transforms/triton_fusion_numerics_verifier.cc
+++ b/xla/service/gpu/transforms/triton_fusion_numerics_verifier.cc
@@ -205,7 +205,7 @@ absl::Status ForAllTritonFusions(
     const absl::flat_hash_set<absl::string_view>& execution_threads,
     absl::AnyInvocable<absl::Status(const HloFusionInstruction&)> fn) {
   for (HloComputation* computation :
-       module.MakeNonfusionComputations(execution_threads)) {
+       module.MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       TF_ASSIGN_OR_RETURN(auto triton_fusion, AsTritonFusion(instruction));
       if (triton_fusion != nullptr) {

--- a/xla/service/gpu/transforms/variadic_op_splitter.cc
+++ b/xla/service/gpu/transforms/variadic_op_splitter.cc
@@ -101,7 +101,7 @@ absl::StatusOr<bool> VariadicOpSplitter::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* op : GetRelevantVariadicOps(comp)) {
       // TODO(b/112613927): Handle also other ops than concatenate.
       TF_ASSIGN_OR_RETURN(bool result, SplitConcatenate(op, comp));

--- a/xla/service/gpu/transforms/windowed_einsum_handler.cc
+++ b/xla/service/gpu/transforms/windowed_einsum_handler.cc
@@ -1358,7 +1358,7 @@ absl::StatusOr<bool> WindowedEinsumHandler::Run(
   int64_t stream_id = hlo_query::NextChannelId(*module);
   std::vector<HloInstruction*> all_windowed_einsum_loops;
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     // If we have a einsum loop with less than 1 dot, it's not
     // a loop of interest.
     if (NumberOfInstructionsInComp(comp, HloOpcode::kDot) <= 1) {
@@ -1391,7 +1391,7 @@ absl::StatusOr<bool> WindowedEinsumHandler::Run(
   }
 
   for (HloComputation* comp :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     WindowedEinsumVisitor visitor(all_ag_loops_);
     TF_RETURN_IF_ERROR(comp->Accept(&visitor));
     changed |= visitor.changed();

--- a/xla/service/hlo_schedule_test.cc
+++ b/xla/service/hlo_schedule_test.cc
@@ -417,9 +417,12 @@ ENTRY %WhileLoop () -> (s32[], f32[10]) {
   TF_ASSERT_OK(schedule.Update({HloInstruction::kMainExecutionThread}));
   TF_ASSERT_OK(schedule.Verify());
 
-  ASSERT_EQ(module->MakeNonfusionComputations({"parallel_thread"}).size(), 1);
+  ASSERT_EQ(
+      module->MakeNonFusionNonCompositeComputations({"parallel_thread"}).size(),
+      1);
   ASSERT_FALSE(schedule.is_computation_scheduled(
-      module->MakeNonfusionComputations({"parallel_thread"}).front()));
+      module->MakeNonFusionNonCompositeComputations({"parallel_thread"})
+          .front()));
 }
 
 TEST_F(HloScheduleTest, UpdateScheduleAddComputation) {

--- a/xla/service/instruction_fusion.cc
+++ b/xla/service/instruction_fusion.cc
@@ -582,7 +582,7 @@ bool MultiOutputFusionCreatesCycle(HloInstruction* producer,
 std::vector<HloComputation*> InstructionFusion::GetNonFusionComputations(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
-  return module->MakeNonfusionComputations(execution_threads);
+  return module->MakeNonFusionNonCompositeComputations(execution_threads);
 }
 
 std::unique_ptr<FusionQueue> InstructionFusion::GetFusionQueue(

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -3092,7 +3092,7 @@ absl::StatusOr<bool> LatencyHidingScheduler::Run(
   computations_to_schedule_.reserve(module->computation_count());
   // Collect which computations have latency hiding opportunities.
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* instr : computation->instructions()) {
       if (scheduling_context_->GetAsyncTracker()->IsSupportedAsyncStart(
               *instr) ||

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -425,7 +425,8 @@ class SchedulingContext {
 class AnnotationTracker {
  public:
   explicit AnnotationTracker(const HloModule* module) : module_(module) {
-    for (const HloComputation* comp : module_->MakeNonfusionComputations()) {
+    for (const HloComputation* comp :
+         module_->MakeNonFusionNonCompositeComputations()) {
       absl::flat_hash_set<int64_t> annotations;
       for (const HloInstruction* instr : comp->instructions()) {
         if (auto annotation = GetAnnotation(instr)) {

--- a/xla/service/layout_assignment.cc
+++ b/xla/service/layout_assignment.cc
@@ -1242,7 +1242,7 @@ absl::Status LayoutAssignment::CheckLayouts(
   TF_ASSIGN_OR_RETURN(auto points_to_analysis,
                       TuplePointsToAnalysis::Run(module));
   for (auto* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (auto* instruction : computation->instructions()) {
       // Verify every instruction has a layout and the layout is valid for the
       // shape.
@@ -2691,7 +2691,7 @@ absl::StatusOr<bool> LayoutAssignment::Run(
                       TuplePointsToAnalysis::Run(module));
   points_to_analysis_ = std::move(points_to_analysis);
   auto computations_to_work =
-      module->MakeNonfusionComputations(execution_threads);
+      module->MakeNonFusionNonCompositeComputations(execution_threads);
   // If the reverse_comptation_order_ flag is set, reverse the ordering of
   // traversing computations, to generate an alternative layout assignment.
   if (reverse_computation_order_ && !computations_to_work.empty()) {

--- a/xla/service/loop_schedule_linearizer.cc
+++ b/xla/service/loop_schedule_linearizer.cc
@@ -173,7 +173,7 @@ absl::StatusOr<bool> LoopScheduleLinearizer::Run(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() != HloOpcode::kWhile) {
         continue;

--- a/xla/service/memory_space_assignment/algorithm.cc
+++ b/xla/service/memory_space_assignment/algorithm.cc
@@ -2354,7 +2354,7 @@ absl::StatusOr<HeapSimulator::Result<HloValue>> MsaAlgorithm::Finish() {
     VLOG(3) << "Running post allocation transformation on module";
     for (HloComputation* comp : alias_analysis_.dataflow_analysis()
                                     .module()
-                                    .MakeNonfusionComputations()) {
+                                    .MakeNonFusionNonCompositeComputations()) {
       for (HloInstruction* instr : comp->MakeInstructionPostOrder()) {
         // If the operand is in alternate memory, we don't run the
         // post-allocation transformation.
@@ -4407,7 +4407,8 @@ void MsaAlgorithm::AddInputAndOutputRequiredAssignments() {
         }
       });
 
-  for (const HloComputation* computation : module.MakeNonfusionComputations()) {
+  for (const HloComputation* computation :
+       module.MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kConstant) {
         auto constant_instruction_it = instruction_schedule.find(instruction);

--- a/xla/service/memory_space_assignment/memory_space_assignment.cc
+++ b/xla/service/memory_space_assignment/memory_space_assignment.cc
@@ -278,7 +278,7 @@ MemorySpaceAssignment::CalculateAsyncCopyStats(
   AsyncCopyStats stats;
   int64_t current_copies = 0;
   for (const HloComputation* computation :
-       module_->MakeNonfusionComputations()) {
+       module_->MakeNonFusionNonCompositeComputations()) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kCopyStart ||
           (instruction->opcode() == HloOpcode::kAsyncStart &&
@@ -680,7 +680,8 @@ void MemorySpaceAssignment::RemoveAssignmentForInstruction(
 
 absl::Status MemorySpaceAssignment::SimplifyGraph() {
   VLOG(1) << "Simplifying graph...";
-  for (HloComputation* computation : module_->MakeNonfusionComputations()) {
+  for (HloComputation* computation :
+       module_->MakeNonFusionNonCompositeComputations()) {
     // Parallel computations aren't in the schedule and don't need to be
     // modified.
     if (!computations_in_schedule_.contains(computation)) {
@@ -1007,7 +1008,7 @@ absl::Status MemorySpaceAssignment::FixSchedule() {
   TF_RET_CHECK(module_->has_schedule());
   HloSchedule& schedule = module_->schedule();
   for (const HloComputation* computation :
-       module_->MakeNonfusionComputations()) {
+       module_->MakeNonFusionNonCompositeComputations()) {
     // Parallel computations aren't in the schedule and don't need to be
     // modified.
     if (!computations_in_schedule_.contains(computation)) {
@@ -1145,7 +1146,7 @@ absl::Status MemorySpaceAssignment::VerifyAndExportHeapSimulatorTrace(
   // Go through all instructions in the module to ensure CopyStart/CopyDone
   // instructions copy between alternate memory and default memory.
   for (const HloComputation* computation :
-       module_->MakeNonfusionComputations()) {
+       module_->MakeNonFusionNonCompositeComputations()) {
     for (const HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kCopyStart) {
         int64_t from_memory_space =

--- a/xla/service/memory_space_assignment/memory_space_assignment_test_base.h
+++ b/xla/service/memory_space_assignment/memory_space_assignment_test_base.h
@@ -187,7 +187,8 @@ class MemorySpaceAssignmentTestBase : public HloTestBase {
 
     HloCostAnalysis hlo_cost_analysis(hlo_cost_options);
     HloCostAnalysisWithAcceptState hlo_cost_analysis_wrapper(hlo_cost_analysis);
-    for (HloComputation* computation : module->MakeNonfusionComputations()) {
+    for (HloComputation* computation :
+         module->MakeNonFusionNonCompositeComputations()) {
       TF_CHECK_OK(computation->Accept(&hlo_cost_analysis));
     }
     TF_CHECK_OK(HloAliasAnalysis::Run(module).status());

--- a/xla/service/multi_output_fusion.cc
+++ b/xla/service/multi_output_fusion.cc
@@ -42,7 +42,7 @@ absl::StatusOr<bool> MultiOutputFusion::Run(
   bool changed = false;
 
   for (auto* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     // Do not operate over async computations (computations of async
     // instructions).
     if (computation->IsAsyncComputation()) {

--- a/xla/service/reduce_scatter_combiner.cc
+++ b/xla/service/reduce_scatter_combiner.cc
@@ -222,7 +222,7 @@ absl::StatusOr<bool> ReduceScatterCombiner::RunWithKeyCombiner(
 
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     if (!combine_while_loops_ &&
         computation->GetUniqueCaller(HloOpcode::kWhile)) {
       VLOG(2) << "Skipping this computation because the computation is a while "

--- a/xla/service/reduce_scatter_decomposer.cc
+++ b/xla/service/reduce_scatter_decomposer.cc
@@ -41,7 +41,7 @@ absl::StatusOr<bool> ReduceScatterDecomposer::Run(
   int64_t next_channel_id = hlo_query::NextChannelId(*module);
 
   for (HloComputation *computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction *instruction :
          computation->MakeInstructionPostOrder()) {
       auto *rs = DynCast<HloReduceScatterInstruction>(instruction);

--- a/xla/service/space_to_batch_converter.cc
+++ b/xla/service/space_to_batch_converter.cc
@@ -4201,7 +4201,8 @@ absl::StatusOr<bool> SpaceToBatchConverter::Run(
       2, "SpaceToBatchConverter::Run(), before:\n" + module->ToString());
   bool changed = false;
 
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     ConvolutionVisitor visitor(ctrl_, comp);
     if (visitor.Run().value()) {
       changed = true;

--- a/xla/service/spmd/collective_permute_motion.cc
+++ b/xla/service/spmd/collective_permute_motion.cc
@@ -310,7 +310,7 @@ absl::StatusOr<bool> CollectivePermuteMotion::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instr : computation->MakeInstructionPostOrder()) {
       if (instr->opcode() == HloOpcode::kWhile) {
         TF_ASSIGN_OR_RETURN(bool moved,

--- a/xla/service/transpose_folding.cc
+++ b/xla/service/transpose_folding.cc
@@ -235,7 +235,8 @@ absl::StatusOr<bool> TransposeFolding::Run(
     return absl::OkStatus();
   });
 
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     TF_RETURN_IF_ERROR(comp->Accept(&visit_fn));
   }
 

--- a/xla/service/while_loop_fusible_sinking.cc
+++ b/xla/service/while_loop_fusible_sinking.cc
@@ -490,7 +490,8 @@ absl::StatusOr<bool> WhileLoopFusibleSinking::Run(
   call_counts_.clear();
   bool changed = false;
   std::vector<HloInstruction*> while_instrs;
-  for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+  for (auto* comp :
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     // Right now we don't particularly care about optimizing while-of-while
     // patterns.  If/When we do, we'll want to visit the outer while (while_0)
     // before we visit the inner while (while_1):
@@ -528,7 +529,8 @@ absl::StatusOr<bool> WhileLoopFusibleSinking::Run(
   }
 
   if (sink_broadcast_of_constant_) {
-    for (auto* comp : module->MakeNonfusionComputations(execution_threads)) {
+    for (auto* comp :
+         module->MakeNonFusionNonCompositeComputations(execution_threads)) {
       for (HloInstruction* instr : comp->instructions()) {
         // TODO: b/358837872 - Handle loops with sharding.
         if (Match(instr, match::While()) && !instr->has_sharding()) {

--- a/xla/service/while_loop_pipeline_unroller.cc
+++ b/xla/service/while_loop_pipeline_unroller.cc
@@ -112,7 +112,7 @@ absl::StatusOr<bool> WhileLoopPipelineUnroller::Run(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   std::vector<std::pair<HloInstruction*, int64_t>> while_instructions;
   for (HloComputation* computation :
-       module->MakeNonfusionComputations(execution_threads)) {
+       module->MakeNonFusionNonCompositeComputations(execution_threads)) {
     for (HloInstruction* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kWhile) {
         int64_t pipeline_depth = ComputeWhileLoopPipelineDepth(*instruction);


### PR DESCRIPTION
Replace `MakeNonfusionComputations` with `MakeNonfusionNoncompositeComputations`