### PR TITLE
Fix XProf program_id metadata mapping

### DIFF
--- a/xla/backends/profiler/cpu/BUILD
+++ b/xla/backends/profiler/cpu/BUILD
@@ -127,6 +127,21 @@ cc_library(
 )
 
 xla_cc_test(
+    name = "metadata_utils_test",
+    srcs = ["metadata_utils_test.cc"],
+    deps = [
+        ":metadata_utils",
+        "//xla/service:hlo_proto_cc",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/profiler/convert:xla_op_utils",
+        "//xla/tsl/profiler/utils:xplane_builder",
+        "//xla/tsl/profiler/utils:xplane_schema",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+xla_cc_test(
     name = "host_tracer_test",
     srcs = ["host_tracer_test.cc"],
     deps = [

--- a/xla/backends/profiler/cpu/metadata_utils.h
+++ b/xla/backends/profiler/cpu/metadata_utils.h
@@ -35,16 +35,18 @@ class MetadataXPlaneBuilder {
             GetStatTypeStr(tsl::profiler::StatType::kProgramId))) {}
 
   void AddHloProto(uint64_t program_id, const xla::HloProto& hlo_proto) {
-    auto name = tsl::profiler::HloModuleNameWithProgramId(
-        hlo_proto.hlo_module().name(), program_id);
     tsl::profiler::XEventMetadata* event_metadata =
-        plane_.GetOrCreateEventMetadata(name);
-    if (event_metadata->display_name().empty()) {
+        plane_.GetOrCreateEventMetadata(static_cast<int64_t>(program_id));
+    if (event_metadata->name().empty()) {
+      auto name = tsl::profiler::HloModuleNameWithProgramId(
+          hlo_proto.hlo_module().name(), program_id);
+      event_metadata->set_name(name);
       event_metadata->set_display_name(name);
       tsl::profiler::XStatsBuilder<tsl::profiler::XEventMetadata> event_stats(
           event_metadata, &plane_);
       event_stats.AddStatValue(*hlo_proto_stat_, hlo_proto);
-      event_stats.AddStatValue(*program_id_stat_, program_id);
+      event_stats.AddStatValue(*program_id_stat_,
+                               static_cast<int64_t>(program_id));
     }
   }
 

--- a/xla/backends/profiler/cpu/metadata_utils_test.cc
+++ b/xla/backends/profiler/cpu/metadata_utils_test.cc
@@ -1,0 +1,138 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/cpu/metadata_utils.h"
+
+#include <cstdint>
+#include <string>
+
+#include "xla/service/hlo.pb.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/tsl/profiler/convert/xla_op_utils.h"
+#include "xla/tsl/profiler/utils/xplane_builder.h"
+#include "xla/tsl/profiler/utils/xplane_schema.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+using tsl::profiler::GetStatTypeStr;
+using tsl::profiler::HloModuleNameWithProgramId;
+using tsl::profiler::StatType;
+
+xla::HloProto MakeHloProto(const std::string& module_name, uint64_t module_id) {
+  xla::HloProto hlo_proto;
+  hlo_proto.mutable_hlo_module()->set_name(module_name);
+  hlo_proto.mutable_hlo_module()->set_id(module_id);
+  return hlo_proto;
+}
+
+TEST(MetadataUtilsTest, MultipleModulesUseActualProgramIdsAsKeys) {
+  tensorflow::profiler::XPlane plane;
+  MetadataXPlaneBuilder builder(&plane);
+
+  const uint64_t ids[] = {664863, 665699, 666536};
+  for (uint64_t id : ids) {
+    builder.AddHloProto(id, MakeHloProto("jit_fn", id));
+  }
+
+  ASSERT_EQ(plane.event_metadata().size(), 3);
+  for (uint64_t id : ids) {
+    EXPECT_TRUE(plane.event_metadata().contains(id))
+        << "Missing event_metadata for program_id=" << id;
+  }
+  EXPECT_FALSE(plane.event_metadata().contains(1));
+  EXPECT_FALSE(plane.event_metadata().contains(2));
+  EXPECT_FALSE(plane.event_metadata().contains(3));
+}
+
+TEST(MetadataUtilsTest, AddHloProtoSetsNameAndDisplayName) {
+  tensorflow::profiler::XPlane plane;
+  MetadataXPlaneBuilder builder(&plane);
+
+  const uint64_t program_id = 664863;
+  const std::string module_name = "jit_fn";
+  builder.AddHloProto(program_id, MakeHloProto(module_name, program_id));
+
+  const auto& em = plane.event_metadata().at(program_id);
+  const std::string expected_name =
+      HloModuleNameWithProgramId(module_name, program_id);
+  EXPECT_EQ(em.name(), expected_name);
+  EXPECT_EQ(em.display_name(), expected_name);
+}
+
+TEST(MetadataUtilsTest, AddHloProtoStoresProgramIdStat) {
+  tensorflow::profiler::XPlane plane;
+  MetadataXPlaneBuilder builder(&plane);
+
+  const uint64_t program_id = 664863;
+  builder.AddHloProto(program_id, MakeHloProto("jit_fn", program_id));
+
+  const std::string kProgramIdName(GetStatTypeStr(StatType::kProgramId));
+  int64_t program_id_stat_key = -1;
+  for (const auto& [key, sm] : plane.stat_metadata()) {
+    if (sm.name() == kProgramIdName) {
+      program_id_stat_key = key;
+      break;
+    }
+  }
+  ASSERT_GE(program_id_stat_key, 0) << "kProgramId stat metadata not found";
+
+  const auto& em = plane.event_metadata().at(program_id);
+  bool found = false;
+  for (const auto& stat : em.stats()) {
+    if (stat.metadata_id() == program_id_stat_key) {
+      EXPECT_EQ(static_cast<uint64_t>(stat.int64_value()), program_id);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found) << "kProgramId stat not found on event_metadata";
+}
+
+TEST(MetadataUtilsTest, AddHloProtoIsIdempotent) {
+  tensorflow::profiler::XPlane plane;
+  MetadataXPlaneBuilder builder(&plane);
+
+  const uint64_t program_id = 664863;
+  builder.AddHloProto(program_id, MakeHloProto("jit_fn", program_id));
+  builder.AddHloProto(program_id, MakeHloProto("jit_fn", program_id));
+
+  EXPECT_EQ(plane.event_metadata().size(), 1);
+}
+
+TEST(MetadataUtilsTest, ScopedOuterBuilderDoesNotCorruptProgramIdKeys) {
+  tensorflow::profiler::XPlane plane;
+
+  {
+    tsl::profiler::XPlaneBuilder xp(&plane);
+    auto* stat_meta = xp.GetOrCreateStatMetadata("jax_version");
+    xp.AddStatValue(*stat_meta, std::string("0.9.2"));
+  }
+
+  const uint64_t program_id = 664863;
+  {
+    MetadataXPlaneBuilder metadata_plane(&plane);
+    metadata_plane.AddHloProto(program_id, MakeHloProto("jit_fn", program_id));
+  }
+
+  ASSERT_EQ(plane.event_metadata().size(), 1);
+  EXPECT_TRUE(plane.event_metadata().contains(program_id))
+      << "Scoped outer XPlaneBuilder must not change event_metadata map keys.";
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/tsl/profiler/convert/xla_op_utils.h
+++ b/xla/tsl/profiler/convert/xla_op_utils.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <string>
 
 #include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "xla/tsl/platform/macros.h"

--- a/xla/tsl/profiler/utils/xplane_utils.cc
+++ b/xla/tsl/profiler/utils/xplane_utils.cc
@@ -368,8 +368,12 @@ void MergePlanes(const XPlane& src_plane, XPlane* dst_plane) {
   });
 
   src.ForEachEventMetadata([&](const XEventMetadataVisitor& event_metadata) {
+    // Preserve metadata-plane event ids because XProf matches program_id
+    // to /host:metadata event_metadata keys during op attribution.
     XEventMetadata* dst_event_metadata =
-        dst.GetOrCreateEventMetadata(event_metadata.Name());
+        src_plane.name() == kMetadataPlaneName
+            ? dst.GetOrCreateEventMetadata(event_metadata.Id())
+            : dst.GetOrCreateEventMetadata(event_metadata.Name());
     CopyEventMetadata(*event_metadata.metadata(), src, *dst_event_metadata,
                       dst);
   });

--- a/xla/tsl/profiler/utils/xplane_utils_test.cc
+++ b/xla/tsl/profiler/utils/xplane_utils_test.cc
@@ -524,6 +524,25 @@ TEST(XplaneUtilsTest, TestAggregateXPlanes) {
 #endif
 }
 
+// Merging /host:metadata must preserve program_id as the event_metadata key
+// so XProf op attribution can still resolve modules.
+TEST(XPlaneUtilsTest, MergePlanesPreservesProgramIdEventMetadataKeys) {
+  XPlane src_plane;
+  src_plane.set_name(std::string(kMetadataPlaneName));
+  XPlaneBuilder src(&src_plane);
+  constexpr int64_t kProgramId = 664863;
+  const std::string hlo_module_name = "jit_train_step(664863)";
+  XEventMetadata* src_event_metadata = src.GetOrCreateEventMetadata(kProgramId);
+  src_event_metadata->set_name(hlo_module_name);
+
+  XPlane dst_plane;
+  MergePlanes(src_plane, &dst_plane);
+
+  ASSERT_TRUE(dst_plane.event_metadata().contains(kProgramId));
+  EXPECT_EQ(dst_plane.event_metadata().at(kProgramId).name(), hlo_module_name);
+  EXPECT_FALSE(dst_plane.event_metadata().contains(1));
+}
+
 TEST(XplaneUtilsTest, TestAggregateXPlanesWithNonUniqueMetadataNames) {
   XPlane xplane;
   XPlaneBuilder builder(&xplane);


### PR DESCRIPTION
📝 Summary of Changes
  This change fixes XProf operation/layer attribution by preserving HLO
  program_id as the /host:metadata event_metadata key throughout the
  profiling pipeline. It restores integer program_id-based metadata
  insertion in metadata_utils.h, preserves those metadata IDs when merging
  /host:metadata planes in xplane_utils.cc, and adds targeted unit tests
  covering both metadata insertion and metadata-plane merge behavior.

🎯 Justification
  XProf’s Operations view relies on GPU kernel program_id values matching
  /host:metadata event_metadata keys so kernels can be attributed back to
  HLO modules and higher-level layers. Recent changes broke that mapping in
  two places: HLO metadata insertion stopped keying entries by integer
  program_id, and metadata-plane merge could also reassign those IDs. This
  change restores that mapping. The main workload validated for this fix is
  MaxText profiling with XPlane/XProf, including a llama3.1-8b
  reproducer that previously showed missing layer attribution.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Not applicable. This change is a correctness fix for profiler metadata 
mapping, not a performance optimization.

🧪 Unit Tests:
  
Added:
  - //xla/backends/profiler/cpu:metadata_utils_test: verifies that HLO
    metadata uses the actual program_id as the key. It also checks that
    name and display name are preserved, kProgramId is stored, repeated
    insertion for the same program_id is idempotent, and the scoped
    builder flow does not corrupt program_id keys.
  - //xla/tsl/profiler/utils:xplane_utils_test: adds a targeted test that
    merging /host:metadata preserves program_id as the event_metadata
    key.

🧪 Execution Tests:
  No new checked-in execution test was added in this PR. External end-to-end
  validation was run with a MaxText reproducer on a single machine/GPU setup
  using llama3.1-8b.