### PR TITLE
[XLA:GPU][oneAPI] Add direction-agnostic asynchronous memcpy and tests

### DIFF
--- a/xla/stream_executor/sycl/sycl_gpu_runtime.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.cc
@@ -413,6 +413,34 @@ absl::StatusOr<std::optional<::sycl::event>> SyclGetRecentEventFromStream(
   }
 }
 
+absl::Status SyclMemcpyAsync(::sycl::queue* stream_handle, void* dst,
+                             const void* src, size_t byte_count,
+                             SyclMemcpyKind kind) {
+  if (dst == nullptr || src == nullptr) {
+    return absl::InvalidArgumentError(
+        "SyclMemcpyAsync: Null pointer provided for destination or source.");
+  }
+  if (byte_count == 0) {
+    LOG(WARNING) << "SyclMemcpyAsync: Attempting to copy zero bytes, "
+                    "skipping operation.";
+    return absl::OkStatus();
+  }
+  switch (kind) {
+    case SyclMemcpyKind::kSyclMemcpyDeviceToHost:
+      return MemcpyDeviceToHost(stream_handle, dst, src, byte_count,
+                                /*async=*/true);
+    case SyclMemcpyKind::kSyclMemcpyHostToDevice:
+      return MemcpyHostToDevice(stream_handle, dst, src, byte_count,
+                                /*async=*/true);
+    case SyclMemcpyKind::kSyclMemcpyDeviceToDevice:
+      return MemcpyDeviceToDevice(stream_handle, dst, src, byte_count,
+                                  /*async=*/true);
+    default:
+      return absl::InvalidArgumentError(
+          "SyclMemcpyAsync: Invalid SyclMemcpyKind provided.");
+  }
+}
+
 absl::Status SyclMemcpyDeviceToHost(int device_ordinal, void* dst_host,
                                     const void* src_device, size_t byte_count) {
   if (dst_host == nullptr || src_device == nullptr) {

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.h
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.h
@@ -165,6 +165,23 @@ absl::StatusOr<std::optional<::sycl::event>> SyclGetRecentEventFromStream(
 // only when the source and destination buffers do not overlap. Add support for
 // overlapping copies if needed via a SYCL kernel.
 
+enum class SyclMemcpyKind {
+  // TODO(intel-tf): Support kSyclMemcpyDefault to let the SYCL runtime infer
+  // the copy direction based on the pointer locations.
+  kSyclMemcpyDeviceToHost,
+  kSyclMemcpyHostToDevice,
+  kSyclMemcpyDeviceToDevice,
+};
+
+// Asynchronously copies data between host and device or between device buffers
+// using the given SYCL stream. The copy direction is determined by `kind`.
+// Does nothing and returns OK status if byte_count is zero.
+// The operation may return before the copy is complete, hence the caller must
+// ensure that the stream is synchronized before accessing the copied data.
+absl::Status SyclMemcpyAsync(::sycl::queue* stream_handle, void* dst,
+                             const void* src, size_t byte_count,
+                             SyclMemcpyKind kind) ABSL_ATTRIBUTE_NONNULL(1);
+
 // Copies data from a device buffer to a host buffer using the default SYCL
 // stream for the specified device ordinal. The copy is synchronous and blocks
 // until the operation is complete.

--- a/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
@@ -270,6 +270,131 @@ TEST_F(SyclGpuRuntimeTest, TestSyclGetRecentEventFromStream) {
   EXPECT_EQ(stream_handle, nullptr);
 }
 
+TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_DeviceToHost) {
+  constexpr int kCount = 10;
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamPtr stream_handle,
+      SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
+                                        /*enable_multiple_streams=*/false));
+  ASSERT_NE(stream_handle, nullptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* src_device,
+                          AllocateAndInitDeviceBuffer(kCount, 0xDEADC0DE));
+  TF_ASSERT_OK_AND_ASSIGN(void* dst_host, AllocateHostBuffer(kCount));
+
+  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_host, src_device,
+                              sizeof(int) * kCount,
+                              SyclMemcpyKind::kSyclMemcpyDeviceToHost)
+                  .ok());
+
+  // Synchronize the stream to ensure the copy is complete before checking
+  // results.
+  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+
+  // Check the results after synchronization.
+  VerifyIntBuffer(dst_host, kCount, 0xDEADC0DE);
+
+  FreeAndNullify(src_device);
+  FreeAndNullify(dst_host);
+
+  // Destroy the stream after use.
+  ASSERT_TRUE(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  EXPECT_EQ(stream_handle, nullptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_HostToDeviceAndBack) {
+  constexpr int kCount = 10;
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamPtr stream_handle,
+      SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
+                                        /*enable_multiple_streams=*/false));
+  ASSERT_NE(stream_handle, nullptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(void* src_host,
+                          AllocateAndInitHostBuffer(kCount, 0xDEADC0DE));
+  TF_ASSERT_OK_AND_ASSIGN(void* dst_device, AllocateDeviceBuffer(kCount));
+
+  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_device, src_host,
+                              sizeof(int) * kCount,
+                              SyclMemcpyKind::kSyclMemcpyHostToDevice)
+                  .ok());
+
+  // Clear out the host buffer to ensure data is copied back correctly.
+  // Before that, synchronize to ensure the first copy is done.
+  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+  for (int i = 0; i < kCount; ++i) {
+    static_cast<int*>(src_host)[i] = 0;
+  }
+
+  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), src_host, dst_device,
+                              sizeof(int) * kCount,
+                              SyclMemcpyKind::kSyclMemcpyDeviceToHost)
+                  .ok());
+
+  // Synchronize the stream to ensure the copy is complete before checking
+  // results.
+  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+
+  // Check the results after synchronization.
+  VerifyIntBuffer(src_host, kCount, 0xDEADC0DE);
+
+  FreeAndNullify(src_host);
+  FreeAndNullify(dst_device);
+
+  // Destroy the stream after use.
+  ASSERT_TRUE(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  EXPECT_EQ(stream_handle, nullptr);
+}
+
+TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_DeviceToDeviceAndBackToHost) {
+  constexpr int kCount = 10;
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamPtr stream_handle,
+      SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
+                                        /*enable_multiple_streams=*/false));
+  ASSERT_NE(stream_handle, nullptr);
+
+  // Allocate device buffers that reside on the same device.
+  TF_ASSERT_OK_AND_ASSIGN(void* src_device,
+                          AllocateAndInitDeviceBuffer(kCount, 0xDEADC0DE));
+  TF_ASSERT_OK_AND_ASSIGN(void* dst_device,
+                          AllocateAndInitDeviceBuffer(kCount, 0));
+
+  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_device, src_device,
+                              sizeof(int) * kCount,
+                              SyclMemcpyKind::kSyclMemcpyDeviceToDevice)
+                  .ok());
+
+  // Synchronize to ensure the device-to-device copy is done before copying
+  // back to host.
+  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+
+  TF_ASSERT_OK_AND_ASSIGN(void* dst_host, AllocateAndInitHostBuffer(kCount, 0));
+
+  // Verify the copy by reading back to host.
+  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_host, dst_device,
+                              sizeof(int) * kCount,
+                              SyclMemcpyKind::kSyclMemcpyDeviceToHost)
+                  .ok());
+
+  // Synchronize the stream to ensure the copy is complete before checking
+  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+
+  // Check the results after synchronization.
+  VerifyIntBuffer(dst_host, kCount, 0xDEADC0DE);
+
+  FreeAndNullify(src_device);
+  FreeAndNullify(dst_device);
+  FreeAndNullify(dst_host);
+
+  // Destroy the stream after use.
+  ASSERT_TRUE(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  EXPECT_EQ(stream_handle, nullptr);
+}
+
 TEST_F(SyclGpuRuntimeTest, TestMemcopyDeviceToHost) {
   constexpr int kCount = 12;
   TF_ASSERT_OK_AND_ASSIGN(void* src_device,

--- a/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
@@ -282,14 +282,13 @@ TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_DeviceToHost) {
                           AllocateAndInitDeviceBuffer(kCount, 0xDEADC0DE));
   TF_ASSERT_OK_AND_ASSIGN(void* dst_host, AllocateHostBuffer(kCount));
 
-  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_host, src_device,
-                              sizeof(int) * kCount,
-                              SyclMemcpyKind::kSyclMemcpyDeviceToHost)
-                  .ok());
+  ASSERT_OK(SyclMemcpyAsync(stream_handle.get(), dst_host, src_device,
+                            sizeof(int) * kCount,
+                            SyclMemcpyKind::kSyclMemcpyDeviceToHost));
 
   // Synchronize the stream to ensure the copy is complete before checking
   // results.
