### PR TITLE
Skip python_hlo_runner_test when transformer_engine_jax is unavailable

### DIFF
--- a/xla/tools/multihost_hlo_runner/python_hlo_runner_test.py
+++ b/xla/tools/multihost_hlo_runner/python_hlo_runner_test.py
@@ -19,12 +19,12 @@ import pathlib
 
 from absl.testing import absltest
 
+from xla.tools.multihost_hlo_runner import py_hlo_multihost_runner
+
 try:
   from transformer_engine import transformer_engine_jax
 except ImportError:
   transformer_engine_jax = None
-
-from xla.tools.multihost_hlo_runner import py_hlo_multihost_runner
 
 
 def _register_transformer_engine_custom_calls():

--- a/xla/tools/multihost_hlo_runner/python_hlo_runner_test.py
+++ b/xla/tools/multihost_hlo_runner/python_hlo_runner_test.py
@@ -18,7 +18,11 @@ import os
 import pathlib
 
 from absl.testing import absltest
-from transformer_engine import transformer_engine_jax
+
+try:
+  from transformer_engine import transformer_engine_jax
+except ImportError:
+  transformer_engine_jax = None
 
 from xla.tools.multihost_hlo_runner import py_hlo_multihost_runner
 
@@ -47,6 +51,8 @@ class RunTEHloTest(absltest.TestCase):
 
   def setUp(self):
     super().setUp()
+    if transformer_engine_jax is None:
+      self.skipTest("transformer_engine_jax not available")
     _register_transformer_engine_custom_calls()
     self.config = py_hlo_multihost_runner.PyHloRunnerConfig()
     self.config.input_format = py_hlo_multihost_runner.InputFormat.Text


### PR DESCRIPTION
📝 Summary of Changes
- Wrap `from transformer_engine import transformer_engine_jax` in a try/except so the test module loads even when transformer_engine is not installed
- Skip the test at runtime with a clear message if the import failed

🎯 Justification
We successfully run many `no_oss`-tagged GPU tests and are working to separate the ones that genuinely cannot work in OSS from those that simply need minor fixes. The `no_oss` tag means "do not execute in public openxla/xla CI" but does not imply the test *cannot* work outside of it. This test fails at import time in environments without `transformer_engine`