### PR TITLE
[ROCm] Enable FP8 Triton GEMM support for ROCm GPUs

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc
@@ -4544,9 +4544,6 @@ INSTANTIATE_TEST_SUITE_P(
     DotUnsetAlgorithmEmitterTest::ParamToString);
 
 TEST_F(TritonEmitterTest, ScaledDotIsSupportedByReferencePlatform) {
-  if (GpuComputeCapability().IsRocm()) {
-    GTEST_SKIP() << "Ignore scaled dot test on ROCM.";
-  }
   constexpr absl::string_view kHloText = R"(
     HloModule ScaledDotIsSupportedByReferencePlatform
 

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -68,10 +68,25 @@ CodegenDecision IsTritonSupportedDataType(
         return CodegenDecision::Allow();
       }
       if (gpu_version.IsRocm()) {
-        return CodegenDecision::Forbid("F8E4M3FN is not supported on ROCm.");
+        if (gpu_version.rocm_compute_capability()->has_ocp_fp8_support()) {
+          return CodegenDecision::Allow();
+        }
+        return CodegenDecision::Forbid(
+            "F8E4M3FN/F8E5M2 requires OCP FP8 support on ROCm.");
       }
       return CodegenDecision::Forbid(
-          "Unsupported GPU architecture for F8E4M3FN.");
+          "Unsupported GPU architecture for F8E4M3FN/F8E5M2.");
+    case F8E4M3FNUZ:
+    case F8E5M2FNUZ:
+      if (gpu_version.IsRocm()) {
+        if (gpu_version.rocm_compute_capability()->has_nanoo_fp8_support()) {
+          return CodegenDecision::Allow();
+        }
+        return CodegenDecision::Forbid(
+            "F8E4M3FNUZ/F8E5M2FNUZ requires NANOO FP8 support on ROCm.");
+      }
+      return CodegenDecision::Forbid(
+          "F8E4M3FNUZ/F8E5M2FNUZ is only supported on ROCm.");
     case BF16:
       if (gpu_version.IsCuda()) {
         return CodegenDecision::Allow();
@@ -399,6 +414,11 @@ CodegenDecision AreTypesSupportedByAlgUnsetDot(
         cuda_cc && !cuda_cc->IsAtLeastHopper()) {
       return CodegenDecision::Forbid(
           "Dot operation for F8E4M3FN is not supported before Hopper.");
+    }
+    if (auto* rocm_cc = gpu_version.rocm_compute_capability();
+        rocm_cc && !rocm_cc->has_ocp_fp8_support()) {
+      return CodegenDecision::Forbid(
+          "Dot operation for F8E4M3FN requires OCP FP8 support on ROCm.");
     }
   }
 

--- a/xla/backends/gpu/codegen/triton/support_legacy.cc
+++ b/xla/backends/gpu/codegen/triton/support_legacy.cc
@@ -68,13 +68,25 @@ bool IsTritonSupportedDotOutputType(
     case F32:
       return true;
     case F8E5M2:
-      if (auto ptr = gpu_version.cuda_compute_capability()) {
-        return ptr->IsAtLeastAmpere();
+      if (auto* cuda_cc = gpu_version.cuda_compute_capability()) {
+        return cuda_cc->IsAtLeastAmpere();
+      }
+      if (auto* rocm_cc = gpu_version.rocm_compute_capability()) {
+        return rocm_cc->has_ocp_fp8_support();
       }
       return false;
     case F8E4M3FN:
-      if (auto ptr = gpu_version.cuda_compute_capability()) {
-        return ptr->IsAtLeastHopper();
+      if (auto* cuda_cc = gpu_version.cuda_compute_capability()) {
+        return cuda_cc->IsAtLeastHopper();
+      }
+      if (auto* rocm_cc = gpu_version.rocm_compute_capability()) {
+        return rocm_cc->has_ocp_fp8_support();
+      }
+      return false;
+    case F8E4M3FNUZ:
+    case F8E5M2FNUZ:
+      if (auto* rocm_cc = gpu_version.rocm_compute_capability()) {
+        return rocm_cc->has_nanoo_fp8_support();
       }
       return false;
     case BF16:

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3153,6 +3153,7 @@ xla_cc_test(
         "//xla/service:hlo_verifier",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor/cuda:cuda_compute_capability",
+        "//xla/stream_executor/rocm:rocm_compute_capability",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status:statusor",


### PR DESCRIPTION
This allows Triton-generated FP8 matrix multiplications to run natively on supported AMD GPUs (e.g., MI300/MI355 series). This can be enabled with --xla_gpu_enable_triton_gemm=true. Also consider using --xla_gpu_exhaustive_tiling_search=true for best performance.

Changes:
- Triton codegen support (support.cc, support_legacy.cc): Allow F8E4M3FN and F8E5M2 (OCP FP8) on GPUs with OCP support (e.g., gfx950/MI350), and F8E4M3FNUZ and F8E5M2FNUZ (NANOO FP8) on GPUs with NANOO support (e.g., gfx942/MI300).

- Float normalization: preserve native FP8 types inside Triton fused computations on capable ROCm hardware, instead of normalizing them to F16. Refactor the kDot handling to check for Triton fusion context first, then branch on platform.

- Add parameterized ROCm FP8 dot conversion tests in gpu_float_support_test.cc covering both standalone and Triton-fused contexts, for both GPU generations and both FP8 families.

- Enable the ScaledDotIsSupportedByReferencePlatform test on ROCm (fusion_emitter_device_test.cc) and enable the Fp8Normalization end-to-end test to run on ROCm (gpu_compiler_test.cc).