### PR TITLE
[XLA:GPU] Add TMA config to autotuning when possible

### DIFF
--- a/xla/backends/gpu/autotuner/block_level_emitter.cc
+++ b/xla/backends/gpu/autotuner/block_level_emitter.cc
@@ -224,6 +224,13 @@ BlockLevelEmitterBackend::GetSupportedConfigs(const HloInstruction& instr) {
     }
     std::vector<std::unique_ptr<BackendConfig>> configs;
     configs.push_back(std::move(config.value()));
+    // If default config is taken from the existing backend config,
+    // leave it as is. Otherwise, add TMA config if available.
+    if (!instr.has_backend_config() &&
+        stream_executor::gpu::IsTmaAvailableForDevice(
+            target_config().device_description)) {
+      ExtendConfigsWithTma(configs);
+    }
     return configs;
   }
 


### PR DESCRIPTION
📝 Summary of Changes

Add configuration with enabled TMA to the list of configurations to autotune when TMA is available and default cost-model config is requested.

🎯 Justification

Previous TMA flag was explicitly removed and config extension with TMA [became default](https://github.com/openxla/xla/commit/b8f485f13c4332fd5c4c0d9d413d3c24204f53b8). However, it is enabled by default only when [use_default_config_](https://github.com/openxla/xla/blob/92b06d5b7044ab4a44401530249792d2dbbbd416/xla/backends/gpu/autotuner/block_level_emitter.cc#L220) is false. With my change, I attempted to enable it for the case when use_default_config_=true. As far as I understand it shouldn't have negative performance impact as it only expands the set of backend configurations to autotune {Native, BlockLevelEmitterWithoutTMA} -> {Native, BlockLevelEmitterWithoutTMA, BlockLevelEmitterWithTMA}.

TMA configs are appended on top of existing non-TMA configs, original non-TMA configs remain in the search space. To avoid breaking existing behavior when search space is not exhaustively explored, I checked that  `xla_gpu_exhaustive_tiling_search` flag only controls behavior of [triton](https://github.com/openxla/xla/blob/c970ddfceecba82b5a674f574e4f05091818f34c/xla/backends/gpu/autotuner/triton.cc#L128), [dot](https://github.com/openxla/xla/blob/c970ddfceecba82b5a674f574e4f05091818f34c/xla/service/gpu/autotuning/dot_search_space.cc#L124), and [gemm](https://github.com/openxla/xla/blob/c970ddfceecba82b5a674f574e4f05091818f34c/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc#L1041) search spaces. It looks like [block_level_emitter](https://github.com/openxla/xla/blob/c970ddfceecba82b5a674f574e4f05091818f34c/xla/backends/gpu/autotuner/block_level_emitter.cc) does not have non-exhaustive option so configs should not be dropped from consideration. There is also a [select_first_config](https://github.com/openxla/xla/blob/c970ddfceecba82b5a674f574e4f05091818f34c/xla/backends/autotuner/autotuner.cc#L356-L357) option, for which we should not modify behavior because we append TMA configs to the end of the list.
