### PR TITLE
[NVIDIA GPU] Set nccl max channels to 32 for blackwell

### DIFF
--- a/xla/backends/cpu/collectives/cpu_collectives.h
+++ b/xla/backends/cpu/collectives/cpu_collectives.h
@@ -64,7 +64,8 @@ class CpuCollectives : public Collectives {
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>> SplitCommunicators(
       absl::Span<const Communicator* const> comms, int32_t color,
-      absl::Span<const RankId> keys, const Config& config) final {
+      absl::Span<const RankId> keys, const Config& config,
+      absl::Span<const DeviceRank> ranks) final {
     return Unimplemented(
         "CPU collectives do not support communicator splitting");
   }

--- a/xla/backends/gpu/collectives/gpu_collectives_stub.h
+++ b/xla/backends/gpu/collectives/gpu_collectives_stub.h
@@ -58,7 +58,7 @@ class GpuCollectivesStub : public GpuCollectives {
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>> SplitCommunicators(
       absl::Span<const Communicator* const>, int32_t, absl::Span<const RankId>,
-      const Collectives::Config&) final {
+      const Collectives::Config&, absl::Span<const DeviceRank> ranks) final {
     return UnimplementedError();
   }
 

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -51,6 +51,7 @@ limitations under the License.
 #include "xla/service/global_device_id.h"
 #include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/status_macros.h"
+#include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -117,7 +117,7 @@ static ncclConfig_t AsNcclConfig(const GpuCollectives::Config& config,
     comm_config.maxCTAs = config.max_nchannels;
   } else if (stream_executor->GetDeviceDescription()
                  .cuda_compute_capability()
-                 .IsAtLeastBlackwell()) {
+                 .IsBlackwell()) {
 #if (NCCL_VERSION_CODE >= 22800)
     // Future NCCL versions will reduce the default max number of channels on
     // Blackwell to 16. We need to manually set it to 32 here to avoid surprise

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -117,14 +117,13 @@ static ncclConfig_t AsNcclConfig(const GpuCollectives::Config& config,
     comm_config.maxCTAs = config.max_nchannels;
   } else if (stream_executor->GetDeviceDescription()
                  .cuda_compute_capability()
-                 .IsBlackwell()) {
-#if (NCCL_VERSION_CODE >= 22800)
+                 .IsBlackwell() &&
+             NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)) {
     // Future NCCL versions will reduce the default max number of channels on
     // Blackwell to 16. We need to manually set it to 32 here to avoid surprise
     // perf regressions.
     VLOG(1) << "Setting max number of channels to 32 on Blackwell.";
     comm_config.maxCTAs = 32;
-#endif  // NCCL_VERSION_CODE >= 22800
   }
   return comm_config;
 }

--- a/xla/backends/gpu/collectives/nccl_collectives.h
+++ b/xla/backends/gpu/collectives/nccl_collectives.h
@@ -56,7 +56,8 @@ class NcclCollectives : public GpuCollectives {
   }
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>> SplitCommunicators(
       absl::Span<const Communicator* const> comms, int32_t color,
-      absl::Span<const RankId> keys, const Collectives::Config& config) final;
+      absl::Span<const RankId> keys, const Collectives::Config& config,
+      absl::Span<const DeviceRank> ranks) final;
 
   absl::StatusOr<void*> Allocate(uint64_t bytes) final;
 

--- a/xla/backends/gpu/collectives/nvshmem_collectives.h
+++ b/xla/backends/gpu/collectives/nvshmem_collectives.h
@@ -76,7 +76,8 @@ class NvshmemCollectives : public GpuCollectives {
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>> SplitCommunicators(
       absl::Span<const Communicator* const> comms, int32_t color,
-      absl::Span<const RankId> keys, const Collectives::Config& config) final {
+      absl::Span<const RankId> keys, const Collectives::Config& config,
+      absl::Span<const DeviceRank> ranks) final {
     return absl::UnimplementedError("Not implemented.");
   }
 

--- a/xla/core/collectives/collectives.h
+++ b/xla/core/collectives/collectives.h
@@ -79,7 +79,8 @@ class Collectives {
   // Creates communicators by splitting `comms`.
   virtual absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
   SplitCommunicators(absl::Span<const Communicator* const> comms, int32_t color,
-                     absl::Span<const RankId> keys, const Config& config) = 0;
+                     absl::Span<const RankId> keys, const Config& config,
+                     absl::Span<const DeviceRank> ranks) = 0;
 
   // Collectives instance can be ephemeral and used only for a small number of
   // XLA program executions. XLA backends that rely on the collectives instances


### PR DESCRIPTION
📝 Summary of Changes
Starting NCCL 2.28, nccl reduced the default max channels for collectives on blackwell from 32 to 16.
We need to pin it to 32 in xla to avoid surprise perf regressions.

🎯 Justification
Without this, default xla will incur perf regression after nccl 2.28 on blackwell.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Ran all benchmarks on blackwell and observed no perf regressions with this change.

🧪 Unit Tests:
NA

🧪 Execution Tests:
All benchmarks under tools/benchmark
