### PR TITLE
[XLA:GPU] Add end-to-end test for VMM memory allocator

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/pjrt/gpu/se_gpu_pjrt_client.h"
 
-#include <stdlib.h>
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -3618,6 +3616,44 @@ TEST(StreamExecutorGpuClientTest, VmmAllocatorCanBeSet) {
   EXPECT_NE(dynamic_cast<se::gpu::CudaDeviceAddressVmmAllocator*>(
                 pjrt_se_client->allocator()),
             nullptr);
+}
+
+TEST(StreamExecutorGpuClientTest, VmmAllocatorE2ETest) {
+  GpuClientOptions options;
+  options.allocator_config.kind = GpuAllocatorConfig::Kind::kVmm;
+  options.allowed_devices = {0};
+
+  TF_ASSERT_OK_AND_ASSIGN(auto client, GetStreamExecutorGpuClient(options));
+
+  static constexpr char kAddProgram[] = R"(
+HloModule Add, entry_computation_layout={(f32[], f32[])->f32[]}
+ENTRY main (a: f32[], b: f32[]) -> f32[] {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  ROOT add = f32[] add(a, b)
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable,
+                          CompileExecutable(kAddProgram, *client));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto* memory_space,
+      client->addressable_devices()[0]->default_memory_space());
+  Literal literal_a = LiteralUtil::CreateR0<float>(1.0f);
+  Literal literal_b = LiteralUtil::CreateR0<float>(2.0f);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto a, client->BufferFromHostLiteral(literal_a, memory_space));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto b, client->BufferFromHostLiteral(literal_b, memory_space));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto results, executable->Execute({{a.get(), b.get()}}, /*options=*/{}));
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_EQ(results[0].size(), 1);
+
+  TF_ASSERT_OK_AND_ASSIGN(std::shared_ptr<Literal> literal,
+                          results[0][0]->ToLiteral().Await());
+  EXPECT_EQ(literal->Get<float>({}), 3.0f);
 }
 #endif  // GOOGLE_CUDA
 

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -407,6 +407,7 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
     ],
 )
 

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -407,7 +407,6 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:errors",
-        "@tsl//tsl/platform:statusor",
     ],
 )
 


### PR DESCRIPTION
  [XLA:GPU] Add end-to-end test for VMM memory allocator

  Summary

  - Adds VmmAllocatorE2ETest to se_gpu_pjrt_client_test.cc that exercises the full execution path with GpuAllocatorConfig::Kind::kVmm enabled — compiling an HLO addition program, allocating input buffers, executing, and verifying the result.
  - Adds @tsl//tsl/platform:statusor as a missing dependency in xla/stream_executor/BUILD.
  - Removes unused <stdlib.h> include from the test file.

  Background

  PR #38955 introduced CudaDeviceAddressVmmAllocator and wired it into the GPU client via GpuAllocatorConfig::Kind::kVmm. The existing VmmAllocatorCanBeSet test only validated that the allocator object is set correctly via dynamic cast. This PR adds a true end-to-end execution test to confirm the VMM allocator works correctly during actual compute.

  Test plan

  - Build and run //xla/pjrt/gpu:se_gpu_pjrt_client_test on a CUDA-capable GPU
  - Verify VmmAllocatorE2ETest passes (scalar 1.0 + 2.0 = 3.0 with VMM allocator active)
  - Verify existing VmmAllocatorCanBeSet test still passes
