### PR TITLE
[ROCM] Adding grid-stride loops for buffer comparator and redzone checker kernels

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -2248,6 +2248,7 @@ xla_test(
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",
         "//xla/tsl/platform:status",
+        "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",

--- a/xla/backends/gpu/runtime/buffer_comparator.cc
+++ b/xla/backends/gpu/runtime/buffer_comparator.cc
@@ -48,6 +48,7 @@ namespace gpu {
 struct ComparisonParams {
   double relative_tol = 0.1;
   bool verbose = true;
+  bool run_host_compare = true;
   const Shape* shape = nullptr;
   se::Stream* stream = nullptr;
   se::DeviceMemoryBase current{};
@@ -85,6 +86,12 @@ static absl::StatusOr<bool> DeviceCompare(const ComparisonParams& params) {
 
   LaunchDimensions dim =
       CalculateLaunchDimensions(*params.shape, gpu_device_info);
+  // Limit # of blocks to some meaningful number which is large enough to
+  // occupy all GPU cores if necessary but not too large to reduce # of idle
+  // blocks
+  dim = LaunchDimensions(se::BlockDim(std::min(dim.num_blocks(), 
+        BufferComparator::kMaxNumThreadBlocksForKernel), 1, 1),
+        dim.thread_counts_per_block());
 
   se::DeviceMemory<uint64_t> as_uint64(out.memory());
   TF_RETURN_IF_ERROR(comparison_kernel.Launch(
@@ -161,9 +168,8 @@ static absl::StatusOr<bool> CompareEqualParameterized(
     const ComparisonParams& params) {
   XLA_SCOPED_LOGGING_TIMER("BufferComparator::CompareEqual");
   TF_ASSIGN_OR_RETURN(bool result, DeviceCompare<ElementT>(params));
-  if (result) {
-    return true;
-  }
+  if (result) return true;
+  if (!params.run_host_compare) return false;
 
   TF_ASSIGN_OR_RETURN(bool host_return,
                       (HostCompare<ElementT, ComparisonT>(params)));
@@ -173,10 +179,10 @@ static absl::StatusOr<bool> CompareEqualParameterized(
 }
 
 absl::StatusOr<bool> BufferComparator::CompareEqual(
-    se::Stream* stream, se::DeviceMemoryBase current,
-    se::DeviceMemoryBase expected) const {
-  ComparisonParams params{relative_tol_, verbose_, &shape_,
-                          stream,        current,  expected};
+    se::Stream* stream, const se::DeviceMemoryBase& current,
+    const se::DeviceMemoryBase& expected) const {
+  ComparisonParams params{relative_tol_, verbose_, run_host_compare_,
+                          &shape_, stream, current, expected};
 
   auto do_compare = [&](auto cst_type) {
     using ElementT = primitive_util::NativeTypeOf<cst_type>;
@@ -206,8 +212,9 @@ absl::StatusOr<bool> BufferComparator::CompareEqual(
 }
 
 BufferComparator::BufferComparator(const Shape& shape, double tolerance,
-                                   bool verbose)
-    : shape_(shape), relative_tol_(tolerance), verbose_(verbose) {
+                                   bool verbose, bool run_host_compare)
+    : shape_(shape), relative_tol_(tolerance), verbose_(verbose),
+      run_host_compare_(run_host_compare) {
   // Normalize complex shapes: since we treat the passed array as a contiguous
   // storage it does not matter which dimension are we doubling.
   auto double_dim_size = [&]() {

--- a/xla/backends/gpu/runtime/buffer_comparator.h
+++ b/xla/backends/gpu/runtime/buffer_comparator.h
@@ -26,11 +26,14 @@ namespace xla::gpu {
 // A device-side comparator that compares buffers.
 class BufferComparator {
  public:
+  // Maximum number of thread blocks to be used for comparator kernel
+  static constexpr uint64_t kMaxNumThreadBlocksForKernel = 32768;
+
   BufferComparator(const BufferComparator&) = delete;
-  BufferComparator(BufferComparator&&) = default;
+  BufferComparator(BufferComparator&&) noexcept = default;
 
   explicit BufferComparator(const Shape& shape, double tolerance = 0.1,
-                            bool verbose = true);
+                            bool verbose = true, bool run_host_compare = true);
 
   // Returns true if the two buffers compare equal. The definition of "equal"
   // is:
@@ -42,12 +45,14 @@ class BufferComparator {
   //
   // See the implementation for the tolerance value.
   absl::StatusOr<bool> CompareEqual(se::Stream* stream,
-                                    se::DeviceMemoryBase current,
-                                    se::DeviceMemoryBase expected) const;
+                                    const se::DeviceMemoryBase& current,
+                                    const se::DeviceMemoryBase& expected) const;
  private:
   Shape shape_;
-  double relative_tol_;  // relative tolerance for comparison
-  bool verbose_;         // whether to print out error message on mismatch
+  double relative_tol_;   // relative tolerance for comparison
+  bool verbose_;          // whether to print out error message on mismatch
+  // enable host-side compare if device compare reports a mismatch
+  bool run_host_compare_; 
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/buffer_comparator_test.cc
+++ b/xla/backends/gpu/runtime/buffer_comparator_test.cc
@@ -449,37 +449,41 @@ TEST_F(BufferComparatorTest, BF16) {
 }
 
 TEST_F(BufferComparatorTest, VeryLargeArray) {
-  constexpr PrimitiveType number_type = U16;
+  constexpr PrimitiveType number_type = U8;
   using NT = primitive_util::PrimitiveTypeToNative< number_type >::type;
 
-  // Set non-power-of-two element count on purpose
-  int64_t element_count = (1LL << 34) - 11;
+  // Set non-power-of-two element count on purpose, use aligned byffer siuze
+  int64_t n_elems = (1LL << 33) - 11,
+  // Buffer size must be 4-bytes aligned for Memset32
+          buf_size = (((n_elems + 1) * sizeof(NT)) + 3) & ~3;
   auto stream = stream_exec_->CreateStream().value();
 
   // Use host memory here since there is a limitation of 4GB per test on
   // device memory alloc
   TF_ASSERT_OK_AND_ASSIGN(
     auto base, 
-    stream_exec_->HostMemoryAllocate((element_count + 1) * sizeof(NT)));
+    stream_exec_->HostMemoryAllocate(buf_size));
 
   // We use overlapping lhs and rhs arrays to reduce memory usage, also this 
   // serves as an extra test for possible pointer aliasing problems
-  se::DeviceMemoryBase lhs(base->opaque(), base->size() - sizeof(NT)),
+  se::DeviceMemoryBase lhs(base->opaque(), n_elems * sizeof(NT)),
                        rhs(static_cast< NT *>(base->opaque()) + 1, lhs.size());
 
-  TF_CHECK_OK(stream->Memset32(&lhs, 0xABCDABCD, base->size()));
+  constexpr uint32_t pattern = 0xABABABAB;
+  TF_CHECK_OK(stream->Memset32(&lhs, pattern, buf_size));
 
-  // Disable host comparison here since it could take a while for ~8GB array
-  BufferComparator comparator(ShapeUtil::MakeShape(number_type, {element_count}),
+  // First we do "positive" test to make sure lhs and rhs are indeed equal:
+  // disable host comparison here since it could take a while for ~8GB array
+  BufferComparator comparator(ShapeUtil::MakeShape(number_type, {n_elems}),
        /*tolerance*/0.1, /* verbose */false, /*run_host_compare*/false);
   EXPECT_TRUE(comparator.CompareEqual(stream.get(), lhs, rhs).value());
 
-  auto slice = rhs.GetByteSlice(element_count*sizeof(NT) - sizeof(uint32_t), 
-        sizeof(uint32_t));
+  se::DeviceMemoryBase last_word(static_cast< uint8_t *>(base->opaque()) +
+                (n_elems & ~3), sizeof(uint32_t));
   // Change only the very last entry of rhs to verify that the whole arrays are 
   // compared (if the grid dimensions are not computed correctly, this might
-  // not be the case). Account for little-endian: [CD AB 77 17].
-  TF_CHECK_OK(stream->Memset32(&slice, 0x1777ABCD, slice.size()));
+  // not be the case). 
+  TF_CHECK_OK(stream->Memset32(&last_word, 0x11223344, last_word.size()));
   EXPECT_FALSE(comparator.CompareEqual(stream.get(), lhs, rhs).value());
 }
 

--- a/xla/backends/gpu/runtime/buffer_comparator_test.cc
+++ b/xla/backends/gpu/runtime/buffer_comparator_test.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/cleanup/cleanup.h"
 #include "absl/strings/ascii.h"
 #include "absl/types/span.h"
 #include "xla/primitive_util.h"
@@ -452,33 +453,32 @@ TEST_F(BufferComparatorTest, VeryLargeArray) {
   constexpr PrimitiveType number_type = U8;
   using NT = primitive_util::PrimitiveTypeToNative< number_type >::type;
 
-  // Set non-power-of-two element count on purpose, use aligned byffer siuze
-  int64_t n_elems = (1LL << 33) - 11,
-  // Buffer size must be 4-bytes aligned for Memset32
-          buf_size = (((n_elems + 1) * sizeof(NT)) + 3) & ~3;
+  // Set non-power-of-two element count on purpose, use aligned buffer size.
+  int64_t n_elems = (1LL << 32) - 11,
+  // Buffer size must be 4-bytes aligned for Memset32.
+        buf_size = (((n_elems + 1) * sizeof(NT)) + 3) & ~3;
   auto stream = stream_exec_->CreateStream().value();
 
-  // Use host memory here since there is a limitation of 4GB per test on
-  // device memory alloc
-  TF_ASSERT_OK_AND_ASSIGN(
-    auto base, 
-    stream_exec_->HostMemoryAllocate(buf_size));
+  auto base = stream_exec_->Allocate(buf_size);
+  EXPECT_TRUE(!base.is_null());
+  auto cleanup = absl::MakeCleanup([this, &base] 
+                                  { stream_exec_->Deallocate(&base); });
 
   // We use overlapping lhs and rhs arrays to reduce memory usage, also this 
-  // serves as an extra test for possible pointer aliasing problems
-  se::DeviceMemoryBase lhs(base->opaque(), n_elems * sizeof(NT)),
-                       rhs(static_cast< NT *>(base->opaque()) + 1, lhs.size());
+  // serves as an extra test for possible pointer aliasing problems.
+  se::DeviceMemoryBase lhs(base.opaque(), n_elems * sizeof(NT)),
+                       rhs(static_cast< NT *>(base.opaque()) + 1, lhs.size());
 
   constexpr uint32_t pattern = 0xABABABAB;
   TF_CHECK_OK(stream->Memset32(&lhs, pattern, buf_size));
 
   // First we do "positive" test to make sure lhs and rhs are indeed equal:
-  // disable host comparison here since it could take a while for ~8GB array
+  // disable host comparison here since it could take a while for ~4GB array
   BufferComparator comparator(ShapeUtil::MakeShape(number_type, {n_elems}),
        /*tolerance*/0.1, /* verbose */false, /*run_host_compare*/false);
   EXPECT_TRUE(comparator.CompareEqual(stream.get(), lhs, rhs).value());
 
-  se::DeviceMemoryBase last_word(static_cast< uint8_t *>(base->opaque()) +
+  se::DeviceMemoryBase last_word(static_cast< uint8_t *>(base.opaque()) +
                 (n_elems & ~3), sizeof(uint32_t));
   // Change only the very last entry of rhs to verify that the whole arrays are 
   // compared (if the grid dimensions are not computed correctly, this might

--- a/xla/backends/gpu/runtime/buffer_comparator_test.cc
+++ b/xla/backends/gpu/runtime/buffer_comparator_test.cc
@@ -448,6 +448,41 @@ TEST_F(BufferComparatorTest, BF16) {
                    .value());
 }
 
+TEST_F(BufferComparatorTest, VeryLargeArray) {
+  constexpr PrimitiveType number_type = U16;
+  using NT = primitive_util::PrimitiveTypeToNative< number_type >::type;
+
+  // Set non-power-of-two element count on purpose
+  int64_t element_count = (1LL << 34) - 11;
+  auto stream = stream_exec_->CreateStream().value();
+
+  // Use host memory here since there is a limitation of 4GB per test on
+  // device memory alloc
+  TF_ASSERT_OK_AND_ASSIGN(
+    auto base, 
+    stream_exec_->HostMemoryAllocate((element_count + 1) * sizeof(NT)));
+
+  // We use overlapping lhs and rhs arrays to reduce memory usage, also this 
+  // serves as an extra test for possible pointer aliasing problems
+  se::DeviceMemoryBase lhs(base->opaque(), base->size() - sizeof(NT)),
+                       rhs(static_cast< NT *>(base->opaque()) + 1, lhs.size());
+
+  TF_CHECK_OK(stream->Memset32(&lhs, 0xABCDABCD, base->size()));
+
+  // Disable host comparison here since it could take a while for ~8GB array
+  BufferComparator comparator(ShapeUtil::MakeShape(number_type, {element_count}),
+       /*tolerance*/0.1, /* verbose */false, /*run_host_compare*/false);
+  EXPECT_TRUE(comparator.CompareEqual(stream.get(), lhs, rhs).value());
+
+  auto slice = rhs.GetByteSlice(element_count*sizeof(NT) - sizeof(uint32_t), 
+        sizeof(uint32_t));
+  // Change only the very last entry of rhs to verify that the whole arrays are 
+  // compared (if the grid dimensions are not computed correctly, this might
+  // not be the case). Account for little-endian: [CD AB 77 17].
+  TF_CHECK_OK(stream->Memset32(&slice, 0x1777ABCD, slice.size()));
+  EXPECT_FALSE(comparator.CompareEqual(stream.get(), lhs, rhs).value());
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/launch_dimensions.cc
+++ b/xla/service/gpu/launch_dimensions.cc
@@ -54,36 +54,16 @@ LaunchDimensions CalculateLaunchDimensions(
   num_elements = CeilOfRatio(num_elements, int64_t{dim_config.unroll_factor});
   const int kWarpSchedulers = 4;
 
-  if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm") {
-    int64_t threads_per_block_x = std::min<int64_t>(
+  int64_t threads_per_block = std::min<int64_t>(
         gpu_device_info.threads_per_warp() * kWarpSchedulers, num_elements);
 
-    int64_t num_blocks = CeilOfRatio(num_elements, threads_per_block_x);
-    CHECK(num_blocks < gpu_device_info.block_dim_limit().x);
-
-    int threads_per_block_y = 1;
-    while ((num_blocks * threads_per_block_x) >
-           std::numeric_limits<uint32_t>::max()) {
-      threads_per_block_x /= 2;
-      threads_per_block_y *= 2;
-    }
-
-    return LaunchDimensions(
-        se::BlockDim(num_blocks, 1, 1),
-        se::ThreadDim(threads_per_block_x, threads_per_block_y, 1));
-
-  } else {
-    int64_t threads_per_block = std::min<int64_t>(
-        gpu_device_info.threads_per_warp() * kWarpSchedulers, num_elements);
-
-    int64_t num_blocks_total = CeilOfRatio(num_elements, threads_per_block);
-    int64_t num_blocks_y = CeilOfRatio<uint64_t>(
+  int64_t num_blocks_total = CeilOfRatio(num_elements, threads_per_block);
+  int64_t num_blocks_y = CeilOfRatio<uint64_t>(
         num_blocks_total, gpu_device_info.block_dim_limit().x);
-    int64_t num_blocks_x = CeilOfRatio(num_blocks_total, num_blocks_y);
+  int64_t num_blocks_x = CeilOfRatio(num_blocks_total, num_blocks_y);
 
-    return LaunchDimensions(se::BlockDim(num_blocks_x, num_blocks_y, 1),
+  return LaunchDimensions(se::BlockDim(num_blocks_x, num_blocks_y, 1),
                             se::ThreadDim(threads_per_block, 1, 1));
-  }
 }
 
 LaunchDimensionsProto LaunchDimensions::ToProto() const {

--- a/xla/service/gpu/launch_dimensions.h
+++ b/xla/service/gpu/launch_dimensions.h
@@ -49,9 +49,9 @@ class LaunchDimensions {
       : block_counts_(block_counts),
         thread_counts_per_block_(thread_counts_per_block) {}
 
-  se::BlockDim block_counts() const { return block_counts_; }
+  const se::BlockDim& block_counts() const { return block_counts_; }
 
-  se::ThreadDim thread_counts_per_block() const {
+  const se::ThreadDim& thread_counts_per_block() const {
     return thread_counts_per_block_;
   }
 

--- a/xla/stream_executor/gpu/buffer_comparator_kernel_lib.cu.h
+++ b/xla/stream_executor/gpu/buffer_comparator_kernel_lib.cu.h
@@ -61,32 +61,34 @@ template <typename T>
 __global__ void xla_fp_comparison(T* buffer_a, T* buffer_b,
                                   float rel_error_threshold,
                                   uint64_t buffer_length, int* mismatch_count) {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx >= buffer_length) {
-    return;
-  }
 
-  auto elem_a = Canonicalize(buffer_a[idx]);
-  auto elem_b = Canonicalize(buffer_b[idx]);
+  const uint64_t block_dim_x = static_cast< uint64_t >(blockDim.x),
+                 stride = block_dim_x * gridDim.x;
+  for(uint64_t idx = threadIdx.x + blockIdx.x * block_dim_x; 
+               idx < buffer_length; idx += stride) {
+  
+    auto elem_a = Canonicalize(buffer_a[idx]);
+    auto elem_b = Canonicalize(buffer_b[idx]);
 
-  // NaN's are considered equal.
-  if (Eigen::numext::isnan(elem_a) && Eigen::numext::isnan(elem_b)) {
-    return;
-  }
+    // NaN's are considered equal.
+    if (Eigen::numext::isnan(elem_a) && Eigen::numext::isnan(elem_b)) {
+      continue;
+    }
+    // Two infinities are considered equal. Computing relative error would
+    // otherwise result in NaN.
+    if (elem_a == elem_b) {
+      continue;
+    }
 
-  // Two infinities are considered equal. Computing relative error would
-  // otherwise result in NaN.
-  if (elem_a == elem_b) {
-    return;
-  }
-
-  float rel_error = Eigen::numext::abs(elem_a - elem_b) /
+    float rel_error = Eigen::numext::abs(elem_a - elem_b) /
                     (Eigen::numext::maxi(Eigen::numext::abs(elem_a),
                                          Eigen::numext::abs(elem_b)) +
                      1);
 
-  if (rel_error > rel_error_threshold || Eigen::numext::isnan(rel_error))
-    atomicAdd(mismatch_count, 1);
+    if (rel_error > rel_error_threshold || Eigen::numext::isnan(rel_error)) {
+      atomicAdd(mismatch_count, 1);
+    }
+  } // for
 }
 
 // TODO(b/191520348): The comparison below requires exact equality.
@@ -95,21 +97,26 @@ __global__ void xla_int_comparison(T* buffer_a, T* buffer_b,
                                    float rel_error_threshold,
                                    uint64_t buffer_length,
                                    int* mismatch_count) {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx >= buffer_length) return;
-  float elem_a;
-  float elem_b;
-  if constexpr (std::numeric_limits<T>::is_signed) {
-    elem_a = static_cast<int64_t>(buffer_a[idx]);
-    elem_b = static_cast<int64_t>(buffer_b[idx]);
-  } else {
-    elem_a = static_cast<uint64_t>(buffer_a[idx]);
-    elem_b = static_cast<uint64_t>(buffer_b[idx]);
-  }
-  float rel_error =
+  
+  const uint64_t block_dim_x = static_cast< uint64_t >(blockDim.x),
+                 stride = block_dim_x * gridDim.x;
+  for(uint64_t idx = threadIdx.x + blockIdx.x * block_dim_x; 
+               idx < buffer_length; idx += stride) {
+    float elem_a;
+    float elem_b;
+    if constexpr (std::numeric_limits<T>::is_signed) {
+      elem_a = static_cast<int64_t>(buffer_a[idx]);
+      elem_b = static_cast<int64_t>(buffer_b[idx]);
+    } else {
+      elem_a = static_cast<uint64_t>(buffer_a[idx]);
+      elem_b = static_cast<uint64_t>(buffer_b[idx]);
+    }
+    float rel_error =
       fabs(elem_a - elem_b) / (fmax(fabs(elem_a), fabs(elem_b)) + 1);
-  if (rel_error > rel_error_threshold || isnan(rel_error))
-    atomicAdd(mismatch_count, 1);
+    if (rel_error > rel_error_threshold || isnan(rel_error)) {
+      atomicAdd(mismatch_count, 1);
+    }
+  } // for
 }
 
 template <typename NativeT>

--- a/xla/stream_executor/gpu/redzone_allocator.cc
+++ b/xla/stream_executor/gpu/redzone_allocator.cc
@@ -178,7 +178,8 @@ static absl::Status RunRedzoneChecker(
   int64_t threads_per_block = std::min(
       executor->GetDeviceDescription().threads_per_block_limit(), num_elements);
   int64_t block_count =
-      tsl::MathUtil::CeilOfRatio(num_elements, threads_per_block);
+      std::min(tsl::MathUtil::CeilOfRatio(num_elements, threads_per_block),
+                 RedzoneAllocator::kMaxNumThreadBlocksForKernel);
 
   TF_RETURN_IF_ERROR(comparison_kernel.Launch(
       ThreadDim(threads_per_block), BlockDim(block_count), stream, redzone,

--- a/xla/stream_executor/gpu/redzone_allocator.h
+++ b/xla/stream_executor/gpu/redzone_allocator.h
@@ -47,6 +47,9 @@ class RedzoneAllocator : public ScratchAllocator {
   static constexpr int64_t kDefaultRedzoneSize =
       1LL << 23;  // 8MiB per side, 16MiB total.
   static constexpr uint8_t kDefaultRedzonePattern = -1;  // NOLINT
+  // Maximum number of thread blocks to be used for redzone checker kernel
+  static constexpr int64_t kMaxNumThreadBlocksForKernel = 32768;
+
   RedzoneAllocator(Stream* stream, DeviceMemoryAllocator* memory_allocator,
                    int64_t memory_limit = (1LL << 32),  // 4GB
                    int64_t redzone_size = kDefaultRedzoneSize,

--- a/xla/stream_executor/gpu/redzone_allocator_kernel_lib.cu.h
+++ b/xla/stream_executor/gpu/redzone_allocator_kernel_lib.cu.h
@@ -24,12 +24,11 @@ __global__ void RedzoneAllocatorKernelImpl(uint8_t* input_buffer,
                                            uint8_t redzone_pattern,
                                            uint64_t buffer_length,
                                            uint32_t* out_mismatched_ptr) {
-  uint64_t idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx >= buffer_length) {
-    return;
-  }
-  if (input_buffer[idx] != redzone_pattern) {
-    atomicAdd(out_mismatched_ptr, 1);
+  const uint64_t block_dim_x = static_cast< uint64_t >(blockDim.x),
+                 stride = block_dim_x * gridDim.x;
+  for(uint64_t idx = threadIdx.x + blockIdx.x * block_dim_x; 
+               idx < buffer_length; idx += stride) {
+    if (input_buffer[idx] != redzone_pattern) atomicAdd(out_mismatched_ptr, 1);
   }
 }
 }  // namespace stream_executor::gpu


### PR DESCRIPTION
📝 Summary of Changes
Added grid-stride loops to buffer_comparator and redzone checker kernels,
extended gpu_kernel_tiling test and buffer_comparator_test, removed rocm-specific hacks

🎯 Justification
When the input shape is too large, buffer_comparator/redzone_checker kernels may fail to launch due to grid size limitations

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.

This PR was extracted as part of the original one: https://github.com/openxla/xla/pull/30127

@xla-rotation: can you have a look, please ?
