### PR TITLE
[onednn] Update onednn custom call name

### DIFF
--- a/xla/backends/cpu/runtime/onednn/onednn_op_thunk.cc
+++ b/xla/backends/cpu/runtime/onednn/onednn_op_thunk.cc
@@ -126,6 +126,8 @@ OneDnnOpThunk::OneDnnRuntime::Invoke(
 absl::StatusOr<std::unique_ptr<OneDnnOpThunk>> OneDnnOpThunk::Create(
     const std::string& custom_call_target, Info info, OpBuffers buffers,
     OneDnnOpConfig config) {
+  // Update custom_call op_name with target
+  info.op_name = absl::StrCat(info.op_name, custom_call_target);
   return absl::WrapUnique(new OneDnnOpThunk(std::move(custom_call_target),
                                             std::move(info), std::move(buffers),
                                             std::move(config)));


### PR DESCRIPTION
📝 Summary of Changes
Update custom_call op_name with target to easily differentiate diff onednn custom ops.

🎯 Justification
This will help debugging and viewing the ops in profile traceview. So, instead of `custom-call.2993.clone` it will show as `custom-call.2993.clone__onednn$matmul`. It will be easier to view the timeline trace.

📊 Benchmark (for Performance Improvements)
This doesn't affect performance.
