### PR TITLE
[ROCm] Add RCCL FP8 support

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -592,6 +592,7 @@ cc_library(
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/rocm:rocm_compute_capability",
         "//xla/tsl/concurrency:executor",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:errors",

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -82,12 +82,15 @@ static size_t ToNcclCount(PrimitiveType dtype, size_t count) {
   return primitive_util::IsComplexType(dtype) ? count * 2 : count;
 }
 
-static absl::StatusOr<ncclDataType_t> ToNcclDataType(PrimitiveType dtype,
-                                                     bool is_reduction_op) {
+static absl::StatusOr<ncclDataType_t> ToNcclDataType(
+    PrimitiveType dtype, bool is_reduction_op,
+    se::RocmComputeCapability rocm_cc) {
   switch (dtype) {
     case S8:
     case F8E5M2:
+      return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e5m2 : ncclInt8;
     case F8E4M3FN:
+      return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e4m3 : ncclInt8;
     case F8E5M2FNUZ:
     case F8E4M3FNUZ:
     case F8E8M0FNU:
@@ -554,7 +557,11 @@ absl::Status RcclCommunicator::LaunchAllReduce(
       recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
       count, reduction_kind, comm_, stream);
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclAllReduce(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
@@ -582,7 +589,11 @@ absl::Status RcclCommunicator::LaunchBroadcast(
       recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
       count, root.value(), comm_, stream);
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclBroadcast(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
@@ -610,7 +621,11 @@ absl::Status RcclCommunicator::LaunchReduceScatter(
       recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
       count, reduction_kind, comm_, stream);
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclReduceScatter(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
@@ -637,7 +652,11 @@ absl::Status RcclCommunicator::LaunchAllGather(
       recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
       count, comm_, stream);
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclAllGather(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
@@ -684,7 +703,11 @@ absl::Status RcclCommunicator::LaunchAllToAll(
         send_buffers.size(), num_ranks);
   }
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(GroupStart());
   for (size_t i = 0; i < send_buffers.size(); ++i) {
@@ -725,7 +748,11 @@ absl::Status RcclCommunicator::LaunchCollectivePermute(
       source_rank ? absl::StrCat(source_rank->value()) : "<empty>",
       absl::StrJoin(target_ranks, ", ", rank_formatter), count, comm_, stream);
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   // Short-circuit if there is no source or target rank.
   if (!source_rank && target_ranks.empty()) {
@@ -767,7 +794,11 @@ absl::Status RcclCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
       primitive_util::LowercasePrimitiveTypeName(dtype), count, peer.value(),
       comm_, stream);
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(
       ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
@@ -794,7 +825,11 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
       primitive_util::LowercasePrimitiveTypeName(dtype), count, peer.value(),
       comm_, stream);
 
-  TF_ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype, ToNcclDataType(dtype, false));
+  TF_ASSIGN_OR_RETURN(
+      ncclDataType_t nccl_dtype,
+      ToNcclDataType(
+          dtype, false,
+          stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(
       ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -86,11 +86,11 @@ static absl::StatusOr<ncclDataType_t> ToNcclDataType(
     PrimitiveType dtype, bool is_reduction_op,
     se::RocmComputeCapability rocm_cc) {
   switch (dtype) {
-    case S8:
     case F8E5M2:
       return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e5m2 : ncclInt8;
     case F8E4M3FN:
       return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e4m3 : ncclInt8;
+    case S8:
     case F8E5M2FNUZ:
     case F8E4M3FNUZ:
     case F8E8M0FNU:
@@ -560,7 +560,7 @@ absl::Status RcclCommunicator::LaunchAllReduce(
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/true,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclAllReduce(
@@ -592,7 +592,7 @@ absl::Status RcclCommunicator::LaunchBroadcast(
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/false,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclBroadcast(
@@ -624,7 +624,7 @@ absl::Status RcclCommunicator::LaunchReduceScatter(
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/true,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclReduceScatter(
@@ -655,7 +655,7 @@ absl::Status RcclCommunicator::LaunchAllGather(
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/false,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclAllGather(
@@ -706,7 +706,7 @@ absl::Status RcclCommunicator::LaunchAllToAll(
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/false,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(GroupStart());
@@ -751,7 +751,7 @@ absl::Status RcclCommunicator::LaunchCollectivePermute(
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/false,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   // Short-circuit if there is no source or target rank.
@@ -797,7 +797,7 @@ absl::Status RcclCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/false,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(
@@ -828,7 +828,7 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
   TF_ASSIGN_OR_RETURN(
       ncclDataType_t nccl_dtype,
       ToNcclDataType(
-          dtype, false,
+          dtype, /*is_reduction_op=*/false,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
   TF_RETURN_IF_ERROR(XLA_RCCL_STATUS(

--- a/xla/tests/all_reduce_e2e_test.cc
+++ b/xla/tests/all_reduce_e2e_test.cc
@@ -91,9 +91,18 @@ class AllReduceTestNoParams : public CollectiveOpsWithFlagsBase {
 
   void SetUp() override {
     CollectiveOpsE2ETestBase::SetUp();
-    if (!IsAmpereAndHigher()) {
-      GTEST_SKIP() << "Test requires Ampere or newer architecture since it's "
-                      "using triton.";
+    // Check for Triton support: Ampere+ for CUDA, MI300+ for ROCm
+    bool has_triton_support = false;
+    if (Capability().IsCuda()) {
+      has_triton_support = IsAmpereAndHigher();
+    } else if (Capability().IsRocm()) {
+      has_triton_support =
+          Capability().rocm_compute_capability()->gfx9_mi300_series();
+    }
+
+    if (!has_triton_support) {
+      GTEST_SKIP() << "Test requires Ampere or newer architecture (CUDA) or "
+                      "MI300+ (ROCm) since it's using triton.";
     }
   }
 };
@@ -426,9 +435,17 @@ TEST_P(AllReduceTest, F32_8GPUs_2ReplicasPerGroup) {
 
 // FP8 vs FP16 training step comparison.
 TEST_F(AllReduceTestNoParams, AsyncAllReduce_F8E4M3FN_TrainingStep_2GPUs) {
-  if (!Capability().IsCuda() ||
-      !Capability().cuda_compute_capability()->IsAtLeast(9, 0)) {
-    GTEST_SKIP() << "FP8 requires CUDA with Hopper or newer architecture.";
+  bool has_fp8_support = false;
+  if (Capability().IsCuda()) {
+    has_fp8_support = Capability().cuda_compute_capability()->IsAtLeast(9, 0);
+  } else if (Capability().IsRocm()) {
+    has_fp8_support =
+        Capability().rocm_compute_capability()->has_ocp_fp8_support();
+  }
+
+  if (!has_fp8_support) {
+    GTEST_SKIP() << "FP8 requires GPU with OCP FP8 support (CUDA Hopper+ or "
+                    "ROCm MI350/gfx12xx with ROCm 7.0+).";
   }
 
   // FP16 baseline
@@ -550,11 +567,18 @@ TEST_F(AllReduceTestNoParams, AsyncAllReduce_F8E4M3FN_TrainingStep_2GPUs) {
   EXPECT_GT(max_abs_diff, 1e-3f);
 }
 
-// Test that FP8 all-reduce fails on pre-Hopper GPUs.
-TEST_F(AllReduceTestNoParams, AsyncAllReduce_F8E4M3FN_FailsOnPreHopper) {
+// Test that FP8 all-reduce fails on pre-Hopper CUDA GPUs without FP8 support.
+// Note: ROCm is skipped because it has a fallback to ncclInt8 for all GPUs.
+TEST_F(AllReduceTestNoParams, AsyncAllReduce_F8E4M3FN_FailsOnUnsupportedGPUs) {
+  if (Capability().IsRocm()) {
+    GTEST_SKIP()
+        << "Test is CUDA-only. ROCm has fallback to ncclInt8 for all GPUs.";
+  }
+
   if (!Capability().IsCuda()) {
     GTEST_SKIP() << "Test requires CUDA.";
   }
+
   if (Capability().cuda_compute_capability()->IsAtLeast(9, 0)) {
     GTEST_SKIP() << "Test requires pre-Hopper GPU (compute capability < 9.0).";
   }

--- a/xla/tests/all_reduce_e2e_test.cc
+++ b/xla/tests/all_reduce_e2e_test.cc
@@ -91,18 +91,10 @@ class AllReduceTestNoParams : public CollectiveOpsWithFlagsBase {
 
   void SetUp() override {
     CollectiveOpsE2ETestBase::SetUp();
-    // Check for Triton support: Ampere+ for CUDA, MI300+ for ROCm
-    bool has_triton_support = false;
-    if (Capability().IsCuda()) {
-      has_triton_support = IsAmpereAndHigher();
-    } else if (Capability().IsRocm()) {
-      has_triton_support =
-          Capability().rocm_compute_capability()->gfx9_mi300_series();
-    }
-
-    if (!has_triton_support) {
-      GTEST_SKIP() << "Test requires Ampere or newer architecture (CUDA) or "
-                      "MI300+ (ROCm) since it's using triton.";
+    // Check for Triton support: Ampere+ for CUDA, any supported GPU for ROCm
+    if (Capability().IsCuda() && !IsAmpereAndHigher()) {
+      GTEST_SKIP() << "Test requires Ampere or newer architecture for CUDA "
+                      "since it's using triton.";
     }
   }
 };


### PR DESCRIPTION
📝 Summary of Changes
Enable FP8 support on RCCL.

🎯 Justification
GPU architecture `gfx9_mi350` and subsequent generations (ROCm 7.0+) support FP8 datatype in RCCL.
This PR enables FP8 support in a similar way to what was done in PR https://github.com/openxla/xla/pull/36158 for NCCL.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature

🧪 Execution Tests:
Extends the tests added in  https://github.com/openxla/xla/pull/36158 to run on ROCm targets as well.
