### PR TITLE
[ROCm] fixed the build error on rocm

### DIFF
--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -70,10 +70,10 @@ cc_library(
         "@tsl//tsl/platform:statusor",
     ] + if_cuda_or_rocm([
         "//xla/service:gpu_plugin",
-        "//xla/backends/profiler/gpu:cupti_tracer",
         "//xla/backends/profiler/gpu:device_tracer",
     ]) + if_cuda([
         "//xla/stream_executor:cuda_platform",
+        "//xla/backends/profiler/gpu:cupti_tracer",
     ] + if_google(
         [
             "//third_party/py/jax/jaxlib/cuda:cuda_gpu_kernels",  # fixdeps: keep


### PR DESCRIPTION
🐛 Bug Fix
Fixed the build error on ROCm, as cupti_tracer is not available on ROCm platform.
It is a separate PR according to the comment in https://github.com/openxla/xla/pull/32002#discussion_r2387941595.

@xla-rotation could you review my PR, please?