-  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+  ASSERT_OK(SyclStreamSynchronize(stream_handle.get()));
 
   // Check the results after synchronization.
   VerifyIntBuffer(dst_host, kCount, 0xDEADC0DE);
@@ -298,8 +297,8 @@ TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_DeviceToHost) {
   FreeAndNullify(dst_host);
 
   // Destroy the stream after use.
-  ASSERT_TRUE(
-      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  ASSERT_OK(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle));
   EXPECT_EQ(stream_handle, nullptr);
 }
 
@@ -315,26 +314,24 @@ TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_HostToDeviceAndBack) {
                           AllocateAndInitHostBuffer(kCount, 0xDEADC0DE));
   TF_ASSERT_OK_AND_ASSIGN(void* dst_device, AllocateDeviceBuffer(kCount));
 
-  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_device, src_host,
-                              sizeof(int) * kCount,
-                              SyclMemcpyKind::kSyclMemcpyHostToDevice)
-                  .ok());
+  ASSERT_OK(SyclMemcpyAsync(stream_handle.get(), dst_device, src_host,
+                            sizeof(int) * kCount,
+                            SyclMemcpyKind::kSyclMemcpyHostToDevice));
 
   // Clear out the host buffer to ensure data is copied back correctly.
   // Before that, synchronize to ensure the first copy is done.
