### PR TITLE
[xla] Add DWYU (Depend on What You Use) check

### DIFF
--- a/.github/workflows/dwyu.yml
+++ b/.github/workflows/dwyu.yml
@@ -1,0 +1,64 @@
+# Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+name: DWYU (Depend on What You Use)
+permissions:
+  contents: read
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  GOBIN: "/usr/local/bin"
+  PYTHONPATH: "."
+  BANT_VERSION: "0.2.5"
+
+jobs:
+  dwyu:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: '0'
+          persist-credentials: false
+      - name: "Fetch HEAD of main branch"
+        run: git fetch origin main --depth=1
+      - name: "Install bant"
+        run: |
+          curl -fSL "https://github.com/hzeller/bant/releases/download/v${BANT_VERSION}/bant-v${BANT_VERSION}-linux-static-x86_64.tar.gz" -o /tmp/bant.tar.gz
+          tar xzf /tmp/bant.tar.gz -C /tmp
+          sudo install /tmp/bant-v${BANT_VERSION}-linux-static-x86_64/bin/bant /usr/local/bin/bant
+      - name: "Install bazelisk"
+        run: parallel --ungroup --retries 3 --delay 15 --nonall -- go install github.com/bazelbuild/bazelisk@24651ab # v1.20.0
+      - name: "Run bazel build --nobuild //xla/... with retries"
+        run: parallel --ungroup --retries 3 --delay 15 --nonall -- bazelisk build --nobuild //xla/...
+      - name: "Find affected targets and run bant dwyu"
+        run: |
+          set -euo pipefail
+          TARGETS=$(python3 build_tools/lint/check_dwyu.py)
+          if [ -z "$TARGETS" ]; then
+            echo "No targets to check."
+            exit 0
+          fi
+          echo "Running: bant dwyu $TARGETS"
+          # shellcheck disable=SC2086
+          bant dwyu $TARGETS

