### PR TITLE
Add HNS Rename folder and storage layout API 

### DIFF
--- a/xla/tsl/platform/cloud/BUILD
+++ b/xla/tsl/platform/cloud/BUILD
@@ -395,7 +395,7 @@ tsl_cc_test(
 
 tsl_cc_test(
     name = "gcs_file_system_test",
-    size = "small",
+    size = "medium",
     srcs = ["gcs_file_system_test.cc"],
     deps = [
         ":gcs_file_system",

--- a/xla/tsl/platform/cloud/BUILD
+++ b/xla/tsl/platform/cloud/BUILD
@@ -131,6 +131,7 @@ cc_library(
         "//xla/tsl/platform:types",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/time",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@jsoncpp_git//:jsoncpp",
@@ -409,6 +410,7 @@ tsl_cc_test(
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:str_util",
         "@tsl//tsl/platform:strcat",
+        "@com_google_absl//absl/status",
     ],
 )
 

--- a/xla/tsl/platform/cloud/gcs_file_system.cc
+++ b/xla/tsl/platform/cloud/gcs_file_system.cc
@@ -23,6 +23,8 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "tsl/platform/retrying_file_system.h"
+#include "absl/time/time.h"
+#include "absl/time/clock.h"
 
 #ifndef _WIN32
 #include <unistd.h>
@@ -896,8 +898,8 @@ GcsFileSystem::GcsFileSystem(bool make_default_cache,
   bucket_location_cache_.reset(new ExpiringLRUCache<string>(
       kCacheNeverExpire, kBucketLocationCacheMaxEntries));
 
-  storage_layout_cache_.reset(new ExpiringLRUCache<Json::Value>(
-      kStorageLayoutCacheMaxAgeSecs, kStorageLayoutCacheMaxEntries));
+  storage_layout_cache_ = std::make_unique<ExpiringLRUCache<Json::Value>>(
+      kStorageLayoutCacheMaxAgeSecs, kStorageLayoutCacheMaxEntries);
 
   int64_t resolve_frequency_secs;
   if (GetEnvVar(kResolveCacheSecs, strings::safe_strto64,

--- a/xla/tsl/platform/cloud/gcs_file_system.h
+++ b/xla/tsl/platform/cloud/gcs_file_system.h
@@ -203,7 +203,7 @@ class GcsFileSystem : public FileSystem {
   absl::Status GetFileSize(const string& fname, TransactionToken* token,
                            uint64* file_size) override;
 
-  absl::Status IsBucketHnsEnabled(const string& bucket, bool* is_hns); 
+  absl::Status IsBucketHnsEnabled(const string& bucket, bool* is_hns);
 
   absl::Status RenameFile(const string& src, const string& target,
                           TransactionToken* token) override;
@@ -480,7 +480,7 @@ class GcsFileSystem : public FileSystem {
 
   using StorageLayoutCache = ExpiringLRUCache<Json::Value>;
   std::unique_ptr<StorageLayoutCache> storage_layout_cache_;
-  
+
   std::unordered_set<string> allowed_locations_;
   bool compose_append_;
 

--- a/xla/tsl/platform/cloud/gcs_file_system.h
+++ b/xla/tsl/platform/cloud/gcs_file_system.h
@@ -202,8 +202,12 @@ class GcsFileSystem : public FileSystem {
   absl::Status GetFileSize(const string& fname, TransactionToken* token,
                            uint64* file_size) override;
 
+  absl::Status IsHnsEnabled(const string& bucket, bool* is_hns); 
+
   absl::Status RenameFile(const string& src, const string& target,
                           TransactionToken* token) override;
+
+  absl::Status RenameFolderHns(const string& src, const string& target);
 
   absl::Status IsDirectory(const string& fname,
                            TransactionToken* token) override;

--- a/xla/tsl/platform/cloud/gcs_file_system_test.cc
+++ b/xla/tsl/platform/cloud/gcs_file_system_test.cc
@@ -2496,10 +2496,11 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            "{\"items\": [ "
            "  { \"name\": \"path1/subfolder/file1.txt\" }]}"),
        new FakeHttpRequest(
-            "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
-            "Auth Token: fake_token\nTimeouts: 5 1 10\n",
-            R"({"name": "bucket"})"), // No "hierarchicalNamespace" field
-            // Requesting the full list of files in the folder.
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+           "Auth Token: fake_token\nTimeouts: 5 1 10\n",
+           R"({"name": "bucket"})"),  // No "hierarchicalNamespace" field
+                                      // Requesting the full list of files in
+                                      // the folder.
        new FakeHttpRequest(
            "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path1%2F\n"
@@ -2574,216 +2575,227 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
 }
 
 TEST(GcsFileSystemTest, RenameFile_HnsFolder) {
-  std::vector<HttpRequest*> requests({
-      // 1. Mock the IsDirectory() check. 
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
-          "fields=items%2Fname%2CnextPageToken&prefix=path1%2F&maxResults=1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"items": [{"name": "path1/some_file.txt"}]})"),
+  std::vector<HttpRequest*> requests(
+      {// 1. Mock the IsDirectory() check.
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+           "fields=items%2Fname%2CnextPageToken&prefix=path1%2F&maxResults=1\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"items": [{"name": "path1/some_file.txt"}]})"),
 
-      // 2. Mock the IsHnsEnabled() check. The response contain the `hierarchicalNamespace` object.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"hierarchicalNamespace": {"enabled": true}})"),
+       // 2. Mock the IsHnsEnabled() check. The response contain the
+       // `hierarchicalNamespace` object.
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"hierarchicalNamespace": {"enabled": true}})"),
 
-      // 3. Mock the initial POST request for the fast RenameFolderHns API.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
-          "path1%2F/renameTo/folders/path2%2F\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-rename-op"})"),
+       // 3. Mock the initial POST request for the fast RenameFolderHns API.
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
+           "path1%2F/renameTo/folders/path2%2F\n"
+           "Auth Token: fake_token\n"
+           "Post: yes\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "projects/_/buckets/bucket/operations/hns-rename-op"})"),
 
-      // 4. Mock the polling GET request for the long-running operation.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-rename-op\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"done": true})")
-  });
+       // 4. Mock the polling GET request for the long-running operation.
+       new FakeHttpRequest("Uri: "
+                           "https://www.googleapis.com/storage/v1/b/bucket/"
+                           "operations/hns-rename-op\n"
+                           "Auth Token: fake_token\n"
+                           "Timeouts: 5 1 10\n",
+                           R"({"done": true})")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
 
   TF_EXPECT_OK(
       fs.RenameFile("gs://bucket/path1/", "gs://bucket/path2/", nullptr));
 }
 
 TEST(GcsFileSystemTest, RenameFile_NonHnsBucket_Fallback) {
-  std::vector<HttpRequest*> requests({
-      // 1. Mock the IsDirectory() check.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
-          "fields=items%2Fname%2CnextPageToken&prefix=folder%2F&maxResults=1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"items": [{"name": "folder/file1.txt"}]})"),
+  std::vector<HttpRequest*> requests(
+      {// 1. Mock the IsDirectory() check.
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+           "fields=items%2Fname%2CnextPageToken&prefix=folder%2F&maxResults=1\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"items": [{"name": "folder/file1.txt"}]})"),
 
-      // 2. Mock the IsBucketHnsEnabled() check via the new storageLayout endpoint.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "bucket"})"), // No "hierarchicalNamespace" field
+       // 2. Mock the IsBucketHnsEnabled() check via the new storageLayout
+       // endpoint.
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "bucket"})"),  // No "hierarchicalNamespace" field
 
-      // 3. Mock the GetChildren() call for the iterative fallback.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
-          "fields=items%2Fname%2CnextPageToken&prefix=folder%2F\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"items": [{"name": "folder/file1.txt"}]})"),
+       // 3. Mock the GetChildren() call for the iterative fallback.
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+           "fields=items%2Fname%2CnextPageToken&prefix=folder%2F\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"items": [{"name": "folder/file1.txt"}]})"),
 
-      // 4. Mock the RenameObject (copy + delete) for the child object.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
-          "folder%2Ffile1.txt/rewriteTo/b/bucket/o/new_folder%2Ffile1.txt\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"done": true})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/folder%2Ffile1.txt\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n"
-          "Delete: yes\n",
-          "")
-  });
+       // 4. Mock the RenameObject (copy + delete) for the child object.
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
+           "folder%2Ffile1.txt/rewriteTo/b/bucket/o/new_folder%2Ffile1.txt\n"
+           "Auth Token: fake_token\n"
+           "Post: yes\n"
+           "Timeouts: 5 1 10\n",
+           R"({"done": true})"),
+       new FakeHttpRequest("Uri: "
+                           "https://www.googleapis.com/storage/v1/b/bucket/o/"
+                           "folder%2Ffile1.txt\n"
+                           "Auth Token: fake_token\n"
+                           "Timeouts: 5 1 10\n"
+                           "Delete: yes\n",
+                           "")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
-      
-  TF_EXPECT_OK(fs.RenameFile("gs://bucket/folder/",
-                               "gs://bucket/new_folder/", nullptr));
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
+
+  TF_EXPECT_OK(
+      fs.RenameFile("gs://bucket/folder/", "gs://bucket/new_folder/", nullptr));
 }
 
 TEST(GcsFileSystemTest, RenameFile_HnsFolder_Success) {
-  std::vector<HttpRequest*> requests({
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
-          "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource-folder%2F&maxResults=1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"items": [{"name": "path/source-folder/file.txt"}]})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"hierarchicalNamespace": {"enabled": true}})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
-          "path%2Fsource-folder%2F/renameTo/folders/path%2Fdest-folder%2F\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/rename-op-12345"})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/rename-op-12345\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "operations/rename-op-12345", "done": true})")});
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+           "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource-folder%2F&"
+           "maxResults=1\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"items": [{"name": "path/source-folder/file.txt"}]})"),
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"hierarchicalNamespace": {"enabled": true}})"),
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
+           "path%2Fsource-folder%2F/renameTo/folders/path%2Fdest-folder%2F\n"
+           "Auth Token: fake_token\n"
+           "Post: yes\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "projects/_/buckets/bucket/operations/rename-op-12345"})"),
+       new FakeHttpRequest(
+           "Uri: "
+           "https://www.googleapis.com/storage/v1/b/bucket/operations/"
+           "rename-op-12345\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "operations/rename-op-12345", "done": true})")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
 
   TF_EXPECT_OK(fs.RenameFile("gs://bucket/path/source-folder/",
                              "gs://bucket/path/dest-folder/", nullptr));
 }
 
 TEST(GcsFileSystemTest, RenameFile_HnsFolder_SucceedsOnSecondPoll) {
-  std::vector<HttpRequest*> requests({
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
-          "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource%2F&maxResults=1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"items": [{"name": "path/source/file.txt"}]})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"hierarchicalNamespace": {"enabled": true}})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
-          "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1"})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": false})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": true})")
-  });
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+           "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource%2F&"
+           "maxResults=1\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"items": [{"name": "path/source/file.txt"}]})"),
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"hierarchicalNamespace": {"enabled": true}})"),
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
+           "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
+           "Auth Token: fake_token\n"
+           "Post: yes\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "projects/_/buckets/bucket/operations/hns-op-1"})"),
+       new FakeHttpRequest(
+           "Uri: "
+           "https://www.googleapis.com/storage/v1/b/bucket/operations/"
+           "hns-op-1\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": false})"),
+       new FakeHttpRequest(
+           "Uri: "
+           "https://www.googleapis.com/storage/v1/b/bucket/operations/"
+           "hns-op-1\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": true})")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
 
   TF_EXPECT_OK(fs.RenameFile("gs://bucket/path/source/",
                              "gs://bucket/path/dest/", nullptr));
 }
 
 TEST(GcsFileSystemTest, RenameFile_HnsFolder_FailsDuringPolling) {
-  std::vector<HttpRequest*> requests({
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
-          "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource%2F&maxResults=1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"items": [{"name": "path/source/file.txt"}]})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"hierarchicalNamespace": {"enabled": true}})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
-          "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-2"})"),
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-2\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-2", "done": true,
-              "error": {"code": 13, "message": "An internal error occurred."}})")
-  });
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+           "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource%2F&"
+           "maxResults=1\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"items": [{"name": "path/source/file.txt"}]})"),
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"hierarchicalNamespace": {"enabled": true}})"),
+       new FakeHttpRequest(
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
+           "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
+           "Auth Token: fake_token\n"
+           "Post: yes\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "projects/_/buckets/bucket/operations/hns-op-2"})"),
+       new FakeHttpRequest(
+           "Uri: "
+           "https://www.googleapis.com/storage/v1/b/bucket/operations/"
+           "hns-op-2\n"
+           "Auth Token: fake_token\n"
+           "Timeouts: 5 1 10\n",
+           R"({"name": "projects/_/buckets/bucket/operations/hns-op-2", "done": true,
+              "error": {"code": 13, "message": "An internal error occurred."}})")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
 
   auto status = fs.RenameFile("gs://bucket/path/source/",
                               "gs://bucket/path/dest/", nullptr);
