### PR TITLE
[ROCM] improving RunAndCompareThreeIterations in command_buffer_test

### DIFF
--- a/xla/service/gpu/tests/BUILD
+++ b/xla/service/gpu/tests/BUILD
@@ -250,6 +250,7 @@ xla_test(
         "//xla/hlo/ir:hlo",
         "//xla/service:hlo_module_config",
         "//xla/service:hlo_runner_interface",
+        "//xla/service:hlo_runner_pjrt",
         "//xla/service:platform_util",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:platform_manager",

--- a/xla/service/gpu/tests/command_buffer_test.cc
+++ b/xla/service/gpu/tests/command_buffer_test.cc
@@ -157,7 +157,7 @@ class CommandBufferTest
         auto exec, CreateExecutable(std::move(module), run_hlo_passes));
 
     auto* pjrt_runner = tsl::down_cast<HloRunnerPjRt*>(&test_runner());
-    EXPECT_TRUE(pjrt_runner != nullptr);
+    ASSERT_TRUE(pjrt_runner != nullptr);
 
     // Create two copies of device buffers to make sure command buffer saved
     // pointers really get updated during the last "update run".
@@ -171,7 +171,7 @@ class CommandBufferTest
 
     static constexpr absl::string_view kPhases[] = {"warm-up", "create",
                                                     "update"};
