### PR TITLE
[ROCm] Support hipblaslt group-gemm 2/5

### DIFF
--- a/xla/backends/gpu/transforms/gemm_fusion.cc
+++ b/xla/backends/gpu/transforms/gemm_fusion.cc
@@ -884,6 +884,10 @@ class GemmFusionVisitor : public DfsHloRewriteVisitor {
             .xla_gpu_experimental_use_ragged_dot_grouped_gemm() &&
         module->config().debug_options().xla_gpu_enable_cublaslt();
     if (has_grouped_gemm) {
+      // At the moment, if Gpublaslt support is available, it is prefered
+      // over triton fused ragged-dot. Therefore, we skip this pass and
+      // does not fused the ragged-dot op if the Gpublaslt support
+      // is available for this operation.
       return absl::OkStatus();
     }
 

--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -716,6 +716,77 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     return absl::OkStatus();
   }
 
+  absl::Status HandleRaggedDot(HloInstruction* instr) override {
+    if (!IsGpublasLtSupportedGroupedMatMul(*instr)) {
+      return absl::OkStatus();
+    }
+    HloRaggedDotInstruction* ragged_dot =
+        DynCast<HloRaggedDotInstruction>(instr);
+    if (ragged_dot == nullptr) {
+      return absl::OkStatus();
+    }
+    const auto& ragged_dims = ragged_dot->ragged_dot_dimension_numbers();
+    const auto& dot_dims = ragged_dims.dot_dimension_numbers();
+    if (ragged_dims.lhs_ragged_dimensions().size() != 1) {
+      return absl::UnimplementedError("lhs_ragged_dimensions must have size 1");
+    }
+    int lhs_ragged_dim = ragged_dims.lhs_ragged_dimensions(0);
+
+    auto isLhsRaggedDimInContractingDim = [](int lhs_ragged_dim,
+                                             const DotDimensionNumbers& dnums) {
+      return std::any_of(dnums.lhs_contracting_dimensions().begin(),
+                         dnums.lhs_contracting_dimensions().end(),
+                         [&](auto dim) { return dim == lhs_ragged_dim; });
+    };
+
+    auto isLhsRaggedDimInBatchDim = [](int lhs_ragged_dim,
+                                       const DotDimensionNumbers& dnums) {
+      return std::any_of(dnums.lhs_batch_dimensions().begin(),
+                         dnums.lhs_batch_dimensions().end(),
+                         [&](auto dim) { return dim == lhs_ragged_dim; });
+    };
+
+    if (!isLhsRaggedDimInContractingDim(lhs_ragged_dim, dot_dims) &&
+        !isLhsRaggedDimInBatchDim(lhs_ragged_dim, dot_dims) &&
+        ragged_dims.rhs_group_dimensions().size() != 1) {
+      return absl::UnimplementedError(
+          "rhs_group_dimensions must have size equal to 1 when lhs ragged "
+          "dimension is a non-contracting dimension");
+    }
+    HloInstruction* grouped_gemm_call =
+        instr->AddInstruction(HloInstruction::CreateCustomCall(
+            ragged_dot->shape(), ragged_dot->mutable_operands(),
+            gpu::kCublasLtGroupedMatmulCallTarget));
+
+    // Create a GroupedGemmBackendConfig based on the instruction.
+    TF_ASSIGN_OR_RETURN(
+        gpu::GpuBackendConfig gpu_backend_config,
+        grouped_gemm_call->backend_config<gpu::GpuBackendConfig>());
+    GroupedGemmBackendConfig& grouped_gemm_backend_config =
+        *gpu_backend_config.mutable_grouped_gemm_backend_config();
+    RaggedDotDimensionNumbers& ragged_dot_dimension_numbers =
+        *grouped_gemm_backend_config.mutable_ragged_dot_dimension_numbers();
+    ragged_dot_dimension_numbers = ragged_dot->ragged_dot_dimension_numbers();
+
+    // Create a GemmBackendConfig based on the instruction.
+    GemmBackendConfig& gemm_backend_config =
+        *grouped_gemm_backend_config.mutable_gemm_backend_config();
+    gemm_backend_config.set_alpha_real(1.0);
+    gemm_backend_config.set_alpha_imag(0.0);
+    gemm_backend_config.set_beta(0.0);
+    *gemm_backend_config.mutable_dot_dimension_numbers() = dot_dims;
+
+    auto attributes = instr->frontend_attributes().map();
+    gemm_backend_config.set_grad_x(attributes["grad_x"] == "true");
+    gemm_backend_config.set_grad_y(attributes["grad_y"] == "true");
+
+    TF_RETURN_IF_ERROR(
+        grouped_gemm_call->set_backend_config(gpu_backend_config));
+
+    TF_RETURN_IF_ERROR(ReplaceInstruction(instr, grouped_gemm_call));
+    return absl::OkStatus();
+  }
+
   absl::Status TurnDotIntoConvertAndDotForBF16BF16F32(
       HloInstruction* instr, GemmBackendConfig& gemm_backend_config,
       GpuBackendConfig& gpu_backend_config) {
@@ -2526,6 +2597,11 @@ class GemmWorkspaceRewriteVisitor : public DfsHloRewriteVisitor {
             instr->shape().IsArray())) {
         return absl::OkStatus();
       }