@@ -3091,7 +3103,8 @@ TEST(GcsFileSystemTest, IsBucketHnsEnabled_ReturnsTrueForHnsEnabledBucket) {
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
                    nullptr, 0, 0, 0, 0, 0, 0, 0, kTestRetryConfig,
-                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr, false);
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
 
   bool is_hns = false;
   absl::Status status = fs.IsBucketHnsEnabled("hns-bucket", &is_hns);
@@ -3112,9 +3125,10 @@ TEST(GcsFileSystemTest, IsBucketHnsEnabled_ReturnsFalseForFlatBucket) {
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
                    nullptr, 0, 0, 0, 0, 0, 0, 0, kTestRetryConfig,
-                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr, false);
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
 
-  bool is_hns = true; // Start with true to ensure it's set to false.
+  bool is_hns = true;  // Start with true to ensure it's set to false.
 
   absl::Status status = fs.IsBucketHnsEnabled("flat-bucket", &is_hns);
 
@@ -3127,7 +3141,8 @@ TEST(GcsFileSystemTest, IsBucketHnsEnabled_UsesCacheOnSecondCall) {
   // Provide only ONE mock request. If a second network call is made,
   // the test will fail.
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com/storage/v1/b/cached-bucket/storageLayout\n"
+      "Uri: "
+      "https://www.googleapis.com/storage/v1/b/cached-bucket/storageLayout\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
       R"({"hierarchicalNamespace": {"enabled": true}})")});
