### PR TITLE
[ROCm] Fix AnnotationMap memory leak in ROCm profiler across profiling sessions

### DIFF
--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -138,6 +138,7 @@ void RocmTracer::Enable(const RocmTracerOptions& options,
   }
   options_ = options;
   collector_ = collector;
+  annotation_map_.Clear();
   api_tracing_enabled_ = true;
   activity_tracing_enabled_ = true;
   rocprofiler_start_context(context_);

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -127,6 +127,22 @@ TEST(RocmTracerTest, AnnotationMapWorks) {
   EXPECT_EQ(result, annotation);
 }
 
+TEST(RocmTracerTest, AnnotationMapClear) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  AnnotationMap* map = tracer.annotation_map();
+  ASSERT_NE(map, nullptr);
+
+  map->Add(100, "op_a");
+  map->Add(101, "op_b");
+  EXPECT_EQ(map->LookUp(100), "op_a");
+  EXPECT_EQ(map->LookUp(101), "op_b");
+
+  map->Clear();
+
+  EXPECT_TRUE(map->LookUp(100).empty());
+  EXPECT_TRUE(map->LookUp(101).empty());
+}
+
 // Simple collector that tracks received events for verification.
 class EventCapturingCollector : public RocmTraceCollector {
  public:

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -108,5 +108,11 @@ absl::string_view AnnotationMap::LookUp(uint32_t correlation_id) {
   return it != map_.correlation_map.end() ? it->second : absl::string_view();
 }
 
+void AnnotationMap::Clear() {
+  absl::MutexLock lock(map_.mutex);
+  map_.correlation_map.clear();
+  map_.annotations.clear();
+}
+
 }  // namespace profiler
 }  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -165,6 +165,7 @@ class AnnotationMap {
   explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
   void Add(uint32_t correlation_id, const std::string& annotation);
   absl::string_view LookUp(uint32_t correlation_id);
+  void Clear();
 
  private:
   struct AnnotationMapImpl {


### PR DESCRIPTION

📝 Summary of Changes
The AnnotationMap in RocmTracer is a singleton member that accumulates annotation strings (correlation_id -> XLA op name mappings) during each profiling session. These entries were never cleared between sessions, causing memory to grow linearly with the number of start_trace/stop_trace cycles.

This fix:
- Adds AnnotationMap::Clear() to release all stored annotations
- Calls Clear() in Enable() to clear stale data from the previous session before new data is collected

🚀 Kind of Contribution
♻️ Cleanup

🧪 Unit Tests:
- Adds AnnotationMapClear unit test
