### PR TITLE
Guard GetReadyFuture with a mutex

### DIFF
--- a/xla/pjrt/c_api_client/pjrt_c_api_client.cc
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.cc
@@ -2958,6 +2958,7 @@ void PjRtCApiBuffer::MakePromiseTrackEvent() {
 }
 
 Future<> PjRtCApiBuffer::GetReadyFuture() {
+  absl::MutexLock lock(mu_);
   if (readiness_promise_ == nullptr) {
     auto [promise, future] = Future<>::MakePromise();
     readiness_promise_ = std::move(promise).ToShared();


### PR DESCRIPTION
Otherwise this function is racy, and I observe the following crash:

```
*** Check failure stack trace: ***
    @     0x7cd97d569874  absl::lts_20250814::log_internal::LogMessage::SendToLog()
    @     0x7cd97d5697f6  absl::lts_20250814::log_internal::LogMessage::Flush()
    @     0x7cd97a0a8522  tsl::internal::FutureBase<>::Promise::emplace<>()
    @     0x7cd97d6a0898  std::_Function_handler<>::_M_invoke()
    @     0x7cd97d69c136  xla::PjRtCApiBuffer::MakePromiseTrackEvent()::$_1::__invoke()
    @     0x7cd87ad12742  tsl::AsyncValue::EnqueueWaiter<>()::Node::RunWaiterAndDeleteWaiterNode()
    @     0x7cd87acd6428  tsl::internal::FutureBase<>::Promise::emplace<>()
    @     0x7cd87ace51d0  absl::internal_any_invocable::RemoteInvoker<>()
    @     0x7cd881db5fa3  tsl::AsyncValue::EnqueueWaiter<>()::Node::RunWaiterAndDeleteWaiterNode()
    @     0x7cd87c163972  absl::internal_any_invocable::RemoteInvoker<>()
    @     0x7cd87c1da239  absl::internal_any_invocable::RemoteInvoker<>()
    @     0x7cd87c1ef44c  tpu::RealProgramContinuator::CompletionLoop()
    @     0x7cd88a215785  thread::Fiber::Body()
    @     0x7cd88a21aab6  thread::(anonymous namespace)::FutexDomainThread::WorkLoop()
    @     0x7cd88a223a52  thread::CommonFiberDomainThread::Run()
    @     0x7cd88a509716  Thread::ThreadBody()
    @     0x7cd9940dbac3  (unknown)
```