### PR TITLE
[xla:gpu] Use CollectiveMemory to acquire peer addresses

### DIFF
--- a/xla/backends/gpu/runtime/collective_memory.cc
+++ b/xla/backends/gpu/runtime/collective_memory.cc
@@ -48,21 +48,23 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_executor.h"
 #include "xla/stream_executor/gpu/multicast_memory.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/safe_reinterpret_cast.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
 CollectiveMemory::CollectiveMemory(
     const BufferAllocations& buffers,
     absl::flat_hash_map<Key, std::unique_ptr<SymmetricMemory>> sym_memories,
-    absl::flat_hash_map<Key, MappedMulticastMemory> mcast_memories)
+    absl::flat_hash_map<Key, MulticastMemory> mcast_memories,
+    absl::flat_hash_map<Key, PeerMemory> peer_memories)
     : buffers_(buffers),
       sym_memories_(std::move(sym_memories)),
-      mcast_memories_(std::move(mcast_memories)) {}
+      mcast_memories_(std::move(mcast_memories)),
+      peer_memories_(std::move(peer_memories)) {}
 
 std::pair<SymmetricMemory*, size_t> CollectiveMemory::FindSymmetricMemory(
     const GpuCliqueKey& clique, BufferAllocation::Index allocation) const {
@@ -90,23 +92,17 @@ std::pair<SymmetricMemory*, size_t> CollectiveMemory::FindSymmetricMemory(
 }
 
 std::pair<void*, size_t> CollectiveMemory::FindMultimemAddress(
-    const GpuCliqueKey& clique, RankId rank,
-    BufferAllocation::Index allocation) const {
+    const GpuCliqueKey& clique, BufferAllocation::Index allocation) const {
   auto it = mcast_memories_.find(std::make_pair(clique, allocation));
   if (it == mcast_memories_.end()) {
     return std::make_pair(nullptr, 0);
   }
 
-  auto ptr = it->second.mapped_ptrs.find(rank);
-  if (ptr == it->second.mapped_ptrs.end()) {
-    return std::make_pair(nullptr, 0);
-  }
-
-  return std::make_pair(ptr->second, 0);
+  return std::make_pair(it->second.multimem_ptr, 0);
 }
 
 std::pair<void*, size_t> CollectiveMemory::FindMultimemAddress(
-    const GpuCliqueKey& clique, RankId rank, se::DeviceAddressBase addr) const {
+    const GpuCliqueKey& clique, se::DeviceAddressBase addr) const {
   auto allocation = buffers_.FindAllocationIndex(addr);
   if (!allocation.has_value()) {
     return std::make_pair(nullptr, 0);
@@ -117,12 +113,97 @@ std::pair<void*, size_t> CollectiveMemory::FindMultimemAddress(
   size_t offset = tsl::safe_reinterpret_cast<uintptr_t>(addr.opaque()) -
                   tsl::safe_reinterpret_cast<uintptr_t>(base.opaque());
 
-  auto [mmem, mmem_offset] = FindMultimemAddress(clique, rank, *allocation);
+  auto [mmem, mmem_offset] = FindMultimemAddress(clique, *allocation);
   return std::make_pair(mmem, mmem_offset + offset);
 }
 
+std::optional<se::DeviceAddressBase> CollectiveMemory::FindPeerAddress(
+    const GpuCliqueKey& clique, RankId rank,
+    BufferAllocation::Index allocation) const {
+  auto it = peer_memories_.find(std::make_pair(clique, allocation));
+  if (it == peer_memories_.end()) {
+    return std::nullopt;
+  }
+
+  auto addr = it->second.addrs.find(rank);
+  if (addr == it->second.addrs.end()) {
+    return std::nullopt;
+  }
+
+  return addr->second;
+}
+
+std::optional<se::DeviceAddressBase> CollectiveMemory::FindPeerAddress(
+    const GpuCliqueKey& clique, RankId rank, se::DeviceAddressBase addr) const {
+  auto allocation = buffers_.FindAllocationIndex(addr);
+  if (!allocation.has_value()) {
+    return std::nullopt;
+  }
+
+  // Find offset from the base allocation.
+  se::DeviceAddressBase base = buffers_.GetDeviceAddress(*allocation);
+  size_t offset = tsl::safe_reinterpret_cast<uintptr_t>(addr.opaque()) -
+                  tsl::safe_reinterpret_cast<uintptr_t>(base.opaque());
+
+  // Find device address for peer allocation.
+  auto peer_alloc = FindPeerAddress(clique, rank, *allocation);
+  if (!peer_alloc.has_value()) {
+    return std::nullopt;
+  }
+
+  return peer_alloc->GetByteSlice(offset, addr.size());
+}
+
 //===----------------------------------------------------------------------===//
-// Symmetric memory allocation.
+// Local rendezvous parameters.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+// Wrap GpuCliqueKey into a unique struct to guarantee we do not accidentally
+// try to run multiple unrelated rendezvous for a same key.
+struct RendezvousKey {
+  GpuCliqueKey clique_key;
+
+  bool operator==(const RendezvousKey& other) const {
+    return clique_key == other.clique_key;
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const RendezvousKey& key) {
+    return H::combine(std::move(h), key.clique_key);
+  }
+};
+
+// Parameters passed to the rendezvous callback from all ranks.
+struct RendezvousParams {
+  RankId rank;
+  se::StreamExecutor* executor;
+  const BufferAllocations& buffers;
+};
+
+struct RankCmp {
+  bool operator()(const RendezvousParams* a, const RendezvousParams* b) const {
+    return a->rank < b->rank;
+  }
+};
+
+struct DeviceOrdinalFormatter {
+  void operator()(std::string* out, const RendezvousParams* param) const {
+    absl::StrAppend(out, param->executor->device_ordinal());
+  }
+};
+
+struct RankFormatter {
+  void operator()(std::string* out, const RendezvousParams* param) const {
+    absl::StrAppend(out, param->rank.value());
+  }
+};
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Symmetric memory acquisition.
 //===----------------------------------------------------------------------===//
 
 // Acquire symmetric memory for all requested allocation.
@@ -168,54 +249,14 @@ AcquireSymmetricMemory(
 }
 
 //===----------------------------------------------------------------------===//
-// Multicast memory allocation.
+// Multicast memory acquisition.
 //===----------------------------------------------------------------------===//
 
 namespace {
 
 using MulticastMemoryMap =
     absl::flat_hash_map<CollectiveMemory::Key,
-                        CollectiveMemory::MappedMulticastMemory>;
-
-// Wrap GpuCliqueKey into a unique struct to guarantee we do not accidentally
-// try to run multiple unrelated rendezvous for a same key.
-struct AllocateRendezvousKey {
-  GpuCliqueKey clique_key;
-
-  bool operator==(const AllocateRendezvousKey& other) const {
-    return clique_key == other.clique_key;
-  }
-
-  template <typename H>
-  friend H AbslHashValue(H h, const AllocateRendezvousKey& key) {
-    return H::combine(std::move(h), key.clique_key);
-  }
-};
-
-// Parameters passed to the rendezvous callback from all ranks.
-struct AllocateParams {
-  se::StreamExecutor* executor;
-  RankId rank;
-  const BufferAllocations& buffers;
-};
-
-struct RankCmp {
-  bool operator()(const AllocateParams* a, const AllocateParams* b) const {
-    return a->rank < b->rank;
-  }
-};
-
-struct DeviceOrdinalFormatter {
-  void operator()(std::string* out, const AllocateParams* param) const {
-    absl::StrAppend(out, param->executor->device_ordinal());
-  }
-};
-
-struct RankFormatter {
-  void operator()(std::string* out, const AllocateParams* param) const {
-    absl::StrAppend(out, param->rank.value());
-  }
-};
+                        CollectiveMemory::MulticastMemory>;
 
 struct MappedPtrFormatter {
   void operator()(std::string* out,
@@ -224,6 +265,15 @@ struct MappedPtrFormatter {
     absl::StrAppend(out, absl::StrFormat("%d:%p", rank.value(), ptr));
   }
 };
+
+// A multicast object and a multimem mapping for all participating ranks.
+struct MappedMulticastMemory {
+  std::shared_ptr<se::gpu::MulticastMemory> multicast_memory;
+  absl::btree_map<RankId, void*> rank_multimem_ptr;
+};
+
+using MappedMulticastMemoryMap =
+    absl::flat_hash_map<CollectiveMemory::Key, MappedMulticastMemory>;
 
 }  // namespace
 
@@ -265,8 +315,8 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
 
     // A callback for rendezvous to allocate and map the multicast memory. We
     // do one round of rendezvous for each clique.
-    auto allocate = [&](absl::Span<const AllocateParams*> params)
-        -> absl::StatusOr<MulticastMemoryMap> {
+    auto allocate = [&](absl::Span<const RendezvousParams*> params)
+        -> absl::StatusOr<MappedMulticastMemoryMap> {
       // Sort all participants by rank to get deterministic execution.
       absl::c_sort(params, RankCmp{});
 
@@ -283,7 +333,10 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
         return Unimplemented("Unsupported stream executor type");
       }
 
-      MulticastMemoryMap clique_mcast_memories;
+      // As a result of rendezvous we collective multicast memory and mapping
+      // for all participating ranks to the multimem address.
+      MappedMulticastMemoryMap clique_mcast_memories;
+
       for (BufferAllocation::Index i : r.allocations) {
         // Allocate a multicast object for all participating devices.
         size_t multicast_size = params[0]->buffers.GetDeviceAddress(i).size();
@@ -314,9 +367,8 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
             absl::StrJoin(params, ",", RankFormatter{}), r.key,
             absl::StrJoin(mapped_ptrs, ", ", MappedPtrFormatter{}));
 
-        clique_mcast_memories[std::make_pair(r.key, i)] =
-            CollectiveMemory::MappedMulticastMemory{std::move(multicast_memory),
-                                                    std::move(mapped_ptrs)};
+        clique_mcast_memories[std::make_pair(r.key, i)] = MappedMulticastMemory{
+            std::move(multicast_memory), std::move(mapped_ptrs)};
       }
       return clique_mcast_memories;
     };
@@ -324,18 +376,19 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
     // We expect that all local participants will collectively allocate the
     // multicast memory. We do one rendezvous for each clique, and from the
     // rendezvous callback allocate multicast memory for all allocations.
-    AllocateRendezvousKey rendezvous_key = {r.key};
-    AllocateParams allocate_params = {params.executor, *rank, buffers};
+    RendezvousKey rendezvous_key = {r.key};
+    RendezvousParams allocate_params = {*rank, params.executor, buffers};
 
     int64_t num_participants = r.key.num_local_participants();
-    ASSIGN_OR_RETURN(std::shared_ptr<MulticastMemoryMap> clique_mcast_memories,
-                     Rendezvous<MulticastMemoryMap>(
-                         rendezvous_name, rendezvous_key, allocate_params,
-                         num_participants, allocate));
+    ASSIGN_OR_RETURN(
+        std::shared_ptr<MappedMulticastMemoryMap> clique_mcast_memories,
+        Rendezvous<MappedMulticastMemoryMap>(rendezvous_name, rendezvous_key,
+                                             allocate_params, num_participants,
+                                             allocate));
 
     // Copy clique multicast memory to each participating thread.
     for (auto& [k, v] : *clique_mcast_memories) {
-      mcast_memories[k] = v;
+      mcast_memories[k] = {v.multicast_memory, v.rank_multimem_ptr.at(*rank)};
     }
   }
 
@@ -343,7 +396,93 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
 }
 
 //===----------------------------------------------------------------------===//
-// Collective memory allocation.
+// Peer memory acquisition.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+using PeerMemoryMap =
+    absl::flat_hash_map<CollectiveMemory::Key, CollectiveMemory::PeerMemory>;
+
+}  // namespace
+
+// Acquire peer memory for all requested allocation.
+absl::StatusOr<PeerMemoryMap> AcquirePeerMemory(
+    const CollectiveParams& params, const CollectiveCliques& cliques,
+    const BufferAllocations& buffers,
+    absl::Span<const CollectiveMemoryRequests::PeerAllocations> allocs) {
+  int32_t device_ordinal = params.executor->device_ordinal();
+
+  PeerMemoryMap peer_memories;
+
+  for (const CollectiveMemoryRequests::PeerAllocations& r : allocs) {
+    std::optional<RankId> rank = r.key.rank(params.global_device_id);
+
+    if (!rank.has_value()) {
+      return Internal("[%d] Can't find global device id %v in clique key %v",
+                      device_ordinal, params.global_device_id, r.key);
+    }
+
+    // We rely on in-process rendezvous to exchange peer memory with all ranks.
+    if (!r.key.is_local()) {
+      return Unimplemented(
+          "[%d] Peer memory is not supported in multi-process mode in clique "
+          "%v",
+          device_ordinal, r.key);
+    }
+
+    std::string rendezvous_name = absl::StrFormat(
+        "[%d] [rank=%v] AcquirePeerMemory for clique %v: allocs=[%s]",
+        device_ordinal, *rank, r.key, absl::StrJoin(r.allocations, ","));
+
+    // A callback for rendezvous to exchange peer allocation addresses with
+    // all participating ranks.
+    auto exchange = [&](absl::Span<const RendezvousParams*> params)
+        -> absl::StatusOr<PeerMemoryMap> {
+      // Sort all participants by rank to get deterministic execution.
+      absl::c_sort(params, RankCmp{});
+
+      VLOG(3) << absl::StrFormat(
+          "[%s] [ranks=%s] Exchange collective peer memory for clique: %v",
+          absl::StrJoin(params, ",", DeviceOrdinalFormatter{}),
+          absl::StrJoin(params, ",", RankFormatter{}), r.key);
+
+      PeerMemoryMap clique_peer_memories;
+      for (BufferAllocation::Index i : r.allocations) {
+        // For all participating devices get allocation device address.
+        absl::btree_map<RankId, se::DeviceAddressBase> addrs;
+        for (const RendezvousParams* param : params) {
+          addrs[param->rank] = param->buffers.GetDeviceAddress(i);
+        }
+        clique_peer_memories[std::make_pair(r.key, i)] =
+            CollectiveMemory::PeerMemory{std::move(addrs)};
+      }
+      return clique_peer_memories;
+    };
+
+    // We expect that all local participants will collectively allocate the
+    // multicast memory. We do one rendezvous for each clique, and from the
+    // rendezvous callback allocate multicast memory for all allocations.
+    RendezvousKey rendezvous_key = {r.key};
+    RendezvousParams allocate_params = {*rank, params.executor, buffers};
+
+    int64_t num_participants = r.key.num_local_participants();
+    ASSIGN_OR_RETURN(
+        std::shared_ptr<PeerMemoryMap> clique_mcast_memories,
+        Rendezvous<PeerMemoryMap>(rendezvous_name, rendezvous_key,
+                                  allocate_params, num_participants, exchange));
+
+    // Copy clique peer memory to each participating thread.
+    for (auto& [k, v] : *clique_mcast_memories) {
+      peer_memories[k] = v;
+    }
+  }
+
+  return peer_memories;
+}
+
+//===----------------------------------------------------------------------===//
+// Collective memory acquisition.
 //===----------------------------------------------------------------------===//
 
 absl::StatusOr<CollectiveMemory> AcquireCollectiveMemory(
@@ -356,18 +495,20 @@ absl::StatusOr<CollectiveMemory> AcquireCollectiveMemory(
       requests.OrderedSymmetricAllocations();
   std::vector<CollectiveMemoryRequests::MulticastAllocations> mcast_allocs =
       requests.OrderedMulticastAllocations();
+  std::vector<CollectiveMemoryRequests::PeerAllocations> peer_allocs =
+      requests.OrderedPeerAllocations();
 
   // Short-circuit if we have nothing to allocate.
-  if (sym_allocs.empty() && mcast_allocs.empty()) {
+  if (sym_allocs.empty() && mcast_allocs.empty() && peer_allocs.empty()) {
     return CollectiveMemory(requests.buffers(), /*sym_memories=*/{},
-                            /*mcast_memories=*/{});
+                            /*mcast_memories=*/{}, /*peer_memories=*/{});
   }
 
   XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
       " Acquire collective memory for global device id %v: run_id=%v "
-      "symmetric=%d multicast=%d",
+      "symmetric=%d multicast=%d peer=%d",
       params.global_device_id, params.run_id, sym_allocs.size(),
-      mcast_allocs.size());
+      mcast_allocs.size(), peer_allocs.size());
   absl::Time start = absl::Now();
 
   for (size_t i = 0; i < sym_allocs.size(); ++i) {
@@ -388,10 +529,20 @@ absl::StatusOr<CollectiveMemory> AcquireCollectiveMemory(
         absl::StrJoin(r.allocations, ", "));
   }
 
