### PR TITLE
[XLA:GPU][oneAPI][Build-fix] Fix ptx custom kernel build issue.

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -24,6 +24,10 @@ load(
     "//xla/tsl/platform/default:cuda_build_defs.bzl",
     "if_cuda_is_configured",
 )
+load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -380,6 +384,22 @@ cc_library(
 )
 
 cc_library(
+    name = "ptx_custom_kernel_emitter_sycl",
+    srcs = ["custom_kernel_emitter_sycl_stub.cc"],
+    hdrs = ["custom_kernel_emitter.h"],
+    tags = [
+        "gpu",
+        "oneapi-only",
+    ],
+    deps = [
+        ":ir_emitter_context",
+        "//xla/hlo/ir:hlo",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
     name = "ptx_custom_kernel_emitter",
     hdrs = ["custom_kernel_emitter.h"],
     tags = ["gpu"],
@@ -387,6 +407,8 @@ cc_library(
         ":ptx_custom_kernel_emitter_cuda",
     ]) + if_rocm_is_configured([
         ":ptx_custom_kernel_emitter_rocm",
+    ]) + if_sycl_is_configured([
+        ":ptx_custom_kernel_emitter_sycl",
     ]) + [
         "//xla/hlo/ir:hlo",
         "@com_google_absl//absl/status:statusor",

--- a/xla/service/gpu/custom_kernel_emitter_sycl_stub.cc
+++ b/xla/service/gpu/custom_kernel_emitter_sycl_stub.cc
@@ -1,0 +1,31 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/custom_kernel_emitter.h"
+#include "xla/service/gpu/ir_emitter_context.h"
+
+namespace xla {
+namespace gpu {
+
+absl::StatusOr<std::unique_ptr<Thunk>> EmitPtxCustomKernelThunk(
+    const HloCustomCallInstruction* /*instr*/, IrEmitterContext* /*context*/) {
+  return absl::UnimplementedError(
+      "Custom kernel emitter for PTX custom call is not yet implemented in "
+      "SYCL platform.");
+}
+
+}  // namespace gpu
+}  // namespace xla


### PR DESCRIPTION
Recent addition of ptx custom kernel to `xla/service/gpu/ir_emitter_unnested.cc` is not supported by SYCL platform. This PR fixes the build issue with a stub implementation.
