### PR TITLE
[ROCm] suppress cuda error messages on ROCm when doing training

### DIFF
--- a/xla/service/computation_placer.cc
+++ b/xla/service/computation_placer.cc
@@ -181,8 +181,11 @@ void ComputationPlacer::RegisterComputationPlacer(
   absl::MutexLock lock(placer_mutex);
   PlacerFactoryMap& placers = GetPlatformComputationPlacers();
   if (placers.find(id) != placers.end()) {
-    LOG(WARNING) << "Computation placer creation function is already "
-                    "registered for this platform";
+    // Silently skip re-registration instead of warning - this can happen
+    // legitimately when multiple libraries are loaded
+    VLOG(1) << "Computation placer already registered for this platform, "
+               "skipping";
+    return;
   }
   placers[id].creation_function = creation_function;
 }

--- a/xla/service/computation_placer.cc
+++ b/xla/service/computation_placer.cc
@@ -181,11 +181,8 @@ void ComputationPlacer::RegisterComputationPlacer(
   absl::MutexLock lock(placer_mutex);
   PlacerFactoryMap& placers = GetPlatformComputationPlacers();
   if (placers.find(id) != placers.end()) {
-    // Silently skip re-registration instead of warning - this can happen
-    // legitimately when multiple libraries are loaded
-    VLOG(1) << "Computation placer already registered for this platform, "
-               "skipping";
-    return;
+    LOG(WARNING) << "Computation placer creation function is already "
+                    "registered for this platform";
   }
   placers[id].creation_function = creation_function;
 }

--- a/xla/stream_executor/cuda/cuda_blas.cc
+++ b/xla/stream_executor/cuda/cuda_blas.cc
@@ -1399,6 +1399,16 @@ absl::Status CUDABlas::GetVersion(std::string *version) {
 }
 
 void initialize_cublas() {
+  // Check if already registered before attempting - prevents duplicate
+  // registration error messages (can happen with multiple library loads)
+  auto already_registered = PluginRegistry::Instance()->HasFactory(
+      kCudaPlatformId, PluginKind::kBlas);
+  
+  if (already_registered) {
+    // Already registered, skip silently (mimics ROCm behavior)
+    return;
+  }
+  
   absl::Status status =
       PluginRegistry::Instance()->RegisterFactory<PluginRegistry::BlasFactory>(
           kCudaPlatformId, "cuBLAS",

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6947,6 +6947,16 @@ absl::Status CudnnGraph::PopulateOrUpdateRawCommandBuffer(
 }  // namespace gpu
 
 void initialize_cudnn() {
+  // Check if already registered before attempting - prevents duplicate
+  // registration error messages (can happen with multiple library loads)
+  auto already_registered = PluginRegistry::Instance()->HasFactory(
+      cuda::kCudaPlatformId, PluginKind::kDnn);
+  
+  if (already_registered) {
+    // Already registered, skip silently (mimics ROCm behavior)
+    return;
+  }
+  
   absl::Status status =
       PluginRegistry::Instance()->RegisterFactory<PluginRegistry::DnnFactory>(
           cuda::kCudaPlatformId, "cuDNN",

--- a/xla/stream_executor/cuda/cuda_fft.cc
+++ b/xla/stream_executor/cuda/cuda_fft.cc
@@ -460,6 +460,16 @@ STREAM_EXECUTOR_CUDA_DEFINE_FFT(double, Z2Z, D2Z, Z2D)
 }  // namespace gpu
 
 void initialize_cufft() {
+  // Check if already registered before attempting - prevents duplicate
+  // registration error messages (can happen with multiple library loads)
+  auto already_registered = PluginRegistry::Instance()->HasFactory(
+      cuda::kCudaPlatformId, PluginKind::kFft);
+  
+  if (already_registered) {
+    // Already registered, skip silently (mimics ROCm behavior)
+    return;
+  }
+  
   absl::Status status =
       PluginRegistry::Instance()->RegisterFactory<PluginRegistry::FftFactory>(
           cuda::kCudaPlatformId, "cuFFT",


### PR DESCRIPTION
## Motivation

- On ROCm, it emits the following messages (harmless) related to CUDA. This PR is to suppress those. On CUDA, the counterpart related to ROCm has been suppressed already. 

```
2025-10-04 10:31:19.517493: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1759573879.528330   74721 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
E0000 00:00:1759573879.531514   74721 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
```


