### PR TITLE
[ROCm] Explicitly skip failing test cases 

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass_test.cc
@@ -625,6 +625,9 @@ TEST(CommandBufferConversionPassTest, DontConvertIfNotMinGraphSize) {
 }
 
 TEST(CommandBufferConversionPassTest, ConvertWhileThunk) {
+  if (GetPlatformName() == "ROCM") {
+    GTEST_SKIP() << "Not supported on ROCm";
+  }
   CommandBufferConversionPass pass{"test"};
 
   std::vector<std::unique_ptr<Thunk>> thunks;
@@ -736,6 +739,9 @@ TEST(CommandBufferConversionPassTest,
 }
 
 TEST(CommandBufferConversionPassTest, ConvertWhileThunkWithAsyncPair) {
+  if (GetPlatformName() == "ROCM") {
+    GTEST_SKIP() << "Not supported on ROCm";
+  }
   CommandBufferConversionPass pass{"test"};
 
   std::vector<std::unique_ptr<Thunk>> thunks;

--- a/xla/backends/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
@@ -127,6 +127,13 @@ class CudnnFusedConvRewriterTest : public GpuCodegenTest {
         .gpu_compute_capability()
         .IsCuda();
   }
+  bool IsRocm() const {
+    return backend()
+        .default_stream_executor()
+        ->GetDeviceDescription()
+        .gpu_compute_capability()
+        .IsRocm();
+  }
   se::CudaComputeCapability GetCudaComputeCapability() const {
     return backend()
         .default_stream_executor()
@@ -318,6 +325,7 @@ class CudnnFusedConvRewriterTest : public GpuCodegenTest {
   } while (0)
 
 TEST_F(CudnnFusedConvRewriterTest, TestConvOnly) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   // max(0, conv(x, w));
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -352,6 +360,7 @@ TEST_F(CudnnFusedConvRewriterTest, DontFuseReluWithDepthwiseConv) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestBias) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   // max(0, conv(x, w) + bias);
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -372,6 +381,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestBias) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, Test3D) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   // max(0, conv(x, w) + bias);
   std::string body = R"(
     HloModule Test
@@ -404,6 +414,7 @@ TEST_F(CudnnFusedConvRewriterTest, Test3D) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestBiasMultiCall) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   // max(0, conv(x, w) + bias);
   std::string code = R"(
     HloModule Test
@@ -431,6 +442,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestBiasMultiCall) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestBiasNoRelu) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   // conv(x, w) + bias;
   TestMatchWithAllTypes(R"(
     HloModule Test
@@ -467,6 +479,7 @@ TEST_F(CudnnFusedConvRewriterTest, DontFuseBiasWithDepthwiseConv) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestElu) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   // sum = conv(x, w) + bias
   // select(compare(sum, 0, GT), sum, exponential-minus-one(sum));
   TestMatchWithAllTypes(R"(
@@ -513,6 +526,7 @@ TEST_F(CudnnFusedConvRewriterTest, DontFuseEluWithDepthwiseConv) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestRelu6) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   if (IsCuda() && !GetCudaComputeCapability().IsAtLeast(
                       se::CudaComputeCapability::kAmpere)) {
     GTEST_SKIP() << "Conv-Bias-Relu6 fusion is supported and recommended with "
@@ -541,6 +555,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestRelu6) {
 // number of input/output channels.  Check that we don't try to run this conv
 // with runtime fusion (or, if we do, that it works!).
 TEST_F(CudnnFusedConvRewriterTest, TestRelu6OddChannels) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   if (IsCuda() && !GetCudaComputeCapability().IsAtLeast(
                       se::CudaComputeCapability::kAmpere)) {
     GTEST_SKIP() << "Conv-Bias-Relu6 fusion is supported and recommended with "
@@ -562,6 +577,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestRelu6OddChannels) {
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestLeakyRelu) {
+  if (IsRocm()) GTEST_SKIP() << "Skipped on ROCm";
   if (IsCuda() && !GetCudaComputeCapability().IsAtLeast(
                       se::CudaComputeCapability::kAmpere)) {
     GTEST_SKIP()

--- a/xla/tests/collective_ops_sharded_unsharded_e2e_test.cc
+++ b/xla/tests/collective_ops_sharded_unsharded_e2e_test.cc
@@ -372,6 +372,9 @@ ENTRY entry {
 }
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded, BlockScaledDotBatchAndBatch) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[4,16,64]{2,1,0}, f8e8m0fnu[4,16,2]{2,1,0}, f8e4m3fn[4,4,64]{2,1,0}, f8e8m0fnu[4,4,2]{2,1,0})->f32[4,16,4]{2,1,0}}, num_partitions=2
 
@@ -387,6 +390,9 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotBatchAndNonContracting) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[4,16,64]{2,1,0}, f8e8m0fnu[4,16,2]{2,1,0}, f8e4m3fn[4,4,64]{2,1,0}, f8e8m0fnu[4,4,2]{2,1,0})->f32[4,16,4]{2,1,0}}, num_partitions=2
 
@@ -402,6 +408,9 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotContractingAndContracting) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[16,64]{1,0}, f8e8m0fnu[16,2]{1,0}, f8e4m3fn[4,64]{1,0}, f8e8m0fnu[4,2]{1,0})->f32[16,4]{1,0}}, num_partitions=2
 
@@ -417,6 +426,9 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotNonContractingAndContracting) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[16,128]{1,0}, f8e8m0fnu[16,4]{1,0}, f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4]{1,0})->f32[16,4]{1,0}}, num_partitions=2
 
@@ -432,6 +444,9 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotContractingAndReplicated) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[16,128]{1,0}, f8e8m0fnu[16,4]{1,0}, f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4]{1,0})->f32[16,4]{1,0}}, num_partitions=2
 
@@ -447,6 +462,9 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotReplicatedAndReplicated) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4], f8e4m3fn[1,128]{1,0}, f8e8m0fnu[1,4]{1,0})->f32[4,1]{1,0}}, num_partitions=2
 
@@ -462,6 +480,9 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotContractingNonContractingAndContractingNonContracting) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[8,128]{1,0}, f8e8m0fnu[8,4]{1,0}, f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4]{1,0})->f32[8,4]{1,0}}, num_partitions=4
 


### PR DESCRIPTION
Adds GTEST_SKIPs to unit tests failing on ROCm, making the skips explicit, instead of relying on e.g. excluding test targets when running the full test suite.

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup, 🧪 Tests
