### PR TITLE
Fix class vs struct ambiguity

### DIFF
--- a/xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.h
+++ b/xla/mlir/tools/mlir_interpreter/framework/tensor_or_memref.h
@@ -163,7 +163,7 @@ struct BufferView {
     Iterator end() const { return {view_, {-1}, false}; }
 
    private:
-    friend class BufferView;
+    friend struct BufferView;
 
     LogicalIndexView(const BufferView* view, bool include_vector_dims)
         : view_(view), include_vector_dims_(include_vector_dims) {}


### PR DESCRIPTION
📝 Summary of Changes
The `BufferView` class was defined as a `struct`, but in the `LogicalIndexView`, it was redefined as `class` which caused build failure on my machine. 

🎯 Justification
This change will fix the ambiguity and thereby prevent any build failures where warnings are treated as errors.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
N/A

🧪 Execution Tests:
N/A