### PR TITLE
[ROCm][XLA:GPU] Rename warp to shmem_group in PackedTranspose

### DIFF
--- a/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_bf16.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_bf16.hlo
@@ -6,4 +6,6 @@ fusion {
   p0 = bf16[30,16,30] parameter(0)
   ROOT transpose = bf16[30,16,30] transpose(p0), dimensions={2,1,0}
 }
+// CHECK: #indexing_map{{.*}}domain:{{.*}}th_x in [0, [[N_THREADS:[0-9]+]]]
+// CHECK: %thread_id_x = gpu.thread_id  x {xla.range = [0 : index, [[N_THREADS]] : index]}
 // CHECK:  xla_gpu.allocate_shared : tensor<64x64xbf16>

--- a/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_f16.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_f16.hlo
@@ -6,4 +6,6 @@ fusion {
   p0 = f16[28,2,6,32] parameter(0)
   ROOT transpose = f16[2,32,6,28] transpose(p0), dimensions={1,3,2,0}
 }
+// CHECK: #indexing_map{{.*}}domain:{{.*}}th_x in [0, [[N_THREADS:[0-9]+]]]
+// CHECK: %thread_id_x = gpu.thread_id  x {xla.range = [0 : index, [[N_THREADS]] : index]}
 // CHECK:  xla_gpu.allocate_shared : tensor<64x64xf16>

--- a/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_s4.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_s4.hlo
@@ -7,4 +7,6 @@ fusion {
   ROOT %transpose= s4[128, 32, 8, 256] transpose(%param_0),
     dimensions={0,3,2,1}
 }
+// CHECK: #indexing_map{{.*}}domain:{{.*}}th_x in [0, [[N_THREADS:[0-9]+]]]
+// CHECK: %thread_id_x = gpu.thread_id  x {xla.range = [0 : index, [[N_THREADS]] : index]}
 // CHECK: xla_gpu.allocate_shared : tensor<256x256xi4>

--- a/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_s8.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_s8.hlo
@@ -6,4 +6,6 @@ fusion {
   p0 = s8[8,64,68] parameter(0)
   ROOT transpose = s8[8,68,64] transpose(p0), dimensions={0, 2, 1}
 }
+// CHECK: #indexing_map{{.*}}domain:{{.*}}th_x in [0, [[N_THREADS:[0-9]+]]]
+// CHECK: %thread_id_x = gpu.thread_id  x {xla.range = [0 : index, [[N_THREADS]] : index]}
 // CHECK:  xla_gpu.allocate_shared : tensor<128x128xi8>

--- a/xla/backends/gpu/codegen/emitters/transpose.h
+++ b/xla/backends/gpu/codegen/emitters/transpose.h
@@ -199,19 +199,24 @@ class TransposeFusion : public TransposeFusionBase {
 //    slice of shared memory.
 //
 // 5. Every GPU block gets a single 64 x 10 x 6 x bf16 tile.
-//    The tile is read by `num_warps_per_block` warps.
-//    Let's assume that there are 4 warps per block. In this case, on every
-//    iteration each warp will read 10 x 6 x bf16 elements, i.e. every thread
-//    (30 out of 32) performs a vector load of 2 x bf16 and stores it to the
-//    shared memory. In total, there will be 16 iterations performed by each
-//    block.
+//    The tile is read by `num_shmem_groups_per_block` shmem groups.
+//    Let's assume that there are 4 shmem groups per block. In this case, on
+//    every iteration each shmem group will read 10 x 6 x bf16 elements, i.e.
+//    every thread (30 out of 32) performs a vector load of 2 x bf16 and stores
+//    it to the shared memory. In total, there will be 16 iterations performed
+//    by each block.
+//
+//    Note: When the hardware warp size equals kNumShmemBanks (32), then
+//    num_shmem_groups_per_block equals the number of warps per block. This is
+//    the case for NVIDIA GPUs, but not always for AMD GPUs where warp size
+//    can differ (64).
 //
 //    The following code snippet shows how the data is read from the input
 //    tensor into the shared memory:
 //
-//    for I = 0 to CEIL(shmem_rows, num_warps_per_block):
+//    for I = 0 to CEIL(shmem_rows, num_shmem_groups_per_block):
 //      for J = 0 to VECTOR_SIZE:
-//        ROW = WARP_ID + NUM_WARPS * I
+//        ROW = SHMEM_GROUP_ID + NUM_SHMEM_GROUPS * I
 //        COL = LANE_ID * VECTOR_SIZE + J
 //        SHMEM[ROW, COL] = INPUT[ROW, COL / 10, COL % 10]
 //
@@ -220,7 +225,7 @@ class TransposeFusion : public TransposeFusionBase {
 // 6. Each thread reads a VECTOR_SIZE x VECTOR_SIZE x bf16 tile from the shared
 //    memory and performs the write of each of the columns of the tile.
 //
-//    for I = 0 to CEIL(shmem_cols, VECTOR_SIZE * num_warps_per_block):
+//    for I = 0 to CEIL(shmem_cols, VECTOR_SIZE * num_shmem_groups_per_block):
 //      VECTOR_2D = arith.constant dense<0>
 //        : vector<VECTOR_SIZE x VECTOR_SIZE x bf16>
 //      for J = 0 to VECTOR_SIZE:
@@ -234,7 +239,8 @@ class PackedTranspose : public TransposeFusionBase {
   explicit PackedTranspose(const HloFusionAnalysis& analysis,
                            const TransposeSpec& spec,
                            absl::Span<const int64_t> output_block_tile,
-                           int64_t num_warps, mlir::MLIRContext* mlir_context);
+                           int64_t num_shmem_groups,
+                           mlir::MLIRContext* mlir_context);
 
   LaunchDimensions launch_dimensions() const override;
 
@@ -281,8 +287,10 @@ class PackedTranspose : public TransposeFusionBase {
   // Vector size in elements.
   int64_t vector_size_;
 
-  // Number of warps per block.
-  int64_t num_warps_per_block_;
+  // Number of shmem groups per block. Each shmem group consists of 32 threads
+  // (kNumShmemBanks), chosen to match the number of shared memory banks for
+  // optimal memory access patterns. This is independent of hardware warp size.
+  int64_t num_shmem_groups_per_block_;
 
   // Tile sizes for the canonicalical dimensions
   // [T2, A, T1, 1] -> [T1, A, T2, 1].


### PR DESCRIPTION
Rename `warp` to `shmem_group` in `PackedTranspose`. 

Also calculate their count as `kNumThreadsPerBlock / kNumShmemBanks` to avoid inconsistency when manually specified.

This change is NFC for any GPU in upstream. However, it fixes a performance regression in downstream for AMD GPUs caused by inconsistency between `shmem_group size`, `kNumThreadsPerBlock` and `kNumShmemBanks`. It ended up in a situation downstream where half of the launched threads per block were not utilized at all.

Update packed transpose tests to verify correct thread utilization.