### PR TITLE
Add HLO Passes documentation to ToC

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -33,6 +33,8 @@ toc:
     path: /xla/emitters
   - title: Hermetic CUDA overview
     path: /xla/hermetic_cuda
+  - title: HLO Passes
+    path: /xla/hlo_passes
   - title: Indexing Analysis
     path: /xla/indexing
   - title: LHS Cost Model


### PR DESCRIPTION
📝 Summary of Changes
Adds previously merged HLO Passes documentation page to site Table of Contents.

🚀 Kind of Contribution
Please remove what does not apply: 📚 Documentation
