### PR TITLE
Fix crash in LatencyHidingScheduler with compute offload

### DIFF
--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -828,6 +828,13 @@ BufferInfoTracker::BufferInfoTracker(
   std::function<void(const HloComputation*)> process_computation =
       [&process_computation, module, alias_analysis, this,
        &shape_size_bytes](const HloComputation* computation) {
+        // Skip computations that don't have schedules (e.g., host computations
+        // created during compute offload that are executed separately).
+        // Note: We don't need to track memory usage on CPU for now. If needed,
+        // it can be added later.
+        if (!module->schedule().is_computation_scheduled(computation)) {
+          return;
+        }
         const HloInstructionSequence& sequence =
             module->schedule().sequence(computation);
         for (int idx = 0; idx < sequence.size(); ++idx) {
@@ -862,6 +869,13 @@ void ModulePressureState::InitializePressureStates() {
                                 HloComputation* computation,
                                 const MemoryPressureTracker::LiveBufferSet&
                                     initial_live_buffers) {
+        // Skip computations that don't have schedules (e.g., host computations
+        // created during compute offload that are executed separately).
+        // Note: We don't need to track memory usage on CPU for now. If needed,
+        // it can be added later.
+        if (!module_->schedule().is_computation_scheduled(computation)) {
+          return;
+        }
         const HloInstructionSequence& sequence =
             module_->schedule().sequence(computation);
         MemoryPressureTracker tracker(hlo_alias_analysis_, buffer_tracker_,
@@ -1006,7 +1020,12 @@ void MemoryPressureTracker::UpdateBuffers(const HloInstruction* instruction) {
       continue;
     }
     auto it = pressure_state_cache_.find(called_comp);
-    CHECK(it != pressure_state_cache_.end());
+    // Skip computations that don't have pressure state tracked (e.g., host
+    // computations created during compute offload that are executed
+    // separately).
+    if (it == pressure_state_cache_.end()) {
+      continue;
+    }
     computations_peak = std::max(computations_peak, it->second.memory_peak);
   }
   if (pressure_state_.memory_peak < live_memory_usage_ + computations_peak) {
@@ -1043,7 +1062,12 @@ std::pair<int64_t, int64_t> MemoryPressureTracker::MemoryPressureDifference(
         continue;
       }
       auto it = pressure_state_cache_.find(called_comp);
-      CHECK(it != pressure_state_cache_.end());
+      // Skip computations that don't have pressure state tracked (e.g., host
+      // computations created during compute offload that are executed
+      // separately).
+      if (it == pressure_state_cache_.end()) {
+        continue;
+      }
       // Take max increase of the called computations.
       peak = called_comp_peak =
           std::max(called_comp_peak, it->second.memory_peak);


### PR DESCRIPTION
📝 Summary of Changes
When running JAX unit tests with compute offload (e.g., test_compute_host_loop), the LatencyHidingScheduler(LHS) crashes with std::out_of_range exceptions when trying to access schedules and pressure states for host computations.

Host computations created during compute offload don't have device schedules (they execute separately on the host CPU), but the scheduler assumed all computations have schedules and pressure states, leading to crashes. So we add defensive checks to skip host computations that don't have schedules or pressure states.

🎯 Justification
This CL prevents JAX compute offload code from crashing in LHS when LHS is enabled. Without this fix, any HLO module containing host computations (created during compute offload) would crash during scheduling.

🚀 Kind of Contribution
 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
A new unit test was added: HostOffloadComputationsWithoutSchedule in xla/service/latency_hiding_scheduler_test.cc.

🧪 Execution Tests:
 The fix was verified with JAX end-to-end execution tests. jax/tests/memories_test.py contains compute offload tests in the ComputeOffload test class (e.g.,  test_compute_host_loop) that previously failed due to the scheduler crash. After the fix, these tests pass, confirming the scheduler correctly handles host computations without device schedules.
