### PR TITLE
[ROCm] Fix hermetic build rocm

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -537,7 +537,7 @@ cc_library(
 cc_library(
     name = "amd_comgr",
     hdrs = glob(["%{rocm_root}/include/amd_comgr/**"]),
-    srcs = glob([
+    data = glob([
         "%{rocm_root}/lib/libamd_comgr_loader.so*",
         "%{rocm_root}/lib/libamd_comgr.so*",
         "%{rocm_root}/lib/llvm/lib/libLLVM.so*",
@@ -549,10 +549,11 @@ cc_library(
     linkopts = select({
         ":build_hermetic": [
             "-lamd_comgr_loader",
+            "-lamd_comgr",
         ],
         "//conditions:default": [
             "-lamd_comgr",
-	],
+        ],
     }),
     strip_include_prefix = "%{rocm_root}",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
📝 Summary of Changes
Move comgr into the data directory, fixing hermetic build

🎯 Justification
Hermetic build with rocm config is broken due to invalid
dependency management. Invalid merge of this PR: https://github.com/openxla/xla/pull/34812


🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
