### PR TITLE
[ROCM] Invalidate cached subset cliques to fix NCCL comm split dea…

### DIFF
--- a/xla/backends/gpu/collectives/gpu_clique_key_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key_test.cc
@@ -221,4 +221,42 @@ TEST(GpuCliqueIdStringTest, ToString) {
   }
 }
 
+// Test that IsSubsetOf correctly identifies subset relationships for clique
+// invalidation. This is important for preventing deadlocks when cached subset
+// cliques need to be invalidated after a larger clique is created.
+TEST(GpuCliqueKeyTest, IsSubsetOfForCliqueInvalidation) {
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+  GlobalDeviceId id2 = GlobalDeviceId(2);
+  GlobalDeviceId id3 = GlobalDeviceId(3);
+
+  // Scenario: First we create clique [0,1], then later create [0,1,2,3].
+  // The cached [0,1] clique should be identified as a subset of [0,1,2,3]
+  // so it can be invalidated to prevent deadlock during comm splitting.
+  GpuCliqueKey small_clique({id0, id1}, /*num_local_participants=*/2, false);
+  GpuCliqueKey large_clique({id0, id1, id2, id3}, /*num_local_participants=*/4,
+                            false);
+
+  // [0,1] is a subset of [0,1,2,3]
+  EXPECT_TRUE(small_clique.IsSubsetOf(large_clique));
+
+  // [0,1,2,3] is not a subset of [0,1]
+  EXPECT_FALSE(large_clique.IsSubsetOf(small_clique));
+
+  // A clique is a subset of itself
+  EXPECT_TRUE(small_clique.IsSubsetOf(small_clique));
+  EXPECT_TRUE(large_clique.IsSubsetOf(large_clique));
+
+  // [2,3] is also a subset of [0,1,2,3]
+  GpuCliqueKey other_small({id2, id3}, /*num_local_participants=*/2, false);
+  EXPECT_TRUE(other_small.IsSubsetOf(large_clique));
+
+  // [0,1] is not a subset of [2,3] (disjoint)
+  EXPECT_FALSE(small_clique.IsSubsetOf(other_small));
+
+  // Different is_p2p flag should prevent subset relationship
+  GpuCliqueKey p2p_clique({id0, id1}, /*num_local_participants=*/2, true);
+  EXPECT_FALSE(p2p_clique.IsSubsetOf(large_clique));
+}
+
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -442,6 +442,48 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       VLOG(3) << absl::StrFormat("[%s] [ranks=%s] Created new clique %v",
                                  DeviceOrdinalsToString(ranks),
                                  DeviceRanksToString(ranks), clique_key);
+
+      // When NCCL comm splitting is enabled, invalidate any cached cliques
+      // that are proper subsets of the newly created clique. This ensures
+      // that subsequent operations using those subset device groups will
+      // create split communicators from this parent clique rather than
+      // reusing stale standalone communicators.
+      //
+      // Without this, if clique [0,1] exists from a previous run and we
+      // create [0,1,2,3], a subsequent [2,3] operation would try to split
+      // from [0,1,2,3] but [0,1] operations would use the old standalone
+      // clique, causing rendezvous deadlocks because NCCL comm split
+      // requires all ranks of the parent clique to participate.
+      static const bool enable_nccl_comm_splitting =
+          xla::GetDebugOptionsFromFlags().xla_gpu_enable_nccl_comm_splitting();
+      if (enable_nccl_comm_splitting) {
+        std::vector<GpuCliqueKey> keys_to_remove;
+        for (auto& [cached_key, cached_clique] : state.cliques) {
+          // Skip the clique we just created and check if cached is a proper
+          // subset of the new clique (same devices would mean equal keys).
+          if (!(cached_key == clique_key) &&
+              cached_key.IsSubsetOf(clique_key)) {
+            VLOG(3) << absl::StrFormat(
+                "[%s] [ranks=%s] Invalidating cached subset clique %v "
+                "(subset of new clique %v)",
+                DeviceOrdinalsToString(ranks), DeviceRanksToString(ranks),
+                cached_key, clique_key);
+            keys_to_remove.push_back(cached_key);
+          }
+        }
+        for (const auto& key : keys_to_remove) {
+          auto it = state.cliques.find(key);
+          if (it != state.cliques.end()) {
+            // Abort the communicators before removing to ensure clean
+            // shutdown of NCCL resources.
+            if (auto status = it->second.Abort(); !status.ok()) {
+              LOG(WARNING) << "Failed to abort subset clique "
+                           << key.ToString() << ": " << status;
+            }
+            state.cliques.erase(it);
+          }
+        }
+      }
     }
 
     return emplaced.first->second.Acquire();


