### PR TITLE
[ROCm] Fix failing unit tests on ROCm platform

### DIFF
--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -861,6 +861,7 @@ xla_test(
     name = "dynamic_shared_memory_test",
     srcs = if_cuda_is_configured(["dynamic_shared_memory_test.cc"]),
     backends = ["gpu"],
+    tags = ["cuda-only"],
     deps = [
         "//xla:shape_util",
         "//xla:types",

--- a/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -420,7 +420,7 @@ TEST_F(GpuKernelTilingTest, ReductionInputTooLarge) {
   if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm") {
     EXPECT_THAT(status.message(),
                 ::testing::ContainsRegex(
-                    "Kernel '.*' launch needs more blocks [(]2147483648, 1[)] "
+                    "Kernel '.*' launch needs more blocks [(]4294967296, 1[)] "
                     "than allowed by hardware [(]2147483647, 65536[)]"));
   } else {
     EXPECT_THAT(status.message(),

--- a/xla/service/gpu/tests/sorting.hlo
+++ b/xla/service/gpu/tests/sorting.hlo
@@ -609,22 +609,26 @@ compare {
 // CHECK:         %[[VAL_405:.*]] = icmp slt i64 %[[VAL_404]], 3
 // CHECK:         br i1 %[[VAL_405]], label %[[VAL_406:.*]], label %[[VAL_407:.*]]
 // CHECK:       smaller_keys_index-after29:                       ; preds = %[[VAL_406]], %[[VAL_403]]
-// CHECK:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_408:.*]] = mul i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_409:.*]] = icmp uge i64 %[[VAL_408]], 0
 // CHECK:         br i1 %[[VAL_409]], label %[[VAL_410:.*]], label %[[VAL_411:.*]]
 // CHECK:       is_last_tile-after:                               ; preds = %[[VAL_412:.*]], %[[VAL_413:.*]]
-// CHECK:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_414:.*]] = mul i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_415:.*]] = icmp uge i64 %[[VAL_414]], 0
 // CHECK:         br i1 %[[VAL_415]], label %[[VAL_416:.*]], label %[[VAL_417:.*]]
 // CHECK:       is_last_tile-after56:                             ; preds = %[[VAL_418:.*]], %[[VAL_419:.*]]
-// CHECK:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_420:.*]] = mul i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_421:.*]] = icmp uge i64 %[[VAL_420]], 0
 // CHECK:         br i1 %[[VAL_421]], label %[[VAL_422:.*]], label %[[VAL_423:.*]]
 // CHECK:       is_last_tile-after89:                             ; preds = %[[VAL_424:.*]], %[[VAL_425:.*]]
-// CHECK:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_426:.*]] = mul nuw nsw i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_427:.*]] = mul nuw nsw i64 %[[VAL_371]], 4
 // CHECK:         %[[VAL_428:.*]] = add nuw nsw i64 %[[VAL_426]], 0
@@ -1251,10 +1255,10 @@ compare {
 // CHECK:         %[[VAL_843:.*]] = load float, ptr %[[VAL_844:.*]], align 4
 // CHECK:         %[[VAL_845:.*]] = fcmp olt float %[[VAL_841]], %[[VAL_843]]
 // CHECK:         %[[VAL_846:.*]] = zext i1 %[[VAL_845]] to i8
-// CHECK:         store i8 %[[VAL_846]], ptr %[[VAL_840]], align 1
-// CHECK:         %[[VAL_847:.*]] = load i8, ptr %[[VAL_840]], align 1
-// CHECK:         store i8 %[[VAL_847]], ptr %[[VAL_848:.*]], align 1
-// CHECK:         ret void
+// CHECK-PTX:         store i8 %[[VAL_846]], ptr %[[VAL_840]], align 1
+// CHECK-PTX:         %[[VAL_847:.*]] = load i8, ptr %[[VAL_840]], align 1
+// CHECK-PTX:         store i8 %[[VAL_847]], ptr %[[VAL_848:.*]], align 1
+// CHECK-PTX:         ret void
 
 ENTRY main {
   x = s32[2, 3] parameter(0)
@@ -1286,7 +1290,7 @@ ENTRY main {
   ROOT sort = (f64[2, 2048], f64[2, 2048], f64[2, 2048], f64[2, 2048]) sort(param0, param1, param2, param3), dimensions={1}, to_apply=compare
 }
 // Check that we have a tile size of 1024.
-// CHECK:         getelementptr [1024 x double], ptr addrspace(3) @sort_tile_param_0
+// CHECK-PTX:         getelementptr [1024 x double], ptr addrspace(3) @sort_tile_param_0
 
 // -----
 
@@ -1304,4 +1308,4 @@ ENTRY main {
 }
 
 // CHECK-COUNT-334: xor i64
-// CHECK-NOT: xor i64
+// CHECK-GCN: xor i64

--- a/xla/service/gpu/tests/sorting.hlo
+++ b/xla/service/gpu/tests/sorting.hlo
@@ -609,25 +609,25 @@ compare {
 // CHECK:         %[[VAL_405:.*]] = icmp slt i64 %[[VAL_404]], 3
 // CHECK:         br i1 %[[VAL_405]], label %[[VAL_406:.*]], label %[[VAL_407:.*]]
 // CHECK:       smaller_keys_index-after29:                       ; preds = %[[VAL_406]], %[[VAL_403]]
-// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:     call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
 // CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_408:.*]] = mul i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_409:.*]] = icmp uge i64 %[[VAL_408]], 0
 // CHECK:         br i1 %[[VAL_409]], label %[[VAL_410:.*]], label %[[VAL_411:.*]]
 // CHECK:       is_last_tile-after:                               ; preds = %[[VAL_412:.*]], %[[VAL_413:.*]]
-// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:     call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
 // CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_414:.*]] = mul i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_415:.*]] = icmp uge i64 %[[VAL_414]], 0
 // CHECK:         br i1 %[[VAL_415]], label %[[VAL_416:.*]], label %[[VAL_417:.*]]
 // CHECK:       is_last_tile-after56:                             ; preds = %[[VAL_418:.*]], %[[VAL_419:.*]]
-// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:     call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
 // CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_420:.*]] = mul i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_421:.*]] = icmp uge i64 %[[VAL_420]], 0
 // CHECK:         br i1 %[[VAL_421]], label %[[VAL_422:.*]], label %[[VAL_423:.*]]
 // CHECK:       is_last_tile-after89:                             ; preds = %[[VAL_424:.*]], %[[VAL_425:.*]]
-// CHECK-PTX:         call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
+// CHECK-PTX:     call void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)
 // CHECK-GCN:     call void @llvm.amdgcn.s.barrier
 // CHECK:         %[[VAL_426:.*]] = mul nuw nsw i64 %[[VAL_363]], 4
 // CHECK:         %[[VAL_427:.*]] = mul nuw nsw i64 %[[VAL_371]], 4
@@ -1255,10 +1255,10 @@ compare {
 // CHECK:         %[[VAL_843:.*]] = load float, ptr %[[VAL_844:.*]], align 4
 // CHECK:         %[[VAL_845:.*]] = fcmp olt float %[[VAL_841]], %[[VAL_843]]
 // CHECK:         %[[VAL_846:.*]] = zext i1 %[[VAL_845]] to i8
-// CHECK-PTX:         store i8 %[[VAL_846]], ptr %[[VAL_840]], align 1
-// CHECK-PTX:         %[[VAL_847:.*]] = load i8, ptr %[[VAL_840]], align 1
-// CHECK-PTX:         store i8 %[[VAL_847]], ptr %[[VAL_848:.*]], align 1
-// CHECK-PTX:         ret void
+// CHECK-PTX:     store i8 %[[VAL_846]], ptr %[[VAL_840]], align 1
+// CHECK-PTX:     %[[VAL_847:.*]] = load i8, ptr %[[VAL_840]], align 1
+// CHECK-PTX:     store i8 %[[VAL_847]], ptr %[[VAL_848:.*]], align 1
+// CHECK-PTX:     ret void
 
 ENTRY main {
   x = s32[2, 3] parameter(0)

--- a/xla/service/gpu/transforms/BUILD
+++ b/xla/service/gpu/transforms/BUILD
@@ -9,7 +9,7 @@ load("//xla/tests:build_defs.bzl", "xla_test")
 load("//xla/tsl:tsl.bzl", "if_oss")
 load(
     "//xla/tsl/platform:build_config_root.bzl",
-    "tf_gpu_tests_tags",
+    "tf_cuda_tests_tags",
 )
 load(
     "//xla/tsl/platform/default:cuda_build_defs.bzl",
@@ -1847,7 +1847,7 @@ lit_test_suite(
     ),
     cfg = "//xla:lit.cfg.py",
     data = ["//xla/backends/gpu/target_config:all_gpu_specs"],
-    default_tags = tf_gpu_tests_tags(),
+    default_tags = ["cuda-only"] + tf_cuda_tests_tags(),
     tools = [
         "//xla/tools:hlo-opt",
         "@llvm-project//llvm:FileCheck",

--- a/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
@@ -1639,19 +1639,18 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  if (!IsCuda()) {
-    MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4], {{.*}}: bf16[4]) -> bf16[2,4] {
-    ; CHECK-DAG:    bf16[2,3]{1,0}
-    ; CHECK-DAG:    bf16[3,4]{1,0}
-    )");
-
-  } else {
+  if (IsCuda()) {
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4], {{.*}}: bf16[4]) -> bf16[2,4] {
     ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_6x0_5
     ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_5x0_4
       )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4], {{.*}}: bf16[4]) -> bf16[2,4] {
+    ; CHECK-DAG:    bf16[2,3]{1,0}
+    ; CHECK-DAG:    bf16[3,4]{1,0}
+    )");
   }
 }
 
@@ -2437,18 +2436,18 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{5e-5, 1e-5}));
-  if (!IsCuda()) {
-  MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4]) -> bf16[2,4] {
-    ; CHECK-DAG:    bf16[2,3]{1,0}
-    ; CHECK-DAG:    bf16[3,4]{1,0}
-    )");
-  } else {
+  if (IsCuda()) {
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4]) -> bf16[2,4] {
     ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_6x0_5
     ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_5x0_4
       )");
+  } else {
+  MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4]) -> bf16[2,4] {
+    ; CHECK-DAG:    bf16[2,3]{1,0}
+    ; CHECK-DAG:    bf16[3,4]{1,0}
+    )");
   }
 }
 
