### PR TITLE
[ROCm] Introduce rocm 7.11 dependency with support of all archs

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -289,7 +289,7 @@ common:rocm_ci --config=rocm
 
 common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_official
-common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_VERSION=rocm_7.10.0_gfx94X"
+common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_VERSION=rocm_7.10.0_gfx110X_all"
 common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.

--- a/third_party/gpus/rocm/rocm_redist.bzl
+++ b/third_party/gpus/rocm/rocm_redist.bzl
@@ -19,6 +19,16 @@ rocm_redist = {
         required_softlinks = [struct(target = "llvm/amdgcn", link = "amdgcn")],
         rocm_root = "",
     ),
+    "rocm_7.10.0_gfx110X_all": struct(
+        packages = [
+            {
+                "url": "https://rocm.nightlies.amd.com/tarball/therock-dist-linux-gfx110X-all-7.11.0a20251125.tar.gz",
+                "sha256": "9a307f098efccf8b5c449911ee65dd96a34928bf8733a128ef4dfa46641bb16b",
+            },
+        ],
+        required_softlinks = [struct(target = "llvm/amdgcn", link = "amdgcn")],
+        rocm_root = "",
+    ),
     "rocm_7.10.0_gfx94X_whl": struct(
         packages = [
             {


### PR DESCRIPTION
📝 Summary of Changes
Add rocm 7.11 as a hermetic dependency with support of all amd archs.

🎯 Justification
This support is required in rbe while rocm setup contains heterogeneous gpus
in their runners.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI tests, hermetic builds

🧪 Execution Tests:
CI tests, hermetic builds
