### PR TITLE
[ROCm] Fix missing sys deps lib in hermetic builds

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -600,6 +600,9 @@ filegroup(
         "%{rocm_root}/lib/llvm/**",
         "%{rocm_root}/share/hip/**",
         "%{rocm_root}/amdgcn/**",
+        "%{rocm_root}/lib/rocm_sysdeps/lib/*.so*",
+        "%{rocm_root}/lib/libamd_comgr_loader.so*",
+        "%{rocm_root}/lib/libamd_comgr.so*",
     ]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
📝 Summary of Changes
Fix buildbreak on hermetic build pipeline

🎯 Justification
rocm clang++ missing syslibs when building kernels.
Providing sys deps target to the toolchain files fixes the issue.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
