### PR TITLE
[GPU] Wrap single instructions in fusions before autotuning.

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1487,6 +1487,7 @@ absl::Status GpuCompiler::OptimizeHloModule(
   TF_RETURN_IF_ERROR(RunAsyncDotPasses(hlo_module));
   {
     HloPassPipeline pipeline("autotune-fusion-emitters");
+    pipeline.AddPass<FusionWrapper>(gpu_target_config.device_description);
     TF_RETURN_IF_ERROR(AddFusionAutotuningPass(
         &pipeline, hlo_module, options, thread_pool.get_mutable(), stream_exec,
         &gpu_target_config, ShapeSizeBytesFunction()));

--- a/xla/service/gpu/tests/dot_bf16.hlo
+++ b/xla/service/gpu/tests/dot_bf16.hlo
@@ -3,11 +3,11 @@
 // RUN: %if IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../../../tools/hlo_opt/gpu_specs/mi200.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
 
 
-// CHECK-SM70: %[[convert1:.+]] = f32[1536,6144]{1,0} convert(%{{.+}})
-// CHECK-SM70: %[[convert2:.+]] = f32[32,1536]{1,0} convert(%{{.+}})
+// CHECK-SM70: %[[convert1:.+]] = f32[1536,6144]{1,0} fusion(%{{.+}})
+// CHECK-SM70: %[[convert2:.+]] = f32[32,1536]{1,0} fusion(%{{.+}})
 // CHECK-SM70: custom-call(%[[convert1]], %[[convert2]]), custom_call_target="__cublas$gemm"
 
-// CHECK-SM80: %[[convert:.+]] = bf16[1536,6144]{1,0} convert(%{{.+}})
+// CHECK-SM80: %[[convert:.+]] = bf16[1536,6144]{1,0} fusion(%{{.+}})
 // CHECK-SM80: %[[b:.+]] = bf16[32,1536]{1,0} parameter(1)
 // CHECK-SM80: custom-call(%[[convert]], %[[b]]), custom_call_target="__cublas$gemm"
 
@@ -22,11 +22,11 @@ ENTRY %computation1 {
 
 // -----
 
-// CHECK-SM70: %[[convert1:.+]] = f32[1536,6144]{1,0} convert(%{{.+}})
-// CHECK-SM70: %[[convert2:.+]] = f32[32,1536]{1,0} convert(%{{.+}})
+// CHECK-SM70: %[[convert1:.+]] = f32[1536,6144]{1,0} fusion(%{{.+}})
+// CHECK-SM70: %[[convert2:.+]] = f32[32,1536]{1,0} fusion(%{{.+}})
 // CHECK-SM70: (f32[6144,32]{1,0}, s8[4194304]{0}) custom-call(%[[convert1]], %[[convert2]]), custom_call_target="__cublas$gemm"
 
-// CHECK-SM80: %[[convert:.+]] = bf16[1536,6144]{1,0} convert(%{{.+}})
+// CHECK-SM80: %[[convert:.+]] = bf16[1536,6144]{1,0} fusion(%{{.+}})
 // CHECK-SM80: %[[b:.+]] = bf16[32,1536]{1,0} parameter(1)
 // CHECK-SM80: (f32[6144,32]{1,0}, s8[4194304]{0}) custom-call(%[[convert]], %[[b]]), custom_call_target="__cublas$gemm"
 

--- a/xla/service/gpu/tests/sub_byte_collectives.hlo
+++ b/xla/service/gpu/tests/sub_byte_collectives.hlo
@@ -19,11 +19,11 @@ e {
 
 // CHECK-NOT: convert
 // CHECK:      s4[4,2]{1,0:E(4)} parameter
-// CHECK-NEXT: s4[2,4]{1,0:E(4)} transpose
+// CHECK:      s4[2,4]{1,0:E(4)} fusion(%{{.+}})
 // CHECK-NEXT: s8[2,2]{0,1} bitcast
 // CHECK:      s8[2,4]{0,1} all-gather-done
 // CHECK-NEXT: s4[4,4]{1,0:E(4)} bitcast
-// CHECK-NEXT: s4[4,4]{1,0:E(4)} transpose
+// CHECK:      s4[4,4]{1,0:E(4)} fusion(%{{.+}})
 
 // -----
 

--- a/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
@@ -583,7 +583,7 @@ ENTRY test {
     EXPECT_THAT(optimized_module->entry_computation()->root_instruction(),
                 GmockMatch(m::GetTupleElement(
                     m::CustomCall(m::Parameter(0), m::Parameter(1),
-                                  m::Negate(m::Parameter(2))),
+                                  m::Fusion(m::Parameter(2))),
                     0)));
   }
 }
@@ -625,7 +625,7 @@ ENTRY test {
     EXPECT_THAT(optimized_module->entry_computation()->root_instruction(),
                 GmockMatch(m::GetTupleElement(
                     m::CustomCall(m::Parameter(0), m::Parameter(1),
-                                  m::Negate(m::Parameter(2))),
+                                  m::Fusion(m::Parameter(2))),
                     0)));
   }
 }
