### PR TITLE
[NVIDIA GPU] Fix a deadlock when doing comm split

### DIFF
--- a/xla/backends/gpu/collectives/gpu_clique_key.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key.cc
@@ -86,6 +86,11 @@ bool GpuCliqueKey::is_p2p() const { return is_p2p_; }
 
 GlobalDeviceId GpuCliqueKey::root_device() const { return root_device_; }
 
+std::vector<std::vector<GlobalDeviceId>> GpuCliqueKey::ParticipantGroups()
+    const {
+  return participant_groups_;
+};
+
 bool GpuCliqueKey::IsSubsetOf(const CliqueKey& other) const {
   auto* other_gpu = tsl::down_cast<const GpuCliqueKey*>(&other);
   if (other_gpu == nullptr) {

--- a/xla/backends/gpu/collectives/gpu_clique_key.h
+++ b/xla/backends/gpu/collectives/gpu_clique_key.h
@@ -62,6 +62,8 @@ class GpuCliqueKey : public CliqueKey {
 
   CollectiveStreamId stream_id() const;
 
+  std::vector<std::vector<GlobalDeviceId>> ParticipantGroups() const;
+
   // Device generating the unique id for this key
   GlobalDeviceId root_device() const;
 

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -492,6 +492,13 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
   GpuCollectives::DeviceRank device_rank = {&gpu_device, rank};
   RankPair rank_pair = {parent_rank, device_rank};
 
+  // Synchronize the device to make sure no other collectives are
+  // running before we do the split.
+  if (!device->SynchronizeAllActivity()) {
+    return Internal(
+        "Failed to synchronize GPU before splitting communicators.");
+  }
+
   // Current approach for communicator splitting works because of XLAs SPMD
   // programming model where all collective operations have replica groups that
   // include all ranks. This property guarantees that we'll split each
@@ -718,7 +725,10 @@ absl::StatusOr<std::shared_ptr<LockableGpuClique::Lock>> AcquireGpuClique(
 
   if (enable_nccl_comm_splitting) {
     for (auto& [acquired_clique_key, acquired_clique] : acquired_cliques) {
-      if (clique_key.IsSubsetOf(acquired_clique_key)) {
+      // If the participant group is empty, we won't know if there are other
+      // ranks involved in the split. Proceed to normal initialization.
+      if (clique_key.IsSubsetOf(acquired_clique_key) &&
+          !clique_key.ParticipantGroups().empty()) {
         return InitializeGpuClique(collectives, device, run_id, clique_key,
                                    acquired_clique, num_local_participants,
                                    rank, config);

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -2899,10 +2899,10 @@ TEST_F(CollectiveOpsTestE2E, MultipleModuleDifferentDeviceGroupsShouldRun) {
 
   const int64_t kNumReplicas_1 = 2;
   const int64_t kNumReplicas_2 = 4;
-
-  ASSERT_GE(hlo_runner_->device_count(), kNumReplicas_2)
-      << "Test requires at least " << kNumReplicas_2 << " devices ("
-      << hlo_runner_->device_count() << " available)";
+  if (hlo_runner_->device_count() < kNumReplicas_2) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas_2 << " devices ("
+                 << hlo_runner_->device_count() << " available)";
+  }
 
   HloModuleConfig config_1 =
       GetModuleConfigForTest(/*replica_count=*/kNumReplicas_1);

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -2915,15 +2915,11 @@ TEST_F(CollectiveOpsTestE2E, MultipleModuleDifferentDeviceGroupsShouldRun) {
   TF_ASSERT_OK_AND_ASSIGN(auto module_2,
                           ParseAndReturnVerifiedModule(kModuleStr_2, config_2));
 
-  int64_t num_elements_1 = module_1->entry_computation()
-                               ->root_instruction()
-                               ->shape()
-                               .dimensions()[0];
+  int64_t num_elements_1 = ShapeUtil::ElementsIn(
+      module_1->entry_computation()->parameter_instructions()[0]->shape());
 
-  int64_t num_elements_2 = module_2->entry_computation()
-                               ->root_instruction()
-                               ->shape()
-                               .dimensions()[0];
+  int64_t num_elements_2 = ShapeUtil::ElementsIn(
+      module_2->entry_computation()->parameter_instructions()[0]->shape());
 
   Array<float> input1_1({num_elements_1}), input1_2({num_elements_1});
   input1_1.FillRandom(1.0f, 10.0f, /*seed=*/0);

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -2863,5 +2863,100 @@ INSTANTIATE_TEST_SUITE_P(
       return absl::StrCat(GetAsyncTestName(std::get<0>(info.param)), "_",
                           std::get<1>(info.param) ? "one_shot" : "nccl");
     });
+
+TEST_F(CollectiveOpsTestE2E, MultipleModuleDifferentDeviceGroupsShouldRun) {
+  const absl::string_view kModuleStr_1 = R"(
+  HloModule test
+
+  apply_op {
+    x = f32[] parameter(0)
+    y = f32[] parameter(1)
+    ROOT apply_op = f32[] add(x, y)
+  }
+
+  ENTRY test_computation {
+    param_0 = f32[65536] parameter(0)
+    ROOT all-reduce = f32[65536] all-reduce(param_0), to_apply=apply_op, replica_groups={{0,1}}
+  }
+  )";
+  const absl::string_view kModuleStr_2 = R"(
+  HloModule test
+
+  apply_op {
+    x = f32[] parameter(0)
+    y = f32[] parameter(1)
+    ROOT apply_op = f32[] add(x, y)
+  }
+
+  ENTRY test_computation {
+    param_0 = f32[65536] parameter(0)
+    all-reduce.1 = f32[65536] all-reduce(param_0), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
+    all-reduce.2 = f32[65536] all-reduce(all-reduce.1), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
+    all-reduce.3 = f32[65536] all-reduce(all-reduce.2), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
+    ROOT all-reduce.4 = f32[65536] all-reduce(all-reduce.3), to_apply=apply_op, replica_groups={{0,1,2,3}}
+  }
+  )";
+
+  const int64_t kNumReplicas_1 = 2;
+  const int64_t kNumReplicas_2 = 4;
+
+  ASSERT_GE(hlo_runner_->device_count(), kNumReplicas_2)
+      << "Test requires at least " << kNumReplicas_2 << " devices ("
+      << hlo_runner_->device_count() << " available)";
+
+  HloModuleConfig config_1 =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas_1);
+  HloModuleConfig config_2 =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas_2);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_1,
+                          ParseAndReturnVerifiedModule(kModuleStr_1, config_1));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_2,
+                          ParseAndReturnVerifiedModule(kModuleStr_2, config_2));
+
+  int64_t num_elements_1 = module_1->entry_computation()
+                               ->root_instruction()
+                               ->shape()
+                               .dimensions()[0];
+
+  int64_t num_elements_2 = module_2->entry_computation()
+                               ->root_instruction()
+                               ->shape()
+                               .dimensions()[0];
+
+  Array<float> input1_1({num_elements_1}), input1_2({num_elements_1});
+  input1_1.FillRandom(1.0f, 10.0f, /*seed=*/0);
+  input1_2.FillRandom(1.0f, 10.0f, /*seed=*/1);
+
+  Literal input_literal1_1 = LiteralUtil::CreateFromArray(input1_1);
+  Literal input_literal1_2 = LiteralUtil::CreateFromArray(input1_2);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result_1,
+      ExecuteReplicated(std::move(module_1),
+                        std::vector<std::vector<Literal*>>{
+                            {&input_literal1_1}, {&input_literal1_2}}));
+
+  Array<float> input2_1({num_elements_2}), input2_2({num_elements_2}),
+      input2_3({num_elements_2}), input2_4({num_elements_2});
+  input2_1.FillRandom(1.0f, 10.0f, /*seed=*/0);
+  input2_2.FillRandom(1.0f, 10.0f, /*seed=*/1);
+  input2_3.FillRandom(1.0f, 10.0f, /*seed=*/2);
+  input2_4.FillRandom(1.0f, 10.0f, /*seed=*/3);
+
+  Literal input_literal2_1 = LiteralUtil::CreateFromArray(input2_1);
+  Literal input_literal2_2 = LiteralUtil::CreateFromArray(input2_2);
+  Literal input_literal2_3 = LiteralUtil::CreateFromArray(input2_3);
+  Literal input_literal2_4 = LiteralUtil::CreateFromArray(input2_4);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result_2,
+      ExecuteReplicated(std::move(module_2), std::vector<std::vector<Literal*>>{
+                                                 {&input_literal2_1},
+                                                 {&input_literal2_2},
+                                                 {&input_literal2_3},
+                                                 {&input_literal2_4}}));
+}
 }  // namespace
 }  // namespace xla

