### PR TITLE
[ROCm] Refactor cub_sort_kernel_rocm.cu.cc

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1141,9 +1141,24 @@ rocm_library(
     alwayslink = 1,
 )
 
+# CUB sort kernel header
+cc_library(
+    name = "cub_sort_kernel_rocm_header",
+    hdrs = ["cub_sort_kernel_rocm.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+# CUB sort kernel implementation (hipCUB/rocPRIM) - compiled with hipcc
 [rocm_library(
-    name = "cub_sort_kernel_rocm_{}".format(typename),
-    srcs = ["cub_sort_kernel_rocm.cu.cc"],
+    name = "cub_sort_kernel_rocm_impl_{}".format(typename),
+    srcs = ["cub_sort_kernel_rocm_impl.cu.cc"],
     # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
     local_defines = ["CUB_TYPE_" + typename.upper()],
     tags = [
@@ -1151,15 +1166,34 @@ rocm_library(
         "rocm-only",
     ],
     deps = [
+        ":cub_sort_kernel_rocm_header",
+        ":rocm_status",
+        "@com_google_absl//absl/status",
+        "@eigen_archive//:eigen3",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocprim",
+        "@tsl//tsl/platform:bfloat16",
+    ],
+    alwayslink = 1,
+) for typename in get_cub_sort_kernel_types()]
+
+# CUB sort kernel FFI registration - compiled with regular C++ compiler
+[cc_library(
+    name = "cub_sort_kernel_rocm_{}".format(typename),
+    srcs = ["cub_sort_kernel_rocm.cc"],
+    local_defines = ["CUB_TYPE_" + typename.upper()],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":cub_sort_kernel_rocm_header",
+        ":cub_sort_kernel_rocm_impl_{}".format(typename),
         "//xla/backends/gpu:ffi",
         "//xla/ffi",
         "//xla/ffi:ffi_api",
-        "//xla/stream_executor/rocm:rocm_status",
-        "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
-        "@eigen_archive//:eigen3",
-        "@local_config_rocm//rocm:rocprim",
-        "@tsl//tsl/platform:bfloat16",
+        "@local_config_rocm//rocm:rocm_headers",
     ],
     alwayslink = 1,
 ) for typename in get_cub_sort_kernel_types()]

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
@@ -1,4 +1,4 @@
-/* Copyright 2023 The OpenXLA Authors.
+/* Copyright 2026 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
@@ -13,126 +13,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "xla/stream_executor/rocm/cub_sort_kernel_rocm.h"
+
 #include <cstddef>
 #include <cstdint>
 
 #include "absl/status/status.h"
-#include "Eigen/Core"
+#include "rocm/include/hip/hip_bfloat16.h"
+#include "rocm/include/hip/hip_fp16.h"
 #include "rocm/include/hip/hip_runtime.h"
-#include "rocm/include/hipcub/backend/rocprim/device/device_radix_sort.hpp"
-#include "rocm/include/hipcub/backend/rocprim/device/device_segmented_radix_sort.hpp"
-#include "rocm/include/rocprim/thread/radix_key_codec.hpp"
-#include "rocm/include/rocprim/type_traits.hpp"
-#include "rocm/rocm_config.h"
 #include "xla/backends/gpu/ffi.h"
 #include "xla/ffi/ffi.h"
 #include "xla/ffi/ffi_api.h"  // IWYU pragma: keep
-#include "xla/stream_executor/rocm/rocm_status.h"
-#include "tsl/platform/bfloat16.h"
-
-// Required for sorting Eigen::half and bfloat16.
-namespace rocprim {
-
-#if (TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000)
-namespace detail {
-template <>
-struct float_bit_mask<Eigen::half> {
-  static constexpr uint16_t sign_bit = 0x8000;
-  static constexpr uint16_t exponent = 0x7C00;
-  static constexpr uint16_t mantissa = 0x03FF;
-  using bit_type = uint16_t;
-};
-
-template <>
-struct float_bit_mask<tsl::bfloat16> {
-  static constexpr uint16_t sign_bit = 0x8000;
-  static constexpr uint16_t exponent = 0x7F80;
-  static constexpr uint16_t mantissa = 0x007F;
-  using bit_type = uint16_t;
-};
-
-template <>
-struct radix_key_codec_base<Eigen::half>
-    : radix_key_codec_floating<Eigen::half, uint16_t> {};
-template <>
-struct radix_key_codec_base<tsl::bfloat16>
-    : radix_key_codec_floating<tsl::bfloat16, uint16_t> {};
-}  // namespace detail
-#else   // TF_ROCM_VERSION >= 70000
-namespace traits {
-
-template <>
-struct define<Eigen::half> {
-  using float_bit_mask =
-      rocprim::traits::float_bit_mask::values<uint16_t, 0x8000, 0x7C00, 0x03FF>;
-  using is_arithmetic = rocprim::traits::is_arithmetic::values<true>;
-  using number_format = rocprim::traits::number_format::values<
-      traits::number_format::kind::floating_point_type>;
-};
-
-template <>
-struct define<tsl::bfloat16> {
-  using float_bit_mask =
-      rocprim::traits::float_bit_mask::values<uint16_t, 0x8000, 0x7F80, 0x007F>;
-  using is_arithmetic = rocprim::traits::is_arithmetic::values<true>;
-  using number_format = rocprim::traits::number_format::values<
-      traits::number_format::kind::floating_point_type>;
-};
-
-}  // namespace traits
-#endif  // TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000
-
-};  // namespace rocprim
 
 namespace stream_executor {
 namespace rocm {
 namespace {
-
-template <typename KeyT>
-absl::Status CubSortKeys(void* d_temp_storage, size_t& temp_bytes,
-                         const void* d_keys_in, void* d_keys_out,
-                         size_t num_items, bool descending,
-                         hipStream_t stream) {
-  auto err =
-      descending
-          ? hipcub::DeviceRadixSort::SortKeysDescending<KeyT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out), num_items, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream)
-          : hipcub::DeviceRadixSort::SortKeys<KeyT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out), num_items, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream);
-  return stream_executor::gpu::ToStatus(err);
-}
-
-template <typename KeyT>
-absl::Status CubSortKeys(void* d_temp_storage, size_t& temp_bytes,
-                         const void* d_keys_in, void* d_keys_out,
-                         size_t num_items, bool descending, size_t batch_size,
-                         hipStream_t stream) {
-  if (batch_size == 1) {
-    return CubSortKeys<KeyT>(d_temp_storage, temp_bytes, d_keys_in, d_keys_out,
-                             num_items, descending, stream);
-  }
-  void* d_offsets = static_cast<char*>(d_temp_storage) + temp_bytes;
-  int* start_offsets =
-      d_temp_storage != nullptr ? static_cast<int*>(d_offsets) : nullptr;
-  int* end_offsets = start_offsets != nullptr ? start_offsets + 1 : nullptr;
-  auto err =
-      descending
-          ? hipcub::DeviceSegmentedRadixSort::SortKeysDescending<KeyT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out), num_items, batch_size,
-                start_offsets, end_offsets, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream)
-          : hipcub::DeviceSegmentedRadixSort::SortKeys<KeyT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out), num_items, batch_size,
-                start_offsets, end_offsets, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream);
-  return stream_executor::gpu::ToStatus(err);
-}
 
 template <typename KeyT>
 absl::Status CubSortKeysExecute(
@@ -150,63 +46,6 @@ absl::Status CubSortKeysGetScratchSize(size_t* temp_bytes, size_t num_items,
                                        size_t batch_size) {
   return CubSortKeys<KeyT>(nullptr, *temp_bytes, nullptr, nullptr, num_items,
                            false, batch_size, nullptr);
-}
-
-template <typename KeyT, typename ValT>
-absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
-                          const void* d_keys_in, void* d_keys_out,
-                          const void* d_values_in, void* d_values_out,
-                          size_t num_items, bool descending,
-                          hipStream_t stream) {
-  auto err =
-      descending
-          ? hipcub::DeviceRadixSort::SortPairsDescending<KeyT, ValT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out),
-                static_cast<const ValT*>(d_values_in),
-                static_cast<ValT*>(d_values_out), num_items, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream)
-          : hipcub::DeviceRadixSort::SortPairs<KeyT, ValT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out),
-                static_cast<const ValT*>(d_values_in),
-                static_cast<ValT*>(d_values_out), num_items, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream);
-  return stream_executor::gpu::ToStatus(err);
-}
-
-template <typename KeyT, typename ValT>
-absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
-                          const void* d_keys_in, void* d_keys_out,
-                          const void* d_values_in, void* d_values_out,
-                          size_t num_items, bool descending, size_t batch_size,
-                          hipStream_t stream) {
-  if (batch_size == 1) {
-    return CubSortPairs<KeyT, ValT>(d_temp_storage, temp_bytes, d_keys_in,
-                                    d_keys_out, d_values_in, d_values_out,
-                                    num_items, descending, stream);
-  }
-  void* d_offsets = static_cast<char*>(d_temp_storage) + temp_bytes;
-  int* start_offsets =
-      d_temp_storage != nullptr ? static_cast<int*>(d_offsets) : nullptr;
-  int* end_offsets = start_offsets != nullptr ? start_offsets + 1 : nullptr;
-  auto err =
-      descending
-          ? hipcub::DeviceSegmentedRadixSort::SortPairsDescending<KeyT, ValT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out),
-                static_cast<const ValT*>(d_values_in),
-                static_cast<ValT*>(d_values_out), num_items, batch_size,
-                start_offsets, end_offsets, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream)
-          : hipcub::DeviceSegmentedRadixSort::SortPairs<KeyT, ValT>(
-                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
-                static_cast<KeyT*>(d_keys_out),
-                static_cast<const ValT*>(d_values_in),
-                static_cast<ValT*>(d_values_out), num_items, batch_size,
-                start_offsets, end_offsets, /*begin_bit=*/0,
-                /*end_bit=*/sizeof(KeyT) * 8, stream);
-  return stream_executor::gpu::ToStatus(err);
 }
 
 template <typename KeyT, typename ValT>

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.h
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.h
@@ -1,0 +1,50 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_CUB_SORT_KERNEL_ROCM_H_
+#define XLA_STREAM_EXECUTOR_ROCM_CUB_SORT_KERNEL_ROCM_H_
+
+#include <cstddef>
+
+#include "absl/status/status.h"
+#include "rocm/include/hip/hip_runtime.h"
+
+namespace stream_executor {
+namespace rocm {
+
+// The CUB sort kernel registration is split into 2 compilation units
+// (cub_sort_kernel_rocm.cc and cub_sort_kernel_rocm_impl.cu.cc) to separate
+// the heavy hipCUB/rocPRIM template instantiations from the XLA FFI
+// registration macros, which significantly speeds up compilation.
+// The following functions declare the interface between the two compilation
+// units.
+
+template <typename KeyT>
+absl::Status CubSortKeys(void* d_temp_storage, size_t& temp_bytes,
+                         const void* d_keys_in, void* d_keys_out,
+                         size_t num_items, bool descending, size_t batch_size,
+                         hipStream_t stream);
+
+template <typename KeyT, typename ValT>
+absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
+                          const void* d_keys_in, void* d_keys_out,
+                          const void* d_values_in, void* d_values_out,
+                          size_t num_items, bool descending, size_t batch_size,
+                          hipStream_t stream);
+
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_CUB_SORT_KERNEL_ROCM_H_

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.h
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 The OpenXLA Authors.
+/* Copyright 2026 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
@@ -1,4 +1,4 @@
-/* Copyright 2023 The OpenXLA Authors.
+/* Copyright 2026 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
@@ -1,0 +1,325 @@
+/* Copyright 2023 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "Eigen/Core"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/hipcub/backend/rocprim/device/device_radix_sort.hpp"
+#include "rocm/include/hipcub/backend/rocprim/device/device_segmented_radix_sort.hpp"
+#include "rocm/include/rocprim/thread/radix_key_codec.hpp"
+#include "rocm/include/rocprim/type_traits.hpp"
+#include "rocm/rocm_config.h"
+#include "xla/stream_executor/rocm/cub_sort_kernel_rocm.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "tsl/platform/bfloat16.h"
+
+// Required for sorting Eigen::half and bfloat16.
+namespace rocprim {
+
+#if (TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000)
+namespace detail {
+template <>
+struct float_bit_mask<Eigen::half> {
+  static constexpr uint16_t sign_bit = 0x8000;
+  static constexpr uint16_t exponent = 0x7C00;
+  static constexpr uint16_t mantissa = 0x03FF;
+  using bit_type = uint16_t;
+};
+
+template <>
+struct float_bit_mask<tsl::bfloat16> {
+  static constexpr uint16_t sign_bit = 0x8000;
+  static constexpr uint16_t exponent = 0x7F80;
+  static constexpr uint16_t mantissa = 0x007F;
+  using bit_type = uint16_t;
+};
+
+template <>
+struct radix_key_codec_base<Eigen::half>
+    : radix_key_codec_floating<Eigen::half, uint16_t> {};
+template <>
+struct radix_key_codec_base<tsl::bfloat16>
+    : radix_key_codec_floating<tsl::bfloat16, uint16_t> {};
+}  // namespace detail
+#else   // TF_ROCM_VERSION >= 70000
+namespace traits {
+
+template <>
+struct define<Eigen::half> {
+  using float_bit_mask =
+      rocprim::traits::float_bit_mask::values<uint16_t, 0x8000, 0x7C00, 0x03FF>;
+  using is_arithmetic = rocprim::traits::is_arithmetic::values<true>;
+  using number_format = rocprim::traits::number_format::values<
+      traits::number_format::kind::floating_point_type>;
+};
+
+template <>
+struct define<tsl::bfloat16> {
+  using float_bit_mask =
+      rocprim::traits::float_bit_mask::values<uint16_t, 0x8000, 0x7F80, 0x007F>;
+  using is_arithmetic = rocprim::traits::is_arithmetic::values<true>;
+  using number_format = rocprim::traits::number_format::values<
+      traits::number_format::kind::floating_point_type>;
+};
+
+}  // namespace traits
+#endif  // TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000
+
+};  // namespace rocprim
+
+namespace stream_executor {
+namespace rocm {
+namespace {
+
+template <typename KeyT>
+absl::Status CubSortKeysImpl(void* d_temp_storage, size_t& temp_bytes,
+                             const void* d_keys_in, void* d_keys_out,
+                             size_t num_items, bool descending,
+                             hipStream_t stream) {
+  auto err =
+      descending
+          ? hipcub::DeviceRadixSort::SortKeysDescending<KeyT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out), num_items, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream)
+          : hipcub::DeviceRadixSort::SortKeys<KeyT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out), num_items, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream);
+  return stream_executor::gpu::ToStatus(err);
+}
+
+template <typename KeyT>
+absl::Status CubSortKeysImpl(void* d_temp_storage, size_t& temp_bytes,
+                             const void* d_keys_in, void* d_keys_out,
+                             size_t num_items, bool descending,
+                             size_t batch_size, hipStream_t stream) {
+  if (batch_size == 1) {
+    return CubSortKeysImpl<KeyT>(d_temp_storage, temp_bytes, d_keys_in,
+                                 d_keys_out, num_items, descending, stream);
+  }
+  void* d_offsets = static_cast<char*>(d_temp_storage) + temp_bytes;
+  int* start_offsets =
+      d_temp_storage != nullptr ? static_cast<int*>(d_offsets) : nullptr;
+  int* end_offsets = start_offsets != nullptr ? start_offsets + 1 : nullptr;
+  auto err =
+      descending
+          ? hipcub::DeviceSegmentedRadixSort::SortKeysDescending<KeyT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out), num_items, batch_size,
+                start_offsets, end_offsets, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream)
+          : hipcub::DeviceSegmentedRadixSort::SortKeys<KeyT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out), num_items, batch_size,
+                start_offsets, end_offsets, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream);
+  return stream_executor::gpu::ToStatus(err);
+}
+
+template <typename KeyT, typename ValT>
+absl::Status CubSortPairsImpl(void* d_temp_storage, size_t& temp_bytes,
+                              const void* d_keys_in, void* d_keys_out,
+                              const void* d_values_in, void* d_values_out,
+                              size_t num_items, bool descending,
+                              hipStream_t stream) {
+  auto err =
+      descending
+          ? hipcub::DeviceRadixSort::SortPairsDescending<KeyT, ValT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out),
+                static_cast<const ValT*>(d_values_in),
+                static_cast<ValT*>(d_values_out), num_items, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream)
+          : hipcub::DeviceRadixSort::SortPairs<KeyT, ValT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out),
+                static_cast<const ValT*>(d_values_in),
+                static_cast<ValT*>(d_values_out), num_items, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream);
+  return stream_executor::gpu::ToStatus(err);
+}
+
+template <typename KeyT, typename ValT>
+absl::Status CubSortPairsImpl(void* d_temp_storage, size_t& temp_bytes,
+                              const void* d_keys_in, void* d_keys_out,
+                              const void* d_values_in, void* d_values_out,
+                              size_t num_items, bool descending,
+                              size_t batch_size, hipStream_t stream) {
+  if (batch_size == 1) {
+    return CubSortPairsImpl<KeyT, ValT>(d_temp_storage, temp_bytes, d_keys_in,
+                                        d_keys_out, d_values_in, d_values_out,
+                                        num_items, descending, stream);
+  }
+  void* d_offsets = static_cast<char*>(d_temp_storage) + temp_bytes;
+  int* start_offsets =
+      d_temp_storage != nullptr ? static_cast<int*>(d_offsets) : nullptr;
+  int* end_offsets = start_offsets != nullptr ? start_offsets + 1 : nullptr;
+  auto err =
+      descending
+          ? hipcub::DeviceSegmentedRadixSort::SortPairsDescending<KeyT, ValT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out),
+                static_cast<const ValT*>(d_values_in),
+                static_cast<ValT*>(d_values_out), num_items, batch_size,
+                start_offsets, end_offsets, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream)
+          : hipcub::DeviceSegmentedRadixSort::SortPairs<KeyT, ValT>(
+                d_temp_storage, temp_bytes, static_cast<const KeyT*>(d_keys_in),
+                static_cast<KeyT*>(d_keys_out),
+                static_cast<const ValT*>(d_values_in),
+                static_cast<ValT*>(d_values_out), num_items, batch_size,
+                start_offsets, end_offsets, /*begin_bit=*/0,
+                /*end_bit=*/sizeof(KeyT) * 8, stream);
+  return stream_executor::gpu::ToStatus(err);
+}
+
+}  // namespace
+
+// Template instantiations for CubSortKeys
+template <typename KeyT>
+absl::Status CubSortKeys(void* d_temp_storage, size_t& temp_bytes,
+                         const void* d_keys_in, void* d_keys_out,
+                         size_t num_items, bool descending, size_t batch_size,
+                         hipStream_t stream) {
+  return CubSortKeysImpl<KeyT>(d_temp_storage, temp_bytes, d_keys_in,
+                               d_keys_out, num_items, descending, batch_size,
+                               stream);
+}
+
+// Template instantiations for CubSortPairs
+template <typename KeyT, typename ValT>
+absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
+                          const void* d_keys_in, void* d_keys_out,
+                          const void* d_values_in, void* d_values_out,
+                          size_t num_items, bool descending, size_t batch_size,
+                          hipStream_t stream) {
+  return CubSortPairsImpl<KeyT, ValT>(
+      d_temp_storage, temp_bytes, d_keys_in, d_keys_out, d_values_in,
+      d_values_out, num_items, descending, batch_size, stream);
+}
+
+#define XLA_CUB_DEFINE_SORT_KEYS(type)                                        \
+  template absl::Status CubSortKeys<type>(void*, size_t&, const void*, void*, \
+                                          size_t, bool, size_t, hipStream_t);
+
+#define XLA_CUB_DEFINE_SORT_PAIRS(type1, type2)                             \
+  template absl::Status CubSortPairs<type1, type2>(                         \
+      void*, size_t&, const void*, void*, const void*, void*, size_t, bool, \
+      size_t, hipStream_t);
+
+// Floating point types.
+#ifdef CUB_TYPE_BF16
+XLA_CUB_DEFINE_SORT_KEYS(hip_bfloat16)
+#endif
+#ifdef CUB_TYPE_F16
+XLA_CUB_DEFINE_SORT_KEYS(__half)
+#endif
+#ifdef CUB_TYPE_F32
+XLA_CUB_DEFINE_SORT_KEYS(float)
+#endif
+#ifdef CUB_TYPE_F64
+XLA_CUB_DEFINE_SORT_KEYS(double)
+#endif
+
+// Signed integer types.
+#ifdef CUB_TYPE_S8
+XLA_CUB_DEFINE_SORT_KEYS(int8_t)
+#endif
+#ifdef CUB_TYPE_S16
+XLA_CUB_DEFINE_SORT_KEYS(int16_t)
+#endif
+#ifdef CUB_TYPE_S32
+XLA_CUB_DEFINE_SORT_KEYS(int32_t)
+#endif
+#ifdef CUB_TYPE_S64
+XLA_CUB_DEFINE_SORT_KEYS(int64_t)
+#endif
+
+// Unsigned integer types.
+#ifdef CUB_TYPE_U8
+XLA_CUB_DEFINE_SORT_KEYS(uint8_t)
+#endif
+#ifdef CUB_TYPE_U16
+XLA_CUB_DEFINE_SORT_KEYS(uint16_t)
+#endif
+#ifdef CUB_TYPE_U32
+XLA_CUB_DEFINE_SORT_KEYS(uint32_t)
+#endif
+#ifdef CUB_TYPE_U64
+XLA_CUB_DEFINE_SORT_KEYS(uint64_t)
+#endif
+
+// Pairs with 8-bit key.
+#ifdef CUB_TYPE_U8_B16
+XLA_CUB_DEFINE_SORT_PAIRS(uint8_t, uint16_t)
+#endif
+#ifdef CUB_TYPE_U8_B32
+XLA_CUB_DEFINE_SORT_PAIRS(uint8_t, uint32_t)
+#endif
+#ifdef CUB_TYPE_U8_B64
+XLA_CUB_DEFINE_SORT_PAIRS(uint8_t, uint64_t)
+#endif
+
+// Pairs with 16-bit key.
+#ifdef CUB_TYPE_U16_B16
+XLA_CUB_DEFINE_SORT_PAIRS(uint16_t, uint16_t)
+#endif
+#ifdef CUB_TYPE_U16_B32
+XLA_CUB_DEFINE_SORT_PAIRS(uint16_t, uint32_t)
+#endif
+#ifdef CUB_TYPE_U16_B64
+XLA_CUB_DEFINE_SORT_PAIRS(uint16_t, uint64_t)
+#endif
+
+// Pairs with 32-bit key.
+#ifdef CUB_TYPE_S32_B32
+XLA_CUB_DEFINE_SORT_PAIRS(int32_t, uint32_t)
+#endif
+#ifdef CUB_TYPE_U32_B16
+XLA_CUB_DEFINE_SORT_PAIRS(uint32_t, uint16_t)
+#endif
+#ifdef CUB_TYPE_U32_B32
+XLA_CUB_DEFINE_SORT_PAIRS(uint32_t, uint32_t)
+#endif
+#ifdef CUB_TYPE_U32_B64
+XLA_CUB_DEFINE_SORT_PAIRS(uint32_t, uint64_t)
+#endif
+#ifdef CUB_TYPE_F32_B16
+XLA_CUB_DEFINE_SORT_PAIRS(float, uint16_t)
+#endif
+#ifdef CUB_TYPE_F32_B32
+XLA_CUB_DEFINE_SORT_PAIRS(float, uint32_t)
+#endif
+#ifdef CUB_TYPE_F32_B64
+XLA_CUB_DEFINE_SORT_PAIRS(float, uint64_t)
+#endif
+
+// Pairs with 64-bit key.
+#ifdef CUB_TYPE_U64_B16
+XLA_CUB_DEFINE_SORT_PAIRS(uint64_t, uint16_t)
+#endif
+#ifdef CUB_TYPE_U64_B32
+XLA_CUB_DEFINE_SORT_PAIRS(uint64_t, uint32_t)
+#endif
+#ifdef CUB_TYPE_U64_B64
+XLA_CUB_DEFINE_SORT_PAIRS(uint64_t, uint64_t)
+#endif
+
+}  // namespace rocm
+}  // namespace stream_executor


