### PR TITLE
[ROCm] Skip CanNotEmitTritonCustomCallOnPreAmpereGpu in gpu_triton_cu…

### DIFF
--- a/xla/service/gpu/tests/gpu_triton_custom_call_test.cc
+++ b/xla/service/gpu/tests/gpu_triton_custom_call_test.cc
@@ -133,6 +133,10 @@ class GpuIrEmitterUnnestedTest : public GpuPjRtCodegenTest {
   se::CudaComputeCapability GetCudaComputeCapability() {
     return device_description().cuda_compute_capability();
   }
+
+  se::GpuComputeCapability GetGpuComputeCapability() {
+    return device_description().gpu_compute_capability();
+  }
 };
 
 TEST_F(GpuIrEmitterUnnestedTest, EmitTritonCustomCallWithCorrectLowering) {
@@ -332,7 +336,8 @@ TEST_F(GpuIrEmitterUnnestedTest, RunTritonCustomCallWithDeviceSideTMA) {
 }
 
 TEST_F(GpuIrEmitterUnnestedTest, CanNotEmitTritonCustomCallOnPreAmpereGpu) {
-  if (GetCudaComputeCapability().IsAtLeastAmpere()) {
+  if (GetGpuComputeCapability().IsRocm() ||
+      GetCudaComputeCapability().IsAtLeastAmpere()) {
     GTEST_SKIP() << "Running on Ampere or more recent GPU, skipping.";
   }
 


### PR DESCRIPTION
…stom_call_test for ROCm

📝 Summary of Changes
skipped CanNotEmitTritonCustomCallOnPreAmpereGpu in gpu_triton_custom_call_test for ROCm

🎯 Justification
Unit test was failing because it works on ROCm

🚀 Kind of Contribution
Please remove what does not apply:  🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
gpu_triton_custom_call_test

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
