### PR TITLE
[XLA:GPUI] dump command buffer graph to the directory specified by enviroment variable

### DIFF
--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -150,6 +150,7 @@ cc_library(
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
+        "//xla/tsl/util:env_var",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",


### PR DESCRIPTION
📝 Summary of Changes
This PR enables dumping the command buffer dot file into the folder specified through environment variable COMMAND_BUFFER_DUMP_DIR, instead to the /tmp directory, which is inconvenient to fetch the files for runs like slurm. 

🎯 Justification
Easy debug

🚀 Kind of Contribution
Please remove what does not apply: 
📚 Documentation
