### PR TITLE
Refactor CUDA backend for Triton_XLA atomic operations lowering (Enable ROCm Triton AllReduce 2/4)

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -642,6 +642,8 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:Support",

--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -150,7 +150,7 @@ cc_library(
     deps = [
         "//xla/backends/gpu/codegen/emitters/transforms:passes",
         "//xla/backends/gpu/codegen/triton/transforms:passes",
-        "//xla/codegen/emitters/transforms:convert_pure_call_ops_pass",
+        "//xla/backends/gpu/codegen/triton/transforms:triton_xla_implement_extern_element_wise_pass",
         "//xla/codegen/emitters/transforms:passes",
         "//xla/service:hlo_module_config",
         "//xla/service/gpu:matmul_utils",

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_cuda.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_cuda.cc
@@ -177,6 +177,10 @@ static void MakeLLIR(mlir::OpPassManager* pm,
   pm->addPass(mlir::createSymbolDCEPass());
   pm->addPass(mlir::createConvertNVVMToLLVMPass());
   // Note: translateTritonGPUToLLVMIR adds line info with LLVMDIScopePass.
+
+  // Add XLA custom pass to implement extern_elementwise functions
+  // This must run after MLIR->LLVM conversion but before final optimizations
+  pm->addPass(mt_xla::CreateTritonXLAImplementExternElementWisePass());
 }
 
 void CreateTritonCudaPipeline(

--- a/xla/backends/gpu/codegen/triton/extern_function_helper.cc
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper.cc
@@ -144,18 +144,19 @@ absl::string_view MemSyncScopeToPTXScope(MemSyncScope scope) {
 }  // namespace
 
 absl::StatusOr<ExternFunctionInstruction> ParseExternFunctionName(
-    absl::string_view func_name) {
+    llvm::StringRef func_name) {
   // Function name format: xla_<functionname>_<arg1>_<arg2>_...
   // Split by underscore to get tokens
-  std::vector<absl::string_view> tokens = absl::StrSplit(func_name, '_');
+  llvm::SmallVector<llvm::StringRef, 5> tokens;
+  func_name.split(tokens, '_');
 
   // Must have at least 2 tokens: "xla" and function name
   if (tokens.size() < 2 || tokens[0] != "xla") {
     return absl::InvalidArgumentError(
-        absl::StrFormat("Invalid extern function name: %s", func_name));
+        absl::StrFormat("Invalid extern function name: %s", func_name.str()));
   }
 
-  absl::string_view fn_name = tokens[1];
+  llvm::StringRef fn_name = tokens[1];
 
   // xla_getthreadid (2 tokens total)
   if (fn_name == "getthreadid") {
@@ -222,6 +223,27 @@ std::string SerializeExternFunctionName(
           },
       },
       instruction);
+}
+
+absl::StatusOr<std::string> ToExternFunctionName(mlir::Operation* op) {
+  ExternFunctionInstruction instruction;
+
+  if (auto atomic_write = mlir::dyn_cast<AtomicWriteOp>(op)) {
+    instruction = AtomicWriteInstruction{atomic_write.getMemSyncSemantic(),
+                                         atomic_write.getMemSyncScope()};
+  } else if (auto atomic_wait = mlir::dyn_cast<AtomicSpinWaitOp>(op)) {
+    instruction = AtomicSpinWaitInstruction{atomic_wait.getMemSyncSemantic(),
+                                            atomic_wait.getMemSyncScope(),
+                                            atomic_wait.getComparator()};
+  } else if (mlir::dyn_cast<GetTidOp>(op)) {
+    instruction = GetThreadIdInstruction{};
+  } else {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Unsupported operation type for extern function name: %s",
+        op->getName().getStringRef().str()));
+  }
+
+  return SerializeExternFunctionName(instruction);
 }
 
 absl::Status ValidateMemorySemantic(

--- a/xla/backends/gpu/codegen/triton/extern_function_helper.cc
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper.cc
@@ -327,8 +327,9 @@ mlir::Value CreateAtomicWriteOps(const AtomicWriteInstruction& instruction,
   )";
     std::string atomic_write_asm = absl::StrFormat(
         kAtomicWriteAsmWithMaskTemplate, scope, memory_semantic);
-    auto asm_op = LLVM::InlineAsmOp::create(
-        builder, params.loc, i32_type, mlir::ValueRange{addr, value, mask},
+    LLVM::InlineAsmOp::create(
+        builder, params.loc, mlir::TypeRange{},
+        mlir::ValueRange{addr, value, mask},
         builder.getStringAttr(atomic_write_asm), builder.getStringAttr("l,r,r"),
         /*has_side_effects=*/builder.getUnitAttr(),
         /*is_align_stack=*/nullptr,
@@ -336,23 +337,24 @@ mlir::Value CreateAtomicWriteOps(const AtomicWriteInstruction& instruction,
                                     LLVM::TailCallKind::None),
         /*asm_dialect=*/nullptr,
         /*operand_attrs=*/nullptr);
-    return asm_op.getResult(0);
-  }
-  constexpr absl::string_view kAtomicWriteAsmTemplate = R"(
+  } else {
+    constexpr absl::string_view kAtomicWriteAsmTemplate = R"(
     st.global.%s.%s.u32 [$0], $1;
   )";
-  std::string atomic_write_asm =
-      absl::StrFormat(kAtomicWriteAsmTemplate, scope, memory_semantic);
-  auto asm_op = LLVM::InlineAsmOp::create(
-      builder, params.loc, i32_type, mlir::ValueRange{addr, value},
-      builder.getStringAttr(atomic_write_asm), builder.getStringAttr("l,r"),
-      /*has_side_effects=*/builder.getUnitAttr(),
-      /*is_align_stack=*/nullptr,
-      LLVM::TailCallKindAttr::get(builder.getContext(),
-                                  LLVM::TailCallKind::None),
-      /*asm_dialect=*/nullptr,
-      /*operand_attrs=*/nullptr);
-  return asm_op.getResult(0);
+    std::string atomic_write_asm =
+        absl::StrFormat(kAtomicWriteAsmTemplate, scope, memory_semantic);
+    LLVM::InlineAsmOp::create(
+        builder, params.loc, mlir::TypeRange{}, mlir::ValueRange{addr, value},
+        builder.getStringAttr(atomic_write_asm), builder.getStringAttr("l,r"),
+        /*has_side_effects=*/builder.getUnitAttr(),
+        /*is_align_stack=*/nullptr,
+        LLVM::TailCallKindAttr::get(builder.getContext(),
+                                    LLVM::TailCallKind::None),
+        /*asm_dialect=*/nullptr,
+        /*operand_attrs=*/nullptr);
+  }
+  // Return poison value since atomic write doesn't produce a meaningful result
+  return builder.create<LLVM::PoisonOp>(params.loc, i32_type);
 }
 
 // Create LLVM ops for AtomicSpinWaitInstruction
@@ -389,8 +391,9 @@ mlir::Value CreateAtomicSpinWaitOps(
   )";
     std::string atomic_wait_asm = absl::StrFormat(
         kAtomicSpinWaitAsmWithMaskTemplate, scope, memory_semantic, comparator);
-    auto asm_op = LLVM::InlineAsmOp::create(
-        builder, params.loc, i32_type, mlir::ValueRange{addr, expected, mask},
+    LLVM::InlineAsmOp::create(
+        builder, params.loc, mlir::TypeRange{},
+        mlir::ValueRange{addr, expected, mask},
         builder.getStringAttr(atomic_wait_asm), builder.getStringAttr("l,r,r"),
         /*has_side_effects=*/builder.getUnitAttr(),
         /*is_align_stack=*/nullptr,
@@ -398,9 +401,8 @@ mlir::Value CreateAtomicSpinWaitOps(
                                     LLVM::TailCallKind::None),
         /*asm_dialect=*/nullptr,
         /*operand_attrs=*/nullptr);
-    return asm_op.getResult(0);
-  }
-  constexpr absl::string_view kAtomicSpinWaitAsmTemplate = R"(
+  } else {
+    constexpr absl::string_view kAtomicSpinWaitAsmTemplate = R"(
     {
     .reg .pred %%p<1>;
     .reg .b32 %%r<1>;
@@ -410,18 +412,22 @@ mlir::Value CreateAtomicSpinWaitOps(
       @%%p0 bra wait;
     }
   )";
-  std::string atomic_wait_asm = absl::StrFormat(
-      kAtomicSpinWaitAsmTemplate, scope, memory_semantic, comparator);
-  auto asm_op = LLVM::InlineAsmOp::create(
-      builder, params.loc, i32_type, mlir::ValueRange{addr, expected},
-      builder.getStringAttr(atomic_wait_asm), builder.getStringAttr("l,r"),
-      /*has_side_effects=*/builder.getUnitAttr(),
-      /*is_align_stack=*/nullptr,
-      LLVM::TailCallKindAttr::get(builder.getContext(),
-                                  LLVM::TailCallKind::None),
-      /*asm_dialect=*/nullptr,
-      /*operand_attrs=*/nullptr);
-  return asm_op.getResult(0);
+    std::string atomic_wait_asm = absl::StrFormat(
+        kAtomicSpinWaitAsmTemplate, scope, memory_semantic, comparator);
+    LLVM::InlineAsmOp::create(
+        builder, params.loc, mlir::TypeRange{},
+        mlir::ValueRange{addr, expected},
+        builder.getStringAttr(atomic_wait_asm), builder.getStringAttr("l,r"),
+        /*has_side_effects=*/builder.getUnitAttr(),
+        /*is_align_stack=*/nullptr,
+        LLVM::TailCallKindAttr::get(builder.getContext(),
+                                    LLVM::TailCallKind::None),
+        /*asm_dialect=*/nullptr,
+        /*operand_attrs=*/nullptr);
+  }
+  // Return poison value since atomic spin wait doesn't produce a meaningful
+  // result
+  return builder.create<LLVM::PoisonOp>(params.loc, i32_type);
 }
 
 }  // namespace

