### PR TITLE
Fix libdevice search

### DIFF
--- a/xla/stream_executor/cuda/assemble_compilation_provider_test.cc
+++ b/xla/stream_executor/cuda/assemble_compilation_provider_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/assemble_compilation_provider.h"
 
+#include <algoritm>
 #include <memory>
 #include <string>
 
@@ -25,6 +26,7 @@ limitations under the License.
 #include "xla/stream_executor/cuda/compilation_provider_options.h"
 #include "xla/stream_executor/cuda/nvjitlink_support.h"
 #include "xla/stream_executor/cuda/ptx_compiler_support.h"
+#include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/status_matchers.h"
 #include "xla/tsl/platform/statusor.h"
 #include "tsl/platform/cuda_root_path.h"
@@ -36,6 +38,18 @@ namespace {
 using ::testing::AllOf;
 using ::testing::HasSubstr;
 using ::tsl::testing::StatusIs;
+
+TEST(AssembleCompilationProviderTest,
+     CandidateCudaRootsConsidersCUDA_HOME) {
+  const std::string cuda_home = "/my/cuda/home";
+  tsl::setenv("CUDA_HOME", cuda_home.c_str(), 1);
+  auto roots = tsl::CandidateCudaRoots();
+  if (roots.empty()) {
+    GTEST_SKIP() << "Test only when any root is set";
+  }
+  EXPECT_THAT(std::find(roots.begin(), roots.end(), cuda_home),
+              Ne(roots.end()));
+}
 
 TEST(AssembleCompilationProviderTest,
      ReturnsErrorIfNoCompilationProviderIsAvailable) {

--- a/xla/stream_executor/cuda/assemble_compilation_provider_test.cc
+++ b/xla/stream_executor/cuda/assemble_compilation_provider_test.cc
@@ -43,12 +43,10 @@ TEST(AssembleCompilationProviderTest,
      CandidateCudaRootsConsidersCUDA_HOME) {
   const std::string cuda_home = "/my/cuda/home";
   tsl::setenv("CUDA_HOME", cuda_home.c_str(), 1);
-  auto roots = tsl::CandidateCudaRoots();
-  if (roots.empty()) {
-    GTEST_SKIP() << "Test only when any root is set";
+  if (!tsl::kIsOpenSource) {
+    GTEST_SKIP() << "CUDA_HOME is only being considered in the OSS build of XLA.";
   }
-  EXPECT_THAT(std::find(roots.begin(), roots.end(), cuda_home),
-              Ne(roots.end()));
+  EXPECT_THAT(tsl::CandidateCudaRoots(), ::testing::Contains(cuda_home));
 }
 
 TEST(AssembleCompilationProviderTest,

--- a/xla/tsl/platform/default/cuda_root_path.cc
+++ b/xla/tsl/platform/default/cuda_root_path.cc
@@ -65,6 +65,9 @@ std::vector<std::string> CandidateCudaRoots() {
     }
   }
 
+  const char* cuda_home = getenv("CUDA_HOME");
+  if (cuda_home)
+    roots.emplace_back(cuda_home);
   roots.push_back(TF_CUDA_TOOLKIT_PATH);
   roots.emplace_back(std::string("/usr/local/cuda"));
   roots.emplace_back(std::string("/opt/cuda"));

--- a/xla/tsl/platform/default/cuda_root_path.cc
+++ b/xla/tsl/platform/default/cuda_root_path.cc
@@ -68,7 +68,9 @@ std::vector<std::string> CandidateCudaRoots() {
   const char* cuda_home = getenv("CUDA_HOME");
   if (cuda_home)
     roots.emplace_back(cuda_home);
-  roots.push_back(TF_CUDA_TOOLKIT_PATH);
+  std::string cuda_toolkit_path = TF_CUDA_TOOLKIT_PATH;
+  if (!cuda_toolkit_path.empty())
+    roots.push_back(std::move(cuda_toolkit_path));
   roots.emplace_back(std::string("/usr/local/cuda"));
   roots.emplace_back(std::string("/opt/cuda"));
 

--- a/xla/tsl/platform/default/cuda_root_path.cc
+++ b/xla/tsl/platform/default/cuda_root_path.cc
@@ -56,11 +56,13 @@ std::vector<std::string> CandidateCudaRoots() {
   // The CUDA candidate root for python targets.
   std::string runfiles_dir = tsl::Env::Default()->GetRunfilesDir();
   std::size_t runfiles_ind = runfiles_dir.rfind(runfiles_suffix);
-  for (const std::string& cuda_dir_name : cuda_dir_names) {
-    std::string cuda_dir = io::JoinPath(
-        runfiles_dir.substr(0, runfiles_ind + runfiles_suffix.length()),
-        cuda_dir_name);
-    roots.push_back(cuda_dir);
+  if (runfiles_ind != std::string::npos) {
+    for (const std::string& cuda_dir_name : cuda_dir_names) {
+      std::string cuda_dir = io::JoinPath(
+          runfiles_dir.substr(0, runfiles_ind + runfiles_suffix.length()),
+          cuda_dir_name);
+      roots.push_back(cuda_dir);
+    }
   }
 
   roots.push_back(TF_CUDA_TOOLKIT_PATH);

--- a/xla/tsl/platform/default/cuda_root_path.cc
+++ b/xla/tsl/platform/default/cuda_root_path.cc
@@ -66,11 +66,13 @@ std::vector<std::string> CandidateCudaRoots() {
   }
 
   const char* cuda_home = getenv("CUDA_HOME");
-  if (cuda_home)
+  if (cuda_home) {
     roots.emplace_back(cuda_home);
+  }
   std::string cuda_toolkit_path = TF_CUDA_TOOLKIT_PATH;
-  if (!cuda_toolkit_path.empty())
+  if (!cuda_toolkit_path.empty()) {
     roots.push_back(std::move(cuda_toolkit_path));
+  }
   roots.emplace_back(std::string("/usr/local/cuda"));
   roots.emplace_back(std::string("/opt/cuda"));
 
@@ -108,12 +110,15 @@ std::vector<std::string> CandidateCudaRoots() {
     // $CONDA_PREFIX/lib/python3.12/site-packages/pkg_name, so if we want
     // to add $CONDA_PREFIX to the candidate roots dirs we need to add
     // ../../../..
-    for (auto path : {"../../../..", "../../../../.."})
+    for (auto path : {"../../../..", "../../../../.."}) {
       roots.emplace_back(io::JoinPath(dir, path));
+    }
   }
 #endif  // defined(PLATFORM_POSIX) && !defined(__APPLE__)
 
-  for (auto root : roots) VLOG(3) << "CUDA root = " << root;
+  for (auto root : roots) {
+    VLOG(3) << "CUDA root = " << root;
+  }
   return roots;
 #else   // !defined(PLATFORM_GOOGLE)
   return {};


### PR DESCRIPTION
📝 Summary of Changes
This enhances the search for the CUDA libdevice path:
- Fix an invalid empty path added when `TF_CUDA_TOOLKIT_PATH` which may be empty
- Fix invalid paths based on runtime folders: `runfiles_dir.substr(0, runfiles_ind + runfiles_suffix.length())` is not meaningful when `runfiles_ind` isn't valid, i.e. `std::string::npos`
- Add `$CUDA_HOME` to the search paths. This is also used in TensorFlow already

🎯 Justification
Without this the libdevice file won't be found if CUDA isn't installed in a standard location or e.g. an updated version is available in a different location.   
This is the case for e.g. HPC systems where multiple CUDA versions are available side-by-side.

🚀 Kind of Contribution
🐛 Bug Fix, ♻️ Cleanup

Fixes #28590

🧪 Unit Tests:

Simple test that when `CandidateCudaRoots` returns anything it contains `$CUDA_HOME`
