### PR TITLE
[xla:gpu] CommandBuffer: clean up child commands APIs

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -841,12 +841,11 @@ absl::Status TracedCommandBufferCmd::RecordTracedCommand(
       record_params,
       [&] {
         return record_params.command_buffer->CreateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
-            Dependencies(record_params));
+            *nested_cmd, Dependencies(record_params));
       },
       [&](const se::CommandBuffer::Command* cmd) {
-        return record_params.command_buffer->UpdateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, cmd, *nested_cmd);
+        return record_params.command_buffer->UpdateChildCommand(cmd,
+                                                                *nested_cmd);
       });
 }
 
@@ -1291,13 +1290,11 @@ absl::Status ChildCmd::Record(const Thunk::ExecuteParams& execute_params,
       record_params,
       [&] {
         return record_params.command_buffer->CreateChildCommand(
-            se::CommandBuffer::ChildCommandType::kMoved,
-            execute_params.stream->parent(), record_fn,
-            Dependencies(record_params));
+            record_fn, Dependencies(record_params));
       },
       [&](const se::CommandBuffer::Command* command) {
-        return record_params.command_buffer->UpdateChildCommand(
-            se::CommandBuffer::ChildCommandType::kMoved, command, record_fn);
+        return record_params.command_buffer->UpdateChildCommand(command,
+                                                                record_fn);
       });
 }
 
@@ -1451,13 +1448,11 @@ absl::Status WhileCmd::Record(const Thunk::ExecuteParams& execute_params,
         record_params,
         [&] {
           return record_params.command_buffer->CreateChildCommand(
-              se::CommandBuffer::ChildCommandType::kMoved,
-              execute_params.stream->parent(), record_fn,
-              Dependencies(record_params));
+              record_fn, Dependencies(record_params));
         },
         [&](const se::CommandBuffer::Command* command) {
-          return record_params.command_buffer->UpdateChildCommand(
-              se::CommandBuffer::ChildCommandType::kMoved, command, record_fn);
+          return record_params.command_buffer->UpdateChildCommand(command,
+                                                                  record_fn);
         });
   }
   return HandleCmdCreateOrUpdate(
@@ -1768,12 +1763,11 @@ absl::Status CustomCallCmd::RecordLegacyCustomCall(
       record_params,
       [&] {
         return record_params.command_buffer->CreateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
-            Dependencies(record_params));
+            *nested_cmd, Dependencies(record_params));
       },
       [&](const se::CommandBuffer::Command* command) {
-        return record_params.command_buffer->UpdateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, command, *nested_cmd);
+        return record_params.command_buffer->UpdateChildCommand(command,
+                                                                *nested_cmd);
       });
 }
 
@@ -1849,12 +1843,11 @@ absl::Status CustomCallCmd::RecordXlaFfiCall(
       record_params,
       [&] {
         return record_params.command_buffer->CreateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
-            Dependencies(record_params));
+            *nested_cmd, Dependencies(record_params));
       },
       [&](const se::CommandBuffer::Command* command) {
-        return record_params.command_buffer->UpdateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, command, *nested_cmd);
+        return record_params.command_buffer->UpdateChildCommand(command,
+                                                                *nested_cmd);
       });
 }
 
@@ -1907,12 +1900,11 @@ absl::Status CollectiveCmd::RecordTracedCommand(
       record_params,
       [&] {
         return record_params.command_buffer->CreateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, *nested_cmd,
-            Dependencies(record_params));
+            *nested_cmd, Dependencies(record_params));
       },
       [&](const se::CommandBuffer::Command* command) {
-        return record_params.command_buffer->UpdateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, command, *nested_cmd);
+        return record_params.command_buffer->UpdateChildCommand(command,
+                                                                *nested_cmd);
       });
 }
 
@@ -2610,13 +2602,11 @@ absl::Status DynamicSliceFusionCmd::Record(
       record_params,
       [&] {
         return record_params.command_buffer->CreateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned,
             *nested_command_buffer, Dependencies(record_params));
       },
       [&](const se::CommandBuffer::Command* command) {
         return record_params.command_buffer->UpdateChildCommand(
-            se::CommandBuffer::ChildCommandType::kCloned, command,
-            *nested_command_buffer);
+            command, *nested_command_buffer);
       });
 }
 

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -410,66 +410,68 @@ absl::Status CudaCommandBuffer::UpdateDnnGraphNode(
       "Failed to set CUDA graph child node params");
 }
 
-absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateChildNode(
-    ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
-    CommandBuffer& nested) {
-  auto& child_command_buffer =
-      tensorflow::down_cast<CudaCommandBuffer&>(nested);
-  CHECK(child_command_buffer.parent_ == nullptr)
+absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateClonedChildNode(
+    absl::Span<const GraphNodeHandle> dependencies,
+    const CommandBuffer& nested) {
+  auto& child_command_buffer = tsl::down_cast<const CudaCommandBuffer&>(nested);
+  CHECK_EQ(child_command_buffer.parent_, nullptr)
       << "Nested command buffer's parent is not null";
-  child_command_buffer.parent_ = this;
+
   CUgraph child_graph = child_command_buffer.graph_;
+  std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
+
   VLOG(2) << "Create a new node by cloning the child graph " << child_graph
           << " and add it to " << graph_ << "; deps: " << dependencies.size();
 
-  std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
-
   CUgraphNode node_handle;
-  if (type == ChildCommandType::kCloned) {
-    TF_RETURN_IF_ERROR(cuda::ToStatus(
-        cuGraphAddChildGraphNode(&node_handle, graph_, deps.data(), deps.size(),
-                                 child_graph),
-        "Failed to create a child graph node and add it to a CUDA graph"));
-    VLOG(5) << "CreateClonedChildNode: "
-            << reinterpret_cast<const void*>(&node_handle);
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuGraphAddChildGraphNode(&node_handle, graph_, deps.data(), deps.size(),
+                               child_graph),
+      "Failed to create a child graph node and add it to a CUDA graph"));
 
-    return FromCudaGraphHandle(node_handle);
-
-  } else if (type == ChildCommandType::kMoved) {
-#if CUDA_VERSION >= 12090
-    child_command_buffer.is_owned_graph_ = false;
-    CUgraphNodeParams nodeParams;
-    std::memset(&nodeParams, 0, sizeof(nodeParams));
-    nodeParams.type = CU_GRAPH_NODE_TYPE_GRAPH;
-    nodeParams.graph.graph = child_graph;
-    nodeParams.graph.ownership = CU_GRAPH_CHILD_GRAPH_OWNERSHIP_MOVE;
-    VLOG(2) << "Create a new node by moving the child graph " << child_graph
-            << " and add it to " << graph_ << "; deps: " << dependencies.size();
-
-    std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
-
-    CUgraphNode node_handle;
-    TF_RETURN_IF_ERROR(cuda::ToStatus(
-        cuGraphAddNode_v2(&node_handle, graph_, deps.data(),
-                          /*dependencyData=*/nullptr, deps.size(), &nodeParams),
-        "Failed to create a child graph node and add it to a CUDA graph"));
-    return FromCudaGraphHandle(node_handle);
-#else
-    return absl::UnimplementedError(
-        "Moved child node is not supported for CUDA < 12.9");
-#endif
-  } else {
-    return absl::InternalError("Unsupported child command type");
-  }
+  return FromCudaGraphHandle(node_handle);
 }
 
