### PR TITLE
Algebraic simplifier: handle bitcast(unary_elementwise(bitcast())).

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -1307,6 +1307,11 @@ absl::Status AlgebraicSimplifierVisitor::HandleBitcast(
     return absl::OkStatus();
   }
 
+  auto not_tiled = [](const HloInstruction& instr) {
+    return !instr.shape().has_layout() ||
+           instr.shape().layout().tiles().empty();
+  };
+
   // Simplify bitcast(unary_elementwise(bitcast(x))) to
   // bitcast(unary_elementwise(x)).
   if (HloInstruction * unary_op, *inner_bitcast;
@@ -1321,7 +1326,8 @@ absl::Status AlgebraicSimplifierVisitor::HandleBitcast(
       ShapeUtil::SameElementType(bitcast->shape(), unary_op->shape()) &&
       ShapeUtil::SameElementType(unary_op->shape(), inner_bitcast->shape()) &&
       ShapeUtil::SameElementType(inner_bitcast->shape(),
-                                 inner_bitcast->operand(0)->shape())) {
+                                 inner_bitcast->operand(0)->shape()) &&
+      not_tiled(*inner_bitcast) && not_tiled(*inner_bitcast->operand(0))) {
     auto new_unary = unary_op->parent()->AddInstruction(
         unary_op->CloneWithNewOperands(inner_bitcast->operand(0)->shape(),
                                        {inner_bitcast->mutable_operand(0)}));

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -12015,6 +12015,20 @@ TEST_F(AlgebraicSimplifierTest, BitcastUnaryBitcast_ElementTypeChange) {
   ASSERT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
 }
 
+TEST_F(AlgebraicSimplifierTest, BitcastUnaryBitcast_TilingChange) {
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    e {
+      p0 = s32[2,512]{1,0:T(2,128)} parameter(0)
+      b1 = s32[512,2]{1,0:T(8,128)} bitcast(p0)
+      neg = s32[512,2]{1,0:T(8,128)} negate(b1)
+      b2 = s32[2,512]{1,0:T(2,128)} bitcast(neg)
+    }
+  )"));
+  AlgebraicSimplifierOptions options = default_options_;
+  options.set_is_layout_sensitive(true);
+  ASSERT_FALSE(AlgebraicSimplifier(options).Run(m.get()).value());
+}
+
 // Reverse(Reverse(A)) ==> A.
 TEST_F(AlgebraicSimplifierTest, RemoveIdenticalNestedReverse) {
   constexpr absl::string_view kModuleStr = R"(


### PR DESCRIPTION
📝 Summary of Changes
Squash pairs of bitcasts.

🎯 Justification
Speeds up some fusions by simplifying index computations. This fusion for example gets 35-45% faster from squashing tmp_16 into tmp_18:
```
f {
  tmp_0 = bf16[16384,14336] parameter(1)
  tmp_1 = bf16[2,8192,14336] bitcast(tmp_0)
  tmp_2 = bf16[] constant(1)
  tmp_3 = f32[] convert(tmp_2)
  tmp_4 = f32[2,8192,14336] broadcast(tmp_3), dimensions={}
  tmp_5 = bf16[2,8192,14336] negate(tmp_1)
  tmp_6 = bf16[2,8192,14336] exponential(tmp_5)
  tmp_7 = bf16[2,8192,14336] broadcast(tmp_2), dimensions={}
  tmp_8 = bf16[2,8192,14336] add(tmp_6, tmp_7)
  tmp_9 = f32[2,8192,14336] convert(tmp_8)
  tmp_10 = f32[2,8192,14336] divide(tmp_4, tmp_9)
  tmp_11 = bf16[2,8192,14336] convert(tmp_10)
  tmp_12 = bf16[2,8192,14336] multiply(tmp_1, tmp_11)
  tmp_13 = bf16[16384,14336] parameter(0)
  tmp_14 = bf16[2,8192,14336] bitcast(tmp_13)
  tmp_15 = bf16[2,8192,14336] multiply(tmp_12, tmp_14)
  tmp_16 = bf16[16384,14336] bitcast(tmp_15)
  tmp_17 = bf16[16384,14336] abs(tmp_16)
  tmp_18 = bf16[28672,8192] bitcast(tmp_17)
  tmp_19 = bf16[] constant(-inf)
  tmp_20 = bf16[28672] reduce(tmp_18, tmp_19), dimensions={1}, to_apply={
    _ = bf16[] maximum(bf16[] parameter(0), bf16[] parameter(1))
  }
  ROOT tmp_21 = (bf16[28672], bf16[2,8192,14336]) tuple(tmp_20, tmp_15)
}
```

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
| Benchmark                                              | Speedup |
|--------------------------------------------------------|---------|
| gpu_hlo.hlo                                            |   1.01x |
| hlo_llama31_8b_bf16_1x8.hlo                            |   0.99x |
| hlo_llama31_8b_fp8_1x8.hlo                             |   1.01x |
| hlo_llama3_8b_bf16_activation_offloading_1x8.hlo       |   1.00x |
| hlo_mixtral_8x7b_bf16_1x8.hlo                          |   1.00x |
| nv_maxtext_1n1g_jit_train_step_before_optimization.hlo |   1.00x |

🧪 Unit Tests:
yes

🧪 Execution Tests:
no