### PR TITLE
[xla:gpu] Add Thunk::Transform API consistent with Thunk::Walk

### DIFF
--- a/xla/backends/gpu/runtime/collective_group_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_group_thunk.cc
@@ -34,8 +34,8 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream.h"
-#include "tsl/platform/casts.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "tsl/platform/casts.h"
 
 namespace xla {
 namespace gpu {
@@ -119,14 +119,9 @@ absl::Status CollectiveGroupThunk::WalkNested(
   return absl::OkStatus();
 }
 
-absl::Status CollectiveGroupThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
-  for (std::unique_ptr<Thunk>& thunk : thunks_) {
-    RETURN_IF_ERROR(thunk->TransformAllNestedThunks(fn));
-    ASSIGN_OR_RETURN(thunk, fn(std::move(thunk)));
-  }
+absl::Status CollectiveGroupThunk::TransformNested(Transformer callback) {
+  ASSIGN_OR_RETURN(thunks_,
+                   TransformThunkSequence(std::move(thunks_), callback));
   return absl::OkStatus();
 }
 

--- a/xla/backends/gpu/runtime/collective_group_thunk.h
+++ b/xla/backends/gpu/runtime/collective_group_thunk.h
@@ -48,10 +48,7 @@ class CollectiveGroupThunk : public Thunk {
   absl::Status WalkNested(
       absl::FunctionRef<absl::Status(Thunk*)> callback) override;
 
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   std::shared_ptr<CollectiveThunk::AsyncEvents> async_events() const {
     return async_events_;

--- a/xla/backends/gpu/runtime/conditional_thunk.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk.cc
@@ -163,16 +163,9 @@ absl::Status ConditionalThunk::WalkNested(
   return absl::OkStatus();
 }
 
-absl::Status ConditionalThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
+absl::Status ConditionalThunk::TransformNested(Transformer callback) {
   for (std::unique_ptr<SequentialThunk>& branch_thunk : branch_thunks_) {
-    TF_RETURN_IF_ERROR(branch_thunk->TransformAllNestedThunks(fn));
-
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<Thunk> thunk,
-                        fn(std::move(branch_thunk)));
-    branch_thunk = SequentialThunk::FromThunk(std::move(thunk));
+    TF_RETURN_IF_ERROR(branch_thunk->TransformNested(callback));
   }
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/conditional_thunk.h
+++ b/xla/backends/gpu/runtime/conditional_thunk.h
@@ -73,10 +73,7 @@ class ConditionalThunk : public Thunk {
   absl::Status WalkNested(
       absl::FunctionRef<absl::Status(Thunk*)> callback) override;
 
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   bool branch_index_is_bool() const { return branch_index_is_bool_; }
 

--- a/xla/backends/gpu/runtime/conditional_thunk_test.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk_test.cc
@@ -303,7 +303,7 @@ TEST(ConditionalThunkTest, ToString) {
             "  000: kGemm\t\n");
 }
 
-TEST(ConditionalThunkTest, TransformAllNestedThunks) {
+TEST(ConditionalThunkTest, Transform) {
   BufferAllocation::Slice slice;
   Shape shape = ShapeUtil::MakeShape(S32, {});
 
@@ -315,7 +315,7 @@ TEST(ConditionalThunkTest, TransformAllNestedThunks) {
   auto conditional_thunk = std::make_unique<ConditionalThunk>(
       Thunk::ThunkInfo(), ShapedSlice{slice, shape}, std::move(branch_thunks));
 
-  TF_EXPECT_OK(conditional_thunk->TransformAllNestedThunks([](auto) {
+  TF_EXPECT_OK(conditional_thunk->Transform([](auto) {
     return std::make_unique<DummyThunk>(Kind::kCustomCall, Thunk::ThunkInfo());
   }));
 

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk.cc
@@ -438,16 +438,8 @@ absl::Status DynamicSliceThunk::WalkNested(
   return embedded_thunk_->Walk(callback);
 }
 
-absl::Status DynamicSliceThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
-  TF_RETURN_IF_ERROR(embedded_thunk_->TransformAllNestedThunks(fn));
-
-  TF_ASSIGN_OR_RETURN(std::unique_ptr<Thunk> thunk,
-                      fn(std::move(embedded_thunk_)));
-  embedded_thunk_ = SequentialThunk::FromThunk(std::move(thunk));
-  return absl::OkStatus();
+absl::Status DynamicSliceThunk::TransformNested(Transformer callback) {
+  return embedded_thunk_->TransformNested(callback);
 }
 
 Thunk::BufferUses DynamicSliceThunk::buffer_uses() const {

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk.h
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk.h
@@ -172,10 +172,7 @@ class DynamicSliceThunk : public Thunk {
   absl::Status WalkNested(
       absl::FunctionRef<absl::Status(Thunk*)> callback) override;
 
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   BufferUses buffer_uses() const override;
 

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
@@ -2126,7 +2126,7 @@ TEST_F(DynamicSliceThunkTest,
   EXPECT_EQ(proto.offsets().offsets(0).hlo_module_offset_idx(), 0);
 }
 
-TEST_F(DynamicSliceThunkTest, TransformAllNestedThunks) {
+TEST_F(DynamicSliceThunkTest, Transform) {
   auto seq = std::make_unique<ThunkSequence>();
   seq->emplace_back(
       std::make_unique<DummyThunk>(Thunk::Kind::kGemm, Thunk::ThunkInfo()));
@@ -2139,7 +2139,7 @@ TEST_F(DynamicSliceThunkTest, TransformAllNestedThunks) {
                           /*sliced_shapes=*/{},
                           /*offset_byte_sizes=*/{});
 
-  TF_EXPECT_OK(thunk.TransformAllNestedThunks([](auto) {
+  TF_EXPECT_OK(thunk.Transform([](auto) {
     return std::make_unique<DummyThunk>(Thunk::Kind::kCustomCall,
                                         Thunk::ThunkInfo());
   }));

--- a/xla/backends/gpu/runtime/sequential_thunk.cc
+++ b/xla/backends/gpu/runtime/sequential_thunk.cc
@@ -132,14 +132,9 @@ absl::Status SequentialThunk::WalkNested(
   return absl::OkStatus();
 }
 
-absl::Status SequentialThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
-  for (std::unique_ptr<Thunk>& thunk : thunks_) {
-    TF_RETURN_IF_ERROR(thunk->TransformAllNestedThunks(fn));
-    TF_ASSIGN_OR_RETURN(thunk, fn(std::move(thunk)));
-  }
+absl::Status SequentialThunk::TransformNested(Transformer callback) {
+  TF_ASSIGN_OR_RETURN(thunks_,
+                      TransformThunkSequence(std::move(thunks_), callback));
   return absl::OkStatus();
 }
 

--- a/xla/backends/gpu/runtime/sequential_thunk.h
+++ b/xla/backends/gpu/runtime/sequential_thunk.h
@@ -48,10 +48,7 @@ class SequentialThunk : public Thunk {
   absl::Status WalkNested(
       absl::FunctionRef<absl::Status(Thunk*)> callback) override;
 
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   absl::StatusOr<ThunkProto> ToProto() const override;
 

--- a/xla/backends/gpu/runtime/sequential_thunk_test.cc
+++ b/xla/backends/gpu/runtime/sequential_thunk_test.cc
@@ -158,7 +158,7 @@ TEST(SequentialThunkTest, ToString) {
             "  003: kGemm\t\n");
 }
 
-TEST(SequentialThunkTest, TransformAllNestedThunks) {
+TEST(SequentialThunkTest, Transform) {
   auto make_info = [](uint64_t id) {
     Thunk::ThunkInfo info;
     info.thunk_id = ThunkId(id);
@@ -173,12 +173,11 @@ TEST(SequentialThunkTest, TransformAllNestedThunks) {
       std::make_unique<DummyThunk>(Thunk::Kind::kGemm, make_info(3)));
   SequentialThunk sequential_thunk(Thunk::ThunkInfo(), std::move(thunks));
 
-  TF_EXPECT_OK(sequential_thunk.TransformAllNestedThunks(
-      [&](std::unique_ptr<Thunk> thunk) -> std::unique_ptr<Thunk> {
-        return std::make_unique<DummyThunk>(
-            Thunk::Kind::kCopy,
-            make_info(thunk->thunk_info().thunk_id.value() + 10));
-      }));
+  TF_EXPECT_OK(sequential_thunk.Transform([&](std::unique_ptr<Thunk> thunk) {
+    return std::make_unique<DummyThunk>(
+        Thunk::Kind::kCopy,
+        make_info(thunk->thunk_info().thunk_id.value() + 10));
+  }));
 
   EXPECT_EQ(sequential_thunk.thunks().size(), 3);
   EXPECT_EQ(sequential_thunk.thunks()[0]->kind(), Thunk::Kind::kCopy);

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
@@ -434,9 +434,9 @@ absl::Status RunFloatCheckPassInternal(SequentialThunk* root_thunk,
       CreateBufferDebugFloatCheckThunk(metadata_store, log_slice, hlo_module));
 
   ThunkFilter thunk_filter = CreateThunkFilter(debug_options);
-  TF_RETURN_IF_ERROR(root_thunk->TransformAllNestedThunks(
-      [&](std::unique_ptr<Thunk> thunk)
-          -> absl::StatusOr<std::unique_ptr<Thunk>> {
+  TF_RETURN_IF_ERROR(
+      root_thunk->Transform([&](std::unique_ptr<Thunk> thunk)
+                                -> absl::StatusOr<std::unique_ptr<Thunk>> {
         if (thunk_filter(*thunk) == InstrumentAction::kSkip) {
           return thunk;
         }

--- a/xla/backends/gpu/runtime/while_thunk.cc
+++ b/xla/backends/gpu/runtime/while_thunk.cc
@@ -192,20 +192,9 @@ absl::Status WhileThunk::WalkNested(
   return body_thunk_sequence_->Walk(callback);
 }
 
-absl::Status WhileThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
-  TF_RETURN_IF_ERROR(condition_thunk_sequence_->TransformAllNestedThunks(fn));
-
-  TF_ASSIGN_OR_RETURN(std::unique_ptr<Thunk> thunk,
-                      fn(std::move(condition_thunk_sequence_)));
-  condition_thunk_sequence_ = SequentialThunk::FromThunk(std::move(thunk));
-
-  TF_RETURN_IF_ERROR(body_thunk_sequence_->TransformAllNestedThunks(fn));
-
-  TF_ASSIGN_OR_RETURN(thunk, fn(std::move(body_thunk_sequence_)));
-  body_thunk_sequence_ = SequentialThunk::FromThunk(std::move(thunk));
+absl::Status WhileThunk::TransformNested(Transformer callback) {
+  TF_RETURN_IF_ERROR(condition_thunk_sequence_->TransformNested(callback));
+  TF_RETURN_IF_ERROR(body_thunk_sequence_->TransformNested(callback));
   return absl::OkStatus();
 }
 

--- a/xla/backends/gpu/runtime/while_thunk.h
+++ b/xla/backends/gpu/runtime/while_thunk.h
@@ -95,10 +95,7 @@ class WhileThunk : public Thunk {
   absl::Status WalkNested(
       absl::FunctionRef<absl::Status(Thunk*)> callback) override;
 
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   std::string ToString(int indent) const override;
 

--- a/xla/backends/gpu/runtime/while_thunk_test.cc
+++ b/xla/backends/gpu/runtime/while_thunk_test.cc
@@ -380,7 +380,7 @@ TEST(WhileThunkTest, FromProto) {
   EXPECT_THAT(round_trip_proto, EqualsProto(proto));
 }
 
-TEST(WhileThunkTest, TransformAllNestedThunks) {
+TEST(WhileThunkTest, TransformNested) {
   BufferAllocation::Slice slice;
   auto condition_thunk_sequence =
       std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), ThunkSequence());
@@ -393,7 +393,7 @@ TEST(WhileThunkTest, TransformAllNestedThunks) {
       /*body_thunk_sequence_=*/std::move(body_thunk_sequence),
       /*trip_count=*/3);
 
-  TF_EXPECT_OK(while_thunk->TransformAllNestedThunks([](auto) {
+  TF_EXPECT_OK(while_thunk->Transform([](auto) {
     return std::make_unique<DummyThunk>(Kind::kCustomCall, Thunk::ThunkInfo());
   }));
 


### PR DESCRIPTION
For consistency with `Walk` and `WalkNested` define Thunk transformation as combination of `Transform` and `TransformNested` APIs.

In contrast to previous implementation, `SequentialThunk` is excluded from transformation function, but this is intentional as  SequentialThunk should be renamed to `ThunkExecutor`, for consistency with `Command` and `CommandExecutor`: executor who is responsible for executing `ThunkSequence`. This refactoring is coming in followup PRs.