### PR DESCRIPTION
📝 Summary of Changes

The  `cub_sort_kernel_rocm.cu.cc` file has been refactored and split into: 
- a file containing only the kernels:  `cub_sort_kernel_rocm_impl.cu.cc`
- a file containing only the FFI registration: `cub_sort_kernel_rocm.cc`
- a header file `cub_sort_kernel_rocm.h`

Similar to what has been done on the CUDA side.

🎯 Justification
The compilation time of this file was slow, especially when using ROCm version prior to ROCm 7.1.
The refactoring has allow us to reduce the compilation as shown below (compilation time measured on the same machine):

Compilation time (seconds) | ROCm 6.4.0 | ROCm 7.0 | ROCm 7.1 | ROCm 7.2
-- | -- | -- | -- | --
cub_sort_kernel_rocm.cu.cc | 298 | 328 | 56 | 64
cub_sort_kernel_rocm_impl.cu.cc | 202 | 207 | 40 | 40
Time Reduction Factor | 0.677852349 | 0.631097561 | 0.714285714 | 0.625


Compilation time target `rocm:all_runtime` (seconds) | ROCm 6.4.0 | ROCm 7.0 | ROCm 7.1 | ROCm 7.2
-- | -- | -- | -- | --
Baseline | 348.58 | 375.94 | 106.87 | 124.18
After Refactor | 228.98 | 236.49 | 102.72 | 102.65
Time Reduction Factor | 0.656893683 | 0.857034138 | 0.961167774 | 0.826622645

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
N/A

🧪 Execution Tests:
N/A