### PR TITLE
[ROCm] bump up ROCm CI to rocm7.2.1  

### DIFF
--- a/.github/workflows/rocm_jax_ut.yml
+++ b/.github/workflows/rocm_jax_ut.yml
@@ -35,9 +35,11 @@ jobs:
     name: JAX Linux x86 AMD Instinct GPU
     runs-on: linux-x86-64-8gpu-amd
     env:
-      DOCKER_IMAGE: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+      # rocm/tensorflow-build:latest-jammy-pythonall-rocm7.2.1-ci_official
+      DOCKER_IMAGE: rocm/tensorflow-build@sha256:66eb4c1e39db76fae2eb0a1029490acbe7bfce0e00d6ab435e170f743921f4c4
     container:
-      image: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+      # rocm/tensorflow-build:latest-jammy-pythonall-rocm7.2.1-ci_official
+      image: rocm/tensorflow-build@sha256:66eb4c1e39db76fae2eb0a1029490acbe7bfce0e00d6ab435e170f743921f4c4
       volumes:
         - /data/ci-cert.crt:/data/ci-cert.crt
         - /data/ci-cert.key:/data/ci-cert.key

--- a/.github/workflows/rocm_xla_ci.yml
+++ b/.github/workflows/rocm_xla_ci.yml
@@ -31,7 +31,8 @@ jobs:
   execute-xla-ut:
     runs-on: linux-x64-mi210-64-2gpu-amd
     env:
-      DOCKER_IMAGE: rocm/tensorflow-build@sha256:7fcfbd36b7ac8f6b0805b37c4248e929e31cf5ee3af766c8409dd70d5ab65faa
+      # rocm/tensorflow-build:latest-jammy-pythonall-rocm7.2.1-ci_official
+      DOCKER_IMAGE: rocm/tensorflow-build@sha256:66eb4c1e39db76fae2eb0a1029490acbe7bfce0e00d6ab435e170f743921f4c4
       CONTAINER_NAME: xla-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       # Pre-clean up in case a previous run crashed


### PR DESCRIPTION
📝 Summary of Changes
Bump up ROCm CI docker image to rocm7.2.1 for JAX and XLA

🎯 Justification
there is a ROCr issuess on ROCm 7.2.0 to cause segfault when the command buffer is ON


🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix 


🧪 Unit Tests:
CI ROCm JAX / JAX Linux x86 AMD Instinct GPU will be green.
 
