### PR TITLE
Sync gha docker image with rbe docker image

### DIFF
--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -79,14 +79,14 @@ jobs:
         run: |
           docker exec \
             ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a"
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a --repo_env=ROCM_DISTRO_VERSION=${{ env.DOCKER_IMAGE }}"
 
       - name: Test XLA [multi_gpu]
         if: always()
         run: |
           docker exec \
             ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2"
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2 --repo_env=ROCM_DISTRO_VERSION=${{ env.DOCKER_IMAGE }}"
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -79,14 +79,14 @@ jobs:
         run: |
           docker exec \
             ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a --repo_env=ROCM_DISTRO_VERSION=${{ env.DOCKER_IMAGE }}"
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}"
 
       - name: Test XLA [multi_gpu]
         if: always()
         run: |
           docker exec \
             ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2 --repo_env=ROCM_DISTRO_VERSION=${{ env.DOCKER_IMAGE }}"
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2 --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}"
 
       - name: Cleanup container
         if: always()


### PR DESCRIPTION
📝 Summary of Changes
Use the same docker image for local build/run as well as for rbe executors

🎯 Justification
The environment between the main ci worker and rbe executor shall match
to avoid inconsistencies and errors during the build

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI tests

🧪 Execution Tests:
CI tests
