### PR TITLE
[xla:gpu] Delete multimem support from FFI

### DIFF
--- a/xla/backends/gpu/BUILD
+++ b/xla/backends/gpu/BUILD
@@ -24,7 +24,6 @@ cc_library(
         "//xla/backends/gpu/runtime:collective_cliques",
         "//xla/backends/gpu/runtime:collective_memory",
         "//xla/backends/gpu/runtime:collective_memory_requests",
-        "//xla/backends/gpu/runtime:collective_multimem_registry",
         "//xla/backends/gpu/runtime:collective_params",
         "//xla/ffi",
         "//xla/ffi/api:c_api",

--- a/xla/backends/gpu/ffi.h
+++ b/xla/backends/gpu/ffi.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/collective_cliques.h"
 #include "xla/backends/gpu/runtime/collective_memory.h"
 #include "xla/backends/gpu/runtime/collective_memory_requests.h"
-#include "xla/backends/gpu/runtime/collective_multimem_registry.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/c_api_internal.h"  // IWYU pragma: keep
@@ -47,10 +46,8 @@ struct ScratchAllocator {};            //  se::OwningScratchAllocator
 struct CollectiveParams {};            //  const xla::gpu::CollectiveParams*
 struct CollectiveCliqueRequests {};    //  xla::gpu::CollectiveCliqueRequests*
 struct CollectiveMemoryRequests {};    //  xla::gpu::CollectiveMemoryRequests*
-struct CollectiveMultimemRequests {};  //  xla::gpu::CollectiveMultimemRequest*
 struct CollectiveCliques {};           //  const xla::gpu::CollectiveCliques*
 struct CollectiveMemory {};            //  const xla::gpu::CollectiveMemory*
-struct CollectiveMultimemProvider {};  //  xla::gpu::CollectiveMultimemProvider*
 struct TargetGpuComputeCapability {};  //  const se::GpuComputeCapability*
 
 // Parametrized type tag for platform stream, e.g. cudaStream_t
@@ -164,34 +161,6 @@ struct CtxDecoding<CollectiveMemoryRequests> {
         api, ctx, diagnostic,
         api->internal_api->XLA_FFI_INTERNAL_CollectiveMemoryRequests_Get,
         "collective memory requests");
-  }
-};
-
-template <>
-struct CtxDecoding<CollectiveMultimemRequests> {
-  using Type = xla::gpu::CollectiveMultimemRequests*;
-
-  static std::optional<Type> Decode(const XLA_FFI_Api* api,
-                                    XLA_FFI_ExecutionContext* ctx,
-                                    DiagnosticEngine& diagnostic) {
-    return internal::DecodeInternalCtx<Type>(
-        api, ctx, diagnostic,
-        api->internal_api->XLA_FFI_INTERNAL_CollectiveMultimemRequests_Get,
-        "collective multimem requests");
-  }
-};
-
-template <>
-struct CtxDecoding<CollectiveMultimemProvider> {
-  using Type = const xla::gpu::CollectiveMultimemProvider*;
-
-  static std::optional<Type> Decode(const XLA_FFI_Api* api,
-                                    XLA_FFI_ExecutionContext* ctx,
-                                    DiagnosticEngine& diagnostic) {
-    return internal::DecodeInternalCtx<Type>(
-        api, ctx, diagnostic,
-        api->internal_api->XLA_FFI_INTERNAL_CollectiveMultimemProvider_Get,
-        "collective multimem provider");
   }
 };
 

--- a/xla/backends/gpu/runtime/custom_call_thunk.h
+++ b/xla/backends/gpu/runtime/custom_call_thunk.h
@@ -209,9 +209,6 @@ class CustomCallThunk : public Thunk {
       const CollectiveParams* absl_nullable collective_params,
       CollectiveCliqueRequests* absl_nullable collective_clique_requests,
       CollectiveMemoryRequests* absl_nullable collective_memory_requests,
-      CollectiveMultimemRequests* absl_nullable collective_multimem_requests,
-      const CollectiveMultimemProvider* absl_nullable
-          collective_multimem_provider,
       const CollectiveCliques* absl_nullable collective_cliques,
       const CollectiveMemory* absl_nullable collective_memory,
       const ffi::ExecutionContext* absl_nullable execution_context);
@@ -223,9 +220,6 @@ class CustomCallThunk : public Thunk {
       const CollectiveParams* absl_nullable collective_params,
       CollectiveCliqueRequests* absl_nullable collective_clique_requests,
       CollectiveMemoryRequests* absl_nullable collective_memory_requests,
-      CollectiveMultimemRequests* absl_nullable collective_multimem_requests,
-      const CollectiveMultimemProvider* absl_nullable
-          collective_multimem_provider,
       const CollectiveCliques* absl_nullable collective_cliques,
       const CollectiveMemory* absl_nullable collective_memory);
 
