### PR TITLE
[xla:gpu] Use default compute stream for compute kernels

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1402,8 +1402,6 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Support",
-        "@tsl//tsl/profiler/lib:traceme",
-        "@tsl//tsl/profiler/lib:traceme_encode",
     ],
 )
 

--- a/xla/backends/gpu/runtime/custom_call_thunk.cc
+++ b/xla/backends/gpu/runtime/custom_call_thunk.cc
@@ -65,11 +65,11 @@ limitations under the License.
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
 #include "tsl/platform/platform.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -378,11 +378,8 @@ absl::Status CustomCallThunk::ExecuteCustomCall(const ExecuteParams& params) {
     }
   }
 
-  TF_ASSIGN_OR_RETURN(
-      se::Stream * stream,
-      GetStreamForExecution(Thunk::execution_stream_id(), params));
   XlaCustomCallStatus custom_call_status;
-  call_target_(stream, buffers.data(), opaque_.data(), opaque_.size(),
+  call_target_(params.stream, buffers.data(), opaque_.data(), opaque_.size(),
                &custom_call_status);
   auto message = CustomCallStatusGetMessage(&custom_call_status);
   if (message) {
@@ -610,9 +607,7 @@ absl::Status CustomCallThunk::Initialize(const InitializeParams& params) {
 }
 
 absl::Status CustomCallThunk::ExecuteOnStream(const ExecuteParams& params) {
-  TF_ASSIGN_OR_RETURN(
-      se::Stream * stream,
-      GetStreamForExecution(Thunk::execution_stream_id(), params));
+  se::Stream* stream = params.stream;
 
   if (bundle_.has_value()) {
     const RunId run_id =

--- a/xla/backends/gpu/runtime/custom_call_thunk_test.cc
+++ b/xla/backends/gpu/runtime/custom_call_thunk_test.cc
@@ -162,39 +162,6 @@ TEST(CustomCallThunkTest, SimpleCustomCall) {
   EXPECT_TRUE(was_called);
 }
 
-TEST(CustomCallThunkTest, CustomCallOnCustomStream) {
-  // Whitebox test to ensure that custom calls respect execution_stream_id
-  // assignments.
-  TF_ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor, GpuExecutor());
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Stream> stream,
-                          executor->CreateStream());
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Stream> extra_stream,
-                          executor->CreateStream());
-  // Setup the additional streams.
-  Thunk::ExecutionStreamIdMap additional_compute_streams = {};
-  additional_compute_streams[ExecutionStreamId(1)] = extra_stream.get();
-  stream_executor::StreamExecutorAddressAllocator allocator(executor);
-  Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
-      ServiceExecutableRunOptions(), BufferAllocations({}, 0, &allocator),
-      stream.get(), stream.get(), nullptr, nullptr, nullptr,
-      additional_compute_streams);
-
-  CustomCallThunk::CustomCallTarget target =
-      [&](se::Stream* stream_in_callback, void** args, const char* target_name,
-          size_t num_args, XlaCustomCallStatus* status) {
-        // We should be launching on the extra stream and not the default one.
-        EXPECT_THAT(stream_in_callback, ::testing::Eq(extra_stream.get()));
-      };
-
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto thunk, CustomCallThunk::Create(Thunk::ThunkInfo(), "target_name",
-                                          target, {}, {}, ""));
-  // Setting this tells the thunk to dispatch on one of the additional streams.
-  thunk->set_execution_stream_id(ExecutionStreamId(1));
-  EXPECT_THAT(thunk->ExecuteOnStream(Thunk::ExecuteParams(params)),
-              absl_testing::IsOk());
-}
-
 // A simple callback function that always returns an error.
 absl::Status ReturnError() {
   return absl::UnknownError("Custom call was executed!");

--- a/xla/backends/gpu/runtime/dynamic_memcpy_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_memcpy_thunk.cc
@@ -70,10 +70,7 @@ absl::Status DynamicMemcpyThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Memcpy of size " << mem_size_ << " from "
           << src_with_offset.opaque() << " (offset " << src_offset << ") to "
           << dst_with_offset.opaque() << " (offset " << dst_offset << ")";
-  TF_ASSIGN_OR_RETURN(
-      se::Stream * stream,
-      GetStreamForExecution(Thunk::execution_stream_id(), params));
-  return stream->Memcpy(&dst_with_offset, src_with_offset, mem_size_);
+  return params.stream->Memcpy(&dst_with_offset, src_with_offset, mem_size_);
 }
 
 DynamicMemcpyThunkProto::Offsets DynamicMemcpyThunk::Offsets::ToProto() const {

--- a/xla/backends/gpu/runtime/gemm_thunk.cc
+++ b/xla/backends/gpu/runtime/gemm_thunk.cc
@@ -60,20 +60,17 @@ absl::Status GemmThunk::ExecuteOnStream(const ExecuteParams& params) {
   if (workspace_.has_value()) {
     workspace = allocs.GetDeviceAddress(workspace_.value());
   }
-  TF_ASSIGN_OR_RETURN(
-      se::Stream * stream,
-      GetStreamForExecution(Thunk::execution_stream_id(), params));
 
   // Sanitizer initcheck may return false positives for TMA (DTCS-1123).
   auto output = allocs.GetDeviceAddress(output_buffer_);
   tsl::profiler::MarkMemoryInitialized(
       output.opaque(), output.size(),
       static_cast<tsl::profiler::StreamHandle>(
-          stream->platform_specific_handle().stream));
+          params.stream->platform_specific_handle().stream));
 
   return RunGemm(config_, allocs.GetDeviceAddress(lhs_buffer_),
                  allocs.GetDeviceAddress(rhs_buffer_), output, workspace,
-                 deterministic_, stream);
+                 deterministic_, params.stream);
 }
 
 absl::Status GemmThunk::Initialize(const InitializeParams& params) {

--- a/xla/backends/gpu/runtime/host_execute_thunk.cc
+++ b/xla/backends/gpu/runtime/host_execute_thunk.cc
@@ -538,9 +538,7 @@ absl::Status HostExecuteStartThunk::Initialize(const InitializeParams& params) {
 
 absl::Status HostExecuteStartThunk::ExecuteOnStream(
     const ExecuteParams& params) {
-  TF_ASSIGN_OR_RETURN(
-      se::Stream * compute_stream,
-      GetStreamForExecution(Thunk::execution_stream_id(), params));
+  se::Stream* compute_stream = params.stream;
 
   // Host execute thunk enqueues compute on the device to host stream to allow
   // for the compute stream to be used for device compute.
@@ -677,9 +675,6 @@ absl::Status HostExecuteDoneThunk::Initialize(const InitializeParams& params) {
 
 absl::Status HostExecuteDoneThunk::ExecuteOnStream(
     const ExecuteParams& params) {
-  TF_ASSIGN_OR_RETURN(
-      se::Stream * stream,
-      GetStreamForExecution(Thunk::execution_stream_id(), params));
   TF_ASSIGN_OR_RETURN(auto event, async_events_->ExtractEvent(
                                       params.host_to_device_stream->parent(),
                                       RunId(params.execution_id)));
@@ -691,7 +686,7 @@ absl::Status HostExecuteDoneThunk::ExecuteOnStream(
 
   // We queue this event on the compute stream so that the host to device copy
   // finishes before the consumer of the data can start.
-  TF_RETURN_IF_ERROR(stream->WaitFor(event.get().get()));
+  TF_RETURN_IF_ERROR(params.stream->WaitFor(event.get().get()));
 
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/kernel_thunk.cc
@@ -50,12 +50,6 @@ limitations under the License.
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
-#include "tsl/profiler/lib/traceme.h"
-#include "tsl/profiler/lib/traceme_encode.h"
-
-using tsl::profiler::TraceMe;
-using tsl::profiler::TraceMeEncode;
-using tsl::profiler::TraceMeLevel;
 
 namespace xla {
 namespace gpu {
@@ -184,25 +178,8 @@ absl::Status KernelThunk::Initialize(const InitializeParams& params) {
 }
 
 absl::Status KernelThunk::ExecuteOnStream(const ExecuteParams& params) {
-  TraceMe trace(
-      [] { return TraceMeEncode("KernelThunk::ExecuteOnStream", {}); },
-      /*level=*/TraceMeLevel::kVerbose);
-
-  // Load the kernel.
-  se::StreamExecutor* executor = params.stream->parent();
-  se::Kernel* kernel = nullptr;
-
-  se::Stream* stream = nullptr;
-  {
-    TraceMe trace(
-        [] {
-          return TraceMeEncode(
-              "KernelThunk::ExecuteOnStream/GetStreamForExecution", {});
-        },
-        /*level=*/TraceMeLevel::kVerbose);
-    TF_ASSIGN_OR_RETURN(
-        stream, GetStreamForExecution(Thunk::execution_stream_id(), params));
-  }
+  se::Stream* stream = params.stream;
+  se::StreamExecutor* executor = stream->parent();
 
   for (int64_t index : zeroed_output_buffer_indices_) {
     se::DeviceAddressBase address =
@@ -210,52 +187,40 @@ absl::Status KernelThunk::ExecuteOnStream(const ExecuteParams& params) {
     TF_RETURN_IF_ERROR(stream->MemZero(&address, address.size()));
   }
 
+  // Lookup the loaded kernel.
+  se::Kernel* kernel = nullptr;
   {
-    TraceMe trace(
-        [] { return TraceMeEncode("KernelThunk::ExecuteOnStream/mutex", {}); },
-        /*level=*/TraceMeLevel::kVerbose);
     absl::MutexLock lock(mutex_);
-    TraceMe trace_find(
-        [] {
-          return TraceMeEncode("KernelThunk::ExecuteOnStream/mutex/find", {});
-        },
-        /*level=*/TraceMeLevel::kVerbose);
     auto it = kernel_cache_.find(executor);
     CHECK(it != kernel_cache_.end())
         << "Initialize() not called for StreamExecutor " << executor;
     kernel = it->second.get();
   }
 
-  absl::InlinedVector<se::KernelArg, 4> kernel_args;
-  {
-    TraceMe trace(
-        [] {
-          return TraceMeEncode("KernelThunk::ExecuteOnStream/kernel_args", {});
-        },
-        /*level=*/TraceMeLevel::kVerbose);
-    int device_ordinal = executor->device_ordinal();
-    XLA_VLOG_DEVICE(3, device_ordinal) << "Launching " << kernel->name();
-    for (const auto& [idx, arg] : llvm::enumerate(args_)) {
-      se::DeviceAddressBase buf =
-          params.buffer_allocations->GetDeviceAddress(arg.slice);
-      XLA_VLOG_DEVICE(3, device_ordinal)
-          << "Arg: alloc #" << arg.slice.index()
-          << ", offset: " << arg.slice.offset() << ": " << buf.opaque() << " ("
-          << buf.size() << "B)";
+  int device_ordinal = executor->device_ordinal();
+  XLA_VLOG_DEVICE(3, device_ordinal) << "Launching " << kernel->name();
 
-      if (auto it = tma_metadata_.arg_index_to_tma_info.find(idx);
-          it != tma_metadata_.arg_index_to_tma_info.end()) {
-        // TMA descriptor argument.
-        const se::gpu::TmaDescriptor& tma_desc = it->second;
-        TF_ASSIGN_OR_RETURN(se::TensorMap tensor_map,
-                            executor->CreateTensorMap(tma_desc, buf.opaque()));
-        XLA_VLOG_DEVICE(3, device_ordinal) << "Using TensorMap for arg #" << idx
-                                           << ": " << tma_desc.ToString();
-        kernel_args.push_back(std::move(tensor_map));
-      } else {
-        // Buffer argument.
-        kernel_args.push_back(buf);
-      }
+  absl::InlinedVector<se::KernelArg, 4> kernel_args;
+  for (const auto& [idx, arg] : llvm::enumerate(args_)) {
+    se::DeviceAddressBase buf =
+        params.buffer_allocations->GetDeviceAddress(arg.slice);
+    XLA_VLOG_DEVICE(3, device_ordinal)
+        << "Arg: alloc #" << arg.slice.index()
+        << ", offset: " << arg.slice.offset() << ": " << buf.opaque() << " ("
+        << buf.size() << "B)";
+
+    if (auto it = tma_metadata_.arg_index_to_tma_info.find(idx);
+        it != tma_metadata_.arg_index_to_tma_info.end()) {
+      // TMA descriptor argument.
+      const se::gpu::TmaDescriptor& tma_desc = it->second;
+      TF_ASSIGN_OR_RETURN(se::TensorMap tensor_map,
+                          executor->CreateTensorMap(tma_desc, buf.opaque()));
+      XLA_VLOG_DEVICE(3, device_ordinal)
+          << "Using TensorMap for arg #" << idx << ": " << tma_desc.ToString();
+      kernel_args.push_back(std::move(tensor_map));
+    } else {
+      // Buffer argument.
+      kernel_args.push_back(buf);
     }
   }
 


### PR DESCRIPTION
Compute thunks use structured concurrency via `AsyncStartThunk` and `AsyncDoneThunks` and should always use the compute stream passed to them via params, which can be swapped to async stream by the parent async thunk.