### PR TITLE
Fix host offloading auto-enablement at O1 and add unit test

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -996,8 +996,7 @@ absl::Status RunCollectiveOptimizationPasses(
     collectives_pipeline.AddPass<CollectivePipeliner>(config);
   }
 
-  if (debug_options.xla_gpu_enable_pipelined_host_offloading() ||
-      IsPassEnabledAtOptimizationEffort<CollectivePipeliner>(*hlo_module)) {
+  if (debug_options.xla_gpu_enable_pipelined_host_offloading()) {
     // Forward pass host offloading pipelining
     CollectivePipeliner::Config config{
         /*level_to_operate_on=*/0,
@@ -1028,8 +1027,7 @@ absl::Status RunCollectiveOptimizationPasses(
     collectives_pipeline.AddPass<CollectivePipeliner>(config);
   }
 
-  if (debug_options.xla_gpu_enable_pipelined_host_offloading() ||
-      IsPassEnabledAtOptimizationEffort<CollectivePipeliner>(*hlo_module)) {
+  if (debug_options.xla_gpu_enable_pipelined_host_offloading()) {
     // Backward pass host offloading pipelining
     auto acceptable_formatting = [](const HloInstruction* instr) {
       return instr->opcode() == HloOpcode::kReshape ||


### PR DESCRIPTION
📝 Summary of Changes
Removes IsPassEnabledAtOptimizationEffort from host offloading conditionals 
in gpu_compiler.cc, making it opt-in only via the 
xla_gpu_enable_pipelined_host_offloading flag.

🎯 Justification
Fixes training regression where host offloading was unintentionally
auto-enabled at O1, creating 18 extra all-gather channels (87 vs 69)
and causing loss convergence failure (12.8+ vs 5.7) for gemma3-27b
on 2x8 B200.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
 Added `HostOffloadingNotAutoEnabledAtO1` test in xla/service/gpu/flag_utils_test.cc                                    
                                                            
  This test verifies that host offloading collective pipeliner remains opt-in                                            
  only and is not automatically enabled by optimization levels.                                                          

  Test assertions:
  - Verifies xla_gpu_enable_pipelined_host_offloading flag defaults to false
  - Confirms CollectivePipeliner is enabled at O1+ but host offloading is not
  - Tests across all optimization levels (O0-O3) to prevent regression where
    IsPassEnabledAtOptimizationEffort would auto-enable host offloading

  This is a behavioral test validating flag behavior and pass enablement logic
  without requiring actual HLO compilation.

🧪 Execution Tests:
N/A.
