### PR TITLE
Fix crashes due to kernel cache confusion. (#33220)

### DIFF
--- a/xla/backends/gpu/codegen/emitters/BUILD
+++ b/xla/backends/gpu/codegen/emitters/BUILD
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//xla:xla.default.bzl", "xla_cc_test")
+load("//xla/tests:build_defs.bzl", "xla_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],

--- a/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
+++ b/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
@@ -378,7 +378,8 @@ absl::StatusOr<FusionEmissionResult> MlirKernelFusion::Emit(
                                   GetDefaultBufferAlignment(), &fusion));
   auto [future_entry, cached] = ir_emitter_context.kernel_cache().GetWithStatus(
       fusion.fused_instructions_computation(), args.args(),
-      /*discriminator=*/"", [&]() -> xla::Future<KernelReuseCache::Entry> {
+      /*discriminator=*/"MlirKernelFusion",
+      [&]() -> xla::Future<KernelReuseCache::Entry> {
         std::string kernel_name = ir_emitter_context.GetSanitizedUniqueName(
             std::string(fusion.name()));
         return EmitLlvmModule(fusion, kernel_name, ir_emitter_context)

--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -217,7 +217,7 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
   auto [status_or_entry, was_cached] =
       ir_emitter_context.kernel_cache().GetWithStatus(
           hlo_computation, kernel_arguments.args(),
-          /*discriminator=*/"", generate);
+          /*discriminator=*/"TritonFusion", generate);
   ASSIGN_OR_RETURN(const KernelReuseCache::Entry* entry,
                    status_or_entry.Await());
   return EmitResult{

--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -713,6 +713,19 @@ xla_test(
 )
 
 xla_test(
+    name = "kernel_cache_regression_test",
+    srcs = ["kernel_cache_regression_test.cc"],
+    backends = ["gpu"],
+    deps = [
+        "//xla:error_spec",
+        "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
+        "//xla/tests:hlo_pjrt_test_base",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+xla_test(
     name = "sorting_test",
     srcs = ["sorting_test.cc"],
     backends = ["gpu"],

--- a/xla/backends/gpu/tests/kernel_cache_regression_test.cc
+++ b/xla/backends/gpu/tests/kernel_cache_regression_test.cc
@@ -1,0 +1,91 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Regression tests for kernel cache behavior.
+// These tests verify that different emitters (Loop, Triton, etc.) properly
+// namespace their cached kernels to avoid cross-emitter cache collisions.
+
+#include <gtest/gtest.h>
+#include "absl/strings/string_view.h"
+#include "xla/error_spec.h"
+#include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_pjrt_test_base.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class KernelCacheRegressionTest
+    : public HloPjRtInterpreterReferenceMixin<HloPjRtTestBase> {};
+
+TEST_F(KernelCacheRegressionTest, LoopAndTritonFusionsWithIdenticalComputation) {
+  constexpr absl::string_view kHloText = R"(
+HloModule test_module
+
+add_f32 {
+  p0 = f32[] parameter(0)
+  p1 = f32[] parameter(1)
+  ROOT add = f32[] add(p0, p1)
+}
+
+fused_computation_triton {
+  p0 = f32[32,4]{1,0} parameter(0)
+  p1 = f32[32,4]{1,0} parameter(1)
+  mul = f32[32,4]{1,0} multiply(p0, p1)
+  zero = f32[] constant(0)
+  reduce = f32[32]{0} reduce(mul, zero), dimensions={1}, to_apply=add_f32
+  ROOT sqrt = f32[32]{0} sqrt(reduce)
+}
+
+fused_computation_loop {
+  p0 = f32[32,4]{1,0} parameter(0)
+  p1 = f32[32,4]{1,0} parameter(1)
+  mul = f32[32,4]{1,0} multiply(p0, p1)
+  zero = f32[] constant(0)
+  reduce = f32[32]{0} reduce(mul, zero), dimensions={1}, to_apply=add_f32
+  ROOT sqrt = f32[32]{0} sqrt(reduce)
+}
+
+ENTRY main {
+  input0 = f32[32,4]{1,0} parameter(0)
+  input1 = f32[32,4]{1,0} parameter(1)
+
+  // Triton fusion
+  triton_result = f32[32]{0} fusion(input0, input1), kind=kCustom,
+    calls=fused_computation_triton,
+    backend_config={"fusion_backend_config":{
+      "kind":"__triton",
+      "block_level_fusion_config":{
+        "output_tiles":[{"sizes":["32"]}],
+        "num_warps":"1",
+        "num_ctas":"1",
+        "num_stages":"1",
+        "is_tma_allowed":false}}}
+
+  // Loop fusion with identical computation structure
+  loop_result = f32[32]{0} fusion(input0, input1), kind=kLoop,
+    calls=fused_computation_loop
+
+  // Output both results - they should be identical
+  ROOT tuple = (f32[32]{0}, f32[32]{0}) tuple(loop_result, triton_result)
+})";
+
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kHloText, ErrorSpec{/*aabs=*/1e-6,
+                                                            /*arel=*/1e-6}));
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla


### PR DESCRIPTION
Use cached launch dimensions in EmitterBase and add the emitter class name to the discriminator when the accessing kernel cache. Fixes https://github.com/openxla/xla/issues/33220. 

To recap, sharing of the kernel cache between TritonFusion and EmitterBase (which handles loop fusions) allows for the different kernel emitters to return each other's kernels. In #33220 this was observed in the form of crashes when the launch dimensions were different -- because EmitterBase returns its own launch dimensions, not those that the cached kernel was compiled against. In most cases this simply causes a runtime error because the generated ptx has an assertion for the launch dimensions inserted into it, but could also manifest as segfaults or data corruption if the CTA shapes happen to be the same. 

I made two changes to fix this:
1. EmitterBase uses the cached launch dimensions. This just makes sense, since we're using the cached kernel.
2. Both EmitterBase and TritonFusion add their names to the discriminator string, which prevents more exotic crashes due to reasons such as the different handling of cluster_dims or tma objects (I don't know how to cause those crashes on demand though). But this does mean that an identical HLO computation can potentially end up being compiled twice, if it's used in both loop and triton fusion contexts.

I also added a unit test that reliably reproduces the issue, on cuda devices:

```
E0000 00:00:1767504254.670422  599411 tfrt_gpu_executable.cc:729] Calling RunAsync failed for executable test_module on device cuda:0, status = INTERNAL: CUDA error: Failed to launch CUDA kernel: triton_result; block dims: 128x1x1; grid dims: 1x1x1; shared memory size: 0: CUDA_ERROR_INVALID_VALUE: invalid argument
xla/backends/gpu/codegen/emitters/kernel_cache_test.cc:87: Failure
Value of: RunAndCompareNoHloPasses(kHloText, ErrorSpec{ 1e-6, 1e-6})
  Actual: false (INTERNAL: CUDA error: Failed to launch CUDA kernel: triton_result; block dims: 128x1x1; grid dims: 1x1x1; shared memory size: 0: CUDA_ERROR_INVALID_VALUE: invalid argument)
Expected: true
```