### PR TITLE
[XLA:CPU][oneDNN] Undo proto workarounds after switching to thunks based execution

### DIFF
--- a/xla/service/cpu/onednn_config.proto
+++ b/xla/service/cpu/onednn_config.proto
@@ -54,9 +54,8 @@ message OneDnnFusionConfig {
     SWISH = 12;
   }
   repeated FusionKind ops = 1;
-  // To avoid protobuf failures for specific decimal values,
-  // the original float value alpha is type-casted to int32.
-  repeated int32 alpha_typecast = 2;
+  reserved 2;  // was alpha_typecast
+  repeated float alpha = 3;
 }
 
 message OneDnnTensorLayoutProto {

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -679,22 +679,20 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
           (*it).window_reversal()) {
         return absl::OkStatus();
       }
-      // Changing the input subspace of uint repeated fields from whole numbers
-      // to natural nummbers to avoid misinterpretation of buffer values.
-      conv_config->mutable_window()->add_pad_left((*it).padding_low() + 1);
-      conv_config->mutable_window()->add_pad_right((*it).padding_high() + 1);
-      conv_config->mutable_window()->add_strides((*it).stride() + 1);
+      conv_config->mutable_window()->add_pad_left((*it).padding_low());
+      conv_config->mutable_window()->add_pad_right((*it).padding_high());
+      conv_config->mutable_window()->add_strides((*it).stride());
       conv_config->mutable_window()->add_window_dilations(
-          (*it).window_dilation() + 1);
+          (*it).window_dilation());
     }
 
     for (int i = 0; i < dims; i++) {
       conv_config->mutable_input()->mutable_data()->add_spatial_dims(
-          conv_dims.input_spatial_dimensions()[i] + 1);
+          conv_dims.input_spatial_dimensions()[i]);
       conv_config->mutable_kernel()->mutable_filter()->add_spatial_dims(
-          conv_dims.kernel_spatial_dimensions()[i] + 1);
+          conv_dims.kernel_spatial_dimensions()[i]);
       conv_config->mutable_output()->mutable_data()->add_spatial_dims(
-          conv_dims.output_spatial_dimensions()[i] + 1);
+          conv_dims.output_spatial_dimensions()[i]);
     }
 
     HloInstruction* custom_call =
@@ -1065,10 +1063,7 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
       auto backend_config = custom_call->backend_config<BackendConfig>();
       auto fusions_config = GetFusionsConfig(&backend_config);
       fusions_config->add_ops(OneDnnFusionConfig::LINEAR);
