### PR TITLE
correctly use the completion queue

### DIFF
--- a/xla/tsl/profiler/rpc/client/profiler_client.cc
+++ b/xla/tsl/profiler/rpc/client/profiler_client.cc
@@ -96,73 +96,61 @@ absl::Status MonitorGrpc(const std::string& service_address,
 
 /*static*/ std::unique_ptr<RemoteProfilerSession> RemoteProfilerSession::Create(
     const std::string& service_address, absl::Time deadline,
-    const ProfileRequest& profile_request) {
-  auto instance = absl::WrapUnique(
-      new RemoteProfilerSession(service_address, deadline, profile_request));
-  instance->ProfileAsync();
+    const ProfileRequest& profile_request, ::grpc::CompletionQueue* cq,
+    int64 client_id) {
+  auto instance = absl::WrapUnique(new RemoteProfilerSession(
+      service_address, deadline, profile_request, client_id));
+  instance->ProfileAsync(cq);
   return instance;
 }
 
 RemoteProfilerSession::RemoteProfilerSession(
     const std::string& service_address, absl::Time deadline,
-    const ProfileRequest& profile_request)
+    const ProfileRequest& profile_request, int64 client_id)
     : response_(absl::make_unique<ProfileResponse>()),
       service_address_(service_address),
       stub_(CreateStub<tensorflow::grpc::ProfilerService>(service_address_)),
       deadline_(deadline),
+      client_id_(client_id),
       profile_request_(profile_request) {
   response_->set_empty_trace(true);
 }
 
 RemoteProfilerSession::~RemoteProfilerSession() {
   absl::Status dummy;
-  WaitForCompletion(dummy);
   grpc_context_.TryCancel();
 }
 
