### PR TITLE
[XLA:GPU] Fix cublas fallback test on Thor GPU (sm_110)

### DIFF
--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner_test.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner_test.cc
@@ -330,6 +330,7 @@ TEST_F(StatelessAutotunerTest, CublasFallbackForBf16Bf16F32Algorithm) {
                "Hopper";
         break;
       case se::CudaComputeCapability::kBlackwell:
+      case se::CudaComputeCapability::kBlackwell_11:
       case se::CudaComputeCapability::kBlackwell_12:
         EXPECT_TRUE(hasCublasConfig(configs))
             << "There should be a cublas fallback for dot_bf16_bf16_f32 on "

--- a/xla/stream_executor/cuda/cuda_compute_capability.h
+++ b/xla/stream_executor/cuda/cuda_compute_capability.h
@@ -70,6 +70,7 @@ struct CudaComputeCapability {
     kAmpere = 8,
     kHopper = 9,
     kBlackwell = 10,
+    kBlackwell_11 = 11,
     kBlackwell_12 = 12
   };
 


### PR DESCRIPTION
This fixes the failing test StatelessAutotunerTest.CublasFallbackForBf16Bf16F32Algorithm on Jetson Thor GPUs with compute capability 11.0.