### PR TITLE
[ROCm] Consider runfiles in lit tests

### DIFF
--- a/xla/BUILD
+++ b/xla/BUILD
@@ -19,6 +19,11 @@ package(
     licenses = ["notice"],
 )
 
+
+exports_files([
+    "sh_test_with_runfiles.py",
+])
+
 exports_files([
     "lit.cfg.py",
 ] + if_google(["lit_google_cfg.py"]))

--- a/xla/lit.bzl
+++ b/xla/lit.bzl
@@ -298,7 +298,7 @@ def lit_test(
     See https://llvm.org/docs/CommandGuide/lit.html for details on lit
     """
     args = args or []
-    data = data or []
+    data = (data or []) + ["//xla:sh_test_with_runfiles.py"]
     tools = tools or []
     env = env or {}
 

--- a/xla/lit.cfg.py
+++ b/xla/lit.cfg.py
@@ -19,6 +19,8 @@ import tempfile
 
 import lit.formats
 
+from xla.sh_test_with_runfiles import ShTestWithRunfiles
+
 # copybara:uncomment_begin(google-only)
 # from xla.lit_google_cfg import ENV_FLAGS as google_env_flags
 # copybara:uncomment_end
@@ -35,7 +37,6 @@ config.name = "XLA"
 config.suffixes = [".cc", ".hlo", ".json", ".mlir", ".pbtxt", ".py", ".ll"]
 
 config.test_format = lit.formats.ShTest(execute_external=True)
-
 
 for env in [
     # Passthrough XLA_FLAGS.
@@ -75,3 +76,6 @@ if lit_config.params.get("PTX") == "GCN":
 config.substitutions.extend(
     ("%%{%s}" % key, val) for key, val in lit_config.params.items()
 )
+
+# Replace the default test format with our wrapped version
+config.test_format = ShTestWithRunfiles(execute_external=True)

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -1,0 +1,44 @@
+# Copyright 2025 The OpenXLA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lit runner configuration."""
+
+import os
+import sys
+import tempfile
+import pathlib
+
+import lit.formats
+
+# Used to symlink bazels runfiles subdirs into the lit tmp test dir
+class ShTestWithRunfiles(lit.formats.ShTest):
+    def execute(self, test, lit_config):
+        runfiles_dir = pathlib.Path(os.environ.get("RUNFILES_DIR")) / "xla"
+        if not runfiles_dir.is_dir():
+            return super().execute(test, lit_config)
+
+        dst = pathlib.Path(test.getExecPath()).parent
+        dst.mkdir(parents=True, exist_ok=True)
+        runfiles = []
+        for item in runfiles_dir.iterdir():
+            target = dst / item.name
+            try:
+                target.symlink_to(item, target_is_directory=item.is_dir())
+                runfiles.append(target)
+            except FileExistsError:
+                pass
+
+        result = super().execute(test, lit_config)
+        for target in runfiles:
+            target.unlink()
+        return result;

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -20,10 +20,16 @@ import pathlib
 
 import lit.formats
 
-# Used to symlink bazels runfiles subdirs into the lit tmp test dir
+
 class ShTestWithRunfiles(lit.formats.ShTest):
+    """Used to symlink bazels runfiles subdirs into the lit tmp test dir"""
+
     def execute(self, test, lit_config):
-        runfiles_dir = pathlib.Path(os.environ.get("RUNFILES_DIR")) / "xla"
+        runfiles = os.environ.get("RUNFILES_DIR")
+        if not runfiles:
+            return super().execute(test, lit_config)
+
+        runfiles_dir = pathlib.Path(runfiles) / "xla"
         if not runfiles_dir.is_dir():
             return super().execute(test, lit_config)
 


### PR DESCRIPTION
📝 Summary of Changes
Fixing lit tests in rocm config

🎯 Justification
rocm provides its libs in the runfiles directory hence
when running the lit test they are missing and gpu_test_correctness fails
with an error that one of the rocm libs is not found. This PR ensures
that runfiles are provided under the lit test execution directory so the libs are there.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
lit tests on CI

🧪 Execution Tests:
lit tests on CI
