### PR TITLE
[ROCm] Fix build: use NCCL_WIN_COLL_SYMMETRIC constant

### DIFF
--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -401,7 +401,7 @@ RcclCommunicator::RegisterBuffer(stream_executor::DeviceAddressBase buffer,
           XLA_RCCL_RETURN_IF_ERROR(ncclGroupStart());
           XLA_RCCL_RETURN_IF_ERROR(ncclCommWindowRegister(
               comm_, buffer.opaque(), buffer.size(), (ncclWindow_t*)&handle,
-              RCCL_WIN_COLL_SYMMETRIC));
+              NCCL_WIN_COLL_SYMMETRIC));
           XLA_RCCL_RETURN_IF_ERROR(ncclGroupEnd());
           if (group_nesting_level_ == 0) {
             TF_RETURN_IF_ERROR(PollUntilDone());


### PR DESCRIPTION
📝 Summary of Changes
RCCL_WIN_COLL_SYMMETRIC does not exist in rccl.h headers. Use the correct NCCL_WIN_COLL_SYMMETRIC constant instead.

🎯 Justification
Fix ROCm build and CI errors introduced in #35200

🚀 Kind of Contribution
🐛 Bug Fix