### PR TITLE
Fix/generalize AR+Slice matching

### DIFF
--- a/xla/service/gpu/transforms/reduce_scatter_creator_test.cc
+++ b/xla/service/gpu/transforms/reduce_scatter_creator_test.cc
@@ -65,11 +65,11 @@ class GpuReduceScatterCreatorTest : public HloHardwareIndependentTestBase {
     return absl::StatusOr<std::unique_ptr<HloModule>>(std::move(module));
   }
 
-  size_t AllReduceCount(std::unique_ptr<HloModule> &module) {
+  size_t AllReduceCount(std::unique_ptr<HloModule>& module) {
     return CollectiveCount(module, HloOpcode::kAllReduce);
   }
 
-  size_t ReduceScatterCount(std::unique_ptr<HloModule> &module) {
+  size_t ReduceScatterCount(std::unique_ptr<HloModule>& module) {
     return CollectiveCount(module, HloOpcode::kReduceScatter);
   }
 
@@ -84,7 +84,7 @@ class GpuReduceScatterCreatorTest : public HloHardwareIndependentTestBase {
   }
 
  private:
-  size_t CollectiveCount(std::unique_ptr<HloModule> &module, HloOpcode opcode) {
+  size_t CollectiveCount(std::unique_ptr<HloModule>& module, HloOpcode opcode) {
     return absl::c_count_if(
         module->entry_computation()->instructions(),
         [&opcode](HloInstruction* instr) { return instr->opcode() == opcode; });
@@ -93,7 +93,7 @@ class GpuReduceScatterCreatorTest : public HloHardwareIndependentTestBase {
   size_t CollectiveCount(HloModule* module, HloOpcode opcode) {
     return absl::c_count_if(
         module->entry_computation()->instructions(),
-        [&opcode](HloInstruction *instr) { return instr->opcode() == opcode; });
+        [&opcode](HloInstruction* instr) { return instr->opcode() == opcode; });
   }
 };
 
@@ -130,7 +130,7 @@ ENTRY %AllReduce {
                                                /*expect_change=*/true));
   ASSERT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::ReduceScatter(m::Parameter(0))));
-  const auto *rs = Cast<HloReduceScatterInstruction>(
+  const auto* rs = Cast<HloReduceScatterInstruction>(
       module->entry_computation()->root_instruction());
   EXPECT_EQ(rs->scatter_dimension(), 0) << rs->ToString();
   EXPECT_EQ(AllReduceCount(module), 0);
@@ -169,7 +169,7 @@ ENTRY %AllReduce {
                                                /*expect_change=*/true));
   ASSERT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::ReduceScatter(m::Parameter(0))));
-  const auto *rs = Cast<HloReduceScatterInstruction>(
+  const auto* rs = Cast<HloReduceScatterInstruction>(
       module->entry_computation()->root_instruction());
   EXPECT_EQ(rs->scatter_dimension(), 0) << rs->ToString();
   EXPECT_EQ(AllReduceCount(module), 0);
@@ -278,7 +278,7 @@ ENTRY %AllReduce {
                                                /*expect_change=*/true));
   ASSERT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::ReduceScatter(m::Parameter(0))));
-  const auto *rs = Cast<HloReduceScatterInstruction>(
+  const auto* rs = Cast<HloReduceScatterInstruction>(
       module->entry_computation()->root_instruction());
   EXPECT_EQ(rs->scatter_dimension(), 2) << rs->ToString();
   EXPECT_EQ(AllReduceCount(module), 0);
@@ -633,7 +633,7 @@ dynamic_slice_sizes={4,8,128}
                                                /*expect_change=*/true));
   ASSERT_THAT(module->entry_computation()->root_instruction(),
               GmockMatch(m::ReduceScatter(m::Parameter(0))));
