### PR TITLE
Add memcopy async wrapper

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1808,6 +1808,7 @@ cc_library(
         "//xla/service/gpu/transforms:gemm_rewriter",
         "//xla/service/gpu/transforms:gemv_rewriter",
         "//xla/service/gpu/transforms:layout_assignment",
+        "//xla/service/gpu/transforms:memcopy_async_wrapper",
         "//xla/service/gpu/transforms:move_copy_to_users",
         "//xla/service/gpu/transforms:nest_gemm_fusion",
         "//xla/service/gpu/transforms:ragged_all_to_all_canonicalizer",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -239,6 +239,7 @@ limitations under the License.
 #include "xla/service/gpu/transforms/gemm_rewriter.h"
 #include "xla/service/gpu/transforms/gemv_rewriter.h"
 #include "xla/service/gpu/transforms/layout_assignment.h"
+#include "xla/service/gpu/transforms/memcopy_async_wrapper.h"
 #include "xla/service/gpu/transforms/move_copy_to_users.h"
 #include "xla/service/gpu/transforms/nest_gemm_fusion.h"
 #include "xla/service/gpu/transforms/ragged_all_to_all_canonicalizer.h"
@@ -1385,6 +1386,13 @@ absl::Status RunLayoutNormalizationPasses(
       .status();
 }
 
+absl::Status RunMemcopyAsyncPasses(HloModule* hlo_module) {
+  tsl::profiler::TraceMe traceme("RunMemcopyAsyncPasses");
+  HloPassPipeline pipeline("async-wrapper");
+  pipeline.AddPass<MemcopyAsyncWrapper>();
+  return pipeline.Run(hlo_module).status();
+}
+
 absl::Status RunAsyncDotPasses(HloModule* hlo_module) {
   tsl::profiler::TraceMe traceme("RunAsyncDotPasses");
   HloPassPipeline pipeline("async-wrapper");
@@ -1631,7 +1639,7 @@ absl::Status GpuCompiler::OptimizeHloModule(
 
   TF_RETURN_IF_ERROR(
       RunCollectiveScheduleLinearizerPasses(hlo_module, stream_exec));
-
+  TF_RETURN_IF_ERROR(RunMemcopyAsyncPasses(hlo_module));
   TF_RETURN_IF_ERROR(RunAsyncDotPasses(hlo_module));
   {
     HloPassPipeline pipeline("autotune-fusion-emitters");

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -83,14 +83,12 @@ bool IsNopInstruction(const HloInstruction& hlo) {
 
 bool IsAsyncComputeStartOp(const HloInstruction& hlo) {
   return hlo.opcode() == HloOpcode::kAsyncStart &&
-         !hlo_query::IsCollectiveCommunicationOp(hlo.async_wrapped_opcode()) &&
-         hlo.async_execution_thread() != hlo.parent()->execution_thread();
+         !hlo_query::IsCollectiveCommunicationOp(hlo.async_wrapped_opcode());
 }
 
 bool IsAsyncComputeDoneOp(const HloInstruction& hlo) {
   return hlo.opcode() == HloOpcode::kAsyncDone &&
-         !hlo_query::IsCollectiveCommunicationOp(hlo.async_wrapped_opcode()) &&
-         hlo.async_execution_thread() != hlo.parent()->execution_thread();
+         !hlo_query::IsCollectiveCommunicationOp(hlo.async_wrapped_opcode());
 }
 
 // Returns the pipeline stream for a P2P instruction recorded in a frontend

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -3092,6 +3092,47 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "memcopy_async_wrapper",
+    srcs = ["memcopy_async_wrapper.cc"],
+    hdrs = ["memcopy_async_wrapper.h"],
+    deps = [
+        "//xla:side_effect_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/backends/gpu/codegen:copy",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:statusor",
+	"//xla/service/gpu/transforms:async_wrapper",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+xla_cc_test(
+    name = "memcopy_async_wrapper_test",
+    srcs = ["memcopy_async_wrapper_test.cc"],
+    deps = [
+        ":memcopy_async_wrapper",
+        "//xla:side_effect_util",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:filecheck",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+
+cc_library(
     name = "windowed_einsum_handler",
     srcs = ["windowed_einsum_handler.cc"],
     hdrs = ["windowed_einsum_handler.h"],

--- a/xla/service/gpu/transforms/async_wrapper.cc
+++ b/xla/service/gpu/transforms/async_wrapper.cc
@@ -59,8 +59,8 @@ absl::StatusOr<bool> AsyncWrapper::Run(
         // If the predicate matches, then wrap the instructions in async blocks.
         TF_RETURN_IF_ERROR(
             computation
-                ->CreateAsyncInstructions(instruction,
-                                          {ShapeUtil::MakeScalarShape(U32)})
+                ->CreateAsyncInstructions(
+                    instruction, {ShapeUtil::MakeScalarShape(U32)})
                 .status());
         changed = true;
         continue;

--- a/xla/service/gpu/transforms/memcopy_async_wrapper.cc
+++ b/xla/service/gpu/transforms/memcopy_async_wrapper.cc
@@ -1,0 +1,49 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/memcopy_async_wrapper.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/codegen/copy.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/gpu/transforms/async_wrapper.h"
+
+namespace xla::gpu {
+
+namespace {
+bool is_memcopy(HloInstruction* instruction) {
+  if (instruction->opcode() == HloOpcode::kFusion) {
+    HloFusionInstruction* fusion =
+        ::xla::Cast<HloFusionInstruction>(instruction);
+    if (DynamicMemcpyFusion::GetMemcpyDescriptorForFusion(*fusion)) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace
+
+absl::StatusOr<bool> MemcopyAsyncWrapper::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  return AsyncWrapper(is_memcopy).Run(module, execution_threads);
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/memcopy_async_wrapper.h
+++ b/xla/service/gpu/transforms/memcopy_async_wrapper.h
@@ -1,0 +1,41 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_MEMCOPY_ASYNC_WRAPPER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_MEMCOPY_ASYNC_WRAPPER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla::gpu {
+
+// Wrap ops that eventually lower to memcopy into async pairs.
+class MemcopyAsyncWrapper : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "memcopy-async-wrapper"; }
+
+  using HloPassInterface::Run;
+  absl::StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_MEMCOPY_ASYNC_WRAPPER_H_

--- a/xla/service/gpu/transforms/memcopy_async_wrapper_test.cc
+++ b/xla/service/gpu/transforms/memcopy_async_wrapper_test.cc
@@ -1,0 +1,70 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/memcopy_async_wrapper.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/testlib/filecheck.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/side_effect_util.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace xla::gpu {
+namespace {
+
+using MemcopyAsyncWrapperTest = HloHardwareIndependentTestBase;
+
+TEST_F(MemcopyAsyncWrapperTest, SimpleSliceIsWrapped) {
+  const absl::string_view hlo_string = R"(
+    dynamic_slice {
+      p0 = f32[200] parameter(0)
+      cn1 = s32[] constant(-1)
+      ROOT slice = f32[100] dynamic-slice(p0, cn1), dynamic_slice_sizes={100}
+    }
+
+    ENTRY main {
+      p0 = f32[200] parameter(0)
+      ROOT fusion = f32[100] fusion(p0), kind=kLoop, calls=dynamic_slice
+    }
+  )";
+
+  auto debug_options = HloHardwareIndependentTestBase::GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_experimental_stream_annotation(true);
+  auto module = ParseAndReturnVerifiedModule(hlo_string).value();
+  module->mutable_config().set_debug_options(debug_options);
+  MemcopyAsyncWrapper wrapper_pass;
+
+  TF_ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
+  absl::StatusOr<bool> filecheck_result = RunFileCheck(module->ToString({}), R"(
+  // CHECK: ENTRY %main {{.*}}
+  // CHECK: %[[PARAM:.*]] = f32[200]{0} parameter(0)
+  // CHECK: %fusion-start = {{.*}} fusion-start(%[[PARAM]]), kind=kLoop, calls=%dynamic_slice.clone
+  // CHECK: ROOT %fusion-done = f32[100]{0} fusion-done(%fusion-start)
+  )");
+  TF_ASSERT_OK(filecheck_result.status());
+  EXPECT_TRUE(*filecheck_result);
+
+  ASSERT_TRUE(mutated);
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
This PR adds the `MemcopyAsyncWrapper` pass to gpu_compiler.cc.

Recently, there has been work from Nvidia to allow dynamic [update] slices that are contiguous to be dispatched from CUDA memcopies. This has the advantage that these operations do not need any SMs to run, and thus do not take away resources from other compute or H2D kernels that need them. However, to fully utilize these changes, it must be possible to run these operations in parallel with other work on different CUDA streams. Thankfully most of the infrastructure to do this already exists, so we just need to call `AsyncWrapper` on our specific fusion operations. 

From our testing, just this simple change results in a ~1% E2E speedup improvement of a Llama7B from MaxText on a single B200 node. Since this change is very general, we expect similar speedups across the board for models / hardware. However, we also find that the default overlap of these operations isn't perfect, and so further improvements to account for this change in the LHS will likely be the next follow ups. We expect improvements to the default scheduling could give another 1% improvement across the board. 

There has been some instability reported from customers around the memcopy feature, so we have this change broken out into an independent pass so that users can disable it using `--xla_disable_hlo_passes=MemcopyAsyncWrapper` without introducing another flag into XLA if they hit issues.

