### PR TITLE
[ROCm] Make ScaledDotRewriter produce a dot that can be handled by cblas[Lt]

### DIFF
--- a/xla/backends/gpu/transforms/scaled_dot_rewriter.cc
+++ b/xla/backends/gpu/transforms/scaled_dot_rewriter.cc
@@ -174,10 +174,17 @@ absl::StatusOr<bool> ScaledDotRewriter::RewriteComputation(
     TF_ASSIGN_OR_RETURN(HloInstruction * lhs, Dequantize(dot, 0, 2, "LHS"));
     TF_ASSIGN_OR_RETURN(HloInstruction * rhs, Dequantize(dot, 1, 3, "RHS"));
 
+    std::tie(lhs, rhs) = UpscaleBoth(lhs, rhs);
+
+    Shape dot_shape = dot->shape();
+    dot_shape.set_element_type(GetTargetType(lhs->shape().element_type(),
+                                             dot->shape().element_type()));
+
     TF_RETURN_IF_ERROR(dot->ReplaceAllUsesWith(
-        computation->AddInstruction(HloInstruction::CreateDot(
-            dot->shape(), lhs, rhs, dot->dot_dimension_numbers(),
-            dot->precision_config()))));
+        Convert(computation->AddInstruction(HloInstruction::CreateDot(
+                    dot_shape, lhs, rhs, dot->dot_dimension_numbers(),
+                    dot->precision_config())),
+                dot->shape().element_type())));
     TF_RETURN_IF_ERROR(computation->RemoveInstruction(dot));
   }
   return changed;

