### PR TITLE
Expose `DeviceEvents` and `DefineBuffer` through the PJRT C/C++ APIs

### DIFF
--- a/xla/pjrt/BUILD
+++ b/xla/pjrt/BUILD
@@ -348,6 +348,8 @@ cc_library(
         ":pjrt_abi_version",
         ":pjrt_common",
         ":pjrt_compiler",
+        ":device_event",
+        ":raw_buffer",
         ":pjrt_device_description",
         ":pjrt_executable",
         ":pjrt_layout",
@@ -1428,7 +1430,6 @@ cc_library(
     deps = [
         ":async_work_runner",
         ":device_event",
-        ":pjrt_client",
         "//xla:future",
         "//xla:literal",
         "//xla:shape_util",

--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -407,6 +407,7 @@ cc_library(
         "//xla/tsl/framework:allocator",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
+        "//xla/tsl/concurrency:interop",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -552,6 +552,8 @@ cc_library(
     ),
     visibility = ["//visibility:public"],
     deps = [
+        ":pjrt_c_api_raw_buffer_extension_hdrs",
+        ":pjrt_c_api_raw_buffer_internal",
         ":pjrt_c_api_abi_version_extension_hdrs",
         ":pjrt_c_api_custom_partitioner_extension_hdrs",
         ":pjrt_c_api_ffi_extension_hdrs",
@@ -691,6 +693,9 @@ xla_test(
         "config-cuda-only",
     ]),
     deps = [
+        ":pjrt_c_api_raw_buffer_extension_hdrs",
+        ":pjrt_c_api_raw_buffer_internal",
+        ":pjrt_c_api_raw_buffer_external",
         ":pjrt_c_api_ffi_extension_hdrs",
         ":pjrt_c_api_gpu",
         ":pjrt_c_api_gpu_extension_hdrs",
@@ -713,6 +718,7 @@ xla_test(
         "//xla/ffi/api:ffi",
         "//xla/pjrt:pjrt_common",
         "//xla/pjrt:pjrt_compiler",
+        "//xla/pjrt:pjrt_c_api_client",
         "//xla/pjrt/distributed:in_memory_key_value_store",
         "//xla/pjrt/gpu:se_gpu_pjrt_client",
         "//xla/service:computation_placer_hdr",

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -386,6 +386,17 @@ typedef PJRT_Error* PJRT_Event_Set(PJRT_Event_Set_Args* args);
 
 typedef struct PJRT_DeviceEvent PJRT_DeviceEvent;
 
+struct PJRT_DeviceEvent_Destroy_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceEvent* device_event;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceEvent_Destroy_Args, device_event);
+
+// Frees `device_event`. `device_event` can be `nullptr`.
+typedef PJRT_Error* PJRT_DeviceEvent_Destroy(
+    PJRT_DeviceEvent_Destroy_Args* args);
+
 struct PJRT_DeviceEvent_GetPJRTEvent_Args {
   size_t struct_size;
   PJRT_Extension_Base* extension_start;
@@ -2670,10 +2681,6 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DonateWithControlDependency_Args,
 typedef PJRT_Error* PJRT_Buffer_DonateWithControlDependency(
     PJRT_Buffer_DonateWithControlDependency_Args* args);
 
-// -------------------------------- Raw Buffers --------------------------------
-
-// TODO.
-
 // ---------------------------- CopyToDeviceStream -----------------------------
 
 struct PJRT_CopyToDeviceStream_Destroy_Args {
@@ -3089,11 +3096,12 @@ typedef struct PJRT_Api {
   _PJRT_API_STRUCT_FIELD(PJRT_Executable_ParameterMemoryKinds);
 
   _PJRT_API_STRUCT_FIELD(PJRT_DeviceEvent_GetPJRTEvent);
+  _PJRT_API_STRUCT_FIELD(PJRT_DeviceEvent_Destroy);
 } PJRT_Api;
 
 enum {
   PJRT_Api_STRUCT_SIZE =
-      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Executable_ParameterMemoryKinds)
+      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_DeviceEvent_Destroy)
 };
 
 #undef _PJRT_API_STRUCT_FIELD

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -1309,6 +1309,18 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateBuffersForAsyncHostToDevice_Args,
 typedef PJRT_Error* PJRT_Client_CreateBuffersForAsyncHostToDevice(
     PJRT_Client_CreateBuffersForAsyncHostToDevice_Args* args);
 
+struct PJRT_Client_CreateDeviceEvent_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  PJRT_DeviceEvent* device_event;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateDeviceEvent_Args, device_event);
+
+// Create a device event.
+typedef PJRT_Error* PJRT_Client_CreateDeviceEvent(
+    PJRT_Client_CreateDeviceEvent_Args* args);
+
 // -------------------------- Device Descriptions ------------------------------
 
 // Device descriptions may be associated with an actual device
@@ -3097,11 +3109,11 @@ typedef struct PJRT_Api {
 
   _PJRT_API_STRUCT_FIELD(PJRT_DeviceEvent_GetPJRTEvent);
   _PJRT_API_STRUCT_FIELD(PJRT_DeviceEvent_Destroy);
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_CreateDeviceEvent);
 } PJRT_Api;
 
 enum {
-  PJRT_Api_STRUCT_SIZE =
-      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_DeviceEvent_Destroy)
+  PJRT_Api_STRUCT_SIZE = PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Client_CreateDeviceEvent)
 };
 
 #undef _PJRT_API_STRUCT_FIELD

--- a/xla/pjrt/c/pjrt_c_api.h
+++ b/xla/pjrt/c/pjrt_c_api.h
@@ -110,7 +110,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 103
+#define PJRT_API_MINOR 104
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in
@@ -376,6 +376,28 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Event_Set_Args, error_message_size);
 
 // Sets the PJRT_Event as completed with the given error code and message.
 typedef PJRT_Error* PJRT_Event_Set(PJRT_Event_Set_Args* args);
+
+// ------------------------------- Device Events -------------------------------
+
+// Represents a device-side event. These are similar to PJRT_Event, but they
+// may occur on a device instead of on the host. This means that the host can
+// enqueue executables and transfers on unfulfilled device events without
+// blocking.
+
+typedef struct PJRT_DeviceEvent PJRT_DeviceEvent;
+
+struct PJRT_DeviceEvent_GetPJRTEvent_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceEvent* device_event;
+  PJRT_Event* event;  // Output.
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceEvent_GetPJRTEvent_Args, event);
+
+// Get a host-side PJRT_Event that is fulfilled when the input device event is
+// completed on the device.
+typedef PJRT_Error* PJRT_DeviceEvent_GetPJRTEvent(
+    PJRT_DeviceEvent_GetPJRTEvent_Args* args);
 
 // ---------------------------------- Client -----------------------------------
 
@@ -2648,6 +2670,10 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DonateWithControlDependency_Args,
 typedef PJRT_Error* PJRT_Buffer_DonateWithControlDependency(
     PJRT_Buffer_DonateWithControlDependency_Args* args);
 
