### PR TITLE
[XLA:GPU][oneAPI] Autotuning stub for Intel GPU Compiler

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3582,8 +3582,6 @@ cc_library(
     deps = [
         ":gpu_compiler",
         ":target_constants",
-        "//xla:debug_options_flags",
-        "//xla/hlo/analysis:hlo_dataflow_analysis",
         "//xla/hlo/ir:hlo",
         "//xla/service:dump",
         "//xla/service/gpu/llvm_gpu_backend:spirv_backend",

--- a/xla/service/gpu/intel_gpu_compiler.cc
+++ b/xla/service/gpu/intel_gpu_compiler.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/service/gpu/intel_gpu_compiler.h"
 
-#include "xla/debug_options_flags.h"
 #include "xla/service/dump.h"
 #include "xla/service/gpu/llvm_gpu_backend/spirv_backend.h"
 #include "xla/service/gpu/target_constants.h"
@@ -33,7 +32,21 @@ absl::Status IntelGpuCompiler::OptimizeHloConvolutionCanonicalization(
     se::dnn::VersionInfo dnn_version,
     const se::SemanticVersion& toolkit_version,
     CompilationStats* compilation_stats) {
-  // Note: this is a stub.
+  // Return OkStatus as a stub.
+  return absl::OkStatus();
+}
+
+absl::Status IntelGpuCompiler::AddConvAndGemmAutotuningPass(
+    HloPassPipeline* pipeline, HloModule* hlo_module,
+    const se::GpuComputeCapability& gpu_version, const CompileOptions& options,
+    AutotuneConfig& autotune_config, tsl::thread::ThreadPool* thread_pool,
+    se::StreamExecutor* stream_exec,
+    const Compiler::GpuTargetConfig* target_config,
+    const MultiProcessKeyValueStore& key_value_store,
+    const se::SemanticVersion& toolkit_version, const AliasInfo* alias_info,
+    const DebugOptions& debug_options, mlir::MLIRContext* mlir_context,
+    HloCostAnalysis::ShapeSizeFunction shape_size_fn) {
+  // Return OkStatus as a stub.
   return absl::OkStatus();
 }
 

--- a/xla/service/gpu/intel_gpu_compiler.h
+++ b/xla/service/gpu/intel_gpu_compiler.h
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include "absl/status/statusor.h"
 #include "llvm/IR/Module.h"
-#include "xla/hlo/analysis/hlo_dataflow_analysis.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/gpu/gpu_compiler.h"
 #include "xla/stream_executor/semantic_version.h"
@@ -39,6 +38,17 @@ class IntelGpuCompiler : public GpuCompiler {
       se::dnn::VersionInfo dnn_version,
       const se::SemanticVersion& toolkit_version,
       CompilationStats* compilation_stats) override;
+
+  absl::Status AddConvAndGemmAutotuningPass(
+      HloPassPipeline* pipeline, HloModule* hlo_module,
+      const se::GpuComputeCapability& gpu_version,
+      const CompileOptions& options, AutotuneConfig& autotune_config,
+      tsl::thread::ThreadPool* thread_pool, se::StreamExecutor* stream_exec,
+      const Compiler::GpuTargetConfig* target_config,
+      const MultiProcessKeyValueStore& key_value_store,
+      const se::SemanticVersion& toolkit_version, const AliasInfo* alias_info,
+      const DebugOptions& debug_options, mlir::MLIRContext* mlir_context,
+      HloCostAnalysis::ShapeSizeFunction shape_size_fn) override;
 
   absl::StatusOr<BackendCompileResult> CompileTargetBinary(
       const HloModuleConfig& module_config, llvm::Module* llvm_module,


### PR DESCRIPTION
This PR provides a stub to IntelGpuCompiler for convolution and gemm autotuning pass. Without this stub many tests fail on SYCL platform.
