### PR TITLE
[ROCm] fix the calling convention for AMD GPU

### DIFF
--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -664,6 +664,7 @@ lit_test_suite_for_gpus(
             "slice_to_dynamic.hlo",
             "sorting.hlo",
             "sub_byte_collectives.hlo",
+            "triton_calling_convention.hlo",
             "triton_naming.hlo",
             "zero_clamp_abs_index.hlo",
         ],
@@ -676,10 +677,12 @@ lit_test_suite_for_gpus(
     disabled_on_gpus = {
         "v100": [
             "kernel_reuse.hlo",
+            "triton_calling_convention.hlo",
             "triton_naming.hlo",
         ],
         "p100": [
             "kernel_reuse.hlo",
+            "triton_calling_convention.hlo",
             "triton_naming.hlo",
         ],
         "mi200": [

--- a/xla/service/gpu/tests/triton_calling_convention.hlo
+++ b/xla/service/gpu/tests/triton_calling_convention.hlo
@@ -1,0 +1,26 @@
+// RUN: hlo-opt %s --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/%{GPU}.txtpb | FileCheck --check-prefixes=CHECK-%{PTX} %s
+
+// Verify that Triton kernels have the correct calling convention:
+// - PTX_KERNEL (71) for NVIDIA targets
+// - AMDGPU_KERNEL (91) for AMD targets
+// CHECK-PTX: define ptx_kernel void @triton_
+// CHECK-GCN: define amdgpu_kernel void @triton_
+
+HloModule TritonCallingConvention, is_scheduled=true
+
+triton_softmax {
+  param_0 = f32[4,4]{1,0} parameter(0)
+  ROOT exp = f32[4,4]{1,0} exponential(param_0)
+}
+
+ENTRY main {
+  param_0 = f32[4,4]{1,0} parameter(0)
+  ROOT triton_softmax = f32[4,4]{1,0} fusion(param_0), kind=kCustom,
+    calls=triton_softmax,
+    backend_config={"fusion_backend_config":{
+      "kind":"__triton",
+      "block_level_fusion_config":{"output_tiles":[{"sizes":["4","4"]}],
+                                   "num_warps":"1",
+                                   "num_ctas":"1",
+                                   "num_stages":"1"}}}
+}


### PR DESCRIPTION
Bugfix: PR #34230 ("argument removal without building prototype") removed the call to **BuildKernelPrototypeFromUniqueName** which internally called **AnnotateFunctionAsGpuKernel** to set the correct calling convention based on the target GPU. Without this, Triton's **PTX_Kernel** calling convention was copied directly, which doesn't work on AMD GPUs and lead to "LLVM ERROR: unsupported calling convention".

Fix: Added a call to **AnnotateFunctionAsGpuKernel** in **RemoveUnusedTritonAbiArguments** to properly set:

PTX_Kernel (71) for NVIDIA
AMDGPU_KERNEL (91) for AMD
SPIR_KERNEL (76) for SPIR

@xla-rotation could you review my PR, please?