### PR TITLE
Expose num_repeats_with_profiler option to Python HLO Runner interface

### DIFF
--- a/xla/tools/multihost_hlo_runner/python_hlo_runner.cc
+++ b/xla/tools/multihost_hlo_runner/python_hlo_runner.cc
@@ -75,6 +75,7 @@ struct PyHloRunnerConfig {
   bool use_layouts_from_hlo_module = false;
   bool force_auto_layout = false;
   int32_t num_repeats = 1;
+  int32_t num_repeats_with_profiler = 1;
   std::string execution_options_path = "";
   int64_t gpu_client_initialization_timeout_sec = 300;
   float gpu_client_mem_fraction = GpuAllocatorConfig{}.memory_fraction;
@@ -104,6 +105,7 @@ absl::StatusOr<FunctionalHloRunner::RunningOptions> RunningOptionsFromFlags(
   out.module_argument_mode = opts.hlo_argument_mode;
   out.module_output_mode = opts.output_mode;
   out.num_repeats = static_cast<size_t>(opts.num_repeats);
+  out.num_repeats_with_profiler = static_cast<size_t>(opts.num_repeats_with_profiler);
   out.log_input_output_mode =
       opts.log_output ? FunctionalHloRunner::LogOutputMode::kLogOutput
                       : FunctionalHloRunner::LogOutputMode::kNotLogOutput;
@@ -386,6 +388,7 @@ NB_MODULE(py_hlo_multihost_runner, m) {
               &PyHloRunnerConfig::use_layouts_from_hlo_module)
       .def_rw("force_auto_layout", &PyHloRunnerConfig::force_auto_layout)
       .def_rw("num_repeats", &PyHloRunnerConfig::num_repeats)
+      .def_rw("num_repeats_with_profiler", &PyHloRunnerConfig::num_repeats_with_profiler)
       .def_rw("gpu_client_initialization_timeout_sec",
               &PyHloRunnerConfig::gpu_client_initialization_timeout_sec)
       .def_rw("gpu_client_mem_fraction",


### PR DESCRIPTION
📝 Summary of Changes
Exposes the `num_repeats_with_profiler` which was missed in the first PR.

🎯 Justification
Enables profiling with more than 1 iteration.

🚀 Kind of Contribution
♻️ Cleanup