### PR TITLE
[XLA:GPU][oneAPI] Fix build issue in IntelGpuCompiler

### DIFF
--- a/xla/service/gpu/intel_gpu_compiler.cc
+++ b/xla/service/gpu/intel_gpu_compiler.cc
@@ -29,7 +29,7 @@ IntelGpuCompiler::IntelGpuCompiler()
                   spir::DataLayout()) {}
 
 absl::Status IntelGpuCompiler::OptimizeHloConvolutionCanonicalization(
-    HloModule* hlo_module, se::GpuComputeCapability gpu_version,
+    HloModule* hlo_module, const se::GpuComputeCapability& gpu_version,
     se::dnn::VersionInfo dnn_version,
     const se::SemanticVersion& toolkit_version) {
   // Note: this is a stub.

--- a/xla/service/gpu/intel_gpu_compiler.h
+++ b/xla/service/gpu/intel_gpu_compiler.h
@@ -35,7 +35,7 @@ class IntelGpuCompiler : public GpuCompiler {
   IntelGpuCompiler();
 
   absl::Status OptimizeHloConvolutionCanonicalization(
-      HloModule* hlo_module, se::GpuComputeCapability gpu_version,
+      HloModule* hlo_module, const se::GpuComputeCapability& gpu_version,
       se::dnn::VersionInfo dnn_version,
       const se::SemanticVersion& toolkit_version) override;
 


### PR DESCRIPTION
📝 Summary of Changes
This PR fixes a build issue in `IntelGpuCompiler` class. It is due to a recent function signature change in the `GpuCompiler::OptimizeHloConvolutionCanonicalization` API.

🎯 Justification
 Fixes a build issue for the CI: XLA Linux X86 GPU ONEAPI

🚀 Kind of Contribution
🐛 Bug Fix
