### PR TITLE
[xla:ifrt] Allow passing PjRt client for autotuning during cross-compile

### DIFF
--- a/xla/python/pjrt_ifrt/pjrt_compiler.cc
+++ b/xla/python/pjrt_ifrt/pjrt_compiler.cc
@@ -159,16 +159,17 @@ tsl::Future<ExecutableRef> PjRtCompiler::Compile(
   if (pjrt_topology == nullptr) {
     return absl::InvalidArgumentError("PjRtCompiler requires a PjRtTopology");
   }
-  auto compile =
-      [program = std::move(program), xla_program = std::move(xla_program),
-       xla_compile_options = std::move(xla_compile_options), pjrt_topology,
-       user_context = UserContextScope::current()]() mutable {
-        UserContextScope scope(std::move(user_context));
-        return PjRtExecutable::Create(
-            std::move(*xla_program).ToMaybeOwningMlirModule(),
-            std::move(xla_compile_options->compile_options),
-            *pjrt_topology->description());
-      };
+  auto compile = [program = std::move(program),
+                  xla_program = std::move(xla_program),
+                  xla_compile_options = std::move(xla_compile_options),
+                  pjrt_topology,
+                  user_context = UserContextScope::current()]() mutable {
+    UserContextScope scope(std::move(user_context));
+    return PjRtExecutable::Create(
+        std::move(*xla_program).ToMaybeOwningMlirModule(),
+        std::move(xla_compile_options->compile_options),
+        *pjrt_topology->description(), xla_compile_options->autotuning_client);
+  };
   if (thread_pool_.has_value()) {
     return tsl::MakeFutureOn(*thread_pool_->AsExecutor(), std::move(compile));
   }

--- a/xla/python/pjrt_ifrt/pjrt_executable.cc
+++ b/xla/python/pjrt_ifrt/pjrt_executable.cc
@@ -400,7 +400,8 @@ char PjRtLoadedExecutable::ID = 0;
 
 absl::StatusOr<ExecutableRef> PjRtExecutable::Create(
     xla::MaybeOwningMlirModule module, xla::CompileOptions compile_options,
-    const xla::PjRtTopologyDescription& topology) {
+    const xla::PjRtTopologyDescription& topology,
+    xla::PjRtClient* autotuning_client) {
   const bool is_portable = compile_options.compile_portable_executable;
 
   // We have to do process the MLIR before the compile call, since the latter
@@ -417,7 +418,7 @@ absl::StatusOr<ExecutableRef> PjRtExecutable::Create(
   TF_ASSIGN_OR_RETURN(
       auto pjrt_executable,
       PjRtCompile(std::move(compile_options), std::move(module), topology,
-                  /*client=*/nullptr));
+                  /*client=*/autotuning_client));
 
   TF_ASSIGN_OR_RETURN(auto output_dtypes_and_shapes,
                       GetDTypesAndShapes(mlir_module_output_xla_shapes));

--- a/xla/python/pjrt_ifrt/pjrt_executable.h
+++ b/xla/python/pjrt_ifrt/pjrt_executable.h
@@ -95,10 +95,13 @@ class PjRtExecutable final
     : public llvm::RTTIExtends<PjRtExecutable, PjRtCompatibleExecutable> {
  public:
   // Creates PjRtExecutable from an MLIR module. Internally, it compiles the
-  // provided MLIR module into an `xla::PjRtExecutable`.
+  // provided MLIR module into an `xla::PjRtExecutable`. Autotuning client,
+  // when non-null, provides a real client that can be used for kernel
+  // autotuning during cross-compilation.
   static absl::StatusOr<ExecutableRef> Create(
       xla::MaybeOwningMlirModule module, xla::CompileOptions compile_options,
-      const xla::PjRtTopologyDescription& topology);
+      const xla::PjRtTopologyDescription& topology,
+      xla::PjRtClient* autotuning_client = nullptr);
 
   // PjRtCompatibleExecutable implementation.
 

--- a/xla/python/pjrt_ifrt/xla_compiler.h
+++ b/xla/python/pjrt_ifrt/xla_compiler.h
@@ -56,6 +56,12 @@ struct XlaCompileOptions
   DeviceListRef devices;
   std::vector<tsl::RCReference<LoadedHostCallback>> loaded_host_callbacks;
 
+  // Optional PjRtClient for GPU autotuning during cross-compilation. When
+  // compiling for a virtual topology (e.g. 1024 H100s) via a compile-only
+  // client, this provides access to local GPU device(s) that can be used for
+  // kernel autotuning. Topology must have compatible device type.
+  xla::PjRtClient* autotuning_client = nullptr;
+
   // CompileOptions implementation.
 
   ~XlaCompileOptions() override = default;


### PR DESCRIPTION
Cross-compilation can happen on a machine with identical GPUs to the worker nodes, in this case we want to be able to run cross-compilation + autotuning on real hardware to select optimal kernels. Plumb autotuning client via `XlaCompileOptions`, so it can be passed to `PjRtCompile` that already supports cross-compile + autotuning mode.