### PR TITLE
[XLA:GPU] Move ReduceScatterCreator after AlgebraicSimplifier

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1083,8 +1083,6 @@ absl::Status RunCollectiveOptimizationPasses(
     collectives_pipeline.AddPass<CollectivePipeliner>(config);
   }
 
-  collectives_pipeline.AddPass<ReduceScatterCreator>();
-
   DebugOptions::PipelineParallelismOptLevel pipeline_parallelism_opt_level =
       debug_options.xla_gpu_experimental_pipeline_parallelism_opt_level();
   if (debug_options.xla_gpu_enable_pipelined_p2p()) {
@@ -1105,6 +1103,8 @@ absl::Status RunCollectiveOptimizationPasses(
   // AllGatherBroadcastReorder pass.
   collectives_pipeline.AddPass<GpuAlgebraicSimplifier>(
       layout_insensitive_algsimp_opts, gpu_version);
+
+  collectives_pipeline.AddPass<ReduceScatterCreator>();
 
   collectives_pipeline.AddPass<AllGatherBroadcastReorder>();
   collectives_pipeline.AddPass<AllGatherRemoveDegenerateDims>();

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -2162,6 +2162,7 @@ xla_cc_test(
     name = "reduce_scatter_creator_test",
     srcs = ["reduce_scatter_creator_test.cc"],
     deps = [
+        ":algebraic_simplifier",
         ":reduce_scatter_creator",
         "//xla:util",
         "//xla/hlo/ir:hlo",
@@ -2170,6 +2171,7 @@ xla_cc_test(
         "//xla/service:hlo_module_config",
         "//xla/service:pattern_matcher",
         "//xla/service/gpu:backend_configs_cc",
+        "//xla/stream_executor:device_description",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/log",

--- a/xla/service/gpu/transforms/reduce_scatter_creator_test.cc
+++ b/xla/service/gpu/transforms/reduce_scatter_creator_test.cc
@@ -34,8 +34,10 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/testlib/pattern_matcher_gmock.h"
 #include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/transforms/algebraic_simplifier.h"
 #include "xla/service/hlo_module_config.h"
 #include "xla/service/pattern_matcher.h"
+#include "xla/stream_executor/device_description.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 
@@ -68,11 +70,27 @@ class GpuReduceScatterCreatorTest : public HloHardwareIndependentTestBase {
   }
 
   size_t ReduceScatterCount(std::unique_ptr<HloModule> &module) {
-    return CollectiveCount(module, HloOpcode::kAllReduce);
+    return CollectiveCount(module, HloOpcode::kReduceScatter);
+  }
+
+  template <typename T>
+  size_t AllReduceCount(std::unique_ptr<T> &module) {
+    return CollectiveCount(module.get(), HloOpcode::kAllReduce);
+  }
+
+  template <typename T>
+  size_t ReduceScatterCount(std::unique_ptr<T> &module) {
+    return CollectiveCount(module.get(), HloOpcode::kReduceScatter);
   }
 
  private:
   size_t CollectiveCount(std::unique_ptr<HloModule> &module, HloOpcode opcode) {
+    return absl::c_count_if(
+        module->entry_computation()->instructions(),
+        [&opcode](HloInstruction *instr) { return instr->opcode() == opcode; });
+  }
+
+  size_t CollectiveCount(HloModule *module, HloOpcode opcode) {
     return absl::c_count_if(
         module->entry_computation()->instructions(),
         [&opcode](HloInstruction *instr) { return instr->opcode() == opcode; });
@@ -693,10 +711,68 @@ ENTRY %SubtractionPattern {
                                                /*expect_change=*/true));
   ASSERT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::ReduceScatter(m::Parameter(0))));
-  const auto* rs = Cast<HloReduceScatterInstruction>(
+  const auto *rs = Cast<HloReduceScatterInstruction>(
       module->entry_computation()->root_instruction());
   EXPECT_EQ(rs->scatter_dimension(), 1) << rs->ToString();
   EXPECT_EQ(AllReduceCount(module), 0);
+}
+
+TEST_F(GpuReduceScatterCreatorTest, AllReduceThroughTuple) {
+  absl::string_view hlo_string = R"(
+HloModule AllReduceThroughTuple
+
+%sum {
+  %a = f32[] parameter(0)
+  %b = f32[] parameter(1)
+  ROOT %add = f32[] add(%a, %b)
+}
+
+ENTRY %AllReduce {
+  %param0 = f32[4096,4096]{1,0} parameter(0)
+  %param1 = f32[1024,4096]{1,0} parameter(1)
+  %all-reduce = f32[4096,4096]{1,0} all-reduce(%param0),
+    replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=5, use_global_device_ids=true, to_apply=%sum
+  %tuple = (f32[4096,4096]{1,0}, f32[1024,4096]{1,0}) tuple(%all-reduce, %param1)
+  %get-tuple-element = f32[4096,4096]{1,0} get-tuple-element(%tuple), index=0
+  %pid = u32[] partition-id()
+  %pid_s32 = s32[] convert(%pid)
+  %slice_size = s32[] constant(512)
+  %offset = s32[] multiply(%pid_s32, %slice_size)
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[512,4096]{1,0} dynamic-slice(%get-tuple-element, %offset, %zero),
+    dynamic_slice_sizes={512,4096}
+}
+)";
+
+  HloModuleConfig config = GetModuleConfigForTest(
+      /*replica_count=*/1, /*num_partitions=*/8);
+  config.set_use_spmd_partitioning(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_without_algsimp,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed_without,
+      ReduceScatterCreator().Run(module_without_algsimp.get()));
+  EXPECT_FALSE(changed_without) << "ReduceScatterCreator should not transform "
+                                   "without AlgebraicSimplifier";
+  EXPECT_EQ(AllReduceCount(module_without_algsimp), 1);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_with_algsimp,
+                          ParseAndReturnVerifiedModule(hlo_string, config));
+
+  AlgebraicSimplifierOptions options;
+  se::GpuComputeCapability compute_capability{se::CudaComputeCapability{8, 0}};
+  GpuAlgebraicSimplifier algsimp(options, compute_capability);
+  TF_ASSERT_OK_AND_ASSIGN(bool algsimp_changed,
+                          algsimp.Run(module_with_algsimp.get(), {}));
+  EXPECT_TRUE(algsimp_changed);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed_with, ReduceScatterCreator().Run(module_with_algsimp.get()));
+  EXPECT_TRUE(changed_with)
+      << "ReduceScatterCreator should transform after AlgebraicSimplifier";
+  EXPECT_GE(ReduceScatterCount(module_with_algsimp), 1)
+      << "Expected at least one ReduceScatter after transformation";
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes
This PR moves the ReduceScatterCreator pass to run after AlgebraicSimplifier, simplifying the transformation pattern and allowing ReduceScatterCreator to convert more all-reduces into reduce-scatters that would otherwise be missed.

🎯 Justification
Running ReduceScatterCreator after AlgebraicSimplifier makes the input patterns easier to recognize. This allows more all-reduces to be converted into reduce-scatters, which would otherwise be missed, leading to better performance. _This was reported internally as an optimization for llama3.3-70b._ 

🚀 Kind of Contribution
⚡️ Performance Improvement,

📊 Benchmark (for Performance Improvements)
On H100:
|  | PR | main |
|----------|----------|----------|
| llama31_8b_bf16_1x8    | 1372251 us   | 1369631 us    |
| llama31_8b_fp8_1x8    | 1106135 us   | 1107605 us    |
| llama31_8b_bf16_2x8    | 1373637 us   | 1370564 us    |
| llama31_8b_fp8_2x8    | 1111912 us   | 1108061 us    |
| llama31_70b_bf16_16x8    | 13933022 us   | 13913957 us    |
| llama31_70b_fp8_16x8    | 9848173 us   | 9867955 us    |
| llama31_70b_bf16_32x8    | 14103619 us   | 14065225 us    |
| llama31_70b_fp8_32x8    | 9732961 us   | 9760739 us    |
| llama31_405b_bf16_64x8    | 52926476 us   | 52886529 us    |
| llama31_405b_fp8_64x8    | 35576505 us   | 37929776 us   |
| mixtral_8x7b_bf16_1x8   | 744367 us   | 744491 us    |
| mixtral_8x7b_bf16_2x8    | 1126425 us   | 1130912 us    |

🧪 Unit Tests:
Added a new unit test

🧪 Execution Tests:
Tested for functionality with llama3.3 70b zero1 + gradient accumulation and saw ~5% performance improvement.
