### PR TITLE
[xla:gpu] Change GpuExecutableProto to store top level thunk sequence

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <set>
@@ -115,6 +116,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
 #include "xla/util/split_proto/split_gpu_executable_writer.h"
@@ -122,7 +124,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -270,7 +271,15 @@ absl::StatusOr<std::unique_ptr<GpuExecutable>> GpuExecutable::Create(
 
   // TODO(b/461380690): Remove this once we have a better way to distinguish
   // between compiler-generated and runtime-loaded GPU executables.
-  absl::StatusOr<ThunkProto> thunk_proto = params.executable->ToProto();
+  absl::StatusOr<std::vector<ThunkProto>> thunk_sequence_proto =
+      [&]() -> absl::StatusOr<std::vector<ThunkProto>> {
+    ASSIGN_OR_RETURN(ThunkProto thunk_proto, params.executable->ToProto());
+    return std::vector<ThunkProto>(
+        std::make_move_iterator(
+            thunk_proto.mutable_sequential_thunk()->mutable_thunks()->begin()),
+        std::make_move_iterator(
+            thunk_proto.mutable_sequential_thunk()->mutable_thunks()->end()));
+  }();
 
   RETURN_IF_ERROR(RunThunkPasses(
       params.debug_options, params.device_description, params.executable.get(),
@@ -285,7 +294,7 @@ absl::StatusOr<std::unique_ptr<GpuExecutable>> GpuExecutable::Create(
       std::move(allocator.MutableAllocations()), std::move(params.alias_info),
       std::move(params.debug_options), std::move(params.constants),
       std::move(params.output_info), params.enable_debug_info_manager,
-      std::move(params.module_stats), std::move(thunk_proto)));
+      std::move(params.module_stats), std::move(thunk_sequence_proto)));
 }
 
 // Implementation note: HLO profiling is always enabled for GPU executables,
@@ -303,7 +312,7 @@ GpuExecutable::GpuExecutable(
     std::vector<ConstantInfo> constants,
     absl::flat_hash_map<ShapeIndex, OutputInfo> output_info,
     bool enable_debug_info_manager, ModuleStats module_stats,
-    absl::StatusOr<ThunkProto> thunk_proto)
+    absl::StatusOr<std::vector<ThunkProto>> thunk_sequence_proto)
     : Executable(std::move(debug_module)),
       text_(std::move(asm_text)),
       binary_(std::move(binary)),