@@ -3136,8 +3151,9 @@ TEST(GcsFileSystemTest, IsBucketHnsEnabled_UsesCacheOnSecondCall) {
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
                    nullptr, 0, 0, 0, 0, 0, 0, 0, kTestRetryConfig,
-                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr, false);
-  
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr,
+                   false);
+
   // Call the method twice.
   // The first call should make a network request and populate the cache.
   bool is_hns_first_call = false;
@@ -3145,7 +3161,8 @@ TEST(GcsFileSystemTest, IsBucketHnsEnabled_UsesCacheOnSecondCall) {
   EXPECT_TRUE(is_hns_first_call);
 
   // The second call should hit the cache and not make a network request.
-  // The FakeHttpRequestFactory will fail the test if it receives an unexpected call.
+  // The FakeHttpRequestFactory will fail the test if it receives an unexpected
+  // call.
   bool is_hns_second_call = false;
   TF_EXPECT_OK(fs.IsBucketHnsEnabled("cached-bucket", &is_hns_second_call));
   EXPECT_TRUE(is_hns_second_call);

--- a/xla/tsl/platform/cloud/gcs_file_system_test.cc
+++ b/xla/tsl/platform/cloud/gcs_file_system_test.cc
@@ -2496,10 +2496,10 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            "{\"items\": [ "
            "  { \"name\": \"path1/subfolder/file1.txt\" }]}"),
        new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
