### PR TITLE
[docs] note mlir-hlo deprecation

### DIFF
--- a/xla/mlir_hlo/README.md
+++ b/xla/mlir_hlo/README.md
@@ -1,5 +1,7 @@
 # MLIR-HLO: A Standalone "HLO" MLIR-based Compiler
 
+> Note: [this project is deprecated](https://groups.google.com/a/openxla.org/g/openxla-discuss/c/Mppuv1Edv1s), and will be removed in the future.
+
 The code here exists in two places:
 
 *   https://github.com/openxla/xla/tree/main/xla/mlir_hlo:


### PR DESCRIPTION
Closes #33472, by noting that the project will be deprecated.  Will reduce the chance of folk exploring the project without this knowledge. 