### PR TITLE
[XLA:GPU] Expose syevBatched from cusolver

### DIFF
--- a/xla/tsl/cuda/cusolver.symbols
+++ b/xla/tsl/cuda/cusolver.symbols
@@ -474,6 +474,8 @@ cusolverDnXgetrs
 cusolverDnXpotrf
 cusolverDnXpotrf_bufferSize
 cusolverDnXpotrs
+cusolverDnXsyevBatched
+cusolverDnXsyevBatched_bufferSize
 cusolverDnXsyevd
 cusolverDnXsyevd_bufferSize
 cusolverDnXsyevdx


### PR DESCRIPTION
This exposes syevBatched* functions from cusolver to be
usable by JAX. We need the batched version to speed up
jax.lax.linalg.eigh for non-trivial batch sizes.

See https://github.com/jax-ml/jax/issues/31368