+// -------------------------------- Raw Buffers --------------------------------
+
+// TODO.
+
 // ---------------------------- CopyToDeviceStream -----------------------------
 
 struct PJRT_CopyToDeviceStream_Destroy_Args {
@@ -3061,6 +3087,8 @@ typedef struct PJRT_Api {
   _PJRT_API_STRUCT_FIELD(PJRT_Error_ForEachPayload);
   _PJRT_API_STRUCT_FIELD(PJRT_TopologyDescription_Fingerprint);
   _PJRT_API_STRUCT_FIELD(PJRT_Executable_ParameterMemoryKinds);
+
+  _PJRT_API_STRUCT_FIELD(PJRT_DeviceEvent_GetPJRTEvent);
 } PJRT_Api;
 
 enum {

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -44,6 +44,8 @@ limitations under the License.
 #include "xla/pjrt/c/pjrt_c_api_layouts_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_memory_descriptions_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_profiler_extension.h"
+#include "xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h"
+#include "xla/pjrt/c/pjrt_c_api_raw_buffer_internal.h"
 #include "xla/pjrt/c/pjrt_c_api_shardings_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_stream_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_triton_extension.h"
@@ -531,11 +533,14 @@ const PJRT_Api* GetGpuPjrtApi() {
   static PJRT_AbiVersion_Extension abi_version_extension =
       pjrt::CreateGpuAbiVersionExtension(&shardings_extension.base);
 
+  static PJRT_RawBuffer_Extension raw_buffer_extension =
+      pjrt::CreateRawBufferExtension(&abi_version_extension.base);
+
   static const PJRT_Api pjrt_api = pjrt::CreatePjrtApi(
       pjrt::gpu_plugin::PJRT_Client_Create,
       pjrt::gpu_plugin::PJRT_ExecuteContext_Create,
       pjrt::gpu_plugin::PJRT_GpuDeviceTopology_Create,
-      pjrt::PJRT_Plugin_Initialize_NoOp, &abi_version_extension.base,
+      pjrt::PJRT_Plugin_Initialize_NoOp, &raw_buffer_extension.base,
       pjrt::gpu_plugin::PJRT_Plugin_Attributes_Gpu);
 
   return &pjrt_api;

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -55,12 +55,14 @@ limitations under the License.
 #include "xla/pjrt/c/pjrt_c_api_gpu_internal.h"
 #include "xla/pjrt/c/pjrt_c_api_helpers.h"
 #include "xla/pjrt/c/pjrt_c_api_layouts_extension.h"
+#include "xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_test.h"
 #include "xla/pjrt/c/pjrt_c_api_test_base.h"
 #include "xla/pjrt/c/pjrt_c_api_triton_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_wrapper_impl.h"
 #include "xla/pjrt/distributed/in_memory_key_value_store.h"
 #include "xla/pjrt/gpu/se_gpu_pjrt_client.h"
+#include "xla/pjrt/pjrt_c_api_client.h"
 #include "xla/pjrt/pjrt_common.h"
 #include "xla/pjrt/pjrt_compiler.h"
 #include "xla/service/computation_placer.h"
@@ -203,6 +205,109 @@ class PjrtCApiGpuBufferTest : public PjrtCApiGpuTest {
 
   std::unique_ptr<PJRT_Buffer, PJRT_BufferDeleter> buffer_;
 };
+
+TEST_F(PjrtCApiGpuTest, CreateAndDestroyDeviceEvent) {
+  // Simple test that checks we can create and destroy a PJRT_DeviceEvent
+  // without an error.
+
+  PJRT_Client_CreateDeviceEvent_Args create_args;
+  create_args.struct_size = PJRT_Client_CreateDeviceEvent_Args_STRUCT_SIZE;
+  create_args.extension_start = nullptr;
+  create_args.client = client_;
+  create_args.device_event = nullptr;
+
+  PJRT_Error* create_error = api_->PJRT_Client_CreateDeviceEvent(&create_args);
+  ASSERT_THAT(create_error, IsNull());
+  ASSERT_NE(create_args.device_event, nullptr);
+
+  PJRT_DeviceEvent_Destroy_Args destroy_args;
+  destroy_args.struct_size = PJRT_DeviceEvent_Destroy_Args_STRUCT_SIZE;
+  destroy_args.extension_start = nullptr;
+  destroy_args.device_event = create_args.device_event;
+
+  PJRT_Error* destroy_error = api_->PJRT_DeviceEvent_Destroy(&destroy_args);
+  ASSERT_THAT(destroy_error, IsNull());
+}
+
+TEST_F(PjrtCApiGpuBufferTest, DefineBuffer) {
+  // Simple test that checks if we can, without raising any errors, define a
+  // PJRT_Buffer from a definition event + raw buffer.
+
+  // Get the RawBuffer extension.
+  PJRT_RawBuffer_Extension* raw_buffer_extension =
+      pjrt::FindExtension<PJRT_RawBuffer_Extension>(
+          api_, PJRT_Extension_Type::PJRT_Extension_Type_RawBuffer);
+  CHECK_NE(raw_buffer_extension, nullptr);
+  CHECK_NE(raw_buffer_extension->PJRT_Client_DefineBuffer, nullptr);
+
+  // Create the raw buffer.
+  auto [buffer, buffer_future] = create_iota_buffer();
+  CHECK_OK(buffer_future.Await());
+  CHECK_NE(raw_buffer_extension->PJRT_RawBuffer_CreateRawAliasOfBuffer,
+           nullptr);
+  PJRT_RawBuffer_CreateRawAliasOfBuffer_Args raw_buffer_creation_args;
+  raw_buffer_creation_args.struct_size =
+      PJRT_RawBuffer_CreateRawAliasOfBuffer_Args_STRUCT_SIZE;
+  raw_buffer_creation_args.extension_start = nullptr;
+  raw_buffer_creation_args.buffer = buffer.get();
+  raw_buffer_creation_args.raw_buffer = nullptr;
+
+  PJRT_Error* raw_buffer_creation_error =
+      raw_buffer_extension->PJRT_RawBuffer_CreateRawAliasOfBuffer(
+          &raw_buffer_creation_args);
+  ASSERT_THAT(raw_buffer_creation_error, IsNull());
+  ASSERT_NE(raw_buffer_creation_args.raw_buffer, nullptr);
+
+  // Create the definition device event.
+  PJRT_Client_CreateDeviceEvent_Args definition_event_creation_args;
+  definition_event_creation_args.struct_size =
+      PJRT_Client_CreateDeviceEvent_Args_STRUCT_SIZE;
+  definition_event_creation_args.extension_start = nullptr;
+  definition_event_creation_args.client = client_;
+  definition_event_creation_args.device_event = nullptr;
+
+  PJRT_Error* definition_event_creation_error =
+      api_->PJRT_Client_CreateDeviceEvent(&definition_event_creation_args);
+  ASSERT_THAT(definition_event_creation_error, IsNull());
+  ASSERT_NE(definition_event_creation_args.device_event, nullptr);
+
+  // Get the shape and memory_space of the new buffer we will define. This is
+  // hardcoded based on the implementation of create_iota_buffer().
+  xla::Shape shape = xla::ShapeUtil::MakeShapeWithType<float>({4});
+  PJRT_Device* device = GetClientAddressableDevices()[0];
+  xla::PjRtMemorySpace* memory_space =
+      device->device->default_memory_space().value();
+
+  PJRT_Memory c_api_memory_space;
+  c_api_memory_space.memory_space = memory_space;
+  c_api_memory_space.client = client_;
+  c_api_memory_space.devices = {device};
+
+  // Define the new PJRT_Buffer.
+  PJRT_Client_DefineBuffer_Args define_buffer_args;
+  define_buffer_args.struct_size = PJRT_Client_DefineBuffer_Args_STRUCT_SIZE;
+  define_buffer_args.extension_start = nullptr;
+  define_buffer_args.client = client_;
+  define_buffer_args.shape_dims = shape.dimensions().data();
+  define_buffer_args.shape_num_dims = shape.dimensions().size();
+  define_buffer_args.shape_element_type =
+      pjrt::ConvertToPjRtBufferType(shape.element_type());
+  define_buffer_args.shape_layout = nullptr;
+  define_buffer_args.memory = &c_api_memory_space;
+  define_buffer_args.raw_buffer = raw_buffer_creation_args.raw_buffer;
+  define_buffer_args.num_definition_events = 1;
+  define_buffer_args.device_events =
+      &definition_event_creation_args.device_event;
+  define_buffer_args.defined_buffer = nullptr;
+
+  PJRT_Error* define_buffer_error =
+      raw_buffer_extension->PJRT_Client_DefineBuffer(&define_buffer_args);
+  ASSERT_THAT(define_buffer_error, IsNull());
+  ASSERT_NE(define_buffer_args.defined_buffer, nullptr);
+
+  std::unique_ptr<PJRT_Buffer, ::pjrt::PJRT_BufferDeleter> defined_buffer(
+      define_buffer_args.defined_buffer, ::pjrt::MakeBufferDeleter(api_));
+}
 
 TEST_F(PjrtCApiGpuBufferTest, CopyRawToHost) {
   auto [buffer, buffer_future] = create_iota_buffer();

--- a/xla/pjrt/c/pjrt_c_api_helpers.cc
+++ b/xla/pjrt/c/pjrt_c_api_helpers.cc
@@ -288,6 +288,18 @@ PJRT_EventDeleter MakeEventDeleter(const PJRT_Api* api) {
   };
 }
 
+PJRT_DeviceEventDeleter MakeDeviceEventDeleter(const PJRT_Api* api) {
+  CHECK(api != nullptr);
+  return [api](PJRT_DeviceEvent* managed) {
+    PJRT_DeviceEvent_Destroy_Args args;
+    args.struct_size = PJRT_DeviceEvent_Destroy_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.device_event = managed;
+
+    LogFatalIfPjrtError(api->PJRT_DeviceEvent_Destroy(&args), api);
+  };
+}
+
 PJRT_Buffer_Type ConvertToPjRtBufferType(xla::PrimitiveType type) {
   switch (type) {
     case xla::PrimitiveType::PRIMITIVE_TYPE_INVALID:

--- a/xla/pjrt/c/pjrt_c_api_helpers.h
+++ b/xla/pjrt/c/pjrt_c_api_helpers.h
@@ -108,6 +108,12 @@ using PJRT_EventDeleter = std::function<void(PJRT_Event*)>;
 // The lifetime of the Api pointed to must be longer than the event.
 PJRT_EventDeleter MakeEventDeleter(const PJRT_Api* api);
 
+using PJRT_DeviceEventDeleter = std::function<void(PJRT_DeviceEvent*)>;
+
+// Pass in an API pointer; receive a custom deleter for smart pointers.
+// The lifetime of the Api pointed to must be longer than the device event.
+PJRT_DeviceEventDeleter MakeDeviceEventDeleter(const PJRT_Api* api);
+
 using PJRT_SerializedExecutableDeleter =
     std::function<void(PJRT_SerializedExecutable*)>;
 

--- a/xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h
@@ -130,7 +130,7 @@ struct PJRT_Client_DefineBuffer_Args {
   PJRT_RawBuffer* raw_buffer;
 
   int num_definition_events;
-  PJRT_DeviceEvent* device_events;
+  PJRT_DeviceEvent** device_events;
 
   PJRT_Buffer* defined_buffer;  // out
 };

--- a/xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h
@@ -114,11 +114,36 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_RawBuffer_CopyRawHostToDevice_Args, event);
 typedef PJRT_Error* PJRT_RawBuffer_CopyRawHostToDevice(
     PJRT_RawBuffer_CopyRawHostToDevice_Args* args);
 
+struct PJRT_Client_DefineBuffer_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+
+  // Shape fields.
+  const int64_t* shape_dims;
+  size_t shape_num_dims;
+  PJRT_Buffer_Type shape_element_type;
+  PJRT_Buffer_MemoryLayout* shape_layout;
+
+  PJRT_Memory* memory;
+
+  PJRT_RawBuffer* raw_buffer;
+
+  int num_definition_events;
+  PJRT_DeviceEvent* device_events;
+
+  PJRT_Buffer* defined_buffer;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_DefineBuffer_Args, defined_buffer);
+
+typedef PJRT_Error* PJRT_Client_DefineBuffer(
+    PJRT_Client_DefineBuffer_Args* args);
+
 // This extension provides capabilities around constructing raw buffers which
 // alias PJRT_Buffers. The extension is both optional and experimental, meaning
 // ABI-breaking and other incompatible changes may be introduced at any time.
 
-#define PJRT_API_RAW_BUFFER_EXTENSION_VERSION 2
+#define PJRT_API_RAW_BUFFER_EXTENSION_VERSION 3
 #define _PJRT_API_STRUCT_FIELD(fn_type) fn_type* fn_type
 
 typedef struct PJRT_RawBuffer_Extension {
@@ -130,9 +155,9 @@ typedef struct PJRT_RawBuffer_Extension {
   _PJRT_API_STRUCT_FIELD(PJRT_RawBuffer_CopyRawHostToDevice);
   _PJRT_API_STRUCT_FIELD(PJRT_RawBuffer_CopyRawDeviceToHost);
   _PJRT_API_STRUCT_FIELD(PJRT_RawBuffer_GetHostPointer);
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_DefineBuffer);
 } PJRT_RawBuffer_Extension;
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_RawBuffer_Extension,
-                          PJRT_RawBuffer_GetHostPointer);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_RawBuffer_Extension, PJRT_Client_DefineBuffer);
 
 #undef _PJRT_API_STRUCT_FIELD
 

--- a/xla/pjrt/c/pjrt_c_api_raw_buffer_external.cc
+++ b/xla/pjrt/c/pjrt_c_api_raw_buffer_external.cc
@@ -143,37 +143,6 @@ absl::StatusOr<PJRT_RawBuffer*> PjRtCApiBuffer_CreateRawAliasOfBuffer(
 
 namespace xla {
 
-PjRtCApiRawBuffer::~PjRtCApiRawBuffer() {
-  pjrt::PjRtCApiRawBuffer_Destroy(c_api_, c_extension_, c_buffer_);
-}
-
-PjRtMemorySpace* PjRtCApiRawBuffer::memory_space() const {
-  return client_->GetCppMemory(
-      pjrt::PjRtCApiRawBuffer_GetMemorySpace(c_api_, c_extension_, c_buffer_));
-}
-
-void* PjRtCApiRawBuffer::GetHostPointer() const {
-  return pjrt::PjRtCApiRawBuffer_GetHostPointer(c_api_, c_extension_,
-                                                c_buffer_);
-}
-
-size_t PjRtCApiRawBuffer::GetOnDeviceSizeInBytes() const {
-  return pjrt::PjRtCApiRawBuffer_GetOnDeviceSizeInBytes(c_api_, c_extension_,
-                                                        c_buffer_);
-}
-
-Future<> PjRtCApiRawBuffer::CopyRawHostToDevice(const void* src, int64_t offset,
-                                                int64_t transfer_size) {
-  return pjrt::PjRtCApiRawBuffer_CopyRawHostToDevice(
-      c_api_, c_extension_, c_buffer_, src, offset, transfer_size);
-}
-
-Future<> PjRtCApiRawBuffer::CopyRawDeviceToHost(void* dst, int64_t offset,
-                                                int64_t transfer_size) {
-  return pjrt::PjRtCApiRawBuffer_CopyRawDeviceToHost(
-      c_api_, c_extension_, c_buffer_, dst, offset, transfer_size);
-}
-
 static std::optional<absl::StatusOr<tsl::RCReference<PjRtRawBuffer>>>
 PjRtCApiBuffer_CreateRawAliasOfBuffer_Factory(PjRtBuffer* buffer) {
   if (auto* c_api_buffer = dynamic_cast<xla::PjRtCApiBuffer*>(buffer)) {

--- a/xla/pjrt/c/pjrt_c_api_raw_buffer_external.h
+++ b/xla/pjrt/c/pjrt_c_api_raw_buffer_external.h
@@ -20,8 +20,6 @@ limitations under the License.
 #include "xla/future.h"
 #include "xla/pjrt/c/pjrt_c_api.h"
 #include "xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h"
-#include "xla/pjrt/c_api_client/pjrt_c_api_client.h"
-#include "xla/pjrt/raw_buffer.h"
 
 namespace pjrt {
 
@@ -34,7 +32,8 @@ PJRT_Memory* PjRtCApiRawBuffer_GetMemorySpace(
     PJRT_RawBuffer* buffer);
 
 void* PjRtCApiRawBuffer_GetHostPointer(
-    PJRT_RawBuffer_GetHostPointer_Args* args);
+    const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+    PJRT_RawBuffer* buffer);
 
 size_t PjRtCApiRawBuffer_GetOnDeviceSizeInBytes(
     const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
@@ -54,35 +53,5 @@ absl::StatusOr<PJRT_RawBuffer*> PjRtCApiBuffer_CreateRawAliasOfBuffer(
     PJRT_Buffer* buffer);
 
 }  // namespace pjrt
-
-namespace xla {
-
-class PjRtCApiRawBuffer : public PjRtRawBuffer {
- public:
-  PjRtCApiRawBuffer(PJRT_RawBuffer* c_buffer, PjRtCApiClient* client,
-                    const PJRT_Api* c_api,
-                    const PJRT_RawBuffer_Extension* c_extension)
-      : c_buffer_(c_buffer),
-        client_(client),
-        c_api_(c_api),
-        c_extension_(c_extension) {}
-  ~PjRtCApiRawBuffer() override;
-
-  PjRtMemorySpace* memory_space() const override;
-  void* GetHostPointer() const override;
-  size_t GetOnDeviceSizeInBytes() const override;
-  Future<> CopyRawHostToDevice(const void* src, int64_t offset,
-                               int64_t transfer_size) override;
-  Future<> CopyRawDeviceToHost(void* dst, int64_t offset,
-                               int64_t transfer_size) override;
-
- private:
-  PJRT_RawBuffer* c_buffer_;
-  PjRtCApiClient* client_;
-  const PJRT_Api* c_api_;
-  const PJRT_RawBuffer_Extension* c_extension_;
-};
-
-}  // namespace xla
 
 #endif  // XLA_PJRT_C_PJRT_C_API_RAW_BUFFER_EXTERNAL_H_

--- a/xla/pjrt/c/pjrt_c_api_raw_buffer_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_raw_buffer_internal.cc
@@ -114,16 +114,17 @@ PJRT_Error* PJRT_Client_DefineBuffer(PJRT_Client_DefineBuffer_Args* args) {
       pjrt::BuildXlaShapeFromC(args->shape_element_type, args->shape_dims,
                                args->shape_num_dims, args->shape_layout));
 
-  absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>> definition_events;
+  absl::InlinedVector<tsl::RCReference<xla::PjRtDeviceEvent>, 4>
+      definition_events;
   definition_events.reserve(args->num_definition_events);
   for (int i = 0; i < args->num_definition_events; ++i) {
     definition_events.push_back(args->device_events[i]->device_event);
   }
 
-  PJRT_ASSIGN_OR_RETURN(std::unique_ptr<PjRtBuffer> defined_cpp_buffer,
+  PJRT_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtBuffer> defined_cpp_buffer,
                         args->client->client->DefineBuffer(
                             shape, args->memory->memory_space,
-                            args->raw_buffer->raw_buffer, definition_events));
+                            args->raw_buffer->buffer, definition_events));
 
   PJRT_Buffer* defined_buffer =
       new PJRT_Buffer{std::move(defined_cpp_buffer), args->client};

--- a/xla/pjrt/c/pjrt_c_api_raw_buffer_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_raw_buffer_internal.cc
@@ -104,6 +104,34 @@ PJRT_Error* PJRT_RawBuffer_CopyRawDeviceToHost(
   return nullptr;
 }
 
+PJRT_Error* PJRT_Client_DefineBuffer(PJRT_Client_DefineBuffer_Args* args) {
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_Client_DefineBuffer_Args",
+      PJRT_Client_DefineBuffer_Args_STRUCT_SIZE, args->struct_size));
+
+  PJRT_ASSIGN_OR_RETURN(
+      xla::Shape shape,
+      pjrt::BuildXlaShapeFromC(args->shape_element_type, args->shape_dims,
+                               args->shape_num_dims, args->shape_layout));
+
+  absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>> definition_events;
+  definition_events.reserve(args->num_definition_events);
+  for (int i = 0; i < args->num_definition_events; ++i) {
+    definition_events.push_back(args->device_events[i]->device_event);
+  }
+
+  PJRT_ASSIGN_OR_RETURN(std::unique_ptr<PjRtBuffer> defined_cpp_buffer,
+                        args->client->client->DefineBuffer(
+                            shape, args->memory->memory_space,
+                            args->raw_buffer->raw_buffer, definition_events));
+
+  PJRT_Buffer* defined_buffer =
+      new PJRT_Buffer{std::move(defined_cpp_buffer), args->client};
+
+  args->defined_buffer = defined_buffer;
+  return nullptr;
+}
+
 PJRT_RawBuffer_Extension CreateRawBufferExtension(PJRT_Extension_Base* next) {
   return {
       PJRT_Extension_Base{
@@ -123,6 +151,8 @@ PJRT_RawBuffer_Extension CreateRawBufferExtension(PJRT_Extension_Base* next) {
       pjrt::PJRT_RawBuffer_CopyRawDeviceToHost,
       /*PJRT_RawBuffer_GetHostPointer=*/
       pjrt::PJRT_RawBuffer_GetHostPointer,
+      /*PJRT_Client_DefineBuffer=*/
+      pjrt::PJRT_Client_DefineBuffer,
   };
 }
 

--- a/xla/pjrt/c/pjrt_c_api_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_test.cc
@@ -992,6 +992,10 @@ FieldOffsetsAndSizesForVersion(int major_version, int minor_version) {
     if (minor_version >= 102) {
       add_field("PJRT_Executable_ParameterMemoryKinds", kFnPtrSize);
     }
+    if (minor_version >= 104) {
+      add_field("PJRT_DeviceEvent_GetPJRTEvent", kFnPtrSize);
+      add_field("PJRT_DeviceEvent_Destroy", kFnPtrSize);
+    }
     return version_offsets_and_sizes;
   }
   LOG(FATAL) << "Unsupported API version: " << major_version << "."
@@ -1438,6 +1442,12 @@ TEST_F(PjrtCAbiTestBase, FieldOffsetsAndSizes) {
           {"PJRT_Executable_ParameterMemoryKinds",
            {offsetof(PJRT_Api, PJRT_Executable_ParameterMemoryKinds),
             sizeof(PJRT_Api::PJRT_Executable_ParameterMemoryKinds)}},
+          {"PJRT_DeviceEvent_GetPJRTEvent",
+           {offsetof(PJRT_Api, PJRT_DeviceEvent_GetPJRTEvent),
+            sizeof(PJRT_Api::PJRT_DeviceEvent_GetPJRTEvent)}},
+          {"PJRT_DeviceEvent_Destroy",
+           {offsetof(PJRT_Api, PJRT_DeviceEvent_Destroy),
+            sizeof(PJRT_Api::PJRT_DeviceEvent_Destroy)}},
       };
   ASSERT_EQ(api_->pjrt_api_version.major_version, PJRT_API_MAJOR);
   ASSERT_EQ(api_->pjrt_api_version.minor_version, PJRT_API_MINOR);

--- a/xla/pjrt/c/pjrt_c_api_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_test.cc
@@ -995,6 +995,7 @@ FieldOffsetsAndSizesForVersion(int major_version, int minor_version) {
     if (minor_version >= 104) {
       add_field("PJRT_DeviceEvent_GetPJRTEvent", kFnPtrSize);
       add_field("PJRT_DeviceEvent_Destroy", kFnPtrSize);
+      add_field("PJRT_Client_CreateDeviceEvent", kFnPtrSize);
     }
     return version_offsets_and_sizes;
   }
@@ -1448,6 +1449,9 @@ TEST_F(PjrtCAbiTestBase, FieldOffsetsAndSizes) {
           {"PJRT_DeviceEvent_Destroy",
            {offsetof(PJRT_Api, PJRT_DeviceEvent_Destroy),
             sizeof(PJRT_Api::PJRT_DeviceEvent_Destroy)}},
+          {"PJRT_Client_CreateDeviceEvent",
+           {offsetof(PJRT_Api, PJRT_Client_CreateDeviceEvent),
+            sizeof(PJRT_Api::PJRT_Client_CreateDeviceEvent)}},
       };
   ASSERT_EQ(api_->pjrt_api_version.major_version, PJRT_API_MAJOR);
   ASSERT_EQ(api_->pjrt_api_version.minor_version, PJRT_API_MINOR);

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
@@ -2717,8 +2717,8 @@ PJRT_Error* PJRT_Buffer_CopyRawToHostFuture(
       future, args->offset, args->transfer_size);
   args->event = new PJRT_Event{std::move(wrapped_promise)};
 
-  typedef absl::AnyInvocable<
-      void(PJRT_Buffer_CopyRawToHostFuture_Callback_Args*) &&>
+  typedef absl::AnyInvocable<void(
+      PJRT_Buffer_CopyRawToHostFuture_Callback_Args*) &&>
       Callback;
   auto callback = new Callback(
       [promise = std::move(promise)](
@@ -3073,6 +3073,15 @@ PJRT_Error* PJRT_Event_Set(PJRT_Event_Set_Args* args) {
 }
 
 // ------------------------------- Device Events -------------------------------
+
+PJRT_Error* PJRT_DeviceEvent_Destroy(PJRT_DeviceEvent_Destroy_Args* args) {
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_DeviceEvent_Destroy", PJRT_DeviceEvent_Destroy_Args_STRUCT_SIZE,
+      args->struct_size));
+
+  delete args->device_event;
+  return nullptr;
+}
 
 PJRT_Error* PJRT_DeviceEvent_GetPJRTEvent(
     PJRT_DeviceEvent_GetPJRTEvent_Args* args) {
@@ -3851,6 +3860,8 @@ PJRT_Api CreatePjrtApi(PJRT_Client_Create* create_fn,
 
       /*PJRT_DeviceEvent_GetPJRTEvent=*/
       pjrt::PJRT_DeviceEvent_GetPJRTEvent,
+      /*PJRT_DeviceEvent_Destroy=*/
+      pjrt::PJRT_DeviceEvent_Destroy,
   };
 }
 

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
@@ -851,6 +851,24 @@ PJRT_Error* PJRT_Client_DmaUnmap(PJRT_Client_DmaUnmap_Args* args) {
   return nullptr;
 }
 
+PJRT_Error* PJRT_Client_CreateDeviceEvent(
+    PJRT_Client_CreateDeviceEvent_Args* args) {
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_Client_CreateDeviceEvent_Args",
+      PJRT_Client_CreateDeviceEvent_Args_STRUCT_SIZE, args->struct_size));
+
+  PJRT_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtDeviceEvent> device_event,
+                        args->client->client->CreateDeviceEvent());
+
+  tsl::RCReference<xla::PjRtDeviceEvent> rc_device_event =
+      tsl::FormRef(device_event.release());
+  PJRT_DeviceEvent* out_device_event =
+      new PJRT_DeviceEvent{std::move(rc_device_event)};
+  args->device_event = out_device_event;
+
+  return nullptr;
+}
+
 // Searches `device_list` for a PJRT_Device* that wraps a provided
 // `xla::PjRtDevice *` (`cpp_device`). If a match is found, that PJRT_Device*
 // is returned. Otherwise, returns nullptr.
