### PR TITLE
Rename sm_101 to sm_110. Naming change for Thor; takes effect on CUDA 13 onward.

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -244,7 +244,7 @@ std::string GetSmName(se::CudaComputeCapability compute_capability) {
   // If the current compute capability isn't known, fallback to the
   // most recent version before it.
   constexpr stream_executor::CudaComputeCapability kSupportedVersions[] = {
-      {12, 1}, {12, 0}, {10, 3}, {10, 1}, {10, 0}, {9, 0}, {8, 9}, {8, 7},
+      {12, 1}, {12, 0}, {11, 0}, {10, 3}, {10, 0}, {9, 0}, {8, 9}, {8, 7},
       {8, 6},  {8, 0},  {7, 5},  {7, 2},  {7, 0},  {6, 2}, {6, 1}, {6, 0},
       {5, 3},  {5, 2},  {5, 0},  {3, 7},  {3, 5},  {3, 2}, {3, 0}};
   auto target_compute_capability = kSupportedVersions[0];

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -43,11 +43,11 @@ TEST(UtilsTest, TestGetSmName) {
                 10, 0, FeatureExtension::kForwardCompatibleFeatures}),
             "sm_100f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
-                10, 1, FeatureExtension::kAcceleratedFeatures}),
-            "sm_101a");
-  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
                 10, 3, FeatureExtension::kAcceleratedFeatures}),
             "sm_103a");
+  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
+                11, 0, FeatureExtension::kAcceleratedFeatures}),
+            "sm_110a");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
                 12, 0, FeatureExtension::kAcceleratedFeatures}),
             "sm_120a");


### PR DESCRIPTION
sm_101 is the SM number for Thor prior to CUDA 13. It will be effectively unused. XLA can support Thor only on CUDA 13 onward.