### PR TITLE
[ROCm] Allow running tests on rbe runners

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -3,6 +3,7 @@
 build:rocm_dev --remote_upload_local_results=false
 build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
 
+build:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
 build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"
 build:rocm_rbe --host_platform="@local_config_rocm//rocm:linux_x64"


### PR DESCRIPTION
📝 Summary of Changes
Allow lit tests to be executed remotely by setting --repo_env=REMOTE_GPU_TESTING=1
when using rocm_rbe config

🎯 Justification
That is required to achieve a better gpu utilization during the PR checks for rocm.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
asserting correctness. Please provide test cases running with at most 2 GPUs.
