### PR TITLE
[ROCm] Enable custom all_reduce

### DIFF
--- a/build_tools/rocm/run_xla_multi_gpu.sh
+++ b/build_tools/rocm/run_xla_multi_gpu.sh
@@ -96,4 +96,5 @@ bazel \
        //xla/tests:replicated_io_feed_test \
        //xla/tools/multihost_hlo_runner:functional_hlo_runner_test \
        //xla/pjrt/distributed:topology_util_test \
-       //xla/pjrt/distributed:client_server_test
+       //xla/pjrt/distributed:client_server_test \
+       //xla/backends/gpu/runtime:all_reduce_test

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1907,6 +1907,7 @@ xla_test(
     backend_tags = {
         "gpu": [
             "multi_gpu_h100",
+            "xla_amdgpu_any",
             "no_oss",
         ],
     },

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1907,6 +1907,7 @@ xla_test(
     backend_tags = {
         "gpu": [
             "multi_gpu_h100",
+            "multi_gpu",
             "xla_amdgpu_any",
             "no_oss",
         ],

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -59,7 +59,10 @@ static constexpr int64_t kMaxTwoShotAllReduceSizeBytes =
 absl::StatusOr<se::DeviceMemoryHandle> AllocateMemory(
     se::StreamExecutor* executor, int64_t size,
     absl::string_view debug_buffer_name) {
-  se::DeviceMemoryHandle local_buffer_alloc(executor, executor->Allocate(size));
+  se::DeviceMemoryHandle local_buffer_alloc(
+      executor,
+      executor->Allocate(size, static_cast<int64_t>(
+                                   stream_executor::MemoryType::kP2PTempBuf)));
   if (local_buffer_alloc.memory().is_null()) {
     return absl::InternalError(absl::StrFormat(
         "Failed to allocate %s for all-reduce.", debug_buffer_name));

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -61,8 +61,8 @@ absl::StatusOr<se::DeviceMemoryHandle> AllocateMemory(
     absl::string_view debug_buffer_name) {
   se::DeviceMemoryHandle local_buffer_alloc(
       executor,
-      executor->Allocate(size, static_cast<int64_t>(
-                                   stream_executor::MemoryType::kP2PTempBuf)));
+      executor->Allocate(
+          size, static_cast<int64_t>(stream_executor::MemoryType::kP2P)));
   if (local_buffer_alloc.memory().is_null()) {
     return absl::InternalError(absl::StrFormat(
         "Failed to allocate %s for all-reduce.", debug_buffer_name));

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -132,6 +132,7 @@ namespace wrap {
   __macro(hipLaunchKernel)                          \
   __macro(hipMalloc)                                \
   __macro(hipMallocManaged)                         \
+  __macro(hipExtMallocWithFlags)                    \
   __macro(hipMemGetAddressRange)                    \
   __macro(hipMemGetInfo)                            \
   __macro(hipMemcpyDtoD)                            \

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -413,14 +413,20 @@ bool GetDeviceProperties(hipDeviceProp_t* device_properties,
 }
 
 // Allocates memory on the GPU device.
-void* DeviceAllocate(Context* context, uint64_t bytes) {
+void* DeviceAllocate(Context* context, uint64_t bytes, bool is_fine_grained) {
   if (bytes == 0) {
     return nullptr;
   }
 
   ScopedActivateContext activated(context);
-  hipDeviceptr_t result = nullptr;
-  hipError_t res = wrap::hipMalloc(&result, bytes);
+  hipDeviceptr_t device_mem = nullptr;
+  hipError_t res;
+  if (is_fine_grained) {
+    res = wrap::hipExtMallocWithFlags(&device_mem, bytes,
+                                      hipDeviceMallocFinegrained);
+  } else {
+    res = wrap::hipMalloc(&device_mem, bytes);
+  }
   if (res != hipSuccess) {
     // LOG(INFO) because this isn't always important to users (e.g. BFCAllocator
     // implements a retry if the first allocation fails).
@@ -429,7 +435,7 @@ void* DeviceAllocate(Context* context, uint64_t bytes) {
               << " bytes) from device: " << ToString(res);
     return nullptr;
   }
-  void* ptr = reinterpret_cast<void*>(result);
+  void* ptr = reinterpret_cast<void*>(device_mem);
   VLOG(2) << "allocated " << ptr << " for device " << context->device_ordinal()
           << " of " << bytes << " bytes";
   return ptr;
@@ -733,7 +739,11 @@ DeviceMemoryBase RocmExecutor::Allocate(uint64_t size, int64_t memory_space) {
   switch (static_cast<MemoryType>(memory_space)) {
     case MemoryType::kCollective:
     case MemoryType::kDevice:
-      return DeviceMemoryBase(DeviceAllocate(rocm_context_, size), size);
+      return DeviceMemoryBase(
+          DeviceAllocate(rocm_context_, size, /*is_fine_grained*/ false), size);
+    case MemoryType::kP2PTempBuf:
+      return DeviceMemoryBase(
+          DeviceAllocate(rocm_context_, size, /*is_fine_grained*/ true), size);
     case MemoryType::kHost:
       if (auto result = HostAllocate(rocm_context_, size); result.ok()) {
         return DeviceMemoryBase(*result, size);

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -413,7 +413,7 @@ bool GetDeviceProperties(hipDeviceProp_t* device_properties,
 }
 
 // Allocates memory on the GPU device.
-void* DeviceAllocate(Context* context, uint64_t bytes, bool is_fine_grained) {
+void* DeviceAllocate(Context* context, uint64_t bytes, bool is_fine_grained = false) {
   if (bytes == 0) {
     return nullptr;
   }
@@ -422,6 +422,9 @@ void* DeviceAllocate(Context* context, uint64_t bytes, bool is_fine_grained) {
   hipDeviceptr_t device_mem = nullptr;
   hipError_t res;
   if (is_fine_grained) {
+    // Fine-grained memory, which has better coherence during the kernel execution.
+    // This type of memory is only used in P2P communication to solve the cache coherence
+    // issue for some archs (e.g., MI200); most of the time, you don't have to use it.
     res = wrap::hipExtMallocWithFlags(&device_mem, bytes,
                                       hipDeviceMallocFinegrained);
   } else {

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -745,6 +745,11 @@ DeviceMemoryBase RocmExecutor::Allocate(uint64_t size, int64_t memory_space) {
       return DeviceMemoryBase(
           DeviceAllocate(rocm_context_, size, /*is_fine_grained*/ false), size);
     case MemoryType::kP2P:
+      // On the ROCm platform, differences in cache design (e.g., coherence
+      // protocol) can cause cache coherence issues for some archs (e.g., MI200)
+      // when using normal device memory. To avoid these problems, we use
+      // fine-grained memory in P2P communication for all archs to make sure of
+      // the correctness.
       return DeviceMemoryBase(
           DeviceAllocate(rocm_context_, size, /*is_fine_grained*/ true), size);
     case MemoryType::kHost:

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -741,7 +741,7 @@ DeviceMemoryBase RocmExecutor::Allocate(uint64_t size, int64_t memory_space) {
     case MemoryType::kDevice:
       return DeviceMemoryBase(
           DeviceAllocate(rocm_context_, size, /*is_fine_grained*/ false), size);
-    case MemoryType::kP2PTempBuf:
+    case MemoryType::kP2P:
       return DeviceMemoryBase(
           DeviceAllocate(rocm_context_, size, /*is_fine_grained*/ true), size);
     case MemoryType::kHost:

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -54,7 +54,7 @@ limitations under the License.
 namespace stream_executor {
 
 // Identifies the memory space where an allocation resides.
-enum class MemoryType { kDevice = 0, kUnified, kCollective, kP2PTempBuf, kHost = 5 };
+enum class MemoryType { kDevice = 0, kUnified, kCollective, kP2P, kHost = 5 };
 
 /// The StreamExecutor is a single-device abstraction for:
 //

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -54,7 +54,7 @@ limitations under the License.
 namespace stream_executor {
 
 // Identifies the memory space where an allocation resides.
-enum class MemoryType { kDevice = 0, kUnified, kCollective, kHost = 5 };
+enum class MemoryType { kDevice = 0, kUnified, kCollective, kP2PTempBuf, kHost = 5 };
 
 /// The StreamExecutor is a single-device abstraction for:
 //


### PR DESCRIPTION
In this PR, we enable custom all_reduce (one-shot / two shot) for the ROCm platform.

In the kernel implementation, we need to introduce fine-grained memory to avoid the cache coherence issue, which happens in some AMD archs in the GPU synchronization.

Reference:
https://rocm.docs.amd.com/en/docs-6.2.1/conceptual/gpu-memory.html?utm_source=chatgpt.com#coherence