### PR TITLE
[XLA:GPU] Fix block scaled dot global scaling for older cuDNN versions

### DIFF
--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -286,8 +286,9 @@ absl::Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
   }
 
   pre_pipeline.AddPass<BlockScalingRewriter>(
-      /*allow_cudnn=*/cuda_compute_capability.IsAtLeastBlackwell() &&
-      gpu_target_config.dnn_version_info >= se::dnn::VersionInfo(9, 7));
+      cuda_compute_capability.IsAtLeastBlackwell()
+          ? gpu_target_config.dnn_version_info
+          : se::dnn::VersionInfo{});
   pre_pipeline.AddPass<DotDimensionMerger>();
 
   if (!hlo_module->config()

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -311,6 +311,7 @@ cc_library(
         "//xla/service:shape_inference",
         "//xla/service/gpu:backend_configs_cc",
         "//xla/service/gpu:cublas_cudnn",
+        "//xla/stream_executor:dnn",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
@@ -350,6 +351,7 @@ xla_test(
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cudnn_header",
     ],
 )
 

--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -20,8 +20,12 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/transforms/expanders/op_expander_pass.h"
+#include "xla/stream_executor/dnn.h"
 
 namespace xla::gpu {
+
+const se::dnn::VersionInfo kCudnnSupportsBlockScaledDot(9, 7);
+const se::dnn::VersionInfo kCudnnSupportsBlockScaledDotWithGlobalScale(9, 13);
 
 // This pass converts the block quantize/dequantize operations (represented as
 // custom calls) to XLA graphs or library calls, if available (e.g. cuDNN).
@@ -68,8 +72,8 @@ namespace xla::gpu {
 //    config if the block scaled dimension is padded.
 class BlockScalingRewriter : public OpExpanderPass {
  public:
-  explicit BlockScalingRewriter(bool allow_cudnn)
-      : allow_cudnn_(allow_cudnn) {};
+  explicit BlockScalingRewriter(se::dnn::VersionInfo cudnn_version)
+      : cudnn_version_(cudnn_version){};
 
   absl::string_view name() const override { return "block-scaling-rewriter"; }
 
@@ -91,7 +95,7 @@ class BlockScalingRewriter : public OpExpanderPass {
   static constexpr int kBlockSizeNVFP4 = 16;
 
  private:
-  bool allow_cudnn_;
+  se::dnn::VersionInfo cudnn_version_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/status/status_matchers.h"
 #include "absl/strings/string_view.h"
+#include "third_party/gpus/cudnn/cudnn_version.h"
 #include "xla/error_spec.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/gpu/transforms/block_scaling_rewriter.h"
@@ -28,6 +29,11 @@ namespace {
 
 using BlockScalingRewriterCudnnTest =
     HloPjRtInterpreterReferenceMixin<HloPjRtTestBase>;
+
+const se::dnn::VersionInfo kCudnnDisabled;
+const se::dnn::VersionInfo kCudnnVersion(CUDNN_VERSION / 10000,
+                                         CUDNN_VERSION % 10000 / 100,
+                                         CUDNN_VERSION % 100);
 
 TEST_F(BlockScalingRewriterCudnnTest, Mxfp8) {
   constexpr absl::string_view hlo_string = R"(
@@ -46,20 +52,20 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        BlockScalingRewriter pass(kCudnnDisabled);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        BlockScalingRewriter pass(kCudnnVersion);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -80,20 +86,20 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        BlockScalingRewriter pass(kCudnnDisabled);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        BlockScalingRewriter pass(kCudnnVersion);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -118,20 +124,20 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        BlockScalingRewriter pass(kCudnnDisabled);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        BlockScalingRewriter pass(kCudnnVersion);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -162,20 +168,20 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        BlockScalingRewriter pass(kCudnnDisabled);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        BlockScalingRewriter pass(kCudnnVersion);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -203,20 +209,20 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/false);
+        BlockScalingRewriter pass(kCudnnDisabled);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(/*allow_cudnn=*/true);
+        BlockScalingRewriter pass(kCudnnVersion);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(false),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(true),
+  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
                             "CHECK: __cudnn$blockScaledDot");
 }
 

--- a/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
@@ -39,7 +39,7 @@ ENTRY main {
       custom_call_target="__op$quantize"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[input:%.+]] = f32[10,256]{1,0} parameter(0)
   CHECK: [[blocks:%.+]] = f32[10,8,32]{2,1,0} reshape([[input]])
@@ -69,7 +69,7 @@ ENTRY main {
       custom_call_target="__op$dequantize"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[input:%.+]] = f8e4m3fn[10,256]{1,0} parameter(0)
   CHECK: [[input_cvt:%.+]] = f32[10,256]{1,0} convert([[input]])
@@ -94,7 +94,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,1,0} convert([[lhs_quant]])
@@ -130,7 +130,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,1,0} convert([[lhs_quant]])
@@ -168,7 +168,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,0,1} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,0,1} convert([[lhs_quant]])
@@ -202,7 +202,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[16,256]{1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f16[16,256]{1,0} convert([[lhs_quant]])
@@ -231,7 +231,7 @@ ENTRY main {
       backend_config={"block_scaled_dot_backend_config":{block_size:32}}
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,224]{2,1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,224]{2,1,0} convert([[lhs_quant]])
@@ -270,7 +270,7 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(auto test_module,
                           ParseAndReturnUnverifiedModule(hlo_test));
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/false);
+  BlockScalingRewriter pass(se::dnn::VersionInfo{});
   TF_ASSERT_OK_AND_ASSIGN(
       auto changed, pass.Run(test_module.get(), /*execution_threads=*/{}));
   EXPECT_TRUE(changed);
@@ -302,7 +302,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/true);
+  BlockScalingRewriter pass(kCudnnSupportsBlockScaledDot);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs:%.+]] = f8e4m3fn[4,128,128]{2,1,0} parameter(0)
   CHECK: [[rhs:%.+]] = f8e4m3fn[4,128,128]{2,1,0} parameter(1)
@@ -333,7 +333,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/true);
+  BlockScalingRewriter pass(kCudnnSupportsBlockScaledDot);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs:%.+]] = f8e4m3fn[128,96]{1,0} parameter(0)
   CHECK: [[lhs_rs:%.+]] = f8e4m3fn[1,128,96]{2,1,0} reshape([[lhs]])
@@ -373,7 +373,7 @@ ENTRY main {
       backend_config={"block_scaled_dot_backend_config":{block_size:32}}
 })";
 
-  BlockScalingRewriter pass(/*allow_cudnn=*/true);
+  BlockScalingRewriter pass(kCudnnSupportsBlockScaledDot);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs:%.+]] = f8e4m3fn[4,120,96]{2,1,0} parameter(0)
   CHECK: [[lhs_pad:%.+]] = f8e4m3fn[4,128,96]{2,1,0} pad([[lhs]], {{.+}}), padding=0_0x0_8x0_0


### PR DESCRIPTION
📝 Summary of Changes
Pass cuDNN version to the `BlockScalingRewriter` pass, and make lowering decisions based on that.

🎯 Justification
The global scaling factor doesn't work before cuDNN v9.13 (the graph is compiled, but the scaling factor is not applied).
Use the slower lowering (apply global scaling factor outside the fusion) in this case.

🚀 Kind of Contribution
🐛 Bug Fix
