### PR TITLE
Manage events for intra-process data transfers after enqueue of dependencies instead of completion

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1167,6 +1167,63 @@ TEST(StreamExecutorGpuClientTest, AsyncCopyToDevice) {
             literal->Relayout(src_literal.shape().layout()).data<float>());
 }
 
+TEST(StreamExecutorGpuClientTest, CopyErrorBufferToDevice) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+
+  auto* src_device = client->addressable_devices()[0];
+  auto* dst_device = client->addressable_devices()[1];
+
+  TF_ASSERT_OK_AND_ASSIGN(auto* src_memory_space,
+                          src_device->default_memory_space());
+  TF_ASSERT_OK_AND_ASSIGN(auto* dst_memory_space,
+                          dst_device->default_memory_space());
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto send_buffer,
+      client->CreateErrorBuffer(Internal("some error"),
+                                ShapeUtil::MakeShape(U32, {3, 2}),
+                                src_memory_space));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto recv_buffer,
+                          send_buffer->CopyToMemorySpace(dst_memory_space));
+
+  EXPECT_THAT(
+      recv_buffer->ToLiteral().Await(),
+      absl_testing::StatusIs(tsl::error::INTERNAL, HasSubstr("some error")));
+}
+
+TEST(StreamExecutorGpuClientTest, CopyDelayedErrorBufferToDevice) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(DefaultOptions()));
+
+  auto* src_device = client->addressable_devices()[0];
+  auto* dst_device = client->addressable_devices()[1];
+
+  TF_ASSERT_OK_AND_ASSIGN(auto* src_memory_space,
+                          src_device->default_memory_space());
+  TF_ASSERT_OK_AND_ASSIGN(auto* dst_memory_space,
+                          dst_device->default_memory_space());
+
+  xla::Shape shape = ShapeUtil::MakeShape(U32, {3, 2});
+
+  TF_ASSERT_OK_AND_ASSIGN(auto alias_pair,
+                          client->CreateAliasBuffer(shape, src_memory_space));
+  auto& send_buffer = alias_pair.first;
+  auto& fulfill_cb = alias_pair.second;
+
+  TF_ASSERT_OK_AND_ASSIGN(auto recv_buffer,
+                          send_buffer->CopyToMemorySpace(dst_memory_space));
+
+  absl::SleepFor(absl::Seconds(3));
+
+  fulfill_cb(absl::InternalError("delayed error"));
+
+  EXPECT_THAT(
+      recv_buffer->ToLiteral().Await(),
+      absl_testing::StatusIs(tsl::error::INTERNAL, HasSubstr("delayed error")));
+}
+
 TEST(StreamExecutorGpuClientTest, CreateMixOfErrorBuffers) {
   TF_ASSERT_OK_AND_ASSIGN(auto client,
                           GetStreamExecutorGpuClient(DefaultOptions()));

--- a/xla/pjrt/se_raw_buffer.cc
+++ b/xla/pjrt/se_raw_buffer.cc
@@ -415,46 +415,10 @@ void PjRtStreamExecutorRawBuffer::CopyTo(
     allocation_event.SetStateConcrete();
   }
   if (dst_raw_buffer->memory_space()->client() == memory_space()->client()) {
-    auto usage_event =
-        BufferSequencingEvent::Create(client_->async_work_runner());
-    client_->async_work_runner()->Schedule(
-        [client = client_, local_device = local_device_,
-         src_buffer = device_buffer_,
-         dst_raw_buffer = std::move(dst_raw_buffer),
-         src_raw_buffer = tsl::FormRef(this), usage_event]() {
-          se::Stream* stream = local_device->GetDeviceToDeviceStream();
-
-          absl::StatusOr<EventPool::Handle> event_or =
-              local_device->event_pool().AllocateEvent(
-                  client->async_work_runner(), stream->parent());
-          if (!event_or.ok()) {
-            client->SetEventAsError(usage_event, event_or.status());
-            return;
-          }
-
-          auto dst_buffer =
-              tensorflow::down_cast<const PjRtStreamExecutorRawBuffer*>(
-                  dst_raw_buffer.get())
-                  ->device_buffer();
-          auto dst_buffer_mem = dst_buffer->mem();
-          client->WaitForAllocation(stream, *src_raw_buffer);
-          client->WaitForAllocation(stream, *dst_raw_buffer);
-          auto status = stream->MemcpyD2D(&dst_buffer_mem, src_buffer->mem(),
-                                          dst_buffer_mem.size());
-          if (!status.ok()) {
-            client->SetEventAsError(usage_event, status);
-            return;
-          }
-
-          client->ThenRecordEvent(usage_event, local_device,
-                                  std::move(event_or).value(), stream);
-          usage_event.AndThen([src_buffer, dst_buffer]() {});
-        });
-
-    definition_event_promise->Set(
-        tsl::MakeRef<PjRtStreamExecutorDeviceEvent>(usage_event));
-    src_usage_event_promise->Set(
-        tsl::MakeRef<PjRtStreamExecutorDeviceEvent>(std::move(usage_event)));
+    IntraClientCopyToWithDependencies(
+        /*dependencies=*/{}, std::move(dst_raw_buffer),
+        std::move(definition_event_promise),
+        std::move(src_usage_event_promise));
   } else if (auto* src_ptr = GetHostPointer()) {
     auto h2d_event = dst_raw_buffer->CopyRawHostToDeviceAndReturnEvent(
         src_ptr, 0, GetOnDeviceSizeInBytes());
@@ -523,6 +487,109 @@ void PjRtStreamExecutorRawBuffer::CopyTo(
         });
     src_usage_event_promise->Set(*std::move(d2h_event));
   }
