### PR TITLE
[ROCm] Fix issue with unsupported types combinations for hipblaslt

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -2462,7 +2462,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
                                          b_dtype, output_dtype})) {
       return true;
     }
-    const TypeCombinations supported_type_combinations = {
+    const TypeCombinations core_type_combinations = {
         // Other data types:
         {ComputationType::kF16, DataType::kHalf, PrimitiveType::F16,
          PrimitiveType::F16, DataType::kHalf},
@@ -2478,18 +2478,36 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
          PrimitiveType::F16, DataType::kHalf},
         {ComputationType::kF32, DataType::kFloat, PrimitiveType::S8,
          PrimitiveType::S8, DataType::kFloat},
-        {ComputationType::kF32, DataType::kFloat, PrimitiveType::BF16,
-         PrimitiveType::BF16, DataType::kFloat},
-        {ComputationType::kF32, DataType::kFloat, PrimitiveType::F16,
-         PrimitiveType::F16, DataType::kFloat},
         {ComputationType::kF32, DataType::kFloat, PrimitiveType::F32,
          PrimitiveType::F32, DataType::kFloat},
     };
 
-    return absl::c_linear_search(
-        supported_type_combinations,
-        std::make_tuple(compute_type, scale_type, a_dtype, b_dtype,
-                        output_dtype));
+    const TypeCombinations extended_type_combinations = {
+        // Type combinations not supported only by mi200
+        {ComputationType::kF32, DataType::kFloat, PrimitiveType::BF16,
+         PrimitiveType::BF16, DataType::kFloat},
+        {ComputationType::kF32, DataType::kFloat, PrimitiveType::F16,
+         PrimitiveType::F16, DataType::kFloat}};
+
+    const bool is_cuda = gpu_version_.IsCuda();
+    const bool is_rocm = gpu_version_.IsRocm();
+    const bool is_mi200 =
+        is_rocm && gpu_version_.rocm_compute_capability()->gfx9_mi200();
+
+    if (absl::c_linear_search(core_type_combinations,
+                              std::make_tuple(compute_type, scale_type, a_dtype,
+                                              b_dtype, output_dtype))) {
+      return true;
+    }
+
+    if ((is_cuda || !is_mi200) &&
+        absl::c_linear_search(extended_type_combinations,
+                              std::make_tuple(compute_type, scale_type, a_dtype,
+                                              b_dtype, output_dtype))) {
+      return true;
+    }
+
+    return false;
   }
 
   absl::StatusOr<bool> GemmIsSupportedByCublasLt(

--- a/xla/backends/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter_test.cc
@@ -80,6 +80,11 @@ ENTRY AddDotsFunc {
 }
 
 TEST_F(GemmRewriteTest, CheckCustomCallHipblasLtBF16) {
+  if (!IsRocm()) {
+    GTEST_SKIP() << "Test is ROCm-specific: verifies that MI200 falls back to "
+                    "legacy cuBLAS for BF16->F32 GEMMs (hipblasLt limitation), "
+                    "while other ROCm architectures use hipblasLt";
+  }
   DebugOptions debug_options = GetDebugOptionsForTest();
   HloModuleConfig config;
   config.set_debug_options(debug_options);

--- a/xla/backends/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter_test.cc
@@ -79,6 +79,37 @@ ENTRY AddDotsFunc {
   }
 }
 
+TEST_F(GemmRewriteTest, CheckCustomCallHipblasLtBF16) {
+  DebugOptions debug_options = GetDebugOptionsForTest();
+  HloModuleConfig config;
+  config.set_debug_options(debug_options);
+  config.mutable_debug_options().set_xla_gpu_enable_cublaslt(true);
+  constexpr absl::string_view kHloText = R"(
+ENTRY e {
+  p0 = bf16[32,32] parameter(0)
+  p1 = bf16[32,32] parameter(1)
+  ROOT d = f32[32,32] dot(p0, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> optimized_module,
+                          GetOptimizedModule(kHloText, config));
+  absl::StatusOr<bool> filecheck_result;
+  if (IsRocm() && Capability().rocm_compute_capability()->gfx9_mi200()) {
+    filecheck_result = RunFileCheck(optimized_module->ToString(), R"(
+    ; CHECK-NOT: convert
+    ; CHECK: __cublas$gemm
+    )");
+  } else {
+    filecheck_result = RunFileCheck(optimized_module->ToString(), R"(
+    ; CHECK-NOT: convert
+    ; CHECK: __cublas$lt$matmul
+    )");
+  }
+  TF_ASSERT_OK(filecheck_result.status());
+  EXPECT_TRUE(filecheck_result.value());
+}
+
 TEST_F(GemmRewriteTest, TestBatchedAutotuning) {
   if (HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {
     GTEST_SKIP()
@@ -1324,6 +1355,10 @@ ENTRY test {
 }
 )";
 
+  bool is_mi200 =
+      IsRocm() && Capability().rocm_compute_capability()->gfx9_mi200();
+  // Mi200 does not support given type combination
+  auto kCustomCallTarget = is_mi200 ? "__cublas$gemm" : CustomCallTarget();
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(hlo_text));
   GemmRewriterOptions options;
@@ -1333,7 +1368,7 @@ ENTRY test {
   EXPECT_TRUE(changed);
   EXPECT_THAT(
       module->entry_computation()->root_instruction(),
-      GmockMatch(m::GetTupleElement(m::CustomCall({CustomCallTarget()}), 0)));
+      GmockMatch(m::GetTupleElement(m::CustomCall({kCustomCallTarget}), 0)));
 }
 
 TEST_P(ParameterizedGemmRewriteTest, UpcastingF16ToF64) {


### PR DESCRIPTION
📝 Summary of Changes
Prevent usage of hipblaslt for gemms with bf16 or f16 with f32 

🎯 Justification
hipblaslt custom call was generated altough not supported on mi200

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
Added CheckCustomCallHipblasLtBF16 test into gemm_rewriter_test

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