@@ -2717,8 +2735,8 @@ PJRT_Error* PJRT_Buffer_CopyRawToHostFuture(
       future, args->offset, args->transfer_size);
   args->event = new PJRT_Event{std::move(wrapped_promise)};
 
-  typedef absl::AnyInvocable<void(
-      PJRT_Buffer_CopyRawToHostFuture_Callback_Args*) &&>
+  typedef absl::AnyInvocable<
+      void(PJRT_Buffer_CopyRawToHostFuture_Callback_Args*) &&>
       Callback;
   auto callback = new Callback(
       [promise = std::move(promise)](
@@ -3089,7 +3107,9 @@ PJRT_Error* PJRT_DeviceEvent_GetPJRTEvent(
       "PJRT_DeviceEvent_GetPJRTEvent",
       PJRT_DeviceEvent_GetPJRTEvent_Args_STRUCT_SIZE, args->struct_size));
 
-  auto [promise, future] = xla::MakePromise();
+  auto promise_and_future = xla::MakePromise();
+  auto& promise = promise_and_future.first;
+  auto& future = promise_and_future.second;
 
   tsl::Future<> backing_future =
       tsl::MakeFutureWhenReady(args->device_event->device_event->async_value());
@@ -3862,6 +3882,8 @@ PJRT_Api CreatePjrtApi(PJRT_Client_Create* create_fn,
       pjrt::PJRT_DeviceEvent_GetPJRTEvent,
       /*PJRT_DeviceEvent_Destroy=*/
       pjrt::PJRT_DeviceEvent_Destroy,
+      /*PJRT_Client_CreateDeviceEvent=*/
+      PJRT_Client_CreateDeviceEvent,
   };
 }
 

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.cc
@@ -75,6 +75,7 @@ limitations under the License.
 #include "xla/service/hlo.pb.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
