### PR TITLE
[ROCm] Reenable miopen autotune when xla_gpu_autotune_level == 0

### DIFF
--- a/xla/backends/gpu/autotuner/miopen.cc
+++ b/xla/backends/gpu/autotuner/miopen.cc
@@ -420,6 +420,14 @@ MIOpenBackend::GetSupportedConfigs(const HloInstruction& instr) {
       return GetFusedConvolutionCustomCallConfigs(
           custom_call_instr, custom_call_instr->GetModule(), stream_executor());
     }
+
+    if (do_not_autotune_) {
+      ASSIGN_OR_RETURN(auto default_config, GetDefaultConfig(instr));
+      std::vector<std::unique_ptr<BackendConfig>> configs;
+      configs.push_back(std::move(default_config));
+      return std::move(configs);
+    }
+
     return GetConvolutionCustomCallConfigs(
         custom_call_instr, custom_call_instr->GetModule(), stream_executor(),
         /* stream */ nullptr);

--- a/xla/backends/gpu/autotuner/miopen.h
+++ b/xla/backends/gpu/autotuner/miopen.h
@@ -39,7 +39,8 @@ class MIOpenBackend : public GpuCodegenBackend {
                          const DebugOptions* debug_options, Compiler* compiler,
                          const Compiler::GpuTargetConfig* target_config)
       : GpuCodegenBackend(autotuner::Backend::MIOPEN, debug_options, compiler,
-                          target_config, stream_executor) {}
+                          target_config, stream_executor),
+        do_not_autotune_(debug_options->xla_gpu_autotune_level() == 0) {}
 
   absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>>
   GetSupportedConfigs(const HloInstruction& instr) override;
@@ -52,6 +53,7 @@ class MIOpenBackend : public GpuCodegenBackend {
 
  private:
   bool IsSupported(const HloInstruction& instr) override;
+  bool do_not_autotune_;
 };
 
 }  // namespace gpu

--- a/xla/backends/gpu/autotuner/miopen_test.cc
+++ b/xla/backends/gpu/autotuner/miopen_test.cc
@@ -85,8 +85,13 @@ class MIOpenBackendTest : public HloHardwareIndependentTestBase {
                              ->ExecutorForDevice(0)
                              .value()),
         target_config_(stream_executor_),
-        backend_(stream_executor_, &debug_options_, &compiler_,
-                 &target_config_) {}
+        backend_(
+            stream_executor_,
+            [](auto& opts) {
+              opts.set_xla_gpu_autotune_level(1);
+              return &opts;
+            }(debug_options_),
+            &compiler_, &target_config_) {}
 
   bool IsRocm() {
     return stream_executor_->GetPlatform()->id() == se::rocm::kROCmPlatformId;

--- a/xla/service/gpu/amdgpu_compiler.cc
+++ b/xla/service/gpu/amdgpu_compiler.cc
@@ -122,10 +122,15 @@ absl::Status AMDGPUCompiler::OptimizeHloConvolutionCanonicalization(
   ConvBfloat16Support conv_bf16_support(*gpu_version.rocm_compute_capability());
   pipeline.AddPass<FloatNormalization>(&conv_bf16_support);
 
-  pipeline.AddPass<ConvRewriter>(gpu_version);
-  pipeline.AddPass<ConvPaddingLegalization>();
-  auto rcc = gpu_version.rocm_compute_capability();
-  pipeline.AddPass<CudnnFusedConvRewriter>(*rcc, dnn_version, toolkit_version);
+  if (!hlo_module->config()
+           .debug_options()
+           .xla_gpu_experimental_disable_binary_libraries()) {
+    pipeline.AddPass<ConvRewriter>(gpu_version);
+    pipeline.AddPass<ConvPaddingLegalization>();
+    auto rcc = gpu_version.rocm_compute_capability();
+    pipeline.AddPass<CudnnFusedConvRewriter>(*rcc, dnn_version,
+                                             toolkit_version);
+  }
 
   // The conv padding/vectorization passes which we need to get rid of.  They
   // also leave behind unnecessary tuple/get-tuple-element pairs that

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -3267,16 +3267,26 @@ absl::Status GpuCompiler::AddConvAndGemmAutotuningPass(
                       GetCodegenBackends(stream_exec, target_config, alias_info,
                                          debug_options, mlir_context));
 
-  bool do_not_autotune_cublas_and_cudnn =
+  bool do_not_autotune_cublas =
       debug_options.xla_gpu_experimental_disable_binary_libraries() ||
       debug_options.xla_gpu_autotune_level() == 0 ||
       debug_options.xla_gpu_exclude_nondeterministic_ops();
-  auto should_autotune = [do_not_autotune_cublas_and_cudnn](
+  // We need to run miopen autotune to decompose unsuported fused convolutions
+  // TODO: Merge this with above once we are able to achieve the same with
+  // FissionBackend
+  bool do_not_autotune_cudnn =
+      debug_options.xla_gpu_experimental_disable_binary_libraries() ||
+      (do_not_autotune_cublas && !gpu_version.IsRocm());
+  auto should_autotune = [do_not_autotune_cublas, do_not_autotune_cudnn](
                              const HloInstruction& instruction) -> bool {
-    if (!do_not_autotune_cublas_and_cudnn &&
+    if (!do_not_autotune_cublas &&
         (instruction.opcode() == HloOpcode::kCustomCall &&
-         (IsCublasGemm(instruction) ||
-          IsCustomCallToDnnConvolution(instruction)))) {
+         IsCublasGemm(instruction))) {
+      return true;
+    }
+    if (!do_not_autotune_cudnn &&
+        (instruction.opcode() == HloOpcode::kCustomCall &&
+         IsCustomCallToDnnConvolution(instruction))) {
       return true;
     }
     if (instruction.opcode() != HloOpcode::kFusion) {

--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -4720,16 +4720,17 @@ class RocmFusedConvRunner : public dnn::FusedConvRunner {
       auto status = wrap::miopenFusionPlanGetWorkSpaceSize(
           miopen.handle(), fusion_plan.fusion_plan_, &workspace_size_,
           miopenConvolutionFwdAlgoImplicitGEMM);
-      constexpr bool miopenFusionPlanGetWorkSpaceSize_is_broken = true;
-
-      if (miopenFusionPlanGetWorkSpaceSize_is_broken) {
-        return absl::InternalError("Cannot reliably query workspace size");
-      }
 
       if (status != miopenStatusSuccess) {
         return absl::InternalError(
             "call to miopenFusionPlanGetWorkSpaceSize failed: " +
             stream_executor::gpu::ToString(status));
+      }
+
+      constexpr bool miopenFusionPlanGetWorkSpaceSize_is_broken = true;
+
+      if (miopenFusionPlanGetWorkSpaceSize_is_broken) {
+        return absl::InternalError("Cannot reliably query workspace size");
       }
     }
 


### PR DESCRIPTION
📝 Summary of Changes
Adapt GpuCompiler::AddConvAndGemmAutotuningPass to match pre refactor behavior of AMDGPUCompiler. 

🎯 Justification
For ROCm we need to run miopen backend even when autotuning is disabled in order to decompose back unsupported fused convolutions. There is no runtime fallback.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
None

🧪 Execution Tests:
None
