### PR TITLE
[NVIDIA GPU] Do out of place allreduce for nvshmem

### DIFF
--- a/xla/hlo/analysis/hlo_dataflow_analysis.cc
+++ b/xla/hlo/analysis/hlo_dataflow_analysis.cc
@@ -1881,6 +1881,14 @@ bool IsDefaultInPlaceOperation(const HloInstruction* hlo) {
 /*static*/ std::vector<std::pair<HloOperandIndex, ShapeIndex>>
 HloDataflowAnalysis::GetInPlaceInputOutputPairs(
     const HloInstruction* instruction) {
+  // TODO tixxx: nvshmem default one-shot allreduce algo requires
+  // separate buffers for IO, remove this once nvshmem is upgraded to 3.3
+  if (instruction->opcode() == HloOpcode::kAllReduceStart) {
+    if (absl::StrContainsIgnoreCase(instruction->raw_backend_config_string(),
+                                    "nvshmem")) {
+      return {};
+    }
+  }
   if (IsDefaultInPlaceOperation(instruction)) {
     int64_t num_in_place_operands = instruction->operand_count();
     const HloScatterInstruction* scatter =

--- a/xla/hlo/analysis/hlo_dataflow_analysis_test.cc
+++ b/xla/hlo/analysis/hlo_dataflow_analysis_test.cc
@@ -3735,5 +3735,32 @@ TEST_P(HloDataflowAnalysisTest, b409756077) {
   EXPECT_THAT(defining_instructions, UnorderedElementsAre(param2, add0));
 }
 
+TEST_F(GetInPlaceInputOutputPairsTest, nvshmem_ar) {
+  const char* kModule = R"(
+    HloModule test_ar
+    region_add {
+      lhs = f32[] parameter(0)
+      rhs = f32[] parameter(1)
+      ROOT ret = f32[] add(lhs, rhs)
+    }
+
+    ENTRY test {
+      p0 = f32[10] parameter(0)
+      ar = f32[10] all-reduce-start(p0), replica_groups={}, to_apply=region_add, backend_config={"collective_backend_config":{"backend":"NVSHMEM"}}
+      ROOT ar.done = f32[10] all-reduce-done(ar)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kModule));
+  const HloInstruction* ar_start =
+      module->entry_computation()->root_instruction()->operand(0);
+
+  auto in_place_pairs =
+      HloDataflowAnalysis::GetInPlaceInputOutputPairs(ar_start);
+  std::vector<std::pair<HloOperandIndex, ShapeIndex>> expected_pairs;
+  // For nvshmem allreduce, we expect no aliasing for input and output buffers
+  // therefore empty inplace pairs.
+  EXPECT_EQ(in_place_pairs, expected_pairs);
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
NVSHMEM's default one-shot allreduce algo requires separate buffers for input and output.
In nvshmem 3.3, the heuristics will change to use 2-shot algo when input and output buffers are the same.
This is a workaround before 3.3 upgrade.