### PR TITLE
Add helper functions to host_offload_utils

### DIFF
--- a/xla/service/host_offload_utils.h
+++ b/xla/service/host_offload_utils.h
@@ -107,6 +107,10 @@ bool ComputeTypeIsHost(const HloInstruction* hlo_instruction);
 // instruction should be lowered as host compute.
 void SetHostComputeFrontendAttribute(HloInstruction& host_instruction);
 
+bool IsMoveToHostWithDynamicUpdateSlice(const HloInstruction* instr);
+
+bool IsMoveToDeviceWithDynamicSlice(const HloInstruction* instr);
+
 }  // namespace host_offload_utils
 }  // namespace xla
 

--- a/xla/service/host_offload_utils_test.cc
+++ b/xla/service/host_offload_utils_test.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/shape_util.h"
 #include "xla/util.h"
-#include "tsl/platform/statusor.h"
+#include "xla/tsl/platform/statusor.h"
 
 namespace xla {
 namespace host_offload_utils {

--- a/xla/service/host_offload_utils_test.cc
+++ b/xla/service/host_offload_utils_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/strings/string_view.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/shape_util.h"
 #include "xla/util.h"


### PR DESCRIPTION
📝 Summary of Changes
This PR adds two new utility functions to `host_offload_utils` for detecting dynamic slice operations in host offload patterns. New Functions:
- IsMoveToHostWithDynamicUpdateSlice - Detects if a MoveToHost operation feeds into a DynamicUpdateSlice
- IsMoveToDeviceWithDynamicSlice - Detects if a MoveToDevice operation consumes from a DynamicSlice

🎯 Justification
These helper functions are necessary for identifying host offloading patterns that involve dynamic slicing operations (child-PR of https://github.com/openxla/xla/pull/32297/)

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
Added.

🧪 Execution Tests:
N/A
