### PR TITLE
[xla:gpu] Fix UndefinedBehaviorSanitizer for thunk_executor test

### DIFF
--- a/xla/backends/gpu/runtime/thunk_executor_test.cc
+++ b/xla/backends/gpu/runtime/thunk_executor_test.cc
@@ -199,7 +199,6 @@ TEST(SequentialThunkProgressTrackerTest, TrackWhileLoopNest) {
       std::move(body_thunks), /*trip_count=*/kTripCount));
 
   ThunkExecutor executor(std::move(outer_sequence));
-  ASSERT_OK(executor.Prepare(Thunk::PrepareParams()));
   ASSERT_OK_AND_ASSIGN(ThunkExecutor::ScopedProgressTracker tracker,
                        InstallProgressTracker(stream_executor, executor));
 


### PR DESCRIPTION
Don't pass default constructed params marked as absl_nonnull, we don't need prepare state anyway in this test.