### PR TITLE
[ROCm] Modify fusion_emitter_large_test to work on ROCm.

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion_emitter_large_test.cc
+++ b/xla/backends/gpu/codegen/triton/fusion_emitter_large_test.cc
@@ -30,12 +30,6 @@ namespace {
 class TritonGemmTest
     : public HloPjRtInterpreterReferenceMixin<HloPjRtTestBase> {
  public:
-  void SetUp() override {
-    if (test_runner().HasProperty(HloRunnerPropertyTag::kUsingGpuRocm)) {
-      GTEST_SKIP() << "Not supported on ROCm until Triton is re-enabled.";
-    }
-  }
-
   DebugOptions GetDebugOptionsForTest() const override {
     DebugOptions debug_options = HloPjRtTestBase::GetDebugOptionsForTest();
     debug_options.set_xla_gpu_cublas_fallback(false);
@@ -44,6 +38,9 @@ class TritonGemmTest
 };
 
 TEST_F(TritonGemmTest, IndexUsing64Bits) {
+  if (test_runner().HasProperty(HloRunnerPropertyTag::kUsingGpuRocm)) {
+    GTEST_SKIP() << "Not enough memory on ROCm.";
+  }
   const char* kHloTextRef = R"(
 HloModule r
 
@@ -133,6 +130,9 @@ using TritonNormalizationTest =
 
 TEST_F(TritonNormalizationTest,
        CanEmitDiamondWithInputNumberOfElementsLargerThanInt32Max) {
+  if (test_runner().HasProperty(HloRunnerPropertyTag::kUsingGpuRocm)) {
+    GTEST_SKIP() << "Not enough memory on ROCm.";
+  }
   const std::string hlo_text = R"(
 HloModule softmax
 


### PR DESCRIPTION
📝 Summary of Changes
Modified triton/fusion_emitter_large_test to pass on ROCm

🎯 Justification
Enebled skipped tests and skip tests that require too much memory.

🚀 Kind of Contribution
Please remove what does not apply: 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
triton/fusion_emitter_large_test

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
