### PR TITLE
[xla:gpu] Remove persistent collective cliques

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1897,11 +1897,8 @@ cc_library(
         "//xla/service/gpu:gpu_executable_run_options",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:statusor",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/base:no_destructor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/synchronization",
         "@tsl//tsl/profiler/lib:traceme",
     ],
 )

--- a/xla/backends/gpu/runtime/collective_cliques.h
+++ b/xla/backends/gpu/runtime/collective_cliques.h
@@ -16,8 +16,6 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_RUNTIME_COLLECTIVE_CLIQUES_H_
 #define XLA_BACKENDS_GPU_RUNTIME_COLLECTIVE_CLIQUES_H_
 
-#include <cstdint>
-
 #include "absl/status/statusor.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_cliques.h"
@@ -34,8 +32,7 @@ namespace xla::gpu {
 class CollectiveCliques {
  public:
   CollectiveCliques() = default;
-  CollectiveCliques(AcquiredCliquesMap cliques_map,
-                    int32_t num_transient_cliques);
+  explicit CollectiveCliques(AcquiredCliquesMap cliques_map);
 
   absl::StatusOr<Communicator*> GetComm(const GpuCliqueKey& clique_key,
                                         RankId rank) const;
@@ -50,23 +47,14 @@ class CollectiveCliques {
 
   bool empty() const { return cliques_map_.empty(); }
 
-  bool num_transient_cliques() const { return num_transient_cliques_; }
-
  private:
   AcquiredCliquesMap cliques_map_;
-
-  // The number of acquired non-persistent clique. We need to keep track of
-  // newly created communicators to insert rendezvous after first
-  // initialization, because otherwise we observe deadlocks with NCCL
-  // collectives backends.
-  int32_t num_transient_cliques_ = 0;
 };
 
 // Acquires collective cliques using the given collective parameters for all
 // requested GPU cliques.
 absl::StatusOr<CollectiveCliques> AcquireCollectiveCliques(
-    const CollectiveParams& params, const CollectiveCliqueRequests& cliques,
-    bool use_persistent_cliques);
+    const CollectiveParams& params, const CollectiveCliqueRequests& cliques);
 
 }  // namespace xla::gpu
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -249,8 +249,6 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_command_buffer_unroll_loops(false);
   opts.set_xla_cmd_buffer_trace_cache_size(16);
 
-  opts.set_xla_gpu_collectives_use_persistent_cliques(false);
-
   // Despite the name, fast min/max on GPUs does not seem to be any faster, and
   // adds very counter-intuitive "NaN-swallowing" behavior.
   opts.set_xla_gpu_enable_fast_min_max(false);
@@ -1707,12 +1705,6 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 bool_setter_for(&DebugOptions::set_xla_gpu_enable_cublaslt),
                 debug_options->xla_gpu_enable_cublaslt(),
                 "Use cuBLASLt for GEMMs when possible."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_collectives_use_persistent_cliques",
-      bool_setter_for(
-          &DebugOptions::set_xla_gpu_collectives_use_persistent_cliques),
-      debug_options->xla_gpu_collectives_use_persistent_cliques(),
-      "Use persistent per-process XLA:GPU collectives cliques"));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_enable_command_buffer",
       SetterForRepeatedEnum<DebugOptions::CommandBufferCmdType>(

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -486,11 +486,7 @@ absl::Status ExecuteThunksImpl(
   if (!mock_collectives) {
     TF_ASSIGN_OR_RETURN(
         collective_cliques,
-        AcquireCollectiveCliques(
-            collective_params, clique_requests,
-            debug_options
-                ? debug_options->xla_gpu_collectives_use_persistent_cliques()
-                : false));
+        AcquireCollectiveCliques(collective_params, clique_requests));
   }
 
   TF_RETURN_IF_ERROR(multimem_registry.Build());
@@ -512,12 +508,12 @@ absl::Status ExecuteThunksImpl(
     TF_RETURN_IF_ERROR(thunk_sequence.Initialize(initialize_params));
   }
 
-  // Maybe join a round of rendezvous after thunk initialization. We do this
-  // only in presence of newly acquired collective cliques which means that we
-  // have collective operations and clique initialization is famous for
-  // introducing deadlocks if we try to execute it concurrently with other
-  // potentially memory-allocating operations.
-  if (collective_cliques.num_transient_cliques() > 0) {
+  // Join a round of rendezvous after thunk initialization. We do this only in
+  // presence of newly acquired collective cliques which means that we have
+  // collective operations and clique initialization is famous for introducing
+  // deadlocks if we try to execute it concurrently with other potentially
+  // memory-allocating operations.
+  if (!collective_cliques.empty()) {
     TF_RETURN_IF_ERROR(
         RendezvousAfterInitialization(run_options, debug_options));
   }

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -429,13 +429,6 @@ message DebugOptions {
   // transformation.
   optional int64 xla_gpu_collective_permute_decomposer_threshold = 237;
 
-  // Do not lock collective cliques for each XLA:GPU execution, and instead
-  // use per-process cliques that are never unlocked. This disables deadlock
-  // prevention mechanism in XLA:GPU and should be used at you own risk. If
-  // collective operations from concurrent executions are not correcctly ordered
-  // it may lead to deadlocks, crashes or will produce garbage.
-  optional bool xla_gpu_collectives_use_persistent_cliques = 354;
-
   optional CommandBufferSchedulingMode xla_gpu_command_buffer_scheduling_mode =
       404;
 


### PR DESCRIPTION
Persistent collective cliques is an unsafe escape hatch to cache NCCL cliques and avoid rendezvous before each execution. This is unused and easily leads to deadlocks. Remove it from XLA.

This is a rollback of experimental feature added in https://github.com/openxla/xla/commit/d93ec4a2f3573e8d3e07f5a628666188dd03e60d#diff-2aa478b8c4a8c178582b43774b52591df68d9f49fed0118db02a2be508cf2c49, it didn't find any users and it adds unneeded complexity to XLA.