### PR TITLE
[GPU] Collectives prefer stream id over stream kind

### DIFF
--- a/xla/backends/gpu/collectives/gpu_clique_key.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key.cc
@@ -36,12 +36,13 @@ limitations under the License.
 namespace xla::gpu {
 
 CollectiveStreamId GetCollectiveStreamId(bool is_async,
+                                         CollectiveStreamId stream_id,
                                          AsyncStreamKind stream_kind) {
-  // TODO(ezhulenev): This implementation does not look correct as stream IDs
-  // are not really unique. Figure out if it's the case and fix either the code
-  // or the documentation.
-  int64_t stream_id = static_cast<int64_t>(stream_kind);
-  return CollectiveStreamId(is_async ? stream_id + 1 : 0);
+  if (!is_async) return CollectiveStreamId(0);
+  // TODO: Remove this fallback once AsyncStreamId is used everywhere.
+  if (stream_id.value() == 0)
+    return CollectiveStreamId(static_cast<int64_t>(stream_kind) + 1);
+  return stream_id;
 }
 
 GpuCliqueKey::GpuCliqueKey(

--- a/xla/backends/gpu/collectives/gpu_clique_key.h
+++ b/xla/backends/gpu/collectives/gpu_clique_key.h
@@ -50,7 +50,8 @@ TSL_LIB_GTL_DEFINE_INT_TYPE(CollectiveStreamId, uint64_t);
 // Assigns a unique ID to a stream for asynchronous or synchronous execution.
 // These IDs can be used, for example, to look up the NCCL communicator.
 CollectiveStreamId GetCollectiveStreamId(
-    bool is_async, AsyncStreamKind stream_kind = AsyncStreamKind::kCollective);
+    bool is_async, CollectiveStreamId stream_id = CollectiveStreamId(1),
+    AsyncStreamKind stream_kind = AsyncStreamKind::kCollective);
 
 // Clique key for identifying a particular collectives clique on a GPU backend.
 class GpuCliqueKey : public CliqueKey {

--- a/xla/backends/gpu/collectives/gpu_clique_key_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key_test.cc
@@ -220,4 +220,22 @@ TEST(GpuCliqueIdStringTest, ToString) {
   }
 }
 
+TEST(GpuCliqueKeyTest, GetCollectiveStreamId) {
+  EXPECT_EQ(GetCollectiveStreamId(false, CollectiveStreamId(0),
+                                  AsyncStreamKind::kP2P0),
+            CollectiveStreamId(0));
+  EXPECT_EQ(GetCollectiveStreamId(true, CollectiveStreamId(0),
+                                  AsyncStreamKind::kCollective),
+            CollectiveStreamId(1));
+  EXPECT_EQ(GetCollectiveStreamId(true, CollectiveStreamId(0),
+                                  AsyncStreamKind::kP2P0),
+            CollectiveStreamId(2));
+  EXPECT_EQ(GetCollectiveStreamId(true, CollectiveStreamId(2),
+                                  AsyncStreamKind::kCollective),
+            CollectiveStreamId(2));
+  EXPECT_EQ(GetCollectiveStreamId(true, CollectiveStreamId(1),
+                                  AsyncStreamKind::kP2P0),
+            CollectiveStreamId(1));
+}
+
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -543,7 +543,7 @@ CollectiveDoneThunk::CollectiveDoneThunk(
     AsyncStreamKind async_stream_kind)
     : Thunk(kind, std::move(thunk_info)),
       async_events_(async_events),
-      async_stream_kind_(async_stream_kind) {}
+      stream_kind_(async_stream_kind) {}
 
 absl::Status CollectiveDoneThunk::ExecuteOnStream(const ExecuteParams& params) {
   se::StreamExecutor* executor = params.stream->parent();

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -954,13 +954,15 @@ class CollectiveCmd : public CommandBufferCmd {
       absl::FunctionRef<absl::Status(se::Stream*)> trace);
 
   virtual AsyncStreamKind GetAsyncStreamKind() = 0;
+  virtual CollectiveStreamId GetAsyncStreamId() = 0;
 
   bool IsAsync() const {
     return async_from_stream_id_ != execution_stream_id();
   }
 
   CollectiveStreamId nccl_stream_id() {
-    return xla::gpu::GetCollectiveStreamId(IsAsync(), GetAsyncStreamKind());
+    return xla::gpu::GetCollectiveStreamId(IsAsync(), GetAsyncStreamId(),
+                                           GetAsyncStreamKind());
   }
 
   ExecutionStreamId async_from_stream_id() const {
@@ -997,6 +999,9 @@ class AllReduceCmd : public CollectiveCmd {
   AsyncStreamKind GetAsyncStreamKind() override {
     return AsyncStreamKind::kCollective;
   };
+  CollectiveStreamId GetAsyncStreamId() override {
+    return CollectiveStreamId(1);
+  };
 
  private:
   ReductionKind reduction_kind_;
@@ -1024,6 +1029,9 @@ class ReduceScatterCmd : public CollectiveCmd {
 
   AsyncStreamKind GetAsyncStreamKind() override {
     return AsyncStreamKind::kCollective;
+  };
+  CollectiveStreamId GetAsyncStreamId() override {
+    return CollectiveStreamId(1);
   };
 
  private:
@@ -1053,6 +1061,9 @@ class AllToAllCmd : public CollectiveCmd {
   AsyncStreamKind GetAsyncStreamKind() override {
     return AsyncStreamKind::kCollective;
   };
+  CollectiveStreamId GetAsyncStreamId() override {
+    return CollectiveStreamId(1);
+  };
 
  private:
   bool has_split_dimension_;
@@ -1079,6 +1090,9 @@ class AllGatherCmd : public CollectiveCmd {
 
   AsyncStreamKind GetAsyncStreamKind() override {
     return AsyncStreamKind::kCollective;
+  };
+  CollectiveStreamId GetAsyncStreamId() override {
+    return CollectiveStreamId(1);
   };
 
  private:


### PR DESCRIPTION
This is a followup PR to https://github.com/openxla/xla/pull/26445, as part of the effort to deprecate AsyncStreamKind,[design doc](https://docs.google.com/document/d/1i1IzE-ycaWmWYN_0B-lxDwk2WO4CRs9huxVz0YAGgMU/edit?tab=t.0.). It allows getting stream id by id instead of stream kind. There are too many downstream usages to be packed into a single PR, so we allow stream kind and stream id to co-exist for now. Multiple followup PRs worked in parallel to come for using stream id in thunks, and a final PR will retire AsyncStreamKind.