### PR TITLE
[ROCm] Skip denorm fp16 dots on MI200 architctures

### DIFF
--- a/xla/backends/gpu/codegen/triton/triton_gemm_fusion_test.cc
+++ b/xla/backends/gpu/codegen/triton/triton_gemm_fusion_test.cc
@@ -653,6 +653,11 @@ ENTRY e {
 ; CHECK-SAME: kind=kCustom
 ; CHECK-SAME: backend_config={{.*}}"kind":"__triton_nested_gemm_fusion"
 )");
+
+  if (GpuComputeCapability().IsRocm()) {
+    if(GpuComputeCapability().rocm_compute_capability()->gfx9_mi200())
+      GTEST_SKIP() << "Denorm fp16 does not work on MI200 ROCm archs";
+  }
   EXPECT_TRUE(RunAndCompare(kHloText, ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 


### PR DESCRIPTION
📝 Summary of Changes
In triton gemm fusion test randomly generated fp16 values for test are not denoramlized and MI200 and lower architecture fails to handle denorm fp16 values.

🎯 Justification
Skip denorm fp16 failing test on MI200 and lower arch

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

