### PR TITLE
[XLA:GPU] add conv fusion support in cudnn fusion compiler

### DIFF
--- a/xla/backends/gpu/codegen/cudnn_test.cc
+++ b/xla/backends/gpu/codegen/cudnn_test.cc
@@ -883,9 +883,9 @@ fusion {
 ENTRY Test {
   input = f32[2,9,9,17] parameter(0)
   filter = f32[32,3,3,17] parameter(1)
-  ROOT conv = f32[2,9,9,32] fusion(input, filter), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config": {kind: "__cudnn$fusion", cudnn_fusion_config: {"name":"conv_fprop"}}}
+  ROOT conv = f32[2,9,9,32] fusion(input, filter), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config": {kind: "__cudnn$fusion", cudnn_fusion_config: {"kind":"CONV_FPROP"}}}
 })",
-                            ErrorSpec{/*aabs=*/1e-2, /*arel=*/1e-3}));
+                            ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-5}));
 }
 
 TEST_F(CuDnnFusionExecutionTest, ConvWgradWithNHWCLayoutExecutesCorrectly) {
@@ -903,14 +903,25 @@ fusion {
 ENTRY Test {
   input = f32[2,9,9,17] parameter(0)
   dout = f32[2,9,9,32] parameter(1)
-  ROOT conv = f32[32,3,3,17] fusion(input, dout), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config": {kind: "__cudnn$fusion", cudnn_fusion_config: {"name":"conv_wgrad"}}}
+  ROOT conv = f32[32,3,3,17] fusion(input, dout), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config": {kind: "__cudnn$fusion", cudnn_fusion_config: {"kind":"CONV_WGRAD"}}}
 })",
-                            ErrorSpec{/*aabs=*/1e-2, /*arel=*/1e-3}));
+                            ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-5}));
 }
 
 TEST_F(CuDnnFusionExecutionTest, ConvDgradWithNHWCLayoutExecutesCorrectly) {
   // TODO: needs to be fixed here because a reverse of filter is missing
-  EXPECT_TRUE(RunAndCompare(R"(
+  const std::string kHloReference = R"(
+ENTRY main {
+  zero = f32[] constant(0)
+  zeros = f32[2,9,9,17] broadcast(zero), dimensions={}
+  dout = f32[2,9,9,32] parameter(0)
+  filter = f32[32,3,3,17] parameter(1)
+  reverse = f32[32,3,3,17] reverse(filter), dimensions={1,2}
+  conv = f32[2,9,9,17] convolution(dout, reverse), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_i01o->b01f, feature_group_count=1
+  ROOT relu = f32[2,9,9,17] maximum(zeros, conv)
+})";
+
+  const std::string kHlo = R"(
 fusion {
   zero = f32[] constant(0)
   zeros = f32[2,9,9,17] broadcast(zero), dimensions={}
@@ -924,9 +935,11 @@ fusion {
 ENTRY Test {
   dout = f32[2,9,9,32] parameter(0)
   filter = f32[32,3,3,17] parameter(1)
-  ROOT conv = f32[2,9,9,17] fusion(dout, filter), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config": {kind: "__cudnn$fusion", cudnn_fusion_config: {"name":"conv_dgrad"}}}
-})",
-                            ErrorSpec{/*aabs=*/1, /*arel=*/1e-3}));
+  ROOT conv = f32[2,9,9,17] fusion(dout, filter), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config": {kind: "__cudnn$fusion", cudnn_fusion_config: {"kind":"CONV_DGRAD"}}}
+})";
+
+  EXPECT_TRUE(RunAndCompareTwoModules(kHlo, kHloReference,
+                                      ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-5}));
 }
 
 class ElementwiseTest : public CuDnnFusionExecutionTest,
@@ -1252,6 +1265,63 @@ CHECK: "stride": [{{[[:space:]]*1,[[:space:]]*1,[[:space:]]*4[[:space:]]*}}]
 )"));
 }
 
