### PR TITLE
[ROCM] Splitting gridDim.x into x and y if necessary for large reductions and loop fusion

### DIFF
--- a/xla/backends/gpu/codegen/emitters/BUILD
+++ b/xla/backends/gpu/codegen/emitters/BUILD
@@ -242,7 +242,6 @@ cc_library(
         "//xla/hlo/analysis:indexing_analysis",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/utils:hlo_traversal",
-        "//xla/service:platform_util",
         "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/service/gpu:ir_emission_utils",
         "//xla/service/gpu:launch_dimensions",

--- a/xla/backends/gpu/codegen/emitters/emitter_base.cc
+++ b/xla/backends/gpu/codegen/emitters/emitter_base.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -223,9 +224,46 @@ absl::Status RunPassPipeline(mlir::ModuleOp module, const HloModule& hlo_module,
 
 }  // namespace
 
+/* static */ std::array<uint64_t, 2> EmitterBase::MaybeSplitGridDimensionX(
+      uint64_t num_threads_x, uint64_t num_blocks_x,
+      const se::DeviceDescription& info)
+{
+
+  const se::BlockDim& limit = info.block_dim_limit();
+  constexpr uint64_t rocm_limit = std::numeric_limits<uint32_t>::max();
+
+  bool is_rocm = info.gpu_compute_capability().IsRocm();
+  // Add an extra condition for ROCM backend
+  if (num_blocks_x <= limit.x && 
+            (!is_rocm || num_blocks_x * num_threads_x <= rocm_limit)) {
+    return {num_blocks_x, 1};
+  }
+  
+  uint64_t dimx = 0, dimy = 0;
+  // We assume that num_blocks_x is most likely of the form: 2^N * K
+  for (uint64_t nzeros = 1; nzeros < 64u; nzeros++) {
+    dimy = 1ULL << nzeros;
+    if (dimy > limit.y) { 
+      // We could not find the proper power-of-two dim Y => use max gridY
+      dimy = limit.y;
+      dimx = CeilOfRatio(num_blocks_x, dimy);
+      break;
+    }
+    // num_blocks_x might not be divided evenly by dimy, so we round up.
+    dimx = (num_blocks_x + dimy-1) >> nzeros;
+    if (dimx <= limit.x) {
+      // We have an extra requirement on ROCM to check
+      if (!is_rocm || dimx * num_threads_x <= rocm_limit) break;
+    }
+  }
+  VLOG(1) << num_blocks_x << " splitting as: " << dimx << "x" << dimy 
+           << " wasted blocks: " << (dimx*dimy - num_blocks_x);
+  return {dimx, dimy};
+}
+
 Value EmitterBase::EmitWorkGroupId(mlir::ImplicitLocOpBuilder& builder,
                                    WorkGroupDimension dim) const {
-  const auto& counts = launch_dimensions().block_counts();
+  const auto counts = launch_dimensions().block_counts();
   int64_t count = dim == WorkGroupDimension::x   ? counts.x
                   : dim == WorkGroupDimension::y ? counts.y
                                                  : counts.z;
@@ -236,7 +274,7 @@ Value EmitterBase::EmitWorkGroupId(mlir::ImplicitLocOpBuilder& builder,
 
 Value EmitterBase::EmitBlockId(mlir::ImplicitLocOpBuilder& builder,
                                int dim) const {
-  const auto& counts = launch_dimensions().block_counts();
+  const auto counts = launch_dimensions().block_counts();
   int64_t count = dim == 0 ? counts.x : dim == 1 ? counts.y : counts.z;
   auto block_id = mlir::gpu::BlockIdOp::create(
       builder, static_cast<mlir::gpu::Dimension>(dim));
@@ -246,7 +284,7 @@ Value EmitterBase::EmitBlockId(mlir::ImplicitLocOpBuilder& builder,
 
 Value EmitterBase::EmitThreadId(mlir::ImplicitLocOpBuilder& builder,
                                 int dim) const {
-  const auto& counts = launch_dimensions().thread_counts_per_block();
+  const auto counts = launch_dimensions().thread_counts_per_block();
   int64_t count = dim == 0 ? counts.x : dim == 1 ? counts.y : counts.z;
   auto thread_id = mlir::gpu::ThreadIdOp::create(
       builder, static_cast<mlir::gpu::Dimension>(dim));

--- a/xla/backends/gpu/codegen/emitters/emitter_base.h
+++ b/xla/backends/gpu/codegen/emitters/emitter_base.h
@@ -97,6 +97,10 @@ class EmitterBase : public KernelFusionInterface {
       mlir::func::FuncOp entry_function,
       const HloFusionInstruction& fusion) const = 0;
 
+  static std::array<uint64_t, 2> MaybeSplitGridDimensionX(
+      uint64_t num_threads_x, uint64_t num_blocks_x,
+      const se::DeviceDescription& info);
+
   mlir::Value EmitWorkGroupId(mlir::ImplicitLocOpBuilder& builder,
                               WorkGroupDimension dim) const;
   mlir::Value EmitBlockId(mlir::ImplicitLocOpBuilder& builder, int dim) const;

--- a/xla/backends/gpu/codegen/emitters/loop.cc
+++ b/xla/backends/gpu/codegen/emitters/loop.cc
@@ -97,8 +97,21 @@ LoopFusion::ComputeThreadIdToInputIndexing(int64_t root_index,
 LaunchDimensions LoopFusion::launch_dimensions() const {
   Shape indexing_shape = emitters::LoopFusionKernelEmitter::GetIndexingShape(
       analysis_.fusion_spec());
-  return CalculateLaunchDimensions(indexing_shape, analysis_.device_info(),
+  auto dims = CalculateLaunchDimensions(indexing_shape, analysis_.device_info(),
                                    config_);
+  const auto& blocks = dims.block_counts();
+  auto split_x = MaybeSplitGridDimensionX(
+          dims.thread_counts_per_block().x, blocks.x, analysis_.device_info());
+  if (split_x[0] != blocks.x) { // dim X has been split
+    if (blocks.z != 1) {
+      LOG(FATAL) << "Unable to split launch dimensions since block.z ("
+                 << blocks.z << ") != 1";
+    }
+    // split blocks.x into x and y, move blocks.y -> blocks.z
+    return LaunchDimensions(se::BlockDim(split_x[0], split_x[1], blocks.y),
+          dims.thread_counts_per_block());
+  }
+  return dims;
 }
 
 WorkDimensions LoopFusion::GetWorkDimensions() const {

--- a/xla/backends/gpu/codegen/emitters/reduction.cc
+++ b/xla/backends/gpu/codegen/emitters/reduction.cc
@@ -65,7 +65,6 @@ limitations under the License.
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/service/gpu/reduction_utils.h"
-#include "xla/service/platform_util.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/stream_executor/launch_dim.h"
@@ -184,7 +183,7 @@ PerThreadOutputs ReductionFusion::EmitterState::EmitPerThreadElements(
   auto tile_indexing = owner.ComputeReductionInputIndexing(mlir_context);
   tile_indexing
       .GetMutableDimensionBound(
-          KernelFusionInterface::kIndexingMapBlockIdxDims[1])
+          KernelFusionInterface::kIndexingMapBlockIdxDims[2])
       .upper = owner.reduction_heroes_.size();
   tile_indexing.Simplify();
   bool vectorize = owner.vector_size_ > 1;
@@ -396,6 +395,7 @@ ReductionFusion::ReductionFusion(const HloFusionAnalysis& analysis,
 
   const auto& groups = GetGroups();
   int num_groups = groups.grouped_roots.size();
+
   side_output_roots_.resize(num_groups);
   reduction_heroes_.resize(num_groups);
   reduction_roots_.resize(num_groups);
@@ -406,6 +406,7 @@ ReductionFusion::ReductionFusion(const HloFusionAnalysis& analysis,
                  groups.is_reduction_root, groups.group_id_per_root)) {
     const HloInstruction* root = &root_adaptor.instruction();
     const HloInstruction* hero = &hero_adaptor.instruction();
+
     if (is_reduction) {
       if (seen_heroes.insert(hero).second) {
         reduction_heroes_[group_id].push_back(hero);
@@ -424,8 +425,9 @@ IndexingMap ReductionFusion::GetIndexingMap(
   auto num_groups = static_cast<int64_t>(reduction_heroes_.size());
   return IndexingMap{
       AffineMap::get(6, symbol_sizes.size(), results, mlir_context),
-      DimVarsFromGPUGrid(
-          {Product(num_threads_), 1, 1, Product(num_blocks_), num_groups, 1}),
+      DimVarsFromGPUGrid({Product(num_threads_), 1, 1,
+                            static_cast<int64_t>(gpu_blocks_[0]), 
+                            static_cast<int64_t>(gpu_blocks_[1]), num_groups}),
       RangeVarsFromTensorSizes(symbol_sizes),
       /*rt_vars=*/{}};
 }
@@ -446,9 +448,10 @@ IndexingMap ReductionFusion::GetThreadIndexingMap(
 }
 
 LaunchDimensions ReductionFusion::launch_dimensions() const {
-  size_t blocks_y = groups_.grouped_roots.size();
-  return {se::BlockDim(/*x=*/Product(num_blocks_),
-                       /*y=*/static_cast<int64_t>(blocks_y), /*z=*/1),
+  uint64_t blocks_z = groups_.grouped_roots.size();
+  return {se::BlockDim( /*x=*/gpu_blocks_[0],
+                        /*y=*/gpu_blocks_[1],
+                        /*z=*/blocks_z),
           se::ThreadDim(/*x=*/Product(num_threads_),
                         /*y=*/1, /*z=*/1)};
 }
@@ -491,7 +494,7 @@ absl::Status ReductionFusion::EmitEntryFunction(
   absl::c_iota(cases, 1);  // `default` is region 0.
   auto switch_op =
       mlir::scf::IndexSwitchOp::create(b, entry_function.getResultTypes(),
-                                       EmitBlockId(b, 1), cases, cases.size());
+                                       EmitBlockId(b, 2), cases, cases.size());
   mlir::func::ReturnOp::create(b, switch_op.getResults());
   for (auto [id, region] : llvm::enumerate(switch_op->getRegions())) {
     b.setInsertionPointToStart(&region.emplaceBlock());
@@ -640,14 +643,27 @@ ColumnReductionFusion::ColumnReductionFusion(const HloFusionAnalysis& analysis,
   int64_t num_blocks_per_row =
       CeilOfRatio(minor_kept_dim, kTileSize * vector_size_);
   num_blocks_ = {major_kept_dim, num_blocks_per_row};
+  gpu_blocks_ = MaybeSplitGridDimensionX(Product(num_threads_), 
+                Product(num_blocks_), analysis_.device_info());
+
+  VLOG(3) << absl::StrFormat(
+      "ColumnReductionFusion selected parameters: num_threads "
+      "= [%s], tile_sizes_per_thread = [%s], "
+      "num_blocks = [%s] real_blocks_ = [%d, %d] ",
+      absl::StrJoin(num_threads_, ","),
+      absl::StrJoin(tile_sizes_per_thread_, ","),
+      absl::StrJoin(num_blocks_, ","),
+      gpu_blocks_[0], gpu_blocks_[1]);
 }
 
 IndexingMap ColumnReductionFusion::ComputeReductionOutputIndexing(
     MLIRContext* mlir_context) const {
   auto thread_id =
       DelinearizeInBoundsIndex(getAffineDimExpr(0, mlir_context), num_threads_);
+  auto bx = mlir::getAffineDimExpr(3, mlir_context), 
+       by = mlir::getAffineDimExpr(4, mlir_context);
   auto block_id =
-      DelinearizeInBoundsIndex(getAffineDimExpr(3, mlir_context), num_blocks_);
+       DelinearizeInBoundsIndex(bx + gpu_blocks_[0] * by, num_blocks_);
   auto vector_index = getAffineSymbolExpr(0, mlir_context);
   SmallVector<AffineExpr, 2> results{
       block_id[0],
@@ -662,8 +678,11 @@ IndexingMap ColumnReductionFusion::ComputeReductionInputIndexing(
     MLIRContext* mlir_context) const {
   auto thread_id =
       DelinearizeInBoundsIndex(getAffineDimExpr(0, mlir_context), num_threads_);
+  auto bx = mlir::getAffineDimExpr(3, mlir_context), 
+       by = mlir::getAffineDimExpr(4, mlir_context);
   auto block_id =
-      DelinearizeInBoundsIndex(getAffineDimExpr(3, mlir_context), num_blocks_);
+       DelinearizeInBoundsIndex(bx + gpu_blocks_[0] * by, num_blocks_);
+
   AffineExpr element_index = getAffineSymbolExpr(0, mlir_context);
   AffineExpr vector_index = getAffineSymbolExpr(1, mlir_context);
 
@@ -737,6 +756,17 @@ SmallColumnReductionFusion::SmallColumnReductionFusion(
   num_blocks_ = {input_shape_[kColMajorKept]};
   loop_size_ = CeilOfRatio(input_shape_[1] * input_shape_[2],
                            vector_size_ * num_threads_[0]);
+  gpu_blocks_ = MaybeSplitGridDimensionX(Product(num_threads_), 
+                            Product(num_blocks_), analysis_.device_info());
+
+  VLOG(3) << absl::StrFormat(
+      "SmallColumnReductionFusion selected parameters: num_threads "
+      "= [%s], tile_sizes_per_thread = [%s], "
+      "num_blocks = [%s] real_blocks_ = [%d, %d] ",
+      absl::StrJoin(num_threads_, ","),
+      absl::StrJoin(tile_sizes_per_thread_, ","),
+      absl::StrJoin(num_blocks_, ","),
+      gpu_blocks_[0], gpu_blocks_[1]);
 }
 
 IndexingMap SmallColumnReductionFusion::ComputeReductionOutputIndexing(
@@ -817,82 +847,80 @@ RowReductionFusion::RowReductionFusion(const HloFusionAnalysis& analysis,
     : ReductionFusion(analysis, mlir_context) {
   CHECK(reduction_dimensions_.is_row_reduction);
   Vector3 shape = reduction_dimensions_.dimensions;
-  int64_t kMinorReducedElementsPerThread = 8;
+  int64_t kMinorReducedElementsPerThread = 16;
 
-  do {
-    kMinorReducedElementsPerThread *= 2;
-    int64_t num_threads_kept = 1;
-    // Number of threads doing the reduction.
-    int64_t num_threads_reduced = [&] {
-      int64_t max_block_size = MinThreadsXRowReduction();
-      return std::min(max_block_size,
-                      RoundUpTo(CeilOfRatio(shape[kRowMinorReduced],
-                                            kMinorReducedElementsPerThread),
-                                WarpSize()));
-    }();
+  int64_t num_threads_kept = 1;
+  // Number of threads doing the reduction.
+  int64_t num_threads_reduced = [&] {
+    int64_t max_block_size = MinThreadsXRowReduction();
+    return std::min(max_block_size,
+                  RoundUpTo(CeilOfRatio(shape[kRowMinorReduced],
+                                        kMinorReducedElementsPerThread),
+                            WarpSize()));
+  }();
 
-    // If we're limited by the size of the x dimension, add additional
-    // parallelism in the y dimension. The code generator doesn't currently
-    // support parallelizing the z dimension (major reduced dimensions). The
-    // general recommendation is to use between 128 and 512 threads, so we just
-    // go for 256. See https://forums.developer.nvidia.com/t/55529
-    constexpr int64_t kThreadsPerBlockTarget = 256;
-    if (num_threads_reduced * 2 <= kThreadsPerBlockTarget) {
-      int64_t kept_size = reduction_dimensions_.dimensions[kRowKept];
-      // Increase the size of the y dimension as long as there's remaining
-      // parallelism.
-      if (kept_size * num_threads_reduced <= kThreadsPerBlockTarget) {
-        num_threads_kept = kept_size;
-      } else {
-        num_threads_kept = kThreadsPerBlockTarget / num_threads_reduced;
-      }
+  // If we're limited by the size of the x dimension, add additional parallelism
+  // in the y dimension. The code generator doesn't currently support
+  // parallelizing the z dimension (major reduced dimensions). The general
+  // recommendation is to use between 128 and 512 threads, so we just go for
+  // 256. See https://forums.developer.nvidia.com/t/55529
+  constexpr int64_t kThreadsPerBlockTarget = 256;
+  if (num_threads_reduced * 2 <= kThreadsPerBlockTarget) {
+    int64_t kept_size = reduction_dimensions_.dimensions[kRowKept];
+    // Increase the size of the y dimension as long as there's remaining
+    // parallelism.
+    if (kept_size * num_threads_reduced <= kThreadsPerBlockTarget) {
+      num_threads_kept = kept_size;
+    } else {
+      num_threads_kept = kThreadsPerBlockTarget / num_threads_reduced;
     }
+  }
 
-    int vector_size = GetVectorSizeForMlir(analysis, /*minor_dim=*/shape.back(),
-                                           num_threads_reduced);
-    num_threads_ = {num_threads_kept, num_threads_reduced};
-    // TODO(jreiffers): Get rid of `vector_size` in here.
-    input_shape_ = {shape[0], shape[1], shape[2] / vector_size, vector_size};
-    // TODO(jreiffers): Tighten ranges based on constraints when simplifying
-    // instead of using min here. For example, based on
-    //
-    //   s1 in [0, 127]
-    //   d0 floordiv 32 + s1 * 32 in [0, 63]
-    //
-    // Tighten the bound of s1 to [0, 1].
-    int minor_reduced_tile_size =
-        std::min(kMinorReducedElementsPerThread / vector_size,
-                 CeilOfRatio(input_shape_[2], num_threads_[1]));
+  int vector_size = GetVectorSizeForMlir(analysis, /*minor_dim=*/shape.back(),
+                                         num_threads_reduced);
+  num_threads_ = {num_threads_kept, num_threads_reduced};
+  // TODO(jreiffers): Get rid of `vector_size` in here.
+  input_shape_ = {shape[0], shape[1], shape[2] / vector_size, vector_size};
+  // TODO(jreiffers): Tighten ranges based on constraints when simplifying
+  // instead of using min here. For example, based on
+  //
+  //   s1 in [0, 127]
+  //   d0 floordiv 32 + s1 * 32 in [0, 63]
+  //
+  // Tighten the bound of s1 to [0, 1].
+  int minor_reduced_tile_size =
+      std::min(kMinorReducedElementsPerThread / vector_size,
+               CeilOfRatio(input_shape_[2], num_threads_[1]));
 
-    tile_sizes_per_thread_ = {shape[0], minor_reduced_tile_size, vector_size};
-    tile_sizes_per_block_ = {num_threads_kept,
-                             minor_reduced_tile_size * num_threads_reduced};
-    num_blocks_ = {CeilOfRatio(input_shape_[1], tile_sizes_per_block_[0]),
-                   CeilOfRatio(input_shape_[2], tile_sizes_per_block_[1])};
-    /* ROCm hipModuleLaunchKernel limitation
-     * https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___module.html#ga2e4de5937aa8171e9eda16c881ed0674
-     */
-  } while (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm" &&
-           kMinorReducedElementsPerThread < 65536 &&
-           ((Product(num_blocks_) * Product(num_threads_)) >
-            std::numeric_limits<uint32_t>::max()));
+  tile_sizes_per_thread_ = {shape[0], minor_reduced_tile_size, vector_size};
+  tile_sizes_per_block_ = {num_threads_kept,
+                           minor_reduced_tile_size * num_threads_reduced};
+  num_blocks_ = {CeilOfRatio(input_shape_[1], tile_sizes_per_block_[0]),
+                 CeilOfRatio(input_shape_[2], tile_sizes_per_block_[1])};
+  gpu_blocks_ = MaybeSplitGridDimensionX(Product(num_threads_), 
+                            Product(num_blocks_), analysis_.device_info());
 
   VLOG(3) << absl::StrFormat(
-      "RowReductionFusion::RowReductionFusion selected parameters: num_threads "
+      "RowReductionFusion selected parameters: num_threads "
       "= [%s], tile_sizes_per_thread = [%s], tile_sizes_per_block = [%s], "
-      "num_blocks = [%s]",
+      "num_blocks = [%s] real_blocks_ = [%d, %d]",
       absl::StrJoin(num_threads_, ","),
       absl::StrJoin(tile_sizes_per_thread_, ","),
       absl::StrJoin(tile_sizes_per_block_, ","),
-      absl::StrJoin(num_blocks_, ","));
+      absl::StrJoin(num_blocks_, ","),
+      gpu_blocks_[0], gpu_blocks_[1]);
 }
 
 IndexingMap RowReductionFusion::ComputeReductionInputIndexing(
     MLIRContext* mlir_context) const {
   auto thread_id = DelinearizeInBoundsIndex(
       mlir::getAffineDimExpr(0, mlir_context), num_threads_);
-  auto block_id = DelinearizeInBoundsIndex(
-      mlir::getAffineDimExpr(3, mlir_context), num_blocks_);
+
+  auto bx = mlir::getAffineDimExpr(3, mlir_context), 
+       by = mlir::getAffineDimExpr(4, mlir_context);
+  auto block_id =
+       DelinearizeInBoundsIndex(bx + gpu_blocks_[0] * by, num_blocks_);
+
   auto major_reduced = getAffineSymbolExpr(0, mlir_context);
   auto minor_reduced = getAffineSymbolExpr(1, mlir_context);
   auto vector_index = getAffineSymbolExpr(2, mlir_context);
@@ -904,7 +932,6 @@ IndexingMap RowReductionFusion::ComputeReductionInputIndexing(
           (minor_reduced * num_threads_[1]) + thread_id[1],
       vector_index,
   };
-
   auto map = GetIndexingMap(indices, tile_sizes_per_thread_);
   for (auto [result, input_dim] : llvm::zip(indices, input_shape_)) {
     map.AddConstraint(result, {0, input_dim - 1});
@@ -916,8 +943,10 @@ IndexingMap RowReductionFusion::ComputeReductionOutputIndexing(
     MLIRContext* mlir_context) const {
   auto thread_id = DelinearizeInBoundsIndex(
       mlir::getAffineDimExpr(0, mlir_context), num_threads_);
-  auto block_id = DelinearizeInBoundsIndex(
-      mlir::getAffineDimExpr(3, mlir_context), num_blocks_);
+  auto bx = mlir::getAffineDimExpr(3, mlir_context), 
+       by = mlir::getAffineDimExpr(4, mlir_context);
+  auto block_id =
+       DelinearizeInBoundsIndex(bx + gpu_blocks_[0] * by, num_blocks_);
   IndexingMap projected_index =
       GetIndexingMap(block_id[0] * tile_sizes_per_block_[0] + thread_id[0]);
   projected_index.AddConstraint(thread_id[1], {0, 0});
@@ -979,6 +1008,17 @@ MultiRowReductionFusion::MultiRowReductionFusion(
   num_threads_ = GetNumThreads(reduction_dimensions_, vector_size);
   num_blocks_ = {GetNumBlocks(reduction_dimensions_, num_threads_)};
   tile_sizes_per_thread_ = {shape[0], vector_size};
+  gpu_blocks_ = MaybeSplitGridDimensionX(Product(num_threads_), 
+                            Product(num_blocks_), analysis_.device_info());
+
+  VLOG(3) << absl::StrFormat(
+      "MultiRowReductionFusion selected parameters: num_threads "
+      "= [%s], tile_sizes_per_thread = [%s], "
+      "num_blocks = [%s] real_blocks_ = [%d, %d]",
+      absl::StrJoin(num_threads_, ","),
+      absl::StrJoin(tile_sizes_per_thread_, ","),
+      absl::StrJoin(num_blocks_, ","),
+      gpu_blocks_[0], gpu_blocks_[1]);
 }
 
 std::unique_ptr<ReductionFusion> MultiRowReductionFusion::TryCreate(
@@ -1050,7 +1090,6 @@ std::unique_ptr<ReductionFusion> MultiRowReductionFusion::TryCreate(
              min_desired_blocks) {
     vector_size /= 2;
   }
-
   // Check again that the reduced dimension fits after potentially reducing the
   // vector size.
   if (shape[kRowMinorReduced] > warp_size * vector_size) {
@@ -1097,9 +1136,12 @@ IndexingMap MultiRowReductionFusion::ComputeReductionInputIndexing(
     MLIRContext* mlir_context) const {
   auto thread_id = DelinearizeInBoundsIndex(
       mlir::getAffineDimExpr(0, mlir_context), num_threads_);
-  auto block_id = num_blocks_.front() == 1
-                      ? mlir::getAffineConstantExpr(0, mlir_context)
-                      : mlir::getAffineDimExpr(3, mlir_context);
+  auto block_id = mlir::getAffineConstantExpr(0, mlir_context);
+  if (num_blocks_.front() != 1) {
+    auto bx = mlir::getAffineDimExpr(3, mlir_context),
+         by = mlir::getAffineDimExpr(4, mlir_context);
+    block_id = DelinearizeInBoundsIndex(bx + gpu_blocks_[0] * by, num_blocks_)[0];
+  }
   auto major_reduced = getAffineSymbolExpr(0, mlir_context);
   auto vector_index = getAffineSymbolExpr(1, mlir_context);
 
@@ -1118,9 +1160,12 @@ IndexingMap MultiRowReductionFusion::ComputeReductionOutputIndexing(
     MLIRContext* mlir_context) const {
   auto thread_id = DelinearizeInBoundsIndex(
       mlir::getAffineDimExpr(0, mlir_context), num_threads_);
-  auto block_id = num_blocks_.front() == 1
-                      ? mlir::getAffineConstantExpr(0, mlir_context)
-                      : mlir::getAffineDimExpr(3, mlir_context);
+  auto block_id = mlir::getAffineConstantExpr(0, mlir_context);
+  if (num_blocks_.front() != 1) {
+    auto bx = mlir::getAffineDimExpr(3, mlir_context),
+         by = mlir::getAffineDimExpr(4, mlir_context);
+    block_id = DelinearizeInBoundsIndex(bx + gpu_blocks_[0] * by, num_blocks_)[0];
+  }
   IndexingMap projected_index =
       GetIndexingMap(block_id * num_threads_[0] + thread_id[0]);
   projected_index.AddConstraint(thread_id[1] % num_threads_[1], {0, 0});

--- a/xla/backends/gpu/codegen/emitters/reduction.h
+++ b/xla/backends/gpu/codegen/emitters/reduction.h
@@ -142,7 +142,10 @@ class ReductionFusion : public EmitterBase {
   absl::InlinedVector<int64_t, 4> tile_sizes_per_thread_;
 
   absl::InlinedVector<int64_t, 4> num_threads_;
+  // virtual grid dimension: used by LLVM internally
   absl::InlinedVector<int64_t, 4> num_blocks_;
+  // real block dimensions used to launch a fusion kernel
+  std::array<uint64_t, 2> gpu_blocks_;
   int64_t vector_size_ = 1;
 
   ReductionDimensions reduction_dimensions_;

--- a/xla/backends/gpu/codegen/emitters/reduction_base.cc
+++ b/xla/backends/gpu/codegen/emitters/reduction_base.cc
@@ -202,7 +202,7 @@ void AddGroupIdConstraint(IndexingMap& map, int64_t root_index,
   // particular root.
   int group_index = groups.group_id_per_root[root_index];
   map.AddConstraint(
-      mlir::getAffineDimExpr(KernelFusionInterface::kIndexingMapBlockIdxDims[1],
+      mlir::getAffineDimExpr(KernelFusionInterface::kIndexingMapBlockIdxDims[2],
                              map.GetMLIRContext()),
       {group_index, group_index});
 }

--- a/xla/backends/gpu/codegen/emitters/tests/reduce_row/reduction_groups.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/reduce_row/reduction_groups.hlo
@@ -16,7 +16,7 @@ fusion {
   ROOT %tuple = (f32[], f32[]) tuple(%reduce1, %reduce2)
 }
 
-// CHECK: %[[BLOCK_ID_Y:.*]] = gpu.block_id y
-// CHECK: scf.index_switch %[[BLOCK_ID_Y]]
+// CHECK: %[[BLOCK_ID_Z:.*]] = gpu.block_id z
+// CHECK: scf.index_switch %[[BLOCK_ID_Z]]
 // CHECK: case 1 {
 // CHECK: default {

--- a/xla/backends/gpu/codegen/fusion_emitter.cc
+++ b/xla/backends/gpu/codegen/fusion_emitter.cc
@@ -111,15 +111,15 @@ absl::Status AnnotateKernelLaunchDimensions(
     const se::DeviceDescription& device_info,
     const LaunchDimensions& launch_dims, llvm::Function* kernel,
     llvm::Module* llvm_module) {
+
+  const se::BlockDim& limit = device_info.block_dim_limit(),
+                    & block_count = launch_dims.block_counts();
   TF_RET_CHECK(
-      (device_info.block_dim_limit().x == 0 ||
-       launch_dims.block_counts().x < device_info.block_dim_limit().x) &&
-      (device_info.block_dim_limit().y == 0 ||
-       launch_dims.block_counts().y < device_info.block_dim_limit().y))
+      (limit.x == 0 || block_count.x <= limit.x) &&
+      (limit.y == 0 || block_count.y <= limit.y))
       << "Kernel '" << kernel->getName().str() << "' launch needs more blocks ("
-      << launch_dims.block_counts().x << ", " << launch_dims.block_counts().y
-      << ") than allowed by hardware (" << device_info.block_dim_limit().x
-      << ", " << device_info.block_dim_limit().y << ").";
+      << block_count.x << ", " << block_count.y
+      << ") than allowed by hardware (" << limit.x << ", " << limit.y << ").";
   // Add __launch_bounds__ to metadata. This limits registers per thread to
   // avoid out-of-resources launching errors.
 
@@ -141,10 +141,10 @@ absl::Status AnnotateKernelLaunchDimensions(
                                      launch_dims.num_threads_per_block()},
                                     ","));
     kernel->addFnAttr("amdgpu-max-num-workgroups",
-                      absl::StrJoin({launch_dims.block_counts().x,
-                                     launch_dims.block_counts().y,
-                                     launch_dims.block_counts().z},
-                                    ","));
+                         absl::StrJoin({block_count.x,
+                                        block_count.y,
+                                        block_count.z},
+                                       ","));
   }
   return absl::OkStatus();
 }

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -159,7 +159,6 @@ cc_library(
         "//xla/runtime:work_dimensions",
         "//xla/runtime:work_group",
         "//xla/runtime:work_item",
-        "//xla/service:platform_util",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:launch_dim",
         "//xla/tsl/platform:statusor",

--- a/xla/service/gpu/launch_dimensions.cc
+++ b/xla/service/gpu/launch_dimensions.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
-#include <limits>
 
 #include "absl/log/check.h"
 #include "absl/status/statusor.h"
@@ -25,7 +24,6 @@ limitations under the License.
 #include "xla/runtime/work_dimensions.h"
 #include "xla/runtime/work_group.h"
 #include "xla/runtime/work_item.h"
-#include "xla/service/platform_util.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/stream_executor/device_description.h"

--- a/xla/service/gpu/launch_dimensions.h
+++ b/xla/service/gpu/launch_dimensions.h
@@ -49,9 +49,9 @@ class LaunchDimensions {
       : block_counts_(block_counts),
         thread_counts_per_block_(thread_counts_per_block) {}
 
-  se::BlockDim block_counts() const { return block_counts_; }
+  const se::BlockDim& block_counts() const { return block_counts_; }
 
-  se::ThreadDim thread_counts_per_block() const {
+  const se::ThreadDim& thread_counts_per_block() const {
     return thread_counts_per_block_;
   }
 

--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -48,16 +48,6 @@ class GpuKernelTilingTest : public GpuCodegenTest {
     config.set_debug_options(debug_options);
     return config;
   }
-
-  HloModuleConfig ConfigWithoutAutotuning() {
-    // We disable autotuning for tests that are meant to test the native 
-    // emitter, not the triton emitter.
-    HloModuleConfig config;
-    auto debug_options = HloTestBase::GetDebugOptionsForTest();
-    debug_options.set_xla_gpu_autotune_level(0);
-    config.set_debug_options(debug_options);
-    return config;
-  }
 };
 
 TEST_F(GpuKernelTilingTest, UnnestedTransposeWithProperDimensionsTiled) {
@@ -421,7 +411,7 @@ ENTRY RowLargeReduce {
   ROOT R = s32[262144,512]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
 })";
   ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+        ParseAndReturnVerifiedModule(kHlo);
   EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
 }
 
@@ -445,7 +435,7 @@ ENTRY RowLargeReduce {
   ROOT O = s16[762145,999] convert(R)
 })";
   ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+        ParseAndReturnVerifiedModule(kHlo);
   EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
 }
 
@@ -469,7 +459,7 @@ ENTRY MultiRowLargeReduce {
   ROOT O = s16[262144,4096]{1,0} convert(R)
 })";
   ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+        ParseAndReturnVerifiedModule(kHlo);
   EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
 }
 
@@ -493,7 +483,7 @@ ENTRY MultiRowLargeReduce {
   ROOT R = s32[762145,999]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
 })";
   ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+        ParseAndReturnVerifiedModule(kHlo);
   EXPECT_OK(CompileToExecutable(std::move(hlo_module)));
 }
 
@@ -506,7 +496,7 @@ ENTRY LargeLoop {
   ROOT B = bf16[80,7,8192,8192]{3,2,1,0} broadcast(C), dimensions={}
 })";
   ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-      ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+      ParseAndReturnVerifiedModule(kHlo);
   EXPECT_OK(CompileToExecutable(std::move(hlo_module)));
 }
 

--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -474,6 +474,12 @@ ENTRY MultiRowLargeReduce {
 }
 
 TEST_F(GpuKernelTilingTest, MultiRowLargeReduceNonMultipleOf2) {
+
+  if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "cuda") {
+    GTEST_SKIP() << "This test is currently broken on B200 system due to "
+                    "fusion autotuner issues.";
+  }
+
   const char *kHlo = 
 R"(
 HloModule Test

--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -393,8 +393,7 @@ ENTRY %primitive_computation_svd.38 (constant_5: f32[841,3], fusion.3: pred[3]) 
 }
 
 TEST_F(GpuKernelTilingTest, LargeRowReduction) {
-  const char *kHlo = 
-R"(
+  const char *kHlo = R"(
 HloModule Test
 reduceOp {
   X = s32[] parameter(1)
@@ -410,14 +409,12 @@ ENTRY RowLargeReduce {
   CC = s32[] constant(0)
   ROOT R = s32[262144,512]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
 })";
-  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo);
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseAndReturnVerifiedModule(kHlo));
   EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
 }
 
 TEST_F(GpuKernelTilingTest, LargeRowReductionNonMultipleOf2) {
-  const char *kHlo = 
-R"(
+  const char *kHlo = R"(
 HloModule Test
 reduceOp {
   X = s32[] parameter(1)
@@ -434,14 +431,12 @@ ENTRY RowLargeReduce {
   R = s32[762145,999]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
   ROOT O = s16[762145,999] convert(R)
 })";
-  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo);
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseAndReturnVerifiedModule(kHlo));
   EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
 }
 
 TEST_F(GpuKernelTilingTest, MultiRowLargeReduce) {
-  const char *kHlo = 
-R"(
+  const char *kHlo = R"(
 HloModule Test
 reduceOp {
   X = s32[] parameter(1)
@@ -458,15 +453,12 @@ ENTRY MultiRowLargeReduce {
   R = s32[262144,4096]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
   ROOT O = s16[262144,4096]{1,0} convert(R)
 })";
-  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo);
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseAndReturnVerifiedModule(kHlo));
   EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
 }
 
 TEST_F(GpuKernelTilingTest, MultiRowLargeReduceNonMultipleOf2) {
-
-  const char *kHlo = 
-R"(
+  const char *kHlo = R"(
 HloModule Test
 reduceOp {
   X = s32[] parameter(1)
@@ -482,21 +474,18 @@ ENTRY MultiRowLargeReduce {
   CC = s32[] constant(0)
   ROOT R = s32[762145,999]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
 })";
-  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-        ParseAndReturnVerifiedModule(kHlo);
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseAndReturnVerifiedModule(kHlo));
   EXPECT_OK(CompileToExecutable(std::move(hlo_module)));
 }
 
 TEST_F(GpuKernelTilingTest, LargeLoopFusion) {
-  const char *kHlo = 
-R"(
+  const char *kHlo = R"(
 HloModule Test
 ENTRY LargeLoop {
   C = bf16[] constant(0)
   ROOT B = bf16[80,7,8192,8192]{3,2,1,0} broadcast(C), dimensions={}
 })";
-  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
-      ParseAndReturnVerifiedModule(kHlo);
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseAndReturnVerifiedModule(kHlo));
   EXPECT_OK(CompileToExecutable(std::move(hlo_module)));
 }
 

--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -48,6 +48,16 @@ class GpuKernelTilingTest : public GpuCodegenTest {
     config.set_debug_options(debug_options);
     return config;
   }
+
+  HloModuleConfig ConfigWithoutAutotuning() {
+    // We disable autotuning for tests that are meant to test the native 
+    // emitter, not the triton emitter.
+    HloModuleConfig config;
+    auto debug_options = HloTestBase::GetDebugOptionsForTest();
+    debug_options.set_xla_gpu_autotune_level(0);
+    config.set_debug_options(debug_options);
+    return config;
+  }
 };
 
 TEST_F(GpuKernelTilingTest, UnnestedTransposeWithProperDimensionsTiled) {
@@ -392,8 +402,116 @@ ENTRY %primitive_computation_svd.38 (constant_5: f32[841,3], fusion.3: pred[3]) 
   EXPECT_TRUE(RunAndCompareNoHloPasses(kHloString, ErrorSpec{0.001}));
 }
 
+TEST_F(GpuKernelTilingTest, LargeRowReduction) {
+  const char *kHlo = 
+R"(
+HloModule Test
+reduceOp {
+  X = s32[] parameter(1)
+  Y = s32[] parameter(0)
+  ROOT Z = s32[] maximum(X, Y)
+}
+ENTRY RowLargeReduce {
+  A = s32[262144]{0} parameter(0)
+  B = s32[262144,262144]{1,0} broadcast(A), dimensions={0}
+  I = s32[262144,262144]{1,0} iota(), iota_dimension=1
+  Z = s32[262144,262144]{1,0} add(B, I)
+  BB = s32[262144,512,512]{2,1,0} reshape(Z)
+  CC = s32[] constant(0)
+  ROOT R = s32[262144,512]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
+})";
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
+        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+  EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
+}
+
+TEST_F(GpuKernelTilingTest, LargeRowReductionNonMultipleOf2) {
+  const char *kHlo = 
+R"(
+HloModule Test
+reduceOp {
+  X = s32[] parameter(1)
+  Y = s32[] parameter(0)
+  ROOT Z = s32[] maximum(X, Y)
+}
+ENTRY RowLargeReduce {
+  A = s32[762145]{0} parameter(0)
+  B = s32[762145,776223]{1,0} broadcast(A), dimensions={0}
+  I = s32[762145,776223]{1,0} iota(), iota_dimension=1
+  Z = s32[762145,776223]{1,0} add(B, I)
+  BB = s32[762145,999,777]{2,1,0} reshape(B)
+  CC = s32[] constant(0)
+  R = s32[762145,999]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
+  ROOT O = s16[762145,999] convert(R)
+})";
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
+        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+  EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
+}
+
+TEST_F(GpuKernelTilingTest, MultiRowLargeReduce) {
+  const char *kHlo = 
+R"(
+HloModule Test
+reduceOp {
+  X = s32[] parameter(1)
+  Y = s32[] parameter(0)
+  ROOT Z = s32[] maximum(X, Y)
+}
+ENTRY MultiRowLargeReduce {
+  A = s32[262144]{0} parameter(0)
+  B = s32[262144,262144]{1,0} broadcast(A), dimensions={0}
+  I = s32[262144,262144]{1,0} iota(), iota_dimension=1
+  Z = s32[262144,262144]{1,0} add(B, I)
+  BB = s32[262144,4096,64]{2,1,0} reshape(Z)
+  CC = s32[] constant(0)
+  R = s32[262144,4096]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
+  ROOT O = s16[262144,4096]{1,0} convert(R)
+})";
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
+        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+  EXPECT_TRUE(Run(std::move(hlo_module), /*run_hlo_passes*/true));
+}
+
+TEST_F(GpuKernelTilingTest, MultiRowLargeReduceNonMultipleOf2) {
+  const char *kHlo = 
+R"(
+HloModule Test
+reduceOp {
+  X = s32[] parameter(1)
+  Y = s32[] parameter(0)
+  ROOT Z = s32[] maximum(X, Y)
+}
+ENTRY MultiRowLargeReduce {
+  A = s32[762145]{0} parameter(0)
+  B = s32[762145,639936]{1,0} broadcast(A), dimensions={0}
+  I = s32[762145,639936]{1,0} iota(), iota_dimension=1
+  Z = s32[762145,639936]{1,0} add(B, I)
+  BB = s32[762145,9999,64]{2,1,0} reshape(B)
+  CC = s32[] constant(0)
+  ROOT R = s32[762145,9999]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
+})";
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
+        ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+  EXPECT_OK(CompileToExecutable(std::move(hlo_module)));
+}
+
+TEST_F(GpuKernelTilingTest, LargeLoopFusion) {
+  const char *kHlo = 
+R"(
+HloModule Test
+ENTRY LargeLoop {
+  C = bf16[] constant(0)
+  ROOT B = bf16[80,7,8192,8192]{3,2,1,0} broadcast(C), dimensions={}
+})";
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, 
+      ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));
+  EXPECT_OK(CompileToExecutable(std::move(hlo_module)));
+}
+
 TEST_F(GpuKernelTilingTest, ReductionInputTooLarge) {
-  const char *const kHloString = R"(
+
+  const char *const kHlo = R"(
   HloModule RowReduce
 
   Sum {
@@ -403,12 +521,12 @@ TEST_F(GpuKernelTilingTest, ReductionInputTooLarge) {
   }
 
   ENTRY reduce.1 {
-    parameter = f32[16,1048576,1024,1024] parameter(0)
+    parameter = f32[1048576,1048576,1024,1024] parameter(0)
     init_value = f32[] constant(0)
-    ROOT reduce = f32[16,1048576,1024] reduce(parameter, init_value), dimensions={3}, to_apply=Sum
+    ROOT reduce = f32[1048576,1048576,1024] reduce(parameter, init_value), dimensions={3}, to_apply=Sum
   }
   )";
-  auto hlo_module = ParseAndReturnVerifiedModule(kHloString).value();
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseAndReturnVerifiedModule(kHlo));
   // Disable autotuning because this is checking for an error returned by the
   // Native Emitter. With autotuning enabled, the error is that autotuning
   // itself fails to find a config because all the backends return failure.
