### PR TITLE
Turn on the scatter determinism expander by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -441,7 +441,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_enable_fast_math(false);
   opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
   opts.set_xla_pjrt_allow_auto_layout_in_hlo(false);
-  opts.set_xla_gpu_enable_scatter_determinism_expander(false);
+  opts.set_xla_gpu_enable_scatter_determinism_expander(true);
   opts.set_xla_gpu_unsupported_enable_ragged_all_to_all_decomposer(false);
   opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(false);
   opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);


### PR DESCRIPTION
📝 Summary of Changes
Enable xla_gpu_enable_scatter_determinism_expander flag by default (change from false to true).
🎯 Justification
The scatter determinism expander provides significant performance improvements for deterministic scatter operations (up to 9000x speedup for certain input sizes compared to the sequential while-loop approach).
With recent fixes for batched scatter support and proper handling of scatter_dims_to_operand_dims, the pass is now robust enough to be enabled by default.
Users who experience issues can still disable it with --xla_gpu_enable_scatter_determinism_expander=false.
🚀 Kind of Contribution
⚡️ Performance Improvement
🧪 Unit Tests
All existing scatter tests pass with the flag enabled by default:
//xla/service:scatter_determinism_expander_test
//xla/tests:scatter_test