### PR TITLE
[XLA:GPU][oneAPI] SYCL memory management functions and tests

### DIFF
--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -264,7 +264,6 @@ sycl_library(
     deps = [
         ":sycl_status",
         "//xla/tsl/platform:statusor",
-        "//xla/tsl/util:env_var",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/xla/stream_executor/sycl/sycl_context.cc
+++ b/xla/stream_executor/sycl/sycl_context.cc
@@ -30,9 +30,7 @@ absl::StatusOr<uint64_t> SyclContext::GetDeviceTotalMemory(
 }
 
 absl::Status SyclContext::Synchronize() {
-  // TODO(intel-tf): Add this feature once SyclStreamPool class is implemented.
-  return absl::UnimplementedError(
-      "SyclContext::Synchronize is not implemented for SYCL platform.");
+  return SyclStreamPool::SynchronizeStreamPool(device_ordinal_);
 }
 
 }  // namespace stream_executor::sycl

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.h
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.h
@@ -73,5 +73,68 @@ class SyclDevicePool {
   SyclDevicePool() = delete;
 };
 
+using StreamPtr = std::shared_ptr<::sycl::queue>;
+using StreamPool = std::vector<StreamPtr>;
+using StreamPoolMap = std::unordered_map<int, StreamPool>;
+
+// TODO(intel-tf): kMaxStreamsPerDevice is the maximum number of streams that
+// can be created per device via GetOrCreateStream when multiple streams are
+// enabled.
+//
+// For now, we set it to 8 so that there is no unbounded growth. However, it can
+// be adjusted based on the device capabilities and workload requirements.
+//
+// This feature will be enabled by default in the future once the performance
+// implications are better understood.
+constexpr int kMaxStreamsPerDevice = 8;
+
+// Manages pools of SYCL streams (queues) per device. All methods are static and
+// thread-safe via a global mutex. For high concurrency workloads, consider
+// refactoring to use per-device mutexes.
+// This class cannot be instantiated and is intended to be used as a
+// static utility.
+class SyclStreamPool {
+ public:
+  // Returns the default (first in the pool) SYCL stream for the given device
+  // ordinal. Returns an error if the device ordinal is invalid or the stream
+  // pool is empty.
+  static absl::StatusOr<StreamPtr> GetDefaultStream(int device_ordinal);
+
+  // Returns a SYCL stream for the given device ordinal.
+  //
+  // If multiple streams are not enabled, returns the default (first in the
+  // pool) SYCL stream. If the stream pool is empty, returns an error.
+  //
+  // If multiple streams are enabled (via enable_multiple_streams), creates
+  // a new stream up to the maximum limit (kMaxStreamsPerDevice). Returns an
+  // error if the limit is reached.
+  static absl::StatusOr<StreamPtr> GetOrCreateStream(
+      int device_ordinal, bool enable_multiple_streams);
+
+  // Synchronizes all streams associated with the given device ordinal.
+  static absl::Status SynchronizeStreamPool(int device_ordinal);
+
+  // Destroys a previously created SYCL stream for the given device ordinal.
+  static absl::Status DestroyStream(int device_ordinal,
+                                    StreamPtr& stream_handle);
+
+ private:
+  // Global mutex protecting the stream pool.
+  // TODO(intel-tf): We should consider using a more fine-grained locking
+  // mechanism (ex. per-device mutex) in the future to avoid performance issues.
+  static absl::Mutex stream_pool_mu_;
+
+  // The underlying stream pool for each device. The device ordinal
+  // is used as the key.
+  static StreamPoolMap stream_pool_map_ ABSL_GUARDED_BY(stream_pool_mu_);
+
+  // Initializes and returns a pointer to the stream pool for the given device
+  // ordinal.
+  static absl::StatusOr<StreamPool*> InitStreamPool(int device_ordinal);
+
+  // Prevent instantiation: this class is intended to be a static utility only
+  SyclStreamPool() = delete;
+};
+
 }  // namespace stream_executor::sycl
 #endif  // XLA_STREAM_EXECUTOR_SYCL_SYCL_GPU_RUNTIME_H_

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.h
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.h
@@ -136,5 +136,49 @@ class SyclStreamPool {
   SyclStreamPool() = delete;
 };
 
