### PR TITLE
[ROCm] update with a flag to configure maximum number of trace events

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -491,6 +491,7 @@ cc_library(
         ":rocm_tracer_utils",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "//xla/tsl/profiler/backends/cpu:annotation_stack",
+        "//xla:debug_options_flags",
         "@com_google_absl//absl/container:fixed_array",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -19,9 +19,12 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "tsl/profiler/lib/profiler_factory.h"
+#include "tsl/profiler/lib/profiler_interface.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/debug_options_flags.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
 #include "tsl/profiler/lib/profiler_factory.h"
@@ -72,17 +75,26 @@ class GpuTracer : public profiler::ProfilerInterface {
 
 RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
   RocmTracerOptions options;
-  options.max_annotation_strings = 1024 * 1024;
+  options.max_annotation_strings = 4 * 1024 * 1024;
   return options;
 }
 
 RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
     uint32_t num_gpus) {
   RocmTraceCollectorOptions options;
-  options.max_callback_api_events = 2 * 1024 * 1024;
-  options.max_activity_api_events = 2 * 1024 * 1024;
-  options.max_annotation_strings = 1024 * 1024;
   options.num_gpus = num_gpus;
+
+  const auto& dbg = xla::GetDebugOptionsFromFlags();
+  int64_t max_events = dbg.xla_gpu_rocm_max_trace_events();
+  VLOG(3) << "max number of events to be trace from flag = " << max_events;
+  if (max_events <= 0) max_events = 4 * 1024 * 1024;
+  if (max_events > 1'000'000'000LL) max_events = 1'000'000'000LL;
+
+  VLOG(3) << "maximum number of events to be traced = " << max_events;
+
+  options.max_callback_api_events = max_events;
+  options.max_activity_api_events = max_events;
+  options.max_annotation_strings = max_events;
   return options;
 }
 

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -86,10 +86,9 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
 
   const auto& dbg = xla::GetDebugOptionsFromFlags();
   int64_t max_events = dbg.xla_gpu_rocm_max_trace_events();
-  VLOG(3) << "max number of events to be trace from flag = " << max_events;
+  VLOG(2) << "max number of events to be trace from flag = " << max_events;
   if (max_events <= 0) max_events = 4 * 1024 * 1024;
   if (max_events > 1'000'000'000LL) max_events = 1'000'000'000LL;
-
   VLOG(3) << "maximum number of events to be traced = " << max_events;
 
   options.max_callback_api_events = max_events;

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -469,11 +469,12 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
-        LOG(WARNING) << "!!! Number of callback events = "
-                     << num_callback_events_
-                     << " is greater than/equal to the max callback api events = "
-                     << options_.max_callback_api_events
-                     << ". To collect more GPU events, please set XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
+        LOG(WARNING)
+            << "!!! Number of callback events = " << num_callback_events_
+            << " is greater than/equal to the max callback api events = "
+            << options_.max_callback_api_events
+            << ". To collect more GPU events, please set "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
         return;
       }
       num_callback_events_++;
@@ -490,13 +491,16 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
     if (event.domain == RocmTracerEventDomain::HIP_API) {
       // we do not count HIP_OPS activities.
       if (num_activity_events_ >= options_.max_activity_api_events) {
-        LOG(WARNING) << "!!! Number of activity events = "
-                     << num_activity_events_
-                     << " is greater than/equal to the max activity api events = "
-                     << options_.max_activity_api_events
-                     << ". To collect more GPU events, please set XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
+        LOG_FIRST_N(WARNING, 1)
+            << "Number of activity events (" << num_activity_events_
+            << ") has reached the configured limit "
+               "(xla_gpu_rocm_max_trace_events="
+            << options_.max_activity_api_events
+            << "). To collect more GPU events, increase "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=<value>.";
         return;
       }
+
       num_activity_events_++;
     }
 

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -469,9 +469,11 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
-        OnEventsDropped("max callback event capacity reached",
-                        event.correlation_id);
-        PrintRocmTracerEvent(event, ". Dropped!");
+        LOG(WARNING) << "!!! Number of callback events = "
+                     << num_callback_events_
+                     << " is greater than/equal to the max callback api events = "
+                     << options_.max_callback_api_events
+                     << ". To collect more GPU events, please set XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
         return;
       }
       num_callback_events_++;
