### PR TITLE
Add lhs/rhs scale scopes to triton fusion analysis (support scaled dot)

### DIFF
--- a/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
@@ -248,6 +248,9 @@ class GemmDimensionAdapter {
                        lhs_noncontracting_index,
                        dot_.shape().dimensions_size() - 1};
         break;
+      case TritonFusionAnalysis::Scope::LHS_SCALE:
+      case TritonFusionAnalysis::Scope::RHS_SCALE:
+        LOG(FATAL) << "Unsupported scope.";
     }
 
     Result result;

--- a/xla/service/gpu/triton_fusion_analysis.h
+++ b/xla/service/gpu/triton_fusion_analysis.h
@@ -46,13 +46,20 @@ class TritonFusionAnalysis {
 
   // Execute the analysis of a dot instruction until it reaches the computation
   // boundaries.
-  static absl::StatusOr<TritonFusionAnalysis> Execute(
-      const HloDotInstruction& dot, int split_k = 1);
+  static absl::StatusOr<TritonFusionAnalysis> Execute(const HloInstruction& dot,
+                                                      int split_k = 1);
 
   // A scope is an HLO graph that can be tiled efficiently using same or
   // compatible tile shapes on all operations. GEMM dot fusion has 3 scopes
-  // defined by left operand, right operand and output.
-  enum class Scope { LHS = 0, RHS = 1, OUTPUT = 2 };
+  // defined by left operand, right operand and output. GEMM scaled dot fusion
+  // has 5 scopes (also includes scale operands).
+  enum class Scope {
+    LHS = 0,
+    RHS = 1,
+    LHS_SCALE = 2,
+    RHS_SCALE = 3,
+    OUTPUT = 4,
+  };
 
   using IterationSpecByInstructionMap =
       ConstHloInstructionMap<TensorIterationSpec>;
@@ -90,10 +97,14 @@ class TritonFusionAnalysis {
   bool IsBatchDimMinorForInt4Parameter(const HloInstruction& dot,
                                        Scope scope) const;
 
+  bool is_scaled_dot() const { return is_scaled_dot_; }
+
  private:
   IterationSpecByInstructionByScopeMap iter_specs_;
   // HLO computation parameters per scope.
   std::map<Scope, ConstHloInstructionSet> parameters_;
+  // Scaled dot has additional scale scopes.
+  bool is_scaled_dot_ = false;
 };
 
 // The details of the Triton fusion / tiling propagation are in a separate


### PR DESCRIPTION
📝 Summary of Changes
Add `LHS_SCALE` and `RHS_SCALE` scopes to `TritonFusionAnalysis`.
This allows passing a scaled-dot fusion to the fusion analysis, which is needed for the fusion emitters (upcoming).

🚀 Kind of Contribution
✨ New Feature (part of block scaled dot fusion support)
