### PR TITLE
[XLA:GPU][spirv] Add support to block unsupported extensions

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -370,3 +370,21 @@ cc_library(
         "@tsl//tsl/platform:errors",
     ],
 )
+
+xla_cc_test(
+    name = "spirv_backend_test",
+    srcs = ["spirv_backend_test.cc"],
+    tags = [
+        "gpu",
+        "oneapi-only",
+    ] + if_google([
+        "notap",
+        "nobuilder",
+        "manual",
+    ]),
+    deps = [
+        ":spirv_backend",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xla/service/gpu/llvm_gpu_backend/spirv_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/spirv_backend.cc
@@ -25,6 +25,8 @@ limitations under the License.
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/lib/Target/SPIRV/SPIRVAPI.h"
+#include "llvm/lib/Target/SPIRV/SPIRVCommandLine.h"
+#include "llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h"
 #include "xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
 #include "xla/service/llvm_ir/llvm_command_line_options.h"
 #include "tsl/platform/errors.h"
@@ -70,10 +72,29 @@ std::vector<std::string> GetSPIRVBackendOptions(
   return backend_llvm_opts;
 }
 
+std::vector<std::string> RemoveUnsupportedExtensionsFromAll(
+    llvm::Triple triple,
+    const std::vector<std::string> unsupported_extensions) {
+  std::set<std::string> extensions;
+  auto valid_extensions =
+      llvm::SPIRVExtensionsParser::getValidExtensions(triple);
+
+  for (auto& ext : valid_extensions) {
+    extensions.insert(llvm::getSymbolicOperandMnemonic(
+        llvm::SPIRV::OperandCategory::ExtensionOperand, ext));
+  }
+
+  for (auto& ext : unsupported_extensions) {
+    extensions.erase(ext);
+  }
+  return std::vector<std::string>(extensions.begin(), extensions.end());
+}
+
 absl::StatusOr<std::string> CompileToSPIRV(
     llvm::Module* module, stream_executor::GpuComputeCapability gpu_version,
     const DebugOptions& debug_options) {
   static absl::once_flag backend_init_flag;
+  static std::vector<std::string> spirv_extensions{};
   absl::call_once(backend_init_flag, SPIRVBackendInit);
   auto llvm_opts = GetSPIRVBackendOptions(debug_options);
   llvm_ir::LLVMCommandLineOptionsLock llvm_lock(llvm_opts);
@@ -138,6 +159,15 @@ absl::StatusOr<std::string> CompileToSPIRV(
   }
 
   llvm::Triple default_target_triple("spirv64-unknown-unknown");
+  // List of extensions to block during module translation.
+  // Block SPV_KHR_float_controls2 extension because the current L0 drivers lack
+  // the needed translation support.
+  const std::vector<std::string> unsupported_extensions = {
+      "SPV_KHR_float_controls2"};
+  if (spirv_extensions.empty()) {
+    spirv_extensions = RemoveUnsupportedExtensionsFromAll(
+        default_target_triple, unsupported_extensions);
+  }
   std::unique_ptr<llvm::TargetMachine> target_machine =
       GetTargetMachine(default_target_triple, "", debug_options, "");
   TF_RETURN_IF_ERROR(LinkAndOptimizeModule(
@@ -153,7 +183,6 @@ absl::StatusOr<std::string> CompileToSPIRV(
 
   std::string spirv_str;
   std::string spirv_err_msg;
-  std::vector<std::string> spirv_extensions{"all"};
   std::vector<std::string> spirv_options{default_target_triple.str()};
   bool spirv_success = llvm::SPIRVTranslateModule(
       module, spirv_str, spirv_err_msg, spirv_extensions, spirv_options);

--- a/xla/service/gpu/llvm_gpu_backend/spirv_backend.h
+++ b/xla/service/gpu/llvm_gpu_backend/spirv_backend.h
@@ -33,6 +33,10 @@ absl::StatusOr<std::string> CompileToSPIRV(
     llvm::Module* module, stream_executor::GpuComputeCapability gpu_version,
     const DebugOptions& debug_options);
 
+// Filters out "unsupported_extensions" from the extensions list
+std::vector<std::string> RemoveUnsupportedExtensionsFromAll(
+    llvm::Triple triple, const std::vector<std::string> unsupported_extensions);
+
 // Returns the LLVM command line flags that we use for compilation.
 std::vector<std::string> GetSPIRVBackendOptions(
     const DebugOptions& debug_options);

--- a/xla/service/gpu/llvm_gpu_backend/spirv_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/spirv_backend_test.cc
@@ -1,0 +1,49 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/llvm_gpu_backend/spirv_backend.h"
+
+#include <gtest/gtest.h>
+
+namespace xla::gpu::spirv {
+namespace {
+
+TEST(SpirvBackendTest, TestUnsupportedExtensions) {
+  llvm::Triple target_triple("spirv64-unknown-unknown");
+  const std::vector<std::string> unsupported_extensions = {
+      "SPV_EXT_optnone", "SPV_EXT_arithmetic_fence", "SPV_EXT_hypthetical_name",
+      "SPV_KHR_uniform_group_instructions", "SPV_KHR_linkonce_odr"};
+
+  auto extensions =
+      RemoveUnsupportedExtensionsFromAll(target_triple, unsupported_extensions);
+  auto extensions_set =
+      std::set<std::string>(extensions.begin(), extensions.end());
+
+  EXPECT_EQ(extensions_set.find("SPV_EXT_optnone"), extensions_set.end());
+  EXPECT_EQ(extensions_set.find("SPV_EXT_arithmetic_fence"),
+            extensions_set.end());
+  EXPECT_EQ(extensions_set.find("SPV_EXT_hypthetical_name"),
+            extensions_set.end());
+  EXPECT_EQ(extensions_set.find("SPV_KHR_uniform_group_instructions"),
+            extensions_set.end());
+  EXPECT_EQ(extensions_set.find("SPV_KHR_linkonce_odr"), extensions_set.end());
+  EXPECT_NE(extensions_set.find("SPV_KHR_cooperative_matrix"),
+            extensions_set.end());
+  EXPECT_NE(extensions_set.find("SPV_EXT_shader_atomic_float_add"),
+            extensions_set.end());
+}
+
+}  // namespace
+}  // namespace xla::gpu::spirv


### PR DESCRIPTION
This PR adds support to block unsupported SPIRV extensions. The added function will filter out unsupported extensions from the full set of valid extensions for the default SPIRV target triple.
