### PR TITLE
Add missing kAllGatherStart/kAllGatherDone verification to HLO verifier

### DIFF
--- a/xla/service/hlo_verifier.cc
+++ b/xla/service/hlo_verifier.cc
@@ -2631,6 +2631,16 @@ absl::Status VerifyAsynchronousInstructionPairs(const HloModule& module) {
               VerifySingleOperand(instruction, {HloOpcode::kAllReduceStart}));
           break;
         }
+        case HloOpcode::kAllGatherStart: {
+          TF_RETURN_IF_ERROR(
+              VerifySingleUser(instruction, {HloOpcode::kAllGatherDone}));
+          break;
+        }
+        case HloOpcode::kAllGatherDone: {
+          TF_RETURN_IF_ERROR(
+              VerifySingleOperand(instruction, {HloOpcode::kAllGatherStart}));
+          break;
+        }
         case HloOpcode::kCopyStart: {
           TF_RETURN_IF_ERROR(
               VerifySingleUser(instruction, {HloOpcode::kCopyDone}));

--- a/xla/service/hlo_verifier_test.cc
+++ b/xla/service/hlo_verifier_test.cc
@@ -1856,6 +1856,45 @@ TEST_F(HloVerifierTest, AllReduceDoneWithoutStart) {
                         "needs to be all-reduce-start, found tuple"));
 }
 
+TEST_F(HloVerifierTest, AllGatherStartAndDone) {
+  const char* const kModuleStr = R"(
+  HloModule test
+  ENTRY entry {
+    p0 = f32[2,3] parameter(0)
+    start = (f32[2,3], f32[4,3]) all-gather-start(p0), dimensions={0},
+      replica_groups={{0,1}}
+    ROOT done = f32[4,3] all-gather-done(start)
+  }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnUnverifiedModule(kModuleStr));
+
+  auto status = verifier().Run(module.get()).status();
+  ASSERT_TRUE(status.ok());
+}
+
+TEST_F(HloVerifierTest, AllGatherStartAndMultipleDone) {
+  const char* const kModuleStr = R"(
+  HloModule test
+  ENTRY entry {
+    p0 = f32[2,3] parameter(0)
+    start = (f32[2,3], f32[4,3]) all-gather-start(p0), dimensions={0},
+      replica_groups={{0,1}}
+    done1 = f32[4,3] all-gather-done(start)
+    ROOT done2 = f32[4,3] all-gather-done(start)
+  }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnUnverifiedModule(kModuleStr));
+
+  auto status = verifier().Run(module.get()).status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(
+      status.message(),
+      HasSubstr(
+          "all-gather-start instruction requires one consumer, found 2"));
+}
+
 absl::StatusOr<std::unique_ptr<HloModule>> MakeAllToAllComputation(
     std::vector<std::vector<int64_t>> replica_groups,
     std::optional<int64_t> replica_count = std::nullopt,

--- a/xla/service/hlo_verifier_test.cc
+++ b/xla/service/hlo_verifier_test.cc
@@ -1867,10 +1867,7 @@ TEST_F(HloVerifierTest, AllGatherStartAndDone) {
   }
   )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnUnverifiedModule(kModuleStr));
-
-  auto status = verifier().Run(module.get()).status();
-  ASSERT_TRUE(status.ok());
+                          ParseAndReturnVerifiedModule(kModuleStr));
 }
 
 TEST_F(HloVerifierTest, AllGatherStartAndMultipleDone) {


### PR DESCRIPTION
## Summary
Fixes #40191

`VerifyAsynchronousInstructionPairs` checks that async Start/Done instructions
are properly connected for all async op types except `kAllGatherStart/kAllGatherDone`.
This adds the missing verification, following the same pattern used for `kAllReduceStart/kAllReduceDone`.

## Changes
- `hlo_verifier.cc`: Add `kAllGatherStart` and `kAllGatherDone` cases to the async pair verification switch
- `hlo_verifier_test.cc`: Add tests for valid AllGather Start/Done pair and invalid multiple-Done case

## Test plan
- [ ] CI verification
- [x] Tests follow existing AllReduce verifier test patterns
- [x] Follow Google C++ style