### PR TITLE
[NVIDIA GPU] Added annotation to allow scheduling of custom communication kernels

### DIFF
--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -2830,5 +2830,61 @@ TEST_F(CollectiveOpsTestE2E, MultipleModuleDifferentDeviceGroupsShouldRun) {
                                                  {&input_literal2_3},
                                                  {&input_literal2_4}}));
 }
+
+TEST_F(CollectiveOpsTestE2E, CustomCollectiveCallShouldRun) {
+  const absl::string_view kModuleStr_1 = R"(
+  HloModule test
+
+  apply_op {
+    x = f32[] parameter(0)
+    y = f32[] parameter(1)
+    ROOT apply_op = f32[] add(x, y)
+  }
+  sub {
+    lhs = f32[4] parameter(0)
+    rhs = f32[4] parameter(1)
+    ROOT sub = f32[4] subtract(lhs, rhs)
+  }
+  ENTRY test_computation {
+    param_0 = f32[4] parameter(0)
+    all-reduce = f32[4] all-reduce(param_0), to_apply=apply_op, replica_groups={{0,1}}
+    call1 = f32[4] call(param_0, param_0), to_apply=sub, frontend_attributes={_xla_stream_annotation="collective", inlineable="false"}
+    ROOT add =  f32[4] add(call1, all-reduce)
+  }
+  )";
+
+  const int64_t kNumReplicas_1 = 2;
+  if (device_count() < kNumReplicas_1) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas_1 << " devices ("
+                 << device_count() << " available)";
+  }
+
+  HloModuleConfig config_1 =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas_1);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_1,
+                          ParseAndReturnVerifiedModule(kModuleStr_1, config_1));
+
+  int64_t num_elements_1 = ShapeUtil::ElementsIn(
+      module_1->entry_computation()->parameter_instructions()[0]->shape());
+
+  Array<float> input1_1({num_elements_1}), input1_2({num_elements_1});
+  input1_1.Fill(1.0f);
+  input1_2.Fill(1.0f);
+
+  Literal input_literal1_1 = LiteralUtil::CreateFromArray(input1_1);
+  Literal input_literal1_2 = LiteralUtil::CreateFromArray(input1_2);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result_1,
+      ExecuteReplicated(std::move(module_1),
+                        std::vector<std::vector<Literal*>>{
+                            {&input_literal1_1}, {&input_literal1_2}}));
+  Literal expected = LiteralUtil::CreateR1<float>({2, 2, 2, 2});
+  for (const Literal& result : execution_result_1.results) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
+  }
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3467,6 +3467,7 @@ cc_library(
     srcs = ["execution_stream_assignment.cc"],
     hdrs = ["execution_stream_assignment.h"],
     deps = [
+        ":gpu_latency_hiding_scheduler",
         "//xla:side_effect_util",
         "//xla/backends/gpu/runtime:execution_stream_id",
         "//xla/hlo/ir:hlo",
@@ -3506,6 +3507,7 @@ cc_library(
         ":backend_configs_cc",
         ":cublas_cudnn",
         "//xla:shape_util",
+        "//xla:side_effect_util",
         "//xla/backends/gpu/transforms/collectives:collective_ops_utils",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/utils:hlo_query",

--- a/xla/service/gpu/execution_stream_assignment.cc
+++ b/xla/service/gpu/execution_stream_assignment.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -35,6 +36,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/collective_opt_utils.h"
+#include "xla/service/gpu/gpu_latency_hiding_scheduler.h"
 #include "xla/side_effect_util.h"
 
 namespace xla::gpu {
@@ -120,8 +122,9 @@ std::optional<ExecutionScopeKind> IsExecutionScopeStart(
     const HloInstruction* hlo) {
   // Async operation that starts a new execution scope.
   if (auto* start = DynCast<HloAsyncStartInstruction>(hlo)) {
-    return IsWrappedCollective(start) ? ExecutionScopeKind::kCommunication
-                                      : ExecutionScopeKind::kCompute;
+    return IsWrappedCollective(start) || IsCustomCollectiveOp(start)
+               ? ExecutionScopeKind::kCommunication
+               : ExecutionScopeKind::kCompute;
   }
 
   // Async-collective operations not yet migrated to async wrappers.
@@ -149,7 +152,9 @@ std::optional<ExecutionScopeKind> IsExecutionScopeStart(
 std::optional<ExecutionStreamId> FindAssignedStreamId(
     const HloInstruction* instr, ExecutionScopeKind kind) {
   auto& attrs = instr->frontend_attributes().map();
-  if (auto it = attrs.find(kXlaStreamAnnotationAttr); it != attrs.end()) {
+  if (auto it = attrs.find(kXlaStreamAnnotationAttr);
+      it != attrs.end() &&
+      !absl::EqualsIgnoreCase(it->second, kXlaCollectiveStreamAnnotation)) {
     int32_t assigned_stream_id;
     CHECK(absl::SimpleAtoi(it->second, &assigned_stream_id));  // Crash OK
     switch (kind) {

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "xla/service/latency_hiding_scheduler.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
+#include "xla/side_effect_util.h"
 #include "xla/stream_executor/stream_executor.h"
 
 namespace xla {
@@ -270,7 +271,8 @@ bool GpuScheduleCrossesOverlapLimit(
   if (resource_type == xla::ResourceTypeToIndex(
                            GpuResourceType::kGpuAsyncStreamCollectives) &&
       sched_state.resource_occupiers_in_flight.contains(resource_type) &&
-      !sched_state.resource_occupiers_in_flight.at(resource_type).empty()) {
+      !sched_state.resource_occupiers_in_flight.at(resource_type).empty() &&
+      !IsCustomCollectiveOp(&node->GetInstr())) {
     const HloInstruction& curr_hlo_inst = node->GetInstr();
     if (sched_state.async_tracker->IsSupportedAsyncDone(curr_hlo_inst)) {
       CHECK(
@@ -435,7 +437,8 @@ ResourcesVector GpuAsyncTracker::GetResourcesFromInstructionImpl(
       usage = op.outer == HloOpcode::kAsyncStart
                   ? ResourceUsageType::kResourceRelease
                   : ResourceUsageType::kResourceOccupy;
-      resource = hlo_query::IsCollectiveCommunicationOp(op.inner)
+      resource = hlo_query::IsCollectiveCommunicationOp(op.inner) ||
+                         IsCustomCollectiveOp(&instr)
                      ? GpuResourceType::kGpuAsyncStreamCollectives
                      : GpuResourceType::kGpuAsyncStreamComputes;
     }
@@ -698,6 +701,19 @@ void GPUProfileStatisticsAggregator::HandleMissingInstructionLatency(
 void GPUProfileStatisticsAggregator::HandleFoundInstructionLatency(
     const HloInstruction& from, const HloInstruction& to) {
   found_instructions_count_++;
+}
+
+// Checks if the async instruction is a custom collective call
+bool IsCustomCollectiveOp(const HloInstruction* instr) {
+  if (instr->opcode() == HloOpcode::kAsyncStart ||
+      instr->opcode() == HloOpcode::kAsyncDone ||
+      instr->opcode() == HloOpcode::kAsyncUpdate) {
+    auto& attrs = instr->frontend_attributes().map();
+    if (auto it = attrs.find(kXlaStreamAnnotationAttr); it != attrs.end()) {
+      return absl::EqualsIgnoreCase(it->second, kXlaCollectiveStreamAnnotation);
+    }
+  }
+  return false;
 }
 
 }  // namespace gpu

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.h
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.h
@@ -157,6 +157,9 @@ class GPUProfileStatisticsAggregator : public ProfileStatisticsAggregator {
                                      const HloInstruction& to) override;
 };
 
+// Checks if the async instruction is a custom collective call.
+bool IsCustomCollectiveOp(const HloInstruction* instr);
+
 }  // namespace gpu
 }  // namespace xla
 

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1241,5 +1241,55 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
       GetIndexByName(instruction_sequence, "all-to-all-start.4"));
 }
 
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       CollectiveStreamAnnotatedOpShouldBeScheduled) {
+  absl::string_view kHloModule = R"(
+HloModule m
+
+reduce {
+  x = f32[] parameter(0)
+  y = f32[] parameter(1)
+  ROOT _ = f32[] add(x, y)
+}
+
+sub (lhs: f32[2]) -> f32[2] {
+  lhs = f32[2] parameter(0)
+  c1 = f32[] constant(1)
+  rhs = f32[2] broadcast(c1), dimensions={}
+  ROOT sub = f32[2] subtract(f32[2] lhs, f32[2] rhs)
+}
+ENTRY main {
+  p0 = f32[] parameter(0)
+  p1 = f32[2] parameter(1)
+  p2 = f32[2] parameter(2)
+  p3 = f32[2] parameter(3)
+  p6 = f32[2] parameter(4)
+  ar_0 = f32[] all-reduce-start(p0), to_apply=reduce
+  ar_1 = f32[] all-reduce-done(ar_0)
+  add_2 = f32[2] add(p1, p6)
+
+  call-start = ((f32[2]), f32[2]) call-start(p2), to_apply=sub, frontend_attributes={_xla_stream_annotation="collective"}
+  call-done = f32[2] call-done(call-start), frontend_attributes={_xla_stream_annotation="collective"}
+  add_3 = f32[2] add(p1, p3)
+  ROOT _ = (f32[], f32[2], f32[2], f32[2]) tuple(ar_1, add_2, call-done, add_3)
+}
+)";
+  absl::string_view kFdoProfile = "";
+
+  auto config = GetModuleConfig(kFdoProfile);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
+
+  TF_EXPECT_OK(ScheduleModule(module.get()));
+  auto schedule = module->schedule();
+  std::vector<HloInstruction*> instruction_sequence =
+      schedule.sequence(module->entry_computation()).instructions();
+  // Index of call-done should be larger than ar_0
+  // since it's treated as native collective and cannot overlap with
+  // native collectives.
+  EXPECT_TRUE(GetIndexByName(instruction_sequence, "call-done") <
+              GetIndexByName(instruction_sequence, "ar_0"));
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/side_effect_util.cc
+++ b/xla/side_effect_util.cc
@@ -67,6 +67,8 @@ const char kXlaBufferPlacementParam[] = "arg";
 
 const char kXlaStreamAnnotationAttr[] = "_xla_stream_annotation";
 
+const char kXlaCollectiveStreamAnnotation[] = "collective";
+
 const char kXlaCollectiveMatmulAttr[] = "_xla_collective_matmul";
 
 const char kXlaCollectiveMatmulLhsAg[] = "lhs_ag";

--- a/xla/side_effect_util.h
+++ b/xla/side_effect_util.h
@@ -78,6 +78,7 @@ extern const char kXlaBufferPlacementParam[];
 
 // XLA frontend attribute for stream annotation.
 extern const char kXlaStreamAnnotationAttr[];
+extern const char kXlaCollectiveStreamAnnotation[];
 
 // XLA frontend attribute for collective matmul control.
 extern const char kXlaCollectiveMatmulAttr[];


### PR DESCRIPTION
Currently all FFIs are treated as opaque kernels which are further treated as compute kernels in LHS.
FFI calls can be asynchronized by add compute_on="gpu_stream:x" to make them async operations but they will still be treated as async compute ops.
This adds the functionality to allow users to configure them to be treated as custom communication kernels.
It introduces a annotation to specific compute_on="gpu_stream:collective", then it can be scheduled in the same way as native collectives and stream assignment will give it the collective stream which is of high priority and wont overlap with other collectives.
