### PR TITLE
[ROCm] Fix FloatNormalization to use gpu_compute_capability

### DIFF
--- a/xla/backends/gpu/autotuner/triton.cc
+++ b/xla/backends/gpu/autotuner/triton.cc
@@ -219,7 +219,7 @@ absl::StatusOr<std::unique_ptr<HloModule>> TritonBackend::RunHloPasses(
   auto gpu_device_info = target_config().device_description;
   for (PrimitiveType type :
        {BF16, F8E5M2, F8E4M3FN, F8E4M3B11FNUZ, F8E5M2FNUZ, F8E4M3FNUZ}) {
-    GpuFloatSupport float_support(gpu_device_info.cuda_compute_capability(),
+    GpuFloatSupport float_support(gpu_device_info.gpu_compute_capability(),
                                   type);
     FloatNormalization float_normalization(&float_support);
     TF_RETURN_IF_ERROR(float_normalization.Run(hlo_module.get()).status());

--- a/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
+++ b/xla/service/gpu/autotuning/gemm_fusion_autotuner.cc
@@ -340,7 +340,7 @@ absl::StatusOr<std::unique_ptr<HloModule>> TritonGemmAutotuneExtractor(
     TF_RETURN_IF_ERROR(MakeDotSplitKBatch(cloned_dot_fusion, config));
     for (PrimitiveType type :
          {BF16, F8E5M2, F8E4M3FN, F8E4M3B11FNUZ, F8E5M2FNUZ, F8E4M3FNUZ}) {
-      GpuFloatSupport float_support(gpu_device_info.cuda_compute_capability(),
+      GpuFloatSupport float_support(gpu_device_info.gpu_compute_capability(),
                                     type);
       FloatNormalization float_normalization(&float_support);
       TF_RETURN_IF_ERROR(float_normalization.Run(new_module.get()).status());


### PR DESCRIPTION
Use gpu_compute_capability() instead of cuda_compute_capability() when constructing GpuFloatSupport for FloatNormalization in the autotuner. This could cause incorrect type support detection or wrong type conversions.
