### PR TITLE
[XLA:CPU][codegen] Fix llvm intrinsic lowering in CPU pipeline

### DIFF
--- a/xla/backends/cpu/codegen/ir_compiler.cc
+++ b/xla/backends/cpu/codegen/ir_compiler.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/Analysis/RuntimeLibcallInfo.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/Orc/Mangling.h"
@@ -431,6 +432,11 @@ std::unique_ptr<llvm::MemoryBuffer> IrCompiler::EmitMachineCode(
   // Generate code.
   llvm::MCContext* mc_context;
   llvm::legacy::PassManager codegen_passes;
+  codegen_passes.add(new llvm::RuntimeLibraryInfoWrapper(
+      module.getTargetTriple(), target_machine->Options.ExceptionModel,
+      target_machine->Options.FloatABIType, target_machine->Options.EABIVersion,
+      target_machine->Options.MCOptions.ABIName,
+      target_machine->Options.VecLib));
   target_machine->addPassesToEmitMC(codegen_passes, mc_context, ostream);
   codegen_passes.run(module);
 

--- a/xla/backends/cpu/codegen/ir_compiler_test.cc
+++ b/xla/backends/cpu/codegen/ir_compiler_test.cc
@@ -256,6 +256,45 @@ TEST(IrCompilerTest, TargetMachineOptionsAreCorrectlySet) {
             "+foo-feature,-bar-feature");
 }
 
+TEST(IrCompilerTest, EmitIntrinsicCall) {
+  constexpr absl::string_view kModuleName = "test_module";
+  constexpr absl::string_view kMemcpyCall = R"(
+  define void @memcpy_call(ptr noalias %a, ptr noalias %b, i64 %n) #0 {
+  entry:
+    call void @llvm.memcpy.p0.p0.i64(ptr align 8 %a, ptr align 8 %b, i64 %n, i1 false)
+    ret void
+  }
+  declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none),
+                            ptr noalias readonly captures(none), i64, i1 immarg) #1
+  )";
+
+  auto context = std::make_unique<llvm::LLVMContext>();
+  IrCompiler::CompilationHooks compilation_hooks;
+
+  std::unique_ptr<IrCompiler> ir_compiler = IrCompiler::Create(
+      llvm::TargetOptions(),
+      IrCompiler::Options{/*opt_level=*/llvm::CodeGenOptLevel::Aggressive,
+                          /*optimize_for_size=*/false,
+                          TargetMachineOptions(GetDebugOptionsFromFlags())},
+      compilation_hooks);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto ir_module,
+                          ParseModule(*context, kMemcpyCall, kModuleName));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto target_machine,
+                          ir_compiler->build_target_machine());
+
+  ir_module->setDataLayout(target_machine->createDataLayout());
+  ir_module->setTargetTriple(target_machine->getTargetTriple());
+  cantFail((*ir_compiler)(*ir_module));
+
+  auto ir = llvm_ir::DumpToString(ir_module.get());
+
+  EXPECT_THAT(ir, ::testing::HasSubstr("tail call"));
+  EXPECT_THAT(ir, ::testing::Not(::testing::HasSubstr("load i8")));
+  EXPECT_THAT(ir, ::testing::Not(::testing::HasSubstr("store i8")));
+}
+
 }  // namespace
 
 }  // namespace xla::cpu


### PR DESCRIPTION
LLVM now has an explicit dependency on library lowering analysis info for libcall lowering decisions, [link](https://github.com/llvm/llvm-project/commit/081a99735c04b2018eeb7e74f9860e1d0e1b#diff-680aac42e651b506634e9cf972770658b7a5119e233a168c11ff7c8edc443e56R666). Hence, this PR adds a pass to the codegen pipeline to make that information available to the compiler. In the absence of the analysis, target intrinsics are marked unsupported and emitted as inline loops.