### PR TITLE
[ROCm] Skip conditional tests on ROCm as they are not supported by HIP Graphs

### DIFF
--- a/xla/service/gpu/tests/command_buffer_test.cc
+++ b/xla/service/gpu/tests/command_buffer_test.cc
@@ -78,6 +78,9 @@ class CommandBufferTest
       public ::testing::WithParamInterface<
           DebugOptions::CommandBufferSchedulingMode> {
  protected:
+  bool IsRocm() {
+    return test_runner().HasProperty(HloRunnerPropertyTag::kUsingGpuRocm);
+  }
   DebugOptions GetDebugOptionsForTest() const override {
     DebugOptions debug_options = HloPjRtTestBase::GetDebugOptionsForTest();
     debug_options.set_xla_gpu_command_buffer_scheduling_mode(GetParam());
@@ -297,6 +300,9 @@ TEST_P(CommandBufferTest, TracedCustomCalls) {
 }
 
 TEST_P(CommandBufferTest, TrueFalseConditional) {
+  if(IsRocm()) {
+    GTEST_SKIP() << "Graph conditionals are not yet supported on HIP graphs";
+  }
   constexpr absl::string_view hlo_text = R"(
   HloModule m, is_scheduled=true
 
@@ -356,6 +362,9 @@ TEST_P(CommandBufferTest, TrueFalseConditional) {
 }
 
 TEST_P(CommandBufferTest, IndexConditional) {
+  if(IsRocm()) {
+    GTEST_SKIP() << "Graph conditionals are not yet supported on HIP graphs";
+  }
   constexpr absl::string_view hlo_text = R"(
   HloModule m, is_scheduled=true
 
@@ -423,6 +432,9 @@ TEST_P(CommandBufferTest, IndexConditional) {
 }
 
 TEST_P(CommandBufferTest, WhileLoop) {
+  if(IsRocm()) {
+    GTEST_SKIP() << "Graph conditionals are not yet supported on HIP graphs";
+  }
   constexpr absl::string_view hlo_text = R"(
   HloModule m, is_scheduled=true
 


### PR DESCRIPTION


📝 Summary of Changes
Conditionals are not supported by HIP graphs and those tests are skipped. 


🚀 Kind of Contribution
 🐛 Bug Fix
