### PR TITLE
Fix MIOpen linking for RNN kernels

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -301,6 +301,7 @@ cc_library(
         "%{rocm_root}/lib/libMIOpen*.so*",
         "%{rocm_root}/share/miopen/**",
     ]),
+    linkopts = ["-lMIOpen"],
     include_prefix = "rocm",
     includes = [
         "%{rocm_root}/include",


### PR DESCRIPTION
Add explicit linkopts to miopen cc_library target to ensure libMIOpen.so is properly linked at runtime. 

📝 Summary of Changes
This fixes AttributeError: module 'jaxlib.gpu_rnn' has no attribute 'compute_rnn_workspace_reserve_space_sizes' in experimental_rnn_test in JAX. Without this change, the _rnn.so shared library fails to load MIOpen symbols properly, causing RNN test failures.
with this fix experimental_rnn_test pass:
<img width="1518" height="1292" alt="experimental_rnn_with_fix" src="https://github.com/user-attachments/assets/4e58fc86-4527-45f1-8a6c-2fd49d0c1b8a" />



🚀 Kind of Contribution
🐛 Bug Fix