+  for (size_t i = 0; i < peer_allocs.size(); ++i) {
+    const CollectiveMemoryRequests::PeerAllocations& r = peer_allocs[i];
+    XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
+        "    peer memory #%d (global device %v): id=%d; clique=%v; "
+        "allocations=[%s]",
+        i, params.global_device_id, r.id, r.key,
+        absl::StrJoin(r.allocations, ", "));
+  }
+
   tsl::profiler::TraceMe trace([&] {
-    return tsl::profiler::TraceMeEncode(
-        "AcquireCollectiveMemory", {{"sym_allocs", sym_allocs.size()},
-                                    {"mcast_allocs", mcast_allocs.size()}});
+    return tsl::profiler::TraceMeEncode("AcquireCollectiveMemory",
+                                        {{"sym_allocs", sym_allocs.size()},
+                                         {"mcast_allocs", mcast_allocs.size()},
+                                         {"peer_allocs", peer_allocs.size()}});
   });
 
   ASSIGN_OR_RETURN(
@@ -402,14 +553,19 @@ absl::StatusOr<CollectiveMemory> AcquireCollectiveMemory(
                    AcquireMulticastMemory(params, cliques, requests.buffers(),
                                           mcast_allocs));
 
+  ASSIGN_OR_RETURN(
+      auto peer_memories,
+      AcquirePeerMemory(params, cliques, requests.buffers(), peer_allocs));
+
   XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
       "Acquired collective memory in %s for global device id %v; "
-      "run_id=%v symmetric=%d multicast=%d",
+      "run_id=%v symmetric=%d multicast=%d peer=%d",
       absl::FormatDuration(absl::Now() - start), params.global_device_id,
-      params.run_id, sym_allocs.size(), mcast_allocs.size());
+      params.run_id, sym_allocs.size(), mcast_allocs.size(),
+      peer_allocs.size());
 
   return CollectiveMemory(requests.buffers(), std::move(sym_memories),
-                          std::move(mcast_memories));
+                          std::move(mcast_memories), std::move(peer_memories));
 }
 
 }  // namespace xla::gpu

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -2936,6 +2936,7 @@ xla_test(
         "//xla/backends/gpu/runtime:collective_memory",
         "//xla/backends/gpu/runtime:collective_memory_requests",
         "//xla/backends/gpu/runtime:collective_params",
+        "//xla/core/collectives:rank_id",
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:reduction_kind",
         "//xla/ffi",

--- a/xla/tests/collective_ops_ffi_kernels.h
+++ b/xla/tests/collective_ops_ffi_kernels.h
@@ -55,6 +55,16 @@ struct MultimemAllReduce {
                       size_t>;                                   // count
 };
 
+// Trivial peer all-reduce for U32 data type without any barriers,
+// the kernel assumes that data is ready when it is launched.
+struct Peer2AllReduce {
+  using KernelType =
+      se::TypedKernel<stream_executor::DeviceAddress<uint32_t>,  // src0
+                      stream_executor::DeviceAddress<uint32_t>,  // src1
+                      stream_executor::DeviceAddress<uint32_t>,  // dst
+                      size_t>;                                   // count
+};
+
 }  // namespace xla::gpu
 
 #endif  // XLA_TESTS_COLLECTIVE_OPS_FFI_KERNELS_H_

