### PR TITLE
Don't hardcode the configs size in GetSupportedConfigsFromCublasCustomCall, e.g., on Spark it is 9.

### DIFF
--- a/xla/backends/gpu/autotuner/fission_test.cc
+++ b/xla/backends/gpu/autotuner/fission_test.cc
@@ -97,7 +97,7 @@ TEST_F(FissionBackendTest, GetSupportedConfigsFromCublasCustomCall) {
   absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>> configs =
       backend_.GetSupportedConfigs(
           (*module->entry_computation()->root_instruction()));
-  EXPECT_THAT(configs, absl_testing::IsOkAndHolds(SizeIs(10)));
+  EXPECT_THAT(configs, absl_testing::IsOkAndHolds(SizeIs(testing::Ge(2))));
   // The first config is the cublas config.
   AutotuneResult::GemmKey cublas_config;
   EXPECT_TRUE(configs.value().front()->UnpackTo(&cublas_config));


### PR DESCRIPTION
The only requirement in the test is that the size is at least 2.


📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
