### PR TITLE
[ROCm] Add CUB support for scan (prefix sum) op

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -394,6 +394,7 @@ cc_library(
         "//xla/tsl/platform:macros",
         "//xla/tsl/platform:statusor",
         "//xla/tsl/util:determinism_hdr_lib",
+        "//xla/tsl/util:determinism",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
@@ -530,6 +531,7 @@ cc_library(
         "//xla/tsl/platform:statusor",
         "//xla/tsl/protobuf:dnn_proto_cc",
         "//xla/tsl/util:determinism_for_kernels",
+        "//xla/tsl/util:determinism",
         "//xla/tsl/util:env_var",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:core_headers",
@@ -850,12 +852,6 @@ cc_library(
         "rocm-only",
     ],
     deps = [
-        ":rocm_platform_id",
-        "//xla/stream_executor:dnn",
-        "//xla/stream_executor:platform_manager",
-        "//xla/stream_executor:scratch_allocator",
-        "//xla/stream_executor/cuda:cuda_platform_id",
-        "//xla/stream_executor/host:host_platform_id",
         "@local_config_rocm//rocm:rocm_rpath",
     ] + if_static(
         [":all_runtime"],

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1206,6 +1206,7 @@ rocm_library(
         "cub_scan_kernel_rocm.h",
         "cub_scan_kernel_rocm_impl.cu.cc",
     ],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
     tags = [
         "gpu",
         "rocm-only",
@@ -1226,6 +1227,7 @@ cc_library(
     name = "cub_scan_kernel_rocm",
     srcs = ["cub_scan_kernel_rocm.cc"],
     hdrs = ["cub_scan_kernel_rocm.h"],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
     tags = [
         "gpu",
         "rocm-only",
@@ -1247,6 +1249,7 @@ xla_test(
     name = "cub_scan_kernel_rocm_test",
     srcs = ["cub_scan_kernel_rocm_test.cc"],
     backends = ["gpu"],
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
     tags = ["rocm-only"],
     deps = [
         ":cub_scan_kernel_rocm",

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -838,7 +838,8 @@ cc_library(
         ":rocm_platform",
         ":rocm_solver_context",
         ":topk_kernel_rocm",
-    ] + [":cub_sort_kernel_rocm_" + suffix for suffix in get_cub_sort_kernel_types()],
+    ] + [":cub_sort_kernel_rocm_" + suffix for suffix in get_cub_sort_kernel_types()] +
+        [":cub_scan_kernel_rocm"],
     alwayslink = 1,
 )
 
@@ -1197,6 +1198,77 @@ cc_library(
     ],
     alwayslink = 1,
 ) for typename in get_cub_sort_kernel_types()]
+
+# CUB scan kernel implementation (hipCUB/rocPRIM) - compiled with hipcc
+rocm_library(
+    name = "cub_scan_kernel_rocm_impl",
+    srcs = [
+        "cub_scan_kernel_rocm.h",
+        "cub_scan_kernel_rocm_impl.cu.cc",
+    ],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_status",
+        "//xla:xla_data_proto_cc",
+        "//xla/tsl/platform:errors",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocprim",
+    ],
+)
+
+# CUB scan kernel FFI registration - compiled with regular C++ compiler
+cc_library(
+    name = "cub_scan_kernel_rocm",
+    srcs = ["cub_scan_kernel_rocm.cc"],
+    hdrs = ["cub_scan_kernel_rocm.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":cub_scan_kernel_rocm_impl",
+        "//xla:xla_data_proto_cc",
+        "//xla/backends/gpu:ffi",
+        "//xla/ffi",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+    alwayslink = 1,
+)
+
+xla_test(
+    name = "cub_scan_kernel_rocm_test",
+    srcs = ["cub_scan_kernel_rocm_test.cc"],
+    backends = ["gpu"],
+    tags = ["rocm-only"],
+    deps = [
+        ":cub_scan_kernel_rocm",
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
 
 rocm_library(
     name = "topk_kernel_rocm",

--- a/xla/stream_executor/rocm/cub_scan_kernel_rocm.cc
+++ b/xla/stream_executor/rocm/cub_scan_kernel_rocm.cc
@@ -1,0 +1,86 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/cub_scan_kernel_rocm.h"
+
+#include <cstddef>
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/backends/gpu/ffi.h"
+#include "xla/ffi/ffi.h"
+#include "xla/tsl/platform/statusor.h"
+
+XLA_FFI_REGISTER_ENUM_ATTR_DECODING(stream_executor::rocm::CubScanKind);
+
+namespace stream_executor::rocm {
+
+namespace {
+
+absl::Status CubScanLaunchKernelFfiHandler(
+    xla::ffi::AnyBuffer d_temp_storage, xla::ffi::AnyBuffer d_in,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_out, int64_t vector_length,
+    int64_t row_length, int64_t column_length, CubScanKind kind,
+    bool is_reverse, hipStream_t stream) {
+  return CubScanLaunchKernel(d_in.element_type(), d_temp_storage.untyped_data(),
+                             d_temp_storage.size_bytes(), d_in.untyped_data(),
+                             d_out->untyped_data(), vector_length, row_length,
+                             column_length, kind, is_reverse, stream);
+}
+
+absl::Status CubScanGetScratchSizeFfiHandler(
+    xla::ffi::AnyBuffer d_in, size_t* temp_bytes, int64_t vector_length,
+    int64_t row_length, int64_t column_length, CubScanKind kind,
+    bool is_reverse) {
+  TF_ASSIGN_OR_RETURN(
+      *temp_bytes,
+      CubScanGetScratchSize(d_in.element_type(), vector_length, row_length,
+                            column_length, kind, is_reverse));
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+XLA_FFI_DEFINE_HANDLER(kCubScanExecute, CubScanLaunchKernelFfiHandler,
+                       xla::ffi::Ffi::Bind()
+                           .Arg<xla::ffi::AnyBuffer>()
+                           .Arg<xla::ffi::AnyBuffer>()
+                           .Ret<xla::ffi::AnyBuffer>()
+                           .Attr<int64_t>("vector_length")
+                           .Attr<int64_t>("row_length")
+                           .Attr<int64_t>("column_length")
+                           .Attr<CubScanKind>("kind")
+                           .Attr<bool>("is_reverse")
+                           .Ctx<xla::ffi::PlatformStream<hipStream_t>>());
+
+XLA_FFI_DEFINE_HANDLER(kCubScanInitialize, CubScanGetScratchSizeFfiHandler,
+                       xla::ffi::Ffi::BindInitialize()
+                           .Arg<xla::ffi::AnyBuffer>()
+                           .Attr<xla::ffi::Pointer<size_t>>("temp_bytes")
+                           .Attr<int64_t>("vector_length")
+                           .Attr<int64_t>("row_length")
+                           .Attr<int64_t>("column_length")
+                           .Attr<CubScanKind>("kind")
+                           .Attr<bool>("is_reverse"));
+
+XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_scan",
+                         "ROCM",
+                         {/* .instantiate = */ nullptr,
+                          /* .prepare = */ nullptr,
+                          /* .initialize = */ kCubScanInitialize,
+                          /* .execute = */ kCubScanExecute});
+
+}  // namespace stream_executor::rocm

--- a/xla/stream_executor/rocm/cub_scan_kernel_rocm.h
+++ b/xla/stream_executor/rocm/cub_scan_kernel_rocm.h
@@ -1,0 +1,46 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_CUB_SCAN_KERNEL_ROCM_H_
+#define XLA_STREAM_EXECUTOR_ROCM_CUB_SCAN_KERNEL_ROCM_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/xla_data.pb.h"
+
+namespace stream_executor::rocm {
+
+enum class CubScanKind { kInvalid, kSum };
+
+absl::Status CubScanLaunchKernel(xla::PrimitiveType type, void* d_temp_storage,
+                                 size_t temp_bytes, const void* d_in,
+                                 void* d_out, int64_t vector_length,
+                                 int64_t row_length, int64_t column_length,
+                                 CubScanKind kind, bool is_reverse,
+                                 hipStream_t stream);
+
+absl::StatusOr<size_t> CubScanGetScratchSize(xla::PrimitiveType type,
+                                             int64_t vector_length,
+                                             int64_t row_length,
+                                             int64_t column_length,
+                                             CubScanKind kind, bool is_reverse);
+
+}  // namespace stream_executor::rocm
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_CUB_SCAN_KERNEL_ROCM_H_

--- a/xla/stream_executor/rocm/cub_scan_kernel_rocm_impl.cu.cc
+++ b/xla/stream_executor/rocm/cub_scan_kernel_rocm_impl.cu.cc
@@ -1,0 +1,208 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/rocprim/block/block_load.hpp"
+#include "rocm/include/rocprim/block/block_scan.hpp"
+#include "rocm/include/rocprim/block/block_store.hpp"
+#include "rocm/include/rocprim/device/detail/device_config_helper.hpp"
+#include "rocm/include/rocprim/device/device_scan.hpp"
+#include "rocm/include/rocprim/functional.hpp"
+#include "xla/stream_executor/rocm/cub_scan_kernel_rocm.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/tsl/platform/errors.h"
+#include "xla/xla_data.pb.h"
+
+namespace stream_executor::rocm {
+
+namespace {
+
+// Architecture-aware tuning from rocPRIM's autotuned scan config.
+template <typename T>
+struct ScanConfig {
+  using RocprimConfig =
+      typename rocprim::detail::default_scan_config_base<T>::type;
+  static constexpr int kBlockSize = RocprimConfig::block_size;
+  static constexpr int kItemsPerThread = RocprimConfig::items_per_thread;
+  static constexpr int kTileSize = kBlockSize * kItemsPerThread;
+  static constexpr auto kLoadMethod = RocprimConfig::block_load_method;
+  static constexpr auto kStoreMethod = RocprimConfig::block_store_method;
+  static constexpr auto kScanAlgorithm = RocprimConfig::block_scan_method;
+};
+
+template <typename T>
+struct BlockPrefixCallback {
+  T prefix;
+
+  __device__ BlockPrefixCallback(T initial) : prefix(initial) {}
+
+  __device__ T operator()(T block_reduction) {
+    T old_prefix = prefix;
+    prefix = old_prefix + block_reduction;
+    return old_prefix;
+  }
+};
+
+template <typename T>
+__launch_bounds__(ScanConfig<T>::kBlockSize) __global__
+    void BlockScanKernel(const T* d_in, T* d_out, int64_t n) {
+  constexpr int kBlockSize = ScanConfig<T>::kBlockSize;
+  constexpr int kItemsPerThread = ScanConfig<T>::kItemsPerThread;
+  constexpr int kTileSize = ScanConfig<T>::kTileSize;
+
+  using BlockLoadT = rocprim::block_load<T, kBlockSize, kItemsPerThread,
+                                         ScanConfig<T>::kLoadMethod>;
+  using BlockStoreT = rocprim::block_store<T, kBlockSize, kItemsPerThread,
+                                           ScanConfig<T>::kStoreMethod>;
+  using BlockScanT =
+      rocprim::block_scan<T, kBlockSize, ScanConfig<T>::kScanAlgorithm>;
+
+  __shared__ union {
+    typename BlockLoadT::storage_type load;
+    typename BlockStoreT::storage_type store;
+    typename BlockScanT::storage_type scan;
+  } storage;
+
+  d_in += blockIdx.x * n;
+  d_out += blockIdx.x * n;
+
+  BlockPrefixCallback<T> prefix_callback(T{});
+
+  for (int64_t tile_offset = 0; tile_offset < n; tile_offset += kTileSize) {
+    int tile_size =
+        static_cast<int>(min(static_cast<int64_t>(kTileSize), n - tile_offset));
+
+    T thread_data[kItemsPerThread];
+    BlockLoadT().load(d_in + tile_offset, thread_data, tile_size, T{},
+                      storage.load);
+    __syncthreads();
+
+    BlockScanT().inclusive_scan(thread_data, thread_data, storage.scan,
+                                prefix_callback, rocprim::plus<T>());
+    __syncthreads();
+
+    BlockStoreT().store(d_out + tile_offset, thread_data, tile_size,
+                        storage.store);
+    __syncthreads();
+  }
+}
+
+template <typename T>
+absl::Status CubScanDispatch(void* d_temp_storage, size_t* temp_bytes,
+                             const T* d_in, T* d_out, int64_t vector_length,
+                             int64_t row_length, int64_t column_length,
+                             CubScanKind kind, bool is_reverse,
+                             hipStream_t stream) {
+  if (kind != CubScanKind::kSum) {
+    return absl::InvalidArgumentError("Only SUM scan kind is supported.");
+  }
+  if (is_reverse) {
+    return absl::InvalidArgumentError("Only forward scan is supported.");
+  }
+  if (vector_length > 1) {
+    return absl::InvalidArgumentError("Only vector_length = 1 is supported.");
+  }
+
+  if (column_length == 1) {
+    // 1D: use rocprim device-wide scan for full GPU parallelism.
+    return stream_executor::gpu::ToStatus(
+        rocprim::inclusive_scan(d_temp_storage, *temp_bytes, d_in, d_out,
+                                row_length, rocprim::plus<T>(), stream));
+  }
+
+  // N-D batched: use block-level scan, one block per row.
+  if (d_in == nullptr) {
+    *temp_bytes = 0;
+    return absl::OkStatus();
+  }
+
+  constexpr int kBlockSize = ScanConfig<T>::kBlockSize;
+  hipLaunchKernelGGL(BlockScanKernel<T>, dim3(column_length), dim3(kBlockSize),
+                     0, stream, d_in, d_out, row_length);
+  return stream_executor::gpu::ToStatus(hipGetLastError());
+}
+
+absl::Status CubScanDispatch(xla::PrimitiveType type, void* d_temp_storage,
+                             size_t* temp_bytes, const void* d_in, void* d_out,
+                             int64_t vector_length, int64_t row_length,
+                             int64_t column_length, CubScanKind kind,
+                             bool is_reverse, hipStream_t stream) {
+  auto impl = [&](auto value) {
+    using T = decltype(value);
+    return CubScanDispatch<T>(d_temp_storage, temp_bytes,
+                              static_cast<const T*>(d_in),
+                              static_cast<T*>(d_out), vector_length, row_length,
+                              column_length, kind, is_reverse, stream);
+  };
+  switch (type) {
+    case xla::PrimitiveType::BF16:
+      return impl(hip_bfloat16{});
+    case xla::PrimitiveType::F16:
+      return impl(__half{});
+    case xla::PrimitiveType::F32:
+      return impl(float{});
+    case xla::PrimitiveType::F64:
+      return impl(double{});
+    case xla::PrimitiveType::S8:
+      return impl(int8_t{});
+    case xla::PrimitiveType::S16:
+      return impl(int16_t());
+    case xla::PrimitiveType::S32:
+      return impl(int32_t{});
+    case xla::PrimitiveType::S64:
+      return impl(int64_t{});
+    case xla::PrimitiveType::U8:
+      return impl(uint8_t{});
+    case xla::PrimitiveType::U16:
+      return impl(uint16_t());
+    case xla::PrimitiveType::U32:
+      return impl(uint32_t());
+    case xla::PrimitiveType::U64:
+      return impl(uint64_t{});
+    default:
+      return absl::InvalidArgumentError(
+          "Unsupported element type for CUB scan");
+  }
+}
+
+}  // namespace
+
+absl::Status CubScanLaunchKernel(xla::PrimitiveType type, void* d_temp_storage,
+                                 size_t temp_bytes, const void* d_in,
+                                 void* d_out, int64_t vector_length,
+                                 int64_t row_length, int64_t column_length,
+                                 CubScanKind kind, bool is_reverse,
+                                 hipStream_t stream) {
+  return CubScanDispatch(type, d_temp_storage, &temp_bytes, d_in, d_out,
+                         vector_length, row_length, column_length, kind,
+                         is_reverse, stream);
+}
+
+absl::StatusOr<size_t> CubScanGetScratchSize(
+    xla::PrimitiveType type, int64_t vector_length, int64_t row_length,
+    int64_t column_length, CubScanKind kind, bool is_reverse) {
+  size_t temp_bytes = 0;
+  TF_RETURN_IF_ERROR(CubScanDispatch(type, nullptr, &temp_bytes, nullptr,
+                                     nullptr, vector_length, row_length,
+                                     column_length, kind, is_reverse, nullptr));
+  return temp_bytes;
+}
+
+}  // namespace stream_executor::rocm

--- a/xla/stream_executor/rocm/cub_scan_kernel_rocm_test.cc
+++ b/xla/stream_executor/rocm/cub_scan_kernel_rocm_test.cc
@@ -1,0 +1,349 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/cub_scan_kernel_rocm.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <tuple>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/cleanup/cleanup.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "rocm/include/hip/hip_bfloat16.h"
+#include "rocm/include/hip/hip_fp16.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/primitive_util.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/xla_data.pb.h"
+
+namespace se = stream_executor;
+
+namespace stream_executor::rocm {
+namespace {
+
+// Host-side bf16 conversion helpers. hip_bfloat16 operators require hipcc,
+// but this test is compiled with the host C++ compiler.
+float Bf16ToFloat(hip_bfloat16 v) {
+  uint16_t bits;
+  std::memcpy(&bits, &v, sizeof(bits));
+  uint32_t f32_bits = static_cast<uint32_t>(bits) << 16;
+  float result;
+  std::memcpy(&result, &f32_bits, sizeof(result));
+  return result;
+}
+
+hip_bfloat16 FloatToBf16(float v) {
+  uint32_t bits;
+  std::memcpy(&bits, &v, sizeof(bits));
+  // Round to nearest even (same algorithm as hip_bfloat16's float_to_bfloat16).
+  uint16_t lsb = (bits >> 16) & 1;
+  bits += 0x7FFF + lsb;
+  uint16_t bf16_bits = static_cast<uint16_t>(bits >> 16);
+  hip_bfloat16 result;
+  std::memcpy(&result, &bf16_bits, sizeof(result));
+  return result;
+}
+
+class CubScanKernelRocmTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<std::tuple<
+          xla::PrimitiveType, size_t, size_t, size_t, CubScanKind, bool>> {
+ protected:
+  void SetUp() override {
+    TF_ASSERT_OK_AND_ASSIGN(platform_,
+                            se::PlatformManager::PlatformWithName("ROCM"));
+    TF_ASSERT_OK_AND_ASSIGN(executor_, platform_->ExecutorForDevice(0));
+    TF_ASSERT_OK_AND_ASSIGN(stream_, executor_->CreateStream(std::nullopt));
+  }
+
+ public:
+  template <typename T>
+  absl::Status RunCubScanTest(xla::PrimitiveType type, size_t vector_length,
+                              size_t row_length, size_t col_length,
+                              CubScanKind kind, bool is_reverse) {
+    if (type == xla::PrimitiveType::BF16 && row_length > 128) {
+      GTEST_SKIP() << "BF16 for row length > 128 has precision issues.",
+          absl::OkStatus();
+    }
+
+    size_t num_elements = vector_length * row_length * col_length;
+    std::vector<T> host_data, expected;
+    host_data.reserve(num_elements);
+    expected.reserve(num_elements);
+    for (size_t i = 0; i < col_length; ++i) {
+      T sum = {};
+      for (size_t j = 0; j < row_length; ++j) {
+        T value = static_cast<T>((i + j) % 5);
+        sum += value;
+        host_data.push_back(value);
+        expected.push_back(sum);
+      }
+    }
+
+    TF_ASSIGN_OR_RETURN(size_t temp_bytes,
+                        CubScanGetScratchSize(type, vector_length, row_length,
+                                              col_length, kind, is_reverse));
+
+    se::DeviceAddress<T> device_data =
+        executor_->AllocateArray<T>(num_elements);
+    auto data_cleanup =
+        absl::MakeCleanup([&]() { executor_->Deallocate(&device_data); });
+    se::DeviceAddress<uint8_t> device_temp =
+        executor_->AllocateArray<uint8_t>(temp_bytes);
+    auto temp_cleanup =
+        absl::MakeCleanup([&]() { executor_->Deallocate(&device_temp); });
+
+    size_t size_bytes = num_elements * sizeof(T);
+    TF_RETURN_IF_ERROR(
+        stream_->Memcpy(&device_data, host_data.data(), size_bytes));
+
+    TF_RETURN_IF_ERROR(CubScanLaunchKernel(
+        type, device_temp.opaque(), temp_bytes, device_data.opaque(),
+        device_data.opaque(), vector_length, row_length, col_length, kind,
+        is_reverse,
+        static_cast<hipStream_t>(stream_->platform_specific_handle().stream)));
+
+    TF_RETURN_IF_ERROR(stream_->BlockHostUntilDone());
+    TF_RETURN_IF_ERROR(
+        stream_->Memcpy(host_data.data(), device_data, size_bytes));
+
+    if constexpr (std::is_same_v<T, float>) {
+      EXPECT_THAT(host_data,
+                  ::testing::Pointwise(::testing::FloatEq(), expected));
+    } else if constexpr (std::is_same_v<T, double>) {
+      EXPECT_THAT(host_data,
+                  ::testing::Pointwise(::testing::DoubleEq(), expected));
+    } else {
+      EXPECT_EQ(host_data, expected);
+    }
+    return absl::OkStatus();
+  }
+
+  // bf16 specialization: host-side conversion via memcpy.
+  absl::Status RunCubScanTestBf16(xla::PrimitiveType type, size_t vector_length,
+                                  size_t row_length, size_t col_length,
+                                  CubScanKind kind, bool is_reverse) {
+    if (row_length > 128) {
+      GTEST_SKIP() << "BF16 for row length > 128 has precision issues.",
+          absl::OkStatus();
+    }
+
+    size_t num_elements = vector_length * row_length * col_length;
+    std::vector<hip_bfloat16> host_data;
+    std::vector<float> expected_f;
+    host_data.reserve(num_elements);
+    expected_f.reserve(num_elements);
+    for (size_t i = 0; i < col_length; ++i) {
+      float sum = 0.0f;
+      for (size_t j = 0; j < row_length; ++j) {
+        float value = static_cast<float>((i + j) % 5);
+        hip_bfloat16 bf_value = FloatToBf16(value);
+        float bf_value_f = Bf16ToFloat(bf_value);
+        sum += bf_value_f;
+        sum = Bf16ToFloat(FloatToBf16(sum));
+        host_data.push_back(bf_value);
+        expected_f.push_back(sum);
+      }
+    }
+
+    TF_ASSIGN_OR_RETURN(size_t temp_bytes,
+                        CubScanGetScratchSize(type, vector_length, row_length,
+                                              col_length, kind, is_reverse));
+
+    se::DeviceAddress<hip_bfloat16> device_data =
+        executor_->AllocateArray<hip_bfloat16>(num_elements);
+    auto data_cleanup =
+        absl::MakeCleanup([&]() { executor_->Deallocate(&device_data); });
+    se::DeviceAddress<uint8_t> device_temp =
+        executor_->AllocateArray<uint8_t>(temp_bytes);
+    auto temp_cleanup =
+        absl::MakeCleanup([&]() { executor_->Deallocate(&device_temp); });
+
+    size_t size_bytes = num_elements * sizeof(hip_bfloat16);
+    TF_RETURN_IF_ERROR(
+        stream_->Memcpy(&device_data, host_data.data(), size_bytes));
+
+    TF_RETURN_IF_ERROR(CubScanLaunchKernel(
+        type, device_temp.opaque(), temp_bytes, device_data.opaque(),
+        device_data.opaque(), vector_length, row_length, col_length, kind,
+        is_reverse,
+        static_cast<hipStream_t>(stream_->platform_specific_handle().stream)));
+
+    TF_RETURN_IF_ERROR(stream_->BlockHostUntilDone());
+    TF_RETURN_IF_ERROR(
+        stream_->Memcpy(host_data.data(), device_data, size_bytes));
+
+    for (size_t i = 0; i < num_elements; ++i) {
+      EXPECT_FLOAT_EQ(Bf16ToFloat(host_data[i]), expected_f[i]);
+    }
+    return absl::OkStatus();
+  }
+
+  // f16 specialization: host-side conversion via __half2float / __float2half.
+  absl::Status RunCubScanTestF16(xla::PrimitiveType type, size_t vector_length,
+                                 size_t row_length, size_t col_length,
+                                 CubScanKind kind, bool is_reverse) {
+    size_t num_elements = vector_length * row_length * col_length;
+    std::vector<__half> host_data;
+    std::vector<float> expected_f;
+    host_data.reserve(num_elements);
+    expected_f.reserve(num_elements);
+    for (size_t i = 0; i < col_length; ++i) {
+      float sum = 0.0f;
+      for (size_t j = 0; j < row_length; ++j) {
+        float value = static_cast<float>((i + j) % 5);
+        __half h_value = __float2half(value);
+        float h_value_f = __half2float(h_value);
+        sum += h_value_f;
+        sum = __half2float(__float2half(sum));
+        host_data.push_back(h_value);
+        expected_f.push_back(sum);
+      }
+    }
+
+    TF_ASSIGN_OR_RETURN(size_t temp_bytes,
+                        CubScanGetScratchSize(type, vector_length, row_length,
+                                              col_length, kind, is_reverse));
+
+    se::DeviceAddress<__half> device_data =
+        executor_->AllocateArray<__half>(num_elements);
+    auto data_cleanup =
+        absl::MakeCleanup([&]() { executor_->Deallocate(&device_data); });
+    se::DeviceAddress<uint8_t> device_temp =
+        executor_->AllocateArray<uint8_t>(temp_bytes);
+    auto temp_cleanup =
+        absl::MakeCleanup([&]() { executor_->Deallocate(&device_temp); });
+
+    size_t size_bytes = num_elements * sizeof(__half);
+    TF_RETURN_IF_ERROR(
+        stream_->Memcpy(&device_data, host_data.data(), size_bytes));
+
+    TF_RETURN_IF_ERROR(CubScanLaunchKernel(
+        type, device_temp.opaque(), temp_bytes, device_data.opaque(),
+        device_data.opaque(), vector_length, row_length, col_length, kind,
+        is_reverse,
+        static_cast<hipStream_t>(stream_->platform_specific_handle().stream)));
+
+    TF_RETURN_IF_ERROR(stream_->BlockHostUntilDone());
+    TF_RETURN_IF_ERROR(
+        stream_->Memcpy(host_data.data(), device_data, size_bytes));
+
+    for (size_t i = 0; i < num_elements; ++i) {
+      EXPECT_FLOAT_EQ(__half2float(host_data[i]), expected_f[i]);
+    }
+    return absl::OkStatus();
+  }
+
+ private:
+  se::Platform* platform_;
+  se::StreamExecutor* executor_;
+  std::unique_ptr<se::Stream> stream_;
+};
+
+TEST_P(CubScanKernelRocmTest, TestPrefixSum) {
+  const auto& params = GetParam();
+  auto type = std::get<xla::PrimitiveType>(params);
+  switch (type) {
+    case xla::PrimitiveType::BF16:
+      TF_EXPECT_OK(std::apply(&CubScanKernelRocmTest::RunCubScanTestBf16,
+                              std::tuple_cat(std::make_tuple(this), params)));
+      return;
+    case xla::PrimitiveType::F16:
+      TF_EXPECT_OK(std::apply(&CubScanKernelRocmTest::RunCubScanTestF16,
+                              std::tuple_cat(std::make_tuple(this), params)));
+      return;
+    default:
+      break;
+  }
+  auto impl = [&](auto value) {
+    TF_EXPECT_OK(
+        std::apply(&CubScanKernelRocmTest::RunCubScanTest<decltype(value)>,
+                   std::tuple_cat(std::make_tuple(this), params)));
+  };
+  switch (type) {
+    case xla::PrimitiveType::F32:
+      return impl(float{});
+    case xla::PrimitiveType::F64:
+      return impl(double{});
+    case xla::PrimitiveType::S8:
+      return impl(int8_t{});
+    case xla::PrimitiveType::S16:
+      return impl(int16_t());
+    case xla::PrimitiveType::S32:
+      return impl(int32_t{});
+    case xla::PrimitiveType::S64:
+      return impl(int64_t{});
+    case xla::PrimitiveType::U8:
+      return impl(uint8_t{});
+    case xla::PrimitiveType::U16:
+      return impl(uint16_t());
+    case xla::PrimitiveType::U32:
+      return impl(uint32_t());
+    case xla::PrimitiveType::U64:
+      return impl(uint64_t{});
+    default:
+      FAIL() << "Unsupported element type for CUB scan";
+  }
+}
+
+std::string CubScanKindToString(CubScanKind kind) {
+  switch (kind) {
+    case CubScanKind::kSum:
+      return "Sum";
+    case CubScanKind::kInvalid:
+      return "Invalid";
+  }
+}
+
+std::string ParametersToString(
+    const ::testing::TestParamInfo<::testing::tuple<
+        xla::PrimitiveType, size_t, size_t, size_t, CubScanKind, bool>>& data) {
+  const auto& [type, vector_length, row_length, col_length, kind, is_reverse] =
+      data.param;
+  return absl::StrFormat("%s_%s_%dx%dx%d_%s", CubScanKindToString(kind),
+                         is_reverse ? "reverse" : "forward", col_length,
+                         row_length, vector_length,
+                         xla::primitive_util::LowercasePrimitiveTypeName(type));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CubScanKernelRocmTestInstance, CubScanKernelRocmTest,
+    ::testing::Combine(::testing::ValuesIn({xla::BF16, xla::F16, xla::F32,
+                                            xla::F64, xla::S8, xla::S16,
+                                            xla::S32, xla::S64, xla::U8,
+                                            xla::U16, xla::U32, xla::U64}),
+                       ::testing::Values(size_t{1}),
+                       ::testing::ValuesIn<size_t>({1, 2, 3, 128, 511, 513}),
+                       ::testing::ValuesIn<size_t>({1, 2, 3, 128, 511, 512}),
+                       ::testing::Values(CubScanKind::kSum),
+                       ::testing::Values(false)),
+    ParametersToString);
+
+}  // namespace
+}  // namespace stream_executor::rocm


### PR DESCRIPTION
📝 Summary of Changes
- Add hybrid scan kernel using rocPRIM primitives:
  * `rocprim::inclusive_scan` (device-wide) for 1D scans
  * Custom `BlockScanKernel` using `block_scan`, `block_load`, `block_store` for N-D batched scans
- Architecture-aware tuning via rocPRIM's autotuned scan config (`default_scan_config_base`)
- Single kernel launch with `gridDim = column_length` for batched case (no host-side loop)
- Register ROCm FFI handler for `xla.gpu.ext.cub_scan` with runtime type dispatch for all 12 supported types
- Add parameterized kernel test covering all types, row/column sizes, and scan configurations


🎯 Justification
PR #38965 added CUB-based prefix sum (scan) support for CUDA via XLA FFI, but ROCm support was missing, causing cub_scan_thunk_test to fail on ROCm builds. This PR adds the symmetric hipCUB implementation 

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix,✨ New Feature

🧪 Unit Tests:
xla/stream_executor/rocm/cub_prefix_sum_kernel_rocm_test.cc
