### PR TITLE
[xla:gpu] CommandExecutor: Correctly split RecordCreate from RecordUpdate and cleanup public facing Record API

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -76,7 +76,11 @@ xla_cc_test(
     deps = [
         ":command_state",
         "//xla/tsl/platform:test",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/profiler/lib:profiler_lock",
     ],
 )
 

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -76,11 +76,7 @@ xla_cc_test(
     deps = [
         ":command_state",
         "//xla/tsl/platform:test",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/profiler/lib:profiler_lock",
     ],
 )
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "llvm/ADT/STLExtras.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/runtime/all_gather_thunk.h"
 #include "xla/backends/gpu/runtime/all_reduce_thunk.h"
@@ -102,7 +103,6 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/types.h"  // IWYU pragma: keep
 #include "xla/util.h"
-#include "tsl/profiler/lib/scoped_annotation.h"
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -97,8 +97,10 @@ struct TestOnlyCommandBufferCmd : public CommandBufferCmd {
       : CommandBufferCmd(CommandBufferCmdType::kUnknownCmd, {}),
         buffer_usage(buffer_usage) {}
 
-  absl::Status Record(const Thunk::ExecuteParams&, RecordParams&) override {
-    return absl::OkStatus();
+  absl::StatusOr<const se::CommandBuffer::Command*> Record(
+      const Thunk::ExecuteParams&, const RecordParams&, RecordAction,
+      se::CommandBuffer*) override {
+    return nullptr;
   }
 
   BufferUseVector buffers() const override { return buffer_usage; }
@@ -111,12 +113,56 @@ class FakeCmd : public CommandBufferCmd {
   explicit FakeCmd()
       : CommandBufferCmd(CommandBufferCmdType::kTracedCommandBufferCmd, {}) {}
 
-  absl::Status Record(const Thunk::ExecuteParams&, RecordParams&) override {
-    return absl::OkStatus();
+  absl::StatusOr<const se::CommandBuffer::Command*> Record(
+      const Thunk::ExecuteParams&, const RecordParams&, RecordAction,
+      se::CommandBuffer*) override {
+    return nullptr;
   }
 
   BufferUseVector buffers() const override { return BufferUseVector{}; }
 };
+
+TEST(CommandBufferCmdStateManageTest, GetOrCreateState) {
+  struct StateA : public CommandState {
+    int32_t value = 0;
+  };
+
+  struct StateB : public CommandState {
+    float value = 0;
+  };
+
+  // We need a fake command and command buffer pointer to use as a key.
+  auto* cmd =
+      tsl::safe_reinterpret_cast<CommandBufferCmd*>(std::intptr_t{0x1234567});
+  auto* command_buffer =
+      tsl::safe_reinterpret_cast<se::CommandBuffer*>(std::intptr_t{0x1234567});
+
+  CommandStateManager state_manager;
+
+  // Create a state of type StateA.
+  auto* stateA0 = state_manager.GetOrNull<StateA>(cmd, command_buffer);
+  ASSERT_EQ(stateA0, nullptr);
+
+  auto* stateA1 = state_manager.GetOrCreate<StateA>(cmd, command_buffer);
+  ASSERT_EQ(stateA1->value, 0);
+  stateA1->value += 42;
+
+  auto* stateA2 = state_manager.GetOrCreate<StateA>(cmd, command_buffer);
+  ASSERT_EQ(stateA2->value, 42);
+  ASSERT_EQ(stateA1, stateA2);
+
+  // StateB has a different type, and has no connection to StateA created above.
+  auto* stateB0 = state_manager.GetOrNull<StateB>(cmd, command_buffer);
+  ASSERT_EQ(stateB0, nullptr);
+
+  auto* stateB1 = state_manager.GetOrCreate<StateB>(cmd, command_buffer);
+  ASSERT_EQ(stateB1->value, 0);
+  stateB1->value += 42.0;
+
+  auto* stateB2 = state_manager.GetOrCreate<StateB>(cmd, command_buffer);
+  ASSERT_EQ(stateB2->value, 42.0);
+  ASSERT_EQ(stateB1, stateB2);
+}
 
 TEST(CommandBufferCmdTest, SerializeExecution) {
   BufferAllocation alloc0(/*index=*/0, /*size=*/1024, /*color=*/0);
@@ -234,7 +280,7 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
 
   ServiceExecutableRunOptions run_options;
-  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
   BufferAllocations allocations({a, b}, 0, &allocator);
 
   CommandStateManager state;
@@ -242,13 +288,12 @@ TEST(CommandBufferCmdTest, MemcpyCmd) {
   Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
       run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
 
+  CommandBufferCmd::RecordParams record_params = {state};
+
   TF_ASSERT_OK_AND_ASSIGN(
       auto command_buffer,
       stream_executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
-
-  CommandBufferCmd::RecordParams record_params = {state};
-  record_params.command_buffer = command_buffer.get();
-  TF_ASSERT_OK(executor.Record(params, record_params));
+  TF_ASSERT_OK(executor.Record(params, record_params, command_buffer.get()));
 
   // Execute command buffer and verify that it copied the memory.
   TF_ASSERT_OK(command_buffer->Submit(stream.get()));
@@ -307,19 +352,18 @@ TEST(CommandBufferCmdTest, LaunchCmd) {
   TF_ASSERT_OK(executor.Initialize({stream_executor, source}, state));
 
   ServiceExecutableRunOptions run_options;
-  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
   BufferAllocations allocations({a, b}, 0, &allocator);
 
   Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
       run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
 
+  CommandBufferCmd::RecordParams record_params = {state};
+
   TF_ASSERT_OK_AND_ASSIGN(
       auto command_buffer,
       stream_executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
-
-  CommandBufferCmd::RecordParams record_params = {state};
-  record_params.command_buffer = command_buffer.get();
-  TF_ASSERT_OK(executor.Record(params, record_params));
+  TF_ASSERT_OK(executor.Record(params, record_params, command_buffer.get()));
 
   // Execute command buffer and verify that it copied the memory.
   TF_ASSERT_OK(command_buffer->Submit(stream.get()));
@@ -380,19 +424,18 @@ TEST(CommandBufferCmdTest, LaunchCmdWithPriority) {
   TF_ASSERT_OK(executor.Initialize({stream_executor, source}, state));
 
   ServiceExecutableRunOptions run_options;
-  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
   BufferAllocations allocations({a, b}, 0, &allocator);
 
   Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
       run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
 
+  CommandBufferCmd::RecordParams record_params = {state};
+
   TF_ASSERT_OK_AND_ASSIGN(
       auto command_buffer,
       stream_executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
-
-  CommandBufferCmd::RecordParams record_params = {state};
-  record_params.command_buffer = command_buffer.get();
-  TF_ASSERT_OK(executor.Record(params, record_params));
+  TF_ASSERT_OK(executor.Record(params, record_params, command_buffer.get()));
 
   // Execute command buffer and verify that it copied the memory.
   TF_ASSERT_OK(command_buffer->Submit(stream.get()));
@@ -438,7 +481,7 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
       CommandBufferCmdExecutor::Create(std::move(commands), serialize));
 
   ServiceExecutableRunOptions run_options;
-  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
   BufferAllocations allocations({a, b}, 0, &allocator);
 
   CommandStateManager state;
@@ -446,13 +489,12 @@ TEST(CommandBufferCmdTest, DynamicSliceCopyFusionCmd) {
   Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
       run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
 
+  CommandBufferCmd::RecordParams record_params = {state};
+
   TF_ASSERT_OK_AND_ASSIGN(
       auto command_buffer,
       stream_executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
-
-  CommandBufferCmd::RecordParams record_params = {state};
-  record_params.command_buffer = command_buffer.get();
-  TF_ASSERT_OK(executor.Record(params, record_params));
+  TF_ASSERT_OK(executor.Record(params, record_params, command_buffer.get()));
 
   // Execute command buffer and verify that it copied the memory.
   TF_ASSERT_OK(command_buffer->Submit(stream.get()));
@@ -483,7 +525,7 @@ TEST(TracedCommandBuffer, GetOrUpdateCommandBuffer) {
     se::DeviceAddressBase mem0(reinterpret_cast<void*>(0x01234567));
     se::DeviceAddressBase mem1(reinterpret_cast<void*>(0x12345670));
 
-    stream_executor::StreamExecutorAddressAllocator allocator(executor);
+    se::StreamExecutorMemoryAllocator allocator(executor);
     BufferAllocations allocations({mem0, mem1}, 0, &allocator);
 
     se::DeviceAddress<int32_t> mem = executor->AllocateArray<int32_t>(16, 0);
@@ -628,7 +670,7 @@ TEST(CommandBufferCmdTest, RecordExecutorsWithDependencies) {
 
   // Execute params and allocations mapping indices 0=a,1=b,2=c
   ServiceExecutableRunOptions run_options;
-  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
   BufferAllocations allocations({a, b, c}, 0, &allocator);
 
   Thunk::ExecuteParams exec_params = Thunk::ExecuteParams::Create(
@@ -640,19 +682,22 @@ TEST(CommandBufferCmdTest, RecordExecutorsWithDependencies) {
       auto command_buffer,
       stream_executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
 
-  record_params.command_buffer = command_buffer.get();
-
   // Record A (no deps)
-  // Record A, B, C with dependencies using the Record API; finalize on C.
-  record_params.is_finalize = false;
-  TF_ASSERT_OK(exec_a.Record(exec_params, record_params));
+  // Record A, B, C with dependencies using the Record API; finalize on B.
+  TF_ASSERT_OK_AND_ASSIGN(auto a_sinks,
+                          exec_a.RecordCreate(exec_params, record_params,
+                                              command_buffer.get(), {}));
 
-  record_params.external_dependencies = exec_a.SinkCommands(record_params);
-  TF_ASSERT_OK(exec_b.Record(exec_params, record_params));
+  TF_ASSERT_OK_AND_ASSIGN(auto b_sinks,
+                          exec_b.RecordCreate(exec_params, record_params,
+                                              command_buffer.get(), a_sinks));
 
-  record_params.external_dependencies = exec_b.SinkCommands(record_params);
-  record_params.is_finalize = true;
-  TF_ASSERT_OK(exec_c.Record(exec_params, record_params));
+  TF_ASSERT_OK_AND_ASSIGN(auto c_sinks,
+                          exec_c.RecordCreate(exec_params, record_params,
+                                              command_buffer.get(), b_sinks))
+
+  // Finalize command buffer after recording multiple iterations.
+  TF_ASSERT_OK(command_buffer->Finalize());
 
   // Submit and verify c == 2 for all elements.
   TF_ASSERT_OK(command_buffer->Submit(stream.get()));
@@ -728,7 +773,7 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
   // nested buffer.
   CommandStateManager state;
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  se::StreamExecutorMemoryAllocator allocator(stream_executor);
   BufferAllocations allocations({a, b, c}, 0, &allocator);
   TF_ASSERT_OK(outer_executor.Initialize(
       {stream_executor, source, &allocations, stream.get(), stream.get()},
@@ -738,14 +783,14 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
   ServiceExecutableRunOptions run_options;
   Thunk::ExecuteParams exec_params = Thunk::ExecuteParams::Create(
       run_options, allocations, stream.get(), stream.get(), nullptr, nullptr);
+  CommandBufferCmd::RecordParams record_params = {state};
+
   // Create a command buffer and record the nested ChildCmd (Create).
   TF_ASSERT_OK_AND_ASSIGN(
       auto command_buffer,
       stream_executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
-
-  CommandBufferCmd::RecordParams record_params = {state};
-  record_params.command_buffer = command_buffer.get();
-  TF_ASSERT_OK(outer_executor.Record(exec_params, record_params));
+  TF_ASSERT_OK(
+      outer_executor.Record(exec_params, record_params, command_buffer.get()));
   TF_ASSERT_OK(command_buffer->Submit(stream.get()));
 
   // Verify c == a (all ones).
@@ -780,9 +825,9 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
   std::vector<BufferAllocation::Index> updated_allocs = {0, 2};
   CommandBufferCmd::RecordParams record_params2 = {state,
                                                    std::move(updated_allocs)};
-  record_params2.command_buffer = command_buffer.get();
 
-  TF_ASSERT_OK(outer_executor.Record(exec_params2, record_params2));
+  TF_ASSERT_OK(outer_executor.Record(exec_params2, record_params2,
+                                     command_buffer.get()));
   TF_ASSERT_OK(command_buffer->Submit(stream.get()));
 
   // Verify c2 == a2 (all sevens).
@@ -819,7 +864,7 @@ static void BM_GetOrTraceCommandBuffer(benchmark::State& state) {
 
   se::DeviceAddressBase mem0(reinterpret_cast<void*>(0x01234567));
   se::DeviceAddressBase mem1(reinterpret_cast<void*>(0x12345670));
-  stream_executor::StreamExecutorAddressAllocator allocator(executor);
+  se::StreamExecutorMemoryAllocator allocator(executor);
 
   std::array<BufferAllocations, 4> allocations = {
       BufferAllocations({mem0, mem1}, 0, &allocator),

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -27,6 +27,9 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
+#include "tsl/profiler/lib/profiler_lock.h"
+#include "tsl/profiler/lib/traceme.h"
+#include "tsl/profiler/lib/traceme_encode.h"
 #include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
@@ -39,9 +42,6 @@ limitations under the License.
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
 #include "xla/tsl/platform/statusor.h"
-#include "tsl/profiler/lib/profiler_lock.h"
-#include "tsl/profiler/lib/traceme.h"
-#include "tsl/profiler/lib/traceme_encode.h"
 
 namespace xla::gpu {
 
@@ -203,13 +203,11 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     auto updated_allocs =
         cmd_buffer->UpdateBufferAllocations(commands_, execute_params);
 
-    CommandBufferCmd::RecordParams record_params = {
-        .state = cmd_buffer->state,
-        .updated_allocs = std::move(updated_allocs),
-        .is_initialization = true,
-        .command_buffer = cmd_buffer->command_buffer.get(),
-    };
-    TF_RETURN_IF_ERROR(commands_.Record(execute_params, record_params));
+    CommandBufferCmd::RecordParams record_params = {cmd_buffer->state,
+                                                    std::move(updated_allocs),
+                                                    /*is_initialization=*/true};
+    TF_RETURN_IF_ERROR(commands_.Record(execute_params, record_params,
+                                        cmd_buffer->command_buffer.get()));
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();
     VLOG(3) << "Initialized command buffer on device #"
@@ -275,12 +273,10 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
 
     uint64_t start_micros = tsl::Env::Default()->NowMicros();
 
-    CommandBufferCmd::RecordParams record_params = {
-        .state = cmd_buffer->state,
-        .updated_allocs = std::move(updated_allocs),
-        .command_buffer = cmd_buffer->command_buffer.get(),
-    };
-    TF_RETURN_IF_ERROR(commands_.Record(params, record_params));
+    CommandBufferCmd::RecordParams record_params = {cmd_buffer->state,
+                                                    std::move(updated_allocs)};
+    TF_RETURN_IF_ERROR(commands_.Record(params, record_params,
+                                        cmd_buffer->command_buffer.get()));
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();
     VLOG(3) << "Updated command buffer in " << (end_micros - start_micros)

--- a/xla/backends/gpu/runtime/command_state.h
+++ b/xla/backends/gpu/runtime/command_state.h
@@ -85,7 +85,10 @@ class CommandState {
 //
 // Note that the same command can be recorded as a part of multiple iterations
 // of unrolled loop, and for this reason the state can be attached to a
-// concreate iteration index.
+// concreate iteration index. Also for unrolled loops the same command can be
+// recorded into multiple command buffers (for cond and body computations), and
+// for this reason state is attached to a triple: (command, command_buffer,
+// unroll_iteration).
 class CommandStateManager {
  public:
   template <typename State>


### PR DESCRIPTION
1. Split public facing `CommandBufferExecutor::Record` API from fine grained `RecordCreate` and `RecordUpdate` APIs.
2. Fix several bugs in child command recording (command buffers must be properly finalized).
3. Break a circular dependency from `CommandBufferCmd` to `CommandBufferCmdExecutor`, this is needed to extract separate `Command` and `CommandExecutor` targets.


In general commands must be dumb, and accept all dependencies as arguments from the caller. Command executor is responsible for tracking dependencies between commands. It is incorrect to call from command back to executor as it breaks abstraction boundaries.

This is how the code will be eventually structured:

`xla::CommandExecutor` (executes) --->>> `xla::Command` (records) --->> `se::CommandBuffer::Command`

This PR removes tight coupling between command record/update and mutable `RecordParams`. `RecordParams` must stay immutable for the whole command sequence recording (similar to how thunk execute params are immutable for the whole execution).