### PR TITLE
[xla:gpu] Allow passing extra compute/comm streams to FFI

### DIFF
--- a/xla/backends/gpu/ffi.h
+++ b/xla/backends/gpu/ffi.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_FFI_H_
 #define XLA_BACKENDS_GPU_FFI_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 
@@ -28,7 +29,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/c_api_internal.h"  // IWYU pragma: keep
-#include "xla/ffi/ffi.h"  // IWYU pragma: export
+#include "xla/ffi/ffi.h"                 // IWYU pragma: export
 #include "xla/stream_executor/device_address_allocator.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/scratch_allocator.h"
@@ -52,7 +53,13 @@ struct CollectiveMemory {};            //  const xla::gpu::CollectiveMemory*
 struct TargetGpuComputeCapability {};  //  const se::GpuComputeCapability*
 struct CpuTargetMachineOptions {};     //  const xla::cpu::TargetMachineOptions*
 
-// Parametrized type tag for platform stream, e.g. cudaStream_t
+// Parametrized type tags for binding additional streams (binds as se::Stream*).
+template <size_t id>
+struct ComputationStream {};
+template <size_t id>
+struct CommunicationStream {};
+
+// Parametrized type tag for platform stream (binds as T, e.g. cudaStream_t).
 template <typename T>
 struct PlatformStream {};
 
@@ -86,6 +93,48 @@ struct CtxDecoding<PlatformStream<T>> {
           stream.value()->platform_specific_handle().stream);
     }
     return std::nullopt;
+  }
+};
+
+template <size_t id>
+struct CtxDecoding<ComputationStream<id>> {
+  using Type = stream_executor::Stream*;
+
+  static std::optional<Type> Decode(const XLA_FFI_Api* api,
+                                    XLA_FFI_ExecutionContext* ctx,
+                                    DiagnosticEngine& diagnostic) {
+    void* result = nullptr;
+    if (XLA_FFI_Error* error =
+            api->internal_api->XLA_FFI_INTERNAL_ComputationStream_Get(
+                ctx, static_cast<int64_t>(id), &result);
+        ABSL_PREDICT_FALSE(error)) {
+      diagnostic.Emit("Failed to get computation stream: ")
+          << internal::GetErrorMessage(api, error);
+      internal::DestroyError(api, error);
+      return std::nullopt;
+    }
+    return reinterpret_cast<Type>(result);
+  }
+};
+
+template <size_t id>
+struct CtxDecoding<CommunicationStream<id>> {
+  using Type = stream_executor::Stream*;
+
+  static std::optional<Type> Decode(const XLA_FFI_Api* api,
+                                    XLA_FFI_ExecutionContext* ctx,
+                                    DiagnosticEngine& diagnostic) {
+    void* result = nullptr;
+    if (XLA_FFI_Error* error =
+            api->internal_api->XLA_FFI_INTERNAL_CommunicationStream_Get(
+                ctx, static_cast<int64_t>(id), &result);
+        ABSL_PREDICT_FALSE(error)) {
+      diagnostic.Emit("Failed to get communication stream: ")
+          << internal::GetErrorMessage(api, error);
+      internal::DestroyError(api, error);
+      return std::nullopt;
+    }
+    return reinterpret_cast<Type>(result);
   }
 };
 

--- a/xla/backends/gpu/runtime/custom_call_thunk.cc
+++ b/xla/backends/gpu/runtime/custom_call_thunk.cc
@@ -65,11 +65,11 @@ limitations under the License.
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
 #include "tsl/platform/platform.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -462,7 +462,8 @@ InvokeContext CustomCallThunk::BuildInvokeContext(
     CollectiveMemoryRequests* absl_nullable collective_memory_requests,
     const CollectiveCliques* absl_nullable collective_cliques,
     const CollectiveMemory* absl_nullable collective_memory,
