### PR TITLE
[XLA:CPU] [OneDnn] Bug fix when emitting Parameter in OneDnnFusion

### DIFF
--- a/xla/backends/cpu/onednn_emitter.cc
+++ b/xla/backends/cpu/onednn_emitter.cc
@@ -125,11 +125,11 @@ static absl::StatusOr<dnnl::graph::logical_tensor> CreateLogicalTensor(
 }
 
 static absl::StatusOr<dnnl::graph::logical_tensor> DefineParameter(
-    const HloInstruction* param) {
+    LogicalTensorMap& logical_tensors, const HloInstruction* param) {
   VLOG(3) << absl::StreamFormat("Define logical tensor for parameter: %s",
                                 param->ToString());
-
-  return CreateLogicalTensor(param->parameter_number(), param->shape());
+  size_t id = logical_tensors.size();
+  return CreateLogicalTensor(id, param->shape());
 }
 
 static absl::StatusOr<dnnl::graph::logical_tensor> DefineUnaryOp(
@@ -240,7 +240,8 @@ static absl::StatusOr<OneDnnFusion> EmitOneDnnFusion(
   for (const HloInstruction* instr : instructions) {
     switch (instr->opcode()) {
       case HloOpcode::kParameter: {
-        TF_ASSIGN_OR_RETURN(logical_tensors[instr], DefineParameter(instr));
+        TF_ASSIGN_OR_RETURN(logical_tensors[instr],
+                            DefineParameter(logical_tensors, instr));
       } break;
 
       // Unary elementwise ops.

--- a/xla/service/cpu/tests/onednn_fusion_test.cc
+++ b/xla/service/cpu/tests/onednn_fusion_test.cc
@@ -128,5 +128,32 @@ TEST_F(OneDnnFusionTest, MatMul) {
   EXPECT_TRUE(RunAndCompare(kModuleStr, ErrorSpec{1e-5}));
 }
 
+TEST_F(OneDnnFusionTest, MatMulAdd) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule mul
+    onednn_fusion {
+      %p0 = f32[10,20] parameter(0)
+      %p1 = f32[20,30] parameter(1)
+      %dot = f32[10,30] dot(%p0, %p1),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      %p2 = f32[10,30] parameter(2)
+      ROOT %add = f32[10,30] add(%dot, %p2)
+    }
+    ENTRY entry {
+      %p0 = f32[10,20] parameter(0)
+      %p1 = f32[20,30] parameter(1)
+      %p2 = f32[10,30] parameter(2)
+      ROOT %fusion = f32[10,30] fusion(%p0, %p1, %p2), kind=kCustom,
+        calls=onednn_fusion,
+        backend_config={"fusion_config": {kind: "__onednn_fusion"}}
+    })";
+
+  if (!IsOneDnnGraphEnabled()) {
+    GTEST_SKIP() << "oneDNN fusion is not supported";
+  }
+
+  EXPECT_TRUE(RunAndCompare(kModuleStr, ErrorSpec{1e-5}));
+}
+
 }  // namespace
 }  // namespace xla::cpu


### PR DESCRIPTION
For mapping parameter to graph logical tensor, Onednn fusion emitter implementation assigns same id as parameter number. When emitting onednn graph op, with post-order traversal, this may cause assigning wrong/repeated ids for logical tensor. This can cause inaccurate results.

For ex:
When emitting following fusion:

```
%fused_computation (param_0: f32[96,768], param_1: f32[768,1000], param_2: f32[96,1000]) -> f32[96,1000] {
  %param_0 = f32[96,768]{1,0} parameter(0)
  %param_1 = f32[768,1000]{1,0} parameter(1)
  %dot_general.0 = f32[96,1000]{1,0} dot(%param_0, %param_1), lhs_contracting_dims={1}, rhs_contracting_dims={0} 
  %param_2 = f32[96,1000]{1,0} parameter(2)
  ROOT %add.28 = f32[96,1000]{1,0} add(%dot_general.0, %param_2)
}
```
With current implementation, mapping of tensors will be :
param_0 --> creates logical_tensor with id 0
param_0 --> creates logical_tensor id 1
dot_general.0 --> creates logical_tensor id 2
param_2 --> **creates logical_tensor id 2** (since id 2 already exists, it will use same logical tensor as of dot_general.0)
add.28 --> creates logical tensor with id 3

As a result of this add.28 will use dot_general.0 as both inputs instead of [ dot_general0, param_2]

**This PR** addresses this bug by assigning unique id to logical tensors for parameter.
This also results in improved performance for matmul fusions, as in backend onednn graph can fuse binary ops as post-ops, which previously ran as onednn matmul + onednn binary_add.
