### PR TITLE
[ROCm] add missing clang flag for hipcc

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -281,6 +281,7 @@ common:rocm_base --repo_env TF_NEED_ROCM=1
 
 common:rocm_clang_official --config=rocm_base
 common:rocm_clang_official --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
+common:rocm_clang_official --action_env=HIPCC_COMPILE_FLAGS_APPEND="--offload-compress"
 common:rocm_clang_official --action_env=TF_ROCM_CLANG="1"
 common:rocm_clang_official --linkopt="-fuse-ld=lld"
 common:rocm_clang_official --host_linkopt="-fuse-ld=lld"


### PR DESCRIPTION
📝 Summary of Changes

Adding `--offload-compress` via HIPCC_COMPILE_FLAGS_APPEND directs the [Clang offload bundler](https://rocm.docs.amd.com/projects/llvm-project/en/latest/LLVM/clang/html/ClangOffloadBundler.html) to compress offloaded code objects (such as those for AMD GPUs) using zlib or zstd. This reduces the binary size of the final executable or library.



🎯 Justification

 Otherwise it causes the error when linking `hlo_runner_main_build_test`

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix,  
 