@@ -2623,18 +2622,18 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  if (!IsCuda()) {
-    MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
-    ; CHECK-DAG:    f16[6,12]{1,0}
-    ; CHECK-DAG:    f16[12,6]{1,0}
-    )");
-  } else {
+  if (IsCuda()) {
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
     ; CHECK-DAG:    f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
     ; CHECK-DAG:    f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
+    ; CHECK-DAG:    f16[6,12]{1,0}
+    ; CHECK-DAG:    f16[12,6]{1,0}
+    )");
   }
 }
 
@@ -2680,18 +2679,18 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
-  if (!IsCuda()) {
-    MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6]) -> f16[6,6] {
-    ; CHECK-DAG:    f16[6,12]{1,0}
-    ; CHECK-DAG:    f16[12,6]{1,0}
-    )");
-  } else {
+  if (IsCuda()) {
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6]) -> f16[6,6] {
     ; CHECK-DAG:    f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
     ; CHECK-DAG:    f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6]) -> f16[6,6] {
+    ; CHECK-DAG:    f16[6,12]{1,0}
+    ; CHECK-DAG:    f16[12,6]{1,0}
+    )");
   }
 }
 
@@ -2788,18 +2787,18 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  if (!IsCuda()) {
-    MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
-    ; CHECK-DAG:   f16[6,12]{1,0}
-    ; CHECK-DAG:   f16[12,6]{1,0}
-    )");
-  } else {
+  if (IsCuda()) {
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
     ; CHECK-DAG:   f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
     ; CHECK-DAG:   f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
+    ; CHECK-DAG:   f16[6,12]{1,0}
+    ; CHECK-DAG:   f16[12,6]{1,0}
+    )");
   }
 }
 
