### PR TITLE
[XLA:GPU] [oneAPI] Use symlinks to preserve RUNPATHS

### DIFF
--- a/xla/codegen/emitters/tests/BUILD
+++ b/xla/codegen/emitters/tests/BUILD
@@ -16,6 +16,7 @@ copy_file(
     testonly = True,
     src = "//xla/backends/cpu/codegen/tools:fusion_to_mlir",
     out = "cpu_fusion_to_mlir",
+    allow_symlink = True,
     is_executable = True,
 )
 
@@ -24,6 +25,7 @@ copy_file(
     testonly = True,
     src = "//xla/backends/gpu/codegen/tools:fusion_to_mlir",
     out = "gpu_fusion_to_mlir",
+    allow_symlink = True,
     is_executable = True,
 )
 


### PR DESCRIPTION
Update copy_file in emitters/test to create symlink instead of copying. Using copy results in the copied executable not finding the shared libraries in rpaths at runtime. (e.g., with oneAPI build, //xla/codegen/emitters/tests:dynamic_update_slice/vectorize_x1_too_small.hlo.test, fails with error "gpu_fusion_to_mlir: error while loading shared libraries: libumf.so.0: cannot open shared object file."