### PR TITLE
[XLA:GPU] Enable command buffer DynamicSliceCopyFusion command unrolling

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -2718,8 +2718,12 @@ DynamicSliceCopyFusionCmd::Record(const Thunk::ExecuteParams& execute_params,
       [&](const se::CommandBuffer::Command* command) {
         int64_t iteration_index = 0;
         if (offsets_.depends_on_loop) {
-          TF_ASSIGN_OR_RETURN(iteration_index,
-                              WhileThunk::CurrentLoopIteration());
+          if (WhileThunk::RunningWhileThunkLoop()) {
+            TF_ASSIGN_OR_RETURN(iteration_index,
+                                WhileThunk::CurrentLoopIteration());
+          } else {
+            iteration_index = record_params.unroll_iteration;
+          }
         }
         int64_t src_offset = offsets_.src_offsets[iteration_index];
         int64_t dst_offset = offsets_.dst_offsets[iteration_index];

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -1295,7 +1295,7 @@ class DynamicSliceCopyFusionCmd : public CommandBufferCmd {
 
   bool force_update() override { return offsets_.depends_on_loop; }
 
-  bool support_loop_unroll() override { return false; }
+  bool support_loop_unroll() override { return true; }
 
   BufferUseVector buffers() const override;
 

--- a/xla/backends/gpu/runtime/while_thunk.cc
+++ b/xla/backends/gpu/runtime/while_thunk.cc
@@ -61,6 +61,8 @@ static std::list<RunningLoop>& RunningLoops() {
   return loops;
 }
 
+bool WhileThunk::RunningWhileThunkLoop() { return RunningLoops().size() > 0; }
+
 absl::StatusOr<int64_t> WhileThunk::CurrentLoopIteration(int64_t depth) {
   if (depth >= RunningLoops().size()) {
     return absl::InvalidArgumentError(absl::StrFormat(

--- a/xla/backends/gpu/runtime/while_thunk.h
+++ b/xla/backends/gpu/runtime/while_thunk.h
@@ -87,6 +87,7 @@ class WhileThunk : public Thunk {
   //
   // Implementation relies on thread local storage, be careful when call it from
   // code running on multiple threads.
+  static bool RunningWhileThunkLoop();
   static absl::StatusOr<int64_t> CurrentLoopIteration(int64_t depth = 0);
   static absl::StatusOr<int64_t> CurrentLoopIteration(
       const HloInstruction* while_instr);


### PR DESCRIPTION
📝 Summary of Changes
This PR enables command buffer DynamicSliceCopy command to be recorded into an unrolled cuda-graph, when it is surrounded by WhileCmd


🎯 Justification
This feature is required if we want to fully command buffer WhileCmd into an unrolled cuda-graph.


🚀 Kind of Contribution
Please remove what does not apply: 
✨ New Feature



🧪 Unit Tests:
xla/backends/gpu/runtime/command_buffer_cmd_test.cc: CommandBufferCmdTest:DynamicSliceCopyFusionCmd
