### PR TITLE
[Nvidia GPU] Do aliasing only when collective permute is in-place

### DIFF
--- a/xla/hlo/analysis/alias_info.cc
+++ b/xla/hlo/analysis/alias_info.cc
@@ -185,16 +185,21 @@ AliasInfo::GetInPlaceInputOutputPairs(const HloInstruction* user) const {
   }
   if (user->opcode() == HloOpcode::kCollectivePermuteStart &&
       user->operands().size() == 4) {
-    if (user->operand(1)->shape().IsTuple()) {
-      std::vector<std::pair<HloOperandIndex, ShapeIndex>> in_place_pairs(
-          {{HloOperandIndex{1, {}}, {1}}});
-      for (int i = 0; i < user->operand(1)->shape().tuple_shapes().size();
-           i++) {
-        in_place_pairs.push_back({HloOperandIndex{1, {i}}, {1, i}});
+    auto cp = Cast<HloCollectivePermuteInstruction>(user);
+    if (cp->inplace()) {
+      if (user->operand(1)->shape().IsTuple()) {
+        std::vector<std::pair<HloOperandIndex, ShapeIndex>> in_place_pairs(
+            {{HloOperandIndex{1, {}}, {1}}});
+        for (int i = 0; i < user->operand(1)->shape().tuple_shapes().size();
+             i++) {
+          in_place_pairs.push_back({HloOperandIndex{1, {i}}, {1, i}});
+        }
+        return in_place_pairs;
       }
-      return in_place_pairs;
+      return {{HloOperandIndex{1, {}}, {1}}};
+    } else {
+      return {};
     }
-    return {{HloOperandIndex{1, {}}, {1}}};
   }
   if (user->opcode() == HloOpcode::kCustomCall) {
     // Custom Calls previously assumed that aliased operands were

--- a/xla/hlo/analysis/hlo_dataflow_analysis_test.cc
+++ b/xla/hlo/analysis/hlo_dataflow_analysis_test.cc
@@ -3713,5 +3713,29 @@ TEST_F(GetInPlaceInputOutputPairsTest, nvshmem_ar) {
   EXPECT_EQ(in_place_pairs, expected_pairs);
 }
 
+TEST_F(GetInPlaceInputOutputPairsTest, CombinedCollectivePermute) {
+  const char* kModule = R"(
+    HloModule test_cp
+    ENTRY test {
+      p0 = f32[2,128]{1,0} parameter(0)
+      p1 = f32[2,128]{1,0} parameter(1)
+      p2 = f32[2,128]{1,0} parameter(2)
+      p3 = f32[2,128]{1,0} parameter(3)
+      collective-permute-start.0 = ((f32[2,128]{1,0}, f32[2,128]{1,0}, f32[2,128]{1,0}, f32[2,128]{1,0}), (f32[2,128]{1,0}, f32[2,128]{1,0}, f32[2,128]{1,0}, f32[2,128]{1,0})) collective-permute-start(p0, p1, p2, p3), channel_id=0, source_target_pairs={{0,2},{2,4},{1,3},{3,5}}, backend_config={"operation_queue_id":"0","wait_on_operation_queues":[],"collective_backend_config":{"is_sync":false,"is_pipelined":false,"backend":"DEFAULT"},"force_earliest_schedule":false,"reification_cost":[],"device_type":"DEVICE_TYPE_INVALID"}
+      ROOT collective-permute-done.0 = (f32[2,128]{1,0}, f32[2,128]{1,0}, f32[2,128]{1,0}, f32[2,128]{1,0}) collective-permute-done(collective-permute-start.0)
+ 
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kModule));
+  const HloInstruction* ar_start =
+      module->entry_computation()->root_instruction()->operand(0);
+
+  auto in_place_pairs = alias_info_.GetInPlaceInputOutputPairs(ar_start);
+  std::vector<std::pair<HloOperandIndex, ShapeIndex>> expected_pairs;
+  // We expect no aliasing for input and output buffers
+  // therefore empty inplace pairs.
+  EXPECT_EQ(in_place_pairs, expected_pairs);
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
alias analysis currently treats cp as in-place when the number of operands is 4 which is not correct as we can have combined cp that have 4 inputs but are not in-place.
This pr only considers cp as in place when the inplace property is true.
