### PR TITLE
Fix family-conditional logic

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -248,12 +248,12 @@ std::string GetSmName(se::CudaComputeCapability compute_capability) {
       {8, 6},  {8, 0},  {7, 5},  {7, 2},  {7, 0},  {6, 2}, {6, 1}, {6, 0},
       {5, 3},  {5, 2},  {5, 0},  {3, 7},  {3, 5},  {3, 2}, {3, 0}};
   auto target_compute_capability = kSupportedVersions[0];
-
   for (const auto& v : kSupportedVersions) {
-    if (!gpu_compute_capability.CanRunOn(v)) {
+    target_compute_capability = v;
+    if (gpu_compute_capability.SupportsAllFeaturesOf(
+            target_compute_capability)) {
       break;
     }
-    target_compute_capability = v;
   }
 
   if (target_compute_capability.major == gpu_compute_capability.major &&

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -247,11 +247,14 @@ std::string GetSmName(se::CudaComputeCapability compute_capability) {
       {12, 1}, {12, 0}, {11, 0}, {10, 3}, {10, 0}, {9, 0}, {8, 9}, {8, 7},
       {8, 6},  {8, 0},  {7, 5},  {7, 2},  {7, 0},  {6, 2}, {6, 1}, {6, 0},
       {5, 3},  {5, 2},  {5, 0},  {3, 7},  {3, 5},  {3, 2}, {3, 0}};
-  auto target_compute_capability = kSupportedVersions[0];
+  // Initialize to the least supported version, which acts as a safe fallback
+  auto target_compute_capability =
+      kSupportedVersions[std::size(kSupportedVersions) - 1];
+
   for (const auto& v : kSupportedVersions) {
-    target_compute_capability = v;
-    if (gpu_compute_capability.SupportsAllFeaturesOf(
-            target_compute_capability)) {
+    if (gpu_compute_capability.SupportsAllFeaturesOf(v)) {
+      // Found the most advanced supported capability
+      target_compute_capability = v;
       break;
     }
   }

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -56,6 +56,10 @@ TEST(UtilsTest, TestGetSmName) {
             "sm_121a");
   // Do not use the extension for a yet-unknown compute capability.
   // https://docs.nvidia.com/cuda/parallel-thread-execution/#release-notes-ptx-release-history
+  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{10, 9}), "sm_103f");
+  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
+                10, 9, FeatureExtension::kAcceleratedFeatures}),
+            "sm_103f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{12, 9}), "sm_121f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{13, 0}), "sm_121");
 }


### PR DESCRIPTION
📝 Summary of Changes
The fallback logic now correctly identifies the highest known compatible architecture when given an unknown architecture as input.

🎯 Justification
Previously the logic would propose an incompatible architecture in this case.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Added a new test case showing the previously-failing case (it used to propose `sm_110`)