### PR TITLE
[XLA:CPU][oneDNN] Fix failing oneDNN tests and F16 regressions

### DIFF
--- a/xla/service/change_op_data_type.cc
+++ b/xla/service/change_op_data_type.cc
@@ -68,8 +68,8 @@ absl::StatusOr<bool> ChangeOpDataType::Run(
 #ifdef XLA_ONEDNN
       // TODO(penporn): Move this logic outside of this pass.
       const DebugOptions& debug_options = module->config().debug_options();
-      if (debug_options.xla_cpu_use_onednn() &&
-          !debug_options.xla_cpu_experimental_onednn_custom_call() &&
+      if ((debug_options.xla_cpu_use_onednn() ||
+           debug_options.xla_cpu_experimental_onednn_custom_call()) &&
           cpu::OneDnnContractionRewriter::ShouldRewriteInstr(instr, true)) {
         continue;
       }

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -684,6 +684,9 @@ absl::Status CpuCompiler::RunHloPassesThroughLayoutAssn(
           .debug_options()
           .xla_cpu_experimental_onednn_custom_call() &&
       IsOneDnnCompatible(is_aot_compile);
+  bool use_onednn_graph =
+      module->config().debug_options().xla_cpu_use_onednn() &&
+      IsOneDnnCompatible(is_aot_compile);
 #ifdef XLA_ONEDNN
   if (use_onednn_custom_call) {
     // Placing OneDnnOpsRewriter here to match the flax patterns
@@ -706,7 +709,7 @@ absl::Status CpuCompiler::RunHloPassesThroughLayoutAssn(
                                target_machine_features);
 #ifdef XLA_ONEDNN
   OneDnnFloatSupport onednn_bf16_support(BF16);
-  if (use_onednn_custom_call) {
+  if (use_onednn_custom_call || use_onednn_graph) {
     pipeline.AddPass<FloatNormalization>(&onednn_bf16_support);
   } else {
     pipeline.AddPass<FloatNormalization>(&bf16_support);

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -684,9 +684,6 @@ absl::Status CpuCompiler::RunHloPassesThroughLayoutAssn(
           .debug_options()
           .xla_cpu_experimental_onednn_custom_call() &&
       IsOneDnnCompatible(is_aot_compile);
-  bool use_onednn_graph =
-      module->config().debug_options().xla_cpu_use_onednn() &&
-      IsOneDnnCompatible(is_aot_compile);
 #ifdef XLA_ONEDNN
   if (use_onednn_custom_call) {
     // Placing OneDnnOpsRewriter here to match the flax patterns
@@ -708,6 +705,9 @@ absl::Status CpuCompiler::RunHloPassesThroughLayoutAssn(
   CpuFloatSupport bf16_support(BF16, call_library_for_dot,
                                target_machine_features);
 #ifdef XLA_ONEDNN
+  bool use_onednn_graph =
+      module->config().debug_options().xla_cpu_use_onednn() &&
+      IsOneDnnCompatible(is_aot_compile);
   OneDnnFloatSupport onednn_bf16_support(BF16);
   if (use_onednn_custom_call || use_onednn_graph) {
     pipeline.AddPass<FloatNormalization>(&onednn_bf16_support);


### PR DESCRIPTION
This PR addresses the side effects of a previous XLA commit (https://github.com/openxla/xla/commit/bd3f15e30fd588a53c8d7a594bafaa34d4f4adb5) that prevented any fusions for oneDNN F16 custom calls. In particular, this PR:
1. Expands the type promotion condition to include checks for oneDNN CCs too.
2. Use oneDNN float support for both oneDNN CCs and graph based execution.