### PR TITLE
fix tensor_or_memref.h compile error

### DIFF
--- a/xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.h
+++ b/xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.h
@@ -163,7 +163,7 @@ struct BufferView {
     Iterator end() const { return {view_, {-1}, false}; }
 
    private:
-    friend class BufferView;
+    friend struct BufferView;
 
     LogicalIndexView(const BufferView* view, bool include_vector_dims)
         : view_(view), include_vector_dims_(include_vector_dims) {}


### PR DESCRIPTION
[XLA:CPU]fix tensor_or_memref.h compile error

📝 Summary of Changes
change class to struct

🎯 Justification
fix compile error on x86_64/gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04.2)
error message:
```
In file included from xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.cc:16:
./xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.h:166:12: error: class 'BufferView' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
166 | friend class BufferView;
| ^
./xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.h:67:8: note: previous use is here
67 | struct BufferView {
| ^
1 error generated.
```

🚀 Kind of Contribution
🐛 Bug Fix,

📊 Benchmark (for Performance Improvements)

🧪 Unit Tests:

🧪 Execution Tests:

