### PR TITLE
[XLA:GPU][oneAPI] Register base oneCCL collective support for XLA

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -1,4 +1,5 @@
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
+load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl_is_configured")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/stream_executor:build_defs.bzl", "if_cuda_or_rocm_is_configured")
 load("//xla/tests:build_defs.bzl", "xla_test")
@@ -40,6 +41,8 @@ cc_library(
         ":nccl_or_rccl_collectives",
     ]) + if_cuda_is_configured([
         ":nvshmem_collectives_if_supported",
+    ]) + if_sycl_is_configured([
+        ":oneccl_collectives",
     ]),
 )
 
@@ -512,6 +515,30 @@ cc_library(
         "@local_config_rocm//rocm:rocm_headers",
         "@tsl//tsl/platform:casts",
         "@tsl//tsl/platform:numbers",
+    ],
+    alwayslink = True,  # registers collectives implementation
+)
+
+cc_library(
+    name = "oneccl_collectives",
+    srcs = ["oneccl_collectives.cc"],
+    hdrs = ["oneccl_collectives.h"],
+    tags = [
+        "gpu",
+        "oneapi-only",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":gpu_collectives",
+        "//xla:util",
+        "//xla/core/collectives",
+        "//xla/core/collectives:clique_id",
+        "//xla/core/collectives:clique_key",
+        "//xla/core/collectives:collectives_registry",
+        "//xla/core/collectives:communicator",
+        "//xla/core/collectives:rank_id",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
     ],
     alwayslink = True,  # registers collectives implementation
 )

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -530,7 +530,6 @@ cc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":gpu_collectives",
-        "//xla:util",
         "//xla/core/collectives",
         "//xla/core/collectives:clique_id",
         "//xla/core/collectives:clique_key",
@@ -539,6 +538,7 @@ cc_library(
         "//xla/core/collectives:rank_id",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
     ],
     alwayslink = True,  # registers collectives implementation
 )

--- a/xla/backends/gpu/collectives/oneccl_collectives.cc
+++ b/xla/backends/gpu/collectives/oneccl_collectives.cc
@@ -1,0 +1,23 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/oneccl_collectives.h"
+
+#include <memory>
+
+#include "xla/core/collectives/collectives_registry.h"
+
+XLA_COLLECTIVES_REGISTER("SYCL", "oneccl", 1,
+                         std::make_unique<xla::gpu::OnecclCollectives>());

--- a/xla/backends/gpu/collectives/oneccl_collectives.h
+++ b/xla/backends/gpu/collectives/oneccl_collectives.h
@@ -1,0 +1,74 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_ONECCL_COLLECTIVES_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_ONECCL_COLLECTIVES_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/core/collectives/clique_id.h"
+#include "xla/core/collectives/clique_key.h"
+#include "xla/core/collectives/collectives.h"
+#include "xla/core/collectives/communicator.h"
+#include "xla/core/collectives/rank_id.h"
+
+namespace xla::gpu {
+
+class OnecclCollectives : public GpuCollectives {
+ public:
+  bool IsImplemented() const final { return true; }
+
+  absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
+  CreateCommunicators(const CliqueKey& clique_key,
+                      const std::optional<CliqueIds>& clique_ids,
+                      absl::Span<const DeviceRank> ranks,
+                      const Collectives::Config& config) final {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::unique_ptr<Communicator>> CreateCommunicator() final {
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::vector<std::unique_ptr<Communicator>>> SplitCommunicators(
+      absl::Span<const Communicator* const> comms, int32_t color,
+      absl::Span<const RankId> keys, const Collectives::Config& config,
+      absl::Span<const DeviceRank> ranks) final {
+    return absl::OkStatus();
+  }
+  absl::StatusOr<void*> Allocate(uint64_t bytes) final {
+    return absl::OkStatus();
+  }
+
+  absl::Status Deallocate(void* location) final { return absl::OkStatus(); }
+
+  absl::StatusOr<CliqueIdCallback> InitializeTopology(
+      const Topology& topology) {
+    return nullptr;
+  }
+};
+}  // namespace xla::gpu
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_ONECCL_COLLECTIVES_H_


### PR DESCRIPTION
📝 Summary of Changes
This PR adds skeleton code to register oneCCL oneAPI collectives for Intel GPUs, as a collective backend when XLA is built with SYCL.

🎯 Justification
This is needed to pass unit tests with the error "XLA compiled without GPU collectives support". Subsequent PRs will add full support for oneCCL collectives.

🚀 Kind of Contribution
✨ New Feature
