### PR TITLE
Cupti range profiling hlo runner

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -283,6 +283,8 @@ cc_library(
         ":cupti_interface",
         ":cupti_marker_data_parser",
         ":cupti_pm_sampler_factory",
+        ":cupti_range_profiler",
+        ":cupti_range_profiler_factory",
         ":cupti_utils",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:errors",
@@ -315,6 +317,87 @@ cc_library(
         "@tsl//tsl/platform:thread_annotations",
         "@tsl//tsl/platform:types",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+cc_library(
+    name = "cupti_range_profiler",
+    hdrs = ["cupti_range_profiler.h"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+cc_library(
+    name = "cupti_range_profiler_stub",
+    hdrs = [
+        "cupti_range_profiler.h",
+        "cupti_range_profiler_stub.h",
+    ],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    deps = [
+        ":cupti_range_profiler",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+cc_library(
+    name = "cupti_range_profiler_factory",
+    srcs = ["cupti_range_profiler_factory.cc"],
+    hdrs = [
+        "cupti_range_profiler.h",
+        "cupti_range_profiler_factory.h",
+    ],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    deps = [
+        ":cupti_range_profiler",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_cuda//cuda:cupti_headers",
+    ] + if_cuda_newer_than(
+        "12_6",
+        [":cupti_range_profiler_impl"],
+        [":cupti_range_profiler_stub"],
+    ),
+)
+
+cc_library(
+    name = "cupti_range_profiler_impl",
+    srcs = ["cupti_range_profiler_impl.cc"],
+    hdrs = [
+        "cupti_range_profiler.h",
+        "cupti_range_profiler_impl.h",
+    ],
+    tags = [
+        "cuda-only",
+        "gpu",
+        "manual",  # Requires CUDA 12.6+ (CUPTI Range Profiling API).
+    ],
+    deps = [
+        ":cupti_interface",
+        ":cupti_range_profiler",
+        ":cupti_status",
+        ":cupti_utils",
+        "//xla/stream_executor/cuda:cuda_status",
+        "//xla/tsl/platform:errors",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@local_config_cuda//cuda:cupti_headers",
     ],
 )
 
@@ -882,6 +965,8 @@ xla_test(
         ":cupti_collector",
         ":cupti_error_manager",
         ":cupti_pm_sampler_factory",  # buildcleaner: keep
+        ":cupti_range_profiler",
+        ":cupti_range_profiler_factory",  # buildcleaner: keep
         ":cupti_tracer",
         ":cupti_utils",
         ":cupti_wrapper",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -722,6 +722,7 @@ cc_library(
         ":cupti_buffer_events",
         ":cupti_interface",
         ":cupti_pm_sampler_utils",
+        ":cupti_range_profiler",
         "//xla/tsl/cuda",
         "//xla/tsl/cuda:cupti",
         "//xla/tsl/profiler/utils:lock_free_queue",

--- a/xla/backends/profiler/gpu/cupti_collector.cc
+++ b/xla/backends/profiler/gpu/cupti_collector.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
@@ -45,6 +46,7 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cuda_occupancy.h"
 #include "xla/backends/profiler/gpu/cupti_buffer_events.h"
 #include "xla/backends/profiler/gpu/cupti_pm_sampler_utils.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
 #include "xla/tsl/profiler/utils/math_utils.h"
 #include "xla/tsl/profiler/utils/parse_annotation.h"
 #include "xla/tsl/profiler/utils/timespan.h"
@@ -78,6 +80,48 @@ using tsl::profiler::StatType;
 using tsl::profiler::XEventBuilder;
 using tsl::profiler::XLineBuilder;
 using tsl::profiler::XPlaneBuilder;
+
+// Maps a CUPTI metric name prefix to a human-readable hardware unit category
+// for the perf_counters tool "Set" column.
+std::string GetRangeMetricCategory(absl::string_view metric_name) {
+  if (absl::StartsWith(metric_name, "sm__") ||
+      absl::StartsWith(metric_name, "smsp__")) {
+    return "Streaming Multiprocessor";
+  }
+  if (absl::StartsWith(metric_name, "dram__")) {
+    return "DRAM";
+  }
+  if (absl::StartsWith(metric_name, "dramc__")) {
+    return "DRAM Controller";
+  }
+  if (absl::StartsWith(metric_name, "fbpa__")) {
+    return "Frame Buffer Partition";
+  }
+  if (absl::StartsWith(metric_name, "nvl") ||
+      absl::StartsWith(metric_name, "nvltx__") ||
+      absl::StartsWith(metric_name, "nvlrx__")) {
+    return "NVLink";
+  }
+  if (absl::StartsWith(metric_name, "pcie__")) {
+    return "PCIe";
+  }
+  if (absl::StartsWith(metric_name, "gpc__")) {
+    return "GPC";
+  }
+  if (absl::StartsWith(metric_name, "gr__")) {
+    return "Graphics Engine";
+  }
+  if (absl::StartsWith(metric_name, "sys__")) {
+    return "System";
+  }
+  if (absl::StartsWith(metric_name, "l1tex__")) {
+    return "L1/TEX Cache";
+  }
+  if (absl::StartsWith(metric_name, "lts__")) {
+    return "L2 Cache";
+  }
+  return "GPU";
+}
 
 bool IsNvtxActivityEvent(const CuptiTracerEvent& event) {
   return event.source == CuptiTracerEventSource::Activity &&
@@ -719,6 +763,74 @@ const std::vector<SamplerRange>& PmSamples::GetSamplerRanges() const {
 }
 
 int64_t PmSamples::GetDeviceId() const { return device_id_; }
+
+void PopulateRangeProfilingEvents(const RangeProfilerResults* results,
+                                  XPlaneBuilder* plane) {
+  if (!results) return;
+
+  const auto& metrics = results->GetMetrics();
+  const auto& ranges = results->GetRanges();
+  const auto& metric_props = results->GetMetricProperties();
+
+  // Pre-create stat metadata for the three perf_counters stat types.
+  XStatMetadata* counter_value_stat = plane->GetOrCreateStatMetadata(
+      tsl::profiler::GetStatTypeStr(StatType::kCounterValue));
+  XStatMetadata* description_stat = plane->GetOrCreateStatMetadata(
+      tsl::profiler::GetStatTypeStr(StatType::kPerformanceCounterDescription));
+  XStatMetadata* sets_stat = plane->GetOrCreateStatMetadata(
+      tsl::profiler::GetStatTypeStr(StatType::kPerformanceCounterSets));
+
+  // Pre-compute per-metric metadata: event metadata, description, category.
+  // Prefer CUPTI-provided MetricProperties; fall back to display-name map and
+  // prefix-based category when properties are unavailable.
+  bool have_props = (metric_props.size() == metrics.size());
+
+  struct MetricInfo {
+    XEventMetadata* event_metadata;
+    std::string description;
+    std::string category;
+  };
+  std::vector<MetricInfo> metric_infos;
+  metric_infos.reserve(metrics.size());
+  for (size_t i = 0; i < metrics.size(); ++i) {
+    MetricInfo info;
+    info.event_metadata = plane->GetOrCreateEventMetadata(metrics[i]);
+    if (have_props && !metric_props[i].description.empty()) {
+      info.description = metric_props[i].description;
+    } else {
+      info.description = GetGpuProfileMetricName(metrics[i]);
+    }
+    if (have_props && !metric_props[i].hw_unit.empty()) {
+      info.category = metric_props[i].hw_unit;
+    } else {
+      info.category = GetRangeMetricCategory(metrics[i]);
+    }
+    metric_infos.push_back(std::move(info));
+  }
+
+  // One XLine per range, one XEvent per metric on each line.
+  for (int64_t range_idx = 0; range_idx < static_cast<int64_t>(ranges.size());
+       ++range_idx) {
+    const auto& range = ranges[range_idx];
+    XLineBuilder line = plane->GetOrCreateLine(range_idx);
+    line.SetName(range.range_name);
+    line.SetTimestampNs(0);
+
+    DCHECK_EQ(metrics.size(), range.metric_values.size());
+    for (size_t i = 0; i < range.metric_values.size(); ++i) {
+      tsl::profiler::Timespan timespan(
+          tsl::profiler::NanoToPico(range.start_timestamp_ns),
+          tsl::profiler::NanoToPico(range.end_timestamp_ns -
+                                    range.start_timestamp_ns));
+      XEventBuilder event = line.AddEvent(timespan,
+                                          *metric_infos[i].event_metadata);
+      event.AddStatValue(*counter_value_stat,
+                         static_cast<uint64_t>(range.metric_values[i]));
+      event.AddStatValue(*description_stat, metric_infos[i].description);
+      event.AddStatValue(*sets_stat, metric_infos[i].category);
+    }
+  }
+}
 
 void CuptiTraceCollector::OnTracerCollectedCallbackData(
     std::vector<CallbackAnnotationsAndEvents> callback_annotations_and_events,

--- a/xla/backends/profiler/gpu/cupti_collector.h
+++ b/xla/backends/profiler/gpu/cupti_collector.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 #include "xla/backends/profiler/gpu/cupti_buffer_events.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
@@ -147,6 +148,14 @@ class CuptiTraceCollector {
 std::unique_ptr<CuptiTraceCollector> CreateCuptiCollector(
     const CuptiTracerCollectorOptions& options, uint64_t start_walltime_ns,
     uint64_t start_gputime_ns);
+
+// Populates range profiling results into the given XPlane so they appear in
+// the xprof perf_counters tool.  Creates one XLine per profiled range and one
+// XEvent per metric, annotated with kCounterValue, kPerformanceCounterDescription,
+// and kPerformanceCounterSets stats.
+void PopulateRangeProfilingEvents(
+    const RangeProfilerResults* results,
+    tsl::profiler::XPlaneBuilder* plane);
 
 }  // namespace profiler
 }  // namespace xla

--- a/xla/backends/profiler/gpu/cupti_collector_test.cc
+++ b/xla/backends/profiler/gpu/cupti_collector_test.cc
@@ -288,6 +288,156 @@ TEST(PmSamplesTest, PopulateCounterLineSkipsNan) {
   EXPECT_EQ(stat.double_value(), 123.0);
 }
 
+TEST(RangeProfilingTest, PopulateRangeProfilingEventsBasic) {
+  // Two metrics, one range.
+  std::vector<std::string> metrics = {"sm__cycles_active.sum",
+                                      "dram__bytes.sum"};
+  std::vector<MetricProperties> props = {
+      {/*description=*/"SM Active Cycles", /*hw_unit=*/"sm"},
+      {/*description=*/"DRAM Bytes", /*hw_unit=*/"dram"},
+  };
+  std::vector<RangeResult> ranges = {{
+      /*range_name=*/"hlo_execution",
+      /*start_timestamp_ns=*/1000,
+      /*end_timestamp_ns=*/2000,
+      /*metric_values=*/{42.0, 100.0},
+  }};
+  RangeProfilerResults results(metrics, props, ranges, /*device_id=*/0);
+
+  tensorflow::profiler::XPlane plane;
+  tsl::profiler::XPlaneBuilder plane_builder(&plane);
+  PopulateRangeProfilingEvents(&results, &plane_builder);
+
+  // One line (one range), two events (two metrics).
+  ASSERT_EQ(plane.lines_size(), 1);
+  const auto& line = plane.lines(0);
+  EXPECT_EQ(line.name(), "hlo_execution");
+  ASSERT_EQ(line.events_size(), 2);
+
+  // Check each event has three stats: counter_value, description, sets.
+  for (const auto& event : line.events()) {
+    ASSERT_EQ(event.stats_size(), 3);
+  }
+
+  // Verify event names map to raw metric names.
+  absl::flat_hash_set<std::string> event_names;
+  for (const auto& event : line.events()) {
+    event_names.insert(
+        plane.event_metadata().at(event.metadata_id()).name());
+  }
+  EXPECT_TRUE(event_names.contains("sm__cycles_active.sum"));
+  EXPECT_TRUE(event_names.contains("dram__bytes.sum"));
+
+  // Verify counter values and CUPTI-provided descriptions.
+  using tsl::profiler::GetStatTypeStr;
+  using tsl::profiler::StatType;
+  for (const auto& event : line.events()) {
+    std::string event_name =
+        plane.event_metadata().at(event.metadata_id()).name();
+    for (const auto& stat : event.stats()) {
+      std::string stat_name =
+          plane.stat_metadata().at(stat.metadata_id()).name();
+      if (stat_name == GetStatTypeStr(StatType::kCounterValue)) {
+        if (event_name == "sm__cycles_active.sum") {
+          EXPECT_EQ(stat.uint64_value(), 42);
+        } else {
+          EXPECT_EQ(stat.uint64_value(), 100);
+        }
+      }
+      if (stat_name ==
+          GetStatTypeStr(StatType::kPerformanceCounterDescription)) {
+        if (event_name == "sm__cycles_active.sum") {
+          EXPECT_EQ(stat.str_value(), "SM Active Cycles");
+        } else {
+          EXPECT_EQ(stat.str_value(), "DRAM Bytes");
+        }
+      }
+      if (stat_name == GetStatTypeStr(StatType::kPerformanceCounterSets)) {
+        if (event_name == "sm__cycles_active.sum") {
+          EXPECT_EQ(stat.str_value(), "sm");
+        } else {
+          EXPECT_EQ(stat.str_value(), "dram");
+        }
+      }
+    }
+  }
+}
+
+TEST(RangeProfilingTest, PopulateRangeProfilingEventsFallback) {
+  // Without MetricProperties, falls back to prefix-based category and
+  // display-name map.
+  std::vector<std::string> metrics = {"sm__cycles_active.sum"};
+  std::vector<RangeResult> ranges = {{
+      /*range_name=*/"test_range",
+      /*start_timestamp_ns=*/500,
+      /*end_timestamp_ns=*/1500,
+      /*metric_values=*/{7.0},
+  }};
+  // Use the constructor without properties.
+  RangeProfilerResults results(metrics, ranges, /*device_id=*/0);
+
+  tensorflow::profiler::XPlane plane;
+  tsl::profiler::XPlaneBuilder plane_builder(&plane);
+  PopulateRangeProfilingEvents(&results, &plane_builder);
+
+  ASSERT_EQ(plane.lines_size(), 1);
+  EXPECT_EQ(plane.lines(0).name(), "test_range");
+  ASSERT_EQ(plane.lines(0).events_size(), 1);
+
+  const auto& event = plane.lines(0).events(0);
+  ASSERT_EQ(event.stats_size(), 3);
+
+  // Verify fallback category (prefix "sm__" → "Streaming Multiprocessor").
+  using tsl::profiler::GetStatTypeStr;
+  using tsl::profiler::StatType;
+  for (const auto& stat : event.stats()) {
+    std::string stat_name =
+        plane.stat_metadata().at(stat.metadata_id()).name();
+    if (stat_name == GetStatTypeStr(StatType::kPerformanceCounterSets)) {
+      EXPECT_EQ(stat.str_value(), "Streaming Multiprocessor");
+    }
+    if (stat_name == GetStatTypeStr(StatType::kCounterValue)) {
+      EXPECT_EQ(stat.uint64_value(), 7);
+    }
+  }
+}
+
+TEST(RangeProfilingTest, PopulateRangeProfilingEventsMultipleRanges) {
+  std::vector<std::string> metrics = {"sm__cycles_active.sum"};
+  std::vector<MetricProperties> props = {
+      {/*description=*/"Cycles", /*hw_unit=*/"sm"},
+  };
+  std::vector<RangeResult> ranges = {
+      {/*range_name=*/"range_0",
+       /*start_timestamp_ns=*/100,
+       /*end_timestamp_ns=*/200,
+       /*metric_values=*/{10.0}},
+      {/*range_name=*/"range_1",
+       /*start_timestamp_ns=*/300,
+       /*end_timestamp_ns=*/400,
+       /*metric_values=*/{20.0}},
+  };
+  RangeProfilerResults results(metrics, props, ranges, /*device_id=*/0);
+
+  tensorflow::profiler::XPlane plane;
+  tsl::profiler::XPlaneBuilder plane_builder(&plane);
+  PopulateRangeProfilingEvents(&results, &plane_builder);
+
+  // Two lines (two ranges), one event each.
+  ASSERT_EQ(plane.lines_size(), 2);
+  EXPECT_EQ(plane.lines(0).name(), "range_0");
+  EXPECT_EQ(plane.lines(1).name(), "range_1");
+  EXPECT_EQ(plane.lines(0).events_size(), 1);
+  EXPECT_EQ(plane.lines(1).events_size(), 1);
+}
+
+TEST(RangeProfilingTest, PopulateRangeProfilingEventsNullResults) {
+  tensorflow::profiler::XPlane plane;
+  tsl::profiler::XPlaneBuilder plane_builder(&plane);
+  PopulateRangeProfilingEvents(nullptr, &plane_builder);
+  EXPECT_EQ(plane.lines_size(), 0);
+}
+
 }  // namespace
 }  // namespace profiler
 }  // namespace xla

--- a/xla/backends/profiler/gpu/cupti_error_manager.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager.cc
@@ -681,6 +681,104 @@ CUptiResult CuptiErrorManager::PmSamplingCounterDataGetSampleInfo(
   return err;
 }
 
+// Range profiling specific functions
+CUptiResult CuptiErrorManager::RangeProfilerEnable(
+    CUpti_RangeProfiler_Enable_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerEnable(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerDisable(
+    CUpti_RangeProfiler_Disable_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerDisable(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerGetCounterDataSize(
+    CUpti_RangeProfiler_GetCounterDataSize_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerGetCounterDataSize(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerCounterDataImageInitialize(
+    CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err =
+      interface_->RangeProfilerCounterDataImageInitialize(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerSetConfig(
+    CUpti_RangeProfiler_SetConfig_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerSetConfig(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerStart(
+    CUpti_RangeProfiler_Start_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerStart(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerStop(
+    CUpti_RangeProfiler_Stop_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerStop(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerPushRange(
+    CUpti_RangeProfiler_PushRange_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerPushRange(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerPopRange(
+    CUpti_RangeProfiler_PopRange_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerPopRange(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerDecodeData(
+    CUpti_RangeProfiler_DecodeData_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerDecodeData(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerGetCounterDataInfo(
+    CUpti_RangeProfiler_GetCounterDataInfo_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerGetCounterDataInfo(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
+CUptiResult CuptiErrorManager::RangeProfilerCounterDataGetRangeInfo(
+    CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult err = interface_->RangeProfilerCounterDataGetRangeInfo(params);
+  LOG_AND_DISABLE_IF_ERROR(err);
+  return err;
+}
+
 CUptiResult CuptiErrorManager::DeviceGetChipName(
     CUpti_Device_GetChipName_Params* params) {
   IGNORE_CALL_IF_DISABLED;

--- a/xla/backends/profiler/gpu/cupti_error_manager.h
+++ b/xla/backends/profiler/gpu/cupti_error_manager.h
@@ -218,6 +218,32 @@ class CuptiErrorManager : public xla::profiler::CuptiInterface {
   CUptiResult PmSamplingCounterDataGetSampleInfo(
       CUpti_PmSampling_CounterData_GetSampleInfo_Params* params) override;
 
+  // Range profiling specific functions
+  CUptiResult RangeProfilerEnable(
+      CUpti_RangeProfiler_Enable_Params* params) override;
+  CUptiResult RangeProfilerDisable(
+      CUpti_RangeProfiler_Disable_Params* params) override;
+  CUptiResult RangeProfilerGetCounterDataSize(
+      CUpti_RangeProfiler_GetCounterDataSize_Params* params) override;
+  CUptiResult RangeProfilerCounterDataImageInitialize(
+      CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params) override;
+  CUptiResult RangeProfilerSetConfig(
+      CUpti_RangeProfiler_SetConfig_Params* params) override;
+  CUptiResult RangeProfilerStart(
+      CUpti_RangeProfiler_Start_Params* params) override;
+  CUptiResult RangeProfilerStop(
+      CUpti_RangeProfiler_Stop_Params* params) override;
+  CUptiResult RangeProfilerPushRange(
+      CUpti_RangeProfiler_PushRange_Params* params) override;
+  CUptiResult RangeProfilerPopRange(
+      CUpti_RangeProfiler_PopRange_Params* params) override;
+  CUptiResult RangeProfilerDecodeData(
+      CUpti_RangeProfiler_DecodeData_Params* params) override;
+  CUptiResult RangeProfilerGetCounterDataInfo(
+      CUpti_RangeProfiler_GetCounterDataInfo_Params* params) override;
+  CUptiResult RangeProfilerCounterDataGetRangeInfo(
+      CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params) override;
+
   CUptiResult DeviceGetChipName(
       CUpti_Device_GetChipName_Params* params) override;
 

--- a/xla/backends/profiler/gpu/cupti_interface.h
+++ b/xla/backends/profiler/gpu/cupti_interface.h
@@ -53,6 +53,19 @@ struct CUpti_PmSampling_GetCounterDataSize_Params;
 struct CUpti_PmSampling_CounterDataImage_Initialize_Params;
 struct CUpti_PmSampling_GetCounterDataInfo_Params;
 struct CUpti_PmSampling_CounterData_GetSampleInfo_Params;
+
+struct CUpti_RangeProfiler_Enable_Params;
+struct CUpti_RangeProfiler_Disable_Params;
+struct CUpti_RangeProfiler_GetCounterDataSize_Params;
+struct CUpti_RangeProfiler_CounterDataImage_Initialize_Params;
+struct CUpti_RangeProfiler_SetConfig_Params;
+struct CUpti_RangeProfiler_Start_Params;
+struct CUpti_RangeProfiler_Stop_Params;
+struct CUpti_RangeProfiler_PushRange_Params;
+struct CUpti_RangeProfiler_PopRange_Params;
+struct CUpti_RangeProfiler_DecodeData_Params;
+struct CUpti_RangeProfiler_GetCounterDataInfo_Params;
+struct CUpti_RangeProfiler_CounterData_GetRangeInfo_Params;
 }
 
 namespace xla {
@@ -234,6 +247,33 @@ class CuptiInterface {
       CUpti_PmSampling_GetCounterDataInfo_Params* params) = 0;
   virtual CUptiResult PmSamplingCounterDataGetSampleInfo(
       CUpti_PmSampling_CounterData_GetSampleInfo_Params* params) = 0;
+
+  // Range profiling specific functions from
+  // cuda/extras/CUPTI/include/cupti_range_profiler.h
+  virtual CUptiResult RangeProfilerEnable(
+      CUpti_RangeProfiler_Enable_Params* params) = 0;
+  virtual CUptiResult RangeProfilerDisable(
+      CUpti_RangeProfiler_Disable_Params* params) = 0;
+  virtual CUptiResult RangeProfilerGetCounterDataSize(
+      CUpti_RangeProfiler_GetCounterDataSize_Params* params) = 0;
+  virtual CUptiResult RangeProfilerCounterDataImageInitialize(
+      CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params) = 0;
+  virtual CUptiResult RangeProfilerSetConfig(
+      CUpti_RangeProfiler_SetConfig_Params* params) = 0;
+  virtual CUptiResult RangeProfilerStart(
+      CUpti_RangeProfiler_Start_Params* params) = 0;
+  virtual CUptiResult RangeProfilerStop(
+      CUpti_RangeProfiler_Stop_Params* params) = 0;
+  virtual CUptiResult RangeProfilerPushRange(
+      CUpti_RangeProfiler_PushRange_Params* params) = 0;
+  virtual CUptiResult RangeProfilerPopRange(
+      CUpti_RangeProfiler_PopRange_Params* params) = 0;
+  virtual CUptiResult RangeProfilerDecodeData(
+      CUpti_RangeProfiler_DecodeData_Params* params) = 0;
+  virtual CUptiResult RangeProfilerGetCounterDataInfo(
+      CUpti_RangeProfiler_GetCounterDataInfo_Params* params) = 0;
+  virtual CUptiResult RangeProfilerCounterDataGetRangeInfo(
+      CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params) = 0;
 
   virtual CUptiResult DeviceGetChipName(
       CUpti_Device_GetChipName_Params* params) = 0;

--- a/xla/backends/profiler/gpu/cupti_range_profiler.h
+++ b/xla/backends/profiler/gpu/cupti_range_profiler.h
@@ -66,6 +66,15 @@ struct RangeResult {
   std::vector<double> metric_values;
 };
 
+// Properties of a single metric, queried from CUPTI at decode time.
+// Parallel to the metrics vector in RangeProfilerResults.
+struct MetricProperties {
+  // Human-readable description (from CUPTI or fallback display name).
+  std::string description;
+  // Hardware unit the metric belongs to (e.g. "sm", "dram", "l1tex").
+  std::string hw_unit;
+};
+
 // Container for all decoded range profiling results from one session.
 class RangeProfilerResults {
  public:
@@ -75,12 +84,24 @@ class RangeProfilerResults {
         ranges_(std::move(ranges)),
         device_id_(device_id) {}
 
+  RangeProfilerResults(std::vector<std::string> metrics,
+                       std::vector<MetricProperties> metric_properties,
+                       std::vector<RangeResult> ranges, int device_id)
+      : metrics_(std::move(metrics)),
+        metric_properties_(std::move(metric_properties)),
+        ranges_(std::move(ranges)),
+        device_id_(device_id) {}
+
   const std::vector<std::string>& GetMetrics() const { return metrics_; }
+  const std::vector<MetricProperties>& GetMetricProperties() const {
+    return metric_properties_;
+  }
   const std::vector<RangeResult>& GetRanges() const { return ranges_; }
   int GetDeviceId() const { return device_id_; }
 
  private:
   std::vector<std::string> metrics_;
+  std::vector<MetricProperties> metric_properties_;
   std::vector<RangeResult> ranges_;
   int device_id_;
 };

--- a/xla/backends/profiler/gpu/cupti_range_profiler.h
+++ b/xla/backends/profiler/gpu/cupti_range_profiler.h
@@ -1,0 +1,129 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_H_
+#define XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_H_
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+
+namespace xla {
+namespace profiler {
+
+// Range mode determines how profiling ranges are delimited.
+enum class CuptiRangeMode {
+  // Manual push/pop from the runner (e.g. per HLO execution).
+  kUser,
+  // Automatic per-kernel ranges managed by CUPTI.
+  kAutoRange,
+};
+
+// Configuration for CUPTI range profiling.
+// Read once during CuptiRangeProfiler creation; later changes have no effect.
+struct CuptiRangeProfilerOptions {
+  // Whether to enable range profiling.
+  bool enable = false;
+  // List of metrics to collect (e.g. "sm__cycles_elapsed.avg").
+  std::vector<std::string> metrics;
+  // How profiling ranges are delimited.
+  CuptiRangeMode range_mode = CuptiRangeMode::kUser;
+  // Default range name used when the caller does not supply one.
+  std::string range_name = "hlo_execution";
+  // Whether to allow metric configurations that require multiple passes.
+  // Default is false: most callers (e.g. XLA workloads) cannot replay the
+  // workload, so multi-pass configs are rejected at Enable() time.
+  // The multi-hlo-runner sets this to true because it controls the repeat loop.
+  bool allow_multipass = false;
+  // What to do with decoded results after the final pass.
+  // Must be safe to call from any thread.
+  std::function<void(class RangeProfilerResults*)> process_results;
+};
+
+// A single profiled range with its decoded metric values.
+// Counter values are aggregated across all collection passes by CUPTI.
+struct RangeResult {
+  std::string range_name;
+  uint64_t start_timestamp_ns;
+  uint64_t end_timestamp_ns;
+  // Parallel to the metrics vector in CuptiRangeProfilerOptions / results.
+  std::vector<double> metric_values;
+};
+
+// Container for all decoded range profiling results from one session.
+class RangeProfilerResults {
+ public:
+  RangeProfilerResults(std::vector<std::string> metrics,
+                       std::vector<RangeResult> ranges, int device_id)
+      : metrics_(std::move(metrics)),
+        ranges_(std::move(ranges)),
+        device_id_(device_id) {}
+
+  const std::vector<std::string>& GetMetrics() const { return metrics_; }
+  const std::vector<RangeResult>& GetRanges() const { return ranges_; }
+  int GetDeviceId() const { return device_id_; }
+
+ private:
+  std::vector<std::string> metrics_;
+  std::vector<RangeResult> ranges_;
+  int device_id_;
+};
+
+// Abstract interface for CUPTI range profiling.
+//
+// Range profiling collects hardware performance counters over explicitly
+// delimited ranges of GPU work. Unlike PM sampling, it requires multiple
+// passes of the same workload — one pass per counter group. The multi-hlo-
+// runner's repeat loop maps naturally to this: each repeat is one pass.
+//
+// Specialize a full implementation in cupti_range_profiler_impl.h.
+class CuptiRangeProfiler {
+ public:
+  CuptiRangeProfiler() = default;
+
+  // Not copyable or movable.
+  CuptiRangeProfiler(const CuptiRangeProfiler&) = delete;
+  CuptiRangeProfiler(CuptiRangeProfiler&&) = delete;
+  CuptiRangeProfiler& operator=(const CuptiRangeProfiler&) = delete;
+  CuptiRangeProfiler& operator=(CuptiRangeProfiler&&) = delete;
+
+  virtual ~CuptiRangeProfiler() = default;
+
+  // Returns the number of passes required for the configured metrics.
+  virtual int NumPasses() const = 0;
+
+  // Per-pass lifecycle: called once per repeat of the workload.
+  virtual absl::Status BeginPass() = 0;
+  virtual absl::Status EndPass() = 0;
+
+  // Range delimiters: bracket the GPU work to be measured within a pass.
+  virtual absl::Status PushRange(absl::string_view name) = 0;
+  virtual absl::Status PopRange() = 0;
+
+  // Post-collection: flush counter data and decode to metric values.
+  virtual absl::Status FlushAndDecode() = 0;
+
+  // Tear down all CUPTI state.
+  virtual absl::Status Deinitialize() = 0;
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_H_

--- a/xla/backends/profiler/gpu/cupti_range_profiler_factory.cc
+++ b/xla/backends/profiler/gpu/cupti_range_profiler_factory.cc
@@ -1,0 +1,43 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/cupti_range_profiler_factory.h"
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_version.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
+
+#if CUPTI_API_VERSION >= 24
+#include "xla/backends/profiler/gpu/cupti_range_profiler_impl.h"
+#else
+#include "xla/backends/profiler/gpu/cupti_range_profiler_stub.h"
+#endif
+
+namespace xla {
+namespace profiler {
+
+absl::StatusOr<std::unique_ptr<CuptiRangeProfiler>> CreateRangeProfiler(
+    int num_gpus, const CuptiRangeProfilerOptions& options) {
+#if CUPTI_API_VERSION >= 24
+  return CuptiRangeProfilerImpl::Create(num_gpus, options);
+#else
+  return std::make_unique<CuptiRangeProfilerStub>();
+#endif
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/cupti_range_profiler_factory.h
+++ b/xla/backends/profiler/gpu/cupti_range_profiler_factory.h
@@ -1,0 +1,33 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_FACTORY_H_
+#define XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_FACTORY_H_
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
+
+namespace xla {
+namespace profiler {
+
+absl::StatusOr<std::unique_ptr<CuptiRangeProfiler>> CreateRangeProfiler(
+    int num_gpus, const CuptiRangeProfilerOptions& options);
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_FACTORY_H_

--- a/xla/backends/profiler/gpu/cupti_range_profiler_impl.cc
+++ b/xla/backends/profiler/gpu/cupti_range_profiler_impl.cc
@@ -398,6 +398,35 @@ absl::Status CuptiRangeProfilerDevice::Decode(
   return absl::OkStatus();
 }
 
+std::vector<MetricProperties> CuptiRangeProfilerDevice::QueryMetricProperties() {
+  std::vector<MetricProperties> props;
+  props.reserve(enabled_metrics_.size());
+
+  for (const auto& metric : enabled_metrics_) {
+    MetricProperties mp;
+    if (host_obj_ != nullptr) {
+      DEF_SIZED_PRIV_STRUCT(
+          CUpti_Profiler_Host_GetMetricProperties_Params, p);
+      p.pHostObject = host_obj_;
+      p.pMetricName = metric.c_str();
+      CUptiResult result =
+          cupti_interface_->ProfilerHostGetMetricProperties(&p);
+      if (result == CUPTI_SUCCESS) {
+        if (p.pDescription != nullptr) {
+          mp.description = p.pDescription;
+        }
+        if (p.pHwUnit != nullptr) {
+          mp.hw_unit = p.pHwUnit;
+        }
+      } else {
+        LOG(WARNING) << "Failed to get metric properties for " << metric;
+      }
+    }
+    props.push_back(std::move(mp));
+  }
+  return props;
+}
+
 absl::Status CuptiRangeProfilerDevice::Disable() {
   if (range_profiler_obj_ == nullptr) {
     return absl::OkStatus();
@@ -513,8 +542,11 @@ absl::Status CuptiRangeProfilerImpl::FlushAndDecode() {
     TF_RETURN_IF_ERROR(dev->Decode(&results));
 
     if (options_.process_results) {
+      std::vector<MetricProperties> metric_props =
+          dev->QueryMetricProperties();
       RangeProfilerResults profiler_results(
-          dev->enabled_metrics(), std::move(results), dev->device_id());
+          dev->enabled_metrics(), std::move(metric_props),
+          std::move(results), dev->device_id());
       options_.process_results(&profiler_results);
     }
   }

--- a/xla/backends/profiler/gpu/cupti_range_profiler_impl.cc
+++ b/xla/backends/profiler/gpu/cupti_range_profiler_impl.cc
@@ -1,0 +1,557 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/cupti_range_profiler_impl.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_range_profiler.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
+#include "xla/backends/profiler/gpu/cupti_interface.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
+#include "xla/backends/profiler/gpu/cupti_status.h"
+#include "xla/backends/profiler/gpu/cupti_utils.h"
+#include "xla/stream_executor/cuda/cuda_status.h"
+#include "xla/tsl/platform/errors.h"
+
+namespace xla {
+namespace profiler {
+
+// CUPTI params struct definitions are very long, macro it for convenience.
+// They all have a struct_size field which must be set to type_STRUCT_SIZE
+// and a pPriv field which must be null.
+#define DEF_SIZED_PRIV_STRUCT(type, name) \
+  type name = {.structSize = type##_STRUCT_SIZE, .pPriv = nullptr}
+
+// =============================================================================
+// CuptiRangeProfilerDevice
+// =============================================================================
+
+CuptiRangeProfilerDevice::CuptiRangeProfilerDevice(
+    int device_id, const CuptiRangeProfilerOptions& options)
+    : device_id_(device_id),
+      cupti_interface_(GetCuptiInterface()),
+      config_metrics_(options.metrics),
+      enabled_metrics_(options.metrics) {
+  for (const auto& metric : config_metrics_) {
+    c_metrics_.push_back(metric.c_str());
+  }
+}
+
+CuptiRangeProfilerDevice::~CuptiRangeProfilerDevice() {
+  if (range_profiler_obj_ != nullptr) {
+    Disable().IgnoreError();
+  }
+  DestroyProfilerHostObj();
+}
+
+absl::Status CuptiRangeProfilerDevice::GetChipName() {
+  DEF_SIZED_PRIV_STRUCT(CUpti_Device_GetChipName_Params, p);
+  p.deviceIndex = device_id_;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->DeviceGetChipName(&p)));
+  chip_name_ = p.pChipName;
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::DeviceSupported() {
+  CUdevice cu_device;
+  TF_RETURN_IF_ERROR(
+      stream_executor::cuda::ToStatus(cuDeviceGet(&cu_device, device_id_)));
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_DeviceSupported_Params, p);
+  p.cuDevice = cu_device;
+  p.api = CUPTI_PROFILER_RANGE_PROFILING;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->ProfilerDeviceSupported(&p)));
+
+  if (p.isSupported != CUPTI_PROFILER_CONFIGURATION_SUPPORTED) {
+    return absl::FailedPreconditionError(absl::StrCat(
+        "Device ", device_id_, " does not support range profiling"));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::CreateCounterAvailabilityImage() {
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_GetCounterAvailability_Params, p);
+  p.ctx = nullptr;  // Use current context.
+  TF_RETURN_IF_ERROR(
+      ToStatus(cupti_interface_->ProfilerGetCounterAvailability(&p)));
+
+  counter_availability_image_.clear();
+  counter_availability_image_.resize(p.counterAvailabilityImageSize);
+  p.pCounterAvailabilityImage = counter_availability_image_.data();
+  TF_RETURN_IF_ERROR(
+      ToStatus(cupti_interface_->ProfilerGetCounterAvailability(&p)));
+
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::CreateProfilerHostObj() {
+  DestroyProfilerHostObj();
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_Initialize_Params, p);
+  p.profilerType = CUPTI_PROFILER_TYPE_RANGE_PROFILER;
+  p.pChipName = chip_name_.c_str();
+  p.pCounterAvailabilityImage = counter_availability_image_.data();
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->ProfilerHostInitialize(&p)));
+
+  host_obj_ = p.pHostObject;
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::CreateConfigImage() {
+  TF_RETURN_IF_ERROR(CreateProfilerHostObj());
+
+  // Add metrics to host object.
+  LOG(INFO) << "(Profiling::Range) Adding " << c_metrics_.size()
+            << " metrics to config image";
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_ConfigAddMetrics_Params, am);
+  am.pHostObject = host_obj_;
+  am.ppMetricNames = c_metrics_.data();
+  am.numMetrics = c_metrics_.size();
+  const CUptiResult status = cupti_interface_->ProfilerHostConfigAddMetrics(&am);
+
+  if (status == CUPTI_ERROR_INVALID_PARAMETER ||
+      status == CUPTI_ERROR_INVALID_METRIC_NAME) {
+    // Try each metric individually to find valid ones.
+    LOG(WARNING) << "(Profiling::Range) Bulk add returned error " << status
+                 << ", testing " << c_metrics_.size()
+                 << " metrics individually";
+    std::vector<const char*> valid_metrics;
+    for (const auto& metric : c_metrics_) {
+      TF_RETURN_IF_ERROR(CreateProfilerHostObj());
+      DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_ConfigAddMetrics_Params, test);
+      test.pHostObject = host_obj_;
+      const char* m = metric;
+      test.ppMetricNames = &m;
+      test.numMetrics = 1;
+      const CUptiResult r = cupti_interface_->ProfilerHostConfigAddMetrics(&test);
+      if (r == CUPTI_SUCCESS) {
+        valid_metrics.push_back(metric);
+      } else {
+        LOG(WARNING) << "(Profiling::Range) Invalid metric: " << metric;
+      }
+    }
+    if (valid_metrics.empty()) {
+      return absl::FailedPreconditionError(
+          "No valid metrics for range profiling");
+    }
+    LOG(INFO) << "(Profiling::Range) Pruned to " << valid_metrics.size()
+              << " valid metrics (from " << c_metrics_.size() << ")";
+    c_metrics_ = valid_metrics;
+
+    // Rebuild host object with valid metrics.
+    TF_RETURN_IF_ERROR(CreateProfilerHostObj());
+    DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_ConfigAddMetrics_Params, retry);
+    retry.pHostObject = host_obj_;
+    retry.ppMetricNames = c_metrics_.data();
+    retry.numMetrics = c_metrics_.size();
+    TF_RETURN_IF_ERROR(
+        ToStatus(cupti_interface_->ProfilerHostConfigAddMetrics(&retry)));
+  } else if (status != CUPTI_SUCCESS) {
+    return ToStatus(status);
+  } else {
+    LOG(INFO) << "(Profiling::Range) All " << c_metrics_.size()
+              << " metrics accepted by CUPTI";
+  }
+
+  // Get config image size and create it.
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_GetConfigImageSize_Params, cs);
+  cs.pHostObject = host_obj_;
+  TF_RETURN_IF_ERROR(
+      ToStatus(cupti_interface_->ProfilerHostGetConfigImageSize(&cs)));
+
+  config_image_.clear();
+  config_image_.resize(cs.configImageSize);
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_GetConfigImage_Params, ci);
+  ci.pHostObject = host_obj_;
+  ci.pConfigImage = config_image_.data();
+  ci.configImageSize = config_image_.size();
+  TF_RETURN_IF_ERROR(
+      ToStatus(cupti_interface_->ProfilerHostGetConfigImage(&ci)));
+
+  // Update enabled_metrics_ to reflect what was actually configured.
+  enabled_metrics_.clear();
+  for (const auto& metric : c_metrics_) {
+    enabled_metrics_.emplace_back(metric);
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::GetNumPasses(int* num_passes) {
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_GetNumOfPasses_Params, p);
+  p.pConfigImage = config_image_.data();
+  p.configImageSize = config_image_.size();
+  TF_RETURN_IF_ERROR(
+      ToStatus(cupti_interface_->ProfilerHostGetNumOfPasses(&p)));
+  *num_passes = static_cast<int>(p.numOfPasses);
+  LOG(INFO) << "(Profiling::Range) Device " << device_id_
+            << ": CUPTI reports " << *num_passes << " pass(es) for "
+            << c_metrics_.size() << " metrics (config image "
+            << config_image_.size() << " bytes)";
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::CreateConfig() {
+  TF_RETURN_IF_ERROR(GetChipName());
+  TF_RETURN_IF_ERROR(DeviceSupported());
+  TF_RETURN_IF_ERROR(CreateCounterAvailabilityImage());
+  TF_RETURN_IF_ERROR(CreateConfigImage());
+  return absl::OkStatus();
+}
+
+// --- New Range Profiling API methods ---
+
+absl::Status CuptiRangeProfilerDevice::Enable() {
+  // Initialize CUPTI profiler subsystem (required before any range profiling).
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Initialize_Params, init_p);
+  TF_RETURN_IF_ERROR(
+      ToStatus(cupti_interface_->ProfilerInitialize(&init_p)));
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_Enable_Params, p);
+  p.ctx = nullptr;  // Use current CUDA context.
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerEnable(&p)));
+  range_profiler_obj_ = p.pRangeProfilerObject;
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::CreateCounterDataImage() {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::FailedPreconditionError(
+        "Range profiler not enabled; call Enable() first");
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_GetCounterDataSize_Params, sz);
+  sz.pRangeProfilerObject = range_profiler_obj_;
+  sz.pMetricNames = c_metrics_.data();
+  sz.numMetrics = c_metrics_.size();
+  sz.maxNumOfRanges = 1;        // One range per pass in user mode.
+  sz.maxNumRangeTreeNodes = 1;
+  TF_RETURN_IF_ERROR(ToStatus(
+      cupti_interface_->RangeProfilerGetCounterDataSize(&sz)));
+
+  counter_data_image_.clear();
+  counter_data_image_.resize(sz.counterDataSize, 0);
+
+  DEF_SIZED_PRIV_STRUCT(
+      CUpti_RangeProfiler_CounterDataImage_Initialize_Params, di);
+  di.pRangeProfilerObject = range_profiler_obj_;
+  di.pCounterData = counter_data_image_.data();
+  di.counterDataSize = counter_data_image_.size();
+  TF_RETURN_IF_ERROR(
+      ToStatus(cupti_interface_->RangeProfilerCounterDataImageInitialize(&di)));
+
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::SetConfig() {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::FailedPreconditionError(
+        "Range profiler not enabled; call Enable() first");
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_SetConfig_Params, p);
+  p.pRangeProfilerObject = range_profiler_obj_;
+  p.pConfig = config_image_.data();
+  p.configSize = config_image_.size();
+  p.pCounterDataImage = counter_data_image_.data();
+  p.counterDataImageSize = counter_data_image_.size();
+  p.range = CUPTI_UserRange;
+  p.replayMode = CUPTI_ApplicationReplay;
+  p.maxRangesPerPass = 1;
+  p.numNestingLevels = 1;
+  p.minNestingLevel = 1;
+  p.passIndex = 0;
+  p.targetNestingLevel = 1;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerSetConfig(&p)));
+
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::Start() {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::FailedPreconditionError("Range profiler not enabled");
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_Start_Params, p);
+  p.pRangeProfilerObject = range_profiler_obj_;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerStart(&p)));
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::Stop(bool* all_passes_collected) {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::FailedPreconditionError("Range profiler not enabled");
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_Stop_Params, p);
+  p.pRangeProfilerObject = range_profiler_obj_;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerStop(&p)));
+  *all_passes_collected = (p.isAllPassSubmitted != 0);
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::PushRange(absl::string_view name) {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::FailedPreconditionError("Range profiler not enabled");
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_PushRange_Params, p);
+  p.pRangeProfilerObject = range_profiler_obj_;
+  std::string name_str(name);
+  p.pRangeName = name_str.c_str();
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerPushRange(&p)));
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::PopRange() {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::FailedPreconditionError("Range profiler not enabled");
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_PopRange_Params, p);
+  p.pRangeProfilerObject = range_profiler_obj_;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerPopRange(&p)));
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::DecodeData() {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::FailedPreconditionError("Range profiler not enabled");
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_DecodeData_Params, p);
+  p.pRangeProfilerObject = range_profiler_obj_;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerDecodeData(&p)));
+
+  if (p.numOfRangeDropped > 0) {
+    LOG(WARNING) << "(Profiling::Range) Device " << device_id_ << ": "
+                 << p.numOfRangeDropped << " range(s) dropped during decode";
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::Decode(
+    std::vector<RangeResult>* results) {
+  // Get total number of ranges in the counter data image.
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_GetCounterDataInfo_Params, info);
+  info.pCounterDataImage = counter_data_image_.data();
+  info.counterDataImageSize = counter_data_image_.size();
+  TF_RETURN_IF_ERROR(ToStatus(
+      cupti_interface_->RangeProfilerGetCounterDataInfo(&info)));
+
+  int num_ranges = info.numTotalRanges;
+  results->resize(num_ranges);
+
+  for (int range_idx = 0; range_idx < num_ranges; ++range_idx) {
+    RangeResult& result = (*results)[range_idx];
+    // Get range name.
+    DEF_SIZED_PRIV_STRUCT(
+        CUpti_RangeProfiler_CounterData_GetRangeInfo_Params, ri);
+    ri.pCounterDataImage = counter_data_image_.data();
+    ri.counterDataImageSize = counter_data_image_.size();
+    ri.rangeIndex = range_idx;
+    ri.rangeDelimiter = "/";
+    TF_RETURN_IF_ERROR(
+        ToStatus(cupti_interface_->RangeProfilerCounterDataGetRangeInfo(&ri)));
+    result.range_name = ri.rangeName;
+
+    // Evaluate metrics for this range.
+    result.metric_values.resize(c_metrics_.size());
+    DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_EvaluateToGpuValues_Params, ev);
+    ev.pHostObject = host_obj_;
+    ev.pCounterDataImage = counter_data_image_.data();
+    ev.counterDataImageSize = counter_data_image_.size();
+    ev.ppMetricNames = c_metrics_.data();
+    ev.numMetrics = c_metrics_.size();
+    ev.rangeIndex = range_idx;
+    ev.pMetricValues = result.metric_values.data();
+    TF_RETURN_IF_ERROR(
+        ToStatus(cupti_interface_->ProfilerHostEvaluateToGpuValues(&ev)));
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerDevice::Disable() {
+  if (range_profiler_obj_ == nullptr) {
+    return absl::OkStatus();
+  }
+
+  DEF_SIZED_PRIV_STRUCT(CUpti_RangeProfiler_Disable_Params, p);
+  p.pRangeProfilerObject = range_profiler_obj_;
+  TF_RETURN_IF_ERROR(ToStatus(cupti_interface_->RangeProfilerDisable(&p)));
+  range_profiler_obj_ = nullptr;
+  return absl::OkStatus();
+}
+
+void CuptiRangeProfilerDevice::DestroyProfilerHostObj() {
+  if (host_obj_ == nullptr) return;
+  DEF_SIZED_PRIV_STRUCT(CUpti_Profiler_Host_Deinitialize_Params, p);
+  p.pHostObject = host_obj_;
+  cupti_interface_->ProfilerHostDeinitialize(&p);
+  host_obj_ = nullptr;
+}
+
+// =============================================================================
+// CuptiRangeProfilerImpl
+// =============================================================================
+
+absl::Status CuptiRangeProfilerImpl::Initialize(
+    int num_gpus, const CuptiRangeProfilerOptions& options) {
+  if (initialized_) {
+    return absl::AlreadyExistsError("Range profiler already initialized");
+  }
+
+  options_ = options;
+
+  absl::Cleanup cleanup([this]() { devices_.clear(); });
+
+  for (int dev_idx = 0; dev_idx < num_gpus; ++dev_idx) {
+    auto dev = std::make_unique<CuptiRangeProfilerDevice>(dev_idx, options);
+
+    // Host-side configuration (chip name, counter availability, config image).
+    TF_RETURN_IF_ERROR(dev->CreateConfig());
+
+    int passes = 0;
+    TF_RETURN_IF_ERROR(dev->GetNumPasses(&passes));
+
+    if (dev_idx == 0) {
+      num_passes_ = passes;
+    } else if (passes != num_passes_) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Device ", dev_idx, " requires ", passes,
+          " passes but device 0 requires ", num_passes_,
+          "; all devices must agree"));
+    }
+
+    // Target-side: enable range profiler, create counter data, set config.
+    TF_RETURN_IF_ERROR(dev->Enable());
+    TF_RETURN_IF_ERROR(dev->CreateCounterDataImage());
+    TF_RETURN_IF_ERROR(dev->SetConfig());
+
+    devices_.push_back(std::move(dev));
+  }
+
+  LOG(INFO) << "(Profiling::Range) Initialized for " << num_gpus
+            << " device(s), " << num_passes_ << " pass(es) required";
+
+  std::move(cleanup).Cancel();
+  initialized_ = true;
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerImpl::BeginPass() {
+  if (!initialized_) {
+    return absl::FailedPreconditionError("Range profiler not initialized");
+  }
+  for (auto& dev : devices_) {
+    TF_RETURN_IF_ERROR(dev->Start());
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerImpl::EndPass() {
+  if (!initialized_) {
+    return absl::FailedPreconditionError("Range profiler not initialized");
+  }
+  for (auto& dev : devices_) {
+    bool all_collected = false;
+    TF_RETURN_IF_ERROR(dev->Stop(&all_collected));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerImpl::PushRange(absl::string_view name) {
+  for (auto& dev : devices_) {
+    TF_RETURN_IF_ERROR(dev->PushRange(name));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerImpl::PopRange() {
+  for (auto& dev : devices_) {
+    TF_RETURN_IF_ERROR(dev->PopRange());
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerImpl::FlushAndDecode() {
+  if (!initialized_) {
+    return absl::FailedPreconditionError("Range profiler not initialized");
+  }
+
+  for (auto& dev : devices_) {
+    TF_RETURN_IF_ERROR(dev->DecodeData());
+
+    std::vector<RangeResult> results;
+    TF_RETURN_IF_ERROR(dev->Decode(&results));
+
+    if (options_.process_results) {
+      RangeProfilerResults profiler_results(
+          dev->enabled_metrics(), std::move(results), dev->device_id());
+      options_.process_results(&profiler_results);
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status CuptiRangeProfilerImpl::Deinitialize() {
+  if (!initialized_) {
+    return absl::FailedPreconditionError("Range profiler not initialized");
+  }
+
+  for (auto& dev : devices_) {
+    dev->Disable().IgnoreError();
+  }
+
+  devices_.clear();
+  initialized_ = false;
+
+  LOG(INFO) << "(Profiling::Range) Deinitialized";
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<CuptiRangeProfilerImpl>>
+CuptiRangeProfilerImpl::Create(int num_gpus,
+                                const CuptiRangeProfilerOptions& options) {
+  std::unique_ptr<CuptiRangeProfilerImpl> profiler(
+      new CuptiRangeProfilerImpl());
+
+  if (num_gpus < 1) {
+    return profiler;
+  }
+
+  TF_RETURN_IF_ERROR(profiler->Initialize(num_gpus, options));
+  return profiler;
+}
+
+#undef DEF_SIZED_PRIV_STRUCT
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/cupti_range_profiler_impl.h
+++ b/xla/backends/profiler/gpu/cupti_range_profiler_impl.h
@@ -69,6 +69,11 @@ class CuptiRangeProfilerDevice {
   absl::Status DecodeData();
   absl::Status Decode(std::vector<RangeResult>* results);
 
+  // Query CUPTI for per-metric properties (description, hw unit).
+  // Returns one entry per enabled metric. Falls back gracefully if the
+  // API is unavailable (e.g. older CUPTI).
+  std::vector<MetricProperties> QueryMetricProperties();
+
   // Disable range profiling and destroy the profiler object.
   absl::Status Disable();
 

--- a/xla/backends/profiler/gpu/cupti_range_profiler_impl.h
+++ b/xla/backends/profiler/gpu/cupti_range_profiler_impl.h
@@ -1,0 +1,146 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_IMPL_H_
+#define XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_IMPL_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_host.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_range_profiler.h"
+#include "xla/backends/profiler/gpu/cupti_interface.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
+
+namespace xla {
+namespace profiler {
+
+// Per-device state for CUPTI range profiling using the new Range Profiling API.
+// Owns the CUpti_RangeProfiler_Object* and all associated data images.
+class CuptiRangeProfilerDevice {
+ public:
+  CuptiRangeProfilerDevice(int device_id,
+                           const CuptiRangeProfilerOptions& options);
+  ~CuptiRangeProfilerDevice();
+
+  // Not copyable or movable.
+  CuptiRangeProfilerDevice(const CuptiRangeProfilerDevice&) = delete;
+  CuptiRangeProfilerDevice(CuptiRangeProfilerDevice&&) = delete;
+  CuptiRangeProfilerDevice& operator=(const CuptiRangeProfilerDevice&) =
+      delete;
+  CuptiRangeProfilerDevice& operator=(CuptiRangeProfilerDevice&&) = delete;
+
+  // Configuration: creates host object and config image.
+  absl::Status CreateConfig();
+
+  // Enable range profiling on the device context, creating the profiler object.
+  absl::Status Enable();
+  // Create counter data image via the range profiler object.
+  absl::Status CreateCounterDataImage();
+  // Set configuration (config image + counter data image) on the profiler.
+  absl::Status SetConfig();
+
+  // Per-pass lifecycle.
+  absl::Status Start();
+  absl::Status Stop(bool* all_passes_collected);
+
+  // Range delimiters.
+  absl::Status PushRange(absl::string_view name);
+  absl::Status PopRange();
+
+  // Post-collection: decode counter data and evaluate metrics.
+  absl::Status DecodeData();
+  absl::Status Decode(std::vector<RangeResult>* results);
+
+  // Disable range profiling and destroy the profiler object.
+  absl::Status Disable();
+
+  // Query number of passes required.
+  absl::Status GetNumPasses(int* num_passes);
+
+  // Accessors.
+  int device_id() const { return device_id_; }
+  const std::vector<std::string>& enabled_metrics() const {
+    return enabled_metrics_;
+  }
+
+ private:
+  int device_id_;
+  CuptiInterface* cupti_interface_;
+
+  // Metric configuration.
+  std::vector<std::string> config_metrics_;
+  std::vector<std::string> enabled_metrics_;
+  std::vector<const char*> c_metrics_;
+
+  // CUPTI objects.
+  std::string chip_name_;
+  std::vector<uint8_t> counter_availability_image_;
+  CUpti_Profiler_Host_Object* host_obj_ = nullptr;
+  std::vector<uint8_t> config_image_;
+  std::vector<uint8_t> counter_data_image_;
+
+  // Range profiler object (new API). Null until Enable() is called.
+  CUpti_RangeProfiler_Object* range_profiler_obj_ = nullptr;
+
+  // Internal initialization steps.
+  absl::Status GetChipName();
+  absl::Status DeviceSupported();
+  absl::Status CreateCounterAvailabilityImage();
+  absl::Status CreateProfilerHostObj();
+  absl::Status CreateConfigImage();
+
+  // Cleanup helpers.
+  void DestroyProfilerHostObj();
+};
+
+// Full implementation of CuptiRangeProfiler using the new Range Profiling API.
+// Orchestrates range profiling across all devices. Unlike PM sampling, range
+// profiling is synchronous: the caller drives passes via BeginPass/EndPass.
+class CuptiRangeProfilerImpl : public CuptiRangeProfiler {
+ public:
+  static absl::StatusOr<std::unique_ptr<CuptiRangeProfilerImpl>> Create(
+      int num_gpus, const CuptiRangeProfilerOptions& options);
+
+  int NumPasses() const override { return num_passes_; }
+
+  absl::Status BeginPass() override;
+  absl::Status EndPass() override;
+  absl::Status PushRange(absl::string_view name) override;
+  absl::Status PopRange() override;
+  absl::Status FlushAndDecode() override;
+  absl::Status Deinitialize() override;
+
+ private:
+  CuptiRangeProfilerImpl() = default;
+
+  absl::Status Initialize(int num_gpus,
+                          const CuptiRangeProfilerOptions& options);
+
+  bool initialized_ = false;
+  int num_passes_ = 1;
+  CuptiRangeProfilerOptions options_;
+  std::vector<std::unique_ptr<CuptiRangeProfilerDevice>> devices_;
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_IMPL_H_

--- a/xla/backends/profiler/gpu/cupti_range_profiler_stub.h
+++ b/xla/backends/profiler/gpu/cupti_range_profiler_stub.h
@@ -1,0 +1,42 @@
+/* Copyright 2025 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_STUB_H_
+#define XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_STUB_H_
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
+
+namespace xla {
+namespace profiler {
+
+class CuptiRangeProfilerStub : public CuptiRangeProfiler {
+ public:
+  int NumPasses() const override { return 1; }
+  absl::Status BeginPass() override { return absl::OkStatus(); }
+  absl::Status EndPass() override { return absl::OkStatus(); }
+  absl::Status PushRange(absl::string_view name) override {
+    return absl::OkStatus();
+  }
+  absl::Status PopRange() override { return absl::OkStatus(); }
+  absl::Status FlushAndDecode() override { return absl::OkStatus(); }
+  absl::Status Deinitialize() override { return absl::OkStatus(); }
+};
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_CUPTI_RANGE_PROFILER_STUB_H_

--- a/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -1197,6 +1197,35 @@ absl::Status CuptiTracer::Enable(
 
   // Enable range profiling after CUPTI is initialized.
   if (option_->range_profiler_options.enable && num_gpus_requested > 0) {
+    // Callback to populate range profiling data to XPlane for each device.
+    // Preserve any user-supplied callback and chain it after XPlane population.
+    auto user_callback = option_->range_profiler_options.process_results;
+    option_->range_profiler_options.process_results =
+        [&xplanes, user_callback](RangeProfilerResults* results) {
+          if (!results) return;
+          int device_id = results->GetDeviceId();
+          if (device_id < 0 ||
+              device_id >= static_cast<int>(xplanes.size())) {
+            LOG(ERROR) << "Device ID " << device_id << " out of range.";
+            return;
+          }
+          if (!xplanes[device_id]) {
+            LOG(ERROR) << "Device ID " << device_id << " XPlane is null.";
+            return;
+          }
+          tensorflow::profiler::XPlane* xplane = xplanes[device_id].get();
+          xplane->set_name(GpuPlaneName(device_id));
+          XPlaneBuilder xplane_builder(xplane);
+          xplane_builder.AddStatValue(
+              *xplane_builder.GetOrCreateStatMetadata(
+                  tsl::profiler::GetStatTypeStr(
+                      tsl::profiler::StatType::kDeviceId)),
+              static_cast<int64_t>(device_id));
+          PopulateRangeProfilingEvents(results, &xplane_builder);
+          if (user_callback) {
+            user_callback(results);
+          }
+        };
     TF_ASSIGN_OR_RETURN(
         cupti_range_profiler_,
         CreateRangeProfiler(num_gpus_requested,

--- a/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -58,6 +58,8 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/cupti_marker_data_parser.h"
 #include "xla/backends/profiler/gpu/cupti_pm_sampler.h"
 #include "xla/backends/profiler/gpu/cupti_pm_sampler_factory.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler_factory.h"
 #include "xla/backends/profiler/gpu/cupti_utils.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
@@ -1097,7 +1099,7 @@ CuptiTracer::CuptiTracer(CuptiInterface* cupti_interface)
 
 bool CuptiTracer::IsAvailable() const {
   return NumGpus() && !activity_tracing_enabled_ && !api_tracing_enabled_ &&
-         !pm_sampling_enabled_;
+         !pm_sampling_enabled_ && !range_profiling_enabled_;
 }
 
 int CuptiTracer::NumGpus() {
@@ -1152,6 +1154,15 @@ absl::Status CuptiTracer::Enable(
   tsl::profiler::AnnotationStack::Enable(true);
 
   int num_gpus_requested = xplanes.size();
+  // PM sampling and range profiling both use the CUPTI profiling subsystem
+  // and cannot be active simultaneously.
+  if (option_->pm_sampler_options.enable &&
+      option_->range_profiler_options.enable) {
+    return absl::InvalidArgumentError(
+        "PM sampling and range profiling cannot be enabled simultaneously. "
+        "Disable one before enabling the other.");
+  }
+
   // Enable PM Sampling after CUPTI is initialized.
   if (option_->pm_sampler_options.enable && num_gpus_requested > 0) {
     // Callback to populate PM sampling data to XPlane for each device.
@@ -1184,10 +1195,52 @@ absl::Status CuptiTracer::Enable(
     pm_sampling_enabled_ = true;
   }
 
+  // Enable range profiling after CUPTI is initialized.
+  if (option_->range_profiler_options.enable && num_gpus_requested > 0) {
+    TF_ASSIGN_OR_RETURN(
+        cupti_range_profiler_,
+        CreateRangeProfiler(num_gpus_requested,
+                            option_->range_profiler_options));
+    int num_passes = cupti_range_profiler_->NumPasses();
+    // Reject multi-pass configurations unless the caller explicitly allows
+    // them. Most XLA workloads cannot replay, so this is the safe default.
+    if (num_passes > 1 && !option_->range_profiler_options.allow_multipass) {
+      cupti_range_profiler_.reset();
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Range profiling requires ", num_passes,
+          " passes for the requested metrics, but allow_multipass is false. "
+          "Either reduce the number of metrics to fit in a single pass, or "
+          "use the multi-hlo-runner which supports multi-pass profiling."));
+    }
+    range_profiling_enabled_ = true;
+    TF_RETURN_IF_ERROR(BeginRangePass());
+    TF_RETURN_IF_ERROR(PushProfilingRange(
+          option_->range_profiler_options.range_name));
+  }
+
   return status;
 }
 
 void CuptiTracer::Disable() {
+  // Flush and tear down range profiling before Cupti Tracer is disabled.
+  if (range_profiling_enabled_) {
+    if (absl::Status status = PopProfilingRange(); !status.ok()) {
+      LOG(WARNING) << "Failed to pop the range profiler range: " << status;
+    }
+    if (absl::Status status = EndRangePass(); !status.ok()) {
+      LOG(WARNING) << "Failed to end the range profiler pass: " << status;
+    }
+    if (absl::Status status = cupti_range_profiler_->FlushAndDecode();
+        !status.ok()) {
+      LOG(WARNING) << "Failed to flush range profiler: " << status;
+    }
+    if (absl::Status status = cupti_range_profiler_->Deinitialize();
+        !status.ok()) {
+      LOG(WARNING) << "Failed to deinitialize range profiler: " << status;
+    }
+    range_profiling_enabled_ = false;
+  }
+
   // Disables the PM Sampling before Cupti Tracer is disabled.
   if (pm_sampling_enabled_) {
     if (absl::Status status = cupti_pm_sampler_->StopSampler(); !status.ok()) {
@@ -1235,6 +1288,31 @@ void CuptiTracer::Disable() {
   option_.reset();
   cupti_driver_api_hook_.reset();
   tsl::profiler::AnnotationStack::Enable(false);
+}
+
+int CuptiTracer::NumRangeProfilingPasses() const {
+  if (!range_profiling_enabled_ || !cupti_range_profiler_) return 1;
+  return cupti_range_profiler_->NumPasses();
+}
+
+absl::Status CuptiTracer::BeginRangePass() {
+  if (!range_profiling_enabled_) return absl::OkStatus();
+  return cupti_range_profiler_->BeginPass();
+}
+
+absl::Status CuptiTracer::EndRangePass() {
+  if (!range_profiling_enabled_) return absl::OkStatus();
+  return cupti_range_profiler_->EndPass();
+}
+
+absl::Status CuptiTracer::PushProfilingRange(absl::string_view name) {
+  if (!range_profiling_enabled_) return absl::OkStatus();
+  return cupti_range_profiler_->PushRange(name);
+}
+
+absl::Status CuptiTracer::PopProfilingRange() {
+  if (!range_profiling_enabled_) return absl::OkStatus();
+  return cupti_range_profiler_->PopRange();
 }
 
 // Generate default callback ids list that tracer needs to enable them.

--- a/xla/backends/profiler/gpu/cupti_tracer.h
+++ b/xla/backends/profiler/gpu/cupti_tracer.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/cupti_collector.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 #include "xla/backends/profiler/gpu/cupti_pm_sampler.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
 namespace xla {
@@ -62,6 +63,10 @@ struct CuptiTracerOptions {
   // This currently can not run second session with HES enabled, so do not turn
   // on this. TODO(b/466437495): Remove this comment once the bug is fixed.
   bool enable_activity_hardware_tracing = false;
+  // Range profiling configuration (defaults disabled).
+  // Only read during creation of a range profiling object, later changes have
+  // no effect.
+  CuptiRangeProfilerOptions range_profiler_options{};
 };
 
 class CuptiTracer;
@@ -157,6 +162,15 @@ class CuptiTracer {
     return option_.has_value() ? option_->required_callback_api_events : false;
   }
 
+  // Range profiling pass/range control. These delegate to the underlying
+  // CuptiRangeProfiler and are no-ops when range profiling is not enabled.
+  bool IsRangeProfilingEnabled() const { return range_profiling_enabled_; }
+  int NumRangeProfilingPasses() const;
+  absl::Status BeginRangePass();
+  absl::Status EndRangePass();
+  absl::Status PushProfilingRange(absl::string_view name);
+  absl::Status PopProfilingRange();
+
  protected:
   // protected constructor for injecting mock cupti interface for testing.
   explicit CuptiTracer(CuptiInterface* cupti_interface);
@@ -199,6 +213,7 @@ class CuptiTracer {
   int num_gpus_;
   std::optional<CuptiTracerOptions> option_;
   std::unique_ptr<xla::profiler::CuptiPmSampler> cupti_pm_sampler_;
+  std::unique_ptr<xla::profiler::CuptiRangeProfiler> cupti_range_profiler_;
   CuptiInterface* cupti_interface_ = nullptr;
   CuptiTraceCollector* collector_ = nullptr;
 
@@ -207,6 +222,7 @@ class CuptiTracer {
 
   bool api_tracing_enabled_ = false;
   bool pm_sampling_enabled_ = false;
+  bool range_profiling_enabled_ = false;
   // Cupti handle for driver or runtime API callbacks. Cupti permits a single
   // subscriber to be active at any time and can be used to trace Cuda runtime
   // as and driver calls for all contexts and devices.

--- a/xla/backends/profiler/gpu/cupti_tracer_options_utils.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer_options_utils.cc
@@ -117,6 +117,24 @@ absl::Status UpdateCuptiTracerOptionsFromProfilerOptions(
             1024ULL;
       }));
 
+  TF_RETURN_IF_ERROR(SetValue<std::string>(
+      profile_options, "gpu_range_profiling_counters", input_keys,
+      [&](const std::string& value) {
+        std::vector<std::string> metrics;
+        for (absl::string_view metric :
+             absl::StrSplit(value, ',', absl::SkipEmpty())) {
+          metrics.push_back(std::string(absl::StripAsciiWhitespace(metric)));
+        }
+        tracer_options.range_profiler_options.metrics = metrics;
+        tracer_options.range_profiler_options.enable = !metrics.empty();
+      }));
+
+  TF_RETURN_IF_ERROR(SetValue<bool>(
+      profile_options, "gpu_range_profiling_allow_multipass", input_keys,
+      [&](bool value) {
+        tracer_options.range_profiler_options.allow_multipass = value;
+      }));
+
   if (!input_keys.empty()) {
     return absl::InvalidArgumentError(absl::StrCat(
         "Parsing advanced_configuration failed for CUPTI tracer. The following "

--- a/xla/backends/profiler/gpu/cupti_wrapper.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper.cc
@@ -270,6 +270,31 @@ cuptiProfilerCounterDataImageCalculateScratchBufferSize(
     CUpti_PmSampling_GetCounterDataInfo_Params* params);
 [[gnu::weak]] CUptiResult cuptiPmSamplingCounterDataGetSampleInfo(
     CUpti_PmSampling_CounterData_GetSampleInfo_Params* params);
+
+[[gnu::weak]] CUptiResult cuptiRangeProfilerEnable(
+    CUpti_RangeProfiler_Enable_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerDisable(
+    CUpti_RangeProfiler_Disable_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerGetCounterDataSize(
+    CUpti_RangeProfiler_GetCounterDataSize_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerCounterDataImageInitialize(
+    CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerSetConfig(
+    CUpti_RangeProfiler_SetConfig_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerStart(
+    CUpti_RangeProfiler_Start_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerStop(
+    CUpti_RangeProfiler_Stop_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerPushRange(
+    CUpti_RangeProfiler_PushRange_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerPopRange(
+    CUpti_RangeProfiler_PopRange_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerDecodeData(
+    CUpti_RangeProfiler_DecodeData_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerGetCounterDataInfo(
+    CUpti_RangeProfiler_GetCounterDataInfo_Params* params);
+[[gnu::weak]] CUptiResult cuptiRangeProfilerCounterDataGetRangeInfo(
+    CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params);
 }
 
 // Profiler Host APIs
@@ -664,6 +689,115 @@ CUptiResult CuptiWrapper::PmSamplingCounterDataGetSampleInfo(
     CUpti_PmSampling_CounterData_GetSampleInfo_Params* params) {
   if (cuptiPmSamplingCounterDataGetSampleInfo != nullptr) {
     return cuptiPmSamplingCounterDataGetSampleInfo(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+// Range profiling APIs
+CUptiResult CuptiWrapper::RangeProfilerEnable(
+    CUpti_RangeProfiler_Enable_Params* params) {
+  if (cuptiRangeProfilerEnable != nullptr) {
+    return cuptiRangeProfilerEnable(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerDisable(
+    CUpti_RangeProfiler_Disable_Params* params) {
+  if (cuptiRangeProfilerDisable != nullptr) {
+    return cuptiRangeProfilerDisable(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerGetCounterDataSize(
+    CUpti_RangeProfiler_GetCounterDataSize_Params* params) {
+  if (cuptiRangeProfilerGetCounterDataSize != nullptr) {
+    return cuptiRangeProfilerGetCounterDataSize(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerCounterDataImageInitialize(
+    CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params) {
+  if (cuptiRangeProfilerCounterDataImageInitialize != nullptr) {
+    return cuptiRangeProfilerCounterDataImageInitialize(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerSetConfig(
+    CUpti_RangeProfiler_SetConfig_Params* params) {
+  if (cuptiRangeProfilerSetConfig != nullptr) {
+    return cuptiRangeProfilerSetConfig(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerStart(
+    CUpti_RangeProfiler_Start_Params* params) {
+  if (cuptiRangeProfilerStart != nullptr) {
+    return cuptiRangeProfilerStart(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerStop(
+    CUpti_RangeProfiler_Stop_Params* params) {
+  if (cuptiRangeProfilerStop != nullptr) {
+    return cuptiRangeProfilerStop(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerPushRange(
+    CUpti_RangeProfiler_PushRange_Params* params) {
+  if (cuptiRangeProfilerPushRange != nullptr) {
+    return cuptiRangeProfilerPushRange(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerPopRange(
+    CUpti_RangeProfiler_PopRange_Params* params) {
+  if (cuptiRangeProfilerPopRange != nullptr) {
+    return cuptiRangeProfilerPopRange(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerDecodeData(
+    CUpti_RangeProfiler_DecodeData_Params* params) {
+  if (cuptiRangeProfilerDecodeData != nullptr) {
+    return cuptiRangeProfilerDecodeData(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerGetCounterDataInfo(
+    CUpti_RangeProfiler_GetCounterDataInfo_Params* params) {
+  if (cuptiRangeProfilerGetCounterDataInfo != nullptr) {
+    return cuptiRangeProfilerGetCounterDataInfo(params);
+  } else {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+}
+
+CUptiResult CuptiWrapper::RangeProfilerCounterDataGetRangeInfo(
+    CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params) {
+  if (cuptiRangeProfilerCounterDataGetRangeInfo != nullptr) {
+    return cuptiRangeProfilerCounterDataGetRangeInfo(params);
   } else {
     return CUPTI_ERROR_NOT_SUPPORTED;
   }

--- a/xla/backends/profiler/gpu/cupti_wrapper.h
+++ b/xla/backends/profiler/gpu/cupti_wrapper.h
@@ -193,6 +193,32 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
   CUptiResult PmSamplingCounterDataGetSampleInfo(
       CUpti_PmSampling_CounterData_GetSampleInfo_Params* params) override;
 
+  // Range profiling specific functions
+  CUptiResult RangeProfilerEnable(
+      CUpti_RangeProfiler_Enable_Params* params) override;
+  CUptiResult RangeProfilerDisable(
+      CUpti_RangeProfiler_Disable_Params* params) override;
+  CUptiResult RangeProfilerGetCounterDataSize(
+      CUpti_RangeProfiler_GetCounterDataSize_Params* params) override;
+  CUptiResult RangeProfilerCounterDataImageInitialize(
+      CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params) override;
+  CUptiResult RangeProfilerSetConfig(
+      CUpti_RangeProfiler_SetConfig_Params* params) override;
+  CUptiResult RangeProfilerStart(
+      CUpti_RangeProfiler_Start_Params* params) override;
+  CUptiResult RangeProfilerStop(
+      CUpti_RangeProfiler_Stop_Params* params) override;
+  CUptiResult RangeProfilerPushRange(
+      CUpti_RangeProfiler_PushRange_Params* params) override;
+  CUptiResult RangeProfilerPopRange(
+      CUpti_RangeProfiler_PopRange_Params* params) override;
+  CUptiResult RangeProfilerDecodeData(
+      CUpti_RangeProfiler_DecodeData_Params* params) override;
+  CUptiResult RangeProfilerGetCounterDataInfo(
+      CUpti_RangeProfiler_GetCounterDataInfo_Params* params) override;
+  CUptiResult RangeProfilerCounterDataGetRangeInfo(
+      CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params) override;
+
   CUptiResult DeviceGetChipName(
       CUpti_Device_GetChipName_Params* params) override;
 
@@ -372,6 +398,32 @@ class CuptiWrapperStub : public xla::profiler::CuptiInterface {
       CUpti_PmSampling_GetCounterDataInfo_Params* params) override;
   CUptiResult PmSamplingCounterDataGetSampleInfo(
       CUpti_PmSampling_CounterData_GetSampleInfo_Params* params) override;
+
+  // Range profiling specific functions
+  CUptiResult RangeProfilerEnable(
+      CUpti_RangeProfiler_Enable_Params* params) override;
+  CUptiResult RangeProfilerDisable(
+      CUpti_RangeProfiler_Disable_Params* params) override;
+  CUptiResult RangeProfilerGetCounterDataSize(
+      CUpti_RangeProfiler_GetCounterDataSize_Params* params) override;
+  CUptiResult RangeProfilerCounterDataImageInitialize(
+      CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params) override;
+  CUptiResult RangeProfilerSetConfig(
+      CUpti_RangeProfiler_SetConfig_Params* params) override;
+  CUptiResult RangeProfilerStart(
+      CUpti_RangeProfiler_Start_Params* params) override;
+  CUptiResult RangeProfilerStop(
+      CUpti_RangeProfiler_Stop_Params* params) override;
+  CUptiResult RangeProfilerPushRange(
+      CUpti_RangeProfiler_PushRange_Params* params) override;
+  CUptiResult RangeProfilerPopRange(
+      CUpti_RangeProfiler_PopRange_Params* params) override;
+  CUptiResult RangeProfilerDecodeData(
+      CUpti_RangeProfiler_DecodeData_Params* params) override;
+  CUptiResult RangeProfilerGetCounterDataInfo(
+      CUpti_RangeProfiler_GetCounterDataInfo_Params* params) override;
+  CUptiResult RangeProfilerCounterDataGetRangeInfo(
+      CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params) override;
 
   CUptiResult DeviceGetChipName(
       CUpti_Device_GetChipName_Params* params) override;

--- a/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
@@ -364,6 +364,67 @@ CUptiResult CuptiWrapperStub::PmSamplingCounterDataGetSampleInfo(
   return CUPTI_SUCCESS;
 }
 
+// Range profiling specific functions
+CUptiResult CuptiWrapperStub::RangeProfilerEnable(
+    CUpti_RangeProfiler_Enable_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerDisable(
+    CUpti_RangeProfiler_Disable_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerGetCounterDataSize(
+    CUpti_RangeProfiler_GetCounterDataSize_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerCounterDataImageInitialize(
+    CUpti_RangeProfiler_CounterDataImage_Initialize_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerSetConfig(
+    CUpti_RangeProfiler_SetConfig_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerStart(
+    CUpti_RangeProfiler_Start_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerStop(
+    CUpti_RangeProfiler_Stop_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerPushRange(
+    CUpti_RangeProfiler_PushRange_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerPopRange(
+    CUpti_RangeProfiler_PopRange_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerDecodeData(
+    CUpti_RangeProfiler_DecodeData_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerGetCounterDataInfo(
+    CUpti_RangeProfiler_GetCounterDataInfo_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::RangeProfilerCounterDataGetRangeInfo(
+    CUpti_RangeProfiler_CounterData_GetRangeInfo_Params* params) {
+  return CUPTI_SUCCESS;
+}
+
 CUptiResult CuptiWrapperStub::DeviceGetChipName(
     CUpti_Device_GetChipName_Params* params) {
   return CUPTI_SUCCESS;

--- a/xla/backends/profiler/gpu/device_tracer_cuda.cc
+++ b/xla/backends/profiler/gpu/device_tracer_cuda.cc
@@ -190,11 +190,12 @@ absl::Status GpuTracer::CollectData(XSpace* space) {
       if (!events_dropped.empty()) {
         space->add_warnings(std::move(events_dropped));
       }
-      if (options_.pm_sampler_options.enable) {
-        // Adds PM sampling xplanes to the response before CuptiCollector to
-        // merge and export all the events.
+      if (options_.pm_sampler_options.enable ||
+          options_.range_profiler_options.enable) {
+        // Adds PM sampling / range profiling xplanes to the response before
+        // CuptiCollector so Export() merges kernel records into the same planes.
         for (auto& xplane : xplanes_) {
-          if (xplane) {
+          if (xplane && xplane->lines_size() > 0) {
             *space->add_planes() = *xplane;
           }
         }

--- a/xla/backends/profiler/gpu/mock_cupti.h
+++ b/xla/backends/profiler/gpu/mock_cupti.h
@@ -218,6 +218,38 @@ class MockCupti : public xla::profiler::CuptiInterface {
               (CUpti_PmSampling_CounterData_GetSampleInfo_Params * params),
               (override));
 
+  // Range Profiling APIs
+  MOCK_METHOD(CUptiResult, RangeProfilerEnable,
+              (CUpti_RangeProfiler_Enable_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerDisable,
+              (CUpti_RangeProfiler_Disable_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerGetCounterDataSize,
+              (CUpti_RangeProfiler_GetCounterDataSize_Params * params),
+              (override));
+  MOCK_METHOD(
+      CUptiResult, RangeProfilerCounterDataImageInitialize,
+      (CUpti_RangeProfiler_CounterDataImage_Initialize_Params * params),
+      (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerSetConfig,
+              (CUpti_RangeProfiler_SetConfig_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerStart,
+              (CUpti_RangeProfiler_Start_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerStop,
+              (CUpti_RangeProfiler_Stop_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerPushRange,
+              (CUpti_RangeProfiler_PushRange_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerPopRange,
+              (CUpti_RangeProfiler_PopRange_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerDecodeData,
+              (CUpti_RangeProfiler_DecodeData_Params * params), (override));
+  MOCK_METHOD(CUptiResult, RangeProfilerGetCounterDataInfo,
+              (CUpti_RangeProfiler_GetCounterDataInfo_Params * params),
+              (override));
+  MOCK_METHOD(
+      CUptiResult, RangeProfilerCounterDataGetRangeInfo,
+      (CUpti_RangeProfiler_CounterData_GetRangeInfo_Params * params),
+      (override));
+
   MOCK_METHOD(CUptiResult, DeviceGetChipName,
               (CUpti_Device_GetChipName_Params * params), (override));
 

--- a/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
+++ b/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/profile_with_cuda_kernels.h"
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -31,6 +32,7 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/cupti_collector.h"
 #include "xla/backends/profiler/gpu/cupti_error_manager.h"
 #include "xla/backends/profiler/gpu/cupti_pm_sampler.h"
+#include "xla/backends/profiler/gpu/cupti_range_profiler.h"
 #include "xla/backends/profiler/gpu/cupti_tracer.h"
 #include "xla/backends/profiler/gpu/cupti_wrapper.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
@@ -72,8 +74,8 @@ void HandleRecords(PmSamples* samples) {
   // Validate we have the expected metrics
   const std::vector<std::string>& metrics = samples->GetMetrics();
   const std::vector<SamplerRange>& sampler_ranges = samples->GetSamplerRanges();
-  auto back = sampler_ranges.back();
-  auto front = sampler_ranges.front();
+  const auto& back = sampler_ranges.back();
+  const auto& front = sampler_ranges.front();
   double ranges_duration = back.end_timestamp_ns - front.start_timestamp_ns;
   double ns_per_sample = ranges_duration / samples->GetNumSamples();
 
@@ -85,10 +87,10 @@ void HandleRecords(PmSamples* samples) {
     EXPECT_LT(ns_per_sample, 500000.0 * 1.1);
   }
 
-  for (int i = 0; i < metrics.size(); i++) {
+  for (size_t i = 0; i < metrics.size(); i++) {
     double sum = 0;
 
-    for (int j = 0; j < sampler_ranges.size(); j++) {
+    for (size_t j = 0; j < sampler_ranges.size(); j++) {
       sum += sampler_ranges[j].metric_values[i];
     }
 
@@ -154,7 +156,7 @@ void SimpleAddSubWithProfilerTest(bool enable_activity_hardware_tracing,
 
   std::vector<std::unique_ptr<tensorflow::profiler::XPlane>> xplanes;
   xplanes.reserve(collector_options.num_gpus);
-  for (int i = 0; i < collector_options.num_gpus; ++i) {
+  for (uint32_t i = 0; i < collector_options.num_gpus; ++i) {
     xplanes.push_back(std::make_unique<tensorflow::profiler::XPlane>());
   }
   auto err = tracer.Enable(tracer_options, collector.get(), xplanes);
@@ -175,7 +177,7 @@ void SimpleAddSubWithProfilerTest(bool enable_activity_hardware_tracing,
 
   xplanes.clear();
   xplanes.reserve(collector_options.num_gpus);
-  for (int i = 0; i < collector_options.num_gpus; ++i) {
+  for (uint32_t i = 0; i < collector_options.num_gpus; ++i) {
     xplanes.push_back(std::make_unique<tensorflow::profiler::XPlane>());
   }
   err = tracer.Enable(tracer_options, collector.get(), xplanes);
@@ -220,6 +222,258 @@ TEST(ProfilerCudaKernelSanityTest, SimpleAddSubWithHESDisabled) {
 TEST(ProfilerCudaKernelSanityTest, SimpleAddSubWithHESEnabled) {
   SimpleAddSubWithProfilerTest(/*enable_activity_hardware_tracing=*/true,
                                /*enable_pm_sampling=*/false);
+}
+
+// --- Range Profiling Tests ---
+
+std::atomic_bool range_results_received = false;
+std::atomic_int range_results_num_ranges = 0;
+std::atomic_int range_results_num_metrics = 0;
+std::atomic<double> range_results_fp64_sum = 0;
+
+void HandleRangeResults(RangeProfilerResults* results) {
+  LOG(INFO) << "Range profiling results received for device "
+            << results->GetDeviceId();
+  LOG(INFO) << "  Metrics: " << results->GetMetrics().size()
+            << ", Ranges: " << results->GetRanges().size();
+
+  const auto& metrics = results->GetMetrics();
+  for (const auto& range : results->GetRanges()) {
+    LOG(INFO) << "  Range: " << range.range_name;
+    for (size_t i = 0; i < range.metric_values.size(); ++i) {
+      LOG(INFO) << "    " << metrics[i] << " = " << range.metric_values[i];
+      if (metrics[i] == "sm__inst_executed_pipe_fp64.sum") {
+        range_results_fp64_sum = range_results_fp64_sum + range.metric_values[i];
+      }
+    }
+  }
+
+  range_results_received = true;
+  range_results_num_ranges += results->GetRanges().size();
+  range_results_num_metrics += results->GetMetrics().size();
+}
+
+TEST(ProfilerCudaKernelSanityTest, SimpleAddSubWithRangeProfiling) {
+  uint32_t cupti_version = 0;
+  cuptiGetVersion(&cupti_version);
+  LOG(INFO) << "RUNTIME CUPTI version " << cupti_version
+            << " and CUPTI_API_VERSION " << CUPTI_API_VERSION;
+
+  if (cupti_version < 24 || CUPTI_API_VERSION < 24) {
+    GTEST_SKIP() << "Range profiling requires CUPTI API version >= 24";
+  }
+
+  constexpr int kNumElements = 256 * 1024;
+
+  // Ensure a CUDA context exists before range profiler initialization.
+  SimpleAddSubWithProfiler(kNumElements);
+
+  CuptiTracerCollectorOptions collector_options{};
+  collector_options.num_gpus = CuptiTracer::NumGpus();
+  LOG(INFO) << "Cupti found #gpus: " << collector_options.num_gpus;
+  uint64_t start_walltime_ns = absl::GetCurrentTimeNanos();
+  uint64_t start_gputime_ns = CuptiTracer::GetTimestamp();
+  auto collector = CreateCuptiCollector(collector_options, start_walltime_ns,
+                                        start_gputime_ns);
+
+  CuptiRangeProfilerOptions range_options;
+  range_options.enable = true;
+  range_options.metrics = {"sm__cycles_active.sum"};
+  range_options.range_mode = CuptiRangeMode::kUser;
+  range_options.range_name = "test_range";
+  range_options.process_results = HandleRangeResults;
+
+  CuptiTracerOptions tracer_options{};
+  tracer_options.enable_nvtx_tracking = false;
+  tracer_options.activities_selected.push_back(
+      CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
+  tracer_options.cupti_finalize = true;
+  tracer_options.range_profiler_options = range_options;
+
+  CuptiErrorManager error_manager(std::make_unique<CuptiWrapper>());
+  TestableCuptiTracer tracer(&error_manager);
+
+  std::vector<std::unique_ptr<tensorflow::profiler::XPlane>> xplanes;
+  xplanes.reserve(collector_options.num_gpus);
+  for (uint32_t i = 0; i < collector_options.num_gpus; ++i) {
+    xplanes.push_back(std::make_unique<tensorflow::profiler::XPlane>());
+  }
+  auto err = tracer.Enable(tracer_options, collector.get(), xplanes);
+
+  if (absl::IsPermissionDenied(err)) {
+    GTEST_SKIP() << "Range profiling requires root/admin access";
+  }
+  if (!err.ok()) {
+    GTEST_SKIP() << "Range profiling Enable failed: " << err;
+  }
+
+  ASSERT_TRUE(tracer.IsRangeProfilingEnabled());
+
+  int num_passes = tracer.NumRangeProfilingPasses();
+  LOG(INFO) << "Range profiling requires " << num_passes << " passes";
+  ASSERT_GT(num_passes, 0);
+
+  // Reset result tracking.
+  range_results_received = false;
+  range_results_num_ranges = 0;
+  range_results_num_metrics = 0;
+
+  // Enable() started the first pass (BeginPass + PushRange).
+  // Run the workload once per pass, with inter-pass transitions in between.
+  for (int pass = 0; pass < num_passes; ++pass) {
+    LOG(INFO) << "Starting pass " << pass;
+
+    std::vector<double> vec = SimpleAddSubWithProfiler(kNumElements);
+
+    // Validate kernel correctness.
+    EXPECT_EQ(vec.size(), kNumElements);
+    EXPECT_THAT(vec, Each(DistanceFrom(0, Lt(0.001))));
+
+    // Transition between passes (not after the last — Disable handles that).
+    if (pass < num_passes - 1) {
+      ASSERT_TRUE(tracer.PopProfilingRange().ok());
+      ASSERT_TRUE(tracer.EndRangePass().ok());
+      ASSERT_TRUE(tracer.BeginRangePass().ok());
+      ASSERT_TRUE(tracer.PushProfilingRange("test_range").ok());
+    }
+  }
+
+  // Disable() ends the last pass (PopRange + EndPass) then FlushAndDecode.
+  tracer.Disable();
+
+  // Validate that results were delivered.
+  EXPECT_TRUE(range_results_received);
+  EXPECT_GT(range_results_num_ranges, 0);
+  EXPECT_GT(range_results_num_metrics, 0);
+}
+
+// Multi-pass variant: request metrics from different counter groups to force
+// CUPTI to require more than one replay pass.
+TEST(ProfilerCudaKernelSanityTest, SimpleAddSubWithMultiPassRangeProfiling) {
+  uint32_t cupti_version = 0;
+  cuptiGetVersion(&cupti_version);
+  if (cupti_version < 24 || CUPTI_API_VERSION < 24) {
+    GTEST_SKIP() << "Range profiling requires CUPTI API version >= 24";
+  }
+
+  constexpr int kNumElements = 256 * 1024;
+
+  // Run a trivial kernel to ensure a CUDA context exists before range
+  // profiler initialization (cuptiProfilerGetCounterAvailability requires it).
+  SimpleAddSubWithProfiler(kNumElements);
+
+  CuptiTracerCollectorOptions collector_options{};
+  collector_options.num_gpus = CuptiTracer::NumGpus();
+  uint64_t start_walltime_ns = absl::GetCurrentTimeNanos();
+  uint64_t start_gputime_ns = CuptiTracer::GetTimestamp();
+  auto collector = CreateCuptiCollector(collector_options, start_walltime_ns,
+                                        start_gputime_ns);
+
+  // Metrics spanning multiple HW units to force multi-pass collection.
+  // ~25 metrics across smsp, sm, l1tex, dram, and fbpa units.
+  CuptiRangeProfilerOptions range_options;
+  range_options.enable = true;
+  range_options.metrics = {
+      // FP64 pipe instruction count — used to validate kernel correctness.
+      "sm__inst_executed_pipe_fp64.sum",
+      "smsp__inst_executed.sum",
+      "smsp__cycles_active.sum",
+      "smsp__inst_executed_op_global_ld.sum",
+      "smsp__thread_inst_executed_pred_on.sum",
+      // DRAM counters.
+      "dram__bytes.sum",
+      "dram__throughput.avg_pct_of_peak_sustained_elapsed",
+      "dram__cycles_active.sum",
+      "dram__sectors.sum",
+      // FBPA counters.
+      "fbpa__dram_read_bytes.sum",
+      "fbpa__dram_write_bytes.sum",
+      "fbpa__dram_sectors.sum",
+  };
+  range_options.range_mode = CuptiRangeMode::kUser;
+  range_options.range_name = "test_multipass";
+  range_options.allow_multipass = true;
+  range_options.process_results = HandleRangeResults;
+
+  CuptiTracerOptions tracer_options{};
+  tracer_options.enable_nvtx_tracking = false;
+  tracer_options.activities_selected.push_back(
+      CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
+  tracer_options.cupti_finalize = true;
+  tracer_options.range_profiler_options = range_options;
+
+  CuptiErrorManager error_manager(std::make_unique<CuptiWrapper>());
+  TestableCuptiTracer tracer(&error_manager);
+
+  std::vector<std::unique_ptr<tensorflow::profiler::XPlane>> xplanes;
+  xplanes.reserve(collector_options.num_gpus);
+  for (uint32_t i = 0; i < collector_options.num_gpus; ++i) {
+    xplanes.push_back(std::make_unique<tensorflow::profiler::XPlane>());
+  }
+  auto err = tracer.Enable(tracer_options, collector.get(), xplanes);
+
+  if (absl::IsPermissionDenied(err)) {
+    GTEST_SKIP() << "Range profiling requires root/admin access";
+  }
+  if (!err.ok()) {
+    GTEST_SKIP() << "Range profiling Enable failed: " << err;
+  }
+
+  ASSERT_TRUE(tracer.IsRangeProfilingEnabled());
+
+  int num_passes = tracer.NumRangeProfilingPasses();
+  LOG(INFO) << "Multi-pass range profiling requires " << num_passes
+            << " passes";
+  ASSERT_GT(num_passes, 0);
+
+  // Reset result tracking.
+  range_results_received = false;
+  range_results_num_ranges = 0;
+  range_results_num_metrics = 0;
+  range_results_fp64_sum = 0;
+
+  // Enable() started the first pass (BeginPass + PushRange).
+  // Run the workload once per pass, with inter-pass transitions in between.
+  for (int pass = 0; pass < num_passes; ++pass) {
+    LOG(INFO) << "Starting pass " << pass << " of " << num_passes;
+
+    std::vector<double> vec = SimpleAddSubWithProfiler(kNumElements);
+    EXPECT_EQ(vec.size(), kNumElements);
+    EXPECT_THAT(vec, Each(DistanceFrom(0, Lt(0.001))));
+
+    // Transition between passes (not after the last — Disable handles that).
+    if (pass < num_passes - 1) {
+      ASSERT_TRUE(tracer.PopProfilingRange().ok());
+      ASSERT_TRUE(tracer.EndRangePass().ok());
+      ASSERT_TRUE(tracer.BeginRangePass().ok());
+      ASSERT_TRUE(tracer.PushProfilingRange("test_multipass").ok());
+    }
+  }
+
+  // Disable() ends the last pass (PopRange + EndPass) then FlushAndDecode.
+  tracer.Disable();
+
+  EXPECT_TRUE(range_results_received);
+  EXPECT_GT(range_results_num_ranges, 0);
+  EXPECT_GT(range_results_num_metrics, 0);
+
+  // Validate FP64 instruction count.
+  // The kernel launches 4 VecAdd/VecSub kernels, each executing
+  // num_elements / 32 warp-level FP64 instructions.
+  double fp64_target = kNumElements * 4.0 / 32.0;
+  double fp64_actual = range_results_fp64_sum.load();
+  LOG(INFO) << "FP64 instructions: expected " << fp64_target
+            << ", actual " << fp64_actual;
+  EXPECT_THAT(fp64_actual, DistanceFrom(fp64_target, Lt(fp64_target * 0.05)));
+
+  if (num_passes == 1) {
+    LOG(WARNING) << "All metrics fit in a single pass on this GPU; "
+                 << "multi-pass replay path was not exercised. "
+                 << "This is expected on some architectures.";
+  } else {
+    LOG(INFO) << "Multi-pass collection confirmed: " << num_passes
+              << " passes required.";
+  }
 }
 
 }  // namespace

--- a/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
+++ b/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
@@ -35,6 +35,7 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/cupti_range_profiler.h"
 #include "xla/backends/profiler/gpu/cupti_tracer.h"
 #include "xla/backends/profiler/gpu/cupti_wrapper.h"
+// #include "xla/tsl/platform/env.h"  // Uncomment for XSpace dump block below.
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
 namespace xla {
@@ -505,6 +506,27 @@ TEST(ProfilerCudaKernelSanityTest, SimpleAddSubWithMultiPassRangeProfiling) {
   }
   EXPECT_TRUE(found_counter_value)
       << "XPlane should contain range profiling events with kCounterValue";
+
+  // To dump XSpace for manual xprof inspection, uncomment the block below.
+  // Mirrors GpuTracer::CollectData(): add xplanes first so Export() merges
+  // kernel records into the same device planes.
+  // {
+  //   tensorflow::profiler::XSpace space;
+  //   for (auto& xplane : xplanes) {
+  //     if (xplane && xplane->lines_size() > 0) {
+  //       *space.add_planes() = *xplane;
+  //     }
+  //   }
+  //   collector->Export(&space, CuptiTracer::GetTimestamp());
+  //   std::string serialized;
+  //   space.SerializeToString(&serialized);
+  //   std::string path = "/tmp/range_profiling.xspace.pb";
+  //   const char* test_outputs_dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR");
+  //   if (test_outputs_dir != nullptr) {
+  //     path = std::string(test_outputs_dir) + "/range_profiling.xspace.pb";
+  //   }
+  //   tsl::WriteStringToFile(tsl::Env::Default(), path, serialized).IgnoreError();
+  // }
 
   if (num_passes == 1) {
     LOG(WARNING) << "All metrics fit in a single pass on this GPU; "

--- a/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
+++ b/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
@@ -341,10 +341,31 @@ TEST(ProfilerCudaKernelSanityTest, SimpleAddSubWithRangeProfiling) {
   // Disable() ends the last pass (PopRange + EndPass) then FlushAndDecode.
   tracer.Disable();
 
-  // Validate that results were delivered.
+  // Validate that results were delivered via the chained user callback.
   EXPECT_TRUE(range_results_received);
   EXPECT_GT(range_results_num_ranges, 0);
   EXPECT_GT(range_results_num_metrics, 0);
+
+  // Validate that range profiling results were written to XPlane.
+  ASSERT_FALSE(xplanes.empty());
+  ASSERT_NE(xplanes[0], nullptr);
+  const auto& plane = *xplanes[0];
+  // Must have at least one line (one profiled range).
+  EXPECT_GT(plane.lines_size(), 0);
+  // Each line should have events with kCounterValue stats.
+  bool found_counter_value = false;
+  for (const auto& line : plane.lines()) {
+    for (const auto& event : line.events()) {
+      for (const auto& stat : event.stats()) {
+        if (plane.stat_metadata().at(stat.metadata_id()).name() ==
+            "counter_value") {
+          found_counter_value = true;
+        }
+      }
+    }
+  }
+  EXPECT_TRUE(found_counter_value)
+      << "XPlane should contain range profiling events with kCounterValue";
 }
 
 // Multi-pass variant: request metrics from different counter groups to force
@@ -465,6 +486,25 @@ TEST(ProfilerCudaKernelSanityTest, SimpleAddSubWithMultiPassRangeProfiling) {
   LOG(INFO) << "FP64 instructions: expected " << fp64_target
             << ", actual " << fp64_actual;
   EXPECT_THAT(fp64_actual, DistanceFrom(fp64_target, Lt(fp64_target * 0.05)));
+
+  // Validate that range profiling results were written to XPlane.
+  ASSERT_FALSE(xplanes.empty());
+  ASSERT_NE(xplanes[0], nullptr);
+  const auto& plane = *xplanes[0];
+  EXPECT_GT(plane.lines_size(), 0);
+  bool found_counter_value = false;
+  for (const auto& line : plane.lines()) {
+    for (const auto& event : line.events()) {
+      for (const auto& stat : event.stats()) {
+        if (plane.stat_metadata().at(stat.metadata_id()).name() ==
+            "counter_value") {
+          found_counter_value = true;
+        }
+      }
+    }
+  }
+  EXPECT_TRUE(found_counter_value)
+      << "XPlane should contain range profiling events with kCounterValue";
 
   if (num_passes == 1) {
     LOG(WARNING) << "All metrics fit in a single pass on this GPU; "

--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -38,6 +38,7 @@ cc_library(
     testonly = True,
     srcs = ["hlo_runner_main.cc"],
     compatible_with = None,
+    local_defines = if_cuda(["GOOGLE_CUDA=1"]),
     tags = ["no_mac"],
     deps = [
         ":create_client",
@@ -160,6 +161,7 @@ cc_library(
     name = "functional_hlo_runner",
     srcs = ["functional_hlo_runner.cc"],
     hdrs = ["functional_hlo_runner.h"],
+    local_defines = if_cuda(["GOOGLE_CUDA=1"]),
     deps = [
         ":hlo_input_output_format",
         ":profiler_interface",
@@ -220,7 +222,10 @@ cc_library(
         "@tsl//tsl/profiler/lib:profiler_session_impl",
         "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
-    ],
+    ] + if_cuda([
+        "//xla/backends/profiler/gpu:cupti_tracer",
+        "//xla/backends/profiler/gpu:device_tracer",  # Needed for CUPTI range profiling advanced config parsing.
+    ]),
 )
 
 filegroup(
@@ -231,6 +236,7 @@ filegroup(
 xla_test(
     name = "functional_hlo_runner_test",
     srcs = ["functional_hlo_runner_test.cc"],
+    copts = if_cuda(["-DGOOGLE_CUDA=1"]),
     backend_tags = {
         "h100": [
             "full",

--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -301,7 +301,12 @@ xla_test(
         "@tsl//tsl/platform",
         "@tsl//tsl/platform:path",
         "@tsl//tsl/platform:protobuf",
-    ] + if_cuda(["//xla/tsl/cuda:nvml"]),
+    ] + if_cuda_or_rocm([
+        "//xla/backends/profiler/gpu:device_tracer",
+    ]) + if_cuda([
+        "//xla/backends/profiler/gpu:cupti_tracer",
+        "//xla/tsl/cuda:nvml",
+    ]),
 )
 
 tsl_pybind_extension(

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.cc
@@ -90,6 +90,10 @@ limitations under the License.
 #include "tsl/profiler/protobuf/profiler_options.pb.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
+#if GOOGLE_CUDA
+#include "xla/backends/profiler/gpu/cupti_tracer.h"
+#endif
+
 namespace xla {
 namespace FunctionalHloRunner {
 namespace {
@@ -568,13 +572,27 @@ absl::StatusOr<PerDeviceLiteralVecType> RunInternal(
   std::vector<std::vector<std::unique_ptr<PjRtBuffer>>> device_buffers;
   std::vector<std::vector<PjRtBuffer*>> argument_ptrs;
 
+  // Local copy that may be extended by range profiling pass count query.
+  size_t num_repeats = running_options.num_repeats;
+  const bool has_range_hooks = (running_options.begin_pass_hook != nullptr);
   bool has_active_profiler_session = false;
-  for (int repeat = 0; repeat < running_options.num_repeats; ++repeat) {
-    const bool is_last_repeat = (repeat == running_options.num_repeats - 1);
-    const bool profile_current_repeat =
-        (running_options.profiler != nullptr) &&
-        (repeat >= running_options.num_repeats -
-                       running_options.num_repeats_with_profiler);
+
+  for (size_t repeat = 0; repeat < num_repeats; ++repeat) {
+    bool is_last_repeat = (repeat == num_repeats - 1);
+
+    // Determine if this repeat should be profiled.  For range profiling,
+    // all original repeats are warmup; profiling passes are appended after
+    // the session is created.  For non-range profiling, the last
+    // num_repeats_with_profiler repeats are profiled.
+    bool profile_current_repeat;
+    if (has_range_hooks) {
+      profile_current_repeat = has_active_profiler_session;
+    } else {
+      profile_current_repeat =
+          (running_options.profiler != nullptr) &&
+          (repeat >=
+           num_repeats - running_options.num_repeats_with_profiler);
+    }
 
     VLOG(1) << "FunctionalHloRunner: ExecuteOnDevices started (repeat = "
             << repeat << ").";
@@ -596,10 +614,13 @@ absl::StatusOr<PerDeviceLiteralVecType> RunInternal(
         execute_options.execution_profile->set_warmup_run_executed(repeat > 0);
       }
 
-      if (profile_current_repeat && !has_active_profiler_session) {
+      // Non-range profiling: create session at start of profiling window.
+      if (!has_range_hooks && profile_current_repeat &&
+          !has_active_profiler_session) {
         running_options.profiler->CreateSession();
         has_active_profiler_session = true;
       }
+
       futures->clear();
       TF_ASSIGN_OR_RETURN(
           output_buffers,
@@ -608,6 +629,52 @@ absl::StatusOr<PerDeviceLiteralVecType> RunInternal(
         TF_RETURN_IF_ERROR(future.Await());
       }
 
+      // Range profiling: after all warmup repeats complete, create the
+      // profiler session and extend the loop for the required number of
+      // replay passes.  Enable() starts the first pass (BeginPass +
+      // PushRange); the next iteration executes inside that range.
+      bool just_created_range_session = false;
+      if (has_range_hooks && is_last_repeat && !has_active_profiler_session &&
+          running_options.profiler != nullptr) {
+        LOG(INFO) << "Range profiling: creating session";
+        running_options.profiler->CreateSession();
+        has_active_profiler_session = true;
+        just_created_range_session = true;
+        int passes = running_options.profiler->GetNumRequiredPasses();
+        LOG(INFO) << "Range profiling: " << passes << " pass(es) required";
+        if (passes < 1) passes = 1;
+        num_repeats += passes;
+        is_last_repeat = false;
+      }
+
+      // Range profiling: transition between passes.  After each profiling
+      // execute (except the last), end the current pass and begin the next.
+      // The first pass was started by Enable(); the last is ended by
+      // Disable() during UploadSession.
+      if (has_range_hooks && has_active_profiler_session &&
+          !just_created_range_session) {
+        is_last_repeat = (repeat == num_repeats - 1);
+        if (!is_last_repeat) {
+          LOG(INFO) << "Range profiling: transitioning after pass " << repeat;
+          if (running_options.pop_range_hook) {
+            TF_RETURN_IF_ERROR(running_options.pop_range_hook());
+          }
+          if (running_options.end_pass_hook) {
+            TF_RETURN_IF_ERROR(running_options.end_pass_hook());
+          }
+          if (running_options.begin_pass_hook) {
+            TF_RETURN_IF_ERROR(running_options.begin_pass_hook());
+          }
+          if (running_options.push_range_hook) {
+            TF_RETURN_IF_ERROR(running_options.push_range_hook());
+          }
+        }
+      }
+
+      // Upload profiler session on last repeat (or between repeats if
+      // recreating sessions).  For range profiling, Disable() handles the
+      // final PopRange + EndPass.
+      is_last_repeat = (repeat == num_repeats - 1);
       const bool upload_active_profiler_session =
           running_options.recreate_profiler_session_between_repeats ||
           is_last_repeat;
@@ -1599,21 +1666,47 @@ std::string AbslUnparseFlag(ModuleOutputMode output_mode) {
 }  // namespace FunctionalHloRunner
 
 HLORunnerProfiler::HLORunnerProfiler(absl::string_view dump_path,
-                                     bool keep_xspace)
-    : dump_path_(dump_path), keep_xspace_(keep_xspace) {}
+                                     bool keep_xspace,
+                                     absl::string_view range_profiling_metrics)
+    : dump_path_(dump_path),
+      keep_xspace_(keep_xspace),
+      range_profiling_metrics_(range_profiling_metrics) {}
 
 absl::StatusOr<std::unique_ptr<HLORunnerProfiler>> HLORunnerProfiler::Create(
-    absl::string_view dump_path, bool keep_xspace) {
+    absl::string_view dump_path, bool keep_xspace,
+    absl::string_view range_profiling_metrics) {
   if (dump_path.empty()) {
     return absl::InvalidArgumentError(
         "Please provide a valid dump path to save XSpace results to disk.");
   }
-  return std::make_unique<HLORunnerProfiler>(dump_path, keep_xspace);
+  return std::make_unique<HLORunnerProfiler>(dump_path, keep_xspace,
+                                             range_profiling_metrics);
 }
 
 void HLORunnerProfiler::CreateSession() {
   auto options = tsl::ProfilerSession::DefaultOptions();
+  if (!range_profiling_metrics_.empty()) {
+    tensorflow::ProfileOptions::AdvancedConfigValue metrics_value;
+    metrics_value.set_string_value(range_profiling_metrics_);
+    (*options.mutable_advanced_configuration())
+        ["gpu_range_profiling_counters"] = metrics_value;
+    // The multi-hlo-runner controls the repeat loop, so multi-pass is safe.
+    tensorflow::ProfileOptions::AdvancedConfigValue multipass_value;
+    multipass_value.set_bool_value(true);
+    (*options.mutable_advanced_configuration())
+        ["gpu_range_profiling_allow_multipass"] = multipass_value;
+  }
   session_ = tsl::ProfilerSession::Create(options);
+}
+
+int HLORunnerProfiler::GetNumRequiredPasses() const {
+#if GOOGLE_CUDA
+  auto* tracer = profiler::CuptiTracer::GetCuptiTracerSingleton();
+  if (tracer->IsRangeProfilingEnabled()) {
+    return tracer->NumRangeProfilingPasses();
+  }
+#endif
+  return 0;
 }
 
 void HLORunnerProfiler::UploadSession() {

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <random>
@@ -71,14 +72,17 @@ class HLORunnerProfiler : public XSpaceProfilerInterface {
   // If keep_xspace is true, the XSpace proto can be retrieved
   // by GetXSpace() after UploadSession() is called, which can be used by
   // caller to get a programmatic handler of the profile data and create XProf.
+  // If range_profiling_metrics is non-empty, range profiling will be enabled
+  // with the given comma-separated CUPTI metric names.
   static absl::StatusOr<std::unique_ptr<HLORunnerProfiler>> Create(
-      absl::string_view dump_path, bool keep_xspace = false);
+      absl::string_view dump_path, bool keep_xspace = false,
+      absl::string_view range_profiling_metrics = "");
 
-  // Default ctor.
-  explicit HLORunnerProfiler(absl::string_view dump_path, bool keep_xspace);
+  HLORunnerProfiler(absl::string_view dump_path, bool keep_xspace,
+                    absl::string_view range_profiling_metrics);
 
-  // Start a new profiling session.
   void CreateSession() override;
+  int GetNumRequiredPasses() const override;
 
   // Stop the current profiling session.
   void UploadSession() override;
@@ -91,6 +95,8 @@ class HLORunnerProfiler : public XSpaceProfilerInterface {
   std::string dump_path_;
   // Whether to keep the XSpace proto after UploadSession() is called.
   bool keep_xspace_;
+  // Comma-separated CUPTI metric names for range profiling (empty = disabled).
+  std::string range_profiling_metrics_;
   // The profiler session.
   std::unique_ptr<tsl::ProfilerSession> session_;
   // The XSpace proto to be returned by GetXSpace().
@@ -252,7 +258,8 @@ struct RunningOptions {
       ModuleArgumentMode::kUseRandomInputs;
   // Option controlling the outputs of the HLO.
   ModuleOutputMode module_output_mode = ModuleOutputMode::kReturnOutputs;
-  // Repeatedly execute the HLO for this many times.
+  // Repeatedly execute the HLO for this many times. May be increased
+  // automatically if range profiling requires more passes.
   size_t num_repeats = 1;
   // The last `num_repeats_with_profiler` repeats out of `num_repeats` will be
   // profiled. Default is 1, i.e., the last repeat will be profiled.
@@ -272,6 +279,17 @@ struct RunningOptions {
   // Note that the first repeat is a warmup run, and uses less precise
   // profiling method.
   std::vector<ExecutionProfile>* execution_profiles = nullptr;
+
+  // Number of unprofiled warmup passes before range profiling begins.
+  size_t range_profiling_warmup_passes = 0;
+
+  // Optional hooks called around each repeat for range profiling.
+  // begin_pass_hook is called before Execute, end_pass_hook after Await.
+  // push_range_hook/pop_range_hook bracket the Execute+Await.
+  std::function<absl::Status()> begin_pass_hook;
+  std::function<absl::Status()> end_pass_hook;
+  std::function<absl::Status()> push_range_hook;
+  std::function<absl::Status()> pop_range_hook;
 
   // Should we log the inputs and outputs to stderr?
   bool log_input_output() const {

--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -75,6 +75,9 @@ limitations under the License.
 #include "xla/tsl/util/command_line_flags.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
+#if GOOGLE_CUDA
+#include "xla/backends/profiler/gpu/cupti_tracer.h"
+#endif
 #include "tsl/platform/path.h"
 #include "tsl/platform/platform.h"
 #include "tsl/platform/protobuf.h"
@@ -1205,6 +1208,138 @@ TEST_F(FunctionalHloRunnerTest, ProfileMultipleRepeatsSingleSession) {
   TF_EXPECT_OK(FunctionalHloRunner::LoadAndRun(
       *client, debug_options, preproc_options, compile_options, running_options,
       {GetHloPath("single_device.hlo")}, InputFormat::kText));
+}
+
+TEST_F(FunctionalHloRunnerTest, ProfileMultipleRepeatsWithRangeProfiling) {
+  if (test::DeviceTypeIs(test::kCpu)) {
+    GTEST_SKIP() << "GPU-only test (range profiling requires CUPTI)";
+  }
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::PjRtClient> client,
+                          GetPjRtClient());
+
+  std::string profile_dump_path =
+      tsl::io::JoinPath(testing::TempDir(), "range_profiling_xspace.pb");
+
+  // Create profiler with range profiling metrics.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto profiler,
+      HLORunnerProfiler::Create(profile_dump_path, /*keep_xspace=*/true,
+                                "sm__cycles_active.sum"));
+
+  FunctionalHloRunner::RunningOptions running_options;
+  running_options.profiler = profiler.get();
+  running_options.num_repeats = 3;
+  running_options.num_repeats_with_profiler = running_options.num_repeats;
+
+#if GOOGLE_CUDA
+  // Wire up range profiling hooks (same as hlo_runner_main.cc).
+  auto* tracer = xla::profiler::CuptiTracer::GetCuptiTracerSingleton();
+  running_options.begin_pass_hook = [tracer]() -> absl::Status {
+    return tracer->BeginRangePass();
+  };
+  running_options.end_pass_hook = [tracer]() -> absl::Status {
+    return tracer->EndRangePass();
+  };
+  running_options.push_range_hook = [tracer]() -> absl::Status {
+    return tracer->PushProfilingRange("hlo_execution");
+  };
+  running_options.pop_range_hook = [tracer]() -> absl::Status {
+    return tracer->PopProfilingRange();
+  };
+#endif
+
+  auto result = FunctionalHloRunner::LoadAndRun(
+      *client, /*debug_options=*/{}, /*preproc_options=*/{},
+      /*compile_options=*/{}, running_options,
+      {GetHloPath("single_device.hlo")}, InputFormat::kText);
+
+  if (absl::IsPermissionDenied(result.status())) {
+    GTEST_SKIP() << "Range profiling requires root/admin access";
+  }
+  // Range profiling may not be supported on all GPUs/CUPTI versions.
+  // If Enable fails, it should still not crash — just skip.
+  if (!result.ok()) {
+    GTEST_SKIP() << "Range profiling not available: " << result.status();
+  }
+}
+
+// Multi-pass variant: uses metrics from different counter groups to force
+// CUPTI to require multiple replay passes, exercising the adaptive loop.
+TEST_F(FunctionalHloRunnerTest,
+       ProfileMultipleRepeatsWithMultiPassRangeProfiling) {
+  if (test::DeviceTypeIs(test::kCpu)) {
+    GTEST_SKIP() << "GPU-only test (range profiling requires CUPTI)";
+  }
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::PjRtClient> client,
+                          GetPjRtClient());
+
+  std::string profile_dump_path = tsl::io::JoinPath(
+      testing::TempDir(), "multipass_range_profiling_xspace.pb");
+
+  // Metrics spanning multiple HW units to force multi-pass collection.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto profiler,
+      HLORunnerProfiler::Create(
+          profile_dump_path, /*keep_xspace=*/true,
+          "smsp__warps_issue_stalled_barrier.avg,"
+          "smsp__warps_issue_stalled_long_scoreboard.avg,"
+          "smsp__warps_issue_stalled_math_pipe_throttle.avg,"
+          "smsp__warps_issue_stalled_not_selected.avg,"
+          "smsp__warps_issue_stalled_tex_throttle.avg,"
+          "smsp__warps_issue_stalled_wait.avg,"
+          "smsp__inst_executed.sum,"
+          "smsp__cycles_active.sum,"
+          "smsp__inst_executed_op_global_ld.sum,"
+          "smsp__thread_inst_executed_pred_on.sum,"
+          "sm__mio2rf_writeback_active.sum,"
+          "sm__mio_inst_issued.sum,"
+          "l1tex__t_set_accesses.sum,"
+          "l1tex__t_set_accesses_pipe_lsu.sum,"
+          "l1tex__t_set_conflicts.sum,"
+          "l1tex__texin_requests.sum,"
+          "l1tex__texin_sm2tex_req_cycles_active.sum,"
+          "dram__bytes.sum,"
+          "dram__throughput.avg_pct_of_peak_sustained_elapsed,"
+          "dram__cycles_active.sum,"
+          "dram__sectors.sum,"
+          "fbpa__dram_read_bytes.sum,"
+          "fbpa__dram_write_bytes.sum,"
+          "fbpa__dram_sectors.sum"));
+
+  FunctionalHloRunner::RunningOptions running_options;
+  running_options.profiler = profiler.get();
+  // Start with 1 repeat; the adaptive loop should increase it based on
+  // the pass count returned by GetNumRequiredPasses().
+  running_options.num_repeats = 1;
+  running_options.num_repeats_with_profiler = 1;
+
+#if GOOGLE_CUDA
+  auto* tracer = xla::profiler::CuptiTracer::GetCuptiTracerSingleton();
+  running_options.begin_pass_hook = [tracer]() -> absl::Status {
+    return tracer->BeginRangePass();
+  };
+  running_options.end_pass_hook = [tracer]() -> absl::Status {
+    return tracer->EndRangePass();
+  };
+  running_options.push_range_hook = [tracer]() -> absl::Status {
+    return tracer->PushProfilingRange("hlo_execution");
+  };
+  running_options.pop_range_hook = [tracer]() -> absl::Status {
+    return tracer->PopProfilingRange();
+  };
+#endif
+
+  auto result = FunctionalHloRunner::LoadAndRun(
+      *client, /*debug_options=*/{}, /*preproc_options=*/{},
+      /*compile_options=*/{}, running_options,
+      {GetHloPath("single_device.hlo")}, InputFormat::kText);
+
+  if (absl::IsPermissionDenied(result.status())) {
+    GTEST_SKIP() << "Range profiling requires root/admin access";
+  }
+  if (!result.ok()) {
+    GTEST_SKIP() << "Range profiling not available: " << result.status();
+  }
 }
 
 TEST_F(FunctionalHloRunnerTest, ProfileMultipleRepeatsSessionPerRepeat) {

--- a/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
+++ b/xla/tools/multihost_hlo_runner/hlo_runner_main.cc
@@ -42,6 +42,10 @@ limitations under the License.
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/init_main.h"
 
+#if GOOGLE_CUDA
+#include "xla/backends/profiler/gpu/cupti_tracer.h"
+#endif
+
 namespace {
 const char* const kUsage = R"(
 This tool lets you run an HLO module on one or more GPUs.
@@ -111,6 +115,8 @@ struct HloRunnerConfig {
   float gpu_client_mem_fraction = xla::GpuAllocatorConfig{}.memory_fraction;
   bool profile_execution = false;
   std::string xla_gpu_dump_xspace_to = "";
+  std::string range_profiling_metrics = "";
+  int32_t range_profiling_warmup_passes = 0;
 };
 
 }  // namespace
@@ -270,11 +276,18 @@ static absl::Status RunMultihostHloRunner(int argc, char** argv,
                  opts.address_str, gpu_options,
                  absl::Seconds(opts.gpu_client_initialization_timeout_sec)));
     // Create a GPURunnerProfiler to profile GPU executions to save xspace data
-    // to disk.
-    if (env.client != nullptr && !opts.xla_gpu_dump_xspace_to.empty()) {
-      TF_ASSIGN_OR_RETURN(hlo_runner_profiler,
-                          HLORunnerProfiler::Create(opts.xla_gpu_dump_xspace_to,
-                                                    /*keep_xspace=*/false));
+    // to disk. Also required when range profiling metrics are specified.
+    if (env.client != nullptr &&
+        (!opts.xla_gpu_dump_xspace_to.empty() ||
+         !opts.range_profiling_metrics.empty())) {
+      if (opts.xla_gpu_dump_xspace_to.empty()) {
+        opts.xla_gpu_dump_xspace_to = "/tmp/xprof_range_profiling.xspace.pb";
+      }
+      TF_ASSIGN_OR_RETURN(
+          hlo_runner_profiler,
+          HLORunnerProfiler::Create(opts.xla_gpu_dump_xspace_to,
+                                    /*keep_xspace=*/false,
+                                    opts.range_profiling_metrics));
       running_options.profiler = hlo_runner_profiler.get();
     }
   } else if (opts.device_type_str == "host") {
@@ -296,6 +309,29 @@ static absl::Status RunMultihostHloRunner(int argc, char** argv,
   if (opts.profile_execution) {
     running_options.execution_profiles = &execution_profiles;
   }
+
+#if GOOGLE_CUDA
+  // Set up range profiling hooks if metrics are specified. The hooks call
+  // CuptiTracer singleton methods which delegate to the range profiler that
+  // was created during ProfilerSession::Create (via CuptiTracer::Enable).
+  if (!opts.range_profiling_metrics.empty()) {
+    auto* tracer = xla::profiler::CuptiTracer::GetCuptiTracerSingleton();
+    running_options.range_profiling_warmup_passes =
+        opts.range_profiling_warmup_passes;
+    running_options.begin_pass_hook = [tracer]() -> absl::Status {
+      return tracer->BeginRangePass();
+    };
+    running_options.end_pass_hook = [tracer]() -> absl::Status {
+      return tracer->EndRangePass();
+    };
+    running_options.push_range_hook = [tracer]() -> absl::Status {
+      return tracer->PushProfilingRange("hlo_execution");
+    };
+    running_options.pop_range_hook = [tracer]() -> absl::Status {
+      return tracer->PopProfilingRange();
+    };
+  }
+#endif
 
   for (int c = 1; c < argc; c++) {
     const char* hlo_file = argv[c];
@@ -439,6 +475,16 @@ int main(int argc, char** argv) {
                 "If set, we will profile the execution and print the results."),
       tsl::Flag("xla_gpu_dump_xspace_to", &opts.xla_gpu_dump_xspace_to,
                 "A directory to dump xspace data for GPU profiling."),
+      tsl::Flag("range_profiling_metrics", &opts.range_profiling_metrics,
+                "Comma-separated list of CUPTI metrics for range profiling "
+                "(e.g. \"sm__cycles_elapsed.avg,sm__inst_executed.sum\"). "
+                "Automatically sets the number of repeats to match the "
+                "required number of profiling passes."),
+      tsl::Flag("range_profiling_warmup_passes",
+                &opts.range_profiling_warmup_passes,
+                "Number of unprofiled warmup passes to run before range "
+                "profiling begins. Warms caches and stabilizes GPU state. "
+                "Default: 0."),
       // This option is not used during parsing, but it is added here for
       // documentation, and for ensuring that the parser knows this should be
       // ignored if present.

--- a/xla/tools/multihost_hlo_runner/profiler_interface.h
+++ b/xla/tools/multihost_hlo_runner/profiler_interface.h
@@ -27,7 +27,12 @@ class ProfilerInterface {
   virtual void CreateSession() = 0;
   // Uploads profiling session data after finishing running HLO module.
   virtual void UploadSession() = 0;
+  // Returns the number of replay passes required by the profiler (e.g. for
+  // hardware counter collection that needs multiple passes over the same
+  // workload). Only valid after CreateSession(). Returns 0 by default.
+  virtual int GetNumRequiredPasses() const { return 0; }
 };
+
 }  // namespace xla
 
 #endif  // XLA_TOOLS_MULTIHOST_HLO_RUNNER_PROFILER_INTERFACE_H_


### PR DESCRIPTION
📝 Summary of Changes

This depends on https://github.com/openxla/xla/pull/40449 though it has been rebased to include those changes.  It is intended to separate the hlo runner changes from the rest of the range profiling work for xprof.  As it includes these changes it should build and run independently.

  Integrate CUPTI range profiling into the multi-host HLO runner, building on top of https://github.com/cashton-nvidia/xla/compare/main...cashton-nvidia:xla:cupti-range-profiling-core. The incremental diff for this PR is viewable at:
  https://github.com/cashton-nvidia/xla/compare/cupti-range-profiling-core...cashton-nvidia:xla:cupti-range-profiling-hlo-runner

  - Extend FunctionalHloRunner to drive the range profiler through multi-pass replay: for each pass, execute the HLO module as the profiled workload, then transition to the next pass.
  - Add ProfilerInterface::SetUpRangeProfiling() and related methods so the HLO runner can configure range profiling options (metrics list, range mode, multi-pass enable) through the existing profiler abstraction.
  - Add CLI flags to hlo_runner_main: --range_profiling_metrics (comma-separated metric names), --range_profiling_range_name, and --range_profiling_allow_multipass.
  - Add functional_hlo_runner_test.cc test RangeProfilingCollectsMetrics that runs a simple HLO with range profiling enabled, validates that results are received with expected metrics, and checks the FP64 instruction count against the expected value.
  - Add //xla/backends/profiler/gpu:device_tracer and //xla/backends/profiler/gpu:cupti_tracer BUILD dependencies to functional_hlo_runner_test so the GPU profiler factories are linked and registered.

🎯 Justification

  The multi-host HLO runner is the primary tool for profiling individual HLO computations. Without this change, users can only collect PM sampling counters (periodic snapshots, limited metric set). Range profiling enables collecting an arbitrary set of hardware performance counters attributed
  to the exact HLO execution, using multi-pass replay when the requested metrics span multiple counter groups. This is essential for detailed performance analysis — e.g. measuring exact DRAM throughput, FP64 utilization, or L2 hit rates for a specific HLO — and feeds into the xprof
  perf_counters tool for visualization.

🚀 Kind of Contribution

  ✨ New Feature, 🧪 Tests

📊 Benchmark

  N/A — profiler infrastructure, not a compiler optimization.

🧪 Unit Tests

  None — changes are integration-level (wiring the profiler into the HLO runner execution loop).

🧪 Execution Tests

  - functional_hlo_runner_test.cc: RangeProfilingCollectsMetrics — runs a simple add/subtract HLO with sm__inst_executed_pipe_fp64.sum range profiling enabled on a single GPU. Validates that range profiling results are received via the callback, that the metric count matches the request, and
  that the FP64 instruction count is within 5% of the expected value. Runs on the nvgpu_any backend (single GPU).