-      // Casting to int32 because of issues in proto config for decimal types
-      // handling.
-      fusions_config->add_alpha_typecast(
-          *(reinterpret_cast<int32_t*>(&constant_value.value())));
+      fusions_config->add_alpha(constant_value.value());
       TF_RETURN_IF_ERROR(custom_call->set_backend_config(*backend_config));
       HloInstruction* new_instr;
       if (optional_convert != nullptr &&

--- a/xla/service/cpu/onednn_convolution.cc
+++ b/xla/service/cpu/onednn_convolution.cc
@@ -56,7 +56,7 @@ using dnnl::prop_kind;
 using dnnl::stream;
 
 memory::dims GetPrimitiveParameter(
-    const tsl::protobuf::RepeatedField<uint64_t>& field, int offset) {
+    const tsl::protobuf::RepeatedField<uint64_t>& field, int offset = 0) {
   memory::dims param_field(field.begin(), field.end());
   // Subtract the offset so that values are interpreted accurately
   for (int64_t& n : param_field) {
@@ -73,7 +73,7 @@ std::vector<int> ComputePermutations(
   perm_axes[dim1] = 1;
   int index = 2;
   for (uint64_t n : spatial_dims) {
-    perm_axes[n - 1] = index++;
+    perm_axes[n] = index++;
   }
   return perm_axes;
 }
@@ -134,14 +134,13 @@ CreateOneDnnPrimDesc<dnnl::convolution_forward::primitive_desc>(
   memory::desc weights_md = ShapeToMemDesc(weight_shape);
   memory::desc output_md = ShapeToMemDesc(output_shape);
 
-  memory::dims strides =
-      GetPrimitiveParameter(conv_config.window().strides(), 1);
+  memory::dims strides = GetPrimitiveParameter(conv_config.window().strides());
   memory::dims pad_left =
-      GetPrimitiveParameter(conv_config.window().pad_left(), 1);
+      GetPrimitiveParameter(conv_config.window().pad_left());
   memory::dims pad_right =
-      GetPrimitiveParameter(conv_config.window().pad_right(), 1);
+      GetPrimitiveParameter(conv_config.window().pad_right());
   memory::dims rhs_dilations =
-      GetPrimitiveParameter(conv_config.window().window_dilations(), 2);
+      GetPrimitiveParameter(conv_config.window().window_dilations(), 1);
 
   uint64_t groups = conv_config.feature_groups();
 
@@ -241,14 +240,13 @@ void ExecuteOneDnnConvolution(absl::Span<MemrefInfoHandler> arguments,
       conv_config.output().data().feature_dim(),
       conv_config.output().data().spatial_dims()));
 
-  memory::dims strides =
-      GetPrimitiveParameter(conv_config.window().strides(), 1);
+  memory::dims strides = GetPrimitiveParameter(conv_config.window().strides());
   memory::dims pad_left =
-      GetPrimitiveParameter(conv_config.window().pad_left(), 1);
+      GetPrimitiveParameter(conv_config.window().pad_left());
   memory::dims pad_right =
-      GetPrimitiveParameter(conv_config.window().pad_right(), 1);
+      GetPrimitiveParameter(conv_config.window().pad_right());
   memory::dims rhs_dilations =
-      GetPrimitiveParameter(conv_config.window().window_dilations(), 2);
+      GetPrimitiveParameter(conv_config.window().window_dilations(), 1);
 
   uint64_t groups = conv_config.feature_groups();
 

--- a/xla/service/cpu/onednn_util.cc
+++ b/xla/service/cpu/onednn_util.cc
@@ -114,9 +114,7 @@ dnnl::post_ops PopulateOneDnnPostOps(
         fused_operand_idx++;
       } break;
       case OneDnnFusionConfig::LINEAR: {
-        float const_float;
-        *(reinterpret_cast<int32_t*>(&const_float)) =
-            fusion_config->alpha_typecast()[linear_scale_idx];
+        float const_float = fusion_config->alpha()[linear_scale_idx];
         post_ops.append_eltwise(dnnl::algorithm::eltwise_linear, const_float,
                                 0.f);
         linear_scale_idx++;

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -300,20 +300,20 @@ TEST_P(ConvolutionTest, ConvInsufficientScratchTest) {
             "dims":"3",
             "input":{
               "dims":"3",
-              "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["2"]}
+              "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["1"]}
             },
             "kernel":{
               "dims":"3",
               "filter":{"input_feature_dim":"1","output_feature_dim":"2",
-                "spatial_dims":["1"],"shape":[]}
+                "spatial_dims":["0"],"shape":[]}
             },
             "output":{
               "dims":"3",
-              "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["2"]}
+              "data":{"batch_dim":"0","feature_dim":"2","spatial_dims":["1"]}
             },
             "window":{
-              "size":[],"pad_left":["1"],"pad_right":["1"],
-              "strides":["2"],"window_dilations":["2"]
+              "size":[],"pad_left":["0"],"pad_right":["0"],
+              "strides":["1"],"window_dilations":["1"]
             },
             "feature_groups":"1",
             "optimization_config":{"user_scratchpad":true}


### PR DESCRIPTION
This PR removes the proto workarounds that were added to make the code work with the legacy runtime. Specifically, it undoes:
1. Using 1-based indexing for proto repeated fields.
2. Type punning for floats.
