### PR TITLE
[XLA:GPU] allow lowering DynamicMemCopy thunk when it depends on loop iteration

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -62,6 +62,7 @@ cc_library(
         ":collective_thunk",
         ":copy_thunk",
         ":custom_call_thunk",
+        ":while_thunk",
         ":dynamic_slice_thunk",
         ":gpublas_lt_matmul_thunk",
         ":thunk",

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -55,6 +55,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/backends/gpu/runtime/dynamic_slice_thunk.h"
 #include "xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h"
+#include "xla/backends/gpu/runtime/while_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/debug_options_flags.h"
 #include "xla/executable_run_options.h"
@@ -456,6 +457,10 @@ absl::Status CommandBufferCmdExecutor::RecordUpdate(
     // allocations didn't change.
     CommandBufferCmd* command = commands_[id].get();
     if (command->requires_initialization() && record_params.is_initialization) {
+      return false;
+    }
+
+    if (command->force_update()) {
       return false;
     }
 
@@ -1180,6 +1185,11 @@ bool CaseCmd::requires_initialization() {
       branches_, [](const auto& seq) { return seq.requires_initialization(); });
 }
 
+bool CaseCmd::force_update() {
+  return absl::c_any_of(branches_,
+                        [](const auto& seq) { return seq.force_update(); });
+}
+
 CommandBufferCmd::BufferUseVector CaseCmd::buffers() const {
   absl::flat_hash_set<BufferUse> buffers;
   buffers.emplace(index_, MemoryAccess::kRead);
@@ -1241,6 +1251,10 @@ absl::StatusOr<const se::CommandBuffer::Command*> WhileCmd::Record(
 bool WhileCmd::requires_initialization() {
   return (cond_commands_.requires_initialization() ||
           body_commands_.requires_initialization());
+}
+
+bool WhileCmd::force_update() {
+  return cond_commands_.force_update() || body_commands_.force_update();
 }
 
 CommandBufferCmd::BufferUseVector WhileCmd::buffers() const {
@@ -2284,25 +2298,13 @@ DynamicSliceCopyFusionCmd::DynamicSliceCopyFusionCmd(
     ExecutionStreamId execution_stream_id,
     const BufferAllocation::Slice& source_buffer,
     const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
-    DynamicMemcpyThunk::Offsets offsets)
+    DynamicMemcpyThunk::Offsets offsets, ResourceUseVector resources)
     : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceCopyFusionCmd,
-                       execution_stream_id, {}),
+                       execution_stream_id, std::move(resources)),
       source_buffer_(source_buffer),
       destination_buffer_(destination_buffer),
       mem_size_(mem_size),
       offsets_(offsets) {}
-
-absl::Status DynamicSliceCopyFusionCmd::Initialize(
-    const Thunk::InitializeParams& params, StateManager& state) {
-  return absl::OkStatus();
-}
-
-absl::Status DynamicSliceCopyFusionCmd::Prepare(
-    const Thunk::PrepareParams& params,
-    Thunk::ResourceRequestsInterface& resource_requests) {
-  TF_RET_CHECK(!offsets_.depends_on_loop);
-  return absl::OkStatus();
-}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
 DynamicSliceCopyFusionCmd::Record(const Thunk::ExecuteParams& execute_params,
@@ -2314,22 +2316,38 @@ DynamicSliceCopyFusionCmd::Record(const Thunk::ExecuteParams& execute_params,
   se::DeviceMemoryBase dst_data =
       execute_params.buffer_allocations->GetDeviceAddress(destination_buffer_);
 
-  int64_t src_offset = offsets_.src_offsets[0];
-  int64_t dst_offset = offsets_.dst_offsets[0];
-
-  auto src_with_offset = src_data.GetByteSlice(src_offset, mem_size_);
-  auto dst_with_offset = dst_data.GetByteSlice(dst_offset, mem_size_);
-  VLOG(3) << "Memcpy of size " << mem_size_ << " from "
-          << src_with_offset.opaque() << " (offset " << src_offset << ") to "
-          << dst_with_offset.opaque() << " (offset " << dst_offset << ")";
-
   return Handle(
       std::move(record_action),
-      [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
+      [&](absl::Span<const se::CommandBuffer::Command* const> dependencies)
+          -> absl::StatusOr<const se::CommandBuffer::Command*> {
+        int64_t src_offset = offsets_.src_offsets[0];
+        int64_t dst_offset = offsets_.dst_offsets[0];
+        auto src_with_offset = src_data.GetByteSlice(src_offset, mem_size_);
+        auto dst_with_offset = dst_data.GetByteSlice(dst_offset, mem_size_);
+        VLOG(3) << "Create DynamicSliceCopyFusionCmd with Memcpy of size "
+                << mem_size_ << " from " << src_with_offset.opaque()
+                << " (offset " << src_offset << ") to "
+                << dst_with_offset.opaque() << " (offset " << dst_offset
+                << "), dependends_on_loop: " << offsets_.depends_on_loop;
         return command_buffer->CreateMemcpyD2D(
             &dst_with_offset, src_with_offset, mem_size_, dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
+        int64_t iteration_index = 0;
+        if (offsets_.depends_on_loop) {
+          TF_ASSIGN_OR_RETURN(iteration_index,
+                              WhileThunk::CurrentLoopIteration());
+        }
+        int64_t src_offset = offsets_.src_offsets[iteration_index];
+        int64_t dst_offset = offsets_.dst_offsets[iteration_index];
+        auto src_with_offset = src_data.GetByteSlice(src_offset, mem_size_);
+        auto dst_with_offset = dst_data.GetByteSlice(dst_offset, mem_size_);
+
+        VLOG(3) << "Update DynamicSliceCopyFusionCmd with Memcpy of size "
+                << mem_size_ << " from " << src_with_offset.opaque()
+                << " (offset " << src_offset << ") to "
+                << dst_with_offset.opaque() << " (offset " << dst_offset
+                << "), iteration_index: " << iteration_index;
         return command_buffer->UpdateMemcpyD2D(command, &dst_with_offset,
                                                src_with_offset, mem_size_);
       });

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -43,6 +43,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/custom_call_thunk.h"
 #include "xla/backends/gpu/runtime/dynamic_slice_thunk.h"
 #include "xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h"
+#include "xla/backends/gpu/runtime/copy_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/call_frame.h"
@@ -282,6 +283,12 @@ class CommandBufferCmd {
   // ensure that all ranks execute NCCL command update.
   virtual bool requires_initialization() { return false; }
 
+  // This is only true for DynamicSliceCopyFusionCmd when offset is dependents
+  // on loop iteration. As the command of slice operation is access the sliced
+  // memory region that varies across loop iterations, so even the original
+  // buffer allocation is the same, it still requires to do update.
+  virtual bool force_update() { return false; }
+
   // Returns all buffers used by the cmd. These will be used to track cmd
   // updates, thus they need to be consistent across calls to the function.
   virtual BufferUseVector buffers() const = 0;
@@ -415,6 +422,11 @@ class CommandBufferCmdExecutor {
     return absl::c_any_of(commands_, [](const auto& cmd) {
       return cmd->requires_initialization();
     });
+  }
+
+  bool force_update() const {
+    return absl::c_any_of(commands_,
+                          [](const auto& cmd) { return cmd->force_update(); });
   }
 
   // Renders the execution graph using default renderer. Returns url of the
@@ -720,6 +732,8 @@ class CaseCmd : public CommandBufferCmd {
 
   bool requires_initialization() override;
 
+  bool force_update() override;
+
   BufferUseVector buffers() const override;
 
  private:
@@ -748,6 +762,8 @@ class WhileCmd : public CommandBufferCmd {
       se::CommandBuffer* command_buffer) override;
 
   bool requires_initialization() override;
+
+  bool force_update() override;
 
   BufferUseVector buffers() const override;
 
@@ -1185,19 +1201,15 @@ class DynamicSliceCopyFusionCmd : public CommandBufferCmd {
                             const BufferAllocation::Slice& source_buffer,
                             const BufferAllocation::Slice& destination_buffer,
                             uint64_t mem_size,
-                            DynamicMemcpyThunk::Offsets offsets);
-
-  absl::Status Initialize(const Thunk::InitializeParams& params,
-                          StateManager& state) override;
-
-  absl::Status Prepare(
-      const Thunk::PrepareParams& params,
-      Thunk::ResourceRequestsInterface& resource_requests) final;
+                            DynamicMemcpyThunk::Offsets offsets,
+                            ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams& execute_params,
       const RecordParams& record_params, RecordAction record_action,
       se::CommandBuffer* command_buffer) override;
+
+  bool force_update() override { return offsets_.depends_on_loop; }
 
   BufferUseVector buffers() const override;
 

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -241,7 +241,7 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   // the last command buffer execution.
   auto updated_allocs = cmd_buffer->UpdateBufferAllocations(commands_, params);
 
-  if (!updated_allocs.empty()) {
+  if (!updated_allocs.empty() || commands_.force_update()) {
     VLOG(3) << "Update command buffer on device #" << executor->device_ordinal()
             << " by recoding command buffer cmd sequence after "
             << cmd_buffer->num_executions << " executions since last update"

--- a/xla/backends/gpu/runtime/copy_thunk.h
+++ b/xla/backends/gpu/runtime/copy_thunk.h
@@ -263,6 +263,13 @@ class DynamicMemcpyThunk : public Thunk {
   DynamicMemcpyThunk(const DynamicMemcpyThunk&) = delete;
   DynamicMemcpyThunk& operator=(const DynamicMemcpyThunk&) = delete;
 
+  Offsets offsets() const { return offsets_; }
+  uint64_t mem_size() const { return mem_size_; }
+  const BufferAllocation::Slice& source() const { return source_buffer_; }
+  const BufferAllocation::Slice& destination() const {
+    return destination_buffer_;
+  }
+
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
 
  private:

--- a/xla/service/gpu/transforms/command_buffer_scheduling.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling.cc
@@ -114,7 +114,8 @@ static bool AsyncStartOrDoneCommandIsSupported(
   if (hlo->async_wrapped_opcode() == HloOpcode::kFusion) {
     // We don't currently support dynamic memcpy fusions in command buffers.
     if (IsDynamicMemcpyFusion(hlo->async_wrapped_instruction())) {
-      return false;
+      return config.enabled_commands.contains(
+          DebugOptions::DYNAMIC_SLICE_COPY_FUSION);
     }
 
     // We currently only support static address computations in command
@@ -265,8 +266,8 @@ static bool IsCommand(const HloInstruction* hlo,
       return config.enabled_commands.contains(DebugOptions::CUDNN);
     }
     if (IsDynamicMemcpyFusion(fusion)) {
-      // Dynamic memcpy fusions do not yet have a command implementation.
-      return false;
+      return config.enabled_commands.contains(
+          DebugOptions::DYNAMIC_SLICE_COPY_FUSION);
     }
     if (IsDynamicSliceFusion(fusion)) {
       auto fusion_analysis =

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -71,6 +71,7 @@ message DebugOptions {
     CUSTOM_CALL = 7;
     CUBLASLT = 8;
     DYNAMIC_SLICE_FUSION = 9;
+    DYNAMIC_SLICE_COPY_FUSION = 10;
   }
 
   enum LibNvJitLinkMode {


### PR DESCRIPTION
This PR enables lowering DynamicMemCopy thunk to command buffer, if it depends on loop iteration. 

This introduce a scenario where even buffer allocations are not changed, the command buffer still needs to be updated,  because the memory pointer that is consumed by cuda-graph nodes are sliced with loop iteration index. 
