### PR TITLE
[XLA]Clamp num_workers to avoid partition overflow

### DIFF
--- a/xla/backends/cpu/runtime/parallel_loop_runner.cc
+++ b/xla/backends/cpu/runtime/parallel_loop_runner.cc
@@ -86,15 +86,10 @@ ABSL_ATTRIBUTE_ALWAYS_INLINE void ParallelLoopRunner::ScheduleAll(
     size_t num_tasks, ParallelTask&& parallel_task) {
   DCHECK_GT(num_tasks, 1) << "Expected at least two task";
 
-  // Use at most `num_threads()` workers as we can't run more parallel workers
-  // than the number of threads in the thread pool.
-  size_t num_workers = std::min(std::min(num_tasks, num_threads()),
-                                size_t{std::numeric_limits<uint16_t>::max()});
-
   auto parallelize =
-      [this, num_workers, num_tasks,
+      [this, num_tasks,
        parallel_task = std::forward<ParallelTask>(parallel_task)](tsl::Chain) {
-        return Worker::Parallelize(device_.load()->getPool(), num_workers,
+        return Worker::Parallelize(device_.load()->getPool(), num_threads(),
                                    num_tasks, std::move(parallel_task));
       };
 

--- a/xla/backends/cpu/runtime/work_queue.h
+++ b/xla/backends/cpu/runtime/work_queue.h
@@ -352,6 +352,9 @@ ABSL_ATTRIBUTE_ALWAYS_INLINE tsl::AsyncValueRef<tsl::Chain> Worker::Parallelize(
   if (ABSL_PREDICT_FALSE(num_workers > std::numeric_limits<uint16_t>::max())) {
     num_workers = std::numeric_limits<uint16_t>::max();
   }
+  // Ensure we don't launch more workers than tasks.
+  // Extra workers would be idle or cause out-of-bounds partition access.
+  num_workers = std::min(num_tasks, num_workers);
 
   tsl::CountDownAsyncValueRef<tsl::Chain> count_down(num_tasks);
   auto execute_event = count_down.AsRef();

--- a/xla/backends/cpu/runtime/work_queue_test.cc
+++ b/xla/backends/cpu/runtime/work_queue_test.cc
@@ -211,6 +211,45 @@ TEST(WorkQueueTest, WorkerParallelizeDeadlockProof) {
   EXPECT_EQ(data, expected);
 }
 
+TEST(WorkQueueTest, WorkerParallelizeVariousWorkerTaskRatios) {
+  tsl::thread::ThreadPool threads(tsl::Env::Default(), "test", 16);
+
+  struct TestCase {
+    size_t num_tasks;
+    size_t num_workers;
+  };
+
+  std::vector<TestCase> test_cases = {
+      {0, 1},    // Edge: no tasks
+      {1, 1},    // Edge: single task, single worker
+      {1, 8},    // Edge: single task, many workers
+      {8, 1},    // Serial execution
+      {8, 4},    // Fewer workers than tasks
+      {8, 8},    // Equal
+      {8, 16},   // More workers than tasks
+      {1024, 8}, // Many tasks, fewer workers
+      {1024, 64} // Many tasks, many workers
+  };
+
+  for (const auto& test : test_cases) {
+    std::vector<size_t> data(test.num_tasks, 0);
+
+    auto event = Worker::Parallelize(threads.AsEigenThreadPool(),
+                                     test.num_workers,
+                                     test.num_tasks,
+                                     [&](size_t task_index) {
+                                       ++data[task_index];
+                                     });
+
+    tsl::BlockUntilReady(event);
+
+    // Verify that all tasks were executed once (if any exist)
+    std::vector<size_t> expected(test.num_tasks, 1);
+    EXPECT_EQ(data, expected) << "Failed for num_tasks=" << test.num_tasks
+                              << ", num_workers=" << test.num_workers;
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Performance benchmarks.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
When invoking Worker::Parallelize in parallel_for(), the number of workers was previously set to thread_pool_->NumThreads(), which could exceed the number of tasks (n). This mismatch could lead to out-of-bounds access when workers attempt to access partitions that don't exist.

This ensures that:
- The number of worker threads does not exceed the number of tasks
- Each worker maps safely to a valid partition index
- Partition and worker ranges stay aligned, preventing undefined behavior

Change-Id: I5c3ab319f73009452d27b4db43f7905c5e136c2b