### PR TITLE
[xla:ffi] Add AttributesMap initializer_list constructor

### DIFF
--- a/xla/ffi/attribute_map.cc
+++ b/xla/ffi/attribute_map.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/ffi/attribute_map.h"
 
 #include <cstdint>
+#include <initializer_list>
 #include <limits>
 #include <memory>
 #include <string>
@@ -531,5 +532,16 @@ bool operator==(const AttributesDictionary& lhs,
   }
   return *lhs.attrs == *rhs.attrs;
 }
+
+AttributesMap::AttributesMap(
+    std::initializer_list<std::pair<std::string, AttributeValue>> attrs) {
+  for (auto& [key, value] : attrs) {
+    (*this)[key] = std::move(const_cast<AttributeValue&>(value)).ToAttribute();
+  }
+}
+
+AttributeValue::AttributeValue(
+    std::initializer_list<std::pair<std::string, AttributeValue>> attrs)
+    : value_(AttributesDictionary{std::make_shared<AttributesMap>(attrs)}) {}
 
 }  // namespace xla::ffi

--- a/xla/ffi/attribute_map.h
+++ b/xla/ffi/attribute_map.h
@@ -17,19 +17,23 @@ limitations under the License.
 #define XLA_FFI_ATTRIBUTE_MAP_H_
 
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "xla/ffi/attribute_map.pb.h"
 
 namespace xla::ffi {
 namespace internal {
-// A little bit of template metaprogramming to append type to std::variant.
+// A little bit of template metaprograming to append type to std::variant.
 template <typename V, class T>
 struct AppendType;
 
@@ -157,10 +161,35 @@ class Attribute : public AttributeBase {
 
 using AttributesMapBase = absl::flat_hash_map<std::string, Attribute>;
 
+class AttributeValue;  // Forward declaration.
+
 // AttributesMap is a map from an arbitrary name (string key) to an attribute.
+//
+// Supports construction from an initializer list of key-value pairs with
+// automatic type deduction for attribute values.
+//
+// Supported value types:
+//   - Scalars: bool, int8_t..int64_t, uint8_t..uint64_t, float, double
+//   - Strings: const char*, absl::string_view, std::string
+//   - Arrays:  brace-enclosed initializer list of scalars
+//   - Nested:  brace-enclosed key-value pairs
+//
+// Example:
+//   AttributesMap attrs = {
+//       {"i32", 42},
+//       {"f32", 42.0f},
+//       {"str", "hello"},
+//       {"arr", {1, 2, 3}},
+//       {"nested", {{"f32", 1.0f}, {"str", "foo"}}},
+//       {"deep", {{"level2", {{"value", 123}}}}},
+//   };
 class AttributesMap : public AttributesMapBase {
  public:
   using AttributesMapBase::AttributesMapBase;
+
+  // NOLINTNEXTLINE
+  AttributesMap(
+      std::initializer_list<std::pair<std::string, AttributeValue>> attrs);
 
   AttributesMapProto ToProto() const;
 
@@ -171,6 +200,49 @@ class AttributesMap : public AttributesMapBase {
 
   static absl::StatusOr<AttributesMap> FromProto(
       const AttributesMapProto& proto);
+};
+
+// A helper type that enables implicit conversion from scalar types, strings,
+// arrays, and nested AttributesMaps into an Attribute. This bridges the gap
+// where C++ would otherwise require two user-defined conversions (e.g.,
+// int -> Scalar -> Attribute).
+class AttributeValue {
+ public:
+  // Scalars.
+  AttributeValue(bool v) : value_(Scalar(v)) {}      // NOLINT
+  AttributeValue(int8_t v) : value_(Scalar(v)) {}    // NOLINT
+  AttributeValue(int16_t v) : value_(Scalar(v)) {}   // NOLINT
+  AttributeValue(int32_t v) : value_(Scalar(v)) {}   // NOLINT
+  AttributeValue(int64_t v) : value_(Scalar(v)) {}   // NOLINT
+  AttributeValue(uint8_t v) : value_(Scalar(v)) {}   // NOLINT
+  AttributeValue(uint16_t v) : value_(Scalar(v)) {}  // NOLINT
+  AttributeValue(uint32_t v) : value_(Scalar(v)) {}  // NOLINT
+  AttributeValue(uint64_t v) : value_(Scalar(v)) {}  // NOLINT
+  AttributeValue(float v) : value_(Scalar(v)) {}     // NOLINT
+  AttributeValue(double v) : value_(Scalar(v)) {}    // NOLINT
+
+  // Strings.
+  AttributeValue(const char* v) : value_(std::string(v)) {}        // NOLINT
+  AttributeValue(absl::string_view v) : value_(std::string(v)) {}  // NOLINT
+  AttributeValue(std::string v) : value_(std::move(v)) {}          // NOLINT
+
+  // Arrays from initializer list, enabling brace syntax:
+  //   {"arr", {1, 2, 3}}
+  template <typename T,
+            std::enable_if_t<std::is_constructible_v<Array, std::vector<T>>>* =
+                nullptr>
+  AttributeValue(std::initializer_list<T> v)  // NOLINT
+      : value_(Array(std::vector<T>(v))) {}
+
+  // Nested attribute maps from initializer list, enabling brace syntax:
+  //   {"nested", {{"key", value}, ...}}
+  AttributeValue(  // NOLINT
+      std::initializer_list<std::pair<std::string, AttributeValue>> attrs);
+
+  Attribute ToAttribute() && { return std::move(value_); }
+
+ private:
+  Attribute value_;
 };
 
 // Converts MLIR dictionary attribute attached to a custom call operation to a

--- a/xla/ffi/attribute_map_test.cc
+++ b/xla/ffi/attribute_map_test.cc
@@ -284,5 +284,97 @@ TEST(AttributeTest, ProtoConversion) {
   EXPECT_THAT(Attribute::FromProto(attr.ToProto()), IsOkAndHolds(attr));
 }
 
+TEST(AttributesMapTest, ScalarConstruction) {
+  AttributesMap attrs = {
+      {"i32", 42},
+      {"f32", 42.0f},
+      {"f64", 42.0},
+      {"b", true},
+  };
+
+  EXPECT_EQ(attrs.size(), 4);
+  auto i32 = std::get<Scalar>(attrs.at("i32").AsVariant());
+  auto f32 = std::get<Scalar>(attrs.at("f32").AsVariant());
+  auto f64 = std::get<Scalar>(attrs.at("f64").AsVariant());
+  auto b = std::get<Scalar>(attrs.at("b").AsVariant());
+  EXPECT_EQ(i32, Scalar(int32_t{42}));
+  EXPECT_EQ(f32, Scalar(42.0f));
+  EXPECT_EQ(f64, Scalar(42.0));
+  EXPECT_EQ(b, Scalar(true));
+}
+
+TEST(AttributesMapTest, StringConstruction) {
+  AttributesMap attrs = {
+      {"str_literal", "hello"},
+      {"str_obj", std::string("world")},
+  };
+
+  EXPECT_EQ(attrs.size(), 2);
+  auto str_literal = std::get<std::string>(attrs.at("str_literal").AsVariant());
+  auto str_obj = std::get<std::string>(attrs.at("str_obj").AsVariant());
+  EXPECT_EQ(str_literal, "hello");
+  EXPECT_EQ(str_obj, "world");
+}
+
+TEST(AttributesMapTest, ArrayConstruction) {
+  AttributesMap attrs = {
+      {"i32_arr", {1, 2, 3}},
+      {"f32_arr", {1.0f, 2.0f, 3.0f}},
+  };
+
+  EXPECT_EQ(attrs.size(), 2);
+  auto i32_arr = std::get<Array>(attrs.at("i32_arr").AsVariant());
+  auto f32_arr = std::get<Array>(attrs.at("f32_arr").AsVariant());
+  EXPECT_EQ(i32_arr, Array(std::vector<int32_t>{1, 2, 3}));
+  EXPECT_EQ(f32_arr, Array(std::vector<float>{1.0f, 2.0f, 3.0f}));
+}
+
+TEST(AttributesMapTest, NestedConstruction) {
+  AttributesMap attrs = {
+      {"i32", 42},
+      {"nested", {{"f32", 1.0f}, {"str", "foo"}}},
+  };
+
+  EXPECT_EQ(attrs.size(), 2);
+  auto i32 = std::get<Scalar>(attrs.at("i32").AsVariant());
+  EXPECT_EQ(i32, Scalar(int32_t{42}));
+
+  auto& dict = std::get<AttributesDictionary>(attrs.at("nested").AsVariant());
+  ASSERT_NE(dict.attrs, nullptr);
+  EXPECT_EQ(dict.attrs->size(), 2);
+  auto f32 = std::get<Scalar>(dict.attrs->at("f32").AsVariant());
+  auto str = std::get<std::string>(dict.attrs->at("str").AsVariant());
+  EXPECT_EQ(f32, Scalar(1.0f));
+  EXPECT_EQ(str, "foo");
+}
+
+TEST(AttributesMapTest, DeeplyNestedConstruction) {
+  AttributesMap attrs = {
+      {"level1", {{"level2", {{"value", 123}}}}},
+  };
+
+  auto& l1 = std::get<AttributesDictionary>(attrs.at("level1").AsVariant());
+  ASSERT_NE(l1.attrs, nullptr);
+  auto& l2 = std::get<AttributesDictionary>(l1.attrs->at("level2").AsVariant());
+  ASSERT_NE(l2.attrs, nullptr);
+  auto value = std::get<Scalar>(l2.attrs->at("value").AsVariant());
+  EXPECT_EQ(value, Scalar(int32_t{123}));
+}
+
+TEST(AttributesMapTest, EmptyConstruction) {
+  AttributesMap attrs = {};
+  EXPECT_TRUE(attrs.empty());
+}
+
+TEST(AttributesMapTest, ConstructionProtoRoundTrip) {
+  AttributesMap attrs = {
+      {"i32", 42},
+      {"str", "hello"},
+      {"nested", {{"f32", 1.0f}}},
+  };
+
+  EXPECT_THAT(AttributesMap::FromProto(attrs.ToProto()), IsOkAndHolds(attrs));
+}
+
 }  // namespace
 }  // namespace xla::ffi


### PR DESCRIPTION
Add `AttributeValue` helper class and `AttributesMap` initializer list constructor to `xla/ffi/attribute_map.h` enabling concise construction of attribute maps with automatic type deduction for scalars, strings, arrays, and nested maps

  Before

```
  CallFrameBuilder::AttributesBuilder attrs;
  attrs.Insert("i32", 42);
  attrs.Insert("f32", 42.0f);
  AttributesMap map = attrs.Build();
```

After

```
  AttributesMap attrs = {
      {"i32", 42},
      {"f32", 42.0f},
  };
```