### PR TITLE
[ROCm] Add minimal ROCm support to ExecutableAbiVersion

### DIFF
--- a/xla/stream_executor/abi/BUILD
+++ b/xla/stream_executor/abi/BUILD
@@ -41,6 +41,7 @@ xla_cc_test(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:semantic_version",
         "//xla/stream_executor/cuda:cuda_compute_capability",
+        "//xla/stream_executor/rocm:rocm_compute_capability",
         "//xla/tsl/util/proto:proto_matchers",
         "@com_google_googletest//:gtest_main",
     ],

--- a/xla/stream_executor/abi/executable_abi_version.cc
+++ b/xla/stream_executor/abi/executable_abi_version.cc
@@ -39,6 +39,16 @@ static absl::StatusOr<ExecutableAbiVersion> CreateForCuda(
   return ExecutableAbiVersion::FromProto(std::move(proto));
 }
 
+// Returns a minimal ABI version for ROCm with no platform-specific version
+// info. Compatibility checks will treat this as always-compatible, preserving
+// pre-existing ROCm behavior until proper ABI versioning is designed.
+static absl::StatusOr<ExecutableAbiVersion> CreateForRocm(
+    const DeviceDescription& /*device_description*/) {
+  ExecutableAbiVersionProto proto;
+  proto.set_platform_name("ROCm");
+  return ExecutableAbiVersion::FromProto(std::move(proto));
+}
+
 absl::StatusOr<ExecutableAbiVersion> ExecutableAbiVersion::FromProto(
     const ExecutableAbiVersionProto& proto) {
   return ExecutableAbiVersion(proto);
@@ -48,6 +58,9 @@ ExecutableAbiVersion::FromDeviceDescription(
     const DeviceDescription& device_description) {
   if (device_description.gpu_compute_capability().IsCuda()) {
     return CreateForCuda(device_description);
+  }
+  if (device_description.gpu_compute_capability().IsRocm()) {
+    return CreateForRocm(device_description);
   }
 
   return absl::UnimplementedError(

--- a/xla/stream_executor/abi/executable_abi_version_test.cc
+++ b/xla/stream_executor/abi/executable_abi_version_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/tsl/util/proto/proto_matchers.h"
 
@@ -57,6 +58,19 @@ TEST(ExecutableAbiVersionTest, FromDeviceDescription) {
                   cub_version: "2.0.0"
                 }
               )pb"));
+}
+
+TEST(ExecutableAbiVersionTest, FromDeviceDescriptionRocm) {
+  DeviceDescription device_description;
+  device_description.set_gpu_compute_capability(
+      GpuComputeCapability(RocmComputeCapability("gfx942")));
+
+  ASSERT_OK_AND_ASSIGN(
+      ExecutableAbiVersion executable_abi_version,
+      ExecutableAbiVersion::FromDeviceDescription(device_description));
+  EXPECT_THAT(executable_abi_version.platform_name(), "ROCm");
+  EXPECT_THAT(executable_abi_version.proto(),
+              EqualsProto(R"pb(platform_name: "ROCm")pb"));
 }
 
 }  // namespace


### PR DESCRIPTION
Hot-Fix for breaking changes added in 5150bfd950

📝 Summary of Changes
The ExecutableAbiVersion::FromDeviceDescription was only implemented for CUDA, returning UNIMPLEMENTED for all other platforms. This broke every ROCm compilation path after 5150bfd950 introduced mandatory ABI version derivation in GpuCompiler::RunBackend.

Add a CreateForRocm handler that returns a minimal ABI version with
only platform_name set to "ROCm" and no platform-specific version
info. This preserves pre-existing ROCm behavior (no compatibility
checks) until proper ABI versioning is designed for ROCm.

🎯 Justification
without this change JAX tests on ROCm platform fail with error:
```bash
jax.errors.JaxRuntimeError: UNIMPLEMENTED: Deriving the executable ABI version from the device description is not implemented for the target platform.
```
🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
added rocm test to test //xla/stream_executor/abi:executable_abi_version_test
