### PR TITLE
[XLA:GPU][oneAPI] Remove change to disable float conversion warning

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -299,7 +299,6 @@ common:sycl --define=tensorflow_mkldnn_contraction_kernel=0
 common:sycl --cxxopt=-std=c++17
 common:sycl --host_cxxopt=-std=c++17
 common:sycl --repo_env=SYCL_BUILD_HERMETIC=0
-common:sycl --copt=-Wno-implicit-float-size-conversion
 
 # Enable Clang for host and icpx for SYCL
 common:icpx_clang --repo_env TF_ICPX_CLANG=1


### PR DESCRIPTION
[631797c](https://github.com/openxla/xla/commit/631797c84cbb02e805ec89090214e8093fd8ba1d) commit in XLA caused the following failure in oneAPI GPU build:

`external/org_brotli/c/enc/backward_references_hq.c:199:27: error: implicit conversion between floating point types of different sizes [-Werror,-Wimplicit-float-size-conversion]`

The failure is fixed in rules_ml_toolchain (https://github.com/google-ml-infra/rules_ml_toolchain/pull/172)

This PR removes the extra change added in [631797c](https://github.com/openxla/xla/commit/631797c84cbb02e805ec89090214e8093fd8ba1d) since it is not needed.