### PR TITLE
[XLA:GPU] use algirhtm id instead algorithm index to pass cublas autotune result

### DIFF
--- a/xla/autotuning.proto
+++ b/xla/autotuning.proto
@@ -64,6 +64,10 @@ message AutotuneResult {
 
   message GemmKey {
     int64 algorithm = 1;
+    // Stable algorithm identity from cuBLAS (CUBLASLT_ALGO_CONFIG_ID).
+    // This ID uniquely identifies the algorithm and is stable across
+    // different GetAlgorithms calls regardless of workspace filtering.
+    int64 algorithm_id = 2;
   }
 
   // Legacy and unused in new data; superseded by AlgorithmProto.

--- a/xla/backends/gpu/autotuner/fission_backend_test.cc
+++ b/xla/backends/gpu/autotuner/fission_backend_test.cc
@@ -299,7 +299,7 @@ INSTANTIATE_TEST_SUITE_P(
          &FissionTest::CreateCublasBackendWiithF8Fallback,
          /*expected_module_substrings=*/
          {"custom_call_target=\"__cublas$lt$matmul$f8\"",
-          "\"selected_algorithm\":\"0\""},
+          "\"algorithm_id\":"},
          /*expected_backend_name=*/"Cublas_fission"},
         {"TritonFusion_CustomKernel",
          kTritonFusionHlo,

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
@@ -37,7 +37,7 @@ class CublasLtMatmulThunk : public Thunk {
  public:
   CublasLtMatmulThunk(Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
                       GemmConfig gemm_config,
-                      se::gpu::BlasLt::Epilogue epilogue, int64_t algorithm_idx,
+                      se::gpu::BlasLt::Epilogue epilogue, int64_t algorithm_id,
                       BufferAllocation::Slice a, BufferAllocation::Slice b,
                       BufferAllocation::Slice c, BufferAllocation::Slice d,
                       BufferAllocation::Slice bias /* may be null */,
@@ -74,7 +74,8 @@ class CublasLtMatmulThunk : public Thunk {
 
   GemmConfig gemm_config_;
   se::gpu::BlasLt::Epilogue epilogue_;
-  int64_t algorithm_idx_;
+  // Stable algorithm identity from cuBLAS (CUBLASLT_ALGO_CONFIG_ID).
+  int64_t algorithm_id_;
   std::string canonical_hlo_;
   BufferAllocation::Slice a_;
   BufferAllocation::Slice b_;

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -218,7 +218,7 @@ message SelectKThunkProto {
 message CublasLtMatmulThunkProto {
   xla.GemmConfigProto gemm_config = 1;
   xla.BlasLtEpilogueProto epilogue = 2;
-  int64 algorithm_idx = 3;
+  reserved 3;  // Previously algorithm_idx (removed).
   string canonical_hlo = 4;
   xla.buffer_assignment.BufferAllocationSliceProto a = 5;
   xla.buffer_assignment.BufferAllocationSliceProto b = 6;
@@ -232,6 +232,8 @@ message CublasLtMatmulThunkProto {
   optional xla.buffer_assignment.BufferAllocationSliceProto d_scale = 14;
   optional xla.buffer_assignment.BufferAllocationSliceProto d_amax = 15;
   optional xla.buffer_assignment.BufferAllocationSliceProto workspace = 16;
+  // Stable algorithm identity from cuBLAS (CUBLASLT_ALGO_CONFIG_ID).
+  int64 algorithm_id = 17;
 }
 
 message CubSortThunkProto {

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -109,6 +109,12 @@ message GemmBackendConfig {
   bool damax_output = 18;
 
   reserved 19;
+
+  // cuBLASLt algorithm identity. This is the stable algorithm ID from cuBLAS
+  // that uniquely identifies the algorithm across different GetAlgorithms
+  // calls. Unlike selected_algorithm (which is an index), this ID is stable
+  // regardless of workspace size filtering.
+  optional int64 algorithm_id = 20;
 }
 
 // Backend config for bitcast operation generated from MLIR MHLO dialect.

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -655,20 +655,13 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunk(
       GemmConfig::For(static_cast<const HloInstruction*>(instr),
                       ir_emitter_context_->gpu_compute_capability()));
 
-  // Use the first algorithm by default (i.e. fastest according to
-  // heuristics).
-  int64_t algorithm =
-      config.algorithm_case() == GemmBackendConfig::kSelectedAlgorithm
-          ? config.selected_algorithm()
-          : 0;
-
-  // Extract the stable algorithm ID if available. This allows finding the
-  // correct algorithm at runtime even if workspace size filtering changes
-  // the algorithm index ordering.
-  std::optional<int64_t> algorithm_id;
-  if (config.has_algorithm_id()) {
-    algorithm_id = config.algorithm_id();
+  // Extract the stable algorithm ID from cuBLAS.
+  if (!config.has_algorithm_id()) {
+    return Internal(
+        "CublasLtMatmul instruction must have algorithm_id set: %s",
+        instr->ToString());
   }
+  int64_t algorithm_id = config.algorithm_id();
 
   BufferAllocation::Slice a_scale, b_scale, c_scale, d_scale, d_amax;
   TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::Epilogue blas_lt_epilogue,
@@ -679,8 +672,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunk(
       HloPrintOptions::Fingerprint().set_print_backend_config(true));
   auto thunk = std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
-      blas_lt_epilogue, algorithm, algorithm_id, a, b, c, d, bias, aux,
-      a_scale, b_scale, c_scale, d_scale, d_amax, workspace_buffer);
+      blas_lt_epilogue, algorithm_id, a, b, c, d, bias, aux, a_scale, b_scale,
+      c_scale, d_scale, d_amax, workspace_buffer);
   return GetThunkSequence(std::move(thunk));
 }
 

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -162,6 +162,10 @@ struct BlasLt {
   struct MatmulAlgorithm {
     std::any opaque_algo;
     size_t workspace_size;
+    // Stable algorithm identity from cuBLAS (CUBLASLT_ALGO_CONFIG_ID).
+    // This ID uniquely identifies the algorithm and is stable across
+    // different GetAlgorithms calls regardless of workspace filtering.
+    int64_t algorithm_id;
   };
 
   struct MemoryArgs {

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -281,10 +281,16 @@ auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
 
   std::vector<MatmulAlgorithm> algorithms;
   algorithms.reserve(results.size());
+  int64_t index = 0;
   for (const hipblasLtMatmulHeuristicResult_t& result : results) {
     if (result.state == HIPBLAS_STATUS_SUCCESS) {  // Skip failed algos.
-      algorithms.push_back({result.algo, result.workspaceSize});
+      // ROCm's hipBLASLt doesn't have an equivalent to CUBLASLT_ALGO_CONFIG_ID,
+      // so we use the index as a fallback algorithm_id. This means ROCm will
+      // still have the workspace size dependency issue.
+      // TODO(b/XXXXXX): Investigate hipBLASLt for stable algorithm IDs.
+      algorithms.push_back({result.algo, result.workspaceSize, index});
     }
+    ++index;
   }
   return std::move(algorithms);
 }


### PR DESCRIPTION
📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