-          "Auth Token: fake_token\nTimeouts: 5 1 10\n",
-          R"({"name": "bucket"})"), // No "hierarchicalNamespace" field
-       // Requesting the full list of files in the folder.
+            "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+            "Auth Token: fake_token\nTimeouts: 5 1 10\n",
+            R"({"name": "bucket"})"), // No "hierarchicalNamespace" field
+            // Requesting the full list of files in the folder.
        new FakeHttpRequest(
            "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path1%2F\n"
@@ -2585,10 +2585,10 @@ TEST(GcsFileSystemTest, RenameFile_HnsFolder) {
 
       // 2. Mock the IsHnsEnabled() check. The response contain the `hierarchicalNamespace` object.
       new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
           "Auth Token: fake_token\n"
           "Timeouts: 5 1 10\n",
-          R"({"name": "bucket", "hierarchicalNamespace": {"enabled": true}})"),
+          R"({"hierarchicalNamespace": {"enabled": true}})"),
 
       // 3. Mock the initial POST request for the fast RenameFolderHns API.
       new FakeHttpRequest(
@@ -2628,9 +2628,9 @@ TEST(GcsFileSystemTest, RenameFile_NonHnsBucket_Fallback) {
           "Timeouts: 5 1 10\n",
           R"({"items": [{"name": "folder/file1.txt"}]})"),
 
-      // 2. Mock the IsHnsEnabled() check, returning a Non-HNS response.
+      // 2. Mock the IsBucketHnsEnabled() check via the new storageLayout endpoint.
       new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
           "Auth Token: fake_token\n"
           "Timeouts: 5 1 10\n",
           R"({"name": "bucket"})"), // No "hierarchicalNamespace" field
@@ -2668,6 +2668,129 @@ TEST(GcsFileSystemTest, RenameFile_NonHnsBucket_Fallback) {
       
   TF_EXPECT_OK(fs.RenameFile("gs://bucket/folder/",
                                "gs://bucket/new_folder/", nullptr));
+}
+
+TEST(GcsFileSystemTest, RenameFile_HnsFolder_Success) {
+  std::vector<HttpRequest*> requests({
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+          "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource-folder%2F&maxResults=1\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"items": [{"name": "path/source-folder/file.txt"}]})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"hierarchicalNamespace": {"enabled": true}})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
+          "path%2Fsource-folder%2F/renameTo/folders/path%2Fdest-folder%2F\n"
+          "Auth Token: fake_token\n"
+          "Post: yes\n"
+          "Timeouts: 5 1 10\n",
+          R"({"name": "projects/_/buckets/bucket/operations/rename-op-12345"})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/rename-op-12345\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"name": "operations/rename-op-12345", "done": true})")});
+
+  GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+                   std::unique_ptr<HttpRequest::Factory>(
+                       new FakeHttpRequestFactory(&requests)),
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
+                   kTestRetryConfig, kTestTimeoutConfig,
+                   *kAllowedLocationsDefault, nullptr, false);
+
+  TF_EXPECT_OK(fs.RenameFile("gs://bucket/path/source-folder/",
+                             "gs://bucket/path/dest-folder/", nullptr));
+}
+
+TEST(GcsFileSystemTest, RenameFile_HnsFolder_SucceedsOnSecondPoll) {
+  std::vector<HttpRequest*> requests({
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+          "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource%2F&maxResults=1\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"items": [{"name": "path/source/file.txt"}]})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"hierarchicalNamespace": {"enabled": true}})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
+          "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
+          "Auth Token: fake_token\n"
+          "Post: yes\n"
+          "Timeouts: 5 1 10\n",
+          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1"})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-1\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": false})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-1\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": true})")
+  });
+
+  GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+                   std::unique_ptr<HttpRequest::Factory>(
+                       new FakeHttpRequestFactory(&requests)),
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
+                   kTestRetryConfig, kTestTimeoutConfig,
+                   *kAllowedLocationsDefault, nullptr, false);
+
+  TF_EXPECT_OK(fs.RenameFile("gs://bucket/path/source/",
+                             "gs://bucket/path/dest/", nullptr));
+}
+
+TEST(GcsFileSystemTest, RenameFile_HnsFolder_FailsDuringPolling) {
+  std::vector<HttpRequest*> requests({
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
+          "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsource%2F&maxResults=1\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"items": [{"name": "path/source/file.txt"}]})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/storageLayout\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"hierarchicalNamespace": {"enabled": true}})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
+          "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
+          "Auth Token: fake_token\n"
+          "Post: yes\n"
+          "Timeouts: 5 1 10\n",
+          R"({"name": "projects/_/buckets/bucket/operations/hns-op-2"})"),
+      new FakeHttpRequest(
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-2\n"
+          "Auth Token: fake_token\n"
+          "Timeouts: 5 1 10\n",
+          R"({"name": "projects/_/buckets/bucket/operations/hns-op-2", "done": true,
+              "error": {"code": 13, "message": "An internal error occurred."}})")
+  });
+
+  GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
+                   std::unique_ptr<HttpRequest::Factory>(
+                       new FakeHttpRequestFactory(&requests)),
+                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
+                   kTestRetryConfig, kTestTimeoutConfig,
+                   *kAllowedLocationsDefault, nullptr, false);
+
+  auto status = fs.RenameFile("gs://bucket/path/source/",
+                              "gs://bucket/path/dest/", nullptr);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInternal);
+  EXPECT_THAT(status.message(),
+              ::testing::HasSubstr("An internal error occurred."));
 }
 
 TEST(GcsFileSystemTest, RenameFile_Object) {
@@ -2957,106 +3080,75 @@ TEST(GcsFileSystemTest, RenameFile_Object_Incomplete) {
       "gs://bucket/path/src.txt", "gs://bucket/path/dst.txt", nullptr)));
 }
 