--- a/xla/tests/collective_ops_e2e_test.cc
+++ b/xla/tests/collective_ops_e2e_test.cc
@@ -2875,8 +2875,8 @@ TEST_F(CollectiveOpsTestE2E, MultipleModuleDifferentDeviceGroupsShouldRun) {
   }
 
   ENTRY test_computation {
-    param_0 = f32[65536] parameter(0)
-    ROOT all-reduce = f32[65536] all-reduce(param_0), to_apply=apply_op, replica_groups={{0,1}}
+    param_0 = f32[8] parameter(0)
+    ROOT all-reduce = f32[8] all-reduce(param_0), to_apply=apply_op, replica_groups={{0,1}}
   }
   )";
   const absl::string_view kModuleStr_2 = R"(
@@ -2889,11 +2889,11 @@ TEST_F(CollectiveOpsTestE2E, MultipleModuleDifferentDeviceGroupsShouldRun) {
   }
 
   ENTRY test_computation {
-    param_0 = f32[65536] parameter(0)
-    all-reduce.1 = f32[65536] all-reduce(param_0), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
-    all-reduce.2 = f32[65536] all-reduce(all-reduce.1), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
-    all-reduce.3 = f32[65536] all-reduce(all-reduce.2), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
-    ROOT all-reduce.4 = f32[65536] all-reduce(all-reduce.3), to_apply=apply_op, replica_groups={{0,1,2,3}}
+    param_0 = f32[8] parameter(0)
+    all-reduce.1 = f32[8] all-reduce(param_0), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
+    all-reduce.2 = f32[8] all-reduce(all-reduce.1), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
+    all-reduce.3 = f32[8] all-reduce(all-reduce.2), to_apply=apply_op, replica_groups={{0,1}, {2,3}}
+    ROOT all-reduce.4 = f32[8] all-reduce(all-reduce.3), to_apply=apply_op, replica_groups={{0,1,2,3}}
   }
   )";
 


### PR DESCRIPTION
📝 Summary of Changes
If participant group of a collective is empty, doing split can sometimes cause deadlocks since we dont know what are the participating ranks. Instead it should proceed to a regular comm init.

🎯 Justification
A target case would be if there are multiple communicators cached from different modules that use different device groups.
We rely one a rendezvous to return early if a communicator has been cached. Since participant groups are part of the key, there will be inconsistent cache hits among ranks leading to some ranks go to split but other won't.  ncclCommSplit requires all ranks to be call the api otherwise it will hang.
🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
NA
🧪 Unit Tests:
can only be tested with execution test

🧪 Execution Tests:
added