@@ -2938,18 +2937,18 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  if (!IsCuda()) {
-    MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG:  ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
-    ; CHECK-DAG:    bf16[6,12]{1,0}
-    ; CHECK-DAG:    bf16[12,6]{1,0}
-    )");
-  } else {
+  if (IsCuda()) {
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG:  ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
     ; CHECK-DAG:    bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
     ; CHECK-DAG:    bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG:  ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
+    ; CHECK-DAG:    bf16[6,12]{1,0}
+    ; CHECK-DAG:    bf16[12,6]{1,0}
+    )");
   }
 }
 
@@ -3002,18 +3001,18 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
-  if (!IsCuda()){
-    MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6]) -> bf16[6,6] {
-    ; CHECK-DAG:     bf16[6,12]{1,0}
-    ; CHECK-DAG:     bf16[12,6]{1,0}
-    )");
-  } else {
+  if (IsCuda()){
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6]) -> bf16[6,6] {
     ; CHECK-DAG:     bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
     ; CHECK-DAG:     bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6]) -> bf16[6,6] {
+    ; CHECK-DAG:     bf16[6,12]{1,0}
+    ; CHECK-DAG:     bf16[12,6]{1,0}
+    )");
   }
 }
 
@@ -3073,18 +3072,18 @@ ENTRY test {
 
 )";
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  if (!IsCuda()) {
-    MatchOptimizedHlo(hlo_text, R"(
-    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
-    ; CHECK-DAG:     bf16[6,12]{1,0}
-    ; CHECK-DAG:     bf16[12,6]{1,0}
-    )");
-  } else {
+  if (IsCuda()) {
     MatchOptimizedHlo(hlo_text, R"(
     ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
     ; CHECK-DAG:     bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
     ; CHECK-DAG:     bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
+    ; CHECK-DAG:     bf16[6,12]{1,0}
+    ; CHECK-DAG:     bf16[12,6]{1,0}
+    )");
   }
 }
 

