### PR TITLE
[XLA:GPU] Add ChildCmd to command buffer cmd.

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -780,10 +780,10 @@ TracedCommandBufferCmd::RecordTracedCommand(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateNestedCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateNestedCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(command, *nested_cmd);
       });
 }
 
@@ -1230,8 +1230,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> ChildCmd::Record(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateMoveNestedCommand(*child_command_buffer_,
-                                                       dependencies);
+        return command_buffer->CreateMoveChildCommand(*child_command_buffer_,
+                                                      dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
         return absl::OkStatus();
@@ -1664,10 +1664,10 @@ CustomCallCmd::RecordLegacyCustomCall(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateNestedCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateNestedCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(command, *nested_cmd);
       });
 }
 
@@ -1743,10 +1743,10 @@ CustomCallCmd::RecordXlaFfiCall(const Thunk::ExecuteParams& execute_params,
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateNestedCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateNestedCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(command, *nested_cmd);
       });
 }
 
@@ -1805,10 +1805,10 @@ CollectiveCmd::RecordTracedCommand(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateNestedCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateNestedCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(command, *nested_cmd);
       });
 }
 
@@ -2369,12 +2369,12 @@ absl::StatusOr<const se::CommandBuffer::Command*> DynamicSliceFusionCmd::Record(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateNestedCommand(*nested_command_buffer,
-                                                   dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_command_buffer,
+                                                  dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateNestedCommand(command,
-                                                   *nested_command_buffer);
+        return command_buffer->UpdateChildCommand(command,
+                                                  *nested_command_buffer);
       });
 }
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -495,6 +495,7 @@ absl::Status CommandBufferCmdExecutor::RecordUpdate(
 
     // Skip updating command if it doesn't use any of the updated allocations.
     if (skip_command_update(id)) {
+      VLOG(3) << "Skip updating command " << command->ToString();
       ++num_skipped_command_updates;
       continue;
     }
@@ -1186,6 +1187,55 @@ absl::StatusOr<const se::CommandBuffer::Command*> Memset32Cmd::Record(
 
 CommandBufferCmd::BufferUseVector Memset32Cmd::buffers() const {
   return {{dst_, MemoryAccess::kWrite}};
+}
+
+//===----------------------------------------------------------------------===//
+// ChildCmd
+//===----------------------------------------------------------------------===//
+
+ChildCmd::ChildCmd(CommandBufferCmdExecutor child_commands,
+                   ResourceUseVector resources)
+    : CommandBufferCmd(CommandBufferCmdType::kChildCmd, std::move(resources)),
+      child_commands_(std::move(child_commands)) {}
+
+bool ChildCmd::requires_initialization() {
+  return child_commands_.requires_initialization();
+}
+
+bool ChildCmd::force_update() { return child_commands_.force_update(); }
+
+CommandBufferCmd::BufferUseVector ChildCmd::buffers() const {
+  return {child_commands_.buffers().begin(), child_commands_.buffers().end()};
+}
+
+absl::Status ChildCmd::Initialize(const Thunk::InitializeParams& params,
+                                  StateManager& state) {
+  TF_RETURN_IF_ERROR(child_commands_.Initialize(params, state));
+  if (child_command_buffer_ == nullptr) {
+    TF_ASSIGN_OR_RETURN(child_command_buffer_,
+                        params.stream->parent()->CreateCommandBuffer(
+                            se::CommandBuffer::Mode::kNested));
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<const se::CommandBuffer::Command*> ChildCmd::Record(
+    const Thunk::ExecuteParams& execute_params,
+    const RecordParams& record_params, RecordAction record_action,
+    se::CommandBuffer* command_buffer) {
+  VLOG(5) << "Record ChildCmd " << child_commands_.size() << " commands";
+  CHECK(child_command_buffer_ != nullptr);
+  TF_RETURN_IF_ERROR(child_commands_.Record(execute_params, record_params,
+                                            child_command_buffer_.get()));
+  return Handle(
+      std::move(record_action),
+      [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
+        return command_buffer->CreateMoveNestedCommand(*child_command_buffer_,
+                                                       dependencies);
+      },
+      [&](const se::CommandBuffer::Command* command) {
+        return absl::OkStatus();
+      });
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -780,11 +780,13 @@ TracedCommandBufferCmd::RecordTracedCommand(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd,
-                                                        dependencies);
+        return command_buffer->CreateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
+            dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateChildCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, command, *nested_cmd);
       });
 }
 
@@ -1231,10 +1233,12 @@ absl::StatusOr<const se::CommandBuffer::Command*> ChildCmd::Record(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateMovedChildCommand(*child_command_buffer_,
-                                                       dependencies);
+        return command_buffer->CreateChildCommand(
+            se::CommandBuffer::ChildCommandType::kMoved, *child_command_buffer_,
+            dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
+        // Moved child command does not need to be updated.
         return absl::OkStatus();
       });
 }
@@ -1665,11 +1669,13 @@ CustomCallCmd::RecordLegacyCustomCall(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd,
-                                                        dependencies);
+        return command_buffer->CreateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
+            dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateChildCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, command, *nested_cmd);
       });
 }
 
@@ -1745,11 +1751,13 @@ CustomCallCmd::RecordXlaFfiCall(const Thunk::ExecuteParams& execute_params,
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd,
-                                                        dependencies);
+        return command_buffer->CreateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
+            dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateChildCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, command, *nested_cmd);
       });
 }
 
@@ -1808,11 +1816,13 @@ CollectiveCmd::RecordTracedCommand(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd,
-                                                        dependencies);
+        return command_buffer->CreateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
+            dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateChildCommand(command, *nested_cmd);
+        return command_buffer->UpdateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, command, *nested_cmd);
       });
 }
 
