### PR TITLE
[Perf] Add expensive AllGather cost adjustment to default GPU Scheduler

### DIFF
--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -50,7 +50,7 @@ static constexpr int64_t kCostlyAllGatherThreshold = 30 * 1024 * 1024;
 
 // Multiplier which we apply to expand the base cost for the costly AR.
 static constexpr int64_t kCostlyAllReduceMultiplier = 4;
-static constexpr int64_t kCosttlyAllGatherMultiplier = 2;
+static constexpr int64_t kCostlyAllGatherMultiplier = 2;
 
 // Multipliers for p2p collectives.
 static constexpr int64_t kCostlyP2PSendMultiplier = 1024;


### PR DESCRIPTION
All-gathers are also 1/2 as expensive as all-reduces, and should therefore be weighted accordingly.