### PR TITLE
[XLA:GPU] Add buffer type information for GpuExecutable memory allocation profile

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -1061,7 +1061,14 @@ absl::Status GpuExecutable::ExecuteThunks(
         }
         module_allocations_[executor][i] =
             buffer_allocations.GetDeviceAddress(i);
-        VLOG(5) << "Gpu address changed for module " << module_name_;
+        const BufferAllocation& allocation =
+            buffer_assignment_->GetAllocation(i);
+        const char* allocation_type =
+            allocation.is_entry_computation_parameter() ? "parameter"
+            : allocation.maybe_live_out()               ? "live-out"
+                                                        : "temp";
+        VLOG(5) << "Gpu address changed for module " << module_name_
+                << ", allocation " << i << " (" << allocation_type << ")";
       }
     }
   }


### PR DESCRIPTION
📝 Summary of Changes
Add buffer type information for GpuExecutable memory allocation profile 

🎯 Justification
Give us some insights on which allocation is frequently changed, and useful for command buffer optimization. 

🚀 Kind of Contribution
 📚 Documentation
