### PR TITLE
Fix concurrent buffer test

### DIFF
--- a/xla/service/gpu/custom_call_test.cc
+++ b/xla/service/gpu/custom_call_test.cc
@@ -1069,7 +1069,7 @@ absl::Status UpadteBufferImpl(se::Stream* stream, ffi::AnyBuffer src,
   if (offset < 0 || offset > 2) {
     return absl::InternalError("Offset must be in [0, 2].");
   }
-  int32_t data[2];
+  int32_t data[4];
   se::DeviceAddressBase buffer_mem = ret->device_memory();
   TF_RETURN_IF_ERROR(stream->Memcpy(data, buffer_mem, sizeof(data)));
   TF_RETURN_IF_ERROR(stream->BlockHostUntilDone());
@@ -1105,8 +1105,7 @@ XLA_FFI_DEFINE_HANDLER(kUpdateBuffer2, UpdateBuffer2,
                            .Arg<ffi::AnyBuffer>()
                            .Ret<ffi::AnyBuffer>());
 
-// TODO: Enable this test once the emitter failure is fixed.
-TEST_F(CustomCallHloTest, DISABLED_CallConcurrentUpdateTwoBuffers) {
+TEST_F(CustomCallHloTest, CallConcurrentUpdateTwoBuffers) {
   xla::ffi::Ffi::RegisterStaticHandler(ffi::GetXlaFfiApi(),
                                        "xla.gpu.update_buffer1", PlatformName(),
                                        kUpdateBuffer1);
@@ -1174,82 +1173,5 @@ TEST_F(CustomCallHloTest, DISABLED_CallConcurrentUpdateTwoBuffers) {
   ASSERT_EQ(results.size(), kNumReplicas);
   EXPECT_THAT(results[0].data<int32_t>(), ::testing::Each(1));
 }
-
-// TODO: Enable this test once the runtime failure is fixed.
-TEST_F(CustomCallHloTest, DISABLED_CustomCallConcurrentUpdateTwoBuffers) {
-  xla::ffi::Ffi::RegisterStaticHandler(ffi::GetXlaFfiApi(),
-                                       "xla.gpu.update_buffer1", PlatformName(),
-                                       kUpdateBuffer1);
-  xla::ffi::Ffi::RegisterStaticHandler(ffi::GetXlaFfiApi(),
-                                       "xla.gpu.update_buffer2", PlatformName(),
-                                       kUpdateBuffer2);
-  const char* const kModuleStr = R"(
-
-  HloModule test
-
-  async_comp1 {
-   pa1 = b(s32[4]) parameter(0)
-   ROOT va1 = b(s32[4]) custom-call(pa1),
-     custom_call_target="xla.gpu.update_buffer1",
-     output_to_operand_aliasing={{}: (0, {})}, api_version=API_VERSION_TYPED_FFI
-  }
-
-  async_comp2 {
-   pa2 = b(s32[4]) parameter(0)
-   ROOT va2 = b(s32[4]) custom-call(pa2),
-     custom_call_target="xla.gpu.update_buffer2",
-     output_to_operand_aliasing={{}: (0, {})}, api_version=API_VERSION_TYPED_FFI
-  }
-
-  ENTRY test_computation {
-    p0 = s32[4] parameter(0)
-    p1 = s32[4] parameter(1)
-
-    b1_0 = b(s32[4]) custom-call(p0), custom_call_target="Pin",
-      output_to_operand_aliasing={{}: (0, {})}
-    b2_0 = b(s32[4]) custom-call(p1), custom_call_target="Pin",
-      output_to_operand_aliasing={{}: (0, {})}
-
-    b1_1_start = ((b(s32[4])), b(s32[4])) async-start(b1_0), calls=async_comp1,
-      frontend_attributes={_xla_stream_annotation="1"}
-    b1_1 = b(s32[4]) async-done(b1_1_start),
-      frontend_attributes={_xla_stream_annotation="1"},
-      backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false,"reification_cost":[],"device_type":"DEVICE_TYPE_INVALID"}
-    b2_1_start = ((b(s32[4])), b(s32[4])) async-start(b2_0), calls=async_comp2,
-      frontend_attributes={_xla_stream_annotation="2"}
-    b2_1 = b(s32[4]) async-done(b2_1_start),
-      frontend_attributes={_xla_stream_annotation="2"},
-      backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false,"reification_cost":[],"device_type":"DEVICE_TYPE_INVALID"}
-
-    v_1 = s32[4] custom-call(b1_1), custom_call_target="Unpin",
-      output_to_operand_aliasing={{}: (0, {})}
-    v_2 = s32[4] custom-call(b2_1), custom_call_target="Unpin",
-    output_to_operand_aliasing={{}: (0, {})}
-    ROOT or = s32[4] or(v_1, v_2)
-  })";
-
-  const int64_t kNumReplicas = 1;
-  HloModuleConfig config =
-      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
-  config.mutable_debug_options().set_xla_gpu_experimental_stream_annotation(
-      true);
-  config.mutable_debug_options().clear_xla_gpu_enable_command_buffer();
-  auto module = ParseAndReturnUnverifiedModule(kModuleStr, config);
-  EXPECT_TRUE(module.ok());
-  Array<int32_t> input1({4}), input2({4});
-  input1.Fill(0);
-  input2.Fill(0);
-  Literal input_literal1 = LiteralUtil::CreateFromArray(input1);
-  Literal input_literal2 = LiteralUtil::CreateFromArray(input2);
-
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::vector<Literal> results,
-      ExecuteReplicated(std::move(module.value()),
-                        {{&input_literal1, &input_literal2}}, kNumReplicas,
-                        /*use_threads=*/true, /*run_hlo_passes=*/true));
-  ASSERT_EQ(results.size(), kNumReplicas);
-  EXPECT_THAT(results[0].data<int32_t>(), ::testing::Each(1));
-}
-
 }  // anonymous namespace
 }  // namespace xla

