### PR TITLE
[GPU] Implement Programmatic Dependent Launch (PDL).

### DIFF
--- a/xla/backends/gpu/codegen/emitters/emitter_base.cc
+++ b/xla/backends/gpu/codegen/emitters/emitter_base.cc
@@ -133,6 +133,14 @@ using mlir::Value;
 using mlir::ValueRange;
 using mlir::func::FuncOp;
 
+bool EnablePDL(const HloModule& module, const se::DeviceDescription& device) {
+  return module.config().debug_options().xla_gpu_enable_pdl() &&
+         device.gpu_compute_capability().IsCuda() &&
+         device.gpu_compute_capability()
+             .cuda_compute_capability()
+             ->IsAtLeastHopper();
+}
+
 void AddRanges(llvm::Function* func, const LaunchDimensions& launch_dims,
                llvm::Module* module) {
   for (auto& block : *func) {
@@ -340,9 +348,12 @@ absl::StatusOr<FusionEmissionResult> EmitterBase::Emit(
               VLOG(3) << "Skipped kernel compilation.";
             }
 
-            return KernelReuseCache::Entry{kernel_name, launch_dims,
-                                           std::nullopt,
-                                           /*shmem_bytes=*/0};
+            KernelReuseCache::Entry entry{kernel_name, launch_dims,
+                                          std::nullopt,
+                                          /*shmem_bytes=*/0};
+            entry.use_pdl = EnablePDL(*fusion.GetModule(),
+                                      ir_emitter_context.gpu_device_info());
+            return entry;
           });
   TF_ASSIGN_OR_RETURN(const KernelReuseCache::Entry* entry, status_or_entry);
 
@@ -357,7 +368,8 @@ absl::StatusOr<FusionEmissionResult> EmitterBase::Emit(
           &fusion, ir_emitter_context.GetNextThunkId()),
       entry->kernel_name, args, launch_dims, entry->cluster_dim,
       entry->shmem_bytes,
-      /*tma_metadata=*/se::gpu::TmaMetadata()));
+      /*tma_metadata=*/se::gpu::TmaMetadata(),
+      /*zeroed_output_buffer_indices=*/std::vector<int64_t>{}, entry->use_pdl));
   return result;
 }
 
@@ -373,6 +385,9 @@ absl::StatusOr<std::unique_ptr<llvm::Module>> EmitterBase::CreateLLVMModule(
   mlir::PassManager pm(&mlir_context);
   emitters::RegisterOptimizationPasses(pm);
   AddLoopTransformationPasses(pm, device, unroll_factor());
+  if (EnablePDL(*fusion.GetModule(), device)) {
+    pm.addPass(CreateInsertPDLPass());
+  }
   AddLoweringPasses(pm, device);
 
   TF_RETURN_IF_ERROR(RunPassPipeline(module.get(), *fusion.GetModule(), pm,
@@ -515,6 +530,7 @@ void AddLoweringPasses(mlir::OpPassManager& pm,
                        const se::DeviceDescription& device) {
   pm.addNestedPass<FuncOp>(emitters::CreateConvertPureCallOpsPass());
   pm.addPass(emitters::CreateLowerTensorsPass(device));
+  pm.addPass(emitters::CreateLowerPdlWaitPass());
   pm.addPass(mlir::createConvertComplexToStandardPass());
   pm.addPass(emitters::CreateMergePointersToSameSlicePass());
 

--- a/xla/backends/gpu/codegen/emitters/ir/xla_gpu_ops.td
+++ b/xla/backends/gpu/codegen/emitters/ir/xla_gpu_ops.td
@@ -195,4 +195,8 @@ def XLAGPU_ReduceOp : XLAGPU_Op<"reduce", [
   let hasVerifier = 1;
 }
 
+def PdlWaitOp : XLAGPU_Op<"pdl_wait", []> {
+  let summary = "Waits for upstream dependencies.";
+}
+
 #endif // XLA_SERVICE_GPU_FUSIONS_MLIR_OPS

--- a/xla/backends/gpu/codegen/emitters/transforms/BUILD
+++ b/xla/backends/gpu/codegen/emitters/transforms/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "convert_float_amd.cc",
         "convert_float_nvidia.cc",
         "convert_index_type.cc",
+        "insert_pdl_ops.cc",
         "lower_xla_shared.cc",
         "optimize_loops.cc",
         "peel_loops.cc",
@@ -41,6 +42,7 @@ cc_library(
     deps = [
         ":passes_inc_gen",
         "//xla/backends/gpu/codegen/emitters/ir:xla_gpu",
+        "//xla/backends/gpu/codegen/triton/ir:triton_xla",
         "//xla/codegen/emitters/ir:xla",
         "//xla/hlo/analysis:indexing_analysis",
         "//xla/service/gpu:gpu_fusible",
@@ -68,5 +70,6 @@ cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:VectorDialect",
+        "@triton//:TritonDialects",
     ],
 )

--- a/xla/backends/gpu/codegen/emitters/transforms/insert_pdl_ops.cc
+++ b/xla/backends/gpu/codegen/emitters/transforms/insert_pdl_ops.cc
@@ -1,0 +1,75 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "xla/backends/gpu/codegen/emitters/ir/xla_gpu_ops.h"
+#include "xla/backends/gpu/codegen/emitters/transforms/passes.h"
+#include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
+#include "xla/codegen/emitters/ir/xla_ops.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+#define GEN_PASS_DEF_INSERTPDLPASS
+#include "xla/backends/gpu/codegen/emitters/transforms/passes.h.inc"
+
+class InsertPDLPass : public impl::InsertPDLPassBase<InsertPDLPass> {
+ public:
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+
+    module.walk([&](mlir::FunctionOpInterface func) {
+      if (func.getFunctionBody().empty()) {
+        return;
+      }
+      if (auto func_op =
+              mlir::dyn_cast<mlir::func::FuncOp>(func.getOperation());
+          func_op && func_op.isPrivate()) {
+        return;
+      }
+
+      mlir::Block& entry_block = func.getFunctionBody().front();
+      mlir::OpBuilder::atBlockBegin(&entry_block)
+          .create<xla::gpu::PdlWaitOp>(func.getLoc());
+    });
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<mlir::Pass> CreateInsertPDLPass() {
+  return std::make_unique<InsertPDLPass>();
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.h
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.h
@@ -44,6 +44,7 @@ std::unique_ptr<mlir::Pass> CreateConvertIndexTypePass();
 std::unique_ptr<mlir::Pass> CreateOptimizeLoopsPass(int max_unroll_factor = 0);
 std::unique_ptr<mlir::Pass> CreatePeelLoopsPass();
 std::unique_ptr<mlir::Pass> CreateLowerXlaSharedPass();
+std::unique_ptr<mlir::Pass> CreateInsertPDLPass();
 std::unique_ptr<mlir::Pass> CreateRecoverExp2Pass();
 
 #define GEN_PASS_REGISTRATION

--- a/xla/backends/gpu/codegen/emitters/transforms/passes.td
+++ b/xla/backends/gpu/codegen/emitters/transforms/passes.td
@@ -132,4 +132,18 @@ def LowerXlaSharedPass :
   let constructor = "CreateLowerXlaSharedPass()";
 }
 
+def InsertPDLPass : Pass<"xla-gpu-insert-pdl", "mlir::ModuleOp"> {
+  let summary = "Inserts programmatic dependent launch (PDL) ops.";
+  let description = [{
+    Inserts `xla_gpu.pdl_wait` op to guard global memory operations.
+  }];
+  let dependentDialects = [
+    "xla::gpu::XlaGpuDialect",
+    "mlir::func::FuncDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::cf::ControlFlowDialect",
+  ];
+  let constructor = "CreateInsertPDLPass()";
+}
+
 #endif  // XLA_SERVICE_GPU_FUSIONS_TRANSFORMS_PASSES_TD_

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline.cc
@@ -32,7 +32,8 @@ namespace xla::gpu {
 void CreateTritonXlaPipeline(
     mlir::OpPassManager* pm,
     const stream_executor::GpuComputeCapability& gpu_cc, bool rewrite_int4,
-    bool allow_tma, int num_stages, bool warp_specialization_allowed) {
+    bool allow_tma, int num_stages, bool warp_specialization_allowed,
+    bool enable_pdl) {
   pm->addPass(mlir::triton::xla::CreateTritonXLASqueezeDimsPass());
   pm->addPass(mlir::triton::xla::CreateTritonXLAFoldTransposePass());
   pm->addPass(mlir::triton::xla::CreateTritonXLALowerBlockBarrierPass());
@@ -53,8 +54,14 @@ void CreateTritonXlaPipeline(
         /*enable_bf16x2=*/is_at_least_hopper));
   }
 
+  if (enable_pdl) {
+    pm->addPass(CreateInsertPDLPass());
+  }
   pm->addPass(mlir::triton::xla::CreateTritonXLAExtractInsertToTritonPass(
       /*allow_tma=*/allow_tma && is_at_least_hopper, num_stages));
+  if (enable_pdl) {
+    pm->addPass(emitters::CreateLowerPdlWaitPass());
+  }
 
   // Lower affine expressions into arithmetic ops.
   pm->addPass(mlir::createLowerAffinePass());

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline.h
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline.h
@@ -25,7 +25,8 @@ namespace xla::gpu {
 void CreateTritonXlaPipeline(
     mlir::OpPassManager* pm,
     const stream_executor::GpuComputeCapability& gpu_cc, bool rewrite_int4,
-    bool allow_tma, int num_stages, bool warp_specialization_allowed);
+    bool allow_tma, int num_stages, bool warp_specialization_allowed,
+    bool enable_pdl);
 
 // Creates a Triton compilation pipeline.
 void CreateTritonPipeline(mlir::OpPassManager* pm,

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_test.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_test.cc
@@ -37,7 +37,8 @@ TEST(CompilationPipelineTest, ContainsUnswitchLoopsCompositePass) {
   CreateTritonXlaPipeline(&pm, stream_executor::CudaComputeCapability(),
                           /*rewrite_int4=*/false, /*allow_tma=*/true,
                           /*num_stages=*/1,
-                          /*warp_specialization_allowed=*/true);
+                          /*warp_specialization_allowed=*/true,
+                          /*enable_pdl=*/false);
 
   std::vector<std::string> pass_names;
   for (const mlir::Pass& pass : pm.getPasses()) {

--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -204,7 +204,8 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
 
     return {{kernel->getName().str(), launch_dimensions,
              /*cluster_dim=*/std::nullopt, triton_wrapper_result.shmem_bytes,
-             /*binary=*/"", triton_wrapper_result.tma_metadata}};
+             /*binary=*/"", triton_wrapper_result.tma_metadata, /*use_pdl=*/
+             triton_wrapper_result.use_pdl}};
   };
 
   auto [status_or_entry, was_cached] =
@@ -217,8 +218,9 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
           Thunk::ThunkInfo::WithProfileAnnotation(
               &fusion, ir_emitter_context.GetNextThunkId()),
           entry->kernel_name, kernel_arguments, entry->launch_dimensions,
-          /*cluster_dim=*/std::nullopt, entry->shmem_bytes,
-          entry->tma_metadata),
+          /*cluster_dim=*/std::nullopt, entry->shmem_bytes, entry->tma_metadata,
+          /*zeroed_output_buffer_indices=*/std::vector<int64_t>{},
+          entry->use_pdl),
       was_cached ? nullptr : std::move(local_module)};
 }
 

