### PR TITLE
[ROCm] Distinguish infra errors vs test failures

### DIFF
--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -76,18 +76,18 @@ jobs:
           docker exec ${{ env.CONTAINER_NAME }} bash -c "/opt/rocm/bin/rocminfo"
 
       - name: Test XLA [single_gpu]
-        # Exit 0=success, 78=infra failure, 124=timeout - only 78/124 are warnings
+        # Exit 0=success, 78=infra failure (warning)
         run: |
-          timeout 2400 docker exec ${{ env.CONTAINER_NAME }} \
+          docker exec ${{ env.CONTAINER_NAME }} \
             bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a" && exit 0
-          ec=$?; [[ $ec -eq 78 || $ec -eq 124 ]] && echo "::warning::Infra/timeout (exit $ec)" && exit 0; exit $ec
+          ec=$?; [[ $ec -eq 78 ]] && echo "::warning::Infra failure (exit $ec)" && echo ":warning: **single_gpu**: Infra failure (exit $ec)" >> $GITHUB_STEP_SUMMARY && exit 0; exit $ec
 
       - name: Test XLA [multi_gpu]
         if: always()
         run: |
-          timeout 2400 docker exec ${{ env.CONTAINER_NAME }} \
+          docker exec ${{ env.CONTAINER_NAME }} \
             bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2" && exit 0
-          ec=$?; [[ $ec -eq 78 || $ec -eq 124 ]] && echo "::warning::Infra/timeout (exit $ec)" && exit 0; exit $ec
+          ec=$?; [[ $ec -eq 78 ]] && echo "::warning::Infra failure (exit $ec)" && echo ":warning: **multi_gpu**: Infra failure (exit $ec)" >> $GITHUB_STEP_SUMMARY && exit 0; exit $ec
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -88,6 +88,13 @@ jobs:
             ${{ env.CONTAINER_NAME }} \
             bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2"
 
+      - name: BuildDir info
+        if: always()
+        run: |
+          docker exec \
+            ${{ env.CONTAINER_NAME }} \
+            bash -c "du -sh /root/.cache/*"
+
       - name: Cleanup container
         if: always()
         run: |

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -76,18 +76,18 @@ jobs:
           docker exec ${{ env.CONTAINER_NAME }} bash -c "/opt/rocm/bin/rocminfo"
 
       - name: Test XLA [single_gpu]
-        # Exit 78 = infra failure (warning), other non-zero = build/test failure (error)
+        # Exit 0=success, 78=infra failure, 124=timeout - only 78/124 are warnings
         run: |
-          docker exec ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a" \
-            || [[ $? -eq 78 ]]
+          timeout 2400 docker exec ${{ env.CONTAINER_NAME }} \
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a" && exit 0
+          ec=$?; [[ $ec -eq 78 || $ec -eq 124 ]] && echo "::warning::Infra/timeout (exit $ec)" && exit 0; exit $ec
 
       - name: Test XLA [multi_gpu]
         if: always()
         run: |
-          docker exec ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2" \
-            || [[ $? -eq 78 ]]
+          timeout 2400 docker exec ${{ env.CONTAINER_NAME }} \
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2" && exit 0
+          ec=$?; [[ $ec -eq 78 || $ec -eq 124 ]] && echo "::warning::Infra/timeout (exit $ec)" && exit 0; exit $ec
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -76,17 +76,18 @@ jobs:
           docker exec ${{ env.CONTAINER_NAME }} bash -c "/opt/rocm/bin/rocminfo"
 
       - name: Test XLA [single_gpu]
+        # Exit 78 = infra failure (warning), other non-zero = build/test failure (error)
         run: |
-          docker exec \
-            ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a"
+          docker exec ${{ env.CONTAINER_NAME }} \
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a" \
+            || [[ $? -eq 78 ]]
 
       - name: Test XLA [multi_gpu]
         if: always()
         run: |
