### PR TITLE
[XLA/GPU] Apply size threshold only to AllReduce ops in CollectiveBackendAssigner

### DIFF
--- a/xla/service/gpu/transforms/collectives/collective_backend_assigner_test.cc
+++ b/xla/service/gpu/transforms/collectives/collective_backend_assigner_test.cc
@@ -126,7 +126,7 @@ TEST_F(CollectiveBackendAssignerTest, SmallCollectivePermuteUsesNvshmem) {
               absl_testing::IsOkAndHolds(CollectiveBackendConfig::NVSHMEM));
 }
 
-TEST_F(CollectiveBackendAssignerTest, LargeCollectivePermuteUsesDefault) {
+TEST_F(CollectiveBackendAssignerTest, LargeCollectivePermuteUsesNvshmem) {
   absl::string_view kHloText = R"(
     HloModule m
 
@@ -139,12 +139,12 @@ TEST_F(CollectiveBackendAssignerTest, LargeCollectivePermuteUsesDefault) {
 
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
   EXPECT_THAT(RunCollectiveBackendAssigner(module.get()),
-              absl_testing::IsOkAndHolds(false));
+              absl_testing::IsOkAndHolds(true));
 
   const HloInstruction* permute =
       module->entry_computation()->root_instruction();
   EXPECT_THAT(GetCollectiveBackendConfig(permute),
-              absl_testing::IsOkAndHolds(CollectiveBackendConfig::DEFAULT));
+              absl_testing::IsOkAndHolds(CollectiveBackendConfig::NVSHMEM));
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes
This PR removes size threshold for CollectivePermute ops in CollectiveBackendAssigner.

🎯 Justification
Size-based backend selection is unnecessary for CollectivePermute, since NVSHMEM uses copy engines and delivers consistent performance regardless of message size, unlike AllReduce where scaling overhead justifies thresholds.

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
No NVSHMEM performance tracking in
`compiler/xla/tools/benchmarks/hlo/`.

We evaluated back-to-back CollectivePermute ops using multihost-hlo-runner, measuring nvshmemx_float_put_nbi_on_stream kernel execution times across data sizes from 1KB to 32MB. NVSHMEM maintained ~5.6-7.5μs latency across all data sizes. This demonstrates scalability for CollectivePermute operations, maintaining constant low latency regardless of data size.

🧪 Unit Tests:
Updated an existing unit test.

🧪 Execution Tests:
N/A
