### PR TITLE
[XLA:GPU] Support global scale in block scaled dot custom call

### DIFF
--- a/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
@@ -179,5 +179,46 @@ ENTRY main {
                             "CHECK: __cudnn$blockScaledDot");
 }
 
+TEST_F(BlockScalingRewriterCudnnTest, Nvfp4_GlobalScale) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+
+ENTRY main {
+  %mult_scalar = f16[] constant(6)
+  %mult = f16[256,256] broadcast(%mult_scalar), dimensions={}
+  %p0 = f16[256,256] parameter(0)
+  %p1 = f16[256,256] parameter(1)
+  %lhs = f4e2m1fn[256,256] convert(f16[256,256] multiply(%p0, %mult))
+  %rhs = f4e2m1fn[256,256] convert(f16[256,256] multiply(%p1, %mult))
+  %p2 = f8e4m3fn[256,16] parameter(2)
+  %p3 = f8e4m3fn[256,16] parameter(3)
+  %lhs_scale = f8e4m3fn[256,16] abs(%p2)
+  %rhs_scale = f8e4m3fn[256,16] abs(%p3)
+  %global_scale = f32[] parameter(4)
+  ROOT %result = f32[256,256] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale, %global_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [](HloModule* reference_module) {
+        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module),
+                    absl_testing::IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [](HloModule* test_module) {
+        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module),
+                    absl_testing::IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
+                            "CHECK-NOT: __cudnn$blockScaledDot");
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
+                            "CHECK: __cudnn$blockScaledDot");
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_custom_call_compiler.cc
@@ -447,7 +447,8 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHAF8(
 
 absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBlockScaledDot(
     se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
-  TF_RET_CHECK(custom_call->operand_count() == 4);
+  const bool has_global_scale = custom_call->operand_count() == 5;
+  TF_RET_CHECK(custom_call->operand_count() == 4 || has_global_scale);
   TF_RET_CHECK(custom_call->shape().tuple_shapes().size() == 2);
 
   TF_ASSIGN_OR_RETURN(TensorDescriptor lhs_data,
@@ -486,12 +487,12 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBlockScaledDot(
   TF_ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph,
                       se::gpu::GetCudnnBlockScaledDotOperationGraph(
                           dnn_support, lhs_data, lhs_scale, rhs_data, rhs_scale,
-                          result_type, block_size));
+                          result_type, block_size, has_global_scale));
   return graph;
 }
 
 absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
-    se::dnn::DnnSupport& dnn_support, HloCustomCallInstruction* custom_call) {
+    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
   if (IsFwdCustomCallTofMHA(*custom_call)) {
     return BuildGraphForCustomCallToForwardFMHA(dnn_support, custom_call);
   }

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -754,7 +754,7 @@ absl::StatusOr<CudnnGraph> GetCudnnBlockScaledDotOperationGraph(
     const dnn::TensorDescriptor& lhs_scale,
     const dnn::TensorDescriptor& rhs_data,
     const dnn::TensorDescriptor& rhs_scale, dnn::DataType result_type,
-    int block_size);
+    int block_size, bool has_global_scale);
 
 }  // namespace gpu
 }  // namespace stream_executor


### PR DESCRIPTION
📝 Summary of Changes
Allows fusion global scale multiplication to the scaled dot kernel.
The JAX API will be updated to accept the global scale parameter.

🎯 Justification
Without this change, the scaled dot followed by a multiply is run as two kernels,
which degrades the performance, as the intermediary results are written and then
read from the global memory.

🚀 Kind of Contribution
⚡️ Performance Improvement

The custom calls will soon be replaced by scaled dot fusions, but in the meanwhile
this change gives the perf improvement to the existing models.
