### PR TITLE
[ROCm] Add bf16 starting from gfx11, bugfix & optimize RocmComputeCapability

### DIFF
--- a/xla/service/algorithm_util.cc
+++ b/xla/service/algorithm_util.cc
@@ -215,7 +215,7 @@ bool IsSupportedByElementalIrEmitter(PrecisionConfig::Algorithm algorithm) {
 // input/output storage types.
 bool IsSupportedDotAlgorithmOnGpu(
     PrecisionConfig::Algorithm algorithm,
-    stream_executor::GpuComputeCapability gpu_compute_capability,
+    const stream_executor::GpuComputeCapability& gpu_compute_capability,
     PrimitiveType input_storage_type, PrimitiveType output_storage_type) {
   // Note: We may want to add some complex types here if people request that.
   const bool is_cuda_ge_ampere =
@@ -236,6 +236,12 @@ bool IsSupportedDotAlgorithmOnGpu(
       std::get<se::RocmComputeCapability>(gpu_compute_capability)
           .gfx9_mi100_or_later();
 
+  const bool is_rocm_bf16 =
+      std::holds_alternative<se::RocmComputeCapability>(
+          gpu_compute_capability) &&
+      std::get<se::RocmComputeCapability>(gpu_compute_capability)
+          .has_bf16_dtype_support();
+
   switch (algorithm) {
     case PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32:
     case PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32_FAST_ACCUM:
@@ -249,7 +255,7 @@ bool IsSupportedDotAlgorithmOnGpu(
       return input_storage_type == F16 &&
              (output_storage_type == F16 || output_storage_type == F32);
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32:
-      if (!is_cuda_ge_ampere && !is_rocm_mi100_and_above) return false;
+      if (!is_cuda_ge_ampere && !is_rocm_bf16) return false;
       switch (input_storage_type) {
         case BF16:
           return output_storage_type == BF16 || output_storage_type == F32;
@@ -261,7 +267,7 @@ bool IsSupportedDotAlgorithmOnGpu(
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X3:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X6:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X9:
-      return (is_cuda_ge_ampere || is_rocm_mi100_and_above) &&
+      return (is_cuda_ge_ampere || is_rocm_bf16) &&
              input_storage_type == F32 && output_storage_type == F32;
     case PrecisionConfig::ALG_DOT_TF32_TF32_F32_X3:
     case PrecisionConfig::ALG_DOT_TF32_TF32_F32:

--- a/xla/service/algorithm_util.h
+++ b/xla/service/algorithm_util.h
@@ -87,7 +87,7 @@ bool IsSupportedByElementalIrEmitter(PrecisionConfig::Algorithm algorithm);
 // input/output storage types.
 bool IsSupportedDotAlgorithmOnGpu(
     PrecisionConfig::Algorithm algorithm,
-    stream_executor::GpuComputeCapability gpu_compute_capability,
+    const stream_executor::GpuComputeCapability& gpu_compute_capability,
     PrimitiveType input_storage_type, PrimitiveType output_storage_type);
 
 }  // namespace algorithm_util

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -186,6 +186,9 @@ class RocmComputeCapability {
 
   bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
 
+  /// \brief Invalid gfx id for default gcn_arch_name_ value and testing
+  static constexpr absl::string_view kInvalidGfx = "gfx000";
+
  private:
   /// \brief Takes one or more arrays of string-like objects and tests if the
   /// result of `gfx_version()` matches to any string in any of the arrays.
@@ -206,7 +209,7 @@ class RocmComputeCapability {
     });
   }
 
-  std::string gcn_arch_name_ = "gfx000";  // default to invalid arch.
+  std::string gcn_arch_name_{kInvalidGfx};  // default to invalid arch.
 };
 
 using GpuComputeCapability =

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -143,10 +143,19 @@ class RocmComputeCapability {
                                                     "gfx1151"};
   bool gfx11_apu() const { return IsThisGfxInAnyList(kGfx11Apu); }
 
+  static constexpr absl::string_view kGfx11Rx7900[] = {"gfx1100", "gfx1101",
+                                                       "gfx1102"};
+  bool gfx11_rx7900() const {
+    // TODO(AMD/TF): instead of this, other gfx11*() methods might be better
+    return IsThisGfxInAnyList(kGfx11Rx7900);
+  }
+
   bool gfx12() const { return absl::StartsWith(gfx_version(), "gfx12"); }
 
   static constexpr absl::string_view kGfx12Discrete[] = {"gfx1200", "gfx1201"};
   bool gfx12_discrete() const { return IsThisGfxInAnyList(kGfx12Discrete); }
+
+  bool gfx12_rx8900() const { return gfx12_discrete(); }
 
   bool has_nhwc_layout_support() const { return gfx9_mi100_or_later(); }
 

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -20,8 +20,10 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_DEVICE_DESCRIPTION_H_
 #define XLA_STREAM_EXECUTOR_DEVICE_DESCRIPTION_H_
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -30,6 +32,7 @@ limitations under the License.
 
 #include "absl/algorithm/container.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
@@ -55,87 +58,6 @@ class RocmComputeCapability {
 
   std::string gcn_arch_name() const { return gcn_arch_name_; }
 
-  std::string gfx_version() const {
-    std::vector<std::string> tokens = absl::StrSplit(gcn_arch_name_, ':');
-    return tokens[0];
-  }
-
-  bool is_supported_gfx_version() const {
-    return absl::c_count(kSupportedGfxVersions, gfx_version()) != 0;
-  }
-
-  std::string supported_gfx_versions_str() const {
-    return absl::StrJoin(kSupportedGfxVersions, ", ");
-  }
-
-  bool gfx9_mi100() const { return gfx_version() == "gfx908"; }
-
-  bool gfx9_mi200() const { return gfx_version() == "gfx90a"; }
-
-  bool gfx9_mi300() const { return gfx_version() == "gfx942"; }
-
-  bool gfx9_mi350() const { return gfx_version() == "gfx950"; }
-
-  bool gfx9_mi300_series() const { return gfx9_mi300() || gfx9_mi350(); }
-
-  bool gfx9_mi100_or_later() const {
-    static constexpr absl::string_view kList[] = {"gfx908", "gfx90a", "gfx942",
-                                                  "gfx950"};
-    return absl::c_count(kList, gfx_version()) != 0;
-  }
-
-  bool gfx9_mi200_or_later() const {
-    static constexpr absl::string_view kList[] = {"gfx90a", "gfx942", "gfx950"};
-    return absl::c_count(kList, gfx_version()) != 0;
-  }
-
-  bool gfx10_rx68xx() const { return gfx_version() == "gfx1030"; }
-
-  bool gfx10_rx69xx() const { return gfx_version() == "gfx1030"; }
-
-  bool gfx11() const { return gfx_version().find("gfx11"); }
-
-  bool gfx1200() const { return gfx_version() == "gfx1200"; }
-
-  bool gfx1201() const { return gfx_version() == "gfx1201"; }
-
-  bool has_nhwc_layout_support() const { return gfx9_mi100_or_later(); }
-
-  bool has_bf16_dtype_support() const { return gfx9_mi100_or_later(); }
-
-  bool has_fast_fp16_support() const {
-    return gfx9_mi100_or_later() || gfx10_rx68xx() || gfx10_rx69xx() || gfx11();
-  }
-
-  bool has_mfma_instr_support() const { return gfx9_mi100_or_later(); }
-
-  bool has_amd_matrix_core() const {
-    return (gfx9_mi100_or_later() || gfx_version().find("gfx11") ||
-            gfx_version().find("gfx12"));
-  }
-
-  bool has_packed_fp16_atomics_support() const { return gfx9_mi100_or_later(); }
-
-  bool has_packed_bf16_atomics_support() const { return gfx9_mi300_series(); }
-
-  bool fence_before_barrier() const {
-    return gfx_version() != "gfx900" && gfx_version() != "gfx906";
-  }
-
-  bool has_hipblaslt() const {
-    return gfx9_mi200_or_later() || gfx1200() || gfx1201();
-  }
-
-  bool has_fp8_support() const {
-    return has_ocp_fp8_support() || has_nanoo_fp8_support();
-  }
-
-  bool has_ocp_fp8_support() const {
-    return gfx1200() || gfx1201() || gfx9_mi350();
-  }
-
-  bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
-
   std::string ToString() const { return gcn_arch_name(); }
 
   RocmComputeCapabilityProto ToProto() const {
@@ -148,20 +70,139 @@ class RocmComputeCapability {
     return gcn_arch_name_ == other.gcn_arch_name_;
   }
 
- private:
-  std::string gcn_arch_name_ = "gfx000";  // default to invalid arch.
+  std::string gfx_version() const {
+    //  std::strchr() is faster for the case than std::string::find()
+    const char *const p_colon = std::strchr(gcn_arch_name_.c_str(), ':');
+    if (nullptr == p_colon) {
+      return gcn_arch_name_;  // likely it's the default invalid value
+    }
+    return std::string(gcn_arch_name_.c_str(), p_colon);
+  }
 
+  // note, while there's no particular reason to make the lists public, it won't
+  // hurt since they are immutable, but keeping them close to methods simplifies
+  // maintanance.
   static constexpr absl::string_view kSupportedGfxVersions[]{
       "gfx900",   // MI25
       "gfx906",   // MI50 / MI60
       "gfx908",   // MI100
       "gfx90a",   // MI200
       "gfx942",   // MI300
-      "gfx950",   // MI355
+      "gfx950",   // MI350
       "gfx1030",  // RX68xx / RX69xx
       "gfx1100",  // RX7900
-      "gfx1101", "gfx1200", "gfx1201",
+      "gfx1101",  // RX7700 / RX7800
+      "gfx1103", "gfx1150", "gfx1151", "gfx1200", "gfx1201",
   };
+
+  bool is_supported_gfx_version() const {
+    return IsThisGfxInAnyList(kSupportedGfxVersions);
+  }
+
+  std::string supported_gfx_versions_str() const {
+    return absl::StrJoin(kSupportedGfxVersions, ", ");
+  }
+
+  bool gfx9_mi100() const { return gfx_version() == "gfx908"; }
+
+  static constexpr absl::string_view kMI100Series[] = {"gfx908"};
+
+  bool gfx9_mi200() const { return gfx_version() == "gfx90a"; }
+
+  static constexpr absl::string_view kMI200Series[] = {"gfx90a"};
+
+  bool gfx9_mi300() const { return gfx_version() == "gfx942"; }
+
+  bool gfx9_mi350() const { return gfx_version() == "gfx950"; }
+
+  static constexpr absl::string_view kMI300Series[] = {"gfx942", "gfx950"};
+  bool gfx9_mi300_series() const { return IsThisGfxInAnyList(kMI300Series); }
+
+  bool gfx9_mi100_or_later() const {
+    return IsThisGfxInAnyList(kMI300Series, kMI200Series, kMI100Series);
+  }
+
+  bool gfx9_mi200_or_later() const {
+    return IsThisGfxInAnyList(kMI300Series, kMI200Series);
+  }
+
+  bool gfx10_rx68xx() const { return gfx_version() == "gfx1030"; }
+
+  bool gfx10_rx69xx() const { return gfx_version() == "gfx1030"; }
+
+  bool gfx11() const { return absl::StartsWith(gfx_version(), "gfx11"); }
+
+  static constexpr absl::string_view kGfx11Discrete[] = {"gfx1100", "gfx1101"};
+  bool gfx11_discrete() const { return IsThisGfxInAnyList(kGfx11Discrete); }
+
+  static constexpr absl::string_view kGfx11Apu[] = {"gfx1103", "gfx1150",
+                                                    "gfx1151"};
+  bool gfx11_apu() const { return IsThisGfxInAnyList(kGfx11Apu); }
+
+  bool gfx12() const { return absl::StartsWith(gfx_version(), "gfx12"); }
+
+  static constexpr absl::string_view kGfx12Discrete[] = {"gfx1200", "gfx1201"};
+  bool gfx12_discrete() const { return IsThisGfxInAnyList(kGfx12Discrete); }
+
+  bool has_nhwc_layout_support() const { return gfx9_mi100_or_later(); }
+
+  bool has_bf16_dtype_support() const {
+    return gfx9_mi100_or_later() || gfx12() || gfx11();
+  }
+
+  bool has_fast_fp16_support() const {
+    return gfx9_mi100_or_later() || gfx11() || gfx10_rx68xx() || gfx10_rx69xx();
+  }
+
+  bool has_mfma_instr_support() const { return gfx9_mi100_or_later(); }
+
+  bool has_amd_matrix_core() const {
+    return gfx9_mi100_or_later() || gfx12() || gfx11();
+  }
+
+  bool has_packed_fp16_atomics_support() const { return gfx9_mi100_or_later(); }
+
+  bool has_packed_bf16_atomics_support() const { return gfx9_mi300_series(); }
+
+  bool fence_before_barrier() const {
+    static constexpr absl::string_view kList[] = {"gfx900", "gfx906"};
+    return !IsThisGfxInAnyList(kList);
+  }
+
+  bool has_hipblaslt() const {
+    return IsThisGfxInAnyList(kMI300Series, kMI200Series, kGfx12Discrete,
+                              kGfx11Discrete, kGfx11Apu);
+  }
+
+  bool has_fp8_support() const {
+    return has_ocp_fp8_support() || has_nanoo_fp8_support();
+  }
+
+  bool has_ocp_fp8_support() const { return gfx9_mi350() || gfx12_discrete(); }
+
+  bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
+
+ private:
+  /// \brief Takes one or more arrays of string-like objects and tests if the
+  /// result of `gfx_version()` matches to any string in any of the arrays.
+  template <typename... ArrayOfStrings>
+  bool IsThisGfxInAnyList(ArrayOfStrings &&...arr) const {
+    static_assert(sizeof...(arr) >= 1);
+    const auto gfx = gfx_version();
+    return (implIsThisGfxInAnyList(std::begin(arr), std::end(arr), gfx) || ...);
+  }
+
+  /// \brief Template-less implementation of IsThisGfxInAnyList().
+  /// \warning Don't use directly!
+  bool implIsThisGfxInAnyList(const absl::string_view *beg,
+                              const absl::string_view *end,
+                              const std::string &gfx) const {
+    return std::any_of(beg, end, [&gfx = gfx](const absl::string_view &s) {
+      return gfx == s;
+    });
+  }
+
+  std::string gcn_arch_name_ = "gfx000";  // default to invalid arch.
 };
 
 using GpuComputeCapability =

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -70,6 +70,10 @@ class RocmComputeCapability {
     return gcn_arch_name_ == other.gcn_arch_name_;
   }
 
+  bool operator!=(const RocmComputeCapability &other) const {
+    return !this->operator==(other);
+  }
+
   std::string gfx_version() const {
     //  std::strchr() is faster for the case than std::string::find()
     const char *const p_colon = std::strchr(gcn_arch_name_.c_str(), ':');

--- a/xla/stream_executor/device_description_test.cc
+++ b/xla/stream_executor/device_description_test.cc
@@ -88,7 +88,7 @@ TEST(RocmComputeCapability, IsSupportedGfxVersion) {
 }
 
 TEST(RocmComputeCapability, Accessors) {
-  // there's not much point in testing individual trivial implementations as 
+  // there's not much point in testing individual trivial implementations as
   // this require to put here the whole knowledge of RocmComputeCapability.
   // This will make maintanance of the class unnecessary more painful.
   // Testing only the most complicated methods, basically IsThisGfxInAnyList().
@@ -137,7 +137,7 @@ TEST(RocmComputeCapability, Accessors) {
   EXPECT_TRUE(RocmComputeCapability{"gfx90a"}.has_hipblaslt());
   EXPECT_TRUE(RocmComputeCapability{"gfx1200"}.has_hipblaslt());
   EXPECT_TRUE(RocmComputeCapability{"gfx1100"}.has_hipblaslt());
-  EXPECT_TRUE(RocmComputeCapability{"gfx1103"}.has_hipblaslt());  
+  EXPECT_TRUE(RocmComputeCapability{"gfx1103"}.has_hipblaslt());
 }
 
 }  // namespace

--- a/xla/stream_executor/device_description_test.cc
+++ b/xla/stream_executor/device_description_test.cc
@@ -39,33 +39,9 @@ TEST(DeviceDescription, DefaultConstruction) {
 // class RocmComputeCapability tests. To be moved to a separate file once the
 // class is refactored out of device_description.h
 
-namespace Stealer {
-// We need a private data member stealer for the default constuction test.
-// This assumes two things: that there's a `gcn_arch_name_` data member
-// and it's type is std::string. Obviously, a compiler will take care about
-// these assumptions from a technical view and a possibility of change of the
-// semantic of the variable is negligible. Beyond everything, these are tests,
-// so it'll fail first should assumptions go wrong.
-
-struct RocmComputeCapabilityMember {
-  using type = std::string RocmComputeCapability::*;
-  friend type get(RocmComputeCapabilityMember);
-};
-
-template <typename Tag, typename Tag::type M>
-struct Robber {
-  friend typename Tag::type get(Tag) { return M; }
-};
-
-// explicit template instantiation is excluded from access rules check.
-template struct Robber<RocmComputeCapabilityMember,
-                       &RocmComputeCapability::gcn_arch_name_>;
-}  // namespace Stealer
-
 TEST(RocmComputeCapability, GfxVersion) {
   RocmComputeCapability rcc0;  // default constructed
-  auto default_gcn_arch_name =
-      rcc0.*get(Stealer::RocmComputeCapabilityMember());
+  auto default_gcn_arch_name = RocmComputeCapability::kInvalidGfx;
   // failure is serious enough to not expect the rest could pass
   ASSERT_EQ(default_gcn_arch_name, rcc0.gfx_version());
 

--- a/xla/stream_executor/device_description_test.cc
+++ b/xla/stream_executor/device_description_test.cc
@@ -14,6 +14,8 @@ limitations under the License.
 ==============================================================================*/
 #include "xla/stream_executor/device_description.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 #include "xla/stream_executor/semantic_version.h"
 
@@ -31,6 +33,111 @@ TEST(DeviceDescription, DefaultConstruction) {
   EXPECT_EQ(desc.driver_version(), kZeroVersion);
   EXPECT_EQ(desc.runtime_version(), kZeroVersion);
   EXPECT_EQ(desc.pci_bus_id(), "<undefined>");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// class RocmComputeCapability tests. To be moved to a separate file once the
+// class is refactored out of device_description.h
+
+namespace Stealer {
+// We need a private data member stealer for the default constuction test.
+// This assumes two things: that there's a `gcn_arch_name_` data member
+// and it's type is std::string. Obviously, a compiler will take care about
+// these assumptions from a technical view and a possibility of change of the
+// semantic of the variable is negligible. Beyond everything, these are tests,
+// so it'll fail first should assumptions go wrong.
+
+struct RocmComputeCapabilityMember {
+  using type = std::string RocmComputeCapability::*;
+  friend type get(RocmComputeCapabilityMember);
+};
+
+template <typename Tag, typename Tag::type M>
+struct Robber {
+  friend typename Tag::type get(Tag) { return M; }
+};
+
+// explicit template instantiation is excluded from access rules check.
+template struct Robber<RocmComputeCapabilityMember,
+                       &RocmComputeCapability::gcn_arch_name_>;
+}  // namespace Stealer
+
+TEST(RocmComputeCapability, GfxVersion) {
+  RocmComputeCapability rcc0;  // default constructed
+  auto default_gcn_arch_name =
+      rcc0.*get(Stealer::RocmComputeCapabilityMember());
+  // failure is serious enough to not expect the rest could pass
+  ASSERT_EQ(default_gcn_arch_name, rcc0.gfx_version());
+
+  const std::string gfx{"some_string"};
+  std::string gcn_arch{gfx};
+  ASSERT_EQ(gfx, RocmComputeCapability{gcn_arch}.gfx_version());
+
+  gcn_arch.append(":tail");
+  ASSERT_EQ(gfx, RocmComputeCapability{gcn_arch}.gfx_version());
+
+  gcn_arch.append(":even_longer");
+  ASSERT_EQ(gfx, RocmComputeCapability{gcn_arch}.gfx_version());
+}
+
+TEST(RocmComputeCapability, IsSupportedGfxVersion) {
+  ASSERT_TRUE(RocmComputeCapability{"gfx900"}.is_supported_gfx_version());
+  ASSERT_TRUE(RocmComputeCapability{"gfx1201"}.is_supported_gfx_version());
+  ASSERT_TRUE(RocmComputeCapability{"gfx942"}.is_supported_gfx_version());
+  ASSERT_FALSE(RocmComputeCapability{"some_string"}.is_supported_gfx_version());
+}
+
+TEST(RocmComputeCapability, Accessors) {
+  // there's not much point in testing individual trivial implementations as 
+  // this require to put here the whole knowledge of RocmComputeCapability.
+  // This will make maintanance of the class unnecessary more painful.
+  // Testing only the most complicated methods, basically IsThisGfxInAnyList().
+  EXPECT_TRUE(RocmComputeCapability{"gfx942"}.gfx9_mi300_series());
+  EXPECT_FALSE(RocmComputeCapability{"gfx942x"}.gfx9_mi300_series());
+  EXPECT_TRUE(RocmComputeCapability{"gfx950"}.gfx9_mi300_series());
+  EXPECT_FALSE(RocmComputeCapability{"gfx951"}.gfx9_mi300_series());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx942"}.gfx9_mi200_or_later());
+  EXPECT_FALSE(RocmComputeCapability{"gfx942x"}.gfx9_mi200_or_later());
+  EXPECT_TRUE(RocmComputeCapability{"gfx950"}.gfx9_mi200_or_later());
+  EXPECT_FALSE(RocmComputeCapability{"gfx951"}.gfx9_mi200_or_later());
+  EXPECT_TRUE(RocmComputeCapability{"gfx90a"}.gfx9_mi200_or_later());
+  EXPECT_FALSE(RocmComputeCapability{"gfx90x"}.gfx9_mi200_or_later());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx942"}.gfx9_mi100_or_later());
+  EXPECT_FALSE(RocmComputeCapability{"gfx942x"}.gfx9_mi100_or_later());
+  EXPECT_TRUE(RocmComputeCapability{"gfx950"}.gfx9_mi100_or_later());
+  EXPECT_FALSE(RocmComputeCapability{"gfx951"}.gfx9_mi100_or_later());
+  EXPECT_TRUE(RocmComputeCapability{"gfx90a"}.gfx9_mi100_or_later());
+  EXPECT_FALSE(RocmComputeCapability{"gfx90x"}.gfx9_mi100_or_later());
+  EXPECT_TRUE(RocmComputeCapability{"gfx908"}.gfx9_mi100_or_later());
+  EXPECT_FALSE(RocmComputeCapability{"gfx907"}.gfx9_mi100_or_later());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx11"}.gfx11());
+  EXPECT_FALSE(RocmComputeCapability{"gfx10"}.gfx11());
+  EXPECT_FALSE(RocmComputeCapability{"gfx12"}.gfx11());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1100"}.gfx11());
+  EXPECT_TRUE(RocmComputeCapability{"gfx11xx"}.gfx11());
+  EXPECT_TRUE(RocmComputeCapability{"gfx11xxblabla"}.gfx11());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx12"}.gfx12());
+  EXPECT_FALSE(RocmComputeCapability{"gfx11"}.gfx12());
+  EXPECT_FALSE(RocmComputeCapability{"gfx13"}.gfx12());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1200"}.gfx12());
+  EXPECT_TRUE(RocmComputeCapability{"gfx12xx"}.gfx12());
+  EXPECT_TRUE(RocmComputeCapability{"gfx12xxblabla"}.gfx12());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx12"}.fence_before_barrier());
+  EXPECT_TRUE(RocmComputeCapability{"anything"}.fence_before_barrier());
+  EXPECT_FALSE(RocmComputeCapability{"gfx900"}.fence_before_barrier());
+  EXPECT_FALSE(RocmComputeCapability{"gfx906"}.fence_before_barrier());
+
+  EXPECT_FALSE(RocmComputeCapability{"gfx900"}.has_hipblaslt());
+  EXPECT_TRUE(RocmComputeCapability{"gfx942"}.has_hipblaslt());
+  EXPECT_TRUE(RocmComputeCapability{"gfx90a"}.has_hipblaslt());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1200"}.has_hipblaslt());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1100"}.has_hipblaslt());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1103"}.has_hipblaslt());  
 }
 
 }  // namespace


### PR DESCRIPTION
* Bugfix and improve device_description.h::RocmComputeCompatibility

* Enable ALG_DOT_BF16* on rocm with HW support
