### PR TITLE
[xla:gpu] Extract Command into a separate target

### DIFF
--- a/xla/backends/gpu/profiler/BUILD
+++ b/xla/backends/gpu/profiler/BUILD
@@ -73,6 +73,7 @@ xla_test(
     ],
     deps = [
         ":kernel_name_tracer",
+        "//xla/backends/gpu/runtime:command",
         "//xla/backends/gpu/runtime:command_buffer_cmd",
         "//xla/backends/gpu/runtime:command_buffer_thunk",
         "//xla/backends/gpu/runtime:thunk",

--- a/xla/backends/gpu/profiler/kernel_name_tracer_test.cc
+++ b/xla/backends/gpu/profiler/kernel_name_tracer_test.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
+#include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_buffer_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
@@ -155,7 +156,7 @@ void LaunchCommandBufferThunk(stream_executor::StreamExecutor* executor,
                       BufferUse::MemoryAccess::kWrite};
 
   // Prepare commands sequence for constructing command buffer.
-  CommandBufferCmdSequence commands;
+  CommandSequence commands;
   commands.Emplace<LaunchCmd>("AddI32", args, args_access,
                               LaunchDimensions(1, kLength),
                               /*shmem_bytes=*/0);

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -81,6 +81,20 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "command",
+    srcs = ["command.cc"],
+    hdrs = ["command.h"],
+    deps = [
+        ":command_state",
+        ":thunk",
+        "//xla/runtime:buffer_use",
+        "//xla/runtime:resource_use",
+        "//xla/stream_executor:command_buffer",
+        "//xla/stream_executor:platform",
+    ],
+)
+
+cc_library(
     name = "command_buffer_cmd",
     srcs = ["command_buffer_cmd.cc"],
     hdrs = ["command_buffer_cmd.h"],
@@ -93,6 +107,7 @@ cc_library(
         ":collective_execution",
         ":collective_permute_thunk",
         ":collective_thunk",
+        ":command",
         ":command_state",
         ":copy_thunk",
         ":custom_call_thunk",
@@ -174,6 +189,7 @@ xla_test(
     srcs = ["command_buffer_cmd_test.cc"],
     backends = ["gpu"],
     deps = [
+        ":command",
         ":command_buffer_cmd",
         ":command_state",
         ":copy_thunk",
@@ -221,6 +237,7 @@ cc_library(
         ":collective_broadcast_thunk",
         ":collective_permute_thunk",
         ":collective_thunk",
+        ":command",
         ":command_buffer_cmd",
         ":command_state",
         ":conditional_thunk",
@@ -354,6 +371,7 @@ cc_library(
     srcs = ["command_buffer_thunk.cc"],
     hdrs = ["command_buffer_thunk.h"],
     deps = [
+        ":command",
         ":command_buffer_cmd",
         ":command_state",
         ":sequential_thunk",  # build_cleaner: keep
@@ -385,6 +403,7 @@ xla_test(
     srcs = ["command_buffer_thunk_test.cc"],
     backends = ["gpu"],
     deps = [
+        ":command",
         ":command_buffer_cmd",
         ":command_buffer_thunk",
         ":dynamic_slice_thunk",
@@ -436,6 +455,7 @@ xla_test(
     backends = ["gpu"],
     tags = ["cuda-only"],
     deps = [
+        ":command",
         ":command_buffer_cmd",
         ":command_buffer_thunk",
         ":thunk",

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -76,7 +76,11 @@ xla_cc_test(
     deps = [
         ":command_state",
         "//xla/tsl/platform:test",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/profiler/lib:profiler_lock",
     ],
 )
 

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -76,11 +76,7 @@ xla_cc_test(
     deps = [
         ":command_state",
         "//xla/tsl/platform:test",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/profiler/lib:profiler_lock",
     ],
 )
 

--- a/xla/backends/gpu/runtime/command.cc
+++ b/xla/backends/gpu/runtime/command.cc
@@ -1,0 +1,44 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/command.h"
+
+namespace xla::gpu {
+
+std::string CommandTypeString(CommandType type) {
+  switch (type) {
+#define CASE_CMD_STRING(enum_name, cmd_name, ...) \
+  case CommandType::enum_name:                    \
+    return cmd_name;
+    XLA_GPU_COMMAND_LIST(CASE_CMD_STRING)
+#undef CASE_CMD_STRING
+  }
+}
+
+bool IsCollectiveCommand(CommandType type) {
+  switch (type) {
+    case CommandType::kAllGatherCmd:
+    case CommandType::kAllReduceCmd:
+    case CommandType::kAllToAllCmd:
+    case CommandType::kReduceScatterCmd:
+    case CommandType::kCollectiveBroadcastCmd:
+    case CommandType::kCollectivePermuteCmd:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -1,0 +1,310 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_COMMAND_H_
+#define XLA_BACKENDS_GPU_RUNTIME_COMMAND_H_
+
+#include <string>
+
+#include "xla/backends/gpu/runtime/command_state.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/runtime/buffer_use.h"
+#include "xla/runtime/resource_use.h"
+#include "xla/stream_executor/command_buffer.h"
+
+namespace xla::gpu {
+
+//===----------------------------------------------------------------------===//
+// CommandType
+//===----------------------------------------------------------------------===//
+
+// clang-format off
+#define XLA_GPU_COMMAND_LIST(V)                              \
+  V(kEmptyCmd, "EmptyCmd")                                   \
+  V(kChildCmd, "ChildCmd")                                   \
+  V(kTracedCommand, "TracedCommand")       \
+  V(kComputationIdCmd, "ComputationIdCmd")                   \
+  V(kLaunchCmd, "LaunchCmd")                                 \
+  V(kCustomKernelLaunchCmd, "CustomKernelLaunchCmd")         \
+  V(kCublasLtCmd, "CublasLtCmd")                             \
+  V(kCuDnnCmd, "CuDnnCmd")                                   \
+  V(kGemmCmd, "GemmCmd")                                     \
+  V(kMemcpyDeviceToDeviceCmd, "MemcpyDeviceToDeviceCmd")     \
+  V(kMemzeroCmd, "MemzeroCmd")                               \
+  V(kMemset32Cmd, "Memset32Cmd")                             \
+  V(kCaseCmd, "CaseCmd")                                     \
+  V(kWhileCmd, "WhileCmd")                                   \
+  V(kCustomCallCmd, "CustomCallCmd")                         \
+  V(kBarrierCmd, "BarrierCmd")                               \
+  V(kCollectiveCmd, "CollectiveCmd")                         \
+  V(kAllReduceCmd, "AllReduceCmd")                           \
+  V(kReduceScatterCmd, "ReduceScatterCmd")                   \
+  V(kAllToAllCmd, "AllToAllCmd")                             \
+  V(kAllGatherCmd, "AllGatherCmd")                           \
+  V(kCollectiveBroadcastCmd, "CollectiveBroadcastCmd")       \
+  V(kCollectivePermuteCmd, "CollectivePermuteCmd")           \
+  V(kAsyncDone, "AsyncDone")                                 \
+  V(kDynamicSliceFusionCmd, "DynamicSliceFusionCmd")         \
+  V(kDynamicSliceCopyFusionCmd, "DynamicSliceCopyFusionCmd") \
+  V(kUnknownCmd, "UnknownCmd") \
+  // clang-format on
+
+enum class CommandType : int32_t {
+#define DECLARE_ENUM(enum_name, cmd_name, ...) enum_name,
+  XLA_GPU_COMMAND_LIST(DECLARE_ENUM)
+#undef DECLARE_ENUM
+};
+
+std::string CommandTypeString(CommandType type);
+
+template <typename Sink>
+void AbslStringify(Sink& sink, CommandType type) {
+  sink.Append(CommandTypeString(type));
+}
+
+// Returns true if command type corresponds to a collective operation.
+bool IsCollectiveCommand(CommandType type);
+
+//===----------------------------------------------------------------------===//
+// Command
+//===----------------------------------------------------------------------===//
+
+// Command is a Thunk counterpart that instead of launching operations directly
+// on the underlying device records them into command buffers.
+//
+// Commands have the same execution stages as thunks as they are executed by a
+// command buffer thunk: Prepare, Initialize and Record (Execute). See Thunk
+// documentation for details.
+//
+// Commands must be thread safe as they can be recorded into multiple command
+// buffers concurrently on different stream executors.
+//
+// IMPORTANT: In contrast to GPU thunks, commands MUST be stateless. Thunk state
+// typically belongs to the Thunk instance itself, and tends to be kept in
+// synchronized hash maps keyed by `se::StreamExecutor*` pointer.
+// Commands on the other hand should attach state to the underlying command
+// buffer, and because the number of command buffers that can be instantiated
+// from a command sequence is unbounded (as we have an eviction policy for
+// command buffers), keeping a state in a map inside the command will lead to
+// memory leaks.
+//
+// Commands have an external state manager, which is responsible for managing
+// the lifetime of command state. See `CommandState` and
+// `CommandCommandStateManager` documentation for details and example. If
+// command want's to attach some mutable state to the command buffer, it must be
+// done with a state manager.
+class Command {
+ public:
+  using BufferUseVector = absl::InlinedVector<BufferUse, 4>;
+  using ResourceUseVector = absl::InlinedVector<ResourceUse, 1>;
+
+ public:
+  explicit Command(CommandType cmd_type,
+                   se::StreamPriority priority = se::StreamPriority::Default)
+      : cmd_type_(cmd_type), priority_(priority) {
+    token_ = Resource::Create(Resource::kToken);
+    resources_.push_back(ResourceUse::Write(token_));
+  }
+
+  virtual ~Command() = default;
+
+  // Parameters for recording commands into the command buffer.
+  struct RecordParams {
+    // An external state manager that gives efficient access to per-device state
+    // to commands without a need to add expensive synchronization.
+    CommandStateManager& state;
+
+    // Buffer allocations that changed since the last call to `Record`. Buffer
+    // allocation indices are sorted. CommandBufferCmdExecutor and individual
+    // commands rely on this information to skip unnecessary updates.
+    std::optional<std::vector<BufferAllocation::Index>> updated_allocs;
+
+    // A flag indicating whether we record comands at command buffer thunk
+    // initialization time.
+    bool is_initialization = false;
+
+    // The command sequence might be recorded in the loop unrolling pattern, so
+    // the command sequence might be instantiated multiple times, we uses
+    // unroll_iteration to locate the commands for current unroll iteration.
+    int64_t unroll_iteration = 0;
+  };
+
+  // Create new commands in the command buffer using the given dependencies.
+  struct RecordCreate {
+    absl::Span<const se::CommandBuffer::Command* const> dependencies;
+  };
+
+  // Update previously recorded commands in the command buffer.
+  struct RecordUpdate {
+    const se::CommandBuffer::Command* command;
+  };
+
+  // When recording a command into the command buffer we can either update
+  // previously recorded commands or create new ones. The command DAG structure
+  // can be defined only when we record commands the first time, after that we
+  // can only update previously recorded commands parameters (i.e. with pointers
+  // to new buffer allocations).
+  using RecordAction = std::variant<RecordCreate, RecordUpdate>;
+
+  // See Thunk documentation for XLA execution stages (prepare, initialize,
+  // execute). Commands mirror thunks as they are executed as CommandBufferThunk
+  // that is plugged into the Thunk execution cycle.
+
+  // Prepare command for execution by allowing command to request shared state
+  // required for recording (i.e. collective commands request cliques).
+  virtual absl::Status Prepare(const Thunk::PrepareParams& params) {
+    return absl::OkStatus();
+  }
+
+  // Initialize a command for recording on a given executor. We split it into a
+  // separate function to allow expensive initialization (e.g. device kernel
+  // loading) to happen before a command buffer thunk execution.
+  virtual absl::Status Initialize(const Thunk::InitializeParams& params,
+                                  CommandStateManager& state) {
+    return absl::OkStatus();
+  }
+
+  // Records commands into the command buffer. Returned commands will be passed
+  // back on the next call to `Record` into the same command buffer, so that it
+  // can do efficient command buffer updates.
+  virtual absl::StatusOr<const se::CommandBuffer::Command*> Record(
+      const Thunk::ExecuteParams& execute_params,
+      const RecordParams& record_params, RecordAction record_action,
+      se::CommandBuffer* command_buffer) {
+    return absl::UnimplementedError("Record is not implemented");
+  }
+
+  // Returns true if command requires initialization (has to be recorded at
+  // command buffer thunk initialization).
+  //
+  // Today this is only true for collective commands that might use NCCL for
+  // communication. With NCCL, all participating ranks must record collective
+  // commands at the same time, if some ranks will skip command updates (because
+  // they got lucky and got the same buffer allocations), it will lead to
+  // deadlocks. By forcing the command update at thunk initialization time, we
+  // ensure that all ranks execute NCCL command update.
+  virtual bool requires_initialization() { return false; }
+
+  // Returns true if command supports loop unroll, the while loop can be
+  // unrolled only if it has pre-known trip count and also all commands from the
+  // body commands are unrollable..
+  virtual bool support_loop_unroll() { return true; }
+
+  // This is only true for DynamicSliceCopyFusionCmd when offset is dependents
+  // on loop iteration. As the command of slice operation is access the sliced
+  // memory region that varies across loop iterations, so even the original
+  // buffer allocation is the same, it still requires to do update.
+  virtual bool force_update() { return false; }
+
+  // Returns all buffers used by the cmd. These will be used to track cmd
+  // updates, thus they need to be consistent across calls to the function.
+  virtual BufferUseVector buffers() const { return {}; }
+
+  std::shared_ptr<Resource> token() const { return token_; }
+
+  void add_resouce_use(ResourceUse resource_use) {
+    resources_.push_back(resource_use);
+  }
+  ResourceUseVector resources() const { return resources_; }
+
+  // Returns true if command implemented as a nested command buffer.
+  virtual bool IsNestedCommandBuffer() const { return false; }
+
+  absl::string_view profile_annotation() const { return profile_annotation_; }
+  void set_profile_annotation(absl::string_view profile_annotation) {
+    profile_annotation_ = profile_annotation;
+  }
+
+  CommandType command_type() const { return cmd_type_; }
+  se::StreamPriority priority() const { return priority_; }
+  void set_priority(se::StreamPriority priority) { priority_ = priority; }
+
+  virtual std::string ToString() const { return CommandTypeString(cmd_type_); }
+
+ private:
+  std::string profile_annotation_;
+  CommandType cmd_type_;
+
+  ResourceUseVector resources_;
+
+  // The token resource is used to specify additional dependency across
+  // commands, like control dependency across HLO operators, and LHS scheduling
+  // dependency.
+  std::shared_ptr<Resource> token_;
+
+  // Command priority, currently only support default, lowest and highest
+  // priority.
+  se::StreamPriority priority_ = se::StreamPriority::Default;
+};
+
+// Returns true if command is a collective one.
+inline bool IsCollectiveCommand(const Command& cmd) {
+  return IsCollectiveCommand(cmd.command_type());
+}
+
+//===----------------------------------------------------------------------===//
+// Asynchronous commands
+//===----------------------------------------------------------------------===//
+
+// A base class for a command that starts an asyncrhonous execution.
+class AsyncStartCommand : public Command {
+ public:
+  using Command::Command;
+
+  // At run time async command might behave like a syncrhonous one, i.e.
+  // some collective operations if they can't be overlapped with compute
+  // operations executed like they have syncrhonous execution semantics.
+  virtual bool IsAsync() const = 0;
+};
+
+// A command that completes an `async_start` command.
+class AsyncDoneCommand : public Command {
+ public:
+  explicit AsyncDoneCommand(const AsyncStartCommand* async_start)
+      : Command(CommandType::kAsyncDone), async_start_(async_start) {
+    DCHECK(async_start_) << "AsyncStart command must be not null";
+  }
+
+  const AsyncStartCommand* async_start() const { return async_start_; }
+  bool IsAsync() const { return async_start_->IsAsync(); }
+
+ private:
+  const AsyncStartCommand* async_start_;
+};
+
+//===----------------------------------------------------------------------===//
+// CommandSequence
+//===----------------------------------------------------------------------===//
+
+// A sequence of commands (corresponds to a ThunkSequence from the Thunk API).
+class CommandSequence : public std::vector<std::unique_ptr<Command>> {
+ public:
+  template <typename Command, typename... Args>
+  void Emplace(Args&&... args) {
+    this->emplace_back(std::make_unique<Command>(std::forward<Args>(args)...));
+  }
+
+  std::string ToString() const {
+    std::string result;
+    for (const auto& cmd : *this) {
+      result += cmd->ToString() + "\n";
+    }
+    return result;
+  }
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_COMMAND_H_

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "llvm/ADT/STLExtras.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/runtime/all_gather_thunk.h"
 #include "xla/backends/gpu/runtime/all_reduce_thunk.h"
@@ -102,7 +103,6 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/types.h"  // IWYU pragma: keep
 #include "xla/util.h"
-#include "tsl/profiler/lib/scoped_annotation.h"
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -43,7 +43,6 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
-#include "llvm/ADT/STLExtras.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/runtime/all_gather_thunk.h"
@@ -54,6 +53,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/collective_execution.h"
 #include "xla/backends/gpu/runtime/collective_permute_thunk.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
+#include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/command_state.h"
 #include "xla/backends/gpu/runtime/copy_thunk.h"
 #include "xla/backends/gpu/runtime/dynamic_slice_thunk.h"
@@ -123,18 +123,6 @@ Literal& Indvar(DynamicSliceFusionCmd* cmd) {
 }
 }  // namespace
 
-std::string CommandBufferCmdString(CommandBufferCmdType type) {
-  switch (type) {
-#define CASE_CMD_STRING(enum_name, cmd_name, ...) \
-  case CommandBufferCmdType::enum_name:           \
-    return cmd_name;
-    COMMAND_BUFFER_CMD_LIST(CASE_CMD_STRING)
-#undef CASE_CMD_STRING
-    default:
-      return "UnknownCmd";
-  }
-}
-
 static absl::string_view ReductionKindString(ReductionKind kind) {
   switch (kind) {
     case ReductionKind::MAX:
@@ -152,7 +140,7 @@ static absl::string_view ReductionKindString(ReductionKind kind) {
 static se::CommandBuffer::CreateCommands CreateCommands(
     const CommandBufferCmdExecutor* commands,
     const Thunk::ExecuteParams* execute_params,
-    const CommandBufferCmd::RecordParams* record_params) {
+    const Command::RecordParams* record_params) {
   return [=](se::CommandBuffer* command_buffer,
              absl::Span<const se::CommandBuffer::Command* const> dependencies) {
     return commands->RecordCreate(*execute_params, *record_params,
@@ -164,7 +152,7 @@ static se::CommandBuffer::CreateCommands CreateCommands(
 static std::vector<se::CommandBuffer::CreateCommands> CreateCommands(
     absl::Span<const CommandBufferCmdExecutor> commands,
     const Thunk::ExecuteParams* execute_params,
-    const CommandBufferCmd::RecordParams* record_params) {
+    const Command::RecordParams* record_params) {
   std::vector<se::CommandBuffer::CreateCommands> create_commands;
   for (const CommandBufferCmdExecutor& cmd : commands) {
     create_commands.push_back(
@@ -177,7 +165,7 @@ static std::vector<se::CommandBuffer::CreateCommands> CreateCommands(
 static se::CommandBuffer::UpdateCommands UpdateCommands(
     const CommandBufferCmdExecutor* commands,
     const Thunk::ExecuteParams* execute_params,
-    const CommandBufferCmd::RecordParams* record_params) {
+    const Command::RecordParams* record_params) {
   return [=](se::CommandBuffer* command_buffer) {
     return commands->RecordUpdate(*execute_params, *record_params,
                                   command_buffer);
@@ -188,7 +176,7 @@ static se::CommandBuffer::UpdateCommands UpdateCommands(
 static std::vector<se::CommandBuffer::UpdateCommands> UpdateCommands(
     absl::Span<const CommandBufferCmdExecutor> commands,
     const Thunk::ExecuteParams* execute_params,
-    const CommandBufferCmd::RecordParams* record_params) {
+    const Command::RecordParams* record_params) {
   std::vector<se::CommandBuffer::UpdateCommands> update_commands;
   for (const CommandBufferCmdExecutor& cmd : commands) {
     update_commands.push_back(
@@ -198,7 +186,7 @@ static std::vector<se::CommandBuffer::UpdateCommands> UpdateCommands(
 }
 
 //===----------------------------------------------------------------------===//
-// CommandBufferCmd::RecordAction helpers.
+// Command::RecordAction helpers.
 //===----------------------------------------------------------------------===//
 
 using CreateCommand =
@@ -210,13 +198,13 @@ using UpdateCommand =
 
 // Handles a record action by calling one of the user-provided functions.
 static absl::StatusOr<const se::CommandBuffer::Command*> Handle(
-    CommandBufferCmd::RecordAction action, CreateCommand create_command,
+    Command::RecordAction action, CreateCommand create_command,
     UpdateCommand update_command) {
-  if (auto* create = std::get_if<CommandBufferCmd::RecordCreate>(&action)) {
+  if (auto* create = std::get_if<Command::RecordCreate>(&action)) {
     return create_command(create->dependencies);
   }
 
-  if (auto* update = std::get_if<CommandBufferCmd::RecordUpdate>(&action)) {
+  if (auto* update = std::get_if<Command::RecordUpdate>(&action)) {
     TF_RETURN_IF_ERROR(update_command(update->command));
     return update->command;
   }
@@ -233,8 +221,8 @@ namespace {
 // execution graph from a command sequence.
 class CommandOperation : public ExecutionGraph::Operation {
  public:
-  explicit CommandOperation(CommandBufferCmd::BufferUseVector buffers,
-                            const CommandBufferCmd* cmd)
+  explicit CommandOperation(Command::BufferUseVector buffers,
+                            const Command* cmd)
       : name_(absl::StrFormat("cmd %s: %s", cmd->ToString(),
                               cmd->profile_annotation())),
         buffers_(std::move(buffers)),
@@ -250,7 +238,7 @@ class CommandOperation : public ExecutionGraph::Operation {
     resources_.push_back(resource_use);
   }
 
-  const CommandBufferCmd* cmd() const { return cmd_; }
+  const Command* cmd() const { return cmd_; }
 
   std::string ToString() const final {
     std::vector<std::string> resource_reprs;
@@ -268,9 +256,9 @@ class CommandOperation : public ExecutionGraph::Operation {
 
  private:
   std::string name_;
-  CommandBufferCmd::BufferUseVector buffers_;
-  const CommandBufferCmd* cmd_;
-  ResourceUseVector resources_;
+  Command::BufferUseVector buffers_;
+  const Command* cmd_;
+  Command::ResourceUseVector resources_;
 
   // The token resource is used to specify dependency other than buffer data
   // flow, e.g, LHS topology will use token resouce to specify dependency across
@@ -280,7 +268,7 @@ class CommandOperation : public ExecutionGraph::Operation {
 }  // namespace
 
 static std::vector<CommandOperation> CreateCommandOperations(
-    const CommandBufferCmdSequence& commands,
+    const CommandSequence& commands,
     CommandBufferCmdExecutor::SynchronizationMode synchronization_mode) {
   std::vector<CommandOperation> operations;
   operations.reserve(commands.size());
@@ -293,7 +281,7 @@ static std::vector<CommandOperation> CreateCommandOperations(
       CommandBufferCmdExecutor::SynchronizationMode::kConcurrent) {
     // For concurrent synchronization mode, pass in buffer and resouces for
     // dependency inference.
-    for (const std::unique_ptr<CommandBufferCmd>& cmd : commands) {
+    for (const std::unique_ptr<Command>& cmd : commands) {
       operations.emplace_back(cmd->buffers(), cmd.get());
     }
   }
@@ -302,8 +290,8 @@ static std::vector<CommandOperation> CreateCommandOperations(
       CommandBufferCmdExecutor::SynchronizationMode::kLHS) {
     // For LHS mode, don't pass in buffers.
     // Will use token resource to specify dependency across commands.
-    for (const std::unique_ptr<CommandBufferCmd>& cmd : commands) {
-      operations.emplace_back(CommandBufferCmd::BufferUseVector{}, cmd.get());
+    for (const std::unique_ptr<Command>& cmd : commands) {
+      operations.emplace_back(Command::BufferUseVector{}, cmd.get());
     }
 
     auto is_async_start = [](const CommandOperation& op) -> bool {
@@ -379,8 +367,7 @@ static std::vector<CommandOperation> CreateCommandOperations(
 }
 
 absl::StatusOr<CommandBufferCmdExecutor> CommandBufferCmdExecutor::Create(
-    CommandBufferCmdSequence commands,
-    SynchronizationMode synchronization_mode) {
+    CommandSequence commands, SynchronizationMode synchronization_mode) {
   std::optional<ExecutionGraph> execution_graph = std::nullopt;
 
   // In automatic synchronization mode construct an execution graph for the
@@ -398,7 +385,7 @@ absl::StatusOr<CommandBufferCmdExecutor> CommandBufferCmdExecutor::Create(
 }
 
 CommandBufferCmdExecutor::CommandBufferCmdExecutor(
-    SynchronizationMode synchronization_mode, CommandBufferCmdSequence commands,
+    SynchronizationMode synchronization_mode, CommandSequence commands,
     std::optional<ExecutionGraph> execution_graph)
     : synchronization_mode_(synchronization_mode),
       commands_(std::move(commands)),
@@ -406,7 +393,7 @@ CommandBufferCmdExecutor::CommandBufferCmdExecutor(
   // Buffer allocations referenced by commands in this sequence.
   absl::btree_set<BufferAllocation::Index> allocs_indices;
 
-  for (const std::unique_ptr<CommandBufferCmd>& cmd : commands_) {
+  for (const std::unique_ptr<Command>& cmd : commands_) {
     absl::btree_set<BufferAllocation::Index> cmd_allocs_indices;
 
     for (const BufferUse& buffer : cmd->buffers()) {
@@ -443,8 +430,7 @@ absl::Status CommandBufferCmdExecutor::Initialize(
 
 // A helper function that logs the details of a given command sequence for
 // debugging purposes only.
-static void VlogCommandSequenceDetails(
-    const CommandBufferCmdSequence& commands) {
+static void VlogCommandSequenceDetails(const CommandSequence& commands) {
   if (!VLOG_IS_ON(5)) {
     return;
   }
@@ -482,7 +468,7 @@ static void VlogCommandSequenceDetails(
       }
     }
 
-    std::string cmd_name = CommandBufferCmdString(cmd->command_type());
+    std::string cmd_name = CommandTypeString(cmd->command_type());
 
     if (has_input && !has_output && !has_temp) {
       input_count++;
@@ -587,7 +573,7 @@ CommandBufferCmdExecutor::RecordCreate(
   std::vector<const se::CommandBuffer::Command*> sink_commands;
 
   for (CommandId id = 0; id < commands_.size(); ++id) {
-    CommandBufferCmd* command = commands_[id].get();
+    Command* command = commands_[id].get();
 
     std::optional<tsl::profiler::ScopedAnnotation> annotation =
         GetKernelAnnotation(command->profile_annotation());
@@ -611,9 +597,9 @@ CommandBufferCmdExecutor::RecordCreate(
     // Source command must depend on external dependencies passed by the
     // caller, internal commands dependencies are defined by the command
     // sequence structure (buffer and resource dependencies).
-    auto record_action =
-        IsSource(id) ? CommandBufferCmd::RecordCreate{dependencies}
-                     : CommandBufferCmd::RecordCreate{command_dependencies};
+    auto record_action = IsSource(id)
+                             ? Command::RecordCreate{dependencies}
+                             : Command::RecordCreate{command_dependencies};
 
     TF_ASSIGN_OR_RETURN(
         record_state->command,
@@ -673,7 +659,7 @@ absl::Status CommandBufferCmdExecutor::RecordUpdate(
 
     // We always update commands that require initialization, even if buffer
     // allocations didn't change.
-    CommandBufferCmd* command = commands_[id].get();
+    Command* command = commands_[id].get();
     if (command->requires_initialization() && record_params.is_initialization) {
       return false;
     }
@@ -700,7 +686,7 @@ absl::Status CommandBufferCmdExecutor::RecordUpdate(
   size_t num_skipped_command_updates = 0;
 
   for (CommandId id = 0; id < commands_.size(); ++id) {
-    CommandBufferCmd* command = commands_[id].get();
+    Command* command = commands_[id].get();
 
     std::optional<tsl::profiler::ScopedAnnotation> annotation =
         GetKernelAnnotation(command->profile_annotation());
@@ -724,7 +710,7 @@ absl::Status CommandBufferCmdExecutor::RecordUpdate(
     DCHECK(record_state) << "Record state must be not null for "
                          << command->ToString();
 
-    CommandBufferCmd::RecordUpdate record_action{record_state->command};
+    Command::RecordUpdate record_action{record_state->command};
     TF_ASSIGN_OR_RETURN(
         record_state->command,
         command->Record(execute_params, record_params, std::move(record_action),
@@ -842,9 +828,9 @@ absl::StatusOr<std::string> CommandBufferCmdExecutor::RenderExecutionGraph() {
 // TracedCommandBuffer
 //===----------------------------------------------------------------------===//
 
-TracedCommandBuffer::TracedCommandBuffer(
-    const CommandBufferCmd* trace_cmd,
-    CommandBufferCmd::BufferUseVector buffers, int64_t capacity)
+TracedCommandBuffer::TracedCommandBuffer(const Command* trace_cmd,
+                                         Command::BufferUseVector buffers,
+                                         int64_t capacity)
     : trace_cmd_(trace_cmd), capacity_(capacity), entries_(capacity) {
   CHECK_GT(capacity, 0) << "capacity must be larger than 0";  // NOLINT
   // Collect unique buffer allocation indices in a set first and convert to
@@ -924,8 +910,8 @@ absl::StatusOr<se::CommandBuffer*> TracedCommandBuffer::GetOrTraceCommandBuffer(
 // TracedCommandBufferCmd
 //===----------------------------------------------------------------------===//
 
-TracedCommandBufferCmd::TracedCommandBufferCmd(CommandBufferCmdType cmd_type)
-    : CommandBufferCmd(cmd_type) {}
+TracedCommandBufferCmd::TracedCommandBufferCmd(CommandType cmd_type)
+    : Command(cmd_type) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
 TracedCommandBufferCmd::RecordTracedCommand(
@@ -963,7 +949,7 @@ TracedCommandBufferCmd::RecordTracedCommand(
 // EmptyCmd
 //===----------------------------------------------------------------------===//
 
-EmptyCmd::EmptyCmd() : CommandBufferCmd(CommandBufferCmdType::kEmptyCmd) {}
+EmptyCmd::EmptyCmd() : Command(CommandType::kEmptyCmd) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
     const Thunk::ExecuteParams& execute_params,
@@ -986,7 +972,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
 
 AsyncDoneCmd::AsyncDoneCmd(
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CommandBufferCmd(CommandBufferCmdType::kAsyncDone),
+    : Command(CommandType::kAsyncDone),
       async_events_(std::move(async_events)) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> AsyncDoneCmd::Record(
@@ -1008,11 +994,9 @@ absl::StatusOr<const se::CommandBuffer::Command*> AsyncDoneCmd::Record(
 //===----------------------------------------------------------------------===//
 
 ComputationIdCmd::ComputationIdCmd(BufferAllocation::Slice dest, Kind kind)
-    : CommandBufferCmd(CommandBufferCmdType::kComputationIdCmd),
-      dest_(dest),
-      kind_(kind) {}
+    : Command(CommandType::kComputationIdCmd), dest_(dest), kind_(kind) {}
 
-CommandBufferCmd::BufferUseVector ComputationIdCmd::buffers() const {
+Command::BufferUseVector ComputationIdCmd::buffers() const {
   return {BufferUse::Write(dest_)};
 }
 
@@ -1059,7 +1043,7 @@ LaunchCmd::LaunchCmd(
     absl::Span<const BufferUse::MemoryAccess> args_access,
     LaunchDimensions dims, int64_t shmem_bytes,
     std::optional<stream_executor::gpu::TmaMetadata> tma_metadata)
-    : CommandBufferCmd(CommandBufferCmdType::kLaunchCmd),
+    : Command(CommandType::kLaunchCmd),
       kernel_name_(std::move(kernel_name)),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
@@ -1151,7 +1135,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> LaunchCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector LaunchCmd::buffers() const {
+Command::BufferUseVector LaunchCmd::buffers() const {
   BufferUseVector buffers;
   for (int32_t i = 0; i < args_.size(); ++i) {
     buffers.emplace_back(args_[i], args_access_[i]);
@@ -1167,7 +1151,7 @@ CustomKernelLaunchCmd::CustomKernelLaunchCmd(
     absl::Span<const BufferAllocation::Slice> args,
     absl::Span<const BufferUse::MemoryAccess> args_access,
     CustomKernel custom_kernel)
-    : CommandBufferCmd(CommandBufferCmdType::kCustomKernelLaunchCmd),
+    : Command(CommandType::kCustomKernelLaunchCmd),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
       custom_kernel_(std::move(custom_kernel)) {}
@@ -1232,7 +1216,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> CustomKernelLaunchCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector CustomKernelLaunchCmd::buffers() const {
+Command::BufferUseVector CustomKernelLaunchCmd::buffers() const {
   BufferUseVector buffers;
   for (int32_t i = 0; i < args_.size(); ++i) {
     buffers.emplace_back(args_[i], args_access_[i]);
@@ -1247,7 +1231,7 @@ CommandBufferCmd::BufferUseVector CustomKernelLaunchCmd::buffers() const {
 MemcpyDeviceToDeviceCmd::MemcpyDeviceToDeviceCmd(ShapedSlice dst,
                                                  ShapedSlice src,
                                                  int64_t num_bytes)
-    : CommandBufferCmd(CommandBufferCmdType::kMemcpyDeviceToDeviceCmd),
+    : Command(CommandType::kMemcpyDeviceToDeviceCmd),
       dst_(dst),
       src_(src),
       num_bytes_(num_bytes) {
@@ -1288,7 +1272,7 @@ MemcpyDeviceToDeviceCmd::Record(const Thunk::ExecuteParams& execute_params,
       });
 }
 
-CommandBufferCmd::BufferUseVector MemcpyDeviceToDeviceCmd::buffers() const {
+Command::BufferUseVector MemcpyDeviceToDeviceCmd::buffers() const {
   return {BufferUse::Write(dst_.slice, dst_.shape),
           BufferUse::Read(src_.slice, src_.shape)};
 }
@@ -1298,7 +1282,7 @@ CommandBufferCmd::BufferUseVector MemcpyDeviceToDeviceCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 MemzeroCmd::MemzeroCmd(ShapedSlice dst)
-    : CommandBufferCmd(CommandBufferCmdType::kMemzeroCmd), dst_(dst) {}
+    : Command(CommandType::kMemzeroCmd), dst_(dst) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> MemzeroCmd::Record(
     const Thunk::ExecuteParams& execute_params,
@@ -1328,7 +1312,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> MemzeroCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector MemzeroCmd::buffers() const {
+Command::BufferUseVector MemzeroCmd::buffers() const {
   return {BufferUse::Write(dst_.slice, dst_.shape)};
 }
 
@@ -1337,7 +1321,7 @@ CommandBufferCmd::BufferUseVector MemzeroCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 Memset32Cmd::Memset32Cmd(BufferAllocation::Slice dst, uint32_t bit_pattern)
-    : CommandBufferCmd(CommandBufferCmdType::kMemset32Cmd),
+    : Command(CommandType::kMemset32Cmd),
       dst_(dst),
       bit_pattern_(bit_pattern) {}
 
@@ -1370,7 +1354,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> Memset32Cmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector Memset32Cmd::buffers() const {
+Command::BufferUseVector Memset32Cmd::buffers() const {
   return {BufferUse::Write(dst_)};
 }
 
@@ -1379,7 +1363,7 @@ CommandBufferCmd::BufferUseVector Memset32Cmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 ChildCmd::ChildCmd(CommandBufferCmdExecutor child_commands)
-    : CommandBufferCmd(CommandBufferCmdType::kChildCmd),
+    : Command(CommandType::kChildCmd),
       child_commands_(std::move(child_commands)) {}
 
 bool ChildCmd::requires_initialization() {
@@ -1388,7 +1372,7 @@ bool ChildCmd::requires_initialization() {
 
 bool ChildCmd::force_update() { return child_commands_.force_update(); }
 
-CommandBufferCmd::BufferUseVector ChildCmd::buffers() const {
+Command::BufferUseVector ChildCmd::buffers() const {
   return {child_commands_.buffers().begin(), child_commands_.buffers().end()};
 }
 
@@ -1432,7 +1416,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> ChildCmd::Record(
 
 CaseCmd::CaseCmd(ShapedSlice index,
                  std::vector<CommandBufferCmdExecutor> branches)
-    : CommandBufferCmd(CommandBufferCmdType::kCaseCmd),
+    : Command(CommandType::kCaseCmd),
       index_(index),
       index_is_bool_(index.shape.element_type() == PRED),
       branches_(std::move(branches)) {}
@@ -1491,7 +1475,7 @@ bool CaseCmd::force_update() {
                         [](const auto& seq) { return seq.force_update(); });
 }
 
-CommandBufferCmd::BufferUseVector CaseCmd::buffers() const {
+Command::BufferUseVector CaseCmd::buffers() const {
   absl::flat_hash_set<BufferUse> buffers;
   buffers.emplace(BufferUse::Read(index_.slice, index_.shape));
   for (auto& branch : branches_) {
@@ -1508,7 +1492,7 @@ WhileCmd::WhileCmd(BufferAllocation::Slice pred,
                    CommandBufferCmdExecutor cond_commands,
                    CommandBufferCmdExecutor body_commands,
                    std::optional<int64_t> trip_count, bool enable_loop_unroll)
-    : CommandBufferCmd(CommandBufferCmdType::kWhileCmd),
+    : Command(CommandType::kWhileCmd),
       pred_(pred),
       cond_commands_(std::move(cond_commands)),
       body_commands_(std::move(body_commands)),
@@ -1561,7 +1545,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> WhileCmd::Record(
       VLOG(3) << "Recording unrolled loop with trip_count: "
               << trip_count_.value();
 
-      CommandBufferCmd::RecordParams new_record_params = record_params;
+      Command::RecordParams new_record_params = record_params;
       std::vector<const se::CommandBuffer::Command*> dependencies;
 
       for (int64_t i = 0; i < trip_count_.value(); ++i) {
@@ -1584,7 +1568,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> WhileCmd::Record(
       VLOG(3) << "Updating unrolled loop with trip_count: "
               << trip_count_.value();
 
-      CommandBufferCmd::RecordParams new_record_params = record_params;
+      Command::RecordParams new_record_params = record_params;
 
       for (int64_t i = 0; i < trip_count_.value(); ++i) {
         new_record_params.unroll_iteration = i;
@@ -1633,7 +1617,7 @@ bool WhileCmd::force_update() {
   return cond_commands_.force_update() || body_commands_.force_update();
 }
 
-CommandBufferCmd::BufferUseVector WhileCmd::buffers() const {
+Command::BufferUseVector WhileCmd::buffers() const {
   absl::flat_hash_set<BufferUse> buffers;
   buffers.emplace(BufferUse::Read(pred_, ShapeUtil::MakeShape(PRED, {})));
   buffers.insert(cond_commands_.buffers().begin(),
@@ -1652,7 +1636,7 @@ GemmCmd::GemmCmd(GemmConfig config, const BufferAllocation::Slice& lhs_buffer,
                  const BufferAllocation::Slice& output_buffer,
                  std::optional<BufferAllocation::Slice> workspace,
                  bool deterministic)
-    : TracedCommandBufferCmd(CommandBufferCmdType::kGemmCmd),
+    : TracedCommandBufferCmd(CommandType::kGemmCmd),
       config_(std::move(config)),
       lhs_buffer_(lhs_buffer),
       rhs_buffer_(rhs_buffer),
@@ -1699,8 +1683,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> GemmCmd::Record(
                              });
 }
 
-CommandBufferCmd::BufferUseVector GemmCmd::buffers() const {
-  CommandBufferCmd::BufferUseVector res{
+Command::BufferUseVector GemmCmd::buffers() const {
+  Command::BufferUseVector res{
       BufferUse::Read(lhs_buffer_, config_.lhs_layout.ToShape()),
       BufferUse::Read(rhs_buffer_, config_.rhs_layout.ToShape()),
       BufferUse::Write(output_buffer_, config_.output_layout.ToShape()),
@@ -1717,7 +1701,7 @@ CommandBufferCmd::BufferUseVector GemmCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 CublasLtCmd::CublasLtCmd(const CublasLtMatmulThunk& matmul_thunk)
-    : TracedCommandBufferCmd(CommandBufferCmdType::kCublasLtCmd),
+    : TracedCommandBufferCmd(CommandType::kCublasLtCmd),
       CublasLtMatmulThunk(matmul_thunk) {}
 
 absl::Status CublasLtCmd::Initialize(const Thunk::InitializeParams& params,
@@ -1756,7 +1740,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> CublasLtCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector CublasLtCmd::buffers() const {
+Command::BufferUseVector CublasLtCmd::buffers() const {
   BufferUseVector buffer_usage;
   buffer_usage.reserve(13);
   buffer_usage.push_back(BufferUse::Read(a_));
@@ -1795,7 +1779,7 @@ CommandBufferCmd::BufferUseVector CublasLtCmd::buffers() const {
 
 CuDnnCmd::CuDnnCmd(absl::Span<const BufferAllocation::Slice> args,
                    const std::shared_ptr<se::dnn::LazyDnnGraph> graph)
-    : TracedCommandBufferCmd(CommandBufferCmdType::kCuDnnCmd),
+    : TracedCommandBufferCmd(CommandType::kCuDnnCmd),
       args_(args.cbegin(), args.cend()),
       graph_(graph) {}
 
@@ -1846,8 +1830,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> CuDnnCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector CuDnnCmd::buffers() const {
-  CommandBufferCmd::BufferUseVector buffer_usage;
+Command::BufferUseVector CuDnnCmd::buffers() const {
+  Command::BufferUseVector buffer_usage;
   buffer_usage.reserve(args_.size());
   for (int i = 0; i < args_.size() - 1; ++i) {
     buffer_usage.push_back(BufferUse::Read(args_[i]));
@@ -2020,8 +2004,8 @@ CustomCallCmd::RecordXlaFfiCall(const Thunk::ExecuteParams& execute_params,
       });
 }
 
-CommandBufferCmd::BufferUseVector CustomCallCmd::buffers() const {
-  CommandBufferCmd::BufferUseVector buffer_usage;
+Command::BufferUseVector CustomCallCmd::buffers() const {
+  Command::BufferUseVector buffer_usage;
   for (auto& slices : {operands_, results_}) {
     for (const std::optional<ShapedSlice>& slice : slices) {
       if (slice.has_value()) {
@@ -2037,9 +2021,9 @@ CommandBufferCmd::BufferUseVector CustomCallCmd::buffers() const {
 //===----------------------------------------------------------------------===//
 
 CollectiveCmd::CollectiveCmd(
-    CommandBufferCmdType cmd_type, CollectiveConfig config,
+    CommandType cmd_type, CollectiveConfig config,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CommandBufferCmd(cmd_type, se::StreamPriority::Highest),
+    : Command(cmd_type, se::StreamPriority::Highest),
       config_(std::move(config)),
       async_events_(std::move(async_events)) {}
 
@@ -2086,7 +2070,7 @@ AllReduceCmd::AllReduceCmd(
     CollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CollectiveCmd(CommandBufferCmdType::kAllReduceCmd, std::move(config),
+    : CollectiveCmd(CommandType::kAllReduceCmd, std::move(config),
                     std::move(async_events)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
@@ -2137,7 +2121,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> AllReduceCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector AllReduceCmd::buffers() const {
+Command::BufferUseVector AllReduceCmd::buffers() const {
   BufferUseVector buffer_usage;
   for (auto& buffer : buffers_) {
     buffer_usage.emplace_back(BufferUse::Read(buffer.source_buffer));
@@ -2154,7 +2138,7 @@ ReduceScatterCmd::ReduceScatterCmd(
     CollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CollectiveCmd(CommandBufferCmdType::kReduceScatterCmd, std::move(config),
+    : CollectiveCmd(CommandType::kReduceScatterCmd, std::move(config),
                     std::move(async_events)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
@@ -2205,7 +2189,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> ReduceScatterCmd::Record(
                              });
 }
 
-CommandBufferCmd::BufferUseVector ReduceScatterCmd::buffers() const {
+Command::BufferUseVector ReduceScatterCmd::buffers() const {
   BufferUseVector buffer_usage;
   for (auto& buffer : buffers_) {
     buffer_usage.emplace_back(BufferUse::Read(buffer.source_buffer));
@@ -2222,7 +2206,7 @@ AllToAllCmd::AllToAllCmd(
     CollectiveConfig config, bool has_split_dimension,
     absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CollectiveCmd(CommandBufferCmdType::kAllToAllCmd, std::move(config),
+    : CollectiveCmd(CommandType::kAllToAllCmd, std::move(config),
                     std::move(async_events)),
       has_split_dimension_(has_split_dimension),
       buffers_(buffers.begin(), buffers.end()) {}
@@ -2274,7 +2258,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> AllToAllCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector AllToAllCmd::buffers() const {
+Command::BufferUseVector AllToAllCmd::buffers() const {
   BufferUseVector buffer_usage;
   for (auto& buffer : buffers_) {
     buffer_usage.emplace_back(BufferUse::Read(buffer.source_buffer));
@@ -2290,7 +2274,7 @@ CommandBufferCmd::BufferUseVector AllToAllCmd::buffers() const {
 AllGatherCmd::AllGatherCmd(
     CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CollectiveCmd(CommandBufferCmdType::kAllGatherCmd, std::move(config),
+    : CollectiveCmd(CommandType::kAllGatherCmd, std::move(config),
                     std::move(async_events)),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -2339,7 +2323,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> AllGatherCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector AllGatherCmd::buffers() const {
+Command::BufferUseVector AllGatherCmd::buffers() const {
   BufferUseVector buffer_usage;
   for (auto& buffer : buffers_) {
     buffer_usage.emplace_back(BufferUse::Read(buffer.source_buffer));
@@ -2355,8 +2339,8 @@ CommandBufferCmd::BufferUseVector AllGatherCmd::buffers() const {
 CollectiveBroadcastCmd::CollectiveBroadcastCmd(
     CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CollectiveCmd(CommandBufferCmdType::kCollectiveBroadcastCmd,
-                    std::move(config), std::move(async_events)),
+    : CollectiveCmd(CommandType::kCollectiveBroadcastCmd, std::move(config),
+                    std::move(async_events)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
@@ -2404,7 +2388,7 @@ CollectiveBroadcastCmd::Record(const Thunk::ExecuteParams& execute_params,
       });
 }
 
-CommandBufferCmd::BufferUseVector CollectiveBroadcastCmd::buffers() const {
+Command::BufferUseVector CollectiveBroadcastCmd::buffers() const {
   BufferUseVector buffer_usage;
   for (auto& buffer : buffers_) {
     buffer_usage.emplace_back(BufferUse::Read(buffer.source_buffer));
@@ -2421,8 +2405,8 @@ CollectivePermuteCmd::CollectivePermuteCmd(
     CollectiveConfig config, P2PConfig p2p_config,
     absl::Span<const CollectiveThunk::Buffer> buffers,
     std::shared_ptr<CollectiveThunk::AsyncEvents> async_events)
-    : CollectiveCmd(CommandBufferCmdType::kCollectivePermuteCmd,
-                    std::move(config), std::move(async_events)),
+    : CollectiveCmd(CommandType::kCollectivePermuteCmd, std::move(config),
+                    std::move(async_events)),
       p2p_config_(std::move(p2p_config)),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -2486,7 +2470,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> CollectivePermuteCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector CollectivePermuteCmd::buffers() const {
+Command::BufferUseVector CollectivePermuteCmd::buffers() const {
   BufferUseVector buffer_usage;
   for (const CollectiveThunk::Buffer& buffer : buffers_) {
     buffer_usage.emplace_back(BufferUse::Read(buffer.source_buffer));
@@ -2510,7 +2494,7 @@ DynamicSliceFusionCmd::DynamicSliceFusionCmd(
     std::optional<
         const DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata*>
         offset_as_function_of_indvar_metadata)
-    : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceFusionCmd),
+    : Command(CommandType::kDynamicSliceFusionCmd),
       embedded_commands_(std::move(embedded_commands)),
       fake_allocations_(std::move(fake_allocations)),
       offset_as_function_of_indvar_metadata_(
@@ -2799,8 +2783,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> DynamicSliceFusionCmd::Record(
       });
 }
 
-CommandBufferCmd::BufferUseVector DynamicSliceFusionCmd::buffers() const {
-  CommandBufferCmd::BufferUseVector buffers;
+Command::BufferUseVector DynamicSliceFusionCmd::buffers() const {
+  Command::BufferUseVector buffers;
   auto embed_buffers = embedded_commands_.buffers();
   for (const auto& buffer_usage : embed_buffers) {
     buffers.emplace_back(
@@ -2818,7 +2802,7 @@ DynamicSliceCopyFusionCmd::DynamicSliceCopyFusionCmd(
     const BufferAllocation::Slice& source_buffer,
     const BufferAllocation::Slice& destination_buffer, uint64_t mem_size,
     DynamicMemcpyThunk::Offsets offsets)
-    : CommandBufferCmd(CommandBufferCmdType::kDynamicSliceCopyFusionCmd),
+    : Command(CommandType::kDynamicSliceCopyFusionCmd),
       source_buffer_(source_buffer),
       destination_buffer_(destination_buffer),
       mem_size_(mem_size),
@@ -2875,8 +2859,8 @@ DynamicSliceCopyFusionCmd::Record(const Thunk::ExecuteParams& execute_params,
       });
 }
 
-CommandBufferCmd::BufferUseVector DynamicSliceCopyFusionCmd::buffers() const {
-  CommandBufferCmd::BufferUseVector buffers;
+Command::BufferUseVector DynamicSliceCopyFusionCmd::buffers() const {
+  Command::BufferUseVector buffers;
   buffers.emplace_back(BufferUse::Read(source_buffer_));
   buffers.emplace_back(BufferUse::Write(destination_buffer_));
   return buffers;

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -22,14 +22,12 @@ limitations under the License.
 #include <optional>
 #include <string>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "absl/algorithm/container.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
-#include "absl/container/inlined_vector.h"
 #include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -39,6 +37,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/collective_permute_thunk.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/backends/gpu/runtime/command_state.h"
+#include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/copy_thunk.h"
 #include "xla/backends/gpu/runtime/custom_call_thunk.h"
 #include "xla/backends/gpu/runtime/dynamic_slice_thunk.h"
@@ -55,7 +54,6 @@ limitations under the License.
 #include "xla/runtime/buffer_use.h"
 #include "xla/runtime/execution_graph.h"
 #include "xla/runtime/object_pool.h"
-#include "xla/runtime/resource_use.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/kernels/custom_kernel.h"
@@ -74,235 +72,6 @@ limitations under the License.
 
 namespace xla::gpu {
 
-// clang-format off
-#define COMMAND_BUFFER_CMD_LIST(V)                               \
-  V(kEmptyCmd, "EmptyCmd")                                       \
-  V(kChildCmd, "ChildCmd")                                       \
-  V(kTracedCommandBufferCmd, "TracedCommandBufferCmd")           \
-  V(kComputationIdCmd, "ComputationIdCmd")                       \
-  V(kLaunchCmd, "LaunchCmd")                                     \
-  V(kCustomKernelLaunchCmd, "CustomKernelLaunchCmd")             \
-  V(kCublasLtCmd, "CublasLtCmd")                                 \
-  V(kCuDnnCmd, "CuDnnCmd")                                       \
-  V(kGemmCmd, "GemmCmd")                                         \
-  V(kMemcpyDeviceToDeviceCmd, "MemcpyDeviceToDeviceCmd")         \
-  V(kMemzeroCmd, "MemzeroCmd")                                   \
-  V(kMemset32Cmd, "Memset32Cmd")                                 \
-  V(kCaseCmd, "CaseCmd")                                         \
-  V(kWhileCmd, "WhileCmd")                                       \
-  V(kCustomCallCmd, "CustomCallCmd")                             \
-  V(kBarrierCmd, "BarrierCmd")                                   \
-  V(kCollectiveCmd, "CollectiveCmd")                             \
-  V(kAllReduceCmd, "AllReduceCmd")                               \
-  V(kReduceScatterCmd, "ReduceScatterCmd")                       \
-  V(kAllToAllCmd, "AllToAllCmd")                                 \
-  V(kAllGatherCmd, "AllGatherCmd")                               \
-  V(kCollectiveBroadcastCmd, "CollectiveBroadcastCmd")           \
-  V(kCollectivePermuteCmd, "CollectivePermuteCmd")               \
-  V(kAsyncDone, "AsyncDone")                                     \
-  V(kDynamicSliceFusionCmd, "DynamicSliceFusionCmd")             \
-  V(kDynamicSliceCopyFusionCmd, "DynamicSliceCopyFusionCmd")     \
-  V(kUnknownCmd, "UnknownCmd") \
-  // clang-format on
-
-enum class CommandBufferCmdType : int32_t {
-#define DECLARE_ENUM(enum_name, cmd_name, ...) enum_name,
-  COMMAND_BUFFER_CMD_LIST(DECLARE_ENUM)
-#undef DECLARE_ENUM
-};
-
-std::string CommandBufferCmdString(CommandBufferCmdType type);
-
-//===----------------------------------------------------------------------===//
-// CommandBufferCmd
-//===----------------------------------------------------------------------===//
-
-using ResourceUseVector = absl::InlinedVector<ResourceUse, 1>;
-
-// Command is a Thunk counterpart that instead of launching operations directly
-// on the underlying device records them into command buffers.
-//
-// Commands have the same execution stages as thunks as they are executed by a
-// command buffer thunk: Prepare, Initialize and Record (Execute). See Thunk
-// documentation for details.
-//
-// Commands must be thread safe as they can be recorded into multiple command
-// buffers concurrently on different stream executors.
-//
-// IMPORTANT: In contrast to GPU thunks, commands MUST be stateless. Thunk state
-// typically belongs to the Thunk instance itself, and tends to be kept in
-// synchronized hash maps keyed by `se::StreamExecutor*` pointer. Commands on
-// the other hand should attach state to the underlying command buffer, and
-// because the number of command buffers that can be instantiated from a command
-// sequence is unbounded (as we have an eviction policy for command buffers),
-// keeping a state in a map inside the command will lead to memory leaks.
-//
-// Commands have an external state manager, which is responsible for managing
-// the lifetime of command state. See `CommandState` and
-// `CommandCommandCommandStateManager` classes for documentation and example.
-class CommandBufferCmd {
- public:
-  explicit CommandBufferCmd(
-      CommandBufferCmdType cmd_type,
-      se::StreamPriority priority = se::StreamPriority::Default)
-      : cmd_type_(cmd_type), priority_(priority) {
-    token_ = Resource::Create(Resource::kToken);
-    resources_.push_back(ResourceUse::Write(token_));
-  }
-
-  virtual ~CommandBufferCmd() = default;
-
-  using BufferUseVector = absl::InlinedVector<BufferUse, 4>;
-
-  // Parameters for recording commands into the command buffer.
-  struct RecordParams {
-    // An external state manager that gives efficient access to per-device state
-    // to commands without a need to add expensive synchronization.
-    CommandStateManager& state;
-
-    // Buffer allocations that changed since the last call to `Record`. Buffer
-    // allocation indices are sorted. CommandBufferCmdExecutor and individual
-    // commands rely on this information to skip unnecessary updates.
-    std::optional<std::vector<BufferAllocation::Index>> updated_allocs;
-
-    // A flag indicating whether we record comands at command buffer thunk
-    // initialization time.
-    bool is_initialization = false;
-
-    // The command sequence might be recorded in the loop unrolling pattern, so
-    // the command sequence might be instantiated multiple times, we uses
-    // unroll_iteration to locate the commands for current unroll iteration.
-    int64_t unroll_iteration = 0;
-  };
-
-  // Create new commands in the command buffer using the given dependencies.
-  struct RecordCreate {
-    absl::Span<const se::CommandBuffer::Command* const> dependencies;
-  };
-
-  // Update previously recorded commands in the command buffer.
-  struct RecordUpdate {
-    const se::CommandBuffer::Command* command;
-  };
-
-  // When recording a command into the command buffer we can either update
-  // previously recorded commands or create new ones. The command DAG structure
-  // can be defined only when we record commands the first time, after that we
-  // can only update previously recorded commands parameters (i.e. with pointers
-  // to new buffer allocations).
-  using RecordAction = std::variant<RecordCreate, RecordUpdate>;
-
-  // See Thunk documentation for XLA execution stages (prepare, initialize,
-  // execute). Commands mirror thunks as they are executed as CommandBufferThunk
-  // that is plugged into the Thunk execution cycle.
-
-  // Prepare command for execution by allowing command to request shared state
-  // required for recording (i.e. collective commands request cliques).
-  virtual absl::Status Prepare(const Thunk::PrepareParams& params) {
-    return absl::OkStatus();
-  }
-
-  // Initialize a command for recording on a given executor. We split it into a
-  // separate function to allow expensive initialization (e.g. device kernel
-  // loading) to happen before a command buffer thunk execution.
-  virtual absl::Status Initialize(const Thunk::InitializeParams& params,
-                                  CommandStateManager& state) {
-    return absl::OkStatus();
-  }
-
-  // Records commands into the command buffer. Returned commands will be passed
-  // back on the next call to `Record` into the same command buffer, so that it
-  // can do efficient command buffer updates.
-  virtual absl::StatusOr<const se::CommandBuffer::Command*> Record(
-      const Thunk::ExecuteParams& execute_params,
-      const RecordParams& record_params, RecordAction record_action,
-      se::CommandBuffer* command_buffer) {
-    return absl::UnimplementedError("Record is not implemented");
-  }
-
-  // Returns true if command requires initialization (has to be recorded at
-  // command buffer thunk initialization).
-  //
-  // Today this is only true for collective commands that might use NCCL for
-  // communication. With NCCL, all participating ranks must record collective
-  // commands at the same time, if some ranks will skip command updates (because
-  // they got lucky and got the same buffer allocations), it will lead to
-  // deadlocks. By forcing the command update at thunk initialization time, we
-  // ensure that all ranks execute NCCL command update.
-  virtual bool requires_initialization() { return false; }
-
-  // Returns true if command supports loop unroll, the while loop can be
-  // unrolled only if it has pre-known trip count and also all commands from the
-  // body commands are unrollable..
-  virtual bool support_loop_unroll() { return true; }
-
-  // This is only true for DynamicSliceCopyFusionCmd when offset is dependents
-  // on loop iteration. As the command of slice operation is access the sliced
-  // memory region that varies across loop iterations, so even the original
-  // buffer allocation is the same, it still requires to do update.
-  virtual bool force_update() { return false; }
-
-  // Returns all buffers used by the cmd. These will be used to track cmd
-  // updates, thus they need to be consistent across calls to the function.
-  virtual BufferUseVector buffers() const { return {}; }
-
-  std::shared_ptr<Resource> token() const { return token_; }
-
-  void add_resouce_use(ResourceUse resource_use) {
-    resources_.push_back(resource_use);
-  }
-  ResourceUseVector resources() const { return resources_; }
-
-  // Returns true if command implemented as a nested command buffer.
-  virtual bool IsNestedCommandBuffer() const { return false; }
-
-  absl::string_view profile_annotation() const { return profile_annotation_; }
-  void set_profile_annotation(absl::string_view profile_annotation) {
-    profile_annotation_ = profile_annotation;
-  }
-
-  CommandBufferCmdType command_type() const { return cmd_type_; }
-  se::StreamPriority priority() const { return priority_; }
-  void set_priority(se::StreamPriority priority) { priority_ = priority; }
-
-  virtual std::string ToString() const {
-    return CommandBufferCmdString(cmd_type_);
-  }
-
- private:
-  std::string profile_annotation_;
-  CommandBufferCmdType cmd_type_;
-
-  ResourceUseVector resources_;
-
-  // The token resource is used to specify additional dependency across
-  // commands, like control dependency across HLO operators, and LHS scheduling
-  // dependency.
-  std::shared_ptr<Resource> token_;
-
-  // Command priority, currently only support default, lowest and highest
-  // priority.
-  se::StreamPriority priority_ = se::StreamPriority::Default;
-};
-
-// A sequence of commands (corresponds to a ThunkSequence from the Thunk API).
-class CommandBufferCmdSequence
-    : public std::vector<std::unique_ptr<CommandBufferCmd>> {
- public:
-  template <typename Command, typename... Args>
-  void Emplace(Args&&... args) {
-    this->emplace_back(std::make_unique<Command>(std::forward<Args>(args)...));
-  }
-
-  std::string ToString() const {
-    std::string result;
-    for (const auto& cmd : *this) {
-      result += cmd->ToString() + "\n";
-    }
-    return result;
-  }
-};
-
 //===----------------------------------------------------------------------===//
 // CommandBufferCmdExecutor
 //===----------------------------------------------------------------------===//
@@ -315,7 +84,7 @@ class CommandBufferCmdExecutor {
   CommandBufferCmdExecutor(CommandBufferCmdExecutor&&) = default;
   CommandBufferCmdExecutor& operator=(CommandBufferCmdExecutor&&) = default;
 
-  using RecordParams = CommandBufferCmd::RecordParams;
+  using RecordParams = Command::RecordParams;
 
   // Synchronization mode defines how much concurrency is allowed between
   // commands in the sequence.
@@ -351,8 +120,7 @@ class CommandBufferCmdExecutor {
   // Creates a command executor from a sequence of commands using given
   // synchronization mode.
   static absl::StatusOr<CommandBufferCmdExecutor> Create(
-      CommandBufferCmdSequence commands,
-      SynchronizationMode synchronization_mode);
+      CommandSequence commands, SynchronizationMode synchronization_mode);
 
   // Prepares all commands added to a sequence.
   absl::Status Prepare(const Thunk::PrepareParams& params);
@@ -436,7 +204,7 @@ class CommandBufferCmdExecutor {
   };
 
   CommandBufferCmdExecutor(SynchronizationMode synchronization_mode,
-                           CommandBufferCmdSequence commands,
+                           CommandSequence commands,
                            std::optional<ExecutionGraph> execution_graph);
 
   absl::Status CheckCommandBufferState(
@@ -455,7 +223,7 @@ class CommandBufferCmdExecutor {
       CommandId id) const;
 
   SynchronizationMode synchronization_mode_;
-  CommandBufferCmdSequence commands_;
+  CommandSequence commands_;
 
   // In automatic synchronization mode we build an execution graph for the
   // sequence of commands and use it to set up dependencies between commands.
@@ -483,8 +251,8 @@ class CommandBufferCmdExecutor {
 // subsequent calls to XLA executable tend to reuse the same allocations.
 class TracedCommandBuffer : public CommandState {
  public:
-  explicit TracedCommandBuffer(const CommandBufferCmd* trace_cmd,
-                               CommandBufferCmd::BufferUseVector buffers,
+  explicit TracedCommandBuffer(const Command* trace_cmd,
+                               Command::BufferUseVector buffers,
                                int64_t capacity = 16);
 
   // Returns cached command buffer traced using the same buffer addresses or
@@ -501,7 +269,7 @@ class TracedCommandBuffer : public CommandState {
     std::vector<se::DeviceAddressBase> recorded_allocs;
     std::unique_ptr<se::CommandBuffer> command_buffer;
   };
-  const CommandBufferCmd* trace_cmd_;
+  const Command* trace_cmd_;
   int64_t capacity_;
   std::vector<Entry> entries_;
 };
@@ -511,9 +279,9 @@ class TracedCommandBuffer : public CommandState {
 //===----------------------------------------------------------------------===//
 
 // A base class for commands implemented as tracing of stream activities.
-class TracedCommandBufferCmd : public CommandBufferCmd {
+class TracedCommandBufferCmd : public Command {
  protected:
-  explicit TracedCommandBufferCmd(CommandBufferCmdType cmd_type);
+  explicit TracedCommandBufferCmd(CommandType cmd_type);
 
   // Creates a command buffer by calling a user-provided `trace` function and
   // adds it as a nested command to `command_buffer`. Traced command buffers
@@ -529,7 +297,7 @@ class TracedCommandBufferCmd : public CommandBufferCmd {
 // EmptyCmd
 //===----------------------------------------------------------------------===//
 
-class EmptyCmd : public CommandBufferCmd {
+class EmptyCmd : public Command {
  public:
   explicit EmptyCmd();
 
@@ -545,7 +313,7 @@ class EmptyCmd : public CommandBufferCmd {
 // AsyncDoneCmd
 //===----------------------------------------------------------------------===//
 
-class AsyncDoneCmd : public CommandBufferCmd {
+class AsyncDoneCmd : public Command {
  public:
   explicit AsyncDoneCmd(
       std::shared_ptr<CollectiveThunk::AsyncEvents> async_events);
@@ -570,7 +338,7 @@ class AsyncDoneCmd : public CommandBufferCmd {
 // ComputationIdCmd (ReplicaId and PartitionId)
 //===----------------------------------------------------------------------===//
 
-class ComputationIdCmd : public CommandBufferCmd {
+class ComputationIdCmd : public Command {
  public:
   enum class Kind { kReplica, kPartition };
 
@@ -592,7 +360,7 @@ class ComputationIdCmd : public CommandBufferCmd {
 // LaunchCmd
 //===----------------------------------------------------------------------===//
 
-class LaunchCmd : public CommandBufferCmd {
+class LaunchCmd : public Command {
  public:
   LaunchCmd(std::string kernel_name,
             absl::Span<const BufferAllocation::Slice> args,
@@ -630,7 +398,7 @@ class LaunchCmd : public CommandBufferCmd {
 // CustomKernelLaunchCmd
 //===----------------------------------------------------------------------===//
 
-class CustomKernelLaunchCmd : public CommandBufferCmd {
+class CustomKernelLaunchCmd : public Command {
  public:
   CustomKernelLaunchCmd(absl::Span<const BufferAllocation::Slice> args,
                         absl::Span<const BufferUse::MemoryAccess> args_access,
@@ -662,7 +430,7 @@ class CustomKernelLaunchCmd : public CommandBufferCmd {
 // MemcpyDeviceToDeviceCmd
 //===----------------------------------------------------------------------===//
 
-class MemcpyDeviceToDeviceCmd : public CommandBufferCmd {
+class MemcpyDeviceToDeviceCmd : public Command {
  public:
   MemcpyDeviceToDeviceCmd(ShapedSlice dst, ShapedSlice src, int64_t num_bytes);
 
@@ -683,7 +451,7 @@ class MemcpyDeviceToDeviceCmd : public CommandBufferCmd {
 // MemzeroCmd
 //===----------------------------------------------------------------------===//
 
-class MemzeroCmd : public CommandBufferCmd {
+class MemzeroCmd : public Command {
  public:
   explicit MemzeroCmd(ShapedSlice dst);
 
@@ -702,7 +470,7 @@ class MemzeroCmd : public CommandBufferCmd {
 // Memset32Cmd
 //===----------------------------------------------------------------------===//
 
-class Memset32Cmd : public CommandBufferCmd {
+class Memset32Cmd : public Command {
  public:
   Memset32Cmd(BufferAllocation::Slice dst, uint32_t bit_pattern);
 
@@ -722,7 +490,7 @@ class Memset32Cmd : public CommandBufferCmd {
 // ChildCmd
 //===----------------------------------------------------------------------===//
 
-class ChildCmd : public CommandBufferCmd {
+class ChildCmd : public Command {
  public:
   explicit ChildCmd(CommandBufferCmdExecutor child_commands);
 
@@ -750,7 +518,7 @@ class ChildCmd : public CommandBufferCmd {
 // CaseCmd
 //===----------------------------------------------------------------------===//
 
-class CaseCmd : public CommandBufferCmd {
+class CaseCmd : public Command {
  public:
   CaseCmd(ShapedSlice index, std::vector<CommandBufferCmdExecutor> branches);
 
@@ -780,7 +548,7 @@ class CaseCmd : public CommandBufferCmd {
 // WhileCmd
 //===----------------------------------------------------------------------===//
 
-class WhileCmd : public CommandBufferCmd {
+class WhileCmd : public Command {
  public:
   WhileCmd(BufferAllocation::Slice pred, CommandBufferCmdExecutor cond_commands,
            CommandBufferCmdExecutor body_commands,
@@ -905,7 +673,7 @@ class CuDnnCmd : public TracedCommandBufferCmd {
 // CustomCallCmd
 //===----------------------------------------------------------------------===//
 
-class CustomCallCmd : public CommandBufferCmd {
+class CustomCallCmd : public Command {
  public:
   using CustomCallTarget = CustomCallThunk::CustomCallTarget;
   using AttributesMap = ffi::AttributesMap;
@@ -916,7 +684,7 @@ class CustomCallCmd : public CommandBufferCmd {
                 std::vector<NullableShapedSlice> operands,
                 std::vector<NullableShapedSlice> results,
                 absl::string_view opaque)
-      : CommandBufferCmd(CommandBufferCmdType::kCustomCallCmd),
+      : Command(CommandType::kCustomCallCmd),
         target_name_(std::move(target_name)),
         call_target_(std::move(call_target)),
         opaque_(opaque),
@@ -929,7 +697,7 @@ class CustomCallCmd : public CommandBufferCmd {
                 ffi::CallFrame call_frame,
                 std::shared_ptr<ffi::ExecutionState> execution_state,
                 const HloComputation* called_computation)
-      : CommandBufferCmd(CommandBufferCmdType::kCustomCallCmd),
+      : Command(CommandType::kCustomCallCmd),
         target_name_(std::move(target_name)),
         handler_(handler),
         call_frame_(std::move(call_frame)),
@@ -991,9 +759,9 @@ class CustomCallCmd : public CommandBufferCmd {
 // CollectiveCmd
 //===----------------------------------------------------------------------===//
 
-class CollectiveCmd : public CommandBufferCmd {
+class CollectiveCmd : public Command {
  public:
-  CollectiveCmd(CommandBufferCmdType cmd_type, CollectiveConfig config,
+  CollectiveCmd(CommandType cmd_type, CollectiveConfig config,
                 std::shared_ptr<CollectiveThunk::AsyncEvents> async_events);
 
   absl::Status Prepare(const Thunk::PrepareParams& params) final;
@@ -1157,7 +925,7 @@ class CollectivePermuteCmd : public CollectiveCmd {
 // DynamicSliceFusionCmd
 //===----------------------------------------------------------------------===//
 
-class DynamicSliceFusionCmd : public CommandBufferCmd {
+class DynamicSliceFusionCmd : public Command {
  public:
   DynamicSliceFusionCmd(
       CommandBufferCmdExecutor embedded_commands,
@@ -1228,7 +996,7 @@ class DynamicSliceFusionCmd : public CommandBufferCmd {
 
 // DynamicSliceCopyFusionCmd is a command that copies a slice from one
 // buffer to another, it is only supported for static slice.
-class DynamicSliceCopyFusionCmd : public CommandBufferCmd {
+class DynamicSliceCopyFusionCmd : public Command {
  public:
   DynamicSliceCopyFusionCmd(const BufferAllocation::Slice& source_buffer,
                             const BufferAllocation::Slice& destination_buffer,

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/collective_broadcast_thunk.h"
 #include "xla/backends/gpu/runtime/collective_permute_thunk.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
+#include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_state.h"
 #include "xla/backends/gpu/runtime/conditional_thunk.h"
@@ -60,7 +61,7 @@ limitations under the License.
 namespace xla::gpu {
 
 // Appends command(s) converted from `sequence` to `cmd_sequence`.
-static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
+static absl::Status AppendCommands(CommandSequence& cmd_sequence,
                                    const ThunkSequence& sequence,
                                    const ConvertToCommandsOptions& options);
 
@@ -274,7 +275,7 @@ static absl::StatusOr<std::unique_ptr<Command>> Convert(const Thunk& thunk,
                       thunk);
 }
 
-static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
+static absl::Status AppendCommands(CommandSequence& cmd_sequence,
                                    const Thunk& thunk,
                                    const ConvertToCommandsOptions& options) {
   auto append =
@@ -383,7 +384,7 @@ static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
   }
 }
 
-static absl::Status AppendCommands(CommandBufferCmdSequence& cmd_sequence,
+static absl::Status AppendCommands(CommandSequence& cmd_sequence,
                                    const ThunkSequence& sequence,
                                    const ConvertToCommandsOptions& options) {
   absl::flat_hash_map<const Thunk*, int64_t> thunk_to_index;
@@ -410,7 +411,7 @@ absl::StatusOr<CommandBufferCmdExecutor> ConvertToCommands(
   VLOG(3) << absl::StreamFormat(
       "Convert thunk sequence to command executor: synchronization_mode=%v",
       options.synchronization_mode);
-  CommandBufferCmdSequence cmd_sequence;
+  CommandSequence cmd_sequence;
   TF_RETURN_IF_ERROR(AppendCommands(cmd_sequence, sequence, options));
   return CommandBufferCmdExecutor::Create(std::move(cmd_sequence),
                                           options.synchronization_mode);

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -203,9 +203,9 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     auto updated_allocs =
         cmd_buffer->UpdateBufferAllocations(commands_, execute_params);
 
-    CommandBufferCmd::RecordParams record_params = {cmd_buffer->state,
-                                                    std::move(updated_allocs),
-                                                    /*is_initialization=*/true};
+    Command::RecordParams record_params = {cmd_buffer->state,
+                                           std::move(updated_allocs),
+                                           /*is_initialization=*/true};
     TF_RETURN_IF_ERROR(commands_.Record(execute_params, record_params,
                                         cmd_buffer->command_buffer.get()));
 
@@ -273,8 +273,8 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
 
     uint64_t start_micros = tsl::Env::Default()->NowMicros();
 
-    CommandBufferCmd::RecordParams record_params = {cmd_buffer->state,
-                                                    std::move(updated_allocs)};
+    Command::RecordParams record_params = {cmd_buffer->state,
+                                           std::move(updated_allocs)};
     TF_RETURN_IF_ERROR(commands_.Record(params, record_params,
                                         cmd_buffer->command_buffer.get()));
 

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -27,6 +27,9 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
+#include "tsl/profiler/lib/profiler_lock.h"
+#include "tsl/profiler/lib/traceme.h"
+#include "tsl/profiler/lib/traceme_encode.h"
 #include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
@@ -39,9 +42,6 @@ limitations under the License.
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
 #include "xla/tsl/platform/statusor.h"
-#include "tsl/profiler/lib/profiler_lock.h"
-#include "tsl/profiler/lib/traceme.h"
-#include "tsl/profiler/lib/traceme_encode.h"
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/runtime/command_state.h
+++ b/xla/backends/gpu/runtime/command_state.h
@@ -27,9 +27,8 @@ class CommandBuffer;
 
 namespace xla::gpu {
 
-// Forward declare and prepare to migration to `Command` type name.
-class CommandBufferCmd;
-using Command = CommandBufferCmd;
+// Forward declaration.
+class Command;
 
 // A base class for externally managed command state.
 //

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_properties.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_utils.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_buffer_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
@@ -146,7 +147,7 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   }
 
   auto dnn_graph = std::make_unique<se::gpu::CudnnGraph>(std::move(graph));
-  CommandBufferCmdSequence commands;
+  CommandSequence commands;
   commands.Emplace<CuDnnCmd>(
       args, std::make_shared<se::dnn::LazyDnnGraph>(std::move(dnn_graph)));
   TF_ASSERT_OK_AND_ASSIGN(


### PR DESCRIPTION
Keep splitting `command_buffer_cmd` into more manageable targets. This is an NFC change, simply moving code into separate build target and updating dependencies.

Add `AsyncStartCommand` and `AsyncDoneCommand` to be able to break circular dependency between Command and CommandExecutor (coming next PR).