### PR TITLE
[Refactor] Completely Remove AsyncStreamKind

### DIFF
--- a/xla/backends/gpu/codegen/custom.cc
+++ b/xla/backends/gpu/codegen/custom.cc
@@ -220,7 +220,8 @@ std::unique_ptr<HloModule> ExtractOffsetModule(
     const HloInstruction* offset_value, int64_t indvar_idx) {
   // Extract offset as a function of parameter to while body.
   std::unique_ptr<HloModule> extracted_offset = ExtractModule(
-      /*instruction=*/offset_value, /*height=*/-1,
+      /*instruction=*/
+      offset_value, /*height=*/-1,
       /*extract_selector=*/
       [](const HloInstruction* instr) -> bool {
         return instr->opcode() != HloOpcode::kParameter;
@@ -1333,8 +1334,7 @@ absl::StatusOr<FusionEmissionResult> EmitCollective(
           /*thunk_info=*/
           Thunk::ThunkInfo::WithProfileAnnotation(
               instr, ir_emitter_context.GetNextThunkId()),
-          /*async_events=*/async_events,
-          /*async_stream_kind=*/AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE);
+          /*async_events=*/async_events);
       seq.emplace_back(std::move(collective_done_thunk));
     }
   } else {

--- a/xla/backends/gpu/collectives/gpu_clique_key_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key_test.cc
@@ -201,24 +201,4 @@ TEST(GpuCliqueIdStringTest, ToString) {
   }
 }
 
