### PR TITLE
[ROCm] Porting CUB sort FFI handler consolidation to ROCm.

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -828,6 +828,7 @@ cc_library(
         ":amdhipblaslt_plugin",
         ":buffer_comparator_kernel_rocm",
         ":collective_signal_rocm",
+        ":cub_sort_kernel_rocm",
         ":hipfft_plugin",
         ":make_batch_pointers_kernel_rocm",
         ":miopen_plugin",
@@ -840,7 +841,6 @@ cc_library(
         ":rocm_platform",
         ":rocm_solver_context",
         ":topk_kernel_rocm",
-    ] + [":cub_sort_kernel_rocm_" + suffix for suffix in get_cub_sort_kernel_types()] + [
         ":cub_scan_kernel_rocm",
     ],
     alwayslink = 1,
@@ -1157,7 +1157,7 @@ cc_library(
 
 # CUB sort kernel implementation (hipCUB/rocPRIM) - compiled with hipcc
 [rocm_library(
-    name = "cub_sort_kernel_rocm_impl_{}".format(typename),
+    name = "cub_sort_kernel_rocm_type_{}".format(typename),
     srcs = ["cub_sort_kernel_rocm_impl.cu.cc"],
     # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
     local_defines = ["CUB_TYPE_" + typename.upper()],
@@ -1178,25 +1178,32 @@ cc_library(
 ) for typename in get_cub_sort_kernel_types()]
 
 # CUB sort kernel FFI registration - compiled with regular C++ compiler
-[cc_library(
-    name = "cub_sort_kernel_rocm_{}".format(typename),
+cc_library(
+    name = "cub_sort_kernel_rocm",
     srcs = ["cub_sort_kernel_rocm.cc"],
-    local_defines = ["CUB_TYPE_" + typename.upper()],
     tags = [
         "gpu",
         "rocm-only",
     ],
     deps = [
         ":cub_sort_kernel_rocm_header",
-        ":cub_sort_kernel_rocm_impl_{}".format(typename),
+        ":rocm_status",
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
         "//xla/backends/gpu:ffi",
         "//xla/ffi",
         "//xla/ffi:ffi_api",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@local_config_rocm//rocm:rocm_headers",
+    ] + [
+        ":cub_sort_kernel_rocm_type_{}".format(typename)
+        for typename in get_cub_sort_kernel_types()
     ],
     alwayslink = 1,
-) for typename in get_cub_sort_kernel_types()]
+)
 
 # CUB scan kernel implementation (hipCUB/rocPRIM) - compiled with hipcc
 rocm_library(

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
@@ -17,208 +17,294 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "rocm/include/hip/hip_bfloat16.h"
 #include "rocm/include/hip/hip_fp16.h"
 #include "rocm/include/hip/hip_runtime.h"
 #include "xla/backends/gpu/ffi.h"
 #include "xla/ffi/ffi.h"
 #include "xla/ffi/ffi_api.h"  // IWYU pragma: keep
+#include "xla/primitive_util.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/xla_data.pb.h"
 
 namespace stream_executor {
 namespace rocm {
 namespace {
 
-template <typename KeyT>
-absl::Status CubSortKeysExecute(
-    xla::ffi::AnyBuffer d_temp_storage, xla::ffi::AnyBuffer d_keys_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out, size_t num_items,
-    bool descending, size_t batch_size, hipStream_t stream) {
-  size_t temp_bytes = d_temp_storage.size_bytes();
-  return CubSortKeys<KeyT>(d_temp_storage.untyped_data(), temp_bytes,
-                           d_keys_in.untyped_data(), d_keys_out->untyped_data(),
-                           num_items, descending, batch_size, stream);
+using SortKeysFn = absl::Status (*)(void* d_temp_storage, size_t& temp_bytes,
+                                    const void* d_keys_in, void* d_keys_out,
+                                    size_t num_items, bool descending,
+                                    size_t batch_size, hipStream_t stream);
+
+using SortPairsFn = absl::Status (*)(void* d_temp_storage, size_t& temp_bytes,
+                                     const void* d_keys_in, void* d_keys_out,
+                                     const void* d_values_in,
+                                     void* d_values_out, size_t num_items,
+                                     bool descending, size_t batch_size,
+                                     hipStream_t stream);
+
+absl::StatusOr<SortKeysFn> GetSortKeysFn(xla::PrimitiveType key_type) {
+  switch (key_type) {
+    case xla::BF16:
+      return CubSortKeys<hip_bfloat16>;
+    case xla::F16:
+      return CubSortKeys<__half>;
+    case xla::F32:
+      return CubSortKeys<float>;
+    case xla::F64:
+      return CubSortKeys<double>;
+    case xla::S8:
+      return CubSortKeys<int8_t>;
+    case xla::S16:
+      return CubSortKeys<int16_t>;
+    case xla::S32:
+      return CubSortKeys<int32_t>;
+    case xla::S64:
+      return CubSortKeys<int64_t>;
+    case xla::U8:
+      return CubSortKeys<uint8_t>;
+    case xla::U16:
+      return CubSortKeys<uint16_t>;
+    case xla::U32:
+      return CubSortKeys<uint32_t>;
+    case xla::U64:
+      return CubSortKeys<uint64_t>;
+    default:
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Unsupported key type for CUB sort: ",
+          xla::primitive_util::LowercasePrimitiveTypeName(key_type)));
+  }
 }
 
 template <typename KeyT>
-absl::Status CubSortKeysGetScratchSize(size_t* temp_bytes, size_t num_items,
-                                       size_t batch_size) {
-  return CubSortKeys<KeyT>(nullptr, *temp_bytes, nullptr, nullptr, num_items,
-                           false, batch_size, nullptr);
+absl::StatusOr<SortPairsFn> GetSortPairsFnForValueWidth(int value_bit_width) {
+  switch (value_bit_width) {
+    case 16:
+      return CubSortPairs<KeyT, uint16_t>;
+    case 32:
+      return CubSortPairs<KeyT, uint32_t>;
+    case 64:
+      return CubSortPairs<KeyT, uint64_t>;
+    default:
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Unsupported value bit width for CUB sort: ", value_bit_width));
+  }
 }
 
-template <typename KeyT, typename ValT>
-static absl::Status CubSortPairsExecute(
-    xla::ffi::AnyBuffer d_temp_storage, xla::ffi::AnyBuffer d_keys_in,
+absl::StatusOr<SortPairsFn> GetSortPairsFn(xla::PrimitiveType key_type,
+                                           int value_bit_width) {
+  switch (key_type) {
+    case xla::U8:
+      return GetSortPairsFnForValueWidth<uint8_t>(value_bit_width);
+    case xla::U16:
+      return GetSortPairsFnForValueWidth<uint16_t>(value_bit_width);
+    case xla::S32:
+      return GetSortPairsFnForValueWidth<int32_t>(value_bit_width);
+    case xla::U32:
+      return GetSortPairsFnForValueWidth<uint32_t>(value_bit_width);
+    case xla::F32:
+      return GetSortPairsFnForValueWidth<float>(value_bit_width);
+    case xla::U64:
+      return GetSortPairsFnForValueWidth<uint64_t>(value_bit_width);
+    default:
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Unsupported key type for CUB sort pairs: ",
+          xla::primitive_util::LowercasePrimitiveTypeName(key_type)));
+  }
+}
+
+// Computes the scratch buffer size needed for CUB sort, including batch
+// offsets if batch_size > 1.
+absl::StatusOr<int64_t> ComputeScratchSize(SortKeysFn fn, int64_t num_items,
+                                           int64_t batch_size) {
+  size_t temp_bytes = 0;
+  RETURN_IF_ERROR(fn(nullptr, temp_bytes, nullptr, nullptr, num_items, false,
+                     batch_size, nullptr));
+  int64_t scratch_size = temp_bytes;
+  if (batch_size > 1) {
+    scratch_size += sizeof(int32_t) - scratch_size % sizeof(int32_t);
+    scratch_size += (batch_size + 1) * sizeof(int32_t);
+  }
+  return scratch_size;
+}
+
+absl::StatusOr<int64_t> ComputeScratchSize(SortPairsFn fn, int64_t num_items,
+                                           int64_t batch_size) {
+  size_t temp_bytes = 0;
+  RETURN_IF_ERROR(fn(nullptr, temp_bytes, nullptr, nullptr, nullptr, nullptr,
+                     num_items, false, batch_size, nullptr));
+  int64_t scratch_size = temp_bytes;
+  if (batch_size > 1) {
+    scratch_size += sizeof(int32_t) - scratch_size % sizeof(int32_t);
+    scratch_size += (batch_size + 1) * sizeof(int32_t);
+  }
+  return scratch_size;
+}
+
+// N pairs of [start_offset, end_offset) require (N+1) storage.
+int64_t GetOffsetsSize(int64_t batch_size) {
+  return (batch_size + 1) * sizeof(int32_t);
+}
+
+// Copies segment offsets [0, segment_size, 2*segment_size, ...] to device
+// memory at the end of the scratch buffer for batched segmented sort.
+absl::Status CopyOffsets(void* scratch, size_t scratch_bytes,
+                         int64_t batch_size, int64_t segment_size,
+                         hipStream_t stream) {
+  int64_t offsets_size = GetOffsetsSize(batch_size);
+  char* offsets_buffer =
+      static_cast<char*>(scratch) + scratch_bytes - offsets_size;
+  std::vector<int32_t> h_offsets(batch_size + 1);
+  for (int32_t i = 0; i <= batch_size; ++i) {
+    h_offsets[i] = i * segment_size;
+  }
+  return gpu::ToStatus(hipMemcpyAsync(offsets_buffer, h_offsets.data(),
+                                      offsets_size, hipMemcpyHostToDevice,
+                                      stream));
+}
+
+//===----------------------------------------------------------------------===//
+// CubSortKeys: instantiate + execute
+//===----------------------------------------------------------------------===//
+
+// HLO custom call layout:
+//   operands: [keys_in]
+//   results:  [keys_out, scratch]
+
+absl::StatusOr<std::unique_ptr<int64_t>> CubSortKeysInstantiate(
+    xla::ffi::AnyBuffer d_keys_in,
     xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::AnyBuffer d_values_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out, size_t num_items,
-    bool descending, size_t batch_size, hipStream_t stream) {
-  size_t temp_bytes = d_temp_storage.size_bytes();
-  return CubSortPairs<KeyT, ValT>(
-      d_temp_storage.untyped_data(), temp_bytes, d_keys_in.untyped_data(),
-      d_keys_out->untyped_data(), d_values_in.untyped_data(),
-      d_values_out->untyped_data(), num_items, descending, batch_size, stream);
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    int64_t batch_size) {
+  ASSIGN_OR_RETURN(auto fn, GetSortKeysFn(d_keys_in.element_type()));
+  int64_t num_items = d_keys_in.element_count();
+  ASSIGN_OR_RETURN(int64_t scratch_size,
+                   ComputeScratchSize(fn, num_items, batch_size));
+  return std::make_unique<int64_t>(scratch_size);
 }
 
-template <typename KeyT, typename ValT>
-static absl::Status CubSortPairsGetScratchSize(size_t* temp_bytes,
-                                               size_t num_items,
-                                               size_t batch_size) {
-  return CubSortPairs<KeyT, ValT>(nullptr, *temp_bytes, nullptr, nullptr,
-                                  nullptr, nullptr, num_items, false,
-                                  batch_size, nullptr);
+absl::Status CubSortKeysExecute(
+    xla::ffi::AnyBuffer d_keys_in,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    int64_t batch_size, hipStream_t stream) {
+  ASSIGN_OR_RETURN(auto fn, GetSortKeysFn(d_keys_in.element_type()));
+  size_t num_items = d_keys_in.element_count();
+  size_t temp_bytes = d_temp_storage->size_bytes();
+  if (batch_size > 1) {
+    RETURN_IF_ERROR(CopyOffsets(d_temp_storage->untyped_data(), temp_bytes,
+                                batch_size, num_items / batch_size, stream));
+    temp_bytes -= GetOffsetsSize(batch_size);
+  }
+  return fn(d_temp_storage->untyped_data(), temp_bytes,
+            d_keys_in.untyped_data(), d_keys_out->untyped_data(), num_items,
+            descending, batch_size, stream);
 }
+
+XLA_FFI_DEFINE_HANDLER(kCubSortKeysInstantiate, CubSortKeysInstantiate,
+                       xla::ffi::Ffi::BindInstantiate()
+                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
+                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
+                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                           .Attr<bool>("descending")
+                           .Attr<int64_t>("batch_size"));
+
+XLA_FFI_DEFINE_HANDLER(kCubSortKeysExecute, CubSortKeysExecute,
+                       xla::ffi::Ffi::Bind()
+                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
+                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
+                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                           .Attr<bool>("descending")
+                           .Attr<int64_t>("batch_size")
+                           .Ctx<xla::ffi::PlatformStream<hipStream_t>>());
+
+XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_keys",
+                         "ROCM",
+                         {/* .instantiate = */ kCubSortKeysInstantiate,
+                          /* .prepare = */ nullptr,
+                          /* .initialize = */ nullptr,
+                          /* .execute = */ kCubSortKeysExecute});
+
+//===----------------------------------------------------------------------===//
+// CubSortPairs: instantiate + execute
+//===----------------------------------------------------------------------===//
+
+// HLO custom call layout:
+//   operands: [keys_in, values_in]
+//   results:  [keys_out, values_out, scratch]
+
+absl::StatusOr<std::unique_ptr<int64_t>> CubSortPairsInstantiate(
+    xla::ffi::AnyBuffer d_keys_in, xla::ffi::AnyBuffer d_values_in,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    int64_t batch_size) {
+  ASSIGN_OR_RETURN(auto fn, GetSortPairsFn(d_keys_in.element_type(),
+                                           xla::primitive_util::BitWidth(
+                                               d_values_in.element_type())));
+  int64_t num_items = d_keys_in.element_count();
+  ASSIGN_OR_RETURN(int64_t scratch_size,
+                   ComputeScratchSize(fn, num_items, batch_size));
+  return std::make_unique<int64_t>(scratch_size);
+}
+
+absl::Status CubSortPairsExecute(
+    xla::ffi::AnyBuffer d_keys_in, xla::ffi::AnyBuffer d_values_in,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out,
+    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    int64_t batch_size, hipStream_t stream) {
+  ASSIGN_OR_RETURN(auto fn, GetSortPairsFn(d_keys_in.element_type(),
+                                           xla::primitive_util::BitWidth(
+                                               d_values_in.element_type())));
+  size_t num_items = d_keys_in.element_count();
+  size_t temp_bytes = d_temp_storage->size_bytes();
+  if (batch_size > 1) {
+    RETURN_IF_ERROR(CopyOffsets(d_temp_storage->untyped_data(), temp_bytes,
+                                batch_size, num_items / batch_size, stream));
+    temp_bytes -= GetOffsetsSize(batch_size);
+  }
+  return fn(d_temp_storage->untyped_data(), temp_bytes,
+            d_keys_in.untyped_data(), d_keys_out->untyped_data(),
+            d_values_in.untyped_data(), d_values_out->untyped_data(), num_items,
+            descending, batch_size, stream);
+}
+
+XLA_FFI_DEFINE_HANDLER(kCubSortPairsInstantiate, CubSortPairsInstantiate,
+                       xla::ffi::Ffi::BindInstantiate()
+                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
+                           .Arg<xla::ffi::AnyBuffer>()  // d_values_in
+                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
+                           .Ret<xla::ffi::AnyBuffer>()  // d_values_out
+                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                           .Attr<bool>("descending")
+                           .Attr<int64_t>("batch_size"));
+
+XLA_FFI_DEFINE_HANDLER(kCubSortPairsExecute, CubSortPairsExecute,
+                       xla::ffi::Ffi::Bind()
+                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
+                           .Arg<xla::ffi::AnyBuffer>()  // d_values_in
+                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
+                           .Ret<xla::ffi::AnyBuffer>()  // d_values_out
+                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                           .Attr<bool>("descending")
+                           .Attr<int64_t>("batch_size")
+                           .Ctx<xla::ffi::PlatformStream<hipStream_t>>());
+
+XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_pairs",
+                         "ROCM",
+                         {/* .instantiate = */ kCubSortPairsInstantiate,
+                          /* .prepare = */ nullptr,
+                          /* .initialize = */ nullptr,
+                          /* .execute = */ kCubSortPairsExecute});
 
 }  // namespace
-
-#define XLA_CUB_DEFINE_SORT_KEYS(suffix, type)                                \
-  XLA_FFI_DEFINE_HANDLER(kCubSortKeysExecute_##suffix,                        \
-                         CubSortKeysExecute<type>,                            \
-                         xla::ffi::Ffi::Bind()                                \
-                             .Arg<xla::ffi::AnyBuffer>()                      \
-                             .Arg<xla::ffi::AnyBuffer>()                      \
-                             .Ret<xla::ffi::AnyBuffer>()                      \
-                             .Attr<size_t>("num_items")                       \
-                             .Attr<bool>("descending")                        \
-                             .Attr<size_t>("batch_size")                      \
-                             .Ctx<xla::ffi::PlatformStream<hipStream_t>>());  \
-  XLA_FFI_DEFINE_HANDLER(                                                     \
-      kCubSortKeysInitialize_##suffix, CubSortKeysGetScratchSize<type>,       \
-      xla::ffi::Ffi::Bind<xla::ffi::ExecutionStage::kInitialize>()            \
-          .Attr<xla::ffi::Pointer<size_t>>("temp_bytes")                      \
-          .Attr<size_t>("num_items")                                          \
-          .Attr<size_t>("batch_size"));                                       \
-  XLA_FFI_REGISTER_HANDLER(                                                   \
-      xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_keys_" #suffix, "ROCM", \
-      {/* .instantiate = */ nullptr, /* .prepare = */ nullptr,                \
-       /* .initialize = */ kCubSortKeysInitialize_##suffix,                   \
-       /* .execute = */ kCubSortKeysExecute_##suffix});
-
-#define XLA_CUB_DEFINE_SORT_PAIRS(suffix, type1, type2)                        \
-  XLA_FFI_DEFINE_HANDLER(kCubSortPairsExecute_##suffix,                        \
-                         (CubSortPairsExecute<type1, type2>),                  \
-                         xla::ffi::Ffi::Bind()                                 \
-                             .Arg<xla::ffi::AnyBuffer>()                       \
-                             .Arg<xla::ffi::AnyBuffer>()                       \
-                             .Ret<xla::ffi::AnyBuffer>()                       \
-                             .Arg<xla::ffi::AnyBuffer>()                       \
-                             .Ret<xla::ffi::AnyBuffer>()                       \
-                             .Attr<size_t>("num_items")                        \
-                             .Attr<bool>("descending")                         \
-                             .Attr<size_t>("batch_size")                       \
-                             .Ctx<xla::ffi::PlatformStream<hipStream_t>>());   \
-  XLA_FFI_DEFINE_HANDLER(                                                      \
-      kCubSortPairsInitialize_##suffix,                                        \
-      (CubSortPairsGetScratchSize<type1, type2>),                              \
-      xla::ffi::Ffi::Bind<xla::ffi::ExecutionStage::kInitialize>()             \
-          .Attr<xla::ffi::Pointer<size_t>>("temp_bytes")                       \
-          .Attr<size_t>("num_items")                                           \
-          .Attr<size_t>("batch_size"));                                        \
-  XLA_FFI_REGISTER_HANDLER(                                                    \
-      xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_pairs_" #suffix, "ROCM", \
-      {/* .instantiate = */ nullptr, /* .prepare = */ nullptr,                 \
-       /* .initialize = */ kCubSortPairsInitialize_##suffix,                   \
-       /* .execute = */ kCubSortPairsExecute_##suffix});
-
-// Floating point types.
-#ifdef CUB_TYPE_BF16
-XLA_CUB_DEFINE_SORT_KEYS(bf16, hip_bfloat16)
-#endif
-#ifdef CUB_TYPE_F16
-XLA_CUB_DEFINE_SORT_KEYS(f16, __half)
-#endif
-#ifdef CUB_TYPE_F32
-XLA_CUB_DEFINE_SORT_KEYS(f32, float)
-#endif
-#ifdef CUB_TYPE_F64
-XLA_CUB_DEFINE_SORT_KEYS(f64, double)
-#endif
-
-// Signed integer types.
-#ifdef CUB_TYPE_S8
-XLA_CUB_DEFINE_SORT_KEYS(s8, int8_t)
-#endif
-#ifdef CUB_TYPE_S16
-XLA_CUB_DEFINE_SORT_KEYS(s16, int16_t)
-#endif
-#ifdef CUB_TYPE_S32
-XLA_CUB_DEFINE_SORT_KEYS(s32, int32_t)
-#endif
-#ifdef CUB_TYPE_S64
-XLA_CUB_DEFINE_SORT_KEYS(s64, int64_t)
-#endif
-
-// Unsigned integer types.
-#ifdef CUB_TYPE_U8
-XLA_CUB_DEFINE_SORT_KEYS(u8, uint8_t)
-#endif
-#ifdef CUB_TYPE_U16
-XLA_CUB_DEFINE_SORT_KEYS(u16, uint16_t)
-#endif
-#ifdef CUB_TYPE_U32
-XLA_CUB_DEFINE_SORT_KEYS(u32, uint32_t)
-#endif
-#ifdef CUB_TYPE_U64
-XLA_CUB_DEFINE_SORT_KEYS(u64, uint64_t)
-#endif
-
-// Pairs with 8-bit key.
-#ifdef CUB_TYPE_U8_B16
-XLA_CUB_DEFINE_SORT_PAIRS(u8_b16, uint8_t, uint16_t)
-#endif
-#ifdef CUB_TYPE_U8_B32
-XLA_CUB_DEFINE_SORT_PAIRS(u8_b32, uint8_t, uint32_t)
-#endif
-#ifdef CUB_TYPE_U8_B64
-XLA_CUB_DEFINE_SORT_PAIRS(u8_b64, uint8_t, uint64_t)
-#endif
-
-// Pairs with 16-bit key.
-#ifdef CUB_TYPE_U16_B16
-XLA_CUB_DEFINE_SORT_PAIRS(u16_b16, uint16_t, uint16_t)
-#endif
-#ifdef CUB_TYPE_U16_B32
-XLA_CUB_DEFINE_SORT_PAIRS(u16_b32, uint16_t, uint32_t)
-#endif
-#ifdef CUB_TYPE_U16_B64
-XLA_CUB_DEFINE_SORT_PAIRS(u16_b64, uint16_t, uint64_t)
-#endif
-
-// Pairs with 32-bit key.
-#ifdef CUB_TYPE_S32_B32
-XLA_CUB_DEFINE_SORT_PAIRS(s32_b32, int32_t, uint32_t)
-#endif
-#ifdef CUB_TYPE_U32_B16
-XLA_CUB_DEFINE_SORT_PAIRS(u32_b16, uint32_t, uint16_t)
-#endif
-#ifdef CUB_TYPE_U32_B32
-XLA_CUB_DEFINE_SORT_PAIRS(u32_b32, uint32_t, uint32_t)
-#endif
-#ifdef CUB_TYPE_U32_B64
-XLA_CUB_DEFINE_SORT_PAIRS(u32_b64, uint32_t, uint64_t)
-#endif
-#ifdef CUB_TYPE_F32_B16
-XLA_CUB_DEFINE_SORT_PAIRS(f32_b16, float, uint16_t)
-#endif
-#ifdef CUB_TYPE_F32_B32
-XLA_CUB_DEFINE_SORT_PAIRS(f32_b32, float, uint32_t)
-#endif
-#ifdef CUB_TYPE_F32_B64
-XLA_CUB_DEFINE_SORT_PAIRS(f32_b64, float, uint64_t)
-#endif
-
-// Pairs with 64-bit key.
-#ifdef CUB_TYPE_U64_B16
-XLA_CUB_DEFINE_SORT_PAIRS(u64_b16, uint64_t, uint16_t)
-#endif
-#ifdef CUB_TYPE_U64_B32
-XLA_CUB_DEFINE_SORT_PAIRS(u64_b32, uint64_t, uint32_t)
-#endif
-#ifdef CUB_TYPE_U64_B64
-XLA_CUB_DEFINE_SORT_PAIRS(u64_b64, uint64_t, uint64_t)
-#endif
-
 }  // namespace rocm
 }  // namespace stream_executor

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.h
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.h
@@ -17,8 +17,11 @@ limitations under the License.
 #define XLA_STREAM_EXECUTOR_ROCM_CUB_SORT_KERNEL_ROCM_H_
 
 #include <cstddef>
+#include <cstdint>
 
 #include "absl/status/status.h"
+#include "rocm/include/hip/hip_bfloat16.h"
+#include "rocm/include/hip/hip_fp16.h"
 #include "rocm/include/hip/hip_runtime.h"
 
 namespace stream_executor {
@@ -43,6 +46,67 @@ absl::Status CubSortPairs(void* d_temp_storage, size_t& temp_bytes,
                           const void* d_values_in, void* d_values_out,
                           size_t num_items, bool descending, size_t batch_size,
                           hipStream_t stream);
+
+// Helper macros for extern template declarations.
+#define XLA_CUB_EXTERN_SORT_KEYS(type)            \
+  extern template absl::Status CubSortKeys<type>( \
+      void*, size_t&, const void*, void*, size_t, bool, size_t, hipStream_t)
+
+#define XLA_CUB_EXTERN_SORT_PAIRS(type1, type2)                             \
+  extern template absl::Status CubSortPairs<type1, type2>(                  \
+      void*, size_t&, const void*, void*, const void*, void*, size_t, bool, \
+      size_t, hipStream_t)
+
+// Floating point types.
+XLA_CUB_EXTERN_SORT_KEYS(hip_bfloat16);
+XLA_CUB_EXTERN_SORT_KEYS(__half);
+XLA_CUB_EXTERN_SORT_KEYS(float);
+XLA_CUB_EXTERN_SORT_KEYS(double);
+
+// Signed integer types.
+XLA_CUB_EXTERN_SORT_KEYS(int8_t);
+XLA_CUB_EXTERN_SORT_KEYS(int16_t);
+XLA_CUB_EXTERN_SORT_KEYS(int32_t);
+XLA_CUB_EXTERN_SORT_KEYS(int64_t);
+
+// Unsigned integer types.
+XLA_CUB_EXTERN_SORT_KEYS(uint8_t);
+XLA_CUB_EXTERN_SORT_KEYS(uint16_t);
+XLA_CUB_EXTERN_SORT_KEYS(uint32_t);
+XLA_CUB_EXTERN_SORT_KEYS(uint64_t);
+
+// Pairs with 8-bit key.
+XLA_CUB_EXTERN_SORT_PAIRS(uint8_t, uint16_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint8_t, uint32_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint8_t, uint64_t);
+
+// Pairs with 16-bit key.
+XLA_CUB_EXTERN_SORT_PAIRS(uint16_t, uint16_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint16_t, uint32_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint16_t, uint64_t);
+
+// Pairs with signed 32-bit key.
+XLA_CUB_EXTERN_SORT_PAIRS(int32_t, uint16_t);
+XLA_CUB_EXTERN_SORT_PAIRS(int32_t, uint32_t);
+XLA_CUB_EXTERN_SORT_PAIRS(int32_t, uint64_t);
+
+// Pairs with unsigned 32-bit key.
+XLA_CUB_EXTERN_SORT_PAIRS(uint32_t, uint16_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint32_t, uint32_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint32_t, uint64_t);
+
+// Pairs with 64-bit key.
+XLA_CUB_EXTERN_SORT_PAIRS(uint64_t, uint16_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint64_t, uint32_t);
+XLA_CUB_EXTERN_SORT_PAIRS(uint64_t, uint64_t);
+
+// Pairs with f32 keys.
+XLA_CUB_EXTERN_SORT_PAIRS(float, uint16_t);
+XLA_CUB_EXTERN_SORT_PAIRS(float, uint32_t);
+XLA_CUB_EXTERN_SORT_PAIRS(float, uint64_t);
+
+#undef XLA_CUB_EXTERN_SORT_KEYS
+#undef XLA_CUB_EXTERN_SORT_PAIRS
 
 }  // namespace rocm
 }  // namespace stream_executor

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
@@ -287,10 +287,18 @@ XLA_CUB_DEFINE_SORT_PAIRS(uint16_t, uint32_t)
 XLA_CUB_DEFINE_SORT_PAIRS(uint16_t, uint64_t)
 #endif
 
-// Pairs with 32-bit key.
+// Pairs with signed 32-bit key.
+#ifdef CUB_TYPE_S32_B16
+XLA_CUB_DEFINE_SORT_PAIRS(int32_t, uint16_t)
+#endif
 #ifdef CUB_TYPE_S32_B32
 XLA_CUB_DEFINE_SORT_PAIRS(int32_t, uint32_t)
 #endif
+#ifdef CUB_TYPE_S32_B64
+XLA_CUB_DEFINE_SORT_PAIRS(int32_t, uint64_t)
+#endif
+
+// Pairs with unsigned 32-bit key.
 #ifdef CUB_TYPE_U32_B16
 XLA_CUB_DEFINE_SORT_PAIRS(uint32_t, uint16_t)
 #endif
@@ -299,15 +307,6 @@ XLA_CUB_DEFINE_SORT_PAIRS(uint32_t, uint32_t)
 #endif
 #ifdef CUB_TYPE_U32_B64
 XLA_CUB_DEFINE_SORT_PAIRS(uint32_t, uint64_t)
-#endif
-#ifdef CUB_TYPE_F32_B16
-XLA_CUB_DEFINE_SORT_PAIRS(float, uint16_t)
-#endif
-#ifdef CUB_TYPE_F32_B32
-XLA_CUB_DEFINE_SORT_PAIRS(float, uint32_t)
-#endif
-#ifdef CUB_TYPE_F32_B64
-XLA_CUB_DEFINE_SORT_PAIRS(float, uint64_t)
 #endif
 
 // Pairs with 64-bit key.
@@ -319,6 +318,17 @@ XLA_CUB_DEFINE_SORT_PAIRS(uint64_t, uint32_t)
 #endif
 #ifdef CUB_TYPE_U64_B64
 XLA_CUB_DEFINE_SORT_PAIRS(uint64_t, uint64_t)
+#endif
+
+// Pairs with f32 key.
+#ifdef CUB_TYPE_F32_B16
+XLA_CUB_DEFINE_SORT_PAIRS(float, uint16_t)
+#endif
+#ifdef CUB_TYPE_F32_B32
+XLA_CUB_DEFINE_SORT_PAIRS(float, uint32_t)
+#endif
+#ifdef CUB_TYPE_F32_B64
+XLA_CUB_DEFINE_SORT_PAIRS(float, uint64_t)
 #endif
 
 }  // namespace rocm


### PR DESCRIPTION
📝 Summary of Changes
The CUB sort FFI handler was recently refactored and consolidated in two commits:
- https://github.com/openxla/xla/commit/878c52525f1a72856e5c5fd42775211f19266568
- https://github.com/openxla/xla/commit/ce4b95a3668977155ec4914b1b28f2d5bf040ef2

In order to allow ROCm devices to continue using the CUB sort function, these same changes were ported to the relevant ROCm files.

Changes to files in `xla/stream_executor/rocm/`
- The build file is restructured so that it no longer compiles `cub_sort_kernel_rocm.cc` for each type.
- The various helper functions from commit https://github.com/openxla/xla/commit/878c52525f1a72856e5c5fd42775211f19266568 have been ported here.
- The missing S32_B16 and S32_B64 template instantiations have been added.

🎯 Justification
This change was breaking unit tests in XLA and JAX on ROCm:
- XLA:
  - xla/gpu/service/tests/sorting_test.cc

- JAX:
  - tests/ann_test.py::AnnTest::test_approx_max_k0
  - tests/ann_test.py::AnnTest::test_approx_max_k5
  - tests/ann_test.py::AnnTest::test_approx_max_k8
  - tests/ann_test.py::AnnTest::test_approx_min_k0
  - tests/ann_test.py::AnnTest::test_approx_min_k5
  - tests/ann_test.py::AnnTest::test_approx_min_k8
  - tests/scipy_signal_test.py::LaxBackedScipySignalTests::testWelchAgainstNumpy8

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
The various unit tests are now passing with the changes in the PR.
- XLA (`sorting_test.cc`):
```
================================================================================
INFO: Found 1 test target...
Target //xla/service/gpu/tests:sorting_test_amdgpu_any up-to-date:
  bazel-bin/xla/service/gpu/tests/sorting_test_amdgpu_any
INFO: Elapsed time: 192.140s, Critical Path: 153.72s
INFO: 5136 processes: 650 internal, 4486 local.
INFO: Build completed successfully, 5136 total actions
//xla/service/gpu/tests:sorting_test_amdgpu_any                          PASSED in 31.8s
  Stats over 15 runs: max = 31.8s, min = 22.3s, avg = 29.9s, dev = 2.7s

Executed 1 out of 1 test: 1 test passes.
```
- JAX (`tests/ann_test.py::AnnTest::test_approx_*`):
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: xdist-3.8.0, hypothesis-6.142.1
collected 42 items / 32 deselected / 10 selected

tests/ann_test.py::AnnTest::test_approx_max_k0 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k1 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k2 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k3 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k4 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k5 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k6 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k7 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k8 PASSED
tests/ann_test.py::AnnTest::test_approx_max_k9 PASSED

============================================================= 10 passed, 32 deselected in 9.25s =============================================================
```
- JAX (`tests/scipy_signal_test.py::LaxBackedScipySignalTests::testWelchAgainstNumpy8`):
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: xdist-3.8.0, hypothesis-6.142.1
collected 100 items / 99 deselected / 1 selected

tests/scipy_signal_test.py::LaxBackedScipySignalTests::testWelchAgainstNumpy8 PASSED

============================================================= 1 passed, 99 deselected in 8.16s ==============================================================
```