### PR TITLE
Correctly generate compile_commands.json

### DIFF
--- a/build_tools/lint/generate_compile_commands.py
+++ b/build_tools/lint/generate_compile_commands.py
@@ -67,7 +67,11 @@ class CompileCommand:
       if arg.endswith(".cc"):
         cc_file = arg
 
-      filtered_args.append(arg)
+      # Split generated commands, because otherwise they get wrapped
+      # into "command with spaces" when passed to clangd, and clangd
+      # can't parse them correctly.
+      for s in arg.split(" "):
+        filtered_args.append(s)
 
     return cls(cc_file, filtered_args)
 


### PR DESCRIPTION
Sometime json incorrectly parse compile commands from blaze, and we end up passing them as

```
"-isystem path/to/includes"
```

to `clangd`, and these flags parsed incorrectly