### PR TITLE
[ROCm] added allreduce kernel registration

### DIFF
--- a/xla/stream_executor/cuda/all_reduce_kernel_cuda.cc
+++ b/xla/stream_executor/cuda/all_reduce_kernel_cuda.cc
@@ -37,15 +37,18 @@ union alignas(8) Vec<__nv_bfloat16> {
   PackedType packed;
 };
 
-__device__ __forceinline__ void PutSignalFlag(uint32_t* addr, uint32_t val) {
+template <>
+__device__ __forceinline__ void PutSignalFlag<PlatformType::CUDA>(
+    uint32_t* addr, uint32_t val) {
   ::cuda::atomic_ref<uint32_t, ::cuda::thread_scope_system> ref(*addr);
   // During signaling release semantics are used to ensure that writes
   // by the current thread are visible to the waiting thread.
   ref.store(val, ::cuda::memory_order_release);
 }
 
-__device__ __forceinline__ void WaitSignalFlag(uint32_t* addr,
-                                               uint32_t expected) {
+template <>
+__device__ __forceinline__ void WaitSignalFlag<PlatformType::CUDA>(
+    uint32_t* addr, uint32_t expected) {
   ::cuda::atomic_ref<uint32_t, ::cuda::thread_scope_system> ref(*addr);
   // During waiting we use acquire semantics to ensure all memory writes by the
   // remote thread are visible to the current thread.
@@ -72,7 +75,8 @@ __device__ __forceinline__ void WaitSignalFlag(uint32_t* addr,
         return stream_executor::KernelLoaderSpec::CreateInProcessSymbolSpec(   \
             absl::bit_cast<void*>(&stream_executor::gpu::AllReduceKernelImpl<  \
                                   NV_TYPE, xla::ReductionKind::REDUCTION_KIND, \
-                                  xla::se::gpu::AllReduceStrategy::STRATEGY>), \
+                                  xla::se::gpu::AllReduceStrategy::STRATEGY,   \
+                                  stream_executor::gpu::PlatformType::CUDA>),  \
             "all_reduce_" #SUFFIX #STRATEGY, arity);                           \
       }));
 

--- a/xla/stream_executor/gpu/all_reduce_kernel_lib.cu.h
+++ b/xla/stream_executor/gpu/all_reduce_kernel_lib.cu.h
@@ -20,10 +20,18 @@ limitations under the License.
 #include <cstdint>
 #include <type_traits>
 
-#include "third_party/gpus/cuda/include/cuda/atomic"
-#include "third_party/gpus/cuda/include/cuda_bf16.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/stream_executor/gpu/all_reduce_kernel.h"
+
+#if TENSORFLOW_USE_ROCM
+#include <hip/hip_runtime.h>
+#include <hip/hip_bfloat16.h>
+using bf16_t = hip_bfloat16;
+#else  // CUDA
+#include "third_party/gpus/cuda/include/cuda/atomic"
+#include "third_party/gpus/cuda/include/cuda_bf16.h"
+using bf16_t = __nv_bfloat16;
+#endif
 
 namespace stream_executor::gpu {
 
@@ -39,10 +47,10 @@ union alignas(16) Vec<float> {
 };
 
 template <>
-union alignas(8) Vec<__nv_bfloat16> {
+union alignas(8) Vec<bf16_t> {
   using PackedType = int2;
 
-  __nv_bfloat16 data[4];
+  bf16_t data[4];
   PackedType packed;
 };
 
@@ -89,14 +97,26 @@ __device__ __forceinline__ void VecOp(Vec<T>& res, const Vec<T>& vec) {
 }
 
 __device__ __forceinline__ void PutSignalFlag(uint32_t* addr, uint32_t val) {
+#if TENSORFLOW_USE_ROCM
+  __atomic_store_n(addr, val, __ATOMIC_RELEASE);
+  __threadfence_system();  // Ensure visibility across all GPUs
+#else                      // cuda
   ::cuda::atomic_ref<uint32_t, ::cuda::thread_scope_system> ref(*addr);
   // During signaling release semantics are used to ensure that writes
   // by the current thread are visible to the waiting thread.
   ref.store(val, ::cuda::memory_order_release);
+#endif
 }
 
 __device__ __forceinline__ void WaitSignalFlag(uint32_t* addr,
                                                uint32_t expected) {
+#if TENSORFLOW_USE_ROCM
+  uint32_t val;
+  do {
+    __threadfence_system();  // Ensure we see the latest value
+    val = __atomic_load_n(addr, __ATOMIC_ACQUIRE);
+  } while (val < expected);
+#else  // cuda
   ::cuda::atomic_ref<uint32_t, ::cuda::thread_scope_system> ref(*addr);
   // During waiting we use acquire semantics to ensure all memory writes by the
   // remote thread are visible to the current thread.
@@ -104,6 +124,7 @@ __device__ __forceinline__ void WaitSignalFlag(uint32_t* addr,
   // the next sync point.
   while (ref.load(::cuda::memory_order_acquire) < expected) {
   }
+#endif
 }
 
 __device__ __forceinline__ void SyncRemoteBlocks(

--- a/xla/stream_executor/gpu/all_reduce_kernel_lib.cu.h
+++ b/xla/stream_executor/gpu/all_reduce_kernel_lib.cu.h
@@ -25,6 +25,12 @@ limitations under the License.
 
 namespace stream_executor::gpu {
 
+enum class PlatformType : uint32_t {
+  ROCM,
+  CUDA,
+  NOGPU,  // place holder for compiling header only without errors
+};
+
 template <typename T>
 union Vec;
 
@@ -78,25 +84,31 @@ __device__ __forceinline__ void VecOp(Vec<T>& res, const Vec<T>& vec) {
   res.data[3] = ApplyBinaryOp<T, ReductionKindT>(res.data[3], vec.data[3]);
 }
 
-__device__ __forceinline__ void PutSignalFlag(uint32_t* addr, uint32_t val);
+template <PlatformType T = PlatformType::NOGPU>
+__device__ __forceinline__ void PutSignalFlag(uint32_t* addr, uint32_t val) {}
 
+template <PlatformType T = PlatformType::NOGPU>
 __device__ __forceinline__ void WaitSignalFlag(uint32_t* addr,
-                                               uint32_t expected);
+                                               uint32_t expected) {}
 
+template <PlatformType T = PlatformType::NOGPU>
 __device__ __forceinline__ void SyncRemoteBlocks(
     std::array<RestrictedPtr<uint32_t>, kMaxNumAllReduceInputPtrs>
         signal_pad_ptrs,
     int64_t rank, int64_t num_ranks, uint32_t signal_value) {
   if (threadIdx.x < num_ranks) {
     auto target_rank = threadIdx.x;
-    PutSignalFlag(signal_pad_ptrs[target_rank] + blockIdx.x * num_ranks + rank,
-                  signal_value);
-    WaitSignalFlag(signal_pad_ptrs[rank] + blockIdx.x * num_ranks + target_rank,
-                   signal_value);
+    PutSignalFlag<T>(
+        signal_pad_ptrs[target_rank] + blockIdx.x * num_ranks + rank,
+        signal_value);
+    WaitSignalFlag<T>(
+        signal_pad_ptrs[rank] + blockIdx.x * num_ranks + target_rank,
+        signal_value);
   }
 }
 
-template <typename T, xla::ReductionKind ReductionKindT>
+template <typename T, xla::ReductionKind ReductionKindT,
+          PlatformType PlatformT = PlatformType::NOGPU>
 __device__ __forceinline__ void OneShotAllReduceKernelImpl(
     const AllReduceKernelParams<T>& args) {
   int64_t offset =
@@ -109,8 +121,8 @@ __device__ __forceinline__ void OneShotAllReduceKernelImpl(
              VecLoad(args.input_buffer + i));
   }
 
-  SyncRemoteBlocks(args.signal_flags_buffers, args.rank, args.num_ranks,
-                   args.signal_value);
+  SyncRemoteBlocks<PlatformT>(args.signal_flags_buffers, args.rank,
+                              args.num_ranks, args.signal_value);
   __syncthreads();
 
   for (int i = offset; i < args.num_elements; i += stride) {
@@ -130,7 +142,8 @@ __device__ __forceinline__ void OneShotAllReduceKernelImpl(
   }
 }
 
-template <typename T, xla::ReductionKind ReductionKindT>
+template <typename T, xla::ReductionKind ReductionKindT,
+          PlatformType PlatformT = PlatformType::NOGPU>
 __device__ __forceinline__ void TwoShotAllReduceKernelImpl(
     const AllReduceKernelParams<T>& args) {
   const int64_t offset = blockIdx.x * args.num_elements_per_block +
@@ -163,8 +176,8 @@ __device__ __forceinline__ void TwoShotAllReduceKernelImpl(
 
   // Shot1: Wait for all participating devices to finish copying data to their
   // shared buffer.
-  SyncRemoteBlocks(args.signal_flags_buffers, args.rank, args.num_ranks,
-                   args.signal_value);
+  SyncRemoteBlocks<PlatformT>(args.signal_flags_buffers, args.rank,
+                              args.num_ranks, args.signal_value);
   __syncthreads();
 
   // Step2: Accumulate data for the responsible indices in the shared buffers.
@@ -193,8 +206,8 @@ __device__ __forceinline__ void TwoShotAllReduceKernelImpl(
   // Shot2: Wait for all participating devices to finish accumulating data in
   // the shared buffer. Note that signal_value + 1 is used to ensure that the
   // synchronization is different from the one used above.
-  SyncRemoteBlocks(args.signal_flags_buffers, args.rank, args.num_ranks,
-                   args.signal_value + 1);
+  SyncRemoteBlocks<PlatformT>(args.signal_flags_buffers, args.rank,
+                              args.num_ranks, args.signal_value + 1);
   __syncthreads();
 
   // Step3: Copy data from the shared buffers to the output buffer.
@@ -218,12 +231,13 @@ __device__ __forceinline__ void TwoShotAllReduceKernelImpl(
 }
 
 template <typename T, xla::ReductionKind ReductionKindT,
-          AllReduceStrategy kAllReduceStrategy>
+          AllReduceStrategy kAllReduceStrategy,
+          PlatformType PlatformT = PlatformType::NOGPU>
 __global__ void AllReduceKernelImpl(AllReduceKernelParams<T> args) {
   if constexpr (kAllReduceStrategy == AllReduceStrategy::kOneShot) {
-    OneShotAllReduceKernelImpl<T, ReductionKindT>(args);
+    OneShotAllReduceKernelImpl<T, ReductionKindT, PlatformT>(args);
   } else if constexpr (kAllReduceStrategy == AllReduceStrategy::kTwoShot) {
-    TwoShotAllReduceKernelImpl<T, ReductionKindT>(args);
+    TwoShotAllReduceKernelImpl<T, ReductionKindT, PlatformT>(args);
   } else {
     assert(false && "Unsupported all-reduce strategy");
   }

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -825,6 +825,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":all_reduce_kernel_rocm",
         ":amdhipblaslt_plugin",
         ":buffer_comparator_kernel_rocm",
         ":hipfft_plugin",
@@ -1253,6 +1254,27 @@ rocm_library(
         "//xla/stream_executor:kernel_spec",
         "//xla/stream_executor/gpu:gpu_kernel_registry",
         "//xla/stream_executor/gpu:gpu_test_kernel_traits",
+    ],
+    alwayslink = 1,
+)
+
+rocm_library(
+    name = "all_reduce_kernel_rocm",
+    srcs = [
+        "all_reduce_kernel_rocm.cc",
+        "//xla/stream_executor/gpu:all_reduce_kernel_lib.cu.h",
+    ],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform_id",
+        "//xla/stream_executor:kernel_spec",
+        "//xla/stream_executor/gpu:all_reduce_kernel",
+        "//xla/stream_executor/gpu:gpu_kernel_registry",
+        "@local_config_rocm//rocm:rocm_headers",
     ],
     alwayslink = 1,
 )

--- a/xla/stream_executor/rocm/all_reduce_kernel_rocm.cc
+++ b/xla/stream_executor/rocm/all_reduce_kernel_rocm.cc
@@ -1,0 +1,62 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <cstdint>
+
+#include <hip/hip_bfloat16.h>
+#include "absl/base/casts.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/stream_executor/rocm/rocm_platform_id.h"
+#include "xla/stream_executor/gpu/all_reduce_kernel.h"
+#include "xla/stream_executor/gpu/all_reduce_kernel_lib.cu.h"
+#include "xla/stream_executor/gpu/gpu_kernel_registry.h"
+#include "xla/stream_executor/kernel_spec.h"
+#include "xla/types.h"
+
+// C++ macros don't like commas in template arguments, so we need to use
+// __VA_ARGS__ to get around this.
+#define SINGLE_ARG(...) __VA_ARGS__
+
+#define REGISTER_ALL_REDUCE_KERNEL_IMPL(SUFFIX, XLA_TYPE, HIP_TYPE,          \
+                                        REDUCTION_KIND, STRATEGY)            \
+  GPU_KERNEL_REGISTRY_REGISTER_KERNEL_STATICALLY(                            \
+      AllReduceKernelRocm##SUFFIX##STRATEGY,                                 \
+      SINGLE_ARG(stream_executor::gpu::AllReduceKernel<                      \
+                 XLA_TYPE, xla::ReductionKind::REDUCTION_KIND,               \
+                 xla::se::gpu::AllReduceStrategy::STRATEGY>),                \
+      stream_executor::rocm::kROCmPlatformId, ([](size_t arity) {            \
+        return stream_executor::KernelLoaderSpec::CreateInProcessSymbolSpec( \
+            absl::bit_cast<void*>(                                           \
+                &stream_executor::gpu::AllReduceKernelImpl<                  \
+                    HIP_TYPE, xla::ReductionKind::REDUCTION_KIND,            \
+                    xla::se::gpu::AllReduceStrategy::STRATEGY>),             \
+            "all_reduce_" #SUFFIX #STRATEGY, arity);                         \
+      }));
+
+// Create instantiations for all all-reduce strategies.
+#define REGISTER_ALL_REDUCE_KERNEL(SUFFIX, XLA_TYPE, HIP_TYPE, REDUCTION_KIND) \
+  REGISTER_ALL_REDUCE_KERNEL_IMPL(SUFFIX, XLA_TYPE, HIP_TYPE, REDUCTION_KIND,  \
+                                  kOneShot)                                    \
+  REGISTER_ALL_REDUCE_KERNEL_IMPL(SUFFIX, XLA_TYPE, HIP_TYPE, REDUCTION_KIND,  \
+                                  kTwoShot)
+
+// Register the kernel for different types using the macro
+REGISTER_ALL_REDUCE_KERNEL(AddBF16, xla::bfloat16, hip_bfloat16, SUM);
+REGISTER_ALL_REDUCE_KERNEL(AddF32, float, float, SUM);
+
+// AllReduce doesn't have a corresponding reduction kind for logical operations.
+// NCCL uses MAX and MIN on uint8_t for logical operations.
+REGISTER_ALL_REDUCE_KERNEL(OrPRED, bool, uint8_t, MAX);


### PR DESCRIPTION
added the missing allreduce kernel registration on ROCm

it fixes all the failed AllReduceTest/AllReduceTest.* in collective_ops_e2e_test. e.g.
`bazel-bin/xla/tests/collective_ops_e2e_test_amdgpu_any --gtest_filter=AllReduceTest/AllReduceTest.AsyncAllReduce_F32_2GPUs/async_one_shot`

@xla-rotation could you review my PR, please?