### PR TITLE
[XLA:GPU][oneAPI] Bug fixes for SPIR-V codegen

### DIFF
--- a/xla/service/gpu/ir_emitter_context.cc
+++ b/xla/service/gpu/ir_emitter_context.cc
@@ -76,9 +76,11 @@ void IrEmitterContext::emit_constant(int64_t num_elements,
                                                 content.span().size()));
   }();
 
-  // Explicitly set global addrspace for SPIR backend.
+  // Explicitly set global addrspace for SPIR-V backend.
   int addrspace =
-      llvm::Triple(llvm_module_constants()->getTargetTriple()).isSPIR() ? 1 : 0;
+      llvm::Triple(llvm_module_constants()->getTargetTriple()).isSPIROrSPIRV()
+          ? 1
+          : 0;
   // These globals will be looked up by name by GpuExecutable so we need to
   // give them an external linkage.  Not all of their uses are visible in
   // the LLVM IR so we can't give then a linkage that merely preserves their

--- a/xla/service/gpu/llvm_gpu_backend/spirv_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/spirv_backend.cc
@@ -73,6 +73,12 @@ std::vector<std::string> GetSPIRVBackendOptions(
 absl::StatusOr<std::string> CompileToSPIRV(
     llvm::Module* module, stream_executor::GpuComputeCapability gpu_version,
     const DebugOptions& debug_options) {
+  // LLVM SPIR-V backend can not translate empty module. Return empty
+  // spirv-binary for empty llvm module.
+  if (module && module->empty() && module->global_empty() &&
+      module->alias_empty() && module->named_metadata_empty()) {
+    return std::string();
+  }
   static absl::once_flag backend_init_flag;
   absl::call_once(backend_init_flag, SPIRVBackendInit);
   auto llvm_opts = GetSPIRVBackendOptions(debug_options);


### PR DESCRIPTION
This PR fixes 2 issues:

- Address space for SPIR-V target triple
- Compiling empty llvm module to SPIR-V binary
