### PR TITLE
[XLA:GPU] Add command buffer NestedChildCmd unittest.

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -237,6 +237,15 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
 
   TF_ASSERT_OK(stream->Memset32(&a, 42, byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
+  // Verify initial values of a and b.
+  {
+    std::vector<int32_t> a_init(length, 0);
+    std::vector<int32_t> b_init(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
+    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
+    ASSERT_EQ(a_init, std::vector<int32_t>(length, 42));
+    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
+  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -278,6 +287,12 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
+  // Verify that a remains unchanged.
+  {
+    std::vector<int32_t> a_after(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
+    ASSERT_EQ(a_after, std::vector<int32_t>(length, 42));
+  }
 }
 
 TEST(CommandBufferCmdTest, LaunchCmd) {
@@ -295,6 +310,15 @@ TEST(CommandBufferCmdTest, LaunchCmd) {
 
   TF_ASSERT_OK(stream->Memset32(&a, 42, byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
+  // Verify initial values of a and b.
+  {
+    std::vector<int32_t> a_init(length, 0);
+    std::vector<int32_t> b_init(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
+    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
+    ASSERT_EQ(a_init, std::vector<int32_t>(length, 42));
+    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
+  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -349,6 +373,12 @@ TEST(CommandBufferCmdTest, LaunchCmd) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42 + 42));
+  // Verify that a remains unchanged.
+  {
+    std::vector<int32_t> a_after(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
+    ASSERT_EQ(a_after, std::vector<int32_t>(length, 42));
+  }
 }
 
 TEST(CommandBufferCmdTest, LaunchCmdWithPriority) {
@@ -366,6 +396,15 @@ TEST(CommandBufferCmdTest, LaunchCmdWithPriority) {
 
   TF_ASSERT_OK(stream->Memset32(&a, 42, byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
+  // Verify initial values of a and b.
+  {
+    std::vector<int32_t> a_init(length, 0);
+    std::vector<int32_t> b_init(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
+    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
+    ASSERT_EQ(a_init, std::vector<int32_t>(length, 42));
+    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
+  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -422,6 +461,12 @@ TEST(CommandBufferCmdTest, LaunchCmdWithPriority) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42 + 42));
+  // Verify that a remains unchanged.
+  {
+    std::vector<int32_t> a_after(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
+    ASSERT_EQ(a_after, std::vector<int32_t>(length, 42));
+  }
 }
 
 TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
@@ -433,7 +478,7 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
 
   std::vector<int32_t> a_data = {40, 41, 42, 43, 44, 45, 46, 47};
 
-  // Prepare arguments: a=42, b=0
+  // Prepare arguments: a has a_data, b=0
   se::DeviceMemory<int32_t> a =
       stream_executor->AllocateArray<int32_t>(length, 0);
   se::DeviceMemory<int32_t> b =
@@ -441,6 +486,15 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
 
   TF_ASSERT_OK(stream->Memcpy(&a, a_data.data(), byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
+  // Verify initial values of a and b.
+  {
+    std::vector<int32_t> a_init(length, 0);
+    std::vector<int32_t> b_init(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
+    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
+    ASSERT_EQ(a_init, a_data);
+    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
+  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -483,6 +537,12 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>({0, 0, 0, 0, 44, 45, 46, 47}));
+  // Verify that a remains unchanged.
+  {
+    std::vector<int32_t> a_after(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
+    ASSERT_EQ(a_after, a_data);
+  }
 }
 
 TEST(TracedCommandBuffer, GetOrUpdateCommandBuffer) {
@@ -683,6 +743,134 @@ TEST(CommandBufferCmdTest, RecordExecutorsWithDependencies) {
   std::vector<int32_t> dst(length, 0);
   TF_ASSERT_OK(stream->Memcpy(dst.data(), c, byte_length));
   ASSERT_EQ(dst, std::vector<int32_t>(length, 2));
+}
+
+TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
+  se::StreamExecutor* stream_executor = GpuExecutor();
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
+
+  // Prepare device memory for three buffers.
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+  se::DeviceMemory<int32_t> a = stream_executor->AllocateArray<int32_t>(length);
+  se::DeviceMemory<int32_t> b = stream_executor->AllocateArray<int32_t>(length);
+  se::DeviceMemory<int32_t> c = stream_executor->AllocateArray<int32_t>(length);
+
+  // Initialize a = 1s, b = 0s, c = 0s.
+  TF_ASSERT_OK(stream->Memset32(&a, /*pattern=*/1, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&b, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&c, byte_length));
+
+  // Buffer allocations.
+  BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
+  BufferAllocation alloc_b(/*index=*/1, byte_length, /*color=*/0);
+  BufferAllocation alloc_c(/*index=*/2, byte_length, /*color=*/0);
+
+  BufferAllocation::Slice slice_a(&alloc_a, 0, byte_length);
+  BufferAllocation::Slice slice_b(&alloc_b, 0, byte_length);
+  BufferAllocation::Slice slice_c(&alloc_c, 0, byte_length);
+
+  // Inner child: c = a (device-to-device memcpy)
+  CommandBufferCmdSequence inner_seq;
+  inner_seq.Emplace<MemcpyDeviceToDeviceCmd>(slice_c, slice_a, byte_length);
+  TF_ASSERT_OK_AND_ASSIGN(
+      CommandBufferCmdExecutor inner_executor,
+      CommandBufferCmdExecutor::Create(std::move(inner_seq), serialize));
+
+  // Middle child wraps inner.
+  CommandBufferCmdSequence middle_seq;
+  middle_seq.Emplace<ChildCmd>(std::move(inner_executor));
+  // Add a couple of extra commands that don't affect `c`.
+  middle_seq.Emplace<Memset32Cmd>(slice_b, /*bit_pattern=*/3);
+  middle_seq.Emplace<MemcpyDeviceToDeviceCmd>(slice_b, slice_b, byte_length);
+  TF_ASSERT_OK_AND_ASSIGN(
+      CommandBufferCmdExecutor middle_executor,
+      CommandBufferCmdExecutor::Create(std::move(middle_seq), serialize));
+
+  // Outer child wraps middle.
+  CommandBufferCmdSequence outer_seq;
+  outer_seq.Emplace<ChildCmd>(std::move(middle_executor));
+  // Add a couple more commands at the outer level that still don't affect `c`.
+  outer_seq.Emplace<MemzeroCmd>(slice_b);
+  outer_seq.Emplace<EmptyCmd>();
+  TF_ASSERT_OK_AND_ASSIGN(
+      CommandBufferCmdExecutor outer_executor,
+      CommandBufferCmdExecutor::Create(std::move(outer_seq), serialize));
+
+  // Prepare state and params; ChildCmd requires initialization to create a
+  // nested buffer.
+  CommandBufferCmd::StateManager state;
+  Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
+  TF_ASSERT_OK(outer_executor.Initialize({stream_executor, source}, state));
+
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
+  BufferAllocations allocations({a, b, c}, 0, &allocator);
+  ServiceExecutableRunOptions run_options;
+  Thunk::ExecuteParams exec_params = Thunk::ExecuteParams::Create(
+      run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
+  CommandBufferCmd::RecordParams record_params = {state};
+
+  // Create a command buffer and record the nested ChildCmd (Create).
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto command_buffer,
+      stream_executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
+  TF_ASSERT_OK(outer_executor.Record(exec_params, record_params,
+                                     CommandBufferCmd::RecordCreate{},
+                                     command_buffer.get(), /*finalize=*/true));
+  TF_ASSERT_OK(command_buffer->Submit(stream.get()));
+
+  // Verify c == a (all ones).
+  std::vector<int32_t> dst(length, 0);
+  TF_ASSERT_OK(stream->Memcpy(dst.data(), c, byte_length));
+  ASSERT_EQ(dst, std::vector<int32_t>(length, 1));
+
+  // Also verify a == 1s and b == 0s.
+  {
+    std::vector<int32_t> a_host(length, 0);
+    std::vector<int32_t> b_host(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a_host.data(), a, byte_length));
+    TF_ASSERT_OK(stream->Memcpy(b_host.data(), b, byte_length));
+    ASSERT_EQ(a_host, std::vector<int32_t>(length, 1));
+    ASSERT_EQ(b_host, std::vector<int32_t>(length, 0));
+  }
+
+  // Now update: change a and c buffers and record an update on the same command
+  // buffer.
+  se::DeviceMemory<int32_t> a2 =
+      stream_executor->AllocateArray<int32_t>(length);
+  se::DeviceMemory<int32_t> c2 =
+      stream_executor->AllocateArray<int32_t>(length);
+  TF_ASSERT_OK(stream->Memset32(&a2, /*pattern=*/7, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&c2, byte_length));
+
+  BufferAllocations allocations2({a2, b, c2}, 0, &allocator);
+  Thunk::ExecuteParams exec_params2 = Thunk::ExecuteParams::Create(
+      run_options, allocations2, stream.get(), stream.get(), nullptr, nullptr);
+
+  // Indicate which allocations changed to ensure update is not skipped.
+  std::vector<BufferAllocation::Index> updated_allocs = {0, 2};
+  CommandBufferCmd::RecordParams record_params2 = {state,
+                                                   std::move(updated_allocs)};
+
+  TF_ASSERT_OK(outer_executor.Record(exec_params2, record_params2,
+                                     CommandBufferCmd::RecordCreate{},
+                                     command_buffer.get(), /*finalize=*/true));
+  TF_ASSERT_OK(command_buffer->Submit(stream.get()));
+
+  // Verify c2 == a2 (all sevens).
+  std::vector<int32_t> dst2(length, 0);
+  TF_ASSERT_OK(stream->Memcpy(dst2.data(), c2, byte_length));
+  ASSERT_EQ(dst2, std::vector<int32_t>(length, 7));
+
+  // Also verify a2 == 7s and b == 0s.
+  {
+    std::vector<int32_t> a2_host(length, 0);
+    std::vector<int32_t> b_host(length, 0);
+    TF_ASSERT_OK(stream->Memcpy(a2_host.data(), a2, byte_length));
+    TF_ASSERT_OK(stream->Memcpy(b_host.data(), b, byte_length));
+    ASSERT_EQ(a2_host, std::vector<int32_t>(length, 7));
+    ASSERT_EQ(b_host, std::vector<int32_t>(length, 0));
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -704,11 +704,11 @@ TEST(CommandBufferCmdTest, RecordExecutorsWithDependencies) {
 }
 
 TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
+  se::StreamExecutor* stream_executor = GpuExecutor();
   if (!IsAtLeastCuda12900(stream_executor)) {
     GTEST_SKIP() << "Child command is not supported for CUDA < 12.9";
   }
 
-  se::StreamExecutor* stream_executor = GpuExecutor();
   TF_ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
 
   // Prepare device memory for three buffers.

--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -237,15 +237,6 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
 
   TF_ASSERT_OK(stream->Memset32(&a, 42, byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
-  // Verify initial values of a and b.
-  {
-    std::vector<int32_t> a_init(length, 0);
-    std::vector<int32_t> b_init(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
-    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
-    ASSERT_EQ(a_init, std::vector<int32_t>(length, 42));
-    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
-  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -287,12 +278,6 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
-  // Verify that a remains unchanged.
-  {
-    std::vector<int32_t> a_after(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
-    ASSERT_EQ(a_after, std::vector<int32_t>(length, 42));
-  }
 }
 
 TEST(CommandBufferCmdTest, LaunchCmd) {
@@ -310,15 +295,6 @@ TEST(CommandBufferCmdTest, LaunchCmd) {
 
   TF_ASSERT_OK(stream->Memset32(&a, 42, byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
-  // Verify initial values of a and b.
-  {
-    std::vector<int32_t> a_init(length, 0);
-    std::vector<int32_t> b_init(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
-    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
-    ASSERT_EQ(a_init, std::vector<int32_t>(length, 42));
-    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
-  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -373,12 +349,6 @@ TEST(CommandBufferCmdTest, LaunchCmd) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42 + 42));
-  // Verify that a remains unchanged.
-  {
-    std::vector<int32_t> a_after(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
-    ASSERT_EQ(a_after, std::vector<int32_t>(length, 42));
-  }
 }
 
 TEST(CommandBufferCmdTest, LaunchCmdWithPriority) {
@@ -396,15 +366,6 @@ TEST(CommandBufferCmdTest, LaunchCmdWithPriority) {
 
   TF_ASSERT_OK(stream->Memset32(&a, 42, byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
-  // Verify initial values of a and b.
-  {
-    std::vector<int32_t> a_init(length, 0);
-    std::vector<int32_t> b_init(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
-    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
-    ASSERT_EQ(a_init, std::vector<int32_t>(length, 42));
-    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
-  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -461,12 +422,6 @@ TEST(CommandBufferCmdTest, LaunchCmdWithPriority) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42 + 42));
-  // Verify that a remains unchanged.
-  {
-    std::vector<int32_t> a_after(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
-    ASSERT_EQ(a_after, std::vector<int32_t>(length, 42));
-  }
 }
 
 TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
@@ -478,7 +433,7 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
 
   std::vector<int32_t> a_data = {40, 41, 42, 43, 44, 45, 46, 47};
 
-  // Prepare arguments: a has a_data, b=0
+  // Prepare arguments: a=42, b=0
   se::DeviceMemory<int32_t> a =
       stream_executor->AllocateArray<int32_t>(length, 0);
   se::DeviceMemory<int32_t> b =
@@ -486,15 +441,6 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
 
   TF_ASSERT_OK(stream->Memcpy(&a, a_data.data(), byte_length));
   TF_ASSERT_OK(stream->MemZero(&b, byte_length));
-  // Verify initial values of a and b.
-  {
-    std::vector<int32_t> a_init(length, 0);
-    std::vector<int32_t> b_init(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_init.data(), a, byte_length));
-    TF_ASSERT_OK(stream->Memcpy(b_init.data(), b, byte_length));
-    ASSERT_EQ(a_init, a_data);
-    ASSERT_EQ(b_init, std::vector<int32_t>(length, 0));
-  }
 
   // Prepare buffer allocations for recording command buffer.
   BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
@@ -537,12 +483,6 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
   TF_ASSERT_OK(stream->Memcpy(dst.data(), b, byte_length));
 
   ASSERT_EQ(dst, std::vector<int32_t>({0, 0, 0, 0, 44, 45, 46, 47}));
-  // Verify that a remains unchanged.
-  {
-    std::vector<int32_t> a_after(length, 0);
-    TF_ASSERT_OK(stream->Memcpy(a_after.data(), a, byte_length));
-    ASSERT_EQ(a_after, a_data);
-  }
 }
 
 TEST(TracedCommandBuffer, GetOrUpdateCommandBuffer) {
@@ -700,21 +640,15 @@ TEST(CommandBufferCmdTest, RecordExecutorsWithDependencies) {
   Thunk::ExecutableSource source_empty = {/*text=*/{}, /*binary=*/{}};
   Thunk::ExecutableSource source_fatbin = {/*text=*/{}, /*binary=*/fatbin};
 
+  CommandBufferCmd::StateManager state;
+  TF_ASSERT_OK(exec_a.Initialize({stream_executor, source_empty}, state));
+  TF_ASSERT_OK(exec_b.Initialize({stream_executor, source_fatbin}, state));
+  TF_ASSERT_OK(exec_c.Initialize({stream_executor, source_empty}, state));
+
   // Execute params and allocations mapping indices 0=a,1=b,2=c
   ServiceExecutableRunOptions run_options;
   se::StreamExecutorMemoryAllocator allocator(stream_executor);
   BufferAllocations allocations({a, b, c}, 0, &allocator);
-
-  CommandBufferCmd::StateManager state;
-  TF_ASSERT_OK(exec_a.Initialize(
-      {stream_executor, source_empty, &allocations, stream.get(), stream.get()},
-      state));
-  TF_ASSERT_OK(exec_b.Initialize({stream_executor, source_fatbin, &allocations,
-                                  stream.get(), stream.get()},
-                                 state));
-  TF_ASSERT_OK(exec_c.Initialize(
-      {stream_executor, source_empty, &allocations, stream.get(), stream.get()},
-      state));
 
   Thunk::ExecuteParams exec_params = Thunk::ExecuteParams::Create(
       run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -871,15 +871,12 @@ TEST(CommandBufferThunkTest, ChildGemmCmd) {
       run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  VLOG(0) << "Initialize thunk";
   TF_ASSERT_OK(thunk.Initialize(
       {stream_executor, source, &allocations, stream.get(), stream.get()}));
 
-  VLOG(0) << "Initialize done";
   // Execute command buffer thunk and verify that it executed a GEMM.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
 
-  VLOG(0) << "Execute thunk done";
   TF_ASSERT_OK(stream->BlockHostUntilDone());
 
   // Copy `out` data back to host.


### PR DESCRIPTION
📝 Summary of Changes
This PR add a unit test to test the command buffer ChildCmd inside another ChildCmd pattern, verify command buffer create and update operation works. 

🎯 Justification
More testing coverage. 



🚀 Kind of Contribution
🧪 Tests

