### PR TITLE
[XLA:GPU] Update HLO cublas workspace size after autotuner select the algorithm

### DIFF
--- a/xla/autotuning.proto
+++ b/xla/autotuning.proto
@@ -64,6 +64,7 @@ message AutotuneResult {
 
   message GemmKey {
     int64 algorithm = 1;
+    int64 autotune_workspace_size = 2;
   }
 
   // Legacy and unused in new data; superseded by AlgorithmProto.

--- a/xla/backends/gpu/autotuner/cublas.cc
+++ b/xla/backends/gpu/autotuner/cublas.cc
@@ -158,7 +158,8 @@ absl::Status CublasBackend::ApplyConfig(HloInstruction& instr,
                       instr.backend_config<GpuBackendConfig>());
   GemmBackendConfig& backend_config = *gpu_config.mutable_gemm_backend_config();
   backend_config.set_selected_algorithm(gemm_key.algorithm());
-  backend_config.set_autotune_workspace_size(gemm_key.autotune_workspace_size());
+  backend_config.set_autotune_workspace_size(
+      gemm_key.autotune_workspace_size());
   TF_RETURN_IF_ERROR(instr.set_backend_config(std::move(gpu_config)));
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/autotuner/cublas.cc
+++ b/xla/backends/gpu/autotuner/cublas.cc
@@ -158,6 +158,7 @@ absl::Status CublasBackend::ApplyConfig(HloInstruction& instr,
                       instr.backend_config<GpuBackendConfig>());
   GemmBackendConfig& backend_config = *gpu_config.mutable_gemm_backend_config();
   backend_config.set_selected_algorithm(gemm_key.algorithm());
+  backend_config.set_autotune_workspace_size(gemm_key.autotune_workspace_size());
   TF_RETURN_IF_ERROR(instr.set_backend_config(std::move(gpu_config)));
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/autotuner/cublaslt.cc
+++ b/xla/backends/gpu/autotuner/cublaslt.cc
@@ -158,7 +158,8 @@ absl::Status CublasLtBackend::ApplyConfig(HloInstruction& instr,
                       instr.backend_config<GpuBackendConfig>());
   GemmBackendConfig& backend_config = *gpu_config.mutable_gemm_backend_config();
   backend_config.set_selected_algorithm(gemm_key.algorithm());
-  backend_config.set_autotune_workspace_size(gemm_key.autotune_workspace_size());
+  backend_config.set_autotune_workspace_size(
+      gemm_key.autotune_workspace_size());
   TF_RETURN_IF_ERROR(instr.set_backend_config(std::move(gpu_config)));
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/autotuner/cublaslt.cc
+++ b/xla/backends/gpu/autotuner/cublaslt.cc
@@ -124,6 +124,7 @@ CublasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
   for (int i = 0; i < num_algorithms; ++i) {
     CublasLtBackendConfig gemm_key;
     gemm_key.set_algorithm(i);
+    gemm_key.set_autotune_workspace_size(workspace_size);
     auto any = std::make_unique<google::protobuf::Any>();
     any->PackFrom(gemm_key);
     configs.push_back(std::move(any));
@@ -157,6 +158,7 @@ absl::Status CublasLtBackend::ApplyConfig(HloInstruction& instr,
                       instr.backend_config<GpuBackendConfig>());
   GemmBackendConfig& backend_config = *gpu_config.mutable_gemm_backend_config();
   backend_config.set_selected_algorithm(gemm_key.algorithm());
+  backend_config.set_autotune_workspace_size(gemm_key.autotune_workspace_size());
   TF_RETURN_IF_ERROR(instr.set_backend_config(std::move(gpu_config)));
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -1131,8 +1131,9 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
   CommandBufferCmdSequence commands;
   commands.Emplace<CublasLtCmd>(CublasLtMatmulThunk(
       Thunk::ThunkInfo(), /*canonical_hlo=*/"", config.value(),
-      se::gpu::BlasLt::Epilogue::kDefault, 0, slice_a, slice_b, slice_c,
-      slice_d, BufferAllocation::Slice(), BufferAllocation::Slice(),
+      se::gpu::BlasLt::Epilogue::kDefault, /*algorithm_idx=*/0,
+      /*autotune_workspace_size=*/0, slice_a, slice_b, slice_c, slice_d,
+      BufferAllocation::Slice(), BufferAllocation::Slice(),
       BufferAllocation::Slice(), BufferAllocation::Slice(),
       BufferAllocation::Slice(), BufferAllocation::Slice(),
       BufferAllocation::Slice(), slice_workspace));

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -44,6 +44,7 @@ CublasLtMatmulThunk::CublasLtMatmulThunk(const CublasLtMatmulThunk& rhs)
       gemm_config_(rhs.gemm_config_),
       epilogue_(rhs.epilogue_),
       algorithm_idx_(rhs.algorithm_idx_),
+      autotune_workspace_size_(rhs.autotune_workspace_size_),
       canonical_hlo_(rhs.canonical_hlo_),
       a_(rhs.a_),
       b_(rhs.b_),
@@ -61,7 +62,8 @@ CublasLtMatmulThunk::CublasLtMatmulThunk(const CublasLtMatmulThunk& rhs)
 CublasLtMatmulThunk::CublasLtMatmulThunk(
     Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
     GemmConfig gemm_config, se::gpu::BlasLt::Epilogue epilogue,
-    int64_t algorithm_idx, BufferAllocation::Slice a, BufferAllocation::Slice b,
+    int64_t algorithm_idx, int64_t autotune_workspace_size,
+    BufferAllocation::Slice a, BufferAllocation::Slice b,
     BufferAllocation::Slice c, BufferAllocation::Slice d,
     BufferAllocation::Slice bias, BufferAllocation::Slice aux,
     BufferAllocation::Slice a_scale, BufferAllocation::Slice b_scale,
@@ -72,6 +74,7 @@ CublasLtMatmulThunk::CublasLtMatmulThunk(
       gemm_config_(std::move(gemm_config)),
       epilogue_(epilogue),
       algorithm_idx_(algorithm_idx),
+      autotune_workspace_size_(autotune_workspace_size),
       canonical_hlo_(std::move(canonical_hlo)),
       a_(a),
       b_(b),
@@ -135,10 +138,8 @@ CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
 
     TF_ASSIGN_OR_RETURN(auto plan,
                         blas_lt->GetMatmulPlan(gemm_config_, epilogue_));
-    // if workspace buffer is not provided, consider only the algorithms which
-    // do not require a scratch space
-    int64_t max_workspace =
-        workspace_.has_value() ? workspace_.value().size() : 0;
+    // Use the workspace size that was determined during autotuning
+    int64_t max_workspace = autotune_workspace_size_;
 
     // If autotuning is disabled, there is no point on retrieving all
     // algorithms, it's enough to get the default one only.
@@ -182,6 +183,7 @@ absl::StatusOr<ThunkProto> CublasLtMatmulThunk::ToProto() const {
   cublas_lt_matmul_thunk->set_epilogue(
       stream_executor::gpu::BlasLt::EpilogueToProto(epilogue_));
   cublas_lt_matmul_thunk->set_algorithm_idx(algorithm_idx_);
+  cublas_lt_matmul_thunk->set_autotune_workspace_size(autotune_workspace_size_);
   cublas_lt_matmul_thunk->set_canonical_hlo(canonical_hlo_);
   TF_ASSIGN_OR_RETURN(*cublas_lt_matmul_thunk->mutable_a(), a_.ToProto());
   TF_ASSIGN_OR_RETURN(*cublas_lt_matmul_thunk->mutable_b(), b_.ToProto());
@@ -286,10 +288,10 @@ absl::StatusOr<std::unique_ptr<Thunk>> CublasLtMatmulThunk::FromProto(
   return std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(proto.canonical_hlo()),
       xla::gpu::GemmConfig(std::move(gemm_config)), std::move(epilogue),
-      proto.algorithm_idx(), std::move(a), std::move(b), std::move(c),
-      std::move(d), std::move(bias), std::move(aux), std::move(a_scale),
-      std::move(b_scale), std::move(c_scale), std::move(d_scale),
-      std::move(d_amax), std::move(workspace));
+      proto.algorithm_idx(), proto.autotune_workspace_size(), std::move(a),
+      std::move(b), std::move(c), std::move(d), std::move(bias), std::move(aux),
+      std::move(a_scale), std::move(b_scale), std::move(c_scale),
+      std::move(d_scale), std::move(d_amax), std::move(workspace));
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -138,7 +138,10 @@ CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
 
     TF_ASSIGN_OR_RETURN(auto plan,
                         blas_lt->GetMatmulPlan(gemm_config_, epilogue_));
-    // Use the workspace size that was determined during autotuning
+
+    // Set the workspace size to the size that was used for autotuning, so
+    // algorithm index will be the same as returned by GetAlgorithms called
+    // during autotuning.
     int64_t max_workspace = autotune_workspace_size_;
 
     // If autotuning is disabled, there is no point on retrieving all

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
@@ -38,6 +38,7 @@ class CublasLtMatmulThunk : public Thunk {
   CublasLtMatmulThunk(Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
                       GemmConfig gemm_config,
                       se::gpu::BlasLt::Epilogue epilogue, int64_t algorithm_idx,
+                      int64_t autotune_workspace_size,
                       BufferAllocation::Slice a, BufferAllocation::Slice b,
                       BufferAllocation::Slice c, BufferAllocation::Slice d,
                       BufferAllocation::Slice bias /* may be null */,
@@ -75,6 +76,7 @@ class CublasLtMatmulThunk : public Thunk {
   GemmConfig gemm_config_;
   se::gpu::BlasLt::Epilogue epilogue_;
   int64_t algorithm_idx_;
+  int64_t autotune_workspace_size_;
   std::string canonical_hlo_;
   BufferAllocation::Slice a_;
   BufferAllocation::Slice b_;

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
@@ -159,9 +159,9 @@ class GpuBlasLtThunkBuilder {
     return std::make_unique<CublasLtMatmulThunk>(
         std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
         epilogue,
-        /*algorithm_idx*/ 0, slices[0], slices[1],
-        has_matrix_bias ? slices[2] : slices.back(), slices.back(), bias,
-        BufferAllocation::Slice{} /* aux */,
+        /*algorithm_idx*/ 0, backend_config.autotune_workspace_size(),
+        slices[0], slices[1], has_matrix_bias ? slices[2] : slices.back(),
+        slices.back(), bias, BufferAllocation::Slice{} /* aux */,
         BufferAllocation::Slice{} /* a_scale */,
         BufferAllocation::Slice{} /* b_scale */,
         BufferAllocation::Slice{} /* c_scale */,

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -232,6 +232,7 @@ message CublasLtMatmulThunkProto {
   optional xla.buffer_assignment.BufferAllocationSliceProto d_scale = 14;
   optional xla.buffer_assignment.BufferAllocationSliceProto d_amax = 15;
   optional xla.buffer_assignment.BufferAllocationSliceProto workspace = 16;
+  int64 autotune_workspace_size = 17;
 }
 
 message CubSortThunkProto {

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1778,6 +1778,7 @@ cc_library(
         "//xla/service/gpu/transforms:gemm_broadcast_folding_rewriter",
         "//xla/service/gpu/transforms:gemm_fusion",
         "//xla/service/gpu/transforms:gemm_fusion_swap_operands",
+        "//xla/service/gpu/transforms:gemm_workspace_rewriter",
         "//xla/service/gpu/transforms:gemm_rewriter",
         "//xla/service/gpu/transforms:gemv_rewriter",
         "//xla/service/gpu/transforms:layout_assignment",

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -109,6 +109,9 @@ message GemmBackendConfig {
   bool damax_output = 18;
 
   reserved 19;
+
+  // The workspace size used during autotuning when the algorithm was selected.
+  int64 autotune_workspace_size = 20;
 }
 
 // Backend config for bitcast operation generated from MLIR MHLO dialect.

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -671,8 +671,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunk(
       HloPrintOptions::Fingerprint().set_print_backend_config(true));
   auto thunk = std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
-      blas_lt_epilogue, algorithm, a, b, c, d, bias, aux, a_scale, b_scale,
-      c_scale, d_scale, d_amax, workspace_buffer);
+      blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
+      bias, aux, a_scale, b_scale, c_scale, d_scale, d_amax, workspace_buffer);
   return GetThunkSequence(std::move(thunk));
 }
 
@@ -766,8 +766,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunkF8(
       HloPrintOptions::Fingerprint().set_print_backend_config(true));
   auto thunk = std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
-      blas_lt_epilogue, algorithm, a, b, c, d, bias, aux, a_scale, b_scale,
-      c_scale, d_scale, d_amax, workspace_buffer);
+      blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
+      bias, aux, a_scale, b_scale, c_scale, d_scale, d_amax, workspace_buffer);
   return GetThunkSequence(std::move(thunk));
 }
 

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1377,6 +1377,30 @@ xla_test(
 )
 
 cc_library(
+    name = "gemm_workspace_rewriter",
+    srcs = ["gemm_workspace_rewriter.cc"],
+    hdrs = ["gemm_workspace_rewriter.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:cublas_cudnn",
+        "//xla/service/gpu:matmul_utils",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/gpu:gpu_blas_lt",
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+cc_library(
     name = "gemm_fusion",
     srcs = ["gemm_fusion.cc"],
     hdrs = ["gemm_fusion.h"],

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -1400,6 +1400,20 @@ cc_library(
     ],
 )
 
+xla_test(
+    name = "gemm_workspace_rewriter_test",
+    srcs = ["gemm_workspace_rewriter_test.cc"],
+    backends = ["gpu"],
+    deps = [
+        ":gemm_workspace_rewriter",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu/tests:gpu_codegen_test",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:statusor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "gemm_fusion",
     srcs = ["gemm_fusion.cc"],

--- a/xla/service/gpu/transforms/gemm_workspace_rewriter.cc
+++ b/xla/service/gpu/transforms/gemm_workspace_rewriter.cc
@@ -1,0 +1,243 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/gemm_workspace_rewriter.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/service/gpu/matmul_utils.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/gpu_blas_lt.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace xla {
+namespace gpu {
+
+namespace se = ::stream_executor;
+using se::gpu::BlasLt;
+
+namespace {
+
+absl::StatusOr<BlasLt::Epilogue> AsBlasLtEpilogue(
+    GemmBackendConfig_Epilogue epilogue) {
+  switch (epilogue) {
+    case GemmBackendConfig::DEFAULT:
+      return BlasLt::Epilogue::kDefault;
+    case GemmBackendConfig::RELU:
+      return BlasLt::Epilogue::kReLU;
+    case GemmBackendConfig::GELU:
+      return BlasLt::Epilogue::kGELU;
+    case GemmBackendConfig::GELU_AUX:
+      return BlasLt::Epilogue::kGELUWithAux;
+    case GemmBackendConfig::BIAS:
+      return BlasLt::Epilogue::kBias;
+    case GemmBackendConfig::BIAS_RELU:
+      return BlasLt::Epilogue::kBiasThenReLU;
+    case GemmBackendConfig::BIAS_GELU:
+      return BlasLt::Epilogue::kBiasThenGELU;
+    case GemmBackendConfig::BIAS_GELU_AUX:
+      return BlasLt::Epilogue::kBiasThenGELUWithAux;
+    default:
+      return absl::InternalError("Unsupported Epilogue.");
+  }
+}
+
+// Visitor that updates workspace sizes for cuBLASLt GEMM operations
+// based on the selected algorithm's actual workspace requirement.
+class GemmWorkspaceRewriteVisitor : public DfsHloRewriteVisitor {
+ public:
+  explicit GemmWorkspaceRewriteVisitor(
+      const se::GpuComputeCapability& gpu_version,
+      se::StreamExecutor* stream_exec)
+      : gpu_version_(gpu_version), stream_exec_(stream_exec) {}
+
+  absl::Status HandleCustomCall(HloInstruction* instr) override {
+    // Only handle cuBLASLt matmul calls
+    if (instr->custom_call_target() != kCublasLtMatmulCallTarget &&
+        instr->custom_call_target() != kCublasLtMatmulF8CallTarget) {
+      return absl::OkStatus();
+    }
+
+    // Skip if stream executor is not available
+    if (stream_exec_ == nullptr) {
+      return absl::OkStatus();
+    }
+
+    // Get the backend config
+    TF_ASSIGN_OR_RETURN(auto gpu_config,
+                        instr->backend_config<GpuBackendConfig>());
+    const GemmBackendConfig& config = gpu_config.gemm_backend_config();
+
+    // Skip if no algorithm has been selected (not autotuned yet)
+    if (config.algorithm_case() != GemmBackendConfig::kSelectedAlgorithm) {
+      return absl::OkStatus();
+    }
+
+    int64_t selected_algorithm = config.selected_algorithm();
+
+    // Get the current output shape - must be a tuple with workspace as last
+    // element
+    if (!instr->shape().IsTuple() || instr->shape().tuple_shapes().empty()) {
+      return absl::OkStatus();
+    }
+
+    // Get the current workspace size
+    const Shape& current_workspace_shape = instr->shape().tuple_shapes().back();
+    if (current_workspace_shape.element_type() != S8) {
+      return absl::OkStatus();
+    }
+    int64_t current_workspace_size =
+        ShapeUtil::ByteSizeOf(current_workspace_shape);
+
+    // Create GemmConfig to get the matmul plan
+    TF_ASSIGN_OR_RETURN(GemmConfig gemm_config,
+                        GemmConfig::For(instr, gpu_version_));
+
+    // Get the epilogue
+    TF_ASSIGN_OR_RETURN(BlasLt::Epilogue epilogue,
+                        AsBlasLtEpilogue(config.epilogue()));
+
+    // Create a stream to query algorithms
+    TF_ASSIGN_OR_RETURN(std::unique_ptr<se::Stream> stream,
+                        stream_exec_->CreateStream());
+
+    // Get the matmul plan
+    TF_ASSIGN_OR_RETURN(
+        std::unique_ptr<BlasLt::MatmulPlan> plan,
+        se::gpu::BlasLt::GetMatmulPlan(stream.get(), gemm_config, epilogue));
+
+    // Query algorithms with the current workspace size limit
+    TF_ASSIGN_OR_RETURN(
+        std::vector<BlasLt::MatmulAlgorithm> algorithms,
+        plan->GetAlgorithms(stream.get(), GemmConfig::kNumAlgorithms,
+                            current_workspace_size));
+
+    // Verify that the selected algorithm index is valid
+    if (selected_algorithm < 0 ||
+        selected_algorithm >= static_cast<int64_t>(algorithms.size())) {
+      VLOG(3) << "Selected algorithm index " << selected_algorithm
+              << " is out of range for " << instr->name()
+              << ", skipping workspace update.";
+      return absl::OkStatus();
+    }
+
+    // Get the actual workspace size for the selected algorithm
+    int64_t actual_workspace_size =
+        static_cast<int64_t>(algorithms[selected_algorithm].workspace_size);
+
+    // If the workspace size is already optimal, nothing to do
+    if (actual_workspace_size == current_workspace_size) {
+      return absl::OkStatus();
+    }
+
+    // Ensure we're not increasing the workspace size
+    if (actual_workspace_size > current_workspace_size) {
+      VLOG(3) << "Algorithm workspace size (" << actual_workspace_size
+              << ") exceeds current allocation (" << current_workspace_size
+              << ") for " << instr->name() << ", skipping update.";
+      return absl::OkStatus();
+    }
+
+    VLOG(2) << "Updating workspace size for " << instr->name() << " from "
+            << current_workspace_size << " to " << actual_workspace_size;
+
+    // Build the new output shape with updated workspace size
+    std::vector<Shape> output_shapes;
+    for (int i = 0; i < instr->shape().tuple_shapes_size() - 1; ++i) {
+      output_shapes.push_back(instr->shape().tuple_shapes(i));
+    }
+    output_shapes.push_back(ShapeUtil::MakeShape(S8, {actual_workspace_size}));
+    Shape new_output_shape = ShapeUtil::MakeTupleShape(output_shapes);
+
+    // Clone the instruction with the new shape
+    HloInstruction* new_call = instr->AddInstruction(
+        instr->CloneWithNewOperands(new_output_shape, instr->operands()));
+
+    // Update operand aliasing if present
+    auto* custom_call = Cast<HloCustomCallInstruction>(new_call);
+    if (!custom_call->output_to_operand_aliasing().empty()) {
+      custom_call->set_output_to_operand_aliasing(
+          Cast<HloCustomCallInstruction>(instr)->output_to_operand_aliasing());
+    }
+
+    // Collect users first to avoid modifying during iteration
+    std::vector<HloInstruction*> users(instr->users().begin(),
+                                       instr->users().end());
+
+    // Replace all users of the old instruction
+    for (HloInstruction* user : users) {
+      HloGetTupleElementInstruction* user_get_tuple =
+          DynCast<HloGetTupleElementInstruction>(user);
+      if (user_get_tuple == nullptr) {
+        continue;
+      }
+      HloInstruction* get_output =
+          instr->AddInstruction(HloInstruction::CreateGetTupleElement(
+              new_call, user_get_tuple->tuple_index()));
+      TF_RETURN_IF_ERROR(ReplaceInstruction(user_get_tuple, get_output));
+    }
+
+    MarkAsChanged();
+    return absl::OkStatus();
+  }
+
+ private:
+  se::GpuComputeCapability gpu_version_;
+  se::StreamExecutor* stream_exec_;
+};
+
+}  // namespace
+
+absl::StatusOr<bool> GemmWorkspaceRewriter::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  // Skip if stream executor is not available
+  if (stream_exec_ == nullptr) {
+    VLOG(2) << "Stream executor not available, skipping workspace rewrite.";
+    return false;
+  }
+
+  bool changed = false;
+  for (HloComputation* computation :
+       module->MakeNonfusionComputations(execution_threads)) {
+    GemmWorkspaceRewriteVisitor visitor(gpu_version_, stream_exec_);
+    TF_RETURN_IF_ERROR(computation->Accept(&visitor));
+    changed |= visitor.changed();
+  }
+  return changed;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/service/gpu/transforms/gemm_workspace_rewriter.h
+++ b/xla/service/gpu/transforms/gemm_workspace_rewriter.h
@@ -1,0 +1,55 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef XLA_SERVICE_GPU_TRANSFORMS_GEMM_WORKSPACE_REWRITER_H_
+#define XLA_SERVICE_GPU_TRANSFORMS_GEMM_WORKSPACE_REWRITER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla {
+namespace gpu {
+
+// This pass updates the workspace size for cuBLAS/cuBLASLt GEMM operations
+// after autotuning has selected a specific algorithm. The GemmRewriter pass
+// conservatively allocates workspace before autotuning. After autotuning,
+// we know the exact algorithm selected and can query its actual workspace
+// requirement, potentially reducing memory usage.
+class GemmWorkspaceRewriter : public HloModulePass {
+ public:
+  explicit GemmWorkspaceRewriter(const se::GpuComputeCapability& gpu_version,
+                                 stream_executor::StreamExecutor* stream_exec)
+      : gpu_version_(gpu_version), stream_exec_(stream_exec) {}
+
+  absl::string_view name() const override { return "gemm-workspace-rewriter"; }
+
+ protected:
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  se::GpuComputeCapability gpu_version_;
+  stream_executor::StreamExecutor* stream_exec_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_SERVICE_GPU_TRANSFORMS_GEMM_WORKSPACE_REWRITER_H_

--- a/xla/service/gpu/transforms/gemm_workspace_rewriter_test.cc
+++ b/xla/service/gpu/transforms/gemm_workspace_rewriter_test.cc
@@ -1,0 +1,69 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/transforms/gemm_workspace_rewriter.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/gpu/tests/gpu_codegen_test.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+namespace se = ::stream_executor;
+
+class GemmWorkspaceRewriterTest : public GpuCodegenTest {};
+
+// Tests that cuBLASLt calls with a selected algorithm and large workspace
+// are rewritten to use a smaller workspace.
+TEST_F(GemmWorkspaceRewriterTest,
+       CublasLtCallWithSelectedAlgorithmIsRewritten) {
+  // This HLO simulates a cuBLASLt matmul after autotuning - it has
+  // selected_algorithm set and a conservatively large workspace.
+  const char* hlo_text = R"(
+HloModule TestModule
+
+ENTRY main {
+  lhs = f32[32,64] parameter(0)
+  rhs = f32[64,128] parameter(1)
+  custom_call = (f32[32,128], s8[4194304]) custom-call(lhs, rhs),
+    custom_call_target="__cublas$lt$matmul",
+    backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"gemm_backend_config":{"alpha_real":1,"alpha_imag":0,"beta":0,"dot_dimension_numbers":{"lhs_contracting_dimensions":["1"],"rhs_contracting_dimensions":["0"],"lhs_batch_dimensions":[],"rhs_batch_dimensions":[]},"precision_config":{"operand_precision":["DEFAULT","DEFAULT"]},"epilogue":"DEFAULT","selected_algorithm":"0"}}
+  ROOT result = f32[32,128] get-tuple-element(custom_call), index=0
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+
+  se::StreamExecutor* stream_exec = backend().default_stream_executor();
+  GemmWorkspaceRewriter pass(
+      stream_exec->GetDeviceDescription().gpu_compute_capability(),
+      stream_exec);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+
+  // The pass should reduce the workspace size from 4MB to the algorithm's
+  // actual requirement (typically much smaller).
+  EXPECT_TRUE(changed);
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes

This PR introduces a pass that updates the workspace size for cuBLAS/cuBLASLt GEMM operations after autotuning has selected a specific algorithm. The GemmRewriter pass conservatively allocates workspace before autotuning. After autotuning,we know the exact algorithm selected and can query its actual workspace requirement, potentially reducing memory usage.

🎯 Justification
Potentially reducing memory usage.

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,

🧪 Unit Tests:
Existing gemm tests should cover the workspace size config.
