### PR TITLE
[GPU] Move bitcast-convert expansion past layout assignment.

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -899,7 +899,6 @@ absl::Status RunOptimizationPasses(
         gpu_target_config.device_description.gpu_compute_capability());
     pipeline.AddPass<GpuAlgebraicSimplifier>(layout_insensitive_algsimp_opts,
                                              gpu_version);
-    pipeline.AddPass<BitcastDtypesExpander>();
     // Only merge "smallish" dots.  This threshold defaults to 32MB today, with
     // a flag to override.
     // Do not merge dots when they are assigned different stream ids.
@@ -1703,6 +1702,10 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
     // duplicate or NOPs, so remove them with algebraic simplification and CSE.
     pipeline.AddPass<HloPassFix<GpuAlgebraicSimplifier>>(simplifier_options,
                                                          gpu_version);
+
+    // Expand bitcast-converts which are not bitcasts remaining after algebraic
+    // simplification.
+    pipeline.AddPass<BitcastDtypesExpander>();
 
     // GemmRewriter assumes that all transposes are folded into gemms, but,
     // since commit 7d529df, this is not always true at this point.

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -609,6 +609,7 @@ lit_test_suite(
     name = "hlo_lit_tests",
     srcs = enforce_glob(
         [
+            "bitcast-convert.hlo",
             "calling_convention.hlo",
             "dot_bf16.hlo",
             "kernel_reuse.hlo",

--- a/xla/service/gpu/tests/bitcast-convert.hlo
+++ b/xla/service/gpu/tests/bitcast-convert.hlo
@@ -1,0 +1,13 @@
+// RUN: hlo-opt %s --platform=gpu --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/%{GPU}.txtpb | FileCheck  %s
+
+e {
+  a = s4[8,2]{1,0} parameter(0)
+  b = s8[8]{0} bitcast-convert(a)
+  c = s8[8]{0} copy(b)
+}
+
+// CHECK-NOT: bitcast-convert
+// CHECK: ENTRY
+// CHECK-NEXT: %[[p0:.*]] = s4[8,2]{1,0:E(4)} parameter(0)
+// CHECK-NEXT: %[[b:.*]] = s8[8]{0} bitcast(%[[p0]])
+// CHECK-NEXT: ROOT %[[c:.*]] = s8[8]{0} copy(%[[b]])


### PR DESCRIPTION
This lets post-layout assignment algebraic simplifier replace no-op bitcast-converts with bitcasts first.