-          docker exec \
-            ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2"
+          docker exec ${{ env.CONTAINER_NAME }} \
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2" \
+            || [[ $? -eq 78 ]]
 
       - name: Cleanup container
         if: always()

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout rocAutomation using local creds
         run: |
           rm -rf rocAutomation
-          git clone -b jenkins-pipelines https://github.com/ROCm/rocAutomation.git rocAutomation
+          git clone -b handle_infra_failures https://github.com/ROCm/rocAutomation.git rocAutomation
 
       - name: Start Container
         run: |
@@ -76,18 +76,17 @@ jobs:
           docker exec ${{ env.CONTAINER_NAME }} bash -c "/opt/rocm/bin/rocminfo"
 
       - name: Test XLA [single_gpu]
-        # Exit 0=success, 78=infra failure (warning)
         run: |
-          docker exec ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a" && exit 0
-          ec=$?; [[ $ec -eq 78 ]] && echo "::warning::Infra failure (exit $ec)" && echo ":warning: **single_gpu**: Infra failure (exit $ec)" >> $GITHUB_STEP_SUMMARY && exit 0; exit $ec
+          docker exec \
+            ${{ env.CONTAINER_NAME }} \
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a"
 
       - name: Test XLA [multi_gpu]
         if: always()
         run: |
-          docker exec ${{ env.CONTAINER_NAME }} \
-            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2" && exit 0
-          ec=$?; [[ $ec -eq 78 ]] && echo "::warning::Infra failure (exit $ec)" && echo ":warning: **multi_gpu**: Infra failure (exit $ec)" >> $GITHUB_STEP_SUMMARY && exit 0; exit $ec
+          docker exec \
+            ${{ env.CONTAINER_NAME }} \
+            bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_multi_gpu --strategy=TestRunner=local --local_test_jobs=2"
 
       - name: Cleanup container
         if: always()

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -15,13 +15,13 @@
 #
 # ==============================================================================
 
-set -e
 set -x
 
 SCRIPT_DIR=$(realpath $(dirname $0))
 TAG_FILTERS=$($SCRIPT_DIR/rocm_tag_filters.sh),-skip_rocprofiler_sdk,-no_oss,-oss_excluded,-oss_serial
 
 mkdir -p /tf/pkg
+BEP_JSON="/tmp/bep.json"
 
 for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
@@ -33,9 +33,12 @@ for arg in "$@"; do
 done
 
 SCRIPT_DIR=$(dirname $0)
+
+set +e
 bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --build_tag_filters=$TAG_FILTERS \
     --test_tag_filters=$TAG_FILTERS \
+    --build_event_json_file="$BEP_JSON" \
     --profile=/tf/pkg/profile.json.gz \
     --keep_going \
     --test_env=TF_TESTS_PER_GPU=1 \
@@ -43,3 +46,17 @@ bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --test_output=errors \
     --run_under=//build_tools/rocm:parallel_gpu_execute \
     "$@"
+
+BAZEL_EXIT_CODE=$?
+set -e
+
+# Classify and exit: 0 = success, 78 = infra failure, other = build/test failure
+if [[ $BAZEL_EXIT_CODE -eq 0 ]]; then
+    exit 0
+elif [[ -f "$BEP_JSON" ]] && jq -e 'select(.aborted.reason) | .aborted.reason | test("REMOTE_FAILURE|OUT_OF_MEMORY|INTERNAL|LOADING_FAILURE|NO_ANALYZE|NO_BUILD")' "$BEP_JSON" >/dev/null 2>&1; then
+    echo "::warning::Infrastructure failure detected (exit code: $BAZEL_EXIT_CODE)"
+    exit 78
+else
+    echo "::error::Build/test failure (exit code: $BAZEL_EXIT_CODE)"
+    exit $BAZEL_EXIT_CODE
+fi


### PR DESCRIPTION
📝 Summary of Changes
Distinguish test failures vs infra errors when executing the tests, making flaky infra not affecting the final result

🎯 Justification
Rocm infrastructure is flaky at the moment. In order to avoid noise and false positive reports from the rocm 
pipelines we start to distinguish the type of the error.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
