### PR TITLE
Update BoringSSL up to 0.20260211

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "abseil-cpp", version = "20250814.1", repo_name = "com_google_a
 bazel_dep(name = "abseil-py", version = "2.1.0", repo_name = "absl_py")
 bazel_dep(name = "bazel_features", version = "1.36.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
-bazel_dep(name = "boringssl", version = "0.20250818.0")
+bazel_dep(name = "boringssl", version = "0.20260211.0")
 bazel_dep(name = "curl", version = "8.11.0")
 bazel_dep(name = "google_benchmark", version = "1.8.5", repo_name = "com_google_benchmark")
 bazel_dep(name = "googletest", version = "1.17.0", repo_name = "com_google_googletest")

--- a/workspace2.bzl
+++ b/workspace2.bzl
@@ -430,11 +430,10 @@ def _tf_repositories():
 
     tf_http_archive(
         name = "boringssl",
-        sha256 = "9dc53f851107eaf87b391136d13b815df97ec8f76dadb487b58b2fc45e624d2c",
-        strip_prefix = "boringssl-c00d7ca810e93780bd0c8ee4eea28f4f2ea4bcdc",
+        sha256 = "9fd4258b6c530059c1b85192c940f3ae5f5f9f0cb4213ce77f892f3eef62437c",
+        strip_prefix = "boringssl-617634bc015344093f5ea0b0a5b653c924cfa20d",
         system_build_file = "//third_party:boringssl.BUILD",
-        patch_file = ["//third_party:boringssl.patch"],
-        urls = tf_mirror_urls("https://github.com/google/boringssl/archive/c00d7ca810e93780bd0c8ee4eea28f4f2ea4bcdc.tar.gz"),
+        urls = tf_mirror_urls("https://github.com/google/boringssl/archive/617634bc015344093f5ea0b0a5b653c924cfa20d.tar.gz"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
📝 Summary of Changes

BoringSSL has not been updated for several years now. This PR bumps the version of BoringSSL to the actual release [0.20260211][boringssl]. The issue has been reported by ArchLinux community (see [the original omment][issue]).

[boringssl]: https://github.com/google/boringssl/releases/tag/0.20260211.0.
[issue]: https://aur.archlinux.org/packages/python-jaxlib#comment-1059987

🎯 Justification

The pull request fix build issues related to obsolete BoringSSL.

🚀 Kind of Contribution

🐛 Bug Fix