### PR TITLE
[ROCm] fixed gpu_hlo_unoptimized_llvm.hlo.test on rocm

### DIFF
--- a/xla/tools/hlo_opt/tests/gpu_hlo_unoptimized_llvm.hlo
+++ b/xla/tools/hlo_opt/tests/gpu_hlo_unoptimized_llvm.hlo
@@ -1,6 +1,7 @@
-// RUN: hlo-opt %s --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=%S/../gpu_specs/%{GPU}.txtpb | FileCheck %s
+// RUN: hlo-opt %s --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=%S/../gpu_specs/%{GPU}.txtpb | FileCheck --check-prefixes=CHECK,CHECK-%{PTX} %s
 
-// CHECK:       define ptx_kernel void @fusion
+// CHECK-PTX:     define ptx_kernel void @fusion
+// CHECK-GCN:     define amdgpu_kernel void @fusion
 // CHECK:         br i1
 // CHECK:         br label
 


### PR DESCRIPTION
This is a fix to the failed //xla/tools/hlo_opt:tests/gpu_hlo_unoptimized_llvm.hlo.test.

@xla-rotation could you review my PR, please?