### PR TITLE
[ROCm] Fix too strict default spanw strategy for rbe builds

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -16,7 +16,7 @@ build:rocm_rbe --spawn_strategy=remote,local
 test:rocm_rbe --jobs=200
 test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
 test:rocm_rbe --remote_timeout=3600
-test:rocm_rbe --strategy=TestRunner=remote
+test:rocm_rbe --strategy=TestRunner=remote,local
 
 build:tsan --strip=never
 build:tsan --copt -fsanitize=thread


### PR DESCRIPTION
📝 Summary of Changes
Fix too strict spawn strategy for rbe builds

🎯 Justification
remote only execution is not possible for all the tests

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
