### PR TITLE
Fix typo in HLO parser: `rls_dilate` -> `rhs_dilate`

### DIFF
--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -5790,7 +5790,7 @@ bool HloParserImpl::ParseWindow(Window* window, bool expect_outer_curlies) {
         return ParseDxD("lhs_dilate", &lhs_dilate);
       }
       if (field_name == "rhs_dilate") {
-        return ParseDxD("rls_dilate", &rhs_dilate);
+        return ParseDxD("rhs_dilate", &rhs_dilate);
       }
       if (field_name == "pad") {
         return ParseWindowPad(&pad);


### PR DESCRIPTION
📝 Summary of Changes
Fix typo in `HloParserImpl::ParseWindow`: the string `"rls_dilate"` passed to ParseDxD was incorrect and should be `"rhs_dilate"`.

🎯 Justification
The typo causes `ParseDxD` to receive an incorrect field name when parsing `rhs_dilate` in HLO window attributes. This could lead to incorrect parsing or misleading error messages when the parser encounters an `rhs_dilate` field.

🚀 Kind of Contribution
🐛 Bug Fix
