### PR TITLE
Add VMM managed APIs for StreamExecutor

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1394,6 +1394,7 @@ xla_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cuda_headers",
     ],
 )
 

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -898,7 +898,8 @@ absl::StatusOr<size_t> CudaExecutor::GetVmmGranularity() const {
   return granularity;
 }
 
-absl::StatusOr<void*> CudaExecutor::VmmAllocateMemory(uint64_t bytes) {
+absl::StatusOr<DeviceAddressBase> CudaExecutor::VmmAllocateMemory(
+    uint64_t bytes) {
   if (!is_vmm_supported_) {
     return absl::InternalError("VMM is not supported on this device.");
   }
@@ -926,26 +927,32 @@ absl::StatusOr<void*> CudaExecutor::VmmAllocateMemory(uint64_t bytes) {
 
   XLA_VLOG_DEVICE(3, device_ordinal())
       << "VMM allocated " << ptr << " requested size: " << bytes
-      << " padded size: " << padded_size << " granularity: " << granularity;
+      << " padded size: " << padded_size << " granularity: " << granularity
+      << " handle: " << handle;
 
-  int device_count = 0;
-  TF_RETURN_IF_ERROR(cuda::ToStatus(cudaGetDeviceCount(&device_count)));
-  for (int peer = 0; peer < device_count; peer++) {
-    if (peer == device_ordinal() || CanEnablePeerAccessTo(peer)) {
-      CUmemAccessDesc accessDesc = GetVmmAccessDescriptor(peer);
-      TF_RETURN_IF_ERROR(
-          cuda::ToStatus(cuMemSetAccess(ptr, padded_size, &accessDesc, 1)));
-    }
-  }
+  // Set VMM access for local device.
+  CUmemAccessDesc accessDesc = GetVmmAccessDescriptor(device_ordinal());
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuMemSetAccess(ptr, padded_size, &accessDesc, 1),
+      absl::StrFormat("Failed to set VMM access for address 0x%x with size %u",
+                      ptr, padded_size)));
 
   if (!vmm_memory_tracker_.Insert(ptr)) {
     LOG(WARNING) << "[" << device_ordinal()
                  << "] VMM memory already tracked: " << ptr;
   }
-  return reinterpret_cast<void*>(ptr);
+
+  {
+    absl::MutexLock lock(&vmm_virtual_to_handle_mu_);
+    vmm_virtual_to_handle_[reinterpret_cast<void*>(ptr)] =
+        RawAddressHandle(handle);
+  }
+
+  return DeviceAddressBase(reinterpret_cast<void*>(ptr), bytes);
 }
 
