### PR TITLE
[ROCm] Assign specific pool only to test targets

### DIFF
--- a/xla/tsl/platform/default/build_config_root.bzl
+++ b/xla/tsl/platform/default/build_config_root.bzl
@@ -20,11 +20,11 @@ GPU_TEST_PROPERTIES = {
 }
 
 ROCM_SINGLE_GPU_TEST_PROPERTIES = {
-    "Pool": "linux_x64_gpu",
+    "test.Pool": "linux_x64_gpu",
 }
 
 ROCM_MULTI_GPU_TEST_PROPERTIES = {
-    "Pool": "linux_x64_multigpu",
+    "test.Pool": "linux_x64_multigpu",
 }
 
 def tf_gpu_tests_tags():


### PR DESCRIPTION
📝 Summary of Changes
Assign gpu pool only for test actions

🎯 Justification
We want to execute build actions on default pool while test actions shall go to the 
gpu specific pools. Hence we adjust these properties to assign specific pool only to test action

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant, CI

🧪 Execution Tests:
Not relevant, CI