-  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+  ASSERT_OK(SyclStreamSynchronize(stream_handle.get()));
   for (int i = 0; i < kCount; ++i) {
     static_cast<int*>(src_host)[i] = 0;
   }
 
-  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), src_host, dst_device,
-                              sizeof(int) * kCount,
-                              SyclMemcpyKind::kSyclMemcpyDeviceToHost)
-                  .ok());
+  ASSERT_OK(SyclMemcpyAsync(stream_handle.get(), src_host, dst_device,
+                            sizeof(int) * kCount,
+                            SyclMemcpyKind::kSyclMemcpyDeviceToHost));
 
   // Synchronize the stream to ensure the copy is complete before checking
   // results.
-  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+  ASSERT_OK(SyclStreamSynchronize(stream_handle.get()));
 
   // Check the results after synchronization.
   VerifyIntBuffer(src_host, kCount, 0xDEADC0DE);
@@ -343,8 +340,8 @@ TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_HostToDeviceAndBack) {
   FreeAndNullify(dst_device);
 
   // Destroy the stream after use.
-  ASSERT_TRUE(
-      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  ASSERT_OK(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle));
   EXPECT_EQ(stream_handle, nullptr);
 }
 
@@ -362,25 +359,23 @@ TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_DeviceToDeviceAndBackToHost) {
   TF_ASSERT_OK_AND_ASSIGN(void* dst_device,
                           AllocateAndInitDeviceBuffer(kCount, 0));
 
-  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_device, src_device,
-                              sizeof(int) * kCount,
-                              SyclMemcpyKind::kSyclMemcpyDeviceToDevice)
-                  .ok());
+  ASSERT_OK(SyclMemcpyAsync(stream_handle.get(), dst_device, src_device,
+                            sizeof(int) * kCount,
+                            SyclMemcpyKind::kSyclMemcpyDeviceToDevice));
 
   // Synchronize to ensure the device-to-device copy is done before copying
   // back to host.
-  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+  ASSERT_OK(SyclStreamSynchronize(stream_handle.get()));
 
   TF_ASSERT_OK_AND_ASSIGN(void* dst_host, AllocateAndInitHostBuffer(kCount, 0));
 
   // Verify the copy by reading back to host.
-  ASSERT_TRUE(SyclMemcpyAsync(stream_handle.get(), dst_host, dst_device,
-                              sizeof(int) * kCount,
-                              SyclMemcpyKind::kSyclMemcpyDeviceToHost)
-                  .ok());
+  ASSERT_OK(SyclMemcpyAsync(stream_handle.get(), dst_host, dst_device,
+                            sizeof(int) * kCount,
+                            SyclMemcpyKind::kSyclMemcpyDeviceToHost));
 
   // Synchronize the stream to ensure the copy is complete before checking
-  ASSERT_TRUE(SyclStreamSynchronize(stream_handle.get()).ok());
+  ASSERT_OK(SyclStreamSynchronize(stream_handle.get()));
 
   // Check the results after synchronization.
   VerifyIntBuffer(dst_host, kCount, 0xDEADC0DE);
@@ -390,8 +385,8 @@ TEST_F(SyclGpuRuntimeTest, TestSyclMemcopyAsync_DeviceToDeviceAndBackToHost) {
   FreeAndNullify(dst_host);
 
   // Destroy the stream after use.
-  ASSERT_TRUE(
-      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle).ok());
+  ASSERT_OK(
+      SyclStreamPool::DestroyStream(kDefaultDeviceOrdinal, stream_handle));
   EXPECT_EQ(stream_handle, nullptr);
 }
 


### PR DESCRIPTION
This PR implements a generic, direction-agnostic asynchronous memcpy and adds corresponding tests. It will be used for adding [profiler](https://github.com/openxla/xla/tree/main/xla/backends/profiler/gpu) support for oneAPI backend.