### PR TITLE
[XLA:CPU] Enable mm-biasadd-add fusion as seen in some models

### DIFF
--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "xla/service/cpu/onednn_contraction_rewriter.h"
 
+#include "tsl/platform/logging.h"  // IWYU pragma: keep
 #include "xla/executable_run_options.h"
 #include "xla/hlo/evaluator/hlo_evaluator.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
@@ -36,7 +37,6 @@ limitations under the License.
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
 #include "xla/tsl/util/onednn_threadpool.h"
-#include "tsl/platform/logging.h"  // IWYU pragma: keep
 
 namespace xla {
 namespace cpu {
@@ -391,6 +391,20 @@ absl::StatusOr<Shape> AdjustAddendShape(const HloInstruction* contraction,
   return new_shape;
 };
 
+// Compute new shape for the binary operand when dot's outer dims
+// are flattened/unflattened with respect to the binary operand dims.
+// Adjusting the operand shape to the dot's shape enables fusion in oneDNN.
+absl::StatusOr<Shape> AdjustBinaryOperandShape(
+    const HloInstruction* operand_instr, const Shape& dot_shape) {
+  if (ShapeUtil::ElementsIn(operand_instr->shape()) !=
+      ShapeUtil::ElementsIn(dot_shape)) {
+    return absl::CancelledError(
+        "Number of elements in operand and dot instruction do not match.");
+  }
+  Shape new_shape = dot_shape;
+  return new_shape;
+};
+
 inline bool IsOperandFusible(HloInstruction* operand, HloInstruction* instr) {
   // Check if the operand's shape is compatible for fusion.
   // An operand is fusable if
@@ -713,6 +727,44 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
         } else if (!ShapeUtil::Equal(*new_shape, addend->shape())) {
           addend = addend->AddInstruction(
               HloInstruction::CreateBitcast(new_shape.value(), addend));
+        }
+      }
+
+      // If addend dtype is different from contraction dtype, add a convert
+      // after the addend.
+      if (addend->shape().element_type() !=
+          contraction->shape().element_type()) {
+        addend = addend->AddInstruction(HloInstruction::CreateConvert(
+            ShapeUtil::ChangeElementType(addend->shape(),
+                                         contraction->shape().element_type()),
+            addend));
+      }
+
+      // For cases where the dot is followed by a reshape, the binary operands
+      // shape can be adjusted, making sure the number of elements match, to
+      // enable the fusion. For example:
+      //      dot = f32[6304,3072] dot(...)
+      //      reshape = f32[32,197,3072] reshape(dot)
+      //      constant = f32[32,197,3072] constant(..)
+      //      add = f32[32,197,3072] add(reshape, constant)
+      // can become
+      //      dot = f32[6304,3072] dot(...)
+      //      constant = f32[32,197,3072] constant(..)
+      //      reshape1 = f32[6304,3072] reshape(constant)
+      //      add = f32[6304,3072] add(dot, reshape1)
+      // and be replaced with the fusion
+      //      fused = f32[6304,3072] custom-call(..)
+      //      bitcast = f32[32,197,3072] bitcast(fused)
+      // clang-format on
+      auto addend_dims = addend->shape().dimensions();
+      auto contraction_dims = contraction->shape().dimensions();
+      if (optional_contraction_bitcast &&
+          addend_dims.size() != contraction_dims.size()) {
+        auto new_addend_shape =
+            AdjustBinaryOperandShape(addend, contraction->shape());
+        if (new_addend_shape.ok()) {
+          addend = addend->AddInstruction(
+              HloInstruction::CreateBitcast(new_addend_shape.value(), addend));
         }
       }
 

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -401,8 +401,7 @@ absl::StatusOr<Shape> AdjustBinaryOperandShape(
     return absl::CancelledError(
         "Number of elements in operand and dot instruction do not match.");
   }
-  Shape new_shape = dot_shape;
-  return new_shape;
+  return dot_shape;
 };
 
 inline bool IsOperandFusible(HloInstruction* operand, HloInstruction* instr) {
@@ -752,10 +751,10 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
       //      constant = f32[32,197,3072] constant(..)
       //      reshape1 = f32[6304,3072] reshape(constant)
       //      add = f32[6304,3072] add(dot, reshape1)
+      //      reshape2 = f32[32,197,3072] reshape(add)
       // and be replaced with the fusion
       //      fused = f32[6304,3072] custom-call(..)
       //      bitcast = f32[32,197,3072] bitcast(fused)
-      // clang-format on
       auto addend_dims = addend->shape().dimensions();
       auto contraction_dims = contraction->shape().dimensions();
       if (optional_contraction_bitcast &&

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -1710,6 +1710,25 @@ TEST_F(MatmulTest, BroadcastedAddAfterFusion) {
   )");
 }
 
+TEST_F(MatmulTest, SimpleTestF32WithBiasAndAddFusionWithReshape) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[6304,768] parameter(0), parameter_replication={false}
+    arg.1 = f32[768,3072] parameter(1), parameter_replication={false}
+    dot.378 = f32[6304,3072] dot(arg.0, arg.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    reshape.11 = f32[32,197,3072] reshape(dot.378)
+    constant.381 = f32[3072] constant(0.3)
+    broadcast.382 = f32[32,197,3072] broadcast(constant.381), dimensions={2}
+    add.0 = f32[32,197,3072] add(reshape.11, broadcast.382)
+    const.1 = f32[32,197,3072] constant(0.65)
+    add.1 = f32[32,197,3072] add(add.0, const.1)
+    ROOT out = f32[6304,3072] reshape(add.1)
+  })";
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_add_str_);
+}
+
 TEST_F(MatmulTest, SimpleTestF32BiasAndSwish) {
   const char* matmul_module_str = R"(
   ENTRY matmul.add.swish.test.f32 {


### PR DESCRIPTION
This PR enables matmul-biasadd-add fusion as seen in some models where dot is followed by a reshape. In such cases, the binary operands shape can be adjusted, making sure the number of elements match, enabling the fusion. This PR also adds a test for the same.