### PR TITLE
Add a new HloModule clone API that can return clone context

### DIFF
--- a/xla/hlo/ir/hlo_module.cc
+++ b/xla/hlo/ir/hlo_module.cc
@@ -1245,9 +1245,6 @@ void CopyUniqueIds(const HloModule& source, HloModule* clone,
 
 void HloModule::Clone(const std::string& suffix, HloCloneContext* context,
                       std::optional<const HloModuleConfig> config) const {
-  CHECK(context != nullptr) << "HloCloneContext pointer must not be null.";
-  CHECK(context->module() != nullptr)
-      << "HloCloneContext must have a valid module set.";
   auto module = context->module();
   if (entry_computation_) {
     auto cloned_computation = entry_computation_->Clone(suffix, context);

--- a/xla/hlo/ir/hlo_module.cc
+++ b/xla/hlo/ir/hlo_module.cc
@@ -1245,6 +1245,9 @@ void CopyUniqueIds(const HloModule& source, HloModule* clone,
 
 void HloModule::Clone(const std::string& suffix, HloCloneContext* context,
                       std::optional<const HloModuleConfig> config) const {
+  CHECK(context != nullptr) << "HloCloneContext pointer must not be null.";
+  CHECK(context->module() != nullptr)
+      << "HloCloneContext must have a valid module set.";
   auto module = context->module();
   if (entry_computation_) {
     auto cloned_computation = entry_computation_->Clone(suffix, context);

--- a/xla/hlo/ir/hlo_module.h
+++ b/xla/hlo/ir/hlo_module.h
@@ -150,6 +150,13 @@ class HloModule {
       const std::string& suffix = "clone",
       std::optional<const HloModuleConfig> config = std::nullopt) const;
 
+  // Performs a deep clone of the module and also returns clone context with
+  // the cloned object mappings.
+  std::pair<std::unique_ptr<HloModule>, std::unique_ptr<HloCloneContext>>
+  CloneWithContext(
+      const std::string& suffix,
+      std::optional<const HloModuleConfig> config = std::nullopt) const;
+
   // Performs a deep clone of the computation, by recursively cloning all
   // the called computations as well. If the clone context is specified, it
   // will be populated with the cloned object mappings.
@@ -710,6 +717,11 @@ class HloModule {
   HloComputation* AddComputationInternal(
       std::unique_ptr<HloComputation> computation, bool is_entry,
       bool uniquify_identifiers, bool preserve_entry_layouts);
+
+  // Performs a deep clone of current module to context->module, and populate
+  // the context with the cloned object mappings.
+  void Clone(const std::string& suffix, HloCloneContext* context,
+             std::optional<const HloModuleConfig> config) const;
 
   std::string name_;
 


### PR DESCRIPTION
This PR adds a new API `CloneWithContext` to `HloModule`, so user can get the mapped instruction/computation inside cloned HloModule. 

This PR is mostly a refactor of existing implementation, so current tests should cover all its functionality. 
