### PR TITLE
Preserve existing backend config in WhileLoopTripCountAnnotator

### DIFF
--- a/xla/hlo/transforms/while_loop_trip_count_annotator.cc
+++ b/xla/hlo/transforms/while_loop_trip_count_annotator.cc
@@ -44,6 +44,13 @@ absl::StatusOr<bool> WhileLoopTripCountAnnotator::RunImpl(
         // The following analyses all need the induction variable index.
         WhileLoopBackendConfig config;
 
+        // Preserve existing backend config data
+        if (auto existing_config =
+                instr->backend_config<WhileLoopBackendConfig>();
+            existing_config.ok()) {
+          config = *existing_config;
+        }
+
         config.mutable_known_induction_variable()->set_tuple_index(
             *induction_variable_index);
         if (auto range = MatchTrivialLoopRange(instr);


### PR DESCRIPTION
📝 Summary of Changes
This PR fixes a bug in WhileLoopTripCountAnnotator where it would overwrite the entire WhileLoopBackendConfig, causing loss of data set by previous passes.

🎯 Justification
Previously, WhileLoopTripCountAnnotator would overwrite the entire WhileLoopBackendConfig when setting trip count and induction variable information. This caused loss of any previously set backend config data.

This change preserves existing backend config fields by reading the current config first before adding new trip count annotations. This is important for passes that set backend config before this annotator runs, such as CollectivePipeliner which may set dynamic variable information.

Without this fix, dynamic variable tuple indices would be lost, breaking optimizations like FusionDynamicMemcpyRewriter that depend on this data.

🚀 Kind of Contribution
 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A (split from https://github.com/openxla/xla/pull/32297)

🧪 Unit Tests:
N/A (split from https://github.com/openxla/xla/pull/32297)

🧪 Execution Tests:
N/A (split from https://github.com/openxla/xla/pull/32297)
