### PR TITLE
[ROCM[ Remove padding for gemms

### DIFF
--- a/xla/service/gpu/cublas_padding_requirements.h
+++ b/xla/service/gpu/cublas_padding_requirements.h
@@ -42,8 +42,8 @@ constexpr std::array<CublasPaddingRequirement, 3> CublasPaddingRequirements{
      {se::CudaComputeCapability::Volta(), F16, 8},
      {se::CudaComputeCapability::Ampere(), BF16, 8}}};
 
-constexpr std::array<HipblasPaddingRequirement, 2> HipblasPaddingRequirements{
-    {{/*rocm gpu arch,*/ F16, 8}, {/*rocm gpu arch,*/ BF16, 8}}};
+// No padding requirements for ROCM
+constexpr std::array<HipblasPaddingRequirement, 0> HipblasPaddingRequirements;
 
 // Tell if either of the operands of the dot requires padding.
 bool CublasRequiresPadding(const HloDotInstruction& dot,

--- a/xla/service/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_test.cc
@@ -979,8 +979,13 @@ ENTRY bf16gemm {
   )";
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 
-  if (!IsCuda() ||
-      HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text,
+                      R"(
+; CHECK: {{.*}} custom-call(bf16[12,4]{1,0} {{.*}}, bf16[4,8]{1,0} {{.*}}), custom_call_target="<<CUBLAS_CUSTOM_CALL_TARGET_PLACEHOLDER>>"
+  )",
+                      /*print_operand_shape=*/true);
+  } else if (HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {
     MatchOptimizedHlo(hlo_text,
                       R"(
 ; CHECK: {{.*}} custom-call(bf16[16,8]{1,0} {{.*}}, bf16[8,8]{1,0} {{.*}}), custom_call_target="<<CUBLAS_CUSTOM_CALL_TARGET_PLACEHOLDER>>"
@@ -1004,8 +1009,13 @@ ENTRY bf16gemm {
   )";
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 
-  if (!IsCuda() ||
-      HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text,
+                      R"(
+    ; CHECK: {{.*}} custom-call(bf16[3,3,4]{2,1,0} {{.*}}, bf16[3,3,2]{2,1,0} {{.*}}), custom_call_target="<<CUBLAS_CUSTOM_CALL_TARGET_PLACEHOLDER>>"
+    )",
+                      /*print_operand_shape=*/true);
+  } else if(HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {
     MatchOptimizedHlo(hlo_text,
                       R"(
     ; CHECK: {{.*}} custom-call(bf16[3,8,8]{2,1,0} {{.*}}, bf16[3,8,8]{2,1,0} {{.*}}), custom_call_target="<<CUBLAS_CUSTOM_CALL_TARGET_PLACEHOLDER>>"


### PR DESCRIPTION
📝 Summary of Changes
Disabled padding for bf16/fp16 gemms on ROCM

🎯 Justification
Padding for gemms was added for parity with NVidia, but upon closer look, it turns out that there is no any advantage of it on ROCM platform. Furthermore, CublasPadForGemms wraps any padded dot op into pad / slice clauses which may prevent certain optimizations (e.g. gemm_rewriter epilogue fusion).

🚀 Kind of Contribution
 ♻️ Cleanup

🧪 Unit Tests:
Adapted the existing gemm_rewriter_test to account for padding on ROCM

@xla-rotation could you have a look please ?