### PR TITLE
[XLA:GPU] Refactor dynamic slice fusion lowering code to reduce the API calls

### DIFF
--- a/xla/backends/gpu/codegen/custom.cc
+++ b/xla/backends/gpu/codegen/custom.cc
@@ -210,16 +210,7 @@ std::optional<HloInstruction*> GetParentWhileOp(const HloInstruction& op,
 // ensured before fusing in
 // `dynamic_slice_fusion_rewriter.cc:IsValueFunctionOfLoopInductionVariable`.
 std::unique_ptr<HloModule> ExtractOffsetModule(
-    const HloInstruction* offset_value,
-    std::optional<const HloInstruction*> while_op) {
-  if (while_op == std::nullopt) return nullptr;
-
-  // First we check that we can get the indvar index.
-  std::optional<int64_t> indvar_idx = GetLoopInductionVarTupleIdx(*while_op);
-  CHECK(indvar_idx != std::nullopt)
-      << "Unable to get tuple idx for offset value: "
-      << (*while_op)->ToString();
-
+    const HloInstruction* offset_value, int64_t indvar_idx) {
   // Extract offset as a function of parameter to while body.
   std::unique_ptr<HloModule> extracted_offset = ExtractModule(
       /*instruction=*/offset_value, /*height=*/-1,
@@ -245,11 +236,11 @@ std::unique_ptr<HloModule> ExtractOffsetModule(
       extracted_offset->entry_computation()->parameter_instruction(0)->users(),
       [indvar_idx](const HloInstruction* instr) {
         return instr->opcode() == HloOpcode::kGetTupleElement &&
-               instr->tuple_index() == *indvar_idx;
+               instr->tuple_index() == indvar_idx;
       }))
       << "Extracted offset module does not have all operations on the "
          "parameter as get-tuple-element for index "
-      << *indvar_idx << ": " << extracted_offset->ToString();
+      << indvar_idx << ": " << extracted_offset->ToString();
 
   // We simply replace the parameter with the get-tuple-element instruction as
   // the parameter.
@@ -266,26 +257,18 @@ std::unique_ptr<HloModule> ExtractOffsetModule(
 // these conditions are ensured before fusing in
 // `dynamic_slice_fusion_rewriter.cc:IsValueFunctionOfLoopInductionVariable`.
 std::unique_ptr<HloModule> ExtractWhileUpdateModule(
-    const HloInstruction* while_op) {
-  std::optional<int64_t> tuple_idx = GetLoopInductionVarTupleIdx(while_op);
-  if (tuple_idx == std::nullopt) {
-    return nullptr;
-  }
+    const HloInstruction* while_op, int64_t indvar_idx) {
   const HloInstruction* update =
-      while_op->while_body()->root_instruction()->operand(*tuple_idx);
-  return ExtractOffsetModule(update, while_op);
+      while_op->while_body()->root_instruction()->operand(indvar_idx);
+  return ExtractOffsetModule(update, indvar_idx);
 }
 
 // Extracts the while induction variable initialization module. This must have
 // no parameters and this condition was ensured before fusing in
 // `dynamic_slice_fusion_rewriter.cc:IsValueFunctionOfLoopInductionVariable`.
 std::unique_ptr<HloModule> ExtractWhileInitModule(
-    const HloInstruction* while_op) {
-  std::optional<int64_t> tuple_idx = GetLoopInductionVarTupleIdx(while_op);
-  if (tuple_idx == std::nullopt) {
-    return nullptr;
-  }
-  const HloInstruction* init = while_op->operand(0)->operand(*tuple_idx);
+    const HloInstruction* while_op, int64_t indvar_idx) {
+  const HloInstruction* init = while_op->operand(0)->operand(indvar_idx);
   std::unique_ptr<HloModule> init_module = ExtractModule(
       /*instruction=*/init, /*height=*/-1, /*extract_selector=*/nullptr,
       /*replace_type_selector=*/nullptr, /*cross_computation=*/false,
@@ -293,6 +276,11 @@ std::unique_ptr<HloModule> ExtractWhileInitModule(
   CHECK(init_module->entry_computation()->num_parameters() == 0)
       << "Expected zero parameter for init module: " << init_module->ToString();
   return init_module;
+}
+
+std::unique_ptr<HloModule> ExtractSliceModule(
+    const HloInstruction* offset_value, int64_t indvar_idx) {
+  return ExtractOffsetModule(offset_value, indvar_idx);
 }
 
 bool IsDynamicSliceOrDynamicUpdateSlice(const HloInstruction* instr) {
@@ -319,6 +307,13 @@ absl::Status CollectSliceInfo(
       Cast<HloDynamicIndexInstruction>(slice_instrs[arg_idx]);
   std::optional<HloInstruction*> async_caller =
       fusion_instr.parent()->GetUniqueCaller(HloOpcode::kAsyncStart);
+
+  std::optional<int64_t> indvar_idx = std::nullopt;
+  if (while_op != std::nullopt) {
+    CHECK(while_op.value() != nullptr)
+        << "GetWhileOp is not expected to return nullptr.";
+    indvar_idx = GetLoopInductionVarTupleIdx(*while_op);
+  }
 
   std::vector<DynamicSliceThunk::Offset> arg_offsets;
   for (auto idx_op : arg_slice_instr->index_operands()) {
@@ -347,10 +342,10 @@ absl::Status CollectSliceInfo(
             absl::StrCat("Unsupported constant offset shape: ",
                          offset_literal->shape().ToString()));
       }
-
-    } else if (std::unique_ptr<HloModule> offset_module =
-                   ExtractOffsetModule(offset_value, while_op);
-               (can_compute_indvar_on_host && offset_module != nullptr)) {
+    } else if (indvar_idx != std::nullopt && can_compute_indvar_on_host) {
+      std::unique_ptr<HloModule> offset_module =
+          ExtractSliceModule(offset_value, indvar_idx.value());
+      CHECK(offset_module != nullptr) << "Failed to extract slice module";
       extracted_offset_modules.push_back(std::move(offset_module));
       arg_offsets.emplace_back() = extracted_offset_modules.back().get();
     } else {
@@ -406,9 +401,9 @@ absl::StatusOr<BufferAllocation::Slice> GetResultSlice(
     return GetAllocationSlice(buffer_assignment, &fusion_instr, shape_idx);
   }
 
-  // Walk through ShapeIndex to find the real "user" (i.e. not get-tuple-element
-  // user). Otherwise one sliced element will mark all buffers of all other
-  // elements "sliced" too.
+  // Walk through ShapeIndex to find the real "user" (i.e. not
+  // get-tuple-element user). Otherwise one sliced element will mark all
+  // buffers of all other elements "sliced" too.
   if (start->shape().IsTuple()) {
     for (auto [index_nesting_level, index_in_shape] :
          llvm::enumerate(shape_idx)) {
@@ -483,8 +478,8 @@ absl::StatusOr<BufferAllocation::Slice> GetResultSlice(
   // computation. There are two options; either, the root is a tuple, or it is
   // not.
   //
-  // If the root is not a tuple, we can simply get the buffer slice assigned to
-  // the fusion itself---there is nothing else to choose from.
+  // If the root is not a tuple, we can simply get the buffer slice assigned
+  // to the fusion itself---there is nothing else to choose from.
   if (fusion_instr.shape().IsArray()) {
     HloInstruction* root = fusion_instr.fused_expression_root();
     if (root->opcode() == HloOpcode::kDynamicUpdateSlice &&
@@ -502,7 +497,8 @@ absl::StatusOr<BufferAllocation::Slice> GetResultSlice(
   do {
     TF_RET_CHECK(current_hlo->user_count() == 1);
     HloInstruction* user = current_hlo->users().front();
-    // We may encounter three ops here: dynamic-update-slice, tuple, or bitcast.
+    // We may encounter three ops here: dynamic-update-slice, tuple, or
+    // bitcast.
     switch (user->opcode()) {
       case HloOpcode::kBitcast:
         break;
@@ -550,27 +546,32 @@ absl::StatusOr<FusionEmissionResult> EmitGemm(
   if (while_op != std::nullopt) {
     CHECK(while_op.value() != nullptr)
         << "GetWhileOp is not expected to return nullptr.";
-    init_module = ExtractWhileInitModule(*while_op);
-    update_module = ExtractWhileUpdateModule(*while_op);
+    std::optional<int64_t> indvar_idx = GetLoopInductionVarTupleIdx(*while_op);
+    if (indvar_idx != std::nullopt) {
+      init_module = ExtractWhileInitModule(*while_op, indvar_idx.value());
+      update_module = ExtractWhileUpdateModule(*while_op, indvar_idx.value());
+    }
   }
   bool can_compute_indvar_on_host =
       (init_module != nullptr && update_module != nullptr);
 
   unsigned arg_idx = 0;
-  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice lhs_slice,
-                      GetOperandSlice(buffer_assignment, adaptor, fusion,
-                                      *custom_call.operand(arg_idx),
-                                      slice_instrs, /*shape_idx=*/{}, arg_idx));
+  TF_ASSIGN_OR_RETURN(
+      BufferAllocation::Slice lhs_slice,
+      GetOperandSlice(buffer_assignment, adaptor, fusion,
+                      *custom_call.operand(arg_idx), slice_instrs,
+                      /*shape_idx=*/{}, arg_idx));
   TF_RETURN_IF_ERROR(CollectSliceInfo(
       buffer_assignment, fusion, absl::Span<HloInstruction*>(slice_instrs),
       offset_buffer_indices, orig_shapes, sliced_shapes, offset_byte_sizes,
       extracted_offset_modules, arg_idx++, can_compute_indvar_on_host,
       while_op));
 
-  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice rhs_slice,
-                      GetOperandSlice(buffer_assignment, adaptor, fusion,
-                                      *custom_call.operand(arg_idx),
-                                      slice_instrs, /*shape_idx=*/{}, arg_idx));
+  TF_ASSIGN_OR_RETURN(
+      BufferAllocation::Slice rhs_slice,
+      GetOperandSlice(buffer_assignment, adaptor, fusion,
+                      *custom_call.operand(arg_idx), slice_instrs,
+                      /*shape_idx=*/{}, arg_idx));
   TF_RETURN_IF_ERROR(CollectSliceInfo(
       buffer_assignment, fusion, absl::Span<HloInstruction*>(slice_instrs),
       offset_buffer_indices, orig_shapes, sliced_shapes, offset_byte_sizes,
@@ -582,9 +583,9 @@ absl::StatusOr<FusionEmissionResult> EmitGemm(
   std::optional<BufferAllocation::Slice> slice_workspace_fake = std::nullopt;
 
   // Handling cases where multiple operands share the same buffer, with
-  // different offset by creating new fake allocations so each operand will have
-  // a different buffer index. The slices can thus always start at offset 0.
-  // DynamicSliceThunk will take care of the offset adjustment.
+  // different offset by creating new fake allocations so each operand will
+  // have a different buffer index. The slices can thus always start at offset
+  // 0. DynamicSliceThunk will take care of the offset adjustment.
   std::vector<std::unique_ptr<BufferAllocation>> fake_allocations(4);
   if (fusion.shape().IsArray()) {
     TF_ASSIGN_OR_RETURN(
@@ -683,7 +684,8 @@ absl::StatusOr<FusionEmissionResult> EmitGemm(
           DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata{
               /*indvar_init=*/std::move(init_module),
               /*indvar_update=*/std::move(update_module),
-              /*extracted_offset_modules=*/std::move(extracted_offset_modules)};
+              /*extracted_offset_modules=*/
+              std::move(extracted_offset_modules)};
     }
     thunk = std::make_unique<DynamicSliceThunk>(
         thunk_info, std::make_unique<ThunkSequence>(std::move(seq)),
@@ -756,8 +758,12 @@ absl::StatusOr<FusionEmissionResult> EmitCustomCall(
   if (while_op != std::nullopt) {
     CHECK(while_op.value() != nullptr)
         << "GetWhileOp is not expected to return nullptr.";
-    init_module = ExtractWhileInitModule(*while_op);
-    update_module = ExtractWhileUpdateModule(*while_op);
+
+    std::optional<int64_t> indvar_idx = GetLoopInductionVarTupleIdx(*while_op);
+    if (indvar_idx != std::nullopt) {
+      init_module = ExtractWhileInitModule(*while_op, indvar_idx.value());
+      update_module = ExtractWhileUpdateModule(*while_op, indvar_idx.value());
+    }
   }
   bool can_compute_indvar_on_host =
       (init_module != nullptr && update_module != nullptr);
@@ -831,8 +837,8 @@ absl::StatusOr<FusionEmissionResult> EmitCustomCall(
   CustomCallThunk::CustomCallTarget custom_call_target;
 
   // For XLA FFI handlers we decode opaque backend config into attributes map
-  // at IR emission time, so that we do not need to parse MLIR at run time. For
-  // FFI handlers backend config must be a compatible MLIR dictionary.
+  // at IR emission time, so that we do not need to parse MLIR at run time.
+  // For FFI handlers backend config must be a compatible MLIR dictionary.
   CustomCallThunk::AttributesMap attributes;
 
   // For information about this calling convention, see
@@ -982,7 +988,8 @@ absl::StatusOr<FusionEmissionResult> EmitCustomCall(
           DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata{
               /*indvar_init=*/std::move(init_module),
               /*indvar_update=*/std::move(update_module),
-              /*extracted_offset_modules=*/std::move(extracted_offset_modules)};
+              /*extracted_offset_modules=*/
+              std::move(extracted_offset_modules)};
     }
     thunk = std::make_unique<DynamicSliceThunk>(
         thunk_info, std::make_unique<ThunkSequence>(std::move(seq)),
@@ -1058,8 +1065,13 @@ CollectSliceArgumentMetadataForCollectives(
   if (while_op != std::nullopt) {
     CHECK(while_op.value() != nullptr)
         << "GetParentWhileOp is not expected to return nullptr.";
-    slice_data.init_module = ExtractWhileInitModule(*while_op);
-    slice_data.update_module = ExtractWhileUpdateModule(*while_op);
+    std::optional<int64_t> indvar_idx = GetLoopInductionVarTupleIdx(*while_op);
+    if (indvar_idx != std::nullopt) {
+      slice_data.init_module =
+          ExtractWhileInitModule(*while_op, indvar_idx.value());
+      slice_data.update_module =
+          ExtractWhileUpdateModule(*while_op, indvar_idx.value());
+    }
   }
   slice_data.can_compute_indvar_on_host = (slice_data.init_module != nullptr &&
                                            slice_data.update_module != nullptr);
@@ -1130,8 +1142,8 @@ CollectSliceArgumentMetadataForCollectives(
       << "Dynamic index operation found in a fusion instruction that is not "
          "labelled dynamic_address_computation";
   if (slice_data.isDynamic) {
-    // Provide fake allocations for inputs and outputs. The dynamic-slice thunk
-    // will own these allocations.
+    // Provide fake allocations for inputs and outputs. The dynamic-slice
+    // thunk will own these allocations.
     unsigned fake_arg_idx = 0;
     for (HloInstruction* operand : instr->operands()) {
       int64_t operand_byte_size = ShapeUtil::ByteSizeOf(operand->shape());
@@ -1157,7 +1169,8 @@ CollectSliceArgumentMetadataForCollectives(
       int64_t out_fake_byte_size = ShapeUtil::ByteSizeOf(user->shape());
       slice_data.fake_allocations[fake_arg_idx] =
           std::make_unique<BufferAllocation>(
-              /*index=*/fake_arg_idx, /*size=*/out_fake_byte_size, /*color=*/0);
+              /*index=*/fake_arg_idx, /*size=*/out_fake_byte_size,
+              /*color=*/0);
       BufferAllocation::Slice fake_slice(
           /*allocation=*/slice_data.fake_allocations[fake_arg_idx].get(),
           /*offset=*/0, /*size=*/out_fake_byte_size);
@@ -1237,7 +1250,8 @@ absl::StatusOr<FusionEmissionResult> EmitCollective(
       std::optional<BufferAllocation::Slice> dst =
           slice_data.args()[idx + instr->operand_count()];
       TF_RET_CHECK(src.has_value() && dst.has_value())
-          << "Expected source and destination to be present for non-degenerate "
+          << "Expected source and destination to be present for "
+             "non-degenerate "
              "collective";
       buffers.push_back(CollectiveThunk::Buffer{
           /*element_count=*/ShapeUtil::ElementsIn(src_shape),
@@ -1272,8 +1286,8 @@ absl::StatusOr<FusionEmissionResult> EmitCollective(
     return implementable_status;
   }
 
-  // Depending on whether this is a dynamic fusion or not, we wrap the thunk(s)
-  // within a dynamic-slice thunk.
+  // Depending on whether this is a dynamic fusion or not, we wrap the
+  // thunk(s) within a dynamic-slice thunk.
   if (slice_data.isDynamic) {
     std::optional<DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata>
         offset_modules_metadata = std::nullopt;

--- a/xla/backends/gpu/codegen/custom.cc
+++ b/xla/backends/gpu/codegen/custom.cc
@@ -292,6 +292,9 @@ bool IsDynamicSliceOrDynamicUpdateSlice(const HloInstruction* instr) {
 // can be computed on host. while_op is the possible while op surrounding the
 // fusion. indvar_idx is the possible tuple index of the induction variable in
 // the while body.
+// Note that when there is a wrapping while loop, we may not have an index
+// variable for the loop, in case when the loop count is not naively controlled
+// by a single loop index, so we will have the while op but no indvar_idx.
 absl::Status CollectSliceInfo(
     const BufferAssignment& buffer_assignment,
     const HloInstruction& fusion_instr,
@@ -540,7 +543,7 @@ absl::StatusOr<FusionEmissionResult> EmitGemm(
   std::optional<HloInstruction*> while_op =
       GetParentWhileOp(fusion, call_graph);
   std::unique_ptr<HloModule> init_module, update_module;
-  std::optional<int64_t> indvar_idx = std::nullopt;
+  std::optional<int64_t> indvar_idx;
   if (while_op != std::nullopt) {
     CHECK(while_op.value() != nullptr)
         << "GetWhileOp is not expected to return nullptr.";

--- a/xla/backends/gpu/codegen/custom.cc
+++ b/xla/backends/gpu/codegen/custom.cc
@@ -209,6 +209,7 @@ std::optional<HloInstruction*> GetParentWhileOp(const HloInstruction& op,
 // hard checks for the conditions on this here, because these conditions are
 // ensured before fusing in
 // `dynamic_slice_fusion_rewriter.cc:IsValueFunctionOfLoopInductionVariable`.
+// indvar_idx is the tuple index of the induction variable in the while body.
 std::unique_ptr<HloModule> ExtractOffsetModule(
     const HloInstruction* offset_value, int64_t indvar_idx) {
   // Extract offset as a function of parameter to while body.
@@ -256,6 +257,7 @@ std::unique_ptr<HloModule> ExtractOffsetModule(
 // variable. There are hard checks for the conditions on this here, because
 // these conditions are ensured before fusing in
 // `dynamic_slice_fusion_rewriter.cc:IsValueFunctionOfLoopInductionVariable`.
+// indvar_idx is the tuple index of the induction variable in the while body.
 std::unique_ptr<HloModule> ExtractWhileUpdateModule(
     const HloInstruction* while_op, int64_t indvar_idx) {
   const HloInstruction* update =
@@ -266,6 +268,7 @@ std::unique_ptr<HloModule> ExtractWhileUpdateModule(
 // Extracts the while induction variable initialization module. This must have
 // no parameters and this condition was ensured before fusing in
 // `dynamic_slice_fusion_rewriter.cc:IsValueFunctionOfLoopInductionVariable`.
+// indvar_idx is the tuple index of the induction variable in the while body.
 std::unique_ptr<HloModule> ExtractWhileInitModule(
     const HloInstruction* while_op, int64_t indvar_idx) {
   const HloInstruction* init = while_op->operand(0)->operand(indvar_idx);
@@ -284,6 +287,11 @@ bool IsDynamicSliceOrDynamicUpdateSlice(const HloInstruction* instr) {
           instr->opcode() == HloOpcode::kDynamicUpdateSlice);
 }
 
+// Collects the slice info for the argument `arg_idx` of the fusion
+// `fusion_instr`. can_compute_indvar_on_host is true if the induction variable
+// can be computed on host. while_op is the possible while op surrounding the
+// fusion. indvar_idx is the possible tuple index of the induction variable in
+// the while body.
 absl::Status CollectSliceInfo(
     const BufferAssignment& buffer_assignment,
     const HloInstruction& fusion_instr,

--- a/xla/backends/gpu/codegen/custom.cc
+++ b/xla/backends/gpu/codegen/custom.cc
@@ -278,11 +278,6 @@ std::unique_ptr<HloModule> ExtractWhileInitModule(
   return init_module;
 }
 
-std::unique_ptr<HloModule> ExtractSliceModule(
-    const HloInstruction* offset_value, int64_t indvar_idx) {
-  return ExtractOffsetModule(offset_value, indvar_idx);
-}
-
 bool IsDynamicSliceOrDynamicUpdateSlice(const HloInstruction* instr) {
   return instr != nullptr &&
          (instr->opcode() == HloOpcode::kDynamicSlice ||
@@ -338,7 +333,7 @@ absl::Status CollectSliceInfo(
       }
     } else if (indvar_idx != std::nullopt && can_compute_indvar_on_host) {
       std::unique_ptr<HloModule> offset_module =
-          ExtractSliceModule(offset_value, indvar_idx.value());
+          ExtractOffsetModule(offset_value, indvar_idx.value());
       CHECK(offset_module != nullptr) << "Failed to extract slice module";
       extracted_offset_modules.push_back(std::move(offset_module));
       arg_offsets.emplace_back() = extracted_offset_modules.back().get();


### PR DESCRIPTION
This PR should be able to remove many redundant calls to `GetLoopInductionVarTupleIdx`