### PR TITLE
[XLA:GPU] Annotate cuBLAS/cuDNN outputs to avoid initcheck failures

### DIFF
--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils.h
@@ -78,5 +78,10 @@ void RangePush(ProfilerDomainHandle domain, StringHandle title,
 // Register the schema of a custom payload type, for use with the more powerful
 // version of RangePush
 uint64_t RegisterSchema(ProfilerDomainHandle domain, const void* schemaAttr);
+
+// Mark a memory region as initialized.
+// This mitigates false positives from the compute sanitizer (initcheck).
+void MarkMemoryInitialized(void const* address, size_t size,
+                           StreamHandle stream);
 }  // namespace tsl::profiler
 #endif  // TENSORFLOW_TSL_PROFILER_LIB_NVTX_UTILS_H_

--- a/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
+++ b/third_party/tsl/tsl/profiler/lib/nvtx_utils_stub.cc
@@ -31,4 +31,6 @@ uint64_t RegisterSchema(ProfilerDomainHandle, const void*) { return 0; }
 StringHandle RegisterString(ProfilerDomainHandle, const std::string&) {
   return {};
 }
+void MarkMemoryInitialized(void const* address, size_t size,
+                           StreamHandle stream) {}
 }  // namespace tsl::profiler

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -440,9 +440,9 @@ def _tf_repositories():
     tf_http_archive(
         name = "nvtx_archive",
         build_file = "//third_party:nvtx/BUILD.bazel",
-        sha256 = "e4438f921fb88a564b0b92791c1c1fdd0f388901213e6a31fdd0dc3803fb9764",
-        strip_prefix = "NVTX-bf31d7859ab3130cbf1ef77c33d18d0ebb8c8d08/c/include",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/NVTX/archive/bf31d7859ab3130cbf1ef77c33d18d0ebb8c8d08.tar.gz"),
+        sha256 = "5a581c3234c5a6b2fd94363e3fdd5a4f5d2a3d9c53c4b9442b0784e6cdfe722c",
+        strip_prefix = "NVTX-2942f167cc30c5e3a44a2aecd5b0d9c07ff61a07/c/include",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/NVTX/archive/2942f167cc30c5e3a44a2aecd5b0d9c07ff61a07.tar.gz"),
     )
 
     tf_http_archive(

--- a/xla/backends/gpu/codegen/cudnn.cc
+++ b/xla/backends/gpu/codegen/cudnn.cc
@@ -45,7 +45,8 @@ absl::StatusOr<FusionEmissionResult> CuDnnFusion::Emit(
   result.thunks.emplace_back(std::make_unique<CuDnnThunk>(
       GetComputationFingerprint(fusion.fused_instructions_computation(), {}),
       Thunk::ThunkInfo::WithProfileAnnotation(&fusion),
-      kernel_arguments.GetArgumentBufferSlices()));
+      kernel_arguments.GetArgumentBufferSlices(),
+      kernel_arguments.GetArgumentOutputFlags()));
   return result;
 }
 

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -695,6 +695,7 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/profiler/lib:nvtx_utils",
     ],
 )
 
@@ -1639,6 +1640,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
+        "@tsl//tsl/profiler/lib:nvtx_utils",
     ],
 )
 

--- a/xla/backends/gpu/runtime/cudnn_thunk.h
+++ b/xla/backends/gpu/runtime/cudnn_thunk.h
@@ -39,6 +39,7 @@ class CuDnnThunk : public Thunk {
  public:
   CuDnnThunk(std::string fingerprint, ThunkInfo,
              std::vector<BufferAllocation::Slice> args,
+             std::vector<bool> output_args,
              std::optional<int64_t> sdpa_dropout_seed = std::nullopt);
   CuDnnThunk(const CuDnnThunk&) = delete;
   CuDnnThunk& operator=(const CuDnnThunk&) = delete;
@@ -63,6 +64,7 @@ class CuDnnThunk : public Thunk {
   std::string fingerprint_;
   std::shared_ptr<se::dnn::LazyDnnGraph> graph_;
   std::vector<BufferAllocation::Slice> args_;
+  std::vector<bool> output_args_;
   // Sdpa dropout seed
   std::optional<int64_t> sdpa_dropout_seed_;
 };

--- a/xla/backends/gpu/runtime/cudnn_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cudnn_thunk_test.cc
@@ -40,6 +40,8 @@ TEST(CuDnnThunkTest, TestSerializationDeserialization) {
         fingerprint: "fingerprint"
         args { offset: 123 size: 456 }
         args { offset: 789 size: 1011 }
+        output_args: false
+        output_args: true
         sdpa_dropout_seed: 123456789
       )pb",
       &cudnn_thunk_proto));

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -110,6 +110,7 @@ message PartitionIdThunkProto {
 message CudnnThunkProto {
   string fingerprint = 1;
   repeated xla.buffer_assignment.BufferAllocationSliceProto args = 2;
+  repeated bool output_args = 4;
   optional int64 sdpa_dropout_seed = 3;
 }
 

--- a/xla/codegen/emitters/kernel_arguments.h
+++ b/xla/codegen/emitters/kernel_arguments.h
@@ -95,6 +95,15 @@ class KernelArguments {
     return arg_slices;
   }
 
+  std::vector<bool> GetArgumentOutputFlags() const {
+    std::vector<bool> output_flags;
+    output_flags.reserve(args_.size());
+    for (const KernelArgument& arg : args_) {
+      output_flags.push_back(arg.written());
+    }
+    return output_flags;
+  }
+
  private:
   explicit KernelArguments(std::vector<KernelArgument> args,
                            const BufferAlignment& buffer_alignment,

--- a/xla/codegen/emitters/kernel_arguments_test.cc
+++ b/xla/codegen/emitters/kernel_arguments_test.cc
@@ -90,6 +90,8 @@ TEST_F(KernelArgumentsTest, GetArgumentBufferSlices) {
                   // The output is last in KernelArguments.
                   BufferAllocation::Slice(&assignment->Allocations()[0],
                                           /*offset=*/0, kExpectedBufferSize)));
+  EXPECT_THAT(kernel_arguments.GetArgumentOutputFlags(),
+              ElementsAre(false, false, true));
 }
 
 }  // namespace

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -985,7 +985,8 @@ absl::Status IrEmitterUnnested::EmitCuDnnThunk(
   }
   AddThunkToThunkSequence(std::make_unique<CuDnnThunk>(
       fingerprint, Thunk::ThunkInfo::WithProfileAnnotation(instr),
-      kernel_arguments.GetArgumentBufferSlices(), dropout_seed));
+      kernel_arguments.GetArgumentBufferSlices(),
+      kernel_arguments.GetArgumentOutputFlags(), dropout_seed));
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
Upgrades NVTX to v3.2.1 and marks the outputs of cuBLAS/cuDNN as initialized (as compute-sanitizer may emit false positives for kernels using TMA).