### PR TITLE
[ROCm] Align triton compilation pipeline

### DIFF
--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -52,22 +52,31 @@ static void MakeTTIR(mlir::OpPassManager* pm) {
   pm->addPass(mt::createTritonLoopUnroll());
 }
 
+static bool is_pingpong_schedule_enabled(
+    const stream_executor::RocmComputeCapability& rocm_cc,
+    bool use_async_copy) {
+  return rocm_cc.gfx9_mi300() || (rocm_cc.gfx9_mi350() && use_async_copy);
+}
+
+static bool is_in_thread_transpose_enabled(
+    const stream_executor::RocmComputeCapability& rocm_cc) {
+  return rocm_cc.gfx9_mi300();
+}
+
 // Based on make_ttgir() in
 // @triton//:third_party/amd/backend/compiler.py
 static void MakeTTGIR(mlir::OpPassManager* pm,
                       const stream_executor::RocmComputeCapability& rocm_cc,
                       int num_warps, int num_ctas, int num_stages) {
-  const std::string& arch_name = rocm_cc.gcn_arch_name();
-  const int threadsPerWarp = (arch_name[3] == '9') ? 64 : 32;
   pm->addPass(mt::createConvertTritonToTritonGPU(
-      {absl::StrCat("hip:", rocm_cc.gfx_version()), num_warps, threadsPerWarp,
-       num_ctas}));
+      {absl::StrCat("hip:", rocm_cc.gfx_version()), num_warps,
+       rocm_cc.threads_per_warp(), num_ctas}));
   pm->addPass(mt::gpu::createTritonGPUCoalesce());
   pm->addPass(mt::gpu::createTritonGPUF32DotTC({false}));
   pm->addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   pm->addPass(mt::gpu::createTritonGPUOptimizeThreadLocality());
-  // TODO ROCm Pass rocm_cc.gfx_version() after fixing issue with fmfa
-  pm->addPass(mlir::createTritonAMDGPUAccelerateMatmul({arch_name}));
+  pm->addPass(
+      mlir::createTritonAMDGPUAccelerateMatmul({rocm_cc.gfx_version()}));
   pm->addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   // TODO ROCm Check if we want to compare MI100 and greater
   pm->addPass(mlir::createTritonAMDGPUOptimizeEpilogue());
@@ -77,43 +86,48 @@ static void MakeTTGIR(mlir::OpPassManager* pm,
       mlir::createTritonAMDGPUHoistLayoutConversions());
 
   pm->addPass(mt::gpu::createTritonGPUFuseNestedLoops());
-  pm->addPass(mlir::createCSEPass());
+  pm->addPass(mlir::createCanonicalizerPass());
   pm->addPass(mlir::createLoopInvariantCodeMotionPass());
   pm->addPass(mlir::createCanonicalizerPass());
 
-  if (rocm_cc.has_amd_matrix_instr()) {
-    // TODO(ROCm) Modify when corresponding run time flags are introduced.
-    pm->addPass(mlir::createTritonAMDGPUScheduleLoops({num_stages}));
-    pm->addPass(mlir::createTritonAMDGPUPipeline(
-        {/*useAsyncCopy=*/false, /*usePingpong=*/false}));
-    if (/*use_async_copy=*//* DISABLES CODE */ (
-        false)) {  // Not enabled by default.
-      pm->addPass(mlir::createTritonAMDGPUCoalesceAsyncCopy());
-    }
-    pm->addPass(mlir::createCanonicalizerPass());
+  // TODO(ROCm) Modify when corresponding run time flags are introduced.
+  std::string schedule_hint = "none";
+
+  bool use_async_copy = false;  // Not enabled by default.
+  bool use_block_pingpong =
+      is_pingpong_schedule_enabled(rocm_cc, use_async_copy);
+
+  pm->addPass(mlir::createTritonAMDGPUScheduleLoops({num_stages}));
+  pm->addPass(
+      mlir::createTritonAMDGPUPipeline({use_async_copy, use_block_pingpong}));
+  if (use_async_copy) {
+    pm->addPass(
+        mlir::createTritonAMDGPUCoalesceAsyncCopy({rocm_cc.gfx_version()}));
   }
-  if (/*(instruction_sched_variant=="none") == */ /* DISABLES CODE */ (false)) {
-    pm->addPass(mt::createTritonAMDGPUInsertInstructionSchedHintsPass("none"));
+  pm->addPass(mlir::createCanonicalizerPass());
+  if (schedule_hint != "none") {
+    pm->addPass(
+        mt::createTritonAMDGPUInsertInstructionSchedHintsPass({schedule_hint}));
   }
-  pm->addPass(mt::gpu::createTritonGPUOptimizeDotOperands({true}));
   pm->addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   pm->addPass(mt::gpu::createTritonGPUReduceDataDuplication());
-  if (/*(instruction_sched_variant=="none") == */ /* DISABLES CODE */ (false)) {
-    pm->addPass(mlir::createTritonAMDGPUInThreadTranspose());
+  if (is_in_thread_transpose_enabled(rocm_cc)) {
+    pm->addNestedPass<mlir::triton::FuncOp>(
+        mlir::createTritonAMDGPUInThreadTranspose());
     pm->addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   }
-  if (rocm_cc.has_amd_matrix_instr()) {
-    pm->addPass(mt::gpu::createTritonGPUReorderInstructions());
-  }
-  if (/*use_block_pingpong=*//* DISABLES CODE */ (false)) {
+  pm->addPass(mlir::createTritonAMDGPUReorderInstructions());
+  if (use_block_pingpong && num_stages > 1) {
     pm->addPass(mlir::createTritonAMDGPUBlockPingpong({num_stages}));
   }
-  if (/*use_buffer_ops=*//* DISABLES CODE */ (
-      false)) {  // Not enabled by default.
-    pm->addPass(mlir::createTritonAMDGPUCanonicalizePointers());
-    pm->addPass(mlir::createCanonicalizerPass());
-    pm->addPass(mlir::createTritonAMDGPUConvertToBufferOps({arch_name}));
-  }
+
+  pm->addNestedPass<mlir::triton::FuncOp>(
+      mlir::createTritonAMDGPUCanonicalizePointers());
+  pm->addPass(mlir::createCanonicalizerPass());
+  pm->addPass(mlir::createTritonAMDGPUConvertToBufferOps(
+      {rocm_cc.gfx_version(), /*allowBufferAtomics*/ true,
+       /*analyzeSmallTensorOfst*/ false}));
+
   pm->addPass(mlir::createTritonAMDFoldTrueCmpI());
   pm->addPass(mlir::createCanonicalizerPass());
   pm->addPass(mlir::createCSEPass());

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -194,6 +194,8 @@ class RocmComputeCapability {
 
   bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
 
+  int threads_per_warp() const { return gfx9_mi100_or_later() ? 64 : 32; }
+
   /// \brief Invalid gfx id for default gcn_arch_name_ value and testing
   static constexpr absl::string_view kInvalidGfx = "gfx000";
 


### PR DESCRIPTION
Align triton compilation pipeline with compiler.py enabling several optimization passes by default.

📝 Summary of Changes
Align ROCm pipeline for making TTGIR with triton/third_party/amd/backend/compiler.py. This also enables several optimization passes by default like AMDGPUInThreadTranspose, AMDGPUBlockPingpong and AMDGPUConvertToBufferOps.

🎯 Justification
This alignment makes sure we are keeping consistency on triton compilation. These passes help leverage specialized AMD hardware features.

🚀 Kind of Contribution
✨ New Feature

@xla-rotation: would you please take a look?