### PR TITLE
[WIP ROCm] Fix flaky PersistedAutotuningTest.SingleOperationGetsAutotuned

### DIFF
--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -395,6 +395,13 @@ ENTRY e {
 
 class PersistedAutotuningTest : public HloTestBase {
  protected:
+  void SetUp() override {
+    AutotunerUtil::ClearAutotuneResults();
+    xla_gpu_dump_autotune_results_to_ = GetUniqueTempFilePath(".txt");
+  }
+
+  void TearDown() override { AutotunerUtil::ClearAutotuneResults(); }
+
   static constexpr absl::string_view kHloText = R"(
 HloModule t
 
@@ -428,7 +435,6 @@ ENTRY e {
 
 TEST_F(PersistedAutotuningTest, WriteResultsOnEachCompilation) {
   constexpr absl::string_view kInvalidTextProto = "Invalid!";
-  xla_gpu_dump_autotune_results_to_ = GetUniqueTempFilePath(".txt");
 
   // Check that it writes the results on the first compilation.
   TF_EXPECT_OK(GetOptimizedModule(kHloText).status());
@@ -459,8 +465,6 @@ TEST_F(PersistedAutotuningTest, WriteResultsOnEachCompilation) {
 }
 
 TEST_F(PersistedAutotuningTest, SingleOperationGetsAutotuned) {
-  xla_gpu_dump_autotune_results_to_ = GetUniqueTempFilePath(".txt");
-
   TF_EXPECT_OK(GetOptimizedModule(R"(
 e {
   a = f32[64,128] parameter(0)


### PR DESCRIPTION
Clear the shared autotune cache in PersistedAutotuningTest::SetUp.

The test was randomly passing or failing depending on test execution order due to a shared global autotune_cache that persists across test executions.

With this fix, the test now consistently fails for ROCm/AMDGPU, which is the expected behavior since transpose autotuning (implemented in #35098) is not yet supported on ROCm/AMDGPU. The test was occasionally and incorrectly passing when it inherited autotune results from other tests via the shared cache.
