### PR TITLE
Changes to the compute capabilities to account for the two different Blackwell Edge GPUs.

### DIFF
--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner_test.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner_test.cc
@@ -330,6 +330,7 @@ TEST_F(StatelessAutotunerTest, CublasFallbackForBf16Bf16F32Algorithm) {
                "Hopper";
         break;
       case se::CudaComputeCapability::kBlackwell:
+      case se::CudaComputeCapability::kBlackwell_12:
         EXPECT_TRUE(hasCublasConfig(configs))
             << "There should be a cublas fallback for dot_bf16_bf16_f32 on "
                "Blackwell";

--- a/xla/service/gpu/model/analytical_latency_estimator_test.cc
+++ b/xla/service/gpu/model/analytical_latency_estimator_test.cc
@@ -119,6 +119,12 @@ TEST_F(AnalyticalLatencyHidingSchedulerTest, TestAnalyticalLatencyEstimator) {
       if (!c.IsAtLeast(se::CudaComputeCapability::kPascal)) {
         GTEST_SKIP() << "This test is for Pascal+ GPUs.";
       }
+      if (c.major == 12 && c.minor == 1) {
+        // Skip this test for Spark. Because of the AllReduce, the test uses
+        // gpu_collective_performance_model, which only makes sense in a
+        // datacenter network setting.
+        GTEST_SKIP() << "This test is for datacenter GPUs.";
+      }
     } else if (!std::is_same_v<stream_executor::RocmComputeCapability, cc>) {
       GTEST_SKIP() << "This test is for Pascal+ GPUs.";
     }

--- a/xla/stream_executor/cuda/cuda_compute_capability.h
+++ b/xla/stream_executor/cuda/cuda_compute_capability.h
@@ -70,7 +70,7 @@ struct CudaComputeCapability {
     kAmpere = 8,
     kHopper = 9,
     kBlackwell = 10,
-    kBlackwellPro = 12
+    kBlackwell_12 = 12
   };
 
   constexpr CudaComputeCapability() = default;
@@ -138,20 +138,6 @@ struct CudaComputeCapability {
                                  FeatureExtension::kForwardCompatibleFeatures};
   }
 
-  // Includes all GPUs with compute capability 12.x. When comparing with
-  // `IsAtLeast` this will true for all compute capabilities of 12.0 or higher.
-  constexpr static CudaComputeCapability BlackwellPro() {
-    return CudaComputeCapability{kBlackwellPro, 0, FeatureExtension::kNone};
-  }
-
-  // Includes all GPUs with compute capability 12.x. When comparing with
-  // `IsAtLeast` this will true for all 12.x compute capabilities but not for
-  // compute capabilities with a higher major version.
-  constexpr static CudaComputeCapability BlackwellProGenerationOnly() {
-    return CudaComputeCapability{kBlackwellPro, 0,
-                                 FeatureExtension::kForwardCompatibleFeatures};
-  }
-
   // Returns true if the compute capability is at least
   // `other_major.other_minor`. It is equivalent to
   // this->SupportsAllFeaturesOf(CudaComputeCapability{other_major,
@@ -183,10 +169,6 @@ struct CudaComputeCapability {
     return major >= CudaComputeCapabilities::kBlackwell;
   }
 
-  bool IsAtLeastBlackwellPro() const {
-    return major >= CudaComputeCapabilities::kBlackwellPro;
-  }
-
   bool IsPascal() const { return major == CudaComputeCapabilities::kPascal; }
 
   bool IsVolta() const { return major == CudaComputeCapabilities::kVolta; }
@@ -202,10 +184,6 @@ struct CudaComputeCapability {
 
   bool IsBlackwell() const {
     return major == CudaComputeCapabilities::kBlackwell;
-  }
-
-  bool IsBlackwellPro() const {
-    return major == CudaComputeCapabilities::kBlackwellPro;
   }
 
   // Returns true if a kernel compiled for compute capability `other` can be run

--- a/xla/stream_executor/cuda/cuda_compute_capability_test.cc
+++ b/xla/stream_executor/cuda/cuda_compute_capability_test.cc
@@ -195,21 +195,6 @@ TEST(CudaComputeCapabilityTest, IsAtLeastMethods) {
       CudaComputeCapability(10, 0, FeatureExtension::kAcceleratedFeatures)
           .IsAtLeastBlackwell());
   EXPECT_TRUE(CudaComputeCapability(10, 1).IsAtLeastBlackwell());
-
-  // IsAtLeastBlackwellPro (sm_120)
-  EXPECT_FALSE(CudaComputeCapability(11, 0).IsAtLeastBlackwellPro());
-  EXPECT_FALSE(
-      CudaComputeCapability(11, 0, FeatureExtension::kForwardCompatibleFeatures)
-          .IsAtLeastBlackwellPro());
-  EXPECT_TRUE(CudaComputeCapability(12, 0).IsAtLeastBlackwellPro());
-  EXPECT_TRUE(
-      CudaComputeCapability(12, 0, FeatureExtension::kAcceleratedFeatures)
-          .IsAtLeastBlackwellPro());
-  EXPECT_TRUE(CudaComputeCapability(12, 0).IsAtLeastBlackwellPro());
-  EXPECT_TRUE(CudaComputeCapability(12, 0).IsAtLeastBlackwellPro());
-  EXPECT_TRUE(
-      CudaComputeCapability(12, 0, FeatureExtension::kForwardCompatibleFeatures)
-          .IsAtLeastBlackwellPro());
 }
 
 TEST(CudaComputeCapabilityTest, FromProtoWithFeatureExtensionSpecified) {


### PR DESCRIPTION
RTX PRO 6000 has CC 12.0.
Spark has CC 12.1.

Removed the IsAtLeastBlackwellPro method because there is no guarantee that future data center GPUs will have CC higher than 12.0.

Also skipped the latency estimator test on Edge GPUs because it uses the collective performance model and crashes here:
https://github.com/openxla/xla/blob/784702574ee3f2df06116e7f7e4b837150c8694a/xla/service/gpu/model/gpu_collective_performance_model.cc#L239