### PR TITLE
[NVIDIA GPU] Add actionable message for NVML library loading error

### DIFF
--- a/xla/service/gpu/model/gpu_collective_performance_model.cc
+++ b/xla/service/gpu/model/gpu_collective_performance_model.cc
@@ -407,7 +407,9 @@ RocmBandwidthSettings CreateSettings(
     if (*se.functor == nullptr) {
       const char* dlsym_error = dlerror();
       if (dlsym_error) {
-        LOG(WARNING) << dlsym_error;
+        VLOG(0) << "Failed to load symbol " << se.name << ": " << dlsym_error;
+        VLOG(0) << "This is likely caused by insufficient CUDA driver version. "
+                   "Please upgrade CUDA driver to 550 or higher.";
       }
     }
   }


### PR DESCRIPTION
📝 Summary of Changes
Users don't need to worry about NVML library loading error when not running on MNNVL nodes, use VLOG(0) so it's not shown by default. Also added actionable messages for fixing it.

🎯 Justification
Showing the error message by default without actionable suggestions caused confusion. https://github.com/jax-ml/jax/issues/31615

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A for logging changes.

🧪 Unit Tests:
N/A for logging changes.

🧪 Execution Tests:
N/A for logging changes.
