### PR TITLE
[xla:gpu] Add AsyncExecution library to manage execution of async thunks

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -346,6 +346,53 @@ cc_library(
 #===-------------------------------------------------------------------------------------------===//
 
 cc_library(
+    name = "async_execution",
+    srcs = ["async_execution.cc"],
+    hdrs = ["async_execution.h"],
+    deps = [
+        ":thunk",
+        ":thunk_id",
+        "//xla:executable_run_options",
+        "//xla:util",
+        "//xla/runtime:object_pool",
+        "//xla/stream_executor:event",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:status_macros",
+        "//xla/tsl/util:unique_any",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+xla_test(
+    name = "async_execution_test",
+    srcs = ["async_execution_test.cc"],
+    backends = ["gpu"],
+    deps = [
+        ":async_execution",
+        ":thunk",
+        ":thunk_id",
+        "//xla:executable_run_options",
+        "//xla/service:platform_util",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "dynamic_slice_thunk",
     srcs = ["dynamic_slice_thunk.cc"],
     hdrs = ["dynamic_slice_thunk.h"],

--- a/xla/backends/gpu/runtime/async_execution.cc
+++ b/xla/backends/gpu/runtime/async_execution.cc
@@ -1,0 +1,122 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/async_execution.h"
+
+#include <memory>
+#include <utility>
+
+#include "absl/log/check.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/thunk_id.h"
+#include "xla/executable_run_options.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/tsl/util/unique_any.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+AsyncExecution::AsyncExecution(const Thunk* start_thunk)
+    : start_thunk_(start_thunk) {}
+
+AsyncExecution::ExecutionGuard::ExecutionGuard(se::Event* event,
+                                               se::Stream* async_stream)
+    : event_(event), async_stream_(async_stream) {}
+
+AsyncExecution::ExecutionGuard::~ExecutionGuard() {
+  // If we fail to record completion event on a stream it is unsafe to continue
+  // as the following computations might not see all the updates done by the
+  // async execution.
+  CHECK_OK(async_stream_->RecordEvent(event_))  // Crash OK
+      << "Failed to record async execution completion event " << event_
+      << " on a stream " << async_stream_;
+}
+
+AsyncExecution::EventPool& AsyncExecution::GetOrCreatePool(
+    se::StreamExecutor* executor) {
+  absl::MutexLock lock(&mu_);
+  auto [it, _] = event_pools_.try_emplace(
+      executor, [executor] { return executor->CreateEvent(); });
+  return it->second;
+}
+
+absl::Status AsyncExecution::Initialize(Thunk::ExecutionScopedState* state,
+                                        se::StreamExecutor* executor) {
+  XLA_VLOG_DEVICE(1, executor->device_ordinal())
+      << absl::StreamFormat("Initialize async execution for `%s`",
+                            start_thunk_->profile_annotation());
+  EventPool& pool = GetOrCreatePool(executor);
+  ASSIGN_OR_RETURN(auto borrowed, pool.GetOrCreate());
+  auto [_, emplaced] = state->try_emplace(
+      start_thunk_->thunk_info().thunk_id,
+      std::in_place_type<EventPool::BorrowedObject>, std::move(borrowed));
+  return emplaced ? absl::OkStatus()
+                  : Internal("Async execution initialized multiple times");
+}
+
+static absl::StatusOr<se::Event*> GetEvent(Thunk::ExecutionScopedState* state,
+                                           ThunkId thunk_id) {
+  auto it = state->find(thunk_id);
+  if (it == state->end()) {
+    return Internal("Async execution event not found for thunk %v", thunk_id);
+  }
+  auto* borrowed =
+      tsl::any_cast<AsyncExecution::EventPool::BorrowedObject>(&it->second);
+  if (!borrowed) {
+    return Internal("Async execution state has wrong type for thunk %v",
+                    thunk_id);
+  }
+  return (*borrowed)->get();
+}
+
+absl::StatusOr<AsyncExecution::ExecutionGuard> AsyncExecution::Start(
+    RunId run_id, Thunk::ExecutionScopedState* state, se::Stream* stream,
+    se::Stream* async_stream) {
+  XLA_VLOG_DEVICE(1, stream->parent()->device_ordinal()) << absl::StreamFormat(
+      "Start async execution for `%s`: run_id=%v; stream=%p, async_stream=%p",
+      start_thunk_->profile_annotation(), run_id, stream, async_stream);
+  ASSIGN_OR_RETURN(se::Event * event,
+                   GetEvent(state, start_thunk_->thunk_info().thunk_id));
+
+  // Record an event on stream and wait for it on async_stream so that
+  // operations launched on `async_stream` observe all prior operations on
+  // `stream`.
+  RETURN_IF_ERROR(stream->RecordEvent(event));
+  RETURN_IF_ERROR(async_stream->WaitFor(event));
+
+  return ExecutionGuard(event, async_stream);
+}
+
+absl::Status AsyncExecution::Done(Thunk::ExecutionScopedState* state,
+                                  se::Stream* stream) {
+  XLA_VLOG_DEVICE(1, stream->parent()->device_ordinal())
+      << absl::StreamFormat("Done async execution for `%s`: stream=%p",
+                            start_thunk_->profile_annotation(), stream);
+  ASSIGN_OR_RETURN(se::Event * event,
+                   GetEvent(state, start_thunk_->thunk_info().thunk_id));
+
+  // Wait for the async operation to complete by waiting for the event that was
+  // recorded by the ExecutionGuard destructor at the end of Start.
+  return stream->WaitFor(event);
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/async_execution.h
+++ b/xla/backends/gpu/runtime/async_execution.h
@@ -1,0 +1,124 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_ASYNC_EXECUTION_H_
+#define XLA_BACKENDS_GPU_RUNTIME_ASYNC_EXECUTION_H_
+
+#include <memory>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/container/node_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/executable_run_options.h"
+#include "xla/runtime/object_pool.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla::gpu {
+
+// AsyncExecution is a helper class to manage async execution of XLA thunks.
+//
+// XLA has several asynchronous operations (mostly communication operations,
+// however it also supports asynchronous computations) that are decomposed into
+// a pair of start and done operations:
+//
+// Example: asynchronous all reduce
+//
+//   %start = all-reduce-start(...), stream_id=comm-stream
+//   ... compute kernels launched on compute stream
+//   %done = all-reduce-done(%start)
+//
+// `%start` operation launches an all-reduce on a dedicated communication
+// stream, and `%done` operation synchronizes it with a compute stream. By
+// decomposing operation into start/done pairs XLA makes them "asynchronous" in
+// a sense that they can run concurrently with the "main" compute stream.
+//
+// Simply synchronizing compute stream with a communication stream is not going
+// to work, because it can create false dependencies between multiple async
+// operations:
+//
+//   %start0 = all-reduce-start(...), stream_id=comm-stream
+//   %start1 = all-reduce-start(...), stream_id=comm-stream
+//   ... compute kernels launched on compute stream
+//   %done0 = all-reduce-done(%start0)
+//   %done1 = all-reduce-done(%start1)
+//
+// If `all-reduce-done` would simply synchronize compute stream with
+// `comm-stream` it would create a false dependency between two unrelated all
+// reduce operations.
+//
+// Async execution scope is always started by a `start` Thunk, and start thunk
+// id is used throughout the runtime as async execution id.
+class AsyncExecution {
+ public:
+  using EventPool = ObjectPool<std::unique_ptr<se::Event>>;
+
+  // We need to know the thunk that starts an async execution, as we use its id
+  // as a key in the execution scoped state and its profile annotation for
+  // logging.
+  explicit AsyncExecution(const Thunk* start_thunk);
+
+  // An RAII guard that automatically records an event on a given async stream
+  // when it goes out of scope.
+  class ExecutionGuard {
+   public:
+    ~ExecutionGuard();
+
+   private:
+    friend class AsyncExecution;
+    ExecutionGuard(se::Event* event, se::Stream* async_stream);
+    se::Event* event_;          // owned by ExecutionScopedState
+    se::Stream* async_stream_;  // owned by GpuExecutable
+  };
+
+  // Initializes async execution state on the given executor. Borrows an event
+  // from the pool (creating one if needed) and stores it in the execution
+  // scoped state. When the state is destroyed, the event is returned to the
+  // pool.
+  absl::Status Initialize(Thunk::ExecutionScopedState* state,
+                          se::StreamExecutor* executor);
+
+  // Starts an async execution on `async_stream`: creates a dependency from
+  // `stream` to `async_stream` which guarantees that async operations launched
+  // on `async_stream` will observe all prior operations launched on `stream`.
+  // Start can be called at most once. Before the next Start can be called,
+  // the async execution has to be completed with Done.
+  absl::StatusOr<ExecutionGuard> Start(RunId run_id,
+                                       Thunk::ExecutionScopedState* state,
+                                       se::Stream* stream,
+                                       se::Stream* async_stream);
+
+  // Completes an async execution on `stream` by synchronizing with the event
+  // recorded by the corresponding Start call.
+  absl::Status Done(Thunk::ExecutionScopedState* state, se::Stream* stream);
+
+ private:
+  // Returns or creates an event pool for the given executor.
+  EventPool& GetOrCreatePool(se::StreamExecutor* executor);
+
+  const Thunk* start_thunk_;
+
+  absl::Mutex mu_;
+  absl::node_hash_map<se::StreamExecutor*, EventPool> event_pools_
+      ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_ASYNC_EXECUTION_H_

--- a/xla/backends/gpu/runtime/async_execution_test.cc
+++ b/xla/backends/gpu/runtime/async_execution_test.cc
@@ -1,0 +1,120 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/async_execution.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/status/statusor.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/thunk_id.h"
+#include "xla/executable_run_options.h"
+#include "xla/service/platform_util.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
+
+namespace xla::gpu {
+namespace {
+
+// A minimal thunk for testing AsyncExecution.
+class TestThunk : public Thunk {
+ public:
+  explicit TestThunk(Thunk::ThunkInfo thunk_info)
+      : Thunk(Thunk::kAllReduce, std::move(thunk_info)) {}
+  absl::Status ExecuteOnStream(const ExecuteParams&) override {
+    return absl::OkStatus();
+  }
+};
+
+static absl::StatusOr<se::StreamExecutor*> CreateExecutor() {
+  ASSIGN_OR_RETURN(std::string platform_name,
+                   xla::PlatformUtil::CanonicalPlatformName("gpu"));
+  ASSIGN_OR_RETURN(se::Platform * platform,
+                   se::PlatformManager::PlatformWithName(platform_name));
+  return platform->ExecutorForDevice(0);
+}
+
+TEST(AsyncExecutionTest, InitializeStartDone) {
+  ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor, CreateExecutor());
+
+  ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  ASSERT_OK_AND_ASSIGN(auto async_stream, executor->CreateStream());
+
+  Thunk::ThunkInfo thunk_info;
+  thunk_info.thunk_id = ThunkId(1);
+  thunk_info.profile_annotation = "test-thunk";
+  TestThunk thunk(thunk_info);
+
+  AsyncExecution async_execution(&thunk);
+  Thunk::ExecutionScopedState state;
+
+  // Initialize creates an event in the execution scoped state.
+  ASSERT_OK(async_execution.Initialize(&state, executor));
+
+  {  // Start creates a dependency from stream to async_stream.
+    ASSERT_OK_AND_ASSIGN(auto guard,
+                         async_execution.Start(RunId(0), &state, stream.get(),
+                                               async_stream.get()));
+  }  // ExecutionGuard destructor records the completion event on async_stream.
+
+  // Done waits for the event recorded by the guard.
+  ASSERT_OK(async_execution.Done(&state, stream.get()));
+}
+
+TEST(AsyncExecutionTest, DoneWithoutStartFails) {
+  ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor, CreateExecutor());
+
+  ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+
+  Thunk::ThunkInfo thunk_info;
+  thunk_info.thunk_id = ThunkId(1);
+  thunk_info.profile_annotation = "test-thunk";
+  TestThunk thunk(thunk_info);
+
+  AsyncExecution async_execution(&thunk);
+  Thunk::ExecutionScopedState state;
+
+  // Done without Initialize should fail because event is not in state.
+  EXPECT_THAT(async_execution.Done(&state, stream.get()),
+              absl_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST(AsyncExecutionTest, DoubleInitializeFails) {
+  ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor, CreateExecutor());
+
+  Thunk::ThunkInfo thunk_info;
+  thunk_info.thunk_id = ThunkId(1);
+  thunk_info.profile_annotation = "test-thunk";
+  TestThunk thunk(thunk_info);
+
+  AsyncExecution async_execution(&thunk);
+  Thunk::ExecutionScopedState state;
+
+  ASSERT_OK(async_execution.Initialize(&state, executor));
+  EXPECT_THAT(async_execution.Initialize(&state, executor),
+              absl_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
`CollectiveThunk::AsyncEvents` has a serious bug, it doesn't distinguish different XLA executions and if XLA programs happens to run multiple instances in parallel, then the completion events will be mixed up an lead to incorrect results.

Extract `AsyncExecution` library that correctly puts events into `ExecutionScopedState` and update all users. This library can be used for all other async executions in XLA, i.e. for async custom calls and async computations.

Instead of passing async events (async execution) to constructor, every thunk that starts an async execution creates `AsyncExecution` object (if it's not sync). Corresponding `Done` thunks access `AsyncExecution` object from the start thunk.

During serialization we detect async thunks by presence of async id, and use a map to connect start and done operations together.

Everything except `async_execution.{h,cc}` is a mechanical rename of `async_event` to `async_execution`.