### PR TITLE
[XLA:GPU] Add shared_memory_per_block_optin device info member

### DIFF
--- a/xla/pjrt/distributed/protocol.proto
+++ b/xla/pjrt/distributed/protocol.proto
@@ -80,6 +80,20 @@ message DeviceProto {
   // for SM100 (Blackwell) and onwards.
   // fabric_uuid is constructed in the format of "clusterUuid/cliqueId".
   string fabric_uuid = 12;
+
+  // Maximum amount of shared memory per block that can possibly be configured
+  // for a kernel on this device. The name of this attribute mirrors the CUDA
+  // driver enum member CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN:
+  // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__DEVICE.html#:~:text=CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN
+  // The _OPTIN suffix indicates that this is the maximum amount configurable on
+  // an opt-in basis (a property of the device), as opposed to
+  // CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK, which is the amount of
+  // shared memory that is actually made available to kernels through software
+  // configuration.
+  // For CUDA, shared_memory_per_block_optin also corresponds to the "Maximum
+  // amount of shared memory per thread block" row of this table:
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/#id401:~:text=100%20KB-,Maximum%20amount%20of%20shared%20memory%20per%20thread%20block,-35
+  int32 shared_memory_per_block_optin = 13;
 }
 
 message LocalTopologyProto {

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1502,6 +1502,8 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     auto compute_capability = MakeComputeCapabilityString(desc.get());
     device_proto->set_compute_capability(compute_capability);
     device_proto->set_core_count(desc->core_count());
+    device_proto->set_shared_memory_per_block_optin(
+        desc->shared_memory_per_block_optin());
 #if defined(GOOGLE_CUDA) && CUDA_VERSION >= 12040
     if (std::stoi(compute_capability) >= 9) {
       auto fabric_info = GetDeviceFabricInfo(ordinal_and_device.first);
@@ -1578,7 +1580,8 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
           device_proto.global_device_id(), std::move(local_device),
           device_proto.name(), device_proto.vendor(),
           device_proto.compute_capability(), device_proto.core_count(),
-          node.node_id(), device_proto.slice_index());
+          device_proto.shared_memory_per_block_optin(), node.node_id(),
+          device_proto.slice_index());
       devices.push_back(std::move(device));
     }
   }
@@ -1622,8 +1625,8 @@ std::string MakeComputeCapabilityString(const se::DeviceDescription* desc) {
 StreamExecutorGpuDevice::StreamExecutorGpuDevice(
     int id, std::unique_ptr<LocalDeviceState> local_device_state,
     std::string device_kind, std::string device_vendor,
-    std::string compute_capability, int core_count, int node_id,
-    int slice_index)
+    std::string compute_capability, int core_count,
+    int shared_memory_per_block_optin, int node_id, int slice_index)
     : PjRtStreamExecutorDevice(id, std::move(local_device_state),
                                /*process_index=*/node_id,
                                std::move(device_kind)),
@@ -1634,12 +1637,15 @@ StreamExecutorGpuDevice::StreamExecutorGpuDevice(
   std::vector<int64_t> v_coords(description().coords().begin(),
                                 description().coords().end());
 
-  description().SetAttributes(
-      {{"coords", xla::PjRtDeviceAttribute(v_coords)},
-       {"device_vendor", device_vendor_},
-       {"slice_index", static_cast<int64_t>(slice_index)},
-       {"compute_capability", xla::PjRtDeviceAttribute(compute_capability)},
-       {"core_count", static_cast<int64_t>(core_count)}});
+  description().SetAttributes({
+      {"coords", xla::PjRtDeviceAttribute(v_coords)},
+      {"device_vendor", device_vendor_},
+      {"slice_index", static_cast<int64_t>(slice_index)},
+      {"compute_capability", xla::PjRtDeviceAttribute(compute_capability)},
+      {"core_count", static_cast<int64_t>(core_count)},
+      {"shared_memory_per_block_optin",
+       static_cast<int64_t>(shared_memory_per_block_optin)},
+  });
   description().SetToString(absl::StrFormat(
       "StreamExecutorGpuDevice(device_kind=%s, id=%i, process_index=%i, "
       "slice_index=%i))",
@@ -1766,7 +1772,7 @@ std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> BuildLocalDevices(
     auto device = std::make_unique<StreamExecutorGpuDevice>(
         ordinal_and_device.first, std::move(ordinal_and_device.second),
         desc.name(), desc.device_vendor(), MakeComputeCapabilityString(&desc),
-        desc.core_count(), node_id);
+        desc.core_count(), desc.shared_memory_per_block_optin(), node_id);
     devices.push_back(std::move(device));
   }
   return devices;

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -66,7 +66,8 @@ class StreamExecutorGpuDevice : public PjRtStreamExecutorDevice {
                           std::unique_ptr<LocalDeviceState> local_device_state,
                           std::string device_kind, std::string device_vendor,
                           std::string compute_capability, int core_count,
-                          int node_id, int slice_index = 0);
+                          int shared_memory_per_block_optin, int node_id,
+                          int slice_index = 0);
 
   int slice_index() const;
 

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1285,6 +1285,20 @@ TEST(StreamExecutorGpuClientTest, GpuDeviceDescriptionTest) {
   }
 }
 
+TEST(StreamExecutorGpuClientTest, GpuDeviceSharedMemoryInfo) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+  for (const auto& device : client->devices()) {
+    auto value = static_cast<PjRtStreamExecutorDevice*>(device)
+                     ->description()
+                     .Attributes()
+                     .find("shared_memory_per_block_optin")
+                     ->second;
+    int64_t shared_memory_per_block_optin = std::get<int64_t>(value);
+    EXPECT_GT(shared_memory_per_block_optin, 0);
+  }
+}
+
 TEST(StreamExecutorGpuClientTest, GetTopologyDescriptionWithGlobalDevicesTest) {
   const int num_nodes = 4;
   GpuClientOptions options;


### PR DESCRIPTION
This allows us to query the amount of available shared memory in JAX, and use it to inform codegeneration of custom kernels.