### PR TITLE
Adding a delayMoveToHost heuristic to LHS and related tests. 

### DIFF
--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -562,6 +562,56 @@ LegalizeSchedulingAnnotations::Config SchedulingAnnotationsConfig() {
   return annotation_config;
 }
 
+// Delays MoveToHostAsyncStart as late as possible
+// to achieve better overlapping with computation.
+// The only pattern we are seeing is async start of a fusion with a dynamic update slice:
+// ```
+// %async_start = async_start(%fusion), async_wrapped={%fusion}
+// %dynamic_update_slice = dynamic_update_slice(%param, %update, %indices)
+// %wrapped_dynamic-update-slice_computation {
+//   %param_0.38286 = ... parameter(0)
+//   %param_1.38949 = ... parameter(1)
+//   %param_2.30408 = s32[] parameter(2)
+//   %param_3.25973 = s32[] parameter(3)
+//   %param_4.20600 = s32[] parameter(4)
+//   %param_5.16397 = s32[] parameter(5)
+//   %param_6.12209 = s32[] parameter(6)
+//   ROOT %dynamic-update-slice.1 = dynamic-update-slice()
+// }
+// ```
+// To add more patterns like non-fused when observed on real workloads.
+std::optional<DefaultSchedulerCore::CandidateResult>
+DelayMoveToHostAsyncStartCandidateCondition(
+    DefaultSchedulerCore::ScheduleCandidate& a,
+    DefaultSchedulerCore::ScheduleCandidate& b) {
+  auto is_send_host_dus_fn =
+      [=](DefaultSchedulerCore::ScheduleCandidate& a) -> bool {
+    bool is_send_host_dus = false;
+    if (a.node->GetOpcode() == HloOpcode::kAsyncStart) {
+      if (a.node->GetInstr().async_wrapped_instruction()->opcode() ==
+          HloOpcode::kFusion) {
+        auto fused_instrs = a.node->GetInstr()
+                                .async_wrapped_instruction()
+                                ->fused_instructions();
+        for (auto instr : fused_instrs) {
+          if (instr->opcode() == HloOpcode::kDynamicUpdateSlice) {
+            is_send_host_dus = true;
+            break;
+          }
+        }
+      }
+    }
+    return is_send_host_dus;
+  };
+
+  if (auto value = DefaultSchedulerCore::ChooseBestCandidate(
+          !is_send_host_dus_fn(a), a, !is_send_host_dus_fn(b), b,
+          "kDelayMoveToHostAsyncStart")) {
+    return value;
+  }
+  return std::nullopt;
+}
+
 // Adds necessary passes to perform latency hiding estimations for the
 // `pipeline`.
 absl::Status RunLatencyHidingSchedulerPasses(
@@ -645,6 +695,11 @@ absl::Status RunLatencyHidingSchedulerPasses(
               b, "kDelayAsyncStartForDepth"};
         }
       }
+    }
+
+    if (!config.top_down_scheduling) {
+      // Only do this for bottom-up scheduling, as top-down scheduling is not supported yet.
+      return DelayMoveToHostAsyncStartCandidateCondition(a, b);
     }
     return std::nullopt;
   };

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1172,5 +1172,76 @@ ENTRY main {
                   GetIndexByName(instruction_sequence, "rs_1"));
 }
 
+TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
+  absl::string_view kHloModule = R"(
+    HloModule delay_moveToHost_asyncStart, is_scheduled=false
+
+
+    %wrapped_dynamic-update-slice_computation.6 (param_0.38286: bf16[8,2,4,128,128], param_1.38949: bf16[1,2,4,128,128], param_2.30408: s32[], param_3.25973: s32[], param_4.20600: s32[], param_5.16397: s32[], param_6.12209: s32[]) -> bf16[8,2,4,128,128] {
+      %param_0.38286 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} parameter(0)
+      %param_1.38949 = bf16[1,2,4,128,128]{4,3,2,1,0} parameter(1)
+      %param_2.30408 = s32[] parameter(2)
+      %param_3.25973 = s32[] parameter(3)
+      %param_4.20600 = s32[] parameter(4)
+      %param_5.16397 = s32[] parameter(5)
+      %param_6.12209 = s32[] parameter(6)
+      ROOT %dynamic-update-slice.536.1 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} dynamic-update-slice(%param_0.38286, %param_1.38949, %param_2.30408, %param_3.25973, %param_4.20600, /*index=5*/%param_5.16397, %param_6.12209)
+    }
+
+    %async_computation.6 (param_0.6: bf16[8,2,4,128,128], param_1.6: bf16[1,2,4,128,128], param_2.6: s32[], param_3.6: s32[], param_4.6: s32[], param_5.2: s32[], param_6: s32[]) -> bf16[8,2,4,128,128] {
+      %param_0.6 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} parameter(0)
+      %param_1.6 = bf16[1,2,4,128,128]{4,3,2,1,0} parameter(1)
+      %param_2.6 = s32[] parameter(2)
+      %param_3.6 = s32[] parameter(3)
+      %param_4.6 = s32[] parameter(4)
+      %param_5.2 = s32[] parameter(5)
+      %param_6 = s32[] parameter(6)
+      ROOT %wrapped_dynamic-update-slice.6 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} fusion(%param_0.6, %param_1.6, %param_2.6, %param_3.6, %param_4.6, /*index=5*/%param_5.2, %param_6), kind=kLoop, calls=%wrapped_dynamic-update-slice_computation.6
+    }
+
+    %async_computation.46 (param_0.38229: bf16[1,8,16,16,128,7168]) -> bf16[1,8,16,16,128,7168] {
+      %param_0.38229 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} parameter(0)
+      ROOT %all-to-all.32.1 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} all-to-all(%param_0.38229), channel_id=474, replica_groups=[8,16]<=[128], dimensions={2}
+    }
+
+
+    ENTRY main {
+      p0 = bf16[8,2,4,128,128] parameter(0)
+      p1 = bf16[1,2,4,128,128] parameter(1)
+      p2 = s32[] parameter(2)
+      p3 = s32[] parameter(3)
+      p4 = s32[] parameter(4)
+      p5 = s32[] parameter(5)
+      p6 = s32[] parameter(6)
+      p7 = bf16[1,8,16,16,128,7168] parameter(7)
+      p8 = bf16[] parameter(8)
+
+      %all-to-all-start.4 = ((bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}), bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}) async-start(p7), calls=%async_computation.46, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"collective_backend_config":{"is_sync":false,"is_pipelined":false,"backend":"DEFAULT"},"force_earliest_schedule":false,"reification_cost":[],"device_type":"DEVICE_TYPE_INVALID"}
+      %all-to-all-done.4 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} async-done(%all-to-all-start.4)
+      %bitcast.309.7 = bf16[128,16,128,7168]{3,2,1,0} bitcast(%all-to-all-done.4)
+      %bitcast.310.9 = bf16[] bitcast(p8)
+      %broadcast_in_dim.6026.9 = bf16[128,16,128,7168]{3,2,1,0} broadcast(%bitcast.310.9), dimensions={}
+      %mul.5173.7 = bf16[128,16,128,7168]{3,2,1,0} multiply(%bitcast.309.7, %broadcast_in_dim.6026.9)
+      %dynamic-update-slice-start.18 = ((bf16[8,2,4,128,128]{4,3,2,1,0:S(5)}, bf16[1,2,4,128,128]{4,3,2,1,0}, s32[], s32[], s32[], /*index=5*/s32[], s32[]), bf16[8,2,4,128,128]{4,3,2,1,0:S(5)}, u32[]) async-start(p0, p1, p2, p3, p4, p5, p6), calls=%async_computation.6
+      %dynamic-update-slice-done.18 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} async-done(%dynamic-update-slice-start.18)
+      ROOT _ = (bf16[128,16,128,7168], bf16[8,2,4,128,128]) tuple(%mul.5173.7, %dynamic-update-slice-done.18)
+    }
+  )";
+
+  absl::string_view kFdoProfile = "";
+  auto config = GetModuleConfig(kFdoProfile);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
+
+  TF_EXPECT_OK(ScheduleModule(module.get()));
+  auto schedule = module->schedule();
+  std::vector<HloInstruction*> instruction_sequence =
+      schedule.sequence(module->entry_computation()).instructions();
+
+  EXPECT_TRUE(
+      GetIndexByName(instruction_sequence, "dynamic-update-slice-start.18") <
+      GetIndexByName(instruction_sequence, "all-to-all-start.4"));
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1177,15 +1177,15 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
     HloModule delay_moveToHost_asyncStart, is_scheduled=false
 
 
