### PR TITLE
[ROCm] Implement empty graph node support and safeguards for HIP command buffer

### DIFF
--- a/xla/stream_executor/gpu/gpu_command_buffer_test.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer_test.cc
@@ -787,6 +787,152 @@ static void BM_CreateCommandBuffer(benchmark::State& state) {
 
 BENCHMARK_SIZES(BM_CreateCommandBuffer);
 
+// Tests that CreateEmptyCmd works: an empty node can be added to a command
+// buffer alongside real commands, the graph finalizes and executes correctly,
+// and the empty node does not interfere with kernel results.
+TEST(GpuCommandBufferTest, EmptyNodeWithKernel) {
+  Platform* platform = GpuPlatform();
+  StreamExecutor* executor = platform->ExecutorForDevice(0).value();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  TF_ASSERT_OK_AND_ASSIGN(auto add, LoadAddI32TestKernel(executor));
+
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+
+  DeviceAddress<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
+  DeviceAddress<int32_t> b = executor->AllocateArray<int32_t>(length, 0);
+  DeviceAddress<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
+
+  TF_ASSERT_OK(stream->Memset32(&a, 1, byte_length));
+  TF_ASSERT_OK(stream->Memset32(&b, 2, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&c, byte_length));
+
+  // Build: empty_node (root) -> kernel (c = a + b).
+  TF_ASSERT_OK_AND_ASSIGN(auto cmd_buffer,
+                          executor->CreateCommandBuffer(primary));
+  TF_ASSERT_OK_AND_ASSIGN(auto* empty_cmd, cmd_buffer->CreateEmptyCmd({}));
+  TF_ASSERT_OK(cmd_buffer->CreateLaunch(add, ThreadDim(), BlockDim(4),
+                                         {empty_cmd}, a, b, c)
+                   .status());
+  TF_ASSERT_OK(cmd_buffer->Finalize());
+
+  TF_ASSERT_OK(cmd_buffer->Submit(stream.get()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  std::vector<int32_t> dst(4, 42);
+  TF_ASSERT_OK(stream->Memcpy(dst.data(), c, byte_length));
+
+  std::vector<int32_t> expected = {3, 3, 3, 3};
+  ASSERT_EQ(dst, expected);
+}
+
+// Tests that a command buffer with only an empty node can be finalized and
+// executed without crashing (exercises PrepareFinalization on HIP).
+TEST(GpuCommandBufferTest, EmptyNodeOnly) {
+  Platform* platform = GpuPlatform();
+  StreamExecutor* executor = platform->ExecutorForDevice(0).value();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+
+  TF_ASSERT_OK_AND_ASSIGN(auto cmd_buffer,
+                          executor->CreateCommandBuffer(primary));
+  TF_ASSERT_OK_AND_ASSIGN(auto* empty_cmd, cmd_buffer->CreateEmptyCmd({}));
+  (void)empty_cmd;
+  TF_ASSERT_OK(cmd_buffer->Finalize());
+
+  TF_ASSERT_OK(cmd_buffer->Submit(stream.get()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+}
+
+// Tests a chain of empty nodes followed by a kernel: exercises dependency
+// propagation through multiple empty nodes.
+TEST(GpuCommandBufferTest, EmptyNodeChain) {
+  Platform* platform = GpuPlatform();
+  StreamExecutor* executor = platform->ExecutorForDevice(0).value();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  TF_ASSERT_OK_AND_ASSIGN(auto add, LoadAddI32TestKernel(executor));
+
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+
+  DeviceAddress<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
+  DeviceAddress<int32_t> b = executor->AllocateArray<int32_t>(length, 0);
+  DeviceAddress<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
+
+  TF_ASSERT_OK(stream->Memset32(&a, 3, byte_length));
+  TF_ASSERT_OK(stream->Memset32(&b, 4, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&c, byte_length));
+
+  // Build: empty_1 -> empty_2 -> empty_3 -> kernel (c = a + b).
+  TF_ASSERT_OK_AND_ASSIGN(auto cmd_buffer,
+                          executor->CreateCommandBuffer(primary));
+  TF_ASSERT_OK_AND_ASSIGN(auto* e1, cmd_buffer->CreateEmptyCmd({}));
+  TF_ASSERT_OK_AND_ASSIGN(auto* e2, cmd_buffer->CreateEmptyCmd({e1}));
+  TF_ASSERT_OK_AND_ASSIGN(auto* e3, cmd_buffer->CreateEmptyCmd({e2}));
+  TF_ASSERT_OK(
+      cmd_buffer->CreateLaunch(add, ThreadDim(), BlockDim(4), {e3}, a, b, c));
+  TF_ASSERT_OK(cmd_buffer->Finalize());
+
+  TF_ASSERT_OK(cmd_buffer->Submit(stream.get()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  std::vector<int32_t> dst(4, 0);
+  TF_ASSERT_OK(stream->Memcpy(dst.data(), c, byte_length));
+
+  std::vector<int32_t> expected = {7, 7, 7, 7};
+  ASSERT_EQ(dst, expected);
+}
+
+// Tests that an empty node can act as a synchronization barrier between two
+// kernels: kernel_1 -> empty -> kernel_2, where kernel_2 reads kernel_1's
+// output.
+TEST(GpuCommandBufferTest, EmptyNodeAsDependencyBarrier) {
+  Platform* platform = GpuPlatform();
+  StreamExecutor* executor = platform->ExecutorForDevice(0).value();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+  TF_ASSERT_OK_AND_ASSIGN(auto add, LoadAddI32TestKernel(executor));
+
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+
+  DeviceAddress<int32_t> a = executor->AllocateArray<int32_t>(length, 0);
+  DeviceAddress<int32_t> b = executor->AllocateArray<int32_t>(length, 0);
+  DeviceAddress<int32_t> c = executor->AllocateArray<int32_t>(length, 0);
+  DeviceAddress<int32_t> d = executor->AllocateArray<int32_t>(length, 0);
+
+  TF_ASSERT_OK(stream->Memset32(&a, 1, byte_length));
+  TF_ASSERT_OK(stream->Memset32(&b, 2, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&c, byte_length));
+  TF_ASSERT_OK(stream->MemZero(&d, byte_length));
+
+  // Build: kernel_1 (c = a+b) -> empty -> kernel_2 (d = a+c).
+  TF_ASSERT_OK_AND_ASSIGN(auto cmd_buffer,
+                          executor->CreateCommandBuffer(primary));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto* k1,
+      cmd_buffer->CreateLaunch(add, ThreadDim(), BlockDim(4), {}, a, b, c));
+  TF_ASSERT_OK_AND_ASSIGN(auto* barrier, cmd_buffer->CreateEmptyCmd({k1}));
+  TF_ASSERT_OK(cmd_buffer->CreateLaunch(add, ThreadDim(), BlockDim(4),
+                                         {barrier}, a, c, d));
+  TF_ASSERT_OK(cmd_buffer->Finalize());
+
+  TF_ASSERT_OK(cmd_buffer->Submit(stream.get()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  // c = 1 + 2 = 3, d = 1 + 3 = 4
+  std::vector<int32_t> dst_c(4, 0), dst_d(4, 0);
+  TF_ASSERT_OK(stream->Memcpy(dst_c.data(), c, byte_length));
+  TF_ASSERT_OK(stream->Memcpy(dst_d.data(), d, byte_length));
+
+  std::vector<int32_t> expected_c = {3, 3, 3, 3};
+  std::vector<int32_t> expected_d = {4, 4, 4, 4};
+  ASSERT_EQ(dst_c, expected_c);
+  ASSERT_EQ(dst_d, expected_d);
+}
+
 static void BM_TraceCommandBuffer(benchmark::State& state) {
   Platform* platform = GpuPlatform();
   StreamExecutor* executor = platform->ExecutorForDevice(0).value();

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -400,6 +400,18 @@ absl::Status RocmCommandBuffer::Trace(
   VLOG(5) << "Traced into the GPU command buffer graph " << graph_ << " (took "
           << (end_nanos - start_nanos) / 1000 << " μs)";
 
+  size_t num_root_nodes = 0;
+  TF_RETURN_IF_ERROR(
+      ToStatus(wrap::hipGraphGetRootNodes(graph_, nullptr, &num_root_nodes),
+               "Failed to get HIP graph root node count"));
+
+  if (num_root_nodes == 0) {
+    return absl::InternalError(
+        "Traced HIP graph is empty. Traced function (custom call) did not "
+        "launch any HIP operations on the captured HIP stream. Instantiating "
+        "empty child nodes leads to crashes.");
+  }
+
   return absl::OkStatus();
 }
 
@@ -421,6 +433,20 @@ absl::StatusOr<size_t> RocmCommandBuffer::GetNodeCount() const {
 }
 
 absl::Status RocmCommandBuffer::PrepareFinalization() {
+  TF_ASSIGN_OR_RETURN(auto node_count, GetNodeCount());
+  if (node_count > 0) {
+    return absl::OkStatus();
+  }
+
+  // HIP graph conditional nodes (once supported) may not handle empty body
+  // graphs. Insert an empty node so the graph is non-empty, analogous to
+  // CUDA's NoOp kernel insertion for the same case.
+  hipGraphNode_t node_handle = nullptr;
+  TF_RETURN_IF_ERROR(
+      ToStatus(wrap::hipGraphAddEmptyNode(&node_handle, graph_,
+                                          /*pDependencies=*/nullptr,
+                                          /*numDependencies=*/0),
+               "Failed to add empty node in PrepareFinalization"));
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -346,7 +346,18 @@ absl::Status RocmCommandBuffer::UpdateKernelNode(
 
 absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateEmptyNode(
     absl::Span<const GraphNodeHandle> dependencies) {
-  return absl::UnimplementedError("Empty nodes are not supported on ROCM.");
+  VLOG(2) << "Add empty node to a graph " << graph_
+          << "; deps: " << dependencies.size();
+
+  std::vector<hipGraphNode_t> deps = ToHipGraphHandles(dependencies);
+
+  hipGraphNode_t node_handle = nullptr;
+  TF_RETURN_IF_ERROR(
+      ToStatus(wrap::hipGraphAddEmptyNode(&node_handle, graph_, deps.data(),
+                                          deps.size()),
+               "Failed to add empty node to a HIP graph"));
+
+  return FromHipGraphHandle(node_handle);
 }
 
 absl::Status RocmCommandBuffer::Trace(

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -151,7 +151,12 @@ class RocmCommandBuffer : public GpuCommandBuffer {
   absl::StatusOr<size_t> GetNodeCount() const override;
 
   absl::Status SetPriority(StreamPriority priority) override {
-    return absl::UnimplementedError("Not implemented.");
+    // HIP does not expose an API to set per-node priority on graph kernel nodes
+    // (no equivalent of cuGraphKernelNodeSetAttribute with
+    // CU_LAUNCH_ATTRIBUTE_PRIORITY). Silently ignore priority requests so that
+    // collectives (which use StreamPriority::Highest) can be captured into HIP
+    // graphs without crashing.
+    return absl::OkStatus();
   }
 
   absl::Status PrepareFinalization() override;

--- a/xla/stream_executor/rocm/rocm_driver_wrapper.h
+++ b/xla/stream_executor/rocm/rocm_driver_wrapper.h
@@ -112,6 +112,7 @@ namespace wrap {
   __macro(hipGraphDebugDotPrint)                    \
   __macro(hipGraphDestroy)                          \
   __macro(hipGraphGetNodes)                         \
+  __macro(hipGraphGetRootNodes)                     \
   __macro(hipGraphExecChildGraphNodeSetParams)      \
   __macro(hipGraphExecDestroy)                      \
   __macro(hipGraphExecKernelNodeSetParams)          \


### PR DESCRIPTION
## 📋 Summary of Changes

- Implement `CreateEmptyNode` for the ROCm command buffer backend using `hipGraphAddEmptyNode`, enabling empty graph nodes to serve as dependency synchronization points in HIP graphs.
- Fix `SetPriority` to silently succeed on HIP, since the HIP runtime does not expose a per-node priority API. This allows collectives using `StreamPriority::Highest` to be captured into HIP graphs without errors.
- Add empty traced graph detection in `RocmCommandBuffer::Trace()` to return a clear error when stream capture produces a graph with no operations, preventing opaque runtime crashes during graph instantiation.
- Implement `PrepareFinalization` to insert an empty node into empty body graphs before finalization, ensuring graph instantiation remains safe when conditional body graphs are empty.

## 🎯 Justification

When command buffers are enabled for collectives on ROCm, the thunk emitter creates `EmptyCmd` nodes for collective-done thunks (AllReduceDone, AllGatherDone, etc.) and WaitForStreams thunks that have control predecessors. These flow down to `CreateEmptyNode`, which was returning `UnimplementedError` on ROCm, causing crashes. Additionally, `SetPriority` was returning `UnimplementedError`, which also crashed when collectives with `StreamPriority::Highest` were captured into HIP graphs.

## 🚀 Kind of Contribution

🐛 Bug Fix, ✨ New Feature, ✏️ Tests

## ✏️ Unit Tests

Four platform-agnostic test cases added to `gpu_command_buffer_test.cc`:
- `EmptyNodeWithKernel` -- empty node as root with a dependent kernel launch
- `EmptyNodeOnly` -- command buffer with a single empty node (exercises `PrepareFinalization`)
- `EmptyNodeChain` -- chain of 3 empty nodes followed by a kernel (multi-hop dependency propagation)
- `EmptyNodeAsDependencyBarrier` -- `kernel -> empty -> kernel` ordering, validating the core use case for collective synchronization

## ✏️ Execution Tests

Built and ran `//xla/stream_executor/gpu:gpu_command_buffer_test` with `--config=rocm` on MI300X:

```
[==========] Running 4 tests from 1 test suite.
[ RUN      ] GpuCommandBufferTest.EmptyNodeOnly
[       OK ] GpuCommandBufferTest.EmptyNodeOnly (1314 ms)
[ RUN      ] GpuCommandBufferTest.EmptyNodeChain
[       OK ] GpuCommandBufferTest.EmptyNodeChain (15 ms)
[ RUN      ] GpuCommandBufferTest.EmptyNodeWithKernel
[       OK ] GpuCommandBufferTest.EmptyNodeWithKernel (10 ms)
[ RUN      ] GpuCommandBufferTest.EmptyNodeAsDependencyBarrier
[       OK ] GpuCommandBufferTest.EmptyNodeAsDependencyBarrier (9 ms)
[  PASSED  ] 4 tests.

Full suite: 8 passed, 0 failed, 35 skipped
```
