### PR TITLE
[ROCm] Fix rocm ci build break

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -229,6 +229,7 @@ build:asan --copt -g
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
 
+build:rocm_base --config=clang_local
 build:rocm_base --copt=-Wno-gnu-offsetof-extensions
 build:rocm_base --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm_base --define=using_rocm_hipcc=true


### PR DESCRIPTION
This fixes rocm CI build compilation errors introduced in the hermetic cc toolchain change.
https://github.com/openxla/xla/pull/27789