### PR TITLE
[NVIDIA GPU] Integrate nccl put api to collective permute

### DIFF
--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -173,6 +173,10 @@ class NcclCommunicator::NcclRegisteredBufferHandle
         symmetric_handle_(symmetric_handle),
         device_ordinal_(device_ordinal) {}
 
+  bool IsSymmetricHandle() const { return symmetric_handle_; }
+
+  void* GetHandle() const override { return handle_; }
+
   ~NcclRegisteredBufferHandle() override {
     if (auto status = Unregister(); !status.ok()) {
       LOG(ERROR) << status.message();
@@ -892,6 +896,69 @@ absl::Status NcclCommunicator::LaunchCollectivePermute(
   }
 
   TF_RETURN_IF_ERROR(GroupStart());
+
+#if NCCL_VERSION_CODE >= 22900
+  TF_ASSIGN_OR_RETURN(auto send_range,
+                      stream->parent()->GetMemoryRange(send_buffer));
+  TF_ASSIGN_OR_RETURN(auto recv_range,
+                      stream->parent()->GetMemoryRange(recv_buffer));
+  bool use_nccl_put = false;
+  Communicator::RegisteredBufferHandle* recv_buffer_handle_ptr;
+  {
+    absl::MutexLock lock(registered_buffers_.mu);
+    auto send_buffer_handle =
+        registered_buffers_.range_to_handle.find(send_range.opaque());
+    auto recv_buffer_handle =
+        registered_buffers_.range_to_handle.find(recv_range.opaque());
+    use_nccl_put =
+        send_buffer_handle != registered_buffers_.range_to_handle.end() &&
+        recv_buffer_handle != registered_buffers_.range_to_handle.end() &&
+        (dynamic_cast<NcclRegisteredBufferHandle*>(
+             send_buffer_handle->second.get()))
+            ->IsSymmetricHandle() &&
+        (dynamic_cast<NcclRegisteredBufferHandle*>(
+             recv_buffer_handle->second.get()))
+            ->IsSymmetricHandle();
+    recv_buffer_handle_ptr = recv_buffer_handle->second.get();
+  }
+
+  if (use_nccl_put) {
+    ncclWindow_t real_handle =
+        (ncclWindow_t)((dynamic_cast<NcclRegisteredBufferHandle*>(
+                            recv_buffer_handle_ptr))
+                           ->GetHandle());
+
+    for (const auto& target_rank : target_ranks) {
+      // Call put to send to receiving rank
+      int64_t recv_window_offset =
+          (uint8_t*)recv_buffer.opaque() - (uint8_t*)recv_range.opaque();
+      // Put data with signal to peer's receive buffer
+      VLOG(3) << absl::StreamFormat(
+          "[%d] Launching NCCL CollectivePermute operation using "
+          "ncclPutSignal.",
+          stream->parent()->device_ordinal());
+
+      XLA_NCCL_RETURN_IF_ERROR(ncclPutSignal(
+          send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
+          target_rank.value(), real_handle, recv_window_offset,
+          /*sigIdx=*/0, /*ctx=*/0, /*flags=*/0, comm_, AsCudaStream(stream)));
+      TF_RETURN_IF_ERROR(GroupEnd());
+      return absl::OkStatus();
+    }
+    TF_RETURN_IF_ERROR(GroupEnd());
+    // Wait for signal from sender
+    if (source_rank) {
+      ncclWaitSignalDesc_t wait_desc = {
+          .opCnt = 1,
+          .peer = static_cast<int>(source_rank->value()),
+          .sigIdx = 0,
+          .ctx = 0};
+      XLA_NCCL_RETURN_IF_ERROR(
+          ncclWaitSignal(/*nDesc=*/1, &wait_desc, comm_, AsCudaStream(stream)));
+    }
+    return absl::OkStatus();
+  }
+#endif  // NCCL_VERSION_CODE >= 22900
 
   if (source_rank) {
     XLA_NCCL_RETURN_IF_ERROR(

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -173,6 +173,8 @@ class RcclCommunicator::RcclRegisteredBufferHandle
         symmetric_handle_(symmetric_handle),
         device_ordinal_(device_ordinal) {}
 
+  void* GetHandle() const override { return handle_; }
+
   ~RcclRegisteredBufferHandle() override {
     if (auto status = Unregister(); !status.ok()) {
       LOG(ERROR) << status.message();

--- a/xla/backends/gpu/runtime/collective_permute_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_permute_thunk.cc
@@ -58,12 +58,12 @@ limitations under the License.
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -384,6 +384,9 @@ absl::Status RunCollectivePermute(P2PConfig::SourceTargetRanks source_target,
     target_ranks.push_back(*source_target.target);
   }
 
+  TF_RETURN_IF_ERROR(MaybeRegisterBuffers(stream.parent(), buffers, &comm,
+                                          use_symmetric_buffer));
+
   // GroupStart/End API is needed if we need to dispatch multiple NCCL kernels
   // for multiple buffers.
   if (buffers.size() <= 1) {
@@ -397,8 +400,6 @@ absl::Status RunCollectivePermute(P2PConfig::SourceTargetRanks source_target,
       TF_RETURN_IF_ERROR(future.Await());
     }
   } else {
-    TF_RETURN_IF_ERROR(MaybeRegisterBuffers(stream.parent(), buffers, &comm,
-                                            use_symmetric_buffer));
     auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
     auto future = gpu_comm->GroupExecute(
         [&source_target, &buffers, &src_addrs, &dest_addrs, &target_ranks,

--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -2830,5 +2830,53 @@ TEST_F(CollectiveOpsTestE2E, MultipleModuleDifferentDeviceGroupsShouldRun) {
                                                  {&input_literal2_3},
                                                  {&input_literal2_4}}));
 }
+
+TEST_P(AsyncCollectiveOps, AsyncCollectivePermuteUsingPut) {
+  const absl::string_view kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    replica = u32[] replica-id()
+    ten = u32[] constant(10)
+    sum = u32[] add(replica, ten)
+    p = u32[2] broadcast(sum), dimensions={}
+    permute = u32[2] collective-permute(p), source_target_pairs={{1,0}, {0,1}}
+    ROOT copy = u32[2] copy(permute)
+  }
+  )";
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(test_runner().device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << test_runner().device_count() << " available)";
+
+  const bool enable_async_collective_permute = GetParam();
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_experimental_enable_nccl_symmetric_buffers(true);
+  config.mutable_debug_options().set_xla_flags_reset(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr, config));
+  tsl::setenv("XLA_FLAGS",
+              "--xla_gpu_experimental_enable_nccl_symmetric_buffers=true",
+              /*overwrite=*/true);
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(module)));
+
+  const HloModule* hlo_module = execution_result.optimized_module;
+  HloInstruction* cp_start =
+      FindInstruction(hlo_module, HloOpcode::kCollectivePermuteStart);
+  HloInstruction* cp_done =
+      FindInstruction(hlo_module, HloOpcode::kCollectivePermuteDone);
+  EXPECT_THAT(cp_start, NotNull());
+  EXPECT_THAT(cp_done, NotNull());
+  EXPECT_EQ(IsAsync(cp_start), enable_async_collective_permute);
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  LiteralTestUtil::ExpectR1Equal<uint32_t>({11, 11}, results[0]);
+  LiteralTestUtil::ExpectR1Equal<uint32_t>({10, 10}, results[1]);
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/core/collectives/communicator.h
+++ b/xla/core/collectives/communicator.h
@@ -74,6 +74,8 @@ class Communicator {
     // handle).
     using PackedKernelArg = std::array<std::byte, 256>;
     virtual PackedKernelArg PackKernelArg() const = 0;
+
+    virtual void* GetHandle() const = 0;
   };
 
   // Register `buffer_range` once for efficient collective operations (i.e. on


### PR DESCRIPTION
📝 Summary of Changes
This pr adds nccl put host api to collective permute.
This api is only available in nccl 2.29+ and it's more performant than the current send/recv apis.
The requirement to trigger nccl put is that symmetric buffers are enabled for both sned and recv buffers.

🎯 Justification
Improve perf of thunks using send/recv APIs.
