### PR TITLE
[ROCm] Fix ExtractThreadDims for AMD targets

### DIFF
--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -123,10 +123,6 @@ static void MakeLLIR(mlir::OpPassManager* pm,
                      const stream_executor::RocmComputeCapability& rocm_cc,
                      int num_stages) {
   const int custom_lds_size = 0;
-  // The `createTritonGPUAllocateWarpGroups` pass is not implemented in the
-  // upstream Triton, but is necessary for `ExtractThreadDims` in emitter
-  // helpers. It adds the `ttg.total-num-warps` attribute.
-  pm->addPass(mt::gpu::createTritonGPUAllocateWarpGroups());
   pm->addPass(mlir::triton::AMD::createOptimizeLDSUsagePass(
       rocm_cc.gfx_version(), custom_lds_size));
   pm->addPass(mlir::createSCFToControlFlowPass());

--- a/xla/backends/gpu/codegen/triton/lowering_util.cc
+++ b/xla/backends/gpu/codegen/triton/lowering_util.cc
@@ -50,6 +50,22 @@ absl::StatusOr<stream_executor::ThreadDim> ExtractThreadDims(
   if (!num_warps_attr) {
     return absl::InternalError("ttg.num-warps attribute not found.");
   }
+  // AMD/ROCm Triton backend does not support warp specialization.
+  // Consequently, `ttg.total-num-warps` and  `nvvm.reqntid` are not added
+  // to triton module/function.
+  // ThreadDim is therefore calculated from the Module attributes and not
+  // retrieved from `nvvm.reqntid`.
+  auto target = triton_module->getAttrOfType<mlir::StringAttr>("ttg.target");
+  if (!target) {
+    return absl::InternalError("ttg.target attribute not found.");
+  }
+  if (target.getValue().find("gfx") != std::string::npos) {
+    stream_executor::ThreadDim thread_dims(num_warps_attr.getInt() *
+                                            threads_per_warp_attr.getInt(),
+                                          1,
+                                          1);
+    return thread_dims;
+  }
   auto total_num_warps_attr =
       triton_module->getAttrOfType<mlir::IntegerAttr>("ttg.total-num-warps");
   if (!total_num_warps_attr) {


### PR DESCRIPTION
📝 Summary of Changes
AMD/ROCm Triton backend does not support warp specialization. `ThreadDims` are therefore calculated from module attributes and not retrieved from `nvvm.reqntid`.

🎯 Justification
As warp specialization is not currently supported by the AMD/ROCm Triton backend, this backend ignores the `nvvm.reqntid` attribute. Therefore, this attribute does not contain a correct value, as the currently Triton implementation assumes the number of threads per warp is always 32, which is not the case for some AMD targets (see https://github.com/triton-lang/triton/blob/49e174c6856aed1d36b85fb2b398ffaa32a80aa8/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp#L204C53-L204C68).
Consequently, the `ExtractThreadDims` has been adapted to calculate `ThreadDims` only based on attributes used and updated by the AMD triton backend.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Fixes failures of type:
```
xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc:4234: Failure
Value of: RunAndCompareNoHloPasses(kHloText, ErrorSpecForDotAlgorithm(algorithm))
 Actual: false (INTERNAL: Expected total threads as per reqntid attribute to be 32 but got 64 as per ttg.total-num-warps and tt.threads-per-warp attributes.)
Expected: true
```
for Triton Tests when targeting AMD GPUs.

🧪 Execution Tests:
Not relevant
