### PR TITLE
[xla:gpu] Migrate all thunks with nested sequences to ThunkSequenceProto

### DIFF
--- a/xla/backends/gpu/codegen/BUILD
+++ b/xla/backends/gpu/codegen/BUILD
@@ -224,7 +224,6 @@ xla_test(
         "//xla:xla_proto_cc",
         "//xla/backends/gpu:ffi",
         "//xla/backends/gpu/runtime:dynamic_slice_thunk",
-        "//xla/backends/gpu/runtime:sequential_thunk",
         "//xla/backends/gpu/runtime:thunk",
         "//xla/backends/gpu/runtime:thunk_executor",
         "//xla/backends/gpu/runtime:while_thunk",

--- a/xla/backends/gpu/codegen/dynamic_slice_fusion_test.cc
+++ b/xla/backends/gpu/codegen/dynamic_slice_fusion_test.cc
@@ -28,7 +28,6 @@ limitations under the License.
 #include "absl/strings/ascii.h"
 #include "xla/backends/gpu/ffi.h"
 #include "xla/backends/gpu/runtime/dynamic_slice_thunk.h"
-#include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk_executor.h"
 #include "xla/backends/gpu/runtime/while_thunk.h"
@@ -3309,10 +3308,7 @@ TEST_F(DynamicSliceFusionTest,
   DynamicSliceThunk* dynamic_slice_thunk =
       dynamic_cast<DynamicSliceThunk*>(thunks[2].get());
   ASSERT_NE(dynamic_slice_thunk, nullptr);
-  const SequentialThunk* embedded_thunk = dynamic_cast<const SequentialThunk*>(
-      dynamic_slice_thunk->embedded_thunk());
-  ASSERT_NE(embedded_thunk, nullptr);
-  EXPECT_THAT(embedded_thunk->thunks(),
+  EXPECT_THAT(dynamic_slice_thunk->get_embedded_executor().thunks(),
               ::testing::ElementsAre(ThunkKindIs(Thunk::kReduceScatterStart)));
 
   // Check that the offsets were propagated as constants, and not as device

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -398,8 +398,8 @@ cc_library(
     hdrs = ["dynamic_slice_thunk.h"],
     deps = [
         ":dynamic_slice_thunk_proto_cc",
-        ":sequential_thunk",
         ":thunk",
+        ":thunk_executor",
         ":thunk_proto_cc",
         "//xla:literal",
         "//xla:literal_util",
@@ -415,8 +415,7 @@ cc_library(
         "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
-        "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -444,7 +443,6 @@ xla_test(
         ":dynamic_slice_thunk",
         ":dynamic_slice_thunk_proto_cc",
         ":gemm_thunk",
-        ":sequential_thunk",
         ":thunk",
         ":thunk_proto_deserialization",
         "//xla:shape_util",
@@ -480,7 +478,6 @@ xla_test(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
-        "@com_google_protobuf//:protobuf_lite",
     ],
 )
 
@@ -619,7 +616,6 @@ cc_library(
     hdrs = ["conditional_thunk.h"],
     deps = [
         ":host_memory_pool",
-        ":sequential_thunk",
         ":thunk",
         ":thunk_executor",
         ":thunk_proto_cc",
@@ -632,7 +628,6 @@ cc_library(
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:status_macros",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/functional:overload",
@@ -3147,7 +3142,6 @@ cc_library(
     hdrs = ["while_thunk.h"],
     deps = [
         ":host_memory_pool",
-        ":sequential_thunk",
         ":thunk",
         ":thunk_executor",
         ":thunk_proto_cc",
@@ -3161,7 +3155,6 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:status_macros",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
@@ -3767,7 +3760,6 @@ xla_cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
-        "@com_google_protobuf//:protobuf_lite",
     ],
 )
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -248,7 +248,7 @@ static absl::StatusOr<std::unique_ptr<Command>> Convert(
     const DynamicSliceThunk& thunk, const ConvertToCommandsOptions& options) {
   TF_ASSIGN_OR_RETURN(
       CommandExecutor embedded_cmds,
-      ConvertToCommands(thunk.get_embedded_thunk()->thunks(), options));
+      ConvertToCommands(thunk.get_embedded_executor().thunks(), options));
 
   auto& thunk_fake_allocations = thunk.get_fake_allocations();
   std::vector<BufferAllocation> fake_allocations;

--- a/xla/backends/gpu/runtime/conditional_thunk.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk.cc
@@ -32,7 +32,6 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/runtime/host_memory_pool.h"
-#include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/backends/gpu/runtime/thunk_executor.h"
@@ -40,10 +39,9 @@ limitations under the License.
 #include "xla/service/shaped_slice.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/device_address.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -91,8 +89,8 @@ absl::Status ConditionalThunk::Initialize(const InitializeParams& params) {
   if (!host_memory_pools_.contains(params.executor)) {
     PrimitiveType type =
         branch_index_is_bool_ ? PrimitiveType::PRED : PrimitiveType::S32;
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<HostMemoryPool> pool,
-                        HostMemoryPool::Create(params.executor, type));
+    ASSIGN_OR_RETURN(std::unique_ptr<HostMemoryPool> pool,
+                     HostMemoryPool::Create(params.executor, type));
     host_memory_pools_[params.executor] = std::move(pool);
   }
 
@@ -107,7 +105,7 @@ absl::Status ConditionalThunk::ExecuteOnStream(const ExecuteParams& params) {
     absl::MutexLock lock(mutex_);
     pool = host_memory_pools_.at(stream.parent()).get();
   }
-  TF_ASSIGN_OR_RETURN(HostMemoryPool::Handle handle, pool->Acquire());
+  ASSIGN_OR_RETURN(HostMemoryPool::Handle handle, pool->Acquire());
 
   // Copy the predicate value from device.
   auto branch_index_or_pred = [&]() -> std::variant<int32_t*, bool*> {
@@ -176,13 +174,13 @@ absl::StatusOr<ThunkProto> ConditionalThunk::ToProto() const {
   *proto.mutable_thunk_info() = thunk_info().ToProto();
 
   auto* conditional_thunk_proto = proto.mutable_conditional_thunk();
-  TF_ASSIGN_OR_RETURN(*conditional_thunk_proto->mutable_branch_index_buffer(),
-                      branch_index_buffer_index_.ToProto());
+  ASSIGN_OR_RETURN(*conditional_thunk_proto->mutable_branch_index_buffer(),
+                   branch_index_buffer_index_.ToProto());
 
   for (const ThunkExecutor& branch_executor : branch_executors_) {
-    SequentialThunkProto thunk_sequence_proto;
+    ThunkSequenceProto thunk_sequence_proto;
     for (const std::unique_ptr<Thunk>& thunk : branch_executor.thunks()) {
-      TF_ASSIGN_OR_RETURN(*thunk_sequence_proto.add_thunks(), thunk->ToProto());
+      ASSIGN_OR_RETURN(*thunk_sequence_proto.add_thunks(), thunk->ToProto());
     }
     *conditional_thunk_proto->add_branch_thunks() =
         std::move(thunk_sequence_proto);
@@ -194,17 +192,19 @@ absl::StatusOr<std::unique_ptr<ConditionalThunk>> ConditionalThunk::FromProto(
     ThunkInfo thunk_info, const ConditionalThunkProto& thunk_proto,
     absl::Span<const BufferAllocation> buffer_allocations,
     const Deserializer& deserializer) {
-  TF_ASSIGN_OR_RETURN(ShapedSlice branch_index_buffer_index,
-                      ShapedSlice::FromProto(thunk_proto.branch_index_buffer(),
-                                             buffer_allocations));
+  ASSIGN_OR_RETURN(ShapedSlice branch_index_buffer_index,
+                   ShapedSlice::FromProto(thunk_proto.branch_index_buffer(),
+                                          buffer_allocations));
 
   std::vector<ThunkSequence> branch_thunks;
   branch_thunks.reserve(thunk_proto.branch_thunks_size());
   for (const auto& thunk_sequence_proto : thunk_proto.branch_thunks()) {
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<SequentialThunk> seq_thunk,
-                        SequentialThunk::FromProto(
-                            thunk_info, thunk_sequence_proto, deserializer));
-    branch_thunks.push_back(std::move(seq_thunk->thunks()));
+    ThunkSequence thunks;
+    for (const auto& proto : thunk_sequence_proto.thunks()) {
+      ASSIGN_OR_RETURN(std::unique_ptr<Thunk> thunk, deserializer(proto));
+      thunks.push_back(std::move(thunk));
+    }
+    branch_thunks.push_back(std::move(thunks));
   }
   return std::make_unique<ConditionalThunk>(std::move(thunk_info),
                                             branch_index_buffer_index,

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk.cc
@@ -38,7 +38,6 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "llvm/ADT/STLExtras.h"
 #include "xla/backends/gpu/runtime/dynamic_slice_thunk.pb.h"
-#include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/hlo/evaluator/hlo_evaluator.h"
@@ -55,8 +54,7 @@ limitations under the License.
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream.h"
-#include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/xla_data.pb.h"
 
 namespace xla {
@@ -98,16 +96,14 @@ DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata::ToProto() const {
 absl::StatusOr<DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata>
 DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata::FromProto(
     const OffsetAsFunctionOfIndvarModulesMetadataProto& proto) {
-  TF_ASSIGN_OR_RETURN(
-      std::unique_ptr<HloModule> indvar_init,
-      HloModule::CreateFromProtoWithConfig(proto.indvar_init()));
-  TF_ASSIGN_OR_RETURN(
-      std::unique_ptr<HloModule> indvar_update,
-      HloModule::CreateFromProtoWithConfig(proto.indvar_update()));
+  ASSIGN_OR_RETURN(std::unique_ptr<HloModule> indvar_init,
+                   HloModule::CreateFromProtoWithConfig(proto.indvar_init()));
+  ASSIGN_OR_RETURN(std::unique_ptr<HloModule> indvar_update,
+                   HloModule::CreateFromProtoWithConfig(proto.indvar_update()));
   std::vector<std::unique_ptr<HloModule>> extracted_offset_modules;
   for (const auto& module_proto : proto.extracted_offset_modules()) {
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<HloModule> module,
-                        HloModule::CreateFromProtoWithConfig(module_proto));
+    ASSIGN_OR_RETURN(std::unique_ptr<HloModule> module,
+                     HloModule::CreateFromProtoWithConfig(module_proto));
     extracted_offset_modules.push_back(std::move(module));
   }
   return OffsetAsFunctionOfIndvarModulesMetadata(
@@ -186,8 +182,7 @@ DynamicSliceThunk::DynamicSliceThunk(
     std::optional<OffsetAsFunctionOfIndvarModulesMetadata>
         offset_as_function_of_indvar_metadata)
     : Thunk(Kind::kDynamicSlice, thunk_info),
-      embedded_thunk_(std::make_unique<SequentialThunk>(
-          ThunkInfo(), std::move(*embedded_thunk))),
+      embedded_executor_(std::move(*embedded_thunk)),
       arguments_(arguments),
       fake_allocations_(std::move(fake_allocations)),
       offsets_(offsets),
@@ -239,7 +234,7 @@ absl::Status DynamicSliceThunk::Prepare(const PrepareParams& params) {
     }
   }
 
-  TF_RETURN_IF_ERROR(embedded_thunk_->Prepare(params));
+  RETURN_IF_ERROR(embedded_executor_.Prepare(params));
 
   if (offset_as_function_of_indvar_metadata_.has_value()) {
     Indvar(this) =
@@ -259,7 +254,7 @@ absl::Status DynamicSliceThunk::Prepare(const PrepareParams& params) {
 }
 
 absl::Status DynamicSliceThunk::Initialize(const InitializeParams& params) {
-  TF_RETURN_IF_ERROR(embedded_thunk_->Initialize(params));
+  RETURN_IF_ERROR(embedded_executor_.Initialize(params));
 
   absl::MutexLock lock(mutex_);
   if (offsets_allocs_.contains(params.executor)) {
@@ -268,9 +263,8 @@ absl::Status DynamicSliceThunk::Initialize(const InitializeParams& params) {
 
   VLOG(2) << "Allocate " << offsets_allocs_size_
           << " bytes for transferring offsets on executor: " << params.executor;
-  TF_ASSIGN_OR_RETURN(
-      std::unique_ptr<se::MemoryAllocation> allocation,
-      params.executor->HostMemoryAllocate(offsets_allocs_size_));
+  ASSIGN_OR_RETURN(std::unique_ptr<se::MemoryAllocation> allocation,
+                   params.executor->HostMemoryAllocate(offsets_allocs_size_));
   offsets_allocs_.emplace(params.executor, std::move(allocation));
 
   return absl::OkStatus();
@@ -335,9 +329,8 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
         offset_value(argument_idx, offset_idx) = *const_offset;
 
       } else if (HloModule** offset_module = std::get_if<HloModule*>(&offset)) {
-        TF_ASSIGN_OR_RETURN(
-            Literal offset,
-            HloEvaluator().Evaluate(**offset_module, {&Indvar(this)}));
+        ASSIGN_OR_RETURN(Literal offset, HloEvaluator().Evaluate(
+                                             **offset_module, {&Indvar(this)}));
         auto offset_int = LiteralUtil::LiteralAsScalarInt64(offset);
         if (offset_int.has_value()) {
           offset_value(argument_idx, offset_idx) = *offset_int;
@@ -359,7 +352,7 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
 
         // Copy the `offset_idx`-th component of the offset for the
         // `argument_idx`-th argument from device to host.
-        TF_RETURN_IF_ERROR(stream.Memcpy(
+        RETURN_IF_ERROR(stream.Memcpy(
             offset_dst, offset_src,
             ShapeUtil::ByteSizeOfPrimitiveType(*slice.offset_primitive_type)));
         ++num_transfers;
@@ -369,7 +362,7 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
     // Wait for the completion of all transfers.
     if (num_transfers > 0) {
       VLOG(2) << "Wait for completion of " << num_transfers << " transfer";
-      TF_RETURN_IF_ERROR(stream.BlockHostUntilDone());
+      RETURN_IF_ERROR(stream.BlockHostUntilDone());
     }
 
     // Clamp start indices:
@@ -419,7 +412,7 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
       Thunk::ExecuteParams::CloneWithNewAllocations(params, slice_allocations);
 
   // Execute the underlying custom call thunk with the new buffers.
-  TF_RETURN_IF_ERROR(embedded_thunk_->ExecuteOnStream(new_params));
+  RETURN_IF_ERROR(embedded_executor_.ExecuteOnStream(new_params));
 
   if (offset_as_function_of_indvar_metadata_.has_value()) {
     Indvar(this) =
@@ -434,13 +427,11 @@ absl::Status DynamicSliceThunk::ExecuteOnStream(const ExecuteParams& params) {
 }
 
 absl::Status DynamicSliceThunk::WalkNested(Walker callback) {
-  return embedded_thunk_->Walk(callback);
+  return embedded_executor_.thunks().WalkNested(callback);
 }
 
 absl::Status DynamicSliceThunk::TransformNested(Transformer callback) {
-  TF_RETURN_IF_ERROR(embedded_thunk_->TransformNested(callback));
-  TF_ASSIGN_OR_RETURN(auto thunk, callback(std::move(embedded_thunk_)));
-  embedded_thunk_ = SequentialThunk::FromThunk(std::move(thunk));
+  RETURN_IF_ERROR(embedded_executor_.thunks().TransformNested(callback));
   return absl::OkStatus();
 }
 
@@ -485,8 +476,8 @@ SerializeOptionalDynamicSliceOffsetsToProto(
         offset_proto.set_const_offset(*const_offset);
       } else if (const BufferAllocation::Slice* slice_offset =
                      std::get_if<BufferAllocation::Slice>(&offset)) {
-        TF_ASSIGN_OR_RETURN(*offset_proto.mutable_slice_offset(),
-                            slice_offset->ToProto());
+        ASSIGN_OR_RETURN(*offset_proto.mutable_slice_offset(),
+                         slice_offset->ToProto());
       } else if (const HloModule* const* module_offset =
                      std::get_if<HloModule*>(&offset)) {
         TF_RET_CHECK(offset_as_function_of_indvar_metadata.has_value());
@@ -514,10 +505,9 @@ absl::Status SerializeOffsetsToProto(
         offset_as_function_of_indvar_metadata,
     DynamicSliceThunkProto* proto) {
   for (const auto& offsets_item : offsets) {
-    TF_ASSIGN_OR_RETURN(
-        *proto->add_offsets(),
-        SerializeOptionalDynamicSliceOffsetsToProto(
-            offsets_item, offset_as_function_of_indvar_metadata));
+    ASSIGN_OR_RETURN(*proto->add_offsets(),
+                     SerializeOptionalDynamicSliceOffsetsToProto(
+                         offsets_item, offset_as_function_of_indvar_metadata));
   }
   return absl::OkStatus();
 }
@@ -540,9 +530,9 @@ DeserializeOptionalDynamicSliceOffsetsFromProto(
         offsets.push_back(offset_proto.const_offset());
         break;
       case DynamicSliceOffsetProto::kSliceOffset: {
-        TF_ASSIGN_OR_RETURN(
-            auto slice, BufferAllocation::Slice::FromProto(
-                            offset_proto.slice_offset(), buffer_allocations));
+        ASSIGN_OR_RETURN(auto slice,
+                         BufferAllocation::Slice::FromProto(
+                             offset_proto.slice_offset(), buffer_allocations));
         offsets.push_back(slice);
         break;
       }
@@ -572,10 +562,10 @@ DeserializeOffsetsFromProto(
         offset_as_function_of_indvar_metadata) {
   std::vector<std::optional<std::vector<DynamicSliceThunk::Offset>>> offsets;
   for (const auto& offsets_proto : proto.offsets()) {
-    TF_ASSIGN_OR_RETURN(offsets.emplace_back(),
-                        DeserializeOptionalDynamicSliceOffsetsFromProto(
-                            offsets_proto, buffer_allocations,
-                            offset_as_function_of_indvar_metadata));
+    ASSIGN_OR_RETURN(offsets.emplace_back(),
+                     DeserializeOptionalDynamicSliceOffsetsFromProto(
+                         offsets_proto, buffer_allocations,
+                         offset_as_function_of_indvar_metadata));
   }
   return offsets;
 }
@@ -587,21 +577,21 @@ absl::StatusOr<ThunkProto> DynamicSliceThunk::ToProto() const {
   DynamicSliceThunkProto* dynamic_slice_proto =
       proto.mutable_dynamic_slice_thunk();
 
-  TF_ASSIGN_OR_RETURN(ThunkProto embedded_thunk_proto,
-                      embedded_thunk_->ToProto());
-  TF_RET_CHECK(embedded_thunk_proto.has_sequential_thunk());
-  *dynamic_slice_proto->mutable_embedded_thunk() =
-      std::move(embedded_thunk_proto.sequential_thunk());
+  ThunkSequenceProto* embedded_proto =
+      dynamic_slice_proto->mutable_embedded_thunk();
+  for (const auto& thunk : embedded_executor_.thunks()) {
+    ASSIGN_OR_RETURN(*embedded_proto->add_thunks(), thunk->ToProto());
+  }
 
   // arguments
   for (const auto& arg : arguments_) {
     auto& proto_arg = *dynamic_slice_proto->add_arguments();
     if (arg.has_value()) {
-      TF_ASSIGN_OR_RETURN(*proto_arg.mutable_slice(), arg->ToProto());
+      ASSIGN_OR_RETURN(*proto_arg.mutable_slice(), arg->ToProto());
     }
   }
 
-  TF_RETURN_IF_ERROR(SerializeOffsetsToProto(
+  RETURN_IF_ERROR(SerializeOffsetsToProto(
       offsets_, offset_as_function_of_indvar_metadata_, dynamic_slice_proto));
 
   // orig_shapes
@@ -631,7 +621,7 @@ absl::StatusOr<ThunkProto> DynamicSliceThunk::ToProto() const {
 
   // offset_as_function_of_indvar_metadata
   if (offset_as_function_of_indvar_metadata_.has_value()) {
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         *dynamic_slice_proto
              ->mutable_offset_as_function_of_indvar_modules_metadata(),
         offset_as_function_of_indvar_metadata_->ToProto());
@@ -653,7 +643,7 @@ absl::StatusOr<std::unique_ptr<DynamicSliceThunk>> DynamicSliceThunk::FromProto(
   std::optional<OffsetAsFunctionOfIndvarModulesMetadata>
       offset_as_function_of_indvar_metadata;
   if (proto.has_offset_as_function_of_indvar_modules_metadata()) {
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         offset_as_function_of_indvar_metadata,
         OffsetAsFunctionOfIndvarModulesMetadata::FromProto(
             proto.offset_as_function_of_indvar_modules_metadata()));
@@ -663,13 +653,13 @@ absl::StatusOr<std::unique_ptr<DynamicSliceThunk>> DynamicSliceThunk::FromProto(
   for (auto& arg_proto : proto.arguments()) {
     arguments.push_back(std::nullopt);
     if (arg_proto.has_slice()) {
-      TF_ASSIGN_OR_RETURN(arguments.back(),
-                          BufferAllocation::Slice::FromProto(
-                              arg_proto.slice(), buffer_allocations));
+      ASSIGN_OR_RETURN(arguments.back(),
+                       BufferAllocation::Slice::FromProto(arg_proto.slice(),
+                                                          buffer_allocations));
     }
   }
 
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       std::vector<std::optional<std::vector<Offset>>> offsets,
       DeserializeOffsetsFromProto(proto, buffer_allocations,
                                   offset_as_function_of_indvar_metadata));
@@ -678,8 +668,8 @@ absl::StatusOr<std::unique_ptr<DynamicSliceThunk>> DynamicSliceThunk::FromProto(
   for (auto& shape_proto : proto.orig_shapes()) {
     orig_shapes.push_back(std::nullopt);
     if (shape_proto.has_shape()) {
-      TF_ASSIGN_OR_RETURN(orig_shapes.back(),
-                          Shape::FromProto(shape_proto.shape()));
+      ASSIGN_OR_RETURN(orig_shapes.back(),
+                       Shape::FromProto(shape_proto.shape()));
     }
   }
 
@@ -687,8 +677,8 @@ absl::StatusOr<std::unique_ptr<DynamicSliceThunk>> DynamicSliceThunk::FromProto(
   for (auto& shape_proto : proto.sliced_shapes()) {
     sliced_shapes.push_back(std::nullopt);
     if (shape_proto.has_shape()) {
-      TF_ASSIGN_OR_RETURN(sliced_shapes.back(),
-                          Shape::FromProto(shape_proto.shape()));
+      ASSIGN_OR_RETURN(sliced_shapes.back(),
+                       Shape::FromProto(shape_proto.shape()));
     }
   }
 
@@ -710,8 +700,8 @@ absl::StatusOr<std::unique_ptr<DynamicSliceThunk>> DynamicSliceThunk::FromProto(
 
   ThunkSequence embedded_thunks;
   for (const auto& thunk_proto : proto.embedded_thunk().thunks()) {
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<Thunk> embedded_thunk,
-                        deserializer(thunk_proto, fake_allocations));
+    ASSIGN_OR_RETURN(std::unique_ptr<Thunk> embedded_thunk,
+                     deserializer(thunk_proto, fake_allocations));
     embedded_thunks.push_back(std::move(embedded_thunk));
   }
 

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk.h
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk.h
@@ -31,8 +31,8 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
-#include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/thunk_executor.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/shape.h"
@@ -124,7 +124,7 @@ class DynamicSliceThunk : public Thunk {
   DynamicSliceThunk(const DynamicSliceThunk&) = delete;
   DynamicSliceThunk& operator=(const DynamicSliceThunk&) = delete;
 
-  const Thunk* embedded_thunk() const { return embedded_thunk_.get(); }
+  const ThunkExecutor& embedded_executor() const { return embedded_executor_; }
 
   absl::Status Prepare(const PrepareParams& params) override;
   absl::Status Initialize(const InitializeParams& params) override;
@@ -141,8 +141,8 @@ class DynamicSliceThunk : public Thunk {
     std::string ToString() const;
   };
 
-  const SequentialThunk* get_embedded_thunk() const {
-    return embedded_thunk_.get();
+  const ThunkExecutor& get_embedded_executor() const {
+    return embedded_executor_;
   }
 
   std::vector<std::optional<BufferAllocation::Slice>> get_arguments() const {
@@ -194,7 +194,7 @@ class DynamicSliceThunk : public Thunk {
   }
 
  private:
-  std::unique_ptr<SequentialThunk> embedded_thunk_;
+  ThunkExecutor embedded_executor_;
   std::vector<std::optional<BufferAllocation::Slice>> arguments_;
   std::vector<BufferAllocation> fake_allocations_;
   std::vector<std::optional<std::vector<Offset>>> offsets_;

--- a/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
@@ -30,14 +30,12 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/types/span.h"
-#include "google/protobuf/repeated_ptr_field.h"
 #include "xla/backends/gpu/ffi.h"
 #include "xla/backends/gpu/runtime/collective_memory_requests.h"
 #include "xla/backends/gpu/runtime/collective_multimem_registry.h"
 #include "xla/backends/gpu/runtime/custom_call_thunk.h"
 #include "xla/backends/gpu/runtime/dynamic_slice_thunk.pb.h"
 #include "xla/backends/gpu/runtime/gemm_thunk.h"
-#include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk_proto_deserialization.h"
 #include "xla/ffi/attribute_map.h"
@@ -119,14 +117,14 @@ void CheckProtoRoundTrip(const DynamicSliceThunk& thunk,
       [](const ThunkProto& thunk_proto,
          absl::Span<const BufferAllocation> fake_allocations_span)
       -> absl::StatusOr<std::unique_ptr<Thunk>> {
-    google::protobuf::RepeatedPtrField<ThunkProto> thunk_protos;
-    *thunk_protos.Add() = thunk_proto;
-    TF_ASSIGN_OR_RETURN(
-        ThunkSequence sequence,
-        DeserializeThunkSequenceProto(thunk_protos, fake_allocations_span,
-                                      /*hlo_module=*/nullptr,
-                                      /*platform_name=*/"TEST_PLATFORM",
-                                      /*gpu_compute_capability=*/{}));
+    ThunkSequenceProto thunk_sequence_proto;
+    *thunk_sequence_proto.add_thunks() = thunk_proto;
+    TF_ASSIGN_OR_RETURN(ThunkSequence sequence,
+                        DeserializeThunkSequenceProto(
+                            thunk_sequence_proto, fake_allocations_span,
+                            /*hlo_module=*/nullptr,
+                            /*platform_name=*/"TEST_PLATFORM",
+                            /*gpu_compute_capability=*/{}));
     return std::move(sequence.front());
   };
 
@@ -2150,9 +2148,8 @@ TEST_F(DynamicSliceThunkTest, TransformNested) {
                                         Thunk::ThunkInfo());
   }));
 
-  EXPECT_THAT(thunk.get_embedded_thunk(), NotNull());
-  EXPECT_THAT(thunk.get_embedded_thunk()->thunks(), SizeIs(1));
-  EXPECT_THAT(thunk.get_embedded_thunk()->thunks()[0]->kind(),
+  EXPECT_THAT(thunk.get_embedded_executor().thunks(), SizeIs(1));
+  EXPECT_THAT(thunk.get_embedded_executor().thunks()[0]->kind(),
               Thunk::Kind::kCustomCall);
 }
 

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -60,14 +60,14 @@ message ThunkMetadataListProto {
 
 message ConditionalThunkProto {
   ShapedSliceProto branch_index_buffer = 1;
-  repeated SequentialThunkProto branch_thunks = 2;
+  repeated ThunkSequenceProto branch_thunks = 2;
 }
 
 message WhileThunkProto {
   xla.buffer_assignment.BufferAllocationSliceProto
       condition_result_buffer_index = 1;
-  SequentialThunkProto condition_thunk_sequence = 2;
-  SequentialThunkProto body_thunk_sequence = 3;
+  ThunkSequenceProto condition_thunk_sequence = 2;
+  ThunkSequenceProto body_thunk_sequence = 3;
   optional int64 trip_count = 4;
 }
 
@@ -162,7 +162,7 @@ message HostExecuteDoneThunkProto {
 }
 
 message DynamicSliceThunkProto {
-  SequentialThunkProto embedded_thunk = 1;
+  ThunkSequenceProto embedded_thunk = 1;
   repeated OptionalBufferAllocationSliceProto arguments = 2;
   repeated OptionalDynamicSliceOffsetsProto offsets = 3;
   repeated OptionalShapeProto orig_shapes = 4;
@@ -390,6 +390,10 @@ message CopyDoneThunkProto {
   int64 copy_start_instr_id = 2;
 }
 
+message SequentialThunkProto {
+  repeated ThunkProto thunks = 1;
+}
+
 message ThunkProto {
   ThunkInfoProto thunk_info = 1;
 
@@ -453,6 +457,6 @@ message ThunkProto {
   }
 }
 
-message SequentialThunkProto {
+message ThunkSequenceProto {
   repeated ThunkProto thunks = 1;
 }

--- a/xla/backends/gpu/runtime/thunk_proto_deserialization.cc
+++ b/xla/backends/gpu/runtime/thunk_proto_deserialization.cc
@@ -364,7 +364,7 @@ absl::StatusOr<std::unique_ptr<Thunk>> DeserializeThunkProtoImpl(
 }  // namespace
 
 absl::StatusOr<ThunkSequence> DeserializeThunkSequenceProto(
-    const tsl::protobuf::RepeatedPtrField<ThunkProto>& thunk_protos,
+    const ThunkSequenceProto& thunk_sequence_proto,
     absl::Span<const BufferAllocation> buffer_allocations,
     const HloModule* absl_nullable hlo_module, absl::string_view platform_name,
     const se::GpuComputeCapability& gpu_compute_capability,
@@ -377,7 +377,7 @@ absl::StatusOr<ThunkSequence> DeserializeThunkSequenceProto(
   std::shared_ptr<NvshmemBufferAddresses> nvshmem_buffer_addresses =
       std::make_shared<NvshmemBufferAddresses>();
   ThunkSequence sequence;
-  for (const ThunkProto& thunk_proto : thunk_protos) {
+  for (const ThunkProto& thunk_proto : thunk_sequence_proto.thunks()) {
     TF_ASSIGN_OR_RETURN(
         std::unique_ptr<Thunk> thunk,
         DeserializeThunkProtoImpl(

--- a/xla/backends/gpu/runtime/thunk_proto_deserialization.h
+++ b/xla/backends/gpu/runtime/thunk_proto_deserialization.h
@@ -22,16 +22,16 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "google/protobuf/repeated_ptr_field.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/buffer_assignment.h"
+#include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/kernel_spec.h"
 
 namespace xla::gpu {
 
-// Deserializes the given `thunk_proto` into a Thunk.
+// Deserializes the given `thunk_sequence_proto` into a ThunkSequence.
 // - `buffer_allocations` is used to deserialize buffer slices.
 // - `hlo_module` is used to deserialize thunks that reference HLO instructions.
 // - `platform_name` is used to look up platform-specific kernels in the
@@ -40,7 +40,7 @@ namespace xla::gpu {
 //   not inlined in the proto, but rather loaded at runtime via symbol
 //   resolution.
 absl::StatusOr<ThunkSequence> DeserializeThunkSequenceProto(
-    const tsl::protobuf::RepeatedPtrField<ThunkProto>& thunk_protos,
+    const ThunkSequenceProto& thunk_sequence_proto,
     absl::Span<const BufferAllocation> buffer_allocations,
     const HloModule* absl_nullable hlo_module, absl::string_view platform_name,
     const se::GpuComputeCapability& gpu_compute_capability,

--- a/xla/backends/gpu/runtime/thunk_proto_deserialization_test.cc
+++ b/xla/backends/gpu/runtime/thunk_proto_deserialization_test.cc
@@ -28,7 +28,6 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "google/protobuf/repeated_ptr_field.h"
 #include "xla/backends/gpu/runtime/conditional_thunk.h"
 #include "xla/backends/gpu/runtime/copy_done_thunk.h"
 #include "xla/backends/gpu/runtime/copy_thunk.h"
@@ -69,11 +68,11 @@ absl::StatusOr<std::unique_ptr<Thunk>> DeserializeThunkProto(
     const se::GpuComputeCapability& gpu_compute_capability,
     const std::optional<stream_executor::KernelLoaderSpec::SymbolResolver>&
         symbol_resolver = std::nullopt) {
-  google::protobuf::RepeatedPtrField<ThunkProto> thunk_protos;
-  *thunk_protos.Add() = thunk_proto;
+  ThunkSequenceProto thunk_sequence_proto;
+  *thunk_sequence_proto.add_thunks() = thunk_proto;
   TF_ASSIGN_OR_RETURN(
       ThunkSequence sequence,
-      DeserializeThunkSequenceProto(thunk_protos, buffer_allocations,
+      DeserializeThunkSequenceProto(thunk_sequence_proto, buffer_allocations,
                                     hlo_module, platform_name,
                                     gpu_compute_capability, symbol_resolver));
   return std::move(sequence.front());

--- a/xla/backends/gpu/runtime/while_thunk.cc
+++ b/xla/backends/gpu/runtime/while_thunk.cc
@@ -29,7 +29,6 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/runtime/host_memory_pool.h"
-#include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/backends/gpu/runtime/thunk_executor.h"
@@ -37,11 +36,10 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -71,7 +69,7 @@ absl::Status WhileThunk::Initialize(const InitializeParams& params) {
 
   absl::MutexLock lock(mutex_);
   if (!host_memory_pools_.contains(params.executor)) {
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         std::unique_ptr<HostMemoryPool> pool,
         HostMemoryPool::Create(params.executor, PrimitiveType::PRED));
     host_memory_pools_[params.executor] = std::move(pool);
@@ -101,7 +99,7 @@ absl::Status WhileThunk::ExecuteOnStream(const ExecuteParams& params) {
     absl::MutexLock lock(mutex_);
     pool = host_memory_pools_.at(stream.parent()).get();
   }
-  TF_ASSIGN_OR_RETURN(HostMemoryPool::Handle handle, pool->Acquire());
+  ASSIGN_OR_RETURN(HostMemoryPool::Handle handle, pool->Acquire());
   bool* condition_result = handle.get<bool>();
   se::DeviceAddressBase condition_result_data =
       params.buffer_allocations->GetDeviceAddress(
@@ -169,22 +167,22 @@ absl::StatusOr<ThunkProto> WhileThunk::ToProto() const {
   *proto.mutable_thunk_info() = thunk_info().ToProto();
 
   auto* while_proto = proto.mutable_while_thunk();
-  TF_ASSIGN_OR_RETURN(*while_proto->mutable_condition_result_buffer_index(),
-                      condition_result_buffer_index_.ToProto());
+  ASSIGN_OR_RETURN(*while_proto->mutable_condition_result_buffer_index(),
+                   condition_result_buffer_index_.ToProto());
 
   {
-    SequentialThunkProto condition_proto;
+    ThunkSequenceProto condition_proto;
     for (const std::unique_ptr<Thunk>& thunk : condition_executor_.thunks()) {
-      TF_ASSIGN_OR_RETURN(*condition_proto.add_thunks(), thunk->ToProto());
+      ASSIGN_OR_RETURN(*condition_proto.add_thunks(), thunk->ToProto());
     }
     *while_proto->mutable_condition_thunk_sequence() =
         std::move(condition_proto);
   }
 
   {
-    SequentialThunkProto body_proto;
+    ThunkSequenceProto body_proto;
     for (const std::unique_ptr<Thunk>& thunk : body_executor_.thunks()) {
-      TF_ASSIGN_OR_RETURN(*body_proto.add_thunks(), thunk->ToProto());
+      ASSIGN_OR_RETURN(*body_proto.add_thunks(), thunk->ToProto());
     }
     *while_proto->mutable_body_thunk_sequence() = std::move(body_proto);
   }
@@ -199,26 +197,27 @@ absl::StatusOr<std::unique_ptr<WhileThunk>> WhileThunk::FromProto(
     ThunkInfo thunk_info, const WhileThunkProto& thunk_proto,
     absl::Span<const BufferAllocation> buffer_allocations,
     const Deserializer& deserializer) {
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       BufferAllocation::Slice condition_result_buffer_index,
       BufferAllocation::Slice::FromProto(
           thunk_proto.condition_result_buffer_index(), buffer_allocations));
-  TF_ASSIGN_OR_RETURN(
-      std::unique_ptr<SequentialThunk> condition_seq_thunk,
-      SequentialThunk::FromProto(
-          thunk_info, thunk_proto.condition_thunk_sequence(), deserializer));
-  TF_ASSIGN_OR_RETURN(
-      std::unique_ptr<SequentialThunk> body_seq_thunk,
-      SequentialThunk::FromProto(thunk_info, thunk_proto.body_thunk_sequence(),
-                                 deserializer));
+  ThunkSequence condition_thunks;
+  for (const auto& proto : thunk_proto.condition_thunk_sequence().thunks()) {
+    ASSIGN_OR_RETURN(std::unique_ptr<Thunk> thunk, deserializer(proto));
+    condition_thunks.push_back(std::move(thunk));
+  }
+  ThunkSequence body_thunks;
+  for (const auto& proto : thunk_proto.body_thunk_sequence().thunks()) {
+    ASSIGN_OR_RETURN(std::unique_ptr<Thunk> thunk, deserializer(proto));
+    body_thunks.push_back(std::move(thunk));
+  }
   std::optional<int64_t> trip_count;
   if (thunk_proto.has_trip_count()) {
     trip_count = thunk_proto.trip_count();
   }
   return std::make_unique<WhileThunk>(
       std::move(thunk_info), condition_result_buffer_index,
-      std::move(condition_seq_thunk->thunks()),
-      std::move(body_seq_thunk->thunks()), trip_count);
+      std::move(condition_thunks), std::move(body_thunks), trip_count);
 }
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -118,6 +118,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/sorted_range.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
@@ -126,7 +127,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -1546,9 +1546,11 @@ absl::StatusOr<std::unique_ptr<GpuExecutable>> GpuExecutable::FromProto(
 
   params.device_description = device_description;
 
+  ThunkSequenceProto thunk_sequence_proto;
+  *thunk_sequence_proto.mutable_thunks() = proto.thunks();
   ASSIGN_OR_RETURN(ThunkSequence thunk_sequence,
                    DeserializeThunkSequenceProto(
-                       proto.thunks(), params.mlir_allocations.value(),
+                       thunk_sequence_proto, params.mlir_allocations.value(),
                        params.debug_module.get(), platform_name,
                        gpu_compute_capability, symbol_resolver));
 


### PR DESCRIPTION
- Migrate `ConditionalThunkProto`, `WhileThunkProto`, and `DynamicSliceThunkProto` from `SequentialThunkProto` to `ThunkSequenceProto` for nested thunk serialization. `SequentialThunkProto` is now only used by `ThunkProto.impl` oneof for the `SequentialThunk` kind itself.
- Migrate `DynamicSliceThunk` from `std::unique_ptr<SequentialThunk>` to `ThunkExecutor` for the embedded thunk, matching the pattern used by `WhileThunk` and `ConditionalThunk`.
- Change `DeserializeThunkSequenceProto` to accept `ThunkSequenceProto` instead of `RepeatedPtrField<ThunkProto>`, removing the `google/protobuf/repeated_ptr_field.h` layering violation from the header.
- Migrate `TF_ASSIGN_OR_RETURN` / `TF_RETURN_IF_ERROR` to `ASSIGN_OR_RETURN` / `RETURN_IF_ERROR` in all touched files.
- Remove unused `:sequential_thunk` and `//xla/tsl/platform:statusor` BUILD deps from `while_thunk`, `conditional_thunk`, and `dynamic_slice_thunk`.