### PR TITLE
[ROCm] Split multigpu and singlegpu tests execution for nightly

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -34,6 +34,17 @@ build:asan --test_env=LSAN_OPTIONS=suppressions=build_tools/rocm/lsan_ignore_lis
 build:asan --//build_tools/rocm:sanitizer=asan
 build:asan --run_under=//build_tools/rocm:sanitizer_wrapper
 
+build:ci_single_gpu --run_under=//build_tools/rocm:parallel_gpu_execute
+build:ci_single_gpu --flaky_test_attempts=3
+
+build:ci_multi_gpu --action_env=XLA_FLAGS="--xla_gpu_force_compilation_parallelism=16 --xla_gpu_enable_llvm_module_compilation_parallelism=true"
+build:ci_multi_gpu --action_env=NCCL_MAX_NCHANNELS=1
+build:ci_multi_gpu --run_under=//build_tools/rocm:sanitizer_wrapper
+build:ci_multi_gpu --test_sharding_strategy=disabled
+build:ci_multi_gpu --flaky_test_attempts=3
+build:ci_multi_gpu --experimental_guard_against_concurrent_changes
+build:ci_multi_gpu --test_env=HIP_VISIBLE_DEVICES=0,1,2,3
+
 test:xla_sgpu -- \
 //xla/... \
 -//xla/backends/gpu/collectives:gpu_clique_key_test \

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -19,11 +19,18 @@ set -e
 set -x
 
 SCRIPT_DIR=$(realpath $(dirname $0))
-TAG_FILTERS=$($SCRIPT_DIR/rocm_tag_filters.sh),gpu,requires-gpu-amd,,-skip_rocprofiler_sdk,-no_oss,-oss_excluded,-oss_serial
+TAG_FILTERS=$($SCRIPT_DIR/rocm_tag_filters.sh),-skip_rocprofiler_sdk,-no_oss,-oss_excluded,-oss_serial
 
-if [ ! -d /tf/pkg ]; then
-	mkdir -p /tf/pkg
-fi
+mkdir -p /tf/pkg
+
+for arg in "$@"; do
+    if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
+        TAG_FILTERS="${TAG_FILTERS},multi_gpu"
+    fi
+    if [[ "$arg" == "--config=ci_single_gpu" ]]; then
+        TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu"
+    fi
+done
 
 SCRIPT_DIR=$(dirname $0)
 bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \


### PR DESCRIPTION
📝 Summary of Changes
Support split of test execution by using ci_multi_gpu and
ci_single_gpu configs.

🎯 Justification
This change is required for rocm internal nightly build because
multigpu tests shall be executed separately from the singlegpu tests
to avoid clashes and use different run_under script which will not hide
all the gpus.

🚀 Kind of Contribution
Please remove what does not apply:  ♻️ Cleanup, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
