### PR TITLE
[ROCm] bugfix - consider the situation where the best time is infinite

### DIFF
--- a/xla/service/gpu/model/gpu_indexing_performance_model.cc
+++ b/xla/service/gpu/model/gpu_indexing_performance_model.cc
@@ -680,6 +680,11 @@ GpuPerformanceModelWithIndexingAnalysis::TryFindBestTilingForFusion(
         EstimateRunTimeForTiledHloComputation(
             fusion_adaptor, tiled_hlo_computation, launch_dimensions));
 
+    // Skip tilings with infinite runtime (e.g., due to register spilling).
+    if (estimate_run_time_data.exec_time == absl::InfiniteDuration()) {
+      continue;
+    }
+
     if (!best_tiled_run_time_data.has_value() ||
         estimate_run_time_data.exec_time <
             best_tiled_run_time_data->runtime_data.exec_time) {

--- a/xla/service/gpu/transforms/priority_fusion_test.cc
+++ b/xla/service/gpu/transforms/priority_fusion_test.cc
@@ -1293,6 +1293,123 @@ TEST_F(PriorityFusionTest, DoNotFuseInsideReducer) {
               absl_testing::IsOkAndHolds(false));
 }
 
+TEST_F(PriorityFusionTest, SkipsTilingsWithInfiniteRuntime) {
+  // This test verifies the fix in TryFindBestTilingForFusion that skips
+  // tilings with infinite runtime estimates.
+  //
+  // The fix: After estimating runtime for each tiling candidate, check if
+  // exec_time == absl::InfiniteDuration() and skip those tilings.
+  //
+  // Background: DoesComputationFitInRegisters() returns false when tiles are
+  // too large to fit in registers (tile_size > 0.4 * registers_per_block).
+  // When this happens, EstimateRunTimeForTiledHloComputation() returns
+  // EstimateRunTimeData::Infinite() with exec_time = absl::InfiniteDuration().
+  //
+  // Without the fix: If all tilings have infinite runtime, the first one
+  // would be selected as "best" by default, leading to certain register
+  // spilling and poor performance.
+  //
+  // With the fix: Infinite-runtime tilings are skipped during evaluation,
+  // allowing:
+  // 1. Selection of tilings that actually fit in registers, OR
+  // 2. Return FusionDecision::Forbid("No valid tilings found") if all fail
+  //
+  // Test structure: LayerNorm-like computation with reductions that can
+  // trigger problematic tile sizes on certain input shapes.
+  const std::string kHloText = R"(
+HloModule m
+%region_2.260.clone.19 (Arg_0.55: f32[], Arg_1.55: f32[]) -> f32[] {
+  %Arg_0.55 = f32[] parameter(0)
+  %Arg_1.55 = f32[] parameter(1)
+  ROOT %add.492.0 = f32[] add(%Arg_0.55, %Arg_1.55)
+}
+
+%region_2.260.clone.8 (Arg_0.44: f32[], Arg_1.44: f32[]) -> f32[] {
+  %Arg_0.44 = f32[] parameter(0)
+  %Arg_1.44 = f32[] parameter(1)
+  ROOT %add.481.0 = f32[] add(%Arg_0.44, %Arg_1.44)
+}
+
+%region_2.260.clone.7 (Arg_0.43: f32[], Arg_1.43: f32[]) -> f32[] {
+  %Arg_0.43 = f32[] parameter(0)
+  %Arg_1.43 = f32[] parameter(1)
+  ROOT %add.480.0 = f32[] add(%Arg_0.43, %Arg_1.43)
+}
+
+%producer_computation (param_0: bf16[16384,4096]) -> bf16[16384,4096] {
+  %param_0 = bf16[16384,4096]{1,0} parameter(0)
+  %constant_0 = bf16[] constant(1e-03)
+  %broadcast_0 = bf16[16384,4096]{1,0} broadcast(%constant_0), dimensions={}
+  ROOT %add_0 = bf16[16384,4096]{1,0} add(%param_0, %broadcast_0)
+}
+
+%fused_computation.337 (param_0.1730: bf16[1,16384,4096], param_1.1795: bf16[16384,4096]) -> f32[128,4096] {
+  %param_0.1730 = bf16[1,16384,4096]{2,1,0} parameter(0)
+  %convert.113.32 = f32[1,16384,4096]{2,1,0} convert(%param_0.1730)
+  %bitcast.1893 = f32[16384,4096]{1,0} bitcast(%convert.113.32)
+  %constant_2184 = f32[] constant(0)
+  %reduce.310 = f32[16384]{0} reduce(%bitcast.1893, %constant_2184), dimensions={1}, to_apply=%region_2.260.clone.7
+  %bitcast.1892 = f32[1,16384]{1,0} bitcast(%reduce.310)
+  %constant_2183 = f32[] constant(0.000244140625)
+  %broadcast.1035 = f32[1,16384]{1,0} broadcast(%constant_2183), dimensions={}
+  %multiply.520 = f32[1,16384]{1,0} multiply(%bitcast.1892, %broadcast.1035)
+  %bitcast.1891 = f32[16384]{0} bitcast(%multiply.520)
+  %broadcast.1034 = f32[1,16384,4096]{2,1,0} broadcast(%bitcast.1891), dimensions={1}
+  %subtract.183 = f32[1,16384,4096]{2,1,0} subtract(%convert.113.32, %broadcast.1034)
+  %multiply.261.15 = f32[1,16384,4096]{2,1,0} multiply(%subtract.183, %subtract.183)
+  %bitcast.1136.15 = f32[16384,4096]{1,0} bitcast(%multiply.261.15)
+  %reduce.127.15 = f32[16384]{0} reduce(%bitcast.1136.15, %constant_2184), dimensions={1}, to_apply=%region_2.260.clone.8
+  %bitcast.1137.13 = f32[1,16384]{1,0} bitcast(%reduce.127.15)
+  %multiply.262.13 = f32[1,16384]{1,0} multiply(%bitcast.1137.13, %broadcast.1035)
+  %constant_1233_1 = f32[] constant(1e-05)
+  %broadcast.449.11 = f32[1,16384]{1,0} broadcast(%constant_1233_1), dimensions={}
+  %add.350.11 = f32[1,16384]{1,0} add(%multiply.262.13, %broadcast.449.11)
+  %bitcast.213.16 = f32[1,16384,1]{2,1,0} bitcast(%add.350.11)
+  %rsqrt.14.5 = f32[1,16384,1]{2,1,0} rsqrt(%bitcast.213.16)
+  %bitcast.215.7 = f32[16384]{0} bitcast(%rsqrt.14.5)
+  %broadcast.472.7 = f32[1,16384,4096]{2,1,0} broadcast(%bitcast.215.7), dimensions={1}
+  %param_1.1795 = bf16[16384,4096]{1,0} parameter(1)
+  %bitcast.211.19 = bf16[1,16384,4096]{2,1,0} bitcast(%param_1.1795)
+  %convert.201.19 = f32[1,16384,4096]{2,1,0} convert(%bitcast.211.19)
+  %multiply.267.5 = f32[1,16384,4096]{2,1,0} multiply(%subtract.183, %convert.201.19)
+  %multiply.282.3 = f32[1,16384,4096]{2,1,0} multiply(%broadcast.472.7, %multiply.267.5)
+  %bitcast.1210.1 = f32[128,128,4096]{2,1,0} bitcast(%multiply.282.3)
+  ROOT %reduce.180.1 = f32[128,4096]{1,0} reduce(%bitcast.1210.1, %constant_2184), dimensions={1}, to_apply=%region_2.260.clone.19
+}
+ENTRY main {
+  p0 = bf16[1,16384,4096] parameter(0)
+  p1 = bf16[16384,4096] parameter(1)
+  producer_fusion = bf16[16384,4096]{1,0} fusion(p1), kind=kLoop, calls=%producer_computation
+
+  ROOT fusion = f32[128,4096] fusion(p0, producer_fusion), kind=kCustom,
+    calls=%fused_computation.337, backend_config={
+      "fusion_backend_config":{
+      "kind":"__triton",
+      "block_level_fusion_config":{
+        "output_tiles":[{"sizes":["1","1"]}],
+        "num_warps":"8",
+        "num_ctas":"1",
+        "num_stages":"1"}}}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_gpu_enable_triton_gemm(false);
+
+  module->mutable_config().mutable_debug_options().set_xla_gpu_autotune_level(
+      0);
+
+  // VLOG(2) << module->ToString() << std::endl;
+
+  // Run priority fusion - it should not fuse producer into
+  // %fused_computation.337.
+  EXPECT_THAT(priority_fusion_.Run(module.get()),
+              absl_testing::IsOkAndHolds(false));
+}
+
 class PriorityFusionWithTritonEnabledTest : public PriorityFusionTest {
  public:
   DebugOptions GetDebugOptionsForTest() const override {


### PR DESCRIPTION
🐛 Bug Fix

it occasionally happens in [TryFindBestTilingForFusion](https://github.com/openxla/xla/blob/b111957fcb2e2e91839c5e70c6b23216416ca99f/xla/service/gpu/model/gpu_indexing_performance_model.cc#L637C42-L637C68), best_tiled_run_time_data contains Infinite. Such situation leads to an unexpected computed_fusion with tile size[1,1] as below, which leads to performance degression due to register spilling (Tested both on MI300x and H100). This bugfix skips tiles with infinite runtime.

```
HloModule m
%region_2.260.clone.19 (Arg_0.55: f32[], Arg_1.55: f32[]) -> f32[] {
  %Arg_0.55 = f32[] parameter(0)
  %Arg_1.55 = f32[] parameter(1)
  ROOT %add.492.0 = f32[] add(%Arg_0.55, %Arg_1.55)
}

%region_2.260.clone.8 (Arg_0.44: f32[], Arg_1.44: f32[]) -> f32[] {
  %Arg_0.44 = f32[] parameter(0)
  %Arg_1.44 = f32[] parameter(1)
  ROOT %add.481.0 = f32[] add(%Arg_0.44, %Arg_1.44)
}

%region_2.260.clone.7 (Arg_0.43: f32[], Arg_1.43: f32[]) -> f32[] {
  %Arg_0.43 = f32[] parameter(0)
  %Arg_1.43 = f32[] parameter(1)
  ROOT %add.480.0 = f32[] add(%Arg_0.43, %Arg_1.43)
}

%fused_computation.337 (param_0.1730: bf16[1,16384,4096], param_1.1795: bf16[16384,4096]) -> f32[128,4096] {
  %param_0.1730 = bf16[1,16384,4096]{2,1,0} parameter(0)
  %convert.113.32 = f32[1,16384,4096]{2,1,0} convert(%param_0.1730)
  %bitcast.1893 = f32[16384,4096]{1,0} bitcast(%convert.113.32)
  %constant_2184 = f32[] constant(0)
  %reduce.310 = f32[16384]{0} reduce(%bitcast.1893, %constant_2184), dimensions={1}, to_apply=%region_2.260.clone.7
  %bitcast.1892 = f32[1,16384]{1,0} bitcast(%reduce.310)
  %constant_2183 = f32[] constant(0.000244140625)
  %broadcast.1035 = f32[1,16384]{1,0} broadcast(%constant_2183), dimensions={}
  %multiply.520 = f32[1,16384]{1,0} multiply(%bitcast.1892, %broadcast.1035)
  %bitcast.1891 = f32[16384]{0} bitcast(%multiply.520)
  %broadcast.1034 = f32[1,16384,4096]{2,1,0} broadcast(%bitcast.1891), dimensions={1}
  %subtract.183 = f32[1,16384,4096]{2,1,0} subtract(%convert.113.32, %broadcast.1034)
  %multiply.261.15 = f32[1,16384,4096]{2,1,0} multiply(%subtract.183, %subtract.183)
  %bitcast.1136.15 = f32[16384,4096]{1,0} bitcast(%multiply.261.15)
  %reduce.127.15 = f32[16384]{0} reduce(%bitcast.1136.15, %constant_2184), dimensions={1}, to_apply=%region_2.260.clone.8
  %bitcast.1137.13 = f32[1,16384]{1,0} bitcast(%reduce.127.15)
  %multiply.262.13 = f32[1,16384]{1,0} multiply(%bitcast.1137.13, %broadcast.1035)
  %constant_1233_1 = f32[] constant(1e-05)
  %broadcast.449.11 = f32[1,16384]{1,0} broadcast(%constant_1233_1), dimensions={}
  %add.350.11 = f32[1,16384]{1,0} add(%multiply.262.13, %broadcast.449.11)
  %bitcast.213.16 = f32[1,16384,1]{2,1,0} bitcast(%add.350.11)
  %rsqrt.14.5 = f32[1,16384,1]{2,1,0} rsqrt(%bitcast.213.16)
  %bitcast.215.7 = f32[16384]{0} bitcast(%rsqrt.14.5)
  %broadcast.472.7 = f32[1,16384,4096]{2,1,0} broadcast(%bitcast.215.7), dimensions={1}
  %param_1.1795 = bf16[16384,4096]{1,0} parameter(1)
  %bitcast.211.19 = bf16[1,16384,4096]{2,1,0} bitcast(%param_1.1795)
  %convert.201.19 = f32[1,16384,4096]{2,1,0} convert(%bitcast.211.19)
  %multiply.267.5 = f32[1,16384,4096]{2,1,0} multiply(%subtract.183, %convert.201.19)
  %multiply.282.3 = f32[1,16384,4096]{2,1,0} multiply(%broadcast.472.7, %multiply.267.5)
  %bitcast.1210.1 = f32[128,128,4096]{2,1,0} bitcast(%multiply.282.3)
  ROOT %reduce.180.1 = f32[128,4096]{1,0} reduce(%bitcast.1210.1, %constant_2184), dimensions={1}, to_apply=%region_2.260.clone.19
}
ENTRY main {
  p0 = bf16[1,16384,4096] parameter(0)
  p1 = bf16[16384,4096] parameter(1)
  ROOT fusion = f32[128,4096] fusion(p0, p1), kind=kCustom,
    calls=%fused_computation.337, backend_config={
      "fusion_backend_config":{
      "kind":"__triton",
      "block_level_fusion_config":{
        "output_tiles":[{"sizes":["1","1"]}],
        "num_warps":"8",
        "num_ctas":"1",
        "num_stages":"1"}}}
}
```

relevant PR https://github.com/openxla/xla/pull/33777#pullrequestreview-3487884860

@xla-rotation could you review my PR, please?
