### PR TITLE
Fix comments for xla/hlo/ir/hlo_input_output_alias_config.h

### DIFF
--- a/xla/hlo/ir/hlo_input_output_alias_config.h
+++ b/xla/hlo/ir/hlo_input_output_alias_config.h
@@ -41,8 +41,8 @@ class HloModule;
 // parameter index in the entry computation.
 class HloInputOutputAliasConfig {
  public:
-  // The kind of aliases which can be set. A kMayAlias is one setup at
-  // compilation time by the user, and has to be respected. A kMustAlias one
+  // The kind of aliases which can be set. A kMustAlias is one setup at
+  // compilation time by the user, and has to be respected. A kMayAlias one
   // might be setup by the compiler, if it decides it is convenient to do so.
   enum AliasKind {
     kMayAlias,


### PR DESCRIPTION
📝 Summary of Changes
I am reading the code of XLA buffer alias, I think the comments for xla::HloInputOutputAliasConfig::AliasKind has the typo. 

🚀 Kind of Contribution
📚 Documentation