@@ -236,9 +230,6 @@ class CustomCallThunk : public Thunk {
       const CollectiveParams* absl_nullable collective_params,
       CollectiveCliqueRequests* absl_nullable collective_clique_requests,
       CollectiveMemoryRequests* absl_nullable collective_memory_requests,
-      CollectiveMultimemRequests* absl_nullable collective_multimem_requests,
-      const CollectiveMultimemProvider* absl_nullable
-          collective_multimem_provider,
       const CollectiveCliques* absl_nullable collective_cliques,
       const CollectiveMemory* absl_nullable collective_memory);
 

--- a/xla/ffi/api/c_api_internal.h
+++ b/xla/ffi/api/c_api_internal.h
@@ -111,22 +111,10 @@ typedef XLA_FFI_Error* XLA_FFI_INTERNAL_CollectiveCliqueRequests_Get(
     XLA_FFI_ExecutionContext* ctx, void** collective_clique_requests);
 
 // Returns a pointer to `xla::gpu::CollectiveMemoryRequests` which allows
-// FFI handlers to request collective (symmettric) memory at run time. Available
+// FFI handlers to request collective (symmetric) memory at run time. Available
 // only for FFI handlers executing at prepare stage.
 typedef XLA_FFI_Error* XLA_FFI_INTERNAL_CollectiveMemoryRequests_Get(
     XLA_FFI_ExecutionContext* ctx, void** collective_memory_requests);
-
-// Returns a pointer to `xla::gpu::CollectiveMultimemRequests` which allows FFI
-// handlers to request multimem at run time. Available only for FFI handlers
-// executing at prepare stage.
-typedef XLA_FFI_Error* XLA_FFI_INTERNAL_CollectiveMultimemRequests_Get(
-    XLA_FFI_ExecutionContext* ctx, void** collective_multimem_requests);
-
-// Returns a pointer to `xla::gpu::CollectiveMultimemProvider` which allows FFI
-// to get multimem at run time. Available only for FFI handlers executing at
-// initialize stage.
-typedef XLA_FFI_Error* XLA_FFI_INTERNAL_CollectiveMultimemProvider_Get(
-    XLA_FFI_ExecutionContext* ctx, void** collective_multimem_provider);
 
 // Returns a pointer to `xla::gpu::CollectiveClique` which allows FFI handlers
 // to get access to requested and acquired GPU cliques. Available only for FFI
@@ -173,10 +161,6 @@ struct XLA_FFI_InternalApi {
       XLA_FFI_INTERNAL_CollectiveCliqueRequests_Get);
   _XLA_FFI_INTERNAL_API_STRUCT_FIELD(
       XLA_FFI_INTERNAL_CollectiveMemoryRequests_Get);
-  _XLA_FFI_INTERNAL_API_STRUCT_FIELD(
-      XLA_FFI_INTERNAL_CollectiveMultimemRequests_Get);
-  _XLA_FFI_INTERNAL_API_STRUCT_FIELD(
-      XLA_FFI_INTERNAL_CollectiveMultimemProvider_Get);
   _XLA_FFI_INTERNAL_API_STRUCT_FIELD(XLA_FFI_INTERNAL_CollectiveCliques_Get);
   _XLA_FFI_INTERNAL_API_STRUCT_FIELD(XLA_FFI_INTERNAL_CollectiveMemory_Get);
   _XLA_FFI_INTERNAL_API_STRUCT_FIELD(XLA_FFI_INTERNAL_GpuComputeCapability_Get);

--- a/xla/ffi/ffi_api.cc
+++ b/xla/ffi/ffi_api.cc
@@ -104,8 +104,6 @@ static XLA_FFI_ExecutionContext CreateExecutionContext(
           options.collective_params,
           options.collective_clique_requests,
           options.collective_memory_requests,
-          options.collective_multimem_requests,
-          options.collective_multimem_provider,
           options.collective_cliques,
           options.collective_memory,
           options.gpu_compute_capability};

--- a/xla/ffi/ffi_api.h
+++ b/xla/ffi/ffi_api.h
@@ -64,8 +64,6 @@ class CollectiveCliqueRequests;
 class CollectiveMemoryRequests;
 class CollectiveCliques;
 class CollectiveMemory;
