### PR TITLE
[ROCm] Add scope_range_id support to ROCm profiler

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -459,6 +459,7 @@ cc_library(
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -714,9 +715,7 @@ cc_library(
         "//xla/tsl/util:env_var",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/log",
-        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings:string_view",
-        "//xla/tsl/platform:logging",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:stringpiece",
     ],
@@ -795,7 +794,6 @@ xla_cc_test(
         ":cupti_buffer_events",
         ":cupti_collector",  # buildcleaner: keep
         ":cupti_utils",
-        "//xla/tsl/platform:test",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:test",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -156,6 +156,7 @@ cc_library(
     ],
     deps = [
         ":cupti_interface",
+        "//xla/tsl/platform:test",
         "@local_config_cuda//cuda:cuda_headers",
         "@tsl//tsl/platform:test",
     ],
@@ -420,6 +421,11 @@ cc_library(
     deps = [
         ":cupti_interface",
         ":cupti_utils",
+        "//xla/tsl/platform:env",
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:logging",
+        "//xla/tsl/platform:macros",
+        "//xla/tsl/platform:types",
         "//xla/tsl/profiler/backends/cpu:annotation_stack",
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -513,6 +519,7 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
         "@local_config_rocm//rocm:rocm_headers",  # buildcleaner: keep
         "@local_config_rocm//rocm:rocprofiler-sdk",  # buildcleaner: keep
         "@tsl//tsl/platform:abi",
@@ -580,7 +587,6 @@ cc_library(
         "gpu",
     ],
     deps = [
-        "//xla/tsl/cuda:cupti",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
@@ -685,6 +691,7 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cuda_headers",
+        "//xla/tsl/platform:errors",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:thread_annotations",
@@ -709,6 +716,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings:string_view",
+        "//xla/tsl/platform:logging",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:stringpiece",
     ],
@@ -787,6 +795,7 @@ xla_cc_test(
         ":cupti_buffer_events",
         ":cupti_collector",  # buildcleaner: keep
         ":cupti_utils",
+        "//xla/tsl/platform:test",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:test",

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -155,7 +155,11 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
       VLOG(3) << "No trace data collected";
       return absl::OkStatus();
     case State::kStoppedOk: {
-      if (rocm_trace_collector_) rocm_trace_collector_->Export(space);
+      if (rocm_trace_collector_) {
+        rocm_trace_collector_->SetScopeRangeIdTree(
+            rocm_tracer_->annotation_map()->TakeScopeRangeIdTree());
+        rocm_trace_collector_->Export(space);
+      }
       return absl::OkStatus();
     }
   }

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -210,6 +210,11 @@ void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
                             GetStatTypeStr(StatType::kCorrelationId)),
                         event.correlation_id);
   }
+  if (event.scope_range_id != 0) {
+    xevent.AddStatValue(*plane->GetOrCreateStatMetadata(
+                            GetStatTypeStr(StatType::kScopeRangeId)),
+                        event.scope_range_id);
+  }
   if (!event.roctx_range.empty()) {
     xevent.AddStatValue(
         *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kNVTXRange)),
@@ -546,6 +551,18 @@ void RocmTraceCollectorImpl::Flush() {
   auxiliary_api_events_map_.clear();
 }
 
+void RocmTraceCollectorImpl::ExportScopeRangeIdTree(XSpace* space) {
+  XPlaneBuilder plane(FindOrAddMutablePlaneWithName(
+      space, tsl::profiler::kScopeRangeIdTreePlaneName));
+  // No metadata is used for this plane, we just use the XStat to
+  // transfer the map without breaking any existing proto.
+  tensorflow::profiler::XStatMetadata metadata;
+  for (const auto& [child_id, parent_id] : scope_range_id_tree_) {
+    metadata.set_id(child_id);
+    plane.AddStatValue(metadata, parent_id);
+  }
+}
+
 void RocmTraceCollectorImpl::Export(XSpace* space) {
   uint64_t end_gputime_ns = get_timestamp();
   XPlaneBuilder host_plane(FindOrAddMutablePlaneWithName(
@@ -566,6 +583,7 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
     NormalizeTimeStamps(&device_plane, start_walltime_ns_);
   }
   NormalizeTimeStamps(&host_plane, start_walltime_ns_);
+  ExportScopeRangeIdTree(space);
 }
 
 std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -127,6 +127,7 @@ class RocmTraceCollector {
                                uint32_t num_events) = 0;
   virtual void Flush() = 0;
   virtual void Export(tsl::profiler::XSpace* space) = 0;
+  virtual void SetScopeRangeIdTree(ScopeRangeIdTree tree) {}
 
  protected:
   RocmTraceCollectorOptions options_;
@@ -180,6 +181,9 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) override;
   void Flush() override;
   void Export(tsl::profiler::XSpace* space) override;
