### PR TITLE
Handle the API change of cuGraphAddNode in CUDA 13.

### DIFF
--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -283,10 +283,10 @@ CudaCommandBuffer::CreateConditionalNode(
 
   std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
   CUgraphNode node_handle = nullptr;
-  TF_RETURN_IF_ERROR(
-      cuda::ToStatus(cuGraphAddNode(&node_handle, graph_, deps.data(),
-                                    deps.size(), &cu_params),
-                     "Failed to add conditional node to a CUDA graph"));
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuGraphAddNode_v2(&node_handle, graph_, deps.data(),
+                        /*dependencyData=*/nullptr, deps.size(), &cu_params),
+      "Failed to add conditional node to a CUDA graph"));
 
   VLOG(2) << "Created conditional CUDA graph "
           << cu_params.conditional.phGraph_out[0];


### PR DESCRIPTION
Starting in CUDA 13, cuGraphAddNode takes an extra argument named dependencyData.
https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1ge01208e62f72a53367a2af903bf17d23

I changed XLA to use cuGraphAddNode_v2, whose signature didn't change with CUDA 13. cuGraphAddNode_v2 was added in CUDA 12.3:
https://docs.nvidia.com/cuda/archive/12.9.1/cuda-driver-api/group__CUDA__GRAPH.html#group__CUDA__GRAPH_1gb26c1065578f8753c0dde6b877186b77
so this fix won't work for earlier CUDA versions.

If Google wants to support CUDA before 12.3, we would have to keep using cuGraphAddNode here, with some conditional compilation depending on the CUDA version. Let me know what is preferable. 