### PR TITLE
Implement cross host transfer optimizations in StreamExecutorGpuClient

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -71,6 +71,7 @@ cc_library(
         "//xla/backends/gpu/collectives:gpu_clique_key",
         "//xla/backends/gpu/collectives:gpu_cliques",
         "//xla/backends/gpu/collectives:gpu_collectives",
+        "//xla/backends/gpu/collectives:gpu_communicator",
         "//xla/client:client_library",
         "//xla/client:local_client",
         "//xla/core/collectives",

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -69,6 +69,7 @@ cc_library(
         "//xla:xla_data_proto_cc",
         "//xla:xla_proto_cc",
         "//xla/backends/gpu/collectives:gpu_clique_key",
+        "//xla/backends/gpu/collectives:gpu_clique",
         "//xla/backends/gpu/collectives:gpu_cliques",
         "//xla/backends/gpu/collectives:gpu_collectives",
         "//xla/backends/gpu/collectives:gpu_communicator",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -597,10 +597,11 @@ absl::StatusOr<PreparedReceive> PrepareReceive(
       client->AllocateRawBuffer(memory_space, on_device_bytes_count,
                                 /*retry_on_oom=*/true,
                                 /*allocate_after=*/{}));
-  TF_ASSIGN_OR_RETURN(
-      std::unique_ptr<PjRtBuffer> buffer,
-      client->DefineBuffer(on_device_shape, raw_buffer, {definition_event},
-                           /*raw_buffer_is_mutable=*/true));
+
+  TF_ASSIGN_OR_RETURN(std::unique_ptr<PjRtBuffer> buffer,
+                      client->DefineBuffer(on_device_shape, memory_space,
+                                           raw_buffer, {definition_event},
+                                           /*raw_buffer_is_mutable=*/true));
   definition_event->AndThen([raw_buffer]() {});
 
   return PreparedReceive{

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -407,10 +407,7 @@ using AcquiredCliqueAndCommunicator =
     std::pair<std::shared_ptr<gpu::LockableGpuClique::Lock>,
               gpu::GpuCommunicator*>;
 
-class PreparedSend {
- public:
-  PreparedSend() = delete;
-
+struct PreparedSend {
   StreamExecutorGpuClient* client;
   gpu::GpuCliqueKey clique_key;
   tsl::RCReference<CommonPjRtRawBuffer> raw_buffer;
@@ -418,6 +415,9 @@ class PreparedSend {
   tsl::RCReference<PjRtStreamExecutorDeviceEvent> usage_event;
   AcquiredCliqueAndCommunicator clique_and_communicator;
   std::shared_ptr<Future<>::Promise> promise;
+
+  PreparedSend(PreparedSend&&) = default;
+  PreparedSend& operator=(PreparedSend&&) = default;
 
   ~PreparedSend() {
     if (!usage_event || usage_event->event()->IsDefined()) {
@@ -429,24 +429,18 @@ class PreparedSend {
         absl::InternalError("PreparedSend destroyed without fulfilling "
                             "usage_event"));
   }
-
-  // Disable copy to prevent double-fulfillment issues.
-  PreparedSend(const PreparedSend&) = delete;
-  PreparedSend& operator=(const PreparedSend&) = delete;
-  PreparedSend(PreparedSend&&) = default;
-  PreparedSend& operator=(PreparedSend&&) = default;
 };
 
-class PreparedReceive {
- public:
-  PreparedReceive() = delete;
-
+struct PreparedReceive {
   StreamExecutorGpuClient* client;
   gpu::GpuCliqueKey clique_key;
   std::unique_ptr<PjRtBuffer> buffer;
   tsl::RCReference<CommonPjRtRawBuffer> raw_buffer;
   tsl::RCReference<PjRtStreamExecutorDeviceEvent> definition_event;
   AcquiredCliqueAndCommunicator clique_and_communicator;
+
+  PreparedReceive(PreparedReceive&&) = default;
+  PreparedReceive& operator=(PreparedReceive&&) = default;
 
   ~PreparedReceive() {
     if (!definition_event || definition_event->event()->IsDefined()) {
@@ -459,12 +453,6 @@ class PreparedReceive {
         absl::InternalError("PreparedReceive destroyed without fulfilling "
                             "definition_event"));
   }
-
-  // Disable copy to prevent double-fulfillment issues.
-  PreparedReceive(const PreparedReceive&) = delete;
-  PreparedReceive& operator=(const PreparedReceive&) = delete;
-  PreparedReceive(PreparedReceive&&) = default;
-  PreparedReceive& operator=(PreparedReceive&&) = default;
 };
 
 // Acquire the GPU clique and communicator for a given clique key.

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -211,8 +211,8 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
 
   void ScheduleSendsOnLocalDevice(
       PjRtDevice* device, std::vector<PjRtBuffer*> buffers,
-      const std::vector<PjRtGlobalDeviceId> dst_global_device_ids,
-      const std::vector<CrossHostTransferKey> transfer_keys,
+      std::vector<PjRtGlobalDeviceId> dst_global_device_ids,
+      std::vector<CrossHostTransferKey> transfer_keys,
       std::vector<std::shared_ptr<Future<>::Promise>> promises);
 
   struct PrepareReceiveBufferResult {

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -115,7 +115,6 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
       bool should_stage_host_to_device_transfers,
       std::unique_ptr<gpu::GpuExecutableRunOptions> gpu_run_options,
       std::shared_ptr<KeyValueStoreInterface> kv_store,
-      std::shared_ptr<DistributedRuntimeClient> distributed_client,
       bool abort_collectives_on_failure,
       std::shared_ptr<const GpuTopology> gpu_topology,
       std::optional<int> num_nodes);
@@ -202,14 +201,10 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
   absl::flat_hash_map<GlobalDeviceId, IncarnationId> GetLatestIncarnations(
       const ExecuteOptions& options);
 
-  absl::StatusOr<absl::flat_hash_map<GlobalDeviceId, IncarnationId>>
-  GetLatestIncarnations();
-
   std::optional<int> num_nodes_;
   const bool abort_collectives_on_failure_ = false;
   std::optional<xla::StreamExecutorGpuTopologyDescription> topology_;
   std::shared_ptr<KeyValueStoreInterface> kv_store_;
-  std::shared_ptr<DistributedRuntimeClient> distributed_client_;
 
   // Helpers for cross host transfers.
   absl::Duration cross_host_transfer_timeout_ = absl::Minutes(3);

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -33,6 +33,8 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/collectives/gpu_cliques.h"
 #include "xla/client/local_client.h"
 #include "xla/executable_run_options.h"
 #include "xla/future.h"
@@ -48,6 +50,7 @@ limitations under the License.
 #include "xla/pjrt/pjrt_compiler.h"
 #include "xla/pjrt/pjrt_executable.h"
 #include "xla/pjrt/pjrt_stream_executor_client.h"
+#include "xla/pjrt/se_raw_buffer.h"
 #include "xla/pjrt/plugin/xla_gpu/xla_gpu_client_options.h"
 #include "xla/pjrt/tracked_device_buffer.h"
 #include "xla/runtime/device_id.h"
@@ -112,6 +115,7 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
       bool should_stage_host_to_device_transfers,
       std::unique_ptr<gpu::GpuExecutableRunOptions> gpu_run_options,
       std::shared_ptr<KeyValueStoreInterface> kv_store,
+      std::shared_ptr<DistributedRuntimeClient> distributed_client,
       bool abort_collectives_on_failure,
       std::shared_ptr<const GpuTopology> gpu_topology,
       std::optional<int> num_nodes);
@@ -198,17 +202,23 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
   absl::flat_hash_map<GlobalDeviceId, IncarnationId> GetLatestIncarnations(
       const ExecuteOptions& options);
 
+  absl::StatusOr<absl::flat_hash_map<GlobalDeviceId, IncarnationId>>
+  GetLatestIncarnations();
+
   std::optional<int> num_nodes_;
   const bool abort_collectives_on_failure_ = false;
   std::optional<xla::StreamExecutorGpuTopologyDescription> topology_;
   std::shared_ptr<KeyValueStoreInterface> kv_store_;
+  std::shared_ptr<DistributedRuntimeClient> distributed_client_;
 
   // Helpers for cross host transfers.
   absl::Duration cross_host_transfer_timeout_ = absl::Minutes(3);
 
-  absl::StatusOr<Future<>> CrossHostSendBuffer(
-      PjRtBuffer* buffer, PjRtGlobalDeviceId dst_global_device_id,
-      CrossHostTransferKey transfer_key);
+  void ScheduleSendsOnLocalDevice(
+      PjRtDevice* device, std::vector<PjRtBuffer*> buffers,
+      const std::vector<PjRtGlobalDeviceId> dst_global_device_ids,
+      const std::vector<CrossHostTransferKey> transfer_keys,
+      std::vector<std::shared_ptr<Future<>::Promise>> promises);
 
   struct PrepareReceiveBufferResult {
     std::unique_ptr<PjRtBuffer> buffer;
@@ -220,11 +230,6 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
 
   absl::StatusOr<PrepareReceiveBufferResult> PrepareReceiveBuffer(
       PjRtDevice* device, Shape shape);
-
-  absl::StatusOr<std::unique_ptr<PjRtBuffer>> CrossHostReceiveBuffer(
-      xla::Shape shape, xla::PjRtDevice* device,
-      PjRtGlobalDeviceId src_global_device_ids,
-      CrossHostTransferKey transfer_keys);
 };
 
 std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> BuildLocalDevices(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -2932,6 +2932,51 @@ TEST(StreamExecutorGpuClientTest, FailedCrossHostSendArgsSizeMismatch) {
                            "must have the same length, but got 1, 1, and 2.")));
 }
 
+TEST(StreamExecutorGpuClientTest, FailedCrossHostTransferSrcAndDstAddressable) {
+  // Create the client.
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+
+  // Create a buffer to try to send.
+  std::vector<int32_t> data(256);
+  std::iota(data.begin(), data.end(), 1);
+
+  Shape shape = ShapeUtil::MakeShape(S32, {256});
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<PjRtBuffer> buffer,
+      client->BufferFromHostBuffer(
+          data.data(), shape.element_type(), shape.dimensions(),
+          /*byte_strides=*/std::nullopt,
+          PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall, nullptr,
+          *client->addressable_devices()[0]->default_memory_space(),
+          /*device_layout=*/nullptr));
+
+  // Try to transfer some data between two addressable devices.
+  EXPECT_THAT(
+      client->CrossHostSendBuffers({buffer.get()}, {PjRtGlobalDeviceId(1)},
+                                   {CrossHostTransferKey(0)}),
+      absl_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          ::testing::StrEq(
+              "CrossHostSendBuffers: destination device for buffer 0 is "
+              "addressable (global device id 1), but cross-host transfers must "
+              "be between an addressable and a non-addressable device.")));
+
+  EXPECT_THAT(
+      client->CrossHostReceiveBuffers(
+          /*device=*/client->addressable_devices()[0],
+          /*shapes=*/{shape},
+          /*src_global_device_ids=*/{PjRtGlobalDeviceId(1)},
+          /*transfer_keys=*/{CrossHostTransferKey(0)}),
+      absl_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          ::testing::StrEq(
+              "CrossHostReceiveBuffers: source device for buffer 0 is "
+              "addressable (global device id 1), but cross-host transfers must "
+              "be between an addressable and a non-addressable device.")));
+}
+
 TEST(StreamExecutorGpuClientTest, FailedCrossHostReceiveArgsSizeMismatch) {
   // Create the client.
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -2939,7 +2939,7 @@ TEST(StreamExecutorGpuClientTest, FailedCrossHostTransferSrcAndDstAddressable) {
 
   // Create a buffer to try to send.
   std::vector<int32_t> data(256);
-  std::iota(data.begin(), data.end(), 1);
+  absl::c_iota(data, 1);
 
   Shape shape = ShapeUtil::MakeShape(S32, {256});
 
@@ -3121,13 +3121,14 @@ absl::Status SuccessfulCrossHostTransferTestBody(bool is_sender,
   // Sender logic.
   if (is_sender) {
     LOG(INFO) << log_prefix << ": creating buffers";
-    std::vector<int32_t> data(256);
-    absl::c_iota(data, 1);
-    Shape shape = ShapeUtil::MakeShape(S32, {256});
 
     // Create the data to send.
+    Shape shape = ShapeUtil::MakeShape(S32, {256});
     std::vector<std::unique_ptr<PjRtBuffer>> buffers;
     for (int i = 0; i < num_arrays; ++i) {
+      std::vector<int32_t> data(256);
+      absl::c_iota(data, 1000 * i);
+
       TF_ASSIGN_OR_RETURN(
           std::unique_ptr<PjRtBuffer> buffer,
           client->BufferFromHostBuffer(
@@ -3166,12 +3167,6 @@ absl::Status SuccessfulCrossHostTransferTestBody(bool is_sender,
     }
   } else {
     // Receiver logic.
-    // Expected data to receive.
-    std::vector<int32_t> expected_data(256);
-    absl::c_iota(expected_data, 1);
-    auto expected_literal = LiteralUtil::CreateR1<int32_t>(expected_data);
-
-    // Receive some data.
     std::vector<Shape> shapes;
     std::vector<PjRtGlobalDeviceId> src_device_ids;
     std::vector<CrossHostTransferKey> transfer_keys;
@@ -3194,6 +3189,10 @@ absl::Status SuccessfulCrossHostTransferTestBody(bool is_sender,
     EXPECT_EQ(receive_buffers.size(), num_arrays);
 
     for (int i = 0; i < num_arrays; ++i) {
+      std::vector<int32_t> expected_data(256);
+      absl::c_iota(expected_data, 1000 * i);
+      auto expected_literal = LiteralUtil::CreateR1<int32_t>(expected_data);
+
       LOG(INFO) << log_prefix << ": waiting for receive " << i
                 << " to complete";
       TF_RETURN_IF_ERROR(receive_buffers[i]->GetReadyFuture().Await());


### PR DESCRIPTION
📝 Summary of Changes
This PR adds three optimizations to the `CrossHost{Send,Receive}Buffers` methods in `StreamExecutorGpuClient`: 
1. Communicators are cached for re-use across transfers with `AcquireGpuClique`.
2. Transfers of multiple arrays are aggregated with NCCL group calls using `GpuCommunicator::GroupExecute`.
3. Usage / definition events and promises that signal the completion of cross-host transfers are fulfilled on `StreamExecutorGpuClient::thread_pool()` instead of blocking the XLA execute thread.

This PR follows up on #33284 and is based on discussions with @emilyfertig, @mwhittaker, and @pschuh.

🎯 Justification
#33284 added `CrossHost{Send,Receive}Buffers` to the PjRt Client API to enable the optimizations implemented in this PR. The old implementation does not cache communicators, aggregate transfers, or asynchronously fulfill events / promises, leading to reduced performance.

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
Benchmarks were ran on these [three toy programs](https://gist.github.com/rao-ashish/28155ffee98406b7c041037c20fc75e6).

Workload | Implementation | Time
-- | -- | --
example_basic_overlap | Unoptimized | 26.968 sec
  | Optimized | 43.124 ms
example_overlap | Unoptimized | 369.541 sec
  | Optimized | 733.071 ms
example_pp | Unoptimized | 369.0924 sec
  | Optimized | 2.433 sec

🧪 Unit Tests:
The unit tests added in #33284 continue to pass. The new implementation requires that cross-host transfers are always between a local device and a remote device; a test has been added to make sure that the implementation throws an InvalidArgument error if this is not the case.

🧪 Execution Tests:
When building XLA with the code in this PR along with [a patch for pjrt_ifrt/pjrt_client.cc](https://gist.github.com/rao-ashish/ba5cd773906c8e428147bb80a3568912) so that it uses the new cross-host transfers API, I verified that [these 4 correctness checks](https://gist.github.com/rao-ashish/24ac0df0cb18243c649ac535964b31b8) pass. These IFRT changes will be included in a follow-up PR once other PjRt clients have implemented the new API.