### PR TITLE
[ROCm] fixed TritonFusionNumericsVerifierTest.VerifyThatDisablingTritonIsFast on rocm

### DIFF
--- a/xla/service/gpu/transforms/triton_fusion_numerics_verifier_test.cc
+++ b/xla/service/gpu/transforms/triton_fusion_numerics_verifier_test.cc
@@ -517,7 +517,7 @@ ENTRY main {
       "kind":"__triton",
       "block_level_fusion_config":{
         "output_tiles":[{"sizes":["1","1","1","16384"]}],
-        "num_warps":"32",
+        "num_warps":"16",
         "num_ctas":"1",
         "num_stages":"1"}}}
 }


### PR DESCRIPTION

The original warp size 32 leads to the following error message: "INTERNAL: Failed to launch ROCm kernel: triton_softmax with block dimensions: 2048x1x1: HIP_ERROR_InvalidValue".

32 warps × 64 threads/wavefront = 2048 threads (exceeds 1024 limit)

For comparison on NVIDIA:
32 warps × 32 threads/warp = 1024 threads (within limit)

This test should be a general test for all the platforms.

@xla-rotation could you review my PR, please?