+#include "xla/tsl/concurrency/interop.h"
 #include "xla/tsl/distributed_runtime/call_options.h"
 #include "xla/tsl/distributed_runtime/coordination/coordination_service_agent.h"
 #include "xla/tsl/framework/allocator.h"
@@ -2716,8 +2717,8 @@ PJRT_Error* PJRT_Buffer_CopyRawToHostFuture(
       future, args->offset, args->transfer_size);
   args->event = new PJRT_Event{std::move(wrapped_promise)};
 
-  typedef absl::AnyInvocable<void(
-      PJRT_Buffer_CopyRawToHostFuture_Callback_Args*) &&>
+  typedef absl::AnyInvocable<
+      void(PJRT_Buffer_CopyRawToHostFuture_Callback_Args*) &&>
       Callback;
   auto callback = new Callback(
       [promise = std::move(promise)](
@@ -3068,6 +3069,25 @@ PJRT_Error* PJRT_Event_Set(PJRT_Event_Set_Args* args) {
       PjrtErrorCodeToStatusCode(args->error_code),
       absl::string_view(args->error_message, args->error_message_size));
   args->event->promise.Set(std::move(status));
+  return nullptr;
+}
+
+// ------------------------------- Device Events -------------------------------
+
+PJRT_Error* PJRT_DeviceEvent_GetPJRTEvent(
+    PJRT_DeviceEvent_GetPJRTEvent_Args* args) {
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_DeviceEvent_GetPJRTEvent",
+      PJRT_DeviceEvent_GetPJRTEvent_Args_STRUCT_SIZE, args->struct_size));
+
+  auto [promise, future] = xla::MakePromise();
+
+  tsl::Future<> backing_future =
+      tsl::MakeFutureWhenReady(args->device_event->device_event->async_value());
+  backing_future.OnReady(
+      [&promise](const absl::Status& status) { promise.Set(status); });
+
+  args->event = new PJRT_Event{std::move(future), std::move(promise)};
   return nullptr;
 }
 