-    const ffi::ExecutionContext* absl_nullable execution_context) {
+    const ffi::ExecutionContext* absl_nullable execution_context,
+    absl::Span<se::Stream* const> computation_streams) {
   int32_t device_ordinal = -1;
   se::DeviceAddressAllocator* allocator = nullptr;
   if (buffer_allocations != nullptr) {
@@ -496,8 +497,10 @@ InvokeContext CustomCallThunk::BuildInvokeContext(
           stream, allocator, collective_params, collective_clique_requests,
           collective_memory_requests, collective_cliques, collective_memory,
           gpu_compute_capability,
-          cpu_target_machine_options_ ? &*cpu_target_machine_options_
-                                      : nullptr},
+          cpu_target_machine_options_ ? &*cpu_target_machine_options_ : nullptr,
+          computation_streams,
+          collective_params ? absl::MakeSpan(collective_params->async_streams)
+                            : absl::Span<se::Stream* const>()},
       InvokeContext::StateContext{execution_state_.get(), prepare_state,
                                   initialize_state},
       called_computation_,
@@ -513,7 +516,8 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
     CollectiveCliqueRequests* absl_nullable collective_clique_requests,
     CollectiveMemoryRequests* absl_nullable collective_memory_requests,
     const CollectiveCliques* absl_nullable collective_cliques,
-    const CollectiveMemory* absl_nullable collective_memory) {
+    const CollectiveMemory* absl_nullable collective_memory,
+    absl::Span<se::Stream* const> computation_streams) {
   if (handler == nullptr) {
     return absl::InternalError("FFI execute handler is not set");
   }
@@ -526,7 +530,8 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
   InvokeContext context = BuildInvokeContext(
       run_id, stream, execution_scoped_state, buffer_allocations,
       collective_params, collective_clique_requests, collective_memory_requests,
-      collective_cliques, collective_memory, execution_context);
+      collective_cliques, collective_memory, execution_context,
+      computation_streams);
   return Invoke(ffi::GetXlaFfiApi(), handler, *call_frame, context, stage);
 }
 
@@ -539,7 +544,8 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
     CollectiveCliqueRequests* absl_nullable collective_clique_requests,
     CollectiveMemoryRequests* absl_nullable collective_memory_requests,
     const CollectiveCliques* absl_nullable collective_cliques,
-    const CollectiveMemory* absl_nullable collective_memory) {
+    const CollectiveMemory* absl_nullable collective_memory,
+    absl::Span<se::Stream* const> computation_streams) {
   if (stage != xla::ffi::ExecutionStage::kPrepare &&
       !(buffer_allocations && stream)) {
     return absl::InternalError("buffer allocations and stream are required");
@@ -549,7 +555,8 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
   InvokeContext context = BuildInvokeContext(
       run_id, stream, execution_scoped_state, buffer_allocations,
       collective_params, collective_clique_requests, collective_memory_requests,
-      collective_cliques, collective_memory, execution_context);
+      collective_cliques, collective_memory, execution_context,
+      computation_streams);
   return Invoke(ffi::GetXlaFfiApi(), handler, *call_frame, context, stage);
 }
 
@@ -571,7 +578,8 @@ absl::Status CustomCallThunk::Prepare(const PrepareParams& params) {
           /*collective_clique_requests=*/params.collective_clique_requests,
           /*collective_memory_requests=*/params.collective_memory_requests,
           /*collective_cliques=*/nullptr,
-          /*collective_memory=*/nullptr);
+          /*collective_memory=*/nullptr,
+          /*computation_streams=*/{});
     }
     if (const auto* owned_bundle =
             std::get_if<OwnedHandlerBundle>(&bundle_.value());
@@ -586,7 +594,8 @@ absl::Status CustomCallThunk::Prepare(const PrepareParams& params) {
           /*collective_clique_requests=*/params.collective_clique_requests,
           /*collective_memory_requests=*/params.collective_memory_requests,
           /*collective_cliques=*/nullptr,
-          /*collective_memory=*/nullptr);
+          /*collective_memory=*/nullptr,
+          /*computation_streams=*/{});
     }
   }
 
@@ -608,7 +617,8 @@ absl::Status CustomCallThunk::Initialize(const InitializeParams& params) {
           params.collective_params,
           /*collective_clique_requests=*/nullptr,
           /*collective_memory_requests=*/nullptr, params.collective_cliques,
-          params.collective_memory);
+          params.collective_memory,
+          /*computation_streams=*/{});
     }
     if (const auto* owned_bundle =
             std::get_if<OwnedHandlerBundle>(&bundle_.value());
@@ -620,7 +630,8 @@ absl::Status CustomCallThunk::Initialize(const InitializeParams& params) {
           params.buffer_allocations, params.collective_params,
           /*collective_clique_requests=*/nullptr,
           /*collective_memory_requests=*/nullptr, params.collective_cliques,
-          params.collective_memory);
+          params.collective_memory,
+          /*computation_streams=*/{});
     }
   }
   return absl::OkStatus();