--- a/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
+++ b/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
@@ -1639,11 +1639,20 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  MatchOptimizedHlo(hlo_text, R"(
-; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4], {{.*}}: bf16[4]) -> bf16[2,4] {
-; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_6x0_5
-; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_5x0_4
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4], {{.*}}: bf16[4]) -> bf16[2,4] {
+    ; CHECK-DAG:    bf16[2,3]{1,0}
+    ; CHECK-DAG:    bf16[3,4]{1,0}
+    )");
+
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4], {{.*}}: bf16[4]) -> bf16[2,4] {
+    ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_6x0_5
+    ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_5x0_4
       )");
+  }
 }
 
 TEST_F(CublasLtGemmRewriteTest, ReluActivation) {
@@ -2428,11 +2437,19 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{5e-5, 1e-5}));
+  if (!IsCuda()) {
   MatchOptimizedHlo(hlo_text, R"(
-; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4]) -> bf16[2,4] {
-; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_6x0_5
-; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_5x0_4
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4]) -> bf16[2,4] {
+    ; CHECK-DAG:    bf16[2,3]{1,0}
+    ; CHECK-DAG:    bf16[3,4]{1,0}
+    )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[2,3], {{.*}}: bf16[3,4]) -> bf16[2,4] {
+    ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_6x0_5
+    ; CHECK-DAG:    bf16[8,8]{1,0} pad({{.*}}), padding=0_5x0_4
       )");
+  }
 }
 
 TEST_F(CublasLtGemmRewriteTest, ApproxGeluActivationBitcast) {
@@ -2606,13 +2623,19 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  MatchOptimizedHlo(hlo_text,
-                    R"(
-
-; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
-; CHECK-DAG:    f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
-; CHECK-DAG:    f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
+    ; CHECK-DAG:    f16[6,12]{1,0}
+    ; CHECK-DAG:    f16[12,6]{1,0}
+    )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
+    ; CHECK-DAG:    f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
+    ; CHECK-DAG:    f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  }
 }
 
 // For F16, the operands are padded on GPUs with Tensor Cores (i.e. Volta and
