### PR TITLE
Enable the use of tcgen05 instructions on Thor by Triton pass

### DIFF
--- a/third_party/triton/temporary/series.bzl
+++ b/third_party/triton/temporary/series.bzl
@@ -14,5 +14,6 @@ those to this list.
 """
 
 temporary_patch_list = [
+    "//third_party/triton:temporary/thor_support.patch",
     # Add new patches just above this line
 ]

--- a/third_party/triton/temporary/thor_support.patch
+++ b/third_party/triton/temporary/thor_support.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+index 3b14c6f6b..028608fd1 100644
+--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
++++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+@@ -39,7 +39,7 @@ static int getMMAVersionSafe(int computeCapability, DotOp op) {
+     versionsSupported = {2};
+   } else if (computeCapability < 100) {
+     versionsSupported = {3, 2};
+-  } else if (computeCapability < 110) {
++  } else if (computeCapability < 120) {
+     versionsSupported = {5, 2};
+   } else if (computeCapability < 130) {
+     versionsSupported = {2};
+@@ -804,7 +804,7 @@ public:
+     auto retShapePerCTA = getShapePerCTA(oldRetType);
+     int numWarps = lookupNumWarps(dotOp);
+     auto CTALayout = getCTALayout(oldRetType.getEncoding());
+-    if ((computeCapability) / 10 != 10)
++    if ((computeCapability) / 10 < 10 || (computeCapability) / 10 > 11)
+       return failure();
+     if (numWarps != 4 && numWarps != 8)
+       return failure();


### PR DESCRIPTION
📝 Summary of Changes

This PR fixes a failure in `//xla/backends/gpu/codegen/triton:fusion_emitter_device_test_b200` on Thor devices (`sm110`). The failure occurs because the Triton pass responsible for enabling the `tcgen05` instruction (`mxf8f6f4.block_scale.scale_vec::1X`) was not previously enabled for the `sm110` architecture.

🎯 Justification for implementing in XLA vs. Triton

While this logic ideally belongs in the Triton repo, we are implementing it in XLA for the following reasons:
- Support for `sm110` was introduced in [PTX ISA 9.0](https://docs.nvidia.com/cuda/parallel-thread-execution/#changes-in-ptx-isa-version-9-0), which relies on CUDA 13.0.
- Upstream Triton [does not yet support CUDA 13.0](https://github.com/triton-lang/triton/blob/main/cmake/nvidia-toolchain-version.json), and support may not land in the immediate future.
- We want to ensure XLA is fully functional on Thor devices irrespective of the Triton status.

We prefer to upstream this patch to ensure Thor is fully supported rather than keeping it in an internal development branch.