### PR DESCRIPTION
…dlock

When `xla_gpu_enable_nccl_comm_splitting` is enabled (default), it is possible for a deadlock to occur if a subset clique was already created and cached, and those devices reuse it from the clique map, while other devices initiate a split and wait forever for the cached devices to join.
For example, this script produces the deadlock
When 

1. 2-GPU operations run with different mesh axes (DP, then TP)
2. 4-GPU operations run afterward
3. Sharding patterns trigger collectives on hidden dimension

```
"""
import os
os.environ["JAX_TRACEBACK_FILTERING"] = "off"

import jax
import jax.numpy as jnp
import numpy as np
from jax import random
from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
from jax._src.pjit import pjit

jax.config.update("jax_use_shardy_partitioner", False)


def run_test(n_devices, mesh_shape, axes, dp_res, tp_res):
    """Run pure JAX operations with specific sharding to trigger collectives."""
    print(f"Running {n_devices}-GPU test with axes={axes}...")
    
    devices = np.array(jax.devices()[:n_devices]).reshape(mesh_shape)
    mesh = Mesh(devices, axes)
    
    # Shard on hidden dim (like bad_sharding=True) to force collectives
    x_spec = P(dp_res, None, None, tp_res)
    
    x = random.normal(random.PRNGKey(0), [32, 12, 128, 128], jnp.float16)
    
    # Function 1: softmax + reduction (forces all-reduce)
    def fn1(x):
        y = jax.nn.softmax(x, axis=-1)  # softmax on sharded dim
        return jnp.mean(y)
    
    # Function 2: different pattern - layer norm style
    def fn2(x):
        mean = jnp.mean(x, axis=-1, keepdims=True)
        var = jnp.var(x, axis=-1, keepdims=True)
        y = (x - mean) / jnp.sqrt(var + 1e-5)
        return jnp.mean(y)
    
    with mesh:
        x_ = jax.device_put(x, NamedSharding(mesh, x_spec))
        
        # Run first function with grad
        jit1 = pjit(jax.value_and_grad(fn1), in_shardings=x_spec, out_shardings=(None, x_spec))
        fwd1, grad1 = jit1(x_)
        
        # Get HLO (triggers compilation)
        _ = jit1.lower(x_).compile().as_text()
        
        # Run second function with grad - different collective pattern
        jit2 = pjit(jax.value_and_grad(fn2), in_shardings=x_spec, out_shardings=(None, x_spec))
        fwd2, grad2 = jit2(x_)
        grad2.block_until_ready()
    
    print(f"  {n_devices}-GPU PASSED")


if __name__ == "__main__":
    print(f"JAX version: {jax.__version__}")
    print(f"Devices: {jax.devices()[:4]}")
    print()
    
    # Same sequence as TE reproducer:
    # 1. 2-GPU with DP axis
    run_test(2, (2,), ("dp",), "dp", None)
    
    # 2. 2-GPU with TP axis  
    run_test(2, (2,), ("tp",), None, "tp")
    
    # 3. 4-GPU with DP+TP axes -> Does it deadlock?
    run_test(4, (2,2), ("dp","tp"), "dp", "tp")
    
    print("\nAll passed!")
```



This was occurring in JAX TransformerEngine tests with pjit when running tests with different mesh configurations sequentially. The scenario is:

1. Test 1: Creates clique [0,1] with 2 GPUs
2. Test 2: Creates clique [0,1] with 2 GPUs (different mesh axis)
3. Test 3: Creates clique [0,1,2,3] with 4 GPUs, then needs [2,3]
   - Ranks 2,3 try to split [2,3] from [0,1,2,3]
   - But ranks 0,1 reuse the cached standalone [0,1] clique
   - NCCL comm split requires ALL ranks of parent clique to participate
   - Ranks 0,1 don't join the split because they reused cached clique
   - DEADLOCK: Ranks 2,3 wait forever for 0,1 to join

The fix invalidates any cached cliques that are proper subsets of a newly created clique. This ensures subsequent operations will create split communicators from the parent clique rather than reusing stale standalone communicators.

This is complementary to the participant_groups fix in PR #15935, which prevents clique key collisions. This fix handles the case where the cached clique was created before the larger clique existed.
