### PR TITLE
Fixed triton_support_test on rocm.

### DIFF
--- a/xla/backends/gpu/codegen/triton/emitter_helpers.cc
+++ b/xla/backends/gpu/codegen/triton/emitter_helpers.cc
@@ -211,6 +211,10 @@ absl::StatusOr<Type> PrimitiveTypeToMlirType(mlir::ImplicitLocOpBuilder& b,
       return b.getType<mlir::Float8E8M0FNUType>();
     case F4E2M1FN:
       return b.getType<mlir::Float4E2M1FNType>();
+    case F8E5M2FNUZ:
+      return b.getType<mlir::Float8E5M2FNUZType>();
+    case F8E4M3FNUZ:
+      return b.getType<mlir::Float8E4M3FNUZType>();
     default:
       return absl::UnimplementedError(
           absl::StrCat("This type is not supported yet: ",
@@ -233,6 +237,8 @@ absl::StatusOr<PrimitiveType> GetPrimitiveType(Type t) {
   if (mlir::isa<mlir::Float8E5M2Type>(t)) return F8E5M2;
   if (mlir::isa<mlir::Float8E4M3FNType>(t)) return F8E4M3FN;
   if (mlir::isa<mlir::Float8E8M0FNUType>(t)) return F8E8M0FNU;
+  if (mlir::isa<mlir::Float8E5M2FNUZType>(t)) return F8E5M2FNUZ;
+  if (mlir::isa<mlir::Float8E4M3FNUZType>(t)) return F8E4M3FNUZ;
   // NOLINTEND(google-readability-braces-around-statements)
   return absl::UnimplementedError("Unsupported type in getPrimitiveType.\n");
 }

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -47,6 +47,8 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
+namespace {
+
 bool IsTritonSupportedDataType(PrimitiveType type,
                                const se::GpuComputeCapability& gpu_version) {
   switch (type) {
@@ -74,8 +76,6 @@ bool IsTritonSupportedDataType(PrimitiveType type,
       return false;
   }
 }
-
-namespace {
 
 // Set of unary elementwise ops that are genuinely supported by Triton.
 absl::flat_hash_set<HloOpcode> TritonSupportedUnaryElementwiseOps(

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -47,8 +47,6 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-namespace {
-
 bool IsTritonSupportedDataType(PrimitiveType type,
                                const se::GpuComputeCapability& gpu_version) {
   switch (type) {
@@ -76,6 +74,8 @@ bool IsTritonSupportedDataType(PrimitiveType type,
       return false;
   }
 }
+
+namespace {
 
 // Set of unary elementwise ops that are genuinely supported by Triton.
 absl::flat_hash_set<HloOpcode> TritonSupportedUnaryElementwiseOps(

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -79,7 +79,7 @@ bool IsTritonSupportedDataType(PrimitiveType type,
 
 // Set of unary elementwise ops that are genuinely supported by Triton.
 absl::flat_hash_set<HloOpcode> TritonSupportedUnaryElementwiseOps(
-    PrimitiveType element_type) {
+    PrimitiveType element_type, const se::GpuComputeCapability& gpu_version) {
   if (element_type == PrimitiveType::PRED) {
     return {HloOpcode::kNot, HloOpcode::kCopy};
   }
@@ -97,8 +97,8 @@ absl::flat_hash_set<HloOpcode> TritonSupportedUnaryElementwiseOps(
   if (element_type != PrimitiveType::F8E5M2 &&
       element_type != PrimitiveType::F8E4M3FN &&
       element_type != PrimitiveType::F8E8M0FNU &&
-      element_type != PrimitiveType::F8E5M2FNUZ &&
-      element_type != PrimitiveType::F8E4M3FNUZ) {
+      !(gpu_version.IsRocm() && element_type == PrimitiveType::F8E5M2FNUZ) &&
+      !(gpu_version.IsRocm() && element_type == PrimitiveType::F8E4M3FNUZ)) {
     ret.insert(HloOpcode::kNegate);
   }
 
@@ -201,8 +201,8 @@ absl::flat_hash_set<HloOpcode> TritonSupportedBinaryElementwiseOps(
   if (element_type == PrimitiveType::S4 || element_type == PrimitiveType::U16 ||
       element_type == PrimitiveType::F8E5M2 ||
       element_type == PrimitiveType::F8E4M3FN || 
-      element_type == PrimitiveType::F8E5M2FNUZ ||
-      element_type == PrimitiveType::F8E4M3FNUZ) {
+      (gpu_version.IsRocm() && element_type == PrimitiveType::F8E5M2FNUZ) ||
+      (gpu_version.IsRocm() && element_type == PrimitiveType::F8E4M3FNUZ)) {
     return {};
   }
 
@@ -256,8 +256,8 @@ absl::flat_hash_set<HloOpcode> TritonSupportedTernaryElementwiseOps(
 
   if (element_type == PrimitiveType::F8E5M2 ||
       element_type == PrimitiveType::F8E4M3FN || 
-      element_type == PrimitiveType::F8E5M2FNUZ ||
-      element_type == PrimitiveType::F8E4M3FNUZ) {
+      (gpu_version.IsRocm() && element_type == PrimitiveType::F8E5M2FNUZ) ||
+      (gpu_version.IsRocm() && element_type == PrimitiveType::F8E4M3FNUZ)) {
     return {HloOpcode::kSelect};
   }
 
@@ -270,7 +270,8 @@ absl::flat_hash_set<HloOpcode> TritonSupportedTernaryElementwiseOps(
 // device of interest.
 bool IsTritonSupportedElementwise(HloOpcode opcode, PrimitiveType element_type,
                                   const se::GpuComputeCapability& gpu_version) {
-  return TritonSupportedUnaryElementwiseOps(element_type).contains(opcode) ||
+  return TritonSupportedUnaryElementwiseOps(element_type, gpu_version)
+             .contains(opcode) ||
          TritonSupportedBinaryElementwiseOps(element_type, gpu_version)
              .contains(opcode) ||
          TritonSupportedTernaryElementwiseOps(element_type, gpu_version)
@@ -286,8 +287,10 @@ CodegenDecision CanTritonHandleReduce(
     const se::GpuComputeCapability& gpu_version) {
   if (reduce.shape().element_type() == PrimitiveType::F8E4M3FN ||
       reduce.shape().element_type() == PrimitiveType::F8E5M2 ||
-      reduce.shape().element_type() == PrimitiveType::F8E5M2FNUZ ||
-      reduce.shape().element_type() == PrimitiveType::F8E4M3FNUZ) {
+      (gpu_version.IsRocm() &&
+       reduce.shape().element_type() == PrimitiveType::F8E5M2FNUZ) ||
+      (gpu_version.IsRocm() &&
+       reduce.shape().element_type() == PrimitiveType::F8E4M3FNUZ)) {
     return CodegenDecision::Forbid(
         "F8E4M3FN and F8E5M2 are not supported for reductions.");
   }
@@ -353,8 +356,7 @@ absl::Status CheckSupportedCheckDotDimensions(const HloDotInstruction& dot) {
   return absl::OkStatus();
 }
 
-bool IsSupportedDotAlgorithm(PrecisionConfig::Algorithm algorithm,
-                             const se::GpuComputeCapability& gpu_version) {
+bool IsSupportedDotAlgorithm(PrecisionConfig::Algorithm algorithm) {
   switch (algorithm) {
     case PrecisionConfig::ALG_UNSET:
     case PrecisionConfig::ALG_DOT_F16_F16_F16:
@@ -394,8 +396,12 @@ CodegenDecision AreTypesSupportedByAlgUnsetDot(
     }
   }
 
-  auto supported_float_types = {BF16, F16, F32, F64, F8E4M3FN, F8E5M2,
-                                F8E4M3FNUZ, F8E5M2FNUZ};
+  std::vector<PrimitiveType> supported_float_types = {BF16, F16, F32, F64,
+                                                      F8E4M3FN, F8E5M2};
+  if (gpu_version.IsRocm()) {
+    supported_float_types.insert(supported_float_types.end(),
+                                 {F8E4M3FNUZ, F8E5M2FNUZ});
+  }
   if (absl::c_linear_search(supported_float_types, input_type)) {
     return CodegenDecision::Allow();
   }
@@ -531,7 +537,7 @@ CodegenDecision IsTritonSupportedDot(
   const PrecisionConfig& precision_config = dot.precision_config();
   const PrecisionConfig::Algorithm algorithm = precision_config.algorithm();
 
-  if (!IsSupportedDotAlgorithm(algorithm, gpu_version)) {
+  if (!IsSupportedDotAlgorithm(algorithm)) {
     return CodegenDecision::Forbid(
         absl::StrCat("Unsupported dot algorithm: ",
                      PrecisionConfig::Algorithm_Name(algorithm)));
@@ -690,8 +696,10 @@ CodegenDecision IsTritonSupportedInstructionImpl(
     return CodegenDecision(
         element_type != PrimitiveType::F8E4M3FN &&
             element_type != PrimitiveType::F8E5M2 &&
-            element_type != PrimitiveType::F8E4M3FNUZ &&
-            element_type != PrimitiveType::F8E5M2FNUZ &&
+            !(gpu_version.IsRocm() &&
+              element_type == PrimitiveType::F8E4M3FNUZ) &&
+            !(gpu_version.IsRocm() &&
+              element_type == PrimitiveType::F8E5M2FNUZ) &&
             element_type != PrimitiveType::S4,
         "F8E4M3FN, F8E5M2 and S4 are not supported for iota.");
   }

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -167,7 +167,11 @@ CodegenDecision IsTritonSupportedConversion(
     return error_message();
   }
 
-  auto supported_fp8_types = {F8E4M3FN, F8E5M2, F8E4M3FNUZ, F8E5M2FNUZ};
+  std::vector<PrimitiveType> supported_fp8_types = {F8E4M3FN, F8E5M2};
+  if (gpu_version.IsRocm()) {
+        supported_fp8_types.insert(supported_fp8_types.end(),
+                                   {F8E4M3FNUZ, F8E5M2FNUZ});
+  }
   bool is_input_fp8 = absl::c_linear_search(supported_fp8_types, input);
   bool is_output_fp8 = absl::c_linear_search(supported_fp8_types, output);
   bool is_f8_conversion = is_input_fp8 && is_output_fp8;

--- a/xla/backends/gpu/codegen/triton/support.h
+++ b/xla/backends/gpu/codegen/triton/support.h
@@ -66,6 +66,11 @@ CodegenDecision IsTritonSupportedComputation(
 // `kTritonGemmFusionKind`.
 bool IsTritonFusedComputation(const HloComputation& computation);
 
+// Returns `CodegenDecision`'s equivalent of `true` if data type
+// is supported by the Triton emitters for the given compute capability.
+bool IsTritonSupportedDataType(PrimitiveType type,
+                               const se::GpuComputeCapability& gpu_version);
+
 namespace internal {
 // TODO(b/363981282): Remove the function below once all ops are tested via
 // HLOs. This is exposed for testing purposes only and will be removed in the

--- a/xla/backends/gpu/codegen/triton/support.h
+++ b/xla/backends/gpu/codegen/triton/support.h
@@ -66,11 +66,6 @@ CodegenDecision IsTritonSupportedComputation(
 // `kTritonGemmFusionKind`.
 bool IsTritonFusedComputation(const HloComputation& computation);
 
-// Returns `CodegenDecision`'s equivalent of `true` if data type
-// is supported by the Triton emitters for the given compute capability.
-bool IsTritonSupportedDataType(PrimitiveType type,
-                               const se::GpuComputeCapability& gpu_version);
-
 namespace internal {
 // TODO(b/363981282): Remove the function below once all ops are tested via
 // HLOs. This is exposed for testing purposes only and will be removed in the

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -627,7 +627,7 @@ ENTRY triton_computation {
           data_type == PrimitiveType::F8E4M3FN || 
           data_type == PrimitiveType::F8E5M2FNUZ ||
           data_type == PrimitiveType::F8E4M3FNUZ))) {
-      fail_mode = ExpectedFailMode::kFailOrCrash;
+      fail_mode = ExpectedFailMode::kCrash;
     }
   }
 
@@ -671,7 +671,7 @@ ENTRY triton_computation {
           data_type == PrimitiveType::F8E4M3FN ||
           data_type == PrimitiveType::F8E5M2FNUZ ||
           data_type == PrimitiveType::F8E4M3FNUZ))) {
-      fail_mode = ExpectedFailMode::kFailOrCrash;
+      fail_mode = ExpectedFailMode::kCrash;
     }
   }
 
@@ -738,7 +738,7 @@ ENTRY triton_computation {
   }
 
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc,
-                 skip_failure_branch_to_avoid_crash ? ExpectedFailMode::kFailOrCrash
+                 skip_failure_branch_to_avoid_crash ? ExpectedFailMode::kCrash
                                                     : ExpectedFailMode::kFail);
 }
 
@@ -2381,7 +2381,7 @@ ENTRY triton_computation {
   if (cc.IsRocm()) {
     if (absl::c_linear_search(std::vector{F8E4M3FNUZ, F8E5M2FNUZ, F8E4M3FN,
                                           S8, S16, S32, S64}, data_type)) {
-      fail_mode = ExpectedFailMode::kFailOrCrash;
+      fail_mode = ExpectedFailMode::kFail;
     }
   }
   TF_ASSERT_OK_AND_ASSIGN(
@@ -2482,7 +2482,7 @@ ENTRY triton_computation {
         (absl::c_linear_search(std::vector{S64, S32, S16, BF16, F16, F32},
                                 data_type)  &&
          algorithm == xla::PrecisionConfig::ALG_DOT_F64_F64_F64)) {
-      fail_mode = ExpectedFailMode::kFailOrCrash;
+      fail_mode = ExpectedFailMode::kFail;
     }
   }
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32}, cc, fail_mode);

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -183,6 +183,10 @@ auto AllDevicesToTest() {
 #endif
 }
 
+stream_executor::GpuComputeCapability DefaultDeviceForTesting() {
+  return AllDevicesToTest()[0];
+}
+
 // Generates all the possible test combinations for a given opcodes. A test
 // combination is a tuple of the form (data_type, opcode, compute_capability).
 auto AllTestCombinationsForOpcodes(absl::Span<const HloOpcode> opcodes) {
@@ -559,16 +563,17 @@ ENTRY triton_computation {
         any_is(PrimitiveType::F8E4M3FN) && any_is(PrimitiveType::F8E5M2);
   }
 
-  // Crashes due to unsupported/unspecified rounding mode.
-  crashes_on_failure |= (data_type_in == PrimitiveType::F64 &&
-                         (data_type_out == PrimitiveType::F8E4M3FN ||
-                          data_type_out == PrimitiveType::F8E5M2));
+  if (cc.IsCuda()) {
+    // Crashes due to unsupported/unspecified rounding mode.
+    crashes_on_failure |= (data_type_in == PrimitiveType::F64 &&
+                          (data_type_out == PrimitiveType::F8E4M3FN ||
+                            data_type_out == PrimitiveType::F8E5M2));
 
-  // Crashes due to unsupported conversion.
-  crashes_on_failure |= (data_type_out == PrimitiveType::F64 &&
-                         (data_type_in == PrimitiveType::F8E4M3FN ||
-                          data_type_in == PrimitiveType::F8E5M2));
-
+    // Crashes due to unsupported conversion.
+    crashes_on_failure |= (data_type_out == PrimitiveType::F64 &&
+                          (data_type_in == PrimitiveType::F8E4M3FN ||
+                            data_type_in == PrimitiveType::F8E5M2));
+  }
   RunSupportTest(
       std::move(ti), /*output_tile_sizes=*/{1, 32}, cc,
       crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);
@@ -609,12 +614,22 @@ ENTRY triton_computation {
                                      data_type, opcode));
 
   ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
-  if (opcode == HloOpcode::kDivide &&
-      (data_type == PrimitiveType::BF16 || data_type == PrimitiveType::F16 ||
-       data_type == PrimitiveType::F8E5M2 ||
-       data_type == PrimitiveType::F8E4M3FN)) {
-    fail_mode = ExpectedFailMode::kCrash;
-  };
+  if (cc.IsCuda()) {
+    if (opcode == HloOpcode::kDivide &&
+        (data_type == PrimitiveType::BF16 || data_type == PrimitiveType::F16 ||
+         data_type == PrimitiveType::F8E5M2 ||
+         data_type == PrimitiveType::F8E4M3FN)) {
+      fail_mode = ExpectedFailMode::kCrash;
+    }
+  } else {
+    if (((opcode == HloOpcode::kMaximum || opcode == HloOpcode::kMinimum) &&
+         (data_type == PrimitiveType::F8E5M2 ||
+          data_type == PrimitiveType::F8E4M3FN || 
+          data_type == PrimitiveType::F8E5M2FNUZ ||
+          data_type == PrimitiveType::F8E4M3FNUZ))) {
+      fail_mode = ExpectedFailMode::kFailOrCrash;
+    }
+  }
 
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc, fail_mode);
 }
@@ -643,11 +658,21 @@ ENTRY triton_computation {
                                      data_type, opcode));
 
   ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
-  if (opcode == HloOpcode::kDivide &&
-      (data_type == PrimitiveType::BF16 || data_type == PrimitiveType::F16 ||
-       data_type == PrimitiveType::F8E5M2 ||
-       data_type == PrimitiveType::F8E4M3FN)) {
-    fail_mode = ExpectedFailMode::kCrash;
+  if (cc.IsCuda()) {
+    if (opcode == HloOpcode::kDivide &&
+        (data_type == PrimitiveType::BF16 || data_type == PrimitiveType::F16 ||
+         data_type == PrimitiveType::F8E5M2 ||
+         data_type == PrimitiveType::F8E4M3FN)) {
+      fail_mode = ExpectedFailMode::kCrash;
+    }
+  } else {
+    if (((opcode == HloOpcode::kMaximum || opcode == HloOpcode::kMinimum) &&
+         (data_type == PrimitiveType::F8E5M2 ||
+          data_type == PrimitiveType::F8E4M3FN ||
+          data_type == PrimitiveType::F8E5M2FNUZ ||
+          data_type == PrimitiveType::F8E4M3FNUZ))) {
+      fail_mode = ExpectedFailMode::kFailOrCrash;
+    }
   }
 
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{}, cc, fail_mode);
@@ -701,7 +726,20 @@ ENTRY triton_computation {
   TF_ASSERT_OK_AND_ASSIGN(
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(hlo_text, data_type, opcode));
-  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc);
+
+  bool skip_failure_branch_to_avoid_crash = false;
+  if (cc.IsRocm()) {
+    skip_failure_branch_to_avoid_crash =
+        (opcode == HloOpcode::kClamp || opcode == HloOpcode::kSelect) &&
+        (data_type == PrimitiveType::F8E5M2 ||
+         data_type == PrimitiveType::F8E4M3FN ||
+         data_type == PrimitiveType::F8E5M2FNUZ ||
+         data_type == PrimitiveType::F8E4M3FNUZ);
+  }
+
+  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc,
+                 skip_failure_branch_to_avoid_crash ? ExpectedFailMode::kFailOrCrash
+                                                    : ExpectedFailMode::kFail);
 }
 
 constexpr std::array kTestedOpsTernaryElementwise = {HloOpcode::kSelect,
@@ -744,7 +782,9 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, data_type, opcode));
   bool crashes_on_failure = data_type == PrimitiveType::F8E4M3FN ||
-                            data_type == PrimitiveType::F8E5M2;
+                            data_type == PrimitiveType::F8E5M2 ||
+                            data_type == PrimitiveType::F8E5M2FNUZ ||
+                            data_type == PrimitiveType::F8E4M3FNUZ;
   RunSupportTest(
       std::move(ti), /*output_tile_sizes=*/{1}, cc,
       crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);
@@ -768,7 +808,7 @@ ENTRY triton_computation {
                           ParseTemplateAndGetInstruction(kHloTestTemplate, F32,
                                                          HloOpcode::kReduce));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{3, 4},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 TEST_P(
@@ -815,7 +855,9 @@ ENTRY triton_computation {
       ParseTemplateAndGetInstruction(kHloTestTemplate, data_type, opcode));
 
   bool crashes_on_failure = data_type == PrimitiveType::F8E4M3FN ||
-                            data_type == PrimitiveType::F8E5M2;
+                            data_type == PrimitiveType::F8E5M2 ||
+                            data_type == PrimitiveType::F8E5M2FNUZ ||
+                            data_type == PrimitiveType::F8E4M3FNUZ;
   RunSupportTest(
       std::move(ti), /*output_tile_sizes=*/{1}, cc,
       crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);
@@ -851,7 +893,7 @@ ENTRY triton_computation {
 }
 
 TEST_F(ReduceTest, ReduceWithNonConstReduceValueIsSupportedWithTriton) {
-  const se::GpuComputeCapability cc = se::CudaComputeCapability::Ampere();
+  const se::GpuComputeCapability cc = DefaultDeviceForTesting();
   const std::string kHloTestTemplate = R"(
 add {
   Arg_0 = $0[] parameter(0)
@@ -931,12 +973,16 @@ ENTRY triton_computation {
 
   // TODO(b/361526623): Reduce the cases where emitter crashes.
   ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
-  if (opcode == HloOpcode::kDivide && (data_type == BF16 || data_type == F16)) {
+  if (opcode == HloOpcode::kDivide && (data_type == BF16 ||
+                                       data_type == F16)) {
     fail_mode = ExpectedFailMode::kCrash;
   }
-  if (data_type == F8E4M3FN || data_type == F8E5M2) {
+  if (data_type == F8E4M3FN || data_type == F8E5M2 ||
+      data_type == PrimitiveType::F8E5M2FNUZ ||
+      data_type == PrimitiveType::F8E4M3FNUZ) {
     fail_mode = ExpectedFailMode::kFailOrCrash;
   }
+
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1}, cc, fail_mode);
 }
 
@@ -1890,6 +1936,14 @@ TEST_P(DotTypesTest, Dot) {
       fail_mode = ExpectedFailMode::kFailOrCrash;
     }
   }
+  if (cc.IsRocm()) {
+    if (absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ, F8E4M3FN}, input_type) ||
+        absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ, F8E4M3FN}, result_type) ||
+        input_type == F64) {
+        // Hits llvm::report_fatal_error during Triton compilation.
+        fail_mode = ExpectedFailMode::kFailOrCrash;
+    }
+  }
 
   std::string hlo_text = R"(
 flhs {
@@ -2038,7 +2092,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 TEST_F(DotTest, NonFusionLhs) {
@@ -2065,7 +2119,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 TEST_F(DotTest, SingleBatchDim) {
@@ -2104,7 +2158,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 16, 32},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 TEST_F(DotTest, MultipleNonContractingDimensions) {
@@ -2142,7 +2196,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 16, 1, 32},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 TEST_F(DotTest, MultipleContractingDimensions) {
@@ -2181,7 +2235,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 TEST_F(DotTest, NonDefaultDimensionOrder_kmkn) {
@@ -2221,7 +2275,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 TEST_F(DotTest, NonDefaultDimensionOrder_mknk) {
@@ -2261,7 +2315,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, F32, HloOpcode::kDot));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32},
-                 se::CudaComputeCapability::Ampere());
+                 DefaultDeviceForTesting());
 }
 
 class DotPrecisionTest
@@ -2323,6 +2377,12 @@ ENTRY triton_computation {
   ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
   if (absl::c_linear_search(std::vector{F8E5M2, F8E4M3FN, S8}, data_type)) {
     fail_mode = ExpectedFailMode::kFailOrCrash;
+  }
+  if (cc.IsRocm()) {
+    if (absl::c_linear_search(std::vector{F8E4M3FNUZ, F8E5M2FNUZ, F8E4M3FN,
+                                          S8, S16, S32, S64}, data_type)) {
+      fail_mode = ExpectedFailMode::kFailOrCrash;
+    }
   }
   TF_ASSERT_OK_AND_ASSIGN(
       TestedInstruction ti,
@@ -2415,6 +2475,15 @@ ENTRY triton_computation {
   if (absl::c_linear_search(std::vector{F8E5M2, F8E4M3FN, F8E4M3, S8},
                             data_type)) {
     fail_mode = ExpectedFailMode::kFailOrCrash;
+  }
+  if (cc.IsRocm()) {
+    if (absl::c_linear_search(std::vector{F8E4M3FN, F8E5M2FNUZ, F8E4M3FNUZ, F64},
+                                data_type) ||
+        (absl::c_linear_search(std::vector{S64, S32, S16, BF16, F16, F32},
+                                data_type)  &&
+         algorithm == xla::PrecisionConfig::ALG_DOT_F64_F64_F64)) {
+      fail_mode = ExpectedFailMode::kFailOrCrash;
+    }
   }
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{16, 32}, cc, fail_mode);
 }
@@ -2583,7 +2652,7 @@ ENTRY triton_computation {
   TF_ASSERT_OK_AND_ASSIGN(
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(hlo_text, F32, HloOpcode::kFusion));
-  se::GpuComputeCapability cc = se::CudaComputeCapability::Ampere();
+  se::GpuComputeCapability cc = DefaultDeviceForTesting();
   ASSERT_FALSE(IsTritonSupportedInstruction(ti.Instruction(), cc));
   RunSupportTest(std::move(ti), /*output_tile_sizes=*/{64, 32}, cc);
 }

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -337,6 +337,10 @@ using BitcastOrReshapeTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(BitcastOrReshapeTest, IsTritonSupportedBitcastOrReshape) {
   auto [data_type, opcode, cc] = GetParam();
+  if (cc.IsCuda() && ((data_type == F8E5M2FNUZ) ||
+                      (data_type == F8E4M3FNUZ))) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[1,16,4] parameter(0)
@@ -350,6 +354,11 @@ ENTRY triton_computation {
 
 TEST_P(BitcastOrReshapeTest, IsTritonSupported0DBitcastOrReshape) {
   auto [data_type, opcode, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[1,1,1] parameter(0)
@@ -423,6 +432,11 @@ using UnaryElementwiseTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(UnaryElementwiseTest, IsTritonSupportedUnaryElementwise) {
   auto [data_type, opcode, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kDefaultHloTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[33,68] parameter(0)
@@ -525,6 +539,13 @@ class ConvertTest
 TEST_P(ConvertTest, Convert) {
   auto [data_type_in, data_type_out, cc] = GetParam();
 
+  if(cc.IsCuda() &&
+     (absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+      data_type_in) ||
+      absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+      data_type_out))) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string hlo_text = absl::Substitute(
       R"(
 ENTRY triton_computation {
@@ -592,6 +613,11 @@ using BinaryElementwiseTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(BinaryElementwiseTest, IsTritonSupportedBinaryElementwise) {
   auto [data_type, opcode, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[11,63] parameter(0)
@@ -636,6 +662,11 @@ ENTRY triton_computation {
 
 TEST_P(BinaryElementwiseTest, IsTritonSupportedBinaryElementwise0D) {
   auto [data_type, opcode, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[] parameter(0)
@@ -710,6 +741,11 @@ using TernaryElementwiseTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(TernaryElementwiseTest, IsTritonSupportedTernaryElementwise) {
   auto [data_type, opcode, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+                           data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $2[13,63] parameter(0)
@@ -1007,6 +1043,11 @@ using TransposeTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(TransposeTest, LoadTranspose3D) {
   auto [data_type, opcode, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[125,127,37] parameter(0)
@@ -1034,6 +1075,11 @@ using SliceTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(SliceTest, ContinuousSlice) {
   auto [data_type, opcode, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = (R"(
 ENTRY triton_computation {
   p = $0[128,32] parameter(0)
@@ -1483,6 +1529,11 @@ using BroadcastTest = TritonSupportTestWithTypeAndDeviceParam;
 
 TEST_P(BroadcastTest, Broadcast) {
   auto [data_type, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   input = $0[35,131] parameter(0)
@@ -1506,6 +1557,11 @@ using ParameterTest = TritonSupportTestWithTypeAndDeviceParam;
 
 TEST_P(ParameterTest, Parameter) {
   auto [data_type, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   std::string hlo_test_template =
       R"(
 ENTRY triton_computation {
@@ -1539,6 +1595,11 @@ TEST_P(ConstantTest, ConstantEffectiveScalar) {
   // The IsTritonSupportedReduction effectively tests the scalar constant
   // support.
   auto [data_type, cc] = GetParam();
+  if(cc.IsCuda() &&
+     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+     data_type)) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   const std::string kHloTestTemplate = absl::Substitute(R"(
 ENTRY triton_computation {
   ROOT const = $$0[1,1] constant({{$0}})
@@ -1928,6 +1989,13 @@ TEST_P(DotTypesTest, Dot) {
   // Testing B[] = dot(A[], A[]).
   auto [result_type, input_type, cc] = GetParam();
 
+  if(cc.IsCuda() &&
+     (absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+      result_type) ||
+      absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+      input_type))) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
   ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
   if (input_type == F8E4M3FN || result_type == F8E4M3FN) {
     if (auto* cuda_cc = cc.cuda_compute_capability();
@@ -2719,6 +2787,14 @@ ENTRY triton_computation {
 
 TEST_P(BitcastConvertTest, BitcastConvertDisguisedAsBitcast) {
   auto [data_type_in, data_type_out, cc] = GetParam();
+
+  if(cc.IsCuda() &&
+     (absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+      data_type_in) ||
+      absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
+      data_type_out))) {
+    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
+  }
 
   if (primitive_util::IsComplexType(data_type_in) !=
       primitive_util::IsComplexType(data_type_out)) {

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -337,10 +337,6 @@ using BitcastOrReshapeTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(BitcastOrReshapeTest, IsTritonSupportedBitcastOrReshape) {
   auto [data_type, opcode, cc] = GetParam();
-  if (cc.IsCuda() && ((data_type == F8E5M2FNUZ) ||
-                      (data_type == F8E4M3FNUZ))) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[1,16,4] parameter(0)
@@ -354,11 +350,6 @@ ENTRY triton_computation {
 
 TEST_P(BitcastOrReshapeTest, IsTritonSupported0DBitcastOrReshape) {
   auto [data_type, opcode, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[1,1,1] parameter(0)
@@ -432,11 +423,6 @@ using UnaryElementwiseTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(UnaryElementwiseTest, IsTritonSupportedUnaryElementwise) {
   auto [data_type, opcode, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kDefaultHloTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[33,68] parameter(0)
@@ -538,14 +524,6 @@ class ConvertTest
 
 TEST_P(ConvertTest, Convert) {
   auto [data_type_in, data_type_out, cc] = GetParam();
-
-  if(cc.IsCuda() &&
-     (absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-      data_type_in) ||
-      absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-      data_type_out))) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string hlo_text = absl::Substitute(
       R"(
 ENTRY triton_computation {
@@ -613,11 +591,6 @@ using BinaryElementwiseTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(BinaryElementwiseTest, IsTritonSupportedBinaryElementwise) {
   auto [data_type, opcode, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[11,63] parameter(0)
@@ -662,11 +635,6 @@ ENTRY triton_computation {
 
 TEST_P(BinaryElementwiseTest, IsTritonSupportedBinaryElementwise0D) {
   auto [data_type, opcode, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[] parameter(0)
@@ -741,11 +709,6 @@ using TernaryElementwiseTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(TernaryElementwiseTest, IsTritonSupportedTernaryElementwise) {
   auto [data_type, opcode, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-                           data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $2[13,63] parameter(0)
@@ -1049,11 +1012,6 @@ using TransposeTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(TransposeTest, LoadTranspose3D) {
   auto [data_type, opcode, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   parameter_0 = $0[125,127,37] parameter(0)
@@ -1081,11 +1039,6 @@ using SliceTest = TritonSupportTestWithTypeAndOpcodeAndDeviceParam;
 
 TEST_P(SliceTest, ContinuousSlice) {
   auto [data_type, opcode, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = (R"(
 ENTRY triton_computation {
   p = $0[128,32] parameter(0)
@@ -1535,11 +1488,6 @@ using BroadcastTest = TritonSupportTestWithTypeAndDeviceParam;
 
 TEST_P(BroadcastTest, Broadcast) {
   auto [data_type, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = R"(
 ENTRY triton_computation {
   input = $0[35,131] parameter(0)
@@ -1563,11 +1511,6 @@ using ParameterTest = TritonSupportTestWithTypeAndDeviceParam;
 
 TEST_P(ParameterTest, Parameter) {
   auto [data_type, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   std::string hlo_test_template =
       R"(
 ENTRY triton_computation {
@@ -1601,11 +1544,6 @@ TEST_P(ConstantTest, ConstantEffectiveScalar) {
   // The IsTritonSupportedReduction effectively tests the scalar constant
   // support.
   auto [data_type, cc] = GetParam();
-  if(cc.IsCuda() &&
-     absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-     data_type)) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   const std::string kHloTestTemplate = absl::Substitute(R"(
 ENTRY triton_computation {
   ROOT const = $$0[1,1] constant({{$0}})
@@ -1995,13 +1933,6 @@ TEST_P(DotTypesTest, Dot) {
   // Testing B[] = dot(A[], A[]).
   auto [result_type, input_type, cc] = GetParam();
 
-  if(cc.IsCuda() &&
-     (absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-      result_type) ||
-      absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-      input_type))) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
   ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
   if (input_type == F8E4M3FN || result_type == F8E4M3FN) {
     if (auto* cuda_cc = cc.cuda_compute_capability();
@@ -2793,14 +2724,6 @@ ENTRY triton_computation {
 
 TEST_P(BitcastConvertTest, BitcastConvertDisguisedAsBitcast) {
   auto [data_type_in, data_type_out, cc] = GetParam();
-
-  if(cc.IsCuda() &&
-     (absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-      data_type_in) ||
-      absl::c_linear_search(std::vector{F8E5M2FNUZ, F8E4M3FNUZ},
-      data_type_out))) {
-    GTEST_SKIP() << "F8E4M3FNUZ and F8E5M2FNUZ not supported on Cuda";
-  }
 
   if (primitive_util::IsComplexType(data_type_in) !=
       primitive_util::IsComplexType(data_type_out)) {

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -818,9 +818,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, data_type, opcode));
   bool crashes_on_failure = data_type == PrimitiveType::F8E4M3FN ||
-                            data_type == PrimitiveType::F8E5M2 ||
-                            data_type == PrimitiveType::F8E5M2FNUZ ||
-                            data_type == PrimitiveType::F8E4M3FNUZ;
+                            data_type == PrimitiveType::F8E5M2;
   RunSupportTest(
       std::move(ti), /*output_tile_sizes=*/{1}, cc,
       crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);
@@ -891,9 +889,7 @@ ENTRY triton_computation {
       ParseTemplateAndGetInstruction(kHloTestTemplate, data_type, opcode));
 
   bool crashes_on_failure = data_type == PrimitiveType::F8E4M3FN ||
-                            data_type == PrimitiveType::F8E5M2 ||
-                            data_type == PrimitiveType::F8E5M2FNUZ ||
-                            data_type == PrimitiveType::F8E4M3FNUZ;
+                            data_type == PrimitiveType::F8E5M2;
   RunSupportTest(
       std::move(ti), /*output_tile_sizes=*/{1}, cc,
       crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -587,18 +587,7 @@ ENTRY triton_computation {
                                          : kHloTestTemplate,
                                      data_type, opcode));
 
-  ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
-  if (cc.IsRocm()) {
-    if (((opcode == HloOpcode::kMaximum || opcode == HloOpcode::kMinimum) &&
-         (data_type == PrimitiveType::F8E5M2 ||
-          data_type == PrimitiveType::F8E4M3FN || 
-          data_type == PrimitiveType::F8E5M2FNUZ ||
-          data_type == PrimitiveType::F8E4M3FNUZ))) {
-      fail_mode = ExpectedFailMode::kCrash;
-    }
-  }
-
-  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc, fail_mode);
+  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc);
 }
 
 TEST_P(BinaryElementwiseTest, IsTritonSupportedBinaryElementwise0D) {
@@ -624,18 +613,7 @@ ENTRY triton_computation {
                                          : kHloTestTemplate,
                                      data_type, opcode));
 
-  ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
-  if (cc.IsRocm()) {
-    if (((opcode == HloOpcode::kMaximum || opcode == HloOpcode::kMinimum) &&
-         (data_type == PrimitiveType::F8E5M2 ||
-          data_type == PrimitiveType::F8E4M3FN ||
-          data_type == PrimitiveType::F8E5M2FNUZ ||
-          data_type == PrimitiveType::F8E4M3FNUZ))) {
-      fail_mode = ExpectedFailMode::kCrash;
-    }
-  }
-
-  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{}, cc, fail_mode);
+  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{}, cc);
 }
 
 constexpr std::array kTestedOpsBinaryElementwise = {
@@ -687,19 +665,7 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(hlo_text, data_type, opcode));
 
-  bool skip_failure_branch_to_avoid_crash = false;
-  if (cc.IsRocm()) {
-    skip_failure_branch_to_avoid_crash =
-        (opcode == HloOpcode::kClamp || opcode == HloOpcode::kSelect) &&
-        (data_type == PrimitiveType::F8E5M2 ||
-         data_type == PrimitiveType::F8E4M3FN ||
-         data_type == PrimitiveType::F8E5M2FNUZ ||
-         data_type == PrimitiveType::F8E4M3FNUZ);
-  }
-
-  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc,
-                 skip_failure_branch_to_avoid_crash ? ExpectedFailMode::kCrash
-                                                    : ExpectedFailMode::kFail);
+  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1, 32}, cc);
 }
 
 constexpr std::array kTestedOpsTernaryElementwise = {HloOpcode::kSelect,
@@ -741,17 +707,9 @@ ENTRY triton_computation {
   TF_ASSERT_OK_AND_ASSIGN(
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, data_type, opcode));
-  bool crashes_on_failure = false;
-  if (cc.IsRocm()) {
-    crashes_on_failure |= (data_type == PrimitiveType::F8E4M3FN ||
-                            data_type == PrimitiveType::F8E5M2);
-    crashes_on_failure |= (data_type == PrimitiveType::F8E5M2FNUZ ||
-                           data_type == PrimitiveType::F8E4M3FNUZ);
-  }
 
   RunSupportTest(
-      std::move(ti), /*output_tile_sizes=*/{1}, cc,
-      crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);
+      std::move(ti), /*output_tile_sizes=*/{1}, cc);
 }
 
 TEST_F(ReduceTest, IsTritonSupportedReductionWithMultidimensionalTile) {
@@ -818,17 +776,8 @@ ENTRY triton_computation {
       TestedInstruction ti,
       ParseTemplateAndGetInstruction(kHloTestTemplate, data_type, opcode));
 
-  bool crashes_on_failure = false;
-  if (cc.IsRocm()) {
-    crashes_on_failure |= (data_type == PrimitiveType::F8E4M3FN ||
-                            data_type == PrimitiveType::F8E5M2);
-    crashes_on_failure |= (data_type == PrimitiveType::F8E5M2FNUZ ||
-                           data_type == PrimitiveType::F8E4M3FNUZ);
-  }
-
   RunSupportTest(
-      std::move(ti), /*output_tile_sizes=*/{1}, cc,
-      crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);
+      std::move(ti), /*output_tile_sizes=*/{1}, cc);
 }
 
 TEST_P(ReduceTest,
@@ -939,16 +888,7 @@ ENTRY triton_computation {
                           ParseTemplateAndGetInstruction(
                               kHloTestTemplate, data_type, HloOpcode::kReduce));
 
-  // TODO(b/361526623): Reduce the cases where emitter crashes.
-  ExpectedFailMode fail_mode = ExpectedFailMode::kFail;
-  if (cc.IsRocm()) {
-    if (data_type == F8E4M3FN || data_type == F8E5M2 ||
-        data_type == PrimitiveType::F8E5M2FNUZ ||
-        data_type == PrimitiveType::F8E4M3FNUZ) {
-      fail_mode = ExpectedFailMode::kCrash;
-    }
-  }
-  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1}, cc, fail_mode);
+  RunSupportTest(std::move(ti), /*output_tile_sizes=*/{1}, cc);
 }
 
 std::vector<HloOpcode> ExcludeOps(absl::Span<const HloOpcode> all_ops,

--- a/xla/backends/gpu/codegen/triton/support_test.cc
+++ b/xla/backends/gpu/codegen/triton/support_test.cc
@@ -819,6 +819,11 @@ ENTRY triton_computation {
       ParseTemplateAndGetInstruction(kHloTestTemplate, data_type, opcode));
   bool crashes_on_failure = data_type == PrimitiveType::F8E4M3FN ||
                             data_type == PrimitiveType::F8E5M2;
+  if (cc.IsRocm()) {
+    crashes_on_failure |= (data_type == PrimitiveType::F8E5M2FNUZ ||
+                           data_type == PrimitiveType::F8E4M3FNUZ);
+  }
+
   RunSupportTest(
       std::move(ti), /*output_tile_sizes=*/{1}, cc,
       crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);
@@ -890,6 +895,11 @@ ENTRY triton_computation {
 
   bool crashes_on_failure = data_type == PrimitiveType::F8E4M3FN ||
                             data_type == PrimitiveType::F8E5M2;
+  if (cc.IsRocm()) {
+    crashes_on_failure |= (data_type == PrimitiveType::F8E5M2FNUZ ||
+                           data_type == PrimitiveType::F8E4M3FNUZ);
+  }
+
   RunSupportTest(
       std::move(ti), /*output_tile_sizes=*/{1}, cc,
       crashes_on_failure ? ExpectedFailMode::kCrash : ExpectedFailMode::kFail);

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -235,18 +235,9 @@ absl::Status ValidateUsedTypes(
   std::vector<PrimitiveType> fusion_data_types;
   const HloComputation* computation = fusion->fused_instructions_computation();
   for (const HloInstruction* instr : computation->instructions()) {
-    std::optional<PrimitiveType> type =
-        instr->shape().IsTuple() ?
-          std::nullopt :
-          std::make_optional(instr->shape().element_type());
-    if (type.has_value()) {
-      if (!IsTritonSupportedDataType(type.value(),
-          device_info.gpu_compute_capability())) {
-          primitive_util::LowercasePrimitiveTypeName(type.value());
-        return absl::UnimplementedError(
-          absl::StrCat("Type is not supported: ",
-            primitive_util::LowercasePrimitiveTypeName(type.value())));
-      }
+    if(!IsTritonSupportedInstruction(
+          *instr, device_info.gpu_compute_capability())) {
+        return absl::UnimplementedError("Not supported instruction");
     }
   }
 }

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -229,12 +229,35 @@ absl::Status IsTritonSupportedFusion(const HloFusionInstruction& fusion,
   return absl::OkStatus();
 }
 
+absl::Status ValidateUsedTypes(
+    const HloFusionInstruction* fusion,
+    const se::DeviceDescription& device_info) {
+  std::vector<PrimitiveType> fusion_data_types;
+  const HloComputation* computation = fusion->fused_instructions_computation();
+  for (const HloInstruction* instr : computation->instructions()) {
+    std::optional<PrimitiveType> type =
+        instr->shape().IsTuple() ?
+          std::nullopt :
+          std::make_optional(instr->shape().element_type());
+    if (type.has_value()) {
+      if (!IsTritonSupportedDataType(type.value(),
+          device_info.gpu_compute_capability())) {
+          primitive_util::LowercasePrimitiveTypeName(type.value());
+        return absl::UnimplementedError(
+          absl::StrCat("Type is not supported: ",
+            primitive_util::LowercasePrimitiveTypeName(type.value())));
+      }
+    }
+  }
+}
+
 absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> CreateTritonModule(
     absl::string_view fn_name, const HloFusionInstruction* fusion,
     const se::DeviceDescription& device_info,
     const BlockLevelParameters& block_level_parameters,
     MLIRContext& mlir_context) {
   TF_RETURN_IF_ERROR(IsTritonSupportedFusion(*fusion, device_info));
+  TF_RETURN_IF_ERROR(ValidateUsedTypes(fusion, device_info));
 
   LoadMlirDialectsForTriton(mlir_context);
 

--- a/xla/service/gpu/gpu_device_info_for_tests.cc
+++ b/xla/service/gpu/gpu_device_info_for_tests.cc
@@ -107,7 +107,7 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI210DeviceInfo() {
   b.set_threads_per_block_limit(1024);
   b.set_threads_per_warp(64);
   b.set_shared_memory_per_block(64 * 1024);
-  b.set_shared_memory_per_block_optin(0);
+  b.set_shared_memory_per_block_optin(64 * 1024);
   b.set_shared_memory_per_core(64 * 1024);
   b.set_threads_per_core_limit(2048);
   b.set_core_count(104);


### PR DESCRIPTION
📝 Summary of Changes
Updated functions from triton/support.c and triton/support_test to execute
correctly on ROCm.

🎯 Justification
support_test was failing on ROCm.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
Used existing triton/support_test 

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
