### PR TITLE
[XLA:GPU] Command buffer supports partial update-free for trace commands. 

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -593,6 +593,7 @@ cc_library(
         ":command_state",
         ":sequential_thunk",  # build_cleaner: keep
         ":thunk",
+        "//xla:debug_options_flags",
         "//xla:util",
         "//xla/service:buffer_assignment",  # build_cleaner: keep
         "//xla/service/gpu:buffer_allocations",  # build_cleaner: keep

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -156,7 +156,7 @@ class Command {
 
     // The CommandBufferUpdateMode for the enclosing command buffer thunk.
     DebugOptions::CommandBufferUpdateMode command_buffer_update_mode =
-        DebugOptions::FULL_UPDATE;
+        DebugOptions::ALWAYS_UPDATE;
   };
 
   // Create new commands in the command buffer using the given dependencies.

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_RUNTIME_COMMAND_H_
 #define XLA_BACKENDS_GPU_RUNTIME_COMMAND_H_
 
-#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -39,6 +38,7 @@ limitations under the License.
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "xla/xla.pb.h"
 
 namespace xla::gpu {
 
@@ -153,6 +153,10 @@ class Command {
     // A flag indicating whether we record commands at command buffer thunk
     // initialization time.
     bool is_initialization = false;
+
+    // The CommandBufferUpdateMode for the enclosing command buffer thunk.
+    DebugOptions::CommandBufferUpdateMode command_buffer_update_mode =
+        DebugOptions::FULL_UPDATE;
   };
 
   // Create new commands in the command buffer using the given dependencies.
@@ -209,6 +213,10 @@ class Command {
   // deadlocks. By forcing the command update at thunk initialization time, we
   // ensure that all ranks execute NCCL command update.
   virtual bool requires_initialization() const { return false; }
+
+  // Returns true if this command is implemented via CUDA stream activity
+  // tracing (i.e. a subclass of TracedCommandBufferCmd).
+  virtual bool IsTracedCommand() const { return false; }
 
   // Returns true if command supports loop unroll, the while loop can be
   // unrolled only if it has pre-known trip count and also all commands from the

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -111,6 +111,9 @@ class TracedCommandBuffer : public CommandState {
 
 // A base class for commands implemented as tracing of stream activities.
 class TracedCommandBufferCmd : public Command {
+ public:
+  bool IsTracedCommand() const override { return true; }
+
  protected:
   explicit TracedCommandBufferCmd(CommandType cmd_type);
 
@@ -549,6 +552,8 @@ class CollectiveCmd : public Command {
   CollectiveCmd(CommandType cmd_type, CollectiveConfig config);
 
   absl::Status Prepare(const Thunk::PrepareParams& params) final;
+
+  bool IsTracedCommand() const override { return true; }
 
   bool requires_initialization() const final { return true; }
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.h
@@ -29,7 +29,7 @@ struct ConvertToCommandsOptions {
       CommandExecutor::SynchronizationMode::kSerialize;
   bool enable_loop_unroll = false;
   DebugOptions::CommandBufferUpdateMode command_buffer_update_mode =
-      DebugOptions::FULL_UPDATE;
+      DebugOptions::ALWAYS_UPDATE;
 };
 
 // Converts thunk sequence to a command buffer cmd sequence.

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "xla/backends/gpu/runtime/command_executor.h"
 #include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/xla.pb.h"
 
 namespace xla::gpu {
 
@@ -27,7 +28,8 @@ struct ConvertToCommandsOptions {
   CommandExecutor::SynchronizationMode synchronization_mode =
       CommandExecutor::SynchronizationMode::kSerialize;
   bool enable_loop_unroll = false;
-  bool enable_command_buffer_va_remapping = false;
+  DebugOptions::CommandBufferUpdateMode command_buffer_update_mode =
+      DebugOptions::FULL_UPDATE;
 };
 
 // Converts thunk sequence to a command buffer cmd sequence.

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
@@ -442,14 +442,13 @@ ConvertThunksToCommandBuffer(
     CommandExecutor::SynchronizationMode synchronization_mode,
     const DebugOptions& debug_options) {
   bool enable_loop_unroll = debug_options.xla_gpu_command_buffer_unroll_loops();
-  bool enable_va_remapping =
-      debug_options.xla_gpu_enable_command_buffer_va_remapping();
-  TF_ASSIGN_OR_RETURN(
-      CommandExecutor cmd_executor,
-      ConvertToCommands(
-          thunks_to_convert,
-          ConvertToCommandsOptions{synchronization_mode, enable_loop_unroll,
-                                   enable_va_remapping}));
+  DebugOptions::CommandBufferUpdateMode update_mode =
+      debug_options.xla_gpu_command_buffer_update_mode();
+  TF_ASSIGN_OR_RETURN(CommandExecutor cmd_executor,
+                      ConvertToCommands(thunks_to_convert,
+                                        ConvertToCommandsOptions{
+                                            synchronization_mode,
+                                            enable_loop_unroll, update_mode}));
 
   std::string command_buffer_profile_annotation = absl::StrCat(
       "command_buffer",
@@ -480,8 +479,7 @@ ConvertThunksToCommandBuffer(
       std::move(cmd_executor), std::move(thunk_info),
       std::make_unique<SequentialThunk>(Thunk::ThunkInfo(),
                                         std::move(thunks_to_convert)),
-      debug_options.xla_enable_command_buffers_during_profiling(),
-      enable_va_remapping);
+      debug_options.xla_enable_command_buffers_during_profiling(), update_mode);
 }
 
 absl::Status FlushCommandBuffer(

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/command_executor.h"
 #include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/debug_options_flags.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -62,13 +63,13 @@ CommandBufferThunk::CommandBufferThunk(
     CommandExecutor commands, ThunkInfo thunk_info,
     std::unique_ptr<SequentialThunk> thunks,
     bool enable_command_buffers_during_profiling,
-    bool enable_command_buffer_va_remapping)
+    DebugOptions::CommandBufferUpdateMode command_buffer_update_mode)
     : Thunk(Thunk::kCommandBuffer, std::move(thunk_info)),
       commands_(std::move(commands)),
       thunks_(std::move(thunks)),
       enable_command_buffers_during_profiling_(
           enable_command_buffers_during_profiling),
-      enable_command_buffer_va_remapping_(enable_command_buffer_va_remapping),
+      command_buffer_update_mode_(command_buffer_update_mode),
       state_(std::make_shared<State>()) {
   if (VLOG_IS_ON(5)) {
     absl::StatusOr<std::string> graph = commands_.RenderExecutionGraph();
@@ -94,6 +95,30 @@ CommandBufferThunk::CommandBufferThunk(
   // all have a pretty large LRU cache for keeping O(1000) XLA executables.
   EvictCommandBuffers();
   TrackCommandBuffers(state_);
+
+  // Pre-compute the minimum allocation index of the first traced command so
+  // GetOrCreateCommandBuffer() doesn't have to walk the command tree on every
+  // call.
+  if (command_buffer_update_mode_ == DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) {
+    bool found = false;
+    CHECK_OK(commands_.Walk([&](const Command* command) -> absl::Status {
+      if (!found && command->IsTracedCommand()) {
+        found = true;
+        std::optional<BufferAllocation::Index> min_idx;
+        for (const auto& use : command->buffer_uses()) {
+          const BufferAllocation* alloc = use.slice().allocation();
+          if (alloc->is_constant() || alloc->size() == 0) continue;
+          if (!min_idx.has_value() || use.slice().index() < *min_idx) {
+            min_idx = use.slice().index();
+          }
+        }
+        if (min_idx.has_value()) {
+          first_traced_cmd_alloc_idx_ = min_idx;
+        }
+      }
+      return absl::OkStatus();
+    }));
+  }
 }
 
 std::vector<BufferAllocation::Index>
@@ -156,10 +181,6 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     return absl::OkStatus();
   }
 
-  TF_ASSIGN_OR_RETURN(std::shared_ptr<ExecutorCommandBuffer> cmd_buffer,
-                      GetOrCreateCommandBuffer(params.executor));
-  absl::MutexLock lock(cmd_buffer->mutex);
-
   // Initialize commands.
   TF_RETURN_IF_ERROR(commands_.Initialize(params));
 
@@ -178,6 +199,11 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     TraceMe trace("WARNING: CommandBuffer disabled when profiling");
     return absl::OkStatus();
   }
+
+  TF_ASSIGN_OR_RETURN(
+      std::shared_ptr<ExecutorCommandBuffer> cmd_buffer,
+      GetOrCreateCommandBuffer(params.executor, *params.buffer_allocations));
+  absl::MutexLock lock(cmd_buffer->mutex);
 
   // If there are no thunks, or command buffer does not require initialization,
   // we can mark warm up as done immediately.
@@ -198,20 +224,24 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
       /*additional_compute_streams=*/{}, params.execution_scoped_state,
       /*mock_collectives=*/false);
 
+  if (!cmd_buffer->warmup_done) {
+    return absl::OkStatus();
+  }
+
   // If command buffer is in `kCreate` state it means that command buffer
   // sequence was never recorded into it. We initialize all command buffers
   // before execution, because command buffers when instantiated will allocate
   // memory on device and this might lead to deadlocks when we have concurrent
   // NCCL operations in flight.
-  //
+
   // If commands require initialization (and VA remapping is not enabled), we
   // also record them into the command buffer before execution. This is required
   // to guarantee that collective commands are recorded on all participating
   // ranks to avoid deadlocks.
-  if (cmd_buffer->warmup_done && (cmd_buffer->command_buffer->state() ==
-                                      se::CommandBuffer::State::kCreate ||
-                                  (!enable_command_buffer_va_remapping_ &&
-                                   commands_.requires_initialization()))) {
+  if (cmd_buffer->command_buffer->state() ==
+          se::CommandBuffer::State::kCreate ||
+      (command_buffer_update_mode_ != DebugOptions::FULL_UPDATE_FREE &&
+       commands_.requires_initialization())) {
     VLOG(3) << "Initialize command buffer on device #"
             << params.executor->device_ordinal()
             << " by recoding command buffer cmd sequence"
@@ -231,7 +261,9 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
 
     Command::RecordParams record_params = {cmd_buffer->state,
                                            std::move(updated_allocs),
-                                           /*is_initialization=*/true};
+                                           /*is_initialization=*/true,
+                                           /*command_buffer_update_mode=*/
+                                           command_buffer_update_mode_};
     TF_RETURN_IF_ERROR(commands_.Record(execute_params, record_params,
                                         cmd_buffer->command_buffer.get()));
 
@@ -264,8 +296,9 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   }
 
   se::StreamExecutor* executor = params.stream->parent();
-  TF_ASSIGN_OR_RETURN(std::shared_ptr<ExecutorCommandBuffer> cmd_buffer,
-                      GetOrCreateCommandBuffer(executor));
+  TF_ASSIGN_OR_RETURN(
+      std::shared_ptr<ExecutorCommandBuffer> cmd_buffer,
+      GetOrCreateCommandBuffer(executor, *params.buffer_allocations));
 
   absl::MutexLock lock(cmd_buffer->mutex);
 
@@ -282,10 +315,13 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   // Determine whether to (re-)record the command buffer and whether this is a
   // first-time initialization recording (VA remapping path).
   bool is_first_record =
-      enable_command_buffer_va_remapping_ &&
+      command_buffer_update_mode_ == DebugOptions::FULL_UPDATE_FREE &&
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
-  bool needs_update = !enable_command_buffer_va_remapping_ &&
-                      (!updated_allocs.empty() || commands_.force_update());
+  bool needs_update =
+      (command_buffer_update_mode_ == DebugOptions::FULL_UPDATE ||
+       command_buffer_update_mode_ ==
+           DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) &&
+      (!updated_allocs.empty() || commands_.force_update());
 
   if (is_first_record || needs_update) {
     XLA_VLOG_DEVICE(3, executor->device_ordinal())
@@ -303,15 +339,16 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
                                ? "command_buffer::update"
                                : "command_buffer::record_for_va_remapping",
                            {{"device", executor->device_ordinal()},
-                            {"num_commands", commands_.size()},
-                            {"num_executions", cmd_buffer->num_executions}});
+                            {"num_commands", commands_.size()}});
     });
 
     uint64_t start_micros = tsl::Env::Default()->NowMicros();
 
     Command::RecordParams record_params = {
         cmd_buffer->state, std::move(updated_allocs),
-        /*is_initialization=*/is_first_record};
+        /*is_initialization=*/is_first_record,
+        /*command_buffer_update_mode=*/
+        command_buffer_update_mode_};
     TF_RETURN_IF_ERROR(commands_.Record(params, record_params,
                                         cmd_buffer->command_buffer.get()));
 
