### PR TITLE
[ROCm] Fix PackedTranspose for adapting to warp size 64

### DIFF
--- a/xla/backends/gpu/codegen/emitters/transpose.cc
+++ b/xla/backends/gpu/codegen/emitters/transpose.cc
@@ -802,7 +802,7 @@ IndexingMap PackedTranspose::GetInputIndexing(MLIRContext* ctx) const {
       KernelFusionInterface::kIndexingMapThreadIdxDims[0], ctx);
   auto block_id =
       getAffineDimExpr(KernelFusionInterface::kIndexingMapBlockIdxDims[0], ctx);
-  auto warp_size = WarpSize(analysis_.device_info());
+  auto warp_size = kNumShmemBanks;
   auto lane_id = thread_id % warp_size;
   auto warp_id = thread_id.floorDiv(warp_size);
   std::vector<IndexingMap::Variable> dim_vars = DimVarsFromGPUGrid(
@@ -863,7 +863,7 @@ IndexingMap PackedTranspose::GetShmemWriteIndexing(
   // Dimensions variables.
   auto thread_id = getAffineDimExpr(
       KernelFusionInterface::kIndexingMapThreadIdxDims[0], ctx);
-  auto warp_size = WarpSize(analysis_.device_info());
+  auto warp_size = kNumShmemBanks;
   auto lane_id = thread_id % warp_size;
   auto warp_id = thread_id.floorDiv(warp_size);
   std::vector<IndexingMap::Variable> dim_vars = DimVarsFromGPUGrid(
@@ -895,7 +895,7 @@ IndexingMap PackedTranspose::GetShmemReadIndexing(
   // Dimensions variables.
   auto thread_id = getAffineDimExpr(
       KernelFusionInterface::kIndexingMapThreadIdxDims[0], ctx);
-  auto warp_size = WarpSize(analysis_.device_info());
+  auto warp_size = kNumShmemBanks;
   auto lane_id = thread_id % warp_size;
   auto warp_id = thread_id.floorDiv(warp_size);
   std::vector<IndexingMap::Variable> dim_vars = DimVarsFromGPUGrid(
@@ -932,7 +932,7 @@ IndexingMap PackedTranspose::GetOutputIndexing(mlir::MLIRContext* ctx) const {
       KernelFusionInterface::kIndexingMapThreadIdxDims[0], ctx);
   auto block_id =
       getAffineDimExpr(KernelFusionInterface::kIndexingMapBlockIdxDims[0], ctx);
-  auto warp_size = WarpSize(analysis_.device_info());
+  auto warp_size = kNumShmemBanks;
   auto lane_id = thread_id % warp_size;
   auto warp_id = thread_id.floorDiv(warp_size);
   std::vector<IndexingMap::Variable> dim_vars = DimVarsFromGPUGrid(


### PR DESCRIPTION
Calculate ranges for dimensions in IndexingMap with kTileSize rather than WarpSize() since tile size is still expected to be vector_size * kNumShmemBanks which we preserve as 32.

Fixed failing test:
[  FAILED  ] Convolve2D_1x2x2x1024_2x2x128x512_Grouped_Valid/0.Types, where TypeParam = Eigen::half