### PR TITLE
Add fusion debug logging

### DIFF
--- a/xla/service/instruction_fusion.cc
+++ b/xla/service/instruction_fusion.cc
@@ -1119,6 +1119,8 @@ FusionDecision InstructionFusion::ShouldFuse(
   if (!legality_check_only && FusionWouldDuplicate(*producer, *consumer) &&
       (!may_duplicate_ || is_expensive_(*producer)) &&
       !IsAlwaysDuplicable(*producer)) {
+    VLOG(2) << "Fusion rejected: producer '" << producer->name() 
+            << "' is too expensive to duplicate into '" << consumer->name() << "'.";
     return FusionDecision::Forbid(may_duplicate_
                                       ? "expensive producer would be duplicated"
                                       : "fusion pass cannot duplicate");

--- a/xla/service/instruction_fusion.cc
+++ b/xla/service/instruction_fusion.cc
@@ -1104,9 +1104,13 @@ FusionDecision InstructionFusion::ShouldFuse(
         inplace_op_fusion_decider,
     bool legality_check_only /*=false*/) {
   HloInstruction* producer = consumer->mutable_operand(operand_index);
-
+  VLOG(2) << "Evaluating fusion: producer '" << producer->name()
+          << "' into consumer '" << consumer->name() << "'.";
   // Don't fuse across a root instruction.
   if (producer == producer->parent()->root_instruction()) {
+    VLOG(2) << "Fusion rejected: producer '" << producer->name() 
+            << "' is the root instruction. Cannot fuse into consumer '" << consumer->name()
+            << "'.";
     return FusionDecision::Forbid(
         "not fusing into the output of the root instruction");
   }


### PR DESCRIPTION
📝 Summary of Changes
Added `VLOG(2)` debugging statements to `xla/service/instruction_fusion.cc`. The logs explicitly output fusion rejections as well as the specific reason for rejection. The logs now surface the exact names of the producer and consumer instructions involved in the `ShouldFuse` decision.

🎯 Justification
This change improves debuggability and compiler observability. Previously, it was tedious to trace exactly why specific instructions in a large HLO graph were not fused. By gating this behind VLOG, developers can now trace exact fusion logic and graph decisions.

🚀 Kind of Contribution
✨ New Feature, ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A - This PR only introduces developer logging and does not affect compiler performance or execution speed.

🧪 Unit Tests:
No new unit tests were required as this does not change compilation semantics. Verified that existing tests pass cleanly:
Ran bazelisk test //xla/service:instruction_fusion_test
Verified log output manually.

🧪 Execution Tests:
N/A - This is a logging-only change and does not affect execution correctness or hardware backends.