@@ -324,7 +333,7 @@ GpuExecutable::GpuExecutable(
       constants_(std::move(constants)),
       output_info_(std::move(output_info)),
       enable_debug_info_manager_(enable_debug_info_manager),
-      thunk_proto_(std::move(thunk_proto)) {
+      thunk_sequence_proto_(std::move(thunk_sequence_proto)) {
   if (gpu_version_.IsRocm()) {
     // ROCm uses hsaco hashes to distinguish between modules.
     // Bad things happen if multiple modules with identical code are loaded.
@@ -1438,7 +1447,11 @@ absl::StatusOr<GpuExecutableProto> GpuExecutable::ToProto() const {
   // TODO(b/461380690): Generate the proto on-the-fly once we have a better way
   // to distinguish between compiler-generated and runtime-loaded GPU
   // executables.
-  ASSIGN_OR_RETURN(*proto.mutable_thunk(), thunk_proto_);
+  ASSIGN_OR_RETURN(const auto& thunk_sequence_proto, thunk_sequence_proto_);
+  proto.mutable_thunks()->Reserve(thunk_sequence_proto.size());
+  for (const auto& thunk_proto : thunk_sequence_proto) {
+    *proto.add_thunks() = thunk_proto;
+  }
 
   proto.set_module_name(module_name_);
   *proto.mutable_program_shape() = program_shape_.ToProto();
@@ -1515,19 +1528,19 @@ absl::StatusOr<std::unique_ptr<GpuExecutable>> GpuExecutable::FromProto(
 
   params.device_description = device_description;
 
-  ASSIGN_OR_RETURN(
-      std::unique_ptr<Thunk> thunk,
-      DeserializeThunkProto(proto.thunk(), params.mlir_allocations.value(),
-                            params.debug_module.get(), platform_name,
-                            gpu_compute_capability, symbol_resolver));
-
-  if (dynamic_cast<const SequentialThunk*>(thunk.get()) == nullptr) {
-    return absl::InvalidArgumentError(
-        "The top-most serialized thunk in the GPU Executable is not a "
-        "SequentialThunk!");
+  ThunkSequence thunk_sequence;
+  thunk_sequence.reserve(proto.thunks_size());
+  for (const auto& thunk_proto : proto.thunks()) {
+    ASSIGN_OR_RETURN(
+        std::unique_ptr<Thunk> thunk,
+        DeserializeThunkProto(thunk_proto, params.mlir_allocations.value(),
+                              params.debug_module.get(), platform_name,
+                              gpu_compute_capability, symbol_resolver));
+    thunk_sequence.push_back(std::move(thunk));
   }
 
-  params.executable = unique_ptr_down_cast<SequentialThunk>(std::move(thunk));
+  params.executable = std::make_unique<SequentialThunk>(
+      Thunk::ThunkInfo(), std::move(thunk_sequence));
 
   params.constants.reserve(proto.constants().size());
   for (const auto& constant_proto : proto.constants()) {

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -37,6 +37,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/annotation.h"
 #include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/client/executable_build_options.h"
 #include "xla/hlo/ir/hlo_input_output_alias_config.h"
 #include "xla/hlo/ir/hlo_module.h"
@@ -59,6 +60,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/scoped_module_handle.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/xla.pb.h"
 
 namespace xla {
 namespace gpu {
@@ -249,7 +251,7 @@ class GpuExecutable : public Executable {
       std::vector<ConstantInfo> constants,
       absl::flat_hash_map<ShapeIndex, OutputInfo> output_info,
       bool enable_debug_info_manager, ModuleStats module_stats,
-      absl::StatusOr<ThunkProto> thunk_proto);
+      absl::StatusOr<std::vector<ThunkProto>> thunk_sequence_proto);
 
   // GpuExecutable check with either AMD's ISA version, or Nvidia's major minor
   // version for compute capability, depending on the hardware.
@@ -372,9 +374,9 @@ class GpuExecutable : public Executable {
   GpuExecutable(const GpuExecutable&) = delete;
   GpuExecutable& operator=(const GpuExecutable&) = delete;
 
-  // Stores the thunk graph as a proto from before running the thunk pass.
+  // Stores the thunk sequence as a proto from before running the thunk pass.
   // Might contain an error if the given thunk graph is not serializable.
-  absl::StatusOr<ThunkProto> thunk_proto_;
+  absl::StatusOr<std::vector<ThunkProto>> thunk_sequence_proto_;
 };
 
 absl::StatusOr<absl::flat_hash_map<ShapeIndex, GpuExecutable::OutputInfo>>

--- a/xla/service/gpu/gpu_executable.proto
+++ b/xla/service/gpu/gpu_executable.proto
@@ -12,11 +12,11 @@ import "xla/xla_data.proto";
 
 // Serialized representation of a GPU executable, used for AOT compilation.
 //
-// There's a legacy and a new verions of this proto, see
+// There's a legacy and a new version of this proto, see
 // `xla::gpu::LegacyGpuAotCompilationResult` and
 // `xla::gpu::GpuAotCompilationResult` respectively for more details.
 //
-// If `thunk` is set, then this is the new format. Otherwise, it's the legacy
+// If `thunks` is set, then this is the new format. Otherwise, it's the legacy
 // format.
 message GpuExecutableProto {
   // The HLO module of the executable - for debugging purposes only.
@@ -50,9 +50,9 @@ message GpuExecutableProto {
   // The target compute capability of the executable.
   stream_executor.GpuComputeCapabilityProto gpu_compute_capability = 6;
 
-  // The thunk tree of the executable.
-  // Not set in the legacy format.
-  optional ThunkProto thunk = 7;
+  // The top level thunk sequence of the executable. Corresponds to thunks
+  // emitted for the ENTRY HLO computation. Not set in the legacy format.
+  repeated ThunkProto thunks = 13;
 
   // The name of the HLO module - for debugging purposes only.
   string module_name = 8;

--- a/xla/service/gpu/gpu_executable_test.cc
+++ b/xla/service/gpu/gpu_executable_test.cc
@@ -579,18 +579,13 @@ TEST(GpuExecutableTest, GpuExecutableDump) {
       ReadSplitProto(std::move(executable_reader), gpu_executable_proto));
   ASSERT_THAT(gpu_executable_proto, Partially(EqualsProto(R"pb(
                 module_name: "test_module"
-                thunk {
-                  thunk_info { thunk_id: 789 }
-                  sequential_thunk: {
-                    thunks: {
-                      thunk_info: { thunk_id: 123 }
-                      kernel_thunk: { kernel_name: "test_kernel" }
-                    }
-                    thunks: {
-                      thunk_info: { thunk_id: 456 }
-                      device_to_device_copy_thunk: {}
-                    }
-                  }
+                thunks: {
+                  thunk_info: { thunk_id: 123 }
+                  kernel_thunk: { kernel_name: "test_kernel" }
+                }
+                thunks: {
+                  thunk_info: { thunk_id: 456 }
+                  device_to_device_copy_thunk: {}
                 }
               )pb")));
 }
@@ -605,34 +600,29 @@ TEST(GpuExecutableTest, FromProtoWithSymbolResolver) {
     gpu_compute_capability: {
       cuda_compute_capability: { major: 9 minor: 0 feature_extension: NONE }
     }
-    thunk {
-      thunk_info { thunk_id: 1 }
-      sequential_thunk {
-        thunks {
-          thunk_info { thunk_id: 2 }
-          custom_kernel_thunk {
-            custom_kernel {
-              kernel_spec {
-                in_process_symbol { persistent_name: "persistent_kernel_name" }
-                kernel_name: "kernel_name"
-                arity: 42
-                kernel_args_packing_spec {
-                  kernel_arguments {
-                    relocations {
-                      kind: KIND_BITS64_ABSOLUTE
-                      argument_index: 0
-                      offset: 0
-                    }
-                    data: "\x00\x00\x00\x00\x00\x00\x00\x00"
-                  }
-                  kernel_arguments { data: "\x34\x12\x00\x00" }
+    thunks {
+      thunk_info { thunk_id: 2 }
+      custom_kernel_thunk {
+        custom_kernel {
+          kernel_spec {
+            in_process_symbol { persistent_name: "persistent_kernel_name" }
+            kernel_name: "kernel_name"
+            arity: 42
+            kernel_args_packing_spec {
+              kernel_arguments {
+                relocations {
+                  kind: KIND_BITS64_ABSOLUTE
+                  argument_index: 0
+                  offset: 0
                 }
+                data: "\x00\x00\x00\x00\x00\x00\x00\x00"
               }
-              block_dims { coordinates { x: 1 y: 1 z: 1 } }
-              thread_dims { coordinates { x: 1 y: 1 z: 1 } }
-              cluster_dim { coordinates { x: 1 y: 1 z: 1 } }
+              kernel_arguments { data: "\x34\x12\x00\x00" }
             }
           }
+          block_dims { coordinates { x: 1 y: 1 z: 1 } }
+          thread_dims { coordinates { x: 1 y: 1 z: 1 } }
+          cluster_dim { coordinates { x: 1 y: 1 z: 1 } }
         }
       }
     }
@@ -734,8 +724,7 @@ TEST(GpuExecutableTest, ToProtoReturnsUnchangedThunkGraph) {
   // The proto should be a straight dump of the thunk graph, without any
   // transformation.
   TF_ASSERT_OK_AND_ASSIGN(GpuExecutableProto proto, executable->ToProto());
-  ASSERT_TRUE(proto.thunk().has_sequential_thunk());
-  EXPECT_THAT(proto.thunk().sequential_thunk().thunks(), SizeIs(5));
+  EXPECT_THAT(proto.thunks(), SizeIs(5));
 }
 
 TEST(GpuExecutableTest, FromProtoRegistersHloModuleWithDebugInfoManager) {
@@ -768,14 +757,9 @@ TEST(GpuExecutableTest, FromProtoRegistersHloModuleWithDebugInfoManager) {
         }
       }
     }
-    thunk {
-      thunk_info { thunk_id: 1 }
-      sequential_thunk {
-        thunks {
-          thunk_info { thunk_id: 2 }
-          host_send_done_thunk { channel_id: 123 async_events_unique_id: 1 }
-        }
-      }
+    thunks {
+      thunk_info { thunk_id: 2 }
+      host_send_done_thunk { channel_id: 123 async_events_unique_id: 1 }
     }
   )pb");
 

--- a/xla/util/split_proto/split_gpu_executable_writer_test.cc
+++ b/xla/util/split_proto/split_gpu_executable_writer_test.cc
@@ -44,7 +44,7 @@ TEST(SplitGpuExecutableWriterTest, WriteSplitGpuExecutable) {
     gpu_compute_capability {
       cuda_compute_capability { major: 9 minor: 0 feature_extension: NONE }
     }
-    thunk { thunk_info { thunk_id: 1 } }
+    thunks { thunk_info { thunk_id: 1 } }
     module_name: "test_module"
     program_shape { parameter_names: [ "name1", "name2" ] }
     output_info_map {

--- a/xla/util/split_proto/split_proto_reader_test.cc
+++ b/xla/util/split_proto/split_proto_reader_test.cc
@@ -58,7 +58,7 @@ TEST(SplitProtoReaderTest, ReadSplitProtoWithProtoMergeRecord) {
   record_writer.WriteRecord(ParseTextProtoOrDie<gpu::GpuExecutableProto>(
       R"pb(asm_text: "test_text")pb"));
   record_writer.WriteRecord(ParseTextProtoOrDie<gpu::GpuExecutableProto>(
-      R"pb(thunk { thunk_info { thunk_id: 1 } })pb"));
+      R"pb(thunks { thunk_info { thunk_id: 1 } })pb"));
   record_writer.WriteRecord(ParseTextProtoOrDie<gpu::GpuExecutableProto>(
       R"pb(asm_text: "overridden_test_text")pb"));
   record_writer.Close();
@@ -68,7 +68,7 @@ TEST(SplitProtoReaderTest, ReadSplitProtoWithProtoMergeRecord) {
 
   EXPECT_THAT(result_proto,
               EqualsProto(R"pb(asm_text: "overridden_test_text"
-                               thunk { thunk_info { thunk_id: 1 } })pb"));
+                               thunks { thunk_info { thunk_id: 1 } })pb"));
 }
 
 TEST(SplitProtoReaderTest, ReadSplitProtoWithFieldOverrideRecord) {
@@ -120,12 +120,12 @@ TEST(SplitProtoReaderTest, UnsupportedFieldOverrideType) {
            records { proto_merge_record {} }
            records {
              field_override_record {
-               field_path { field_number: 7 }  # thunk field number
+               field_path { field_number: 13 }  # thunks field number
                field_type: TYPE_UNKNOWN
              }
            })pb"));
   record_writer.WriteRecord(ParseTextProtoOrDie<gpu::GpuExecutableProto>(
-      R"pb(thunk { thunk_info { thunk_id: 1 } })pb"));
+      R"pb(thunks { thunk_info { thunk_id: 1 } })pb"));
   record_writer.WriteRecord("some_data");
   record_writer.Close();
 


### PR DESCRIPTION
Result of compilation XLA:GPU is a `ThunkSequence` for the `ENTRY` computation.  The fact that GpuExecutable abuses SequentialThunk for execution is implementation detail that will be changed after https://github.com/openxla/xla/pull/38473 and few followup changes. In preparation for them change serialization format.