### PR TITLE
[ROCm] Fix reduction emitter for adapting to warp size 64

### DIFF
--- a/xla/backends/gpu/codegen/emitters/reduction.cc
+++ b/xla/backends/gpu/codegen/emitters/reduction.cc
@@ -681,7 +681,8 @@ llvm::SmallVector<mlir::Value> ColumnReductionFusion::EmitReduction(
   HloValueMap inits = GetInits(group_id, state);
   auto per_thread =
       state.EmitPerThreadElements(group_id, inits, state.FusionOutputs());
-  return state.ReduceViaSharedMemory(group_id, per_thread, inits);
+  return state.ReduceViaSharedMemory(group_id, per_thread, inits, std::nullopt,
+                                     kTileSize / 2);
 }
 
 SmallColumnReductionFusion::SmallColumnReductionFusion(


### PR DESCRIPTION
Max distance for shuffling during warp reduction should be set to 16 since we still preserve 32x32 tiling in column reduction.

Fixed failing tests:
[  FAILED  ] ReduceTest.VectorizedReduce_Max
[  FAILED  ] ReduceTest.ReduceR2_1000x1500_To_R1
[  FAILED  ] ReduceTest.VectorizedReduce_Add
[  FAILED  ] ReduceTest.ReduceR2_1024x1024_To_R1
[  FAILED  ] ReduceTest.VectorizedReduce_Multiply
[  FAILED  ] ReduceTest.VectorizedReduce_Min
[  FAILED  ] ReduceR3ToR2Test_Instantiation/ReduceR3ToR2Test.ReduceR3ToR2/17