### PR TITLE
[XLA:GPU] Bump cuDNN version for block scaled dot support to 9.10

### DIFF
--- a/xla/service/gpu/transforms/block_scaling_rewriter.h
+++ b/xla/service/gpu/transforms/block_scaling_rewriter.h
@@ -25,7 +25,7 @@ limitations under the License.
 
 namespace xla::gpu {
 
-const se::dnn::VersionInfo kCudnnSupportsBlockScaledDot(9, 7);
+const se::dnn::VersionInfo kCudnnSupportsBlockScaledDot(9, 10);
 const se::dnn::VersionInfo kCudnnSupportsBlockScaledDotWithGlobalScale(9, 13);
 
 // This pass converts the block quantize/dequantize operations (represented as


### PR DESCRIPTION
📝 Summary of Changes
Fixes CUDNN_STATUS_EXECUTION_FAILED_CUBLAS issue in multithreaded environment (multi-GPU)

The `collective_ops_e2e_test` on multi-GPU Blackwell fails without this patch.

cuDNN changelog: https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html#cudnn-9-10-0

🚀 Kind of Contribution
🐛 Bug Fix
