### PR TITLE
[ROCm] Enable Triton MLIR lit tests

### DIFF
--- a/xla/backends/gpu/codegen/triton/ir/tests/BUILD
+++ b/xla/backends/gpu/codegen/triton/ir/tests/BUILD
@@ -1,4 +1,4 @@
-load("//xla:lit.bzl", "lit_test_suite")  # @unused
+load("//xla:lit.bzl", "lit_test_suite")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -13,14 +13,12 @@ package_group(
     ],
 )
 
-# copybara:uncomment_begin(triton-opt tool doesn't build in OSS)
-# lit_test_suite(
-#     name = "mlir_lit_tests",
-#     srcs = glob(["*.mlir"]),
-#     cfg = "//xla:lit.cfg.py",
-#     tools = [
-#         "@llvm-project//llvm:FileCheck",
-#         "//xla/service/gpu/tests:xla-opt",
-#     ],
-# )
-# copybara:uncomment_end
+lit_test_suite(
+    name = "mlir_lit_tests",
+    srcs = glob(["*.mlir"]),
+    cfg = "//xla:lit.cfg.py",
+    tools = [
+        "@llvm-project//llvm:FileCheck",
+        "//xla/service/gpu/tests:xla-opt",
+    ],
+)

--- a/xla/backends/gpu/codegen/triton/transforms/tests/BUILD
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/BUILD
@@ -1,4 +1,4 @@
-load("//xla:lit.bzl", "lit_test_suite")  # @unused
+load("//xla:lit.bzl", "lit_test_suite")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -13,15 +13,13 @@ package_group(
     ],
 )
 
-# copybara:uncomment_begin(triton-opt tool doesn't build in OSS)
-# lit_test_suite(
-#     name = "mlir_lit_tests",
-#     srcs = glob(["*.mlir"]),
-#     cfg = "//xla:lit.cfg.py",
-#     tools = [
-#         "@llvm-project//llvm:FileCheck",
-#         "//xla/service/gpu/tests:xla-opt",
-#         "@triton//:triton-opt",
-#     ],
-# )
-# copybara:uncomment_end
+lit_test_suite(
+    name = "mlir_lit_tests",
+    srcs = glob(["*.mlir"]),
+    cfg = "//xla:lit.cfg.py",
+    tools = [
+        "@llvm-project//llvm:FileCheck",
+        "//xla/service/gpu/tests:xla-opt",
+        "@triton//:triton-opt",
+    ],
+)


### PR DESCRIPTION
The xla-opt binary was enabled for OSS builds in PR #37157 (e4a4ef67160) and triton-opt is also available. With both tools now building, uncomment the lit_test_suite targets in:

  - xla/backends/gpu/codegen/triton/ir/tests/ (4 tests)
  - xla/backends/gpu/codegen/triton/transforms/tests/ (23 tests)
