### PR TITLE
[xla:gpu] Improve host tracing debuggability

### DIFF
--- a/xla/pjrt/common_pjrt_client.cc
+++ b/xla/pjrt/common_pjrt_client.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
@@ -1108,8 +1109,14 @@ CommonPjRtLoadedExecutable::Execute(
     absl::Span<const std::vector<PjRtBuffer*>> argument_handles,
     const ExecuteOptions& options,
     std::optional<std::vector<tsl::Future<void>>>& returned_futures) const {
-  tsl::profiler::TraceMe traceme("CommonPjRtLoadedExecutable::Execute");
-  VLOG(1) << "CommonPjRtLoadedExecutable::Execute";
+  RunId run_id = options.launch_id != 0 ? RunId(options.launch_id)
+                                        : RunId::CreateUniqueId();
+  int num_addressable_devices = addressable_devices_.size();
+
+  VLOG(1) << absl::StreamFormat(
+      "CommonPjRtLoadedExecutable::Execute: run_id=%d, execution_mode=%v",
+      run_id.ToInt(), options.execution_mode);
+
   if (!client()->allows_execute_recursion() &&
       ThisThreadIsInsideHostCallback()) {
     // Because TPU is single threaded, and the host callback currently blocking
@@ -1118,13 +1125,18 @@ CommonPjRtLoadedExecutable::Execute(
     return InvalidArgument("Execute() called from inside host callback.");
   }
 
-  RunId run_id = options.launch_id != 0 ? RunId(options.launch_id)
-                                        : RunId::CreateUniqueId();
-  tsl::profiler::TraceMeProducer producer("CommonPjRtLoadedExecutable::Execute",
-                                          tsl::profiler::ContextType::kPjRt,
-                                          run_id.ToInt());
-
-  const int num_addressable_devices = addressable_devices_.size();
+  tsl::profiler::TraceMeProducer producer(
+      [&] {
+        return tsl::profiler::TraceMeEncode(
+            absl::StrFormat("CommonPjRtLoadedExecutable::Execute (%s)", name()),
+            {{"run_id", run_id.ToInt()},
+             {"execution_mode", absl::StrCat(options.execution_mode)},
+             {"name", name()},
+             {"num_replicas", num_replicas()},
+             {"num_partitions", num_partitions()},
+             {"num_addressable_devices", num_addressable_devices}});
+      },
+      tsl::profiler::ContextType::kPjRt, run_id.ToInt());
 
   if (argument_handles.size() != num_addressable_devices) {
     return InvalidArgument(
@@ -1170,9 +1182,18 @@ CommonPjRtLoadedExecutable::Execute(
         const int replica = addressable_device_logical_ids_[i].replica;
         const int partition = addressable_device_logical_ids_[i].partition;
         PjRtDevice* device = addressable_devices_[i];
-        LaunchOnDevice(device, [&, replica, partition, i, context_id] {
+        LaunchOnDevice(device, [&, context_id, i, replica, partition, device] {
           tsl::profiler::TraceMeConsumer consumer(
-              "Scheduled CommonPjRtLoadedExecutable::Execute",
+              [&] {
+                return tsl::profiler::TraceMeEncode(
+                    absl::StrFormat(
+                        "[%d] CommonPjRtLoadedExecutable::Execute (%s)", i,
+                        name()),
+                    {{"name", name()},
+                     {"replica", replica},
+                     {"partition", partition},
+                     {"global_device_id", device->global_device_id()}});
+              },
               tsl::profiler::ContextType::kPjRt, context_id);
 
           // Two phase launch. Phase 1: Prepare on all cores. Abort
@@ -1216,6 +1237,7 @@ CommonPjRtLoadedExecutable::Execute(
     }
 
     // Wait until we either fail Phase 1 or completes two phases.
+    tsl::profiler::TraceMe trace_wait("Wait for LaunchOnDevice completion");
     auto done = [&]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu) {
       return launching == 0;
     };

--- a/xla/pjrt/pjrt_executable.h
+++ b/xla/pjrt/pjrt_executable.h
@@ -301,6 +301,21 @@ struct ExecuteOptions {
   absl::StatusOr<ExecuteOptionsProto> ToProto() const;
   static absl::StatusOr<ExecuteOptions> FromProto(
       const ExecuteOptionsProto& proto);
+
+  // Pretty-printing for ExecutionMode enum.
+  template <typename Sink>
+  friend void AbslStringify(Sink& sink, const ExecutionMode& mode) {
+    absl::Format(&sink, "%s", [&] {
+      switch (mode) {
+        case ExecutionMode::kDefault:
+          return "default";
+        case ExecutionMode::kSynchronous:
+          return "synchronous";
+        case ExecutionMode::kAsynchronous:
+          return "asynchronous";
+      }
+    }());
+  }
 };
 
 // Static memory usage for a compiled program.

--- a/xla/pjrt/semaphore.h
+++ b/xla/pjrt/semaphore.h
@@ -41,6 +41,12 @@ class Semaphore {
   // Returns the capacity of the semaphore.
   int64_t capacity() const { return max_capacity_; }
 
+  // Returns the current value of the semaphore.
+  int64_t value() const {
+    absl::MutexLock lock(mu_);
+    return value_;
+  }
+
   class ScopedReservation {
    public:
     ScopedReservation(Semaphore* semaphore, int64_t amount)
@@ -69,7 +75,7 @@ class Semaphore {
   static bool CanAcquire(CanAcquireArgs* args)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(args->semaphore->mu_);
 
-  absl::Mutex mu_;
+  mutable absl::Mutex mu_;
   int64_t value_ ABSL_GUARDED_BY(mu_);
   const int64_t max_capacity_;
 };

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -113,6 +113,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
 #include "xla/util/split_proto/split_gpu_executable_writer.h"
@@ -120,7 +121,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -1180,8 +1180,10 @@ absl::Status GpuExecutable::ExecuteThunks(
     const BufferAllocations& buffer_allocations,
     const ServiceExecutableRunOptions* run_options) {
   tsl::profiler::TraceMe trace([&] {
-    return tsl::profiler::TraceMeEncode("GpuExecutable::ExecuteThunks",
-                                        {{"module_name", module_name_}});
+    return tsl::profiler::TraceMeEncode(
+        absl::StrFormat("[%d] GpuExecutable::ExecuteThunks",
+                        run_options->device_ordinal()),
+        {{"module_name", module_name_}});
   });
 
   if (VLOG_IS_ON(5)) {


### PR DESCRIPTION
Sprinkle `TraceMe` annotations with `XLA_LOG_DEVICE`-compatible format in `CommonPjRtClient` and in XLA:GPU-specific `StreamExecutor` client. This improves debuggability of host runtime by including important metadata into each trace.