### PR TITLE
 [ROCm] added rocm7 support to EnablePeerAccess

### DIFF
--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -51,7 +51,7 @@ namespace wrap {
     static FuncPtrT loaded = []() -> FuncPtrT {                             \
       static const char *kName = TO_STR(hipSymbolName);                     \
       void *f;                                                              \
-      auto s = tsl::Env::Default()->GetSymbolFromLibrary(                   \
+      auto s = tsl::Env::Default() -> GetSymbolFromLibrary(                 \
           tsl::internal::CachedDsoLoader::GetHipDsoHandle().value(), kName, \
           &f);                                                              \
       CHECK(s.ok()) << "could not find " << kName                           \
@@ -100,6 +100,7 @@ namespace wrap {
   __macro(hipGetDeviceCount)                        \
   __macro(hipGetDeviceProperties)                   \
   __macro(hipGetErrorString)                        \
+  __macro(hipGetLastError)                          \
   __macro(hipGraphAddKernelNode)                    \
   __macro(hipGraphAddChildGraphNode)                \
   __macro(hipGraphAddEmptyNode)                     \

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -380,11 +380,13 @@ absl::Status EnablePeerAccess(Context* from, Context* to) {
   hipError_t result =
       wrap::hipDeviceEnablePeerAccess(to->device_ordinal(), 0 /* = flags */);
 
-  if (result != hipSuccess && result != hipErrorPeerAccessAlreadyEnabled) {
+  if (result == hipErrorPeerAccessAlreadyEnabled) {
+    hipGetLastError();
+  } else if (result != hipSuccess) {
     return absl::InternalError(
         absl::StrFormat("failed to enable peer access from %d to %d: %s",
                         from->device_ordinal(), to->device_ordinal(),
-                        ToString(result).c_str()));
+                        hipGetErrorString(result)));
   }
 
   return absl::OkStatus();

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -381,12 +381,15 @@ absl::Status EnablePeerAccess(Context* from, Context* to) {
       wrap::hipDeviceEnablePeerAccess(to->device_ordinal(), 0 /* = flags */);
 
   if (result == hipErrorPeerAccessAlreadyEnabled) {
-    hipGetLastError();
+    // hipGetLastError is used to reset per thread error state,
+    // as hipGetLastError would get the recent error code since rocm7 even the
+    // last call is successful.
+    (void)wrap::hipGetLastError();
   } else if (result != hipSuccess) {
     return absl::InternalError(
         absl::StrFormat("failed to enable peer access from %d to %d: %s",
                         from->device_ordinal(), to->device_ordinal(),
-                        hipGetErrorString(result)));
+                        wrap::hipGetErrorString(result)));
   }
 
   return absl::OkStatus();


### PR DESCRIPTION
Since rocm7, hipGetLastError returns last error even if last call was successful. This change makes it possible to work correctly with rocm7. We need to call hipGetLastError to reset per thread error state. 

Especially, it fixed the failed test in TransformerEngine compiled with rocm7, `pytest -vvv -s tests/jax/test_distributed_layernorm_mlp.py::TestDistributedLayernormMLP::test_layernorm_fp8_mlp_primitive[True-bfloat16-activation_type0-input_shape0-mesh_config1]`

@xla-rotation could you review my PR, please?

