### PR TITLE
[XLA] Collective combiner: skip reachable instructions instead of breaking

### DIFF
--- a/xla/hlo/transforms/collectives/collective_permute_combiner_test.cc
+++ b/xla/hlo/transforms/collectives/collective_permute_combiner_test.cc
@@ -344,5 +344,52 @@ ENTRY %CombineCollectivePermutes () -> (f32[256], f32[512], f32[2560], f32[1792]
   EXPECT_TRUE(changed);
 }
 
+// Tests that independent collective permutes separated by interleaved
+// dependency chains are combined. Two chains: cp_A→cp_B and cp_C→cp_D.
+// Topological order: A, B, C, D. With the fix (continue instead of break),
+// A and C get combined, B and D get combined → 2 ops.
+// Without the fix (break), A becomes a singleton, B+C get combined, D becomes
+// a singleton → 3 ops.
+TEST_F(CollectivePermuteCombinerTest, CombineAcrossInterleavedDependencyChains) {
+  auto module = CreateNewVerifiedModule();
+
+  HloComputation::Builder b(TestName());
+  const std::vector<std::pair<int64_t, int64_t>> source_target_pairs{{0, 1}};
+  Shape shape = ShapeUtil::MakeShape(F32, {256});
+
+  // Chain 1: constant1 → broadcast1 → cp_A → cp_B
+  auto constant1 = b.AddInstruction(
+      HloInstruction::CreateConstant(LiteralUtil::CreateR0(1.0)));
+  auto input_a =
+      b.AddInstruction(HloInstruction::CreateBroadcast(shape, constant1, {}));
+  auto cp_a = b.AddInstruction(HloInstruction::CreateCollectivePermute(
+      shape, input_a, source_target_pairs, /*channel_id=*/std::nullopt));
+  auto cp_b = b.AddInstruction(HloInstruction::CreateCollectivePermute(
+      shape, cp_a, source_target_pairs, /*channel_id=*/std::nullopt));
+
+  // Chain 2: constant3 → broadcast3 → cp_C → cp_D
+  auto constant3 = b.AddInstruction(
+      HloInstruction::CreateConstant(LiteralUtil::CreateR0(3.0)));
+  auto input_c =
+      b.AddInstruction(HloInstruction::CreateBroadcast(shape, constant3, {}));
+  auto cp_c = b.AddInstruction(HloInstruction::CreateCollectivePermute(
+      shape, input_c, source_target_pairs, /*channel_id=*/std::nullopt));
+  auto cp_d = b.AddInstruction(HloInstruction::CreateCollectivePermute(
+      shape, cp_c, source_target_pairs, /*channel_id=*/std::nullopt));
+
+  b.AddInstruction(HloInstruction::CreateTuple({cp_a, cp_b, cp_c, cp_d}));
+  module->AddEntryComputation(b.Build());
+
+  ASSERT_EQ(CollectivePermuteCount(*module), 4);
+
+  CollectivePermuteCombiner combine(1024 * 1024, kMaxCombineCount);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, combine.Run(module.get()));
+
+  // With continue: combine(A,C) + combine(B,D) → 2 ops.
+  // With break: A singleton + combine(B,C) + D singleton → 3 ops.
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(CollectivePermuteCount(*module), 2);
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/collective_combiner_utils.h
+++ b/xla/service/collective_combiner_utils.h
@@ -148,8 +148,8 @@ absl::StatusOr<bool> CombineInstructionsByKey(
             return reachable;
           });
       if (is_reachable) {
-        VLOG(1) << "Instruction is reachable.";
-        break;
+        VLOG(1) << "Instruction is reachable, skipping.";
+        continue;
       }
 
       VLOG(1) << "Adding instruction to set.";


### PR DESCRIPTION
## Summary

- Change `break` to `continue` in `CombineInstructionsByKey` when a reachable (dependent) instruction is encountered, so the combiner skips it and keeps scanning for independent instructions instead of stopping early
- This is a one-line fix to a shared template in `collective_combiner_utils.h` that benefits all four collective combiners (AllReduce, AllGather, ReduceScatter, CollectivePermute)
- Add `CombineAcrossInterleavedDependencyChains` test that fails with `break` (3 ops) and passes with `continue` (2 ops)

## Motivation

When iterating in topological order, the combiner would `break` on the first dependent instruction — missing independent instructions further down. With two interleaved dependency chains (A→B, C→D), the old behavior produces 3 ops (A singleton, B+C combined, D singleton) instead of the optimal 2 ops (A+C combined, B+D combined).

## Test plan

- [x] Existing `collective_permute_combiner_test` (7 tests) pass
- [x] New `CombineAcrossInterleavedDependencyChains` test passes with fix, fails without
- [x] `all_reduce_combiner_test`, `all_gather_combiner_test`, `reduce_scatter_combiner_test` all pass
- [x] GPU and CPU backend combiner tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)