### PR TITLE
Build and use xxd from source

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,6 +28,7 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_python", version = "1.6.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "snappy", version = "1.2.1")
+bazel_dep(name = "xxd", version = "9.1.0917")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 # go/keep-sorted end
 

--- a/third_party/extensions/third_party.bzl
+++ b/third_party/extensions/third_party.bzl
@@ -40,6 +40,7 @@ load("//third_party/tensorrt:workspace.bzl", tensorrt = "repo")
 load("//third_party/triton:workspace.bzl", triton = "repo")
 load("//third_party/uv:workspace.bzl", uv = "repo")
 load("//third_party/xnnpack:workspace.bzl", xnnpack = "repo")
+load("//third_party/xxd:workspace.bzl", xxd = "repo")
 
 def _third_party_ext_impl(mctx):  # @unused
     benchmark()

--- a/third_party/xxd/workspace.bzl
+++ b/third_party/xxd/workspace.bzl
@@ -1,0 +1,12 @@
+"""xxd is a tool that converts a binary file into a C/C++ header file containing an array of bytes."""
+
+load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
+
+def repo():
+    tf_http_archive(
+        name = "xxd",
+        sha256 = "a5cdcfcfeb13dc4deddcba461d40234dbf47e61941cb7170c9ebe147357bb62d",
+        strip_prefix = "vim-9.1.0917/src/xxd",
+        urls = tf_mirror_urls("https://github.com/vim/vim/archive/refs/tags/v9.1.0917.tar.gz"),
+        build_file = "//third_party/xxd:xxd.BUILD",
+    )

--- a/third_party/xxd/xxd.BUILD
+++ b/third_party/xxd/xxd.BUILD
@@ -1,0 +1,26 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(["LICENSE"])
+
+license(
+    name = "license",
+    package_name = "vim",
+    license_kinds = [
+        "@rules_license//licenses/spdx:Vim",
+    ],
+    license_text = "LICENSE",
+    package_url = "https://github.com/vim/vim",
+)
+
+cc_binary(
+    name = "xxd",
+    srcs = [
+        "xxd.c",
+    ],
+)

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -57,6 +57,7 @@ load("//third_party/transformer_engine:workspace.bzl", transformer_engine = "rep
 load("//third_party/triton:workspace.bzl", triton = "repo")
 load("//third_party/uv:workspace.bzl", uv = "repo")
 load("//third_party/xnnpack:workspace.bzl", xnnpack = "repo")
+load("//third_party/xxd:workspace.bzl", xxd = "repo")
 load("//tools/def_file_filter:def_file_filter_configure.bzl", "def_file_filter_configure")
 load("//tools/toolchains:cpus/aarch64/aarch64_compiler_configure.bzl", "aarch64_compiler_configure")
 load("//tools/toolchains:cpus/arm/arm_compiler_configure.bzl", "arm_compiler_configure")
@@ -111,6 +112,7 @@ def _initialize_third_party():
     triton()
     uv()
     xnnpack()
+    xxd()
 
     # copybara: tsl vendor
 

--- a/xla/util/build_defs.bzl
+++ b/xla/util/build_defs.bzl
@@ -41,6 +41,7 @@ def embed_files(name, srcs, cpp_namespace = "", compatible_with = None, **kwargs
             name + ".cc",
             name + ".h",
         ],
+        tools = ["@xxd//:xxd"],
         cmd = """
             HDR_OUT=$(location {name}.h)
             CC_OUT=$(location {name}.cc)
@@ -76,7 +77,7 @@ def embed_files(name, srcs, cpp_namespace = "", compatible_with = None, **kwargs
                 echo "const std::string& $${{FUNC_NAME}}();" >> "$${{HDR_OUT}}"
 
                 # CC: Embed data using xxd
-                xxd -i "$${{src}}" | \
+                $(location @xxd//:xxd) -i "$${{src}}" | \
                 sed -e "s/^unsigned char [^[]*/static const unsigned char $${{VAR_NAME}}/" \
                     -e "s/^unsigned int .*_len/static const size_t $${{VAR_NAME}}_size/" \
                     >> "$${{CC_OUT}}"


### PR DESCRIPTION
This is small yet important change since it was the only non hermetic, non posix tool used as part of the PJRT plugins build graph.

Building xxd from source enables fully remote, fully hermetic building of the PJRT plugins (at least) on a vanilla debian docker image (with a few other config modifications and toolchain registration).

See https://app.buildbuddy.io/invocation/41378ea1-d350-4c19-b08a-27ec865d95af 

If this is appealing enough, I'm willing to submit a few other patches to enable fully remote hermetic builds using user provided CC toolchain with full backward compliance with the existing config setup.