### PR TITLE
Use human readable string to display memory allocator sizes

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -815,7 +815,10 @@ cc_library(
     name = "allocator_stats",
     srcs = ["allocator_stats.cc"],
     hdrs = ["allocator_stats.h"],
-    deps = ["@com_google_absl//absl/strings:str_format"],
+    deps = [
+        "@com_google_absl//absl/strings:str_format",
+        "@tsl//tsl/platform:numbers",
+    ],
 )
 
 cc_library(

--- a/xla/stream_executor/allocator_stats.cc
+++ b/xla/stream_executor/allocator_stats.cc
@@ -18,23 +18,28 @@ limitations under the License.
 #include <string>
 
 #include "absl/strings/str_format.h"
+#include "tsl/platform/numbers.h"
 
 namespace stream_executor {
 
 std::string AllocatorStats::DebugString() const {
   return absl::StrFormat(
-      "Limit:            %20lld\n"
-      "InUse:            %20lld\n"
-      "MaxInUse:         %20lld\n"
+      "Limit:            %20s\n"
+      "InUse:            %20s\n"
+      "MaxInUse:         %20s\n"
       "NumAllocs:        %20lld\n"
-      "MaxAllocSize:     %20lld\n"
-      "Reserved:         %20lld\n"
-      "PeakReserved:     %20lld\n"
-      "LargestFreeBlock: %20lld\n",
-      this->bytes_limit ? *this->bytes_limit : 0, this->bytes_in_use,
-      this->peak_bytes_in_use, this->num_allocs, this->largest_alloc_size,
-      this->bytes_reserved, this->peak_bytes_reserved,
-      this->largest_free_block_bytes);
+      "MaxAllocSize:     %20s\n"
+      "Reserved:         %20s\n"
+      "PeakReserved:     %20s\n"
+      "LargestFreeBlock: %20s\n",
+      strings::HumanReadableNumBytes(this->bytes_limit ? *this->bytes_limit
+                                                       : 0),
+      strings::HumanReadableNumBytes(this->bytes_in_use),
+      strings::HumanReadableNumBytes(this->peak_bytes_in_use), this->num_allocs,
+      strings::HumanReadableNumBytes(this->largest_alloc_size),
+      strings::HumanReadableNumBytes(this->bytes_reserved),
+      strings::HumanReadableNumBytes(this->peak_bytes_reserved),
+      strings::HumanReadableNumBytes(this->largest_free_block_bytes));
 }
 
 }  // namespace stream_executor

--- a/xla/stream_executor/allocator_stats.cc
+++ b/xla/stream_executor/allocator_stats.cc
@@ -34,12 +34,12 @@ std::string AllocatorStats::DebugString() const {
       "LargestFreeBlock: %20s\n",
       strings::HumanReadableNumBytes(this->bytes_limit ? *this->bytes_limit
                                                        : 0),
-      strings::HumanReadableNumBytes(this->bytes_in_use),
-      strings::HumanReadableNumBytes(this->peak_bytes_in_use), this->num_allocs,
-      strings::HumanReadableNumBytes(this->largest_alloc_size),
-      strings::HumanReadableNumBytes(this->bytes_reserved),
-      strings::HumanReadableNumBytes(this->peak_bytes_reserved),
-      strings::HumanReadableNumBytes(this->largest_free_block_bytes));
+      tsl::strings::HumanReadableNumBytes(this->bytes_in_use),
+      tsl::strings::HumanReadableNumBytes(this->peak_bytes_in_use), this->num_allocs,
+      tsl::strings::HumanReadableNumBytes(this->largest_alloc_size),
+      tsl::strings::HumanReadableNumBytes(this->bytes_reserved),
+      tsl::strings::HumanReadableNumBytes(this->peak_bytes_reserved),
+      tsl::strings::HumanReadableNumBytes(this->largest_free_block_bytes));
 }
 
 }  // namespace stream_executor

