### PR TITLE
[NVIDIA GPU] Use both parallel and host threads for processing scheduling passes

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2235,6 +2235,7 @@ cc_library(
         "//xla/service/gpu/model:sol_latency_estimator",
         "//xla/service/gpu/transforms:pgle_accuracy_checker",
         "//xla/service/gpu/transforms:scheduling_instruction_annotator",
+        "//xla/service/gpu/transforms:stream_attribute_async_wrapper",
         "//xla/service/gpu/transforms/collectives:async_collective_annotator",
         "//xla/service/gpu/transforms/collectives:collective_ops_utils",
         "//xla/stream_executor:device_description",

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -64,6 +64,7 @@ limitations under the License.
 #include "xla/service/gpu/transforms/collectives/collective_ops_utils.h"
 #include "xla/service/gpu/transforms/pgle_accuracy_checker.h"
 #include "xla/service/gpu/transforms/scheduling_instruction_annotator.h"
+#include "xla/service/gpu/transforms/stream_attribute_async_wrapper.h"
 #include "xla/service/hlo_module_config.h"
 #include "xla/service/latency_hiding_scheduler.h"
 #include "xla/service/legalize_scheduling_annotations.h"
@@ -646,7 +647,9 @@ absl::StatusOr<HloSchedule> ScheduleGpuModuleWithMemoryScheduler(
   return ScheduleModule(
       module,
       DefaultMemoryScheduler(alias_info, size_func, PostProcessSchedule),
-      /*execution_threads=*/{HloInstruction::kMainExecutionThread},
+      /*execution_threads=*/
+      {HloInstruction::kMainExecutionThread,
+       StreamAttributeAsyncWrapper::kParallelExecutionThread},
       peak_memory_bytes);
 }
 


### PR DESCRIPTION
📝 Summary of Changes
This is to fix a bug where scheduling pipelines only use the main host execution threads(introduced in this https://github.com/openxla/xla/pull/30487).
It should use both main host and parallel threads as there are passes before scheduler that convert computes into async computes that use parallel threads

🎯 Justification
If async compute is present, the scheduling pass will error out with
"absl::raw_hash_map out of range"

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
NA

🧪 Unit Tests:
Added scheduler test to verify changes

🧪 Execution Tests:

