### PR TITLE
[ROCm] Make TmaPTX tests cuda specific

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1020,6 +1020,7 @@ xla_test(
         "//xla/runtime:buffer_use",
         "//xla/service:buffer_assignment",
         "//xla/service:executable",
+        "//xla/service:platform_util",
         "//xla/service/gpu:buffer_allocations",
         "//xla/service/gpu:launch_dimensions",
         "//xla/service/gpu/kernels:custom_kernel",

--- a/xla/backends/gpu/runtime/kernel_thunk_test.cc
+++ b/xla/backends/gpu/runtime/kernel_thunk_test.cc
@@ -43,6 +43,7 @@ limitations under the License.
 #include "xla/service/gpu/kernels/custom_kernel.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/service/service_executable_run_options.h"
+#include "xla/service/platform_util.h"
 #include "xla/shape_util.h"
 #include "xla/stream_executor/gpu/gpu_test_kernels.h"
 #include "xla/stream_executor/gpu/tma_metadata.h"
@@ -427,8 +428,13 @@ class KernelThunkTmaPTXTest : public ::testing::TestWithParam<bool> {
 };
 
 TEST_P(KernelThunkTmaPTXTest, TmaPTX) {
+  auto name = absl::AsciiStrToUpper(
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
+  if (name == "ROCM") {
+    GTEST_SKIP() << "TmaPTX cannot run on ROCm.";
+  }
   TF_ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                          se::PlatformManager::PlatformWithName("cuda"));
+                          se::PlatformManager::PlatformWithName(name));
   TF_ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor,
                           platform->ExecutorForDevice(0));
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Stream> stream,


### PR DESCRIPTION
📝 Summary of Changes
PTX tests are cuda specific and skip them on ROCm platform



🚀 Kind of Contribution
🐛 Bug Fix, 



🧪 Execution Tests:
//xla/backends/gpu/runtime:kernel_thunk_test.cc
