### PR TITLE
[XLA:GPU][oneAPI] Update timestamp mask calculation to support 64-bit kernel timestamps

### DIFF
--- a/xla/stream_executor/sycl/sycl_gpu_runtime.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.cc
@@ -387,8 +387,18 @@ absl::StatusOr<SyclTimerProperties> SyclGetTimerProperties(int device_ordinal) {
                      device_ordinal, " with return code: ", status));
   }
   uint64_t timer_freq_hz = lz_device_props.timerResolution;
-  uint64_t timestamp_mask =
-      (1ull << lz_device_props.kernelTimestampValidBits) - 1ull;
+  uint32_t kernel_ts_valid_bits = lz_device_props.kernelTimestampValidBits;
+  uint64_t timestamp_mask = 0;
+  if (kernel_ts_valid_bits == 0 || kernel_ts_valid_bits > 64) {
+    return absl::InternalError(absl::StrCat(
+        "SyclGetTimerProperties: Invalid kernel timestamp valid bits (",
+        kernel_ts_valid_bits, ") for device ordinal ", device_ordinal));
+  } else if (kernel_ts_valid_bits < 64) {
+    timestamp_mask = (1ull << kernel_ts_valid_bits) - 1ull;
+  } else {
+    // Prevent overflow when shifting by 64.
+    timestamp_mask = ~0ull;
+  }
   return SyclTimerProperties{timer_freq_hz, timestamp_mask};
 }
 


### PR DESCRIPTION
Currently, the timestamp mask calculation supports up to 32-bit kernel timestamps. However, newer Intel GPUs (such as [BMG](https://www.intel.com/content/www/us/en/products/sku/241598/intel-arc-b580-graphics/specifications.html)) use 64-bit kernel timestamps, and this PR updates this calculation accordingly.