@@ -341,11 +378,37 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
 }
 
 absl::StatusOr<std::shared_ptr<CommandBufferThunk::ExecutorCommandBuffer>>
-CommandBufferThunk::GetOrCreateCommandBuffer(se::StreamExecutor* executor) {
+CommandBufferThunk::GetOrCreateCommandBuffer(
+    se::StreamExecutor* executor, const BufferAllocations& buffer_allocations) {
+  void* first_alloc_address = nullptr;
+  if (command_buffer_update_mode_ == DebugOptions::FULL_UPDATE_FREE &&
+      !allocs_indices().empty()) {
+    first_alloc_address =
+        buffer_allocations.GetDeviceAddress(allocs_indices()[0]).opaque();
+  } else if (command_buffer_update_mode_ ==
+             DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) {
+    // Use the cached minimum allocation index of the first traced command
+    // (computed once at construction time) to look up the physical address of
+    // its buffer allocation. This address serves as the key to identify which
+    // VA reservation set is active for the current execution.
+    //
+    // This works because the VMM allocator assigns each VA reservation set a
+    // distinct physical memory region: when execution alternates between two
+    // VA ranges (indices 0 and 1), the physical address backing
+    // first_traced_cmd_alloc_idx_ will differ between the two sets, uniquely
+    // identifying the active VA range. Constants and zero-size allocations are
+    // excluded (at construction time) to ensure the chosen index maps to a
+    // real, varying physical address.
+    if (first_traced_cmd_alloc_idx_.has_value()) {
+      first_alloc_address =
+          buffer_allocations.GetDeviceAddress(*first_traced_cmd_alloc_idx_)
+              .opaque();
+    }
+  }
+  auto key = std::make_pair(executor, first_alloc_address);
   absl::MutexLock lock(state_->mutex);
-
   // Check if command buffer already exists
-  if (auto it = state_->command_buffers.find(executor);
+  if (auto it = state_->command_buffers.find(key);
       it != state_->command_buffers.end()) {
     return it->second;
   }
@@ -355,8 +418,12 @@ CommandBufferThunk::GetOrCreateCommandBuffer(se::StreamExecutor* executor) {
       auto command_buffer,
       executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
   auto emplaced = state_->command_buffers.emplace(
-      executor,
-      std::make_shared<ExecutorCommandBuffer>(std::move(command_buffer)));
+      key, std::make_shared<ExecutorCommandBuffer>(std::move(command_buffer)));
+  // With kNumVaReservationSets=2, at most 2 command buffers should exist per
+  // executor (one per VA reservation set).
+  DCHECK_LE(state_->command_buffers.size(), static_cast<size_t>(2))
+      << "command_buffers map has more entries than expected VA reservation "
+      << "sets for executor " << executor;
 
   return emplaced.first->second;
 }

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -99,7 +99,7 @@ CommandBufferThunk::CommandBufferThunk(
   // Pre-compute the minimum allocation index of the first traced command so
   // GetOrCreateCommandBuffer() doesn't have to walk the command tree on every
   // call.
-  if (command_buffer_update_mode_ == DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) {
+  if (command_buffer_update_mode_ == DebugOptions::CAPTURE_CMD_NEVER_UPDATE) {
     bool found = false;
     CHECK_OK(commands_.Walk([&](const Command* command) -> absl::Status {
       if (!found && command->IsTracedCommand()) {
@@ -240,7 +240,7 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
   // ranks to avoid deadlocks.
   if (cmd_buffer->command_buffer->state() ==
           se::CommandBuffer::State::kCreate ||
-      (command_buffer_update_mode_ != DebugOptions::FULL_UPDATE_FREE &&
+      (command_buffer_update_mode_ != DebugOptions::NEVER_UPDATE &&
        commands_.requires_initialization())) {
     VLOG(3) << "Initialize command buffer on device #"
             << params.executor->device_ordinal()
@@ -315,12 +315,11 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   // Determine whether to (re-)record the command buffer and whether this is a
   // first-time initialization recording (VA remapping path).
   bool is_first_record =
-      command_buffer_update_mode_ == DebugOptions::FULL_UPDATE_FREE &&
+      command_buffer_update_mode_ == DebugOptions::NEVER_UPDATE &&
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
   bool needs_update =
-      (command_buffer_update_mode_ == DebugOptions::FULL_UPDATE ||
-       command_buffer_update_mode_ ==
-           DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) &&
+      (command_buffer_update_mode_ == DebugOptions::ALWAYS_UPDATE ||
+       command_buffer_update_mode_ == DebugOptions::CAPTURE_CMD_NEVER_UPDATE) &&
       (!updated_allocs.empty() || commands_.force_update());
 
   if (is_first_record || needs_update) {
@@ -381,12 +380,12 @@ absl::StatusOr<std::shared_ptr<CommandBufferThunk::ExecutorCommandBuffer>>
 CommandBufferThunk::GetOrCreateCommandBuffer(
     se::StreamExecutor* executor, const BufferAllocations& buffer_allocations) {
   void* first_alloc_address = nullptr;
-  if (command_buffer_update_mode_ == DebugOptions::FULL_UPDATE_FREE &&
+  if (command_buffer_update_mode_ == DebugOptions::NEVER_UPDATE &&
       !allocs_indices().empty()) {
     first_alloc_address =
         buffer_allocations.GetDeviceAddress(allocs_indices()[0]).opaque();
   } else if (command_buffer_update_mode_ ==
-             DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) {
+             DebugOptions::CAPTURE_CMD_NEVER_UPDATE) {
     // Use the cached minimum allocation index of the first traced command
     // (computed once at construction time) to look up the physical address of
     // its buffer allocation. This address serves as the key to identify which

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -47,7 +47,7 @@ class CommandBufferThunk : public Thunk {
       std::unique_ptr<SequentialThunk> thunks = nullptr,
       bool enable_command_buffers_during_profiling = false,
       DebugOptions::CommandBufferUpdateMode command_buffer_update_mode =
-          DebugOptions::FULL_UPDATE);
+          DebugOptions::ALWAYS_UPDATE);
 
   const std::unique_ptr<SequentialThunk>& thunks() const { return thunks_; }
 
@@ -176,7 +176,7 @@ class CommandBufferThunk : public Thunk {
   DebugOptions::CommandBufferUpdateMode command_buffer_update_mode_;
 
   // Cached minimum allocation index of the first traced command. Computed once
-  // in the constructor for CUSTOM_LIBRARY_UPDATE_FREE mode.
+  // in the constructor for CAPTURE_CMD_NEVER_UPDATE mode.
   std::optional<BufferAllocation::Index> first_traced_cmd_alloc_idx_;
 
   // Command buffer thunk state allocated in heap to allow global (per-process)

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -16,9 +16,10 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_RUNTIME_COMMAND_BUFFER_THUNK_H_
 #define XLA_BACKENDS_GPU_RUNTIME_COMMAND_BUFFER_THUNK_H_
 
-#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/base/thread_annotations.h"
@@ -35,21 +36,30 @@ limitations under the License.
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/xla.pb.h"
 
 namespace xla::gpu {
 
 class CommandBufferThunk : public Thunk {
  public:
-  CommandBufferThunk(CommandExecutor commands, ThunkInfo thunk_info,
-                     std::unique_ptr<SequentialThunk> thunks = nullptr,
-                     bool enable_command_buffers_during_profiling = false,
-                     bool enable_command_buffer_va_remapping = false);
+  CommandBufferThunk(
+      CommandExecutor commands, ThunkInfo thunk_info,
+      std::unique_ptr<SequentialThunk> thunks = nullptr,
+      bool enable_command_buffers_during_profiling = false,
+      DebugOptions::CommandBufferUpdateMode command_buffer_update_mode =
+          DebugOptions::FULL_UPDATE);
 
   const std::unique_ptr<SequentialThunk>& thunks() const { return thunks_; }
 
   // Returns buffer allocation indices referenced by commands in this thunk.
   absl::Span<const BufferAllocation::Index> allocs_indices() const {
     return commands_.allocs_indices();
+  }
+
+  // Walks all commands in this thunk, invoking the callback for each.
+  absl::Status WalkCommands(
+      absl::FunctionRef<absl::Status(const Command*)> callback) const {
+    return commands_.Walk(callback);
   }
 
   absl::Status Prepare(const PrepareParams& params) override;
@@ -117,16 +127,22 @@ class CommandBufferThunk : public Thunk {
   };
 
   // Command buffer thunk owns commands buffers instantiated on all executors.
+  // When VA remapping is enabled, the key includes the first allocation's VA
+  // address to distinguish between command buffers for different VA ranges.
   struct State {
     absl::Mutex mutex;
-    absl::flat_hash_map<se::StreamExecutor*,
+    absl::flat_hash_map<std::pair<se::StreamExecutor*, void*>,
                         std::shared_ptr<ExecutorCommandBuffer>>
         command_buffers ABSL_GUARDED_BY(mutex);
   };
 
-  // Returns a command buffer instantiated for `executor` or creates new one.
+  // Returns a command buffer for (executor, buffer_allocations) or creates a
+  // new one. When VA remapping is enabled the key includes the first
+  // allocation's device address to distinguish per-VA-range command buffers;
+  // otherwise the key uses nullptr.
   absl::StatusOr<std::shared_ptr<ExecutorCommandBuffer>>
-  GetOrCreateCommandBuffer(se::StreamExecutor* executor);
+  GetOrCreateCommandBuffer(se::StreamExecutor* executor,
+                           const BufferAllocations& buffer_allocations);
 
   // Each individual command buffer allocates state on device (CUDA graph) and
   // it adds up pretty quickly. To prevent OOM errors we proactively evict
@@ -156,9 +172,12 @@ class CommandBufferThunk : public Thunk {
   // TODO(b/355487968): Remove this option when validation complete.
   bool enable_command_buffers_during_profiling_;
 
-  // When true, VA remapping is used for command buffer buffer allocations so
-  // that the command buffer can be recorded once and replayed without updates.
-  bool enable_command_buffer_va_remapping_;
+  // The update mode controlling VA remapping strategy for this command buffer.
+  DebugOptions::CommandBufferUpdateMode command_buffer_update_mode_;
+
+  // Cached minimum allocation index of the first traced command. Computed once
+  // in the constructor for CUSTOM_LIBRARY_UPDATE_FREE mode.
+  std::optional<BufferAllocation::Index> first_traced_cmd_alloc_idx_;
 
   // Command buffer thunk state allocated in heap to allow global (per-process)
   // management of instantiated command buffers.

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -565,9 +565,29 @@ absl::Status CommandExecutor::RecordUpdate(
       return false;
     }
 
+    Command* command = commands_[id].get();
+
+    // For CUSTOM_LIBRARY_UPDATE_FREE mode, always skip updates for commands
+    // implemented via tracing (TracedCommandBufferCmd subclasses) or collective
+    // operations (CollectiveCmd subclasses). Their buffer allocations are
+    // VA-remapped to fixed offsets within the reserved VA range, so their
+    // recorded addresses remain valid across executions — no update is needed.
+    //
+    // Note: CollectiveCmd satisfies both IsTracedCommand() and
+    // requires_initialization(), but the requires_initialization() check below
+    // is intentionally unreachable for traced commands in this mode. Because
+    // their buffer addresses are stable (VA-mapped), re-initialization is
+    // unnecessary.
+    if (record_params.command_buffer_update_mode ==
+            DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE &&
+        command->IsTracedCommand()) {
+      VLOG(3) << "Skipping update for traced command " << id
+              << " (CUSTOM_LIBRARY_UPDATE_FREE mode)";
+      return true;
+    }
+
     // We always update commands that require initialization, even if buffer
     // allocations didn't change.
-    Command* command = commands_[id].get();
     if (command->requires_initialization() && record_params.is_initialization) {
       return false;
     }

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -567,7 +567,7 @@ absl::Status CommandExecutor::RecordUpdate(
 
     Command* command = commands_[id].get();
 
-    // For CUSTOM_LIBRARY_UPDATE_FREE mode, always skip updates for commands
+    // For CAPTURE_CMD_NEVER_UPDATE mode, always skip updates for commands
     // implemented via tracing (TracedCommandBufferCmd subclasses) or collective
     // operations (CollectiveCmd subclasses). Their buffer allocations are
     // VA-remapped to fixed offsets within the reserved VA range, so their
@@ -579,10 +579,10 @@ absl::Status CommandExecutor::RecordUpdate(
     // their buffer addresses are stable (VA-mapped), re-initialization is
     // unnecessary.
     if (record_params.command_buffer_update_mode ==
-            DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE &&
+            DebugOptions::CAPTURE_CMD_NEVER_UPDATE &&
         command->IsTracedCommand()) {
       VLOG(3) << "Skipping update for traced command " << id
-              << " (CUSTOM_LIBRARY_UPDATE_FREE mode)";
+              << " (CAPTURE_CMD_NEVER_UPDATE mode)";
       return true;
     }
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -504,7 +504,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_print_compilation_stats(false);
 
   opts.set_xla_gpu_enable_pdl(true);
-  opts.set_xla_gpu_command_buffer_update_mode(DebugOptions::FULL_UPDATE);
+  opts.set_xla_gpu_command_buffer_update_mode(DebugOptions::ALWAYS_UPDATE);
   return opts;
 }
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -105,7 +105,8 @@ absl::StatusOr<std::vector<RepeatedFlagModifier>> ParseRepeatedEnumModifiers(
 namespace {
 
 template <typename T>
-static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list, T value) {
+static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list,
+                                   T value) {
   for (auto it = list->begin(); it != list->end(); ++it) {
     if (*it == value) {
       return it;
@@ -503,7 +504,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_print_compilation_stats(false);
 
   opts.set_xla_gpu_enable_pdl(true);
-  opts.set_xla_gpu_enable_command_buffer_va_remapping(false);
+  opts.set_xla_gpu_command_buffer_update_mode(DebugOptions::FULL_UPDATE);
   return opts;
 }
 
@@ -711,6 +712,18 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
           debug_options->set_xla_gpu_command_buffer_scheduling_mode(
               DebugOptions::SERIALIZE);
         }
+        return true;
+      };
+
+  // Custom "sub-parser" lambda for
+  // `xla_gpu_command_buffer_update_mode`.
+  auto setter_for_xla_gpu_command_buffer_update_mode =
+      [debug_options](const std::string& value) {
+        DebugOptions::CommandBufferUpdateMode mode;
+        if (!DebugOptions::CommandBufferUpdateMode_Parse(value, &mode)) {
+          return false;
+        }
+        debug_options->set_xla_gpu_command_buffer_update_mode(mode);
         return true;
       };
 
@@ -2988,18 +3001,18 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 debug_options->xla_gpu_enable_pdl(),
                 "Enable PDL (Programmatic Dependent Launch)."));
   flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_command_buffer_va_remapping",
-      bool_setter_for(
-          &DebugOptions::set_xla_gpu_enable_command_buffer_va_remapping),
-      debug_options->xla_gpu_enable_command_buffer_va_remapping(),
-      "Enable VA remapping for command buffer thunks. When enabled, command "
-      "buffer thunks use fixed virtual addresses across executions, allowing "
-      "the command buffer to be recorded once and replayed without updates."));
-  flag_list->push_back(tsl::Flag(
       "xla_dump_buffer_assignment_analysis",
       bool_setter_for(&DebugOptions::set_xla_dump_buffer_assignment_analysis),
       debug_options->xla_dump_buffer_assignment_analysis(),
       "Dump BufferAssignment analysis."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_command_buffer_update_mode",
+      setter_for_xla_gpu_command_buffer_update_mode,
+      DebugOptions::CommandBufferUpdateMode_Name(
+          debug_options->xla_gpu_command_buffer_update_mode()),
+      "Controls the VA remapping update strategy for command buffer thunks. "
+      "See CommandBufferUpdateMode for details."));
+>>>>>>> 4a778a0836 (Add StreamExecutorVmmAllocator and DeviceAddressVmmAllocator)
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more
@@ -3093,8 +3106,7 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_pipelined_all_gather",

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -3012,7 +3012,6 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
           debug_options->xla_gpu_command_buffer_update_mode()),
       "Controls the VA remapping update strategy for command buffer thunks. "
       "See CommandBufferUpdateMode for details."));
->>>>>>> 4a778a0836 (Add StreamExecutorVmmAllocator and DeviceAddressVmmAllocator)
 }  // NOLINT(readability/fn_size)
 
 // Allocates flag_values and flag_objects; this function must not be called more

--- a/xla/executable_run_options.cc
+++ b/xla/executable_run_options.cc
@@ -193,4 +193,14 @@ std::vector<std::unique_ptr<CliqueKey>>* ExecutableRunOptions::clique_keys()
   return clique_keys_;
 }
 
+ExecutableRunOptions& ExecutableRunOptions::set_command_buffer_va_range_idx(
+    int idx) {
+  command_buffer_va_range_idx_ = idx;
+  return *this;
+}
+
+int ExecutableRunOptions::command_buffer_va_range_idx() const {
+  return command_buffer_va_range_idx_;
+}
+
 }  // namespace xla

--- a/xla/executable_run_options.h
+++ b/xla/executable_run_options.h
@@ -266,6 +266,12 @@ class ExecutableRunOptions {
       std::vector<std::unique_ptr<CliqueKey>>* clique_keys);
   std::vector<std::unique_ptr<CliqueKey>>* clique_keys() const;
 
+  // Index into the set of VA reservations used for command buffer remapping.
+  // With kNumVaReservationSets=2 reservations, alternating between idx 0 and
+  // 1 allows CPU remapping of one range while the GPU executes the other.
+  ExecutableRunOptions& set_command_buffer_va_range_idx(int idx);
+  int command_buffer_va_range_idx() const;
+
  private:
   stream_executor::DeviceAddressAllocator* allocator_ = nullptr;
   int device_ordinal_ = -1;
@@ -287,6 +293,7 @@ class ExecutableRunOptions {
   const gpu::GpuExecutableRunOptions* gpu_executable_run_options_ = nullptr;
   const ffi::ExecutionContext* ffi_execution_context_ = nullptr;
   std::vector<std::unique_ptr<CliqueKey>>* clique_keys_ = nullptr;
+  int command_buffer_va_range_idx_ = 0;
 };
 
 }  // namespace xla

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1521,7 +1521,7 @@ GetStreamExecutorGpuDeviceAllocator(
   std::vector<se::MultiDeviceAdapter::AllocatorInfo> allocators;
   GpuAllocatorConfig::Kind effective_kind = allocator_config.kind;
   if (GetDebugOptionsFromFlags().xla_gpu_command_buffer_update_mode() !=
-          DebugOptions::FULL_UPDATE &&
+          DebugOptions::ALWAYS_UPDATE &&
       effective_kind != GpuAllocatorConfig::Kind::kVmm) {
     LOG(WARNING) << "xla_gpu_command_buffer_update_mode requires the "
                     "VMM allocator. Overriding allocator kind to kVmm.";

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -115,6 +115,7 @@ limitations under the License.
 #include "xla/tsl/framework/allocator.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/coordination_service.pb.h"
 #include "xla/xla_data.pb.h"
@@ -124,7 +125,6 @@ limitations under the License.
 #include "tsl/platform/protobuf.h"
 #include "tsl/profiler/lib/nvtx_utils.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 #if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
 #include "xla/debug_options_flags.h"
@@ -1519,7 +1519,15 @@ GetStreamExecutorGpuDeviceAllocator(
     const std::map<int, std::unique_ptr<LocalDeviceState>>&
         addressable_devices) {
   std::vector<se::MultiDeviceAdapter::AllocatorInfo> allocators;
-  switch (allocator_config.kind) {
+  GpuAllocatorConfig::Kind effective_kind = allocator_config.kind;
+  if (GetDebugOptionsFromFlags().xla_gpu_command_buffer_update_mode() !=
+          DebugOptions::FULL_UPDATE &&
+      effective_kind != GpuAllocatorConfig::Kind::kVmm) {
+    LOG(WARNING) << "xla_gpu_command_buffer_update_mode requires the "
+                    "VMM allocator. Overriding allocator kind to kVmm.";
+    effective_kind = GpuAllocatorConfig::Kind::kVmm;
+  }
+  switch (effective_kind) {
     case GpuAllocatorConfig::Kind::kCudaAsync: {
       for (const auto& ordinal_and_device : addressable_devices) {
         TF_ASSIGN_OR_RETURN(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -130,6 +130,9 @@ limitations under the License.
 namespace xla {
 namespace {
 
+using ::testing::_;
+using ::testing::Contains;
+using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
 using ::testing::Eq;
@@ -3685,7 +3688,7 @@ GpuClientOptions VmmClientOptions() {
 CompileOptions CmdBufVaRemappingOptions() {
   CompileOptions opts;
   auto* dbg = opts.executable_build_options.mutable_debug_options();
-  dbg->set_xla_gpu_enable_command_buffer_va_remapping(true);
+  dbg->set_xla_gpu_command_buffer_update_mode(DebugOptions::FULL_UPDATE_FREE);
   dbg->set_xla_gpu_graph_min_graph_size(1);
   dbg->add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
   dbg->add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
@@ -4002,7 +4005,7 @@ TEST(StreamExecutorGpuClientTest, CommandBufferVaRemappingDynamicSliceFusion) {
   absl::SetVLogLevel("gpu_executable", old_vlog);
 }
 
-// Tests the kNumOfVaReservationSets=2 multiplexing: runs 6 iterations so the
+// Tests the kNumVaReservationSets=2 multiplexing: runs 6 iterations so the
 // VA range index cycles 0,1,0,1,0,1. Verifies no memory corruption from the
 // alternating remapping across all runs.
 TEST(StreamExecutorGpuClientTest, CommandBufferVaRemappingMultiplexing) {
@@ -4048,6 +4051,211 @@ TEST(StreamExecutorGpuClientTest, CommandBufferVaRemappingMultiplexing) {
   }
   mock_log.StopCapturingLogs();
   absl::SetVLogLevel("gpu_executable", old_vlog);
+}
+
+// Tests that CUSTOM_LIBRARY_UPDATE_FREE mode produces correct results across
+// multiple runs. The GEMM is routed through cuBLAS (GemmCmd/CublasLtCmd), which
+// are traced commands. In CUSTOM_LIBRARY_UPDATE_FREE mode only traced commands
+// populate command_buffer_allocation_indexes_, activating VA remapping so that
+// traced commands skip command buffer updates across alternating VA ranges.
+TEST(StreamExecutorGpuClientTest,
+     CommandBufferVaRemappingCustomLibraryUpdateFree) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(VmmClientOptions()));
+
+  // Pure GEMM: lhs * rhs. With Triton disabled the dot is lowered to a
+  // GemmCmd/CublasLtCmd (TracedCommandBufferCmd subclass), so its allocations
+  // populate command_buffer_allocation_indexes_ under
+  // CUSTOM_LIBRARY_UPDATE_FREE.
+  static constexpr char kHlo[] = R"(
+    HloModule custom_lib_update_free_test
+    ENTRY main {
+      lhs = f32[4,4] parameter(0)
+      rhs = f32[4,4] parameter(1)
+      ROOT dot = f32[4,4] dot(lhs, rhs),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    })";
+
+  CompileOptions opts;
+  auto* dbg = opts.executable_build_options.mutable_debug_options();
+  dbg->set_xla_gpu_command_buffer_update_mode(
+      DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE);
+  dbg->set_xla_gpu_graph_min_graph_size(1);
+  dbg->add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
+  dbg->add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
+  dbg->add_xla_gpu_enable_command_buffer(DebugOptions::CUBLASLT);
+  // Force CUBLAS routing even for small matrices.
+  dbg->set_xla_gpu_gemm_rewrite_size_threshold(0);
+  // Disable Triton GEMM fusion so the dot is lowered to a cuBLAS GemmCmd
+  // (a TracedCommandBufferCmd subclass) rather than a non-traced KernelCmd.
+  dbg->set_xla_gpu_enable_triton_gemm(false);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto executable,
+                          CompileExecutable(kHlo, *client, opts));
+
+  auto* device = client->addressable_devices()[0];
+  TF_ASSERT_OK_AND_ASSIGN(auto* mem, device->default_memory_space());
+
+  // rhs = identity → lhs * identity = lhs.
+  auto identity = LiteralUtil::CreateR2<float>(
+      {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}});
+
+  // Verify VA remapping is active: traced GEMM allocations are in
+  // command_buffer_allocation_indexes_, so ExecuteThunksWithVaRemapping fires.
+  int old_vlog = absl::SetVLogLevel("gpu_executable", 3);
+  absl::ScopedMockLog mock_log(absl::MockLogDefault::kIgnoreUnexpected);
+  EXPECT_CALL(mock_log, Log(absl::LogSeverity::kInfo, ::testing::_,
+                            ::testing::HasSubstr("VA remapping: Mapped")))
+      .Times(::testing::AtLeast(1));
+  mock_log.StartCapturingLogs();
+
+  // 3 runs cover VA reservation set indices 0, 1, 0.
+  for (int run = 0; run < 3; ++run) {
+    float s = static_cast<float>(run + 1);
+    // lhs = s * identity → s * identity * identity = s * identity.
+    auto lhs = LiteralUtil::CreateR2<float>(
+        {{s, 0, 0, 0}, {0, s, 0, 0}, {0, 0, s, 0}, {0, 0, 0, s}});
+
+    TF_ASSERT_OK_AND_ASSIGN(auto lhs_buf,
+                            client->BufferFromHostLiteral(lhs, mem));
+    TF_ASSERT_OK_AND_ASSIGN(auto rhs_buf,
+                            client->BufferFromHostLiteral(identity, mem));
+
+    auto result = executable->Execute({{lhs_buf.get(), rhs_buf.get()}}, {});
+    TF_ASSERT_OK_AND_ASSIGN(auto result_lit, ExtractSingleResult(result));
+
+    EXPECT_TRUE(LiteralTestUtil::Near(lhs, *result_lit, ErrorSpec{1e-5}))
+        << "Mismatch on run " << run;
+  }
+  mock_log.StopCapturingLogs();
+  absl::SetVLogLevel("gpu_executable", old_vlog);
+}
+
+// Tests that two different executables using FULL_UPDATE_FREE can coexist
+// and interleave executions without interfering with each other's VA ranges.
+// Each executable maintains its own per-(executable, device) VA reservation,
+// so remapping in one does not corrupt the other.
+TEST(StreamExecutorGpuClientTest, CommandBufferVaRemappingTwoExecutables) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client,
+                          GetStreamExecutorGpuClient(VmmClientOptions()));
+
+  // exec1: element-wise add.
+  static constexpr char kHlo1[] = R"(
+    HloModule exec1_va_remapping
+    ENTRY main {
+      x = f32[8] parameter(0)
+      y = f32[8] parameter(1)
+      ROOT add = f32[8] add(x, y)
+    })";
+
+  // exec2: element-wise multiply.
+  static constexpr char kHlo2[] = R"(
+    HloModule exec2_va_remapping
+    ENTRY main {
+      a = f32[8] parameter(0)
+      b = f32[8] parameter(1)
+      ROOT mul = f32[8] multiply(a, b)
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto exec1,
+      CompileExecutable(kHlo1, *client, CmdBufVaRemappingOptions()));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto exec2,
+      CompileExecutable(kHlo2, *client, CmdBufVaRemappingOptions()));
+
+  auto* device = client->addressable_devices()[0];
+  TF_ASSERT_OK_AND_ASSIGN(auto* mem, device->default_memory_space());
+
+  auto ones = LiteralUtil::CreateR1<float>({1, 1, 1, 1, 1, 1, 1, 1});
+  auto twos = LiteralUtil::CreateR1<float>({2, 2, 2, 2, 2, 2, 2, 2});
+
+  // --- Assertions for VA range index cycling and command buffer separation ---
+  //
+  // VA range index per-executable: GetNextCommandBufferVaRangeIdx is keyed by
+  // (executable_ptr, device_ordinal), so exec1 and exec2 cycle independently:
+  //   run 0: exec1→idx=0, exec2→idx=0
+  //   run 1: exec1→idx=1, exec2→idx=1
+  //   run 2: exec1→idx=0, exec2→idx=0  (wraps)
+  //
+  // Separate command buffers per (exec, VA range): GetOrCreateCommandBuffer
+  // keys by (executor, physical_address_of_first_alloc). The VMM allocator
+  // gives each VA reservation set a distinct physical region, so VA range 0
+  // and VA range 1 for the same executable get different physical addresses
+  // → different map entries → different CUDA graphs.
+  //
+  // On first use of each (exec, va_range_idx) pair, state==kCreate triggers
+  // "Initialize command buffer" (records the graph).  On run 2 both execs
+  // reuse the existing VA range 0 command buffer — no re-initialization.
+  // 2 execs × 2 VA range indices = 4 initializations total.
+  int old_vlog_exec = absl::SetVLogLevel("gpu_executable", 3);
+  int old_vlog_cbt = absl::SetVLogLevel("command_buffer_thunk", 3);
+  absl::ScopedMockLog mock_log(absl::MockLogDefault::kIgnoreUnexpected);
+
+  // exec1 independently cycles va_range_idx: 0 (run 0), 1 (run 1), 0 (run 2).
+  EXPECT_CALL(mock_log, Log(absl::LogSeverity::kInfo, ::testing::_,
+                            AllOf(HasSubstr("exec1_va_remapping"),
+                                  HasSubstr("va_range_idx=0"))))
+      .Times(2);
+  EXPECT_CALL(mock_log, Log(absl::LogSeverity::kInfo, ::testing::_,
+                            AllOf(HasSubstr("exec1_va_remapping"),
+                                  HasSubstr("va_range_idx=1"))))
+      .Times(1);
+
+  // exec2 independently cycles va_range_idx the same way.
+  EXPECT_CALL(mock_log, Log(absl::LogSeverity::kInfo, ::testing::_,
+                            AllOf(HasSubstr("exec2_va_remapping"),
+                                  HasSubstr("va_range_idx=0"))))
+      .Times(2);
+  EXPECT_CALL(mock_log, Log(absl::LogSeverity::kInfo, ::testing::_,
+                            AllOf(HasSubstr("exec2_va_remapping"),
+                                  HasSubstr("va_range_idx=1"))))
+      .Times(1);
+
+  // Each (exec, va_range_idx) pair creates its own CUDA graph (command buffer).
+  // Initialization fires once per new graph: 2 execs × 2 VA ranges = 4 times.
+  // Run 2 reuses the existing VA range 0 graphs → no additional initialization.
+  EXPECT_CALL(mock_log, Log(absl::LogSeverity::kInfo, ::testing::_,
+                            HasSubstr("Initialize command buffer on device")))
+      .Times(4);
+
+  mock_log.StartCapturingLogs();
+
+  // 3 runs interleaved: each executable cycles VA range indices 0, 1, 0
+  // independently. Interleaving stresses that the two executables' VA ranges
+  // do not alias or corrupt each other.
+  for (int run = 0; run < 3; ++run) {
+    float base = static_cast<float>(run + 1);
+    auto x = LiteralUtil::CreateR1<float>(
+        {base, base, base, base, base, base, base, base});
+
+    TF_ASSERT_OK_AND_ASSIGN(auto x_buf, client->BufferFromHostLiteral(x, mem));
+    TF_ASSERT_OK_AND_ASSIGN(auto ones_buf,
+                            client->BufferFromHostLiteral(ones, mem));
+    TF_ASSERT_OK_AND_ASSIGN(auto twos_buf,
+                            client->BufferFromHostLiteral(twos, mem));
+
+    // exec1: x + ones = base + 1.
+    auto res1 = exec1->Execute({{x_buf.get(), ones_buf.get()}}, {});
+    TF_ASSERT_OK_AND_ASSIGN(auto lit1, ExtractSingleResult(res1));
+    EXPECT_TRUE(LiteralTestUtil::Equal(
+        LiteralUtil::CreateR1<float>({base + 1, base + 1, base + 1, base + 1,
+                                      base + 1, base + 1, base + 1, base + 1}),
+        *lit1))
+        << "exec1 mismatch on run " << run;
+
+    // exec2: x * twos = base * 2.
+    auto res2 = exec2->Execute({{x_buf.get(), twos_buf.get()}}, {});
+    TF_ASSERT_OK_AND_ASSIGN(auto lit2, ExtractSingleResult(res2));
+    EXPECT_TRUE(LiteralTestUtil::Equal(
+        LiteralUtil::CreateR1<float>({base * 2, base * 2, base * 2, base * 2,
+                                      base * 2, base * 2, base * 2, base * 2}),
+        *lit2))
+        << "exec2 mismatch on run " << run;
+  }
+  mock_log.StopCapturingLogs();
+  absl::SetVLogLevel("gpu_executable", old_vlog_exec);
+  absl::SetVLogLevel("command_buffer_thunk", old_vlog_cbt);
 }
 
 #endif  // GOOGLE_CUDA

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -131,8 +131,8 @@ namespace xla {
 namespace {
 
 using ::testing::_;
-using ::testing::Contains;
 using ::testing::AllOf;
+using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
 using ::testing::Eq;
@@ -3688,7 +3688,7 @@ GpuClientOptions VmmClientOptions() {
 CompileOptions CmdBufVaRemappingOptions() {
   CompileOptions opts;
   auto* dbg = opts.executable_build_options.mutable_debug_options();
-  dbg->set_xla_gpu_command_buffer_update_mode(DebugOptions::FULL_UPDATE_FREE);
+  dbg->set_xla_gpu_command_buffer_update_mode(DebugOptions::NEVER_UPDATE);
   dbg->set_xla_gpu_graph_min_graph_size(1);
   dbg->add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
   dbg->add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
@@ -4053,9 +4053,9 @@ TEST(StreamExecutorGpuClientTest, CommandBufferVaRemappingMultiplexing) {
   absl::SetVLogLevel("gpu_executable", old_vlog);
 }
 
-// Tests that CUSTOM_LIBRARY_UPDATE_FREE mode produces correct results across
+// Tests that CAPTURE_CMD_NEVER_UPDATE mode produces correct results across
 // multiple runs. The GEMM is routed through cuBLAS (GemmCmd/CublasLtCmd), which
-// are traced commands. In CUSTOM_LIBRARY_UPDATE_FREE mode only traced commands
+// are traced commands. In CAPTURE_CMD_NEVER_UPDATE mode only traced commands
 // populate command_buffer_allocation_indexes_, activating VA remapping so that
 // traced commands skip command buffer updates across alternating VA ranges.
 TEST(StreamExecutorGpuClientTest,
@@ -4066,7 +4066,7 @@ TEST(StreamExecutorGpuClientTest,
   // Pure GEMM: lhs * rhs. With Triton disabled the dot is lowered to a
   // GemmCmd/CublasLtCmd (TracedCommandBufferCmd subclass), so its allocations
   // populate command_buffer_allocation_indexes_ under
-  // CUSTOM_LIBRARY_UPDATE_FREE.
+  // CAPTURE_CMD_NEVER_UPDATE.
   static constexpr char kHlo[] = R"(
     HloModule custom_lib_update_free_test
     ENTRY main {
@@ -4079,7 +4079,7 @@ TEST(StreamExecutorGpuClientTest,
   CompileOptions opts;
   auto* dbg = opts.executable_build_options.mutable_debug_options();
   dbg->set_xla_gpu_command_buffer_update_mode(
-      DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE);
+      DebugOptions::CAPTURE_CMD_NEVER_UPDATE);
   dbg->set_xla_gpu_graph_min_graph_size(1);
   dbg->add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
   dbg->add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
@@ -4131,7 +4131,7 @@ TEST(StreamExecutorGpuClientTest,
   absl::SetVLogLevel("gpu_executable", old_vlog);
 }
 
-// Tests that two different executables using FULL_UPDATE_FREE can coexist
+// Tests that two different executables using NEVER_UPDATE can coexist
 // and interleave executions without interfering with each other's VA ranges.
 // Each executable maintains its own per-(executable, device) VA reservation,
 // so remapping in one does not corrupt the other.

--- a/xla/pjrt/gpu/tfrt/utils.cc
+++ b/xla/pjrt/gpu/tfrt/utils.cc
@@ -45,13 +45,15 @@ limitations under the License.
 #include "absl/synchronization/notification.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
-#include "unsupported/Eigen/CXX11/Tensor"
 #include "google/protobuf/text_format.h"
+#include "xla/backends/cpu/target_machine_options.h"
+#include "unsupported/Eigen/CXX11/Tensor"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/client/executable_build_options.h"
 #include "xla/client/local_client.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/collectives_registry.h"
+#include "xla/debug_options_flags.h"
 #include "xla/executable_run_options.h"
 #include "xla/future.h"
 #include "xla/layout.h"
@@ -652,9 +654,18 @@ absl::StatusOr<std::unique_ptr<tsl::Allocator>> CreateAllocatorForDevice(
 absl::StatusOr<MaybeOwning<se::DeviceAddressAllocator>> CreateDeviceAllocator(
     LocalClient* xla_client, const GpuAllocatorConfig& allocator_config,
     const std::vector<std::unique_ptr<TfrtGpuDevice>>& devices) {
-  if (allocator_config.kind == GpuAllocatorConfig::Kind::kPlatform) {
+  GpuAllocatorConfig effective_config = allocator_config;
+  if (GetDebugOptionsFromFlags().xla_gpu_command_buffer_update_mode() !=
+          DebugOptions::FULL_UPDATE &&
+      effective_config.kind != GpuAllocatorConfig::Kind::kVmm) {
+    LOG(WARNING) << "xla_gpu_command_buffer_update_mode requires the "
+                    "VMM allocator. Overriding allocator kind to kVmm.";
+    effective_config.kind = GpuAllocatorConfig::Kind::kVmm;
+  }
+
+  if (effective_config.kind == GpuAllocatorConfig::Kind::kPlatform) {
     LOG(INFO) << "Using platform allocator.";
-    if (allocator_config.collective_memory_size != 0) {
+    if (effective_config.collective_memory_size != 0) {
       LOG(WARNING)
           << "collective_memory_size is non-zero, but allocator kind is set "
              "to \"platform\". Collective memory will not be allocated.";
@@ -663,7 +674,7 @@ absl::StatusOr<MaybeOwning<se::DeviceAddressAllocator>> CreateDeviceAllocator(
         xla_client->backend().memory_allocator());
   }
 
-  if (allocator_config.kind == GpuAllocatorConfig::Kind::kVmm) {
+  if (effective_config.kind == GpuAllocatorConfig::Kind::kVmm) {
 #if GOOGLE_CUDA
     std::vector<std::pair<se::StreamExecutor*, se::Stream*>> executor_streams;
     for (const auto& device : devices) {
@@ -677,8 +688,8 @@ absl::StatusOr<MaybeOwning<se::DeviceAddressAllocator>> CreateDeviceAllocator(
     TF_ASSIGN_OR_RETURN(
         auto vmm_alloc,
         se::gpu::CudaDeviceAddressVmmAllocator::Create(
-            xla_client->platform(), allocator_config.memory_fraction,
-            allocator_config.gpu_system_memory_size, executor_streams));
+            xla_client->platform(), effective_config.memory_fraction,
+            effective_config.gpu_system_memory_size, executor_streams));
     return MaybeOwning<se::DeviceAddressAllocator>(std::move(vmm_alloc));
 #else
     return absl::UnimplementedError(
@@ -698,10 +709,10 @@ absl::StatusOr<MaybeOwning<se::DeviceAddressAllocator>> CreateDeviceAllocator(
     se::Stream* stream = device->stream();
 
     std::unique_ptr<tsl::Allocator> allocator;
-    if ((allocator_config.kind == GpuAllocatorConfig::Kind::kDefault ||
-         allocator_config.kind == GpuAllocatorConfig::Kind::kBFC) &&
-        allocator_config.preallocate) {
-      GpuAllocatorConfig device_allocator_config = allocator_config;
+    if ((effective_config.kind == GpuAllocatorConfig::Kind::kDefault ||
+         effective_config.kind == GpuAllocatorConfig::Kind::kBFC) &&
+        effective_config.preallocate) {
+      GpuAllocatorConfig device_allocator_config = effective_config;
       // Assert that CUDA alloc/free calls are not made on the caller thread.
       auto visitor = [](void*, int index, size_t) {
         TfrtGpuThreadChecker::AssertCudaCallAllowedOnThisThread();
@@ -727,7 +738,7 @@ absl::StatusOr<MaybeOwning<se::DeviceAddressAllocator>> CreateDeviceAllocator(
              "which is problematic if the calling thread is a fiber";
 #endif
       TF_ASSIGN_OR_RETURN(allocator,
-                          CreateAllocatorForDevice(executor, allocator_config));
+                          CreateAllocatorForDevice(executor, effective_config));
     }
     allocators.emplace_back(
         std::move(allocator), stream,
@@ -739,8 +750,8 @@ absl::StatusOr<MaybeOwning<se::DeviceAddressAllocator>> CreateDeviceAllocator(
         auto collective_bfc_allocator,
         CreateCollectiveBFCAllocator(
             executor,
-            /*memory_fraction=*/1.0 - allocator_config.memory_fraction,
-            allocator_config.collective_memory_size));
+            /*memory_fraction=*/1.0 - effective_config.memory_fraction,
+            effective_config.collective_memory_size));
     allocators.emplace_back(std::move(collective_bfc_allocator), stream,
                             /*memory_space=*/1, executor->device_ordinal(),
                             executor->GetPlatform());

--- a/xla/pjrt/gpu/tfrt/utils.cc
+++ b/xla/pjrt/gpu/tfrt/utils.cc
@@ -46,8 +46,8 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "google/protobuf/text_format.h"
-#include "xla/backends/cpu/target_machine_options.h"
 #include "unsupported/Eigen/CXX11/Tensor"
+#include "xla/backends/cpu/target_machine_options.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/client/executable_build_options.h"
 #include "xla/client/local_client.h"
@@ -656,7 +656,7 @@ absl::StatusOr<MaybeOwning<se::DeviceAddressAllocator>> CreateDeviceAllocator(
     const std::vector<std::unique_ptr<TfrtGpuDevice>>& devices) {
   GpuAllocatorConfig effective_config = allocator_config;
   if (GetDebugOptionsFromFlags().xla_gpu_command_buffer_update_mode() !=
-          DebugOptions::FULL_UPDATE &&
+          DebugOptions::ALWAYS_UPDATE &&
       effective_config.kind != GpuAllocatorConfig::Kind::kVmm) {
     LOG(WARNING) << "xla_gpu_command_buffer_update_mode requires the "
                     "VMM allocator. Overriding allocator kind to kVmm.";

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -158,6 +158,7 @@ limitations under the License.
 #include "xla/tsl/framework/allocator.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
@@ -169,7 +170,6 @@ limitations under the License.
 #include "tsl/platform/fingerprint.h"
 #include "tsl/platform/mem.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 
@@ -1682,6 +1682,30 @@ PjRtStreamExecutorClient::RunAsync(
   return PjRtStreamExecutorExecutionOutput({{}, std::move(se_to_be_released)});
 }
 
+// Number of VA reservation sets used for command buffer remapping multiplexing.
+// With 2 sets, one VA range can be remapped by the CPU while the GPU executes
+// commands on the other, enabling CPU/GPU overlap.
+constexpr int kNumVaReservationSets = 2;
+
+// Returns the next VA range index for the given executable and device, keyed
+// per executable so each compiled module independently alternates between VA
+// range sets, enabling CPU/GPU overlap regardless of inter-module dispatch
+// order. Must be computed at lambda scheduling time (not inside the async
+// lambda) so that the scheduling order determines the counter order, keeping
+// all ranks in sync.
+int GetNextCommandBufferVaRangeIdx(const void* executable_key,
+                                   int device_ordinal) {
+  static absl::Mutex mu;
+  static auto* counters =
+      new absl::flat_hash_map<std::pair<const void*, int>, int>();
+  absl::MutexLock lock(&mu);
+  auto key = std::make_pair(executable_key, device_ordinal);
+  int& idx = (*counters)[key];
+  int result = idx;
+  idx = (idx + 1) % kNumVaReservationSets;
+  return result;
+}
+
 // Enqueues a computation onto the compute stream. Each buffer returned in
 // device_buffers has a usage hold added that must be dropped on error or
 // converted on success.
@@ -1739,11 +1763,16 @@ PjRtStreamExecutorRawLoadedExecutable::Execute(
         compute_semaphore.ScopedAcquire(1));
   }
 
+  // Compute the VA range index at scheduling time so the scheduling order
+  // determines the counter order, keeping all ranks in sync.
+  int command_buffer_va_range_idx =
+      GetNextCommandBufferVaRangeIdx(executable_->executable(), device_ordinal);
+
   auto launch_on_device =
       [device_state, gpu_run_options = client_->gpu_run_options(options),
        launch_id = options.launch_id, run_id = run_id_,
-       context = options.context, client = client_, device = device_,
-       device_assignment = device_assignment_,
+       command_buffer_va_range_idx, context = options.context, client = client_,
+       device = device_, device_assignment = device_assignment_,
        compute_reservation = std::move(compute_reservation),
        send_device_memory = std::move(send_device_memory),
        recv_device_memory = std::move(recv_device_memory),
@@ -1781,6 +1810,7 @@ PjRtStreamExecutorRawLoadedExecutable::Execute(
         client->client()->backend().eigen_intra_op_thread_pool_device());
     run_options.set_device_assignment(device_assignment.get());
     run_options.set_run_id(run_id);
+    run_options.set_command_buffer_va_range_idx(command_buffer_va_range_idx);
     run_options.set_rng_seed(device_state->GetNewPrngSeed());
     run_options.set_gpu_executable_run_options(std::move(gpu_run_options));
     run_options.set_launch_id(launch_id);

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -120,6 +120,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/env_time.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/sorted_range.h"
 #include "xla/util.h"
 #include "xla/util/split_proto/split_executable_and_options_writer.h"
@@ -128,7 +129,6 @@ limitations under the License.
 #include "tsl/platform/random.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -173,7 +173,7 @@ class GpuExecutableThunkPassBufferAllocator : public ThunkPassBufferAllocator {
       BufferAllocation::Index start_idx)
       : next_idx_(start_idx) {}
 
-  absl::StatusOr<BufferAllocation* absl_nonnull> NewEmptyAllocation(
+  absl::StatusOr<BufferAllocation * absl_nonnull> NewEmptyAllocation(
       int64_t size) override {
     allocations_.push_back(BufferAllocation(next_idx_++, size, /*color=*/0));
     return &allocations_.back();
@@ -365,25 +365,49 @@ GpuExecutable::GpuExecutable(
   // command buffer thunks. Skip constant and zero-size allocations since they
   // don't need VA remapping (constants are allocated as global values with
   // fixed addresses; zero-size allocations have nothing to map).
+  //
+  // The set of collected indices depends on xla_gpu_command_buffer_update_mode:
+  //   FULL_UPDATE - collect nothing (VA remapping disabled)
+  //   FULL_UPDATE_FREE - collect all allocations from all command buffer
+  //     commands
+  //   CUSTOM_LIBRARY_UPDATE_FREE - collect only allocations from traced
+  //     commands (TracedCommandBufferCmd subclasses) and collective commands
+  //     (CollectiveCmd subclasses)
   if (thunk_executor_) {
-    CHECK_OK(thunk_executor_->thunks().WalkNested(
-        [this](const Thunk* t) -> absl::Status {
-          auto* cmd_buffer_thunk = dynamic_cast<const CommandBufferThunk*>(t);
-          if (cmd_buffer_thunk == nullptr) {
-            return absl::OkStatus();
-          }
-          for (BufferAllocation::Index index :
-               cmd_buffer_thunk->allocs_indices()) {
-            if (buffer_assignment_) {
-              const auto& alloc = buffer_assignment_->GetAllocation(index);
-              if (alloc.is_constant() || alloc.size() == 0) {
-                continue;
+    DebugOptions::CommandBufferUpdateMode update_mode =
+        has_module() ? module_config()
+                           .debug_options()
+                           .xla_gpu_command_buffer_update_mode()
+                     : DebugOptions::FULL_UPDATE;
+
+    if (update_mode == DebugOptions::FULL_UPDATE_FREE ||
+        update_mode == DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) {
+      CHECK_OK(thunk_executor_->thunks().WalkNested(
+          [this, update_mode](const Thunk* t) -> absl::Status {
+            auto* cbt = dynamic_cast<const CommandBufferThunk*>(t);
+            if (cbt == nullptr) return absl::OkStatus();
+            return cbt->WalkCommands([this, update_mode](
+                                         const Command* cmd) -> absl::Status {
+              if (update_mode == DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE &&
+                  !cmd->IsTracedCommand()) {
+                return absl::OkStatus();
               }
-            }
-            command_buffer_allocation_indexes_.insert(index);
-          }
-          return absl::OkStatus();
-        }));
+              for (const BufferUse& use : cmd->buffer_uses()) {
+                BufferAllocation::Index index = use.slice().index();
+                if (buffer_assignment_) {
+                  const auto& alloc = buffer_assignment_->GetAllocation(index);
+                  if (alloc.is_constant() || alloc.size() == 0) continue;
+                }
+                command_buffer_allocation_indexes_.insert(index);
+              }
+              return absl::OkStatus();
+            });
+          }));
+      VLOG(3) << "VA remapping: collected "
+              << command_buffer_allocation_indexes_.size()
+              << " allocation indexes for module " << module_name_;
+    }
+    // update_mode == FULL_UPDATE: collect nothing.
   }
 }
 
@@ -1296,39 +1320,40 @@ absl::Status GpuExecutable::VerboseAllocationError(absl::Status s) {
 //
 // clang-format off
 // NOLINTBEGIN
-//                                     +-------------------------+                +------------------------+
-// GPU                                 |      Execute Exec1      |                |     Execute Exec2      |
-//                                     +-------------------------+                +------------------------+
-//       +-------------------++-------++----------+  +-----------++-------++-------++----------+
-// CPU   | CreateReservation || MapTo ||  Submit  |  |Synchronize||  Unmap|| MapTo ||  Submit  |
-//       | + CreateEvent     ||       || +RecordEv|  | (wait GPU)||       ||       || +RecordEv|
-//       | (1st run only)    ||       ||          |  |           ||       ||       ||          |
-//       +-------------------++-------++----------+  +-----------++-------++-------++----------+
+//                   +---------------------+---------------------++---------------------+---------------------+
+// GPU               |  VA1 Execute        |  VA2 Execute        ||  VA1 Execute        |  VA2 Execute        |
+//                   +---------------------+---------------------++---------------------+---------------------+
+//         +---------++---------+           +---------++---------+ +---------++---------++---------+           +---------+
+// CPU     | VA1 Map || VA2 Map |           |VA1 UnMap|| VA1 Map | |VA2 UnMap|| VA2 Map ||VA1 UnMap|           |VA2 UnMap|
+//         +---------++---------+           +---------++---------+ +---------++---------++---------+           +---------+
 // NOLINTEND
 // clang-format on
-//
-// Submit      = ExecuteThunksImpl() enqueues GPU work; RecordEvent(unmap_event)
-//               queues the event to signal after GPU kernels complete.
-// Synchronize = unmap_event->Synchronize() blocks the CPU until GPU finishes
-//               Exec1 (i.e., GPU Execute Exec1 and CPU Synchronize overlap).
-// Unmap       = scoped_mapping.reset() unmaps physical pages from the VA range.
-// MapTo       = MapTo() maps new physical pages to the fixed VA range.
 absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     const BufferAllocations& buffer_allocations,
     const ServiceExecutableRunOptions* run_options,
     se::StreamExecutor* executor, int64_t unique_id,
     Thunk::ExecutableSource executable_source, bool block_host_until_done) {
-  // Get or create VaRanges for this executor. We hold va_ranges_mutex_ briefly
-  // just to access/create the VaRanges entry.
+  // Get or create VaRanges for this executor and VA range index. We hold
+  // va_ranges_mutex_ briefly just to access/create the VaRanges entry.
+  // The VA range index allows multiplexing: with kNumVaReservationSets=2
+  // reservations, the CPU can remap one range while the GPU executes the other.
+  int command_buffer_va_range_idx =
+      run_options->run_options().command_buffer_va_range_idx();
   VaRanges* va_ranges = nullptr;
   {
     absl::MutexLock lock(&va_ranges_mutex_);
-    va_ranges = &module_va_ranges_[executor];
+    auto va_ranges_key = std::make_pair(executor, command_buffer_va_range_idx);
+    va_ranges = &module_va_ranges_[va_ranges_key];
   }
+
+  XLA_VLOG_DEVICE(3, executor->device_ordinal())
+      << "VA remapping: module " << module_name_
+      << " va_range_idx=" << command_buffer_va_range_idx
+      << " num_allocations=" << command_buffer_allocation_indexes_.size();
 
   // Get the DeviceAddressVmmAllocator to look up physical allocations.
   // vmm_allocator is guaranteed non-null here because
-  // enable_command_buffer_va_remapping already checked for it.
+  // use_command_buffer_va_remapping already checked for it.
   se::DeviceAddressVmmAllocator* vmm_allocator =
       dynamic_cast<se::DeviceAddressVmmAllocator*>(run_options->allocator());
   if (vmm_allocator == nullptr) {
@@ -1591,21 +1616,20 @@ absl::Status GpuExecutable::ExecuteThunks(
 
   se::StreamExecutor* executor = run_options->stream()->parent();
 
-  // Check if command buffer VA remapping is enabled.
-  bool enable_command_buffer_va_remapping =
+  // Check if command buffer VA remapping is active.
+  bool use_command_buffer_va_remapping =
       (command_buffer_allocation_indexes_.size() > 0) && has_module() &&
-      module_config()
-          .debug_options()
-          .xla_gpu_enable_command_buffer_va_remapping() &&
+      module_config().debug_options().xla_gpu_command_buffer_update_mode() !=
+          DebugOptions::FULL_UPDATE &&
       dynamic_cast<se::DeviceAddressVmmAllocator*>(memory_allocator) != nullptr;
 
   XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
       "ExecuteThunks: command_buffer_allocation_indexes_.size()=%d "
-      "enable_command_buffer_va_remapping=%d",
+      "use_command_buffer_va_remapping=%d",
       command_buffer_allocation_indexes_.size(),
-      enable_command_buffer_va_remapping);
+      use_command_buffer_va_remapping);
 
-  if (enable_command_buffer_va_remapping) {
+  if (use_command_buffer_va_remapping) {
     TF_RETURN_IF_ERROR(ExecuteThunksWithVaRemapping(
         buffer_allocations, run_options, executor, unique_id, executable_source,
         block_host_until_done));

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -367,10 +367,10 @@ GpuExecutable::GpuExecutable(
   // fixed addresses; zero-size allocations have nothing to map).
   //
   // The set of collected indices depends on xla_gpu_command_buffer_update_mode:
-  //   FULL_UPDATE - collect nothing (VA remapping disabled)
-  //   FULL_UPDATE_FREE - collect all allocations from all command buffer
+  //   ALWAYS_UPDATE - collect nothing (VA remapping disabled)
+  //   NEVER_UPDATE - collect all allocations from all command buffer
   //     commands
-  //   CUSTOM_LIBRARY_UPDATE_FREE - collect only allocations from traced
+  //   CAPTURE_CMD_NEVER_UPDATE - collect only allocations from traced
   //     commands (TracedCommandBufferCmd subclasses) and collective commands
   //     (CollectiveCmd subclasses)
   if (thunk_executor_) {
@@ -378,17 +378,16 @@ GpuExecutable::GpuExecutable(
         has_module() ? module_config()
                            .debug_options()
                            .xla_gpu_command_buffer_update_mode()
-                     : DebugOptions::FULL_UPDATE;
+                     : DebugOptions::ALWAYS_UPDATE;
 
-    if (update_mode == DebugOptions::FULL_UPDATE_FREE ||
-        update_mode == DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE) {
+    if (update_mode == DebugOptions::NEVER_UPDATE ||
+        update_mode == DebugOptions::CAPTURE_CMD_NEVER_UPDATE) {
       CHECK_OK(thunk_executor_->thunks().WalkNested(
-          [this, update_mode](const Thunk* t) -> absl::Status {
+          [&](const Thunk* t) -> absl::Status {
             auto* cbt = dynamic_cast<const CommandBufferThunk*>(t);
             if (cbt == nullptr) return absl::OkStatus();
-            return cbt->WalkCommands([this, update_mode](
-                                         const Command* cmd) -> absl::Status {
-              if (update_mode == DebugOptions::CUSTOM_LIBRARY_UPDATE_FREE &&
+            return cbt->WalkCommands([&](const Command* cmd) -> absl::Status {
+              if (update_mode == DebugOptions::CAPTURE_CMD_NEVER_UPDATE &&
                   !cmd->IsTracedCommand()) {
                 return absl::OkStatus();
               }
@@ -407,7 +406,7 @@ GpuExecutable::GpuExecutable(
               << command_buffer_allocation_indexes_.size()
               << " allocation indexes for module " << module_name_;
     }
-    // update_mode == FULL_UPDATE: collect nothing.
+    // update_mode == ALWAYS_UPDATE: collect nothing.
   }
 }
 
@@ -1620,7 +1619,7 @@ absl::Status GpuExecutable::ExecuteThunks(
   bool use_command_buffer_va_remapping =
       (command_buffer_allocation_indexes_.size() > 0) && has_module() &&
       module_config().debug_options().xla_gpu_command_buffer_update_mode() !=
-          DebugOptions::FULL_UPDATE &&
+          DebugOptions::ALWAYS_UPDATE &&
       dynamic_cast<se::DeviceAddressVmmAllocator*>(memory_allocator) != nullptr;
 
   XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -195,7 +195,7 @@ class GpuExecutable : public Executable {
       const ServiceExecutableRunOptions* run_options,
       VariantArguments arguments);
 
-  absl::Span<const BufferAllocation* absl_nonnull const> GetAllocations()
+  absl::Span<const BufferAllocation * absl_nonnull const> GetAllocations()
       const override {
     return allocation_ptrs_;
   }
@@ -427,7 +427,8 @@ class GpuExecutable : public Executable {
   // Separate mutex for VA ranges to avoid contention with module_handle_mutex_
   // during VA remapping operations which may involve GPU synchronization.
   absl::Mutex va_ranges_mutex_;
-  absl::node_hash_map<stream_executor::StreamExecutor*, VaRanges>
+  absl::node_hash_map<std::pair<stream_executor::StreamExecutor*, int>,
+                      VaRanges>
       module_va_ranges_ ABSL_GUARDED_BY(va_ranges_mutex_);
 
   GpuExecutable(const GpuExecutable&) = delete;

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -165,6 +165,7 @@ limitations under the License.
 #include "xla/stream_executor/memory_space.h"
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -173,7 +174,6 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/human_readable_json.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -261,10 +261,9 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
 
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       nvshmem_buffer_addresses_(std::make_shared<NvshmemBufferAddresses>()),
@@ -400,14 +399,13 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCommandBufferThunk(
 
   bool enable_loop_unroll = ir_emitter_context_->debug_options()
                                 .xla_gpu_command_buffer_unroll_loops();
-  bool enable_va_remapping = ir_emitter_context_->debug_options()
-                                 .xla_gpu_enable_command_buffer_va_remapping();
+  DebugOptions::CommandBufferUpdateMode update_mode =
+      ir_emitter_context_->debug_options().xla_gpu_command_buffer_update_mode();
   TF_ASSIGN_OR_RETURN(
       CommandExecutor cmd_executor,
-      ConvertToCommands(
-          thunk_sequence,
-          ConvertToCommandsOptions{synchronization_mode, enable_loop_unroll,
-                                   enable_va_remapping}));
+      ConvertToCommands(thunk_sequence, ConvertToCommandsOptions{
+                                            synchronization_mode,
+                                            enable_loop_unroll, update_mode}));
 
   return GetThunkSequence(std::make_unique<CommandBufferThunk>(
       std::move(cmd_executor),
@@ -417,7 +415,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCommandBufferThunk(
                                         std::move(thunk_sequence)),
       ir_emitter_context_->debug_options()
           .xla_enable_command_buffers_during_profiling(),
-      enable_va_remapping));
+      update_mode));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitConvolutionThunk(

--- a/xla/service/service.cc
+++ b/xla/service/service.cc
@@ -78,6 +78,28 @@ namespace {
 using absl::StrCat;
 using absl::StrFormat;
 
+// Number of VA reservation sets used for command buffer remapping multiplexing.
+// With 2 sets, one VA range can be remapped by the CPU while the GPU executes
+// commands on the other, enabling CPU/GPU overlap.
+constexpr int kNumVaReservationSets = 2;
+
+// Returns the next VA range index for the given executable and device, keyed
+// per executable so each compiled module independently alternates between VA
+// range sets, enabling CPU/GPU overlap regardless of inter-module dispatch
+// order.
+int GetNextCommandBufferVaRangeIdx(const void* executable_key,
+                                   int device_ordinal) {
+  static absl::Mutex mu;
+  static auto* counters =
+      new absl::flat_hash_map<std::pair<const void*, int>, int>();
+  absl::MutexLock lock(&mu);
+  auto key = std::make_pair(executable_key, device_ordinal);
+  int& idx = (*counters)[key];
+  int result = idx;
+  idx = (idx + 1) % kNumVaReservationSets;
+  return result;
+}
+
 // Records the arguments used to invoke a computation in an HloSnapshot proto.
 absl::Status RecordArguments(
     const absl::Span<const ShapedBuffer* const> arguments, se::Stream* stream,
@@ -364,6 +386,8 @@ absl::StatusOr<GlobalDataHandle> Service::ExecuteAndRegisterResult(
         backend->eigen_intra_op_thread_pool_device());
     options.set_device_assignment(device_assignment_ptr);
     options.set_execution_profile(profile);
+    options.set_command_buffer_va_range_idx(GetNextCommandBufferVaRangeIdx(
+        executable, stream->parent()->device_ordinal()));
     run_options.emplace_back(options, backend->StreamBorrowerWithPriority());
   }
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -348,16 +348,16 @@ message DebugOptions {
   }
 
   // Controls the VA remapping strategy for command buffer thunks.
-  //   FULL_UPDATE: VA remapping disabled; all commands update on every
+  //   ALWAYS_UPDATE: VA remapping disabled; all commands update on every
   //     execution.
-  //   FULL_UPDATE_FREE: All allocations VA-remapped to fixed addresses; no
+  //   NEVER_UPDATE: All allocations VA-remapped to fixed addresses; no
   //     command buffer update needed after initial recording.
-  //   CUSTOM_LIBRARY_UPDATE_FREE: Only traced/collective commands are
+  //   CAPTURE_CMD_NEVER_UPDATE: Only traced/collective commands are
   //     VA-remapped; other commands still update on each execution.
   enum CommandBufferUpdateMode {
-    FULL_UPDATE = 0;
-    FULL_UPDATE_FREE = 1;
-    CUSTOM_LIBRARY_UPDATE_FREE = 2;
+    ALWAYS_UPDATE = 0;
+    NEVER_UPDATE = 1;
+    CAPTURE_CMD_NEVER_UPDATE = 2;
   }
 
   // Experimental optimizations for SPMD-based pipeline parallelism on GPU.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -347,6 +347,19 @@ message DebugOptions {
     CONCURRENT_REGIONS = 3;
   }
 
+  // Controls the VA remapping strategy for command buffer thunks.
+  //   FULL_UPDATE: VA remapping disabled; all commands update on every
+  //     execution.
+  //   FULL_UPDATE_FREE: All allocations VA-remapped to fixed addresses; no
+  //     command buffer update needed after initial recording.
+  //   CUSTOM_LIBRARY_UPDATE_FREE: Only traced/collective commands are
+  //     VA-remapped; other commands still update on each execution.
+  enum CommandBufferUpdateMode {
+    FULL_UPDATE = 0;
+    FULL_UPDATE_FREE = 1;
+    CUSTOM_LIBRARY_UPDATE_FREE = 2;
+  }
+
   // Experimental optimizations for SPMD-based pipeline parallelism on GPU.
   enum PipelineParallelismOptLevel {
     PIPELINE_PARALLELISM_OPT_LEVEL_DISABLE = 0;
@@ -463,6 +476,10 @@ message DebugOptions {
   // loop count and the loop body does not have unsupported commands.
   optional bool xla_gpu_command_buffer_unroll_loops = 411;
 
+  // Controls the VA remapping update strategy for command buffer thunks.
+  // See CommandBufferUpdateMode for details.
+  optional CommandBufferUpdateMode xla_gpu_command_buffer_update_mode = 464;
+
   optional bool xla_gpu_copy_insertion_use_region_analysis = 236;
 
   // Crashes the program when any kind of verification fails, instead of just
@@ -544,11 +561,6 @@ message DebugOptions {
 
   // Determine the types of commands that are recorded into command buffers.
   repeated CommandBufferCmdType xla_gpu_enable_command_buffer = 258;
-
-  // Enable VA remapping for command buffer thunks. When enabled, command buffer
-  // thunks use fixed virtual addresses across executions, allowing the command
-  // buffer to be recorded once and replayed without updates.
-  optional bool xla_gpu_enable_command_buffer_va_remapping = 464;
 
   // Enable radix sort using CUB.
   optional bool xla_gpu_enable_cub_radix_sort = 259;


### PR DESCRIPTION
📝 Summary of Changes

  Replaces the boolean flag xla_gpu_enable_command_buffer_va_remapping with a three-value enum CommandBufferUpdateMode in DebugOptions:

  - FULL_UPDATE (default): VA remapping disabled; all command buffer commands are updated on every execution.
  - FULL_UPDATE_FREE: All buffer allocations are VA-remapped to fixed virtual addresses; the command buffer is recorded once and replayed without any updates.
  - CUSTOM_LIBRARY_UPDATE_FREE: Only traced commands (TracedCommandBufferCmd subclasses such as GEMM, cuDNN) and collective operations (CollectiveCmd subclasses) are VA-remapped. Non-library commands (e.g., memcpy, elementwise kernels) still update normally. This enables update-free replay for the expensive custom-library kernels while retaining correctness for all others.

  Additionally introduces VA range multiplexing (kNumVaReservationSets = 2): two VA reservation sets alternate between executions, allowing the CPU to remap one VA range while the GPU executes on the other, enabling CPU/GPU overlap during remapping.

  The CommandBufferThunk state map key is updated from se::StreamExecutor* to (se::StreamExecutor*, void*) — the second element is the physical address of the first VA-mapped allocation, used to identify which reservation set is active.

  🎯 Justification

  The original boolean flag only covered the all-or-nothing case (FULL_UPDATE_FREE): either every allocation is VA-remapped or none are. This is insufficient for models that mix custom library calls (GEMM, cuDNN, NCCL collectives) with regular XLA-emitted kernels, because:

  1. Custom library commands (cuBLAS, cuDNN, NCCL) use opaque traced command buffers that cannot be updated by XLA after recording — they must be VA-remapped to be replay-safe.
  2. Regular XLA kernels are cheap to update and do not need VA remapping.

  CUSTOM_LIBRARY_UPDATE_FREE covers this common case: it eliminates redundant updates for the expensive library calls while keeping full update semantics for everything else. This reduces per-execution overhead on models dominated by GEMM and collective operations, while can also greatly reduce the cost of cuda VMM API.

Some benchmarks on GB200: 
<img width="1726" height="1579" alt="image" src="https://github.com/user-attachments/assets/c46f75ad-813b-4a05-bb59-73051fef6558" />


  🚀 Kind of Contribution

  ⚡️ Performance Improvement, ✨ New Feature

  📊 Benchmark

  N/A — the performance benefit is execution-latency reduction on models with repeated identical executions (e.g., training loops). The overhead eliminated is the per-step command buffer update cost for cuBLAS/cuDNN/NCCL commands. Benchmark numbers to be added separately against representative training HLOs.

  🧪 Unit Tests

  No new compiler unit tests — the change is in runtime thunk behavior, not HLO transformations. Existing CommandBufferThunk unit tests cover the update/record path.

  🧪 Execution Tests

  Six new end-to-end execution tests added in xla/pjrt/gpu/se_gpu_pjrt_client_test.cc, all exercising the VA remapping modes with 1 GPU:

  - CommandBufferVaRemappingFusionOps — elementwise fusion with FULL_UPDATE_FREE
  - CommandBufferVaRemappingGemmOps — GEMM with FULL_UPDATE_FREE
  - CommandBufferVaRemappingConditional — conditional op with FULL_UPDATE_FREE
  - CommandBufferVaRemappingWhileLoop — while loop with FULL_UPDATE_FREE
  - CommandBufferVaRemappingDynamicSliceFusion — dynamic slice fusion with FULL_UPDATE_FREE
  - CommandBufferVaRemappingMultiplexing — concurrent execution across two VA reservation sets to verify CPU/GPU overlap correctness
