### PR TITLE
[GPU] Use intrinsics to accelerate f4e2m1fn conversions on Blackwell.

### DIFF
--- a/xla/backends/gpu/codegen/emitters/emitter_base.cc
+++ b/xla/backends/gpu/codegen/emitters/emitter_base.cc
@@ -502,13 +502,8 @@ void AddLoweringPasses(mlir::OpPassManager& pm,
     se::SemanticVersion ptx_version =
         nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
             device.runtime_version());
-
-    // FP8 conversion intrinsics are available on sm89 since ptx 8.1
-    // Older ptx versions only support FP8 conversion for sm90
-    if ((ptx_version >= se::SemanticVersion(8, 1, 0) && cc->IsAtLeast(8, 9)) ||
-        (ptx_version >= se::SemanticVersion(7, 8, 0) && cc->IsAtLeast(9, 0))) {
-      pm.addPass(CreateConvertFloatNvidiaPass());
-    }
+    pm.addPass(CreateConvertFloatNvidiaPass(
+        cc->major, cc->minor, ptx_version.major(), ptx_version.minor()));
   } else if (auto* cc = std::get_if<se::RocmComputeCapability>(
                  &device.gpu_compute_capability())) {
     if (cc->has_fp8_support()) {

--- a/xla/backends/gpu/codegen/emitters/tests/convert/f4e2m1fn_intrinsics.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/convert/f4e2m1fn_intrinsics.hlo
@@ -1,0 +1,11 @@
+// RUN: fusion_to_mlir %s | emitters_opt -xla-gpu-convert-float-nvidia='compute_capability_major=10 compute_capability_minor=0 ptx_version_major=8 ptx_version_minor=6' | FileCheck %s
+// RUN: gpu_test_correctness %s
+
+f {
+  a = f32[15,20] parameter(0)
+  b = f4e2m1fn[15,20] convert(a)
+  c = f32[15,20] convert(b)
+}
+
+// CHECK: llvm.nvvm.ff.to.e2m1x2.rn
+// CHECK: llvm.nvvm.e2m1x2.to.f16x2.rn

--- a/xla/backends/gpu/codegen/emitters/transforms/convert_float_nvidia.cc
+++ b/xla/backends/gpu/codegen/emitters/transforms/convert_float_nvidia.cc
@@ -32,7 +32,6 @@ limitations under the License.
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "xla/backends/gpu/codegen/emitters/transforms/passes.h"
 
-
 namespace xla {
 namespace gpu {
 
@@ -53,57 +52,85 @@ int GetExponentBias(mlir::FloatType ty) {
   return 1 - llvm::APFloat::semanticsMinExponent(ty.getFloatSemantics());
 }
 
+Value ConvertToF32(Value v, mlir::ImplicitLocOpBuilder& b) {
+  mlir::FloatType f32_ty = b.getF32Type();
+  if (v.getType() == f32_ty) {
+    return v;
+  }
+  if (v.getType().getIntOrFloatBitWidth() < f32_ty.getWidth()) {
+    return b.create<ma::ExtFOp>(f32_ty, v);
+  }
+  return b.create<ma::TruncFOp>(f32_ty, v);
+}
+
 struct RewriteTruncFPattern : public mlir::OpRewritePattern<ma::TruncFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  RewriteTruncFPattern(mlir::MLIRContext* context, bool enable_f8,
+                       bool enable_f4)
+      : OpRewritePattern(context),
+        enable_f8_(enable_f8),
+        enable_f4_(enable_f4) {}
 
   mlir::LogicalResult matchAndRewrite(
       ma::TruncFOp op, mlir::PatternRewriter& rewriter) const override {
     using FloatValue = mlir::TypedValue<mlir::FloatType>;
     auto src = mlir::cast<FloatValue>(op.getOperand());
     auto dst_ty = mlir::cast<mlir::FloatType>(op.getType());
-    if (!llvm::isa<mlir::Float8E4M3FNType>(dst_ty) &&
-        !llvm::isa<mlir::Float8E5M2Type>(dst_ty)) {
-      return rewriter.notifyMatchFailure(op, "unsupported float conversion");
+
+    const bool is_f8 = llvm::isa<mlir::Float8E4M3FNType>(dst_ty) ||
+                       llvm::isa<mlir::Float8E5M2Type>(dst_ty);
+    const bool is_f4 = llvm::isa<mlir::Float4E2M1FNType>(dst_ty);
+
+    if ((is_f8 && enable_f8_) || (is_f4 && enable_f4_)) {
+      mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+      rewriter.replaceOp(op, EmitTruncFIntrinsic(src, dst_ty, b));
+      return mlir::success();
     }
 
-    mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);
-    rewriter.replaceOp(op, EmitTruncToF8Intrinsic(src, dst_ty, b));
-    return mlir::success();
+    return rewriter.notifyMatchFailure(op, "unsupported float conversion");
   }
 
-  Value EmitTruncToF8Intrinsic(Value value, mlir::FloatType to_ty,
-                               mlir::ImplicitLocOpBuilder& b) const {
-    assert((llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type>(to_ty)));
+ private:
+  bool enable_f8_;
+  bool enable_f4_;
+
+  Value EmitTruncFIntrinsic(Value value, mlir::FloatType to_ty,
+                            mlir::ImplicitLocOpBuilder& b) const {
+    assert((llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type,
+                      mlir::Float4E2M1FNType>(to_ty)));
 
     ml::CallIntrinsicOp cvtOp;
-    if (value.getType() == b.getF16Type()) {
+    if (llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type>(to_ty) &&
+        value.getType() == b.getF16Type()) {
       // Fast path for truncating F16 type.
       Value vec =
           b.create<ml::UndefOp>(mlir::VectorType::get(2, value.getType()));
       vec = b.create<ml::InsertElementOp>(vec, value,
                                           b.create<ma::ConstantIntOp>(0, 8));
-      auto cvtIntr = llvm::isa<mlir::Float8E4M3FNType>(to_ty)
-                         ? "llvm.nvvm.f16x2.to.e4m3x2.rn"
-                         : "llvm.nvvm.f16x2.to.e5m2x2.rn";
+      const std::string cvtIntr = llvm::isa<mlir::Float8E4M3FNType>(to_ty)
+                                      ? "llvm.nvvm.f16x2.to.e4m3x2.rn"
+                                      : "llvm.nvvm.f16x2.to.e5m2x2.rn";
       cvtOp = b.create<ml::CallIntrinsicOp>(b.getIntegerType(16),
                                             b.getStringAttr(cvtIntr),
                                             mlir::ValueRange{vec});
     } else {
       // Other FP types get converted to F32 first.
-      mlir::FloatType f32_ty = b.getF32Type();
-      if (value.getType().getIntOrFloatBitWidth() < f32_ty.getWidth()) {
-        value = b.create<ma::ExtFOp>(f32_ty, value);
-      } else if (value.getType() != f32_ty) {
-        value = b.create<ma::TruncFOp>(f32_ty, value);
-      }
-      auto cvtIntr = llvm::isa<mlir::Float8E4M3FNType>(to_ty)
-                         ? "llvm.nvvm.ff.to.e4m3x2.rn"
-                         : "llvm.nvvm.ff.to.e5m2x2.rn";
+      value = ConvertToF32(value, b);
+      const std::string cvtIntr = llvm::isa<mlir::Float4E2M1FNType>(to_ty)
+                                      ? "llvm.nvvm.ff.to.e2m1x2.rn.satfinite"
+                                  : llvm::isa<mlir::Float8E4M3FNType>(to_ty)
+                                      ? "llvm.nvvm.ff.to.e4m3x2.rn"
+                                      : "llvm.nvvm.ff.to.e5m2x2.rn";
       cvtOp = b.create<ml::CallIntrinsicOp>(b.getIntegerType(16),
                                             b.getStringAttr(cvtIntr),
                                             mlir::ValueRange{value, value});
     }
-    Value res = b.create<ml::TruncOp>(b.getIntegerType(8), cvtOp.getResults());
+
+    Value res = b.create<ml::TruncOp>(
+        b.getIntegerType(to_ty.getIntOrFloatBitWidth()), cvtOp.getResults());
+
+    if (llvm::isa<mlir::Float4E2M1FNType>(to_ty)) {
+      return b.create<ma::BitcastOp>(to_ty, res);
+    }
 
     // Downcasting to float8 saturates the value (uses "satfinite" modifier).
     // Handle infinity separately to mitigate the issue.
@@ -183,37 +210,53 @@ struct RewriteTruncFPattern : public mlir::OpRewritePattern<ma::TruncFOp> {
 };
 
 struct RewriteExtFPattern : public mlir::OpRewritePattern<ma::ExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  RewriteExtFPattern(mlir::MLIRContext* context, bool enable_f8, bool enable_f4)
+      : OpRewritePattern(context),
+        enable_f8_(enable_f8),
+        enable_f4_(enable_f4) {}
 
   mlir::LogicalResult matchAndRewrite(
       ma::ExtFOp op, mlir::PatternRewriter& rewriter) const override {
     using FloatValue = mlir::TypedValue<mlir::FloatType>;
     auto src = mlir::cast<FloatValue>(op.getOperand());
     auto dst_ty = mlir::cast<mlir::FloatType>(op.getType());
-    if (!llvm::isa<mlir::Float8E4M3FNType>(src.getType()) &&
-        !llvm::isa<mlir::Float8E5M2Type>(src.getType())) {
-      return rewriter.notifyMatchFailure(op, "unsupported float conversion");
+
+    const bool is_f8 = llvm::isa<mlir::Float8E4M3FNType>(src.getType()) ||
+                       llvm::isa<mlir::Float8E5M2Type>(src.getType());
+    const bool is_f4 = llvm::isa<mlir::Float4E2M1FNType>(src.getType());
+
+    if ((is_f8 && enable_f8_) || (is_f4 && enable_f4_)) {
+      mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+      rewriter.replaceOp(op, EmitExtFIntrinsic(src, dst_ty, b));
+      return mlir::success();
     }
 
-    mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);
-    rewriter.replaceOp(op, EmitExtFromF8Intrinsic(src, dst_ty, b));
-    return mlir::success();
+    return rewriter.notifyMatchFailure(op, "unsupported float conversion");
   }
 
-  Value EmitExtFromF8Intrinsic(Value value, mlir::FloatType to_ty,
-                               mlir::ImplicitLocOpBuilder& b) const {
-    assert((llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type>(
-        value.getType())));
+ private:
+  bool enable_f8_;
+  bool enable_f4_;
+
+  Value EmitExtFIntrinsic(Value value, mlir::FloatType to_ty,
+                          mlir::ImplicitLocOpBuilder& b) const {
+    assert((llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type,
+                      mlir::Float4E2M1FNType>(value.getType())));
 
     // Extend the smaller type to the FP16 type using the intrinsic, and then
     // to the destination type. In the case of BF16 go through the intermediate
     // FP32 type (as there's no F2F op for f16->bf16).
+    const std::string cvtIntr =
+        llvm::isa<mlir::Float4E2M1FNType>(value.getType())
+            ? "llvm.nvvm.e2m1x2.to.f16x2.rn"
+        : llvm::isa<mlir::Float8E4M3FNType>(value.getType())
+            ? "llvm.nvvm.e4m3x2.to.f16x2.rn"
+            : "llvm.nvvm.e5m2x2.to.f16x2.rn";
     Value input = b.create<ml::ZExtOp>(
         b.getIntegerType(16),
-        b.create<ma::BitcastOp>(b.getIntegerType(8), value));
-    auto cvtIntr = llvm::isa<mlir::Float8E4M3FNType>(value.getType())
-                       ? "llvm.nvvm.e4m3x2.to.f16x2.rn"
-                       : "llvm.nvvm.e5m2x2.to.f16x2.rn";
+        b.create<ma::BitcastOp>(
+            b.getIntegerType(value.getType().getIntOrFloatBitWidth()), value));
+
     mlir::FloatType f16_ty = b.getF16Type();
     auto cvtOp = b.create<ml::CallIntrinsicOp>(mlir::VectorType::get(2, f16_ty),
                                                b.getStringAttr(cvtIntr),
@@ -238,8 +281,16 @@ class ConvertFloatNvidiaPass
   using ConvertFloatNvidiaPassBase::ConvertFloatNvidiaPassBase;
 
   void runOnOperation() override {
+    const int cc_version =
+        compute_capability_major_ * 10 + compute_capability_minor_;
+    const int ptx_version = ptx_version_major_ * 10 + ptx_version_minor_;
+    const bool enable_f8 = (ptx_version >= 78 && cc_version >= 90) ||
+                           (ptx_version >= 81 && cc_version >= 89);
+    const bool enable_f4 = (ptx_version >= 86 && cc_version >= 100);
+
     mlir::RewritePatternSet patterns(&getContext());
-    patterns.add<RewriteTruncFPattern, RewriteExtFPattern>(&getContext());
+    patterns.add<RewriteTruncFPattern>(&getContext(), enable_f8, enable_f4);
+    patterns.add<RewriteExtFPattern>(&getContext(), enable_f8, enable_f4);
     if (mlir::failed(
             mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
@@ -249,8 +300,15 @@ class ConvertFloatNvidiaPass
 
 }  // namespace
 
-std::unique_ptr<mlir::Pass> CreateConvertFloatNvidiaPass() {
-  return std::make_unique<ConvertFloatNvidiaPass>();
+std::unique_ptr<mlir::Pass> CreateConvertFloatNvidiaPass(
+    int compute_capability_major, int compute_capability_minor,
+    int ptx_version_major, int ptx_version_minor) {
+  ConvertFloatNvidiaPassOptions options;
+  options.compute_capability_major_ = compute_capability_major;
+  options.compute_capability_minor_ = compute_capability_minor;
+  options.ptx_version_major_ = ptx_version_major;
+  options.ptx_version_minor_ = ptx_version_minor;
+  return std::make_unique<ConvertFloatNvidiaPass>(options);
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/codegen/emitters/transforms/convert_float_nvidia.cc
+++ b/xla/backends/gpu/codegen/emitters/transforms/convert_float_nvidia.cc
@@ -76,8 +76,8 @@ struct RewriteTruncFPattern : public mlir::OpRewritePattern<ma::TruncFOp> {
     auto src = mlir::cast<FloatValue>(op.getOperand());
     auto dst_ty = mlir::cast<mlir::FloatType>(op.getType());
 
-    const bool is_f8 = llvm::isa<mlir::Float8E4M3FNType>(dst_ty) ||
-                       llvm::isa<mlir::Float8E5M2Type>(dst_ty);
+    const bool is_f8 =
+        llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type>(dst_ty);
     const bool is_f4 = llvm::isa<mlir::Float4E2M1FNType>(dst_ty);
 
     if ((is_f8 && enable_f8_) || (is_f4 && enable_f4_)) {

--- a/xla/backends/gpu/codegen/emitters/transforms/convert_float_nvidia.cc
+++ b/xla/backends/gpu/codegen/emitters/transforms/convert_float_nvidia.cc
@@ -221,8 +221,8 @@ struct RewriteExtFPattern : public mlir::OpRewritePattern<ma::ExtFOp> {
     auto src = mlir::cast<FloatValue>(op.getOperand());
     auto dst_ty = mlir::cast<mlir::FloatType>(op.getType());
 
-    const bool is_f8 = llvm::isa<mlir::Float8E4M3FNType>(src.getType()) ||
-                       llvm::isa<mlir::Float8E5M2Type>(src.getType());
+    const bool is_f8 =
+        llvm::isa<mlir::Float8E4M3FNType, mlir::Float8E5M2Type>(src.getType());
     const bool is_f4 = llvm::isa<mlir::Float4E2M1FNType>(src.getType());
 
     if ((is_f8 && enable_f8_) || (is_f4 && enable_f4_)) {

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.h
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.h
@@ -33,7 +33,9 @@ namespace gpu {
 #define GEN_PASS_DECL
 #include "xla/backends/gpu/codegen/emitters/transforms/passes.h.inc"
 
-std::unique_ptr<mlir::Pass> CreateConvertFloatNvidiaPass();
+std::unique_ptr<mlir::Pass> CreateConvertFloatNvidiaPass(
+    int compute_capability_major = 0, int compute_capability_minor = 0,
+    int ptx_version_major = 0, int ptx_version_minor = 0);
 std::unique_ptr<mlir::Pass> CreateConvertFloatAMDPass(
     const std::string& gpu_device_info = "");
 std::unique_ptr<mlir::Pass> CreateConvertFloatAMDPass(

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.td
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.td
@@ -43,6 +43,16 @@ def ConvertFloatNvidiaPass : Pass<"xla-gpu-convert-float-nvidia", "mlir::ModuleO
     "mlir::LLVM::LLVMDialect",
     "mlir::arith::ArithDialect",
   ];
+  let options = [
+    Option<"compute_capability_major_", "compute_capability_major", "int", /*default=*/"0",
+           "CUDA compute capability major version.">,
+    Option<"compute_capability_minor_", "compute_capability_minor", "int", /*default=*/"0",
+           "CUDA compute capability minor version.">,
+    Option<"ptx_version_major_", "ptx_version_major", "int", /*default=*/"0",
+           "PTX version major.">,
+    Option<"ptx_version_minor_", "ptx_version_minor", "int", /*default=*/"0",
+           "PTX version minor.">
+  ];
   let constructor = "CreateConvertFloatNvidiaPass()";
 }
 


### PR DESCRIPTION
📝 Summary of Changes
Use intrinsics to accelerate f4e2m1fn conversions on Blackwell.

🎯 Justification
Accelerates type conversions.

🚀 Kind of Contribution
Performance Improvement.

📊 Benchmark (for Performance Improvements)
Public HLOs in `compiler/xla/tools/benchmarks/hlo/` don't use f4e2m1fn.
On a trivial microbenchmark (bf16->f4e2m1fn conversion of a large buffer) leads to ~2x speedup.

🧪 Unit Tests: Yes.

🧪 Execution Tests: Yes.