### PR TITLE
[GPU] Sub-byte collective normalization: support collectives with non-minor-most last dimension.

### DIFF
--- a/xla/service/gpu/tests/sub_byte_collectives.hlo
+++ b/xla/service/gpu/tests/sub_byte_collectives.hlo
@@ -13,6 +13,21 @@ e {
 // -----
 
 e {
+  a = s4[4,2]{1,0:E(4)} parameter(0)
+  b = s4[4,4]{1,0:E(4)} all-gather(a), dimensions={1}
+}
+
+// CHECK-NOT: convert
+// CHECK:      s4[4,2]{1,0:E(4)} parameter
+// CHECK-NEXT: s4[2,4]{1,0:E(4)} transpose
+// CHECK-NEXT: s8[2,2]{0,1} bitcast
+// CHECK:      s8[2,4]{0,1} all-gather-done
+// CHECK-NEXT: s4[4,4]{1,0:E(4)} bitcast
+// CHECK-NEXT: s4[4,4]{1,0:E(4)} transpose
+
+// -----
+
+e {
   a = f4e2m1fn[80,20]{1,0:E(4)} parameter(0)
   b = f4e2m1fn[80,20]{1,0:E(4)} all-to-all(a), dimensions={0}
 }

--- a/xla/tools/benchmarks/hlo/u4_all_gather_1x8.hlo
+++ b/xla/tools/benchmarks/hlo/u4_all_gather_1x8.hlo
@@ -1,0 +1,4 @@
+e {
+  a = u4[1024,512]{1,0:E(4)} parameter(0)
+  b = u4[1024,4096]{1,0:E(4)} all-gather(a), dimensions={1}
+}


### PR DESCRIPTION
📝 Summary of Changes
Support collectives with non-minor-most last dimension in the sub-byte collective normalization pass.

🎯 Justification
Makes more collectives efficient, not require type conversion.

🚀 Kind of Contribution
Performance Improvement.

📊 Benchmark (for Performance Improvements)
```
Before:

## Execution time, file=u4_all_gather_1x8.hlo repeat=1 duration=68384ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=2 duration=67744ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=3 duration=66976ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=4 duration=67040ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=5 duration=66816ns

After:

## Execution time, file=u4_all_gather_1x8.hlo repeat=1 duration=41216ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=2 duration=40960ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=3 duration=40960ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=4 duration=41056ns
## Execution time, file=u4_all_gather_1x8.hlo repeat=5 duration=40960ns
```
Measured on 8xH100 DGX.

🧪 Unit Tests:
yes

🧪 Execution Tests:
yes