### PR TITLE
Fix delay kernel timeouts in the autotuner.

### DIFF
--- a/xla/backends/autotuner/BUILD
+++ b/xla/backends/autotuner/BUILD
@@ -104,7 +104,6 @@ xla_cc_test(
         "//xla/tsl/distributed_runtime:call_options",
         "//xla/tsl/distributed_runtime/coordination:coordination_service_agent",
         "//xla/tsl/platform:env",
-        "//xla/tsl/platform:statusor",
         "//xla/tsl/platform:test",
         "//xla/tsl/testing:temporary_directory",
         "//xla/tsl/util/proto:proto_matchers",

--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -435,7 +435,7 @@ tsl::Future<Autotuner::Config> Autotuner::TuneBestConfig(
         }
 
         TF_ASSIGN_OR_RETURN(std::vector<ConfigResult> results,
-                            ProfileAll(executable_candidates));
+                            ProfileAll(std::move(executable_candidates)));
         LogConfigResults(*instr, results);
         absl::StatusOr<ConfigResult> best_result = PickBestConfig(results);
         if (!best_result.ok()) {
@@ -565,7 +565,7 @@ Autotuner::CompileAll(HloInstruction* instr, std::vector<Config>& configs) {
 }
 
 absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
-    std::vector<ExecutableCandidate>& candidates) {
+    std::vector<ExecutableCandidate> candidates) {
   std::vector<ConfigResult> results_vec;
   results_vec.reserve(candidates.size());
 
@@ -611,6 +611,11 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
     results_vec.push_back(
         {std::move(candidates[i].config), failure, duration, scratch_bytes});
   }
+  // Clear the candidates while holding the profiler lock
+  // to unload their CUDA modules before any other thread starts profiling;
+  // not doing this for example causes timeouts of delay kernels used for
+  // precise CUDA event-based timing.
+  candidates.clear();
   return results_vec;
 }
 

--- a/xla/backends/autotuner/autotuner.h
+++ b/xla/backends/autotuner/autotuner.h
@@ -210,7 +210,7 @@ class Autotuner {
   CompileAll(HloInstruction* instr, std::vector<Config>& configs);
 
   absl::StatusOr<std::vector<ConfigResult>> ProfileAll(
-      std::vector<ExecutableCandidate>& candidates);
+      std::vector<ExecutableCandidate> candidates);
   absl::StatusOr<ConfigResult> PickBestConfig(
       std::vector<ConfigResult>& results);
 

--- a/xla/backends/autotuner/autotuner_test.cc
+++ b/xla/backends/autotuner/autotuner_test.cc
@@ -15,9 +15,11 @@ limitations under the License.
 
 #include "xla/backends/autotuner/autotuner.h"
 
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -28,6 +30,7 @@ limitations under the License.
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "google/protobuf/text_format.h"
@@ -47,6 +50,7 @@ limitations under the License.
 #include "xla/service/executable.h"
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/gpu_executable.h"
+#include "xla/service/service_executable_run_options.h"
 #include "xla/service/shaped_buffer.h"
 #include "xla/shape.h"
 #include "xla/stream_executor/device_description.h"
@@ -54,7 +58,6 @@ limitations under the License.
 #include "xla/tsl/distributed_runtime/call_options.h"
 #include "xla/tsl/distributed_runtime/coordination/coordination_service_agent.h"
 #include "xla/tsl/platform/env.h"
-#include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/platform/test.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/tsl/testing/temporary_directory.h"
@@ -1095,6 +1098,92 @@ TEST_F(AutotunerTest, DumpHlos) {
           MatchesRegex(".*\\.test_module\\.autotuner_1\\.copy\\.after\\.txt"),
           MatchesRegex(
               ".*\\.test_module\\.autotuner_1\\.copy\\.before\\.txt")));
