### PR TITLE
[pjrt] Add cuda_version attribute to GPU plugin

### DIFF
--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -427,7 +427,10 @@ cc_library(
     name = "pjrt_c_api_gpu_internal",
     srcs = ["pjrt_c_api_gpu_internal.cc"],
     hdrs = ["pjrt_c_api_gpu_internal.h"],
-    local_defines = if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
+    local_defines = (
+        if_cuda_is_configured(["GOOGLE_CUDA=1"]) +
+        if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"])
+    ),
     visibility = ["//visibility:public"],
     deps = [
         ":pjrt_c_api_custom_partitioner_extension_hdrs",
@@ -472,7 +475,9 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:str_format",
-    ],
+    ]+ if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ]),
 )
 
 cc_library(


### PR DESCRIPTION
📝 Summary of Changes
Adds a C API plugin attribute `cuda_version` that's set to the cuda runtime version the plugin was compiled against. The verison may be queried from JAX, e.g.,
```bash
$ python3 -c "import jax.extend; print(jax.extend.backend.get_backend().cuda_version)"
13000
```

🎯 Justification
This allows CUDA-version-specific packages to detect the CUDA version present in JAX. See also https://github.com/jax-ml/jax/issues/32729

🚀 Kind of Contribution
New Feature

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
None

🧪 Execution Tests:
None

cc @skye 