### PR TITLE
[Trivial] Fixed a bug in the handling of recv callbacks in PJRT.

### DIFF
--- a/xla/pjrt/gpu/tfrt/utils.cc
+++ b/xla/pjrt/gpu/tfrt/utils.cc
@@ -478,7 +478,7 @@ SendDeviceMemoryFunction ConvertSendCallbacksToSendFunction(
 RecvDeviceMemoryFunction ConvertRecvCallbacksToRecvFunction(
     int replica, const ExecuteOptions& options) {
   // Check if we have callbacks registered for the given replica.
-  if (replica >= options.send_callbacks.size()) {
+  if (replica >= options.recv_callbacks.size()) {
     return [replica](int64_t channel_id, se::Stream*, const Shape&,
                      se::DeviceAddressBase*,
                      const absl::flat_hash_map<std::string, std::string>&) {

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -1382,7 +1382,7 @@ class StreamExecutorCopyToDeviceStream : public CopyToDeviceStream {
 static RecvDeviceMemoryFunction ConvertRecvCallbacksToRecvFunction(
     int replica, const ExecuteOptions& options) {
   // Check if we have callbacks registered for the given replica.
-  if (replica >= options.send_callbacks.size()) {
+  if (replica >= options.recv_callbacks.size()) {
     return [replica](int64_t channel_id, se::Stream*, const Shape&,
                      se::DeviceAddressBase*,
                      const absl::flat_hash_map<std::string, std::string>&) {


### PR DESCRIPTION
📝 Summary of Changes

Switched from `options.send_callbacks.size()` to `options.recv_callbacks.size()` in a couple places that dealt with receive callbacks instead of send callbacks. I'm guessing this was probably a copy-pasta bug.

🎯 Justification

I discovered this because I've been developing Rust bindings for PJRT and I kept getting segfaults while trying to use a send callback with a program that had a send operation and no receive operations. I verified that this fix resolved the segfault I was hitting.

🚀 Kind of Contribution

🐛 Bug Fix