### PR TITLE
[XLA:GPU] Fix broadcast shape for non-standard layouts of block scaled dot custom call.

### DIFF
--- a/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
@@ -115,6 +115,41 @@ ENTRY main {
 })");
 }
 
+TEST_F(BlockScalingRewriterTest, ExpandBlockScaledDotNonDefaultLayout) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %lhs = f8e4m3fn[4,16,256]{2,0,1} parameter(0)
+  %rhs = f8e4m3fn[4,32,256]{0,1,2} parameter(1)
+  %lhs_scale = f8e5m2[4,16,8]{2,0,1} parameter(2)
+  %rhs_scale = f8e5m2[4,32,8]{0,1,2} parameter(3)
+  ROOT %result = f32[4,16,32] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+
+  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
+  CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,0,1} parameter(0)
+  CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,0,1} convert([[lhs_quant]])
+  CHECK: [[lhs_scale:%.+]] = f8e5m2[4,16,8]{2,0,1} parameter(2)
+  CHECK: [[lhs_scale_cvt:%.+]] = f32[4,16,8]{2,0,1} convert([[lhs_scale]])
+  CHECK: [[lhs_scale_bc:%.+]] = f32[4,16,8,32]{3,0,2,1} broadcast([[lhs_scale_cvt]])
+  CHECK: [[lhs_scale_rs:%.+]] = f32[4,16,256]{2,0,1} reshape([[lhs_scale_bc]])
+  CHECK: [[lhs:%.+]] = f32[4,16,256]{2,0,1} multiply([[lhs_quant_cvt]], [[lhs_scale_rs]])
+  CHECK: [[rhs_quant:%.+]] = f8e4m3fn[4,32,256]{0,1,2} parameter(1)
+  CHECK: [[rhs_quant_cvt:%.+]] = f32[4,32,256]{0,1,2} convert([[rhs_quant]])
+  CHECK: [[rhs_scale:%.+]] = f8e5m2[4,32,8]{0,1,2} parameter(3)
+  CHECK: [[rhs_scale_cvt:%.+]] = f32[4,32,8]{0,1,2} convert([[rhs_scale]])
+  CHECK: [[rhs_scale_bc:%.+]] = f32[4,32,8,32]{0,1,3,2} broadcast([[rhs_scale_cvt]])
+  CHECK: [[rhs_scale_rs:%.+]] = f32[4,32,256]{0,1,2} reshape([[rhs_scale_bc]])
+  CHECK: [[rhs:%.+]] = f32[4,32,256]{0,1,2} multiply([[rhs_quant_cvt]], [[rhs_scale_rs]])
+  CHECK: ROOT {{.+}} = f32[4,16,32]{2,1,0} dot([[lhs]], [[rhs]])
+  CHECK-SAME: lhs_batch_dims={0}, lhs_contracting_dims={2}
+  CHECK-SAME: rhs_batch_dims={0}, rhs_contracting_dims={2}
+})");
+}
+
 TEST_F(BlockScalingRewriterTest, ExpandBlockScaledDotQuantizedLhs) {
   constexpr absl::string_view hlo_string = R"(
 HloModule test


### PR DESCRIPTION
📝 Summary of Changes
SPMD pass could generate non-default shape layouts for block scaled dot custom call.
The XLA builder inherits the layout from the operand, but cannot do that in the case of a broadcast.
This PR fixes the layout of the broadcast after building the HLO computation (currently this issue results in a compilation failure).

🚀 Kind of Contribution
🐛 Bug Fix

Note: this bug could happen with any code that uses the XLA builder and generates a broadcast.
(right now it generates a default layout, which could also imply a transpose)