### PR TITLE
Document "--xla_syntax_sugar_async_ops" flag

### DIFF
--- a/docs/hlo_dumps.md
+++ b/docs/hlo_dumps.md
@@ -73,6 +73,12 @@ graph.
 specified, it will dump to stdout. But the dump will not include binary data,
 e.g., proto files, to stdout.
 
+You can also set the HLO Dumps to use syntactic sugar wrappers as op names, by setting the `--xla_syntax_sugar_async_ops` flag to `true`. This can reduce the dump by about 20%. By default, this flag is set to `false`, and actual op names are used in the dump.
+
+```shell
+XLA_FLAGS="--xla_dump_to=DIRECTORY_PATH --xla_syntax_sugar_async_ops=true
+```
+
 ## Dump Specific Intermediate Passes
 
 In addition to the standard pre-optimized / final-optimized HLOs, you can also

--- a/docs/hlo_dumps.md
+++ b/docs/hlo_dumps.md
@@ -76,7 +76,7 @@ e.g., proto files, to stdout.
 You can also set the HLO Dumps to use syntactic sugar wrappers as op names, by setting the `--xla_syntax_sugar_async_ops` flag to `true`. This can reduce the dump by about 20%. By default, this flag is set to `false`, and actual op names are used in the dump.
 
 ```shell
-XLA_FLAGS="--xla_dump_to=DIRECTORY_PATH --xla_syntax_sugar_async_ops=true
+XLA_FLAGS="--xla_dump_to=DIRECTORY_PATH --xla_syntax_sugar_async_ops=true"
 ```
 
 ## Dump Specific Intermediate Passes


### PR DESCRIPTION
**📝 Summary of Changes**

Add a few sentences about the [`--xla_syntax_sugar_async_ops` flag](https://github.com/openxla/xla/blob/5a29513cd4ab3667821acc9de97103f99c3e9524/xla/xla.proto#L1360-L1385) in the HLO Dumps documentation.

**🎯 Justification**

A useful flag that can be included on this page.

**🚀 Kind of Contribution**

📚 Documentation
