### PR TITLE
[xla] Fix hang watchdog accidental blocking

### DIFF
--- a/xla/runtime/BUILD
+++ b/xla/runtime/BUILD
@@ -107,7 +107,6 @@ cc_library(
     hdrs = ["hang_watchdog.h"],
     deps = [
         "//xla/tsl/platform:env",
-        "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",

--- a/xla/runtime/hang_watchdog.cc
+++ b/xla/runtime/hang_watchdog.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/runtime/hang_watchdog.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdlib>
 #include <functional>
@@ -24,7 +25,6 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "absl/base/call_once.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -67,7 +67,7 @@ HangWatchdog::CancelCallback HangWatchdog::Abort(absl::string_view action,
   // Only one thread actually aborts the process. We wait 10 seconds before
   // aborting to give other hang watchdogs a chance to trigger their cancel
   // callbacks and log useful debugging information.
-  static absl::once_flag abort_once;
+  static std::atomic<bool> abort_scheduled(false);
 
   return [action = std::string(action), duration,
           pre_abort = std::move(pre_abort)]() mutable {
@@ -77,13 +77,14 @@ HangWatchdog::CancelCallback HangWatchdog::Abort(absl::string_view action,
       std::move(pre_abort)();
     }
 
-    absl::call_once(abort_once, [&] {
+    // Check if we are the first watchdog that triggered the process abort.
+    if (!abort_scheduled.exchange(true)) {
       LOG(ERROR) << absl::StreamFormat(
           "%s: prepare to abort the process to avoid infinite hangs.", action);
       absl::SleepFor(absl::Seconds(10));
       LOG(FATAL) << absl::StreamFormat(
           "%s: abort the process to avoid infinite hangs.", action);
-    });
+    }
   };
 }
 


### PR DESCRIPTION
`absl::call_once` prevented hang watchdogs from all local devices to fire. Change it to simple atomic flag.