### PR TITLE
[xla:gpu] Update GPU memory colorer to handle custom calls with memory space requirements

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -110,7 +110,9 @@ cc_library(
     deps = [
         ":backend_configs_cc",
         ":ir_emission_utils",
+        "//xla:shape_util",
         "//xla:status_macros",
+        "//xla:util",
         "//xla:xla_proto_cc",
         "//xla/hlo/analysis:hlo_alias_analysis",
         "//xla/hlo/analysis:hlo_ordering",
@@ -118,11 +120,14 @@ cc_library(
         "//xla/service:buffer_assignment",
         "//xla/service:buffer_value",
         "//xla/service:hlo_value",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/base:no_destructor",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log:die_if_null",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -134,6 +139,7 @@ xla_cc_test(
         "//xla/hlo/analysis:alias_info",
         "//xla/hlo/analysis:hlo_alias_analysis",
         "//xla/hlo/analysis:hlo_ordering",
+        "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/hlo/testlib:verified_hlo_module",
         "//xla/service:buffer_assignment",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -328,6 +328,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
@@ -341,7 +342,6 @@ limitations under the License.
 #include "tsl/platform/protobuf.h"  // IWYU pragma: keep
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 #ifdef PLATFORM_GOOGLE
 #include "xla/hlo/experimental/auto_sharding/auto_sharding.h"

--- a/xla/service/gpu/gpu_memory_space_assignment.cc
+++ b/xla/service/gpu/gpu_memory_space_assignment.cc
@@ -16,21 +16,33 @@ limitations under the License.
 #include "xla/service/gpu/gpu_memory_space_assignment.h"
 
 #include <cstdint>
+#include <utility>
+#include <vector>
 
 #include "absl/base/no_destructor.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/functional/function_ref.h"
 #include "absl/log/die_if_null.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
 #include "xla/hlo/analysis/hlo_alias_analysis.h"
 #include "xla/hlo/analysis/hlo_ordering.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/buffer_value.h"
+#include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/hlo_value.h"
+#include "xla/shape_util.h"
 #include "xla/status_macros.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/util.h"
 
 namespace xla::gpu {
 
@@ -50,6 +62,51 @@ const absl::NoDestructor<absl::flat_hash_set<HloOpcode>>
         HloOpcode::kCollectivePermuteDone,
         HloOpcode::kAllToAll,
     });
+
+absl::StatusOr<MemorySpaceColor> AsMemorySpaceColor(int64_t memory_space) {
+  switch (memory_space) {
+    case static_cast<int64_t>(MemorySpaceColor::kDefault):
+    case static_cast<int64_t>(MemorySpaceColor::kCollective):
+    case static_cast<int64_t>(MemorySpaceColor::kTempBuffer):
+      return static_cast<MemorySpaceColor>(memory_space);
+    default:
+      return InvalidArgument(
+          "Invalid memory space %d. "
+          "Valid values are 0 (default), 1 (collective), 2 (temp).",
+          memory_space);
+  }
+}
+
+absl::StatusOr<std::vector<std::pair<int64_t, MemorySpaceColor>>>
+ParseIndexMemorySpacePairs(absl::string_view str) {
+  if (!absl::ConsumePrefix(&str, "{") || !absl::ConsumeSuffix(&str, "}")) {
+    return InvalidArgument("Expected format {index:memory_space,...}, got: %s",
+                           str);
+  }
+
+  std::vector<std::pair<int64_t, MemorySpaceColor>> result;
+  if (str.empty()) {
+    return result;
+  }
+
+  for (absl::string_view pair : absl::StrSplit(str, ',')) {
+    pair = absl::StripAsciiWhitespace(pair);
+    std::vector<absl::string_view> parts = absl::StrSplit(pair, ':');
+    if (parts.size() != 2) {
+      return InvalidArgument("Expected index:memory_space pair, got: %s", pair);
+    }
+    int64_t index, memory_space;
+    if (!absl::SimpleAtoi(absl::StripAsciiWhitespace(parts[0]), &index) ||
+        !absl::SimpleAtoi(absl::StripAsciiWhitespace(parts[1]),
+                          &memory_space)) {
+      return InvalidArgument("Failed to parse integers in pair: %s", pair);
+    }
+    ASSIGN_OR_RETURN(MemorySpaceColor color, AsMemorySpaceColor(memory_space));
+    result.emplace_back(index, color);
+  }
+
+  return result;
+}
 
 bool IsNvshmemInstruction(const HloInstruction* inst) {
   bool is_nvshmem_collective = false;
@@ -107,9 +164,63 @@ bool HasMosaicWithMultimemInstruction(const HloValue& input_alias) {
   return HasMosaicInstruction(input_alias, IsMosaicWithMultimem);
 }
 
+// Returns the memory space requested for the given custom call use, or
+// MemorySpaceColor::kDefault if none is specified.
+static absl::StatusOr<MemorySpaceColor> GetCustomCallOperandMemorySpace(
+    const HloUse& use) {
+  if (use.instruction->opcode() != HloOpcode::kCustomCall ||
+      !use.operand_index.empty()) {
+    return MemorySpaceColor::kDefault;
+  }
+
+  auto attr =
+      use.instruction->get_frontend_attribute(kOperandsMemorySpacesAttr);
+  if (!attr.has_value()) {
+    return MemorySpaceColor::kDefault;
+  }
+
+  ASSIGN_OR_RETURN(auto pairs, ParseIndexMemorySpacePairs(*attr));
+  for (auto [index, memory_space] : pairs) {
+    if (index == use.operand_number) {
+      return memory_space;
+    }
+  }
+
+  return MemorySpaceColor::kDefault;
+}
+
+// Returns the memory space requested for a custom call result value, or
+// MemorySpaceColor::kDefault if none is specified.
+static absl::StatusOr<MemorySpaceColor> GetCustomCallResultMemorySpace(
+    const HloValue& value) {
+  const HloInstruction* instr = value.instruction();
+  if (instr->opcode() != HloOpcode::kCustomCall) {
+    return MemorySpaceColor::kDefault;
+  }
+
+  auto attr = instr->get_frontend_attribute(kResultsMemorySpacesAttr);
+  if (!attr.has_value()) {
+    return MemorySpaceColor::kDefault;
+  }
+
+  ASSIGN_OR_RETURN(auto pairs, ParseIndexMemorySpacePairs(*attr));
+  const ShapeIndex& idx = value.defining_index();
+  for (auto [index, memory_space] : pairs) {
+    if (instr->shape().IsTuple() ? (idx.size() == 1 && idx[0] == index)
+                                 : (idx.empty() && index == 0)) {
+      return memory_space;
+    }
+  }
+
+  return MemorySpaceColor::kDefault;
+}
+
 // Set memory space to MemorySpaceColor::kCollective for all allocations used by
 // all-reduce, all-gather, and reduce-scatter. This memory space maps to
 // collective memory using ncclMemAlloc in the runtime.
+//
+// Also assigns memory space colors for custom call operands and results based
+// on `operands_memory_spaces` and `results_memory_spaces` frontend attributes.
 absl::Status AssignColors(bool use_collective_memory, bool use_nvshmem,
                           HloAliasAnalysis* alias_analysis) {
   for (HloValue* value : alias_analysis->dataflow_analysis().values()) {
@@ -129,9 +240,32 @@ absl::Status AssignColors(bool use_collective_memory, bool use_nvshmem,
       continue;
     }
 
+    // Check if this value is a custom call result with a requested memory
+    // space.
+    ASSIGN_OR_RETURN(MemorySpaceColor result_ms,
+                     GetCustomCallResultMemorySpace(*value));
+    if (result_ms != MemorySpaceColor::kDefault) {
+      value->set_color(static_cast<int>(result_ms));
+      continue;
+    }
+
     for (const xla::HloValue* alias :
          alias_analysis->GetBufferContainingValue(*value).values()) {
       TF_RET_CHECK(alias != nullptr);
+
+      // Check if any use of this alias is a custom call operand with a
+      // requested memory space.
+      for (const HloUse& use : alias->GetUses()) {
+        ASSIGN_OR_RETURN(MemorySpaceColor operand_ms,
+                         GetCustomCallOperandMemorySpace(use));
+        if (operand_ms != MemorySpaceColor::kDefault) {
+          value->set_color(static_cast<int>(operand_ms));
+        }
+      }
+      if (value->has_color()) {
+        break;
+      }
+
       // TODO(479768130): Mark only buffers used with multimem instructions
       // instead of marking all buffers.
       if ((HasMosaicWithNvshmemInstruction(*alias) && use_nvshmem) ||

--- a/xla/service/gpu/gpu_memory_space_assignment.h
+++ b/xla/service/gpu/gpu_memory_space_assignment.h
@@ -16,20 +16,32 @@ limitations under the License.
 #ifndef XLA_SERVICE_GPU_GPU_MEMORY_SPACE_ASSIGNMENT_H_
 #define XLA_SERVICE_GPU_GPU_MEMORY_SPACE_ASSIGNMENT_H_
 
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "xla/service/buffer_assignment.h"
-#include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/xla.pb.h"
 
-namespace xla {
-namespace gpu {
+namespace xla::gpu {
+
+// Frontend attribute names for specifying memory spaces on custom call
+// operands and results. The format is {index:memory_space,...}, e.g.
+// "{0:1,2:1}" means operand/result 0 and 2 should be in memory space 1.
+inline constexpr absl::string_view kOperandsMemorySpacesAttr =
+    "operands_memory_spaces";
+inline constexpr absl::string_view kResultsMemorySpacesAttr =
+    "results_memory_spaces";
 
 enum class MemorySpaceColor {
   // Corresponds to stream_executor::MemoryTypes::kDefault or kUnified.
   // This memory can be allocated with any device allocation API.
   kDefault = 0,
 
-  // Corresponds to stream_executor::MemoryTypes::kCollective.
-  // This memory should be allocated with ncclMemAlloc in the runtime.
+  // Corresponds to stream_executor::MemoryTypes::kCollective. This memory
+  // should be compatible with symmetric memory requirements.
   kCollective = 1,
 
   // Temp buffers can be allocated within separate memory space (if
@@ -38,8 +50,25 @@ enum class MemorySpaceColor {
   kTempBuffer = 2,
 };
 
+// Converts an integer to a MemorySpaceColor, returning an error if the value
+// does not correspond to a known color.
+absl::StatusOr<MemorySpaceColor> AsMemorySpaceColor(int64_t memory_space);
+
+// Parses a string of the form "{index:memory_space,...}" into a vector of
+// (index, memory_space) pairs. For example, "{0:1,2:1}" means index 0 and 2
+// should be in memory space 1.
+absl::StatusOr<std::vector<std::pair<int64_t, MemorySpaceColor>>>
+ParseIndexMemorySpacePairs(absl::string_view str);
+
+// Creates a buffer colorer that assigns memory space colors to HLO values
+// during buffer assignment. It handles:
+//  - Collective operations (all-reduce, all-gather, etc.) → kCollective
+//  - Mosaic with NVSHMEM/multimem → kCollective
+//  - Custom call `operands_memory_spaces` / `results_memory_spaces` frontend
+//    attributes → requested memory space
+//  - Everything else → kDefault
 BufferAssigner::Colorer CreateColorer(const DebugOptions& option);
-}  // namespace gpu
-}  // namespace xla
+
+}  // namespace xla::gpu
 
 #endif  // XLA_SERVICE_GPU_GPU_MEMORY_SPACE_ASSIGNMENT_H_

--- a/xla/service/gpu/gpu_memory_space_assignment_test.cc
+++ b/xla/service/gpu/gpu_memory_space_assignment_test.cc
@@ -15,7 +15,9 @@ limitations under the License.
 
 #include "xla/service/gpu/gpu_memory_space_assignment.h"
 
+#include <cstdint>
 #include <memory>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -24,6 +26,7 @@ limitations under the License.
 #include "xla/hlo/analysis/alias_info.h"
 #include "xla/hlo/analysis/hlo_alias_analysis.h"
 #include "xla/hlo/analysis/hlo_ordering.h"
+#include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/testlib/verified_hlo_module.h"
 #include "xla/service/buffer_assignment.h"
@@ -330,5 +333,161 @@ TEST_F(GpuMemorySpaceAssignmentTest, TestMultimemMosaicMemorySpaceAssignment) {
     ASSERT_THAT(value->color(), Eq(expected_color));
   }
 }
+
+TEST(ParseIndexMemorySpacePairsTest, SinglePair) {
+  TF_ASSERT_OK_AND_ASSIGN(auto pairs, ParseIndexMemorySpacePairs("{0:1}"));
+  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs[0].first, 0);
+  EXPECT_EQ(pairs[0].second, MemorySpaceColor::kCollective);
+}
+
+TEST(ParseIndexMemorySpacePairsTest, MultiplePairs) {
+  TF_ASSERT_OK_AND_ASSIGN(auto pairs, ParseIndexMemorySpacePairs("{0:1,2:2}"));
+  ASSERT_EQ(pairs.size(), 2);
+  EXPECT_EQ(pairs[0].first, 0);
+  EXPECT_EQ(pairs[0].second, MemorySpaceColor::kCollective);
+  EXPECT_EQ(pairs[1].first, 2);
+  EXPECT_EQ(pairs[1].second, MemorySpaceColor::kTempBuffer);
+}
+
+TEST(ParseIndexMemorySpacePairsTest, EmptyBraces) {
+  TF_ASSERT_OK_AND_ASSIGN(auto pairs, ParseIndexMemorySpacePairs("{}"));
+  EXPECT_TRUE(pairs.empty());
+}
+
+TEST(ParseIndexMemorySpacePairsTest, WhitespaceHandling) {
+  TF_ASSERT_OK_AND_ASSIGN(auto pairs,
+                          ParseIndexMemorySpacePairs("{ 0 : 1 , 2 : 0 }"));
+  ASSERT_EQ(pairs.size(), 2);
+  EXPECT_EQ(pairs[0].first, 0);
+  EXPECT_EQ(pairs[0].second, MemorySpaceColor::kCollective);
+  EXPECT_EQ(pairs[1].first, 2);
+  EXPECT_EQ(pairs[1].second, MemorySpaceColor::kDefault);
+}
+
+TEST(ParseIndexMemorySpacePairsTest, MissingBraces) {
+  EXPECT_FALSE(ParseIndexMemorySpacePairs("0:1").ok());
+}
+
+TEST(ParseIndexMemorySpacePairsTest, InvalidPairFormat) {
+  EXPECT_FALSE(ParseIndexMemorySpacePairs("{0}").ok());
+}
+
+TEST(ParseIndexMemorySpacePairsTest, NonIntegerValues) {
+  EXPECT_FALSE(ParseIndexMemorySpacePairs("{a:b}").ok());
+}
+
+TEST(ParseIndexMemorySpacePairsTest, InvalidMemorySpace) {
+  EXPECT_FALSE(ParseIndexMemorySpacePairs("{0:99}").ok());
+}
+
+// Helper to find the HloValue color for a given instruction name.
+static int FindColorByName(const HloAliasAnalysis& alias_analysis,
+                           absl::string_view name) {
+  for (const auto& buffer : alias_analysis.buffers()) {
+    for (const HloValue* value : buffer.values()) {
+      if (value->instruction()->name() == name) {
+        return value->color();
+      }
+    }
+  }
+  return -1;
+}
+
+TEST_F(GpuMemorySpaceAssignmentTest, CustomCallOperandMemorySpace) {
+  absl::string_view kHloModule = R"(
+    HloModule m
+
+    ENTRY main {
+      p0 = f32[1024]{0} parameter(0)
+      p1 = f32[1024]{0} parameter(1)
+      ROOT custom-call = f32[1024]{0} custom-call(p0, p1),
+        custom_call_target="my_custom_call",
+        frontend_attributes={operands_memory_spaces="{0:1}"}
+    }
+  )";
+
+  HloModuleConfig config = GetModuleConfigForTest();
+  BufferAssigner::Colorer colorer = CreateColorer(config.debug_options());
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
+  AliasInfo alias_info;
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloAliasAnalysis> alias_analysis,
+                          HloAliasAnalysis::Run(module.get(), &alias_info));
+  DependencyHloOrdering ordering(module.get());
+  TF_EXPECT_OK(colorer(alias_analysis.get(), ordering));
+
+  // Operand 0 (p0) should be colored with memory space 1.
+  EXPECT_EQ(FindColorByName(*alias_analysis, "p0"), 1);
+  // Operand 1 (p1) should remain in default memory space.
+  EXPECT_EQ(FindColorByName(*alias_analysis, "p1"),
+            (int)MemorySpaceColor::kDefault);
+}
+
+TEST_F(GpuMemorySpaceAssignmentTest, CustomCallResultMemorySpace) {
+  absl::string_view kHloModule = R"(
+    HloModule m
+
+    ENTRY main {
+      p0 = f32[1024]{0} parameter(0)
+      ROOT custom-call = f32[1024]{0} custom-call(p0),
+        custom_call_target="my_custom_call",
+        frontend_attributes={results_memory_spaces="{0:1}"}
+    }
+  )";
+
+  HloModuleConfig config = GetModuleConfigForTest();
+  BufferAssigner::Colorer colorer = CreateColorer(config.debug_options());
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
+  AliasInfo alias_info;
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloAliasAnalysis> alias_analysis,
+                          HloAliasAnalysis::Run(module.get(), &alias_info));
+  DependencyHloOrdering ordering(module.get());
+  TF_EXPECT_OK(colorer(alias_analysis.get(), ordering));
+
+  // The custom call result should be colored with memory space 1.
+  EXPECT_EQ(FindColorByName(*alias_analysis, "custom-call"), 1);
+}
+
+TEST_F(GpuMemorySpaceAssignmentTest, CustomCallTupleResultMemorySpace) {
+  absl::string_view kHloModule = R"(
+    HloModule m
+
+    ENTRY main {
+      p0 = f32[1024]{0} parameter(0)
+      custom-call = (f32[1024]{0}, f32[512]{0}) custom-call(p0),
+        custom_call_target="my_custom_call",
+        frontend_attributes={results_memory_spaces="{0:1,1:1}"}
+      ROOT gte = f32[1024]{0} get-tuple-element(custom-call), index=0
+    }
+  )";
+
+  HloModuleConfig config = GetModuleConfigForTest();
+  BufferAssigner::Colorer colorer = CreateColorer(config.debug_options());
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule, config));
+  AliasInfo alias_info;
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloAliasAnalysis> alias_analysis,
+                          HloAliasAnalysis::Run(module.get(), &alias_info));
+  DependencyHloOrdering ordering(module.get());
+  TF_EXPECT_OK(colorer(alias_analysis.get(), ordering));
+
+  // Find values defined by the custom call at tuple indices 0 and 1.
+  for (const auto& buffer : alias_analysis->buffers()) {
+    for (const HloValue* value : buffer.values()) {
+      if (value->instruction()->name() != "custom-call") continue;
+      const ShapeIndex& idx = value->defining_index();
+      if (idx.size() == 1 && (idx[0] == 0 || idx[0] == 1)) {
+        EXPECT_EQ(value->color(), 1)
+            << "Tuple element " << idx[0] << " should have color 1";
+      }
+    }
+  }
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/tests/collective_ops_ffi_test.cc
+++ b/xla/tests/collective_ops_ffi_test.cc
@@ -550,6 +550,58 @@ TEST_F(CollectiveOpsTestFFI, DeviceAllReduce) {
   }
 }
 
