### PR TITLE
Proposed PjRt API Changes for Improved Cross-Process Transfers on GPUs

### DIFF
--- a/xla/pjrt/common_pjrt_client.cc
+++ b/xla/pjrt/common_pjrt_client.cc
@@ -310,7 +310,8 @@ absl::StatusOr<xla::Shape> CommonPjRtClient::MakeDefaultShapeForMemorySpace(
 }
 
 void CommonPjRtBufferImpl::CopyToRemoteDevice(
-    Future<std::string> serialized_descriptor, RemoteSendCallback on_done) {
+    PjRtGlobalDeviceId dst_global_device_id, CrossHostTransferId transfer_id,
+    PjRtBuffer::RemoteSendCallback on_done) {
   auto* common_client = tensorflow::down_cast<CommonPjRtClient*>(client());
   std::vector<tsl::RCReference<tsl::AsyncValue>> definition_events;
   tsl::RCReference<PjRtDeviceEventPromise> usage_event_promise;
@@ -351,8 +352,8 @@ void CommonPjRtBufferImpl::CopyToRemoteDevice(
 
   common_client->ScheduleRemoteSend(
       memory_space(), std::move(raw_buffer), std::move(definition_events),
-      std::move(usage_event_promise), std::move(serialized_descriptor),
-      std::move(on_done));
+      std::move(usage_event_promise), std::move(dst_global_device_id),
+      transfer_id, std::move(on_done));
 }
 
 void CommonPjRtClient::ScheduleRemoteSend(
@@ -360,7 +361,7 @@ void CommonPjRtClient::ScheduleRemoteSend(
     tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
     std::vector<tsl::RCReference<tsl::AsyncValue>> definition_events,
     tsl::RCReference<PjRtDeviceEventPromise> usage_event_promise,
-    Future<std::string> serialized_descriptor,
+    PjRtGlobalDeviceId dst_global_device_id, CrossHostTransferId transfer_id,
     PjRtBuffer::RemoteSendCallback on_done) {
   auto error = absl::UnimplementedError(
       absl::StrCat("ScheduleRemoteSend is not implemented for %s",

--- a/xla/pjrt/common_pjrt_client.h
+++ b/xla/pjrt/common_pjrt_client.h
@@ -237,7 +237,7 @@ class CommonPjRtClient : public PjRtClient {
       tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
       std::vector<tsl::RCReference<tsl::AsyncValue>> definition_events,
       tsl::RCReference<PjRtDeviceEventPromise> usage_event_promise,
-      Future<std::string> serialized_descriptor,
+      PjRtGlobalDeviceId dst_global_device_id, CrossHostTransferId transfer_id,
       PjRtBuffer::RemoteSendCallback on_done);
 };
 
@@ -278,8 +278,9 @@ class CommonPjRtBufferImpl : public CommonPjRtBuffer {
   // device to host transfer to read the metadata of dynamic shape.
   absl::StatusOr<Shape> logical_on_device_shape() override;
 
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
-                          RemoteSendCallback on_done) override;
+  void CopyToRemoteDevice(PjRtGlobalDeviceId dst_global_device_id,
+                          CrossHostTransferId transfer_id,
+                          PjRtBuffer::RemoteSendCallback on_done) override;
 
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;

--- a/xla/pjrt/cpu/cpu_client.h
+++ b/xla/pjrt/cpu/cpu_client.h
@@ -155,6 +155,8 @@ class PjRtCpuClient final : public CommonPjRtClient {
   absl::StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
   MakeCrossHostReceiveBuffers(absl::Span<const Shape> shapes,
                               PjRtDevice* device,
+                              PjRtGlobalDeviceId src_global_device_id,
+                              absl::Span<CrossHostTransferId> transfer_ids,
                               PjRtCrossHostRecvNotifier notifier) override {
     return Unimplemented("MakeCrossHostReceiveBuffers not implemented.");
   }

--- a/xla/pjrt/extensions/cross_host_transfers/pjrt_c_api_cross_host_transfers_extension.h
+++ b/xla/pjrt/extensions/cross_host_transfers/pjrt_c_api_cross_host_transfers_extension.h
@@ -35,8 +35,7 @@ extern "C" {
 // ---------------------------------- Methods ----------------------------------
 
 typedef void (*PJRT_Transfers_CrossHostRecvNotifier)(
-    PJRT_Error* error, const char** serialized_descriptors,
-    size_t* descriptors_sizes, size_t num_descriptors, void* user_arg);
+    PJRT_Error* error, xla::CrossHostTransferId transfer_id, void* user_arg);
 
 struct PJRT_Transfers_CrossHostRecvNotifierInfo {
   void* user_arg;
@@ -51,6 +50,8 @@ struct PJRT_Transfers_PJRT_Client_MakeCrossHostReceiveBuffers_Args {
   size_t num_shapes;
   size_t* shape_num_dims;
   const int64_t** num_dims;
+  int32_t src_global_device_id;
+  xla::CrossHostTransferId* transfer_ids;
   PJRT_Buffer_Type* element_types;
   PJRT_Buffer_MemoryLayout** layouts;
   PJRT_Device* device;
@@ -68,11 +69,11 @@ struct PJRT_Transfers_PJRT_Buffer_CopyToRemoteDevice_Args {
   size_t struct_size;
   PJRT_Extension_Base* extension_start;
   PJRT_Buffer* buffer;
-  const char* serialized_descriptor;
-  size_t serialized_descriptor_size;
+  xla::PjRtGlobalDeviceId dst_global_device_id;
+  xla::CrossHostTransferId transfer_id;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Transfers_PJRT_Buffer_CopyToRemoteDevice_Args,
-                          serialized_descriptor_size);
+                          transfer_id);
 
 typedef void PJRT_Buffer_CopyToRemoteDevice(
     PJRT_Transfers_PJRT_Buffer_CopyToRemoteDevice_Args* args);

--- a/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer.h
+++ b/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer.h
@@ -85,7 +85,8 @@ class TfrtGpuBuffer final : public PjRtBuffer {
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
 
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
+  void CopyToRemoteDevice(PjRtGlobalDeviceId dst_global_device_id,
+                          CrossHostTransferId transfer_id,
                           RemoteSendCallback on_done) override {
     on_done(Unimplemented("CopyToRemoteDevice not implemented."),
             /*sends_were_enqueued=*/false);

--- a/xla/pjrt/pjrt_c_api_client.h
+++ b/xla/pjrt/pjrt_c_api_client.h
@@ -373,6 +373,8 @@ class PjRtCApiClient : public PjRtClient {
   absl::StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
   MakeCrossHostReceiveBuffers(absl::Span<const Shape> shapes,
                               PjRtDevice* device,
+                              PjRtGlobalDeviceId src_global_device_id,
+                              absl::Span<int64_t> transfer_run_ids,
                               PjRtCrossHostRecvNotifier notifier) override;
 
   absl::Status DmaMap(void* data, size_t size) override;
@@ -401,7 +403,7 @@ class PjRtCApiClient : public PjRtClient {
   }
 
   using CrossHostRecvNotifierFunction =
-      std::function<void(PJRT_Error*, const char**, size_t*, size_t)>;
+      std::function<void(PJRT_Error*, int64_t)>;
 
   template <typename ExtType>
   ExtType* FindExtension(PJRT_Extension_Type type) const {
@@ -497,8 +499,9 @@ class PjRtCApiBuffer : public PjRtBuffer {
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
 
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
-                          RemoteSendCallback on_done) override;
+  void CopyToRemoteDevice(PjRtGlobalDeviceId dst_global_device_id,
+                          CrossHostTransferId transfer_id,
+                          PjRtBuffer::RemoteSendCallback on_done) override;
 
   Future<> GetReadyFuture() override;
 

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -1943,14 +1943,11 @@ PjRtStreamExecutorBuffer::CopyToMemorySpace(PjRtMemorySpace* dst_memory_space) {
 }
 
 void PjRtStreamExecutorBuffer::CopyToRemoteDevice(
-    Future<std::string> serialized_descriptor, RemoteSendCallback on_done) {
+    PjRtGlobalDeviceId dst_global_device_id, CrossHostTransferId transfer_id,
+    RemoteSendCallback on_done) {
   VLOG(3) << "PjRtStreamExecutorBuffer::CopyToRemoteDevice";
-  auto desc = serialized_descriptor.Await();
-  if (desc.ok()) {
-    client_->CopyToRemoteDevice(this, *desc, std::move(on_done));
-  } else {
-    on_done(desc.status(), /*sends_enqueued=*/false);
-  }
+  client_->CopyToRemoteDevice(this, dst_global_device_id, transfer_id,
+                              std::move(on_done));
 }
 
 Future<> PjRtStreamExecutorBuffer::GetReadyFuture() {

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -420,7 +420,8 @@ class PjRtStreamExecutorClient : public CommonPjRtClient {
   friend class PjRtStreamExecutorRawBuffer;
 
   virtual void CopyToRemoteDevice(PjRtBuffer* buffer,
-                                  absl::string_view serialized_descriptor,
+                                  PjRtGlobalDeviceId dst_global_device_id,
+                                  CrossHostTransferId transfer_id,
                                   PjRtBuffer::RemoteSendCallback on_done) {
     on_done(Unimplemented("Cross host sends not implemented."),
             /*sends_were_enqueued=*/false);
@@ -651,7 +652,8 @@ class PjRtStreamExecutorBuffer : public CommonPjRtBuffer {
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
 
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
+  void CopyToRemoteDevice(PjRtGlobalDeviceId dst_global_device_id,
+                          CrossHostTransferId transfer_id,
                           RemoteSendCallback on_done) override;
 
   Future<> GetReadyFuture() override;

--- a/xla/python/pjrt_ifrt/pjrt_client.h
+++ b/xla/python/pjrt_ifrt/pjrt_client.h
@@ -360,16 +360,16 @@ class PjRtClient final
       absl::Span<ArrayRef> arrays, DeviceListRef src_devices,
       DeviceListRef dst_devices, std::optional<MemoryKind> memory_kind);
 
-  // Extracts receive descriptors from a key-value store and sends buffers to a
-  // remote device.
-  absl::Status CrossHostSendBuffers(PjRtBuffers buffers,
-                                    const std::vector<int64_t>& keys);
+  // Sends buffers to a remote device.
+  absl::Status CrossHostSendBuffers(
+      PjRtBuffers buffers, PjRtGlobalDeviceId dst_global_device_id,
+      std::vector<CrossHostTransferId> transfer_ids);
 
-  // Populates a key-value store with receive descriptors and places buffers
-  // from a cross-host send onto device.
+  // Places buffers from a cross-host send onto device.
   absl::StatusOr<PjRtBuffers> CrossHostReceiveBuffers(
       absl::Span<const xla::Shape> shapes, xla::PjRtDevice* device,
-      std::vector<int64_t> keys);
+      PjRtGlobalDeviceId src_global_device_id,
+      std::vector<CrossHostTransferId> transfer_ids);
 
   // Copies arrays from source to destination devices when at least one of the
   // (source, destination) pairs is cross-host using an experimental DCN
@@ -382,14 +382,14 @@ class PjRtClient final
   // Creates a unique identifier for each cross-host transfer. Every process
   // must call it, regardless of whether it participates in the cross-host
   // transfer, so that the returned value must be the same in all processes.
-  int64_t CreateNewTransferKey();
+  int64_t CreateNewTransferId();
 
   // If true, the backend implements the cross-host transfer APIs.
   bool pjrt_supports_cross_host_transfers_ = false;
 
   absl::Status WatchGlobalProcessInfo(tsl::CoordinationServiceAgent& agent);
 
-  std::atomic<int64_t> next_transfer_key_ = 0;
+  std::atomic<int64_t> next_transfer_id_ = 0;
   std::shared_ptr<xla::DistributedRuntimeClient> distributed_client_;
   std::shared_ptr<xla::KeyValueStoreInterface> kv_store_;
   absl::Duration cross_host_transfer_timeout_;


### PR DESCRIPTION
📝 Summary of Changes
This PR is a sketch outlining potential modifications to the PjRt API to better support cross-process transfers on GPUs, intended for discussion with @emilyfertig and @mwhittaker.

🎯 Justification
The current implementation of cross-process device-puts on GPUs does not cache communicators for reuse across multiple transfers between the same sets of devices, and does not aggregate transfers of multiple arrays together with ncclGroup calls. This PR changes the PjRt API so that the MakeCrossHostReceiveBuffers and CopyToRemoteDevice functions now receive information about the global device IDs involved in the data transfer so that communicators can be cached.

🚀 Kind of Contribution
Performance Improvement

📊 Benchmark (for Performance Improvements)
This PR only makes API changes necessary for future performance improvements such as communicator caching, so no benchmarks were ran for this PR. Follow-up PRs implementing performance improvements will include benchmarks.

🧪 Execution Tests:
Verified that [these 4 correctness checks](https://gist.github.com/rao-ashish/24ac0df0cb18243c649ac535964b31b8) for cross-process device-puts pass.
