### PR TITLE
[ROCm] Add new hip_runtime bazel target

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -180,6 +180,24 @@ cc_library(
     ],
 )
 
+# NOTE(mrodden): used by jax_rocm_plugin to minimally link to hip runtime
+cc_library(
+    name = "hip_runtime",
+    visibility = ["//visibility:public"],
+    hdrs = glob(["%{rocm_root}/include/hip/**"]),
+    srcs = glob(["%{rocm_root}/lib/libamdhip*.so"]),
+    include_prefix = "rocm",
+    includes = [
+        "%{rocm_root}/include",
+    ],
+    strip_include_prefix = "%{rocm_root}",
+    deps = [
+        ":rocm_config",
+        ":rocprofiler_register",
+        ":system_libs",
+    ],
+)
+
 cc_library(
     name = "rocblas",
     hdrs = glob(["%{rocm_root}/include/rocblas/**"]),


### PR DESCRIPTION
In the jaxlib extension for ROCm, we need to link to the HIP runtime (libamdhip64.so) but without the extra links that are on rocm_hip, such as comgr, rocm-smi, and HSA runtime (which are linked by libamdhip itself)

Comgr shouldn't be directly linked by any HIP users either, but that hasn't been an issue for others apparently, so add this target that we can use from jaxlib and not intefere with rocm_hip.