### PR TITLE
[ROCm] Treat warnings as errors by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,4 +14,7 @@ common:clang_local --repo_env USE_HERMETIC_CC_TOOLCHAIN=0
 import %workspace%/tensorflow.bazelrc
 import %workspace%/warnings.bazelrc
 
+# Treat warnings as errors
+build --config=warnings 
+
 try-import %workspace%/xla_configure.bazelrc


### PR DESCRIPTION
📝 Summary of Changes
This PR enables `--config=warnings` as a default build option, so we can treat warnings as errors and avoid potential bugs early
