### PR TITLE
[XLA:CPU][BugFix] Fix bug in populating oneDNN post-op arguments

### DIFF
--- a/xla/service/cpu/onednn_convolution.cc
+++ b/xla/service/cpu/onednn_convolution.cc
@@ -278,12 +278,6 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnConvolution(
   std::vector<memory::desc> fused_mds;
   std::vector<void*> fused_bufs;
   for (int64_t i = 0; i < num_fused_operands; ++i) {
-    // Skip the MemrefInfo object for the SUM operand, as oneDNN does not
-    // require an input and performs in-place accumulation.
-    if (conv_config.fusions().ops(i) == OneDnnFusionConfig::SUM) {
-      arg_indx++;
-      continue;
-    }
     MemrefInfo operand_minfo(args[arg_indx++]);
     memory::desc mem_desc = operand_minfo.GetOneDnnMemDesc();
     if (mem_desc.get_ndims() == new_res_md.get_ndims()) {

--- a/xla/service/cpu/onednn_matmul.cc
+++ b/xla/service/cpu/onednn_matmul.cc
@@ -306,12 +306,6 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
   std::vector<memory::desc> fused_mds;
   std::vector<void*> fused_bufs;
   for (int64_t i = 0; i < num_fused_operands; ++i) {
-    // Skip the MemrefInfo object for the SUM operand, as oneDNN does not
-    // require an input and performs in-place accumulation.
-    if (matmul_config.fusions().ops(i) == OneDnnFusionConfig::SUM) {
-      arg_indx++;
-      continue;
-    }
     MemrefInfo operand_minfo(args[arg_indx++]);
     fused_mds.push_back(operand_minfo.GetOneDnnMemDesc());
     fused_bufs.push_back(operand_minfo.Data());

--- a/xla/service/cpu/onednn_util.cc
+++ b/xla/service/cpu/onednn_util.cc
@@ -73,6 +73,8 @@ dnnl::post_ops PopulateOneDnnPostOps(
         break;
       case OneDnnFusionConfig::SUM:
         post_ops.append_sum();
+        // oneDNN does not require an input for SUM post-op.
+        fused_operand_idx++;
         break;
       case OneDnnFusionConfig::BIAS: {
         *bias_md = fused_mds.at(fused_operand_idx);


### PR DESCRIPTION
This PR fixes a potential bug where an incorrect argument pod might get used in some long post-op chains.