### PR TITLE
[XLA:GPU][oneAPI][Bug fix] Add autotune cache key for oneapi device description

### DIFF
--- a/xla/service/gpu/autotuning/autotune_cache_key.cc
+++ b/xla/service/gpu/autotuning/autotune_cache_key.cc
@@ -60,11 +60,11 @@ std::string AutotuneCacheKey::DeviceDescriptionToCacheKey(
   } else if (auto* rcc = device_description.gpu_compute_capability()
                              .rocm_compute_capability()) {
     compute_capability = absl::StrCat("ROCM: ", rcc->gfx_version());
-  } else {
-    auto* oneapi_cc =
-        device_description.gpu_compute_capability().oneapi_compute_capability();
-    CHECK(oneapi_cc != nullptr) << "Unknown compute capability type";
+  } else if (auto* oneapi_cc = device_description.gpu_compute_capability()
+                                   .oneapi_compute_capability()) {
     compute_capability = absl::StrCat("oneAPI: ", oneapi_cc->ToString());
+  } else {
+    LOG(FATAL) << "Unknown compute capability type";
   }
 
   // The string below should include only as much information as is needed to

--- a/xla/service/gpu/autotuning/autotune_cache_key.cc
+++ b/xla/service/gpu/autotuning/autotune_cache_key.cc
@@ -57,11 +57,14 @@ std::string AutotuneCacheKey::DeviceDescriptionToCacheKey(
   if (auto* ccc = device_description.gpu_compute_capability()
                       .cuda_compute_capability()) {
     compute_capability = absl::StrCat("CUDA: ", ccc->major, ".", ccc->minor);
-  } else {
-    auto* rcc =
-        device_description.gpu_compute_capability().rocm_compute_capability();
-    CHECK(rcc != nullptr) << "Unknown compute capability type";
+  } else if (auto* rcc = device_description.gpu_compute_capability()
+                             .rocm_compute_capability()) {
     compute_capability = absl::StrCat("ROCM: ", rcc->gfx_version());
+  } else {
+    auto* oneapi_cc =
+        device_description.gpu_compute_capability().oneapi_compute_capability();
+    CHECK(oneapi_cc != nullptr) << "Unknown compute capability type";
+    compute_capability = absl::StrCat("oneAPI: ", oneapi_cc->ToString());
   }
 
   // The string below should include only as much information as is needed to

--- a/xla/service/gpu/autotuning/autotune_cache_key_test.cc
+++ b/xla/service/gpu/autotuning/autotune_cache_key_test.cc
@@ -91,6 +91,11 @@ TEST(AutotuneCacheKeyTest, DeviceDescriptionToCacheKey) {
                 device_description("mi200.txtpb")),
             "ROCM: gfx90a, Cores: 110, GPU clock: 1.7 GHz, Memory bandwidth: "
             "1638 GB/s, L2 cache: 8 MB, DNN version: 0.0.0");
+
+  EXPECT_EQ(AutotuneCacheKey::DeviceDescriptionToCacheKey(
+                device_description("bmg_g21.txtpb")),
+            "oneAPI: BMG, Cores: 20, GPU clock: 2.85 GHz, Memory "
+            "bandwidth: 456 GB/s, L2 cache: 18 MB, DNN version: 0.0.0");
 }
 
 TEST(AutotuneCacheKeyTest, VersionIsIncludedInCacheKey) {

--- a/xla/stream_executor/sycl/oneapi_compute_capability.cc
+++ b/xla/stream_executor/sycl/oneapi_compute_capability.cc
@@ -45,8 +45,7 @@ OneAPIComputeCapabilityProto OneAPIComputeCapability::ToProto() const {
 std::string OneAPIComputeCapability::ToString() const {
   // TODO(intel-tf): Remove proto conversion and expose utility methods to get
   // device architecture.
-  auto proto = ToProto();
-  return proto.architecture();
+  return ToProto().architecture();
 }
 
 std::pair<uint32_t, uint32_t> OneAPIComputeCapability::BaseVersionTupleFor(

--- a/xla/stream_executor/sycl/oneapi_compute_capability.cc
+++ b/xla/stream_executor/sycl/oneapi_compute_capability.cc
@@ -43,7 +43,10 @@ OneAPIComputeCapabilityProto OneAPIComputeCapability::ToProto() const {
 }
 
 std::string OneAPIComputeCapability::ToString() const {
-  return absl::StrCat(generation_, ".", version_);
+  // TODO(intel-tf): Remove proto conversion and expose utility methods to get
+  // device architecture.
+  auto proto = ToProto();
+  return proto.architecture();
 }
 
 std::pair<uint32_t, uint32_t> OneAPIComputeCapability::BaseVersionTupleFor(

--- a/xla/stream_executor/sycl/oneapi_compute_capability_test.cc
+++ b/xla/stream_executor/sycl/oneapi_compute_capability_test.cc
@@ -42,7 +42,7 @@ TEST(OneAPIComputeCapabilityTest, ToProtoTest2) {
 }
 
 TEST(OneAPIComputeCapabilityTest, ToString) {
-  EXPECT_EQ(OneAPIComputeCapability(100, 20).ToString(), "100.20");
+  EXPECT_EQ(OneAPIComputeCapability::BMG().ToString(), "BMG");
 }
 
 TEST(OneAPIComputeCapabilityTest, PlatformCCTest) {


### PR DESCRIPTION
This PR fixes `nullptr` issue of `gpu_compute_capability` for oneAPI device description in the `AutotuneCacheKey::DeviceDescriptionToCacheKey`.