### PR TITLE
[Rocm] Fix CollectivePipelineParallelismTest: Add missing attribute to pipelined send/recv operations

### DIFF
--- a/xla/tests/collective_pipeline_parallelism_test.cc
+++ b/xla/tests/collective_pipeline_parallelism_test.cc
@@ -1325,8 +1325,8 @@ TEST_P(CollectivePipelineParallelismTest,
     // Shift data to the next stage in the pipeline.
     after_all_fwd = token[] after-all()
     fwd_send = (f32[16], u32[], token[]) send(next_stage_slice, after_all_fwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}}
-    fwd_send_done = token[] send-done(fwd_send)
+      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_pipeline="1"}
+    fwd_send_done = token[] send-done(fwd_send), frontend_attributes={_xla_send_recv_pipeline="1"}
 
     // Select compute argument from previous stage or from input and perform
     // compute.
@@ -1350,20 +1350,20 @@ TEST_P(CollectivePipelineParallelismTest,
 
     after_all_bwd = token[] after-all()
     bwd_recv = (f32[16], u32[], token[]) recv(after_all_bwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}}},
+      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}},_xla_send_recv_pipeline="0"},
       control-predecessors={fwd_send_done, fwd_send}
     bwd_recv_done = (f32[16], token[]) recv-done(bwd_recv),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}}}
+      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}},_xla_send_recv_pipeline="0"}
     bwd_send = (f32[16], u32[], token[]) send(next_stage_slice, after_all_bwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}}},
+      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}},_xla_send_recv_pipeline="0"},
       control-predecessors={bwd_recv_done, bwd_recv}
-    bwd_send_done = token[] send-done(bwd_send)
+    bwd_send_done = token[] send-done(bwd_send), frontend_attributes={_xla_send_recv_pipeline="0"}
 
     fwd_recv = (f32[16], u32[], token[]) recv(after_all_fwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}},
+      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_pipeline="1"},
       control-predecessors={bwd_send_done, bwd_send}
     fwd_recv_done = (f32[16], token[]) recv-done(fwd_recv),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}}
+      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_pipeline="1"}
 
     i_ = add(i, c1)
 
@@ -1386,19 +1386,19 @@ TEST_P(CollectivePipelineParallelismTest,
 
     after_all_bwd = token[] after-all()
     bwd_recv = (f32[16], u32[], token[]) recv(after_all_bwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}}}
-    bwd_recv_done = (f32[16], token[]) recv-done(bwd_recv)
+      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}},_xla_send_recv_pipeline="0"}
+    bwd_recv_done = (f32[16], token[]) recv-done(bwd_recv), frontend_attributes={_xla_send_recv_pipeline="0"}
     bwd_send = (f32[16], u32[], token[]) send(input_slice, after_all_bwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}}},
+      frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}},_xla_send_recv_pipeline="0"},
       control-predecessors={bwd_recv_done, bwd_recv}
-    bwd_send_done = token[] send-done(bwd_send)
+    bwd_send_done = token[] send-done(bwd_send), frontend_attributes={_xla_send_recv_pipeline="0"}
 
     after_all_fwd = token[] after-all()
     fwd_recv = (f32[16], u32[], token[]) recv(after_all_fwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}},
+      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_pipeline="1"},
       control-predecessors={bwd_send_done, bwd_send}
     fwd_recv_done = (f32[16], token[]) recv-done(fwd_recv),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}}
+      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_pipeline="1"}
 
     // Iterate through pipeline stages.
     tuple = (f32[16,16], f32[5,16], f32[5,16], f32[5,16], f32[16], u32[],
@@ -1440,8 +1440,8 @@ TEST_P(CollectivePipelineParallelismTest,
         prev_iteration_compute_res_)
 
     fwd_send = (f32[16], u32[], token[]) send(next_stage_slice_, after_all_fwd),
-      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}}}
-    fwd_send_done = token[] send-done(fwd_send)
+      frontend_attributes={_xla_send_recv_source_target_pairs={{0,1},{1,2},{2,3}},_xla_send_recv_pipeline="1"}
+    fwd_send_done = token[] send-done(fwd_send), frontend_attributes={_xla_send_recv_pipeline="1"}
 
 
     // Select compute argument from previous stage or from input and perform


### PR DESCRIPTION
The test CollectivePipelineParallelismTest.NaiveBFSMb5Cr2Replica4SendRecvPartiallyPipelined was failing with the error:
```
INTERNAL: during context [hlo verifier]: Expected recv, but found %bwd_send.3 = (f32[16]{0}, u32[], token[]) send(%loop_sele
ct_fusion, %after_all_bwd.3.0), frontend_attributes={_xla_send_recv_source_target_pairs={{3,0}}}, control-predecessors={%bwd
_recv_done.3, %bwd_recv.3}, metadata={scheduling_name="bwd_send.3"}
```

The order of send/recv operations in the test CollectivePipelineParallelismTest.NaiveBFSMb5Cr2Replica4SendRecvPartiallyPipelined should not be checked by the `CheckDeadlocksForSend` function as it was case, given that the hlo code of this function is pipelined (as suggested [here](https://github.com/openxla/xla/blob/146f134eabd75efd7a8f19a0f2cd33c7762d1930/xla/service/hlo_verifier.cc#L2728-L2730)).
This commit adds therefore `_xla_send_recv_pipeline` attributes to `send/recv` operations to bypass this test.

## Test Result

The test passes
