### PR TITLE
[CPU] Fix Use-After-Free in JitCompiler caused by zombie tasks in ThreadPool

### DIFF
--- a/xla/backends/cpu/codegen/jit_compiler.cc
+++ b/xla/backends/cpu/codegen/jit_compiler.cc
@@ -237,7 +237,7 @@ void JitCompiler::TaskDispatcher::dispatch(
 
     if (task_holder->task) {
       // We run and explicitly destroy the task before decrementing the
-      // counterand notifying the condition variable, to ensure that the
+      // counter and notifying the condition variable to ensure that the
       // task is fully executed and cleaned up before task dispatcher shut
       // down.
       task_holder->task->run();

--- a/xla/backends/cpu/codegen/jit_compiler.cc
+++ b/xla/backends/cpu/codegen/jit_compiler.cc
@@ -224,15 +224,30 @@ void JitCompiler::TaskDispatcher::dispatch(
     ++num_dispatched_tasks_;
   }
 
-  task_runner_([this, task = std::shared_ptr<llvm::orc::Task>(
+  // Wrap the move-only task in a shared struct. This satisfies the thread
+  // pool's requirement for copyable tasks while enabling explicit control of
+  // the task's lifetime.
+  struct TaskHolder {
+    std::unique_ptr<llvm::orc::Task> task;
+  };
+
+  task_runner_([this, task_holder = std::make_shared<TaskHolder>(
                           std::move(task))]() mutable {
     TraceMe trace("TaskDispatcher::dispatch");
 
-    // We run and explicitly destroy the task before decrementing the counter
-    // and notifying the condition variable, to ensure that the task is fully
-    // executed and cleaned up before task dispatcher shut down.
-    task->run();
-    task.reset();
+    if (task_holder->task) {
+      // We run and explicitly destroy the task before decrementing the
+      // counterand notifying the condition variable, to ensure that the
+      // task is fully executed and cleaned up before task dispatcher shut
+      // down.
+      task_holder->task->run();
+
+      // Eagerly destroy the task. The thread pool may retain a copy of this
+      // lambda indefinitely (a "zombie" task). We must ensure the task releases
+      // its resources (e.g. ExecutionSession) immediately, rather than waiting
+      // for the pool to overwrite this slot.
+      task_holder->task.reset();
+    }
 
     absl::MutexLock lock(mu_);
     --num_dispatched_tasks_;

--- a/xla/backends/cpu/codegen/jit_compiler.h
+++ b/xla/backends/cpu/codegen/jit_compiler.h
@@ -103,6 +103,8 @@ class JitCompiler {
   llvm::TargetMachine* target_machine() { return target_machine_.get(); }
 
  private:
+  friend class JitCompilerTest;
+
   // LLVM ORC task dispatcher that uses `TaskRunner` to run compilation tasks.
   class TaskDispatcher : public llvm::orc::TaskDispatcher {
    public:

--- a/xla/backends/cpu/codegen/jit_compiler_test.cc
+++ b/xla/backends/cpu/codegen/jit_compiler_test.cc
@@ -35,6 +35,7 @@ limitations under the License.
 #include "llvm/ExecutionEngine/Orc/CoreContainers.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
+#include "llvm/ExecutionEngine/Orc/TaskDispatch.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/LLVMContext.h"
@@ -239,6 +240,58 @@ TEST(JitCompilerTest, ExternalDefinitionGenerator) {
   float value = 1.0f;
   call_external_fn(&value);
   EXPECT_EQ(value, 2.0f);
+}
+
+class JitCompilerTest : public ::testing::Test {
+ protected:
+  // Access to private inner class types.
+  using TaskDispatcher = JitCompiler::TaskDispatcher;
+  using Task = JitCompiler::Task;
+};
+
+TEST_F(JitCompilerTest, TaskMemoryReleasedWhenTaskRetainedByQueue) {
+  // A minimal task that flags when its resource is freed.
+  class TrackedTask : public llvm::orc::Task {
+   public:
+    explicit TrackedTask(bool* free_resource_flag, int* tasks_run)
+        : free_resource_flag_(free_resource_flag), tasks_run_(tasks_run) {}
+    void printDescription(llvm::raw_ostream&) override {}
+    void run() override { (*tasks_run_)++; }
+    ~TrackedTask() override { *free_resource_flag_ = true; }
+
+   private:
+    bool* free_resource_flag_ = nullptr;
+    int* tasks_run_ = nullptr;
+  };
+
+  // Simulate the thread pool's internal storage.
+  std::vector<JitCompiler::Task> thread_pool_storage;
+  // The worker runs a queued task by copying it to its local stack, but leaving
+  // the original in the queue as an optimization.
+  JitCompiler::TaskRunner worker_thread =
+      [&thread_pool_storage](JitCompiler::Task task) {
+        thread_pool_storage.push_back(std::move(task));  // Enqueue
+
+        // Copy to local stack (simulating thread-local execution)
+        JitCompiler::Task local_task = thread_pool_storage.back();
+        local_task();
+      };
+
+  auto dispatcher = std::make_unique<TaskDispatcher>(std::move(worker_thread));
+
+  bool task_resource_freed = false;
+  int tasks_run = 0;
+  dispatcher->dispatch(
+      std::make_unique<TrackedTask>(&task_resource_freed, &tasks_run));
+
+  ASSERT_EQ(tasks_run, 1);
+  // The task has run, but the thread pool still holds a reference to the task
+  // wrapper.
+  EXPECT_FALSE(thread_pool_storage.empty());
+  // The task's resources must have been freed, otherwise a use-after free can
+  // occur when the task wrapper is eventually destroyed from the thread pool.
+  EXPECT_TRUE(task_resource_freed)
+      << "The Queue is keeping the Task resource alive!";
 }
 
 }  // namespace xla::cpu


### PR DESCRIPTION
📝 Summary of Changes
This PR fixes a use-after-free race condition in `xla::cpu::JitCompiler` where tasks lingering in the thread pool extend the lifetime of JIT resources beyond the lifetime of the compiler itself.

The issue stems from how the `Eigen::ThreadPool` used by `JitCompiler` (via `TaskRunner`) manages task lifetimes. Worker threads copy tasks to their local stack for execution, but the original std::function often remains alive in the thread pool's circular buffer until it is eventually overwritten. 
If the JitCompiler (and its underlying `llvm::orc::ExecutionSession`) is destroyed while these zombie tasks are still in the queue, the `llvm::orc::Task` objects inside them stay alive, causing two distinct crash signatures depending on the task type:
- Use-After-Free (Segfault): If the zombie task is destroyed after the `ExecutionSession` is freed, its destructor may try to access the dead session (via `~MaterializationResponsibility`), causing a crash in `recursive_mutex`.
- Assertion Failure (`SymbolStringPool`): If the zombie task holds a `SymbolStringPtr` (eg a `MaterializationTask`), it keeps the `SymbolStringPool` reference count above zero. When the `ExecutionSession` tries to destroy the pool, it hits an assertion: `Assertion Pool.empty() && "Dangling references at pool destruction time"` failed.

This change introduces a `TaskHolder` indirection  to decouple the lifetime of the `llvm::orc::Task` from the lifetime of the thread pool queue entry. We wrap the `std::unique_ptr<Task>` in a `std::shared_ptr<TaskHolder>`.
Both the thread pool queue and the worker thread hold references to this shared holder.
Immediately after `task->run()` completes, we explicitly call `task.reset()` inside the wrapper.
This ensures that the Task resources are released synchronously at the end of execution. Even if the wrapper struct remains alive in the thread pool queue, it no longer keeps a Task alive with it, and can be safely destroyed at any time thereafter.

🎯 Justification
Fixes recurring crashes on resource-constrained environments (like ChromeOS/CrosVM) where the ThreadPool queue wraps around frequently when there are multiple calls to `PjRtClient.CompileAndLoad`.
Fixes occasional assertion failure crashes on destruction.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
New CPU JitCompiler unit test added which mimics the behavior of the Eigen thread pool by holding a copy of a task in a vector while executing a local copy. The test asserts that the task's resources are freed immediately after execution, even while the vector retains a reference to the task wrapper.
Without the fix, this test fails (resources are retained by the queue). With the fix, it passes.

🧪 Execution Tests:
N/A
