### PR TITLE
[ROCm] Fix parse empty rocm distro links

### DIFF
--- a/third_party/gpus/rocm/rocm_redist.bzl
+++ b/third_party/gpus/rocm/rocm_redist.bzl
@@ -42,6 +42,9 @@ rocm_redist = {
 
 def _parse_rocm_distro_links(distro_links):
     result = []
+    if distro_links == "":
+        return result
+
     for pair in distro_links.split(","):
         link = pair.split(":")
         result.append(struct(target = link[0], link = link[1]))


### PR DESCRIPTION
📝 Summary of Changes
Fix parsing of rocm symlink if the value is empty

🎯 Justification
rocm_configure will fail if the symlinks are not required for a particular distro of therock

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
