### PR TITLE
[ROCm] Fix TopK algorithm for RDNA

### DIFF
--- a/xla/backends/gpu/runtime/topk_test.cc
+++ b/xla/backends/gpu/runtime/topk_test.cc
@@ -111,8 +111,10 @@ TEST_P(TopKKernelTest, TopKFloat) {
   TF_ASSERT_OK(
       stream->MemZero(&output_indices, k * batch_size * sizeof(uint32_t)));
 
+  TF_ASSERT_OK_AND_ASSIGN(auto desc, platform->DescriptionForDevice(0));
   auto custom_kernel = GetTopKKernel("topk", PrimitiveType::F32, n, k,
-                                     batch_size, platform->Name(), 32);
+                                     batch_size, platform->Name(),
+                                     desc->threads_per_warp());
 
   TF_ASSERT_OK_AND_ASSIGN(auto kernel,
                           executor->LoadKernel(custom_kernel->kernel_spec()));
@@ -165,8 +167,10 @@ TEST_P(TopKKernelTest, TopKPackedNegative) {
   TF_ASSERT_OK(
       stream->MemZero(&output_indices, k * batch_size * sizeof(uint32_t)));
 
+  TF_ASSERT_OK_AND_ASSIGN(auto desc, platform->DescriptionForDevice(0));
   auto custom_kernel = GetTopKKernel("topk", PrimitiveType::F32, n, k,
-                                     batch_size, platform->Name(), 32);
+                                     batch_size, platform->Name(),
+                                     desc->threads_per_warp());
 
   TF_ASSERT_OK_AND_ASSIGN(auto kernel,
                           executor->LoadKernel(custom_kernel->kernel_spec()));
@@ -200,8 +204,10 @@ TEST_P(TopKKernelTest, EnsureSerializable) {
   const auto [n_kb, k, batch_size, offset] = GetParam();
   const size_t n = n_kb * 1024 + offset;
 
+  TF_ASSERT_OK_AND_ASSIGN(auto desc, platform->DescriptionForDevice(0));
   auto custom_kernel = GetTopKKernel("topk", PrimitiveType::F32, n, k,
-                                     batch_size, platform->Name(), 32);
+                                     batch_size, platform->Name(),
+                                     desc->threads_per_warp());
 
   stream_executor::gpu::VerifyKernelIsSerializable(custom_kernel->kernel_spec(),
                                                    platform->id());

--- a/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
+++ b/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/tsl/lib/math/math_util.h"
 
+// https://rocm.docs.amd.com/en/latest/about/release-notes.html#amdgpu-wavefront-size-compiler-macro-deprecation
 #if defined(__GFX9__)
   #define WAVEFRONT_SIZE 64
 #else

--- a/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
+++ b/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
@@ -29,7 +29,11 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/tsl/lib/math/math_util.h"
 
-#define WAVEFRONT_SIZE 32
+#if defined(__GFX9__)
+  #define WAVEFRONT_SIZE 64
+#else
+  #define WAVEFRONT_SIZE 32
+#endif
 
 namespace stream_executor::rocm {
 

--- a/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
+++ b/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
@@ -29,10 +29,10 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/tsl/lib/math/math_util.h"
 
-#ifdef __AMDGCN_WAVEFRONT_SIZE
-#define WAVEFRONT_SIZE __AMDGCN_WAVEFRONT_SIZE
+#if defined(__GFX9__)
+  #define WAVEFRONT_SIZE 64
 #else
-#define WAVEFRONT_SIZE 64
+  #define WAVEFRONT_SIZE 32
 #endif
 
 namespace stream_executor::rocm {

--- a/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
+++ b/xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h
@@ -29,11 +29,7 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/tsl/lib/math/math_util.h"
 
-#if defined(__GFX9__)
-  #define WAVEFRONT_SIZE 64
-#else
-  #define WAVEFRONT_SIZE 32
-#endif
+#define WAVEFRONT_SIZE 32
 
 namespace stream_executor::rocm {
 
@@ -290,13 +286,15 @@ __launch_bounds__(stream_executor::gpu::kTopKMaxThreadsPerBlock, 1) __global__
   GPU_KERNEL_REGISTRY_REGISTER_KERNEL_STATICALLY(                             \
       TopKKernelRocm_K##K_VAL##_##TYPE##_##VT, KERNEL_TRAIT(K_VAL, TYPE, VT), \
       stream_executor::rocm::kROCmPlatformId, ([](size_t arity) {             \
-        return stream_executor::KernelLoaderSpec::CreateInProcessSymbolSpec(  \
+        return stream_executor::KernelLoaderSpec::                            \
+            CreateSerializableInProcessSymbolSpec(                            \
+            /*persistent_kernel_name=*/"topk_k" #K_VAL "_" #TYPE "_" #VT,     \
             absl::bit_cast<void*>(&Run<K_VAL, TYPE, VT>),                     \
             "topk_k" #K_VAL "_" #TYPE "_" #VT, arity);                        \
       }));                                                                    \
   KERNEL_SYMBOL_REGISTRY_REGISTER_SYMBOL_STATICALLY(                          \
-      TopKKernelRocm_K##K_VAL##_##TYPE##_##VT,                                \
-      stream_executor::rocm::kROCmPlatformId, (&Run<K_VAL, TYPE, VT>));
+      topk_k##K_VAL##_##TYPE##_##VT, stream_executor::rocm::kROCmPlatformId,  \
+      (&Run<K_VAL, TYPE, VT>));
 
 }  // namespace stream_executor::rocm
 


### PR DESCRIPTION
📝 Summary of Changes
xla/stream_executor/rocm/topk_kernel_rocm_common.cu.h now implements proper handling of WAVEFRONT_SIZE based on the architecture. __AMDGCN_WAVEFRONT_SIZE is removed as it is deprecated in newer versions of ROCm. 

🎯 Justification
Fixes sort_ops_test_gpu and sort_ops_test_gpu_mlir_bridge_test UT failures.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Fixes sort_ops_test_gpu and sort_ops_test_gpu_mlir_bridge_test UT failures.

**NOTE:** The changes are verified on gfx1100, gfx1201, and gfx90a.