### PR TITLE
[ROCm] Use one gpu runner for jax pipeline

### DIFF
--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -33,7 +33,7 @@ jobs:
   execute-jax-ut:
     if: github.event.repository.fork == false
     name: JAX Linux x86 AMD Instinct GPU
-    runs-on: linux-x86-64-8gpu-amd
+    runs-on: linux-x86-64-1gpu-amd
     env:
       DOCKER_IMAGE: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
     container:
@@ -83,5 +83,5 @@ jobs:
           ./ci/run_bazel_test_rocm_rbe.sh \
             --override_repository=xla=${GITHUB_WORKSPACE} \
             --config=single_gpu \
-            --local_test_jobs=4 \
+            --local_test_jobs=1 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${DOCKER_IMAGE}


### PR DESCRIPTION
📝 Summary of Changes
Use 1gpu runner for jax pipeline

🎯 Justification
Using 8gpus for a jax pipeline is wasteful as we do not execute multigpu tests anyway.
Also we use rbe so tests are not executed locally

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
