### PR TITLE
[XLA:GPU] Remove Stream Id from command buffer

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -701,10 +701,9 @@ absl::StatusOr<se::CommandBuffer*> TracedCommandBuffer::GetOrTraceCommandBuffer(
 // TracedCommandBufferCmd
 //===----------------------------------------------------------------------===//
 
-TracedCommandBufferCmd::TracedCommandBufferCmd(
-    CommandBufferCmdType cmd_type, ExecutionStreamId execution_stream_id,
-    ResourceUseVector resources)
-    : CommandBufferCmd(cmd_type, execution_stream_id, std::move(resources)) {}
+TracedCommandBufferCmd::TracedCommandBufferCmd(CommandBufferCmdType cmd_type,
+                                               ResourceUseVector resources)
+    : CommandBufferCmd(cmd_type, std::move(resources)) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
 TracedCommandBufferCmd::RecordTracedCommand(
@@ -740,10 +739,8 @@ TracedCommandBufferCmd::RecordTracedCommand(
 // EmptyCmd
 //===----------------------------------------------------------------------===//
 
-EmptyCmd::EmptyCmd(ExecutionStreamId execution_stream_id,
-                   ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kEmptyCmd, execution_stream_id,
-                       std::move(resources)) {}
+EmptyCmd::EmptyCmd(ResourceUseVector resources)
+    : CommandBufferCmd(CommandBufferCmdType::kEmptyCmd, std::move(resources)) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
     const Thunk::ExecuteParams& execute_params,
@@ -764,11 +761,10 @@ absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
 // ComputationId
 //===----------------------------------------------------------------------===//
 
-ComputationIdCmd::ComputationIdCmd(ExecutionStreamId execution_stream_id,
-                                   BufferAllocation::Slice dest, Kind kind,
+ComputationIdCmd::ComputationIdCmd(BufferAllocation::Slice dest, Kind kind,
                                    ResourceUseVector resources)
     : CommandBufferCmd(CommandBufferCmdType::kComputationIdCmd,
-                       execution_stream_id, std::move(resources)),
+                       std::move(resources)),
       dest_(dest),
       kind_(kind) {}
 
@@ -814,14 +810,12 @@ absl::StatusOr<const se::CommandBuffer::Command*> ComputationIdCmd::Record(
 // LaunchCmd
 //===----------------------------------------------------------------------===//
 
-LaunchCmd::LaunchCmd(ExecutionStreamId execution_stream_id,
-                     std::string kernel_name,
+LaunchCmd::LaunchCmd(std::string kernel_name,
                      absl::Span<const BufferAllocation::Slice> args,
                      absl::Span<const MemoryAccess> args_access,
                      LaunchDimensions dims, int64_t shmem_bytes,
                      ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kLaunchCmd, execution_stream_id,
-                       std::move(resources)),
+    : CommandBufferCmd(CommandBufferCmdType::kLaunchCmd, std::move(resources)),
       kernel_name_(std::move(kernel_name)),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
@@ -910,12 +904,11 @@ CommandBufferCmd::BufferUseVector LaunchCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 CustomKernelLaunchCmd::CustomKernelLaunchCmd(
-    ExecutionStreamId execution_stream_id,
     absl::Span<const BufferAllocation::Slice> args,
     absl::Span<const MemoryAccess> args_access, CustomKernel custom_kernel,
     ResourceUseVector resources)
     : CommandBufferCmd(CommandBufferCmdType::kCustomKernelLaunchCmd,
-                       execution_stream_id, std::move(resources)),
+                       std::move(resources)),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
       custom_kernel_(std::move(custom_kernel)) {}
@@ -992,11 +985,12 @@ CommandBufferCmd::BufferUseVector CustomKernelLaunchCmd::buffers() const {
 // MemcpyDeviceToDeviceCmd
 //===----------------------------------------------------------------------===//
 
-MemcpyDeviceToDeviceCmd::MemcpyDeviceToDeviceCmd(
-    ExecutionStreamId execution_stream_id, BufferAllocation::Slice dst,
-    BufferAllocation::Slice src, int64_t num_bytes, ResourceUseVector resources)
+MemcpyDeviceToDeviceCmd::MemcpyDeviceToDeviceCmd(BufferAllocation::Slice dst,
+                                                 BufferAllocation::Slice src,
+                                                 int64_t num_bytes,
+                                                 ResourceUseVector resources)
     : CommandBufferCmd(CommandBufferCmdType::kMemcpyDeviceToDeviceCmd,
-                       execution_stream_id, std::move(resources)),
+                       std::move(resources)),
       dst_(dst),
       src_(src),
       num_bytes_(num_bytes) {}
@@ -1039,10 +1033,8 @@ CommandBufferCmd::BufferUseVector MemcpyDeviceToDeviceCmd::buffers() const {
 // MemzeroCmd
 //===----------------------------------------------------------------------===//
 
-MemzeroCmd::MemzeroCmd(ExecutionStreamId execution_stream_id,
-                       BufferAllocation::Slice dst, ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kMemzeroCmd, execution_stream_id,
-                       std::move(resources)),
+MemzeroCmd::MemzeroCmd(BufferAllocation::Slice dst, ResourceUseVector resources)
+    : CommandBufferCmd(CommandBufferCmdType::kMemzeroCmd, std::move(resources)),
       dst_(dst) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> MemzeroCmd::Record(
@@ -1081,10 +1073,9 @@ CommandBufferCmd::BufferUseVector MemzeroCmd::buffers() const {
 // Memset32Cmd
 //===----------------------------------------------------------------------===//
 
-Memset32Cmd::Memset32Cmd(ExecutionStreamId execution_stream_id,
-                         BufferAllocation::Slice dst, uint32_t bit_pattern,
+Memset32Cmd::Memset32Cmd(BufferAllocation::Slice dst, uint32_t bit_pattern,
                          ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kMemset32Cmd, execution_stream_id,
+    : CommandBufferCmd(CommandBufferCmdType::kMemset32Cmd,
                        std::move(resources)),
       dst_(dst),
       bit_pattern_(bit_pattern) {}
@@ -1126,12 +1117,10 @@ CommandBufferCmd::BufferUseVector Memset32Cmd::buffers() const {
 // CaseCmd
 //===----------------------------------------------------------------------===//
 
-CaseCmd::CaseCmd(ExecutionStreamId execution_stream_id,
-                 BufferAllocation::Slice index, bool index_is_bool,
+CaseCmd::CaseCmd(BufferAllocation::Slice index, bool index_is_bool,
                  std::vector<CommandBufferCmdExecutor> branches,
                  ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kCaseCmd, execution_stream_id,
-                       std::move(resources)),
+    : CommandBufferCmd(CommandBufferCmdType::kCaseCmd, std::move(resources)),
       index_(index),
       index_is_bool_(index_is_bool),
       branches_(std::move(branches)) {}
@@ -1203,13 +1192,11 @@ CommandBufferCmd::BufferUseVector CaseCmd::buffers() const {
 // WhileCmd
 //===----------------------------------------------------------------------===//
 
-WhileCmd::WhileCmd(ExecutionStreamId execution_stream_id,
-                   BufferAllocation::Slice pred,
+WhileCmd::WhileCmd(BufferAllocation::Slice pred,
                    CommandBufferCmdExecutor cond_commands,
                    CommandBufferCmdExecutor body_commands,
                    ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kWhileCmd, execution_stream_id,
-                       std::move(resources)),
+    : CommandBufferCmd(CommandBufferCmdType::kWhileCmd, std::move(resources)),
       pred_(pred),
       cond_commands_(std::move(cond_commands)),
       body_commands_(std::move(body_commands)) {}
@@ -1271,14 +1258,13 @@ CommandBufferCmd::BufferUseVector WhileCmd::buffers() const {
 // GemmCmd
 //===----------------------------------------------------------------------===//
 
-GemmCmd::GemmCmd(ExecutionStreamId execution_stream_id, GemmConfig config,
-                 const BufferAllocation::Slice& lhs_buffer,
+GemmCmd::GemmCmd(GemmConfig config, const BufferAllocation::Slice& lhs_buffer,
                  const BufferAllocation::Slice& rhs_buffer,
                  const BufferAllocation::Slice& output_buffer,
                  const BufferAllocation::Slice& workspace, bool deterministic,
                  ResourceUseVector resources)
     : TracedCommandBufferCmd(CommandBufferCmdType::kGemmCmd,
-                             execution_stream_id, std::move(resources)),
+                             std::move(resources)),
       config_(std::move(config)),
       lhs_buffer_(lhs_buffer),
       rhs_buffer_(rhs_buffer),
@@ -1332,11 +1318,10 @@ CommandBufferCmd::BufferUseVector GemmCmd::buffers() const {
 // CublasLtCmd
 //===----------------------------------------------------------------------===//
 
-CublasLtCmd::CublasLtCmd(ExecutionStreamId execution_stream_id,
-                         const CublasLtMatmulThunk& matmul_thunk,
+CublasLtCmd::CublasLtCmd(const CublasLtMatmulThunk& matmul_thunk,
                          ResourceUseVector resources)
     : TracedCommandBufferCmd(CommandBufferCmdType::kCublasLtCmd,
-                             execution_stream_id, std::move(resources)),
+                             std::move(resources)),
       CublasLtMatmulThunk(matmul_thunk) {}
 
 absl::Status CublasLtCmd::Initialize(const Thunk::InitializeParams& params,
@@ -1412,12 +1397,11 @@ CommandBufferCmd::BufferUseVector CublasLtCmd::buffers() const {
 // CuDnnCmd
 //===----------------------------------------------------------------------===//
 
-CuDnnCmd::CuDnnCmd(ExecutionStreamId execution_stream_id,
-                   absl::Span<const BufferAllocation::Slice> args,
+CuDnnCmd::CuDnnCmd(absl::Span<const BufferAllocation::Slice> args,
                    const std::shared_ptr<se::dnn::LazyDnnGraph> graph,
                    ResourceUseVector resources)
     : TracedCommandBufferCmd(CommandBufferCmdType::kCuDnnCmd,
-                             execution_stream_id, std::move(resources)),
+                             std::move(resources)),
       args_(args.cbegin(), args.cend()),
       graph_(graph) {}
 
@@ -1658,12 +1642,9 @@ CommandBufferCmd::BufferUseVector CustomCallCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 CollectiveCmd::CollectiveCmd(CommandBufferCmdType cmd_type,
-                             ExecutionStreamId execution_stream_id,
-                             ExecutionStreamId async_from_stream_id,
                              CollectiveConfig config,
                              ResourceUseVector resources)
-    : CommandBufferCmd(cmd_type, execution_stream_id, std::move(resources)),
-      async_from_stream_id_(async_from_stream_id),
+    : CommandBufferCmd(cmd_type, std::move(resources)),
       config_(std::move(config)) {}
 
 absl::Status CollectiveCmd::Prepare(
@@ -1675,7 +1656,7 @@ absl::Status CollectiveCmd::Prepare(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(collectives, *params.collective_params,
                       config().replica_groups, config().group_mode,
-                      GetAsyncStreamKind()));
+                      AsyncStreamKind::kCollective));
   return resource_requests.AddClique(clique_key);
 }
 
@@ -1708,14 +1689,11 @@ CollectiveCmd::RecordTracedCommand(
 // AllReduceCmd
 //===----------------------------------------------------------------------===//
 
-AllReduceCmd::AllReduceCmd(ExecutionStreamId execution_stream_id,
-                           ExecutionStreamId async_from_stream_id,
-                           CollectiveConfig config,
+AllReduceCmd::AllReduceCmd(CollectiveConfig config,
                            ReductionKind reduction_kind,
                            absl::Span<const CollectiveThunk::Buffer> buffers,
                            ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kAllReduceCmd, execution_stream_id,
-                    async_from_stream_id, std::move(config),
+    : CollectiveCmd(CommandBufferCmdType::kAllReduceCmd, std::move(config),
                     std::move(resources)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
@@ -1746,11 +1724,11 @@ absl::StatusOr<const se::CommandBuffer::Command*> AllReduceCmd::Record(
   TF_ASSIGN_OR_RETURN(GpuCollectives * collectives,
                       Thunk::GetGpuCollectives(execute_params));
 
-  TF_ASSIGN_OR_RETURN(
-      CommunicatorHandle comm_handle,
-      GetComm(collectives, *execute_params.collective_params,
-              *execute_params.collective_cliques, config().replica_groups,
-              config().group_mode, GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(CommunicatorHandle comm_handle,
+                      GetComm(collectives, *execute_params.collective_params,
+                              *execute_params.collective_cliques,
+                              config().replica_groups, config().group_mode,
+                              AsyncStreamKind::kCollective));  // Use constant
 
   return RecordTracedCommand(
       execute_params, record_params, std::move(record_action), command_buffer,
@@ -1774,13 +1752,10 @@ CommandBufferCmd::BufferUseVector AllReduceCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 ReduceScatterCmd::ReduceScatterCmd(
-    ExecutionStreamId execution_stream_id,
-    ExecutionStreamId async_from_stream_id, CollectiveConfig config,
-    ReductionKind reduction_kind,
+    CollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const CollectiveThunk::Buffer> buffers,
     ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kReduceScatter, execution_stream_id,
-                    async_from_stream_id, std::move(config),
+    : CollectiveCmd(CommandBufferCmdType::kReduceScatterCmd, std::move(config),
                     std::move(resources)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
@@ -1812,11 +1787,11 @@ absl::StatusOr<const se::CommandBuffer::Command*> ReduceScatterCmd::Record(
   TF_ASSIGN_OR_RETURN(GpuCollectives * collectives,
                       Thunk::GetGpuCollectives(execute_params));
 
-  TF_ASSIGN_OR_RETURN(
-      CommunicatorHandle comm_handle,
-      GetComm(collectives, *execute_params.collective_params,
-              *execute_params.collective_cliques, config().replica_groups,
-              config().group_mode, GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(CommunicatorHandle comm_handle,
+                      GetComm(collectives, *execute_params.collective_params,
+                              *execute_params.collective_cliques,
+                              config().replica_groups, config().group_mode,
+                              AsyncStreamKind::kCollective));  // Use constant
 
   return RecordTracedCommand(execute_params, record_params, record_action,
                              command_buffer, [&](se::Stream* stream) {
@@ -1839,13 +1814,10 @@ CommandBufferCmd::BufferUseVector ReduceScatterCmd::buffers() const {
 // AllToAllCmd
 //===----------------------------------------------------------------------===//
 
-AllToAllCmd::AllToAllCmd(ExecutionStreamId execution_stream_id,
-                         ExecutionStreamId async_from_stream_id,
-                         CollectiveConfig config, bool has_split_dimension,
+AllToAllCmd::AllToAllCmd(CollectiveConfig config, bool has_split_dimension,
                          absl::Span<const CollectiveThunk::Buffer> buffers,
                          ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kAllToAll, execution_stream_id,
-                    async_from_stream_id, std::move(config),
+    : CollectiveCmd(CommandBufferCmdType::kAllToAllCmd, std::move(config),
                     std::move(resources)),
       has_split_dimension_(has_split_dimension),
       buffers_(buffers.begin(), buffers.end()) {}
@@ -1875,11 +1847,11 @@ absl::StatusOr<const se::CommandBuffer::Command*> AllToAllCmd::Record(
 
   TF_ASSIGN_OR_RETURN(GpuCollectives * collectives,
                       Thunk::GetGpuCollectives(execute_params));
-  TF_ASSIGN_OR_RETURN(
-      CommunicatorHandle comm_handle,
-      GetComm(collectives, *execute_params.collective_params,
-              *execute_params.collective_cliques, config().replica_groups,
-              config().group_mode, GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(CommunicatorHandle comm_handle,
+                      GetComm(collectives, *execute_params.collective_params,
+                              *execute_params.collective_cliques,
+                              config().replica_groups, config().group_mode,
+                              AsyncStreamKind::kCollective));  // Use constant
 
   return RecordTracedCommand(
       execute_params, record_params, std::move(record_action), command_buffer,
@@ -1902,13 +1874,10 @@ CommandBufferCmd::BufferUseVector AllToAllCmd::buffers() const {
 // AllGatherCmd
 //===----------------------------------------------------------------------===//
 
-AllGatherCmd::AllGatherCmd(ExecutionStreamId execution_stream_id,
-                           ExecutionStreamId async_from_stream_id,
-                           CollectiveConfig config,
+AllGatherCmd::AllGatherCmd(CollectiveConfig config,
                            absl::Span<const CollectiveThunk::Buffer> buffers,
                            ResourceUseVector resources)
-    : CollectiveCmd(CommandBufferCmdType::kAllGatherCmd, execution_stream_id,
-                    async_from_stream_id, std::move(config),
+    : CollectiveCmd(CommandBufferCmdType::kAllGatherCmd, std::move(config),
                     std::move(resources)),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1938,11 +1907,11 @@ absl::StatusOr<const se::CommandBuffer::Command*> AllGatherCmd::Record(
   TF_ASSIGN_OR_RETURN(GpuCollectives * collectives,
                       Thunk::GetGpuCollectives(execute_params));
 
-  TF_ASSIGN_OR_RETURN(
-      CommunicatorHandle comm_handle,
-      GetComm(collectives, *execute_params.collective_params,
-              *execute_params.collective_cliques, config().replica_groups,
-              config().group_mode, GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(CommunicatorHandle comm_handle,
+                      GetComm(collectives, *execute_params.collective_params,
+                              *execute_params.collective_cliques,
+                              config().replica_groups, config().group_mode,
+                              AsyncStreamKind::kCollective));  // Use constant
 
   return RecordTracedCommand(
       execute_params, record_params, std::move(record_action), command_buffer,
@@ -1965,12 +1934,9 @@ CommandBufferCmd::BufferUseVector AllGatherCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 CollectiveBroadcastCmd::CollectiveBroadcastCmd(
-    ExecutionStreamId execution_stream_id,
-    ExecutionStreamId async_from_stream_id, CollectiveConfig config,
-    absl::Span<const CollectiveThunk::Buffer> buffers,
+    CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers,
     ResourceUseVector resources)
     : CollectiveCmd(CommandBufferCmdType::kCollectiveBroadcastCmd,
-                    execution_stream_id, async_from_stream_id,
                     std::move(config), std::move(resources)),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -2001,11 +1967,11 @@ CollectiveBroadcastCmd::Record(const Thunk::ExecuteParams& execute_params,
   TF_ASSIGN_OR_RETURN(GpuCollectives * collectives,
                       Thunk::GetGpuCollectives(execute_params));
 
-  TF_ASSIGN_OR_RETURN(
-      CommunicatorHandle comm_handle,
-      GetComm(collectives, *execute_params.collective_params,
-              *execute_params.collective_cliques, config().replica_groups,
-              config().group_mode, GetAsyncStreamKind()));
+  TF_ASSIGN_OR_RETURN(CommunicatorHandle comm_handle,
+                      GetComm(collectives, *execute_params.collective_params,
+                              *execute_params.collective_cliques,
+                              config().replica_groups, config().group_mode,
+                              AsyncStreamKind::kCollective));  // Use constant
 
   return RecordTracedCommand(execute_params, record_params,
                              std::move(record_action), command_buffer,
@@ -2029,7 +1995,6 @@ CommandBufferCmd::BufferUseVector CollectiveBroadcastCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 DynamicSliceFusionCmd::DynamicSliceFusionCmd(
-    ExecutionStreamId execution_stream_id,
     CommandBufferCmdExecutor embedded_commands,
     std::vector<std::optional<BufferAllocation::Slice>> arguments,
     std::vector<std::unique_ptr<BufferAllocation>> fake_allocations,
@@ -2039,7 +2004,7 @@ DynamicSliceFusionCmd::DynamicSliceFusionCmd(
     std::vector<std::optional<uint64_t>> offset_byte_sizes,
     ResourceUseVector resources)
     : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceFusionCmd,
-                       execution_stream_id, std::move(resources)),
+                       std::move(resources)),
       embedded_commands_(std::move(embedded_commands)),
       fake_allocations_(std::move(fake_allocations)) {
   // Zip all arguments together to create a list of SliceDef.
@@ -2295,12 +2260,11 @@ CommandBufferCmd::BufferUseVector DynamicSliceFusionCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 DynamicSliceCopyFusionCmd::DynamicSliceCopyFusionCmd(
-    ExecutionStreamId execution_stream_id,
     const BufferAllocation::Slice& source_buffer,
     const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
     DynamicMemcpyThunk::Offsets offsets, ResourceUseVector resources)
     : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceCopyFusionCmd,
-                       execution_stream_id, std::move(resources)),
+                       std::move(resources)),
       source_buffer_(source_buffer),
       destination_buffer_(destination_buffer),
       mem_size_(mem_size),

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -89,8 +89,8 @@ namespace xla::gpu {
   V(kBarrierCmd, "BarrierCmd")                                   \
   V(kCollectiveCmd, "CollectiveCmd")                             \
   V(kAllReduceCmd, "AllReduceCmd")                               \
-  V(kReduceScatter, "ReduceScatterCmd")                          \
-  V(kAllToAll, "AllToAllCmd")                                    \
+  V(kReduceScatterCmd, "ReduceScatterCmd")                       \
+  V(kAllToAllCmd, "AllToAllCmd")                                 \
   V(kAllGatherCmd, "AllGatherCmd")                               \
   V(kCollectiveBroadcastCmd, "CollectiveBroadcastCmd")           \
   V(kDynamicSliceFusionCmd, "DynamicSliceFusionCmd")             \
@@ -124,12 +124,9 @@ using ResourceUseVector = absl::InlinedVector<ResourceUse, 1>;
 
 class CommandBufferCmd {
  public:
-  CommandBufferCmd(CommandBufferCmdType cmd_type,
-                   ExecutionStreamId execution_stream_id,
-                   ResourceUseVector resources,
+  CommandBufferCmd(CommandBufferCmdType cmd_type, ResourceUseVector resources,
                    se::StreamPriority priority = se::StreamPriority::Default)
       : cmd_type_(cmd_type),
-        execution_stream_id_(execution_stream_id),
         resources_(std::move(resources)),
         priority_(priority) {}
 
@@ -309,12 +306,9 @@ class CommandBufferCmd {
     return CommandBufferCmdString(cmd_type_);
   }
 
-  ExecutionStreamId execution_stream_id() const { return execution_stream_id_; }
-
  private:
   std::string profile_annotation_;
   CommandBufferCmdType cmd_type_;
-  ExecutionStreamId execution_stream_id_;
   ResourceUseVector resources_;
 
   // Command priority, currently only support default, lowest and highest
@@ -521,7 +515,6 @@ class TracedCommandBuffer : public CommandBufferCmd::State {
 class TracedCommandBufferCmd : public CommandBufferCmd {
  protected:
   explicit TracedCommandBufferCmd(CommandBufferCmdType cmd_type,
-                                  ExecutionStreamId execution_stream_id,
                                   ResourceUseVector resources = {});
 
   // Creates a command buffer by calling a user-provided `trace` function and
@@ -540,8 +533,7 @@ class TracedCommandBufferCmd : public CommandBufferCmd {
 
 class EmptyCmd : public CommandBufferCmd {
  public:
-  explicit EmptyCmd(ExecutionStreamId execution_stream_id,
-                    ResourceUseVector resources = {});
+  explicit EmptyCmd(ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams& execute_params,
@@ -559,8 +551,7 @@ class ComputationIdCmd : public CommandBufferCmd {
  public:
   enum class Kind { kReplica, kPartition };
 
-  ComputationIdCmd(ExecutionStreamId execution_stream_id,
-                   BufferAllocation::Slice dest, Kind kind,
+  ComputationIdCmd(BufferAllocation::Slice dest, Kind kind,
                    ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
@@ -581,7 +572,7 @@ class ComputationIdCmd : public CommandBufferCmd {
 
 class LaunchCmd : public CommandBufferCmd {
  public:
-  LaunchCmd(ExecutionStreamId execution_stream_id, std::string kernel_name,
+  LaunchCmd(std::string kernel_name,
             absl::Span<const BufferAllocation::Slice> args,
             absl::Span<const BufferUse::MemoryAccess> args_access,
             LaunchDimensions dims, int64_t shmem_bytes,
@@ -617,8 +608,7 @@ class LaunchCmd : public CommandBufferCmd {
 
 class CustomKernelLaunchCmd : public CommandBufferCmd {
  public:
-  CustomKernelLaunchCmd(ExecutionStreamId execution_stream_id,
-                        absl::Span<const BufferAllocation::Slice> args,
+  CustomKernelLaunchCmd(absl::Span<const BufferAllocation::Slice> args,
                         absl::Span<const BufferUse::MemoryAccess> args_access,
                         CustomKernel custom_kernel,
                         ResourceUseVector resources = {});
@@ -651,8 +641,7 @@ class CustomKernelLaunchCmd : public CommandBufferCmd {
 
 class MemcpyDeviceToDeviceCmd : public CommandBufferCmd {
  public:
-  MemcpyDeviceToDeviceCmd(ExecutionStreamId execution_stream_id,
-                          BufferAllocation::Slice dst,
+  MemcpyDeviceToDeviceCmd(BufferAllocation::Slice dst,
                           BufferAllocation::Slice src, int64_t num_bytes,
                           ResourceUseVector resources = {});
 
@@ -675,8 +664,7 @@ class MemcpyDeviceToDeviceCmd : public CommandBufferCmd {
 
 class MemzeroCmd : public CommandBufferCmd {
  public:
-  MemzeroCmd(ExecutionStreamId execution_stream_id, BufferAllocation::Slice dst,
-             ResourceUseVector resources = {});
+  MemzeroCmd(BufferAllocation::Slice dst, ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams& execute_params,
@@ -695,8 +683,7 @@ class MemzeroCmd : public CommandBufferCmd {
 
 class Memset32Cmd : public CommandBufferCmd {
  public:
-  Memset32Cmd(ExecutionStreamId execution_stream_id,
-              BufferAllocation::Slice dst, uint32_t bit_pattern,
+  Memset32Cmd(BufferAllocation::Slice dst, uint32_t bit_pattern,
               ResourceUseVector resources = {});
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
@@ -717,8 +704,8 @@ class Memset32Cmd : public CommandBufferCmd {
 
 class CaseCmd : public CommandBufferCmd {
  public:
-  CaseCmd(ExecutionStreamId execution_stream_id, BufferAllocation::Slice index,
-          bool index_is_bool, std::vector<CommandBufferCmdExecutor> branches,
+  CaseCmd(BufferAllocation::Slice index, bool index_is_bool,
+          std::vector<CommandBufferCmdExecutor> branches,
           ResourceUseVector resources = {});
 
   absl::Status Initialize(const Thunk::InitializeParams& params,
@@ -747,8 +734,7 @@ class CaseCmd : public CommandBufferCmd {
 
 class WhileCmd : public CommandBufferCmd {
  public:
-  WhileCmd(ExecutionStreamId execution_stream_id, BufferAllocation::Slice pred,
-           CommandBufferCmdExecutor cond_commands,
+  WhileCmd(BufferAllocation::Slice pred, CommandBufferCmdExecutor cond_commands,
            CommandBufferCmdExecutor body_commands,
            ResourceUseVector resources = {});
 
@@ -778,8 +764,7 @@ class WhileCmd : public CommandBufferCmd {
 
 class GemmCmd : public TracedCommandBufferCmd {
  public:
-  GemmCmd(ExecutionStreamId execution_stream_id, GemmConfig config,
-          const BufferAllocation::Slice& lhs_buffer,
+  GemmCmd(GemmConfig config, const BufferAllocation::Slice& lhs_buffer,
           const BufferAllocation::Slice& rhs_buffer,
           const BufferAllocation::Slice& output_buffer,
           const BufferAllocation::Slice& workspace, bool deterministic,
@@ -813,8 +798,7 @@ class GemmCmd : public TracedCommandBufferCmd {
 
 class CublasLtCmd : public TracedCommandBufferCmd, public CublasLtMatmulThunk {
  public:
-  CublasLtCmd(ExecutionStreamId execution_stream_id,
-              const CublasLtMatmulThunk& matmul_thunk,
+  CublasLtCmd(const CublasLtMatmulThunk& matmul_thunk,
               ResourceUseVector resources = {});
 
   absl::Status Initialize(const Thunk::InitializeParams& params,
@@ -841,8 +825,7 @@ class CublasLtCmd : public TracedCommandBufferCmd, public CublasLtMatmulThunk {
 
 class CuDnnCmd : public TracedCommandBufferCmd {
  public:
-  CuDnnCmd(ExecutionStreamId execution_stream_id,
-           absl::Span<const BufferAllocation::Slice> args,
+  CuDnnCmd(absl::Span<const BufferAllocation::Slice> args,
            std::shared_ptr<se::dnn::LazyDnnGraph> graph,
            ResourceUseVector resources = {});
 
@@ -875,28 +858,26 @@ class CustomCallCmd : public CommandBufferCmd {
 
   // This is a legacy custom call API that is discouraged, and will be
   // deprecated once XLA:FFI mechanism is ready.
-  CustomCallCmd(ExecutionStreamId execution_stream_id, std::string target_name,
-                CustomCallTarget call_target,
+  CustomCallCmd(std::string target_name, CustomCallTarget call_target,
                 std::vector<std::optional<Slice>> operands,
                 std::vector<std::optional<Slice>> results,
                 absl::string_view opaque, ResourceUseVector resources = {})
       : CommandBufferCmd(CommandBufferCmdType::kCustomCallCmd,
-                         execution_stream_id, resources),
+                         std::move(resources)),
         target_name_(std::move(target_name)),
         call_target_(std::move(call_target)),
         opaque_(opaque),
         operands_(std::move(operands)),
         results_(std::move(results)) {}
 
-  CustomCallCmd(ExecutionStreamId execution_stream_id, std::string target_name,
-                XLA_FFI_Handler* handler,
+  CustomCallCmd(std::string target_name, XLA_FFI_Handler* handler,
                 std::vector<std::optional<Slice>> operands,
                 std::vector<std::optional<Slice>> results,
                 ffi::CallFrame call_frame,
                 const HloComputation* called_computation,
                 ResourceUseVector resources = {})
       : CommandBufferCmd(CommandBufferCmdType::kCustomCallCmd,
-                         execution_stream_id, resources),
+                         std::move(resources)),
         target_name_(std::move(target_name)),
         handler_(handler),
         call_frame_(std::move(call_frame)),
@@ -955,9 +936,7 @@ class CustomCallCmd : public CommandBufferCmd {
 
 class CollectiveCmd : public CommandBufferCmd {
  public:
-  CollectiveCmd(CommandBufferCmdType cmd_type,
-                ExecutionStreamId execution_stream_id,
-                ExecutionStreamId async_from_stream_id, CollectiveConfig config,
+  CollectiveCmd(CommandBufferCmdType cmd_type, CollectiveConfig config,
                 ResourceUseVector resources = {});
 
   absl::Status Prepare(
@@ -974,27 +953,12 @@ class CollectiveCmd : public CommandBufferCmd {
       se::CommandBuffer* command_buffer,
       absl::FunctionRef<absl::Status(se::Stream*)> trace);
 
-  virtual AsyncStreamKind GetAsyncStreamKind() = 0;
-  virtual CollectiveStreamId GetAsyncStreamId() = 0;
-
-  bool IsAsync() const {
-    return async_from_stream_id_ != execution_stream_id();
-  }
-
-  CollectiveStreamId nccl_stream_id() {
-    return xla::gpu::GetCollectiveStreamId(IsAsync(), GetAsyncStreamId(),
-                                           GetAsyncStreamKind());
-  }
-
-  ExecutionStreamId async_from_stream_id() const {
-    return async_from_stream_id_;
-  }
+  bool IsAsync() const { return false; }
 
  protected:
   const CollectiveConfig& config() const { return config_; }
 
  private:
-  ExecutionStreamId async_from_stream_id_;
   CollectiveConfig config_;
 };
 
@@ -1004,9 +968,7 @@ class CollectiveCmd : public CommandBufferCmd {
 
 class AllReduceCmd : public CollectiveCmd {
  public:
-  AllReduceCmd(ExecutionStreamId execution_stream_id,
-               ExecutionStreamId async_from_stream_id, CollectiveConfig config,
-               ReductionKind reduction_kind,
+  AllReduceCmd(CollectiveConfig config, ReductionKind reduction_kind,
                absl::Span<const CollectiveThunk::Buffer> buffers,
                ResourceUseVector resources = {});
 
@@ -1016,13 +978,6 @@ class AllReduceCmd : public CollectiveCmd {
       se::CommandBuffer* command_buffer) override;
 
   BufferUseVector buffers() const override;
-
-  AsyncStreamKind GetAsyncStreamKind() override {
-    return AsyncStreamKind::kCollective;
-  };
-  CollectiveStreamId GetAsyncStreamId() override {
-    return CollectiveStreamId(1);
-  };
 
  private:
   ReductionKind reduction_kind_;
@@ -1035,9 +990,7 @@ class AllReduceCmd : public CollectiveCmd {
 
 class ReduceScatterCmd : public CollectiveCmd {
  public:
-  ReduceScatterCmd(ExecutionStreamId execution_stream_id,
-                   ExecutionStreamId async_from_stream_id,
-                   CollectiveConfig config, ReductionKind reduction_kind,
+  ReduceScatterCmd(CollectiveConfig config, ReductionKind reduction_kind,
                    absl::Span<const CollectiveThunk::Buffer> buffers,
                    ResourceUseVector resources = {});
 
@@ -1047,13 +1000,6 @@ class ReduceScatterCmd : public CollectiveCmd {
       se::CommandBuffer* command_buffer) override;
 
   BufferUseVector buffers() const override;
-
-  AsyncStreamKind GetAsyncStreamKind() override {
-    return AsyncStreamKind::kCollective;
-  };
-  CollectiveStreamId GetAsyncStreamId() override {
-    return CollectiveStreamId(1);
-  };
 
  private:
   ReductionKind reduction_kind_;
@@ -1066,9 +1012,7 @@ class ReduceScatterCmd : public CollectiveCmd {
 
 class AllToAllCmd : public CollectiveCmd {
  public:
-  AllToAllCmd(ExecutionStreamId execution_stream_id,
-              ExecutionStreamId async_from_stream_id, CollectiveConfig config,
-              bool has_split_dimension,
+  AllToAllCmd(CollectiveConfig config, bool has_split_dimension,
               absl::Span<const CollectiveThunk::Buffer> buffers,
               ResourceUseVector resources = {});
 
@@ -1078,13 +1022,6 @@ class AllToAllCmd : public CollectiveCmd {
       se::CommandBuffer* command_buffer) override;
 
   BufferUseVector buffers() const override;
-
-  AsyncStreamKind GetAsyncStreamKind() override {
-    return AsyncStreamKind::kCollective;
-  };
-  CollectiveStreamId GetAsyncStreamId() override {
-    return CollectiveStreamId(1);
-  };
 
  private:
   bool has_split_dimension_;
@@ -1097,8 +1034,7 @@ class AllToAllCmd : public CollectiveCmd {
 
 class AllGatherCmd : public CollectiveCmd {
  public:
-  AllGatherCmd(ExecutionStreamId execution_stream_id,
-               ExecutionStreamId async_from_stream_id, CollectiveConfig config,
+  AllGatherCmd(CollectiveConfig config,
                absl::Span<const CollectiveThunk::Buffer> buffers,
                ResourceUseVector resources = {});
 
@@ -1108,13 +1044,6 @@ class AllGatherCmd : public CollectiveCmd {
       se::CommandBuffer* command_buffer) override;
 
   BufferUseVector buffers() const override;
-
-  AsyncStreamKind GetAsyncStreamKind() override {
-    return AsyncStreamKind::kCollective;
-  };
-  CollectiveStreamId GetAsyncStreamId() override {
-    return CollectiveStreamId(1);
-  };
 
  private:
   std::vector<CollectiveThunk::Buffer> buffers_;
@@ -1126,9 +1055,7 @@ class AllGatherCmd : public CollectiveCmd {
 
 class CollectiveBroadcastCmd : public CollectiveCmd {
  public:
-  CollectiveBroadcastCmd(ExecutionStreamId execution_stream_id,
-                         ExecutionStreamId async_from_stream_id,
-                         CollectiveConfig config,
+  CollectiveBroadcastCmd(CollectiveConfig config,
                          absl::Span<const CollectiveThunk::Buffer> buffers,
                          ResourceUseVector resources = {});
 
@@ -1150,7 +1077,6 @@ class CollectiveBroadcastCmd : public CollectiveCmd {
 class DynamicSliceFusionCmd : public CommandBufferCmd {
  public:
   DynamicSliceFusionCmd(
-      ExecutionStreamId execution_stream_id,
       CommandBufferCmdExecutor embedded_commands,
       std::vector<std::optional<BufferAllocation::Slice>> arguments,
       std::vector<std::unique_ptr<BufferAllocation>> fake_allocations_,
@@ -1210,8 +1136,7 @@ class DynamicSliceFusionCmd : public CommandBufferCmd {
 // buffer to another, it is only supported for static slice.
 class DynamicSliceCopyFusionCmd : public CommandBufferCmd {
  public:
-  DynamicSliceCopyFusionCmd(ExecutionStreamId execution_stream_id,
-                            const BufferAllocation::Slice& source_buffer,
+  DynamicSliceCopyFusionCmd(const BufferAllocation::Slice& source_buffer,
                             const BufferAllocation::Slice& destination_buffer,
                             uint64_t mem_size,
                             DynamicMemcpyThunk::Offsets offsets,

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -128,10 +128,6 @@ bool IsAtLeastCuda12300(const se::StreamExecutor* stream_executor) {
   return false;
 }
 
-// Give a short aliases to execution threads.
-constexpr auto s0 = ExecutionStreamId(0);
-constexpr auto s1 = ExecutionStreamId(1);
-
 // Give a short alias to synchronization mode.
 static constexpr auto serialize =
     CommandBufferCmdExecutor::SynchronizationMode::kSerialize;
@@ -164,7 +160,7 @@ TEST(CommandBufferThunkTest, MemcpyCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<MemcpyDeviceToDeviceCmd>(s0, slice_b, slice_a, byte_length);
+  commands.Emplace<MemcpyDeviceToDeviceCmd>(slice_b, slice_a, byte_length);
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -222,7 +218,7 @@ TEST(CommandBufferThunkTest, MemzeroCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<MemzeroCmd>(s0, slice_a);
+  commands.Emplace<MemzeroCmd>(slice_a);
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -268,7 +264,7 @@ TEST(CommandBufferThunkTest, Memset32Cmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<Memset32Cmd>(s0, slice_a, int32_t{84});
+  commands.Emplace<Memset32Cmd>(slice_a, int32_t{84});
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -321,7 +317,7 @@ TEST(CommandBufferThunkTest, Memset32CmdCommandBuffersDisabledDuringProfiling) {
   // Prepare commands sequence for constructing command buffer that should not
   // be used.
   CommandBufferCmdSequence commands;
-  commands.Emplace<Memset32Cmd>(s0, slice_a, int32_t{12});
+  commands.Emplace<Memset32Cmd>(slice_a, int32_t{12});
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -379,7 +375,7 @@ TEST(CommandBufferThunkTest, Memset32CmdCommandBuffersEnabledDuringProfiling) {
   // Prepare commands sequence for constructing command buffer that should not
   // be used.
   CommandBufferCmdSequence commands;
-  commands.Emplace<Memset32Cmd>(s0, slice_a, int32_t{12});
+  commands.Emplace<Memset32Cmd>(slice_a, int32_t{12});
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -425,8 +421,8 @@ TEST(CommandBufferThunkTest, Memset32CmdOnDifferentStreams) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<Memset32Cmd>(s0, slice0, int32_t{12});
-  commands.Emplace<Memset32Cmd>(s1, slice1, int32_t{34});
+  commands.Emplace<Memset32Cmd>(slice0, int32_t{12});
+  commands.Emplace<Memset32Cmd>(slice1, int32_t{34});
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -482,7 +478,7 @@ TEST(CommandBufferThunkTest, LaunchCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<LaunchCmd>(s0, "AddI32", args, args_access,
+  commands.Emplace<LaunchCmd>("AddI32", args, args_access,
                               LaunchDimensions(1, 4),
                               /*shmem_bytes=*/0);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -586,7 +582,7 @@ TEST(CommandBufferThunkTest, CustomAddKernelLaunchCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<LaunchCmd>(s0, "AddI32", args, args_access,
+  commands.Emplace<LaunchCmd>("AddI32", args, args_access,
                               LaunchDimensions(1, 4),
                               /*shmem_bytes=*/0);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -707,7 +703,7 @@ TEST(CommandBufferThunkTest, GemmCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<GemmCmd>(s0, config.value(), slice_lhs, slice_rhs, slice_out,
+  commands.Emplace<GemmCmd>(config.value(), slice_lhs, slice_rhs, slice_out,
                             slice_workspace,
                             /*deterministic=*/true);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -837,7 +833,7 @@ TEST(CommandBufferThunkTest, DISABLED_DynamicSliceFusionCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence embed_commands;
-  embed_commands.Emplace<GemmCmd>(s0, config.value(), fake_slice_lhs, slice_rhs,
+  embed_commands.Emplace<GemmCmd>(config.value(), fake_slice_lhs, slice_rhs,
                                   slice_out, slice_workspace,
                                   /*deterministic=*/true);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -870,7 +866,7 @@ TEST(CommandBufferThunkTest, DISABLED_DynamicSliceFusionCmd) {
 
   CommandBufferCmdSequence commands;
   commands.Emplace<DynamicSliceFusionCmd>(
-      s0, std::move(embed_executor), arguments, std::move(fake_allocations),
+      std::move(embed_executor), arguments, std::move(fake_allocations),
       offsets, orig_shapes, sliced_shapes, offset_byte_sizes);
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
@@ -982,14 +978,12 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<CublasLtCmd>(
-      s0, CublasLtMatmulThunk(
-              nullptr, config.value(), se::gpu::BlasLt::Epilogue::kDefault, 0,
-              slice_a, slice_b, slice_c, slice_d, BufferAllocation::Slice(),
-              BufferAllocation::Slice(), BufferAllocation::Slice(),
-              BufferAllocation::Slice(), BufferAllocation::Slice(),
-              BufferAllocation::Slice(), BufferAllocation::Slice(),
-              slice_workspace));
+  commands.Emplace<CublasLtCmd>(CublasLtMatmulThunk(
+      nullptr, config.value(), se::gpu::BlasLt::Epilogue::kDefault, 0, slice_a,
+      slice_b, slice_c, slice_d, BufferAllocation::Slice(),
+      BufferAllocation::Slice(), BufferAllocation::Slice(),
+      BufferAllocation::Slice(), BufferAllocation::Slice(),
+      BufferAllocation::Slice(), BufferAllocation::Slice(), slice_workspace));
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -1125,10 +1119,10 @@ TEST(CommandBufferThunkTest, MultipleLaunchCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandBufferCmdSequence commands;
-  commands.Emplace<LaunchCmd>(s0, "AddI32", args, args_access,
+  commands.Emplace<LaunchCmd>("AddI32", args, args_access,
                               LaunchDimensions(1, 4),
                               /*shmem_bytes=*/0);
-  commands.Emplace<LaunchCmd>(s0, "AddI32", args_1, args_access,
+  commands.Emplace<LaunchCmd>("AddI32", args_1, args_access,
                               LaunchDimensions(1, 4),
                               /*shmem_bytes=*/0);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -1248,14 +1242,14 @@ TEST(CommandBufferThunkTest, CaseCmd) {
 
   {  // Case 0: b = a + a
     auto args = {slice_a, slice_a, slice_b};
-    branches_sequence[0].Emplace<LaunchCmd>(s0, "AddI32", args, args_access,
+    branches_sequence[0].Emplace<LaunchCmd>("AddI32", args, args_access,
                                             LaunchDimensions(1, 4),
                                             /*shmem_bytes=*/0);
   }
 
   {  // Case 1: b = b + b
     auto args = {slice_b, slice_b, slice_b};
-    branches_sequence[1].Emplace<LaunchCmd>(s0, "AddI32", args, args_access,
+    branches_sequence[1].Emplace<LaunchCmd>("AddI32", args, args_access,
                                             LaunchDimensions(1, 4),
                                             /*shmem_bytes=*/0);
   }
@@ -1270,7 +1264,7 @@ TEST(CommandBufferThunkTest, CaseCmd) {
 
   // Prepare commands sequence for thunk.
   CommandBufferCmdSequence commands;
-  commands.Emplace<CaseCmd>(s0, slice_i, false, std::move(branches));
+  commands.Emplace<CaseCmd>(slice_i, false, std::move(branches));
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
@@ -1361,7 +1355,7 @@ TEST(CommandBufferThunkTest, WhileCmd) {
 
   // Prepare commands sequence for loop `cond`.
   CommandBufferCmdSequence cond_commands;
-  cond_commands.Emplace<LaunchCmd>(s0, "IncAndCmp", cond_args, cond_args_access,
+  cond_commands.Emplace<LaunchCmd>("IncAndCmp", cond_args, cond_args_access,
                                    LaunchDimensions(1, 1),
                                    /*shmem_bytes=*/0);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -1370,7 +1364,7 @@ TEST(CommandBufferThunkTest, WhileCmd) {
 
   // Prepare commands sequence for loop `body`.
   CommandBufferCmdSequence body_commands;
-  body_commands.Emplace<LaunchCmd>(s0, "AddI32", body_args, body_args_access,
+  body_commands.Emplace<LaunchCmd>("AddI32", body_args, body_args_access,
                                    LaunchDimensions(1, 4),
                                    /*shmem_bytes=*/0);
   TF_ASSERT_OK_AND_ASSIGN(
@@ -1379,7 +1373,7 @@ TEST(CommandBufferThunkTest, WhileCmd) {
 
   // Prepare commands sequence for thunk.
   CommandBufferCmdSequence commands;
-  commands.Emplace<WhileCmd>(s0, slice_pred, std::move(cond_executor),
+  commands.Emplace<WhileCmd>(slice_pred, std::move(cond_executor),
                              std::move(body_executor));
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
@@ -1533,7 +1527,7 @@ TEST(CommandBufferThunkTest, ToStringPrintsNestedThunks) {
   BufferAllocation alloc_a(/*index=*/0, /*size=*/4, /*color=*/0);
   BufferAllocation::Slice slice_a(&alloc_a, /*offset=*/0, /*size=*/4);
   CommandBufferCmdSequence commands;
-  commands.Emplace<Memset32Cmd>(s0, slice_a, int32_t{42});
+  commands.Emplace<Memset32Cmd>(slice_a, int32_t{42});
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -71,9 +71,6 @@ se::StreamExecutor* GpuExecutor() {
   return platform->ExecutorForDevice(0).value();
 }
 
-// Give a short aliases to execution threads.
-constexpr auto s0 = ExecutionStreamId(0);
-
 // Give a short alias to synchronization mode.
 static constexpr auto serialize =
     CommandBufferCmdExecutor::SynchronizationMode::kSerialize;
@@ -147,7 +144,7 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   auto dnn_graph = std::make_unique<se::gpu::CudnnGraph>(std::move(graph));
   CommandBufferCmdSequence commands;
   commands.Emplace<CuDnnCmd>(
-      s0, args, std::make_shared<se::dnn::LazyDnnGraph>(std::move(dnn_graph)));
+      args, std::make_shared<se::dnn::LazyDnnGraph>(std::move(dnn_graph)));
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));


### PR DESCRIPTION
Command buffer now uses DAG to specify dependency, so stream id is totally not used, this PR remove the Stream ID from command buffer implementation.