### PR TITLE
[ROCm] RCCL fp8 support : Add missing ROCm version check for backward compatibility.

### DIFF
--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -87,9 +87,17 @@ static absl::StatusOr<ncclDataType_t> ToNcclDataType(
     se::RocmComputeCapability rocm_cc) {
   switch (dtype) {
     case F8E5M2:
+#if TF_ROCM_VERSION >= 70000
       return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e5m2 : ncclInt8;
+#else
+      return ncclInt8;
+#endif
     case F8E4M3FN:
+#if TF_ROCM_VERSION >= 70000
       return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e4m3 : ncclInt8;
+#else
+      return ncclInt8;
+#endif
     case S8:
     case F8E5M2FNUZ:
     case F8E4M3FNUZ:


### PR DESCRIPTION
📝 Summary of Changes
Add missing ROCm version check to ensure backward compatibility.

🎯 Justification
Previous PR https://github.com/openxla/xla/pull/38269 added fp8 support to RCCL.
However, the code was no longer compatible with ROCm versions prior to ROCm 7.0 as `ncclFloat8e5m2` and `ncclFloat8e4m3` are not declared in those older versions (resulting in compilation errors).

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix