### PR TITLE
[xla:gpu] Improve XLA + collectives debuggability

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -88,6 +88,7 @@ cc_library(
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:casts",
     ],

--- a/xla/backends/gpu/collectives/gpu_clique.cc
+++ b/xla/backends/gpu/collectives/gpu_clique.cc
@@ -75,9 +75,8 @@ absl::Status GpuClique::AddDeviceComm(
 
 std::string GpuClique::DebugString() const {
   std::string out = absl::StrFormat(
-      "key: %s; fingerprint(id): %d; size: %d; communicators: ",
-      key_.ToString(), ids_.has_value() ? ids_->fingerprint() : 0,
-      num_communicators());
+      "key: %v; fingerprint(id): %d; size: %d; communicators: ", key_,
+      ids_.has_value() ? ids_->fingerprint() : 0, num_communicators());
   int32_t cnt = 0;
   ForEachComm([&](RankId rank, Communicator* comm) {
     if (cnt++) {
@@ -102,12 +101,12 @@ absl::Status GpuClique::HealthCheck() const {
 }
 
 absl::Status GpuClique::Abort() {
-  VLOG(1) << "Aborting GpuClique " << key().ToString();
+  VLOG(1) << "Aborting GpuClique " << key();
   absl::Status result = absl::OkStatus();
   ForEachComm([this, &result](RankId rank, Communicator* comm) {
     if (absl::Status s = comm->Abort(); !s.ok()) {
       LOG(ERROR) << "Error aborting GPU communicator (rank " << rank
-                 << ") for clique " << key().ToString() << ": " << s;
+                 << ") for clique " << key() << ": " << s;
       result = std::move(s);
     }
   });
@@ -115,14 +114,14 @@ absl::Status GpuClique::Abort() {
 }
 
 void GpuClique::Cancel() {
-  VLOG(1) << "Cancel GpuClique " << key().ToString();
+  VLOG(1) << "Cancel GpuClique " << key();
   cancel_->Cancel();
 }
 
 bool GpuClique::IsCancelled() const { return cancel_->IsCancelled(); }
 
 std::string GpuClique::LockableName::ToString(const GpuClique& clique) {
-  return absl::StrFormat("lockable clique %s", clique.key().ToString());
+  return absl::StrFormat("lockable clique %v", clique.key());
 }
 
 LockableGpuClique::LockableGpuClique(

--- a/xla/backends/gpu/collectives/gpu_clique_key_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key_test.cc
@@ -179,8 +179,22 @@ TEST(GpuCliqueKeyGettersTest, IsP2P) {
 
 TEST(GpuCliqueKeyGetterTest, ToString) {
   EXPECT_EQ(GetBaseCliqueKey().ToString(),
-            "devices=[0,1]; is_p2p=0; groups=[[0,1],[2,3]]; root=0; "
+            "devices=2:[0,1]; is_p2p=false; groups=[[0,1],[2,3]]; root=0; "
             "local_participants=2; incarnations=[]");
+}
+
+TEST(GpuCliqueKeyGetterTest, ToStringManyDevices) {
+  std::vector<GlobalDeviceId> devices;
+  devices.reserve(100);
+  for (size_t i = 0; i < 100; ++i) {
+    devices.push_back(GlobalDeviceId(i));
+  }
+
+  GpuCliqueKey key(devices, 100, /*is_p2p=*/false);
+
+  EXPECT_EQ(key.ToString(),
+            "devices=100:[0,1,2,3,4,5,6,7,8,9...96,97,98,99]; is_p2p=false; "
+            "root=-1; local_participants=100; incarnations=[]");
 }
 
 TEST(GpuCliqueIdGettersTest, Data) {

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -235,7 +235,7 @@ NcclCollectives::CreateCommunicatorsWithCancel(
         "CliqueIds size must be 1 for NCCL communicator initialization");
   }
   VLOG(1) << absl::StreamFormat(
-      "[%s] ranks=[%s] Initialize NCCL (version %d.%d.%d) "
+      "[%s] [ranks=%s] Initialize NCCL (version %d.%d.%d) "
       "communicators for %d local devices (out of %d global devices); "
       "fingerprint(id)=%v",
       DeviceOrdinalsToString(ranks), DeviceRanksToString(ranks), NCCL_MAJOR,
@@ -313,7 +313,7 @@ NcclCollectives::SplitCommunicatorsWithCancel(
   };
 
   VLOG(1) << absl::StreamFormat(
-      "[%s] ranks=[%s] Split %d NCCL communicators using color %d and "
+      "[%s] [ranks=%s] Split %d NCCL communicators using color %d and "
       "keys [%s]",
       DeviceOrdinalsToString(ranks), DeviceRanksToString(ranks), comms.size(),
       color, absl::StrJoin(keys, ",", rank_formatter));

--- a/xla/service/rendezvous.cc
+++ b/xla/service/rendezvous.cc
@@ -125,7 +125,7 @@ void AwaitAndLogIfStuck(RendezvousStateSynchronization& state, int32_t id,
       LOG(ERROR) << absl::StreamFormat(
           "[id=%d] This thread is unstuck waiting for `%s` after %s. Threads "
           "joined rendezvous with significant delay, system can be overloaded "
-          "and theads make progess at different rate. Warning above was a "
+          "and threads make progress at different rate. Warning above was a "
           "false-positive. Perhaps the timeout is too short.",
           id, name, absl::FormatDuration(rendezvous_end - rendezvous_start));
     }

--- a/xla/service/rendezvous.cc
+++ b/xla/service/rendezvous.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "xla/tsl/platform/logging.h"
 #include "tsl/profiler/lib/traceme.h"
@@ -71,6 +72,9 @@ void AwaitAndLogIfStuck(RendezvousStateSynchronization& state, int32_t id,
                         absl::string_view name,
                         absl::Duration warn_stuck_timeout,
                         absl::Duration terminate_timeout) {
+  // Record the time when a thread joined a rendezvous.
+  absl::Time rendezvous_start = absl::Now();
+
   // Wait for `warn_stuck_timeout` for the rendezvous to be ready.
   if (WaitForReadyWithTimeout(state, warn_stuck_timeout)) {
     return;
@@ -107,8 +111,24 @@ void AwaitAndLogIfStuck(RendezvousStateSynchronization& state, int32_t id,
   // Wait for `terminate_timeout` for the rendezvous to be ready before killing
   // the process.
   if (WaitForReadyWithTimeout(state, terminate_timeout)) {
-    LOG(ERROR) << "Thread is unstuck! Warning above was a false-positive. "
-                  "Perhaps the timeout is too short.";
+    // Record the time when a thread completed a rendezvous.
+    absl::Time rendezvous_end = absl::Now();
+
+    if (is_all_participants_arrived) {
+      LOG(ERROR) << absl::StreamFormat(
+          "[id=%d] This thread is unstuck waiting for `%s` after %s. All "
+          "threads joined the rendezvous on time however the leader took long "
+          "time to complete it. Warning above was a false-positive. Perhaps "
+          "the timeout is too short.",
+          id, name, absl::FormatDuration(rendezvous_end - rendezvous_start));
+    } else {
+      LOG(ERROR) << absl::StreamFormat(
+          "[id=%d] This thread is unstuck waiting for `%s` after %s. Threads "
+          "joined rendezvous with significant delay, system can be overloaded "
+          "and theads make progess at different rate. Warning above was a "
+          "false-positive. Perhaps the timeout is too short.",
+          id, name, absl::FormatDuration(rendezvous_end - rendezvous_start));
+    }
     return;
   }
 

--- a/xla/util.h
+++ b/xla/util.h
@@ -46,7 +46,6 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
-#include "Eigen/Core"
 #include "xla/status_macros.h"
 #include "xla/tsl/lib/math/math_util.h"
 #include "xla/tsl/platform/errors.h"  // IWYU pragma: keep
@@ -58,6 +57,7 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/ml_dtypes.h"
 #include "tsl/platform/protobuf.h"
+#include "Eigen/Core"
 
 namespace xla {
 
@@ -130,7 +130,7 @@ struct TimerStats {
 };
 
 inline std::string XlaFormatDevice(int device_ordinal) {
-  return absl::StrFormat("device=[%d] ", device_ordinal);
+  return absl::StrFormat("[%d] ", device_ordinal);
 }
 
 #define XLA_VLOG_DEVICE(level, device_ordinal) \


### PR DESCRIPTION
**NFC:** Improve XLA + collectives debuggability

1. Don't print extremely long list of devices for GPU cliques and instead print first + last devices, it's enough to identify what devices are communicating in the logs
2. Consistently use `[device_ordinal] [extra_keys]` logging format for collective operations and XLA in general.
3. Improve rendezvous debugging when threads are unstuck, so that it is possible to tell from the logs which threads are still stuck in rendezvous


All of the changes are NFC and pure quality-of-debugging improvement