### PR TITLE
[ROCm] Support SiLU epilogues in gpu autotuning

### DIFF
--- a/xla/backends/gpu/autotuner/cublaslt.cc
+++ b/xla/backends/gpu/autotuner/cublaslt.cc
@@ -61,6 +61,8 @@ absl::StatusOr<BlasLt::Epilogue> AsBlasLtEpilogue(
       return BlasLt::Epilogue::kGELU;
     case GemmBackendConfig::GELU_AUX:
       return BlasLt::Epilogue::kGELUWithAux;
+    case GemmBackendConfig::SILU:
+      return BlasLt::Epilogue::kSILU;
     case GemmBackendConfig::BIAS:
       return BlasLt::Epilogue::kBias;
     case GemmBackendConfig::BIAS_RELU:
@@ -69,6 +71,8 @@ absl::StatusOr<BlasLt::Epilogue> AsBlasLtEpilogue(
       return BlasLt::Epilogue::kBiasThenGELU;
     case GemmBackendConfig::BIAS_GELU_AUX:
       return BlasLt::Epilogue::kBiasThenGELUWithAux;
+    case GemmBackendConfig::BIAS_SILU:
+      return BlasLt::Epilogue::kBiasThenSILU;
     default:
       return Internal("Unsupported Epilogue.");
   }


### PR DESCRIPTION
Add missing SiLU GemmBackendConfig->BlatLt::Epilogue mappings in gpu autotuner. Fixes errors on ROCm where SiLU epilogues are supported but autotuning fails with "Unsupported Epilogue".
