### PR TITLE
[GPU] Support int4 in cuDNN GEMM fusions.

### DIFF
--- a/xla/backends/gpu/codegen/BUILD
+++ b/xla/backends/gpu/codegen/BUILD
@@ -104,7 +104,6 @@ xla_test(
         "//xla/stream_executor:dnn",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor:stream_executor_memory_allocator",
-        "//xla/tsl/lib/core:status_test_util",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",

--- a/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
@@ -149,6 +149,8 @@ inline std::optional<fe::DataType_t> ToCudnnDataType(const PrimitiveType type) {
       return t::BFLOAT16;
     case PrimitiveType::S32:
       return t::INT32;
+    case PrimitiveType::S4:
+      return t::INT4;
     case PrimitiveType::S8:
       return t::INT8;
     case PrimitiveType::PRED:


### PR DESCRIPTION
📝 Summary of Changes
Support int4 in cuDNN GEMM fusions.

🎯 Justification
Accelerates some int4 GEMM fusions (under the flag xla_gpu_cudnn_gemm_fusion_level).

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
> Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

These do not use int4.

🧪 Unit Tests:
yes

🧪 Execution Tests:
yes