### PR TITLE
[xla:emitters][oneAPI] Enable math.log1p in MathToLLVMConversionPatterns

### DIFF
--- a/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
+++ b/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
@@ -1,0 +1,15 @@
+// RUN: emitters_opt %s --split-input-file \
+// RUN:   --xla-lower-to-llvm-gpu="gpu_device_info='oneapi_compute_capability { architecture: \"bmg\"}'" \
+// RUN: | FileCheck %s
+
+module {
+  // CHECK-LABEL: func @test_log1p
+  func.func @test_log1p(%arg0: f32) -> f32 {
+    // CHECK: %[[ONE:.*]] = llvm.mlir.constant(1.000000e+00 : f32) : f32
+    // CHECK: %[[ADD:.*]] = llvm.fadd %[[ONE]], %arg0 : f32
+    // CHECK: %[[LOG:.*]] = llvm.intr.log(%[[ADD]]) : (f32) -> f32
+    // CHECK: return %[[LOG]] : f32
+    %0 = math.log1p %arg0 : f32
+    return %0 : f32
+  }
+}

--- a/xla/codegen/emitters/transforms/lower_to_llvm_common.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_common.cc
@@ -47,7 +47,8 @@ mlir::LogicalResult LowerToLLVM(
     absl::FunctionRef<mlir::LogicalResult(mlir::LLVMTypeConverter&,
                                           mlir::RewritePatternSet&,
                                           mlir::ConversionTarget&)>
-        populate_platform_patterns) {
+        populate_platform_patterns,
+    bool lower_math_log1p) {
   // Populate type conversions.
   mlir::LowerToLLVMOptions llvm_opts(op.getContext(), mlir::DataLayout(op));
   mlir::LLVMTypeConverter type_converter(op.getContext(), llvm_opts);
@@ -82,7 +83,7 @@ mlir::LogicalResult LowerToLLVM(
   // Clean up any leftover math ops.
   mlir::RewritePatternSet mathPatterns(op.getContext());
   mlir::populateMathToLLVMConversionPatterns(type_converter, mathPatterns,
-                                             /*approximateLog1p=*/false);
+                                             lower_math_log1p);
   target.addIllegalDialect<mlir::math::MathDialect>();
 
   if (mlir::failed(applyFullConversion(op, target, std::move(mathPatterns)))) {

--- a/xla/codegen/emitters/transforms/lower_to_llvm_common.h
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_common.h
@@ -32,7 +32,8 @@ mlir::LogicalResult LowerToLLVM(
                                           mlir::ConversionTarget&)>
         populate_platform_patterns =
             [](mlir::LLVMTypeConverter&, mlir::RewritePatternSet&,
-               mlir::ConversionTarget&) { return mlir::success(); });
+               mlir::ConversionTarget&) { return mlir::success(); },
+    bool lower_math_log1p = false);
 
 }  // namespace emitters
 }  // namespace xla

--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -123,7 +123,12 @@ class LowerToLLVMGPUPass
       return mlir::success();
     };
 
-    if (mlir::failed(LowerToLLVM(getOperation(), populate_patterns))) {
+    // NVVM and ROCDL lower math.log1p directly via their GPU pattern sets, but
+    // the SPIR-V pipeline does not. For Intel GPUs we therefore fall back to
+    // the generic MathToLLVM conversion, hence enabling approximate log1p.
+    if (mlir::failed(
+            LowerToLLVM(getOperation(), populate_patterns,
+                        /* approximateLog1p */ device_spec_.IsIntelGpu()))) {
       signalPassFailure();
     }
   }

--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -126,9 +126,9 @@ class LowerToLLVMGPUPass
     // NVVM and ROCDL lower math.log1p directly via their GPU pattern sets, but
     // the SPIR-V pipeline does not. For Intel GPUs we therefore fall back to
     // the generic MathToLLVM conversion, hence enabling approximate log1p.
+    bool lower_math_log1p = device_spec_.IsIntelGpu();
     if (mlir::failed(
-            LowerToLLVM(getOperation(), populate_patterns,
-                        /* approximateLog1p */ device_spec_.IsIntelGpu()))) {
+            LowerToLLVM(getOperation(), populate_patterns, lower_math_log1p))) {
       signalPassFailure();
     }
   }

--- a/xla/codegen/tools/emitters_opt.cc
+++ b/xla/codegen/tools/emitters_opt.cc
@@ -41,6 +41,7 @@ limitations under the License.
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
+#include "stablehlo/dialect/StablehloOps.h"
 #include "xla/backends/cpu/codegen/emitters/ir/xla_cpu_dialect.h"
 #include "xla/backends/cpu/codegen/emitters/transforms/passes.h"
 #include "xla/backends/cpu/codegen/tiled/transforms/passes.h"
@@ -55,7 +56,6 @@ limitations under the License.
 #include "xla/codegen/xtile/ir/xtile_dialect.h"
 #include "xla/mlir_hlo/mhlo/IR/hlo_ops.h"
 #include "xla/service/gpu/gpu_device_info_for_tests.h"
-#include "stablehlo/dialect/StablehloOps.h"
 
 int main(int argc, char** argv) {
   mlir::DialectRegistry registry;

--- a/xla/codegen/tools/emitters_opt.cc
+++ b/xla/codegen/tools/emitters_opt.cc
@@ -41,7 +41,6 @@ limitations under the License.
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
-#include "stablehlo/dialect/StablehloOps.h"
 #include "xla/backends/cpu/codegen/emitters/ir/xla_cpu_dialect.h"
 #include "xla/backends/cpu/codegen/emitters/transforms/passes.h"
 #include "xla/backends/cpu/codegen/tiled/transforms/passes.h"
@@ -49,12 +48,14 @@ limitations under the License.
 #include "xla/backends/gpu/codegen/emitters/ir/xla_gpu_ops.h"
 #include "xla/backends/gpu/codegen/emitters/transforms/passes.h"
 #include "xla/codegen/emitters/ir/xla_dialect.h"
+#include "xla/codegen/emitters/transforms/lower_to_llvm_gpu.h"
 #include "xla/codegen/emitters/transforms/pass_pipelines.h"
 #include "xla/codegen/emitters/transforms/passes.h"
 #include "xla/codegen/xtile/ir/transforms/passes.h"
 #include "xla/codegen/xtile/ir/xtile_dialect.h"
 #include "xla/mlir_hlo/mhlo/IR/hlo_ops.h"
 #include "xla/service/gpu/gpu_device_info_for_tests.h"
+#include "stablehlo/dialect/StablehloOps.h"
 
 int main(int argc, char** argv) {
   mlir::DialectRegistry registry;
@@ -73,6 +74,7 @@ int main(int argc, char** argv) {
   mlir::registerCSEPass();
   mlir::registerInliner();
   xla::emitters::registerTransformsPasses();
+  xla::emitters::registerTransformsLLVMGPUPasses();
   xla::gpu::registerGpuFusionTransformsPasses();
   xla::cpu::registerXlaCpuTransformsPasses();
   xla::cpu::registerXTileCpuTransformsPasses();


### PR DESCRIPTION
📝 Summary of Changes
This PR fixes lowering `mlir::math::Log1pOp` on Intel GPU targets. The NVVM and ROCDL lower math.log1p directly via their GPU pattern sets, but he SPIR-V pipeline does not. For Intel GPUs we therefore enable approximate log1p option in the generic MathToLLVM conversion.

🚀 Kind of Contribution: 🐛 Bug Fix

🧪 Unit Tests:
Added the following lit test: `xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir`
