### PR TITLE
[ROCm] Add missing dependencies to header file 

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -94,6 +94,7 @@ cc_library(
     deps = [
         ":rocm_headers_includes",
         ":rocm_rpath",
+        ":rocm_config",
     ],
 )
 

--- a/xla/pjrt/gpu/tfrt/BUILD
+++ b/xla/pjrt/gpu/tfrt/BUILD
@@ -153,7 +153,6 @@ cc_library(
         "@local_config_cuda//cuda:cuda_headers",
     ]) + if_rocm([
         # keep sorted
-        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -1084,6 +1084,7 @@ xla_test(
         "@tsl//tsl/platform:test_benchmark",
     ] + if_rocm_is_configured([
         # keep sorted
+        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
@@ -1141,6 +1142,7 @@ xla_test(
         "@tsl//tsl/platform:test_benchmark",
     ] + if_rocm_is_configured([
         # keep sorted
+        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
@@ -1197,6 +1199,7 @@ xla_test(
         "@tsl//tsl/platform:ml_dtypes",
     ] + if_rocm_is_configured([
         # keep sorted
+        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
@@ -1368,6 +1371,7 @@ xla_test(
         "@tsl//tsl/platform:test_benchmark",
     ] + if_rocm_is_configured([
         # keep sorted
+        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -1084,7 +1084,6 @@ xla_test(
         "@tsl//tsl/platform:test_benchmark",
     ] + if_rocm_is_configured([
         # keep sorted
-        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
@@ -1142,7 +1141,6 @@ xla_test(
         "@tsl//tsl/platform:test_benchmark",
     ] + if_rocm_is_configured([
         # keep sorted
-        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
@@ -1199,7 +1197,6 @@ xla_test(
         "@tsl//tsl/platform:ml_dtypes",
     ] + if_rocm_is_configured([
         # keep sorted
-        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
@@ -1371,7 +1368,6 @@ xla_test(
         "@tsl//tsl/platform:test_benchmark",
     ] + if_rocm_is_configured([
         # keep sorted
-        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )

--- a/xla/tsl/platform/default/BUILD
+++ b/xla/tsl/platform/default/BUILD
@@ -123,7 +123,6 @@ cc_library(
         "@local_config_nccl//:nccl_config",
         "@local_config_tensorrt//:tensorrt_headers",
     ]) + if_rocm_is_configured([
-        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
@@ -399,7 +398,6 @@ cc_library(
     deps = [
         "//xla/tsl/platform:logging",
         "//xla/tsl/platform:types",
-        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
         "@tsl//tsl/platform:path",
     ],


### PR DESCRIPTION
📝 Summary of Changes
The `rocm_config` bazel target has been included in the `rocm_hearders` targets to avoid having to manage the dependency to `rocm_config` target independently when `rocm/rocm_config.h` is included in source code file.
Existing dependencies to `rocm_config` have been removed from BUILD files. 

🎯 Justification
The global build of XLA for rocm targets:
`bazel build --config=rocm_clang_official --build_tag_filters -no_oss,-cuda-only,-oneapi-only --test_tag_filters -no_oss,-cuda-only,-oneapi-only //xla/...`
was failing, with the following error:
```
xla/tests/dot_operation_test.cc:43:10: fatal error: 'rocm/rocm_config.h' file not found
  43 | #include "rocm/rocm_config.h"
     |          ^~~~~~~~~~~~~~~~~~~~
140 warnings and 1 error generated.
```
because dot_operation_test.cc includes `rocm.rocm_config.h` but the dependency to `rocm_config` was missing from the build instructions.
Including the `rocm_config` target in the `rocm_headers` target fixed this error.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
