### PR TITLE
[XLA:GPU] add legacy triton custom call target to command buffer by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -241,6 +241,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUDNN);
   opts.set_xla_gpu_graph_min_graph_size(5);
   opts.set_xla_gpu_command_buffer_scheduling_mode(DebugOptions::LHS);
+  opts.add_legacy_command_buffer_custom_call_targets("__gpu$xla.gpu.triton");
   opts.set_xla_cmd_buffer_trace_cache_size(16);
 
   opts.set_xla_gpu_collectives_use_persistent_cliques(false);


### PR DESCRIPTION
📝 Summary of Changes
add legacy triton custom call target to command buffer by default

🎯 Justification
Triton kernel is frequent, and enable command buffer lowering by default can save lot of user efforts for setting the knob.

🚀 Kind of Contribution
⚡️ Performance Improvement,

🧪 Unit Tests:
This custom call lowering is covered by existing unit tests. 
xla/backends/gpu/runtime/command_buffer_conversion_pass_test.cc


