### PR TITLE
[ROCm] Add cuda-only tag to cuda_library

### DIFF
--- a/third_party/gpus/cuda/build_defs.bzl.tpl
+++ b/third_party/gpus/cuda/build_defs.bzl.tpl
@@ -162,7 +162,10 @@ def cuda_library(copts = [], tags = [], deps = [], **kwargs):
     local_defines = kwargs.pop("local_defines", []) + ["register="]
     native.cc_library(
         copts = cuda_default_copts() + copts,
-        tags = tags + ["gpu"],
+        tags = tags + [
+            "gpu",
+            "cuda-only",
+        ],
         deps = deps + if_cuda_is_configured([
             "@local_config_cuda//cuda:implicit_cuda_headers_dependency",
         ]),


### PR DESCRIPTION
📝 Summary of Changes
Fix building xla with rocm.

🎯 Justification
Add cuda-only tag to cuda_library targets,
that will prevent building them when build with rocm config.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI, build fix

🧪 Execution Tests:
Not relevant
