### PR TITLE
fix collective permute clone

### DIFF
--- a/xla/hlo/ir/hlo_instructions.cc
+++ b/xla/hlo/ir/hlo_instructions.cc
@@ -1358,9 +1358,7 @@ HloCollectivePermuteInstruction::CloneWithNewOperandsImpl(
     HloCloneContext* /*context*/) const {
   if (dynamic_slice_sizes_list().empty()) {
     return std::make_unique<HloCollectivePermuteInstruction>(
-        opcode(), shape,
-        absl::Span<HloInstruction* const>(new_operands.subspan(0, 1)),
-        source_target_pairs(), channel_id());
+        opcode(), shape, new_operands, source_target_pairs(), channel_id());
   }
   return std::make_unique<HloCollectivePermuteInstruction>(
       opcode(), shape, new_operands[0], new_operands[1], new_operands[2],


### PR DESCRIPTION
📝 Summary of Changes
Collective permute instruction `CloneWithNewOperands` only clones first operand while Collective permute is variadic op. Fixed this by cloning whole operands list.

🎯 Justification
Required whenever collective permute that needs to be cloned has more than 1 operand. It is common to have more than 1 operands with collective permute combiner pass enabled. Observed this bug in maxtext gradient accumulation.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
No performance improvements expected

🧪 Unit Tests:
Add minimum hlo unit test that makes sure the cloned instruction has same number of operands.

🧪 Execution Tests:
No execution tests added.
