### PR TITLE
[ROCm] fixed //xla/tools/hlo_opt:tests/gpu_hlo_llvm.hlo.test

### DIFF
--- a/xla/tools/hlo_opt/tests/gpu_hlo_llvm.hlo
+++ b/xla/tools/hlo_opt/tests/gpu_hlo_llvm.hlo
@@ -22,9 +22,9 @@ ENTRY e {
 HloModule Test, is_scheduled=true
 
 
-// CHECK-LABEL: fusion
-// CHECK-PTX:     call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
-// CHECK-GCN:     call void @llvm.amdgcn.s.barrier
+// CHECK-LABEL: wrapped_b
+// CHECK-PTX:     call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+// CHECK-GCN:     call i32 @llvm.amdgcn.workitem.id.x()
 fused_computation {
   param_0 = f32[100,200]{1,0} parameter(0)
   ROOT b.1 = f32[100,200]{0,1} copy(f32[100,200]{1,0} param_0)


### PR DESCRIPTION
The PR fixed the failed //xla/tools/hlo_opt:tests/gpu_hlo_llvm.hlo.test on rocm.

The @wrapped_b kernel (the transpose) was never actually tested because its name doesn't contain "fusion".

The test passed on NVIDIA "by accident" - it was checking the reduce kernel twice, not the transpose kernel. The fix to use CHECK-LABEL: wrapped_b actually makes the test check what it was originally intended to check.

For the second transpose test, both platforms use the direct element-wise copy approach.

With this PR,  the test can pass on both MI300x and H100.

**./bazel-7.4.1-linux-x86_64 run --test_sharding_strategy=disabled //xla/tools/hlo_opt:tests/gpu_hlo_llvm.hlo.test**

@xla-rotation could you review my PR, please?