-TEST(GpuCliqueKeyTest, GetCollectiveStreamId) {
-  EXPECT_EQ(GetCollectiveStreamId(false, CollectiveStreamId(0),
-                                  AsyncStreamKind::ASYNC_STREAM_KIND_P2P0),
-            CollectiveStreamId(0));
-  EXPECT_EQ(
-      GetCollectiveStreamId(true, CollectiveStreamId(0),
-                            AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
-      CollectiveStreamId(1));
-  EXPECT_EQ(GetCollectiveStreamId(true, CollectiveStreamId(0),
-                                  AsyncStreamKind::ASYNC_STREAM_KIND_P2P0),
-            CollectiveStreamId(2));
-  EXPECT_EQ(
-      GetCollectiveStreamId(true, CollectiveStreamId(2),
-                            AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
-      CollectiveStreamId(2));
-  EXPECT_EQ(GetCollectiveStreamId(true, CollectiveStreamId(1),
-                                  AsyncStreamKind::ASYNC_STREAM_KIND_P2P0),
-            CollectiveStreamId(1));
-}
-
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -41,10 +41,10 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -78,8 +78,7 @@ AllGatherStartThunk::AllGatherStartThunk(
     ThunkInfo thunk_info,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
     CollectiveConfig config, std::vector<Buffer> buffers)
-    : CollectiveThunk(Thunk::kAllGatherStart, thunk_info, async_events,
-                      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
+    : CollectiveThunk(Thunk::kAllGatherStart, thunk_info, async_events, false),
       config_(AllGatherConfig{config}),
       buffers_(std::move(buffers)) {}
 
@@ -88,8 +87,7 @@ AllGatherStartThunk::AllGatherStartThunk(ThunkInfo thunk_info,
                                          std::vector<Buffer> buffers,
                                          bool p2p_memcpy_enabled)
     : CollectiveThunk(Thunk::kAllGatherStart, thunk_info,
-                      IsGPUSyncCollective(*inst),
-                      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
+                      IsGPUSyncCollective(*inst), false),
       config_(GetAllGatherConfig(inst)),
       buffers_(std::move(buffers)) {
   CHECK_EQ(config_.config.operand_element_type.size(), buffers_.size());

--- a/xla/backends/gpu/runtime/all_reduce_thunk.cc
+++ b/xla/backends/gpu/runtime/all_reduce_thunk.cc
@@ -46,11 +46,11 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -148,8 +148,7 @@ absl::Status RunAllReduce(ReductionKind reduction_kind,
 AllReduceReduceScatterThunkBase::AllReduceReduceScatterThunkBase(
     Thunk::Kind kind, ThunkInfo thunk_info, AllReduceConfig config,
     std::vector<Buffer> buffers, bool is_sync)
-    : CollectiveThunk(kind, thunk_info, is_sync,
-                      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
+    : CollectiveThunk(kind, thunk_info, is_sync, false),
       config_(std::move(config)),
       buffers_(std::move(buffers)) {
   CHECK_EQ(config_.config.operand_element_type.size(), buffers_.size());
@@ -159,8 +158,7 @@ AllReduceReduceScatterThunkBase::AllReduceReduceScatterThunkBase(
     Thunk::Kind kind, ThunkInfo thunk_info, AllReduceConfig config,
     std::vector<Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CollectiveThunk(kind, thunk_info, async_events,
-                      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
+    : CollectiveThunk(kind, thunk_info, async_events, false),
       config_(std::move(config)),
       buffers_(std::move(buffers)) {
   CHECK_EQ(config_.config.operand_element_type.size(), buffers_.size());

--- a/xla/backends/gpu/runtime/all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/all_to_all_thunk.cc
@@ -54,10 +54,10 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -83,7 +83,7 @@ AllToAllStartThunk::AllToAllStartThunk(
     const AllToAllConfig& config, std::vector<CollectiveThunk::Buffer> buffers,
     bool p2p_memcpy_enabled)
     : CollectiveThunk(Thunk::kAllToAllStart, thunk_info, async_events,
-                      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
+                      p2p_memcpy_enabled),
       config_(config),
       buffers_(std::move(buffers)),
       p2p_memcpy_enabled_(p2p_memcpy_enabled) {
@@ -134,12 +134,10 @@ absl::Status AllToAllStartThunk::Initialize(const InitializeParams& params) {
       << "Local device count : " << device_count_;
 
   if (is_local() && p2p_memcpy_enabled_) {
-    AsyncStreamKind stream_kind = GetAsyncStreamKind();
-
     TF_ASSIGN_OR_RETURN(
         GpuCliqueKey clique_key,
         GetGpuCliqueKey(*params.collective_params, config().replica_groups,
-                        config().group_mode, stream_kind));
+                        config().group_mode, p2p_memcpy_enabled_));
 
     TF_ASSIGN_OR_RETURN(
         Communicator * comm,
@@ -261,13 +259,6 @@ absl::StatusOr<bool> AllToAllStartThunk::RunCollective(
       xla::gpu::RunAllToAll(config_.has_split_dimension, device_buffers, stream,
                             comm, config_.config.use_symmetric_buffer));
   return true;
-}
-
-AsyncStreamKind AllToAllStartThunk::GetAsyncStreamKind() const {
-  if (is_local() && p2p_memcpy_enabled_) {
-    return AsyncStreamKind::ASYNC_STREAM_KIND_MEMCPYP2P;
-  }
-  return CollectiveThunk::GetAsyncStreamKind();
 }
 
 bool AllToAllStartThunk::is_local() const {

--- a/xla/backends/gpu/runtime/all_to_all_thunk.h
+++ b/xla/backends/gpu/runtime/all_to_all_thunk.h
@@ -87,8 +87,6 @@ class AllToAllStartThunk : public CollectiveThunk {
                                      se::Stream& stream,
                                      Communicator& comm) override;
 
-  AsyncStreamKind GetAsyncStreamKind() const override;
-
   bool is_local() const;
 
  private:

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
@@ -38,9 +38,9 @@ limitations under the License.
 #include "xla/service/gpu/transforms/collectives/collective_ops_utils.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -48,8 +48,7 @@ CollectiveBroadcastStartThunk::CollectiveBroadcastStartThunk(
     ThunkInfo thunk_info, CollectiveConfig config,
     std::shared_ptr<AsyncEvents> async_events, std::vector<Buffer> buffers)
     : CollectiveThunk(Thunk::kCollectiveBroadcastStart, thunk_info,
-                      async_events,
-                      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
+                      async_events, false),
       config_(config),
       buffers_(std::move(buffers)) {}
 

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk_test.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk_test.cc
@@ -131,8 +131,7 @@ ENTRY test_computation {
   cb_start_thunk->set_async_events(async_events);
 
   auto cb_done_thunk = std::make_unique<CollectiveDoneThunk>(
-      Kind::kCollectiveBroadcastDone, Thunk::ThunkInfo{}, async_events,
-      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE);
+      Kind::kCollectiveBroadcastDone, Thunk::ThunkInfo{}, async_events);
 
   ThunkSequence thunk_sequence;
   thunk_sequence.push_back(std::move(cb_start_thunk));

--- a/xla/backends/gpu/runtime/collective_execution.cc
+++ b/xla/backends/gpu/runtime/collective_execution.cc
@@ -57,7 +57,7 @@ static int64_t GetNumLocalParticipants(
 absl::StatusOr<GpuCliqueKey> GetGpuCliqueKey(
     const CollectiveParams& params,
     absl::Span<const ReplicaGroup> replica_groups,
-    CollectiveOpGroupMode group_mode, AsyncStreamKind stream_kind,
+    CollectiveOpGroupMode group_mode, bool is_p2p,
     bool include_participant_groups) {
   TF_RET_CHECK(params.collectives) << "Collectives API is not provided";
 
@@ -125,8 +125,7 @@ absl::StatusOr<GpuCliqueKey> GetGpuCliqueKey(
                                           unique_incarnations.end());
   absl::c_sort(incarnations);
 
-  return GpuCliqueKey(std::move(participants), num_local_participants,
-                      xla::gpu::IsP2PStreamKind(stream_kind),
+  return GpuCliqueKey(std::move(participants), num_local_participants, is_p2p,
                       std::move(participant_groups), root_device, incarnations);
 }
 

--- a/xla/backends/gpu/runtime/collective_execution.h
+++ b/xla/backends/gpu/runtime/collective_execution.h
@@ -34,7 +34,7 @@ namespace xla::gpu {
 absl::StatusOr<GpuCliqueKey> GetGpuCliqueKey(
     const CollectiveParams& params,
     absl::Span<const ReplicaGroup> replica_groups,
-    CollectiveOpGroupMode group_mode, AsyncStreamKind stream_kind,
+    CollectiveOpGroupMode group_mode, bool is_p2p,
     bool include_participant_groups = true);
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_group_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_group_thunk.cc
@@ -34,19 +34,17 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream.h"
-#include "tsl/platform/casts.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "tsl/platform/casts.h"
 
 namespace xla {
 namespace gpu {
 
 CollectiveGroupThunk::CollectiveGroupThunk(
     ThunkInfo thunk_info, Thunk::Kind kind,
-    std::vector<std::unique_ptr<Thunk>> thunks, AsyncStreamKind stream_kind,
+    std::vector<std::unique_ptr<Thunk>> thunks,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : Thunk(kind, std::move(thunk_info)),
-      stream_kind_(stream_kind),
-      async_events_(async_events) {
+    : Thunk(kind, std::move(thunk_info)), async_events_(async_events) {
   for (auto& thunk : thunks) {
     thunks_.emplace_back(std::move(thunk));
   }
@@ -69,7 +67,7 @@ absl::Status CollectiveGroupThunk::Initialize(const InitializeParams& params) {
 
 absl::Status CollectiveGroupThunk::ExecuteOnStream(
     const Thunk::ExecuteParams& params) {
-  int64_t async_stream_idx = static_cast<int64_t>(stream_kind_);
+  int64_t async_stream_idx = Thunk::execution_stream_id().value();
   // Async streams are already assigned in gpu_executable.cc::ExecuteThunks.
   // async_streams is therefore guaranteed to be non-null and to have enough
   // elements to index by the AsyncStreamKind enum.
@@ -172,8 +170,7 @@ CollectiveGroupThunk::FromProto(
                    Thunk::KindFromProto(thunk_proto.thunk_kind()));
 
   return std::make_unique<CollectiveGroupThunk>(
-      std::move(thunk_info), kind, std::move(thunk_sequence),
-      thunk_proto.async_stream_kind(), async_events);
+      std::move(thunk_info), kind, std::move(thunk_sequence), async_events);
 }
 
 absl::StatusOr<ThunkProto> CollectiveGroupThunk::ToProto() const {
@@ -182,7 +179,6 @@ absl::StatusOr<ThunkProto> CollectiveGroupThunk::ToProto() const {
 
   CollectiveGroupThunkProto* thunk_proto =
       proto.mutable_collective_group_thunk();
-  thunk_proto->set_async_stream_kind(stream_kind_);
 
   std::optional<AsyncEventsUniqueId> async_events_id = GetAsyncEventsUniqueId();
   if (async_events_id.has_value()) {

--- a/xla/backends/gpu/runtime/collective_group_thunk.h
+++ b/xla/backends/gpu/runtime/collective_group_thunk.h
@@ -38,7 +38,7 @@ class CollectiveGroupThunk : public Thunk {
  public:
   CollectiveGroupThunk(
       ThunkInfo thunk_info, Thunk::Kind kind,
-      std::vector<std::unique_ptr<Thunk>> thunks, AsyncStreamKind stream_kind,
+      std::vector<std::unique_ptr<Thunk>> thunks,
       std::shared_ptr<CollectiveThunk::AsyncEvents> async_events =
           std::make_shared<CollectiveThunk::AsyncEvents>());
   absl::Status Prepare(const PrepareParams& params) override;
@@ -65,7 +65,6 @@ class CollectiveGroupThunk : public Thunk {
 
  private:
   ThunkSequence thunks_;
-  AsyncStreamKind stream_kind_;
   std::shared_ptr<CollectiveThunk::AsyncEvents> async_events_;
 };
 

--- a/xla/backends/gpu/runtime/collective_permute_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_permute_thunk.cc
@@ -54,11 +54,11 @@ limitations under the License.
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -91,23 +91,21 @@ bool IsLocalPeerTransfer(const P2PConfig::SourceTargetMapEntry& source_target,
 CollectivePermuteStartThunk::CollectivePermuteStartThunk(
     ThunkInfo thunk_info, const HloCollectivePermuteInstruction* instr,
     int64_t replica_count, int64_t partition_count,
-    const std::vector<Buffer>& buffers, bool p2p_memcpy_enabled,
-    AsyncStreamKind stream_kind)
+    const std::vector<Buffer>& buffers, bool p2p_memcpy_enabled)
     : CollectivePermuteStartThunk(
           std::move(thunk_info),
           GetP2PConfig(instr, replica_count, partition_count),
           IsGPUSyncCollective(*instr)
               ? nullptr
               : std::make_shared<CollectiveThunk::AsyncEvents>(),
-          buffers, p2p_memcpy_enabled, stream_kind) {}
+          buffers, p2p_memcpy_enabled) {}
 
 CollectivePermuteStartThunk::CollectivePermuteStartThunk(
     ThunkInfo thunk_info, const P2PConfig& config,
     std::shared_ptr<AsyncEvents> async_events,
-    const std::vector<Buffer>& buffers, bool p2p_memcpy_enabled,
-    AsyncStreamKind stream_kind)
+    const std::vector<Buffer>& buffers, bool p2p_memcpy_enabled)
     : CollectiveThunk(Thunk::kCollectivePermuteStart, thunk_info, async_events,
-                      stream_kind),
+                      p2p_memcpy_enabled),
       config_(config),
       buffers_(buffers),
       p2p_memcpy_enabled_(p2p_memcpy_enabled) {}
@@ -284,8 +282,7 @@ CollectivePermuteStartThunk::FromProto(
 
   return std::make_unique<CollectivePermuteStartThunk>(
       std::move(thunk_info), P2PConfig{config, std::move(id_to_source_target)},
-      async_events, std::move(buffers), thunk_proto.p2p_memcpy_enabled(),
-      thunk_proto.async_stream_kind());
+      async_events, std::move(buffers), thunk_proto.p2p_memcpy_enabled());
 }
 
 absl::StatusOr<ThunkProto> CollectivePermuteStartThunk::ToProto() const {

--- a/xla/backends/gpu/runtime/collective_permute_thunk.h
+++ b/xla/backends/gpu/runtime/collective_permute_thunk.h
@@ -97,13 +97,11 @@ class CollectivePermuteStartThunk : public CollectiveThunk {
                               const HloCollectivePermuteInstruction* instr,
                               int64_t replica_count, int64_t partition_count,
                               const std::vector<Buffer>& buffers,
-                              bool p2p_memcpy_enabled,
-                              AsyncStreamKind stream_kind);
+                              bool p2p_memcpy_enabled);
   CollectivePermuteStartThunk(ThunkInfo thunk_info, const P2PConfig& config,
                               std::shared_ptr<AsyncEvents> async_events,
                               const std::vector<Buffer>& buffers,
-                              bool p2p_memcpy_enabled,
-                              AsyncStreamKind stream_kind);
+                              bool p2p_memcpy_enabled);
 
   static P2PConfig GetP2PConfig(const HloCollectivePermuteInstruction* instr,
                                 int64_t replica_count, int64_t partition_count);

--- a/xla/backends/gpu/runtime/collective_permute_thunk_test.cc
+++ b/xla/backends/gpu/runtime/collective_permute_thunk_test.cc
@@ -129,14 +129,12 @@ ENTRY test_computation {
   auto cp_start_thunk = std::make_unique<CollectivePermuteStartThunk>(
       Thunk::ThunkInfo{}, cp_instr, /*replica_count=*/2,
       /*partition_count=*/1, std::move(buffers),
-      /*p2p_memcpy_enabled=*/false,
-      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE);
+      /*p2p_memcpy_enabled=*/false);
 
   cp_start_thunk->set_async_events(async_events);
 
   auto cp_done_thunk = std::make_unique<CollectiveDoneThunk>(
-      Kind::kCollectivePermuteDone, Thunk::ThunkInfo{}, async_events,
-      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE);
+      Kind::kCollectivePermuteDone, Thunk::ThunkInfo{}, async_events);
 
   ThunkSequence thunk_sequence;
   thunk_sequence.push_back(std::move(cp_start_thunk));
@@ -227,7 +225,6 @@ TEST(CollectiveThunkTest, ProtoRoundTrip) {
           async_events_unique_id: 3
           collective_config {}
           p2p_memcpy_enabled: true
-          async_stream_kind: ASYNC_STREAM_KIND_COLLECTIVE
           source_target_pairs: { source: 1 target: 2 }
         }
       )pb");
@@ -267,7 +264,6 @@ TEST(CollectiveThunkTest, SyncCollective) {
         collective_permute_start_thunk {
           collective_config {}
           p2p_memcpy_enabled: true
-          async_stream_kind: ASYNC_STREAM_KIND_COLLECTIVE
           source_target_pairs: { source: 1 target: 2 }
         }
       )pb");

--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -57,11 +57,11 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -206,24 +206,21 @@ CollectiveConfig GetCollectiveConfig(
 }
 
 CollectiveThunk::CollectiveThunk(Kind kind, ThunkInfo thunk_info, bool is_sync,
-                                 AsyncStreamKind stream_kind)
+                                 bool is_p2p)
     : Thunk(kind, thunk_info),
-      stream_kind_(stream_kind),
-      async_events_(is_sync ? nullptr : std::make_shared<AsyncEvents>()) {}
+      async_events_(is_sync ? nullptr : std::make_shared<AsyncEvents>()),
+      is_p2p_(is_p2p) {}
 
 CollectiveThunk::CollectiveThunk(Kind kind, ThunkInfo thunk_info,
                                  std::shared_ptr<AsyncEvents> async_events,
-                                 AsyncStreamKind stream_kind)
-    : Thunk(kind, thunk_info),
-      stream_kind_(stream_kind),
-      async_events_(async_events) {}
+                                 bool is_p2p)
+    : Thunk(kind, thunk_info), async_events_(async_events), is_p2p_(is_p2p) {}
 
 absl::StatusOr<GpuCliqueKey> GetCollectiveGpuCliqueKey(
     const CollectiveParams& params, const CollectiveConfig& collective_config,
     bool include_participant_groups) {
   return GetGpuCliqueKey(params, collective_config.replica_groups,
                          collective_config.group_mode,
-                         AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE,
                          include_participant_groups);
 }
 
@@ -346,7 +343,7 @@ absl::Status CollectiveThunk::Prepare(const PrepareParams& params) {
   ASSIGN_OR_RETURN(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(*params.collective_params, config().replica_groups,
-                      config().group_mode, GetAsyncStreamKind()));
+                      config().group_mode, is_p2p_));
   return params.clique_requests->RequestClique(clique_key);
 }
 
@@ -361,12 +358,11 @@ absl::Status CollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(1) << absl::StreamFormat(
       "[%d] Starting %s %s.", params.stream->parent()->device_ordinal(),
       IsAsync() ? "async" : "sync", Thunk::KindToString(kind()));
-  AsyncStreamKind stream_kind = GetAsyncStreamKind();
 
   ASSIGN_OR_RETURN(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(*params.collective_params, config().replica_groups,
-                      config().group_mode, stream_kind));
+                      config().group_mode, is_p2p_));
 
   ASSIGN_OR_RETURN(Communicator * comm,
                    params.collective_cliques->GetComm(
@@ -374,7 +370,7 @@ absl::Status CollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
   DCHECK(comm) << "Failed to get communicator for collective operation";
 
   se::StreamExecutor* executor = params.stream->parent();
-  int64_t async_stream_idx = static_cast<int64_t>(stream_kind);
+  int64_t async_stream_idx = Thunk::execution_stream_id().value();
 
   bool is_first_rendezvous_needed = false;
   if (IsAsync()) {
@@ -442,12 +438,10 @@ absl::Status CollectiveThunk::ExecuteOnStream(const ExecuteParams& params) {
 
 absl::StatusOr<std::vector<Communicator*>> CollectiveThunk::GetCommunicators(
     const ExecuteParams& params) const {
-  AsyncStreamKind stream_kind = GetAsyncStreamKind();
-
   ASSIGN_OR_RETURN(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(*params.collective_params, config().replica_groups,
-                      config().group_mode, stream_kind));
+                      config().group_mode, is_p2p_));
   ASSIGN_OR_RETURN(Communicator * comm,
                    params.collective_cliques->GetComm(
                        clique_key, params.collective_params->global_device_id));
@@ -479,8 +473,6 @@ absl::StatusOr<CollectiveThunkProto> CollectiveThunk::ToCollectiveThunkProto()
     const {
   CollectiveThunkProto proto;
 
-  proto.set_async_stream_kind(stream_kind_);
-
   std::optional<AsyncEventsUniqueId> async_events_id = GetAsyncEventsUniqueId();
   if (!async_events_id.has_value()) {
     return absl::FailedPreconditionError("AsyncEvents is not set.");
@@ -493,11 +485,8 @@ absl::StatusOr<CollectiveThunkProto> CollectiveThunk::ToCollectiveThunkProto()
 
 CollectiveDoneThunk::CollectiveDoneThunk(
     Thunk::Kind kind, ThunkInfo thunk_info,
-    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events,
-    AsyncStreamKind async_stream_kind)
-    : Thunk(kind, std::move(thunk_info)),
-      async_events_(async_events),
-      stream_kind_(async_stream_kind) {}
+    std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
+    : Thunk(kind, std::move(thunk_info)), async_events_(async_events) {}
 
 absl::Status CollectiveDoneThunk::ExecuteOnStream(const ExecuteParams& params) {
   se::StreamExecutor* executor = params.stream->parent();
@@ -533,7 +522,6 @@ absl::StatusOr<ThunkProto> CollectiveDoneThunk::ToProto() const {
   *proto.mutable_thunk_info() = thunk_info().ToProto();
 
   CollectiveDoneThunkProto* thunk_proto = proto.mutable_collective_done_thunk();
-  thunk_proto->set_async_stream_kind(stream_kind_);
 
   std::optional<AsyncEventsUniqueId> async_events_id = GetAsyncEventsUniqueId();
   if (async_events_id.has_value()) {
@@ -561,8 +549,7 @@ CollectiveDoneThunk::FromProto(
   ASSIGN_OR_RETURN(Thunk::Kind kind,
                    Thunk::KindFromProto(thunk_proto.thunk_kind()));
   return std::make_unique<CollectiveDoneThunk>(kind, std::move(thunk_info),
-                                               async_events,
-                                               thunk_proto.async_stream_kind());
+                                               async_events);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_thunk_test.cc
+++ b/xla/backends/gpu/runtime/collective_thunk_test.cc
@@ -42,7 +42,6 @@ TEST(CollectiveDoneThunkTest, ProtoRoundTrip) {
         }
         collective_done_thunk {
           thunk_kind: 1
-          async_stream_kind: 2
           async_events_unique_id: 3
         }
       )pb");

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass_test.cc
@@ -161,8 +161,7 @@ std::unique_ptr<CollectiveDoneThunk> CreateAllGatherDoneThunk(
   auto async_events =
       static_cast<const AllGatherStartThunk*>(start_thunk)->async_events();
   return std::make_unique<CollectiveDoneThunk>(
-      Thunk::kAllGatherDone, Thunk::ThunkInfo(), std::move(async_events),
-      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE);
+      Thunk::kAllGatherDone, Thunk::ThunkInfo(), std::move(async_events));
 }
 
 std::unique_ptr<WhileThunk> CreateWhileThunk(

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
@@ -56,11 +56,11 @@ limitations under the License.
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -238,7 +238,7 @@ RaggedAllToAllStartThunk::RaggedAllToAllStartThunk(
     std::shared_ptr<AsyncEvents> async_events,
     std::vector<CollectiveThunk::Buffer> buffers, bool one_shot_kernel_enabled)
     : CollectiveThunk(Thunk::kRaggedAllToAllStart, thunk_info, async_events,
-                      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE),
+                      false),
       config_(config),
       buffers_(std::move(buffers)),
       one_shot_kernel_enabled_(one_shot_kernel_enabled) {

--- a/xla/backends/gpu/runtime/recv_thunk.h
+++ b/xla/backends/gpu/runtime/recv_thunk.h
@@ -44,8 +44,7 @@ class RecvThunk : public CollectiveThunk {
             int64_t replica_count, int64_t partition_count,
             const Buffer& buffer);
   RecvThunk(ThunkInfo thunk_info, const P2PConfig& config,
-            std::shared_ptr<AsyncEvents> async_events,
-            AsyncStreamKind stream_kind, const Buffer& buffer,
+            std::shared_ptr<AsyncEvents> async_events, const Buffer& buffer,
             absl::string_view instr_name);
   absl::Status Initialize(const InitializeParams& params) override;
 

--- a/xla/backends/gpu/runtime/recv_thunk_test.cc
+++ b/xla/backends/gpu/runtime/recv_thunk_test.cc
@@ -42,7 +42,6 @@ TEST(CollectiveThunkTest, ProtoRoundTrip) {
         recv_thunk {
           async_events_unique_id: 3
           collective_config {}
-          async_stream_kind: ASYNC_STREAM_KIND_COLLECTIVE
           source_target_pairs: { source: 1 target: 2 }
         }
       )pb");

--- a/xla/backends/gpu/runtime/send_recv_thunk_test.cc
+++ b/xla/backends/gpu/runtime/send_recv_thunk_test.cc
@@ -130,8 +130,7 @@ ENTRY computation {
   send_thunk->set_async_events(async_events);
 
   auto send_done_thunk = std::make_unique<CollectiveDoneThunk>(
-      Kind::kSendDone, Thunk::ThunkInfo{}, async_events,
-      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE);
+      Kind::kSendDone, Thunk::ThunkInfo{}, async_events);
 
   ThunkSequence thunk_sequence;
   thunk_sequence.push_back(std::move(send_thunk));
@@ -222,8 +221,7 @@ ENTRY computation {
   recv_thunk->set_async_events(async_events);
 
   auto recv_done_thunk = std::make_unique<CollectiveDoneThunk>(
-      Kind::kRecvDone, Thunk::ThunkInfo{}, async_events,
-      AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE);
+      Kind::kRecvDone, Thunk::ThunkInfo{}, async_events);
 
   ThunkSequence thunk_sequence;
   thunk_sequence.push_back(std::move(recv_thunk));

--- a/xla/backends/gpu/runtime/send_thunk.cc
+++ b/xla/backends/gpu/runtime/send_thunk.cc
@@ -44,9 +44,9 @@ limitations under the License.
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/xla_data.pb.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -57,14 +57,13 @@ SendThunk::SendThunk(ThunkInfo thunk_info, const HloSendInstruction* instr,
     : SendThunk(std::move(thunk_info),
                 GetP2PConfigForSendRecv(instr, instr->operand(0)->shape(),
                                         replica_count, partition_count),
-                std::make_shared<CollectiveThunk::AsyncEvents>(),
-                GetStreamKindForP2P(instr), buffer, instr->name()) {}
+                std::make_shared<CollectiveThunk::AsyncEvents>(), buffer,
+                instr->name()) {}
 
 SendThunk::SendThunk(ThunkInfo thunk_info, const P2PConfig& config,
                      std::shared_ptr<AsyncEvents> async_events,
-                     AsyncStreamKind stream_kind, const Buffer& buffer,
-                     absl::string_view instr_name)
-    : CollectiveThunk(Thunk::kSend, thunk_info, async_events, stream_kind),
+                     const Buffer& buffer, absl::string_view instr_name)
+    : CollectiveThunk(Thunk::kSend, thunk_info, async_events, true),
       config_(config),
       buffer_(buffer),
       execution_counters_(config_.validation_kind ==
@@ -85,7 +84,7 @@ absl::Status SendThunk::Initialize(const InitializeParams& params) {
 absl::StatusOr<bool> SendThunk::ConditionalShouldRun(
     const ExecuteParams& params, int64_t current_id, int64_t target_id) const {
   se::StreamExecutor* executor = params.stream->parent();
-  TF_ASSIGN_OR_RETURN(int64_t* counter,
+  TF_ASSIGN_OR_RETURN(int64_t * counter,
                       execution_counters_->GetCounter(
                           executor, params.collective_params->run_id));
   auto it = config_.source_target_to_bounds.find(
@@ -127,8 +126,7 @@ absl::StatusOr<std::unique_ptr<SendThunk>> SendThunk::FromProto(
 
   return std::make_unique<SendThunk>(
       std::move(thunk_info), P2PConfig{config, std::move(id_to_source_target)},
-      async_events, thunk_proto.async_stream_kind(), buffer,
-      thunk_proto.instruction_name());
+      async_events, buffer, thunk_proto.instruction_name());
 }
 
 absl::StatusOr<ThunkProto> SendThunk::ToProto() const {
@@ -160,7 +158,6 @@ absl::StatusOr<ThunkProto> SendThunk::ToProto() const {
   thunk_proto->mutable_source_target_pairs()->Assign(
       source_target_pairs.begin(), source_target_pairs.end());
 
-  thunk_proto->set_async_stream_kind(GetAsyncStreamKind());
   thunk_proto->set_instruction_name(hlo_name_);
   return proto;
 }

--- a/xla/backends/gpu/runtime/send_thunk.h
+++ b/xla/backends/gpu/runtime/send_thunk.h
@@ -43,8 +43,7 @@ class SendThunk : public CollectiveThunk {
             int64_t replica_count, int64_t partition_count,
             const Buffer& buffer);
   SendThunk(ThunkInfo thunk_info, const P2PConfig& config,
-            std::shared_ptr<AsyncEvents> async_events,
-            AsyncStreamKind stream_kind, const Buffer& buffer,
+            std::shared_ptr<AsyncEvents> async_events, const Buffer& buffer,
             absl::string_view instr_name);
 
   absl::Status Initialize(const InitializeParams& params) override;

--- a/xla/backends/gpu/runtime/send_thunk_test.cc
+++ b/xla/backends/gpu/runtime/send_thunk_test.cc
@@ -42,7 +42,6 @@ TEST(CollectiveThunkTest, ProtoRoundTrip) {
         send_thunk {
           async_events_unique_id: 3
           collective_config {}
-          async_stream_kind: ASYNC_STREAM_KIND_COLLECTIVE
           source_target_pairs: { source: 1 target: 2 }
         }
       )pb");

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -389,7 +389,6 @@ message CollectiveConfigProto {
 
 message CollectiveThunkProto {
   ThunkKindProto thunk_kind = 1;
-  AsyncStreamKind async_stream_kind = 2;
   uint64 async_events_unique_id = 3;
 }
 
@@ -447,7 +446,6 @@ message CollectivePermuteStartThunkProto {
   CollectiveConfigProto collective_config = 3;
   repeated SourceTarget source_target_pairs = 4;
 
-  AsyncStreamKind async_stream_kind = 5;
   bool p2p_memcpy_enabled = 6;
 }
 
@@ -458,7 +456,6 @@ message SendThunkProto {
   CollectiveConfigProto collective_config = 3;
   repeated SourceTarget source_target_pairs = 4;
 
-  AsyncStreamKind async_stream_kind = 5;
   string instruction_name = 6;
 }
 
@@ -469,7 +466,6 @@ message RecvThunkProto {
   CollectiveConfigProto collective_config = 3;
   repeated SourceTarget source_target_pairs = 4;
 
-  AsyncStreamKind async_stream_kind = 5;
   string instruction_name = 6;
 }
 
@@ -481,14 +477,12 @@ message CollectiveBroadcastStartThunkProto {
 
 message CollectiveDoneThunkProto {
   ThunkKindProto thunk_kind = 1;
-  AsyncStreamKind async_stream_kind = 2;
   optional uint64 async_events_unique_id = 3;
 }
 
 message CollectiveGroupThunkProto {
   ThunkKindProto thunk_kind = 1;
   repeated ThunkProto thunks = 2;
-  AsyncStreamKind async_stream_kind = 3;
   optional uint64 async_events_unique_id = 4;
 }
 

--- a/xla/tests/collective_ops_ffi_test.cc
+++ b/xla/tests/collective_ops_ffi_test.cc
@@ -74,8 +74,7 @@ static absl::Status PrepareAllReduce(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
-          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID, false));
 
   // Ask XLA:GPU runtime to acquire a clique for this key. Later we will be able
   // to get access to it from the execute handler.
@@ -97,8 +96,7 @@ static absl::Status AllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
-          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID, false));
 
   // Get the communicator for the requested clique.
   TF_ASSIGN_OR_RETURN(Communicator * comm,


### PR DESCRIPTION
Coauthored with @terryysun 

📝 Summary of Changes

In this PR, we completely remove the AsyncStreamKind type and all of its uses. Instead, we rely only on using `ExecutionStreamId`s to determine op stream placement. In the places where `AsyncStreamKind` were explicitly used (such as in the send/recv ops), we did our best to replicate the behavior with `GetStreamIdOverride`. 

🎯 Justification

This is a continuation of the multi stream collective work.

Relevant design docs
https://docs.google.com/document/d/1i1IzE-ycaWmWYN_0B-lxDwk2WO4CRs9huxVz0YAGgMU/edit?usp=sharing
https://docs.google.com/document/d/1Nxwr9j92yHx--ryBqFkQk2lW-Jx6_2ejjVD7XponOvI/edit?usp=sharing 

🚀 Kind of Contribution: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
This is a non functional change, so no benchmarks are expected to be impacted. In our next follow up PR, we will enable overlapped collective scheduling, which will then have performance impact. This was broken out to reduce the size of this PR.

🧪 Unit Tests:
We removed dead tests in `gpu_clique_key_test.cc`. Updated test in `command_buffer_conversion_pass_test.cc`.

🧪 Execution Tests:
We added new e2e execution tests in `collective_ops_e2e_test.cc`
