### PR TITLE
[xla:pjrt] Switch PjRt to xla/runtime ids: ProcessId, DeviceId, ChipId

### DIFF
--- a/xla/backends/gpu/transforms/collectives/all_reduce_blueconnect.cc
+++ b/xla/backends/gpu/transforms/collectives/all_reduce_blueconnect.cc
@@ -82,14 +82,14 @@ static std::optional<GlobalDeviceId> TryConvertingReplicaIdToDeviceId(
       // devices on different partitions.
       return std::nullopt;
     }
-    return GlobalDeviceId{device_assignment(replica_id, /*computation_id=*/0)};
+    return GlobalDeviceId(device_assignment(replica_id, /*computation_id=*/0));
   }
   if (collective_group_mode ==
       CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID) {
     int partition_count = device_assignment.computation_count();
     int64_t actual_replica_id = replica_id / partition_count;
     int64_t partition_id = replica_id % partition_count;
-    return GlobalDeviceId{device_assignment(actual_replica_id, partition_id)};
+    return GlobalDeviceId(device_assignment(actual_replica_id, partition_id));
   }
 
   // COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION and

--- a/xla/pjrt/BUILD
+++ b/xla/pjrt/BUILD
@@ -554,7 +554,10 @@ cc_library(
     visibility = internal_visibility([":friends"]),
     deps = [
         "//xla/pjrt/proto:pjrt_value_type_proto_cc",
-        "//xla/tsl/lib/gtl:int_type",
+        "//xla/runtime:chip_id",
+        "//xla/runtime:device_id",
+        "//xla/runtime:process_id",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:inlined_vector",
     ],
 )

--- a/xla/pjrt/pjrt_common.h
+++ b/xla/pjrt/pjrt_common.h
@@ -21,9 +21,12 @@ limitations under the License.
 #include <variant>
 #include <vector>
 
+#include "absl/base/macros.h"
 #include "absl/container/inlined_vector.h"
 #include "xla/pjrt/proto/pjrt_value_type.pb.h"
