### PR TITLE
[ROCm] Move cupti_tracer to cuda dependencies in py_hlo_multihost_runner target

### DIFF
--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -323,10 +323,10 @@ tsl_pybind_extension(
         "@tsl//tsl/platform:statusor",
     ] + if_cuda_or_rocm([
         "//xla/service:gpu_plugin",
-        "//xla/backends/profiler/gpu:cupti_tracer",
         "//xla/backends/profiler/gpu:device_tracer",
     ]) + if_cuda([
         "//xla/stream_executor:cuda_platform",
+        "//xla/backends/profiler/gpu:cupti_tracer",
     ] + if_google(
         [
             "//third_party/py/jax/jaxlib/cuda:cuda_gpu_kernels",  # fixdeps: keep


### PR DESCRIPTION
📝 Summary of Changes
Move cupti_tracer to cuda dependencies in py_hlo_multihost_runner target

🎯 Justification
This PR fixes building py_hlo_multihost_runner on ROCm, where CUPTI is not available, missed in #32012

🚀 Kind of Contribution
🐛 Bug Fix

@xla-rotation could I get a review for this PR, please?