### PR TITLE
[ROCm] Add option to disable automatic solib and rocm rpaths adding to the final library

### DIFF
--- a/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
@@ -382,6 +382,10 @@ def _impl(ctx):
         provides = ["profile"],
     )
 
+    # Targets can set features = ["no_solib_rpaths"] to suppress the
+    # automatic solib RPATH entries and rely on their own linkopts instead.
+    no_solib_rpaths_feature = feature(name = "no_solib_rpaths")
+
     runtime_library_search_directories_feature = feature(
         name = "runtime_library_search_directories",
         flag_sets = [
@@ -409,7 +413,10 @@ def _impl(ctx):
                     ),
                 ],
                 with_features = [
-                    with_feature_set(features = ["static_link_cpp_runtimes"]),
+                    with_feature_set(
+                        features = ["static_link_cpp_runtimes"],
+                        not_features = ["no_solib_rpaths"],
+                    ),
                 ],
             ),
             flag_set(
@@ -430,7 +437,7 @@ def _impl(ctx):
                 ],
                 with_features = [
                     with_feature_set(
-                        not_features = ["static_link_cpp_runtimes"],
+                        not_features = ["static_link_cpp_runtimes", "no_solib_rpaths"],
                     ),
                 ],
             ),
@@ -1084,6 +1091,7 @@ def _impl(ctx):
         shared_flag_feature,
         linkstamps_feature,
         output_execpath_flags_feature,
+        no_solib_rpaths_feature,
         runtime_library_search_directories_feature,
         library_search_directories_feature,
         archiver_flags_feature,


### PR DESCRIPTION
📝 Summary of Changes
Add no_solib toolchain feature. 

🎯 Justification
When used no solib rpaths are added to that specific target.
This is required for building the rocm jax plugins while setting custom rpaths for the wheels.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