+}
+
+// We override ScheduleCopyTo so that for intra-client D2D copies, we can issue
+// the transfer after the definition events are enqueued (instead of until after
+// they are complete).
+void PjRtStreamExecutorRawBuffer::ScheduleCopyTo(
+    AsyncWorkRunner* async_work_runner,
+    std::vector<tsl::RCReference<tsl::AsyncValue>> transfer_dependency_avs,
+    tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
+    tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
+    tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise,
+    ::tsl::AsyncValueRef<bool> allocation_event) {
+  if (dst_raw_buffer->memory_space()->client() == memory_space()->client()) {
+    async_work_runner->Schedule(
+        [this_ref = tsl::FormRef(this),
+         transfer_dependency_avs = std::move(transfer_dependency_avs),
+         dst_raw_buffer = std::move(dst_raw_buffer),
+         definition_event_promise = std::move(definition_event_promise),
+         src_usage_event_promise = std::move(src_usage_event_promise),
+         allocation_event = std::move(allocation_event)]() mutable {
+          for (const auto& av : transfer_dependency_avs) {
+            if (auto* error = av->GetErrorIfPresent()) {
+              auto status = *error;
+              if (allocation_event) {
+                allocation_event.SetError(status);
+              }
+              definition_event_promise->SetError(status);
+              src_usage_event_promise->SetError(status);
+              return;
+            }
+          }
+          if (allocation_event) {
+            allocation_event.SetStateConcrete();
+          }
+          this_ref->IntraClientCopyToWithDependencies(
+              std::move(transfer_dependency_avs), std::move(dst_raw_buffer),
+              std::move(definition_event_promise),
+              std::move(src_usage_event_promise));
+        });
+    return;
+  }
+  CommonPjRtRawBuffer::ScheduleCopyTo(
+      async_work_runner, std::move(transfer_dependency_avs),
+      std::move(dst_raw_buffer), std::move(definition_event_promise),
+      std::move(src_usage_event_promise), std::move(allocation_event));
+}
+
+void PjRtStreamExecutorRawBuffer::IntraClientCopyToWithDependencies(
+    std::vector<tsl::RCReference<tsl::AsyncValue>> dependencies,
+    tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
+    tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
+    tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise) {
+  auto usage_event =
+      BufferSequencingEvent::Create(client_->async_work_runner());
+
+  client_->async_work_runner()->Schedule(
+      [client = client_, local_device = local_device_,
+       src_buffer = device_buffer_, dst_raw_buffer = std::move(dst_raw_buffer),
+       src_raw_buffer = tsl::FormRef(this), usage_event,
+       dependencies = std::move(dependencies)]() {
+        se::Stream* stream = local_device->GetDeviceToDeviceStream();
+
+        // Wait for dependencies.
+        for (const auto& dep : dependencies) {
+          if (dep.get()->IsType<BufferSequencingEvent>()) {
+            tsl::AsyncValueRef<BufferSequencingEvent> event_ref(dep);
+            event_ref->WaitForEventOnStream(stream);
+          } else {
+            tsl::BlockUntilReady(dep.get());
+          }
+        }
+
+        absl::StatusOr<EventPool::Handle> event_or =
+            local_device->event_pool().AllocateEvent(
+                client->async_work_runner(), stream->parent());
+        if (!event_or.ok()) {
+          client->SetEventAsError(usage_event, event_or.status());
+          return;
+        }
+
+        auto dst_buffer =
+            tensorflow::down_cast<const PjRtStreamExecutorRawBuffer*>(
+                dst_raw_buffer.get())
+                ->device_buffer();
+        auto dst_buffer_mem = dst_buffer->mem();
+        client->WaitForAllocation(stream, *src_raw_buffer);
+        client->WaitForAllocation(stream, *dst_raw_buffer);
+        auto status = stream->MemcpyD2D(&dst_buffer_mem, src_buffer->mem(),
+                                        dst_buffer_mem.size());
+        if (!status.ok()) {
+          client->SetEventAsError(usage_event, status);
+          return;
+        }
+
+        client->ThenRecordEvent(usage_event, local_device,
+                                std::move(event_or).value(), stream);
+        usage_event.AndThen([src_buffer, dst_buffer]() {});
+      });
+
+  definition_event_promise->Set(
+      tsl::MakeRef<PjRtStreamExecutorDeviceEvent>(usage_event));
+  src_usage_event_promise->Set(
+      tsl::MakeRef<PjRtStreamExecutorDeviceEvent>(std::move(usage_event)));
 }
 
 }  // namespace xla