+  void SetScopeRangeIdTree(ScopeRangeIdTree tree) override {
+    scope_range_id_tree_ = std::move(tree);
+  }
 
   void OnEventsDropped(const std::string& reason,
                        uint32_t correlation_id) override {
@@ -212,7 +216,10 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   std::vector<RocmTracerEvent> ApiActivityInfoExchange()
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(event_maps_mutex_);
 
+  void ExportScopeRangeIdTree(tsl::profiler::XSpace* space);
+
   absl::node_hash_map<uint32_t, PerDeviceCollector> per_device_collector_;
+  ScopeRangeIdTree scope_range_id_tree_;
 };  // RocmTraceCollectorImpl
 
 std::unique_ptr<RocmTraceCollector> CreateRocmCollector(

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -19,8 +19,6 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 
-#include <unistd.h>
-
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -32,6 +30,7 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/types/span.h"
 #include "rocm/include/rocprofiler-sdk/agent.h"
 #include "rocm/include/rocprofiler-sdk/buffer.h"
 #include "rocm/include/rocprofiler-sdk/buffer_tracing.h"
@@ -43,6 +42,7 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/internal_threading.h"
 #include "rocm/include/rocprofiler-sdk/registration.h"
 #include "rocm/include/rocprofiler-sdk/rocprofiler.h"
+#include <unistd.h>
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/backends/cpu/annotation_stack.h"
@@ -157,6 +157,8 @@ void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->scope_range_id =
+      annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
   trace_event->stream_id = RocmTracerEvent::kInvalidStreamId;
   trace_event->kernel_info = KernelDetails{};
@@ -251,6 +253,8 @@ void RocmTracer::MemcpyEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->scope_range_id =
+      annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
   // we do not know valid stream ID for memcpy
   // rec.stream_id.handle;
@@ -284,6 +288,8 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->scope_range_id =
+      annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
   trace_event->stream_id = kinfo.queue_id.handle;
   trace_event->kernel_info = KernelDetails{
@@ -462,8 +468,10 @@ int RocmTracer::toolInit(rocprofiler_client_finalize_t fini_func,
             const std::string& annotation =
                 tsl::profiler::AnnotationStack::Get();
             if (!annotation.empty()) {
+              absl::Span<const int64_t> range_ids =
+                  tsl::profiler::AnnotationStack::GetScopeRangeIds();
               RocmTracer::GetRocmTracerSingleton().annotation_map()->Add(
-                  record.correlation_id.internal, annotation);
+                  record.correlation_id.internal, annotation, range_ids);
             }
           }
         },

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -87,8 +87,8 @@ const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
   return "";
 }
 
