### PR TITLE
[XLA:GPU] command buffer ChildCmd and WhileCmd support multiple device

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -822,12 +822,6 @@ class ChildCmd : public CommandBufferCmd {
 
  private:
   CommandBufferCmdExecutor child_commands_;
-
-  // child command buffer is created at initialization time and then use the
-  // move semantics to move it to the command buffer implementation. We do not
-  // use the copy semantics because we will lose track of of the grahp nodes for
-  // underlying implementation.
-  std::unique_ptr<se::CommandBuffer> child_command_buffer_;
 };
 
 //===----------------------------------------------------------------------===//
@@ -897,8 +891,6 @@ class WhileCmd : public CommandBufferCmd {
   std::optional<int64_t> trip_count_;
   bool enable_loop_unroll_ = false;
   bool is_unrolled_loop_ = false;
-  std::unique_ptr<se::CommandBuffer>
-      child_command_buffer_;  // The body command buffer for unrolled loop.
 };
 
 //===----------------------------------------------------------------------===//

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -186,6 +186,18 @@ class CommandBuffer {
                                           const Command* command,
                                           const CommandBuffer& nested) = 0;
 
+  virtual absl::StatusOr<const Command*> CreateChildCommand(
+      ChildCommandType type, StreamExecutor* executor,
+      absl::AnyInvocable<absl::Status(stream_executor::CommandBuffer*)>
+          record_fn,
+      absl::Span<const Command* const> dependencies) = 0;
+
+  // Updates a command that launches a nested command buffer.
+  virtual absl::Status UpdateChildCommand(
+      ChildCommandType type, const Command* command,
+      absl::AnyInvocable<absl::Status(stream_executor::CommandBuffer*)>
+          record_fn) = 0;
+
   // Creates a device-to-device memory copy.
   virtual absl::StatusOr<const Command*> CreateMemcpyD2D(
       DeviceMemoryBase* dst, const DeviceMemoryBase& src, uint64_t size,


### PR DESCRIPTION
📝 Summary of Changes
This PR fixes an issue that will broken when running the command buffer WhileCmd in the SPMD config. The child_command_buffer_ object should be per device object.


🚀 Kind of Contribution
🐛 Bug Fix


🧪 Unit Tests:
xla/service/gpu/tests/command_buffer_test.cc:WhileLoopMultiDevice