### PR TITLE
make cudnn fusion config conv kind optional for cudnn gemm fusion

### DIFF
--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -177,7 +177,7 @@ message CuDnnFusionConfig {
     CONV_WGRAD = 1;
     CONV_DGRAD = 2;
   }
-  Kind kind = 2;
+  optional Kind kind = 2;
 }
 
 // Output tile sizes for a fusion root.

--- a/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
@@ -383,8 +383,10 @@ class ConvDimensionAdapter {
                         fusion.backend_config<GpuBackendConfig>());
     const FusionBackendConfig& fusion_backend_config =
         gpu_config.fusion_backend_config();
-    if (!fusion_backend_config.has_cudnn_fusion_config()) {
-      VLOG(3) << "Can't find cudnn fusion config for cudnn conv fusion.";
+    if (!fusion_backend_config.has_cudnn_fusion_config() ||
+        !fusion_backend_config.cudnn_fusion_config().has_kind()) {
+      VLOG(3) << "Can't find cudnn fusion config or conv kind for cudnn conv "
+                 "fusion.";
       return std::nullopt;
     }
     CuDnnFusionConfig_Kind conv_kind =


### PR DESCRIPTION
📝 Summary of Changes
make cudnn fusion config conv type field optional since cudnn gemm fusion doesn't need it.

🎯 Justification
conv kind is not required by cudnn gemm fusion, it is better clean it up.

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
None

🧪 Unit Tests:
None

🧪 Execution Tests:
None
