### PR TITLE
[XLA:CPU] Add support for riscv64

### DIFF
--- a/third_party/hwloc/hwloc.BUILD
+++ b/third_party/hwloc/hwloc.BUILD
@@ -272,6 +272,10 @@ cc_library(
             "hwloc/topology-linux.c",
             "include/hwloc/linux.h",
         ],
+        "@xla//xla/tsl:linux_riscv64": [
+            "hwloc/topology-linux.c",
+            "include/hwloc/linux.h",
+        ],
         "@xla//xla/tsl:linux_s390x": [
             "hwloc/topology-linux.c",
             "include/hwloc/linux.h",

--- a/third_party/mkl_dnn/mkldnn_v1.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1.BUILD
@@ -220,6 +220,7 @@ cc_library(
         "@xla//xla/tsl:linux_aarch64": ["-lrt"],
         "@xla//xla/tsl:linux_x86_64": ["-lrt"],
         "@xla//xla/tsl:linux_ppc64le": ["-lrt"],
+        "@xla//xla/tsl:linux_riscv64": ["-lrt"],
         "//conditions:default": [],
     }),
     textual_hdrs = _TEXTUAL_HDRS_LIST,

--- a/third_party/py/manylinux_compliance_test.py
+++ b/third_party/py/manylinux_compliance_test.py
@@ -46,6 +46,11 @@ def parse_args():
       required=True,
       help="ManyLinux compliance tag for ppc64le",
   )
+  parser.add_argument(
+      "--riscv64-compliance-tag",
+      required=True,
+      help="ManyLinux compliance tag for riscv64",
+  )
   return parser.parse_args()
 
 
