### PR TITLE
[ROCm] Make amd rbe pool parametrized, do not use dynamic pool selection

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -536,12 +536,12 @@ cc_library(
 
 cc_library(
     name = "amd_comgr",
-    hdrs = glob(["%{rocm_root}/include/amd_comgr/**"]),
     srcs = glob([
         "%{rocm_root}/lib/libamd_comgr_loader.so*",
         "%{rocm_root}/lib/libamd_comgr.so*",
         "%{rocm_root}/lib/llvm/lib/libLLVM.so*",
     ]),
+    hdrs = glob(["%{rocm_root}/include/amd_comgr/**"]),
     include_prefix = "rocm",
     includes = [
         "%{rocm_root}/include",
@@ -552,7 +552,7 @@ cc_library(
         ],
         "//conditions:default": [
             "-lamd_comgr",
-	],
+        ],
     }),
     strip_include_prefix = "%{rocm_root}",
     visibility = ["//visibility:public"],
@@ -640,5 +640,6 @@ platform(
     exec_properties = {
         "container-image": "docker://%{rocm_rbe_docker_image}",
         "OSFamily": "Linux",
+        "Pool": "%{rocm_rbe_pool}",
     },
 )

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -81,6 +81,3 @@ def rocm_library(copts = [], deps = [], **kwargs):
     if "@local_config_rocm//rocm:rocm_headers" not in deps:
       deps.append("@local_config_rocm//rocm:rocm_headers")
     native.cc_library(copts = rocm_default_copts() + copts, deps = deps, **kwargs)
-
-def get_rbe_amdgpu_pool(is_single_gpu = False):
-    return "%{single_gpu_rbe_pool}" if is_single_gpu else "%{multi_gpu_rbe_pool}"

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -10,8 +10,7 @@
   * `ROCM_PATH`: The path to the ROCm toolkit. Default is `/opt/rocm`.
   * `TF_ROCM_AMDGPU_TARGETS`: The AMDGPU targets.
   * `TF_ROCM_RBE_DOCKER_IMAGE`: Docker image to be used in rbe worker to execute the action
-  * `TF_ROCM_RBE_SINGLE_GPU_POOL`: The name of the rbe pool used to execute single gpu tests
-  * `TF_ROCM_RBE_MULTI_GPU_POOL`: The name of the rbe pool used to execute multi gpu tests
+  * `TF_ROCM_RBE_POOL`: The name of the rbe pool used to execute tests
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
@@ -59,10 +58,7 @@ _TMPDIR = "TMPDIR"
 _DEFAULT_ROCM_TOOLKIT_PATH = "/opt/rocm"
 _TF_ROCM_MULTIPLE_PATHS = "TF_ROCM_MULTIPLE_PATHS"
 _TF_ROCM_RBE_DOCKER_IMAGE = "TF_ROCM_RBE_DOCKER_IMAGE"
-_TF_ROCM_RBE_SINGLE_GPU_POOL = "TF_ROCM_RBE_SINGLE_GPU_POOL"
-_TF_ROCM_RBE_MULTI_GPU_POOL = "TF_ROCM_RBE_MULTI_GPU_POOL"
-_DEFAULT_TF_ROCM_RBE_SINGLE_GPU_POOL = "linux_x64_gpu"
-_DEFAULT_TF_ROCM_RBE_MULTI_GPU_POOL = "linux_x64_multigpu"
+_TF_ROCM_RBE_POOL = "TF_ROCM_RBE_POOL"
 
 # rocm/tensorflow-build:latest-jammy-python3.11-rocm7.0.2
 _DEFAULT_TF_ROCM_RBE_DOCKER_IMAGE = "rocm/tensorflow-build@sha256:a2672ff2510b369b4a5f034272a518dc93c2e492894e3befaeef19649632ccaa"
@@ -442,8 +438,6 @@ def _create_dummy_repository(repository_ctx):
             "%{rocm_gpu_architectures}": "[]",
             "%{rocm_version_number}": "0",
             "%{rocm_hipblaslt}": "False",
-            "%{single_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_SINGLE_GPU_POOL, _DEFAULT_TF_ROCM_RBE_SINGLE_GPU_POOL),
-            "%{multi_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_MULTI_GPU_POOL, _DEFAULT_TF_ROCM_RBE_MULTI_GPU_POOL),
         },
     )
     _tpl(
@@ -628,8 +622,6 @@ def _create_local_rocm_repository(repository_ctx):
                 repository_ctx,
                 rocm_config.amdgpu_targets,
             ),
