### PR TITLE
[NVIDIA GPU] Add copies for collective memory ops if they are consuming from constant or module inputs

### DIFF
--- a/xla/service/copy_insertion.cc
+++ b/xla/service/copy_insertion.cc
@@ -1226,15 +1226,20 @@ absl::Status CopyInsertion::AddCopiesToResolveInterference(
 
 absl::Status CopyInsertion::AddSpecialCaseCopies(
     HloModule* module,
-    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+    const absl::flat_hash_set<absl::string_view>& execution_threads,
+    std::function<bool(const HloValue* value)>
+        should_add_target_specific_copies) {
   std::unique_ptr<CallGraph> call_graph = CallGraph::Build(module);
-  return AddSpecialCaseCopies(*call_graph, execution_threads, module);
+  return AddSpecialCaseCopies(*call_graph, execution_threads, module,
+                              should_add_target_specific_copies);
 }
 
 absl::Status CopyInsertion::AddSpecialCaseCopies(
     const CallGraph& call_graph,
     const absl::flat_hash_set<absl::string_view>& execution_threads,
-    HloModule* module) {
+    HloModule* module,
+    std::function<bool(const HloValue* value)>
+        should_add_target_specific_copies) {
   TF_ASSIGN_OR_RETURN(std::unique_ptr<HloAliasAnalysis> alias_analysis,
                       HloAliasAnalysis::Run(module, can_share_buffer_));
 
@@ -1276,6 +1281,14 @@ absl::Status CopyInsertion::AddSpecialCaseCopies(
                  "Copying.";
       add_index_to_copy(value->defining_instruction(), value->defining_index());
     }
+
+    if (should_add_target_specific_copies &&
+        should_add_target_specific_copies(value)) {
+      VLOG(2) << "Adding target specific copies for value "
+              << value->ToShortString();
+      add_index_to_copy(value->defining_instruction(), value->defining_index());
+    }
+
     for (const HloValue* value2 : buffer.values()) {
       // Find HloValues that share a position and use, which would cause the use
       // and operand to share buffers. Check if this is allowed and insert a

--- a/xla/service/copy_insertion.h
+++ b/xla/service/copy_insertion.h
@@ -113,14 +113,18 @@ class CopyInsertion : public HloModulePass {
   //
   absl::Status AddSpecialCaseCopies(
       HloModule* module,
-      const absl::flat_hash_set<absl::string_view>& execution_threads = {});
+      const absl::flat_hash_set<absl::string_view>& execution_threads = {},
+      std::function<bool(const HloValue* value)>
+          should_add_target_specific_copies = nullptr);
 
  protected:
   // Override which requires the caller to pass in a call graph.
   virtual absl::Status AddSpecialCaseCopies(
       const CallGraph& call_graph,
       const absl::flat_hash_set<absl::string_view>& execution_threads,
-      HloModule* module);
+      HloModule* module,
+      std::function<bool(const HloValue* value)>
+          should_add_target_specific_copies = nullptr);
 
   // Add copies for conditional instructions.
   virtual absl::Status AddCopiesForConditional(

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1916,6 +1916,29 @@ absl::StatusOr<std::unique_ptr<HloModule>> GpuCompiler::RunHloPasses(
 }
 
 namespace {
+bool ShouldAddCopyForCollectiveMemorySpace(const HloValue* value) {
+  const HloInstruction* inst = value->defining_instruction();
+  const HloModule* module = inst->GetModule();
+  // If no collective memory is needed, return.
+  if (!module->config().debug_options().xla_gpu_enable_nccl_user_buffers() &&
+      !module->config().debug_options().xla_gpu_experimental_enable_nvshmem()) {
+    return false;
+  }
+  // Add copy if a potential collective-memmory-spaced op directly consumes from
+  // module input or a constant as they are allocated by bfc ahead of time and
+  // the alignment might not match collective memory space's requiment.
+  if (absl::c_linear_search(
+          module->entry_computation()->parameter_instructions(), inst) ||
+      (inst->opcode() == HloOpcode::kConstant)) {
+    for (auto& use : value->GetUses()) {
+      if (IsCollective(use.instruction)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 absl::Status RunPostSchedulingCopyInsertion(HloModule* module,
                                             const GpuAliasInfo* alias_info) {
   // We run a separate pass of copy elision here because the sequential ordering
@@ -1939,8 +1962,9 @@ absl::Status RunPostSchedulingCopyInsertion(HloModule* module,
   // whether it is legal to remove a copy. However, copies in the graph may be
   // necessary for other reason such as preventing a constant from being live
   // out of the graph. So run AddSpecialCaseCopies to re-insert these copies.
-  TF_RETURN_IF_ERROR(
-      copy_insertion.CopyInsertion::AddSpecialCaseCopies(module));
+
+  TF_RETURN_IF_ERROR(copy_insertion.CopyInsertion::AddSpecialCaseCopies(
+      module, /*execution_threads=*/{}, ShouldAddCopyForCollectiveMemorySpace));
 
   TF_RETURN_IF_ERROR(HloDCE().Run(module).status());
 

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -3264,6 +3264,61 @@ ENTRY main {
   EXPECT_EQ(ag_start->operand(0)->shape().layout().memory_space(), 1);
 }
 
+TEST_F(CollectiveOpsTestE2E,
+       CollectiveConsumingContantAndModuleShouldHaveCopies) {
+  absl::string_view hlo_string = R"(
+HloModule CollectiveCopies, entry_computation_layout={(bf16[1024,1024]{1,0})->(bf16[1024,1024]{1,0}, bf16[])}, num_partitions=4
+apply_op {
+  x = bf16[] parameter(0)
+  y = bf16[] parameter(1)
+  ROOT apply_op = bf16[] add(x, y)
+}
+
+ENTRY main {
+  Arg_1 = bf16[1024,1024]{1,0} parameter(0)
+  constant0 = bf16[] constant(10)
+  all-reduce-start.const = bf16[] all-reduce-start(constant0), to_apply=apply_op, replica_groups={{0,1,2,3}}
+  all-reduce-done.const = bf16[] all-reduce-done(all-reduce-start.const)
+
+  all-reduce-start = bf16[1024,1024]{1,0} all-reduce-start(Arg_1), to_apply=apply_op, replica_groups={{0,1,2,3}}
+  all-reduce-done = bf16[1024,1024]{1,0} all-reduce-done(all-reduce-start)
+
+  ROOT tuple = (bf16[1024,1024]{1,0}, bf16[]) tuple(all-reduce-done, all-reduce-done.const)
+} // main
+)";
+
+  const int64_t kNumReplicas = 1;
+  const int64_t kNumPartitions = 4;
+  if (test_runner().device_count() < kNumReplicas * kNumPartitions) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas * kNumPartitions
+                 << " devices (" << test_runner().device_count()
+                 << " available)";
+  }
+
+  HloModuleConfig config = GetModuleConfigForTest(kNumReplicas, kNumPartitions);
+  auto opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_enable_nccl_user_buffers(true);
+  opts.add_xla_disable_hlo_passes("gpu-convert-async-collectives-to-sync");
+
+  config.set_debug_options(opts);
+  config.set_use_spmd_partitioning(false);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executable,
+      CreateExecutable(std::move(module), /*run_hlo_passes=*/false));
+  TF_ASSERT_OK_AND_ASSIGN(const HloModule* const executable_module,
+                          test_runner().HloModuleFromWrapped(executable.get()));
+  std::vector<HloInstruction*> all_ar =
+      FindInstructions(executable_module, HloOpcode::kAllReduceStart);
+  // Both allreduces should have their operands copied to collective memory
+  // space.
+  for (auto ar : all_ar) {
+    EXPECT_EQ(ar->operand(0)->opcode(), HloOpcode::kCopy);
+    EXPECT_EQ(ar->operand(0)->shape().layout().memory_space(), 1);
+  }
+}
+
 class AllReduceTest
     : public CollectiveOpsWithFlagsBase,
       public ::testing::WithParamInterface<std::tuple<bool, bool>> {


### PR DESCRIPTION
Some collective allocators like ncclMemAlloc or nvshmemAlloc require specific alignment of allocated memory to be able to use underlying hardware feature, if inputs are coming from module inputs or constants which are pre-allocated by default bfc ahead of time, it will sometimes fail during runtime due to invalid permission or other memory errors.
This is to add an intermediate copy for those scenarios so the copy will have the collective color and allocated by appropriate allocator.