--- a/xla/backends/gpu/codegen/triton/transforms/tests/pdl.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/pdl.mlir
@@ -1,0 +1,44 @@
+// RUN: xla-opt %s -split-input-file -xla-gpu-insert-pdl \
+// RUN:   | FileCheck %s --check-prefix=INSERT
+// RUN: xla-opt %s -split-input-file -xla-gpu-insert-pdl \
+// RUN:   -triton-xla-extract-insert-to-triton \
+// RUN:   -xla-lower-pdl-wait \
+// RUN:   | FileCheck %s --check-prefix=LOWER
+// RUN: xla-opt %s -split-input-file -xla-gpu-insert-pdl \
+// RUN:   -triton-xla-extract-insert-to-triton="allow_tma=1 num_stages=3" \
+// RUN:   -xla-lower-pdl-wait \
+// RUN:   | FileCheck %s --check-prefix=LOWER-TMA
+
+func.func @basic(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>) {
+  %extracted_tensor = triton_xla.extract from %arg0
+      as memref<128xbf16, #xtile.layout<[0]>>
+      [0] [16] [1] : tensor<16xbf16>
+  triton_xla.insert %extracted_tensor into %arg1
+      as memref<256xbf16, #xtile.layout<[0]>>
+      [0] [16] [1] : tensor<16xbf16>
+  func.return
+}
+
+// INSERT-LABEL:  func.func @basic(
+// INSERT:        xla_gpu.pdl_wait
+// INSERT:        %[[EXTRACTED:.*]] = triton_xla.extract from %arg0
+// INSERT:        triton_xla.insert %[[EXTRACTED]] into %arg1
+// INSERT:        return
+
+// LOWER-LABEL:   tt.func @basic(
+// LOWER:         nvvm.griddepcontrol wait
+// LOWER-NOT:     nvvm.griddepcontrol wait
+// LOWER:         tt.load
+// LOWER:         tt.store
+// LOWER:         tt.return
+
+// LOWER-TMA-LABEL:   tt.func @basic(
+// LOWER-TMA-SAME:    %arg0: !tt.tensordesc<tensor<16xbf16>>
+// LOWER-TMA-SAME:    %arg1: !tt.tensordesc<tensor<16xbf16>>
+// LOWER-TMA:         nvvm.griddepcontrol wait
+// LOWER-TMA-NOT:     nvvm.griddepcontrol wait
+// LOWER-TMA:         %[[LOAD:.*]] = tt.descriptor_load %arg0
+// LOWER-TMA:         tt.descriptor_store %arg1[{{.*}}], %[[LOAD]]
+// LOWER-TMA-NOT:     tt.load
+// LOWER-TMA-NOT:     tt.store
+// LOWER-TMA:         tt.return

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -436,11 +436,6 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
   EnableIRPrintingIfRequested(pm, &mlir_context, hlo_module, kernel_name,
                               "triton-to-llvm");
   pm.enableVerifier(should_verify);
-  CreateTritonXlaPipeline(
-      &pm, gpu_cc, /*rewrite_int4=*/is_xla_fusion,
-      block_level_parameters.is_tma_allowed, block_level_parameters.num_stages,
-      block_level_parameters.is_warp_specialization_allowed);
-
   int num_warps = block_level_parameters.num_warps;
   int num_ctas = block_level_parameters.num_ctas;
   int num_stages = block_level_parameters.num_stages;
@@ -449,6 +444,13 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
         "(num_warps, num_ctas, num_stages) must be positive, but got: (",
         num_warps, ", ", num_ctas, ", ", num_stages, ")"));
   }
+  const bool enable_pdl = hlo_config.debug_options().xla_gpu_enable_pdl() &&
+                          gpu_cc.IsCuda() &&
+                          gpu_cc.cuda_compute_capability()->IsAtLeastHopper();
+  CreateTritonXlaPipeline(&pm, gpu_cc, /*rewrite_int4=*/is_xla_fusion,
+                          block_level_parameters.is_tma_allowed, num_stages,
+                          block_level_parameters.is_warp_specialization_allowed,
+                          enable_pdl);
 
   CreateTritonPipeline(&pm, gpu_cc, num_warps, num_ctas, num_stages);
 
@@ -556,6 +558,7 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
                                 global_scratch_memory_size,
                                 tma_metadata,
                                 thread_dims,
+                                enable_pdl,
                                 captured_nvvm_annotations,
                                 std::move(ll_triton_module)};
   return result;

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.h
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.h
@@ -55,6 +55,7 @@ struct TritonWrapperResult {
   int64_t global_scratch_memory_size = 0;
   se::gpu::TmaMetadata tma_metadata;
   se::ThreadDim thread_dims;
+  bool use_pdl = false;
 
   // The captured nvvm.annotations from the lowest level LLVM IR coming from
   // Triton. We need to propagate them because we later create the kernel and

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -422,14 +422,15 @@ LaunchCmd::LaunchCmd(
     std::string kernel_name, absl::Span<const ShapedSlice> args,
     absl::Span<const BufferUse::MemoryAccess> args_access,
     LaunchDimensions dims, int64_t shmem_bytes,
-    std::optional<stream_executor::gpu::TmaMetadata> tma_metadata)
+    std::optional<stream_executor::gpu::TmaMetadata> tma_metadata, bool use_pdl)
     : Command(CommandType::kLaunchCmd),
       kernel_name_(std::move(kernel_name)),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
       dims_(dims),
       shmem_bytes_(shmem_bytes),
-      tma_metadata_(std::move(tma_metadata)) {}
+      tma_metadata_(std::move(tma_metadata)),
+      use_pdl_(use_pdl) {}
 
 absl::Status LaunchCmd::Initialize(const Thunk::InitializeParams& params) {
   {
@@ -443,12 +444,12 @@ absl::Status LaunchCmd::Initialize(const Thunk::InitializeParams& params) {
   if (!params.src.binary.empty()) {
     TF_ASSIGN_OR_RETURN(
         kernel, CreateKernel(kernel_name_, args_.size(), params.src.binary,
-                             params.executor, shmem_bytes_));
+                             params.executor, shmem_bytes_, use_pdl_));
 
   } else {
     TF_ASSIGN_OR_RETURN(
         kernel, CreateKernel(kernel_name_, args_.size(), params.src.text,
-                             params.executor, shmem_bytes_));
+                             params.executor, shmem_bytes_, use_pdl_));
   }
 
   absl::MutexLock lock(mutex_);

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -190,6 +190,7 @@ class LaunchCmd : public Command {
   LaunchDimensions dims_;
   int64_t shmem_bytes_;
   std::optional<stream_executor::gpu::TmaMetadata> tma_metadata_;
+  // Programmatic Dependent Launch.
   bool use_pdl_;
 
   // Command sequence can be recorded concurrently for multiple command buffers

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -170,7 +170,8 @@ class LaunchCmd : public Command {
             absl::Span<const BufferUse::MemoryAccess> args_access,
             LaunchDimensions dims, int64_t shmem_bytes,
             std::optional<stream_executor::gpu::TmaMetadata> tma_metadata =
-                std::nullopt);
+                std::nullopt,
+            bool use_pdl = false);
 
   absl::Status Initialize(const Thunk::InitializeParams& params) override;
 