-absl::Status CudaCommandBuffer::UpdateChildNode(ChildCommandType type,
-                                                GraphNodeHandle node_handle,
-                                                const CommandBuffer& nested) {
-  CHECK(type == ChildCommandType::kCloned)
-      << "Moved child node update is not supported";
-  CUgraph child_graph =
-      tensorflow::down_cast<const CudaCommandBuffer&>(nested).graph_;
+absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateMovedChildNode(
+    absl::Span<const GraphNodeHandle> dependencies, CommandBuffer* nested) {
+  auto* child_command_buffer = tsl::down_cast<CudaCommandBuffer*>(nested);
+  CHECK_EQ(child_command_buffer->parent_, nullptr)
+      << "Nested command buffer's parent is not null";
+
+  CUgraph child_graph = child_command_buffer->graph_;
+  std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
+
+  VLOG(2) << "Create a new node by moving the child graph " << child_graph
+          << " and add it to " << graph_ << "; deps: " << dependencies.size();
+
+  // When we move the ownership of the graph to *this command buffer, we must
+  // make sure that we don't accidentally destroy it, and that graph updates
+  // will find an executable that corresponds to the top-level command buffer.
+  child_command_buffer->parent_ = this;
+  child_command_buffer->is_owned_graph_ = false;
+
+#if CUDA_VERSION >= 12090
+  CUgraphNodeParams nodeParams{};
+  nodeParams.type = CU_GRAPH_NODE_TYPE_GRAPH;
+  nodeParams.graph.graph = child_graph;
+  nodeParams.graph.ownership = CU_GRAPH_CHILD_GRAPH_OWNERSHIP_MOVE;
+
+  CUgraphNode node_handle;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuGraphAddNode_v2(&node_handle, graph_, deps.data(),
+                        /*dependencyData=*/nullptr, deps.size(), &nodeParams),
+      "Failed to create a child graph node and add it to a CUDA graph"));
+
+  return FromCudaGraphHandle(node_handle);
+#else
+  return absl::UnimplementedError(
+      "Moved child node is not supported for CUDA < 12.9");
+#endif
+}
+
+absl::Status CudaCommandBuffer::UpdateClonedChildNode(
+    GraphNodeHandle node_handle, const CommandBuffer& nested) {
+  CUgraph child_graph = tsl::down_cast<const CudaCommandBuffer&>(nested).graph_;
   VLOG(2) << "Set child node params " << node_handle << " in graph executable "
           << graph_exec() << " to params contained in " << child_graph;
 

--- a/xla/stream_executor/cuda/cuda_command_buffer.h
+++ b/xla/stream_executor/cuda/cuda_command_buffer.h
@@ -132,13 +132,16 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
                                   absl::Span<DeviceAddressBase> operands,
                                   GraphNodeHandle) override;
 
-  absl::StatusOr<GraphNodeHandle> CreateChildNode(
-      ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
-      CommandBuffer& nested) override;
+  absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      const CommandBuffer& nested) override;
 
