### PR TITLE
[XLA:GPU][oneAPI] Fix --config=warnings error on SYCL backend

### DIFF
--- a/xla/stream_executor/sycl/sycl_context_test.cc
+++ b/xla/stream_executor/sycl/sycl_context_test.cc
@@ -22,18 +22,7 @@ limitations under the License.
 namespace stream_executor::sycl {
 namespace {
 
-class SyclContextTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    TF_ASSERT_OK_AND_ASSIGN(
-        Platform * platform,
-        stream_executor::PlatformManager::PlatformWithId(kSyclPlatformId));
-    TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
-                            platform->ExecutorForDevice(kDefaultDeviceOrdinal));
-  }
-};
-
-TEST_F(SyclContextTest, GetDeviceTotalMemory) {
+TEST(SyclContextTest, GetDeviceTotalMemory) {
   TF_ASSERT_OK_AND_ASSIGN(::sycl::device device,
                           SyclDevicePool::GetDevice(kDefaultDeviceOrdinal));
   TF_ASSERT_OK_AND_ASSIGN(uint64_t total_memory,
@@ -42,7 +31,7 @@ TEST_F(SyclContextTest, GetDeviceTotalMemory) {
       << "Total memory should be greater than 0, got " << total_memory;
 }
 
-TEST_F(SyclContextTest, CreateAndSynchronizeContext) {
+TEST(SyclContextTest, CreateAndSynchronizeContext) {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<SyclContext> sycl_context_ptr,
                           SyclContext::Create(kDefaultDeviceOrdinal));
   EXPECT_NE(sycl_context_ptr, nullptr);


### PR DESCRIPTION
PR #37430 enables warnings as errors by default. Due to this change, the following error occurs on the SYCL backend:

`xla/stream_executor/sycl/sycl_context_test.cc:31:46: error: unused variable 'executor' [-Werror,-Wunused-variable] 31 |     TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,`

This PR fixes the above error.
