### PR TITLE
[xla:gpu] Add support for NCCL scalable initialization

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -397,7 +397,6 @@ cc_library(
         "//xla/pjrt/distributed:key_value_store_interface",
         "//xla/runtime:device_id",
         "//xla/runtime:process_id",
-        "//xla/service/gpu:gpu_executable_run_options",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor/cuda:nccl_memory_allocator",  # buildcleaner: keep (static registration)
         "//xla/tsl/cuda:nccl",
@@ -408,6 +407,7 @@ cc_library(
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/xla/backends/gpu/collectives/gpu_clique_key_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key_test.cc
@@ -40,8 +40,7 @@ static GpuCliqueKey GetBaseCliqueKey() {
                       /*participant_groups=*/
                       std::vector<std::vector<GlobalDeviceId>>{
                           {GlobalDeviceId(0), GlobalDeviceId(1)},
-                          {GlobalDeviceId(2), GlobalDeviceId(3)}},
-                      /*root_device=*/GlobalDeviceId(0));
+                          {GlobalDeviceId(2), GlobalDeviceId(3)}});
 }
 
 TEST(GpuCliqueKeyTest, IsSubsetOf) {
@@ -60,29 +59,36 @@ TEST(GpuCliqueKeyTest, IsSubsetOf) {
   EXPECT_FALSE(key0.IsSubsetOf(key3));
 }
 
-TEST(GpuCliqueKeyTest, GetSubKeys) {
+TEST(GpuCliqueKeyTest, GetRootDevices) {
   GlobalDeviceId id0 = GlobalDeviceId(0);
   GlobalDeviceId id1 = GlobalDeviceId(1);
   GlobalDeviceId id2 = GlobalDeviceId(2);
   GlobalDeviceId id3 = GlobalDeviceId(3);
 
-  GpuCliqueKey key({id0, id1, id2, id3}, /*num_local_participants=*/1, true);
-  std::array<int64_t, 4> nroots{1, 2, 3, 4};
-  std::vector<std::vector<GlobalDeviceId>> exp_root_devs{
-      {id0}, {id0, id2}, {id0, id2, id3}, {id0, id1, id2, id3}};
-  for (int ridx = 0; ridx < nroots.size(); ++ridx) {
-    int64_t n = nroots[ridx];
-    const auto& subkeys = key.GetSubKeys(n);
-    EXPECT_EQ(subkeys.size(), exp_root_devs[ridx].size());
-    for (int kidx = 0; kidx < subkeys.size(); ++kidx) {
-      GpuCliqueKey exp_subkey(
-          /*devices=*/{id0, id1, id2, id3},
-          /*num_local_participants=*/1,
-          /*is_p2p=*/true,
-          /*participant_groups=*/{},
-          /*root_device=*/exp_root_devs[ridx][kidx]);
-      EXPECT_EQ(subkeys[kidx], exp_subkey);
-    }
+  GpuCliqueKey key({id0, id1, id2, id3}, /*num_local_participants=*/1);
+
+  {
+    std::vector<GlobalDeviceId> roots = key.GetRootDevices(1);
+    std::vector<GlobalDeviceId> expected = {id0};
+    ASSERT_EQ(roots, expected);
+  }
+
+  {
+    std::vector<GlobalDeviceId> roots = key.GetRootDevices(2);
+    std::vector<GlobalDeviceId> expected = {id0, id2};
+    ASSERT_EQ(roots, expected);
+  }
+
+  {
+    std::vector<GlobalDeviceId> roots = key.GetRootDevices(3);
+    std::vector<GlobalDeviceId> expected = {id0, id2, id3};
+    ASSERT_EQ(roots, expected);
+  }
+
+  {
+    std::vector<GlobalDeviceId> roots = key.GetRootDevices(4);
+    std::vector<GlobalDeviceId> expected = {id0, id1, id2, id3};
+    ASSERT_EQ(roots, expected);
   }
 }
 
@@ -179,7 +185,7 @@ TEST(GpuCliqueKeyGettersTest, IsP2P) {
 
 TEST(GpuCliqueKeyGetterTest, ToString) {
   EXPECT_EQ(GetBaseCliqueKey().ToString(),
-            "devices=2:[0,1]; is_p2p=false; groups=[[0,1],[2,3]]; root=0; "
+            "devices=2:[0,1]; is_p2p=false; groups=[[0,1],[2,3]]; "
             "local_participants=2; incarnations=[]");
 }
 
@@ -194,7 +200,7 @@ TEST(GpuCliqueKeyGetterTest, ToStringManyDevices) {
 
   EXPECT_EQ(key.ToString(),
             "devices=100:[0,1,2,3,4,5,6,7,8,9...96,97,98,99]; is_p2p=false; "
-            "root=-1; local_participants=100; incarnations=[]");
+            "local_participants=100; incarnations=[]");
 }
 
 TEST(GpuCliqueIdGettersTest, Data) {

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -50,9 +50,9 @@ class GpuCollectives : public Collectives {
   // Returns the default collectives implementation for the given platform.
   static GpuCollectives* Default(absl::string_view platform_name);
 
-  // A callback to get a unique clique id.
+  // A callback to get a unique clique ids.
   using CliqueIdCallback =  // NOLINT
-      std::function<absl::StatusOr<CliqueId>(const CliqueKey&)>;
+      std::function<absl::StatusOr<CliqueIds>(const CliqueKey&)>;
 
   // Topology describes how exactly the current process fits into the collection
   // of distributed processes, and based on this information the underlying

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/algorithm/container.h"
 #include "absl/base/call_once.h"
 #include "absl/base/thread_annotations.h"
+#include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -35,6 +36,7 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "third_party/nccl/nccl.h"
@@ -53,7 +55,6 @@ limitations under the License.
 #include "xla/pjrt/distributed/key_value_store_interface.h"
 #include "xla/runtime/device_id.h"
 #include "xla/runtime/process_id.h"
-#include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/env.h"
@@ -84,8 +85,8 @@ class NcclIdStore {
         device_to_process_(std::move(device_to_process)),
         kv_store_(std::move(kv_store)) {}
 
-  absl::StatusOr<CliqueId> GetCliqueId(const CliqueKey& key,
-                                       NcclCollectives& nccl_collectives) {
+  absl::StatusOr<CliqueIds> GetCliqueIds(const CliqueKey& key,
+                                         NcclCollectives& nccl_collectives) {
     auto* gpu_key = tsl::down_cast<const gpu::GpuCliqueKey*>(&key);
     if (gpu_key == nullptr) {
       return InvalidArgument("Expected GPU clique key");
@@ -102,31 +103,88 @@ class NcclIdStore {
       }
     }
 
-    CliqueId clique_id;
-    if (process_id_ == device_to_process_.at(gpu_key->root_device())) {
-      TF_ASSIGN_OR_RETURN(clique_id, nccl_collectives.CreateUniqueCliqueId());
-      TF_RETURN_IF_ERROR(
-          kv_store_->Set(gpu_key->ToString(), clique_id.ToString()));
-    } else {
-      TF_ASSIGN_OR_RETURN(
-          std::string id_str,
-          kv_store_->Get(gpu_key->ToString(), absl::Minutes(10)));
-      clique_id = CliqueId(id_str);
+    // Check how many roots are needed to initialize the GpuClique.
+    static const int64_t nccl_init_rank_per_root_ratio =
+        xla::GetDebugOptionsFromFlags()
+            .xla_gpu_nccl_init_max_rank_per_root_ratio();
+    int64_t nranks = key.num_devices();
+    int64_t nroots = nccl_init_rank_per_root_ratio != 0
+                         ? CeilOfRatio(nranks, nccl_init_rank_per_root_ratio)
+                         : 1;
+
+    // Create a KV store key for the given root process and captured clique key.
+    auto kv_key = [&](ProcessId root_process) {
+      return absl::StrFormat("root_process: %v; clique: %v", root_process, key);
+    };
+
+    // Global devices that are responsible for generating clique ids.
+    std::vector<GlobalDeviceId> root_devices = gpu_key->GetRootDevices(nroots);
+
+    // Processes that are responsible for generating clique ids. Note that if
+    // multiple root devices belong to the same process id, we will generate
+    // just one clique id for them. We keep processes in a sorted container to
+    // guarantee that all ranks will generate identical clique ids.
+    absl::btree_set<ProcessId> root_processes;
+    for (GlobalDeviceId root : root_devices) {
+      root_processes.insert(device_to_process_.at(root));
     }
 
+    VLOG(4) << absl::StreamFormat(
+        "Get NCCL clique ids: process=%v; root_devices=%d:[%s]; "
+        "root_processes=%d:[%s]; clique=%v",
+        process_id_, root_devices.size(), HumanReadableDevices(root_devices),
+        root_processes.size(),
+        HumanReadableProcesses(std::vector<ProcessId>(root_processes.begin(),
+                                                      root_processes.end())),
+        key);
+
+    // If we are one of the root processes, generate the key and exchange it
+    // with other ranks by putting into KV store.
+    if (root_processes.contains(process_id_)) {
+      absl::Time set_clique_id_start = absl::Now();
+      TF_ASSIGN_OR_RETURN(CliqueId clique_id,
+                          nccl_collectives.CreateUniqueCliqueId());
+      TF_RETURN_IF_ERROR(
+          kv_store_->Set(kv_key(process_id_), clique_id.ToString()));
+      VLOG(5) << absl::StreamFormat(
+          "Set NCCL clique id process=%v in %s", process_id_,
+          absl::FormatDuration(absl::Now() - set_clique_id_start));
+    }
+
+    // Collect generated clique ids for all root processes. We will read back
+    // the key that we just generated, it's a small performance vs code
+    // readbility tradeoff.
+    absl::Time get_clique_ids_start = absl::Now();
+    CliqueIds clique_ids;
+    for (ProcessId root : root_processes) {
+      TF_ASSIGN_OR_RETURN(std::string id_str,
+                          kv_store_->Get(kv_key(root), absl::Minutes(10)));
+      clique_ids.Add(CliqueId(id_str));
+    }
+
+    VLOG(5) << absl::StreamFormat(
+        "Got NCCL clique ids in %s: root_devices=%d:[%s]; "
+        "root_processes=%d:[%s]; clique=%v",
+        absl::FormatDuration(absl::Now() - get_clique_ids_start),
+        root_devices.size(), HumanReadableDevices(root_devices),
+        root_processes.size(),
+        HumanReadableProcesses(std::vector<ProcessId>(root_processes.begin(),
+                                                      root_processes.end())),
+        key);
+
     absl::MutexLock lock(mu_);
-    auto result = cache_.emplace(*gpu_key, std::move(clique_id));
-    TF_RET_CHECK(result.second) << "Unique ID already in cache.";
+    auto result = cache_.emplace(*gpu_key, std::move(clique_ids));
+    TF_RET_CHECK(result.second) << "Clique IDs already in cache";
     return result.first->second;
   }
 
  private:
   ProcessId process_id_;
-  const absl::flat_hash_map<GlobalDeviceId, ProcessId> device_to_process_;
-  const std::shared_ptr<KeyValueStoreInterface> kv_store_;
+  absl::flat_hash_map<GlobalDeviceId, ProcessId> device_to_process_;
+  std::shared_ptr<KeyValueStoreInterface> kv_store_;
 
   absl::Mutex mu_;
-  absl::flat_hash_map<gpu::GpuCliqueKey, CliqueId> cache_ ABSL_GUARDED_BY(mu_);
+  absl::flat_hash_map<gpu::GpuCliqueKey, CliqueIds> cache_ ABSL_GUARDED_BY(mu_);
 };
 }  // namespace
 
@@ -161,7 +219,6 @@ static ncclComm_t Cast(const Communicator* comm) {
 }
 
 absl::StatusOr<CliqueId> NcclCollectives::CreateUniqueCliqueId() const {
-  VLOG(3) << "Create NCCL unique clique id";
   ncclUniqueId id;
   XLA_NCCL_RETURN_IF_ERROR(ncclGetUniqueId(&id));
   return CliqueId(absl::string_view(id.internal, NCCL_UNIQUE_ID_BYTES));
@@ -229,17 +286,13 @@ NcclCollectives::CreateCommunicatorsWithCancel(
   if (!clique_ids.has_value() || clique_ids->data().empty()) {
     return InvalidArgument("CliqueId is required to create NCCL communicators");
   }
-  if (clique_ids->data().size() != 1) {
-    return InvalidArgument(
-        "CliqueIds size must be 1 for NCCL communicator initialization");
-  }
   VLOG(1) << absl::StreamFormat(
       "[%s] [ranks=%s] Initialize NCCL (version %d.%d.%d) "
       "communicators for %d local devices (out of %d global devices); "
-      "fingerprint(id)=%v",
+      "size(id)=%zu; fingerprint(id)=%v",
       DeviceOrdinalsToString(ranks), DeviceRanksToString(ranks), NCCL_MAJOR,
       NCCL_MINOR, NCCL_PATCH, ranks.size(), clique_key.num_devices(),
-      clique_ids->fingerprint());
+      clique_ids->size(), clique_ids->fingerprint());
 
   const auto& gpu_config =
       tsl::down_cast<const GpuCollectives::Config&>(config);
@@ -254,25 +307,44 @@ NcclCollectives::CreateCommunicatorsWithCancel(
 
   // make_comm returns a new ncclComm_t.
   auto make_comm = [&](int i) -> absl::StatusOr<ncclComm_t> {
+    absl::Time init_start = absl::Now();
     VLOG(1) << absl::StreamFormat(
         "[%d] [rank=%v] Initialize NCCL communicator for rank %v of %d; "
-        "fingerprint(id)=%v; size(id)=%zu",
+        "size(id)=%zu; fingerprint(id)=%v",
         DeviceOrdinal(ranks[i]), ranks[i].rank, ranks[i].rank,
-        clique_key.num_devices(), clique_ids->fingerprint(),
-        clique_ids->data().size());
+        clique_key.num_devices(), clique_ids->size(),
+        clique_ids->fingerprint());
 
     auto* device = tsl::down_cast<GpuCollectives::Device*>(ranks[i].device);
     TF_RET_CHECK(device != nullptr);
     auto activate_context = device->stream_executor()->Activate();
 
+    std::vector<ncclUniqueId> nccl_unique_ids;
+    for (const CliqueId& clique_id : clique_ids->data()) {
+      TF_ASSIGN_OR_RETURN(nccl_unique_ids.emplace_back(),
+                          AsNcclUniqueId(clique_id));
+    }
+
     TF_ASSIGN_OR_RETURN(ncclConfig_t comm_config,
                         AsNcclConfig(gpu_config, stream_executors[i]));
 
-    TF_ASSIGN_OR_RETURN(auto nccl_unique_id, AsNcclUniqueId(clique_ids->at(0)));
     ncclComm_t comm;
-    XLA_NCCL_RETURN_IF_ERROR(
-        ncclCommInitRankConfig(&comm, clique_key.num_devices(), nccl_unique_id,
-                               ranks[i].rank.value(), &comm_config));
+    if (nccl_unique_ids.size() > 1) {
+      XLA_NCCL_RETURN_IF_ERROR(ncclCommInitRankScalable(
+          &comm, clique_key.num_devices(), ranks[i].rank.value(),
+          nccl_unique_ids.size(), nccl_unique_ids.data(), &comm_config));
+    } else {
+      XLA_NCCL_RETURN_IF_ERROR(ncclCommInitRankConfig(
+          &comm, clique_key.num_devices(), nccl_unique_ids[0],
+          ranks[i].rank.value(), &comm_config));
+    }
+
+    absl::Time init_done = absl::Now();
+    VLOG(1) << absl::StreamFormat(
+        "[%d] [rank=%v] Initialized NCCL communicator for rank %v of %d in %s",
+        DeviceOrdinal(ranks[i]), ranks[i].rank, ranks[i].rank,
+        clique_key.num_devices(), absl::FormatDuration(init_done - init_start));
+
     return comm;
   };
 
@@ -430,7 +502,7 @@ NcclCollectives::InitializeTopology(const Topology& topology) {
         topology.process_id, topology.device_to_process,
         std::move(topology.kv_store));
     return [nccl_id_store, this](const CliqueKey& key) {
-      return nccl_id_store->GetCliqueId(key, *this);
+      return nccl_id_store->GetCliqueIds(key, *this);
     };
   }
 

--- a/xla/backends/gpu/collectives/nvshmem_collectives.cc
+++ b/xla/backends/gpu/collectives/nvshmem_collectives.cc
@@ -67,7 +67,7 @@ NvshmemCollectives::InitializeTopology(const Topology& topology) {
   se::gpu::nvshmem::SetEnvInfo(topology.process_id, topology.num_processes,
                                topology.device_count_per_process,
                                topology.kv_store);
-  return [](const CliqueKey&) { return CliqueId(""); };
+  return [](const CliqueKey&) { return CliqueIds(CliqueId("")); };
 }
 
 absl::StatusOr<void*> NvshmemCollectives::Allocate(uint64_t bytes) {

--- a/xla/backends/gpu/runtime/collective_execution.cc
+++ b/xla/backends/gpu/runtime/collective_execution.cc
@@ -101,8 +101,6 @@ absl::StatusOr<GpuCliqueKey> GetGpuCliqueKey(
   int64_t num_local_participants =
       GetNumLocalParticipants(params, participants);
 
-  GlobalDeviceId root_device = GlobalDeviceId(-1);
-
   absl::flat_hash_set<IncarnationId> unique_incarnations;
   if (params.incarnations) {
     for (GlobalDeviceId id : participants) {
@@ -119,7 +117,7 @@ absl::StatusOr<GpuCliqueKey> GetGpuCliqueKey(
   absl::c_sort(incarnations);
 
   return GpuCliqueKey(std::move(participants), num_local_participants, is_p2p,
-                      std::move(participant_groups), root_device, incarnations);
+                      std::move(participant_groups), incarnations);
 }
 
 }  // namespace xla::gpu

--- a/xla/core/collectives/clique_id.cc
+++ b/xla/core/collectives/clique_id.cc
@@ -44,6 +44,8 @@ CliqueIds::CliqueIds(const CliqueId& id) { Add(id); }
 
 void CliqueIds::Add(const CliqueId& id) { ids_.push_back(id); }
 
+size_t CliqueIds::size() const { return ids_.size(); }
+
 absl::Span<const CliqueId> CliqueIds::data() const { return ids_; }
 
 const CliqueId& CliqueIds::at(size_t index) const { return ids_[index]; }

--- a/xla/core/collectives/clique_id.h
+++ b/xla/core/collectives/clique_id.h
@@ -71,9 +71,11 @@ class CliqueIds {
  public:
   CliqueIds() = default;
 
-  explicit CliqueIds(const CliqueId& id);
+  CliqueIds(const CliqueId& id);  // NOLINT
 
   void Add(const CliqueId& id);
+
+  size_t size() const;
 
   absl::Span<const CliqueId> data() const;
 

--- a/xla/runtime/BUILD
+++ b/xla/runtime/BUILD
@@ -161,13 +161,21 @@ cc_library(
     deps = [
         "//xla/tsl/distributed_runtime/coordination:coordination_service",
         "//xla/tsl/lib/gtl:int_type",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
 cc_library(
     name = "process_id",
     hdrs = ["process_id.h"],
-    deps = ["//xla/tsl/lib/gtl:int_type"],
+    deps = [
+        "//xla/tsl/lib/gtl:int_type",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
 )
 
 cc_library(

--- a/xla/runtime/device_id.h
+++ b/xla/runtime/device_id.h
@@ -16,8 +16,14 @@ limitations under the License.
 #ifndef XLA_RUNTIME_DEVICE_ID_H_
 #define XLA_RUNTIME_DEVICE_ID_H_
 
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/tsl/distributed_runtime/coordination/coordination_service.h"
 #include "xla/tsl/lib/gtl/int_type.h"
 
@@ -40,6 +46,21 @@ void AbslStringify(Sink& sink, GlobalDeviceId id) {
 template <typename Sink>
 void AbslStringify(Sink& sink, LocalDeviceId id) {
   absl::Format(&sink, "%d", id.value());
+}
+
+// StrJoin for global devices that shortens long list of devices for readbility.
+//
+// It is not uncommon to see in XLA a list of global devices with more than 1k
+// of entries. We don't need to print them all to get a human readable list
+// of devices for logging and debugging.
+inline std::string HumanReadableDevices(
+    absl::Span<const GlobalDeviceId> devices, absl::string_view separator = ",",
+    size_t first = 10, size_t last = 4) {
+  if (devices.size() > first + last) {
+    return absl::StrCat(absl::StrJoin(devices.first(first), separator), "...",
+                        absl::StrJoin(devices.last(last), separator));
+  }
+  return absl::StrJoin(devices, separator);
 }
 
 }  // namespace xla

--- a/xla/runtime/process_id.h
+++ b/xla/runtime/process_id.h
@@ -16,8 +16,14 @@ limitations under the License.
 #ifndef XLA_RUNTIME_PROCESS_ID_H_
 #define XLA_RUNTIME_PROCESS_ID_H_
 
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/tsl/lib/gtl/int_type.h"
 
 namespace xla {
@@ -30,6 +36,21 @@ TSL_LIB_GTL_DEFINE_INT_TYPE(ProcessId, int64_t);
 template <typename Sink>
 void AbslStringify(Sink& sink, ProcessId id) {
   absl::Format(&sink, "%d", id.value());
+}
+
+// StrJoin for processes that shortens long list of processes for readbility.
+//
+// It is not uncommon to see in XLA a list of processes with more than 1k
+// of entries. We don't need to print them all to get a human readable list
+// of proceses for logging and debugging.
+inline std::string HumanReadableProcesses(absl::Span<const ProcessId> processes,
+                                          absl::string_view separator = ",",
+                                          size_t first = 10, size_t last = 4) {
+  if (processes.size() > first + last) {
+    return absl::StrCat(absl::StrJoin(processes.first(first), separator), "...",
+                        absl::StrJoin(processes.last(last), separator));
+  }
+  return absl::StrJoin(processes, separator);
 }
 
 }  // namespace xla

--- a/xla/service/gpu/gpu_executable_run_options.h
+++ b/xla/service/gpu/gpu_executable_run_options.h
@@ -30,12 +30,9 @@ limitations under the License.
 
 namespace xla::gpu {
 
-// A callback to get a unique clique id.
-//
-// TODO(b/380457503): Delete this alias and switch to
-// GpuCollectives::CliqueIdCallback.
+// A callback to get a unique clique ids.
 using CliqueIdCallback =  // NOLINT
-    std::function<absl::StatusOr<CliqueId>(const CliqueKey&)>;
+    std::function<absl::StatusOr<CliqueIds>(const CliqueKey&)>;
 
 // GPU-specific executable options.
 // We keep these separate from ExecutableRunOptions to avoid adding


### PR DESCRIPTION
Remove `root_device` from `GpuCliqueKey`: root device is not a property of the gpu clique key, but has meaning only during clique initialization. 

1. Change CliqueId callback type to return `CliqueIds`
2. Update NCCL Id store to set and get multiple clique ids for all root devices
3. Use NCCL scalable initialization API when XLA generates more that 1 clique id
4. Improve logging and add timing to critical places that tend to deadlock or get stuck
5. Improve logging by adding HumanReadable Devices and Processes APIs for printing large number of devices and processes