### PR TITLE
[ROCm] Reimplement register spilling detection

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -579,7 +579,6 @@ alias(
         threshold = 71000,
         value = rocm_version_number(),
     ),
-    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -207,13 +207,12 @@ cc_library(
         "@llvm-project//llvm:Linker",
         "@llvm-project//llvm:MC",
         "@llvm-project//llvm:ObjCARC",  # buildcleaner: keep
+        "@llvm-project//llvm:Object",
         "@llvm-project//llvm:Passes",
         "@llvm-project//llvm:Scalar",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
         "@llvm-project//llvm:TargetParser",
-        "@local_config_rocm//rocm:amd_comgr",
-        "@local_config_rocm//rocm:rocm_headers",
         "@tsl//tsl/platform:path",
         "@tsl//tsl/platform:random",
         "@tsl//tsl/profiler/lib:traceme",
@@ -310,6 +309,33 @@ xla_cc_test(
         "@com_google_googletest//:gtest_main",
         "@llvm-project//llvm:ir_headers",
         "@tsl//tsl/platform:path",
+    ],
+)
+
+xla_cc_test(
+    name = "amdgpu_register_spilling_test",
+    size = "small",
+    srcs = ["amdgpu_register_spilling_test.cc"],
+    data = [
+        "tests_data/amdgpu_dynamic_stack.ll",
+        "tests_data/amdgpu_no_spills.ll",
+        "tests_data/amdgpu_sgpr_spills.ll",
+        "tests_data/amdgpu_vgpr_spills.ll",
+    ],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":amdgpu_backend",
+        ":load_ir_module",
+        "//xla/stream_executor:device_description",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//llvm:ir_headers",
+        "@tsl//tsl/platform:path",
+        "@tsl//tsl/platform:test",
     ],
 )
 

--- a/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
@@ -40,10 +40,15 @@ limitations under the License.
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
-#include "amd_comgr/amd_comgr.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/AMDGPUMetadata.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
@@ -150,6 +155,231 @@ struct HsacoCache {
 };
 
 static HsacoCache g_hsacoCache;  // NOLINT: static/global vars forbidden
