### PR TITLE
[ROCm] Fix invalid rocblas version for rocm 7

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -734,7 +734,7 @@ def _create_local_rocm_repository(repository_ctx):
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
             "%{hipblaslt_flag}": have_hipblaslt,
             "%{hip_soversion_number}": "6" if int(rocm_config.rocm_version_number) >= 60000 else "5",
-            "%{rocblas_soversion_number}": "4" if int(rocm_config.rocm_version_number) >= 60000 else "3",
+            "%{rocblas_soversion_number}": "5" if int(rocm_config.rocm_version_number) >= 70000 else "4",
         },
     )
 
@@ -753,7 +753,7 @@ def _create_local_rocm_repository(repository_ctx):
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
             "%{hipblaslt_flag}": have_hipblaslt,
             "%{hip_soversion_number}": "6" if int(rocm_config.rocm_version_number) >= 60000 else "5",
-            "%{rocblas_soversion_number}": "4" if int(rocm_config.rocm_version_number) >= 60000 else "3",
+            "%{rocblas_soversion_number}": "5" if int(rocm_config.rocm_version_number) >= 70000 else "4",
         },
     )
 


### PR DESCRIPTION
There is a try to load invalid version of rocblas library while running the tests under rocm7.
This PR removes support for very old versions of rocm but adds support for rocm7