--- a/xla/stream_executor/allocator_stats.cc
+++ b/xla/stream_executor/allocator_stats.cc
@@ -32,10 +32,11 @@ std::string AllocatorStats::DebugString() const {
       "Reserved:         %20s\n"
       "PeakReserved:     %20s\n"
       "LargestFreeBlock: %20s\n",
-      strings::HumanReadableNumBytes(this->bytes_limit ? *this->bytes_limit
-                                                       : 0),
+      tsl::strings::HumanReadableNumBytes(this->bytes_limit ? *this->bytes_limit
+                                                            : 0),
       tsl::strings::HumanReadableNumBytes(this->bytes_in_use),
-      tsl::strings::HumanReadableNumBytes(this->peak_bytes_in_use), this->num_allocs,
+      tsl::strings::HumanReadableNumBytes(this->peak_bytes_in_use),
+      this->num_allocs,
       tsl::strings::HumanReadableNumBytes(this->largest_alloc_size),
       tsl::strings::HumanReadableNumBytes(this->bytes_reserved),
       tsl::strings::HumanReadableNumBytes(this->peak_bytes_reserved),

--- a/xla/tsl/framework/BUILD
+++ b/xla/tsl/framework/BUILD
@@ -120,6 +120,7 @@ cc_library(
             ":allocator_registry_impl",
             "@com_google_absl//absl/synchronization",
             "//xla/tsl/lib/gtl:inlined_vector",
+            "@tsl//tsl/platform:numbers",
             "@tsl//tsl/platform:strcat",
             "//xla/tsl/platform:env",
             "//xla/tsl/platform:env_impl",
@@ -132,6 +133,7 @@ cc_library(
         otherwise = [
             "//xla/tsl/lib/gtl:inlined_vector",
             "//xla/tsl/platform:logging",
+            "@tsl//tsl/platform:numbers",
             "@tsl//tsl/platform:platform_port",
             "@tsl//tsl/platform:strcat",
             "//xla/tsl/platform:env",

--- a/xla/tsl/framework/allocator.cc
+++ b/xla/tsl/framework/allocator.cc
@@ -24,28 +24,30 @@ limitations under the License.
 #include "xla/tsl/framework/tracking_allocator.h"
 #include "xla/tsl/platform/types.h"
 #include "tsl/platform/mem.h"
+#include "tsl/platform/numbers.h"
 #include "tsl/platform/strcat.h"
 
 namespace tsl {
 
 std::string AllocatorStats::DebugString() const {
   return absl::StrFormat(
-      "Limit:            %20lld\n"
-      "InUse:            %20lld\n"
-      "MaxInUse:         %20lld\n"
+      "Limit:            %20s\n"
+      "InUse:            %20s\n"
+      "MaxInUse:         %20s\n"
       "NumAllocs:        %20lld\n"
-      "MaxAllocSize:     %20lld\n"
-      "Reserved:         %20lld\n"
-      "PeakReserved:     %20lld\n"
-      "LargestFreeBlock: %20lld\n",
-      static_cast<long long>(this->bytes_limit ? *this->bytes_limit : 0),
-      static_cast<long long>(this->bytes_in_use),
-      static_cast<long long>(this->peak_bytes_in_use),
+      "MaxAllocSize:     %20s\n"
+      "Reserved:         %20s\n"
+      "PeakReserved:     %20s\n"
+      "LargestFreeBlock: %20s\n",
+      strings::HumanReadableNumBytes(this->bytes_limit ? *this->bytes_limit
+                                                       : 0),
+      strings::HumanReadableNumBytes(this->bytes_in_use),
+      strings::HumanReadableNumBytes(this->peak_bytes_in_use),
       static_cast<long long>(this->num_allocs),
-      static_cast<long long>(this->largest_alloc_size),
-      static_cast<long long>(this->bytes_reserved),
-      static_cast<long long>(this->peak_bytes_reserved),
-      static_cast<long long>(this->largest_free_block_bytes));
+      strings::HumanReadableNumBytes(this->largest_alloc_size),
+      strings::HumanReadableNumBytes(this->bytes_reserved),
+      strings::HumanReadableNumBytes(this->peak_bytes_reserved),
+      strings::HumanReadableNumBytes(this->largest_free_block_bytes));
 }
 
 constexpr size_t Allocator::kAllocatorAlignment;

--- a/xla/tsl/framework/bfc_allocator.cc
+++ b/xla/tsl/framework/bfc_allocator.cc
@@ -1116,11 +1116,15 @@ void BFCAllocator::DumpMemoryLog(size_t num_bytes) {
   }
   LOG(INFO) << "Sum Total of in-use chunks: "
             << strings::HumanReadableNumBytes(total_bytes);
-  LOG(INFO) << "Total bytes in pool: " << *stats_.pool_bytes
-            << " memory_limit_: " << memory_limit_
-            << " available bytes: " << (memory_limit_ - *stats_.pool_bytes)
+  LOG(INFO) << "Total size in pool: "
+            << strings::HumanReadableNumBytes(*stats_.pool_bytes)
+            << " memory_limit_: "
+            << strings::HumanReadableNumBytes(memory_limit_)
+            << " available size: "
+            << strings::HumanReadableNumBytes(memory_limit_ -
+                                              *stats_.pool_bytes)
             << " curr_region_allocation_bytes_: "
-            << curr_region_allocation_bytes_;
+            << strings::HumanReadableNumBytes(curr_region_allocation_bytes_);
   LOG(INFO) << "Stats: \n" << stats_.DebugString();
 }
 


### PR DESCRIPTION
📝 Summary of Changes
This pull request updates the allocator statistics reporting across both `stream_executor` and `tsl/framework` to improve readability and consistency. 