### PR TITLE
[XLA:GPU] Add Put, Signal, and WaitSignal APIs to Communicator for NCCL

### DIFF
--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -189,11 +189,14 @@ class GpuCommunicator : public Communicator {
     return Unimplemented("LaunchPut is not implemented");
   }
 
-  virtual absl::Status LaunchSignal(const Executor& executor) {
+  virtual absl::Status LaunchSignal(RankId peer, const SignalDesc& desc,
+                                    const Executor& executor) {
     return Unimplemented("LaunchSignal is not implemented");
   }
 
-  virtual absl::Status LaunchWaitSignal(RankId peer, const Executor& executor) {
+  virtual absl::Status LaunchWaitSignal(RankId peer, int op_cnt,
+                                        const SignalDesc& desc,
+                                        const Executor& executor) {
     return Unimplemented("LaunchWaitSignal is not implemented");
   }
 };

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -181,6 +181,21 @@ class GpuCommunicator : public Communicator {
   virtual absl::Status LaunchRecv(se::DeviceAddressBase recv_buffer,
                                   PrimitiveType dtype, size_t count,
                                   RankId peer, const Executor& executor) = 0;
+
+  virtual absl::Status LaunchPut(se::DeviceAddressBase send_buffer,
+                                 SymmetricMemory* recv_buffer, size_t offset,
+                                 size_t count, RankId peer,
+                                 const Executor& executor) {
+    return Unimplemented("LaunchPut is not implemented");
+  }
+
+  virtual absl::Status LaunchSignal(const Executor& executor) {
+    return Unimplemented("LaunchSignal is not implemented");
+  }
+
+  virtual absl::Status LaunchWaitSignal(RankId peer, const Executor& executor) {
+    return Unimplemented("LaunchWaitSignal is not implemented");
+  }
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -189,13 +189,13 @@ class GpuCommunicator : public Communicator {
     return Unimplemented("LaunchPut is not implemented");
   }
 
-  virtual absl::Status LaunchSignal(RankId peer, const SignalDesc& desc,
+  virtual absl::Status LaunchSignal(RankId peer, const SignalDesc& signal_desc,
                                     const Executor& executor) {
     return Unimplemented("LaunchSignal is not implemented");
   }
 
   virtual absl::Status LaunchWaitSignal(RankId peer, int op_cnt,
-                                        const SignalDesc& desc,
+                                        const SignalDesc& signal_desc,
                                         const Executor& executor) {
     return Unimplemented("LaunchWaitSignal is not implemented");
   }

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -569,13 +569,19 @@ Future<> NcclCommunicator::Put(se::DeviceAddressBase send_buffer,
   });
 }
 
-Future<> NcclCommunicator::Signal(const Executor& executor) {
-  return Execute([&executor, this]() { return LaunchSignal(executor); });
+Future<> NcclCommunicator::Signal(RankId peer, const SignalDesc& desc,
+                                  const Executor& executor) {
+  return Execute([peer, &desc, &executor, this]() {
+    return LaunchSignal(peer, desc, executor);
+  });
 }
 
-Future<> NcclCommunicator::WaitSignal(RankId peer, const Executor& executor) {
-  return Execute(
-      [peer, &executor, this]() { return LaunchWaitSignal(peer, executor); });
+Future<> NcclCommunicator::WaitSignal(RankId peer, int op_cnt,
+                                      const SignalDesc& desc,
+                                      const Executor& executor) {
+  return Execute([peer, op_cnt, &desc, &executor, this]() {
+    return LaunchWaitSignal(peer, op_cnt, desc, executor);
+  });
 }
 
 absl::Status NcclCommunicator::GroupStart() {
@@ -953,11 +959,14 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
   return Unimplemented("NCCL Put is not yet implemented");
 }
 
-absl::Status NcclCommunicator::LaunchSignal(const Executor& executor) {
+absl::Status NcclCommunicator::LaunchSignal(RankId peer,
+                                            const SignalDesc& desc,
+                                            const Executor& executor) {
   return Unimplemented("NCCL Signal is not yet implemented");
 }
 
-absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer,
+absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
+                                                const SignalDesc& desc,
                                                 const Executor& executor) {
   return Unimplemented("NCCL WaitSignal is not yet implemented");
 }

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -559,6 +559,25 @@ Future<> NcclCommunicator::Recv(se::DeviceAddressBase recv_buffer,
   });
 }
 
+Future<> NcclCommunicator::Put(se::DeviceAddressBase send_buffer,
+                               SymmetricMemory* recv_buffer, size_t offset,
+                               size_t count, RankId peer,
+                               const Executor& executor) {
+  return Execute([send_buffer, recv_buffer, offset, count, peer, &executor,
+                  this]() {
+    return LaunchPut(send_buffer, recv_buffer, offset, count, peer, executor);
+  });
+}
+
+Future<> NcclCommunicator::Signal(const Executor& executor) {
+  return Execute([&executor, this]() { return LaunchSignal(executor); });
+}
+
+Future<> NcclCommunicator::WaitSignal(RankId peer, const Executor& executor) {
+  return Execute(
+      [peer, &executor, this]() { return LaunchWaitSignal(peer, executor); });
+}
+
 absl::Status NcclCommunicator::GroupStart() {
   VLOG(5) << "Start NCCL group";
   XLA_NCCL_RETURN_IF_ERROR(ncclGroupStart());
@@ -924,6 +943,23 @@ absl::Status NcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
+}
+
+absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
+                                         SymmetricMemory* recv_buffer,
+                                         size_t offset, size_t count,
+                                         RankId peer,
+                                         const Executor& executor) {
+  return Unimplemented("NCCL Put is not yet implemented");
+}
+
+absl::Status NcclCommunicator::LaunchSignal(const Executor& executor) {
+  return Unimplemented("NCCL Signal is not yet implemented");
+}
+
+absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer,
+                                                const Executor& executor) {
+  return Unimplemented("NCCL WaitSignal is not yet implemented");
 }
 
 std::string NcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -569,18 +569,18 @@ Future<> NcclCommunicator::Put(se::DeviceAddressBase send_buffer,
   });
 }
 
