### PR TITLE
[ROCm] Handle cancellation in multi_gpu step of rocm xla pipeline

### DIFF
--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -79,7 +79,6 @@ jobs:
           JAXCI_BUILD_JAX: "true"
           JAXCI_BUILD_JAXLIB: wheel
         working-directory: jax
-        timeout-minutes: 120
         run: |
           ./ci/run_bazel_test_rocm_rbe.sh \
             --override_repository=xla=${GITHUB_WORKSPACE} \

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -78,7 +78,7 @@ jobs:
           docker exec ${{ env.CONTAINER_NAME }} bash -c "/opt/rocm/bin/rocminfo"
 
       - name: Test XLA [single_gpu]
-        timeout-minutes: 60
+        timeout-minutes: 80
         run: |
           docker exec \
             ${{ env.CONTAINER_NAME }} \
@@ -86,7 +86,7 @@ jobs:
 
       - name: Test XLA [multi_gpu]
         timeout-minutes: 80
-        if: always()
+        if: always() && !cancelled()
         run: |
           docker exec \
             ${{ env.CONTAINER_NAME }} \


### PR DESCRIPTION
📝 Summary of Changes
Cancel multigpu tests if cancel is requested. Fixes jax-ut rocm pipeline by
removal of a redundant timeout field.

🎯 Justification
add is not canceled condition to multigpu tests.
This change will reduce the time a node is occupied by this task
while it is cancelled

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
