### PR TITLE
[xla:gpu] Add ResourceUses to Thunk and use it from Command

### DIFF
--- a/docs/hlo_to_thunks.md
+++ b/docs/hlo_to_thunks.md
@@ -219,7 +219,7 @@ that runs on the ThunkSequence itself.
 The pass identifies contiguous sub-sequences of compatible thunks (e.g., a
 series of `KernelThunk`s and `GemmThunk`s). It then replaces the found
 sub-sequence with a single `CommandBufferThunk`. The new thunk encapsulates the
-logic of the original thunks as a list of lightweight CommandBufferCmd objects.
+logic of the original thunks as a list of lightweight Command objects.
 When a `CommandBufferThunk` executes for the first time on a given GPU stream,
 it "records" its sequence of commands into a hardware command buffer. On all
 subsequent executions, it simply issues a single command to the GPU to "replay"

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -127,7 +127,7 @@ bool IsCollectiveCommand(CommandType type);
 class Command {
  public:
   using BufferUses = Thunk::BufferUses;
-  using ResourceUses = absl::InlinedVector<ResourceUse, 1>;
+  using ResourceUses = Thunk::ResourceUses;
 
  public:
   explicit Command(CommandType cmd_type,

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -54,7 +54,7 @@ limitations under the License.
 namespace xla::gpu {
 
 namespace {
-// An adaptor from CommandBufferCmd to ExecutionGraph::Operation for building an
+// An adaptor from Command to ExecutionGraph::Operation for building an
 // execution graph from a command sequence.
 class CommandOperation : public ExecutionGraph::Operation {
  public:

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -56,9 +56,9 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -127,7 +127,7 @@ class Thunk {
       absl::flat_hash_map<ExecutionStreamId, se::Stream*>;
 
   using BufferUses = absl::InlinedVector<BufferUse, 4>;
-  using ResourceUses = absl::InlinedVector<ResourceUse, 4>;
+  using ResourceUses = absl::InlinedVector<ResourceUse, 1>;
 
   // When default execution stream id is used, operations launched by a thunk
   // must be synchronized with a stream passed in ExecuteOptions.
@@ -459,12 +459,23 @@ class Thunk {
   // Precondition: Initialize(initialize_params) has been called.
   virtual absl::Status ExecuteOnStream(const ExecuteParams& params) = 0;
 
-  // Returns all device buffers used by the thunk.
-  //
-  // Does not propagate buffers from nested thunks.
+  // Returns device buffers used by the thunk.
   //
   // The order of the buffers in returned vector is consistent across calls.
+  //
+  // Buffer uses do not include buffers that might be used by nested thunks,
+  // they must be collected separately by walking the nested thunks using `Walk`
+  // API.
   virtual BufferUses buffer_uses() const { return {}; }
+
+  // Returns resources used by this thunk.
+  //
+  // The order of the resources in returned vector is consistent across calls.
+  //
+  // Resource uses do not include resources that might be used by nested thunks,
+  // they must be collected separately by walking the nested thunks using `Walk`
+  // API.
+  virtual ResourceUses resource_uses() const { return {}; }
 
   static absl::string_view KindToString(Thunk::Kind kind);
 

--- a/xla/runtime/resource_use.h
+++ b/xla/runtime/resource_use.h
@@ -67,6 +67,14 @@ class Resource {
 // For consistency with BufferUse, we model resource uses as writes or reads
 // to and from resource. Resources have referential equality: we rely on
 // comparing pointers to check if resource is the same or not.
+//
+// Examples of using resources in XLA:
+//
+//   - HLO control dependencies that are not representable as buffers also
+//     modeled as resource writes and reads.
+//   - in XLA:CPU all collective operations must be ordered at run time. We use
+//     a global "collective communication" resource to model this constraint.
+//
 class ResourceUse {
  public:
   enum class ResourceAccess { kRead, kWrite };

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -165,6 +165,7 @@ limitations under the License.
 #include "xla/stream_executor/memory_space.h"
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -173,7 +174,6 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/human_readable_json.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -371,9 +371,9 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitSliceToDynamic(
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCommandBufferThunk(
     const HloInstruction* instr) {
   // Spawn a new ThunkEmitter to emit thunks for the command buffer computation.
-  // Then convert emitted thunks to a sequence of CommandBufferCmd. The
-  // resulting thunk added to the thunk sequence is a CommandBufferThunk. Thunks
-  // emitted from the command buffer computation are discarded.
+  // Then convert emitted thunks to a sequence of Commands. The resulting thunk
+  // added to the thunk sequence is a CommandBufferThunk. Thunks emitted from
+  // the command buffer computation are discarded.
   DCHECK_EQ(instr->called_computations().size(), 1);
   const HloComputation* command_buffer = instr->called_computations().front();
   TF_ASSIGN_OR_RETURN(auto thunk_sequence, EmitHloComputation(command_buffer));


### PR DESCRIPTION
One step towards unifying `Command` and `Thunk`. Also remove remaining mentions of `CommandBufferCmd` that was replaced by `Command`