+
+// Structure to hold register spilling and stack information from HSACO metadata
+struct RegisterSpillInfo {
+  uint64_t sgpr_spill_count = 0;
+  uint64_t vgpr_spill_count = 0;
+  uint64_t private_segment_size = 0;
+  bool uses_dynamic_stack = false;
+
+  bool HasSpilling() const {
+    return sgpr_spill_count > 0 || vgpr_spill_count > 0;
+  }
+
+  bool HasStackUsage() const {
+    return private_segment_size > 0 || uses_dynamic_stack;
+  }
+};
+
+// Parse NT_AMDGPU_METADATA note contents and extract register spill counts.
+// The metadata is in MessagePack format containing kernel information.
+RegisterSpillInfo ParseAMDGPUMetadataForSpills(llvm::StringRef metadata) {
+  RegisterSpillInfo spill_info;
+
+  // Parse the MsgPack metadata
+  llvm::msgpack::Document doc;
+  if (!doc.readFromBlob(metadata, /*Multi=*/false)) {
+    VLOG(2) << "Could not parse MsgPack metadata from NT_AMDGPU_METADATA note";
+    return spill_info;
+  }
+
+  llvm::msgpack::DocNode root = doc.getRoot();
+  if (!root.isMap()) {
+    VLOG(2) << "AMDGPU metadata root is not a map (unexpected format)";
+    return spill_info;
+  }
+
+  // Look for "amdhsa.kernels" array
+  llvm::msgpack::MapDocNode root_map = root.getMap();
+  auto kernels_it = root_map.find("amdhsa.kernels");
+
+  if (kernels_it == root_map.end() || !kernels_it->second.isArray()) {
+    VLOG(2) << "NT_AMDGPU_METADATA found but missing 'amdhsa.kernels' array";
+    return spill_info;
+  }
+
+  llvm::msgpack::ArrayDocNode kernels_array = kernels_it->second.getArray();
+
+  // Iterate through each kernel
+  for (auto& kernel_node : kernels_array) {
+    uint64_t kernel_sgpr_spill = 0;
+    uint64_t kernel_vgpr_spill = 0;
+    uint64_t kernel_sgpr_count = 0;
+    uint64_t kernel_vgpr_count = 0;
+    uint64_t kernel_private_size = 0;
+    bool kernel_uses_dynamic = false;
+
+    if (!kernel_node.isMap()) continue;
+
+    llvm::msgpack::MapDocNode kernel_map = kernel_node.getMap();
+
+    // Look for ".sgpr_spill_count"
+    auto sgpr_it = kernel_map.find(".sgpr_spill_count");
+    if (sgpr_it != kernel_map.end() &&
+        sgpr_it->second.getKind() == llvm::msgpack::Type::UInt) {
+      kernel_sgpr_spill = sgpr_it->second.getUInt();
+      spill_info.sgpr_spill_count =
+          std::max(spill_info.sgpr_spill_count, kernel_sgpr_spill);
+    }
+
+    // Look for ".vgpr_spill_count"
+    auto vgpr_it = kernel_map.find(".vgpr_spill_count");
+    if (vgpr_it != kernel_map.end() &&
+        vgpr_it->second.getKind() == llvm::msgpack::Type::UInt) {
+      kernel_vgpr_spill = vgpr_it->second.getUInt();
+      spill_info.vgpr_spill_count =
+          std::max(spill_info.vgpr_spill_count, kernel_vgpr_spill);
+    }
+
+    // Look for ".private_segment_fixed_size"
+    auto priv_it = kernel_map.find(".private_segment_fixed_size");
+    if (priv_it != kernel_map.end() &&
+        priv_it->second.getKind() == llvm::msgpack::Type::UInt) {
+      kernel_private_size = priv_it->second.getUInt();
+      spill_info.private_segment_size =
+          std::max(spill_info.private_segment_size, kernel_private_size);
+    }
+
+    // Look for ".uses_dynamic_stack"
+    auto dyn_it = kernel_map.find(".uses_dynamic_stack");
+    if (dyn_it != kernel_map.end() &&
+        dyn_it->second.getKind() == llvm::msgpack::Type::Boolean) {
+      kernel_uses_dynamic = dyn_it->second.getBool();
+      spill_info.uses_dynamic_stack =
+          spill_info.uses_dynamic_stack || kernel_uses_dynamic;
+    }
+
+    // Helper to get kernel name for logging (only when needed)
+    auto get_kernel_name = [&kernel_map]() -> std::string {
+      auto name_it = kernel_map.find(".name");
+      if (name_it != kernel_map.end() &&
+          name_it->second.getKind() == llvm::msgpack::Type::String) {
+        return name_it->second.getString().str();
+      }
+      return "unknown";
+    };
+
+    // Log per-kernel spill information with register usage
+    if (kernel_sgpr_spill > 0 || kernel_vgpr_spill > 0) {
+      // Look for ".sgpr_count" (total SGPRs used)
+      auto sgpr_count_it = kernel_map.find(".sgpr_count");
+      if (sgpr_count_it != kernel_map.end() &&
+          sgpr_count_it->second.getKind() == llvm::msgpack::Type::UInt) {
+        kernel_sgpr_count = sgpr_count_it->second.getUInt();
+      }
+
+      // Look for ".vgpr_count" (total VGPRs used)
+      auto vgpr_count_it = kernel_map.find(".vgpr_count");
+      if (vgpr_count_it != kernel_map.end() &&
+          vgpr_count_it->second.getKind() == llvm::msgpack::Type::UInt) {
+        kernel_vgpr_count = vgpr_count_it->second.getUInt();
+      }
+
+      VLOG(2) << "Kernel '" << get_kernel_name() << "' has register spilling: "
+              << "SGPR=" << kernel_sgpr_spill << ", VGPR=" << kernel_vgpr_spill
+              << ". Register count: SGPR=" << kernel_sgpr_count
+              << ", VGPR=" << kernel_vgpr_count;
+    }
+
+    // Log per-kernel stack usage
+    if (kernel_private_size > 0 || kernel_uses_dynamic) {
+      VLOG(2) << "Kernel '" << get_kernel_name() << "' stack usage: "
+              << "private=" << kernel_private_size
+              << ", dynamic=" << (kernel_uses_dynamic ? "true" : "false");
+    }
+  }
+
+  return spill_info;
+}
+
+// ELF note descriptor alignment per ELF specification
+constexpr int kElfNoteDescAlignment = 4;
+
+// Returns spill counts by parsing AMDGPU metadata from note sections of HSACO
+// ELF binary.
+//
+// HSACO file (ELF binary)
+//   -- .note section(s)
+//       -- ELF Note with type=NT_AMDGPU_METADATA
+//           -- MessagePack data
+//               -- Root map
+//                   -- "amdhsa.kernels" array
+//                       -- Each kernel object
+//                           - ".sgpr_spill_count"
+//                           - ".vgpr_spill_count"
+//                           - ... (other kernel properties)
+RegisterSpillInfo ExtractRegisterSpillingFromHsaco(
+    const std::vector<uint8_t>& hsaco) {
+  RegisterSpillInfo spill_info;
+
+  // Create memory buffer from HSACO data
+  std::unique_ptr<llvm::MemoryBuffer> mem_buffer =
+      llvm::MemoryBuffer::getMemBuffer(
+          llvm::StringRef(reinterpret_cast<const char*>(hsaco.data()),
+                          hsaco.size()),
+          "", /*RequiresNullTerminator=*/false);
+
+  // Parse as ELF object file
+  llvm::Expected<std::unique_ptr<llvm::object::ObjectFile>> obj_or_err =
+      llvm::object::ObjectFile::createObjectFile(mem_buffer->getMemBufferRef());
+
+  if (!obj_or_err) {
+    VLOG(2) << "Could not parse HSACO as ELF object file: "
+            << llvm::toString(obj_or_err.takeError());
+    return spill_info;
+  }
+
+  llvm::object::ObjectFile* obj = obj_or_err->get();
+
+  // Cast to ELF64LE object file (AMDGPU uses 64-bit little-endian ELF)
+  auto* elf_obj = llvm::dyn_cast<llvm::object::ELF64LEObjectFile>(obj);
+  if (!elf_obj) {
+    VLOG(2) << "HSACO is not a 64-bit little-endian ELF file";
+    return spill_info;
+  }
+
+  // Get the underlying ELFFile to access the notes() API
+  const auto& elf_file = elf_obj->getELFFile();
+
+  for (const auto& section : elf_obj->sections()) {
+    llvm::Expected<const typename llvm::object::ELF64LEObjectFile::Elf_Shdr*>
+        shdr_or_err = elf_obj->getSection(section.getRawDataRefImpl());
+
+    if (!shdr_or_err) {
+      continue;  // Skip sections we can't access
+    }
+
+    const auto* shdr = *shdr_or_err;
+
+    if (shdr->sh_type != llvm::ELF::SHT_NOTE) {
+      continue;
+    }
+
+    llvm::Error err = llvm::Error::success();
+    for (const auto& note : elf_file.notes(*shdr, err)) {
+      if (note.getType() == llvm::ELF::NT_AMDGPU_METADATA) {
+        llvm::StringRef metadata = note.getDescAsStringRef(kElfNoteDescAlignment);
+
+        if (metadata.empty()) {
+          VLOG(2) << "Found NT_AMDGPU_METADATA note but it contains no data";
+          continue;
+        }
+
+        // Parse the metadata and extract spill counts, return immediately
+        return ParseAMDGPUMetadataForSpills(metadata);
+      }
+    }
+
+    if (err) {
+      VLOG(2) << "Error parsing notes: " << llvm::toString(std::move(err));
+    }
+  }
+
+  // If we reach here, no metadata was found
+  VLOG(2) << "No AMDGPU metadata found in HSACO";
+  return spill_info;
+}
 
 bool HsacoCache::Find(const std::string& ir, uint64_t& hash,
                       const std::string& gfx, std::vector<uint8_t>& hsaco) {
@@ -332,136 +562,42 @@ absl::StatusOr<std::vector<uint8_t>> EmitModuleToHsaco(
   hsaco_file.close();
 
   // Check for register spilling using HSACO metadata
-  // Use amd_comgr library for fast in-process metadata extraction
   VLOG(2) << "Checking for register spilling in: "
           << module->getModuleIdentifier();
 
-  bool has_spilling = false;
-  int sgpr_spill_count = 0;
-  int vgpr_spill_count = 0;
-  int private_segment_size = 0;
+  RegisterSpillInfo spill_info = ExtractRegisterSpillingFromHsaco(hsaco);
 
-  // Use already-loaded HSACO data for amd_comgr parsing
-  {
-    // Create amd_comgr data object from HSACO
-    amd_comgr_data_t comgr_data;
-    amd_comgr_status_t status =
-        amd_comgr_create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &comgr_data);
-
-    if (status == AMD_COMGR_STATUS_SUCCESS) {
-      status = amd_comgr_set_data(comgr_data, hsaco.size(),
-                                  reinterpret_cast<const char*>(hsaco.data()));
-
-      if (status == AMD_COMGR_STATUS_SUCCESS) {
-        // Get metadata from the executable
-        amd_comgr_metadata_node_t metadata;
-        status = amd_comgr_get_data_metadata(comgr_data, &metadata);
-
-        if (status == AMD_COMGR_STATUS_SUCCESS) {
-          // Helper lambda to lookup integer value from metadata map
-          auto lookup_int_value = [](amd_comgr_metadata_node_t root,
-                                     const char* key) -> int {
-            amd_comgr_metadata_node_t value_node;
-            amd_comgr_status_t s =
-                amd_comgr_metadata_lookup(root, key, &value_node);
-            if (s != AMD_COMGR_STATUS_SUCCESS) {
-              return 0;
-            }
-
-            size_t size = 0;
-            s = amd_comgr_get_metadata_string(value_node, &size, nullptr);
-            if (s != AMD_COMGR_STATUS_SUCCESS || size == 0) {
-              amd_comgr_destroy_metadata(value_node);
-              return 0;
-            }
-
-            std::string str_value(size, '\0');
-            s = amd_comgr_get_metadata_string(value_node, &size,
-                                              str_value.data());
-            amd_comgr_destroy_metadata(value_node);
-
-            if (s != AMD_COMGR_STATUS_SUCCESS) {
-              return 0;
-            }
-
-            // Parse the integer value
-            try {
-              return std::stoi(str_value);
-            } catch (...) {
-              return 0;
-            }
-          };
-
-          // Navigate to amdhsa.kernels array and check each kernel
-          amd_comgr_metadata_node_t kernels_node;
-          if (amd_comgr_metadata_lookup(metadata, "amdhsa.kernels",
-                                        &kernels_node) ==
-              AMD_COMGR_STATUS_SUCCESS) {
-            size_t kernel_count = 0;
-            amd_comgr_get_metadata_list_size(kernels_node, &kernel_count);
-
-            for (size_t i = 0; i < kernel_count; ++i) {
-              amd_comgr_metadata_node_t kernel_node;
-              if (amd_comgr_index_list_metadata(kernels_node, i,
-                                                &kernel_node) ==
-                  AMD_COMGR_STATUS_SUCCESS) {
-                // Get spill counts for this kernel
-                int kernel_sgpr_spill =
-                    lookup_int_value(kernel_node, ".sgpr_spill_count");
-                int kernel_vgpr_spill =
-                    lookup_int_value(kernel_node, ".vgpr_spill_count");
-                int kernel_private_size = lookup_int_value(
-                    kernel_node, ".private_segment_fixed_size");
-
-                // Aggregate max values across all kernels
-                sgpr_spill_count =
-                    std::max(sgpr_spill_count, kernel_sgpr_spill);
-                vgpr_spill_count =
-                    std::max(vgpr_spill_count, kernel_vgpr_spill);
-                private_segment_size =
-                    std::max(private_segment_size, kernel_private_size);
-
-                amd_comgr_destroy_metadata(kernel_node);
-              }
-            }
-            amd_comgr_destroy_metadata(kernels_node);
-          }
-
-          amd_comgr_destroy_metadata(metadata);
-        } else {
-          VLOG(2) << "Could not get HSACO metadata via amd_comgr";
-        }
-      }
-      amd_comgr_release_data(comgr_data);
-    } else {
-      VLOG(2) << "Could not create amd_comgr data object";
-    }
-
-    if (sgpr_spill_count > 0 || vgpr_spill_count > 0 ||
-        private_segment_size > 0) {
-      has_spilling = true;
-    }
+  if (spill_info.HasSpilling()) {
+    // We can have SGPR spills without stack being used. They are saved to
+    // VGPRs. In that case, we don't want to discard such kernel, so just
+    // report such cases.
+    VLOG(1) << "Register spilling (SGPR: " << spill_info.sgpr_spill_count
+            << ", VGPR: " << spill_info.vgpr_spill_count << ") detected in "
+            << module->getModuleIdentifier();
+  } else {
+    VLOG(2) << "No register spilling detected in "
+            << module->getModuleIdentifier();
   }
 
-  if (has_spilling) {
-    VLOG(0) << "====== REGISTER SPILLING DETECTED ======";
-    VLOG(0) << "Module: " << module->getModuleIdentifier();
-    VLOG(0) << "SGPR spill count: " << sgpr_spill_count;
-    VLOG(0) << "VGPR spill count: " << vgpr_spill_count;
-    VLOG(0) << "Private segment size: " << private_segment_size << " bytes";
-    VLOG(0) << "Performance may be degraded due to register pressure";
-    VLOG(0) << "========================================";
+  if (spill_info.HasStackUsage()) {
+    VLOG(1) << "Stack usage (private: " << spill_info.private_segment_size
+            << ", dynamic: "
+            << (spill_info.uses_dynamic_stack ? "true" : "false")
+            << ") detected in " << module->getModuleIdentifier();
 
     // Filter out kernels with register spilling during autotuning
     // This matches NVIDIA's behavior in ptx_compiler_impl.cc
     // TODO: remove ptx from xla_gpu_fail_ptx_compilation_on_register_spilling
     // to make the flag more general
     if (debug_options.xla_gpu_fail_ptx_compilation_on_register_spilling()) {
+      VLOG(0) << "Discard module " << module->getModuleIdentifier()
+              << " due register spilling or stack usage";
       return xla::Cancelled(
-          "Compilation result discarded due to register spilling");
+          "Compilation result discarded due to register spilling or stack "
+          "usage");
     }
   } else {
-    VLOG(2) << "No register spilling detected";
+    VLOG(2) << "No stack usage detected in " << module->getModuleIdentifier();
   }
 
   // Clean up temp files

--- a/xla/service/gpu/llvm_gpu_backend/amdgpu_register_spilling_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/amdgpu_register_spilling_test.cc
@@ -1,0 +1,147 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "tsl/platform/path.h"
+#include "tsl/platform/test.h"
+#include "xla/service/gpu/llvm_gpu_backend/amdgpu_backend.h"
+#include "xla/service/gpu/llvm_gpu_backend/load_ir_module.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/xla.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+namespace se = ::stream_executor;
+
+static std::string RemoveLLExtension(const std::string& filename) {
+  return filename.substr(0, filename.find(".ll"));
+}
+
+// Test parameter structure
+struct SpillingTestParam {
+  std::string ir_filename;         // IR file to compile
+  bool fail_on_spilling;           // Flag value
+  absl::StatusCode expected_code;  // Expected status code
+  std::string expected_substring;  // Expected substring in error (if any)
+};
+
+class AMDGPURegisterSpillingTest
+    : public ::testing::TestWithParam<SpillingTestParam> {
+ protected:
+  // Helper to load IR module from test data
+  std::unique_ptr<llvm::Module> LoadTestModule(llvm::LLVMContext* context,
+                                                const std::string& filename) {
+    return LoadIRModule(
+        tsl::io::JoinPath(tsl::testing::XlaSrcRoot(), "service", "gpu",
+                         "llvm_gpu_backend", "tests_data", filename),
+        context);
+  }
+
+  // Helper to compile with given debug options
+  absl::StatusOr<std::vector<uint8_t>> CompileModule(
+      llvm::Module* module, const std::string& module_id,
+      bool fail_on_spilling) {
+    DebugOptions debug_options;
+    debug_options.set_xla_gpu_fail_ptx_compilation_on_register_spilling(
+        fail_on_spilling);
+
+    module->setModuleIdentifier(module_id);
+
+    return amdgpu::CompileToHsaco(
+        module, se::GpuComputeCapability{se::RocmComputeCapability{"gfx1100"}},
+        debug_options, module_id);
+  }
+};
+
+TEST_P(AMDGPURegisterSpillingTest, CompileTest) {
+  const SpillingTestParam& param = GetParam();
+  llvm::LLVMContext context;
+
+  auto module = LoadTestModule(&context, param.ir_filename);
+  ASSERT_NE(module, nullptr);
+
+  // Generate module ID from filename and flag state
+  std::string module_id = RemoveLLExtension(param.ir_filename) +
+                          (param.fail_on_spilling ? "_fail_on_spilling" : "_allow_spilling");
+
+  auto result = CompileModule(module.get(), module_id, param.fail_on_spilling);
+
+  EXPECT_EQ(result.status().code(), param.expected_code)
+      << "IR: " << param.ir_filename
+      << ", Flag: " << (param.fail_on_spilling ? "enabled" : "disabled")
+      << ", Status: " << result.status().message();
+
+  if (!param.expected_substring.empty()) {
+    EXPECT_THAT(result.status().message(),
+                ::testing::HasSubstr(param.expected_substring))
+        << "IR: " << param.ir_filename;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RegisterSpillingTests,
+    AMDGPURegisterSpillingTest,
+    ::testing::Values(
+        SpillingTestParam{
+            "amdgpu_no_spills.ll",
+            /*fail_on_spilling=*/true,
+            absl::StatusCode::kOk,
+            ""
+        },
+        SpillingTestParam{
+            "amdgpu_vgpr_spills.ll",
+            /*fail_on_spilling=*/false,
+            absl::StatusCode::kOk,
+            ""
+        },
+        SpillingTestParam{
+            "amdgpu_vgpr_spills.ll",
+            /*fail_on_spilling=*/true,
+            absl::StatusCode::kCancelled,
+            "register spilling"
+        },
+        SpillingTestParam{
+            "amdgpu_sgpr_spills.ll",
+            /*fail_on_spilling=*/false,
+            absl::StatusCode::kOk,
+            ""
+        },
+        SpillingTestParam{
+            "amdgpu_sgpr_spills.ll",
+            /*fail_on_spilling=*/true,
+            absl::StatusCode::kOk,
+            ""
+        },
+        SpillingTestParam{
+            "amdgpu_dynamic_stack.ll",
+            /*fail_on_spilling=*/true,
+            absl::StatusCode::kCancelled,
+            "stack usage"
+        }
+    ),
+    [](const ::testing::TestParamInfo<SpillingTestParam>& info) {
+      return RemoveLLExtension(info.param.ir_filename) +
+             (info.param.fail_on_spilling ? "_fail_on_spilling" : "_allow_spilling");
+    });
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_dynamic_stack.ll
+++ b/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_dynamic_stack.ll
@@ -1,0 +1,26 @@
+; AMDGPU kernel with dynamic stack usage (indirect function call)
+; Based on real HIP code that uses function pointers
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
+target triple = "amdgcn-amd-amdhsa"
+
+@__hip_cuid_40fa47637d275275 = addrspace(1) global i8 0
+
+@llvm.compiler.used = appending addrspace(1) global [1 x ptr] [ptr addrspacecast (ptr addrspace(1) @__hip_cuid_40fa47637d275275 to ptr)], section "llvm.metadata"
+
+; Kernel that uses indirect function call requiring dynamic stack
+define protected amdgpu_kernel void @_Z4TestPDF16bS_S_(ptr addrspace(1) noundef %dst.coerce, ptr addrspace(1) noundef %ptr1.coerce, ptr addrspace(1) noundef %ptr2.coerce) local_unnamed_addr {
+entry:
+  %0 = ptrtoint ptr addrspace(1) %dst.coerce to i64
+  %1 = inttoptr i64 %0 to ptr
+  %2 = ptrtoint ptr addrspace(1) %ptr1.coerce to i64
+  %3 = inttoptr i64 %2 to ptr
+  %4 = ptrtoint ptr addrspace(1) %ptr2.coerce to i64
+  %5 = inttoptr i64 %4 to ptr
+  %6 = tail call ptr asm "", "=s"() #1
+  tail call void %6(ptr noundef %1, ptr noundef %3, ptr noundef %5) #2
+  ret void
+}
+
+attributes #1 = { nounwind }
+attributes #2 = { nounwind }
+

--- a/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_no_spills.ll
+++ b/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_no_spills.ll
@@ -1,0 +1,29 @@
+; Simple AMDGPU kernel for testing register spilling detection
+; This module has no external dependencies and minimal module flags
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
+target triple = "amdgcn-amd-amdhsa"
+
+; Simple kernel that adds two arrays
+define amdgpu_kernel void @simple_add(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %c) {
+entry:
+  %tid = call i32 @llvm.amdgcn.workitem.id.x()
+  %tidx = zext i32 %tid to i64
+
+  %a_ptr = getelementptr float, ptr addrspace(1) %a, i64 %tidx
+  %b_ptr = getelementptr float, ptr addrspace(1) %b, i64 %tidx
+  %c_ptr = getelementptr float, ptr addrspace(1) %c, i64 %tidx
+
+  %a_val = load float, ptr addrspace(1) %a_ptr, align 4
+  %b_val = load float, ptr addrspace(1) %b_ptr, align 4
+
+  %sum = fadd float %a_val, %b_val
+
+  store float %sum, ptr addrspace(1) %c_ptr, align 4
+  ret void
+}
+
+; Intrinsic declaration
+declare i32 @llvm.amdgcn.workitem.id.x() #0
+
+attributes #0 = { nounwind readnone speculatable }
+

--- a/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_sgpr_spills.ll
+++ b/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_sgpr_spills.ll
@@ -1,0 +1,166 @@
+; AMDGPU kernel with high SGPR pressure to force scalar register spilling
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
+target triple = "amdgcn-amd-amdhsa"
+
+; Kernel using many scalar operations with limited SGPRs
+; We use readfirstlane to force values into SGPRs
+define amdgpu_kernel void @sgpr_pressure(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 {
+entry:
+  %tid = call i32 @llvm.amdgcn.workitem.id.x()
+  %tidx = zext i32 %tid to i64
+
+  ; Load many scalar values from memory
+  ; Using readfirstlane forces values into SGPRs (uniform across wavefront)
+  %ptr0 = getelementptr i32, ptr addrspace(1) %in, i64 0
+  %v0_vec = load i32, ptr addrspace(1) %ptr0, align 4
+  %v0 = call i32 @llvm.amdgcn.readfirstlane(i32 %v0_vec)
+
+  %ptr1 = getelementptr i32, ptr addrspace(1) %in, i64 1
+  %v1_vec = load i32, ptr addrspace(1) %ptr1, align 4
+  %v1 = call i32 @llvm.amdgcn.readfirstlane(i32 %v1_vec)
+
+  %ptr2 = getelementptr i32, ptr addrspace(1) %in, i64 2
+  %v2_vec = load i32, ptr addrspace(1) %ptr2, align 4
+  %v2 = call i32 @llvm.amdgcn.readfirstlane(i32 %v2_vec)
+
+  %ptr3 = getelementptr i32, ptr addrspace(1) %in, i64 3
+  %v3_vec = load i32, ptr addrspace(1) %ptr3, align 4
+  %v3 = call i32 @llvm.amdgcn.readfirstlane(i32 %v3_vec)
+
+  %ptr4 = getelementptr i32, ptr addrspace(1) %in, i64 4
+  %v4_vec = load i32, ptr addrspace(1) %ptr4, align 4
+  %v4 = call i32 @llvm.amdgcn.readfirstlane(i32 %v4_vec)
+
+  %ptr5 = getelementptr i32, ptr addrspace(1) %in, i64 5
+  %v5_vec = load i32, ptr addrspace(1) %ptr5, align 4
+  %v5 = call i32 @llvm.amdgcn.readfirstlane(i32 %v5_vec)
+
+  %ptr6 = getelementptr i32, ptr addrspace(1) %in, i64 6
+  %v6_vec = load i32, ptr addrspace(1) %ptr6, align 4
+  %v6 = call i32 @llvm.amdgcn.readfirstlane(i32 %v6_vec)
+
+  %ptr7 = getelementptr i32, ptr addrspace(1) %in, i64 7
+  %v7_vec = load i32, ptr addrspace(1) %ptr7, align 4
+  %v7 = call i32 @llvm.amdgcn.readfirstlane(i32 %v7_vec)
+
+  %ptr8 = getelementptr i32, ptr addrspace(1) %in, i64 8
+  %v8_vec = load i32, ptr addrspace(1) %ptr8, align 4
+  %v8 = call i32 @llvm.amdgcn.readfirstlane(i32 %v8_vec)
+
+  %ptr9 = getelementptr i32, ptr addrspace(1) %in, i64 9
+  %v9_vec = load i32, ptr addrspace(1) %ptr9, align 4
+  %v9 = call i32 @llvm.amdgcn.readfirstlane(i32 %v9_vec)
+
+  %ptr10 = getelementptr i32, ptr addrspace(1) %in, i64 10
+  %v10_vec = load i32, ptr addrspace(1) %ptr10, align 4
+  %v10 = call i32 @llvm.amdgcn.readfirstlane(i32 %v10_vec)
+
+  %ptr11 = getelementptr i32, ptr addrspace(1) %in, i64 11
+  %v11_vec = load i32, ptr addrspace(1) %ptr11, align 4
+  %v11 = call i32 @llvm.amdgcn.readfirstlane(i32 %v11_vec)
+
+  %ptr12 = getelementptr i32, ptr addrspace(1) %in, i64 12
+  %v12_vec = load i32, ptr addrspace(1) %ptr12, align 4
+  %v12 = call i32 @llvm.amdgcn.readfirstlane(i32 %v12_vec)
+
+  %ptr13 = getelementptr i32, ptr addrspace(1) %in, i64 13
+  %v13_vec = load i32, ptr addrspace(1) %ptr13, align 4
+  %v13 = call i32 @llvm.amdgcn.readfirstlane(i32 %v13_vec)
+
+  %ptr14 = getelementptr i32, ptr addrspace(1) %in, i64 14
+  %v14_vec = load i32, ptr addrspace(1) %ptr14, align 4
+  %v14 = call i32 @llvm.amdgcn.readfirstlane(i32 %v14_vec)
+
+  %ptr15 = getelementptr i32, ptr addrspace(1) %in, i64 15
+  %v15_vec = load i32, ptr addrspace(1) %ptr15, align 4
+  %v15 = call i32 @llvm.amdgcn.readfirstlane(i32 %v15_vec)
+
+  ; Create many scalar computations - chain A
+  %a0 = add i32 %v0, %v1
+  %a1 = mul i32 %a0, %v2
+  %a2 = add i32 %a1, %v3
+  %a3 = mul i32 %a2, %v4
+  %a4 = add i32 %a3, %v5
+  %a5 = mul i32 %a4, %v6
+  %a6 = add i32 %a5, %v7
+  %a7 = mul i32 %a6, %v8
+  %a8 = add i32 %a7, %v9
+  %a9 = mul i32 %a8, %v10
+  %a10 = add i32 %a9, %v11
+  %a11 = mul i32 %a10, %v12
+  %a12 = add i32 %a11, %v13
+  %a13 = mul i32 %a12, %v14
+  %a14 = add i32 %a13, %v15
+
+  ; Chain B - reverse
+  %b0 = mul i32 %v15, %v14
+  %b1 = add i32 %b0, %v13
+  %b2 = mul i32 %b1, %v12
+  %b3 = add i32 %b2, %v11
+  %b4 = mul i32 %b3, %v10
+  %b5 = add i32 %b4, %v9
+  %b6 = mul i32 %b5, %v8
+  %b7 = add i32 %b6, %v7
+  %b8 = mul i32 %b7, %v6
+  %b9 = add i32 %b8, %v5
+  %b10 = mul i32 %b9, %v4
+  %b11 = add i32 %b10, %v3
+  %b12 = mul i32 %b11, %v2
+  %b13 = add i32 %b12, %v1
+  %b14 = mul i32 %b13, %v0
+
+  ; Chain C - subtraction
+  %c0 = sub i32 %v0, %v1
+  %c1 = mul i32 %c0, %v2
+  %c2 = sub i32 %c1, %v3
+  %c3 = mul i32 %c2, %v4
+  %c4 = sub i32 %c3, %v5
+  %c5 = mul i32 %c4, %v6
+  %c6 = sub i32 %c5, %v7
+  %c7 = mul i32 %c6, %v8
+  %c8 = sub i32 %c7, %v9
+  %c9 = mul i32 %c8, %v10
+  %c10 = sub i32 %c9, %v11
+  %c11 = mul i32 %c10, %v12
+  %c12 = sub i32 %c11, %v13
+  %c13 = mul i32 %c12, %v14
+  %c14 = sub i32 %c13, %v15
+
+  ; Chain D - cross dependencies
+  %d0 = add i32 %a0, %b0
+  %d1 = mul i32 %d0, %c0
+  %d2 = add i32 %a1, %b1
+  %d3 = mul i32 %d2, %c1
+  %d4 = add i32 %a2, %b2
+  %d5 = mul i32 %d4, %c2
+  %d6 = add i32 %a3, %b3
+  %d7 = mul i32 %d6, %c3
+  %d8 = add i32 %a4, %b4
+  %d9 = mul i32 %d8, %c4
+  %d10 = add i32 %a5, %b5
+  %d11 = mul i32 %d10, %c5
+  %d12 = add i32 %a6, %b6
+  %d13 = mul i32 %d12, %c6
+
+  ; Combine all chains
+  %r0 = add i32 %a14, %b14
+  %r1 = add i32 %r0, %c14
+  %r2 = add i32 %r1, %d1
+  %r3 = add i32 %r2, %d3
+  %r4 = add i32 %r3, %d5
+  %r5 = add i32 %r4, %d7
+  %r6 = add i32 %r5, %d9
+  %r7 = add i32 %r6, %d11
+  %result = add i32 %r7, %d13
+
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i64 %tidx
+  store i32 %result, ptr addrspace(1) %out_ptr, align 4
+  ret void
+}
+
+declare i32 @llvm.amdgcn.workitem.id.x() #1
+declare i32 @llvm.amdgcn.readfirstlane(i32) #1
+
+; Limit SGPRs to 32, this should force SGPR spilling
+attributes #0 = { "amdgpu-num-sgpr"="32" "amdgpu-flat-work-group-size"="1,256" }
+attributes #1 = { nounwind readnone speculatable }

--- a/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_vgpr_spills.ll
+++ b/xla/service/gpu/llvm_gpu_backend/tests_data/amdgpu_vgpr_spills.ll
@@ -1,0 +1,145 @@
+; AMDGPU kernel with high register pressure to force spilling
+; This uses many vector operations to exhaust available VGPRs
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
+target triple = "amdgcn-amd-amdhsa"
+
+; Kernel with many live values to force register spilling
+define amdgpu_kernel void @high_register_pressure(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 {
+entry:
+  %tid = call i32 @llvm.amdgcn.workitem.id.x()
+  %tidx = zext i32 %tid to i64
+
+  ; Load many vectors from memory - using volatile to prevent optimization
+  %ptr0 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 %tidx
+  %v0 = load volatile <4 x float>, ptr addrspace(1) %ptr0, align 16
+
+  %ptr1 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 1
+  %v1 = load volatile <4 x float>, ptr addrspace(1) %ptr1, align 16
+
+  %ptr2 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 2
+  %v2 = load volatile <4 x float>, ptr addrspace(1) %ptr2, align 16
+
+  %ptr3 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 3
+  %v3 = load volatile <4 x float>, ptr addrspace(1) %ptr3, align 16
+
+  %ptr4 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 4
+  %v4 = load volatile <4 x float>, ptr addrspace(1) %ptr4, align 16
+
+  %ptr5 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 5
+  %v5 = load volatile <4 x float>, ptr addrspace(1) %ptr5, align 16
+
+  %ptr6 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 6
+  %v6 = load volatile <4 x float>, ptr addrspace(1) %ptr6, align 16
+
+  %ptr7 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 7
+  %v7 = load volatile <4 x float>, ptr addrspace(1) %ptr7, align 16
+
+  %ptr8 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 8
+  %v8 = load volatile <4 x float>, ptr addrspace(1) %ptr8, align 16
+
+  %ptr9 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 9
+  %v9 = load volatile <4 x float>, ptr addrspace(1) %ptr9, align 16
+
+  %ptr10 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 10
+  %v10 = load volatile <4 x float>, ptr addrspace(1) %ptr10, align 16
+
+  %ptr11 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 11
+  %v11 = load volatile <4 x float>, ptr addrspace(1) %ptr11, align 16
+
+  %ptr12 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 12
+  %v12 = load volatile <4 x float>, ptr addrspace(1) %ptr12, align 16
+
+  %ptr13 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 13
+  %v13 = load volatile <4 x float>, ptr addrspace(1) %ptr13, align 16
+
+  %ptr14 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 14
+  %v14 = load volatile <4 x float>, ptr addrspace(1) %ptr14, align 16
+
+  %ptr15 = getelementptr <4 x float>, ptr addrspace(1) %in, i64 15
+  %v15 = load volatile <4 x float>, ptr addrspace(1) %ptr15, align 16
+
+  ; Create many dependent calculations - chain A
+  %a0 = fadd <4 x float> %v0, %v1
+  %a1 = fmul <4 x float> %a0, %v2
+  %a2 = fadd <4 x float> %a1, %v3
+  %a3 = fmul <4 x float> %a2, %v4
+  %a4 = fadd <4 x float> %a3, %v5
+  %a5 = fmul <4 x float> %a4, %v6
+  %a6 = fadd <4 x float> %a5, %v7
+  %a7 = fmul <4 x float> %a6, %v8
+  %a8 = fadd <4 x float> %a7, %v9
+  %a9 = fmul <4 x float> %a8, %v10
+  %a10 = fadd <4 x float> %a9, %v11
+  %a11 = fmul <4 x float> %a10, %v12
+  %a12 = fadd <4 x float> %a11, %v13
+  %a13 = fmul <4 x float> %a12, %v14
+  %a14 = fadd <4 x float> %a13, %v15
+
+  ; Chain B - reverse direction
+  %b0 = fmul <4 x float> %v15, %v14
+  %b1 = fadd <4 x float> %b0, %v13
+  %b2 = fmul <4 x float> %b1, %v12
+  %b3 = fadd <4 x float> %b2, %v11
+  %b4 = fmul <4 x float> %b3, %v10
+  %b5 = fadd <4 x float> %b4, %v9
+  %b6 = fmul <4 x float> %b5, %v8
+  %b7 = fadd <4 x float> %b6, %v7
+  %b8 = fmul <4 x float> %b7, %v6
+  %b9 = fadd <4 x float> %b8, %v5
+  %b10 = fmul <4 x float> %b9, %v4
+  %b11 = fadd <4 x float> %b10, %v3
+  %b12 = fmul <4 x float> %b11, %v2
+  %b13 = fadd <4 x float> %b12, %v1
+  %b14 = fmul <4 x float> %b13, %v0
+
+  ; Chain C - subtraction chain
+  %c0 = fsub <4 x float> %v0, %v1
+  %c1 = fmul <4 x float> %c0, %v2
+  %c2 = fsub <4 x float> %c1, %v3
+  %c3 = fmul <4 x float> %c2, %v4
+  %c4 = fsub <4 x float> %c3, %v5
+  %c5 = fmul <4 x float> %c4, %v6
+  %c6 = fsub <4 x float> %c5, %v7
+  %c7 = fmul <4 x float> %c6, %v8
+  %c8 = fsub <4 x float> %c7, %v9
+  %c9 = fmul <4 x float> %c8, %v10
+  %c10 = fsub <4 x float> %c9, %v11
+  %c11 = fmul <4 x float> %c10, %v12
+  %c12 = fsub <4 x float> %c11, %v13
+  %c13 = fmul <4 x float> %c12, %v14
+  %c14 = fsub <4 x float> %c13, %v15
+
+  ; Chain D - cross dependencies
+  %d0 = fadd <4 x float> %a0, %b0
+  %d1 = fmul <4 x float> %d0, %c0
+  %d2 = fadd <4 x float> %a1, %b1
+  %d3 = fmul <4 x float> %d2, %c1
+  %d4 = fadd <4 x float> %a2, %b2
+  %d5 = fmul <4 x float> %d4, %c2
+  %d6 = fadd <4 x float> %a3, %b3
+  %d7 = fmul <4 x float> %d6, %c3
+  %d8 = fadd <4 x float> %a4, %b4
+  %d9 = fmul <4 x float> %d8, %c4
+  %d10 = fadd <4 x float> %a5, %b5
+  %d11 = fmul <4 x float> %d10, %c5
+
+  ; Final combination to keep all values live
+  %result0 = fadd <4 x float> %a14, %b14
+  %result1 = fadd <4 x float> %result0, %c14
+  %result2 = fadd <4 x float> %result1, %d1
+  %result3 = fadd <4 x float> %result2, %d3
+  %result4 = fadd <4 x float> %result3, %d5
+  %result5 = fadd <4 x float> %result4, %d7
+  %result6 = fadd <4 x float> %result5, %d9
+  %result = fadd <4 x float> %result6, %d11
+
+  %out_ptr = getelementptr <4 x float>, ptr addrspace(1) %out, i64 %tidx
+  store <4 x float> %result, ptr addrspace(1) %out_ptr, align 16
+  ret void
+}
+
+declare i32 @llvm.amdgcn.workitem.id.x() #1
+
+; Limit VGPRs to 64 to force spilling
+attributes #0 = { "amdgpu-num-vgpr"="64" "amdgpu-flat-work-group-size"="1,256" }
+attributes #1 = { nounwind readnone speculatable }


### PR DESCRIPTION
Replace amd_comgr library with LLVM's native API to find NT_AMDGPU_METADATA note sections and extract the stack usage and register spill counts from there.

Add detection for dynamic stack usage.

Add VLOG(2) dumps for per-kernel stats as well as register counts.

Change the logic of discarding the module. The module is discarded only if the stack is used, i.e., either .private_segment_fixed_size is not zero or .uses_dynamic_stack is true. There are examples where there are SGPR spills, but they are saved to VGPRs and not to the stack.

Add tests in amdgpu_register_spilling_test.cc which cover cases where no spills, VGPR-only spills, SGPR-only spills, or dynamic stack usage occur. For that, the following LLVM IR inputs are added:
- amdgpu_no_spills.ll: Simple kernel with minimal register usage
- amdgpu_vgpr_spills.ll: High VGPR pressure with limited VGPRs (64)
- amdgpu_sgpr_spills.ll: High SGPR pressure with limited SGPRs (32)
- amdgpu_dynamic_stack.ll: Indirect function call requiring dynamic stack