### PR TITLE
[NVIDIA GPU] Enable nccl symmetric kernels by default

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -282,7 +282,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_termination_timeout_seconds(-1);
   opts.set_xla_gpu_enable_shared_constants(true);
   opts.set_xla_gpu_enable_nccl_user_buffers(false);
-  opts.set_xla_gpu_experimental_enable_nccl_symmetric_buffers(false);
+  opts.set_xla_gpu_experimental_enable_nccl_symmetric_buffers(true);
   opts.set_xla_gpu_experimental_enable_nvshmem(false);
   opts.set_xla_gpu_enable_nccl_comm_splitting(true);
   opts.set_xla_gpu_nccl_init_max_rank_per_root_ratio(0);


### PR DESCRIPTION
📝 Summary of Changes
Enables nccl symmetric kernels by default

🎯 Justification
Symmetric kernels have smaller latencies compared legacy kernels, they also consume less SMs. NCCL symmetric kernels have been integrated into xla for some time and we have been running with it on. This pr attempts to enable it by default.
Note that symmetric buffers are allocated in the collective memory space which is outside of xla's default bfc allocator pool. XLA_CLIENT_MEM_FRACTION needs to be lowered if it's manually set to a high ratio. This needs xla to upgrade to nccl 2.28.

🚀 Kind of Contribution
⚡️ Performance Improvement,


📊 Benchmark (for Performance Improvements)
hlo_llama31_8b_bf16_1x8.hlo -> 7% speedup
hlo_llama31_8b_fp8_1x8.hlo -> 8% speedup


🧪 Unit Tests:
all existing unit tests

🧪 Execution Tests:
all existing execution tests