### PR TITLE
[NFC] Remove META scope from triton fusion analysis

### DIFF
--- a/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
@@ -248,8 +248,6 @@ class GemmDimensionAdapter {
                        lhs_noncontracting_index,
                        dot_.shape().dimensions_size() - 1};
         break;
-      case TritonFusionAnalysis::Scope::META:
-        LOG(FATAL) << "Unsupported scope.";
     }
 
     Result result;

--- a/xla/service/gpu/triton_fusion_analysis.cc
+++ b/xla/service/gpu/triton_fusion_analysis.cc
@@ -234,11 +234,8 @@ bool TritonFusionAnalysis::IsBatchDimMinorForInt4Parameter(
 absl::Status TritonFusionAnalysis::ExecuteForDotFusion(
     const HloInstruction& dot, const int split_k) {
   DotRequirements lhs_requirements(kNoSplitRequirement);
-  for (const Scope scope : {Scope::LHS, Scope::RHS, Scope::META}) {
+  for (const Scope scope : {Scope::LHS, Scope::RHS}) {
     const int operand_number = static_cast<int>(scope);
-    if (dot.operand_count() < operand_number + 1) {
-      continue;  // Meta scope is optional.
-    }
     TF_ASSIGN_OR_RETURN(auto context, FusionContext::FromDotOperand(
                                           dot, operand_number, split_k));
     TF_RETURN_IF_ERROR(context.PropagateDimensionOrdersToParameters(
@@ -339,8 +336,6 @@ std::string ScopeToString(TritonFusionAnalysis::Scope s) {
       return "LHS";
     case TritonFusionAnalysis::Scope::RHS:
       return "RHS";
-    case TritonFusionAnalysis::Scope::META:
-      return "META";
     case TritonFusionAnalysis::Scope::OUTPUT:
       return "OUTPUT";
   }

--- a/xla/service/gpu/triton_fusion_analysis.h
+++ b/xla/service/gpu/triton_fusion_analysis.h
@@ -50,10 +50,9 @@ class TritonFusionAnalysis {
       const HloDotInstruction& dot, int split_k = 1);
 
   // A scope is an HLO graph that can be tiled efficiently using same or
-  // compatible tile shapes on all operations. GEMM fusion has 3 or 4 scopes
-  // defined by left operand, right operand, optional meta (third operand) and
-  // output.
-  enum class Scope { LHS = 0, RHS = 1, META = 2, OUTPUT = 3 };
+  // compatible tile shapes on all operations. GEMM dot fusion has 3 scopes
+  // defined by left operand, right operand and output.
+  enum class Scope { LHS = 0, RHS = 1, OUTPUT = 2 };
 
   using IterationSpecByInstructionMap =
       ConstHloInstructionMap<TensorIterationSpec>;


### PR DESCRIPTION
📝 Summary of Changes
Remove `TritonFusionAnalysis::Scope::META` enum value, which is not used.
Next PR will add scopes for LHS/RHS scales.

🚀 Kind of Contribution
♻️ Cleanup
