### PR TITLE
[ROCm] fix se_gpu_pjrt_client_test target

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1005,7 +1005,7 @@ TEST(StreamExecutorGpuClientTest, DeleteBufferThenFulfillBufferNoDeadLock) {
   std::vector<float> data{1, 3, 5, 7, 11, 13, 17, 19};
   Shape shape = ShapeUtil::MakeShape(F32, {static_cast<int64_t>(data.size())});
   // On ROCm 10k buffers hit vm.max_map_count causing pthread_create to fail
-  const int num_buffers = client->platform_name() == "rocm" ? 2000 : 10000;
+  const int num_buffers = client->platform_name() == xla::RocmName() ? 2000 : 10000;
   std::vector<std::unique_ptr<PjRtClient::AsyncHostToDeviceTransferManager>>
       txms;
   for (int i = 0; i < num_buffers; ++i) {
@@ -1333,8 +1333,8 @@ TEST(StreamExecutorGpuClientTest, DistributedInit) {
       options.num_nodes = num_nodes;
       options.kv_store = kv_store;
       TF_ASSERT_OK_AND_ASSIGN(auto client, GetStreamExecutorGpuClient(options));
-      EXPECT_TRUE(client->platform_name() == "cuda" ||
-                  client->platform_name() == "rocm");
+      EXPECT_TRUE(client->platform_name() == xla::CudaName() ||
+                  client->platform_name() == xla::RocmName());
       EXPECT_EQ(client->addressable_device_count(), 2);
       EXPECT_EQ(client->device_count(), 4);
     });
@@ -1973,7 +1973,7 @@ TEST(StreamExecutorGpuClientTest,
   EXPECT_EQ(memory_stats.output_size_in_bytes, 1764786624);
   EXPECT_EQ(memory_stats.host_output_size_in_bytes, 0);
   // Difference in buffer aliasing causes a difference in peak memory usage
-  if (client->platform_name() == "rocm") {
+  if (client->platform_name() == xla::RocmName()) {
     EXPECT_EQ(memory_stats.peak_memory_in_bytes, 1845006788);
   } else {
     EXPECT_EQ(memory_stats.peak_memory_in_bytes, 1845010888);
@@ -3447,9 +3447,9 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id,
                                                  /*key_prefix=*/"gpu:");
   TF_ASSIGN_OR_RETURN(std::unique_ptr<PjRtClient> client,
                       GetStreamExecutorGpuClient(options));
-  TF_RET_CHECK(client->platform_name() == "cuda" ||
-               client->platform_name() == "rocm");
-  if (client->platform_name() == "cuda") {
+  TF_RET_CHECK(client->platform_name() == xla::CudaName() ||
+               client->platform_name() == xla::RocmName());
+  if (client->platform_name() == xla::CudaName()) {
     TF_ASSIGN_OR_RETURN(
         se::CudaComputeCapability cc,
         se::CudaComputeCapability::FromString(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -1004,9 +1004,11 @@ TEST(StreamExecutorGpuClientTest, DeleteBufferThenFulfillBufferNoDeadLock) {
           PinnedHostMemorySpace::kKind));
   std::vector<float> data{1, 3, 5, 7, 11, 13, 17, 19};
   Shape shape = ShapeUtil::MakeShape(F32, {static_cast<int64_t>(data.size())});
+  // On ROCm 10k buffers hit vm.max_map_count causing pthread_create to fail
+  const int num_buffers = client->platform_name() == "rocm" ? 2000 : 10000;
   std::vector<std::unique_ptr<PjRtClient::AsyncHostToDeviceTransferManager>>
       txms;
-  for (int i = 0; i < 10000; ++i) {
+  for (int i = 0; i < num_buffers; ++i) {
     TF_ASSERT_OK_AND_ASSIGN(
         std::unique_ptr<PjRtClient::AsyncHostToDeviceTransferManager> txm,
         client->CreateBuffersForAsyncHostToDevice({shape}, memspace));
@@ -1016,7 +1018,7 @@ TEST(StreamExecutorGpuClientTest, DeleteBufferThenFulfillBufferNoDeadLock) {
     // Delete the buffer
   }
 
-  // At this point, we have 10000 buffers pending deallocation.
+  // At this point, we have num_buffers buffers pending deallocation.
 
   absl::string_view raw_view(reinterpret_cast<char*>(data.data()),
                              data.size() * sizeof(data[0]));
@@ -1970,7 +1972,12 @@ TEST(StreamExecutorGpuClientTest,
       auto memory_stats, executable->GetExecutable()->GetCompiledMemoryStats());
   EXPECT_EQ(memory_stats.output_size_in_bytes, 1764786624);
   EXPECT_EQ(memory_stats.host_output_size_in_bytes, 0);
-  EXPECT_EQ(memory_stats.peak_memory_in_bytes, 1845010888);
+  // Difference in buffer aliasing causes a difference in peak memory usage
+  if (client->platform_name() == "rocm") {
+    EXPECT_EQ(memory_stats.peak_memory_in_bytes, 1845006788);
+  } else {
+    EXPECT_EQ(memory_stats.peak_memory_in_bytes, 1845010888);
+  }
 }
 
 TEST(StreamExecutorGpuClientTest, GetCompiledMemoryStatsMixedTuple) {
@@ -3440,14 +3447,20 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id,
                                                  /*key_prefix=*/"gpu:");
   TF_ASSIGN_OR_RETURN(std::unique_ptr<PjRtClient> client,
                       GetStreamExecutorGpuClient(options));
-  TF_RET_CHECK(client->platform_name() == "cuda");
-  TF_ASSIGN_OR_RETURN(
-      se::CudaComputeCapability cc,
-      se::CudaComputeCapability::FromString(std::get<std::string>(
-          client->addressable_devices().front()->description().Attributes().at(
-              "compute_capability"))));
-  if (!cc.IsAtLeastAmpere()) {
-    return absl::FailedPreconditionError("Ampere+ GPU required");
+  TF_RET_CHECK(client->platform_name() == "cuda" ||
+               client->platform_name() == "rocm");
+  if (client->platform_name() == "cuda") {
+    TF_ASSIGN_OR_RETURN(
+        se::CudaComputeCapability cc,
+        se::CudaComputeCapability::FromString(
+            std::get<std::string>(client->addressable_devices()
+                                      .front()
+                                      ->description()
+                                      .Attributes()
+                                      .at("compute_capability"))));
+    if (!cc.IsAtLeastAmpere()) {
+      return absl::FailedPreconditionError("Ampere+ GPU required");
+    }
   }
   TF_RET_CHECK(client->addressable_device_count() == 1);
   TF_RET_CHECK(client->device_count() == ShardedAutotuningTest::kNumNodes);


### PR DESCRIPTION
📝 Summary of Changes
Includes ROCm-specific parameters and removes hardcoded CUDA expectation in se_gpu_pjrt_client_test target to fix on ROCm 

🎯 Justification
Expands ROCm test coverage

🚀 Kind of Contribution
🧪 Tests
