### PR TITLE
[XLA:GPU] make DYNAMIC_SLICE_COPY_FUSION command default lowered to cuda-graph

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -244,6 +244,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUSTOM_CALL);
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUDNN);
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::DYNAMIC_SLICE_FUSION);
+  opts.add_xla_gpu_enable_command_buffer(
+      DebugOptions::DYNAMIC_SLICE_COPY_FUSION);
   opts.set_xla_gpu_graph_min_graph_size(5);
   opts.set_xla_gpu_command_buffer_scheduling_mode(DebugOptions::LHS);
   opts.set_xla_gpu_command_buffer_unroll_loops(false);

--- a/xla/debug_options_parsers_test.cc
+++ b/xla/debug_options_parsers_test.cc
@@ -393,12 +393,13 @@ TEST(ParseRepeatedEnumFlagsTest, CommandBufferCmdType) {
 
   // Check that the default setting has 6 types.
   const auto& enabled_types = debug_options.xla_gpu_enable_command_buffer();
-  ASSERT_EQ(enabled_types.size(), 6);
+  ASSERT_EQ(enabled_types.size(), 7);
   ASSERT_THAT(
       enabled_types,
       ElementsAre(DebugOptions::FUSION, DebugOptions::CUBLAS,
                   DebugOptions::CUBLASLT, DebugOptions::CUSTOM_CALL,
-                  DebugOptions::CUDNN, DebugOptions::DYNAMIC_SLICE_FUSION));
+                  DebugOptions::CUDNN, DebugOptions::DYNAMIC_SLICE_FUSION,
+                  DebugOptions::DYNAMIC_SLICE_COPY_FUSION));
 
   // Initialize the flag objects.
   std::vector<tsl::Flag> flag_objects;
@@ -407,29 +408,32 @@ TEST(ParseRepeatedEnumFlagsTest, CommandBufferCmdType) {
   // Removing options from the existing setting.
   SetXlaFlagsEnvVar("--xla_gpu_enable_command_buffer=-fusion,-cublas");
   ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", flag_objects);
-  EXPECT_EQ(enabled_types.size(), 4);
+  EXPECT_EQ(enabled_types.size(), 5);
   EXPECT_THAT(
       enabled_types,
       ElementsAre(DebugOptions::CUBLASLT, DebugOptions::CUSTOM_CALL,
-                  DebugOptions::CUDNN, DebugOptions::DYNAMIC_SLICE_FUSION));
+                  DebugOptions::CUDNN, DebugOptions::DYNAMIC_SLICE_FUSION,
+                  DebugOptions::DYNAMIC_SLICE_COPY_FUSION));
 
   // Removing an option that isn't there and adding a duplicate.
   SetXlaFlagsEnvVar("--xla_gpu_enable_command_buffer=+cublaslt,-fusion");
-  ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", flag_objects);
-  EXPECT_EQ(enabled_types.size(), 4);
-  EXPECT_THAT(
-      enabled_types,
-      ElementsAre(DebugOptions::CUBLASLT, DebugOptions::CUSTOM_CALL,
-                  DebugOptions::CUDNN, DebugOptions::DYNAMIC_SLICE_FUSION));
-
-  // Adding an option.
-  SetXlaFlagsEnvVar("--xla_gpu_enable_command_buffer=+cublas");
   ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", flag_objects);
   EXPECT_EQ(enabled_types.size(), 5);
   EXPECT_THAT(
       enabled_types,
       ElementsAre(DebugOptions::CUBLASLT, DebugOptions::CUSTOM_CALL,
                   DebugOptions::CUDNN, DebugOptions::DYNAMIC_SLICE_FUSION,
+                  DebugOptions::DYNAMIC_SLICE_COPY_FUSION));
+
+  // Adding an option.
+  SetXlaFlagsEnvVar("--xla_gpu_enable_command_buffer=+cublas");
+  ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", flag_objects);
+  EXPECT_EQ(enabled_types.size(), 6);
+  EXPECT_THAT(
+      enabled_types,
+      ElementsAre(DebugOptions::CUBLASLT, DebugOptions::CUSTOM_CALL,
+                  DebugOptions::CUDNN, DebugOptions::DYNAMIC_SLICE_FUSION,
+                  DebugOptions::DYNAMIC_SLICE_COPY_FUSION,
                   DebugOptions::CUBLAS));
 
   // Overwriting the default setting.


### PR DESCRIPTION
📝 Summary of Changes

* Added `DebugOptions::DYNAMIC_SLICE_COPY_FUSION` to the list of enabled GPU command buffers in the default debug options.



🚀 Kind of Contribution
⚡️ Performance Improvement



🧪 Unit Tests:
change the default setting, unittest has already been added.
