### PR TITLE
[ROCm] Use rocminfo instead of lspci as it will report all connected gpus ev…

### DIFF
--- a/build_tools/rocm/BUILD
+++ b/build_tools/rocm/BUILD
@@ -77,6 +77,9 @@ sh_binary(
 sh_binary(
     name = "parallel_gpu_execute",
     srcs = ["parallel_gpu_execute.sh"],
-    data = [":sanitizer_ignore_lists"],
+    data = [
+        ":sanitizer_ignore_lists",
+        "@local_config_rocm//rocm:rocminfo",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/build_tools/rocm/parallel_gpu_execute.sh
+++ b/build_tools/rocm/parallel_gpu_execute.sh
@@ -21,7 +21,8 @@
 # Required environment variables:
 #     TF_GPU_COUNT = Number of GPUs available.
 
-TF_GPU_COUNT=$(rocminfo | grep "Name: *gfx*" | wc -l)
+ROCMINFO=$(find "external/local_config_rocm/rocm/rocm_dist/" -name "rocminfo" -path "*/bin/rocminfo")
+TF_GPU_COUNT=$($ROCMINFO | grep "Name: *gfx*" | wc -l)
 TF_TESTS_PER_GPU=${TF_TESTS_PER_GPU:-8}
 
 # This function is used below in rlocation to check that a path is absolute

--- a/build_tools/rocm/parallel_gpu_execute.sh
+++ b/build_tools/rocm/parallel_gpu_execute.sh
@@ -21,7 +21,7 @@
 # Required environment variables:
 #     TF_GPU_COUNT = Number of GPUs available.
 
-TF_GPU_COUNT=$(lspci | grep -e 'controller' -e 'accelerators' | grep 'AMD/ATI' | wc -l)
+TF_GPU_COUNT=$(rocminfo | grep "Name: *gfx*" | wc -l)
 TF_TESTS_PER_GPU=${TF_TESTS_PER_GPU:-8}
 
 # This function is used below in rlocation to check that a path is absolute

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -92,9 +92,9 @@ cc_library(
     strip_include_prefix = "%{rocm_root}",
     visibility = ["//visibility:public"],
     deps = [
+        ":rocm_config",
         ":rocm_headers_includes",
         ":rocm_rpath",
-        ":rocm_config",
     ],
 )
 
@@ -244,8 +244,8 @@ cc_library(
     deps = [
         ":hipblaslt",
         ":rocm_config",
-        ":roctracer",
         ":rocm_rpath",
+        ":roctracer",
     ],
 )
 
@@ -611,6 +611,12 @@ filegroup(
 filegroup(
     name = "all_files",
     srcs = glob(["%{rocm_root}/**"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "rocminfo",
+    srcs = glob(["%{rocm_root}/bin/rocminfo"]),
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -616,7 +616,12 @@ filegroup(
 
 filegroup(
     name = "rocminfo",
-    srcs = ["%{rocm_root}/bin/rocminfo"],
+    srcs = glob([
+        "%{rocm_root}/bin/rocminfo",
+        "%{rocm_root}/lib/libhsa-runtime64.so*",
+        "%{rocm_root}/lib/rocm_sysdeps/lib/*",
+        "%{rocm_root}/lib/librocprofiler-register.so.0*",
+    ]),
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -616,7 +616,7 @@ filegroup(
 
 filegroup(
     name = "rocminfo",
-    srcs = glob(["%{rocm_root}/bin/rocminfo"]),
+    srcs = ["%{rocm_root}/bin/rocminfo"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
…en inside docker container

📝 Summary of Changes
Use rocminfo to detect number of gpus visible to xla

🎯 Justification
lspci will report all the gpus connected to bus
even inside the docker container with a limited visibility,
hence the number of available gpus will be invalid for 
the tests synchonization

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
