### PR TITLE
pjrt/ffi: add FFI handler registration API to the FFI PjRt extension

### DIFF
--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -72,10 +72,8 @@ cc_library(
         "//xla/ffi:ffi_api",
         "//xla/ffi/api:c_api",
         "//xla/ffi/api:ffi",
-        "//xla/service:custom_call_target_registry",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -69,8 +69,13 @@ cc_library(
         ":pjrt_c_api_wrapper_impl",
         "//xla/ffi:execution_context",
         "//xla/ffi:type_id_registry",
+        "//xla/ffi:ffi_api",
+        "//xla/ffi/api:c_api",
+        "//xla/ffi/api:ffi",
+        "//xla/service:custom_call_target_registry",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/xla/pjrt/c/pjrt_c_api_ffi_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_ffi_extension.h
@@ -77,8 +77,7 @@ struct PJRT_FFI_Register_Handler_Args {
   size_t struct_size;
   const char* target_name;
   size_t target_name_size;
-  int api_version;  // 0 for an untyped call, 1 -- for typed
-  void* handler;
+  void* handler;  // XLA_FFI_Handler* for typed FFI calls
   const char* platform_name;
   size_t platform_name_size;
   PJRT_FFI_Handler_TraitsBits traits;
@@ -86,6 +85,7 @@ struct PJRT_FFI_Register_Handler_Args {
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_Register_Handler_Args, traits);
 
 // Registers an FFI call handler for a specific platform.
+// Only supports typed FFI handlers (XLA_FFI_Handler*).
 typedef PJRT_Error* PJRT_FFI_Register_Handler(
     PJRT_FFI_Register_Handler_Args* args);
 

--- a/xla/pjrt/c/pjrt_c_api_ffi_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_ffi_extension.h
@@ -69,12 +69,33 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_UserData_Add_Args, user_data);
 // Adds a user data to the execute context.
 typedef PJRT_Error* PJRT_FFI_UserData_Add(PJRT_FFI_UserData_Add_Args* args);
 
+typedef enum PJRT_FFI_Handler_TraitsBits {
+  PJRT_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE = 1u << 0,
+} PJRT_FFI_Handler_TraitsBits;
+
+struct PJRT_FFI_Register_Handler_Args {
+  size_t struct_size;
+  const char* target_name;
+  size_t target_name_size;
+  int api_version;  // 0 for an untyped call, 1 -- for typed
+  void* handler;
+  const char* platform_name;
+  size_t platform_name_size;
+  PJRT_FFI_Handler_TraitsBits traits;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_Register_Handler_Args, traits);
+
+// Registers an FFI call handler for a specific platform.
+typedef PJRT_Error* PJRT_FFI_Register_Handler(
+    PJRT_FFI_Register_Handler_Args* args);
+
 typedef struct PJRT_FFI_Extension {
   PJRT_Extension_Base base;
   PJRT_FFI_TypeID_Register* type_id_register;
   PJRT_FFI_UserData_Add* user_data_add;
+  PJRT_FFI_Register_Handler* register_handler;
 } PJRT_FFI;
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_Extension, user_data_add);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_FFI_Extension, register_handler);
 
 #ifdef __cplusplus
 }

--- a/xla/pjrt/c/pjrt_c_api_ffi_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_ffi_internal.cc
@@ -77,17 +77,17 @@ static PJRT_Error* PJRT_FFI_Register_Handler(
       PJRT_FFI_Register_Handler_Args_STRUCT_SIZE, args->struct_size));
   std::string target_name(args->target_name, args->target_name_size);
   std::string platform_name(args->platform_name, args->platform_name_size);
-  
+
   // Validate that handler is not null
   if (args->handler == nullptr) {
-    return new PJRT_Error{absl::InvalidArgumentError(
-        "FFI handler cannot be null")};
+    return new PJRT_Error{
+        absl::InvalidArgumentError("FFI handler cannot be null")};
   }
-  
+
   // Only support typed FFI handlers
   xla::ffi::Ffi::RegisterStaticHandler(
       xla::ffi::GetXlaFfiApi(), target_name, platform_name,
-      reinterpret_cast<XLA_FFI_Handler*>(args->handler), 
+      reinterpret_cast<XLA_FFI_Handler*>(args->handler),
       static_cast<XLA_FFI_Handler_TraitsBits>(args->traits));
   return nullptr;
 }

--- a/xla/pjrt/c/pjrt_c_api_ffi_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_ffi_internal.cc
@@ -13,16 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "xla/pjrt/c/pjrt_c_api_ffi_internal.h"
+#include <string>
 
 #include "absl/status/status.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "xla/ffi/api/c_api.h"
 #include "xla/ffi/execution_context.h"
 #include "xla/ffi/type_id_registry.h"
+#include "xla/ffi/ffi_api.h"
 #include "xla/pjrt/c/pjrt_c_api.h"
 #include "xla/pjrt/c/pjrt_c_api_ffi_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_helpers.h"
 #include "xla/pjrt/c/pjrt_c_api_wrapper_impl.h"
+#include "xla/service/custom_call_target_registry.h"
 
 namespace pjrt {
 
@@ -68,6 +72,31 @@ static PJRT_Error* PJRT_FFI_UserData_Add(PJRT_FFI_UserData_Add_Args* args) {
   return nullptr;
 }
 
+static PJRT_Error* PJRT_FFI_Register_Handler(
+    PJRT_FFI_Register_Handler_Args* args) {
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_FFI_Register_Handler_Args",
+      PJRT_FFI_Register_Handler_Args_STRUCT_SIZE, args->struct_size));
+  std::string target_name(args->target_name, args->target_name_size);
+  std::string platform_name(args->platform_name, args->platform_name_size);
+  switch (args->api_version) {
+    case 0:
+      xla::CustomCallTargetRegistry::Global()->Register(
+          target_name, args->handler, platform_name);
+      return nullptr;
+    case 1:
+      xla::ffi::Ffi::RegisterStaticHandler(
+          xla::ffi::GetXlaFfiApi(), target_name, platform_name,
+          reinterpret_cast<XLA_FFI_Handler*>(args->handler), static_cast<XLA_FFI_Handler_TraitsBits>(args->traits));
+      return nullptr;
+    default:
+      return new PJRT_Error{absl::UnimplementedError(
+          absl::StrFormat("API version %d not supported for PJRT GPU plugin. "
+                          "Supported versions are 0 and 1.",
+                          args->api_version))};
+  }
+}
+
 PJRT_FFI_Extension CreateFfiExtension(PJRT_Extension_Base* next) {
   return {
       PJRT_Extension_Base{
@@ -77,6 +106,7 @@ PJRT_FFI_Extension CreateFfiExtension(PJRT_Extension_Base* next) {
       },
       /*type_id_register=*/PJRT_FFI_TypeID_Register,
       /*user_data_add=*/PJRT_FFI_UserData_Add,
+      /*register_handler=*/PJRT_FFI_Register_Handler,
   };
 }
 

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -326,11 +326,10 @@ TEST_F(PjrtCApiGpuTest, CreateAndDestroyExecuteContext) {
 }
 
 // Helper functions for FFI handler tests
-static xla::ffi::Error TestTypedHandler() {
-  return xla::ffi::Error::Success();
-}
+static xla::ffi::Error TestTypedHandler() { return xla::ffi::Error::Success(); }
 
-XLA_FFI_DEFINE_HANDLER(kTestTypedHandler, TestTypedHandler, xla::ffi::Ffi::Bind());
+XLA_FFI_DEFINE_HANDLER(kTestTypedHandler, TestTypedHandler,
+                       xla::ffi::Ffi::Bind());
 
 TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerTyped) {
   const PJRT_FFI_Extension* ffi_extension =
@@ -359,7 +358,8 @@ TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerTyped) {
 
   // Verify the handler was registered by checking the FFI registry
   auto registration = xla::ffi::FindHandler(target_name, platform_name);
-  EXPECT_EQ(reinterpret_cast<void*>(registration->bundle.execute), kTestTypedHandler);
+  EXPECT_EQ(reinterpret_cast<void*>(registration->bundle.execute),
+            kTestTypedHandler);
 }
 
 TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerNullHandler) {
@@ -388,7 +388,7 @@ TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerNullHandler) {
   PJRT_Error* error = ffi_extension->register_handler(&register_args);
   ASSERT_NE(error, nullptr);
   EXPECT_THAT(error->status.message(), HasSubstr("FFI handler cannot be null"));
-  
+
   // Clean up the error
   PJRT_Error_Destroy_Args destroy_args;
   destroy_args.struct_size = PJRT_Error_Destroy_Args_STRUCT_SIZE;
@@ -404,7 +404,7 @@ TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerWithDifferentPlatforms) {
   ASSERT_NE(ffi_extension, nullptr);
 
   std::string target_name = "test_multi_platform_handler";
-  
+
   // Register for CUDA platform
   std::string cuda_platform = "cuda";
   PJRT_FFI_Register_Handler_Args cuda_args;
@@ -436,8 +436,10 @@ TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerWithDifferentPlatforms) {
   // Verify both registrations
   auto cuda_registration = xla::ffi::FindHandler(target_name, cuda_platform);
   auto rocm_registration = xla::ffi::FindHandler(target_name, rocm_platform);
-  EXPECT_EQ(reinterpret_cast<void*>(cuda_registration->bundle.execute), kTestTypedHandler);
-  EXPECT_EQ(reinterpret_cast<void*>(rocm_registration->bundle.execute), kTestTypedHandler);
+  EXPECT_EQ(reinterpret_cast<void*>(cuda_registration->bundle.execute),
+            kTestTypedHandler);
+  EXPECT_EQ(reinterpret_cast<void*>(rocm_registration->bundle.execute),
+            kTestTypedHandler);
 }
 
 TEST_F(PjrtCApiGpuTest, DmaMapAndUnmap) {

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -325,6 +325,195 @@ TEST_F(PjrtCApiGpuTest, CreateAndDestroyExecuteContext) {
   api_->PJRT_ExecuteContext_Destroy(&destroy_args);
 }
 
+// Helper functions for FFI handler tests
+static void TestUntypedHandler(void* result, void** args) {
+  // Simple test handler that just sets a known value
+  *static_cast<int*>(result) = 12345;
+}
+
+static xla::ffi::Error TestTypedHandler() {
+  return xla::ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER(kTestTypedHandler, TestTypedHandler, xla::ffi::Ffi::Bind());
+
+TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerUntyped) {
+  const PJRT_FFI_Extension* ffi_extension =
+      pjrt::FindExtension<PJRT_FFI_Extension>(
+          api_, PJRT_Extension_Type::PJRT_Extension_Type_FFI);
+  ASSERT_NE(ffi_extension, nullptr);
+
+  std::string target_name = "test_untyped_handler";
+#ifdef TENSORFLOW_USE_ROCM
+  std::string platform_name = "rocm";
+#else
+  std::string platform_name = "cuda";
+#endif
+
+  PJRT_FFI_Register_Handler_Args register_args;
+  register_args.struct_size = PJRT_FFI_Register_Handler_Args_STRUCT_SIZE;
+  register_args.target_name = target_name.c_str();
+  register_args.target_name_size = target_name.size();
+  register_args.api_version = 0;  // Untyped API
+  register_args.handler = reinterpret_cast<void*>(&TestUntypedHandler);
+  register_args.platform_name = platform_name.c_str();
+  register_args.platform_name_size = platform_name.size();
+  register_args.traits = static_cast<PJRT_FFI_Handler_TraitsBits>(0);
+
+  PJRT_Error* error = ffi_extension->register_handler(&register_args);
+  EXPECT_EQ(error, nullptr);
+
+  // Verify the handler was registered by checking the custom call registry
+  auto* registry = xla::CustomCallTargetRegistry::Global();
+  void* registered_handler = registry->Lookup(target_name, platform_name);
+  EXPECT_EQ(registered_handler, reinterpret_cast<void*>(&TestUntypedHandler));
+}
+
+TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerTyped) {
+  const PJRT_FFI_Extension* ffi_extension =
+      pjrt::FindExtension<PJRT_FFI_Extension>(
+          api_, PJRT_Extension_Type::PJRT_Extension_Type_FFI);
+  ASSERT_NE(ffi_extension, nullptr);
+
+  std::string target_name = "test_typed_handler";
+#ifdef TENSORFLOW_USE_ROCM
+  std::string platform_name = "rocm";
+#else
+  std::string platform_name = "cuda";
+#endif
+
+  PJRT_FFI_Register_Handler_Args register_args;
+  register_args.struct_size = PJRT_FFI_Register_Handler_Args_STRUCT_SIZE;
+  register_args.target_name = target_name.c_str();
+  register_args.target_name_size = target_name.size();
+  register_args.api_version = 1;  // Typed API
+  register_args.handler = reinterpret_cast<void*>(kTestTypedHandler);
+  register_args.platform_name = platform_name.c_str();
+  register_args.platform_name_size = platform_name.size();
+  register_args.traits = PJRT_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE;
+
+  PJRT_Error* error = ffi_extension->register_handler(&register_args);
+  EXPECT_EQ(error, nullptr);
+
+  // Verify the handler was registered by checking the FFI registry
+  auto registration = xla::ffi::FindHandler(target_name, platform_name);
+  EXPECT_EQ(reinterpret_cast<void*>(registration->bundle.execute), kTestTypedHandler);
+}
+
+TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerUnsupportedApiVersion) {
+  const PJRT_FFI_Extension* ffi_extension =
+      pjrt::FindExtension<PJRT_FFI_Extension>(
+          api_, PJRT_Extension_Type::PJRT_Extension_Type_FFI);
+  ASSERT_NE(ffi_extension, nullptr);
+
+  std::string target_name = "test_unsupported_handler";
+#ifdef TENSORFLOW_USE_ROCM
+  std::string platform_name = "rocm";
+#else
+  std::string platform_name = "cuda";
+#endif
+
+  PJRT_FFI_Register_Handler_Args register_args;
+  register_args.struct_size = PJRT_FFI_Register_Handler_Args_STRUCT_SIZE;
+  register_args.target_name = target_name.c_str();
+  register_args.target_name_size = target_name.size();
+  register_args.api_version = 999;  // Unsupported API version
+  register_args.handler = reinterpret_cast<void*>(&TestUntypedHandler);
+  register_args.platform_name = platform_name.c_str();
+  register_args.platform_name_size = platform_name.size();
+  register_args.traits = static_cast<PJRT_FFI_Handler_TraitsBits>(0);
+
+  PJRT_Error* error = ffi_extension->register_handler(&register_args);
+  ASSERT_NE(error, nullptr);
+  EXPECT_THAT(error->status.message(), HasSubstr("API version 999 not supported"));
+  
+  // Clean up the error
+  PJRT_Error_Destroy_Args destroy_args;
+  destroy_args.struct_size = PJRT_Error_Destroy_Args_STRUCT_SIZE;
+  destroy_args.extension_start = nullptr;
+  destroy_args.error = error;
+  api_->PJRT_Error_Destroy(&destroy_args);
+}
+
+TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerWithDifferentPlatforms) {
+  const PJRT_FFI_Extension* ffi_extension =
+      pjrt::FindExtension<PJRT_FFI_Extension>(
+          api_, PJRT_Extension_Type::PJRT_Extension_Type_FFI);
+  ASSERT_NE(ffi_extension, nullptr);
+
+  std::string target_name = "test_multi_platform_handler";
+  
+  // Register for CUDA platform
+  std::string cuda_platform = "cuda";
+  PJRT_FFI_Register_Handler_Args cuda_args;
+  cuda_args.struct_size = PJRT_FFI_Register_Handler_Args_STRUCT_SIZE;
+  cuda_args.target_name = target_name.c_str();
+  cuda_args.target_name_size = target_name.size();
+  cuda_args.api_version = 0;
+  cuda_args.handler = reinterpret_cast<void*>(&TestUntypedHandler);
+  cuda_args.platform_name = cuda_platform.c_str();
+  cuda_args.platform_name_size = cuda_platform.size();
+  cuda_args.traits = static_cast<PJRT_FFI_Handler_TraitsBits>(0);
+
+  PJRT_Error* cuda_error = ffi_extension->register_handler(&cuda_args);
+  EXPECT_EQ(cuda_error, nullptr);
+
+  // Register for ROCM platform
+  std::string rocm_platform = "rocm";
+  PJRT_FFI_Register_Handler_Args rocm_args;
+  rocm_args.struct_size = PJRT_FFI_Register_Handler_Args_STRUCT_SIZE;
+  rocm_args.target_name = target_name.c_str();
+  rocm_args.target_name_size = target_name.size();
+  rocm_args.api_version = 0;
+  rocm_args.handler = reinterpret_cast<void*>(&TestUntypedHandler);
+  rocm_args.platform_name = rocm_platform.c_str();
+  rocm_args.platform_name_size = rocm_platform.size();
+  rocm_args.traits = static_cast<PJRT_FFI_Handler_TraitsBits>(0);
+
+  PJRT_Error* rocm_error = ffi_extension->register_handler(&rocm_args);
+  EXPECT_EQ(rocm_error, nullptr);
+
+  // Verify both registrations
+  auto* registry = xla::CustomCallTargetRegistry::Global();
+  void* cuda_handler = registry->Lookup(target_name, cuda_platform);
+  void* rocm_handler = registry->Lookup(target_name, rocm_platform);
+  EXPECT_EQ(cuda_handler, reinterpret_cast<void*>(&TestUntypedHandler));
+  EXPECT_EQ(rocm_handler, reinterpret_cast<void*>(&TestUntypedHandler));
+}
+
+TEST_F(PjrtCApiGpuTest, FFIRegisterHandlerNullHandler) {
+  const PJRT_FFI_Extension* ffi_extension =
+      pjrt::FindExtension<PJRT_FFI_Extension>(
+          api_, PJRT_Extension_Type::PJRT_Extension_Type_FFI);
+  ASSERT_NE(ffi_extension, nullptr);
+
+  std::string target_name = "test_null_handler";
+#ifdef TENSORFLOW_USE_ROCM
+  std::string platform_name = "rocm";
+#else
+  std::string platform_name = "cuda";
+#endif
+
+  PJRT_FFI_Register_Handler_Args register_args;
+  register_args.struct_size = PJRT_FFI_Register_Handler_Args_STRUCT_SIZE;
+  register_args.target_name = target_name.c_str();
+  register_args.target_name_size = target_name.size();
+  register_args.api_version = 0;
+  register_args.handler = nullptr;  // Null handler
+  register_args.platform_name = platform_name.c_str();
+  register_args.platform_name_size = platform_name.size();
+  register_args.traits = static_cast<PJRT_FFI_Handler_TraitsBits>(0);
+
+  // Should succeed (the registry accepts null handlers)
+  PJRT_Error* error = ffi_extension->register_handler(&register_args);
+  EXPECT_EQ(error, nullptr);
+
+  // Verify null handler was registered
+  auto* registry = xla::CustomCallTargetRegistry::Global();
+  void* registered_handler = registry->Lookup(target_name, platform_name);
+  EXPECT_EQ(registered_handler, nullptr);
+}
+
 TEST_F(PjrtCApiGpuTest, DmaMapAndUnmap) {
   size_t dma_size = 1024 * 1024;
   size_t alignment = 1024 * 1024;


### PR DESCRIPTION
Add support for registering FFI call handlers in the PJRT C API.

These changes enhance the extensibility of the PJRT API by enabling dynamic FFI handler registration, making it easier to support platform-specific custom calls.

--

Discussion from the OpenXLA Discord : https://discord.com/channels/999073994483433573/1397021126680383529
Linked issues : https://github.com/openxla/xla/issues/26928 ; https://github.com/zml/pjrt-artifacts/issues/39

c/ @jparkerh 