-void RemoteProfilerSession::ProfileAsync() {
+void RemoteProfilerSession::ProfileAsync(::grpc::CompletionQueue* cq) {
   LOG(INFO) << "Asynchronous gRPC Profile() to " << service_address_;
   grpc_context_.set_deadline(absl::ToChronoTime(deadline_));
   VLOG(1) << "Deadline set to " << deadline_;
-  rpc_ = stub_->AsyncProfile(&grpc_context_, profile_request_, &cq_);
+  rpc_ = stub_->AsyncProfile(&grpc_context_, profile_request_, cq);
   // Connection failure will create lame channel whereby grpc_status_ will be an
   // error.
-  rpc_->Finish(response_.get(), &grpc_status_,
-               static_cast<void*>(&status_on_completion_));
+  rpc_->Finish(response_.get(), &grpc_status_, (void*)this->client_id_);
   VLOG(2) << "Asynchronous gRPC Profile() issued." << absl::Now();
 }
 
-std::unique_ptr<ProfileResponse> RemoteProfilerSession::WaitForCompletion(
-    absl::Status& out_status) {
-  if (!response_) {
-    out_status = errors::FailedPrecondition(
-        "WaitForCompletion must only be called once.");
-    return nullptr;
-  }
-  LOG(INFO) << "Waiting for completion.";
-
-  void* got_tag = nullptr;
-  bool ok = false;
-  // Next blocks until there is a response in the completion queue. Expect the
-  // completion queue to have exactly a single response because deadline is set
-  // and completion queue is only drained once at destruction time.
-  bool success = cq_.Next(&got_tag, &ok);
-  if (!success || !ok || got_tag == nullptr) {
+std::unique_ptr<ProfileResponse> RemoteProfilerSession::HandleCompletion(
+    absl::Status& out_status, void* got_tag, bool ok) {
+  VLOG(2) << "Received completion event for client " << this->client_id_
+          << " at " << this->service_address_;
+  if (!ok || got_tag == nullptr) {
     out_status =
-        errors::Internal("Missing or invalid event from completion queue.");
+        absl::InternalError("Missing or invalid event from completion queue.");
     return nullptr;
   }
-
-  VLOG(1) << "Writing out status.";
-  // For the event read from the completion queue, expect that got_tag points to
-  // the memory location of status_on_completion.
-  DCHECK_EQ(got_tag, &status_on_completion_);
+  DCHECK_EQ(got_tag, (void*)this->client_id_);
   // tagged status points to pre-allocated memory which is okay to overwrite.
   status_on_completion_.Update(FromGrpcStatus(grpc_status_));
+
   if (status_on_completion_.code() == error::DEADLINE_EXCEEDED) {
-    LOG(WARNING) << status_on_completion_;
+    LOG(WARNING) << status_on_completion_ << " from client " << this->client_id_
+                 << " at " << this->service_address_;
   } else if (!status_on_completion_.ok()) {
-    LOG(ERROR) << status_on_completion_;
+    LOG(ERROR) << status_on_completion_ << " from client " << this->client_id_
+               << " at " << this->service_address_;
   }
 
   out_status = status_on_completion_;

--- a/xla/tsl/profiler/rpc/client/profiler_client.cc
+++ b/xla/tsl/profiler/rpc/client/profiler_client.cc
@@ -136,7 +136,7 @@ std::unique_ptr<ProfileResponse> RemoteProfilerSession::HandleCompletion(
     absl::Status& out_status, void* got_tag, bool ok) {
   VLOG(2) << "Received completion event for client " << this->client_id_
           << " at " << this->service_address_;
-  if (!ok || got_tag == nullptr) {
+  if (!ok) {
     out_status =
         absl::InternalError("Missing or invalid event from completion queue.");
     return nullptr;

--- a/xla/tsl/profiler/rpc/client/profiler_client.h
+++ b/xla/tsl/profiler/rpc/client/profiler_client.h
@@ -61,10 +61,17 @@ class RemoteProfilerSession {
 
   absl::string_view GetServiceAddress() const { return service_address_; }
 
+  // Processes a completion event that has been received from the gRPC
+  // completion queue. Updates internal state with the final status and returns
+  // the response. Subsequent calls after the first will yield nullptr and an
+  // error status.
   std::unique_ptr<tensorflow::ProfileResponse> HandleCompletion(
       absl::Status& out_status, void* got_tag, bool ok);
 
  private:
+  // Constructs a new RemoteProfilerSession instance.
+  // client_id is a unique identifier used as a tag for gRPC completion queue
+  // operations.
   explicit RemoteProfilerSession(
       const std::string& service_addr, absl::Time deadline,
       const tensorflow::ProfileRequest& profile_request, int64 client_id);

--- a/xla/tsl/profiler/rpc/client/profiler_client.h
+++ b/xla/tsl/profiler/rpc/client/profiler_client.h
@@ -50,7 +50,8 @@ class RemoteProfilerSession {
   // Response must outlive the instantiation.
   static std::unique_ptr<RemoteProfilerSession> Create(
       const std::string& service_address, absl::Time deadline,
-      const tensorflow::ProfileRequest& profile_request);
+      const tensorflow::ProfileRequest& profile_request,
+      ::grpc::CompletionQueue* cq, int64 client_id);
 
   // Not copyable or movable.
   RemoteProfilerSession(const RemoteProfilerSession&) = delete;
@@ -60,23 +61,20 @@ class RemoteProfilerSession {
 
   absl::string_view GetServiceAddress() const { return service_address_; }
 
-  // Blocks until a response has been received or until deadline expiry,
-  // whichever is first. Subsequent calls after the first will yield nullptr and
-  // an error status.
-  std::unique_ptr<tensorflow::ProfileResponse> WaitForCompletion(
-      absl::Status& out_status);
+  std::unique_ptr<tensorflow::ProfileResponse> HandleCompletion(
+      absl::Status& out_status, void* got_tag, bool ok);
 
  private:
   explicit RemoteProfilerSession(
       const std::string& service_addr, absl::Time deadline,
-      const tensorflow::ProfileRequest& profile_request);
+      const tensorflow::ProfileRequest& profile_request, int64 client_id);
 
   // Starts a remote profiling session. This is a non-blocking call.
   // Will be called exactly once during instantiation.
   // RPC will write to response.profile_response eagerly. However, since
   // response.status requires a conversion from grpc::Status, it can only be
   //  evaluated lazily at WaitForCompletion() time.
-  void ProfileAsync();
+  void ProfileAsync(::grpc::CompletionQueue* cq);
 
   absl::Status status_on_completion_;
   std::unique_ptr<tensorflow::ProfileResponse> response_;
@@ -90,8 +88,7 @@ class RemoteProfilerSession {
       rpc_;
   ::grpc::Status grpc_status_ = ::grpc::Status::OK;
 
-  // Asynchronous completion queue states.
-  ::grpc::CompletionQueue cq_;
+  int64 client_id_;
 
   tensorflow::ProfileRequest profile_request_;
 };

--- a/xla/tsl/profiler/rpc/client/remote_profiler_session_manager.h
+++ b/xla/tsl/profiler/rpc/client/remote_profiler_session_manager.h
@@ -77,6 +77,8 @@ class RemoteProfilerSessionManager {
       TF_GUARDED_BY(mutex_);
   // Resolves an address into a format that gRPC understands.
   AddressResolver resolver_ TF_GUARDED_BY(mutex_);
+
+  ::grpc::CompletionQueue cq_;
 };
 
 }  // namespace profiler


### PR DESCRIPTION
📝 Summary of Changes
Fixed a scalability issue in the asynchronous gRPC profiling client where each RemoteProfilerSession used its own CompletionQueue, causing "UNAVAILABLE" errors (e.g., gRPC connection failures) beyond 64 concurrent sessions. Now uses a single shared CompletionQueue managed by RemoteProfilerSessionManager, with client_id tags for event tracking, non-blocking HandleCompletion processing, and enhanced error logging. Key updates: pass shared CQ to sessions, tag events by ID, and dispatch completions via manager loop.

🎯 Justification
This change prevents profiling failures in high-concurrency environments, such as distributed training with multiple sessions (e.g., multi-GPU workflows). It improves reliability and scalability for XLA's remote profiling, benefiting workloads like large-scale ML training where concurrent profiling is common, reducing downtime and enabling better performance debugging.
- If having to use the async completion-queue API, the best scalability trade-off is having numcpu’s threads. The ideal number of completion queues in relation to the number of threads can change over time (as gRPC C++ evolves), but as of gRPC 1.41 (Sept 2021), using 2 threads per completion queue seems to give the best performance. (https://grpc.io/docs/guides/performance/)


🚀 Kind of Contribution
 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
None

🧪 Unit Tests:
Reusing the same unit test, xla/tsl/profiler/rpc/client/remote_profiler_session_manager_test.cc
xla/tsl/profiler/rpc/client/profiler_client_test.cc

