### PR TITLE
Update gemma2 keras benchmark script - fix ttft, and use tokenizer

### DIFF
--- a/xla/backends/cpu/benchmarks/e2e/gemma2/keras/benchmark.py
+++ b/xla/backends/cpu/benchmarks/e2e/gemma2/keras/benchmark.py
@@ -74,9 +74,7 @@ def run(gemma_lm, tokenizer, max_len):
   output = gemma_lm.generate(_QUERY, max_length=total_output_len + 1)
   warmup_time = (time.time() - start) * 1000
   num_actual_output_tokens = len(tokenizer(output))
-  gen_tokens = 0
-  if num_actual_output_tokens > in_tokens_len:
-    gen_tokens = num_actual_output_tokens - in_tokens_len
+  gen_tokens = max(num_actual_output_tokens - in_tokens_len, 0)
 
   print(f"Warmup: Number of generated output tokens: ", gen_tokens)
 
@@ -92,9 +90,6 @@ def run(gemma_lm, tokenizer, max_len):
     elapsed_time = (time.time() - start) * 1000
     assert num_actual_output_tokens == len(tokenizer(output))
     times.append(elapsed_time)
-    gen_tokens = 0
-    if num_actual_output_tokens > in_tokens_len:
-      gen_tokens = num_actual_output_tokens - in_tokens_len
 
     if _VERBOSE:
       print("%d: %lf ms" % (i, elapsed_time))
@@ -112,8 +107,9 @@ def main():
   if _VERBOSE:
     print("Query: %s" % _QUERY)
 
-  gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset("gemma2_2b_en")
-  tokenizer = keras_nlp.models.GemmaTokenizer.from_preset("gemma2_2b_en")
+  model_name = "gemma2_2b_en"
+  gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset(model_name)
+  tokenizer = keras_nlp.models.GemmaTokenizer.from_preset(model_name)
   mean_1, diff_1, _ = run(gemma_lm, tokenizer, 1)
   mean_n, diff_n, num_output_tokens = run(gemma_lm, tokenizer, _NUM_OUTPUT_TOKENS)
 

--- a/xla/backends/cpu/benchmarks/e2e/gemma2/keras/benchmark.py
+++ b/xla/backends/cpu/benchmarks/e2e/gemma2/keras/benchmark.py
@@ -51,21 +51,34 @@ def compute_stats(array):
   return (mean, diff)
 
 
-def run(gemma_lm, max_len):
+def run(gemma_lm, tokenizer, max_len):
   """Benchmarks inferences with at most `max_len` output tokens.
 
   Args:
     gemma_lm: The Gemma2 Keras model.
+    tokenizer: The tokenizer for the Gemma2 model.
     max_len: The maximum number of output tokens per one inference.
 
   Returns:
     mean ± %diff and the actual number of output tokens generated per inference.
   """
+  in_tokens = tokenizer(_QUERY)
+  in_tokens_len = len(in_tokens)
+  total_output_len = in_tokens_len + max_len
+  if max_len < 1:
+    print(f"Error: max_len {max_len} should be >= 1")
+    exit()
+
   # Warm up.
   start = time.time()
-  output = gemma_lm.generate(_QUERY, max_length=max_len + 1)
-  num_actual_output_tokens = len(output.split(" "))
+  output = gemma_lm.generate(_QUERY, max_length=total_output_len + 1)
   warmup_time = (time.time() - start) * 1000
+  num_actual_output_tokens = len(tokenizer(output))
+  gen_tokens = 0
+  if num_actual_output_tokens > in_tokens_len:
+    gen_tokens = num_actual_output_tokens - in_tokens_len
+
+  print(f"Warmup: Number of generated output tokens: ", gen_tokens)
 
   if _VERBOSE:
     print("=== Max len: %d ===" % max_len)
@@ -75,18 +88,24 @@ def run(gemma_lm, max_len):
   times = []
   for i in range(1, 6):
     start = time.time()
-    output = gemma_lm.generate(_QUERY, max_length=max_len + 1)
-    assert num_actual_output_tokens == len(output.split(" "))
+    output = gemma_lm.generate(_QUERY, max_length=total_output_len + 1)
     elapsed_time = (time.time() - start) * 1000
+    assert num_actual_output_tokens == len(tokenizer(output))
     times.append(elapsed_time)
+    gen_tokens = 0
+    if num_actual_output_tokens > in_tokens_len:
+      gen_tokens = num_actual_output_tokens - in_tokens_len
+
     if _VERBOSE:
       print("%d: %lf ms" % (i, elapsed_time))
+      print(f"Benchmark: Number of generated output tokens: ", gen_tokens)
+
 
   mean, diff = compute_stats(times)
   if _VERBOSE:
     print("Mean: %lf ± %d%% ms\n" % (mean, diff))
 
-  return (mean, diff, num_actual_output_tokens)
+  return (mean, diff, gen_tokens)
 
 
 def main():
@@ -94,8 +113,9 @@ def main():
     print("Query: %s" % _QUERY)
 
   gemma_lm = keras_nlp.models.GemmaCausalLM.from_preset("gemma2_2b_en")
-  mean_1, diff_1, _ = run(gemma_lm, 1)
-  mean_n, diff_n, num_output_tokens = run(gemma_lm, _NUM_OUTPUT_TOKENS)
+  tokenizer = keras_nlp.models.GemmaTokenizer.from_preset("gemma2_2b_en")
+  mean_1, diff_1, _ = run(gemma_lm, tokenizer, 1)
+  mean_n, diff_n, num_output_tokens = run(gemma_lm, tokenizer, _NUM_OUTPUT_TOKENS)
 
   print("Generated %d tokens", num_output_tokens)
   tpot = (mean_n - mean_1) / (num_output_tokens - 1)


### PR DESCRIPTION
📝 Summary of Changes

1. Update calculation for TTFT to be the time to first generated token. This will also impact TPOT calculations.
2. Use tokenizer to count the number of tokens generated instead of counting words using space

🎯 Justification
Currently the script computes TTFT as time to first token which is from the prompt and still in prefill stage.

🚀 Kind of Contribution
🐛 Bug Fix