@@ -488,9 +490,11 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
     if (event.domain == RocmTracerEventDomain::HIP_API) {
       // we do not count HIP_OPS activities.
       if (num_activity_events_ >= options_.max_activity_api_events) {
-        OnEventsDropped("max activity event capacity reached",
-                        event.correlation_id);
-        PrintRocmTracerEvent(event, ". Dropped!");
+        LOG(WARNING) << "!!! Number of activity events = "
+                     << num_activity_events_
+                     << " is greater than/equal to the max activity api events = "
+                     << options_.max_activity_api_events
+                     << ". To collect more GPU events, please set XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
         return;
       }
       num_activity_events_++;

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -131,13 +131,14 @@ bool RocmTracer::IsAvailable() const {
 
 void RocmTracer::Enable(const RocmTracerOptions& options,
                         RocmTraceCollector* collector) {
-  absl::MutexLock lock(collector_mutex_);
+  absl::MutexLock lock(&collector_mutex_);
   if (collector_ != nullptr) {
     LOG(WARNING) << "ROCM tracer is already running!";
     return;
   }
   options_ = options;
   collector_ = collector;
+  AnnotationMap(options_->max_annotation_strings);
   api_tracing_enabled_ = true;
   activity_tracing_enabled_ = true;
   rocprofiler_start_context(context_);

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -131,7 +131,7 @@ bool RocmTracer::IsAvailable() const {
 
 void RocmTracer::Enable(const RocmTracerOptions& options,
                         RocmTraceCollector* collector) {
-  absl::MutexLock lock(&collector_mutex_);
+  absl::MutexLock lock(collector_mutex_);
   if (collector_ != nullptr) {
     LOG(WARNING) << "ROCM tracer is already running!";
     return;

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -103,7 +103,8 @@ absl::StatusOr<std::vector<RepeatedFlagModifier>> ParseRepeatedEnumModifiers(
 namespace {
 
 template <typename T>
-static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list, T value) {
+static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list,
+                                   T value) {
   for (auto it = list->begin(); it != list->end(); ++it) {
     if (*it == value) {
       return it;
@@ -495,8 +496,13 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_keep_shardings_after_spmd(false);
   opts.set_xla_gpu_experimental_enable_checksum_tracing_on_thunks(false);
   opts.set_xla_gpu_experimental_enable_buffer_saver_on_thunks(false);
+
+  // Disable NaN/Inf detection.
   opts.set_xla_gpu_detect_nan(DebugOptions::DETECTION_MODE_NONE);
   opts.set_xla_gpu_detect_inf(DebugOptions::DETECTION_MODE_NONE);
+
+  // maximum number of events to be traced, default to 4M
+  opts.set_xla_gpu_rocm_max_trace_events(4 * 1024 * 1024);
   return opts;
 }
 
@@ -2810,6 +2816,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
           &DebugOptions::set_xla_gpu_experimental_enable_fusion_autotuner),
       debug_options->xla_gpu_experimental_enable_fusion_autotuner(),
       "Enable autotuning between the native & triton fusion emitters."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_rocm_max_trace_events",
+      int64_setter_for(&DebugOptions::set_xla_gpu_rocm_max_trace_events),
+      debug_options->xla_gpu_rocm_max_trace_events(),
+      "Maximum number of ROCm trace events (applies to callback/activity/"
+      "annotation). Set as high as memory allows; up to 1e9."));
 
   auto setter_for_xla_gpu_detect_nan =
       [debug_options, detection_mode](const std::string& value) {

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -921,6 +921,10 @@ message DebugOptions {
   // multi-thread mode.
   optional bool xla_gpu_require_exclusive_lock = 347;
 
+  // Maximum number of trace events for ROCm GPU profiling. Limits memory
+  // usage during profiling on AMD GPUs.
+  optional int64 xla_gpu_rocm_max_trace_events = 448;
+
   optional ShapeChecks xla_gpu_shape_checks = 170;
 
   // If true, shards the autotuning work between participating compiler
@@ -1364,7 +1368,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 448
+  // Next id: 449
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
@xla-rotation, would you please kindly help review this PR?

📝 Summary of Changes
update with a flag to configure maximum number of trace events and default number is set to 4M.

🎯 Justification

- a flag to adjust the maximum number of trace events to be collected that can be set via `XLA_FLAGS="--xla_gpu_rocm_max_trace_events=1000" `
- default to 4M that can cover a reasonable number of steps for LLMs
- gives warning if the number of trace events >= the pre-set number.