-  const auto *rs = Cast<HloReduceScatterInstruction>(
+  const auto* rs = Cast<HloReduceScatterInstruction>(
       module->entry_computation()->root_instruction());
   EXPECT_TRUE(rs->backend_config<GpuBackendConfig>()
                   ->collective_backend_config()
@@ -715,6 +715,317 @@ ENTRY %SubtractionPattern {
       module->entry_computation()->root_instruction());
   EXPECT_EQ(rs->scatter_dimension(), 1) << rs->ToString();
   EXPECT_EQ(AllReduceCount(module), 0);
+}
+
+// Multiplier is clamped but table index is not, and we can't prove the clamp is
+// no-op.
+TEST_F(GpuReduceScatterCreatorTest,
+       SubtractionPatternWithTableLookupMultiplierUnprovableNoopClamp) {
+  absl::string_view hlo_string = R"(
+HloModule SubtractionPatternClampNoop
+
+%sum {
+  %a = f32[] parameter(0)
+  %b = f32[] parameter(1)
+  ROOT %add = f32[] add(%a, %b)
+}
+
+ENTRY %SubtractionPatternClampNoop {
+  %param = f32[4,64,1024]{2,1,0} parameter(0)
+  %all-reduce = f32[4,64,1024]{2,1,0} all-reduce(%param),
+    replica_groups={{0,1,2,3},{4,5,6,7}}, to_apply=%sum, channel_id=1, use_global_device_ids=true
+  %pid = u32[] partition-id()
+  %table = s32[8]{0} constant({0, 0, 0, 0, 64, 64, 64, 64})
+  %id = s32[1] dynamic-slice(%table, %pid), dynamic_slice_sizes={1}
+  %reshape = s32[] reshape(%id)
+  %slice_size = s32[] constant(16)
+  %zero_u32 = u32[] constant(0)
+  %max_u32 = u32[] constant(7)
+  %pid_clamp = u32[] clamp(%zero_u32, %pid, %max_u32)
+  %pid_s32 = s32[] convert(%pid_clamp)
+  %multiply = s32[] multiply(%pid_s32, %slice_size)
+  %offset = s32[] subtract(%multiply, %reshape)
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[4,16,1024] dynamic-slice(%all-reduce, %zero, %offset, %zero),
+    dynamic_slice_sizes={4,16,1024}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, RunPass(hlo_string,
+                                               /*num_replicas=*/1,
+                                               /*num_partitions=*/8,
+                                               /*use_spmd_partitioning=*/true,
+                                               /*expect_change=*/false));
+  EXPECT_EQ(AllReduceCount(module), 1);
+  EXPECT_EQ(ReduceScatterCount(module), 0);
+}
+
+// Table index is clamped but multiplier is not, and we can't prove the clamp is
+// no-op.
+TEST_F(GpuReduceScatterCreatorTest,
+       SubtractionPatternWithTableLookupIndexUnprovableNoopClamp) {
+  absl::string_view hlo_string = R"(
+HloModule SubtractionPatternClampIndex
+
+%sum {
+  %a = f32[] parameter(0)
+  %b = f32[] parameter(1)
+  ROOT %add = f32[] add(%a, %b)
+}
+
+ENTRY %SubtractionPatternClampIndex {
+  %param = f32[4,64,1024]{2,1,0} parameter(0)
+  %all-reduce = f32[4,64,1024]{2,1,0} all-reduce(%param),
+    replica_groups={{0,1,2,3},{4,5,6,7}}, to_apply=%sum, channel_id=1, use_global_device_ids=true
+  %pid = u32[] partition-id()
+  %pid_min = u32[] constant(0)
+  %pid_max = u32[] constant(7)
+  %pid_clamp = u32[] clamp(%pid_min, %pid, %pid_max)
+  %table = s32[8]{0} constant({0, 0, 0, 0, 64, 64, 64, 64})
+  %id = s32[1] dynamic-slice(%table, %pid_clamp), dynamic_slice_sizes={1}
+  %reshape = s32[] reshape(%id)
+  %slice_size = s32[] constant(16)
+  %pid_s32 = s32[] convert(%pid)
+  %multiply = s32[] multiply(%pid_s32, %slice_size)
+  %offset = s32[] subtract(%multiply, %reshape)
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[4,16,1024] dynamic-slice(%all-reduce, %zero, %offset, %zero),
+    dynamic_slice_sizes={4,16,1024}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, RunPass(hlo_string,
+                                               /*num_replicas=*/1,
+                                               /*num_partitions=*/8,
+                                               /*use_spmd_partitioning=*/true,
+                                               /*expect_change=*/false));
+  EXPECT_EQ(AllReduceCount(module), 1);
+  EXPECT_EQ(ReduceScatterCount(module), 0);
+}
+
+// Multiplier is clamped to [0,3], which is NOT a no-op for 8 partitions.
+// Table index uses raw pid. Pattern should not match.
+TEST_F(GpuReduceScatterCreatorTest, SubtractionPatternWithMultiplierClamped) {
+  absl::string_view hlo_string = R"(
+HloModule SubtractionPatternClampNonNoop
+
+%sum {
+  %a = f32[] parameter(0)
+  %b = f32[] parameter(1)
+  ROOT %add = f32[] add(%a, %b)
+}
+
+ENTRY %SubtractionPatternClampNonNoop {
+  %param = f32[4,64,1024]{2,1,0} parameter(0)
+  %all-reduce = f32[4,64,1024]{2,1,0} all-reduce(%param),
+    replica_groups={{0,1,2,3},{4,5,6,7}}, to_apply=%sum, channel_id=1, use_global_device_ids=true
+  %pid = u32[] partition-id()
+  %pid_min = u32[] constant(0)
+  %pid_max = u32[] constant(3)
+  %pid_clamp = u32[] clamp(%pid_min, %pid, %pid_max)
+  %table = s32[8]{0} constant({0, 0, 0, 0, 64, 64, 64, 64})
+  %id = s32[1] dynamic-slice(%table, %pid), dynamic_slice_sizes={1}
+  %reshape = s32[] reshape(%id)
+  %slice_size = s32[] constant(16)
+  %pid_s32 = s32[] convert(%pid_clamp)
+  %multiply = s32[] multiply(%pid_s32, %slice_size)
+  %offset = s32[] subtract(%multiply, %reshape)
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[4,16,1024] dynamic-slice(%all-reduce, %zero, %offset, %zero),
+    dynamic_slice_sizes={4,16,1024}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, RunPass(hlo_string,
+                                               /*num_replicas=*/1,
+                                               /*num_partitions=*/8,
+                                               /*use_spmd_partitioning=*/true,
+                                               /*expect_change=*/false));
+  EXPECT_EQ(AllReduceCount(module), 1);
+  EXPECT_EQ(ReduceScatterCount(module), 0);
+}
+
+// Table index and multiplier have (different) noop chains, but ultimately are
+// derived from the same value.
+TEST_F(GpuReduceScatterCreatorTest,
+       SubtractionPatternWithTableLookupNoopChains) {
+  absl::string_view hlo_string = R"(
+HloModule SubtractionPatternNoopChains
+
+%sum {
+  %a = f32[] parameter(0)
+  %b = f32[] parameter(1)
+  ROOT %add = f32[] add(%a, %b)
+}
+
+ENTRY %SubtractionPatternNoopChains {
+  %param = f32[4,64,1024]{2,1,0} parameter(0)
+  %all-reduce = f32[4,64,1024]{2,1,0} all-reduce(%param),
+    replica_groups={{0,1,2,3},{4,5,6,7}}, to_apply=%sum, channel_id=1, use_global_device_ids=true
+  %pid = u32[] partition-id()
+  %table = s32[8]{0} constant({0, 0, 0, 0, 64, 64, 64, 64})
+  %id = s32[1] dynamic-slice(%table, %pid), dynamic_slice_sizes={1}
+  %id_bitcast = s32[1] bitcast(%id)
+  %reshape = s32[] reshape(%id_bitcast)
+  %slice_size = s32[] constant(16)
+  %pid_copy = u32[] copy(%pid)
+  %pid_s32 = s32[] convert(%pid_copy)
+  %multiply = s32[] multiply(%pid_s32, %slice_size)
+  %offset = s32[] subtract(%multiply, %reshape)
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[4,16,1024] dynamic-slice(%all-reduce, %zero, %offset, %zero),
+    dynamic_slice_sizes={4,16,1024}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, RunPass(hlo_string,
+                                               /*num_replicas=*/1,
+                                               /*num_partitions=*/8,
+                                               /*use_spmd_partitioning=*/true,
+                                               /*expect_change=*/true));
+  ASSERT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::ReduceScatter(m::Parameter(0))));
+  const auto* rs = Cast<HloReduceScatterInstruction>(
+      module->entry_computation()->root_instruction());
+  EXPECT_EQ(rs->scatter_dimension(), 1) << rs->ToString();
+  EXPECT_EQ(AllReduceCount(module), 0);
+}
+
+// Global IDs wrap around the table for ND meshes.
+TEST_F(GpuReduceScatterCreatorTest,
+       SubtractionPatternWithTableLookupGlobalIdsModulo) {
+  absl::string_view hlo_string = R"(
+HloModule SubtractionPatternGlobalIdsModulo
+
+%sum {
+  %a = f32[] parameter(0)
+  %b = f32[] parameter(1)
+  ROOT %add = f32[] add(%a, %b)
+}
+
+ENTRY %SubtractionPatternGlobalIdsModulo {
+  %param = f32[4,64,1024]{2,1,0} parameter(0)
+  %all-reduce = f32[4,64,1024]{2,1,0} all-reduce(%param),
+    replica_groups={{0,1,2,3},{4,5,6,7}}, to_apply=%sum, channel_id=1, use_global_device_ids=true
+  %pid = u32[] partition-id()
+  %table = s32[4]{0} constant({0, 0, 0, 0})
+  %id = s32[1] dynamic-slice(%table, %pid), dynamic_slice_sizes={1}
+  %reshape = s32[] reshape(%id)
+  %slice_size = s32[] constant(16)
+  %pid_s32 = s32[] convert(%pid)
+  %multiply = s32[] multiply(%pid_s32, %slice_size)
+  %offset = s32[] subtract(%multiply, %reshape)
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[4,16,1024] dynamic-slice(%all-reduce, %zero, %offset, %zero),
+    dynamic_slice_sizes={4,16,1024}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, RunPass(hlo_string,
+                                               /*num_replicas=*/2,
+                                               /*num_partitions=*/4,
+                                               /*use_spmd_partitioning=*/true,
+                                               /*expect_change=*/true));
+  ASSERT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::ReduceScatter(m::Parameter(0))));
+  const auto* rs = Cast<HloReduceScatterInstruction>(
+      module->entry_computation()->root_instruction());
+  EXPECT_EQ(rs->scatter_dimension(), 1) << rs->ToString();
+  EXPECT_EQ(AllReduceCount(module), 0);
+}
+
+// Manually computing global ID and using it directly produces wrong offsets
+// for groups beyond the first one.
+TEST_F(GpuReduceScatterCreatorTest,
+       SubtractionPatternWithManualGlobalIdFalsePositive) {
+  absl::string_view hlo_string = R"(
+HloModule SubtractionPatternGlobalIdsModuloFalsePositive
+
+%sum {
+  %a = f32[] parameter(0)
+  %b = f32[] parameter(1)
+  ROOT %add = f32[] add(%a, %b)
+}
+
+ENTRY %SubtractionPatternGlobalIdsModuloFalsePositive {
+  %param = f32[4,64,1024]{2,1,0} parameter(0)
+  %all-reduce = f32[4,64,1024]{2,1,0} all-reduce(%param),
+    replica_groups={{0,1,2,3},{4,5,6,7}}, to_apply=%sum, channel_id=1, use_global_device_ids=true
+  %pid = u32[] partition-id()
+  %rid = u32[] replica-id()
+  %pcount = u32[] constant(4)
+  %ridxp = u32[] multiply(%rid, %pcount)
+  %gid = u32[] add(%ridxp, %pid)
+  %table = s32[8]{0} constant({0, 0, 0, 0, 0, 0, 0, 0})
+  %id = s32[1] dynamic-slice(%table, %gid), dynamic_slice_sizes={1}
+  %reshape = s32[] reshape(%id)
+  %slice_size = s32[] constant(16)
+  %gid_s32 = s32[] convert(%gid)
+  %multiply = s32[] multiply(%gid_s32, %slice_size)
+  %offset = s32[] subtract(%multiply, %reshape)
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[4,16,1024] dynamic-slice(%all-reduce, %zero, %offset, %zero),
+    dynamic_slice_sizes={4,16,1024}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, RunPass(hlo_string,
+                                               /*num_replicas=*/2,
+                                               /*num_partitions=*/4,
+                                               /*use_spmd_partitioning=*/true,
+                                               /*expect_change=*/false));
+  EXPECT_EQ(AllReduceCount(module), 1);
+  EXPECT_EQ(ReduceScatterCount(module), 0);
+}
+
+TEST_F(GpuReduceScatterCreatorTest, ReproClampOnGroupLocalIndex) {
+  absl::string_view hlo_string = R"(
+HloModule reduce_scatter_repro, num_partitions=128
+
+%add.17.clone (x.35: bf16[], y.35: bf16[]) -> bf16[] {
+  %x.35 = bf16[] parameter(0)
+  %y.35 = bf16[] parameter(1)
+  ROOT %add.1629 = bf16[] add(%x.35, %y.35)
+}
+
+ENTRY main {
+  input = bf16[1,8192,2560] parameter(0)
+
+  %constant.1513 = s32[] constant(0)
+  %constant.1710 = s32[8]{0} constant({0, 0, 0, 0, 8192, 8192, 8192, 8192})
+  %partition-id.14 = u32[] partition-id()
+
+  %all-reduce.365 = bf16[1,8192,2560]{2,1,0} all-reduce(input),
+    channel_id=72, replica_groups=[32,4]<=[128], use_global_device_ids=true, to_apply=%add.17.clone
+
+  %constant.1691 = u32[128]{0} constant({0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7})
+  %dynamic-slice.444 = u32[1]{0} dynamic-slice(%constant.1691, %partition-id.14), dynamic_slice_sizes={1}
+  %reshape.2062 = u32[] reshape(%dynamic-slice.444)
+  %dynamic-slice.448 = s32[1]{0} dynamic-slice(%constant.1710, %reshape.2062), dynamic_slice_sizes={1}
+  %reshape.2090 = s32[] reshape(%dynamic-slice.448)
+
+  %constant.1690 = u32[] constant(0)
+  %constant.1692 = u32[] constant(7)
+  %clamp.8 = u32[] clamp(%constant.1690, %reshape.2062, %constant.1692)
+  %convert.7 = s32[] convert(%clamp.8)
+  %constant.1693 = s32[] constant(2048)
+  %multiply.260 = s32[] multiply(%convert.7, %constant.1693)
+
+  %subtract.55 = s32[] subtract(%multiply.260, %reshape.2090)
+
+  ROOT %dynamic-slice.456 = bf16[1,2048,2560]{2,1,0} dynamic-slice(%all-reduce.365, %constant.1513, %subtract.55, %constant.1513), dynamic_slice_sizes={1,2048,2560}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, RunPass(hlo_string,
+                                               /*num_replicas=*/1,
+                                               /*num_partitions=*/128,
+                                               /*use_spmd_partitioning=*/true,
+                                               /*expect_change=*/true));
+  ASSERT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::ReduceScatter(m::Parameter(0))));
+  EXPECT_EQ(AllReduceCount(module), 0);
+  EXPECT_EQ(ReduceScatterCount(module), 1);
 }
 
 TEST_F(GpuReduceScatterCreatorTest, AllReduceThroughTuple) {


### PR DESCRIPTION
📝 Summary of Changes
Reduce scatter creator was missing some replacement opportunities. In my case there were (provably) no-op clamps that were making it think the multiplier and offset index were different.

🎯 Justification
In pretty standard 3D parallel workload, missing AR->RS replacements causes 50% in TP comms and 50% increase in DP comms.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
Added unit tests for expected matching patterns, also a minimized version of the matching that was previously failing for me.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