-Future<> NcclCommunicator::Signal(RankId peer, const SignalDesc& desc,
+Future<> NcclCommunicator::Signal(RankId peer, const SignalDesc& signal_desc,
                                   const Executor& executor) {
-  return Execute([peer, &desc, &executor, this]() {
-    return LaunchSignal(peer, desc, executor);
+  return Execute([peer, &signal_desc, &executor, this]() {
+    return LaunchSignal(peer, signal_desc, executor);
   });
 }
 
 Future<> NcclCommunicator::WaitSignal(RankId peer, int op_cnt,
-                                      const SignalDesc& desc,
+                                      const SignalDesc& signal_desc,
                                       const Executor& executor) {
-  return Execute([peer, op_cnt, &desc, &executor, this]() {
-    return LaunchWaitSignal(peer, op_cnt, desc, executor);
+  return Execute([peer, op_cnt, &signal_desc, &executor, this]() {
+    return LaunchWaitSignal(peer, op_cnt, signal_desc, executor);
   });
 }
 
@@ -960,13 +960,13 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
 }
 
 absl::Status NcclCommunicator::LaunchSignal(RankId peer,
-                                            const SignalDesc& desc,
+                                            const SignalDesc& signal_desc,
                                             const Executor& executor) {
   return Unimplemented("NCCL Signal is not yet implemented");
 }
 
 absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
-                                                const SignalDesc& desc,
+                                                const SignalDesc& signal_desc,
                                                 const Executor& executor) {
   return Unimplemented("NCCL WaitSignal is not yet implemented");
 }

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -158,10 +158,10 @@ class NcclCommunicator : public GpuCommunicator {
                size_t offset, size_t count, RankId peer,
                const Executor& executor) final;
 
-  Future<> Signal(RankId peer, const SignalDesc& desc,
+  Future<> Signal(RankId peer, const SignalDesc& signal_desc,
                   const Executor& executor) final;
 
-  Future<> WaitSignal(RankId peer, int op_cnt, const SignalDesc& desc,
+  Future<> WaitSignal(RankId peer, int op_cnt, const SignalDesc& signal_desc,
                       const Executor& executor) final;
 
   std::string ToString() const final;
@@ -239,11 +239,11 @@ class NcclCommunicator : public GpuCommunicator {
                          size_t count, RankId peer,
                          const Executor& executor) final;
 
-  absl::Status LaunchSignal(RankId peer, const SignalDesc& desc,
+  absl::Status LaunchSignal(RankId peer, const SignalDesc& signal_desc,
                             const Executor& executor) final;
 
   absl::Status LaunchWaitSignal(RankId peer, int op_cnt,
-                                const SignalDesc& desc,
+                                const SignalDesc& signal_desc,
                                 const Executor& executor) final;
 
   // Polls the communicator until any pending non-blocking operations are "done"

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -143,6 +143,14 @@ class NcclCommunicator : public GpuCommunicator {
   Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
                 size_t count, RankId peer, const Executor& executor) final;
 
+  Future<> Put(se::DeviceAddressBase send_buffer, SymmetricMemory* recv_buffer,
+               size_t offset, size_t count, RankId peer,
+               const Executor& executor) final;
+
+  Future<> Signal(const Executor& executor) final;
+
+  Future<> WaitSignal(RankId peer, const Executor& executor) final;
+
   std::string ToString() const final;
 
   ncclComm_t comm() const { return comm_; }
@@ -212,6 +220,15 @@ class NcclCommunicator : public GpuCommunicator {
   absl::Status LaunchRecv(se::DeviceAddressBase recv_buffer,
                           PrimitiveType dtype, size_t count, RankId peer,
                           const Executor& executor) final;
+
+  absl::Status LaunchPut(se::DeviceAddressBase send_buffer,
+                         SymmetricMemory* recv_buffer, size_t offset,
+                         size_t count, RankId peer,
+                         const Executor& executor) final;
+
+  absl::Status LaunchSignal(const Executor& executor) final;
+
+  absl::Status LaunchWaitSignal(RankId peer, const Executor& executor) final;
 
   // Polls the communicator until any pending non-blocking operations are "done"
   // or aborted.

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -55,6 +55,17 @@ limitations under the License.
 
 namespace xla::gpu {
 
+class NcclSignalDesc final : public Communicator::SignalDesc {
+ public:
+  NcclSignalDesc(int sig_idx, int ctx) : sig_idx_(sig_idx), ctx_(ctx) {}
+  int sig_idx() const { return sig_idx_; }
+  int ctx() const { return ctx_; }
+
+ private:
+  int sig_idx_;
+  int ctx_;
+};
+
 // XLA collectives communicator wrapping an NCCL communicator.
 class NcclCommunicator : public GpuCommunicator {
  public:
@@ -147,9 +158,11 @@ class NcclCommunicator : public GpuCommunicator {
                size_t offset, size_t count, RankId peer,
                const Executor& executor) final;
 
-  Future<> Signal(const Executor& executor) final;
+  Future<> Signal(RankId peer, const SignalDesc& desc,
+                  const Executor& executor) final;
 
-  Future<> WaitSignal(RankId peer, const Executor& executor) final;
+  Future<> WaitSignal(RankId peer, int op_cnt, const SignalDesc& desc,
+                      const Executor& executor) final;
 
   std::string ToString() const final;
 
@@ -226,9 +239,12 @@ class NcclCommunicator : public GpuCommunicator {
                          size_t count, RankId peer,
                          const Executor& executor) final;
 
-  absl::Status LaunchSignal(const Executor& executor) final;
+  absl::Status LaunchSignal(RankId peer, const SignalDesc& desc,
+                            const Executor& executor) final;
 
-  absl::Status LaunchWaitSignal(RankId peer, const Executor& executor) final;
+  absl::Status LaunchWaitSignal(RankId peer, int op_cnt,
+                                const SignalDesc& desc,
+                                const Executor& executor) final;
 
   // Polls the communicator until any pending non-blocking operations are "done"
   // or aborted.

--- a/xla/core/collectives/BUILD
+++ b/xla/core/collectives/BUILD
@@ -71,6 +71,7 @@ cc_library(
     deps = [
         ":rank_id",
         ":reduction_kind",
+        ":symmetric_memory",
         "//xla:future",
         "//xla:util",
         "//xla:xla_data_proto_cc",

--- a/xla/core/collectives/communicator.h
+++ b/xla/core/collectives/communicator.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/util.h"
@@ -159,6 +160,20 @@ class Communicator {
                         se::DeviceAddressBase send_buffer, PrimitiveType dtype,
                         size_t count, RankId peer, const Executor& executor) {
     return Unimplemented("One-way recv is not implemented");
+  }
+
+  virtual Future<> Put(se::DeviceAddressBase send_buffer,
+                       SymmetricMemory* recv_buffer, size_t offset,
+                       size_t count, RankId peer, const Executor& executor) {
+    return Unimplemented("Put is not implemented");
+  }
+
+  virtual Future<> Signal(const Executor& executor) {
+    return Unimplemented("Signal is not implemented");
+  }
+
+  virtual Future<> WaitSignal(RankId peer, const Executor& executor) {
+    return Unimplemented("WaitSignal is not implemented");
   }
 
   // Returns the number of ranks in the communicator.

--- a/xla/core/collectives/communicator.h
+++ b/xla/core/collectives/communicator.h
@@ -55,6 +55,11 @@ class Communicator {
     virtual ~Executor() = default;
   };
 
+  class SignalDesc {
+   public:
+    virtual ~SignalDesc() = default;
+  };
+
   // An RAII handle for buffers registered with the communicator. Child classes
   // are responsible for unregistering the buffer when the handle is destroyed.
   class RegisteredBufferHandle {
@@ -162,17 +167,29 @@ class Communicator {
     return Unimplemented("One-way recv is not implemented");
   }
 
+  // One-sided write: copies data from send_buffer to the peer's symmetric
+  // memory at recv_buffer + offset (count bytes). Used for RMA patterns such as
+  // ragged all-to-all. Does not send signal metadata; use Signal for that.
   virtual Future<> Put(se::DeviceAddressBase send_buffer,
                        SymmetricMemory* recv_buffer, size_t offset,
                        size_t count, RankId peer, const Executor& executor) {
     return Unimplemented("Put is not implemented");
   }
 
-  virtual Future<> Signal(const Executor& executor) {
+  // Sends a signal to peer without transferring data. Can be used as a barrier
+  // or to notify peer that prior Puts (and Signals) to the same descriptor have
+  // completed. desc carries backend-specific signal identity (e.g. sigIdx, ctx).
+  virtual Future<> Signal(RankId peer, const SignalDesc& desc,
+                          const Executor& executor) {
     return Unimplemented("Signal is not implemented");
   }
 
-  virtual Future<> WaitSignal(RankId peer, const Executor& executor) {
+  // Counted wait: completes when this rank has received op_cnt signals from
+  // peer that match desc (e.g. same sigIdx/ctx). Used to synchronize after
+  // Put/Signal; the backend uses desc to match which signals to wait for.
+  virtual Future<> WaitSignal(RankId peer, int op_cnt,
+                              const SignalDesc& desc,
+                              const Executor& executor) {
     return Unimplemented("WaitSignal is not implemented");
   }
 

--- a/xla/core/collectives/communicator.h
+++ b/xla/core/collectives/communicator.h
@@ -178,17 +178,19 @@ class Communicator {
 
   // Sends a signal to peer without transferring data. Can be used as a barrier
   // or to notify peer that prior Puts (and Signals) to the same descriptor have
-  // completed. desc carries backend-specific signal identity (e.g. sigIdx, ctx).
-  virtual Future<> Signal(RankId peer, const SignalDesc& desc,
+  // completed. signal_desc carries backend-specific signal identity (e.g.
+  // sigIdx, ctx).
+  virtual Future<> Signal(RankId peer, const SignalDesc& signal_desc,
                           const Executor& executor) {
     return Unimplemented("Signal is not implemented");
   }
 
   // Counted wait: completes when this rank has received op_cnt signals from
-  // peer that match desc (e.g. same sigIdx/ctx). Used to synchronize after
-  // Put/Signal; the backend uses desc to match which signals to wait for.
+  // peer that match signal_desc (e.g. same sigIdx/ctx). Used to synchronize
+  // after Put/Signal; the backend uses signal_desc to match which signals to
+  // wait for.
   virtual Future<> WaitSignal(RankId peer, int op_cnt,
-                              const SignalDesc& desc,
+                              const SignalDesc& signal_desc,
                               const Executor& executor) {
     return Unimplemented("WaitSignal is not implemented");
   }


### PR DESCRIPTION
📝 Summary of Changes
Adds the Put, Signal, and WaitSignal APIs to the Collectives/Communicator so the NCCL one-sided put path (e.g. ragged all-to-all with symmetric buffers) can be implemented on top of the existing CollectiveMemory and SymmetricMemory APIs.

🎯 Justification
Declare Put/Signal/WaitSignal on the communicator so the NCCL one-sided put path (e.g. ragged all-to-all with symmetric buffers) can be implemented later. Stub implementations only on the NCCL path.

🚀 Kind of Contribution
✨ New Feature/API

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
N/A

🧪 Execution Tests:
N/A
