### PR TITLE
[xla:gpu] Add a stress test for HangWatchdog + a delay before abort

### DIFF
--- a/xla/runtime/BUILD
+++ b/xla/runtime/BUILD
@@ -107,7 +107,9 @@ cc_library(
     hdrs = ["hang_watchdog.h"],
     deps = [
         "//xla/tsl/platform:env",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",

--- a/xla/runtime/hang_watchdog.h
+++ b/xla/runtime/hang_watchdog.h
@@ -16,11 +16,12 @@ limitations under the License.
 #ifndef XLA_RUNTIME_HANG_WATCHDOG_H_
 #define XLA_RUNTIME_HANG_WATCHDOG_H_
 
-#include <functional>
+#include <cstddef>
 #include <memory>
 #include <vector>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/functional/any_invocable.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
@@ -30,36 +31,41 @@ limitations under the License.
 namespace xla {
 
 // HangWatchdog is responsible for watching XLA actions to make progress and
-// finish in reasonable time. If the action doesn't complete in the given
-// timeout, then the watchdog calls the cancellation callback which typically
+// finish in a reasonable time. If the action doesn't complete in the given
+// timeout, then the watchdog calls the cancellation callback, which typically
 // aborts the process if there is no other way to safely cancel the action.
 //
-// For example if XLA:GPU execution doesn't finish under a minute it is
+// For example, if XLA:GPU execution doesn't finish under a minute, it is
 // reasonable to assume that it deadlocked in one of the GPU kernels or inside
-// the collective operation. There is no way to recover from such deadlock
-// except aborting the process. In distributed environment XLA tracks alive
-// devices using `IncarnationId`, but this might not be enough to detect hangs
-// as all processes are alive, but not making any progress.
+// a collective operation. There is no way to recover from such a deadlock
+// except aborting the process. In a distributed environment, XLA tracks alive
+// devices using `IncarnationId`, but this might not be enough to detect hangs,
+// as all processes are alive but not making any progress.
+//
+// IMPORTANT: Cancellation callbacks must be cheap; running expensive work
+// inside the callback can delay processing of other guards. Be careful with
+// setting AsyncValue/Future in the callback, as it will process all OnReady
+// callbacks in the caller thread.
 class HangWatchdog {
  public:
   // Forward declare.
   struct Guard;
 
   // Cancel callback has to be copyable because we pass it to thread pool.
-  using CancelCallback = std::function<void()>;
+  using CancelCallback = absl::AnyInvocable<void() &&>;
 
-  HangWatchdog(tsl::Env* env, absl::string_view name);
+  HangWatchdog(tsl::Env* env, absl::string_view name, size_t num_threads = 1);
 
   // Returns a cancel callback that will abort the process.
   static CancelCallback Abort(absl::string_view action,
                               absl::Duration duration);
 
-  // Issues the watch guard to a caller that watchdog started tracking progress
-  // of the action and expects it to finish in the given duration. If action
-  // doesn't finish within the given duration the watchdog will call the
-  // `cancel` callback. Action considered completed when the watch guard gets
-  // destructed. It is up to the caller to make sure that guard is destroyed
-  // when the action is completed.
+  // Issues a watch guard to the caller indicating that the watchdog has started
+  // tracking the action and expects it to finish in the given duration. If the
+  // action doesn't finish within the given duration, the watchdog will call the
+  // `cancel` callback. The action is considered completed when the watch guard
+  // is destructed. It is up to the caller to make sure that the guard is
+  // destroyed when the action is completed.
   std::shared_ptr<Guard> Watch(absl::string_view action,
                                absl::Duration duration, CancelCallback cancel);
 
@@ -70,10 +76,12 @@ class HangWatchdog {
   // head-of-line blocking a thread pool thread for the entire watch duration.
   void ScheduleCheck(std::weak_ptr<Guard> guard, absl::Duration sleep_interval);
 
-  tsl::thread::ThreadPool thread_pool_;
-
   absl::Mutex mu_;
   std::vector<std::weak_ptr<Guard>> guards_ ABSL_GUARDED_BY(mu_);
+
+  // Thread pool must be declared last so it is destroyed first, joining all
+  // pending ScheduleCheck tasks before `mu_` and `guards_` are destroyed.
+  tsl::thread::ThreadPool thread_pool_;
 };
 
 }  // namespace xla

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -115,6 +115,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
 #include "xla/util/split_proto/split_gpu_executable_writer.h"
@@ -122,7 +123,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -130,8 +130,11 @@ namespace gpu {
 namespace {
 
 HangWatchdog& StaticHangWatchDog() {
-  static absl::NoDestructor<HangWatchdog> watchdog(tsl::Env::Default(),
-                                                   "gpu-executable");
+  // Create a GPU execution hang watchdog with 2 threads. One thread counts down
+  // a grace period before aborting. The other thread reports detected hangs for
+  // all devices in the current process.
+  static absl::NoDestructor<HangWatchdog> watchdog(
+      tsl::Env::Default(), "gpu-executable", /*num_threads=*/2);
   return *watchdog;
 }
 


### PR DESCRIPTION
Add a stress test for multi-threaded hang watchdog to make sure it doesn't have any asan errors.