### PR TITLE
[XLA:GPU] Change the NCCL command to have the highest priority in command buffer

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -1999,7 +1999,7 @@ CommandBufferCmd::BufferUseVector CustomCallCmd::buffers() const {
 CollectiveCmd::CollectiveCmd(
     CommandBufferCmdType cmd_type, CollectiveConfig config,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CommandBufferCmd(cmd_type),
+    : CommandBufferCmd(cmd_type, se::StreamPriority::Highest),
       config_(std::move(config)),
       async_events_(std::move(async_events)) {}
 


### PR DESCRIPTION
📝 Summary of Changes
Change the collective command buffer cmd to have the highest priority by default.

🎯 Justification
collective has the highest priority should have more compute-communicate overlap

🚀 Kind of Contribution
⚡️ Performance Improvement,

All collective command buffer unitests should have covered the fix in this PR. 