+// Sets the device buffer to a byte value using the default SYCL stream
+// for the specified device ordinal. The operation is synchronous
+// and blocks until the operation is complete.
+absl::Status SyclMemsetDevice(int device_ordinal, void* dst_device,
+                              unsigned char value, size_t count);
+
+// Asynchronously sets the device buffer to a byte value using the specified
+// SYCL stream. The operation may return before it is complete.
+absl::Status SyclMemsetDeviceAsync(::sycl::queue* stream_handle,
+                                   void* dst_device, unsigned char value,
+                                   size_t count);
+
+// Sets the device buffer to an unsigned 32-bit value using the default SYCL
+// stream for the specified device ordinal. The operation is synchronous and
+// blocks until the operation is complete.
+absl::Status SyclMemfillDevice(int device_ordinal, void* dst_device,
+                               uint32_t value, size_t count);
+
+// Asynchronously sets the device buffer to an unsigned 32-bit value using the
+// specified SYCL stream. The operation may return before it is complete.
+absl::Status SyclMemfillDeviceAsync(::sycl::queue* stream_handle,
+                                    void* dst_device, uint32_t value,
+                                    size_t count);
+
+// Allocates a block of memory on the given device ordinal using the default
+// stream for that device. The memory is aligned to 64 bytes.
+absl::StatusOr<void*> SyclMallocDevice(int device_ordinal, size_t byte_count);
+
+// Allocates a block of host-accessible memory on the given device ordinal
+// using the default stream for that device. The memory is aligned to 64 bytes.
+absl::StatusOr<void*> SyclMallocHost(int device_ordinal, size_t byte_count);
+
+// Allocates a block of shared memory that is accessible by both the host and
+// the specified device ordinal, using the default stream for that device. The
+// memory is aligned to 64 bytes.
+absl::StatusOr<void*> SyclMallocShared(int device_ordinal, size_t byte_count);
+
+// Frees a previously allocated block of memory on the specified device ordinal
+// using the default stream for that device. After successful deallocation, the
+// pointer is set to nullptr.
+// This function is thread-safe only for different pointers. Concurrent calls
+// to free the same pointer requires synchronization by the caller.
+absl::Status SyclFree(int device_ordinal, void*& ptr);
+
 }  // namespace stream_executor::sycl
 #endif  // XLA_STREAM_EXECUTOR_SYCL_SYCL_GPU_RUNTIME_H_

--- a/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
@@ -15,18 +15,100 @@ limitations under the License.
 #include "xla/stream_executor/sycl/sycl_gpu_runtime.h"
 
 #include <gtest/gtest.h>
