### PR TITLE
[ROCm] Fix CI build break

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -5,6 +5,10 @@ load(
     "if_cuda_or_rocm_is_configured",
     "if_gpu_is_configured",
 )
+load(
+    "//xla/tsl/platform/default:cuda_build_defs.bzl",
+    "if_cuda_is_configured",
+)
 load("//xla/tests:build_defs.bzl", "xla_test")
 load("//xla/tsl:tsl.bzl", "if_google")
 
@@ -263,7 +267,6 @@ cc_library(
         "//xla/service/gpu:ir_emission_utils",
         "//xla/service/gpu:launch_dimensions",
         "//xla/service/gpu/llvm_gpu_backend:amdgpu_backend",
-        "//xla/service/gpu/llvm_gpu_backend:nvptx_backend",
         "//xla/service/gpu/llvm_gpu_backend:nvptx_libdevice_path",
         "//xla/service/gpu:matmul_utils",
         "//xla/service/gpu:triton_fusion_analysis",
@@ -278,6 +281,8 @@ cc_library(
         "@tsl//tsl/platform:path",
         "@tsl//tsl/platform:statusor",
         "@triton//:TritonTransforms",
+    ]) + if_cuda_is_configured([
+        "//xla/service/gpu/llvm_gpu_backend:nvptx_backend",
     ]),
 )
 


### PR DESCRIPTION
📝 Summary of Changes
Moved `//xla/service/gpu/llvm_gpu_backend:nvptx_backend` dependency of `xla/backends/gpu/codegen/triton:fusion_emitter` behind `if_cuda_is_configured` guard.

🎯 Justification
ROCm CI was failing to build with:
```
ERROR: /root/xla/xla/service/gpu/llvm_gpu_backend/BUILD:83:11: Compiling xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing CppCompile command (from target //xla/service/gpu/llvm_gpu_backend:nvptx_backend) external/local_config_rocm/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer ... (remaining 359 arguments skipped)
xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc:32:10: fatal error: 'third_party/gpus/cuda/include/cuda.h' file not found
   32 | #include "third_party/gpus/cuda/include/cuda.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
/

🧪 Unit Tests:
/

🧪 Execution Tests:
/
