### PR TITLE
Ci dev mx datatype rocm

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -344,7 +344,7 @@ static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
       return Internal(
           "Error trying to emit command for a CommandBufferThunk. Input HLO "
           "must already contain command buffers and XLA should not run command "
-          "buffer scheduling pass the second time. It it happens in the test, "
+          "buffer scheduling pass the second time. If it happens in the test, "
           "try explicitly disabling command buffers in tested HLO module.");
 
     default:

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -718,7 +718,7 @@ TEST(CommandBufferThunkTest, GemmCmd) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {4, 3}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {2, 3}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       stream_executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -839,7 +839,7 @@ TEST(CommandBufferThunkTest, ChildGemmCmd) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {4, 3}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {2, 3}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       stream_executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -975,7 +975,7 @@ TEST(CommandBufferThunkTest, DISABLED_DynamicSliceFusionCmd) {
       ShapeUtil::MakeShape(PrimitiveType::F32, {4, 3}), {}, {0},
       ShapeUtil::MakeShape(PrimitiveType::F32, {2, 3}), 1.0, 0.0, 0.0,
       PrecisionConfig::ALG_UNSET, std::nullopt,
-      se::blas::kDefaultComputePrecision, false, false,
+      se::blas::kDefaultComputePrecision, false, false, false,
       stream_executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 
@@ -1120,7 +1120,7 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
       /*precision_algorithm*/ PrecisionConfig::ALG_UNSET,
       /*algorithm*/ std::nullopt,
       /*compute_precision*/ se::blas::kDefaultComputePrecision,
-      /*grad_x*/ false, /*grad_y*/ false,
+      /*grad_x*/ false, /*grad_y*/ false, /*mx_mode*/ false,
       stream_executor->GetDeviceDescription().gpu_compute_capability());
   ASSERT_TRUE(config.ok());
 

--- a/xla/literal_util.cc
+++ b/xla/literal_util.cc
@@ -339,6 +339,24 @@ void PopulateWithRandomFloatingPointData(Literal* literal,
   }
 }
 
