### PR TITLE
[ROCm] correct LHS logic with force_earliest_schedule()

### DIFF
--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -390,8 +390,9 @@ void GpuAsyncTrackerBase::PostProcessScheduleGraph(
       auto gpu_config = inst->backend_config<GpuBackendConfig>();
       if (gpu_config.ok()) {
         HloGraphNode& node = schedule_graph->GetNode(inst);
-        node.SetForceDelay(gpu_config->force_earliest_schedule());
-        VLOG(5) << "Setting force delay for instruction: " << inst->ToString();
+        node.SetForceEarly(gpu_config->force_earliest_schedule());
+        VLOG(5) << "Setting force early for instruction: " << inst->ToString()
+                << " to " << gpu_config->force_earliest_schedule();
       }
     }
   }


### PR DESCRIPTION
📝 Summary of Changes
To be consistent with `force_earliest_schedule` logic.

🎯 Justification

Since we want `gpu_config->force_earliest_schedule()` to schedule the node as early as possible, we shouldn't use `node.SetForceDelay()` here.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 

@xla-rotation please check this PR, thanks!