@@ -180,6 +181,7 @@ class LaunchCmd : public Command {
       se::CommandBuffer* command_buffer) override;
 
   BufferUses buffer_uses() const override;
+  bool use_pdl() const { return use_pdl_; }
 
  private:
   std::string kernel_name_;
@@ -188,6 +190,7 @@ class LaunchCmd : public Command {
   LaunchDimensions dims_;
   int64_t shmem_bytes_;
   std::optional<stream_executor::gpu::TmaMetadata> tma_metadata_;
+  bool use_pdl_;
 
   // Command sequence can be recorded concurrently for multiple command buffers
   // on different stream executors and we need to synchronize mutable state.

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -100,7 +100,8 @@ static absl::StatusOr<std::unique_ptr<Command>> Convert(
     const KernelThunk& thunk) {
   return std::make_unique<LaunchCmd>(
       thunk.kernel_name(), thunk.arguments(), ArgsAccess(thunk.written()),
-      thunk.launch_dimensions(), thunk.shmem_bytes(), thunk.tma_metadata());
+      thunk.launch_dimensions(), thunk.shmem_bytes(), thunk.tma_metadata(),
+      thunk.use_pdl());
 }
 
 static absl::StatusOr<std::unique_ptr<Command>> Convert(

--- a/xla/backends/gpu/runtime/kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/kernel_thunk.cc
@@ -66,7 +66,8 @@ KernelThunk::KernelThunk(Thunk::ThunkInfo thunk_info, std::string kernel_name,
                          std::optional<se::ClusterDim> cluster_dim,
                          int64_t shmem_bytes,
                          stream_executor::gpu::TmaMetadata tma_metadata,
-                         std::vector<int64_t> zeroed_output_buffer_indices)
+                         std::vector<int64_t> zeroed_output_buffer_indices,
+                         bool use_pdl)
     : Thunk(Kind::kKernel, std::move(thunk_info)),
       args_(kernel_arguments.GetArgumentShapedSlices()),
       written_(kernel_arguments.GetArgumentOutputFlags()),
@@ -75,7 +76,8 @@ KernelThunk::KernelThunk(Thunk::ThunkInfo thunk_info, std::string kernel_name,
       launch_dimensions_(std::move(launch_dimensions)),
       cluster_dim_(std::move(cluster_dim)),
       shmem_bytes_(shmem_bytes),
-      tma_metadata_(std::move(tma_metadata)) {}
+      tma_metadata_(std::move(tma_metadata)),
+      use_pdl_(use_pdl) {}
 
 std::string KernelThunk::ToString(int indent) const {
   return absl::StrFormat(
@@ -102,6 +104,7 @@ absl::StatusOr<ThunkProto> KernelThunk::ToProto() const {
     *kernel_proto->mutable_cluster_dim() = cluster_dim_->ToProto();
   }
   kernel_proto->set_shmem_bytes(shmem_bytes_);
+  kernel_proto->set_use_pdl(use_pdl_);
   *kernel_proto->mutable_tma_metadata() = tma_metadata_.ToProto();
   return proto;
 }
@@ -150,7 +153,7 @@ absl::StatusOr<std::unique_ptr<KernelThunk>> KernelThunk::FromProto(
       thunk_info, proto.kernel_name(),
       emitters::KernelArguments(std::move(arguments)), launch_dimensions,
       cluster_dim, proto.shmem_bytes(), tma_metadata,
-      std::move(zeroed_output_buffer_indices));
+      std::move(zeroed_output_buffer_indices), proto.use_pdl());
 }
 
 absl::Status KernelThunk::Initialize(const InitializeParams& params) {
@@ -166,12 +169,12 @@ absl::Status KernelThunk::Initialize(const InitializeParams& params) {
     if (!params.src.binary.empty()) {
       TF_ASSIGN_OR_RETURN(
           kernel, CreateKernel(kernel_name_, args_.size(), params.src.binary,
-                               params.executor, shmem_bytes_));
+                               params.executor, shmem_bytes_, use_pdl_));
 
     } else {
       TF_ASSIGN_OR_RETURN(
           kernel, CreateKernel(kernel_name_, args_.size(), params.src.text,
-                               params.executor, shmem_bytes_));
+                               params.executor, shmem_bytes_, use_pdl_));
     }
 
     kernel_cache_.emplace(params.executor, std::move(kernel));

--- a/xla/backends/gpu/runtime/kernel_thunk.h
+++ b/xla/backends/gpu/runtime/kernel_thunk.h
@@ -131,6 +131,7 @@ class KernelThunk : public Thunk {
   // kernel.
   stream_executor::gpu::TmaMetadata tma_metadata_;
 
+  // Programmatic Dependent Launch.
   bool use_pdl_;
 
   // Loaded kernels for each `StreamExecutor`.

--- a/xla/backends/gpu/runtime/kernel_thunk.h
+++ b/xla/backends/gpu/runtime/kernel_thunk.h
@@ -70,7 +70,8 @@ class KernelThunk : public Thunk {
               LaunchDimensions launch_dimensions,
               std::optional<se::ClusterDim> cluster_dim, int64_t shmem_bytes,
               stream_executor::gpu::TmaMetadata tma_metadata,
-              std::vector<int64_t> zeroed_output_buffer_indices = {});
+              std::vector<int64_t> zeroed_output_buffer_indices = {},
+              bool use_pdl = false);
   KernelThunk(const KernelThunk&) = delete;
   KernelThunk& operator=(const KernelThunk&) = delete;
   ~KernelThunk() override = default;
@@ -102,6 +103,8 @@ class KernelThunk : public Thunk {
     return tma_metadata_;
   }
 
+  bool use_pdl() const { return use_pdl_; }
+
   BufferUses buffer_uses() const override;
 
  private:
