### PR TITLE
Support systemlib build of boringssl

### DIFF
--- a/third_party/boringssl.BUILD
+++ b/third_party/boringssl.BUILD
@@ -1,0 +1,21 @@
+licenses(["notice"])
+
+filegroup(
+    name = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "crypto",
+    linkopts = ["-lcrypto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ssl",
+    linkopts = ["-lssl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":crypto",
+    ],
+)

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -419,6 +419,7 @@ def _tf_repositories():
         name = "boringssl",
         sha256 = "9dc53f851107eaf87b391136d13b815df97ec8f76dadb487b58b2fc45e624d2c",
         strip_prefix = "boringssl-c00d7ca810e93780bd0c8ee4eea28f4f2ea4bcdc",
+        system_build_file = "//third_party:boringssl.BUILD",
         urls = tf_mirror_urls("https://github.com/google/boringssl/archive/c00d7ca810e93780bd0c8ee4eea28f4f2ea4bcdc.tar.gz"),
     )
 


### PR DESCRIPTION
📝 Summary of Changes

This allows building XLA with a user-/system-provided version of boringssl/OpenSSL.

🎯 Justification

We use this in [conda-forge's packaging of `jaxlib`](https://github.com/conda-forge/jaxlib-feedstock) to unbundle the OpenSSL code from the jaxlib package and use the conda-provided `openssl` package. Thus, one can upgrade `openssl` without rebuilding `jaxlib`.

🚀 Kind of Contribution
✨ New Feature