+template <>
+void PopulateWithRandomFloatingPointData<tsl::float8_e8m0fnu, float>(
+    Literal* literal, std::minstd_rand0* engine) {
+  std::uniform_real_distribution<float> generator(0.0f, 2.0f);
+  for (tsl::float8_e8m0fnu& value : literal->data<tsl::float8_e8m0fnu>()) {
+    value = static_cast<tsl::float8_e8m0fnu>(generator(*engine));
+  }
+}
+
+template <>
+void PopulateWithRandomFloatingPointData<tsl::float4_e2m1fn, float>(
+    Literal* literal, std::minstd_rand0* engine) {
+  std::uniform_real_distribution<float> generator(-6.0f, 6.0f);
+  for (tsl::float4_e2m1fn& value : literal->data<tsl::float4_e2m1fn>()) {
+    value = static_cast<tsl::float4_e2m1fn>(generator(*engine));
+  }
+}
+
 template <typename FloatT>
 void PopulateWithFloatingPointData(
     Literal* literal, std::minstd_rand0* engine, bool no_duplicates,

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2444,6 +2444,7 @@ cc_library(
         "//xla/service/gpu/autotuning:gemm_fusion_autotuner",
         "//xla/service/gpu/llvm_gpu_backend:amdgpu_backend",
         "//xla/service/gpu/transforms:algebraic_simplifier",
+        "//xla/service/gpu/transforms:block_scaling_rewriter",
         "//xla/service/gpu/transforms:conv_padding_legalization",
         "//xla/service/gpu/transforms:conv_rewriter",
         "//xla/service/gpu/transforms:cublas_pad_for_gemms",

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -56,6 +56,7 @@ limitations under the License.
 #include "xla/service/gpu/llvm_gpu_backend/amdgpu_backend.h"
 #include "xla/service/gpu/target_constants.h"
 #include "xla/service/gpu/transforms/algebraic_simplifier.h"
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
 #include "xla/service/gpu/transforms/conv_padding_legalization.h"
 #include "xla/service/gpu/transforms/conv_rewriter.h"
 #include "xla/service/gpu/transforms/cublas_pad_for_gemms.h"
@@ -183,14 +184,17 @@ absl::Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
     HloModule* hlo_module, se::StreamExecutor* stream_exec,
     const CompileOptions& options, const TargetConfig& gpu_target_config,
     const GpuAliasInfo* alias_info, tsl::thread::ThreadPool* thread_pool) {
-  HloPassPipeline pre_pipeline("AMDGPU post-layout_assignment part 1");
+  auto& gpu_version = gpu_target_config.device_description.gpu_compute_capability();
 
+  HloPassPipeline pre_pipeline("AMDGPU post-layout_assignment part 1");
+  pre_pipeline.AddPass<BlockScalingRewriter>(
+      gpu_target_config.device_description, se::dnn::VersionInfo{},
+      gpu_version.rocm_compute_capability()->has_hipblaslt_mx_support());
   pre_pipeline.AddPass<DotDimensionMerger>();
 
   for (const auto& req : HipblasPaddingRequirements) {
-    pre_pipeline.AddPass<CublasPadForGemms>(
-        gpu_target_config.device_description.gpu_compute_capability(),
-        req.data_type, req.multiple_of);
+    pre_pipeline.AddPass<CublasPadForGemms>(gpu_version, req.data_type,
+                                            req.multiple_of);
   }
   // Padding a gemm operand that's a constant results in pad(constant).  Run
   // constant-folding to simplify this into a new constant.

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -108,7 +108,9 @@ message GemmBackendConfig {
   optional bool grad_y = 17;
   bool damax_output = 18;
 
-  reserved 19;
+  bool mx_mode = 19;
+
+  reserved 20;
 }
 
 // Backend config for bitcast operation generated from MLIR MHLO dialect.

--- a/xla/service/gpu/cublas_cudnn.cc
+++ b/xla/service/gpu/cublas_cudnn.cc
@@ -48,6 +48,11 @@ bool IsCublasLtMatmulF8(const HloInstruction& hlo) {
          hlo.custom_call_target() == kCublasLtMatmulF8CallTarget;
 }
 
+bool IsCublasLtMatmulMX(const HloInstruction& hlo) {
+  return hlo.opcode() == HloOpcode::kCustomCall &&
+         hlo.custom_call_target() == kCublasLtMatmulMXCallTarget;
+}
+
 bool IsTriangularSolve(const HloInstruction& hlo) {
   return hlo.opcode() == HloOpcode::kCustomCall &&
          hlo.custom_call_target() == kTriangularSolveCallTarget;
@@ -56,6 +61,7 @@ bool IsTriangularSolve(const HloInstruction& hlo) {
 const absl::string_view kGemmCallTarget = "__cublas$gemm";
 const absl::string_view kCublasLtMatmulCallTarget = "__cublas$lt$matmul";
 const absl::string_view kCublasLtMatmulF8CallTarget = "__cublas$lt$matmul$f8";
+const absl::string_view kCublasLtMatmulMXCallTarget = "__cublas$lt$matmul$mx";
 const absl::string_view kTriangularSolveCallTarget = "__cublas$triangularSolve";
 
 const absl::string_view kCudnnConvBackwardInputCallTarget =

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -99,6 +99,9 @@ bool IsCublasLtMatmul(const HloInstruction& hlo);
 // Scaled matrix multiplication in FP8. Calls into cublasLt.
 bool IsCublasLtMatmulF8(const HloInstruction& hlo);
 
+// Scaled matrix multiplication in FP8. Calls into cublasLt.
+bool IsCublasLtMatmulMX(const HloInstruction& hlo);
+
 // Triangular solve that calls into legacy cublas.
 bool IsTriangularSolve(const HloInstruction& hlo);
 
@@ -212,6 +215,9 @@ bool MHACallHasDropout(absl::string_view fmha_call_name);
 
 // A call to cuDNN for a block scaled dot.
 extern const absl::string_view kCudnnBlockScaledDotCallTarget;
+
+// A call to hipblaslt for a block scaled dot.
+extern const absl::string_view kCublasLtMatmulMXCallTarget;
 
 bool IsCustomCallToBlockScaledDot(const HloInstruction& hlo);
 

--- a/xla/service/gpu/ir_emitter_unnested.cc
+++ b/xla/service/gpu/ir_emitter_unnested.cc
@@ -879,6 +879,65 @@ absl::Status IrEmitterUnnested::EmitCublasLtMatmulThunkF8(
   return absl::OkStatus();
 }
 
+absl::Status IrEmitterUnnested::EmitCublasLtMatmulThunkMX(
+    const HloCustomCallInstruction* instr) {
+  TF_RET_CHECK(instr->operand_count() == 4);
+  TF_ASSIGN_OR_RETURN(const auto gpu_config,
+                      instr->backend_config<xla::gpu::GpuBackendConfig>());
+  const xla::gpu::GemmBackendConfig& config = gpu_config.gemm_backend_config();
+  xla::gpu::GemmBackendConfig_Epilogue epilogue = config.epilogue();
+
+  TF_RET_CHECK(instr->shape().IsTuple());
+  xla::ShapeIndex output_index = xla::ShapeIndex{0};
+
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice a,
+                      GetAllocationSliceForHlo(instr->operand(0)));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice b,
+                      GetAllocationSliceForHlo(instr->operand(1)));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice a_scale,
+                      GetAllocationSliceForHlo(instr->operand(2)));
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice b_scale,
+                      GetAllocationSliceForHlo(instr->operand(3)));
+  BufferAllocation::Slice c;
+  TF_ASSIGN_OR_RETURN(c, GetAllocationSliceForHlo(instr, output_index));
+  BufferAllocation::Slice c_scale, d_scale, bias;  // not used
+
+  TF_ASSIGN_OR_RETURN(BufferAllocation::Slice d,
+                      GetAllocationSliceForHlo(instr, output_index));
+  BufferAllocation::Slice d_amax, aux;  // not used
+
+  TF_ASSIGN_OR_RETURN(
+      auto gemm_config,
+      GemmConfig::For(static_cast<const HloInstruction*>(instr),
+                      ir_emitter_context_->gpu_compute_capability()));
+
+  // Use the first algorithm by default (i.e. fastest according to heuristics).
+  int64_t algorithm =
+      config.algorithm_case() == GemmBackendConfig::kSelectedAlgorithm
+          ? config.selected_algorithm()
+          : 0;
+
+  std::optional<BufferAllocation::Slice> workspace_buffer;
+  if (instr->shape().tuple_shapes().size() - config.damax_output() == 2) {
+    TF_ASSIGN_OR_RETURN(workspace_buffer,
+                        GetAllocationSliceForHlo(
+                            instr, {instr->shape().tuple_shapes_size() - 1}));
+  }
+
+  TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::Epilogue blas_lt_epilogue,
+                      gpublas_lt::AsBlasLtEpilogue(epilogue));
+  Thunk::ThunkInfo thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(
+      instr, ir_emitter_context_->GetNextThunkId());
+  std::string canonical_hlo = instr->ToString(
+      HloPrintOptions::Fingerprint().set_print_backend_config(true));
+  auto thunk = std::make_unique<CublasLtMatmulThunk>(
+      std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
+      blas_lt_epilogue, algorithm, a, b, c, d, bias, aux, a_scale, b_scale,
+      c_scale, d_scale, d_amax, workspace_buffer);
+  AddThunkToThunkSequence(std::move(thunk));
+  return absl::OkStatus();
+}
+
 absl::Status IrEmitterUnnested::EmitConvolutionReorderThunk(
     const HloCustomCallInstruction* instr) {
   bool has_bias = instr->operand_count() > 1;
@@ -1627,6 +1686,13 @@ absl::Status IrEmitterUnnested::EmitAsyncCustomCallStart(
   }
   if (IsCublasLtMatmulF8(*wrapped)) {
     auto status = EmitCublasLtMatmulThunkF8(custom_call);
+    if (status.ok()) {
+      thunk_sequence_.back()->set_execution_stream_id(execution_stream_id);
+    }
+    return status;
+  }
+  if (IsCublasLtMatmulMX(*wrapped)) {
+    auto status = EmitCublasLtMatmulThunkMX(custom_call);
     if (status.ok()) {
       thunk_sequence_.back()->set_execution_stream_id(execution_stream_id);
     }
@@ -3205,6 +3271,9 @@ absl::Status IrEmitterUnnested::EmitHloInstruction(
       }
       if (IsCublasLtMatmulF8(*instr)) {
         return EmitCublasLtMatmulThunkF8(custom_call);
+      }
+      if (IsCublasLtMatmulMX(*instr)) {
+        return EmitCublasLtMatmulThunkMX(custom_call);
       }
       if (IsCudnnConvolutionReorder(*instr)) {
         return EmitConvolutionReorderThunk(custom_call);

--- a/xla/service/gpu/ir_emitter_unnested.h
+++ b/xla/service/gpu/ir_emitter_unnested.h
@@ -120,6 +120,7 @@ class IrEmitterUnnested : public IrEmitter {
   absl::Status EmitGemmThunk(const HloCustomCallInstruction* instr);
   absl::Status EmitCublasLtMatmulThunk(const HloCustomCallInstruction* instr);
   absl::Status EmitCublasLtMatmulThunkF8(const HloCustomCallInstruction* instr);
+  absl::Status EmitCublasLtMatmulThunkMX(const HloCustomCallInstruction* instr);
   absl::Status EmitConvolutionReorderThunk(
       const HloCustomCallInstruction* instr);
   absl::Status EmitNormThunk(const HloCustomCallInstruction* instr);

--- a/xla/service/gpu/matmul_utils.cc
+++ b/xla/service/gpu/matmul_utils.cc
@@ -265,13 +265,13 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
     double alpha_real, double alpha_imag, double beta,
     PrecisionConfig::Algorithm precision_algorithm,
     std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-    bool grad_y, const se::GpuComputeCapability& gpu_version) {
+    bool grad_y, bool mx_mode, const se::GpuComputeCapability& gpu_version) {
   return GemmConfig::For(lhs_shape, lhs_batch_dims, lhs_contracting_dims,
                          rhs_shape, rhs_batch_dims, rhs_contracting_dims,
                          /*c_shape=*/output_shape, /*bias_shape_ptr=*/nullptr,
                          output_shape, alpha_real, alpha_imag, beta,
                          precision_algorithm, algorithm, compute_precision,
-                         grad_x, grad_y, gpu_version);
+                         grad_x, grad_y, mx_mode, gpu_version);
 }
 
 /*static*/ absl::StatusOr<GemmConfig> GemmConfig::For(
@@ -283,7 +283,7 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
     double alpha_imag, double beta,
     PrecisionConfig::Algorithm precision_algorithm,
     std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-    bool grad_y, const se::GpuComputeCapability& gpu_version) {
+    bool grad_y, bool mx_mode, const se::GpuComputeCapability& gpu_version) {
   absl::Span<const int64_t> lhs_col_dims = lhs_contracting_dims;
   TF_ASSIGN_OR_RETURN(
       std::vector<int64_t> lhs_row_dims,
@@ -401,7 +401,8 @@ absl::StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
                                         precision_algorithm,
                                         algorithm,
                                         grad_x,
-                                        grad_y});
+                                        grad_y,
+                                        mx_mode});
 }
 
 namespace {
@@ -475,7 +476,8 @@ bool IsTf32Allowed(PrecisionConfig::Algorithm algorithm,
       /*bias_shape_ptr=*/
       vector_bias_shape ? &vector_bias_shape.value() : nullptr, output_shape,
       config.alpha_real(), config.alpha_imag(), config.beta(),
-      precision_algorithm, algorithm, precision, grad_x, grad_y, gpu_version);
+      precision_algorithm, algorithm, precision, grad_x, grad_y,
+      config.mx_mode(), gpu_version);
 }
 
 absl::StatusOr<GemmConfig::DescriptorsTuple> GemmConfig::GetMatrixDescriptors(

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -123,7 +123,7 @@ struct GemmConfig : public se::gpu::GemmConfig {
       double alpha_real, double alpha_imag, double beta,
       PrecisionConfig::Algorithm precision_algorithm,
       std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-      bool grad_y, const se::GpuComputeCapability& gpu_version);
+      bool grad_y, bool mx_mode, const se::GpuComputeCapability& gpu_version);
 
   // As above with additional `c_shape` and `bias_shape_ptr` parameter, both
   // which are only necessarily for F8 gemms.
