### PR TITLE
fix: improve parsing in TextLiteralReader

### DIFF
--- a/xla/text_literal_reader.cc
+++ b/xla/text_literal_reader.cc
@@ -87,7 +87,18 @@ absl::StatusOr<Literal> TextLiteralReader::ReadAllLines() {
   std::vector<int64_t> coordinate_values;
   std::string line;
   while (buf.ReadLine(&line).ok()) {
-    pieces = absl::StrSplit(line, ':');
+    // Ignore empty or whitespace-only lines.
+    absl::string_view trimmed_line = absl::StripAsciiWhitespace(line);
+    if (trimmed_line.empty()) {
+      continue;
+    }
+
+    pieces = absl::StrSplit(trimmed_line, ':');
+    if (pieces.size() != 2) {
+      return InvalidArgument(
+          "expected ':' separating coordinates and value: \"%s\"",
+          line);
+    }
     absl::string_view coordinates_string =
         absl::StripAsciiWhitespace(pieces[0]);
     absl::string_view value_string = absl::StripAsciiWhitespace(pieces[1]);

--- a/xla/text_literal_reader_test.cc
+++ b/xla/text_literal_reader_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <string>
 
+#include "absl/status/status.h"
 #include <gtest/gtest.h>
 #include "xla/hlo/testlib/test.h"
 #include "xla/literal.h"
@@ -50,6 +51,34 @@ TEST(TextLiteralReaderTest, ReadsR3File) {
   EXPECT_EQ(45.5, literal.Get<float>({0, 1, 0}));
   EXPECT_EQ(46.5, literal.Get<float>({0, 1, 1}));
   EXPECT_EQ(47.5, literal.Get<float>({0, 1, 2}));
+}
+
+TEST(TextLiteralReaderTest, WhitespaceOnlyLineAfterShapeDoesNotCrashAndYieldsScalarNaN) {
+  // Equivalent to the fuzzed input: "f32[]\n "
+  std::string contents = "f32[]\n ";
+
+  std::string fname = tsl::testing::TmpDir() + "/WhitespaceOnlyAfterShape.data.txt";
+  EXPECT_TRUE(tsl::WriteStringToFile(tsl::Env::Default(), fname, contents).ok());
+
+  absl::StatusOr<Literal> literal_or = TextLiteralReader::ReadPath(fname);
+  ASSERT_TRUE(literal_or.ok()) << literal_or.status();
+  const Literal& literal = *literal_or;
+  EXPECT_TRUE(ShapeUtil::Equal(ShapeUtil::MakeShape(F32, {}), literal.shape()));
+  float value = literal.Get<float>({});
+  EXPECT_TRUE(std::isnan(value));
+}
+
+TEST(TextLiteralReaderTest, MissingColonReturnsInvalidArgument) {
+  std::string contents = R"(f32[1]
+ (0) 1.0
+)";
+
+  std::string fname = tsl::testing::TmpDir() + "/MissingColon.data.txt";
+  EXPECT_TRUE(tsl::WriteStringToFile(tsl::Env::Default(), fname, contents).ok());
+
+  absl::StatusOr<Literal> literal_or = TextLiteralReader::ReadPath(fname);
+  EXPECT_FALSE(literal_or.ok());
+  EXPECT_EQ(literal_or.status().code(), absl::StatusCode::kInvalidArgument);
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes

- Ignore empty or whitespace-only lines when parsing literal data in `TextLiteralReader`. Trim lines before splitting and enforce that each data line contains a colon separating coordinates and value. Return InvalidArgument when the separator is missing.
- Add tests for whitespace-only line and for missing colon.

🎯 Justification

- Fixes [OSS-Fuzz finding #427934198](https://issues.oss-fuzz.com/issues/427934198), found through a Tensorflow fuzzer.

🚀 Kind of Contribution

- 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
- N/A

🧪 Unit Tests:
- Add unit tests to cover malformed input (whitespace, or missing colon). The test yields a crash + stacktrace against the `main` branch.
- Tests run successfully with:

```
docker exec xla bazel test \
  --spawn_strategy=sandboxed \
  --test_output=all \
  //xla:text_literal_reader_test
```

Output:

```
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from TextLiteralReaderTest
[ RUN      ] TextLiteralReaderTest.WhitespaceOnlyLineAfterShapeDoesNotCrashAndYieldsScalarNaN
[       OK ] TextLiteralReaderTest.WhitespaceOnlyLineAfterShapeDoesNotCrashAndYieldsScalarNaN (19 ms)
[ RUN      ] TextLiteralReaderTest.MissingColonReturnsInvalidArgument
[       OK ] TextLiteralReaderTest.MissingColonReturnsInvalidArgument (10 ms)
[ RUN      ] TextLiteralReaderTest.ReadsR3File
[       OK ] TextLiteralReaderTest.ReadsR3File (1 ms)
[----------] 3 tests from TextLiteralReaderTest (32 ms total)
```


🧪 Execution Tests:
- N/A