@@ -2657,11 +2680,19 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
-  MatchOptimizedHlo(hlo_text, R"(
-; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6]) -> f16[6,6] {
-; CHECK-DAG:    f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
-; CHECK-DAG:    f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6]) -> f16[6,6] {
+    ; CHECK-DAG:    f16[6,12]{1,0}
+    ; CHECK-DAG:    f16[12,6]{1,0}
+    )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6]) -> f16[6,6] {
+    ; CHECK-DAG:    f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
+    ; CHECK-DAG:    f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  }
 }
 
 TEST_F(CublasLtGemmRewriteTest, MatrixBiasReluActivationF16) {
@@ -2757,11 +2788,19 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  MatchOptimizedHlo(hlo_text, R"(
-; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
-; CHECK-DAG:   f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
-; CHECK-DAG:   f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
+    ; CHECK-DAG:   f16[6,12]{1,0}
+    ; CHECK-DAG:   f16[12,6]{1,0}
+    )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: f16[6,12], {{.*}}: f16[12,6], {{.*}}: f16[6]) -> f16[6,6] {
+    ; CHECK-DAG:   f16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
+    ; CHECK-DAG:   f16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  }
 }
 
 // For bfloat16, the sizes of all dimensions of the operands are required to be
@@ -2899,11 +2938,19 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  MatchOptimizedHlo(hlo_text, R"(
-; CHECK-DAG:  ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
-; CHECK-DAG:    bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
-; CHECK-DAG:    bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG:  ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
+    ; CHECK-DAG:    bf16[6,12]{1,0}
+    ; CHECK-DAG:    bf16[12,6]{1,0}
+    )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG:  ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
+    ; CHECK-DAG:    bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
+    ; CHECK-DAG:    bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  }
 }
 
 // For bfloat16, the operands are padded if necessary on Ampere and newer
@@ -2955,11 +3002,19 @@ ENTRY test {
 })";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
-  MatchOptimizedHlo(hlo_text, R"(
-; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6]) -> bf16[6,6] {
-; CHECK-DAG:     bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
-; CHECK-DAG:     bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
+  if (!IsCuda()){
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6]) -> bf16[6,6] {
+    ; CHECK-DAG:     bf16[6,12]{1,0}
+    ; CHECK-DAG:     bf16[12,6]{1,0}
+    )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6]) -> bf16[6,6] {
+    ; CHECK-DAG:     bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
+    ; CHECK-DAG:     bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  }
 }
 
 // For bfloat16, the operands are padded if necessary on Ampere and newer
