### PR TITLE
[ROCm] Fix //xla/service/gpu/tests:pad_to_static.hlo.test_mi200 on rbe, miss…

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -92,9 +92,9 @@ cc_library(
     strip_include_prefix = "%{rocm_root}",
     visibility = ["//visibility:public"],
     deps = [
+        ":rocm_config",
         ":rocm_headers_includes",
         ":rocm_rpath",
-        ":rocm_config",
     ],
 )
 
@@ -112,6 +112,7 @@ cc_library(
         ":miopen",
         ":rocblas",
         ":rocm_config",
+        ":rocm_smi",
         ":rocprofiler_register",
         ":rocsolver",
         ":rocsparse",
@@ -191,7 +192,6 @@ cc_library(
         ":amd_comgr",
         ":hsa_rocr",
         ":rocm_config",
-        ":rocm_smi",
         ":rocprofiler_register",
         ":system_libs",
     ],
@@ -244,8 +244,8 @@ cc_library(
     deps = [
         ":hipblaslt",
         ":rocm_config",
-        ":roctracer",
         ":rocm_rpath",
+        ":roctracer",
     ],
 )
 
@@ -324,7 +324,6 @@ cc_library(
     includes = [
         "%{rocm_root}/include",
     ],
-    linkopts = ["-lnuma"],
     linkstatic = 1,
     strip_include_prefix = "%{rocm_root}",
     visibility = ["//visibility:public"],
@@ -560,20 +559,29 @@ cc_library(
 
 cc_library(
     name = "rocm_smi",
-    srcs = glob([
-        "%{rocm_root}/lib/librocm_smi64.so*",
-        "%{rocm_root}/lib/libroam.so*",
-    ]),
     hdrs = glob([
         "%{rocm_root}/include/oam/**",
         "%{rocm_root}/include/rocm_smi/**",
+    ]),
+    data = glob([
+        "%{rocm_root}/lib/librocm_smi64.so*",
+        "%{rocm_root}/lib/libroam.so*",
     ]),
     include_prefix = "rocm",
     includes = [
         "%{rocm_root}/include",
     ],
+    linkopts = select({
+        ":build_hermetic": [
+            "-lrocm_smi64.so",
+        ],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "%{rocm_root}",
-    deps = [":rocm_config"],
+    deps = [
+        ":rocm_config",
+        ":rocm_rpath",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
📝 Summary of Changes
Fixing //xla/service/gpu/tests:pad_to_static.hlo.test_mi200 test 
when executed through rbe with rocm configuration.

🎯 Justification
We get this error.
```
[2025-12-04T08:39:01.132Z] FAIL: XLA :: service/gpu/tests/with_xla_gpu_cuda_data_dir_mi200_pad_to_static.hlo (1 of 1)
[2025-12-04T08:39:01.132Z] ******************** TEST 'XLA :: service/gpu/tests/with_xla_gpu_cuda_data_dir_mi200_pad_to_static.hlo' FAILED ********************
[2025-12-04T08:39:01.132Z] Script:
[2025-12-04T08:39:01.132Z] --
[2025-12-04T08:39:01.132Z] : 'RUN: at line 1';   hlo-opt /var/cache/engflow/worker/work/34/exec/bazel-out/k8-opt/bin/xla/service/gpu/tests/pad_to_static.hlo.test_mi200.runfiles/xla/xla/service/gpu/tests/with_xla_gpu_cuda_data_dir_mi200_pad_to_static.hlo --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=/var/cache/engflow/worker/work/34/exec/bazel-out/k8-opt/bin/xla/service/gpu/tests/pad_to_static.hlo.test_mi200.runfiles/xla/xla/service/gpu/tests/../../../tools/hlo_opt/gpu_specs/mi200.txtpb | FileCheck --check-prefixes=CHECK,CHECK-GCN /var/cache/engflow/worker/work/34/exec/bazel-out/k8-opt/bin/xla/service/gpu/tests/pad_to_static.hlo.test_mi200.runfiles/xla/xla/service/gpu/tests/with_xla_gpu_cuda_data_dir_mi200_pad_to_static.hlo
[2025-12-04T08:39:01.132Z] --
[2025-12-04T08:39:01.132Z] Exit Code: 2
[2025-12-04T08:39:01.132Z] 
[2025-12-04T08:39:01.132Z] Command Output (stderr):
[2025-12-04T08:39:01.132Z] --
[2025-12-04T08:39:01.132Z] hlo-opt: error while loading shared libraries: librocm_smi64.so.1: cannot open shared object file: No such file or directory
[2025-12-04T08:39:01.132Z] FileCheck error: '<stdin>' is empty.
[2025-12-04T08:39:01.132Z] FileCheck command line:  FileCheck --check-prefixes=CHECK,CHECK-GCN /var/cache/engflow/worker/work/34/exec/bazel-out/k8-opt/bin/xla/service/gpu/tests/pad_to_static.hlo.test_mi200.runfiles/xla/xla/service/gpu/tests/with_xla_gpu_cuda_data_dir_mi200_pad_to_static.hlo
```

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant, only build is affected

🧪 Unit Tests:
Not relevant, only build is affected

🧪 Execution Tests:
Not relevant, only build is affected