### PR TITLE
[ROCm] Restore hipblaslt gemm support

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2127,6 +2127,7 @@ cc_library(
         "//xla:xla_proto_cc",
         "//xla/backends/autotuner:codegen_backend",
         "//xla/backends/gpu/autotuner:cublas",
+        "//xla/backends/gpu/autotuner:cublaslt",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
         "//xla/hlo/pass:hlo_pass_pipeline",

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "llvm/IR/Module.h"
 #include "xla/backends/autotuner/codegen_backend.h"
 #include "xla/backends/gpu/autotuner/cublas.h"
+#include "xla/backends/gpu/autotuner/cublaslt.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
@@ -266,6 +267,8 @@ absl::Status AMDGPUCompiler::AddConvAndGemmAutotuningPasses(
   // backend uses the same API as rocBLAS.
   backends.push_back(
       std::make_unique<CublasBackend>(stream_exec, &debug_options, this));
+  backends.push_back(
+      std::make_unique<CublasLtBackend>(stream_exec, &debug_options, this));
   auto should_autotune = [](const HloInstruction& instruction) -> bool {
     return instruction.opcode() == HloOpcode::kCustomCall &&
            IsCublasGemm(instruction);


### PR DESCRIPTION
📝 Summary of Changes
Include cublaslt (hipblaslt) in gemm autotuning for rocm

🎯 Justification
Restore old behaviour

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
None

🧪 Execution Tests:
None
