### PR TITLE
Update `shapes.md` with example and memory location info

### DIFF
--- a/docs/operation_semantics.md
+++ b/docs/operation_semantics.md
@@ -13,6 +13,8 @@ arbitrary-dimensional array. For convenience, special cases have more specific
 and familiar names; for example a *vector* is a 1-dimensional array and a
 *matrix* is a 2-dimensional array.
 
+Learn more about the structure of an Op in [_Shapes and layout_](shapes.md) and [_Tiled Layout_](tiled_layout.md).
+
 ## Abs
 
 See also

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -5,27 +5,41 @@
 Consider an example HLO:
 
 ```
+add.936 = bf16[8,1,1280,16384]{3,2,0,1:T(8,128)(2,1)}
+          add(exponential.183, broadcast.3115)
+```
+
+This consists of the following components:
+
+* Op Name: `add.936`
+  * This is the unique name for the operation.
+* Shape: `bf16[8,1,1280,16384]`
+  * This is the output shape of the Op. Here the dtype is [bf316](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) and the shape is `[8,1,1280,16384]`.
+* Layout (with Tiling): `3,2,0,1:T(8,128)(2,1)`
+  * This describes how the array is stored in memory. `3,2,0,1` denotes the order of the axes in memory (i.e., column major, row major, etc.) and `T(8,128)(2,1)` denotes the tiling & padding used.
+  * Layout is optional. If not specified, there is no tiling and the dimensions are assumed to be ordered from most-major to most-minor.
+* Operation: `add`
+  * The operation being performed. Here, it is [Add](operation_semantics.md#add), which is also mentioned in the Op name.
+* Arguments: `exponential.183`, `broadcast.3115`
+  * This operation takes two arguments, specified with their unique names.
+
+Let's consider another example, a fusion Op:
+
+```
 %fusion.3 = bf16[32,32,4096]{2,1,0:T(8,128)(2,1)S(1)}
             fusion(bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)} %fusion.32),
             kind=kCustom, calls=%all-reduce-scatter.3
 ```
 
-This consists on the following components:
+In addition to the previously described components, this consists of:
 
-* Op Name: `%fusion.3`
-  * This is the unique name for the operation. Here, the name indicates this is a fusion operation (which combines multiple operations into a single kernel). The `%` sign is part of the name, and may or may not be present in all operations. Learn about other Ops in [Operation Semantics](operation_semantics.md).
-* Shape: `bf16[32,32,4096]`
-  * This is the output shape of the op. Here the dtype is bf16 (2 bytes per parameter) and the shape is `[32,32,4096]`. The following sections have more details about Shape.
-* Layout (with Tiling): `{2,1,0:T(8,128)(2,1)}`
-  * This describes how the array is stored in memory. `2,1,0` denotes the order of the axes in memory (column major, row major, etc.) and `T(8,128)(2,1)` denotes the tiling & padding used. The following sections have more details about Layout, you can also learn more in [Tiled Layout](tiled_layout.md).
-  * This is optional. If not specified, there is no tiling and the dimensions are assumed to be ordered from most-major to most-minor.
+* Attributes: `kind` and `calls`
+  * These provide more information about the operation being performed, in this case: fusion.
 * Memory location (memory space identifier): `S(1)`
-  * This denotes the memory space/location where the array is stored. `S(1)` denotes this array lives in VMEM (on a TPU). More [memory space identifiers are listed below](#memory-space-identifiers).
-* Arguments: `bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)} %fusion.32`
-  * This op has one input, a bf16 array called `fusion.32` with a particular shape (as well as layout, tiling, and memory location): ` bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)}`. This tells us what function feeds into this one.
-* Attributes:
-  * `kind=kCustom`: This describes the "kind" of fusion operation, `kCustom` denotes this is a custom or composite operation.
-  * `calls=%all-reduce-scatter.3` : This describes the computation that will be called for this fusion operation.
+  * This denotes the memory space/location where the array is stored. `S(1)` here denotes this array lives in VMEM (on a TPU).
+* Shape and layout details for the input argument `%fusion.32`
+
+The following sections describe Shapes, [Layout](#layout), and [Memory Space Identifiers](#memory-space-identifiers). You can learn more about Tiling in [Tiled Layout](tiled_layout.md).
 
 ## Shapes
 

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -13,7 +13,7 @@ Consider an example HLO:
 This consists on the following components:
 
 * Op Name: `%fusion.3`
-  * This is the unique name for the operation. Here, the name indicates this is a fusion operation (which combines multiple operations into a single kernel). Learn more about other ops in [Operation Semantics](operation_semantics.md).
+  * This is the unique name for the operation. Here, the name indicates this is a fusion operation (which combines multiple operations into a single kernel). The `%` sign is part of the name, and may or may not be present in all operations. Learn about other Ops in [Operation Semantics](operation_semantics.md).
 * Shape: `bf16[32,32,4096]`
   * This is the output shape of the op. Here the dtype is bf16 (2 bytes per parameter) and the shape is `[32,32,4096]`. The following sections have more details about Shape.
 * Layout (with Tiling): `{2,1,0:T(8,128)(2,1)}`

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -2,26 +2,30 @@
 
 ## Structure of an XLA Op
 
-Consider an example Op:
+Consider an example HLO:
 
 ```
-%fusion.3 = bf16[32,32,4096]{2,1,0:T(8,128)(2,1)S(1)} fusion(bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)} %fusion.32), kind=kCustom, calls=%all-reduce-scatter.3
+%fusion.3 = bf16[32,32,4096]{2,1,0:T(8,128)(2,1)S(1)}
+            fusion(bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)} %fusion.32),
+            kind=kCustom, calls=%all-reduce-scatter.3
 ```
 
-This consists on the following main components:
+This consists on the following components:
 
-* Op Name: `fusion.3`
-  * A dot or fusion op is a set of operations containing at most 1 matrix multiplication and possibly a bunch of related pointwise VPU-ops.
+* Op Name: `%fusion.3`
+  * This is the unique name for the operation. Here, the name indicates this is a fusion operation (which combines multiple operations into a single kernel). Learn more about other ops in [Operation Semantics](operation_semantics.md).
 * Shape: `bf16[32,32,4096]`
-  * This is the output shape of the op. Here the dtype is bf16 (2 bytes per parameter) and the shape is `[32,32,4096]`. More details in the following sections.
+  * This is the output shape of the op. Here the dtype is bf16 (2 bytes per parameter) and the shape is `[32,32,4096]`. The following sections have more details about Shape.
 * Layout (with Tiling): `{2,1,0:T(8,128)(2,1)}`
-  * This describes how the array is stored in memory. More details in the following sections.
-  * `2,1,0` denotes the order of the axes in memory (column major, row major, etc.).
-  * `T(8,128)(2,1)` denotes the tiling & padding used. Learn more in [Tiled Layout](tiled_layout.md).
-* Memory location: `S(1)`
-  * `S(1)` denotes this array lives in VMEM. More details at the end of page.
-* Arguments:`bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)} %fusion.32`
+  * This describes how the array is stored in memory. `2,1,0` denotes the order of the axes in memory (column major, row major, etc.) and `T(8,128)(2,1)` denotes the tiling & padding used. The following sections have more details about Layout, you can also learn more in [Tiled Layout](tiled_layout.md).
+  * This is optional. If not specified, there is no tiling and the dimensions are assumed to be ordered from most-major to most-minor.
+* Memory location (memory space identifier): `S(1)`
+  * This denotes the memory space/location where the array is stored. `S(1)` denotes this array lives in VMEM (on a TPU). More [memory space identifiers are listed below](#memory-space-identifiers).
+* Arguments: `bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)} %fusion.32`
   * This op has one input, a bf16 array called `fusion.32` with a particular shape (as well as layout, tiling, and memory location): ` bf16[32,32,8192]{2,1,0:T(8,128)(2,1)S(1)}`. This tells us what function feeds into this one.
+* Attributes:
+  * `kind=kCustom`: This describes the "kind" of fusion operation, `kCustom` denotes this is a custom or composite operation.
+  * `calls=%all-reduce-scatter.3` : This describes the computation that will be called for this fusion operation.
 
 ## Shapes
 


### PR DESCRIPTION
**📝 Summary of Changes**

- Added an example for how to read an Op, derived from [JAX scaling book](https://jax-ml.github.io/scaling-book/profiling/#how-to-read-an-xla-op).
- Added description for Memory Space Identifier (also derived from the book), because it was not documented in the XLA docs.
- Added relevant cross-links between pages.

**🎯 Justification**

While there are notes about Shape, Layout, and Tiling, there was some gap in contextualizing this information with an example. Additionally, there was no information about Memory Space Identifiers.

These were originally noted/flagged by @GleasonK and @harini-sridhar.

**🚀 Kind of Contribution**

📚 Documentation