@@ -127,6 +130,8 @@ class KernelThunk : public Thunk {
   // Map of argument index to TmaDescriptor used to create arguments to the
   // kernel.
   stream_executor::gpu::TmaMetadata tma_metadata_;
+
+  bool use_pdl_;
 
   // Loaded kernels for each `StreamExecutor`.
   mutable absl::Mutex mutex_;

--- a/xla/backends/gpu/runtime/kernel_thunk_test.cc
+++ b/xla/backends/gpu/runtime/kernel_thunk_test.cc
@@ -25,9 +25,11 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "xla/backends/gpu/codegen/kernels/custom_kernel.h"
+#include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_buffer_cmd_emitter.h"
 #include "xla/backends/gpu/runtime/command_buffer_thunk.h"
 #include "xla/backends/gpu/runtime/command_executor.h"
@@ -175,7 +177,9 @@ TEST(KernelThunkTest, ToProto) {
                     /*launch_dimensions=*/launch_dimensions,
                     /*cluster_dim=*/se::ClusterDim(8, 7, 6),
                     /*shmem_bytes=*/1024,
-                    /*tma_metadata=*/tma_metadata);
+                    /*tma_metadata=*/tma_metadata,
+                    /*zeroed_output_buffer_indices=*/{},
+                    /*use_pdl=*/true);
   TF_ASSERT_OK_AND_ASSIGN(ThunkProto proto, thunk.ToProto());
   EXPECT_THAT(
       proto, EqualsProto(R"pb(
@@ -204,6 +208,7 @@ TEST(KernelThunkTest, ToProto) {
           }
           cluster_dim { coordinates { x: 8 y: 7 z: 6 } }
           shmem_bytes: 1024
+          use_pdl: true
           tma_metadata {
             arg_index_to_tma_info {
               key: 0
@@ -269,7 +274,8 @@ TEST(KernelThunkTest, ToAndFromProto) {
 
   KernelThunk thunk(thunk_info, std::string{kKernelName}, kernel_arguments,
                     launch_dimensions, cluster_dim, kSharedMemoryBytes,
-                    tma_metadata);
+                    tma_metadata, /*zeroed_output_buffer_indices=*/{},
+                    /*use_pdl=*/true);
   TF_ASSERT_OK_AND_ASSIGN(ThunkProto proto, thunk.ToProto());
   ASSERT_TRUE(proto.has_kernel_thunk());
   TF_ASSERT_OK_AND_ASSIGN(
@@ -286,6 +292,45 @@ TEST(KernelThunkTest, ToAndFromProto) {
               ::testing::ElementsAre(ShapedSlice{slice0, arg0.shape()},
                                      ShapedSlice{slice1, arg1.shape()}));
   EXPECT_THAT(reconstructed_thunk->tma_metadata(), tma_metadata);
+  EXPECT_TRUE(reconstructed_thunk->use_pdl());
+}
+
+TEST(KernelThunkTest, ConvertToCommandsPropagatesUsePdl) {
+  BufferAllocation allocation(/*index=*/0, /*size=*/1024, /*color=*/0);
+  BufferAllocation::Slice slice(&allocation, /*offset=*/0, /*size=*/1024);
+
+  emitters::KernelArgument arg(ShapeUtil::MakeShape(F32, {256}), slice);
+  arg.set_written(true);
+
+  auto kernel_thunk = std::make_unique<KernelThunk>(
+      Thunk::ThunkInfo(),
+      /*kernel_name=*/"kernel",
+      /*kernel_arguments=*/
+      emitters::KernelArguments(std::vector<emitters::KernelArgument>{arg}),
+      /*launch_dimensions=*/LaunchDimensions(),
+      /*cluster_dim=*/se::ClusterDim(),
+      /*shmem_bytes=*/0,
+      /*tma_metadata=*/se::gpu::TmaMetadata(),
+      /*zeroed_output_buffer_indices=*/std::vector<int64_t>{},
+      /*use_pdl=*/true);
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(kernel_thunk));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      CommandExecutor commands,
+      ConvertToCommands(thunks, ConvertToCommandsOptions()));
+
+  bool found_launch_cmd = false;
+  TF_ASSERT_OK(commands.Walk([&](const Command* command) {
+    if (auto* launch_cmd = dynamic_cast<const LaunchCmd*>(command);
+        launch_cmd != nullptr) {
+      found_launch_cmd = true;
+      EXPECT_TRUE(launch_cmd->use_pdl());
+    }
+    return absl::OkStatus();
+  }));
+  EXPECT_TRUE(found_launch_cmd);
 }
 
 TEST(KernelThunkTest, BufferUsesReturnsCorrectBuffers) {

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -81,6 +81,7 @@ message KernelThunkProto {
   int64 shmem_bytes = 6;
   optional stream_executor.gpu.TmaMetadataProto tma_metadata = 7;
   repeated int64 zeroed_output_buffer_indices = 9;
+  bool use_pdl = 10;
 }
 
 message GemmThunkProto {

--- a/xla/codegen/emitters/transforms/BUILD
+++ b/xla/codegen/emitters/transforms/BUILD
@@ -170,6 +170,7 @@ cc_library(
         "expand_integer_power.cc",
         "flatten_tensors.cc",
         "lower_tensors.cc",
+        "lower_pdl_ops.cc",
         "lower_xla_intrinsic_lib.cc",
         "lower_xla_to_scf.cc",
         "merge_pointers_to_same_slice.cc",

--- a/xla/codegen/emitters/transforms/lower_pdl_ops.cc
+++ b/xla/codegen/emitters/transforms/lower_pdl_ops.cc
@@ -1,0 +1,66 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+#include <vector>
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "xla/backends/gpu/codegen/emitters/ir/xla_gpu_ops.h"
+#include "xla/codegen/emitters/transforms/passes.h"
+
+namespace xla {
+namespace emitters {
+namespace {
+
+#define GEN_PASS_DEF_LOWERPDLWAITPASS
+#include "xla/codegen/emitters/transforms/passes.h.inc"
+
+struct LowerPdlWaitPattern
+    : public mlir::OpRewritePattern<xla::gpu::PdlWaitOp> {
+  using OpRewritePattern<xla::gpu::PdlWaitOp>::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      xla::gpu::PdlWaitOp op, mlir::PatternRewriter& rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::NVVM::GriddepcontrolOp>(
+        op, mlir::NVVM::GridDepActionKind::wait);
+    return mlir::success();
+  }
+};
+
+class LowerPdlWaitPass : public impl::LowerPdlWaitPassBase<LowerPdlWaitPass> {
+ public:
+  void runOnOperation() override {
+    mlir::RewritePatternSet patterns(&getContext());
+    patterns.add<LowerPdlWaitPattern>(&getContext());
+    if (mlir::failed(
+            mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<mlir::Pass> CreateLowerPdlWaitPass() {
+  return std::make_unique<LowerPdlWaitPass>();
+}
+
+}  // namespace emitters
+}  // namespace xla

--- a/xla/codegen/emitters/transforms/passes.h
+++ b/xla/codegen/emitters/transforms/passes.h
@@ -58,6 +58,7 @@ std::unique_ptr<mlir::Pass> CreateVectorizeLoadsAndStoresPass(
     const stream_executor::DeviceDescription& device_description);
 std::unique_ptr<mlir::Pass> CreateSafeIntegerArithmeticPass();
 std::unique_ptr<mlir::Pass> CreateExpandIntegerPowerPass();
+std::unique_ptr<mlir::Pass> CreateLowerPdlWaitPass();
 
 #define GEN_PASS_REGISTRATION
 #include "xla/codegen/emitters/transforms/passes.h.inc"

--- a/xla/codegen/emitters/transforms/passes.td
+++ b/xla/codegen/emitters/transforms/passes.td
@@ -333,4 +333,13 @@ def ExpandIntegerPowerPass : Pass<"xla-expand-integer-power"> {
   ];
 }
 
+def LowerPdlWaitPass : Pass<"xla-lower-pdl-wait", "mlir::ModuleOp"> {
+  let summary = "Lowers xla_gpu.pdl_wait to NVVM griddepcontrol.";
+  let dependentDialects = [
+    "xla::gpu::XlaGpuDialect",
+    "mlir::NVVM::NVVMDialect",
+  ];
+  let constructor = "CreateLowerPdlWaitPass()";
+}
+
 #endif  // XLA_CODEGEN_EMITTERS_TRANSFORMS_PASSES_TD_

--- a/xla/codegen/emitters/transforms/tests/pdl.mlir
+++ b/xla/codegen/emitters/transforms/tests/pdl.mlir
@@ -1,0 +1,77 @@
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-gpu-insert-pdl | FileCheck %s --check-prefix=INSERT
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-gpu-insert-pdl \
+// RUN: -xla-lower-tensors="gpu_device_info='cuda_compute_capability {major: 9}'" \
+// RUN: -xla-lower-pdl-wait \
+// RUN: | FileCheck %s --check-prefix=LOWER
+
+func.func @pdl_entry_store(%arg0: tensor<8xf32> {xla.slice_index = 0}) -> tensor<8xf32> attributes {xla.entry} {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 1.0 : f32
+  %out = tensor.insert %cst into %arg0[%c0] : tensor<8xf32>
+  func.return %out : tensor<8xf32>
+}
+
+// INSERT-LABEL: func.func @pdl_entry_store(
+// INSERT: xla_gpu.pdl_wait
+// INSERT: tensor.insert %cst into %arg0[%c0]
+// INSERT: return
+
+// LOWER-LABEL: func.func @pdl_entry_store(
+// LOWER: nvvm.griddepcontrol wait
+// LOWER-NOT: nvvm.griddepcontrol wait
+// LOWER: llvm.store
+// LOWER: return
+
+// -----
+
+func.func private @helper(%arg0: tensor<8xf32> {xla.slice_index = 0}, %arg1: index) -> f32 {
+  %v = tensor.extract %arg0[%arg1] : tensor<8xf32>
+  func.return %v : f32
+}
+
+func.func @entry_calls_helper(%arg0: tensor<8xf32> {xla.slice_index = 0}, %arg1: index) -> f32 attributes {xla.entry} {
+  %v0 = call @helper(%arg0, %arg1) : (tensor<8xf32>, index) -> f32
+  %v1 = tensor.extract %arg0[%arg1] : tensor<8xf32>
+  %sum = arith.addf %v0, %v1 : f32
+  func.return %sum : f32
+}
+
+// INSERT-LABEL: func.func private @helper(
+// INSERT-NOT: pdl
+// INSERT: tensor.extract
+// INSERT: return
+// INSERT-LABEL: func.func @entry_calls_helper(
+// INSERT: xla_gpu.pdl_wait
+// INSERT: call @helper
+// INSERT: tensor.extract
+// INSERT: return
+
+// LOWER-LABEL: func.func private @helper(
+// LOWER-NOT: griddepcontrol
+// LOWER: llvm.load
+// LOWER: return
+// LOWER-LABEL: func.func @entry_calls_helper(
+// LOWER: nvvm.griddepcontrol wait
+// LOWER-NOT: nvvm.griddepcontrol wait
+// LOWER: call @helper
+// LOWER: llvm.load
+// LOWER: return
+
+// -----
+
+func.func @mixed_memory_access(%arg0: tensor<4xf32> {xla.slice_index = 0}) -> (f32, f32) attributes {xla.entry} {
+  %c0 = arith.constant 0 : index
+  %t = arith.constant dense<1.0> : tensor<4xf32>
+  %v_local = tensor.extract %t[%c0] : tensor<4xf32>
+  %v_global = tensor.extract %arg0[%c0] : tensor<4xf32>
+  func.return %v_local, %v_global : f32, f32
+}
+
+// INSERT-LABEL: func.func @mixed_memory_access
+// INSERT: xla_gpu.pdl_wait
+// INSERT: arith.constant 0
+// INSERT: arith.constant dense
+// INSERT: tensor.extract
+// INSERT: tensor.extract

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -500,6 +500,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_rocm_max_trace_events(4 * 1024 * 1024);
 
   opts.set_xla_gpu_print_compilation_stats(false);
+
+  opts.set_xla_gpu_enable_pdl(false);
   return opts;
 }
 
@@ -2947,6 +2949,11 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_print_compilation_stats(),
       "Prints statistics about the HLO passes: how many times each pass was "
       "run, and how long it took."));
+  flag_list->push_back(
+      tsl::Flag("xla_gpu_enable_pdl",
+                bool_setter_for(&DebugOptions::set_xla_gpu_enable_pdl),
+                debug_options->xla_gpu_enable_pdl(),
+                "Enable PDL (Programmatic Dependent Launch)."));
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/service/gpu/kernel_reuse_cache.h
+++ b/xla/service/gpu/kernel_reuse_cache.h
@@ -48,6 +48,7 @@ class KernelReuseCache {
     int64_t shmem_bytes = 0;
     std::string binary;
     stream_executor::gpu::TmaMetadata tma_metadata;
+    bool use_pdl = false;
   };
   struct NamedBinary {
     std::string name;

--- a/xla/service/gpu/stream_executor_util.cc
+++ b/xla/service/gpu/stream_executor_util.cc
@@ -378,7 +378,7 @@ absl::Mutex& GetGpuMutex(const se::StreamExecutor* stream_exec) {
 
 absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
     std::string kernel_name, uint64_t num_args, absl::string_view ptx,
-    se::StreamExecutor* stream_exec, uint32_t shared_mem_bytes) {
+    se::StreamExecutor* stream_exec, uint32_t shared_mem_bytes, bool use_pdl) {
   se::KernelLoaderSpec loader_spec =
       se::KernelLoaderSpec::CreateCudaPtxInMemorySpec(
           ptx, std::move(kernel_name), num_args);
@@ -389,13 +389,14 @@ absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
   se::KernelMetadata m;
   m.set_shared_memory_bytes(shared_mem_bytes);
   kernel->set_metadata(m);
+  kernel->set_use_pdl(use_pdl);
   return kernel;
 }
 
 absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
     std::string kernel_name, uint64_t num_args,
     absl::Span<const uint8_t> cubin_data, se::StreamExecutor* stream_exec,
-    uint32_t shared_mem_bytes) {
+    uint32_t shared_mem_bytes, bool use_pdl) {
   se::KernelLoaderSpec loader_spec =
       se::KernelLoaderSpec::CreateCudaCubinInMemorySpec(
           cubin_data, std::move(kernel_name), num_args);
@@ -406,6 +407,7 @@ absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
   se::KernelMetadata m;
   m.set_shared_memory_bytes(shared_mem_bytes);
   kernel->set_metadata(m);
+  kernel->set_use_pdl(use_pdl);
   return kernel;
 }
 

--- a/xla/service/gpu/stream_executor_util.h
+++ b/xla/service/gpu/stream_executor_util.h
@@ -100,7 +100,8 @@ absl::Mutex& GetGpuMutex(const se::StreamExecutor* stream_exec);
 // The canonical storage for ptx should outlive the lifetime of the kernel.
 absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
     std::string kernel_name, uint64_t num_args, absl::string_view ptx,
-    se::StreamExecutor* stream_exec, uint32_t shared_mem_bytes = 0);
+    se::StreamExecutor* stream_exec, uint32_t shared_mem_bytes = 0,
+    bool use_pdl = false);
 
 // Creates a kernel with a provided name, based from provided CUBIN in
 // cubin_data. The kernel should be executed using the provided executor.
@@ -109,7 +110,7 @@ absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
 absl::StatusOr<std::unique_ptr<se::Kernel>> CreateKernel(
     std::string kernel_name, uint64_t num_args,
     absl::Span<const uint8_t> cubin_data, se::StreamExecutor* stream_exec,
-    uint32_t shared_mem_bytes = 0);
+    uint32_t shared_mem_bytes = 0, bool use_pdl = false);
 
 // Runs loaded kernel on the stream with the provided arguments.
 absl::Status ExecuteKernelOnStream(

--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -775,6 +775,7 @@ lit_test_suite_for_gpus(
             "reduce_fold_zero_add.hlo",
             "reduce-precision.hlo",
             "rng_get_and_update_state.hlo",
+            "pdl.hlo",
             "single_instruction.hlo",
             "slice_to_dynamic.hlo",
             "sorting.hlo",
@@ -796,12 +797,14 @@ lit_test_suite_for_gpus(
             "triton_calling_convention.hlo",
             "triton_naming.hlo",
             "vectorization.hlo",
+            "pdl.hlo",
         ],
         "p100": [
             "kernel_reuse.hlo",
             "triton_calling_convention.hlo",
             "triton_naming.hlo",
             "vectorization.hlo",
+            "pdl.hlo",
         ],
         "mi200": [
             "element_wise_row_vectorization.hlo",
@@ -810,6 +813,7 @@ lit_test_suite_for_gpus(
             "reduce_unnested.hlo",
             "reduction_vectorization_sm_all.hlo",
             "vectorization.hlo",
+            "pdl.hlo",
         ],
     },
     gpus = [

--- a/xla/service/gpu/tests/pdl.hlo
+++ b/xla/service/gpu/tests/pdl.hlo
@@ -1,0 +1,77 @@
+// RUN: hlo-opt %s --xla_gpu_enable_pdl --platform=gpu --stage=llvm-before-optimizations --split-input-file --xla_gpu_target_config_filename=%S/../../../backends/gpu/target_config/specs/a100_pcie_80.txtpb | FileCheck %s
+// RUN: hlo-opt %s --xla_gpu_enable_pdl --platform=gpu --stage=llvm-before-optimizations --split-input-file --xla_gpu_target_config_filename=%S/../../../backends/gpu/target_config/specs/h100_sxm.txtpb | FileCheck %s  --check-prefixes=CHECK-SM90
+
+// CHECK-LABEL: wrapped_exponential
+// CHECK-SM90: call void @llvm.nvvm.griddepcontrol.wait
+// CHECK-NOT: call void @llvm.nvvm.griddepcontrol.wait
+
+e {
+  a = f32[] exponential(f32[] parameter(0))
+}
+
+// -----
+
+// CHECK-LABEL: define ptx_kernel void @triton_softmax
+// CHECK-SM90: call void @llvm.nvvm.griddepcontrol.wait
+// CHECK-NOT: call void @llvm.nvvm.griddepcontrol.wait
+
+triton_softmax {
+  param_0 = f32[4,4]{1,0} parameter(0)
+  exp = f32[4,4]{1,0} exponential(param_0)
+}
+
+e {
+  a = f32[4,4]{1,0} parameter(0)
+  triton_softmax = f32[4,4]{1,0} fusion(a), kind=kCustom,
+    calls=triton_softmax,
+    backend_config={"fusion_backend_config":{
+      "kind":"__triton",
+      "block_level_fusion_config":{"output_tiles":[{"sizes":["4","4"]}],
+                                   "num_warps":"1",
+                                   "num_ctas":"1",
+                                   "num_stages":"1"}}}
+}
+
+// -----
+
+// CHECK-LABEL: define ptx_kernel void @loop_add_compare_fusion
+// CHECK-SM90: call void @llvm.nvvm.griddepcontrol.wait
+// CHECK-NOT: call void @llvm.nvvm.griddepcontrol.wait
+
+HloModule m, is_scheduled=true
+
+add_region {
+  p0 = s32[] parameter(0)
+  p1 = s32[] parameter(1)
+  sum = s32[] add(p0, p1)
+}
+
+fused_add_compare_40 {
+  param_0 = s32[1,11]{1,0} parameter(0)
+  zero = s32[] constant(0)
+  zero_bcast = s32[1,11]{1,0} broadcast(zero), dimensions={}
+  mask = pred[1,11]{1,0} compare(param_0, zero_bcast), direction=NE
+  mask_s32 = s32[1,11]{1,0} convert(mask)
+  prefix = s32[1,11]{1,0} reduce-window(mask_s32, zero),
+    window={size=1x11 pad=0_0x10_0}, to_apply=add_region
+  one = s32[] constant(1)
+  one_bcast = s32[1,11]{1,0} broadcast(one), dimensions={}
+  ge_one = pred[1,11]{1,0} compare(prefix, one_bcast), direction=GE
+  ge_one_s32 = s32[1,11]{1,0} convert(ge_one)
+  prefix_minus_ge = s32[1,11]{1,0} subtract(prefix, ge_one_s32)
+  minus_1024 = s32[] constant(-1024)
+  plus_1024 = s32[] constant(1024)
+  minus_1024_bcast = s32[1,11]{1,0} broadcast(minus_1024), dimensions={}
+  plus_1024_bcast = s32[1,11]{1,0} broadcast(plus_1024), dimensions={}
+  out0 = s32[1,11]{1,0} add(prefix_minus_ge, minus_1024_bcast)
+  out1 = s32[1,11]{1,0} add(prefix_minus_ge, plus_1024_bcast)
+  out = (s32[1,11]{1,0}, s32[1,11]{1,0}, pred[1,11]{1,0})
+    tuple(out0, out1, mask)
+}
+
+e {
+  p0 = s32[1,11]{1,0} parameter(0)
+  loop_add_compare_fusion =
+    (s32[1,11]{1,0}, s32[1,11]{1,0}, pred[1,11]{1,0}) fusion(p0),
+    kind=kLoop, calls=fused_add_compare_40
+}

--- a/xla/service/gpu/tests/xla-opt.cc
+++ b/xla/service/gpu/tests/xla-opt.cc
@@ -51,6 +51,7 @@ struct TritonPipelineOptions
   Option<int> num_warps{*this, "num-warps", llvm::cl::init(4)};
   Option<int> num_ctas{*this, "num-ctas", llvm::cl::init(1)};
   Option<int> num_stages{*this, "num-stages", llvm::cl::init(3)};
+  Option<bool> enable_pdl{*this, "enable-pdl", llvm::cl::init(false)};
 };
 
 mlir::PassPipelineRegistration<TritonPipelineOptions>
@@ -73,7 +74,8 @@ mlir::PassPipelineRegistration<TritonPipelineOptions>
           bool warp_specialization_allowed = true;
           xla::gpu::CreateTritonXlaPipeline(
               &pm, gpu_cc, options.rewrite_int4, options.allow_tma,
-              options.num_stages, warp_specialization_allowed);
+              options.num_stages, warp_specialization_allowed,
+              options.enable_pdl);
 
           xla::gpu::CreateTritonPipeline(&pm, gpu_cc, options.num_warps,
                                          options.num_ctas, options.num_stages);

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -273,10 +273,9 @@ std::optional<const HloInstruction*> GetCollectiveHeroForDynamicSliceFusion(
 
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       copy_events_(std::make_shared<CopyThunk::AsyncEvents>()),
@@ -1218,7 +1217,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTritonCustomCall(
 
     kernel_modules_.push_back(std::move(result.llvm_module));
     return {{kernel_name, launch_dimensions, /*cluster_dim=*/std::nullopt,
-             result.shmem_bytes}};
+             result.shmem_bytes, /*binary=*/"", /*tma_metadata=*/{},
+             result.use_pdl}};
   };
 
   auto [status_or_entry, was_cached] =
@@ -1240,7 +1240,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTritonCustomCall(
           instr, ir_emitter_context_->GetNextThunkId()),
       entry->kernel_name, kernel_arguments, entry->launch_dimensions,
       /*cluster_dim=*/std::nullopt, entry->shmem_bytes, entry->tma_metadata,
-      /*zeroed_output_buffer_indices=*/call.zeroed_outputs));
+      /*zeroed_output_buffer_indices=*/call.zeroed_outputs, entry->use_pdl));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitAsyncComputation(

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1836,6 +1836,7 @@ xla_test(
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/gpu:gpu_test_kernels",
         "//xla/tsl/lib/core:status_test_util",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status:status_matchers",

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -499,7 +499,14 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateKernelNode(
           << " bdz: " << threads.z << "; shmem: " << shared_mem_bytes
           << "; deps: " << dependencies.size();
 
+#if CUDA_VERSION >= 12030
+  CUgraphNodeParams cu_params;
+  std::memset(&cu_params, 0, sizeof(cu_params));
+  cu_params.type = CU_GRAPH_NODE_TYPE_KERNEL;
+  CUDA_KERNEL_NODE_PARAMS_v3& params = cu_params.kernel;
+#else
   CUDA_KERNEL_NODE_PARAMS params{};
+#endif
 
   CUfunction function = static_cast<const CudaKernel&>(kernel).gpu_function();
   params.func = function;
@@ -527,10 +534,34 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateKernelNode(
   std::vector<CUgraphNode> deps = ToCudaGraphHandles(dependencies);
 
   CUgraphNode node_handle = nullptr;
+
+#if CUDA_VERSION >= 12030
+  std::vector<CUgraphEdgeData> edge_data;
+  edge_data.reserve(deps.size());
+  for (size_t i = 0; i < deps.size(); ++i) {
+    CUgraphEdgeData edge_data_item;
+    std::memset(&edge_data_item, 0, sizeof(edge_data_item));
+    CUgraphNodeType type;
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphNodeGetType(deps[i], &type),
+        absl::StrCat("Failed to get CUDA graph node type for dependency ", i)));
+    if (kernel.use_pdl() && type == CU_GRAPH_NODE_TYPE_KERNEL) {
+      edge_data_item.from_port = CU_GRAPH_KERNEL_NODE_PORT_PROGRAMMATIC;
+      edge_data_item.type = CU_GRAPH_DEPENDENCY_TYPE_PROGRAMMATIC;
+    }
+    edge_data.push_back(edge_data_item);
+  }
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuGraphAddNode_v2(&node_handle, graph_, deps.data(), edge_data.data(),
+                        deps.size(), &cu_params),
+      "Failed to add kernel node to a CUDA graph"));
+#else
+  TF_RET_CHECK(!kernel.use_pdl()) << "PDL is not supported for CUDA < 12.3";
   TF_RETURN_IF_ERROR(
       cuda::ToStatus(cuGraphAddKernelNode(&node_handle, graph_, deps.data(),
                                           deps.size(), &params),
                      "Failed to add kernel node to a CUDA graph"));
