### PR TITLE
[ROCm] Extend select_threshold macro to be more selective

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -601,9 +601,11 @@ cc_library(
 alias(
     name = "amd_comgr",
     actual = select_threshold(
-        above_or_eq = ":amd_comgr_dynamic",
-        below = ":amd_comgr_static",
-        threshold = 71000,
+        threshold_dict = {
+            62000: ":amd_comgr_static",
+            71000: ":amd_comgr_dynamic",
+            71200: ":amd_comgr_static",
+        },
         value = rocm_version_number(),
     ),
 )

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -14,8 +14,9 @@ def if_rocm(if_true, if_false = []):
     })
 
 def select_threshold(value, threshold_dict):
-    result = []
-    for key in sorted(threshold_dict.keys()):
+    sorted_keys = sorted(threshold_dict.keys())
+    result = threshold_dict[sorted_keys[0]]  # Default to the first threshold's value
+    for key in sorted_keys:
         if value >= key:
             result = threshold_dict[key]
 

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -13,8 +13,13 @@ def if_rocm(if_true, if_false = []):
         "//conditions:default": if_false
     })
 
-def select_threshold(value, above_or_eq, threshold, below):
-    return below if value < threshold else above_or_eq
+def select_threshold(value, threshold_dict):
+    result = []
+    for key in sorted(threshold_dict.keys()):
+        if value >= key:
+            result = threshold_dict[key]
+
+    return result
 
 def rocm_default_copts():
     """Default options for all ROCm compilations."""


### PR DESCRIPTION
📝 Summary of Changes
Extend select threshold macro to accept dictionary

🎯 Justification
We use select_threshold to handle changes in rocm interfaces changes in bazel 
dependencies. It appears that we need to handle more than one interface change
in currently supported distros. Therefore we introduce the handling through the dict

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