+}
+
+class CountingDestructorExecutable : public Executable {
+ public:
+  explicit CountingDestructorExecutable(std::atomic<int>* destroy_count)
+      : Executable(nullptr), destroy_count_(destroy_count) {}
+  ~CountingDestructorExecutable() override {
+    absl::SleepFor(absl::Milliseconds(10));
+    ++(*destroy_count_);
+  }
+  absl::StatusOr<ExecutionOutput> ExecuteAsyncOnStream(
+      const ServiceExecutableRunOptions*,
+      std::vector<ExecutionInput>) override {
+    return absl::UnimplementedError("unused in test");
+  }
+
+ private:
+  std::atomic<int>* destroy_count_;
+};
+
+TEST_F(AutotunerTest, ProfileAllUnloadsCandidatesBeforeReleasingProfilerLock) {
+  std::atomic<int> executable_destroy_count{0};
+
+  auto backend = std::make_unique<MockCodegenBackend>();
+  EXPECT_CALL(*backend, name()).WillRepeatedly(Return("mock_backend"));
+  EXPECT_CALL(*backend, backend())
+      .WillRepeatedly(Return(autotuner::Backend::UNSPECIFIED_BACKEND));
+  EXPECT_CALL(*backend, GetSupportedConfigs(_)).WillRepeatedly([]() {
+    std::vector<std::unique_ptr<BackendConfig>> out;
+    out.push_back(GetTestConfig("config_1"));
+    out.push_back(GetTestConfig("config_2"));
+    return out;
+  });
+  EXPECT_CALL(*backend, Compile(_, _))
+      .WillRepeatedly([&executable_destroy_count]() {
+        return std::make_unique<CountingDestructorExecutable>(
+            &executable_destroy_count);
+      });
+  EXPECT_CALL(*backend, ApplyConfig(_, _))
+      .WillRepeatedly(Return(absl::OkStatus()));
+
+  std::atomic<int> create_input_buffers_call_count{0};
+  auto profiler = std::make_unique<MockProfiler>();
+  EXPECT_CALL(*profiler, CreateInputBuffers(_))
+      .WillRepeatedly([&executable_destroy_count,
+                       &create_input_buffers_call_count](const Executable*) {
+        int call = ++create_input_buffers_call_count;
+        if (call == 2) {
+          EXPECT_EQ(executable_destroy_count.load(), 2)
+              << "First run's executables must be destroyed before second run "
+                 "acquires profiler lock (avoids delay kernel timeouts)";
+        }
+        return std::make_unique<InputBuffers>();
+      });
+  EXPECT_CALL(*profiler, Profile(_, _)).WillRepeatedly([] {
+    return ProfileResult({absl::Seconds(1)});
+  });
+
+  std::vector<std::unique_ptr<CodegenBackend>> backends;
+  backends.push_back(std::move(backend));
+  auto cache = std::make_unique<MockAutotunerCache>();
+  EXPECT_CALL(*cache, Lookup(_)).WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*cache, Insert(_, _)).WillRepeatedly(Return(absl::OkStatus()));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto autotuner,
+      Autotuner::Create(std::move(backends), std::move(profiler), config_,
+                        std::move(cache)));
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+
+  absl::Status status1;
+  absl::Status status2;
+  std::thread t1([&]() {
+    status1 = autotuner->Autotune(
+        module->entry_computation()->GetInstructionWithName("add"));
+  });
+  std::thread t2([&]() {
+    status2 = autotuner->Autotune(
+        module->entry_computation()->GetInstructionWithName("copy"));
+  });
+  t1.join();
+  t2.join();
+  ASSERT_OK(status1);
+  ASSERT_OK(status2);
 }
 
 TEST(AutotuneConfigTest, ToString) {

--- a/xla/backends/autotuner/autotuner_test.cc
+++ b/xla/backends/autotuner/autotuner_test.cc
@@ -19,11 +19,9 @@ limitations under the License.
 #include <memory>
 #include <optional>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
-#include "google/protobuf/any.pb.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
@@ -33,6 +31,7 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "google/protobuf/any.pb.h"
 #include "google/protobuf/text_format.h"
 #include "xla/autotune_results.pb.h"
 #include "xla/autotuning.pb.h"
@@ -1172,16 +1171,18 @@ TEST_F(AutotunerTest, ProfileAllUnloadsCandidatesBeforeReleasingProfilerLock) {
 
   absl::Status status1;
   absl::Status status2;
-  std::thread t1([&]() {
-    status1 = autotuner->Autotune(
-        module->entry_computation()->GetInstructionWithName("add"));
-  });
-  std::thread t2([&]() {
-    status2 = autotuner->Autotune(
-        module->entry_computation()->GetInstructionWithName("copy"));
-  });
-  t1.join();
-  t2.join();
+  std::unique_ptr<tsl::Thread> t1(
+      tsl::Env::Default()->StartThread({}, "autotuner-test-t1", [&]() {
+        status1 = autotuner->Autotune(
+            module->entry_computation()->GetInstructionWithName("add"));
+      }));
+  std::unique_ptr<tsl::Thread> t2(
+      tsl::Env::Default()->StartThread({}, "autotuner-test-t2", [&]() {
+        status2 = autotuner->Autotune(
+            module->entry_computation()->GetInstructionWithName("copy"));
+      }));
+  t1.reset();
+  t2.reset();
   ASSERT_OK(status1);
   ASSERT_OK(status2);
 }


### PR DESCRIPTION
📝 Summary of Changes
Unload probed candidates synchronously before next ones start being profiled.
Without this unloading can overlap with profiling started in other threads preventing them from launching kernels and causing their delay kernels timeouts.

🎯 Justification
🐛 Bug Fix

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
yes

🧪 Execution Tests:
no