-class CollectiveMultimemRequests;
-class CollectiveMultimemProvider;
 }  // namespace xla::gpu
 
 namespace xla::ffi {
@@ -88,10 +86,6 @@ struct CallOptions {
     const xla::gpu::CollectiveParams* collective_params = nullptr;
     xla::gpu::CollectiveCliqueRequests* collective_clique_requests = nullptr;
     xla::gpu::CollectiveMemoryRequests* collective_memory_requests = nullptr;
-    xla::gpu::CollectiveMultimemRequests* collective_multimem_requests =
-        nullptr;
-    const xla::gpu::CollectiveMultimemProvider* collective_multimem_provider =
-        nullptr;
     const xla::gpu::CollectiveCliques* collective_cliques = nullptr;
     const xla::gpu::CollectiveMemory* collective_memory = nullptr;
     const stream_executor::GpuComputeCapability* gpu_compute_capability =

--- a/xla/ffi/ffi_internal_api.cc
+++ b/xla/ffi/ffi_internal_api.cc
@@ -195,32 +195,6 @@ static XLA_FFI_Error* XLA_FFI_INTERNAL_CollectiveMemory_Get(
       InvalidArgument("XLA FFI GPU context is not available")};
 }
 
-static XLA_FFI_Error* XLA_FFI_INTERNAL_CollectiveMultimemRequests_Get(
-    XLA_FFI_ExecutionContext* ctx, void** collective_multimem_requests) {
-  if (auto* gpu = std::get_if<XLA_FFI_ExecutionContext::GpuContext>(
-          &ctx->backend_context)) {
-    *collective_multimem_requests = gpu->collective_multimem_requests;
-    return nullptr;
-  }
-
-  return new XLA_FFI_Error{
-      InvalidArgument("XLA FFI GPU context is not available")};
-}
-
-static XLA_FFI_Error* XLA_FFI_INTERNAL_CollectiveMultimemProvider_Get(
-    XLA_FFI_ExecutionContext* ctx, void** collective_multimem_provider) {
-  if (auto* gpu = std::get_if<XLA_FFI_ExecutionContext::GpuContext>(
-          &ctx->backend_context)) {
-    *collective_multimem_provider =
-        const_cast<xla::gpu::CollectiveMultimemProvider*>(  // NOLINT
-            gpu->collective_multimem_provider);
-    return nullptr;
-  }
-
-  return new XLA_FFI_Error{
-      InvalidArgument("XLA FFI GPU context is not available")};
-}
-
 static XLA_FFI_Error* XLA_FFI_INTERNAL_GpuComputeCapability_Get(
     XLA_FFI_ExecutionContext* ctx, void** gpu_compute_capability) {
   if (auto* gpu = std::get_if<XLA_FFI_ExecutionContext::GpuContext>(
@@ -255,8 +229,6 @@ const XLA_FFI_InternalApi* GetInternalApi() {
       XLA_FFI_INTERNAL_CollectiveParams_Get,
       XLA_FFI_INTERNAL_CollectiveCliqueRequests_Get,
       XLA_FFI_INTERNAL_CollectiveMemoryRequests_Get,
-      XLA_FFI_INTERNAL_CollectiveMultimemRequests_Get,
-      XLA_FFI_INTERNAL_CollectiveMultimemProvider_Get,
       XLA_FFI_INTERNAL_CollectiveCliques_Get,
       XLA_FFI_INTERNAL_CollectiveMemory_Get,
       XLA_FFI_INTERNAL_GpuComputeCapability_Get,

--- a/xla/ffi/ffi_structs.h
+++ b/xla/ffi/ffi_structs.h
@@ -44,8 +44,6 @@ class DeviceAddressAllocator;
 namespace xla::gpu {
 struct CollectiveParams;
 class CollectiveCliqueRequests;
-class CollectiveMultimemRequests;
-class CollectiveMultimemProvider;
 class CollectiveMemoryRequests;
 class CollectiveCliques;
 class CollectiveMemory;
@@ -74,10 +72,6 @@ struct XLA_FFI_ExecutionContext {
     const xla::gpu::CollectiveParams* collective_params = nullptr;
     xla::gpu::CollectiveCliqueRequests* collective_clique_requests = nullptr;
     xla::gpu::CollectiveMemoryRequests* collective_memory_requests = nullptr;
-    xla::gpu::CollectiveMultimemRequests* collective_multimem_requests =
-        nullptr;
-    const xla::gpu::CollectiveMultimemProvider* collective_multimem_provider =
-        nullptr;
     const xla::gpu::CollectiveCliques* collective_cliques = nullptr;
     const xla::gpu::CollectiveMemory* collective_memory = nullptr;
     const stream_executor::GpuComputeCapability* gpu_compute_capability =

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -2892,7 +2892,6 @@ xla_test(
         "//xla/backends/gpu/runtime:collective_execution",
         "//xla/backends/gpu/runtime:collective_memory",
         "//xla/backends/gpu/runtime:collective_memory_requests",
-        "//xla/backends/gpu/runtime:collective_multimem",
         "//xla/backends/gpu/runtime:collective_params",
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:reduction_kind",


### PR DESCRIPTION
Multimem addresses can be requested with `CollectiveMemoryRequests` and later resolved with `CollectiveMemory`. Remove `CollectiveMultimem` as it will be fully subsumed by `CollectiveMemory`.