+#endif
 
   if (priority != StreamPriority::Default) {
     CUlaunchAttributeValue value;

--- a/xla/stream_executor/cuda/cuda_command_buffer_test.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -20,6 +21,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/base/casts.h"
 #include "absl/status/status_matchers.h"
 #include "absl/strings/ascii.h"
 #include "absl/types/span.h"
@@ -27,6 +29,7 @@ limitations under the License.
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_interface.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_properties.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_utils.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/service/platform_util.h"
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
@@ -34,6 +37,11 @@ limitations under the License.
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/engine_options.h"
+#include "xla/stream_executor/gpu/gpu_command_buffer.h"
+#include "xla/stream_executor/gpu/gpu_test_kernels.h"
+#include "xla/stream_executor/kernel.h"
+#include "xla/stream_executor/kernel_args.h"
+#include "xla/stream_executor/launch_dim.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream.h"
@@ -164,6 +172,73 @@ TEST(CudaCommandBufferTest, CuDnnExplicitConstructionAndUpdateWork) {
   TF_ASSERT_OK(stream->Memcpy(host_buffer.data(), output1, output1.size()));
   TF_ASSERT_OK(stream->BlockHostUntilDone());
   EXPECT_THAT(host_buffer, Each(0));
+}
+
+TEST(CudaCommandBufferTest, PdlKernelEdgeUsesProgrammaticDependency) {
+#if CUDA_VERSION < 12030
+  GTEST_SKIP() << "Requires CUDA toolkit 12.3+";
+#else
+  Platform* platform = CudaPlatform();
+  StreamExecutor* executor = platform->ExecutorForDevice(0).value();
+  if (!executor->GetDeviceDescription()
+           .cuda_compute_capability()
+           .IsAtLeastHopper()) {
+    GTEST_SKIP() << "Requires at least a Hopper GPU.";
+  }
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Stream> stream,
+                          executor->CreateStream());
+  KernelLoaderSpec add_spec = ::stream_executor::gpu::GetAddI32TestKernelSpec(
+                                  executor->GetPlatform()->id())
+                                  .value();
+  std::unique_ptr<Kernel> kernel = executor->LoadKernel(add_spec).value();
+  kernel->set_use_pdl(true);
+
+  DeviceAddress<int32_t> a = executor->AllocateArray<int32_t>(4);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<CommandBuffer> cmd_buffer,
+                          executor->CreateCommandBuffer(primary));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      const CommandBuffer::Command* first,
+      cmd_buffer->CreateLaunch(ThreadDim(4, 1, 1), BlockDim(1, 1, 1), *kernel,
+                               *stream_executor::PackKernelArgs(0, a, a, a),
+                               {}));
+  std::array<const CommandBuffer::Command*, 1> dependencies = {first};
+  TF_ASSERT_OK_AND_ASSIGN(
+      const CommandBuffer::Command* second,
+      cmd_buffer->CreateLaunch(
+          ThreadDim(4, 1, 1), BlockDim(1, 1, 1), *kernel,
+          *stream_executor::PackKernelArgs(0, a, a, a),
+          absl::Span<const CommandBuffer::Command* const>(dependencies)));
+
+  auto* first_kernel =
+      dynamic_cast<const gpu::GpuCommandBuffer::GpuCommand*>(first);
+  auto* second_kernel =
+      dynamic_cast<const gpu::GpuCommandBuffer::GpuCommand*>(second);
+  ASSERT_NE(first_kernel, nullptr);
+  ASSERT_NE(second_kernel, nullptr);
+
+  const CUgraphNode first_node =
+      absl::bit_cast<CUgraphNode>(first_kernel->handle);
+  const CUgraphNode second_node =
+      absl::bit_cast<CUgraphNode>(second_kernel->handle);
+
+  size_t num_dependencies = 0;
+  ASSERT_EQ(cuGraphNodeGetDependencies_v2(second_node, nullptr, nullptr,
+                                          &num_dependencies),
+            CUDA_SUCCESS);
+  ASSERT_EQ(num_dependencies, 1);
+
+  CUgraphNode dep_node;
+  CUgraphEdgeData edge_data;
+  ASSERT_EQ(cuGraphNodeGetDependencies_v2(second_node, &dep_node, &edge_data,
+                                          &num_dependencies),
+            CUDA_SUCCESS);
+
+  EXPECT_EQ(dep_node, first_node);
+  EXPECT_EQ(edge_data.from_port, CU_GRAPH_KERNEL_NODE_PORT_PROGRAMMATIC);
+  EXPECT_EQ(edge_data.type, CU_GRAPH_DEPENDENCY_TYPE_PROGRAMMATIC);
+#endif
 }
 
 }  // namespace

