### PR TITLE
Improvements to the HBM OOM Error page (Error E1000)

### DIFF
--- a/docs/errors/error_0101.md
+++ b/docs/errors/error_0101.md
@@ -39,7 +39,9 @@ fails with an OOM error, because the HBM is now occupied with more data buffers.
         reduce the amount of memory used for activations.
     -   **Parameter sharding:** For very large models, use model parallelism or
         sharding techniques (like FSDP or Megascale) to distribute the model's
-        parameters and computation across multiple TPU cores or hosts.
+        parameters and computation across multiple TPU cores or hosts. Note that
+        this can increase the network communication overhead due to splitting
+        tensors across multiple chips.
     -   **Shorten sequence/context length:** For models processing sequential
         data (e.g., NLP models), reducing the sequence length can significantly
         decrease memory usage.

--- a/docs/errors/error_1000.md
+++ b/docs/errors/error_1000.md
@@ -221,11 +221,14 @@ performance.
 #### Scenario 3.E Tune XLA rematerialization pass/manual checkpointing
 
 If the model is close to fitting into memory, you can use the
-[jax.checkpoint](https://docs.jax.dev/en/latest/notebooks/autodiff_remat.html)
+[jax.checkpoint](https://docs.jax.dev/en/latest/_autosummary/jax.checkpoint.html)
 decorator with `jax.grad` to manually control which intermediates are saved on
 the forward pass versus recomputed on the backward pass. Note that this
 operation may impact performance, since you are explicitly trading compute
-cycles for HBM.
+cycles for HBM. Check out the JAX documentation for more information:
+- [Gradient checkpointing with `jax.checkpoint` (`jax.remat`)](https://docs.jax.dev/en/latest/gradient-checkpointing.html)
+- [Control autodiff’s saved values with `jax.checkpoint` (aka `jax.remat`)](https://docs.jax.dev/en/latest/notebooks/autodiff_remat.html)
+- [JAX Memories and Host Offloading](https://docs.jax.dev/en/latest/notebooks/host-offloading.html)
 
 Alternatively, you can force the `XLA::Rematerialization` pass to prioritize
 memory savings, potentially at the cost of slower compilations:

--- a/docs/errors/error_1000.md
+++ b/docs/errors/error_1000.md
@@ -154,6 +154,9 @@ for the current hardware setup.
     -   Specify
         [sharding hints](https://docs.jax.dev/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html#constraining-shardings-of-intermediates-in-jitted-code)
         for intermediate values and outputs.
+
+    Note that this may cause an increase in network communication overhead due
+    to splitting tensors across multiple chips.
 -   **Use JAX host offloading:** Host offloading techniques allow the user to
     offload large tensors to the host CPU memory (e.g.
     [activation offloading](https://docs.jax.dev/en/latest/notebooks/host-offloading.html#activation-offloading)
@@ -236,7 +239,7 @@ errors and information that will help you decide what to do.
 
 | Intervention | Safe to do? (Will it change the behavior of the program?) | Potential gains | Telltale signs (is this actually the bottleneck that you're experiencing?) |
 | --- | --- | --- | --- |
-| Using advanced sharding techniques | **Yes.** It almost never changes the numerical correctness of the experiment. | **Massive gains** (up to a 256x reduction) | Unexpectedly large individual allocations in the memory viewer (e.g., a single tensor replicated across all TPUs that is 256x bigger than the others). Active arrays showing as un-sharded in TensorBoard hooks. |
+| Using advanced sharding techniques | **Yes.** It almost never changes the numerical correctness of the experiment, although it can cause network communication overhead due to splitting tensors across multiple chips. | **Massive gains** (up to a 256x reduction) | Unexpectedly large individual allocations in the memory viewer (e.g., a single tensor replicated across all TPUs that is 256x bigger than the others). Active arrays showing as un-sharded in TensorBoard hooks. |
 | Reducing batch size | **No.** It changes the training dynamics and usually requires retuning the learning rate. (Note: **Microbatching** is a safe alternative that reduces memory without changing behavior). | **Massive gains** (can save a factor of thousands). | "Temporaries" failing to allocate during gradient calculations. Seeing "JVP" in the operation name, and encountering many batch-size-shaped tensors in the memory profile. |
 | Enabling mixed Precision (e.g., Bfloat16) | **Risky.** It alters numerical precision, which can change experiment results or cause the model to fail to converge entirely. | **Moderate gains** (typically a factor of 2x, as it halves memory usage). | The memory viewer confirms that the largest tensors are currently utilizing 32-bit floats (`float32`). |
 | Manual checkpointing (`jax.checkpoint`) | **Yes.** It does not alter behavior; it merely trades computation time (flops) to save memory by recomputing tensors instead of storing them. | **Large gains** (e.g., can result in only half of the activations needing to exist in memory at the same time). | Multiple tensors of the exact same size filling up memory during a backward pass. Often accompanied by "JVP" in the operation name. |

--- a/docs/errors/error_1000.md
+++ b/docs/errors/error_1000.md
@@ -159,6 +159,9 @@ for the current hardware setup.
     [activation offloading](https://docs.jax.dev/en/latest/notebooks/host-offloading.html#activation-offloading)
     and
     [optimizer state offloading](https://docs.jax.dev/en/latest/notebooks/host-offloading.html#optimizer-state-offloading)).
+    Note that host offloading techniques can severely impact performance, since
+    these operations will force the system to constantly move large tensors back
+    and forth between TPU HBM and CPU RAM.
 
 #### Scenario 3.C Check tensor padding and alignment
 

--- a/docs/errors/error_1000.md
+++ b/docs/errors/error_1000.md
@@ -224,3 +224,18 @@ is crucial for understanding exactly what consumes HBM at the point of peak
 utilization. For general profiling setup, see
 [Getting started with Xprof](https://openxla.org/xprof#getting_started) and
 [TensorBoard Profiling](https://docs.jax.dev/en/latest/profiling.html#xprof-tensorboard-profiling).
+
+## Summary table
+
+The following table contains a summary of potential interventions to solve OOM
+errors and information that will help you decide what to do.
+
+| Intervention | Safe to do? (Will it change the behavior of the program?) | Potential gains | Telltale signs (is this actually the bottleneck that you're experiencing?) |
+| --- | --- | --- | --- |
+| Using advanced sharding techniques | **Yes.** It almost never changes the numerical correctness of the experiment. | **Massive gains** (up to a 256x reduction) | Unexpectedly large individual allocations in the memory viewer (e.g., a single tensor replicated across all TPUs that is 256x bigger than the others). Active arrays showing as un-sharded in TensorBoard hooks. |
+| Reducing batch size | **No.** It changes the training dynamics and usually requires retuning the learning rate. (Note: **Microbatching** is a safe alternative that reduces memory without changing behavior). | **Massive gains** (can save a factor of thousands). | "Temporaries" failing to allocate during gradient calculations. Seeing "JVP" in the operation name, and encountering many batch-size-shaped tensors in the memory profile. |
+| Enabling mixed Precision (e.g., Bfloat16) | **Risky.** It alters numerical precision, which can change experiment results or cause the model to fail to converge entirely. | **Moderate gains** (typically a factor of 2x, as it halves memory usage). | The memory viewer confirms that the largest tensors are currently utilizing 32-bit floats (`float32`). |
+| Explicit checkpointing (`jax.checkpoint`) | **Yes.** It does not alter behavior; it merely trades computation time (flops) to save memory by recomputing tensors instead of storing them. | **Large gains** (e.g., can result in only half of the activations needing to exist in memory at the same time). | Multiple tensors of the exact same size filling up memory during a backward pass. Often accompanied by "JVP" in the operation name. |
+| Donating input buffers (`donate_argnums`) | **Yes.** Maintains experiment integrity. If applied incorrectly, it will not corrupt data but will simply throw a clear error message. | **Marginal gains** (~1% memory savings). | There is no specific telltale sign, but it is considered a "free win" that is always worth trying. |
+| Changing model dimensions | **No.** Directly alters the model's behavior. Modifying input or output dimensions can completely break compatibility with the dataset. | **Variable gains** depending on how drastically hidden dimensions or layers are reduced. | The Xprof memory viewer shows a large amount of memory wasted on "padding" because array dimensions are not powers of two or multiples of 128 (e.g., a dimension of 2050 instead of 2048). |
+| Host offloading (CPU) | **Yes (numerically)**, but **No (performance)**. While mathematically safe, it is considered a "foot gun" that may cause severe speed bottlenecks due to data transfer between the CPU and TPU. | **Marginal gains** (the CPU only has about 3x the memory of the TPU). | Typically a last resort for massive optimizer states or for memory-heavy data preparation/pre-processing steps. |

--- a/docs/errors/error_1000.md
+++ b/docs/errors/error_1000.md
@@ -130,7 +130,9 @@ You can often resolve OOMs with these configuration adjustments:
 
 -   **Reduce batch size:** The memory needed for intermediate activations and
     gradients is directly proportional to the batch size. Reducing the batch
-    size can often help reduce memory usage.
+    size can often help reduce memory usage, although you may need to retune
+    your learning rate, momentum, or optimizer hyperparameters to maintain
+    model stability.
 -   **Donate input buffers:** When using `jax.jit`, specify
     [donate_argnums](https://docs.jax.dev/en/latest/buffer_donation.html) for
     your model parameters. This allows XLA to overwrite the input memory with
@@ -139,6 +141,26 @@ You can often resolve OOMs with these configuration adjustments:
     etc) for the largest tensors in the program if the model architecture and
     quality requirements allow. Note that this change can affect model behaviour
     and should be considered carefully.
+
+##### Micro-batching (optional)
+
+If reducing the global batch size or increasing the chip count is not viable,
+and the batch size per chip is not already minimized, you can try a
+micro-batching strategy:
+
+- Split each batch into `n` micro-batches;
+- For each micro-batch, process the forward and backward pass;
+- Once this is done, accumulate the gradients and update the weight as a whole.
+
+This process reduces the activation memory as we divided each batch into `n`
+micro-batches, so that the if the original batch had size `M`, the activation
+memory size becomes `M/n`.
+
+**Potential issues:**
+- This process increases step time as we have multiple forward and backward
+  passes.
+- If the sizes of the model and micro-batch are too different, you may face
+  convergence issues in your model.
 
 #### Scenario 3.B Optimize architecture and sharding
 

--- a/docs/errors/error_1000.md
+++ b/docs/errors/error_1000.md
@@ -198,8 +198,9 @@ performance.
 If the model is close to fitting into memory, you can use the
 [jax.checkpoint](https://docs.jax.dev/en/latest/notebooks/autodiff_remat.html)
 decorator with `jax.grad` to manually control which intermediates are saved on
-the forward pass versus recomputed on the backward pass, trading compute cycles
-for HBM.
+the forward pass versus recomputed on the backward pass. Note that this
+operation may impact performance, since you are explicitly trading compute
+cycles for HBM.
 
 Alternatively, you can force the `XLA::Rematerialization` pass to prioritize
 memory savings, potentially at the cost of slower compilations:
@@ -238,7 +239,7 @@ errors and information that will help you decide what to do.
 | Using advanced sharding techniques | **Yes.** It almost never changes the numerical correctness of the experiment. | **Massive gains** (up to a 256x reduction) | Unexpectedly large individual allocations in the memory viewer (e.g., a single tensor replicated across all TPUs that is 256x bigger than the others). Active arrays showing as un-sharded in TensorBoard hooks. |
 | Reducing batch size | **No.** It changes the training dynamics and usually requires retuning the learning rate. (Note: **Microbatching** is a safe alternative that reduces memory without changing behavior). | **Massive gains** (can save a factor of thousands). | "Temporaries" failing to allocate during gradient calculations. Seeing "JVP" in the operation name, and encountering many batch-size-shaped tensors in the memory profile. |
 | Enabling mixed Precision (e.g., Bfloat16) | **Risky.** It alters numerical precision, which can change experiment results or cause the model to fail to converge entirely. | **Moderate gains** (typically a factor of 2x, as it halves memory usage). | The memory viewer confirms that the largest tensors are currently utilizing 32-bit floats (`float32`). |
-| Explicit checkpointing (`jax.checkpoint`) | **Yes.** It does not alter behavior; it merely trades computation time (flops) to save memory by recomputing tensors instead of storing them. | **Large gains** (e.g., can result in only half of the activations needing to exist in memory at the same time). | Multiple tensors of the exact same size filling up memory during a backward pass. Often accompanied by "JVP" in the operation name. |
+| Manual checkpointing (`jax.checkpoint`) | **Yes.** It does not alter behavior; it merely trades computation time (flops) to save memory by recomputing tensors instead of storing them. | **Large gains** (e.g., can result in only half of the activations needing to exist in memory at the same time). | Multiple tensors of the exact same size filling up memory during a backward pass. Often accompanied by "JVP" in the operation name. |
 | Donating input buffers (`donate_argnums`) | **Yes.** Maintains experiment integrity. If applied incorrectly, it will not corrupt data but will simply throw a clear error message. | **Marginal gains** (~1% memory savings). | There is no specific telltale sign, but it is considered a "free win" that is always worth trying. |
 | Changing model dimensions | **No.** Directly alters the model's behavior. Modifying input or output dimensions can completely break compatibility with the dataset. | **Variable gains** depending on how drastically hidden dimensions or layers are reduced. | The Xprof memory viewer shows a large amount of memory wasted on "padding" because array dimensions are not powers of two or multiples of 128 (e.g., a dimension of 2050 instead of 2048). |
 | Host offloading (CPU) | **Yes (numerically)**, but **No (performance)**. While mathematically safe, it is considered a "foot gun" that may cause severe speed bottlenecks due to data transfer between the CPU and TPU. | **Marginal gains** (the CPU only has about 3x the memory of the TPU). | Typically a last resort for massive optimizer states or for memory-heavy data preparation/pre-processing steps. |

--- a/docs/errors/error_1000.md
+++ b/docs/errors/error_1000.md
@@ -133,10 +133,11 @@ You can often resolve OOMs with these configuration adjustments:
     size can often help reduce memory usage, although you may need to retune
     your learning rate, momentum, or optimizer hyperparameters to maintain
     model stability.
--   **Donate input buffers:** When using `jax.jit`, specify
-    [donate_argnums](https://docs.jax.dev/en/latest/buffer_donation.html) for
-    your model parameters. This allows XLA to overwrite the input memory with
-    the output.
+-   **Donate input buffers:** When JAX executes a computation it uses buffers on
+    the device for all inputs and outputs. If you know that one of the inputs is
+    not needed after the computation, and if it matches the shape and element
+    type of one of the outputs, you can specify that you want the corresponding
+    input buffer to be donated to hold an output. This will reduce the memory required for the execution by the size of the donated buffer. You can achieve this by specifying [donate_argnums](https://docs.jax.dev/en/latest/buffer_donation.html) parameter as an argument when using `jax.jit`.
 -   **Enable mixed precision (bfloat16):** Use bfloat16 or quantization (int8
     etc) for the largest tensors in the program if the model architecture and
     quality requirements allow. Note that this change can affect model behaviour

--- a/docs/oom_debugging.md
+++ b/docs/oom_debugging.md
@@ -72,10 +72,11 @@ The
 describes the components of the tool and the information presented.
 
 Focus on the *HLO Ops at Peak Memory Allocation* section that shows three buffer
-charts at the peak memory usage point. The buffer includes: * Program Inputs and
-Outputs: Training batches, optimizer states, etc. * TensorCore and SparseCore
-Temporaries: Dynamic memory required for intermediate calculations (like
-activations, gradients, etc.)
+charts at the peak memory usage point. The buffer includes:
+
+- **Program Inputs and Outputs:** Training batches, optimizer states, etc.
+- **TensorCore and SparseCore Temporaries:** Dynamic memory required for
+  intermediate calculations (like activations, gradients, etc.)
 
 You can hover on the buffer charts to get more details about the Op like it's
 size, shape, allocation type, and more. This can help you identify and evaluate


### PR DESCRIPTION
📝 Summary of Changes
This PR adds the following updates to the error E1000 page:
- Adds a table with a summary of potential interventions for OOM errors and how to rank them in terms of safety, impact and caveats;
- Adds a few notes about drawbacks of specific interventions, such as host offloading, microbatching, manual checkpointing and advanced sharding techniques;
- Adds more context on donating input buffers.

🎯 Justification
These improvements are suggested by the an internal UXR study.

🚀 Kind of Contribution
Please remove what does not apply: 📚 Documentation

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
N/A

🧪 Execution Tests:
N/A