-absl::StatusOr<bool> CudaExecutor::VmmDeallocateMemory(void* ptr) {
+absl::StatusOr<bool> CudaExecutor::VmmDeallocateMemory(DeviceAddressBase addr) {
+  void* ptr = addr.opaque();
   CUdeviceptr device_ptr = reinterpret_cast<CUdeviceptr>(ptr);
   if (!vmm_memory_tracker_.Remove(device_ptr)) {
     return false;
@@ -962,12 +969,20 @@ absl::StatusOr<bool> CudaExecutor::VmmDeallocateMemory(void* ptr) {
 
   std::unique_ptr<ActivateContext> activation = Activate();
 
-  CUmemGenericAllocationHandle handle = 0;
+  RawAddressHandle raw_handle(0);
   {
-    TF_ASSIGN_OR_RETURN(VmmMemoryHandle scoped_handle,
-                        RetainVmmMemoryHandle(ptr));
-    handle = static_cast<CUmemGenericAllocationHandle>(scoped_handle.handle());
+    absl::MutexLock lock(&vmm_virtual_to_handle_mu_);
+    auto it = vmm_virtual_to_handle_.find(ptr);
+    if (it == vmm_virtual_to_handle_.end()) {
+      return absl::InvalidArgumentError(
+          "DeviceAddressBase does not have a VMM handle mapping.");
+    }
+    raw_handle = it->second;
+    vmm_virtual_to_handle_.erase(it);
   }
+  CUmemGenericAllocationHandle handle =
+      static_cast<CUmemGenericAllocationHandle>(raw_handle.value());
+
   size_t size = 0;
   TF_RETURN_IF_ERROR(
       cuda::ToStatus(cuMemGetAddressRange(nullptr, &size, device_ptr)));
@@ -978,6 +993,43 @@ absl::StatusOr<bool> CudaExecutor::VmmDeallocateMemory(void* ptr) {
   TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemAddressFree(device_ptr, size)));
   deletion_completed = true;
   return true;
+}
+
+absl::Status CudaExecutor::VmmSetAccess(DeviceAddressBase* address,
+                                        CUmemAccessDesc access_desc,
+                                        uint64_t count) {
+  if (address == nullptr || address->is_null()) {
+    return absl::InvalidArgumentError("Cannot set VMM access on null address.");
+  }
+  if (address->size() == 0) {
+    return absl::OkStatus();
+  }
+
+  std::unique_ptr<ActivateContext> activation = Activate();
+
+  CUdeviceptr ptr = reinterpret_cast<CUdeviceptr>(address->opaque());
+
+  // Round size up to allocation granularity.
+  uint64_t granularity = GetAllocationGranularity();
+  uint64_t size =
+      ((address->size() + granularity - 1) / granularity) * granularity;
+
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuMemSetAccess(ptr, size, &access_desc, count),
+      absl::StrFormat("Failed to set VMM access for address %p with size %llu",
+                      address->opaque(),
+                      static_cast<unsigned long long>(size))));
+
+  XLA_VLOG_DEVICE(3, device_ordinal())
+      << "Set VMM access for address " << address->opaque() << " with size "
+      << size << " location.id=" << access_desc.location.id;
+
+  return absl::OkStatus();
+}
+
+absl::Status CudaExecutor::VmmSetAccess(DeviceAddressBase* address) {
+  CUmemAccessDesc access_desc = GetVmmAccessDescriptor(device_ordinal());
+  return VmmSetAccess(address, access_desc, /*count=*/1);
 }
 
 absl::StatusOr<void*> CollectiveMemoryAllocate(StreamExecutor* executor,
@@ -1418,16 +1470,32 @@ DeviceAddressBase CudaExecutor::Allocate(uint64_t size, int64_t memory_space) {
 
   if (memory_space == static_cast<int64_t>(MemorySpace::kP2P) &&
       is_vmm_supported_) {
-    auto device_buf_base = VmmAllocateMemory(size);
-
-    if (device_buf_base.ok()) {
-      return DeviceAddressBase(device_buf_base.value(), size);
+    auto result = VmmAllocateMemory(size);
+    if (!result.ok()) {
+      XLA_LOG_DEVICE(ERROR, device_ordinal())
+          << "Failed to allocate VMM memory: " << result.status();
+      return DeviceAddressBase(nullptr, 0);
     }
+    DeviceAddressBase device_address = result.value();
 
-    XLA_LOG_DEVICE(ERROR, device_ordinal())
-        << "Failed to allocate memory with VMM: " << device_buf_base.status();
-
-    return DeviceAddressBase(nullptr, 0);
+    int device_count = 0;
+    auto count_status = cuda::ToStatus(cudaGetDeviceCount(&device_count));
+    if (!count_status.ok()) {
+      LOG(WARNING) << "Failed to get device count for peer access: "
+                   << count_status;
+      return device_address;
+    }
+    for (int peer = 0; peer < device_count; peer++) {
+      if (peer != device_ordinal() && CanEnablePeerAccessTo(peer)) {
+        CUmemAccessDesc accessDesc = GetVmmAccessDescriptor(peer);
+        auto access_status = VmmSetAccess(&device_address, accessDesc, 1);
+        if (!access_status.ok()) {
+          LOG(WARNING) << "Failed to set VMM access for peer " << peer << ": "
+                       << access_status;
+        }
+      }
+    }
+    return device_address;
   }
 
   CHECK(memory_space == static_cast<int64_t>(MemorySpace::kDevice) ||
@@ -1460,7 +1528,7 @@ void CudaExecutor::Deallocate(DeviceAddressBase* mem) {
     // Memory space is always kDevice here, so the only way to check if the
     // memory was allocated with VMM API is to try to retain the handle with VMM
     // API (which VmmDeallocateMemory does).
-    auto result = VmmDeallocateMemory(mem->opaque());
+    auto result = VmmDeallocateMemory(*mem);
     if (!result.ok()) {
       LOG(WARNING) << "Failed to deallocate VMM memory handle: "
                    << result.status();
@@ -1468,6 +1536,199 @@ void CudaExecutor::Deallocate(DeviceAddressBase* mem) {
       DeviceDeallocate(cuda_context_, mem->opaque());
     }
   }
+}
+
+absl::StatusOr<DeviceAddressBase> CudaExecutor::ReserveAddress(
+    uint64_t size, int64_t memory_space) {
+  XLA_VLOG_DEVICE(1, device_ordinal())
+      << "CudaExecutor::ReserveAddress size: " << size
+      << " memory_space: " << memory_space;
+
+  if (size == 0) {
+    return DeviceAddressBase(nullptr, 0);
+  }
+
+  std::unique_ptr<ActivateContext> activation = Activate();
+
+  // Get the granularity for address reservation.
+  CUmemAllocationProp properties =
+      GetVmmAllocationProperties(device_, is_rdma_supported_);
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
+      &granularity, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
+
+  // Round up size to be a multiple of the granularity.
+  // cuMemAddressReserve requires size to be aligned to granularity.
+  uint64_t aligned_size =
+      ((size + granularity - 1) / granularity) * granularity;
+
+  // Reserve virtual address space using cuMemAddressReserve.
+  CUdeviceptr ptr = 0;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemAddressReserve(
+      &ptr, aligned_size, granularity, /*addr=*/0, /*flags=*/0)));
+
+  XLA_VLOG_DEVICE(2, device_ordinal())
+      << "Reserved virtual address " << reinterpret_cast<void*>(ptr)
+      << " of size " << aligned_size << " bytes (requested " << size
+      << ") with granularity " << granularity;
+
+  // Note: We do NOT call VmmSetAccess here because the virtual address
+  // has no physical memory mapped yet. Access permissions must be set
+  // AFTER physical memory is mapped via MapRawAddress.
+
+  // Return the original requested size - FreeAddress will need to handle
+  // the alignment when freeing.
+  return DeviceAddressBase(reinterpret_cast<void*>(ptr), size);
+}
+
+absl::Status CudaExecutor::FreeAddress(DeviceAddressBase* mem) {
+  XLA_VLOG_DEVICE(1, device_ordinal())
+      << "CudaExecutor::FreeAddress mem: " << mem->opaque()
+      << " size: " << mem->size();
+
+  if (mem->is_null()) {
+    return absl::OkStatus();
+  }
+
+  std::unique_ptr<ActivateContext> activation = Activate();
+
+  // Get granularity and align the size, since cuMemAddressFree requires
+  // the same aligned size that was used in cuMemAddressReserve.
+  uint64_t granularity = GetAllocationGranularity();
+  uint64_t size = mem->size();
+  uint64_t aligned_size =
+      ((size + granularity - 1) / granularity) * granularity;
+
+  CUdeviceptr ptr = reinterpret_cast<CUdeviceptr>(mem->opaque());
+  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemAddressFree(ptr, aligned_size)));
+
+  XLA_VLOG_DEVICE(2, device_ordinal())
+      << "Freed virtual address " << mem->opaque() << " of size "
+      << aligned_size << " (requested " << size << ")";
+
+  return absl::OkStatus();
+}
+
+uint64_t CudaExecutor::GetAllocationGranularity() const {
+  absl::call_once(allocation_granularity_once_, [this]() {
+    CUmemAllocationProp properties =
+        GetVmmAllocationProperties(device_, is_rdma_supported_);
+    size_t granularity = 0;
+    absl::Status status = cuda::ToStatus(cuMemGetAllocationGranularity(
+        &granularity, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED));
+    if (!status.ok()) {
+      XLA_LOG_DEVICE(ERROR, device_ordinal())
+          << "Failed to get allocation granularity: " << status;
+      allocation_granularity_query_ok_ = false;
+      return;
+    }
+    allocation_granularity_ = static_cast<uint64_t>(granularity);
+    allocation_granularity_query_ok_ = true;
+  });
+
+  if (!allocation_granularity_query_ok_) {
+    return 0;
+  }
+  return allocation_granularity_;
+}
+
+absl::Status CudaExecutor::MapRawAddress(DeviceAddressBase* address,
+                                         size_t offset,
+                                         RawAddressHandle handle) {
+  // Currently offset must be 0.
+  if (offset != 0) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("MapRawAddress offset must be 0, got %zu", offset));
+  }
+
+  if (address == nullptr || address->is_null()) {
+    return absl::InvalidArgumentError("Cannot map to null address");
+  }
+
+  // Round size up to allocation granularity.
+  uint64_t granularity = GetAllocationGranularity();
+  uint64_t size =
+      ((address->size() + granularity - 1) / granularity) * granularity;
+
+  XLA_VLOG_DEVICE(1, device_ordinal())
+      << "CudaExecutor::MapRawAddress address: " << address->opaque()
+      << " size: " << size << " (original: " << address->size() << ")"
+      << " offset: " << offset << " handle: " << handle.value();
+
+  std::unique_ptr<ActivateContext> activation = Activate();
+
+  CUdeviceptr ptr = reinterpret_cast<CUdeviceptr>(address->opaque());
+  CUmemGenericAllocationHandle cu_handle =
+      static_cast<CUmemGenericAllocationHandle>(handle.value());
+
+  // Map physical memory to virtual address using cuMemMap.
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuMemMap(ptr, size, 0, cu_handle, 0),
+      absl::StrFormat("Failed to map raw physical memory handle %llu to "
+                      "virtual address %p with size %zu",
+                      handle.value(), address->opaque(), size)));
+
+  {
+    absl::MutexLock lock(&vmm_virtual_to_handle_mu_);
+    vmm_virtual_to_handle_[address->opaque()] = handle;
+  }
+
+  XLA_VLOG_DEVICE(2, device_ordinal())
+      << "Mapped raw physical memory handle " << handle.value()
+      << " to virtual address " << address->opaque() << " with size " << size;
+
+  return absl::OkStatus();
+}
+
+absl::Status CudaExecutor::UnmapRawAddress(DeviceAddressBase* address) {
+  if (address == nullptr || address->is_null()) {
+    return absl::OkStatus();
+  }
+
+  // Round size up to allocation granularity.
+  uint64_t granularity = GetAllocationGranularity();
+  uint64_t size =
+      ((address->size() + granularity - 1) / granularity) * granularity;
+
+  XLA_VLOG_DEVICE(1, device_ordinal())
+      << "CudaExecutor::UnmapRawAddress address: " << address->opaque()
+      << " size: " << size << " (original: " << address->size() << ")";
+
+  std::unique_ptr<ActivateContext> activation = Activate();
+
+  CUdeviceptr ptr = reinterpret_cast<CUdeviceptr>(address->opaque());
+
+  // Unmap the memory using cuMemUnmap.
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuMemUnmap(ptr, size),
+      absl::StrFormat("Failed to unmap virtual address %p with size %zu",
+                      address->opaque(), size)));
+
+  {
+    absl::MutexLock lock(&vmm_virtual_to_handle_mu_);
+    vmm_virtual_to_handle_.erase(address->opaque());
+  }
+
+  XLA_VLOG_DEVICE(2, device_ordinal())
+      << "Unmapped virtual address " << address->opaque() << " with size "
+      << size;
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<RawAddressHandle> CudaExecutor::GetRawHandleForVmmAddress(
+    DeviceAddressBase& addr) {
+  if (addr.is_null()) {
+    return absl::InvalidArgumentError(
+        "Cannot get raw handle for null address.");
+  }
+  absl::MutexLock lock(&vmm_virtual_to_handle_mu_);
+  auto it = vmm_virtual_to_handle_.find(addr.opaque());
+  if (it == vmm_virtual_to_handle_.end()) {
+    return absl::NotFoundError(absl::StrFormat(
+        "No VMM handle mapping found for virtual address %p", addr.opaque()));
+  }
+  return it->second;
 }
 
 bool CudaExecutor::SynchronizeAllActivity() {

--- a/xla/stream_executor/cuda/cuda_executor.h
+++ b/xla/stream_executor/cuda/cuda_executor.h
@@ -35,6 +35,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -103,6 +104,18 @@ class CudaExecutor : public GpuExecutor {
       Stream* stream, absl::Span<const uint8_t> content) override;
   DeviceAddressBase Allocate(uint64_t size, int64_t memory_space) override;
   void Deallocate(DeviceAddressBase* mem) override;
+  absl::StatusOr<DeviceAddressBase> ReserveAddress(
+      uint64_t size, int64_t memory_space) override;
+  absl::Status FreeAddress(DeviceAddressBase* mem) override;
+  uint64_t GetAllocationGranularity() const override;
+  absl::Status MapRawAddress(DeviceAddressBase* address, size_t offset,
+                             RawAddressHandle handle) override;
+  absl::Status UnmapRawAddress(DeviceAddressBase* address) override;
+  absl::Status VmmSetAccess(DeviceAddressBase* address) override;
+  absl::StatusOr<DeviceAddressBase> VmmAllocateMemory(uint64_t bytes) override;
+  absl::StatusOr<bool> VmmDeallocateMemory(DeviceAddressBase addr) override;
+  absl::StatusOr<RawAddressHandle> GetRawHandleForVmmAddress(
+      DeviceAddressBase& addr) override;
   blas::BlasSupport* AsBlas() override;
   fft::FftSupport* AsFft() override;
   dnn::DnnSupport* AsDnn() override;
@@ -211,13 +224,13 @@ class CudaExecutor : public GpuExecutor {
     return is_multicast_supported_;
   }
 
- private:
-  // Checks if the memory was allocated with VMM API.
-  // If yes, deallocates the memory and returns true.
-  // If not, returns false.
-  absl::StatusOr<bool> VmmDeallocateMemory(void* ptr);
+  // Sets memory access permissions for a VMM-allocated address range.
+  // Uses cuMemSetAccess to configure access for the specified memory region.
+  // Must be called after MapRawAddress to enable access to the mapped memory.
+  absl::Status VmmSetAccess(DeviceAddressBase* address,
+                            CUmemAccessDesc access_desc, uint64_t count);
 
-  absl::StatusOr<void*> VmmAllocateMemory(uint64_t bytes);
+ private:
 
   // Loads a module in cubin format.
   absl::StatusOr<ModuleHandle> LoadModuleFromCuBin(const char* cubin)
@@ -311,6 +324,14 @@ class CudaExecutor : public GpuExecutor {
   // Memory allocation tracker for VMM memory.
   MemoryTracker vmm_memory_tracker_;
 
+  // Guards vmm_virtual_to_handle_.
+  absl::Mutex vmm_virtual_to_handle_mu_;
+  // Maps virtual address pointer to its raw VMM handle. Populated on
+  // VmmAllocateMemory and MapRawAddress; cleared on VmmDeallocateMemory and
+  // UnmapRawAddress.
+  absl::flat_hash_map<void*, RawAddressHandle> vmm_virtual_to_handle_
+      ABSL_GUARDED_BY(vmm_virtual_to_handle_mu_);
+
   // CudaContext for this device.
   CudaContext* cuda_context_;
 
@@ -320,6 +341,12 @@ class CudaExecutor : public GpuExecutor {
   int stream_priority_lowest_ = 0;
   int stream_priority_highest_ = 0;
   bool stream_priority_query_ok_ = false;
+
+  // Cached allocation granularity. Initialized once on first request.
+  mutable absl::once_flag allocation_granularity_once_;
+  mutable uint64_t allocation_granularity_ = 0;
+  mutable bool allocation_granularity_query_ok_ = false;
+
   absl::flat_hash_map<int, bool> peer_access_cache_;
 };
 

--- a/xla/stream_executor/cuda/cuda_executor_test.cc
+++ b/xla/stream_executor/cuda/cuda_executor_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
@@ -255,6 +256,191 @@ TEST(CudaExecutorTest,
 
   EXPECT_THAT(cuda_executor->RetainVmmMemoryHandle(ptr.opaque()),
               absl_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST(CudaExecutorTest, ReserveAddressAndFreeAddress) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("CUDA"));
+  TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                          platform->ExecutorForDevice(0));
+
+  auto cuda_executor = dynamic_cast<CudaExecutor*>(executor);
+  ASSERT_NE(cuda_executor, nullptr);
+
+  // Get granularity to ensure proper alignment.
+  uint64_t granularity = cuda_executor->GetAllocationGranularity();
+  EXPECT_GT(granularity, 0);
+
+  // Reserve a virtual address range.
+  uint64_t size = granularity;  // Use granularity-aligned size.
+  TF_ASSERT_OK_AND_ASSIGN(
+      DeviceAddressBase reserved,
+      cuda_executor->ReserveAddress(size, static_cast<int>(MemorySpace::kP2P)));
+
+  EXPECT_NE(reserved.opaque(), nullptr);
+  EXPECT_EQ(reserved.size(), size);
+
+  // Free the reserved address.
+  EXPECT_THAT(cuda_executor->FreeAddress(&reserved), absl_testing::IsOk());
+}
+
+TEST(CudaExecutorTest, MapRawAddressAndUnmapRawAddress) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("CUDA"));
+  TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                          platform->ExecutorForDevice(0));
+
+  auto cuda_executor = dynamic_cast<CudaExecutor*>(executor);
+  ASSERT_NE(cuda_executor, nullptr);
+
+  // Get granularity to ensure proper alignment.
+  uint64_t granularity = cuda_executor->GetAllocationGranularity();
+  EXPECT_GT(granularity, 0);
+
+  uint64_t size = granularity;
+
+  // Allocate physical memory with VMM API.
+  TF_ASSERT_OK_AND_ASSIGN(DeviceAddressBase vmm_alloc,
+                          cuda_executor->VmmAllocateMemory(size));
+  EXPECT_NE(vmm_alloc.opaque(), nullptr);
+  EXPECT_TRUE(cuda_executor->GetRawHandleForVmmAddress(vmm_alloc).ok());
+
+  // Clean up the VMM allocation (which already has memory mapped).
+  TF_ASSERT_OK_AND_ASSIGN(bool deallocated,
+                          cuda_executor->VmmDeallocateMemory(vmm_alloc));
+  EXPECT_TRUE(deallocated);
+}
+
+TEST(CudaExecutorTest, MapRawAddressWithManualReserveAndMap) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("CUDA"));
+  TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                          platform->ExecutorForDevice(0));
+
+  auto cuda_executor = dynamic_cast<CudaExecutor*>(executor);
+  ASSERT_NE(cuda_executor, nullptr);
+
+  // Create a stream for memory operations.
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+
+  // Get granularity to ensure proper alignment.
+  uint64_t granularity = cuda_executor->GetAllocationGranularity();
+  EXPECT_GT(granularity, 0);
+
+  uint64_t size = granularity;
+
+  // Step 1: Allocate physical memory with VMM API to get a raw handle.
+  TF_ASSERT_OK_AND_ASSIGN(DeviceAddressBase vmm_alloc,
+                          cuda_executor->VmmAllocateMemory(size));
+  ASSERT_NE(vmm_alloc.opaque(), nullptr);
+  ASSERT_TRUE(cuda_executor->GetRawHandleForVmmAddress(vmm_alloc).ok());
+  RawAddressHandle raw_handle =
+      *cuda_executor->GetRawHandleForVmmAddress(vmm_alloc);
+
+  // Step 2: Write test data to the original virtual address.
+  constexpr uint64_t kTestValue = 0xDEADBEEFCAFEBABE;
+  EXPECT_THAT(stream->Memcpy(&vmm_alloc, &kTestValue, sizeof(kTestValue)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  // Step 3: Reserve a separate virtual address range.
+  TF_ASSERT_OK_AND_ASSIGN(
+      DeviceAddressBase reserved,
+      cuda_executor->ReserveAddress(size, static_cast<int>(MemorySpace::kP2P)));
+  ASSERT_NE(reserved.opaque(), nullptr);
+  EXPECT_EQ(reserved.size(), size);
+
+  // Step 4: Map the physical memory to the new reserved virtual address.
+  // The physical memory is now mapped to both vmm_alloc and reserved.
+  EXPECT_THAT(
+      cuda_executor->MapRawAddress(&reserved, /*offset=*/0, raw_handle),
+      absl_testing::IsOk());
+
+  // Step 4b: Set access permissions for the newly mapped virtual address.
+  CUmemAccessDesc access_desc = {};
+  access_desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  access_desc.location.id = cuda_executor->device_ordinal();
+  access_desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  EXPECT_THAT(cuda_executor->VmmSetAccess(&reserved, access_desc, /*count=*/1),
+              absl_testing::IsOk());
+
+  // Step 5: Verify that reading from both addresses gives the same value.
+  uint64_t value_from_original = 0;
+  uint64_t value_from_new = 0;
+  EXPECT_THAT(
+      stream->Memcpy(&value_from_original, vmm_alloc, sizeof(uint64_t)),
+      absl_testing::IsOk());
+  EXPECT_THAT(stream->Memcpy(&value_from_new, reserved, sizeof(uint64_t)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  EXPECT_EQ(value_from_original, kTestValue);
+  EXPECT_EQ(value_from_new, kTestValue);
+  EXPECT_EQ(value_from_original, value_from_new);
+
+  // Step 6: Clean up - unmap from the new address and free it.
+  EXPECT_THAT(cuda_executor->UnmapRawAddress(&reserved), absl_testing::IsOk());
+  EXPECT_THAT(cuda_executor->FreeAddress(&reserved), absl_testing::IsOk());
+
+  // Step 7: Deallocate the original VMM memory.
+  TF_ASSERT_OK_AND_ASSIGN(bool deallocated,
+                          cuda_executor->VmmDeallocateMemory(vmm_alloc));
+  EXPECT_TRUE(deallocated);
+}
+
+TEST(CudaExecutorTest, MapRawAddressFailsWithNonZeroOffset) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("CUDA"));
+  TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                          platform->ExecutorForDevice(0));
+
+  auto cuda_executor = dynamic_cast<CudaExecutor*>(executor);
+  ASSERT_NE(cuda_executor, nullptr);
+
+  uint64_t granularity = cuda_executor->GetAllocationGranularity();
+  uint64_t size = granularity;
+
+  // Allocate physical memory.
+  TF_ASSERT_OK_AND_ASSIGN(DeviceAddressBase vmm_alloc,
+                          cuda_executor->VmmAllocateMemory(size));
+  ASSERT_TRUE(cuda_executor->GetRawHandleForVmmAddress(vmm_alloc).ok());
+  RawAddressHandle raw_handle =
+      *cuda_executor->GetRawHandleForVmmAddress(vmm_alloc);
+
+  // Reserve address.
+  TF_ASSERT_OK_AND_ASSIGN(
+      DeviceAddressBase reserved,
+      cuda_executor->ReserveAddress(size, static_cast<int>(MemorySpace::kP2P)));
+  ASSERT_NE(reserved.opaque(), nullptr);
+
+  // Try to map with non-zero offset - should fail.
+  EXPECT_THAT(
+      cuda_executor->MapRawAddress(&reserved, /*offset=*/1024, raw_handle),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                             HasSubstr("offset must be 0")));
+
+  // Clean up.
+  EXPECT_THAT(cuda_executor->FreeAddress(&reserved), absl_testing::IsOk());
+  EXPECT_THAT(cuda_executor->VmmDeallocateMemory(vmm_alloc),
+              absl_testing::IsOkAndHolds(true));
+}
+
+TEST(CudaExecutorTest, MapRawAddressFailsWithNullAddress) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("CUDA"));
+  TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                          platform->ExecutorForDevice(0));
+
+  auto cuda_executor = dynamic_cast<CudaExecutor*>(executor);
+  ASSERT_NE(cuda_executor, nullptr);
+
+  DeviceAddressBase null_address;
+  RawAddressHandle dummy_handle{0};
+
+  EXPECT_THAT(
+      cuda_executor->MapRawAddress(&null_address, /*offset=*/0, dummy_handle),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                             HasSubstr("null address")));
 }
 }  // namespace
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -59,6 +59,8 @@ limitations under the License.
 
 namespace stream_executor {
 
+TSL_LIB_GTL_DEFINE_INT_TYPE(RawAddressHandle, uint64_t);
+
 /// The StreamExecutor is a single-device abstraction for:
 //
 // * Loading/launching data-parallel-kernels
@@ -174,6 +176,63 @@ class StreamExecutor {
   // Deallocates the DeviceAddress previously allocated via this interface.
   // Deallocation of a nullptr-representative value is permitted.
   virtual void Deallocate(DeviceAddressBase* mem) = 0;
+
+  // Reserves size bytes on the underlying platform and returns a
+  // DeviceAddressBase representing that reservation.
+  virtual absl::StatusOr<DeviceAddressBase> ReserveAddress(
+      uint64_t size, int64_t memory_space) {
+    return absl::UnimplementedError("ReserveAddress not supported");
+  }
+  absl::StatusOr<DeviceAddressBase> ReserveAddress(uint64_t size) {
+    return ReserveAddress(size, /*memory_space=*/0);
+  }
+
+  // Frees the DeviceAddress previously reserved via this interface.
+  // Deallocation of a nullptr-representative value is permitted.
+  virtual absl::Status FreeAddress(DeviceAddressBase* mem) {
+    return absl::UnimplementedError("FreeAddress not supported");
+  }
+
+  // Maps raw physical memory to a reserved virtual address.
+  virtual absl::Status MapRawAddress(DeviceAddressBase* address, size_t offset,
+                                     RawAddressHandle handle) {
+    return absl::UnimplementedError("MapRawAddress not supported");
+  }
+
+  virtual absl::Status VmmSetAccess(DeviceAddressBase* address) {
+    return absl::UnimplementedError("MapRawAddress not supported");
+  }
+
+  // Unmaps raw physical memory from a virtual address.
+  virtual absl::Status UnmapRawAddress(DeviceAddressBase* address) {
+    return absl::UnimplementedError("UnmapRawAddress not supported");
+  }
+
+  // Allocates memory using VMM (Virtual Memory Management) APIs.
+  // Returns a DeviceAddressBase for the allocated virtual address. The
+  // raw VMM handle is tracked internally and can be retrieved via
+  // GetRawHandleForVmmAddress. The caller is responsible for setting memory
+  // access permissions and eventually calling VmmDeallocateMemory.
+  virtual absl::StatusOr<DeviceAddressBase> VmmAllocateMemory(uint64_t bytes) {
+    return absl::UnimplementedError("VMM allocation not supported");
+  }
+
+  // Deallocates memory that was allocated with VmmAllocateMemory.
+  // Returns true if the memory was deallocated, false if the memory was not
+  // allocated with VMM API.
+  virtual absl::StatusOr<bool> VmmDeallocateMemory(DeviceAddressBase addr) {
+    return absl::UnimplementedError("VMM deallocation not supported");
+  }
+
+  // Returns the raw VMM handle for the given virtual address, which must have
+  // been previously allocated via VmmAllocateMemory or mapped via MapRawAddress.
+  virtual absl::StatusOr<RawAddressHandle> GetRawHandleForVmmAddress(
+      DeviceAddressBase& addr) {
+    return absl::UnimplementedError("GetRawHandleForVmmAddress not supported");
+  }
+
+  // Returns the allocation granularity for VMM operations.
+  virtual uint64_t GetAllocationGranularity() const { return 0; }
 
   // Allocates a region of host memory and registers it with the platform API.
   // Memory allocated in this manner is required for use in asynchronous memcpy


### PR DESCRIPTION
This PR extends the StreamExecutor and CudaExecutor interfaces with a comprehensive Virtual Memory Management (VMM) API that exposes low-level CUDA virtual memory operations. The key addition is tracking the raw CUmemGenericAllocationHandle for each virtual address, enabling callers to explicitly control the map/unmap lifecycle of physical memory backing.

This change is prerequisite for another PR (https://github.com/openxla/xla/pull/35315, Avoid command buffer update by virtual address remapping) 

Changes

stream_executor.h
  - Introduces RawAddressHandle — a typed wrapper (uint64_t) for opaque platform VMM handles
  - Adds virtual API methods to StreamExecutor with default UnimplementedError stubs:
    - ReserveAddress / FreeAddress — reserve/release virtual address space without physical backing
    - MapRawAddress / UnmapRawAddress — map/unmap physical memory to a reserved virtual address
    - VmmSetAccess — set memory access permissions on a virtual address range
    - VmmAllocateMemory / VmmDeallocateMemory — high-level VMM alloc/dealloc (now returning DeviceAddressBase)
    - GetRawHandleForVmmAddress — retrieve the RawAddressHandle associated with a virtual address
    - GetAllocationGranularity — query the recommended granularity for VMM operations

  cuda_executor.h / cuda_executor.cc
  - Implements all new StreamExecutor VMM methods
  - Adds a thread-safe absl::flat_hash_map<void*, RawAddressHandle> (vmm_virtual_to_handle_) protected by absl::Mutex to track virtual-to-handle mappings
  - Caches allocation granularity via absl::once_flag to avoid repeated CUDA API calls
  - Updates VmmAllocateMemory return type from void* to DeviceAddressBase
  - Refactors VmmDeallocateMemory to look up the handle from the internal map instead of calling RetainVmmMemoryHandle
  - Separates peer access setup in Allocate() so it's done after VMM allocation via VmmSetAccess

  cuda_executor_test.cc
  - Adds 5 new tests covering the full VMM address lifecycle:
    - ReserveAddressAndFreeAddress
    - MapRawAddressAndUnmapRawAddress
    - MapRawAddressWithManualReserveAndMap — end-to-end test verifying two virtual addresses can alias the same physical memory
    - MapRawAddressFailsWithNonZeroOffset
    - MapRawAddressFailsWithNullAddress

  Motivation

  The previous VMM implementation did not expose the raw handle externally, making it impossible for callers to implement scenarios like multi-mapping (mapping the same physical allocation to multiple virtual addresses). This is required for advanced memory management patterns such as ring-buffer aliasing and memory compaction used in collective communication operations.

