### PR TITLE
[xla:gpu] Add async thunk passes for optimizing async execution

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -465,6 +465,57 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "async_thunk_passes",
+    srcs = ["async_thunk_passes.cc"],
+    hdrs = ["async_thunk_passes.h"],
+    deps = [
+        ":async_execution",
+        ":async_thunk",
+        ":conditional_thunk",
+        ":sequential_thunk",
+        ":thunk",
+        ":thunk_pass_pipeline",
+        ":while_thunk",
+        "//xla:xla_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/runtime:buffer_use",
+        "//xla/runtime:resource_use",
+        "//xla/stream_executor:device_description",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/base:nullability",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@tsl//tsl/platform:casts",
+    ],
+)
+
+xla_cc_test(
+    name = "async_thunk_passes_test",
+    srcs = ["async_thunk_passes_test.cc"],
+    deps = [
+        ":async_thunk",
+        ":async_thunk_passes",
+        ":conditional_thunk",
+        ":sequential_thunk",
+        ":thunk",
+        ":thunk_pass_pipeline",
+        ":while_thunk",
+        "//xla:debug_options_flags",
+        "//xla:shape_util",
+        "//xla:xla_proto_cc",
+        "//xla/runtime:buffer_use",
+        "//xla/service:buffer_assignment",
+        "//xla/service:shaped_slice",
+        "//xla/stream_executor:device_description",
+        "@com_google_absl//absl/base:nullability",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 xla_test(
     name = "async_thunk_test",
     srcs = ["async_thunk_test.cc"],

--- a/xla/backends/gpu/runtime/async_thunk.h
+++ b/xla/backends/gpu/runtime/async_thunk.h
@@ -74,8 +74,6 @@ class AsyncStartThunk : public Thunk {
   absl::Status Initialize(const InitializeParams& params) override;
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
 
-  const ThunkSequence& thunks() const { return executor_.thunks(); }
-
   absl::StatusOr<ThunkProto> ToProto() const override;
   static absl::StatusOr<std::unique_ptr<AsyncStartThunk>> FromProto(
       ThunkInfo thunk_info, const AsyncStartThunkProto& proto,
@@ -83,6 +81,9 @@ class AsyncStartThunk : public Thunk {
 
   AsyncExecutionId async_execution_id() const;
   std::shared_ptr<AsyncExecution> async_execution() const;
+
+  const ThunkSequence& thunks() const { return executor_.thunks(); }
+  ThunkSequence& thunks() { return executor_.thunks(); }
 
  protected:
   absl::Status WalkNested(Walker callback) override;

--- a/xla/backends/gpu/runtime/async_thunk_passes.cc
+++ b/xla/backends/gpu/runtime/async_thunk_passes.cc
@@ -1,0 +1,237 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/async_thunk_passes.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "absl/base/nullability.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+#include "xla/backends/gpu/runtime/async_execution.h"
+#include "xla/backends/gpu/runtime/async_thunk.h"
+#include "xla/backends/gpu/runtime/conditional_thunk.h"
+#include "xla/backends/gpu/runtime/sequential_thunk.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/thunk_pass_pipeline.h"
+#include "xla/backends/gpu/runtime/while_thunk.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/runtime/buffer_use.h"
+#include "xla/runtime/resource_use.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/xla.pb.h"
+#include "tsl/platform/casts.h"
+
+namespace xla::gpu {
+
+// Returns mutable pointers to nested ThunkSequences inside a control flow
+// thunk (WhileThunk, ConditionalThunk, SequentialThunk). Returns an empty
+// vector for non-control-flow thunks.
+static std::vector<ThunkSequence*> GetNestedThunkSequences(Thunk* thunk) {
+  switch (thunk->kind()) {
+    case Thunk::kWhile: {
+      auto* while_thunk = tsl::down_cast<WhileThunk*>(thunk);
+      return {&while_thunk->condition_executor().thunks(),
+              &while_thunk->body_executor().thunks()};
+    }
+    case Thunk::kConditional: {
+      auto* cond_thunk = tsl::down_cast<ConditionalThunk*>(thunk);
+      std::vector<ThunkSequence*> nested;
+      for (auto& executor : cond_thunk->branch_executors()) {
+        nested.push_back(&executor.thunks());
+      }
+      return nested;
+    }
+    case Thunk::kSequential: {
+      auto* seq_thunk = tsl::down_cast<SequentialThunk*>(thunk);
+      return {&seq_thunk->executor().thunks()};
+    }
+    default:
+      return {};
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// RemoveRedundantAsyncThunkPass.
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<bool> RemoveRedundantAsyncThunkPass::Run(
+    ThunkSequence* thunk_sequence, const DebugOptions& debug_options,
+    const HloModule* absl_nullable hlo_module,
+    const se::DeviceDescription& device_info,
+    ThunkPassBufferAllocator& allocator) {
+  bool changed = false;
+
+  // Build a new thunk sequence, replacing adjacent start/done pairs with the
+  // inlined nested thunks from the start thunk.
+  ThunkSequence result;
+  result.reserve(thunk_sequence->size());
+
+  for (size_t i = 0; i < thunk_sequence->size(); ++i) {
+    std::unique_ptr<Thunk>& thunk = (*thunk_sequence)[i];
+
+    // Check for the pattern: AsyncStartThunk immediately followed by its
+    // matching AsyncDoneThunk.
+    if (thunk->kind() == Thunk::kAsyncStart && i + 1 < thunk_sequence->size()) {
+      if (std::unique_ptr<Thunk>& next = (*thunk_sequence)[i + 1];
+          next->kind() == Thunk::kAsyncDone) {
+        auto* start = tsl::down_cast<AsyncStartThunk*>(thunk.get());
+        auto* done = tsl::down_cast<AsyncDoneThunk*>(next.get());
+
+        // If async start and done thunks share execution id, inline them into
+        // the parent thunk sequence.
+        if (start->async_execution_id() == done->async_execution_id()) {
+          result.Append(std::move(start->thunks()));
+          changed = true;
+          ++i;
+          continue;
+        }
+      }
+    }
+
+    // Otherwise move thunk into the new sequence.
+    result.push_back(std::move(thunk));
+  }
+
+  // Recurse into nested control flow thunks. We must iterate over `result`
+  // because thunks have been moved out of `*thunk_sequence`.
+  for (auto& thunk : result) {
+    for (ThunkSequence* nested : GetNestedThunkSequences(thunk.get())) {
+      ASSIGN_OR_RETURN(
+          bool nested_changed,
+          Run(nested, debug_options, hlo_module, device_info, allocator));
+      changed |= nested_changed;
+    }
+  }
+
+  *thunk_sequence = std::move(result);
+  return changed;
+}
+
+//===----------------------------------------------------------------------===//
+// ExpandAsyncScopeThunkPass.
+//===----------------------------------------------------------------------===//
+
+// Returns true if thunks at positions `a` and `b` have buffer or resource
+// conflicts that prevent reordering.
+static bool HasConflicts(
+    std::vector<BufferUse::ReadWriteSet>& buffer_rw_sets,
+    std::vector<ResourceUse::ReadWriteSet>& resource_rw_sets, size_t a,
+    size_t b) {
+  return buffer_rw_sets[a].HasConflicts(buffer_rw_sets[b]) ||
+         resource_rw_sets[a].HasConflicts(resource_rw_sets[b]);
+}
+
+absl::StatusOr<bool> ExpandAsyncScopeThunkPass::Run(
+    ThunkSequence* thunk_sequence, const DebugOptions& debug_options,
+    const HloModule* absl_nullable hlo_module,
+    const se::DeviceDescription& device_info,
+    ThunkPassBufferAllocator& allocator) {
+  size_t n = thunk_sequence->size();
+
+  // Start thunks found in the thunk sequence grouped by async execution id.
+  absl::flat_hash_map<AsyncExecutionId, std::vector<const AsyncStartThunk*>>
+      start_thunks;
+
+  // Pre-compute buffer and resource read-write sets for all thunks using the
+  // transitive Walk API to collect uses from nested thunks. For
+  // AsyncStartThunks we also record them in start_thunks so that we can look up
+  // the matching start when processing AsyncDoneThunks. AsyncDoneThunk doesn't
+  // report buffer or resource uses of its own, so we copy the matching start
+  // thunk's uses.
+  std::vector<BufferUse::ReadWriteSet> buffer_rw_sets(n);
+  std::vector<ResourceUse::ReadWriteSet> resource_rw_sets(n);
+  for (size_t i = 0; i < n; ++i) {
+    Thunk* current = (*thunk_sequence)[i].get();
+
+    current->Walk([&](auto* thunk) {
+      buffer_rw_sets[i].AddAll(thunk->buffer_uses());
+      resource_rw_sets[i].AddAll(thunk->resource_uses());
+    });
+
+    if (current->kind() == Thunk::kAsyncStart) {
+      auto* start = tsl::down_cast<AsyncStartThunk*>(current);
+      start_thunks[start->async_execution_id()].push_back(start);
+    }
+
+    if (current->kind() == Thunk::kAsyncDone) {
+      auto* done = tsl::down_cast<AsyncDoneThunk*>(current);
+      // Walk all matching start thunks because pipelined async chains may have
+      // multiple start thunks sharing the same execution id. They should all
+      // have the same buffer and resource uses, but we traverse them all to be
+      // safe.
+      for (auto* start : start_thunks.at(done->async_execution_id())) {
+        start->Walk([&](auto* thunk) {
+          buffer_rw_sets[i].AddAll(thunk->buffer_uses());
+          resource_rw_sets[i].AddAll(thunk->resource_uses());
+        });
+      }
+    }
+  }
+
+  bool changed = false;
+
+  // Move AsyncStartThunks as far up the sequence as possible.
+  for (int64_t i = 1; i < n; ++i) {
+    if ((*thunk_sequence)[i]->kind() != Thunk::kAsyncStart) {
+      continue;
+    }
+
+    int64_t j = i;
+    while (j > 0 && !HasConflicts(buffer_rw_sets, resource_rw_sets, j - 1, j)) {
+      std::swap((*thunk_sequence)[j], (*thunk_sequence)[j - 1]);
+      std::swap(buffer_rw_sets[j], buffer_rw_sets[j - 1]);
+      std::swap(resource_rw_sets[j], resource_rw_sets[j - 1]);
+      --j;
+      changed = true;
+    }
+  }
+
+  // Move AsyncDoneThunks as far down the sequence as possible.
+  for (int64_t i = n - 2; i >= 0; --i) {
+    if ((*thunk_sequence)[i]->kind() != Thunk::kAsyncDone) {
+      continue;
+    }
+
+    int64_t j = i;
+    while (j < n - 1 &&
+           !HasConflicts(buffer_rw_sets, resource_rw_sets, j, j + 1)) {
+      std::swap((*thunk_sequence)[j], (*thunk_sequence)[j + 1]);
+      std::swap(buffer_rw_sets[j], buffer_rw_sets[j + 1]);
+      std::swap(resource_rw_sets[j], resource_rw_sets[j + 1]);
+      ++j;
+      changed = true;
+    }
+  }
+
+  // Recurse into nested control flow thunks.
+  for (auto& thunk : *thunk_sequence) {
+    for (ThunkSequence* nested : GetNestedThunkSequences(thunk.get())) {
+      ASSIGN_OR_RETURN(
+          bool nested_changed,
+          Run(nested, debug_options, hlo_module, device_info, allocator));
+      changed |= nested_changed;
+    }
+  }
+
+  return changed;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/async_thunk_passes.h
+++ b/xla/backends/gpu/runtime/async_thunk_passes.h
@@ -1,0 +1,128 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_ASYNC_THUNK_PASSES_H_
+#define XLA_BACKENDS_GPU_RUNTIME_ASYNC_THUNK_PASSES_H_
+
+#include "absl/base/nullability.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/thunk_pass_pipeline.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/xla.pb.h"
+
+namespace xla::gpu {
+
+// A collection of thunk passes for optimizing async execution of XLA:GPU. At
+// compile time we rely on various passes (i.e. latency hiding scheduler) to
+// come up with an optimized schedule that overlaps compute with communication
+// (or in some cases compute with another compute). However the resulting thunk
+// sequence might still have optimization opportunities, depending on the exact
+// scheduling and buffer assignment produced by the compiler, and by doing one
+// more round of optimizations on top of the thunk sequence we can correct
+// suboptimal decisions made when compiling HLO programs.
+
+//===----------------------------------------------------------------------===//
+// RemoveRedundantAsyncThunkPass.
+//===----------------------------------------------------------------------===//
+
+// Removes redundant async start/done thunk pairs from a thunk sequence. When an
+// AsyncDoneThunk immediately follows its matching AsyncStartThunk, there is no
+// actual asynchronous execution: the done thunk just waits for an event that
+// was recorded right before it. In this case, we can inline the nested thunk
+// sequence from the start thunk, avoiding the overhead of creating an async
+// execution scope (recording events and synchronizing streams).
+//
+// Example:
+//
+//   %start = AsyncStartThunk([thunk-sequence])
+//   %done  = AsyncDoneThunk(%start)
+//
+// is replaced by:
+//
+//   [thunk-sequence]
+//
+class RemoveRedundantAsyncThunkPass : public ThunkPassInterface {
+ public:
+  absl::string_view name() const override { return "remove-redundant-async"; }
+
+  absl::StatusOr<bool> Run(ThunkSequence* thunk_sequence,
+                           const DebugOptions& debug_options,
+                           const HloModule* absl_nullable hlo_module,
+                           const se::DeviceDescription& device_info,
+                           ThunkPassBufferAllocator& allocator) override;
+};
+
+//===----------------------------------------------------------------------===//
+// ExpandAsyncScopeThunkPass.
+//===----------------------------------------------------------------------===//
+
+// Expands async execution scopes by moving AsyncStartThunk as far up the thunk
+// sequence as possible and the corresponding AsyncDoneThunk as far down as
+// possible, maximizing the window of asynchronous overlap.
+//
+// Motivation: The latency hiding scheduler operates at the HLO level before
+// buffer assignment, so it makes scheduling decisions without knowing the final
+// buffer layout. After buffer assignment, some async start/done pairs may end
+// up closer together than necessary -- e.g., a collective-start might be placed
+// just one or two thunks before its done, leaving little room to overlap
+// communication with compute. By widening the gap between start and done at the
+// thunk level, this pass recovers latency hiding opportunities that the HLO
+// scheduler could not exploit.
+//
+// Example:
+//
+//   %kernel0 = KernelThunk()
+//   %kernel1 = KernelThunk()
+//   %start   = AsyncStartThunk()
+//   %kernel2 = KernelThunk()
+//   %done    = AsyncDoneThunk(%start)
+//   %kernel3 = KernelThunk()
+//
+// is replaced by:
+//
+//   %start   = AsyncStartThunk()
+//   %kernel0 = KernelThunk()
+//   %kernel1 = KernelThunk()
+//   %kernel2 = KernelThunk()
+//   %kernel3 = KernelThunk()
+//   %done    = AsyncDoneThunk(%start)
+//
+// The pass uses `buffer_uses()` and `resource_uses()` (collected transitively
+// via the `Thunk::Walk` API to account for nested thunk sequences) to detect
+// read-write conflicts between thunks. A start or done thunk can be moved past
+// another thunk only when their buffer and resource use sets do not conflict.
+//
+// AsyncDoneThunk does not report buffer or resource uses of its own; for
+// conflict resolution purposes this pass assigns it the same buffer and
+// resource uses as the corresponding AsyncStartThunk, since the done thunk
+// logically waits for the start thunk's work to complete and therefore touches
+// the same buffers and resources.
+class ExpandAsyncScopeThunkPass : public ThunkPassInterface {
+ public:
+  absl::string_view name() const override { return "expand-async-scope"; }
+
+  absl::StatusOr<bool> Run(ThunkSequence* thunk_sequence,
+                           const DebugOptions& debug_options,
+                           const HloModule* absl_nullable hlo_module,
+                           const se::DeviceDescription& device_info,
+                           ThunkPassBufferAllocator& allocator) override;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_ASYNC_THUNK_PASSES_H_

--- a/xla/backends/gpu/runtime/async_thunk_passes_test.cc
+++ b/xla/backends/gpu/runtime/async_thunk_passes_test.cc
@@ -1,0 +1,511 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/async_thunk_passes.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/backends/gpu/runtime/async_thunk.h"
+#include "xla/backends/gpu/runtime/conditional_thunk.h"
+#include "xla/backends/gpu/runtime/sequential_thunk.h"
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/thunk_pass_pipeline.h"
+#include "xla/backends/gpu/runtime/while_thunk.h"
+#include "xla/debug_options_flags.h"
+#include "xla/runtime/buffer_use.h"
+#include "xla/service/buffer_assignment.h"
+#include "xla/service/shaped_slice.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/xla.pb.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+class FakeThunkPassBufferAllocator : public ThunkPassBufferAllocator {
+  absl::StatusOr<BufferAllocation*> NewEmptyAllocation(int64_t size) final {
+    return absl::UnimplementedError("NewEmptyAllocation is not implemented.");
+  }
+};
+
+// A thunk with configurable buffer use for testing conflict detection.
+class FakeThunk : public Thunk {
+ public:
+  explicit FakeThunk(std::optional<BufferUse> buffer_use = std::nullopt)
+      : Thunk(Thunk::kKernel, Thunk::ThunkInfo()),
+        buffer_use_(std::move(buffer_use)) {}
+
+  absl::Status ExecuteOnStream(const ExecuteParams& params) override {
+    return absl::OkStatus();
+  }
+
+  BufferUses buffer_uses() const override {
+    if (buffer_use_.has_value()) {
+      return {*buffer_use_};
+    }
+    return {};
+  }
+
+ private:
+  std::optional<BufferUse> buffer_use_;
+};
+
+// Creates a FakeThunk with an optional buffer use.
+std::unique_ptr<FakeThunk> MakeFakeThunk(
+    std::optional<BufferUse> buffer_use = std::nullopt) {
+  if (buffer_use.has_value()) {
+    return std::make_unique<FakeThunk>(std::move(*buffer_use));
+  }
+  return std::make_unique<FakeThunk>();
+}
+
+// Creates an AsyncStartThunk wrapping a single FakeThunk with an optional
+// buffer use, so that the start thunk transitively reports it via Walk.
+std::unique_ptr<AsyncStartThunk> MakeAsyncStart() {
+  ThunkSequence nested;
+  nested.push_back(MakeFakeThunk());
+  return std::make_unique<AsyncStartThunk>(Thunk::ThunkInfo(),
+                                           AsyncStartThunk::AsyncKind::kCompute,
+                                           std::move(nested));
+}
+
+std::unique_ptr<AsyncStartThunk> MakeAsyncStart(BufferUse buffer_use) {
+  ThunkSequence nested;
+  nested.push_back(MakeFakeThunk(std::move(buffer_use)));
+  return std::make_unique<AsyncStartThunk>(Thunk::ThunkInfo(),
+                                           AsyncStartThunk::AsyncKind::kCompute,
+                                           std::move(nested));
+}
+
+// Creates an AsyncDoneThunk matching the given start thunk.
+std::unique_ptr<AsyncDoneThunk> MakeAsyncDone(AsyncStartThunk* start) {
+  return std::make_unique<AsyncDoneThunk>(Thunk::ThunkInfo(),
+                                          start->async_execution());
+}
+
+//===----------------------------------------------------------------------===//
+// RemoveRedundantAsyncThunkPass tests.
+//===----------------------------------------------------------------------===//
+
+TEST(RemoveRedundantAsyncThunkPassTest, InlinesAdjacentStartDone) {
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(start));
+  thunks.push_back(std::move(done));
+
+  DebugOptions debug_options = GetDebugOptionsFromFlags();
+  se::DeviceDescription device_info;
+  FakeThunkPassBufferAllocator allocator;
+  RemoveRedundantAsyncThunkPass pass;
+
+  ASSERT_OK_AND_ASSIGN(bool changed,
+                       pass.Run(&thunks, debug_options, /*hlo_module=*/nullptr,
+                                device_info, allocator));
+  EXPECT_TRUE(changed);
+  // The start/done pair should be replaced by the single nested thunk.
+  ASSERT_EQ(thunks.size(), 1);
+  EXPECT_EQ(thunks[0]->kind(), Thunk::kKernel);
+}
+
+TEST(RemoveRedundantAsyncThunkPassTest, PreservesNonAdjacentStartDone) {
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(start));
+  thunks.push_back(MakeFakeThunk());
+  thunks.push_back(std::move(done));
+
+  DebugOptions debug_options = GetDebugOptionsFromFlags();
+  se::DeviceDescription device_info;
+  FakeThunkPassBufferAllocator allocator;
+  RemoveRedundantAsyncThunkPass pass;
+
+  ASSERT_OK_AND_ASSIGN(bool changed,
+                       pass.Run(&thunks, debug_options, /*hlo_module=*/nullptr,
+                                device_info, allocator));
+  EXPECT_FALSE(changed);
+  EXPECT_EQ(thunks.size(), 3);
+}
+
+//===----------------------------------------------------------------------===//
+// ExpandAsyncScopeThunkPass tests.
+//===----------------------------------------------------------------------===//
+
+// Helper to run the expand pass and return whether it changed the sequence.
+absl::StatusOr<bool> RunExpandPass(ThunkSequence* thunks) {
+  DebugOptions debug_options = GetDebugOptionsFromFlags();
+  se::DeviceDescription device_info;
+  FakeThunkPassBufferAllocator allocator;
+  ExpandAsyncScopeThunkPass pass;
+  return pass.Run(thunks, debug_options, /*hlo_module=*/nullptr, device_info,
+                  allocator);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, MovesStartUpAndDoneDown) {
+  // No buffer uses on any thunk => no conflicts => start moves to front,
+  // done moves to back.
+  //
+  //   kernel0, kernel1, start, kernel2, done, kernel3
+  //   => start, kernel0, kernel1, kernel2, kernel3, done
+  auto start = MakeAsyncStart();
+  auto* start_ptr = start.get();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence thunks;
+  thunks.push_back(MakeFakeThunk());
+  thunks.push_back(MakeFakeThunk());
+  thunks.push_back(std::move(start));
+  thunks.push_back(MakeFakeThunk());
+  thunks.push_back(std::move(done));
+  thunks.push_back(MakeFakeThunk());
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(thunks.size(), 6);
+  EXPECT_EQ(thunks[0]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(thunks[0].get(), start_ptr);
+  EXPECT_EQ(thunks[5]->kind(), Thunk::kAsyncDone);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, StartStopsAtConflictingThunk) {
+  // start writes buffer 0; kernel0 also writes buffer 0 => conflict.
+  // start should not move past kernel0.
+  //
+  //   kernel0(write buf0), start(write buf0), done
+  //   => kernel0(write buf0), start(write buf0), done  (unchanged for start)
+  //   done can move... but there is nothing after it.
+  BufferAllocation alloc(/*index=*/0, /*size=*/1024, /*color=*/0);
+  auto slice = BufferAllocation::Slice(&alloc, 0, 1024);
+  auto shape = ShapeUtil::MakeShape(F32, {256});
+
+  auto start = MakeAsyncStart(BufferUse::Write(slice, shape));
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence thunks;
+  thunks.push_back(MakeFakeThunk(BufferUse::Write(slice, shape)));
+  thunks.push_back(std::move(start));
+  thunks.push_back(std::move(done));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_FALSE(changed);
+  EXPECT_EQ(thunks[0]->kind(),
+            Thunk::kKernel);  // FakeThunk
+  EXPECT_EQ(thunks[1]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(thunks[2]->kind(), Thunk::kAsyncDone);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, DoneStopsAtConflictingThunk) {
+  // done (inherits start's write to buf0) cannot move past kernel that also
+  // writes buf0.
+  //
+  //   start(write buf0), done, kernel(write buf0)
+  //   => start(write buf0), done, kernel(write buf0)  (unchanged)
+  BufferAllocation alloc(/*index=*/0, /*size=*/1024, /*color=*/0);
+  auto slice = BufferAllocation::Slice(&alloc, 0, 1024);
+  auto shape = ShapeUtil::MakeShape(F32, {256});
+
+  auto start = MakeAsyncStart(BufferUse::Write(slice, shape));
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(start));
+  thunks.push_back(std::move(done));
+  thunks.push_back(MakeFakeThunk(BufferUse::Write(slice, shape)));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_FALSE(changed);
+  EXPECT_EQ(thunks[0]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(thunks[1]->kind(), Thunk::kAsyncDone);
+  EXPECT_EQ(thunks[2]->kind(), Thunk::kKernel);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, StartMovesUpPastNonConflicting) {
+  // start writes buf0, kernel writes buf1 => no conflict => start moves up.
+  //
+  //   kernel(write buf1), start(write buf0), done
+  //   => start(write buf0), kernel(write buf1), done
+  BufferAllocation alloc0(/*index=*/0, /*size=*/1024, /*color=*/0);
+  BufferAllocation alloc1(/*index=*/1, /*size=*/1024, /*color=*/0);
+  auto slice0 = BufferAllocation::Slice(&alloc0, 0, 1024);
+  auto slice1 = BufferAllocation::Slice(&alloc1, 0, 1024);
+  auto shape = ShapeUtil::MakeShape(F32, {256});
+
+  auto start = MakeAsyncStart(BufferUse::Write(slice0, shape));
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence thunks;
+  thunks.push_back(MakeFakeThunk(BufferUse::Write(slice1, shape)));
+  thunks.push_back(std::move(start));
+  thunks.push_back(std::move(done));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(thunks[0]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(thunks[1]->kind(), Thunk::kKernel);  // FakeThunk
+  EXPECT_EQ(thunks[2]->kind(), Thunk::kAsyncDone);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, ReadReadDoesNotConflict) {
+  // Both start and kernel only read buf0 => no conflict => start moves up,
+  // done moves down.
+  //
+  //   kernel(read buf0), start(read buf0), done, kernel2(read buf0)
+  //   => start, kernel, kernel2, done
+  BufferAllocation alloc(/*index=*/0, /*size=*/1024, /*color=*/0);
+  auto slice = BufferAllocation::Slice(&alloc, 0, 1024);
+  auto shape = ShapeUtil::MakeShape(F32, {256});
+
+  auto start = MakeAsyncStart(BufferUse::Read(slice, shape));
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence thunks;
+  thunks.push_back(MakeFakeThunk(BufferUse::Read(slice, shape)));
+  thunks.push_back(std::move(start));
+  thunks.push_back(std::move(done));
+  thunks.push_back(MakeFakeThunk(BufferUse::Read(slice, shape)));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(thunks.size(), 4);
+  EXPECT_EQ(thunks[0]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(thunks[3]->kind(), Thunk::kAsyncDone);
+}
+
+//===----------------------------------------------------------------------===//
+// Helpers for running a pass on a single ThunkSequence.
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<bool> RunRemovePass(ThunkSequence* thunks) {
+  DebugOptions debug_options = GetDebugOptionsFromFlags();
+  se::DeviceDescription device_info;
+  FakeThunkPassBufferAllocator allocator;
+  RemoveRedundantAsyncThunkPass pass;
+  return pass.Run(thunks, debug_options, /*hlo_module=*/nullptr, device_info,
+                  allocator);
+}
+
+//===----------------------------------------------------------------------===//
+// Nested control flow tests: SequentialThunk.
+//===----------------------------------------------------------------------===//
+
+TEST(RemoveRedundantAsyncThunkPassTest, RecursesIntoSequentialThunk) {
+  // Place an adjacent start/done pair inside a SequentialThunk and verify the
+  // pass inlines it.
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence inner;
+  inner.push_back(std::move(start));
+  inner.push_back(std::move(done));
+
+  auto seq =
+      std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), std::move(inner));
+  auto* seq_ptr = seq.get();
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(seq));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunRemovePass(&thunks));
+  EXPECT_TRUE(changed);
+  // The SequentialThunk is still there, but its inner sequence should now
+  // contain only the inlined kernel thunk.
+  ASSERT_EQ(thunks.size(), 1);
+  EXPECT_EQ(thunks[0]->kind(), Thunk::kSequential);
+  ASSERT_EQ(seq_ptr->thunks().size(), 1);
+  EXPECT_EQ(seq_ptr->thunks()[0]->kind(), Thunk::kKernel);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, RecursesIntoSequentialThunk) {
+  // Place kernel, start, kernel, done, kernel inside a SequentialThunk and
+  // verify the expand pass widens the async scope within it.
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence inner;
+  inner.push_back(MakeFakeThunk());
+  inner.push_back(std::move(start));
+  inner.push_back(MakeFakeThunk());
+  inner.push_back(std::move(done));
+  inner.push_back(MakeFakeThunk());
+
+  auto seq =
+      std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), std::move(inner));
+  auto* seq_ptr = seq.get();
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(seq));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_TRUE(changed);
+  // start should be at position 0 and done at position 4 within the
+  // SequentialThunk's inner sequence.
+  ASSERT_EQ(seq_ptr->thunks().size(), 5);
+  EXPECT_EQ(seq_ptr->thunks()[0]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(seq_ptr->thunks()[4]->kind(), Thunk::kAsyncDone);
+}
+
+//===----------------------------------------------------------------------===//
+// Nested control flow tests: WhileThunk.
+//===----------------------------------------------------------------------===//
+
+TEST(RemoveRedundantAsyncThunkPassTest, RecursesIntoWhileThunkBody) {
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence body;
+  body.push_back(std::move(start));
+  body.push_back(std::move(done));
+
+  // WhileThunk needs a condition buffer and a condition thunk sequence.
+  BufferAllocation alloc(/*index=*/0, /*size=*/1, /*color=*/0);
+  auto cond_slice = BufferAllocation::Slice(&alloc, 0, 1);
+
+  ThunkSequence condition;
+  condition.push_back(MakeFakeThunk());
+
+  auto while_thunk = std::make_unique<WhileThunk>(
+      Thunk::ThunkInfo(), cond_slice, std::move(condition), std::move(body));
+  auto* while_ptr = while_thunk.get();
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(while_thunk));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunRemovePass(&thunks));
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(while_ptr->body_executor().thunks().size(), 1);
+  EXPECT_EQ(while_ptr->body_executor().thunks()[0]->kind(), Thunk::kKernel);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, RecursesIntoWhileThunkBody) {
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence body;
+  body.push_back(MakeFakeThunk());
+  body.push_back(std::move(start));
+  body.push_back(MakeFakeThunk());
+  body.push_back(std::move(done));
+  body.push_back(MakeFakeThunk());
+
+  BufferAllocation alloc(/*index=*/0, /*size=*/1, /*color=*/0);
+  auto cond_slice = BufferAllocation::Slice(&alloc, 0, 1);
+
+  ThunkSequence condition;
+  condition.push_back(MakeFakeThunk());
+
+  auto while_thunk = std::make_unique<WhileThunk>(
+      Thunk::ThunkInfo(), cond_slice, std::move(condition), std::move(body));
+  auto* while_ptr = while_thunk.get();
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(while_thunk));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_TRUE(changed);
+  auto& body_thunks = while_ptr->body_executor().thunks();
+  ASSERT_EQ(body_thunks.size(), 5);
+  EXPECT_EQ(body_thunks[0]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(body_thunks[4]->kind(), Thunk::kAsyncDone);
+}
+
+//===----------------------------------------------------------------------===//
+// Nested control flow tests: ConditionalThunk.
+//===----------------------------------------------------------------------===//
+
+TEST(RemoveRedundantAsyncThunkPassTest, RecursesIntoConditionalThunkBranches) {
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence branch0;
+  branch0.push_back(std::move(start));
+  branch0.push_back(std::move(done));
+
+  ThunkSequence branch1;
+  branch1.push_back(MakeFakeThunk());
+
+  std::vector<ThunkSequence> branches;
+  branches.push_back(std::move(branch0));
+  branches.push_back(std::move(branch1));
+
+  BufferAllocation alloc(/*index=*/0, /*size=*/4, /*color=*/0);
+  auto index_slice = BufferAllocation::Slice(&alloc, 0, 4);
+  ShapedSlice shaped_slice{index_slice, ShapeUtil::MakeShape(S32, {})};
+
+  auto cond_thunk = std::make_unique<ConditionalThunk>(
+      Thunk::ThunkInfo(), shaped_slice, std::move(branches));
+  auto* cond_ptr = cond_thunk.get();
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(cond_thunk));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunRemovePass(&thunks));
+  EXPECT_TRUE(changed);
+  // Branch 0 should have the start/done inlined to a single kernel thunk.
+  ASSERT_EQ(cond_ptr->branch_executors()[0].thunks().size(), 1);
+  EXPECT_EQ(cond_ptr->branch_executors()[0].thunks()[0]->kind(),
+            Thunk::kKernel);
+  // Branch 1 should be unchanged.
+  ASSERT_EQ(cond_ptr->branch_executors()[1].thunks().size(), 1);
+  EXPECT_EQ(cond_ptr->branch_executors()[1].thunks()[0]->kind(),
+            Thunk::kKernel);
+}
+
+TEST(ExpandAsyncScopeThunkPassTest, RecursesIntoConditionalThunkBranches) {
+  auto start = MakeAsyncStart();
+  auto done = MakeAsyncDone(start.get());
+
+  ThunkSequence branch0;
+  branch0.push_back(MakeFakeThunk());
+  branch0.push_back(std::move(start));
+  branch0.push_back(MakeFakeThunk());
+  branch0.push_back(std::move(done));
+  branch0.push_back(MakeFakeThunk());
+
+  std::vector<ThunkSequence> branches;
+  branches.push_back(std::move(branch0));
+
+  BufferAllocation alloc(/*index=*/0, /*size=*/4, /*color=*/0);
+  auto index_slice = BufferAllocation::Slice(&alloc, 0, 4);
+  ShapedSlice shaped_slice{index_slice, ShapeUtil::MakeShape(S32, {})};
+
+  auto cond_thunk = std::make_unique<ConditionalThunk>(
+      Thunk::ThunkInfo(), shaped_slice, std::move(branches));
+  auto* cond_ptr = cond_thunk.get();
+
+  ThunkSequence thunks;
+  thunks.push_back(std::move(cond_thunk));
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunExpandPass(&thunks));
+  EXPECT_TRUE(changed);
+  auto& branch_thunks = cond_ptr->branch_executors()[0].thunks();
+  ASSERT_EQ(branch_thunks.size(), 5);
+  EXPECT_EQ(branch_thunks[0]->kind(), Thunk::kAsyncStart);
+  EXPECT_EQ(branch_thunks[4]->kind(), Thunk::kAsyncDone);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/thunk.cc
+++ b/xla/backends/gpu/runtime/thunk.cc
@@ -547,6 +547,13 @@ static std::optional<int64_t> NextDep(
   return std::nullopt;
 }
 
+void ThunkSequence::Append(ThunkSequence other) {
+  reserve(size() + other.size());
+  for (auto& thunk : other) {
+    push_back(std::move(thunk));
+  }
+}
+
 absl::Status ThunkSequence::WalkNested(Thunk::Walker callback) {
   for (auto& thunk : *this) {
     RETURN_IF_ERROR(thunk->Walk(callback));

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -580,6 +580,9 @@ class ThunkSequence : public std::vector<std::unique_ptr<Thunk>> {
     return thunks;
   }
 
+  // Appends all thunks from `other` into this sequence.
+  void Append(ThunkSequence other);
+
   // Walks/Transforms all thunks nested in *this sequence.
   absl::Status WalkNested(Thunk::Walker callback);
   absl::Status TransformNested(Thunk::Transformer callback);


### PR DESCRIPTION
Thunk passes that correct LHS scheduling decisions if buffer assignment permits it:

- **Implement `RemoveRedundantAsyncThunkPass`** — removes redundant async start/done thunk pairs where an `AsyncDoneThunk` immediately follows its matching `AsyncStartThunk`. In this case there is no actual asynchronous execution (the done thunk just waits for an event recorded right before it), so we inline the nested thunk sequence from the start thunk, avoiding the overhead of creating an async execution scope (recording events and synchronizing streams).

- **Implement `ExpandAsyncScopeThunkPass`** — a new thunk pass that widens async execution scopes by moving `AsyncStartThunk` as far up the thunk sequence as possible and `AsyncDoneThunk` as far down as possible, maximizing the overlap window between async operations (e.g., collectives) and compute.

- **Conflict detection** uses `BufferUse::ReadWriteSet` and `ResourceUse::ReadWriteSet`, with buffer and resource uses collected transitively via the `Thunk::Walk` API. `AsyncDoneThunk` (which reports no uses of its own) inherits the uses of all matching `AsyncStartThunk`s to handle pipelined async chains correctly.

