### PR TITLE
[GPU] Do not float-normalize bf16 negation and abs.

### DIFF
--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -131,8 +131,10 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
         return compute_capability_.IsCuda();
       }
       return false;
+    case HloOpcode::kAbs:
     case HloOpcode::kMaximum:
     case HloOpcode::kMinimum:
+    case HloOpcode::kNegate:
       if (LowPrecisionType() == BF16) {
         auto* cuda_compute_capability =
             compute_capability_.cuda_compute_capability();


### PR DESCRIPTION
📝 Summary of Changes
Avoid unnecessary type casts - bf16 negation and abs are supported in PTX.

🚀 Kind of Contribution
♻️ Cleanup

🧪 Unit Tests:
yes

🧪 Execution Tests:
no
