### PR TITLE
[xla:pjrt] Rename node_id to process_id and nodes to processes

### DIFF
--- a/xla/pjrt/distributed/client_server_test.cc
+++ b/xla/pjrt/distributed/client_server_test.cc
@@ -35,12 +35,6 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
-#include "grpcpp/channel.h"
-#include "grpcpp/security/credentials.h"
-#include "grpcpp/security/server_credentials.h"
-#include "grpcpp/server.h"
-#include "grpcpp/server_builder.h"
-#include "grpcpp/support/channel_arguments.h"
 #include "xla/pjrt/distributed/client.h"
 #include "xla/pjrt/distributed/distributed.h"
 #include "xla/pjrt/distributed/protocol.pb.h"
@@ -58,6 +52,12 @@ limitations under the License.
 #include "xla/tsl/platform/test.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/tsl/util/proto/proto_matchers.h"
+#include "grpcpp/channel.h"
+#include "grpcpp/security/credentials.h"
+#include "grpcpp/security/server_credentials.h"
+#include "grpcpp/server.h"
+#include "grpcpp/server_builder.h"
+#include "grpcpp/support/channel_arguments.h"
 
 namespace xla {
 namespace {
@@ -181,8 +181,8 @@ TEST_F(ClientServerTest, ConnectAndEnumerateDevices) {
   std::string host_0_boot_id = "foo";
   std::string host_1_boot_id = "bar";
   std::vector<LocalTopologyProto> locals(2);
-  locals[0].set_node_id(0);
-  locals[1].set_node_id(1);
+  locals[0].set_process_id(0);
+  locals[1].set_process_id(1);
   locals[0].set_boot_id(host_0_boot_id);
   locals[1].set_boot_id(host_1_boot_id);
   DeviceProto* d0 = locals[0].add_devices();
@@ -195,8 +195,8 @@ TEST_F(ClientServerTest, ConnectAndEnumerateDevices) {
   d3->set_local_device_ordinal(1);
 
   GlobalTopologyProto expected_topology;
-  auto* node0 = expected_topology.add_nodes();
-  auto* node1 = expected_topology.add_nodes();
+  auto* node0 = expected_topology.add_processes();
+  auto* node1 = expected_topology.add_processes();
   *node0 = locals[0];
   node0->set_boot_id(host_0_boot_id);
   node0->mutable_devices(0)->set_global_device_id(0);
@@ -287,7 +287,7 @@ TEST_F(ClientServerTest, EnumerateElevenDevices) {
   StartService(num_nodes);
   std::vector<LocalTopologyProto> locals(num_nodes);
   for (int i = 0; i < num_nodes; ++i) {
-    locals[i].set_node_id(i);
+    locals[i].set_process_id(i);
     // Two unique boot_id, one per host.
     locals[i].set_boot_id(absl::StrCat("test_boot_id_", i % 2));
     auto device = locals[i].add_devices();
@@ -300,7 +300,7 @@ TEST_F(ClientServerTest, EnumerateElevenDevices) {
   GlobalTopologyProto expected_topology;
   int slice_0_global_id = 0, slice_1_global_id = num_nodes / 2 + 1;
   for (int i = 0; i < num_nodes; ++i) {
-    auto* node = expected_topology.add_nodes();
+    auto* node = expected_topology.add_processes();
     *node = locals[i];
     node->mutable_devices(0)->set_global_device_id(
         (i % 2 == 0) ? slice_0_global_id++ : slice_1_global_id++);

--- a/xla/pjrt/distributed/protocol.proto
+++ b/xla/pjrt/distributed/protocol.proto
@@ -53,7 +53,7 @@ message DeviceProto {
 
   // The following fields are present in the GlobalTopologyProto message
   // returned by EnumerateDevices() but not in the LocalTopologyProto messages
-  // passed to EnumerateDevices(). In other words, the coordinator node
+  // passed to EnumerateDevices(). In other words, the coordinator process
   // determines the global device IDs during EnumerateDevices().
   int32 global_device_id = 4;  // Globally unique ID number.
 
@@ -101,7 +101,9 @@ message DeviceProto {
 }
 
 message LocalTopologyProto {
-  int32 node_id = 1;
+  // Unique id of the communicating process in the [0, num_processes) range.
+  int32 process_id = 1;
+
   // Unique per OS kernel restart to uniquely identify a host.
   // See /proc/sys/kernel/random/boot_id.
   string boot_id = 2;
@@ -112,5 +114,5 @@ message LocalTopologyProto {
 }
 
 message GlobalTopologyProto {
-  repeated LocalTopologyProto nodes = 1;
+  repeated LocalTopologyProto processes = 1;
 }

--- a/xla/pjrt/distributed/topology_util_test.cc
+++ b/xla/pjrt/distributed/topology_util_test.cc
@@ -49,9 +49,9 @@ TEST(TopologyTest, BuildGlobalTopology) {
       GlobalTopologyProto global,
       BuildGlobalTopology(absl::Span<LocalTopologyProto>(locals),
                           /*assign_global_device_ids=*/true));
-  EXPECT_EQ(global.nodes_size(), 2);
-  EXPECT_EQ(global.nodes()[0].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[1].devices_size(), 2);
+  EXPECT_EQ(global.processes_size(), 2);
+  EXPECT_EQ(global.processes()[0].devices_size(), 2);
+  EXPECT_EQ(global.processes()[1].devices_size(), 2);
 }
 
 TEST(TopologyTest, BuildGlobalTopologyWithFabricUuid) {
@@ -73,13 +73,13 @@ TEST(TopologyTest, BuildGlobalTopologyWithFabricUuid) {
       GlobalTopologyProto global,
       BuildGlobalTopology(absl::Span<LocalTopologyProto>(locals),
                           /*assign_global_device_ids=*/true));
-  EXPECT_EQ(global.nodes_size(), 2);
-  EXPECT_EQ(global.nodes()[0].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[1].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[0].devices()[0].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[0].devices()[1].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[1].devices()[0].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[1].devices()[1].partition_index(), 0);
+  EXPECT_EQ(global.processes_size(), 2);
+  EXPECT_EQ(global.processes()[0].devices_size(), 2);
+  EXPECT_EQ(global.processes()[1].devices_size(), 2);
+  EXPECT_EQ(global.processes()[0].devices()[0].partition_index(), 0);
+  EXPECT_EQ(global.processes()[0].devices()[1].partition_index(), 0);
+  EXPECT_EQ(global.processes()[1].devices()[0].partition_index(), 0);
+  EXPECT_EQ(global.processes()[1].devices()[1].partition_index(), 0);
 }
 
 TEST(TopologyTest, BuildGlobalTopologyMultipleFabricUuid) {
@@ -113,24 +113,24 @@ TEST(TopologyTest, BuildGlobalTopologyMultipleFabricUuid) {
       GlobalTopologyProto global,
       BuildGlobalTopology(absl::Span<LocalTopologyProto>(locals),
                           /*assign_global_device_ids=*/true));
-  EXPECT_EQ(global.nodes_size(), 4);
-  EXPECT_EQ(global.nodes()[0].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[1].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[2].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[3].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[0].devices()[0].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[0].devices()[1].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[1].devices()[0].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[1].devices()[1].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[2].devices()[0].partition_index(), 1);
-  EXPECT_EQ(global.nodes()[2].devices()[1].partition_index(), 1);
-  EXPECT_EQ(global.nodes()[3].devices()[0].partition_index(), 1);
-  EXPECT_EQ(global.nodes()[3].devices()[1].partition_index(), 1);
+  EXPECT_EQ(global.processes_size(), 4);
+  EXPECT_EQ(global.processes()[0].devices_size(), 2);
+  EXPECT_EQ(global.processes()[1].devices_size(), 2);
+  EXPECT_EQ(global.processes()[2].devices_size(), 2);
+  EXPECT_EQ(global.processes()[3].devices_size(), 2);
+  EXPECT_EQ(global.processes()[0].devices()[0].partition_index(), 0);
+  EXPECT_EQ(global.processes()[0].devices()[1].partition_index(), 0);
+  EXPECT_EQ(global.processes()[1].devices()[0].partition_index(), 0);
+  EXPECT_EQ(global.processes()[1].devices()[1].partition_index(), 0);
+  EXPECT_EQ(global.processes()[2].devices()[0].partition_index(), 1);
+  EXPECT_EQ(global.processes()[2].devices()[1].partition_index(), 1);
+  EXPECT_EQ(global.processes()[3].devices()[0].partition_index(), 1);
+  EXPECT_EQ(global.processes()[3].devices()[1].partition_index(), 1);
 }
 
 TEST(TopologyTest, ExchangeTopology) {
-  int num_nodes = 2;
-  std::vector<LocalTopologyProto> locals(num_nodes);
+  int num_processes = 2;
+  std::vector<LocalTopologyProto> locals(num_processes);
   DeviceProto* d0 = locals[0].add_devices();
   d0->set_local_device_ordinal(0);
   DeviceProto* d1 = locals[0].add_devices();
@@ -141,14 +141,14 @@ TEST(TopologyTest, ExchangeTopology) {
   d3->set_local_device_ordinal(1);
 
   InMemoryKeyValueStore kv_store;
-  std::vector<GlobalTopologyProto> globals(num_nodes);
+  std::vector<GlobalTopologyProto> globals(num_processes);
   {
     tsl::thread::ThreadPool thread_pool(tsl::Env::Default(), "TestPool",
-                                        num_nodes);
-    for (int i = 0; i < num_nodes; i++) {
+                                        num_processes);
+    for (int i = 0; i < num_processes; i++) {
       thread_pool.Schedule([&, i] {
         TF_ASSERT_OK(ExchangeTopologies(
-            /*platform=*/"cuda", /*node_id=*/i, num_nodes,
+            /*platform=*/"cuda", /*node_id=*/i, num_processes,
             /*get_local_topology_timeout=*/
             absl::Seconds(10), /*get_global_topology_timeout=*/
             absl::Seconds(10), &kv_store, locals[i], &globals[i],
@@ -157,15 +157,15 @@ TEST(TopologyTest, ExchangeTopology) {
     }
   }
   for (const GlobalTopologyProto& global : globals) {
-    EXPECT_EQ(global.nodes_size(), 2);
-    EXPECT_EQ(global.nodes()[0].devices_size(), 2);
-    EXPECT_EQ(global.nodes()[1].devices_size(), 2);
+    EXPECT_EQ(global.processes_size(), 2);
+    EXPECT_EQ(global.processes()[0].devices_size(), 2);
+    EXPECT_EQ(global.processes()[1].devices_size(), 2);
   }
 }
 
 TEST(TopologyTest, ExchangeTopology_Twice_Succeeds) {
-  int num_nodes = 2;
-  std::vector<LocalTopologyProto> locals(num_nodes);
+  int num_processes = 2;
+  std::vector<LocalTopologyProto> locals(num_processes);
   DeviceProto* d0 = locals[0].add_devices();
   d0->set_local_device_ordinal(0);
   DeviceProto* d1 = locals[0].add_devices();
@@ -176,14 +176,14 @@ TEST(TopologyTest, ExchangeTopology_Twice_Succeeds) {
   d3->set_local_device_ordinal(1);
 
   InMemoryKeyValueStore kv_store(/*allow_overwrite=*/false);
-  std::vector<GlobalTopologyProto> globals(num_nodes);
+  std::vector<GlobalTopologyProto> globals(num_processes);
   {
     tsl::thread::ThreadPool thread_pool(tsl::Env::Default(), "TestPool",
-                                        num_nodes);
-    for (int i = 0; i < num_nodes; i++) {
+                                        num_processes);
+    for (int i = 0; i < num_processes; i++) {
       thread_pool.Schedule([&, i] {
         TF_ASSERT_OK(ExchangeTopologies(
-            /*platform=*/"cuda", /*node_id=*/i, num_nodes,
+            /*platform=*/"cuda", /*node_id=*/i, num_processes,
             /*get_local_topology_timeout=*/
             absl::Seconds(10), /*get_global_topology_timeout=*/
             absl::Seconds(10), &kv_store, locals[i], &globals[i],
@@ -191,7 +191,7 @@ TEST(TopologyTest, ExchangeTopology_Twice_Succeeds) {
         // Simulate node 1 restarting and exchanging topologies again.
         if (i == 1) {
           TF_ASSERT_OK(ExchangeTopologies(
-              /*platform=*/"cuda", /*node_id=*/i, num_nodes,
+              /*platform=*/"cuda", /*node_id=*/i, num_processes,
               /*get_local_topology_timeout=*/
               absl::Seconds(10), /*get_global_topology_timeout=*/
               absl::Seconds(10), &kv_store, locals[i], &globals[i],
@@ -201,15 +201,15 @@ TEST(TopologyTest, ExchangeTopology_Twice_Succeeds) {
     }
   }
   for (const GlobalTopologyProto& global : globals) {
-    EXPECT_EQ(global.nodes_size(), 2);
-    EXPECT_EQ(global.nodes()[0].devices_size(), 2);
-    EXPECT_EQ(global.nodes()[1].devices_size(), 2);
+    EXPECT_EQ(global.processes_size(), 2);
+    EXPECT_EQ(global.processes()[0].devices_size(), 2);
+    EXPECT_EQ(global.processes()[1].devices_size(), 2);
   }
 }
 
 TEST(TopologyTest, ExchangeTopology_TwiceWithDifferentLocalTopology_Fails) {
-  int num_nodes = 2;
-  std::vector<LocalTopologyProto> locals(num_nodes);
+  int num_processes = 2;
+  std::vector<LocalTopologyProto> locals(num_processes);
   DeviceProto* d0 = locals[0].add_devices();
   d0->set_local_device_ordinal(0);
   DeviceProto* d1 = locals[0].add_devices();
@@ -220,14 +220,14 @@ TEST(TopologyTest, ExchangeTopology_TwiceWithDifferentLocalTopology_Fails) {
   d3->set_local_device_ordinal(1);
 
   InMemoryKeyValueStore kv_store(/*allow_overwrite=*/false);
-  std::vector<GlobalTopologyProto> globals(num_nodes);
+  std::vector<GlobalTopologyProto> globals(num_processes);
   {
     tsl::thread::ThreadPool thread_pool(tsl::Env::Default(), "TestPool",
-                                        num_nodes);
-    for (int i = 0; i < num_nodes; i++) {
+                                        num_processes);
+    for (int i = 0; i < num_processes; i++) {
       thread_pool.Schedule([&, i] {
         TF_ASSERT_OK(ExchangeTopologies(
-            /*platform=*/"cuda", /*node_id=*/i, num_nodes,
+            /*platform=*/"cuda", /*node_id=*/i, num_processes,
             /*get_local_topology_timeout=*/
             absl::Seconds(10), /*get_global_topology_timeout=*/
             absl::Seconds(10), &kv_store, locals[i], &globals[i],
@@ -239,7 +239,7 @@ TEST(TopologyTest, ExchangeTopology_TwiceWithDifferentLocalTopology_Fails) {
           // This should fail because the local topology is unexpectedly
           // different.
           EXPECT_THAT(ExchangeTopologies(
-                          /*platform=*/"cuda", /*node_id=*/i, num_nodes,
+                          /*platform=*/"cuda", /*node_id=*/i, num_processes,
                           /*get_local_topology_timeout=*/
                           absl::Seconds(10), /*get_global_topology_timeout=*/
                           absl::Seconds(10), &kv_store, locals[i], &globals[i],
@@ -257,8 +257,8 @@ TEST(TopologyTest, BuildGlobalTopologyWithExplicitSliceIndices) {
   std::vector<LocalTopologyProto> locals(2);
   locals[0].set_boot_id(boot_id);
   locals[1].set_boot_id(boot_id);
-  locals[0].set_node_id(0);
-  locals[1].set_node_id(1);
+  locals[0].set_process_id(0);
+  locals[1].set_process_id(1);
   locals[0].set_partition_index(1);
   locals[1].set_partition_index(0);
   // Adds 2 devices to each host.
@@ -276,13 +276,13 @@ TEST(TopologyTest, BuildGlobalTopologyWithExplicitSliceIndices) {
       BuildGlobalTopology(absl::Span<LocalTopologyProto>(locals),
                           /*assign_global_device_ids=*/true));
 
-  EXPECT_EQ(global.nodes_size(), 2);
-  EXPECT_EQ(global.nodes()[0].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[0].devices()[0].partition_index(), 1);
-  EXPECT_EQ(global.nodes()[0].devices()[1].partition_index(), 1);
-  EXPECT_EQ(global.nodes()[1].devices_size(), 2);
-  EXPECT_EQ(global.nodes()[1].devices()[0].partition_index(), 0);
-  EXPECT_EQ(global.nodes()[1].devices()[1].partition_index(), 0);
+  EXPECT_EQ(global.processes_size(), 2);
+  EXPECT_EQ(global.processes()[0].devices_size(), 2);
+  EXPECT_EQ(global.processes()[0].devices()[0].partition_index(), 1);
+  EXPECT_EQ(global.processes()[0].devices()[1].partition_index(), 1);
+  EXPECT_EQ(global.processes()[1].devices_size(), 2);
+  EXPECT_EQ(global.processes()[1].devices()[0].partition_index(), 0);
+  EXPECT_EQ(global.processes()[1].devices()[1].partition_index(), 0);
 }
 
 TEST(TopologyTest, BuildGpuTopology) {
@@ -292,8 +292,8 @@ TEST(TopologyTest, BuildGpuTopology) {
   // Adds 1 host to partition 0 and 1 host to partition 1.
   locals[0].set_boot_id(partition_0_boot_id);
   locals[1].set_boot_id(partition_1_boot_id);
-  locals[0].set_node_id(0);
-  locals[1].set_node_id(1);
+  locals[0].set_process_id(0);
+  locals[1].set_process_id(1);
   // Adds 2 devices to host 0 and 2 devices to host 1.
   DeviceProto* d0 = locals[0].add_devices();
   d0->set_local_device_ordinal(0);
@@ -327,9 +327,9 @@ TEST(TopologyTest, BuildGpuTopologyWithDifferentNumHostsPerSlice) {
   locals[0].set_boot_id(partition_0_boot_id);
   locals[1].set_boot_id(partition_0_boot_id);
   locals[2].set_boot_id(partition_1_boot_id);
-  locals[0].set_node_id(0);
-  locals[1].set_node_id(1);
-  locals[2].set_node_id(2);
+  locals[0].set_process_id(0);
+  locals[1].set_process_id(1);
+  locals[2].set_process_id(2);
   DeviceProto* d0 = locals[0].add_devices();
   d0->set_local_device_ordinal(0);
   DeviceProto* d1 = locals[1].add_devices();
@@ -354,8 +354,8 @@ TEST(TopologyTest, BuildGpuTopologyWithDifferentNumDevicesPerHost) {
   std::vector<LocalTopologyProto> locals(2);
   locals[0].set_boot_id(partition_0_boot_id);
   locals[1].set_boot_id(partition_1_boot_id);
-  locals[0].set_node_id(0);
-  locals[1].set_node_id(1);
+  locals[0].set_process_id(0);
+  locals[1].set_process_id(1);
   // Adds 2 devices to host 0 and 1 device to host 1.
   DeviceProto* d0 = locals[0].add_devices();
   d0->set_local_device_ordinal(0);

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1525,10 +1525,10 @@ GetStreamExecutorGpuDeviceAllocator(
 void NameDeviceAndLauncherThread(const LocalTopologyProto& node,
                                  const DeviceProto& device_proto,
                                  WorkerThread* launcher_thread) {
-  auto suffix = absl::StrFormat(":#global=%d,local=%d,process=%d,partition=%d#",
-                                device_proto.global_device_id(),
-                                device_proto.local_device_ordinal(),
-                                node.node_id(), device_proto.partition_index());
+  auto suffix = absl::StrFormat(
+      ":#global=%d,local=%d,process=%d,partition=%d#",
+      device_proto.global_device_id(), device_proto.local_device_ordinal(),
+      node.process_id(), device_proto.partition_index());
   // Name the device.
   tsl::profiler::NameDevice(device_proto.local_device_ordinal(),
                             absl::StrCat("Xla", suffix));
@@ -1546,7 +1546,7 @@ void NameDeviceAndLauncherThread(const LocalTopologyProto& node,
 absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     absl::string_view platform_name,
     std::map<int, std::unique_ptr<LocalDeviceState>> local_device_states,
-    int node_id, int num_nodes,
+    int process_id, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
     std::optional<absl::string_view> mock_gpu_topology,
@@ -1555,7 +1555,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     absl::Duration get_global_topology_timeout) {
   std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> devices;
   LocalTopologyProto local_topology;
-  local_topology.set_node_id(node_id);
+  local_topology.set_process_id(process_id);
   std::string boot_id_str;
   auto boot_id_str_or_status = GetBootIdString();
   if (!boot_id_str_or_status.ok()) {
@@ -1622,9 +1622,9 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     std::vector<LocalTopologyProto> local_topologies(num_nodes, local_topology);
     for (int i = 0; i < sizes.num_partitions; ++i) {
       for (int j = 0; j < sizes.num_hosts_per_partition; j++) {
-        int node_id = i * sizes.num_hosts_per_partition + j;
-        local_topologies[node_id].set_node_id(node_id);
-        local_topologies[node_id].set_boot_id(absl::StrCat(i));
+        int process_id = i * sizes.num_hosts_per_partition + j;
+        local_topologies[process_id].set_process_id(process_id);
+        local_topologies[process_id].set_boot_id(absl::StrCat(i));
       }
     }
     TF_ASSIGN_OR_RETURN(global_topology,
@@ -1632,7 +1632,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
                                             /*assign_global_device_ids=*/true));
   } else {
     TF_RETURN_IF_ERROR(ExchangeTopologies(
-        platform_name, node_id, num_nodes, get_local_topology_timeout,
+        platform_name, process_id, num_nodes, get_local_topology_timeout,
         get_global_topology_timeout, kv_store.get(), local_topology,
         &global_topology, /*assign_global_device_ids=*/true));
   }
@@ -1642,25 +1642,25 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
   int curr_partition_index = -1;
   int curr_process_index = -1;
   int curr_process_index_in_partition = 0;
-  for (const LocalTopologyProto& node : global_topology.nodes()) {
+  for (const LocalTopologyProto& node : global_topology.processes()) {
     for (const DeviceProto& device_proto : node.devices()) {
-      // The devices in the global topology are ordered by node_id,
+      // The devices in the global topology are ordered by process_id,
       // partition_index. This is guaranteed by the `BuildGlobalTopology`
       // function and the `ExchangeTopologies` function.
       if (curr_partition_index != device_proto.partition_index()) {
         curr_partition_index = device_proto.partition_index();
-        curr_process_index = node.node_id();
+        curr_process_index = node.process_id();
         curr_process_index_in_partition = 0;
       }
-      if (curr_process_index != node.node_id()) {
-        curr_process_index = node.node_id();
+      if (curr_process_index != node.process_id()) {
+        curr_process_index = node.process_id();
         curr_process_index_in_partition++;
       }
 
       GlobalDeviceId global_device_id(device_proto.global_device_id());
-      device_to_process[global_device_id] = node.node_id();
+      device_to_process[global_device_id] = node.process_id();
       std::unique_ptr<LocalDeviceState> local_device;
-      if (node.node_id() == node_id) {
+      if (node.process_id() == process_id) {
         auto it = local_device_states.find(device_proto.local_device_ordinal());
         TF_RET_CHECK(it != local_device_states.end())
             << device_proto.local_device_ordinal();
@@ -1677,7 +1677,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
           device_proto.name(), device_proto.vendor(),
           device_proto.compute_capability(), device_proto.core_count(),
           device_proto.shared_memory_per_block_optin(),
-          device_proto.local_device_ordinal(), node.node_id(),
+          device_proto.local_device_ordinal(), node.process_id(),
           curr_process_index_in_partition, device_proto.partition_index(),
           device_proto.numa_node());
       devices.push_back(std::move(device));
@@ -1698,10 +1698,10 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     return absl::InternalError("Failed to get GPU collectives");
   }
 
-  size_t num_processes = global_topology.nodes().size();
+  size_t num_processes = global_topology.processes().size();
   TF_ASSIGN_OR_RETURN(
       auto clique_id_callback,
-      gpu_collectives->InitializeTopology({ProcessId(node_id), num_processes,
+      gpu_collectives->InitializeTopology({ProcessId(process_id), num_processes,
                                            local_device_states.size(), kv_store,
                                            device_to_process}));
   gpu_executable_run_options->set_clique_id_callback(
@@ -1863,7 +1863,7 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
 
 std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> BuildLocalDevices(
     std::map<int, std::unique_ptr<LocalDeviceState>> local_device_states,
-    int node_id) {
+    int process_id) {
   std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> devices;
   for (auto& ordinal_and_device : local_device_states) {
     const se::DeviceDescription& desc =
@@ -1873,7 +1873,7 @@ std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> BuildLocalDevices(
         desc.name(), desc.device_vendor(),
         MakeComputeCapabilityAttributeString(desc), desc.core_count(),
         desc.shared_memory_per_block_optin(),
-        ordinal_and_device.second->local_device_id().value(), node_id,
+        ordinal_and_device.second->local_device_id().value(), process_id,
         desc.numa_node());
     devices.push_back(std::move(device));
   }

--- a/xla/pjrt/gpu/tfrt/utils.cc
+++ b/xla/pjrt/gpu/tfrt/utils.cc
@@ -44,7 +44,6 @@ limitations under the License.
 #include "absl/synchronization/notification.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
-#include "unsupported/Eigen/CXX11/Tensor"
 #include "google/protobuf/text_format.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/client/executable_build_options.h"
@@ -106,6 +105,7 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/fingerprint.h"
 #include "tsl/profiler/lib/traceme.h"
+#include "unsupported/Eigen/CXX11/Tensor"
 
 #if defined(PLATFORM_WINDOWS)
 // Required to build successfully with Mingw
@@ -728,7 +728,7 @@ using DeviceTopologyPair =
     std::pair<std::vector<std::unique_ptr<TfrtGpuDevice>>, GpuTopologyProto>;
 
 absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
-    absl::string_view platform_name, LocalClient* xla_client, int node_id,
+    absl::string_view platform_name, LocalClient* xla_client, int process_id,
     int max_inflight_computations, int num_nodes,
     gpu::GpuExecutableRunOptions* gpu_executable_run_options,
     std::shared_ptr<KeyValueStoreInterface> kv_store, bool enable_mock_nccl,
@@ -738,7 +738,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     absl::Duration get_global_topology_timeout) {
   std::vector<std::unique_ptr<TfrtGpuDevice>> devices;
   LocalTopologyProto local_topology;
-  local_topology.set_node_id(node_id);
+  local_topology.set_process_id(process_id);
   auto boot_id_str_or_status = GetBootIdString();
   if (!boot_id_str_or_status.ok()) {
     LOG(INFO) << boot_id_str_or_status.status();
@@ -806,9 +806,9 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     std::vector<LocalTopologyProto> local_topologies(num_nodes, local_topology);
     for (int i = 0; i < sizes.num_partitions; ++i) {
       for (int j = 0; j < sizes.num_hosts_per_partition; j++) {
-        int node_id = i * sizes.num_hosts_per_partition + j;
-        local_topologies[node_id].set_node_id(node_id);
-        local_topologies[node_id].set_boot_id(absl::StrCat(i));
+        int process_id = i * sizes.num_hosts_per_partition + j;
+        local_topologies[process_id].set_process_id(process_id);
+        local_topologies[process_id].set_boot_id(absl::StrCat(i));
       }
     }
     TF_ASSIGN_OR_RETURN(global_topology,
@@ -816,7 +816,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
                                             /*assign_global_device_ids=*/true));
   } else {
     TF_RETURN_IF_ERROR(ExchangeTopologies(
-        platform_name, node_id, num_nodes, get_local_topology_timeout,
+        platform_name, process_id, num_nodes, get_local_topology_timeout,
         get_global_topology_timeout, kv_store.get(), local_topology,
         &global_topology, /*assign_global_device_ids=*/true));
   }
@@ -826,25 +826,25 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
   int curr_partition_index = -1;
   int curr_process_index = -1;
   int curr_process_index_in_partition = 0;
-  for (const LocalTopologyProto& node : global_topology.nodes()) {
+  for (const LocalTopologyProto& node : global_topology.processes()) {
     for (const DeviceProto& device_proto : node.devices()) {
-      // The devices in the global topology are ordered by node_id,
+      // The devices in the global topology are ordered by process_id,
       // partition_index. This is guaranteed by the `BuildGlobalTopology`
       // function and the `ExchangeTopologies` function.
       if (curr_partition_index != device_proto.partition_index()) {
         curr_partition_index = device_proto.partition_index();
-        curr_process_index = node.node_id();
+        curr_process_index = node.process_id();
         curr_process_index_in_partition = 0;
       }
-      if (curr_process_index != node.node_id()) {
-        curr_process_index = node.node_id();
+      if (curr_process_index != node.process_id()) {
+        curr_process_index = node.process_id();
         curr_process_index_in_partition++;
       }
 
       GlobalDeviceId global_device_id(device_proto.global_device_id());
-      device_to_process[global_device_id] = ProcessId(node.node_id());
+      device_to_process[global_device_id] = ProcessId(node.process_id());
       TfrtGpuDevice::Options options;
-      if (node.node_id() == node_id) {
+      if (node.process_id() == process_id) {
         gpu_device_ids[LocalDeviceId(device_proto.local_device_ordinal())] =
             global_device_id;
         // Assign some descriptive names for profiling tools.
@@ -864,7 +864,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
         options.executor = nullptr;
       }
       options.id = device_proto.global_device_id();
-      options.process_index = node.node_id();
+      options.process_index = node.process_id();
       options.process_index_in_partition = curr_process_index_in_partition;
       options.partition_index = device_proto.partition_index();
       options.max_inflight_computations = max_inflight_computations;
@@ -894,10 +894,10 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
     return absl::InternalError("Failed to get GPU collectives");
   }
 
-  size_t num_processes = global_topology.nodes().size();
+  size_t num_processes = global_topology.processes().size();
   TF_ASSIGN_OR_RETURN(auto clique_id_callback,
                       gpu_collectives->InitializeTopology(
-                          {ProcessId(node_id), num_processes,
+                          {ProcessId(process_id), num_processes,
                            xla_client->backend().stream_executors().size(),
                            kv_store, device_to_process}));
   gpu_executable_run_options->set_clique_id_callback(

--- a/xla/python/pjrt_ifrt/pjrt_client.cc
+++ b/xla/python/pjrt_ifrt/pjrt_client.cc
@@ -327,8 +327,8 @@ absl::StatusOr<GlobalTopology> MakeGlobalTopologyFromPjRtClient(
   // information.
   GlobalTopologyProto global_topology_proto;
   for (int process_index = 0; process_index < num_processes; ++process_index) {
-    LocalTopologyProto& node = *global_topology_proto.add_nodes();
-    node.set_node_id(process_index);
+    LocalTopologyProto& node = *global_topology_proto.add_processes();
+    node.set_process_id(process_index);
 
     const std::vector<DeviceId>& process_device_ids =
         process_index_to_ifrt_device_ids[process_index];
@@ -395,7 +395,7 @@ absl::StatusOr<GlobalTopology> MakeGlobalTopologyFromPjRtClient(
 LocalTopologyProto MakeLocalTopologyFromPjRtClient(
     xla::PjRtClient* pjrt_client, const PjRtClient::CreateOptions& options) {
   LocalTopologyProto local_topology_proto;
-  local_topology_proto.set_node_id(options.process_id);
+  local_topology_proto.set_process_id(options.process_id);
   std::string boot_id_str;
   auto boot_id_str_or_status = GetBootIdString();
   if (!boot_id_str_or_status.ok()) {
@@ -439,20 +439,22 @@ absl::StatusOr<GlobalTopology> MakeGlobalTopologyWithLocalTopology(
   absl::flat_hash_map<DeviceId, xla::PjRtGlobalDeviceId>
       ifrt_device_id_to_pjrt_global_device_id;
   for (int process_index = 0;
-       process_index < global_topology_proto.nodes_size(); ++process_index) {
-    const LocalTopologyProto& node = global_topology_proto.nodes(process_index);
-    if (node.node_id() == options.process_id) {
+       process_index < global_topology_proto.processes_size();
+       ++process_index) {
+    const LocalTopologyProto& process =
+        global_topology_proto.processes(process_index);
+    if (process.process_id() == options.process_id) {
       if (my_process_index.has_value()) {
         if (*my_process_index != process_index) {
           return InvalidArgument(
-              "GlobalTopologyProto contains multiple nodes with the same "
+              "GlobalTopologyProto contains multiple processes with the same "
               "process ID");
         }
       } else {
         my_process_index = process_index;
       }
     }
-    for (const DeviceProto& device_proto : node.devices()) {
+    for (const DeviceProto& device_proto : process.devices()) {
       // Use the same PjRt global device ID as IFRT device ID when topology
       // exchange is used.
       ifrt_device_id_to_pjrt_global_device_id.insert(
@@ -482,10 +484,10 @@ MakePjRtDevicesFromGlobalTopology(PjRtClient* client,
   int next_partition_index = 0;
   absl::flat_hash_map<std::string, int> boot_id_to_partition_index;
   for (int process_index = 0;
-       process_index < global_topology.global_topology_proto.nodes_size();
+       process_index < global_topology.global_topology_proto.processes_size();
        ++process_index) {
     const LocalTopologyProto& node =
-        global_topology.global_topology_proto.nodes(process_index);
+        global_topology.global_topology_proto.processes(process_index);
     int64_t partition_index = -1;
     if (!node.boot_id().empty()) {
       // Every new boot_id seen is treated as a new host/partition.


### PR DESCRIPTION
**NFC**: First step toward standardizing XLA APIs to use `ProcessId` to identify a communicating process. In practice we might have multiple processes running on the same node (host).