### PR TITLE
[HLO] Add option to print inline stack frames. 

### DIFF
--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -4074,10 +4074,25 @@ void HloInstruction::PrintWithCanonicalNameMap(
       (metadata_ != nullptr &&
        (!metadata_->op_type().empty() || !metadata_->op_name().empty() ||
         !metadata_->source_file().empty() ||
-        !metadata_->scheduling_name().empty()))) {
+        !metadata_->scheduling_name().empty() ||
+        metadata_->stack_frame_id() != 0))) {
     printer->Append(", metadata={");
-    printer->Append(xla::OpMetadataToString(
-        *metadata_, options.print_metadata_only_op_name()));
+    if (options.print_inline_stack_frames() && metadata_->stack_frame_id() != 0 &&
+        GetModule() != nullptr) {
+      OpMetadata metadata = *metadata_;
+      metadata.set_stack_frame_id(0);
+      auto frame = GetModule()->get_stack_frame(metadata_->stack_frame_id());
+      if (!frame.empty()) {
+        metadata.set_source_file(frame.file_name);
+        metadata.set_source_line(frame.line);
+        metadata.set_source_column(frame.column);
+      }
+      printer->Append(xla::OpMetadataToString(
+          metadata, options.print_metadata_only_op_name()));
+    } else {
+      printer->Append(xla::OpMetadataToString(
+          *metadata_, options.print_metadata_only_op_name()));
+    }
     printer->Append("}");
   }
   if (options.print_backend_config() && !backend_config_.empty()) {

--- a/xla/hlo/ir/hlo_module.cc
+++ b/xla/hlo/ir/hlo_module.cc
@@ -524,6 +524,8 @@ std::string HloModule::ToString() const {
   print_options.set_print_metadata(!db_options.xla_dump_disable_metadata());
   print_options.set_syntax_sugar_async_ops(
       db_options.xla_syntax_sugar_async_ops());
+  print_options.set_print_inline_stack_frames(
+      db_options.xla_hlo_print_inline_stack_frames());
   return ToString(print_options);
 }
 

--- a/xla/hlo/ir/hlo_print_options.h
+++ b/xla/hlo/ir/hlo_print_options.h
@@ -83,7 +83,8 @@ class HloPrintOptions {
         print_name_after_closing_brace_(false),
         print_full_replica_group_list_(false),
         print_parameter_number_(true),
-        print_channel_id_(true) {}
+        print_channel_id_(true),
+        print_inline_stack_frames_(false) {}
   // Static reference to a default construction HloPrintOptions, to avoid
   // constructing a new one each time default is needed.
   static const HloPrintOptions& Default() {
@@ -382,6 +383,12 @@ class HloPrintOptions {
     return *this;
   }
 
+  // If true, the HLO dumper will print the stack frame inline.
+  HloPrintOptions& set_print_inline_stack_frames(bool value) {
+    print_inline_stack_frames_ = value;
+    return *this;
+  }
+
   bool print_large_constants() const { return print_large_constants_; }
   bool print_only_essential_constants() const {
     return print_only_essential_constants_;
@@ -432,6 +439,7 @@ class HloPrintOptions {
   }
   bool print_parameter_number() const { return print_parameter_number_; }
   bool print_channel_id() const { return print_channel_id_; }
+  bool print_inline_stack_frames() const { return print_inline_stack_frames_; }
 
  private:
   // The interval between the /*index=*/ annotated operands. 0 means never print
@@ -466,6 +474,7 @@ class HloPrintOptions {
   bool print_full_replica_group_list_;
   bool print_parameter_number_;
   bool print_channel_id_;
+  bool print_inline_stack_frames_;
 };
 
 // For canonical string output, we need to have a canonical way to rename

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1322,6 +1322,9 @@ message DebugOptions {
   // TODO(b/355487968): Remove this option when validation complete.
   optional bool xla_enable_command_buffers_during_profiling = 317;
 
+  // If true, the HLO dumper will print the stack frame inline.
+  optional bool xla_hlo_print_inline_stack_frames = 254;
+
   enum AutotuneCacheMode {
     AUTOTUNE_CACHE_MODE_UNSPECIFIED = 0;
 


### PR DESCRIPTION
Issue No.: #36953 

📝 Summary of Changes 
Added a new debug option xla_hlo_print_inline_stack_frames to DebugOptions. When enabled, the HLO printer resolves stack_frame_ids and prints the source file and line number directly inline with the instruction's metadata. This bypasses the default behavior of printing compact stack frame IDs that reference a separate index.

🎯 Justification 
Current HLO output separates stack frame information into a specific section at the end of the module to reduce file size. While efficient, this makes debugging difficult for users (especially JAX/Python users) who need to quickly correlate HLO instructions with their source code location. This change provides an opt-in flag to restore the inline display of source locations, significantly improving the debugging experience for manual HLO inspection.

🚀 Kind of Contribution 
✨ New Feature

📊 Benchmark N/A - This is a debug-only feature affecting text dumping.

🧪 Unit Tests: Manual verification was performed to ensure the flag correctly triggers the inline printing logic in HloInstruction::ToString. No new unit tests were added as the change relies on GetModule() access which is standard pattern in HloInstruction.

🧪 Execution Tests: N/A