### PR TITLE
Broaden metadata propagation in ReplaceInstructionWithDifferentShape

### DIFF
--- a/xla/hlo/ir/hlo_computation.cc
+++ b/xla/hlo/ir/hlo_computation.cc
@@ -1778,10 +1778,24 @@ absl::StatusOr<bool> HloComputation::ReplaceInstructionWithDifferentShape(
   // function, and that they would be correlated to the same TF op. This might
   // not always be correct since HLO optimizations can cross TF op boundaries.
   // But still this seems to be better than nothing.
-  bool overwrite_op_name = new_instruction->metadata().op_name().empty() &&
-                           !old_instruction->metadata().op_name().empty();
-  if (overwrite_op_name) {
-    new_instruction->set_metadata(old_instruction->metadata());
+  //
+  // We propagate metadata when the new instruction has no meaningful metadata
+  // and the old instruction does. This covers op_name as well as other
+  // provenance fields (op_type, source_file, source_line) that may be set
+  // independently of op_name (e.g. by frontends that populate source
+  // locations but not op names).
+  const auto& old_md = old_instruction->metadata();
+  const auto& new_md = new_instruction->metadata();
+  bool new_has_no_metadata = new_md.op_name().empty() &&
+                             new_md.op_type().empty() &&
+                             new_md.source_file().empty() &&
+                             new_md.source_line() == 0;
+  bool old_has_metadata = !old_md.op_name().empty() ||
+                          !old_md.op_type().empty() ||
+                          !old_md.source_file().empty() ||
+                          old_md.source_line() != 0;
+  if (new_has_no_metadata && old_has_metadata) {
+    new_instruction->set_metadata(old_md);
   }
   if (preserve_frontend_attributes &&
       new_instruction->frontend_attributes().map().empty()) {

--- a/xla/hlo/ir/hlo_computation_test.cc
+++ b/xla/hlo/ir/hlo_computation_test.cc
@@ -213,5 +213,41 @@ ENTRY entry {
   EXPECT_EQ(mul_int->caller_computations().size(), 1);
   EXPECT_TRUE(mul_int->caller_computations().contains(entry));
 }
+TEST_F(HLOComputationTest, ReplaceInstructionPropagatesMetadataWithoutOpName) {
+  // Verify that metadata is propagated when the old instruction has
+  // source_file but no op_name.
+  auto builder = HloComputation::Builder("test");
+  auto p0 = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, ShapeUtil::MakeShape(F32, {4}), "p0"));
+  auto p1 = builder.AddInstruction(
+      HloInstruction::CreateParameter(1, ShapeUtil::MakeShape(F32, {4}), "p1"));
+  auto add = builder.AddInstruction(HloInstruction::CreateBinary(
+      ShapeUtil::MakeShape(F32, {4}), HloOpcode::kAdd, p0, p1));
+
+  // Set metadata with source_file but no op_name.
+  OpMetadata metadata;
+  metadata.set_source_file("test.py");
+  metadata.set_source_line(42);
+  add->set_metadata(metadata);
+
+  auto module = CreateNewVerifiedModule();
+  auto computation = module->AddEntryComputation(builder.Build());
+
+  // Replace add with multiply (no metadata on the new instruction).
+  auto new_mul = HloInstruction::CreateBinary(
+      ShapeUtil::MakeShape(F32, {4}), HloOpcode::kMultiply, p0, p1);
+  EXPECT_TRUE(new_mul->metadata().source_file().empty());
+
+  EXPECT_EQ(
+      computation->ReplaceWithNewInstruction(add, std::move(new_mul)),
+      absl::OkStatus());
+
+  // The new instruction should have inherited the metadata.
+  auto* root = computation->root_instruction();
+  EXPECT_EQ(root->opcode(), HloOpcode::kMultiply);
+  EXPECT_EQ(root->metadata().source_file(), "test.py");
+  EXPECT_EQ(root->metadata().source_line(), 42);
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -13573,5 +13573,26 @@ TEST_F(AlgebraicSimplifierTest, HoistTransposeOfReshapeLayoutSensitive) {
   EXPECT_FALSE(simplifier.Run(m.get()).value());
 }
 
+TEST_F(AlgebraicSimplifierTest, MetadataPreservedThroughPowerSimplification) {
+  // pow(A, 2) => A*A should preserve metadata (source_file, etc.)
+  // even when op_name is empty.
+  const char* hlo_string = R"(
+    HloModule m
+    ENTRY test {
+      p0 = f32[4] parameter(0)
+      c = f32[] constant(2)
+      b = f32[4] broadcast(c), dimensions={}
+      ROOT pow = f32[4] power(p0, b), metadata={source_file="test.py" source_line=10}
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  // pow(A,2) should become multiply(A,A)
+  auto* root = m->entry_computation()->root_instruction();
+  EXPECT_EQ(root->opcode(), HloOpcode::kMultiply);
+  EXPECT_EQ(root->metadata().source_file(), "test.py");
+  EXPECT_EQ(root->metadata().source_line(), 10);
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
HloComputation::ReplaceInstructionWithDifferentShape only propagates metadata from the old instruction to the new one when op_name is non-empty. This change broadens the condition to check all four provenance fields: op_name, op_type, source_file, and source_line. Metadata is propagated whenever the old instruction has any of these set and the new instruction has none.

🎯 Justification
Judging by the comments in `ir/hlo_computation.cc`, the status-quo for metadata propogation appears to be TensorFlow specific, where op_name must serve as a good indicator of whether an instruction carried meaningful provenance metadata. Other frontends may populate source_file, source_line, or op_type without setting op_name, causing optimization passes like AlgebraicSimplifier to silently drop this metadata.

On a real-world Qwen2-0.5B model (~3500 input ops), a single algebraic simplification pass drops metadata on ~28% of ops without the fix, vs ~9% with it. Across the full CPU optimization pipeline, the fix preserves metadata on ~1200 additional ops (60% coverage vs 45%).

🚀 Kind of Contribution
Bug Fix

🧪 Unit Tests
- HLOComputationTest.ReplaceInstructionPropagatesMetadataWithoutOpName — directly tests that ReplaceWithNewInstruction 
propagates metadata when op_name is empty but source_file is set on the old instruction.
- AlgebraicSimplifierTest.MetadataPreservedThroughPowerSimplification — tests that pow(A, 2) → A * A simplification 
preserves source_file and source_line metadata through the transformation.

Both the full hlo_computation_test and algebraic_simplifier_test suites pass without modification.

🧪 Execution Tests

N/A 