### PR TITLE
[ROCm] Changed error value for SplitK test in triton_gemm_fusion_test.cc

### DIFF
--- a/xla/backends/gpu/codegen/triton/triton_gemm_fusion_test.cc
+++ b/xla/backends/gpu/codegen/triton/triton_gemm_fusion_test.cc
@@ -2154,7 +2154,7 @@ ENTRY e {
   EXPECT_TRUE(
       RunAndCompareTwoModules(std::move(ref_module_and_metadata.module),
                               std::move(test_module_and_metadata.module),
-                              ErrorSpec{/*aabs=*/1e-6, /*arel=*/1e-6},
+                              ErrorSpec{/*aabs=*/1e-5, /*arel=*/1e-6},
                               /*run_hlo_passes=*/false));
 }
 


### PR DESCRIPTION
📝 Summary of Changes
Changed error value for SplitK test in triton_gemm_fusion_test.cc.

🎯 Justification
Considering error mismatch on ROCm:
```
Top relative error mismatches:
  actual           -0.106737137, expected           -0.106735229, index {8,7}, rel error 1.79e-05, abs error 1.91e-06
```
Input vectors of operation are:
```
-102 -27 -50 10 89 -84 62 -78 74 -22 97 -101 13 50 107 40 88 84 62 -109 -53 -121 104 -42 -3 79 80 100 100 -33 6 -48 -120 50 -65 23 -124 -1 -58 -68 59 -83 -25 25 -70 103 -73 102 -7 -119 -78 -57 125 21 -115 72 62 0 89 -75 112 5 11 36
```
and
```
0.120117 0.152344 0.0268555 0.112305 0.0217285 0.0578613 0.0576172 -0.0727539 0.0211182 0.134766 -0.0205078 -0.00762939 -0.0444336 0.126953 0.0864258 0.09375 -0.00180817 -0.0537109 -0.0446777 0.0366211 0.0600586 -0.0512695 0.177734 0.0227051 -0.0908203 -0.0498047 0.0693359 0.195312 -0.0578613 7.10487e-05 -0.00726318 0.00628662 -0.0510254 -0.00335693 0.013855 0.0922852 0.0805664 -0.0888672 0.000530243 -0.0766602 0.0629883 0.0473633 -0.0136108 -0.0241699 0.0317383 0.0976562 -0.00231934 -0.0996094 0.191406 -0.0698242 -0.00448608 0.186523 0.00479126 -0.050293 0.195312 -0.0649414 -0.0874023 0.188477 0.135742 -0.0339355 -0.0693359 -0.0236816 0.03125 -0.0270996
```
Result of dot product of these two vectors with sequential multiply-then-add gives:
```
-0.106735229
```
It gives 4 sub dot products on splitting K-dimension before reduce-sum:
```
5.882385254 24.400915146 -0.174797058 -30.215240479(0xc1f1b8d0)
```
If we compare the accumulation steps of the two algorithms (sequential first):
On step 15: `5.882385254` versus `5.882385254`
On step 31: `30.2833004` versus `30.2833004`
On step 47: `30.108505249` versus `30.108503342`
This is the first place 1 ULP mismatch is encountered if checking their hexadecimal representation: `0x41f0de38` versus `0x41f0de37`
On step 63: `-0.106735229` versus `-0.106737137`
Here the mismatch becomes 256 ULP (`0xbdda9800` versus `0xbdda9900`).
To verify validity of reduce-sum in splitting K-dimension computation we compute the addition manually:
Mantissa of the last sub dot product: `1.11100011011100011010000` minus
Mantissa of accumulation sum: `1.11100001101111000110111` equals
```
 0.00000001101010011011001
```
Notice the tailing `0b1` becomes `0b100000000` after normalization (due to cancellation of most significant bits) which explains the difference in precision.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

🧪 Execution Tests:
//xla/backends/gpu/codegen/triton:triton_gemm_fusion_test_amdgpu_any.

Hi @xla-rotation, would you help take a look? Thanks!