### PR TITLE
[debug-options-dump] Fix dumping for repeated string fields

### DIFF
--- a/xla/service/dump.cc
+++ b/xla/service/dump.cc
@@ -800,7 +800,8 @@ std::string GetRepeatedValueAsString(
       return std::string(
           reflection->GetRepeatedEnum(debug_options, field, index)->name());
     case tsl::protobuf::FieldDescriptor::TYPE_STRING:
-      return reflection->GetRepeatedString(debug_options, field, index);
+      return "\"" + reflection->GetRepeatedString(debug_options, field, index) +
+             "\"";
     case tsl::protobuf::FieldDescriptor::TYPE_MESSAGE: {
       tsl::protobuf::TextFormat::Printer tsl_printer;
       tsl_printer.SetInitialIndentLevel(1);

--- a/xla/service/dump_test.cc
+++ b/xla/service/dump_test.cc
@@ -478,5 +478,16 @@ TEST(DumpTest, GetNonDefaultDebugOptions) {
   EXPECT_THAT(real_contents, testing::Eq(non_default_options));
 }
 
+TEST(DumpTest, DumpRepeatedStringTest) {
+  DebugOptions options = DefaultDebugOptionsIgnoringFlags();
+  options.add_legacy_command_buffer_custom_call_targets("__gpu.gpu.triton");
+
+  std::string non_default_options = GetNonDefaultDebugOptions(options);
+  EXPECT_THAT(
+      non_default_options,
+      testing::HasSubstr(
+          "legacy_command_buffer_custom_call_targets: \"__gpu.gpu.triton\""));
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
Earlier they were being dumped without quotation marks - which meant that parsing failed later. Fixed this.