### PR TITLE
[xla:gpu] Correctly report thunk execution index

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -2863,7 +2863,6 @@ cc_library(
     hdrs = ["thunk_executor.h"],
     deps = [
         ":annotation",
-        ":collective_thunk",
         ":event_pool",
         ":thunk",
         ":while_loop",

--- a/xla/backends/gpu/runtime/thunk_executor.cc
+++ b/xla/backends/gpu/runtime/thunk_executor.cc
@@ -32,17 +32,16 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/runtime/annotation.h"
-#include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/backends/gpu/runtime/event_pool.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/while_loop.h"
 #include "xla/stream_executor/event.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -103,18 +102,7 @@ absl::Status ThunkExecutor::ExecuteOnStream(
     if (tracker) {
       // Borrow an event from the pool and record it on the execution stream.
       ASSIGN_OR_RETURN(auto event, tracker->event_pool->GetOrCreateEvent());
-
-      // Record execution completion event on a stream.
-      se::Stream* execution_stream = params.stream;
-
-      // Async collectives launch work on a dedicated async stream, so we
-      // must record the event there instead of on the main compute stream.
-      if (auto* collective = dynamic_cast<const CollectiveThunk*>(thunk.get());
-          thunk->IsAsyncStart() && collective && params.collective_params) {
-        execution_stream = params.collective_params->async_streams.at(
-            thunk->execution_stream_id().value());
-      }
-      RETURN_IF_ERROR(execution_stream->RecordEvent(event->get()));
+      RETURN_IF_ERROR(params.stream->RecordEvent(event->get()));
 
       absl::MutexLock lock(tracker->mu);
       tracker->events.emplace_back(thunk.get(), std::move(event),
@@ -162,6 +150,11 @@ ThunkExecutor::ScopedProgressTracker::~ScopedProgressTracker() {
   }
 }
 
+size_t ThunkExecutor::ScopedProgressTracker::num_executions() const {
+  absl::MutexLock lock(tracker_->mu);
+  return tracker_->events.size();
+}
+
 size_t ThunkExecutor::ScopedProgressTracker::NumPendingThunks() {
   absl::MutexLock lock(tracker_->mu);
   return absl::c_count_if(tracker_->events, [](const auto& event) {
@@ -187,26 +180,27 @@ std::vector<ThunkExecution> ThunkExecutor::ScopedProgressTracker::CollectThunks(
   // for oldest-first or backward for most-recent-first.
   std::vector<ThunkExecution> result;
 
-  auto collect = [&](const ThunkExecutionEvent& event) {
+  auto collect = [&](size_t exec_idx, const ThunkExecutionEvent& event) {
     if (event.event->get()->PollForStatus() == status) {
-      result.push_back({indexing.at(event.thunk), event.executed,
-                        event.thunk->profile_annotation(), event.loop_nest});
+      result.push_back({exec_idx, indexing.at(event.thunk), event.executed,
+                        event.thunk->kind(), event.thunk->profile_annotation(),
+                        event.loop_nest});
     }
   };
 
   if (most_recent_first) {
-    for (auto it = events.rbegin(); it != events.rend(); ++it) {
+    for (size_t i = events.size(); i > 0; --i) {
       if (result.size() >= n) {
         break;
       }
-      collect(*it);
+      collect(i - 1, events[i - 1]);
     }
   } else {
-    for (auto it = events.begin(); it != events.end(); ++it) {
+    for (size_t i = 0; i < events.size(); ++i) {
       if (result.size() >= n) {
         break;
       }
-      collect(*it);
+      collect(i, events[i]);
     }
   }
 

--- a/xla/backends/gpu/runtime/thunk_executor.h
+++ b/xla/backends/gpu/runtime/thunk_executor.h
@@ -92,11 +92,22 @@ class ThunkExecutor::ScopedProgressTracker {
   // the index that is used by `ThunkExecutor` progress v-logging.
   using ThunkIndexing = absl::flat_hash_map<const Thunk*, size_t>;
 
-  // Thunk execution record: the thunk's global index, the wall-clock time it
-  // was launched, its human-readable name, and the enclosing loop nest state.
+  // Thunk execution record: captures both the identity and the execution order
+  // of a thunk launch, along with wall-clock time and loop nest context.
   struct ThunkExecution {
-    size_t index;
+    // Monotonically increasing index reflecting the real order in which thunks
+    // were launched on the GPU stream. In the presence of while loops, the same
+    // thunk can be launched multiple times, each with a distinct exec_idx.
+    // This is the position of the corresponding event in the events vector.
+    size_t exec_idx;
+
+    // The thunk's identity within the thunk sequence, assigned by DFS traversal
+    // via WalkNested. This is stable across loop iterations: the same thunk
+    // always has the same thunk_idx regardless of how many times it executes.
+    size_t thunk_idx;
+
     absl::Time executed;
+    Thunk::Kind kind;
     absl::string_view name;
     std::vector<WhileLoopState> loop_nest;
   };
@@ -106,9 +117,13 @@ class ThunkExecutor::ScopedProgressTracker {
   ScopedProgressTracker(ScopedProgressTracker&&) = default;
   ScopedProgressTracker& operator=(ScopedProgressTracker&&) = default;
 
-  // Returns the number of thunks in the tracked thunk sequence. This includes
-  // all thunks nested inside others.
+  // Returns the number of unique thunks in the tracked thunk sequence. This
+  // includes all thunks nested inside others.
   size_t num_thunks() const { return tracker_->indexing.size(); }
+
+  // Returns the total number of thunk executions (launches). This can exceed
+  // num_thunks() when thunks are executed multiple times inside while loops.
+  size_t num_executions() const;
 
   // Returns the number of thunks that have been launched on the GPU stream and
   // have completed execution. This polls all executed thunk events.

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -117,6 +117,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/sorted_range.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
@@ -125,7 +126,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -497,17 +497,22 @@ absl::Status ExecuteThunksImpl(
                                               state.loop_iteration));
             }
             LOG(ERROR) << absl::StreamFormat(
-                "  - thunk[%d/%d]: %s at %s%s", thunk.index,
-                tracker->num_thunks(), thunk.name,
+                "  - exec[%d] thunk[%d/%d] %v: %s at %s%s", thunk.exec_idx,
+                thunk.thunk_idx, tracker->num_thunks(), thunk.kind, thunk.name,
                 absl::FormatTime("%Y-%m-%d %H:%M:%S.%E6f", thunk.executed,
                                  absl::LocalTimeZone()),
                 loop_info);
           }
         };
 
+        size_t num_executions = tracker->num_executions();
         LOG(ERROR) << absl::StreamFormat(
-            "[%d] Pending thunks: %d/%d", device_ordinal,
-            tracker->NumPendingThunks(), tracker->num_thunks());
+            "[%d] Completed thunks: %d/%d (unique thunks: %d)", device_ordinal,
+            tracker->NumCompletedThunks(), num_executions,
+            tracker->num_thunks());
+        LOG(ERROR) << absl::StreamFormat(
+            "[%d] Pending thunks: %d/%d (unique thunks: %d)", device_ordinal,
+            tracker->NumPendingThunks(), num_executions, tracker->num_thunks());
 
         log_progress("Last completed thunks",
                      tracker->LastCompletedThunks(progress_tracking_n));
@@ -596,12 +601,10 @@ absl::Status ExecuteThunksImpl(
   CollectiveMemoryRequests collective_memory_requests(buffer_allocations);
 
   {  // Prepare thunks for execution and collect requested GPU cliques.
-    Thunk::PrepareParams prepare_params{&collective_params,
-                                        &collective_clique_requests,
-                                        &collective_memory_requests,
-                                        executor,
-                                        &buffer_allocations,
-                                        &execution_scoped_state};
+    Thunk::PrepareParams prepare_params{
+        &collective_params,          &collective_clique_requests,
+        &collective_memory_requests, executor,
+        &buffer_allocations,         &execution_scoped_state};
 
     tsl::profiler::TraceMe trace_prepare("Thunks::Prepare");
     RETURN_IF_ERROR(thunk_executor.Prepare(prepare_params));


### PR DESCRIPTION
Track two types of thunk indixes: `thunk_idx` - index of a thunk in a thunk sequence, `exec_idx` - execution index. They can be different in presence of control flow in a thunk sequence.

Also remove special handling of collective thunks in `thunk_executor.cc`, as async execution now handled in a generic `AsyncStartThunk`.