### PR TITLE
[xla:gpu] It's a CUDA UB to memcpy to/from same buffer

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -709,8 +709,7 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
   middle_seq.Emplace<ChildCmd>(std::move(inner_executor));
   // Add a couple of extra commands that don't affect `c`.
   middle_seq.Emplace<Memset32Cmd>(slice_b, /*bit_pattern=*/3);
-  middle_seq.Emplace<MemcpyDeviceToDeviceCmd>(
-      ShapedSlice{slice_b, shape}, ShapedSlice{slice_b, shape}, byte_length);
+  middle_seq.Emplace<Memset32Cmd>(slice_b, /*bit_pattern=*/5);
   TF_ASSERT_OK_AND_ASSIGN(
       CommandBufferCmdExecutor middle_executor,
       CommandBufferCmdExecutor::Create(std::move(middle_seq), serialize));


### PR DESCRIPTION
We don't care what command is executing in nested command buffer as we overwrite the memory in the outer command buffer later. Remove UB from the test as it leads to flakiness.

