### PR TITLE
[XLA:GPU][oneAPI] Adding sycl all_runtime dependency to codegen tools

### DIFF
--- a/xla/backends/gpu/codegen/tools/BUILD
+++ b/xla/backends/gpu/codegen/tools/BUILD
@@ -2,6 +2,10 @@ load(
     "@local_config_rocm//rocm:build_defs.bzl",
     "if_rocm_is_configured",
 )
+load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//xla:py_strict.bzl", "py_strict_binary", "py_strict_library", "py_strict_test")
 load("//xla:xla.default.bzl", "xla_cc_binary")
@@ -101,6 +105,8 @@ xla_cc_binary(
         "//xla/stream_executor/cuda:all_runtime",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor/rocm:all_runtime",
+    ]) + if_sycl_is_configured([
+        "//xla/stream_executor/sycl:all_runtime",
     ]),
 )
 


### PR DESCRIPTION
This PR fixes 
`"Failed to create PjRt client. NOT_FOUND: Could not find registered platform with name: "sycl". Available platform names are: Interprete"` 

Following test suits will pass 
//xla/backends/gpu/codegen/emitters/tests/...
//xla/codegen/emitters/tests/...