### PR TITLE
Dump optimized HLO when deserializing

### DIFF
--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -3854,14 +3854,14 @@ PjRtStreamExecutorClient::LoadSerializedExecutable(
                       DeserializeToLocalExecutable(serialized, options));
   return LoadInternal(/*unoptimized_hlo_module_proto=*/std::nullopt,
                       std::move(local_executables_and_options.first),
-                      local_executables_and_options.second);
+                      local_executables_and_options.second, /*dump=*/true);
 }
 
 absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>>
 PjRtStreamExecutorClient::LoadInternal(
     std::optional<HloModuleProto> unoptimized_hlo_module_proto,
     std::vector<std::unique_ptr<LocalExecutable>> local_executables,
-    CompileOptions compile_options) {
+    CompileOptions compile_options, bool dump) {
   auto input_options = compile_options;
 
   TF_RETURN_IF_ERROR(compile_options.ApplyAllOptionOverrides());
@@ -3879,6 +3879,24 @@ PjRtStreamExecutorClient::LoadInternal(
   const bool xla_dump_hlo_unoptimized_snapshots =
       ex_options.has_debug_options() &&
       ex_options.debug_options().xla_dump_hlo_unoptimized_snapshots();
+  if (dump) {
+    for (std::unique_ptr<LocalExecutable>& local_executable :
+         local_executables) {
+      VLOG(1) << "Dumping deserialized executable";
+      // Override the debug_options() embedded in the module with those
+      // explicitly passed in when deserializing. This allows options such as
+      // --xla_dump_to to be changed. Does not quite match the naming convention
+      // of the dump during compilation, which includes a backend-specific
+      // prefix.
+      if (local_executable->executable()->has_module()) {
+        DumpHloModuleIfEnabled(local_executable->executable()->module(),
+                               kAfterOptimizationsDumpName,
+                               ex_options.has_debug_options()
+                                   ? &ex_options.debug_options()
+                                   : nullptr);
+      }
+    }
+  }
 
   auto executable = std::make_unique<PjRtStreamExecutorLoadedExecutable>(
       std::move(local_executables),
@@ -3911,7 +3929,8 @@ PjRtStreamExecutorClient::Load(std::unique_ptr<PjRtExecutable> executable,
   TF_ASSIGN_OR_RETURN(auto local_executables, se_executable->ConsumeExecutable(
                                                   client(), compile_options));
   return LoadInternal(se_executable->unoptimized_hlo_module_proto(),
-                      std::move(local_executables), compile_options);
+                      std::move(local_executables), compile_options,
+                      /*dump=*/false);
 }
 
 bool PjRtStreamExecutorClient::IsDmaMapped(const void* data_start,

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -507,7 +507,7 @@ class PjRtStreamExecutorClient : public CommonPjRtClient {
   absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> LoadInternal(
       std::optional<HloModuleProto> unoptimized_hlo_module_proto,
       std::vector<std::unique_ptr<LocalExecutable>> local_executables,
-      CompileOptions compile_options);
+      CompileOptions compile_options, bool dump);
 
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> BufferFromHostBufferInternal(
       const void* data, PrimitiveType type, absl::Span<int64_t const> dims,

--- a/xla/pjrt/pjrt_stream_executor_client_test.cc
+++ b/xla/pjrt/pjrt_stream_executor_client_test.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
+#include "tsl/platform/path.h"
 #include "xla/client/client_library.h"
 #include "xla/client/local_client.h"
 #include "xla/hlo/builder/xla_builder.h"
@@ -83,8 +84,8 @@ absl::StatusOr<std::unique_ptr<PjRtStreamExecutorClient>> GetClient() {
 
 absl::StatusOr<std::unique_ptr<PjRtLoadedExecutable>> ToyExecutable(
     PjRtStreamExecutorClient& client, Shape shape,
-    absl::AnyInvocable<void(XlaBuilder&)> set_up_aliases) {
-  CompileOptions compile_options;
+    absl::AnyInvocable<void(XlaBuilder&)> set_up_aliases,
+    CompileOptions compile_options = {}) {
   XlaBuilder builder("Add");
   auto a = Parameter(&builder, 0, shape, "a");
   auto b = Parameter(&builder, 1, shape, "b");
@@ -208,6 +209,59 @@ TEST(PjRtStreamExecutorClientTest, ExecuteWithInputError) {
                 absl_testing::StatusIs(absl::StatusCode::kInternal,
                                        HasSubstr("test error")));
   }
+}
+
+TEST(PjRtStreamExecutorClientTest, DeserializeAndDump) {
+  tsl::Env* env = tsl::Env::Default();
+  EXPECT_TRUE(env);
+  Shape shape = xla::ShapeUtil::MakeScalarShape(F32);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtStreamExecutorClient> client,
+                          GetClient());
+  std::string compile_dump_dir;
+  EXPECT_TRUE(env->LocalTempFilename(&compile_dump_dir));
+  CompileOptions compile_options;
+  compile_options.executable_build_options.mutable_debug_options()
+      ->set_xla_dump_to(compile_dump_dir);
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<PjRtLoadedExecutable> executable,
+      ToyExecutable(
+          *client, shape, [](XlaBuilder& builder) {}, compile_options));
+  std::string compile_dump_name, compile_dump_contents;
+  {
+    std::vector<std::string> matches;
+    TF_ASSERT_OK(env->GetMatchingPaths(
+        tsl::io::JoinPath(compile_dump_dir, "*after_optimizations.txt"),
+        &matches));
+    EXPECT_THAT(matches, testing::SizeIs(1));
+    compile_dump_name = std::move(matches.front());
+    TF_ASSERT_OK(
+        tsl::ReadFileToString(env, compile_dump_name, &compile_dump_contents));
+  }
+  TF_ASSERT_OK_AND_ASSIGN(std::string serialized,
+                          client->SerializeExecutable(*executable));
+  std::string deserialize_dump_dir;
+  EXPECT_TRUE(env->LocalTempFilename(&deserialize_dump_dir));
+  EXPECT_NE(compile_dump_dir, deserialize_dump_dir);
+  CompileOptions deserialize_options;
+  deserialize_options.executable_build_options.mutable_debug_options()
+      ->set_xla_dump_to(deserialize_dump_dir);
+  LoadOptions load_options;
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<PjRtLoadedExecutable> reloaded_executable,
+      client->LoadSerializedExecutable(serialized, deserialize_options,
+                                       load_options));
+  std::string deserialize_dump_name, deserialize_dump_contents;
+  {
+    std::vector<std::string> matches;
+    TF_ASSERT_OK(env->GetMatchingPaths(
+        tsl::io::JoinPath(deserialize_dump_dir, "*after_optimizations.txt"),
+        &matches));
+    EXPECT_THAT(matches, testing::SizeIs(1));
+    deserialize_dump_name = std::move(matches.front());
+    TF_ASSERT_OK(tsl::ReadFileToString(env, deserialize_dump_name,
+                                       &deserialize_dump_contents));
+  }
+  EXPECT_EQ(compile_dump_contents, deserialize_dump_contents);
 }
 
 }  // namespace