-void AnnotationMap::Add(uint32_t correlation_id,
-                        const std::string& annotation) {
+void AnnotationMap::Add(uint32_t correlation_id, const std::string& annotation,
+                        absl::Span<const int64_t> scope_range_ids) {
   if (annotation.empty()) {
     return;
   }
@@ -99,6 +99,17 @@ void AnnotationMap::Add(uint32_t correlation_id,
     absl::string_view annotation_str =
         *map_.annotations.insert(annotation).first;
     map_.correlation_map.emplace(correlation_id, annotation_str);
+    if (!scope_range_ids.empty()) {
+      map_.scope_range_id_map.emplace(correlation_id, scope_range_ids.back());
+      if (scope_range_ids.size() > 1) {
+        const int64_t* head = scope_range_ids.data();
+        const int64_t* curr = &scope_range_ids.back();
+        for (; curr > head && !map_.scope_range_id_tree.contains(*curr);
+             --curr) {
+          map_.scope_range_id_tree.emplace(*curr, *(curr - 1));
+        }
+      }
+    }
   }
 }
 
@@ -108,9 +119,22 @@ absl::string_view AnnotationMap::LookUp(uint32_t correlation_id) {
   return it != map_.correlation_map.end() ? it->second : absl::string_view();
 }
 
+int64_t AnnotationMap::LookUpScopeRangeId(uint32_t correlation_id) {
+  absl::MutexLock lock(map_.mutex);
+  auto it = map_.scope_range_id_map.find(correlation_id);
+  return it != map_.scope_range_id_map.end() ? it->second : 0;
+}
+
+ScopeRangeIdTree AnnotationMap::TakeScopeRangeIdTree() {
+  absl::MutexLock lock(map_.mutex);
+  return std::move(map_.scope_range_id_tree);
+}
+
 void AnnotationMap::Clear() {
   absl::MutexLock lock(map_.mutex);
   map_.correlation_map.clear();
+  map_.scope_range_id_map.clear();
+  map_.scope_range_id_tree.clear();
   map_.annotations.clear();
 }
 

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -25,9 +25,14 @@ limitations under the License.
 #include "absl/container/node_hash_set.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/types/span.h"
 
 namespace xla {
 namespace profiler {
+
+// Mirrors the identical typedef in cupti_buffer_events.h for the CUPTI path.
+// Both resolve to the same type; ROCm and CUPTI are never compiled together.
+using ScopeRangeIdTree = absl::flat_hash_map<int64_t, int64_t>;
 
 struct MemcpyDetails {
   // The amount of data copied for memcpy events.
@@ -137,6 +142,7 @@ struct RocmTracerEvent {
   uint32_t correlation_id = kInvalidCorrelationId;
   uint64_t thread_id = kInvalidThreadId;
   uint64_t stream_id = kInvalidStreamId;
+  int64_t scope_range_id = 0;
 
   union {
     MemcpyDetails memcpy_info;                    // If type == Memcpy*
@@ -163,8 +169,11 @@ struct RocmTraceCollectorOptions {
 class AnnotationMap {
  public:
   explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
-  void Add(uint32_t correlation_id, const std::string& annotation);
+  void Add(uint32_t correlation_id, const std::string& annotation,
+           absl::Span<const int64_t> scope_range_ids = {});
   absl::string_view LookUp(uint32_t correlation_id);
+  int64_t LookUpScopeRangeId(uint32_t correlation_id);
+  ScopeRangeIdTree TakeScopeRangeIdTree();
   void Clear();
 
  private:
@@ -174,8 +183,12 @@ class AnnotationMap {
     absl::Mutex mutex;
     // Annotation tends to be repetitive, use a hash_set to store the strings,
     // an use the reference to the string in the map.
-    absl::node_hash_set<std::string> annotations;
-    absl::flat_hash_map<uint32_t, absl::string_view> correlation_map;
+    absl::node_hash_set<std::string> annotations ABSL_GUARDED_BY(mutex);
+    absl::flat_hash_map<uint32_t, absl::string_view> correlation_map
+        ABSL_GUARDED_BY(mutex);
+    absl::flat_hash_map<uint32_t, int64_t> scope_range_id_map
+        ABSL_GUARDED_BY(mutex);
+    ScopeRangeIdTree scope_range_id_tree ABSL_GUARDED_BY(mutex);
   };
   const uint64_t max_size_;
   AnnotationMapImpl map_;


### PR DESCRIPTION
📝 Summary of Changes
- Capture scope_range_id from AnnotationStack during HIP API correlation callbacks and propagate it through AnnotationMap to GPU kernel events in the profiler trace
- Build the scope_range_id tree (child-to-parent mapping) from the full range ID sequence in AnnotationMap::Add, matching the CUPTI AddScopeRangeIdSequence pattern
- Export the tree as a separate XPlane so xprof can reconstruct the scope hierarchy for derived timeline grouping
- Set scope_range_id on all event types (kernel, HIP API, memcpy) for uniform coverage, matching the CUPTI path

🚀 Kind of Contribution
Please remove what does not apply:✨ New Feature