### PR TITLE
[XLA:GPU] Add LHS schedule mode for command buffer

### DIFF
--- a/xla/backends/gpu/runtime/collective_thunk.h
+++ b/xla/backends/gpu/runtime/collective_thunk.h
@@ -265,6 +265,10 @@ class CollectiveDoneThunk : public Thunk {
 
   bool IsAsyncDone() const override { return async_events_ != nullptr; }
 
+  std::shared_ptr<CollectiveThunk::AsyncEvents> async_events() const {
+    return async_events_;
+  }
+
  private:
   std::shared_ptr<CollectiveThunk::AsyncEvents> async_events_;
   AsyncStreamKind stream_kind_ = AsyncStreamKind::kCollective;

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -274,7 +274,7 @@ absl::StatusOr<CommandBufferCmdExecutor> CommandBufferCmdExecutor::Create(
   // In automatic synchronization mode construct an execution graph for the
   // sequence of commands and derive the structure of command dependencies
   // from the buffer use conflicts.
-  if (synchronization_mode == SynchronizationMode::kAutomatic) {
+  if (synchronization_mode == SynchronizationMode::kConcurrent) {
     auto operations = CreateCommandOperations(commands);
     TF_ASSIGN_OR_RETURN(execution_graph,
                         ExecutionGraph::Create<CommandOperation>(operations));
@@ -543,7 +543,10 @@ CommandBufferCmdExecutor::Dependencies(const RecordParams& record_params,
                                        se::CommandBuffer* command_buffer,
                                        CommandId id) const {
   // Source commands have no dependencies.
+  VLOG(2) << "CommandSequence is :\n" << commands_.ToString();
   if (IsSource(id)) {
+    VLOG(2) << "Command ID " << id
+            << " is a source command, empty dependencies";
     return {};
   }
 
@@ -553,6 +556,56 @@ CommandBufferCmdExecutor::Dependencies(const RecordParams& record_params,
     for (const ExecutionGraph::NodeEdge& in_edge :
          execution_graph_->in_edges(id)) {
       dependencies_ids.push_back(in_edge.id);
+    }
+  } else if (synchronization_mode_ == SynchronizationMode::kLHS) {
+    CHECK(id < commands_.size());
+    auto is_async_start = [](const CommandBufferCmd* cmd) -> bool {
+      return cmd->command_type() == CommandBufferCmdType::kAllGatherCmd ||
+             cmd->command_type() == CommandBufferCmdType::kAllReduceCmd ||
+             cmd->command_type() == CommandBufferCmdType::kReduceScatter ||
+             cmd->command_type() == CommandBufferCmdType::kAllToAll;
+    };
+
+    auto find_async_start_cmd_id =
+        [&](const AsyncDoneCmd* async_done_cmd) -> CommandId {
+      CHECK(async_done_cmd->async_events() != nullptr);
+      for (CommandId i = id - 1; i >= 0; --i) {
+        if (is_async_start(commands_[i].get()) &&
+            static_cast<const CollectiveCmd*>(commands_[i].get())
+                    ->async_events() == async_done_cmd->async_events()) {
+          return i;
+        }
+      }
+      return -1;
+    };
+
+    if (commands_[id]->command_type() == CommandBufferCmdType::kAsyncDone) {
+      // Add dependency on the async start command.
+      auto async_start_cmd_id = find_async_start_cmd_id(
+          static_cast<const AsyncDoneCmd*>(commands_[id].get()));
+      CHECK_NE(async_start_cmd_id, -1);
+      dependencies_ids.push_back(async_start_cmd_id);
+
+      // Add dependency on the last command in async region.
+      for (CommandId i = id - 1; i > async_start_cmd_id; --i) {
+        if (is_async_start(commands_[i].get()) &&
+            static_cast<const CollectiveCmd*>(commands_[i].get())->IsAsync()) {
+          continue;
+        } else {
+          dependencies_ids.push_back(i);
+          break;
+        }
+      }
+    } else {
+      for (CommandId i = id - 1; i >= 0; --i) {
+        if (is_async_start(commands_[i].get()) &&
+            static_cast<const CollectiveCmd*>(commands_[i].get())->IsAsync()) {
+          continue;
+        } else {
+          dependencies_ids.push_back(i);
+          break;
+        }
+      }
     }
   } else {
     dependencies_ids.push_back(id - 1);
@@ -598,10 +651,10 @@ absl::StatusOr<std::string> CommandBufferCmdExecutor::RenderExecutionGraph() {
     return Unimplemented("No execution graph renderer registered");
   }
 
-  if (synchronization_mode_ != SynchronizationMode::kAutomatic) {
+  if (synchronization_mode_ != SynchronizationMode::kConcurrent) {
     return Unimplemented(
         "Execution graph rendering is only supported for "
-        "automatic synchronization mode");
+        "concurrent synchronization mode");
   }
 
   auto operations = CreateCommandOperations(commands_);
@@ -753,6 +806,32 @@ absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
       },
       [&](const se::CommandBuffer::Command* command) {
         // Empty command is not updatable.
+        return absl::OkStatus();
+      });
+}
+
+//===----------------------------------------------------------------------===//
+// AsyncDoneCmd
+//===----------------------------------------------------------------------===//
+
+AsyncDoneCmd::AsyncDoneCmd(
+    ExecutionStreamId execution_stream_id,
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
+    ResourceUseVector resources)
+    : CommandBufferCmd(CommandBufferCmdType::kAsyncDone, execution_stream_id,
+                       std::move(resources)),
+      async_events_(std::move(async_events)) {}
+
+absl::StatusOr<const se::CommandBuffer::Command*> AsyncDoneCmd::Record(
+    const Thunk::ExecuteParams& execute_params,
+    const RecordParams& record_params, RecordAction record_action,
+    se::CommandBuffer* command_buffer) {
+  return Handle(
+      std::move(record_action),
+      [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
+        return command_buffer->CreateEmptyCmd(dependencies, priority());
+      },
+      [&](const se::CommandBuffer::Command* command) {
         return absl::OkStatus();
       });
 }
@@ -1641,11 +1720,13 @@ CommandBufferCmd::BufferUseVector CustomCallCmd::buffers() const {
 // CollectiveCmd
 //===----------------------------------------------------------------------===//
 
-CollectiveCmd::CollectiveCmd(CommandBufferCmdType cmd_type,
-                             CollectiveConfig config,
-                             ResourceUseVector resources)
+CollectiveCmd::CollectiveCmd(
+    CommandBufferCmdType cmd_type, CollectiveConfig config,
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
+    ResourceUseVector resources)
     : CommandBufferCmd(cmd_type, std::move(resources)),
-      config_(std::move(config)) {}
+      config_(std::move(config)),
+      async_events_(std::move(async_events)) {}
 
 absl::Status CollectiveCmd::Prepare(
     const Thunk::PrepareParams& params,
@@ -1689,12 +1770,13 @@ CollectiveCmd::RecordTracedCommand(
 // AllReduceCmd
 //===----------------------------------------------------------------------===//
 
-AllReduceCmd::AllReduceCmd(CollectiveConfig config,
-                           ReductionKind reduction_kind,
-                           absl::Span<const CollectiveThunk::Buffer> buffers,
-                           ResourceUseVector resources)
+AllReduceCmd::AllReduceCmd(
+    CollectiveConfig config, ReductionKind reduction_kind,
+    absl::Span<const CollectiveThunk::Buffer> buffers,
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
+    ResourceUseVector resources)
     : CollectiveCmd(CommandBufferCmdType::kAllReduceCmd, std::move(config),
-                    std::move(resources)),
+                    std::move(async_events), std::move(resources)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1754,9 +1836,10 @@ CommandBufferCmd::BufferUseVector AllReduceCmd::buffers() const {
 ReduceScatterCmd::ReduceScatterCmd(
     CollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const CollectiveThunk::Buffer> buffers,
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
     ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kReduceScatterCmd, std::move(config),
-                    std::move(resources)),
+    : CollectiveCmd(CommandBufferCmdType::kReduceScatter, std::move(config),
+                    std::move(async_events), std::move(resources)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1814,11 +1897,13 @@ CommandBufferCmd::BufferUseVector ReduceScatterCmd::buffers() const {
 // AllToAllCmd
 //===----------------------------------------------------------------------===//
 
-AllToAllCmd::AllToAllCmd(CollectiveConfig config, bool has_split_dimension,
-                         absl::Span<const CollectiveThunk::Buffer> buffers,
-                         ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kAllToAllCmd, std::move(config),
-                    std::move(resources)),
+AllToAllCmd::AllToAllCmd(
+    CollectiveConfig config, bool has_split_dimension,
+    absl::Span<const CollectiveThunk::Buffer> buffers,
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
+    ResourceUseVector resources)
+    : CollectiveCmd(CommandBufferCmdType::kAllToAll, std::move(config),
+                    std::move(async_events), std::move(resources)),
       has_split_dimension_(has_split_dimension),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1874,11 +1959,12 @@ CommandBufferCmd::BufferUseVector AllToAllCmd::buffers() const {
 // AllGatherCmd
 //===----------------------------------------------------------------------===//
 
-AllGatherCmd::AllGatherCmd(CollectiveConfig config,
-                           absl::Span<const CollectiveThunk::Buffer> buffers,
-                           ResourceUseVector resources)
+AllGatherCmd::AllGatherCmd(
+    CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers,
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
+    ResourceUseVector resources)
     : CollectiveCmd(CommandBufferCmdType::kAllGatherCmd, std::move(config),
-                    std::move(resources)),
+                    std::move(async_events), std::move(resources)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> AllGatherCmd::Record(
@@ -1935,9 +2021,11 @@ CommandBufferCmd::BufferUseVector AllGatherCmd::buffers() const {
 
 CollectiveBroadcastCmd::CollectiveBroadcastCmd(
     CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers,
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
     ResourceUseVector resources)
     : CollectiveCmd(CommandBufferCmdType::kCollectiveBroadcastCmd,
-                    std::move(config), std::move(resources)),
+                    std::move(config), std::move(async_events),
+                    std::move(resources)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -562,8 +562,8 @@ CommandBufferCmdExecutor::Dependencies(const RecordParams& record_params,
     auto is_async_start = [](const CommandBufferCmd* cmd) -> bool {
       return cmd->command_type() == CommandBufferCmdType::kAllGatherCmd ||
              cmd->command_type() == CommandBufferCmdType::kAllReduceCmd ||
-             cmd->command_type() == CommandBufferCmdType::kReduceScatter ||
-             cmd->command_type() == CommandBufferCmdType::kAllToAll;
+             cmd->command_type() == CommandBufferCmdType::kReduceScatterCmd ||
+             cmd->command_type() == CommandBufferCmdType::kAllToAllCmd;
     };
 
     auto find_async_start_cmd_id =
@@ -815,11 +815,9 @@ absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
 //===----------------------------------------------------------------------===//
 
 AsyncDoneCmd::AsyncDoneCmd(
-    ExecutionStreamId execution_stream_id,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
     ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kAsyncDone, execution_stream_id,
-                       std::move(resources)),
+    : CommandBufferCmd(CommandBufferCmdType::kAsyncDone, std::move(resources)),
       async_events_(std::move(async_events)) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> AsyncDoneCmd::Record(
@@ -1838,7 +1836,7 @@ ReduceScatterCmd::ReduceScatterCmd(
     absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
     ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kReduceScatter, std::move(config),
+    : CollectiveCmd(CommandBufferCmdType::kReduceScatterCmd, std::move(config),
                     std::move(async_events), std::move(resources)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
@@ -1902,7 +1900,7 @@ AllToAllCmd::AllToAllCmd(
     absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
     ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kAllToAll, std::move(config),
+    : CollectiveCmd(CommandBufferCmdType::kAllToAllCmd, std::move(config),
                     std::move(async_events), std::move(resources)),
       has_split_dimension_(has_split_dimension),
       buffers_(buffers.begin(), buffers.end()) {}

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -93,6 +93,7 @@ namespace xla::gpu {
   V(kAllToAllCmd, "AllToAllCmd")                                 \
   V(kAllGatherCmd, "AllGatherCmd")                               \
   V(kCollectiveBroadcastCmd, "CollectiveBroadcastCmd")           \
+  V(kAsyncDone, "AsyncDone")                                       \
   V(kDynamicSliceFusionCmd, "DynamicSliceFusionCmd")             \
   V(kDynamicSliceCopyFusionCmd, "DynamicSliceCopyFusionCmd")     \
   V(kUnknownCmd, "UnknownCmd") \
@@ -266,7 +267,9 @@ class CommandBufferCmd {
   virtual absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams& execute_params,
       const RecordParams& record_params, RecordAction record_action,
-      se::CommandBuffer* command_buffer) = 0;
+      se::CommandBuffer* command_buffer) {
+    return absl::UnimplementedError("Record is not implemented");
+  }
 
   // Returns true if command requires initialization (has to be recorded at
   // command buffer thunk initialization).
@@ -287,7 +290,7 @@ class CommandBufferCmd {
 
   // Returns all buffers used by the cmd. These will be used to track cmd
   // updates, thus they need to be consistent across calls to the function.
-  virtual BufferUseVector buffers() const = 0;
+  virtual BufferUseVector buffers() const { return {}; }
   ResourceUseVector resources() const { return resources_; }
 
   // Returns true if command implemented as a nested command buffer.
@@ -324,6 +327,14 @@ class CommandBufferCmdSequence
   void Emplace(Args&&... args) {
     this->emplace_back(std::make_unique<Command>(std::forward<Args>(args)...));
   }
+
+  std::string ToString() const {
+    std::string result;
+    for (const auto& cmd : *this) {
+      result += cmd->ToString() + "\n";
+    }
+    return result;
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -349,7 +360,11 @@ class CommandBufferCmdExecutor {
 
     // Relies on execution graph to insert dependencies between commands
     // that have buffer of resource conflicts, and building a DAG of commands.
-    kAutomatic
+    kConcurrent,
+
+    // Uses the same latency hidden scheduling results used in the thunk
+    // scheduling.
+    kLHS,
   };
 
   template <typename Sink>
@@ -358,8 +373,11 @@ class CommandBufferCmdExecutor {
       case SynchronizationMode::kSerialize:
         sink.Append("serialize");
         break;
-      case SynchronizationMode::kAutomatic:
-        sink.Append("automatic");
+      case SynchronizationMode::kConcurrent:
+        sink.Append("concurrent");
+        break;
+      case SynchronizationMode::kLHS:
+        sink.Append("lhs");
         break;
     }
   }
@@ -541,6 +559,33 @@ class EmptyCmd : public CommandBufferCmd {
       se::CommandBuffer* command_buffer) override;
 
   BufferUseVector buffers() const override { return {}; }
+};
+
+//===----------------------------------------------------------------------===//
+// AsyncDoneCmd
+//===----------------------------------------------------------------------===//
+
+class AsyncDoneCmd : public CommandBufferCmd {
+ public:
+  explicit AsyncDoneCmd(
+      ExecutionStreamId execution_stream_id,
+      std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
+      ResourceUseVector resources = {});
+
+  absl::StatusOr<const se::CommandBuffer::Command*> Record(
+      const Thunk::ExecuteParams& execute_params,
+      const RecordParams& record_params, RecordAction record_action,
+      se::CommandBuffer* command_buffer) override;
+
+  BufferUseVector buffers() const override { return {}; }
+
+  bool IsAsync() const { return async_events_ != nullptr; }
+  std::shared_ptr<CollectiveThunk::AsyncEvents> async_events() const {
+    return async_events_;
+  }
+
+ private:
+  std::shared_ptr<CollectiveThunk::AsyncEvents> async_events_;
 };
 
 //===----------------------------------------------------------------------===//
@@ -937,6 +982,7 @@ class CustomCallCmd : public CommandBufferCmd {
 class CollectiveCmd : public CommandBufferCmd {
  public:
   CollectiveCmd(CommandBufferCmdType cmd_type, CollectiveConfig config,
+                std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
                 ResourceUseVector resources = {});
 
   absl::Status Prepare(
@@ -953,13 +999,17 @@ class CollectiveCmd : public CommandBufferCmd {
       se::CommandBuffer* command_buffer,
       absl::FunctionRef<absl::Status(se::Stream*)> trace);
 
-  bool IsAsync() const { return false; }
+  bool IsAsync() const { return async_events_ != nullptr; }
+  std::shared_ptr<CollectiveThunk::AsyncEvents> async_events() const {
+    return async_events_;
+  }
 
  protected:
   const CollectiveConfig& config() const { return config_; }
 
  private:
   CollectiveConfig config_;
+  std::shared_ptr<CollectiveThunk::AsyncEvents> async_events_;
 };
 
 //===----------------------------------------------------------------------===//
@@ -970,6 +1020,7 @@ class AllReduceCmd : public CollectiveCmd {
  public:
   AllReduceCmd(CollectiveConfig config, ReductionKind reduction_kind,
                absl::Span<const CollectiveThunk::Buffer> buffers,
+               std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
                ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
@@ -992,6 +1043,7 @@ class ReduceScatterCmd : public CollectiveCmd {
  public:
   ReduceScatterCmd(CollectiveConfig config, ReductionKind reduction_kind,
                    absl::Span<const CollectiveThunk::Buffer> buffers,
+                   std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
                    ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
@@ -1014,6 +1066,7 @@ class AllToAllCmd : public CollectiveCmd {
  public:
   AllToAllCmd(CollectiveConfig config, bool has_split_dimension,
               absl::Span<const CollectiveThunk::Buffer> buffers,
+              std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
               ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
@@ -1036,6 +1089,7 @@ class AllGatherCmd : public CollectiveCmd {
  public:
   AllGatherCmd(CollectiveConfig config,
                absl::Span<const CollectiveThunk::Buffer> buffers,
+               std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
                ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
@@ -1055,9 +1109,11 @@ class AllGatherCmd : public CollectiveCmd {
 
 class CollectiveBroadcastCmd : public CollectiveCmd {
  public:
-  CollectiveBroadcastCmd(CollectiveConfig config,
-                         absl::Span<const CollectiveThunk::Buffer> buffers,
-                         ResourceUseVector resources = {});
+  CollectiveBroadcastCmd(
+      CollectiveConfig config,
+      absl::Span<const CollectiveThunk::Buffer> buffers,
+      std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
+      ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams& execute_params,

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -93,7 +93,7 @@ namespace xla::gpu {
   V(kAllToAllCmd, "AllToAllCmd")                                 \
   V(kAllGatherCmd, "AllGatherCmd")                               \
   V(kCollectiveBroadcastCmd, "CollectiveBroadcastCmd")           \
-  V(kAsyncDone, "AsyncDone")                                       \
+  V(kAsyncDone, "AsyncDone")                                     \
   V(kDynamicSliceFusionCmd, "DynamicSliceFusionCmd")             \
   V(kDynamicSliceCopyFusionCmd, "DynamicSliceCopyFusionCmd")     \
   V(kUnknownCmd, "UnknownCmd") \
@@ -568,7 +568,6 @@ class EmptyCmd : public CommandBufferCmd {
 class AsyncDoneCmd : public CommandBufferCmd {
  public:
   explicit AsyncDoneCmd(
-      ExecutionStreamId execution_stream_id,
       std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
       ResourceUseVector resources = {});
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -342,7 +342,6 @@ static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
       if (options.synchronization_mode ==
           CommandBufferCmdExecutor::SynchronizationMode::kLHS) {
         return append(absl::StatusOr<Command>(std::make_unique<AsyncDoneCmd>(
-            thunk.execution_stream_id(),
             static_cast<const CollectiveDoneThunk&>(thunk).async_events(),
             resources)));
       } else {
@@ -351,8 +350,8 @@ static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
         } else {
           // If there control dependencies between these thunks, we will create
           // an empty command act as dependency nodes.
-          return append(absl::StatusOr<Command>(std::make_unique<EmptyCmd>(
-              thunk.execution_stream_id(), resources)));
+          return append(
+              absl::StatusOr<Command>(std::make_unique<EmptyCmd>(resources)));
         }
       }
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -180,25 +180,28 @@ static absl::StatusOr<Command> Convert(
 static absl::StatusOr<Command> Convert(const AllReduceStartThunk& thunk,
                                        ResourceUseVector resources) {
   return std::make_unique<AllReduceCmd>(thunk.config(), thunk.reduction_kind(),
-                                        thunk.buffers(), resources);
+                                        thunk.buffers(), thunk.async_events(),
+                                        resources);
 }
 
 static absl::StatusOr<Command> Convert(const ReduceScatterStartThunk& thunk,
                                        ResourceUseVector resources) {
   return std::make_unique<ReduceScatterCmd>(
-      thunk.config(), thunk.reduction_kind(), thunk.buffers(), resources);
+      thunk.config(), thunk.reduction_kind(), thunk.buffers(),
+      thunk.async_events(), resources);
 }
 
 static absl::StatusOr<Command> Convert(const AllToAllStartThunk& thunk,
                                        ResourceUseVector resources) {
   return std::make_unique<AllToAllCmd>(
-      thunk.config(), thunk.has_split_dimension(), thunk.buffers(), resources);
+      thunk.config(), thunk.has_split_dimension(), thunk.buffers(),
+      thunk.async_events(), resources);
 }
 
 static absl::StatusOr<Command> Convert(const AllGatherStartThunk& thunk,
                                        ResourceUseVector resources) {
   return std::make_unique<AllGatherCmd>(thunk.config(), thunk.buffers(),
-                                        resources);
+                                        thunk.async_events(), resources);
 }
 
 static absl::StatusOr<Command> Convert(
@@ -332,19 +335,33 @@ static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
                             static_cast<const SequentialThunk&>(thunk).thunks(),
                             options);
 
-    // Thunks that simply wait for stream events are no-op in the command buffer
-    // context, as we convert async thunks to command dependency graph.
     case Thunk::Kind::kAllGatherDone:
     case Thunk::Kind::kAllReduceDone:
     case Thunk::Kind::kReduceScatterDone:
     case Thunk::Kind::kAllToAllDone:
+      if (options.synchronization_mode ==
+          CommandBufferCmdExecutor::SynchronizationMode::kLHS) {
+        return append(absl::StatusOr<Command>(std::make_unique<AsyncDoneCmd>(
+            thunk.execution_stream_id(),
+            static_cast<const CollectiveDoneThunk&>(thunk).async_events(),
+            resources)));
+      } else {
+        if (resources.empty()) {
+          return absl::OkStatus();
+        } else {
+          // If there control dependencies between these thunks, we will create
+          // an empty command act as dependency nodes.
+          return append(absl::StatusOr<Command>(std::make_unique<EmptyCmd>(
+              thunk.execution_stream_id(), resources)));
+        }
+      }
+
     case Thunk::Kind::kWaitForStreams:
       if (resources.empty()) {
         return absl::OkStatus();
       } else {
-        // If there control dependencies between these thunks, we will create an
-        // empty command act as dependency nodes.
-        VLOG(0) << "Add empty command for asyndone synchronization";
+        // If there control dependencies between these thunks, we will create
+        // an empty command act as dependency nodes.
         return append(
             absl::StatusOr<Command>(std::make_unique<EmptyCmd>(resources)));
       }

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -240,7 +240,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUSTOM_CALL);
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUDNN);
   opts.set_xla_gpu_graph_min_graph_size(5);
-  opts.set_xla_gpu_graph_enable_concurrent_region(false);
+  opts.set_xla_gpu_command_buffer_scheduling_mode(DebugOptions::SERIALIZE);
   opts.set_xla_cmd_buffer_trace_cache_size(16);
 
   opts.set_xla_gpu_collectives_use_persistent_cliques(false);
@@ -636,6 +636,18 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
         }
         debug_options->set_xla_gpu_experimental_pipeline_parallelism_opt_level(
             level);
+        return true;
+      };
+
+  // Custom "sub-parser" lambda for
+  // xla_gpu_command_buffer_scheduling_mode.
+  auto setter_for_xla_gpu_command_buffer_scheduling_mode =
+      [debug_options](const std::string& value) {
+        DebugOptions::CommandBufferSchedulingMode mode;
+        if (!DebugOptions::CommandBufferSchedulingMode_Parse(value, &mode)) {
+          return false;
+        }
+        debug_options->set_xla_gpu_command_buffer_scheduling_mode(mode);
         return true;
       };
 
@@ -1589,13 +1601,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_graph_min_graph_size(),
       "Capture a region as a function to be launched as cuda graph if the "
       "number of moved instructions reaches this threshold."));
+
   flag_list->push_back(
-      tsl::Flag("xla_gpu_graph_enable_concurrent_region",
-                bool_setter_for(
-                    &DebugOptions::set_xla_gpu_graph_enable_concurrent_region),
-                debug_options->xla_gpu_graph_enable_concurrent_region(),
-                "Identify concurrent regions in gpu graphs and execute them "
-                "concurrently."));
+      tsl::Flag("xla_gpu_command_buffer_scheduling_mode",
+                setter_for_xla_gpu_command_buffer_scheduling_mode,
+                DebugOptions::CommandBufferSchedulingMode_Name(
+                    debug_options->xla_gpu_command_buffer_scheduling_mode()),
+                "The command buffer shceduling mode for XLA:GPU."));
+
   flag_list->push_back(tsl::Flag(
       "xla_cmd_buffer_trace_cache_size",
       int64_setter_for(&DebugOptions::set_xla_cmd_buffer_trace_cache_size),

--- a/xla/service/gpu/tests/command_buffer_test.cc
+++ b/xla/service/gpu/tests/command_buffer_test.cc
@@ -31,7 +31,8 @@ class CommandBufferTest : public HloPjRtTestBase,
                           public ::testing::WithParamInterface<bool> {
   DebugOptions GetDebugOptionsForTest() const override {
     DebugOptions debug_options = HloPjRtTestBase::GetDebugOptionsForTest();
-    debug_options.set_xla_gpu_graph_enable_concurrent_region(GetParam());
+    debug_options.set_xla_gpu_command_buffer_scheduling_mode(
+        DebugOptions::CONCURRENT);
     return debug_options;
   }
 };

--- a/xla/service/gpu/transforms/command_buffer_conversion_pass.cc
+++ b/xla/service/gpu/transforms/command_buffer_conversion_pass.cc
@@ -276,10 +276,24 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
   CommandBufferConfig config =
       GetCommandBufferConfig(debug_options, device_info);
 
-  CommandBufferCmdExecutor::SynchronizationMode synchronization_mode =
-      debug_options.xla_gpu_graph_enable_concurrent_region()
-          ? CommandBufferCmdExecutor::SynchronizationMode::kAutomatic
-          : CommandBufferCmdExecutor::SynchronizationMode::kSerialize;
+  CommandBufferCmdExecutor::SynchronizationMode synchronization_mode;
+  auto mode = debug_options.xla_gpu_command_buffer_scheduling_mode();
+  switch (mode) {
+    case DebugOptions::SERIALIZE:
+      synchronization_mode =
+          CommandBufferCmdExecutor::SynchronizationMode::kSerialize;
+      break;
+    case DebugOptions::CONCURRENT:
+      synchronization_mode =
+          CommandBufferCmdExecutor::SynchronizationMode::kConcurrent;
+      break;
+    case DebugOptions::LHS:
+      synchronization_mode =
+          CommandBufferCmdExecutor::SynchronizationMode::kLHS;
+      break;
+    default:
+      return Internal("Unsupported command buffer scheduling mode: %d", mode);
+  }
 
   bool changed = false;
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -255,10 +255,22 @@ message DebugOptions {
   // XLA:GPU options.
   //--------------------------------------------------------------------------//
   // clang-format off
-  // go/keep-sorted start newline_separated=yes skip_lines=2 ignore_prefixes=["optional AutotuneCacheMode","optional bool","optional float","optional int32","optional int64","optional LibNvJitLinkMode","map<string, string>","optional PGLEStrictnessLevel","optional PipelineParallelismOptLevel","repeated CollectiveOpType","repeated CommandBufferCmdType","repeated string","optional ShapeChecks","optional string","optional WhileLoopUnrolling","reserved","repeated GenericTritonEmitterFeature"] // NOLINT
+  // go/keep-sorted start newline_separated=yes skip_lines=2 ignore_prefixes=["optional AutotuneCacheMode","optional bool","optional float","optional int32","optional int64","optional LibNvJitLinkMode","map<string, string>","optional PGLEStrictnessLevel","optional PipelineParallelismOptLevel","repeated CollectiveOpType","repeated CommandBufferCmdType","repeated string","optional ShapeChecks","optional string","optional WhileLoopUnrolling","reserved","repeated GenericTritonEmitterFeature","optional CommandBufferSchedulingMode"] // NOLINT
   // clang-format on
 
   reserved 160;  // Was xla_gpu_enable_cudnn_frontend
+
+  // Command buffer scheduling mode. 
+  // SERIALIZE: Serialize all commands in a command buffer.
+  // CONCURRENT: Identify concurrent across operator through data conflicts.
+  // LHS: Uses the same latency hidden scheduling results as adopted by
+  // LatencyHidingScheduler which hides latencies of operations that can run in
+  // parallel with other operations.
+  enum CommandBufferSchedulingMode {
+    SERIALIZE = 0;
+    CONCURRENT = 1;
+    LHS = 2;
+  }
 
   // Options for the generic Triton emitter.
   // Set with xla_gpu_unsupported_generic_triton_emitter_features.
@@ -368,6 +380,8 @@ message DebugOptions {
   // collective operations from concurrent executions are not correcctly ordered
   // it may lead to deadlocks, crashes or will produce garbage.
   optional bool xla_gpu_collectives_use_persistent_cliques = 354;
+
+  optional CommandBufferSchedulingMode xla_gpu_command_buffer_scheduling_mode = 215;
 
   optional bool xla_gpu_copy_insertion_use_region_analysis = 236;
 
@@ -693,19 +707,6 @@ message DebugOptions {
   // If true, we generate line info when compiling PTX. This is useful for
   // profiling and debugging.
   optional bool xla_gpu_generate_line_info = 349;
-
-  // Command buffer scheduling mode. 
-  // SERIALIZE: Serialize all commands in a command buffer.
-  // CONCURRENT: Identify concurrent across operator through data conflicts.
-  // LHS: Uses the same latency hidden scheduling results as adopted by
-  // LatencyHidingScheduler which hides latencies of operations that can run in
-  // parallel with other operations.
-  enum CommandBufferSchedulingMode {
-    SERIALIZE = 0;
-    CONCURRENT = 1;
-    LHS = 2;
-  }
-  optional CommandBufferSchedulingMode xla_gpu_command_buffer_scheduling_mode = 215;
 
   // This number determines how many moved instructions like fusion kernels are
   // required for a region to be captured as a function to be launched as a GPU

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -694,8 +694,16 @@ message DebugOptions {
   // profiling and debugging.
   optional bool xla_gpu_generate_line_info = 349;
 
-  // Identify concurrent regions in GPU graphs and execute them concurrently.
-  optional bool xla_gpu_graph_enable_concurrent_region = 215;
+  // Command buffer scheduling mode. 
+  // SERIALIZE: Serialize all commands in a command buffer.
+  // CONCURRENT: Identify concurrent across operator through data conflicts.
+  // LHS: Uses the same latency hidden scheulding results.
+  enum CommandBufferSchedulingMode   {
+    SERIALIZE = 0;
+    CONCURRENT = 1;
+    LHS = 2;
+  }
+  optional CommandBufferSchedulingMode xla_gpu_command_buffer_scheduling_mode = 215;
 
   // This number determines how many moved instructions like fusion kernels are
   // required for a region to be captured as a function to be launched as a GPU

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -697,8 +697,10 @@ message DebugOptions {
   // Command buffer scheduling mode. 
   // SERIALIZE: Serialize all commands in a command buffer.
   // CONCURRENT: Identify concurrent across operator through data conflicts.
-  // LHS: Uses the same latency hidden scheulding results.
-  enum CommandBufferSchedulingMode   {
+  // LHS: Uses the same latency hidden scheduling results as adopted by
+  // LatencyHidingScheduler which hides latencies of operations that can run in
+  // parallel with other operations.
+  enum CommandBufferSchedulingMode {
     SERIALIZE = 0;
     CONCURRENT = 1;
     LHS = 2;


### PR DESCRIPTION
This PR adds LHS (Latency Hidding Scheduler) mode for command buffer scheduling, it will uses the same LHS scheduling results in the non-cuda-graph run.  For some cases, command buffer's automatic scheduling mode may not generate best perf, and user may want to try the legacy LHS scheduling. 
