### PR TITLE
Fix dtype reference in shapes documentation

### DIFF
--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -15,7 +15,7 @@ This consists of the following components:
     *   This is the unique name for the operation.
 *   Shape: `bf16[8,1,1280,16384]`
     *   This is the output shape of the Op. Here the dtype is
-        [bf316](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format)
+        [bf16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format)
         and the shape is `[8,1,1280,16384]`.
 *   Layout (with Tiling): `3,2,0,1:T(8,128)(2,1)`
     *   This describes how the array is stored in memory. `3,2,0,1` denotes the


### PR DESCRIPTION
Corrected the dtype reference from 'bf316' to 'bf16'.

📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
