### PR TITLE
[XLA:CPU][oneDNN] Refine conditions for Transpose Folding

### DIFF
--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -997,8 +997,9 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
       // oneDNN does not dispatch to optimized algorithm in these cases, hence
       // avoid folding transposes here.
       // TODO(intel-tf): Reevaluate this condition with future oneDNN releases.
-      if (rank >= 5 || transpose->dimensions()[rank - 1] != rank - 1)
+      if (rank >= 5 || transpose->dimensions()[rank - 1] != rank - 1) {
         return absl::OkStatus();
+      }
       auto backend_config = custom_call->backend_config<BackendConfig>();
       auto dimensions = backend_config->mutable_onednn_matmul_config()
                             ->mutable_result()

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -993,6 +993,12 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
     if (Match(instr,
               m::Copy(&copy, m::Transpose(&transpose,
                                           OneDnnMatmulInstr(&custom_call))))) {
+      auto rank = transpose->dimensions().size();
+      // oneDNN does not dispatch to optimized algorithm in these cases, hence
+      // avoid folding transposes here.
+      // TODO(intel-tf): Reevaluate this condition with future oneDNN releases.
+      if (rank >= 5 || transpose->dimensions()[rank - 1] != rank - 1)
+        return absl::OkStatus();
       auto backend_config = custom_call->backend_config<BackendConfig>();
       auto dimensions = backend_config->mutable_onednn_matmul_config()
                             ->mutable_result()

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -1595,7 +1595,7 @@ TEST_F(MatmulTest, SimpleTestTransposeFusionF16) {
   MatchOptimizedHlo(matmul_module_str, matmul_transpose_rewrite_str_);
 }
 
-TEST_F(MatmulTest, SimpleTestNoTransposeFusion) {
+TEST_F(MatmulTest, SimpleTestNoTransposeFusion1) {
   const char* matmul_module_str = R"(
   ENTRY matmul.test {
     arg0.1 = f32[32,40,40,32] parameter(0), parameter_replication={false}
@@ -1610,6 +1610,24 @@ TEST_F(MatmulTest, SimpleTestNoTransposeFusion) {
                     R"(
     ; CHECK:     transpose(%{{[a-z,A-Z,0-9,_,\.]*}}),
     ; CHECK:     custom_call_target="__onednn$matmul",
+    )");
+}
+
+TEST_F(MatmulTest, SimpleTestNoTransposeFusion2) {
+  const char* matmul_module_str = R"(
+  ENTRY matmul.test {
+    arg0.1 = f32[32,40,40,32] parameter(0), parameter_replication={false}
+    arg0.2 = f32[32,40,32,40] parameter(1), parameter_replication={false}
+    dot.1 = f32[32,40,40,40] dot(arg0.1, arg0.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+    transpose.2 = f32[40,32,40,40] transpose(dot.1), dimensions={1,0,3,2}
+    ROOT copy.2 = f32[40,32,40,40] copy(transpose.2)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str,
+                    R"(
+    ; CHECK:     custom_call_target="__onednn$matmul",
+    ; CHECK:     call(%{{[a-z,A-Z,0-9,_,-]*}})
     )");
 }
 


### PR DESCRIPTION
This PR avoids folding transposes in cases where oneDNN does not dispatch to optimized algorithms. We can revisit these restrictions as and when oneDNN optimizes these cases.

Most likely fixes: https://github.com/jax-ml/jax/issues/29070