### PR TITLE
🐛 Bug Fix: propagate memory_space 

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1082,7 +1082,7 @@ StreamExecutorGpuClient::MakeCrossHostReceiveBuffers(
       AllocateDestinationBuffer(shape, device, local_device,
                                 /*copy_stream=*/stream,
                                 /*is_uninitialized_create=*/true, this,
-                                definition_event));
+                                definition_event, /*memory_space=*/nullptr));
 
   // Acquire a hold on the buffer to access the underlying memory.
   PjRtStreamExecutorBuffer::ScopedHold hold = buffer->GetBufferWithUsageHold();

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -1326,7 +1326,7 @@ PjRtStreamExecutorClient::CreateUninitializedBuffer(
       AllocateDestinationBuffer(compact_shape, device, local_device,
                                 /*copy_stream=*/nullptr,
                                 /*is_uninitialized_create=*/true, this,
-                                definition_event));
+                                definition_event, memory_space));
   return std::unique_ptr<PjRtBuffer>(std::move(py_buffer));
 }
 
@@ -1392,7 +1392,8 @@ PjRtStreamExecutorClient::BufferFromHostLiteral(const LiteralSlice& literal,
       std::unique_ptr<PjRtStreamExecutorBuffer> py_buffer,
       AllocateDestinationBuffer(compact_shape, device, local_device,
                                 local_device->host_to_device_stream(),
-                                /*is_uninitialized_create=*/false, this));
+                                /*is_uninitialized_create=*/false, this,
+                                /*definition_event=*/nullptr, memory_space));
 
   PjRtStreamExecutorBuffer::ScopedHold device_buffer(
       py_buffer->GetBufferWithUsageHold());


### PR DESCRIPTION
🐛 Bug Fix

📝 Summary of Changes
Propagate memory space in `PJRT_Client_CreateUninitializedBuffer`

🎯 Justification
Currently `PJRT_Client_CreateUninitializedBuffer` doesn't honor the memory space argument it received.
`CreateUninitializedBuffer` is not passing memory_space to `AllocateDestinationBuffer`.
The argument then defaults to null, which is interpreted as the default memory space.