--- a/xla/tests/collective_ops_ffi_test.cc
+++ b/xla/tests/collective_ops_ffi_test.cc
@@ -28,11 +28,13 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/ffi.h"
 #include "xla/backends/gpu/runtime/collective_clique_requests.h"
+#include "xla/backends/gpu/runtime/collective_cliques.h"
 #include "xla/backends/gpu/runtime/collective_execution.h"
 #include "xla/backends/gpu/runtime/collective_memory.h"
 #include "xla/backends/gpu/runtime/collective_memory_requests.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/core/collectives/communicator.h"
+#include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/ffi.h"
@@ -132,7 +134,7 @@ static absl::Status PrepareDeviceAllReduce(
 }
 
 // This is a prepare handler for device-initiated collective operation which
-// uses collective multimem to access peer devics.
+// uses collective multimem to access peer devices.
 static absl::Status PrepareMulticastAllReduce(
     ffi::BufferR0<U32> src, ffi::Result<ffi::BufferR0<U32>> dst,
     const CollectiveParams* collective_params,
@@ -154,6 +156,29 @@ static absl::Status PrepareMulticastAllReduce(
   // underlying collective library.
   TF_RETURN_IF_ERROR(memory_requests->RequestMulticastAddress(
       clique_key, src.device_memory()));
+
+  return absl::OkStatus();
+}
+
+// This is a prepare handler for device-initiated collective operation which
+// uses collective peer memory to access peer devices.
+static absl::Status PreparePeerAllReduce(
+    ffi::BufferR0<U32> src, ffi::Result<ffi::BufferR0<U32>> dst,
+    const CollectiveParams* collective_params,
+    CollectiveMemoryRequests* memory_requests) {
+  TF_RET_CHECK(collective_params && memory_requests);
+
+  // Request a clique that covers all devices (this test runs on 2 gpus).
+  TF_ASSIGN_OR_RETURN(
+      GpuCliqueKey clique_key,
+      GetGpuCliqueKey(
+          *collective_params, {AllDevices()},
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
+          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+
+  // Request src buffer from all peers in the given clique.
+  TF_RETURN_IF_ERROR(
+      memory_requests->RequestPeerAddress(clique_key, src.device_memory()));
 
   return absl::OkStatus();
 }
@@ -246,9 +271,8 @@ static absl::Status MulticastAllReduce(
           CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
           AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
 
-  auto rank = clique_key.rank(collective_params->global_device_id);
-  auto [src_mmem, src_offset] = collective_memory->FindMultimemAddress(
-      clique_key, *rank, src.device_memory());
+  auto [src_mmem, src_offset] =
+      collective_memory->FindMultimemAddress(clique_key, src.device_memory());
 
   TF_RET_CHECK(src_mmem != nullptr);
 
@@ -275,6 +299,53 @@ static absl::Status MulticastAllReduce(
 
   TF_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream, src_addr,
                                    dst->device_memory(), src_offset,
+                                   src.element_count()));
+
+  // Wait for kernel to finish before destructor will unload it.
+  return stream->BlockHostUntilDone();
+}
+
+// FFI handler that launches device kernel that does all-reduce using peer
+// memory access.
+static absl::Status PeerAllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
+                                  ffi::Result<ffi::BufferR0<U32>> dst,
+                                  const CollectiveParams* collective_params,
+                                  const CollectiveMemory* collective_memory) {
+  TF_RET_CHECK(collective_params && collective_memory);
+
+  TF_ASSIGN_OR_RETURN(
+      GpuCliqueKey clique_key,
+      GetGpuCliqueKey(
+          *collective_params, {AllDevices()},
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
+          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+
+  auto src0 = collective_memory->FindPeerAddress(clique_key, RankId(0),
+                                                 src.device_memory());
+  auto src1 = collective_memory->FindPeerAddress(clique_key, RankId(1),
+                                                 src.device_memory());
+
+  TF_RET_CHECK(src0 && src1);
+
+  // Load custom kernel that does device-initiated collectives.
+  TF_ASSIGN_OR_RETURN(
+      auto kernel,
+      se::gpu::GpuKernelRegistry::GetGlobalRegistry()
+          .LoadKernel<Peer2AllReduce>(collective_params->executor));
+
+  // Because we launch a trivial kernel we use a device-side rendezvous to make
+  // sure that both devices will execute the kernel together after inputs become
+  // ready on both devices. Any real kernel must use device-side barriers.
+  static constexpr int32_t kKey = 0;
+  const int32_t* key = &kKey;
+  TF_RETURN_IF_ERROR(Rendezvous<const int32_t*>(
+      "PeerAllReduce", key, 2, absl::Seconds(1), absl::Seconds(5)));
+
+  se::BlockDim block_dims(1);
+  se::ThreadDim thread_dims(8);
+
+  TF_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream, *src0,
+                                   *src1, dst->device_memory(),
                                    src.element_count()));
 
   // Wait for kernel to finish before destructor will unload it.
@@ -326,6 +397,21 @@ XLA_FFI_DEFINE_HANDLER(kMulticastAllReduce, MulticastAllReduce,
                            .Ctx<ffi::CollectiveParams>()
                            .Ctx<ffi::CollectiveMemory>());
 
+XLA_FFI_DEFINE_HANDLER(kPreparePeerAllReduce, PreparePeerAllReduce,
+                       ffi::Ffi::BindPrepare()
+                           .Arg<ffi::BufferR0<U32>>()  // src
+                           .Ret<ffi::BufferR0<U32>>()  // dst
+                           .Ctx<ffi::CollectiveParams>()
+                           .Ctx<ffi::CollectiveMemoryRequests>());
+
+XLA_FFI_DEFINE_HANDLER(kPeerAllReduce, PeerAllReduce,
+                       ffi::Ffi::Bind()
+                           .Ctx<ffi::Stream>()
+                           .Arg<ffi::BufferR0<U32>>()  // src
+                           .Ret<ffi::BufferR0<U32>>()  // dst
+                           .Ctx<ffi::CollectiveParams>()
+                           .Ctx<ffi::CollectiveMemory>());
+
 // Register handler bundle for the custom all-reduce operation.
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "__xla_test$$all_reduce", "gpu",
                          XLA_FFI_Handler_Bundle{
@@ -355,6 +441,17 @@ XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "__xla_test$$multimem_all_reduce",
                              /*prepare=*/kPrepareMulticastAllReduce,
                              /*initialize=*/nullptr,
                              /*execute=*/kMulticastAllReduce,
+                         });
+
+// Register handler bundle for the custom all-reduce operation with
+// device-initiated collective kernels that use peer addresses.
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "__xla_test$$peer_all_reduce",
+                         "gpu",
+                         XLA_FFI_Handler_Bundle{
+                             /*instantiate=*/nullptr,
+                             /*prepare=*/kPreparePeerAllReduce,
+                             /*initialize=*/nullptr,
+                             /*execute=*/kPeerAllReduce,
                          });
 
 TEST_F(CollectiveOpsTestFFI, AllReduce) {
@@ -470,6 +567,42 @@ TEST_F(CollectiveOpsTestFFI, MulticastAllReduce) {
   ASSERT_EQ(results.size(), kNumReplicas);
 
   const uint32_t expected = 2;
+  for (int i = 0; i < kNumReplicas; ++i) {
+    LiteralTestUtil::ExpectR0Equal<uint32_t>(expected, results[i]);
+  }
+}
+
+TEST_F(CollectiveOpsTestFFI, PeerAllReduce) {
+  if (device_count() < kNumReplicas) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas << " devices ("
+                 << device_count() << " available)";
+  }
+
+  constexpr absl::string_view hlo_string = R"(
+      HloModule m, replica_count=2
+
+      ENTRY test_computation {
+        id = u32[] replica-id()
+        ROOT all-reduce = u32[] custom-call(id),
+          custom_call_target="__xla_test$$peer_all_reduce",
+          api_version=API_VERSION_TYPED_FFI
+      }
+    )";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(hlo_string, kNumReplicas));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/std::vector<Literal*>(),
+                        /*run_hlo_passes=*/false));
+
+  absl::Span<const Literal> results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  // sum [0, num_devices)
+  const uint32_t expected = kNumReplicas * (kNumReplicas - 1) / 2;
   for (int i = 0; i < kNumReplicas; ++i) {
     LiteralTestUtil::ExpectR0Equal<uint32_t>(expected, results[i]);
   }


### PR DESCRIPTION
For consistency with symmetric and mutimem collective memory add APIs to acquire peer addresses.