### PR TITLE
[xla:gpu] Use Global HangWatchdog in se_gpu_pjrt_client

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -161,7 +161,6 @@ cc_library(
         "//xla/tsl/util:env_var",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/base:no_destructor",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -28,7 +28,6 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
-#include "absl/base/no_destructor.h"
 #include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/inlined_vector.h"
@@ -117,6 +116,7 @@ limitations under the License.
 #include "xla/tsl/framework/allocator.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/coordination_service.pb.h"
 #include "xla/xla_data.pb.h"
@@ -126,7 +126,6 @@ limitations under the License.
 #include "tsl/platform/protobuf.h"
 #include "tsl/profiler/lib/nvtx_utils.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 #if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM)
 #include "xla/debug_options_flags.h"
@@ -506,15 +505,6 @@ class PreparedReceive {
   }
 };
 
-// Hang watchdog for GPU clique acquisition in the PjRt client. Clique
-// acquisition can block indefinitely inside ncclCommInit if remote nodes are
-// unreachable.
-static HangWatchdog& PjRtClientHangWatchdog() {
-  static absl::NoDestructor<HangWatchdog> watchdog(
-      tsl::Env::Default(), "pjrt-gpu-client", /*num_threads=*/2);
-  return *watchdog;
-}
-
 static absl::Duration PjRtClientWatchdogTimeout() {
   const auto& debug_options = GetDebugOptionsFromFlags();
   absl::Duration timeout = absl::InfiniteDuration();
@@ -555,7 +545,7 @@ absl::StatusOr<AcquiredCliqueAndCommunicator> AcquireCliqueAndCommunicator(
       std::string watchdog_name =
           absl::StrFormat("[%d] PjRt GPU client AcquireGpuClique for %v",
                           device_ordinal, clique_key);
-      guard = PjRtClientHangWatchdog().Watch(
+      guard = HangWatchdog::Global().Watch(
           watchdog_name, watchdog_timeout,
           HangWatchdog::Abort(watchdog_name, watchdog_timeout));
     }


### PR DESCRIPTION
Reduce the number of global thread pools in JAX/XLA by using global hang watchdog.