### PR TITLE
[ROCm] Fix asan error reported when running set_dimension_size_test under rocm

### DIFF
--- a/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer.cc
+++ b/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer.cc
@@ -528,7 +528,7 @@ Future<> TfrtGpuBuffer::ToLiteralHelper(Future<MutableLiteralBase*> literal) {
           }
           if (on_device_shape.IsArray() && !should_unpack &&
               transpose == nullptr) {
-            std::memcpy(literal->untyped_data(), buffer, byte_size);
+            std::memcpy(literal->untyped_data(), buffer, literal->size_bytes());
           }
           promise.Set(absl::OkStatus());
         });


### PR DESCRIPTION
📝 Summary of Changes
Fixes invalid memory access detected by asan when executing set_dimension_size_test under rocm

🎯 Justification
Fixes a bug while copying invalid member of bytes to the host memory.
The literal was allocated based on on_device_shape_, which may have different dimensions than what's actually stored in the device buffer. This can happen with dynamic shapes where the buffer was allocated for a maximum size, but the actual data is smaller.
Hence when using the device buffers size it tries to copy out of the literals memory.

```
[2025-11-21T08:19:29.296Z] INFO: From Testing //xla/tests:set_dimension_size_test_amdgpu_any:
[2025-11-21T08:19:29.296Z] ==================== Test output for //xla/tests:set_dimension_size_test_amdgpu_any:
[2025-11-21T08:19:29.296Z] Running test /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/bazel-out/k8-opt/bin/xla/tests/set_dimension_size_test_amdgpu_any.runfiles/xla/xla/tests/set_dimension_size_test_amdgpu_any --gtest_shuffle --gtest_fail_if_no_test_linked on GPU 2
[2025-11-21T08:19:29.296Z] Note: Randomizing tests' orders with a seed of 95132 .
[2025-11-21T08:19:29.296Z] [==========] Running 2 tests from 1 test suite.
[2025-11-21T08:19:29.296Z] [----------] Global test environment set-up.
[2025-11-21T08:19:29.296Z] [----------] 2 tests from SetDimensionSizeTest
[2025-11-21T08:19:29.296Z] [ RUN      ] SetDimensionSizeTest.CorrectComputation
[2025-11-21T08:19:29.296Z] WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
[2025-11-21T08:19:29.296Z] I0000 00:00:1763713160.655559    4315 service.cc:158] XLA service 0x513000053080 initialized for platform ROCM (this does not guarantee that XLA will be used). Devices:
[2025-11-21T08:19:29.296Z] I0000 00:00:1763713160.655641    4315 service.cc:166]   StreamExecutor device (0): gfx90a:sramecc+:xnack-, AMDGPU ISA version: gfx90a:sramecc+:xnack-
[2025-11-21T08:19:29.296Z] I0000 00:00:1763713160.678712    4315 utils.cc:640] Using BFC allocator.
[2025-11-21T08:19:29.296Z] I0000 00:00:1763713160.678758    4315 gpu_helpers.cc:136] XLA backend allocating 5496215961 bytes on device 0 for BFCAllocator.
[2025-11-21T08:19:29.296Z] I0000 00:00:1763713160.678804    4315 gpu_helpers.cc:177] XLA backend will use up to 63206483558 bytes on device 0 for CollectiveBFCAllocator.
[2025-11-21T08:19:29.296Z] I0000 00:00:1763713166.016783    4315 tfrt_gpu_client.cc:187] TfrtGpuClient created with 1 / 1 addressable devices.
[2025-11-21T08:19:29.296Z] W0000 00:00:1763713166.124690    4315 stream_executor.h:408] Not enough memory to allocate 5496215808 on device 0 within provided limit.  limit=4294967296]
[2025-11-21T08:19:29.296Z] W0000 00:00:1763713166.124731    4315 stream_executor.h:408] Not enough memory to allocate 4946593792 on device 0 within provided limit.  limit=4294967296]
[2025-11-21T08:19:29.296Z] W0000 00:00:1763713166.124741    4315 stream_executor.h:408] Not enough memory to allocate 4451934208 on device 0 within provided limit.  limit=4294967296]
[2025-11-21T08:19:29.296Z] =================================================================
[2025-11-21T08:19:29.296Z] ==4315==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5090000000dc at pc 0x5601237ebfa4 bp 0x7f645f1076d0 sp 0x7f645f106e90
[2025-11-21T08:19:29.296Z] WRITE of size 40 at 0x5090000000dc thread T259
[2025-11-21T08:19:29.296Z]     #0 0x5601237ebfa3 in __asan_memcpy (/root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/bazel-out/k8-opt/bin/xla/tests/set_dimension_size_test_amdgpu_any+0x1b7fa3) (BuildId: 540b373526bfe27a16c2960341daf633)
[2025-11-21T08:19:29.296Z]     #1 0x7f6e31020839 in memcpy /usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10
[2025-11-21T08:19:29.296Z]     #2 0x7f6e31020839 in xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)::operator()(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&) /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer.cc:531:13
[2025-11-21T08:19:29.296Z]     #3 0x7f6e31020839 in auto tsl::internal::FutureBase<absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>>, false>::AndThen<xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) const &::'lambda'()::operator()() /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/./xla/tsl/concurrency/future.h:427:7
[2025-11-21T08:19:29.296Z]     #4 0x7f6e3101e936 in void tsl::AsyncValue::AndThen<auto tsl::internal::FutureBase<absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>>, false>::AndThen<xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) const &::'lambda'()>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/./xla/tsl/concurrency/async_value.h:1046:5
[2025-11-21T08:19:29.296Z]     #5 0x7f6e3101e936 in void tsl::AsyncValuePtr<absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>>>::AndThen<auto tsl::internal::FutureBase<absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>>, false>::AndThen<xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) const &::'lambda'(), (void*)0>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) const /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/./xla/tsl/concurrency/async_value_ref.h:533:13
[2025-11-21T08:19:29.296Z]     #6 0x7f6e3101e936 in void tsl::AsyncValueRef<absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>>>::AndThen<auto tsl::internal::FutureBase<absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>>, false>::AndThen<xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) const &::'lambda'()>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) const /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/./xla/tsl/concurrency/async_value_ref.h:260:13
[2025-11-21T08:19:29.296Z]     #7 0x7f6e3101e936 in void tsl::internal::FutureBase<absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>>, false>::OnReady<xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&), (void*)0>(xla::TfrtGpuBuffer::ToLiteralHelper(tsl::Future<xla::MutableLiteralBase*>)::$_1::operator()()::'lambda'(absl::lts_20250814::StatusOr<std::pair<xla::MutableLiteralBase*, std::shared_ptr<xla::TransposePlan>>> const&)&&) const & /root/.cache/bazel/_bazel_root/217377b0e928b171b843eb11ea7bc36e/execroot/xla/./xla/tsl/concurrency/future.h:378:14
```

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI unit tests.

🧪 Execution Tests:
CI unit tests.