@@ -641,7 +652,7 @@ absl::Status CustomCallThunk::ExecuteOnStream(const ExecuteParams& params) {
           params.buffer_allocations, params.collective_params,
           /*collective_clique_requests=*/nullptr,
           /*collective_memory_requests=*/nullptr, params.collective_cliques,
-          params.collective_memory);
+          params.collective_memory, params.additional_compute_streams);
     }
     if (const auto* owned_bundle =
             std::get_if<OwnedHandlerBundle>(&bundle_.value());
@@ -655,7 +666,7 @@ absl::Status CustomCallThunk::ExecuteOnStream(const ExecuteParams& params) {
           params.buffer_allocations, params.collective_params,
           /*collective_clique_requests=*/nullptr,
           /*collective_memory_requests=*/nullptr, params.collective_cliques,
-          params.collective_memory);
+          params.collective_memory, params.additional_compute_streams);
     }
   }
 
@@ -758,7 +769,7 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CustomCallThunk::FromProto(
     } else {
       LOG(WARNING)
           << "Failed to deserialize the custom call execution state. Falling "
-             "back to runtime instantiaton of the execution state. Reason: "
+             "back to runtime instantiation of the execution state. Reason: "
           << state.status();
     }
   }

--- a/xla/backends/gpu/runtime/custom_call_thunk.h
+++ b/xla/backends/gpu/runtime/custom_call_thunk.h
@@ -227,7 +227,8 @@ class CustomCallThunk : public Thunk {
       CollectiveMemoryRequests* absl_nullable collective_memory_requests,
       const CollectiveCliques* absl_nullable collective_cliques,
       const CollectiveMemory* absl_nullable collective_memory,
-      const ffi::ExecutionContext* absl_nullable execution_context);
+      const ffi::ExecutionContext* absl_nullable execution_context,
+      absl::Span<se::Stream* const> computation_streams);
 
   absl::Status ExecuteFfiHandler(
       RunId run_id, XLA_FFI_Handler* handler, XLA_FFI_ExecutionStage stage,
@@ -238,7 +239,8 @@ class CustomCallThunk : public Thunk {
       CollectiveCliqueRequests* absl_nullable collective_clique_requests,
       CollectiveMemoryRequests* absl_nullable collective_memory_requests,
       const CollectiveCliques* absl_nullable collective_cliques,
-      const CollectiveMemory* absl_nullable collective_memory);
+      const CollectiveMemory* absl_nullable collective_memory,
+      absl::Span<se::Stream* const> computation_streams);
 
   absl::Status ExecuteFfiHandler(
       RunId run_id, xla::ffi::Ffi& handler, xla::ffi::ExecutionStage stage,
@@ -249,7 +251,8 @@ class CustomCallThunk : public Thunk {
       CollectiveCliqueRequests* absl_nullable collective_clique_requests,
       CollectiveMemoryRequests* absl_nullable collective_memory_requests,
       const CollectiveCliques* absl_nullable collective_cliques,
-      const CollectiveMemory* absl_nullable collective_memory);
+      const CollectiveMemory* absl_nullable collective_memory,
+      absl::Span<se::Stream* const> computation_streams);
 
   // API version of the custom call. If not set, it means the custom call thunk
   // was initialized from a non-registered function pointer and can't be

--- a/xla/backends/gpu/tests/collective_ops_ffi_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_ffi_test.cc
@@ -205,8 +205,11 @@ static absl::Status PreparePeerAllReduce(
 
 // FFI handler that uses XLA:GPU collectives API to perform an all reduce. This
 // is just a test that demonstrates how to use XLA:GPU collectives API in an FFI
-// handler, builtin all-reduce is a much better option.
-static absl::Status AllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
+// handler, builtin all-reduce is a much better option. This version
+// demonstrates requesting a communication stream and synchronizing it with the
+// main stream.
+static absl::Status AllReduce(se::Stream* stream, se::Stream* comm_stream,
+                              ffi::BufferR0<U32> src,
                               ffi::Result<ffi::BufferR0<U32>> dst,
                               const CollectiveParams* collective_params,
                               const CollectiveCliques* collective_cliques) {
@@ -223,10 +226,22 @@ static absl::Status AllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
                       collective_cliques->GetComm(
                           clique_key, collective_params->global_device_id));
 
-  Future<> future = comm->AllReduce(
-      src.device_memory(), dst->device_memory(), src.element_type(),
-      src.element_count(), ReductionKind::SUM, GpuCollectives::On(*stream));
-  return future.Await();
+  // Synchronize communication stream with the main stream: make the
+  // communication stream wait for all prior work on the main stream.
+  TF_RETURN_IF_ERROR(comm_stream->WaitFor(stream));
+
+  // Launch all-reduce on the communication stream.
+  Future<> future =
+      comm->AllReduce(src.device_memory(), dst->device_memory(),
+                      src.element_type(), src.element_count(),
+                      ReductionKind::SUM, GpuCollectives::On(*comm_stream));
+  TF_RETURN_IF_ERROR(future.Await());
+
+  // Synchronize main stream with the communication stream: make the main
+  // stream wait for the all-reduce to complete.
+  TF_RETURN_IF_ERROR(stream->WaitFor(comm_stream));
+
+  return absl::OkStatus();
 }
 
 // FFI handler that launches device kernel that does all-reduce using NCCL
