### PR TITLE
Set names for XLA threads

### DIFF
--- a/xla/tsl/platform/default/env.cc
+++ b/xla/tsl/platform/default/env.cc
@@ -84,6 +84,9 @@ class PThread : public Thread {
     CHECK_EQ(ret, 0) << "Thread " << name
                      << " creation via pthread_create() failed.";
     pthread_attr_destroy(&attributes);
+  #if !defined(__APPLE__)
+    pthread_setname_np(thread_, name.c_str());
+  #endif
   }
 
   ~PThread() override {


### PR DESCRIPTION
Let us call `pthread_setname_np` for XLA threads so that the thread names are visible in gdb.

I should say that `pthread_setname_np` is not posix, but it should be provided on Linux and Mac.
If there is concern about this, we could put some `#if` around this.