### PR TITLE
[xla:gpu] Use default memory space for output in collective_ops_ffi_test

### DIFF
--- a/xla/tests/collective_ops_ffi_test.cc
+++ b/xla/tests/collective_ops_ffi_test.cc
@@ -507,9 +507,10 @@ TEST_F(CollectiveOpsTestFFI, DeviceAllReduce) {
       ENTRY test_computation {
         id = u32[] replica-id()
         in = u32[]{:S(1)} copy(id)
-        ROOT all-reduce = u32[]{:S(1)} custom-call(in),
+        all-reduce = u32[]{:S(1)} custom-call(in),
           custom_call_target="__xla_test$$device_all_reduce",
           api_version=API_VERSION_TYPED_FFI
+        ROOT out = u32[] copy(all-reduce)
       }
     )";
 


### PR DESCRIPTION
We should not be returning results in collective memory space to users, they should always be returned in default device memory space.