### PR TITLE
[xla] Log StreamExecutor device details

### DIFF
--- a/xla/service/service.cc
+++ b/xla/service/service.cc
@@ -158,9 +158,13 @@ Service::Service(const ServiceOptions& options,
     for (int i = 0; i < execute_backend_->device_count(); ++i) {
       se::StreamExecutor* executor = stream_executors.at(i);
       const auto& description = executor->GetDeviceDescription();
-      LOG(INFO) << StrFormat("  StreamExecutor device (%d): %s, %s", i,
-                             description.name(),
-                             description.platform_version());
+      LOG(INFO) << StrFormat(
+          "  StreamExecutor [%d]: %s, %s"
+          " (Driver: %v; Runtime: %v; Tolkit: %v; DNN: %v)",
+          i, description.name(), description.platform_version(),
+          description.driver_version(), description.runtime_version(),
+          description.compile_time_toolkit_version(),
+          description.dnn_version());
     }
   } else {
     VLOG(1) << "XLA compile-only service constructed";

--- a/xla/service/service.cc
+++ b/xla/service/service.cc
@@ -160,7 +160,7 @@ Service::Service(const ServiceOptions& options,
       const auto& description = executor->GetDeviceDescription();
       LOG(INFO) << StrFormat(
           "  StreamExecutor [%d]: %s, %s"
-          " (Driver: %v; Runtime: %v; Tolkit: %v; DNN: %v)",
+          " (Driver: %v; Runtime: %v; Toolkit: %v; DNN: %v)",
           i, description.name(), description.platform_version(),
           description.driver_version(), description.runtime_version(),
           description.compile_time_toolkit_version(),


### PR DESCRIPTION
Example:

```
I1230 23:57:10.564970  746717 service.cc:153] XLA service 0x39d003e0 initialized for platform CUDA (this does not guarantee that XLA will be used). Devices:
I1230 23:57:10.565088  746717 service.cc:161]   StreamExecutor [0]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
I1230 23:57:10.565126  746717 service.cc:161]   StreamExecutor [1]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
I1230 23:57:10.565152  746717 service.cc:161]   StreamExecutor [2]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
I1230 23:57:10.565177  746717 service.cc:161]   StreamExecutor [3]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
I1230 23:57:10.565199  746717 service.cc:161]   StreamExecutor [4]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
I1230 23:57:10.565225  746717 service.cc:161]   StreamExecutor [5]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
I1230 23:57:10.565248  746717 service.cc:161]   StreamExecutor [6]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
I1230 23:57:10.565270  746717 service.cc:161]   StreamExecutor [7]: NVIDIA H100 80GB HBM3, Compute Capability 9.0a  (Driver: 13.0.0; Runtime: 13.0.0; Tolkit: 13.0.0; DNN: 9.13.1)
```