### PR TITLE
[ROCm] Use VLOG(1) for tracer teardown logs

### DIFF
--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -490,7 +490,7 @@ int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
 
 void RocmTracer::toolFinalize(void* tool_data) {
   auto& obj = RocmTracer::GetRocmTracerSingleton();
-  LOG(INFO) << "Calling toolFinalize!";
+  VLOG(1) << "Calling toolFinalize!";
   rocprofiler_stop_context(obj.utility_context_);
   obj.utility_context_.handle = 0;
   rocprofiler_stop_context(obj.context_);


### PR DESCRIPTION
📝 Summary of Changes
The ROCm tracer was using LOG(INFO) in toolFinalize(). Those run during tracer teardown, so the messages were always printed and could still appear after logging was turned off. That broke JAX  tests that expect no log output once logging is disabled i.e tests/logging_test.py::LoggingTest::test_subprocess_toggling_logging_level. The teardown message were switched from LOG(INFO) to VLOG(1)

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

<img width="750" height="426" alt="image" src="https://github.com/user-attachments/assets/9be2487f-c412-4daa-a3cf-640fff8f61eb" />

