### PR TITLE
[GPU] Make fabric info test compatible with lower CUDA driver versions 

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1235,14 +1235,13 @@ TEST(StreamExecutorGpuClientTest, GetDeviceFabricInfo) {
               auto fabric_info =
                   GetDeviceFabricInfo(executor->device_ordinal());
               if (!fabric_info.ok()) {
-                auto error_message = fabric_info.status().message();
                 // Only allow failures due to insufficient CUDA driver version.
-                EXPECT_TRUE(
-                    (error_message.find("Failed to initialize NVML library.") !=
-                     std::string::npos) ||
-                    (error_message.find(
-                         "NVML library doesn't have required functions.") !=
-                     std::string::npos));
+                EXPECT_THAT(
+                    fabric_info.status().message(),
+                    AnyOf(
+                        HasSubstr("Failed to initialize NVML library."),
+                        HasSubstr(
+                            "NVML library doesn't have required functions.")));
               }
             }
           }


### PR DESCRIPTION
Existing fabric info test assumes sufficient CUDA driver version (550+), which is not always the case. This PR make the test compatible with lower driver version. The enforcement of getting empty fabric info on Hopper is also removed as there's no guarantee for the status quo.