### PR TITLE
GPU collectives: increase maximum device comm size

### DIFF
--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -91,7 +91,7 @@ class GpuDeviceCommunicator {
 
   // A packed kernel argument type for passing device communicator to device
   // kernels (byte storage appropriately sized to fit platform-specific handle).
-  using PackedKernelArg = std::array<std::byte, 200>;
+  using PackedKernelArg = std::array<std::byte, 256>;
   virtual PackedKernelArg PackKernelArg() const = 0;
 
   template <typename Sink>


### PR DESCRIPTION
📝 Summary of Changes
XLA hardcodes a buffer size that must be large enough for all platforms. Increase it slightly.

🎯 Justification
Future platform-specific implementation versions are free to increase their size requirements, which results in compilation failures if the hardcoded size is too small.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
n/a

🧪 Unit Tests:
n/a

🧪 Execution Tests:
n/a