### PR TITLE
[ROCm] Initialze collectives to nullptr to force its allocation later

### DIFF
--- a/xla/service/gpu/gpu_executable_run_options.h
+++ b/xla/service/gpu/gpu_executable_run_options.h
@@ -92,7 +92,7 @@ class GpuExecutableRunOptions {
   bool enable_mock_collectives_ = false;
   std::optional<DeviceIdMap> gpu_global_device_ids_;
   CliqueIdCallback clique_id_callback_;
-  GpuCollectives* collectives_;
+  GpuCollectives* collectives_ = nullptr;
   std::optional<absl::flat_hash_map<GlobalDeviceId, IncarnationId>>
       incarnations_;
 };


### PR DESCRIPTION
📝 Summary of Changes
Initialize collectives pointer to nullptr

🎯 Justification

Gpu runtime options are initialized in TF and transferred to XLA to execute thunks. Since the memory is not cleared collectives point to an uninitialized memory resulting in segfault during nccl collective initialization and operation.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 


