### PR TITLE
Enable Linux system calls on arm64

### DIFF
--- a/third_party/hwloc/hwloc.BUILD
+++ b/third_party/hwloc/hwloc.BUILD
@@ -51,6 +51,7 @@ expand_template(
     out = "include/hwloc/autogen/config.h",
     substitutions = select({
         "@xla//xla/tsl:linux_x86_64": _INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_LINUX_SUBS,
+        "@xla//xla/tsl:linux_aarch64": _INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_LINUX_SUBS,
         "//conditions:default": _INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS,
     }),
     template = "include/hwloc/autogen/config.h.in",


### PR DESCRIPTION
📝 Summary of Changes
Include Linux definitions when compiling for arm64 as well as x86_64.

🎯 Justification
Without this, some NUMA-aware operations provided by hwloc do not work on arm64 Linux systems.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
This fixes `@tsl//tsl/platform:numa_test` on relevant platforms.