### PR TITLE
fix: add recursion depth limit to HLO parser

### DIFF
--- a/xla/hlo/parser/BUILD
+++ b/xla/hlo/parser/BUILD
@@ -57,6 +57,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -31,6 +31,7 @@ limitations under the License.
 
 #include "absl/algorithm/container.h"
 #include "absl/base/casts.h"
+#include "absl/cleanup/cleanup.h"
 #include "absl/container/btree_map.h"
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
@@ -47,8 +48,8 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "absl/types/span.h"
-#include "Eigen/Core"
 #include "google/protobuf/descriptor.h"
+#include "Eigen/Core"
 #include "xla/array.h"
 #include "xla/comparison_util.h"
 #include "xla/hlo/ir/collective_op_group_mode.h"
@@ -730,6 +731,9 @@ class HloParserImpl : public HloParser {
   NameUniquer name_uniquer_{/*separator=*/"."};
 
   const HloParserOptions options_;
+
+  // Tracks recursion depth to prevent stack overflow from deeply nested input.
+  int current_recursion_depth_ = 0;
   StackFrameIndexProto stack_frame_index_proto_;
 };
 
@@ -1491,6 +1495,12 @@ bool HloParserImpl::ParseInstruction(HloComputation::Builder* builder,
 bool HloParserImpl::ParseInstructionRhs(HloComputation::Builder* builder,
                                         std::string name, LocTy name_loc,
                                         bool allow_attributes) {
+  ++current_recursion_depth_;
+  auto depth_guard = absl::MakeCleanup([this] { --current_recursion_depth_; });
+  if (current_recursion_depth_ > options_.max_recursion_depth()) {
+    return Error(lexer_.GetLoc(), "maximum recursion depth exceeded");
+  }
+
   Shape shape;
   HloOpcode opcode;
   std::optional<HloOpcode> async_wrapped_opcode;
@@ -5128,6 +5138,11 @@ bool HloParserImpl::SetValueInLiteral(LocTy loc, std::complex<double> value,
 // Similar to ParseLiteral(Literal* literal, const Shape& shape), but parse the
 // shape instead of accepting one as argument.
 bool HloParserImpl::ParseLiteral(Literal* literal) {
+  ++current_recursion_depth_;
+  auto depth_guard = absl::MakeCleanup([this] { --current_recursion_depth_; });
+  if (current_recursion_depth_ > options_.max_recursion_depth()) {
+    return Error(lexer_.GetLoc(), "maximum recursion depth exceeded");
+  }
   if (lexer_.GetKind() == TokKind::kLparen) {
     // Consume Lparen
     lexer_.Lex();
@@ -5168,6 +5183,11 @@ bool HloParserImpl::ParseLiteral(Literal* literal, const Shape& shape) {
 //  ::= /*empty*/
 //  ::= literal (',' literal)*
 bool HloParserImpl::ParseTupleLiteral(Literal* literal, const Shape& shape) {
+  ++current_recursion_depth_;
+  auto depth_guard = absl::MakeCleanup([this] { --current_recursion_depth_; });
+  if (current_recursion_depth_ > options_.max_recursion_depth()) {
+    return Error(lexer_.GetLoc(), "maximum recursion depth exceeded");
+  }
   if (!ParseToken(TokKind::kLparen, "expects '(' in front of tuple elements")) {
     return false;
   }
@@ -5404,6 +5424,12 @@ bool HloParserImpl::ParseDenseLiteral(Literal* literal, const Shape& shape) {
 bool HloParserImpl::ParseOperands(std::vector<HloInstruction*>* operands,
                                   HloComputation::Builder* builder) {
   CHECK(operands != nullptr);
+  ++current_recursion_depth_;
+  auto depth_guard = absl::MakeCleanup([this] { --current_recursion_depth_; });
+  if (current_recursion_depth_ > options_.max_recursion_depth()) {
+    return Error(lexer_.GetLoc(), "maximum recursion depth exceeded");
+  }
+
   if (!ParseToken(TokKind::kLparen,
                   "expects '(' at the beginning of operands")) {
     return false;
@@ -6500,6 +6526,11 @@ bool HloParserImpl::ParsePrecisionList(
 }
 
 bool HloParserImpl::ParseHloComputation(HloComputation** result) {
+  ++current_recursion_depth_;
+  auto depth_guard = absl::MakeCleanup([this] { --current_recursion_depth_; });
+  if (current_recursion_depth_ > options_.max_recursion_depth()) {
+    return Error(lexer_.GetLoc(), "maximum recursion depth exceeded");
+  }
   if (lexer_.GetKind() == TokKind::kLbrace) {
     // This means it is a nested computation.
     return ParseInstructionList(result, /*computation_name=*/"_");
@@ -7030,6 +7061,11 @@ bool HloParserImpl::ParseShape(Shape* result,
     ~DepthGuard() { (*d)--; }
   } guard(&shape_depth_);
 
+  ++current_recursion_depth_;
+  auto depth_guard = absl::MakeCleanup([this] { --current_recursion_depth_; });
+  if (current_recursion_depth_ > options_.max_recursion_depth()) {
+    return Error(lexer_.GetLoc(), "maximum recursion depth exceeded");
+  }
   if (lexer_.GetKind() == TokKind::kIdent && lexer_.GetStrVal() == "b" &&
       lexer_.LookAhead() == TokKind::kLparen) {  // Buffer shape
     lexer_.Lex();

--- a/xla/hlo/parser/hlo_parser.h
+++ b/xla/hlo/parser/hlo_parser.h
@@ -65,10 +65,22 @@ class HloParserOptions {
 
   bool keep_module_auto_layouts() const { return keep_module_auto_layouts_; }
 
+  // Maximum recursion depth for parsing nested operands. Protects against
+  // stack overflow from malicious or malformed input.
+  HloParserOptions& set_max_recursion_depth(int value) {
+    max_recursion_depth_ = value;
+    return *this;
+  }
+
+  int max_recursion_depth() const { return max_recursion_depth_; }
+
+  static constexpr int kDefaultMaxRecursionDepth = 500;
+
  private:
   bool fill_missing_layouts_ = true;
   bool fill_shortform_constants_with_random_values_ = true;
   bool keep_module_auto_layouts_ = false;
+  int max_recursion_depth_ = kDefaultMaxRecursionDepth;
 };
 
 // Given a string in the HloModule::ToString() format, parses the string and

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -6539,5 +6539,159 @@ ENTRY main {
   EXPECT_THAT(status.message(), HasSubstr("Unknown opcode: recv-update"));
 }
 
+TEST_F(HloParserTest, DeeplyNestedOperandsExceedsRecursionLimit) {
+  constexpr int kTestRecursionDepth = 10;
+  std::string deeply_nested = "f32[] ";
+
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested += "add(f32[] constant(0), f32[] ";
+  }
+  deeply_nested += "constant(0)";
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested += ")";
+  }
+  HloParserOptions options;
+  options.set_max_recursion_depth(kTestRecursionDepth);
+  auto result =
+      ParseAndReturnUnverifiedModule(deeply_nested, HloModuleConfig(), options);
+  EXPECT_NE(absl::OkStatus(), result.status());
+  ExpectHasSubstr(result.status().message(),
+                  "maximum recursion depth exceeded");
+}
+
+TEST_F(HloParserTest, DeeplyNestedShapesExceedsRecursionLimit) {
+  constexpr int kTestRecursionDepth = 10;
+  std::string deeply_nested = "";
+
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested += "(";
+  }
+  deeply_nested += "f32[]";
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested += ")";
+  }
+
+  // Create a minimal HLO string using this shape.
+  // ENTRY entry (p0: (((...f32[]...)))) -> (((...f32[]...))) { ... }
+  std::string hlo_string =
+      "HloModule test\nENTRY entry (p0: " + deeply_nested + ") -> " +
+      deeply_nested + " {\n  ROOT %p0 = " + deeply_nested + " parameter(0)\n}";
+
+  HloParserOptions options;
+  options.set_max_recursion_depth(kTestRecursionDepth);
+  auto result =
+      ParseAndReturnUnverifiedModule(hlo_string, HloModuleConfig(), options);
+  EXPECT_NE(absl::OkStatus(), result.status());
+  ExpectHasSubstr(result.status().message(),
+                  "maximum recursion depth exceeded");
+}
+
+TEST_F(HloParserTest, DeeplyNestedTupleLiteralsExceedsRecursionLimit) {
+  constexpr int kTestRecursionDepth = 10;
+  std::string deeply_nested_shape = "";
+  std::string deeply_nested_literal = "";
+
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested_shape += "(";
+    deeply_nested_literal += "(";
+  }
+  deeply_nested_shape += "f32[]";
+  deeply_nested_literal += "0";
+
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested_shape += ")";
+    deeply_nested_literal += ")";
+  }
+
+  std::string hlo_string = "HloModule test\nENTRY entry () -> " +
+                           deeply_nested_shape +
+                           " {\n  ROOT %c = " + deeply_nested_shape +
+                           " constant(" + deeply_nested_literal + ")\n}";
+
+  HloParserOptions options;
+  options.set_max_recursion_depth(kTestRecursionDepth);
+  auto result =
+      ParseAndReturnUnverifiedModule(hlo_string, HloModuleConfig(), options);
+  EXPECT_NE(absl::OkStatus(), result.status());
+  ExpectHasSubstr(result.status().message(),
+                  "maximum recursion depth exceeded");
+}
+
+TEST_F(HloParserTest, DeeplyNestedUntypedTupleLiteralExceedsRecursionLimit) {
+  constexpr int kTestRecursionDepth = 10;
+  std::string deeply_nested_literal = "";
+
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested_literal += "(";
+  }
+  deeply_nested_literal += "s32[] 0";
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested_literal += ")";
+  }
+
+  std::string hlo_string =
+      "HloModule test\nENTRY entry {\n"
+      "  %constant = f32[1]{0} constant({0})\n"
+      "  ROOT %custom-call = f32[1]{0} custom-call(f32[1]{0} %constant), "
+      "custom_call_target=\"foo\", literal=" +
+      deeply_nested_literal + "\n}";
+
+  HloParserOptions options;
+  options.set_max_recursion_depth(kTestRecursionDepth);
+  auto result =
+      ParseAndReturnUnverifiedModule(hlo_string, HloModuleConfig(), options);
+  EXPECT_NE(absl::OkStatus(), result.status());
+  ExpectHasSubstr(result.status().message(),
+                  "maximum recursion depth exceeded");
+}
+
+TEST_F(HloParserTest, DeeplyNestedInlineComputationsExceedsRecursionLimit) {
+  constexpr int kTestRecursionDepth = 10;
+  std::string deeply_nested = "";
+
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested += "p" + std::to_string(i) + " = f32[] parameter(0)\n";
+    deeply_nested += "ROOT r" + std::to_string(i) + " = f32[] call(p" +
+                     std::to_string(i) + "), to_apply={\n";
+  }
+
+  deeply_nested += "p_inner = f32[] parameter(0)\n";
+  deeply_nested += "ROOT r_inner = f32[] negate(p_inner)\n";
+
+  for (int i = 0; i < kTestRecursionDepth + 1; ++i) {
+    deeply_nested += "}\n";
+  }
+
+  std::string hlo_string =
+      "HloModule test\nENTRY entry {\n" + deeply_nested + "}";
+
+  HloParserOptions options;
+  options.set_max_recursion_depth(kTestRecursionDepth);
+  auto result =
+      ParseAndReturnUnverifiedModule(hlo_string, HloModuleConfig(), options);
+  EXPECT_NE(absl::OkStatus(), result.status());
+  ExpectHasSubstr(result.status().message(),
+                  "maximum recursion depth exceeded");
+}
+
+// Regression test for OSS-Fuzz stack overflow finding #390461336.
+// Generate deeply nested valid HLO that triggers ParseOperands recursion.
+TEST_F(HloParserTest, DeeplyNestedOperandsDoesNotStackOverflow) {
+  constexpr int kDepth = 50000;
+  std::string deeply_nested = "f32[] ";
+  for (int i = 0; i < kDepth; ++i) {
+    deeply_nested += "add(f32[] ";
+  }
+  deeply_nested += "constant(0)";
+  for (int i = 0; i < kDepth; ++i) {
+    deeply_nested += ", f32[] constant(0))";
+  }
+  auto result = ParseAndReturnUnverifiedModule(deeply_nested);
+  // The key assertion: parsing fails gracefully instead of crashing.
+  EXPECT_FALSE(result.ok());
+  ExpectHasSubstr(result.status().message(),
+                  "maximum recursion depth exceeded");
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes

Add recursion depth tracking to HLO parser to prevent stack overflow crashes from deeply nested input. A shared `current_recursion_depth_` counter is added to 6 recursive parse functions. When the configurable limit (default 500) is exceeded, the parser returns a graceful `"maximum recursion depth exceeded"` error instead of crashing.

🎯 Justification

The HLO parser is vulnerable to stack exhaustion from maliciously crafted or malformed deeply nested HLO text. This is reachable anywhere HLO text is accepted (tools, file loading, etc.).

Note the parser is not recommended for production use and can be considered as a debug API. This issue was disclosed & discussed with the maintainers.

Fixes OSS-Fuzz [#390461336](https://issues.oss-fuzz.com/issues/390461336) from Tensorflow.

🚀 Kind of Contribution

🐛 Bug Fix

📊 Benchmark (for Performance Improvements)

N/A -- not a performance change. The added overhead is essentially one integer increment/compare and a trivial RAII guard per recursive parse call.

🧪 Unit Tests:

Five new tests for the HLO parser:

- `DeeplyNestedOperandsExceedsRecursionLimit`: verifies `add(add(add...` nesting triggers the depth error at a reduced limit of 10.
- `DeeplyNestedShapesExceedsRecursionLimit`: verifies `(((f32[])))` shape nesting triggers the depth error.
- `DeeplyNestedTupleLiteralsExceedsRecursionLimit`: verifies `(((0)))` tuple literal nesting triggers the depth error.
- `DeeplyNestedInlineComputationsExceedsRecursionLimit`: verifies nested `call(...), to_apply={...}` inline computations trigger the depth error.
- `DeeplyNestedOperandsDoesNotStackOverflow`: regression test with 50,000 nesting levels using the default limit, confirming no stack overflow crash.
- `DeeplyNestedUntypedTupleLiteralExceedsRecursionLimit`: verifies that deeply nested untyped tuple literals in `literal=` attributes hit the recursion limit instead of overflowing the stack.

Test output:

```
$ docker exec xla bazel-bin/xla/hlo/parser/hlo_parser_test --gtest_filter='*DeeplyNested*' --gtest_print_time=1
Note: Google Test filter = *DeeplyNested*
...
HloParserTest.DeeplyNestedShapesExceedsRecursionLimit                               [       OK ] 
HloParserTest.DeeplyNestedShapesExceedsRecursionLimit (1 ms)                        [ RUN      ] 
HloParserTest.DeeplyNestedTupleLiteralsExceedsRecursionLimit                        [       OK ] 
HloParserTest.DeeplyNestedTupleLiteralsExceedsRecursionLimit (0 ms)                 [ RUN      ] 
HloParserTest.DeeplyNestedInlineComputationsExceedsRecursionLimit                   [       OK ] 
HloParserTest.DeeplyNestedInlineComputationsExceedsRecursionLimit (0 ms)            [ RUN      ] 
HloParserTest.DeeplyNestedOperandsExceedsRecursionLimit                             [       OK ] 
HloParserTest.DeeplyNestedOperandsExceedsRecursionLimit (0 ms)                      [ RUN      ] 
HloParserTest.DeeplyNestedUntypedTupleLiteralExceedsRecursionLimit                  [       OK ] 
HloParserTest.DeeplyNestedUntypedTupleLiteralExceedsRecursionLimit (0 ms)           [ RUN      ]
HloParserTest.DeeplyNestedOperandsDoesNotStackOverflow                              [       OK ] 
HloParserTest.DeeplyNestedOperandsDoesNotStackOverflow (496 ms)                     [----------] 
6 tests from HloParserTest (498 ms total)
```

🧪 Execution Tests:

N/A -- this is a parser-level fix.
