### PR TITLE
[tsl] Add tsl::UniqueAny container

### DIFF
--- a/xla/tsl/util/BUILD
+++ b/xla/tsl/util/BUILD
@@ -411,6 +411,25 @@ tsl_cc_test(
     ],
 )
 
+cc_library(
+    name = "unique_any",
+    hdrs = ["unique_any.h"],
+    deps = [
+        "@com_google_absl//absl/log:check",
+    ],
+)
+
+tsl_cc_test(
+    name = "unique_any_test",
+    srcs = ["unique_any_test.cc"],
+    deps = [
+        ":unique_any",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_benchmark",
+        "//xla/tsl/platform:test_main",
+    ],
+)
+
 cc_binary(
     name = "filewrapper",
     srcs = ["filewrapper.cc"],

--- a/xla/tsl/util/unique_any.h
+++ b/xla/tsl/util/unique_any.h
@@ -1,0 +1,218 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_TSL_UTIL_UNIQUE_ANY_H_
+#define XLA_TSL_UTIL_UNIQUE_ANY_H_
+
+#include <cstddef>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#include "absl/log/check.h"
+
+namespace tsl {
+
+// A move-only variant of std::any.
+//
+// Provides the same interface as std::any but supports types that are
+// move-only (not copyable). Uses small-buffer optimization to store
+// values of 24 bytes or less inline without heap allocation.
+class UniqueAny {
+ public:
+  constexpr UniqueAny() noexcept = default;
+  ~UniqueAny() { reset(); }
+
+  template <typename T, typename Decayed = std::decay_t<T>,
+            std::enable_if_t<!std::is_same_v<Decayed, UniqueAny>>* = nullptr>
+  UniqueAny(T&& value) {  // NOLINT(google-explicit-constructor)
+    emplace<Decayed>(std::forward<T>(value));
+  }
+
+  template <typename T, typename... Args>
+  explicit UniqueAny(std::in_place_type_t<T>, Args&&... args) {
+    emplace<T>(std::forward<Args>(args)...);
+  }
+
+  UniqueAny(UniqueAny&& other) noexcept {
+    if (other.storage_) {
+      other.storage_->MoveTo(this);
+      other.storage_ = nullptr;
+    }
+  }
+
+  UniqueAny& operator=(UniqueAny&& other) noexcept {
+    if (this != &other) {
+      reset();
+      if (other.storage_) {
+        other.storage_->MoveTo(this);
+        other.storage_ = nullptr;
+      }
+    }
+    return *this;
+  }
+
+  template <typename T, typename Decayed = std::decay_t<T>,
+            std::enable_if_t<!std::is_same_v<Decayed, UniqueAny>>* = nullptr>
+  UniqueAny& operator=(T&& value) {
+    reset();
+    emplace<Decayed>(std::forward<T>(value));
+    return *this;
+  }
+
+  template <typename T, typename... Args>
+  T& emplace(Args&&... args) {
+    reset();
+    Storage<T>* s;
+    if constexpr (IsSmall<T>()) {
+      s = ::new (inline_storage_)
+          Storage<T>(std::in_place, std::forward<Args>(args)...);
+    } else {
+      s = new Storage<T>(std::in_place, std::forward<Args>(args)...);
+    }
+    storage_ = s;
+    return s->value;
+  }
+
+  void reset() noexcept {
+    if (storage_) {
+      if (is_inline()) {
+        storage_->~StorageBase();
+      } else {
+        delete storage_;
+      }
+      storage_ = nullptr;
+    }
+  }
+
+  bool has_value() const noexcept { return storage_ != nullptr; }
+
+  void swap(UniqueAny& other) noexcept {
+    UniqueAny tmp = std::move(other);
+    other = std::move(*this);
+    *this = std::move(tmp);
+  }
+
+ private:
+  // Use small object optimization to keep small objects inline.
+  static constexpr size_t kInlineSize = 24;
+  static constexpr size_t kInlineAlign = alignof(std::max_align_t);
+
+  template <typename T>
+  struct TypeId {
+    static const char kId;
+  };
+
+  struct StorageBase {
+    virtual ~StorageBase() = default;
+    virtual const void* type_id() const noexcept = 0;
+    virtual void MoveTo(UniqueAny* other) noexcept = 0;
+  };
+
+  template <typename T>
+  struct Storage final : StorageBase {
+    template <typename... Args>
+    explicit Storage(std::in_place_t, Args&&... args)
+        : value(std::forward<Args>(args)...) {}
+
+    const void* type_id() const noexcept final { return &TypeId<T>::kId; }
+
+    void MoveTo(UniqueAny* other) noexcept final {
+      if constexpr (IsSmall<T>()) {
+        other->storage_ = ::new (other->inline_storage_)
+            Storage(std::in_place, std::move(value));
+        this->~Storage();
+      } else {
+        other->storage_ = this;
+      }
+    }
+
+    T value;
+
+   private:
+    Storage(const Storage&) = delete;
+    Storage& operator=(const Storage&) = delete;
+  };
+
+  template <typename T>
+  static constexpr bool IsSmall() {
+    return sizeof(Storage<T>) <= kInlineSize &&
+           alignof(Storage<T>) <= kInlineAlign &&
+           std::is_nothrow_move_constructible_v<T>;
+  }
+
+  bool is_inline() const noexcept {
+    return storage_ == reinterpret_cast<const StorageBase*>(inline_storage_);
+  }
+
+  // Storage for small object optimized unique any.
+  alignas(kInlineAlign) unsigned char inline_storage_[kInlineSize] = {};
+  StorageBase* storage_ = nullptr;
+
+  template <typename T>
+  friend T* any_cast(UniqueAny*) noexcept;
+
+  template <typename T>
+  friend const T* any_cast(const UniqueAny*) noexcept;
+};
+
+template <typename T>
+const char UniqueAny::TypeId<T>::kId = 0;
+
+template <typename T, typename... Args>
+UniqueAny make_unique_any(Args&&... args) {
+  return UniqueAny(std::in_place_type<T>, std::forward<Args>(args)...);
+}
+
+template <typename T>
+T* any_cast(UniqueAny* any) noexcept {
+  if (!any || !any->storage_ ||
+      any->storage_->type_id() != &UniqueAny::TypeId<T>::kId)
+    return nullptr;
+  return &static_cast<UniqueAny::Storage<T>*>(any->storage_)->value;
+}
+
+template <typename T>
+const T* any_cast(const UniqueAny* any) noexcept {
+  if (!any || !any->storage_ ||
+      any->storage_->type_id() != &UniqueAny::TypeId<T>::kId)
+    return nullptr;
+  return &static_cast<const UniqueAny::Storage<T>*>(any->storage_)->value;
+}
+
+template <typename T>
+T& any_cast(UniqueAny& any) {
+  T* p = any_cast<T>(&any);
+  CHECK(p) << "any_cast type mismatch";  // Crash OK
+  return *p;
+}
+
+template <typename T>
+const T& any_cast(const UniqueAny& any) {
+  const T* p = any_cast<T>(&any);
+  CHECK(p) << "any_cast type mismatch";  // Crash OK
+  return *p;
+}
+
+template <typename T>
+T any_cast(UniqueAny&& any) {
+  T* p = any_cast<T>(&any);
+  CHECK(p) << "any_cast type mismatch";  // Crash OK
+  return std::move(*p);
+}
+
+}  // namespace tsl
+
+#endif  // XLA_TSL_UTIL_UNIQUE_ANY_H_

--- a/xla/tsl/util/unique_any_test.cc
+++ b/xla/tsl/util/unique_any_test.cc
@@ -1,0 +1,142 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/tsl/util/unique_any.h"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "xla/tsl/platform/test.h"
+#include "xla/tsl/platform/test_benchmark.h"
+
+namespace tsl {
+namespace {
+
+struct LargeCopyableValue {
+  std::array<int32_t, 10> payload;
+};
+
+struct LargeMoveOnlyValue {
+  LargeMoveOnlyValue(LargeMoveOnlyValue&&) = default;
+  LargeMoveOnlyValue& operator=(LargeMoveOnlyValue&&) = default;
+
+  std::array<int32_t, 10> payload;
+};
+
+TEST(UniqueAnyTest, DefaultConstructedIsEmpty) {
+  UniqueAny a;
+  EXPECT_FALSE(a.has_value());
+}
+
+TEST(UniqueAnyTest, SmallCopyableValues) {
+  UniqueAny any(42);
+
+  int32_t* i32 = any_cast<int32_t>(&any);
+  int64_t* i64 = any_cast<int64_t>(&any);
+
+  ASSERT_TRUE(i32);
+  ASSERT_FALSE(i64);
+  EXPECT_EQ(*i32, 42);
+
+  int32_t& ref = any_cast<int32_t>(any);
+  EXPECT_EQ(ref, 42);
+
+  auto moved = any_cast<int32_t>(std::move(any));
+  EXPECT_EQ(moved, 42);
+}
+
+TEST(UniqueAnyTest, SmallMoveOnlyValues) {
+  UniqueAny any(std::make_unique<int32_t>(42));
+
+  std::unique_ptr<int32_t>* i32 = any_cast<std::unique_ptr<int32_t>>(&any);
+  std::unique_ptr<int64_t>* i64 = any_cast<std::unique_ptr<int64_t>>(&any);
+
+  ASSERT_TRUE(i32);
+  ASSERT_FALSE(i64);
+  EXPECT_EQ(**i32, 42);
+
+  std::unique_ptr<int32_t>& ref = any_cast<std::unique_ptr<int32_t>>(any);
+  EXPECT_EQ(*ref, 42);
+
+  auto moved = any_cast<std::unique_ptr<int32_t>>(std::move(any));
+  EXPECT_EQ(*moved, 42);
+}
+
+TEST(UniqueAnyTest, LargeCopyableValues) {
+  LargeCopyableValue value = {{0, 1, 2, 3, 4, 5, 7, 8, 9}};
+  UniqueAny any(value);
+
+  LargeCopyableValue* ptr = any_cast<LargeCopyableValue>(&any);
+  ASSERT_TRUE(ptr);
+  EXPECT_EQ(ptr->payload, value.payload);
+
+  LargeCopyableValue& ref = any_cast<LargeCopyableValue>(any);
+  EXPECT_EQ(ref.payload, value.payload);
+
+  auto moved = any_cast<LargeCopyableValue>(std::move(any));
+  EXPECT_EQ(moved.payload, value.payload);
+}
+
+TEST(UniqueAnyTest, LargeMoveOnlyValues) {
+  LargeMoveOnlyValue value = {{0, 1, 2, 3, 4, 5, 7, 8, 9}};
+  UniqueAny any(LargeMoveOnlyValue{value.payload});
+
+  LargeMoveOnlyValue* ptr = any_cast<LargeMoveOnlyValue>(&any);
+  ASSERT_TRUE(ptr);
+  EXPECT_EQ(ptr->payload, value.payload);
+
+  LargeMoveOnlyValue& ref = any_cast<LargeMoveOnlyValue>(any);
+  EXPECT_EQ(ref.payload, value.payload);
+
+  auto moved = any_cast<LargeMoveOnlyValue>(std::move(any));
+  EXPECT_EQ(moved.payload, value.payload);
+}
+
+TEST(UniqueAnyTest, MoveConstruction) {
+  UniqueAny any(std::make_unique<int32_t>(42));
+  UniqueAny move_constructed(std::move(any));
+
+  EXPECT_FALSE(any.has_value());
+  EXPECT_TRUE(move_constructed.has_value());
+  EXPECT_EQ(*any_cast<std::unique_ptr<int32_t>>(move_constructed), 42);
+}
+
+TEST(UniqueAnyTest, MoveAssignment) {
+  UniqueAny any(std::make_unique<int32_t>(42));
+  UniqueAny move_assigned;
+  move_assigned = std::move(any);
+
+  EXPECT_FALSE(any.has_value());
+  EXPECT_TRUE(move_assigned.has_value());
+  EXPECT_EQ(*any_cast<std::unique_ptr<int32_t>>(move_assigned), 42);
+}
+
+//===----------------------------------------------------------------------===//
+// Performance benchmarks below
+//===----------------------------------------------------------------------===//
+
+static void BM_MakeInt32(benchmark::State& state) {
+  for (auto _ : state) {
+    UniqueAny any = make_unique_any<int32_t>(42);
+    benchmark::DoNotOptimize(any);
+  }
+}
+
+BENCHMARK(BM_MakeInt32);
+
+}  // namespace
+}  // namespace tsl


### PR DESCRIPTION
An `std::any`-like container for move-only types.

```
-------------------------------------------------------
Benchmark             Time             CPU   Iterations
-------------------------------------------------------
BM_MakeInt32       1.97 ns         1.97 ns    355405340
```