### PR TITLE
[tsl] Add `TiedRef<T>` and `Tied<T>` lifetime-tying primitives

### DIFF
--- a/xla/tsl/util/BUILD
+++ b/xla/tsl/util/BUILD
@@ -413,6 +413,21 @@ tsl_cc_test(
 )
 
 cc_library(
+    name = "tied_ref",
+    hdrs = ["tied_ref.h"],
+)
+
+tsl_cc_test(
+    name = "tied_ref_test",
+    srcs = ["tied_ref_test.cc"],
+    deps = [
+        ":tied_ref",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_main",
+    ],
+)
+
+cc_library(
     name = "unique_any",
     hdrs = ["unique_any.h"],
     deps = [

--- a/xla/tsl/util/tied_ref.h
+++ b/xla/tsl/util/tied_ref.h
@@ -1,0 +1,175 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_TSL_UTIL_TIED_REF_H_
+#define XLA_TSL_UTIL_TIED_REF_H_
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace tsl {
+
+template <typename T>
+class Tied;
+
+// A weak reference to a value stored in a Tied<T> container.
+//
+// Tied<T> is a container for values of type T whose lifetime is tied to the
+// container object. Callers receive TiedRef<T> handles that can be used to
+// check if the value (and the container it is tied to) is still alive.
+//
+// When the Tied<T> container is destroyed, all outstanding TiedRefs safely
+// expire (Lock returns nullptr). Additionally, when a TiedRef is destroyed
+// while the Tied<T> container is still alive, the tied value is eagerly
+// released — there is no need to wait for the container to be destroyed.
+//
+// Example:
+//
+//   class Session : private Tied<Connection> {
+//    public:
+//     TiedRef<Connection> Connect() {
+//       return Tie(std::make_unique<Connection>(*this));
+//     }
+//   };
+//
+//   // Caller does not control Session's lifetime.
+//   void DoWork(Session* session) {
+//     auto conn_ref = session->Connect();
+//     // ... later, possibly after `session` was replaced or shut down:
+//     if (auto conn = conn_ref.Lock()) {
+//       conn->Execute();  // Safe: session is still alive.
+//     }
+//   }
+//
+// It is the caller's responsibility to ensure that the Tied<T> container stays
+// alive for as long as the locked shared_ptr is in use. Lock() guarantees that
+// the value was alive at the time of the call, but does not prevent the
+// container from being destroyed concurrently. In practice, the caller
+// typically receives the container by pointer (e.g. Session*) with an
+// external guarantee that it outlives the current scope — so locking and
+// using the value within that scope is safe. Callers may also maintain their
+// own cache of TiedRefs and use Lock() to detect which ones are still valid
+// after the underlying session has been replaced.
+//
+template <typename T>
+class TiedRef {
+ public:
+  TiedRef() = default;
+  ~TiedRef();
+
+  TiedRef(TiedRef&& other) noexcept;
+  TiedRef& operator=(TiedRef&& other) noexcept;
+
+  // Returns a shared_ptr to the tied value if both the TiedRef and the Tied<T>
+  // container are still alive, or nullptr otherwise.
+  std::shared_ptr<T> Lock() const;
+
+  // Returns true if the Tied<T> container has been destroyed.
+  bool Expired() const;
+
+ private:
+  friend class Tied<T>;
+  explicit TiedRef(std::weak_ptr<std::shared_ptr<T>> ptr);
+
+  std::weak_ptr<std::shared_ptr<T>> ptr_;
+};
+
+// A container for values of type T whose lifetime is tied to *this object.
+// When *this is destroyed, all tied values are destroyed. Callers receive
+// TiedRef<T> handles to check if the values are still alive.
+// See TiedRef<T> for full documentation and usage examples.
+template <typename T>
+class Tied {
+ public:
+  Tied() = default;
+  ~Tied() = default;
+
+  Tied(Tied&&) = default;
+  Tied& operator=(Tied&&) = default;
+
+  // Ties ownership of `value` to *this and returns a TiedRef to it. The
+  // value is released when the TiedRef is destroyed or when *this is
+  // destroyed, whichever comes first. A shared_ptr obtained from Lock()
+  // independently extends the value's lifetime.
+  TiedRef<T> Tie(std::unique_ptr<T> value);
+
+ private:
+  std::vector<std::shared_ptr<std::shared_ptr<T>>> entries_;
+};
+
+//===----------------------------------------------------------------------===//
+// TiedRef<T> and Tied<T> implementation detail.
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+TiedRef<T>::TiedRef(std::weak_ptr<std::shared_ptr<T>> ptr)
+    : ptr_(std::move(ptr)) {}
+
+template <typename T>
+TiedRef<T>::~TiedRef() {
+  if (auto locked = ptr_.lock()) {
+    locked->reset();
+  }
+}
+
+template <typename T>
+TiedRef<T>::TiedRef(TiedRef&& other) noexcept : ptr_(std::move(other.ptr_)) {}
+
+template <typename T>
+TiedRef<T>& TiedRef<T>::operator=(TiedRef&& other) noexcept {
+  if (this != &other) {
+    if (auto locked = ptr_.lock()) {
+      locked->reset();
+    }
+    ptr_ = std::move(other.ptr_);
+  }
+  return *this;
+}
+
+template <typename T>
+std::shared_ptr<T> TiedRef<T>::Lock() const {
+  if (auto locked = ptr_.lock()) {
+    return *locked;
+  }
+  return nullptr;
+}
+
+template <typename T>
+bool TiedRef<T>::Expired() const {
+  return ptr_.expired();
+}
+
+template <typename T>
+TiedRef<T> Tied<T>::Tie(std::unique_ptr<T> value) {
+  // Lazy garbage collection: erase entries whose inner shared_ptr was reset
+  // by a TiedRef destructor.
+  entries_.erase(std::remove_if(entries_.begin(), entries_.end(),
+                                [](const auto& entry) { return !*entry; }),
+                 entries_.end());
+
+  if (!value) {
+    return TiedRef<T>{};
+  }
+
+  auto& entry = entries_.emplace_back(std::make_shared<std::shared_ptr<T>>(
+      std::shared_ptr<T>(value.release())));
+  return TiedRef<T>{std::weak_ptr<std::shared_ptr<T>>(entry)};
+}
+
+}  // namespace tsl
+
+#endif  // XLA_TSL_UTIL_TIED_REF_H_

--- a/xla/tsl/util/tied_ref_test.cc
+++ b/xla/tsl/util/tied_ref_test.cc
@@ -1,0 +1,147 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/tsl/util/tied_ref.h"
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "xla/tsl/platform/test.h"
+
+namespace tsl {
+namespace {
+
+// Forward declare.
+class Connection;
+
+// A Session is a long-lived entity that creates multiple Connections during its
+// lifetime. Connections are tied to the session and expire when the session is
+// destroyed or replaced.
+class Session : private Tied<Connection> {
+ public:
+  TiedRef<Connection> Connect() {
+    return Tie(std::make_unique<Connection>(&alive_connections_));
+  }
+
+  int32_t alive_connections() const { return alive_connections_; }
+
+ private:
+  int32_t alive_connections_ = 0;
+};
+
+// A Connection tracks its own construction/destruction via an external counter,
+// so tests can verify when tied values are created and released.
+class Connection {
+ public:
+  explicit Connection(int32_t* alive_count) : alive_count_(alive_count) {
+    ++(*alive_count_);
+  }
+  ~Connection() { --(*alive_count_); }
+
+ private:
+  int32_t* alive_count_;
+};
+
+TEST(TiedRefTest, ConnectionLocksWhileSessionAlive) {
+  Session session;
+  TiedRef<Connection> ref = session.Connect();
+
+  std::shared_ptr<Connection> conn = ref.Lock();
+  ASSERT_NE(conn, nullptr);
+  EXPECT_EQ(session.alive_connections(), 1);
+  EXPECT_FALSE(ref.Expired());
+}
+
+TEST(TiedRefTest, ConnectionExpiresWhenSessionDestroyed) {
+  TiedRef<Connection> ref;
+  {
+    Session session;
+    ref = session.Connect();
+    EXPECT_EQ(session.alive_connections(), 1);
+    EXPECT_FALSE(ref.Expired());
+  }
+  EXPECT_TRUE(ref.Expired());
+  EXPECT_EQ(ref.Lock(), nullptr);
+}
+
+TEST(TiedRefTest, ConnectionReleasedWhenTiedRefDestroyed) {
+  Session session;
+  {
+    TiedRef<Connection> ref = session.Connect();
+    EXPECT_EQ(session.alive_connections(), 1);
+  }
+  // TiedRef destroyed while session is alive — connection eagerly released.
+  EXPECT_EQ(session.alive_connections(), 0);
+}
+
+TEST(TiedRefTest, MultipleConnections) {
+  Session session;
+  TiedRef<Connection> ref1 = session.Connect();
+  TiedRef<Connection> ref2 = session.Connect();
+
+  EXPECT_EQ(session.alive_connections(), 2);
+  EXPECT_NE(ref1.Lock(), nullptr);
+  EXPECT_NE(ref2.Lock(), nullptr);
+}
+
+TEST(TiedRefTest, CachedRefsDetectSessionReplacement) {
+  std::vector<TiedRef<Connection>> cache;
+
+  std::unique_ptr<Session> session = std::make_unique<Session>();
+  cache.push_back(session->Connect());
+  cache.push_back(session->Connect());
+  EXPECT_EQ(session->alive_connections(), 2);
+
+  // Replace the session — old tied connections expire.
+  session = std::make_unique<Session>();
+  for (TiedRef<Connection>& ref : cache) {
+    EXPECT_TRUE(ref.Expired());
+  }
+
+  // New connections from the replacement are alive.
+  cache.clear();
+  cache.push_back(session->Connect());
+  EXPECT_EQ(session->alive_connections(), 1);
+  EXPECT_FALSE(cache[0].Expired());
+}
+
+TEST(TiedRefTest, DefaultTiedRefIsExpired) {
+  TiedRef<Connection> ref;
+  EXPECT_TRUE(ref.Expired());
+  EXPECT_EQ(ref.Lock(), nullptr);
+}
+
+TEST(TiedRefTest, MoveSession) {
+  Session session;
+  TiedRef<Connection> ref = session.Connect();
+
+  Session moved_session = std::move(session);
+
+  // TiedRef is still valid because tied connections moved with the session.
+  EXPECT_FALSE(ref.Expired());
+  EXPECT_NE(ref.Lock(), nullptr);
+}
+
+TEST(TiedRefTest, TieNullptrReturnsExpiredRef) {
+  Tied<Connection> tied;
+  TiedRef<Connection> ref = tied.Tie(nullptr);
+  EXPECT_TRUE(ref.Expired());
+  EXPECT_EQ(ref.Lock(), nullptr);
+}
+
+}  // namespace
+}  // namespace tsl


### PR DESCRIPTION
Introduce `tsl::Tied<T>` and `tsl::TiedRef<T>` — a pair of templates for tying the lifetime of dynamically-created values to a container object.

`Tied<T>`is a container that owns values of type `T`. Callers receive move-only `TiedRef<T>` handles that can `Lock()` to obtain a `shared_ptr<T>`, or check `Expired()` to detect if the container was destroyed.

### Key properties:

- When the `Tied<T>` container is destroyed, all outstanding `TiedRef`s expire
- When a `TiedRef` is destroyed while the container is alive, the tied value is **eagerly released** (no waiting for the container to be destroyed)
- `Lock()` returns an independent `shared_ptr<T>` that extends the value's lifetime
- `Tie(nullptr)` returns an already-expired `TiedRef`
- Lazy garbage collection of released entries on each `Tie()` call

Uses double-indirection (`shared_ptr<shared_ptr<T>>` in `Tied`, `weak_ptr<shared_ptr<T>>` in `TiedRef`) to enable eager cleanup from the `TiedRef` destructor.

Intended use case:  GPU collectives - objects like `SymmetricMemory` are only valid while their parent clique (communicator) is alive.
