### PR TITLE
[XLA:GPU] Add support for pre-padded scales for block scaled dot custom call

### DIFF
--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -330,8 +330,14 @@ message CustomCallBackendConfig {
   }
 }
 
+// Backend config for block scaled dot custom call instruction.
+message BlockScaledDotBackendConfig {
+  // Block size for the block scaled dot op.
+  int32 block_size = 1;
+}
+
 // Generic backend config for XLA:GPU
-// Next-Id: 13
+// Next-Id: 14
 message GpuBackendConfig {
   // Specifies which operation queue the current instruction will run on.
   // A backend may have multiple operation queues to run instructions
@@ -361,6 +367,8 @@ message GpuBackendConfig {
     CudnnfMHABackendConfig cudnn_fmha_backend_config = 9;
 
     CustomCallBackendConfig custom_call_backend_config = 11;
+
+    BlockScaledDotBackendConfig block_scaled_dot_backend_config = 13;
   }
 
   // This attribute instructs the latency-hiding scheduler to

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -295,6 +295,7 @@ cc_library(
         "//xla/hlo/transforms/expanders:op_expander_pass",
         "//xla/service:hlo_creation_utils",
         "//xla/service:shape_inference",
+        "//xla/service/gpu:backend_configs_cc",
         "//xla/service/gpu:cublas_cudnn",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",

--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -62,10 +62,13 @@ namespace xla::gpu {
 //               lhs_batch_dims={0}, lhs_contracting_dims={2},
 //               rhs_batch_dims={0}, rhs_contracting_dims={2}
 //
+//    Note: the scale tensor may be padded; with cuDNN lowering, the underlying
+//    kernel will handle this correctly, with default lowering the extra values
+//    will be ignored. An explicit block size must be passed in the backend
+//    config if the block scaled dimension is padded.
 class BlockScalingRewriter : public OpExpanderPass {
  public:
-  explicit BlockScalingRewriter(bool allow_cudnn)
-      : allow_cudnn_(allow_cudnn) {};
+  explicit BlockScalingRewriter(bool allow_cudnn) : allow_cudnn_(allow_cudnn){};
 
   absl::string_view name() const override { return "block-scaling-rewriter"; }
 


### PR DESCRIPTION
The cuDNN block scaled dot kernel expects the scales tensor to have the contracting dimension padded to the next multiple of 4. To avoid the padding operation overhead, the scales tensor could be pre-padded.

This, however, makes implying the block size from the tensor shapes not possible, so it has to be passed explicitly.
Example: previously, the mxfp8 input (f8e4m3fn[128,192], f8e8m0fnu[128,6]) could now have the shape (f8e4m3fn[128,192], f8e8m0fnu[128,8]), but the scales tensor is pre-padded and the block size is still 32.

If the block size is not present in the backend config, the block scaled dot functions as before (block size is implied).