### PR TITLE
[xla:gpu] Delete unused GpuCollectives::Allocate API

### DIFF
--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -139,11 +139,6 @@ class GpuCollectives : public Collectives {
       stream_executor::DeviceAddressBase buff, PrimitiveType dtype,
       size_t offset, size_t count);
 
-  // TODO(b/410686553): Use smart wrapper instead of void*.
-  virtual absl::StatusOr<void*> Allocate(uint64_t bytes) = 0;
-
-  virtual absl::Status Deallocate(void* buffer) = 0;
-
   struct Topology {
     int32_t node_id;
     int32_t num_nodes;

--- a/xla/backends/gpu/collectives/gpu_collectives_stub.h
+++ b/xla/backends/gpu/collectives/gpu_collectives_stub.h
@@ -62,12 +62,6 @@ class GpuCollectivesStub : public GpuCollectives {
     return UnimplementedError();
   }
 
-  absl::StatusOr<void*> Allocate(uint64_t bytes) final {
-    return UnimplementedError();
-  }
-
-  absl::Status Deallocate(void* buffer) final { return UnimplementedError(); }
-
   absl::Status InitializeTopology(Topology topology) final {
     return UnimplementedError();
   }

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -280,44 +280,6 @@ static absl::StatusOr<xla::gpu::GpuCollectives*> GetNvshmemCollectives() {
   return nvshmem_collectives;
 }
 
-absl::StatusOr<void*> NcclCollectives::Allocate(uint64_t bytes) {
-  if (xla::GetDebugOptionsFromFlags().xla_gpu_experimental_enable_nvshmem()) {
-    TF_ASSIGN_OR_RETURN(auto* nvshmem_collectives, GetNvshmemCollectives());
-    return nvshmem_collectives->Allocate(bytes);
-  }
-
-  void* ptr = nullptr;
-  ncclResult_t res = ncclMemAlloc(&ptr, bytes);
-  if (res != ncclSuccess) {
-    return absl::InternalError(absl::StrFormat(
-        "failed to allocate %s (%llu bytes) from device collective memory: %s, "
-        "Last NCCL warning(error) log entry (may be unrelated): %s",
-        tsl::strings::HumanReadableNumBytes(bytes), bytes,
-        ncclGetErrorString(res), ncclGetLastError(nullptr)));
-  }
-  VLOG(2) << "Allocated collective memory " << ptr << " of " << bytes
-          << " bytes";
-  return ptr;
-}
-
-absl::Status NcclCollectives::Deallocate(void* location) {
-  if (xla::GetDebugOptionsFromFlags().xla_gpu_experimental_enable_nvshmem()) {
-    TF_ASSIGN_OR_RETURN(auto* nvshmem_collectives, GetNvshmemCollectives());
-    return nvshmem_collectives->Deallocate(location);
-  }
-
-  ncclResult_t res = ncclMemFree(location);
-  if (res != ncclSuccess) {
-    return absl::InternalError(absl::StrFormat(
-        "failed to free device collective memory at %p; result: %s, Last NCCL "
-        "warning(error) log entry (may be unrelated): %s",
-        location, ncclGetErrorString(res), ncclGetLastError(nullptr)));
-  }
-
-  VLOG(2) << "Deallocated collective memory " << location;
-  return absl::OkStatus();
-}
-
 class NcclIdStore {
  public:
   NcclIdStore(int node_id,

--- a/xla/backends/gpu/collectives/nccl_collectives.h
+++ b/xla/backends/gpu/collectives/nccl_collectives.h
@@ -81,10 +81,6 @@ class NcclCollectives : public GpuCollectives {
     return absl::UnimplementedError("Not implemented.");
   }
 
-  absl::StatusOr<void*> Allocate(uint64_t bytes) final;
-
-  absl::Status Deallocate(void* location) final;
-
   absl::Status InitializeTopology(Topology topology) final;
 };
 

--- a/xla/backends/gpu/collectives/nvshmem_collectives.cc
+++ b/xla/backends/gpu/collectives/nvshmem_collectives.cc
@@ -66,28 +66,6 @@ absl::Status NvshmemCollectives::InitializeTopology(Topology topology) {
   return absl::OkStatus();
 }
 
-absl::StatusOr<void*> NvshmemCollectives::Allocate(uint64_t bytes) {
-  TF_RETURN_IF_ERROR(se::gpu::nvshmem::InitializeOnce());
-  VLOG(3) << absl::StreamFormat(
-      "Start allocation of %s (%llu bytes) for NVSHMEM",
-      tsl::strings::HumanReadableNumBytes(bytes), bytes);
-  void* buffer = nvshmem_malloc(bytes);
-  if (buffer == nullptr) {
-    return absl::InternalError(absl::StrFormat(
-        "Failed to allocate %s (%llu bytes) from NVSHMEM memory",
-        tsl::strings::HumanReadableNumBytes(bytes), bytes));
-  }
-  return buffer;
-}
-
-absl::Status NvshmemCollectives::Deallocate(void* buffer) {
-  TF_RETURN_IF_ERROR(se::gpu::nvshmem::InitializeOnce());
-  VLOG(3) << absl::StreamFormat("Start de-allocation for NVSHMEM buffer: %p",
-                                buffer);
-  nvshmem_free(buffer);
-  return absl::OkStatus();
-}
-
 absl::StatusOr<std::unique_ptr<Communicator>>
 NvshmemCollectives::CreateCommunicator() {
   auto comm = std::make_unique<NvshmemCommunicator>(this);

--- a/xla/backends/gpu/collectives/nvshmem_collectives.h
+++ b/xla/backends/gpu/collectives/nvshmem_collectives.h
@@ -42,10 +42,6 @@ class NvshmemCollectives : public GpuCollectives {
 
   bool IsInitialized() const;
 
-  absl::StatusOr<void*> Allocate(uint64_t bytes) final;
-
-  absl::Status Deallocate(void* buffer) final;
-
   absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final {
     return absl::UnimplementedError("Not implemented.");
   }

--- a/xla/backends/gpu/collectives/nvshmem_collectives_test.cc
+++ b/xla/backends/gpu/collectives/nvshmem_collectives_test.cc
@@ -86,9 +86,6 @@ absl::Status InitializationTestBody(const int node_id, const int num_nodes) {
 
   se::gpu::nvshmem::SetEnvInfo(node_id, num_nodes, 1, kv_store);
   cudaSetDevice(node_id);
-  TF_ASSIGN_OR_RETURN(void* ptr, NvshmemCollectives::Default()->Allocate(1024));
-  TF_RET_CHECK(ptr != nullptr);
-  TF_RETURN_IF_ERROR(NvshmemCollectives::Default()->Deallocate(ptr));
   TF_ASSIGN_OR_RETURN(std::unique_ptr<Communicator> comm,
                       NvshmemCollectives::Default()->CreateCommunicator());
   TF_RET_CHECK(*comm->NumRanks() == num_nodes);

--- a/xla/backends/gpu/collectives/rccl_collectives.h
+++ b/xla/backends/gpu/collectives/rccl_collectives.h
@@ -81,10 +81,6 @@ class RcclCollectives : public GpuCollectives {
     return absl::UnimplementedError("Not implemented.");
   }
 
-  absl::StatusOr<void*> Allocate(uint64_t bytes) final;
-
-  absl::Status Deallocate(void* location) final;
-
   absl::Status InitializeTopology(Topology topology) final;
 };
 


### PR DESCRIPTION
Collective memory allocation must be done with SE MemoryAllocator APIs.
