### PR TITLE
DRAFT: [xla:gpu] Add support for GPU coredumps on detected hangs

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -434,6 +434,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_executable_warn_stuck_timeout_seconds(10);
   opts.set_xla_gpu_executable_terminate_timeout_seconds(30);
   opts.set_xla_gpu_execution_terminate_timeout("inf");
+  opts.set_xla_gpu_execution_terminate_coredump_pipe("");
 
   opts.set_xla_gpu_first_collective_call_warn_stuck_timeout_seconds(20);
   opts.set_xla_gpu_first_collective_call_terminate_timeout_seconds(40);
@@ -2517,6 +2518,15 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
           &DebugOptions::set_xla_gpu_execution_terminate_timeout),
       debug_options->xla_gpu_execution_terminate_timeout(),
       "Set timeout for XLA:GPU execution to prevent undetected deadlocks"));
+
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_execution_terminate_coredump_pipe",
+      string_setter_for(
+          &DebugOptions::set_xla_gpu_execution_terminate_coredump_pipe),
+      debug_options->xla_gpu_execution_terminate_coredump_pipe(),
+      "Path to the GPU coredump named pipe (e.g. the same path as "
+      "CUDA_COREDUMP_PIPE). When set, XLA writes to this pipe to trigger a "
+      "GPU coredump before aborting on execution timeout."));
 
   flag_list->push_back(tsl::Flag(
       "xla_gpu_first_collective_call_warn_stuck_timeout_seconds",

--- a/xla/runtime/hang_watchdog.h
+++ b/xla/runtime/hang_watchdog.h
@@ -50,9 +50,13 @@ class HangWatchdog {
 
   HangWatchdog(tsl::Env* env, absl::string_view name);
 
-  // Returns a cancel callback that will abort the process.
+  // Returns a cancel callback that will abort the process. If `pre_abort` is
+  // provided, it is invoked after logging the timeout but before aborting,
+  // giving callers a chance to collect diagnostics (e.g. trigger GPU
+  // coredumps).
   static CancelCallback Abort(absl::string_view action,
-                              absl::Duration duration);
+                              absl::Duration duration,
+                              CancelCallback pre_abort = nullptr);
 
   // Issues the watch guard to a caller that watchdog started tracking progress
   // of the action and expects it to finish in the given duration. If action

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -707,6 +707,7 @@ cc_library(
         "//xla:status_macros",
         "//xla:util",
         "//xla:xla_proto_cc",
+        "//xla/stream_executor/gpu:coredump",
         "//xla/backends/gpu/collectives:gpu_clique_key",
         "//xla/backends/gpu/collectives:gpu_collectives",
         "//xla/backends/gpu/runtime:annotation",

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -56,6 +56,22 @@ cc_library(
 )
 
 cc_library(
+    name = "coredump",
+    srcs = ["coredump.cc"],
+    hdrs = ["coredump.h"],
+    deps = [
+        "//xla/tsl/platform:env",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+    ],
+)
+
+cc_library(
     name = "context_map",
     hdrs = ["context_map.h"],
     deps = [

--- a/xla/stream_executor/gpu/coredump.cc
+++ b/xla/stream_executor/gpu/coredump.cc
@@ -1,0 +1,95 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/gpu/coredump.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/base/const_init.h"
+#include "absl/cleanup/cleanup.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "xla/tsl/platform/env.h"
+#include "xla/tsl/platform/file_system.h"
+
+namespace stream_executor::gpu {
+
+// Performs the actual coredump trigger. Called exactly once under the mutex.
+static absl::Status TriggerGpuCoredumpImpl(absl::string_view pipe_path,
+                                           absl::Duration wait_duration) {
+  tsl::Env* env = tsl::Env::Default();
+
+  // Write a single byte to the named pipe to trigger GPU coredump generation.
+  std::unique_ptr<tsl::WritableFile> file;
+
+  if (absl::Status s = env->NewWritableFile(std::string(pipe_path), &file);
+      !s.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to open GPU coredump pipe '%s': %s. For CUDA, check that "
+        "CUDA_ENABLE_USER_TRIGGERED_COREDUMP=1 and CUDA_COREDUMP_PIPE are "
+        "set correctly.",
+        pipe_path, s.message()));
+  }
+
+  if (absl::Status s = file->Append("1"); !s.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to write to GPU coredump pipe '%s': %s",
+                        pipe_path, s.message()));
+  }
+
+  if (absl::Status s = file->Close(); !s.ok()) {
+    return absl::InternalError(absl::StrFormat(
+        "Failed to close GPU coredump pipe '%s': %s", pipe_path, s.message()));
+  }
+
+  absl::SleepFor(wait_duration);
+  return absl::OkStatus();
+}
+
+absl::Status TriggerGpuCoredump(absl::string_view pipe_path,
+                                absl::Duration wait_duration) {
+  // Use a mutex so that only one thread triggers the coredump and all other
+  // threads wait for it to complete before returning. This prevents any thread
+  // from reaching LOG(FATAL) in the Abort callback while the coredump is still
+  // being written.
+  //
+  // Use a timeout to avoid hanging forever if the coredump itself gets stuck
+  // (e.g. a pipe write blocks indefinitely). After the timeout, waiting threads
+  // give up and let the caller proceed to abort.
+  static absl::Mutex mu(absl::kConstInit);
+  static absl::Status* result = nullptr;
+
+  // Add one second to give the trigger implementation one extra second to
+  // finish, so we don't get time out errors because of the jitter.
+  absl::Duration lock_wait = wait_duration + absl::Seconds(1);
+
+  if (!mu.LockWhenWithTimeout(absl::Condition::kTrue, lock_wait)) {
+    return absl::DeadlineExceededError(
+        "Timed out waiting for GPU coredump trigger to complete");
+  }
+  absl::Cleanup unlock = [] { mu.Unlock(); };
+
+  if (result == nullptr) {
+    result = new absl::Status(TriggerGpuCoredumpImpl(pipe_path, wait_duration));
+  }
+  return *result;
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/gpu/coredump.h
+++ b/xla/stream_executor/gpu/coredump.h
@@ -1,0 +1,61 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_GPU_COREDUMP_H_
+#define XLA_STREAM_EXECUTOR_GPU_COREDUMP_H_
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/time.h"
+
+namespace stream_executor::gpu {
+
+// Triggers GPU coredump generation by writing to a coredump named pipe.
+//
+// On CUDA, the runtime supports user-triggered coredumps when the process is
+// launched with the following environment variables:
+//
+//   CUDA_ENABLE_USER_TRIGGERED_COREDUMP=1
+//   CUDA_ENABLE_LIGHTWEIGHT_COREDUMP=1
+//   CUDA_COREDUMP_FILE=<path_to_coredump_output>
+//   CUDA_COREDUMP_PIPE=<path_to_named_pipe>
+//   CUDA_COREDUMP_SHOW_PROGRESS=1
+//
+// When these are set, the CUDA runtime creates a named pipe at the path
+// specified by CUDA_COREDUMP_PIPE. Writing a single byte to this pipe signals
+// the CUDA runtime to generate a GPU coredump containing the state of all
+// active GPU contexts.
+//
+// This function is designed to be called from the hang watchdog abort handler,
+// where multiple threads (one per GPU guard) may attempt to trigger a coredump
+// simultaneously. Only the first caller performs the actual trigger; subsequent
+// concurrent callers block until the trigger completes, then return.
+//
+// After writing to the pipe, the function sleeps for `wait_duration` to allow
+// the GPU runtime to finish writing the coredump files before the process is
+// aborted.
+//
+// Returns OkStatus on success. Returns an error status if the pipe cannot be
+// opened or written to.
+//
+// `pipe_path`: Path to the GPU coredump named pipe (same as CUDA_COREDUMP_PIPE)
+// `wait_duration`: How long to sleep after triggering to let the GPU runtime
+//                  finish writing coredumps
+absl::Status TriggerGpuCoredump(absl::string_view pipe_path,
+                                absl::Duration wait_duration);
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_GPU_COREDUMP_H_

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -653,6 +653,17 @@ message DebugOptions {
   // Simple examples include "300ms", "-1.5h", and "2h45m". Default is "inf".
   optional string xla_gpu_execution_terminate_timeout = 451;
 
+  // Path to the GPU coredump named pipe. When set together with
+  // xla_gpu_execution_terminate_timeout, XLA writes a trigger byte to this
+  // pipe before aborting the process on execution timeout, causing the GPU
+  // runtime to generate a coredump for debugging hung kernels or collective
+  // operations.
+  //
+  // For CUDA, the runtime creates a named pipe at this path when launched
+  // with CUDA_ENABLE_USER_TRIGGERED_COREDUMP=1 and CUDA_COREDUMP_PIPE set
+  // to the same path. This should match the value of CUDA_COREDUMP_PIPE.
+  optional string xla_gpu_execution_terminate_coredump_pipe = 455;
+
   optional bool xla_gpu_exhaustive_tiling_search = 219;
 
   // If true, autotune all fusions with block level emitter.
@@ -1403,7 +1414,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 455
+  // Next id: 456
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
When `HangWatchdog` detects that `GpuExecutable` stuck, add a way to dump the GPU state to a file. For CUDA platform it enables `cuda-dbg` to look at what GPU kernels were running on device at the time of detected deadlock.