### PR TITLE
[ROCm] bugfix EnablePeerAccess in rocm_executor

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -372,8 +372,9 @@ absl::Status EnablePeerAccess(Context* from, Context* to) {
   }
 
   ScopedActivateContext activated(from);
-  hipError_t result = wrap::hipCtxEnablePeerAccess(
-      tensorflow::down_cast<RocmContext*>(to)->context(), 0 /* = flags */);
+  hipError_t result =
+      wrap::hipDeviceEnablePeerAccess(to->device_ordinal(), 0 /* = flags */);
+
   if (result != hipSuccess && result != hipErrorPeerAccessAlreadyEnabled) {
     return absl::InternalError(
         absl::StrFormat("failed to enable peer access from %d to %d: %s",


### PR DESCRIPTION
This would fix the failed unit test //xla/backends/gpu/runtime:all_reduce_test, previously the peer to peer access was not properly enabled.

@xla-rotation could you review my PR, please?