--- a/xla/backends/gpu/codegen/triton/extern_function_helper.h
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "llvm/ADT/StringRef.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Value.h"
@@ -85,12 +86,17 @@ using ExternFunctionInstruction =
 // - <scope>: system, gpu, cta
 // - <comparator>: eq, lt
 absl::StatusOr<ExternFunctionInstruction> ParseExternFunctionName(
-    absl::string_view func_name);
+    llvm::StringRef func_name);
 
 // Serializes an ExternFunctionInstruction back to its string representation.
 // This is the inverse of ParseExternFunctionName.
 std::string SerializeExternFunctionName(
     const ExternFunctionInstruction& instruction);
+
+// Creates an extern function name from a Triton XLA operation.
+// Supports AtomicWriteOp, AtomicSpinWaitOp, and GetTidOp.
+// Returns an error status if the operation type is not supported.
+absl::StatusOr<std::string> ToExternFunctionName(mlir::Operation* op);
 
 // Validates that the memory semantic is appropriate for the instruction type.
 // Returns an error status if validation fails.

--- a/xla/backends/gpu/codegen/triton/extern_function_helper_test.cc
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper_test.cc
@@ -325,10 +325,12 @@ TEST_F(ExternFunctionNameTest, CreateAtomicWriteOpsVerifyPTXAssembly) {
   ASSERT_TRUE(result != nullptr);
   EXPECT_TRUE(result.getType().isInteger(32));
 
-  // Verify inline assembly was created with correct PTX instruction
-  auto* defining_op = result.getDefiningOp();
-  ASSERT_TRUE(defining_op != nullptr);
-  auto asm_op = mlir::dyn_cast<LLVM::InlineAsmOp>(defining_op);
+  // Result is a poison value, find the inline assembly in the block
+  LLVM::InlineAsmOp asm_op;
+  entry_block->walk([&](LLVM::InlineAsmOp op) {
+    asm_op = op;
+    return mlir::WalkResult::interrupt();
+  });
   ASSERT_TRUE(asm_op != nullptr);
   EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("st.global"));
   EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("gpu"));
@@ -365,10 +367,12 @@ TEST_F(ExternFunctionNameTest, CreateAtomicSpinWaitOpsVerifyPTXAssembly) {
   ASSERT_TRUE(result != nullptr);
   EXPECT_TRUE(result.getType().isInteger(32));
 
-  // Verify inline assembly was created with correct PTX instructions
-  auto* defining_op = result.getDefiningOp();
-  ASSERT_TRUE(defining_op != nullptr);
-  auto asm_op = mlir::dyn_cast<LLVM::InlineAsmOp>(defining_op);
+  // Result is a poison value, find the inline assembly in the block
+  LLVM::InlineAsmOp asm_op;
+  entry_block->walk([&](LLVM::InlineAsmOp op) {
+    asm_op = op;
+    return mlir::WalkResult::interrupt();
+  });
   ASSERT_TRUE(asm_op != nullptr);
   EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("ld.global"));
   EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("gpu"));
@@ -405,10 +409,12 @@ TEST_F(ExternFunctionNameTest, CreateAtomicSpinWaitOpsVerifyComparator) {
   mlir::Value result = CreateLLVMOpsForInstruction(instruction, params);
   ASSERT_TRUE(result != nullptr);
 
-  // Verify inline assembly was created with correct comparator
-  auto* defining_op = result.getDefiningOp();
-  ASSERT_TRUE(defining_op != nullptr);
-  auto asm_op = mlir::dyn_cast<LLVM::InlineAsmOp>(defining_op);
+  // Result is a poison value, find the inline assembly in the block
+  LLVM::InlineAsmOp asm_op;
+  entry_block->walk([&](LLVM::InlineAsmOp op) {
+    asm_op = op;
+    return mlir::WalkResult::interrupt();
+  });
   ASSERT_TRUE(asm_op != nullptr);
   EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("ld.global"));
   EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("sys"));

--- a/xla/backends/gpu/codegen/triton/transforms/BUILD
+++ b/xla/backends/gpu/codegen/triton/transforms/BUILD
@@ -59,6 +59,7 @@ cc_library(
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/backends/gpu/codegen/triton:collective_emitter",
+        "//xla/backends/gpu/codegen/triton:extern_function_helper",
         "//xla/backends/gpu/codegen/triton:lowering_util",
         "//xla/backends/gpu/codegen/triton/ir:triton_xla",
         "//xla/codegen/emitters/ir:xla",

--- a/xla/backends/gpu/codegen/triton/transforms/BUILD
+++ b/xla/backends/gpu/codegen/triton/transforms/BUILD
@@ -105,7 +105,7 @@ cc_library(
         "@llvm-project//mlir:TransformUtils",
         "@stablehlo//:stablehlo_ops",
         "@triton//:TritonDialects",
-        "@tsl//tsl/platform:tensor_float_32_hdr_lib",
+        "@tsl//tsl/platform:tensor_float_32_utils",
     ],
 )
 
@@ -118,16 +118,14 @@ cc_library(
         "//xla/backends/gpu/codegen/triton:extern_function_helper",
         "//xla/backends/gpu/codegen/triton/ir:triton_xla",
         "//xla/codegen/xtile/ir:xtile",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/strings",
-        "@llvm-project//llvm:Core",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:Rewrite",
         "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:ToLLVMIRTranslation",
         "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/xla/backends/gpu/codegen/triton/transforms/BUILD
+++ b/xla/backends/gpu/codegen/triton/transforms/BUILD
@@ -107,3 +107,26 @@ cc_library(
         "@tsl//tsl/platform:tensor_float_32_hdr_lib",
     ],
 )
+
+cc_library(
+    name = "triton_xla_implement_extern_element_wise_pass",
+    srcs = ["triton_xla_implement_extern_element_wise_pass.cc"],
+    hdrs = ["passes.h"],
+    deps = [
+        ":passes_inc_gen",
+        "//xla/backends/gpu/codegen/triton:extern_function_helper",
+        "//xla/backends/gpu/codegen/triton/ir:triton_xla",
+        "//xla/codegen/xtile/ir:xtile",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
+        "@llvm-project//llvm:Core",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Rewrite",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:ToLLVMIRTranslation",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)

--- a/xla/backends/gpu/codegen/triton/transforms/passes.h
+++ b/xla/backends/gpu/codegen/triton/transforms/passes.h
@@ -45,6 +45,7 @@ std::unique_ptr<mlir::Pass> CreateTritonXLAUnswitchLoopsPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerGetTidPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerAtomicsPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerBlockBarrierPass();
+std::unique_ptr<mlir::Pass> CreateTritonXLAImplementExternElementWisePass();
 std::unique_ptr<mlir::Pass> CreateTritonXLAConvertUnsupportedTypesPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerRemoteAccessPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerXTilePass();

--- a/xla/backends/gpu/codegen/triton/transforms/passes.td
+++ b/xla/backends/gpu/codegen/triton/transforms/passes.td
@@ -278,4 +278,16 @@ def UnsupportedElementwiseToTritonPass
   ];
 }
 
+def TritonXLAImplementExternElementWisePass
+    : Pass<"triton-xla-implement-extern-element-wise", "mlir::ModuleOp"> {
+  let summary = "Implement extern_elementwise functions for GPU target.";
+  let description = [{
+    This pass implements custom atomic functions declared by tt.extern_elementwise
+    operations using LLVM IR intrinsics and atomic operations with proper memory
+    ordering and sync scopes. It supports CUDA (NVPTX) backend.
+    It runs in the Triton pipeline after MLIR has been converted to LLVM dialect.
+    The target backend must be specified via the target option.
+  }];
+}
+
 #endif  // XLA_BACKENDS_GPU_CODEGEN_TRITON_PASSES_TD_

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_atomic_spin_wait.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_atomic_spin_wait.mlir
@@ -1,21 +1,14 @@
 // RUN: xla-opt %s --triton-xla-atomics | FileCheck %s
 
+// Test lowering of AtomicSpinWaitOp to tt.extern_elementwise
+
 // CHECK-LABEL: tt.func @nomask_kernel
 // CHECK-SAME:    %[[ARG0:.*]]: !tt.ptr<i32>
 // CHECK-SAME:    %[[ARG1:.*]]: i32
 tt.func @nomask_kernel(%ptr : !tt.ptr<i32>, %expected : i32) {
-// CHECK-NEXT:  %[[RES:.+]] = tt.elementwise_inline_asm
-// CHECK-SAME:  {
-// CHECK-SAME:  .reg .pred %p<1>;
-// CHECK-SAME:  .reg .b32 %r<1>;
-// CHECK-SAME:  wait:
-// CHECK-SAME:  ld.global.gpu.relaxed.u32 %r0, [$1];
-// CHECK-SAME:  setp.eq.u32 %p0, %r0, $2;
-// CHECK-SAME:  @%p0 bra wait;
-// CHECK-SAME:  }
-// CHECK-SAME:  {constraints = "=r,l,r", packed_element = 1 : i32, pure = false}
-// CHECK-SAME:  %[[ARG0]], %[[ARG1]]
-// CHECK-SAME:  !tt.ptr<i32>, i32 -> i32
+// CHECK-NEXT:  %[[RES:.+]] = tt.extern_elementwise %[[ARG0]], %[[ARG1]]
+// CHECK-SAME:  {libname = "", libpath = "", pure = false, symbol = "xla_atomicspinwait_relaxed_gpu_eq"}
+// CHECK-SAME:  : (!tt.ptr<i32>, i32) -> i32
   triton_xla.atomic_spin_wait gpu, relaxed, %ptr, equal_to, %expected  : (!tt.ptr<i32>, i32) -> ()
   tt.return
 }
