### PR TITLE
[GPU] Make cuDNN GEMM backend aware of dot algorithms.

### DIFF
--- a/xla/backends/gpu/codegen/cudnn_test.cc
+++ b/xla/backends/gpu/codegen/cudnn_test.cc
@@ -559,6 +559,24 @@ ENTRY e {
 })"));
 }
 
+TEST_F(CuDnnFusionExecutionTest, NonDefaultDotAlgorithmIsNotSupported) {
+  EXPECT_FALSE(Run(R"(
+fusion1 {
+  a = bf16[32,96] parameter(0)
+  b = bf16[96,64] parameter(1)
+  r = f32[32,64] dot(a, b),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0},
+    algorithm=dot_bf16_bf16_f32
+}
+
+e {
+  a = bf16[32,96] parameter(0)
+  b = bf16[96,64] parameter(1)
+  _ = f32[32,64] fusion(a, b), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})"));
+}
+
 TEST_F(CuDnnFusionExecutionTest,
        DotF16NegateNonDefaultDimensionsExecutesCorrectly) {
   EXPECT_TRUE(RunAndCompare(R"(

--- a/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/service/gpu/transforms/cudnn_fusion_compiler.cc
@@ -217,6 +217,10 @@ class GemmDimensionAdapter {
       VLOG(3) << "Non-default precision is not supported.";
       return std::nullopt;
     }
+    if (dot->precision_config().algorithm() != PrecisionConfig::ALG_UNSET) {
+      VLOG(3) << "Non-default algorithm is not supported.";
+      return std::nullopt;
+    }
     TF_ASSIGN_OR_RETURN(auto analysis,
                         TritonFusionAnalysis::Execute(computation));
     return GemmDimensionAdapter{*dot, std::move(analysis)};

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -462,11 +462,6 @@ message DebugOptions {
   optional string xla_gpu_cuda_data_dir = 61;
 
   // Let GEMM fusion autotuning probe cuDNN as a backend.
-  //
-  // CAUTION:
-  // * HLO dot precision (e.g. `algorithm=dot_bf16_bf16_f32`) is ignored.
-  // * `tf32` matmuls are enabled unconditionally.
-  //
   // Current levels:
   // 0: Disabled.
   // 1: Enabled on Blackwell+ GPUs.


### PR DESCRIPTION
📝 Summary of Changes
Makes the cuDNN backend respect dot algorithms - for now failing on any non-default one requested.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
yes

🧪 Execution Tests:
no