### PR TITLE
[GPU] Disable priority and multi-output fusion of bitwidth-changing bitcasts.

### DIFF
--- a/xla/hlo/ir/BUILD
+++ b/xla/hlo/ir/BUILD
@@ -291,6 +291,7 @@ cc_library(
     hdrs = ["hlo_instruction_utils.h"],
     deps = [
         ":hlo",
+        "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",

--- a/xla/hlo/ir/hlo_instruction_utils.cc
+++ b/xla/hlo/ir/hlo_instruction_utils.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/primitive_util.h"
 #include "xla/xla_data.pb.h"
 
 namespace xla {
@@ -35,6 +36,17 @@ bool IsUnstridedSlice(const HloInstruction* hlo) {
   }
   return absl::c_all_of(hlo->slice_strides(),
                         [](int64_t stride) { return stride == 1; });
+}
+
+bool KeepsBitwidth(const HloInstruction& hlo) {
+  CHECK(hlo.shape().IsArray());
+  if (absl::c_any_of(hlo.operands(), [&](const HloInstruction* operand) {
+        return primitive_util::BitWidth(operand->shape().element_type()) !=
+               primitive_util::BitWidth(hlo.shape().element_type());
+      })) {
+    return false;
+  }
+  return true;
 }
 
 using Interval = std::pair<int64_t, int64_t>;

--- a/xla/hlo/ir/hlo_instruction_utils.h
+++ b/xla/hlo/ir/hlo_instruction_utils.h
@@ -29,6 +29,9 @@ namespace hlo_instruction_utils {
 // all dimensions.
 bool IsUnstridedSlice(const HloInstruction* hlo);
 
+// Checks that all instruction operands have the same bitwidth as its output.
+bool KeepsBitwidth(const HloInstruction&);
+
 // Adds or updates the attributes for an instruction. If the attribute is
 // already present, then it is overwritten. Otherwise, this is added as another
 // attribute.

--- a/xla/hlo/ir/hlo_instruction_utils_test.cc
+++ b/xla/hlo/ir/hlo_instruction_utils_test.cc
@@ -56,6 +56,20 @@ TEST_F(HloInstructionUtilsTest, TestIsUnstridedSlice) {
   EXPECT_FALSE(IsUnstridedSlice(strided_slice));
 }
 
+TEST_F(HloInstructionUtilsTest, KeepsBitwidth) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> m,
+                          ParseAndReturnVerifiedModule(R"(
+e {
+  a = s8[2] parameter(0)
+  b = s16[] bitcast(a)
+  c = s16[] add(b, b)
+})"));
+  const HloInstruction& root = *m->entry_computation()->root_instruction();
+  EXPECT_TRUE(KeepsBitwidth(root));
+  EXPECT_FALSE(KeepsBitwidth(*root.operand(0)));
+  EXPECT_TRUE(KeepsBitwidth(*root.operand(0)->operand(0)));
+}
+
 TEST_F(HloInstructionUtilsTest, TestAddOrUpdateVectorOfPairsAsAttribute) {
   const char* hlo = R"(
     HloModule test

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2571,6 +2571,7 @@ cc_library(
         "//xla:util",
         "//xla/hlo/analysis:hlo_dataflow_analysis",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/ir:hlo_instruction_utils",
         "//xla/hlo/utils:hlo_traversal",
         "//xla/service:instruction_fusion",
         "//xla/stream_executor:device_description",

--- a/xla/service/gpu/gpu_fusible_test.cc
+++ b/xla/service/gpu/gpu_fusible_test.cc
@@ -1281,6 +1281,17 @@ TEST_F(GpuFusibleTest, ProducerConsumerFusionInPlaceOperation) {
   EXPECT_TRUE(ShapesCompatibleForMultiOutputFusion(*dus, *transpose));
 }
 
+TEST_F(GpuFusibleTest, BitwidthChangingBitcastIsNotFusible) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+e {
+  a = s32[7,2]{1,0} parameter(0)
+  b = s16[7]{0} bitcast(a)
+})")
+                    .value();
+  EXPECT_FALSE(IsProducerMultiOutputFusible(
+      *module->entry_computation()->root_instruction()));
+}
+
 TEST_F(GpuFusibleTest, ChooseFusionKind) {
   auto module = ParseAndReturnVerifiedModule(R"(
 HloModule module

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -2111,6 +2111,7 @@ cc_library(
         "//xla/backends/gpu/codegen/triton:support",
         "//xla/hlo/analysis:hlo_dfs_reachability",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/ir:hlo_instruction_utils",
         "//xla/hlo/pass:hlo_pass",
         "//xla/hlo/utils:hlo_traversal",
         "//xla/service:dump",

--- a/xla/service/gpu/transforms/priority_fusion.cc
+++ b/xla/service/gpu/transforms/priority_fusion.cc
@@ -48,6 +48,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/ir/hlo_print_options.h"
+#include "xla/hlo/ir/hlo_instruction_utils.h"
 #include "xla/hlo/utils/hlo_traversal.h"
 #include "xla/map_util.h"
 #include "xla/service/dump.h"
@@ -97,11 +98,12 @@ bool IsFusible(const HloInstruction& instr) {
     case HloOpcode::kFusion:
       return IsGenericTritonFusion(instr) ||
              instr.fusion_kind() != HloInstruction::FusionKind::kCustom;
+    case HloOpcode::kBitcast:
+      return hlo_instruction_utils::KeepsBitwidth(instr);
     case HloOpcode::kCopy:
     case HloOpcode::kIota:
     case HloOpcode::kConstant:
     case HloOpcode::kReduce:
-    case HloOpcode::kBitcast:
     case HloOpcode::kBroadcast:
     case HloOpcode::kConcatenate:
     case HloOpcode::kDynamicSlice:

--- a/xla/service/gpu/transforms/priority_fusion_test.cc
+++ b/xla/service/gpu/transforms/priority_fusion_test.cc
@@ -213,6 +213,20 @@ CHECK-NEXT: ROOT %{{.*}} = (f32[512]{0}, s32[512]{0}) tuple(%[[FUSION_F32]], %[[
   )");
 }
 
+TEST_F(PriorityFusionTest, DoNotFuseBitWidthChangingBitcast) {
+  EXPECT_TRUE(RunAndCheckHloRewrite(R"(
+e {
+  a = s8[3,5,2]{2,1,0} parameter(0)
+  n = s8[3,5,2]{2,1,0} negate(a)
+  b = s16[3,5]{1,0} bitcast(n)
+  m = s16[3,5]{1,0} multiply(b, b)
+})",
+                                    std::move(priority_fusion_),
+                                    /*expect_change=*/false)
+                  .status()
+                  .ok());
+}
+
 TEST_F(PriorityFusionTest, FuseConvertIntoReduce) {
   absl::string_view kHlo = R"(
     HloModule test_module


### PR DESCRIPTION
These better stay outside fusions to remain truly no-ops - inside fusions they can affect indexing and result in suboptimal access patterns.