@@ -2373,12 +2383,14 @@ absl::StatusOr<const se::CommandBuffer::Command*> DynamicSliceFusionCmd::Record(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_command_buffer,
-                                                        dependencies);
+        return command_buffer->CreateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned,
+            *nested_command_buffer, dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateChildCommand(command,
-                                                  *nested_command_buffer);
+        return command_buffer->UpdateChildCommand(
+            se::CommandBuffer::ChildCommandType::kCloned, command,
+            *nested_command_buffer);
       });
 }
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -780,7 +780,8 @@ TracedCommandBufferCmd::RecordTracedCommand(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd,
+                                                        dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
         return command_buffer->UpdateChildCommand(command, *nested_cmd);
@@ -1230,8 +1231,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> ChildCmd::Record(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateMoveChildCommand(*child_command_buffer_,
-                                                      dependencies);
+        return command_buffer->CreateMovedChildCommand(*child_command_buffer_,
+                                                       dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
         return absl::OkStatus();
@@ -1664,7 +1665,8 @@ CustomCallCmd::RecordLegacyCustomCall(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd,
+                                                        dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
         return command_buffer->UpdateChildCommand(command, *nested_cmd);
@@ -1743,7 +1745,8 @@ CustomCallCmd::RecordXlaFfiCall(const Thunk::ExecuteParams& execute_params,
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd,
+                                                        dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
         return command_buffer->UpdateChildCommand(command, *nested_cmd);
@@ -1805,7 +1808,8 @@ CollectiveCmd::RecordTracedCommand(
   return Handle(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateClonedChildCommand(*nested_cmd, dependencies);
+        return command_buffer->CreateClonedChildCommand(*nested_cmd,
+                                                        dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
         return command_buffer->UpdateChildCommand(command, *nested_cmd);
@@ -2370,7 +2374,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> DynamicSliceFusionCmd::Record(
       std::move(record_action),
       [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
         return command_buffer->CreateClonedChildCommand(*nested_command_buffer,
-                                                  dependencies);
+                                                        dependencies);
       },
       [&](const se::CommandBuffer::Command* command) {
         return command_buffer->UpdateChildCommand(command,

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -768,6 +768,138 @@ TEST(CommandBufferThunkTest, GemmCmd) {
   ASSERT_EQ(dst, std::vector<float>({10, 10, 10, 26, 26, 26}));
 }
 
+TEST(CommandBufferThunkTest, ChildGemmCmd) {
+  se::StreamExecutor* stream_executor = GpuExecutor();
+
+  if (!IsAtLeastCuda12300(stream_executor)) {
+    GTEST_SKIP() << "CUDA graph tracing is not supported";
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
+
+  int64_t lhs_length = sizeof(float) * 2 * 4;
+  int64_t rhs_length = sizeof(float) * 4 * 3;
+  int64_t out_length = sizeof(float) * 2 * 3;
+
+  // Prepare arguments:
+  // lhs = [1.0, 2.0, 3.0, 4.0
+  //        5.0, 6.0, 7.0, 8.0]
+  // rhs = [1.0, 1.0, 1.0
+  //        1.0, 1.0, 1.0
+  //        1.0, 1.0, 1.0
+  //        1.0, 1.0, 1.0]
+  se::DeviceMemory<float> lhs = stream_executor->AllocateArray<float>(2 * 4);
+  std::vector<float> lhs_arr{1, 2, 3, 4, 5, 6, 7, 8};
+  TF_ASSERT_OK(stream->Memcpy(&lhs, lhs_arr.data(), lhs_length));
+
+  se::DeviceMemory<float> rhs = stream_executor->AllocateArray<float>(4 * 3);
+  std::vector<float> rhs_arr(12, 1);
+  TF_ASSERT_OK(stream->Memcpy(&rhs, rhs_arr.data(), rhs_length));
+
+  se::DeviceMemory<float> out = stream_executor->AllocateArray<float>(2 * 3);
+  TF_ASSERT_OK(stream->MemZero(&out, out_length));
+
+  se::DeviceMemory<float> workspace =
+      stream_executor->AllocateArray<float>(1024 * 1024);
+  TF_ASSERT_OK(stream->MemZero(&workspace, 1024 * 1024));
+
+  // Prepare buffer allocations for recording command buffer.
+  BufferAllocation alloc_lhs(/*index=*/0, lhs_length, /*color=*/0);
+  BufferAllocation alloc_rhs(/*index=*/1, rhs_length, /*color=*/0);
+  BufferAllocation alloc_out(/*index=*/2, out_length, /*color=*/0);
+  BufferAllocation alloc_workspace(/*index=*/3, 1024 * 1024, /*color=*/0);
+
+  BufferAllocation::Slice slice_lhs(&alloc_lhs, 0, lhs_length);
+  BufferAllocation::Slice slice_rhs(&alloc_rhs, 0, rhs_length);
+  BufferAllocation::Slice slice_out(&alloc_out, 0, out_length);
+  BufferAllocation::Slice slice_workspace(&alloc_workspace, 0, 1024 * 1024);
+
+  auto config = GemmConfig::For(
+      ShapeUtil::MakeShape(PrimitiveType::F32, {2, 4}), {}, {1},
+      ShapeUtil::MakeShape(PrimitiveType::F32, {4, 3}), {}, {0},
+      ShapeUtil::MakeShape(PrimitiveType::F32, {2, 3}), 1.0, 0.0, 0.0,
+      PrecisionConfig::ALG_UNSET, std::nullopt,
+      se::blas::kDefaultComputePrecision, false, false,
+      stream_executor->GetDeviceDescription().gpu_compute_capability());
+  ASSERT_TRUE(config.ok());
+
+  // Prepare commands sequence for constructing command buffer.
+  CommandBufferCmdSequence child_commands;
+  child_commands.Emplace<GemmCmd>(config.value(), slice_lhs, slice_rhs,
+                                  slice_out, slice_workspace,
+                                  /*deterministic=*/true);
+  TF_ASSERT_OK_AND_ASSIGN(
+      CommandBufferCmdExecutor child_executor,
+      CommandBufferCmdExecutor::Create(std::move(child_commands), serialize));
+
+  CommandBufferCmdSequence commands;
+  commands.Emplace<ChildCmd>(std::move(child_executor), ResourceUseVector{});
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      CommandBufferCmdExecutor executor,
+      CommandBufferCmdExecutor::Create(std::move(commands), serialize));
+
+  // Construct a thunk with command sequence.
+  CommandBufferThunk thunk(std::move(executor), Thunk::ThunkInfo());
+
+  ServiceExecutableRunOptions run_options;
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
+  BufferAllocations allocations({lhs, rhs, out, workspace}, 0, &allocator);
+
+  Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
+      run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
+
+  Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
+  VLOG(0) << "Initialize thunk";
+  TF_ASSERT_OK(thunk.Initialize(
+      {stream_executor, source, &allocations, stream.get(), stream.get()}));
+
+  VLOG(0) << "Initialize done";
+  // Execute command buffer thunk and verify that it executed a GEMM.
+  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+
+  VLOG(0) << "Execute thunk done";
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  // Copy `out` data back to host.
+  std::vector<float> dst(6, 0);
+  TF_ASSERT_OK(stream->Memcpy(dst.data(), out, out_length));
+
+  ASSERT_EQ(dst, std::vector<float>({10, 10, 10, 26, 26, 26}));
+
+  // Prepare buffer allocation for updating command buffer.
+  se::DeviceMemory<float> updated_out =
+      stream_executor->AllocateArray<float>(2 * 3);
+  TF_ASSERT_OK(stream->MemZero(&updated_out, out_length));
+
+  // Update buffer allocation to updated `out` buffer.
+  allocations =
+      BufferAllocations({lhs, rhs, updated_out, workspace}, 0, &allocator);
+
+  // Thunk execution should automatically update underlying command buffer.
+  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  // Copy `updated_out` data back to host.
+  std::fill(dst.begin(), dst.end(), 0);
+  TF_ASSERT_OK(stream->Memcpy(dst.data(), updated_out, out_length));
+
+  ASSERT_EQ(dst, std::vector<float>({10, 10, 10, 26, 26, 26}));
+
+  // Try to update the command buffer with the same buffers.
+  TF_ASSERT_OK(stream->MemZero(&updated_out, out_length));
+
+  // Thunk execution should automatically update underlying command buffer.
+  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  // Copy `updated_out` data back to host.
+  std::fill(dst.begin(), dst.end(), 0);
+  TF_ASSERT_OK(stream->Memcpy(dst.data(), updated_out, out_length));
+
+  ASSERT_EQ(dst, std::vector<float>({10, 10, 10, 26, 26, 26}));
+}
+
 TEST(CommandBufferThunkTest, DISABLED_DynamicSliceFusionCmd) {
   se::StreamExecutor* stream_executor = GpuExecutor();
 

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -182,6 +182,9 @@ class CommandBuffer {
   virtual absl::Status UpdateNestedCommand(const Command* command,
                                            const CommandBuffer& nested) = 0;
 
+  virtual absl::StatusOr<const Command*> CreateMoveNestedCommand(
+      CommandBuffer& nested, absl::Span<const Command* const> dependencies) = 0;
+
   // Creates a device-to-device memory copy.
   virtual absl::StatusOr<const Command*> CreateMemcpyD2D(
       DeviceMemoryBase* dst, const DeviceMemoryBase& src, uint64_t size,

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -181,7 +181,7 @@ class CommandBuffer {
 
   // Creates a command that launches a nested command buffer. Nested command
   // buffer is constructed is through move semantics.
-  virtual absl::StatusOr<const Command*> CreateMoveChildCommand(
+  virtual absl::StatusOr<const Command*> CreateMovedChildCommand(
       CommandBuffer& nested, absl::Span<const Command* const> dependencies) = 0;
 
   // Updates a command that launches a nested command buffer.

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -174,16 +174,19 @@ class CommandBuffer {
                             const ThreadDim& threads, const BlockDim& blocks,
                             Args... args);
 
-  // Creates a command that launches a nested command buffer.
-  virtual absl::StatusOr<const Command*> CreateNestedCommand(
+  // Creates a command that launches a nested command buffer. Nested command
+  // buffer is constructed is through cloning.
+  virtual absl::StatusOr<const Command*> CreateClonedChildCommand(
+      CommandBuffer& nested, absl::Span<const Command* const> dependencies) = 0;
+
+  // Creates a command that launches a nested command buffer. Nested command
+  // buffer is constructed is through move semantics.
+  virtual absl::StatusOr<const Command*> CreateMoveChildCommand(
       CommandBuffer& nested, absl::Span<const Command* const> dependencies) = 0;
 
   // Updates a command that launches a nested command buffer.
-  virtual absl::Status UpdateNestedCommand(const Command* command,
-                                           const CommandBuffer& nested) = 0;
-
-  virtual absl::StatusOr<const Command*> CreateMoveNestedCommand(
-      CommandBuffer& nested, absl::Span<const Command* const> dependencies) = 0;
+  virtual absl::Status UpdateChildCommand(const Command* command,
+                                          const CommandBuffer& nested) = 0;
 
   // Creates a device-to-device memory copy.
   virtual absl::StatusOr<const Command*> CreateMemcpyD2D(

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -174,18 +174,16 @@ class CommandBuffer {
                             const ThreadDim& threads, const BlockDim& blocks,
                             Args... args);
 
-  // Creates a command that launches a nested command buffer. Nested command
-  // buffer is constructed is through cloning.
-  virtual absl::StatusOr<const Command*> CreateClonedChildCommand(
-      CommandBuffer& nested, absl::Span<const Command* const> dependencies) = 0;
-
-  // Creates a command that launches a nested command buffer. Nested command
-  // buffer is constructed is through move semantics.
-  virtual absl::StatusOr<const Command*> CreateMovedChildCommand(
-      CommandBuffer& nested, absl::Span<const Command* const> dependencies) = 0;
+  // kCloned: child command is cloned into parent command.
+  // kMoved: child command is moved into parent command.
+  enum class ChildCommandType { kCloned, kMoved };
+  virtual absl::StatusOr<const Command*> CreateChildCommand(
+      ChildCommandType type, CommandBuffer& nested,
+      absl::Span<const Command* const> dependencies) = 0;
 
   // Updates a command that launches a nested command buffer.
-  virtual absl::Status UpdateChildCommand(const Command* command,
+  virtual absl::Status UpdateChildCommand(ChildCommandType type,
+                                          const Command* command,
                                           const CommandBuffer& nested) = 0;
 
   // Creates a device-to-device memory copy.

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -449,6 +449,7 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
     return FromCudaGraphHandle(node_handle);
 
   } else if (type == ChildCommandType::kMoved) {
+#if CUDA_VERSION >= 12090
     child_command_buffer.is_owned_graph_ = false;
     CUgraphNodeParams nodeParams;
     std::memset(&nodeParams, 0, sizeof(nodeParams));
@@ -466,7 +467,10 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
                        &nodeParams),
         "Failed to create a child graph node and add it to a CUDA graph"));
     return FromCudaGraphHandle(node_handle);
-
+#else
+    return absl::UnimplementedError(
+        "Moved child node is not supported for CUDA < 12.9");
+#endif
   } else {
     return absl::InternalError("Unsupported child command type");
   }

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -460,6 +460,34 @@ absl::Status CudaCommandBuffer::UpdateChildNode(GraphNodeHandle node_handle,
       "Failed to set CUDA graph child node params");
 }
 
+absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateMovedChildNode(
+    absl::Span<const GraphNodeHandle> dependencies, CommandBuffer& nested) {
+  auto& child_command_buffer =
+      tensorflow::down_cast<CudaCommandBuffer&>(nested);
+  CUgraph child_graph =
+      tensorflow::down_cast<CudaCommandBuffer&>(nested).graph_;
+
+  child_command_buffer.is_owned_graph_ = false;
+  child_command_buffer.parent_ = this;
+
+  CUgraphNodeParams nodeParams;
+  std::memset(&nodeParams, 0, sizeof(nodeParams));
+  nodeParams.type = CU_GRAPH_NODE_TYPE_GRAPH;
+  nodeParams.graph.graph = child_graph;
+  nodeParams.graph.ownership = CU_GRAPH_CHILD_GRAPH_OWNERSHIP_MOVE;
+  VLOG(2) << "Create a new node by moving the child graph " << child_graph
+          << " and add it to " << graph_ << "; deps: " << dependencies.size();
+
+  std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
+
+  CUgraphNode node_handle;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuGraphAddNode(&node_handle, graph_, deps.data(), deps.size(),
+                     &nodeParams),
+      "Failed to create a child graph node and add it to a CUDA graph"));
+  return FromCudaGraphHandle(node_handle);
+}
+
 absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateKernelNode(
     absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,
     const ThreadDim& threads, const BlockDim& blocks, const Kernel& kernel,

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -423,8 +423,9 @@ absl::Status CudaCommandBuffer::UpdateDnnGraphNode(
       "Failed to set CUDA graph child node params");
 }
 
-absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateClonedChildNode(
-    absl::Span<const GraphNodeHandle> dependencies, CommandBuffer& nested) {
+absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
+    ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
+    CommandBuffer& nested) {
   auto& child_command_buffer =
       tensorflow::down_cast<CudaCommandBuffer&>(nested);
   CHECK(child_command_buffer.parent_ == nullptr)
@@ -437,17 +438,45 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateClonedChildNode(
   std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
 
   CUgraphNode node_handle;
-  TF_RETURN_IF_ERROR(cuda::ToStatus(
-      cuGraphAddChildGraphNode(&node_handle, graph_, deps.data(), deps.size(),
-                               child_graph),
-      "Failed to create a child graph node and add it to a CUDA graph"));
-  VLOG(5) << "CreateClonedChildNode: "
-          << reinterpret_cast<const void*>(&node_handle);
-  return FromCudaGraphHandle(node_handle);
+  if (type == ChildCommandType::kCloned) {
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphAddChildGraphNode(&node_handle, graph_, deps.data(), deps.size(),
+                                 child_graph),
+        "Failed to create a child graph node and add it to a CUDA graph"));
+    VLOG(5) << "CreateClonedChildNode: "
+            << reinterpret_cast<const void*>(&node_handle);
+
+    return FromCudaGraphHandle(node_handle);
+
+  } else if (type == ChildCommandType::kMoved) {
+    child_command_buffer.is_owned_graph_ = false;
+    CUgraphNodeParams nodeParams;
+    std::memset(&nodeParams, 0, sizeof(nodeParams));
+    nodeParams.type = CU_GRAPH_NODE_TYPE_GRAPH;
+    nodeParams.graph.graph = child_graph;
+    nodeParams.graph.ownership = CU_GRAPH_CHILD_GRAPH_OWNERSHIP_MOVE;
+    VLOG(2) << "Create a new node by moving the child graph " << child_graph
+            << " and add it to " << graph_ << "; deps: " << dependencies.size();
+
+    std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
+
+    CUgraphNode node_handle;
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphAddNode(&node_handle, graph_, deps.data(), deps.size(),
+                       &nodeParams),
+        "Failed to create a child graph node and add it to a CUDA graph"));
+    return FromCudaGraphHandle(node_handle);
+
+  } else {
+    return absl::InternalError("Unsupported child command type");
+  }
 }
 
-absl::Status CudaCommandBuffer::UpdateChildNode(GraphNodeHandle node_handle,
+absl::Status CudaCommandBuffer::UpdateChildNode(ChildCommandType type,
+                                                GraphNodeHandle node_handle,
                                                 const CommandBuffer& nested) {
+  CHECK(type == ChildCommandType::kCloned)
+      << "Moved child node update is not supported";
   CUgraph child_graph =
       tensorflow::down_cast<const CudaCommandBuffer&>(nested).graph_;
   VLOG(2) << "Set child node params " << node_handle << " in graph executable "
@@ -459,34 +488,6 @@ absl::Status CudaCommandBuffer::UpdateChildNode(GraphNodeHandle node_handle,
       cuGraphExecChildGraphNodeSetParams(
           exec_update, ToCudaGraphHandle(node_handle), child_graph),
       "Failed to set CUDA graph child node params");
-}
-
-absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateMovedChildNode(
-    absl::Span<const GraphNodeHandle> dependencies, CommandBuffer& nested) {
-  auto& child_command_buffer =
-      tensorflow::down_cast<CudaCommandBuffer&>(nested);
-  CUgraph child_graph =
-      tensorflow::down_cast<CudaCommandBuffer&>(nested).graph_;
-
-  child_command_buffer.is_owned_graph_ = false;
-  child_command_buffer.parent_ = this;
-
-  CUgraphNodeParams nodeParams;
-  std::memset(&nodeParams, 0, sizeof(nodeParams));
-  nodeParams.type = CU_GRAPH_NODE_TYPE_GRAPH;
-  nodeParams.graph.graph = child_graph;
-  nodeParams.graph.ownership = CU_GRAPH_CHILD_GRAPH_OWNERSHIP_MOVE;
-  VLOG(2) << "Create a new node by moving the child graph " << child_graph
-          << " and add it to " << graph_ << "; deps: " << dependencies.size();
-
-  std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
-
-  CUgraphNode node_handle;
-  TF_RETURN_IF_ERROR(cuda::ToStatus(
-      cuGraphAddNode(&node_handle, graph_, deps.data(), deps.size(),
-                     &nodeParams),
-      "Failed to create a child graph node and add it to a CUDA graph"));
-  return FromCudaGraphHandle(node_handle);
 }
 
 absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateKernelNode(

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -423,7 +423,7 @@ absl::Status CudaCommandBuffer::UpdateDnnGraphNode(
       "Failed to set CUDA graph child node params");
 }
 
-absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
+absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateClonedChildNode(
     absl::Span<const GraphNodeHandle> dependencies, CommandBuffer& nested) {
   auto& child_command_buffer =
       tensorflow::down_cast<CudaCommandBuffer&>(nested);
@@ -441,7 +441,8 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
       cuGraphAddChildGraphNode(&node_handle, graph_, deps.data(), deps.size(),
                                child_graph),
       "Failed to create a child graph node and add it to a CUDA graph"));
-  VLOG(5) << "CreateChildNode: " << reinterpret_cast<const void*>(&node_handle);
+  VLOG(5) << "CreateClonedChildNode: "
+          << reinterpret_cast<const void*>(&node_handle);
   return FromCudaGraphHandle(node_handle);
 }
 

--- a/xla/stream_executor/cuda/cuda_command_buffer.h
+++ b/xla/stream_executor/cuda/cuda_command_buffer.h
@@ -130,16 +130,13 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
                                   absl::Span<DeviceMemoryBase> operands,
                                   GraphNodeHandle) override;
 
-  absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
-      absl::Span<const GraphNodeHandle> dependencies,
+  absl::StatusOr<GraphNodeHandle> CreateChildNode(
+      ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
       CommandBuffer& nested) override;
 
-  absl::Status UpdateChildNode(GraphNodeHandle node_handle,
+  absl::Status UpdateChildNode(ChildCommandType type,
+                               GraphNodeHandle node_handle,
                                const CommandBuffer& nested) override;
-
-  absl::StatusOr<GraphNodeHandle> CreateMovedChildNode(
-      absl::Span<const GraphNodeHandle> dependencies,
-      CommandBuffer& nested) override;
 
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(
       absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,

--- a/xla/stream_executor/cuda/cuda_command_buffer.h
+++ b/xla/stream_executor/cuda/cuda_command_buffer.h
@@ -137,6 +137,10 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
   absl::Status UpdateChildNode(GraphNodeHandle node_handle,
                                const CommandBuffer& nested) override;
 
+  absl::StatusOr<GraphNodeHandle> CreateMovedChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      CommandBuffer& nested) override;
+
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(
       absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,
       const ThreadDim& threads, const BlockDim& blocks, const Kernel& kernel,

--- a/xla/stream_executor/cuda/cuda_command_buffer.h
+++ b/xla/stream_executor/cuda/cuda_command_buffer.h
@@ -130,7 +130,7 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
                                   absl::Span<DeviceMemoryBase> operands,
                                   GraphNodeHandle) override;
 
-  absl::StatusOr<GraphNodeHandle> CreateChildNode(
+  absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
       absl::Span<const GraphNodeHandle> dependencies,
       CommandBuffer& nested) override;
 

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -226,7 +226,7 @@ GpuCommandBuffer::CreateClonedChildCommand(
 
   TF_ASSIGN_OR_RETURN(
       GraphNodeHandle handle,
-      CreateChildNode(ToGraphNodeDependencies(dependencies), nested));
+      CreateClonedChildNode(ToGraphNodeDependencies(dependencies), nested));
   return AppendCommand(GpuCommand{handle});
 }
 
@@ -239,7 +239,7 @@ absl::Status GpuCommandBuffer::UpdateChildCommand(const Command* command,
 }
 
 absl::StatusOr<const CommandBuffer::Command*>
-GpuCommandBuffer::CreateMoveChildCommand(
+GpuCommandBuffer::CreateMovedChildCommand(
     CommandBuffer& nested, absl::Span<const Command* const> dependencies) {
   TF_RETURN_IF_ERROR(CheckInState(State::kCreate));
   TF_ASSIGN_OR_RETURN(
@@ -310,7 +310,7 @@ GpuCommandBuffer::CreateDnnGraphCommand(
 
   TF_ASSIGN_OR_RETURN(
       GraphNodeHandle handle,
-      CreateChildNode(ToGraphNodeDependencies(dependencies), *nested));
+      CreateClonedChildNode(ToGraphNodeDependencies(dependencies), *nested));
 
   return AppendCommand(GpuCommand{handle});
 }

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -239,6 +239,17 @@ absl::Status GpuCommandBuffer::UpdateNestedCommand(
   return UpdateChildNode(gpu_command->handle, nested);
 }
 
+absl::StatusOr<const CommandBuffer::Command*>
+GpuCommandBuffer::CreateMoveNestedCommand(
+    CommandBuffer& nested, absl::Span<const Command* const> dependencies) {
+  TF_RETURN_IF_ERROR(CheckInState(State::kCreate));
+  TF_ASSIGN_OR_RETURN(
+      GraphNodeHandle handle,
+      CreateMovedChildNode(ToGraphNodeDependencies(dependencies), nested));
+  VLOG(5) << "CreateNestedCommand: ";
+  return AppendCommand(GpuCommand{handle});
+}
+
 absl::StatusOr<const CommandBuffer::Command*> GpuCommandBuffer::CreateMemcpyD2D(
     DeviceMemoryBase* dst, const DeviceMemoryBase& src, uint64_t size,
     absl::Span<const Command* const> dependencies) {

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -220,33 +220,31 @@ absl::Status GpuCommandBuffer::UpdateLaunch(const Command* command,
 }
 
 absl::StatusOr<const CommandBuffer::Command*>
-GpuCommandBuffer::CreateNestedCommand(
+GpuCommandBuffer::CreateClonedChildCommand(
     CommandBuffer& nested, absl::Span<const Command* const> dependencies) {
   TF_RETURN_IF_ERROR(CheckInState(State::kCreate));
 
   TF_ASSIGN_OR_RETURN(
       GraphNodeHandle handle,
       CreateChildNode(ToGraphNodeDependencies(dependencies), nested));
-  VLOG(5) << "CreateNestedCommand: ";
   return AppendCommand(GpuCommand{handle});
 }
 
-absl::Status GpuCommandBuffer::UpdateNestedCommand(
-    const Command* command, const CommandBuffer& nested) {
+absl::Status GpuCommandBuffer::UpdateChildCommand(const Command* command,
+                                                  const CommandBuffer& nested) {
   TF_RETURN_IF_ERROR(CheckInState(State::kUpdate));
   auto* gpu_command = tsl::down_cast<const GpuCommand*>(command);
-  VLOG(5) << "UpdateNestedCommand: " << reinterpret_cast<const void*>(command);
+  VLOG(5) << "UpdateChildCommand: " << reinterpret_cast<const void*>(command);
   return UpdateChildNode(gpu_command->handle, nested);
 }
 
 absl::StatusOr<const CommandBuffer::Command*>
-GpuCommandBuffer::CreateMoveNestedCommand(
+GpuCommandBuffer::CreateMoveChildCommand(
     CommandBuffer& nested, absl::Span<const Command* const> dependencies) {
   TF_RETURN_IF_ERROR(CheckInState(State::kCreate));
   TF_ASSIGN_OR_RETURN(
       GraphNodeHandle handle,
       CreateMovedChildNode(ToGraphNodeDependencies(dependencies), nested));
-  VLOG(5) << "CreateNestedCommand: ";
   return AppendCommand(GpuCommand{handle});
 }
 

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -124,15 +124,11 @@ class GpuCommandBuffer : public CommandBuffer {
                             const BlockDim& blocks, const Kernel& kernel,
                             const KernelArgs& args) override;
 
-  absl::StatusOr<const Command*> CreateClonedChildCommand(
-      CommandBuffer& nested,
+  absl::StatusOr<const Command*> CreateChildCommand(
+      ChildCommandType type, CommandBuffer& nested,
       absl::Span<const Command* const> dependencies) override;
 
-  absl::StatusOr<const Command*> CreateMovedChildCommand(
-      CommandBuffer& nested,
-      absl::Span<const Command* const> dependencies) override;
-
-  absl::Status UpdateChildCommand(const Command* command,
+  absl::Status UpdateChildCommand(ChildCommandType type, const Command* command,
                                   const CommandBuffer& nested) override;
 
   absl::StatusOr<const Command*> CreateMemcpyD2D(
@@ -332,18 +328,14 @@ class GpuCommandBuffer : public CommandBuffer {
                                           GraphNodeHandle) = 0;
 
   // Adds a new nested command buffer node to the graph.
-  virtual absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
-      absl::Span<const GraphNodeHandle> dependencies,
+  virtual absl::StatusOr<GraphNodeHandle> CreateChildNode(
+      ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
       CommandBuffer& nested) = 0;
 
-  // Adds a new nested command buffer node to the graph.
-  virtual absl::StatusOr<GraphNodeHandle> CreateMovedChildNode(
-      absl::Span<const GraphNodeHandle> dependencies,
-      CommandBuffer& nested) = 0;
-
-  // Associate another command buffer with this child node. Will return an
-  // error if the given node has not been created as a child node.
-  virtual absl::Status UpdateChildNode(GraphNodeHandle node_handle,
+  // Updates an existing child node. Will return an error if the given node has
+  // not been created as a child node.
+  virtual absl::Status UpdateChildNode(ChildCommandType type,
+                                       GraphNodeHandle node_handle,
                                        const CommandBuffer& nested) = 0;
 
   // Adds a new kernel launch node to the graph.

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -128,7 +128,7 @@ class GpuCommandBuffer : public CommandBuffer {
       CommandBuffer& nested,
       absl::Span<const Command* const> dependencies) override;
 
-  absl::StatusOr<const Command*> CreateMoveChildCommand(
+  absl::StatusOr<const Command*> CreateMovedChildCommand(
       CommandBuffer& nested,
       absl::Span<const Command* const> dependencies) override;
 
@@ -332,7 +332,7 @@ class GpuCommandBuffer : public CommandBuffer {
                                           GraphNodeHandle) = 0;
 
   // Adds a new nested command buffer node to the graph.
-  virtual absl::StatusOr<GraphNodeHandle> CreateChildNode(
+  virtual absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
       absl::Span<const GraphNodeHandle> dependencies,
       CommandBuffer& nested) = 0;
 

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -128,6 +128,10 @@ class GpuCommandBuffer : public CommandBuffer {
       CommandBuffer& nested,
       absl::Span<const Command* const> dependencies) override;
 
+  absl::StatusOr<const Command*> CreateMoveNestedCommand(
+      CommandBuffer& nested,
+      absl::Span<const Command* const> dependencies) override;
+
   absl::Status UpdateNestedCommand(const Command* command,
                                    const CommandBuffer& nested) override;
 
@@ -329,6 +333,11 @@ class GpuCommandBuffer : public CommandBuffer {
 
   // Adds a new nested command buffer node to the graph.
   virtual absl::StatusOr<GraphNodeHandle> CreateChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      CommandBuffer& nested) = 0;
+
+  // Adds a new nested command buffer node to the graph.
+  virtual absl::StatusOr<GraphNodeHandle> CreateMovedChildNode(
       absl::Span<const GraphNodeHandle> dependencies,
       CommandBuffer& nested) = 0;
 

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -124,16 +124,16 @@ class GpuCommandBuffer : public CommandBuffer {
                             const BlockDim& blocks, const Kernel& kernel,
                             const KernelArgs& args) override;
 
-  absl::StatusOr<const Command*> CreateNestedCommand(
+  absl::StatusOr<const Command*> CreateClonedChildCommand(
       CommandBuffer& nested,
       absl::Span<const Command* const> dependencies) override;
 
-  absl::StatusOr<const Command*> CreateMoveNestedCommand(
+  absl::StatusOr<const Command*> CreateMoveChildCommand(
       CommandBuffer& nested,
       absl::Span<const Command* const> dependencies) override;
 
-  absl::Status UpdateNestedCommand(const Command* command,
-                                   const CommandBuffer& nested) override;
+  absl::Status UpdateChildCommand(const Command* command,
+                                  const CommandBuffer& nested) override;
 
   absl::StatusOr<const Command*> CreateMemcpyD2D(
       DeviceMemoryBase* dst, const DeviceMemoryBase& src, uint64_t size,

--- a/xla/stream_executor/gpu/gpu_command_buffer_test.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer_test.cc
@@ -201,8 +201,10 @@ TEST(GpuCommandBufferTest, LaunchNestedCommandBuffer) {
                           executor->CreateCommandBuffer(nested));
   TF_ASSERT_OK(
       nested_cmd->CreateLaunch(add, ThreadDim(), BlockDim(4), {}, a, b, c));
-  TF_ASSERT_OK_AND_ASSIGN(auto* nested_command,
-                          primary_cmd->CreateClonedChildCommand(*nested_cmd, {}));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto* nested_command,
+      primary_cmd->CreateChildCommand(CommandBuffer::ChildCommandType::kCloned,
+                                      *nested_cmd, {}));
   TF_ASSERT_OK(primary_cmd->Finalize());
 
   TF_ASSERT_OK(primary_cmd->Submit(stream.get()));
@@ -224,7 +226,8 @@ TEST(GpuCommandBufferTest, LaunchNestedCommandBuffer) {
   TF_ASSERT_OK(
       nested_cmd->CreateLaunch(add, ThreadDim(), BlockDim(4), {}, a, b, d));
   TF_ASSERT_OK(primary_cmd->Update());
-  TF_ASSERT_OK(primary_cmd->UpdateChildCommand(nested_command, *nested_cmd));
+  TF_ASSERT_OK(primary_cmd->UpdateChildCommand(
+      CommandBuffer::ChildCommandType::kCloned, nested_command, *nested_cmd));
   TF_ASSERT_OK(primary_cmd->Finalize());
 
   TF_ASSERT_OK(primary_cmd->Submit(stream.get()));
@@ -716,7 +719,8 @@ TEST(GpuCommandBufferTest, DISABLED_WhileNestedConditional) {
 
   CommandBuffer::CreateCommands create_body = [&](CommandBuffer* body_cmd,
                                                   auto deps) {
-    return Wrap(body_cmd->CreateClonedChildCommand(*nested_cmd, deps));
+    return Wrap(body_cmd->CreateChildCommand(
+        CommandBuffer::ChildCommandType::kCloned, *nested_cmd, deps));
   };
 
   // Create a command buffer with a single conditional operation.

--- a/xla/stream_executor/gpu/gpu_command_buffer_test.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer_test.cc
@@ -202,7 +202,7 @@ TEST(GpuCommandBufferTest, LaunchNestedCommandBuffer) {
   TF_ASSERT_OK(
       nested_cmd->CreateLaunch(add, ThreadDim(), BlockDim(4), {}, a, b, c));
   TF_ASSERT_OK_AND_ASSIGN(auto* nested_command,
-                          primary_cmd->CreateNestedCommand(*nested_cmd, {}));
+                          primary_cmd->CreateClonedChildCommand(*nested_cmd, {}));
   TF_ASSERT_OK(primary_cmd->Finalize());
 
   TF_ASSERT_OK(primary_cmd->Submit(stream.get()));
@@ -224,7 +224,7 @@ TEST(GpuCommandBufferTest, LaunchNestedCommandBuffer) {
   TF_ASSERT_OK(
       nested_cmd->CreateLaunch(add, ThreadDim(), BlockDim(4), {}, a, b, d));
   TF_ASSERT_OK(primary_cmd->Update());
-  TF_ASSERT_OK(primary_cmd->UpdateNestedCommand(nested_command, *nested_cmd));
+  TF_ASSERT_OK(primary_cmd->UpdateChildCommand(nested_command, *nested_cmd));
   TF_ASSERT_OK(primary_cmd->Finalize());
 
   TF_ASSERT_OK(primary_cmd->Submit(stream.get()));
@@ -716,7 +716,7 @@ TEST(GpuCommandBufferTest, DISABLED_WhileNestedConditional) {
 
   CommandBuffer::CreateCommands create_body = [&](CommandBuffer* body_cmd,
                                                   auto deps) {
-    return Wrap(body_cmd->CreateNestedCommand(*nested_cmd, deps));
+    return Wrap(body_cmd->CreateClonedChildCommand(*nested_cmd, deps));
   };
 
   // Create a command buffer with a single conditional operation.

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -218,7 +218,7 @@ absl::Status RocmCommandBuffer::UpdateMemcpyD2DNode(
       "Failed to set memcpy d2d node params");
 }
 
-absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateChildNode(
+absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateClonedChildNode(
     absl::Span<const GraphNodeHandle> dependencies, CommandBuffer& nested) {
   auto& child_command_buffer =
       tensorflow::down_cast<RocmCommandBuffer&>(nested);

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -218,8 +218,11 @@ absl::Status RocmCommandBuffer::UpdateMemcpyD2DNode(
       "Failed to set memcpy d2d node params");
 }
 
-absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateClonedChildNode(
-    absl::Span<const GraphNodeHandle> dependencies, CommandBuffer& nested) {
+absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateChildNode(
+    ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
+    CommandBuffer& nested) {
+  CHECK(type == ChildCommandType::kCloned)
+      << "Moved child node creation is not supported";
   auto& child_command_buffer =
       tensorflow::down_cast<RocmCommandBuffer&>(nested);
   CHECK(child_command_buffer.parent_ == nullptr)
@@ -239,8 +242,11 @@ absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateClonedChildNode(
   return FromHipGraphHandle(node_handle);
 }
 
-absl::Status RocmCommandBuffer::UpdateChildNode(GraphNodeHandle node_handle,
+absl::Status RocmCommandBuffer::UpdateChildNode(ChildCommandType type,
+                                                GraphNodeHandle node_handle,
                                                 const CommandBuffer& nested) {
+  CHECK(type == ChildCommandType::kCloned)
+      << "Moved child node update is not supported";
   hipGraph_t child_graph =
       tensorflow::down_cast<const RocmCommandBuffer&>(nested).graph_;
 

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -116,11 +116,12 @@ class RocmCommandBuffer : public GpuCommandBuffer {
     return absl::UnimplementedError("Not implemented.");
   }
 
-  absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
-      absl::Span<const GraphNodeHandle> dependencies,
+  absl::StatusOr<GraphNodeHandle> CreateChildNode(
+      ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
       CommandBuffer& nested) override;
 
-  absl::Status UpdateChildNode(GraphNodeHandle node_handle,
+  absl::Status UpdateChildNode(ChildCommandType type,
+                               GraphNodeHandle node_handle,
                                const CommandBuffer& nested) override;
 
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -116,7 +116,7 @@ class RocmCommandBuffer : public GpuCommandBuffer {
     return absl::UnimplementedError("Not implemented.");
   }
 
-  absl::StatusOr<GraphNodeHandle> CreateChildNode(
+  absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
       absl::Span<const GraphNodeHandle> dependencies,
       CommandBuffer& nested) override;
 


### PR DESCRIPTION
This PR introduces the `ChildCmd` command type for command buffer. ChildCmd allows to construct the command buffer command sequence in a hierarchical way, which is convenient for some cases. 

`ChildCmd` will be lowered to child node for cuda implementation. Also to allow the child command sequence to be updated individually, the cuda implementation uses the [move semantics](https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaChildGraphNodeParams.html#structcudaChildGraphNodeParams_12650010fec316afac87d512424bc4ba8), i.e, user constructed the cuda graph, and transfer the ownership to cuda when creating the child node.  We can not use the clone semantics, because this will make the cuda graph node handles maintained by the command buffer non-valid. 

This PR also renames the `CreateChildNode` to `CreateClonedChildNode`, and `CreateNestedCmd` to `CreateClonedChildCmd` for naming consistency and clarification.

  