### PR TITLE
[ROCM] bug-fixing SortRewriter and fixing self_adjoint_test on ROCM

### DIFF
--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -2629,7 +2629,6 @@ xla_test(
         "gpu",
     ],
     tags = [
-        "cuda-only",
         "test_migrated_to_hlo_runner_pjrt",
     ],
     deps = [

--- a/xla/service/gpu/transforms/sort_rewriter_test.cc
+++ b/xla/service/gpu/transforms/sort_rewriter_test.cc
@@ -439,6 +439,9 @@ ENTRY %main {
   ROOT %sort = f32[$0,100000] sort(%input), dimensions={1}, to_apply=%compare
 })";
 
+  if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm") {
+    GTEST_SKIP() << "Skipping CUDA-specific test";
+  }
   auto pass = SortRewriter(TestGpuDeviceInfo::RTXH100SXMDeviceInfo(), "CUDA");
 
   // Batch 1
@@ -477,6 +480,9 @@ ENTRY %main {
   ROOT %sort = f32[$0,100000] sort(%input), dimensions={1}, to_apply=%compare
 })";
 
+  if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm") {
+    GTEST_SKIP() << "Skipping CUDA-specific test";
+  }
   auto pass = SortRewriter(TestGpuDeviceInfo::RTXA6000DeviceInfo(), "CUDA");
 
   // Batch 1
@@ -571,13 +577,25 @@ ENTRY %main {
       dimensions={0}, to_apply=%compare, metadata={op_type="sort" op_name="sort" source_file="path/to/test.cc" source_line=68}
 })";
   constexpr char kExpectedPattern[] = R"(
-    // CHECK: %[[CC:.*]] = (u16[1000]{0}, u8[1]{0}) custom-call({{.*}}), custom_call_target="__cub$DeviceRadixSortUnassignedScratchSize", metadata={op_type="sort" op_name="sort" source_file="path/to/test.cc" source_line=68}, backend_config={"descending":true}
+    // CHECK: %[[CC:.*]] = (u16[1000]{0}, u8[{{[0-9]+}}]{0}) custom-call({{.*}}), custom_call_target="__cub$DeviceRadixSortUnassignedScratchSize", metadata={op_type="sort" op_name="sort" source_file="path/to/test.cc" source_line=68}, backend_config={"descending":true}
   )";
-  for (const auto& [device_description, platform_name] :
-       {std::tuple{TestGpuDeviceInfo::RTXA6000DeviceInfo(), "CUDA"},
-        std::tuple{TestGpuDeviceInfo::RTXH100SXMDeviceInfo(), "CUDA"}}) {
+
+  auto platform_name = absl::AsciiStrToUpper(
+                      xla::PlatformUtil::CanonicalPlatformName("gpu").value());
+  auto device_list = [platform_name]() -> 
+                              std::vector< se::DeviceDescription > {
+    if (platform_name == "CUDA") {
+      return {TestGpuDeviceInfo::RTXA6000DeviceInfo(),
+              TestGpuDeviceInfo::RTXH100SXMDeviceInfo()};
+    } else {
+      return {TestGpuDeviceInfo::AMDMI210DeviceInfo(),
+              TestGpuDeviceInfo::AMDRX7900DeviceInfo()};
+    }
+  };
+
+  for (const auto& device_desc : device_list()) {
     RunAndFilecheckHloRewrite(kHlo,
-                              SortRewriter(device_description, platform_name),
+                              SortRewriter(device_desc, platform_name),
                               kExpectedPattern);
   }
 }

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.cu.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.cu.cc
@@ -252,7 +252,7 @@ static absl::Status CubSortPairsGetScratchSize(size_t* temp_bytes,
           .Attr<size_t>("num_items")                                          \
           .Attr<size_t>("batch_size"));                                       \
   XLA_FFI_REGISTER_HANDLER(                                                   \
-      xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_keys_" #suffix, "CUDA", \
+      xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_keys_" #suffix, "ROCM", \
       {/* .instantiate = */ nullptr, /* .prepare = */ nullptr,                \
        /* .initialize = */ kCubSortKeysInitialize_##suffix,                   \
        /* .execute = */ kCubSortKeysExecute_##suffix});
@@ -278,7 +278,7 @@ static absl::Status CubSortPairsGetScratchSize(size_t* temp_bytes,
           .Attr<size_t>("num_items")                                           \
           .Attr<size_t>("batch_size"));                                        \
   XLA_FFI_REGISTER_HANDLER(                                                    \
-      xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_pairs_" #suffix, "CUDA", \
+      xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_pairs_" #suffix, "ROCM", \
       {/* .instantiate = */ nullptr, /* .prepare = */ nullptr,                 \
        /* .initialize = */ kCubSortPairsInitialize_##suffix,                   \
        /* .execute = */ kCubSortPairsExecute_##suffix});


### PR DESCRIPTION
📝 Summary of Changes
- This reenables SortRewriter which was erroneously disabled on ROCM (wrong platform).
- SortRewriter is called after EighExpander to make sure sort op inserted by EighExpander gets properly rewritten
- Reenables sort_rewriter_test on ROCM which was marked 'cuda-only'

This shall also improve the perf of EighExpander on CUDA since [this sort op](https://github.com/ROCm/xla/blob/855c22fafe82b400429380621fa8596a523a2014/xla/hlo/transforms/expanders/eigh_expander.cc#L375) gets now rewritten to CUB custom-call

🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement,

🧪 Unit Tests:
The existing self_adjoint_test was failing on ROCM due to disabled SortRewriter.
Also sort_rewriter_test is now enabled on ROCM too

@xla-rotation could you have a look please?