--- a/xla/backends/gpu/transforms/scaled_dot_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/scaled_dot_rewriter_test.cc
@@ -51,9 +51,11 @@ class ScaledDotRewriterTestFixture : public HloTestBase,
 TEST_P(ScaledDotRewriterTestFixture, ScaledDot) {
   const ScaledDotRewriterTestCase& test_case = GetParam();
 
-  // lhs_scale should have two dim
-  const std::string hlo_string = absl::Substitute(
-      R"(
+  for (auto output_type :
+       {PrimitiveType::F32, PrimitiveType::BF16, PrimitiveType::F16}) {
+    // lhs_scale should have two dim
+    const std::string hlo_string = absl::Substitute(
+        R"(
         HloModule module
 
         ENTRY main {
@@ -61,53 +63,62 @@ TEST_P(ScaledDotRewriterTestFixture, ScaledDot) {
           rhs = $0[64,512] parameter(1)
           lhs_scale = $1[32,2] parameter(2)
           rhs_scale = $1[64,2] parameter(3)
-          ROOT dot = f32[1024,64] scaled-dot(lhs, rhs, lhs_scale, rhs_scale),
+          ROOT dot = $2[1024,64] scaled-dot(lhs, rhs, lhs_scale, rhs_scale),
             lhs_contracting_dims={1},
             rhs_contracting_dims={1}
         }
       )",
-      absl::AsciiStrToLower(PrimitiveType_Name(test_case.operand_type)),
-      absl::AsciiStrToLower(PrimitiveType_Name(test_case.scale_type)));
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnUnverifiedModule(hlo_string));
+        absl::AsciiStrToLower(PrimitiveType_Name(test_case.operand_type)),
+        absl::AsciiStrToLower(PrimitiveType_Name(test_case.scale_type)),
+        absl::AsciiStrToLower(PrimitiveType_Name(output_type)));
+    TF_ASSERT_OK_AND_ASSIGN(auto module,
+                            ParseAndReturnUnverifiedModule(hlo_string));
 
-  ScaledDotRewriter rewriter;
-  TF_ASSERT_OK_AND_ASSIGN(bool changed, rewriter.Run(module.get()));
-  EXPECT_TRUE(changed);
+    ScaledDotRewriter rewriter;
+    TF_ASSERT_OK_AND_ASSIGN(bool changed, rewriter.Run(module.get()));
+    EXPECT_TRUE(changed);
 
-  // Verify that the module is still valid after the rewrite.
-  auto status_or_module = ParseAndReturnVerifiedModule(module->ToString());
-  EXPECT_TRUE(status_or_module.status().ok()) << status_or_module.status();
+    // Verify that the module is still valid after the rewrite.
+    auto status_or_module = ParseAndReturnVerifiedModule(module->ToString());
+    EXPECT_TRUE(status_or_module.status().ok()) << status_or_module.status();
 
-  const HloInstruction* root = module->entry_computation()->root_instruction();
-  EXPECT_EQ(root->opcode(), HloOpcode::kDot);
-  for (const HloInstruction* operand : root->operands()) {
-    std::vector<HloOpcode> actual_op_codes{};
-    while (operand->opcode() != HloOpcode::kParameter) {
-      actual_op_codes.push_back(operand->opcode());
-      if (operand->opcode() == HloOpcode::kMultiply) {
-        operand = operand->operand(1);
+    const HloInstruction* root =
+        module->entry_computation()->root_instruction();
+
+    if (output_type == PrimitiveType::F16) {
+      EXPECT_EQ(root->opcode(), HloOpcode::kConvert);
+      root = root->operand(0);
+    }
+
+    EXPECT_EQ(root->opcode(), HloOpcode::kDot);
+    for (const HloInstruction* operand : root->operands()) {
+      std::vector<HloOpcode> actual_op_codes{};
+      while (operand->opcode() != HloOpcode::kParameter) {
+        actual_op_codes.push_back(operand->opcode());
+        if (operand->opcode() == HloOpcode::kMultiply) {
+          operand = operand->operand(1);
+        } else {
+          operand = operand->operand(0);
+        }
+      }
+      actual_op_codes = std::vector<HloOpcode>(actual_op_codes.rbegin(),
+                                               actual_op_codes.rend());
+
+      if (test_case.scale_type == PrimitiveType::BF16) {
+        const std::vector<HloOpcode> expected_op_codes{
+            HloOpcode::kBroadcast, HloOpcode::kReshape, HloOpcode::kMultiply};
+        EXPECT_THAT(actual_op_codes, expected_op_codes);
       } else {
-        operand = operand->operand(0);
+        const std::vector<HloOpcode> expected_op_codes_with_convert{
+            HloOpcode::kConvert, HloOpcode::kBroadcast, HloOpcode::kReshape,
+            HloOpcode::kMultiply};
+        EXPECT_THAT(actual_op_codes, expected_op_codes_with_convert);
       }
     }
-    actual_op_codes = std::vector<HloOpcode>(actual_op_codes.rbegin(),
-                                             actual_op_codes.rend());
 
-    if (test_case.scale_type == PrimitiveType::BF16) {
-      const std::vector<HloOpcode> expected_op_codes{
-          HloOpcode::kBroadcast, HloOpcode::kReshape, HloOpcode::kMultiply};
-      EXPECT_THAT(actual_op_codes, expected_op_codes);
-    } else {
-      const std::vector<HloOpcode> expected_op_codes_with_convert{
-          HloOpcode::kConvert, HloOpcode::kBroadcast, HloOpcode::kReshape,
-          HloOpcode::kMultiply};
-      EXPECT_THAT(actual_op_codes, expected_op_codes_with_convert);
-    }
+    EXPECT_TRUE(RunAndCompare(std::move(module),
+                              ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
   }
-
-  EXPECT_TRUE(RunAndCompare(std::move(module),
-                            ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
📝 Summary of Changes
Makes sure scaled_dot_rewriter does not generate dots with output being less precise than inputs like bf16 x bf16 -> f16.

🎯 Justification
This makes rocm work with xla_gpu_experimental_scaled_dot_with_triton=true while triton support for scaled dot is not fixed. Current fallback path relies on fission backend with scaled_dot_rewriter + gemm_rewriter pipeline.

🚀 Kind of Contribution
 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
N\A

🧪 Execution Tests:
N\A
