### PR TITLE
[XLA:CPU] Add s390x support to XLA CPU intrinsic device detection

### DIFF
--- a/xla/backends/cpu/codegen/ir_compiler.cc
+++ b/xla/backends/cpu/codegen/ir_compiler.cc
@@ -355,6 +355,8 @@ llvm::Error IrCompiler::RunIrPasses(llvm::Module& module,
     }
   } else if (target_triple.isAArch64() || target_triple.isARM()) {
     device_type = xla::codegen::intrinsics::DeviceType::kArmCpu;
+  } else if (target_triple.isSystemZ()) {
+    device_type = xla::codegen::intrinsics::DeviceType::kSystemZCpu;
   } else {
     LOG(FATAL) << "Unsupported CPU type: " << target_triple.str();
   }

--- a/xla/codegen/intrinsic/intrinsic.h
+++ b/xla/codegen/intrinsic/intrinsic.h
@@ -40,6 +40,7 @@ enum class DeviceType {
   kAmdCpu,
   kIntelCpu,
   kArmCpu,
+  kSystemZCpu,
   kNvidiaGpu,
   kAmdGpu,
 };


### PR DESCRIPTION
📝 Summary of Changes
Mapped the LLVM SystemZ target triple to a new DeviceType::kSystemZCpu in XLA CPU codegen, allowing intrinsic implementations to specialize for s390x platforms. These changes were also approved by [Tensorflow](https://github.com/tensorflow/tensorflow/pull/108270).

🎯 Justification
This change adds the necessary adjustments in XLA to ensure correct behavior on s390x (IBM Z) systems resolving test inconsistencies observed in TensorFlow. Changes are minimal and architecture-scoped, with no impact on existing little-endian platforms.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

🧪 Unit Tests:
Architecture specific changes, hence not needed.

🧪 Execution Tests:
Architecture specific changes, hence not needed.
