### PR TITLE
[xla:gpu] Fix a bug when emitting degenerate collective permute

### DIFF
--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -1583,8 +1583,6 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectivePermute(
           /*destination_buffer=*/
           ShapedSlice{result_slice, result_buffer_shape},
           /*mem_size=*/ShapeUtil::ByteSizeOf(operand_shape)));
-      // Signal that start thunk not created (degenerate) with nullptr.
-      hlo_async_executions_.try_emplace(instr, nullptr);
     } else {
       const CollectiveThunk::Buffer buffer = {
           /*element_count=*/ShapeUtil::ElementsIn(operand_shape),


### PR DESCRIPTION
`hlo_async_executions_` updated below for sync/async execution. Adding nullptr to the map is not correct, because degenerate copies become async copies with their own async execution tracking.

Fix for an error: `Async execution already exists for instruction collective-permute`