### PR TITLE
Command buffer support nested buffer which has memory allocation/free node.

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -475,6 +475,11 @@ class TracedCommandBuffer : public CommandBufferCmd::State {
       se::Stream* stream, absl::FunctionRef<absl::Status(se::Stream*)> trace,
       se::StreamPriority priority = se::StreamPriority::Default);
 
+  // To implement nested command buffer, some platform requires that the nested
+  // command buffer should use the move semantics to avoid graph cloning, so we
+  // need to move the command buffer from cache for this case.
+  absl::Status RemoveCommandBuffer(se::CommandBuffer* cmd_buffer);
+
  private:
   std::vector<BufferAllocation::Index> allocs_indices_;
 

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -291,7 +291,7 @@ class CommandBuffer {
   // To implement nested command buffer, some platform requires that the nested
   // command buffer should use the move semantics to avoid graph cloning due to
   // implementation details. We use this method to determine whether we need to
-  // use move semantics when creating nested command buffer..
+  // use move semantics when creating nested command buffer.
   virtual absl::StatusOr<bool> NestedCommandRequiresMove() const = 0;
 
   // Finalizes command buffer and makes it executable. Once command buffer is

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -447,7 +447,8 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
 absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
     absl::Span<const GraphNodeHandle> dependencies,
     std::unique_ptr<CommandBuffer> nested) {
-  CUgraph child_graph = static_cast<CudaCommandBuffer*>(nested.get())->graph_;
+  CUgraph child_graph =
+      std::move(static_cast<CudaCommandBuffer*>(nested.get())->graph_);
   VLOG(2) << "Create a new node by moving the child graph " << child_graph
           << " and add it to " << graph_ << "; deps: " << dependencies.size();
 
@@ -455,8 +456,8 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
 
   CUgraphNode node_handle;
   TF_RETURN_IF_ERROR(cuda::ToStatus(
-      cuGraphAddChildGraphNode(&node_handle, std::move(graph_), deps.data(),
-                               deps.size(), child_graph),
+      cuGraphAddChildGraphNode(&node_handle, graph_, deps.data(), deps.size(),
+                               std::move(child_graph)),
       "Failed to create a child graph node and add it to a CUDA graph"));
 
   return FromCudaGraphHandle(node_handle);
@@ -476,7 +477,8 @@ absl::Status CudaCommandBuffer::UpdateChildNode(GraphNodeHandle node_handle,
 
 absl::Status CudaCommandBuffer::UpdateChildNode(
     GraphNodeHandle node_handle, std::unique_ptr<CommandBuffer> nested) {
-  CUgraph child_graph = static_cast<CudaCommandBuffer*>(nested.get())->graph_;
+  CUgraph child_graph =
+      std::move(static_cast<CudaCommandBuffer*>(nested.get())->graph_);
   VLOG(2) << "Set child node params " << node_handle << " in graph executable "
           << exec_ << "to params contained in " << child_graph << " (moved)";
 

--- a/xla/stream_executor/cuda/cuda_command_buffer.h
+++ b/xla/stream_executor/cuda/cuda_command_buffer.h
@@ -136,8 +136,15 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
       absl::Span<const GraphNodeHandle> dependencies,
       const CommandBuffer& nested) override;
 
+  absl::StatusOr<GraphNodeHandle> CreateChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      std::unique_ptr<CommandBuffer> nested) override;
+
   absl::Status UpdateChildNode(GraphNodeHandle node_handle,
                                const CommandBuffer& nested) override;
+
+  absl::Status UpdateChildNode(GraphNodeHandle node_handle,
+                               std::unique_ptr<CommandBuffer> nested) override;
 
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(
       absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,
@@ -159,6 +166,8 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
   // Set the nodes inside the command buffer to the target priority, cuda
   // currently only support kernel node's priority.
   absl::Status SetPriority(StreamPriority priority) override;
+
+  absl::StatusOr<bool> NestedCommandRequiresMove() const override;
 
   absl::Status PrepareFinalization() override;
 

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -125,8 +125,15 @@ class GpuCommandBuffer : public CommandBuffer {
       const CommandBuffer& nested,
       absl::Span<const Command* const> dependencies) override;
 
+  absl::StatusOr<const Command*> CreateNestedCommand(
+      std::unique_ptr<CommandBuffer> nested,
+      absl::Span<const Command* const> dependencies) override;
+
   absl::Status UpdateNestedCommand(const Command* command,
                                    const CommandBuffer& nested) override;
+
+  absl::Status UpdateNestedCommand(
+      const Command* command, std::unique_ptr<CommandBuffer> nested) override;
 
   absl::StatusOr<const Command*> CreateMemcpyD2D(
       DeviceMemoryBase* dst, const DeviceMemoryBase& src, uint64_t size,
@@ -329,6 +336,13 @@ class GpuCommandBuffer : public CommandBuffer {
   virtual absl::StatusOr<GraphNodeHandle> CreateChildNode(
       absl::Span<const GraphNodeHandle> dependencies,
       const CommandBuffer& nested) = 0;
+
+  virtual absl::StatusOr<GraphNodeHandle> CreateChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      std::unique_ptr<CommandBuffer> nested) = 0;
+
+  virtual absl::Status UpdateChildNode(
+      GraphNodeHandle node_handle, std::unique_ptr<CommandBuffer> nested) = 0;
 
   // Associate another command buffer with this child node. Will return an
   // error if the given node has not been created as a child node.

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -409,6 +409,10 @@ absl::StatusOr<size_t> RocmCommandBuffer::GetNodeCount() const {
   return numNodes;
 }
 
+absl::StatusOr<bool> RocmCommandBuffer::NestedCommandRequiresMove() const {
+  return absl::UnimplementedError("Not implemented.");
+}
+
 absl::Status RocmCommandBuffer::PrepareFinalization() {
   return absl::OkStatus();
 }

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -251,6 +251,17 @@ absl::Status RocmCommandBuffer::UpdateChildNode(GraphNodeHandle node_handle,
                   "Failed to set HIP graph child node params");
 }
 
+absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateChildNode(
+    absl::Span<const GraphNodeHandle> dependencies,
+    std::unique_ptr<CommandBuffer> nested) {
+  return absl::UnimplementedError("Not implemented.");
+}
+
+absl::Status RocmCommandBuffer::UpdateChildNode(
+    GraphNodeHandle node_handle, std::unique_ptr<CommandBuffer> nested) {
+  return absl::UnimplementedError("Not implemented.");
+}
+
 absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateKernelNode(
     absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,
     const ThreadDim& threads, const BlockDim& blocks, const Kernel& kernel,

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -153,6 +153,8 @@ class RocmCommandBuffer : public GpuCommandBuffer {
     return absl::UnimplementedError("Not implemented.");
   }
 
+  absl::StatusOr<bool> NestedCommandRequiresMove() const override;
+
   absl::Status PrepareFinalization() override;
 
   absl::StatusOr<GraphConditionalHandle> CreateConditionalHandle() override;

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -125,6 +125,14 @@ class RocmCommandBuffer : public GpuCommandBuffer {
   absl::Status UpdateChildNode(GraphNodeHandle node_handle,
                                const CommandBuffer& nested) override;
 
+  absl::StatusOr<GraphNodeHandle> CreateChildNodeWith(
+      absl::Span<const GraphNodeHandle> dependencies,
+      std::unique_ptr<CommandBuffer> nested) override;
+
+  absl::Status UpdateChildNode(
+      GraphNodeHandle node_handle,
+      std::unique_ptr<CommandBuffer> nested) override;
+
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(
       absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,
       const ThreadDim& threads, const BlockDim& blocks, const Kernel& kernel,

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -125,13 +125,12 @@ class RocmCommandBuffer : public GpuCommandBuffer {
   absl::Status UpdateChildNode(GraphNodeHandle node_handle,
                                const CommandBuffer& nested) override;
 
-  absl::StatusOr<GraphNodeHandle> CreateChildNodeWith(
+  absl::StatusOr<GraphNodeHandle> CreateChildNode(
       absl::Span<const GraphNodeHandle> dependencies,
       std::unique_ptr<CommandBuffer> nested) override;
 
-  absl::Status UpdateChildNode(
-      GraphNodeHandle node_handle,
-      std::unique_ptr<CommandBuffer> nested) override;
+  absl::Status UpdateChildNode(GraphNodeHandle node_handle,
+                               std::unique_ptr<CommandBuffer> nested) override;
 
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(
       absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,


### PR DESCRIPTION
When creating nested command buffer that has memory allocation node use move semantics when calling cuGraphAddChildGraphNode