### PR TITLE
[xla:gpu] Use MakeFutureWhenReady(...).OnReady() instead of ScheduleW…

### DIFF
--- a/xla/BUILD
+++ b/xla/BUILD
@@ -433,7 +433,10 @@ cc_library(
     name = "future",
     hdrs = ["future.h"],
     visibility = ["//visibility:public"],
-    deps = ["//xla/tsl/concurrency:future"],
+    deps = [
+        "//xla/tsl/concurrency:future",
+        "//xla/tsl/concurrency:interop",
+    ],
 )
 
 cc_library(

--- a/xla/future.h
+++ b/xla/future.h
@@ -16,7 +16,8 @@ limitations under the License.
 #ifndef XLA_FUTURE_H_
 #define XLA_FUTURE_H_
 
-#include "xla/tsl/concurrency/future.h"  // IWYU pragma: export
+#include "xla/tsl/concurrency/future.h"   // IWYU pragma: export
+#include "xla/tsl/concurrency/interop.h"  // IWYU pragma: export
 
 namespace xla {
 
@@ -24,6 +25,7 @@ using ::tsl::Future;
 using ::tsl::FutureHelpers;
 using ::tsl::JoinFutures;
 using ::tsl::MakeFutureOn;
+using ::tsl::MakeFutureWhenReady;
 using ::tsl::MakePromise;
 using ::tsl::Promise;
 

--- a/xla/pjrt/raw_buffer.cc
+++ b/xla/pjrt/raw_buffer.cc
@@ -84,33 +84,29 @@ void CommonPjRtRawBuffer::ScheduleCopyTo(
     tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
     tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
     tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise,
-    ::tsl::AsyncValueRef<bool> allocation_event) {
-  absl::Span<const tsl::RCReference<tsl::AsyncValue>> definition_events_span =
-      transfer_dependency_avs;
-  async_work_runner->ScheduleWhenReady(
-      definition_events_span,
-      [src_raw_buffer = tsl::FormRef(this),
-       dst_raw_buffer = std::move(dst_raw_buffer),
-       transfer_dependency_avs = std::move(transfer_dependency_avs),
-       definition_event_promise = std::move(definition_event_promise),
-       src_usage_event_promise = std::move(src_usage_event_promise),
-       allocation_event = std::move(allocation_event)]() {
-        for (const auto& av : transfer_dependency_avs) {
-          if (auto* error = av->GetErrorIfPresent()) {
-            auto status = *error;
-            if (allocation_event) {
-              allocation_event.SetError(status);
-            }
-            definition_event_promise->SetError(status);
-            src_usage_event_promise->SetError(status);
-            return;
-          }
-        }
+    tsl::AsyncValueRef<bool> allocation_event) {
+  MakeFutureWhenReady(transfer_dependency_avs)
+      .OnReady(*async_work_runner,
+               [src_raw_buffer = tsl::FormRef(this),
+                dst_raw_buffer = std::move(dst_raw_buffer),
+                definition_event_promise = std::move(definition_event_promise),
+                src_usage_event_promise = std::move(src_usage_event_promise),
+                allocation_event =
+                    std::move(allocation_event)](absl::Status status) {
+                 if (!status.ok()) {
+                   if (allocation_event) {
+                     allocation_event.SetError(status);
+                   }
+                   definition_event_promise->SetError(status);
+                   src_usage_event_promise->SetError(status);
+                   return;
+                 }
 
-        src_raw_buffer->CopyTo(
-            std::move(dst_raw_buffer), std::move(definition_event_promise),
-            std::move(src_usage_event_promise), std::move(allocation_event));
-      });
+                 src_raw_buffer->CopyTo(std::move(dst_raw_buffer),
+                                        std::move(definition_event_promise),
+                                        std::move(src_usage_event_promise),
+                                        std::move(allocation_event));
+               });
 }
 
 absl::StatusOr<tsl::RCReference<PjRtRawBuffer>>

--- a/xla/pjrt/raw_buffer.h
+++ b/xla/pjrt/raw_buffer.h
@@ -16,7 +16,10 @@ limitations under the License.
 #ifndef XLA_PJRT_RAW_BUFFER_H_
 #define XLA_PJRT_RAW_BUFFER_H_
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -27,6 +30,7 @@ limitations under the License.
 #include "xla/pjrt/device_event.h"
 #include "xla/shape.h"
 #include "xla/tsl/concurrency/async_value.h"
+#include "xla/tsl/concurrency/async_value_ref.h"
 #include "xla/tsl/concurrency/ref_count.h"
 
 namespace xla {
@@ -157,7 +161,7 @@ class CommonPjRtRawBuffer : public PjRtRawBuffer {
       tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
       tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
       tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise,
-      ::tsl::AsyncValueRef<bool> allocation_event) = 0;
+      tsl::AsyncValueRef<bool> allocation_event) = 0;
 
   // Blocks on a list of dependencies and then copies directly into
   // dst_raw_buffer. Must set definition_event_promise,
@@ -169,7 +173,7 @@ class CommonPjRtRawBuffer : public PjRtRawBuffer {
       tsl::RCReference<CommonPjRtRawBuffer> dst_raw_buffer,
       tsl::RCReference<PjRtDeviceEventPromise> definition_event_promise,
       tsl::RCReference<PjRtDeviceEventPromise> src_usage_event_promise,
-      ::tsl::AsyncValueRef<bool> allocation_event);
+      tsl::AsyncValueRef<bool> allocation_event);
 
   // Returns the async value associated with the buffer.
   virtual absl::StatusOr<tsl::RCReference<tsl::AsyncValue>>


### PR DESCRIPTION
Use standard concurrency features for scheduling callbacks.