### PR TITLE
Correct usage of Protobuf DebugString APIs in mhlo_to_hlo translate

### DIFF
--- a/xla/hlo/translate/mhlo_to_hlo/BUILD
+++ b/xla/hlo/translate/mhlo_to_hlo/BUILD
@@ -317,6 +317,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Support",
+        "@tsl//tsl/platform:protobuf",
     ],
 )
 

--- a/xla/hlo/translate/mhlo_to_hlo/translate.cc
+++ b/xla/hlo/translate/mhlo_to_hlo/translate.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "mlir/Parser/Parser.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
+#include "tsl/platform/protobuf.h"
 #include "xla/debug_options_flags.h"
 #include "xla/hlo/builder/xla_builder.h"
 #include "xla/hlo/builder/xla_computation.h"
@@ -77,7 +78,8 @@ mlir::LogicalResult MlirHloToHloTranslateFunction(mlir::ModuleOp module,
   }
 
   // Print as HloProto with empty BufferAssignment for legacy compatibility.
-  output << MakeHloProto(*statusOrModule.value()).DebugString();
+  output << tsl::LegacyUnredactedDebugString(
+      MakeHloProto(*statusOrModule.value()));
   return mlir::success();
 }
 


### PR DESCRIPTION
📝 Summary of Changes
use tsl::LegacyUnredactedDebugString since Protobuf message DebugString output contains debug markers likes "goo.gle/debugproto".

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
🐛 Bug Fix
