### PR TITLE
Addin a knob to control the limitation of async-compute resource.

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -450,6 +450,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_dot_merger_threshold_mb(64);
   opts.set_xla_enable_fast_math(false);
   opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
+  opts.set_xla_gpu_experimental_parallel_async_compute_limit(2);
   opts.set_xla_pjrt_allow_auto_layout_in_hlo(false);
   opts.set_xla_gpu_enable_scatter_determinism_expander(false);
   opts.set_xla_gpu_unsupported_enable_all_reduce_decomposer(false);
@@ -2601,6 +2602,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
               set_xla_gpu_experimental_parallel_collective_overlap_limit),
       debug_options->xla_gpu_experimental_parallel_collective_overlap_limit(),
       "This controls how many in-flight collectives "
+      "latency hiding scheduler can schedule."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_parallel_async_compute_limit",
+      int32_setter_for(
+          &DebugOptions::
+              set_xla_gpu_experimental_parallel_async_compute_limit),
+      debug_options->xla_gpu_experimental_parallel_async_compute_limit(),
+      "This controls how many in-flight asynchronous computations "
       "latency hiding scheduler can schedule."));
   flag_list->push_back(tsl::Flag(
       "xla_pjrt_allow_auto_layout_in_hlo",

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -576,7 +576,8 @@ absl::Status RunLatencyHidingSchedulerPasses(
 
   SchedulerConfig config = MakeGPUSchedulerConfig(
       memory_limit,
-      options.xla_gpu_experimental_parallel_collective_overlap_limit());
+      options.xla_gpu_experimental_parallel_collective_overlap_limit(),
+      options.xla_gpu_experimental_parallel_async_compute_limit());
 
   auto shape_size_in_bytes = ShapeSizeBytesFunction(pointer_size);
 
@@ -883,7 +884,8 @@ uint64_t GetSchedulerMemoryLimit(const HloModule& module,
 }
 
 SchedulerConfig MakeGPUSchedulerConfig(uint64_t memory_limit,
-                                       int64_t overlap_limit) {
+                                       int64_t overlap_limit,
+                                       int64_t async_compute_limit) {
   SchedulerConfig config;
   config.all_reduce_overlap_limit = 1;
   config.collective_broadcast_overlap_limit = 1;
@@ -893,6 +895,7 @@ SchedulerConfig MakeGPUSchedulerConfig(uint64_t memory_limit,
   config.schedule_send_recvs = true;
   config.memory_limit = memory_limit;
   config.parallel_collective_overlap_limit = overlap_limit;
+  config.parallel_async_compute_limit = async_compute_limit;
 
   CHECK(config.collective_broadcast_overlap_limit <=
         config.parallel_collective_overlap_limit);

--- a/xla/service/gpu/gpu_hlo_schedule.h
+++ b/xla/service/gpu/gpu_hlo_schedule.h
@@ -46,7 +46,8 @@ struct ScheduleMetadata {
 
 // Defines the scheduler config to be used by LHS.
 SchedulerConfig MakeGPUSchedulerConfig(uint64_t memory_limit,
-                                       int64_t overlap_limit);
+                                       int64_t overlap_limit,
+                                       int64_t async_compute_limit);
 
 // Compute the device memory limit to be used by passes like scheduler and
 // HLO rematerialization.

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -472,7 +472,7 @@ int64_t GpuAsyncTracker::GetNumAvailableResources(int64_t resource_type) const {
   // another collective.
   if (resource_type ==
       ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamComputes)) {
-    return 2;
+    return config_.parallel_async_compute_limit;
   }
 
   if (resource_type ==

--- a/xla/service/gpu/model/sol_gpu_cost_model_stats_collection.cc
+++ b/xla/service/gpu/model/sol_gpu_cost_model_stats_collection.cc
@@ -112,7 +112,10 @@ absl::StatusOr<bool> SolGpuCostModelStatsCollection::RunImpl(
       memory_limit,
       module->config()
           .debug_options()
-          .xla_gpu_experimental_parallel_collective_overlap_limit());
+          .xla_gpu_experimental_parallel_collective_overlap_limit(),
+      module->config()
+          .debug_options()
+          .xla_gpu_experimental_parallel_async_compute_limit());
   TF_ASSIGN_OR_RETURN(
       std::unique_ptr<SolLatencyEstimator> estimator,
       SolLatencyEstimator::Create(

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -142,6 +142,7 @@ struct SchedulerConfig {
   int64_t max_hops_to_closest_selective_overlap = 0;
   int64_t rerun = 0;
   int64_t parallel_collective_overlap_limit = 1;
+  int64_t parallel_async_compute_limit = 2;
   bool schedule_send_recvs = false;
   bool deannotate_group_if_blocked = false;
   // Consider send recv as the same resource. Some platforms do not take well

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -809,6 +809,8 @@ message DebugOptions {
   //   coll.2-done = collective(coll.2-start)
   optional int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
 
+  optional int32 xla_gpu_experimental_parallel_async_compute_limit = 465;
+
   optional PipelineParallelismOptLevel
       xla_gpu_experimental_pipeline_parallelism_opt_level = 351;
 
@@ -1436,7 +1438,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 465
+  // Next id: 466
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -809,6 +809,11 @@ message DebugOptions {
   //   coll.2-done = collective(coll.2-start)
   optional int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
 
+  // This controls the limitation of async-compute resource.
+  // This provides ample flexibility for control, enabling more asynchronous
+  // computations to execute concurrently. In host-offloading experiments,
+  // increasing this value effectively overlaps device-to-host (D2H) transfers
+  // with other computations, resulting in improved performance.
   optional int32 xla_gpu_experimental_parallel_async_compute_limit = 465;
 
   optional PipelineParallelismOptLevel


### PR DESCRIPTION
📝 Summary of Changes

-  Addin a knob to control the limitation of async-compute resource. This switch provides ample flexibility for control, enabling more asynchronous computations to execute concurrently. In host-offloading experiments, increasing this value effectively overlaps device-to-host (D2H) transfers with other computations, resulting in improved performance.﻿

🎯 Justification
This could allow users to control how many in-fligh async-computation in LHS.

🚀 Kind of Contribution
✨ New Feature,