@@ -420,12 +538,12 @@ TEST_F(GpuKernelTilingTest, ReductionInputTooLarge) {
   if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm") {
     EXPECT_THAT(status.message(),
                 ::testing::ContainsRegex(
-                    "Kernel '.*' launch needs more blocks [(]4294967296, 1[)] "
+                    "Kernel '.*' launch needs more blocks [(]4294967296, 65536[)] "
                     "than allowed by hardware [(]2147483647, 65536[)]"));
   } else {
     EXPECT_THAT(status.message(),
                 ::testing::ContainsRegex(
-                    "Kernel '.*' launch needs more blocks [(]4294967296, 1[)] "
+                    "Kernel '.*' launch needs more blocks [(].*, 65535[)] "
                     "than allowed by hardware [(]2147483647, 65535[)]"));
   }
 }

--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -475,11 +475,6 @@ ENTRY MultiRowLargeReduce {
 
 TEST_F(GpuKernelTilingTest, MultiRowLargeReduceNonMultipleOf2) {
 
-  if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "cuda") {
-    GTEST_SKIP() << "This test is currently broken on B200 system due to "
-                    "fusion autotuner issues.";
-  }
-
   const char *kHlo = 
 R"(
 HloModule Test
@@ -490,12 +485,12 @@ reduceOp {
 }
 ENTRY MultiRowLargeReduce {
   A = s32[762145]{0} parameter(0)
-  B = s32[762145,639936]{1,0} broadcast(A), dimensions={0}
-  I = s32[762145,639936]{1,0} iota(), iota_dimension=1
-  Z = s32[762145,639936]{1,0} add(B, I)
-  BB = s32[762145,9999,64]{2,1,0} reshape(B)
+  B = s32[762145,63936]{1,0} broadcast(A), dimensions={0}
+  I = s32[762145,63936]{1,0} iota(), iota_dimension=1
+  Z = s32[762145,63936]{1,0} add(B, I)
+  BB = s32[762145,999,64]{2,1,0} reshape(B)
   CC = s32[] constant(0)
-  ROOT R = s32[762145,9999]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
+  ROOT R = s32[762145,999]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
 })";
   ASSERT_OK_AND_ASSIGN(auto hlo_module, 
         ParseAndReturnVerifiedModule(kHlo, ConfigWithoutAutotuning()));

