### PR TITLE
Rename "forward compatible" capabilities to "family compatible", per NVIDIA naming.

### DIFF
--- a/xla/service/gpu/autotuning/dot_search_space_test.cc
+++ b/xla/service/gpu/autotuning/dot_search_space_test.cc
@@ -154,7 +154,7 @@ class DotSearchSpaceTest : public DefaultDeviceDotSearchSpaceTest {
     device_description_.set_threads_per_warp(32);
     device_description_.set_shared_memory_per_block_optin(227 * 1024);
     device_description_.set_gpu_compute_capability(
-        se::CudaComputeCapability::H100Family());
+        se::CudaComputeCapability::H100Accelerated());
   }
 };
 

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -276,7 +276,7 @@ std::string GetSmName(se::CudaComputeCapability compute_capability) {
     // major version supports the forward compatible feature
     // extension.
     target_compute_capability.feature_extension =
-        se::CudaComputeCapability::FeatureExtension::kForwardCompatibleFeatures;
+        se::CudaComputeCapability::FeatureExtension::kFamilyCompatibleFeatures;
   }
 
   // If the current CC isn't supported by LLVM and it is newer then

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -40,7 +40,7 @@ TEST(UtilsTest, TestGetSmName) {
                 10, 0, FeatureExtension::kAcceleratedFeatures}),
             "sm_100a");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
-                10, 0, FeatureExtension::kForwardCompatibleFeatures}),
+                10, 0, FeatureExtension::kFamilyCompatibleFeatures}),
             "sm_100f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
                 10, 3, FeatureExtension::kAcceleratedFeatures}),

--- a/xla/stream_executor/cuda/cuda_compute_capability.cc
+++ b/xla/stream_executor/cuda/cuda_compute_capability.cc
@@ -43,7 +43,7 @@ absl::StatusOr<CudaComputeCapability> CudaComputeCapability::FromString(
   }
 
   if (!split[1].empty() && (split[1].back() == 'f' || split[1].back() == 'F')) {
-    feature_extension = FeatureExtension::kForwardCompatibleFeatures;
+    feature_extension = FeatureExtension::kFamilyCompatibleFeatures;
     split[1].remove_suffix(1);
   }
 
@@ -63,7 +63,7 @@ static std::string FeatureExtensionToString(
       return "";
     case CudaComputeCapability::FeatureExtension::kAcceleratedFeatures:
       return "a";
-    case CudaComputeCapability::FeatureExtension::kForwardCompatibleFeatures:
+    case CudaComputeCapability::FeatureExtension::kFamilyCompatibleFeatures:
       return "f";
   }
 }
