### PR TITLE
Add StreamExecutorVmmAllocator and VMM interface to StreamExecutor

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -86,6 +86,7 @@ cc_library(
     name = "device_address",
     hdrs = ["device_address.h"],
     deps = [
+        "//xla/tsl/lib/gtl:int_type",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log:check",
     ],
@@ -310,6 +311,49 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:numbers",
+    ],
+)
+
+cc_library(
+    name = "stream_executor_vmm_allocator",
+    srcs = ["stream_executor_vmm_allocator.cc"],
+    hdrs = ["stream_executor_vmm_allocator.h"],
+    deps = [
+        ":device_address",
+        ":device_address_allocator",
+        ":platform",
+        ":stream",
+        ":stream_executor_h",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:numbers",
+        "@tsl//tsl/profiler/lib:scoped_annotation",
+    ],
+)
+
+xla_cc_test(
+    name = "stream_executor_vmm_allocator_test",
+    srcs = ["stream_executor_vmm_allocator_test.cc"],
+    tags = ["cuda-only"],
+    deps = [
+        ":device_address",
+        ":platform",
+        ":platform_manager",
+        ":stream",
+        ":stream_executor_h",
+        ":stream_executor_vmm_allocator",
+        "//xla/stream_executor/cuda:cuda_platform",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -341,7 +341,10 @@ cc_library(
 xla_cc_test(
     name = "stream_executor_vmm_allocator_test",
     srcs = ["stream_executor_vmm_allocator_test.cc"],
-    tags = ["cuda-only"],
+    tags = [
+        "cuda-only",
+        "requires-gpu-nvidia",
+    ],
     deps = [
         ":device_address",
         ":platform",

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -59,6 +59,8 @@ limitations under the License.
 
 namespace stream_executor {
 
+TSL_LIB_GTL_DEFINE_INT_TYPE(RawAddressHandle, uint64_t);
+
 /// The StreamExecutor is a single-device abstraction for:
 //
 // * Loading/launching data-parallel-kernels
@@ -174,6 +176,63 @@ class StreamExecutor {
   // Deallocates the DeviceAddress previously allocated via this interface.
   // Deallocation of a nullptr-representative value is permitted.
   virtual void Deallocate(DeviceAddressBase* mem) = 0;
+
+  // Reserves size bytes on the underlying platform and returns a
+  // DeviceAddressBase representing that reservation.
+  virtual absl::StatusOr<DeviceAddressBase> ReserveAddress(
+      uint64_t size, int64_t memory_space) {
+    return absl::UnimplementedError("ReserveAddress not supported");
+  }
+  absl::StatusOr<DeviceAddressBase> ReserveAddress(uint64_t size) {
+    return ReserveAddress(size, /*memory_space=*/0);
+  }
+
+  // Frees the DeviceAddress previously reserved via this interface.
+  // Deallocation of a nullptr-representative value is permitted.
+  virtual absl::Status FreeAddress(DeviceAddressBase* mem) {
+    return absl::UnimplementedError("FreeAddress not supported");
+  }
+
+  // Maps raw physical memory to a reserved virtual address.
+  virtual absl::Status MapRawAddress(DeviceAddressBase* address, size_t offset,
+                                     RawAddressHandle handle) {
+    return absl::UnimplementedError("MapRawAddress not supported");
+  }
+
+  virtual absl::Status VmmSetAccess(DeviceAddressBase* address) {
+    return absl::UnimplementedError("MapRawAddress not supported");
+  }
+
+  // Unmaps raw physical memory from a virtual address.
+  virtual absl::Status UnmapRawAddress(DeviceAddressBase* address) {
+    return absl::UnimplementedError("UnmapRawAddress not supported");
+  }
+
+  // Allocates memory using VMM (Virtual Memory Management) APIs.
+  // Returns a DeviceAddressBase for the allocated virtual address. The
+  // raw VMM handle is tracked internally and can be retrieved via
+  // GetRawHandleForVmmAddress. The caller is responsible for setting memory
+  // access permissions and eventually calling VmmDeallocateMemory.
+  virtual absl::StatusOr<DeviceAddressBase> VmmAllocateMemory(uint64_t bytes) {
+    return absl::UnimplementedError("VMM allocation not supported");
+  }
+
+  // Deallocates memory that was allocated with VmmAllocateMemory.
+  // Returns true if the memory was deallocated, false if the memory was not
+  // allocated with VMM API.
+  virtual absl::StatusOr<bool> VmmDeallocateMemory(DeviceAddressBase addr) {
+    return absl::UnimplementedError("VMM deallocation not supported");
+  }
+
+  // Returns the raw VMM handle for the given virtual address, which must have
+  // been previously allocated via VmmAllocateMemory or mapped via MapRawAddress.
+  virtual absl::StatusOr<RawAddressHandle> GetRawHandleForVmmAddress(
+      DeviceAddressBase& addr) {
+    return absl::UnimplementedError("GetRawHandleForVmmAddress not supported");
+  }
+
+  // Returns the allocation granularity for VMM operations.
+  virtual uint64_t GetAllocationGranularity() const { return 0; }
 
   // Allocates a region of host memory and registers it with the platform API.
   // Memory allocated in this manner is required for use in asynchronous memcpy

--- a/xla/stream_executor/stream_executor_vmm_allocator.cc
+++ b/xla/stream_executor/stream_executor_vmm_allocator.cc
@@ -1,0 +1,366 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/stream_executor_vmm_allocator.h"
+
+#include <cstdint>
+#include <utility>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/device_address_allocator.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/statusor.h"
+#include "tsl/platform/numbers.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
+
+namespace stream_executor {
+
+DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(StreamExecutor* executor,
+                                                     Stream* stream,
+                                                     uint64_t pa_budget)
+    : DeviceAddressAllocator(executor->GetPlatform()),
+      allocation_granularity_(executor->GetAllocationGranularity()) {
+  stream_executors_ = {executor};
+  streams_[executor->device_ordinal()] = stream;
+  allocator_pa_budget_[executor->device_ordinal()] = pa_budget;
+  VLOG(3) << "DeviceAddressVmmAllocator created for device "
+          << executor->device_ordinal() << " with pa_budget " << pa_budget;
+}
+
+DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(
+    const Platform* platform, absl::Span<const DeviceInfo> devices)
+    : DeviceAddressAllocator(platform) {
+  CHECK_EQ(devices.size(), 1)
+      << "DeviceAddressVmmAllocator only supports single-device "
+         "instantiation. Got "
+      << devices.size() << " devices.";
+  stream_executors_.reserve(devices.size());
+  for (const auto& device : devices) {
+    stream_executors_.push_back(device.executor);
+    streams_[device.executor->device_ordinal()] = device.stream;
+    allocator_pa_budget_[device.executor->device_ordinal()] = device.pa_budget;
+    // Initialize allocation granularity from the first device.
+    if (allocation_granularity_ == 0) {
+      allocation_granularity_ = device.executor->GetAllocationGranularity();
+    }
+    VLOG(3) << "DeviceAddressVmmAllocator created for device "
+            << device.executor->device_ordinal() << " with pa_budget "
+            << device.pa_budget;
+  }
+}
+
+DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
+  // Process all remaining pending deallocations synchronously.
+  for (auto& pending : pending_deallocations_) {
+    // Wait for the event to complete.
+    if (pending.event) {
+      auto status = pending.event->Synchronize();
+      if (!status.ok()) {
+        LOG(WARNING) << "Failed to synchronize event during cleanup: "
+                     << status;
+      }
+    }
+    DoDeallocate(pending.device_ordinal, pending.mem);
+  }
+  pending_deallocations_.clear();
+}
+
+void DeviceAddressVmmAllocator::ProcessCompletedPendingDeallocations() {
+  // Process pending deallocations whose events have completed.
+  while (!pending_deallocations_.empty()) {
+    auto& front = pending_deallocations_.front();
+
+    // Check if the event has completed.
+    if (front.event) {
+      Event::Status status = front.event->PollForStatus();
+      if (status == Event::Status::kPending) {
+        // Not ready yet, stop processing.
+        break;
+      }
+      if (status == Event::Status::kError) {
+        LOG(WARNING) << "Event error while processing pending deallocation";
+      }
+    }
+
+    // Event completed (or no event), perform the actual deallocation.
+    DoDeallocate(front.device_ordinal, front.mem);
+
+    pending_deallocations_.pop_front();
+  }
+}
+
+void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
+    uint64_t size) {
+  if (pending_deallocations_.empty()) {
+    return;
+  }
+
+  // Determine how many pending deallocations from the front of the queue
+  // we need to wait for to free enough memory for the requested size.
+  // Use rounded sizes since physical memory is allocated at granularity.
+  uint64_t accumulated_size = 0;
+  size_t count_to_wait = 0;
+  uint64_t rounded_size = RoundUpToGranularity(size);
+
+  // Target 1.1x the requested size to provide some headroom.
+  uint64_t target_size = rounded_size + rounded_size / 10;
+
+  for (const auto& pending : pending_deallocations_) {
+    accumulated_size += RoundUpToGranularity(pending.mem.size());
+    ++count_to_wait;
+    if (accumulated_size >= target_size) {
+      break;
+    }
+  }
+
+  if (count_to_wait == 0) {
+    return;
+  }
+
+  tsl::profiler::ScopedAnnotation annotation([&] {
+    return absl::StrFormat(
+        "WaitPendingDeallocations:#count=%zu,target_size=%s#", count_to_wait,
+        tsl::strings::HumanReadableNumBytes(target_size));
+  });
+
+  // Wait only for the last event from the selected deallocations. Since events
+  // are recorded in order on the stream, waiting for the last event guarantees
+  // all previous events have also completed.
+  auto& last_selected = pending_deallocations_[count_to_wait - 1];
+
+  if (last_selected.event) {
+    auto status = last_selected.event->Synchronize();
+    if (!status.ok()) {
+      LOG(WARNING) << "Failed to synchronize event during "
+                      "WaitPendingDeallocationsToComplete: "
+                   << status;
+    }
+  }
+
+  // Now process and deallocate all selected pending deallocations.
+  for (size_t i = 0; i < count_to_wait && !pending_deallocations_.empty();
+       ++i) {
+    auto& front = pending_deallocations_.front();
+    DoDeallocate(front.device_ordinal, front.mem);
+    pending_deallocations_.pop_front();
+  }
+}
+
+void DeviceAddressVmmAllocator::DoDeallocate(int device_ordinal,
+                                             DeviceAddressBase mem) {
+  auto executor_or = GetStreamExecutor(device_ordinal);
+  if (!executor_or.ok()) {
+    LOG(WARNING) << "Failed to get executor for deallocation: "
+                 << executor_or.status();
+    return;
+  }
+  StreamExecutor* executor = executor_or.value();
+
+  VLOG(3) << absl::StreamFormat(
+      "Actually freeing virtual address %p (size=%uB) on device ordinal %d",
+      mem.opaque(), mem.size(), device_ordinal);
+
+  executor->Deallocate(&mem);
+  allocator_info_[device_ordinal].pa_allocated -=
+      RoundUpToGranularity(mem.size());
+}
+
+absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
+    int device_ordinal, StreamExecutor* executor, uint64_t size) {
+  if (size == 0) {
+    return DeviceAddressBase(nullptr, 0);
+  }
+  uint64_t rounded_size = RoundUpToGranularity(size);
+  uint64_t pa_allocated = allocator_info_[device_ordinal].pa_allocated;
+  if (pa_allocated + rounded_size > allocator_pa_budget_[device_ordinal]) {
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Not enough PA budget for allocation: pa_allocated=%uB, "
+        "rounded_size=%uB, pa_budget=%uB",
+        pa_allocated, rounded_size, allocator_pa_budget_[device_ordinal]));
+  }
+
+  allocator_info_[device_ordinal].pa_allocated += rounded_size;
+  return executor->VmmAllocateMemory(size);
+}
+
+absl::StatusOr<ScopedDeviceAddress<uint8_t>>
+DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
+                                    bool retry_on_failure,
+                                    int64_t memory_space) {
+  // Handle zero-size allocation.
+  if (size == 0) {
+    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
+                                        this);
+  }
+
+  TF_ASSIGN_OR_RETURN(StreamExecutor * executor,
+                      GetStreamExecutor(device_ordinal));
+
+  // Calculate rounded size for reuse matching.
+  uint64_t rounded_size = RoundUpToGranularity(size);
+
+  // Try to reuse a completed pending deallocation with matching size.
+  std::optional<DeviceAddressBase> reused =
+      TryReusePendingDeallocation(device_ordinal, size, rounded_size);
+  if (reused.has_value()) {
+    return ScopedDeviceAddress<uint8_t>(*reused, device_ordinal, this);
+  }
+
+  // Use AllocateWithBudget which handles the full flow: reserve virtual
+  // address, allocate physical memory, map, and set access permissions.
+  absl::StatusOr<DeviceAddressBase> result =
+      AllocateWithBudget(device_ordinal, executor, size);
+
+  // If allocation failed (e.g., out of memory), try processing pending
+  // deallocations to free memory, then retry.
+  if (!result.ok()) {
+    ProcessCompletedPendingDeallocations();
+    // Retry allocation after freeing memory.
+    result = AllocateWithBudget(device_ordinal, executor, size);
+  }
+
+  if (!result.ok()) {
+    WaitPendingDeallocationsToComplete(size);
+    // Retry allocation after freeing memory.
+    result = AllocateWithBudget(device_ordinal, executor, size);
+  }
+
+  if (!result.ok()) {
+    return result.status();
+  }
+
+  VLOG(3) << absl::StreamFormat(
+      "Allocated virtual address %s (%uB) on device ordinal %d: %p",
+      tsl::strings::HumanReadableNumBytes(size), size, device_ordinal,
+      result->opaque());
+
+  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
+}
+
+absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
+                                                   DeviceAddressBase mem) {
+  if (mem.is_null()) {
+    return absl::OkStatus();
+  }
+
+  TF_ASSIGN_OR_RETURN(StreamExecutor * executor,
+                      GetStreamExecutor(device_ordinal));
+
+  VLOG(3) << absl::StreamFormat(
+      "Queueing deferred deallocation for virtual address %p (size=%uB) "
+      "on device ordinal %d",
+      mem.opaque(), mem.size(), device_ordinal);
+
+  // Create an event and record it on the stream.
+  TF_ASSIGN_OR_RETURN(auto event, executor->CreateEvent());
+
+  // Get or create the stream for this device.
+  TF_ASSIGN_OR_RETURN(Stream * stream, GetStream(device_ordinal));
+
+  // Record the event on the stream - deallocation will happen after all
+  // currently enqueued work completes.
+  TF_RETURN_IF_ERROR(stream->RecordEvent(event.get()));
+
+  // Add this deallocation to the pending queue. Completed deallocations will
+  // be processed (freed or reused) during the next Allocate() call.
+  pending_deallocations_.push_back(
+      PendingDeallocation{device_ordinal, mem, std::move(event)});
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
+    int device_ordinal) const {
+  if (device_ordinal < 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "device ordinal value (%d) must be non-negative", device_ordinal));
+  }
+  for (StreamExecutor* se : stream_executors_) {
+    if (se->device_ordinal() == device_ordinal) {
+      return se;
+    }
+  }
+  return absl::NotFoundError(
+      absl::StrFormat("Device %s:%d present but not supported",
+                      platform()->Name(), device_ordinal));
+}
+
+absl::StatusOr<Stream*> DeviceAddressVmmAllocator::GetStream(
+    int device_ordinal) {
+  auto it = streams_.find(device_ordinal);
+  if (it == streams_.end()) {
+    return absl::NotFoundError(
+        absl::StrFormat("No stream registered for device ordinal %d. "
+                        "DeviceAddressVmmAllocator requires streams to be "
+                        "provided at construction time.",
+                        device_ordinal));
+  }
+  return it->second;
+}
+
+uint64_t DeviceAddressVmmAllocator::RoundUpToGranularity(uint64_t size) const {
+  if (allocation_granularity_ == 0) {
+    return size;
+  }
+  return ((size + allocation_granularity_ - 1) / allocation_granularity_) *
+         allocation_granularity_;
+}
+
+std::optional<DeviceAddressBase>
+DeviceAddressVmmAllocator::TryReusePendingDeallocation(int device_ordinal,
+                                                       uint64_t size,
+                                                       uint64_t rounded_size) {
+  // Search for a pending deallocation with matching rounded size on the same
+  // device whose event has already completed.
+  for (auto it = pending_deallocations_.begin();
+       it != pending_deallocations_.end(); ++it) {
+    if (it->device_ordinal != device_ordinal) {
+      continue;
+    }
+
+    // Check if the rounded size matches.
+    uint64_t pending_rounded_size = RoundUpToGranularity(it->mem.size());
+    if (pending_rounded_size != rounded_size) {
+      continue;
+    }
+
+    // We don't need to check if the event has completed and ordering is
+    // guaranteed by the stream.
+    uint64_t original_size = it->mem.size();
+    // Create the reused address with the new requested size but same underlying
+    // memory (which has the rounded size).
+    DeviceAddressBase reused_mem(it->mem.opaque(), size);
+    pending_deallocations_.erase(it);
+
+    VLOG(3) << absl::StreamFormat(
+        "Reusing pending deallocation: address=%p original_size=%uB "
+        "new_size=%uB rounded_size=%uB device=%d",
+        reused_mem.opaque(), original_size, size, rounded_size, device_ordinal);
+
+    return reused_mem;
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace stream_executor

--- a/xla/stream_executor/stream_executor_vmm_allocator.h
+++ b/xla/stream_executor/stream_executor_vmm_allocator.h
@@ -1,0 +1,174 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_STREAM_EXECUTOR_VMM_ALLOCATOR_H_
+#define XLA_STREAM_EXECUTOR_STREAM_EXECUTOR_VMM_ALLOCATOR_H_
+
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/device_address_allocator.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor {
+
+// Virtual address allocator that separates virtual address reservation from
+// physical memory allocation. This allocator:
+// 1. Reserves virtual address space using StreamExecutor::ReserveAddress
+// 2. Allocates unmapped physical memory using StreamExecutor::AllocateRaw
+// 3. Maps physical memory to virtual address using
+// StreamExecutor::MapRawAddress
+//
+// The returned DeviceAddress will have the raw_handle set to the underlying
+// physical memory handle.
+//
+// This allocator supports asynchronous deallocation: when Deallocate() is
+// called, it records an event on the stream and defers the actual deallocation
+// until the event completes. This allows callers to deallocate memory while
+// device kernels may still be consuming the data.
+//
+// IMPORTANT: This allocator only supports single-device instantiation and is
+// NOT thread-safe. All operations must be performed from a single thread.
+class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
+ public:
+  // Information needed per device for the allocator.
+  struct DeviceInfo {
+    StreamExecutor* executor;
+    Stream* stream;  // The stream to use for this device. Must outlive the
+                     // allocator.
+    uint64_t pa_budget;
+  };
+
+  // Create an allocator supporting a single device.
+  //
+  // Parameters:
+  //   executor: The stream executor to use for allocation operations.
+  //   stream: The stream to use for deferred deallocation. Must outlive the
+  //           allocator. This should typically be the main compute stream from
+  //           ServiceExecutableRunOptions.
+  //   pa_budget: The physical address budget for the allocator.
+  DeviceAddressVmmAllocator(StreamExecutor* executor, Stream* stream,
+                            uint64_t pa_budget);
+
+  // Create an allocator for a single device using DeviceInfo.
+  //
+  // Precondition: devices must contain exactly one element.
+  //
+  // Parameters:
+  //   platform: The platform for this allocator.
+  //   devices: List containing exactly one device info (executor + stream).
+  //            The stream must outlive the allocator and should typically be
+  //            the main compute stream from ServiceExecutableRunOptions.
+  //            CHECKs if devices.size() != 1.
+  DeviceAddressVmmAllocator(const Platform* platform,
+                            absl::Span<const DeviceInfo> devices);
+
+  ~DeviceAddressVmmAllocator() override;
+
+  absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
+      int device_ordinal, uint64_t size, bool retry_on_failure,
+      int64_t memory_space) override;
+
+  // Pull in two-arg overload that sets retry_on_failure to true.
+  using DeviceAddressAllocator::Allocate;
+
+  // Deallocates memory asynchronously. The caller can call this function even
+  // if device kernels are still consuming the data - the actual deallocation
+  // will be deferred until all previously enqueued work on the stream
+  // completes.
+  absl::Status Deallocate(int device_ordinal, DeviceAddressBase mem) override;
+
+  // Returns true - this allocator supports asynchronous deallocation.
+  bool AllowsAsynchronousDeallocation() const override { return true; }
+
+  // Returns the stream for the given device ordinal. This is the stream that
+  // was passed to the constructor and should be the main compute stream from
+  // ServiceExecutableRunOptions.
+  absl::StatusOr<Stream*> GetStream(int device_ordinal) override;
+
+  // Gets the stream executor for given device ordinal.
+  absl::StatusOr<StreamExecutor*> GetStreamExecutor(int device_ordinal) const;
+
+ private:
+  // Structure to track pending deallocations.
+  struct PendingDeallocation {
+    int device_ordinal;
+    DeviceAddressBase mem;
+    std::unique_ptr<Event> event;
+  };
+
+  struct AllocatorInfo {
+    uint64_t pa_allocated;
+  };
+
+  absl::StatusOr<DeviceAddressBase> AllocateWithBudget(int device_ordinal,
+                                                       StreamExecutor* executor,
+                                                       uint64_t size);
+
+  // Process any pending deallocations whose events have completed.
+  void ProcessCompletedPendingDeallocations();
+
+  // Wait for enough pending deallocations to complete to free at least 'size'
+  // bytes. Selects deallocations from the front of the queue until their
+  // cumulative size meets or exceeds the requested size, then synchronously
+  // waits for their events to complete and performs the deallocations.
+  void WaitPendingDeallocationsToComplete(uint64_t size);
+
+  // Actually perform the synchronous deallocation.
+  void DoDeallocate(int device_ordinal, DeviceAddressBase mem);
+
+  // Round up size to allocation granularity.
+  uint64_t RoundUpToGranularity(uint64_t size) const;
+
+  // Try to reuse a pending deallocation with matching rounded size.
+  // Returns the reused address if found, or std::nullopt if no match.
+  // Only reuses deallocations whose events have already completed
+  // (non-blocking).
+  std::optional<DeviceAddressBase> TryReusePendingDeallocation(
+      int device_ordinal, uint64_t size, uint64_t rounded_size);
+
+  // Available stream executors. Each stream executor has a different device
+  // ordinal.
+  std::vector<StreamExecutor*> stream_executors_;
+
+  // Streams for each device ordinal. These are not owned by this allocator;
+  // they must outlive the allocator.
+  std::map<int, Stream*> streams_;
+
+  // Allocation granularity for rounding sizes.
+  uint64_t allocation_granularity_ = 0;
+
+  absl::flat_hash_map<int, uint64_t> allocator_pa_budget_;
+
+  absl::flat_hash_map<int, AllocatorInfo> allocator_info_;
+
+  // Queue of pending deallocations waiting for their events to complete.
+  std::deque<PendingDeallocation> pending_deallocations_;
+};
+
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_STREAM_EXECUTOR_VMM_ALLOCATOR_H_

--- a/xla/stream_executor/stream_executor_vmm_allocator_test.cc
+++ b/xla/stream_executor/stream_executor_vmm_allocator_test.cc
@@ -1,0 +1,277 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/stream_executor_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace stream_executor {
+namespace {
+
+using ::absl_testing::IsOk;
+using ::absl_testing::IsOkAndHolds;
+using ::absl_testing::StatusIs;
+using ::testing::HasSubstr;
+using ::testing::Ne;
+
+class DeviceAddressVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("CUDA");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "CUDA platform not available";
+    }
+    platform_ = platform_or.value();
+
+    auto executor_or = platform_->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "CUDA executor not available";
+    }
+    executor_ = executor_or.value();
+
+    auto stream_or = executor_->CreateStream();
+    if (!stream_or.ok()) {
+      GTEST_SKIP() << "Failed to create stream";
+    }
+    stream_ = std::move(stream_or.value());
+  }
+
+  Platform* platform_ = nullptr;
+  StreamExecutor* executor_ = nullptr;
+  std::unique_ptr<Stream> stream_;
+};
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateAndDeallocate) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Allocate memory.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator.Allocate(executor_->device_ordinal(), 1024,
+                         /*retry_on_failure=*/true,
+                         static_cast<int64_t>(MemorySpace::kP2P)));
+
+  EXPECT_FALSE(scoped_address.is_null());
+  EXPECT_EQ(scoped_address->size(), 1024);
+  EXPECT_TRUE(executor_->GetRawHandleForVmmAddress(*scoped_address).ok());
+
+  // The ScopedDeviceAddress will automatically deallocate when it goes out of
+  // scope.
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateZeroSize) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Allocate zero-size memory.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator.Allocate(executor_->device_ordinal(), 0,
+                         /*retry_on_failure=*/true,
+                         static_cast<int64_t>(MemorySpace::kP2P)));
+
+  // Zero-size allocation should return a null address.
+  EXPECT_TRUE(scoped_address.is_null());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateMultiple) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Allocate multiple memory regions.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1,
+      allocator.Allocate(executor_->device_ordinal(), 1024,
+                         /*retry_on_failure=*/true,
+                         static_cast<int64_t>(MemorySpace::kP2P)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2,
+      allocator.Allocate(executor_->device_ordinal(), 2048,
+                         /*retry_on_failure=*/true,
+                         static_cast<int64_t>(MemorySpace::kP2P)));
+
+  // Both allocations should be valid and distinct.
+  EXPECT_FALSE(addr1.is_null());
+  EXPECT_FALSE(addr2.is_null());
+  EXPECT_NE(addr1->opaque(), addr2->opaque());
+  EXPECT_EQ(addr1.cref().size(), 1024);
+  EXPECT_EQ(addr2.cref().size(), 2048);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, MemoryReadWrite) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Allocate memory.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator.Allocate(executor_->device_ordinal(), 1024,
+                         /*retry_on_failure=*/true,
+                         static_cast<int64_t>(MemorySpace::kP2P)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+
+  // Create a stream for memory operations.
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+
+  // Write data to the allocated memory.
+  constexpr uint64_t kTestValue = 0xDEADBEEFCAFEBABE;
+  DeviceAddressBase addr = scoped_address.cref();
+  EXPECT_THAT(stream->Memcpy(&addr, &kTestValue, sizeof(kTestValue)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  // Read data back.
+  uint64_t read_value = 0;
+  EXPECT_THAT(stream->Memcpy(&read_value, addr, sizeof(read_value)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  EXPECT_EQ(read_value, kTestValue);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStream) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Get the stream - should return the same stream that was provided at
+  // construction.
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream,
+                          allocator.GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream_.get());
+
+  // Getting the stream again should return the same pointer.
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream2,
+                          allocator.GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStreamInvalidOrdinal) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Non-existent device ordinal should fail.
+  EXPECT_THAT(allocator.GetStream(9999),
+              StatusIs(absl::StatusCode::kNotFound,
+                       HasSubstr("No stream registered")));
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStreamExecutor) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamExecutor * retrieved_executor,
+      allocator.GetStreamExecutor(executor_->device_ordinal()));
+  EXPECT_EQ(retrieved_executor, executor_);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStreamExecutorInvalidOrdinal) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Negative device ordinal should fail.
+  EXPECT_THAT(allocator.GetStreamExecutor(-1),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("non-negative")));
+
+  // Non-existent device ordinal should fail.
+  EXPECT_THAT(allocator.GetStreamExecutor(9999),
+              StatusIs(absl::StatusCode::kNotFound));
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllowsAsynchronousDeallocation) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Virtual address allocator supports asynchronous deallocation via deferred
+  // event-based processing.
+  EXPECT_TRUE(allocator.AllowsAsynchronousDeallocation());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, MultipleExecutors) {
+  // Get all available executors and create streams for each.
+  std::vector<DeviceAddressVmmAllocator::DeviceInfo> device_infos;
+  std::vector<std::unique_ptr<Stream>> streams;
+  int device_count = platform_->VisibleDeviceCount();
+  for (int i = 0; i < device_count; ++i) {
+    auto executor_or = platform_->ExecutorForDevice(i);
+    if (executor_or.ok()) {
+      StreamExecutor* executor = executor_or.value();
+      auto stream_or = executor->CreateStream();
+      if (stream_or.ok()) {
+        streams.push_back(std::move(stream_or.value()));
+        device_infos.push_back({executor, streams.back().get()});
+      }
+    }
+  }
+
+  if (device_infos.size() < 2) {
+    GTEST_SKIP() << "Need at least 2 GPUs for multi-executor test";
+  }
+
+  // Create allocator with multiple devices.
+  DeviceAddressVmmAllocator allocator(platform_, device_infos);
+
+  // Allocate on each device.
+  for (const auto& device_info : device_infos) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto scoped_address,
+        allocator.Allocate(device_info.executor->device_ordinal(), 1024,
+                           /*retry_on_failure=*/true,
+                           static_cast<int64_t>(MemorySpace::kP2P)));
+
+    EXPECT_NE(scoped_address->opaque(), nullptr);
+    EXPECT_EQ(scoped_address.cref().size(), 1024);
+  }
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, ExplicitDeallocate) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Allocate memory.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator.Allocate(executor_->device_ordinal(), 1024,
+                         /*retry_on_failure=*/true,
+                         static_cast<int64_t>(MemorySpace::kP2P)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+  DeviceAddressBase addr = scoped_address.cref();
+
+  // Explicitly deallocate.
+  EXPECT_THAT(allocator.Deallocate(executor_->device_ordinal(), addr),
+              absl_testing::IsOk());
+
+  // Release ownership to prevent double-free.
+  scoped_address.Release();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
+  DeviceAddressVmmAllocator allocator(executor_, stream_.get());
+
+  // Deallocating null address should succeed.
+  DeviceAddressBase null_addr;
+  EXPECT_THAT(allocator.Deallocate(executor_->device_ordinal(), null_addr),
+              absl_testing::IsOk());
+}
+
+}  // namespace
+}  // namespace stream_executor


### PR DESCRIPTION
Extract stream_executor_vmm_allocator.h/cc and its test from the update_free_cmd_buffer branch, along with the VMM virtual methods added to StreamExecutor (ReserveAddress, FreeAddress, MapRawAddress, VmmAllocateMemory, VmmDeallocateMemory, etc.) and the corresponding BUILD targets.

📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