@@ -3018,11 +3073,19 @@ ENTRY test {
 
 )";
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
-  MatchOptimizedHlo(hlo_text, R"(
-; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
-; CHECK-DAG:     bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
-; CHECK-DAG:     bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
+  if (!IsCuda()) {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
+    ; CHECK-DAG:     bf16[6,12]{1,0}
+    ; CHECK-DAG:     bf16[12,6]{1,0}
+    )");
+  } else {
+    MatchOptimizedHlo(hlo_text, R"(
+    ; CHECK-DAG: ENTRY %test ({{.*}}: bf16[6,12], {{.*}}: bf16[12,6], {{.*}}: bf16[6]) -> bf16[6,6] {
+    ; CHECK-DAG:     bf16[8,16]{1,0} pad({{.*}}), padding=0_2x0_4
+    ; CHECK-DAG:     bf16[16,8]{1,0} pad({{.*}}), padding=0_4x0_2
       )");
+  }
 }
 
 TEST_F(CublasLtGemmRewriteTest, VectorBiasReluActivationF64) {

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -927,6 +927,7 @@ xla_test(
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -917,6 +917,7 @@ xla_test(
         "//xla/backends/gpu/runtime:buffer_debug_log_proto_cc",
         "//xla/backends/gpu/runtime:buffer_debug_log_structs",
         "//xla/backends/gpu/runtime:thunk_id",
+        "//xla/service:platform_util",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",

--- a/xla/stream_executor/gpu/buffer_debug_log_test.cc
+++ b/xla/stream_executor/gpu/buffer_debug_log_test.cc
@@ -24,11 +24,13 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/strings/ascii.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "xla/backends/gpu/runtime/buffer_debug_log.pb.h"
 #include "xla/backends/gpu/runtime/buffer_debug_log_structs.h"
 #include "xla/backends/gpu/runtime/thunk_id.h"
+#include "xla/service/platform_util.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
@@ -47,8 +49,10 @@ using ::xla::gpu::ThunkId;
 class BufferDebugLogTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    auto name = absl::AsciiStrToUpper(
+            xla::PlatformUtil::CanonicalPlatformName("gpu").value());
     TF_ASSERT_OK_AND_ASSIGN(platform_,
-                            PlatformManager::PlatformWithName("CUDA"));
+                            PlatformManager::PlatformWithName(name));
     TF_ASSERT_OK_AND_ASSIGN(executor_, platform_->ExecutorForDevice(0));
     TF_ASSERT_OK_AND_ASSIGN(stream_, executor_->CreateStream(std::nullopt));
     allocator_ =

--- a/xla/tests/sample_file_test.cc
+++ b/xla/tests/sample_file_test.cc
@@ -63,6 +63,9 @@ TEST_F(SampleFileTest, Convolution) {
       .mutable_debug_options()
       .set_xla_cpu_parallel_codegen_split_count(1);
 
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_gpu_autotune_level(4);
   EXPECT_TRUE(RunAndCompare(std::move(module), ErrorSpec{0.01}));
 }
 

--- a/xla/tsl/platform/default/build_config_root.bzl
+++ b/xla/tsl/platform/default/build_config_root.bzl
@@ -44,10 +44,7 @@ def tf_gpu_tests_tags():
 
 # terminology changes: saving tf_cuda_* for compatibility
 def tf_cuda_tests_tags():
-    if is_cuda_configured():
-        return ["requires-gpu-cuda", "gpu"] + gpu_test_tags()
-    else:
-        return []
+    return tf_gpu_tests_tags()
 
 def tf_has_tag(kwargs, tag):
     return ("tags" in kwargs and kwargs["tags"] != None and tag in kwargs["tags"])

--- a/xla/tsl/platform/default/build_config_root.bzl
+++ b/xla/tsl/platform/default/build_config_root.bzl
@@ -44,7 +44,10 @@ def tf_gpu_tests_tags():
 
 # terminology changes: saving tf_cuda_* for compatibility
 def tf_cuda_tests_tags():
-    return tf_gpu_tests_tags()
+    if is_cuda_configured():
+        return ["requires-gpu-cuda", "gpu"] + gpu_test_tags()
+    else:
+        return []
 
 def tf_has_tag(kwargs, tag):
     return ("tags" in kwargs and kwargs["tags"] != None and tag in kwargs["tags"])


### PR DESCRIPTION
📝 Summary of Changes

- layout_assignment tests are marked cuda-only.
- sample_file_test needs higher autotuner level for MIOpen to return conv algorithm. Earlier this was coming from GetDebugOptionsForTest.
- buffer_debug_log test is made gpu agnostic by using cannonical gpu name.
- cublas_gemm_rewriter_test_amdgpu_any fix unit test to remove padding for ROCm as introduced in https://github.com/openxla/xla/pull/33854 
- gpu_kernel_tiling_test_amdgpu_any is updated to respect higher launch dimensions now supported by hipruntime
- Mark dynamic_shared_memory_test as cuda-only
- Add arch specific checks for barriers to sorting.hlo


🎯 Justification
Fixes failing unit tests on ROCm platform 

🚀 Kind of Contribution
 🐛 Bug Fix, 🧪 Tests
