### PR TITLE
Guard CuDNN compiler includes with GOOGLE_CUDA

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -284,6 +284,7 @@ cc_library(
     name = "cudnn",
     srcs = ["cudnn.cc"],
     hdrs = ["cudnn.h"],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     tags = [
         "cuda-only",
         "gpu",

--- a/xla/backends/gpu/autotuner/cudnn.cc
+++ b/xla/backends/gpu/autotuner/cudnn.cc
@@ -26,7 +26,6 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "xla/autotuning.pb.h"
 #include "xla/backends/autotuner/codegen_backend.h"
-#include "xla/backends/gpu/transforms/cudnn_fusion_compiler.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
@@ -52,6 +51,10 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
+
+#if GOOGLE_CUDA
+#include "xla/backends/gpu/transforms/cudnn_fusion_compiler.h"
+#endif  // GOOGLE_CUDA
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
 
@@ -255,6 +258,7 @@ absl::StatusOr<std::vector<CudnnBackendConfig>> GetAlgorithms(
   return configs;
 }
 
+#if GOOGLE_CUDA
 absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>>
 GetCudnnFusionConfigs(const HloInstruction& instr,
                       se::StreamExecutor* stream_executor) {
@@ -272,6 +276,7 @@ GetCudnnFusionConfigs(const HloInstruction& instr,
   }
   return configs;
 }
+#endif  // GOOGLE_CUDA
 
 absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>>
 GetConvolutionCustomCallConfigs(const HloCustomCallInstruction* instr,
@@ -386,7 +391,11 @@ CudnnBackend::GetSupportedConfigs(const HloInstruction& instr) {
     return std::vector<std::unique_ptr<BackendConfig>>();
   }
   if (instr.opcode() == HloOpcode::kFusion) {
+#if GOOGLE_CUDA
     return GetCudnnFusionConfigs(instr, stream_executor());
+#else
+    return std::vector<std::unique_ptr<BackendConfig>>();
+#endif  // GOOGLE_CUDA
   }
   if (IsCustomCallToDnnConvolution(instr)) {
     auto custom_call_instr = Cast<HloCustomCallInstruction>(&instr);

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -2265,6 +2265,7 @@ cc_library(
     hdrs = [
         "nvptx_compiler.h",
     ],
+    local_defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
     tags = [
         "cuda-only",
         "gpu",

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -46,9 +46,7 @@ limitations under the License.
 #include "xla/backends/gpu/transforms/conv_padding_legalization.h"
 #include "xla/backends/gpu/transforms/conv_rewriter.h"
 #include "xla/backends/gpu/transforms/cublas_pad_for_gemms.h"
-#include "xla/backends/gpu/transforms/cudnn_custom_call_compiler.h"
 #include "xla/backends/gpu/transforms/cudnn_fused_conv_rewriter.h"
-#include "xla/backends/gpu/transforms/cudnn_fusion_compiler.h"
 #include "xla/backends/gpu/transforms/cudnn_norm_rewriter.h"
 #include "xla/backends/gpu/transforms/cudnn_pad_for_convolutions.h"
 #include "xla/backends/gpu/transforms/cudnn_simplify_padding.h"
@@ -104,6 +102,11 @@ limitations under the License.
 #include "tsl/platform/path.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
+
+#if GOOGLE_CUDA
+#include "xla/backends/gpu/transforms/cudnn_custom_call_compiler.h"
+#include "xla/backends/gpu/transforms/cudnn_fusion_compiler.h"
+#endif  // GOOGLE_CUDA
 
 namespace xla {
 namespace gpu {
@@ -325,6 +328,7 @@ absl::Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
 absl::Status NVPTXCompiler::RunCudnnCompilerPasses(
     HloModule* module, se::dnn::DnnSupport& dnn_support,
     BinaryMap* dnn_compiled_graphs) {
+#if GOOGLE_CUDA
   if (module->config()
           .debug_options()
           .xla_gpu_experimental_disable_binary_libraries()) {
@@ -341,6 +345,9 @@ absl::Status NVPTXCompiler::RunCudnnCompilerPasses(
   CuDnnCustomCallCompiler call_compiler(dnn_support, *dnn_compiled_graphs);
   return call_compiler.Run(module, {HloInstruction::kMainExecutionThread})
       .status();
+#else
+  return absl::UnimplementedError("CuDNN passes require CUDA.");
+#endif  // GOOGLE_CUDA
 }
 
 namespace {


### PR DESCRIPTION
cudnn_fusion_compiler and cudnn_custom_call_compiler BUILD targets expose their headers only under if_cuda_is_configured, so including them unconditionally causes "file not found" errors in CPU-only builds.

Move the includes into #if GOOGLE_CUDA blocks in:
- xla/backends/gpu/autotuner/cudnn.cc: guard cudnn_fusion_compiler.h include and GetCudnnFusionConfigs usage.
- xla/service/gpu/nvptx_compiler.cc: guard cudnn_custom_call_compiler.h and cudnn_fusion_compiler.h includes and RunCudnnCompilerPasses body.

📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
