### PR TITLE
[ROCm] make toolchain hermetic compatible with rbe for rocm CI

### DIFF
--- a/third_party/gpus/crosstool/BUILD.rocm.tpl
+++ b/third_party/gpus/crosstool/BUILD.rocm.tpl
@@ -35,7 +35,7 @@ cc_toolchain_suite(
 
 cc_toolchain(
     name = "cc-compiler-local",
-    all_files = ":crosstool_wrapper_driver_is_not_gcc",
+    all_files = "@local_config_rocm//rocm:all_files",
     compiler_files = ":crosstool_wrapper_driver_is_not_gcc",
     ar_files = ":crosstool_wrapper_driver_is_not_gcc",
     as_files = ":crosstool_wrapper_driver_is_not_gcc",
@@ -112,6 +112,8 @@ filegroup(
 
 filegroup(
   name = "crosstool_wrapper_driver_is_not_gcc",
-  srcs = [":clang/bin/crosstool_wrapper_driver_is_not_gcc"],
-  data = ["@local_config_rocm//rocm:all_files"],
+  srcs = [
+      ":clang/bin/crosstool_wrapper_driver_is_not_gcc", 
+      "@local_config_rocm//rocm:toolchain_data",
+  ],
 )

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -29,9 +29,9 @@ HOST_COMPILER_PATH = ('%{host_compiler_path}')
 HIPCC_PATH = '%{rocm_root}/bin/hipcc'
 PREFIX_DIR = os.path.dirname(HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
-HIP_RUNTIME_PATH = '%{hip_runtime_path}'
-HIP_RUNTIME_LIBRARY = '%{hip_runtime_library}'
-ROCR_RUNTIME_PATH = '%{rocr_runtime_path}'
+HIP_RUNTIME_PATH = '%{rocm_root}/lib'
+HIP_RUNTIME_LIBRARY = '%{rocm_root}/lib'
+ROCR_RUNTIME_PATH = '%{rocm_root}/lib'
 ROCR_RUNTIME_LIBRARY = '%{rocr_runtime_library}'
 VERBOSE = '%{crosstool_verbose}'=='1'
 
@@ -206,7 +206,7 @@ def InvokeHipcc(argv, log=False):
   hipccopts += defines
   hipccopts += std_options
   hipccopts += m_options
-  hipccopts += ' --rocm-path="%{rocm_path}" '
+  hipccopts += ' --rocm-path="%{rocm_root}" '
 
   if depfiles:
     # Generate the dependency file

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -27,7 +27,6 @@ CPU_COMPILER = ('%{cpu_compiler}')
 HOST_COMPILER_PATH = ('%{host_compiler_path}')
 
 HIPCC_PATH = '%{rocm_root}/bin/hipcc'
-PREFIX_DIR = os.path.dirname(HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
 HIP_RUNTIME_PATH = '%{rocm_root}/lib'
 HIP_RUNTIME_LIBRARY = '%{rocm_root}/lib'

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -26,7 +26,7 @@ import shlex
 CPU_COMPILER = ('%{cpu_compiler}')
 HOST_COMPILER_PATH = ('%{host_compiler_path}')
 
-HIPCC_PATH = '%{hipcc_path}'
+HIPCC_PATH = '%{rocm_root}/bin/hipcc'
 PREFIX_DIR = os.path.dirname(HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
 HIP_RUNTIME_PATH = '%{hip_runtime_path}'

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -170,6 +170,7 @@ cc_library(
         "%{rocm_root}/include",
     ],
     strip_include_prefix = "%{rocm_root}",
+    visibility = ["//visibility:public"],
     deps = [
         ":amd_comgr",
         ":hsa_rocr",
@@ -258,6 +259,7 @@ cc_library(
 
 cc_library(
     name = "miopen",
+    srcs = glob(["%{rocm_root}/lib/libMIOpen*.so*"]),
     hdrs = glob(["%{rocm_root}/include/miopen/**"]),
     data = glob([
         "%{rocm_root}/lib/libMIOpen*.so*",
@@ -512,6 +514,15 @@ filegroup(
     srcs = [
         "%{rocm_root}/bin/clang-offload-bundler",
     ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "toolchain_data",
+    srcs = glob([
+        "%{rocm_root}/bin/hipcc",
+        "%{rocm_root}/lib/llvm/bin/clang*",
+    ]),
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -521,7 +521,9 @@ filegroup(
     name = "toolchain_data",
     srcs = glob([
         "%{rocm_root}/bin/hipcc",
-        "%{rocm_root}/lib/llvm/bin/clang*",
+        "%{rocm_root}/lib/llvm/**",
+        "%{rocm_root}/share/hip/**",
+        "%{rocm_root}/amdgcn/**",
     ]),
     visibility = ["//visibility:public"],
 )

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -83,7 +83,7 @@ def verify_build_defines(params):
             ".",
         )
 
-def find_cc(repository_ctx, use_rocm_clang):
+def find_cc(repository_ctx):
     """Find the C++ compiler."""
 
     target_cc_name = "clang"
@@ -633,7 +633,11 @@ def _create_local_rocm_repository(repository_ctx):
     )
 
     # Set up crosstool/
-    cc = find_cc(repository_ctx, is_rocm_clang)
+    if is_rocm_clang:
+        cc = rocm_config.rocm_toolkit_path + '/lib/llvm/bin/clang++'
+    else:
+        cc = find_cc(repository_ctx)
+
     host_compiler_includes = get_cxx_inc_directories(
         repository_ctx,
         cc,
@@ -645,7 +649,7 @@ def _create_local_rocm_repository(repository_ctx):
     rocm_defines = {}
     rocm_defines["%{builtin_sysroot}"] = tf_sysroot
     rocm_defines["%{compiler}"] = "clang"
-    host_compiler_prefix = "/usr/bin"
+    host_compiler_prefix = get_host_environ(repository_ctx, _GCC_HOST_COMPILER_PREFIX, "/usr/bin")
     rocm_defines["%{host_compiler_prefix}"] = host_compiler_prefix
     rocm_defines["%{linker_bin_path}"] = rocm_config.rocm_toolkit_path + host_compiler_prefix
     rocm_defines["%{extra_no_canonical_prefixes_flags}"] = ""
@@ -689,7 +693,7 @@ def _create_local_rocm_repository(repository_ctx):
         {
             "%{cpu_compiler}": str(cc),
             "%{compiler_is_clang}": "True" if is_rocm_clang else "False",
-            "%{hipcc_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path + "/bin/hipcc")),
+            "%{rocm_root}": rocm_config.rocm_toolkit_path,
             "%{hipcc_env}": _hipcc_env(repository_ctx),
             "%{rocm_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path)),
             "%{rocr_runtime_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path + "/lib")),

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -87,10 +87,9 @@ def find_cc(repository_ctx):
     """Find the C++ compiler."""
 
     target_cc_name = "clang"
-    cc_path_envvar = _CLANG_COMPILER_PATH
     cc_name = target_cc_name
 
-    cc_name_from_env = get_host_environ(repository_ctx, cc_path_envvar)
+    cc_name_from_env = get_host_environ(repository_ctx, _CLANG_COMPILER_PATH)
     if cc_name_from_env:
         cc_name = cc_name_from_env
     if cc_name.startswith("/"):
@@ -99,7 +98,7 @@ def find_cc(repository_ctx):
     cc = which(repository_ctx, cc_name)
     if cc == None:
         fail(("Cannot find {}, either correct your path or set the {}" +
-              " environment variable").format(target_cc_name, cc_path_envvar))
+              " environment variable").format(target_cc_name, _CLANG_COMPILER_PATH))
     return cc
 
 def auto_configure_fail(msg):
@@ -633,10 +632,7 @@ def _create_local_rocm_repository(repository_ctx):
     )
 
     # Set up crosstool/
-    if is_rocm_clang:
-        cc = rocm_config.rocm_toolkit_path + '/lib/llvm/bin/clang++'
-    else:
-        cc = find_cc(repository_ctx)
+    cc = find_cc(repository_ctx)
 
     host_compiler_includes = get_cxx_inc_directories(
         repository_ctx,
@@ -692,13 +688,10 @@ def _create_local_rocm_repository(repository_ctx):
         tpl_paths["crosstool:clang/bin/crosstool_wrapper_driver_rocm"],
         {
             "%{cpu_compiler}": str(cc),
-            "%{compiler_is_clang}": "True" if is_rocm_clang else "False",
-            "%{rocm_root}": rocm_config.rocm_toolkit_path,
+            "%{compiler_is_clang}": "True",
+            "%{rocm_root}": "external/local_config_rocm/" + str(rocm_config.rocm_toolkit_path),
             "%{hipcc_env}": _hipcc_env(repository_ctx),
-            "%{rocm_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path)),
-            "%{rocr_runtime_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path + "/lib")),
             "%{rocr_runtime_library}": "hsa-runtime64",
-            "%{hip_runtime_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path + "/lib")),
             "%{hip_runtime_library}": "amdhip64",
             "%{crosstool_verbose}": _crosstool_verbose(repository_ctx),
             "%{gcc_host_compiler_path}": str(cc),

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -645,7 +645,7 @@ def _create_local_rocm_repository(repository_ctx):
     rocm_defines = {}
     rocm_defines["%{builtin_sysroot}"] = tf_sysroot
     rocm_defines["%{compiler}"] = "clang"
-    host_compiler_prefix = get_host_environ(repository_ctx, _GCC_HOST_COMPILER_PREFIX, "/usr/bin")
+    host_compiler_prefix = "/usr/bin"
     rocm_defines["%{host_compiler_prefix}"] = host_compiler_prefix
     rocm_defines["%{linker_bin_path}"] = rocm_config.rocm_toolkit_path + host_compiler_prefix
     rocm_defines["%{extra_no_canonical_prefixes_flags}"] = ""


### PR DESCRIPTION
📝 Summary of Changes
Ensures hipcc toolchain is hermetic, preparation for rbe workflows

🎯 Justification
Required to be able to support distributed builds

🚀 Kind of Contribution
✨ New Feature

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
