### PR TITLE
[xla:gpu] Remove deprecated IsGlobalConfig and document how clique ids are generated

### DIFF
--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -318,7 +318,7 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
     tsl::profiler::TraceMe trace("InitializeGpuClique");
 
     CliqueIds clique_ids;
-    const auto& subkeys = clique_key.GetSubKeys(nroots);
+    std::vector<GpuCliqueKey> subkeys = clique_key.GetSubKeys(nroots);
     for (const auto& subkey : subkeys) {
       VLOG(3) << absl::StreamFormat(
           "Get CliqueId for sub clique key %s; nroots=%lld", subkey.ToString(),

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -144,16 +144,8 @@ class GpuCollectives : public Collectives {
   // Returns true if GPU collectives are implemented.
   virtual bool IsImplemented() const = 0;
 
-  // Returns true if collectives backend uses global config.
-  virtual bool IsGlobalConfig() const = 0;
-
   // Returns true if GPU collectives support device-initiated communication.
   virtual bool SupportsDeviceComm() const { return false; }
-
-  // Returns a clique id callback passed as an argument if it's not null or a
-  // default callback to get create a clique id if we are running in local mode.
-  virtual absl::StatusOr<const CliqueIdCallback*> GetCliqueIdCallback(
-      const CliqueIdCallback* clique_id_callback, bool is_local) = 0;
 
   // Returns a slice of device memory `buff` containing `count` values of data
   // type `dtype` starting from `offset`.

--- a/xla/backends/gpu/collectives/gpu_collectives_stub.h
+++ b/xla/backends/gpu/collectives/gpu_collectives_stub.h
@@ -38,14 +38,8 @@ namespace xla::gpu {
 class GpuCollectivesStub : public GpuCollectives {
  public:
   bool IsImplemented() const final { return false; }
-  bool IsGlobalConfig() const final { return false; }
 
   absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final {
-    return UnimplementedError();
-  }
-
-  absl::StatusOr<const CliqueIdCallback*> GetCliqueIdCallback(
-      const CliqueIdCallback*, bool) final {
     return UnimplementedError();
   }
 

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -147,29 +147,8 @@ absl::StatusOr<CliqueId> NcclCollectives::CreateUniqueCliqueId() const {
   return CliqueId(absl::string_view(id.internal, NCCL_UNIQUE_ID_BYTES));
 }
 
-bool NcclCollectives::IsGlobalConfig() const {
-  static const char* const nccl_comm_id = std::getenv("NCCL_COMM_ID");
-  return nccl_comm_id != nullptr;
-}
-
 bool NcclCollectives::SupportsDeviceComm() const {
   return NCCL_VERSION_CODE >= 22800;
-}
-
-absl::StatusOr<const NcclCollectives::CliqueIdCallback*>
-NcclCollectives::GetCliqueIdCallback(const CliqueIdCallback* clique_id_callback,
-                                     bool is_local) {
-  if (clique_id_callback != nullptr) {
-    return clique_id_callback;
-  }
-
-  TF_RET_CHECK(is_local || IsGlobalConfig())
-      << "If non-local devices are taking part of a collective API on "
-         "GPU, the clique_id_callback must be provided by the client.";
-
-  static auto* const local_callback = new CliqueIdCallback(
-      [this](const CliqueKey&) { return CreateUniqueCliqueId(); });
-  return local_callback;
 }
 
 static absl::StatusOr<ncclConfig_t> AsNcclConfig(

--- a/xla/backends/gpu/collectives/nccl_collectives.h
+++ b/xla/backends/gpu/collectives/nccl_collectives.h
@@ -39,12 +39,7 @@ class NcclCollectives : public GpuCollectives {
  public:
   bool IsImplemented() const final { return true; }
 
-  bool IsGlobalConfig() const final;
-
   bool SupportsDeviceComm() const final;
-
-  absl::StatusOr<const CliqueIdCallback*> GetCliqueIdCallback(
-      const CliqueIdCallback* clique_id_callback, bool is_local) final;
 
   absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final;
 

--- a/xla/backends/gpu/collectives/nvshmem_collectives.h
+++ b/xla/backends/gpu/collectives/nvshmem_collectives.h
@@ -52,13 +52,6 @@ class NvshmemCollectives : public GpuCollectives {
 
   bool IsImplemented() const final { return true; }
 
-  bool IsGlobalConfig() const final { return false; }
-
-  absl::StatusOr<const CliqueIdCallback*> GetCliqueIdCallback(
-      const CliqueIdCallback* clique_id_callback, bool is_local) final {
-    return absl::UnimplementedError("Not implemented.");
-  }
-
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
   CreateCommunicators(const CliqueKey& clique_key,
                       const std::optional<CliqueIds>& clique_ids,

--- a/xla/backends/gpu/collectives/rccl_collectives.cc
+++ b/xla/backends/gpu/collectives/rccl_collectives.cc
@@ -150,27 +150,6 @@ absl::StatusOr<CliqueId> RcclCollectives::CreateUniqueCliqueId() const {
   return CliqueId(absl::string_view(id.internal, NCCL_UNIQUE_ID_BYTES));
 }
 
-bool RcclCollectives::IsGlobalConfig() const {
-  static const char* const nccl_comm_id = std::getenv("NCCL_COMM_ID");
-  return nccl_comm_id != nullptr;
-}
-
-absl::StatusOr<const RcclCollectives::CliqueIdCallback*>
-RcclCollectives::GetCliqueIdCallback(const CliqueIdCallback* clique_id_callback,
-                                     bool is_local) {
-  if (clique_id_callback != nullptr) {
-    return clique_id_callback;
-  }
-
-  TF_RET_CHECK(is_local || IsGlobalConfig())
-      << "If non-local devices are taking part of a collective API on "
-         "GPU, the clique_id_callback must be provided by the client.";
-
-  static auto* const local_callback = new CliqueIdCallback(
-      [this](const CliqueKey&) { return CreateUniqueCliqueId(); });
-  return local_callback;
-}
-
 static absl::StatusOr<ncclConfig_t> AsRcclConfig(
     const GpuCollectives::Config& config,
     const se::StreamExecutor* stream_executor) {

--- a/xla/backends/gpu/collectives/rccl_collectives.h
+++ b/xla/backends/gpu/collectives/rccl_collectives.h
@@ -39,11 +39,6 @@ class RcclCollectives : public GpuCollectives {
  public:
   bool IsImplemented() const final { return true; }
 
-  bool IsGlobalConfig() const final;
-
-  absl::StatusOr<const CliqueIdCallback*> GetCliqueIdCallback(
-      const CliqueIdCallback* clique_id_callback, bool is_local) final;
-
   absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final;
 
   absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1945,6 +1945,9 @@ cc_library(
         "//xla/backends/gpu/collectives:gpu_clique_key",
         "//xla/backends/gpu/collectives:gpu_cliques",
         "//xla/backends/gpu/collectives:gpu_communicator",
+        "//xla/core/collectives:clique_id",
+        "//xla/core/collectives:clique_key",
+        "//xla/core/collectives:communicator",
         "//xla/core/collectives:rank_id",
         "//xla/runtime:device_id",
         "//xla/service/gpu:gpu_executable_run_options",
@@ -1956,6 +1959,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@tsl//tsl/platform:casts",
         "@tsl//tsl/profiler/lib:traceme",
     ],
 )

--- a/xla/backends/gpu/runtime/collective_execution.cc
+++ b/xla/backends/gpu/runtime/collective_execution.cc
@@ -90,13 +90,6 @@ absl::StatusOr<GpuCliqueKey> GetGpuCliqueKey(
                           GetParticipatingDevicesGroups(
                               *params.device_assn, replica_groups, group_mode));
     }
-
-    if (params.collectives->IsGlobalConfig() &&
-        (participants.size() != params.device_assn->replica_count())) {
-      return InvalidArgument(
-          "Partial replica groups are not allowed when using NCCL_COMM_ID "
-          "environment configuration.");
-    }
   }
 
   // Remove trivial group that contains all participants, as we do not want to

--- a/xla/backends/gpu/runtime/collective_params.cc
+++ b/xla/backends/gpu/runtime/collective_params.cc
@@ -95,7 +95,7 @@ CollectiveParams::CollectiveParams(
     absl::Span<se::Stream* const> async_streams, LocalDeviceId local_device_id,
     GlobalDeviceId global_device_id, const DeviceAssignment* device_assn,
     const GlobalDeviceIdMap* global_device_id_map,
-    const CliqueIdCallback* nccl_clique_id_callback,
+    const CliqueIdCallback* clique_id_callback,
     const absl::flat_hash_map<GlobalDeviceId, IncarnationId>* incarnations,
     int64_t collective_max_nchannels, int64_t p2p_max_nchannels)
     : collectives(collectives),
@@ -106,7 +106,7 @@ CollectiveParams::CollectiveParams(
       global_device_id(global_device_id),
       device_assn(device_assn),
       global_device_id_map(global_device_id_map),
-      nccl_clique_id_callback(nccl_clique_id_callback),
+      clique_id_callback(clique_id_callback),
       incarnations(incarnations),
       collective_max_nchannels(collective_max_nchannels),
       p2p_max_nchannels(p2p_max_nchannels) {}

--- a/xla/backends/gpu/runtime/collective_params.h
+++ b/xla/backends/gpu/runtime/collective_params.h
@@ -62,7 +62,7 @@ struct CollectiveParams {
 
   const DeviceAssignment* device_assn;
   const GlobalDeviceIdMap* global_device_id_map;
-  const CliqueIdCallback* nccl_clique_id_callback;
+  const CliqueIdCallback* clique_id_callback;
   const absl::flat_hash_map<GlobalDeviceId, IncarnationId>* incarnations;
 
   int64_t collective_max_nchannels;
@@ -77,7 +77,7 @@ struct CollectiveParams {
       LocalDeviceId local_device_id, GlobalDeviceId global_device_id,
       const DeviceAssignment* device_assn,
       const GlobalDeviceIdMap* global_device_id_map,
-      const CliqueIdCallback* nccl_clique_id_callback,
+      const CliqueIdCallback* clique_id_callback,
       const absl::flat_hash_map<GlobalDeviceId, IncarnationId>* incarnations,
       int64_t collective_max_nchannels, int64_t p2p_max_nchannels);
 };


### PR DESCRIPTION
Remove deprecated IsGlobalConfig and document how clique ids are generated

Setting clique id via `NCCL_COMM_ID` variable is unused and doesn't work in practice as it doesn't allow to create multiple non-overlapping GPU cliques.