### PR TITLE
Set KV store to null with mocked GPU processes

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1702,9 +1702,10 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
 
   std::shared_ptr<KeyValueStoreInterface> kv_store = options.kv_store;
   if (options.enable_mock_nccl) {
-    kv_store = std::make_shared<InMemoryKeyValueStore>();
+    kv_store = {};
   }
-  TF_RET_CHECK(options.num_nodes == 1 || kv_store != nullptr);
+  TF_RET_CHECK(options.enable_mock_nccl || options.num_nodes == 1 ||
+               kv_store != nullptr);
   TF_ASSIGN_OR_RETURN(
       DeviceTopologyPair device_topology_pair,
       BuildDistributedDevices(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1488,6 +1488,11 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyExecuteTest) {
   options.executable_build_options.set_num_partitions(8)
       .set_use_spmd_partitioning(true)
       .set_allow_spmd_sharding_propagation_to_output({true});
+
+  // Mock NCCL does not support sharded autotuning.
+  options.executable_build_options.mutable_debug_options()
+      ->set_xla_gpu_shard_autotuning(false);
+
   TF_ASSERT_OK_AND_ASSIGN(auto executable,
                           client->CompileAndLoad(*module, options));
 
@@ -1512,6 +1517,37 @@ TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyExecuteTest) {
   // Test that running the program does not crash/hang.
   TF_ASSERT_OK(
       executable->Execute(absl::MakeSpan(input_ptrs), ExecuteOptions()));
+}
+
+TEST(StreamExecutorGpuClientTest, MockNcclClientWithAutotuningFails) {
+  GpuClientOptions client_options = DefaultOptions();
+  client_options.enable_mock_nccl = true;
+  client_options.num_nodes = 4;
+  client_options.mock_gpu_topology = "2x2x2";
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(client_options));
+
+  auto devices_per_host = client->addressable_device_count();
+  EXPECT_EQ(devices_per_host, 2) << "This test requires 2 local GPUs.";
+
+  mlir::MLIRContext context;
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, xla::ParseMlirModuleString(kMlirDistributedSum, context));
+
+  xla::CompileOptions options;
+  options.executable_build_options.set_num_partitions(8)
+      .set_use_spmd_partitioning(true)
+      .set_allow_spmd_sharding_propagation_to_output({true});
+  options.executable_build_options.mutable_debug_options()
+      ->set_xla_gpu_shard_autotuning(true);
+
+  auto compiled = client->CompileAndLoad(*module, options);
+
+  EXPECT_FALSE(compiled.ok());
+  EXPECT_THAT(
+      compiled.status().message(),
+      HasSubstr(
+          "Sharded autotuning requested but key-value store is missing."));
 }
 
 TEST(StreamExecutorGpuClientTest, MockNcclClientWithGpuTopologyMismatchTest) {

--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
@@ -1421,10 +1421,13 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
   AutotuneCacheKeySet keys_of_this_rank;
 
   const bool shard_autotuning = debug_options.xla_gpu_shard_autotuning() &&
-                                key_value_store_.key_value_store &&
                                 key_value_store_.process_count > 1 &&
                                 autotuner.IsAutotuningEnabled();
   if (shard_autotuning) {
+    if (key_value_store_.key_value_store == nullptr) {
+      return absl::FailedPreconditionError(
+          "Sharded autotuning requested but key-value store is missing.");
+    }
     fusions.keys_and_instructions = fusion_collector.Shard(
         fusions.keys_and_instructions, key_value_store_.process_index,
         key_value_store_.process_count);

--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
@@ -1421,13 +1421,10 @@ absl::StatusOr<bool> GemmFusionAutotuner::Run(
   AutotuneCacheKeySet keys_of_this_rank;
 
   const bool shard_autotuning = debug_options.xla_gpu_shard_autotuning() &&
+                                key_value_store_.key_value_store &&
                                 key_value_store_.process_count > 1 &&
                                 autotuner.IsAutotuningEnabled();
   if (shard_autotuning) {
-    if (key_value_store_.key_value_store == nullptr) {
-      return absl::FailedPreconditionError(
-          "Sharded autotuning requested but key-value store is missing.");
-    }
     fusions.keys_and_instructions = fusion_collector.Shard(
         fusions.keys_and_instructions, key_value_store_.process_index,
         key_value_store_.process_count);


### PR DESCRIPTION
With GPU mocking, there are no other processes, so any communication
over KV store will hang (e.g., sharding autotuning). Let us just set KV store
to null with GPU mocking on.

Fixes https://github.com/openxla/xla/issues/28959