### PR TITLE
refactor: use Literal::Make() in TextLiteralReader

### DIFF
--- a/xla/text_literal_reader.cc
+++ b/xla/text_literal_reader.cc
@@ -79,7 +79,7 @@ absl::StatusOr<Literal> TextLiteralReader::ReadAllLines() {
         ShapeUtil::HumanString(shape));
   }
 
-  Literal result(shape);
+  TF_ASSIGN_OR_RETURN(Literal result, Literal::Make(shape));
   const float fill = std::numeric_limits<float>::quiet_NaN();
   result.PopulateWithValue<float>(fill);
   std::vector<absl::string_view> pieces;


### PR DESCRIPTION
📝 Summary of Changes

Replace deprecated `Literal(shape)` constructor with `Literal::Make(shape)` which returns StatusOr and handles allocation failure gracefully.

🎯 Justification

The `Literal(shape)` constructor is deprecated as seen in `literal.h`:

```cpp
  ABSL_DEPRECATED(
      "This ctor may crash if allocation fails. Use Literal::Make() instead.")
  explicit Literal(
      const Shape& shape, bool allocate_arrays = true,
      ArrayValueState leaf_array_value_state = ArrayValueState::kKnown);
```

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not applicable.

🧪 Unit Tests:
Not applicable.

🧪 Execution Tests:
Not applicable.