@@ -136,7 +136,7 @@ struct GemmConfig : public se::gpu::GemmConfig {
       double alpha_imag, double beta,
       PrecisionConfig::Algorithm precision_algorithm,
       std::optional<int64_t> algorithm, int64_t compute_precision, bool grad_x,
-      bool grad_y, const se::GpuComputeCapability& gpu_version);
+      bool grad_y, bool mx_mode, const se::GpuComputeCapability& gpu_version);
 
   struct DescriptorsTuple {
     se::gpu::MatrixDescriptor lhs;

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -282,9 +282,11 @@ absl::Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
   }
 
   pre_pipeline.AddPass<BlockScalingRewriter>(
+      gpu_target_config.device_description,
       cuda_compute_capability->IsAtLeastBlackwell()
           ? gpu_target_config.dnn_version_info
-          : se::dnn::VersionInfo{});
+          : se::dnn::VersionInfo{},
+      /*allow_hipblaslt*/ false);
   pre_pipeline.AddPass<DotDimensionMerger>();
 
   if (!hlo_module->config()

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -314,6 +314,7 @@ cc_library(
         "//xla/service/gpu:backend_configs_cc",
         "//xla/service/gpu:cublas_cudnn",
         "//xla/stream_executor:dnn",
+        "//xla/service/gpu:matmul_utils",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
@@ -325,14 +326,15 @@ cc_library(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "block_scaling_rewriter_test",
     srcs = ["block_scaling_rewriter_test.cc"],
+    backends = ["gpu"],
     deps = [
         ":block_scaling_rewriter",
         "//xla:error_spec",
         "//xla/hlo/parser:hlo_parser",
-        "//xla/tests:hlo_test_base",
+        "//xla/service/gpu/tests:gpu_codegen_test",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
@@ -354,6 +356,22 @@ xla_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
         "@local_config_cuda//cuda:cudnn_header",
+    ],
+)
+
+xla_test(
+    name = "block_scaling_rewriter_hipblaslt_test",
+    srcs = ["block_scaling_rewriter_hipblaslt_test.cc"],
+    backends = ["gpu"],
+    deps = [
+        ":block_scaling_rewriter",
+        "//xla:error_spec",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu/tests:gpu_codegen_test",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/platform:status_matchers",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/xla/service/gpu/transforms/block_scaling_rewriter.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.cc
@@ -42,6 +42,8 @@ limitations under the License.
 #include "xla/service/gpu/cublas_cudnn.h"
 #include "xla/service/hlo_creation_utils.h"
 #include "xla/service/shape_inference.h"
+#include "xla/service/gpu/matmul_utils.h"
+#include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/status_macros.h"
@@ -53,17 +55,8 @@ limitations under the License.
 namespace xla::gpu {
 namespace {
 
-// Expand builder into a new instruction that will replace the old one.
-absl::StatusOr<HloInstruction*> ExpandInstructionUsingBuilder(
-    XlaBuilder& builder, HloInstruction* old_instruction) {
-  TF_ASSIGN_OR_RETURN(XlaComputation xla_computation, builder.Build());
-  TF_ASSIGN_OR_RETURN(
-      HloComputation * computation,
-      XlaComputationToHloComputation(xla_computation,
-                                     old_instruction->parent()->parent()));
-
-  // Fix broadcast layouts (they cannot be inferred correctly).
-  for (HloInstruction* instruction : computation->instructions()) {
+void FixBroadcastLayouts(HloComputation* hlo_computation) {
+  for (HloInstruction* instruction : hlo_computation->instructions()) {
     auto broadcast = DynCast<HloBroadcastInstruction>(instruction);
     if (broadcast != nullptr && !LayoutUtil::IsMonotonicWithDim0Major(
                                     broadcast->operand(0)->shape().layout())) {
@@ -88,9 +81,53 @@ absl::StatusOr<HloInstruction*> ExpandInstructionUsingBuilder(
       *reshape->mutable_shape()->mutable_layout() = convert->shape().layout();
     }
   }
+}
+
+// Expand builder into a new instruction that will replace the old one.
+absl::StatusOr<HloInstruction*> ExpandInstructionUsingBuilder(
+    XlaBuilder& builder, HloInstruction* old_instruction) {
+  TF_ASSIGN_OR_RETURN(XlaComputation xla_computation, builder.Build());
+  TF_ASSIGN_OR_RETURN(
+      HloComputation * hlo_computation,
+      XlaComputationToHloComputation(xla_computation,
+                                     old_instruction->parent()->parent()));
+
+  // Fix broadcast layouts (they cannot be inferred correctly).
+  FixBroadcastLayouts(hlo_computation);
 
   return old_instruction->parent()->AddInstruction(HloInstruction::CreateCall(
-      old_instruction->shape(), old_instruction->operands(), computation));
+      old_instruction->shape(), old_instruction->operands(), hlo_computation));
+}
+
+absl::StatusOr<HloInstruction*> ExpandInstructionWithGemmConfigUsingBuilder(
+    XlaBuilder& builder, HloInstruction* old_instruction,
+    const xla::gpu::GemmBackendConfig& gemm_cfg) {
+  TF_ASSIGN_OR_RETURN(XlaComputation xla_computation, builder.Build());
+  TF_ASSIGN_OR_RETURN(
+      HloComputation * hlo_computation,
+      XlaComputationToHloComputation(xla_computation,
+                                     old_instruction->parent()->parent()));
+
+  // search for hipblaslt custom call and populate its backend_config
+  HloInstruction* target = nullptr;
+  for (HloInstruction* instr : hlo_computation->instructions()) {
+    if (instr->opcode() == HloOpcode::kCustomCall &&
+        instr->custom_call_target() == kCublasLtMatmulMXCallTarget) {
+      target = instr;
+      break;
+    }
+  }
+  if (target != nullptr) {
+    xla::gpu::GpuBackendConfig gpu_cfg;
+    *gpu_cfg.mutable_gemm_backend_config() = gemm_cfg;
+    TF_RETURN_IF_ERROR(target->set_backend_config(gpu_cfg));
+  }
+
+  // Fix broadcast layouts (they cannot be inferred correctly).
+  FixBroadcastLayouts(hlo_computation);
+
+  return old_instruction->parent()->AddInstruction(HloInstruction::CreateCall(
+      old_instruction->shape(), old_instruction->operands(), hlo_computation));
 }
 
 // Determine block size from the shapes.
@@ -248,7 +285,9 @@ absl::StatusOr<HloInstruction*> ExpandDequantizeCustomCall(
   return ExpandInstructionUsingBuilder(builder, instruction);
 }
 
-// ----- Block scaled dot (cuDNN)
+/*****************************************************************************************
+ *      CUDA Solution: __op$block_scaled_dot --> cudnn graph                             *
+ *****************************************************************************************/
 
 enum class CudnnMxType {
   // Not a supported composite type.
@@ -502,7 +541,7 @@ absl::StatusOr<XlaOp> BuildBlockScaledDotInput(
 }
 
 // Build HLO for scaled dot op.
-absl::StatusOr<XlaOp> BuildBlockScaledDot(
+absl::StatusOr<XlaOp> BuildBlockScaledDotForCuda(
     XlaBuilder& builder, const HloInstruction* lhs_input,
     const HloInstruction* rhs_input, const HloInstruction* lhs_scale,
     const HloInstruction* rhs_scale, const HloInstruction* global_scale,
@@ -557,7 +596,7 @@ absl::StatusOr<XlaOp> BuildBlockScaledDot(
 }
 
 // Convert scaled dot custom call to HLO computation.
-absl::StatusOr<HloInstruction*> ExpandBlockScaledDotCustomCall(
+absl::StatusOr<HloInstruction*> CudaExpandBlockScaledDotCustomCall(
     HloInstruction* instruction, se::dnn::VersionInfo cudnn_version) {
   PrimitiveType result_type = instruction->shape().element_type();
 
@@ -611,7 +650,7 @@ absl::StatusOr<HloInstruction*> ExpandBlockScaledDotCustomCall(
   auto operands = absl::MakeSpan(instruction->operands());
   TF_ASSIGN_OR_RETURN(
       XlaOp block_scaled_dot,
-      BuildBlockScaledDot(builder, operands[0], operands[1], operands[2],
+      BuildBlockScaledDotForCuda(builder, operands[0], operands[1], operands[2],
                           operands.size() >= 4 ? operands[3] : nullptr,
                           operands.size() == 5 ? operands[4] : nullptr, dnums,
                           result_type, block_size, std::move(cudnn_version)));
@@ -625,6 +664,191 @@ absl::StatusOr<HloInstruction*> ExpandBlockScaledDotCustomCall(
     Reshape(instruction->shape(), block_scaled_dot);
   }
   return ExpandInstructionUsingBuilder(builder, instruction);
+}
+
+/*****************************************************************************************
+ *      ROCm Solution: __op$block_scaled_dot --> hipblaslt matmul call                   *
+ *****************************************************************************************/
+bool IsSupportedByHipblaslt(const Shape& lhs_shape, const Shape& rhs_shape,
+                            const Shape& lhs_scale_shape,
+                            const Shape& rhs_scale_shape) {
+  auto IsSupported = [&](const Shape& input_shape,
+                         const Shape& scale_shape) -> bool {
+    // Check supported shapes
+    // TODO: remove this constraint when hipblaslt supports batch_size > 1
+    if (input_shape.dimensions().size() == 3 &&
+        input_shape.dimensions(0) != 1) {
+      return false;
+    }
+    // TODO: remove this constraint when hipblaslt supports other M, N, K values
+    if (input_shape.dimensions().size() == 2) {
+      if (input_shape.dimensions(0) % 16 != 0 ||
+          input_shape.dimensions(1) % 32 != 0) {
+        return false;
+      }
+    } else if (input_shape.dimensions().size() == 3) {
+      if (input_shape.dimensions(1) % 16 != 0 ||
+          input_shape.dimensions(2) % 32 != 0) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    int block_size = GetBlockSize(input_shape, scale_shape).value_or(0);
+    if (block_size != BlockScalingRewriter::kBlockSizeHipblaslt) {
+      return false;
+    }
+    // Check supported data types
+    if (input_shape.element_type() != PrimitiveType::F8E4M3FN &&
+        input_shape.element_type() != PrimitiveType::F8E5M2 &&
+        input_shape.element_type() != PrimitiveType::F4E2M1FN) {
+      return false;
+    }
+    if (scale_shape.element_type() != PrimitiveType::F8E8M0FNU) {
+      return false;
+    }
+    return true;
+  };
+
+  return IsSupported(lhs_shape, lhs_scale_shape) &&
+         IsSupported(rhs_shape, rhs_scale_shape);
+}
+
+// Build HLO for hipblaslt custom call op.
+absl::StatusOr<XlaOp> BuildHipblasltScaledDot(
+    XlaOp lhs_input, XlaOp rhs_input, XlaOp lhs_scale, XlaOp rhs_scale,
+    const PrimitiveType result_type,
+    const se::DeviceDescription& device_description) {
+  // Calculate output shape.
+  XlaBuilder& builder = *lhs_input.builder();
+  TF_ASSIGN_OR_RETURN(Shape lhs_shape, builder.GetShape(lhs_input));
+  TF_ASSIGN_OR_RETURN(Shape rhs_shape, builder.GetShape(rhs_input));
+  Shape result_shape;
+  if (lhs_shape.dimensions().size() == 2) {
+    result_shape = ShapeUtil::MakeShape(
+        result_type, {lhs_shape.dimensions(0), rhs_shape.dimensions(0)});
+  } else if (lhs_shape.dimensions().size() == 3) {
+    result_shape = ShapeUtil::MakeShape(
+        result_type, {lhs_shape.dimensions(0), lhs_shape.dimensions(1),
+                      rhs_shape.dimensions(1)});
+  } else {
+    return InvalidArgument("Unsupported input shape for hipblaslt scaled dot");
+  }
+  // Append workspace buffer to instruction outputs.
+  int64_t workspace = GemmConfig::kDefaultWorkspace;
+  auto* rocm_cc = device_description.gpu_compute_capability().rocm_compute_capability();
+  if (rocm_cc->gfx_version() == "gfx950") {
+    workspace = GemmConfig::kGFX950Workspace;
+  }
+  Shape workspace_shape = ShapeUtil::MakeShape(PrimitiveType::S8, {workspace});
+  Shape output_shape =
+      ShapeUtil::MakeTupleShape({result_shape, workspace_shape});
+
+  // Build custom call to hipblaslt.
+  std::string custom_call_target{kCublasLtMatmulMXCallTarget};
+  XlaOp custom_call =
+      CustomCall(&builder, custom_call_target,
+                 {lhs_input, rhs_input, lhs_scale, rhs_scale}, output_shape);
+  XlaOp result = GetTupleElement(custom_call, 0);
+
+  return result;
+}
+
+// Build HLO for scaled dot op for ROCm platform.
+absl::StatusOr<XlaOp> BuildBlockScaledDotForROCm(
+    XlaBuilder& builder, const HloInstruction* lhs_input,
+    const HloInstruction* rhs_input, const HloInstruction* lhs_scale,
+    const HloInstruction* rhs_scale, const DotDimensionNumbers& dnums,
+    const bool allow_hipblaslt, const PrimitiveType result_type,
+    const se::DeviceDescription& device_description) {
+  // Get dot LHS parameter(s).
+  XlaOp lhs_op = Parameter(&builder, 0, lhs_input->shape(), "lhs");
+  XlaOp lhs_scale_op = Parameter(&builder, 2, lhs_scale->shape(), "lhs_scale");
+
+  // Get dot RHS parameter(s).
+  XlaOp rhs_op = Parameter(&builder, 1, rhs_input->shape(), "rhs");
+  XlaOp rhs_scale_op;
+  if (rhs_scale != nullptr) {
+    rhs_scale_op = Parameter(&builder, 3, rhs_scale->shape(), "rhs_scale");
+  }
+
+  // Use hipblaslt kernel, if possible.
+  if (allow_hipblaslt && rhs_scale_op.valid() &&
+      IsSupportedByHipblaslt(lhs_input->shape(), rhs_input->shape(),
+                             lhs_scale->shape(), rhs_scale->shape())) {
+    return BuildHipblasltScaledDot(lhs_op, rhs_op, lhs_scale_op, rhs_scale_op,
+                                   result_type, device_description);
+  }
+
+  // Fallback solution: build general dot op.
+  TF_ASSIGN_OR_RETURN(lhs_op,
+                      BuildDequantize(lhs_op, lhs_scale_op, result_type));
+  TF_ASSIGN_OR_RETURN(Shape lhs_op_shape, builder.GetShape(lhs_op));
+  if (rhs_scale_op.valid()) {
+    TF_ASSIGN_OR_RETURN(rhs_op,
+                        BuildDequantize(rhs_op, rhs_scale_op, result_type));
+    TF_ASSIGN_OR_RETURN(Shape rhs_op_shape, builder.GetShape(rhs_op));
+  }
+  return DotGeneral(lhs_op, rhs_op, dnums, /*precision_config=*/nullptr,
+                    /*preferred_element_type=*/result_type);
+}
+
+// Convert scaled dot custom call to HLO computation for ROCm platform.
+absl::StatusOr<HloInstruction*> RocmExpandBlockScaledDotCustomCall(
+    HloInstruction* instruction, const bool allow_hipblaslt,
+    const se::DeviceDescription& device_description) {
+  PrimitiveType result_type = instruction->shape().element_type();
+
+  // Check operand count.
+  if (instruction->operand_count() != 3 && instruction->operand_count() != 4) {
+    return InvalidArgument(
+        "Incorrect number of operands for block scaled dot op");
+  }
+
+  // Check output shape.
+  const Shape& lhs_shape = instruction->operand(0)->shape();
+  const Shape& rhs_shape = instruction->operand(1)->shape();
+  DotDimensionNumbers dnums;
+  dnums.add_lhs_contracting_dimensions(lhs_shape.dimensions().size() - 1);
+  dnums.add_rhs_contracting_dimensions(rhs_shape.dimensions().size() - 1);
+  if (lhs_shape.dimensions().size() == 3) {
+    dnums.add_lhs_batch_dimensions(0);
+    dnums.add_rhs_batch_dimensions(0);
+  }
+  TF_ASSIGN_OR_RETURN(Shape inferred_shape,
+                      ShapeInference::InferDotOpShape(lhs_shape, rhs_shape,
+                                                      dnums, result_type));
+  if (inferred_shape != instruction->shape()) {
+    return InvalidArgument("Incorrect output shape for block scaled dot op");
+  }
+
+  // Build replacement instruction sequence.
+  XlaBuilder builder(std::string(instruction->name()));
+  auto operands = absl::MakeSpan(instruction->operands());
+  TF_ASSIGN_OR_RETURN(XlaOp block_scaled_dot,
+                      BuildBlockScaledDotForROCm(
+                          builder, operands[0], operands[1], operands[2],
+                          operands.size() == 4 ? operands[3] : nullptr, dnums,
+                          allow_hipblaslt, result_type, device_description));
+  TF_ASSIGN_OR_RETURN(Shape result_shape, builder.GetShape(block_scaled_dot));
+  CHECK_EQ(result_shape, instruction->shape());
+
+  // Build gemm_cfg
+  xla::gpu::GemmBackendConfig gemm_cfg;
+  gemm_cfg.set_alpha_real(1.0);
+  gemm_cfg.set_alpha_imag(0.0);
+  gemm_cfg.set_beta(0.0);
+  *gemm_cfg.mutable_dot_dimension_numbers() = dnums;
+  gemm_cfg.mutable_precision_config()->add_operand_precision(
+      PrecisionConfig::DEFAULT);
+  gemm_cfg.set_epilogue(xla::gpu::GemmBackendConfig::DEFAULT);
+  gemm_cfg.set_grad_x(true);
+  gemm_cfg.set_grad_y(true);
+  gemm_cfg.set_damax_output(false);
+  gemm_cfg.set_mx_mode(true);
+
+  return ExpandInstructionWithGemmConfigUsingBuilder(builder, instruction,
+                                                     gemm_cfg);
 }
 
 }  // namespace
@@ -646,7 +870,12 @@ absl::StatusOr<HloInstruction*> BlockScalingRewriter::ExpandInstruction(
     return ExpandDequantizeCustomCall(instruction);
   }
   if (instruction->custom_call_target() == kBlockScaledDotCustomCallTarget) {
-    return ExpandBlockScaledDotCustomCall(instruction, cudnn_version_);
+    if (device_description_.gpu_compute_capability().IsCuda()) {
+      return CudaExpandBlockScaledDotCustomCall(instruction, cudnn_version_);
+    } else if (device_description_.gpu_compute_capability().IsRocm()) {
+      return RocmExpandBlockScaledDotCustomCall(instruction, allow_hipblaslt_,
+                                                device_description_);
+    }
   }
   LOG(FATAL) << "Unexpected custom call target: "
              << instruction->custom_call_target();

--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -72,8 +72,12 @@ const se::dnn::VersionInfo kCudnnSupportsBlockScaledDotWithGlobalScale(9, 13);
 //    config if the block scaled dimension is padded.
 class BlockScalingRewriter : public OpExpanderPass {
  public:
-  explicit BlockScalingRewriter(se::dnn::VersionInfo cudnn_version)
-      : cudnn_version_(cudnn_version) {};
+  explicit BlockScalingRewriter(const se::DeviceDescription& device_description,
+                                const se::dnn::VersionInfo& cudnn_version,
+                                const bool allow_hipblaslt)
+      : device_description_(device_description),
+        cudnn_version_(cudnn_version),
+        allow_hipblaslt_(allow_hipblaslt) {};
 
   absl::string_view name() const override { return "block-scaling-rewriter"; }
 
@@ -90,12 +94,16 @@ class BlockScalingRewriter : public OpExpanderPass {
   static constexpr absl::string_view kBlockScaledDotCustomCallTarget =
       "__op$block_scaled_dot";
 
-  // Common block size constants.
+  // Common block size constants for CUDA
   static constexpr int kBlockSizeMXFP8 = 32;
   static constexpr int kBlockSizeNVFP4 = 16;
+  // Common block size constants for ROCm
+  static constexpr int kBlockSizeHipblaslt = 32;
 
  private:
-  se::dnn::VersionInfo cudnn_version_;
+  const se::DeviceDescription device_description_;
+  const se::dnn::VersionInfo cudnn_version_;
+  const bool allow_hipblaslt_;
 };
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_cudnn_test.cc
@@ -21,14 +21,17 @@ limitations under the License.
 #include "xla/error_spec.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/gpu/transforms/block_scaling_rewriter.h"
-#include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
-#include "xla/tests/hlo_pjrt_test_base.h"
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
 
 namespace xla::gpu {
 namespace {
 
-using BlockScalingRewriterCudnnTest =
-    HloPjRtInterpreterReferenceMixin<HloPjRtTestBase>;
+class BlockScalingRewriterCudnnTest : public GpuCodegenTest {
+ protected:
+  const auto& device_desc() const {
+    return backend().default_stream_executor()->GetDeviceDescription();
+  }
+};
 
 const se::dnn::VersionInfo kCudnnDisabled;
 const se::dnn::VersionInfo kCudnnVersion(CUDNN_VERSION / 10000,
@@ -52,20 +55,26 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(kCudnnDisabled);
+        BlockScalingRewriter pass(device_desc(), kCudnnDisabled,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(kCudnnVersion);
+        BlockScalingRewriter pass(device_desc(), kCudnnVersion,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnDisabled,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnVersion,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -86,20 +95,26 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(kCudnnDisabled);
+        BlockScalingRewriter pass(device_desc(), kCudnnDisabled,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(kCudnnVersion);
+        BlockScalingRewriter pass(device_desc(), kCudnnVersion,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnDisabled,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnVersion,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -124,20 +139,26 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(kCudnnDisabled);
+        BlockScalingRewriter pass(device_desc(), kCudnnDisabled,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(kCudnnVersion);
+        BlockScalingRewriter pass(device_desc(), kCudnnVersion,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnDisable,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnVersion,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -168,20 +189,26 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(kCudnnDisabled);
+        BlockScalingRewriter pass(device_desc(), kCudnnDisabled,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(kCudnnVersion);
+        BlockScalingRewriter pass(device_desc(), kCudnnVersion,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnDisabled,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnVersion,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK: __cudnn$blockScaledDot");
 }
 
@@ -209,20 +236,26 @@ ENTRY main {
       hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
       /*reference_preprocessor=*/
       [](HloModule* reference_module) {
-        BlockScalingRewriter pass(kCudnnDisabled);
+        BlockScalingRewriter pass(device_desc(), kCudnnDisabled,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, reference_module),
                     absl_testing::IsOkAndHolds(true));
       },
       /*test_preprocessor=*/
       [](HloModule* test_module) {
-        BlockScalingRewriter pass(kCudnnVersion);
+        BlockScalingRewriter pass(device_desc(), kCudnnVersion,
+                                  /*allow_hipblaslt*/ false);
         EXPECT_THAT(RunHloPass(&pass, test_module),
                     absl_testing::IsOkAndHolds(true));
       }));
 
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnDisabled),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnDisabled,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK-NOT: __cudnn$blockScaledDot");
-  RunAndFilecheckHloRewrite(hlo_string, BlockScalingRewriter(kCudnnVersion),
+  RunAndFilecheckHloRewrite(hlo_string,
+                            BlockScalingRewriter(device_desc(), kCudnnVersion,
+                                                 /*allow_hipblaslt*/ false),
                             "CHECK: __cudnn$blockScaledDot");
 }
 

--- a/xla/service/gpu/transforms/block_scaling_rewriter_hipblaslt_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_hipblaslt_test.cc
@@ -1,0 +1,243 @@
+/* Copyright 2025 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/strings/string_view.h"
+#include "xla/error_spec.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/gpu/transforms/block_scaling_rewriter.h"
+#include "xla/tsl/platform/status_matchers.h"
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::tsl::testing::IsOkAndHolds;
+
+class BlockScalingRewriterHipblasltTest : public GpuCodegenTest {
+ protected:
+  const auto& device_desc() const {
+    return backend().default_stream_executor()->GetDeviceDescription();
+  }
+
+  const auto& GpuCapability() const {
+    return device_desc().gpu_compute_capability();
+  }
+
+  bool IsRocm() const {
+    return GpuCapability().IsRocm();
+  }
+
+  void SetUp() override {
+    if (!IsRocm()) {
+      GTEST_SKIP();
+    }
+    auto* rocm_cc = GpuCapability().rocm_compute_capability();
+    if (rocm_cc->gfx_version() != "gfx950") {
+      GTEST_SKIP();
+    }
+  };
+};
+
+TEST_F(BlockScalingRewriterHipblasltTest, Mxfp8) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+ENTRY main {
+  %lhs = f8e4m3fn[32,256] parameter(0)
+  %rhs = f8e4m3fn[16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[16,8] parameter(3)
+  ROOT %result = f32[32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp8) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+ENTRY main {
+  %lhs = f8e4m3fn[1,32,256] parameter(0)
+  %rhs = f8e4m3fn[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp8_MixedTypes) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+ENTRY main {
+  %lhs = f8e4m3fn[1,32,256] parameter(0)
+  %rhs = f8e5m2[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp4) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+ENTRY main {
+  %lhs = f4e2m1fn[1,32,256] parameter(0)
+  %rhs = f4e2m1fn[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+TEST_F(BlockScalingRewriterHipblasltTest, BatchedMxfp4fp8) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule test
+ENTRY main {
+  %lhs = f4e2m1fn[1,32,256] parameter(0)
+  %rhs = f8e4m3fn[1,16,256] parameter(1)
+  %lhs_scale = f8e8m0fnu[1,32,8] parameter(2)
+  %rhs_scale = f8e8m0fnu[1,16,8] parameter(3)
+  ROOT %result = f32[1,32,16] custom-call(%lhs, %rhs, %lhs_scale, %rhs_scale),
+      custom_call_target="__op$block_scaled_dot"
+})";
+  EXPECT_TRUE(RunAndCompare(
+      hlo_string, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5),
+      /*reference_preprocessor=*/
+      [&](HloModule* reference_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/false);
+        EXPECT_THAT(RunHloPass(&pass, reference_module), IsOkAndHolds(true));
+      },
+      /*test_preprocessor=*/
+      [&](HloModule* test_module) {
+        BlockScalingRewriter pass(this->device_desc(), se::dnn::VersionInfo{},
+                                  /*allow_hipblaslt=*/true);
+        EXPECT_THAT(RunHloPass(&pass, test_module), IsOkAndHolds(true));
+      }));
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/false),
+      "CHECK-NOT: __cublas$lt$matmul$mx");
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      BlockScalingRewriter(this->device_desc(), se::dnn::VersionInfo{},
+                           /*allow_hipblaslt=*/true),
+      "CHECK: __cublas$lt$matmul$mx");
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
+++ b/xla/service/gpu/transforms/block_scaling_rewriter_test.cc
@@ -21,13 +21,26 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "xla/error_spec.h"
 #include "xla/hlo/parser/hlo_parser.h"
-#include "xla/tests/hlo_test_base.h"
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
 #include "xla/tsl/platform/statusor.h"
 
 namespace xla::gpu {
 namespace {
 
-using BlockScalingRewriterTest = HloTestBase;
+class BlockScalingRewriterTest : public GpuCodegenTest {
+ protected:
+  const auto& device_desc() const {
+    return backend().default_stream_executor()->GetDeviceDescription();
+  }
+
+  const auto& GpuCapability() const {
+    return device_desc().gpu_compute_capability();
+  }
+
+  bool IsCuda() const { return GpuCapability().IsCuda(); }
+
+  bool IsRocm() const { return GpuCapability().IsRocm(); }
+};
 
 TEST_F(BlockScalingRewriterTest, ExpandQuantizeCustomCall) {
   constexpr absl::string_view hlo_string = R"(
@@ -39,7 +52,7 @@ ENTRY main {
       custom_call_target="__op$quantize"
 })";
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[input:%.+]] = f32[10,256]{1,0} parameter(0)
   CHECK: [[blocks:%.+]] = f32[10,8,32]{2,1,0} reshape([[input]])
@@ -69,7 +82,7 @@ ENTRY main {
       custom_call_target="__op$dequantize"
 })";
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[input:%.+]] = f8e4m3fn[10,256]{1,0} parameter(0)
   CHECK: [[input_cvt:%.+]] = f32[10,256]{1,0} convert([[input]])
@@ -94,7 +107,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,1,0} convert([[lhs_quant]])
@@ -117,6 +130,9 @@ ENTRY main {
 }
 
 TEST_F(BlockScalingRewriterTest, ExpandBlockScaledDotGlobalScale) {
+  // ROCm currently doesn't support global scale
+  if (IsRocm()) { GTEST_SKIP(); }
+
   constexpr absl::string_view hlo_string = R"(
 HloModule test
 
@@ -130,7 +146,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,1,0} convert([[lhs_quant]])
@@ -168,7 +184,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,256]{2,0,1} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,256]{2,0,1} convert([[lhs_quant]])
@@ -202,7 +218,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[16,256]{1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f16[16,256]{1,0} convert([[lhs_quant]])
@@ -218,6 +234,9 @@ ENTRY main {
 }
 
 TEST_F(BlockScalingRewriterTest, ExpandBlockScaledDotExplicitBlockSize) {
+  // ROCm currently doesn't support padding
+  if (IsRocm()) { GTEST_SKIP(); }
+
   constexpr absl::string_view hlo_string = R"(
 HloModule test
 
@@ -231,7 +250,7 @@ ENTRY main {
       backend_config={"block_scaled_dot_backend_config":{block_size:32}}
 })";
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs_quant:%.+]] = f8e4m3fn[4,16,224]{2,1,0} parameter(0)
   CHECK: [[lhs_quant_cvt:%.+]] = f32[4,16,224]{2,1,0} convert([[lhs_quant]])
@@ -270,7 +289,7 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(auto test_module,
                           ParseAndReturnUnverifiedModule(hlo_test));
 
-  BlockScalingRewriter pass(se::dnn::VersionInfo{});
+  BlockScalingRewriter pass(device_desc(), se::dnn::VersionInfo{}, /*allow_hipblaslt*/ false);
   TF_ASSERT_OK_AND_ASSIGN(
       auto changed, pass.Run(test_module.get(), /*execution_threads=*/{}));
   EXPECT_TRUE(changed);
@@ -289,7 +308,13 @@ ENTRY main {
                                       /*run_hlo_passes=*/false));
 }
 
-TEST_F(BlockScalingRewriterTest, CudnnScaledDotSimple) {
+class BlockScalingRewriterCudnnTest : public BlockScalingRewriterTest {
+ protected:
+  void SetUp() override { if (!IsCuda()) { GTEST_SKIP(); } };
+};
+
+
+TEST_F(BlockScalingRewriterCudnnTest, CudnnScaledDotSimple) {
   constexpr absl::string_view hlo_string = R"(
 HloModule test
 
@@ -302,7 +327,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(kCudnnSupportsBlockScaledDot);
+  BlockScalingRewriter pass(device_desc(), kCudnnSupportsBlockScaledDot, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs:%.+]] = f8e4m3fn[4,128,128]{2,1,0} parameter(0)
   CHECK: [[rhs:%.+]] = f8e4m3fn[4,128,128]{2,1,0} parameter(1)
@@ -320,7 +345,7 @@ ENTRY main {
 })");
 }
 
-TEST_F(BlockScalingRewriterTest, CudnnScaledDotTransforms) {
+TEST_F(BlockScalingRewriterCudnnTest, CudnnScaledDotTransforms) {
   constexpr absl::string_view hlo_string = R"(
 HloModule test
 
@@ -333,7 +358,7 @@ ENTRY main {
       custom_call_target="__op$block_scaled_dot"
 })";
 
-  BlockScalingRewriter pass(kCudnnSupportsBlockScaledDot);
+  BlockScalingRewriter pass(device_desc(), kCudnnSupportsBlockScaledDot, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs:%.+]] = f8e4m3fn[128,96]{1,0} parameter(0)
   CHECK: [[lhs_rs:%.+]] = f8e4m3fn[1,128,96]{2,1,0} reshape([[lhs]])
@@ -359,7 +384,7 @@ ENTRY main {
 })");
 }
 
-TEST_F(BlockScalingRewriterTest, CudnnScaledDotPaddedScales) {
+TEST_F(BlockScalingRewriterCudnnTest, CudnnScaledDotPaddedScales) {
   constexpr absl::string_view hlo_string = R"(
 HloModule test
 
@@ -373,7 +398,7 @@ ENTRY main {
       backend_config={"block_scaled_dot_backend_config":{block_size:32}}
 })";
 
-  BlockScalingRewriter pass(kCudnnSupportsBlockScaledDot);
+  BlockScalingRewriter pass(device_desc(), kCudnnSupportsBlockScaledDot, /*allow_hipblaslt*/ false);
   RunAndFilecheckHloRewrite(hlo_string, std::move(pass), R"(
   CHECK: [[lhs:%.+]] = f8e4m3fn[4,120,96]{2,1,0} parameter(0)
   CHECK: [[lhs_pad:%.+]] = f8e4m3fn[4,128,96]{2,1,0} pad([[lhs]], {{.+}}), padding=0_0x0_8x0_0

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -334,6 +334,7 @@ absl::StatusOr<GemmConfig> GemmConfig::FromProto(
       proto.has_algorithm() ? std::optional(proto.algorithm()) : std::nullopt,
       proto.grad_x(),
       proto.grad_y(),
+      proto.mx_mode(),
       compute_type};
 }
 

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -129,6 +129,7 @@ struct GemmConfig {  // plain GemmConfig which is extended with create functions
   std::optional<int64_t> algorithm;
   bool grad_x;
   bool grad_y;
+  bool mx_mode;
   std::optional<blas::ComputationType> compute_type;
 
   static absl::StatusOr<GemmConfig> FromProto(

--- a/xla/stream_executor/gpu/gpu_blas_lt.proto
+++ b/xla/stream_executor/gpu/gpu_blas_lt.proto
@@ -49,7 +49,8 @@ message GemmConfigProto {
   optional int64 algorithm = 10;
   bool grad_x = 11;
   bool grad_y = 12;
-  xla.BlasComputationTypeProto compute_type = 13;
+  bool mx_mode = 13;
+  xla.BlasComputationTypeProto compute_type = 14;
 }
 
 enum BlasLtEpilogueProto {

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -185,13 +185,13 @@ absl::Status BlasLt::Init() {
 /*static*/ absl::StatusOr<BlasLt::MatmulDesc> BlasLt::MatmulDesc::Create(
     blas::ComputationType compute_type, blas::DataType scale_type,
     blas::Transpose trans_a, blas::Transpose trans_b, Epilogue epilogue,
-    PointerMode pointer_mode) {
+    PointerMode pointer_mode, bool mx_mode) {
   hipblasLtMatmulDesc_t hip_desc;
   VLOG(2) << "BlasLt::MatmulDesc::Create compute_type: " << int(compute_type)
           << " scale_type: " << int(scale_type)
           << " epilogue: " << int(epilogue) << " trans_a: " << int(trans_a)
           << " trans_b: " << int(trans_b) << " pointer_mode "
-          << int(pointer_mode);
+          << int(pointer_mode) << "mx_mode: " << mx_mode;
   auto hip_scale_type = AsHipblasDataType(scale_type);
   auto hip_compute_type = AsHipblasComputeType(compute_type);
   SE_HIPBLAS_RETURN_IF_ERROR(wrap::hipblasLtMatmulDescCreate(
@@ -201,7 +201,7 @@ absl::Status BlasLt::Init() {
       static_cast<int32_t>(epilogue) & static_cast<int32_t>(Epilogue::kBias);
   // Wrap hipblas handle immediately, so it is cleaned up if an error occurs.
   BlasLt::MatmulDesc desc(hip_desc, hip_compute_type, hip_scale_type,
-                          bias_flag != 0);
+                          bias_flag != 0, mx_mode);
   if (pointer_mode != PointerMode::kHost) {
     return absl::InternalError("hipblaslt does not support device pointers");
   }
@@ -257,7 +257,7 @@ auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
              layout.type() == HIP_R_8F_E4M3_FNUZ ||
              layout.type() == HIP_R_8F_E5M2 || layout.type() == HIP_R_8F_E4M3;
     };
-    if (IsFP8(a_desc_) && IsFP8(b_desc_)) {
+    if ((IsFP8(a_desc_) && IsFP8(b_desc_)) || op_desc_.mx_mode()) {
       static int64_t dummy_pointer = 0xACEBALL;
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
@@ -266,6 +266,17 @@ auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
                                  HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
                                  &dummy_pointer));
     }
+
+#if TF_ROCM_VERSION >= 70000
+    if (op_desc_.mx_mode()) {
+      hipblasLtMatmulMatrixScale_t MXScaleType =
+          HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
+      TF_RETURN_IF_ERROR(SetAttr(
+          op_desc_.get(), HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, MXScaleType));
+      TF_RETURN_IF_ERROR(SetAttr(
+          op_desc_.get(), HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, MXScaleType));
+    }
+#endif
 
     int found_algorithm_count = 0;
     auto error = wrap::hipblasLtMatmulAlgoGetHeuristic(
@@ -309,7 +320,7 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& cfg, Epilogue epilogue) const
   // this is only true if A and B are column-major. If A is row-major, A must
   // *not* be transposed, and if B is row-major, B must be transposed. We never
   // transpose A or B, and expect the caller to ensure A is row-major and B is
-  // column when A and B are FP8.
+  // column-major when A and B are FP8.
   auto trans_a = lhs_layout.transpose, trans_b = rhs_layout.transpose;
 
   if (xla::primitive_util::IsF8Type(lhs_layout.dtype) &&
@@ -343,9 +354,20 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& cfg, Epilogue epilogue) const
 
   TF_ASSIGN_OR_RETURN(
       auto op_desc,
-      MatmulDesc::Create(*compute_type,
-                         gpu::GetScaleType(output_dtype, *compute_type),
-                         trans_a, trans_b, epilogue));
+      MatmulDesc::Create(
+          *compute_type, gpu::GetScaleType(output_dtype, *compute_type),
+          trans_a, trans_b, epilogue, PointerMode::kHost, cfg.mx_mode));
+
+#if TF_ROCM_VERSION >= 70000
+  if (op_desc.mx_mode()) {
+    hipblasLtMatmulMatrixScale_t MXScaleType =
+        HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
+    TF_RETURN_IF_ERROR(SetAttr(
+        op_desc.get(), HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, MXScaleType));
+    TF_RETURN_IF_ERROR(SetAttr(
+        op_desc.get(), HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, MXScaleType));
+  }
+#endif
 
   TF_ASSIGN_OR_RETURN(auto a_desc, MatrixLayout::Create(lhs_layout));
   TF_ASSIGN_OR_RETURN(auto b_desc, MatrixLayout::Create(rhs_layout));
@@ -390,9 +412,15 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     return absl::InternalError(
         "Algorithm must be set before calling DoMatMul!");
   }
-  DeviceMemoryBase a = args.a, b = args.b;
+  DeviceMemoryBase a = args.a;
+  DeviceMemoryBase b = args.b;
+  DeviceMemoryBase a_scale = args.a_scale;
+  DeviceMemoryBase b_scale = args.b_scale;
   if (must_swap_operands_) {
     std::swap(a, b);
+    if (a_scale != nullptr && b_scale != nullptr) {
+      std::swap(a_scale, b_scale);
+    }
   }
 
   auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
@@ -437,15 +465,15 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     }
 
 #if TF_ROCM_VERSION >= 60000
-    if (args.a_scale != nullptr) {
+    if (a_scale != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
-                                 args.a_scale.opaque()));
+                                 a_scale.opaque()));
     }
-    if (args.b_scale != nullptr) {
+    if (b_scale != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                  HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
-                                 args.b_scale.opaque()));
+                                 b_scale.opaque()));
     }
     if (args.c_scale != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
@@ -458,8 +486,8 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
                                  args.d_scale.opaque()));
     }
 #else