@@ -3828,6 +3848,9 @@ PJRT_Api CreatePjrtApi(PJRT_Client_Create* create_fn,
       pjrt::PJRT_TopologyDescription_Fingerprint,
       /*PJRT_Executable_ParameterMemoryKinds=*/
       pjrt::PJRT_Executable_ParameterMemoryKinds,
+
+      /*PJRT_DeviceEvent_GetPJRTEvent=*/
+      pjrt::PJRT_DeviceEvent_GetPJRTEvent,
   };
 }
 

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.h
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.h
@@ -356,6 +356,9 @@ PJRT_Error* PJRT_Client_CreateBuffersForAsyncHostToDevice(
     PJRT_Client_CreateBuffersForAsyncHostToDevice_Args* args);
 PJRT_Error* PJRT_Client_DmaMap(PJRT_Client_DmaMap_Args* args);
 PJRT_Error* PJRT_Client_DmaUnmap(PJRT_Client_DmaUnmap_Args* args);
+PJRT_Error* PJRT_Client_CreateDeviceEvent(
+    PJRT_Client_CreateDeviceEvent_Args* args);
+
 PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_Destroy(
     PJRT_AsyncHostToDeviceTransferManager_Destroy_Args* args);
 PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_TransferData(

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.h
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.h
@@ -317,6 +317,7 @@ PJRT_Error* PJRT_Event_OnReady(PJRT_Event_OnReady_Args* args);
 PJRT_Error* PJRT_Event_Create(PJRT_Event_Create_Args* args);
 PJRT_Error* PJRT_Event_Set(PJRT_Event_Set_Args* args);
 
+PJRT_Error* PJRT_DeviceEvent_Destroy(PJRT_DeviceEvent_Destroy_Args* args);
 PJRT_Error* PJRT_DeviceEvent_GetPJRTEvent(
     PJRT_DeviceEvent_GetPJRTEvent_Args* args);
 

--- a/xla/pjrt/c/pjrt_c_api_wrapper_impl.h
+++ b/xla/pjrt/c/pjrt_c_api_wrapper_impl.h
@@ -233,6 +233,10 @@ struct PJRT_Event {
   xla::Promise<> promise;
 };
 
+struct PJRT_DeviceEvent {
+  tsl::RCReference<xla::PjRtDeviceEvent> device_event;
+};
+
 struct PJRT_SerializedExecutable {
   std::string serialized;
 };
@@ -312,6 +316,9 @@ PJRT_Error* PJRT_Event_Await(PJRT_Event_Await_Args* args);
 PJRT_Error* PJRT_Event_OnReady(PJRT_Event_OnReady_Args* args);
 PJRT_Error* PJRT_Event_Create(PJRT_Event_Create_Args* args);
 PJRT_Error* PJRT_Event_Set(PJRT_Event_Set_Args* args);
+
+PJRT_Error* PJRT_DeviceEvent_GetPJRTEvent(
+    PJRT_DeviceEvent_GetPJRTEvent_Args* args);
 
 PJRT_Error* PJRT_Client_Destroy(PJRT_Client_Destroy_Args* args);
 PJRT_Error* PJRT_Client_PlatformName(PJRT_Client_PlatformName_Args* args);

--- a/xla/pjrt/c_api_client/BUILD
+++ b/xla/pjrt/c_api_client/BUILD
@@ -93,6 +93,7 @@ cc_library(
         "//xla/pjrt/distributed:key_value_store_interface",
         "//xla/pjrt/distributed/coordination:coordination_service_proto_cc",
         "//xla/pjrt/extensions/cross_host_transfers:pjrt_c_api_cross_host_transfer_extension",
+        "//xla/pjrt/c:pjrt_c_api_raw_buffer_extension_hdrs",
         "//xla/pjrt/extensions/executable_metadata:executable_metadata_extension",
         "//xla/pjrt/extensions/host_allocator:host_allocator_extension",
         "//xla/pjrt/extensions/host_allocator:host_allocator_interface_impl",

--- a/xla/pjrt/c_api_client/pjrt_c_api_client.cc
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.cc
@@ -62,6 +62,7 @@ limitations under the License.
 #include "xla/pjrt/c/pjrt_c_api_memory_descriptions_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_phase_compile_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_profiler_extension.h"
+#include "xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_shardings_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_stream_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_tpu_topology_extension.h"
@@ -108,6 +109,30 @@ limitations under the License.
 #include "tsl/profiler/lib/connected_traceme.h"
 #include "tsl/profiler/lib/context_types.h"
 #include "tsl/profiler/lib/traceme.h"
+
+namespace pjrt {
+
+void PjRtCApiRawBuffer_Destroy(const PJRT_Api* c_api,
+                 const PJRT_RawBuffer_Extension* extension,
+                 PJRT_RawBuffer* buffer);
+PJRT_Memory* PjRtCApiRawBuffer_GetMemorySpace(
+  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+  PJRT_RawBuffer* buffer);
+void* PjRtCApiRawBuffer_GetHostPointer(
+  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+  PJRT_RawBuffer* buffer);
+size_t PjRtCApiRawBuffer_GetOnDeviceSizeInBytes(
+  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+  PJRT_RawBuffer* buffer);
+xla::Future<> PjRtCApiRawBuffer_CopyRawHostToDevice(
+  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+  PJRT_RawBuffer* buffer, const void* src, int64_t offset,
+  int64_t transfer_size);
+xla::Future<> PjRtCApiRawBuffer_CopyRawDeviceToHost(
+  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+  PJRT_RawBuffer* buffer, void* dst, int64_t offset, int64_t transfer_size);
+
+}  // namespace pjrt
 
 namespace xla {
 
@@ -980,6 +1005,81 @@ PjRtCApiClient::CreateAliasBuffer(const Shape& shape,
 
   return std::make_pair(std::move(alias_buffer),
                         std::move(fulfill_alias_buffer_cb));
+}
+
+absl::StatusOr<std::unique_ptr<PjRtBuffer>> PjRtCApiClient::DefineBuffer(
+    const Shape& shape, PjRtMemorySpace* memory_space,
+    tsl::RCReference<PjRtRawBuffer> raw_buffer,
+    absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
+        definition_device_events) {
+  const PJRT_Api* c_api = pjrt_c_api();
+  auto* extension = FindExtension<PJRT_RawBuffer_Extension>(
+      PJRT_Extension_Type::PJRT_Extension_Type_RawBuffer);
+  if (extension == nullptr) {
+    return absl::UnimplementedError(
+        "DefineBuffer is not implemented in this PJRT plugin.");
+  }
+  if (extension->PJRT_Client_DefineBuffer == nullptr) {
+    return absl::UnimplementedError(
+        "PJRT_Client_DefineBuffer is not implemented in this PJRT plugin.");
+  }
+
+  auto* c_api_raw_buffer = dynamic_cast<PjRtCApiRawBuffer*>(raw_buffer.get());
+  if (c_api_raw_buffer == nullptr) {
+    return absl::InvalidArgumentError(
+        "DefineBuffer requires a PjRtCApiRawBuffer when called via "
+        "PjRtCApiClient.");
+  }
+  if (c_api_raw_buffer->client() != this) {
+    return absl::InvalidArgumentError(
+        "raw_buffer passed to PjRtCApiClient::DefineBuffer() belongs to a "
+        "different client.");
+  }
+
+  PJRT_Client_DefineBuffer_Args args;
+  args.struct_size = PJRT_Client_DefineBuffer_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.client = c_client_.get();
+
+  args.shape_dims = shape.dimensions().data();
+  args.shape_num_dims = shape.dimensions().size();
+  args.shape_element_type = pjrt::ConvertToPjRtBufferType(shape.element_type());
+
+  std::optional<pjrt::BufferMemoryLayoutData> c_layout_data;
+  if (shape.has_layout()) {
+    TF_ASSIGN_OR_RETURN(c_layout_data,
+                        pjrt::ConvertToBufferMemoryLayoutData(shape.layout()));
+    args.shape_layout = &c_layout_data->c_layout;
+  } else {
+    args.shape_layout = nullptr;
+  }
+
+  args.memory =
+      tensorflow::down_cast<PjRtCApiMemorySpace*>(memory_space)->c_memory();
+
+  args.raw_buffer = c_api_raw_buffer->c_buffer();
+
+  args.num_definition_events = definition_device_events.size();
+
+  std::vector<PJRT_DeviceEvent*> device_events;
+  device_events.reserve(definition_device_events.size());
+  for (tsl::RCReference<PjRtDeviceEvent> device_event :
+       definition_device_events) {
+    auto* c_api_device_event =
+        dynamic_cast<PjRtCApiDeviceEvent*>(device_event.get());
+    if (c_api_device_event == nullptr) {
+      return absl::InvalidArgumentError(
+          "PjRtCApiClient::DefineBuffer requires input definition events to be "
+          "PjRtCApiDeviceEvents.");
+    }
+    device_events.push_back(c_api_device_event->c_device_event());
+  }
+  args.device_events = device_events.data();
+
+  RETURN_STATUS_IF_PJRT_ERROR(extension->PJRT_Client_DefineBuffer(&args),
+                              c_api);
+
+  return std::make_unique<PjRtCApiBuffer>(this, args.defined_buffer);
 }
 
 absl::StatusOr<const PjRtTopologyDescription*>
@@ -2080,6 +2180,23 @@ PjRtCApiAsyncTrackingEvent::~PjRtCApiAsyncTrackingEvent() {
 void PjRtCApiAsyncTrackingEvent::AddDependency(
     tsl::RCReference<tsl::AsyncValue> dependency) {
   LOG(FATAL) << "AddDependency is not supported in C API yet.";
+}
+
+// ---------------------------- Device Events ----------------------------------
+
+PjRtCApiDeviceEvent::PjRtCApiDeviceEvent(
+    std::unique_ptr<PJRT_DeviceEvent, ::pjrt::PJRT_DeviceEventDeleter>
+        device_event,
+    const PJRT_Api* c_api)
+    : device_event_(std::move(device_event)) {
+  PJRT_DeviceEvent_GetPJRTEvent_Args args;
+  args.struct_size = PJRT_DeviceEvent_GetPJRTEvent_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.device_event = device_event_.get();
+  args.event = nullptr;
+
+  pjrt::LogFatalIfPjrtError(c_api->PJRT_DeviceEvent_GetPJRTEvent(&args), c_api);
+  ready_future_ = pjrt::ConvertCEventToCppFuture(args.event, c_api);
 }
 
 // ------------------------------- Memory --------------------------------------
@@ -4104,6 +4221,38 @@ absl::Status PjRtCApiExternalReference::WaitUntilBufferReadyOnStream(
   args.buffer = buffer_->c_buffer();
   RETURN_STATUS_IF_PJRT_ERROR(extension->wait_stream(&args), c_api);
   return absl::OkStatus();
+}
+
+PjRtCApiRawBuffer::~PjRtCApiRawBuffer() {
+  pjrt::PjRtCApiRawBuffer_Destroy(c_api_, c_extension_, c_buffer_);
+}
+
+PjRtMemorySpace* PjRtCApiRawBuffer::memory_space() const {
+  return client_->GetCppMemory(
+      pjrt::PjRtCApiRawBuffer_GetMemorySpace(c_api_, c_extension_, c_buffer_));
+}
+
+void* PjRtCApiRawBuffer::GetHostPointer() const {
+  return pjrt::PjRtCApiRawBuffer_GetHostPointer(c_api_, c_extension_,
+                                                c_buffer_);
+}
+
+size_t PjRtCApiRawBuffer::GetOnDeviceSizeInBytes() const {
+  return pjrt::PjRtCApiRawBuffer_GetOnDeviceSizeInBytes(c_api_, c_extension_,
+                                                        c_buffer_);
+}
+
+Future<> PjRtCApiRawBuffer::CopyRawHostToDevice(const void* src,
+                                                int64_t offset,
+                                                int64_t transfer_size) {
+  return pjrt::PjRtCApiRawBuffer_CopyRawHostToDevice(
+      c_api_, c_extension_, c_buffer_, src, offset, transfer_size);
+}
+
+Future<> PjRtCApiRawBuffer::CopyRawDeviceToHost(void* dst, int64_t offset,
+                                                int64_t transfer_size) {
+  return pjrt::PjRtCApiRawBuffer_CopyRawDeviceToHost(
+      c_api_, c_extension_, c_buffer_, dst, offset, transfer_size);
 }
 
 // ------------------------------ Device Topology ------------------------------

--- a/xla/pjrt/c_api_client/pjrt_c_api_client.cc
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.cc
@@ -113,24 +113,24 @@ limitations under the License.
 namespace pjrt {
 
 void PjRtCApiRawBuffer_Destroy(const PJRT_Api* c_api,
-                 const PJRT_RawBuffer_Extension* extension,
-                 PJRT_RawBuffer* buffer);
+                               const PJRT_RawBuffer_Extension* extension,
+                               PJRT_RawBuffer* buffer);
 PJRT_Memory* PjRtCApiRawBuffer_GetMemorySpace(
-  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
-  PJRT_RawBuffer* buffer);
+    const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+    PJRT_RawBuffer* buffer);
 void* PjRtCApiRawBuffer_GetHostPointer(
-  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
-  PJRT_RawBuffer* buffer);
+    const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+    PJRT_RawBuffer* buffer);
 size_t PjRtCApiRawBuffer_GetOnDeviceSizeInBytes(
-  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
-  PJRT_RawBuffer* buffer);
+    const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+    PJRT_RawBuffer* buffer);
 xla::Future<> PjRtCApiRawBuffer_CopyRawHostToDevice(
-  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
-  PJRT_RawBuffer* buffer, const void* src, int64_t offset,
-  int64_t transfer_size);
+    const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+    PJRT_RawBuffer* buffer, const void* src, int64_t offset,
+    int64_t transfer_size);
 xla::Future<> PjRtCApiRawBuffer_CopyRawDeviceToHost(
-  const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
-  PJRT_RawBuffer* buffer, void* dst, int64_t offset, int64_t transfer_size);
+    const PJRT_Api* c_api, const PJRT_RawBuffer_Extension* extension,
+    PJRT_RawBuffer* buffer, void* dst, int64_t offset, int64_t transfer_size);
 
 }  // namespace pjrt
 
