### PR TITLE
Schedule cross-host transfers on XLA launcher threads to prevent deadlock

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1039,7 +1039,7 @@ void StreamExecutorGpuClient::CopyToRemoteDevice(
       on_done(absl::OkStatus(), /*sends_were_enqueued=*/true);
     }
   };
-  thread_pool()->Schedule(send);
+  (*local_device)->execute_thread()->Schedule(send);
 }
 
 absl::StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
@@ -1154,7 +1154,7 @@ StreamExecutorGpuClient::MakeCrossHostReceiveBuffers(
       SetEventAsError(definition_event, s);
     }
   };
-  thread_pool()->Schedule(recv);
+  local_device->execute_thread()->Schedule(recv);
 
   std::vector<std::unique_ptr<PjRtBuffer>> buffers;
   buffers.push_back(std::move(buffer));


### PR DESCRIPTION
Summary of Changes
- Schedules cross-host data transfers using the XLA launcher threads instead of a separate thread pool.

Justification
- The current implementation can deadlock in the presence of other computations. An example of this can be found [here](https://gist.github.com/rao-ashish/e37d7460c7ef5225587a8291b63f6bfe), where a deadlock is observed in a program using cross-host device puts with `jax.experimental.multihost_utils.sync_global_devices()`.

Kind of Contribution
- Bug Fix

Tests
- Verified with [this script](https://gist.github.com/rao-ashish/e37d7460c7ef5225587a8291b63f6bfe) that deadlock occurs in the original implementation, but not with the change made by this PR.