-    if (!(args.a_scale == nullptr && args.b_scale == nullptr &&
-          args.c_scale == nullptr && args.d_scale == nullptr)) {
+    if (!(a_scale == nullptr && b_scale == nullptr && args.c_scale == nullptr &&
+          args.d_scale == nullptr)) {
       return absl::InternalError("hipblaslt does not support scale");
     }
 #endif
@@ -588,6 +616,58 @@ absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_8F_E5M2)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_16F)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_32F)
+#endif
+
+#if TF_ROCM_VERSION >= 70000
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_4F_E2M1_EXT, HIP_R_8F_E5M2, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16F)
+
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_32F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16F, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1_EXT, HIP_R_16BF, HIP_R_16F)
 #endif
 
   // Other data types:

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -61,7 +61,7 @@ class BlasLt : public gpu::BlasLt {
         blas::Transpose trans_a = blas::Transpose::kNoTranspose,
         blas::Transpose trans_b = blas::Transpose::kNoTranspose,
         Epilogue epilogue = Epilogue::kDefault,
-        PointerMode pointer_mode = PointerMode::kHost);
+        PointerMode pointer_mode = PointerMode::kHost, bool mx_mode = false);
 
     hipblasComputeType_t compute_type() const { return compute_type_; }
     hipDataType scale_type() const { return datatype_; }
