### PR TITLE
Allow accessing precision config attribute for scaled dot op

### DIFF
--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -5408,6 +5408,9 @@ const PrecisionConfig& HloInstruction::precision_config() const {
   if (auto* dot = DynCast<HloDotInstruction>(this)) {
     return dot->precision_config();
   }
+  if (auto* scaled_dot = DynCast<HloScaledDotInstruction>(this)) {
+    return scaled_dot->precision_config();
+  }
   if (auto* ragged_dot = DynCast<HloRaggedDotInstruction>(this)) {
     return ragged_dot->precision_config();
   }


### PR DESCRIPTION
📝 Summary of Changes
`HloInstruction` class exposes some properties of subclasses, like `dot_dimension_numbers` and `precision_config`.
This PR makes sure accessing `precision_config` doesn't fail for `scaled-dot` HLO op.

🚀 Kind of Contribution
🐛 Bug Fix
