### PR TITLE
[xla:gpu] Add thunk-free library for supporting while loops at run time

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -167,7 +167,7 @@ cc_library(
         ":send_thunk",
         ":thunk",
         ":thunk_id",
-        ":while_thunk",
+        ":while_loop",
         "//xla:debug_options_flags",
         "//xla:executable_run_options",
         "//xla:literal",
@@ -845,7 +845,8 @@ cc_library(
         ":copy_thunk_proto_cc",
         ":thunk",
         ":thunk_proto_cc",
-        ":while_thunk",
+        ":while_loop",
+        "//xla:status_macros",
         "//xla/hlo/ir:hlo",
         "//xla/runtime:buffer_use",
         "//xla/service:buffer_assignment",
@@ -2996,6 +2997,25 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "while_loop",
+    srcs = ["while_loop.cc"],
+    hdrs = ["while_loop.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+xla_cc_test(
+    name = "while_loop_test",
+    srcs = ["while_loop_test.cc"],
+    deps = [
+        ":while_loop",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "while_thunk",
     srcs = ["while_thunk.cc"],
     hdrs = ["while_thunk.h"],
@@ -3004,20 +3024,21 @@ cc_library(
         ":sequential_thunk",
         ":thunk",
         ":thunk_proto_cc",
+        ":while_loop",
+        "//xla:shape_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/runtime:buffer_use",
         "//xla/service:buffer_assignment",
         "//xla/stream_executor:device_address",
+        "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/functional:function_ref",
-        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -3036,6 +3057,7 @@ xla_test(
         ":sequential_thunk",
         ":thunk",
         ":thunk_proto_cc",
+        ":while_loop",
         ":while_thunk",
         "//xla:executable_run_options",
         "//xla/hlo/ir:hlo",

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -153,11 +153,6 @@ class Command {
     // A flag indicating whether we record commands at command buffer thunk
     // initialization time.
     bool is_initialization = false;
-
-    // The command sequence might be recorded in the loop unrolling pattern, so
-    // the command sequence might be instantiated multiple times, we uses
-    // unroll_iteration to locate the commands for current unroll iteration.
-    int64_t unroll_iteration = 0;
   };
 
   // Create new commands in the command buffer using the given dependencies.

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -68,7 +68,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/recv_thunk.h"
 #include "xla/backends/gpu/runtime/send_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
-#include "xla/backends/gpu/runtime/while_thunk.h"
+#include "xla/backends/gpu/runtime/while_loop.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
@@ -113,13 +113,13 @@ limitations under the License.
 #include "xla/stream_executor/trace_command_buffer_factory.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/types.h"  // IWYU pragma: keep
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -914,9 +914,9 @@ absl::StatusOr<const se::CommandBuffer::Command*> WhileCmd::Record(
       Command::RecordParams new_record_params = record_params;
       std::vector<const se::CommandBuffer::Command*> dependencies;
 
-      for (int64_t i = 0; i < trip_count_.value(); ++i) {
+      ScopedWhileLoop loop("record_fn", trip_count_);
+      for (int64_t i = 0; i < *trip_count_; loop.IncLoopIteration(), ++i) {
         CommandExecutor::RecordId record_id(i);
-        new_record_params.unroll_iteration = i;
         TF_ASSIGN_OR_RETURN(dependencies,
                             cond_commands_.RecordCreate(
                                 execute_params, new_record_params,
@@ -937,9 +937,9 @@ absl::StatusOr<const se::CommandBuffer::Command*> WhileCmd::Record(
 
       Command::RecordParams new_record_params = record_params;
 
-      for (int64_t i = 0; i < trip_count_.value(); ++i) {
+      ScopedWhileLoop loop("record_fn", trip_count_);
+      for (int64_t i = 0; i < *trip_count_; loop.IncLoopIteration(), ++i) {
         CommandExecutor::RecordId record_id(i);
-        new_record_params.unroll_iteration = i;
         TF_RETURN_IF_ERROR(
             cond_commands_.RecordUpdate(execute_params, new_record_params,
                                         child_command_buffer, record_id));
@@ -2445,19 +2445,16 @@ DynamicSliceCopyFusionCmd::Record(const Thunk::ExecuteParams& execute_params,
                 << mem_size_ << " from " << src_with_offset.opaque()
                 << " (offset " << src_offset << ") to "
                 << dst_with_offset.opaque() << " (offset " << dst_offset
-                << "), dependends_on_loop: " << offsets_.depends_on_loop;
+                << "), depends_on_loop: " << offsets_.depends_on_loop;
         return command_buffer->CreateMemcpyD2D(
             &dst_with_offset, src_with_offset, mem_size_, dependencies);
       },
-      [&](const se::CommandBuffer::Command* command) {
+      [&](const se::CommandBuffer::Command* command) -> absl::Status {
         int64_t iteration_index = 0;
         if (offsets_.depends_on_loop) {
-          if (WhileThunk::RunningWhileThunkLoop()) {
-            TF_ASSIGN_OR_RETURN(iteration_index,
-                                WhileThunk::CurrentLoopIteration());
-          } else {
-            iteration_index = record_params.unroll_iteration;
-          }
+          const WhileLoopState* state = IsInsideWhileLoop();
+          TF_RET_CHECK(state) << "DynamicSliceCopyFusionCmd depends on loop";
+          iteration_index = state->loop_iteration;
         }
         int64_t src_offset = offsets_.src_offsets[iteration_index];
         int64_t dst_offset = offsets_.dst_offsets[iteration_index];

--- a/xla/backends/gpu/runtime/while_loop.cc
+++ b/xla/backends/gpu/runtime/while_loop.cc
@@ -1,0 +1,75 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/while_loop.h"
+
+#include <cstddef>
+#include <list>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "absl/strings/string_view.h"
+
+namespace xla::gpu {
+
+static thread_local std::list<WhileLoopState> while_loop_stack;
+
+static const WhileLoopState* EnterWhileLoop(absl::string_view loop_name,
+                                            std::optional<size_t> trip_count) {
+  size_t depth = while_loop_stack.size();
+  while_loop_stack.push_back(
+      WhileLoopState{std::string(loop_name), trip_count, depth, 0});
+  return &while_loop_stack.back();
+}
+
+static const WhileLoopState* IncWhileLoopIteration() {
+  if (while_loop_stack.empty()) return nullptr;
+  ++while_loop_stack.back().loop_iteration;
+  return &while_loop_stack.back();
+}
+
+static WhileLoopState ExitWhileLoop() {
+  WhileLoopState state = std::move(while_loop_stack.back());
+  while_loop_stack.pop_back();
+  return state;
+}
+
+const WhileLoopState* IsInsideWhileLoop() {
+  if (while_loop_stack.empty()) return nullptr;
+  return &while_loop_stack.back();
+}
+
+ScopedWhileLoop::ScopedWhileLoop(absl::string_view loop_name,
+                                 std::optional<size_t> trip_count)
+    : state(EnterWhileLoop(loop_name, trip_count)) {}
+
+ScopedWhileLoop::~ScopedWhileLoop() { ExitWhileLoop(); }
+
+absl::string_view ScopedWhileLoop::loop_name() const {
+  return state->loop_name;
+}
+
+std::optional<size_t> ScopedWhileLoop::trip_count() const {
+  return state->loop_trip_count;
+}
+
+size_t ScopedWhileLoop::loop_depth() const { return state->loop_depth; }
+
+size_t ScopedWhileLoop::loop_iteration() const { return state->loop_iteration; }
+
+void ScopedWhileLoop::IncLoopIteration() { IncWhileLoopIteration(); }
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/while_loop.h
+++ b/xla/backends/gpu/runtime/while_loop.h
@@ -1,0 +1,110 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_WHILE_LOOP_H_
+#define XLA_BACKENDS_GPU_RUNTIME_WHILE_LOOP_H_
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+namespace xla::gpu {
+
+// A library that supports running while loops in the XLA:GPU runtime.
+//
+// See StableHLO documentation for the while loop semantics:
+// https://openxla.org/stablehlo/spec#while
+//
+// This library supports both Thunks and Commands. When a while loop executes
+// thunks (via the WhileThunk), some of the nested thunks might depend on the
+// loop induction variable, which is typically available in device memory.
+// However, having to copy it back to host every time is very expensive.
+// Instead, we keep track of the current loop iteration in a thread local
+// variable, and each individual thunk (e.g., dynamic slices) can access it
+// without having to synchronize with device activity. Each individual thunk is
+// responsible for computing the loop induction variable from the iteration
+// number.
+//
+// At compile time, XLA:GPU can choose to unroll the while loop, which later
+// enables command buffer thunk passes to form much larger command buffers and
+// launch the whole loop as one command. However, when we execute unrolled
+// thunks (or record commands for them), we still need to know in which loop
+// iteration a thunk or command is executing, and we rely on thread local
+// storage and metadata-only thunks/commands to keep the state in thread local
+// storage. Essentially we keep a thread local stack of `WhileLoopState` entries
+// for all runtime loops.
+//
+// Example:
+//
+//   1. WhileThunk(cond, body); name="while.0", trip_count=2
+//
+// Thunk sequence after unrolling:
+//
+//   1. WhileEnterThunk: name="while.0", trip_count=2
+//   2. SequentialThunk(cond)
+//   3. SequentialThunk(body)
+//   4. WhileIncrementThunk
+//   5. SequentialThunk(cond)
+//   6. SequentialThunk(body)
+//   7. WhileExitThunk
+//
+// Thunks corresponding to loop Enter/Exit push/pop while loop state onto the
+// thread local stack, and between every repetition of cond/body thunk
+// sequences, we increment the loop iteration counter.
+//
+// When we record commands, we have similar metadata-only commands that update
+// the thread local while loop state, so each individual command has access to
+// the correct loop iteration number.
+
+// State of a while loop execution tracked by the XLA:GPU runtime.
+struct WhileLoopState {
+  std::string loop_name;
+  std::optional<size_t> loop_trip_count;
+  size_t loop_depth = 0;
+  size_t loop_iteration = 0;
+};
+
+// Returns the while loop state for the innermost loop. Returns nullptr if the
+// current thread is not running within a while loop.
+const WhileLoopState* IsInsideWhileLoop();
+
+// An RAII helper that manages while loop state. Enters the loop upon
+// construction and exits it upon destruction. This is the only public API for
+// mutating while loop state.
+class ScopedWhileLoop {
+ public:
+  explicit ScopedWhileLoop(absl::string_view loop_name,
+                           std::optional<size_t> trip_count = std::nullopt);
+  ~ScopedWhileLoop();
+
+  ScopedWhileLoop(ScopedWhileLoop&&) = delete;
+  ScopedWhileLoop& operator=(ScopedWhileLoop&&) = delete;
+
+  absl::string_view loop_name() const;
+  std::optional<size_t> trip_count() const;
+  size_t loop_depth() const;
+  size_t loop_iteration() const;
+
+  void IncLoopIteration();
+
+ private:
+  const WhileLoopState* state;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_WHILE_LOOP_H_

--- a/xla/backends/gpu/runtime/while_loop_test.cc
+++ b/xla/backends/gpu/runtime/while_loop_test.cc
@@ -1,0 +1,91 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/while_loop.h"
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/strings/str_cat.h"
+
+namespace xla::gpu {
+
+TEST(WhileLoopTest, NotInsideLoop) { EXPECT_EQ(IsInsideWhileLoop(), nullptr); }
+
+TEST(WhileLoopTest, EnterExit) {
+  {
+    ScopedWhileLoop loop("while.0");
+    EXPECT_EQ(loop.loop_name(), "while.0");
+    EXPECT_EQ(loop.trip_count(), std::nullopt);
+    EXPECT_EQ(loop.loop_depth(), 0);
+    EXPECT_EQ(loop.loop_iteration(), 0);
+    EXPECT_NE(IsInsideWhileLoop(), nullptr);
+  }
+  EXPECT_EQ(IsInsideWhileLoop(), nullptr);
+}
+
+TEST(WhileLoopTest, Increment) {
+  ScopedWhileLoop loop("while.0", 10);
+  EXPECT_EQ(loop.trip_count(), 10);
+  EXPECT_EQ(loop.loop_iteration(), 0);
+
+  loop.IncLoopIteration();
+  EXPECT_EQ(loop.loop_iteration(), 1);
+
+  loop.IncLoopIteration();
+  EXPECT_EQ(loop.loop_iteration(), 2);
+}
+
+TEST(WhileLoopTest, NestedLoops) {
+  ScopedWhileLoop outer("while.0");
+  EXPECT_EQ(outer.loop_depth(), 0);
+
+  {
+    ScopedWhileLoop inner("while.1");
+    EXPECT_EQ(inner.loop_depth(), 1);
+    EXPECT_EQ(IsInsideWhileLoop()->loop_name, "while.1");
+
+    inner.IncLoopIteration();
+    EXPECT_EQ(inner.loop_iteration(), 1);
+    EXPECT_EQ(outer.loop_iteration(), 0);
+  }
+
+  EXPECT_EQ(IsInsideWhileLoop()->loop_name, "while.0");
+  EXPECT_EQ(outer.loop_iteration(), 0);
+}
+
+TEST(WhileLoopTest, PointerStability) {
+  std::vector<std::unique_ptr<ScopedWhileLoop>> loops(10);
+  for (int i = 0; i < 10; ++i) {
+    loops[i] = std::make_unique<ScopedWhileLoop>(absl::StrCat("while.", i));
+  }
+
+  // All previously created loops remain accessible after 10 nested pushes.
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(loops[i]->loop_name(), absl::StrCat("while.", i));
+    EXPECT_EQ(loops[i]->loop_depth(), i);
+    EXPECT_EQ(loops[i]->loop_iteration(), 0);
+  }
+
+  for (int i = 9; i >= 0; --i) {
+    EXPECT_EQ(IsInsideWhileLoop()->loop_name, absl::StrCat("while.", i));
+    loops.pop_back();
+  }
+  EXPECT_EQ(IsInsideWhileLoop(), nullptr);
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/while_thunk.h
+++ b/xla/backends/gpu/runtime/while_thunk.h
@@ -35,7 +35,9 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/runtime/buffer_use.h"
 #include "xla/service/buffer_assignment.h"
+#include "xla/shape_util.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/xla_data.pb.h"
 
 namespace xla {
 namespace gpu {
@@ -83,25 +85,14 @@ class WhileThunk : public Thunk {
 
   std::optional<int64_t> trip_count() const { return trip_count_; }
 
-  // Returns the current loop iteration if the caller is inside a while loop(s).
-  //
-  // Implementation relies on thread local storage, be careful when call it from
-  // code running on multiple threads.
-  static bool RunningWhileThunkLoop();
-  static absl::StatusOr<int64_t> CurrentLoopIteration(int64_t depth = 0);
-  static absl::StatusOr<int64_t> CurrentLoopIteration(
-      const HloInstruction* while_instr);
-
   absl::Status WalkNested(Walker callback) override;
   absl::Status TransformNested(Transformer callback) override;
 
   std::string ToString(int indent) const override;
 
   BufferUses buffer_uses() const override {
-    return {
-        BufferUse::Read(condition_result_buffer_index_,
-                        ShapeUtil::MakeShape(PRED, {})),
-    };
+    return {BufferUse::Read(condition_result_buffer_index_,
+                            ShapeUtil::MakeShape(PRED, {}))};
   }
 
   absl::StatusOr<ThunkProto> ToProto() const override;
@@ -127,7 +118,7 @@ class WhileThunk : public Thunk {
   std::unique_ptr<SequentialThunk> body_thunk_sequence_;
   std::optional<int64_t> trip_count_;
 
-  // Host memory pool for transfering predicate value from device to host.
+  // Host memory pool for transferring predicate value from device to host.
   absl::Mutex mutex_;
   absl::flat_hash_map<se::StreamExecutor*, std::unique_ptr<HostMemoryPool>>
       host_memory_pools_ ABSL_GUARDED_BY(mutex_);


### PR DESCRIPTION
Refactor tracking of the while loop iterations and move it outside of `WhileThunk` in preparation for reuse in command buffer implementation. Also add `while_loop.h` documentation that explains the intended use case (to be implemented in followup PRs).