### PR TITLE
[ROCm] Fix fp8 on ROCm when xla_gpu_enable_cublaslt=false

### DIFF
--- a/xla/backends/gpu/autotuner/factory_rocm.cc
+++ b/xla/backends/gpu/autotuner/factory_rocm.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_XLA_BACKENDS_GPU_AUTOTUNER_ROCM_FACTORY_H_
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -49,18 +50,20 @@ namespace gpu {
 namespace {
 
 using ::mlir::MLIRContext;
+using DType = GemmRewriterOptions::DType;
+
+constexpr std::array kFp8OnlyDTypes = {DType::kFp8Only};
+constexpr std::array kAllDTypes = {DType::kFp8Only, DType::kNonFp8Only};
 
 std::unique_ptr<HloPassPipeline> GetGemmRewriterPipeline(
     const stream_executor::DeviceDescription& device_description,
-    bool enable_cublaslt) {
+    bool enable_cublaslt, absl::Span<const DType> dtypes) {
   auto pipeline = std::make_unique<HloPassPipeline>(
       enable_cublaslt ? "hipblaslt_rewriter_pipeline"
                       : "rocblas_rewriter_pipeline");
   pipeline->AddPass(std::make_unique<DotAlgorithmRewriter>());
   pipeline->AddPass(std::make_unique<ScaledDotRewriter>());
-  for (GemmRewriterOptions::DType dtype :
-       {GemmRewriterOptions::DType::kFp8Only,
-        GemmRewriterOptions::DType::kNonFp8Only}) {
+  for (DType dtype : dtypes) {
     GemmRewriterOptions options{dtype};
     options.enable_cublaslt = enable_cublaslt;
     auto gemm_rewriter = std::make_unique<GemmRewriter>(
@@ -93,14 +96,17 @@ std::vector<std::unique_ptr<CodegenBackend>> GetCodegenBackendsForROCm(
       std::make_unique<RocblasBackend>(stream_executor, debug_options, compiler,
                                        target_config),
       GetGemmRewriterPipeline(target_config->device_description,
-                              /*enable_cublaslt=*/false),
+                              /*enable_cublaslt=*/false, kAllDTypes),
       alias_info, mlir_context));
+  bool enable_cublaslt = debug_options->xla_gpu_enable_cublaslt();
   backends.push_back(std::make_unique<FissionBackend>(
       debug_options, compiler, target_config,
       std::make_unique<HipblasLtBackend>(stream_executor, debug_options,
                                          compiler, target_config),
-      GetGemmRewriterPipeline(target_config->device_description,
-                              /*enable_cublaslt=*/true),
+      GetGemmRewriterPipeline(
+          target_config->device_description, /*enable_cublaslt=*/true,
+          enable_cublaslt ? absl::Span<const DType>(kAllDTypes)
+                          : kFp8OnlyDTypes),
       alias_info, mlir_context));
   if (!backend_allowlist.empty()) {
     backends.erase(

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -3373,8 +3373,10 @@ GpuCompiler::GetAutotunerBackends(
   if (!debug_options.xla_gpu_enable_cublaslt()) {
     disabled_autotune_backends.push_back(autotuner::Backend::CUBLASLT);
     disabled_autotune_backends.push_back(autotuner::Backend::CUBLASLT_FISSION);
-    disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT);
-    disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT_FISSION);
+    // NOTE(ROCm): Do not disable hipblaslt backends even with
+    // xla_gpu_enable_cublaslt=false since we need them for fp8
+    // disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT);
+    // disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT_FISSION);
   } else {
     // Breaks xla/backends/gpu/transforms:gemm_rewriter_test_b200, it requires
     // CUBLAS and CUBLASLT both to be available. TODO: fix tests and uncomment.

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -3375,8 +3375,6 @@ GpuCompiler::GetAutotunerBackends(
     disabled_autotune_backends.push_back(autotuner::Backend::CUBLASLT_FISSION);
     // NOTE(ROCm): Do not disable hipblaslt backends even with
     // xla_gpu_enable_cublaslt=false since we need them for fp8
-    // disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT);
-    // disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT_FISSION);
   } else {
     // Breaks xla/backends/gpu/transforms:gemm_rewriter_test_b200, it requires
     // CUBLAS and CUBLASLT both to be available. TODO: fix tests and uncomment.


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/openxla/xla/pull/38792 where the hipBLASLt autotuner backend is fully disabled when `xla_gpu_enable_cublaslt=false`. However, on ROCm we always need hipBLASLt for fp8.

🚀 Kind of Contribution
🐛 Bug Fix

