### PR TITLE
[ROCm] Make autotuner cublaslt_test platform independent and enable amdgpu backends

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -242,9 +242,10 @@ xla_test(
         "a100",
         "h100",
         "b200",
+        "amdgpu_any",
     ],
     tags = [
-        "cuda-only",
+        "gpu",
         "no_mac",
     ],
     deps = [
@@ -258,9 +259,9 @@ xla_test(
         "//xla/service:compiler",
         "//xla/service:executable",
         "//xla/service:platform_util",
-        "//xla/service/gpu:nvptx_compiler_impl",
         "//xla/stream_executor:blas",
         "//xla/stream_executor:device_description_proto_cc",
+        "//xla/stream_executor:platform",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/lib/core:status_test_util",
         "//xla/tsl/platform:statusor",

--- a/xla/backends/gpu/autotuner/cublaslt_test.cc
+++ b/xla/backends/gpu/autotuner/cublaslt_test.cc
@@ -31,10 +31,10 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/service/compiler.h"
 #include "xla/service/executable.h"
-#include "xla/service/gpu/nvptx_compiler.h"
 #include "xla/service/platform_util.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/device_description.pb.h"
+#include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/lib/core/status_test_util.h"
 #include "xla/tsl/platform/statusor.h"
@@ -103,18 +103,18 @@ const char kUnsupportedHlo[] = R"(
 class CublasLtBackendTest : public HloHardwareIndependentTestBase {
  protected:
   DebugOptions debug_options_;
-  NVPTXCompiler compiler_;
+  se::Platform* platform_;
   se::StreamExecutor* stream_executor_;
   Compiler::GpuTargetConfig target_config_;
+  std::unique_ptr<Compiler> compiler_;
   CublasLtBackend backend_;
 
   CublasLtBackendTest()
-      : stream_executor_(PlatformUtil::GetDefaultPlatform()
-                             .value()
-                             ->ExecutorForDevice(0)
-                             .value()),
+      : platform_(PlatformUtil::GetDefaultPlatform().value()),
+        stream_executor_(platform_->ExecutorForDevice(0).value()),
+        compiler_(Compiler::GetForPlatform(platform_).value()),
         target_config_(stream_executor_),
-        backend_(stream_executor_, &debug_options_, &compiler_,
+        backend_(stream_executor_, &debug_options_, compiler_.get(),
                  &target_config_) {}
 
   CublasLtBackendConfig ExpectedDefaultAlgorithm() {


### PR DESCRIPTION
In order to enable autotuner cublaslt tests on ROCm
- Removed dependency on `NVPTXCompiler` and changed to using `Compiler::GetForPlatform`
- Removed cuda-only tag
- Added amdgpu backend

@xla-rotation could I get a review for this PR, please?