### PR TITLE
[ROCm] Add CI specific bazelrc file

### DIFF
--- a/build_tools/rocm/rocm_xla_ci.bazelrc
+++ b/build_tools/rocm/rocm_xla_ci.bazelrc
@@ -1,0 +1,3 @@
+# CI related imports
+try-import /usertools/rocm.bazelrc
+try-import %workspace%/build_tools/rocm/rocm_xla.bazelrc

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -26,7 +26,7 @@ if [ ! -d /tf/pkg ]; then
 fi
 
 SCRIPT_DIR=$(dirname $0)
-bazel --bazelrc="$SCRIPT_DIR/rocm_xla.bazelrc" test \
+bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
 	"$@" \
 	--build_tag_filters=$TAG_FILTERS \
     --test_tag_filters=$TAG_FILTERS \


### PR DESCRIPTION
📝 Summary of Changes
Add CI-specific bazelrc that will import both `rocm.bazelrc` from `/usertools` and `rocm_xla.bazelrc`

🎯 Justification
Temporary workaround until split logic in CI (which relies on `/usertools/rocm.bazelrc`) is removed
