### PR TITLE
[tsl] Add tsl::TiedAny for tying lifetime of any type

### DIFF
--- a/xla/tsl/util/BUILD
+++ b/xla/tsl/util/BUILD
@@ -415,6 +415,11 @@ tsl_cc_test(
 cc_library(
     name = "tied_ref",
     hdrs = ["tied_ref.h"],
+    deps = [
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
+    ],
 )
 
 tsl_cc_test(

--- a/xla/tsl/util/tied_ref.h
+++ b/xla/tsl/util/tied_ref.h
@@ -21,6 +21,10 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+
 namespace tsl {
 
 template <typename T>
@@ -83,6 +87,7 @@ class TiedRef {
 
  private:
   friend class Tied<T>;
+  friend class TiedAny;
   explicit TiedRef(std::weak_ptr<std::shared_ptr<T>> ptr);
 
   std::weak_ptr<std::shared_ptr<T>> ptr_;
@@ -98,8 +103,8 @@ class Tied {
   Tied() = default;
   ~Tied() = default;
 
-  Tied(Tied&&) = default;
-  Tied& operator=(Tied&&) = default;
+  Tied(Tied&&) = delete;
+  Tied& operator=(Tied&&) = delete;
 
   // Ties ownership of `value` to *this and returns a TiedRef to it. The
   // value is released when the TiedRef is destroyed or when *this is
@@ -108,8 +113,68 @@ class Tied {
   TiedRef<T> Tie(std::unique_ptr<T> value);
 
  private:
-  std::vector<std::shared_ptr<std::shared_ptr<T>>> entries_;
+  absl::Mutex mu_;
+  std::vector<std::shared_ptr<std::shared_ptr<T>>> entries_
+      ABSL_GUARDED_BY(mu_);
 };
+
+// A type-erased container for tied values of heterogeneous types.
+//
+// TiedAny is like Tied<T>, but supports tying values of different types in a
+// single container. Internally, each type T gets its own Tied<T> instance
+// stored in a flat_hash_map keyed by a compile-time type identifier (the same
+// TypeId pattern used by UniqueAny).
+//
+// When the TiedAny container is destroyed, all tied values of all types are
+// destroyed, and all outstanding TiedRefs safely expire. When a TiedRef<T> is
+// destroyed while the container is still alive, the corresponding value is
+// eagerly released.
+//
+// Example:
+//
+//   class Server : private TiedAny {
+//    public:
+//     TiedRef<HttpConn> ConnectHttp() {
+//       return Tie(std::make_unique<HttpConn>());
+//     }
+//     TiedRef<GrpcConn> ConnectGrpc() {
+//       return Tie(std::make_unique<GrpcConn>());
+//     }
+//   };
+//
+class TiedAny {
+ public:
+  TiedAny() = default;
+  ~TiedAny() = default;
+
+  TiedAny(TiedAny&&) = delete;
+  TiedAny& operator=(TiedAny&&) = delete;
+
+  // Ties ownership of `value` to *this and returns a TiedRef<T> to it.
+  // See Tied<T>::Tie for full semantics.
+  template <typename T>
+  TiedRef<T> Tie(std::unique_ptr<T> value);
+
+ private:
+  template <typename T>
+  struct TypeId {
+    static const char kId;
+  };
+
+  struct TiedBase {
+    virtual ~TiedBase() = default;
+  };
+
+  template <typename T>
+  struct TiedTyped : TiedBase, Tied<T> {};
+
+  absl::Mutex mu_;
+  absl::flat_hash_map<const void*, std::unique_ptr<TiedBase>> entries_
+      ABSL_GUARDED_BY(mu_);
+};
+
+template <typename T>
+const char TiedAny::TypeId<T>::kId = 0;
 
 //===----------------------------------------------------------------------===//
 // TiedRef<T> and Tied<T> implementation detail.
@@ -155,6 +220,8 @@ bool TiedRef<T>::Expired() const {
 
 template <typename T>
 TiedRef<T> Tied<T>::Tie(std::unique_ptr<T> value) {
+  absl::MutexLock lock(&mu_);
+
   // Lazy garbage collection: erase entries whose inner shared_ptr was reset
   // by a TiedRef destructor.
   entries_.erase(std::remove_if(entries_.begin(), entries_.end(),
@@ -168,6 +235,16 @@ TiedRef<T> Tied<T>::Tie(std::unique_ptr<T> value) {
   auto& entry = entries_.emplace_back(std::make_shared<std::shared_ptr<T>>(
       std::shared_ptr<T>(value.release())));
   return TiedRef<T>{std::weak_ptr<std::shared_ptr<T>>(entry)};
+}
+
+template <typename T>
+TiedRef<T> TiedAny::Tie(std::unique_ptr<T> value) {
+  absl::MutexLock lock(&mu_);
+  auto& base = entries_[&TypeId<T>::kId];
+  if (!base) {
+    base = std::make_unique<TiedTyped<T>>();
+  }
+  return static_cast<TiedTyped<T>&>(*base).Tie(std::move(value));
 }
 
 }  // namespace tsl

--- a/xla/tsl/util/tied_ref_test.cc
+++ b/xla/tsl/util/tied_ref_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
-#include <utility>
 #include <vector>
 
 #include "xla/tsl/platform/test.h"
@@ -25,8 +24,28 @@ limitations under the License.
 namespace tsl {
 namespace {
 
-// Forward declare.
-class Connection;
+// A Connection tracks its own construction/destruction via an external counter,
+// so tests can verify when tied values are created and released.
+class Connection {
+ public:
+  explicit Connection(int32_t* alive_count) : alive_count_(alive_count) {
+    ++(*alive_count_);
+  }
+  ~Connection() { --(*alive_count_); }
+
+ private:
+  int32_t* alive_count_;
+};
+
+// A second tracked type used by TiedAny tests to verify that heterogeneous
+// types can be tied in a single container.
+struct Widget {
+  explicit Widget(int32_t* alive_count) : alive_count_(alive_count) {
+    ++(*alive_count_);
+  }
+  ~Widget() { --(*alive_count_); }
+  int32_t* alive_count_;
+};
 
 // A Session is a long-lived entity that creates multiple Connections during its
 // lifetime. Connections are tied to the session and expire when the session is
@@ -41,19 +60,6 @@ class Session : private Tied<Connection> {
 
  private:
   int32_t alive_connections_ = 0;
-};
-
-// A Connection tracks its own construction/destruction via an external counter,
-// so tests can verify when tied values are created and released.
-class Connection {
- public:
-  explicit Connection(int32_t* alive_count) : alive_count_(alive_count) {
-    ++(*alive_count_);
-  }
-  ~Connection() { --(*alive_count_); }
-
- private:
-  int32_t* alive_count_;
 };
 
 TEST(TiedRefTest, ConnectionLocksWhileSessionAlive) {
@@ -125,22 +131,60 @@ TEST(TiedRefTest, DefaultTiedRefIsExpired) {
   EXPECT_EQ(ref.Lock(), nullptr);
 }
 
-TEST(TiedRefTest, MoveSession) {
-  Session session;
-  TiedRef<Connection> ref = session.Connect();
-
-  Session moved_session = std::move(session);
-
-  // TiedRef is still valid because tied connections moved with the session.
-  EXPECT_FALSE(ref.Expired());
-  EXPECT_NE(ref.Lock(), nullptr);
-}
-
 TEST(TiedRefTest, TieNullptrReturnsExpiredRef) {
   Tied<Connection> tied;
   TiedRef<Connection> ref = tied.Tie(nullptr);
   EXPECT_TRUE(ref.Expired());
   EXPECT_EQ(ref.Lock(), nullptr);
+}
+
+TEST(TiedAnyTest, TieAndLockMultipleTypes) {
+  TiedAny container;
+  int32_t alive_connections = 0;
+  int32_t alive_widgets = 0;
+
+  TiedRef<Connection> conn_ref =
+      container.Tie(std::make_unique<Connection>(&alive_connections));
+  TiedRef<Widget> widget_ref =
+      container.Tie(std::make_unique<Widget>(&alive_widgets));
+
+  EXPECT_EQ(alive_connections, 1);
+  EXPECT_EQ(alive_widgets, 1);
+  EXPECT_NE(conn_ref.Lock(), nullptr);
+  EXPECT_NE(widget_ref.Lock(), nullptr);
+}
+
+TEST(TiedAnyTest, AllRefsExpireWhenContainerDestroyed) {
+  TiedRef<Connection> conn_ref;
+  TiedRef<Widget> widget_ref;
+  int32_t alive_connections = 0;
+  int32_t alive_widgets = 0;
+
+  {
+    TiedAny container;
+    conn_ref = container.Tie(std::make_unique<Connection>(&alive_connections));
+    widget_ref = container.Tie(std::make_unique<Widget>(&alive_widgets));
+    EXPECT_EQ(alive_connections, 1);
+    EXPECT_EQ(alive_widgets, 1);
+  }
+
+  EXPECT_TRUE(conn_ref.Expired());
+  EXPECT_TRUE(widget_ref.Expired());
+  EXPECT_EQ(alive_connections, 0);
+  EXPECT_EQ(alive_widgets, 0);
+}
+
+TEST(TiedAnyTest, EagerReleaseOnRefDestruction) {
+  TiedAny container;
+  int32_t alive_connections = 0;
+
+  {
+    TiedRef<Connection> ref =
+        container.Tie(std::make_unique<Connection>(&alive_connections));
+    EXPECT_EQ(alive_connections, 1);
+  }
+
+  EXPECT_EQ(alive_connections, 0);
 }
 
 }  // namespace


### PR DESCRIPTION
- Added `absl::MutexLock` to `Tied<T>::Tie()` to properly synchronize access to `entries_` 
- Made `Tied<T>` non-movable (mutex is not movable)
- Implemented `TiedAny` — a type-erased container that ties values of heterogeneous types. Uses `TypeId` (same pattern as `UniqueAny`) to key a `flat_hash_map` of `Tied<T>` instances, each behind a `TiedBase`/`TiedTyped<T>` type-erasure layer