### PR TITLE
[ROCm] Remove the second timeout definition form rocm_jax_ut workflow

### DIFF
--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -79,7 +79,6 @@ jobs:
           JAXCI_BUILD_JAX: "true"
           JAXCI_BUILD_JAXLIB: wheel
         working-directory: jax
-        timeout-minutes: 120
         run: |
           ./ci/run_bazel_test_rocm_rbe.sh \
             --override_repository=xla=${GITHUB_WORKSPACE} \


### PR DESCRIPTION
📝 Summary of Changes
 Remove the second timeout definition form rocm_jax_ut workflow

🎯 Justification
It fixes:

 Invalid workflow file

(Line: 82, Col: 9): 'timeout-minutes' is already defined

This was introduced in 08de72604a2eed40

🚀 Kind of Contribution
🐛 Bug Fix