--- a/xla/stream_executor/cuda/cuda_kernel.cc
+++ b/xla/stream_executor/cuda/cuda_kernel.cc
@@ -114,8 +114,8 @@ absl::Status CudaKernel::Launch(const ThreadDim& thread_dims,
     void** params = const_cast<void**>(packed.argument_addresses().data());
 
     return stream->LaunchKernel(thread_dims, block_dims, cluster_dims, function,
-                                name(), params,
-                                packed.number_of_shared_bytes());
+                                name(), params, packed.number_of_shared_bytes(),
+                                use_pdl());
   };
 
   // If arguments are already packed we can just launch the kernel.

--- a/xla/stream_executor/cuda/cuda_stream.cc
+++ b/xla/stream_executor/cuda/cuda_stream.cc
@@ -360,8 +360,8 @@ absl::Status LaunchCudaKernel(
     CUfunction function, unsigned int grid_dim_x, unsigned int grid_dim_y,
     unsigned int grid_dim_z, unsigned int block_dim_x, unsigned int block_dim_y,
     unsigned int block_dim_z, unsigned int shared_mem_bytes, CUstream stream,
-    void** kernel_params, void** extra,
-    std::optional<ClusterDim> cluster_dims) {
+    void** kernel_params, void** extra, std::optional<ClusterDim> cluster_dims,
+    bool use_pdl) {
   TraceMe trace0([] { return TraceMeEncode("LaunchCudaKernel", {}); },
                  /*level=*/TraceMeLevel::kVerbose);
 
@@ -410,7 +410,7 @@ absl::Status LaunchCudaKernel(
     return cuda::ToStatus(result, msg);
   };
 
-  if (cluster_dims.has_value()) {
+  if (cluster_dims.has_value() || use_pdl) {
     CUlaunchConfig launch_config;
     memset(&launch_config, 0, sizeof(launch_config));
     launch_config.blockDimX = block_dim_x;
@@ -422,15 +422,26 @@ absl::Status LaunchCudaKernel(
     launch_config.hStream = stream;
     launch_config.sharedMemBytes = shared_mem_bytes;
 
-    CUlaunchAttribute cluster_dims_attr;
-    memset(&cluster_dims_attr, 0, sizeof(cluster_dims_attr));
-    cluster_dims_attr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-    cluster_dims_attr.value.clusterDim.x = cluster_dims->x;
-    cluster_dims_attr.value.clusterDim.y = cluster_dims->y;
-    cluster_dims_attr.value.clusterDim.z = cluster_dims->z;
+    absl::InlinedVector<CUlaunchAttribute, 2> attrs;
 
-    launch_config.attrs = &cluster_dims_attr;
-    launch_config.numAttrs = 1;
+    if (cluster_dims.has_value()) {
+      CUlaunchAttribute attr{};
+      attr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+      attr.value.clusterDim.x = static_cast<unsigned int>(cluster_dims->x);
+      attr.value.clusterDim.y = static_cast<unsigned int>(cluster_dims->y);
+      attr.value.clusterDim.z = static_cast<unsigned int>(cluster_dims->z);
+      attrs.push_back(attr);
+    }
+
+    if (use_pdl) {
+      CUlaunchAttribute attr{};
+      attr.id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+      attr.value.programmaticStreamSerializationAllowed = 1;
+      attrs.push_back(attr);
+    }
+
+    launch_config.attrs = attrs.data();
+    launch_config.numAttrs = attrs.size();
 
     TraceMe trace(
         [] { return TraceMeEncode("LaunchCudaKernel/cuLaunchKernelEx", {}); },
@@ -452,7 +463,7 @@ absl::Status LaunchCudaKernel(
 absl::Status CudaStream::LaunchKernel(
     const ThreadDim& thread_dims, const BlockDim& block_dims,
     const std::optional<ClusterDim>& cluster_dims, void* function,
-    absl::string_view name, void** args, int64_t shmem_bytes) {
+    absl::string_view name, void** args, int64_t shmem_bytes, bool use_pdl) {
   TraceMe trace([] { return TraceMeEncode("CudaStream::LaunchKernel", {}); },
                 /*level=*/TraceMeLevel::kVerbose);
 
@@ -460,7 +471,7 @@ absl::Status CudaStream::LaunchKernel(
                           block_dims.x, block_dims.y, block_dims.z,
                           thread_dims.x, thread_dims.y, thread_dims.z,
                           shmem_bytes, stream_handle_, args,
-                          /*extra=*/nullptr, cluster_dims);
+                          /*extra=*/nullptr, cluster_dims, use_pdl);
 }
 
 void CudaStream::SetName(std::string name) {

--- a/xla/stream_executor/cuda/cuda_stream.h
+++ b/xla/stream_executor/cuda/cuda_stream.h
@@ -96,7 +96,7 @@ class CudaStream : public StreamCommon {
                             const BlockDim& block_dims,
                             const std::optional<ClusterDim>& cluster_dims,
                             void* function, absl::string_view name, void** args,
-                            int64_t shmem_bytes) override;
+                            int64_t shmem_bytes, bool use_pdl) override;
 
   StreamExecutor* executor_;
   CudaEvent completed_event_;

--- a/xla/stream_executor/kernel.h
+++ b/xla/stream_executor/kernel.h
@@ -145,11 +145,15 @@ class Kernel {
                               const std::optional<ClusterDim>& cluster_dims,
                               Stream* stream, const KernelArgs& args) = 0;
 
+  void set_use_pdl(bool use_pdl) { use_pdl_ = use_pdl; }
+  bool use_pdl() const { return use_pdl_; }
+
  private:
   std::string name_;
 
   KernelMetadata metadata_;
   KernelArgsPacking args_packing_;
+  bool use_pdl_ = false;
 };
 
 inline absl::Status Kernel::Launch(const ThreadDim& thread_dims,

--- a/xla/stream_executor/kernel.h
+++ b/xla/stream_executor/kernel.h
@@ -153,6 +153,7 @@ class Kernel {
 
   KernelMetadata metadata_;
   KernelArgsPacking args_packing_;
+  // Programmatic Dependent Launch.
   bool use_pdl_ = false;
 };
 

--- a/xla/stream_executor/mock_stream.h
+++ b/xla/stream_executor/mock_stream.h
@@ -82,7 +82,8 @@ class MockStream : public Stream {
   MOCK_METHOD(absl::Status, LaunchKernel,
               (const ThreadDim &thread_dims, const BlockDim &block_dims,
                const std::optional<ClusterDim> &cluster_dims, void *function,
-               absl::string_view name, void **args, int64_t shmem_bytes),
+               absl::string_view name, void **args, int64_t shmem_bytes,
+               bool use_pdl),
               (override));
   MOCK_METHOD(const std::string &, GetName, (), (const, override));
   MOCK_METHOD(void, SetName, (std::string name), (override));

--- a/xla/stream_executor/rocm/rocm_kernel.cc
+++ b/xla/stream_executor/rocm/rocm_kernel.cc
@@ -100,8 +100,8 @@ absl::Status RocmKernel::Launch(const ThreadDim& thread_dims,
     void** params = const_cast<void**>(packed.argument_addresses().data());
 
     return stream->LaunchKernel(thread_dims, block_dims, cluster_dims, function,
-                                name(), params,
-                                packed.number_of_shared_bytes());
+                                name(), params, packed.number_of_shared_bytes(),
+                                /*use_pdl=*/false);
   };
 
   // If arguments are already packed we can just launch the kernel.

--- a/xla/stream_executor/rocm/rocm_stream.cc
+++ b/xla/stream_executor/rocm/rocm_stream.cc
@@ -375,7 +375,7 @@ absl::Status RocmStream::BlockHostUntilDone() {
 absl::Status RocmStream::LaunchKernel(
     const ThreadDim& thread_dims, const BlockDim& block_dims,
     const std::optional<ClusterDim>& cluster_dims, void* function,
-    absl::string_view name, void** args, int64_t shmem_bytes) {
+    absl::string_view name, void** args, int64_t shmem_bytes, bool use_pdl) {
   if (cluster_dims.has_value()) {
     return LaunchRocmKernel(
         executor_, name, static_cast<hipFunction_t>(function), cluster_dims->x,

--- a/xla/stream_executor/rocm/rocm_stream.h
+++ b/xla/stream_executor/rocm/rocm_stream.h
@@ -90,7 +90,7 @@ class RocmStream : public StreamCommon {
                             const BlockDim& block_dims,
                             const std::optional<ClusterDim>& cluster_dims,
                             void* function, absl::string_view name, void** args,
-                            int64_t shmem_bytes) override;
+                            int64_t shmem_bytes, bool use_pdl) override;
 
   StreamExecutor* executor_;
   RocmEvent completed_event_;

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -282,7 +282,7 @@ class Stream {
   virtual absl::Status LaunchKernel(
       const ThreadDim& thread_dims, const BlockDim& block_dims,
       const std::optional<ClusterDim>& cluster_dims, void* function,
-      absl::string_view name, void** args, int64_t shmem_bytes) {
+      absl::string_view name, void** args, int64_t shmem_bytes, bool use_pdl) {
     return absl::UnimplementedError("Not implemented");
   }
 

--- a/xla/stream_executor/sycl/sycl_kernel.cc
+++ b/xla/stream_executor/sycl/sycl_kernel.cc
@@ -80,9 +80,9 @@ absl::Status SyclKernel::Launch(const ThreadDim& thread_dims,
     // If there are no arguments to pass (e.g., when using shared memory),
     // we can skip packing the kernel arguments.
     if (arg_addrs.empty() && packed.number_of_arguments() == 0) {
-      return stream->LaunchKernel(thread_dims, block_dims, cluster_dims,
-                                  function, name(), nullptr,
-                                  packed.number_of_shared_bytes());
+      return stream->LaunchKernel(
+          thread_dims, block_dims, cluster_dims, function, name(), nullptr,
+          packed.number_of_shared_bytes(), /*use_pdl=*/false);
     } else {
       kernel_args.reserve(arg_addrs.size());
       for (const void* const arg : arg_addrs) {
@@ -91,10 +91,10 @@ absl::Status SyclKernel::Launch(const ThreadDim& thread_dims,
       }
       size_t kernel_args_size = kernel_args.size();
       std::array<void*, 2> config = {kernel_args.data(), &kernel_args_size};
-      return stream->LaunchKernel(thread_dims, block_dims, cluster_dims,
-                                  function, name(),
-                                  reinterpret_cast<void**>(config.data()),
-                                  packed.number_of_shared_bytes());
+      return stream->LaunchKernel(
+          thread_dims, block_dims, cluster_dims, function, name(),
+          reinterpret_cast<void**>(config.data()),
+          packed.number_of_shared_bytes(), /*use_pdl=*/false);
     }
   };
 

--- a/xla/stream_executor/sycl/sycl_stream.cc
+++ b/xla/stream_executor/sycl/sycl_stream.cc
@@ -307,7 +307,7 @@ absl::Status SyclStream::RecordCompletedEvent() {
 absl::Status SyclStream::LaunchKernel(
     const ThreadDim& thread_dims, const BlockDim& block_dims,
     const std::optional<ClusterDim>& cluster_dims, void* function,
-    absl::string_view name, void** args, int64_t shmem_bytes) {
+    absl::string_view name, void** args, int64_t shmem_bytes, bool use_pdl) {
   if (cluster_dims.has_value()) {
     return LaunchSyclKernel(
         executor_, name, static_cast<::sycl::kernel*>(function),

--- a/xla/stream_executor/sycl/sycl_stream.h
+++ b/xla/stream_executor/sycl/sycl_stream.h
@@ -121,7 +121,7 @@ class SyclStream : public StreamCommon {
                             const BlockDim& block_dims,
                             const std::optional<ClusterDim>& cluster_dims,
                             void* function, absl::string_view name, void** args,
-                            int64_t shmem_bytes) override;
+                            int64_t shmem_bytes, bool use_pdl) override;
 
   // The Executor to which this stream is bound.
   StreamExecutor* executor_;

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -574,6 +574,8 @@ message DebugOptions {
   // Enable NCCL user buffers.
   optional bool xla_gpu_enable_nccl_user_buffers = 267;
 
+  optional bool xla_gpu_enable_pdl = 460;
+
   optional bool xla_gpu_enable_pipelined_all_gather = 227;
 
   optional bool xla_gpu_enable_pipelined_all_reduce = 217;
@@ -1418,7 +1420,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 460
+  // Next id: 461
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -574,6 +574,7 @@ message DebugOptions {
   // Enable NCCL user buffers.
   optional bool xla_gpu_enable_nccl_user_buffers = 267;
 
+  // Enable PDL - Programmatic Dependent Launch.
   optional bool xla_gpu_enable_pdl = 460;
 
   optional bool xla_gpu_enable_pipelined_all_gather = 227;


### PR DESCRIPTION
📝 Summary of Changes
This is an initial simple implementation of PDL which only adds `griddepcontrol.wait` instruction at starts of all XLA-generated MLIR kernels (emitters and Triton). It can be enhanced later by moving `griddepcontrol.wait` further from kernel entrypoints using data dependency info and by adding `griddepcontrol.launch_dependents` - with that in mind the design already includes 2 separate passes, one to insert PDL ops and another to lower them to NVVM.

🎯 Justification
Reduces kernel launch latencies on Hopper+.

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)

B200

| Benchmark                                           | Speedup | Error | Memory | Compilation speedup |
|-----------------------------------------------------|---------|-------|--------|---------------------|
|  gpu_hlo                                            |   1.00x | 0.01x |    N/A |               1.02x |
|  hlo_llama3_8b_bf16_activation_offloading_1x8       |   1.00x | 0.01x |    N/A |               0.92x |
|  hlo_llama3_8b_cp_bf16_1x4                          |   1.01x | 0.02x |    N/A |               1.03x |
|  hlo_llama31_8b_bf16_1x8                            |   1.01x | 0.02x |    N/A |               1.18x |
|  hlo_llama31_8b_fp8_1x8                             |   1.00x | 0.45x |    N/A |               1.60x |
|  hlo_mixtral_8x7b_bf16_1x8                          |   1.01x | 0.01x |    N/A |               0.95x |
|  nv_maxtext_1n1g_jit_train_step_before_optimization |   1.00x | 0.00x |    N/A |               1.00x |
|  u4_all_gather_1x8                                  |   1.04x | 0.05x |    N/A |               1.14x |
|  gemma2_2b_keras_jax                                |   1.02x | 0.00x |    N/A |               0.94x |
|  gemma3_1b_flax_call                                |   1.33x | 0.04x |    N/A |               1.09x |
|  gemma3_1b_flax_sample_loop                         |   0.98x | 0.03x |    N/A |               1.00x |
|  gemma3_4b_flax_call                                |   1.02x | 0.02x |    N/A |               1.06x |
|  gemma3_4b_flax_sample_loop                         |   0.98x | 0.01x |    N/A |               1.00x |
|  gemma3_12b_flax_call                               |   1.00x | 0.03x |    N/A |               1.04x |
|  gemma3_12b_flax_sample_loop                        |   1.05x | 0.01x |    N/A |               0.99x |

H100

| Benchmark                    | Speedup | Error | Memory | Compilation speedup |
|------------------------------|---------|-------|--------|---------------------|
|  gemma2_2b_keras_jax         |   1.02x | 0.00x |    N/A |               0.95x |
|  gemma3_1b_flax_call         |   1.08x | 0.02x |    N/A |               0.95x |
|  gemma3_1b_flax_sample_loop  |   1.08x | 0.03x |    N/A |               1.01x |
|  gemma3_4b_flax_call         |   1.03x | 0.02x |    N/A |               1.04x |
|  gemma3_4b_flax_sample_loop  |   1.02x | 0.01x |    N/A |               1.01x |
|  gemma3_12b_flax_call        |   1.03x | 0.21x |    N/A |               0.99x |
|  gemma3_12b_flax_sample_loop |   1.03x | 0.01x |    N/A |               1.03x |

🧪 Unit Tests:
yes

🧪 Execution Tests:
no