### PR TITLE
[clangd] Add strict includes checking to clangd config

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,27 @@
+# Copyright 2026 The OpenXLA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CompileFlags:
+  # Use the compile_commands.json for build flags
+  CompilationDatabase: .
+
+Diagnostics:
+  # Enable strict include checking
+  UnusedIncludes: Strict
+  MissingIncludes: Strict
+
+# Improve code completion and navigation
+Index:
+  Background: Build
+  StandardLibrary: Yes


### PR DESCRIPTION
clangd + vscode plugin correctly highlight missing headers