### PR TITLE
[DOCS] Error codes cleanup

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -31,10 +31,6 @@ toc:
     path: /xla/effort_levels
   - title: Emitters
     path: /xla/emitters
-  - title: Error Codes
-    path: /xla/error_codes
-  - title: Errors Overview
-    path: /xla/errors_overview
   - title: Hermetic CUDA overview
     path: /xla/hermetic_cuda
   - title: Indexing Analysis
@@ -66,6 +62,10 @@ toc:
   # This is the default tab for the Debugging section.
   - title: Dump HLO Computations
     path: /xla/hlo_dumps
+  - title: Errors Overview
+    path: /xla/errors_overview
+  - title: Error Codes
+    path: /xla/error_codes
 - title: Contributing
   # These should be in alphabetical order unless otherwise noted.
   section:

--- a/docs/errors/error_0100.md
+++ b/docs/errors/error_0100.md
@@ -1,8 +1,10 @@
 # Error code: 0100
 
-**Category:** Buffer allocation failure - TPU
+**Category:** Buffer allocation failure
 
 **Type:** Runtime
+
+**XLA backend:** TPU
 
 ## Error log example
 
@@ -36,7 +38,7 @@ is available for the buffer.
 So an error encountered after the above mitigations typically require user
 action.
 
-## How can a user fix their program when they do happen?
+## Potential fixes
 
 -   Reduce your model's memory footprint:
     -   Decrease Batch Size: Reducing the batch size directly lowers memory
@@ -61,7 +63,7 @@ action.
         intended. Holding on to `jax.Array` objects might prevent automatic
         de-allocation even after program compilation is completed.
 
-## How can a user debug these failures?
+## Debugging techniques
 
 Enable the `tpu_log_allocations_on_oom` flag for which the allocator will dump a
 detailed report of all current allocations when an OOM occurs, which can be

--- a/docs/errors/error_0101.md
+++ b/docs/errors/error_0101.md
@@ -4,6 +4,8 @@
 
 **Type:** Runtime
 
+**XLA backed:** TPU
+
 ## Error log example
 
 ```
@@ -27,7 +29,7 @@ the runtime will evict already loaded programs from HBM to free up space. This
 can lead to a situation where a program that loaded successfully before now
 fails with an OOM error, because the HBM is now occupied with more data buffers.
 
-## How can a user fix their program when they do happen?
+## Potential fixes
 
 -   Reduce Buffer Memory Footprint: Freeing up memory used by data buffers will
     leave more room for the program itself:
@@ -56,7 +58,7 @@ fails with an OOM error, because the HBM is now occupied with more data buffers.
         intended. Holding on to `jax.Array` objects might prevent automatic
         de-allocation even after program compilation is completed.
 
-## How can a user debug these failures?
+## Debugging techniques
 
 -   Enable the `tpu_log_allocations_on_oom` flag for which the allocator will
     dump a detailed report of all current allocations when an OOM occurs, which

--- a/docs/errors/error_0102.md
+++ b/docs/errors/error_0102.md
@@ -21,23 +21,13 @@ Note that these errors might occur even if two tensors have the same shape but
 their size in memory can be different if their physical layout (how the data is
 tiled and arranged on the hardware) is different.
 
-These errors are predominantly caused by: - **Checkpoint and XLA configuration
-mismatch** - A model is trained and a checkpoint is saved. The physical layout
-of the weights in that checkpoint is determined by the exact XLA version and
-configuration (e.g. XLA flags) at that time. Later, this checkpoint is loaded in
-a different environment where the configuration has changed. A new flag, a
-different default value, or a change in the model/XLA code can cause the runtime
-to expect a different physical layout for the weights. When the old buffer from
-the checkpoint is passed to the new compiled XLA program, the runtime throws an
-error. - **Hardware/Topology-Specific Layouts** - The XLA compiler is free to
-choose different physical layouts for tensors to optimize performance on
-different hardware. A layout that is optimal for v4 TPU might be different from
-a v5 TPU, or even for different pod slices of the same chip (e.g., 4x4x4 vs
-4x8). The error occurs when a model is compiled with an assumption about one
-topology's layout, but at runtime it is scheduled on a different topology, or
-there is a bug in the compiler's layout logic for a specific piece of hardware.
+These errors are predominantly caused by:
+- **Checkpoint and XLA configuration mismatch**
+  - A model is trained and a checkpoint is saved. The physical layout of the weights in that checkpoint is determined by the exact XLA version and configuration (e.g. XLA flags) at that time. Later, this checkpoint is loaded in a different environment where the configuration has changed. A new flag, a different default value, or a change in the model/XLA code can cause the runtime to expect a different physical layout for the weights. When the old buffer from the checkpoint is passed to the new compiled XLA program, the runtime throws an error.
+- **Hardware/Topology-Specific Layouts**
+  - The XLA compiler is free to choose different physical layouts for tensors to optimize performance on different hardware. A layout that is optimal for v4 TPU might be different from a v5 TPU, or even for different pod slices of the same chip (e.g., 4x4x4 vs 4x8). The error occurs when a model is compiled with an assumption about one topology's layout, but at runtime it is scheduled on a different topology, or there is a bug in the compiler's layout logic for a specific piece of hardware.
 
-## How can a user fix their program when they do happen?
+## Potential fixes
 
 -   Ensure configuration consistency between model export and re-runs from
     checkpoints:


### PR DESCRIPTION
**📝 Summary of Changes**

Minor clean-up of error codes docs:
- simplify headings 
- move the docs to the debugging section

**🎯 Justification**

Initially noted in: https://github.com/openxla/xla/pull/35746#discussion_r2648444830

**🚀 Kind of Contribution**
📚 Documentation