### PR TITLE
[xla:ffi] ffi_api.h is an internal header and XLA:FFI users should only need ffi.h

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -376,9 +376,7 @@ cc_library(
 xla_test(
     name = "dynamic_slice_thunk_test",
     srcs = ["dynamic_slice_thunk_test.cc"],
-    backends = [
-        "gpu",
-    ],
+    backends = ["gpu"],
     deps = [
         ":collective_memory_requests",
         ":collective_multimem_registry",
@@ -394,7 +392,6 @@ xla_test(
         "//xla/backends/gpu:ffi",
         "//xla/ffi",
         "//xla/ffi:attribute_map",
-        "//xla/ffi:ffi_api",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/parser:hlo_parser",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
@@ -1005,7 +1002,6 @@ xla_cc_test(
         ":thunk",
         ":thunk_proto_cc",
         "//xla/ffi",
-        "//xla/ffi:ffi_api",
         "//xla/service:buffer_assignment",
         "//xla/service:platform_util",
         "//xla/stream_executor:platform",
@@ -1090,7 +1086,6 @@ xla_test(
         "//xla/ffi",
         "//xla/ffi:attribute_map",
         "//xla/ffi:execution_state",
-        "//xla/ffi:ffi_api",
         "//xla/ffi:type_registry",
         "//xla/hlo/ir:hlo",
         "//xla/runtime:device_id",
@@ -4029,7 +4024,7 @@ cc_library(
         "//xla:xla_data_proto_cc",
         "//xla/backends/gpu:ffi",
         "//xla/ffi",
-        "//xla/ffi:ffi_api",
+        "//xla/ffi:ffi_api",  # build_cleaner: keep
         "//xla/service:collective_ops_utils",
         "//xla/service:custom_call_status",
         "//xla/service:custom_call_target_registry",

--- a/xla/backends/gpu/runtime/custom_call_thunk_test.cc
+++ b/xla/backends/gpu/runtime/custom_call_thunk_test.cc
@@ -39,7 +39,6 @@ limitations under the License.
 #include "xla/ffi/attribute_map.h"
 #include "xla/ffi/execution_state.h"
 #include "xla/ffi/ffi.h"
-#include "xla/ffi/ffi_api.h"
 #include "xla/ffi/type_registry.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
@@ -41,7 +41,6 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/thunk_proto_deserialization.h"
 #include "xla/ffi/attribute_map.h"
 #include "xla/ffi/ffi.h"
-#include "xla/ffi/ffi_api.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/parser/hlo_parser.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"

--- a/xla/backends/gpu/runtime/runtime_intrinsics.cc
+++ b/xla/backends/gpu/runtime/runtime_intrinsics.cc
@@ -33,7 +33,6 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "xla/backends/gpu/ffi.h"
 #include "xla/ffi/ffi.h"
-#include "xla/ffi/ffi_api.h"
 #include "xla/layout_util.h"
 #include "xla/literal.h"
 #include "xla/service/collective_ops_utils.h"

--- a/xla/ffi/BUILD
+++ b/xla/ffi/BUILD
@@ -164,6 +164,12 @@ cc_library(
     ],
 )
 
+# IMPORTANT: This is an internal (to XLA) implementation of XLA:FFI API and it
+# contains multiple global static registries (FFI handler registry and Type
+# Registry). This library must be linked exactly once into the target process,
+# or it is possible to have multiple registries, which will lead to crashes and
+# undefined behavior as XLA:FFI will be calling destructors for unrelated types,
+# or fail to find an FFI handler.
 cc_library(
     name = "ffi_api",
     srcs = ["ffi_api.cc"],

--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -296,7 +296,7 @@ class Ffi {
   // Automatic FFI binding that does binding specification inference from the
   // `fn` type signature and binds `fn` to it. This enables a more concise FFI
   // handler registration with fully automatic type inference at the cost of
-  // less readable error messages, template metaprogramming "magic" and a risk
+  // less readable error messages, template metaprograming "magic" and a risk
   // to accidentally change handler type without noticing it.
   template <typename Fn, ExecutionStage stage = ExecutionStage::kExecute>
   static auto BindTo(Fn fn, std::initializer_list<Traits> traits = {});
@@ -366,7 +366,7 @@ class Ffi {
   template <typename... Args>
   static std::string StrCat(Args... args);
 
-  static XLA_FFI_Error* Sucess();
+  static XLA_FFI_Error* Success();
 
   static XLA_FFI_Error* MakeError(const XLA_FFI_Api* api,
                                   XLA_FFI_Error_Code errc, std::string message);
@@ -428,7 +428,7 @@ std::string Ffi::StrCat(Args... args) {
   return ss.str();
 }
 
-inline XLA_FFI_Error* Ffi::Sucess() { return nullptr; }
+inline XLA_FFI_Error* Ffi::Success() { return nullptr; }
 
 inline XLA_FFI_Error* Ffi::MakeError(const XLA_FFI_Api* api,
                                      XLA_FFI_Error_Code errc,
@@ -516,7 +516,7 @@ class Context;
 
 namespace internal {
 
-// WARNING: A lot of template metaprogramming on top of C++ variadic templates
+// WARNING: A lot of template metaprograming on top of C++ variadic templates
 // parameter packs. We need this to be able to pattern match FFI handler
 // signature at compile time.
 
@@ -769,11 +769,11 @@ inline Binding<ExecutionStage::kInitialize> Ffi::BindInitialize() {
 }
 
 //===----------------------------------------------------------------------===//
-// Template metaprogramming to automatically infer Binding from invocable
+// Template metaprograming to automatically infer Binding from invocable
 // object.
 //===----------------------------------------------------------------------===//
 
-// A little bit of metaprogramming that automatically infers the binding schema
+// A little bit of metaprograming that automatically infers the binding schema
 // from an invocable type signature.
 
 // XLA FFI binding for an argument.
@@ -1545,7 +1545,7 @@ class ContextBase {
 }  // namespace internal
 
 //===----------------------------------------------------------------------===//
-// Template metaprogramming for decoding handler signature
+// Template metaprograming for decoding handler signature
 //===----------------------------------------------------------------------===//
 
 // Forward declare classes for decoding variadic number of arguments and
@@ -1607,7 +1607,7 @@ struct FnArgType<internal::CtxTag<T>> {
 
 // A template to detect result encodings that are state constructors. We use
 // this to report back the TypeId of the state as a part of the metadata.
-template <typename ResultEnconding, typename = void>
+template <typename ResultEncoding, typename = void>
 struct IsStateConstructor : std::false_type {};
 
 // Check if the ResultEncoding has a static `state_type_id()` method returning
@@ -1716,7 +1716,7 @@ class Handler : public Ffi {
                    call_frame->args.size));
       }
     } else {
-      // It is safe to not theck the number of arguments if we don't plan to
+      // It is safe to not check the number of arguments if we don't plan to
       // decode any of them, i.e. for prepare/initialize stages where the FFI
       // handler might be interested only in the attributes or context.
       if (XLA_FFI_PREDICT_FALSE(call_frame->args.size != kNumArgs &&
@@ -1750,7 +1750,7 @@ class Handler : public Ffi {
                    call_frame->rets.size));
       }
     } else {
-      // It is safe to not theck the number of results if we don't plan to
+      // It is safe to not check the number of results if we don't plan to
       // decode any of them, i.e. for prepare/initialize stages where the FFI
       // handler might be interested only in the attributes or context.
       if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size != kNumRets &&
@@ -1847,7 +1847,7 @@ class Handler : public Ffi {
       extension->metadata->state_type_id = XLA_FFI_UNKNOWN_TYPE_ID;
     }
 
-    return Sucess();
+    return Success();
   }
 
   template <size_t... Is>

--- a/xla/ffi/api/ffi.h
+++ b/xla/ffi/api/ffi.h
@@ -51,6 +51,20 @@ limitations under the License.
 
 namespace xla::ffi {
 
+//===----------------------------------------------------------------------===//
+// XLA FFI Api
+//===----------------------------------------------------------------------===//
+
+// This is a declaration of the API that returns an XLA:FFI instance for a
+// process. This API is implemented in `xla/ffi/ffi_api.cc` and implementation
+// must be linked into the target process exactly once, or it is possible to
+// have multiple global static registries of FFI handlers and types.
+const XLA_FFI_Api* GetXlaFfiApi();
+
+//===----------------------------------------------------------------------===//
+// Type aliases for XLA_FFI C structs.
+//===----------------------------------------------------------------------===//
+
 // All user data types that are passed via the execution context or state must
 // be registered with the XLA FFI ahead of time to get unique type id.
 using TypeId = XLA_FFI_TypeId;      // NOLINT

--- a/xla/ffi/api/ffi_test.cc
+++ b/xla/ffi/api/ffi_test.cc
@@ -65,7 +65,7 @@ using xla::ffi::internal::ArgTag;
 using xla::ffi::internal::NumTagged;
 using xla::ffi::internal::RetTag;
 
-// Compile-time test for the template metaprogramming for counting tags.
+// Compile-time test for the template metaprograming for counting tags.
 static_assert(NumTagged<ArgTag, RetTag<int32_t>>::value == 0);
 static_assert(NumTagged<ArgTag, ArgTag<int32_t>>::value == 1);
 static_assert(NumTagged<ArgTag, ArgTag<int32_t>, RetTag<int32_t>>::value == 1);

--- a/xla/ffi/ffi.h
+++ b/xla/ffi/ffi.h
@@ -64,6 +64,16 @@ struct DeviceOrdinal {};      // binds `int32_t` with device ordinal
 struct CalledComputation {};  // binds `HloComputation*`
 
 //===----------------------------------------------------------------------===//
+// XLA FFI Api
+//===----------------------------------------------------------------------===//
+
+// This is a declaration of the API that returns an XLA:FFI instance for a
+// process. This API is implemented in `xla/ffi/ffi_api.cc` and implementation
+// must be linked into the target process exactly once, or it is possible to
+// have multiple global static registries of FFI handlers and types.
+const XLA_FFI_Api* GetXlaFfiApi();
+
+//===----------------------------------------------------------------------===//
 // Arguments
 //===----------------------------------------------------------------------===//
 
@@ -393,7 +403,7 @@ struct internal::Decode<internal::RemainingRetsTag> {
 // Attributes decoding
 //===----------------------------------------------------------------------===//
 
-#define XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING(T, TYPE)                   \
+#define XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(T, TYPE)                    \
   template <>                                                            \
   struct AttrDecoding<absl::Span<const T>> {                             \
     using Type = absl::Span<const T>;                                    \
@@ -415,14 +425,14 @@ struct internal::Decode<internal::RemainingRetsTag> {
     }                                                                    \
   }
 
-XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING(int8_t, XLA_FFI_DataType_S8);
-XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING(int16_t, XLA_FFI_DataType_S16);
-XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING(int32_t, XLA_FFI_DataType_S32);
-XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING(int64_t, XLA_FFI_DataType_S64);
-XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING(float, XLA_FFI_DataType_F32);
-XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING(double, XLA_FFI_DataType_F64);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int8_t, XLA_FFI_DataType_S8);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int16_t, XLA_FFI_DataType_S16);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int32_t, XLA_FFI_DataType_S32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int64_t, XLA_FFI_DataType_S64);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(float, XLA_FFI_DataType_F32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(double, XLA_FFI_DataType_F64);
 
-#undef XLA_FFI_REGISTER_ARRRAY_ATTR_DECODING
+#undef XLA_FFI_REGISTER_ARRAY_ATTR_DECODING
 
 template <>
 struct AttrDecoding<absl::string_view> {

--- a/xla/ffi/ffi_api.cc
+++ b/xla/ffi/ffi_api.cc
@@ -60,6 +60,14 @@ limitations under the License.
 
 namespace xla::ffi {
 
+// Forward declare XLA:FFI API access defined below. This API is available
+// publicly via the `xla/ffi/ffi.h` or `xla/ffi/api/ffi.h` header. In this
+// translation unit we implement it, and it is critical that this translation
+// unit linked exactly one time into the main binary. It must not be linked
+// into FFI handler implementations as it will lead to duplicate static
+// registries in multiple object files.
+const XLA_FFI_Api* GetXlaFfiApi();
+
 // The minimum XLA:FFI API version that XLA runtime supports.
 static constexpr std::pair<int32_t, int32_t> kMinSupportedApiVersion = {
     /*major=*/0,

--- a/xla/ffi/ffi_api.h
+++ b/xla/ffi/ffi_api.h
@@ -187,12 +187,6 @@ absl::StatusOr<absl::flat_hash_map<std::string, HandlerRegistration>>
 StaticRegisteredHandlers(absl::string_view platform);
 
 //===----------------------------------------------------------------------===//
-// XLA FFI Api Implementation
-//===----------------------------------------------------------------------===//
-
-const XLA_FFI_Api* GetXlaFfiApi();
-
-//===----------------------------------------------------------------------===//
 // Helper functions
 //===----------------------------------------------------------------------===//
 

--- a/xla/ffi/type_registry.cc
+++ b/xla/ffi/type_registry.cc
@@ -58,13 +58,14 @@ TypeRegistry::TypeId TypeRegistry::GetNextTypeId() {
 
 absl::StatusOr<TypeRegistry::TypeId> TypeRegistry::AssignExternalTypeId(
     absl::string_view name, TypeInfo type_info) {
-  VLOG(3) << absl::StrFormat("Assign external type id: name=%s", name);
-
   absl::MutexLock lock(type_registry_mutex);
   auto& registry = StaticTypeRegistryMap();
 
-  // Try to emplace with unknow type id and fill it with real type id only if we
-  // successfully acquired an entry for a given name.
+  VLOG(3) << absl::StreamFormat("Assign external type id: name=%s registry=%p",
+                                name, &registry);
+
+  // Try to emplace with unknown type id and fill it with real type id only if
+  // we successfully acquired an entry for a given name.
   auto emplaced =
       registry.emplace(name, TypeRegistration{kUnknownTypeId, type_info});
   if (!emplaced.second) {
@@ -84,19 +85,21 @@ absl::StatusOr<TypeRegistry::TypeId> TypeRegistry::AssignExternalTypeId(
     type_id = GetNextTypeId();
   }
 
-  VLOG(3) << absl::StrFormat("Assigned external type id: name=%s type_id=%d",
-                             name, type_id.value());
+  VLOG(3) << absl::StreamFormat(
+      "Assigned external type id: name=%s type_id=%v registry=%p", name,
+      type_id, &registry);
   return emplaced.first->second.type_id = type_id;
 }
 
 absl::Status TypeRegistry::RegisterExternalTypeId(absl::string_view name,
                                                   TypeId type_id,
                                                   TypeInfo type_info) {
-  VLOG(3) << absl::StrFormat("Register external type id: name=%s type_id=%d",
-                             name, type_id.value());
-
   absl::MutexLock lock(type_registry_mutex);
   auto& registry = StaticTypeRegistryMap();
+
+  VLOG(3) << absl::StreamFormat(
+      "Register external type id: name=%s type_id=%v registry=%p", name,
+      type_id, &registry);
 
   auto emplaced = registry.emplace(name, TypeRegistration{type_id, type_info});
   if (!emplaced.second && emplaced.first->second.type_id != type_id) {


### PR DESCRIPTION
Adding dependency on `ffi_api.h` just to get `XLA_FFI_Api*` leads to duplicate static registries in multiple translation units and run time crashes. This is a first step towards cleaning up this mess.