### PR TITLE
[GPU] Fix layout assignment of bitcast-converts.

### DIFF
--- a/xla/service/gpu/transforms/layout_assignment.cc
+++ b/xla/service/gpu/transforms/layout_assignment.cc
@@ -562,18 +562,36 @@ absl::Status GpuLayoutAssignment::AddBackendConstraints(
     } else if (HloPredicateIsOp<HloOpcode::kBitcastConvert>(instruction)) {
       Shape operand_shape = instruction->operand(0)->shape();
       Shape output_shape = instruction->shape();
-      // Make the added or removed dimension the minor most to give the
-      // operation a chance to become a no-op (bitcast).
+
+      // Sets the layouts of the operand and output shapes to make the bitcast a
+      // no-op. The changed dimension is moved to be the most minor one in the
+      // layout of the larger shape, and the layout of the smaller shape is
+      // derived from the larger one.
+      auto assign_layouts = [](Shape* larger_shape, Shape* smaller_shape) {
+        const int changed_dim = larger_shape->dimensions().size() - 1;
+        *larger_shape->mutable_layout() =
+            LayoutUtil::MoveDimToMinor(larger_shape->layout(), changed_dim);
+        *smaller_shape->mutable_layout() =
+            ShapeUtil::DeleteDimension(changed_dim, *larger_shape).layout();
+      };
+
+      bool ranks_differ = true;
       if (operand_shape.dimensions().size() >
           output_shape.dimensions().size()) {
-        *operand_shape.mutable_layout() = LayoutUtil::MoveDimToMinor(
-            operand_shape.layout(), operand_shape.dimensions().size() - 1);
-        TF_RETURN_IF_ERROR(SetOperandLayout(operand_shape, instruction, 0));
+        assign_layouts(&operand_shape, &output_shape);
       } else if (operand_shape.dimensions().size() <
                  output_shape.dimensions().size()) {
-        *output_shape.mutable_layout() = LayoutUtil::MoveDimToMinor(
-            output_shape.layout(), output_shape.dimensions().size() - 1);
-        TF_RETURN_IF_ERROR(SetInstructionLayout(output_shape, instruction));
+        assign_layouts(&output_shape, &operand_shape);
+      } else {
+        ranks_differ = false;
+      }
+
+      if (ranks_differ) {
+        TF_RETURN_IF_ERROR(SetOperandLayout(operand_shape, instruction,
+                                            /*operand_no=*/0,
+                                            /*mandatory=*/true));
+        TF_RETURN_IF_ERROR(SetInstructionLayout(output_shape, instruction,
+                                                /*mandatory=*/true));
       }
     } else if (HloPredicateIsOp<HloOpcode::kTriangularSolve>(instruction)) {
       // TODO(phawkins): Ideally we would relax this constraint. What we


### PR DESCRIPTION
📝 Summary of Changes
"mandatory" compatible layouts have to be assigned to both operands and outputs simultaneously such that subsequent layout propagation does not alter one of them making the operation invalid.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
yes

🧪 Execution Tests:
no