### PR TITLE
[NVIDIA GPU] Minimize collective resource for optimal overlap

### DIFF
--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -762,7 +762,8 @@ absl::StatusOr<std::shared_ptr<LockableGpuClique::Lock>> AcquireGpuClique(
     const GpuCliqueKey& clique_key,
     absl::Span<const std::vector<GlobalDeviceId>> device_groups,
     const GpuCollectives::CliqueIdCallback& clique_id_callback, RankId rank,
-    const AcquiredCliquesMap& acquired_cliques, int64_t max_nchannels) {
+    const AcquiredCliquesMap& acquired_cliques, int64_t max_nchannels,
+    bool use_minimal_resource) {
   VLOG(2) << absl::StreamFormat(
       "[%d] [rank=%v] [run=%v] Acquire GPU clique %v; device_groups=%d:[%s]; "
       "acquired_cliques=%d; max_channels=%d",
@@ -931,7 +932,7 @@ absl::StatusOr<std::shared_ptr<LockableGpuClique::Lock>> AcquireGpuClique(
       GetDebugOptionsFromFlags().xla_gpu_nccl_blocking_communicators();
   config.async_execution =
       GetDebugOptionsFromFlags().xla_gpu_nccl_async_execution();
-
+  config.use_minimal_resource = use_minimal_resource;
   // Split from the already acquired clique.
   if (split_from) {
     return InitializeGpuClique(collectives, device, run_id, clique_key,

--- a/xla/backends/gpu/collectives/gpu_cliques.h
+++ b/xla/backends/gpu/collectives/gpu_cliques.h
@@ -76,7 +76,7 @@ absl::StatusOr<std::shared_ptr<LockableGpuClique::Lock>> AcquireGpuClique(
     absl::Span<const std::vector<GlobalDeviceId>> device_groups,
     const GpuCollectives::CliqueIdCallback& clique_id_callback, RankId rank,
     const AcquiredCliquesMap& acquired_cliques, int64_t max_nchannels = 0,
-    bool use_minimal_resource = true);
+    bool use_minimal_resource = false);
 
 // Returns a non-ok status if the provided clique key is "stale". A clique key
 // is stale if its incarnations don't match the latest incarnations or if any of

--- a/xla/backends/gpu/collectives/gpu_cliques.h
+++ b/xla/backends/gpu/collectives/gpu_cliques.h
@@ -75,7 +75,8 @@ absl::StatusOr<std::shared_ptr<LockableGpuClique::Lock>> AcquireGpuClique(
     const GpuCliqueKey& clique_key,
     absl::Span<const std::vector<GlobalDeviceId>> device_groups,
     const GpuCollectives::CliqueIdCallback& clique_id_callback, RankId rank,
-    const AcquiredCliquesMap& acquired_cliques, int64_t max_nchannels = 0);
+    const AcquiredCliquesMap& acquired_cliques, int64_t max_nchannels = 0,
+    bool use_minimal_resource = true);
 
 // Returns a non-ok status if the provided clique key is "stale". A clique key
 // is stale if its incarnations don't match the latest incarnations or if any of

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -117,6 +117,11 @@ class GpuCollectives : public Collectives {
     //
     // If blocking_communicators is false, then async_execution must be true.
     bool async_execution = false;
+
+    // Decides whether communicators will be created to minimize resource
+    // utilization (i.e SM) during runtime. This is mainly used for overlapping
+    // with compute to avoid taking up compute resources.
+    bool use_minimal_resource = true;
   };
 
   // A cancelable version of Collectives::CreateCommunicators.

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -121,7 +121,7 @@ class GpuCollectives : public Collectives {
     // Decides whether communicators will be created to minimize resource
     // utilization (i.e SM) during runtime. This is mainly used for overlapping
     // with compute to avoid taking up compute resources.
-    bool use_minimal_resource = true;
+    bool use_minimal_resource = false;
   };
 
   // A cancelable version of Collectives::CreateCommunicators.

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -59,12 +59,12 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 #include "tsl/platform/numbers.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -250,14 +250,16 @@ static absl::StatusOr<ncclConfig_t> AsNcclConfig(
   int nccl_version;
   XLA_NCCL_RETURN_IF_ERROR(ncclGetVersion(&nccl_version));
 
-#if (NCCL_VERSION_CODE >= 22800)
   if (xla::GetDebugOptionsFromFlags()
           .xla_gpu_experimental_enable_nccl_symmetric_buffers() &&
       config.use_minimal_resource) {
+#if (NCCL_VERSION_CODE >= 22800)
     VLOG(1) << "Setting CTAPolicy to NCCL_CTA_POLICY_ZERO";
     comm_config.CTAPolicy = NCCL_CTA_POLICY_ZERO;
-  }
+#else
+    VLOG(1) << "Requires NCCL version >= 2.28 to use NCCL_CTA_POLICY_ZERO";
 #endif
+  }
 
   if (config.max_nchannels > 0) {
     VLOG(1) << "Maximum number of channels is set to: " << comm_config.maxCTAs;

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -249,6 +249,16 @@ static absl::StatusOr<ncclConfig_t> AsNcclConfig(
   comm_config.splitShare = config.split_share;
   int nccl_version;
   XLA_NCCL_RETURN_IF_ERROR(ncclGetVersion(&nccl_version));
+
+#if (NCCL_VERSION_CODE >= 22800)
+  if (xla::GetDebugOptionsFromFlags()
+          .xla_gpu_experimental_enable_nccl_symmetric_buffers() &&
+      config.use_minimal_resource) {
+    VLOG(1) << "Setting CTAPolicy to NCCL_CTA_POLICY_ZERO";
+    comm_config.CTAPolicy = NCCL_CTA_POLICY_ZERO;
+  }
+#endif
+
   if (config.max_nchannels > 0) {
     VLOG(1) << "Maximum number of channels is set to: " << comm_config.maxCTAs;
     comm_config.maxCTAs = config.max_nchannels;

--- a/xla/backends/gpu/runtime/collective_cliques.cc
+++ b/xla/backends/gpu/runtime/collective_cliques.cc
@@ -137,10 +137,10 @@ absl::StatusOr<CollectiveCliques> AcquireCollectiveCliques(
   XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
       "[run=%v] Acquire %d collective cliques for global device id %v; "
       "max number of channels for collectives %d; max number of "
-      "channels for p2p %d; use_minimal_resource=%s",
+      "channels for p2p %d; use_minimal_resource=%v",
       params.run_id, ordered_cliques.size(), params.global_device_id,
       params.collective_max_nchannels, params.p2p_max_nchannels,
-      params.collective_use_minimal_resource ? "true" : "false");
+      params.collective_use_minimal_resource);
 
   for (size_t i = 0; i < ordered_cliques.size(); ++i) {
     const CollectiveCliqueRequests::CliqueRequest& r = ordered_cliques[i];

--- a/xla/backends/gpu/runtime/collective_cliques.cc
+++ b/xla/backends/gpu/runtime/collective_cliques.cc
@@ -137,9 +137,10 @@ absl::StatusOr<CollectiveCliques> AcquireCollectiveCliques(
   XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
       "[run=%v] Acquire %d collective cliques for global device id %v; "
       "max number of channels for collectives %d; max number of "
-      "channels for p2p %d",
+      "channels for p2p %d; use_minimal_resource=%s",
       params.run_id, ordered_cliques.size(), params.global_device_id,
-      params.collective_max_nchannels, params.p2p_max_nchannels);
+      params.collective_max_nchannels, params.p2p_max_nchannels,
+      params.collective_use_minimal_resource ? "true" : "false");
 
   for (size_t i = 0; i < ordered_cliques.size(); ++i) {
     const CollectiveCliqueRequests::CliqueRequest& r = ordered_cliques[i];
@@ -197,7 +198,8 @@ absl::StatusOr<CollectiveCliques> AcquireCollectiveCliques(
                          r.key, r.device_groups,
                          params.clique_id_callback ? *params.clique_id_callback
                                                    : default_clique_id_callback,
-                         *rank, cliques_map, max_channels));
+                         *rank, cliques_map, max_channels,
+                         params.collective_use_minimal_resource));
 
     cliques_map[r.key] = std::move(clique);
   }

--- a/xla/backends/gpu/runtime/collective_params.cc
+++ b/xla/backends/gpu/runtime/collective_params.cc
@@ -80,7 +80,8 @@ absl::StatusOr<CollectiveParams> CollectiveParams::Create(
     const ServiceExecutableRunOptions& run_options,
     absl::Span<se::Stream* const> async_streams, LocalDeviceId local_device_id,
     std::optional<std::string> implementation_name,
-    int64_t collective_max_nchannels, int64_t p2p_max_nchannels) {
+    int64_t collective_max_nchannels, int64_t p2p_max_nchannels,
+    bool collective_use_minimal_resource) {
   const GpuExecutableRunOptions* gpu_options =
       run_options.run_options().gpu_executable_run_options();
 
@@ -109,7 +110,8 @@ absl::StatusOr<CollectiveParams> CollectiveParams::Create(
       run_options.run_options().run_id(), async_streams, local_device_id,
       global_device_id, run_options.run_options().device_assignment(),
       device_id_map, clique_id_callback, incarnations, collective_max_nchannels,
-      p2p_max_nchannels, run_options.run_options().local_device_count());
+      p2p_max_nchannels, run_options.run_options().local_device_count(),
+      collective_use_minimal_resource);
 }
 
 CollectiveParams::CollectiveParams(
@@ -120,7 +122,7 @@ CollectiveParams::CollectiveParams(
     const CliqueIdCallback* clique_id_callback,
     const absl::flat_hash_map<GlobalDeviceId, IncarnationId>* incarnations,
     int64_t collective_max_nchannels, int64_t p2p_max_nchannels,
-    int local_device_count)
+    int local_device_count, bool collective_use_minimal_resource)
     : collectives(collectives),
       executor(executor),
       run_id(run_id),
