### PR TITLE
[ROCm] Fix //xla/backends/gpu/autotuner:fission_backend_test failure

### DIFF
--- a/xla/backends/gpu/autotuner/fission_backend_test.cc
+++ b/xla/backends/gpu/autotuner/fission_backend_test.cc
@@ -624,8 +624,8 @@ TEST_F(CublasFissionBackendTest, CublasFallbackForBf16Bf16F32Algorithm) {
       EXPECT_FALSE(hasCublasConfig(configs));
     }
   } else {
-    // ROCm
-    EXPECT_TRUE(hasCublasConfig(configs));
+    // ROCm does not support kBF16AsF32
+    EXPECT_FALSE(hasCublasConfig(configs));
   }
 }
 


### PR DESCRIPTION
📝 Summary of Changes
 Fix CublasFissionBackendTest.CublasFallbackForBf16Bf16F32Algorithm failure.

🎯 Justification
 Makes the CI happy.

🚀 Kind of Contribution
🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
N\A

🧪 Execution Tests:
N\A
