### PR TITLE
[xla:gpu] Track while loop state in Thunk progerss tracking

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -2913,6 +2913,7 @@ cc_library(
         ":annotation",
         ":collective_thunk",
         ":thunk",
+        ":while_loop",
         "//xla:util",
         "//xla/stream_executor:event",
         "//xla/stream_executor:stream",
@@ -2928,6 +2929,7 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
         "@tsl//tsl/profiler/lib:scoped_annotation",
         "@tsl//tsl/profiler/lib:traceme",
     ],
@@ -3059,6 +3061,7 @@ cc_library(
     hdrs = ["while_loop.h"],
     deps = [
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/xla/backends/gpu/runtime/thunk_executor.cc
+++ b/xla/backends/gpu/runtime/thunk_executor.cc
@@ -31,16 +31,18 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "absl/types/span.h"
 #include "xla/backends/gpu/runtime/annotation.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/while_loop.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -101,8 +103,7 @@ absl::Status ThunkExecutor::ExecuteOnStream(
     // Maybe track thunk execution to report the progress.
     if (tracker) {
       absl::MutexLock lock(tracker->mu);
-      // Record when thunk was executed last time.
-      tracker->map.at(thunk).executed = absl::Now();
+      tracker->map.at(thunk).RecordExecution(IsInsideWhileLoopNest());
 
       // Record execution completion event on a stream.
       se::Stream* execution_stream = params.stream;
@@ -131,6 +132,12 @@ absl::Status ThunkExecutor::ExecuteOnStream(
 
 using ThunkExecution = ThunkExecutor::ScopedProgressTracker::ThunkExecution;
 
+void ThunkExecutor::ScopedProgressTracker::ThunkProgress::RecordExecution(
+    absl::Span<const WhileLoopState> loop_nest) {
+  executed = absl::Now();
+  this->loop_nest.assign(loop_nest.begin(), loop_nest.end());
+}
+
 thread_local ThunkExecutor::ScopedProgressTracker::ThunkEvents*
     ThunkExecutor::ScopedProgressTracker::installed_progress_tracker = nullptr;
 
@@ -151,6 +158,18 @@ ThunkExecutor::ScopedProgressTracker::~ScopedProgressTracker() {
     absl::MutexLock lock(events_->mu);
     events_->map.clear();
   }
+}
+
+size_t ThunkExecutor::ScopedProgressTracker::NumPendingThunks() {
+  absl::MutexLock lock(events_->mu);
+  size_t count = 0;
+  for (auto& [thunk, progress] : events_->map) {
+    if (progress.executed != absl::InfinitePast() &&
+        progress.event->PollForStatus() == se::Event::Status::kPending) {
+      ++count;
+    }
+  }
+  return count;
 }
 
 std::vector<ThunkExecution> ThunkExecutor::ScopedProgressTracker::CollectThunks(
@@ -187,7 +206,8 @@ std::vector<ThunkExecution> ThunkExecutor::ScopedProgressTracker::CollectThunks(
     if (result.size() >= n) break;
     if (entry.progress->event->PollForStatus() == status) {
       result.push_back({entry.progress->index, entry.progress->executed,
-                        entry.thunk->profile_annotation()});
+                        entry.thunk->profile_annotation(),
+                        entry.progress->loop_nest});
     }
   }
   return result;
@@ -222,7 +242,8 @@ absl::StatusOr<ThunkExecutor::ScopedProgressTracker> InstallProgressTracker(
       executor.thunks().WalkNested([&](Thunk* thunk) -> absl::Status {
         size_t index = progress_map.size();
         ASSIGN_OR_RETURN(auto event, stream_executor->CreateEvent());
-        progress_map[thunk] = {index, absl::InfinitePast(), std::move(event)};
+        progress_map[thunk] = ThunkProgress{
+            index, std::move(event), absl::InfinitePast(), /*loop_nest=*/{}};
         return absl::OkStatus();
       }));
 

--- a/xla/backends/gpu/runtime/thunk_executor.h
+++ b/xla/backends/gpu/runtime/thunk_executor.h
@@ -28,7 +28,9 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
+#include "absl/types/span.h"
 #include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/while_loop.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream_executor.h"
 
@@ -89,6 +91,7 @@ class ThunkExecutor::ScopedProgressTracker {
     size_t index;
     absl::Time executed;
     absl::string_view name;
+    std::vector<WhileLoopState> loop_nest;
   };
 
   ~ScopedProgressTracker();
@@ -100,6 +103,10 @@ class ThunkExecutor::ScopedProgressTracker {
     absl::MutexLock lock(events_->mu);
     return events_->map.size();
   }
+
+  // Returns the number of thunks that have been launched on the GPU stream but
+  // have not yet completed execution. This polls all executed thunk events.
+  size_t NumPendingThunks();
 
   // Returns the last `n` thunks that successfully completed execution.
   std::vector<ThunkExecution> LastCompletedThunks(size_t n);
@@ -122,9 +129,15 @@ class ThunkExecutor::ScopedProgressTracker {
   // index that is used by `ThunkExecutor` progress v-logging. We track the
   // time when a thunk was executed, but not when it completed.
   struct ThunkProgress {
+    // Records thunk execution time and snapshots the current loop nest.
+    void RecordExecution(absl::Span<const WhileLoopState> loop_nest);
+
     size_t index;
-    absl::Time executed;
     std::unique_ptr<se::Event> event;
+
+    // Updated on every call to `RecordExecution`.
+    absl::Time executed;
+    std::vector<WhileLoopState> loop_nest;
   };
 
   struct ThunkEvents {

--- a/xla/backends/gpu/runtime/while_loop.cc
+++ b/xla/backends/gpu/runtime/while_loop.cc
@@ -16,59 +16,63 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/while_loop.h"
 
 #include <cstddef>
-#include <list>
 #include <optional>
 #include <string>
-#include <utility>
+#include <vector>
 
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 namespace xla::gpu {
 
-static thread_local std::list<WhileLoopState> while_loop_stack;
+static thread_local std::vector<WhileLoopState> while_loop_stack;
 
-static const WhileLoopState* EnterWhileLoop(absl::string_view loop_name,
-                                            std::optional<size_t> trip_count) {
+static size_t EnterWhileLoop(absl::string_view loop_name,
+                             std::optional<size_t> trip_count) {
   size_t depth = while_loop_stack.size();
   while_loop_stack.push_back(
       WhileLoopState{std::string(loop_name), trip_count, depth, 0});
-  return &while_loop_stack.back();
+  return depth;
 }
 
-static const WhileLoopState* IncWhileLoopIteration() {
-  if (while_loop_stack.empty()) return nullptr;
-  ++while_loop_stack.back().loop_iteration;
-  return &while_loop_stack.back();
+static void IncWhileLoopIteration() {
+  if (!while_loop_stack.empty()) {
+    ++while_loop_stack.back().loop_iteration;
+  }
 }
 
-static WhileLoopState ExitWhileLoop() {
-  WhileLoopState state = std::move(while_loop_stack.back());
-  while_loop_stack.pop_back();
-  return state;
-}
+static void ExitWhileLoop() { while_loop_stack.pop_back(); }
 
 const WhileLoopState* IsInsideWhileLoop() {
   if (while_loop_stack.empty()) return nullptr;
   return &while_loop_stack.back();
 }
 
+absl::Span<const WhileLoopState> IsInsideWhileLoopNest() {
+  return while_loop_stack;
+}
+
 ScopedWhileLoop::ScopedWhileLoop(absl::string_view loop_name,
                                  std::optional<size_t> trip_count)
-    : state(EnterWhileLoop(loop_name, trip_count)) {}
+    : loop_depth_(EnterWhileLoop(loop_name, trip_count)) {}
 
 ScopedWhileLoop::~ScopedWhileLoop() { ExitWhileLoop(); }
 
 absl::string_view ScopedWhileLoop::loop_name() const {
-  return state->loop_name;
+  return while_loop_stack[loop_depth_].loop_name;
 }
 
 std::optional<size_t> ScopedWhileLoop::trip_count() const {
-  return state->loop_trip_count;
+  return while_loop_stack[loop_depth_].loop_trip_count;
 }
 
-size_t ScopedWhileLoop::loop_depth() const { return state->loop_depth; }
+size_t ScopedWhileLoop::loop_depth() const {
+  return while_loop_stack[loop_depth_].loop_depth;
+}
 
-size_t ScopedWhileLoop::loop_iteration() const { return state->loop_iteration; }
+size_t ScopedWhileLoop::loop_iteration() const {
+  return while_loop_stack[loop_depth_].loop_iteration;
+}
 
 void ScopedWhileLoop::IncLoopIteration() { IncWhileLoopIteration(); }
 

--- a/xla/backends/gpu/runtime/while_loop.h
+++ b/xla/backends/gpu/runtime/while_loop.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <string>
 
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 namespace xla::gpu {
 
@@ -82,6 +83,16 @@ struct WhileLoopState {
 // current thread is not running within a while loop.
 const WhileLoopState* IsInsideWhileLoop();
 
+// Returns the current while loop nest as a span of WhileLoopState entries, from
+// outermost to innermost loop. Returns an empty span if the current thread is
+// not running within a while loop. The back of the span is the innermost loop.
+//
+// WARNING: The returned span points into thread-local storage and is
+// invalidated by entering or exiting a while loop (i.e., constructing or
+// destroying a ScopedWhileLoop). Callers must consume the span immediately and
+// not hold it across such operations.
+absl::Span<const WhileLoopState> IsInsideWhileLoopNest();
+
 // An RAII helper that manages while loop state. Enters the loop upon
 // construction and exits it upon destruction. This is the only public API for
 // mutating while loop state.
@@ -102,7 +113,7 @@ class ScopedWhileLoop {
   void IncLoopIteration();
 
  private:
-  const WhileLoopState* state;
+  size_t loop_depth_;
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/while_loop_test.cc
+++ b/xla/backends/gpu/runtime/while_loop_test.cc
@@ -88,4 +88,27 @@ TEST(WhileLoopTest, PointerStability) {
   EXPECT_EQ(IsInsideWhileLoop(), nullptr);
 }
 
+TEST(WhileLoopTest, LoopNestSpan) {
+  ScopedWhileLoop outer("while.0", 5);
+  outer.IncLoopIteration();
+  outer.IncLoopIteration();
+
+  {
+    ScopedWhileLoop inner("while.1", 3);
+    inner.IncLoopIteration();
+
+    auto nest = IsInsideWhileLoopNest();
+    EXPECT_EQ(nest.size(), 2);
+    EXPECT_EQ(nest[0].loop_name, "while.0");
+    EXPECT_EQ(nest[0].loop_iteration, 2);
+    EXPECT_EQ(nest[1].loop_name, "while.1");
+    EXPECT_EQ(nest[1].loop_iteration, 1);
+  }
+
+  auto nest = IsInsideWhileLoopNest();
+  EXPECT_EQ(nest.size(), 1);
+  EXPECT_EQ(nest[0].loop_name, "while.0");
+  EXPECT_EQ(nest[0].loop_iteration, 2);
+}
+
 }  // namespace xla::gpu

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -118,6 +118,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/sorted_range.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
@@ -126,7 +127,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -486,13 +486,24 @@ absl::Status ExecuteThunksImpl(
           LOG(ERROR) << absl::StreamFormat("[%d] %s: size=%d", device_ordinal,
                                            label, thunks.size());
           for (auto& thunk : thunks) {
+            std::string loop_info;
+            for (const auto& state : thunk.loop_nest) {
+              absl::StrAppend(&loop_info,
+                              absl::StrFormat(" [%s iter=%d]", state.loop_name,
+                                              state.loop_iteration));
+            }
             LOG(ERROR) << absl::StreamFormat(
-                "  - thunk[%d/%d]: %s at %s", thunk.index,
+                "  - thunk[%d/%d]: %s at %s%s", thunk.index,
                 tracker->num_thunks(), thunk.name,
                 absl::FormatTime("%Y-%m-%d %H:%M:%S.%E6f", thunk.executed,
-                                 absl::LocalTimeZone()));
+                                 absl::LocalTimeZone()),
+                loop_info);
           }
         };
+
+        LOG(ERROR) << absl::StreamFormat(
+            "[%d] Pending thunks: %d/%d", device_ordinal,
+            tracker->NumPendingThunks(), tracker->num_thunks());
 
         log_progress("Last completed thunks",
                      tracker->LastCompletedThunks(progress_tracking_n));


### PR DESCRIPTION
Track inside what loop nest thunks are executed, because it's critical for debugging deadlocks that happen inside while loop iteration and thunks printed in reverse order, which is very confusing. Together with XLA dumps it becomes unambiguous what thunks are being executed.

For a thunk executing inside nested loops, the log will show all enclosing loops from outermost to innermost:

```
  [0] Pending thunks: 42/200
  [0] Last completed thunks: size=5
    - thunk[38/200]: kernel_a at 2026-03-24 10:00:01.123456 [while.0 iter=3] [while.1 iter=7]
    - thunk[37/200]: kernel_b at 2026-03-24 10:00:01.100000 [while.0 iter=3] [while.1 iter=7]
    - thunk[36/200]: kernel_c at 2026-03-24 10:00:01.050000 [while.0 iter=3] [while.1 iter=6]
```