-    for (int i = 0; i < 3; i++) {
+    for (size_t i = 0; i < std::size(kPhases); i++) {
       BufferSet current_set = (i < 2) ? kInitial : kUpdated;
       TF_ASSERT_OK_AND_ASSIGN(auto output_buffers,
                               pjrt_runner->ExecuteWithDeviceBuffers(

--- a/xla/service/gpu/tests/command_buffer_test.cc
+++ b/xla/service/gpu/tests/command_buffer_test.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #include "xla/literal_util.h"
 #include "xla/service/hlo_module_config.h"
 #include "xla/service/hlo_runner_interface.h"
+#include "xla/service/hlo_runner_pjrt.h"
 #include "xla/service/platform_util.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/platform_manager.h"
@@ -130,68 +131,57 @@ class CommandBufferTest
 
   // Same as above, but generates fake inputs and compares results to a
   // reference execution. Useful for tests originally using RunAndCompare.
-  ::testing::AssertionResult RunAndCompareThreeIterations(
-      std::unique_ptr<HloModule> module, bool run_hlo_passes,
-      const std::optional<ErrorSpec>& error) {
+  void RunAndCompareThreeIterations(std::unique_ptr<HloModule> module,
+                                    bool run_hlo_passes,
+                                    const std::optional<ErrorSpec>& error) {
     // Verify module then clone for reference.
     CHECK_OK(this->verifier().Run(module.get()).status());
     std::unique_ptr<HloModule> reference_module = module->Clone();
 
     // Prepare fake args for both runners.
-    absl::StatusOr<std::vector<Literal>> fake_args_or =
-        MakeFakeArguments(module.get());
-    if (!fake_args_or.ok()) {
-      return ::testing::AssertionFailure() << fake_args_or.status().message();
-    }
-    std::vector<Literal> fake_args = std::move(*fake_args_or);
-    std::vector<const Literal*> arg_ptrs = LiteralUtil::MakePointers(fake_args);
+    TF_ASSERT_OK_AND_ASSIGN(auto fake_args, MakeFakeArguments(module.get()));
+    auto arg_ptrs = LiteralUtil::MakePointers(fake_args);
+
+    // Store input_layouts and untuple_results before the module is
+    // consumed by CreateExecutable.
+    auto input_layouts = module->entry_computation_layout().parameter_layouts();
+    bool untuple_results = module->result_shape().IsTuple();
 
     // Reference once.
-    absl::StatusOr<Literal> reference = reference_runner().Execute(
-        std::move(reference_module), absl::MakeSpan(arg_ptrs), run_hlo_passes);
-    if (!reference.ok()) {
-      return ::testing::AssertionFailure() << reference.status();
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto reference,
+        reference_runner().Execute(std::move(reference_module),
+                                   absl::MakeSpan(arg_ptrs), run_hlo_passes));
+
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto exec, CreateExecutable(std::move(module), run_hlo_passes));
+
+    auto* pjrt_runner = tsl::down_cast<HloRunnerPjRt*>(&test_runner());
+    EXPECT_TRUE(pjrt_runner != nullptr);
+
+    // Create two copies of device buffers to make sure command buffer saved
+    // pointers really get updated during the last "update run".
+    std::array<std::vector<std::unique_ptr<PjRtBuffer>>, 2> argument_handles;
+    for (auto& handle : argument_handles) {
+      TF_ASSERT_OK_AND_ASSIGN(handle,
+                              pjrt_runner->TransferLiteralsToDefaultDevice(
+                                  input_layouts, absl::MakeSpan(arg_ptrs)));
     }
+    for (int i = 0; i < 3; i++) {
+      TF_ASSERT_OK_AND_ASSIGN(auto output_buffers,
+                              pjrt_runner->ExecuteWithDeviceBuffers(
+                                  exec.get(), argument_handles[i < 2 ? 0 : 1]));
 
-    // Compile once on test backend and run three iterations.
-    absl::StatusOr<std::unique_ptr<OpaqueExecutable>> exec_or =
-        CreateExecutable(std::move(module), run_hlo_passes);
-    if (!exec_or.ok()) {
-      return ::testing::AssertionFailure() << exec_or.status();
-    }
-    std::unique_ptr<OpaqueExecutable> exec = std::move(*exec_or);
-
-    // 1) Warm-up
-    absl::StatusOr<Literal> r1 = test_runner().ExecuteWithExecutable(
-        exec.get(), absl::MakeSpan(arg_ptrs));
-    if (!r1.ok()) return ::testing::AssertionFailure() << r1.status();
-    if (!LiteralTestUtil::NearOrEqual(*reference, *r1, error))
-      return ::testing::AssertionFailure() << "Mismatch on warm-up run";
-
-    // 2) Create
-    absl::StatusOr<Literal> r2 = test_runner().ExecuteWithExecutable(
-        exec.get(), absl::MakeSpan(arg_ptrs));
-    if (!r2.ok()) return ::testing::AssertionFailure() << r2.status();
-    if (!LiteralTestUtil::NearOrEqual(*reference, *r2, error))
-      return ::testing::AssertionFailure() << "Mismatch on create run";
-
-    // 3) Update with cloned args
-    std::vector<Literal> cloned_args_storage;
-    cloned_args_storage.reserve(arg_ptrs.size());
-    std::vector<const Literal*> cloned_arg_ptrs;
-    cloned_arg_ptrs.reserve(arg_ptrs.size());
-    for (const Literal* a : arg_ptrs) {
-      cloned_args_storage.push_back(a->Clone());
-      cloned_arg_ptrs.push_back(&cloned_args_storage.back());
-    }
-
-    absl::StatusOr<Literal> r3 = test_runner().ExecuteWithExecutable(
-        exec.get(), absl::MakeSpan(cloned_arg_ptrs));
-    if (!r3.ok()) return ::testing::AssertionFailure() << r3.status();
-    if (!LiteralTestUtil::NearOrEqual(*reference, *r3, error))
-      return ::testing::AssertionFailure() << "Mismatch on update run";
-
-    return ::testing::AssertionSuccess();
+      TF_ASSERT_OK_AND_ASSIGN(auto result,
+                              pjrt_runner->TransferLiteralsFromDevice(
+                                  output_buffers, untuple_results));
+      if (!LiteralTestUtil::NearOrEqual(reference, result, error)) {
+        ::testing::AssertionFailure() << "Mismatch on "
+                                      << (i == 0   ? "warm-up run"
+                                          : i == 1 ? "create run"
+                                                   : "update run");
+      }
+    }  // for
   }
 };
 
@@ -820,8 +810,8 @@ TEST_P(CommandBufferTest, DynamicSliceCopyFusionCmd) {
   TF_ASSERT_OK_AND_ASSIGN(auto module,
                           ParseAndReturnVerifiedModule(hlo_text, config));
 
-  EXPECT_TRUE(RunAndCompareThreeIterations(
-      std::move(module), /*run_hlo_passes=*/false, ErrorSpec{1e-3, 2e-3}));
+  RunAndCompareThreeIterations(std::move(module), /*run_hlo_passes=*/false,
+                               ErrorSpec{1e-3, 2e-3});
 
   if (!IsAtLeastCuda12900(GpuExecutor())) {
     GTEST_SKIP() << "While loop unrolling is not supported for CUDA < 12.9";
@@ -842,9 +832,8 @@ TEST_P(CommandBufferTest, DynamicSliceCopyFusionCmd) {
   TF_ASSERT_OK_AND_ASSIGN(auto unrolled_module,
                           ParseAndReturnVerifiedModule(hlo_text, config));
 
-  EXPECT_TRUE(RunAndCompareThreeIterations(std::move(unrolled_module),
-                                           /*run_hlo_passes=*/false,
-                                           ErrorSpec{1e-3, 2e-3}));
+  RunAndCompareThreeIterations(std::move(unrolled_module),
+                               /*run_hlo_passes=*/false, ErrorSpec{1e-3, 2e-3});
 }
 
 TEST_P(CommandBufferUnrollTest, WhileLoop) {

--- a/xla/service/gpu/tests/command_buffer_test.cc
+++ b/xla/service/gpu/tests/command_buffer_test.cc
@@ -142,8 +142,8 @@ class CommandBufferTest
     TF_ASSERT_OK_AND_ASSIGN(auto fake_args, MakeFakeArguments(module.get()));
     auto arg_ptrs = LiteralUtil::MakePointers(fake_args);
 
-    // Store input_layouts and untuple_results before the module is
-    // consumed by CreateExecutable.
+    // Store input_layouts and untuple_results before the module is consumed
+    // by CreateExecutable.
     auto input_layouts = module->entry_computation_layout().parameter_layouts();
     bool untuple_results = module->result_shape().IsTuple();
 
@@ -161,26 +161,27 @@ class CommandBufferTest
 
     // Create two copies of device buffers to make sure command buffer saved
     // pointers really get updated during the last "update run".
+    enum BufferSet { kInitial = 0, kUpdated = 1 };
     std::array<std::vector<std::unique_ptr<PjRtBuffer>>, 2> argument_handles;
     for (auto& handle : argument_handles) {
       TF_ASSERT_OK_AND_ASSIGN(handle,
                               pjrt_runner->TransferLiteralsToDefaultDevice(
                                   input_layouts, absl::MakeSpan(arg_ptrs)));
     }
+
+    static constexpr absl::string_view kPhases[] = {"warm-up", "create",
+                                                    "update"};
     for (int i = 0; i < 3; i++) {
+      BufferSet current_set = (i < 2) ? kInitial : kUpdated;
       TF_ASSERT_OK_AND_ASSIGN(auto output_buffers,
                               pjrt_runner->ExecuteWithDeviceBuffers(
-                                  exec.get(), argument_handles[i < 2 ? 0 : 1]));
+                                  exec.get(), argument_handles[current_set]));
 
       TF_ASSERT_OK_AND_ASSIGN(auto result,
                               pjrt_runner->TransferLiteralsFromDevice(
                                   output_buffers, untuple_results));
-      if (!LiteralTestUtil::NearOrEqual(reference, result, error)) {
-        ::testing::AssertionFailure() << "Mismatch on "
-                                      << (i == 0   ? "warm-up run"
-                                          : i == 1 ? "create run"
-                                                   : "update run");
-      }
+      EXPECT_TRUE(LiteralTestUtil::NearOrEqual(reference, result, error))
+          << "Mismatch on " << kPhases[i] << " run (iteration " << i << ")";
     }  // for
   }
 };


### PR DESCRIPTION
📝 Summary of Changes
Rewirting RunAndCompareThreeIterations function

🎯 Justification
The above function clones input literals with the idea that this will cause command buffer updates but this does not really happen.
The point is, the function [ExecuteWithExecutable](https://github.com/openxla/xla/blob/5e9258842fe13c6c155684d7263604d3d2963380/xla/service/hlo_runner_pjrt.cc#L509-L512) creates and destroys device buffers on every call, hence just cloning the input literals won't help to force command buffer update. This is because BFC allocator used by PJRT runner would likely to allocate device buffers on exact same locations as before. So, I had to rewrite this function to really keep 2 sets of input arguments allocated at the same time.
Though, to get it working I had to use a small hack to [downcast runner pointer](https://github.com/openxla/xla/blob/5e9258842fe13c6c155684d7263604d3d2963380/xla/service/gpu/tests/command_buffer_test.cc#L157) to HloRunnerPjRt type..

🚀 Kind of Contribution
 🧪 Tests

Extracted as a separate PR from https://github.com/openxla/xla/pull/34572
