### PR TITLE
[ROCm] Set jobs timeout, preventing blocking nodes

### DIFF
--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -79,6 +79,7 @@ jobs:
           JAXCI_BUILD_JAX: "true"
           JAXCI_BUILD_JAXLIB: wheel
         working-directory: jax
+        timeout-minutes: 120
         run: |
           ./ci/run_bazel_test_rocm_rbe.sh \
             --override_repository=xla=${GITHUB_WORKSPACE} \

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -78,12 +78,14 @@ jobs:
           docker exec ${{ env.CONTAINER_NAME }} bash -c "/opt/rocm/bin/rocminfo"
 
       - name: Test XLA [single_gpu]
+        timeout-minutes: 60
         run: |
           docker exec \
             ${{ env.CONTAINER_NAME }} \
             bash -c "build_tools/rocm/execute_ci_build.sh --config=ci_single_gpu --local_test_jobs=2 --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}"
 
       - name: Test XLA [multi_gpu]
+        timeout-minutes: 80
         if: always()
         run: |
           docker exec \


### PR DESCRIPTION
📝 Summary of Changes
Set ci jobs timeouts

🎯 Justification
Timeout job if the test execution takes way too long time,
this is required to not block the consequent ci jobs from execution
if one is taking too long time

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant, ci job adaption

🧪 Unit Tests:
Not relevant, ci job adaption

🧪 Execution Tests:
Not relevant, ci job adaption
