### PR TITLE
[XLA:GPU][oneAPI] SYCL stream and tests

### DIFF
--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -125,6 +125,55 @@ xla_cc_test(
     ],
 )
 
+sycl_library(
+    name = "sycl_stream",
+    srcs = ["sycl_stream.cc"],
+    hdrs = ["sycl_stream.h"],
+    tags = [
+        "gpu",
+        "oneapi-only",
+    ],
+    deps = [
+        ":sycl_context",
+        ":sycl_event",
+        "//xla/backends/gpu/runtime:kernel_thunk",
+        "//xla/service/gpu:gpu_executable",
+        "//xla/stream_executor:device_memory",
+        "//xla/stream_executor:event",
+        "//xla/stream_executor:event_based_timer",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_common",
+        "//xla/tsl/platform:logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+xla_test(
+    name = "sycl_stream_test",
+    srcs = ["sycl_stream_test.cc"],
+    backends = ["gpu"],
+    tags = [
+        "gpu",
+        "oneapi-only",
+    ],
+    deps = [
+        ":sycl_event",
+        ":sycl_platform_id",
+        ":sycl_stream",
+        "//xla/stream_executor:device_memory",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:typed_kernel_factory",
+        "//xla/tests:llvm_irgen_test_base",
+        "//xla/tsl/platform:status_matchers",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "sycl_solver_context",
     srcs = ["sycl_solver_context.cc"],

--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -136,8 +136,6 @@ sycl_library(
     deps = [
         ":sycl_context",
         ":sycl_event",
-        "//xla/backends/gpu/runtime:kernel_thunk",
-        "//xla/service/gpu:gpu_executable",
         "//xla/stream_executor:device_memory",
         "//xla/stream_executor:event",
         "//xla/stream_executor:event_based_timer",
@@ -161,6 +159,8 @@ xla_test(
         ":sycl_event",
         ":sycl_platform_id",
         ":sycl_stream",
+        "//xla/backends/gpu/runtime:kernel_thunk",
+        "//xla/service/gpu:gpu_executable",
         "//xla/stream_executor:device_memory",
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:typed_kernel_factory",

--- a/xla/stream_executor/sycl/sycl_stream.cc
+++ b/xla/stream_executor/sycl/sycl_stream.cc
@@ -1,0 +1,353 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/sycl/sycl_stream.h"
+
+#include "xla/backends/gpu/runtime/kernel_thunk.h"
+#include "xla/tsl/platform/logging.h"
+
+namespace stream_executor::sycl {
+
+namespace {
+
+absl::Status LaunchSyclKernel(
+    StreamExecutor* executor, absl::string_view kernel_name,
+    ::sycl::kernel* function, unsigned int thread_dim_x,
+    unsigned int thread_dim_y, unsigned int thread_dim_z,
+    unsigned int block_dim_x, unsigned int block_dim_y,
+    unsigned int block_dim_z, unsigned int shared_mem_bytes,
+    ::sycl::queue* stream_handle, void** kernel_params, void** extra) {
+  VLOG(2) << "Launching kernel '" << kernel_name << "' using ThreadDim{"
+          << thread_dim_x << ", " << thread_dim_y << ", " << thread_dim_z
+          << "}, BlockDim{" << block_dim_x << ", " << block_dim_y << ", "
+          << block_dim_z << "}; function: " << (const void*)function;
+
+  if (function == nullptr) {
+    return absl::InvalidArgumentError(
+        "LaunchSyclKernel: No kernel function provided.");
+  }
+
+  if (stream_handle == nullptr) {
+    return absl::InvalidArgumentError(
+        "LaunchSyclKernel: No stream handle provided.");
+  }
+
+  ::sycl::range<3> global_range(block_dim_z * thread_dim_z,
+                                block_dim_y * thread_dim_y,
+                                block_dim_x * thread_dim_x);
+  ::sycl::range<3> local_range(thread_dim_z, thread_dim_y, thread_dim_x);
+  ::sycl::nd_range<3> nd_range(global_range, local_range);
+
+  stream_handle->submit([&](::sycl::handler& cgh) {
+    if (kernel_params == nullptr) {
+      VLOG(2) << "LaunchSyclKernel: No kernel parameters provided; launching "
+                 "kernel.";
+      cgh.parallel_for(nd_range, *function);
+      return;
+    }
+
+    // kernel_params is expected to be an array of two pointers:
+    // kernel_params[0]: pointer to array of kernel argument pointers
+    // kernel_params[1]: pointer to number of kernel arguments
+    if (kernel_params[0] == nullptr || kernel_params[1] == nullptr) {
+      LOG(ERROR)
+          << "LaunchSyclKernel: kernel_params[0] or kernel_params[1] is null, "
+             "cannot set kernel arguments.";
+      return;
+    }
+
+    void** arg_ptrs = static_cast<void**>(kernel_params[0]);
+    size_t* num_args_ptr = static_cast<size_t*>(kernel_params[1]);
+    size_t num_args = num_args_ptr ? *num_args_ptr : 0;
+
+    for (size_t arg_index = 0; arg_index < num_args; ++arg_index) {
+      if (arg_ptrs[arg_index] == nullptr) {
+        LOG(ERROR) << "LaunchSyclKernel: kernel argument " << arg_index
+                   << " is null, cannot set kernel argument.";
+        return;
+      }
+      VLOG(2) << "Setting kernel argument " << arg_index
+              << " at address: " << arg_ptrs[arg_index];
+      cgh.set_arg(arg_index, arg_ptrs[arg_index]);
+    }
+
+    if (num_args == 0) {
+      VLOG(2)
+          << "LaunchSyclKernel: No kernel arguments to set; launching kernel.";
+    }
+    cgh.parallel_for(nd_range, *function);
+  });
+  return absl::OkStatus();
+}
+
+absl::Status LaunchSyclKernel(
+    StreamExecutor* executor, absl::string_view kernel_name,
+    ::sycl::kernel* function, unsigned int cluster_dim_x,
+    unsigned int cluster_dim_y, unsigned int cluster_dim_z,
+    unsigned int thread_dim_x, unsigned int thread_dim_y,
+    unsigned int thread_dim_z, unsigned int block_dim_x,
+    unsigned int block_dim_y, unsigned int block_dim_z,
+    unsigned int shared_mem_bytes, ::sycl::queue* stream_handle,
+    void** kernel_params, void** extra) {
+  if (cluster_dim_x != 1 || cluster_dim_y != 1 || cluster_dim_z != 1)
+    return absl::UnimplementedError(
+        "LaunchSyclKernel: Non-default cluster dimensions are not supported.");
+  return LaunchSyclKernel(executor, kernel_name, function, thread_dim_x,
+                          thread_dim_y, thread_dim_z, block_dim_x, block_dim_y,
+                          block_dim_z, shared_mem_bytes, stream_handle,
+                          kernel_params, extra);
+}
+
+}  // namespace
+
+absl::Status SyclStream::WaitFor(Stream* other) {
+  SyclStream* other_stream = static_cast<SyclStream*>(other);
+  TF_RETURN_IF_ERROR(other_stream->RecordCompletedEvent());
+  return SyclEvent::WaitStreamOnEvent(
+      executor_, stream_handle_.get(),
+      other_stream->completed_event_.GetEvent());
+}
+
+absl::Status SyclStream::RecordEvent(Event* event) {
+  ::sycl::event sycl_event = static_cast<SyclEvent*>(event)->GetEvent();
+  TF_ASSIGN_OR_RETURN(std::optional<::sycl::event> recent_event,
+                      SyclGetRecentEventFromStream(stream_handle_.get()));
+  if (!recent_event.has_value()) {
+    // TODO(intel-tf): Record sycl_event via SyclEvent's SetEvent() if no
+    // recent event is found.
+    return absl::InternalError(
+        "RecordEvent: No event returned from SyclGetRecentEventFromStream");
+  }
+  // Update the event to the most recent one on the stream.
+  sycl_event = recent_event.value();
+  VLOG(2) << "Recording SYCL event on stream " << stream_handle_.get();
+  return absl::OkStatus();
+}
+
+absl::Status SyclStream::WaitFor(Event* event) {
+  return SyclEvent::WaitStreamOnEvent(
+      executor_, stream_handle_.get(),
+      static_cast<SyclEvent*>(event)->GetEvent());
+}
+
+absl::Status SyclStream::Memset32(DeviceMemoryBase* location, uint32_t pattern,
+                                  uint64_t size) {
+  VLOG(2) << "Enqueuing memset32 operation onto stream " << stream_handle_.get()
+          << " at location " << reinterpret_cast<const void*>(location)
+          << " with size " << size << " and pattern 0x" << std::hex << pattern
+          << std::dec;
+  if (absl::bit_cast<uintptr_t>(location->opaque()) % alignof(uint32_t) != 0) {
+    return absl::InvalidArgumentError("Location must be 4 byte aligned");
+  }
+  if (size % sizeof(uint32_t) != 0) {
+    return absl::InvalidArgumentError("Size must be a multiple of 4 bytes.");
+  }
+  TF_RETURN_IF_ERROR(SyclMemfillDeviceAsync(
+      stream_handle_.get(), const_cast<void*>(location->opaque()), pattern,
+      size / sizeof(uint32_t)));
+  VLOG(2) << "Successfully enqueued async memset32 of "
+          << size / sizeof(uint32_t) << " uint32s at " << location
+          << " with value 0x" << std::hex << pattern << std::dec
+          << " on stream " << stream_handle_;
+  return absl::OkStatus();
+}
+
+absl::Status SyclStream::MemZero(DeviceMemoryBase* location, uint64_t size) {
+  if (absl::bit_cast<uintptr_t>(location->opaque()) % alignof(uint32_t) == 0 &&
+      size % sizeof(uint32_t) == 0) {
+    return SyclStream::Memset32(location, 0x0, size);
+  }
+  TF_RETURN_IF_ERROR(SyclMemsetDeviceAsync(
+      stream_handle_.get(), const_cast<void*>(location->opaque()), 0x0, size));
+  VLOG(2) << "Successfully enqueued async memset8 of " << size << " bytes at "
+          << location << " with value 0x0 on stream " << stream_handle_;
+  return absl::OkStatus();
+}
+
+absl::Status SyclStream::Memcpy(DeviceMemoryBase* gpu_dst, const void* host_src,
+                                uint64_t size) {
+  TF_RETURN_IF_ERROR(SyclMemcpyHostToDeviceAsync(
+      stream_handle_.get(), const_cast<void*>(gpu_dst->opaque()), host_src,
+      size));
+  VLOG(2) << "Successfully enqueued async memcpy H2D of " << size << " bytes"
+          << " from " << host_src << " to " << gpu_dst << " on stream "
+          << stream_handle_;
+  return absl::OkStatus();
+}
+
+absl::Status SyclStream::Memcpy(void* host_dst, const DeviceMemoryBase& gpu_src,
+                                uint64_t size) {
+  TF_RETURN_IF_ERROR(
+      SyclMemcpyDeviceToHostAsync(stream_handle_.get(), host_dst,
+                                  const_cast<void*>(gpu_src.opaque()), size));
+  VLOG(2) << "Successfully enqueued async memcpy D2H of " << size << " bytes"
+          << " from " << gpu_src.opaque() << " to " << host_dst << " on stream "
+          << stream_handle_;
+  return absl::OkStatus();
+}
+
+absl::Status SyclStream::Memcpy(DeviceMemoryBase* gpu_dst,
+                                const DeviceMemoryBase& gpu_src,
+                                uint64_t size) {
+  TF_RETURN_IF_ERROR(SyclMemcpyDeviceToDeviceAsync(
+      stream_handle_.get(), const_cast<void*>(gpu_dst->opaque()),
+      const_cast<void*>(gpu_src.opaque()), size));
+  VLOG(2) << "Successfully enqueued async memcpy D2D of " << size << " bytes"
+          << " from " << gpu_src.opaque() << " to " << gpu_dst << " on stream "
+          << stream_handle_;
+  return absl::OkStatus();
+}
+
+absl::Status SyclStream::DoHostCallbackWithStatus(
+    absl::AnyInvocable<absl::Status() &&> callback) {
+  // Heap-allocate and wrap the callback to ensure its lifetime for async
+  // execution.
+  auto callback_ptr =
+      new absl::AnyInvocable<void() &&>([cb = std::move(callback)]() mutable {
+        absl::Status status = std::move(cb)();
+        if (!status.ok()) {
+          LOG(WARNING) << "Host callback failed: " << status;
+        }
+      });
+  // Cast to void* to simplify lambda capture for SYCL host task.
+  auto callback_ptr_void = reinterpret_cast<void*>(callback_ptr);
+
+  // Lambda invokes and deletes the callback.
+  auto callback_function = std::function<void()>([callback_ptr_void]() {
+    auto* callback_ptr =
+        reinterpret_cast<absl::AnyInvocable<void() &&>*>(callback_ptr_void);
+    std::move (*callback_ptr)();
+    delete callback_ptr;
+  });
+
+  // Enqueue the host callback for asynchronous execution.
+  stream_handle_->submit([&](::sycl::handler& cgh) {
+    cgh.host_task(std::move(callback_function));
+  });
+
+  // Callback successfully enqueued. Since it is executed asynchronously,
+  // return OK status even if the callback itself may fail.
+  return absl::OkStatus();
+}
+
+absl::Status SyclStream::BlockHostUntilDone() {
+  stream_handle_->wait();
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<SyclStream>> SyclStream::Create(
+    StreamExecutor* executor, bool enable_multiple_streams,
+    std::optional<std::variant<StreamPriority, int>> priority) {
+  // Determine stream priority.
+  int stream_priority = 0;
+  if (priority.has_value()) {
+    if (std::holds_alternative<int>(priority.value())) {
+      stream_priority = std::get<int>(priority.value());
+    } else if (std::get<StreamPriority>(priority.value()) ==
+               StreamPriority::Default) {
+      stream_priority = 0;
+    } else {
+      return absl::UnimplementedError(
+          "SyclStream::Create: SYCL does not support non-default (non-zero) "
+          "stream priority.");
+    }
+  }
+
+  VLOG(0) << "Creating stream for device ordinal " << executor->device_ordinal()
+          << (enable_multiple_streams ? " with" : " without")
+          << " multiple streams enabled";
+
+  TF_ASSIGN_OR_RETURN(StreamPtr stream_handle,
+                      SyclStreamPool::GetOrCreateStream(
+                          executor->device_ordinal(), enable_multiple_streams));
+
+  TF_ASSIGN_OR_RETURN(SyclEvent completed_event, SyclEvent::Create(executor));
+
+  return std::unique_ptr<SyclStream>(new SyclStream(
+      executor, std::move(completed_event), priority, stream_handle));
+}
+
+SyclStream::~SyclStream() {
+  // Wait for all pending operations to complete before destroying the stream.
+  BlockHostUntilDone().IgnoreError();
+
+  // Remove this stream from the executor's list of allocated streams.
+  executor_->DeallocateStream(this);
+
+  // Destroy the underlying SYCL stream.
+  absl::Status destroy_status = SyclStreamPool::DestroyStream(
+      executor_->device_ordinal(), stream_handle_);
+  if (!destroy_status.ok()) {
+    LOG(ERROR) << "Failed to destroy stream " << stream_handle_.get()
+               << " for device " << executor_->device_ordinal() << ", got "
+               << destroy_status;
+  } else {
+    VLOG(2) << "Successfully destroyed stream " << stream_handle_.get()
+            << " for device " << executor_->device_ordinal();
+    stream_handle_ = nullptr;
+  }
+}
+
+std::string SyclStream::GetKernelNameFromGpuExecutable(
+    GpuExecutable* gpu_exec) {
+  if (gpu_exec == nullptr) {
+    LOG(WARNING)
+        << "GetKernelNameFromGpuExecutable: GpuExecutable pointer is null. "
+        << "Returning empty string.";
+    return "";
+  }
+  const xla::gpu::SequentialThunk& seq_thunk = gpu_exec->GetThunk();
+  std::string kernel_name = "";
+  // Extract the kernel name from the first KernelThunk in the sequence.
+  for (const auto& thunk_ptr : seq_thunk.thunks()) {
+    const xla::gpu::Thunk* thunk = thunk_ptr.get();
+    if (thunk->kind() == xla::gpu::Thunk::Kind::kKernel) {
+      const auto* kernel_thunk =
+          dynamic_cast<const xla::gpu::KernelThunk*>(thunk);
+      if (kernel_thunk != nullptr) {
+        kernel_name = kernel_thunk->kernel_name();
+        break;
+      }
+    }
+  }
+  if (kernel_name.empty()) {
+    LOG(WARNING) << "GetKernelNameFromGpuExecutable: No kernel name found in "
+                 << "GpuExecutable. Returning empty string.";
+  }
+  return kernel_name;
+}
+
+absl::Status SyclStream::RecordCompletedEvent() {
+  return RecordEvent(&completed_event_);
+}
+
+absl::Status SyclStream::LaunchKernel(
+    const ThreadDim& thread_dims, const BlockDim& block_dims,
+    const std::optional<ClusterDim>& cluster_dims, void* function,
+    absl::string_view name, void** args, int64_t shmem_bytes) {
+  if (cluster_dims.has_value()) {
+    return LaunchSyclKernel(
+        executor_, name, static_cast<::sycl::kernel*>(function),
+        cluster_dims->x, cluster_dims->y, cluster_dims->z, thread_dims.x,
+        thread_dims.y, thread_dims.z, block_dims.x, block_dims.y, block_dims.z,
+        shmem_bytes, stream_handle_.get(), args, /*extra=*/nullptr);
+  }
+  return LaunchSyclKernel(
+      executor_, name, static_cast<::sycl::kernel*>(function), thread_dims.x,
+      thread_dims.y, thread_dims.z, block_dims.x, block_dims.y, block_dims.z,
+      shmem_bytes, stream_handle_.get(), args, /*extra=*/nullptr);
+}
+
+}  // namespace stream_executor::sycl

--- a/xla/stream_executor/sycl/sycl_stream.cc
+++ b/xla/stream_executor/sycl/sycl_stream.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/sycl/sycl_stream.h"
 
-#include "xla/backends/gpu/runtime/kernel_thunk.h"
 #include "xla/tsl/platform/logging.h"
 
 namespace stream_executor::sycl {
@@ -298,35 +297,6 @@ SyclStream::~SyclStream() {
             << " for device " << executor_->device_ordinal();
     stream_handle_ = nullptr;
   }
-}
-
-std::string SyclStream::GetKernelNameFromGpuExecutable(
-    GpuExecutable* gpu_exec) {
-  if (gpu_exec == nullptr) {
-    LOG(WARNING)
-        << "GetKernelNameFromGpuExecutable: GpuExecutable pointer is null. "
-        << "Returning empty string.";
-    return "";
-  }
-  const xla::gpu::SequentialThunk& seq_thunk = gpu_exec->GetThunk();
-  std::string kernel_name = "";
-  // Extract the kernel name from the first KernelThunk in the sequence.
-  for (const auto& thunk_ptr : seq_thunk.thunks()) {
-    const xla::gpu::Thunk* thunk = thunk_ptr.get();
-    if (thunk->kind() == xla::gpu::Thunk::Kind::kKernel) {
-      const auto* kernel_thunk =
-          dynamic_cast<const xla::gpu::KernelThunk*>(thunk);
-      if (kernel_thunk != nullptr) {
-        kernel_name = kernel_thunk->kernel_name();
-        break;
-      }
-    }
-  }
-  if (kernel_name.empty()) {
-    LOG(WARNING) << "GetKernelNameFromGpuExecutable: No kernel name found in "
-                 << "GpuExecutable. Returning empty string.";
-  }
-  return kernel_name;
 }
 
 absl::Status SyclStream::RecordCompletedEvent() {

--- a/xla/stream_executor/sycl/sycl_stream.h
+++ b/xla/stream_executor/sycl/sycl_stream.h
@@ -1,0 +1,143 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_SYCL_SYCL_STREAM_H_
+#define XLA_STREAM_EXECUTOR_SYCL_SYCL_STREAM_H_
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/service/gpu/gpu_executable.h"
+#include "xla/stream_executor/device_memory.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/event_based_timer.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_common.h"
+#include "xla/stream_executor/sycl/sycl_context.h"
+#include "xla/stream_executor/sycl/sycl_event.h"
+
+namespace stream_executor::sycl {
+
+using GpuExecutable = xla::gpu::GpuExecutable;
+
+class SyclStream : public StreamCommon {
+ public:
+  // Makes the current stream wait until all operations enqueued in the other
+  // stream up to its most recently recorded event have completed.
+  absl::Status WaitFor(Stream* other) override;
+
+  // Records the most recent event on the current stream into the given Event
+  // object. This typically marks the point up to which work has been enqueued
+  // on the stream. This allows other streams or operations to synchronize with
+  // this point in the stream's execution.
+  absl::Status RecordEvent(Event* event) override;
+
+  // Blocks execution on the current stream until the given event is completed.
+  absl::Status WaitFor(Event* event) override;
+
+  // Enqueues an asynchronous operation to set the specified device memory
+  // region to the given value.
+  absl::Status Memset32(DeviceMemoryBase* location, uint32_t pattern,
+                        uint64_t size) override;
+
+  // Enqueues an asynchronous operation to zero out the specified device memory
+  // region.
+  absl::Status MemZero(DeviceMemoryBase* location, uint64_t size) override;
+
+  // Enqueues an asynchronous copy from host memory to device memory.
+  absl::Status Memcpy(DeviceMemoryBase* gpu_dst, const void* host_src,
+                      uint64_t size) override;
+
+  // Enqueues an asynchronous copy from device memory to host memory.
+  absl::Status Memcpy(void* host_dst, const DeviceMemoryBase& gpu_src,
+                      uint64_t size) override;
+
+  // Enqueues an asynchronous copy from one device memory region to another.
+  absl::Status Memcpy(DeviceMemoryBase* gpu_dst,
+                      const DeviceMemoryBase& gpu_src, uint64_t size) override;
+
+  // Enqueues a host callback to be executed after all previously enqueued
+  // operations on the current stream have completed.
+  absl::Status DoHostCallbackWithStatus(
+      absl::AnyInvocable<absl::Status() &&> callback) override;
+
+  // Blocks the host until all previously enqueued operations on the current
+  // stream have completed.
+  absl::Status BlockHostUntilDone() override;
+
+  // Returns a platform-specific handle for the underlying SYCL stream.
+  Stream::PlatformSpecificHandle platform_specific_handle() const override {
+    return {stream_handle_.get()};
+  }
+
+  // Creates an event-based timer for measuring elapsed time on the current
+  // stream.
+  absl::StatusOr<std::unique_ptr<EventBasedTimer>> CreateEventBasedTimer(
+      bool use_delay_kernel) override {
+    return executor_->CreateEventBasedTimer(this, use_delay_kernel);
+  }
+
+  // Creates a new SyclStream instance for the specified executor.
+  // Supports optional stream priority and multiple streams per device.
+  static absl::StatusOr<std::unique_ptr<SyclStream>> Create(
+      StreamExecutor* executor, bool enable_multiple_streams,
+      std::optional<std::variant<StreamPriority, int>> priority);
+
+  // Destructor: waits for all pending operations on the stream to complete,
+  // deallocates the stream from the executor, and destroys the underlying SYCL
+  // stream.
+  ~SyclStream() override;
+
+  ::sycl::queue* stream_handle() const { return stream_handle_.get(); }
+
+  static std::string GetKernelNameFromGpuExecutable(GpuExecutable* gpu_exec);
+
+ private:
+  SyclStream(StreamExecutor* executor, SyclEvent completed_event,
+             std::optional<std::variant<StreamPriority, int>> priority,
+             StreamPtr stream_handle)
+      : StreamCommon(executor, priority),
+        executor_(executor),
+        completed_event_(std::move(completed_event)),
+        stream_handle_(std::move(stream_handle)) {}
+
+  // Updates 'completed_event_' to the most recent event available on the
+  // current stream. This allows other streams or events to synchronize with
+  // this point.
+  // NOTE: This does *not* record a new event; it only copies the most recent
+  // event. Actual event recording will be implemented in the future.
+  absl::Status RecordCompletedEvent();
+
+  // Launches a SYCL kernel on the current stream with the specified thread,
+  // block, and optional cluster dimensions, kernel function, name, arguments,
+  // and shared memory size.
+  absl::Status LaunchKernel(const ThreadDim& thread_dims,
+                            const BlockDim& block_dims,
+                            const std::optional<ClusterDim>& cluster_dims,
+                            void* function, absl::string_view name, void** args,
+                            int64_t shmem_bytes) override;
+
+  // The Executor to which this stream is bound.
+  StreamExecutor* executor_;
+
+  // The most recent event recorded on this stream, representing the completion
+  // of all operations enqueued up to that point.
+  SyclEvent completed_event_;
+
+  // The underlying SYCL stream (queue).
+  StreamPtr stream_handle_;
+};
+
+}  // namespace stream_executor::sycl
+#endif  // XLA_STREAM_EXECUTOR_SYCL_SYCL_STREAM_H_

--- a/xla/stream_executor/sycl/sycl_stream.h
+++ b/xla/stream_executor/sycl/sycl_stream.h
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "xla/service/gpu/gpu_executable.h"
 #include "xla/stream_executor/device_memory.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/event_based_timer.h"
@@ -28,8 +27,6 @@ limitations under the License.
 #include "xla/stream_executor/sycl/sycl_event.h"
 
 namespace stream_executor::sycl {
-
-using GpuExecutable = xla::gpu::GpuExecutable;
 
 class SyclStream : public StreamCommon {
  public:
@@ -100,8 +97,6 @@ class SyclStream : public StreamCommon {
   ~SyclStream() override;
 
   ::sycl::queue* stream_handle() const { return stream_handle_.get(); }
-
-  static std::string GetKernelNameFromGpuExecutable(GpuExecutable* gpu_exec);
 
  private:
   SyclStream(StreamExecutor* executor, SyclEvent completed_event,

--- a/xla/stream_executor/sycl/sycl_stream_test.cc
+++ b/xla/stream_executor/sycl/sycl_stream_test.cc
@@ -1,0 +1,427 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/sycl/sycl_stream.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_memory.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/sycl/sycl_event.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+#include "xla/stream_executor/typed_kernel_factory.h"
+#include "xla/tests/llvm_irgen_test_base.h"
+#include "xla/tsl/platform/status_matchers.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace stream_executor::sycl {
+namespace {
+
+constexpr int kDefaultDeviceOrdinal = 0;
+
+using ::testing::Each;
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::HasSubstr;
+using ::testing::UnorderedElementsAreArray;
+
+class SyclStreamTest : public xla::LlvmIrGenTestBase {
+ public:
+  // TODO(intel-tf): Use SyclExecutor once it is implemented.
+  StreamExecutor* executor_;
+
+  // Parses the given HLO IR and compiles it into an Executable.
+  absl::StatusOr<std::unique_ptr<xla::Executable>> CompileHloToExecutable(
+      absl::string_view hlo_ir) {
+    xla::HloModuleConfig config;
+    config.set_debug_options(GetDebugOptionsForTest());
+    TF_ASSIGN_OR_RETURN(std::unique_ptr<xla::HloModule> hlo_module,
+                        xla::ParseAndReturnUnverifiedModule(hlo_ir, config));
+
+    TF_ASSIGN_OR_RETURN(std::unique_ptr<xla::Executable> exec,
+                        CompileToExecutable(std::move(hlo_module),
+                                            /*run_optimization_passes=*/true));
+    return exec;
+  }
+
+ private:
+  void SetUp() override {
+    TF_ASSERT_OK_AND_ASSIGN(
+        Platform * platform,
+        stream_executor::PlatformManager::PlatformWithId(kSyclPlatformId));
+    TF_ASSERT_OK_AND_ASSIGN(executor_,
+                            platform->ExecutorForDevice(kDefaultDeviceOrdinal));
+  }
+};
+
+TEST_F(SyclStreamTest, CreateWithNonDefaultPriority) {
+  // SYCL doesn't support stream priorities yet, so we expect creation to fail
+  // if a non-default priority is requested.
+  EXPECT_THAT(SyclStream::Create(executor_,
+                                 /*enable_multiple_streams=*/false,
+                                 /*priority=*/StreamPriority::Highest),
+              absl_testing::StatusIs(absl::StatusCode::kUnimplemented));
+}
+
+TEST_F(SyclStreamTest, Memset32) {
+  constexpr int kBufferNumElements = 42;
+  DeviceMemory<uint32_t> device_buffer =
+      executor_->AllocateArray<uint32_t>(kBufferNumElements, 0);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  constexpr uint64_t kBufferSizeBytes = kBufferNumElements * sizeof(uint32_t);
+
+  // Should fail due to the invalid size parameter.
+  EXPECT_THAT(
+      stream->Memset32(&device_buffer, 0xDEADBEEF, kBufferSizeBytes + 1),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+
+  // Should fail due to the non-4-byte-aligned pointer.
+  DeviceMemoryBase unaligned_device_memory =
+      device_buffer.GetByteSlice(/*offset_bytes=*/1, /*size_bytes=*/0);
+  EXPECT_THAT(stream->Memset32(&unaligned_device_memory, 0xDEADBEEF,
+                               kBufferSizeBytes + 1),
+              absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+
+  // Correct call. Should succeed.
+  EXPECT_THAT(stream->Memset32(&device_buffer, 0xDEADBEEF, kBufferSizeBytes),
+              absl_testing::IsOk());
+
+  std::array<uint32_t, kBufferNumElements> host_buffer;
+  EXPECT_THAT(
+      stream->Memcpy(host_buffer.data(), device_buffer, kBufferSizeBytes),
+      absl_testing::IsOk());
+
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_THAT(host_buffer, Each(0xDEADBEEF));
+}
+
+TEST_F(SyclStreamTest, MemZero) {
+  constexpr int kBufferNumElements = 42;
+  DeviceMemory<uint32_t> device_buffer =
+      executor_->AllocateArray<uint32_t>(kBufferNumElements, 0);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  constexpr uint64_t kBufferSizeBytes = kBufferNumElements * sizeof(uint32_t);
+
+  EXPECT_THAT(stream->Memset32(&device_buffer, 0xDEADBEEF, kBufferSizeBytes),
+              absl_testing::IsOk());
+
+  // We overwrite half the device_buffer with zeros.
+  EXPECT_THAT(stream->MemZero(&device_buffer,
+                              kBufferNumElements / 2 * sizeof(uint32_t)),
+              absl_testing::IsOk());
+
+  std::array<uint32_t, kBufferNumElements> host_buffer;
+  EXPECT_THAT(
+      stream->Memcpy(host_buffer.data(), device_buffer, kBufferSizeBytes),
+      absl_testing::IsOk());
+
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  // We expect the first half of the host_buffer to be zeros.
+  EXPECT_THAT(
+      absl::MakeConstSpan(host_buffer).subspan(0, kBufferNumElements / 2),
+      Each(0x0));
+
+  // And it shouldn't have touched the second half.
+  EXPECT_THAT(absl::MakeConstSpan(host_buffer).subspan(kBufferNumElements / 2),
+              Each(0xDEADBEEF));
+}
+
+TEST_F(SyclStreamTest, MemcpyHostToDeviceAndBack) {
+  constexpr int kBufferNumElements = 42;
+  DeviceMemory<uint32_t> device_buffer =
+      executor_->AllocateArray<uint32_t>(kBufferNumElements, 0);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  constexpr uint64_t kBufferSizeBytes = kBufferNumElements * sizeof(uint32_t);
+
+  std::array<uint32_t, kBufferNumElements> src_buffer;
+  std::generate(src_buffer.begin(), src_buffer.end(),
+                [i = 0]() mutable { return i++; });
+
+  EXPECT_THAT(
+      stream->Memcpy(&device_buffer, src_buffer.data(), kBufferSizeBytes),
+      absl_testing::IsOk());
+
+  std::array<uint32_t, kBufferNumElements> host_buffer;
+  EXPECT_THAT(
+      stream->Memcpy(host_buffer.data(), device_buffer, kBufferSizeBytes),
+      absl_testing::IsOk());
+
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_THAT(host_buffer, ElementsAreArray(src_buffer));
+}
+
+TEST_F(SyclStreamTest, MemcpyDeviceToDevice) {
+  constexpr int kBufferNumElements = 42;
+  DeviceMemory<uint32_t> device_buffer1 =
+      executor_->AllocateArray<uint32_t>(kBufferNumElements, 0);
+  DeviceMemory<uint32_t> device_buffer2 =
+      executor_->AllocateArray<uint32_t>(kBufferNumElements, 0);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  constexpr uint64_t kBufferSizeBytes = kBufferNumElements * sizeof(uint32_t);
+
+  EXPECT_THAT(stream->Memset32(&device_buffer1, 0xDEADBEEF, kBufferSizeBytes),
+              absl_testing::IsOk());
+
+  EXPECT_THAT(stream->Memcpy(&device_buffer2, device_buffer1, kBufferSizeBytes),
+              absl_testing::IsOk());
+
+  std::array<uint32_t, kBufferNumElements> host_buffer;
+  EXPECT_THAT(
+      stream->Memcpy(host_buffer.data(), device_buffer2, kBufferSizeBytes),
+      absl_testing::IsOk());
+
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_THAT(host_buffer, Each(0xDEADBEEF));
+}
+
+TEST_F(SyclStreamTest, DoHostCallbackAndBlockHostUntilDone) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  bool callback_called = false;
+  EXPECT_THAT(
+      stream->DoHostCallback([&callback_called]() { callback_called = true; }),
+      absl_testing::IsOk());
+
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_TRUE(callback_called);
+}
+
+TEST_F(SyclStreamTest, KernelName_NonEmpty) {
+  // Multiply is lowered to a custom kernel, so a kernel name is expected.
+  absl::string_view hlo_ir = R"(
+    ENTRY e {
+      p0 = u32[4] parameter(0)
+      p1 = u32[4] parameter(1)
+      ROOT res = u32[4] multiply(p0, p1)
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::Executable> exec,
+                          CompileHloToExecutable(hlo_ir));
+  auto* gpu_exec = static_cast<GpuExecutable*>(exec.get());
+  ASSERT_NE(gpu_exec, nullptr);
+
+  std::string kernel_name =
+      SyclStream::GetKernelNameFromGpuExecutable(gpu_exec);
+  ASSERT_EQ(kernel_name, "wrapped_multiply");
+}
+
+TEST_F(SyclStreamTest, KernelName_Empty) {
+  // Copy is lowered into a memcpy operation, which does not generate a kernel.
+  absl::string_view hlo_ir = R"(
+    ENTRY e {
+      p0 = u32[4] parameter(0)
+      ROOT res = u32[4] copy(p0)
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::Executable> exec,
+                          CompileHloToExecutable(hlo_ir));
+  auto* gpu_exec = static_cast<GpuExecutable*>(exec.get());
+  ASSERT_NE(gpu_exec, nullptr);
+
+  std::string kernel_name =
+      SyclStream::GetKernelNameFromGpuExecutable(gpu_exec);
+  ASSERT_EQ(kernel_name, "");
+}
+
+TEST_F(SyclStreamTest, LaunchKernel) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  using AddKernel =
+      TypedKernelFactory<DeviceMemory<int32_t>, DeviceMemory<int32_t>,
+                         DeviceMemory<int32_t>>;
+
+  // Add is lowered to a custom kernel, so a kernel name is expected.
+  absl::string_view hlo_ir = R"(
+    ENTRY e {
+      p0 = u32[4] parameter(0)
+      p1 = u32[4] parameter(1)
+      ROOT res = u32[4] add(p0, p1)
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::Executable> exec,
+                          CompileHloToExecutable(hlo_ir));
+  auto* gpu_exec = static_cast<GpuExecutable*>(exec.get());
+  ASSERT_NE(gpu_exec, nullptr);
+
+  std::string kernel_name =
+      SyclStream::GetKernelNameFromGpuExecutable(gpu_exec);
+  ASSERT_EQ(kernel_name, "wrapped_add");
+
+  std::vector<uint8_t> spirv_binary(gpu_exec->binary());
+
+  KernelLoaderSpec spec = KernelLoaderSpec::CreateCudaCubinInMemorySpec(
+      spirv_binary, kernel_name, 3);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto add, AddKernel::Create(executor_, spec));
+
+  constexpr int64_t kLength = 4;
+  constexpr int64_t kByteLength = sizeof(int32_t) * kLength;
+
+  // Prepare arguments: a=3, b=2, c=0
+  DeviceMemory<int32_t> a = executor_->AllocateArray<int32_t>(kLength, 0);
+  DeviceMemory<int32_t> b = executor_->AllocateArray<int32_t>(kLength, 0);
+  DeviceMemory<int32_t> c = executor_->AllocateArray<int32_t>(kLength, 0);
+
+  EXPECT_THAT(stream->Memset32(&a, 3, kByteLength), absl_testing::IsOk());
+  EXPECT_THAT(stream->Memset32(&b, 2, kByteLength), absl_testing::IsOk());
+  EXPECT_THAT(stream->MemZero(&c, kByteLength), absl_testing::IsOk());
+  EXPECT_THAT(add.Launch(ThreadDim(kLength), BlockDim(), stream.get(), a, b, c),
+              absl_testing::IsOk());
+
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  std::array<int32_t, kLength> host_buffer;
+  EXPECT_THAT(stream->Memcpy(host_buffer.data(), c, kByteLength),
+              absl_testing::IsOk());
+  EXPECT_THAT(host_buffer, Each(5));
+}
+
+TEST_F(SyclStreamTest, SetName) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  constexpr absl::string_view kStreamName = "Test stream";
+  stream->SetName(std::string(kStreamName));
+  EXPECT_EQ(stream->GetName(), kStreamName);
+}
+
+TEST_F(SyclStreamTest, WaitForEvent) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  TF_ASSERT_OK_AND_ASSIGN(SyclEvent event, SyclEvent::Create(executor_));
+
+  EXPECT_THAT(stream->WaitFor(&event), absl_testing::IsOk());
+
+  bool callback_called = false;
+  EXPECT_THAT(
+      stream->DoHostCallback([&callback_called]() { callback_called = true; }),
+      absl_testing::IsOk());
+
+  EXPECT_THAT(stream->RecordEvent(&event), absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_TRUE(callback_called);
+}
+
+// SYCL does not guarantee any specific ordering of host callbacks
+// across different streams, even when using event or stream waits.
+// Therefore, the WaitForOtherStream test (which tests WaitFor(Stream* other))
+// is omitted for SYCL.
+
+TEST_F(SyclStreamTest, MultipleStreams) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream1,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/true,
+                                             /*priority=*/std::nullopt));
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream2,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/true,
+                                             /*priority=*/std::nullopt));
+
+  std::vector<int> host_buffer;
+  EXPECT_THAT(
+      stream1->DoHostCallback([&host_buffer]() { host_buffer.push_back(1); }),
+      absl_testing::IsOk());
+  EXPECT_THAT(
+      stream2->DoHostCallback([&host_buffer]() { host_buffer.push_back(2); }),
+      absl_testing::IsOk());
+
+  EXPECT_THAT(stream1->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_THAT(stream2->BlockHostUntilDone(), absl_testing::IsOk());
+
+  std::vector<int> expected = {1, 2};
+
+  // Callbacks may run concurrently or in any order since the streams are
+  // independent.
+  EXPECT_THAT(host_buffer, UnorderedElementsAreArray(expected));
+}
+
+TEST_F(SyclStreamTest, DoHostCallbackWithStatus) {
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclStream> stream,
+                          SyclStream::Create(executor_,
+                                             /*enable_multiple_streams=*/false,
+                                             /*priority=*/std::nullopt));
+
+  bool callback_called = false;
+  EXPECT_THAT(stream->DoHostCallbackWithStatus([&callback_called]() {
+    callback_called = true;
+    return absl::OkStatus();
+  }),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_TRUE(callback_called);
+
+  // Use std::promise for thread-safe communication of callback status.
+  std::promise<absl::Status> callback_promise;
+  EXPECT_THAT(stream->DoHostCallbackWithStatus([&callback_promise]() {
+    absl::Status error_status = absl::InternalError("Callback error");
+    callback_promise.set_value(error_status);
+    return error_status;
+  }),
+              absl_testing::IsOk());
+
+  // Wait for the callback to finish and get the status.
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  absl::Status callback_status = callback_promise.get_future().get();
+  EXPECT_THAT(callback_status,
+              absl_testing::StatusIs(absl::StatusCode::kInternal));
+  EXPECT_EQ(callback_status.message(), "Callback error");
+}
+
+}  // namespace
+}  // namespace stream_executor::sycl

--- a/xla/stream_executor/sycl/sycl_timer_test.cc
+++ b/xla/stream_executor/sycl/sycl_timer_test.cc
@@ -203,7 +203,7 @@ class SyclTimerTest : public ::testing::Test {
     ASSERT_THAT(stream->Memset32(&a, 1.0, kByteLength), IsOk());
     ASSERT_THAT(stream->Memset32(&b, 2.0, kByteLength), IsOk());
     ASSERT_THAT(stream->Memset32(&c, 0.0, kByteLength), IsOk());
-    ASSERT_THAT(add.Launch(ThreadDim(), BlockDim(kLength), stream, a, b, c),
+    ASSERT_THAT(add.Launch(ThreadDim(kLength), BlockDim(), stream, a, b, c),
                 IsOk());
   }
 


### PR DESCRIPTION
Co-author: @kanvi-nervana.

This PR implements SYCL stream and adds corresponding tests. The tests will be updated to use `SyclExecutor` once it is implemented.
