### PR TITLE
[ROCm] Fix expected output in fusion_emitter_int4_device_test for ROCm.

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter_int4_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter_int4_device_test.cc
@@ -136,7 +136,9 @@ TEST_F(TritonTest, FuseSubchannelDequantizationWithTranspose) {
       R"(
     CHECK:    %[[transpose:.*]] = bf16[2,64,8]{2,1,0} transpose(
     CHECK:    %[[broadcast:.*]] = {{.*}} broadcast(%[[transpose]])
-    CHECK:    multiply({{.*}}, %[[broadcast]])
+    CHECK-PTX: multiply({{.*}}, %[[broadcast]])
+    CHECK-GCN: %[[convert:.*]] = f32[2,64,8,256]{3,2,1,0} convert(%[[broadcast]])
+    CHECK-GCN: multiply({{.*}}, %[[convert]])
     CHECK:    ENTRY
     CHECK:    __triton_nested_gemm_fusion
   )";


### PR DESCRIPTION
📝 Summary of Changes
Created expected output for FuseSubchannelDequantizationWithTranspose in triton/fusion_emitter_int4_device_test on ROCm.

🎯 Justification
triton/fusion_emitter_int4_device_test  was failing

🚀 Kind of Contribution
Please remove what does not apply: 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
triton/fusion_emitter_int4_device_test

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
