### PR TITLE
[XLA:GPU] Refactoring the command dependency implementation through token resources

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -275,7 +275,6 @@ class CommandOperation : public ExecutionGraph::Operation {
   CommandBufferCmd::BufferUseVector buffers_;
   const CommandBufferCmd* cmd_;
   ResourceUseVector resources_;
-  const CommandBufferCmd* cmd_;
 
   // The token resource is used to specify dependency other than buffer data
   // flow, e.g, LHS topology will use token resouce to specify dependency across

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -238,16 +238,12 @@ namespace {
 class CommandOperation : public ExecutionGraph::Operation {
  public:
   explicit CommandOperation(CommandBufferCmd::BufferUseVector buffers,
-                            ResourceUseVector resources,
                             const CommandBufferCmd* cmd)
       : name_(absl::StrFormat("cmd %s: %s", cmd->ToString(),
                               cmd->profile_annotation())),
         buffers_(std::move(buffers)),
-        resources_(std::move(resources)),
         cmd_(cmd),
-        token_(Resource::Create(Resource::Kind::kToken)) {
-    resources_.push_back(ResourceUse::Write(token_));
-  }
+        resources_(cmd_->resources()) {}
 
   absl::string_view name() const final { return name_; }
   absl::Span<const BufferUse> BufferUses() const final { return buffers_; }
@@ -258,7 +254,6 @@ class CommandOperation : public ExecutionGraph::Operation {
     resources_.push_back(resource_use);
   }
 
-  std::shared_ptr<Resource> token() const { return token_; }
   const CommandBufferCmd* cmd() const { return cmd_; }
 
   std::string ToString() const final {
@@ -271,7 +266,6 @@ class CommandOperation : public ExecutionGraph::Operation {
       resource_reprs.push_back(
           absl::StrFormat("%s@%p(%s)", kind, use.resource().get(), access));
     }
-
     return absl::StrFormat("%s resources=[%s]", cmd_->ToString(),
                            absl::StrJoin(resource_reprs, ", "));
   }
@@ -279,6 +273,7 @@ class CommandOperation : public ExecutionGraph::Operation {
  private:
   std::string name_;
   CommandBufferCmd::BufferUseVector buffers_;
+  const CommandBufferCmd* cmd_;
   ResourceUseVector resources_;
   const CommandBufferCmd* cmd_;
 
@@ -304,7 +299,7 @@ static std::vector<CommandOperation> CreateCommandOperations(
     // For concurrent synchronization mode, pass in buffer and resouces for
     // dependency inference.
     for (const std::unique_ptr<CommandBufferCmd>& cmd : commands) {
-      operations.emplace_back(cmd->buffers(), cmd->resources(), cmd.get());
+      operations.emplace_back(cmd->buffers(), cmd.get());
     }
   }
 
@@ -313,8 +308,7 @@ static std::vector<CommandOperation> CreateCommandOperations(
     // For LHS mode, don't pass in buffers.
     // Will use token resource to specify dependency across commands.
     for (const std::unique_ptr<CommandBufferCmd>& cmd : commands) {
-      operations.emplace_back(CommandBufferCmd::BufferUseVector{},
-                              cmd->resources(), cmd.get());
+      operations.emplace_back(CommandBufferCmd::BufferUseVector{}, cmd.get());
     }
 
     auto is_async_start = [](const CommandOperation& op) -> bool {
@@ -352,18 +346,18 @@ static std::vector<CommandOperation> CreateCommandOperations(
             continue;
           }
           operations[i].add_resouce_use(
-              ResourceUse::Read(operations[j].token()));
+              ResourceUse::Read(commands[j]->token()));
           break;
         }
       } else if (is_async_done(operations[i])) {
         int64_t async_start_cmd_id = find_async_start_cmd_id(i);
         CHECK_NE(async_start_cmd_id, -1);
         operations[i].add_resouce_use(
-            ResourceUse::Read(operations[async_start_cmd_id].token()));
+            ResourceUse::Read(commands[async_start_cmd_id]->token()));
         CHECK_GT(i, 0);
         if ((i - 1) != async_start_cmd_id) {
           operations[i].add_resouce_use(
-              ResourceUse::Read(operations[i - 1].token()));
+              ResourceUse::Read(commands[i - 1]->token()));
         }
       } else {
         for (int64_t j = i - 1; j >= 0; --j) {
@@ -373,7 +367,7 @@ static std::vector<CommandOperation> CreateCommandOperations(
             continue;
           }
           operations[i].add_resouce_use(
-              ResourceUse::Read(operations[j].token()));
+              ResourceUse::Read(commands[j]->token()));
           break;
         }
       }
