### PR TITLE
Add xla_cpu_ftz flag to control flush-to-zero on CPU

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -240,6 +240,9 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_fast_math_honor_functions(true);
   opts.set_xla_cpu_fast_math_honor_division(true);
 
+  // Default to true for backwards compatibility (always flush denormals).
+  opts.set_xla_cpu_ftz(true);
+
   opts.set_xla_gpu_fused_attention_use_cudnn_rng(false);
 
   // By default, copy TF's Eigen style min_max behavior with nans.
@@ -1173,6 +1176,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "When xla_cpu_enable_fast_math is true then this controls whether we "
       "forbid to approximate calculations for functions. Ignored when "
       "xla_cpu_enable_fast_math is false."));
+  flag_list->push_back(tsl::Flag(
+      "xla_cpu_ftz", bool_setter_for(&DebugOptions::set_xla_cpu_ftz),
+      debug_options->xla_cpu_ftz(),
+      "If true, flush-to-zero semantics are enabled in the code generated for "
+      "CPUs. Default is true."));
   flag_list->push_back(tsl::Flag(
       "xla_cpu_enable_fast_min_max",
       bool_setter_for(&DebugOptions::set_xla_cpu_enable_fast_min_max),

--- a/xla/service/llvm_ir/llvm_util.cc
+++ b/xla/service/llvm_ir/llvm_util.cc
@@ -776,10 +776,11 @@ llvm::Function* CreateCpuFunction(llvm::FunctionType* function_type,
   // created by the JIT compiled code.
   function->setUWTableKind(llvm::UWTableKind::Default);
 
-  // Tensorflow always flushes denormals to zero, let LLVM know that flushing
-  // denormals is safe. This allows vectorization using ARM's neon instruction
-  // set.
-  function->addFnAttr("denormal-fp-math", "preserve-sign");
+  // Optionally flush denormals to zero. This allows vectorization using ARM's
+  // NEON instruction set. Controlled by the xla_cpu_ftz flag.
+  if (module_config.debug_options().xla_cpu_ftz()) {
+    function->addFnAttr("denormal-fp-math", "preserve-sign");
+  }
 
   // Add the optimize attribute to the function if optimizing for size. This
   // controls internal behavior of some optimization passes (e.g. loop

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -306,6 +306,11 @@ message DebugOptions {
   // false.
   optional bool xla_cpu_fast_math_honor_nans = 120;
 
+  // Enable flush-to-zero semantics in the CPU backend. When true, denormal
+  // floating-point values are flushed to zero. Default is true for backwards
+  // compatibility.
+  optional bool xla_cpu_ftz = 493;
+
   // When true, XLA:CPU all LLVM kernels entry points will be prefixed with the
   // module name. They will also be converted to C style names. This is required
   // for AOT compilation.
@@ -1613,7 +1618,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 493
+  // Next id: 494
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
Fixes #22858

I ran into needing to control denormal handling on CPU similar to how
xla_gpu_ftz works for GPU. Currently the CPU backend unconditionally sets
the denormal-fp-math=preserve-sign attribute on all functions.

This adds an xla_cpu_ftz flag (field 493 in DebugOptions) that controls
whether this attribute gets applied in CreateCpuFunction. It defaults to
true so existing behavior is preserved. Users who want to disable
flush-to-zero can set --xla_cpu_ftz=false.

Usage:
```
XLA_FLAGS="--xla_cpu_ftz=false" ./program
```
