### PR TITLE
Trace through `kTranspose` and `kReshape` in `GetFusionInstructionInPlaceInputOutputPairs`

### DIFF
--- a/xla/hlo/analysis/alias_info.cc
+++ b/xla/hlo/analysis/alias_info.cc
@@ -102,9 +102,13 @@ AliasInfo::GetFusionInstructionInPlaceInputOutputPairs(
         }
       }
     }
-    // Skip bitcast
-    if (in_place_input_source != nullptr &&
-        in_place_input_source->opcode() == HloOpcode::kBitcast) {
+    // Skip zero-copy shape/layout modifiers to find the originating
+    // parameter. These ops reinterpret the same underlying buffer without
+    // creating new independent data.
+    while (in_place_input_source != nullptr &&
+           (in_place_input_source->opcode() == HloOpcode::kBitcast ||
+            in_place_input_source->opcode() == HloOpcode::kTranspose ||
+            in_place_input_source->opcode() == HloOpcode::kReshape)) {
       in_place_input_source = in_place_input_source->operand(0);
     }
     if (in_place_input_source != nullptr &&


### PR DESCRIPTION
fixes https://github.com/openxla/xla/issues/38597