@@ -830,9 +824,8 @@ absl::StatusOr<se::CommandBuffer*> TracedCommandBuffer::GetOrTraceCommandBuffer(
 // TracedCommandBufferCmd
 //===----------------------------------------------------------------------===//
 
-TracedCommandBufferCmd::TracedCommandBufferCmd(CommandBufferCmdType cmd_type,
-                                               ResourceUseVector resources)
-    : CommandBufferCmd(cmd_type, std::move(resources)) {}
+TracedCommandBufferCmd::TracedCommandBufferCmd(CommandBufferCmdType cmd_type)
+    : CommandBufferCmd(cmd_type) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
 TracedCommandBufferCmd::RecordTracedCommand(
@@ -871,8 +864,7 @@ TracedCommandBufferCmd::RecordTracedCommand(
 // EmptyCmd
 //===----------------------------------------------------------------------===//
 
-EmptyCmd::EmptyCmd(ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kEmptyCmd, std::move(resources)) {}
+EmptyCmd::EmptyCmd() : CommandBufferCmd(CommandBufferCmdType::kEmptyCmd) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
     const Thunk::ExecuteParams& execute_params,
@@ -894,9 +886,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
 //===----------------------------------------------------------------------===//
 
 AsyncDoneCmd::AsyncDoneCmd(
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kAsyncDone, std::move(resources)),
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
+    : CommandBufferCmd(CommandBufferCmdType::kAsyncDone),
       async_events_(std::move(async_events)) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> AsyncDoneCmd::Record(
@@ -917,10 +908,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> AsyncDoneCmd::Record(
 // ComputationId
 //===----------------------------------------------------------------------===//
 
-ComputationIdCmd::ComputationIdCmd(BufferAllocation::Slice dest, Kind kind,
-                                   ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kComputationIdCmd,
-                       std::move(resources)),
+ComputationIdCmd::ComputationIdCmd(BufferAllocation::Slice dest, Kind kind)
+    : CommandBufferCmd(CommandBufferCmdType::kComputationIdCmd),
       dest_(dest),
       kind_(kind) {}
 
@@ -969,9 +958,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> ComputationIdCmd::Record(
 LaunchCmd::LaunchCmd(std::string kernel_name,
                      absl::Span<const BufferAllocation::Slice> args,
                      absl::Span<const MemoryAccess> args_access,
-                     LaunchDimensions dims, int64_t shmem_bytes,
-                     ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kLaunchCmd, std::move(resources)),
+                     LaunchDimensions dims, int64_t shmem_bytes)
+    : CommandBufferCmd(CommandBufferCmdType::kLaunchCmd),
       kernel_name_(std::move(kernel_name)),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
@@ -1061,10 +1049,8 @@ CommandBufferCmd::BufferUseVector LaunchCmd::buffers() const {
 
 CustomKernelLaunchCmd::CustomKernelLaunchCmd(
     absl::Span<const BufferAllocation::Slice> args,
-    absl::Span<const MemoryAccess> args_access, CustomKernel custom_kernel,
-    ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kCustomKernelLaunchCmd,
-                       std::move(resources)),
+    absl::Span<const MemoryAccess> args_access, CustomKernel custom_kernel)
+    : CommandBufferCmd(CommandBufferCmdType::kCustomKernelLaunchCmd),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
       custom_kernel_(std::move(custom_kernel)) {}
@@ -1143,10 +1129,8 @@ CommandBufferCmd::BufferUseVector CustomKernelLaunchCmd::buffers() const {
 
 MemcpyDeviceToDeviceCmd::MemcpyDeviceToDeviceCmd(BufferAllocation::Slice dst,
                                                  BufferAllocation::Slice src,
-                                                 int64_t num_bytes,
-                                                 ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kMemcpyDeviceToDeviceCmd,
-                       std::move(resources)),
+                                                 int64_t num_bytes)
+    : CommandBufferCmd(CommandBufferCmdType::kMemcpyDeviceToDeviceCmd),
       dst_(dst),
       src_(src),
       num_bytes_(num_bytes) {}
@@ -1189,9 +1173,8 @@ CommandBufferCmd::BufferUseVector MemcpyDeviceToDeviceCmd::buffers() const {
 // MemzeroCmd
 //===----------------------------------------------------------------------===//
 
-MemzeroCmd::MemzeroCmd(BufferAllocation::Slice dst, ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kMemzeroCmd, std::move(resources)),
-      dst_(dst) {}
+MemzeroCmd::MemzeroCmd(BufferAllocation::Slice dst)
+    : CommandBufferCmd(CommandBufferCmdType::kMemzeroCmd), dst_(dst) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> MemzeroCmd::Record(
     const Thunk::ExecuteParams& execute_params,
@@ -1229,10 +1212,8 @@ CommandBufferCmd::BufferUseVector MemzeroCmd::buffers() const {
 // Memset32Cmd
 //===----------------------------------------------------------------------===//
 
-Memset32Cmd::Memset32Cmd(BufferAllocation::Slice dst, uint32_t bit_pattern,
-                         ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kMemset32Cmd,
-                       std::move(resources)),
+Memset32Cmd::Memset32Cmd(BufferAllocation::Slice dst, uint32_t bit_pattern)
+    : CommandBufferCmd(CommandBufferCmdType::kMemset32Cmd),
       dst_(dst),
       bit_pattern_(bit_pattern) {}
 
@@ -1273,9 +1254,8 @@ CommandBufferCmd::BufferUseVector Memset32Cmd::buffers() const {
 // ChildCmd
 //===----------------------------------------------------------------------===//
 
-ChildCmd::ChildCmd(CommandBufferCmdExecutor child_commands,
-                   ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kChildCmd, std::move(resources)),
+ChildCmd::ChildCmd(CommandBufferCmdExecutor child_commands)
+    : CommandBufferCmd(CommandBufferCmdType::kChildCmd),
       child_commands_(std::move(child_commands)) {}
 
 bool ChildCmd::requires_initialization() {
@@ -1325,9 +1305,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> ChildCmd::Record(
 //===----------------------------------------------------------------------===//
 
 CaseCmd::CaseCmd(BufferAllocation::Slice index, bool index_is_bool,
-                 std::vector<CommandBufferCmdExecutor> branches,
-                 ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kCaseCmd, std::move(resources)),
+                 std::vector<CommandBufferCmdExecutor> branches)
+    : CommandBufferCmd(CommandBufferCmdType::kCaseCmd),
       index_(index),
       index_is_bool_(index_is_bool),
       branches_(std::move(branches)) {}
@@ -1401,9 +1380,8 @@ CommandBufferCmd::BufferUseVector CaseCmd::buffers() const {
 
 WhileCmd::WhileCmd(BufferAllocation::Slice pred,
                    CommandBufferCmdExecutor cond_commands,
-                   CommandBufferCmdExecutor body_commands,
-                   ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kWhileCmd, std::move(resources)),
+                   CommandBufferCmdExecutor body_commands)
+    : CommandBufferCmd(CommandBufferCmdType::kWhileCmd),
       pred_(pred),
       cond_commands_(std::move(cond_commands)),
       body_commands_(std::move(body_commands)) {}
@@ -1468,10 +1446,8 @@ CommandBufferCmd::BufferUseVector WhileCmd::buffers() const {
 GemmCmd::GemmCmd(GemmConfig config, const BufferAllocation::Slice& lhs_buffer,
                  const BufferAllocation::Slice& rhs_buffer,
                  const BufferAllocation::Slice& output_buffer,
-                 const BufferAllocation::Slice& workspace, bool deterministic,
-                 ResourceUseVector resources)
-    : TracedCommandBufferCmd(CommandBufferCmdType::kGemmCmd,
-                             std::move(resources)),
+                 const BufferAllocation::Slice& workspace, bool deterministic)
+    : TracedCommandBufferCmd(CommandBufferCmdType::kGemmCmd),
       config_(std::move(config)),
       lhs_buffer_(lhs_buffer),
       rhs_buffer_(rhs_buffer),
@@ -1525,10 +1501,8 @@ CommandBufferCmd::BufferUseVector GemmCmd::buffers() const {
 // CublasLtCmd
 //===----------------------------------------------------------------------===//
 
-CublasLtCmd::CublasLtCmd(const CublasLtMatmulThunk& matmul_thunk,
-                         ResourceUseVector resources)
-    : TracedCommandBufferCmd(CommandBufferCmdType::kCublasLtCmd,
-                             std::move(resources)),
+CublasLtCmd::CublasLtCmd(const CublasLtMatmulThunk& matmul_thunk)
+    : TracedCommandBufferCmd(CommandBufferCmdType::kCublasLtCmd),
       CublasLtMatmulThunk(matmul_thunk) {}
 
 absl::Status CublasLtCmd::Initialize(const Thunk::InitializeParams& params,
@@ -1605,10 +1579,8 @@ CommandBufferCmd::BufferUseVector CublasLtCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 CuDnnCmd::CuDnnCmd(absl::Span<const BufferAllocation::Slice> args,
-                   const std::shared_ptr<se::dnn::LazyDnnGraph> graph,
-                   ResourceUseVector resources)
-    : TracedCommandBufferCmd(CommandBufferCmdType::kCuDnnCmd,
-                             std::move(resources)),
+                   const std::shared_ptr<se::dnn::LazyDnnGraph> graph)
+    : TracedCommandBufferCmd(CommandBufferCmdType::kCuDnnCmd),
       args_(args.cbegin(), args.cend()),
       graph_(graph) {}
 
@@ -1856,9 +1828,8 @@ CommandBufferCmd::BufferUseVector CustomCallCmd::buffers() const {
 
 CollectiveCmd::CollectiveCmd(
     CommandBufferCmdType cmd_type, CollectiveConfig config,
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    ResourceUseVector resources)
-    : CommandBufferCmd(cmd_type, std::move(resources)),
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
+    : CommandBufferCmd(cmd_type),
       config_(std::move(config)),
       async_events_(std::move(async_events)) {}
 
@@ -1910,10 +1881,9 @@ CollectiveCmd::RecordTracedCommand(
 AllReduceCmd::AllReduceCmd(
     CollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const CollectiveThunk::Buffer> buffers,
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    ResourceUseVector resources)
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
     : CollectiveCmd(CommandBufferCmdType::kAllReduceCmd, std::move(config),
-                    std::move(async_events), std::move(resources)),
+                    std::move(async_events)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1973,10 +1943,9 @@ CommandBufferCmd::BufferUseVector AllReduceCmd::buffers() const {
 ReduceScatterCmd::ReduceScatterCmd(
     CollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const CollectiveThunk::Buffer> buffers,
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    ResourceUseVector resources)
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
     : CollectiveCmd(CommandBufferCmdType::kReduceScatterCmd, std::move(config),
-                    std::move(async_events), std::move(resources)),
+                    std::move(async_events)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -2038,10 +2007,9 @@ CommandBufferCmd::BufferUseVector ReduceScatterCmd::buffers() const {
 AllToAllCmd::AllToAllCmd(
     CollectiveConfig config, bool has_split_dimension,
     absl::Span<const CollectiveThunk::Buffer> buffers,
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    ResourceUseVector resources)
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
     : CollectiveCmd(CommandBufferCmdType::kAllToAllCmd, std::move(config),
-                    std::move(async_events), std::move(resources)),
+                    std::move(async_events)),
       has_split_dimension_(has_split_dimension),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -2099,10 +2067,9 @@ CommandBufferCmd::BufferUseVector AllToAllCmd::buffers() const {
 
 AllGatherCmd::AllGatherCmd(
     CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers,
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    ResourceUseVector resources)
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
     : CollectiveCmd(CommandBufferCmdType::kAllGatherCmd, std::move(config),
-                    std::move(async_events), std::move(resources)),
+                    std::move(async_events)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> AllGatherCmd::Record(
@@ -2160,11 +2127,9 @@ CommandBufferCmd::BufferUseVector AllGatherCmd::buffers() const {
 
 CollectiveBroadcastCmd::CollectiveBroadcastCmd(
     CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers,
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    ResourceUseVector resources)
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
     : CollectiveCmd(CommandBufferCmdType::kCollectiveBroadcastCmd,
-                    std::move(config), std::move(async_events),
-                    std::move(resources)),
+                    std::move(config), std::move(async_events)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
@@ -2228,10 +2193,8 @@ DynamicSliceFusionCmd::DynamicSliceFusionCmd(
     std::vector<std::optional<std::vector<DynamicSliceThunk::Offset>>> offsets,
     std::vector<std::optional<Shape>> orig_shapes,
     std::vector<std::optional<Shape>> sliced_shapes,
-    std::vector<std::optional<uint64_t>> offset_byte_sizes,
-    ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceFusionCmd,
-                       std::move(resources)),
+    std::vector<std::optional<uint64_t>> offset_byte_sizes)
+    : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceFusionCmd),
       embedded_commands_(std::move(embedded_commands)),
       fake_allocations_(std::move(fake_allocations)) {
   // Zip all arguments together to create a list of SliceDef.
@@ -2491,9 +2454,8 @@ CommandBufferCmd::BufferUseVector DynamicSliceFusionCmd::buffers() const {
 DynamicSliceCopyFusionCmd::DynamicSliceCopyFusionCmd(
     const BufferAllocation::Slice& source_buffer,
     const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
-    DynamicMemcpyThunk::Offsets offsets, ResourceUseVector resources)
-    : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceCopyFusionCmd,
-                       std::move(resources)),
+    DynamicMemcpyThunk::Offsets offsets)
+    : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceCopyFusionCmd),
       source_buffer_(source_buffer),
       destination_buffer_(destination_buffer),
       mem_size_(mem_size),

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -850,7 +850,7 @@ TEST(CommandBufferThunkTest, ChildGemmCmd) {
       CommandBufferCmdExecutor::Create(std::move(child_commands), serialize));
 
   CommandBufferCmdSequence commands;
-  commands.Emplace<ChildCmd>(std::move(child_executor), ResourceUseVector{});
+  commands.Emplace<ChildCmd>(std::move(child_executor));
 
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor executor,


### PR DESCRIPTION
📝 Summary of Changes
In command buffer, there are two places that relies on resource dependency to specify command order. 
1.  When command buffer preserves the control dependency that is original existed across HLO operators.
2.  When specifying the dependency for cuda-graph topology inferred from LHS scheduling. 

This PR introduces a unified way to specify the token dependency across commands: 
1.  Each CommandBufferCmd has a local variable of type `std::shared_ptr<Resource> token_`, 
2. On instantiating CommandBufferCmd, auto create a Write resource use for local token resources;
3. If other commands has execution dependency on current command, then other command needs to include a READ resource use of the token resource of current command in other commands' resoure_use vector. 

In this approach, LHS and control dependency has the unified way to describe the dependency across commands. 


🎯 Justification
More clean and easy to understand design. 

🚀 Kind of Contribution
♻️ Cleanup 

🧪 Unit Tests:
This PR reimplements existing feature, so it is already covered by current unit tests.
xla/backends/gpu/runtime/command_buffer_thunk_test.cc


