### PR TITLE
[NVIDIA GPU] Change collective pipeliner to honor opt-barrier

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1026,7 +1026,8 @@ absl::Status RunCollectiveOptimizationPasses(
         /*pipelining_direction=*/
         collective_pipeliner_utils::PipeliningDirection::kForward,
         /*should_process=*/HloPredicateIsOp<HloOpcode::kAllReduce>,
-        /*acceptable_formatting=*/HloPredicateTrue,
+        /*acceptable_formatting=*/
+        HloPredicateIsNotOp<HloOpcode::kOptimizationBarrier>,
         /*reuse_pipelined_op_buffer=*/HloPredicateFalse,
         /*should_allow_loop_variant_parameter_in_chain=*/HloPredicateFalse,
         /*should_allow_control_dependencies=*/false,
@@ -1049,7 +1050,8 @@ absl::Status RunCollectiveOptimizationPasses(
         /*pipelining_direction=*/
         collective_pipeliner_utils::PipeliningDirection::kBackward,
         /*should_process=*/HloPredicateIsOp<HloOpcode::kAllGather>,
-        /*acceptable_formatting=*/HloPredicateTrue,
+        /*acceptable_formatting=*/
+        HloPredicateIsNotOp<HloOpcode::kOptimizationBarrier>,
         /*reuse_pipelined_op_buffer=*/HloPredicateFalse,
         /*should_allow_loop_variant_parameter_in_chain=*/HloPredicateFalse,
         /*should_allow_control_dependencies=*/false,
@@ -1072,7 +1074,8 @@ absl::Status RunCollectiveOptimizationPasses(
         /*pipelining_direction=*/
         collective_pipeliner_utils::PipeliningDirection::kForward,
         /*should_process=*/HloPredicateIsOp<HloOpcode::kReduceScatter>,
-        /*acceptable_formatting=*/HloPredicateTrue,
+        /*acceptable_formatting=*/
+        HloPredicateIsNotOp<HloOpcode::kOptimizationBarrier>,
         /*reuse_pipelined_op_buffer=*/HloPredicateFalse,
         /*should_allow_loop_variant_parameter_in_chain=*/HloPredicateFalse,
         /*should_allow_control_dependencies=*/false,


### PR DESCRIPTION
📝 Summary of Changes
The current collective pipeliners don't honor opt-barrier in their user/producer chain.
This pr changes the behavior to teach collective pipeliners to use acceptable_formatting function to filter out what cannot be pipelined.
🎯 Justification
Without this, opt-barriers connected with target collectives will be peeled and pipelined to other loop iterations which changes the semantic of the whole program.

🚀 Kind of Contribution
 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
NA

🧪 Unit Tests:
Added unit tests

🧪 Execution Tests:
NA
