### PR TITLE
[NVIDIA GPU] Add pred, int8 and uint8 as supported nvshmem reduction types

### DIFF
--- a/xla/backends/gpu/collectives/nvshmem_communicator.cc
+++ b/xla/backends/gpu/collectives/nvshmem_communicator.cc
@@ -293,6 +293,20 @@ Future<> NvshmemCommunicator::AllReduce(
           dest_ptr, count);
       break;
     }
+    case PrimitiveType::PRED:
+    case PrimitiveType::U8: {
+      CALL_NVSHMEM_BITWISE_REDUCTION_DATATYPE(
+          uint8, uint8_t, NVSHMEM_TEAM_SHARED,
+          se::gpu::AsGpuStreamValue(stream), reduction_kind, source_ptr,
+          dest_ptr, count);
+      break;
+    }
+    case PrimitiveType::S8: {
+      CALL_NVSHMEM_BITWISE_REDUCTION_DATATYPE(
+          int8, int8_t, NVSHMEM_TEAM_SHARED, se::gpu::AsGpuStreamValue(stream),
+          reduction_kind, source_ptr, dest_ptr, count);
+      break;
+    }
     default:
       return absl::InternalError("Invalid Nvshmem reduction type.");
   }


### PR DESCRIPTION
📝 Summary of Changes
Add pred, int8 and uint8 as supported nvshmem reduction types

🎯 Justification
Nvshmem 3.2.5 supports doing reductions for byte-sized numerics. This pr adds that missing feature.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
NA
🧪 Unit Tests:
Unit test added

🧪 Execution Tests:
Unit test also executes the module.
