### PR TITLE
[XLA:GPU]Improve Flag Handling while Linking for oneAPI

### DIFF
--- a/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/gpus/sycl/BUILD.tpl
@@ -10,16 +10,6 @@ package(default_visibility = ["//visibility:public"])
 # The GNU General Public License v3.0 -> Tools-- Intel(R) Distribution for GDB*
 licenses(["restricted"])  
 
-# Intel(R) Software Development Tools Licensed under the Intel End User License Agreement for Developer Tools (Version August 2024)
-# Tools -> Intel(R) oneAPI DPC++/C++ Compiler, Intel(R) Vtune(TM) Profiler
-# Intel(R) Software Development Tools Licensed under the Intel Simplified Software License (Version October 2022)  
-# Tools -> oneAPI Math Kernel Library (oneMKL)
-# Intel(R) Software Development Tools Licensed under Open Source Licenses Apache License, Version 2.0 
-# Tools -> oneAPI Deep Neural Network Library, Intel(R) oneAPI Data Analytics Library (oneDAL)
-# Apache License, Version 2.0 with LLVM Exception -- Tools ->Intel(R) oneAPI DPC++/C++ Compiler,Intel(R) oneAPI DPC++ Library (oneDPL)
-# The GNU General Public License v3.0 -> Tools-- Intel(R) Distribution for GDB*
-licenses(["restricted"])  
-
 config_setting(
     name = "using_sycl",
     values = {


### PR DESCRIPTION
This PR addresses a linking failure caused by an overflow of command-line flags, resulting in an exit code 127 error during the linking stage. To resolve this, we introduced the following changes:

**Improved Handling of Whole-Archive Object Files**
Object files with .o or .lo extensions are now linked using the --whole-archive and --no-whole-archive flags. This forces the linker to include all symbols from these files, ensuring none are removed during linking. This change helps reduce the total number of linker flags while preserving necessary symbols, which in turn prevents command-line overflow issues.

For better debugging, we introduced support for the VERBOSE=1 environment variable. When set, it prints the full command line used to invoke the compiler, which helps with diagnosing cross-compilation issues and verifying correct toolchain usage.