### PR TITLE
[ROCm] Disable keep_going for rocm pipelines

### DIFF
--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -37,7 +37,7 @@ bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --build_tag_filters=$TAG_FILTERS \
     --test_tag_filters=$TAG_FILTERS \
     --profile=/tf/pkg/profile.json.gz \
-    --keep_going \
+    --nokeep_going \
     --test_env=TF_TESTS_PER_GPU=1 \
     --action_env=XLA_FLAGS="--xla_gpu_enable_llvm_module_compilation_parallelism=true --xla_gpu_force_compilation_parallelism=16" \
     --test_output=errors \


### PR DESCRIPTION
📝 Summary of Changes
Disable keep_going for rocm PR check pipeline

🎯 Justification
Rocm rbe is overloaded with the current PR income.
We disable the keep_going in order to fail faster and
release resources for a next job

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
