### PR TITLE
[xla:gpu] Add Walk API for walking commands and thunks sequences

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -92,7 +92,9 @@ cc_library(
         "//xla/service:buffer_assignment",
         "//xla/stream_executor:command_buffer",
         "//xla/stream_executor:platform",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
@@ -127,6 +129,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
@@ -215,6 +218,7 @@ cc_library(
         "//xla/stream_executor/gpu:tma_metadata",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:core_headers",
@@ -2871,6 +2875,7 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/lib/gtl:int_type",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
@@ -2907,8 +2912,8 @@ cc_library(
 )
 
 xla_cc_test(
-    name = "for_all_thunks_test",
-    srcs = ["for_all_thunks_test.cc"],
+    name = "thunk_walk_test",
+    srcs = ["thunk_walk_test.cc"],
     tags = ["gpu"],
     deps = [
         ":command_buffer_thunk",

--- a/xla/backends/gpu/runtime/collective_group_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_group_thunk.cc
@@ -34,8 +34,8 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream.h"
-#include "tsl/platform/casts.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "tsl/platform/casts.h"
 
 namespace xla {
 namespace gpu {
@@ -77,18 +77,14 @@ absl::Status CollectiveGroupThunk::ExecuteOnStream(
 
   // Gather the set of all communicators. There should be only one.
   absl::flat_hash_set<Communicator*> communicator_set;
-  absl::Status s;
-  ForAllThunks([&params, &s, &communicator_set](const Thunk* thunk) {
-    absl::StatusOr<std::vector<Communicator*>> communicators =
-        thunk->GetCommunicators(params);
-    if (!communicators.ok()) {
-      s = communicators.status();
-      return;
-    }
-    for (Communicator* comm : *communicators) {
+  RETURN_IF_ERROR(Walk([&](const Thunk* thunk) -> absl::Status {
+    ASSIGN_OR_RETURN(auto communicators, thunk->GetCommunicators(params));
+    for (Communicator* comm : communicators) {
       communicator_set.insert(comm);
     }
-  });
+    return absl::OkStatus();
+  }));
+
   if (communicator_set.empty()) {
     return absl::InvalidArgumentError("No communicators in NCCL group");
   }
@@ -115,20 +111,12 @@ absl::Status CollectiveGroupThunk::ExecuteOnStream(
   return absl::OkStatus();
 }
 
-void CollectiveGroupThunk::ForAllThunks(
-    absl::FunctionRef<void(const Thunk*)> fn) const {
-  fn(this);
+absl::Status CollectiveGroupThunk::WalkNested(
+    absl::FunctionRef<absl::Status(Thunk*)> callback) {
   for (const std::unique_ptr<Thunk>& thunk : thunks_) {
-    thunk->ForAllThunks(fn);
+    RETURN_IF_ERROR(thunk->Walk(callback));
   }
-}
-
-void CollectiveGroupThunk::ForAllThunksMutable(
-    absl::FunctionRef<void(Thunk*)> fn) {
-  fn(this);
-  for (const std::unique_ptr<Thunk>& thunk : thunks_) {
-    thunk->ForAllThunksMutable(fn);
-  }
+  return absl::OkStatus();
 }
 
 absl::Status CollectiveGroupThunk::TransformAllNestedThunks(

--- a/xla/backends/gpu/runtime/collective_group_thunk.h
+++ b/xla/backends/gpu/runtime/collective_group_thunk.h
@@ -44,8 +44,10 @@ class CollectiveGroupThunk : public Thunk {
   absl::Status Prepare(const PrepareParams& params) override;
   absl::Status ExecuteOnStream(const Thunk::ExecuteParams& params) override;
   absl::Status Initialize(const InitializeParams& params) override;
-  void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const override;
-  void ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) override;
+
+  absl::Status WalkNested(
+      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
+
   absl::Status TransformAllNestedThunks(
       absl::FunctionRef<
           absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -20,10 +20,13 @@ limitations under the License.
 #include <memory>
 #include <optional>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/functional/function_ref.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -36,6 +39,7 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/platform.h"
+#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -247,6 +251,26 @@ class Command {
 
   virtual std::string ToString() const { return CommandTypeString(cmd_type_); }
 
+  // Type predicate for `Walk` callback.
+  template <typename F, typename Arg>
+  using Walker = std::enable_if_t<std::is_invocable_v<F, Arg> ||
+                                  std::is_invocable_r_v<absl::Status, F, Arg>>;
+
+  // Recursively walks all the commands nested inside *this one and calls
+  // the user provided callback on every command. Always starts traversal with
+  // *this.
+  template <typename F, Walker<F, Command*>* = nullptr>
+  std::invoke_result_t<F, Command*> Walk(F&& callback);
+  template <typename F, Walker<F, const Command*>* = nullptr>
+  std::invoke_result_t<F, const Command*> Walk(F&& callback) const;
+
+ protected:
+  // Walks all nested commands and calls `callback` for them.
+  virtual absl::Status WalkNested(
+      absl::FunctionRef<absl::Status(Command*)> callback) {
+    return absl::OkStatus();
+  }
+
  private:
   std::string profile_annotation_;
   CommandType cmd_type_;
@@ -269,17 +293,39 @@ inline bool IsCollectiveCommand(const Command& cmd) {
 }
 
 //===----------------------------------------------------------------------===//
+// Command templates implementation.
+//===----------------------------------------------------------------------===//
+
+template <typename F, Command::Walker<F, Command*>*>
+std::invoke_result_t<F, Command*> Command::Walk(F&& callback) {
+  if constexpr (std::is_void_v<std::invoke_result_t<F, Command*>>) {
+    Walk([f = std::forward<F>(callback)](Command* command) {
+      return (f(command), absl::OkStatus());
+    }).IgnoreError();  // Error can never happen here.
+  } else {
+    RETURN_IF_ERROR(callback(this));
+    return WalkNested(callback);
+  }
+}
+
+template <typename F, Command::Walker<F, const Command*>*>
+std::invoke_result_t<F, const Command*> Command::Walk(F&& callback) const {
+  return const_cast<Command*>(this)->Walk(  // NOLINT
+      std::forward<F>(callback));
+}
+
+//===----------------------------------------------------------------------===//
 // Asynchronous commands
 //===----------------------------------------------------------------------===//
 
-// A base class for a command that starts an asyncrhonous execution.
+// A base class for a command that starts an asynchronous execution.
 class AsyncStartCommand : public Command {
  public:
   using Command::Command;
 
-  // At run time async command might behave like a syncrhonous one, i.e.
+  // At run time async command might behave like a synchronous one, i.e.
   // some collective operations if they can't be overlapped with compute
-  // operations executed like they have syncrhonous execution semantics.
+  // operations executed like they have synchronous execution semantics.
   virtual bool IsAsync() const = 0;
 };
 
@@ -316,6 +362,21 @@ class CommandSequence : public std::vector<std::unique_ptr<Command>> {
       result += cmd->ToString() + "\n";
     }
     return result;
+  }
+
+  absl::Status Walk(
+      absl::FunctionRef<absl::Status(const Command*)> callback) const {
+    for (const std::unique_ptr<Command>& cmd : *this) {
+      RETURN_IF_ERROR(cmd->Walk(callback));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::Status Walk(absl::FunctionRef<absl::Status(Command*)> callback) {
+    for (std::unique_ptr<Command>& cmd : *this) {
+      RETURN_IF_ERROR(cmd->Walk(callback));
+    }
+    return absl::OkStatus();
   }
 };
 

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -379,20 +379,12 @@ void CommandBufferThunk::EvictCommandBuffers() {
   }
 }
 
-void CommandBufferThunk::ForAllThunks(
-    absl::FunctionRef<void(const Thunk*)> fn) const {
-  fn(this);
+absl::Status CommandBufferThunk::WalkNested(
+    absl::FunctionRef<absl::Status(Thunk*)> callback) {
   if (thunks_ != nullptr) {
-    thunks_->ForAllThunks(fn);
+    TF_RETURN_IF_ERROR(thunks_->Walk(callback));
   }
-}
-
-void CommandBufferThunk::ForAllThunksMutable(
-    absl::FunctionRef<void(Thunk*)> fn) {
-  fn(this);
-  if (thunks_ != nullptr) {
-    thunks_->ForAllThunksMutable(fn);
-  }
+  return absl::OkStatus();
 }
 
 std::string CommandBufferThunk::ToString(int indent) const {

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -56,8 +56,8 @@ class CommandBufferThunk : public Thunk {
   absl::StatusOr<se::DeviceAddressBase> GetCommandBufferAllocationAddress(
       const ExecuteParams& params, int64_t index);
 
-  void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const override;
-  void ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) override;
+  absl::Status WalkNested(
+      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
 
   std::string ToString(int indent) const override;
 

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/base/macros.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/node_hash_map.h"
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
@@ -163,6 +164,16 @@ class CommandExecutor {
   // Renders the execution graph using default renderer. Returns url of the
   // rendered graph, or an error if rendering failed.
   absl::StatusOr<std::string> RenderExecutionGraph();
+
+  // Recursively traverses all commands in the executor and nested executors.
+  absl::Status Walk(
+      absl::FunctionRef<absl::Status(const Command*)> callback) const {
+    return commands_.Walk(callback);
+  }
+
+  absl::Status Walk(absl::FunctionRef<absl::Status(Command*)> callback) {
+    return commands_.Walk(callback);
+  }
 
  private:
   // We use index into the `commands_` vector as a command id.

--- a/xla/backends/gpu/runtime/conditional_thunk.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk.cc
@@ -155,19 +155,12 @@ absl::Status ConditionalThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-void ConditionalThunk::ForAllThunks(
-    absl::FunctionRef<void(const Thunk*)> fn) const {
-  fn(this);
+absl::Status ConditionalThunk::WalkNested(
+    absl::FunctionRef<absl::Status(Thunk*)> callback) {
   for (const std::unique_ptr<SequentialThunk>& branch_thunk : branch_thunks_) {
-    branch_thunk->ForAllThunks(fn);
+    TF_RETURN_IF_ERROR(branch_thunk->Walk(callback));
   }
-}
-
-void ConditionalThunk::ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) {
-  fn(this);
-  for (const std::unique_ptr<SequentialThunk>& branch_thunk : branch_thunks_) {
-    branch_thunk->ForAllThunksMutable(fn);
-  }
+  return absl::OkStatus();
 }
 
 absl::Status ConditionalThunk::TransformAllNestedThunks(

--- a/xla/backends/gpu/runtime/conditional_thunk.h
+++ b/xla/backends/gpu/runtime/conditional_thunk.h
@@ -70,8 +70,9 @@ class ConditionalThunk : public Thunk {
     return branch_index_buffer_index_;
   }
 
-  void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const override;
-  void ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) override;
+  absl::Status WalkNested(
+      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
+
   absl::Status TransformAllNestedThunks(
       absl::FunctionRef<
           absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk.cc
@@ -433,16 +433,9 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-void DynamicSliceThunk::ForAllThunks(
-    absl::FunctionRef<void(const Thunk*)> fn) const {
-  fn(this);
-  embedded_thunk_->ForAllThunks(fn);
-}
-
-void DynamicSliceThunk::ForAllThunksMutable(
-    absl::FunctionRef<void(Thunk*)> fn) {
-  fn(this);
-  embedded_thunk_->ForAllThunksMutable(fn);
+absl::Status DynamicSliceThunk::WalkNested(
+    absl::FunctionRef<absl::Status(Thunk*)> callback) {
+  return embedded_thunk_->Walk(callback);
 }
 
 absl::Status DynamicSliceThunk::TransformAllNestedThunks(

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk.h
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk.h
@@ -169,8 +169,9 @@ class DynamicSliceThunk : public Thunk {
     return offset_primitive_types_;
   }
 
-  void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const override;
-  void ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) override;
+  absl::Status WalkNested(
+      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
+
   absl::Status TransformAllNestedThunks(
       absl::FunctionRef<
           absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>

--- a/xla/backends/gpu/runtime/sequential_thunk.cc
+++ b/xla/backends/gpu/runtime/sequential_thunk.cc
@@ -124,19 +124,12 @@ absl::Status SequentialThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-void SequentialThunk::ForAllThunks(
-    absl::FunctionRef<void(const Thunk*)> fn) const {
-  fn(this);
+absl::Status SequentialThunk::WalkNested(
+    absl::FunctionRef<absl::Status(Thunk*)> callback) {
   for (const std::unique_ptr<Thunk>& thunk : thunks_) {
-    thunk->ForAllThunks(fn);
+    TF_RETURN_IF_ERROR(thunk->Walk(callback));
   }
-}
-
-void SequentialThunk::ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) {
-  fn(this);
-  for (const std::unique_ptr<Thunk>& thunk : thunks_) {
-    thunk->ForAllThunksMutable(fn);
-  }
+  return absl::OkStatus();
 }
 
 absl::Status SequentialThunk::TransformAllNestedThunks(

--- a/xla/backends/gpu/runtime/sequential_thunk.h
+++ b/xla/backends/gpu/runtime/sequential_thunk.h
@@ -45,8 +45,9 @@ class SequentialThunk : public Thunk {
   absl::Status Initialize(const InitializeParams& params) override;
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
 
-  void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const override;
-  void ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) override;
+  absl::Status WalkNested(
+      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
+
   absl::Status TransformAllNestedThunks(
       absl::FunctionRef<
           absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>

--- a/xla/backends/gpu/runtime/thunk.cc
+++ b/xla/backends/gpu/runtime/thunk.cc
@@ -593,14 +593,6 @@ bool Thunk::IsCollective() const {
   }
 }
 
-void Thunk::ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const {
-  fn(this);
-}
-
-void Thunk::ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) {
-  fn(this);
-}
-
 absl::StatusOr<ThunkProto> Thunk::ToProto() const {
   return absl::UnimplementedError(absl::StrFormat(
       "Proto serialization for thunk of type %s is not implemented",
@@ -617,7 +609,7 @@ ThunkMetadataProto Thunk::ToMetadataProto() const {
 ThunkMetadataListProto GetMetadataListProtoFromThunkGraph(
     const Thunk& root_thunk) {
   ThunkMetadataListProto metadata_list_proto;
-  root_thunk.ForAllThunks([&metadata_list_proto](const Thunk* thunk) {
+  root_thunk.Walk([&metadata_list_proto](const Thunk* thunk) {
     *metadata_list_proto.add_thunk_metadata() = thunk->ToMetadataProto();
   });
   return metadata_list_proto;

--- a/xla/backends/gpu/runtime/thunk_walk_test.cc
+++ b/xla/backends/gpu/runtime/thunk_walk_test.cc
@@ -39,11 +39,11 @@ namespace {
 using ::testing::IsSupersetOf;
 using ::testing::UnorderedElementsAre;
 
-// Invokes `ForAllThunks` on the `root` and returns a `vector` containing all
+// Invokes `Walk` on the `root` and returns a `vector` containing all
 // iterated `Thunks`.
-std::vector<const Thunk*> GetAllThunks(Thunk* root) {
+std::vector<const Thunk*> GetAllThunks(const Thunk* root) {
   std::vector<const Thunk*> thunks;
-  root->ForAllThunks([&](const Thunk* thunk) { thunks.push_back(thunk); });
+  root->Walk([&](const Thunk* thunk) { thunks.push_back(thunk); });
   return thunks;
 }
 
@@ -57,12 +57,12 @@ struct DummyThunk : public Thunk {
   absl::StatusOr<ThunkProto> ToProto() const override { return ThunkProto{}; }
 };
 
-TEST(ForAllThunksTest, SingleThunk) {
+TEST(ThunkWalkTest, SingleThunk) {
   DummyThunk thunk;
   EXPECT_THAT(GetAllThunks(&thunk), UnorderedElementsAre(&thunk));
 }
 
-TEST(ForAllThunksTest, DynamicSliceThunk) {
+TEST(ThunkWalkTest, DynamicSliceThunk) {
   auto thunk = std::make_unique<DummyThunk>();
   Thunk* thunk_ptr = thunk.get();
 
@@ -78,7 +78,7 @@ TEST(ForAllThunksTest, DynamicSliceThunk) {
               IsSupersetOf<const Thunk*>({thunk_ptr, &dynamic_slice_thunk}));
 }
 
-TEST(ForAllThunksTest, CommandBufferThunk) {
+TEST(ThunkWalkTest, CommandBufferThunk) {
   auto thunk = std::make_unique<DummyThunk>();
   Thunk* thunk_ptr = thunk.get();
 
@@ -97,7 +97,7 @@ TEST(ForAllThunksTest, CommandBufferThunk) {
                                    sequential_thunk_ptr));
 }
 
-TEST(ForAllThunksTest, ConditionalThunk) {
+TEST(ThunkWalkTest, ConditionalThunk) {
   auto thunk = std::make_unique<DummyThunk>();
   Thunk* thunk_ptr = thunk.get();
 
@@ -122,7 +122,7 @@ TEST(ForAllThunksTest, ConditionalThunk) {
                                    &conditional_thunk));
 }
 
-TEST(ForAllThunksTest, WhileThunk) {
+TEST(ThunkWalkTest, WhileThunk) {
   auto condition_thunk = std::make_unique<DummyThunk>();
   Thunk* condition_thunk_ptr = condition_thunk.get();
 

--- a/xla/backends/gpu/runtime/while_thunk.cc
+++ b/xla/backends/gpu/runtime/while_thunk.cc
@@ -186,16 +186,10 @@ absl::Status WhileThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-void WhileThunk::ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const {
-  fn(this);
-  condition_thunk_sequence_->ForAllThunks(fn);
-  body_thunk_sequence_->ForAllThunks(fn);
-}
-
-void WhileThunk::ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) {
-  fn(this);
-  condition_thunk_sequence_->ForAllThunksMutable(fn);
-  body_thunk_sequence_->ForAllThunksMutable(fn);
+absl::Status WhileThunk::WalkNested(
+    absl::FunctionRef<absl::Status(Thunk*)> callback) {
+  TF_RETURN_IF_ERROR(condition_thunk_sequence_->Walk(callback));
+  return body_thunk_sequence_->Walk(callback);
 }
 
 absl::Status WhileThunk::TransformAllNestedThunks(

--- a/xla/backends/gpu/runtime/while_thunk.h
+++ b/xla/backends/gpu/runtime/while_thunk.h
@@ -92,8 +92,9 @@ class WhileThunk : public Thunk {
   static absl::StatusOr<int64_t> CurrentLoopIteration(
       const HloInstruction* while_instr);
 
-  void ForAllThunks(absl::FunctionRef<void(const Thunk*)> fn) const override;
-  void ForAllThunksMutable(absl::FunctionRef<void(Thunk*)> fn) override;
+  absl::Status WalkNested(
+      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
+
   absl::Status TransformAllNestedThunks(
       absl::FunctionRef<
           absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2657,7 +2657,7 @@ GpuCompiler::CompileToBackendResult(
   // Host executable has to be compiled the GPU compilation is done to
   // avoid a deadlock on the LLVM command line options lock. We can then load
   // it.
-  compile_module_results.executable->ForAllThunksMutable([&](Thunk* thunk) {
+  compile_module_results.executable->Walk([&](Thunk* thunk) {
     if (thunk->kind() == Thunk::Kind::kHostExecuteStart) {
       auto* host_execute_start_thunk =
           tsl::down_cast<HostExecuteStartThunk*>(thunk);

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -110,6 +110,7 @@ limitations under the License.
 #include "xla/stream_executor/sycl/sycl_platform_id.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
 #include "xla/util/split_proto/split_gpu_executable_writer.h"
@@ -117,7 +118,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -186,7 +186,7 @@ using ::tsl::profiler::ScopedAnnotation;
 static absl::flat_hash_set<ExecutionStreamId> GetExecutionStreamIds(
     const SequentialThunk& thunks) {
   absl::flat_hash_set<ExecutionStreamId> stream_ids;
-  thunks.ForAllThunks([&](const Thunk* thunk) {
+  thunks.Walk([&](const Thunk* thunk) {
     if (thunk->execution_stream_id() > 0) {
       stream_ids.insert(thunk->execution_stream_id());
     }


### PR DESCRIPTION
Unify `Walk` APIs between commands and thunks in preparation for merging them. Add a little bit of templates to support walking with early termination via returning `absl::Status`. 