### PR TITLE
Cross-Host Transfer PjRt API Changes: Move CrossHostSendBuffers and CrossHostReceiveBuffers into PjRt API

### DIFF
--- a/xla/pjrt/c_api_client/pjrt_c_api_client.cc
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.cc
@@ -946,67 +946,83 @@ absl::Status PjRtCApiClient::DmaUnmap(void* data) {
   return absl::OkStatus();
 }
 
-PJRT_Transfers_CrossHostRecvNotifierInfo CppCrossHostRecvNotifierToC(
-    const PJRT_Api* c_api, xla::PjRtCrossHostRecvNotifier cpp_notifier) {
-  auto notifier_function = new PjRtCApiClient::CrossHostRecvNotifierFunction(
-      [cpp_notifier = std::move(cpp_notifier), c_api](
-          PJRT_Error* error, const char** serialized_descriptors,
-          size_t* descriptors_sizes, size_t num_descriptors) {
-        if (error != nullptr) {
-          absl::Status state = ::pjrt::PjrtErrorToStatus(error, c_api);
-          return cpp_notifier(std::move(state));
-        }
-        xla::PjRtCrossHostRecvState state;
-        state.descriptors.reserve(num_descriptors);
-        for (int i = 0; i < num_descriptors; ++i) {
-          xla::PjRtCrossHostRecvDescriptors descriptors;
-          descriptors.serialized_descriptors.push_back(
-              std::string(serialized_descriptors[i], descriptors_sizes[i]));
-          state.descriptors.push_back(std::move(descriptors));
-        }
+std::vector<Future<>> PjRtCApiClient::CrossHostSendBuffers(
+    const std::vector<PjRtBuffer*> buffers,
+    const std::vector<PjRtGlobalDeviceId>& dst_global_device_ids,
+    CrossHostTransferKey transfer_key) {
+  // Get C API extension.
+  const PJRT_Api* c_api = pjrt_c_api();
+  PJRT_CrossHostTransfers_Extension* extension =
+      FindExtension<PJRT_CrossHostTransfers_Extension>(
+          PJRT_Extension_Type::PJRT_Extension_Type_CrossHostTransfers);
+  if (extension == nullptr) {
+    absl::Status error = absl::UnimplementedError(
+        "CrossHostSendBuffers is not implemented in this PJRT plugin.");
+    std::vector<Future<>> futures;
+    futures.reserve(buffers.size());
+    for (int i = 0; i < buffers.size(); ++i) {
+      futures.push_back(Future<>(error));
+    }
+    return futures;
+  }
 
-        // TODO(emilyaf): Support cancellation.
-        xla::PjRtCrossHostSendCancelNotifier cancel_notifier =
-            [](absl::string_view, absl::Status,
-               std::function<void(absl::Status)>) {
-              LOG(FATAL) << "MakeCrossHostReceiveBuffers: Cancellation is not "
-                            "supported in PJRT C API.";
-            };
-        state.cancel_notifier = cancel_notifier;
-        return cpp_notifier(std::move(state));
-      });
-  return PJRT_Transfers_CrossHostRecvNotifierInfo{
-      /*user_arg=*/notifier_function,
-      /*notifier=*/
-      [](PJRT_Error* error, const char** serialized_descriptors,
-         size_t* descriptors_sizes, size_t num_descriptors, void* user_arg) {
-        PjRtCApiClient::CrossHostRecvNotifierFunction* notifier_fn =
-            reinterpret_cast<PjRtCApiClient::CrossHostRecvNotifierFunction*>(
-                user_arg);
-        (*notifier_fn)(error, serialized_descriptors, descriptors_sizes,
-                       num_descriptors);
-        delete notifier_fn;
-      }};
+  // Form inputs.
+  PJRT_Transfers_PJRT_Client_CrossHostSendBuffers_Args args;
+  args.struct_size =
+      PJRT_Transfers_PJRT_Client_CrossHostSendBuffers_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.client = c_client_.get();
+  args.num_buffers = buffers.size();
+
+  std::vector<PJRT_Buffer*> c_buffers;
+  c_buffers.reserve(buffers.size());
+  for (PjRtBuffer* buffer : buffers) {
+    c_buffers.push_back(
+        tensorflow::down_cast<const PjRtCApiBuffer*>(buffer)->c_buffer());
+  }
+
+  args.buffers = c_buffers.data();
+  args.dst_global_device_ids = dst_global_device_ids.data();
+  args.transfer_key = transfer_key;
+
+  auto send_events = std::vector<PJRT_Event*>(args.num_buffers);
+  args.send_events = send_events.data();
+
+  extension->PJRT_Transfers_PJRT_Client_CrossHostSendBuffers(&args);
+
+  std::vector<Future<>> send_futures;
+  for (int i = 0; i < args.num_buffers; ++i) {
+    send_futures.push_back(
+        pjrt::ConvertCEventToCppFuture(args.send_events[i], c_api));
+  }
+
+  return send_futures;
 }
 
 absl::StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
-PjRtCApiClient::MakeCrossHostReceiveBuffers(
-    absl::Span<const Shape> shapes, PjRtDevice* device,
-    PjRtCrossHostRecvNotifier notifier) {
+PjRtCApiClient::CrossHostReceiveBuffers(
+    absl::Span<const xla::Shape> shapes, xla::PjRtDevice* device,
+    const std::vector<PjRtGlobalDeviceId>& src_global_device_ids,
+    CrossHostTransferKey transfer_key) {
+  // Get C API extension.
   const PJRT_Api* c_api = pjrt_c_api();
   PJRT_CrossHostTransfers_Extension* extension =
       FindExtension<PJRT_CrossHostTransfers_Extension>(
           PJRT_Extension_Type::PJRT_Extension_Type_CrossHostTransfers);
   if (extension == nullptr) {
     return absl::UnimplementedError(
-        "MakeCrossHostReceiveBuffers is not implemented in this PJRT plugin.");
+        "CrossHostReceiveBuffers is not implemented in this PJRT plugin.");
   }
-  PJRT_Transfers_PJRT_Client_MakeCrossHostReceiveBuffers_Args args;
+
+  // Form inputs.
+  PJRT_Transfers_PJRT_Client_CrossHostReceiveBuffers_Args args;
   args.struct_size =
-      PJRT_Transfers_PJRT_Client_MakeCrossHostReceiveBuffers_Args_STRUCT_SIZE;
+      PJRT_Transfers_PJRT_Client_CrossHostReceiveBuffers_Args_STRUCT_SIZE;
   args.extension_start = nullptr;
   args.client = c_client_.get();
+
   args.num_shapes = shapes.size();
+
   std::vector<size_t> shape_num_dims;
   shape_num_dims.reserve(shapes.size());
   std::vector<PJRT_Buffer_MemoryLayout*> layout_list;
@@ -1031,22 +1047,26 @@ PjRtCApiClient::MakeCrossHostReceiveBuffers(
     //   layout_list.push_back(&(c_layout_data.c_layout));
     layout_list.push_back(nullptr);
   }
+
   args.shape_num_dims = shape_num_dims.data();
   args.num_dims = num_dims.data();
   args.element_types = element_type_list.data();
   args.layouts = layout_list.data();
 
-  args.notifier = CppCrossHostRecvNotifierToC(c_api, std::move(notifier));
   args.device = tensorflow::down_cast<PjRtCApiDevice*>(device)->c_device();
+  args.src_global_device_ids = src_global_device_ids.data();
+  args.transfer_key = transfer_key;
 
   std::vector<PJRT_Buffer*> temp_buffers(shapes.size());
   args.buffers = temp_buffers.data();
+
   RETURN_STATUS_IF_PJRT_ERROR(
-      extension->PJRT_Transfers_PJRT_Client_MakeCrossHostReceiveBuffers(&args),
+      extension->PJRT_Transfers_PJRT_Client_CrossHostReceiveBuffers(&args),
       c_api);
+
   std::vector<std::unique_ptr<PjRtBuffer>> buffers;
-  buffers.reserve(args.num_buffers);
-  for (int i = 0; i < args.num_buffers; ++i) {
+  buffers.reserve(args.num_shapes);
+  for (int i = 0; i < args.num_shapes; ++i) {
     buffers.emplace_back(std::unique_ptr<PjRtBuffer>(
         std::make_unique<PjRtCApiBuffer>(this, args.buffers[i])));
   }
@@ -2937,29 +2957,6 @@ PjRtCApiBuffer::AcquireExternalReference() {
       opaque_device_memory_data_pointer_args.device_memory_ptr;
   return std::make_unique<PjRtCApiExternalReference>(client_, this,
                                                      device_memory_ptr);
-}
-
-void PjRtCApiBuffer::CopyToRemoteDevice(
-    Future<std::string> serialized_descriptor, RemoteSendCallback on_done) {
-  PJRT_CrossHostTransfers_Extension* extension =
-      client_->FindExtension<PJRT_CrossHostTransfers_Extension>(
-          PJRT_Extension_Type::PJRT_Extension_Type_CrossHostTransfers);
-  if (extension == nullptr) {
-    LOG(FATAL) << "PjRtBuffer::CopyToRemoteDevice: Cross host transfers "
-                  "extension not found in PJRT plugin.";
-  }
-  PJRT_Transfers_PJRT_Buffer_CopyToRemoteDevice_Args args;
-  args.struct_size =
-      PJRT_Transfers_PJRT_Buffer_CopyToRemoteDevice_Args_STRUCT_SIZE;
-  args.extension_start = nullptr;
-  args.buffer = c_buffer();
-  // TODO(emilyaf): Support async instead of awaiting here.
-  absl::StatusOr<std::string> descriptor = serialized_descriptor.Await();
-  CHECK_OK(descriptor) << "Failed to copy buffer to remote device: "
-                       << descriptor.status();
-  args.serialized_descriptor = descriptor->c_str();
-  args.serialized_descriptor_size = descriptor->size();
-  extension->PJRT_Transfers_PJRT_Buffer_CopyToRemoteDevice(&args);
 }
 
 PjRtCApiExternalReference::~PjRtCApiExternalReference() {

--- a/xla/pjrt/c_api_client/pjrt_c_api_client.h
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.h
@@ -372,14 +372,20 @@ class PjRtCApiClient : public PjRtClient {
   absl::StatusOr<std::uintptr_t> UnsafeBufferPointer(
       PjRtBuffer* buffer) override;
 
-  absl::StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
-  MakeCrossHostReceiveBuffers(absl::Span<const Shape> shapes,
-                              PjRtDevice* device,
-                              PjRtCrossHostRecvNotifier notifier) override;
-
   absl::Status DmaMap(void* data, size_t size) override;
 
   absl::Status DmaUnmap(void* data) override;
+
+  std::vector<Future<>> CrossHostSendBuffers(
+      const std::vector<PjRtBuffer*> buffers,
+      const std::vector<PjRtGlobalDeviceId>& dst_global_device_ids,
+      CrossHostTransferKey transfer_key) override;
+
+  absl::StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
+  CrossHostReceiveBuffers(
+      absl::Span<const xla::Shape> shapes, xla::PjRtDevice* device,
+      const std::vector<PjRtGlobalDeviceId>& src_global_device_ids,
+      CrossHostTransferKey transfer_key) override;
 
   const PJRT_Api* pjrt_c_api() const;
 
@@ -500,9 +506,6 @@ class PjRtCApiBuffer : public PjRtBuffer {
 
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
-
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
-                          RemoteSendCallback on_done) override;
 
   Future<> GetReadyFuture() override;
 

--- a/xla/pjrt/common_pjrt_client.cc
+++ b/xla/pjrt/common_pjrt_client.cc
@@ -311,66 +311,6 @@ absl::StatusOr<xla::Shape> CommonPjRtClient::MakeDefaultShapeForMemorySpace(
   return shape;
 }
 
-void CommonPjRtBufferImpl::CopyToRemoteDevice(
-    Future<std::string> serialized_descriptor, RemoteSendCallback on_done) {
-  auto* common_client = tensorflow::down_cast<CommonPjRtClient*>(client());
-  std::vector<tsl::RCReference<tsl::AsyncValue>> definition_events;
-  tsl::RCReference<PjRtDeviceEventPromise> usage_event_promise;
-  tsl::RCReference<CommonPjRtRawBuffer> raw_buffer;
-  auto hold_status = AcquireScopedRawBuffer(
-      [&](tsl::RCReference<CommonPjRtRawBuffer> buf_raw_buffer,
-          std::vector<tsl::RCReference<tsl::AsyncValue>> buf_definition_events)
-          -> absl::StatusOr<tsl::RCReference<PjRtDeviceEvent>> {
-        raw_buffer = std::move(buf_raw_buffer);
-        definition_events = std::move(buf_definition_events);
-        tsl::RCReference<PjRtDeviceEvent> usage_event;
-        if (common_client->event_tracking_enabled()) {
-          // Dependencies are added later either to the src_buffer_ptr's
-          // definition events if they are not yet available, and to a boxcar's
-          // ready event once the send is added to a boxcar.
-          const auto& current_anno =
-              tsl::profiler::ScopedMemoryDebugAnnotation::CurrentAnnotation();
-          std::string op_name =
-              !current_anno.pending_op_name.empty()
-                  ? absl::StrCat(" Op:", current_anno.pending_op_name)
-                  : "";
-          TF_ASSIGN_OR_RETURN(
-              std::tie(usage_event_promise, usage_event),
-              common_client->CreateLinkedEventPromise(
-                  memory_space(), absl::StrCat("RemoteSend", op_name)));
-        } else {
-          TF_ASSIGN_OR_RETURN(std::tie(usage_event_promise, usage_event),
-                              common_client->CreateLinkedEventPromise(
-                                  memory_space(), "CopyToRemoteDevice"));
-        }
-        return usage_event;
-      },
-      "CopyToRemoteDevice()");
-  if (!hold_status.ok()) {
-    on_done(hold_status, /*sends_were_enqueued=*/false);
-    return;
-  }
-
-  common_client->ScheduleRemoteSend(
-      memory_space(), std::move(raw_buffer), std::move(definition_events),
-      std::move(usage_event_promise), std::move(serialized_descriptor),
-      std::move(on_done));
-}
-
-void CommonPjRtClient::ScheduleRemoteSend(
-    PjRtMemorySpace* memory_space,
-    tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
-    std::vector<tsl::RCReference<tsl::AsyncValue>> definition_events,
-    tsl::RCReference<PjRtDeviceEventPromise> usage_event_promise,
-    Future<std::string> serialized_descriptor,
-    PjRtBuffer::RemoteSendCallback on_done) {
-  auto error = absl::UnimplementedError(
-      absl::StrCat("ScheduleRemoteSend is not implemented for %s",
-                   memory_space->DebugString()));
-  on_done(error, /*sends_were_enqueued=*/false);
-  usage_event_promise->SetError(error);
-}
-
 absl::StatusOr<std::unique_ptr<PjRtBuffer>>
 CommonPjRtBufferImpl::CopyToCpuMemorySpace(const xla::Shape& dst_shape,
                                            PjRtMemorySpace* dst_memory_space) {

--- a/xla/pjrt/common_pjrt_client.h
+++ b/xla/pjrt/common_pjrt_client.h
@@ -231,14 +231,6 @@ class CommonPjRtClient : public PjRtClient {
       tsl::RCReference<CommonPjRtRawBuffer> raw_buffer) {
     return absl::UnimplementedError("LinearizeHostBufferInto is not supported");
   }
-
-  virtual void ScheduleRemoteSend(
-      PjRtMemorySpace* memory_space,
-      tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
-      std::vector<tsl::RCReference<tsl::AsyncValue>> definition_events,
-      tsl::RCReference<PjRtDeviceEventPromise> usage_event_promise,
-      Future<std::string> serialized_descriptor,
-      PjRtBuffer::RemoteSendCallback on_done);
 };
 
 // TODO(parkers): Merge everything here into CommonPjRtBuffer.
@@ -277,9 +269,6 @@ class CommonPjRtBufferImpl : public CommonPjRtBuffer {
   // The implementation of logical_on_device_shape may involve a blocking
   // device to host transfer to read the metadata of dynamic shape.
   absl::StatusOr<Shape> logical_on_device_shape() override;
-
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
-                          RemoteSendCallback on_done) override;
 
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;

--- a/xla/pjrt/cpu/cpu_client.h
+++ b/xla/pjrt/cpu/cpu_client.h
@@ -153,13 +153,6 @@ class PjRtCpuClient final : public CommonPjRtClient {
 
   using PjRtClient::BufferFromHostLiteral;
 
-  absl::StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
-  MakeCrossHostReceiveBuffers(absl::Span<const Shape> shapes,
-                              PjRtDevice* device,
-                              PjRtCrossHostRecvNotifier notifier) override {
-    return Unimplemented("MakeCrossHostReceiveBuffers not implemented.");
-  }
-
   absl::StatusOr<tsl::RCReference<CommonPjRtRawBuffer>> ImportForeignMemory(
       void* device_ptr, absl::AnyInvocable<void() &&> on_delete_callback,
       size_t on_device_bytes_count, PjRtMemorySpace* memory_space) override;

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -2657,6 +2657,285 @@ TEST(StreamExecutorGpuClientTest, MultipleDeviceShareDmaMapping) {
   TF_EXPECT_OK(client->DmaUnmap(host_dma_ptr.get()));
 }
 
+TEST(StreamExecutorGpuClientTest, FailedCrossHostSendArgsSizeMismatch) {
+  // Create the client.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+
+  // Create a buffer to try to send.
+  std::vector<int32_t> data(256);
+  std::iota(data.begin(), data.end(), 1);
+
+  Shape shape = ShapeUtil::MakeShape(S32, {256});
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<PjRtBuffer> buffer,
+      client->BufferFromHostBuffer(
+          data.data(), shape.element_type(), shape.dimensions(),
+          /*byte_strides=*/std::nullopt,
+          PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall, nullptr,
+          *client->addressable_devices()[0]->default_memory_space(),
+          /*device_layout=*/nullptr));
+
+  // Try to send some data, giving an extra dst_global_device_id.
+  std::vector<Future<>> send_futures = client->CrossHostSendBuffers(
+      {buffer.get()}, {PjRtGlobalDeviceId(1), PjRtGlobalDeviceId(2)},
+      CrossHostTransferKey(0));
+
+  EXPECT_EQ(send_futures.size(), 1);
+
+  EXPECT_THAT(
+      send_futures[0].Await(),
+      absl_testing::StatusIs(
+          absl::StatusCode::kInternal,
+          ::testing::StrEq("CrossHostSendBuffers: dst_global_device_ids "
+                           "must be the same size as buffers.")));
+}
+
+TEST(StreamExecutorGpuClientTest, FailedCrossHostSendMoreThanOneBuffer) {
+  // Create the client.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+
+  // Create a buffer to try to send.
+  std::vector<int32_t> data(256);
+  std::iota(data.begin(), data.end(), 1);
+
+  Shape shape = ShapeUtil::MakeShape(S32, {256});
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<PjRtBuffer> buffer,
+      client->BufferFromHostBuffer(
+          data.data(), shape.element_type(), shape.dimensions(),
+          /*byte_strides=*/std::nullopt,
+          PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall, nullptr,
+          *client->addressable_devices()[0]->default_memory_space(),
+          /*device_layout=*/nullptr));
+
+  // Try to send some data, giving more than one buffer.
+  std::vector<Future<>> send_futures = client->CrossHostSendBuffers(
+      {buffer.get(), buffer.get()},
+      {PjRtGlobalDeviceId(1), PjRtGlobalDeviceId(2)}, CrossHostTransferKey(0));
+
+  EXPECT_EQ(send_futures.size(), 2);
+
+  for (auto& send_future : send_futures) {
+    EXPECT_THAT(
+        send_future.Await(),
+        absl_testing::StatusIs(
+            absl::StatusCode::kUnimplemented,
+            ::testing::StrEq("CrossHostSendBuffers currently only supports one "
+                             "buffer, but got 2")));
+  }
+}
+
+TEST(StreamExecutorGpuClientTest, FailedCrossHostReceiveBadNumShapes) {
+  // Create the client.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+
+  // Create a shape we will use for this set of tests.
+  Shape shape = ShapeUtil::MakeShape(S32, {256});
+
+  // Check InvalidArgument status when we give 0 shapes.
+  std::vector<Shape> no_shapes;
+  absl::StatusOr no_shapes_status_or = client->CrossHostReceiveBuffers(
+      /*shapes=*/absl::MakeSpan(no_shapes),
+      /*device=*/client->addressable_devices()[0],
+      /*src_global_device_ids=*/{},
+      /*transfer_key=*/CrossHostTransferKey(0));
+
+  EXPECT_THAT(no_shapes_status_or.status(),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  ::testing::StrEq(
+                      "shapes parameter empty in CrossHostReceiveBuffers")));
+
+  // Check InvalidArgument status when we give > 1 shape.
+  std::vector<Shape> two_shapes = {shape, shape};
+  absl::StatusOr two_shapes_status_or = client->CrossHostReceiveBuffers(
+      /*shapes=*/absl::MakeSpan(two_shapes),
+      /*device=*/client->addressable_devices()[0],
+      /*src_global_device_ids=*/{PjRtGlobalDeviceId(0), PjRtGlobalDeviceId(1)},
+      /*transfer_key=*/CrossHostTransferKey(0));
+
+  EXPECT_THAT(two_shapes_status_or.status(),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kUnimplemented,
+                  ::testing::StrEq("CrossHostReceiveBuffers currently only "
+                                   "supports one shape, but got 2")));
+}
+
+TEST(StreamExecutorGpuClientTest, FailedCrossHostReceiveArgsSizeMismatch) {
+  // Create the client.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+
+  // Create shapes to receive.
+  std::vector<Shape> shapes = {ShapeUtil::MakeShape(S32, {256})};
+
+  // Check InvalidArgument status when shapes.size() !=
+  // src_global_device_ids.size().
+  absl::StatusOr mismatch_status_or = client->CrossHostReceiveBuffers(
+      /*shapes=*/absl::MakeSpan(shapes),
+      /*device=*/client->addressable_devices()[0],
+      /*src_global_device_ids=*/{},
+      /*transfer_key=*/CrossHostTransferKey(0));
+
+  EXPECT_THAT(
+      mismatch_status_or.status(),
+      absl_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          ::testing::StrEq("shapes and src_global_device_ids parameters to "
+                           "CrossHostReceiveBuffers must have the same length, "
+                           "but got 1 and 0")));
+}
+
+TEST(StreamExecutorGpuClientTest, SuccessfulCrossHostTransfer) {
+  tsl::SubProcess sender;
+  tsl::SubProcess receiver;
+
+  std::vector<std::string> sender_argv;
+  sender_argv.push_back("successful_cross_host_transfer_test");
+  sender_argv.push_back("--test_to_run=SuccessfulCrossHostTransferHelper");
+  sender_argv.push_back("--cross_host_test_role=sender");
+
+  std::vector<std::string> receiver_argv;
+  receiver_argv.push_back("successful_cross_host_transfer_test");
+  receiver_argv.push_back("--test_to_run=SuccessfulCrossHostTransferHelper");
+  receiver_argv.push_back("--cross_host_test_role=receiver");
+
+  sender.SetProgram("/proc/self/exe", sender_argv);
+  sender.SetChannelAction(tsl::CHAN_STDOUT, tsl::ACTION_PIPE);
+  sender.SetChannelAction(tsl::CHAN_STDERR, tsl::ACTION_PIPE);
+
+  receiver.SetProgram("/proc/self/exe", receiver_argv);
+  receiver.SetChannelAction(tsl::CHAN_STDOUT, tsl::ACTION_PIPE);
+  receiver.SetChannelAction(tsl::CHAN_STDERR, tsl::ACTION_PIPE);
+
+  ASSERT_TRUE(sender.Start());
+  ASSERT_TRUE(receiver.Start());
+
+  std::string sender_stdout, sender_stderr;
+  std::string receiver_stdout, receiver_stderr;
+
+  int sender_status =
+      sender.Communicate(nullptr, &sender_stdout, &sender_stderr);
+  int receiver_status =
+      receiver.Communicate(nullptr, &receiver_stdout, &receiver_stderr);
+
+  EXPECT_EQ(sender_status, 0) << "sender stdout:\n"
+                              << sender_stdout << "\nsender stderr:\n"
+                              << sender_stderr;
+  EXPECT_EQ(receiver_status, 0) << "receiver stdout:\n"
+                                << receiver_stdout << "\nreceiver stderr:\n"
+                                << receiver_stderr;
+}
+
+absl::Status SuccessfulCrossHostTransferTestBody(bool is_sender) {
+  std::string log_prefix = is_sender ? "sender" : "receiver";
+
+  // Sender creates a coordination service on so both processes can find each
+  // other via the distributed runtime (port chosen arbitrarily).
+  std::unique_ptr<xla::DistributedRuntimeService> service;
+  if (is_sender) {
+    LOG(INFO) << log_prefix << ": creating coordination service";
+    TF_ASSIGN_OR_RETURN(
+        service, xla::GetDistributedRuntimeService(
+                     "127.0.0.1:12347",
+                     xla::CoordinationServiceImpl::Options{.num_nodes = 2}));
+    LOG(INFO) << log_prefix << ": created service";
+  }
+
+  // Connect to the coordination service.
+  int32_t node_id = is_sender ? 0 : 1;
+  xla::DistributedRuntimeClient::Options distributed_options;
+  distributed_options.node_id = node_id;
+  distributed_options.init_timeout = absl::Seconds(120);
+  auto distributed_client =
+      GetDistributedRuntimeClient("127.0.0.1:12347", distributed_options);
+
+  LOG(INFO) << log_prefix << ": connecting distributed client";
+  TF_QCHECK_OK(distributed_client->Connect());
+  LOG(INFO) << log_prefix << ": distributed client connected";
+
+  // Create the GPU client.
+  GpuClientOptions options = DefaultOptions();
+  options.node_id = node_id;
+  options.num_nodes = 2;
+  options.kv_store =
+      GetDistributedKeyValueStore(distributed_client, /*key_prefix=*/"cross:");
+  options.allowed_devices = {node_id};
+
+  LOG(INFO) << log_prefix << ": creating PjRtClient";
+  TF_ASSIGN_OR_RETURN(std::unique_ptr<PjRtClient> client,
+                      GetStreamExecutorGpuClient(options));
+  LOG(INFO) << log_prefix << ": PjRtClient created";
+
+  // Sender logic.
+  if (is_sender) {
+    // Create the data to send.
+    std::vector<int32_t> data(256);
+    std::iota(data.begin(), data.end(), 1);
+
+    Shape shape = ShapeUtil::MakeShape(S32, {256});
+
+    LOG(INFO) << log_prefix << ": creating buffer";
+    TF_ASSIGN_OR_RETURN(
+        std::unique_ptr<PjRtBuffer> buffer,
+        client->BufferFromHostBuffer(
+            data.data(), shape.element_type(), shape.dimensions(),
+            /*byte_strides=*/std::nullopt,
+            PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall, nullptr,
+            *client->addressable_devices()[0]->default_memory_space(),
+            /*device_layout=*/nullptr));
+
+    LOG(INFO) << log_prefix << ": waiting for buffer ready";
+    TF_RETURN_IF_ERROR(buffer->GetReadyFuture().Await());
+    LOG(INFO) << log_prefix << ": buffer ready";
+
+    // Send some data.
+    LOG(INFO) << log_prefix << ": issuing CrossHostSendBuffers";
+    std::vector<Future<>> send_futures = client->CrossHostSendBuffers(
+        {buffer.get()}, {PjRtGlobalDeviceId(1)}, CrossHostTransferKey(0));
+    EXPECT_EQ(send_futures.size(), 1);
+    TF_RETURN_IF_ERROR(send_futures[0].Await());
+    LOG(INFO) << log_prefix << ": send completed";
+  }
+
+  // Receiver logic.
+  else {
+    // Receive some data.
+    std::vector<Shape> shapes = {ShapeUtil::MakeShape(S32, {256})};
+
+    LOG(INFO) << log_prefix << ": calling CrossHostReceiveBuffers";
+    TF_ASSIGN_OR_RETURN(
+        std::vector<std::unique_ptr<PjRtBuffer>> receive_buffers,
+        client->CrossHostReceiveBuffers(
+            /*shapes=*/absl::MakeSpan(shapes),
+            /*device=*/client->addressable_devices()[0],
+            /*src_global_device_ids=*/{PjRtGlobalDeviceId(0)},
+            /*transfer_key=*/CrossHostTransferKey(0)));
+    LOG(INFO) << log_prefix
+              << ": CrossHostReceiveBuffers returned, waiting for ready";
+
+    // Verify we received the expected data.
+    EXPECT_EQ(receive_buffers.size(), 1);
+    TF_RETURN_IF_ERROR(receive_buffers[0]->GetReadyFuture().Await());
+    LOG(INFO) << log_prefix << ": buffer ready, converting to literal";
+
+    TF_ASSIGN_OR_RETURN(std::shared_ptr<xla::Literal> recv_literal,
+                        receive_buffers[0]->ToLiteralSync());
+    std::vector<int32_t> expected_data(256);
+    std::iota(expected_data.begin(), expected_data.end(), 1);
+    EXPECT_TRUE(LiteralTestUtil::Equal(
+        LiteralUtil::CreateR1<int32_t>(expected_data), *recv_literal));
+    LOG(INFO) << log_prefix << ": verification complete";
+  }
+
+  return absl::OkStatus();
+}
+
 TEST(StreamExecutorGpuClientTest, RawBuffer) {
   TF_ASSERT_OK_AND_ASSIGN(auto client,
                           GetStreamExecutorGpuClient(DefaultOptions()));
@@ -2915,6 +3194,7 @@ TEST_P(ShardedAutotuningTest, ShardedAutotuningWorks) {
       std::vector<std::string> argv;
       argv.reserve(6);
       argv.push_back("sharded_autotuning_test");
+      argv.push_back("--test_to_run=ShardedAutotuningWorksHelper");
       argv.push_back(absl::StrFormat("--node_id=%d", node_id));
       argv.push_back(absl::StrFormat("--use_xla_computation=%d",
                                      param.use_xla_computation));
@@ -3069,13 +3349,29 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace xla
 
 int main(int argc, char* argv[]) {
-  // Save name of binary so that it may invoke itself.
+  // Populated by a command line flag. Will be either
+  // 'ShardedAutotuningWorksHelper', 'SuccessfulCrossHostTransferHelper', or
+  // empty. If empty, all tests are run. Otherwise, the test body for
+  // 'ShardedAutotuningWorks' or 'SuccessfulCrossHostTransfer' will be run.
+  std::string test_to_run;
+
+  // Variables used by ShardedAutotuningWorks.
   int node_id = -1;
   int num_active_nodes = -1;
   int num_nodes_using_cache = -1;
   std::string cache_dir;
   bool use_xla_computation = false;
+
+  // Variables used by SuccessfulCrossHostTransfer.
+  std::string cross_host_test_role;
+
   std::vector<tsl::Flag> flag_list = {
+      tsl::Flag("test_to_run", &test_to_run,
+                "Which test(s) to execute. Allowed values: '' (runs "
+                "all tests), 'ShardedAutotuningWorksHelper' or "
+                "'SuccessfulCrossHostTransferHelper'."),
+
+      // Flags for ShardedAutotuningWorks.
       tsl::Flag("node_id", &node_id,
                 "Node ID for ShardedAutotuningWorks test."),
       tsl::Flag("num_active_nodes", &num_active_nodes,
@@ -3086,12 +3382,22 @@ int main(int argc, char* argv[]) {
                 "Test parameter for ShardedAutotuningWorks."),
       tsl::Flag("use_xla_computation", &use_xla_computation,
                 "Test parameter for ShardedAutotuningWorks."),
-  };
+
+      // Flags for SuccessfulCrossHostTransfer.
+      tsl::Flag("cross_host_test_role", &cross_host_test_role,
+                "Test parameter for SuccessfulCrossHostTransfer; either "
+                "'sender' or 'receiver'.")};
+
   xla::AppendDebugOptionsFlags(&flag_list);
   std::string usage = tsl::Flags::Usage(argv[0], flag_list);
   tsl::Flags::Parse(&argc, argv, flag_list);
-  testing::InitGoogleTest(&argc, argv);
-  if (node_id >= 0) {
+
+  if (test_to_run.empty()) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+  }
+
+  if (test_to_run == "ShardedAutotuningWorksHelper") {
     absl::Status result = xla::ShardedAutotuningWorksTestBody(
         node_id, num_active_nodes, num_nodes_using_cache, cache_dir,
         use_xla_computation);
@@ -3100,5 +3406,23 @@ int main(int argc, char* argv[]) {
     }
     return result.raw_code();
   }
-  return RUN_ALL_TESTS();
+
+  else if (test_to_run == "SuccessfulCrossHostTransferHelper") {
+    absl::Status s;
+    if (cross_host_test_role == "sender") {
+      s = xla::SuccessfulCrossHostTransferTestBody(/*is_sender=*/true);
+    } else if (cross_host_test_role == "receiver") {
+      s = xla::SuccessfulCrossHostTransferTestBody(/*is_sender=*/false);
+    } else {
+      LOG(ERROR) << "cross_host_test_role must be 'sender' or 'receiver'.";
+      return 1;
+    }
+    if (!s.ok()) LOG(ERROR) << s;
+    return s.raw_code();
+  }
+
+  else {
+    LOG(ERROR) << "Unrecognized multiprocess test name " << test_to_run << ".";
+    return 1;
+  }
 }

--- a/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer.h
+++ b/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer.h
@@ -85,12 +85,6 @@ class TfrtGpuBuffer final : public PjRtBuffer {
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
 
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
-                          RemoteSendCallback on_done) override {
-    on_done(Unimplemented("CopyToRemoteDevice not implemented."),
-            /*sends_were_enqueued=*/false);
-  }
-
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> DonateWithControlDependency(
       Future<> dependency) override;
 

--- a/xla/pjrt/interpreter/interpreter_client.h
+++ b/xla/pjrt/interpreter/interpreter_client.h
@@ -268,12 +268,6 @@ class InterpreterLiteralWrapperBuffer final : public PjRtBuffer {
         "InterpreterLiteralWrapperBuffer.");
   }
 
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
-                          RemoteSendCallback on_done) override {
-    LOG(ERROR) << "InterpreterLiteralWrapperBuffer::CopyToRemoteDevice was "
-                  "called but is not implemented.";
-  }
-
   Future<> GetReadyFuture() override { return Future<>(absl::OkStatus()); }
 
   bool IsOnCpu() const override { return true; }

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -424,13 +424,6 @@ class PjRtStreamExecutorClient : public CommonPjRtClient {
   friend class PjRtStreamExecutorBuffer;
   friend class PjRtStreamExecutorRawBuffer;
 
-  virtual void CopyToRemoteDevice(PjRtBuffer* buffer,
-                                  absl::string_view serialized_descriptor,
-                                  PjRtBuffer::RemoteSendCallback on_done) {
-    on_done(Unimplemented("Cross host sends not implemented."),
-            /*sends_were_enqueued=*/false);
-  }
-
   virtual Future<> CopyRawSubBufferToHost(PjRtBuffer* buffer, Future<void*> dst,
                                           int64_t offset,
                                           int64_t transfer_size) {

--- a/xla/pjrt/tf_pjrt_client.h
+++ b/xla/pjrt/tf_pjrt_client.h
@@ -101,11 +101,7 @@ class TfPjRtBuffer : public PjRtBuffer {
   bool IsDeleted() const override { return wrapped_->IsDeleted(); }
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CopyToMemorySpace(
       PjRtMemorySpace* dst_memory_space) override;
-  void CopyToRemoteDevice(Future<std::string> serialized_descriptor,
-                          RemoteSendCallback on_done) override {
-    wrapped_->CopyToRemoteDevice(std::move(serialized_descriptor),
-                                 std::move(on_done));
-  }
+
   Future<> GetReadyFuture() override { return wrapped_->GetReadyFuture(); }
   bool IsOnCpu() const override { return wrapped_->IsOnCpu(); }
 

--- a/xla/python/pjrt_ifrt/pjrt_client.h
+++ b/xla/python/pjrt_ifrt/pjrt_client.h
@@ -391,17 +391,6 @@ class PjRtClient final
       absl::Span<ArrayRef> arrays, DeviceListRef src_devices,
       DeviceListRef dst_devices, std::optional<MemoryKind> memory_kind);
 
-  // Extracts receive descriptors from a key-value store and sends buffers to a
-  // remote device.
-  absl::Status CrossHostSendBuffers(PjRtBuffers buffers,
-                                    const std::vector<int64_t>& keys);
-
-  // Populates a key-value store with receive descriptors and places buffers
-  // from a cross-host send onto device.
-  absl::StatusOr<PjRtBuffers> CrossHostReceiveBuffers(
-      absl::Span<const xla::Shape> shapes, xla::PjRtDevice* device,
-      std::vector<int64_t> keys);
-
   // Copies arrays from source to destination devices when at least one of the
   // (source, destination) pairs is cross-host using an experimental DCN
   // transfer library. Called when the PjRt backend does not support
@@ -413,7 +402,7 @@ class PjRtClient final
   // Creates a unique identifier for each cross-host transfer. Every process
   // must call it, regardless of whether it participates in the cross-host
   // transfer, so that the returned value must be the same in all processes.
-  int64_t CreateNewTransferKey();
+  CrossHostTransferKey CreateNewTransferKey();
 
   // If true, the backend implements the cross-host transfer APIs.
   bool pjrt_supports_cross_host_transfers_ = false;


### PR DESCRIPTION
📝 Summary of Changes
This PR is a sketch outlining potential modifications to the PjRt API to better support cross-process transfers on GPUs, intended for discussion with @emilyfertig and @mwhittaker.

A [previous PR](https://github.com/openxla/xla/pull/32074) had also proposed PjRt API modifications for cross-process transfers, but this PR takes a different approach which simplifies the API, and which would allow us to aggregate transfers with ncclGroup calls in the future.

🎯 Justification
The current implementation of cross-process device-puts on GPUs does not cache communicators for reuse across multiple transfers between the same sets of devices, and does not aggregate transfers of multiple arrays together with ncclGroup calls. This PR changes the PjRt API to make CrossHostSendBuffers and CrossHostReceiveBuffers virtual functions inside xla::PjRtClient, allowing for client-specific implementations. Follow-on PRs can build on these API changes to implement communicator caching and aggregating transfers with ncclGroup calls.

🚀 Kind of Contribution
Performance Improvement

📊 Benchmark (for Performance Improvements)
This PR only makes API changes necessary for future performance improvements such as communicator caching and aggregating transfers with ncclGroup calls, so no benchmarks were ran for this PR. Follow-up PRs implementing performance improvements will include benchmarks.

🧪 Execution Tests:
Verified that [these 4 correctness checks](https://gist.github.com/rao-ashish/24ac0df0cb18243c649ac535964b31b8) for cross-process device-puts pass.