### PR TITLE
[ROCm] Add support for parametrized rocm hermetic dependency

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -287,7 +287,9 @@ common:rocm_ci --config=rocm
 
 common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_official
-common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_VERSION=rocm_7.10.0_gfx94X"
+common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_URL=https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-linux-gfx94X-dcgpu-7.10.0a20251107.tar.gz"
+common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_HASH=486dbf647bcf9b78f21d7477f43addc7b2075b1a322a119045db9cdc5eb98380"
+common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_LINKS=llvm/amdgcn:amdgcn"
 common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.

--- a/third_party/gpus/rocm/rocm_redist.bzl
+++ b/third_party/gpus/rocm/rocm_redist.bzl
@@ -39,3 +39,22 @@ rocm_redist = {
         rocm_root = "_rocm_sdk_devel",
     ),
 }
+
+def _parse_rocm_distro_links(distro_links):
+    result = []
+    for pair in distro_links.split(","):
+        link = pair.split(":")
+        result.append(struct(target = link[0], link = link[1]))
+    return result
+
+def create_rocm_distro(distro_url, distro_hash, symlinks):
+    return struct(
+        packages = [
+            {
+                "url": distro_url,
+                "sha256": distro_hash,
+            },
+        ],
+        required_softlinks = _parse_rocm_distro_links(symlinks),
+        rocm_root = "",
+    )

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -54,6 +54,9 @@ _TF_ROCM_AMDGPU_TARGETS = "TF_ROCM_AMDGPU_TARGETS"
 _TF_ROCM_CONFIG_REPO = "TF_ROCM_CONFIG_REPO"
 _DISTRIBUTION_PATH = "rocm/rocm_dist"
 _ROCM_DISTRO_VERSION = "ROCM_DISTRO_VERSION"
+_ROCM_DISTRO_URL = "ROCM_DISTRO_URL"
+_ROCM_DISTRO_HASH = "ROCM_DISTRO_HASH"
+_ROCM_DISTRO_LINKS = "ROCM_DISTRO_LINKS"
 _TMPDIR = "TMPDIR"
 
 _DEFAULT_ROCM_TOOLKIT_PATH = "/opt/rocm"
@@ -545,9 +548,43 @@ def _remove_root_dir(path, root_dir):
         return path[len(root_dir) + 1:]
     return path
 
+def _parse_rocm_distro_links(distro_links):
+    result = []
+    for pair in distro_links.split(","):
+        link = pair.split(":")
+        result.append(struct(target = link[0], link = link[1]))
+    return result
+
 def _setup_rocm_distro_dir(repository_ctx):
     """Sets up the rocm hermetic installation directory to be used in hermetic build"""
     bash_bin = get_bash_bin(repository_ctx)
+    rocm_distro_url = repository_ctx.os.environ.get(_ROCM_DISTRO_URL)
+    if rocm_distro_url:
+        rocm_distro_hash = repository_ctx.os.environ.get(_ROCM_DISTRO_HASH)
+        if not rocm_distro_hash:
+            fail("{} environment variable is required", _ROCM_DISTRO_HASH)
+        rocm_distro_links = repository_ctx.os.environ.get(_ROCM_DISTRO_LINKS, "")
+        rocm_distro = struct(
+            packages = [
+                {
+                    "url": rocm_distro_url,
+                    "sha256": rocm_distro_hash,
+                },
+            ],
+            required_softlinks = _parse_rocm_distro_links(rocm_distro_links),
+            rocm_root = "",
+        )
+        repository_ctx.file("rocm/.index")
+        for pkg in rocm_distro.packages:
+            _download_package(repository_ctx, pkg)
+
+        for entry in rocm_distro.required_softlinks:
+            repository_ctx.symlink(
+                "{}/{}".format(_DISTRIBUTION_PATH, entry.target),
+                "{}/{}".format(_DISTRIBUTION_PATH, entry.link),
+            )
+        return _get_rocm_config(repository_ctx, bash_bin, _canonical_path("{}/{}".format(_DISTRIBUTION_PATH, rocm_distro.rocm_root)), "")
+
     rocm_distro = repository_ctx.os.environ.get(_ROCM_DISTRO_VERSION)
     multiple_paths = repository_ctx.os.environ.get(_TF_ROCM_MULTIPLE_PATHS)
     if rocm_distro:
@@ -855,6 +892,9 @@ _ENVIRONS = [
     _ROCM_TOOLKIT_PATH,
     _TF_ROCM_AMDGPU_TARGETS,
     _ROCM_DISTRO_VERSION,
+    _ROCM_DISTRO_URL,
+    _ROCM_DISTRO_HASH,
+    _ROCM_DISTRO_LINKS,
     _TF_ROCM_RBE_DOCKER_IMAGE,
     _TF_ROCM_RBE_SINGLE_GPU_POOL,
     _TF_ROCM_RBE_MULTI_GPU_POOL,


### PR DESCRIPTION
📝 Summary of Changes
This change adds support of parametrized
hermetic rocm dependency through the environment variables.
One can set these 3 environment variables:
```
--repo_env="ROCM_DISTRO_URL=https://therock-nightly-tarball.s3.amazonaws.com/therock-dist-linux-gfx94X-dcgpu-7.10.0a20251107.tar.gz"
--repo_env="ROCM_DISTRO_HASH=486dbf647bcf9b78f21d7477f43addc7b2075b1a322a119045db9cdc5eb98380"
--repo_env="ROCM_DISTRO_LINKS=llvm/amdgcn:amdgcn"
```
Where ROCM_DISTRO_LINKS is a list of pairs formed like:
"target:link,target2:link2" that will create symlinks after the extraction of the tar file.


🎯 Justification
This change adds more flexibility to rocm hermetic builds and eliminates the need
to modify the rocm_redist.bzl file.

🚀 Kind of Contribution
Please remove what does not apply:
✨ New Feature

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