@@ -29,22 +22,32 @@ tt.func @masked_kernel(
   %mask: tensor<4xi1>,
   %expected: i32
 ) {
-// CHECK:         tt.elementwise_inline_asm
-// CHECK-SAME:    {
-// CHECK-SAME:    .reg .pred %p<2>;
-// CHECK-SAME:    .reg .b32 %r<1>;
-// CHECK-SAME:    setp.ne.u32 %p0, $3, 0;
-// CHECK-SAME:    @%!p0 bra done;
-// CHECK-SAME:    wait:
-// CHECK-SAME:    ld.global.gpu.acquire.u32 %r0, [$1];
-// CHECK-SAME:    setp.lt.u32 %p1, %r0, $2;
-// CHECK-SAME:    @%p1 bra wait;
-// CHECK-SAME:    done:
-// CHECK-SAME:    }
-// CHECK-SAME:    {constraints = "=r,l,r,r", packed_element = 1 : i32, pure = false}
-// CHECK-SAME:    %[[ARG0]], %[[ARG2]], %[[ARG1]]
-// CHECK-SAME:    tensor<4x!tt.ptr<i32>>, i32, tensor<4xi1> -> tensor<4xi32>
+// CHECK:         %[[RES:.+]] = tt.extern_elementwise %[[ARG0]], %[[ARG2]], %[[ARG1]]
+// CHECK-SAME:    {libname = "", libpath = "", pure = false, symbol = "xla_atomicspinwait_acquire_gpu_lt"}
+// CHECK-SAME:    : (tensor<4x!tt.ptr<i32>>, i32, tensor<4xi1>) -> tensor<4xi32>
   triton_xla.atomic_spin_wait gpu, acquire, %ptr, less_than, %expected, %mask
       : (tensor<4x!tt.ptr<i32>>, i32, tensor<4xi1>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: tt.func @test_vectorized_lt
+// CHECK-SAME:    %[[ARG0:.*]]: tensor<4x!tt.ptr<i32>>
+// CHECK-SAME:    %[[ARG1:.*]]: i32
+tt.func @test_vectorized_lt(%ptr: tensor<4x!tt.ptr<i32>>, %expected: i32) {
+  // CHECK-NOT: triton_xla.atomic_spin_wait
+  // CHECK: tt.extern_elementwise %[[ARG0]], %[[ARG1]]
+  // CHECK-SAME: symbol = "xla_atomicspinwait_acquire_system_lt"
+  triton_xla.atomic_spin_wait sys, acquire, %ptr, less_than, %expected : (tensor<4x!tt.ptr<i32>>, i32) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: tt.func @test_vectorized_eq
+// CHECK-SAME:    %[[ARG0:.*]]: tensor<4x!tt.ptr<i32>>
+// CHECK-SAME:    %[[ARG1:.*]]: i32
+tt.func @test_vectorized_eq(%ptr: tensor<4x!tt.ptr<i32>>, %expected: i32) {
+  // CHECK-NOT: triton_xla.atomic_spin_wait
+  // CHECK: tt.extern_elementwise %[[ARG0]], %[[ARG1]]
+  // CHECK-SAME: symbol = "xla_atomicspinwait_acquire_system_eq"
+  triton_xla.atomic_spin_wait sys, acquire, %ptr, equal_to, %expected : (tensor<4x!tt.ptr<i32>>, i32) -> ()
   tt.return
 }

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_atomic_write.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_atomic_write.mlir
@@ -1,12 +1,13 @@
 // RUN: xla-opt %s --triton-xla-atomics | FileCheck %s
 
+// Test lowering of AtomicWriteOp to tt.extern_elementwise
+
 // CHECK-LABEL: tt.func @nomask_kernel
 // CHECK-SAME: (%[[ARG0:.+]]: !tt.ptr<i32>, %[[ARG1:.+]]: i32)
 tt.func @nomask_kernel(%ptr : !tt.ptr<i32>, %value : i32) {
-  // CHECK-NEXT: %[[RES:.+]] = tt.elementwise_inline_asm
-  // CHECK-SAME: st.global.gpu.relaxed.u32 [$1], $2;
-  // CHECK-SAME: {constraints = "=r,l,r", packed_element = 1 : i32, pure = false}
-  // CHECK-SAME: %[[ARG0]], %[[ARG1]] : !tt.ptr<i32>, i32 -> i32
+  // CHECK-NEXT: %[[RES:.+]] = tt.extern_elementwise %[[ARG0]], %[[ARG1]]
+  // CHECK-SAME: {libname = "", libpath = "", pure = false, symbol = "xla_atomicwrite_relaxed_gpu"}
+  // CHECK-SAME: : (!tt.ptr<i32>, i32) -> i32
   triton_xla.atomic_write gpu, relaxed, %ptr,  %value: (!tt.ptr<i32>, i32) -> ()
   // CHECK-NEXT: tt.return
   tt.return
@@ -15,10 +16,9 @@ tt.func @nomask_kernel(%ptr : !tt.ptr<i32>, %value : i32) {
 // CHECK-LABEL: tt.func @nomask_vector_kernel
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<8x!tt.ptr<i32>>, %[[ARG1:.+]]: i32)
 tt.func @nomask_vector_kernel(%ptr : tensor<8x!tt.ptr<i32>>, %value : i32) {
-  // CHECK-NEXT: %[[RES:.+]] = tt.elementwise_inline_asm
-  // CHECK-SAME: st.global.gpu.relaxed.u32 [$1], $2;
-  // CHECK-SAME: {constraints = "=r,l,r", packed_element = 1 : i32, pure = false}
-  // CHECK-SAME: %[[ARG0]], %[[ARG1]] : tensor<8x!tt.ptr<i32>>, i32 -> tensor<8xi32>
+  // CHECK-NEXT: %[[RES:.+]] = tt.extern_elementwise %[[ARG0]], %[[ARG1]]
+  // CHECK-SAME: {libname = "", libpath = "", pure = false, symbol = "xla_atomicwrite_relaxed_gpu"}
+  // CHECK-SAME: : (tensor<8x!tt.ptr<i32>>, i32) -> tensor<8xi32>
   triton_xla.atomic_write gpu, relaxed, %ptr,  %value:
     (tensor<8x!tt.ptr<i32>>, i32) -> ()
   // CHECK-NEXT: tt.return
@@ -28,16 +28,37 @@ tt.func @nomask_vector_kernel(%ptr : tensor<8x!tt.ptr<i32>>, %value : i32) {
 // CHECK-LABEL: tt.func @mask_kernel
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<4x!tt.ptr<i32>>, %[[ARG1:.+]]: i32, %[[ARG2:.+]]: tensor<4xi1>)
 tt.func @mask_kernel(%ptr : tensor<4x!tt.ptr<i32>>, %value : i32, %mask : tensor<4xi1>) {
-  // CHECK-NEXT: %[[RES:.+]] = tt.elementwise_inline_asm
-  // CHECK-SAME: {
-  // CHECK-SAME: .reg .pred %p<>;
-  // CHECK-SAME: setp.ne.u32 %p<>, $3, 0;
-  // CHECK-SAME: @%p st.global.sys.release.u32 [$1], $2;
-  // CHECK-SAME: }
-  // CHECK-SAME: {constraints = "=r,l,r,r", packed_element = 1 : i32, pure = false}
-  // CHECK-SAME: %[[ARG0]], %[[ARG1]], %[[ARG2]] : tensor<4x!tt.ptr<i32>>, i32, tensor<4xi1> -> tensor<4xi32>
+  // CHECK-NEXT: %[[RES:.+]] = tt.extern_elementwise %[[ARG0]], %[[ARG1]], %[[ARG2]]
+  // CHECK-SAME: {libname = "", libpath = "", pure = false, symbol = "xla_atomicwrite_release_system"}
+  // CHECK-SAME: : (tensor<4x!tt.ptr<i32>>, i32, tensor<4xi1>) -> tensor<4xi32>
   triton_xla.atomic_write sys, release, %ptr,  %value, %mask:
     (tensor<4x!tt.ptr<i32>>, i32, tensor<4xi1>) -> ()
+  // CHECK-NEXT: tt.return
+  tt.return
+}
+
+// CHECK-LABEL: tt.func @test_different_scopes
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<4x!tt.ptr<i32>>, %[[ARG1:.+]]: i32)
+tt.func @test_different_scopes(%ptr: tensor<4x!tt.ptr<i32>>, %value: i32) {
+  // CHECK: tt.extern_elementwise
+  // CHECK-SAME: symbol = "xla_atomicwrite_release_gpu"
+  triton_xla.atomic_write gpu, release, %ptr, %value : (tensor<4x!tt.ptr<i32>>, i32) -> ()
+  
+  // CHECK: tt.extern_elementwise
+  // CHECK-SAME: symbol = "xla_atomicwrite_release_cta"
+  triton_xla.atomic_write cta, release, %ptr, %value : (tensor<4x!tt.ptr<i32>>, i32) -> ()
+  
+  // CHECK-NEXT: tt.return
+  tt.return
+}
+
+// CHECK-LABEL: tt.func @test_scalar_with_mask
+// CHECK-SAME: (%[[ARG0:.+]]: !tt.ptr<i32>, %[[ARG1:.+]]: i32, %[[ARG2:.+]]: i1)
+tt.func @test_scalar_with_mask(%ptr: !tt.ptr<i32>, %value: i32, %mask: i1) {
+  // CHECK-NOT: triton_xla.atomic_write
+  // CHECK: tt.extern_elementwise %[[ARG0]], %[[ARG1]], %[[ARG2]]
+  // CHECK-SAME: symbol = "xla_atomicwrite_release_system"
+  triton_xla.atomic_write sys, release, %ptr, %value, %mask : (!tt.ptr<i32>, i32, i1) -> ()
   // CHECK-NEXT: tt.return
   tt.return
 }

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_get_tid.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_get_tid.mlir
@@ -1,11 +1,39 @@
 // RUN: xla-opt %s --triton-xla-get-tid | FileCheck %s
 
-// CHECK-LABEL: tt.func @kernel()
-tt.func @kernel() -> i32 {
-  // CHECK-NOT: triton_xla.get_flat_tid
-  // CHECK: %[[TID:.*]] = tt.elementwise_inline_asm
-  // CHECK-SAME: mov.u32 $0, %tid.x;
-  // CHECK: tt.return %[[TID]] : i32
-  %0 = triton_xla.get_tid : () -> i32
-  tt.return %0 : i32
+// Test lowering of GetTidOp to tt.extern_elementwise
+
+// CHECK-LABEL: @test_get_tid
+tt.func @test_get_tid() -> i32 {
+  // CHECK-NOT: triton_xla.get_tid
+  // CHECK: [[TID:%.*]] = tt.extern_elementwise
+  // CHECK-SAME: pure = true
+  // CHECK-SAME: symbol = "xla_getthreadid"
+  // CHECK: tt.return [[TID]]
+  %tid = triton_xla.get_tid : () -> i32
+  tt.return %tid : i32
+}
+
+// CHECK-LABEL: @test_get_tid_used_in_computation
+tt.func @test_get_tid_used_in_computation(%value: i32) -> i32 {
+  // CHECK: [[TID:%.*]] = tt.extern_elementwise
+  // CHECK-SAME: symbol = "xla_getthreadid"
+  // CHECK: [[RESULT:%.*]] = arith.addi [[TID]], %arg0
+  // CHECK: tt.return [[RESULT]]
+  %tid = triton_xla.get_tid : () -> i32
+  %result = arith.addi %tid, %value : i32
+  tt.return %result : i32
+}
+
+// CHECK-LABEL: @test_multiple_get_tid_calls
+tt.func @test_multiple_get_tid_calls() -> i32 {
+  // CHECK: [[TID1:%.*]] = tt.extern_elementwise
+  // CHECK-SAME: symbol = "xla_getthreadid"
+  // CHECK: [[TID2:%.*]] = tt.extern_elementwise
+  // CHECK-SAME: symbol = "xla_getthreadid"
+  // CHECK: [[RESULT:%.*]] = arith.addi [[TID1]], [[TID2]]
+  // CHECK: tt.return [[RESULT]]
+  %tid1 = triton_xla.get_tid : () -> i32
+  %tid2 = triton_xla.get_tid : () -> i32
+  %result = arith.addi %tid1, %tid2 : i32
+  tt.return %result : i32
 }

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_implement_extern_atomics_cuda.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_implement_extern_atomics_cuda.mlir
@@ -17,10 +17,11 @@ module {
   // CHECK-LABEL: llvm.func @test_atomic_write_unmasked
   llvm.func @test_atomic_write_unmasked(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicwrite_release_system
-    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
+    // CHECK: llvm.inline_asm has_side_effects "
     // CHECK-SAME: st.global.sys.release.u32 [$0], $1;
-    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> i32
-    // CHECK: llvm.return [[RESULT]]
+    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> ()
+    // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicwrite_release_system(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
@@ -28,24 +29,27 @@ module {
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_unmasked
   llvm.func @test_atomic_spin_wait_unmasked(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicspinwait_acquire_system_lt
-    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
+    // CHECK: llvm.inline_asm has_side_effects "
     // CHECK-SAME: .reg .pred %p<1>;
     // CHECK-SAME: .reg .b32 %r<1>;
     // CHECK-SAME: wait:
     // CHECK-SAME: ld.global.sys.acquire.u32 %r0, [$0];
     // CHECK-SAME: setp.lt.u32 %p0, %r0, $1;
     // CHECK-SAME: @%p0 bra wait;
-    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> i32
-    // CHECK: llvm.return [[RESULT]]
+    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> ()
+    // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicspinwait_acquire_system_lt(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
   
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_eq
   llvm.func @test_atomic_spin_wait_eq(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
-    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
+    // CHECK: llvm.inline_asm has_side_effects "
     // CHECK-SAME: setp.eq.u32 %p0, %r0, $1;
-    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> i32
+    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> ()
+    // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicspinwait_acquire_system_eq(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
@@ -101,12 +105,13 @@ module {
   // CHECK-LABEL: llvm.func @test_atomic_write_masked
   llvm.func @test_atomic_write_masked(%ptr: !llvm.ptr<1>, %value: i32, %mask: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicwrite_release_system
-    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
+    // CHECK: llvm.inline_asm has_side_effects "
     // CHECK-SAME: .reg .pred %p<>;
     // CHECK-SAME: setp.ne.u32 %p<>, $2, 0;
     // CHECK-SAME: @%p<> st.global.sys.release.u32 [$0], $1;
-    // CHECK-SAME: ", "l,r,r" %arg0, %arg1, %arg2 : (!llvm.ptr<1>, i32, i32) -> i32
-    // CHECK: llvm.return [[RESULT]]
+    // CHECK-SAME: ", "l,r,r" %arg0, %arg1, %arg2 : (!llvm.ptr<1>, i32, i32) -> ()
+    // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicwrite_release_system(%ptr, %value, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
     llvm.return %result : i32
   }
@@ -114,7 +119,8 @@ module {
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_masked
   llvm.func @test_atomic_spin_wait_masked(%ptr: !llvm.ptr<1>, %expected: i32, %mask: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicspinwait_acquire_system_lt
-    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
+    // CHECK: llvm.inline_asm has_side_effects "
     // CHECK-SAME: .reg .pred %p<2>;
     // CHECK-SAME: .reg .b32 %r<1>;
     // CHECK-SAME: setp.ne.u32 %p0, $2, 0;
@@ -124,17 +130,19 @@ module {
     // CHECK-SAME: setp.lt.u32 %p1, %r0, $1;
     // CHECK-SAME: @%p1 bra wait;
     // CHECK-SAME: done:
-    // CHECK-SAME: ", "l,r,r" %arg0, %arg1, %arg2 : (!llvm.ptr<1>, i32, i32) -> i32
-    // CHECK: llvm.return [[RESULT]]
+    // CHECK-SAME: ", "l,r,r" %arg0, %arg1, %arg2 : (!llvm.ptr<1>, i32, i32) -> ()
+    // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicspinwait_acquire_system_lt(%ptr, %expected, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
     llvm.return %result : i32
   }
   
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_masked_eq
   llvm.func @test_atomic_spin_wait_masked_eq(%ptr: !llvm.ptr<1>, %expected: i32, %mask: i32) -> i32 {
-    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
+    // CHECK: llvm.inline_asm has_side_effects "
     // CHECK-SAME: setp.eq.u32 %p1, %r0, $1;
-    // CHECK-SAME: ", "l,r,r"
+    // CHECK-SAME: ", "l,r,r" %arg0, %arg1, %arg2 : (!llvm.ptr<1>, i32, i32) -> ()
+    // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicspinwait_acquire_system_eq(%ptr, %expected, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
     llvm.return %result : i32
   }

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_implement_extern_atomics_cuda.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_implement_extern_atomics_cuda.mlir
@@ -1,0 +1,146 @@
+// RUN: xla-opt %s -triton-xla-implement-extern-element-wise | FileCheck %s
+
+// Test CUDA implementation of extern_elementwise atomic functions
+// This pass operates on LLVM dialect and inlines PTX assembly implementations
+
+// Test unmasked operations
+module {
+  // CHECK-LABEL: llvm.func @test_get_thread_id
+  llvm.func @test_get_thread_id() -> i32 {
+    // CHECK-NOT: llvm.call @xla_getthreadid
+    // CHECK: [[TID:%.*]] = llvm.inline_asm {{.*}}mov.u32 $0, %tid.x;{{.*}}, "=r" : () -> i32
+    // CHECK: llvm.return [[TID]]
+    %tid = llvm.call @xla_getthreadid() : () -> i32
+    llvm.return %tid : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_atomic_write_unmasked
+  llvm.func @test_atomic_write_unmasked(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
+    // CHECK-NOT: llvm.call @xla_atomicwrite_release_system
+    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK-SAME: st.global.sys.release.u32 [$0], $1;
+    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> i32
+    // CHECK: llvm.return [[RESULT]]
+    %result = llvm.call @xla_atomicwrite_release_system(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_atomic_spin_wait_unmasked
+  llvm.func @test_atomic_spin_wait_unmasked(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
+    // CHECK-NOT: llvm.call @xla_atomicspinwait_acquire_system_lt
+    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK-SAME: .reg .pred %p<1>;
+    // CHECK-SAME: .reg .b32 %r<1>;
+    // CHECK-SAME: wait:
+    // CHECK-SAME: ld.global.sys.acquire.u32 %r0, [$0];
+    // CHECK-SAME: setp.lt.u32 %p0, %r0, $1;
+    // CHECK-SAME: @%p0 bra wait;
+    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> i32
+    // CHECK: llvm.return [[RESULT]]
+    %result = llvm.call @xla_atomicspinwait_acquire_system_lt(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_atomic_spin_wait_eq
+  llvm.func @test_atomic_spin_wait_eq(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
+    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK-SAME: setp.eq.u32 %p0, %r0, $1;
+    // CHECK-SAME: ", "l,r" %arg0, %arg1 : (!llvm.ptr<1>, i32) -> i32
+    %result = llvm.call @xla_atomicspinwait_acquire_system_eq(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_relaxed_ordering
+  llvm.func @test_relaxed_ordering(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
+    // CHECK: llvm.inline_asm has_side_effects "
+    // CHECK-SAME: st.global.sys.relaxed.u32 [$0], $1;
+    // CHECK-SAME: ", "l,r"
+    %result = llvm.call @xla_atomicwrite_relaxed_system(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_gpu_scope
+  llvm.func @test_gpu_scope(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
+    // CHECK: llvm.inline_asm has_side_effects "
+    // CHECK-SAME: st.global.gpu.release.u32 [$0], $1;
+    // CHECK-SAME: ", "l,r"
+    %result = llvm.call @xla_atomicwrite_release_gpu(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_cta_scope
+  llvm.func @test_cta_scope(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
+    // CHECK: llvm.inline_asm has_side_effects "
+    // CHECK-SAME: st.global.cta.release.u32 [$0], $1;
+    // CHECK-SAME: ", "l,r"
+    %result = llvm.call @xla_atomicwrite_release_cta(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_acquire_ordering
+  llvm.func @test_acquire_ordering(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
+    // CHECK: llvm.inline_asm has_side_effects "
+    // CHECK-SAME: ld.global.sys.acquire.u32 %r0, [$0];
+    // CHECK-SAME: ", "l,r"
+    %result = llvm.call @xla_atomicspinwait_acquire_system_lt(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // Extern function declarations (will be removed by the pass)
+  llvm.func @xla_getthreadid() -> i32
+  llvm.func @xla_atomicwrite_release_system(!llvm.ptr<1>, i32) -> i32
+  llvm.func @xla_atomicwrite_relaxed_system(!llvm.ptr<1>, i32) -> i32
+  llvm.func @xla_atomicwrite_release_gpu(!llvm.ptr<1>, i32) -> i32
+  llvm.func @xla_atomicwrite_release_cta(!llvm.ptr<1>, i32) -> i32
+  llvm.func @xla_atomicspinwait_acquire_system_lt(!llvm.ptr<1>, i32) -> i32
+  llvm.func @xla_atomicspinwait_acquire_system_eq(!llvm.ptr<1>, i32) -> i32
+}
+
+// Test masked operations in separate module to avoid function redefinition
+module {
+  // CHECK-LABEL: llvm.func @test_atomic_write_masked
+  llvm.func @test_atomic_write_masked(%ptr: !llvm.ptr<1>, %value: i32, %mask: i32) -> i32 {
+    // CHECK-NOT: llvm.call @xla_atomicwrite_release_system
+    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK-SAME: .reg .pred %p<>;
+    // CHECK-SAME: setp.ne.u32 %p<>, $2, 0;
+    // CHECK-SAME: @%p<> st.global.sys.release.u32 [$0], $1;
+    // CHECK-SAME: ", "l,r,r" %arg0, %arg1, %arg2 : (!llvm.ptr<1>, i32, i32) -> i32
+    // CHECK: llvm.return [[RESULT]]
+    %result = llvm.call @xla_atomicwrite_release_system(%ptr, %value, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_atomic_spin_wait_masked
+  llvm.func @test_atomic_spin_wait_masked(%ptr: !llvm.ptr<1>, %expected: i32, %mask: i32) -> i32 {
+    // CHECK-NOT: llvm.call @xla_atomicspinwait_acquire_system_lt
+    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK-SAME: .reg .pred %p<2>;
+    // CHECK-SAME: .reg .b32 %r<1>;
+    // CHECK-SAME: setp.ne.u32 %p0, $2, 0;
+    // CHECK-SAME: @%!p0 bra done;
+    // CHECK-SAME: wait:
+    // CHECK-SAME: ld.global.sys.acquire.u32 %r0, [$0];
+    // CHECK-SAME: setp.lt.u32 %p1, %r0, $1;
+    // CHECK-SAME: @%p1 bra wait;
+    // CHECK-SAME: done:
+    // CHECK-SAME: ", "l,r,r" %arg0, %arg1, %arg2 : (!llvm.ptr<1>, i32, i32) -> i32
+    // CHECK: llvm.return [[RESULT]]
+    %result = llvm.call @xla_atomicspinwait_acquire_system_lt(%ptr, %expected, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // CHECK-LABEL: llvm.func @test_atomic_spin_wait_masked_eq
+  llvm.func @test_atomic_spin_wait_masked_eq(%ptr: !llvm.ptr<1>, %expected: i32, %mask: i32) -> i32 {
+    // CHECK: [[RESULT:%.*]] = llvm.inline_asm has_side_effects "
+    // CHECK-SAME: setp.eq.u32 %p1, %r0, $1;
+    // CHECK-SAME: ", "l,r,r"
+    %result = llvm.call @xla_atomicspinwait_acquire_system_eq(%ptr, %expected, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
+    llvm.return %result : i32
+  }
+  
+  // Extern function declarations for masked versions
+  llvm.func @xla_atomicwrite_release_system(!llvm.ptr<1>, i32, i32) -> i32
+  llvm.func @xla_atomicspinwait_acquire_system_lt(!llvm.ptr<1>, i32, i32) -> i32
+  llvm.func @xla_atomicspinwait_acquire_system_eq(!llvm.ptr<1>, i32, i32) -> i32
+}

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <utility>
 
 #include "absl/log/log.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Builders.h"
@@ -49,43 +50,38 @@ class RewriteExternCallPattern : public OpRewritePattern<LLVM::CallOp> {
   LogicalResult matchAndRewrite(LLVM::CallOp call_op,
                                 PatternRewriter& rewriter) const override {
     // Check if this is a call to one of our extern functions
-    auto callee = call_op.getCallee();
+    std::optional<llvm::StringRef> callee = call_op.getCallee();
     if (!callee) {
       return failure();
     }
 
     llvm::StringRef callee_name = *callee;
-    if (!callee_name.starts_with("xla_atomicwrite_") &&
-        !callee_name.starts_with("xla_atomicspinwait_") &&
-        !callee_name.starts_with("xla_getthreadid")) {
-      return failure();
-    }
 
     // Parse the function name to get the instruction
-    auto parsed = ParseExternFunctionName(callee_name.str());
+    absl::StatusOr<ExternFunctionInstruction> parsed =
+        ParseExternFunctionName(callee_name);
     if (!parsed.ok()) {
       return rewriter.notifyMatchFailure(
-          call_op, "Failed to parse extern function name: " +
-                       callee_name.str() + " - " + parsed.status().ToString());
+          call_op,
+          absl::StrFormat("Failed to parse extern function name: %s - %s",
+                          callee_name, parsed.status().ToString()));
     }
 
-    // Validate memory semantic
-    auto validation = ValidateMemorySemantic(*parsed);
+    absl::Status validation = ValidateMemorySemantic(*parsed);
     if (!validation.ok()) {
       return rewriter.notifyMatchFailure(
-          call_op, "Invalid memory semantic for function: " +
-                       callee_name.str() + " - " + validation.ToString());
+          call_op,
+          absl::StrFormat("Invalid memory semantic for function: %s - %s",
+                          callee_name, validation.ToString()));
     }
 
-    // Create LLVM operations for the instruction
-    LLVMOpCreationParams params{.builder = rewriter,
-                                .loc = call_op.getLoc(),
-                                .target = TargetBackend::CUDA,
-                                .operands = call_op.getOperands()};
+    LLVMOpCreationParams params{/*.builder=*/rewriter,
+                                /*.loc=*/call_op.getLoc(),
+                                /*.target=*/TargetBackend::CUDA,
+                                /*.operands=*/call_op.getOperands()};
 
     mlir::Value result = CreateLLVMOpsForInstruction(*parsed, params);
 
-    // Replace the call with the generated operations
     rewriter.replaceOp(call_op, result);
     return success();
   }
@@ -104,14 +100,17 @@ class EraseUnusedExternFuncPattern : public OpRewritePattern<LLVM::LLVMFuncOp> {
     }
 
     llvm::StringRef name = func_op.getName();
-    if (!name.starts_with("xla_atomicwrite_") &&
-        !name.starts_with("xla_atomicspinwait_") &&
-        !name.starts_with("xla_getthreadid")) {
+    // Check if a valid XLA extern function remains
+    absl::StatusOr<ExternFunctionInstruction> parsed =
+        ParseExternFunctionName(name);
+    if (!parsed.ok()) {
       return failure();
     }
 
     // Check if the function has any uses
     if (!func_op.use_empty()) {
+      func_op.emitError() << "Extern function '" << name
+                          << "' still has uses after call replacement";
       return failure();
     }
 
@@ -133,7 +132,6 @@ class TritonXLAImplementExternElementWisePass
     mlir::ModuleOp module = getOperation();
     mlir::MLIRContext* context = &getContext();
 
-    // Apply rewrite patterns
     RewritePatternSet patterns(context);
     patterns.add<RewriteExternCallPattern>(context);
     patterns.add<EraseUnusedExternFuncPattern>(context);

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
@@ -19,16 +19,16 @@ limitations under the License.
 // intrinsics.
 
 #include <memory>
-#include <string>
+#include <optional>
 #include <utility>
 
-#include "absl/log/log.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/string_view.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
@@ -1,0 +1,153 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// CUDA-specific implementation of extern_elementwise atomic functions.
+// This pass runs in the Triton CUDA pipeline and inlines the implementations
+// of custom atomic functions by replacing llvm.call operations with LLVM
+// intrinsics.
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "absl/log/log.h"
+#include "absl/strings/string_view.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
+
+namespace mlir::triton::xla {
+
+#define GEN_PASS_DEF_TRITONXLAIMPLEMENTEXTERNELEMENTWISEPASS
+#include "xla/backends/gpu/codegen/triton/transforms/passes.h.inc"
+
+namespace {
+
+// Pattern to rewrite llvm.call operations to XLA extern functions
+class RewriteExternCallPattern : public OpRewritePattern<LLVM::CallOp> {
+ public:
+  using OpRewritePattern<LLVM::CallOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::CallOp call_op,
+                                PatternRewriter& rewriter) const override {
+    // Check if this is a call to one of our extern functions
+    auto callee = call_op.getCallee();
+    if (!callee) {
+      return failure();
+    }
+
+    llvm::StringRef callee_name = *callee;
+    if (!callee_name.starts_with("xla_atomicwrite_") &&
+        !callee_name.starts_with("xla_atomicspinwait_") &&
+        !callee_name.starts_with("xla_getthreadid")) {
+      return failure();
+    }
+
+    // Parse the function name to get the instruction
+    auto parsed = ParseExternFunctionName(callee_name.str());
+    if (!parsed.ok()) {
+      return rewriter.notifyMatchFailure(
+          call_op, "Failed to parse extern function name: " +
+                       callee_name.str() + " - " + parsed.status().ToString());
+    }
+
+    // Validate memory semantic
+    auto validation = ValidateMemorySemantic(*parsed);
+    if (!validation.ok()) {
+      return rewriter.notifyMatchFailure(
+          call_op, "Invalid memory semantic for function: " +
+                       callee_name.str() + " - " + validation.ToString());
+    }
+
+    // Create LLVM operations for the instruction
+    LLVMOpCreationParams params{.builder = rewriter,
+                                .loc = call_op.getLoc(),
+                                .target = TargetBackend::CUDA,
+                                .operands = call_op.getOperands()};
+
+    mlir::Value result = CreateLLVMOpsForInstruction(*parsed, params);
+
+    // Replace the call with the generated operations
+    rewriter.replaceOp(call_op, result);
+    return success();
+  }
+};
+
+// Pattern to erase unused extern function declarations
+class EraseUnusedExternFuncPattern : public OpRewritePattern<LLVM::LLVMFuncOp> {
+ public:
+  using OpRewritePattern<LLVM::LLVMFuncOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::LLVMFuncOp func_op,
+                                PatternRewriter& rewriter) const override {
+    // Only match external functions
+    if (!func_op.isExternal()) {
+      return failure();
+    }
+
+    llvm::StringRef name = func_op.getName();
+    if (!name.starts_with("xla_atomicwrite_") &&
+        !name.starts_with("xla_atomicspinwait_") &&
+        !name.starts_with("xla_getthreadid")) {
+      return failure();
+    }
+
+    // Check if the function has any uses
+    if (!func_op.use_empty()) {
+      return failure();
+    }
+
+    // Erase the unused function declaration
+    rewriter.eraseOp(func_op);
+    return success();
+  }
+};
+
+// MLIR pass that inlines extern function calls with LLVM intrinsics
+class TritonXLAImplementExternElementWisePass
+    : public impl::TritonXLAImplementExternElementWisePassBase<
+          TritonXLAImplementExternElementWisePass> {
+ public:
+  using Base::Base;
+
+ private:
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+    mlir::MLIRContext* context = &getContext();
+
+    // Apply rewrite patterns
+    RewritePatternSet patterns(context);
+    patterns.add<RewriteExternCallPattern>(context);
+    patterns.add<EraseUnusedExternFuncPattern>(context);
+
+    if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<mlir::Pass> CreateTritonXLAImplementExternElementWisePass() {
+  return std::make_unique<TritonXLAImplementExternElementWisePass>();
+}
+
+}  // namespace mlir::triton::xla

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_atomics_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_atomics_pass.cc
@@ -13,10 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// Generic lowering of atomic operations for Triton XLA using
+// tt.extern_elementwise. This implementation uses tt.extern_elementwise to call
+// custom atomic functions that will be implemented in platform-specific passes
+// later in the Triton pipeline.
+
 #include <memory>
 #include <string>
 #include <utility>
 
+#include "absl/log/log.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "mlir/IR/Builders.h"
@@ -38,7 +44,8 @@ namespace mlir::triton::xla {
 
 namespace {
 
-absl::string_view GetMemorySemanticStr(triton::MemSemantic semantic) {
+// Helper function to convert MemSemantic enum to string
+absl::string_view MemSemanticToString(triton::MemSemantic semantic) {
   switch (semantic) {
     case triton::MemSemantic::RELAXED:
       return "relaxed";
@@ -49,26 +56,31 @@ absl::string_view GetMemorySemanticStr(triton::MemSemantic semantic) {
     case triton::MemSemantic::ACQUIRE_RELEASE:
       return "acq_rel";
   }
+  LOG(FATAL) << "Unknown MemSemantic value";
 }
 
-absl::string_view GetMemSyncScopeStr(triton::MemSyncScope scope) {
+// Helper function to convert MemSyncScope enum to string
+absl::string_view MemSyncScopeToString(triton::MemSyncScope scope) {
   switch (scope) {
+    case triton::MemSyncScope::SYSTEM:
+      return "system";
     case triton::MemSyncScope::GPU:
       return "gpu";
-    case triton::MemSyncScope::SYSTEM:
-      return "sys";
     case triton::MemSyncScope::CTA:
       return "cta";
   }
+  LOG(FATAL) << "Unknown MemSyncScope value";
 }
 
-absl::string_view GetComparatorStr(Comparator comparator) {
+// Helper function to convert Comparator enum to string
+absl::string_view ComparatorToString(Comparator comparator) {
   switch (comparator) {
     case Comparator::EQ:
       return "eq";
     case Comparator::LT:
       return "lt";
   }
+  LOG(FATAL) << "Unknown Comparator value";
 }
 
 mlir::Type GetResultType(mlir::Type ptr_type, PatternRewriter& rewriter) {
@@ -82,132 +94,117 @@ mlir::Type GetResultType(mlir::Type ptr_type, PatternRewriter& rewriter) {
   return result_type;
 }
 
+// Lower AtomicWriteOp to tt.extern_elementwise.
+// This creates extern calls that will be implemented in a separate ROCm pass.
 LogicalResult LowerAtomicWriteOp(AtomicWriteOp atomic_write,
                                  PatternRewriter& rewriter) {
+  VLOG(2) << "LowerAtomicWriteOp: Starting tt.extern_elementwise lowering";
   mlir::ImplicitLocOpBuilder builder(atomic_write.getLoc(), rewriter);
 
   mlir::Value ptr = atomic_write.getPtr();
   mlir::Value value = atomic_write.getValue();
+  mlir::Value mask = atomic_write.getMask();
+
   triton::MemSemantic semantic = atomic_write.getMemSyncSemantic();
+  triton::MemSyncScope scope = atomic_write.getMemSyncScope();
+
+  // Validate memory semantics
   if (semantic != triton::MemSemantic::RELAXED &&
       semantic != triton::MemSemantic::RELEASE) {
     return rewriter.notifyMatchFailure(
-        atomic_write, absl::StrFormat("Unsupported memory semantic: %s",
-                                      stringifyMemSemantic(semantic)));
+        atomic_write,
+        "AtomicWriteOp only supports RELAXED or RELEASE semantics");
   }
-  absl::string_view memory_semantic = GetMemorySemanticStr(semantic);
-  absl::string_view scope = GetMemSyncScopeStr(atomic_write.getMemSyncScope());
 
-  // Predicate ASM to check if the mask is set.
-  // NB: The arguments start from 1 because 0 is reserved to be the output.
-  // Even though we don't care about result($0) in this case it must be there
-  // for ElementwiseInlineAsmOp verifiers to work
-  constexpr absl::string_view kAtomicWriteAsmWithMaskTemplate = R"(
-    {
-    .reg .pred %%p<>;
-    setp.ne.u32 %%p<>, $3, 0;
-    @%%p st.global.%s.%s.u32 [$1], $2;
-    }
-  )";
-  constexpr absl::string_view kAtomicWriteAsmTemplate = R"(
-    st.global.%s.%s.u32 [$1], $2;
-  )";
+  // Build function name: xla_atomicwrite_<semantic>_<scope>
+  std::string func_name =
+      absl::StrFormat("xla_atomicwrite_%s_%s", MemSemanticToString(semantic),
+                      MemSyncScopeToString(scope));
 
+  VLOG(3) << "LowerAtomicWriteOp: Creating extern_elementwise call to "
+          << func_name;
+
+  // Get result type (handles both tensor and scalar pointers)
   mlir::Type result_type = GetResultType(ptr.getType(), rewriter);
-  mlir::Value mask = atomic_write.getMask();
+
+  // Prepare operands: ptr (tensor or scalar), value (always scalar)
+  llvm::SmallVector<mlir::Value> operands = {ptr, value};
+
+  // If mask is provided, pass it as third argument
   if (mask) {
-    const std::string atomic_write_asm_with_mask = absl::StrFormat(
-        kAtomicWriteAsmWithMaskTemplate, scope, memory_semantic);
-    triton::ElementwiseInlineAsmOp::create(
-        builder,
-        /*result_types=*/result_type,
-        /*asm_string=*/rewriter.getStringAttr(atomic_write_asm_with_mask),
-        /*constraints=*/rewriter.getStringAttr("=r,l,r,r"),
-        /*pure=*/rewriter.getBoolAttr(false),
-        /*packed_element=*/rewriter.getI32IntegerAttr(1),
-        /*args=*/mlir::ValueRange{ptr, value, mask});
-  } else {
-    const std::string atomic_write_asm =
-        absl::StrFormat(kAtomicWriteAsmTemplate, scope, memory_semantic);
-    triton::ElementwiseInlineAsmOp::create(
-        builder,
-        /*result_types=*/result_type,
-        /*asm_string=*/rewriter.getStringAttr(atomic_write_asm),
-        /*constraints=*/rewriter.getStringAttr("=r,l,r"),
-        /*pure=*/rewriter.getBoolAttr(false),
-        /*packed_element=*/rewriter.getI32IntegerAttr(1),
-        /*args=*/mlir::ValueRange{ptr, value});
+    operands.push_back(mask);
   }
-  // No results to replace; just erase the op.
+
+  // Create tt.extern_elementwise call
+  // The function will perform atomic exchange and return the old value
+  // Note: extern_elementwise handles broadcasting scalar value to tensor
+  // automatically
+  builder.create<triton::ExternElementwiseOp>(
+      /*resultType=*/result_type,
+      /*srcs=*/operands,
+      /*libname=*/"",
+      /*libpath=*/"",
+      /*symbol=*/func_name,
+      /*pure=*/false);
+
   rewriter.eraseOp(atomic_write);
   return success();
 }
 
+// Lower AtomicSpinWaitOp to tt.extern_elementwise.
+// This creates extern calls that will be implemented in a separate ROCm pass.
 LogicalResult LowerAtomicSpinWaitOp(AtomicSpinWaitOp atomic_wait,
                                     PatternRewriter& rewriter) {
+  VLOG(2) << "LowerAtomicSpinWaitOp: Starting tt.extern_elementwise lowering";
   mlir::ImplicitLocOpBuilder builder(atomic_wait.getLoc(), rewriter);
 
   mlir::Value ptr = atomic_wait.getPtr();
   mlir::Value expected = atomic_wait.getExpected();
+  mlir::Value mask = atomic_wait.getMask();
+
   triton::MemSemantic semantic = atomic_wait.getMemSyncSemantic();
+  triton::MemSyncScope scope = atomic_wait.getMemSyncScope();
+  Comparator comparator = atomic_wait.getComparator();
+
+  // Validate memory semantics
   if (semantic != triton::MemSemantic::RELAXED &&
       semantic != triton::MemSemantic::ACQUIRE) {
     return rewriter.notifyMatchFailure(
-        atomic_wait, absl::StrFormat("Unsupported memory semantic: %s",
-                                     stringifyMemSemantic(semantic)));
+        atomic_wait,
+        "AtomicSpinWaitOp only supports RELAXED or ACQUIRE semantics");
   }
-  absl::string_view memory_semantic = GetMemorySemanticStr(semantic);
-  absl::string_view scope = GetMemSyncScopeStr(atomic_wait.getMemSyncScope());
 
-  absl::string_view comparator = GetComparatorStr(atomic_wait.getComparator());
-  constexpr absl::string_view kAtomicSpinWaitAsmTemplate = R"(
-    {
-    .reg .pred %%p<1>;
-    .reg .b32 %%r<1>;
-    wait:
-      ld.global.%s.%s.u32 %%r0, [$1];
-      setp.%s.u32 %%p0, %%r0, $2;
-      @%%p0 bra wait;
-    }
-  )";
-  constexpr absl::string_view kAtomicSpinWaitAsmWithMaskTemplate = R"(
-    {
-    .reg .pred %%p<2>;
-    .reg .b32 %%r<1>;
-    setp.ne.u32 %%p0, $3, 0;
-    @%%!p0 bra done;
-    wait:
-      ld.global.%s.%s.u32 %%r0, [$1];
-      setp.%s.u32 %%p1, %%r0, $2;
-      @%%p1 bra wait;
-    done:
-    }
-  )";
+  // Build function name: xla_atomicspinwait_<semantic>_<scope>_<comparator>
+  std::string func_name = absl::StrFormat(
+      "xla_atomicspinwait_%s_%s_%s", MemSemanticToString(semantic),
+      MemSyncScopeToString(scope), ComparatorToString(comparator));
+
+  VLOG(3) << "LowerAtomicSpinWaitOp: Creating extern_elementwise call to "
+          << func_name;
+
+  // Get result type (handles both tensor and scalar pointers)
   mlir::Type result_type = GetResultType(ptr.getType(), rewriter);
-  Value mask = atomic_wait.getMask();
+
+  // Prepare operands: ptr (tensor or scalar), expected (always scalar)
+  llvm::SmallVector<mlir::Value> operands = {ptr, expected};
+
+  // If mask is provided, pass it as third argument
   if (mask) {
-    const std::string atomic_wait_asm_with_mask = absl::StrFormat(
-        kAtomicSpinWaitAsmWithMaskTemplate, scope, memory_semantic, comparator);
-    triton::ElementwiseInlineAsmOp::create(
-        builder,
-        /*result_types=*/result_type,
-        /*asm_string=*/rewriter.getStringAttr(atomic_wait_asm_with_mask),
-        /*constraints=*/rewriter.getStringAttr("=r,l,r,r"),
-        /*pure=*/rewriter.getBoolAttr(false),
-        /*packed_element=*/rewriter.getI32IntegerAttr(1),
-        /*args=*/mlir::ValueRange{ptr, expected, mask});
-  } else {
-    const std::string atomic_wait_asm = absl::StrFormat(
-        kAtomicSpinWaitAsmTemplate, scope, memory_semantic, comparator);
-    triton::ElementwiseInlineAsmOp::create(
-        builder,
-        /*result_types=*/result_type,
-        /*asm_string=*/rewriter.getStringAttr(atomic_wait_asm),
-        /*constraints=*/rewriter.getStringAttr("=r,l,r"),
-        /*pure=*/rewriter.getBoolAttr(false),
-        /*packed_element=*/rewriter.getI32IntegerAttr(1),
-        /*args=*/mlir::ValueRange{ptr, expected});
+    operands.push_back(mask);
   }
+
+  // Create tt.extern_elementwise call
+  // The function will spin-wait until the condition is met
+  // Note: extern_elementwise handles broadcasting scalar expected to tensor
+  // automatically
+  builder.create<triton::ExternElementwiseOp>(
+      /*resultType=*/result_type,
+      /*srcs=*/operands,
+      /*libname=*/"",
+      /*libpath=*/"",
+      /*symbol=*/func_name,
+      /*pure=*/false);
+
   rewriter.eraseOp(atomic_wait);
   return success();
 }

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_atomics_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_atomics_pass.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
@@ -43,45 +44,6 @@ namespace mlir::triton::xla {
 #include "xla/backends/gpu/codegen/triton/transforms/passes.h.inc"
 
 namespace {
-
-// Helper function to convert MemSemantic enum to string
-absl::string_view MemSemanticToString(triton::MemSemantic semantic) {
-  switch (semantic) {
-    case triton::MemSemantic::RELAXED:
-      return "relaxed";
-    case triton::MemSemantic::ACQUIRE:
-      return "acquire";
-    case triton::MemSemantic::RELEASE:
-      return "release";
-    case triton::MemSemantic::ACQUIRE_RELEASE:
-      return "acq_rel";
-  }
-  LOG(FATAL) << "Unknown MemSemantic value";
-}
-
-// Helper function to convert MemSyncScope enum to string
-absl::string_view MemSyncScopeToString(triton::MemSyncScope scope) {
-  switch (scope) {
-    case triton::MemSyncScope::SYSTEM:
-      return "system";
-    case triton::MemSyncScope::GPU:
-      return "gpu";
-    case triton::MemSyncScope::CTA:
-      return "cta";
-  }
-  LOG(FATAL) << "Unknown MemSyncScope value";
-}
-
-// Helper function to convert Comparator enum to string
-absl::string_view ComparatorToString(Comparator comparator) {
-  switch (comparator) {
-    case Comparator::EQ:
-      return "eq";
-    case Comparator::LT:
-      return "lt";
-  }
-  LOG(FATAL) << "Unknown Comparator value";
-}
 
 mlir::Type GetResultType(mlir::Type ptr_type, PatternRewriter& rewriter) {
   mlir::Type result_type = rewriter.getI32Type();
@@ -98,17 +60,15 @@ mlir::Type GetResultType(mlir::Type ptr_type, PatternRewriter& rewriter) {
 // This creates extern calls that will be implemented in a separate ROCm pass.
 LogicalResult LowerAtomicWriteOp(AtomicWriteOp atomic_write,
                                  PatternRewriter& rewriter) {
-  VLOG(2) << "LowerAtomicWriteOp: Starting tt.extern_elementwise lowering";
+  VLOG(3) << "LowerAtomicWriteOp: Starting tt.extern_elementwise lowering";
   mlir::ImplicitLocOpBuilder builder(atomic_write.getLoc(), rewriter);
 
   mlir::Value ptr = atomic_write.getPtr();
   mlir::Value value = atomic_write.getValue();
   mlir::Value mask = atomic_write.getMask();
 
-  triton::MemSemantic semantic = atomic_write.getMemSyncSemantic();
-  triton::MemSyncScope scope = atomic_write.getMemSyncScope();
-
   // Validate memory semantics
+  triton::MemSemantic semantic = atomic_write.getMemSyncSemantic();
   if (semantic != triton::MemSemantic::RELAXED &&
       semantic != triton::MemSemantic::RELEASE) {
     return rewriter.notifyMatchFailure(
@@ -116,10 +76,13 @@ LogicalResult LowerAtomicWriteOp(AtomicWriteOp atomic_write,
         "AtomicWriteOp only supports RELAXED or RELEASE semantics");
   }
 
-  // Build function name: xla_atomicwrite_<semantic>_<scope>
-  std::string func_name =
-      absl::StrFormat("xla_atomicwrite_%s_%s", MemSemanticToString(semantic),
-                      MemSyncScopeToString(scope));
+  // Build function name using helper
+  absl::StatusOr<std::string> func_name_or = ToExternFunctionName(atomic_write);
+  if (!func_name_or.ok()) {
+    return rewriter.notifyMatchFailure(atomic_write,
+                                       func_name_or.status().ToString());
+  }
+  std::string func_name = *func_name_or;
 
   VLOG(3) << "LowerAtomicWriteOp: Creating extern_elementwise call to "
           << func_name;
@@ -155,18 +118,15 @@ LogicalResult LowerAtomicWriteOp(AtomicWriteOp atomic_write,
 // This creates extern calls that will be implemented in a separate ROCm pass.
 LogicalResult LowerAtomicSpinWaitOp(AtomicSpinWaitOp atomic_wait,
                                     PatternRewriter& rewriter) {
-  VLOG(2) << "LowerAtomicSpinWaitOp: Starting tt.extern_elementwise lowering";
+  VLOG(3) << "LowerAtomicSpinWaitOp: Starting tt.extern_elementwise lowering";
   mlir::ImplicitLocOpBuilder builder(atomic_wait.getLoc(), rewriter);
 
   mlir::Value ptr = atomic_wait.getPtr();
   mlir::Value expected = atomic_wait.getExpected();
   mlir::Value mask = atomic_wait.getMask();
 
-  triton::MemSemantic semantic = atomic_wait.getMemSyncSemantic();
-  triton::MemSyncScope scope = atomic_wait.getMemSyncScope();
-  Comparator comparator = atomic_wait.getComparator();
-
   // Validate memory semantics
+  triton::MemSemantic semantic = atomic_wait.getMemSyncSemantic();
   if (semantic != triton::MemSemantic::RELAXED &&
       semantic != triton::MemSemantic::ACQUIRE) {
     return rewriter.notifyMatchFailure(
@@ -174,10 +134,13 @@ LogicalResult LowerAtomicSpinWaitOp(AtomicSpinWaitOp atomic_wait,
         "AtomicSpinWaitOp only supports RELAXED or ACQUIRE semantics");
   }
 
-  // Build function name: xla_atomicspinwait_<semantic>_<scope>_<comparator>
-  std::string func_name = absl::StrFormat(
-      "xla_atomicspinwait_%s_%s_%s", MemSemanticToString(semantic),
-      MemSyncScopeToString(scope), ComparatorToString(comparator));
+  // Build function name using helper
+  absl::StatusOr<std::string> func_name_or = ToExternFunctionName(atomic_wait);
+  if (!func_name_or.ok()) {
+    return rewriter.notifyMatchFailure(atomic_wait,
+                                       func_name_or.status().ToString());
+  }
+  std::string func_name = *func_name_or;
 
   VLOG(3) << "LowerAtomicSpinWaitOp: Creating extern_elementwise call to "
           << func_name;

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_atomics_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_atomics_pass.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <utility>
 
 #include "absl/log/log.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "mlir/IR/Builders.h"

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_get_tid_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_get_tid_pass.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
@@ -48,6 +49,13 @@ LogicalResult LowerGetTidOp(GetTidOp get_flat_tid, PatternRewriter& rewriter) {
   // Get i32 type for the result
   mlir::Type i32_type = rewriter.getI32Type();
 
+  // Get function name using helper
+  absl::StatusOr<std::string> func_name_or = ToExternFunctionName(get_flat_tid);
+  if (!func_name_or.ok()) {
+    return rewriter.notifyMatchFailure(get_flat_tid,
+                                       func_name_or.status().ToString());
+  }
+
   // Use tt.extern_elementwise to call a custom function that returns thread ID
   // This function will be implemented in platform-specific passes
   auto tid_op = rewriter.create<triton::ExternElementwiseOp>(
@@ -56,7 +64,7 @@ LogicalResult LowerGetTidOp(GetTidOp get_flat_tid, PatternRewriter& rewriter) {
       /*srcs=*/mlir::ValueRange{},  // No inputs needed
       /*libname=*/"",
       /*libpath=*/"",
-      /*symbol=*/"xla_getthreadid",
+      /*symbol=*/*func_name_or,
       /*pure=*/true);  // Thread ID is pure (deterministic for a given thread)
 
   rewriter.replaceOp(get_flat_tid, tid_op.getResult());

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_get_tid_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_get_tid_pass.cc
@@ -13,6 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// Generic lowering of GetTidOp using tt.extern_elementwise.
+// This implementation uses tt.extern_elementwise to call a custom function
+// that will be implemented in platform-specific passes in the Triton pipeline.
+
 #include <memory>
 #include <utility>
 
@@ -41,19 +45,21 @@ LogicalResult LowerGetTidOp(GetTidOp get_flat_tid, PatternRewriter& rewriter) {
   rewriter.setInsertionPoint(get_flat_tid);
   const Location loc = get_flat_tid.getLoc();
 
-  const mlir::Type i32_type = rewriter.getI32Type();
-  const absl::string_view get_tid_asm = R"(
-    mov.u32 $0, %tid.x;
-  )";
-  auto tid_op = mlir::triton::ElementwiseInlineAsmOp::create(
-      rewriter, loc,
-      /*result_types=*/i32_type,
-      /*asm_string=*/rewriter.getStringAttr(get_tid_asm),
-      /*constraints=*/rewriter.getStringAttr("=r"),
-      /*pure=*/rewriter.getBoolAttr(true),
-      /*packed_element=*/rewriter.getI32IntegerAttr(1),
-      /*args*/ mlir::ValueRange{});
-  rewriter.replaceOp(get_flat_tid, tid_op->getResults());
+  // Get i32 type for the result
+  mlir::Type i32_type = rewriter.getI32Type();
+
+  // Use tt.extern_elementwise to call a custom function that returns thread ID
+  // This function will be implemented in platform-specific passes
+  auto tid_op = rewriter.create<triton::ExternElementwiseOp>(
+      loc,
+      /*resultType=*/i32_type,
+      /*srcs=*/mlir::ValueRange{},  // No inputs needed
+      /*libname=*/"",
+      /*libpath=*/"",
+      /*symbol=*/"xla_getthreadid",
+      /*pure=*/true);  // Thread ID is pure (deterministic for a given thread)
+
+  rewriter.replaceOp(get_flat_tid, tid_op.getResult());
   return success();
 }
 

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_get_tid_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_lower_get_tid_pass.cc
@@ -18,8 +18,10 @@ limitations under the License.
 // that will be implemented in platform-specific passes in the Triton pipeline.
 
 #include <memory>
+#include <string>
 #include <utility>
 
+#include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Location.h"
@@ -58,8 +60,8 @@ LogicalResult LowerGetTidOp(GetTidOp get_flat_tid, PatternRewriter& rewriter) {
 
   // Use tt.extern_elementwise to call a custom function that returns thread ID
   // This function will be implemented in platform-specific passes
-  auto tid_op = rewriter.create<triton::ExternElementwiseOp>(
-      loc,
+  auto tid_op = triton::ExternElementwiseOp::create(
+      rewriter, loc,
       /*resultType=*/i32_type,
       /*srcs=*/mlir::ValueRange{},  // No inputs needed
       /*libname=*/"",


### PR DESCRIPTION
📝 Summary of Changes
This PR is the second PR in a series of four.

PR 1/4: https://github.com/openxla/xla/pull/40462
PR 2/4: https://github.com/openxla/xla/pull/40460 <= This PR
PR 3/4: https://github.com/openxla/xla/pull/40463
PR 4/4: https://github.com/openxla/xla/pull/40464

This PR refactors the CUDA lowering of `Triton_XLA` atomic operations.
It modifies the lowering of atomic operations `triton_xla.atomic_write`, `triton_xla.atomic_spin_wait` and `triton_xla.get_tid` to rely on `extern_elementwise` triton operations instead of inline-assembly. The extern_elementwise ops are then caught later in the triton compiler pipeline and replaced by PTX inline assembly.

🎯 Justification
This PR is part of a rework of the AllReduce triton support to facilitate the enabling of different target GPUs (starting with ROCm). 
Prior to these PRs, the `triton_xla.get_tid`, `triton_xla.atomic_write` and `triton_xla.atomic_spin_wait` operations were lowered using PTX assembly. Therefore, AllReduce triton backend was only available for CUDA target.
This PR replaces the existing CUDA-only lowering strategy to lower these operations via Triton operations (`tt.extern_elementwise`), and then catch this operations, at the end of the triton pipeline.

The current PR is conservative and only delays the insertion of the same PTX inline assemble, however subsequent PRs will replace this by using LLVM target dependent intrinsics.
This unifies the lowering of triton_xla.atomic_write and triton_xla.atomic_spin_wait and triton_xla.get_tid operations for CUDA and ROCm targets.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature ♻️ Cleanup

🧪 Unit Tests:
This PR includes a LIT test checking the lowering of atomic operations.

🧪 Execution Tests:
The existing test xla/tests:all_reduce_e2e_test is relevant for testing this support.