### PR TITLE
[xla] DWYU check only modified targets

### DIFF
--- a/build_tools/lint/check_dwyu.py
+++ b/build_tools/lint/check_dwyu.py
@@ -14,9 +14,12 @@
 # ============================================================================
 """Find modified Bazel targets of allowed types for DWYU checking.
 
-Finds Bazel packages affected by the current diff, extracts targets matching
-an allowlist of rule types, and prints their labels. Intended to be used with
-`bant dwyu` in CI to check that modified targets depend on what they use.
+Finds Bazel targets whose source files (srcs/hdrs) were modified in the
+current diff, and prints their labels. Intended to be used with `bant dwyu`
+in CI to check that modified targets depend on what they use.
+
+Only targets that directly include a modified file are checked, rather than
+all targets in affected packages.
 
 Usage:
   python3 build_tools/lint/check_dwyu.py --allowed_rules cc_library xla_test
@@ -34,6 +37,7 @@ from build_tools.lint import diff_parser
 
 _RULE_START = re.compile(r"^(\w+)\s*\(", re.MULTILINE)
 _NAME_ATTR = re.compile(r'name\s*=\s*"([^"]+)"')
+_STRING_LITERAL = re.compile(r'"([^"]+)"')
 
 DEFAULT_ALLOWED_RULES = ("cc_library", "xla_test", "xla_cc_test")
 
@@ -70,27 +74,83 @@ def find_packages(changed_files: list[str]) -> set[str]:
   return packages
 
 
-def extract_targets(build_content: str, allowed_rules: set[str]) -> list[str]:
-  """Extract target names of allowed rule types from BUILD file content."""
+def _find_rule_end(lines: list[str], start: int) -> int:
+  """Find the line index where the rule's parentheses are balanced."""
+  depth = 0
+  for i in range(start, len(lines)):
+    depth += lines[i].count("(") - lines[i].count(")")
+    if depth <= 0:
+      return i
+  return len(lines) - 1
+
+
+def _extract_string_list(block: str, attr: str) -> list[str]:
+  """Extract string literals from a list-valued attribute in a rule block."""
+  pattern = re.compile(
+      rf"{attr}\s*=\s*\[([^\]]*)\]", re.DOTALL
+  )
+  m = pattern.search(block)
+  if not m:
+    return []
+  return _STRING_LITERAL.findall(m.group(1))
+
+
+def extract_targets(
+    build_content: str, allowed_rules: set[str]
+) -> list[tuple[str, set[str]]]:
+  """Extract target names and their source files from allowed rule types.
+
+  Args:
+    build_content: the contents of a BUILD file.
+    allowed_rules: set of rule types to consider.
+
+  Returns:
+    A list of (target_name, source_files) tuples, where source_files
+    is the set of filenames referenced in srcs and hdrs attributes.
+  """
   targets = []
   lines = build_content.split("\n")
   for i, line in enumerate(lines):
     m = _RULE_START.match(line.strip())
     if not m or m.group(1) not in allowed_rules:
       continue
-    # name= is typically within the first few lines of a rule definition.
+    # Find the target name.
+    name = None
     for j in range(i, min(i + 5, len(lines))):
       nm = _NAME_ATTR.search(lines[j])
       if nm:
-        targets.append(nm.group(1))
+        name = nm.group(1)
         break
+    if name is None:
+      continue
+    # Extract the full rule block to find srcs/hdrs.
+    end = _find_rule_end(lines, i)
+    block = "\n".join(lines[i : end + 1])
+    source_files = set()
+    source_files.update(_extract_string_list(block, "srcs"))
+    source_files.update(_extract_string_list(block, "hdrs"))
+    targets.append((name, source_files))
   return targets
 
 
 def find_affected_targets(
-    packages: set[str], allowed_rules: set[str]
+    packages: set[str],
+    allowed_rules: set[str],
+    changed_basenames: dict[str, set[str]],
+    build_files_changed: set[str],
 ) -> list[str]:
-  """Find targets of allowed types in the given packages."""
+  """Find targets whose source files were modified.
+
+  Args:
+    packages: set of Bazel package paths to scan.
+    allowed_rules: set of rule types to consider.
+    changed_basenames: mapping from package path to set of changed file
+      basenames within that package.
+    build_files_changed: set of package paths whose BUILD files were modified.
+
+  Returns:
+    list of Bazel target labels that include modified files.
+  """
   targets = []
   for package in sorted(packages):
     for build_name in ("BUILD", "BUILD.bazel"):
