### PR TITLE
[ROCm] Pass AMDGPU_TARGETS to crosstool wrapper

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -716,6 +716,9 @@ def _create_local_rocm_repository(repository_ctx):
             "%{hip_runtime_library}": "amdhip64",
             "%{crosstool_verbose}": _crosstool_verbose(repository_ctx),
             "%{gcc_host_compiler_path}": str(cc),
+            "%{rocm_amdgpu_targets}": ",".join(
+                ["\"%s\"" % c for c in rocm_config.amdgpu_targets],
+            ),
         },
     )
 


### PR DESCRIPTION
This is an old fix that wasn't merged properly.
Original PR: https://github.com/openxla/xla/pull/17544
What copybara merged: https://github.com/openxla/xla/commit/0d9511953b74eb614b9db1dcd45f100d89067c6b