### PR TITLE
[ROCm] Fix triton softmax slowness upstream

### DIFF
--- a/xla/codegen/tiling/tiled_hlo_computation.h
+++ b/xla/codegen/tiling/tiled_hlo_computation.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -69,6 +70,16 @@ class TiledHloComputation {
     return Product(num_output_tiles_per_dim());
   }
 
+  // Returns the largest tile size (after padding) across all instructions.
+  // Returns std::nullopt if not yet computed.
+  std::optional<int64_t> GetLargestTileSize() const {
+    return largest_tile_size_;
+  }
+
+  // Sets the largest tile size. This should be called after all instructions
+  // are added.
+  void SetLargestTileSize(int64_t size) { largest_tile_size_ = size; }
+
   // Returns the root instructions of the computation. When a computation has
   // several outputs (i.e. it has a tuple root), the roots are the operands of
   // the root tuple. The roots are order by increasing output index, and point
@@ -99,6 +110,10 @@ class TiledHloComputation {
 
   // Stores the number of output tiles for each dimension.
   llvm::SmallVector<int64_t> num_output_tiles_per_dim_;
+
+  // Stores the largest tile size (after padding) across all instructions.
+  // Cached to avoid recomputation.
+  std::optional<int64_t> largest_tile_size_ = std::nullopt;
 };
 
 }  // namespace xla

--- a/xla/service/gpu/model/gpu_indexing_performance_model.cc
+++ b/xla/service/gpu/model/gpu_indexing_performance_model.cc
@@ -128,6 +128,22 @@ bool DoesTileFitInRegisters(int64_t tile_size,
                           device_info.registers_per_block_limit();
 }
 
+// Computes and caches the largest tile size in the tiled computation.
+int64_t ComputeLargestTileSize(TiledHloComputation& tiled_hlo_computation) {
+  if (tiled_hlo_computation.GetLargestTileSize().has_value()) {
+    return *tiled_hlo_computation.GetLargestTileSize();
+  }
+
+  int64_t largest_tile_size = 1;
+  for (const TiledHloInstruction* tiled_hlo :
+       tiled_hlo_computation.instructions()) {
+    largest_tile_size =
+        std::max(largest_tile_size, GetPaddedTileSize(tiled_hlo->tile_sizes()));
+  }
+  tiled_hlo_computation.SetLargestTileSize(largest_tile_size);
+  return largest_tile_size;
+}
+
 // Checks if all tiles in the computation fit in registers.
 //
 // There is no way to know for sure if emitted computation will not spill
@@ -162,6 +178,12 @@ bool DoesComputationFitInRegisters(
         return false;
       }
     }
