### PR TITLE
[tsl:concurrency] Add AsyncValue<->Future interop library

### DIFF
--- a/xla/tsl/concurrency/BUILD
+++ b/xla/tsl/concurrency/BUILD
@@ -181,6 +181,33 @@ tsl_cc_test(
 )
 
 cc_library(
+    name = "interop",
+    srcs = ["interop.cc"],
+    hdrs = ["interop.h"],
+    compatible_with = get_compatible_with_portable(),
+    deps = [
+        ":async_value",
+        ":future",
+        ":ref_count",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+tsl_cc_test(
+    name = "interop_test",
+    srcs = ["interop_test.cc"],
+    deps = [
+        ":async_value",
+        ":interop",
+        ":ref_count",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_main",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_library(
     name = "ref_count",
     hdrs = ["ref_count.h"],
     compatible_with = get_compatible_with_portable(),

--- a/xla/tsl/concurrency/interop.cc
+++ b/xla/tsl/concurrency/interop.cc
@@ -1,0 +1,69 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/tsl/concurrency/interop.h"
+
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "xla/tsl/concurrency/async_value.h"
+#include "xla/tsl/concurrency/future.h"
+#include "xla/tsl/concurrency/ref_count.h"
+
+namespace tsl {
+
+static Future<> MakeFutureWhenValuesReady(
+    std::vector<RCReference<AsyncValue>> values) {
+  auto [promise, future] = MakePromise<>();
+
+  absl::Span<const RCReference<AsyncValue>> span(values);
+  RunWhenReady(span, [promise = std::move(promise),
+                      values = std::move(values)]() mutable {
+    for (const auto& value : values) {
+      if (value->IsError()) {
+        promise.Set(value->GetError());
+        return;
+      }
+    }
+    promise.Set(absl::OkStatus());
+  });
+
+  return std::move(future);
+}
+
+Future<> MakeFutureWhenReady(AsyncValue* value) {
+  return MakeFutureWhenReady(absl::MakeSpan(&value, 1));
+}
+
+Future<> MakeFutureWhenReady(const RCReference<AsyncValue>& value) {
+  return MakeFutureWhenReady(value.get());
+}
+
+Future<> MakeFutureWhenReady(absl::Span<AsyncValue* const> values) {
+  std::vector<RCReference<AsyncValue>> captured;
+  captured.reserve(values.size());
+  for (auto* v : values) {
+    captured.push_back(FormRef(v));
+  }
+  return MakeFutureWhenValuesReady(std::move(captured));
+}
+
+Future<> MakeFutureWhenReady(absl::Span<const RCReference<AsyncValue>> values) {
+  return MakeFutureWhenValuesReady({values.begin(), values.end()});
+}
+
+}  // namespace tsl

--- a/xla/tsl/concurrency/interop.h
+++ b/xla/tsl/concurrency/interop.h
@@ -1,0 +1,47 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_TSL_CONCURRENCY_INTEROP_H_
+#define XLA_TSL_CONCURRENCY_INTEROP_H_
+
+#include "absl/types/span.h"
+#include "xla/tsl/concurrency/async_value.h"
+#include "xla/tsl/concurrency/future.h"
+#include "xla/tsl/concurrency/ref_count.h"
+
+namespace tsl {
+
+// In all APIs below, the returned `Future<>` will become ready on a thread that
+// makes the last pending async value available. To avoid running `OnReady`
+// callbacks on the wrong thread use `Detach` to jump into a separate executor.
+
+// Returns a future that becomes ready when `value` becomes available. If the
+// async value becomes an error, the returned future will also be an error.
+[[nodiscard]] Future<> MakeFutureWhenReady(AsyncValue* value);
+[[nodiscard]] Future<> MakeFutureWhenReady(
+    const RCReference<AsyncValue>& value);
+
+// Returns a future that becomes ready when all `values` become available. If
+// any of the async values become an error, returned future will also be an
+// error. The first encountered async value error will be returned via the
+// future.
+[[nodiscard]] Future<> MakeFutureWhenReady(
+    absl::Span<AsyncValue* const> values);
+[[nodiscard]] Future<> MakeFutureWhenReady(
+    absl::Span<const RCReference<AsyncValue>> values);
+
+}  // namespace tsl
+
+#endif  // XLA_TSL_CONCURRENCY_INTEROP_H_

--- a/xla/tsl/concurrency/interop_test.cc
+++ b/xla/tsl/concurrency/interop_test.cc
@@ -1,0 +1,128 @@
+/* Copyright 2026 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/tsl/concurrency/interop.h"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "xla/tsl/concurrency/async_value.h"
+#include "xla/tsl/concurrency/async_value_ref.h"
+#include "xla/tsl/concurrency/ref_count.h"
+#include "xla/tsl/platform/test.h"
+
+namespace tsl {
+
+// Use this helper function to test that `MakeFutureWhenReady` correctly extends
+// the lifetime of captured async values.
+template <typename T>
+static void SetStateConcrete(AsyncValueRef<T> ref) {
+  ref.SetStateConcrete();
+}
+
+TEST(InteropTest, MakeFutureWhenAsyncValuesReady) {
+  auto v0 = MakeConstructedAsyncValueRef<int32_t>(1);
+  auto v1 = MakeConstructedAsyncValueRef<int32_t>(2);
+
+  auto future = MakeFutureWhenReady({v0.GetAsyncValue(), v1.GetAsyncValue()});
+  ASSERT_FALSE(future.IsReady());
+
+  SetStateConcrete(std::move(v0));
+  SetStateConcrete(std::move(v1));
+
+  ASSERT_TRUE(future.IsReady());
+  EXPECT_EQ(future.Await(), absl::OkStatus());
+}
+
+TEST(InteropTest, MakeFutureWhenRCReferencesReady) {
+  auto v0 = MakeConstructedAsyncValueRef<int32_t>(1);
+  auto v1 = MakeConstructedAsyncValueRef<int32_t>(2);
+
+  std::vector<RCReference<AsyncValue>> values;
+  values.push_back(v0.CopyRCRef());
+  values.push_back(v1.CopyRCRef());
+
+  auto future = MakeFutureWhenReady(values);
+  ASSERT_FALSE(future.IsReady());
+
+  SetStateConcrete(std::move(v0));
+  SetStateConcrete(std::move(v1));
+
+  ASSERT_TRUE(future.IsReady());
+  EXPECT_EQ(future.Await(), absl::OkStatus());
+}
+
+TEST(InteropTest, MakeFutureWhenReadyWithError) {
+  auto v0 = MakeConstructedAsyncValueRef<int32_t>(1);
+  auto v1 = MakeConstructedAsyncValueRef<int32_t>(2);
+
+  auto future = MakeFutureWhenReady({v0.GetAsyncValue(), v1.GetAsyncValue()});
+  ASSERT_FALSE(future.IsReady());
+
+  SetStateConcrete(std::move(v0));
+  v1.SetError(absl::InternalError("test error"));
+
+  ASSERT_TRUE(future.IsReady());
+  EXPECT_EQ(future.Await(), absl::InternalError("test error"));
+}
+
+TEST(InteropTest, MakeFutureWhenAvailable) {
+  auto v0 = MakeAvailableAsyncValueRef<int32_t>(1);
+  auto v1 = MakeAvailableAsyncValueRef<int32_t>(2);
+
+  auto future = MakeFutureWhenReady({v0.GetAsyncValue(), v1.GetAsyncValue()});
+  ASSERT_TRUE(future.IsReady());
+  EXPECT_EQ(future.Await(), absl::OkStatus());
+}
+
+TEST(InteropTest, MakeFutureWhenAsyncValueReady) {
+  auto v0 = MakeConstructedAsyncValueRef<int32_t>(1);
+
+  auto future = MakeFutureWhenReady(v0.GetAsyncValue());
+  ASSERT_FALSE(future.IsReady());
+
+  SetStateConcrete(std::move(v0));
+
+  ASSERT_TRUE(future.IsReady());
+  EXPECT_EQ(future.Await(), absl::OkStatus());
+}
+
+TEST(InteropTest, MakeFutureWhenAsyncValueError) {
+  auto v0 = MakeConstructedAsyncValueRef<int32_t>(1);
+
+  auto future = MakeFutureWhenReady(v0.GetAsyncValue());
+  ASSERT_FALSE(future.IsReady());
+
+  v0.SetError(absl::InternalError("single error"));
+
+  ASSERT_TRUE(future.IsReady());
+  EXPECT_EQ(future.Await(), absl::InternalError("single error"));
+}
+
+TEST(InteropTest, MakeFutureWhenRCReferenceReady) {
+  auto v0 = MakeConstructedAsyncValueRef<int32_t>(1);
+
+  auto future = MakeFutureWhenReady(v0.CopyRCRef());
+  ASSERT_FALSE(future.IsReady());
+
+  SetStateConcrete(std::move(v0));
+
+  ASSERT_TRUE(future.IsReady());
+  EXPECT_EQ(future.Await(), absl::OkStatus());
+}
+
+}  // namespace tsl


### PR DESCRIPTION
PjRt has a mix of `AsyncValue`/`AsyncValueRef` and `Future`. Add a library that helps jumping between different concurrency primitives.