### PR TITLE
[XLA:GPU] Command buffer allows multiple CommandBufferCmdExecutor to be recorded into one command buffer

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -457,7 +457,8 @@ absl::Status CommandBufferCmdExecutor::Initialize(
 absl::Status CommandBufferCmdExecutor::Record(
     const Thunk::ExecuteParams& execute_params,
     const CommandBufferCmd::RecordParams& record_params,
-    se::CommandBuffer* command_buffer) {
+    CommandBufferCmd::RecordAction record_action,
+    se::CommandBuffer* command_buffer, bool finalize) {
   VLOG(3) << "Record " << commands_.size() << " commands into command buffer";
 
   if (command_buffer->state() == se::CommandBuffer::State::kFinalized) {
@@ -468,12 +469,16 @@ absl::Status CommandBufferCmdExecutor::Record(
     TF_RETURN_IF_ERROR(
         RecordUpdate(execute_params, record_params, command_buffer));
   } else {
-    TF_RETURN_IF_ERROR(
-        RecordCreate(execute_params, record_params, command_buffer, {})
-            .status());
+    auto* create = std::get_if<CommandBufferCmd::RecordCreate>(&record_action);
+    CHECK(create);
+    TF_RETURN_IF_ERROR(RecordCreate(execute_params, record_params,
+                                    command_buffer, create->dependencies)
+                           .status());
   }
-
-  return command_buffer->Finalize();
+  if (finalize) {
+    return command_buffer->Finalize();
+  }
+  return absl::OkStatus();
 }
 
 absl::StatusOr<std::vector<const se::CommandBuffer::Command*>>
@@ -663,6 +668,48 @@ bool CommandBufferCmdExecutor::IsSource(CommandId id) const {
 bool CommandBufferCmdExecutor::IsSink(CommandId id) const {
   return execution_graph_ ? execution_graph_->is_sink(id)
                           : id + 1 == commands_.size();
+}
+
+std::vector<const se::CommandBuffer::Command*>
+CommandBufferCmdExecutor::SinkCommands(
+    const RecordParams& record_params,
+    se::CommandBuffer* command_buffer) const {
+  std::vector<CommandId> sink_ids;
+  if (execution_graph_) {
+    auto sink_span = execution_graph_->sink();
+    sink_ids.assign(sink_span.begin(), sink_span.end());
+  } else {
+    sink_ids.push_back(commands_.size() - 1);
+  }
+
+  std::vector<const se::CommandBuffer::Command*> sink_commands;
+  for (CommandId id : sink_ids) {
+    auto* record_state = record_params.state.GetOrNull<RecordState>(
+        commands_[id].get(), command_buffer);
+    sink_commands.push_back(record_state->command);
+  }
+  return sink_commands;
+}
+
+std::vector<const se::CommandBuffer::Command*>
+CommandBufferCmdExecutor::SourceCommands(
+    const RecordParams& record_params,
+    se::CommandBuffer* command_buffer) const {
+  std::vector<CommandId> source_ids;
+  if (execution_graph_) {
+    auto source_span = execution_graph_->source();
+    source_ids.assign(source_span.begin(), source_span.end());
+  } else {
+    source_ids.push_back(0);
+  }
+
+  std::vector<const se::CommandBuffer::Command*> source_commands;
+  for (CommandId id : source_ids) {
+    auto* record_state = record_params.state.GetOrNull<RecordState>(
+        commands_[id].get(), command_buffer);
+    source_commands.push_back(record_state->command);
+  }
+  return source_commands;
 }
 
 std::vector<const se::CommandBuffer::Command*>
@@ -1306,6 +1353,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> ChildCmd::Record(
   VLOG(5) << "Record ChildCmd " << child_commands_.size() << " commands";
   CHECK(child_command_buffer_ != nullptr);
   TF_RETURN_IF_ERROR(child_commands_.Record(execute_params, record_params,
+                                            CommandBufferCmd::RecordCreate{},
                                             child_command_buffer_.get()));
   return Handle(
       std::move(record_action),
@@ -2457,6 +2505,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> DynamicSliceFusionCmd::Record(
           ->CreateCommandBuffer(se::CommandBuffer::Mode::kNested)
           .value();
   TF_RETURN_IF_ERROR(embedded_commands_.Record(new_params, record_params,
+                                               CommandBufferCmd::RecordCreate{},
                                                nested_command_buffer.get()));
 
   return Handle(

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -399,12 +399,26 @@ class CommandBufferCmdExecutor {
 
   // Records commands into the command buffer. This method automatically
   // switches between `RecordCreate` or `RecordUpdate` depending on the command
-  // buffer state. This method assumes that no other command buffer sequence is
-  // recorded into the same command buffer, and doesn't set up initial
-  // dependencies for recorded commands.
+  // buffer state.
+
+  // This Record function allows multiple CommandbufferCmdEXecutor to be
+  // recorded into a single command buffer. e.g. we can have Executor A, B, C to
+  // be recorded into the same command buffer in the order of A -> B -> C. In
+  // this pattern, B's source commands will depend on A's sink commands, and C's
+  // source commands will also depend on B's sink commands.
+
+  // If record_action is `RecordCreate`, it will set up initial
+  // dependencies for recorded commands by the `dependencies` parameter.
+  // If record_action is `RecordUpdate`, it will only update previously
+  // recorded commands' dependencies, no other actions.
+
+  // If finalize is true, it will finalize the command buffer after recording,
+  // if not, this allows the command_buffer to further record other executors
+  // into the this command buffer.
   absl::Status Record(const Thunk::ExecuteParams& execute_params,
                       const RecordParams& record_params,
-                      se::CommandBuffer* command_buffer);
+                      CommandBufferCmd::RecordAction record_action,
+                      se::CommandBuffer* command_buffer, bool finalize = true);
 
   // Records command creation into the command buffer. Command buffer must be
   // in create state. The next command sequence recorded into the same command
@@ -440,6 +454,16 @@ class CommandBufferCmdExecutor {
     return absl::c_any_of(commands_,
                           [](const auto& cmd) { return cmd->force_update(); });
   }
+
+  // Returns all source commands for current command executor.
+  std::vector<const se::CommandBuffer::Command*> SourceCommands(
+      const RecordParams& record_params,
+      se::CommandBuffer* command_buffer) const;
+
+  // Returns all sink commands for current command executor.
+  std::vector<const se::CommandBuffer::Command*> SinkCommands(
+      const RecordParams& record_params,
+      se::CommandBuffer* command_buffer) const;
 
   // Renders the execution graph using default renderer. Returns url of the
   // rendered graph, or an error if rendering failed.

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -201,6 +201,7 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
                                                     std::move(updated_allocs),
                                                     /*is_initialization=*/true};
     TF_RETURN_IF_ERROR(commands_.Record(execute_params, record_params,
+                                        CommandBufferCmd::RecordCreate{},
                                         cmd_buffer->command_buffer.get()));
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();
@@ -261,6 +262,7 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
     CommandBufferCmd::RecordParams record_params = {cmd_buffer->state,
                                                     std::move(updated_allocs)};
     TF_RETURN_IF_ERROR(commands_.Record(params, record_params,
+                                        CommandBufferCmd::RecordCreate{},
                                         cmd_buffer->command_buffer.get()));
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();


### PR DESCRIPTION
📝 Summary of Changes
In Current implementation, one command buffer (cuda graph) can only be recorded from one command sequence (CommandBufferCmdExecutor), i.e, command buffer will be finalized after recording the last command from the command sequence.  But in some cases, we may want to recording multiple command sequence into the same command buffer.  This PR enables this feature. 

the new CommandBufferCmdExecutor::Record function will have the prototype:  
```
  absl::Status Record(const Thunk::ExecuteParams& execute_params,
                      const RecordParams& record_params,
                      CommandBufferCmd::RecordAction record_action,
                      se::CommandBuffer* command_buffer, bool finalize = true);
```

`record_action` is the dependency sets for source command of current sequence, `finalize` is a flag to indicate whether to finalize the cuda-graph after recording current sequence. 

For example, if we have 3 command sequences: A , B, C, and we want include them into one cuda-graph, the recorded order is A -> B -> C, where B's source commands depend on A's sink commands, and C's source commands depend on B's sink commands. 

🎯 Justification

This new record pattern will make constructing cuda-graph more easily in some cases.  For example, if we want to unroll the loop (do not use cuda-graph while node to modeling the loop), we can just recorded the loop body sequence into one command buffer in sequence very easily:  Iteration1.Record() -> Iteration2.Record() -> ....
   

🚀 Kind of Contribution
✨ New Feature

📊 Benchmark (for Performance Improvements)
This is a pre-requisite feature for command buffer loop unrolling, so no perf number in this PR 

🧪 Unit Tests:
command_buffer_cmd_test.cc: CommandBufferCmdTest.RecordExecutorsWithDependencies

