### PR TITLE
[XLA:GPU] Explicitly set shared memory config for kernels

### DIFF
--- a/xla/stream_executor/cuda/cuda_stream.cc
+++ b/xla/stream_executor/cuda/cuda_stream.cc
@@ -379,6 +379,8 @@ absl::Status LaunchCudaKernel(
                            CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                            shared_mem_bytes),
         "Failed to set shared memory size"));
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuFuncSetCacheConfig(function, CU_FUNC_CACHE_PREFER_SHARED)));
   }
 
   return cuda::ToStatus(
@@ -417,6 +419,8 @@ absl::Status LaunchCudaKernel(
                            CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                            shared_mem_bytes),
         "Failed to set shared memory size"));
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuFuncSetCacheConfig(function, CU_FUNC_CACHE_PREFER_SHARED)));
   }
 
   CUlaunchConfig launch_config;


### PR DESCRIPTION
Not setting the cache config causes regressions with a newer driver.

Reference: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1g40f8c11e81def95dc0072a375f965681