--- a/build_tools/lint/check_dwyu.py
+++ b/build_tools/lint/check_dwyu.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The OpenXLA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Find modified Bazel targets of allowed types for DWYU checking.
+
+Finds Bazel packages affected by the current diff, extracts targets matching
+an allowlist of rule types, and prints their labels. Intended to be used with
+`bant dwyu` in CI to check that modified targets depend on what they use.
+
+Usage:
+  python3 build_tools/lint/check_dwyu.py --allowed_rules cc_library xla_test
+"""
+import argparse
+import logging
+import os
+import re
+import subprocess
+import sys
+from typing import Sequence
+
+from build_tools.lint import diff_parser
+
+_RULE_START = re.compile(r"^(\w+)\s*\(", re.MULTILINE)
+_NAME_ATTR = re.compile(r'name\s*=\s*"([^"]+)"')
+
+DEFAULT_ALLOWED_RULES = ("cc_library", "xla_test", "xla_cc_test")
+
+
+def get_diff(base_ref: str) -> str:
+  """Run git diff against base_ref and return stdout."""
+  proc = subprocess.run(
+      ["git", "diff", base_ref, "HEAD"],
+      capture_output=True,
+      check=True,
+      text=True,
+  )
+  return proc.stdout
+
+
+def changed_files_from_diff(diff: str) -> list[str]:
+  """Extract unique file paths from a parsed diff."""
+  hunks = diff_parser.parse_hunks(diff)
+  return sorted(set(h.file for h in hunks))
+
+
+def find_packages(changed_files: list[str]) -> set[str]:
+  """Find Bazel packages containing the changed files."""
+  packages = set()
+  for filepath in changed_files:
+    dirpath = os.path.dirname(filepath)
+    while dirpath:
+      if os.path.isfile(os.path.join(dirpath, "BUILD")) or os.path.isfile(
+          os.path.join(dirpath, "BUILD.bazel")
+      ):
+        packages.add(dirpath)
+        break
+      dirpath = os.path.dirname(dirpath)
+  return packages
+
+
+def extract_targets(
+    build_content: str, allowed_rules: set[str]
+) -> list[str]:
+  """Extract target names of allowed rule types from BUILD file content."""
+  targets = []
+  lines = build_content.split("\n")
+  for i, line in enumerate(lines):
+    m = _RULE_START.match(line.strip())
+    if not m or m.group(1) not in allowed_rules:
+      continue
+    # name= is typically within the first few lines of a rule definition.
+    for j in range(i, min(i + 5, len(lines))):
+      nm = _NAME_ATTR.search(lines[j])
+      if nm:
+        targets.append(nm.group(1))
+        break
+  return targets
+
+
+def find_affected_targets(
+    packages: set[str], allowed_rules: set[str]
+) -> list[str]:
+  """Find targets of allowed types in the given packages."""
+  targets = []
+  for package in sorted(packages):
+    for build_name in ("BUILD", "BUILD.bazel"):
+      build_path = os.path.join(package, build_name)
+      if not os.path.isfile(build_path):
+        continue
+      with open(build_path) as f:
+        content = f.read()
+      for target_name in extract_targets(content, allowed_rules):
+        targets.append(f"//{package}:{target_name}")
+      break
+  return targets
+
+
+def main(argv: Sequence[str]):
+  parser = argparse.ArgumentParser(
+      description="Find modified Bazel targets for DWYU checking."
+  )
+  parser.add_argument(
+      "--allowed_rules",
+      nargs="+",
+      default=list(DEFAULT_ALLOWED_RULES),
+      help="Rule types to include (default: %(default)s)",
+  )
+  parser.add_argument(
+      "--base_ref",
+      default="origin/main",
+      help="Git ref to diff against (default: origin/main)",
+  )
+  args = parser.parse_args(argv[1:])
+  allowed_rules = set(args.allowed_rules)
+
+  diff = get_diff(args.base_ref)
+  changed = changed_files_from_diff(diff)
+  if not changed:
+    logging.info("No files changed.")
+    sys.exit(0)
+
+  packages = find_packages(changed)
+  if not packages:
+    logging.info("No Bazel packages affected.")
+    sys.exit(0)
+
+  targets = find_affected_targets(packages, allowed_rules)
+  if not targets:
+    logging.info("No targets of allowed types found in affected packages.")
+    sys.exit(0)
+
+  logging.info("Found %d target(s) to check:", len(targets))
+  for t in targets:
+    logging.info("  %s", t)
+
+  # Write targets to stdout, one per line, for consumption by bant.
+  sys.stdout.write("\n".join(targets) + "\n")
+
+
+if __name__ == "__main__":
+  main(sys.argv)

--- a/build_tools/lint/check_dwyu_test.py
+++ b/build_tools/lint/check_dwyu_test.py
@@ -1,0 +1,95 @@
+# Copyright 2026 The OpenXLA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import unittest
+
+from build_tools.lint.check_dwyu import extract_targets
+
+ALLOWED_RULES = {"cc_library", "xla_test", "xla_cc_test"}
+
+
+class ExtractTargetsTest(unittest.TestCase):
+
+  def test_cc_library(self):
+    build = '''\
+cc_library(
+    name = "foo",
+    srcs = ["foo.cc"],
+)
+'''
+    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["foo"])
+
+  def test_xla_test(self):
+    build = '''\
+xla_test(
+    name = "bar_test",
+    srcs = ["bar_test.cc"],
+)
+'''
+    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["bar_test"])
+
+  def test_xla_cc_test(self):
+    build = '''\
+xla_cc_test(
+    name = "baz_test",
+    srcs = ["baz_test.cc"],
+)
+'''
+    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["baz_test"])
+
+  def test_skips_non_allowed_rules(self):
+    build = '''\
+cc_binary(
+    name = "my_binary",
+    srcs = ["main.cc"],
+)
+
+py_library(
+    name = "my_lib",
+    srcs = ["lib.py"],
+)
+'''
+    self.assertEqual(extract_targets(build, ALLOWED_RULES), [])
+
+  def test_mixed_rules(self):
+    build = '''\
+cc_library(
+    name = "lib",
+    srcs = ["lib.cc"],
+)
+
+cc_binary(
+    name = "bin",
+    srcs = ["main.cc"],
+)
+
+xla_test(
+    name = "lib_test",
+    srcs = ["lib_test.cc"],
+)
+'''
+    self.assertEqual(
+        extract_targets(build, ALLOWED_RULES), ["lib", "lib_test"]
+    )
+
+  def test_empty_build_file(self):
+    self.assertEqual(extract_targets("", ALLOWED_RULES), [])
+
+  def test_name_on_same_line(self):
+    build = 'cc_library(name = "inline_lib", srcs = ["a.cc"])\n'
+    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["inline_lib"])
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Add `bant`-based (https://github.com/hzeller/bant) presubmit that does roughly the same check as google-internal buildcleaner check, but visible for OSS contributors. It might not be always correct, but it catches most of the common problems.