### PR TITLE
[ROCm] Fix failing test TritonEmitterTest/RocmWarpSizeIsSetCorrectly

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc
@@ -4549,7 +4549,7 @@ TEST_F(TritonEmitterTest, RocmWarpSizeIsSetCorrectly) {
   }
   DebugOptions debug_options = verified_module->config().debug_options();
   debug_options.set_xla_dump_to(output_directory);
-  debug_options.set_xla_dump_hlo_pass_re("triton-fusion-emitter");
+  debug_options.set_xla_dump_emitter_re("triton-to-llvm");
   verified_module->mutable_config().set_debug_options(debug_options);
 
   const HloFusionInstruction* triton_fusion = Cast<HloFusionInstruction>(
@@ -4562,16 +4562,26 @@ TEST_F(TritonEmitterTest, RocmWarpSizeIsSetCorrectly) {
   std::vector<std::string> paths;
   std::string triton_passes_log;
 
+  // https://github.com/openxla/xla/commit/e00d5aa8029d228b148bf0ac463bdc5d1b70ea16
+  // adds bounds checks in Triton fusion emitter.
+  // Consequently valid, non-empty, tile parameters/sizes must be provided.
+  BlockLevelParameters block_level_parameters;
+  block_level_parameters.output_tile_sizes = {{16, 64}};
+  block_level_parameters.num_warps = 1;
+
   // For MI210 warp_size should be 64
-  const se::DeviceDescription dev_info =
+  se::DeviceDescription dev_info =
       TestGpuDeviceInfo::AMDMI210DeviceInfo();
+  // Now, we pass valud tiles, we also need to set non-zero `shared_memory_per_block_optin`
+  // to pass this check https://github.com/openxla/xla/blob/c8b710f1b70f890c9ee4b8756bc53f3a599a0ed5/xla/backends/gpu/codegen/triton/fusion_emitter.cc#L1863-L1867
+  dev_info.set_shared_memory_per_block_optin(64 * 1024);
   TF_ASSERT_OK(TritonWrapper(
       "test_fn", triton_fusion,
       se::GpuComputeCapability{se::RocmComputeCapability("gfx942")}, dev_info,
-      BlockLevelParameters(), target_triple, data_layout, llvm_ctx,
+      block_level_parameters, target_triple, data_layout, llvm_ctx,
       mlir_context));
   TF_EXPECT_OK(tsl::Env::Default()->GetMatchingPaths(
-      tsl::io::JoinPath(output_directory, "*.triton-passes.log"), &paths));
+      tsl::io::JoinPath(output_directory, "*.triton-to-llvm.txt"), &paths));
   EXPECT_EQ(paths.size(), 1);
   TF_ASSERT_OK(
       tsl::ReadFileToString(tsl::Env::Default(), paths[0], &triton_passes_log));
@@ -4581,15 +4591,18 @@ TEST_F(TritonEmitterTest, RocmWarpSizeIsSetCorrectly) {
   EXPECT_THAT(RunFileCheck(triton_passes_log, kPattern), true);
 
   // For RX7900 warp_size should be 32
-  const se::DeviceDescription dev_info_n =
+  se::DeviceDescription dev_info_n =
       TestGpuDeviceInfo::AMDRX7900DeviceInfo();
+  // Now, we pass valud tiles, we also need to set non-zero `shared_memory_per_block_optin`
+  // to pass this check https://github.com/openxla/xla/blob/c8b710f1b70f890c9ee4b8756bc53f3a599a0ed5/xla/backends/gpu/codegen/triton/fusion_emitter.cc#L1863-L1867
+  dev_info_n.set_shared_memory_per_block_optin(64 * 1024);
   TF_ASSERT_OK(TritonWrapper(
       "test_fn", triton_fusion,
       se::GpuComputeCapability{se::RocmComputeCapability("gfx1100")},
-      dev_info_n, BlockLevelParameters(), target_triple, data_layout, llvm_ctx,
+      dev_info_n, block_level_parameters, target_triple, data_layout, llvm_ctx,
       mlir_context));
   TF_EXPECT_OK(tsl::Env::Default()->GetMatchingPaths(
-      tsl::io::JoinPath(output_directory, "*.triton-passes.log"), &paths));
+      tsl::io::JoinPath(output_directory, "*.triton-to-llvm.txt"), &paths));
   EXPECT_EQ(paths.size(), 1);
   TF_ASSERT_OK(
       tsl::ReadFileToString(tsl::Env::Default(), paths[0], &triton_passes_log));


### PR DESCRIPTION
📝 Summary of Changes
Define valid tile parameters and non-zero shared memory, which are required to pass checks in the emitter.

🎯 Justification
The TritonEmitterTest/RocmWarpSizeIsSetCorrectly test is failing with the following error:
```
[ RUN      ] TritonEmitterTest.RocmWarpSizeIsSetCorrectly
xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc:4473: Failure
Value of: (TritonWrapper( "test_fn", triton_fusion, se::GpuComputeCapability{se::RocmComputeCapability("gfx942")}, dev_info, BlockLevelParameters(), &llvm_module, symbolic_expr_context))
Expected: is OK
  Actual: 128-byte object <70-BE 1E-9F E1-55 00-00 F8-5F 52-8A E1-55 00-00 00-00 00-00 00-00 00-00 40-67 C3-87 B8-7F 00-00 18-63 07-A4 E1-55 00-00 50-EE 78-86 FE-7F 00-00 B9-14 B8-43 B8-7F 00-00 00-63 07-A4 E1-55 00-00 18-63 07-A4 E1-55 00-00 C0-EA F4-42 B8-7F 00-00 E8-70 FF-FF FF-FF FF-FF F0-5F 52-8A E1-55 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-10 00-00 00-00 00-00 00-00 00-00 00-00 00-00>

[  FAILED  ] TritonEmitterTest.RocmWarpSizeIsSetCorrectly (4 ms)
```
The failure is related to additionan bounds checks added in the Triton fusion emitter, by this commit: https://github.com/openxla/xla/commit/e00d5aa8029d228b148bf0ac463bdc5d1b70ea16

These additional checks require us to provide valid tile parameters.
The tile size has been chosen randomly as this is not related to the purpose of this test, which aims to check the number of threads per warp for two AMD GPU architectures. 


🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Fixed test `TritonEmitterTest/RocmWarpSizeIsSetCorrectly`

🧪 Execution Tests:
Not relevant
