### PR TITLE
[Rocm] Add flag to control hipblaslt swish activation fusion.

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -374,6 +374,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_collective_max_nchannels(0);
   opts.set_xla_gpu_nccl_p2p_max_nchannels(0);
   opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  opts.set_xla_gpu_experimental_enable_cublaslt_swish_fusion(true);
 
   opts.set_xla_gpu_experimental_stream_annotation(true);
   // Minimum combined size of matrices in matrix multiplication to
@@ -2323,6 +2324,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "(minimum combined number of elements of both matrices "
       "in non-batch dimensions to be considered for a rewrite)."));
   flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_enable_cublaslt_swish_fusion",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_experimental_enable_cublaslt_swish_fusion),
+      debug_options->xla_gpu_experimental_enable_cublaslt_swish_fusion(),
+      "Enable fusion of the swish activiation with cublaslt gemm."));
+  flag_list->push_back(tsl::Flag(
       "xla_gpu_use_embeded_device_lib",
       bool_setter_for(&DebugOptions::set_xla_gpu_use_embeded_device_lib),
       debug_options->xla_gpu_use_embeded_device_lib(),
@@ -2966,8 +2973,7 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_pipelined_all_gather",

--- a/xla/service/gpu/transforms/gemm_rewriter.cc
+++ b/xla/service/gpu/transforms/gemm_rewriter.cc
@@ -806,7 +806,12 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     }
 
     const auto is_rocm = gpu_version_.IsRocm();
-    if (is_rocm &&
+    const bool swishFusionEnabled =
+        instr->GetModule()
+            ->config()
+            .debug_options()
+            .xla_gpu_experimental_enable_cublaslt_swish_fusion();
+    if (swishFusionEnabled && is_rocm &&
         toolkit_version_ >= stream_executor::SemanticVersion{7, 0, 0}) {
       // Attempt to match approximate Swish activation
       // (https://flax.readthedocs.io/en/v0.5.3/_autosummary/flax.linen.swish.html),

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -814,6 +814,8 @@ message DebugOptions {
   // rewrite).
   optional int64 xla_gpu_gemm_rewrite_size_threshold = 283;
 
+  optional bool xla_gpu_experimental_enable_cublaslt_swish_fusion = 502;
+
   // If true, we generate debug info when compiling PTX. This is useful for
   // profiling and debugging.
   optional bool xla_gpu_generate_debug_info = 348;


### PR DESCRIPTION
📝 Summary of Changes
This PR adds a flag to allow users to disable this fusion if they wish.

🎯 Justification
We notice that performance of certain LLM models decreases when the hipblaslt swish activation fusion was enabled. We therefore add a new flag to allow users to choose when to use this fusion.


🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,

🧪 Unit Tests:
2 tests have been added to test the flag behavior.

🧪 Execution Tests:
Tests pass.
