### PR TITLE
Fix the xla/service/gpu:gpu_aot_compilation_test

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2066,6 +2066,7 @@ xla_cc_test(
     ]),
     deps = if_cuda_is_configured([
         ":nvptx_compiler_impl",
+	"//xla/stream_executor:cuda_platform",
     ]) + if_rocm_is_configured([
         ":amdgpu_compiler_impl",
     ]) + [


### PR DESCRIPTION
A bug was reported in NVIDIA that GpuAotCompilationTest was failing, specifically these two
```
[  FAILED  ] GpuAotCompilationTest.ExportAndLoadExecutable
[  FAILED  ] GpuAotCompilationTest.AotCompilationWithoutGpuDevice
```
with the error message 
```
NOT_FOUND: Could not find registered platform with name: "CUDA". Available platform names are: Interpreter
```

The cause is the cuda platform was not properly registered. Modified the BUILD file to link the cuda platform to make sure it is registered before executing the test.