### PR TITLE
[XLA:GPU] Add experimental flag to allow all fusions to be autotuned with Triton

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -471,6 +471,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_experimental_scaled_dot_with_triton(false);
   opts.set_xla_gpu_experimental_use_raft_select_k(false);
   opts.set_xla_early_exit_with_layouts(false);
+  opts.set_xla_gpu_experimental_all_fusions_with_triton(false);
 
   opts.add_xla_gpu_experimental_autotune_backends(
       DebugOptions::AUTOTUNE_BACKEND_TRITON);
@@ -2388,6 +2389,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "  'cudnn,triton' (overwrites defaults)\n"
       "  '+cudnn,-cublas' (adds/removes from defaults)\n"
       "Available: cudnn, triton, cublas, cublaslt."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_all_fusions_with_triton",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_experimental_all_fusions_with_triton),
+      debug_options->xla_gpu_experimental_all_fusions_with_triton(),
+      "Experimental: If true, autotune all fusions with block level emitter."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_gemm_autotuner_override_file",
       string_setter_for(

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -426,10 +426,7 @@ NVPTXCompiler::GetCodegenBackends(
 
 namespace {
 
-// Returns true if the instruction is a fusion that would go through the native
-// emitter, but may benefit from going through the block-level emitter.
-// Currently, we only do this for reductions and transposes.
-bool ShouldAutotuneBetweenFusionEmitters(const HloInstruction& instruction) {
+bool ShouldAutotuneBetweenFusionEmittersAny(const HloInstruction& instruction) {
   if (instruction.opcode() != HloOpcode::kFusion) {
     return false;
   }
@@ -445,6 +442,15 @@ bool ShouldAutotuneBetweenFusionEmitters(const HloInstruction& instruction) {
                      HloPredicateIsOp<HloOpcode::kScatter>)) {
     return false;
   }
+  return true;
+}
+
+// Returns true if the instruction is a fusion that would go through the native
+// emitter, but may benefit from going through the block-level emitter.
+// Currently, we only do this for reductions and transposes.
+bool ShouldAutotuneBetweenFusionEmitters(const HloInstruction& instruction) {
+  if (!ShouldAutotuneBetweenFusionEmittersAny(instruction)) return false;
+  auto fusion = Cast<const HloFusionInstruction>(&instruction);
   return absl::c_any_of(
       fusion->fused_instructions_computation()->instructions(),
       HloPredicateIsOp<HloOpcode::kReduce, HloOpcode::kTranspose>);
@@ -477,14 +483,18 @@ absl::Status NVPTXCompiler::AddFusionAutotuningPass(
       /*use_default_config=*/true);
   backends.push_back(std::move(ble_backend));
 
+  auto should_autotune =
+      debug_options.xla_gpu_experimental_all_fusions_with_triton()
+          ? ShouldAutotuneBetweenFusionEmittersAny
+          : ShouldAutotuneBetweenFusionEmitters;
+
   TF_ASSIGN_OR_RETURN(
       std::unique_ptr<AutotunerPass> autotuner_pass,
-      AutotunerPass::Create(std::move(backends), debug_options, stream_executor,
-                            thread_pool, ShouldAutotuneBetweenFusionEmitters,
-                            target_config, options.device_allocator,
-                            /*optimize_scratch_bytes=*/false,
-                            MultiProcessKeyValueStore(),
-                            /*allow_reg_spills=*/true));
+      AutotunerPass::Create(
+          std::move(backends), debug_options, stream_executor, thread_pool,
+          should_autotune, target_config, options.device_allocator,
+          /*optimize_scratch_bytes=*/false, MultiProcessKeyValueStore(),
+          /*allow_reg_spills=*/true));
   pipeline->AddPass(std::move(autotuner_pass));
   return absl::OkStatus();
 }

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -624,6 +624,9 @@ message DebugOptions {
 
   optional bool xla_gpu_exhaustive_tiling_search = 219;
 
+  // If true, autotune all fusions with block level emitter.
+  optional bool xla_gpu_experimental_all_fusions_with_triton = 444;
+
   // If true, allows unroll factor 8 on Blackwell architectures. This is also
   // guarded with a heuristic, but the heuristic is not perfect, so enabling
   // this flag can cause both performance improvements and performance
@@ -1349,7 +1352,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 444
+  // Next id: 445
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
📝 Summary of Changes
This addition of the flag "xla_gpu_experimental_autotune_all_fusions_with_block_level_emitter" enables all fusions (including elementwise) to be implemented through Triton backend. 

🎯 Justification
This can be useful for evaluating the effect of enabling TMA through Triton.