### PR TITLE
[xla:gpu] Correctly track thunk progress in presence of loops

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -19,14 +19,44 @@ package_group(
 )
 
 #===-------------------------------------------------------------------------------------------===//
-# Runtime tracing libraries
+# Runtime support libraries
 #===-------------------------------------------------------------------------------------------===//
 
 cc_library(
-    name = "thunk_runtime_dependencies",
-    # Register GPU collectives plugin.
-    deps = ["//xla/backends/gpu/collectives:gpu_collectives_plugin"],
+    name = "event_pool",
+    srcs = ["event_pool.cc"],
+    hdrs = ["event_pool.h"],
+    deps = [
+        "//xla/runtime:object_pool",
+        "//xla/stream_executor:event",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/status:statusor",
+    ],
 )
+
+cc_library(
+    name = "while_loop",
+    srcs = ["while_loop.cc"],
+    hdrs = ["while_loop.h"],
+    deps = [
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "while_loop_test",
+    srcs = ["while_loop_test.cc"],
+    deps = [
+        ":while_loop",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+#===-------------------------------------------------------------------------------------------===//
+# Runtime tracing libraries
+#===-------------------------------------------------------------------------------------------===//
 
 cc_library(
     name = "annotation",
@@ -131,6 +161,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/profiler/lib:scoped_annotation",
     ],
@@ -341,6 +372,12 @@ cc_library(
 #===-------------------------------------------------------------------------------------------===//
 # XLA Thunks Runtime
 #===-------------------------------------------------------------------------------------------===//
+
+cc_library(
+    name = "thunk_runtime_dependencies",
+    # Register GPU collectives plugin.
+    deps = ["//xla/backends/gpu/collectives:gpu_collectives_plugin"],
+)
 
 cc_library(
     name = "async_execution",
@@ -2824,6 +2861,7 @@ cc_library(
     deps = [
         ":annotation",
         ":collective_thunk",
+        ":event_pool",
         ":thunk",
         ":while_loop",
         "//xla:util",
@@ -2856,6 +2894,8 @@ xla_test(
         ":sequential_thunk",
         ":thunk",
         ":thunk_executor",
+        ":while_loop",
+        ":while_thunk",
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/service:buffer_assignment",
@@ -2871,6 +2911,7 @@ xla_test(
         "//xla/stream_executor:stream_executor_h",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
@@ -2964,26 +3005,6 @@ xla_cc_test(
         "@com_google_absl//absl/log:check",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
-    ],
-)
-
-cc_library(
-    name = "while_loop",
-    srcs = ["while_loop.cc"],
-    hdrs = ["while_loop.h"],
-    deps = [
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
-    ],
-)
-
-xla_cc_test(
-    name = "while_loop_test",
-    srcs = ["while_loop_test.cc"],
-    deps = [
-        ":while_loop",
-        "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -469,7 +469,7 @@ CommandExecutor::RecordCreate(
     return std::vector<const se::CommandBuffer::Command*>{};
   }
 
-  auto* state = command_buffer->GetOrCreateResource<CommandExecutorsState>();
+  auto* state = command_buffer->GetOrConstructResource<CommandExecutorsState>();
   RecordedCommands& recorded_commands =
       state->recorded_commands[std::make_pair(this, record_id)];
 
@@ -588,7 +588,7 @@ absl::Status CommandExecutor::RecordUpdate(
     return alloc_intersection.empty();
   };
 
-  auto* state = command_buffer->GetOrCreateResource<CommandExecutorsState>();
+  auto* state = command_buffer->GetOrConstructResource<CommandExecutorsState>();
   RecordedCommands& recorded_commands =
       state->recorded_commands[std::make_pair(this, record_id)];
 
@@ -675,7 +675,7 @@ std::vector<const se::CommandBuffer::Command*> CommandExecutor::Dependencies(
     dependencies_ids.push_back(id - 1);
   }
 
-  auto* state = command_buffer->GetOrCreateResource<CommandExecutorsState>();
+  auto* state = command_buffer->GetOrConstructResource<CommandExecutorsState>();
   RecordedCommands& recorded_commands =
       state->recorded_commands[std::make_pair(this, record_id)];
 

--- a/xla/backends/gpu/runtime/event_pool.cc
+++ b/xla/backends/gpu/runtime/event_pool.cc
@@ -1,0 +1,34 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/event_pool.h"
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla::gpu {
+
+EventPool::EventPool(stream_executor::StreamExecutor* executor)
+    : Base([executor] { return executor->CreateEvent(); }),
+      executor_(executor) {}
+
+absl::StatusOr<EventPool::Event> EventPool::GetOrCreateEvent() {
+  return GetOrCreate();
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/event_pool.h
+++ b/xla/backends/gpu/runtime/event_pool.h
@@ -1,0 +1,47 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_EVENT_POOL_H_
+#define XLA_BACKENDS_GPU_RUNTIME_EVENT_POOL_H_
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "xla/runtime/object_pool.h"
+#include "xla/stream_executor/event.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla::gpu {
+
+// A pool of lazily created stream executor events. Events are returned to the
+// pool when the borrowed Event handle goes out of scope. Can be attached to a
+// StreamExecutor as a resource via GetOrConstructResource<EventPool>(executor).
+class EventPool : public stream_executor::StreamExecutor::Resource,
+                  ObjectPool<std::unique_ptr<stream_executor::Event>> {
+  using Base = ObjectPool<std::unique_ptr<stream_executor::Event>>;
+
+ public:
+  using Event = Base::BorrowedObject;
+  explicit EventPool(stream_executor::StreamExecutor* executor);
+
+  absl::StatusOr<Event> GetOrCreateEvent();
+
+ private:
+  stream_executor::StreamExecutor* executor_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_EVENT_POOL_H_

--- a/xla/backends/gpu/runtime/thunk_executor.cc
+++ b/xla/backends/gpu/runtime/thunk_executor.cc
@@ -18,31 +18,31 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <utility>
 #include <vector>
 
 #include "absl/algorithm/container.h"
-#include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
-#include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/runtime/annotation.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
+#include "xla/backends/gpu/runtime/event_pool.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/while_loop.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -76,10 +76,9 @@ absl::Status ThunkExecutor::ExecuteOnStream(
         GetKernelAnnotation(thunk->profile_annotation());
 
     // If progress tracker is installed for current thread, verify that a
-    // thunk progress record exists for the given `thunk`.
+    // thunk indexing record exists for the given `thunk`.
     if (tracker) {
-      absl::MutexLock lock(tracker->mu);
-      if (!tracker->map.contains(thunk.get())) {
+      if (!tracker->indexing.contains(thunk.get())) {
         return Internal(
             "[thunk=%d/%d] Progress tracker is missing a record for thunk `%s`",
             i, thunks_.size(), thunk->profile_annotation());
@@ -102,8 +101,8 @@ absl::Status ThunkExecutor::ExecuteOnStream(
 
     // Maybe track thunk execution to report the progress.
     if (tracker) {
-      absl::MutexLock lock(tracker->mu);
-      tracker->map.at(thunk).RecordExecution(IsInsideWhileLoopNest());
+      // Borrow an event from the pool and record it on the execution stream.
+      ASSIGN_OR_RETURN(auto event, tracker->event_pool->GetOrCreateEvent());
 
       // Record execution completion event on a stream.
       se::Stream* execution_stream = params.stream;
@@ -115,8 +114,11 @@ absl::Status ThunkExecutor::ExecuteOnStream(
         execution_stream = params.collective_params->async_streams.at(
             thunk->execution_stream_id().value());
       }
-      RETURN_IF_ERROR(
-          execution_stream->RecordEvent(tracker->map.at(thunk).event.get()));
+      RETURN_IF_ERROR(execution_stream->RecordEvent(event->get()));
+
+      absl::MutexLock lock(tracker->mu);
+      tracker->events.emplace_back(thunk.get(), std::move(event),
+                                   IsInsideWhileLoopNest());
     }
 
     XLA_VLOG_DEVICE(1, device_ordinal) << absl::StreamFormat(
@@ -132,84 +134,82 @@ absl::Status ThunkExecutor::ExecuteOnStream(
 
 using ThunkExecution = ThunkExecutor::ScopedProgressTracker::ThunkExecution;
 
-void ThunkExecutor::ScopedProgressTracker::ThunkProgress::RecordExecution(
-    absl::Span<const WhileLoopState> loop_nest) {
-  executed = absl::Now();
-  this->loop_nest.assign(loop_nest.begin(), loop_nest.end());
-}
-
-thread_local ThunkExecutor::ScopedProgressTracker::ThunkEvents*
+thread_local ThunkExecutor::ScopedProgressTracker::ProgressTracker*
     ThunkExecutor::ScopedProgressTracker::installed_progress_tracker = nullptr;
 
+ThunkExecutor::ScopedProgressTracker::ThunkExecutionEvent::ThunkExecutionEvent(
+    const Thunk* thunk, EventPool::Event event,
+    absl::Span<const WhileLoopState> loop_nest)
+    : thunk(thunk),
+      executed(absl::Now()),
+      event(std::move(event)),
+      loop_nest(loop_nest.begin(), loop_nest.end()) {}
+
 ThunkExecutor::ScopedProgressTracker::ScopedProgressTracker(
-    absl::flat_hash_map<const Thunk*, ThunkProgress> progress_map)
-    : events_(std::make_unique<ThunkEvents>(std::move(progress_map))) {
+    EventPool* event_pool, ThunkIndexing indexing)
+    : tracker_(
+          std::make_unique<ProgressTracker>(std::move(indexing), event_pool)) {
   CHECK_EQ(installed_progress_tracker, nullptr)  // Crash OK
       << "Tried to install multiple progress trackers";
-  installed_progress_tracker = events_.get();
+  installed_progress_tracker = tracker_.get();
 }
 
 ThunkExecutor::ScopedProgressTracker::~ScopedProgressTracker() {
-  if (events_ != nullptr) {  // Skip moved-from ScopedProgressTracker
-    tsl::profiler::TraceMe trace("~ScopedProgressTracker");
-    CHECK_EQ(installed_progress_tracker, events_.get())  // Crash OK
+  if (tracker_) {  // Skip moved-from ScopedProgressTracker
+    CHECK_EQ(installed_progress_tracker, tracker_.get())  // Crash OK
         << "Tried to destroy progress tracker on a different thread";
     installed_progress_tracker = nullptr;
-    absl::MutexLock lock(events_->mu);
-    events_->map.clear();
   }
 }
 
 size_t ThunkExecutor::ScopedProgressTracker::NumPendingThunks() {
-  absl::MutexLock lock(events_->mu);
-  size_t count = 0;
-  for (auto& [thunk, progress] : events_->map) {
-    if (progress.executed != absl::InfinitePast() &&
-        progress.event->PollForStatus() == se::Event::Status::kPending) {
-      ++count;
-    }
-  }
-  return count;
+  absl::MutexLock lock(tracker_->mu);
+  return absl::c_count_if(tracker_->events, [](const auto& event) {
+    return event.event->get()->PollForStatus() == se::Event::Status::kPending;
+  });
+}
+
+size_t ThunkExecutor::ScopedProgressTracker::NumCompletedThunks() {
+  absl::MutexLock lock(tracker_->mu);
+  return absl::c_count_if(tracker_->events, [](const auto& event) {
+    return event.event->get()->PollForStatus() == se::Event::Status::kComplete;
+  });
 }
 
 std::vector<ThunkExecution> ThunkExecutor::ScopedProgressTracker::CollectThunks(
     se::Event::Status status, bool most_recent_first, size_t n) {
-  absl::MutexLock lock(events_->mu);
+  absl::MutexLock lock(tracker_->mu);
 
-  // Helper struct for sorting executed thunks by timestamp before lazily
-  // polling event status. We keep a pointer to the map entry to avoid copying
-  // and to defer the expensive PollForStatus call.
-  struct ExecutedThunkEntry {
-    const Thunk* thunk;
-    ThunkProgress* progress;
+  ThunkIndexing& indexing = tracker_->indexing;
+  absl::Span<const ThunkExecutionEvent> events = tracker_->events;
+
+  // Events are naturally in chronological order (oldest first). Iterate forward
+  // for oldest-first or backward for most-recent-first.
+  std::vector<ThunkExecution> result;
+
+  auto collect = [&](const ThunkExecutionEvent& event) {
+    if (event.event->get()->PollForStatus() == status) {
+      result.push_back({indexing.at(event.thunk), event.executed,
+                        event.thunk->profile_annotation(), event.loop_nest});
+    }
   };
 
-  // Collect all thunks that have been executed (cheap: just reads timestamps).
-  std::vector<ExecutedThunkEntry> entries;
-  entries.reserve(events_->map.size());
-  for (auto& [thunk, progress] : events_->map) {
-    if (progress.executed != absl::InfinitePast()) {
-      entries.push_back({thunk, &progress});
+  if (most_recent_first) {
+    for (auto it = events.rbegin(); it != events.rend(); ++it) {
+      if (result.size() >= n) {
+        break;
+      }
+      collect(*it);
+    }
+  } else {
+    for (auto it = events.begin(); it != events.end(); ++it) {
+      if (result.size() >= n) {
+        break;
+      }
+      collect(*it);
     }
   }
 
-  // Sort by executed time before checking event status.
-  absl::c_stable_sort(
-      entries, [most_recent_first](const auto& a, const auto& b) {
-        return most_recent_first ? a.progress->executed > b.progress->executed
-                                 : a.progress->executed < b.progress->executed;
-      });
-
-  // Lazily check event status and stop once we have enough results.
-  std::vector<ThunkExecution> result;
-  for (auto& entry : entries) {
-    if (result.size() >= n) break;
-    if (entry.progress->event->PollForStatus() == status) {
-      result.push_back({entry.progress->index, entry.progress->executed,
-                        entry.thunk->profile_annotation(),
-                        entry.progress->loop_nest});
-    }
-  }
   return result;
 }
 
@@ -235,22 +235,20 @@ absl::StatusOr<ThunkExecutor::ScopedProgressTracker> InstallProgressTracker(
     se::StreamExecutor* stream_executor, ThunkExecutor& executor) {
   tsl::profiler::TraceMe trace("InstallProgressTracker");
 
-  using ThunkProgress = ThunkExecutor::ScopedProgressTracker::ThunkProgress;
-  absl::flat_hash_map<const Thunk*, ThunkProgress> progress_map;
-
+  ThunkExecutor::ScopedProgressTracker::ThunkIndexing indexing;
   RETURN_IF_ERROR(
       executor.thunks().WalkNested([&](Thunk* thunk) -> absl::Status {
-        size_t index = progress_map.size();
-        ASSIGN_OR_RETURN(auto event, stream_executor->CreateEvent());
-        progress_map[thunk] = ThunkProgress{
-            index, std::move(event), absl::InfinitePast(), /*loop_nest=*/{}};
+        size_t index = indexing.size();
+        indexing[thunk] = index;
         return absl::OkStatus();
       }));
 
   XLA_VLOG_DEVICE(1, stream_executor->device_ordinal()) << absl::StreamFormat(
-      "Installed progress tracker for %d thunks", progress_map.size());
+      "Installed progress tracker for %d thunks", indexing.size());
 
-  return ThunkExecutor::ScopedProgressTracker(std::move(progress_map));
+  return ThunkExecutor::ScopedProgressTracker(
+      stream_executor->GetOrConstructResource<EventPool>(stream_executor),
+      std::move(indexing));
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/thunk_executor.h
+++ b/xla/backends/gpu/runtime/thunk_executor.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "xla/backends/gpu/runtime/event_pool.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/while_loop.h"
 #include "xla/stream_executor/event.h"
@@ -85,8 +86,14 @@ class ThunkExecutor {
 // single-threaded.
 class ThunkExecutor::ScopedProgressTracker {
  public:
+  // We use global indexing across all nested thunks in a sequence, not only the
+  // top-level thunks executed by `ThunkExecutor`. The index is assigned by DFS
+  // traversal of the thunk sequence using WalkNested. This is different from
+  // the index that is used by `ThunkExecutor` progress v-logging.
+  using ThunkIndexing = absl::flat_hash_map<const Thunk*, size_t>;
+
   // Thunk execution record: the thunk's global index, the wall-clock time it
-  // was launched, and its human-readable name.
+  // was launched, its human-readable name, and the enclosing loop nest state.
   struct ThunkExecution {
     size_t index;
     absl::Time executed;
@@ -99,10 +106,13 @@ class ThunkExecutor::ScopedProgressTracker {
   ScopedProgressTracker(ScopedProgressTracker&&) = default;
   ScopedProgressTracker& operator=(ScopedProgressTracker&&) = default;
 
-  size_t num_thunks() const {
-    absl::MutexLock lock(events_->mu);
-    return events_->map.size();
-  }
+  // Returns the number of thunks in the tracked thunk sequence. This includes
+  // all thunks nested inside others.
+  size_t num_thunks() const { return tracker_->indexing.size(); }
+
+  // Returns the number of thunks that have been launched on the GPU stream and
+  // have completed execution. This polls all executed thunk events.
+  size_t NumCompletedThunks();
 
   // Returns the number of thunks that have been launched on the GPU stream but
   // have not yet completed execution. This polls all executed thunk events.
@@ -121,39 +131,43 @@ class ThunkExecutor::ScopedProgressTracker {
 
  private:
   friend class ThunkExecutor;
-  friend absl::StatusOr<ThunkExecutor::ScopedProgressTracker>
-  InstallProgressTracker(se::StreamExecutor*, ThunkExecutor&);
+  friend absl::StatusOr<ScopedProgressTracker> InstallProgressTracker(
+      se::StreamExecutor*, ThunkExecutor&);
 
-  // We use global indexing across all nested thunks in a sequence, not only the
-  // top-level thunks executed by `ThunkExecutor`. This is different from the
-  // index that is used by `ThunkExecutor` progress v-logging. We track the
-  // time when a thunk was executed, but not when it completed.
-  struct ThunkProgress {
-    // Records thunk execution time and snapshots the current loop nest.
-    void RecordExecution(absl::Span<const WhileLoopState> loop_nest);
+  // An event recorded for every thunk execution. The same thunk can be executed
+  // 0 to N times during XLA program execution: it can be in a not-taken
+  // conditional branch, or it can be inside a while loop (or the whole while
+  // loop nest). We keep a separate record for each execution to be able to
+  // distinguish executions that happens in different loop iterations.
+  struct ThunkExecutionEvent {
+    ThunkExecutionEvent(const Thunk* thunk, EventPool::Event event,
+                        absl::Span<const WhileLoopState> loop_nest);
 
-    size_t index;
-    std::unique_ptr<se::Event> event;
-
-    // Updated on every call to `RecordExecution`.
-    absl::Time executed;
-    std::vector<WhileLoopState> loop_nest;
+    const Thunk* thunk;
+    absl::Time executed;                    // wall time when thunk was launched
+    EventPool::Event event;                 // device event for the launch
+    std::vector<WhileLoopState> loop_nest;  // enclosing loop state snapshot
   };
 
-  struct ThunkEvents {
-    explicit ThunkEvents(absl::flat_hash_map<const Thunk*, ThunkProgress> map)
-        : map(std::move(map)) {}
+  // Mutable state shared between the ScopedProgressTracker and the
+  // ThunkExecutor via thread-local pointer. Holds thunk indexing (immutable),
+  // the event pool, and a growing log of execution events.
+  struct ProgressTracker {
+    ProgressTracker(ThunkIndexing indexing, EventPool* event_pool)
+        : indexing(std::move(indexing)), event_pool(event_pool) {}
+
+    ThunkIndexing indexing;
+    EventPool* event_pool;
 
     absl::Mutex mu;
-    absl::flat_hash_map<const Thunk*, ThunkProgress> map ABSL_GUARDED_BY(mu);
+    std::vector<ThunkExecutionEvent> events ABSL_GUARDED_BY(mu);
   };
 
   // Each thread can have at most one progress tracker installed and it is
   // automatically removed when the scoped progress tracker goes out of scope.
-  static thread_local ThunkEvents* installed_progress_tracker;
+  static thread_local ProgressTracker* installed_progress_tracker;
 
-  explicit ScopedProgressTracker(
-      absl::flat_hash_map<const Thunk*, ThunkProgress> progress_map);
+  explicit ScopedProgressTracker(EventPool* event_pool, ThunkIndexing indexing);
 
   // Collects up to `n` thunks matching `status`, sorted by executed time.
   // If `most_recent_first` is true, returns most recently executed thunks
@@ -162,7 +176,7 @@ class ThunkExecutor::ScopedProgressTracker {
   std::vector<ThunkExecution> CollectThunks(se::Event::Status status,
                                             bool most_recent_first, size_t n);
 
-  std::unique_ptr<ThunkEvents> events_;
+  std::unique_ptr<ProgressTracker> tracker_;
 };
 
 // Installs a progress tracker for the given sequential thunk in the current

--- a/xla/backends/gpu/runtime/thunk_executor_test.cc
+++ b/xla/backends/gpu/runtime/thunk_executor_test.cc
@@ -30,6 +30,8 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/memset_thunk.h"
 #include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/backends/gpu/runtime/while_loop.h"
+#include "xla/backends/gpu/runtime/while_thunk.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/platform_util.h"
@@ -134,6 +136,95 @@ TEST(SequentialThunkProgressTrackerTest, TrackProgress) {
   EXPECT_EQ(completed[2].name, "nested_memzero#2");
   EXPECT_EQ(completed[3].name, "nested_memzero#1");
   EXPECT_EQ(completed[4].name, "nested_memzero#0");
+
+  // Execute the same thunk sequence a second time to verify that execution
+  // events accumulate and the progress tracker reports 2x completed thunks.
+  ASSERT_OK(executor.ExecuteOnStream(params));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  static constexpr size_t kThunksPerExecution = kLength + 1 + kLength;
+  EXPECT_EQ(tracker.NumCompletedThunks(), 2 * kThunksPerExecution);
+  EXPECT_EQ(tracker.NumPendingThunks(), 0);
+
+  // LastCompletedThunks should return thunks from the second execution first
+  // (most recent), then from the first execution.
+  auto completed2 = tracker.LastCompletedThunks(5);
+  ASSERT_EQ(completed2.size(), 5);
+  EXPECT_EQ(completed2[0].name, "nested");
+  EXPECT_EQ(completed2[1].name, "nested_memzero#3");
+  EXPECT_EQ(completed2[2].name, "nested_memzero#2");
+  EXPECT_EQ(completed2[3].name, "nested_memzero#1");
+  EXPECT_EQ(completed2[4].name, "nested_memzero#0");
+
+  // Second execution thunks must have later timestamps than first execution.
+  for (size_t i = 0; i < completed2.size(); ++i) {
+    EXPECT_GT(completed2[i].executed, completed[i].executed);
+  }
+}
+
+TEST(SequentialThunkProgressTrackerTest, TrackWhileLoopNest) {
+  ASSERT_OK_AND_ASSIGN(se::StreamExecutor * stream_executor, GpuExecutor());
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Stream> stream,
+                       stream_executor->CreateStream());
+
+  static constexpr int64_t kLength = 4;
+  static constexpr int64_t kByteLength = sizeof(int32_t) * kLength;
+  static constexpr int64_t kTripCount = 3;
+
+  BufferAllocation alloc(/*index=*/0, kByteLength, /*color=*/0);
+  BufferAllocation::Slice slice(&alloc, 0, sizeof(int32_t));
+
+  ServiceExecutableRunOptions run_options;
+  se::StreamExecutorAddressAllocator allocator(stream_executor);
+
+  se::DeviceAddress<int32_t> storage =
+      stream_executor->AllocateArray<int32_t>(kLength, 0);
+  BufferAllocations allocations({storage}, 0, &allocator);
+
+  Thunk::ExecuteParams params =
+      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
+                                   stream.get(), nullptr, nullptr, nullptr);
+
+  Shape shape = ShapeUtil::MakeShape(S32, {1});
+
+  // Build a while loop with a known trip count containing a single body thunk.
+  ThunkSequence condition_thunks;  // empty, not used with trip_count
+  ThunkSequence body_thunks;
+  body_thunks.push_back(std::make_unique<MemzeroThunk>(
+      ThunkInfo("loop_body_memzero"), ShapedSlice{slice, shape}));
+
+  ThunkSequence outer_sequence;
+  outer_sequence.push_back(std::make_unique<WhileThunk>(
+      ThunkInfo("while_loop"), slice, std::move(condition_thunks),
+      std::move(body_thunks), /*trip_count=*/kTripCount));
+
+  ThunkExecutor executor(std::move(outer_sequence));
+  ASSERT_OK(executor.Prepare(Thunk::PrepareParams()));
+  ASSERT_OK_AND_ASSIGN(ThunkExecutor::ScopedProgressTracker tracker,
+                       InstallProgressTracker(stream_executor, executor));
+
+  ASSERT_OK(executor.ExecuteOnStream(params));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  // The while loop body executes kTripCount times, plus one event for the
+  // WhileThunk itself. LastCompletedThunks returns most recent first.
+  auto completed = tracker.LastCompletedThunks(kTripCount + 1);
+  ASSERT_EQ(completed.size(), kTripCount + 1);
+
+  // The most recent event is the WhileThunk itself (recorded after all body
+  // iterations complete). It has an empty loop nest since it runs at top level.
+  EXPECT_EQ(completed[0].name, "while_loop");
+  EXPECT_THAT(completed[0].loop_nest, testing::IsEmpty());
+
+  // The remaining events are the body thunk executions in reverse iteration
+  // order: iteration kTripCount-1 first, then kTripCount-2, etc.
+  for (size_t i = 0; i < kTripCount; ++i) {
+    const auto& thunk = completed[1 + i];
+    EXPECT_EQ(thunk.name, "loop_body_memzero");
+    ASSERT_EQ(thunk.loop_nest.size(), 1);
+    EXPECT_EQ(thunk.loop_nest[0], WhileLoopState({"while_loop", kTripCount, 0,
+                                                  kTripCount - 1 - i}));
+  }
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/while_loop.h
+++ b/xla/backends/gpu/runtime/while_loop.h
@@ -77,6 +77,12 @@ struct WhileLoopState {
   std::optional<size_t> loop_trip_count;
   size_t loop_depth = 0;
   size_t loop_iteration = 0;
+
+  friend bool operator==(const WhileLoopState& a, const WhileLoopState& b) {
+    return a.loop_name == b.loop_name &&
+           a.loop_trip_count == b.loop_trip_count &&
+           a.loop_depth == b.loop_depth && a.loop_iteration == b.loop_iteration;
+  }
 };
 
 // Returns the while loop state for the innermost loop. Returns nullptr if the

--- a/xla/runtime/object_pool.h
+++ b/xla/runtime/object_pool.h
@@ -69,8 +69,8 @@ class ObjectPool {
    public:
     ~BorrowedObject();
 
-    T& operator*() { return *entry_->object; }
-    T* operator->() { return &*entry_->object; }
+    T& operator*() const { return *entry_->object; }
+    T* operator->() const { return &*entry_->object; }
 
     BorrowedObject(BorrowedObject&&) = default;
     BorrowedObject& operator=(BorrowedObject&&) = default;

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -926,6 +926,7 @@ cc_library(
         ":device_address",
         ":dnn",
         ":kernel",
+        ":kernel_args",
         ":launch_dim",
         ":platform",
         "//xla/tsl/lib/gtl:int_type",

--- a/xla/stream_executor/command_buffer.h
+++ b/xla/stream_executor/command_buffer.h
@@ -18,19 +18,24 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <string>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/stream_executor/bit_pattern.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/kernel.h"
+#include "xla/stream_executor/kernel_args.h"
 #include "xla/stream_executor/launch_dim.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/tsl/lib/gtl/int_type.h"
@@ -251,7 +256,7 @@ class CommandBuffer {
       absl::Span<DeviceAddressBase> operands) = 0;
 
   //--------------------------------------------------------------------------//
-  // Command buffer condtitional commands API
+  // Command buffer conditional commands API
   //--------------------------------------------------------------------------//
 
   // Creates a conditional operation that will execute a command buffer
@@ -334,30 +339,29 @@ class CommandBuffer {
   //--------------------------------------------------------------------------//
 
   // Returns a pointer to the resource of the given type, or nullptr if resource
-  // of the given type is not attached to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrNullResource() {
-    static_assert(std::is_base_of_v<Resource, ConcreteResource>);
-    return static_cast<ConcreteResource*>(
-        GetOrNullResource(GetResourceTypeId<ConcreteResource>()));
+  // of the given type is not attached to this command buffer.
+  template <typename R>
+  R* GetOrNullResource() {
+    static_assert(std::is_base_of_v<Resource, R>);
+    return static_cast<R*>(GetOrNullResource(GetResourceTypeId<R>()));
   }
 
   // Returns a pointer to the resource of the given type, or creates a new
-  // resource of the given type and attaches it to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrCreateResource(
-      absl::FunctionRef<std::unique_ptr<ConcreteResource>()> create) {
-    static_assert(std::is_base_of_v<Resource, ConcreteResource>);
-    return static_cast<ConcreteResource*>(GetOrCreateResource(
-        GetResourceTypeId<ConcreteResource>(), [&] { return create(); }));
+  // resource of the given type and attaches it to this command buffer.
+  template <typename R>
+  R* GetOrCreateResource(absl::FunctionRef<std::unique_ptr<R>()> create) {
+    static_assert(std::is_base_of_v<Resource, R>);
+    return static_cast<R*>(
+        GetOrCreateResource(GetResourceTypeId<R>(), [&] { return create(); }));
   }
 
   // Returns a pointer to the resource of the given type, or creates a new
-  // resource of the given type and attaches it to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrCreateResource() {
-    return GetOrCreateResource<ConcreteResource>(
-        [] { return std::make_unique<ConcreteResource>(); });
+  // resource of the given type and attaches it to this command buffer.
+  // Constructor arguments are forwarded to std::make_unique<R>.
+  template <typename R, typename... Args>
+  R* GetOrConstructResource(Args&&... args) {
+    return GetOrCreateResource<R>(
+        [&] { return std::make_unique<R>(std::forward<Args>(args)...); });
   }
 
  private:

--- a/xla/stream_executor/stream.h
+++ b/xla/stream_executor/stream.h
@@ -313,30 +313,29 @@ class Stream {
   }
 
   // Returns a pointer to the resource of the given type, or nullptr if resource
-  // of the given type is not attached to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrNullResource() {
-    static_assert(std::is_base_of_v<Resource, ConcreteResource>);
-    return static_cast<ConcreteResource*>(
-        GetOrNullResource(GetResourceTypeId<ConcreteResource>()));
+  // of the given type is not attached to this stream.
+  template <typename R>
+  R* GetOrNullResource() {
+    static_assert(std::is_base_of_v<Resource, R>);
+    return static_cast<R*>(GetOrNullResource(GetResourceTypeId<R>()));
   }
 
   // Returns a pointer to the resource of the given type, or creates a new
-  // resource of the given type and attaches it to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrCreateResource(
-      absl::FunctionRef<std::unique_ptr<ConcreteResource>()> create) {
-    static_assert(std::is_base_of_v<Resource, ConcreteResource>);
-    return static_cast<ConcreteResource*>(GetOrCreateResource(
-        GetResourceTypeId<ConcreteResource>(), [&] { return create(); }));
+  // resource of the given type and attaches it to this stream.
+  template <typename R>
+  R* GetOrCreateResource(absl::FunctionRef<std::unique_ptr<R>()> create) {
+    static_assert(std::is_base_of_v<Resource, R>);
+    return static_cast<R*>(
+        GetOrCreateResource(GetResourceTypeId<R>(), [&] { return create(); }));
   }
 
   // Returns a pointer to the resource of the given type, or creates a new
-  // resource of the given type and attaches it to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrCreateResource() {
-    return GetOrCreateResource<ConcreteResource>(
-        [] { return std::make_unique<ConcreteResource>(); });
+  // resource of the given type and attaches it to this stream.
+  // Constructor arguments are forwarded to std::make_unique<R>.
+  template <typename R, typename... Args>
+  R* GetOrConstructResource(Args&&... args) {
+    return GetOrCreateResource<R>(
+        [&] { return std::make_unique<R>(std::forward<Args>(args)...); });
   }
 
  private:

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -360,29 +360,28 @@ class StreamExecutor {
 
   // Returns a pointer to the resource of the given type, or nullptr if resource
   // of the given type is not attached to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrNullResource() {
-    static_assert(std::is_base_of_v<Resource, ConcreteResource>);
-    return static_cast<ConcreteResource*>(
-        GetOrNullResource(GetResourceTypeId<ConcreteResource>()));
+  template <typename R>
+  R* GetOrNullResource() {
+    static_assert(std::is_base_of_v<Resource, R>);
+    return static_cast<R*>(GetOrNullResource(GetResourceTypeId<R>()));
   }
 
   // Returns a pointer to the resource of the given type, or creates a new
   // resource of the given type and attaches it to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrCreateResource(
-      absl::FunctionRef<std::unique_ptr<ConcreteResource>()> create) {
-    static_assert(std::is_base_of_v<Resource, ConcreteResource>);
-    return static_cast<ConcreteResource*>(GetOrCreateResource(
-        GetResourceTypeId<ConcreteResource>(), [&] { return create(); }));
+  template <typename R>
+  R* GetOrCreateResource(absl::FunctionRef<std::unique_ptr<R>()> create) {
+    static_assert(std::is_base_of_v<Resource, R>);
+    return static_cast<R*>(
+        GetOrCreateResource(GetResourceTypeId<R>(), [&] { return create(); }));
   }
 
   // Returns a pointer to the resource of the given type, or creates a new
   // resource of the given type and attaches it to this stream executor.
-  template <typename ConcreteResource>
-  ConcreteResource* GetOrCreateResource() {
-    return GetOrCreateResource<ConcreteResource>(
-        [] { return std::make_unique<ConcreteResource>(); });
+  // Constructor arguments are forwarded to std::make_unique<R>.
+  template <typename R, typename... Args>
+  R* GetOrConstructResource(Args&&... args) {
+    return GetOrCreateResource<R>(
+        [&] { return std::make_unique<R>(std::forward<Args>(args)...); });
   }
 
  private:


### PR DESCRIPTION
The previous progress tracking design pre-allocated one `se::Event` per thunk and overwrote its timestamp on each execution. This meant that for thunks inside while loops, only the *last* iteration's state was visible -- earlier iterations were silently lost. When diagnosing deadlocks inside loops, the tracker could not tell which iteration hung or show the full execution history.

This PR redesigns the progress tracker to append a new event record for every thunk execution, preserving the complete chronological history including loop iteration state.

**Test coverage**: Extended `thunk_executor_test` to verify double-execution accumulation (2x event count, correct timestamps) and while loop nest tracking (trip count, loop depth, iteration number recorded per body thunk execution).