### PR TITLE
Enqueue cross-host send after send buffer definition events are recorded, not complete

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -792,7 +792,12 @@ void StreamExecutorGpuClient::ScheduleSendsOnLocalDevice(
     for (PreparedSend& prepared_send : prepared_sends) {
       // Wait until the buffer we want to send is fully materialized.
       for (const auto& event : prepared_send.definition_events_) {
-        tsl::BlockUntilReady(event.get());
+        if (event->IsType<BufferSequencingEvent>()) {
+          tsl::AsyncValueRef<BufferSequencingEvent> event_ref(event);
+          event_ref->WaitForEventOnStream(stream);
+        } else {
+          tsl::BlockUntilReady(event.get());
+        }
         if (auto* status = event->GetErrorIfPresent(); status != nullptr) {
           return *status;
         }


### PR DESCRIPTION
📝 Summary of Changes
This PR modifies `StreamExecutorGpuClient::ScheduleSendsOnLocalDevice` to enqueue cross-host sends as soon as the definition event of the buffer that needs to be sent has been recorded, instead of waiting for it to complete.

🎯 Justification
The original implementation blocks the execute thread until the send buffer is fully materialized before enqueuing the cross-host send. This prevents the execute thread from 'running ahead' and enqueuing multiple executables to launch on the device.

We can see this happening with [this toy program](https://gist.github.com/rao-ashish/0ecb3e3874328798e30412ab7e4870e3), which performs a matmul on devices 0-3 and transfers the result to devices 4-7. Without this fix, \~19 ms are spent blocking the execute thread between the `ncclGroupStart` and `ncclGroupEnd` for one batch of transfers:

<img width="2132" height="450" alt="cross_host_transfer_before_fix" src="https://github.com/user-attachments/assets/fff3f5c1-026f-4ead-9b64-837fc0f71d74" />

With this fix, this is reduced to \~88 us:

<img width="1195" height="636" alt="cross_host_transfer_after_fix" src="https://github.com/user-attachments/assets/b338632a-6a07-43dc-96f5-2ef26b12ef07" />

On this program, this ends up allowing us to launch matmul and data transfer kernels back-to-back, instead of incurring \~300 us of idle time on the device.

Profile screenshot before the fix, with the 300 us gap:
<img width="1587" height="76" alt="cross_host_transfer_device_before_fix" src="https://github.com/user-attachments/assets/3d4320cf-b922-463c-9b94-9e5462d9ed43" />

Profile screenshot after the fix, showing back-to-back launches:
<img width="2004" height="72" alt="cross_host_transfer_device_after_fix" src="https://github.com/user-attachments/assets/8a3d4463-afa7-449c-9f81-731f1b16993b" />


🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
The previously added unit tests inside `se_gpu_pjrt_client_test.cc` continue to pass.

🧪 Execution Tests:
Verified that the implementation still works on these [four end-to-end tests](https://gist.github.com/rao-ashish/24ac0df0cb18243c649ac535964b31b8).