### PR TITLE
[ROCm] Support hipblaslt group-gemm 1/4

### DIFF
--- a/xla/backends/gpu/transforms/gemm_fusion.cc
+++ b/xla/backends/gpu/transforms/gemm_fusion.cc
@@ -877,6 +877,16 @@ class GemmFusionVisitor : public DfsHloRewriteVisitor {
   }
 
   absl::Status HandleRaggedDot(HloInstruction* ragged_dot) override {
+    auto module = ragged_dot->GetModule();
+    const bool has_grouped_gemm =
+        module->config()
+            .debug_options()
+            .xla_gpu_experimental_use_ragged_dot_grouped_gemm() &&
+        module->config().debug_options().xla_gpu_enable_cublaslt();
+    if (has_grouped_gemm) {
+      return absl::OkStatus();
+    }
+
     HloComputation::Builder builder(
         absl::StrCat("ragged_fusion_", ragged_dot->name(), "_computation"));
 
@@ -891,9 +901,8 @@ class GemmFusionVisitor : public DfsHloRewriteVisitor {
         ragged_dot->CloneWithNewOperands(ragged_dot->shape(), new_operands));
 
     HloComputation* computation =
-        ragged_dot->GetModule()->AddComputationAndUnifyNamesAndIds(
-            builder.Build(),
-            /*is_entry=*/false);
+        module->AddComputationAndUnifyNamesAndIds(builder.Build(),
+                                                  /*is_entry=*/false);
     HloInstruction* dot_fusion = ragged_dot->parent()->AddInstruction(
         HloInstruction::CreateFusion(computation->root_instruction()->shape(),
                                      HloInstruction::FusionKind::kCustom,

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -480,6 +480,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_experimental_use_raft_select_k(false);
   opts.set_xla_early_exit_with_layouts(false);
   opts.set_xla_gpu_experimental_all_fusions_with_triton(false);
+  opts.set_xla_gpu_experimental_use_ragged_dot_grouped_gemm(true);
 
   opts.set_xla_cpu_collective_call_warn_stuck_seconds(20);
   opts.set_xla_cpu_collective_call_terminate_timeout_seconds(40);
@@ -2807,6 +2808,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_experimental_ragged_all_to_all_use_barrier(),
       "If true, use the MultiGpuBarrierKernel in one-shot RaggedAllToAll "
       "thunk."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_use_ragged_dot_grouped_gemm",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_experimental_use_ragged_dot_grouped_gemm),
+      debug_options->xla_gpu_experimental_use_ragged_dot_grouped_gemm(),
+      "If true, use grouped GEMM (hipBLASLt) for ragged dot operations."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_scaled_dot_with_triton",
       bool_setter_for(

--- a/xla/hlo/transforms/expanders/ragged_dot_rewriter.cc
+++ b/xla/hlo/transforms/expanders/ragged_dot_rewriter.cc
@@ -354,9 +354,10 @@ bool IsBF16Operation(const HloInstruction* ragged_dot) {
          (ragged_dot->operand(1)->shape().element_type() == BF16);
 }
 
-bool CanBeHandledByCublasltGroupGemm(
+bool CanBeHandledByGpublasltGroupGemm(
     const se::GpuComputeCapability& gpu_compute_capability,
     const HloInstruction* instruction) {
+  // Currently only Hipblaslt supports GroupGemm.
   // The current status of  Hipblaslt support for GroupGemm is as follows:
   // For MI300 targets (gfx942) : datatype supported FP16 and BF16
   // For MI350/355 targets (gfx950) : datatype supported FP16 only
@@ -400,9 +401,9 @@ absl::StatusOr<bool> RaggedDotRewriter::RunImpl(
     for (auto* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kRaggedDot) {
         if (!(has_grouped_gemm && gpu_compute_capability_.has_value() &&
-              CanBeHandledByCublasltGroupGemm(gpu_compute_capability_.value(),
-                                              instruction))) {
-          // Only ragged-dot that cannot be lowered through cublatLt GroupGemm
+              CanBeHandledByGpublasltGroupGemm(gpu_compute_capability_.value(),
+                                               instruction))) {
+          // Only ragged-dot that cannot be lowered through Gpublaslt GroupGemm
           // are added to the list of operations to rewrite in regular dot.
           ragged_dots.push_back(Cast<HloRaggedDotInstruction>(instruction));
         }

--- a/xla/hlo/transforms/expanders/ragged_dot_rewriter.cc
+++ b/xla/hlo/transforms/expanders/ragged_dot_rewriter.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <iterator>
 #include <memory>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
@@ -43,6 +44,8 @@ limitations under the License.
 #include "xla/xla_data.pb.h"
 
 namespace xla {
+
+namespace se = ::stream_executor;
 
 namespace {
 
@@ -339,11 +342,51 @@ absl::StatusOr<std::unique_ptr<HloInstruction>> RaggedToGeneral(
                                    ragged_dot->precision_config());
 }
 
+bool IsFP16Operation(const HloInstruction* ragged_dot) {
+  return (ragged_dot->shape().element_type() == F16) &&
+         (ragged_dot->operand(0)->shape().element_type() == F16) &&
+         (ragged_dot->operand(1)->shape().element_type() == F16);
+}
+
+bool IsBF16Operation(const HloInstruction* ragged_dot) {
+  return (ragged_dot->shape().element_type() == BF16) &&
+         (ragged_dot->operand(0)->shape().element_type() == BF16) &&
+         (ragged_dot->operand(1)->shape().element_type() == BF16);
+}
+
+bool CanBeHandledByCublasltGroupGemm(
+    const se::GpuComputeCapability& gpu_compute_capability,
+    const HloInstruction* instruction) {
+  // The current status of  Hipblaslt support for GroupGemm is as follows:
+  // For MI300 targets (gfx942) : datatype supported FP16 and BF16
+  // For MI350/355 targets (gfx950) : datatype supported FP16 only
+
+  if (const auto* rocm_cc = gpu_compute_capability.rocm_compute_capability()) {
+    const std::string& gfx_version = rocm_cc->gfx_version();
+    VLOG(2) << "RaggedDotRewriter running on ROCm device: " << gfx_version;
+
+    if (gfx_version == "gfx942" &&
+        (IsFP16Operation(instruction) || IsBF16Operation(instruction))) {
+      return true;
+    }
+
+    if (gfx_version == "gfx950" && IsFP16Operation(instruction)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 absl::StatusOr<bool> RaggedDotRewriter::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  const bool has_grouped_gemm =
+      module->config()
+          .debug_options()
+          .xla_gpu_experimental_use_ragged_dot_grouped_gemm() &&
+      module->config().debug_options().xla_gpu_enable_cublaslt();
   if (module->config()
           .debug_options()
           .xla_gpu_experimental_use_ragged_dot_fusion()) {
@@ -356,7 +399,13 @@ absl::StatusOr<bool> RaggedDotRewriter::RunImpl(
        module->MakeNonfusionComputations(execution_threads)) {
     for (auto* instruction : computation->instructions()) {
       if (instruction->opcode() == HloOpcode::kRaggedDot) {
-        ragged_dots.push_back(Cast<HloRaggedDotInstruction>(instruction));
+        if (!(has_grouped_gemm && gpu_compute_capability_.has_value() &&
+              CanBeHandledByCublasltGroupGemm(gpu_compute_capability_.value(),
+                                              instruction))) {
+          // Only ragged-dot that cannot be lowered through cublatLt GroupGemm
+          // are added to the list of operations to rewrite in regular dot.
+          ragged_dots.push_back(Cast<HloRaggedDotInstruction>(instruction));
+        }
       }
     }
   }

--- a/xla/hlo/transforms/expanders/ragged_dot_rewriter.h
+++ b/xla/hlo/transforms/expanders/ragged_dot_rewriter.h
@@ -21,18 +21,25 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/pass/hlo_pass_interface.h"
+#include "xla/stream_executor/device_description.h"
 
 namespace xla {
 
 // RaggedDotRewriter converts ragged dots to general dots through expansion.
 class RaggedDotRewriter : public HloModulePass {
  public:
+  explicit RaggedDotRewriter(se::GpuComputeCapability gpu_compute_capability)
+      : gpu_compute_capability_(gpu_compute_capability) {}
+
   absl::string_view name() const override { return "ragged_dot_rewriter"; }
 
  protected:
   absl::StatusOr<bool> RunImpl(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  std::optional<stream_executor::GpuComputeCapability> gpu_compute_capability_;
 };
 
 }  // namespace xla

--- a/xla/hlo/transforms/expanders/ragged_dot_rewriter_test.cc
+++ b/xla/hlo/transforms/expanders/ragged_dot_rewriter_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/utils/hlo_matchers.h"
+#include "xla/stream_executor/device_description.h"
 #include "xla/tsl/platform/statusor.h"
 
 namespace xla {
@@ -31,7 +32,16 @@ namespace {
 
 namespace op = ::xla::testing::opcode_matchers;
 
-using RaggedDotRewriterTest = HloHardwareIndependentTestBase;
+class RaggedDotRewriterTest : public HloHardwareIndependentTestBase {
+ protected:
+  se::GpuComputeCapability GetCudaComputeCapability() {
+    return se::CudaComputeCapability{se::CudaComputeCapability::kAmpere, 0};
+  }
+
+  se::GpuComputeCapability GetRocmComputeCapability() {
+    return se::GpuComputeCapability(se::RocmComputeCapability{"gfx942"});
+  }
+};
 
 TEST_F(RaggedDotRewriterTest, DontDoAnythingIfNoRaggedDot) {
   absl::string_view module_string = R"(
@@ -48,7 +58,9 @@ TEST_F(RaggedDotRewriterTest, DontDoAnythingIfNoRaggedDot) {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, RaggedDotRewriter().Run(module.get()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
   EXPECT_FALSE(changed);
 }
 
@@ -70,8 +82,84 @@ TEST_F(RaggedDotRewriterTest, DontRewriteIfUsingRaggedDotFusion) {
   module->mutable_config()
       .mutable_debug_options()
       .set_xla_gpu_experimental_use_ragged_dot_fusion(true);
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, RaggedDotRewriter().Run(module.get()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetRocmComputeCapability()).Run(module.get()));
   EXPECT_FALSE(changed);
+}
+
+TEST_F(RaggedDotRewriterTest, DontRewriteIfUsingRaggedDotGroupedGemm) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    p0 = bf16[64,9]{1,0} parameter(0)
+    p1 = bf16[2,9,8]{2,1,0} parameter(1)
+    p2 = s64[2]{0} parameter(2)
+    ROOT ragged-dot = bf16[64,8]{1,0} ragged-dot(p0, p1, p2),
+                      lhs_contracting_dims={1}, rhs_contracting_dims={1},
+                      lhs_ragged_dims={0}, rhs_group_dims={0}
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(module_string));
+  auto& debug_option = module->mutable_config().mutable_debug_options();
+  debug_option.set_xla_gpu_experimental_use_ragged_dot_grouped_gemm(true);
+  debug_option.set_xla_gpu_enable_cublaslt(true);
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetRocmComputeCapability()).Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(RaggedDotRewriterTest,
+       RewriteIfUsingRaggedDotGroupedGemmAndUnsupportedDatatype) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    p0 = f32[64,9]{1,0} parameter(0)
+    p1 = f32[2,9,8]{2,1,0} parameter(1)
+    p2 = s64[2]{0} parameter(2)
+    ROOT ragged-dot = f32[64,8]{1,0} ragged-dot(p0, p1, p2),
+                      lhs_contracting_dims={1}, rhs_contracting_dims={1},
+                      lhs_ragged_dims={0}, rhs_group_dims={0}
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(module_string));
+  auto& debug_option = module->mutable_config().mutable_debug_options();
+  debug_option.set_xla_gpu_experimental_use_ragged_dot_grouped_gemm(true);
+  debug_option.set_xla_gpu_enable_cublaslt(true);
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetRocmComputeCapability()).Run(module.get()));
+  EXPECT_TRUE(changed);
+}
+
+TEST_F(RaggedDotRewriterTest,
+       RewriteIfUsingRaggedDotGroupedGemmWithCudaComputeCapability) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    p0 = bf16[64,9]{1,0} parameter(0)
+    p1 = bf16[2,9,8]{2,1,0} parameter(1)
+    p2 = s64[2]{0} parameter(2)
+    ROOT ragged-dot = bf16[64,8]{1,0} ragged-dot(p0, p1, p2),
+                      lhs_contracting_dims={1}, rhs_contracting_dims={1},
+                      lhs_ragged_dims={0}, rhs_group_dims={0}
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(module_string));
+  auto& debug_option = module->mutable_config().mutable_debug_options();
+  debug_option.set_xla_gpu_experimental_use_ragged_dot_grouped_gemm(true);
+  debug_option.set_xla_gpu_enable_cublaslt(true);
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
+  EXPECT_TRUE(changed);
 }
 
 TEST_F(RaggedDotRewriterTest, RaggedNonContracting) {
@@ -89,11 +177,14 @@ TEST_F(RaggedDotRewriterTest, RaggedNonContracting) {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, RaggedDotRewriter().Run(module.get()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Dot(op::Select(), op::Parameter()));
-  RunAndFilecheckHloRewrite(module_string, RaggedDotRewriter(), R"(
+  RunAndFilecheckHloRewrite(module_string,
+                            RaggedDotRewriter(GetCudaComputeCapability()), R"(
   // CHECK: ROOT [[dot:%[^ ]+]] = bf16[64,8]{1,0}
   // CHECK-SAME: lhs_contracting_dims={0,2}, rhs_contracting_dims={0,1}
   )");
@@ -115,11 +206,14 @@ TEST_F(RaggedDotRewriterTest, RaggedNonContractingWithBatchDimensions) {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, RaggedDotRewriter().Run(module.get()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Dot(op::Select(), op::Parameter()));
-  RunAndFilecheckHloRewrite(module_string, RaggedDotRewriter(), R"(
+  RunAndFilecheckHloRewrite(module_string,
+                            RaggedDotRewriter(GetCudaComputeCapability()), R"(
   // CHECK: ROOT [[dot:%[^ ]+]] = bf16[3,64,8]{2,1,0}
   // CHECK-SAME: lhs_batch_dims={0}, lhs_contracting_dims={1,3},
   // CHECK-SAME: rhs_batch_dims={0}, rhs_contracting_dims={1,2}
@@ -142,11 +236,14 @@ TEST_F(RaggedDotRewriterTest, RaggedContracting) {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, RaggedDotRewriter().Run(module.get()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Dot(op::Select(), op::Select()));
-  RunAndFilecheckHloRewrite(module_string, RaggedDotRewriter(), R"(
+  RunAndFilecheckHloRewrite(module_string,
+                            RaggedDotRewriter(GetCudaComputeCapability()), R"(
   // CHECK: ROOT [[dot:%[^ ]+]] = f32[3,11,7]{2,1,0}
   // CHECK-SAME: lhs_batch_dims={0}, lhs_contracting_dims={2},
   // CHECK-SAME: rhs_batch_dims={0}, rhs_contracting_dims={1}
@@ -171,12 +268,15 @@ TEST_F(RaggedDotRewriterTest, RaggedContractingWithBatchDims) {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, RaggedDotRewriter().Run(module.get()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_THAT(
       module->entry_computation()->root_instruction(),
       op::Dot(op::Transpose(op::Select()), op::Transpose(op::Select())));
-  RunAndFilecheckHloRewrite(module_string, RaggedDotRewriter(), R"(
+  RunAndFilecheckHloRewrite(module_string,
+                            RaggedDotRewriter(GetCudaComputeCapability()), R"(
   // CHECK: ROOT [[dot:%[^ ]+]] = f32[3,2,11,7]{3,2,1,0}
   // CHECK-SAME: lhs_batch_dims={0,1}, lhs_contracting_dims={3},
   // CHECK-SAME: rhs_batch_dims={0,1}, rhs_contracting_dims={2}
@@ -199,7 +299,9 @@ TEST_F(RaggedDotRewriterTest, BatchContracting) {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, RaggedDotRewriter().Run(module.get()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Dot(op::Parameter(0), op::Parameter(1),

--- a/xla/hlo/transforms/expanders/ragged_dot_rewriter_test.cc
+++ b/xla/hlo/transforms/expanders/ragged_dot_rewriter_test.cc
@@ -84,6 +84,30 @@ TEST_F(RaggedDotRewriterTest, DontRewriteIfUsingRaggedDotFusion) {
       .set_xla_gpu_experimental_use_ragged_dot_fusion(true);
   TF_ASSERT_OK_AND_ASSIGN(
       bool changed,
+      RaggedDotRewriter(GetCudaComputeCapability()).Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+TEST_F(RaggedDotRewriterTest, DontRewriteIfUsingRaggedDotFusionRocm) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    p0 = bf16[64,9]{1,0} parameter(0)
+    p1 = bf16[2,9,8]{2,1,0} parameter(1)
+    p2 = s64[2]{0} parameter(2)
+    ROOT ragged-dot = bf16[64,8]{1,0} ragged-dot(p0, p1, p2),
+                      lhs_contracting_dims={1}, rhs_contracting_dims={1},
+                      lhs_ragged_dims={0}, rhs_group_dims={0}
+  })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(module_string));
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_gpu_experimental_use_ragged_dot_fusion(true);
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed,
       RaggedDotRewriter(GetRocmComputeCapability()).Run(module.get()));
   EXPECT_FALSE(changed);
 }

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -643,7 +643,7 @@ absl::Status RunOptimizationPasses(
     pipeline.AddPass<UnstableReductionDetector>();
   }
   pipeline.AddPass<OneHotGatherRewriter>();
-  pipeline.AddPass<RaggedDotRewriter>();
+  pipeline.AddPass<RaggedDotRewriter>(gpu_version);
   if (!debug_options.xla_gpu_experimental_scaled_dot_with_triton()) {
     pipeline.AddPass<ScaledDotRewriter>();
   }

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -794,6 +794,8 @@ message DebugOptions {
   // regular dot.
   optional bool xla_gpu_experimental_use_ragged_dot_fusion = 401;
 
+  optional bool xla_gpu_experimental_use_ragged_dot_grouped_gemm = 501;
+
   // If true, PTX compilation will fail if a kernel spills registers.
   // This is meant for debugging and only applies to CUDA PTX compilation.
   optional bool xla_gpu_fail_ptx_compilation_on_register_spilling = 353;


### PR DESCRIPTION
**PR 1/4: Upper layers of the support**

PR 1/4 : https://github.com/openxla/xla/pull/38732  <==
PR 2/4 : https://github.com/openxla/xla/pull/38735
PR 3/4 : https://github.com/openxla/xla/pull/38736
PR 4/4 : https://github.com/openxla/xla/pull/38737

📝 Summary of Changes
Add HipBlasLT-Ext GroupedGemm support for RaggedDot operation implemented for matrices with and without batch dimension.
Three ragged modes supported:
    - ragged in Non-Contracting dimension
    - ragged in Contracting dimension
    - ragged in Batch dimension
This support takes advantage of the hip group-gemm support (https://rocm.docs.amd.com/projects/hipBLASLt/en/develop/reference/ext-reference.html#groupedgemm).

Please note that the HIP group-gemm support is not fully optimized yet and some configurations still need to be fine-tuned by the HIP team. Also, not all datatypes are supported yet. On MI300, only FP16 and BF16 are supported. On MI350, only FP16 is supported but not tuned yet. For these reasons, we have added a flag allowing users to enable or disable this feature.

Note that this PR is the first out of four PRs. 
It specifically adds the higher layers of the group-gemm support:
-	Changes to the existing compilation passes to let `RaggedDot` reaches `gemm_rewriter` where it will be rewritten into custom-call.

🎯 Justification
Group-gemm support enables faster execution of ragged dot operations while reducing the memory usage. Indeed, the baseline handles ragged-dot operation by duplicating the ragged input matrices in multiple matrices, then perform regular dot operations. With the group-gemm support, the ragged inputs are no longer duplicated but the hardware support fetches the data directly from the original ragged matrix, reducing the memory usage of such operations.
See below (benchmark section) for more details on performance improvements.

🚀 Kind of Contribution
Please remove what does not apply:⚡️ Performance Improvement, ✨ New Feature,

📊 Benchmark (for Performance Improvements)

Performance evaluation has been carried out on MI300.
Grou-Gemm performances were compared to performances of the ragged-dot rewritten into regular dot operation by the ragged-dot-rewriter pass (baseline).

### Micro-benchmark
We run JAX `lax.ragged_dot` operation with different input sizes, with and without using the group-gemm support.
After a a warm-up of 10 execution, we run 10 times 10  `lax.ragged_dot` operations and take the mean runtime.

#### num_experts = 16

| num_tokens | d_model | Group-gemm with autotune (ms) | Padded-dot (ms) | Speedup |
|------------|---------|-------------------------------|-----------------|---------|
| 256 | 512 | 0.107 | 0.169 | 1.58x |
| 256 | 1,024 | 0.116 | 0.219 | 1.89x |
| 256 | 2,048 | 0.306 | 0.499 | 1.63x |
| 256 | 4,096 | 0.745 | 1.101 | 1.48x |
| 512 | 512 | 0.102 | 0.147 | 1.44x |
| 512 | 1,024 | 0.141 | 0.277 | 1.96x |
| 512 | 2,048 | 0.307 | 0.620 | 2.02x |
| 512 | 4,096 | 0.760 | 3.227 | 4.25x |
| 1,024 | 512 | 0.114 | 0.209 | 1.83x |
| 1,024 | 1,024 | 0.130 | 0.405 | 3.12x |
| 1,024 | 2,048 | 0.318 | 0.942 | 2.96x |
| 1,024 | 4,096 | 0.787 | 2.976 | 3.78x |
| 2,048 | 512 | 0.110 | 0.272 | 2.47x |
| 2,048 | 1,024 | 0.191 | 0.600 | 3.14x |
| 2,048 | 2,048 | 0.425 | 1.764 | 4.15x |
| 2,048 | 4,096 | 1.243 | 6.030 | 4.85x |
| 4,096 | 512 | 0.109 | 0.324 | 2.97x |
| 4,096 | 1,024 | 0.210 | 0.827 | 3.94x |
| 4,096 | 2,048 | 0.555 | 2.805 | 5.05x |
| 4,096 | 4,096 | 1.850 | 11.919 | 6.44x |
| 8,256 | 512 | 0.165 | 0.545 | 3.30x |
| 8,256 | 1,024 | 0.322 | 1.499 | 4.66x |
| 8,256 | 2,048 | 0.781 | 5.514 | 7.06x |
| 8,256 | 4,096 | 3.097 | 22.766 | 7.35x |
| 16,384 | 512 | 0.219 | 0.875 | 4.00x |
| 16,384 | 1,024 | 0.482 | 2.872 | 5.96x |
| 16,384 | 2,048 | 1.394 | 11.519 | 8.26x |
| 16,384 | 4,096 | 5.824 | 44.981 | 7.72x |
| 32,768 | 512 | 0.341 | 1.662 | 4.87x |
| 32,768 | 1,024 | 0.795 | 6.065 | 7.63x |
| 32,768 | 2,048 | 2.618 | 22.910 | 8.75x |
| 32,768 | 4,096 | 11.038 | 88.276 | 8.00x |
| 65,536 | 512 | 0.556 | 3.249 | 5.84x |
| 65,536 | 1,024 | 1.517 | 11.950 | 7.88x |
| 65,536 | 2,048 | 4.919 | 45.050 | 9.16x |
| 65,536 | 4,096 | 21.617 | 174.706 | 8.08x |

#### num_experts = 32

| num_tokens | d_model | Group-gemm with autotune (ms) | Padded-dot (ms) | Speedup |
|------------|---------|-------------------------------|-----------------|---------|
| 512 | 512 | 0.095 | 0.230 | 2.42x |
| 512 | 1,024 | 0.187 | 0.429 | 2.29x |
| 512 | 2,048 | 0.448 | 1.956 | 4.37x |
| 1,024 | 512 | 0.107 | 0.295 | 2.76x |
| 1,024 | 1,024 | 0.189 | 1.055 | 5.58x |
| 1,024 | 2,048 | 0.458 | 2.493 | 5.44x |
| 2,048 | 512 | 0.107 | 0.412 | 3.85x |
| 2,048 | 1,024 | 0.192 | 1.292 | 6.73x |
| 2,048 | 2,048 | 0.473 | 3.005 | 6.35x |
| 4,096 | 512 | 0.153 | 0.710 | 4.64x |
| 4,096 | 1,024 | 0.267 | 1.555 | 5.82x |
| 4,096 | 2,048 | 0.686 | 5.678 | 8.28x |
| 8,192 | 512 | 0.176 | 0.845 | 4.80x |
| 8,192 | 1,024 | 0.376 | 2.892 | 7.69x |
| 8,192 | 2,048 | 0.981 | 10.937 | 11.15x |
| 16,512 | 512 | 0.239 | 1.651 | 6.91x |
| 16,512 | 1,024 | 0.519 | 5.781 | 11.14x |
| 16,512 | 2,048 | 1.552 | 22.976 | 14.80x |
| 32,768 | 512 | 0.361 | 3.125 | 8.66x |
| 32,768 | 1,024 | 0.861 | 12.003 | 13.94x |
| 32,768 | 2,048 | 2.825 | 44.452 | 15.74x |
| 65,536 | 512 | 0.575 | 6.436 | 11.19x |
| 65,536 | 1,024 | 1.571 | 23.412 | 14.90x |
| 65,536 | 2,048 | 5.349 | 87.849 | 16.42x |
| 131,072 | 512 | 0.992 | 12.616 | 12.72x |
| 131,072 | 1,024 | 3.030 | 46.059 | 15.20x |
| 131,072 | 2,048 | 10.062 | 174.556 | 17.35x |

#### num_experts = 64

| num_tokens | d_model | Group-gemm with autotune (ms) | Padded-dot (ms) | Speedup |
|------------|---------|-------------------------------|-----------------|---------|
| 1,024 | 512 | 0.157 | 0.442 | 2.82x |
| 1,024 | 1,024 | 0.297 | 2.442 | 8.22x |
| 1,024 | 2,048 | 0.751 | 4.728 | 6.30x |
| 2,048 | 512 | 0.156 | 0.611 | 3.92x |
| 2,048 | 1,024 | 0.302 | 2.310 | 7.65x |
| 2,048 | 2,048 | 0.772 | 5.934 | 7.69x |
| 4,096 | 512 | 0.158 | 1.235 | 7.82x |
| 4,096 | 1,024 | 0.314 | 3.034 | 9.66x |
| 4,096 | 2,048 | 0.808 | 11.284 | 13.97x |
| 8,192 | 512 | 0.201 | 1.615 | 8.03x |
| 8,192 | 1,024 | 0.440 | 5.890 | 13.39x |
| 8,192 | 2,048 | 1.326 | 23.135 | 17.45x |
| 16,384 | 512 | 0.266 | 3.203 | 12.04x |
| 16,384 | 1,024 | 0.609 | 11.696 | 19.21x |
| 16,384 | 2,048 | 1.956 | 45.292 | 23.16x |
| 33,024 | 512 | 0.381 | 6.309 | 16.56x |
| 33,024 | 1,024 | 0.965 | 23.716 | 24.58x |
| 33,024 | 2,048 | 3.091 | 87.298 | 28.24x |
| 65,536 | 512 | 0.612 | 12.600 | 20.59x |
| 65,536 | 1,024 | 1.740 | 45.794 | 26.32x |
| 65,536 | 2,048 | 5.751 | 174.996 | 30.43x |
| 131,072 | 512 | 1.055 | 24.604 | 23.32x |
| 131,072 | 1,024 | 3.203 | 90.576 | 28.28x |
| 131,072 | 2,048 | 11.075 | 351.204 | 31.71x |
| 262,144 | 512 | 1.979 | 48.168 | 24.34x |
| 262,144 | 1,024 | 6.183 | 180.242 | 29.15x |
| 262,144 | 2,048 | 20.616 | 706.826 | 34.29x |

### AI Model
We run the MaxText Mixtral MoE model on MI300 with and without the group-gemm support and obtained the following performance.

| Config | Method | Experts | Experts/Tok | Emb Dim | MLP Dim | Layers | Seq Length | Runtime (s) | TFLOPS/device | Tokens/s/device | Speedup |
|--------|--------|---------|-------------|---------|---------|--------|------------|-------------|---------------|-----------------|---------|
| 1 | baseline | 8 | 2 | 2048 | 8192 | 8 | 1024 | 2.974 | 26.62 | 344.36 | 1.000x |
| 1 | **gmm** | 8 | 2 | 2048 | 8192 | 8 | 1024 | **2.294** | **34.50** | **446.36** | **1.296x** |
| 2 |baseline  | 8 | 2 | 2560 | 10240 | 10 | 1024 | 3.172 | 24.96 | 322.86 | 1.000x |
| 2 | **gmm** | 8 | 2 | 2560 | 10240 | 10 | 1024 | **2.164** | **36.58** | **473.30** | **1.466x** |
| 3 | baseline  | 16 | 2 | 4096 | 14336 | 16 | 2048 | 4.093 | 39.08 | 500.43 | 1.000x |
| 3 | **gmm** | 16 | 2 | 4096 | 14336 | 16 | 2048 | **2.638** | **60.63** | **776.26** | **1.551x** |
| 4 | baseline | 24 | 3 | 6144 | 20480 | 24 | 3072 | 5.513 | 43.97 | 557.19 | 1.000x |
| 4 | **gmm** | 24 | 3 | 6144 | 20480 | 24 | 3072 | **4.260** | **56.91** | **721.16** | **1.294x** |


🧪 Unit Tests:
Unit tests are included in this PR. The tests verify that ragged-dot ops are not rewritten into regular dot is supported by the group-gemm backend.