-TEST(GcsFileSystemTest, RenameFolderHns_Success) {
-  std::vector<HttpRequest*> requests({
-      // 1. The initial POST request.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
-          "path%2Fsource-folder%2F/renameTo/folders/path%2Fdest-folder%2F\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/rename-op-12345"})"),
-
-      // 2. The polling GET request to match the GCS v1 operations endpoint.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/rename-op-12345\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "operations/rename-op-12345", "done": true})")});
+TEST(GcsFileSystemTest, IsBucketHnsEnabled_ReturnsTrueForHnsEnabledBucket) {
+  std::vector<HttpRequest*> requests({new FakeHttpRequest(
+      "Uri: https://www.googleapis.com/storage/v1/b/hns-bucket/storageLayout\n"
+      "Auth Token: fake_token\n"
+      "Timeouts: 5 1 10\n",
+      R"({"hierarchicalNamespace": {"enabled": true}})")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
+                   nullptr, 0, 0, 0, 0, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr, false);
 
-  TF_EXPECT_OK(fs.RenameFolderHns("gs://bucket/path/source-folder/",
-                               "gs://bucket/path/dest-folder/"));
+  bool is_hns = false;
+  absl::Status status = fs.IsBucketHnsEnabled("hns-bucket", &is_hns);
+
+  // ASSERT: The call should succeed and return true.
+  TF_EXPECT_OK(status);
+  EXPECT_TRUE(is_hns);
 }
 
-TEST(GcsFileSystemTest, RenameFolderHns_SucceedsOnSecondPoll) {
-  std::vector<HttpRequest*> requests({
-      // 1. The initial POST request to start the rename.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
-          "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1"})"),
-
-      // 2. The FIRST poll, which returns "done: false".
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": false})"),
-
-      // 3. The SECOND poll, which returns "done: true".
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-1\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-1", "done": true})")
-  });
+TEST(GcsFileSystemTest, IsBucketHnsEnabled_ReturnsFalseForFlatBucket) {
+  std::vector<HttpRequest*> requests({new FakeHttpRequest(
+      "Uri: https://www.googleapis.com/storage/v1/b/flat-bucket/storageLayout\n"
+      "Auth Token: fake_token\n"
+      "Timeouts: 5 1 10\n",
+      R"({"name": "flat-bucket"})")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
+                   nullptr, 0, 0, 0, 0, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr, false);
 
-  TF_EXPECT_OK(fs.RenameFolderHns("gs://bucket/path/source/",
-                                    "gs://bucket/path/dest/"));
+  bool is_hns = true; // Start with true to ensure it's set to false.
+
+  absl::Status status = fs.IsBucketHnsEnabled("flat-bucket", &is_hns);
+
+  // ASSERT: The call should succeed and return false.
+  TF_EXPECT_OK(status);
+  EXPECT_FALSE(is_hns);
 }
 
-TEST(GcsFileSystemTest, RenameFolderHns_FailsDuringPolling) {
-  std::vector<HttpRequest*> requests({
-      // 1. The initial POST request.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/folders/"
-          "path%2Fsource%2F/renameTo/folders/path%2Fdest%2F\n"
-          "Auth Token: fake_token\n"
-          "Post: yes\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-2"})"),
-
-      // 2. The failing poll response, which contains an "error" object.
-      new FakeHttpRequest(
-          "Uri: https://www.googleapis.com/storage/v1/b/bucket/operations/hns-op-2\n"
-          "Auth Token: fake_token\n"
-          "Timeouts: 5 1 10\n",
-          R"({"name": "projects/_/buckets/bucket/operations/hns-op-2", "done": true,
-              "error": {"code": 13, "message": "An internal error occurred."}})")
-  });
+TEST(GcsFileSystemTest, IsBucketHnsEnabled_UsesCacheOnSecondCall) {
+  // Provide only ONE mock request. If a second network call is made,
+  // the test will fail.
+  std::vector<HttpRequest*> requests({new FakeHttpRequest(
+      "Uri: https://www.googleapis.com/storage/v1/b/cached-bucket/storageLayout\n"
+      "Auth Token: fake_token\n"
+      "Timeouts: 5 1 10\n",
+      R"({"hierarchicalNamespace": {"enabled": true}})")});
 
   GcsFileSystem fs(std::unique_ptr<AuthProvider>(new FakeAuthProvider),
                    std::unique_ptr<HttpRequest::Factory>(
                        new FakeHttpRequestFactory(&requests)),
-                   nullptr, 16, 64, 0, 3600, 0, 0, 0,
-                   kTestRetryConfig, kTestTimeoutConfig,
-                   *kAllowedLocationsDefault, nullptr, false);
+                   nullptr, 0, 0, 0, 0, 0, 0, 0, kTestRetryConfig,
+                   kTestTimeoutConfig, *kAllowedLocationsDefault, nullptr, false);
+  
+  // Call the method twice.
+  // The first call should make a network request and populate the cache.
+  bool is_hns_first_call = false;
+  TF_EXPECT_OK(fs.IsBucketHnsEnabled("cached-bucket", &is_hns_first_call));
+  EXPECT_TRUE(is_hns_first_call);
 
