### PR TITLE
fix: cap shape size in TextLiteralReader

### DIFF
--- a/xla/text_literal_reader_test.cc
+++ b/xla/text_literal_reader_test.cc
@@ -89,5 +89,16 @@ TEST(TextLiteralReaderTest, MissingColonReturnsInvalidArgument) {
   EXPECT_THAT(literal, StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
+TEST(TextLiteralReaderTest, ShapeTooLargeReturnsResourceExhausted) {
+  // Shape requires too much memory, should fail gracefully rather than crash.
+  std::string contents = "f32[272222222222222222]\n";
+
+  std::string fname = tsl::testing::TmpDir() + "/ShapeTooLarge.data.txt";
+  ASSERT_THAT(tsl::WriteStringToFile(tsl::Env::Default(), fname, contents),
+              IsOk());
+  absl::StatusOr<Literal> literal = TextLiteralReader::ReadPath(fname);
+  EXPECT_THAT(literal, StatusIs(absl::StatusCode::kResourceExhausted));
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes

Add size check in TextLiteralReader before allocation to avoid null-dereference crash when parsing shapes with extremely large dimensions. 

Cap at `int32_t` maximum (around 2 GB), which should be sufficient for this text-based format.

Fixes OSS-Fuzz finding [#428771909](https://issues.oss-fuzz.com/issues/428771909)and probably [#429123948](https://issues.oss-fuzz.com/issues/429123948) from the Tensorflow fuzzer.

🎯 Justification

This change prevents crashes from unbounded memory allocation triggered by malformed input files.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant.

🧪 Unit Tests:

Added a unit test from the OSS-Fuzz reproducer test case. Test command:

```
docker exec xla bazel test \
  --spawn_strategy=sandboxed \                                                                                                                                                           --test_output=all \
  //xla:text_literal_reader_test
```

Output:

```
==================== Test output for //xla:text_literal_reader_test:
Note: Randomizing tests' orders with a seed of 8787 .
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from TextLiteralReaderTest
[ RUN      ] TextLiteralReaderTest.MissingColonReturnsInvalidArgument
[       OK ] TextLiteralReaderTest.MissingColonReturnsInvalidArgument (32 ms)
[ RUN      ] TextLiteralReaderTest.ShapeTooLargeReturnsResourceExhausted
[       OK ] TextLiteralReaderTest.ShapeTooLargeReturnsResourceExhausted (1 ms)
[ RUN      ] TextLiteralReaderTest.WhitespaceOnlyLineAfterShapeDoesNotCrashAndYieldsScalarNaN
[       OK ] TextLiteralReaderTest.WhitespaceOnlyLineAfterShapeDoesNotCrashAndYieldsScalarNaN (1 ms)
[ RUN      ] TextLiteralReaderTest.ReadsR3File
[       OK ] TextLiteralReaderTest.ReadsR3File (0 ms)
[----------] 4 tests from TextLiteralReaderTest (36 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (39 ms total)
[  PASSED  ] 4 tests.
================================================================================
//xla:text_literal_reader_test                                  (cached) PASSED in 0.4s
```

🧪 Execution Tests:
Not relevant.