+    } else if (instr->custom_call_target() ==
+               kCublasLtGroupedMatmulCallTarget) {
+      if (!instr->shape().IsArray()) {
+        return absl::OkStatus();
+      }
     } else if (instr->custom_call_target() != kGemmCallTarget ||
                !instr->shape().IsArray()) {
       return absl::OkStatus();
@@ -2561,6 +2637,12 @@ class GemmWorkspaceRewriteVisitor : public DfsHloRewriteVisitor {
         operands_byte_size += ShapeUtil::ByteSizeOf(operand->shape());
       }
       workspace = std::min(workspace, operands_byte_size);
+    }
+
+    // For grouped matmul, add workspace for user args updates
+    if (instr->custom_call_target() == kCublasLtGroupedMatmulCallTarget) {
+      size_t num_groups = instr->operand(2)->shape().dimensions().back();
+      workspace = GroupedGemmConfig::kUserArgsSizeBytes * num_groups;
     }
 
     // Append workspace buffer to instruction outputs.

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -114,6 +114,15 @@ message GemmBackendConfig {
   int64 autotune_workspace_size = 20;
 }
 
+// Backend config for the GEMM operation running through cuBLASLt.
+message GroupedGemmBackendConfig {
+  oneof gemm_config {
+    GemmBackendConfig gemm_backend_config = 1;
+  }
+
+  xla.RaggedDotDimensionNumbers ragged_dot_dimension_numbers = 2;
+}
+
 // Backend config for bitcast operation generated from MLIR MHLO dialect.
 message BitcastBackendConfig {
   LayoutProto source_layout = 1;
@@ -405,6 +414,8 @@ message GpuBackendConfig {
     NativeEmitterBackendConfig native_emitter_backend_config = 15;
 
     CollectiveMetadataBackendConfig collective_metadata_backend_config = 16;
+    
+    GroupedGemmBackendConfig grouped_gemm_backend_config = 17;
   }
 
   // This attribute instructs the latency-hiding scheduler to

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -378,7 +378,7 @@ enum DeviceType {
 }
 
 // Generic backend config for XLA:GPU
-// Next-Id: 17
+// Next-Id: 18
 message GpuBackendConfig {
   // Specifies which operation queue the current instruction will run on.
   // A backend may have multiple operation queues to run instructions

--- a/xla/service/gpu/cublas_cudnn.h
+++ b/xla/service/gpu/cublas_cudnn.h
@@ -113,6 +113,10 @@ inline constexpr absl::string_view kCublasLtMatmulCallTarget =
 inline constexpr absl::string_view kCublasLtMatmulF8CallTarget =
     "__cublas$lt$matmul$f8";
 
+// A call to cuBLAS Lt Ext API Grouped matrix multiplication.
+inline constexpr absl::string_view kCublasLtGroupedMatmulCallTarget =
+    "__cublas$lt$groupedMatmul";
+
 // A call to cuBLAS for a triangular solve.
 //
 // Like cudnn convolutions, this op returns a tuple (result, scratch_memory).

--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -74,6 +74,23 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
+bool IsGpublasLtSupportedGroupedMatMul(const HloInstruction& instr) {
+  if (instr.opcode() == HloOpcode::kRaggedDot) {
+    switch (instr.shape().element_type()) {
+      // Only float 16 and bf 16 are supported by HipBlasLt GroupGemm
+      case F16:
+      case BF16:
+        return (((instr.operand(0)->shape().element_type() == F16) ||
+                 (instr.operand(0)->shape().element_type() == BF16)) &&
+                ((instr.operand(1)->shape().element_type() == F16) ||
+                 (instr.operand(1)->shape().element_type() == BF16)));
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
 absl::StatusOr<bool> IsCublasSupportedMatMul(
     const HloInstruction& dot, bool allow_matrix_vector_multiplication) {
   if (dot.opcode() != HloOpcode::kDot) {

--- a/xla/service/gpu/ir_emission_utils.h
+++ b/xla/service/gpu/ir_emission_utils.h
@@ -71,6 +71,10 @@ inline constexpr int64_t kMaxBitsInMostMinorDimension = 8 * 8;
 absl::StatusOr<bool> IsCublasSupportedMatMul(
     const HloInstruction& dot, bool allow_matrix_vector_multiplication);
 
+// Returns true if the given instruction is supported by gpuBLASLt
+// GroupedMatMul.
+bool IsGpublasLtSupportedGroupedMatMul(const HloInstruction& instr);
+
 inline constexpr int64_t WarpSize(
     const se::DeviceDescription& gpu_device_info) {
   return gpu_device_info.threads_per_warp();

--- a/xla/service/gpu/matmul_utils.h
+++ b/xla/service/gpu/matmul_utils.h
@@ -151,6 +151,14 @@ struct GemmConfig : public se::gpu::GemmConfig {
       const se::GpuComputeCapability& gpu_version) const;
 };
 
+/* Temporary code due to split PRs */
+struct GroupedGemmConfig {
+  // For legacy Gemm operations XLA:GPU allocates its own workspace and passes
+  // it to all BLAS API calls.
+  static constexpr int64_t kUserArgsSizeBytes = 196;
+};
+/* End of temporary code due to split PRs */
+
 // Run the given GEMM instruction `gemm` subject to the configuration
 // in `gemm_config` and the passed buffers.
 //


### PR DESCRIPTION
**PR 2/5: Middle layers of the support: transform and IR emission**

PR 1/5 : https://github.com/openxla/xla/pull/38732  
PR 2/5 : https://github.com/openxla/xla/pull/38735 <==
PR 3/5 : https://github.com/openxla/xla/pull/38909 
PR 4/5 : https://github.com/openxla/xla/pull/38736
PR 5/5 : https://github.com/openxla/xla/pull/38737

📝 Summary of Changes
This is the second PR out of five.
It introduces some of the middle layers of the group-gemm support:
- the remaining transform passes
- IR emission passes