### PR TITLE
[XLA:GPU] Set NCCL kernels to highest priority in cuda graph

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -2001,7 +2001,7 @@ CommandBufferCmd::BufferUseVector CustomCallCmd::buffers() const {
 CollectiveCmd::CollectiveCmd(
     CommandBufferCmdType cmd_type, CollectiveConfig config,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CommandBufferCmd(cmd_type),
+    : CommandBufferCmd(cmd_type, se::StreamPriority::Highest),
       config_(std::move(config)),
       async_events_(std::move(async_events)) {}
 


### PR DESCRIPTION
📝 Summary of Changes
This PR change the default priority for NCCL kernels in command buffer to highest priority, which is the same as when NCCL is running without cuda-graph. 

🎯 Justification
Test below workloads on GB200 clusters, the PR's perf improvements, all have perf improvements, I think we should make the default setting.  

<img width="283" height="155" alt="image" src="https://github.com/user-attachments/assets/377a7776-912b-42d3-a48e-a948be56c3c5" />


🚀 Kind of Contribution
⚡️ Performance Improvement,

🧪 Unit Tests:
Change the default settings for command buffer command, not new feature. 


