### PR TITLE
Fix tensor memory size check to use tcgen05 capability instead of IsBlackwell()

### DIFF
--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -492,7 +492,7 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
   }
 
   if (auto* cuda_cc = gpu_cc.cuda_compute_capability();
-      cuda_cc != nullptr && cuda_cc->IsBlackwell()) {
+      cuda_cc != nullptr && cuda_cc->IsAtLeastBlackwell()) {
     // https://docs.nvidia.com/cuda/parallel-thread-execution/#tensor-memory
     constexpr int kTensorMemoryColumns = 512;
     const int tensor_mem_columns =

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -492,7 +492,7 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
   }
 
   if (auto* cuda_cc = gpu_cc.cuda_compute_capability();
-      cuda_cc != nullptr && cuda_cc->IsAtLeastBlackwell()) {
+      cuda_cc != nullptr && cuda_cc->HasTcgen05()) {
     // https://docs.nvidia.com/cuda/parallel-thread-execution/#tensor-memory
     constexpr int kTensorMemoryColumns = 512;
     const int tensor_mem_columns =

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1135,6 +1135,7 @@ xla_cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/xla/stream_executor/cuda/cuda_compute_capability.h
+++ b/xla/stream_executor/cuda/cuda_compute_capability.h
@@ -187,6 +187,13 @@ struct CudaComputeCapability {
     return major == CudaComputeCapabilities::kBlackwell;
   }
 
+  // TensorCore 5th Generation Family Instructions (tcgen05)
+  // are available on SM 10.0, 10.3, and 11.0 but not on SM 12.0+.
+  bool HasTcgen05() const {
+    return major == CudaComputeCapabilities::kBlackwell ||
+           major == CudaComputeCapabilities::kBlackwell_11;
+  }
+
   // Returns true if a kernel compiled for compute capability `other` can be run
   // on a GPU with compute capability `this`.
   bool SupportsAllFeaturesOf(const CudaComputeCapability& other) const {

--- a/xla/stream_executor/cuda/cuda_compute_capability.h
+++ b/xla/stream_executor/cuda/cuda_compute_capability.h
@@ -188,7 +188,7 @@ struct CudaComputeCapability {
   }
 
   // TensorCore 5th Generation Family Instructions (tcgen05)
-  // are available on SM 10.0, 10.3, and 11.0 but not on SM 12.0+.
+  // are available on SM 10.0, 10.3, and 11.0 but not on SM 12.0.
   bool HasTcgen05() const {
     return major == CudaComputeCapabilities::kBlackwell ||
            major == CudaComputeCapabilities::kBlackwell_11;

--- a/xla/stream_executor/cuda/cuda_compute_capability_test.cc
+++ b/xla/stream_executor/cuda/cuda_compute_capability_test.cc
@@ -197,6 +197,23 @@ TEST(CudaComputeCapabilityTest, IsAtLeastMethods) {
   EXPECT_TRUE(CudaComputeCapability(10, 1).IsAtLeastBlackwell());
 }
 
+TEST(CudaComputeCapabilityTest, HasTcgen05) {
+  // Hopper and earlier: no tcgen05.
+  EXPECT_FALSE(CudaComputeCapability(9, 0).HasTcgen05());
+
+  // SM 10.0 (B200): tcgen05 supported.
+  EXPECT_TRUE(CudaComputeCapability(10, 0).HasTcgen05());
+  // SM 10.3 (B300): tcgen05 supported.
+  EXPECT_TRUE(CudaComputeCapability(10, 3).HasTcgen05());
+
+  // SM 11.0: tcgen05 supported.
+  EXPECT_TRUE(CudaComputeCapability(11, 0).HasTcgen05());
+
+  // SM 12.0 (consumer Blackwell) and 12.1 (DGX Spark): no tcgen05.
+  EXPECT_FALSE(CudaComputeCapability(12, 0).HasTcgen05());
+  EXPECT_FALSE(CudaComputeCapability(12, 1).HasTcgen05());
+}
+
 TEST(CudaComputeCapabilityTest, FromProtoWithFeatureExtensionSpecified) {
   using FeatureExtension = CudaComputeCapability::FeatureExtension;
 

--- a/xla/stream_executor/cuda/ptx_compiler_test.cc
+++ b/xla/stream_executor/cuda/ptx_compiler_test.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
 #include "xla/stream_executor/cuda/compilation_provider.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/cuda/ptx_compiler_support.h"
@@ -149,6 +150,31 @@ constexpr const char kSimplePtx[] = R"(
 
 })";
 
+// Returns a minimal PTX kernel using a tcgen05.st instruction, targeting the
+// given compute capability and PTX ISA version.
+std::string MakeTcgen05Ptx(stream_executor::CudaComputeCapability cc,
+                           int ptx_isa_version) {
+  return absl::StrFormat(R"(
+.version %d.%d
+.target %s
+.address_size 64
+
+.visible .entry tcgen05_kernel(
+        .param .u32 tcgen05_kernel_param_0
+)
+{
+        .reg .b32       %%r<2>;
+        .reg .f32       %%f<2>;
+
+        ld.param.b32    %%r1, [tcgen05_kernel_param_0];
+        mov.f32         %%f1, 1.0;
+        tcgen05.st.sync.aligned.32x32b.x1.b32 [%%r1], {%%f1};
+        ret;
+})",
+                         ptx_isa_version / 10, ptx_isa_version % 10,
+                         cc.GetPtxAsTargetName());
+}
+
 constexpr stream_executor::CudaComputeCapability kDefaultComputeCapability{5,
                                                                            2};
 
@@ -247,5 +273,59 @@ TEST_F(PtxCompilerTest, ReturnsReasonableVersion) {
   EXPECT_THAT(stream_executor::GetLibNvPtxCompilerVersion(),
               absl_testing::IsOkAndHolds(testing::Ge(kMinSupportedVersion)));
 }
+
+struct Tcgen05TestCase {
+  int major, minor, min_ptx_isa_version;
+  const char* name;
+};
+
+class PtxCompilerTcgen05Test
+    : public PtxCompilerTest,
+      public ::testing::WithParamInterface<Tcgen05TestCase> {};
+
+TEST_P(PtxCompilerTcgen05Test, CompilesTcgen05OnlyForSupportedArchitectures) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      int ptx_isa_version,
+      stream_executor::GetLatestPtxIsaVersionForNvptxCompiler());
+
+  auto [major, minor, min_ptx, name] = GetParam();
+  if (ptx_isa_version < min_ptx) {
+    GTEST_SKIP() << "PTX ISA version " << ptx_isa_version
+                 << " does not support sm_" << major << minor
+                 << " (need >= " << min_ptx << ")";
+  }
+
+  using CC = stream_executor::CudaComputeCapability;
+  CC cc(major, minor, CC::FeatureExtension::kAcceleratedFeatures);
+  auto result = CompileHelper(cc, MakeTcgen05Ptx(cc, ptx_isa_version).c_str());
+  if (cc.HasTcgen05()) {
+    EXPECT_THAT(result, absl_testing::IsOk())
+        << "Expected tcgen05 PTX to compile for " << name << " ("
+        << cc.ToString() << ")";
+  } else {
+    EXPECT_THAT(result, testing::Not(absl_testing::IsOk()))
+        << "Expected tcgen05 PTX to fail for " << name << " (" << cc.ToString()
+        << ")";
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Tcgen05, PtxCompilerTcgen05Test,
+    ::testing::Values(
+        // sm_90a: Hopper, no tcgen05
+        Tcgen05TestCase{9, 0, 78, "Hopper"},
+        // sm_100a requires PTX ISA 8.7
+        Tcgen05TestCase{10, 0, 87, "B200"},
+        // sm_103a requires PTX ISA 8.8
+        Tcgen05TestCase{10, 3, 88, "B300"},
+        // sm_110a requires PTX ISA 9.0
+        Tcgen05TestCase{11, 0, 90, "Thor"},
+        // sm_120a: consumer Blackwell, no tcgen05
+        Tcgen05TestCase{12, 0, 87, "RTX5090"},
+        // sm_121a: DGX Spark, no tcgen05
+        Tcgen05TestCase{12, 1, 88, "DGXSpark"}),
+    [](const ::testing::TestParamInfo<Tcgen05TestCase>& info) {
+      return info.param.name;
+    });
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes
- Add `HasTcgen05()` to `CudaComputeCapability` that returns true for SM 10.x
    and SM 11.x (architectures with tcgen05 support) and false for SM 12.x
- Replace the `IsBlackwell()` guard in `xtile_compiler.cc` with `HasTcgen05()`
- Add unit tests for `HasTcgen05()` and parameterized PTX compiler tests that
    verify tcgen05 instructions compile only on supported architectures

🎯 Justification
The Triton compiler's tensor memory size check used `IsBlackwell()` which only matches SM 10.x. This breaks on SM 11.0 (Thor) which also has tcgen05 tensor memory. When the check is skipped, the Triton `TritonTensorMemoryAllocationPass` may assign TMEM column offsets > 512. These out-of-bounds offsets cannot be allocated, so `ttng.tmem_alloc` [lowers](https://github.com/triton-lang/triton/blob/3e15c1a3e3a931578d2bfc9cb06ad12628adae2c/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp#L595-L598) to LLVM `undef`/`trap` instruction. The kernel launches, immediately hits the trap, and returns `CUDA_ERROR_LAUNCH_FAILED`. Since all autotuning configs are profiled on a shared CUDA stream, this fatal error poisons the GPU context and causes **all** subsequent kernel launches to fail.