### PR TITLE
[XLA:GPU] Escape MLIR in triton parsing error

### DIFF
--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -35,6 +35,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
@@ -1531,7 +1532,7 @@ absl::Status IrEmitterUnnested::EmitTritonCustomCall(
         return absl::InvalidArgumentError(
             absl::StrCat("Failed to parse Triton module: ",
                          diagnostic_handler.ConsumeStatus().message(),
-                         "\ninput ir: ", call.ir));
+                         "\ninput ir: \"", absl::CHexEscape(call.ir), "\""));
       }
     }
 

--- a/xla/service/gpu/tests/gpu_triton_custom_call_test.cc
+++ b/xla/service/gpu/tests/gpu_triton_custom_call_test.cc
@@ -164,6 +164,43 @@ TEST_F(GpuIrEmitterUnnestedTest,
                      /*match_optimized_ir=*/false);
 }
 
+TEST_F(GpuIrEmitterUnnestedTest, EmitTritonCustomCallParseErrorHasEscapedIr) {
+  if (!GetCudaComputeCapability().IsAtLeastAmpere()) {
+    GTEST_SKIP() << "Triton support is only enabled for Ampere GPUs and up.";
+  }
+
+  // Tests that MLIR IR with invalid unicode characters is escaped correctly
+  // on error.
+  constexpr absl::string_view kMlirIrInvalidUnicode = "ML\xef";
+
+  HloComputation::Builder computation_builder(TestName());
+
+  // Create parameters and custom call in the computation builder.
+  Shape scalar_shape = xla::ShapeUtil::MakeShape(xla::F32, {});
+  Shape tuple_shape = ShapeUtil::MakeTupleShape({scalar_shape, scalar_shape});
+
+  HloInstruction* param_0 = computation_builder.AddInstruction(
+      HloInstruction::CreateParameter(0, scalar_shape, "arg_0"));
+
+  HloInstruction* param_1 = computation_builder.AddInstruction(
+      HloInstruction::CreateParameter(1, scalar_shape, "arg_1"));
+
+  computation_builder.AddInstruction(CreateTritonCustomCall(
+      tuple_shape, param_0, param_1, kMlirIrInvalidUnicode, kCallName));
+
+  auto module = CreateNewVerifiedModule();
+  module->AddEntryComputation(computation_builder.Build());
+
+  auto result =
+      CompileToExecutable(std::move(module), /*run_optimization_passes=*/true);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("Failed to parse Triton module"));
+
+  // Verify that the error message contains the escaped IR.
+  EXPECT_THAT(result.status().message(), HasSubstr("input ir: \"ML\\xef\""));
+}
+
 TEST_F(GpuIrEmitterUnnestedTest,
        EmitTritonCustomCallWithCorrectKernelParamAttributes) {
   if (!GetCudaComputeCapability().IsAtLeastAmpere()) {


### PR DESCRIPTION
📝 Summary of Changes
This patch escapes the dumped IR in the error message when triton
parser fails. This ensures that the error message is always valid UTF-8.

🎯 Justification
JAX interprets error message as UTF8. If an error message is
an invalid UTF8, JAX presents the exception as a failed UTF8
decoding exception, rather than showing the actual error message.
With this patch, the users gets the correct error message.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
The unit test checks that the error message contains
the escaped IR.

🧪 Execution Tests:
N/A