--- a/xla/stream_executor/rocm/rocm_stream.cc
+++ b/xla/stream_executor/rocm/rocm_stream.cc
@@ -342,8 +342,9 @@ absl::Status LaunchRocmKernel(
   }
   TF_RETURN_IF_ERROR(
       ToStatus(res, absl::StrCat("Failed to launch ROCm kernel: ", kernel_name,
-                                 " with block dimensions: ", block_dim_x, "x",
-                                 block_dim_y, "x", block_dim_z)));
+                  "; grid: ", grid_dim_x, "x", grid_dim_y, "x", grid_dim_z,
+                  "; block: ", block_dim_x, "x", block_dim_y, "x", block_dim_z,
+                  "; shared_mem: ", shared_mem_bytes)));
 
   VLOG(2) << "successfully launched kernel";
   return absl::OkStatus();


### PR DESCRIPTION
During maxtext training we had fusion kernel launch failures due to very large grid X dimension. Two examples of this are:
```
HloModule Test
reduceOp {
  X = s32[] parameter(1)
  Y = s32[] parameter(0)
  ROOT Z = s32[] maximum(X, Y)
}
ENTRY RowLargeReduce {
  A = s32[262144]{0} parameter(0)
  B = s32[262144,262144]{1,0} broadcast(A), dimensions={0}
  I = s32[262144,262144]{1,0} iota(), iota_dimension=1
  Z = s32[262144,262144]{1,0} add(B, I)
  BB = s32[262144,512,512]{2,1,0} reshape(Z)
  CC = s32[] constant(0)
  ROOT R = s32[262144,512]{1,0} reduce(BB, CC), dimensions={2}, to_apply=reduceOp
}
```
and this one appeared during while loop initialization:
```
HloModule Test
ENTRY LargeLoop {
  C = bf16[] constant(0)
  ROOT B = bf16[80,7,8192,8192]{3,2,1,0} broadcast(C), dimensions={}
}
```
The solution here is to split gridDim.x into gridDim.x and y for these cases. This might also be useful on CUDA side (yet, CUDA has large grid dimension limits).

📝 Summary of Changes

- added gridDim.x splitting (into x and y) for reduction and loop fusions to handle large grid sizes
- removed a few hacks on ROCM side for fusion kernels (so all fixes are unified now)
- extended gpu_kernel_tiling test
- improved error logging in rocm_stream.cc in case of kernel launch failure
- fixing dangling reference bugs in emitter_base.cc

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Added a new subtest for xla/service/gpu/tests/gpu_kernel_tiling_test.cc

@xla-rotation: could you have a look please ?