### PR TITLE
[ROCm][TSAN] Read device_count from collective params and avoid race with concurrent updates

### DIFF
--- a/xla/backends/gpu/runtime/all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/all_to_all_thunk.cc
@@ -128,12 +128,11 @@ AllToAllStartThunk::AllToAllStartThunk(
 
 absl::Status AllToAllStartThunk::Initialize(const InitializeParams& params) {
   TF_RETURN_IF_ERROR(CollectiveThunk::Initialize(params));
-  device_count_ = params.local_device_count;
-  CHECK_GT(device_count_, 0);
+  CHECK_GT(params.local_device_count, 0);
   XLA_VLOG_DEVICE(5, params.executor->device_ordinal())
-      << "Local device count : " << device_count_;
+      << "Local device count : " << params.local_device_count;
 
-  if (is_local() && p2p_memcpy_enabled_) {
+  if (is_local(params.local_device_count) && p2p_memcpy_enabled_) {
     TF_ASSIGN_OR_RETURN(
         GpuCliqueKey clique_key,
         GetGpuCliqueKey(*params.collective_params, config().replica_groups,
@@ -230,7 +229,8 @@ absl::StatusOr<bool> AllToAllStartThunk::RunCollective(
       ConvertToDeviceBuffers(params.buffer_allocations, buffers_,
                              config_.config.operand_element_type));
 
-  if (is_local() && p2p_memcpy_enabled_) {
+  if (is_local(params.collective_params->local_device_count) &&
+               p2p_memcpy_enabled_) {
     uint64_t* receive_pointer_map = nullptr;
     {
       absl::MutexLock lock(pointer_maps_mutex_);
@@ -261,12 +261,12 @@ absl::StatusOr<bool> AllToAllStartThunk::RunCollective(
   return true;
 }
 
-bool AllToAllStartThunk::is_local() const {
+bool AllToAllStartThunk::is_local(int device_count) const {
   for (const auto& replica_group : config_.config.replica_groups) {
-    const int64_t node_id = replica_group.replica_ids().at(0) / device_count_;
+    const int64_t node_id = replica_group.replica_ids().at(0) / device_count;
     if (!absl::c_all_of(replica_group.replica_ids(),
-                        [this, node_id](const int64_t rank) {
-                          return rank / device_count_ == node_id;
+                        [node_id, device_count](const int64_t rank) {
+                          return rank / device_count == node_id;
                         })) {
       return false;
     }

--- a/xla/backends/gpu/runtime/all_to_all_thunk.h
+++ b/xla/backends/gpu/runtime/all_to_all_thunk.h
@@ -100,12 +100,11 @@ class AllToAllStartThunk : public CollectiveThunk {
                                      se::Stream& stream,
                                      Communicator& comm) override;
 
-  bool is_local() const;
+  bool is_local(int device_count) const;
 
  private:
   const AllToAllConfig config_;
   const std::vector<Buffer> buffers_;
-  int64_t device_count_ = 1;
   bool p2p_memcpy_enabled_ = false;
 
   absl::Mutex pointer_maps_mutex_;

--- a/xla/backends/gpu/runtime/collective_params.cc
+++ b/xla/backends/gpu/runtime/collective_params.cc
@@ -87,7 +87,8 @@ absl::StatusOr<CollectiveParams> CollectiveParams::Create(
                           local_device_id, global_device_id,
                           run_options.run_options().device_assignment(),
                           device_id_map, clique_id_callback, incarnations,
-                          collective_max_nchannels, p2p_max_nchannels);
+                          collective_max_nchannels, p2p_max_nchannels,
+                          run_options.run_options().local_device_count());
 }
 
 CollectiveParams::CollectiveParams(
@@ -97,7 +98,7 @@ CollectiveParams::CollectiveParams(
     const GlobalDeviceIdMap* global_device_id_map,
     const CliqueIdCallback* clique_id_callback,
     const absl::flat_hash_map<GlobalDeviceId, IncarnationId>* incarnations,
-    int64_t collective_max_nchannels, int64_t p2p_max_nchannels)
+    int64_t collective_max_nchannels, int64_t p2p_max_nchannels, int local_device_count)
     : collectives(collectives),
       executor(executor),
       run_id(run_id),
@@ -109,6 +110,7 @@ CollectiveParams::CollectiveParams(
       clique_id_callback(clique_id_callback),
       incarnations(incarnations),
       collective_max_nchannels(collective_max_nchannels),
-      p2p_max_nchannels(p2p_max_nchannels) {}
+      p2p_max_nchannels(p2p_max_nchannels),
+      local_device_count(local_device_count) {}
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_params.h
+++ b/xla/backends/gpu/runtime/collective_params.h
@@ -68,6 +68,8 @@ struct CollectiveParams {
   int64_t collective_max_nchannels;
   int64_t p2p_max_nchannels;
 
+  int local_device_count = 0;
+
  private:
   CollectiveParams(
       GpuCollectives* collectives, se::StreamExecutor* executor, RunId run_id,
@@ -77,7 +79,7 @@ struct CollectiveParams {
       const GlobalDeviceIdMap* global_device_id_map,
       const CliqueIdCallback* clique_id_callback,
       const absl::flat_hash_map<GlobalDeviceId, IncarnationId>* incarnations,
-      int64_t collective_max_nchannels, int64_t p2p_max_nchannels);
+      int64_t collective_max_nchannels, int64_t p2p_max_nchannels, int local_device_count);
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_permute_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_permute_thunk.cc
@@ -182,9 +182,8 @@ CollectivePermuteStartThunk::CollectivePermuteStartThunk(
 absl::Status CollectivePermuteStartThunk::Initialize(
     const InitializeParams& params) {
   TF_RETURN_IF_ERROR(CollectiveThunk::Initialize(params));
-  device_count_ = params.local_device_count;
-  CHECK_GT(device_count_, 0);
-  VLOG(5) << "Local device count: " << device_count_;
+  CHECK_GT(params.local_device_count, 0);
+  VLOG(5) << "Local device count: " << params.local_device_count;
 
   if (p2p_memcpy_enabled_) {
     TF_ASSIGN_OR_RETURN(
@@ -341,7 +340,7 @@ absl::StatusOr<bool> CollectivePermuteStartThunk::RunCollective(
   const P2PConfig::SourceTargetMapEntry source_target =
       P2PConfig::GetSourceTarget(config_.id_to_source_target, current_id);
   bool is_local_peer =
-      IsLocalPeerTransfer(source_target, current_id, device_count_);
+      IsLocalPeerTransfer(source_target, current_id, params.collective_params->local_device_count);
   VLOG(5) << "Is local peer : " << (is_local_peer ? "true" : "false");
 
   bool use_memcpy = is_local_peer && recv_ptr_map_.IsInitialized(current_id) &&

--- a/xla/backends/gpu/runtime/collective_permute_thunk.h
+++ b/xla/backends/gpu/runtime/collective_permute_thunk.h
@@ -158,7 +158,6 @@ class CollectivePermuteStartThunk : public CollectiveThunk {
   absl::flat_hash_map<int64_t, std::unique_ptr<se::Event>>
       sender_barrier_events_;
   bool p2p_memcpy_enabled_ = false;
-  int64_t device_count_ = 0;
 };
 
 absl::Status RunCollectivePermute(

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
@@ -346,12 +346,12 @@ RaggedAllToAllStartThunk::InitializeOnce(const InitializeParams& params) {
     return absl::InternalError("Failed to allocate output offsets buffer.");
   }
 
-  if (is_local() && !use_multi_gpu_barrier_in_one_shot_kernel_) {
+  if (is_local(params.local_device_count) && !use_multi_gpu_barrier_in_one_shot_kernel_) {
     ASSIGN_OR_RETURN(state->start_event, executor->CreateEvent());
     ASSIGN_OR_RETURN(state->end_event, executor->CreateEvent());
   }
 
-  if (is_local() && use_multi_gpu_barrier_in_one_shot_kernel_) {
+  if (is_local(params.local_device_count) && use_multi_gpu_barrier_in_one_shot_kernel_) {
     using MultiGpuBarrierKernel = se::gpu::MultiGpuBarrierKernel;
 
     // 1. Allocate Signal Buffer (Array of uint32_t)
@@ -394,11 +394,10 @@ RaggedAllToAllStartThunk::InitializeOnce(const InitializeParams& params) {
 absl::Status RaggedAllToAllStartThunk::Initialize(
     const InitializeParams& params) {
   RETURN_IF_ERROR(CollectiveThunk::Initialize(params));
-  device_count_ = params.local_device_count;
 
   ASSIGN_OR_RETURN(RaggedAllToAllStreamState * state, InitializeOnce(params));
 
-  if (is_local() && use_multi_gpu_barrier_in_one_shot_kernel_) {
+  if (is_local(params.local_device_count) && use_multi_gpu_barrier_in_one_shot_kernel_) {
     // Rendezvous - Exchange output pointers and barrier signal buffers.
     ASSIGN_OR_RETURN(
         std::vector<DeviceBufferPair> device_buffers,
@@ -515,7 +514,8 @@ absl::StatusOr<bool> RaggedAllToAllStartThunk::RunCollective(
 
   bool should_use_one_shot_kernel = one_shot_kernel_enabled_ &&
                                     peer_access_enabled &&
-                                    IsOneShotKernelSupported() && is_local();
+                                    IsOneShotKernelSupported() &&
+                                    is_local(params.collective_params->local_device_count);
 
   if (should_use_one_shot_kernel &&
       !use_multi_gpu_barrier_in_one_shot_kernel_) {

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.h
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.h
@@ -185,13 +185,12 @@ class RaggedAllToAllStartThunk : public CollectiveThunk {
                                      Communicator& comm) override;
 
  private:
-  bool is_local() const {
-    return IsAllReplicasLocal(device_count_, config_.config);
+  bool is_local(int device_count) const {
+    return IsAllReplicasLocal(device_count, config_.config);
   }
 
   const RaggedAllToAllConfig config_;
   const std::vector<Buffer> buffers_;
-  int64_t device_count_ = -1;
   const bool one_shot_kernel_enabled_;
   const bool use_multi_gpu_barrier_in_one_shot_kernel_;
 


### PR DESCRIPTION
📝 Summary of Changes
Fix race condition detected by TSAN whilst updating local device count

🎯 Justification
Prevent race condition by reading local_device_count from collective params

🚀 Kind of Contribution
 🐛 Bug Fix

