### PR TITLE
Fix test CommandBufferTest.DynamicSliceCopyFusionCmd  failure

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -1523,7 +1523,11 @@ absl::Status WhileCmd::Initialize(const Thunk::InitializeParams& params,
       cond_commands_.support_loop_unroll() && trip_count_ != std::nullopt) {
     is_unrolled_loop_ = true;
   }
-  VLOG(3) << "while command trip_count: " << trip_count_.value_or(-1);
+  VLOG(3) << "WhileCmd::Initialize: enable_loop_unroll_=" << enable_loop_unroll_
+          << ", body_support=" << body_commands_.support_loop_unroll()
+          << ", cond_support=" << cond_commands_.support_loop_unroll()
+          << ", trip_count=" << trip_count_.value_or(-1)
+          << ", is_unrolled_loop_=" << is_unrolled_loop_;
   return absl::OkStatus();
 }
 

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
@@ -341,10 +341,13 @@ ConvertThunksToCommandBuffer(
     std::vector<std::unique_ptr<Thunk>> thunks_to_convert,
     CommandBufferCmdExecutor::SynchronizationMode synchronization_mode,
     const DebugOptions& debug_options) {
+  bool enable_loop_unroll =
+      debug_options.xla_gpu_command_buffer_unroll_loops();
   TF_ASSIGN_OR_RETURN(
       CommandBufferCmdExecutor cmd_executor,
       ConvertToCommands(thunks_to_convert,
-                        ConvertToCommandsOptions{synchronization_mode}));
+                        ConvertToCommandsOptions{synchronization_mode,
+                                                 enable_loop_unroll}));
 
   Thunk::ThunkInfo thunk_info;
   thunk_info.profile_annotation = "command_buffer";

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1663,6 +1663,7 @@ cc_library(
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",


### PR DESCRIPTION
There are 3 bugs in XLA which accidently makes test CommandBufferTest.DynamicSliceCopyFusionCmd passed.

1. When lowering the command buffer WhileCmd, the nested body command buffer is not setting its parent properly, this leads to assertion failure when doing the update. 

2. In WhileCmd::Initialize(), enable_loop_unroll_ is hardcoded to 1, which was original for debug purpose, but forget to remove it. 

3. The command_buffer_conversion_pass is not passing the debug flags xla_gpu_command_buffer_unroll_loops down to the command_buffer_cmd_emitter. 

This PR fixed the above issue, and the test PASSed as expected. 
