### PR TITLE
[XLA:CPU][BugFix] Fix ODR Violation by Renaming Duplicate IsSupportedType Definition

### DIFF
--- a/xla/backends/cpu/runtime/convolution_lib.cc
+++ b/xla/backends/cpu/runtime/convolution_lib.cc
@@ -93,7 +93,7 @@ static absl::Status ValidateConvolutionShapes(
   return absl::OkStatus();
 }
 
-bool IsSupportedType(PrimitiveType primitive_type) {
+bool IsConvSupportedType(PrimitiveType primitive_type) {
   return primitive_type == PrimitiveType::F16 ||
          primitive_type == PrimitiveType::F32;
 }
@@ -105,7 +105,7 @@ absl::StatusOr<ConvolutionCanonicalDims> GetConvolutionCanonicalDims(
       slices.input_shape, slices.kernel_shape, slices.output_shape, dnums));
 
   auto primitive_type = slices.input_shape.element_type();
-  if (!IsSupportedType(primitive_type)) {
+  if (!IsConvSupportedType(primitive_type)) {
     return InvalidArgument("ConvolutionThunk: Unsupported element type (%s)",
                            PrimitiveType_Name(primitive_type));
   }

--- a/xla/backends/cpu/runtime/convolution_lib.cc
+++ b/xla/backends/cpu/runtime/convolution_lib.cc
@@ -93,7 +93,7 @@ static absl::Status ValidateConvolutionShapes(
   return absl::OkStatus();
 }
 
-bool IsConvSupportedType(PrimitiveType primitive_type) {
+inline bool IsConvSupportedType(PrimitiveType primitive_type) {
   return primitive_type == PrimitiveType::F16 ||
          primitive_type == PrimitiveType::F32;
 }


### PR DESCRIPTION
Two different definitions of `xla::cpu::IsSupportedType(...)` in `onednn_util.h` and `convolution_lib.cc` cause ODR (One Definition Rule) violation. This occurs when modifying the `IsSupportedType(...)` function in `onednn_util.h` (e.g., adding logs), which causes the compiler not to inline the function and results in undefined behavior.

This PR fixes the issue by renaming the `IsSupportedType(...)` function in `convolution_lib.cc` (as changing the name in `onednn_util.h` will need changes in its multiple invocations).