### PR TITLE
[ROCm] Fix reduction emitter tests to work on ROCm

### DIFF
--- a/xla/backends/gpu/codegen/emitters/tests/reduce_row/mof_scalar_variadic.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/reduce_row/mof_scalar_variadic.hlo
@@ -16,11 +16,14 @@
   ROOT tuple = (f32[], f32[]) tuple(add0, add1)
 }
 
-fusion {
-  %p0 = f32[6,6] parameter(0)
+// Use 8x8 (64 elements) to ensure the reduction is routed to the Reduction
+// emitter on both CUDA (warp_size=32) and ROCm (warp_size=64). The heuristic
+// IsUnnestedReductionFasterThanElemental requires dims >= warp_size.
+%fusion {
+  %p0 = f32[8,8] parameter(0)
   %c0 = f32[] constant(0)
-  %neg = f32[6,6] negate(%p0)
+  %neg = f32[8,8] negate(%p0)
   %reduce1 = f32[] reduce(%neg, %c0), dimensions={0,1}, to_apply=%reducer1
   %reduce2 = (f32[], f32[]) reduce(%p0, %p0, %c0, %c0), dimensions={0,1}, to_apply=%reducer2
-  ROOT %tuple = (f32[], (f32[], f32[]), f32[6,6]) tuple(%reduce1, %reduce2, %neg)
+  ROOT %tuple = (f32[], (f32[], f32[]), f32[8,8]) tuple(%reduce1, %reduce2, %neg)
 }

--- a/xla/backends/gpu/codegen/emitters/tests/reduce_row/side_output_broadcast.hlo
+++ b/xla/backends/gpu/codegen/emitters/tests/reduce_row/side_output_broadcast.hlo
@@ -6,10 +6,13 @@
   ROOT add = f32[] add(p0, p1)
 }
 
+// Use 8x8 (64 elements) to ensure the reduction is routed to the Reduction
+// emitter on both CUDA (warp_size=32) and ROCm (warp_size=64). The heuristic
+// IsUnnestedReductionFasterThanElemental requires dims >= warp_size.
 fusion {
-  %p0 = f32[6,6] parameter(0)
+  %p0 = f32[8,8] parameter(0)
   %c0 = f32[] constant(0)
   %reduce = f32[] reduce(%p0, %c0), dimensions={0,1}, to_apply=%add
-  %broadcast = f32[6,6] broadcast(%reduce), dimensions={}
-  ROOT %tuple = (f32[6,6], f32[]) tuple(%broadcast, %reduce)
+  %broadcast = f32[8,8] broadcast(%reduce), dimensions={}
+  ROOT %tuple = (f32[8,8], f32[]) tuple(%broadcast, %reduce)
 }


### PR DESCRIPTION
The tests mof_scalar_variadic.hlo and side_output_broadcast.hlo were designed to test the Reduction emitter with Multi-Output Fusions (MOF) containing variadic reductions and side outputs. However, they used f32[6,6] (36 elements) which fails the
IsUnnestedReductionFasterThanElemental heuristic on ROCm (warp_size=64) while passing on CUDA (warp_size=32).

When the heuristic fails, the fusion is routed to the Loop emitter instead of the Reduction emitter. The Loop emitter cannot handle fusions with incompatible output shapes (e.g., f32[] and f32[6,6] in the same tuple), causing a segmentation fault in GetBitcastMap/ApplyIndexing.

Fix by increasing the test dimensions from 6x6 to 8x8 (64 elements), which satisfies the heuristic on both platforms. This ensures the tests exercise the Reduction emitter as originally intended on both CUDA and ROCm.