@@ -133,6 +135,7 @@ CollectiveParams::CollectiveParams(
       incarnations(incarnations),
       collective_max_nchannels(collective_max_nchannels),
       p2p_max_nchannels(p2p_max_nchannels),
-      local_device_count(local_device_count) {}
+      local_device_count(local_device_count),
+      collective_use_minimal_resource(collective_use_minimal_resource) {}
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_params.h
+++ b/xla/backends/gpu/runtime/collective_params.h
@@ -48,7 +48,8 @@ struct CollectiveParams {
       absl::Span<se::Stream* const> async_streams,
       LocalDeviceId local_device_id,
       std::optional<std::string> implementation_name = std::nullopt,
-      int64_t collective_max_nchannels = 0, int64_t p2p_max_nchannels = 0);
+      int64_t collective_max_nchannels = 0, int64_t p2p_max_nchannels = 0,
+      bool collective_use_minimal_resource = true);
 
   GpuCollectives* collectives;
   se::StreamExecutor* executor;
@@ -72,6 +73,8 @@ struct CollectiveParams {
   int64_t p2p_max_nchannels;
 
   int local_device_count = 0;
+  bool need_barrier = false;
+  bool collective_use_minimal_resource;
 
  private:
   CollectiveParams(
@@ -83,7 +86,7 @@ struct CollectiveParams {
       const CliqueIdCallback* clique_id_callback,
       const absl::flat_hash_map<GlobalDeviceId, IncarnationId>* incarnations,
       int64_t collective_max_nchannels, int64_t p2p_max_nchannels,
-      int local_device_count);
+      int local_device_count, bool collective_use_minimal_resource);
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_params.h
+++ b/xla/backends/gpu/runtime/collective_params.h
@@ -49,7 +49,7 @@ struct CollectiveParams {
       LocalDeviceId local_device_id,
       std::optional<std::string> implementation_name = std::nullopt,
       int64_t collective_max_nchannels = 0, int64_t p2p_max_nchannels = 0,
-      bool collective_use_minimal_resource = true);
+      bool collective_use_minimal_resource = false);
 
   GpuCollectives* collectives;
   se::StreamExecutor* executor;

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -752,6 +752,7 @@ cc_library(
         "//xla/runtime:device_id",
         "//xla/runtime:hang_watchdog",
         "//xla/service:buffer_assignment",
+        "//xla/service:collective_ops_utils",
         "//xla/service:computation_layout",
         "//xla/service:dump",
         "//xla/service:executable",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -81,6 +81,7 @@ limitations under the License.
 #include "xla/runtime/device_id.h"
 #include "xla/runtime/hang_watchdog.h"
 #include "xla/service/buffer_assignment.h"
+#include "xla/service/collective_ops_utils.h"
 #include "xla/service/dump.h"
 #include "xla/service/executable.h"
 #include "xla/service/gpu/alias_info.h"
@@ -133,7 +134,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -178,7 +178,7 @@ class GpuExecutableThunkPassBufferAllocator : public ThunkPassBufferAllocator {
       BufferAllocation::Index start_idx)
       : next_idx_(start_idx) {}
 
-  absl::StatusOr<BufferAllocation* absl_nonnull> NewEmptyAllocation(
+  absl::StatusOr<BufferAllocation * absl_nonnull> NewEmptyAllocation(
       int64_t size) override {
     allocations_.push_back(BufferAllocation(next_idx_++, size, /*color=*/0));
     return &allocations_.back();
@@ -192,6 +192,39 @@ class GpuExecutableThunkPassBufferAllocator : public ThunkPassBufferAllocator {
   std::deque<BufferAllocation> allocations_;
 };
 
+absl::StatusOr<bool> ShouldCollectiveUseMinimalResource(
+    const HloModule& module) {
+  int64_t sync_collective_count = 0;
+  int64_t total_sync_coll_size = 0;
+
+  int64_t async_collective_count = 0;
+  int64_t total_async_coll_size = 0;
+  for (HloComputation* computation : module.MakeNonfusionComputations()) {
+    for (HloInstruction* inst : computation->instructions()) {
+      if (IsCollective(inst)) {
+        TF_ASSIGN_OR_RETURN(GpuBackendConfig gpu_backend_config,
+                            inst->backend_config<GpuBackendConfig>());
+
+        bool is_sync = gpu_backend_config.collective_backend_config().is_sync();
+        int64_t total_size = ShapeUtil::ElementsInRecursive(inst->shape());
+
+        if (is_sync) {
+          sync_collective_count++;
+          total_sync_coll_size += total_size;
+        } else {
+          async_collective_count++;
+          total_async_coll_size += total_size;
+        }
+      }
+    }
+  }
+  // Simple Heuristics to determine if we should minimize SM usage.
+  // If we have more async collective count or larger message sizes
+  // for async collectives, then we will choose to minimize SM
+  // usage to give resource for computes.
+  return (sync_collective_count <= async_collective_count ||
+          total_sync_coll_size <= total_async_coll_size);
+}
 }  // namespace
 
 using ::tsl::profiler::ScopedAnnotation;
@@ -473,7 +506,8 @@ absl::Status ExecuteThunksImpl(const DebugOptions* debug_options,
                                const BufferAllocations& buffer_allocations,
                                bool block_host_until_done,
                                int64_t num_additional_compute_streams,
-                               CollectiveMemoryCache& collective_memory_cache) {
+                               CollectiveMemoryCache& collective_memory_cache,
+                               bool collective_use_minimal_resource) {
   bool mock_collectives =
       run_options->run_options().gpu_executable_run_options()
           ? run_options->run_options()
@@ -653,12 +687,13 @@ absl::Status ExecuteThunksImpl(const DebugOptions* debug_options,
     collectives_impl_name = debug_options->xla_gpu_collectives_implementation();
   }
 
-  ASSIGN_OR_RETURN(CollectiveParams collective_params,
-                   CollectiveParams::Create(
-                       *run_options, async_comms_streams,
-                       LocalDeviceId(main_stream->parent()->device_ordinal()),
-                       std::move(collectives_impl_name),
-                       collective_max_nchannels, p2p_max_nchannels));
+  ASSIGN_OR_RETURN(
+      CollectiveParams collective_params,
+      CollectiveParams::Create(
+          *run_options, async_comms_streams,
+          LocalDeviceId(main_stream->parent()->device_ordinal()),
+          std::move(collectives_impl_name), collective_max_nchannels,
+          p2p_max_nchannels, collective_use_minimal_resource));
 
   CollectiveCliqueRequests collective_clique_requests;
   CollectiveMemoryRequests collective_memory_requests(buffer_allocations);
@@ -1366,7 +1401,8 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     const BufferAllocations& buffer_allocations,
     const ServiceExecutableRunOptions* run_options,
     se::StreamExecutor* executor, int64_t unique_id,
-    Thunk::ExecutableSource executable_source, bool block_host_until_done) {
+    Thunk::ExecutableSource executable_source, bool block_host_until_done,
+    bool collective_use_minimal_resource) {
   // Get or create VaRanges for this executor and VA range index. We hold
   // va_ranges_mutex_ briefly just to access/create the VaRanges entry.
   // The VA range index allows multiplexing: with kNumVaReservationSets=2
@@ -1569,7 +1605,8 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
       has_module() ? &module_config().debug_options() : nullptr, module_name_,
       unique_id, *thunk_executor_, executable_source, run_options,
       remapped_buffer_allocations, block_host_until_done,
-      num_additional_compute_streams_, collective_memory_cache_));
+      num_additional_compute_streams_, collective_memory_cache_,
+      collective_use_minimal_resource));
 
   // Record event so VA range can be reclaimed after GPU finishes.
   TF_RETURN_IF_ERROR(
@@ -1663,16 +1700,22 @@ absl::Status GpuExecutable::ExecuteThunks(
       command_buffer_allocation_indexes_.size(),
       use_command_buffer_va_remapping);
 
+  bool collective_use_minimal_resource = true;
+  if (has_module()) {
+    ASSIGN_OR_RETURN(collective_use_minimal_resource,
+                     ShouldCollectiveUseMinimalResource(module()));
+  }
   if (use_command_buffer_va_remapping) {
     TF_RETURN_IF_ERROR(ExecuteThunksWithVaRemapping(
         buffer_allocations, run_options, executor, unique_id, executable_source,
-        block_host_until_done));
+        block_host_until_done, collective_use_minimal_resource));
   } else {
     TF_RETURN_IF_ERROR(ExecuteThunksImpl(
         has_module() ? &module_config().debug_options() : nullptr, module_name_,
         unique_id, *thunk_executor_, executable_source, run_options,
         buffer_allocations, block_host_until_done,
-        num_additional_compute_streams_, collective_memory_cache_));
+        num_additional_compute_streams_, collective_memory_cache_,
+        collective_use_minimal_resource));
   }
   return absl::OkStatus();
 }

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -206,7 +206,8 @@ absl::StatusOr<bool> ShouldCollectiveUseMinimalResource(
                             inst->backend_config<GpuBackendConfig>());
 
         bool is_sync = gpu_backend_config.collective_backend_config().is_sync();
