### PR TITLE
Update .clang-format for header sorting rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,34 +6,42 @@ AlignTrailingComments:
 IncludeBlocks: Regroup
 IncludeCategories:
   # Priority 1: Standard C/C++ headers (angle brackets) - separated by blank line
-  - Regex:    '^<.*>$'
+  - Regex:    '^<[a-z_]+>$'
     Priority: 1
     SortPriority: 1
   # Priority 2: All other headers (no blank lines between them, sorted by SortPriority)
-  # absl headers
-  - Regex:    '^"absl/.*"$'
+  # gtest/gmock headers (angle brackets, but not standard headers)
+  - Regex:    '^<g(test|mock)/.*>$'
     Priority: 2
     SortPriority: 2
+  # absl headers    
+  - Regex:    '^"absl/.*"$'
+    Priority: 2
+    SortPriority: 3
   # llvm headers
   - Regex:    '^"llvm/.*"$'
     Priority: 2
-    SortPriority: 3
+    SortPriority: 4
   # mlir headers
   - Regex:    '^"mlir/.*"$'
     Priority: 2
-    SortPriority: 4
+    SortPriority: 5
+  # third_party libraries
+  - Regex:    '^"third_party/.*"$'
+    Priority: 2
+    SortPriority: 6
   # google (protobuf, etc.) headers
   - Regex:    '^"google/.*"$'
     Priority: 2
-    SortPriority: 5
+    SortPriority: 7
   # xla headers (including xla/tsl)
   - Regex:    '^"xla/.*"$'
     Priority: 2
-    SortPriority: 6
+    SortPriority: 8
   # tsl headers (without xla/ prefix)
   - Regex:    '^"tsl/.*"$'
     Priority: 2
-    SortPriority: 7
+    SortPriority: 9
   # Default catch-all for any other headers
   - Regex:    '.*'
     Priority: 2


### PR DESCRIPTION
Update .clang-format for header sorting rules to keep gmock/gtest and third_party includes