@@ -446,6 +461,7 @@ XLA_FFI_DEFINE_HANDLER(kPrepareAllReduce, PrepareAllReduce,
 XLA_FFI_DEFINE_HANDLER(kAllReduce, AllReduce,
                        ffi::Ffi::Bind()
                            .Ctx<ffi::Stream>()
+                           .Ctx<ffi::CommunicationStream<0>>()
                            .Arg<ffi::BufferR0<U32>>()  // src
                            .Ret<ffi::BufferR0<U32>>()  // dst
                            .Ctx<ffi::CollectiveParams>()

--- a/xla/ffi/BUILD
+++ b/xla/ffi/BUILD
@@ -187,6 +187,7 @@ cc_library(
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -297,6 +298,7 @@ cc_library(
         "//xla/stream_executor:device_description",
         "//xla/tsl/concurrency:async_value",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/xla/ffi/api/c_api_internal.h
+++ b/xla/ffi/api/c_api_internal.h
@@ -101,6 +101,18 @@ typedef XLA_FFI_Error* XLA_FFI_INTERNAL_IntraOpThreadPool_Get(
 typedef XLA_FFI_Error* XLA_FFI_INTERNAL_Stream_Get(
     XLA_FFI_ExecutionContext* ctx, void** stream);
 
+// Returns a pointer to an additional computation stream (`se::Stream` pointer)
+// identified by the given `id`. These are extra compute streams available for
+// async fusions and async calls.
+typedef XLA_FFI_Error* XLA_FFI_INTERNAL_ComputationStream_Get(
+    XLA_FFI_ExecutionContext* ctx, int64_t id, void** stream);
+
+// Returns a pointer to a communication stream (`se::Stream` pointer) identified
+// by the given `id`. These are streams used for launching asynchronous
+// collective communication operations.
+typedef XLA_FFI_Error* XLA_FFI_INTERNAL_CommunicationStream_Get(
+    XLA_FFI_ExecutionContext* ctx, int64_t id, void** stream);
+
 // Returns a pointer to device memory allocator (`se::DeviceAddressAllocator`
 // pointer) which allows to allocate memory inside a custom call from the same
 // allocator as XLA (i.e. it allows to construct scratch memory allocator).
@@ -170,6 +182,8 @@ struct XLA_FFI_InternalApi {
 
   // XLA:GPU specific APIs.
   _XLA_FFI_INTERNAL_API_STRUCT_FIELD(XLA_FFI_INTERNAL_Stream_Get);
+  _XLA_FFI_INTERNAL_API_STRUCT_FIELD(XLA_FFI_INTERNAL_ComputationStream_Get);
+  _XLA_FFI_INTERNAL_API_STRUCT_FIELD(XLA_FFI_INTERNAL_CommunicationStream_Get);
   _XLA_FFI_INTERNAL_API_STRUCT_FIELD(
       XLA_FFI_INTERNAL_DeviceMemoryAllocator_Get);
   _XLA_FFI_INTERNAL_API_STRUCT_FIELD(XLA_FFI_INTERNAL_CollectiveParams_Get);

--- a/xla/ffi/ffi_internal_api.cc
+++ b/xla/ffi/ffi_internal_api.cc
@@ -139,6 +139,40 @@ static XLA_FFI_Error* XLA_FFI_INTERNAL_Stream_Get(XLA_FFI_ExecutionContext* ctx,
       InvalidArgument("XLA FFI GPU context is not available")};
 }
 
+static XLA_FFI_Error* XLA_FFI_INTERNAL_ComputationStream_Get(
+    XLA_FFI_ExecutionContext* ctx, int64_t id, void** stream) {
+  if (auto* gpu = std::get_if<XLA_FFI_ExecutionContext::GpuContext>(
+          &ctx->backend_context)) {
+    if (id < 0 || id >= gpu->computation_streams.size()) {
+      return new XLA_FFI_Error{
+          InvalidArgument("Computation stream id %d is out of range [0, %d)",
+                          id, gpu->computation_streams.size())};
+    }
+    *stream = gpu->computation_streams[id];
+    return nullptr;
+  }
+
+  return new XLA_FFI_Error{
+      InvalidArgument("XLA FFI GPU context is not available")};
+}
+
+static XLA_FFI_Error* XLA_FFI_INTERNAL_CommunicationStream_Get(
+    XLA_FFI_ExecutionContext* ctx, int64_t id, void** stream) {
+  if (auto* gpu = std::get_if<XLA_FFI_ExecutionContext::GpuContext>(
+          &ctx->backend_context)) {
+    if (id < 0 || id >= gpu->communication_streams.size()) {
+      return new XLA_FFI_Error{
+          InvalidArgument("Communication stream id %d is out of range [0, %d)",
+                          id, gpu->communication_streams.size())};
+    }
+    *stream = gpu->communication_streams[id];
+    return nullptr;
+  }
+
+  return new XLA_FFI_Error{
+      InvalidArgument("XLA FFI GPU context is not available")};
+}
+
 static XLA_FFI_Error* XLA_FFI_INTERNAL_DeviceMemoryAllocator_Get(
     XLA_FFI_ExecutionContext* ctx, void** allocator) {
   if (auto* gpu = std::get_if<XLA_FFI_ExecutionContext::GpuContext>(
@@ -260,6 +294,8 @@ const XLA_FFI_InternalApi* GetInternalApi() {
 
       // XLA:GPU specific APIs.
       XLA_FFI_INTERNAL_Stream_Get,
+      XLA_FFI_INTERNAL_ComputationStream_Get,
+      XLA_FFI_INTERNAL_CommunicationStream_Get,
       XLA_FFI_INTERNAL_DeviceMemoryAllocator_Get,
       XLA_FFI_INTERNAL_CollectiveParams_Get,
       XLA_FFI_INTERNAL_CollectiveCliqueRequests_Get,

--- a/xla/ffi/ffi_structs.h
+++ b/xla/ffi/ffi_structs.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <variant>
 
 #include "absl/status/status.h"
+#include "absl/types/span.h"
 #include "xla/executable_run_options.h"
 #include "xla/ffi/execution_context.h"
 #include "xla/ffi/execution_state.h"
@@ -83,6 +84,8 @@ struct XLA_FFI_ExecutionContext {
     const stream_executor::GpuComputeCapability* gpu_compute_capability =
         nullptr;
     const xla::cpu::TargetMachineOptions* cpu_target_machine_options = nullptr;
+    absl::Span<stream_executor::Stream* const> computation_streams;
+    absl::Span<stream_executor::Stream* const> communication_streams;
   };
 
   using BackendContext = std::variant<std::monostate, CpuContext, GpuContext>;

--- a/xla/ffi/invoke.cc
+++ b/xla/ffi/invoke.cc
@@ -64,6 +64,8 @@ struct BackendVisitor {
         gpu.collective_memory,
         gpu.compute_capability,
         gpu.cpu_target_machine_options,
+        gpu.computation_streams,
+        gpu.communication_streams,
     };
   }
 };

--- a/xla/ffi/invoke.h
+++ b/xla/ffi/invoke.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/types/span.h"
 #include "xla/executable_run_options.h"
 #include "xla/ffi/api/api.h"
 #include "xla/ffi/api/c_api.h"
@@ -87,6 +88,8 @@ struct InvokeContext {
     const gpu::CollectiveMemory* collective_memory = nullptr;
     const stream_executor::GpuComputeCapability* compute_capability = nullptr;
     const xla::cpu::TargetMachineOptions* cpu_target_machine_options = nullptr;
+    absl::Span<stream_executor::Stream* const> computation_streams;
+    absl::Span<stream_executor::Stream* const> communication_streams;
   };
 
   using BackendContext = std::variant<std::monostate, CpuContext, GpuContext>;


### PR DESCRIPTION
Add support for binding additional execution stream ids in XLA:GPU FFI handlers, i.e. it allows to run collectives in FFI handlers on a dedicated collective stream.