### PR TITLE
[ROCm] Switch jax ut pipeline to use k8s runners

### DIFF
--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -33,7 +33,7 @@ jobs:
   execute-jax-ut:
     if: github.event.repository.fork == false
     name: JAX Linux x86 AMD Instinct GPU
-    runs-on: linux-x86-64-8gpu-amd
+    runs-on: linux-x86_64-cirrascale-64-8gpu-amd-mi250
     env:
       DOCKER_IMAGE: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
     container:
@@ -84,4 +84,5 @@ jobs:
             --override_repository=xla=${GITHUB_WORKSPACE} \
             --config=single_gpu \
             --local_test_jobs=4 \
-            --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${DOCKER_IMAGE}
+            --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${DOCKER_IMAGE} \
+            --crosstool_top=@local_config_rocm//crosstool:toolchain-local


### PR DESCRIPTION
📝 Summary of Changes
Switch jax-ut pipeline to use k8s runners pool

🎯 Justification
There are more runners with a given label available, that shall improve our response time

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
asserting correctness. Please provide test cases running with at most 2 GPUs.
