### PR TITLE
[XLA:GPU] Enable block_n=8 for triton dot fusion emitter

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter_legacy_matmul.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter_legacy_matmul.cc
@@ -828,7 +828,7 @@ absl::Status ValidateMatMulConfig(const TritonGemmConfig& config,
   TF_RET_CHECK(config.split_k >= 1);
   TF_RET_CHECK(config.block_m >= 16);
   TF_RET_CHECK(config.block_k >= 16);
-  TF_RET_CHECK(config.block_n >= 16);
+  TF_RET_CHECK(config.block_n >= 8);
 
   const auto& dims = dot.dot_dimension_numbers();
   int num_batch_dims =

--- a/xla/service/gpu/autotuning/dot_search_space_test.cc
+++ b/xla/service/gpu/autotuning/dot_search_space_test.cc
@@ -188,7 +188,7 @@ TEST_F(DotSearchSpaceTest, SerializesSearchSpace) {
 
   EXPECT_EQ(search_space.ToString(),
             "problem_size_BxMxNxKxE: 1x1024x1024x1024x(16->16) "
-            "tile_range_SxMxNxK: [1-64]x[16-256]x[16-512]x[16-?] "
+            "tile_range_SxMxNxK: [1-64]x[16-256]x[8-512]x[16-?] "
             "desired_total_warps: 2640 occupancy_optimization: 1 "
             "warps_per_cta: [2-?]");
 }
@@ -307,7 +307,7 @@ TEST_F(DotSearchSpaceTest,
                           /*contracting_dim=*/64));
   TritonDotFusionSearchSpace search_space = MakeSearchSpace(module.get());
   EXPECT_THAT(search_space.GenerateConfigs(),
-              AllOf(SizeIs(1), Each(AllOf(BlockMIs(Eq(16)), BlockNIs(Eq(16)),
+              AllOf(SizeIs(1), Each(AllOf(BlockMIs(Eq(16)), BlockNIs(Eq(8)),
                                           SplitKIs(Eq(4))))));
 }
 
@@ -341,7 +341,7 @@ TEST_F(DotSearchSpaceTest, HonorsMinimumOutputTileSizeForTinyProblem) {
 
   EXPECT_THAT(
       search_space.GenerateConfigs(),
-      AllOf(Not(IsEmpty()), Each(BlockMIs(Ge(16))), Each(BlockNIs(Ge(16)))));
+      AllOf(Not(IsEmpty()), Each(BlockMIs(Ge(16))), Each(BlockNIs(Ge(8)))));
 }
 
 TEST_F(DotSearchSpaceTest, AssignsEnoughWarpsPerScheduler) {


### PR DESCRIPTION
This results in significant improvement for shapes with small non-contracting dim (N).

TritonDotFusionSearchSpace is updated, as it currently produces configs that fail at runtime:
{block_m=?, block_n=8, block_k=16, num_warps=8}

Related Triton change: https://github.com/triton-lang/triton/commit/19277de9a45dce943b246cd0875221a3a644c06a