### PR TITLE
[XLA:GPU] Add CUDA VMM RAII wrappers: CudaRawMemoryAllocation and CudaMemoryReservation

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -366,6 +366,24 @@ cc_library(
 )
 
 cc_library(
+    name = "memory_reservation",
+    srcs = ["memory_reservation.cc"],
+    hdrs = ["memory_reservation.h"],
+    deps = [
+        ":device_address",
+        ":memory_allocation",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
     name = "platform_manager",
     srcs = ["platform_manager.cc"],
     hdrs = ["platform_manager.h"],

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -777,6 +777,56 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "cuda_raw_memory_allocation",
+    srcs = ["cuda_raw_memory_allocation.cc"],
+    hdrs = ["cuda_raw_memory_allocation.h"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    deps = [
+        ":cuda_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
+    name = "cuda_memory_reservation",
+    srcs = ["cuda_memory_reservation.cc"],
+    hdrs = ["cuda_memory_reservation.h"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    deps = [
+        ":cuda_raw_memory_allocation",
+        ":cuda_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
 xla_test(
     name = "cuda_event_test",
     srcs = ["cuda_event_test.cc"],
@@ -793,6 +843,54 @@ xla_test(
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/lib/core:status_test_util",
         "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+xla_test(
+    name = "cuda_raw_memory_allocation_test",
+    srcs = ["cuda_raw_memory_allocation_test.cc"],
+    backends = ["gpu"],
+    tags = ["cuda-only"],
+    deps = [
+        ":cuda_platform_id",
+        ":cuda_raw_memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+xla_test(
+    name = "cuda_memory_reservation_test",
+    srcs = ["cuda_memory_reservation_test.cc"],
+    backends = ["gpu"],
+    tags = ["cuda-only"],
+    deps = [
+        ":cuda_memory_reservation",
+        ":cuda_platform_id",
+        ":cuda_raw_memory_allocation",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@local_config_cuda//cuda:cuda_headers",

--- a/xla/stream_executor/cuda/cuda_memory_reservation.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation.cc
@@ -1,0 +1,132 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/cuda/cuda_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
+#include "xla/stream_executor/cuda/cuda_status.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+CUmemAllocationProp BuildAllocationProperties(CUdevice device) {
+  CUmemAllocationProp props = {};
+  props.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  props.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  props.location.id = device;
+  props.requestedHandleTypes =
+      static_cast<CUmemAllocationHandleType>(CU_MEM_HANDLE_TYPE_NONE);
+  return props;
+}
+
+}  // namespace
+
+absl::StatusOr<std::unique_ptr<CudaMemoryReservation>>
+CudaMemoryReservation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  CUdevice device;
+  TF_RETURN_IF_ERROR(
+      cuda::ToStatus(cuDeviceGet(&device, executor->device_ordinal())));
+
+  CUmemAllocationProp props = BuildAllocationProperties(device);
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
+      &granularity, &props, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  CUdeviceptr ptr;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuMemAddressReserve(&ptr, padded_size, granularity, 0, 0)));
+
+  return std::unique_ptr<CudaMemoryReservation>(
+      new CudaMemoryReservation(executor, ptr, padded_size));
+}
+
+CudaMemoryReservation::CudaMemoryReservation(StreamExecutor* executor,
+                                             CUdeviceptr ptr, uint64_t size)
+    : executor_(executor), ptr_(ptr), size_(size) {}
+
+DeviceAddressBase CudaMemoryReservation::address() const {
+  return DeviceAddressBase(reinterpret_cast<void*>(ptr_), size_);
+}
+
+absl::Status CudaMemoryReservation::Map(size_t reservation_offset,
+                                        size_t allocation_offset, size_t size,
+                                        MemoryAllocation& allocation) {
+  auto* cuda_alloc = dynamic_cast<CudaRawMemoryAllocation*>(&allocation);
+  if (cuda_alloc == nullptr) {
+    return absl::InvalidArgumentError(
+        "CudaMemoryReservation::Map requires a CudaRawMemoryAllocation");
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  return cuda::ToStatus(cuMemMap(ptr_ + reservation_offset, size,
+                                 allocation_offset, cuda_alloc->GetHandle(),
+                                 0));
+}
+
+absl::Status CudaMemoryReservation::SetAccess(uint64_t reservation_offset,
+                                              size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  CUmemAccessDesc desc = {};
+  desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  desc.location.id = static_cast<int>(executor_->device_ordinal());
+  desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  return cuda::ToStatus(
+      cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1));
+}
+
+absl::Status CudaMemoryReservation::UnMap(size_t offset, size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  return cuda::ToStatus(cuMemUnmap(ptr_ + offset, size));
+}
+
+CudaMemoryReservation::~CudaMemoryReservation() {
+  if (ptr_ == 0) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  // Attempt to unmap the full range before freeing the virtual address space.
+  // Sub-ranges already unmapped by ScopedMapping destructors will cause this
+  // call to fail; the error is logged and the address range is freed anyway.
+  auto unmap_status =
+      cuda::ToStatus(cuMemUnmap(ptr_, size_), "Error unmapping CUDA memory");
+  if (!unmap_status.ok()) {
+    LOG(ERROR) << unmap_status.message();
+  }
+  auto free_status = cuda::ToStatus(cuMemAddressFree(ptr_, size_),
+                                    "Error freeing CUDA address range");
+  if (!free_status.ok()) {
+    LOG(ERROR) << free_status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_memory_reservation.h
+++ b/xla/stream_executor/cuda/cuda_memory_reservation.h
@@ -1,0 +1,74 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_CUDA_CUDA_MEMORY_RESERVATION_H_
+#define XLA_STREAM_EXECUTOR_CUDA_CUDA_MEMORY_RESERVATION_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a CUDA virtual address range reserved via
+// cuMemAddressReserve. Physical memory can be mapped into sub-ranges of the
+// reservation via MapTo, which also enables device access before returning.
+class CudaMemoryReservation : public MemoryReservation {
+ public:
+  // Reserves a virtual address range of at least `size` bytes using
+  // cuMemAddressReserve. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<CudaMemoryReservation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns the base address and padded size of the reserved virtual range.
+  DeviceAddressBase address() const override;
+
+  ~CudaMemoryReservation() override;
+  CudaMemoryReservation(CudaMemoryReservation&&) = delete;
+  CudaMemoryReservation& operator=(CudaMemoryReservation&&) = delete;
+
+ private:
+  explicit CudaMemoryReservation(StreamExecutor* executor, CUdeviceptr ptr,
+                                 uint64_t size);
+
+  // Maps [reservation_offset, reservation_offset+size) in the reservation to
+  // [allocation_offset, allocation_offset+size) in allocation via cuMemMap.
+  // allocation must be a CudaRawMemoryAllocation.
+  absl::Status Map(size_t reservation_offset, size_t allocation_offset,
+                   size_t size, MemoryAllocation& allocation) override;
+
+  // Enables read/write access to the full reservation for the owning device
+  // via cuMemSetAccess.
+  absl::Status SetAccess(uint64_t reservation_offset, size_t size) override;
+
+  // Unmaps [offset, offset+size) within this reservation via cuMemUnmap.
+  absl::Status UnMap(size_t reservation_offset, size_t size) override;
+
+  StreamExecutor* executor_;
+  CUdeviceptr ptr_;  // 0 means moved-from / released
+  uint64_t size_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_CUDA_CUDA_MEMORY_RESERVATION_H_

--- a/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
@@ -1,0 +1,168 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/cuda/cuda_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/cuda/cuda_platform_id.h"
+#include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+using absl_testing::StatusIs;
+
+// 1 MB — will be rounded up to the VMM granularity (typically 2 MB).
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+// A minimal MemoryAllocation that is NOT a CudaRawMemoryAllocation, used to
+// exercise the wrong-type error path in MapTo.
+class FakeAllocation : public MemoryAllocation {
+ public:
+  DeviceAddressBase address() const override { return DeviceAddressBase(); }
+};
+
+class CudaMemoryReservationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    TF_ASSERT_OK_AND_ASSIGN(
+        Platform * platform,
+        PlatformManager::PlatformWithId(cuda::kCudaPlatformId));
+    TF_ASSERT_OK_AND_ASSIGN(executor_, platform->ExecutorForDevice(0));
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+// Verifies that Create reserves a non-null virtual address range of at least
+// the requested size.
+TEST_F(CudaMemoryReservationTest, CreateReservation) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res->address().opaque(), nullptr);
+  EXPECT_GE(res->address().size(), kTestSize);
+}
+
+// Verifies that passing a non-CudaRawMemoryAllocation to MapTo returns an
+// InvalidArgument error.
+TEST_F(CudaMemoryReservationTest, MapToWrongType) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  FakeAllocation fake;
+  EXPECT_THAT(res->MapTo(0, 0, kTestSize, fake),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+// Verifies the full MapTo workflow. The ScopedMapping is destroyed first,
+// unmapping the reservation range, then the allocation is released.
+TEST_F(CudaMemoryReservationTest, MapToSingleAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  // The mapped address starts at the reservation base (offset 0) and spans
+  // the full allocation size.
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), alloc_size);
+  // ScopedMapping destructor: cuMemUnmap.
+  // CudaMemoryReservation destructor: cuMemUnmap (logs error, already unmapped)
+  // + cuMemAddressFree. Allocation destructor: cuMemRelease.
+}
+
+// Verifies that ScopedMapping unmaps the range on destruction, allowing a
+// second mapping into the same reservation range.
+TEST_F(CudaMemoryReservationTest, ScopedMappingUnmapsOnDestruction) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  {
+    TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+    // mapping goes out of scope here, triggering cuMemUnmap.
+  }
+
+  // After the ScopedMapping is destroyed, the range is unmapped and can be
+  // remapped.
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2, res->MapTo(0, 0, alloc_size, *alloc));
+  EXPECT_NE(mapping2.mapped_address().opaque(), nullptr);
+}
+
+// Verifies that multiple physical allocations can be mapped into a contiguous
+// reservation range via the span-based MapTo overload.
+TEST_F(CudaMemoryReservationTest, MapToMultipleAllocations) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc1, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc2, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+
+  const size_t size1 = alloc1->address().size();
+  const size_t size2 = alloc2->address().size();
+
+  // Reserve enough virtual space for both allocations.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto res, CudaMemoryReservation::Create(executor_, size1 + size2));
+  ASSERT_GE(res->address().size(), size1 + size2);
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, size1, alloc1.get()},
+      {/*reservation_offset=*/size1, /*allocation_offset=*/0, size2,
+       alloc2.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  // The contiguous mapping starts at the reservation base and spans both
+  // allocations.
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), size1 + size2);
+}
+
+// Verifies that a second reservation does not alias the first.
+TEST_F(CudaMemoryReservationTest, TwoReservationsDifferentAddresses) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res1,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res2,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res1->address().opaque(), res2->address().opaque());
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_raw_memory_allocation.cc
+++ b/xla/stream_executor/cuda/cuda_raw_memory_allocation.cc
@@ -1,0 +1,93 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/cuda/cuda_status.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+CUmemAllocationProp BuildAllocationProperties(CUdevice device) {
+  CUmemAllocationProp props = {};
+  props.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  props.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  props.location.id = device;
+  props.requestedHandleTypes =
+      static_cast<CUmemAllocationHandleType>(CU_MEM_HANDLE_TYPE_NONE);
+  return props;
+}
+
+}  // namespace
+
+absl::StatusOr<std::unique_ptr<CudaRawMemoryAllocation>>
+CudaRawMemoryAllocation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  CUdevice device;
+  TF_RETURN_IF_ERROR(
+      cuda::ToStatus(cuDeviceGet(&device, executor->device_ordinal())));
+
+  CUmemAllocationProp props = BuildAllocationProperties(device);
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
+      &granularity, &props, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  CUmemGenericAllocationHandle handle;
+  TF_RETURN_IF_ERROR(
+      cuda::ToStatus(cuMemCreate(&handle, padded_size, &props, 0)));
+
+  return std::unique_ptr<CudaRawMemoryAllocation>(
+      new CudaRawMemoryAllocation(executor, handle, padded_size));
+}
+
+CudaRawMemoryAllocation::CudaRawMemoryAllocation(
+    StreamExecutor* executor, CUmemGenericAllocationHandle handle,
+    uint64_t size)
+    : executor_(executor), handle_(handle), size_(size) {}
+
+DeviceAddressBase CudaRawMemoryAllocation::address() const {
+  return DeviceAddressBase(
+      reinterpret_cast<void*>(static_cast<uintptr_t>(handle_)), size_);
+}
+
+CudaRawMemoryAllocation::~CudaRawMemoryAllocation() {
+  if (handle_ == 0) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  auto status =
+      cuda::ToStatus(cuMemRelease(handle_), "Error releasing CUDA memory");
+  if (!status.ok()) {
+    LOG(ERROR) << status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_raw_memory_allocation.h
+++ b/xla/stream_executor/cuda/cuda_raw_memory_allocation.h
@@ -1,0 +1,62 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_CUDA_CUDA_RAW_MEMORY_ALLOCATION_H_
+#define XLA_STREAM_EXECUTOR_CUDA_CUDA_RAW_MEMORY_ALLOCATION_H_
+
+#include <cstdint>
+
+#include "absl/status/statusor.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a physical memory allocation created via cuMemCreate.
+// The handle is not mapped to any virtual address; this class only manages
+// the lifetime of the CUmemGenericAllocationHandle.
+class CudaRawMemoryAllocation : public MemoryAllocation {
+ public:
+  // Creates a physical memory allocation of at least `size` bytes using
+  // cuMemCreate. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<CudaRawMemoryAllocation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns a DeviceAddressBase whose opaque() holds the raw
+  // CUmemGenericAllocationHandle cast to void*, and size() is the
+  // padded allocation size.
+  DeviceAddressBase address() const override;
+
+  CUmemGenericAllocationHandle GetHandle() const { return handle_; }
+
+  ~CudaRawMemoryAllocation() override;
+  CudaRawMemoryAllocation(const CudaRawMemoryAllocation&) = delete;
+  CudaRawMemoryAllocation& operator=(const CudaRawMemoryAllocation&) = delete;
+
+ private:
+  explicit CudaRawMemoryAllocation(StreamExecutor* executor,
+                                   CUmemGenericAllocationHandle handle,
+                                   uint64_t size);
+
+  StreamExecutor* executor_;
+  CUmemGenericAllocationHandle handle_;  // 0 means moved-from / released
+  uint64_t size_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_CUDA_CUDA_RAW_MEMORY_ALLOCATION_H_

--- a/xla/stream_executor/cuda/cuda_raw_memory_allocation_test.cc
+++ b/xla/stream_executor/cuda/cuda_raw_memory_allocation_test.cc
@@ -1,0 +1,85 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/status/status_matchers.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/stream_executor/cuda/cuda_platform_id.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+
+// 1 MB — will be rounded up to the VMM granularity (typically 2 MB).
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class CudaRawMemoryAllocationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    TF_ASSERT_OK_AND_ASSIGN(
+        Platform * platform,
+        PlatformManager::PlatformWithId(cuda::kCudaPlatformId));
+    TF_ASSERT_OK_AND_ASSIGN(executor_, platform->ExecutorForDevice(0));
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+// Verifies that Create returns a valid handle and that the allocation is at
+// least as large as requested.
+TEST_F(CudaRawMemoryAllocationTest, CreateAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_NE(alloc->GetHandle(), 0u);
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+// Verifies that address().opaque() is the handle cast to void* and that
+// address().size() matches the padded allocation size.
+TEST_F(CudaRawMemoryAllocationTest, AddressReflectsHandle) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_EQ(
+      alloc->address().opaque(),
+      reinterpret_cast<void*>(static_cast<uintptr_t>(alloc->GetHandle())));
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+// Verifies that a very small request is still satisfied (padded to
+// granularity).
+TEST_F(CudaRawMemoryAllocationTest, SizeIsAtLeastRequested) {
+  TF_ASSERT_OK_AND_ASSIGN(auto alloc,
+                          CudaRawMemoryAllocation::Create(executor_, 1));
+
+  EXPECT_NE(alloc->GetHandle(), 0u);
+  EXPECT_GE(alloc->address().size(), 1u);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/memory_reservation.cc
+++ b/xla/stream_executor/memory_reservation.cc
@@ -1,0 +1,146 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/memory_reservation.h"
+
+#include <cstddef>
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "tsl/platform/errors.h"
+
+namespace stream_executor {
+
+// ScopedMapping
+
+void MemoryReservation::ScopedMapping::UnmapAndLogIfError(
+    MemoryReservation* reservation, size_t reservation_offset, size_t size) {
+  absl::Status status = reservation->UnMap(reservation_offset, size);
+  if (!status.ok()) {
+    LOG(ERROR) << "ScopedMapping: failed to unmap reservation range: "
+               << status.message();
+  }
+}
+
+MemoryReservation::ScopedMapping::ScopedMapping(MemoryReservation* reservation,
+                                                size_t reservation_offset,
+                                                size_t size)
+    : reservation_(reservation),
+      reservation_offset_(reservation_offset),
+      size_(size) {}
+
+MemoryReservation::ScopedMapping::~ScopedMapping() {
+  if (reservation_ == nullptr) {
+    return;
+  }
+  UnmapAndLogIfError(reservation_, reservation_offset_, size_);
+}
+
+MemoryReservation::ScopedMapping::ScopedMapping(ScopedMapping&& other) noexcept
+    : reservation_(other.reservation_),
+      reservation_offset_(other.reservation_offset_),
+      size_(other.size_) {
+  other.reservation_ = nullptr;
+}
+
+MemoryReservation::ScopedMapping& MemoryReservation::ScopedMapping::operator=(
+    ScopedMapping&& other) noexcept {
+  if (this != &other) {
+    if (reservation_ != nullptr) {
+      UnmapAndLogIfError(reservation_, reservation_offset_, size_);
+    }
+    reservation_ = other.reservation_;
+    reservation_offset_ = other.reservation_offset_;
+    size_ = other.size_;
+    other.reservation_ = nullptr;
+  }
+  return *this;
+}
+
+DeviceAddressBase MemoryReservation::ScopedMapping::mapped_address() const {
+  return reservation_->address().GetByteSlice(reservation_offset_, size_);
+}
+
+// MemoryReservation::MapTo
+
+absl::StatusOr<MemoryReservation::ScopedMapping> MemoryReservation::MapTo(
+    size_t reservation_offset, size_t allocation_offset, size_t size,
+    MemoryAllocation& allocation) {
+  TF_RETURN_IF_ERROR(
+      Map(reservation_offset, allocation_offset, size, allocation));
+
+  auto cleanup = absl::MakeCleanup([&] {
+    absl::Status unmap_status = UnMap(reservation_offset, size);
+    if (!unmap_status.ok()) {
+      LOG(ERROR) << "MapTo: failed to unmap after failure: "
+                 << unmap_status.message();
+    }
+  });
+
+  TF_RETURN_IF_ERROR(SetAccess(reservation_offset, size));
+
+  std::move(cleanup).Cancel();
+  return ScopedMapping(this, reservation_offset, size);
+}
+
+absl::StatusOr<MemoryReservation::ScopedMapping> MemoryReservation::MapTo(
+    absl::Span<const MappingDescriptor> mappings) {
+  if (mappings.empty()) {
+    return absl::InvalidArgumentError("MapTo: mappings must not be empty");
+  }
+
+  size_t start_offset = mappings[0].reservation_offset;
+  size_t expected_offset = start_offset;
+  for (const MappingDescriptor& desc : mappings) {
+    if (desc.reservation_offset != expected_offset) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "MapTo: mappings are not contiguous. Expected reservation_offset=%zu "
+          "but got %zu",
+          expected_offset, desc.reservation_offset));
+    }
+    expected_offset += desc.size;
+  }
+
+  size_t total_size = 0;
+
+  auto cleanup = absl::MakeCleanup([&] {
+    if (total_size > 0) {
+      absl::Status unmap_status = UnMap(start_offset, total_size);
+      if (!unmap_status.ok()) {
+        LOG(ERROR) << "MapTo: failed to unmap after failure: "
+                   << unmap_status.message();
+      }
+    }
+  });
+
+  for (const MappingDescriptor& desc : mappings) {
+    TF_RETURN_IF_ERROR(Map(desc.reservation_offset, desc.allocation_offset,
+                           desc.size, *desc.allocation));
+    total_size += desc.size;
+  }
+
+  TF_RETURN_IF_ERROR(SetAccess(start_offset, total_size));
+
+  std::move(cleanup).Cancel();
+  return ScopedMapping(this, start_offset, total_size);
+}
+
+}  // namespace stream_executor

--- a/xla/stream_executor/memory_reservation.h
+++ b/xla/stream_executor/memory_reservation.h
@@ -1,0 +1,115 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_MEMORY_RESERVATION_H_
+#define XLA_STREAM_EXECUTOR_MEMORY_RESERVATION_H_
+
+#include <cstddef>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+
+namespace stream_executor {
+
+// A MemoryReservation represents a reserved virtual address range on a
+// StreamExecutor device. The range is not backed by physical memory until
+// physical allocations are mapped into it via MapTo.
+//
+// MemoryReservation is the base class for platform-specific implementations
+// (e.g. CUDA virtual memory management via cuMemAddressReserve).
+class MemoryReservation {
+ public:
+  MemoryReservation() = default;
+  virtual ~MemoryReservation() = default;
+
+  MemoryReservation(MemoryReservation&&) = delete;
+  MemoryReservation& operator=(MemoryReservation&&) = delete;
+
+  // Returns the base address and size of the reserved virtual address range.
+  // The returned address is a valid device virtual address, but may not be
+  // accessible until physical memory is mapped via MapTo.
+  virtual DeviceAddressBase address() const = 0;
+
+  // Describes a mapping from a memory reservation range
+  // [reservation_offset, reservation_offset + size) to a physical allocation
+  // range [allocation_offset, allocation_offset + size).
+  struct MappingDescriptor {
+    size_t reservation_offset;
+    size_t allocation_offset;
+    size_t size;
+    MemoryAllocation* allocation;
+  };
+
+  // An RAII wrapper that gives access to a contiguous slice of a memory
+  // reservation backed by one or more physical memory allocations.
+  // Unmaps the mapped range from the reservation on destruction.
+  class ScopedMapping {
+   public:
+    ScopedMapping() = default;
+    ~ScopedMapping();
+
+    ScopedMapping(ScopedMapping&&) noexcept;
+    ScopedMapping& operator=(ScopedMapping&&) noexcept;
+
+    // Returns the device address range that is mapped to the physical memory
+    // allocation(s) and can be accessed from the device.
+    DeviceAddressBase mapped_address() const;
+
+   private:
+    // Unmaps the given range on the reservation and logs on failure.
+    static void UnmapAndLogIfError(MemoryReservation* reservation,
+                                   size_t reservation_offset, size_t size);
+
+    friend class MemoryReservation;
+    ScopedMapping(MemoryReservation* reservation, size_t reservation_offset,
+                  size_t size);
+
+    MemoryReservation* reservation_ = nullptr;
+    size_t reservation_offset_ = 0;
+    size_t size_ = 0;
+  };
+
+  // Maps a single physical allocation to the reservation range
+  // [reservation_offset, reservation_offset + size), backed by the allocation
+  // range [allocation_offset, allocation_offset + size). Enables device access
+  // to the mapped range before returning.
+  absl::StatusOr<ScopedMapping> MapTo(size_t reservation_offset,
+                                      size_t allocation_offset, size_t size,
+                                      MemoryAllocation& allocation);
+
+  // Maps multiple physical allocations to a contiguous memory reservation
+  // range. The descriptors must form a contiguous range in the reservation.
+  // Enables device access to the full contiguous range before returning.
+  // For non-contiguous mappings, use separate MapTo calls instead.
+  absl::StatusOr<ScopedMapping> MapTo(
+      absl::Span<const MappingDescriptor> mappings);
+
+ private:
+  virtual absl::Status Map(size_t reservation_offset, size_t allocation_offset,
+                           size_t size, MemoryAllocation& allocation) = 0;
+
+  // Enable read/write access to the reservation range specified by the offset
+  // and size.
+  virtual absl::Status SetAccess(uint64_t reservation_offset, size_t size) = 0;
+
+  virtual absl::Status UnMap(size_t reservation_offset, size_t size) = 0;
+};
+
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_MEMORY_RESERVATION_H_


### PR DESCRIPTION
  Add CUDA Virtual Memory Management RAII wrappers

  Introduces building blocks for CUDA VMM (Virtual Memory Management API):

  - MemoryReservation — new abstract base class in stream_executor representing a reserved virtual address range, with MapToAllocation, SetAccess, and UnMap as the core interface.
  - CudaRawMemoryAllocation — RAII wrapper for a physical memory handle created via cuMemCreate. The handle is not yet mapped to any virtual address; lifetime is managed automatically.
  - CudaMemoryReservation — RAII wrapper for a virtual address range reserved via cuMemAddressReserve. Supports mapping a CudaRawMemoryAllocation into a sub-range, enabling device access via cuMemSetAccess, and explicit unmapping. The destructor handles cleanup automatically.

  All classes follow the CudaEvent design pattern (static Create factory, move semantics, context activation via StreamExecutor). Unit tests are included for both CUDA classes covering creation, address invariants, move semantics, and the full map+access workflow.