@@ -932,7 +932,7 @@ ENTRY AddDotsFunc {
 ; CHECK-DAG:         "epilogue":"DEFAULT"
 ; CHECK:           }
 ; CHECK-NEXT:  [[GEMM:%[^ ]+]] = f32[1024,1024]{1,0} get-tuple-element([[GEMM_TUPLE]]), index=0
-; CHECK-NEXT:  ROOT [[OUT:%[^ ]+]] = f32[1024,1024]{1,0} add([[GEMM]], [[BIAS]])
+; CHECK:  ROOT [[OUT:%[^ ]+]] = f32[1024,1024]{1,0} fusion([[GEMM]], [[BIAS]]), kind=kLoop
 )");
 }
 
@@ -1399,7 +1399,7 @@ ENTRY test {
 ; CHECK-DAG:         "epilogue":"BIAS"
 ; CHECK:           }
 ; CHECK-NEXT:    [[GETTUPLE:%[^ ]+]] = f32[4,4]{1,0} get-tuple-element([[MATMUL]]), index=0
-; CHECK-NEXT:    ROOT [[OUT:%[^ ]+]] = f32[2,3]{1,0} slice([[GETTUPLE]]), slice={[0:2], [0:3]}
+; CHECK:    ROOT [[OUT:%[^ ]+]] = f32[2,3]{1,0} fusion([[GETTUPLE]]), kind=kLoop
       )");
 }
 
@@ -1775,7 +1775,7 @@ ENTRY test {
 ; CHECK-DAG:         "epilogue":"RELU"
 ; CHECK:           }
 ; CHECK:         [[MATMUL:%[^ ]+]] = f32[2,4]{1,0} get-tuple-element([[MATMUL_TUPLE]]), index=0
-; CHECK-NEXT:    ROOT [[OUT:%[^ ]+]] = f32[2,2]{1,0} slice([[MATMUL]]), slice={[0:2], [0:2]}
+; CHECK:    ROOT [[OUT:%[^ ]+]] = f32[2,2]{1,0} fusion([[MATMUL]]), kind=kLoop
       )");
 }
 
@@ -3335,7 +3335,7 @@ ENTRY test {
     EXPECT_THAT(optimized_module->entry_computation()->root_instruction(),
                 GmockMatch(m::GetTupleElement(
                     m::CustomCall(m::Parameter(0), m::Parameter(1),
-                                  m::Negate(m::Parameter(2))),
+                                  m::Fusion(m::Parameter(2))),
                     0)));
   }
 }

--- a/xla/service/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter_test.cc
@@ -585,10 +585,9 @@ ENTRY AddDotsFunc {
                     R"(
 ; CHECK-LABEL: ENTRY %AddDotsFunc ({{.*}}: f32[3,2,5], {{.*}}: f32[5,3,4]) -> f32[5,2,4] {
 ; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[3,2,5]{2,1,0} parameter(0)
+; CHECK-DAG:     [[FUSION:%[^ ]+]] = f32[5,2,3]{2,1,0} fusion([[P0]])
 ; CHECK-DAG:     [[P1:%[^ ]+]] = f32[5,3,4]{2,1,0} parameter(1)
-; CHECK-DAG:     [[FUSION:%[^ ]+]] = f32[5,2,3]{2,1,0} transpose([[P0]])
-; CHECK-NEXT:    [[GEMM:%[^ ]+]] = {{.*}} custom-call([[FUSION]], [[P1]]),
-; CHECK:           custom_call_target="<<CUBLAS_CUSTOM_CALL_TARGET_PLACEHOLDER>>",
+; CHECK:         {{[^ ]+}} = {{.*}} custom-call([[FUSION]], [[P1]]), custom_call_target="<<CUBLAS_CUSTOM_CALL_TARGET_PLACEHOLDER>>",
 ; CHECK:           backend_config={
 ; CHECK-DAG:         "alpha_real":1
 ; CHECK-DAG:         "alpha_imag":0
@@ -1545,8 +1544,7 @@ ENTRY DotFunc {
 ; CHECK-LABEL: ENTRY %DotFunc ({{.*}}: f32[3,3], {{.*}}: f32[3,3]) -> f32[3,3] {
 ; CHECK-NEXT:    [[P0:%[^ ]+]] = f32[3,3]{1,0} parameter(0)
 ; CHECK-NEXT:    [[P1:%[^ ]+]] = f32[3,3]{1,0} parameter(1)
-; CHECK-NEXT:    [[GEMM:%[^ ]+]] = {{.*}} dot([[P0]], [[P1]]),
-; CHECK:           lhs_contracting_dims={1}, rhs_contracting_dims={0}
+; CHECK-NEXT:    ROOT {{[^ ]+}} = f32[3,3]{1,0} fusion([[P0]], [[P1]]), kind=kLoop
 )");
 }
 


### PR DESCRIPTION
📝 Summary of Changes
Wrap single instructions into fusions before autotuning so that they get picked up.

🎯 Justification
Creating fusions out of single instructions earlier enables more autotuning.

🚀 Kind of Contribution
⚡️ Performance Improvement ♻️ Cleanup

📊 Benchmark (for Performance Improvements)

🧪 Unit Tests:
yes

🧪 Execution Tests:
no