### PR TITLE
[XLA] Add missing return to prevent nullptr dereference

### DIFF
--- a/xla/service/memory_space_assignment/algorithm.cc
+++ b/xla/service/memory_space_assignment/algorithm.cc
@@ -4445,6 +4445,8 @@ void MsaAlgorithm::UpdateAllocationRequirementForUseAliases(
           << (aliased_allocation ? aliased_allocation->ToString()
                                  : "couldn't find the aliased allocation");
 
+  if (!aliased_allocation) return;
+
   for (const HloPosition& aliased_position : use.aliases) {
     AddAliasedRequiredAssignment(aliased_position.instruction,
                                  aliased_position.index, aliased_allocation);


### PR DESCRIPTION
Hi, I was testing TensorFlow code with Svace static analyzer and found possible null dereference in XLA.

Possible null dereference may occur because of missing return in MsaAlgorithm::UpdateAllocationRequirementForUseAliases(). There is a case when `aliased_allocation` variable could be null, and it could be dereferenced in AddAliasedRequiredAssignment().

https://github.com/tensorflow/tensorflow/issues/99907

