### PR TITLE
Changed the heading level for the TPU XLA flags section

### DIFF
--- a/docs/flags_guidance.md
+++ b/docs/flags_guidance.md
@@ -45,7 +45,7 @@ Flag                                                          | Description     
 | :---- | :---- | :----- |
 | `xla_dump_to` | String (filepath) | The folder where pre-optimization HLO files and other artifacts will be placed (see [XLA Tools](https://openxla.org/xla/tools)). |
 
-#### TPU XLA flags
+### TPU XLA flags
 | Flag | Type | Notes |
 | :---- | :---- | :----- |
 | `xla_tpu_enable_data_parallel_all_reduce_opt` | Boolean (true/false) | Optimization to increase overlap opportunities for DCN (data center networking) all-reduces used for data parallel sharding. |


### PR DESCRIPTION
Changed the heading level for the TPU XLA flags section so that it is at the same level as the GPU XLA flags section and will be displayed in the right-hand nav.