### PR TITLE
[ROCm] CI: Add GHA workflow for ROCm JAX unit tests

### DIFF
--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -18,6 +18,8 @@ permissions:
   contents: read
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -29,6 +31,7 @@ concurrency:
 
 jobs:
   execute-jax-ut:
+    if: github.event.repository.fork == false
     name: JAX Linux x86 AMD Instinct GPU
     runs-on: linux-x86-64-8gpu-amd
     env:

--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -1,0 +1,83 @@
+# Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+name: CI ROCm JAX
+permissions:
+  contents: read
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'main' }}
+
+jobs:
+  execute-jax-ut:
+    runs-on: linux-x86-64-8gpu-amd
+    env:
+      DOCKER_IMAGE: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+    container:
+      image: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+      volumes:
+        - /data/ci-cert.crt:/data/ci-cert.crt
+        - /data/ci-cert.key:/data/ci-cert.key
+        - /data:/data
+      options: >-
+        --device=/dev/dri
+        --device=/dev/kfd
+        --ipc=host
+        --shm-size=64G
+        --cap-add=SYS_PTRACE
+        --security-opt=seccomp=unconfined
+        --tmpfs /root/.cache/bazel:rw,exec,size=80g
+        --group-add video
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout JAX
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: jax-ml/jax
+          path: jax
+          persist-credentials: false
+
+      - name: CPU Info
+        run: lscpu
+
+      - name: ROCm info
+        run: /opt/rocm/bin/rocminfo
+
+      - name: Run JAX Unit Tests
+        timeout-minutes: 120
+        env:
+          JAXCI_HERMETIC_PYTHON_VERSION: "3.14"
+          JAXCI_ENABLE_X64: "1"
+          JAXCI_ROCM_VERSION: "7"
+          JAXCI_WRITE_TO_BAZEL_REMOTE_CACHE: "0"
+          JAXCI_BUILD_JAX: "true"
+          JAXCI_BUILD_JAXLIB: wheel
+        working-directory: jax
+        run: |
+          ./ci/run_bazel_test_rocm_rbe.sh \
+            --override_repository=xla=${GITHUB_WORKSPACE} \
+            --config=single_gpu \
+            --local_test_jobs=4 \
+            --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${DOCKER_IMAGE}

--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -29,6 +29,7 @@ concurrency:
 
 jobs:
   execute-jax-ut:
+    name: JAX Linux x86 AMD Instinct GPU
     runs-on: linux-x86-64-8gpu-amd
     env:
       DOCKER_IMAGE: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa


### PR DESCRIPTION
## Summary
Migrate the JAX unit test (`jax-ut`) stage from the Jenkins CI pipeline to GitHub Actions, aligning with the upstream JAX ROCm test infrastructure introduced in [jax-ml/jax@bec3b79](https://github.com/jax-ml/jax/commit/bec3b7903197321ffa2d0a168733ca337a157a68).

## Changes
- **`.github/workflows/rocm_jax_ut.yml`** - New GHA workflow that:
  - Runs on `linux-x86-64-8gpu-amd` runners inside a `rocm/tensorflow-build` container with GPU device access, 64G shared memory, and bazel tmpfs cache
  - Checks out XLA (this repo) and JAX (`jax-ml/jax`)
  - Sets `JAXCI_*` environment variables and delegates test execution directly to JAX's upstream `ci/run_bazel_test_rocm_rbe.sh`, which defines test targets, tag filters, and exclusions
  - Passes `--override_repository=xla=${GITHUB_WORKSPACE}` to test against this repo's XLA checkout
  - Triggers on PRs, pushes to `main`, and manual dispatch
  - 120-minute timeout on the test step