### PR TITLE
collective combiner improvement

### DIFF
--- a/xla/hlo/transforms/collectives/all_reduce_combiner_test.cc
+++ b/xla/hlo/transforms/collectives/all_reduce_combiner_test.cc
@@ -542,5 +542,55 @@ TEST_F(AllReduceCombinerTest, PreservesMetadata) {
                         op::GetTupleElement(combined_all_reduce, 1)));
 }
 
+TEST_F(AllReduceCombinerTest, IndependentBlocksWithDependentStages) {
+  const char* const hlo_string = R"(
+HloModule test
+
+add {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT add = f32[] add(lhs, rhs)
+}
+
+ENTRY entry {
+  p0 = f32[128] parameter(0)
+  p1 = f32[128] parameter(1)
+  p2 = f32[128] parameter(2)
+  p3 = f32[128] parameter(3)
+
+  ar_a1 = f32[128] all-reduce(p0), replica_groups={}, to_apply=add
+  neg_a = f32[128] negate(ar_a1)
+  ar_a2 = f32[128] all-reduce(neg_a), replica_groups={}, to_apply=add
+
+  ar_b1 = f32[128] all-reduce(p1), replica_groups={}, to_apply=add
+  neg_b = f32[128] negate(ar_b1)
+  ar_b2 = f32[128] all-reduce(neg_b), replica_groups={}, to_apply=add
+
+  ar_c1 = f32[128] all-reduce(p2), replica_groups={}, to_apply=add
+  neg_c = f32[128] negate(ar_c1)
+  ar_c2 = f32[128] all-reduce(neg_c), replica_groups={}, to_apply=add
+
+  ar_d1 = f32[128] all-reduce(p3), replica_groups={}, to_apply=add
+  neg_d = f32[128] negate(ar_d1)
+  ar_d2 = f32[128] all-reduce(neg_d), replica_groups={}, to_apply=add
+
+  ROOT tuple = (f32[128], f32[128], f32[128], f32[128]) tuple(ar_a2, ar_b2, ar_c2, ar_d2)
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                           ParseAndReturnVerifiedModule(hlo_string));
+
+  AllReduceCombiner combine(1024 * 1024, kMaxCombineCount);
+  ASSERT_EQ(AllReduceCount(*module), 8);
+  EXPECT_THAT(combine.Run(module.get()), absl_testing::IsOkAndHolds(true));
+
+  // Optimal: all stage-1 ARs combined + all stage-2 ARs combined = 2.
+  EXPECT_EQ(AllReduceCount(*module), 2)
+      << "Expected all independent stage-1 ARs to be combined together and "
+         "all independent stage-2 ARs to be combined together, but the "
+         "combiner produced " << AllReduceCount(*module)
+      << " all-reduces instead of 2.";
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/collective_combiner_utils.h
+++ b/xla/service/collective_combiner_utils.h
@@ -148,8 +148,8 @@ absl::StatusOr<bool> CombineInstructionsByKey(
             return reachable;
           });
       if (is_reachable) {
-        VLOG(1) << "Instruction is reachable.";
-        break;
+        VLOG(1) << "Instruction is reachable, skipping.";
+        continue;
       }
 
       VLOG(1) << "Adding instruction to set.";


### PR DESCRIPTION
📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

given this pattern
```
fn (a0, b0)
  a1 = all_reduce(a0)
  a2 = all_reduce(a1)

  b1 = all_reduce(b0)
  b2 = all_reduce(b1)
```
we want bucketing of *1 and *2, but the combiner stops looking for combine candidates as soon as it sees a reachable collective (i.e. a1 would never find b1 because it sees a2 first). this change lets it continue looking and find b1

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
