### PR TITLE
[XLA:GPU][oneAPI][Bug Fix] Add minimal oneAPI support to ExecutableAbiVersion

### DIFF
--- a/xla/stream_executor/abi/BUILD
+++ b/xla/stream_executor/abi/BUILD
@@ -42,6 +42,7 @@ xla_cc_test(
         "//xla/stream_executor:semantic_version",
         "//xla/stream_executor/cuda:cuda_compute_capability",
         "//xla/stream_executor/rocm:rocm_compute_capability",
+        "//xla/stream_executor/sycl:oneapi_compute_capability",
         "//xla/tsl/util/proto:proto_matchers",
         "@com_google_googletest//:gtest_main",
     ],

--- a/xla/stream_executor/abi/executable_abi_version.cc
+++ b/xla/stream_executor/abi/executable_abi_version.cc
@@ -49,6 +49,17 @@ static absl::StatusOr<ExecutableAbiVersion> CreateForRocm(
   return ExecutableAbiVersion::FromProto(std::move(proto));
 }
 
+// Returns a minimal ABI version for oneAPI with no platform-specific version
+// info. Compatibility checks will treat this as always-compatible, preserving
+// pre-existing oneAPI behavior until proper ABI versioning is designed.
+static absl::StatusOr<ExecutableAbiVersion> CreateForOneAPI(
+    const DeviceDescription& /*device_description*/) {
+  ExecutableAbiVersionProto proto;
+  // Platform name is "SYCL" for oneAPI devices.
+  proto.set_platform_name("SYCL");
+  return ExecutableAbiVersion::FromProto(std::move(proto));
+}
+
 absl::StatusOr<ExecutableAbiVersion> ExecutableAbiVersion::FromProto(
     const ExecutableAbiVersionProto& proto) {
   return ExecutableAbiVersion(proto);
@@ -61,6 +72,9 @@ ExecutableAbiVersion::FromDeviceDescription(
   }
   if (device_description.gpu_compute_capability().IsRocm()) {
     return CreateForRocm(device_description);
+  }
+  if (device_description.gpu_compute_capability().IsOneAPI()) {
+    return CreateForOneAPI(device_description);
   }
 
   return absl::UnimplementedError(

--- a/xla/stream_executor/abi/executable_abi_version_test.cc
+++ b/xla/stream_executor/abi/executable_abi_version_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/rocm/rocm_compute_capability.h"
+#include "xla/stream_executor/sycl/oneapi_compute_capability.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/tsl/util/proto/proto_matchers.h"
 
@@ -71,6 +72,19 @@ TEST(ExecutableAbiVersionTest, FromDeviceDescriptionRocm) {
   EXPECT_THAT(executable_abi_version.platform_name(), "ROCm");
   EXPECT_THAT(executable_abi_version.proto(),
               EqualsProto(R"pb(platform_name: "ROCm")pb"));
+}
+
+TEST(ExecutableAbiVersionTest, FromDeviceDescriptionOneAPI) {
+  DeviceDescription device_description;
+  device_description.set_gpu_compute_capability(
+      GpuComputeCapability(OneAPIComputeCapability::BMG()));
+
+  ASSERT_OK_AND_ASSIGN(
+      ExecutableAbiVersion executable_abi_version,
+      ExecutableAbiVersion::FromDeviceDescription(device_description));
+  EXPECT_THAT(executable_abi_version.platform_name(), "SYCL");
+  EXPECT_THAT(executable_abi_version.proto(),
+              EqualsProto(R"pb(platform_name: "SYCL")pb"));
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes
Hot-Fix for breaking changes in https://github.com/openxla/xla/commit/5150bfd950537354a9517654df71efbf91fd876b
 
This is in line with the similar fix for ROCm https://github.com/openxla/xla/commit/b8c135866b6aa901bb22a85823f96dbeeaf18ad0

🎯 Justification
Without this change many tests fail with the following error
`UNIMPLEMENTED: Deriving the executable ABI version from the device description is not implemented for the target platform.`

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Added oneAPI test to //xla/stream_executor/abi:executable_abi_version_test