### PR TITLE
[ROCm] Fix crashes in hermetic build tests

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -116,12 +116,8 @@ cc_library(
         ":rocsolver",
         ":rocsparse",
         ":roctracer",
-    ] + select_threshold(
-        above_or_eq = [":hipfft"],
-        below = [":rocfft"],
-        threshold = 40100,
-        value = rocm_version_number(),
-    ),
+        ":hipfft",
+    ],
 )
 
 cc_library(
@@ -535,8 +531,9 @@ cc_library(
 )
 
 cc_library(
-    name = "amd_comgr",
+    name = "amd_comgr_dynamic",
     hdrs = glob(["%{rocm_root}/include/amd_comgr/**"]),
+    srcs = ["%{rocm_root}/lib/libamd_comgr_stub.a"],
     data = glob([
         "%{rocm_root}/lib/libamd_comgr_loader.so*",
         "%{rocm_root}/lib/libamd_comgr.so*",
@@ -546,22 +543,43 @@ cc_library(
     includes = [
         "%{rocm_root}/include",
     ],
-    linkopts = select({
-        ":build_hermetic": [
-            "-lamd_comgr_loader",
-            "-lamd_comgr",
-        ],
-        "//conditions:default": [
-            "-lamd_comgr",
-        ],
-    }),
+    linkopts = ["-lamd_comgr_loader"],
     strip_include_prefix = "%{rocm_root}",
-    visibility = ["//visibility:public"],
     deps = [
         ":rocm_config",
         ":rocm_rpath",
         ":system_libs",
     ],
+)
+
+cc_library(
+    name = "amd_comgr_static",
+    hdrs = glob(["%{rocm_root}/include/amd_comgr/**"]),
+    data = glob([
+        "%{rocm_root}/lib/libamd_comgr.so*",
+    ]),
+    include_prefix = "rocm",
+    includes = [
+        "%{rocm_root}/include",
+    ],
+    linkopts = ["-lamd_comgr"],
+    strip_include_prefix = "%{rocm_root}",
+    deps = [
+        ":rocm_config",
+        ":rocm_rpath",
+        ":system_libs",
+    ],
+)
+
+alias(
+    name = "amd_comgr",
+    actual = select_threshold(
+        above_or_eq = ":amd_comgr_dynamic",
+        below = ":amd_comgr_static",
+        threshold = 71000,
+        value = rocm_version_number(),
+    ),
+    visibility = ["//visibility:public"],
 )
 
 cc_library(


### PR DESCRIPTION
📝 Summary of Changes
Fixing crash due to conflicting llvm in rocm vs llvm-project symbols

🎯 Justification
new versions of rocm are linked agains an internal version of llvm
the symbols of this library are hidden behind the libamd_comgr_loader.so library.
It is wrong to link libamd_comgr.so directoy to any xla target. Instead we have to link
libamd_comgr_loader.so and a specific stub file. This will ensure that internal 
rocm llvm is loaded dynamically and calls are propagated to it through the loader.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Existing u-tests in hermetic build with rocm 7.10.0

🧪 Execution Tests:
Rocm CI hermetic tests + //xla/service/gpu:gpu_offloading_test_amdgpu_any locally
