### PR TITLE
[ROCm] Fix invalid isSubset implementation, missing incarnations_ comparison

### DIFF
--- a/xla/backends/gpu/collectives/gpu_clique_key.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key.cc
@@ -94,8 +94,13 @@ bool GpuCliqueKey::IsSubsetOf(const CliqueKey& other) const {
   }
 
   return is_p2p() == other_gpu->is_p2p() &&
-         absl::c_all_of(devices(), [&](GlobalDeviceId id) {
-           return absl::c_linear_search(other_gpu->devices(), id);
+         absl::c_all_of(devices(),
+                        [&](GlobalDeviceId id) {
+                          return absl::c_linear_search(other_gpu->devices(),
+                                                       id);
+                        }) &&
+         absl::c_all_of(incarnations_, [&](IncarnationId id) {
+           return absl::c_linear_search(other_gpu->incarnations_, id);
          });
 }
 

--- a/xla/backends/gpu/collectives/gpu_clique_key_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_key_test.cc
@@ -212,4 +212,54 @@ TEST(GpuCliqueKeyTest, IsSubsetOfForCliqueInvalidation) {
   EXPECT_FALSE(p2p_clique.IsSubsetOf(large_clique));
 }
 
+// Test that IsSubsetOf correctly compares incarnations to prevent false
+// positives. This is a regression test for a bug where incarnations were
+// not being compared, causing cliques with different incarnations to be
+// incorrectly identified as subsets, leading to deadlocks.
+TEST(GpuCliqueKeyTest, IsSubsetOfComparesIncarnations) {
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+  GlobalDeviceId id2 = GlobalDeviceId(2);
+  GlobalDeviceId id3 = GlobalDeviceId(3);
+
+  // Create two cliques with the same devices and is_p2p flag,
+  // but different incarnations
+  std::vector<IncarnationId> incarnations1 = {IncarnationId(1),
+                                              IncarnationId(2)};
+  std::vector<IncarnationId> incarnations2 = {IncarnationId(3),
+                                              IncarnationId(4)};
+
+  GpuCliqueKey key_with_incarnations1({id0, id1}, /*num_local_participants=*/2,
+                                      /*is_p2p=*/false, incarnations1);
+  GpuCliqueKey key_with_incarnations2({id0, id1}, /*num_local_participants=*/2,
+                                      /*is_p2p=*/false, incarnations2);
+
+  // These keys should NOT be subsets of each other because their
+  // incarnations differ, even though devices and is_p2p match
+  EXPECT_FALSE(key_with_incarnations1.IsSubsetOf(key_with_incarnations2));
+  EXPECT_FALSE(key_with_incarnations2.IsSubsetOf(key_with_incarnations1));
+
+  // Test subset relationship with matching incarnations
+  GpuCliqueKey small_key({id0, id1}, /*num_local_participants=*/2,
+                         /*is_p2p=*/false, incarnations1);
+  GpuCliqueKey large_key({id0, id1, id2, id3}, /*num_local_participants=*/4,
+                         /*is_p2p=*/false, incarnations1);
+
+  // With matching incarnations, the subset relationship should work
+  EXPECT_TRUE(small_key.IsSubsetOf(large_key));
+  EXPECT_FALSE(large_key.IsSubsetOf(small_key));
+
+  // But with different incarnations, it should fail even if devices are a
+  // subset
+  GpuCliqueKey small_key_different_incarnations(
+      {id0, id1}, /*num_local_participants=*/2, /*is_p2p=*/false,
+      incarnations2);
+
+  EXPECT_FALSE(small_key_different_incarnations.IsSubsetOf(large_key));
+
+  // Keys with same devices and incarnations should be subsets of themselves
+  EXPECT_TRUE(key_with_incarnations1.IsSubsetOf(key_with_incarnations1));
+  EXPECT_TRUE(key_with_incarnations2.IsSubsetOf(key_with_incarnations2));
+}
+
 }  // namespace xla::gpu


### PR DESCRIPTION
📝 Summary of Changes


🎯 Justification
Add missing incarnations comparison in isSubsetOf the clique key.
Fix timeout on jax test target //tests:image_test_gpu

This change: https://github.com/openxla/xla/pull/37063
Uncovered a bug in IsSubsetOf implementation where comparison
to incarnations was missing leading to triggering ncclAbort on the old
cached cliques and consequently to a deadlock.

```
  Test Run 1:
  - JAX backend created with incarnation=X
  - Creates clique [GPU0, incarnation=X]
  - Clique stored in process-level cache
  - Test finishes

  Test Run 2 (same process):
  - JAX backend re-created with NEW incarnation=Y
  - Tries to create clique [GPU0, incarnation=Y]
  - XLA finds old clique [GPU0, incarnation=X] in cache
  - Buggy IsSubsetOf() thinks [GPU0, X] is subset of [GPU0, Y]
    (because it only checks devices, not incarnations)
  - Calls Abort() on old clique → HANG!

  The cache persistence is intentional because:
  - Destroying NCCL/RCCL communicators during process lifetime can be dangerous
  - The cliques might still be in use by pending operations
  - It's designed to handle process restarts via incarnations, not in-process reinitializations

  Bottom line: The clique cache is NOT supposed to be cleaned up between test runs in the same process. The incarnation mechanism is specifically designed to handle this - but the bug in IsSubsetOf() broke that mechanism by not checking incarnations when determining if cliques are subsets of each other.
```

✻ Brewed for 3m 1s

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Jax-u-tests pipeline (got new test target timeout)

🧪 Execution Tests:
CI tests
