### PR TITLE
[ROCm] Fix ROCm accuracy budget for intrinsic_accuracy_test

### DIFF
--- a/xla/codegen/intrinsic/accuracy/accuracy_budget.h
+++ b/xla/codegen/intrinsic/accuracy/accuracy_budget.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define XLA_CODEGEN_INTRINSIC_ACCURACY_ACCURACY_BUDGET_H_
 
 #include <cstdint>
+#include <optional>
 
 namespace xla::codegen::intrinsic::accuracy {
 
@@ -33,6 +34,7 @@ struct UlpBudget {
 struct AccuracyBudget {
   UlpBudget cpu;
   UlpBudget gpu;
+  std::optional<UlpBudget> rocm_gpu = {};
 };
 
 // Exp
@@ -65,6 +67,9 @@ constexpr AccuracyBudget kLog1pF64Budget = {
     /*gpu=*/
     {/*regular=*/1,
      /*subnormal=*/0},
+    /*rocm_gpu=*/
+    UlpBudget{/*regular=*/2,
+              /*subnormal=*/1},
 };
 
 // Log
@@ -74,6 +79,9 @@ constexpr AccuracyBudget kLogF32Budget = {
     /*gpu=*/
     {/*regular=*/1,
      /*subnormal=*/0},
+    /*rocm_gpu=*/
+    UlpBudget{/*regular=*/3,
+              /*subnormal=*/0},
 };
 
 constexpr AccuracyBudget kLogF64Budget = {
@@ -104,6 +112,10 @@ constexpr AccuracyBudget kRsqrtF64Budget = {
     {/*regular=*/0,
      /*subnormal=*/0,
      /*special_values=*/2},
+    /*rocm_gpu=*/
+    UlpBudget{/*regular=*/1,
+              /*subnormal=*/0,
+              /*special_values=*/2},
 };
 
 // Tanh
@@ -130,6 +142,9 @@ constexpr AccuracyBudget kErfF32Budget = {
     /*gpu=*/
     {/*regular=*/2,
      /*subnormal=*/0},
+    /*rocm_gpu=*/
+    UlpBudget{/*regular=*/3,
+              /*subnormal=*/0},
 };
 
 constexpr AccuracyBudget kErfF64Budget = {

--- a/xla/codegen/intrinsic/accuracy/intrinsic_accuracy_test.cc
+++ b/xla/codegen/intrinsic/accuracy/intrinsic_accuracy_test.cc
@@ -308,6 +308,10 @@ class HloIntrinsicAccuracyParamTest
     return test_runner().HasProperty(HloRunnerPropertyTag::kCpu);
   }
 
+  bool is_rocm() const {
+    return test_runner().HasProperty(HloRunnerPropertyTag::kUsingGpuRocm);
+  }
+
  private:
   template <typename T>
   void DoRunAccuracyTest(const IntrinsicAccuracyTestParam& param) {
@@ -346,7 +350,10 @@ class HloIntrinsicAccuracyParamTest
                                            result_data.size());
     LogAccuracyReport(report, ToPascalCase(param.hlo_op_name));
 
-    const UlpBudget& budget = is_cpu() ? param.budget.cpu : param.budget.gpu;
+    const UlpBudget& budget = is_cpu() ? param.budget.cpu
+                              : (is_rocm() && param.budget.rocm_gpu.has_value())
+                                  ? *param.budget.rocm_gpu
+                                  : param.budget.gpu;
 
     EXPECT_LE(report.regular.max_ulp_error, budget.regular)
         << "Regular max ULP error " << report.regular.max_ulp_error


### PR DESCRIPTION
Introduce ROCm-specific accuracy budgets to fix `intrinsic_accuracy_test`. Values based on https://github.com/ROCm/llvm-project/blob/amd-staging/amd/device-libs/doc/OCML.md as well as empirical measurements.