### PR TITLE
[xla] Fix potentially expensive spin in ObjectPool

### DIFF
--- a/xla/runtime/BUILD
+++ b/xla/runtime/BUILD
@@ -155,6 +155,7 @@ xla_cc_test(
         "//xla/tsl/platform:test_benchmark",
         "//xla/tsl/platform:test_main",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/functional:bind_front",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/synchronization",

--- a/xla/runtime/object_pool.h
+++ b/xla/runtime/object_pool.h
@@ -31,34 +31,71 @@ limitations under the License.
 
 namespace xla {
 
-// A non-blocking pool of objects of type `T`. Objects in the pool are created
+// A lock-free pool of objects of type `T`. Objects in the pool are created
 // lazily when needed by calling the user-provided `builder` function.
 //
 // This object pool is intended to be used on a critical path and optimized for
 // zero-allocation in steady state.
+//
+// ABA problem is avoided by packing a monotonically increasing version counter
+// into the upper bits of the head pointer (above the usable virtual address
+// space). The version counter increments on every CAS, ensuring that even if a
+// pointer value is recycled, the tagged pointer will differ.
 template <typename T, typename... Args>
 class ObjectPool {
-  struct Entry {
+  struct alignas(64) Entry {
     // Keep `object` as optional to allow using object pool for objects that
     // cannot be default-constructed.
     std::optional<T> object;
     Entry* next = nullptr;
   };
 
-  // We use pointer tagging for the logical deletion of entries from the linked
-  // list to avoid data races on the `entry->next` pointer and to avoid ABA
-  // problem. A thread that tries to pop an entry from the pool first tags the
-  // entry pointer to get an exclusive access to the entry, concurrent pop
-  // operations will wait in the spin loop.
-  static constexpr uintptr_t kMask = 0x1;
+  // Tagged pointer layout: [hi tag bits | pointer | lo tag bits]
+  //
+  // We pack a monotonic version counter into bits that are unused in Entry
+  // pointers. The tag is split across two regions:
+  //
+  //  - High bits: above the usable virtual address space. On x86-64 with
+  //    5-level paging (LA57), userspace uses up to 57-bit virtual addresses.
+  //    This leaves 7 high bits.
+  //
+  //  - Low bits: Entry is alignas(64) (cache-line aligned), so the low 6
+  //    bits of any Entry* are always zero.
+  //
+  // Combined: 7 + 6 = 13 tag bits (8192 versions). ABA requires the same
+  // pointer to be popped and re-pushed 8192 times while a single CAS is in
+  // flight. This is a pragmatic choice for XLA where pooled objects (e.g.
+  // stream executor events or XNNPACK executors) used sparingly during a single
+  // execution and we don't expect millions of push/pop events per second.
+  static constexpr int kPtrBits = 57;
+  static constexpr int kLowTagBits = 6;
+  static constexpr uintptr_t kLowTagMask = (uintptr_t{1} << kLowTagBits) - 1;
+  static constexpr uintptr_t kPtrMask =
+      ((uintptr_t{1} << kPtrBits) - 1) & ~kLowTagMask;
+  static constexpr uintptr_t kTagIncr = uintptr_t{1} << kPtrBits;
 
-  static bool IsMarked(Entry* entry) {
-    return (tsl::safe_reinterpret_cast<uintptr_t>(entry) & kMask) == kMask;
+  static_assert(sizeof(uintptr_t) == 8,
+                "ObjectPool tagged pointer requires a 64-bit platform");
+  static_assert(alignof(Entry) >= (1 << kLowTagBits),
+                "Entry alignment must provide enough low tag bits");
+
+  static Entry* GetPtr(uintptr_t tagged) {
+    return tsl::safe_reinterpret_cast<Entry*>(tagged & kPtrMask);
   }
 
-  static Entry* Mark(Entry* entry) {
-    return tsl::safe_reinterpret_cast<Entry*>(
-        tsl::safe_reinterpret_cast<uintptr_t>(entry) | kMask);
+  static uintptr_t MakeTagged(Entry* ptr, uintptr_t old_tagged) {
+    uintptr_t raw = tsl::safe_reinterpret_cast<uintptr_t>(ptr);
+    // Increment the combined tag. Low bits overflow naturally into the pointer
+    // region and then into the high bits — but we must not let tag bits
+    // corrupt the pointer. Instead, manage high and low tag independently:
+    // increment the low tag, and when it wraps, increment the high tag.
+    uintptr_t old_lo = old_tagged & kLowTagMask;
+    uintptr_t new_lo = (old_lo + 1) & kLowTagMask;
+    uintptr_t hi = old_tagged & ~kPtrMask & ~kLowTagMask;
+    if (new_lo == 0) {
+      hi = (hi + kTagIncr);  // carry into high bits
+    }
+    return raw | hi | new_lo;
   }
 
  public:
@@ -97,20 +134,22 @@ class ObjectPool {
   void PushEntry(std::unique_ptr<Entry> entry);
 
   absl::AnyInvocable<absl::StatusOr<T>(Args...)> builder_;
-  std::atomic<Entry*> head_;
+  std::atomic<uintptr_t> head_;
   std::atomic<size_t> num_created_;
 };
 
 template <typename T, typename... Args>
 ObjectPool<T, Args...>::ObjectPool(
     absl::AnyInvocable<absl::StatusOr<T>(Args...)> builder)
-    : builder_(std::move(builder)), head_(nullptr), num_created_(0) {}
+    : builder_(std::move(builder)), head_(0), num_created_(0) {}
 
 template <typename T, typename... Args>
 ObjectPool<T, Args...>::~ObjectPool() {
-  while (Entry* entry = head_.load(std::memory_order_acquire)) {
-    head_.store(entry->next, std::memory_order_relaxed);
+  Entry* entry = GetPtr(head_.load(std::memory_order_acquire));
+  while (entry) {
+    Entry* next = entry->next;
     delete entry;
+    entry = next;
   }
 }
 
@@ -126,41 +165,34 @@ auto ObjectPool<T, Args...>::CreateEntry(Args... args)
 
 template <typename T, typename... Args>
 auto ObjectPool<T, Args...>::PopEntry() -> std::unique_ptr<Entry> {
-  Entry* head = head_.load(std::memory_order_relaxed);
+  uintptr_t head = head_.load(std::memory_order_acquire);
 
-  // Try to mark the entry at head for deletion with a CAS operation.
-  while (head &&
-         (IsMarked(head) || !head_.compare_exchange_weak(
-                                head, Mark(head), std::memory_order_acquire,
-                                std::memory_order_relaxed))) {
-    if (ABSL_PREDICT_FALSE(IsMarked(head))) {
-      head = head_.load(std::memory_order_relaxed);
+  while (Entry* ptr = GetPtr(head)) {
+    // Single CAS: swing head to ptr->next with an incremented version counter.
+    // If another thread modified head between our load and CAS (push or pop),
+    // the version bits will differ and CAS fails — no ABA possible.
+    uintptr_t desired = MakeTagged(ptr->next, head);
+    if (ABSL_PREDICT_TRUE(head_.compare_exchange_weak(
+            head, desired, std::memory_order_acquire,
+            std::memory_order_acquire))) {
+      return std::unique_ptr<Entry>(ptr);
     }
+    // head is reloaded by compare_exchange_weak on failure.
   }
 
-  // Object pool is empty.
-  if (ABSL_PREDICT_FALSE(head == nullptr)) {
-    return nullptr;
-  }
-
-  // Update head pointer to the next entry.
-  head_.store(head->next, std::memory_order_relaxed);
-
-  return std::unique_ptr<Entry>(head);
+  return nullptr;
 }
 
 template <typename T, typename... Args>
 void ObjectPool<T, Args...>::PushEntry(std::unique_ptr<Entry> entry) {
   Entry* new_head = entry.release();
-  new_head->next = head_.load(std::memory_order_relaxed);
-  while (IsMarked(new_head->next) ||
-         !head_.compare_exchange_weak(new_head->next, new_head,
-                                      std::memory_order_release,
-                                      std::memory_order_relaxed)) {
-    if (ABSL_PREDICT_FALSE(IsMarked(new_head->next))) {
-      new_head->next = head_.load(std::memory_order_relaxed);
-    }
-  }
+  uintptr_t head = head_.load(std::memory_order_relaxed);
+
+  do {
+    new_head->next = GetPtr(head);
+  } while (ABSL_PREDICT_FALSE(!head_.compare_exchange_weak(
+      head, MakeTagged(new_head, head), std::memory_order_release,
+      std::memory_order_relaxed)));
 }
 
 template <typename T, typename... Args>

--- a/xla/runtime/object_pool.h
+++ b/xla/runtime/object_pool.h
@@ -43,60 +43,13 @@ namespace xla {
 // pointer value is recycled, the tagged pointer will differ.
 template <typename T, typename... Args>
 class ObjectPool {
+ protected:
   struct alignas(64) Entry {
     // Keep `object` as optional to allow using object pool for objects that
     // cannot be default-constructed.
     std::optional<T> object;
     Entry* next = nullptr;
   };
-
-  // Tagged pointer layout: [hi tag bits | pointer | lo tag bits]
-  //
-  // We pack a monotonic version counter into bits that are unused in Entry
-  // pointers. The tag is split across two regions:
-  //
-  //  - High bits: above the usable virtual address space. On x86-64 with
-  //    5-level paging (LA57), userspace uses up to 57-bit virtual addresses.
-  //    This leaves 7 high bits.
-  //
-  //  - Low bits: Entry is alignas(64) (cache-line aligned), so the low 6
-  //    bits of any Entry* are always zero.
-  //
-  // Combined: 7 + 6 = 13 tag bits (8192 versions). ABA requires the same
-  // pointer to be popped and re-pushed 8192 times while a single CAS is in
-  // flight. This is a pragmatic choice for XLA where pooled objects (e.g.
-  // stream executor events or XNNPACK executors) used sparingly during a single
-  // execution and we don't expect millions of push/pop events per second.
-  static constexpr int kPtrBits = 57;
-  static constexpr int kLowTagBits = 6;
-  static constexpr uintptr_t kLowTagMask = (uintptr_t{1} << kLowTagBits) - 1;
-  static constexpr uintptr_t kPtrMask =
-      ((uintptr_t{1} << kPtrBits) - 1) & ~kLowTagMask;
-  static constexpr uintptr_t kTagIncr = uintptr_t{1} << kPtrBits;
-
-  static_assert(sizeof(uintptr_t) == 8,
-                "ObjectPool tagged pointer requires a 64-bit platform");
-  static_assert(alignof(Entry) >= (1 << kLowTagBits),
-                "Entry alignment must provide enough low tag bits");
-
-  static Entry* GetPtr(uintptr_t tagged) {
-    return tsl::safe_reinterpret_cast<Entry*>(tagged & kPtrMask);
-  }
-
-  static uintptr_t MakeTagged(Entry* ptr, uintptr_t old_tagged) {
-    uintptr_t raw = tsl::safe_reinterpret_cast<uintptr_t>(ptr);
-    // Increment the combined tag. Low bits overflow naturally into the pointer
-    // region and then into the high bits — but we must not let tag bits
-    // corrupt the pointer. Instead, manage high and low tag independently:
-    // increment the low tag, and when it wraps, increment the high tag.
-    uintptr_t old_lo = old_tagged & kLowTagMask;
-    uintptr_t new_lo = (old_lo + 1) & kLowTagMask;
-    uintptr_t hi = old_tagged & ~kPtrMask & ~kLowTagMask;
-    if (new_lo == 0) {
-      hi = (hi + kTagIncr);  // carry into high bits
-    }
-    return raw | hi | new_lo;
-  }
 
  public:
   explicit ObjectPool(absl::AnyInvocable<absl::StatusOr<T>(Args...)> builder);
@@ -127,6 +80,54 @@ class ObjectPool {
     return num_created_.load(std::memory_order_relaxed);
   }
 
+ protected:
+  // Tagged pointer layout: [hi tag bits | pointer | lo tag bits]
+  //
+  // We pack a monotonic version counter into bits that are unused in Entry
+  // pointers. The tag is split across two regions:
+  //
+  //  - High bits: above the usable virtual address space. On x86-64 with
+  //    5-level paging (LA57), userspace uses up to 57-bit virtual addresses.
+  //    This leaves 7 high bits.
+  //
+  //  - Low bits: Entry is alignas(64) (cache-line aligned), so the low 6
+  //    bits of any Entry* are always zero.
+  //
+  // Combined: 7 + 6 = 13 tag bits (8192 versions). ABA requires the same
+  // pointer to be popped and re-pushed 8192 times while a single CAS is in
+  // flight. This is a pragmatic choice for XLA where pooled objects (e.g.
+  // stream executor events or XNNPACK executors) used sparingly during a single
+  // execution and we don't expect millions of push/pop events per second.
+  static constexpr int32_t kPtrBits = 57;
+  static constexpr int32_t kLowTagBits = 6;
+
+  static constexpr uintptr_t kLowTagMask = (uintptr_t{1} << kLowTagBits) - 1;
+  static constexpr uintptr_t kPtrMask =
+      ((uintptr_t{1} << kPtrBits) - 1) & ~kLowTagMask;
+  static constexpr uintptr_t kTagIncr = uintptr_t{1} << kPtrBits;
+
+  static Entry* GetPtr(uintptr_t tagged) {
+    return tsl::safe_reinterpret_cast<Entry*>(tagged & kPtrMask);
+  }
+
+  static size_t GetTag(uintptr_t tagged) {
+    uintptr_t lo = tagged & kLowTagMask;
+    uintptr_t hi = (tagged >> kPtrBits);
+    return (hi << kLowTagBits) | lo;
+  }
+
+  static uintptr_t PackTagBits(size_t tag) {
+    uintptr_t lo = tag & kLowTagMask;
+    uintptr_t hi = tag >> kLowTagBits;
+    return (hi << kPtrBits) | lo;
+  }
+
+  static uintptr_t MakeTagged(Entry* ptr, uintptr_t old_tagged) {
+    uintptr_t raw = tsl::safe_reinterpret_cast<uintptr_t>(ptr);
+    DCHECK_EQ(raw & ~kPtrMask, 0) << "pointer has non-zero tag bits";
+    return raw | PackTagBits(GetTag(old_tagged) + 1);
+  }
+
  private:
   absl::StatusOr<std::unique_ptr<Entry>> CreateEntry(Args... args);
 
@@ -141,7 +142,12 @@ class ObjectPool {
 template <typename T, typename... Args>
 ObjectPool<T, Args...>::ObjectPool(
     absl::AnyInvocable<absl::StatusOr<T>(Args...)> builder)
-    : builder_(std::move(builder)), head_(0), num_created_(0) {}
+    : builder_(std::move(builder)), head_(0), num_created_(0) {
+  static_assert(sizeof(uintptr_t) == 8,
+                "ObjectPool tagged pointer requires a 64-bit platform");
+  static_assert(alignof(Entry) >= (1 << kLowTagBits),
+                "Entry alignment must provide enough low tag bits");
+}
 
 template <typename T, typename... Args>
 ObjectPool<T, Args...>::~ObjectPool() {

--- a/xla/runtime/object_pool_test.cc
+++ b/xla/runtime/object_pool_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/functional/bind_front.h"
 #include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/blocking_counter.h"
@@ -36,13 +37,25 @@ limitations under the License.
 namespace xla {
 namespace {
 
-using IntPool = ObjectPool<std::unique_ptr<int32_t>>;
+struct IntPool : public ObjectPool<std::unique_ptr<int32_t>> {
+  using Base = ObjectPool<std::unique_ptr<int32_t>>;
+  IntPool() : Base(absl::bind_front(&IntPool::Create, this)) {}
+
+  // Expose protected members for testing.
+  using Base::Entry;
+  using Base::GetPtr;
+  using Base::GetTag;
+  using Base::MakeTagged;
+
+  std::unique_ptr<int32_t> Create() {
+    return std::make_unique<int32_t>(counter++);
+  }
+
+  int32_t counter = 0;
+};
 
 TEST(ObjectPoolTest, GetOrCreate) {
-  int32_t counter = 0;
-  IntPool pool([&]() -> absl::StatusOr<std::unique_ptr<int32_t>> {
-    return std::make_unique<int32_t>(counter++);
-  });
+  IntPool pool;
 
   TF_ASSERT_OK_AND_ASSIGN(auto obj0, pool.GetOrCreate());
   ASSERT_EQ(**obj0, 0);
@@ -56,7 +69,7 @@ TEST(ObjectPoolTest, GetOrCreate) {
 
   TF_ASSERT_OK_AND_ASSIGN(auto obj2, pool.GetOrCreate());
   ASSERT_EQ(**obj2, 1);
-  ASSERT_EQ(counter, 2);
+  ASSERT_EQ(pool.counter, 2);
 }
 
 TEST(ObjectPoolTest, GetOrCreateUnderContention) {
@@ -109,14 +122,46 @@ TEST(ObjectPoolTest, GetOrCreateUnderContention) {
   EXPECT_EQ(sum, num_tasks * num_iters);
 }
 
+TEST(ObjectPoolTest, GetTagStartsAtZero) { EXPECT_EQ(IntPool::GetTag(0), 0); }
+
+TEST(ObjectPoolTest, GetTagIncrementsMonotonically) {
+  IntPool::Entry entry;
+  IntPool::Entry* raw = &entry;
+
+  uintptr_t tagged = 0;
+  for (size_t i = 1; i <= 200; ++i) {
+    tagged = IntPool::MakeTagged(raw, tagged);
+    EXPECT_EQ(IntPool::GetTag(tagged), i);
+  }
+}
+
+TEST(ObjectPoolTest, GetTagWithNullPointer) {
+  uintptr_t tagged = 0;
+  for (size_t i = 1; i <= 200; ++i) {
+    tagged = IntPool::MakeTagged(nullptr, tagged);
+    EXPECT_EQ(IntPool::GetTag(tagged), i);
+  }
+}
+
+TEST(ObjectPoolTest, GetTagSurvivesLowTagWrap) {
+  IntPool::Entry entry;
+  IntPool::Entry* raw = &entry;
+
+  // Increment past the low-tag boundary (2^kLowTagBits = 64) to verify the
+  // counter remains correct when the low bits wrap and carry into high bits.
+  uintptr_t tagged = 0;
+  for (size_t i = 1; i <= 128; ++i) {
+    tagged = IntPool::MakeTagged(raw, tagged);
+  }
+  EXPECT_EQ(IntPool::GetTag(tagged), 128);
+}
+
 //===----------------------------------------------------------------------===//
 // Performance benchmarks.
 //===----------------------------------------------------------------------===//
 
 static void BM_GetOrCreate(benchmark::State& state) {
-  IntPool pool([cnt = 0]() mutable -> absl::StatusOr<std::unique_ptr<int32_t>> {
-    return std::make_unique<int32_t>(cnt++);
-  });
+  IntPool pool;
 
   for (auto _ : state) {
     auto obj = pool.GetOrCreate();
@@ -129,14 +174,11 @@ static void BM_GetOrCreate(benchmark::State& state) {
 BENCHMARK(BM_GetOrCreate);
 
 static void BM_GetOrCreateUnderContention(benchmark::State& state) {
+  IntPool pool;
+
   size_t num_threads = state.range(0);
   size_t num_iters = state.range(1);
-
   tsl::thread::ThreadPool threads(tsl::Env::Default(), "bench", num_threads);
-
-  IntPool pool([cnt = 0]() mutable -> absl::StatusOr<std::unique_ptr<int32_t>> {
-    return std::make_unique<int32_t>(cnt++);
-  });
 
   for (auto _ : state) {
     absl::BlockingCounter blocking_counter(num_threads);


### PR DESCRIPTION
The previous implementation used a pointer mark bit to gain exclusive access during pop, which caused all concurrent push/pop operations to spin-wait — making it obstruction-free, not lock-free. Replace with a version counter packed into the upper 12 bits of the head pointer (52-bit VA, safe for both x86-64 and ARM64). Pop and push are now single-CAS operations where no thread can block another.

```
------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------
BM_GetOrCreate                                          8.37 ns         8.37 ns     83134582 items_per_second=119.519M/s
BM_GetOrCreateUnderContention/1/1000/process_time      19335 ns        25475 ns        27939 items_per_second=39.2536M/s
BM_GetOrCreateUnderContention/2/1000/process_time      33608 ns        67020 ns         9940 items_per_second=29.8416M/s
BM_GetOrCreateUnderContention/4/1000/process_time     251662 ns       781488 ns          829 items_per_second=5.11844M/s
BM_GetOrCreateUnderContention/8/1000/process_time    1025087 ns      6448060 ns          122 items_per_second=1.24068M/s
```