+  }
+
+  // Check that the largest tile fits in registers.
+  int64_t largest_tile_size = *tiled_hlo_computation.GetLargestTileSize();
+  if (!DoesTileFitsInRegisters(largest_tile_size, device_info)) {
+    return false;
   }
 
   for (const TiledHloInstruction* tiled_hlo :
@@ -640,11 +662,7 @@ GpuPerformanceModelWithIndexingAnalysis::GetLaunchDimensionsForTiledFusion(
 
   // Decide on the number of warps to use based on the largest live tile size
   // at any given point within the computation.
-  int64_t largest_live_tile_size = 1;
-  for (const auto& tiled_hlo : tiled_hlo_computation.instructions()) {
-    largest_live_tile_size = std::max(
-        largest_live_tile_size, GetPaddedTileSize(tiled_hlo->tile_sizes()));
-  }
+  int64_t largest_live_tile_size = *tiled_hlo_computation.GetLargestTileSize();
   int64_t num_warps = GetNumWarps(largest_live_tile_size);
 
   return {static_cast<uint64_t>(num_blocks),
@@ -690,6 +708,7 @@ GpuPerformanceModelWithIndexingAnalysis::TryFindBestTilingForFusion(
     }
 
     auto tiled_hlo_computation = std::move(maybe_tiled_hlo_computation.value());
+    ComputeLargestTileSize(tiled_hlo_computation);
     LaunchDimensions launch_dimensions =
         GetLaunchDimensionsForTiledFusion(tiled_hlo_computation, *device_info_);
 

--- a/xla/service/gpu/model/gpu_indexing_performance_model.cc
+++ b/xla/service/gpu/model/gpu_indexing_performance_model.cc
@@ -698,6 +698,11 @@ GpuPerformanceModelWithIndexingAnalysis::TryFindBestTilingForFusion(
         EstimateRunTimeForTiledHloComputation(
             fusion_adaptor, tiled_hlo_computation, launch_dimensions));
 
+    // Skip tilings with infinite runtime (e.g., due to register spilling).
+    if (estimate_run_time_data.exec_time == absl::InfiniteDuration()) {
+      continue;
+    }
+
     if (!best_tiled_run_time_data.has_value() ||
         estimate_run_time_data.exec_time <
             best_tiled_run_time_data->runtime_data.exec_time) {

--- a/xla/service/gpu/model/triton_emitter_constraints.cc
+++ b/xla/service/gpu/model/triton_emitter_constraints.cc
@@ -291,16 +291,12 @@ absl::StatusOr<bool> TritonEmitterConstraints::ParametersSatisfyConstraints(
   // 2. Poor instruction cache utilization
   // 3. Terrible memory access patterns
   // 4. High kernel launch overhead
-  //
-  // We check the root tile sizes (not intermediate tiles in the fusion).
-  int64_t root_tile_product = 1;
-  for (int64_t size : tile_parameters) {
-    root_tile_product *= size;
-  }
-  if (root_tile_product < kMinReasonableTileSize) {
-    VLOG(2) << "Root tile size product (" << root_tile_product
-            << ") is smaller than minimum reasonable size ("
-            << kMinReasonableTileSize << "). Bailing out.";
+  if (absl::c_any_of(tile_size_maps_, [&](const auto& tile_size_map) {
+        return NumberOfElementsInPaddedTile(tile_size_map, tile_parameters) <
+               kMinReasonableTileSize;
+      })) {
+    VLOG(2) << "Found a tile with fewer than " << kMinReasonableTileSize
+            << " elements. Bailing out.";
     return false;
   }
 

--- a/xla/service/gpu/model/triton_emitter_constraints.cc
+++ b/xla/service/gpu/model/triton_emitter_constraints.cc
@@ -70,11 +70,6 @@ constexpr int64_t kMaxTensorNumElements = 1048576;
 // Also for MMA instruction we don't want tiles greater than 256.
 constexpr int64_t kMaxMMADimSize = 256;
 
-// Filter by checking the product of tile dimensions - a tile with
-// product < 16 elements cannot saturate even half a warp and will have
-// terrible performance characteristics on GPUs.
-constexpr int64_t kMinReasonableTileSize = 16;
-
 llvm::SmallVector<int64_t> GetPaddedTileSizes(
     llvm::SmallVector<int64_t> tile_sizes) {
   llvm::SmallVector<int64_t> result;
@@ -285,21 +280,6 @@ bool NumberOfBlocksFitsOnDeviceGrid(const Shape& output_shape,
 
 absl::StatusOr<bool> TritonEmitterConstraints::ParametersSatisfyConstraints(
     absl::Span<const int64_t> tile_parameters) const {
-  // Filter out pathologically small tiles that lead to poor performance.
-  // Tiles with very small dimensions (especially [1,1]) cause:
-  // 1. Massive number of thread blocks overwhelming the Triton scheduler
-  // 2. Poor instruction cache utilization
-  // 3. Terrible memory access patterns
-  // 4. High kernel launch overhead
-  if (absl::c_any_of(tile_size_maps_, [&](const auto& tile_size_map) {
-        return NumberOfElementsInPaddedTile(tile_size_map, tile_parameters) <
-               kMinReasonableTileSize;
-      })) {
-    VLOG(2) << "Found a tile with fewer than " << kMinReasonableTileSize
-            << " elements. Bailing out.";
-    return false;
-  }
-
   // Verify that the tile sizes are not too big.
   if (absl::c_any_of(tile_size_maps_, [&](const auto& tile_size_map) {
         return NumberOfElementsInPaddedTile(tile_size_map, tile_parameters) >


### PR DESCRIPTION
The changes prevent generating fused hlo with too small tile sizes e.g. [1,1], which often lead to register spilling in TritonEmitterConstraints.

@xla-rotation could you review my PR, please?




