### PR TITLE
[ROCm] Use f16 versions of functions from libdevice.

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter_parametrized_test.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter_parametrized_test.cc
@@ -1032,7 +1032,9 @@ ENTRY main {
 
   const std::string hlo_ref = R"(
 ; CHECK:      %[[P0_FUSION:.*]] = bf16[127,125]{1,0} parameter(0)
-; CHECK:      %[[REDUCE:.*]] = bf16[127]{0} reduce(%[[P0_FUSION]]
+; CHECK-PTX:      %[[REDUCE:.*]] = bf16[127]{0} reduce(%[[P0_FUSION]]
+; CHECK-GCN:      %[[CONVERT:.*]] = f32[127,125]{1,0} convert(%[[P0_FUSION]]
+; CHECK-GCN:      %[[REDUCE:.*]] = f32[127]{0} reduce(%[[CONVERT]]
 ; CHECK:    ENTRY
 ; CHECK:      %[[P0_ENTRY:.*]] = bf16[127,125]{1,0} parameter(0)
 ; CHECK:      ROOT

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_math_to_libdevice.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_math_to_libdevice.cc
@@ -193,7 +193,8 @@ class ConvertToLibdevice : public mlir::OpRewritePattern<OpTy> {
     mlir::ImplicitLocOpBuilder builder(op->getLoc(), rewriter);
 
     llvm::SmallVector<Value, 2> casted_inputs;
-    if (output_type_is_16bit_float) {
+    if (output_type_is_16bit_float &&
+        !::xla::gpu::HasF16Implementation(OpInfo<OpTy>::kFunctionID, triple_)) {
       // Upcast the inputs to F32.
       for (auto operand : op->getOperands()) {
         Type f32_type = rewriter.getF32Type();
@@ -220,7 +221,8 @@ class ConvertToLibdevice : public mlir::OpRewritePattern<OpTy> {
       original_output_type = shaped_type.clone(output_type);
     }
 
-    if (res.getType() != original_output_type) {
+    if (res.getType() != original_output_type &&
+        !::xla::gpu::HasF16Implementation(OpInfo<OpTy>::kFunctionID, triple_)) {
       // Downcast back to the original output type.
       res = arith::TruncFOp::create(builder, op.getLoc(), original_output_type,
                                     res);

--- a/xla/service/gpu/target_util.cc
+++ b/xla/service/gpu/target_util.cc
@@ -360,6 +360,34 @@ std::optional<TargetDeviceFunctionID> GetTargetDeviceFunctionID(HloOpcode op) {
   return std::nullopt;
 }
 
+bool HasF16Implementation(TargetDeviceFunctionID func_id,
+                          llvm::Triple target_triple) {
+  return target_triple.isAMDGPU() &&
+         (func_id == TargetDeviceFunctionID::kAtan2 ||
+          func_id == TargetDeviceFunctionID::kCbrt ||
+          func_id == TargetDeviceFunctionID::kCos ||
+          func_id == TargetDeviceFunctionID::kExp ||
+          func_id == TargetDeviceFunctionID::kExpm1 ||
+          func_id == TargetDeviceFunctionID::kFmod ||
+          func_id == TargetDeviceFunctionID::kHypot ||
+          func_id == TargetDeviceFunctionID::kLog ||
+          func_id == TargetDeviceFunctionID::kLog1p ||
+          func_id == TargetDeviceFunctionID::kPow ||
+          func_id == TargetDeviceFunctionID::kRsqrt ||
+          func_id == TargetDeviceFunctionID::kSin ||
+          func_id == TargetDeviceFunctionID::kSqrt ||
+          func_id == TargetDeviceFunctionID::kTan ||
+          func_id == TargetDeviceFunctionID::kTanh ||
+          func_id == TargetDeviceFunctionID::kErf ||
+          func_id == TargetDeviceFunctionID::kAcosh ||
+          func_id == TargetDeviceFunctionID::kAcos ||
+          func_id == TargetDeviceFunctionID::kSinh ||
+          func_id == TargetDeviceFunctionID::kAsin ||
+          func_id == TargetDeviceFunctionID::kAsinh ||
+          func_id == TargetDeviceFunctionID::kCosh ||
+          func_id == TargetDeviceFunctionID::kAtanh);
+}
+
 namespace {
 // TODO(b/370452608): Add more functions that have a fast approximation for f32
 // that we can use for f16 types.
@@ -397,6 +425,10 @@ std::string ObtainDeviceFunctionName(TargetDeviceFunctionID func_id,
   } else if (target_triple.getArch() == llvm::Triple::amdgcn) {
     // TODO(b/370452608): Are there approximate functions we can use for BF16
     // and F16 types?
+    if (output_type == F16 && HasF16Implementation(func_id, target_triple)) {
+      // All these functions have f16 implementation - no need for conversion
+      return StrCat(gpu_root_names.amdgpu_root, "_f16");
+    }
     if (output_type == BF16 || output_type == F16 || output_type == F32) {
       return StrCat(gpu_root_names.amdgpu_root, "_f32");
     } else if (output_type == F64) {

--- a/xla/service/gpu/target_util.h
+++ b/xla/service/gpu/target_util.h
@@ -107,6 +107,8 @@ std::string ObtainDeviceFunctionName(TargetDeviceFunctionID func_id,
                                      PrimitiveType output_type,
                                      llvm::Triple target_triple);
 
+bool HasF16Implementation(TargetDeviceFunctionID func_id,
+                          llvm::Triple target_triple);
 }  // namespace gpu
 }  // namespace xla
 


### PR DESCRIPTION
       Fix fusion_emitter_parametrized_test.

📝 Summary of Changes
Use f16 versions of functions from libdevice in order to avoid unnecessary conversions

🎯 Justification
Precision loss because of unnecessary conversions

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, , 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
fusion_emitter_parametrized_test is fixed 

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
