### PR TITLE
[XLA:CPU][oneDNN][BugFix] Fix a failing FP16 matmul test

### DIFF
--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -732,6 +732,11 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
               contraction->shape(), new_operands)));
 
       auto backend_config = custom_call->backend_config<BackendConfig>();
+      // SUM post-op does not work for BF16 because element-wise addition
+      // is not allowed due to precision constraints by oneDNN.
+      // Hence, the SUM use case is fused as BINARY_ADD for BF16.
+      // This is verified by checking if the output shape of the
+      // custom call matches the addend shape.
       bool can_fuse_sum =
           (ShapeUtil::Equal(custom_call->shape(), addend->shape()) &&
            addend_user_count == 1 &&

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -206,6 +206,10 @@ TEST_F(MatmulTest, SimpleTestBF16) {
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-4}));
+  // For BF16, we match the optimized HLO with HLO containing
+  // BINARY_ADD instead of SUM as SUM post-op does not work for
+  // BF16 because element-wise addition is not allowed due to
+  // precision constraints by oneDNN.
   MatchOptimizedHlo(matmul_module_str, matmul_rewrite_str_);
 }
 

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -1795,7 +1795,7 @@ TEST_F(MatmulTest, SimpleTestF16WithBiasAndAddFusion) {
   const std::string matmul_module_str =
       CreateMatmulBiasAddAndAddModuleText("f16", "f16");
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-2, 1e-4}));
-  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_add_str_);
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_add_sum_str_);
 }
 
 TEST_F(MatmulTest, SimpleTestF32WithAddFusion_2) {


### PR DESCRIPTION
This PR fixes a failing FP16 matmul test (`SimpleTestF16WithBiasAndAddFusion`). SUM post-op works for FP16 (just not for BF16, as element-wise addition is not allowed by oneDNN for BF16), and the correct optimized HLO must compare with `fused_matmul_bias_add_sum_str_`.