### PR TITLE
[ROCm] Fix paralle gpu execute script to support running tests on a machine …

### DIFF
--- a/build_tools/rocm/parallel_gpu_execute.sh
+++ b/build_tools/rocm/parallel_gpu_execute.sh
@@ -25,6 +25,14 @@ ROCMINFO=$(find "external/local_config_rocm/rocm/rocm_dist/" -name "rocminfo" -p
 TF_GPU_COUNT=$($ROCMINFO | grep "Name: *gfx*" | wc -l)
 TF_TESTS_PER_GPU=${TF_TESTS_PER_GPU:-8}
 
+# There are certain tests in xla that do not require any gpu in order to be executed
+# here we allow executing these tests on a machine without gpu support.
+# if there are no GPUs on that system e.g rbe default pool then execute the test without lock
+if [[ $TF_GPU_COUNT == 0 ]];then
+    echo "Execute with no GPU support"
+    exec "$@"
+fi
+
 # This function is used below in rlocation to check that a path is absolute
 function is_absolute {
   [[ "$1" = /* ]] || [[ "$1" =~ ^[a-zA-Z]:[/\\].* ]]


### PR DESCRIPTION
📝 Summary of Changes
Support test execution on a machine without GPU for parallel_gpu_execute script

🎯 Justification
This change is required mostly for rbe test execution.
If the pool is assigned to default, the runners of this pool do not 
have any gpus. This makes these tests failing but in fact these tests
do not require gpu to be executed, e.g build_test targets!

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI testing

🧪 Execution Tests:
CI testing