--- a/xla/service/gpu/custom_call_test.cc
+++ b/xla/service/gpu/custom_call_test.cc
@@ -1173,5 +1173,82 @@ TEST_F(CustomCallHloTest, CallConcurrentUpdateTwoBuffers) {
   ASSERT_EQ(results.size(), kNumReplicas);
   EXPECT_THAT(results[0].data<int32_t>(), ::testing::Each(1));
 }
+
+// TODO: Enable this test once the runtime failure is fixed.
+TEST_F(CustomCallHloTest, DISABLED_CustomCallConcurrentUpdateTwoBuffers) {
+  xla::ffi::Ffi::RegisterStaticHandler(ffi::GetXlaFfiApi(),
+                                       "xla.gpu.update_buffer1", PlatformName(),
+                                       kUpdateBuffer1);
+  xla::ffi::Ffi::RegisterStaticHandler(ffi::GetXlaFfiApi(),
+                                       "xla.gpu.update_buffer2", PlatformName(),
+                                       kUpdateBuffer2);
+  const char* const kModuleStr = R"(
+
+  HloModule test
+
+  async_comp1 {
+   pa1 = b(s32[4]) parameter(0)
+   ROOT va1 = b(s32[4]) custom-call(pa1),
+     custom_call_target="xla.gpu.update_buffer1",
+     output_to_operand_aliasing={{}: (0, {})}, api_version=API_VERSION_TYPED_FFI
+  }
+
+  async_comp2 {
+   pa2 = b(s32[4]) parameter(0)
+   ROOT va2 = b(s32[4]) custom-call(pa2),
+     custom_call_target="xla.gpu.update_buffer2",
+     output_to_operand_aliasing={{}: (0, {})}, api_version=API_VERSION_TYPED_FFI
+  }
+
+  ENTRY test_computation {
+    p0 = s32[4] parameter(0)
+    p1 = s32[4] parameter(1)
+
+    b1_0 = b(s32[4]) custom-call(p0), custom_call_target="Pin",
+      output_to_operand_aliasing={{}: (0, {})}
+    b2_0 = b(s32[4]) custom-call(p1), custom_call_target="Pin",
+      output_to_operand_aliasing={{}: (0, {})}
+
+    b1_1_start = ((b(s32[4])), b(s32[4])) async-start(b1_0), calls=async_comp1,
+      frontend_attributes={_xla_stream_annotation="1"}
+    b1_1 = b(s32[4]) async-done(b1_1_start),
+      frontend_attributes={_xla_stream_annotation="1"},
+      backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false,"reification_cost":[],"device_type":"DEVICE_TYPE_INVALID"}
+    b2_1_start = ((b(s32[4])), b(s32[4])) async-start(b2_0), calls=async_comp2,
+      frontend_attributes={_xla_stream_annotation="2"}
+    b2_1 = b(s32[4]) async-done(b2_1_start),
+      frontend_attributes={_xla_stream_annotation="2"},
+      backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"force_earliest_schedule":false,"reification_cost":[],"device_type":"DEVICE_TYPE_INVALID"}
+
+    v_1 = s32[4] custom-call(b1_1), custom_call_target="Unpin",
+      output_to_operand_aliasing={{}: (0, {})}
+    v_2 = s32[4] custom-call(b2_1), custom_call_target="Unpin",
+    output_to_operand_aliasing={{}: (0, {})}
+    ROOT or = s32[4] or(v_1, v_2)
+  })";
+
+  const int64_t kNumReplicas = 1;
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options().set_xla_gpu_experimental_stream_annotation(
+      true);
+  config.mutable_debug_options().clear_xla_gpu_enable_command_buffer();
+  auto module = ParseAndReturnUnverifiedModule(kModuleStr, config);
+  EXPECT_TRUE(module.ok());
+  Array<int32_t> input1({4}), input2({4});
+  input1.Fill(0);
+  input2.Fill(0);
+  Literal input_literal1 = LiteralUtil::CreateFromArray(input1);
+  Literal input_literal2 = LiteralUtil::CreateFromArray(input2);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::vector<Literal> results,
+      ExecuteReplicated(std::move(module.value()),
+                        {{&input_literal1, &input_literal2}}, kNumReplicas,
+                        /*use_threads=*/true, /*run_hlo_passes=*/true));
+  ASSERT_EQ(results.size(), kNumReplicas);
+  EXPECT_THAT(results[0].data<int32_t>(), ::testing::Each(1));
+}
+
 }  // anonymous namespace
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
fixes the failing CallConcurrentUpdateTwoBuffers test.
The UpadteBufferImpl function was not updating the correct offsets.