-            "%{single_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_SINGLE_GPU_POOL, _DEFAULT_TF_ROCM_RBE_SINGLE_GPU_POOL),
-            "%{multi_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_MULTI_GPU_POOL, _DEFAULT_TF_ROCM_RBE_MULTI_GPU_POOL),
             "%{rocm_gpu_architectures}": str(rocm_config.amdgpu_targets),
             "%{rocm_version_number}": str(rocm_version_number),
             "%{rocm_hipblaslt}": "True",
@@ -640,6 +632,7 @@ def _create_local_rocm_repository(repository_ctx):
         "%{rocm_root}": rocm_toolkit_path,
         "%{rocm_toolkit_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path)),
         "%{rocm_rbe_docker_image}": repository_ctx.os.environ.get(_TF_ROCM_RBE_DOCKER_IMAGE, _DEFAULT_TF_ROCM_RBE_DOCKER_IMAGE),
+        "%{rocm_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_POOL, "default"),
     }
 
     is_rocm_clang = _use_rocm_clang(repository_ctx)
@@ -856,8 +849,7 @@ _ENVIRONS = [
     _TF_ROCM_AMDGPU_TARGETS,
     _ROCM_DISTRO_VERSION,
     _TF_ROCM_RBE_DOCKER_IMAGE,
-    _TF_ROCM_RBE_SINGLE_GPU_POOL,
-    _TF_ROCM_RBE_MULTI_GPU_POOL,
+    _TF_ROCM_RBE_POOL,
     _TF_ROCM_MULTIPLE_PATHS,
 ]
 

--- a/xla/tsl/platform/default/build_config_root.bzl
+++ b/xla/tsl/platform/default/build_config_root.bzl
@@ -5,7 +5,7 @@ be separate to avoid cyclic references.
 """
 
 load("@local_config_remote_execution//:remote_execution.bzl", "gpu_test_tags")
-load("@local_config_rocm//rocm:build_defs.bzl", "get_rbe_amdgpu_pool", "is_rocm_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "is_rocm_configured")
 load("//third_party/py/rules_pywrap:pywrap.default.bzl", "use_pywrap_rules")
 load("//xla/tsl:package_groups.bzl", "DEFAULT_LOAD_VISIBILITY")
 load("//xla/tsl/platform/default:cuda_build_defs.bzl", "is_cuda_configured")
@@ -17,14 +17,6 @@ visibility(DEFAULT_LOAD_VISIBILITY)
 GPU_TEST_PROPERTIES = {
     "dockerRuntime": "nvidia",
     "Pool": "gpu-pool",
-}
-
-ROCM_SINGLE_GPU_TEST_PROPERTIES = {
-    "test.Pool": get_rbe_amdgpu_pool(is_single_gpu = True),
-}
-
-ROCM_MULTI_GPU_TEST_PROPERTIES = {
-    "test.Pool": get_rbe_amdgpu_pool(is_single_gpu = False),
 }
 
 def tf_gpu_tests_tags():
@@ -57,12 +49,7 @@ def tf_exec_properties(kwargs):
     Returns:
         execution_properties with the execution pool names for rbe.
     """
-    if is_rocm_configured():
-        if tf_has_tag(kwargs, "multi_gpu"):
-            return ROCM_MULTI_GPU_TEST_PROPERTIES
-        if tf_has_tag(kwargs, "gpu"):
-            return ROCM_SINGLE_GPU_TEST_PROPERTIES
-    elif tf_has_tag(kwargs, "remote-gpu"):
+    if tf_has_tag(kwargs, "remote-gpu"):
         return GPU_TEST_PROPERTIES
     return {}
 


### PR DESCRIPTION
📝 Summary of Changes
Make rocm rbe pool selection parametrized
using this env variable we can select the pool where the tests will be executed on 
e.g --repo_env=TF_ROCM_RBE_POOL="linux_x86_gpu_gfx90a"

🎯 Justification
Recent changes upstream broke our dynamic pool selection for rbe tests.
Then there was no any pool assignment to rocm tests and they were into the default pool.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
