### PR TITLE
[GPU] Erase stale sibling sub-cliques to avoid deadlocks

### DIFF
--- a/xla/backends/gpu/collectives/gpu_clique.cc
+++ b/xla/backends/gpu/collectives/gpu_clique.cc
@@ -146,6 +146,10 @@ bool LockableGpuClique::HasParent(const GpuClique* parent) const {
   return this->value().parent() == parent;
 }
 
+const GpuClique* LockableGpuClique::parent() const {
+  return this->value().parent();
+}
+
 std::string LockableGpuClique::DebugString() const {
   return absl::StrFormat("LockableGpuClique: %s", value().DebugString());
 }

--- a/xla/backends/gpu/collectives/gpu_clique.h
+++ b/xla/backends/gpu/collectives/gpu_clique.h
@@ -124,6 +124,9 @@ class LockableGpuClique : public Lockable<GpuClique, GpuClique::LockableName> {
   // Returns if *this lockable clique has a given parent.
   bool HasParent(const GpuClique* parent) const;
 
+  // Returns the parent clique pointer, or nullptr if not created by splitting.
+  const GpuClique* parent() const;
+
   std::string DebugString() const;
 
   // Checks for async errors for all the communicators in the clique without


### PR DESCRIPTION
📝 Summary of Changes
When a cached sub-clique is evicted due to a parent communicator mismatch, also evict all sibling sub-cliques that were split from the same old parent. This prevents asymmetric cache state where some siblings skip `ncclCommSplit` (cache hit) while others trigger it (cache miss), violating the collective requirement that all parent ranks participate simultaneously.

🎯 Justification
`ncclCommSplit` is collective over all ranks of the parent communicator — every rank must call it. The process-global clique cache `ProcessGpuCliques` can develop asymmetric state when different computations create the same child clique from different parents:

  1. Computation A (8-device mesh): creates parent {0,...,7}, splits children {0,1}, {2,3}, {4,5}, {6,7} — all with parent_ = P8.
  2. Computation B (4-device mesh): needs child {0,1}, finds it cached with P8, but wants to split from P4 — evicts and re-creates {0,1} with parent_ = P4. Children {4,5}, {6,7} are not accessed and retain parent_ = P8.
  3. Computation A repeats: {0,1} has wrong parent → evict → call `ncclCommSplit` on P8. But {4,5} still matches P8 → cache hit → skip `ncclCommSplit`. Deadlock: only 4 of 8 parent ranks called the collective.

This deadlock is reproducible by running `pytest -s tests/pmap_test.py tests/pjit_test.py` in the JAX test suite .

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
N/A.

🧪 Execution Tests:
Verified with aforementioned JAX tests.
