### PR TITLE
Disable float normalization for bitcasts.

### DIFF
--- a/xla/hlo/transforms/simplifiers/float_normalization.cc
+++ b/xla/hlo/transforms/simplifiers/float_normalization.cc
@@ -595,6 +595,7 @@ absl::Status FloatNormalizationVisitor::DefaultAction(HloInstruction* hlo) {
       hlo->opcode() == HloOpcode::kWhile ||            //
       hlo->opcode() == HloOpcode::kConditional ||      //
       hlo->opcode() == HloOpcode::kBitcastConvert ||   //
+      hlo->opcode() == HloOpcode::kBitcast ||          //
       hlo->opcode() == HloOpcode::kAsyncStart ||       //
       hlo->opcode() == HloOpcode::kAsyncDone ||        //
       hlo->HasSideEffectNoRecurse()) {

--- a/xla/hlo/transforms/simplifiers/float_normalization_test.cc
+++ b/xla/hlo/transforms/simplifiers/float_normalization_test.cc
@@ -583,6 +583,16 @@ TEST_F(FloatNormalizationTest, DoNotChangeBitcastConvert) {
   EXPECT_EQ(root->operand(0)->shape().element_type(), U16);
 }
 
+TEST_F(FloatNormalizationTest, DoNotChangeBitcast) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(R"(
+m {
+  a = s4[4,2] parameter(0)
+  b = s8[4] bitcast(a)
+})"));
+  EXPECT_FALSE(Normalize(module.get(), S4));
+}
+
 TEST_P(FloatNormalizationF8Test, ResolveIfUnsupportedF8) {
   PrimitiveType f8_type = GetParam();
   auto builder = HloComputation::Builder(TestName());

--- a/xla/hlo/transforms/simplifiers/float_normalization_test.cc
+++ b/xla/hlo/transforms/simplifiers/float_normalization_test.cc
@@ -587,7 +587,7 @@ TEST_F(FloatNormalizationTest, DoNotChangeBitcast) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(R"(
 m {
-  a = s4[4,2] parameter(0)
+  a = s4[4,2]{1,0:E(4)} parameter(0)
   b = s8[4] bitcast(a)
 })"));
   EXPECT_FALSE(Normalize(module.get(), S4));


### PR DESCRIPTION
Bitcasts can be used to express no-op data type conversions.
