### PR TITLE
Force command buffer usage on all compatible custom calls. 

### DIFF
--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -389,6 +389,7 @@ xla_test(
     deps = [
         ":command_buffer_scheduling",
         "//xla:xla_proto_cc",
+	"//xla/ffi:ffi",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/parser:hlo_parser",
         "//xla/hlo/testlib:filecheck",

--- a/xla/service/gpu/transforms/command_buffer_scheduling.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling.cc
@@ -221,6 +221,18 @@ bool IsCommand<HloOpcode::kConditional>(const HloInstruction* hlo,
                         });
 }
 
+static bool CanUseCommandBuffer(
+    const HloInstruction* hlo,
+    const CommandBufferConfig& config) {
+  // Check if FFI handler is compatible with command buffers.
+  if (auto* custom_call = DynCast<HloCustomCallInstruction>(hlo)) {
+    auto registration = ffi::FindHandler(custom_call->custom_call_target(), "gpu");
+    return registration.ok()
+               ? ffi::IsCommandBufferCompatible(registration->traits)
+               : false;
+  }
+}
+
 static bool IsCommand(const HloCustomCallInstruction* hlo,
                       const CommandBufferConfig& config) {
   // cuBLAS gemms represented in the HLO as custom call instructions.
@@ -251,12 +263,7 @@ static bool IsCommand(const HloCustomCallInstruction* hlo,
             << hlo->custom_call_target() << " into command buffer.";
     return true;
   }
-
-  // Check if FFI handler is compatible with command buffers.
-  auto registration = ffi::FindHandler(hlo->custom_call_target(), "gpu");
-  return registration.ok()
-             ? ffi::IsCommandBufferCompatible(registration->traits)
-             : false;
+  return CanUseCommandBuffer(hlo, config);
 }
 
 static bool IsCommand(const HloInstruction* hlo,
@@ -451,14 +458,16 @@ CommandBufferScheduling::CollectCommandBufferSequences(
 
   HloInstructionSequence current_seq;
   int64_t num_commands_in_current_seq = 0;
+  auto must_use_command_buffer = false;
 
   // Adds `current_seq` to `sequences` if it has enough commands in it.
   auto collect_current_seq = [&]() {
-    if (num_commands_in_current_seq >= std::max(1, min_num_commands)) {
+    if (num_commands_in_current_seq >= std::max(1, min_num_commands) || must_use_command_buffer) {
       RemoveTrailingNoOps(current_seq);
       sequences.push_back(std::move(current_seq));
     }
     current_seq = HloInstructionSequence();
+    must_use_command_buffer = false;
     num_commands_in_current_seq = 0;
   };
 
@@ -579,6 +588,9 @@ CommandBufferScheduling::CollectCommandBufferSequences(
         check_dynamic_slice_operand_not_from_seq(current_seq, inst)) {
       num_commands_in_current_seq++;
       current_seq.push_back(inst);
+      if (CanUseCommandBuffer(inst, config)) {
+        must_use_command_buffer = true;
+      }
       continue;
     }
 

--- a/xla/service/gpu/transforms/command_buffer_scheduling.cc
+++ b/xla/service/gpu/transforms/command_buffer_scheduling.cc
@@ -221,16 +221,17 @@ bool IsCommand<HloOpcode::kConditional>(const HloInstruction* hlo,
                         });
 }
 
-static bool CanUseCommandBuffer(
-    const HloInstruction* hlo,
-    const CommandBufferConfig& config) {
+static bool CallCanUseCommandBuffer(const HloInstruction* hlo,
+                                    const CommandBufferConfig& config) {
   // Check if FFI handler is compatible with command buffers.
   if (auto* custom_call = DynCast<HloCustomCallInstruction>(hlo)) {
-    auto registration = ffi::FindHandler(custom_call->custom_call_target(), "gpu");
+    auto registration =
+        ffi::FindHandler(custom_call->custom_call_target(), "gpu");
     return registration.ok()
                ? ffi::IsCommandBufferCompatible(registration->traits)
                : false;
   }
+  return false;
 }
 
 static bool IsCommand(const HloCustomCallInstruction* hlo,
@@ -263,7 +264,7 @@ static bool IsCommand(const HloCustomCallInstruction* hlo,
             << hlo->custom_call_target() << " into command buffer.";
     return true;
   }
-  return CanUseCommandBuffer(hlo, config);
+  return CallCanUseCommandBuffer(hlo, config);
 }
 
 static bool IsCommand(const HloInstruction* hlo,
@@ -462,7 +463,8 @@ CommandBufferScheduling::CollectCommandBufferSequences(
 
   // Adds `current_seq` to `sequences` if it has enough commands in it.
   auto collect_current_seq = [&]() {
-    if (num_commands_in_current_seq >= std::max(1, min_num_commands) || must_use_command_buffer) {
+    if (num_commands_in_current_seq >= std::max(1, min_num_commands) ||
+        must_use_command_buffer) {
       RemoveTrailingNoOps(current_seq);
       sequences.push_back(std::move(current_seq));
     }
@@ -587,10 +589,10 @@ CommandBufferScheduling::CollectCommandBufferSequences(
     if (IsCommand(inst, config) &&
         check_dynamic_slice_operand_not_from_seq(current_seq, inst)) {
       num_commands_in_current_seq++;
-      current_seq.push_back(inst);
-      if (CanUseCommandBuffer(inst, config)) {
+      if (CallCanUseCommandBuffer(inst, config)) {
         must_use_command_buffer = true;
       }
+      current_seq.push_back(inst);
       continue;
     }
 


### PR DESCRIPTION
Previously, when a user enabled command buffers on a custom call, it might not have been wrapped if there were not enough other operations to combine with. This change forces all registered compatible custom calls to be command buffer wrapped, regardless whether enough other operations can be combined. 

This is the implementation of Proposal A of https://docs.google.com/document/d/1kyAWzpPDrYNpeQGd07npSU7A_d-AgRKn1_ako1YtPk8/edit?usp=sharing