--- a/xla/service/dump.cc
+++ b/xla/service/dump.cc
@@ -124,12 +124,14 @@ absl::Status CreateDirIfNeeded(const std::string& dir, tsl::Env* env) {
 
 std::string RenderGraph(absl::string_view label, const HloModule& module,
                         RenderedGraphFormat format,
-                        bool show_fusion_subcomputations) {
+                        bool show_fusion_subcomputations,
+                        const DebugOptions* dump_options) {
   HloRenderOptions hlo_render_options;
   hlo_render_options.show_fusion_subcomputations = show_fusion_subcomputations;
-  absl::StatusOr<std::string> rendered_graph =
-      RenderGraph(*module.entry_computation(), label,
-                  module.config().debug_options(), format, hlo_render_options);
+  const DebugOptions& opts =
+      dump_options ? *dump_options : module.config().debug_options();
+  absl::StatusOr<std::string> rendered_graph = RenderGraph(
+      *module.entry_computation(), label, opts, format, hlo_render_options);
   if (rendered_graph.ok()) {
     return std::move(rendered_graph).value();
   }
@@ -465,7 +467,8 @@ static bool IsTrivial(const HloComputation& computation) {
 // Returns full file paths of all dumps of the module.
 static std::vector<std::string> DumpHloModuleImpl(
     const HloModule& module, const BufferAssignment* buffer_assn,
-    string_view prefix, string_view suffix, const CanonicalDebugOptions& opts) {
+    string_view prefix, string_view suffix, const CanonicalDebugOptions& opts,
+    const DebugOptions& debug_options) {
   tsl::profiler::ScopedAnnotation annotation([&] {
     return absl::StrFormat("XlaDumpHloModule:#module=%s,program_id=%d#",
                            module.name(), module.unique_id());
@@ -507,17 +510,22 @@ static std::vector<std::string> DumpHloModuleImpl(
   if (opts.dump_as_dot) {
     file_paths.push_back(DumpToFileInDirImpl(
         StrFormat("%s.dot", filename),
-        RenderGraph(filename, module, RenderedGraphFormat::kDot), opts));
+        RenderGraph(filename, module, RenderedGraphFormat::kDot,
+                    /*show_fusion_subcomputations=*/true, &debug_options),
+        opts));
   }
 
   if (opts.dump_as_html) {
     file_paths.push_back(DumpToFileInDirImpl(
         StrFormat("%s.html", filename),
-        RenderGraph(filename, module, RenderedGraphFormat::kHtml), opts));
+        RenderGraph(filename, module, RenderedGraphFormat::kHtml,
+                    /*show_fusion_subcomputations=*/true, &debug_options),
+        opts));
     if (absl::StrContains(filename, kAfterOptimizationsDumpName)) {
       file_paths.push_back(DumpToFileInDirImpl(
           StrFormat("%s.top_level.html", filename),
-          RenderGraph(filename, module, RenderedGraphFormat::kHtml, false),
+          RenderGraph(filename, module, RenderedGraphFormat::kHtml,
+                      /*show_fusion_subcomputations=*/false, &debug_options),
           opts));
     }
   }
@@ -554,7 +562,9 @@ static std::vector<std::string> DumpHloModuleImpl(
   // Special case for rendering graphs as URLs.  We'll dump them to a file
   // because why not, but we always log them to stdout as well.
   if (opts.dump_as_url) {
-    std::string url = RenderGraph(filename, module, RenderedGraphFormat::kUrl);
+    std::string url =
+        RenderGraph(filename, module, RenderedGraphFormat::kUrl,
+                    /*show_fusion_subcomputations=*/true, &debug_options);
     std::cout << filename << " --> " << url << std::endl;
     if (!opts.dumping_to_stdout()) {
       file_paths.push_back(
@@ -601,13 +611,18 @@ static void DumpHloModuleMetadata(
 
 std::vector<std::string> DumpHloModuleIfEnabledImpl(
     const HloModule& module, const BufferAssignment* buffer_assn,
-    string_view name) {
-  CanonicalDebugOptions opts(module.config().debug_options());
+    const DebugOptions* maybe_dump_options, string_view name) {
+  const DebugOptions& dump_options = maybe_dump_options
+                                         ? *maybe_dump_options
+                                         : module.config().debug_options();
+  CanonicalDebugOptions opts(dump_options);
   if (opts.should_dump_module(module.name())) {
     std::vector<std::string> filepaths = DumpHloModuleImpl(
-        module, /*buffer_assn=*/buffer_assn, TimestampFor(module), name, opts);
+        module, /*buffer_assn=*/buffer_assn,
+        TimestampFor(module, &dump_options), name, opts, dump_options);
     std::optional<std::string> maybe_debug_options_filepath =
-        DumpNonDefaultDebugOptions(module, kNonDefaultDebugOptionsDumpSuffix);
+        DumpNonDefaultDebugOptions(module, kNonDefaultDebugOptionsDumpSuffix,
+                                   maybe_dump_options);
     if (maybe_debug_options_filepath.has_value()) {
       filepaths.push_back(*maybe_debug_options_filepath);
     }
@@ -620,8 +635,11 @@ std::vector<std::string> DumpHloModuleIfEnabledImpl(
 
 // Get a timestamp which we can use as a filename prefix specific to this
 // module.
-std::string TimestampFor(const HloModule& module) {
-  if (!module.config().debug_options().xla_dump_include_timestamp()) {
+std::string TimestampFor(const HloModule& module,
+                         const DebugOptions* dump_options) {
+  const DebugOptions& opts =
+      dump_options ? *dump_options : module.config().debug_options();
+  if (!opts.xla_dump_include_timestamp()) {
     return "";
   }
   absl::MutexLock lock(&mu);
@@ -901,23 +919,30 @@ std::string GetNonDefaultDebugOptions(const DebugOptions& debug_options) {
 }
 
 std::optional<std::string> DumpNonDefaultDebugOptions(
-    const HloModule& module, absl::string_view suffix) {
+    const HloModule& module, absl::string_view suffix,
+    const DebugOptions* dump_options) {
+  // Substance of the which-options-have-non-default-values logic always based
+  // on the options embedded in the HloModule
   const DebugOptions& debug_options = module.config().debug_options();
   std::string filename = FilenameFor(module, "", suffix);
   std::string nonDefaultDebugOptions = GetNonDefaultDebugOptions(debug_options);
-  return DumpToFileInDirImpl(filename, nonDefaultDebugOptions,
-                             CanonicalDebugOptions(debug_options));
+  // Options steering where the dump is actually written to can be overriden
+  CanonicalDebugOptions opts(dump_options ? *dump_options : debug_options);
+  return DumpToFileInDirImpl(filename, nonDefaultDebugOptions, opts);
 }
 
-std::vector<std::string> DumpHloModuleIfEnabled(const HloModule& module,
-                                                string_view name) {
-  return DumpHloModuleIfEnabledImpl(module, /*buffer_assn=*/nullptr, name);
+std::vector<std::string> DumpHloModuleIfEnabled(
+    const HloModule& module, string_view name,
+    const DebugOptions* dump_options) {
+  return DumpHloModuleIfEnabledImpl(module, /*buffer_assn=*/nullptr,
+                                    dump_options, name);
 }
 
 std::vector<std::string> DumpHloModuleIfEnabled(
     const HloModule& module, const BufferAssignment& buffer_assn,
     string_view name) {
-  return DumpHloModuleIfEnabledImpl(module, &buffer_assn, name);
+  return DumpHloModuleIfEnabledImpl(module, &buffer_assn,
+                                    /*dump_options=*/nullptr, name);
 }
 
 std::vector<std::string> DumpHloModuleProtoIfEnabled(
@@ -931,7 +956,8 @@ std::vector<std::string> DumpHloModuleProtoIfEnabled(
   CanonicalDebugOptions opts(module->config().debug_options());
   if (opts.should_dump_module(module->name())) {
     return DumpHloModuleImpl(*module, /*buffer_assn=*/nullptr,
-                             TimestampFor(*module), name, opts);
+                             TimestampFor(*module), name, opts,
+                             module->config().debug_options());
   }
   return {};
 }
@@ -996,7 +1022,8 @@ std::vector<std::string> DumpHloModuleBetweenPassesIfEnabled(
       StrFormat("%04d.%s.after_%s.before_%s", step_number, pipeline_name,
                 after_pass_name, before_pass_name);
   return DumpHloModuleImpl(module, /*buffer_assn=*/nullptr, timestamp,
-                           filename_suffix, opts);
+                           filename_suffix, opts,
+                           module.config().debug_options());
 }
 
 void DumpHloModuleDuringPassIfEnabled(string_view pass_name,
@@ -1014,7 +1041,7 @@ void DumpHloModuleDuringPassIfEnabled(string_view pass_name,
   std::string filename_suffix =
       StrFormat("%04d.%s.%s", step_number, pass_name, step_name);
   DumpHloModuleImpl(module, /*buffer_assn=*/nullptr, timestamp, filename_suffix,
-                    opts);
+                    opts, module.config().debug_options());
 }
 
 void DumpHloSnapshotIfEnabled(const HloModule& module,

--- a/xla/service/dump.h
+++ b/xla/service/dump.h
@@ -52,7 +52,8 @@ absl::Status CreateDirIfNeeded(const std::string& dir, tsl::Env* env);
 
 // Get a timestamp which we can use as a filename prefix specific to this
 // module.
-std::string TimestampFor(const HloModule& module);
+std::string TimestampFor(const HloModule& module,
+                         const DebugOptions* debug_options_override = nullptr);
 
 // Create the filename we will use to dump in DumpToFileInDir.
 std::string FilenameFor(int unique_id, absl::string_view module_name,
@@ -107,7 +108,8 @@ void DumpProtobufToFile(const tsl::protobuf::Message& proto,
 // Render graph in a given format.
 std::string RenderGraph(absl::string_view label, const HloModule& module,
                         RenderedGraphFormat format,
-                        bool show_fusion_subcomputations = true);
+                        bool show_fusion_subcomputations = true,
+                        const DebugOptions* dump_options = nullptr);
 
 // Similar to above, but the filename depends on module's information and the
 // given name. Also allows for the optional serialization function.
@@ -122,9 +124,11 @@ void DumpPerModuleProtobufToFile(const HloModule& module,
 // Dumps the given HLO module if dumping is enabled for the module. Exactly
 // where and in what formats it's dumped is determined by the module's config.
 // Returns the full file paths of all dumps of the module, or an empty vector if
-// nothing was dumped.
-std::vector<std::string> DumpHloModuleIfEnabled(const HloModule& module,
-                                                absl::string_view name);
+// nothing was dumped. If not null, `dump_options` are used to determine the
+// dump directory, file formats, and so on.
+std::vector<std::string> DumpHloModuleIfEnabled(
+    const HloModule& module, absl::string_view name,
+    const DebugOptions* dump_options = nullptr);
 std::vector<std::string> DumpHloModuleIfEnabled(
     const HloModule& module, const BufferAssignment& buffer_assn,
     absl::string_view name);
@@ -205,8 +209,9 @@ void DumpHloConfigIfEnabled(const HloModule& module);
 // Dumps the non-default debug options to a file in the xla_dump_to directory
 // specified by the module's DebugOptions. Returns the full file path of the
 // dump. If unable to dump, returns std::nullopt.
-std::optional<std::string> DumpNonDefaultDebugOptions(const HloModule& module,
-                                                      absl::string_view suffix);
+std::optional<std::string> DumpNonDefaultDebugOptions(
+    const HloModule& module, absl::string_view suffix,
+    const DebugOptions* dump_options = nullptr);
 
 // Returns the non-default debug options as a string. The default debug options
 // are received from DefaultDebugOptionsIgnoringFlags().


### PR DESCRIPTION
This makes HLO dumps available when using the JAX compilation cache.