@@ -110,8 +110,8 @@ absl::StatusOr<CudaComputeCapability> CudaComputeCapability::FromProto(
     case CudaComputeCapabilityProto::ACCELERATED_FEATURES:
       cc.feature_extension = FeatureExtension::kAcceleratedFeatures;
       break;
-    case CudaComputeCapabilityProto::FORWARD_COMPATIBLE_FEATURES:
-      cc.feature_extension = FeatureExtension::kForwardCompatibleFeatures;
+    case CudaComputeCapabilityProto::FAMILY_COMPATIBLE_FEATURES:
+      cc.feature_extension = FeatureExtension::kFamilyCompatibleFeatures;
       break;
     default:
       return absl::InvalidArgumentError(absl::StrCat(
@@ -133,9 +133,9 @@ CudaComputeCapabilityProto CudaComputeCapability::ToProto() const {
       proto.set_feature_extension(
           CudaComputeCapabilityProto::ACCELERATED_FEATURES);
       break;
-    case FeatureExtension::kForwardCompatibleFeatures:
+    case FeatureExtension::kFamilyCompatibleFeatures:
       proto.set_feature_extension(
-          CudaComputeCapabilityProto::FORWARD_COMPATIBLE_FEATURES);
+          CudaComputeCapabilityProto::FAMILY_COMPATIBLE_FEATURES);
       break;
   }
   return proto;

--- a/xla/stream_executor/cuda/cuda_compute_capability.h
+++ b/xla/stream_executor/cuda/cuda_compute_capability.h
@@ -57,9 +57,9 @@ struct CudaComputeCapability {
             // a higher compute capability. Example: sm_90
     kAcceleratedFeatures,  // Enables features that only work on GPUs with the
                            // same compute capability. Example: sm_90a
-    kForwardCompatibleFeatures  // Enables features that only work on GPUs
-                                // within the same major version and a later
-                                // minor version. Example: sm_100f
+    kFamilyCompatibleFeatures  // Enables features that only work on GPUs
+                               // within the same major version and a later
+                               // minor version. Example: sm_100f
   };
   FeatureExtension feature_extension = FeatureExtension::kNone;
 
@@ -104,7 +104,7 @@ struct CudaComputeCapability {
   // Includes all GPUs with compute capability 9.0, notably H100, H200, and
   // GH200. When comparing with `IsAtLeast` this will only be true for GPUs with
   // compute capability 9.0.
-  constexpr static CudaComputeCapability H100Family() {
+  constexpr static CudaComputeCapability H100Accelerated() {
     return CudaComputeCapability{kHopper, 0,
                                  FeatureExtension::kAcceleratedFeatures};
   }
@@ -119,7 +119,7 @@ struct CudaComputeCapability {
   // Includes all GPUs with compute capability 10.0, notably B200 and GB200.
   // When comparing with `IsAtLeast` this will only be true for GPUs with
   // compute capability 10.0.
-  constexpr static CudaComputeCapability B200Family() {
+  constexpr static CudaComputeCapability B200Accelerated() {
     return CudaComputeCapability{kBlackwell, 0,
                                  FeatureExtension::kAcceleratedFeatures};
   }
@@ -133,9 +133,9 @@ struct CudaComputeCapability {
   // Includes all GPUs with compute capability 10.x. When comparing with
   // `IsAtLeast` this will true for all 10.x compute capabilities but not for
   // compute capabilities with a higher major version.
-  constexpr static CudaComputeCapability BlackwellGenerationOnly() {
+  constexpr static CudaComputeCapability BlackwellFamily() {
     return CudaComputeCapability{kBlackwell, 0,
-                                 FeatureExtension::kForwardCompatibleFeatures};
+                                 FeatureExtension::kFamilyCompatibleFeatures};
   }
 
   // Returns true if the compute capability is at least
@@ -194,7 +194,7 @@ struct CudaComputeCapability {
         return std::tie(major, minor) >= std::tie(other.major, other.minor);
       case FeatureExtension::kAcceleratedFeatures:
         return std::tie(major, minor) == std::tie(other.major, other.minor);
-      case FeatureExtension::kForwardCompatibleFeatures:
+      case FeatureExtension::kFamilyCompatibleFeatures:
         return major == other.major && minor >= other.minor;
     }
   }

--- a/xla/stream_executor/cuda/cuda_compute_capability.proto
+++ b/xla/stream_executor/cuda/cuda_compute_capability.proto
@@ -22,10 +22,13 @@ message CudaComputeCapabilityProto {
   int32 minor = 2;
 
   enum FeatureExtension {
+    // UNSPECIFIED is only needed because when this field is not set
+    // it defaults to 0, but on Hopper and Blackwell we want to detect that
+    // and default to ACCELERATED_FEATURES, not to NONE.
     UNSPECIFIED = 0;
     NONE = 1;
     ACCELERATED_FEATURES = 2;
-    FORWARD_COMPATIBLE_FEATURES = 3;
+    FAMILY_COMPATIBLE_FEATURES = 3;
   }
 
   FeatureExtension feature_extension = 3;

--- a/xla/stream_executor/cuda/cuda_compute_capability_test.cc
+++ b/xla/stream_executor/cuda/cuda_compute_capability_test.cc
@@ -44,7 +44,7 @@ TEST(CudaComputeCapabilityTest, ToString) {
   EXPECT_EQ(
       CudaComputeCapability(
           100, 52,
-          CudaComputeCapability::FeatureExtension::kForwardCompatibleFeatures)
+          CudaComputeCapability::FeatureExtension::kFamilyCompatibleFeatures)
           .ToString(),
       "100.52f");
 }
@@ -65,13 +65,13 @@ TEST(CudaComputeCapabilityTest, FromString) {
                   100, 52, FeatureExtension::kAcceleratedFeatures)));
   EXPECT_THAT(CudaComputeCapability::FromString("100.52f"),
               IsOkAndHolds(CudaComputeCapability(
-                  100, 52, FeatureExtension::kForwardCompatibleFeatures)));
+                  100, 52, FeatureExtension::kFamilyCompatibleFeatures)));
   EXPECT_THAT(CudaComputeCapability::FromString("100.52F"),
               IsOkAndHolds(CudaComputeCapability(
-                  100, 52, FeatureExtension::kForwardCompatibleFeatures)));
+                  100, 52, FeatureExtension::kFamilyCompatibleFeatures)));
   EXPECT_THAT(CudaComputeCapability::FromString("100.52 f"),
               IsOkAndHolds(CudaComputeCapability(
-                  100, 52, FeatureExtension::kForwardCompatibleFeatures)));
+                  100, 52, FeatureExtension::kFamilyCompatibleFeatures)));
   EXPECT_THAT(CudaComputeCapability::FromString("1"),
               StatusIs(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(CudaComputeCapability::FromString("12"),
@@ -103,12 +103,12 @@ TEST(CudaComputeCapabilityTest, ToProto) {
   CudaComputeCapabilityProto proto2 =
       CudaComputeCapability(
           100, 5,
-          CudaComputeCapability::FeatureExtension::kForwardCompatibleFeatures)
+          CudaComputeCapability::FeatureExtension::kFamilyCompatibleFeatures)
           .ToProto();
   EXPECT_EQ(proto2.major(), 100);
   EXPECT_EQ(proto2.minor(), 5);
   EXPECT_EQ(proto2.feature_extension(),
-            CudaComputeCapabilityProto::FORWARD_COMPATIBLE_FEATURES);
+            CudaComputeCapabilityProto::FAMILY_COMPATIBLE_FEATURES);
 }
 
 TEST(CudaComputeCapabilityTest, FromProtoWithFeatureExtensionUnspecified) {
@@ -167,7 +167,7 @@ TEST(CudaComputeCapabilityTest, IsAtLeastMethods) {
   // IsAtLeastAmpere (sm_80)
   EXPECT_FALSE(CudaComputeCapability(7, 5).IsAtLeastAmpere());
   EXPECT_FALSE(
-      CudaComputeCapability(7, 5, FeatureExtension::kForwardCompatibleFeatures)
+      CudaComputeCapability(7, 5, FeatureExtension::kFamilyCompatibleFeatures)
           .IsAtLeastAmpere());
   EXPECT_TRUE(CudaComputeCapability(8, 0).IsAtLeastAmpere());
   EXPECT_TRUE(
@@ -188,7 +188,7 @@ TEST(CudaComputeCapabilityTest, IsAtLeastMethods) {
   // IsAtLeastBlackwell (sm_100)
   EXPECT_FALSE(CudaComputeCapability(9, 0).IsAtLeastBlackwell());
   EXPECT_FALSE(
-      CudaComputeCapability(9, 0, FeatureExtension::kForwardCompatibleFeatures)
+      CudaComputeCapability(9, 0, FeatureExtension::kFamilyCompatibleFeatures)
           .IsAtLeastBlackwell());
   EXPECT_TRUE(CudaComputeCapability(10, 0).IsAtLeastBlackwell());
   EXPECT_TRUE(
@@ -216,16 +216,16 @@ TEST(CudaComputeCapabilityTest, Hash) {
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
       CudaComputeCapability(0, 0),
       CudaComputeCapability(0, 0, FeatureExtension::kAcceleratedFeatures),
-      CudaComputeCapability(0, 0, FeatureExtension::kForwardCompatibleFeatures),
+      CudaComputeCapability(0, 0, FeatureExtension::kFamilyCompatibleFeatures),
       CudaComputeCapability(0, 1),
       CudaComputeCapability(0, 1, FeatureExtension::kAcceleratedFeatures),
-      CudaComputeCapability(0, 1, FeatureExtension::kForwardCompatibleFeatures),
+      CudaComputeCapability(0, 1, FeatureExtension::kFamilyCompatibleFeatures),
       CudaComputeCapability(1, 0),
       CudaComputeCapability(1, 0, FeatureExtension::kAcceleratedFeatures),
-      CudaComputeCapability(1, 0, FeatureExtension::kForwardCompatibleFeatures),
+      CudaComputeCapability(1, 0, FeatureExtension::kFamilyCompatibleFeatures),
       CudaComputeCapability(1, 1),
       CudaComputeCapability(1, 1, FeatureExtension::kAcceleratedFeatures),
-      CudaComputeCapability(1, 1, FeatureExtension::kForwardCompatibleFeatures),
+      CudaComputeCapability(1, 1, FeatureExtension::kFamilyCompatibleFeatures),
   }));
 }
 
@@ -241,12 +241,12 @@ TEST(CudaComputeCapabilityTest, ComparisonTest) {
   CudaComputeCapability base_but_accelerated{
       1, 0, FeatureExtension::kAcceleratedFeatures};
   CudaComputeCapability base_but_forward_compatible{
-      1, 0, FeatureExtension::kForwardCompatibleFeatures};
+      1, 0, FeatureExtension::kFamilyCompatibleFeatures};
   CudaComputeCapability newer_but_same_generation{1, 1};
   CudaComputeCapability newer_but_same_generation_accelerated{
       1, 1, FeatureExtension::kAcceleratedFeatures};
   CudaComputeCapability newer_but_same_generation_compatible{
-      1, 1, FeatureExtension::kForwardCompatibleFeatures};
+      1, 1, FeatureExtension::kFamilyCompatibleFeatures};
   CudaComputeCapability next_generation{2, 0};
 
   EXPECT_TRUE(base == base);
@@ -325,7 +325,7 @@ TEST(CudaComputeCapabilityTest, GetPtxAsTargetName) {
   EXPECT_EQ(
       CudaComputeCapability(
           10, 0,
-          CudaComputeCapability::FeatureExtension::kForwardCompatibleFeatures)
+          CudaComputeCapability::FeatureExtension::kFamilyCompatibleFeatures)
           .GetPtxAsTargetName(),
       "sm_100f");
 }
@@ -343,7 +343,7 @@ TEST(CudaComputeCapabilityTest, WithoutAnyFeatureExtension) {
   EXPECT_EQ(
       CudaComputeCapability(
           100, 52,
-          CudaComputeCapability::FeatureExtension::kForwardCompatibleFeatures)
+          CudaComputeCapability::FeatureExtension::kFamilyCompatibleFeatures)
           .WithoutAnyFeatureExtension(),
       CudaComputeCapability(100, 52));
 }

--- a/xla/stream_executor/cuda/driver_compilation_provider.cc
+++ b/xla/stream_executor/cuda/driver_compilation_provider.cc
@@ -95,7 +95,7 @@ absl::StatusOr<Assembly> DriverCompilationProvider::CompileAndLink(
 #endif
 
   if (cc.feature_extension ==
-      CudaComputeCapability::FeatureExtension::kForwardCompatibleFeatures) {
+      CudaComputeCapability::FeatureExtension::kFamilyCompatibleFeatures) {
     return absl::UnimplementedError(
         "Compiling forward compatible kernels is not implemented yet.");
   }


### PR DESCRIPTION
See:
https://developer.nvidia.com/blog/nvidia-blackwell-and-nvidia-cuda-12-9-introduce-family-specific-architecture-features/

Family compatible supported was introduced in https://github.com/openxla/xla/commit/16b9d957ff9c4b177ccb0e736b9e5135b392749a.
It's not clear to me how someone can actually configure XLA to use sm_100f. Will look into that next.