+TEST_F(CuDnnFusionFileCheckTest, ConvFpropGraphConvertedCorrectly) {
+  const std::string kHloText = R"(
+fusion {
+  input = f32[2,9,9,17] parameter(0)
+  filter = f32[32,3,3,17] parameter(1)
+  ROOT conv = f32[2,9,9,32] convolution(input, filter), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, feature_group_count=1
+}
+
+
+ENTRY Test {
+  input = f32[2,9,9,17] parameter(0)
+  filter = f32[32,3,3,17] parameter(1)
+  ROOT conv = f32[2,9,9,32] fusion(input, filter), kind=kCustom, calls=fusion, backend_config={"fusion_backend_config": {kind: "__cudnn$fusion", cudnn_fusion_config: {"kind":"CONV_FPROP"}}}
+})";
+
+  EXPECT_TRUE(*RunCuDnnFileCheck(kHloText, R"(
+CHECK: "nodes": [
+CHECK:  {
+CHECK:   "compute_data_type": "FLOAT",
+CHECK:   "dilation": [{{[[:space:]]*1,[[:space:]]*1[[:space:]]*}}],
+CHECK:   "inputs": {
+CHECK:    "W": "filter",
+CHECK:    "X": "input"
+CHECK:   },
+CHECK:   "math_mode": "CROSS_CORRELATION",
+CHECK:   "name": "0",
+CHECK:   "outputs": {
+CHECK:    "Y": "conv"
+CHECK:   },
+CHECK:   "post_padding": [{{[[:space:]]*1,[[:space:]]*1[[:space:]]*}}],
+CHECK:   "pre_padding": [{{[[:space:]]*1,[[:space:]]*1[[:space:]]*}}],
+CHECK:   "stride": [{{[[:space:]]*1,[[:space:]]*1[[:space:]]*}}],
+CHECK:   "tag": "CONV_FPROP"
+CHECK:  }
+CHECK: ],
+CHECK:"tensors": {
+CHECK:  "conv": {
+CHECK:   "data_type": "FLOAT",
+CHECK:   "dim": [{{[[:space:]]*2,[[:space:]]*32,[[:space:]]*9,[[:space:]]*9[[:space:]]*}}],
+CHECK:   "name": "conv",
+CHECK:   "stride": [{{[[:space:]]*2592,[[:space:]]*1,[[:space:]]*288,[[:space:]]*32[[:space:]]*}}],
+CHECK:  },
+CHECK:  "filter": {
+CHECK:   "data_type": "FLOAT",
+CHECK:   "dim": [{{[[:space:]]*32,[[:space:]]*17,[[:space:]]*3,[[:space:]]*3[[:space:]]*}}],
+CHECK:   "name": "filter",
+CHECK:   "stride": [{{[[:space:]]*153,[[:space:]]*1,[[:space:]]*51,[[:space:]]*17[[:space:]]*}}],
+CHECK:  },
+CHECK:  "input": {
+CHECK:   "data_type": "FLOAT",
+CHECK:   "dim": [{{[[:space:]]*2,[[:space:]]*17,[[:space:]]*9,[[:space:]]*9[[:space:]]*}}],
+CHECK:   "name": "input",
+CHECK:   "stride": [{{[[:space:]]*1377,[[:space:]]*1,[[:space:]]*153,[[:space:]]*17[[:space:]]*}}],
+CHECK:  }
+CHECK: }
+)"));
+}
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/backends/gpu/codegen/cudnn_test.cc
+++ b/xla/backends/gpu/codegen/cudnn_test.cc
@@ -909,7 +909,6 @@ ENTRY Test {
 }
 
 TEST_F(CuDnnFusionExecutionTest, ConvDgradWithNHWCLayoutExecutesCorrectly) {
-  // TODO: needs to be fixed here because a reverse of filter is missing
   const std::string kHloReference = R"(
 ENTRY main {
   zero = f32[] constant(0)

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -171,8 +171,13 @@ message CustomFusionConfig {
 message CuDnnFusionConfig {
   int64 plan_id = 1;
 
-  // Specify the conv_fprop/conv_wgrad/conv_dgrad for conv fusion
-  string name = 2;
+  // Conv type.
+  enum Kind {
+    CONV_FPROP = 0;
+    CONV_WGRAD = 1;
+    CONV_DGRAD = 2;
+  }
+  Kind kind = 2;
 }
 
 // Output tile sizes for a fusion root.

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -170,6 +170,9 @@ message CustomFusionConfig {
 
 message CuDnnFusionConfig {
   int64 plan_id = 1;
+
+  // Specify the conv_fprop/conv_wgrad/conv_dgrad for conv fusion
+  string name = 2;
 }
 
 // Output tile sizes for a fusion root.

--- a/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
@@ -828,7 +828,7 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
     output = instructions.back()->operand(0);
   }
 
-  std::optional<Result> dims =
+  const std::optional<Result> dims =
       conv_adapter.has_value()
           ? conv_adapter->DimensionsAndStrides(*output)
           : gemm_adapter->DimensionsAndStrides(
@@ -842,7 +842,6 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
       .set_dim(dims->sizes)
       .set_stride(dims->strides)
       .set_uid(se::gpu::CuDnnTensorUID(fusion.operand_count()));
-
   if (!fusion.GetModule()->config().debug_options().xla_dump_to().empty()) {
     json dump;
     graph.serialize(dump);


### PR DESCRIPTION
📝 Summary of Changes
This PR adds conv fusion support in cudnn fusion compiler.

* add conv type in `CuDnnFusionConfig` to represent different types of conv. We are getting rid of the conv custom call target so this info has be preserved in fusion config.
* add `ConvDimensionAdapter` to generate NCHW **logical layout** for cudnn frontend while physical layout could be NHWC (most preferable layout) or NCHW (for int conv). Only NHWC layout is used in the unit tests because layout assignment currently doesn't handle conv fusion to transform other layouts to NHWC, this needs to be addressed in separate PR.
* add conv translation rule from XLA conv to cudnn frontend graph API.
* Other parts of the lowering is taken care automatically by current cudnn fusion compiler: workspace allocation/graph validation/graph  compilation/graph serialization.

🎯 Justification
This is the first step to unify the conv as cudnn fusion in XLA. Conv custom call will be replaced with conv fusions in the future.

🚀 Kind of Contribution
✨ New Feature

📊 Benchmark (for Performance Improvements)
No Performance changes are expected.

🧪 Unit Tests:
Added 3 hand written NHWC conv unit tests for conv_fprop/conv_dgrad/conv_wgrad.

🧪 Execution Tests:
Added 3 hand written NHWC conv unit tests for conv_fprop/conv_dgrad/conv_wgrad.