### PR TITLE
Make autotuner annotation more consistent

### DIFF
--- a/xla/backends/autotuner/BUILD
+++ b/xla/backends/autotuner/BUILD
@@ -63,6 +63,8 @@ cc_library(
         "@tsl//tsl/platform:blocking_counter",
         "@tsl//tsl/platform:fingerprint",
         "@tsl//tsl/platform:path",
+        "@tsl//tsl/profiler/lib:scoped_annotation",
+        "@tsl//tsl/profiler/lib:traceme",
     ],
 )
 

--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -57,6 +57,8 @@ limitations under the License.
 #include "xla/tsl/util/proto/proto_utils.h"
 #include "tsl/platform/blocking_counter.h"
 #include "tsl/platform/fingerprint.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
+#include "tsl/profiler/lib/traceme.h"
 
 namespace xla {
 
@@ -439,6 +441,9 @@ absl::StatusOr<std::vector<Autotuner::Config>> Autotuner::GetSupportedConfigs(
 
 std::vector<absl::StatusOr<std::unique_ptr<Executable>>> Autotuner::CompileAll(
     HloInstruction* instr, std::vector<Config>& configs) {
+  XLA_SCOPED_LOGGING_TIMER_LEVEL("CompileAll", 5);
+  tsl::profiler::TraceMe traceme("CompileAll");
+  tsl::profiler::ScopedAnnotation annotation("XlaAutotunerCompilation");
   if (thread_pool_ == nullptr) {
     std::vector<absl::StatusOr<std::unique_ptr<Executable>>> executables;
     executables.reserve(configs.size());


### PR DESCRIPTION
📝 Summary of Changes
Consistent annotations are now emitted in `autotuner.cc` and `gemm_fusion_autotuner.cc`:
https://github.com/openxla/xla/blob/a9e717e30ab1d7d87ce5aa9f04424af41da8c56c/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc#L1050-L1052

🎯 Justification
This makes it easier to see autotuner compilation in the main thread timeline, as otherwise the compilation is hidden in worker threads.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
n/a

🧪 Unit Tests:
n/a

🧪 Execution Tests:
n/a