-
 #include "xla/tsl/platform/status_matchers.h"
 
 namespace stream_executor::sycl {
 namespace {
 
-TEST(SyclGpuRuntimeTest, GetDeviceCount) {
+class SyclGpuRuntimeTest : public ::testing::Test {
+ public:
+  std::vector<::sycl::device> sycl_devices_;
+
+ protected:
+  absl::StatusOr<void*> AllocateHostBuffer(int count) {
+    TF_ASSIGN_OR_RETURN(
+        void* buf, SyclMallocHost(kDefaultDeviceOrdinal, sizeof(int) * count));
+    if (buf == nullptr) {
+      return absl::InternalError(
+          "SyclGpuRuntimeTest::AllocateHostBuffer: Failed to allocate host "
+          "buffer.");
+    }
+    return buf;
+  }
+
+  absl::StatusOr<void*> AllocateDeviceBuffer(
+      int count, int device_ordinal = kDefaultDeviceOrdinal) {
+    TF_ASSIGN_OR_RETURN(void* buf,
+                        SyclMallocDevice(device_ordinal, sizeof(int) * count));
+    if (buf == nullptr) {
+      return absl::InternalError(
+          "SyclGpuRuntimeTest::AllocateDeviceBuffer: Failed to allocate "
+          "device buffer.");
+    }
+    return buf;
+  }
+
+  void VerifyIntBuffer(void* buf, int count, int expected) {
+    for (int i = 0; i < count; ++i) {
+      EXPECT_EQ(static_cast<int*>(buf)[i], expected)
+          << "Buffer mismatch at index " << i;
+    }
+  }
+
+  absl::StatusOr<void*> AllocateAndInitHostBuffer(int count, int value) {
+    TF_ASSIGN_OR_RETURN(void* buf, AllocateHostBuffer(count));
+    for (int i = 0; i < count; ++i) {
+      static_cast<int*>(buf)[i] = value;
+    }
+    return buf;
+  }
+
+  absl::StatusOr<void*> AllocateAndInitDeviceBuffer(
+      int count, int value, int device_ordinal = kDefaultDeviceOrdinal) {
+    TF_ASSIGN_OR_RETURN(void* buf, AllocateDeviceBuffer(count));
+    TF_RETURN_IF_ERROR(
+        SyclMemfillDevice(device_ordinal, buf, value, sizeof(int) * count));
+    if (buf == nullptr) {
+      return absl::InternalError(
+          "SyclGpuRuntimeTest::AllocateAndInitDeviceBuffer: Failed to fill "
+          "device buffer.");
+    }
+    return buf;
+  }
+
+  void FreeAndNullify(void*& ptr, int device_ordinal = kDefaultDeviceOrdinal) {
+    if (ptr != nullptr) {
+      EXPECT_THAT(SyclFree(device_ordinal, ptr), absl_testing::IsOk());
+      EXPECT_EQ(ptr, nullptr);
+    }
+  }
+
+ private:
+  void SetUp() override {
+    // Find the number of SYCL devices available. If there are none, skip the
+    // test.
+    TF_ASSERT_OK_AND_ASSIGN(int device_count, SyclDevicePool::GetDeviceCount());
+    if (device_count <= 0) {
+      GTEST_SKIP() << "No SYCL devices found.";
+    } else {
+      VLOG(2) << "Found " << device_count << " SYCL devices.";
+    }
+
+    // Initialize the device pool with available devices.
+    for (int i = 0; i < device_count; ++i) {
+      TF_ASSERT_OK_AND_ASSIGN(::sycl::device sycl_device,
+                              SyclDevicePool::GetDevice(i));
+      sycl_devices_.push_back(sycl_device);
+    }
+  }
+};
+
+TEST_F(SyclGpuRuntimeTest, GetDeviceCount) {
   EXPECT_THAT(SyclDevicePool::GetDeviceCount(),
               ::absl_testing::IsOkAndHolds(::testing::Gt(0)));
 }
 
-TEST(SyclGpuRuntimeTest, GetDeviceOrdinal) {
+TEST_F(SyclGpuRuntimeTest, GetDeviceOrdinal) {
   TF_ASSERT_OK_AND_ASSIGN(::sycl::device sycl_device,
                           SyclDevicePool::GetDevice(kDefaultDeviceOrdinal));
   TF_ASSERT_OK_AND_ASSIGN(int device_ordinal,
@@ -34,7 +116,7 @@ TEST(SyclGpuRuntimeTest, GetDeviceOrdinal) {
   EXPECT_EQ(device_ordinal, kDefaultDeviceOrdinal);
 }
 
-TEST(SyclGpuRuntimeTest, TestStaticDeviceContext) {
+TEST_F(SyclGpuRuntimeTest, TestStaticDeviceContext) {
   // Verify that GetDeviceContext returns the same context instance on multiple
   // calls.
   TF_ASSERT_OK_AND_ASSIGN(::sycl::context saved_sycl_context,
@@ -44,7 +126,21 @@ TEST(SyclGpuRuntimeTest, TestStaticDeviceContext) {
   EXPECT_EQ(saved_sycl_context, current_sycl_context);
 }
 
-TEST(SyclGpuRuntimeTest, TestStreamPoolCreateSynchronizeAndDestroy) {
+TEST_F(SyclGpuRuntimeTest, TestDefaultStreamSynchronizeAndDestroy) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamPtr stream_handle,
+      SyclStreamPool::GetDefaultStream(kDefaultDeviceOrdinal));
+  ASSERT_NE(stream_handle, nullptr);
+
+  ASSERT_TRUE(
+      SyclStreamPool::SynchronizeStreamPool(kDefaultDeviceOrdinal).ok());
+
+  ASSERT_TRUE(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  EXPECT_EQ(stream_handle, nullptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestCreateStreamSynchronizeAndDestroy) {
   TF_ASSERT_OK_AND_ASSIGN(
       StreamPtr stream_handle,
       SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
@@ -59,7 +155,7 @@ TEST(SyclGpuRuntimeTest, TestStreamPoolCreateSynchronizeAndDestroy) {
   EXPECT_EQ(stream_handle, nullptr);
 }
 
-TEST(SyclGpuRuntimeTest, TestStreamPoolCreateAfterDestroy) {
+TEST_F(SyclGpuRuntimeTest, TestStreamPoolCreateAfterDestroy) {
   TF_ASSERT_OK_AND_ASSIGN(
       StreamPtr stream_handle,
       SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
@@ -83,7 +179,7 @@ TEST(SyclGpuRuntimeTest, TestStreamPoolCreateAfterDestroy) {
   EXPECT_EQ(stream_handle, nullptr);
 }
 
-TEST(SyclGpuRuntimeTest, TestStreamPoolCreate_Negative) {
+TEST_F(SyclGpuRuntimeTest, TestStreamPoolCreate_Negative) {
   constexpr int kInvalidDeviceOrdinal = -1;
   EXPECT_EQ(SyclStreamPool::GetOrCreateStream(kInvalidDeviceOrdinal,
                                               /*enable_multiple_streams=*/false)
@@ -92,7 +188,7 @@ TEST(SyclGpuRuntimeTest, TestStreamPoolCreate_Negative) {
             absl::StatusCode::kInvalidArgument);
 }
 
-TEST(SyclGpuRuntimeTest, TestStreamPoolDestroy_Negative) {
+TEST_F(SyclGpuRuntimeTest, TestStreamPoolDestroy_Negative) {
   TF_ASSERT_OK_AND_ASSIGN(
       StreamPtr stream_handle,
       SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
@@ -110,7 +206,7 @@ TEST(SyclGpuRuntimeTest, TestStreamPoolDestroy_Negative) {
   EXPECT_EQ(stream_handle, nullptr);
 }
 
-TEST(SyclGpuRuntimeTest, TestMaxStreamsPerDevice) {
+TEST_F(SyclGpuRuntimeTest, TestMaxStreamsPerDevice) {
   // Ensure that the maximum number of streams per device is respected.
   constexpr int kMaxStreams = 8;
   std::vector<StreamPtr> streams(kMaxStreams);
@@ -134,6 +230,194 @@ TEST(SyclGpuRuntimeTest, TestMaxStreamsPerDevice) {
         SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, streams[i]).ok());
     EXPECT_EQ(streams[i], nullptr);
   }
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMemsetDevice) {
+  constexpr int kCount = 10;
+  TF_ASSERT_OK_AND_ASSIGN(
+      void* src_device,
+      SyclMallocDevice(kDefaultDeviceOrdinal, sizeof(char) * kCount));
+  ASSERT_NE(src_device, nullptr);
+
+  ASSERT_TRUE(SyclMemsetDevice(kDefaultDeviceOrdinal, src_device, 'A',
+                               sizeof(char) * kCount)
+                  .ok());
+
+  // TODO(intel-tf): Verify the results by copying back to host once SyclMemcpy
+  // is implemented.
+  FreeAndNullify(src_device);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMemsetDevice_Negative) {
+  constexpr int kCount = 10;
+  constexpr int kInvalidDeviceOrdinal = -1;
+
+  TF_ASSERT_OK_AND_ASSIGN(void* src_device, AllocateDeviceBuffer(kCount));
+  ASSERT_NE(src_device, nullptr);
+
+  // Attempt to memset with an invalid device ordinal.
+  EXPECT_EQ(SyclMemsetDevice(kInvalidDeviceOrdinal, src_device, 'A',
+                             sizeof(char) * kCount)
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+
+  // Attempt to memset a null pointer.
+  void* null_ptr = nullptr;
+  EXPECT_EQ(SyclMemsetDevice(kDefaultDeviceOrdinal, null_ptr, 'A',
+                             sizeof(char) * kCount)
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+
+  FreeAndNullify(src_device);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMemsetDeviceAsync) {
+  constexpr int kCount = 10;
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamPtr stream_handle,
+      SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
+                                        /*enable_multiple_streams=*/false));
+  ASSERT_NE(stream_handle, nullptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* device_buf, AllocateDeviceBuffer(kCount));
+
+  ASSERT_TRUE(SyclMemsetDeviceAsync(stream_handle.get(), device_buf, 'B',
+                                    sizeof(char) * kCount)
+                  .ok());
+
+  // Synchronize the stream to ensure the memset is complete before checking
+  // results.
+  ASSERT_TRUE(
+      SyclStreamPool::SynchronizeStreamPool(kDefaultDeviceOrdinal).ok());
+
+  // TODO(intel-tf): Verify the results by copying back to host once SyclMemcpy
+  // is implemented.
+  FreeAndNullify(device_buf);
+
+  // Destroy the stream after use.
+  ASSERT_TRUE(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  EXPECT_EQ(stream_handle, nullptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMemfillDeviceAsync) {
+  constexpr int kCount = 10;
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamPtr stream_handle,
+      SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
+                                        /*enable_multiple_streams=*/false));
+  ASSERT_NE(stream_handle, nullptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* device_buf, AllocateDeviceBuffer(kCount));
+
+  ASSERT_TRUE(SyclMemfillDeviceAsync(stream_handle.get(), device_buf,
+                                     0xDEADC0DE, sizeof(int) * kCount)
+                  .ok());
+
+  // Synchronize the stream to ensure the fill is complete before checking
+  // results.
+  ASSERT_TRUE(
+      SyclStreamPool::SynchronizeStreamPool(kDefaultDeviceOrdinal).ok());
+
+  // TODO(intel-tf): Verify the results by copying back to host once SyclMemcpy
+  // is implemented.
+  FreeAndNullify(device_buf);
+
+  // Destroy the stream after use.
+  ASSERT_TRUE(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  ASSERT_EQ(stream_handle, nullptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMemfillDeviceAsync_Negative) {
+  constexpr int kCount = 10;
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamPtr stream_handle,
+      SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
+                                        /*enable_multiple_streams=*/false));
+  ASSERT_NE(stream_handle, nullptr);
+
+  // Attempt to fill a null pointer.
+  void* null_ptr = nullptr;
+  EXPECT_EQ(SyclMemfillDeviceAsync(stream_handle.get(), null_ptr, 0xFEEDEAF,
+                                   sizeof(int) * kCount)
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+
+  // Destroy the stream after use.
+  ASSERT_TRUE(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  EXPECT_EQ(stream_handle, nullptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMallocAll_Positive) {
+  TF_ASSERT_OK_AND_ASSIGN(void* host_ptr, AllocateHostBuffer(/*count=*/256));
+  FreeAndNullify(host_ptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* device_ptr,
+                          AllocateDeviceBuffer(/*count=*/256));
+  FreeAndNullify(device_ptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* shared_ptr,
+                          SyclMallocShared(kDefaultDeviceOrdinal,
+                                           /*byte_count=*/1024));
+  EXPECT_NE(shared_ptr, nullptr);
+  FreeAndNullify(shared_ptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMallocAll_InvalidDeviceOrdinal) {
+  constexpr int kInvalidDeviceOrdinal = -1;
+  EXPECT_EQ(SyclMallocHost(kInvalidDeviceOrdinal, 10).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(SyclMallocDevice(kInvalidDeviceOrdinal, 20).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(SyclMallocShared(kInvalidDeviceOrdinal, 30).status().code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestMallocAll_ZeroAllocation) {
+  constexpr size_t kByteCount = 0;
+  TF_ASSERT_OK_AND_ASSIGN(void* host_ptr,
+                          SyclMallocHost(kDefaultDeviceOrdinal, kByteCount));
+  EXPECT_EQ(host_ptr, nullptr)
+      << "Expected nullptr for zero allocation on host memory.";
+  FreeAndNullify(host_ptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* device_ptr,
+                          SyclMallocDevice(kDefaultDeviceOrdinal, kByteCount));
+  EXPECT_EQ(device_ptr, nullptr)
+      << "Expected nullptr for zero allocation on device memory.";
+  FreeAndNullify(device_ptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* shared_ptr,
+                          SyclMallocShared(kDefaultDeviceOrdinal, kByteCount));
+  EXPECT_EQ(shared_ptr, nullptr)
+      << "Expected nullptr for zero allocation on shared memory.";
+  FreeAndNullify(shared_ptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestSyclFree_Negative) {
+  constexpr int kInvalidDeviceOrdinal = -1;
+  void* null_ptr = nullptr;  // Null pointer should not cause issues.
+
+  // Attempt to free with an invalid device ordinal.
+  EXPECT_EQ(SyclFree(kInvalidDeviceOrdinal, null_ptr).code(),
+            absl::StatusCode::kInvalidArgument);
+
+  // Attempt to free a null pointer.
+  EXPECT_EQ(SyclFree(kDefaultDeviceOrdinal, null_ptr).code(),
+            absl::StatusCode::kInvalidArgument)
+      << "Expected error when trying to free a null pointer.";
+}
+
+TEST_F(SyclGpuRuntimeTest, TestSyclFree_DoubleFree) {
+  TF_ASSERT_OK_AND_ASSIGN(void* device_ptr, AllocateDeviceBuffer(10));
+  ASSERT_TRUE(SyclFree(kDefaultDeviceOrdinal, device_ptr).ok());
+  EXPECT_EQ(device_ptr, nullptr);
+
+  // Try to free again, which should return an error.
+  EXPECT_EQ(SyclFree(kDefaultDeviceOrdinal, device_ptr).code(),
+            absl::StatusCode::kInvalidArgument);
 }
 
 }  // namespace


### PR DESCRIPTION
Co-author: @kanvi-nervana 

This PR implements SYCL memory management functions and adds corresponding tests. It depends on #32305.