+// Same as DeviceAllReduce, but uses frontend_attributes to specify memory
+// spaces instead of hardcoded S(1).
+TEST_F(CollectiveOpsTestFFI, DeviceAllReduceWithFrontendAttributes) {
+  if (device_count() < kNumReplicas) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas << " devices ("
+                 << device_count() << " available)";
+  }
+
+  if (!IsHopperAndHigher()) {
+    GTEST_SKIP() << "NCCL symmetric memory requires Hopper+";
+  }
+
+  GpuCollectives* collectives = GpuCollectives::Default("CUDA");
+  if (!collectives || !collectives->SupportsDeviceComm()) {
+    GTEST_SKIP() << "GPU collectives do not support device communication";
+  }
+
+  constexpr absl::string_view hlo_string = R"(
+      HloModule m, replica_count=2
+
+      ENTRY test_computation {
+        id = u32[] replica-id()
+        all-reduce = u32[] custom-call(id),
+          custom_call_target="__xla_test$$device_all_reduce",
+          api_version=API_VERSION_TYPED_FFI,
+          frontend_attributes={
+            operands_memory_spaces="{0:1}",
+            results_memory_spaces="{0:1}"
+          }
+        ROOT out = u32[] copy(all-reduce)
+      }
+    )";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(hlo_string, kNumReplicas));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/std::vector<Literal*>(),
+                        /*run_hlo_passes=*/true));
+
+  absl::Span<const Literal> results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  // sum [0, num_devices)
+  const uint32_t expected = kNumReplicas * (kNumReplicas - 1) / 2;
+  for (int i = 0; i < kNumReplicas; ++i) {
+    LiteralTestUtil::ExpectR0Equal<uint32_t>(expected, results[i]);
+  }
+}
+
 TEST_F(CollectiveOpsTestFFI, MulticastAllReduce) {
   if (device_count() < kNumReplicas) {
     GTEST_SKIP() << "Test requires at least " << kNumReplicas << " devices ("


### PR DESCRIPTION
Add support for assigning memory spaces to custom call operands and results via frontend attributes, handled directly by the buffer colorer in `gpu_memory_space_assignment.{h,cc}`.

Custom calls can now specify `operands_memory_spaces` and `results_memory_spaces` frontend attributes (e.g. `{0:1}`) to request non-default memory spaces for their buffers. The colorer reads these attributes during buffer assignment and colors the corresponding buffer values with the requested `MemorySpaceColor`, alongside the existing collective and Mosaic memory space logic.

#### Key additions:
- `AsMemorySpaceColor()` — converts and validates integer → `MemorySpaceColor`
- `ParseIndexMemorySpacePairs()` — parses `{index:memory_space,...}` strings
  into typed `std::pair<int64_t, MemorySpaceColor>` with validation
- `GetCustomCallOperandMemorySpace()` / `GetCustomCallResultMemorySpace()` —
  inspect custom call frontend attributes and return the requested color
- Custom call coloring integrated into `AssignColors()` within `CreateColorer`