### PR TITLE
[XLA:GPU] Add GetInlinedModule helper function in call_inliner

### DIFF
--- a/xla/service/call_inliner.cc
+++ b/xla/service/call_inliner.cc
@@ -30,7 +30,9 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
+#include "absl/algorithm/container.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_opcode.h"
@@ -127,8 +129,8 @@ class SubcomputationInsertionVisitor : public DfsHloVisitorWithDefault {
             call_instruction_name =
                 call_original_value->leaf_begin()->second->instruction_name;
           }
-          absl::StrAppend(&original_array->instruction_name, "/",
-                          call_instruction_name);
+          original_array->instruction_name = absl::StrCat(
+              call_instruction_name, "/", original_array->instruction_name);
         }
       }
     }
@@ -344,8 +346,10 @@ bool CallInliner::ShouldInline(const CallGraph& call_graph,
 
 absl::StatusOr<bool> CallInliner::InlineAndLegalize(
     const CallGraph& call_graph, HloComputation* computation,
-    absl::Span<HloInstruction* const> instruction_sequence) const {
+    absl::Span<HloInstruction* const> instruction_sequence,
+    std::optional<InlinedInstructionMap*> inline_map) {
   HloModule* module = computation->parent();
+  VLOG(0) << "module has schedule: " << module->has_schedule();
   bool did_node_mutate = false;
   std::vector<HloInstruction*> inlined_instructions;
   for (HloInstruction* instruction : instruction_sequence) {
@@ -357,23 +361,29 @@ absl::StatusOr<bool> CallInliner::InlineAndLegalize(
       // The caller instruction will get removed after inlining. Record the
       // callee computation beforehand, so we can find its schedule.
       HloComputation* callee = instruction->to_apply();
-      TF_ASSIGN_OR_RETURN(CallInliner::InlinedInstructionMap inline_map,
-                          Inline(instruction));
+      TF_ASSIGN_OR_RETURN(
+          CallInliner::InlinedInstructionMap inline_map_cur_call,
+          Inline(instruction));
       if (module->has_schedule()) {
         for (HloInstruction* inlined_instruction :
              module->schedule().sequence(callee).instructions()) {
           // Parameters were already added to sequence as operands to the
           // call.
           if (inlined_instruction->opcode() != HloOpcode::kParameter) {
-            inlined_instructions.push_back(inline_map[inlined_instruction]);
+            inlined_instructions.push_back(
+                inline_map_cur_call[inlined_instruction]);
           }
         }
       }
       if (update_domain_) {
         HloDomainIsolator isolator([]() { return ShardingDomainCreator{}; });
-        for (const auto& [call_inst, inlined_inst] : inline_map) {
+        for (const auto& [call_inst, inlined_inst] : inline_map_cur_call) {
           TF_RETURN_IF_ERROR(isolator.UpdateDomains(inlined_inst).status());
         }
+      }
+      if (inline_map.has_value()) {
+        inline_map.value()->insert(inline_map_cur_call.begin(),
+                                   inline_map_cur_call.end());
       }
       did_node_mutate = true;
     } else if (module->has_schedule()) {
@@ -395,8 +405,8 @@ absl::StatusOr<bool> CallInliner::InlineAndLegalize(
   return did_node_mutate;
 }
 
-absl::StatusOr<bool> CallInliner::Run(
-    HloModule* module,
+absl::StatusOr<bool> CallInliner::RunWithInlineMap(
+    HloModule* module, std::optional<InlinedInstructionMap*> inline_map,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   std::unique_ptr<CallGraph> call_graph = CallGraph::Build(module);
   // Because call graph nodes are visited in post-order (callees before callers)
@@ -414,12 +424,12 @@ absl::StatusOr<bool> CallInliner::Run(
               HloInstructionSequence& sequence =
                   module->schedule().GetOrCreateSequence(node.computation());
               return InlineAndLegalize(*call_graph, node.computation(),
-                                       sequence.instructions());
+                                       sequence.instructions(), inline_map);
             }
 
             return InlineAndLegalize(
                 *call_graph, node.computation(),
-                node.computation()->MakeInstructionPostOrder());
+                node.computation()->MakeInstructionPostOrder(), inline_map);
           }));
   if (did_mutate) {
     // Run DCE to remove called computations which are now becoming unused.
@@ -433,6 +443,51 @@ absl::StatusOr<bool> CallInliner::Run(
     }
   }
   return did_mutate;
+}
+
+absl::StatusOr<bool> CallInliner::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  return RunWithInlineMap(module, std::nullopt, execution_threads);
+}
+
+bool IsInlineableComputation(HloComputation* computation) {
+  auto is_inlineable_call_op = [](HloInstruction* instruction) {
+    bool prerequisite = instruction->opcode() == HloOpcode::kCall &&
+                        !instruction->has_backend_config() &&
+                        !instruction->parent()->IsAsyncComputation();
+    if (!prerequisite || !InlineInstruction(instruction)) {
+      return false;
+    }
+    return true;
+  };
+  return absl::c_any_of(computation->instructions(), is_inlineable_call_op);
+}
+
+const HloInstruction* InlinedModule::get_inlined_inst(
+    const HloInstruction* inst) {
+  auto it = clone_context->cloned_instructions().find(inst);
+  if (it != clone_context->cloned_instructions().end()) {
+    auto it2 = clone_inlined_map.find(it->second);
+    if (it2 != clone_inlined_map.end()) {
+      return it2->second;
+    } else {
+      return it->second;
+    }
+  }
+  return nullptr;
+}
+
+absl::StatusOr<InlinedModule> GetInlinedModule(HloModule* module) {
+  auto [cloned_module, clone_context] =
+      module->CloneWithContext("inline", module->config());
+  CallInliner::InlinedInstructionMap clone_inlined_map;
+  CallInliner inliner;
+  TF_RETURN_IF_ERROR(
+      inliner.RunWithInlineMap(cloned_module.get(), &clone_inlined_map, {})
+          .status());
+  return InlinedModule{std::move(cloned_module), std::move(clone_context),
+                       std::move(clone_inlined_map)};
 }
 
 }  // namespace xla

