### PR TITLE
[xla:gpu] Allow cross-compilation via PjRtCompiler::Compile

### DIFF
--- a/xla/python/pjrt_ifrt/pjrt_compiler.cc
+++ b/xla/python/pjrt_ifrt/pjrt_compiler.cc
@@ -149,26 +149,34 @@ tsl::Future<ExecutableRef> PjRtCompiler::Compile(
       llvm::cast<HloProgram>(std::move(program));
   TF_ASSIGN_OR_RETURN(auto xla_compile_options,
                       GetXlaCompileOptions(std::move(options)));
-  if (client_ != nullptr) {
-    // Device ID translation is unnecessary because it is a property of the
-    // client.
-    TF_RETURN_IF_ERROR(
-        TranslateDeviceIds(client_, xla_compile_options->compile_options));
-  }
   const auto* pjrt_topology = llvm::dyn_cast<PjRtTopology>(&topology);
   if (pjrt_topology == nullptr) {
     return absl::InvalidArgumentError("PjRtCompiler requires a PjRtTopology");
   }
+
+  // Only translate device IDs when the client is present and the compile
+  // options contain a device list referencing this client's devices.
+  // When cross-compiling, the caller passes an empty device list because
+  // device IDs belong to the target topology, not this client.
+  if (client_ != nullptr && xla_compile_options->devices) {
+    TF_RETURN_IF_ERROR(
+        TranslateDeviceIds(client_, xla_compile_options->compile_options));
+  }
+
+  xla::PjRtClient* compile_client =
+      client_ != nullptr ? client_->pjrt_client() : nullptr;
+
   auto compile =
       [program = std::move(program), xla_program = std::move(xla_program),
        xla_compile_options = std::move(xla_compile_options), pjrt_topology,
-       user_context = UserContextScope::current()]() mutable {
+       compile_client, user_context = UserContextScope::current()]() mutable {
         UserContextScope scope(std::move(user_context));
         return PjRtExecutable::Create(
             std::move(*xla_program).ToMaybeOwningMlirModule(),
             std::move(xla_compile_options->compile_options),
-            *pjrt_topology->description());
+            *pjrt_topology->description(), compile_client);
       };
+
   if (thread_pool_.has_value()) {
     return tsl::MakeFutureOn(*thread_pool_->AsExecutor(), std::move(compile));
   }

--- a/xla/python/pjrt_ifrt/pjrt_executable.cc
+++ b/xla/python/pjrt_ifrt/pjrt_executable.cc
@@ -356,7 +356,8 @@ char PjRtLoadedExecutable::ID = 0;
 
 absl::StatusOr<ExecutableRef> PjRtExecutable::Create(
     xla::MaybeOwningMlirModule module, xla::CompileOptions compile_options,
-    const xla::PjRtTopologyDescription& topology) {
+    const xla::PjRtTopologyDescription& topology,
+    xla::PjRtClient* compile_client) {
   const bool is_portable = compile_options.compile_portable_executable;
 
   // We have to do process the MLIR before the compile call, since the latter
@@ -370,10 +371,9 @@ absl::StatusOr<ExecutableRef> PjRtExecutable::Create(
   TF_ASSIGN_OR_RETURN(const std::vector<xla::LayoutMode> output_layout_modes,
                       GetOutputLayoutModes(module.mlir_module()));
 
-  TF_ASSIGN_OR_RETURN(
-      auto pjrt_executable,
-      PjRtCompile(std::move(compile_options), std::move(module), topology,
-                  /*client=*/nullptr));
+  TF_ASSIGN_OR_RETURN(auto pjrt_executable,
+                      PjRtCompile(std::move(compile_options), std::move(module),
+                                  topology, compile_client));
 
   TF_ASSIGN_OR_RETURN(auto output_dtypes_and_shapes,
                       GetDTypesAndShapes(mlir_module_output_xla_shapes));

--- a/xla/python/pjrt_ifrt/pjrt_executable.h
+++ b/xla/python/pjrt_ifrt/pjrt_executable.h
@@ -95,10 +95,13 @@ class PjRtExecutable final
     : public llvm::RTTIExtends<PjRtExecutable, PjRtCompatibleExecutable> {
  public:
   // Creates PjRtExecutable from an MLIR module. Internally, it compiles the
-  // provided MLIR module into an `xla::PjRtExecutable`.
+  // provided MLIR module into an `xla::PjRtExecutable`. When `compile_client`
+  // is non-null, it is passed to `xla::PjRtCompile` to request
+  // cross-compilation.
   static absl::StatusOr<ExecutableRef> Create(
       xla::MaybeOwningMlirModule module, xla::CompileOptions compile_options,
-      const xla::PjRtTopologyDescription& topology);
+      const xla::PjRtTopologyDescription& topology,
+      xla::PjRtClient* compile_client = nullptr);
 
   // PjRtCompatibleExecutable implementation.
 


### PR DESCRIPTION
Allow passing `PjRtClient` to `PjRtCompile` when cross compiling for topology different from the clients topology (the cross compilation use case).

Corresponding JAX change: https://github.com/jax-ml/jax/pull/36350