### PR TITLE
Make tfrt_gpu_buffer_test pass in OSS

### DIFF
--- a/xla/pjrt/gpu/tfrt/BUILD
+++ b/xla/pjrt/gpu/tfrt/BUILD
@@ -384,10 +384,10 @@ xla_cc_test(
         "//xla/pjrt:pjrt_client",
         "//xla/pjrt/plugin/xla_gpu:xla_gpu_client_options",
         "//xla/service:gpu_plugin",  # build_cleaner: keep
+        "//xla/stream_executor/cuda:cuda_platform",
         "//xla/tsl/concurrency:async_value",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:statusor",
-        "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",

--- a/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer_test.cc
+++ b/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer_test.cc
@@ -22,7 +22,6 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "absl/base/casts.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
@@ -51,17 +50,11 @@ namespace {
 
 using ::tsl::thread::ThreadPool;
 
-#if !defined(PLATFORM_GOOGLE)
-TEST(TfrtGpuBufferTest, NotAvailableInOSS) {
-  GTEST_SKIP() << "Test uses absl::down_cast not available in OSS build";
-}
-#else
-
 class TfrtGpuBufferTest : public ::testing::Test {
  protected:
   void SetUp() override {
     ASSERT_OK_AND_ASSIGN(client_, GetTfrtGpuClient(GpuClientOptions()));
-    tfrt_gpu_client_ = absl::down_cast<TfrtGpuClient*>(client_.get());
+    tfrt_gpu_client_ = tsl::down_cast<TfrtGpuClient*>(client_.get());
   }
 
   TfrtGpuThreadChecker thread_checker_;
@@ -72,7 +65,7 @@ class TfrtGpuBufferTest : public ::testing::Test {
 TEST_F(TfrtGpuBufferTest, CreateBuffer) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
   TfrtGpuDevice* device =
-      absl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -101,7 +94,7 @@ TEST_F(TfrtGpuBufferTest, CreateBuffer) {
 TEST_F(TfrtGpuBufferTest, AcquireExternalReference) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
   TfrtGpuDevice* device =
-      absl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -144,7 +137,7 @@ TEST_F(TfrtGpuBufferTest, AcquireExternalReference) {
 TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipNoWait) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
   TfrtGpuDevice* device =
-      absl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -188,7 +181,7 @@ TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipNoWait) {
 TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipWait) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
   TfrtGpuDevice* device =
-      absl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -253,7 +246,7 @@ TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipWait) {
 TEST_F(TfrtGpuBufferTest, Delete) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
   TfrtGpuDevice* device =
-      absl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -364,8 +357,6 @@ TEST_F(TfrtGpuBufferTest, Bitcast) {
 
 // TODO: b/382117736 - Add test for logical shape when shape is dynamic after
 // TfrtGpuClient::Execute() is ready.
-
-#endif  // defined(PLATFORM_GOOGLE)
 
 }  // namespace
 }  // namespace xla

--- a/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer_test.cc
+++ b/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer_test.cc
@@ -64,8 +64,7 @@ class TfrtGpuBufferTest : public ::testing::Test {
 
 TEST_F(TfrtGpuBufferTest, CreateBuffer) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
-  TfrtGpuDevice* device =
-      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+  TfrtGpuDevice* device = tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -93,8 +92,7 @@ TEST_F(TfrtGpuBufferTest, CreateBuffer) {
 
 TEST_F(TfrtGpuBufferTest, AcquireExternalReference) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
-  TfrtGpuDevice* device =
-      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+  TfrtGpuDevice* device = tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -136,8 +134,7 @@ TEST_F(TfrtGpuBufferTest, AcquireExternalReference) {
 
 TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipNoWait) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
-  TfrtGpuDevice* device =
-      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+  TfrtGpuDevice* device = tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -180,8 +177,7 @@ TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipNoWait) {
 
 TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipWait) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
-  TfrtGpuDevice* device =
-      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+  TfrtGpuDevice* device = tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,
@@ -245,8 +241,7 @@ TEST_F(TfrtGpuBufferTest, ReleaseDeviceMemoryOwnershipWait) {
 
 TEST_F(TfrtGpuBufferTest, Delete) {
   Shape on_device_shape = ShapeUtil::MakeShapeWithType<int32_t>({4, 4});
-  TfrtGpuDevice* device =
-      tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
+  TfrtGpuDevice* device = tsl::down_cast<TfrtGpuDevice*>(client_->devices()[0]);
   auto size_in_bytes = ShapeUtil::ByteSizeOf(on_device_shape);
   TF_ASSERT_OK_AND_ASSIGN(
       auto device_buffer,

--- a/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer_test.cc
+++ b/xla/pjrt/gpu/tfrt/tfrt_gpu_buffer_test.cc
@@ -51,6 +51,12 @@ namespace {
 
 using ::tsl::thread::ThreadPool;
 
+#if !defined(PLATFORM_GOOGLE)
+TEST(TfrtGpuBufferTest, NotAvailableInOSS) {
+  GTEST_SKIP() << "Test uses absl::down_cast not available in OSS build";
+}
+#else
+
 class TfrtGpuBufferTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -358,6 +364,8 @@ TEST_F(TfrtGpuBufferTest, Bitcast) {
 
 // TODO: b/382117736 - Add test for logical shape when shape is dynamic after
 // TfrtGpuClient::Execute() is ready.
+
+#endif  // defined(PLATFORM_GOOGLE)
 
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
  - Fix `tfrt_gpu_buffer_test` to build and pass outside of google-internal CI
  - Replace `absl::down_cast` with `tsl::down_cast` (fixes build: `absl::down_cast` is not available in the OSS absl)
  - Add missing `cuda_platform` dep so the GPU platform is registered at test startup
  - Remove unused `absl/base` dep

🎯 Justification
We successfully run many `no_oss`-tagged GPU tests and are working to separate the ones that genuinely cannot work in OSS from those that simply need minor fixes. The `no_oss` tag means "do not execute in public openxla/xla CI" but does not imply the test *cannot* work outside of it. This test only needed a build fix and a missing dependency.
