### PR TITLE
Gracefully handle missing handler on legacy custom call path

### DIFF
--- a/xla/backends/gpu/runtime/custom_call_thunk.cc
+++ b/xla/backends/gpu/runtime/custom_call_thunk.cc
@@ -137,8 +137,14 @@ ResolveLegacyCustomCall(const CustomCallTargetRegistry& registry,
                         absl::string_view target_name,
                         absl::string_view platform_name,
                         CustomCallApiVersion api_version) {
-  void* call_target = CustomCallTargetRegistry::Global()->Lookup(
-      std::string(target_name), std::string(platform_name));
+  void* call_target =
+      registry.Lookup(std::string(target_name), std::string(platform_name));
+
+  if (call_target == nullptr) {
+    return NotFound(
+        "No registered implementation for custom call to %s for platform %s",
+        target_name, platform_name);
+  }
 
   // For information about this calling convention, see
   // xla/g3doc/custom_call.md.

--- a/xla/service/gpu/custom_call_test.cc
+++ b/xla/service/gpu/custom_call_test.cc
@@ -221,6 +221,24 @@ TEST_F(CustomCallTest, WithStatusFailed) {
   EXPECT_THAT(status.message(), ::testing::HasSubstr("Failed"));
 }
 
+TEST_F(CustomCallTest, WithNoCallback) {
+  XlaBuilder b(TestName());
+  CustomCall(
+      &b, "NoCallback", /*operands=*/{}, ShapeUtil::MakeShape(F32, {}),
+      /*opaque=*/"",
+      /*has_side_effect=*/false,
+      /*output_operand_aliasing=*/{}, /*literal=*/nullptr,
+      /*schedule=*/CustomCallSchedule::SCHEDULE_NONE,
+      /*api_version=*/CustomCallApiVersion::API_VERSION_STATUS_RETURNING);
+  auto status = ExecuteAndTransfer(&b, {}).status();
+  EXPECT_THAT(
+      status,
+      StatusIs(
+          absl::StatusCode::kNotFound,
+          HasSubstr(
+              "No registered implementation for custom call to NoCallback")));
+}
+
 //===----------------------------------------------------------------------===//
 // XLA runtime custom calls provides type-safe custom call API
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
📝 Summary of Changes
Add error checking when doing lookup for legacy custom call handler

🎯 Justification
Prevents segmentation fault when trying to invoke legacy custom call with no handler registred

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
Ne test case added to //xla/service/gpu:custom_call_test

🧪 Execution Tests:
N\A