@@ -106,7 +111,7 @@ def verify_manylinux_compliance(
 
 def test_manylinux_compliance(args):
   machine_type = platform.uname().machine
-  supported_machine_types = ["x86_64", "aarch64", "ppc64le"]
+  supported_machine_types = ["x86_64", "aarch64", "ppc64le", "riscv64"]
   if machine_type not in supported_machine_types:
     raise RuntimeError(
         "Unsupported machine type {machine_type}. The supported are:"
@@ -118,8 +123,10 @@ def test_manylinux_compliance(args):
     compliance_tag = args.x86_64_compliance_tag
   elif machine_type == "aarch64":
     compliance_tag = args.aarch64_compliance_tag
-  else:
+  elif machine_type == "ppc64le":
     compliance_tag = args.ppc64le_compliance_tag
+  else:  # machine_type == "riscv64"
+    compliance_tag = args.riscv64_compliance_tag
   auditwheel_output = get_auditwheel_output(args.wheel_path)
   verify_manylinux_compliance(
       auditwheel_output,

--- a/third_party/py/py_manylinux_compliance_test.bzl
+++ b/third_party/py/py_manylinux_compliance_test.bzl
@@ -8,6 +8,7 @@ def verify_manylinux_compliance_test(
         aarch64_compliance_tag,
         x86_64_compliance_tag,
         ppc64le_compliance_tag,
+        riscv64_compliance_tag,
         test_tags = []):
     py_test(
         name = name,
@@ -21,6 +22,7 @@ def verify_manylinux_compliance_test(
             "--aarch64-compliance-tag={}".format(aarch64_compliance_tag),
             "--x86_64-compliance-tag={}".format(x86_64_compliance_tag),
             "--ppc64le-compliance-tag={}".format(ppc64le_compliance_tag),
+            "--riscv64-compliance-tag={}".format(riscv64_compliance_tag),
         ],
         main = "manylinux_compliance_test.py",
         tags = ["manual"] + test_tags,

--- a/third_party/py/python_init_rules.bzl
+++ b/third_party/py/python_init_rules.bzl
@@ -44,5 +44,6 @@ def python_init_rules(extra_patches = []):
             Label("//third_party/py:rules_python_pip_version.patch"),
             Label("//third_party/py:rules_python_freethreaded.patch"),
             Label("//third_party/py:rules_python_versions.patch"),
+            Label("//third_party/py:rules_python_riscv64_pypi.patch"),
         ] + extra_patches,
     )

--- a/third_party/py/rules_python_riscv64_pypi.patch
+++ b/third_party/py/rules_python_riscv64_pypi.patch
@@ -1,0 +1,131 @@
+From: Levi Zim <rsworktech@outlook.com>
+Date: Tue, 14 Oct 2025 19:45:36 +0800
+Subject: [PATCH] fix: Add linux_riscv64 to _pip_repository_impl
+
+Fix https://github.com/bazel-contrib/rules_python/discussions/2729
+---
+ python/private/pypi/pip_repository.bzl                   | 1 +
+ python/private/pypi/whl_installer/platform.py            | 3 +++
+ python/private/pypi/whl_target_platforms.bzl             | 1 +
+ tests/pypi/whl_installer/platform_test.py                | 6 +++---
+ .../whl_target_platforms/whl_target_platforms_tests.bzl  | 9 +++++++++
+ 5 files changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/python/private/pypi/pip_repository.bzl b/python/private/pypi/pip_repository.bzl
+index e9a4c44da3..d635651039 100644
+--- a/python/private/pypi/pip_repository.bzl
++++ b/python/private/pypi/pip_repository.bzl
+@@ -96,6 +96,7 @@ def _pip_repository_impl(rctx):
+                 "linux_aarch64",
+                 "linux_arm",
+                 "linux_ppc",
++                "linux_riscv64",
+                 "linux_s390x",
+                 "linux_x86_64",
+                 "osx_aarch64",
+diff --git a/python/private/pypi/whl_installer/platform.py b/python/private/pypi/whl_installer/platform.py
+index ff267fe4aa..0757d86990 100644
+--- a/python/private/pypi/whl_installer/platform.py
++++ b/python/private/pypi/whl_installer/platform.py
+@@ -45,6 +45,7 @@ class Arch(Enum):
+     ppc64le = 5
+     s390x = 6
+     arm = 7
++    riscv64 = 8
+     amd64 = x86_64
+     arm64 = aarch64
+     i386 = x86_32
+@@ -269,6 +270,8 @@ def platform_machine(self) -> str:
+             return "ppc"
+         elif self.arch == Arch.ppc64le:
+             return "ppc64le"
++        elif self.arch == Arch.riscv64:
++            return "riscv64"
+         elif self.arch == Arch.s390x:
+             return "s390x"
+         else:
+diff --git a/python/private/pypi/whl_target_platforms.bzl b/python/private/pypi/whl_target_platforms.bzl
+index 6c3dd5da83..28547c679c 100644
+--- a/python/private/pypi/whl_target_platforms.bzl
++++ b/python/private/pypi/whl_target_platforms.bzl
+@@ -30,6 +30,7 @@ _CPU_ALIASES = {
+     "ppc": "ppc",
+     "ppc64": "ppc",
+     "ppc64le": "ppc64le",
++    "riscv64": "riscv64",
+     "s390x": "s390x",
+     "arm": "arm",
+     "armv6l": "arm",
+diff --git a/tests/pypi/whl_installer/platform_test.py b/tests/pypi/whl_installer/platform_test.py
+index ad65650779..0d944bb196 100644
+--- a/tests/pypi/whl_installer/platform_test.py
++++ b/tests/pypi/whl_installer/platform_test.py
+@@ -38,17 +38,17 @@ def test_can_get_specific_from_string(self):
+ 
+     def test_can_get_all_for_py_version(self):
+         cp39 = Platform.all(minor_version=9, micro_version=0)
+-        self.assertEqual(21, len(cp39), f"Got {cp39}")
++        self.assertEqual(24, len(cp39), f"Got {cp39}")
+         self.assertEqual(cp39, Platform.from_string("cp39.0_*"))
+ 
+     def test_can_get_all_for_os(self):
+         linuxes = Platform.all(OS.linux, minor_version=9)
+-        self.assertEqual(7, len(linuxes))
++        self.assertEqual(8, len(linuxes))
+         self.assertEqual(linuxes, Platform.from_string("cp39_linux_*"))
+ 
+     def test_can_get_all_for_os_for_host_python(self):
+         linuxes = Platform.all(OS.linux)
+-        self.assertEqual(7, len(linuxes))
++        self.assertEqual(8, len(linuxes))
+         self.assertEqual(linuxes, Platform.from_string("linux_*"))
+ 
+     def test_platform_sort(self):
+diff --git a/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl b/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl
+index a976a0cf95..8b7f0ad02b 100644
+--- a/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl
++++ b/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl
+@@ -34,6 +34,9 @@ def _test_simple(env):
+         "musllinux_1_1_ppc64le": [
+             struct(os = "linux", cpu = "ppc64le", abi = None, target_platform = "linux_ppc64le", version = (1, 1)),
+         ],
++        "musllinux_1_2_riscv64": [
++            struct(os = "linux", cpu = "riscv64", abi = None, target_platform = "linux_riscv64", version = (1, 2)),
++        ],
+         "win_amd64": [
+             struct(os = "windows", cpu = "x86_64", abi = None, target_platform = "windows_x86_64", version = (0, 0)),
+         ],
+@@ -66,6 +69,9 @@ def _test_with_abi(env):
+         "musllinux_1_1_ppc64le": [
+             struct(os = "linux", cpu = "ppc64le", abi = "cp311", target_platform = "cp311_linux_ppc64le", version = (1, 1)),
+         ],
++        "musllinux_1_2_riscv64": [
++            struct(os = "linux", cpu = "riscv64", abi = "cp311", target_platform = "cp311_linux_riscv64", version = (1, 2)),
++        ],
+         "win_amd64": [
+             struct(os = "windows", cpu = "x86_64", abi = "cp311", target_platform = "cp311_windows_x86_64", version = (0, 0)),
+         ],
+@@ -96,6 +102,7 @@ def _can_parse_existing_tags(env):
+         "manylinux2014_i686": 1,
+         "manylinux2014_ppc64": 1,
+         "manylinux2014_ppc64le": 1,
++        "manylinux2014_riscv64": 1,
+         "manylinux2014_s390x": 1,
+         "manylinux2014_x86_64": 1,
+         "manylinux_11_12_aarch64": 1,
+@@ -103,6 +110,7 @@ def _can_parse_existing_tags(env):
+         "manylinux_11_12_i686": 1,
+         "manylinux_11_12_ppc64": 1,
+         "manylinux_11_12_ppc64le": 1,
++        "manylinux_11_12_riscv64": 1,
+         "manylinux_11_12_s390x": 1,
+         "manylinux_11_12_x86_64": 1,
+         "manylinux_1_2_aarch64": 1,
+@@ -111,6 +119,7 @@ def _can_parse_existing_tags(env):
+         "musllinux_11_12_armv7l": 1,
+         "musllinux_11_12_i686": 1,
+         "musllinux_11_12_ppc64le": 1,
++        "musllinux_11_12_riscv64": 1,
+         "musllinux_11_12_s390x": 1,
+         "musllinux_11_12_x86_64": 1,
+         "win32": 1,

--- a/third_party/py/rules_python_riscv64_pypi.patch
+++ b/third_party/py/rules_python_riscv64_pypi.patch
@@ -1,15 +1,23 @@
 From: Levi Zim <rsworktech@outlook.com>
-Date: Tue, 14 Oct 2025 19:45:36 +0800
-Subject: [PATCH] fix: Add linux_riscv64 to _pip_repository_impl
+Date: Sun, 26 Oct 2025 12:35:53 +0800
+Subject: [PATCH] fix: Add linux_riscv64 to _pip_repository_impl (#3350)
 
-Fix https://github.com/bazel-contrib/rules_python/discussions/2729
+Add `linux_riscv64` support for pulling pip dependencies. This is not
+adding any hermetic toolchain support - user has to provide a working
+toolchain.
+
+Fix #2729
+
+---------
+
+Co-authored-by: Ignas Anikevicius <240938+aignas@users.noreply.github.com>
 ---
- python/private/pypi/pip_repository.bzl                   | 1 +
- python/private/pypi/whl_installer/platform.py            | 3 +++
- python/private/pypi/whl_target_platforms.bzl             | 1 +
- tests/pypi/whl_installer/platform_test.py                | 6 +++---
- .../whl_target_platforms/whl_target_platforms_tests.bzl  | 9 +++++++++
- 5 files changed, 17 insertions(+), 3 deletions(-)
+ python/private/pypi/pip_repository.bzl                    | 1 +
+ python/private/pypi/whl_installer/platform.py             | 3 +++
+ python/private/pypi/whl_target_platforms.bzl              | 1 +
+ tests/pypi/whl_installer/platform_test.py                 | 6 +++---
+ .../whl_target_platforms/whl_target_platforms_tests.bzl   | 8 ++++++++
+ 5 files changed, 16 insertions(+), 3 deletions(-)
 
 diff --git a/python/private/pypi/pip_repository.bzl b/python/private/pypi/pip_repository.bzl
 index e9a4c44da3..d635651039 100644
@@ -82,7 +90,7 @@ index ad65650779..0d944bb196 100644
  
      def test_platform_sort(self):
 diff --git a/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl b/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl
-index a976a0cf95..8b7f0ad02b 100644
+index a976a0cf95..6bec26c10c 100644
 --- a/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl
 +++ b/tests/pypi/whl_target_platforms/whl_target_platforms_tests.bzl
 @@ -34,6 +34,9 @@ def _test_simple(env):
@@ -105,15 +113,7 @@ index a976a0cf95..8b7f0ad02b 100644
          "win_amd64": [
              struct(os = "windows", cpu = "x86_64", abi = "cp311", target_platform = "cp311_windows_x86_64", version = (0, 0)),
          ],
-@@ -96,6 +102,7 @@ def _can_parse_existing_tags(env):
-         "manylinux2014_i686": 1,
-         "manylinux2014_ppc64": 1,
-         "manylinux2014_ppc64le": 1,
-+        "manylinux2014_riscv64": 1,
-         "manylinux2014_s390x": 1,
-         "manylinux2014_x86_64": 1,
-         "manylinux_11_12_aarch64": 1,
-@@ -103,6 +110,7 @@ def _can_parse_existing_tags(env):
+@@ -103,6 +109,7 @@ def _can_parse_existing_tags(env):
          "manylinux_11_12_i686": 1,
          "manylinux_11_12_ppc64": 1,
          "manylinux_11_12_ppc64le": 1,
@@ -121,7 +121,7 @@ index a976a0cf95..8b7f0ad02b 100644
          "manylinux_11_12_s390x": 1,
          "manylinux_11_12_x86_64": 1,
          "manylinux_1_2_aarch64": 1,
-@@ -111,6 +119,7 @@ def _can_parse_existing_tags(env):
+@@ -111,6 +118,7 @@ def _can_parse_existing_tags(env):
          "musllinux_11_12_armv7l": 1,
          "musllinux_11_12_i686": 1,
          "musllinux_11_12_ppc64le": 1,

--- a/xla/backends/cpu/codegen/BUILD
+++ b/xla/backends/cpu/codegen/BUILD
@@ -5,6 +5,7 @@ load(
     "//xla/tsl/platform:build_config_root.bzl",
     "if_llvm_aarch64_available",
     "if_llvm_powerpc_available",
+    "if_llvm_riscv_available",
     "if_llvm_system_z_available",
     "if_llvm_x86_available",
 )
@@ -129,6 +130,8 @@ xla_cc_test(
         "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
     ]) + if_llvm_powerpc_available([
         "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_riscv_available([
+        "@llvm-project//llvm:RISCVCodeGen",  # fixdeps: keep
     ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
     ]) + if_llvm_x86_available([
@@ -250,6 +253,8 @@ cc_library(
         "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
     ]) + if_llvm_powerpc_available([
         "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_riscv_available([
+        "@llvm-project//llvm:RISCVCodeGen",  # fixdeps: keep
     ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
     ]) + if_llvm_x86_available([

--- a/xla/backends/cpu/codegen/tools/BUILD
+++ b/xla/backends/cpu/codegen/tools/BUILD
@@ -4,6 +4,7 @@ load(
     "//xla/tsl/platform:build_config_root.bzl",
     "if_llvm_aarch64_available",
     "if_llvm_powerpc_available",
+    "if_llvm_riscv_available",
     "if_llvm_system_z_available",
     "if_llvm_x86_available",
 )
@@ -38,6 +39,8 @@ cc_library(
         "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
     ]) + if_llvm_powerpc_available([
         "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_riscv_available([
+        "@llvm-project//llvm:RISCVCodeGen",  # fixdeps: keep
     ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
     ]) + if_llvm_x86_available([

--- a/xla/codegen/intrinsic/BUILD
+++ b/xla/codegen/intrinsic/BUILD
@@ -3,6 +3,7 @@ load(
     "//xla/tsl/platform:build_config_root.bzl",
     "if_llvm_aarch64_available",
     "if_llvm_powerpc_available",
+    "if_llvm_riscv_available",
     "if_llvm_system_z_available",
     "if_llvm_x86_available",
 )
@@ -149,6 +150,9 @@ cc_library(
     ]) + if_llvm_powerpc_available([
         "@llvm-project//llvm:PowerPCAsmParser",  # fixdeps: keep
         "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_riscv_available([
+        "@llvm-project//llvm:RISCVAsmParser",  # fixdeps: keep
+        "@llvm-project//llvm:RISCVCodeGen",  # fixdeps: keep
     ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZAsmParser",  # fixdeps: keep
         "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -20,6 +20,7 @@ load(
     "//xla/tsl/platform:build_config_root.bzl",
     "if_llvm_aarch64_available",
     "if_llvm_powerpc_available",
+    "if_llvm_riscv_available",
     "if_llvm_system_z_available",
     "if_llvm_x86_available",
 )
@@ -398,6 +399,8 @@ cc_library(
         "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
     ]) + if_llvm_powerpc_available([
         "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_riscv_available([
+        "@llvm-project//llvm:RISCVCodeGen",  # fixdeps: keep
     ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
     ]) + if_llvm_x86_available([
@@ -2188,6 +2191,8 @@ cc_library(
         "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
     ]) + if_llvm_powerpc_available([
         "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_riscv_available([
+        "@llvm-project//llvm:RISCVCodeGen",  # fixdeps: keep
     ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
     ]) + if_llvm_x86_available([

--- a/xla/service/cpu/test_target_triple_helper.h
+++ b/xla/service/cpu/test_target_triple_helper.h
@@ -23,6 +23,9 @@ static const char kTargetTripleForHost[] = "aarch64-unknown-linux-gnu";
        defined(__ppc__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
 static const char kTargetCpuForHost[] = "ppc";
 static const char kTargetTripleForHost[] = "ppc64le-ibm-linux-gnu";
+#elif defined(__riscv) && (__riscv_xlen == 64)
+static const char kTargetCpuForHost[] = "";
+static const char kTargetTripleForHost[] = "riscv64-unknown-linux-gnu";
 #elif defined(__s390x__)
 static const char kTargetCpuForHost[] = "s390x";
 static const char kTargetTripleForHost[] = "systemz-none-linux-gnu";

--- a/xla/tsl/BUILD
+++ b/xla/tsl/BUILD
@@ -317,6 +317,16 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_riscv64",
+    constraint_values =
+        [
+            "@platforms//cpu:riscv64",
+            "@platforms//os:linux",
+        ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_s390x",
     constraint_values =
         [
@@ -377,6 +387,15 @@ selects.config_setting_group(
     name = "ppc64le_or_cross",
     match_any = [
         ":linux_ppc64le",
+        ":with_cross_compiler_support",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "riscv64_or_cross",
+    match_any = [
+        ":linux_riscv64",
         ":with_cross_compiler_support",
     ],
     visibility = ["//visibility:public"],
@@ -453,6 +472,7 @@ selects.config_setting_group(
         ":linux_aarch64",
         ":linux_armhf",
         ":linux_ppc64le",
+        ":linux_riscv64",
         ":linux_s390x",
         ":linux_x86_64",
     ],

--- a/xla/tsl/framework/contraction/BUILD
+++ b/xla/tsl/framework/contraction/BUILD
@@ -113,6 +113,7 @@ cc_library(
         "//xla/tsl:fuchsia_x86_64": [],
         "//xla/tsl:ios": [],
         "//xla/tsl:linux_ppc64le": [],
+        "//xla/tsl:linux_riscv64": [],
         "//xla/tsl:linux_s390x": [],
         "//xla/tsl:macos_arm64": [],
         "//conditions:default": [
@@ -132,6 +133,7 @@ cc_library(
         "//xla/tsl:fuchsia_x86_64": [],
         "//xla/tsl:ios": [],
         "//xla/tsl:linux_ppc64le": [],
+        "//xla/tsl:linux_riscv64": [],
         "//xla/tsl:linux_s390x": [],
         "//xla/tsl:macos_arm64": [],
         "//conditions:default": ["//xla/tsl/mkl:onednn"],

--- a/xla/tsl/platform/build_config_root.bzl
+++ b/xla/tsl/platform/build_config_root.bzl
@@ -11,6 +11,7 @@ load(
     _if_llvm_aarch64_available = "if_llvm_aarch64_available",
     _if_llvm_arm_available = "if_llvm_arm_available",
     _if_llvm_powerpc_available = "if_llvm_powerpc_available",
+    _if_llvm_riscv_available = "if_llvm_riscv_available",
     _if_llvm_system_z_available = "if_llvm_system_z_available",
     _if_llvm_x86_available = "if_llvm_x86_available",
     _if_pywrap = "if_pywrap",
@@ -32,6 +33,7 @@ if_llvm_aarch32_available = _if_llvm_aarch32_available
 if_llvm_aarch64_available = _if_llvm_aarch64_available
 if_llvm_arm_available = _if_llvm_arm_available
 if_llvm_powerpc_available = _if_llvm_powerpc_available
+if_llvm_riscv_available = _if_llvm_riscv_available
 if_llvm_system_z_available = _if_llvm_system_z_available
 if_llvm_x86_available = _if_llvm_x86_available
 if_static = _if_static

--- a/xla/tsl/platform/default/build_config_root.bzl
+++ b/xla/tsl/platform/default/build_config_root.bzl
@@ -144,6 +144,12 @@ def if_llvm_powerpc_available(then, otherwise = []):
         "//conditions:default": otherwise,
     })
 
+def if_llvm_riscv_available(then, otherwise = []):
+    return select({
+        str(Label("//xla/tsl:riscv64_or_cross")): then,
+        "//conditions:default": otherwise,
+    })
+
 def if_llvm_system_z_available(then, otherwise = []):
     return select({
         str(Label("//xla/tsl:s390x_or_cross")): then,


### PR DESCRIPTION
Co-author: @kxxt

📝 Summary of Changes:

This pull request adds support for RISC-V 64 architecture across the build system, code generation, and Python packaging infrastructure.

🎯 Justification:

The changes ensure that riscv64 is recognized as a valid target in Bazel build configurations, LLVM toolchain selection, Python manylinux compliance checks, and related tests and patches. This allows the project to build and test components for riscv64 alongside other supported architectures.

🚀 Kind of Contribution: ✨ New Feature

