### PR TITLE
Introduce xla_googletest_wrapper with module extension instead of a bazel_dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,6 @@ bazel_dep(name = "boringssl", version = "0.20250818.0")
 bazel_dep(name = "curl", version = "8.11.0")
 bazel_dep(name = "google_benchmark", version = "1.8.5", repo_name = "com_google_benchmark")
 bazel_dep(name = "googletest", version = "1.17.0", repo_name = "com_google_googletest_upstream")
-bazel_dep(name = "xla_googletest_wrapper", version = "1.0", repo_name = "com_google_googletest")
 bazel_dep(name = "grpc", version = "1.74.1", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "gutil", version = "20250502.0", repo_name = "com_google_gutil")
 bazel_dep(name = "jsoncpp", version = "1.9.6", repo_name = "jsoncpp_git")
@@ -89,6 +88,7 @@ use_repo(
     third_party,
     "FXdiv",
     "XNNPACK",
+    "com_google_googletest",
     "cpuinfo",
     "cudnn_frontend_archive",
     "dlpack",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,11 +74,6 @@ archive_override(
     urls = ["https://github.com/google/googletest/archive/28e9d1f26771c6517c3b4be10254887673c94018.zip"],
 )
 
-local_path_override(
-    module_name = "xla_googletest_wrapper",
-    path = "third_party/xla_googletest_wrapper",
-)
-
 ##############################################################
 # C++ dependencies
 

--- a/third_party/extensions/third_party.bzl
+++ b/third_party/extensions/third_party.bzl
@@ -37,6 +37,7 @@ load("//third_party/tensorrt:workspace.bzl", tensorrt = "repo")
 load("//third_party/triton:workspace.bzl", triton = "repo")
 load("//third_party/uv:workspace.bzl", uv = "repo")
 load("//third_party/xnnpack:workspace.bzl", xnnpack = "repo")
+load("//third_party:repo.bzl", "tf_vendored")
 
 def _third_party_ext_impl(mctx):  # @unused
     benchmark()
@@ -76,6 +77,10 @@ def _third_party_ext_impl(mctx):  # @unused
     triton()
     uv()
     xnnpack()
+    tf_vendored(
+        name = "com_google_googletest",
+        path = "third_party/xla_googletest_wrapper",
+    )
 
 third_party_ext = module_extension(
     implementation = _third_party_ext_impl,

--- a/third_party/xla_googletest_wrapper/MODULE.bazel
+++ b/third_party/xla_googletest_wrapper/MODULE.bazel
@@ -1,4 +1,0 @@
-module(name = "xla_googletest_wrapper", version = "1.0")
-
-bazel_dep(name = "abseil-cpp", version = "20250814.0", repo_name = "com_google_absl")
-bazel_dep(name = "googletest", version = "1.17.0", repo_name = "com_google_googletest_upstream")


### PR DESCRIPTION
So that other projects depending on XLA doesn't have to provide the `local_path_override`