### PR TITLE
[GPU] Clean up setting of kernel dynamic shared memory size.

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -704,6 +704,7 @@ cc_library(
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -710,6 +710,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cuda_headers",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/profiler/lib:traceme",

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -512,17 +512,10 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateKernelNode(
           << "; deps: " << dependencies.size();
 
   CUgraphNode node_handle = nullptr;
-  CUfunction function = static_cast<const CudaKernel&>(kernel).gpu_function();
-  // TODO(ezhulenev): Why do we do it on every call to launch kernel? This
-  // should be moved one level up to se::Kernel level, and done just once (or
-  // updated once we get a new larger shared memory request).
-  if (shared_mem_bytes != 0) {
-    TF_RETURN_IF_ERROR(cuda::ToStatus(
-        cuFuncSetAttribute(function,
-                           CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                           shared_mem_bytes),
-        "Failed to set shared memory size"));
-  }
+  const auto& cuda_kernel = static_cast<const CudaKernel&>(kernel);
+  CUfunction function = cuda_kernel.gpu_function();
+  TF_RETURN_IF_ERROR(
+      cuda_kernel.UpdateMaxDynamicSharedMemoryBytes(shared_mem_bytes));
 
   auto set_params = [&](auto& params) {
     params.func = function;
@@ -617,7 +610,8 @@ absl::Status CudaCommandBuffer::UpdateKernelNode(
           << "; shmem: " << shared_mem_bytes;
 
   CUDA_KERNEL_NODE_PARAMS params{};
-  CUfunction function = static_cast<const CudaKernel&>(kernel).gpu_function();
+  const auto& cuda_kernel = static_cast<const CudaKernel&>(kernel);
+  CUfunction function = cuda_kernel.gpu_function();
   params.func = function;
   params.gridDimX = blocks.x;
   params.gridDimY = blocks.y;
@@ -629,16 +623,9 @@ absl::Status CudaCommandBuffer::UpdateKernelNode(
   params.kernelParams = const_cast<void**>(args.argument_addresses().data());
   params.extra = nullptr;
 
-  // TODO(ezhulenev): Why do we do it on every call to launch kernel? This
-  // should be moved one level up to se::Kernel level, and done just once (or
-  // updated once we get a new larger shared memory request).
-  if (shared_mem_bytes != 0) {
-    TF_RETURN_IF_ERROR(cuda::ToStatus(
-        cuFuncSetAttribute(function,
-                           CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                           shared_mem_bytes),
-        "Failed to set shared memory size"));
-  }
+  TF_RETURN_IF_ERROR(
+      cuda_kernel.UpdateMaxDynamicSharedMemoryBytes(shared_mem_bytes));
+
   return cuda::ToStatus(
       cuGraphExecKernelNodeSetParams(graph_exec(),
                                      ToCudaGraphHandle(node_handle), &params),

--- a/xla/stream_executor/cuda/cuda_kernel.cc
+++ b/xla/stream_executor/cuda/cuda_kernel.cc
@@ -54,6 +54,13 @@ absl::Status GetCudaAttribute(CUfunction_attribute attribute, CUfunction func,
       absl::StrCat("Failed to query kernel attribute: ", attribute));
 }
 
+absl::Status SetCudaAttribute(CUfunction_attribute attribute, CUfunction func,
+                              int value) {
+  return cuda::ToStatus(
+      cuFuncSetAttribute(func, attribute, value),
+      absl::StrCat("Failed to set kernel attribute: ", attribute));
+}
+
 }  // namespace
 
 absl::StatusOr<int32_t> CudaKernel::GetMaxOccupiedBlocksPerCore(
@@ -87,6 +94,31 @@ absl::StatusOr<KernelMetadata> CudaKernel::GetKernelMetadata() {
   return kernel_metadata;
 }
 
+absl::Status CudaKernel::UpdateMaxDynamicSharedMemoryBytes(
+    int32_t shared_memory_bytes) const {
+  if (shared_memory_bytes <=
+      max_dynamic_shared_memory_bytes_.load(std::memory_order_relaxed)) {
+    return absl::OkStatus();
+  }
+
+  absl::MutexLock lock(&mu_);
+  if (shared_memory_bytes <=
+      max_dynamic_shared_memory_bytes_.load(std::memory_order_relaxed)) {
+    return absl::OkStatus();
+  }
+
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  TF_RETURN_IF_ERROR(
+      SetCudaAttribute(CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                       gpu_function_, shared_memory_bytes));
+  TF_RETURN_IF_ERROR(cuda::ToStatus(
+      cuFuncSetCacheConfig(gpu_function_, CU_FUNC_CACHE_PREFER_SHARED)));
+
+  max_dynamic_shared_memory_bytes_.store(shared_memory_bytes,
+                                         std::memory_order_relaxed);
+  return absl::OkStatus();
+}
+
 absl::Status CudaKernel::Launch(const ThreadDim& thread_dims,
                                 const BlockDim& block_dims,
                                 const std::optional<ClusterDim>& cluster_dims,
@@ -112,6 +144,9 @@ absl::Status CudaKernel::Launch(const ThreadDim& thread_dims,
         << "; number_of_shared_bytes=" << packed.number_of_shared_bytes();
 
     void** params = const_cast<void**>(packed.argument_addresses().data());
+
+    TF_RETURN_IF_ERROR(
+        UpdateMaxDynamicSharedMemoryBytes(packed.number_of_shared_bytes()));
 
     return stream->LaunchKernel(thread_dims, block_dims, cluster_dims, function,
                                 name(), params, packed.number_of_shared_bytes(),

--- a/xla/stream_executor/cuda/cuda_kernel.h
+++ b/xla/stream_executor/cuda/cuda_kernel.h
@@ -22,11 +22,14 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_CUDA_CUDA_KERNEL_H_
 #define XLA_STREAM_EXECUTOR_CUDA_CUDA_KERNEL_H_
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 
+#include "absl/base/thread_annotations.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/stream_executor/kernel.h"
 #include "xla/stream_executor/kernel_metadata.h"
@@ -61,6 +64,10 @@ class CudaKernel : public Kernel {
   // Collects metadata for the specified kernel.
   absl::StatusOr<KernelMetadata> GetKernelMetadata();
 
+  // Updates the maximum dynamic shared memory bytes for this kernel.
+  absl::Status UpdateMaxDynamicSharedMemoryBytes(
+      int32_t shared_memory_bytes) const;
+
  private:
   absl::Status Launch(const ThreadDim& thread_dims, const BlockDim& block_dims,
                       const std::optional<ClusterDim>& cluster_dims,
@@ -70,6 +77,9 @@ class CudaKernel : public Kernel {
 
   CUfunction gpu_function_ = nullptr;  // wrapped CUDA kernel handle
   unsigned arity_ = 0;  // number of formal parameters the kernel takes
+
+  mutable absl::Mutex mu_;
+  mutable std::atomic<int32_t> max_dynamic_shared_memory_bytes_{0};
 };
 
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_stream.cc
+++ b/xla/stream_executor/cuda/cuda_stream.cc
@@ -416,19 +416,6 @@ absl::Status LaunchCudaKernel(
     VLOG(2) << msg;
   }
 
-  // TODO(ezhulenev): Why do we do it on every call to launch kernel? This
-  // should be moved one level up to se::Kernel level, and done just once (or
-  // updated once we get a new larger shared memory request).
-  if (shared_mem_bytes != 0) {
-    TF_RETURN_IF_ERROR(cuda::ToStatus(
-        cuFuncSetAttribute(function,
-                           CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                           shared_mem_bytes),
-        "Failed to set shared memory size"));
-    TF_RETURN_IF_ERROR(cuda::ToStatus(
-        cuFuncSetCacheConfig(function, CU_FUNC_CACHE_PREFER_SHARED)));
-  }
-
   auto to_status = [&](CUresult result) {
     if (result == CUDA_SUCCESS) {
       return absl::OkStatus();


### PR DESCRIPTION
📝 Summary of Changes
Cleanup handling of kernel dynamic shared memory size. Call CUDA APIs only when a size increase is needed instead of on every kernel call.

🎯 Justification
cleanup

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
no

🧪 Unit Tests:
existing

🧪 Execution Tests:
existing