### PR TITLE
[GPU] Unroll and vectorize up to 32 elements / 256 bits on Blackwell.

### DIFF
--- a/xla/backends/gpu/codegen/emitters/emitter_base.cc
+++ b/xla/backends/gpu/codegen/emitters/emitter_base.cc
@@ -372,7 +372,7 @@ absl::StatusOr<std::unique_ptr<llvm::Module>> EmitterBase::CreateLLVMModule(
 
   mlir::PassManager pm(&mlir_context);
   emitters::RegisterOptimizationPasses(pm);
-  AddLoopTransformationPasses(pm, device);
+  AddLoopTransformationPasses(pm, device, unroll_factor());
   AddLoweringPasses(pm, device);
 
   TF_RETURN_IF_ERROR(RunPassPipeline(module.get(), *fusion.GetModule(), pm,
@@ -481,7 +481,8 @@ absl::Status EmitterBase::EmitMlir(mlir::ModuleOp module, FuncOp entry_function,
 }
 
 void AddLoopTransformationPasses(mlir::OpPassManager& pm,
-                                 const se::DeviceDescription& device) {
+                                 const se::DeviceDescription& device,
+                                 int max_unroll_factor) {
   pm.addNestedPass<FuncOp>(CreateLowerXlaSharedPass());
   pm.addNestedPass<FuncOp>(
       emitters::CreateLowerXlaToScfPass(device.threads_per_warp()));
@@ -505,7 +506,7 @@ void AddLoopTransformationPasses(mlir::OpPassManager& pm,
   // instructions over ifs.
   pm.addPass(mlir::createLoopInvariantCodeMotionPass());
   pm.addNestedPass<FuncOp>(emitters::CreateVectorizeLoadsAndStoresPass(device));
-  pm.addNestedPass<FuncOp>(CreateOptimizeLoopsPass());
+  pm.addNestedPass<FuncOp>(CreateOptimizeLoopsPass(max_unroll_factor));
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
 }

--- a/xla/backends/gpu/codegen/emitters/emitter_base.h
+++ b/xla/backends/gpu/codegen/emitters/emitter_base.h
@@ -121,7 +121,8 @@ class EmitterBase : public KernelFusionInterface {
 // Adds passes that transform XLA_GPU and SCF loops, e.g. peel, pipeline,
 // vectorize.
 void AddLoopTransformationPasses(mlir::OpPassManager& pm,
-                                 const se::DeviceDescription& device);
+                                 const se::DeviceDescription& device,
+                                 int max_unroll_factor = 0);
 
 // Adds passes that lower transformed loops to LLVM.
 void AddLoweringPasses(mlir::OpPassManager& pm,

--- a/xla/backends/gpu/codegen/emitters/loop.h
+++ b/xla/backends/gpu/codegen/emitters/loop.h
@@ -40,6 +40,7 @@ class LoopFusion final : public EmitterBase {
   LoopFusion(const HloFusionAnalysis& analysis, mlir::MLIRContext* mlir_context)
       : analysis_(analysis), config_(ComputeLoopFusionConfig(analysis)) {}
   LaunchDimensions launch_dimensions() const override;
+  int unroll_factor() const override { return config_.unroll_factor; }
 
   std::optional<IndexingMap> ComputeThreadIdToOutputIndexing(
       int64_t root_index, mlir::MLIRContext* mlir_context) const override;

--- a/xla/backends/gpu/codegen/emitters/transforms/optimize_loops.cc
+++ b/xla/backends/gpu/codegen/emitters/transforms/optimize_loops.cc
@@ -63,7 +63,7 @@ bool IsExpensiveToUnroll(mlir::Operation* op) {
       >(op);
 }
 
-int GetUnrollingFactor(mlir::scf::ForOp op) {
+int GetUnrollingFactor(mlir::scf::ForOp op, int max_unroll_factor) {
   // We only unroll loops with a step of 1 and a lower bound of 0. That's the
   // only type we generate.
   if (auto step = op.getConstantStep(); !step || step->getSExtValue() != 1) {
@@ -122,7 +122,7 @@ int GetUnrollingFactor(mlir::scf::ForOp op) {
 
   // Always unroll if the trip count is smaller than the max unroll factor,
   // because it's very likely that the loop was meant to be unrolled.
-  if (trip_count <= MaxUnrollFactor()) {
+  if (trip_count <= max_unroll_factor) {
     return trip_count;
   }
 
@@ -136,22 +136,31 @@ int GetUnrollingFactor(mlir::scf::ForOp op) {
 struct UnrollLoops : mlir::OpRewritePattern<mlir::scf::ForOp> {
   using mlir::OpRewritePattern<mlir::scf::ForOp>::OpRewritePattern;
 
+  UnrollLoops(mlir::MLIRContext* context, int max_unroll_factor)
+      : mlir::OpRewritePattern<mlir::scf::ForOp>(context),
+        max_unroll_factor_(max_unroll_factor) {}
+
   mlir::LogicalResult matchAndRewrite(
       mlir::scf::ForOp op, mlir::PatternRewriter& rewriter) const override {
-    if (int factor = GetUnrollingFactor(op); factor > 1) {
+    if (int factor = GetUnrollingFactor(op, max_unroll_factor_); factor > 1) {
       return mlir::loopUnrollByFactor(op, factor);
     }
     return rewriter.notifyMatchFailure(op, "loop can't be unrolled");
   }
+
+ private:
+  int max_unroll_factor_;
 };
 
 class OptimizeLoopsPass
     : public impl::OptimizeLoopsPassBase<OptimizeLoopsPass> {
  public:
+  using impl::OptimizeLoopsPassBase<OptimizeLoopsPass>::OptimizeLoopsPassBase;
+
   void runOnOperation() override {
     // First unroll loops. If unrolling is possible, we prefer it.
     mlir::RewritePatternSet unroll_patterns(&getContext());
-    unroll_patterns.add<UnrollLoops>(&getContext());
+    unroll_patterns.add<UnrollLoops>(&getContext(), max_unroll_factor_);
     if (mlir::failed(mlir::applyPatternsGreedily(getOperation(),
                                                  std::move(unroll_patterns)))) {
       signalPassFailure();
@@ -162,8 +171,11 @@ class OptimizeLoopsPass
 
 }  // namespace
 
-std::unique_ptr<mlir::Pass> CreateOptimizeLoopsPass() {
-  return std::make_unique<OptimizeLoopsPass>();
+std::unique_ptr<mlir::Pass> CreateOptimizeLoopsPass(int max_unroll_factor) {
+  OptimizeLoopsPassOptions options;
+  options.max_unroll_factor_ =
+      max_unroll_factor ? max_unroll_factor : MaxUnrollFactor();
+  return std::make_unique<OptimizeLoopsPass>(options);
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.h
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.h
@@ -41,7 +41,7 @@ std::unique_ptr<mlir::Pass> CreateConvertFloatAMDPass(
 std::unique_ptr<mlir::Pass> CreateConvertFloatAMDPass(
     const stream_executor::RocmComputeCapability& cc);
 std::unique_ptr<mlir::Pass> CreateConvertIndexTypePass();
-std::unique_ptr<mlir::Pass> CreateOptimizeLoopsPass();
+std::unique_ptr<mlir::Pass> CreateOptimizeLoopsPass(int max_unroll_factor = 0);
 std::unique_ptr<mlir::Pass> CreatePeelLoopsPass();
 std::unique_ptr<mlir::Pass> CreateLowerXlaSharedPass();
 std::unique_ptr<mlir::Pass> CreateRecoverExp2Pass();

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.td
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.td
@@ -106,6 +106,11 @@ def OptimizeLoopsPass :
     "xla::XlaDialect",
   ];
 
+  let options = [
+    Option<"max_unroll_factor_", "max_unroll_factor", "int", /*default=*/"0",
+           "Maximum unroll factor.">
+  ];
+
   let constructor = "CreateOptimizeLoopsPass()";
 }
 

--- a/xla/backends/gpu/codegen/emitters/transforms/tests/optimize_loops.mlir
+++ b/xla/backends/gpu/codegen/emitters/transforms/tests/optimize_loops.mlir
@@ -1,4 +1,5 @@
 // RUN: emitters_opt %s -split-input-file -xla-gpu-optimize-loops | FileCheck %s
+// RUN: emitters_opt %s -split-input-file -xla-gpu-optimize-loops="max_unroll_factor=16" | FileCheck %s --check-prefix=CHECK-MAX16
 
 #map = #xla.indexing_map<"(d0) -> (d0 floordiv 8), domain: d0 in [0, 31]">
 #map1 = #xla.indexing_map<"(d0) -> (d0 mod 8), domain: d0 in [0, 31]">
@@ -105,3 +106,26 @@ module {
 // CHECK-LABEL: @do_not_unroll
 // CHECK: %[[C1:.*]] = arith.constant 1 : index
 // CHECK: scf.for {{.*}} step %[[C1]]
+
+// -----
+
+module {
+  func.func @unroll_up_to_max(%arg0: f32) -> f32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %ret = scf.for %i = %c0 to %c16 step %c1 iter_args (%v = %arg0) -> (f32) {
+      %exp = math.exp %v : f32
+      %add = arith.addf %v, %exp : f32
+      %log = math.log %add : f32
+      scf.yield %log : f32
+    }
+    return %ret : f32
+  }
+}
+
+// CHECK-LABEL: @unroll_up_to_max
+// CHECK: %[[C8:.*]] = arith.constant 8 : index
+// CHECK: scf.for {{.*}} step %[[C8]]
+// CHECK-MAX16-LABEL: @unroll_up_to_max
+// CHECK-MAX16-NOT: scf.for

--- a/xla/backends/gpu/codegen/fusion_emitter.h
+++ b/xla/backends/gpu/codegen/fusion_emitter.h
@@ -65,6 +65,7 @@ class KernelFusionInterface : public FusionInterface {
 
   // Returns the fusion's launch dimensions.
   virtual LaunchDimensions launch_dimensions() const = 0;
+  virtual int unroll_factor() const { return 0; }
 
   // Computes an indexing map from thread to output element(s) of the **hero**.
   //

--- a/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
+++ b/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
@@ -132,7 +132,7 @@ int64_t GetAlignmentOfRemainder(mlir::AffineExpr expr,
 // Attempts to extract the vector type for the given loop. This means:
 // - checks that the lower bound is 0
 // - checks that the step is 1
-// - checks that the upper bound is 2, 4, or 8.
+// - checks that the upper bound is a power of 2 between 2 and 32.
 // Returns a vector type with the given upper bound and the tensor's element
 // type.
 // All tensors are 1D after flatten-tensors pass.
@@ -151,10 +151,14 @@ mlir::VectorType GetVectorType(mlir::RankedTensorType tensor_type,
       mlir::getConstantIntValue(loop.getLowerBound()) != 0) {
     return nullptr;
   }
-  std::optional<int> vector_size =
+  std::optional<unsigned int> vector_size =
       mlir::getConstantIntValue(loop.getUpperBound());
-  if (vector_size != 2 && vector_size != 4 && vector_size != 8) {
+  if (vector_size < 2 || vector_size > 32 ||
+      !absl::has_single_bit(*vector_size)) {
     return nullptr;  // Unsupported vector size.
+  }
+  if (tensor_type.getElementTypeBitWidth() * *vector_size > 256) {
+    return nullptr;  // Vector size is too large.
   }
   if (tensor_type.getShape().back() % *vector_size) {
     return nullptr;  // Misaligned start indices.

--- a/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
+++ b/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/numeric/bits.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -151,10 +152,10 @@ mlir::VectorType GetVectorType(mlir::RankedTensorType tensor_type,
       mlir::getConstantIntValue(loop.getLowerBound()) != 0) {
     return nullptr;
   }
-  std::optional<unsigned int> vector_size =
+  std::optional<int64_t> vector_size =
       mlir::getConstantIntValue(loop.getUpperBound());
   if (vector_size < 2 || vector_size > 32 ||
-      !absl::has_single_bit(*vector_size)) {
+      !absl::has_single_bit(static_cast<unsigned int>(*vector_size))) {
     return nullptr;  // Unsupported vector size.
   }
   if (tensor_type.getElementTypeBitWidth() * *vector_size > 256) {

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -459,7 +459,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(false);
   opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);
   opts.set_xla_gpu_experimental_enable_fusion_autotuner(true);
-  opts.set_xla_gpu_experimental_allow_unroll_factor_eight(true);
+  opts.set_xla_gpu_experimental_max_unroll_factor(32);
   opts.set_xla_gpu_experimental_pack_dot_operands_along_k_dimension(true);
   opts.set_xla_unsupported_crash_on_hlo_pass_fix_max_iterations(false);
   opts.set_xla_hlo_pass_fix_detect_cycles(false);
@@ -2770,12 +2770,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
               set_xla_gpu_experimental_enable_triton_warp_specialization),
       debug_options->xla_gpu_experimental_enable_triton_warp_specialization(),
       "Enable Triton's auto warp specialization feature where applicable."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_experimental_allow_unroll_factor_eight",
-      bool_setter_for(
-          &DebugOptions::set_xla_gpu_experimental_allow_unroll_factor_eight),
-      debug_options->xla_gpu_experimental_allow_unroll_factor_eight(),
-      "If true, allows unroll factor 8 on Blackwell architectures."));
+  flag_list->push_back(
+      tsl::Flag("xla_gpu_experimental_max_unroll_factor",
+                int32_setter_for(
+                    &DebugOptions::set_xla_gpu_experimental_max_unroll_factor),
+                debug_options->xla_gpu_experimental_max_unroll_factor(),
+                "Controls max unroll factor on Blackwell architectures."));
   flag_list->push_back(
       tsl::Flag("xla_detect_unstable_reductions",
                 setter_for_xla_detect_unstable_reductions,

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3019,6 +3019,7 @@ cc_library(
         "//xla/hlo/utils:hlo_traversal",
         "//xla/service:instruction_fusion",
         "//xla/stream_executor:device_description",
+        "//xla/stream_executor:semantic_version",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3007,6 +3007,7 @@ cc_library(
         ":ir_emission_utils",
         ":launch_dimensions",
         ":reduction_utils",
+        "//xla:comparison_util",
         "//xla:permutation_util",
         "//xla:shape_util",
         "//xla:side_effect_util",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3007,7 +3007,6 @@ cc_library(
         ":ir_emission_utils",
         ":launch_dimensions",
         ":reduction_utils",
-        "//xla:comparison_util",
         "//xla:permutation_util",
         "//xla:shape_util",
         "//xla:side_effect_util",

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -114,12 +114,12 @@ int ComputeMaxUnrollFactor(int64_t num_elements, int64_t max_unroll) {
 }  // namespace
 
 int64_t MaxUnrollFactor(const HloFusionAnalysis* analysis) {
-  constexpr int kDefaultUnrollFactor = 4;
+  constexpr int64_t kDefaultUnrollFactor = 4;
   if (analysis == nullptr) {
     return kDefaultUnrollFactor;
   }
 
-  // On Blackwell we would like to increase the maximum unroll factor to 8, as
+  // On Blackwell we would like to increase the maximum unroll factor, as
   // we need more vectorization for full performance.
   // However we need to check additional conditions:
   //   - Unrolling is potentially bad for fusions with reductions, where one
@@ -151,8 +151,10 @@ int64_t MaxUnrollFactor(const HloFusionAnalysis* analysis) {
            stream_executor::SemanticVersion(12, 9, 0))
           ? 256
           : 128;
+  // Apply unroll factors >= 2 * kDefaultUnrollFactor only to narrow enough data
+  // types.
   const int max_bits_for_aggressive_unrolling =
-      max_vector_bit_width / kDefaultUnrollFactor;
+      max_vector_bit_width / (2 * kDefaultUnrollFactor);
   if (analysis->device_info().cuda_compute_capability().IsBlackwell() &&
       (analysis->emitter_fusion_kind() ==
            HloFusionAnalysis::EmitterFusionKind::kLoop ||
@@ -195,7 +197,7 @@ int64_t MaxUnrollFactor(const HloFusionAnalysis* analysis) {
                                                   unroll_factor)) {
       unroll_factor /= 2;
     }
-    return unroll_factor;
+    return std::max(unroll_factor, kDefaultUnrollFactor * 2);
   }
   return kDefaultUnrollFactor;
 }

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -164,7 +164,8 @@ int64_t MaxUnrollFactor(const HloFusionAnalysis* analysis) {
       !HloAnyOf(analysis->fusion(), [](HloInstructionAdaptor node) {
         return node.opcode() == HloOpcode::kReduce;
       })) {
-    int64_t max_dtype_bits = 0;
+    // Do not unroll sub-byte types further for now.
+    int64_t max_dtype_bits = 8;
     for (const HloInstruction* param : analysis->fusion().GetParameters()) {
       max_dtype_bits = std::max(
           max_dtype_bits, static_cast<int64_t>(primitive_util::StorageBitWidth(
@@ -175,26 +176,23 @@ int64_t MaxUnrollFactor(const HloFusionAnalysis* analysis) {
           max_dtype_bits, static_cast<int64_t>(primitive_util::StorageBitWidth(
                               root.instruction().shape().element_type())));
     }
-    // Do not unroll sub-byte types further for now.
-    max_dtype_bits = std::max(int64_t{8}, max_dtype_bits);
 
-    int64_t unroll_factor =
-        std::min(int64_t(analysis->fusion_root(0)
-                             .instruction()
-                             .GetModule()
-                             ->config()
-                             .debug_options()
-                             .xla_gpu_experimental_max_unroll_factor()),
-                 max_vector_bit_width / max_dtype_bits);
+    int64_t unroll_factor = std::min(
+        static_cast<int64_t>(analysis->fusion_root(0)
+                                 .instruction()
+                                 .GetModule()
+                                 ->config()
+                                 .debug_options()
+                                 .xla_gpu_experimental_max_unroll_factor()),
+        max_vector_bit_width / max_dtype_bits);
     unroll_factor =
         1LL << (absl::bit_width(static_cast<uint64_t>(unroll_factor)) - 1);
-    while (unroll_factor > kDefaultUnrollFactor) {
-      if (!ContainsTransposeWithSmallMostMinorDim(analysis->fusion(),
+    while (unroll_factor > kDefaultUnrollFactor &&
+           ContainsTransposeWithSmallMostMinorDim(analysis->fusion(),
                                                   unroll_factor)) {
-        return unroll_factor;
-      }
       unroll_factor /= 2;
     }
+    return unroll_factor;
   }
   return kDefaultUnrollFactor;
 }

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -167,6 +167,9 @@ int64_t MaxUnrollFactor(const HloFusionAnalysis* analysis) {
     // Do not unroll sub-byte types further for now.
     int64_t max_dtype_bits = 8;
     for (const HloInstruction* param : analysis->fusion().GetParameters()) {
+      if (ShapeUtil::IsScalar(param->shape())) {
+        continue;
+      }
       max_dtype_bits = std::max(
           max_dtype_bits, static_cast<int64_t>(primitive_util::StorageBitWidth(
                               param->shape().element_type())));

--- a/xla/service/gpu/gpu_fusible_test.cc
+++ b/xla/service/gpu/gpu_fusible_test.cc
@@ -49,6 +49,13 @@ absl::StatusOr<se::DeviceDescription> MakeDeviceDescription() {
   return device_description;
 }
 
+se::DeviceDescription B200WithCUDA129() {
+  se::DeviceDescription result = TestGpuDeviceInfo::B200SXMDeviceInfo();
+  result.set_compile_time_toolkit_version(
+      stream_executor::SemanticVersion(12, 9, 0));
+  return result;
+}
+
 class GpuFusibleTest : public HloHardwareIndependentTestBase {
  public:
   void SetUp() override {
@@ -1685,18 +1692,26 @@ ENTRY main {
   ROOT res = f16[2048,1024]{1,0} negate(p0)
 }
 )"));
-  const HloInstruction* root = module->entry_computation()->root_instruction();
-  se::DeviceDescription device_info_h100{
-      TestGpuDeviceInfo::H100SXMDeviceInfo()};
-  auto analysis = HloFusionAnalysis::Create(*root, device_info_h100);
-  auto config = ComputeLoopFusionConfig(analysis, root->shape());
-  EXPECT_EQ(config.unroll_factor, 4);
+  const HloInstruction& root = *module->entry_computation()->root_instruction();
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(HloFusionAnalysis::Create(
+                                  root, TestGpuDeviceInfo::H100SXMDeviceInfo()),
+                              root.shape())
+          .unroll_factor,
+      4);
 
-  se::DeviceDescription device_info_b200{
-      TestGpuDeviceInfo::B200SXMDeviceInfo()};
-  analysis = HloFusionAnalysis::Create(*root, device_info_b200);
-  config = ComputeLoopFusionConfig(analysis, root->shape());
-  EXPECT_EQ(config.unroll_factor, 16);
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(HloFusionAnalysis::Create(
+                                  root, TestGpuDeviceInfo::B200SXMDeviceInfo()),
+                              root.shape())
+          .unroll_factor,
+      8);
+
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(
+          HloFusionAnalysis::Create(root, B200WithCUDA129()), root.shape())
+          .unroll_factor,
+      16);
 }
 
 TEST_F(GpuFusibleTest, ComputeLoopFusionConfig32Bit) {
@@ -1708,21 +1723,29 @@ ENTRY main {
   ROOT res = f32[2048,1024]{1,0} negate(p0)
 }
 )"));
-  const HloInstruction* root = module->entry_computation()->root_instruction();
-  se::DeviceDescription device_info_h100{
-      TestGpuDeviceInfo::H100SXMDeviceInfo()};
-  auto analysis = HloFusionAnalysis::Create(*root, device_info_h100);
-  auto config = ComputeLoopFusionConfig(analysis, root->shape());
-  EXPECT_EQ(config.unroll_factor, 4);
+  const HloInstruction& root = *module->entry_computation()->root_instruction();
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(HloFusionAnalysis::Create(
+                                  root, TestGpuDeviceInfo::H100SXMDeviceInfo()),
+                              root.shape())
+          .unroll_factor,
+      4);
 
-  se::DeviceDescription device_info_b200{
-      TestGpuDeviceInfo::B200SXMDeviceInfo()};
-  analysis = HloFusionAnalysis::Create(*root, device_info_b200);
-  config = ComputeLoopFusionConfig(analysis, root->shape());
-  EXPECT_EQ(config.unroll_factor, 8);
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(HloFusionAnalysis::Create(
+                                  root, TestGpuDeviceInfo::B200SXMDeviceInfo()),
+                              root.shape())
+          .unroll_factor,
+      4);
+
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(
+          HloFusionAnalysis::Create(root, B200WithCUDA129()), root.shape())
+          .unroll_factor,
+      8);
 }
 
-TEST_F(GpuFusibleTest, FourBitTypeUnrolled32xOnBlackwell) {
+TEST_F(GpuFusibleTest, FourBitTypeUnrolled16or32xOnBlackwell) {
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
 e {
   n = s4[1024000] negate(s4[1024000] parameter(0))
@@ -1738,6 +1761,11 @@ e {
       ComputeLoopFusionConfig(HloFusionAnalysis::Create(
                                   root, TestGpuDeviceInfo::B200SXMDeviceInfo()),
                               root.shape())
+          .unroll_factor,
+      16);
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(
+          HloFusionAnalysis::Create(root, B200WithCUDA129()), root.shape())
           .unroll_factor,
       32);
 }

--- a/xla/service/gpu/gpu_fusible_test.cc
+++ b/xla/service/gpu/gpu_fusible_test.cc
@@ -1745,6 +1745,44 @@ ENTRY main {
       8);
 }
 
+TEST_F(GpuFusibleTest, ScalarParameterTypeDoesNotLimitUnrolling) {
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
+f {
+  p0 = bf16[2048,1024] parameter(0)
+  p1 = f32[] parameter(1)
+  broadcast = f32[2048,1024] broadcast(p1), dimensions={}
+  convert = f32[2048,1024] convert(p0)
+  add = f32[2048,1024] add(convert, broadcast)
+  res = bf16[2048,1024] convert(add)
+}
+
+e {
+  p0 = bf16[2048,1024] parameter(0)
+  p1 = f32[] parameter(1)
+  r = bf16[2048,1024] fusion(p0, p1), kind=kLoop, calls=f
+})"));
+  const HloInstruction& root = *module->entry_computation()->root_instruction();
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(HloFusionAnalysis::Create(
+                                  root, TestGpuDeviceInfo::H100SXMDeviceInfo()),
+                              root.shape())
+          .unroll_factor,
+      4);
+
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(HloFusionAnalysis::Create(
+                                  root, TestGpuDeviceInfo::B200SXMDeviceInfo()),
+                              root.shape())
+          .unroll_factor,
+      8);
+
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(
+          HloFusionAnalysis::Create(root, B200WithCUDA129()), root.shape())
+          .unroll_factor,
+      16);
+}
+
 TEST_F(GpuFusibleTest, FourBitTypeUnrolled16or32xOnBlackwell) {
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
 e {

--- a/xla/service/gpu/gpu_fusible_test.cc
+++ b/xla/service/gpu/gpu_fusible_test.cc
@@ -1745,6 +1745,27 @@ ENTRY main {
       8);
 }
 
+TEST_F(GpuFusibleTest, DoNotExceedMaxVectorBitWidth) {
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
+e {
+  a = f64[2048,1024] parameter(0)
+  r = f64[2048,1024] negate(a)
+})"));
+  const HloInstruction& root = *module->entry_computation()->root_instruction();
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(HloFusionAnalysis::Create(
+                                  root, TestGpuDeviceInfo::H100SXMDeviceInfo()),
+                              root.shape())
+          .unroll_factor,
+      4);
+
+  EXPECT_EQ(
+      ComputeLoopFusionConfig(
+          HloFusionAnalysis::Create(root, B200WithCUDA129()), root.shape())
+          .unroll_factor,
+      4);
+}
+
 TEST_F(GpuFusibleTest, ScalarParameterTypeDoesNotLimitUnrolling) {
   TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
 f {
@@ -1858,7 +1879,7 @@ ENTRY main {
       TestGpuDeviceInfo::B200SXMDeviceInfo()};
   analysis = HloFusionAnalysis::Create(*root, device_info_b200);
   config = ComputeLoopFusionConfig(analysis, root->shape());
-  EXPECT_EQ(config.unroll_factor, 4);
+  EXPECT_EQ(config.unroll_factor, 8);
 }
 
 TEST_F(GpuFusibleTest, ComputeLoopFusionConfigForLoopTransposeLargerMinorDim) {

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -781,6 +781,7 @@ lit_test_suite_for_gpus(
             "sub_byte_collectives.hlo",
             "triton_calling_convention.hlo",
             "triton_naming.hlo",
+            "vectorization.hlo",
             "zero_clamp_abs_index.hlo",
         ],
         include = [
@@ -794,11 +795,13 @@ lit_test_suite_for_gpus(
             "kernel_reuse.hlo",
             "triton_calling_convention.hlo",
             "triton_naming.hlo",
+            "vectorization.hlo",
         ],
         "p100": [
             "kernel_reuse.hlo",
             "triton_calling_convention.hlo",
             "triton_naming.hlo",
+            "vectorization.hlo",
         ],
         "mi200": [
             "element_wise_row_vectorization.hlo",
@@ -806,6 +809,7 @@ lit_test_suite_for_gpus(
             "single_instruction.hlo",
             "reduce_unnested.hlo",
             "reduction_vectorization_sm_all.hlo",
+            "vectorization.hlo",
         ],
     },
     gpus = [

--- a/xla/service/gpu/tests/vectorization.hlo
+++ b/xla/service/gpu/tests/vectorization.hlo
@@ -1,8 +1,8 @@
 // RUN: hlo-opt %s --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=%S/../../../backends/gpu/target_config/specs/%{GPU}.txtpb | FileCheck --check-prefixes=CHECK-LLVM-%{GPU} %s
 // RUN: hlo-opt %s --platform=gpu --stage=ptx --xla_gpu_target_config_filename=%S/../../../backends/gpu/target_config/specs/%{GPU}.txtpb | FileCheck --check-prefixes=CHECK-PTX-%{GPU} %s
 
-// CHECK-LLVM-b200: store <32 x i8>
-// CHECK-PTX-b200: st.global.v8.b32
+// CHECK-LLVM-b200: store <16 x i8>
+// CHECK-PTX-b200: st.global.v4.b32
 
 // Note, these aren't the optimal values for H100, this just reflects the
 // current behavior of XLA. H100 would also benefit from further vectorization.

--- a/xla/service/gpu/tests/vectorization.hlo
+++ b/xla/service/gpu/tests/vectorization.hlo
@@ -1,0 +1,26 @@
+// RUN: hlo-opt %s --platform=gpu --stage=llvm-before-optimizations --xla_gpu_target_config_filename=%S/../../../backends/gpu/target_config/specs/%{GPU}.txtpb | FileCheck --check-prefixes=CHECK-LLVM-%{GPU} %s
+// RUN: hlo-opt %s --platform=gpu --stage=ptx --xla_gpu_target_config_filename=%S/../../../backends/gpu/target_config/specs/%{GPU}.txtpb | FileCheck --check-prefixes=CHECK-PTX-%{GPU} %s
+
+// CHECK-LLVM-b200: store <32 x i8>
+// CHECK-PTX-b200: st.global.v8.b32
+
+// Note, these aren't the optimal values for H100, this just reflects the
+// current behavior of XLA. H100 would also benefit from further vectorization.
+// CHECK-LLVM-h100_sxm: store <4 x i8>
+// CHECK-PTX-h100_sxm: st.global.b32
+// CHECK-LLVM-a100_pcie_80: store <4 x i8>
+// CHECK-PTX-a100_pcie_80: st.global.b32
+// CHECK-LLVM-a6000: store <4 x i8>
+// CHECK-PTX-a6000: st.global.b32
+
+HloModule m8, is_scheduled=true
+
+tr {
+  a = s8[8,14336,256] parameter(0)
+  b = s8[14336,8,256] transpose(a), dimensions={1,0,2}
+}
+
+e {
+  p = s8[8,14336,256] parameter(0)
+  t = s8[14336,8,256] fusion(p), kind=kInput, calls=tr
+}

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -769,7 +769,7 @@ message DebugOptions {
   // guarded with a heuristic, but the heuristic is not perfect, so changing
   // this flag can cause both performance improvements and performance
   // regressions.
-  optional int32 xla_gpu_experimental_max_unroll_factor = 458;
+  optional int32 xla_gpu_experimental_max_unroll_factor = 459;
 
   // For sub-byte dot operands, layout them along contracting dimensions.
   optional bool xla_gpu_experimental_pack_dot_operands_along_k_dimension = 362;
@@ -1418,7 +1418,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 459
+  // Next id: 460
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -765,6 +765,12 @@ message DebugOptions {
   // When possible, XLA will use Triton's auto warp specialization feature.
   optional bool xla_gpu_experimental_enable_triton_warp_specialization = 421;
 
+  // Controls max unroll factor on Blackwell architectures. This is also
+  // guarded with a heuristic, but the heuristic is not perfect, so changing
+  // this flag can cause both performance improvements and performance
+  // regressions.
+  optional int32 xla_gpu_experimental_max_unroll_factor = 458;
+
   // For sub-byte dot operands, layout them along contracting dimensions.
   optional bool xla_gpu_experimental_pack_dot_operands_along_k_dimension = 362;
 
@@ -1042,12 +1048,6 @@ message DebugOptions {
   // If true, will verify that the numerical results of Triton fusions match
   // the results of regular emitters.
   optional bool xla_gpu_verify_triton_fusion_numerics = 291;
-
-  // Controls max unroll factor on Blackwell architectures. This is also
-  // guarded with a heuristic, but the heuristic is not perfect, so changing
-  // this flag can cause both performance improvements and performance
-  // regressions.
-  optional int32 xla_gpu_experimental_max_unroll_factor = 458;
 
   // go/keep-sorted end
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -666,12 +666,6 @@ message DebugOptions {
   // If true, autotune all fusions with block level emitter.
   optional bool xla_gpu_experimental_all_fusions_with_triton = 444;
 
-  // If true, allows unroll factor 8 on Blackwell architectures. This is also
-  // guarded with a heuristic, but the heuristic is not perfect, so enabling
-  // this flag can cause both performance improvements and performance
-  // regressions.
-  optional bool xla_gpu_experimental_allow_unroll_factor_eight = 430;
-
   // Enables an Ahead-of-Time (AOT) compilation flow where the compiled binary
   // includes the generated Thunks. In contrast, the legacy flow only compiles
   // up to the HLO optimization stage, before Thunk generation.
@@ -1048,6 +1042,12 @@ message DebugOptions {
   // If true, will verify that the numerical results of Triton fusions match
   // the results of regular emitters.
   optional bool xla_gpu_verify_triton_fusion_numerics = 291;
+
+  // Controls max unroll factor on Blackwell architectures. This is also
+  // guarded with a heuristic, but the heuristic is not perfect, so changing
+  // this flag can cause both performance improvements and performance
+  // regressions.
+  optional int32 xla_gpu_experimental_max_unroll_factor = 458;
 
   // go/keep-sorted end
 
@@ -1522,6 +1522,7 @@ message DebugOptions {
   reserved "xla_gpu_experimental_enable_triton_tma";
   reserved "xla_gpu_strict_conv_algorithm_picker";
   reserved "xla_gpu_experimental_use_autotuner_pass";
+  reserved "xla_gpu_experimental_allow_unroll_factor_eight";
 
   reserved 5, 63, 80, 93, 94, 98, 117, 130, 133, 134, 139, 141, 143, 152, 156,
       158, 160, 161, 162, 167, 168, 169, 171, 172, 173, 176, 177, 178, 179, 180,
@@ -1529,7 +1530,7 @@ message DebugOptions {
       206, 207, 211, 214, 218, 220, 221, 226, 229, 230, 233, 234, 238, 242, 249,
       263, 264, 266, 270, 271, 275, 276, 278, 279, 281, 282, 286, 298, 299, 302,
       303, 309, 313, 314, 319, 320, 325, 326, 332, 346, 352, 354, 355, 358, 361,
-      367, 369, 371, 385, 394, 396, 398, 402, 423, 446;
+      367, 369, 371, 385, 394, 396, 398, 402, 423, 430, 446;
 }
 
 // Contains flags which affects the GPU compilation result.


### PR DESCRIPTION
📝 Summary of Changes
Increase maximum unroll factor and maximum vector width.

🎯 Justification
Speeds up kernels.

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)

B200:

| Benchmark                                           | Speedup | Error | Memory | Compilation speedup |
|-----------------------------------------------------|---------|-------|--------|---------------------|
|  gpu_hlo                                            |   1.03x | 0.01x |  1.00x |               0.89x |
|  hlo_llama3_8b_bf16_activation_offloading_1x8       |   0.99x | 0.01x |  1.00x |               0.98x |
|  hlo_llama3_8b_cp_bf16_1x4                          |   0.99x | 0.01x |  1.00x |               0.92x |
|  hlo_llama31_8b_bf16_1x8                            |   1.01x | 0.01x |  1.00x |               0.99x |
|  hlo_llama31_8b_fp8_1x8                             |   0.99x | 0.03x |  1.00x |               0.98x |
|  hlo_mixtral_8x7b_bf16_1x8                          |   1.05x | 0.01x |  1.00x |               0.96x |
|  nv_maxtext_1n1g_jit_train_step_before_optimization |   1.01x | 0.00x |  1.00x |               0.95x |
|  gemma2_2b_keras_jax                                |   1.04x | 0.02x |  1.00x |               1.03x |
|  gemma3_1b_flax_call                                |   1.01x | 0.11x |  1.00x |               1.05x |
|  gemma3_1b_flax_sample_loop                         |   1.37x | 0.43x |  1.00x |               0.99x |
|  gemma3_4b_flax_call                                |   1.39x | 0.17x |  1.00x |               0.99x |
|  gemma3_4b_flax_sample_loop                         |   0.92x | 0.17x |  1.00x |               0.93x |
|  gemma3_12b_flax_call                               |   1.03x | 0.01x |  1.00x |               1.07x |
|  gemma3_12b_flax_sample_loop                        |   1.02x | 0.06x |  1.00x |               1.08x |
|  4                                                  |   3.43x | 0.02x |  1.00x |               1.22x |
|  8                                                  |   2.50x | 0.03x |  1.00x |               0.94x |
|  16                                                 |   1.38x | 0.03x |  1.00x |               1.30x |
|  32                                                 |   1.39x | 0.02x |  1.00x |               1.15x |
|  64                                                 |   1.01x | 0.02x |  1.00x |               1.12x |
|  128                                                |   1.00x | 0.01x |  1.00x |               1.15x |
|  ComputeLoopFusionConfig32Bit                       |   1.26x | 0.03x |  1.00x |               1.15x |
|  ComputeLoopFusionConfig                            |   1.16x | 0.04x |  1.00x |               1.05x |
|  pr38174_1                                          |   1.00x | 0.00x |  1.00x |               0.98x |
|  pr38174_2                                          |   1.46x | 0.00x |  1.00x |               1.03x |

ComputeLoopFusionConfig* are taken from affected cases of gpu_fusible_test. pr38174_1 and pr38174_2 were provided by Adrian in the comments to the PR. HLOs for microbenchmarks are in the first comment.

🧪 Unit Tests:
yes

🧪 Execution Tests:
no