--- a/xla/service/call_inliner.cc
+++ b/xla/service/call_inliner.cc
@@ -349,7 +349,6 @@ absl::StatusOr<bool> CallInliner::InlineAndLegalize(
     absl::Span<HloInstruction* const> instruction_sequence,
     std::optional<InlinedInstructionMap*> inline_map) {
   HloModule* module = computation->parent();
-  VLOG(0) << "module has schedule: " << module->has_schedule();
   bool did_node_mutate = false;
   std::vector<HloInstruction*> inlined_instructions;
   for (HloInstruction* instruction : instruction_sequence) {

--- a/xla/service/call_inliner.h
+++ b/xla/service/call_inliner.h
@@ -101,7 +101,7 @@ class CallInliner : public HloModulePass {
       should_inline_;
 };
 
-// Returns true if the computation has instructioin that is inlinable.
+// Returns true if the computation has instructions that are inlinable.
 bool IsInlineableComputation(HloComputation* computation);
 
 struct InlinedModule {
@@ -111,8 +111,8 @@ struct InlinedModule {
   const HloInstruction* get_inlined_inst(const HloInstruction* inst);
 };
 
-// Given a module, this function first clone the module, then inline the module,
-// and return the inlined module, clone context and inlined map in InlinedModule
+// Given a module, this function first clones the module, then inlines the module,
+// and returns the inlined module, clone context and inlined map in InlinedModule
 // struct.
 absl::StatusOr<InlinedModule> GetInlinedModule(HloModule* module);
 

--- a/xla/service/call_inliner.h
+++ b/xla/service/call_inliner.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
+#include "xla/hlo/ir/hlo_clone_context.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/pass/hlo_pass_interface.h"
@@ -71,6 +72,10 @@ class CallInliner : public HloModulePass {
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
 
+  absl::StatusOr<bool> RunWithInlineMap(
+      HloModule* module, std::optional<InlinedInstructionMap*> inline_map,
+      const absl::flat_hash_set<absl::string_view>& execution_threads);
+
   // Returns true if the instruction is a kCall operation and is eligible for
   // inlining.
   virtual bool IsInlineableCallOp(HloInstruction* instruction) const;
@@ -81,7 +86,8 @@ class CallInliner : public HloModulePass {
  private:
   absl::StatusOr<bool> InlineAndLegalize(
       const CallGraph& call_graph, HloComputation* computation,
-      absl::Span<HloInstruction* const> instruction_sequence) const;
+      absl::Span<HloInstruction* const> instruction_sequence,
+      std::optional<InlinedInstructionMap*> inline_map);
 
   bool ShouldInline(const CallGraph& call_graph,
                     HloInstruction* instruction) const;
@@ -93,7 +99,23 @@ class CallInliner : public HloModulePass {
   std::optional<
       std::function<bool(const CallGraph& call_graph, HloInstruction*)>>
       should_inline_;
+  InlinedInstructionMap inline_map_;
 };
+
+// Returns true if the computation has instructioin that is inlinable.
+bool IsInlineableComputation(HloComputation* computation);
+
+struct InlinedModule {
+  std::unique_ptr<HloModule> module;
+  std::unique_ptr<HloCloneContext> clone_context;
+  CallInliner::InlinedInstructionMap clone_inlined_map;
+  const HloInstruction* get_inlined_inst(const HloInstruction* inst);
+};
+
+// Given a module, this function first clone the module, then inline the module,
+// and return the inlined module, clone context and inlined map in InlinedModule
+// struct.
+absl::StatusOr<InlinedModule> GetInlinedModule(HloModule* module);
 
 }  // namespace xla
 

--- a/xla/service/call_inliner.h
+++ b/xla/service/call_inliner.h
@@ -99,7 +99,6 @@ class CallInliner : public HloModulePass {
   std::optional<
       std::function<bool(const CallGraph& call_graph, HloInstruction*)>>
       should_inline_;
-  InlinedInstructionMap inline_map_;
 };
 
 // Returns true if the computation has instructioin that is inlinable.

--- a/xla/service/call_inliner_test.cc
+++ b/xla/service/call_inliner_test.cc
@@ -884,8 +884,7 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
                           ParseAndReturnVerifiedModule(hlo));
 
-  TF_ASSERT_OK_AND_ASSIGN(auto inlined_module,
-                          GetInlinedModule(m->entry_computation()));
+  TF_ASSERT_OK_AND_ASSIGN(auto inlined_module, GetInlinedModule(m.get()));
   auto root = inlined_module.module->entry_computation()->root_instruction();
   EXPECT_THAT(root, op::Reduce());
   EXPECT_EQ(root->metadata().op_name(), "x/reduce");

--- a/xla/service/call_inliner_test.cc
+++ b/xla/service/call_inliner_test.cc
@@ -861,6 +861,37 @@ ENTRY main {
   EXPECT_EQ(root->to_apply()->root_instruction()->metadata().op_name(), "");
 }
 
+TEST_F(CallInlinerTest, GetInlinedModule) {
+  const char* hlo = R"(
+
+reducer {
+  x = f32[] parameter(0)
+  y = f32[] parameter(1)
+  ROOT add = f32[] add(x, y)
+}
+
+callee {
+  input = f32[128,32] parameter(0)
+  const = f32[] constant(0)
+  ROOT reduce = f32[128] reduce(input, const), dimensions={1}, to_apply=reducer, metadata={op_name="reduce"}
+}
+
+ENTRY main {
+  input = f32[128,32] parameter(0)
+  ROOT result = f32[128] call(input), to_apply=callee, metadata={op_name="x"}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
+                          ParseAndReturnVerifiedModule(hlo));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto inlined_module,
+                          GetInlinedModule(m->entry_computation()));
+  auto root = inlined_module.module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, op::Reduce());
+  EXPECT_EQ(root->metadata().op_name(), "x/reduce");
+  EXPECT_EQ(root->to_apply()->root_instruction()->metadata().op_name(), "");
+}
+
 TEST_F(CallInlinerTest, InliningDoesNotDuplicateLongOpNames) {
   const char* hlo = R"(
 callee {


### PR DESCRIPTION
This PR add a function `GetInlinedModule`, which is  Given a module, this function first clone the module, then inline the module, and return the inlined module, clone context and inlined map in InlinedModule struct.

This class is required because we found that while_loop_analysis pass can not work on the module that has been parsed by command buffer rewriter, so to do loop analysis, we have to first inline the command buffer call. 

This PR is depended by :  https://github.com/openxla/xla/pull/28740