### PR TITLE
autotuner: iterate in deterministic order

### DIFF
--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -271,7 +271,9 @@ absl::Status Autotuner::Autotune(HloModule* module,
 
   // 6. Apply the results to all candidate instructions, must be already in
   // cache_ due to step 3 and 5 above.
-  for (auto& [_, instructions] : all_instructions_by_fingerprint) {
+  for (tsl::Fprint128 fingerprint : sorted_fingerprints) {
+    std::vector<HloInstruction*>& instructions =
+        all_instructions_by_fingerprint[fingerprint];
     CHECK(!instructions.empty());
     std::optional<Config> cached_config = LookUp(instructions[0]);
     CHECK(cached_config.has_value())


### PR DESCRIPTION
📝 Summary of Changes
Avoid iterating in a run-to-run-unstable order (https://abseil.io/docs/cpp/guides/container#iteration-order-instability). This was causing different processes in distributed JAX runs to use inconsistent operation names.

🎯 Justification
PGLE expects consistent operation names.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
None

🧪 Execution Tests:
None