### PR TITLE
[XLA:GPU] Adds a new construction mode (kCapture) for command buffer

### DIFF
--- a/xla/backends/gpu/runtime/command.cc
+++ b/xla/backends/gpu/runtime/command.cc
@@ -16,6 +16,11 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/command.h"
 
 #include <string>
+#include <variant>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/command_buffer.h"
 
 namespace xla::gpu {
 
@@ -27,6 +32,32 @@ std::string CommandTypeString(CommandType type) {
     XLA_GPU_COMMAND_LIST(CASE_CMD_STRING)
 #undef CASE_CMD_STRING
   }
+}
+
+absl::StatusOr<const se::CommandBuffer::Command*> Command::Record(
+    const Thunk::ExecuteParams& execute_params,
+    const RecordParams& /*record_params*/, RecordAction record_action,
+    se::CommandBuffer* command_buffer) {
+  if (construction_mode_ == ConstructionMode::kExplicit) {
+    return absl::UnimplementedError("Record is not implemented");
+  }
+
+  // kCapture mode
+  if (std::holds_alternative<RecordUpdate>(record_action)) {
+    return absl::UnimplementedError(
+        "RecordUpdate is not supported in kCapture construction mode.");
+  }
+
+  // RecordCreate: capture ExecuteOnStream into the command buffer via Trace.
+  auto& create = std::get<RecordCreate>(record_action);
+  se::Stream* trace_stream = execute_params.command_buffer_trace_stream;
+
+  return command_buffer->Trace(
+      trace_stream,
+      [this, &execute_params]() -> absl::Status {
+        return ExecuteOnStream(execute_params);
+      },
+      create.dependencies);
 }
 
 bool IsCollectiveCommand(CommandType type) {

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -38,8 +38,8 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/platform.h"
-#include "tsl/platform/casts.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 
@@ -127,11 +127,35 @@ bool IsCollectiveCommand(CommandType type);
 // done with a state manager.
 class Command : public Thunk {
  public:
-  explicit Command(CommandType cmd_type,
-                   se::StreamPriority priority = se::StreamPriority::Default)
-      : Thunk(Thunk::Kind::kCommand, ThunkInfo{}),
+  enum class ConstructionMode {
+    // Explicitly records each command using RecordCreate/RecordUpdate.
+    kExplicit,
+
+    // Captures command execution directly into the outer command buffer via
+    // stream tracing. RecordUpdate is not supported. Requires CUDA 12.3+.
+    kCapture,
+  };
+
+  template <typename Sink>
+  friend void AbslStringify(Sink& sink, ConstructionMode mode) {
+    switch (mode) {
+      case ConstructionMode::kExplicit:
+        sink.Append("explicit");
+        break;
+      case ConstructionMode::kCapture:
+        sink.Append("capture");
+        break;
+    }
+  }
+
+  explicit Command(
+      CommandType cmd_type,
+      se::StreamPriority priority = se::StreamPriority::Default,
+      ConstructionMode construction_mode = ConstructionMode::kExplicit)
+      : Thunk(Kind::kCommand, ThunkInfo()),
         cmd_type_(cmd_type),
-        priority_(priority) {
+        priority_(priority),
+        construction_mode_(construction_mode) {
     token_ = Resource::Create(Resource::kToken);
   }
 
@@ -171,7 +195,8 @@ class Command : public Thunk {
   using RecordAction = std::variant<RecordCreate, RecordUpdate>;
 
   // Commands are not executed directly as Thunks; they are recorded into
-  // command buffers via Record(). ExecuteOnStream is not supported.
+  // command buffers via Record(). Subclasses that support kCapture mode must
+  // override ExecuteOnStream to perform stream-capture recording.
   absl::Status ExecuteOnStream(const ExecuteParams& params) override {
     return absl::UnimplementedError(
         "Command cannot be executed directly as a Thunk; use Record() instead");
@@ -180,12 +205,13 @@ class Command : public Thunk {
   // Records commands into the command buffer. Returned commands will be passed
   // back on the next call to `Record` into the same command buffer, so that it
   // can do efficient command buffer updates.
+  //
+  // The base implementation handles kCapture mode by tracing ExecuteOnStream.
+  // Subclasses that support kExplicit mode must override this method.
   virtual absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams& execute_params,
       const RecordParams& record_params, RecordAction record_action,
-      se::CommandBuffer* command_buffer) {
-    return absl::UnimplementedError("Record is not implemented");
-  }
+      se::CommandBuffer* command_buffer);
 
   // Returns true if command requires initialization (has to be recorded at
   // command buffer thunk initialization).
@@ -217,6 +243,7 @@ class Command : public Thunk {
   CommandType command_type() const { return cmd_type_; }
   se::StreamPriority priority() const { return priority_; }
   void set_priority(se::StreamPriority priority) { priority_ = priority; }
+  ConstructionMode construction_mode() const { return construction_mode_; }
 
   std::string ToString(int indent) const override {
     return CommandTypeString(cmd_type_);
@@ -247,6 +274,8 @@ class Command : public Thunk {
   // Command priority, currently only support default, lowest and highest
   // priority.
   se::StreamPriority priority_ = se::StreamPriority::Default;
+
+  ConstructionMode construction_mode_ = ConstructionMode::kExplicit;
 };
 
 // Returns true if command is a collective one.

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -284,6 +284,17 @@ CommandExecutor::CommandExecutor(SynchronizationMode synchronization_mode,
     : synchronization_mode_(synchronization_mode),
       commands_(std::move(commands)),
       execution_graph_(std::move(execution_graph)) {
+  // Derive construction mode from commands: kCapture only if the sequence is
+  // non-empty and every command is kCapture; otherwise kExplicit.
+  construction_mode_ = ConstructionMode::kExplicit;
+  if (!commands_.empty()) {
+    construction_mode_ = ConstructionMode::kCapture;
+    commands_.Walk([&](const Command* command) {
+      if (command->construction_mode() != ConstructionMode::kCapture) {
+        construction_mode_ = ConstructionMode::kExplicit;
+      }
+    });
+  }
   // Walk all nested commands and collect all buffers used by this executor.
   commands_.Walk([&](const Command* command) {
     Command::BufferUses buffer_uses = command->buffer_uses();
@@ -466,14 +477,49 @@ CommandExecutor::RecordCreate(
       commands_.size(), command_buffer, dependencies.size(), record_id);
   uint64_t start_micros = tsl::Env::Default()->NowMicros();
 
+  auto* state = command_buffer->GetOrConstructResource<CommandExecutorsState>();
+  auto key = std::make_pair(this, record_id);
+
+  // kCapture: run all commands via ExecuteOnStream inside a single Trace call.
+  if (construction_mode_ == ConstructionMode::kCapture) {
+    if (state->recorded_commands.contains(key)) {
+      return Internal(
+          "Commands already recorded for this executor/record_id pair. "
+          "kCapture records the command buffer only once.");
+    }
+
+    se::Stream* trace_stream = execute_params.command_buffer_trace_stream;
+
+    auto run_on_stream = [&](se::Stream* stream) -> absl::Status {
+      Thunk::ExecuteParams capture_params = execute_params;
+      capture_params.stream = stream;
+      for (auto& cmd : commands_) {
+        TF_RETURN_IF_ERROR(cmd->ExecuteOnStream(capture_params));
+      }
+      return absl::OkStatus();
+    };
+
+    VLOG(1) << absl::StreamFormat(
+        "Record create (inline capture) %d commands into command buffer %p: "
+        "deps=%d, record_id=%v",
+        commands_.size(), command_buffer, dependencies.size(), record_id);
+    TF_ASSIGN_OR_RETURN(
+        const se::CommandBuffer::Command* sink,
+        command_buffer->Trace(
+            trace_stream, [&] { return run_on_stream(trace_stream); },
+            dependencies));
+    state->recorded_commands[key] = RecordedCommands({sink});
+    return {{sink}};
+  }
+
+  // kExplicit: record each command individually into the command buffer.
+
   // Short-circuit if there are no commands to record.
   if (commands_.empty()) {
     return std::vector<const se::CommandBuffer::Command*>{};
   }
 
-  auto* state = command_buffer->GetOrConstructResource<CommandExecutorsState>();
-  RecordedCommands& recorded_commands =
-      state->recorded_commands[std::make_pair(this, record_id)];
+  RecordedCommands& recorded_commands = state->recorded_commands[key];
 
   // Check that this executor was not already recorded into the command buffer.
   if (!recorded_commands.empty()) {
@@ -593,6 +639,15 @@ absl::Status CommandExecutor::RecordUpdate(
   auto* state = command_buffer->GetOrConstructResource<CommandExecutorsState>();
   RecordedCommands& recorded_commands =
       state->recorded_commands[std::make_pair(this, record_id)];
+
+  // kCapture does not support update: the captured nodes are inline in
+  // the outer graph and cannot be atomically swapped. Memory addresses must be
+  // persistent.
+  if (construction_mode_ == ConstructionMode::kCapture) {
+    return absl::UnimplementedError(
+        "RecordUpdate is not supported for kCapture construction mode. "
+        "Memory addresses must be persistent.");
+  }
 
   // Check this this executor was correctly recorded into the command buffer.
   if (recorded_commands.size() != commands_.size()) {

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -92,10 +92,17 @@ class CommandExecutor {
     }
   }
 
+  // Construction mode controls how the underlying command buffer (CUDA graph)
+  // is built. See Command::ConstructionMode for values and documentation.
+  using ConstructionMode = Command::ConstructionMode;
+
   // Creates a command executor from a sequence of commands using given
   // synchronization mode. `extra_resources` provides per-command additional
   // resource uses (e.g. control-dependency tokens from the emitter); if empty,
   // no extra resource uses are added.
+  // Construction mode is derived from the commands
+  // themselves: if all commands are kCapture, the executor is kCapture;
+  // otherwise it is kExplicit.
   static absl::StatusOr<CommandExecutor> Create(
       CommandSequence commands, SynchronizationMode synchronization_mode,
       std::vector<Command::ResourceUses> extra_resources = {});
@@ -150,6 +157,11 @@ class CommandExecutor {
 
   // Returns buffer allocations indices referenced by commands in this sequence.
   absl::Span<const BufferAllocation::Index> allocs_indices() const;
+
+  SynchronizationMode synchronization_mode() const {
+    return synchronization_mode_;
+  }
+  ConstructionMode construction_mode() const { return construction_mode_; }
 
   bool empty() const { return commands_.empty(); }
   size_t size() const { return commands_.size(); }
@@ -239,6 +251,7 @@ class CommandExecutor {
       RecordId record_id) const;
 
   SynchronizationMode synchronization_mode_;
+  ConstructionMode construction_mode_;
   CommandSequence commands_;
 
   // In automatic synchronization mode we build an execution graph for the

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -306,6 +306,23 @@ class CommandBuffer {
                                    UpdateCommands update_cond,
                                    UpdateCommands update_body) = 0;
 
+  //--------------------------------------------------------------------------//
+  // Tracing API
+  //--------------------------------------------------------------------------//
+
+  // Captures `function` invocation by recording all stream operations directly
+  // into this command buffer at the current graph level (not as a child node).
+  // Appended nodes are ordered after `dependencies`; pass {} for a root
+  // capture (equivalent to the old Trace() with no deps). Returns the sink
+  // commands of the captured subgraph. Callers that only need status can call
+  // .status() on the result. Requires CUDA 12.3+.
+  virtual absl::StatusOr<const Command*> Trace(
+      Stream* stream, absl::AnyInvocable<absl::Status()> function,
+      absl::Span<const Command* const> dependencies) {
+    return absl::UnimplementedError(
+        "Trace is not implemented for this command buffer.");
+  }
+
   // Set the priority of all nodes in the command buffer.
   virtual absl::Status SetPriority(StreamPriority priority) = 0;
 
@@ -365,18 +382,6 @@ class CommandBuffer {
   }
 
  private:
-  friend class TraceCommandBufferFactory;
-
-  // Tracing APIs are private because they do not compose with command buffer
-  // updates. Instead of tracing directly into the command buffer users should
-  // create traced command buffers using factory methods and add them to primary
-  // command buffers as nested operations.
-
-  // Traces `function` invocation by recording all operations on the `stream`
-  // into the command buffer. Command buffer must be empty.
-  virtual absl::Status Trace(Stream* stream,
-                             absl::AnyInvocable<absl::Status()> function) = 0;
-
   // We use ResourceTypeId to distinguish between different resource types.
   TSL_LIB_GTL_DEFINE_INT_TYPE(ResourceTypeId, int64_t);
 

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -2102,6 +2102,7 @@ cc_library(
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/debugging:leak_check",
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/casts.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/debugging/leak_check.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
@@ -647,67 +648,132 @@ absl::StatusOr<GraphNodeHandle> CudaCommandBuffer::CreateEmptyNode(
   return FromCudaGraphHandle(node_handle);
 }
 
-absl::Status CudaCommandBuffer::Trace(
-    Stream* stream, absl::AnyInvocable<absl::Status()> function) {
+absl::StatusOr<std::vector<GpuCommandBuffer::GraphNodeHandle>>
+CudaCommandBuffer::CaptureInlineAndReturnSinks(
+    absl::Span<const GraphNodeHandle> dependencies, Stream* stream,
+    absl::AnyInvocable<absl::Status()> function) {
 #if CUDA_VERSION < 12030
   return absl::UnimplementedError(
-      "StreamBeginCaptureToGraph is not implemented for CUDA below version "
-      "12.3. Therefore tracing is not supported.");
+      "CaptureInlineAndReturnSinks is not implemented for CUDA below version "
+      "12.3.");
 #else
   if (stream_exec_->GetDeviceDescription().driver_version() <
       SemanticVersion{12, 3, 0}) {
     return absl::UnimplementedError(
-        "StreamBeginCaptureToGraph is not implemented for CUDA below version "
-        "12.3. Therefore tracing is not supported.");
+        "CaptureInlineAndReturnSinks is not implemented for CUDA below version "
+        "12.3.");
   }
 
   TF_RETURN_IF_ERROR(CheckNotFinalized());
 
-  VLOG(5) << "Trace into GPU command buffer graph " << graph_
-          << " on a stream: " << stream;
-
   CUstream stream_handle =
       absl::bit_cast<CUstream>(stream->platform_specific_handle().stream);
+  std::vector<CUgraphNode> dep_handles = ToCudaGraphHandles(dependencies);
 
-  // Switch stream into the capture mode.
-  uint64_t start_nanos = tsl::Env::Default()->NowNanos();
+  // Snapshot the nodes currently in the graph so we can identify new ones.
+  size_t num_nodes_before = 0;
+  TF_RETURN_IF_ERROR(
+      cuda::ToStatus(cuGraphGetNodes(graph_, nullptr, &num_nodes_before)));
+  std::vector<CUgraphNode> nodes_before(num_nodes_before);
+  if (num_nodes_before > 0) {
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphGetNodes(graph_, nodes_before.data(), &num_nodes_before)));
+  }
+  absl::flat_hash_set<CUgraphNode> nodes_before_set(nodes_before.begin(),
+                                                    nodes_before.end());
 
-  TF_RETURN_IF_ERROR(cuda::ToStatus(
-      cuStreamBeginCaptureToGraph(stream_handle, graph_,
-                                  /*dependencies=*/nullptr,
-                                  /*dependencyData=*/nullptr,
-                                  /*numDependencies=*/0,
-                                  CU_STREAM_CAPTURE_MODE_THREAD_LOCAL),
-      "Failed to begin stream capture to graph"));
+  VLOG(5) << "CaptureInlineAndReturnSinks into graph " << graph_
+          << " on stream " << stream << "; deps=" << dep_handles.size()
+          << " existing_nodes=" << num_nodes_before;
+
+  // Begin capturing directly into graph_.
+  TF_RETURN_IF_ERROR(
+      cuda::ToStatus(cuStreamBeginCaptureToGraph(
+                         stream_handle, graph_,
+                         dep_handles.empty() ? nullptr : dep_handles.data(),
+                         /*dependencyData=*/nullptr, dep_handles.size(),
+                         CU_STREAM_CAPTURE_MODE_THREAD_LOCAL),
+                     "Failed to begin inline stream capture to graph"));
+
   auto traced = function();
 
-  // Always stop capturing the stream before checking `traced` result.
-  VLOG(5) << "End stream " << stream << " capture";
   CUgraph captured_graph;
   TF_RETURN_IF_ERROR(
       cuda::ToStatus(cuStreamEndCapture(stream_handle, &captured_graph),
-                     "Failed to end stream capture"));
-  DCHECK(captured_graph == graph_) << "Stream capture should update graph_";
+                     "Failed to end inline stream capture"));
+  DCHECK(captured_graph == graph_)
+      << "Inline stream capture should update graph_";
+
   TF_RETURN_IF_ERROR(traced);
 
-  uint64_t end_nanos = tsl::Env::Default()->NowNanos();
-  VLOG(5) << "Traced into the GPU command buffer graph " << graph_ << " (took "
-          << (end_nanos - start_nanos) / 1000 << " μs)";
-
-  // Check that traced graph is not empty. Trying to instantiate a CUDA graph
-  // with empty child node leads to a crash.
-  size_t num_root_nodes = 0;
-  TF_RETURN_IF_ERROR(cuda::ToStatus(
-      cuGraphGetRootNodes(captured_graph, nullptr, &num_root_nodes)));
-
-  if (num_root_nodes == 0) {
-    return absl::InternalError(
-        "Traced CUDA graph is empty. Traced function (custom call) did not "
-        "launch any CUDA operations on the captured CUDA stream. Instantiating "
-        "empty child nodes leads to CUDA crashes.");
+  // Enumerate all nodes now in graph_ and find the newly-added ones.
+  size_t num_nodes_after = 0;
+  TF_RETURN_IF_ERROR(
+      cuda::ToStatus(cuGraphGetNodes(graph_, nullptr, &num_nodes_after)));
+  std::vector<CUgraphNode> nodes_after(num_nodes_after);
+  if (num_nodes_after > 0) {
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphGetNodes(graph_, nodes_after.data(), &num_nodes_after)));
   }
 
-  return absl::OkStatus();
+  std::vector<CUgraphNode> new_nodes;
+  new_nodes.reserve(num_nodes_after - num_nodes_before);
+  absl::flat_hash_set<CUgraphNode> new_nodes_set;
+  for (CUgraphNode node : nodes_after) {
+    if (!nodes_before_set.contains(node)) {
+      new_nodes.push_back(node);
+      new_nodes_set.insert(node);
+    }
+  }
+
+  // Find sinks: new nodes that no other new node depends on.
+  absl::flat_hash_set<CUgraphNode> has_successor;
+  for (CUgraphNode new_node : new_nodes) {
+    size_t num_deps = 0;
+#if CUDA_VERSION >= 12030
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphNodeGetDependentNodes(new_node, nullptr, nullptr, &num_deps)));
+    if (num_deps == 0) continue;
+    std::vector<CUgraphNode> dependents(num_deps);
+    TF_RETURN_IF_ERROR(cuda::ToStatus(cuGraphNodeGetDependentNodes(
+        new_node, dependents.data(), nullptr, &num_deps)));
+#else
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphNodeGetDependentNodes(new_node, nullptr, &num_deps)));
+    if (num_deps == 0) continue;
+    std::vector<CUgraphNode> dependents(num_deps);
+    TF_RETURN_IF_ERROR(cuda::ToStatus(
+        cuGraphNodeGetDependentNodes(new_node, dependents.data(), &num_deps)));
+#endif
+    for (CUgraphNode dep : dependents) {
+      if (new_nodes_set.contains(dep)) {
+        has_successor.insert(new_node);
+        break;
+      }
+    }
+  }
+
+  std::vector<GraphNodeHandle> sinks;
+  for (CUgraphNode new_node : new_nodes) {
+    if (!has_successor.contains(new_node)) {
+      sinks.push_back(FromCudaGraphHandle(new_node));
+    }
+  }
+
+  VLOG(5) << "CaptureInlineAndReturnSinks: captured " << new_nodes.size()
+          << " nodes, " << sinks.size() << " sinks";
+
+  // When capturing into a previously-empty graph (factory use case), require
+  // that at least one node was recorded. An empty captured graph used as a
+  // child node leads to CUDA crashes.
+  if (num_nodes_before == 0 && new_nodes.empty()) {
+    return absl::InternalError(
+        "Traced CUDA graph is empty. The traced function did not launch any "
+        "CUDA operations on the captured stream. Instantiating empty child "
+        "nodes leads to CUDA crashes.");
+  }
+
+  return sinks;
 #endif
 }
 

--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -730,7 +730,7 @@ CudaCommandBuffer::CaptureInlineAndReturnSinks(
   absl::flat_hash_set<CUgraphNode> has_successor;
   for (CUgraphNode new_node : new_nodes) {
     size_t num_deps = 0;
-#if CUDA_VERSION >= 12030
+#if CUDA_VERSION >= 12030 && CUDA_VERSION < 12090
     TF_RETURN_IF_ERROR(cuda::ToStatus(
         cuGraphNodeGetDependentNodes(new_node, nullptr, nullptr, &num_deps)));
     if (num_deps == 0) continue;

--- a/xla/stream_executor/cuda/cuda_command_buffer.h
+++ b/xla/stream_executor/cuda/cuda_command_buffer.h
@@ -156,8 +156,9 @@ class CudaCommandBuffer final : public GpuCommandBuffer {
   absl::StatusOr<GraphNodeHandle> CreateEmptyNode(
       absl::Span<const GraphNodeHandle> dependencies) override;
 
-  absl::Status Trace(Stream* stream,
-                     absl::AnyInvocable<absl::Status()> function) override;
+  absl::StatusOr<std::vector<GraphNodeHandle>> CaptureInlineAndReturnSinks(
+      absl::Span<const GraphNodeHandle> dependencies, Stream* stream,
+      absl::AnyInvocable<absl::Status()> function) override;
 
   absl::Status LaunchGraph(Stream* stream) override;
 

--- a/xla/stream_executor/gpu/gpu_command_buffer.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer.cc
@@ -119,6 +119,10 @@ GpuCommandBuffer::ToGraphNodeDependencies(
       handles.push_back(gpu_command->conditional_node.handle);
     } else if (auto* gpu_command = dynamic_cast<const GpuChildCommand*>(dep)) {
       handles.push_back(gpu_command->handle);
+    } else if (auto* gpu_command = dynamic_cast<const GpuTraceCommand*>(dep)) {
+      for (const GraphNodeHandle& node : gpu_command->sink_nodes) {
+        handles.push_back(node);
+      }
     } else {
       LOG(FATAL) << "Unsupported command type";  // Crash OK
     }
@@ -220,6 +224,21 @@ absl::Status GpuCommandBuffer::UpdateLaunch(const Command* command,
   }
 
   return absl::InternalError("Unsupported kernel arguments type");
+}
+
+absl::StatusOr<const CommandBuffer::Command*> GpuCommandBuffer::Trace(
+    Stream* stream, absl::AnyInvocable<absl::Status()> function,
+    absl::Span<const Command* const> dependencies) {
+  TF_RETURN_IF_ERROR(CheckInState(State::kCreate));
+
+  TF_ASSIGN_OR_RETURN(
+      std::vector<GraphNodeHandle> sink_handles,
+      CaptureInlineAndReturnSinks(ToGraphNodeDependencies(dependencies), stream,
+                                  std::move(function)));
+
+  GpuTraceCommand trace_cmd;
+  trace_cmd.sink_nodes = std::move(sink_handles);
+  return AppendCommand(std::move(trace_cmd));
 }
 
 absl::StatusOr<const CommandBuffer::Command*>

--- a/xla/stream_executor/gpu/gpu_command_buffer.h
+++ b/xla/stream_executor/gpu/gpu_command_buffer.h
@@ -117,6 +117,12 @@ class GpuCommandBuffer : public CommandBuffer {
     std::unique_ptr<CommandBuffer> command_buffer;
   };
 
+  // A GpuTraceCommand is created by tracing a function invocation. It contains
+  // the handles of the sink nodes that were added by the traced function.
+  struct GpuTraceCommand : public CommandBuffer::Command {
+    std::vector<GraphNodeHandle> sink_nodes;
+  };
+
   GpuCommandBuffer(Mode mode, StreamExecutor* executor);
 
   // Bring CreateLaunch and UpdateLaunch template functions into scope.
@@ -197,6 +203,10 @@ class GpuCommandBuffer : public CommandBuffer {
   absl::Status UpdateWhile(const Command* command, DeviceAddress<bool> pred,
                            UpdateCommands update_cond,
                            UpdateCommands update_body) override;
+
+  absl::StatusOr<const Command*> Trace(
+      Stream* stream, absl::AnyInvocable<absl::Status()> function,
+      absl::Span<const Command* const> dependencies) override;
 
   absl::Status Finalize() override;
   absl::Status Update() override;
@@ -310,6 +320,14 @@ class GpuCommandBuffer : public CommandBuffer {
   // Adds a new empty node to the underlying graph.
   virtual absl::StatusOr<GraphNodeHandle> CreateEmptyNode(
       absl::Span<const GraphNodeHandle> dependencies) = 0;
+
+  // Captures `function` invocation directly into the underlying graph starting
+  // from `dependencies`, and returns the handles of the sink nodes added by the
+  // capture. Called by Trace(). Requires platform support (CUDA 12.3+).
+  virtual absl::StatusOr<std::vector<GraphNodeHandle>>
+  CaptureInlineAndReturnSinks(absl::Span<const GraphNodeHandle> dependencies,
+                              Stream* stream,
+                              absl::AnyInvocable<absl::Status()> function) = 0;
 
   // Adds a new conditional node to the graph and creates a corresponding
   // nested command buffer.

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -360,13 +360,25 @@ absl::StatusOr<GraphNodeHandle> RocmCommandBuffer::CreateEmptyNode(
   return FromHipGraphHandle(node_handle);
 }
 
-absl::Status RocmCommandBuffer::Trace(
-    Stream* stream, absl::AnyInvocable<absl::Status()> function) {
+absl::StatusOr<std::vector<GpuCommandBuffer::GraphNodeHandle>>
+RocmCommandBuffer::CaptureInlineAndReturnSinks(
+    absl::Span<const GraphNodeHandle> dependencies, Stream* stream,
+    absl::AnyInvocable<absl::Status()> function) {
+  // ROCm does not expose hipGraphNodeGetDependentNodes, so full sink detection
+  // for inline capture with dependencies is not supported. For the common
+  // no-dependencies case (TraceCommandBufferFactory), fall back to the
+  // hipStreamBeginCapture approach which replaces graph_.
+  if (!dependencies.empty()) {
+    return absl::UnimplementedError(
+        "ROCm inline capture with explicit dependencies is not supported.");
+  }
+
   TF_RETURN_IF_ERROR(CheckNotFinalized());
   TF_ASSIGN_OR_RETURN(size_t count, GetNodeCount());
-  if (count != 0 || !is_owned_graph_)
+  if (count != 0 || !is_owned_graph_) {
     return absl::InternalError(
-        "Stream can't be traced on non empty command buffer");
+        "ROCm Trace (no dependencies) requires an empty owned graph.");
+  }
 
   VLOG(5) << "Trace into GPU command buffer graph " << graph_
           << " on a stream: " << stream;
@@ -374,7 +386,6 @@ absl::Status RocmCommandBuffer::Trace(
   hipStream_t stream_handle =
       static_cast<hipStream_t>(stream->platform_specific_handle().stream);
 
-  // Switch stream into the capture mode.
   uint64_t start_nanos = tsl::Env::Default()->NowNanos();
   TF_RETURN_IF_ERROR(
       ToStatus(wrap::hipStreamBeginCapture(stream_handle,
@@ -382,7 +393,6 @@ absl::Status RocmCommandBuffer::Trace(
                "Failed to begin stream capture"));
   auto traced = function();
 
-  // Always stop capturing the stream before checking `traced` result.
   VLOG(5) << "End stream " << stream << " capture";
   hipGraph_t captured_graph;
   TF_RETURN_IF_ERROR(
@@ -393,9 +403,10 @@ absl::Status RocmCommandBuffer::Trace(
                "Failed to destroy HIP graph"));
   uint64_t end_nanos = tsl::Env::Default()->NowNanos();
 
-  if (!traced.ok())
+  if (!traced.ok()) {
     return absl::InternalError(
         absl::StrCat("Failed to capture gpu graph: ", traced.message()));
+  }
 
   VLOG(5) << "Traced into the GPU command buffer graph " << graph_ << " (took "
           << (end_nanos - start_nanos) / 1000 << " μs)";

--- a/xla/stream_executor/rocm/rocm_command_buffer.h
+++ b/xla/stream_executor/rocm/rocm_command_buffer.h
@@ -143,8 +143,9 @@ class RocmCommandBuffer : public GpuCommandBuffer {
   absl::StatusOr<GraphNodeHandle> CreateEmptyNode(
       absl::Span<const GraphNodeHandle> dependencies) override;
 
-  absl::Status Trace(Stream* stream,
-                     absl::AnyInvocable<absl::Status()> function) override;
+  absl::StatusOr<std::vector<GraphNodeHandle>> CaptureInlineAndReturnSinks(
+      absl::Span<const GraphNodeHandle> dependencies, Stream* stream,
+      absl::AnyInvocable<absl::Status()> function) override;
 
   absl::Status LaunchGraph(Stream* stream) override;
 

--- a/xla/stream_executor/trace_command_buffer_factory.cc
+++ b/xla/stream_executor/trace_command_buffer_factory.cc
@@ -54,7 +54,8 @@ TraceCommandBufferFactory::Create(
 
   // Trace and finalize the command buffer.
   TF_RETURN_IF_ERROR(
-      command_buffer->Trace(stream, [&]() { return function(stream); }));
+      command_buffer->Trace(stream, [&]() { return function(stream); }, {})
+          .status());
   TF_RETURN_IF_ERROR(command_buffer->Finalize());
 
   return command_buffer;


### PR DESCRIPTION
 Introduces a new kCapture construction mode for CommandExecutor alongside the existing kExplicit mode, enabling more efficient CUDA graph construction via inline stream capture.

  - ConstructionMode enum (kExplicit / kCapture) added to Command and exposed on CommandExecutor. Mode is automatically derived at construction time: kCapture is selected only when all commands in the sequence support it; otherwise falls back to kExplicit.
  - kExplicit (existing default): records each command individually as a graph node.
  - kCapture (new): executes all commands via ExecuteOnStream() within a single CommandBuffer::Trace() call, capturing them inline into the outer CUDA graph. This avoids child-graph overhead since captured nodes become direct nodes in the outer graph.
  - Command::Record() base implementation handles the kCapture path: on RecordCreate, it drives the trace using each command's ExecuteOnStream(); RecordUpdate is rejected in capture mode (inlined nodes cannot be atomically swapped).
  - CommandBuffer::Trace() moved to public API and its return type changed from vector<Command*> to absl::StatusOr<const Command*> (a single sink node, since Trace always produces exactly one GpuTraceCommand).
  - ToGraphNodeDependencies updated to handle GpuTraceCommand (mirrors existing GpuCaseCommand pattern), so trace commands can appear as dependencies without hitting the fatal fallthrough.

  🎯 Justification

  The existing kExplicit mode records each command as a separate CUDA child graph node. For command sequences that execute simple stream operations (e.g., kernel launches, memcpy), the child-graph indirection adds overhead. kCapture mode uses CUDA 12.3+ inline stream capture to fold these commands directly into the outer graph as first-class nodes, eliminating child-graph overhead and enabling more efficient graph
  execution for eligible command sequences.

  🚀 Kind of Contribution

  - Performance Improvement
  - New Feature

  📊 Benchmark (for Performance Improvements)

  (To be filled in — kCapture mode eliminates child-graph node overhead for eligible command sequences. Benchmarks pending.)

  🧪 Unit Tests

  (To be filled in.)

  🧪 Execution Tests

  (To be filled in.)
