### PR TITLE
[ROCm][XLA:GPU] Add ROCm-specific tuning for transpose emitter

### DIFF
--- a/xla/backends/gpu/codegen/emitters/BUILD
+++ b/xla/backends/gpu/codegen/emitters/BUILD
@@ -376,6 +376,7 @@ cc_library(
         "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/service/gpu:ir_emission_utils",
         "//xla/service/gpu:launch_dimensions",
+        "//xla/stream_executor:device_description",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",

--- a/xla/backends/gpu/codegen/emitters/transpose.cc
+++ b/xla/backends/gpu/codegen/emitters/transpose.cc
@@ -71,12 +71,15 @@ limitations under the License.
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
+#include "xla/stream_executor/device_description.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 
 namespace xla {
 namespace gpu {
 namespace {
+
+namespace se = ::stream_executor;
 
 using emitters::ApplyIndexing;
 using llvm::SmallVector;
@@ -98,9 +101,28 @@ namespace mt = ::mlir::tensor;
 namespace mv = ::mlir::vector;
 
 constexpr int kTileSize = 32;
-constexpr int kNumRows = 4;
-constexpr int kNumThreadsPerBlock = 128;
-constexpr int kMaxVectorizedBytes = 4;
+
+// Helper functions to get backend-specific configuration values.
+inline int GetNumRowsForDevice(const se::DeviceDescription& device) {
+  if (device.gpu_compute_capability().IsRocm()) {
+    return 8;
+  } else {
+    return 4;
+  }
+}
+
+inline int GetMaxVectorizedBytesForDevice(const se::DeviceDescription& device) {
+  if (device.gpu_compute_capability().IsRocm()) {
+    return 16;
+  } else {
+    return 4;
+  }
+}
+
+inline int64_t GetNumThreadsPerBlockForDevice(
+    const se::DeviceDescription& device) {
+  return static_cast<int64_t>(GetNumRowsForDevice(device)) * kTileSize;
+}
 
 // Reads the 2D vector tile <vector_size x vector_size> from the shared memory
 // at the given indices.
@@ -141,6 +163,13 @@ AffineExpr Swizzle(AffineExpr shmem_row, AffineExpr shmem_col,
 }
 
 }  // namespace
+
+TransposeFusionBase::TransposeFusionBase(const HloFusionAnalysis& analysis,
+                                         mlir::MLIRContext* mlir_context)
+    : analysis_(analysis),
+      mlir_context_(mlir_context),
+      num_threads_per_block_(
+          GetNumThreadsPerBlockForDevice(analysis.device_info())) {}
 
 absl::Status TransposeFusionBase::EmitEntryFunction(
     const emitters::PartitionedComputations& computations,
@@ -184,7 +213,8 @@ TransposeFusion::TransposeFusion(const HloFusionAnalysis& analysis,
       permutation_(transpose_.permutation),
       input_shape_(
           Permute(transpose_.dimensions, InversePermutation(permutation_))),
-      base_block_size_(kTileSize) {
+      base_block_size_(kTileSize),
+      num_rows_(GetNumRowsForDevice(analysis.device_info())) {
   ConstHloInstructionSet transposes_to_tile;
   int index = 0;
   int64_t shmem_usage = 0;
@@ -242,10 +272,11 @@ TransposeFusion::TransposeFusion(const HloFusionAnalysis& analysis,
     // the input dimensions are divisible by the vector size. Vectorizing loads
     // for large data types does not help (there's already enough parallelism).
     const auto& device = analysis_.device_info();
-    for (int vec_size = kMaxVectorizedBytes / max_element_bytes; vec_size > 1;
+    int max_vectorized_bytes = GetMaxVectorizedBytesForDevice(device);
+    for (int vec_size = max_vectorized_bytes / max_element_bytes; vec_size > 1;
          vec_size /= 2) {
       int elems_per_thread = vec_size * vec_size;
-      bool enough_work = Product(block_counts_) * kNumThreadsPerBlock >=
+      bool enough_work = Product(block_counts_) * num_threads_per_block_ >=
                          elems_per_thread * device.core_count() *
                              device.threads_per_core_limit();
       bool enough_shmem =
@@ -303,7 +334,7 @@ TransposeFusion::ComputeThreadIdToInputIndexing(
 }
 
 LaunchDimensions TransposeFusion::launch_dimensions() const {
-  return LaunchDimensions(Product(block_counts_), kNumThreadsPerBlock);
+  return LaunchDimensions(Product(block_counts_), num_threads_per_block_);
 }
 
 IndexingMap TransposeFusion::GetSharedMemoryIndexing(
@@ -321,12 +352,12 @@ IndexingMap TransposeFusion::GetSharedMemoryIndexing(
   }
   std::vector<int64_t> dim_var_sizes(6, 1);
   dim_var_sizes[KernelFusionInterface::kIndexingMapThreadIdxDims[0]] =
-      kNumThreadsPerBlock;
+      num_threads_per_block_;
   dim_var_sizes[KernelFusionInterface::kIndexingMapBlockIdxDims[0]] =
       Product(block_counts_);
   return {mlir::AffineMap::get(6, 2, thread_offsets, mlir_context),
           DimVarsFromGPUGrid(dim_var_sizes),
-          RangeVarsFromTensorSizes({block_size_ / kNumRows, vector_size_}),
+          RangeVarsFromTensorSizes({block_size_ / num_rows_, vector_size_}),
           {}};
 }
 
@@ -482,7 +513,7 @@ llvm::SmallVector<mlir::AffineExpr, 4> TransposeFusion::GetThreadOffsets(
       KernelFusionInterface::kIndexingMapThreadIdxDims[0], mlir_context);
   auto loop = getAffineSymbolExpr(0, mlir_context);
   auto vector = getAffineSymbolExpr(1, mlir_context);
-  int loop_stride = block_size_ * kNumRows;
+  int loop_stride = block_size_ * num_rows_;
   if (MostMinorDimensionUnchanged()) {
     loop_stride *= vector_size_;
   }
@@ -508,13 +539,13 @@ IndexingMap TransposeFusion::GetIndexing(bool input, const xla::Shape& shape,
   }
   std::vector<int64_t> dim_var_sizes(6, 1);
   dim_var_sizes[KernelFusionInterface::kIndexingMapThreadIdxDims[0]] =
-      kNumThreadsPerBlock;
+      num_threads_per_block_;
   dim_var_sizes[KernelFusionInterface::kIndexingMapBlockIdxDims[0]] =
       Product(block_counts_);
   IndexingMap result{
       mlir::AffineMap::get(6, 2, offsets, mlir_context),
       DimVarsFromTensorSizes(dim_var_sizes),
-      RangeVarsFromTensorSizes({block_size_ / kNumRows, vector_size_}),
+      RangeVarsFromTensorSizes({block_size_ / num_rows_, vector_size_}),
       {}};
   auto normalized_shape =
       input ? ShapeUtil::MakeShape(shape.element_type(), input_shape_)
@@ -545,14 +576,13 @@ std::vector<int64_t> GetBlockCounts(absl::Span<const int64_t> shape,
 PackedTranspose::PackedTranspose(const HloFusionAnalysis& analysis,
                                  const PackedTransposeDescription& spec,
                                  absl::Span<const int64_t> output_block_tile,
-                                 int64_t num_shmem_groups,
                                  MLIRContext* mlir_context)
     : TransposeFusionBase(analysis, mlir_context),
       spec_(spec),
       output_tile_(output_block_tile.begin(), output_block_tile.end()),
       input_tile_(Permute(output_tile_, spec_.canonical_inv_permutation)),
       block_counts_(GetBlockCounts(spec_.canonical_output_shape, output_tile_)),
-      num_shmem_groups_per_block_(num_shmem_groups),
+      num_shmem_groups_per_block_(num_threads_per_block_ / kNumShmemBanks),
       tile_size_t1_(input_tile_[spec_.dim_T1_input_id()]),
       tile_size_a_(input_tile_[spec_.dim_A_id()]),
       tile_size_t2_(input_tile_[spec_.dim_T2_input_id()]),
@@ -560,7 +590,8 @@ PackedTranspose::PackedTranspose(const HloFusionAnalysis& analysis,
       populated_shmem_rows_(tile_size_t2_) {
   VLOG(5) << "Transpose spec: " << spec.ToString()
           << "Output block tile: " << absl::StrJoin(output_block_tile, ", ")
-          << "\nNumber of shmem groups: " << num_shmem_groups << "\n";
+          << "\nNumber of shmem groups: " << num_shmem_groups_per_block_
+          << "\n";
   auto bits_per_element = GetBitwidth(spec_.elem_type());
   vector_size_ = kBankBitwidth / bits_per_element;
   CHECK_GE(vector_size_, 1);
@@ -637,7 +668,7 @@ PackedTranspose::ComputeThreadIdToInputIndexing(
 }
 
 LaunchDimensions PackedTranspose::launch_dimensions() const {
-  return LaunchDimensions(Product(block_counts_), kNumThreadsPerBlock);
+  return LaunchDimensions(Product(block_counts_), num_threads_per_block_);
 }
 
 PackedTranspose::WriteResult PackedTranspose::EmitWriteToShMemMlir(
@@ -1055,8 +1086,7 @@ std::unique_ptr<EmitterBase> CreateTransposeFusion(
   auto packed_transpose_tile = GetPackedTransposeTileSizes(spec);
   if (packed_transpose_tile.ok()) {
     return std::make_unique<PackedTranspose>(
-        analysis, spec, *packed_transpose_tile,
-        kNumThreadsPerBlock / kNumShmemBanks, mlir_context);
+        analysis, spec, *packed_transpose_tile, mlir_context);
   }
   return std::make_unique<TransposeFusion>(analysis, mlir_context);
 }

--- a/xla/backends/gpu/codegen/emitters/transpose.h
+++ b/xla/backends/gpu/codegen/emitters/transpose.h
@@ -50,8 +50,7 @@ namespace gpu {
 class TransposeFusionBase : public EmitterBase {
  public:
   explicit TransposeFusionBase(const HloFusionAnalysis& analysis,
-                               mlir::MLIRContext* mlir_context)
-      : analysis_(analysis), mlir_context_(mlir_context) {}
+                               mlir::MLIRContext* mlir_context);
 
  protected:
   absl::Status EmitEntryFunction(
@@ -88,6 +87,9 @@ class TransposeFusionBase : public EmitterBase {
 
   const HloFusionAnalysis& analysis_;
   mlir::MLIRContext* mlir_context_;
+
+  // Number of threads per block.
+  int64_t num_threads_per_block_;
 
   // Transpose instructions that require shared memory. Note that not all
   // transposes require shared memory, e.g. the ones with a large innermost
@@ -161,6 +163,7 @@ class TransposeFusion : public TransposeFusionBase {
   int vector_size_;
   int block_size_;
   int64_t base_block_size_;
+  int num_rows_;
 };
 
 // Packed transpose is a more advanced version of the transpose emitter.
@@ -239,7 +242,6 @@ class PackedTranspose : public TransposeFusionBase {
   explicit PackedTranspose(const HloFusionAnalysis& analysis,
                            const PackedTransposeDescription& spec,
                            absl::Span<const int64_t> output_block_tile,
-                           int64_t num_shmem_groups,
                            mlir::MLIRContext* mlir_context);
 
   LaunchDimensions launch_dimensions() const override;


### PR DESCRIPTION
Use different thread/vectorization parameters for AMD vs NVIDIA GPUs. It allows the transpose kernel to perform better on AMD hardware while maintaining the existing behavior on other platforms.