### PR TITLE
[ROCm] Use addNestedPass for TritonAMDGPUOptimizeBufferOpPtr

### DIFF
--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -132,7 +132,8 @@ static void MakeTTGIR(mlir::OpPassManager* pm,
   pm->addPass(mlir::createTritonAMDGPUConvertToBufferOps(
       {rocm_cc.gfx_version(), /*allowBufferAtomics*/ true,
        /*analyzeSmallTensorOfst*/ false}));
-  pm->addPass(mlir::createTritonAMDGPUOptimizeBufferOpPtr());
+  pm->addNestedPass<mlir::triton::FuncOp>(
+      mlir::createTritonAMDGPUOptimizeBufferOpPtr());
 
   pm->addPass(mlir::createTritonAMDFoldTrueCmpI());
   pm->addNestedPass<mlir::triton::FuncOp>(


### PR DESCRIPTION
📝 Summary of Changes
Use addNestedPass for TritonAMDGPUOptimizeBufferOpPtr

🎯 Justification
Crash when running triton pipeline for ROCm

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
triton/support_test

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
