### PR TITLE
[XLA:GPU][oneAPI] Fix platform error in stream executor tests with SYCL backend

### DIFF
--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -3,6 +3,10 @@ load(
     "if_rocm_is_configured",
 )
 load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
+load(
     "//xla:xla.default.bzl",
     "xla_cc_binary",
     "xla_cc_test",
@@ -437,7 +441,7 @@ cc_library(
     local_defines = (
         if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured([
             "TENSORFLOW_USE_ROCM=1",
-        ])
+        ]) + if_sycl_is_configured(["TENSORFLOW_USE_SYCL=1"])
     ),
     visibility = ["//visibility:public"],
     deps = [

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -1,5 +1,6 @@
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
+load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/pjrt/gpu:package_groups.bzl", "xla_gpu_internal_packages")
 load("//xla/stream_executor:build_defs.bzl", "if_cuda_or_rocm")
@@ -50,7 +51,9 @@ cc_library(
     name = "se_gpu_pjrt_client",
     srcs = ["se_gpu_pjrt_client.cc"],
     hdrs = ["se_gpu_pjrt_client.h"],
-    defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]),
+    defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]) + if_sycl([
+        "TENSORFLOW_USE_SYCL=1",
+    ]),
     visibility = internal_visibility(["//xla/pjrt/gpu:legacy_gpu_client_users"]),
     deps = [
         ":gpu_helpers",

--- a/xla/pjrt/gpu/tfrt/BUILD
+++ b/xla/pjrt/gpu/tfrt/BUILD
@@ -1,5 +1,6 @@
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
+load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/pjrt/gpu:package_groups.bzl", "xla_gpu_internal_packages")
 load("//xla/tests:build_defs.bzl", "xla_test")
@@ -33,7 +34,9 @@ cc_library(
         "tfrt_gpu_executable.h",
         "utils.h",
     ],
-    defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]),
+    defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]) + if_sycl([
+        "TENSORFLOW_USE_SYCL=1",
+    ]),
     visibility = internal_visibility(["//xla/pjrt/gpu:legacy_gpu_client_users"]),
     deps = [
         ":gpu_event",

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -3,6 +3,8 @@
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
+load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl")
 load(
     "@local_config_rocm//rocm:build_defs.bzl",
     "if_rocm_is_configured",
@@ -1136,7 +1138,9 @@ cc_library(
     name = "platform_util",
     srcs = ["platform_util.cc"],
     hdrs = ["platform_util.h"],
-    local_defines = if_sycl_is_configured(["TENSORFLOW_USE_SYCL=1"]),
+    local_defines = if_rocm(["TENSORFLOW_USE_ROCM=1"]) + if_sycl([
+        "TENSORFLOW_USE_SYCL=1",
+    ]),
     deps = [
         ":compiler",
         "//xla:debug_options_flags",

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -1136,7 +1136,7 @@ cc_library(
     name = "platform_util",
     srcs = ["platform_util.cc"],
     hdrs = ["platform_util.h"],
-    copts = tsl_copts(),
+    local_defines = if_sycl_is_configured(["TENSORFLOW_USE_SYCL=1"]),
     deps = [
         ":compiler",
         "//xla:debug_options_flags",

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -1136,6 +1136,7 @@ cc_library(
     name = "platform_util",
     srcs = ["platform_util.cc"],
     hdrs = ["platform_util.h"],
+    copts = tsl_copts(),
     deps = [
         ":compiler",
         "//xla:debug_options_flags",

--- a/xla/tsl/tsl.bzl
+++ b/xla/tsl/tsl.bzl
@@ -24,6 +24,10 @@ load(
     "if_rocm",
 )
 load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl",
+)
+load(
     "//xla/tsl/platform:rules_cc.bzl",
     "cc_binary",
     "cc_library",
@@ -340,6 +344,7 @@ def tsl_copts(
         if_xla_available(["-DTENSORFLOW_USE_XLA=1"]) +
         if_tensorrt(["-DGOOGLE_TENSORRT=1"]) +
         if_rocm(["-DTENSORFLOW_USE_ROCM=1"]) +
+        if_sycl(["-DTENSORFLOW_USE_SYCL=1"]) +
         # Compile in oneDNN based ops when building for x86 platforms
         if_onednn(["-DXLA_ONEDNN"]) +
         # Enable additional ops (e.g., ops with non-NHWC data layout) and
@@ -414,7 +419,7 @@ def tsl_gpu_library(deps = None, cuda_deps = None, copts = tsl_copts(), **kwargs
             "@local_config_rocm//rocm:hip",
             "@local_config_rocm//rocm:rocm_headers",
         ]),
-        copts = (copts + if_cuda(["-DGOOGLE_CUDA=1", "-DNV_CUDNN_DISABLE_EXCEPTION"]) + if_rocm(["-DTENSORFLOW_USE_ROCM=1"]) + if_xla_available(["-DTENSORFLOW_USE_XLA=1"]) + if_onednn(["-DXLA_ONEDNN"]) + if_enable_mkl(["-DENABLE_MKL"]) + if_tensorrt(["-DGOOGLE_TENSORRT=1"])),
+        copts = (copts + if_cuda(["-DGOOGLE_CUDA=1", "-DNV_CUDNN_DISABLE_EXCEPTION"]) + if_rocm(["-DTENSORFLOW_USE_ROCM=1"]) + if_sycl(["-DTENSORFLOW_USE_SYCL=1"]) + if_xla_available(["-DTENSORFLOW_USE_XLA=1"]) + if_onednn(["-DXLA_ONEDNN"]) + if_enable_mkl(["-DENABLE_MKL"]) + if_tensorrt(["-DGOOGLE_TENSORRT=1"])),
         **kwargs
     )
 


### PR DESCRIPTION
This PR fixes `Could not find registered platform with name: "cuda". Available platform names are: SYCL Host"` error when running the following stream executor tests with SYCL backend:

1. `//xla/stream_executor/gpu:gpu_executor_test`
2. `//xla/stream_executor/gpu:memcpy_test`
3. `//xla/stream_executor/gpu:stream_search_test`

`TENSORFLOW_USE_SYCL` macro was automatically added as part of the [toolchain](https://github.com/openxla/xla/blob/main/third_party/gpus/sycl_configure.bzl#L657) for all targets when compiled with SYCL. Since we have migrated to hermetic build (via `rules_ml_toolchain`), this fix is needed.