### PR TITLE
Generalize a bit on while loop analysis.

### DIFF
--- a/xla/hlo/analysis/while_loop_analysis.h
+++ b/xla/hlo/analysis/while_loop_analysis.h
@@ -69,7 +69,7 @@ std::optional<int64_t> GetLoopInductionVarTupleIdxWithKnownValues(
 // `(N - K + 1) div C`, respectively.
 std::optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction *while_op,
                                                  int64_t indvar_tuple_idx,
-                                                 const Literal &indvar_init);
+                                                 const int64_t indvar_init_val);
 
 // Same as above, but returns the loop range, i.e., start (inclusive), end
 // (inclusive) and step instead of the trip count.

--- a/xla/hlo/analysis/while_loop_analysis_test.cc
+++ b/xla/hlo/analysis/while_loop_analysis_test.cc
@@ -99,7 +99,8 @@ absl::StatusOr<int64_t> WhileLoopAnalysisTest::MakeWhileLoopAndGetTripCount(
       Cast<HloConstantInstruction>(
           module->GetComputationWithName("entry")->GetInstructionWithName(
               "param.1"))
-          ->literal());
+          ->literal()
+          .Get<int64_t>({0}));
 
   CHECK(trip_count.has_value());
 
@@ -1116,13 +1117,56 @@ TEST_F(WhileLoopAnalysisTest,
       m_with_constant->entry_computation()->root_instruction();
   HloInstruction* while_op_without_constant =
       m_without_constant->entry_computation()->root_instruction();
-  std::optional<int64_t> trip_count_with_constant = MatchTrivialLoopTripCount(
-      while_op_with_constant, 0, LiteralUtil::CreateR0<int32_t>(0));
+  std::optional<int64_t> trip_count_with_constant =
+      MatchTrivialLoopTripCount(while_op_with_constant, 0, 0);
   EXPECT_EQ(trip_count_with_constant, 10);
   std::optional<int64_t> trip_count_without_constant =
-      MatchTrivialLoopTripCount(while_op_without_constant, 0,
-                                LiteralUtil::CreateR0<int32_t>(0));
+      MatchTrivialLoopTripCount(while_op_without_constant, 0, 0);
   EXPECT_EQ(trip_count_without_constant, std::nullopt);
+}
+
+TEST_F(WhileLoopAnalysisTest,
+       MatchTrivialLoopCountWithSimpleArithmeticOnIndvar) {
+  absl::string_view hlo_string = R"(
+HloModule ModuleWithWhile
+body {
+  p_body = (f32[2], s32[]) parameter(0)
+  val = f32[2] get-tuple-element(p_body), index=0
+  index = s32[] get-tuple-element(p_body), index=1
+  one = s32[] constant(1)
+  inc = s32[] add(index, one)
+  ROOT root = (f32[2], s32[]) tuple(val, inc)
+}
+
+condition {
+  p_cond = (f32[2], s32[]) parameter(0)
+  gte = s32[] get-tuple-element(p_cond), index=1
+  const = s32[] constant(10)
+  ROOT result = pred[] compare(gte, const), direction=LE
+}
+
+ENTRY entry {
+  param.0 = f32[2] parameter(0)
+  const.0 = s32[] constant(1)
+  const.1 = s32[] constant(1)
+  add.0 = s32[] add(const.0, const.1)
+  while_init = (f32[2], s32[]) tuple(param.0, add.0)
+  ROOT while = (f32[2], s32[]) while(while_init), condition=condition, body=body
+}
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  HloInstruction* while_op = m->entry_computation()->root_instruction();
+  std::optional<Range> range = MatchTrivialLoopRange(while_op);
+
+  EXPECT_TRUE(range.has_value());
+  EXPECT_EQ(range->min().GetSignedValue(), 2);
+  EXPECT_TRUE(range->max().has_value());
+  EXPECT_EQ(range->max().value().GetSignedValue(), 10);
+  EXPECT_TRUE(range->step().has_value());
+  EXPECT_EQ(range->step().value().GetSignedValue(), 1);
 }
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
Actually currently, the while loop analysis failed generating metadata when the induction variable has some very simple arithmetic. This will lead to lots of inefficiency downstream on GPU compiler.

This PR is just for illustrating the idea and it was a quick fix used internally in x.AI. But I think in general this file needs to be reworked together with the while loop annotator.

I think the two paths (match + evaluator) needs to be merged, if matching doesn't work, then just try evaluating the HLO instruction in best efforts.

I hope in general there should be a pass in XLA that can evaluate all trivial indices for all use cases.