@@ -1013,6 +1013,11 @@ absl::StatusOr<std::unique_ptr<PjRtBuffer>> PjRtCApiClient::DefineBuffer(
     absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
         definition_device_events) {
   const PJRT_Api* c_api = pjrt_c_api();
+  if (c_api->pjrt_api_version.major_version == 0 &&
+      c_api->pjrt_api_version.minor_version < 104) {
+    return absl::UnimplementedError(
+        "DefineBuffer requires PJRT C API version 0.104 or higher.");
+  }
   auto* extension = FindExtension<PJRT_RawBuffer_Extension>(
       PJRT_Extension_Type::PJRT_Extension_Type_RawBuffer);
   if (extension == nullptr) {
@@ -1080,6 +1085,30 @@ absl::StatusOr<std::unique_ptr<PjRtBuffer>> PjRtCApiClient::DefineBuffer(
                               c_api);
 
   return std::make_unique<PjRtCApiBuffer>(this, args.defined_buffer);
+}
+
+absl::StatusOr<std::unique_ptr<PjRtDeviceEvent>>
+PjRtCApiClient::CreateDeviceEvent() {
+  const PJRT_Api* c_api = pjrt_c_api();
+  if (c_api->pjrt_api_version.major_version == 0 &&
+      c_api->pjrt_api_version.minor_version < 104) {
+    return absl::UnimplementedError(
+        "CreateDeviceEvent requires PJRT C API version 0.104 or higher.");
+  }
+
+  PJRT_Client_CreateDeviceEvent_Args args;
+  args.struct_size = PJRT_Client_CreateDeviceEvent_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.client = c_client_.get();
+
+  RETURN_STATUS_IF_PJRT_ERROR(c_api->PJRT_Client_CreateDeviceEvent(&args),
+                              c_api);
+
+  pjrt::PJRT_DeviceEventDeleter deleter = pjrt::MakeDeviceEventDeleter(c_api);
+  std::unique_ptr<PJRT_DeviceEvent, ::pjrt::PJRT_DeviceEventDeleter>
+      device_event(args.device_event, deleter);
+
+  return std::make_unique<PjRtCApiDeviceEvent>(std::move(device_event), c_api);
 }
 
 absl::StatusOr<const PjRtTopologyDescription*>
@@ -4242,8 +4271,7 @@ size_t PjRtCApiRawBuffer::GetOnDeviceSizeInBytes() const {
                                                         c_buffer_);
 }
 
