### PR TITLE
[ROCm] Fix triton integration failures

### DIFF
--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -120,7 +120,8 @@ static void MakeTTGIR(mlir::OpPassManager* pm,
         mlir::createTritonAMDGPUInThreadTranspose());
     pm->addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   }
-  pm->addPass(mlir::createTritonAMDGPUMoveUpPrologueLoads());
+  pm->addNestedPass<mlir::triton::FuncOp>(
+      mlir::createTritonAMDGPUMoveUpPrologueLoads());
   if (use_block_pingpong && num_stages > 1) {
     pm->addPass(mlir::createTritonAMDGPUBlockPingpong({num_stages}));
   }
@@ -133,7 +134,8 @@ static void MakeTTGIR(mlir::OpPassManager* pm,
        /*analyzeSmallTensorOfst*/ false}));
 
   pm->addPass(mlir::createTritonAMDFoldTrueCmpI());
-  pm->addPass(mlir::createTritonAMDGPUPrepareIfCombining());
+  pm->addNestedPass<mlir::triton::FuncOp>(
+      mlir::createTritonAMDGPUPrepareIfCombining());
   pm->addPass(mlir::createCanonicalizerPass());
   pm->addPass(mlir::createCSEPass());
   pm->addPass(mlir::createSymbolDCEPass());


### PR DESCRIPTION
📝 Summary of Changes
Fix ROCm test failures after triton integration:
//xla/hlo/builder/lib:self_adjoint_eig_test_amdgpu_any
//xla/hlo/builder/lib:svd_test_amdgpu_any
//xla/tests:conditional_test_amdgpu_any
//xla/tests:dot_operation_autotune_disabled_test_amdgpu_any //xla/tests:dot_operation_single_threaded_runtime_test_amdgpu_any

🎯 Justification
TritonAMDGPUMoveUpPrologueLoads and TritonAMDGPUPrepareIfCombining are changed to function pass which needs adaptation correspondingly.

🚀 Kind of Contribution
🐛 Bug Fix

@xla-rotation Would you help take a look please?