-#include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/runtime/chip_id.h"
+#include "xla/runtime/device_id.h"
+#include "xla/runtime/process_id.h"
 
 namespace xla {
 
@@ -50,13 +53,11 @@ PjRtIdContainer<Id> MakeContinuousIds(int start, int size) {
   return container;
 }
 
-// The strong-typed integer classes to better disambiguate different IDs for
-// PJRT devices.
-TSL_LIB_GTL_DEFINE_INT_TYPE(PjRtProcessId, int32_t);
-TSL_LIB_GTL_DEFINE_INT_TYPE(PjRtGlobalChipId, int32_t);
-TSL_LIB_GTL_DEFINE_INT_TYPE(PjRtGlobalDeviceId, int32_t);
-TSL_LIB_GTL_DEFINE_INT_TYPE(PjRtLocalDeviceId, int32_t);
-TSL_LIB_GTL_DEFINE_INT_TYPE(PjRtLocalHardwareId, int32_t);
+using PjRtProcessId ABSL_DEPRECATE_AND_INLINE() = ProcessId;
+using PjRtLocalDeviceId ABSL_DEPRECATE_AND_INLINE() = LocalDeviceId;
+using PjRtGlobalDeviceId ABSL_DEPRECATE_AND_INLINE() = GlobalDeviceId;
+using PjRtLocalHardwareId ABSL_DEPRECATE_AND_INLINE() = LocalChipId;
+using PjRtGlobalChipId ABSL_DEPRECATE_AND_INLINE() = GlobalChipId;
 
 using PjRtPlatformId = uint64_t;
 

--- a/xla/runtime/BUILD
+++ b/xla/runtime/BUILD
@@ -166,6 +166,17 @@ cc_library(
 )
 
 cc_library(
+    name = "chip_id",
+    hdrs = ["chip_id.h"],
+    deps = [
+        "//xla/tsl/lib/gtl:int_type",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
     name = "process_id",
     hdrs = ["process_id.h"],
     deps = [

--- a/xla/runtime/chip_id.h
+++ b/xla/runtime/chip_id.h
@@ -1,0 +1,77 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_RUNTIME_CHIP_ID_H_
+#define XLA_RUNTIME_CHIP_ID_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/tsl/lib/gtl/int_type.h"
+
+namespace xla {
+
+// Some of the accelerator devices consist of multiple chips, and XLA might need
+// to address them separately. For example GB200 (1) from NVIDIA can be viewed
+// as a single device that consists of one Grace CPU and two Blackwell GPUs (one
+// `LocalDeviceId` with two `LocalChipId`s). Some TPU chips from Google have two
+// tensor cores (2) that appear as a single device to JAX/XLA users, and XLA
+// (including PjRt runtime) need to address these chips separately.
+//
+// (1) https://www.nvidia.com/en-us/data-center/gb200-nvl72/
+// (2)
+// https://docs.jax.dev/en/latest/pallas/tpu/pipelining.html#tpus-in-megacore-configuration
+
+// Strongly-typed integer type for identifying local chips that belong to one of
+// the local devices.
+TSL_LIB_GTL_DEFINE_INT_TYPE(LocalChipId, int32_t);
+
+// Strongly-typed integer type for identifying global chips in a distributed
+// execution.
+TSL_LIB_GTL_DEFINE_INT_TYPE(GlobalChipId, int32_t);
+
+template <typename Sink>
+void AbslStringify(Sink& sink, LocalChipId id) {
+  absl::Format(&sink, "%d", id.value());
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, GlobalChipId id) {
+  absl::Format(&sink, "%d", id.value());
+}
+
+// StrJoin for global chip ids that shortens long list of ids for readability.
+//
+// It is not uncommon to see in XLA a list of global chips with more than 1k
+// of entries. We don't need to print them all to get a human readable list
+// of chips for logging and debugging.
+inline std::string HumanReadableChips(absl::Span<const GlobalChipId> chips,
+                                      absl::string_view separator = ",",
+                                      size_t first = 8, size_t last = 2) {
+  if (chips.size() > first + last) {
+    return absl::StrCat(absl::StrJoin(chips.first(first), separator), "...",
+                        absl::StrJoin(chips.last(last), separator));
+  }
+  return absl::StrJoin(chips, separator);
+}
+
+}  // namespace xla
+
+#endif  // XLA_RUNTIME_CHIP_ID_H_

--- a/xla/runtime/device_id.h
+++ b/xla/runtime/device_id.h
@@ -33,8 +33,8 @@ namespace xla {
 // system. XLA doesn't have a strong opinion about what global numbering scheme
 // is applied to GPUs; the user must provide a local -> global mapping via
 // GpuExecutableRunOptions for the local GPUs.
-TSL_LIB_GTL_DEFINE_INT_TYPE(GlobalDeviceId, int64_t);
-TSL_LIB_GTL_DEFINE_INT_TYPE(LocalDeviceId, int64_t);
+TSL_LIB_GTL_DEFINE_INT_TYPE(GlobalDeviceId, int32_t);
+TSL_LIB_GTL_DEFINE_INT_TYPE(LocalDeviceId, int32_t);
 
 using ::tsl::IncarnationId;  // NOLINT(misc-unused-using-decls)
 
@@ -48,7 +48,8 @@ void AbslStringify(Sink& sink, LocalDeviceId id) {
   absl::Format(&sink, "%d", id.value());
 }
 
-// StrJoin for global devices that shortens long list of devices for readbility.
+// StrJoin for global devices that shortens long list of devices for
+// readability.
 //
 // It is not uncommon to see in XLA a list of global devices with more than 1k
 // of entries. We don't need to print them all to get a human readable list

--- a/xla/runtime/process_id.h
+++ b/xla/runtime/process_id.h
@@ -31,18 +31,18 @@ namespace xla {
 // Strongly-typed integer type for identifying processes in a distributed
 // execution. Processes can belong to the same physical host, or can be
 // distributed over multiple nodes.
-TSL_LIB_GTL_DEFINE_INT_TYPE(ProcessId, int64_t);
+TSL_LIB_GTL_DEFINE_INT_TYPE(ProcessId, int32_t);
 
 template <typename Sink>
 void AbslStringify(Sink& sink, ProcessId id) {
   absl::Format(&sink, "%d", id.value());
 }
 
-// StrJoin for processes that shortens long list of processes for readbility.
+// StrJoin for processes that shortens long list of processes for readability.
 //
 // It is not uncommon to see in XLA a list of processes with more than 1k
 // of entries. We don't need to print them all to get a human readable list
-// of proceses for logging and debugging.
+// of processes for logging and debugging.
 inline std::string HumanReadableProcesses(absl::Span<const ProcessId> processes,
                                           absl::string_view separator = ",",
                                           size_t first = 10, size_t last = 4) {


### PR DESCRIPTION
Use the same strongly-typed ids across PjRt and XLA