-Future<> PjRtCApiRawBuffer::CopyRawHostToDevice(const void* src,
-                                                int64_t offset,
+Future<> PjRtCApiRawBuffer::CopyRawHostToDevice(const void* src, int64_t offset,
                                                 int64_t transfer_size) {
   return pjrt::PjRtCApiRawBuffer_CopyRawHostToDevice(
       c_api_, c_extension_, c_buffer_, src, offset, transfer_size);

--- a/xla/pjrt/c_api_client/pjrt_c_api_client.h
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.h
@@ -47,7 +47,9 @@ limitations under the License.
 #include "xla/pjrt/c/pjrt_c_api_abi_version_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_callback_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_helpers.h"
+#include "xla/pjrt/c/pjrt_c_api_raw_buffer_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_tpu_topology_extension.h"
+#include "xla/pjrt/device_event.h"
 #include "xla/pjrt/distributed/coordination/coordination_service.pb.h"
 #include "xla/pjrt/distributed/key_value_store_interface.h"
 #include "xla/pjrt/maybe_owning_mlir_module.h"
@@ -60,6 +62,7 @@ limitations under the License.
 #include "xla/pjrt/pjrt_executable.h"
 #include "xla/pjrt/pjrt_layout.h"
 #include "xla/pjrt/proto/topology_description.pb.h"
+#include "xla/pjrt/raw_buffer.h"
 #include "xla/pjrt/scoped_async_tracking_event.h"
 #include "xla/service/computation_placer.h"
 #include "xla/service/hlo_cost_analysis.h"
@@ -425,6 +428,12 @@ class PjRtCApiClient : public PjRtClient {
       std::pair<std::unique_ptr<PjRtBuffer>, PjRtFulfillAliasBufferCallback>>
   CreateAliasBuffer(const Shape& shape, PjRtMemorySpace* memory_space) override;
 
+  absl::StatusOr<std::unique_ptr<PjRtBuffer>> DefineBuffer(
+      const Shape& shape, PjRtMemorySpace* memory_space,
+      tsl::RCReference<PjRtRawBuffer> raw_buffer,
+      absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
+          definition_device_events) override;
+
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CreateErrorBuffer(
       absl::Status error, const Shape& shape, PjRtMemorySpace* memory) override;
 
@@ -696,6 +705,35 @@ class PjRtCApiExternalReference : public PjRtBuffer::ExternalReference {
   PjRtCApiBuffer* buffer_;
 };
 
+class PjRtCApiRawBuffer : public PjRtRawBuffer {
+ public:
+  PjRtCApiRawBuffer(PJRT_RawBuffer* c_buffer, PjRtCApiClient* client,
+                    const PJRT_Api* c_api,
+                    const PJRT_RawBuffer_Extension* c_extension)
+      : c_buffer_(c_buffer),
+        client_(client),
+        c_api_(c_api),
+        c_extension_(c_extension) {}
+  ~PjRtCApiRawBuffer() override;
+
+  PjRtMemorySpace* memory_space() const override;
+  void* GetHostPointer() const override;
+  size_t GetOnDeviceSizeInBytes() const override;
+  Future<> CopyRawHostToDevice(const void* src, int64_t offset,
+                               int64_t transfer_size) override;
+  Future<> CopyRawDeviceToHost(void* dst, int64_t offset,
+                               int64_t transfer_size) override;
+
+  PJRT_RawBuffer* c_buffer() const { return c_buffer_; }
+  PjRtCApiClient* client() const { return client_; }
+
+ private:
+  PJRT_RawBuffer* c_buffer_;
+  PjRtCApiClient* client_;
+  const PJRT_Api* c_api_;
+  const PJRT_RawBuffer_Extension* c_extension_;
+};
+
 class PjRtCApiExecutable : public PjRtExecutable {
  public:
   PjRtCApiExecutable(const PJRT_Api* c_api, PJRT_Executable* executable);
@@ -949,6 +987,25 @@ class PjRtCApiLoadedExecutable : public PjRtLoadedExecutable {
   void InitAddressableDeviceLogicalIds();
   void InitDevices();
   void InitDeviceAssignment();
+};
+
+class PjRtCApiDeviceEvent : public PjRtDeviceEvent {
+ public:
+  PjRtCApiDeviceEvent(
+      std::unique_ptr<PJRT_DeviceEvent, ::pjrt::PJRT_DeviceEventDeleter>
+          device_event,
+      const PJRT_Api* c_api);
+
+  tsl::AsyncValue* async_value() const override {
+    return ready_future_.async_value();
+  }
+
+  PJRT_DeviceEvent* c_device_event() const { return device_event_.get(); }
+
+ private:
+  std::unique_ptr<PJRT_DeviceEvent, ::pjrt::PJRT_DeviceEventDeleter>
+      device_event_;
+  Future<> ready_future_;
 };
 
 class CApiCopyToDeviceStream : public CopyToDeviceStream {

--- a/xla/pjrt/c_api_client/pjrt_c_api_client.h
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.h
@@ -434,6 +434,8 @@ class PjRtCApiClient : public PjRtClient {
       absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
           definition_device_events) override;
 
+  absl::StatusOr<std::unique_ptr<PjRtDeviceEvent>> CreateDeviceEvent() override;
+
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> CreateErrorBuffer(
       absl::Status error, const Shape& shape, PjRtMemorySpace* memory) override;
 

--- a/xla/pjrt/common_pjrt_client.h
+++ b/xla/pjrt/common_pjrt_client.h
@@ -140,15 +140,6 @@ class CommonPjRtClient : public PjRtClient {
     return absl::UnimplementedError("LinearizeInto is not supported");
   }
 
-  // Defines a pjrt buffer from a shape, raw_buffer and definition events.
-  virtual absl::StatusOr<std::unique_ptr<PjRtBuffer>> DefineBuffer(
-      const Shape& on_device_shape, PjRtMemorySpace* memory_space,
-      tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
-      absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
-          definition_device_events) {
-    return absl::UnimplementedError("DefineBuffer is not supported");
-  }
-
   // When calling APIs that take extra debug information, we may want
   // to omit this debug information if it is not going to be used.
   virtual bool event_tracking_enabled() { return false; }

--- a/xla/pjrt/cpu/cpu_client.cc
+++ b/xla/pjrt/cpu/cpu_client.cc
@@ -1043,9 +1043,18 @@ std::unique_ptr<PjRtDeviceEventSet> PjRtCpuClient::CreateDeviceEventSet(
 
 absl::StatusOr<std::unique_ptr<PjRtBuffer>> PjRtCpuClient::DefineBuffer(
     const Shape& on_device_shape, PjRtMemorySpace* memory_space,
-    tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
+    tsl::RCReference<PjRtRawBuffer> raw_buffer,
     absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
         definition_device_events) {
+  auto* common_raw_buffer_ptr =
+      dynamic_cast<CommonPjRtRawBuffer*>(raw_buffer.get());
+  if (common_raw_buffer_ptr == nullptr) {
+    return absl::InvalidArgumentError(
+        "PjRtCpuClient::DefineBuffer requires a CommonPjRtRawBuffer.");
+  }
+  tsl::RCReference<CommonPjRtRawBuffer> common_raw_buffer =
+      tsl::FormRef(common_raw_buffer_ptr);
+
   if (raw_buffer && raw_buffer->memory_space() != memory_space) {
     return absl::InvalidArgumentError(
         absl::StrFormat("DefineBuffer: Mismatch in memory spaces: %s vs %s",
@@ -1055,7 +1064,7 @@ absl::StatusOr<std::unique_ptr<PjRtBuffer>> PjRtCpuClient::DefineBuffer(
   return std::unique_ptr<PjRtBuffer>(std::make_unique<CommonPjRtBufferImpl>(
       on_device_shape,
       std::make_unique<TrackedCpuDeviceBuffer>(
-          std::move(raw_buffer),
+          std::move(common_raw_buffer),
           CpuTrackedDeviceEvent::AfterAll(definition_device_events)),
       memory_space));
 }

--- a/xla/pjrt/cpu/cpu_client.h
+++ b/xla/pjrt/cpu/cpu_client.h
@@ -242,7 +242,7 @@ class PjRtCpuClient final : public CommonPjRtClient {
 
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> DefineBuffer(
       const Shape& on_device_shape, PjRtMemorySpace* memory_space,
-      tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
+      tsl::RCReference<PjRtRawBuffer> raw_buffer,
       absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
           definition_device_events) override;
 

--- a/xla/pjrt/pjrt_client.h
+++ b/xla/pjrt/pjrt_client.h
@@ -45,6 +45,7 @@ limitations under the License.
 #include "xla/hlo/builder/xla_computation.h"
 #include "xla/layout.h"
 #include "xla/literal.h"
+#include "xla/pjrt/device_event.h"
 #include "xla/pjrt/distributed/coordination/coordination_service.pb.h"
 #include "xla/pjrt/distributed/key_value_store_interface.h"
 #include "xla/pjrt/host_memory_allocator.h"
@@ -55,6 +56,7 @@ limitations under the License.
 #include "xla/pjrt/pjrt_device_description.h"
 #include "xla/pjrt/pjrt_executable.h"
 #include "xla/pjrt/pjrt_layout.h"
+#include "xla/pjrt/raw_buffer.h"
 #include "xla/pjrt/scoped_async_tracking_event.h"
 #include "xla/service/computation_placer.h"
 #include "xla/service/hlo_cost_analysis.h"
@@ -708,6 +710,15 @@ class PjRtClient {
       std::pair<std::unique_ptr<PjRtBuffer>, PjRtFulfillAliasBufferCallback>>
   CreateAliasBuffer(const Shape& shape, PjRtMemorySpace* memory_space) {
     return absl::UnimplementedError("CreateAliasBuffer is not supported.");
+  }
+
+  // Defines a pjrt buffer from a shape, raw_buffer and definition events.
+  virtual absl::StatusOr<std::unique_ptr<PjRtBuffer>> DefineBuffer(
+      const Shape& shape, PjRtMemorySpace* memory_space,
+      tsl::RCReference<PjRtRawBuffer> raw_buffer,
+      absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
+          definition_device_events) {
+    return absl::UnimplementedError("DefineBuffer is not supported");
   }
 
   // Creates buffer in the given memory space that carries an error future

--- a/xla/pjrt/pjrt_client.h
+++ b/xla/pjrt/pjrt_client.h
@@ -712,13 +712,18 @@ class PjRtClient {
     return absl::UnimplementedError("CreateAliasBuffer is not supported.");
   }
 
+  // Creates a PjRtDeviceEvent which can be passed into DefineBuffer.
+  virtual absl::StatusOr<std::unique_ptr<PjRtDeviceEvent>> CreateDeviceEvent() {
+    return absl::UnimplementedError("CreateDeviceEvent is not supported.");
+  }
+
   // Defines a pjrt buffer from a shape, raw_buffer and definition events.
   virtual absl::StatusOr<std::unique_ptr<PjRtBuffer>> DefineBuffer(
       const Shape& shape, PjRtMemorySpace* memory_space,
       tsl::RCReference<PjRtRawBuffer> raw_buffer,
       absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
           definition_device_events) {
-    return absl::UnimplementedError("DefineBuffer is not supported");
+    return absl::UnimplementedError("DefineBuffer is not supported.");
   }
 
   // Creates buffer in the given memory space that carries an error future

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -595,6 +595,12 @@ PjRtStreamExecutorClient::DefineBuffer(
   return py_buffer;
 }
 
+absl::StatusOr<std::unique_ptr<PjRtDeviceEvent>>
+PjRtStreamExecutorClient::CreateDeviceEvent() {
+  return std::make_unique<PjRtStreamExecutorDeviceEvent>(
+      BufferSequencingEvent::Create(async_work_runner()));
+}
+
 absl::StatusOr<std::pair<tsl::RCReference<CommonPjRtRawBuffer>,
                          CommonPjRtClient::PjRtFulfillAliasRawBufferCallback>>
 PjRtStreamExecutorClient::CreateRawBufferChannel(PjRtMemorySpace* memory_space,

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -558,13 +558,23 @@ PjRtStreamExecutorClient::AllocateRawBufferForExecute(
 absl::StatusOr<std::unique_ptr<PjRtBuffer>>
 PjRtStreamExecutorClient::DefineBuffer(
     const Shape& on_device_shape, PjRtMemorySpace* memory_space,
-    tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
+    tsl::RCReference<PjRtRawBuffer> raw_buffer,
     absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
         definition_device_events) {
-  if (raw_buffer && raw_buffer->memory_space() != memory_space) {
+  auto* common_raw_buffer_ptr =
+      dynamic_cast<CommonPjRtRawBuffer*>(raw_buffer.get());
+  if (common_raw_buffer_ptr == nullptr) {
+    return absl::InvalidArgumentError(
+        "PjRtStreamExecutorClient::DefineBuffer requires a "
+        "CommonPjRtRawBuffer.");
+  }
+  tsl::RCReference<CommonPjRtRawBuffer> common_raw_buffer =
+      tsl::FormRef(common_raw_buffer_ptr);
+
+  if (common_raw_buffer && common_raw_buffer->memory_space() != memory_space) {
     return absl::InvalidArgumentError(
         absl::StrFormat("DefineBuffer: Mismatch in memory spaces: %s vs %s",
-                        raw_buffer->memory_space()->DebugString(),
+                        common_raw_buffer->memory_space()->DebugString(),
                         memory_space->DebugString()));
   }
   absl::InlinedVector<BufferSequencingEventRef, 2> definition_events;
@@ -578,7 +588,7 @@ PjRtStreamExecutorClient::DefineBuffer(
       memory_space->devices()[0]);
 
   auto dst_device_buffer = std::make_unique<TrackedDeviceBuffer>(
-      device, std::move(raw_buffer), definition_events);
+      device, std::move(common_raw_buffer), definition_events);
 
   auto py_buffer = std::make_unique<CommonPjRtBufferImpl>(
       on_device_shape, std::move(dst_device_buffer), memory_space);

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -408,6 +408,8 @@ class PjRtStreamExecutorClient : public CommonPjRtClient {
                               size_t on_device_bytes_count,
                               bool retry_on_oom) override;
 
+  absl::StatusOr<std::unique_ptr<PjRtDeviceEvent>> CreateDeviceEvent() override;
+
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> DefineBuffer(
       const Shape& on_device_shape, PjRtMemorySpace* memory_space,
       tsl::RCReference<PjRtRawBuffer> raw_buffer,

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -57,6 +57,7 @@ limitations under the License.
 #include "xla/pjrt/pjrt_compiler.h"
 #include "xla/pjrt/pjrt_executable.h"
 #include "xla/pjrt/pjrt_stream_executor_device_description.h"
+#include "xla/pjrt/raw_buffer.h"
 #include "xla/pjrt/tracked_device_buffer.h"
 #include "xla/pjrt/transpose.h"
 #include "xla/pjrt/utils.h"
@@ -409,7 +410,7 @@ class PjRtStreamExecutorClient : public CommonPjRtClient {
 
   absl::StatusOr<std::unique_ptr<PjRtBuffer>> DefineBuffer(
       const Shape& on_device_shape, PjRtMemorySpace* memory_space,
-      tsl::RCReference<CommonPjRtRawBuffer> raw_buffer,
+      tsl::RCReference<PjRtRawBuffer> raw_buffer,
       absl::InlinedVector<tsl::RCReference<PjRtDeviceEvent>, 4>
           definition_device_events) override;
 

--- a/xla/pjrt/raw_buffer.cc
+++ b/xla/pjrt/raw_buffer.cc
@@ -26,7 +26,6 @@ limitations under the License.
 #include "xla/future.h"
 #include "xla/pjrt/async_work_runner.h"
 #include "xla/pjrt/device_event.h"
-#include "xla/pjrt/pjrt_client.h"
 #include "xla/shape.h"
 #include "xla/tsl/concurrency/async_value.h"
 #include "xla/tsl/concurrency/async_value_ref.h"
@@ -43,8 +42,8 @@ std::vector<RegisterRawBufferFactory::FactoryFuncT>& GetFactoryFuncs() {
 absl::StatusOr<tsl::RCReference<CommonPjRtRawBuffer>>
 CommonPjRtRawBuffer::RemoveDynamicShapeMetadataIfPresent(
     const xla::Shape& logical_shape) {
-  return absl::InvalidArgumentError(absl::StrCat(
-      "Dynamic shapes are not supported for ", memory_space()->DebugString()));
+  return absl::InvalidArgumentError(
+      "Dynamic shapes are not supported for current memory space.");
 }
 
 absl::StatusOr<tsl::RCReference<CommonPjRtRawBuffer>>
@@ -55,8 +54,8 @@ CommonPjRtRawBuffer::Slice(int64_t offset, int64_t size) {
 
 absl::StatusOr<std::vector<tsl::RCReference<CommonPjRtRawBuffer>>>
 CommonPjRtRawBuffer::MultiSlice(absl::Span<const SliceInfo> slices) {
-  return absl::UnimplementedError(absl::StrCat("Slicing is not supported for ",
-                                               memory_space()->DebugString()));
+  return absl::UnimplementedError(
+      "Slicing is not supported for current memory_space.");
 }
 
 void CommonPjRtRawBuffer::ScheduleCopyTo(
@@ -105,9 +104,7 @@ PjRtRawBuffer::CreateRawAliasOfBuffer(PjRtBuffer* buffer) {
   if (buffer == nullptr) {
     return absl::InvalidArgumentError("Cannot create view of null buffer.");
   }
-  return absl::UnimplementedError(
-      absl::StrCat("CreateRawAliasOfBuffer not implemented for: ",
-                   buffer->client()->platform_version()));
+  return absl::UnimplementedError("CreateRawAliasOfBuffer not implemented.");
 }
 
 RegisterRawBufferFactory::RegisterRawBufferFactory(


### PR DESCRIPTION
📝 Summary of Changes / 🎯 Justification

We would like to add the capability to perform cross-host data transfers into preallocated receive buffers. This is important for improving comm/compute overlap, because the current implementation allocates receive buffers when a data transfer is requested, and memory allocation on GPUs blocks on the compute stream (see [this GitHub discussion](https://github.com/jax-ml/jax/discussions/36003)). This draft PR that is a first step at adding new methods to the PJRT C/C++ APIs to enable this, and has been opened for discussion with @pschuh and @emilyfertig.

More specifically, this PR:
- Adds a `PJRT_DeviceEvent` struct to the PJRT C API, which corresponds to `PjRtDeviceEvent` in the C++ API.
- Adds methods `PJRT_DeviceEvent_Create` / `xla::PjRtClient::CreateDeviceEvent`, `PJRT_DeviceEvent_Destroy`, `PJRT_DeviceEvent_GetPJRTEvent` (converts the `DeviceEvent` into a `PJRT_Event` that the host can wait on).
- Changes the function signature of `CommonPjRtClient::DefineBuffer` and moves it into `xla::PjRtClient`.
- Modifies the implementation of `DefineBuffer` in `CommonPjRtClient` and `StreamExecutorGpuClient` to conform with the new signature.
- Adds new PjRt methods `DefineBuffer` (C++) and `PJRT_Client_DefineBuffer` (C). The implementation of `DefineBuffer` has been placed inside the existing `pjrt_c_api_raw_buffer_extension` files.

Two basic tests have been added to `pjrt_c_api_gpu_test.cc`:
- `CreateAndDestroyDeviceEvent`: Checks if we can create and destroy a `PJRT_DeviceEvent` without any errors.
- `DefineBuffer`: Checks if we can call `PJRT_Client_DefineBuffer` without any errors.
If the general approach of this PR is in-line with the PJRT C API changes proposed by @pschuh, I will refine this PR + add more tests before removing its 'draft' status.

🚀 Kind of Contribution: ✨ New Feature

🧪 Unit Tests:

In `pjrt_c_api_gpu_test.cc`:
- `CreateAndDestroyDeviceEvent`: Checks if we can create and destroy a `PJRT_DeviceEvent` without any errors.
- `DefineBuffer`: Checks if we can call `PJRT_Client_DefineBuffer` without any errors.