### PR TITLE
[ROCm] Use working sha256 for latest ROCm 7.0 docker image and fix test scripts

### DIFF
--- a/build_tools/rocm/platform/linux_x64/BUILD
+++ b/build_tools/rocm/platform/linux_x64/BUILD
@@ -26,7 +26,8 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://rocm/tensorflow-build:latest-jammy-python3.10-rocm6.4.0@sha256:9c2fbc861570735fc86dbf39dd3cefef6a13fcf6ae08358271af52f1aebd4248",
+        # SHA256 for rocm/tensorflow-build:latest-jammy-python3.10-rocm7.0.0
+        "container-image": "docker://rocm/tensorflow-build@sha256:7cd444ac48657fee2f5087fbda7766266704d3f8fb2299f681952ae4eabed060",
         "OSFamily": "Linux",
     },
 )

--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -72,5 +72,6 @@ bazel \
     --action_env=TF_ROCM_AMDGPU_TARGETS=${AMD_GPU_GFX_ID} \
     --action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
     --action_env=XLA_FLAGS=--xla_gpu_enable_llvm_module_compilation_parallelism=true \
+    --repo_env="ROCM_PATH=$ROCM_PATH" \
     --run_under=//build_tools/ci:parallel_gpu_execute \
     -- //xla/...

--- a/build_tools/rocm/run_xla_multi_gpu.sh
+++ b/build_tools/rocm/run_xla_multi_gpu.sh
@@ -90,6 +90,7 @@ bazel \
     --action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
     --action_env=XLA_FLAGS=--xla_gpu_enable_llvm_module_compilation_parallelism=true \
     --action_env=NCCL_MAX_NCHANNELS=1 \
+    --repo_env="ROCM_PATH=$ROCM_PATH" \
     -- //xla/tests:collective_ops_e2e_test \
        //xla/tests:collective_ops_test \
        //xla/tests:collective_pipeline_parallelism_test \


### PR DESCRIPTION
📝 Summary of Changes
- Fix sha256 of docker image to ensure CI is not broken due to malformed image
- Fix test scripts by passing ROCM_PATH to bazel sandbox via repo_env

🎯 Justification
Continued CI runs

🚀 Kind of Contribution
 🧪 Tests

