### PR TITLE
[GPU] Emitters: improve loop unrolling heuristic.

### DIFF
--- a/xla/backends/gpu/codegen/emitters/transforms/optimize_loops.cc
+++ b/xla/backends/gpu/codegen/emitters/transforms/optimize_loops.cc
@@ -28,8 +28,10 @@ limitations under the License.
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
@@ -50,108 +52,159 @@ bool IsExpensiveToUnroll(mlir::Operation* op) {
   return mlir::isa<
       // clang-format off
       // go/keep-sorted start
-      mlir::func::CallOp,
       mlir::math::AcosOp,
       mlir::math::AcoshOp,
       mlir::math::AsinOp,
       mlir::math::AsinhOp,
       mlir::math::AtanhOp,
-      mlir::math::SinhOp,
-      mlir::scf::ForOp
+      mlir::math::SinhOp
       // go/keep-sorted end
       // clang-format on
       >(op);
 }
 
-int GetUnrollingFactor(mlir::scf::ForOp op) {
-  // We only unroll loops with a step of 1 and a lower bound of 0. That's the
-  // only type we generate.
-  if (auto step = op.getConstantStep(); !step || step->getSExtValue() != 1) {
-    return 1;
-  }
-  llvm::APInt lb, ub;
-  if (!mlir::matchPattern(op.getLowerBound(), mlir::m_ConstantInt(&lb)) ||
-      !mlir::matchPattern(op.getUpperBound(), mlir::m_ConstantInt(&ub))) {
-    return 1;
-  }
-  if (lb.getSExtValue() != 0) {
-    return 1;
+std::optional<int64_t> GetConstantTripCount(mlir::scf::ForOp for_op) {
+  std::optional<llvm::APInt> step = for_op.getConstantStep();
+  if (!step) {
+    return std::nullopt;
   }
 
-  int64_t trip_count = ub.getSExtValue();
-  constexpr int kMaxSize = 400;  // Chosen empirically.
+  llvm::APInt lower_bound, upper_bound;
+  if (mlir::matchPattern(for_op.getLowerBound(),
+                         mlir::m_ConstantInt(&lower_bound)) &&
+      mlir::matchPattern(for_op.getUpperBound(),
+                         mlir::m_ConstantInt(&upper_bound))) {
+    return (upper_bound.getSExtValue() - lower_bound.getSExtValue()) /
+           step->getSExtValue();
+  }
+  return std::nullopt;
+}
 
-  // Get a rough estimate of the size of the loop body.
-  int64_t size = 0;
-  bool can_unroll = true;
-  op.getBodyRegion().walk([&](mlir::Operation* op) {
-    if (IsExpensiveToUnroll(op)) {
-      can_unroll = false;
-      return;
+// Returns a rough estimate of the number of instructions in the operation.
+// Returns std::nullopt if the operation is expensive to unroll.
+std::optional<int64_t> EstimateSize(mlir::Operation* op,
+                                    const mlir::SymbolTable& symbolTable) {
+  if (IsExpensiveToUnroll(op)) {
+    return std::nullopt;
+  }
+
+  if (auto call = mlir::dyn_cast<mlir::CallOpInterface>(op)) {
+    if (auto symbol = mlir::dyn_cast_or_null<mlir::SymbolRefAttr>(
+            call.getCallableForCallee())) {
+      if (auto callee = symbolTable.lookup<mlir::func::FuncOp>(
+              symbol.getLeafReference())) {
+        return EstimateSize(callee, symbolTable);
+      }
     }
+  }
 
-    int64_t this_size = 1;
-    if (mlir::isa<mlir::math::MathDialect>(op->getDialect())) {
-      // Integer instructions in math are ok, but many float ops lower to lots
-      // of instructions.
-      if (!op->getResultTypes().front().isIntOrIndex()) {
-        namespace mm = mlir::math;
-        // We err on the side of not unrolling, so we maintain a list of ops
-        // known to be cheap.
-        if (!mlir::isa<mm::AbsFOp, mm::CeilOp, mm::CopySignOp, mm::FloorOp,
-                       mm::FmaOp, mm::RoundEvenOp, mm::RoundOp, mm::RsqrtOp,
-                       mm::SqrtOp, mm::TruncOp>(op)) {
-          this_size = 20;  // Rough estimate.
-        }
+  int64_t size = 0;
+  if (!mlir::isa<mlir::func::FuncOp, mlir::func::ReturnOp, mlir::scf::ForOp,
+                 mlir::scf::YieldOp, xla::YieldOp, mlir::scf::IfOp>(op)) {
+    size = 1;
+    if (mlir::isa<mlir::math::MathDialect, mlir::arith::ArithDialect>(
+            op->getDialect()) &&
+        !op->getResultTypes().empty() &&
+        !op->getResultTypes().front().isIntOrIndex()) {
+      namespace mm = mlir::math;
+      namespace ma = mlir::arith;
+      if (!mlir::isa<mm::AbsFOp, mm::CeilOp, mm::CopySignOp, mm::FloorOp,
+                     mm::FmaOp, mm::RoundEvenOp, mm::RoundOp, mm::RsqrtOp,
+                     mm::SqrtOp, mm::TruncOp, ma::AddFOp, ma::SubFOp,
+                     ma::MulFOp, ma::ExtFOp, ma::TruncFOp>(op)) {
+        size = 20;
       }
     }
 
     if (!op->getResultTypes().empty()) {
       if (auto vector_ty =
               mlir::dyn_cast<mlir::VectorType>(op->getResultTypes().front())) {
-        this_size *= vector_ty.getNumElements();
+        size *= vector_ty.getNumElements();
       }
     }
+  }
 
-    size += this_size;
-  });
+  for (mlir::Region& region : op->getRegions()) {
+    for (mlir::Operation& nested_op : region.getOps()) {
+      auto nested_size = EstimateSize(&nested_op, symbolTable);
+      if (!nested_size) {
+        return std::nullopt;
+      }
+      size += *nested_size;
+    }
+  }
 
-  if (!can_unroll) {
+  if (auto for_op = mlir::dyn_cast<mlir::scf::ForOp>(op)) {
+    constexpr int kDefaultAssumedTripCount = 10;
+    return size *
+           GetConstantTripCount(for_op).value_or(kDefaultAssumedTripCount);
+  }
+
+  return size;
+}
+
+int GetUnrollingFactor(mlir::scf::ForOp op,
+                       const mlir::SymbolTable& symbolTable) {
+  // We only unroll loops with a step of 1 and a lower bound of 0. That's the
+  // only type we generate.
+  if (auto step = op.getConstantStep();
+      !step || step->getSExtValue() != 1 ||
+      !mlir::matchPattern(op.getLowerBound(), mlir::m_Zero())) {
+    return 1;
+  }
+
+  auto trip_count = GetConstantTripCount(op);
+  if (!trip_count) {
+    return 1;
+  }
+
+  constexpr int kMaxSize = 400;  // Chosen empirically.
+
+  auto size = EstimateSize(op, symbolTable);
+  if (!size) {
     return 1;
   }
 
   // Always unroll if the trip count is smaller than the max unroll factor,
   // because it's very likely that the loop was meant to be unrolled.
-  if (trip_count <= MaxUnrollFactor()) {
-    return trip_count;
+  // We also check the total size to avoid massive register pressure.
+  if (*trip_count <= MaxUnrollFactor() && *size <= kMaxSize) {
+    return *trip_count;
   }
 
-  int factor = std::min(trip_count, kMaxSize / size);
-  while (factor > 1 && trip_count % factor) {
+  int factor = std::min<int64_t>(*trip_count, kMaxSize / (*size / *trip_count));
+  while (factor > 1 && *trip_count % factor) {
     --factor;
   }
   return factor;
 }
 
 struct UnrollLoops : mlir::OpRewritePattern<mlir::scf::ForOp> {
-  using mlir::OpRewritePattern<mlir::scf::ForOp>::OpRewritePattern;
+  UnrollLoops(mlir::MLIRContext* context, const mlir::SymbolTable& symbolTable)
+      : mlir::OpRewritePattern<mlir::scf::ForOp>(context),
+        symbolTable(symbolTable) {}
 
   mlir::LogicalResult matchAndRewrite(
       mlir::scf::ForOp op, mlir::PatternRewriter& rewriter) const override {
-    if (int factor = GetUnrollingFactor(op); factor > 1) {
+    if (int factor = GetUnrollingFactor(op, symbolTable); factor > 1) {
       return mlir::loopUnrollByFactor(op, factor);
     }
     return rewriter.notifyMatchFailure(op, "loop can't be unrolled");
   }
+
+  const mlir::SymbolTable& symbolTable;
 };
 
 class OptimizeLoopsPass
     : public impl::OptimizeLoopsPassBase<OptimizeLoopsPass> {
  public:
   void runOnOperation() override {
+    mlir::func::FuncOp func = getOperation();
+    mlir::SymbolTable symbolTable(func->getParentOfType<mlir::ModuleOp>());
+
     // First unroll loops. If unrolling is possible, we prefer it.
     mlir::RewritePatternSet unroll_patterns(&getContext());
-    unroll_patterns.add<UnrollLoops>(&getContext());
+    unroll_patterns.add<UnrollLoops>(&getContext(), symbolTable);
     if (mlir::failed(mlir::applyPatternsGreedily(getOperation(),
                                                  std::move(unroll_patterns)))) {
       signalPassFailure();


### PR DESCRIPTION
📝 Summary of Changes
Make the heuristic traverse xla.pure_call computations while estimating the
cost of unrolling. Increase cost of math.exp.

🎯 Justification
Speeds up some fusions by preventing excessive unrolling and heavy register pressure it causes.
This one gets 15% faster on B200:
```
f {
  tmp_0 = bf16[16384,14336] parameter(1)
  tmp_1 = bf16[2,8192,14336] bitcast(tmp_0)
  tmp_2 = bf16[] constant(1)
  tmp_3 = f32[] convert(tmp_2)
  tmp_4 = f32[2,8192,14336] broadcast(tmp_3), dimensions={}
  tmp_5 = bf16[2,8192,14336] negate(tmp_1)
  tmp_6 = bf16[2,8192,14336] exponential(tmp_5)
  tmp_7 = bf16[2,8192,14336] broadcast(tmp_2), dimensions={}
  tmp_8 = bf16[2,8192,14336] add(tmp_6, tmp_7)
  tmp_9 = f32[2,8192,14336] convert(tmp_8)
  tmp_10 = f32[2,8192,14336] divide(tmp_4, tmp_9)
  tmp_11 = bf16[2,8192,14336] convert(tmp_10)
  tmp_12 = bf16[2,8192,14336] multiply(tmp_1, tmp_11)
  tmp_13 = bf16[16384,14336] parameter(0)
  tmp_14 = bf16[2,8192,14336] bitcast(tmp_13)
  tmp_15 = bf16[2,8192,14336] multiply(tmp_12, tmp_14)
  tmp_16 = bf16[2,8192,14336] abs(tmp_15)
  tmp_17 = bf16[28672,8192] bitcast(tmp_16)
  tmp_18 = bf16[] constant(-inf)
  tmp_19 = bf16[28672] reduce(tmp_17, tmp_18), dimensions={1}, to_apply={
    _ = bf16[] maximum(bf16[] parameter(0), bf16[] parameter(1))
  }
  ROOT tmp_20 = (bf16[28672], bf16[2,8192,14336]) tuple(tmp_19, tmp_15)
}
```

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
8x B200:

| Benchmark                                          | Speedup | Memory | Compilation speedup |
|----------------------------------------------------|---------|--------|---------------------|
| gpu_hlo                                            |   1.00x |  1.00x |               0.93x |
| hlo_llama3_8b_bf16_activation_offloading_1x8       |   1.01x |  1.00x |               0.97x |
| hlo_llama31_8b_bf16_1x8                            |   0.98x |  1.00x |               0.96x |
| hlo_llama31_8b_fp8_1x8                             |   1.09x |  1.00x |               0.95x |
| hlo_mixtral_8x7b_bf16_1x8                          |   1.00x |  0.99x |               1.05x |
| nv_maxtext_1n1g_jit_train_step_before_optimization |   1.00x |  1.00x |               0.98x |

🧪 Unit Tests:
yes

🧪 Execution Tests:
no