### PR TITLE
[NVIDIA GPU]Use default main stream when no stream borrower is created for executable

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -137,7 +137,7 @@ class GpuExecutableThunkPassBufferAllocator : public ThunkPassBufferAllocator {
       BufferAllocation::Index start_idx)
       : next_idx_(start_idx) {}
 
-  absl::StatusOr<BufferAllocation* absl_nonnull> NewEmptyAllocation(
+  absl::StatusOr<BufferAllocation * absl_nonnull> NewEmptyAllocation(
       int64_t size) override {
     allocations_.push_back(BufferAllocation(next_idx_++, size, /*color=*/0));
     return &allocations_.back();


### PR DESCRIPTION
📝 Summary of Changes
This is a bug fix to address the xla assert when no stream borrower is created for an executable that contains
parallel computes. In such case, default compute stream will be used for all parallel compute nodes.

🎯 Justification
If no stream borrower is created, currently xla asserts with "No stream borrower" error.

🚀 Kind of Contribution
 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
NA
🧪 Unit Tests:
Added a unit test

🧪 Execution Tests:
Unit test executes impacted code path.
