### PR TITLE
[ROCm] Clean up ROCm profiler includes and update stale comment

### DIFF
--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -13,15 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// This translation unit is **self‑contained**: it provides minimal stub
-// implementations for the rocprofiler callbacks that XLA needs to register
-// (toolInit / toolFinialize / code_object_callback).  They do nothing except
-// keep the compiler and linker happy.  Once real logging is implemented, you
-// can replace the stubs with the actual logic.
+// ROCm profiler integration using rocprofiler-sdk.
+// Provides RocmTracer singleton that manages rocprofiler contexts,
+// buffer tracing, and callback services for GPU event collection.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
-#include <time.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -29,7 +26,6 @@ limitations under the License.
 #include <cstdint>
 #include <cstring>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -16,18 +16,12 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
 #define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
 
-#include "absl/container/fixed_array.h"
 #include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 #include "absl/container/node_hash_set.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/stream_executor/rocm/roctracer_wrapper.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/macros.h"
-#include "tsl/platform/status.h"
-#include "tsl/platform/types.h"
 
 namespace xla {
 namespace profiler {
@@ -104,9 +98,10 @@ class RocmTracer {
   };
 
   using kernel_info_map_t =
-      std::unordered_map<rocprofiler_kernel_id_t, ProfilerKernelInfo>;
+      absl::flat_hash_map<rocprofiler_kernel_id_t, ProfilerKernelInfo>;
 
-  using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
+  using agent_info_map_t =
+      absl::flat_hash_map<uint64_t, rocprofiler_agent_v0_t>;
 
   using callback_name_info = rocprofiler::sdk::callback_name_info;
 


### PR DESCRIPTION
📝 Summary of Changes
rocm_tracer.h:
- Remove 6 unused includes: fixed_array.h, flat_hash_set.h, errors.h, macros.h, status.h, types.h
- Replace std::unordered_map with absl::flat_hash_map for kernel_info_ and agent_info_ type aliases

rocm_tracer.cc:
- Remove unused <time.h> and <unordered_map> includes
- Update outdated file-level comment that described the file as minimal stubs to accurately reflect its role as the rocprofiler-sdk integration


🚀 Kind of Contribution
♻️ Cleanup

