### PR TITLE
Enable .clang-format header sorting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,40 @@
 BasedOnStyle: Google
 Language: Cpp
 PointerBindsToType: true
-SortIncludes: Never
 AlignTrailingComments:
   Kind: Always
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Priority 1: Standard C/C++ headers (angle brackets) - separated by blank line
+  - Regex:    '^<.*>$'
+    Priority: 1
+    SortPriority: 1
+  # Priority 2: All other headers (no blank lines between them, sorted by SortPriority)
+  # absl headers
+  - Regex:    '^"absl/.*"$'
+    Priority: 2
+    SortPriority: 2
+  # llvm headers
+  - Regex:    '^"llvm/.*"$'
+    Priority: 2
+    SortPriority: 3
+  # mlir headers
+  - Regex:    '^"mlir/.*"$'
+    Priority: 2
+    SortPriority: 4
+  # google (protobuf, etc.) headers
+  - Regex:    '^"google/.*"$'
+    Priority: 2
+    SortPriority: 5
+  # xla headers (including xla/tsl)
+  - Regex:    '^"xla/.*"$'
+    Priority: 2
+    SortPriority: 6
+  # tsl headers (without xla/ prefix)
+  - Regex:    '^"tsl/.*"$'
+    Priority: 2
+    SortPriority: 7
+  # Default catch-all for any other headers
+  - Regex:    '.*'
+    Priority: 2
+    SortPriority: 100


### PR DESCRIPTION
Enable .clang-format header sorting using custom rules that would preserve the order of headers inside internal google repo