### PR TITLE
[XLA::CPU][OneDnn]Async threadpool for onednn_fusion_thunk

### DIFF
--- a/xla/backends/cpu/runtime/onednn/onednn_fusion_thunk.cc
+++ b/xla/backends/cpu/runtime/onednn/onednn_fusion_thunk.cc
@@ -49,9 +49,10 @@ struct OneDnnFusionThunk::OneDnnRuntime {
   OneDnnRuntime(OneDnnRuntime&&) = default;
   OneDnnRuntime& operator=(OneDnnRuntime&&) = default;
 
-  absl::Status Invoke(Eigen::ThreadPoolInterface* thread_pool,
-                      absl::Span<se::DeviceMemoryBase> arguments,
-                      absl::Span<se::DeviceMemoryBase> results);
+  tsl::AsyncValueRef<OneDnnFusionThunk::ExecuteEvent> Invoke(
+      Eigen::ThreadPoolInterface* thread_pool,
+      absl::Span<se::DeviceMemoryBase> arguments,
+      absl::Span<se::DeviceMemoryBase> results);
 
   OneDnnFusion fusion;
 
@@ -65,11 +66,13 @@ struct OneDnnFusionThunk::OneDnnRuntime {
 OneDnnFusionThunk::OneDnnRuntime::OneDnnRuntime(
     OneDnnFusion fusion, Eigen::ThreadPoolInterface* thread_pool)
     : fusion(std::move(fusion)),
-      threadpool(std::make_unique<OneDnnThreadPool>(thread_pool)),
+      threadpool(
+          std::make_unique<OneDnnThreadPool>(thread_pool, /*is_async=*/true)),
       engine(dnnl::engine::kind::cpu, 0),
       stream(dnnl::threadpool_interop::make_stream(engine, threadpool.get())) {}
 
-absl::Status OneDnnFusionThunk::OneDnnRuntime::Invoke(
+tsl::AsyncValueRef<OneDnnFusionThunk::ExecuteEvent>
+OneDnnFusionThunk::OneDnnRuntime::Invoke(
     Eigen::ThreadPoolInterface* thread_pool,
     absl::Span<se::DeviceMemoryBase> arguments,
     absl::Span<se::DeviceMemoryBase> results) {
@@ -103,7 +106,7 @@ absl::Status OneDnnFusionThunk::OneDnnRuntime::Invoke(
     partition.execute(stream, argument_data, result_data);
   }
 
-  return absl::OkStatus();
+  return threadpool->done_event();
 }
 
 absl::StatusOr<OneDnnFusionThunk::OneDnnRuntime>
@@ -208,11 +211,14 @@ tsl::AsyncValueRef<OneDnnFusionThunk::ExecuteEvent> OneDnnFusionThunk::Execute(
   // Borrow oneDNN runtime from the pool.
   TF_ASSIGN_OR_RETURN(auto runtime,
                       onednn_runtime_pool_.GetOrCreate(thread_pool));
-  TF_RETURN_IF_ERROR(runtime->Invoke(thread_pool,
-                                     absl::MakeSpan(arguments_buffers),
-                                     absl::MakeSpan(results_buffers)));
+  auto executed =
+      runtime->Invoke(thread_pool, absl::MakeSpan(arguments_buffers),
+                      absl::MakeSpan(results_buffers));
+  executed.AndThen([runtime = std::move(runtime)]() mutable {
+    // runtime will be destroyed here
+  });
 
-  return OkExecuteEvent();
+  return executed;
 }
 
 }  // namespace xla::cpu

--- a/xla/backends/cpu/runtime/onednn/onednn_fusion_thunk.cc
+++ b/xla/backends/cpu/runtime/onednn/onednn_fusion_thunk.cc
@@ -214,9 +214,8 @@ tsl::AsyncValueRef<OneDnnFusionThunk::ExecuteEvent> OneDnnFusionThunk::Execute(
   auto executed =
       runtime->Invoke(thread_pool, absl::MakeSpan(arguments_buffers),
                       absl::MakeSpan(results_buffers));
-  executed.AndThen([runtime = std::move(runtime)]() mutable {
-    // runtime will be destroyed here
-  });
+  // Destroy the runtime after the task is done.
+  executed.AndThen([runtime = std::move(runtime)] {});
 
   return executed;
 }


### PR DESCRIPTION
This PR updates the [OneDnnthreadpool ](https://github.com/openxla/xla/blob/09bb90bed5d0c036e1cdc67a6b4706016e7c8adc/xla/backends/cpu/runtime/onednn/onednn_fusion_thunk.cc#L68)used for creating OneDnnRuntime object inside onednn_fusion_thunk, to use threadpool with asynchronous execution. 
This results in improved the performance for onednn_fusion_thunks .

