### PR TITLE
[ROCm] Fix rocm build due to inverted condition

### DIFF
--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -77,7 +77,7 @@ class LowerToLLVMGPUPass
       : device_spec_(device_description) {}
 
   void runOnOperation() override {
-    if (gpu_device_info_.empty()) {
+    if (!gpu_device_info_.empty()) {
       se::GpuDeviceInfoProto device_info;
       CHECK(tsl::protobuf::TextFormat::ParseFromString(gpu_device_info_,
                                                        &device_info));


### PR DESCRIPTION
📝 Summary of Changes
Looks there is invalid check introduced in this commit:
https://github.com/openxla/xla/commit/349a1d4e00cf33dbabd1db5771d03b0c5a4aea61
<img width="1012" height="175" alt="image" src="https://github.com/user-attachments/assets/03ead4ea-b5ab-40f5-9af2-17d85e402cd0" />
 

🎯 Justification
This commit breaks all the rocm tests, we start getting ir code for nvidia gpus. 
Inverting the check fixes them.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
All rocm u-tests

🧪 Execution Tests:
CI
