### PR TITLE
Skip AutoShardingTest.MatMulWithAutosharding in OSS

### DIFF
--- a/xla/service/gpu/auto_sharding_gpu_compiler_test.cc
+++ b/xla/service/gpu/auto_sharding_gpu_compiler_test.cc
@@ -66,6 +66,9 @@ ENTRY matmul {
 };
 
 TEST_F(AutoShardingTest, MatMulWithAutosharding) {
+#if !defined(PLATFORM_GOOGLE)
+  GTEST_SKIP() << "GPU autosharding not available in OSS";
+#endif
   std::unique_ptr<HloModule> compiled_module = CompileMatMul(true, 4);
   const HloInstruction* parameter1 =
       compiled_module->entry_computation()->parameter_instruction(0);


### PR DESCRIPTION
📝 Summary of Changes
  - Skip `AutoShardingTest.MatMulWithAutosharding` when building outside of google-internal (`PLATFORM_GOOGLE`)
  - The test depends on internal autosharding infrastructure not available in OSS builds and fails on all GPU configurations
 
🎯 Justification
We successfully run many `no_oss`-tagged GPU tests and are working to separate the ones that genuinely cannot work in OSS from those that simply need minor fixes. The `no_oss` tag means "do not execute in public openxla/xla CI" but does not imply the test *cannot* work outside of it. This particular subtest legitimately cannot pass in OSS due to missing infrastructure, so it is skipped with a clear message.