### PR TITLE
[ROCm][XLA:GPU] Fuse shmem write loops for transposes in PackedTranspose

### DIFF
--- a/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_multiple_heroes.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/transpose/packed_transpose_multiple_heroes.hlo
@@ -17,4 +17,14 @@
    ROOT tuple = (f16[16,512,64], f16[1024,512], f16[16,512,64], f16[16,512,64])
      tuple(transpose1, slice2, transpose2, transpose3)
  }
-// CHECK-COUNT-2:  xla_gpu.allocate_shared : tensor<64x64xf16>
+// Capture the three allocated shared memory tensors in order and verify
+// the unified loop structure: one xla.loop that takes all 3 shmem tensors
+// as iter_args and yields 3 results (one per transpose).
+// CHECK:  [[SHMEM0:%.*]] = xla_gpu.allocate_shared : tensor<64x64xf16>
+// CHECK:  [[SHMEM1:%.*]] = xla_gpu.allocate_shared : tensor<64x64xf16>
+// CHECK:  [[SHMEM2:%.*]] = xla_gpu.allocate_shared : tensor<64x64xf16>
+// CHECK:  xla.loop
+// CHECK-SAME:  iter_args(%{{.*}} = [[SHMEM0]], %{{.*}} = [[SHMEM1]], %{{.*}} = [[SHMEM2]])
+// CHECK-SAME:  -> (tensor<64x64xf16>, tensor<64x64xf16>, tensor<64x64xf16>)
+// CHECK:  xla.yield
+// CHECK-SAME:  tensor<64x64xf16>, tensor<64x64xf16>, tensor<64x64xf16>

--- a/xla/backends/gpu/codegen/emitters/transpose.cc
+++ b/xla/backends/gpu/codegen/emitters/transpose.cc
@@ -650,48 +650,55 @@ PackedTranspose::WriteResult PackedTranspose::EmitWriteToShMemMlir(
   IndexingMap shmem_write_indexing = GetShmemWriteIndexing(mlir_context_);
 
   int64_t shmem_dim = kNumShmemBanks * vector_size_;
-  SmallVector<Value> shmem_tensors;
+
+  // Allocate all shared memory tensors upfront (one per transpose).
+  SmallVector<Value> shmem_inits;
   for (auto* transpose : shmem_transposes_) {
     Type elem_type = emitters::PrimitiveTypeToMlirType(
         transpose->shape().element_type(), builder);
     Value shmem = AllocateSharedOp::create(
         builder, RankedTensorType::get({shmem_dim, shmem_dim}, elem_type));
-
-    auto tids_and_bids = EmitThreadAndBlockIds(builder);
-    Value updated_shmem =
-        emitters::EmitXlaLoopOp(
-            builder, tids_and_bids, shmem, input_indexing,
-            [&](ImplicitLocOpBuilder& nested_b, ValueRange ivs,
-                ValueRange input_indices,
-                ValueRange iter_arg) -> SmallVector<Value> {
-              ValueRange indices = input_indices;
-              SmallVector<Value> indices_storage;
-              if (!ShapeUtil::SameDimensions(transpose->operand(0)->shape(),
-                                             spec_.original_input_shape())) {
-                auto map = GetBitcastMap(spec_.original_input_shape(),
-                                         transpose->operand(0)->shape(),
-                                         mlir_context_);
-                indices_storage =
-                    emitters::ApplyIndexing(map, input_indices, {}, nested_b);
-                indices = indices_storage;
-              }
-
-              Value input_element =
-                  emitters::ProvideParameter(root_computation, transpose,
-                                             /*operand_index=*/0, indices,
-                                             call_target_provider,
-                                             entry_function, nested_b)
-                      .front();
-              auto shmem_indices = emitters::ApplyIndexing(
-                  shmem_write_indexing, tids_and_bids, ivs, nested_b);
-              return nested_b
-                  .create<mt::InsertOp>(input_element, iter_arg.front(),
-                                        shmem_indices)
-                  ->getResults();
-            })
-            .front();
-    shmem_tensors.push_back(updated_shmem);
+    shmem_inits.push_back(shmem);
   }
+
+  // Create a single loop that writes to all shared memory tensors.
+  auto tids_and_bids = EmitThreadAndBlockIds(builder);
+  SmallVector<Value> shmem_tensors = emitters::EmitXlaLoopOp(
+      builder, tids_and_bids, shmem_inits, input_indexing,
+      [&](ImplicitLocOpBuilder& nested_b, ValueRange ivs,
+          ValueRange input_indices,
+          ValueRange iter_args) -> SmallVector<Value> {
+        SmallVector<Value> updated_shmems;
+        auto shmem_indices = emitters::ApplyIndexing(
+            shmem_write_indexing, tids_and_bids, ivs, nested_b);
+
+        // Process all transposes in a single loop iteration.
+        for (auto [transpose, shmem_tensor] :
+             llvm::zip(shmem_transposes_, iter_args)) {
+          // Compute bitcasted indices for this specific transpose if needed.
+          ValueRange indices = input_indices;
+          SmallVector<Value> indices_storage;
+          if (!ShapeUtil::SameDimensions(transpose->operand(0)->shape(),
+                                         spec_.original_input_shape())) {
+            auto map = GetBitcastMap(spec_.original_input_shape(),
+                                     transpose->operand(0)->shape(),
+                                     mlir_context_);
+            indices_storage =
+                emitters::ApplyIndexing(map, input_indices, {}, nested_b);
+            indices = indices_storage;
+          }
+
+          Value input_element =
+              emitters::ProvideParameter(root_computation, transpose,
+                                         /*operand_index=*/0, indices,
+                                         call_target_provider, entry_function,
+                                         nested_b)
+                  .front();
+          updated_shmems.push_back(nested_b.create<mt::InsertOp>(
+              input_element, shmem_tensor, shmem_indices));
+        }
+        return updated_shmems;
+      });
 
   // Produce all side outputs and then write them.
   int num_inputs = fusion.fused_instructions_computation()->num_parameters();


### PR DESCRIPTION
Replace per-transpose loops with a single unified loop that processes all transposes simultaneously, computing indices once and reusing them across all operations.

Update `packed_transpose_multiple_heroes.hlo` test to verify the single-loop structure with multiple iter_args.

It reduces the execution time for `fused_convert_transpose_3.hlo` ([attached](https://github.com/user-attachments/files/23861262/fused_convert_transpose_3.txt)) from Llama 3 8B FP8 by ~30% for MI300 and MI355. 

