### PR TITLE
[ROCm] Fix ShardedAutotuningWorks test for ROCm platform

### DIFF
--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -23,7 +23,6 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "xla/tests/xla_test_backend_predicates.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/log/check.h"
@@ -33,6 +32,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
@@ -59,6 +59,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/tests/test_utils.h"
+#include "xla/tests/xla_test_backend_predicates.h"
 #include "xla/tools/multihost_hlo_runner/create_client.h"
 #include "xla/tools/multihost_hlo_runner/hlo_input_output_format.h"
 #include "xla/tools/multihost_hlo_runner/profiler_interface.h"
@@ -602,6 +603,17 @@ TEST_F(FunctionalHloRunnerTest, WhileKnownTripCountGetsCapped) {
                       FunctionalHloRunner::HloPassesMode::kRunXLABackendOnly);
 }
 
+namespace {
+absl::StatusOr<std::string> GetExpectedBackendFingerprint() {
+  TF_ASSIGN_OR_RETURN(std::string platform_name,
+                      PlatformUtil::CanonicalPlatformName("gpu"));
+  if (platform_name == "rocm") {
+    return "2971291867";
+  }
+  return "3357903800";
+}
+}  // namespace
+
 // Name of the test binary.
 static const char* binary_name;
 constexpr int kNumNodes = 2;