-        int64_t total_size = ShapeUtil::ElementsInRecursive(inst->shape());
+        int64_t total_size =
+            ShapeUtil::ByteSizeOfElementsRecursive(inst->shape());
 
         if (is_sync) {
           sync_collective_count++;
@@ -1700,7 +1701,7 @@ absl::Status GpuExecutable::ExecuteThunks(
       command_buffer_allocation_indexes_.size(),
       use_command_buffer_va_remapping);
 
-  bool collective_use_minimal_resource = true;
+  bool collective_use_minimal_resource = false;
   if (has_module()) {
     ASSIGN_OR_RETURN(collective_use_minimal_resource,
                      ShouldCollectiveUseMinimalResource(module()));

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -195,7 +195,7 @@ class GpuExecutable : public Executable {
       const ServiceExecutableRunOptions* run_options,
       VariantArguments arguments);
 
-  absl::Span<const BufferAllocation* absl_nonnull const> GetAllocations()
+  absl::Span<const BufferAllocation * absl_nonnull const> GetAllocations()
       const override {
     return allocation_ptrs_;
   }
@@ -320,7 +320,8 @@ class GpuExecutable : public Executable {
       const BufferAllocations& buffer_allocations,
       const ServiceExecutableRunOptions* run_options,
       stream_executor::StreamExecutor* executor, int64_t unique_id,
-      Thunk::ExecutableSource executable_source, bool block_host_until_done);
+      Thunk::ExecutableSource executable_source, bool block_host_until_done,
+      bool collective_use_minimal_resource);
 
   // The LLVM IR, in string format, of the unoptimized module generated for
   // this GpuExecutable. We save a string instead of an llvm::Module* because

--- a/xla/shape_util.cc
+++ b/xla/shape_util.cc
@@ -1007,6 +1007,9 @@ Shape ShapeUtil::PrependMajorDimension(int64_t bound, Shape shape) {
 
 /* static */ int64_t ShapeUtil::ByteSizeOfElementsRecursive(
     const Shape& shape) {
+  if (shape.IsToken()) {
+    return 0;
+  }
   CHECK(shape.IsArray() || shape.IsTuple());
   if (shape.IsArray()) {
     return ByteSizeOfElements(shape);


### PR DESCRIPTION
📝 Summary of Changes
Starting nccl 2.28, nccl has exposed a communicator config to instruct nccl to minimize SM utilization for collectives.
This new policy is great for overlapping since it leaves as much compute resource as possible to compute kernels. This doesn't necessarily mean to take a runtime perf hit. It means that nccl will try to offload traffic to copy engine or networking hardware like switch as much as possible.
This pr adds the mechanism to set this policy if there are more async collectives in the graph.

🎯 Justification
This new policy can help reduce the SM usage for collectives therefore leave more resources to compute kernels.

🚀 Kind of Contribution
Please remove what does not apply: 
✨ New Feature

📊 Benchmark (for Performance Improvements)
hlo_llama31_8b_bf16_1x8.hlo gave ~7% speedup vs baseline with nccl 2.28 on h100 gpus

🧪 Unit Tests:
NA

🧪 Execution Tests:

