### PR TITLE
[XLA:GPU][oneAPI] Remove context activation and update SYCL memfill/memset tests

### DIFF
--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -362,7 +362,6 @@ sycl_library(
         "oneapi-only",
     ],
     deps = [
-        "//xla/stream_executor:activate_context",
         "//xla/stream_executor:event",
         "//xla/stream_executor:stream_executor_h",
         "@com_google_absl//absl/base",
@@ -397,7 +396,6 @@ sycl_library(
     deps = [
         ":sycl_event",
         ":sycl_gpu_runtime",
-        "//xla/stream_executor:activate_context",
         "//xla/stream_executor:event_based_timer",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",

--- a/xla/stream_executor/sycl/sycl_event.cc
+++ b/xla/stream_executor/sycl/sycl_event.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include "absl/base/casts.h"
 #include "absl/status/statusor.h"
-#include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/event.h"
 
 namespace stream_executor::sycl {

--- a/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
@@ -67,8 +67,7 @@ class SyclGpuRuntimeTest : public ::testing::Test {
   absl::StatusOr<void*> AllocateAndInitDeviceBuffer(
       int count, int value, int device_ordinal = kDefaultDeviceOrdinal) {
     TF_ASSIGN_OR_RETURN(void* buf, AllocateDeviceBuffer(count));
-    TF_RETURN_IF_ERROR(
-        SyclMemfillDevice(device_ordinal, buf, value, sizeof(int) * count));
+    TF_RETURN_IF_ERROR(SyclMemfillDevice(device_ordinal, buf, value, count));
     if (buf == nullptr) {
       return absl::InternalError(
           "SyclGpuRuntimeTest::AllocateAndInitDeviceBuffer: Failed to fill "
@@ -472,8 +471,8 @@ TEST_F(SyclGpuRuntimeTest, TestMemsetDevice) {
       SyclMallocDevice(kDefaultDeviceOrdinal, sizeof(char) * kCount));
   ASSERT_NE(src_device, nullptr);
 
-  TF_ASSERT_OK(SyclMemsetDevice(kDefaultDeviceOrdinal, src_device, 'A',
-                                sizeof(char) * kCount));
+  TF_ASSERT_OK(
+      SyclMemsetDevice(kDefaultDeviceOrdinal, src_device, 'A', kCount));
 
   TF_ASSERT_OK_AND_ASSIGN(void* dst_host, AllocateHostBuffer(kCount));
 
@@ -497,14 +496,12 @@ TEST_F(SyclGpuRuntimeTest, TestMemsetDevice_Negative) {
   ASSERT_NE(src_device, nullptr);
 
   // Attempt to memset with an invalid device ordinal.
-  EXPECT_THAT(SyclMemsetDevice(kInvalidDeviceOrdinal, src_device, 'A',
-                               sizeof(char) * kCount),
+  EXPECT_THAT(SyclMemsetDevice(kInvalidDeviceOrdinal, src_device, 'A', kCount),
               absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
 
   // Attempt to memset a null pointer.
   void* null_ptr = nullptr;
-  EXPECT_THAT(SyclMemsetDevice(kDefaultDeviceOrdinal, null_ptr, 'A',
-                               sizeof(char) * kCount),
+  EXPECT_THAT(SyclMemsetDevice(kDefaultDeviceOrdinal, null_ptr, 'A', kCount),
               absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
 
   FreeAndNullify(src_device);
@@ -520,8 +517,8 @@ TEST_F(SyclGpuRuntimeTest, TestMemsetDeviceAsync) {
 
   TF_ASSERT_OK_AND_ASSIGN(void* device_buf, AllocateDeviceBuffer(kCount));
 
-  TF_ASSERT_OK(SyclMemsetDeviceAsync(stream_handle.get(), device_buf, 'B',
-                                     sizeof(char) * kCount));
+  TF_ASSERT_OK(
+      SyclMemsetDeviceAsync(stream_handle.get(), device_buf, 'B', kCount));
 
   // Synchronize the stream to ensure the memset is complete before checking
   // results.
@@ -552,7 +549,7 @@ TEST_F(SyclGpuRuntimeTest, TestMemfillDeviceAsync) {
   TF_ASSERT_OK_AND_ASSIGN(void* device_buf, AllocateDeviceBuffer(kCount));
 
   TF_ASSERT_OK(SyclMemfillDeviceAsync(stream_handle.get(), device_buf,
-                                      0xDEADC0DE, sizeof(int) * kCount));
+                                      0xDEADC0DE, kCount));
 
   // Synchronize the stream to ensure the fill is complete before checking
   // results.
@@ -579,9 +576,9 @@ TEST_F(SyclGpuRuntimeTest, TestMemfillDeviceAsync_Negative) {
 
   // Attempt to fill a null pointer.
   void* null_ptr = nullptr;
-  EXPECT_THAT(SyclMemfillDeviceAsync(stream_handle.get(), null_ptr, 0xFEEDEAF,
-                                     sizeof(int) * kCount),
-              absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(
+      SyclMemfillDeviceAsync(stream_handle.get(), null_ptr, 0xFEEDEAF, kCount),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
 TEST_F(SyclGpuRuntimeTest, TestMultiDeviceAllocationAndSyncCopy) {

--- a/xla/stream_executor/sycl/sycl_timer.cc
+++ b/xla/stream_executor/sycl/sycl_timer.cc
@@ -17,8 +17,6 @@ limitations under the License.
 
 #include <level_zero/ze_api.h>
 
-#include "xla/stream_executor/activate_context.h"
-
 constexpr int kMsecInSec = 1000;
 
 namespace stream_executor::sycl {
@@ -28,8 +26,6 @@ namespace {
 absl::StatusOr<float> GetEventElapsedTime(StreamExecutor* executor,
                                           const ::sycl::event& start,
                                           const ::sycl::event& stop) {
-  std::unique_ptr<ActivateContext> activation = executor->Activate();
-
   // Get the native Level Zero event handles.
   ze_event_handle_t start_event =
       ::sycl::get_native<::sycl::backend::ext_oneapi_level_zero>(start);


### PR DESCRIPTION
This PR contains the following changes:

1. Redundant context activation code is removed since SYCL contexts do not require explicit activation.
2. SYCL memfill and memset functions (both sync and async versions) expect count (i.e. number of elements) instead of bytes when filling device memory. The corresponding tests have been updated.