### PR TITLE
[tsl:concurrency] Fix JoinFutures<T>() when futures finish with errors

### DIFF
--- a/xla/tsl/concurrency/future.h
+++ b/xla/tsl/concurrency/future.h
@@ -1363,7 +1363,11 @@ class JoinState {
 
     if (pending_count == 1) {
       absl::MutexLock lock(mu_);
-      promise_.Set(std::move(values_));
+      if (ABSL_PREDICT_TRUE(status_.ok())) {
+        promise_.Set(std::move(values_));
+      } else {
+        promise_.Set(std::move(status_));
+      }
     }
   }
 

--- a/xla/tsl/concurrency/future_test.cc
+++ b/xla/tsl/concurrency/future_test.cc
@@ -30,10 +30,10 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/tsl/concurrency/executor.h"
 #include "xla/tsl/platform/env.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/test.h"
 #include "xla/tsl/platform/test_benchmark.h"
 #include "xla/tsl/platform/threadpool.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace tsl {
 
@@ -1015,6 +1015,21 @@ TEST(FutureTest, JoinCopyableFutures) {
   EXPECT_EQ(v1, std::vector<int32_t>({1, 2}));
 }
 
+TEST(FutureTest, JoinCopyableFuturesError) {
+  auto [promise0, future0] = MakePromise<int32_t>();
+  auto [promise1, future1] = MakePromise<int32_t>();
+
+  std::vector<Future<int32_t>> futures = {future0, future1};
+  Future<std::vector<int32_t>> join_two = JoinFutures<int32_t>(futures);
+  EXPECT_FALSE(join_two.IsReady());
+
+  promise0.Set(absl::InternalError("error0"));
+  promise1.Set(absl::InternalError("error1"));
+
+  EXPECT_TRUE(join_two.IsReady());
+  EXPECT_EQ(join_two.Await().status(), absl::InternalError("error0"));
+}
+
 TEST(FutureTest, JoinMoveOnlyFuture) {
   auto [promise0, future0] = MakePromise<std::unique_ptr<int32_t>>();
   auto [promise1, future1] = MakePromise<std::unique_ptr<int32_t>>();
@@ -1035,6 +1050,25 @@ TEST(FutureTest, JoinMoveOnlyFuture) {
   ASSERT_EQ(vec.size(), 2);
   EXPECT_EQ(*vec[0], 1);
   EXPECT_EQ(*vec[1], 2);
+}
+
+TEST(FutureTest, JoinMoveOnlyFuturesError) {
+  auto [promise0, future0] = MakePromise<std::unique_ptr<int32_t>>();
+  auto [promise1, future1] = MakePromise<std::unique_ptr<int32_t>>();
+
+  std::vector<Future<std::unique_ptr<int32_t>>> futures;
+  futures.push_back(std::move(future0));
+  futures.push_back(std::move(future1));
+
+  Future<std::vector<std::unique_ptr<int32_t>>> join_two =
+      JoinFutures<std::unique_ptr<int32_t>>(absl::MakeSpan(futures));
+  EXPECT_FALSE(join_two.IsReady());
+
+  promise0.Set(absl::InternalError("error0"));
+  promise1.Set(absl::InternalError("error1"));
+
+  EXPECT_TRUE(join_two.IsReady());
+  EXPECT_EQ(join_two.Await().status(), absl::InternalError("error0"));
 }
 
 TEST(FutureTest, WithProfiling) {


### PR DESCRIPTION
Fix JoinFutures<T>() when futures finish with errors