-  absl::Status UpdateChildNode(ChildCommandType type,
-                               GraphNodeHandle node_handle,
-                               const CommandBuffer& nested) override;
+  absl::StatusOr<GraphNodeHandle> CreateMovedChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      CommandBuffer* nested) override;
+
+  absl::Status UpdateClonedChildNode(GraphNodeHandle node_handle,
+                                     const CommandBuffer& nested) override;
 
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(
       absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -128,9 +128,7 @@ xla_cc_test(
 cc_library(
     name = "gpu_command_buffer",
     srcs = ["gpu_command_buffer.cc"],
-    hdrs = [
-        "gpu_command_buffer.h",
-    ],
+    hdrs = ["gpu_command_buffer.h"],
     deps = [
         "//xla:debug_options_flags",
         "//xla/service:dump",
@@ -157,7 +155,6 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:casts",
-        "@tsl//tsl/platform:path",
     ],
 )
 

--- a/xla/stream_executor/gpu/gpu_command_buffer_test.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer_test.cc
@@ -201,10 +201,8 @@ TEST(GpuCommandBufferTest, LaunchNestedCommandBuffer) {
                           executor->CreateCommandBuffer(nested));
   TF_ASSERT_OK(
       nested_cmd->CreateLaunch(add, ThreadDim(), BlockDim(4), {}, a, b, c));
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto* nested_command,
-      primary_cmd->CreateChildCommand(CommandBuffer::ChildCommandType::kCloned,
-                                      *nested_cmd, {}));
+  TF_ASSERT_OK_AND_ASSIGN(auto* nested_command,
+                          primary_cmd->CreateChildCommand(*nested_cmd, {}));
   TF_ASSERT_OK(primary_cmd->Finalize());
 
   TF_ASSERT_OK(primary_cmd->Submit(stream.get()));
@@ -226,8 +224,7 @@ TEST(GpuCommandBufferTest, LaunchNestedCommandBuffer) {
   TF_ASSERT_OK(
       nested_cmd->CreateLaunch(add, ThreadDim(), BlockDim(4), {}, a, b, d));
   TF_ASSERT_OK(primary_cmd->Update());
-  TF_ASSERT_OK(primary_cmd->UpdateChildCommand(
-      CommandBuffer::ChildCommandType::kCloned, nested_command, *nested_cmd));
+  TF_ASSERT_OK(primary_cmd->UpdateChildCommand(nested_command, *nested_cmd));
   TF_ASSERT_OK(primary_cmd->Finalize());
 
   TF_ASSERT_OK(primary_cmd->Submit(stream.get()));
@@ -719,8 +716,7 @@ TEST(GpuCommandBufferTest, DISABLED_WhileNestedConditional) {
 
   CommandBuffer::CreateCommands create_body = [&](CommandBuffer* body_cmd,
                                                   auto deps) {
-    return Wrap(body_cmd->CreateChildCommand(
-        CommandBuffer::ChildCommandType::kCloned, *nested_cmd, deps));
+    return Wrap(body_cmd->CreateChildCommand(*nested_cmd, deps));
   };
 
   // Create a command buffer with a single conditional operation.

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -217,11 +217,9 @@ absl::Status RocmCommandBuffer::UpdateMemcpyD2DNode(
       "Failed to set memcpy d2d node params");
 }
 
-absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateChildNode(
-    ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
-    CommandBuffer& nested) {
-  CHECK(type == ChildCommandType::kCloned)
-      << "Moved child node creation is not supported";
+absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateClonedChildNode(
+    absl::Span<const GraphNodeHandle> dependencies,
+    const CommandBuffer& nested) {
   auto& child_command_buffer =
       tensorflow::down_cast<RocmCommandBuffer&>(nested);
   CHECK(child_command_buffer.parent_ == nullptr)
@@ -241,11 +239,13 @@ absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateChildNode(
   return FromHipGraphHandle(node_handle);
 }
 
-absl::Status RocmCommandBuffer::UpdateChildNode(ChildCommandType type,
-                                                GraphNodeHandle node_handle,
-                                                const CommandBuffer& nested) {
-  CHECK(type == ChildCommandType::kCloned)
-      << "Moved child node update is not supported";
+absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateMovedChildNode(
+    absl::Span<const GraphNodeHandle> dependencies, CommandBuffer* nested) {
+  return absl::UnimplementedError("Moved child nodes are not supported");
+}
+
+absl::Status RocmCommandBuffer::UpdateClonedChildNode(
+    GraphNodeHandle node_handle, const CommandBuffer& nested) {
   hipGraph_t child_graph =
       tensorflow::down_cast<const RocmCommandBuffer&>(nested).graph_;
 

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -119,13 +119,16 @@ class RocmCommandBuffer : public GpuCommandBuffer {
     return absl::UnimplementedError("Not implemented.");
   }
 
-  absl::StatusOr<GraphNodeHandle> CreateChildNode(
-      ChildCommandType type, absl::Span<const GraphNodeHandle> dependencies,
-      CommandBuffer& nested) override;
+  absl::StatusOr<GraphNodeHandle> CreateClonedChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      const CommandBuffer& nested) override;
 
-  absl::Status UpdateChildNode(ChildCommandType type,
-                               GraphNodeHandle node_handle,
-                               const CommandBuffer& nested) override;
+  absl::StatusOr<GraphNodeHandle> CreateMovedChildNode(
+      absl::Span<const GraphNodeHandle> dependencies,
+      CommandBuffer* nested) override;
+
+  absl::Status UpdateClonedChildNode(GraphNodeHandle node_handle,
+                                     const CommandBuffer& nested) override;
 
   absl::StatusOr<GraphNodeHandle> CreateKernelNode(
       absl::Span<const GraphNodeHandle> dependencies, StreamPriority priority,


### PR DESCRIPTION
Instead of a enum that was used inconsistently (ignored in half of the API calls), introduce a document two separate APIs for creating child command buffers:

1. Create a clone of a pre-recorded command buffer and later update it with a new clone
2. Create a "managed" command buffer whose lifetime tied to a parent command buffer