### PR TITLE
[xla:gpu] NFC: Thunk::TransformNested API consistent with Thunk::WalkNested

### DIFF
--- a/xla/backends/gpu/runtime/collective_group_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_group_thunk.cc
@@ -34,8 +34,8 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream.h"
-#include "tsl/platform/casts.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "tsl/platform/casts.h"
 
 namespace xla {
 namespace gpu {
@@ -111,21 +111,17 @@ absl::Status CollectiveGroupThunk::ExecuteOnStream(
   return absl::OkStatus();
 }
 
-absl::Status CollectiveGroupThunk::WalkNested(
-    absl::FunctionRef<absl::Status(Thunk*)> callback) {
+absl::Status CollectiveGroupThunk::WalkNested(Walker callback) {
   for (const std::unique_ptr<Thunk>& thunk : thunks_) {
     RETURN_IF_ERROR(thunk->Walk(callback));
   }
   return absl::OkStatus();
 }
 
-absl::Status CollectiveGroupThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
+absl::Status CollectiveGroupThunk::TransformNested(Transformer callback) {
   for (std::unique_ptr<Thunk>& thunk : thunks_) {
-    RETURN_IF_ERROR(thunk->TransformAllNestedThunks(fn));
-    ASSIGN_OR_RETURN(thunk, fn(std::move(thunk)));
+    RETURN_IF_ERROR(thunk->TransformNested(callback));
+    ASSIGN_OR_RETURN(thunk, callback(std::move(thunk)));
   }
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/collective_group_thunk.h
+++ b/xla/backends/gpu/runtime/collective_group_thunk.h
@@ -45,13 +45,8 @@ class CollectiveGroupThunk : public Thunk {
   absl::Status ExecuteOnStream(const Thunk::ExecuteParams& params) override;
   absl::Status Initialize(const InitializeParams& params) override;
 
-  absl::Status WalkNested(
-      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
-
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status WalkNested(Walker callback) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   std::shared_ptr<CollectiveThunk::AsyncEvents> async_events() const {
     return async_events_;

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -380,8 +380,7 @@ void CommandBufferThunk::EvictCommandBuffers() {
   }
 }
 
-absl::Status CommandBufferThunk::WalkNested(
-    absl::FunctionRef<absl::Status(Thunk*)> callback) {
+absl::Status CommandBufferThunk::WalkNested(Walker callback) {
   if (thunks_ != nullptr) {
     TF_RETURN_IF_ERROR(thunks_->Walk(callback));
   }

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -56,8 +56,7 @@ class CommandBufferThunk : public Thunk {
   absl::StatusOr<se::DeviceAddressBase> GetCommandBufferAllocationAddress(
       const ExecuteParams& params, int64_t index);
 
-  absl::Status WalkNested(
-      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
+  absl::Status WalkNested(Walker callback) override;
 
   std::string ToString(int indent) const override;
 

--- a/xla/backends/gpu/runtime/conditional_thunk.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk.cc
@@ -155,23 +155,17 @@ absl::Status ConditionalThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-absl::Status ConditionalThunk::WalkNested(
-    absl::FunctionRef<absl::Status(Thunk*)> callback) {
+absl::Status ConditionalThunk::WalkNested(Walker callback) {
   for (const std::unique_ptr<SequentialThunk>& branch_thunk : branch_thunks_) {
     TF_RETURN_IF_ERROR(branch_thunk->Walk(callback));
   }
   return absl::OkStatus();
 }
 
-absl::Status ConditionalThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
+absl::Status ConditionalThunk::TransformNested(Transformer callback) {
   for (std::unique_ptr<SequentialThunk>& branch_thunk : branch_thunks_) {
-    TF_RETURN_IF_ERROR(branch_thunk->TransformAllNestedThunks(fn));
-
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<Thunk> thunk,
-                        fn(std::move(branch_thunk)));
+    TF_RETURN_IF_ERROR(branch_thunk->TransformNested(callback));
+    TF_ASSIGN_OR_RETURN(auto thunk, callback(std::move(branch_thunk)));
     branch_thunk = SequentialThunk::FromThunk(std::move(thunk));
   }
   return absl::OkStatus();

--- a/xla/backends/gpu/runtime/conditional_thunk.h
+++ b/xla/backends/gpu/runtime/conditional_thunk.h
@@ -70,13 +70,8 @@ class ConditionalThunk : public Thunk {
     return branch_index_buffer_index_;
   }
 
-  absl::Status WalkNested(
-      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
-
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status WalkNested(Walker callback) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   bool branch_index_is_bool() const { return branch_index_is_bool_; }
 

--- a/xla/backends/gpu/runtime/conditional_thunk_test.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk_test.cc
@@ -303,7 +303,7 @@ TEST(ConditionalThunkTest, ToString) {
             "  000: kGemm\t\n");
 }
 
-TEST(ConditionalThunkTest, TransformAllNestedThunks) {
+TEST(ConditionalThunkTest, TransformNested) {
   BufferAllocation::Slice slice;
   Shape shape = ShapeUtil::MakeShape(S32, {});
 
@@ -315,7 +315,7 @@ TEST(ConditionalThunkTest, TransformAllNestedThunks) {
   auto conditional_thunk = std::make_unique<ConditionalThunk>(
       Thunk::ThunkInfo(), ShapedSlice{slice, shape}, std::move(branch_thunks));
 
-  TF_EXPECT_OK(conditional_thunk->TransformAllNestedThunks([](auto) {
+  TF_EXPECT_OK(conditional_thunk->TransformNested([](auto) {
     return std::make_unique<DummyThunk>(Kind::kCustomCall, Thunk::ThunkInfo());
   }));
 

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk.h
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk.h
@@ -169,13 +169,8 @@ class DynamicSliceThunk : public Thunk {
     return offset_primitive_types_;
   }
 
-  absl::Status WalkNested(
-      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
-
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status WalkNested(Walker callback) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   BufferUses buffer_uses() const override;
 

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
@@ -2126,7 +2126,7 @@ TEST_F(DynamicSliceThunkTest,
   EXPECT_EQ(proto.offsets().offsets(0).hlo_module_offset_idx(), 0);
 }
 
-TEST_F(DynamicSliceThunkTest, TransformAllNestedThunks) {
+TEST_F(DynamicSliceThunkTest, TransformNested) {
   auto seq = std::make_unique<ThunkSequence>();
   seq->emplace_back(
       std::make_unique<DummyThunk>(Thunk::Kind::kGemm, Thunk::ThunkInfo()));
@@ -2139,7 +2139,7 @@ TEST_F(DynamicSliceThunkTest, TransformAllNestedThunks) {
                           /*sliced_shapes=*/{},
                           /*offset_byte_sizes=*/{});
 
-  TF_EXPECT_OK(thunk.TransformAllNestedThunks([](auto) {
+  TF_EXPECT_OK(thunk.TransformNested([](auto) {
     return std::make_unique<DummyThunk>(Thunk::Kind::kCustomCall,
                                         Thunk::ThunkInfo());
   }));

--- a/xla/backends/gpu/runtime/sequential_thunk.cc
+++ b/xla/backends/gpu/runtime/sequential_thunk.cc
@@ -124,21 +124,17 @@ absl::Status SequentialThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-absl::Status SequentialThunk::WalkNested(
-    absl::FunctionRef<absl::Status(Thunk*)> callback) {
+absl::Status SequentialThunk::WalkNested(Walker callback) {
   for (const std::unique_ptr<Thunk>& thunk : thunks_) {
     TF_RETURN_IF_ERROR(thunk->Walk(callback));
   }
   return absl::OkStatus();
 }
 
-absl::Status SequentialThunk::TransformAllNestedThunks(
-    absl::FunctionRef<
-        absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-        fn) {
+absl::Status SequentialThunk::TransformNested(Transformer callback) {
   for (std::unique_ptr<Thunk>& thunk : thunks_) {
-    TF_RETURN_IF_ERROR(thunk->TransformAllNestedThunks(fn));
-    TF_ASSIGN_OR_RETURN(thunk, fn(std::move(thunk)));
+    TF_RETURN_IF_ERROR(thunk->TransformNested(callback));
+    TF_ASSIGN_OR_RETURN(thunk, callback(std::move(thunk)));
   }
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/sequential_thunk.h
+++ b/xla/backends/gpu/runtime/sequential_thunk.h
@@ -45,13 +45,8 @@ class SequentialThunk : public Thunk {
   absl::Status Initialize(const InitializeParams& params) override;
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
 
-  absl::Status WalkNested(
-      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
-
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status WalkNested(Walker callback) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   absl::StatusOr<ThunkProto> ToProto() const override;
 

--- a/xla/backends/gpu/runtime/sequential_thunk_test.cc
+++ b/xla/backends/gpu/runtime/sequential_thunk_test.cc
@@ -158,7 +158,7 @@ TEST(SequentialThunkTest, ToString) {
             "  003: kGemm\t\n");
 }
 
-TEST(SequentialThunkTest, TransformAllNestedThunks) {
+TEST(SequentialThunkTest, TransformNested) {
   auto make_info = [](uint64_t id) {
     Thunk::ThunkInfo info;
     info.thunk_id = ThunkId(id);
@@ -173,7 +173,7 @@ TEST(SequentialThunkTest, TransformAllNestedThunks) {
       std::make_unique<DummyThunk>(Thunk::Kind::kGemm, make_info(3)));
   SequentialThunk sequential_thunk(Thunk::ThunkInfo(), std::move(thunks));
 
-  TF_EXPECT_OK(sequential_thunk.TransformAllNestedThunks(
+  TF_EXPECT_OK(sequential_thunk.TransformNested(
       [&](std::unique_ptr<Thunk> thunk) -> std::unique_ptr<Thunk> {
         return std::make_unique<DummyThunk>(
             Thunk::Kind::kCopy,

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -56,9 +56,9 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -490,24 +490,26 @@ class Thunk {
 
   // Type predicate for `Walk` callback.
   template <typename F, typename Arg>
-  using Walker = std::enable_if_t<std::is_invocable_v<F, Arg> ||
-                                  std::is_invocable_r_v<absl::Status, F, Arg>>;
+  using WalkCallback =
+      std::enable_if_t<std::is_invocable_v<F, Arg> ||
+                       std::is_invocable_r_v<absl::Status, F, Arg>>;
 
   // Recursively walks all the thunks nested inside *this one and calls the
-  // user provided callback on every thunk. Always starts traversal with *this.
-  template <typename F, Walker<F, Thunk*>* = nullptr>
+  // user-provided callback on every thunk. Always starts traversal with *this,
+  // and traverses thunks in DFS order.
+  template <typename F, WalkCallback<F, Thunk*>* = nullptr>
   std::invoke_result_t<F, Thunk*> Walk(F&& callback);
-  template <typename F, Walker<F, const Thunk*>* = nullptr>
+  template <typename F, WalkCallback<F, const Thunk*>* = nullptr>
   std::invoke_result_t<F, const Thunk*> Walk(F&& callback) const;
 
-  // Recursively replaces all nested thunks with the result of applying `fn` to
-  // them.
-  // An error will leave the transformation in invalid state.
-  // InternalError should be used for status.
-  virtual absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) {
+  // Recursively applies transformation to all nested thunks inside *this one.
+  // Transformation can be applied optionally by returning the argument back to
+  // the caller. Any error during transformation leaves the thunk in an invalid
+  // state. Traverses thunks in reverse-DFS order (transforms innermost thunk
+  // first).
+  using Transformer = absl::FunctionRef<absl::StatusOr<std::unique_ptr<Thunk>>(
+      std::unique_ptr<Thunk>)>;
+  virtual absl::Status TransformNested(Transformer callback) {
     return absl::OkStatus();
   }
 
@@ -545,10 +547,8 @@ class Thunk {
 
  protected:
   // Walks all nested thunks and calls `callback` for them.
-  virtual absl::Status WalkNested(
-      absl::FunctionRef<absl::Status(Thunk*)> callback) {
-    return absl::OkStatus();
-  }
+  using Walker = absl::FunctionRef<absl::Status(Thunk*)>;
+  virtual absl::Status WalkNested(Walker callback) { return absl::OkStatus(); }
 
  private:
   Kind kind_;
@@ -579,7 +579,7 @@ ThunkMetadataListProto GetMetadataListProtoFromThunkGraph(
 // Thunk templates implementation.
 //===----------------------------------------------------------------------===//
 
-template <typename F, Thunk::Walker<F, Thunk*>*>
+template <typename F, Thunk::WalkCallback<F, Thunk*>*>
 std::invoke_result_t<F, Thunk*> Thunk::Walk(F&& callback) {
   if constexpr (std::is_void_v<std::invoke_result_t<F, Thunk*>>) {
     Walk([f = std::forward<F>(callback)](Thunk* thunk) {
@@ -591,7 +591,7 @@ std::invoke_result_t<F, Thunk*> Thunk::Walk(F&& callback) {
   }
 }
 
-template <typename F, Thunk::Walker<F, const Thunk*>*>
+template <typename F, Thunk::WalkCallback<F, const Thunk*>*>
 std::invoke_result_t<F, const Thunk*> Thunk::Walk(F&& callback) const {
   return const_cast<Thunk*>(this)->Walk(  // NOLINT
       std::forward<F>(callback));

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_checksum.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_checksum.cc
@@ -236,7 +236,7 @@ absl::Status RunChecksumPassInternal(SequentialThunk* root_thunk,
 
   ThunkFilter thunk_filter = CreateThunkFilter(debug_options);
   TF_RETURN_IF_ERROR(
-      root_thunk->TransformAllNestedThunks([&](std::unique_ptr<Thunk> thunk) {
+      root_thunk->TransformNested([&](std::unique_ptr<Thunk> thunk) {
         if (thunk_filter(*thunk) == InstrumentAction::kSkip) {
           return thunk;
         }

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
@@ -434,7 +434,7 @@ absl::Status RunFloatCheckPassInternal(SequentialThunk* root_thunk,
       CreateBufferDebugFloatCheckThunk(metadata_store, log_slice, hlo_module));
 
   ThunkFilter thunk_filter = CreateThunkFilter(debug_options);
-  TF_RETURN_IF_ERROR(root_thunk->TransformAllNestedThunks(
+  TF_RETURN_IF_ERROR(root_thunk->TransformNested(
       [&](std::unique_ptr<Thunk> thunk)
           -> absl::StatusOr<std::unique_ptr<Thunk>> {
         if (thunk_filter(*thunk) == InstrumentAction::kSkip) {

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_saver_inserter.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_saver_inserter.cc
@@ -101,7 +101,7 @@ absl::Status RunDebugSaverInserter(SequentialThunk& root_thunk,
     return absl::OkStatus();
   }
   ThunkFilter thunk_filter = CreateThunkFilter(debug_options);
-  return root_thunk.TransformAllNestedThunks(
+  return root_thunk.TransformNested(
       [&](std::unique_ptr<Thunk> thunk)
           -> absl::StatusOr<std::unique_ptr<Thunk>> {
         if (thunk_filter(*thunk) == InstrumentAction::kSkip) {

--- a/xla/backends/gpu/runtime/while_thunk.h
+++ b/xla/backends/gpu/runtime/while_thunk.h
@@ -92,13 +92,8 @@ class WhileThunk : public Thunk {
   static absl::StatusOr<int64_t> CurrentLoopIteration(
       const HloInstruction* while_instr);
 
-  absl::Status WalkNested(
-      absl::FunctionRef<absl::Status(Thunk*)> callback) override;
-
-  absl::Status TransformAllNestedThunks(
-      absl::FunctionRef<
-          absl::StatusOr<std::unique_ptr<Thunk>>(std::unique_ptr<Thunk>)>
-          fn) override;
+  absl::Status WalkNested(Walker callback) override;
+  absl::Status TransformNested(Transformer callback) override;
 
   std::string ToString(int indent) const override;
 

--- a/xla/backends/gpu/runtime/while_thunk_test.cc
+++ b/xla/backends/gpu/runtime/while_thunk_test.cc
@@ -380,7 +380,7 @@ TEST(WhileThunkTest, FromProto) {
   EXPECT_THAT(round_trip_proto, EqualsProto(proto));
 }
 
-TEST(WhileThunkTest, TransformAllNestedThunks) {
+TEST(WhileThunkTest, TransformNested) {
   BufferAllocation::Slice slice;
   auto condition_thunk_sequence =
       std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), ThunkSequence());
@@ -393,7 +393,7 @@ TEST(WhileThunkTest, TransformAllNestedThunks) {
       /*body_thunk_sequence_=*/std::move(body_thunk_sequence),
       /*trip_count=*/3);
 
-  TF_EXPECT_OK(while_thunk->TransformAllNestedThunks([](auto) {
+  TF_EXPECT_OK(while_thunk->TransformNested([](auto) {
     return std::make_unique<DummyThunk>(Kind::kCustomCall, Thunk::ThunkInfo());
   }));
 


### PR DESCRIPTION
**NFC:** rename `Thunk` `Transform` API for consistency with `Walk` API + introduce type aliases for mouthful type names.