@@ -99,10 +159,46 @@ def find_affected_targets(
         continue
       with open(build_path) as f:
         content = f.read()
-      for target_name in extract_targets(content, allowed_rules):
-        targets.append(f"//{package}:{target_name}")
+      pkg_changed = changed_basenames.get(package, set())
+      build_changed = package in build_files_changed
+      for target_name, source_files in extract_targets(content, allowed_rules):
+        # Include target if: (1) any of its srcs/hdrs were modified, or
+        # (2) the BUILD file itself was modified (deps may have changed).
+        if build_changed or (source_files & pkg_changed):
+          targets.append(f"//{package}:{target_name}")
       break
   return targets
+
+
+def _group_changed_files_by_package(
+    changed_files: list[str], packages: set[str]
+) -> tuple[dict[str, set[str]], set[str]]:
+  """Group changed file basenames by their Bazel package.
+
+  Args:
+    changed_files: list of changed file paths.
+    packages: set of Bazel package paths to consider.
+
+  Returns:
+    A tuple of (changed_basenames, build_files_changed) where
+    changed_basenames maps package path to set of changed file basenames,
+    and build_files_changed is a set of package paths whose BUILD file
+    was modified.
+  """
+  changed_basenames: dict[str, set[str]] = {}
+  build_files_changed: set[str] = set()
+  for filepath in changed_files:
+    basename = os.path.basename(filepath)
+    dirpath = os.path.dirname(filepath)
+    # Walk up to find which package this file belongs to.
+    while dirpath:
+      if dirpath in packages:
+        changed_basenames.setdefault(dirpath, set()).add(basename)
+        if basename in ("BUILD", "BUILD.bazel"):
+          build_files_changed.add(dirpath)
+        break
+      dirpath = os.path.dirname(dirpath)
+  return changed_basenames, build_files_changed
 
 
 def main(argv: Sequence[str]):
@@ -134,7 +230,12 @@ def main(argv: Sequence[str]):
     logging.info("No Bazel packages affected.")
     sys.exit(0)
 
-  targets = find_affected_targets(packages, allowed_rules)
+  changed_basenames, build_files_changed = _group_changed_files_by_package(
+      changed, packages
+  )
+  targets = find_affected_targets(
+      packages, allowed_rules, changed_basenames, build_files_changed
+  )
   if not targets:
     logging.info("No targets of allowed types found in affected packages.")
     sys.exit(0)

--- a/build_tools/lint/check_dwyu_test.py
+++ b/build_tools/lint/check_dwyu_test.py
@@ -28,7 +28,10 @@ cc_library(
     srcs = ["foo.cc"],
 )
 """
-    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["foo"])
+    result = extract_targets(build, ALLOWED_RULES)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0][0], "foo")
+    self.assertEqual(result[0][1], {"foo.cc"})
 
   def test_xla_test(self):
     build = """\
@@ -37,7 +40,10 @@ xla_test(
     srcs = ["bar_test.cc"],
 )
 """
-    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["bar_test"])
+    result = extract_targets(build, ALLOWED_RULES)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0][0], "bar_test")
+    self.assertEqual(result[0][1], {"bar_test.cc"})
 
   def test_xla_cc_test(self):
     build = """\
@@ -46,7 +52,10 @@ xla_cc_test(
     srcs = ["baz_test.cc"],
 )
 """
-    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["baz_test"])
+    result = extract_targets(build, ALLOWED_RULES)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0][0], "baz_test")
+    self.assertEqual(result[0][1], {"baz_test.cc"})
 
   def test_skips_non_allowed_rules(self):
     build = """\
@@ -79,14 +88,52 @@ xla_test(
     srcs = ["lib_test.cc"],
 )
 """
-    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["lib", "lib_test"])
+    result = extract_targets(build, ALLOWED_RULES)
+    self.assertEqual(len(result), 2)
+    self.assertEqual(result[0][0], "lib")
+    self.assertEqual(result[1][0], "lib_test")
 
   def test_empty_build_file(self):
     self.assertEqual(extract_targets("", ALLOWED_RULES), [])
 
   def test_name_on_same_line(self):
     build = 'cc_library(name = "inline_lib", srcs = ["a.cc"])\n'
-    self.assertEqual(extract_targets(build, ALLOWED_RULES), ["inline_lib"])
+    result = extract_targets(build, ALLOWED_RULES)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0][0], "inline_lib")
+    self.assertEqual(result[0][1], {"a.cc"})
+
+  def test_srcs_and_hdrs(self):
+    build = """\
+cc_library(
+    name = "mylib",
+    srcs = ["mylib.cc"],
+    hdrs = ["mylib.h"],
+)
+"""
+    result = extract_targets(build, ALLOWED_RULES)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0][0], "mylib")
+    self.assertEqual(result[0][1], {"mylib.cc", "mylib.h"})
+
+  def test_multiple_srcs(self):
+    build = """\
+cc_library(
+    name = "multi",
+    srcs = [
+        "a.cc",
+        "b.cc",
+    ],
+    hdrs = [
+        "a.h",
+        "b.h",
+    ],
+)
+"""
+    result = extract_targets(build, ALLOWED_RULES)
+    self.assertEqual(len(result), 1)
+    self.assertEqual(result[0][0], "multi")
+    self.assertEqual(result[0][1], {"a.cc", "b.cc", "a.h", "b.h"})
 
 
 if __name__ == "__main__":

--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -564,8 +564,7 @@ TEST(TracedCommandBuffer, GetOrUpdateCommandBuffer) {
                             traced_cmd_buffer.GetOrTraceCommandBuffer(
                                 &allocations, executor, stream.get(), trace));
 
-    // Check that command buffer was reused as buffer allocations didn't
-    // change.
+    // Check that command buffer was reused as buffer allocations didn't change.
     ASSERT_EQ(command_buffer0, command_buffer1);
     EXPECT_EQ(num_calls, 1);
 


### PR DESCRIPTION
Finds Bazel targets whose source files (srcs/hdrs) were modified in the
current diff, and prints their labels. Intended to be used with `bant dwyu`
in CI to check that modified targets depend on what they use.

Only targets that directly include a modified file are checked, rather than
all targets in affected packages.