### PR TITLE
[ROCm] Add GPU context activation and error clearing for FFI handlers

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1051,6 +1051,7 @@ cc_library(
         "//xla/stream_executor:device_address_allocator",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
@@ -1461,6 +1462,7 @@ xla_test(
     ],
     deps = [
         ":select_k_exec_raft",
+        ":select_k_exec_stub",
         "//xla:types",
         "//xla:xla_data_proto_cc",
         "//xla:xla_proto_cc",

--- a/xla/backends/gpu/runtime/custom_call_thunk.cc
+++ b/xla/backends/gpu/runtime/custom_call_thunk.cc
@@ -64,12 +64,13 @@ limitations under the License.
 #include "xla/stream_executor/device_address_allocator.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
 #include "tsl/platform/platform.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -498,6 +499,20 @@ InvokeContext CustomCallThunk::BuildInvokeContext(
       execution_context};
 }
 
+// Activate the GPU context for the target device and clear any stale error
+// before invoking an FFI handler. FFI handlers call GPU runtime APIs
+// (hipBLAS, hipSOLVER, etc.) that depend on the thread-local active device
+// and a clean error state.
+static std::unique_ptr<se::ActivateContext> ActivateAndClearError(
+    se::Stream* stream) {
+  std::unique_ptr<se::ActivateContext> activation;
+  if (stream != nullptr) {
+    activation = stream->parent()->Activate();
+    stream->parent()->ClearError();
+  }
+  return activation;
+}
+
 absl::Status CustomCallThunk::ExecuteFfiHandler(
     RunId run_id, XLA_FFI_Handler* handler, XLA_FFI_ExecutionStage stage,
     se::Stream* stream, Thunk::ExecutionScopedState* execution_scoped_state,
@@ -515,6 +530,8 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
       !(buffer_allocations && stream)) {
     return absl::InternalError("buffer allocations and stream are required");
   }
+
+  auto activation = ActivateAndClearError(stream);
 
   TF_ASSIGN_OR_RETURN(auto call_frame, BuildCallFrame(buffer_allocations));
   InvokeContext context = BuildInvokeContext(
@@ -538,6 +555,8 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
       !(buffer_allocations && stream)) {
     return absl::InternalError("buffer allocations and stream are required");
   }
+
+  auto activation = ActivateAndClearError(stream);
 
   TF_ASSIGN_OR_RETURN(auto call_frame, BuildCallFrame(buffer_allocations));
   InvokeContext context = BuildInvokeContext(

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -525,6 +525,13 @@ std::unique_ptr<ActivateContext> RocmExecutor::Activate() {
   return std::make_unique<ScopedActivateContext>(rocm_context_);
 }
 
+void RocmExecutor::ClearError() {
+  hipError_t err = wrap::hipGetLastError();
+  if (err != hipSuccess) {
+    VLOG(3) << "Cleared stale GPU error: " << ToString(err);
+  }
+}
+
 bool RocmExecutor::UnloadModule(ModuleHandle module_handle) {
   absl::MutexLock lock{in_memory_modules_mu_};
   return UnloadGpuBinary(module_handle);

--- a/xla/stream_executor/rocm/rocm_executor.h
+++ b/xla/stream_executor/rocm/rocm_executor.h
@@ -64,6 +64,7 @@ class RocmExecutor : public GpuExecutor {
       : GpuExecutor(platform, device_ordinal) {}
   ~RocmExecutor() override;
   std::unique_ptr<ActivateContext> Activate() override;
+  void ClearError() override;
 
   absl::Status Init() override;
   blas::BlasSupport* AsBlas() override;

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -83,6 +83,13 @@ class StreamExecutor {
   // activated for the duration of the returned ActivateContext's scope.
   virtual std::unique_ptr<ActivateContext> Activate() = 0;
 
+  // Clears any pending sticky error state from the GPU runtime on the calling
+  // thread. On HIP, hipGetLastError() is sticky and per-thread; a prior
+  // failed operation leaves a latent error that the next hipGetLastError()
+  // call will pick up. Call this before dispatching work that will check
+  // hipGetLastError to ensure a clean baseline.
+  virtual void ClearError() {}
+
   // Returns a reference to the platform that created this executor.
   virtual const Platform* GetPlatform() const = 0;
 


### PR DESCRIPTION
📝 Summary of Changes
- Activate the GPU context and clear sticky per-thread error state before invoking FFI handlers in CustomCallThunk::ExecuteFfiHandler
- Add StreamExecutor::ClearError() virtual with ROCm implementation that drains hipGetLastError()
- Fixes flaky test failures in JAX unit tests where stale GPU errors from prior operations cause FFI handler invocations to fail spuriously

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 