-  auto status = fs.RenameFolderHns("gs://bucket/path/source/",
-                                     "gs://bucket/path/dest/");
-
-  // Verify that the function returns an Internal error.
-  EXPECT_EQ(status.code(), absl::StatusCode::kInternal);
-  EXPECT_THAT(status.message(),
-              ::testing::HasSubstr("An internal error occurred."));
+  // The second call should hit the cache and not make a network request.
+  // The FakeHttpRequestFactory will fail the test if it receives an unexpected call.
+  bool is_hns_second_call = false;
+  TF_EXPECT_OK(fs.IsBucketHnsEnabled("cached-bucket", &is_hns_second_call));
+  EXPECT_TRUE(is_hns_second_call);
 }
 
 TEST(GcsFileSystemTest, Stat_Object) {

--- a/xla/tsl/platform/cloud/gcs_file_system_test.cc
+++ b/xla/tsl/platform/cloud/gcs_file_system_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "xla/tsl/platform/test.h"
 #include "tsl/platform/str_util.h"
 #include "tsl/platform/strcat.h"
+#include "absl/status/status.h"
 
 // Undef DeleteFile macro defined in wndows.h.
 #ifdef PLATFORM_WINDOWS


### PR DESCRIPTION
📝 Summary of Changes
Adding rename folder API for HNS bucket in the existing rename method. In order to identify if bucket is HNS enabled using storage layout api 

🎯 Justification
Rename on HSN bucekt without this new API involves slow copy of every object and subfolders. This is an efficient, fast atomic operation which customers can use in their checkpointing workload 

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N/A. This PR is a filesystem enhancement (improving GCS HNS rename operations) and does not directly affect the computational performance or compilation time of the HLO benchmarks.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.
N/A for the HLO examples, as this is a C++ filesystem change.
Unit tests were added to gcs_file_system_test.cc to validate the new rename logic and its fallbacks:
- The successful HNS rename path, including multi-poll LRO logic.
- Correct parsing of JSON error responses from the LRO.
- The critical fallback to the legacy copy/delete logic for non-HNS buckets.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
N/A
