### PR TITLE
[Autotuner] Provide a better error message when no configs are found

### DIFF
--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -618,15 +618,23 @@ absl::StatusOr<Autotuner::ConfigResult> Autotuner::PickBestConfig(
     std::vector<ConfigResult>& results) {
   absl::Duration min_duration = absl::InfiniteDuration();
   ConfigResult* best_result = nullptr;
+  std::vector<std::string> failures;
   for (ConfigResult& result : results) {
-    if (!result.failure.has_value() && result.duration < min_duration) {
+    if (result.failure.has_value()) {
+      failures.push_back(result.failure->ToString());
+    } else if (result.duration < min_duration) {
       min_duration = result.duration;
       best_result = &result;
     }
   }
 
   if (best_result == nullptr) {
-    return absl::NotFoundError("No valid config found!");
+    std::string message = "No valid config found!";
+    if (!failures.empty()) {
+      absl::StrAppend(&message, " Failures: ", failures.size(), "\n",
+                      absl::StrJoin(failures, "\n"));
+    }
+    return absl::NotFoundError(message);
   }
 
   if (autotune_config_.optimize_scratch_bytes) {


### PR DESCRIPTION
📝 Summary of Changes
Improves error logging (do not discard error messages).

🎯 Justification
Currently, if the autotuner fails due to OOM (for example), it's not easy to see that from the error logs.
This PR adds autotuner error messages to the logs.