### PR TITLE
[XLA:GPU] Enable deterministic scatter for batched operations

### DIFF
--- a/xla/tests/scatter_test.cc
+++ b/xla/tests/scatter_test.cc
@@ -1050,11 +1050,6 @@ ENTRY main {
 }
 
 TEST_F(ScatterTest, Scatter_Add_F32) {
-  if (GetDebugOptionsForTest().xla_gpu_enable_scatter_determinism_expander() &&
-      GetDebugOptionsForTest().xla_gpu_deterministic_ops()) {
-    // TODO(b/443204632): Re-enable this test.
-    GTEST_SKIP() << "Currently fails";
-  }
   const std::string hlo_text = R"(
 HloModule scatter_add
 


### PR DESCRIPTION
📝 Summary of Changes
Fix ScatterDeterminismExpander to correctly handle scatter operations that have been normalized from batched form by BatchedGatherScatterNormalizer.
The key fix is in FlattenIndices: when computing scalar indices for sorting, we now use scatter_dims_to_operand_dims to select the correct stride for each index column, rather than assuming index columns map to operand dimensions in order.
🎯 Justification
Previously, ScatterDeterminismExpander would produce incorrect results for batched scatter operations because:
BatchedGatherScatterNormalizer runs first and transforms batched scatter into a normalized form where batch indices are concatenated into the index tensor
After normalization, scatter_dims_to_operand_dims could be {0, 2} (not {0, 1, 2})
FlattenIndices assumed direct column→dimension mapping, causing indices from different batches to collide and mix updates incorrectly
This enables deterministic scatter for models using batched scatter operations (e.g., batched attention, batched embedding lookups).

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests
Existing test ScatterTest.Scatter_Add_F32 in xla/tests/scatter_test.cc now passes - it exercises batched scatter with input_batching_dims={0} and validates correctness against the interpreter reference.
🧪 Execution Tests
ScatterTest.Scatter_Add_F32 runs end-to-end on GPU, triggering the BatchedGatherScatterNormalizer → ScatterDeterminismExpander pipeline and asserting correct output.