@@ -669,16 +681,20 @@ absl::Status ShardedAutotuningWorksTestBody(const int node_id) {
       kNumNodes, /*kv_store=*/nullptr,
       /*use_gpu_count_workaround=*/false));
   if (node_id == 0) {
+    TF_ASSIGN_OR_RETURN(std::string backend_fp,
+                        GetExpectedBackendFingerprint());
     TF_ASSIGN_OR_RETURN(
         std::string results0,
         env.kv_store->Get(
-            "autotune_results_adb7d459c2974fa512555763cba3d92a_3357903800_0",
+            absl::StrCat("autotune_results_adb7d459c2974fa512555763cba3d92a_",
+                         backend_fp, "_0"),
             absl::Seconds(1)));
     CHECK(absl::StrContains(results0, "result"));
     TF_ASSIGN_OR_RETURN(
         std::string results1,
         env.kv_store->Get(
-            "autotune_results_adb7d459c2974fa512555763cba3d92a_3357903800_1",
+            absl::StrCat("autotune_results_adb7d459c2974fa512555763cba3d92a_",
+                         backend_fp, "_1"),
             absl::Seconds(1)));
     CHECK(absl::StrContains(results1, "result"));
     // The nodes autotune different fusions.


### PR DESCRIPTION
📝 Summary of Changes
Commit c28a2c59af added a backend fingerprint to the KV store key used in sharded autotuning. The test hardcodes the CUDA backend fingerprint (4253997026), but ROCm registers different backends (MIOPEN, ROCBLAS, ROCBLAS_FISSION, and TRITON), producing a different fingerprint (3662254336).

This causes the test to fail with DEADLINE_EXCEEDED when it tries to read autotuning results using the wrong key.

Use a platform-conditional fingerprint so the test passes on both CUDA and ROCm.

🚀 Kind of Contribution
🐛 Bug Fix, 

Test Result:
```bash
root@0e7313836813 [docker:manju_ci_testing]:/workspace/upstream/xla (main) # bazel test --config=rocm //xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any
INFO: Reading 'startup' options from /workspace/upstream/xla/tensorflow.bazelrc: --windows_enable_symlinks
INFO: Options provided by the client:
  Inherited 'common' options: --isatty=1 --terminal_columns=153
INFO: Reading rc options for 'test' from /workspace/upstream/xla/.bazelrc:
  Inherited 'common' options: --noenable_bzlmod --incompatible_enable_cc_toolchain_resolution --repo_env USE_HERMETIC_CC_TOOLCHAIN=1
INFO: Reading rc options for 'test' from /workspace/upstream/xla/tensorflow.bazelrc:
  Inherited 'common' options: --define framework_shared_object=true --define tsl_protobuf_header_only=true --define=allow_oversize_protos=true --spawn_strategy=standalone -c opt --repo_env=USE_PYWRAP_RULES=True --copt=-DGRPC_BAZEL_BUILD --host_copt=-DGRPC_BAZEL_BUILD --action_env=GRPC_BAZEL_RUNTIME=1 --repo_env=PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb --action_env=PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb --@rules_python//python/config_settings:precompile=force_disabled --@rules_python//python/config_settings:bootstrap_impl=script --repo_env=RULES_PYTHON_ENABLE_PIPSTAR=0 --incompatible_default_to_explicit_init_py --announce_rc --define=grpc_no_ares=true --noincompatible_remove_legacy_whole_archive --features=-force_no_whole_archive --enable_platform_specific_config --config=short_logs --@rules_python//python/config_settings:precompile=force_disabled --experimental_cc_shared_library --experimental_link_static_libraries_once=false --incompatible_enforce_config_setting_visibility --experimental_repo_remote_exec
INFO: Reading rc options for 'test' from /workspace/upstream/xla/.bazelrc:
  Inherited 'build' options: --config=warnings
INFO: Reading rc options for 'test' from /workspace/upstream/xla/tensorflow.bazelrc:
  'test' options: --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1
INFO: Found applicable config definition common:short_logs in file /workspace/upstream/xla/tensorflow.bazelrc: --output_filter=DONT_MATCH_ANYTHING
INFO: Found applicable config definition build:warnings in file /workspace/upstream/xla/warnings.bazelrc: --copt=-Werror --host_copt=-Werror --per_file_copt=external/.*@-w --host_per_file_copt=external/.*@-w --copt=-Wall --copt=-Werror --copt=-Wno-address-of-packed-member --copt=-Wno-defaulted-function-deleted --copt=-Wno-deprecated-builtins --copt=-Wno-enum-compare-switch --copt=-Wno-expansion-to-defined --copt=-Wno-ignored-attributes --copt=-Wno-ignored-qualifiers --copt=-Wno-inconsistent-missing-override --copt=-Wno-nontrivial-memaccess --copt=-Wno-nullability-completeness --copt=-Wno-potentially-evaluated-expression --copt=-Wno-range-loop-analysis --copt=-Wno-return-type-c-linkage --copt=-Wno-tautological-undefined-compare --copt=-Wno-unused-but-set-variable --copt=-Wno-unused-lambda-capture --copt=-Wno-unused-local-typedef --copt=-Wno-deprecated-volatile --copt=-Wno-deprecated-anon-enum-enum-conversion --copt=-Wno-deprecated-enum-compare --copt=-Wno-deprecated-enum-enum-conversion --copt=-Wno-deprecated-enum-compare-conditional --copt=-Wno-deprecated-enum-float-conversion --copt=-Wno-deprecated-this-capture --copt=-Wno-strict-prototypes --copt=-Wno-tautological-type-limit-compare --copt=-Wno-tautological-unsigned-enum-zero-compare --copt=-Wno-tautological-unsigned-zero-compare --copt=-Wno-thread-safety-reference --copt=-Wno-undefined-func-template --copt=-Wno-bitfield-constant-conversion --copt=-Wno-bitwise-instead-of-logical --copt=-Wno-comment --copt=-Wno-compound-token-split --copt=-Wno-deprecated-non-prototype --copt=-Wno-misleading-indentation --copt=-Wno-psabi --copt=-Wno-unqualified-std-cast-call --copt=-Wno-deprecated-literal-operator --copt=-Wno-ambiguous-member-template --copt=-Wno-char-subscripts --copt=-Wno-deprecated-declarations --copt=-Wno-deprecated-pragma --copt=-Wno-extern-c-compat --copt=-Wno-gnu-alignof-expression --copt=-Wno-gnu-variable-sized-type-not-at-end --copt=-Wno-implicit-int-float-conversion --copt=-Wno-invalid-source-encoding --copt=-Wno-pointer-sign --copt=-Wno-private-header --copt=-Wno-sign-compare --copt=-Wno-strict-overflow --copt=-Wno-unknown-pragmas --copt=-Wno-unused-command-line-argument --copt=-Wno-unused-const-variable --copt=-Wno-unused-function --copt=-Wno-unused-private-field --copt=-Wno-user-defined-warnings --copt=-Wno-mismatched-tags --copt=-Wfloat-overflow-conversion --copt=-Wfloat-zero-conversion --copt=-Wfor-loop-analysis --copt=-Wgnu-redeclared-enum --copt=-Winfinite-recursion --copt=-Wself-assign --copt=-Wno-self-assign-overloaded --copt=-Wstring-conversion --copt=-Wtautological-overlap-compare --copt=-Wunused-but-set-parameter --copt=-Wunused-comparison --copt=-Wvla --copt=-Wctad-maybe-unsupported --copt=-Wno-trigraphs --copt=-Woverloaded-virtual --copt=-Wno-invalid-offsetof --copt=-Wno-final-dtor-non-final-class --copt=-Wnon-virtual-dtor --copt=-Wimplicit-fallthrough --copt=-Wthread-safety-analysis --copt=-Wno-builtin-macro-redefined --copt=-Wno-macro-redefined --copt=-Wno-deprecated-register --copt=-Wno-register
INFO: Found applicable config definition common:rocm in file /workspace/upstream/xla/tensorflow.bazelrc: --config=rocm_clang_official
INFO: Found applicable config definition common:rocm_clang_official in file /workspace/upstream/xla/tensorflow.bazelrc: --config=rocm_base --action_env=CLANG_COMPILER_PATH=/usr/lib/llvm-18/bin/clang --action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress --action_env=TF_ROCM_CLANG=1 --linkopt=-fuse-ld=lld --host_linkopt=-fuse-ld=lld
INFO: Found applicable config definition common:rocm_base in file /workspace/upstream/xla/tensorflow.bazelrc: --config=clang_local --copt=-Wno-gnu-offsetof-extensions --crosstool_top=@local_config_rocm//crosstool:toolchain --define=using_rocm_hipcc=true --define=tensorflow_mkldnn_contraction_kernel=0 --repo_env TF_NEED_ROCM=1
INFO: Found applicable config definition common:clang_local in file /workspace/upstream/xla/.bazelrc: --noincompatible_enable_cc_toolchain_resolution --@rules_ml_toolchain//common:enable_hermetic_cc=False --repo_env USE_HERMETIC_CC_TOOLCHAIN=0
INFO: Found applicable config definition common:linux in file /workspace/upstream/xla/tensorflow.bazelrc: --host_copt=-w --define=PREFIX=/usr --define=LIBDIR=$(PREFIX)/lib --define=INCLUDEDIR=$(PREFIX)/include --define=PROTOBUF_INCLUDE_PATH=$(PREFIX)/include --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --experimental_guard_against_concurrent_changes
INFO: Analyzed target //xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any (0 packages loaded, 0 targets configured).
[1 / 2] Testing //xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any; 186s
[1 / 2] Testing //xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any; 187s
[1 / 2] 1 / 1 tests;  1 action; last test: //xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any
    Testing //xla/tools/multihost_hlo_runner:f
INFO: Found 1 test target...
[2 / 2] 1 / 1 tests; no actions running; last test: //xla/tools/multihost_hlo_runner:functio
Target //xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any up-to-date:
[2 / 2] 1 / 1 tests; no actions running; last test: //xla/tools/multihost_hlo_runner:functio
  bazel-bin/xla/tools/multihost_hlo_runner/functional_hlo_runner_test_amdgpu_any
[2 / 2] 1 / 1 tests; no actions running; last test: //xla/tools/multihost_hlo_runner:functio
INFO: Elapsed time: 190.963s, Critical Path: 188.96s
[2 / 2] 1 / 1 tests; no actions running; last test: //xla/tools/multihost_hlo_runner:functio
INFO: 2 processes: 1 internal, 1 local.
[2 / 2] 1 / 1 tests; no actions running; last test: //xla/tools/multihost_hlo_runner:functio
INFO: Build completed successfully, 2 total actions
//xla/tools/multihost_hlo_runner:functional_hlo_runner_test_amdgpu_any   PASSED in 188.9s

Executed 1 out of 1 test: 1 test passes.
root@0e7313836813 [docker:manju_ci_testing]:/w
orkspace/upstream/xla (main) # 
```