-    %wrapped_dynamic-update-slice_computation.6 (param_0.38286: bf16[8,2,4,128,128], param_1.38949: bf16[1,2,4,128,128], param_2.30408: s32[], param_3.25973: s32[], param_4.20600: s32[], param_5.16397: s32[], param_6.12209: s32[]) -> bf16[8,2,4,128,128] {
-      %param_0.38286 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} parameter(0)
-      %param_1.38949 = bf16[1,2,4,128,128]{4,3,2,1,0} parameter(1)
-      %param_2.30408 = s32[] parameter(2)
-      %param_3.25973 = s32[] parameter(3)
-      %param_4.20600 = s32[] parameter(4)
-      %param_5.16397 = s32[] parameter(5)
-      %param_6.12209 = s32[] parameter(6)
-      ROOT %dynamic-update-slice.536.1 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} dynamic-update-slice(%param_0.38286, %param_1.38949, %param_2.30408, %param_3.25973, %param_4.20600, /*index=5*/%param_5.16397, %param_6.12209)
+    %wrapped_dynamic-update-slice_computation.6 (p0.0: bf16[8,2,4,128,128], p1.0: bf16[1,2,4,128,128], p2.0: s32[], p3.0: s32[], p4.0: s32[], p5.0: s32[], p6.0: s32[]) -> bf16[8,2,4,128,128] {
+      %p0.0 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} parameter(0)
+      %p1.0 = bf16[1,2,4,128,128]{4,3,2,1,0} parameter(1)
+      %p2.0 = s32[] parameter(2)
+      %p3.0 = s32[] parameter(3)
+      %p4.0 = s32[] parameter(4)
+      %p5.0 = s32[] parameter(5)
+      %p6.0 = s32[] parameter(6)
+      ROOT %dynamic-update-slice.536.1 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} dynamic-update-slice(%p0.0, %p1.0, %p2.0, %p3.0, %p4.0, /*index=5*/%p5.0, %p6.0)
     }
 
     %async_computation.6 (param_0.6: bf16[8,2,4,128,128], param_1.6: bf16[1,2,4,128,128], param_2.6: s32[], param_3.6: s32[], param_4.6: s32[], param_5.2: s32[], param_6: s32[]) -> bf16[8,2,4,128,128] {
@@ -1216,7 +1216,7 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
       p7 = bf16[1,8,16,16,128,7168] parameter(7)
       p8 = bf16[] parameter(8)
 
-      %all-to-all-start.4 = ((bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}), bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}) async-start(p7), calls=%async_computation.46, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"collective_backend_config":{"is_sync":false,"is_pipelined":false,"backend":"DEFAULT"},"force_earliest_schedule":false,"reification_cost":[],"device_type":"DEVICE_TYPE_INVALID"}
+      %all-to-all-start.4 = ((bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}), bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}) async-start(p7), calls=%async_computation.46
       %all-to-all-done.4 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} async-done(%all-to-all-start.4)
       %bitcast.309.7 = bf16[128,16,128,7168]{3,2,1,0} bitcast(%all-to-all-done.4)
       %bitcast.310.9 = bf16[] bitcast(p8)
@@ -1230,13 +1230,12 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
 
   absl::string_view kFdoProfile = "";
   auto config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
+  TF_ASSERT_OK_AND_ASSIGN(auto module, // xla::HloModule
                           ParseAndReturnVerifiedModule(kHloModule, config));
 
   TF_EXPECT_OK(ScheduleModule(module.get()));
-  auto schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
-      schedule.sequence(module->entry_computation()).instructions();
+      module->schedule().sequence(module->entry_computation()).instructions();
 
   EXPECT_TRUE(
       GetIndexByName(instruction_sequence, "dynamic-update-slice-start.18") <

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1219,8 +1219,7 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
       %all-to-all-start.4 = ((bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}), bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}) async-start(p7), calls=%async_computation.46
       %all-to-all-done.4 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} async-done(%all-to-all-start.4)
       %bitcast.309.7 = bf16[128,16,128,7168]{3,2,1,0} bitcast(%all-to-all-done.4)
-      %bitcast.310.9 = bf16[] bitcast(p8)
-      %broadcast_in_dim.6026.9 = bf16[128,16,128,7168]{3,2,1,0} broadcast(%bitcast.310.9), dimensions={}
+      %broadcast_in_dim.6026.9 = bf16[128,16,128,7168]{3,2,1,0} broadcast(%p8), dimensions={}
       %mul.5173.7 = bf16[128,16,128,7168]{3,2,1,0} multiply(%bitcast.309.7, %broadcast_in_dim.6026.9)
       %dynamic-update-slice-start.18 = ((bf16[8,2,4,128,128]{4,3,2,1,0:S(5)}, bf16[1,2,4,128,128]{4,3,2,1,0}, s32[], s32[], s32[], /*index=5*/s32[], s32[]), bf16[8,2,4,128,128]{4,3,2,1,0:S(5)}, u32[]) async-start(p0, p1, p2, p3, p4, p5, p6), calls=%async_computation.6
       %dynamic-update-slice-done.18 = bf16[8,2,4,128,128]{4,3,2,1,0:S(5)} async-done(%dynamic-update-slice-start.18)
@@ -1230,7 +1229,7 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
 
   absl::string_view kFdoProfile = "";
   auto config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(auto module, // xla::HloModule
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kHloModule, config));
 
   TF_EXPECT_OK(ScheduleModule(module.get()));

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -1574,6 +1574,7 @@ class ReadySetLt {
       CMP_EXPLICIT(ShouldScheduleAsyncDone(a, an),
                    ShouldScheduleAsyncDone(b, bn), "kScheduleDone");
     }
+
     // The following rule targets the async ops using resources that should
     // be released right after the op's estimated time cost has past. It
     // prevents increasing the overlaps of such async ops more than


### PR DESCRIPTION
📝 Summary of Changes

- Adding a heurisitic to GPU-scheduler for having better MoveToHost overlapping.

🎯 Justification
This could help hide D2H/H2D data movement behind computations.

🚀 Kind of Contribution
✨ New Feature

📊 Benchmark (for Performance Improvements)


🧪 Unit Tests:
Added unit-testes.

🧪 Execution Tests:
Maxtext/DeepSeek3-671B
