### PR TITLE
[XLA:CPU][oneDNN] Fix a failing matmul test with thunk runtime

### DIFF
--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -1630,7 +1630,7 @@ TEST_F(MatmulTest, SimpleTestNoTransposeFusion2) {
   MatchOptimizedHlo(matmul_module_str,
                     R"(
     ; CHECK:     custom_call_target="__onednn$matmul",
-    ; CHECK:     call(%{{[a-z,A-Z,0-9,_,-]*}})
+    ; CHECK:     fusion(%{{[a-z,A-Z,0-9,_,-]*}})
     )");
 }
 


### PR DESCRIPTION
In legacy runtime, parallel transposes were encapsulated in separate computations however, that is not the case with the thunk runtime. This PR fixes a test that expected a call to a transpose computation.