--- a/xla/pjrt/se_raw_buffer.h
+++ b/xla/pjrt/se_raw_buffer.h
@@ -143,16 +143,31 @@ class PjRtStreamExecutorRawBuffer : public CommonPjRtRawBuffer {
       Promise<> promise,
       tsl::RCReference<PjRtDeviceEventPromise> device_promise,
       MutableLiteralBase* literal, xla::Shape shape) override;
+
   void CopyTo(tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
               tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
               tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise,
               ::tsl::AsyncValueRef<bool> allocation_event) override;
+
+  void ScheduleCopyTo(
+      AsyncWorkRunner* async_work_runner,
+      std::vector<tsl::RCReference<tsl::AsyncValue>> transfer_dependency_avs,
+      tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
+      tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
+      tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise,
+      ::tsl::AsyncValueRef<bool> allocation_event) override;
 
  private:
   PjRtStreamExecutorClient* client_;
   PjRtMemorySpace* memory_space_;
   LocalDeviceState* local_device_;
   tsl::AsyncValueRef<RawSEDeviceMemory> device_buffer_;
+
+  void IntraClientCopyToWithDependencies(
+      std::vector<tsl::RCReference<tsl::AsyncValue>> dependencies,
+      tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
+      tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
+      tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise);
 };
 
 }  // namespace xla

--- a/xla/pjrt/se_raw_buffer.h
+++ b/xla/pjrt/se_raw_buffer.h
@@ -167,7 +167,8 @@ class PjRtStreamExecutorRawBuffer : public CommonPjRtRawBuffer {
       std::vector<tsl::RCReference<tsl::AsyncValue>> dependencies,
       tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
       tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
-      tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise);
+      tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise,
+      ::tsl::AsyncValueRef<bool> allocation_event);
 };
 
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
This PR modifies `PjRtStreamExecutorRawBuffer` to allocate and record the definition event of the receive buffer / the usage event of the send buffer after the definition event of the send buffer has been recorded instead of waiting for it to complete. This is a fix similar to #35113 but for the single-process case.

🎯 Justification
Intra-process data transfers currently allocate and record events only after the buffers they need to transfer have been materialized, instead of just after their definition events have been recorded. This means that if the host tries to launch an executable that depends on the result of the transfer, the host thread will block until the buffer being sent by the transfer has been fully materialized.

[Here](https://gist.github.com/rao-ashish/855d4536af5c96413a1826955728237a) is a toy program illustrating the issue, which transfers an array from one set of devices to another, does a matmul, transfers the result back to the first set of devices, and does another matmul. A profile shows that the host blocks while enqueuing the second matmul until the first matmul is complete:

<img width="1723" height="162" alt="image" src="https://github.com/user-attachments/assets/7a0a9044-4201-4c3d-84c5-8a7b803a8a0e" />

After this fix, we see that the host can enqueue the computation without blocking:

<img width="1033" height="162" alt="image" src="https://github.com/user-attachments/assets/79660959-0365-40ef-bf75-7ee9c957cf56" />


🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
The previously added unit tests inside `se_gpu_pjrt_client_test.cc` continue to pass (the existing `AsyncCopyToDevice` test in particular already tests the relevant functionality).

🧪 Execution Tests: Verified that the implementation still works on these [four end-to-end tests](https://gist.github.com/rao-ashish/aeaf2a1166bcce60e54186a004acf0d2).