@@ -69,20 +69,23 @@ class BlasLt : public gpu::BlasLt {
     hipblasPointerMode_t pointer_mode() const {
       return HIPBLAS_POINTER_MODE_HOST;
     }
+    bool mx_mode() const { return mx_mode_; }
     hipblasLtMatmulDesc_t get() const { return handle_.get(); }
 
    private:
     MatmulDesc(hipblasLtMatmulDesc_t handle, hipblasComputeType_t compute_type,
-               hipDataType datatype, bool bias_epilogue)
+               hipDataType datatype, bool bias_epilogue, bool mx_mode)
         : handle_(handle, wrap::hipblasLtMatmulDescDestroy),
           compute_type_(compute_type),
           datatype_(datatype),
-          has_bias_epilogue_(bias_epilogue) {}
+          has_bias_epilogue_(bias_epilogue),
+          mx_mode_(mx_mode) {}
 
     Owned<hipblasLtMatmulDesc_t> handle_;
     hipblasComputeType_t compute_type_;
     hipDataType datatype_;
     bool has_bias_epilogue_;
+    bool mx_mode_;
   };
 
   struct MatmulPlan : public gpu::BlasLt::MatmulPlan {

--- a/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -37,10 +37,8 @@ hipDataType AsHipblasDataType(blas::DataType type) {
   switch (type) {
     case blas::DataType::kF8E4M3:
     case blas::DataType::kF8E3M4:
-    case blas::DataType::kF4E2M1FN:
     case blas::DataType::kF8E8M0FNU:
-      LOG(FATAL) << "hipblaslt does not support, F8E4M3, F8E3M4, F4E2M1FN and "
-                    "F8E8M0FNU";
+      LOG(FATAL) << "hipblaslt does not support F8E4M3, F8E3M4, and F8E8M0FNU";
 #if TF_ROCM_VERSION >= 60000
     case blas::DataType::kF8E5M2FNUZ:
       return HIP_R_8F_E5M2_FNUZ;
@@ -49,7 +47,7 @@ hipDataType AsHipblasDataType(blas::DataType type) {
 #else
     case blas::DataType::kF8E5M2FNUZ:
     case blas::DataType::kF8E4M3FNUZ:
-      LOG(FATAL) << "hipblaslt only supports nanoo F8 in ROCm 6.0 and above";
+      LOG(FATAL) << "hipblaslt only supports NANOO F8 in ROCm 6.0 and above";
 #endif
 #if TF_ROCM_VERSION >= 60300
     case blas::DataType::kF8E5M2:
@@ -60,6 +58,13 @@ hipDataType AsHipblasDataType(blas::DataType type) {
     case blas::DataType::kF8E5M2:
     case blas::DataType::kF8E4M3FN:
       LOG(FATAL) << "hipblaslt only supports OCP F8 in ROCm 6.3 and above";
+#endif
+#if TF_ROCM_VERSION >= 70000
+    case blas::DataType::kF4E2M1FN:
+      return static_cast<hipDataType>(HIP_R_4F_E2M1_EXT);
+#else
+    case blas::DataType::kF4E2M1FN:
+      LOG(FATAL) << "hipblaslt only supports FP4 in ROCm 7.0 and above";
 #endif
     case blas::DataType::kHalf:
       return HIP_R_16F;

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -194,6 +194,8 @@ class RocmComputeCapability {
 
   bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
 
+  bool has_hipblaslt_mx_support() const { return gfx9_mi350(); }
+
   /// \brief Invalid gfx id for default gcn_arch_name_ value and testing
   static constexpr absl::string_view kInvalidGfx = "gfx000";
 


### PR DESCRIPTION
In this PR, we support MX datatypes for the ROCm platform. While the CUDA path uses **cuDNN**,  ROCm implements MX datatypes through **hipBLASLt**.

### Key updates
* **BlockScalingRewriter**  
  * Rewrites `__op$block_scaled_dot` into an HLO graph that invokes the hipBLASLt custom call `__cublaslt$matmul$mx`.

* **CublasLtMatmulThunk**  
  * Extends the existing lowering stage so the new custom call is finally dispatched to a hipBLASLt kernel.

Note:
* `GemmAlgorithmPicker` isn't enabled for MX datatypes. We will support it in a separate PR.

### Reference

- https://arxiv.org/pdf/2310.10537
- https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
- https://github.com/openxla/xla/pull/21800
- https://github.com/openxla/xla/pull/22256