### PR TITLE
[ROCm] Skip GpuCompilerSelectKTest.SelectKOrCustomKernelThunk

### DIFF
--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -2179,6 +2179,15 @@ class GpuCompilerSelectKTest
 TEST_P(GpuCompilerSelectKTest, SelectKOrCustomKernelThunk) {
   auto [n, k, expected_impl] = GetParam();
 
+  bool is_rocm = std::holds_alternative<stream_executor::RocmComputeCapability>(
+      backend()
+          .default_stream_executor()
+          ->GetDeviceDescription()
+          .gpu_compute_capability());
+
+  if (is_rocm && expected_impl == TopKImpl::kSelectK) {
+    GTEST_SKIP() << "raft::select_k is not supported in ROCm.";
+  }
   // Generate HLO text with parameters substituted.
   std::string hlo_text = absl::Substitute(R"(
 HloModule m


### PR DESCRIPTION
📝 Summary of Changes
Partially skip GpuCompilerSelectKTest.SelectKOrCustomKernelThunk.

🎯 Justification
Makes the CI green.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
N\A

🧪 Execution Tests:
N\A
