### PR TITLE
Add helper functions to convert triton `extern_elementwise` atomic operations into LLVM inline ssembly (Enable ROCm Triton AllReduce 1/4)

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -624,6 +624,39 @@ xla_test(
 )
 
 cc_library(
+    name = "extern_function_helper",
+    srcs = ["extern_function_helper.cc"],
+    hdrs = ["extern_function_helper.h"],
+    deps = [
+        "//xla/backends/gpu/codegen/triton/ir:triton_xla",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:Support",
+        "@triton//:TritonDialects",
+    ],
+)
+
+xla_cc_test(
+    name = "extern_function_helper_test",
+    srcs = ["extern_function_helper_test.cc"],
+    deps = [
+        ":extern_function_helper",
+        "//xla/backends/gpu/codegen/triton/ir:triton_xla",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+        "@triton//:TritonDialects",
+    ],
+)
+
+cc_library(
     name = "tma_utils",
     srcs = ["tma_utils.cc"],
     hdrs = ["tma_utils.h"],

--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -629,6 +629,8 @@ cc_library(
     hdrs = ["extern_function_helper.h"],
     deps = [
         "//xla/backends/gpu/codegen/triton/ir:triton_xla",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/functional:overload",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/xla/backends/gpu/codegen/triton/extern_function_helper.cc
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper.cc
@@ -1,0 +1,478 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
+
+#include <string>
+#include <variant>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Support/LLVM.h"
+#include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton::xla {
+
+namespace {
+
+// Helper to parse MemSemantic from string
+absl::StatusOr<triton::MemSemantic> ParseMemSemantic(
+    absl::string_view semantic_str) {
+  if (semantic_str == "relaxed") {
+    return triton::MemSemantic::RELAXED;
+  } else if (semantic_str == "acquire") {
+    return triton::MemSemantic::ACQUIRE;
+  } else if (semantic_str == "release") {
+    return triton::MemSemantic::RELEASE;
+  } else if (semantic_str == "acq_rel") {
+    return triton::MemSemantic::ACQUIRE_RELEASE;
+  }
+  return absl::InvalidArgumentError(
+      absl::StrFormat("Unknown memory semantic: %s", semantic_str));
+}
+
+// Helper to parse MemSyncScope from string
+absl::StatusOr<triton::MemSyncScope> ParseMemSyncScope(
+    absl::string_view scope_str) {
+  if (scope_str == "system") {
+    return triton::MemSyncScope::SYSTEM;
+  } else if (scope_str == "gpu") {
+    return triton::MemSyncScope::GPU;
+  } else if (scope_str == "cta") {
+    return triton::MemSyncScope::CTA;
+  }
+  return absl::InvalidArgumentError(
+      absl::StrFormat("Unknown memory sync scope: %s", scope_str));
+}
+
+// Helper to parse Comparator from string
+absl::StatusOr<Comparator> ParseComparator(absl::string_view comparator_str) {
+  if (comparator_str == "eq") {
+    return Comparator::EQ;
+  } else if (comparator_str == "lt") {
+    return Comparator::LT;
+  }
+  return absl::InvalidArgumentError(
+      absl::StrFormat("Unknown comparator: %s", comparator_str));
+}
+
+// Helper to convert MemSemantic to string
+absl::string_view MemSemanticToString(triton::MemSemantic semantic) {
+  switch (semantic) {
+    case triton::MemSemantic::RELAXED:
+      return "relaxed";
+    case triton::MemSemantic::ACQUIRE:
+      return "acquire";
+    case triton::MemSemantic::RELEASE:
+      return "release";
+    case triton::MemSemantic::ACQUIRE_RELEASE:
+      return "acq_rel";
+  }
+  return "unknown";
+}
+
+// Helper to convert MemSyncScope to string
+absl::string_view MemSyncScopeToString(triton::MemSyncScope scope) {
+  switch (scope) {
+    case triton::MemSyncScope::SYSTEM:
+      return "system";
+    case triton::MemSyncScope::GPU:
+      return "gpu";
+    case triton::MemSyncScope::CTA:
+      return "cta";
+  }
+  return "unknown";
+}
+
+// Helper to convert Comparator to string
+absl::string_view ComparatorToString(Comparator comparator) {
+  switch (comparator) {
+    case Comparator::EQ:
+      return "eq";
+    case Comparator::LT:
+      return "lt";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+absl::StatusOr<ExternFunctionInstruction> ParseExternFunctionName(
+    absl::string_view func_name) {
+  // Check for xla_get_thread_id
+  if (func_name == "xla_get_thread_id") {
+    return GetThreadIdInstruction{};
+  }
+
+  // Check for xla_atomic_write_<semantic>_<scope>
+  if (absl::StartsWith(func_name, "xla_atomic_write_")) {
+    absl::string_view remainder =
+        func_name.substr(17);  // Skip "xla_atomic_write_"
+
+    // Find the positions of underscores to split semantic and scope
+    size_t first_underscore = remainder.find('_');
+    if (first_underscore == absl::string_view::npos) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Invalid atomic write function name: %s", func_name));
+    }
+
+    size_t second_underscore = remainder.find('_', first_underscore + 1);
+    absl::string_view semantic_str;
+    absl::string_view scope_str;
+
+    if (second_underscore == absl::string_view::npos) {
+      // Pattern: <semantic>_<scope>
+      semantic_str = remainder.substr(0, first_underscore);
+      scope_str = remainder.substr(first_underscore + 1);
+    } else {
+      // Pattern: <semantic_part1>_<semantic_part2>_<scope> (e.g., acq_rel_gpu)
+      absl::string_view potential_semantic =
+          remainder.substr(0, second_underscore);
+      scope_str = remainder.substr(second_underscore + 1);
+
+      // Check if there's another underscore in scope (invalid)
+      if (scope_str.find('_') != absl::string_view::npos) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Invalid atomic write function name: %s", func_name));
+      }
+
+      semantic_str = potential_semantic;
+    }
+
+    auto semantic = ParseMemSemantic(semantic_str);
+    if (!semantic.ok()) {
+      return semantic.status();
+    }
+
+    auto scope = ParseMemSyncScope(scope_str);
+    if (!scope.ok()) {
+      return scope.status();
+    }
+
+    return AtomicWriteInstruction{*semantic, *scope};
+  }
+
+  // Check for xla_atomic_spin_wait_<semantic>_<scope>_<comparator>
+  if (absl::StartsWith(func_name, "xla_atomic_spin_wait_")) {
+    absl::string_view remainder =
+        func_name.substr(21);  // Skip "xla_atomic_spin_wait_"
+
+    // Find underscores to split semantic, scope, and comparator
+    size_t first_underscore = remainder.find('_');
+    if (first_underscore == absl::string_view::npos) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Invalid atomic spin wait function name: %s", func_name));
+    }
+
+    size_t second_underscore = remainder.find('_', first_underscore + 1);
+    if (second_underscore == absl::string_view::npos) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Invalid atomic spin wait function name: %s", func_name));
+    }
+
+    size_t third_underscore = remainder.find('_', second_underscore + 1);
+
+    absl::string_view semantic_str;
+    absl::string_view scope_str;
+    absl::string_view comparator_str;
+
+    if (third_underscore == absl::string_view::npos) {
+      // Pattern: <semantic>_<scope>_<comparator>
+      semantic_str = remainder.substr(0, first_underscore);
+      scope_str = remainder.substr(first_underscore + 1,
+                                   second_underscore - first_underscore - 1);
+      comparator_str = remainder.substr(second_underscore + 1);
+    } else {
+      // Pattern: <semantic_part1>_<semantic_part2>_<scope>_<comparator>
+      // (e.g., acq_rel_gpu_eq)
+      absl::string_view potential_semantic =
+          remainder.substr(0, second_underscore);
+      scope_str = remainder.substr(second_underscore + 1,
+                                   third_underscore - second_underscore - 1);
+      comparator_str = remainder.substr(third_underscore + 1);
+
+      // Check if there are more underscores (invalid)
+      if (comparator_str.find('_') != absl::string_view::npos) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "Invalid atomic spin wait function name: %s", func_name));
+      }
+
+      semantic_str = potential_semantic;
+    }
+
+    auto semantic = ParseMemSemantic(semantic_str);
+    if (!semantic.ok()) {
+      return semantic.status();
+    }
+
+    auto scope = ParseMemSyncScope(scope_str);
+    if (!scope.ok()) {
+      return scope.status();
+    }
+
+    auto comparator = ParseComparator(comparator_str);
+    if (!comparator.ok()) {
+      return comparator.status();
+    }
+
+    return AtomicSpinWaitInstruction{*semantic, *scope, *comparator};
+  }
+
+  return absl::InvalidArgumentError(
+      absl::StrFormat("Unknown extern function name: %s", func_name));
+}
+
+std::string SerializeExternFunctionName(
+    const ExternFunctionInstruction& instruction) {
+  return std::visit(
+      [](auto&& arg) -> std::string {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, GetThreadIdInstruction>) {
+          return "xla_get_thread_id";
+        } else if constexpr (std::is_same_v<T, AtomicWriteInstruction>) {
+          return absl::StrFormat("xla_atomic_write_%s_%s",
+                                 MemSemanticToString(arg.semantic),
+                                 MemSyncScopeToString(arg.scope));
+        } else if constexpr (std::is_same_v<T, AtomicSpinWaitInstruction>) {
+          return absl::StrFormat("xla_atomic_spin_wait_%s_%s_%s",
+                                 MemSemanticToString(arg.semantic),
+                                 MemSyncScopeToString(arg.scope),
+                                 ComparatorToString(arg.comparator));
+        }
+      },
+      instruction);
+}
+
+absl::Status ValidateMemorySemantic(
+    const ExternFunctionInstruction& instruction) {
+  return std::visit(
+      [](auto&& arg) -> absl::Status {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, GetThreadIdInstruction>) {
+          // No memory semantic validation needed for GetThreadId
+          return absl::OkStatus();
+        } else if constexpr (std::is_same_v<T, AtomicWriteInstruction>) {
+          // AtomicWrite only supports RELAXED or RELEASE semantics
+          if (arg.semantic != triton::MemSemantic::RELAXED &&
+              arg.semantic != triton::MemSemantic::RELEASE) {
+            return absl::InvalidArgumentError(
+                "AtomicWriteOp only supports RELAXED or RELEASE semantics");
+          }
+          return absl::OkStatus();
+        } else if constexpr (std::is_same_v<T, AtomicSpinWaitInstruction>) {
+          // AtomicSpinWait supports RELAXED, ACQUIRE, or ACQUIRE_RELEASE
+          // semantics
+          if (arg.semantic != triton::MemSemantic::RELAXED &&
+              arg.semantic != triton::MemSemantic::ACQUIRE &&
+              arg.semantic != triton::MemSemantic::ACQUIRE_RELEASE) {
+            return absl::InvalidArgumentError(
+                "AtomicSpinWaitOp only supports RELAXED, ACQUIRE, or "
+                "ACQUIRE_RELEASE semantics");
+          }
+          return absl::OkStatus();
+        }
+      },
+      instruction);
+}
+
+namespace {
+
+// Helper to convert MemSyncScope to PTX scope string
+absl::string_view MemSyncScopeToPTXScope(triton::MemSyncScope scope) {
+  switch (scope) {
+    case triton::MemSyncScope::SYSTEM:
+      return "sys";
+    case triton::MemSyncScope::GPU:
+      return "gpu";
+    case triton::MemSyncScope::CTA:
+      return "cta";
+  }
+  LOG(FATAL) << "Unknown MemSyncScope value";
+}
+
+// Create LLVM ops for GetThreadIdInstruction
+mlir::Value CreateGetThreadIdOps(const LLVMOpCreationParams& params) {
+  auto& builder = params.builder;
+  auto i32_type = builder.getI32Type();
+
+  // Use inline PTX assembly for CUDA
+  const absl::string_view get_tid_asm = R"(
+    mov.u32 $0, %tid.x;
+  )";
+  auto asm_op = builder.create<LLVM::InlineAsmOp>(
+      params.loc, i32_type, mlir::ValueRange{},
+      builder.getStringAttr(get_tid_asm), builder.getStringAttr("=r"),
+      /*has_side_effects=*/mlir::UnitAttr(),
+      /*is_align_stack=*/mlir::UnitAttr(),
+      LLVM::TailCallKindAttr::get(builder.getContext(),
+                                  LLVM::TailCallKind::None),
+      /*asm_dialect=*/LLVM::AsmDialectAttr(),
+      /*operand_attrs=*/mlir::ArrayAttr());
+  return asm_op.getResult(0);
+}
+
+// Create LLVM ops for AtomicWriteInstruction
+mlir::Value CreateAtomicWriteOps(const AtomicWriteInstruction& instruction,
+                                 const LLVMOpCreationParams& params) {
+  auto& builder = params.builder;
+  auto operands = params.operands;
+  auto i32_type = builder.getI32Type();
+
+  // Expected operand layout: [ptr, value, mask?]
+  auto addr = operands[0];
+  auto value = operands[1];
+  mlir::Value mask = operands.size() > 2 ? operands[2] : mlir::Value{};
+
+  absl::string_view memory_semantic = MemSemanticToString(instruction.semantic);
+  absl::string_view scope = MemSyncScopeToPTXScope(instruction.scope);
+
+  // Build PTX inline assembly based on whether mask is present
+  if (mask) {
+    constexpr absl::string_view kAtomicWriteAsmWithMaskTemplate = R"(
+    {
+    .reg .pred %%p<>;
+    setp.ne.u32 %%p<>, $2, 0;
+    @%%p st.global.%s.%s.u32 [$0], $1;
+    }
+  )";
+    std::string atomic_write_asm = absl::StrFormat(
+        kAtomicWriteAsmWithMaskTemplate, scope, memory_semantic);
+    auto asm_op = builder.create<LLVM::InlineAsmOp>(
+        params.loc, i32_type, mlir::ValueRange{addr, value, mask},
+        builder.getStringAttr(atomic_write_asm), builder.getStringAttr("l,r,r"),
+        /*has_side_effects=*/builder.getUnitAttr(),
+        /*is_align_stack=*/nullptr,
+        LLVM::TailCallKindAttr::get(builder.getContext(),
+                                    LLVM::TailCallKind::None),
+        /*asm_dialect=*/nullptr,
+        /*operand_attrs=*/nullptr);
+    return asm_op.getResult(0);
+  } else {
+    constexpr absl::string_view kAtomicWriteAsmTemplate = R"(
+    st.global.%s.%s.u32 [$0], $1;
+  )";
+    std::string atomic_write_asm =
+        absl::StrFormat(kAtomicWriteAsmTemplate, scope, memory_semantic);
+    auto asm_op = builder.create<LLVM::InlineAsmOp>(
+        params.loc, i32_type, mlir::ValueRange{addr, value},
+        builder.getStringAttr(atomic_write_asm), builder.getStringAttr("l,r"),
+        /*has_side_effects=*/builder.getUnitAttr(),
+        /*is_align_stack=*/nullptr,
+        LLVM::TailCallKindAttr::get(builder.getContext(),
+                                    LLVM::TailCallKind::None),
+        /*asm_dialect=*/nullptr,
+        /*operand_attrs=*/nullptr);
+    return asm_op.getResult(0);
+  }
+}
+
+// Create LLVM ops for AtomicSpinWaitInstruction
+mlir::Value CreateAtomicSpinWaitOps(
+    const AtomicSpinWaitInstruction& instruction,
+    const LLVMOpCreationParams& params) {
+  auto& builder = params.builder;
+  auto operands = params.operands;
+  auto i32_type = builder.getI32Type();
+
+  // Expected operand layout: [ptr, expected, mask?]
+  auto addr = operands[0];
+  auto expected = operands[1];
+  mlir::Value mask = operands.size() > 2 ? operands[2] : mlir::Value{};
+
+  absl::string_view memory_semantic = MemSemanticToString(instruction.semantic);
+  absl::string_view scope = MemSyncScopeToPTXScope(instruction.scope);
+  absl::string_view comparator = ComparatorToString(instruction.comparator);
+
+  // Build PTX inline assembly based on whether mask is present
+  if (mask) {
+    constexpr absl::string_view kAtomicSpinWaitAsmWithMaskTemplate = R"(
+    {
+    .reg .pred %%p<2>;
+    .reg .b32 %%r<1>;
+    setp.ne.u32 %%p0, $2, 0;
+    @%%!p0 bra done;
+    wait:
+      ld.global.%s.%s.u32 %%r0, [$0];
+      setp.%s.u32 %%p1, %%r0, $1;
+      @%%p1 bra wait;
+    done:
+    }
+  )";
+    std::string atomic_wait_asm = absl::StrFormat(
+        kAtomicSpinWaitAsmWithMaskTemplate, scope, memory_semantic, comparator);
+    auto asm_op = builder.create<LLVM::InlineAsmOp>(
+        params.loc, i32_type, mlir::ValueRange{addr, expected, mask},
+        builder.getStringAttr(atomic_wait_asm), builder.getStringAttr("l,r,r"),
+        /*has_side_effects=*/builder.getUnitAttr(),
+        /*is_align_stack=*/nullptr,
+        LLVM::TailCallKindAttr::get(builder.getContext(),
+                                    LLVM::TailCallKind::None),
+        /*asm_dialect=*/nullptr,
+        /*operand_attrs=*/nullptr);
+    return asm_op.getResult(0);
+  } else {
+    constexpr absl::string_view kAtomicSpinWaitAsmTemplate = R"(
+    {
+    .reg .pred %%p<1>;
+    .reg .b32 %%r<1>;
+    wait:
+      ld.global.%s.%s.u32 %%r0, [$0];
+      setp.%s.u32 %%p0, %%r0, $1;
+      @%%p0 bra wait;
+    }
+  )";
+    std::string atomic_wait_asm = absl::StrFormat(
+        kAtomicSpinWaitAsmTemplate, scope, memory_semantic, comparator);
+    auto asm_op = builder.create<LLVM::InlineAsmOp>(
+        params.loc, i32_type, mlir::ValueRange{addr, expected},
+        builder.getStringAttr(atomic_wait_asm), builder.getStringAttr("l,r"),
+        /*has_side_effects=*/builder.getUnitAttr(),
+        /*is_align_stack=*/nullptr,
+        LLVM::TailCallKindAttr::get(builder.getContext(),
+                                    LLVM::TailCallKind::None),
+        /*asm_dialect=*/nullptr,
+        /*operand_attrs=*/nullptr);
+    return asm_op.getResult(0);
+  }
+}
+
+}  // namespace
+
+mlir::Value CreateLLVMOpsForInstruction(
+    const ExternFunctionInstruction& instruction,
+    const LLVMOpCreationParams& params) {
+  return std::visit(
+      [&params](auto&& arg) -> mlir::Value {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, GetThreadIdInstruction>) {
+          return CreateGetThreadIdOps(params);
+        } else if constexpr (std::is_same_v<T, AtomicWriteInstruction>) {
+          return CreateAtomicWriteOps(arg, params);
+        } else if constexpr (std::is_same_v<T, AtomicSpinWaitInstruction>) {
+          return CreateAtomicSpinWaitOps(arg, params);
+        }
+      },
+      instruction);
+}
+
+}  // namespace mlir::triton::xla

--- a/xla/backends/gpu/codegen/triton/extern_function_helper.cc
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper.cc
@@ -18,48 +18,53 @@ limitations under the License.
 #include <string>
 #include <variant>
 
+#include "absl/functional/overload.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Support/LLVM.h"
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
+#include "xla/tsl/platform/statusor.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace mlir::triton::xla {
 
 namespace {
 
+using ::mlir::triton::MemSemantic;
+using ::mlir::triton::MemSyncScope;
+
 // Helper to parse MemSemantic from string
-absl::StatusOr<triton::MemSemantic> ParseMemSemantic(
-    absl::string_view semantic_str) {
+absl::StatusOr<MemSemantic> ParseMemSemantic(absl::string_view semantic_str) {
   if (semantic_str == "relaxed") {
-    return triton::MemSemantic::RELAXED;
+    return MemSemantic::RELAXED;
   } else if (semantic_str == "acquire") {
-    return triton::MemSemantic::ACQUIRE;
+    return MemSemantic::ACQUIRE;
   } else if (semantic_str == "release") {
-    return triton::MemSemantic::RELEASE;
-  } else if (semantic_str == "acq_rel") {
-    return triton::MemSemantic::ACQUIRE_RELEASE;
+    return MemSemantic::RELEASE;
+  } else if (semantic_str == "acqrel") {
+    return MemSemantic::ACQUIRE_RELEASE;
   }
   return absl::InvalidArgumentError(
       absl::StrFormat("Unknown memory semantic: %s", semantic_str));
 }
 
 // Helper to parse MemSyncScope from string
-absl::StatusOr<triton::MemSyncScope> ParseMemSyncScope(
-    absl::string_view scope_str) {
+absl::StatusOr<MemSyncScope> ParseMemSyncScope(absl::string_view scope_str) {
   if (scope_str == "system") {
-    return triton::MemSyncScope::SYSTEM;
+    return MemSyncScope::SYSTEM;
   } else if (scope_str == "gpu") {
-    return triton::MemSyncScope::GPU;
+    return MemSyncScope::GPU;
   } else if (scope_str == "cta") {
-    return triton::MemSyncScope::CTA;
+    return MemSyncScope::CTA;
   }
   return absl::InvalidArgumentError(
       absl::StrFormat("Unknown memory sync scope: %s", scope_str));
@@ -77,31 +82,31 @@ absl::StatusOr<Comparator> ParseComparator(absl::string_view comparator_str) {
 }
 
 // Helper to convert MemSemantic to string
-absl::string_view MemSemanticToString(triton::MemSemantic semantic) {
+absl::string_view MemSemanticToString(MemSemantic semantic) {
   switch (semantic) {
-    case triton::MemSemantic::RELAXED:
+    case MemSemantic::RELAXED:
       return "relaxed";
-    case triton::MemSemantic::ACQUIRE:
+    case MemSemantic::ACQUIRE:
       return "acquire";
-    case triton::MemSemantic::RELEASE:
+    case MemSemantic::RELEASE:
       return "release";
-    case triton::MemSemantic::ACQUIRE_RELEASE:
-      return "acq_rel";
+    case MemSemantic::ACQUIRE_RELEASE:
+      return "acqrel";
   }
-  return "unknown";
+  LOG(FATAL) << "Unknown MemSemantic value";
 }
 
 // Helper to convert MemSyncScope to string
-absl::string_view MemSyncScopeToString(triton::MemSyncScope scope) {
+absl::string_view MemSyncScopeToString(MemSyncScope scope) {
   switch (scope) {
-    case triton::MemSyncScope::SYSTEM:
+    case MemSyncScope::SYSTEM:
       return "system";
-    case triton::MemSyncScope::GPU:
+    case MemSyncScope::GPU:
       return "gpu";
-    case triton::MemSyncScope::CTA:
+    case MemSyncScope::CTA:
       return "cta";
   }
-  return "unknown";
+  LOG(FATAL) << "Unknown MemSyncScope value";
 }
 
 // Helper to convert Comparator to string
@@ -112,130 +117,75 @@ absl::string_view ComparatorToString(Comparator comparator) {
     case Comparator::LT:
       return "lt";
   }
-  return "unknown";
+  LOG(FATAL) << "Unknown Comparator value";
+}
+
+// Helper to convert MemSyncScope to PTX scope string
+absl::string_view MemSyncScopeToPTXScope(MemSyncScope scope) {
+  switch (scope) {
+    case MemSyncScope::SYSTEM:
+      return "sys";
+    case MemSyncScope::GPU:
+      return "gpu";
+    case MemSyncScope::CTA:
+      return "cta";
+  }
+  LOG(FATAL) << "Unknown MemSyncScope value";
 }
 
 }  // namespace
 
 absl::StatusOr<ExternFunctionInstruction> ParseExternFunctionName(
     absl::string_view func_name) {
-  // Check for xla_get_thread_id
-  if (func_name == "xla_get_thread_id") {
+  // Function name format: xla_<functionname>_<arg1>_<arg2>_...
+  // Split by underscore to get tokens
+  std::vector<absl::string_view> tokens = absl::StrSplit(func_name, '_');
+
+  // Must have at least 2 tokens: "xla" and function name
+  if (tokens.size() < 2 || tokens[0] != "xla") {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Invalid extern function name: %s", func_name));
+  }
+
+  absl::string_view fn_name = tokens[1];
+
+  // xla_getthreadid (2 tokens total)
+  if (fn_name == "getthreadid") {
+    if (tokens.size() != 2) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "getthreadid expects no arguments, got %d", tokens.size() - 2));
+    }
     return GetThreadIdInstruction{};
   }
 
-  // Check for xla_atomic_write_<semantic>_<scope>
-  if (absl::StartsWith(func_name, "xla_atomic_write_")) {
-    absl::string_view remainder =
-        func_name.substr(17);  // Skip "xla_atomic_write_"
-
-    // Find the positions of underscores to split semantic and scope
-    size_t first_underscore = remainder.find('_');
-    if (first_underscore == absl::string_view::npos) {
-      return absl::InvalidArgumentError(
-          absl::StrFormat("Invalid atomic write function name: %s", func_name));
+  // xla_atomicwrite_<semantic>_<scope> (4 tokens total)
+  if (fn_name == "atomicwrite") {
+    if (tokens.size() != 4) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "atomicwrite expects 2 arguments (semantic, scope), got %d",
+          tokens.size() - 2));
     }
 
-    size_t second_underscore = remainder.find('_', first_underscore + 1);
-    absl::string_view semantic_str;
-    absl::string_view scope_str;
+    TF_ASSIGN_OR_RETURN(auto semantic, ParseMemSemantic(tokens[2]));
+    TF_ASSIGN_OR_RETURN(auto scope, ParseMemSyncScope(tokens[3]));
 
-    if (second_underscore == absl::string_view::npos) {
-      // Pattern: <semantic>_<scope>
-      semantic_str = remainder.substr(0, first_underscore);
-      scope_str = remainder.substr(first_underscore + 1);
-    } else {
-      // Pattern: <semantic_part1>_<semantic_part2>_<scope> (e.g., acq_rel_gpu)
-      absl::string_view potential_semantic =
-          remainder.substr(0, second_underscore);
-      scope_str = remainder.substr(second_underscore + 1);
-
-      // Check if there's another underscore in scope (invalid)
-      if (scope_str.find('_') != absl::string_view::npos) {
-        return absl::InvalidArgumentError(absl::StrFormat(
-            "Invalid atomic write function name: %s", func_name));
-      }
-
-      semantic_str = potential_semantic;
-    }
-
-    auto semantic = ParseMemSemantic(semantic_str);
-    if (!semantic.ok()) {
-      return semantic.status();
-    }
-
-    auto scope = ParseMemSyncScope(scope_str);
-    if (!scope.ok()) {
-      return scope.status();
-    }
-
-    return AtomicWriteInstruction{*semantic, *scope};
+    return AtomicWriteInstruction{semantic, scope};
   }
 
-  // Check for xla_atomic_spin_wait_<semantic>_<scope>_<comparator>
-  if (absl::StartsWith(func_name, "xla_atomic_spin_wait_")) {
-    absl::string_view remainder =
-        func_name.substr(21);  // Skip "xla_atomic_spin_wait_"
-
-    // Find underscores to split semantic, scope, and comparator
-    size_t first_underscore = remainder.find('_');
-    if (first_underscore == absl::string_view::npos) {
+  // xla_atomicspinwait_<semantic>_<scope>_<comparator> (5 tokens total)
+  if (fn_name == "atomicspinwait") {
+    if (tokens.size() != 5) {
       return absl::InvalidArgumentError(absl::StrFormat(
-          "Invalid atomic spin wait function name: %s", func_name));
+          "atomicspinwait expects 3 arguments (semantic, scope, comparator), "
+          "got %d",
+          tokens.size() - 2));
     }
 
-    size_t second_underscore = remainder.find('_', first_underscore + 1);
-    if (second_underscore == absl::string_view::npos) {
-      return absl::InvalidArgumentError(absl::StrFormat(
-          "Invalid atomic spin wait function name: %s", func_name));
-    }
+    TF_ASSIGN_OR_RETURN(auto semantic, ParseMemSemantic(tokens[2]));
+    TF_ASSIGN_OR_RETURN(auto scope, ParseMemSyncScope(tokens[3]));
+    TF_ASSIGN_OR_RETURN(auto comparator, ParseComparator(tokens[4]));
 
-    size_t third_underscore = remainder.find('_', second_underscore + 1);
-
-    absl::string_view semantic_str;
-    absl::string_view scope_str;
-    absl::string_view comparator_str;
-
-    if (third_underscore == absl::string_view::npos) {
-      // Pattern: <semantic>_<scope>_<comparator>
-      semantic_str = remainder.substr(0, first_underscore);
-      scope_str = remainder.substr(first_underscore + 1,
-                                   second_underscore - first_underscore - 1);
-      comparator_str = remainder.substr(second_underscore + 1);
-    } else {
-      // Pattern: <semantic_part1>_<semantic_part2>_<scope>_<comparator>
-      // (e.g., acq_rel_gpu_eq)
-      absl::string_view potential_semantic =
-          remainder.substr(0, second_underscore);
-      scope_str = remainder.substr(second_underscore + 1,
-                                   third_underscore - second_underscore - 1);
-      comparator_str = remainder.substr(third_underscore + 1);
-
-      // Check if there are more underscores (invalid)
-      if (comparator_str.find('_') != absl::string_view::npos) {
-        return absl::InvalidArgumentError(absl::StrFormat(
-            "Invalid atomic spin wait function name: %s", func_name));
-      }
-
-      semantic_str = potential_semantic;
-    }
-
-    auto semantic = ParseMemSemantic(semantic_str);
-    if (!semantic.ok()) {
-      return semantic.status();
-    }
-
-    auto scope = ParseMemSyncScope(scope_str);
-    if (!scope.ok()) {
-      return scope.status();
-    }
-
-    auto comparator = ParseComparator(comparator_str);
-    if (!comparator.ok()) {
-      return comparator.status();
-    }
-
-    return AtomicSpinWaitInstruction{*semantic, *scope, *comparator};
+    return AtomicSpinWaitInstruction{semantic, scope, comparator};
   }
 
   return absl::InvalidArgumentError(
@@ -245,20 +195,23 @@ absl::StatusOr<ExternFunctionInstruction> ParseExternFunctionName(
 std::string SerializeExternFunctionName(
     const ExternFunctionInstruction& instruction) {
   return std::visit(
-      [](auto&& arg) -> std::string {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, GetThreadIdInstruction>) {
-          return "xla_get_thread_id";
-        } else if constexpr (std::is_same_v<T, AtomicWriteInstruction>) {
-          return absl::StrFormat("xla_atomic_write_%s_%s",
-                                 MemSemanticToString(arg.semantic),
-                                 MemSyncScopeToString(arg.scope));
-        } else if constexpr (std::is_same_v<T, AtomicSpinWaitInstruction>) {
-          return absl::StrFormat("xla_atomic_spin_wait_%s_%s_%s",
-                                 MemSemanticToString(arg.semantic),
-                                 MemSyncScopeToString(arg.scope),
-                                 ComparatorToString(arg.comparator));
-        }
+      absl::Overload{
+          [](const GetThreadIdInstruction&) -> std::string {
+            return "xla_getthreadid";
+          },
+          [](const AtomicWriteInstruction& arg) -> std::string {
+            return absl::StrJoin(
+                {"xla", "atomicwrite", MemSemanticToString(arg.semantic),
+                 MemSyncScopeToString(arg.scope)},
+                "_");
+          },
+          [](const AtomicSpinWaitInstruction& arg) -> std::string {
+            return absl::StrJoin(
+                {"xla", "atomicspinwait", MemSemanticToString(arg.semantic),
+                 MemSyncScopeToString(arg.scope),
+                 ComparatorToString(arg.comparator)},
+                "_");
+          },
       },
       instruction);
 }
@@ -266,49 +219,37 @@ std::string SerializeExternFunctionName(
 absl::Status ValidateMemorySemantic(
     const ExternFunctionInstruction& instruction) {
   return std::visit(
-      [](auto&& arg) -> absl::Status {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, GetThreadIdInstruction>) {
-          // No memory semantic validation needed for GetThreadId
-          return absl::OkStatus();
-        } else if constexpr (std::is_same_v<T, AtomicWriteInstruction>) {
-          // AtomicWrite only supports RELAXED or RELEASE semantics
-          if (arg.semantic != triton::MemSemantic::RELAXED &&
-              arg.semantic != triton::MemSemantic::RELEASE) {
-            return absl::InvalidArgumentError(
-                "AtomicWriteOp only supports RELAXED or RELEASE semantics");
-          }
-          return absl::OkStatus();
-        } else if constexpr (std::is_same_v<T, AtomicSpinWaitInstruction>) {
-          // AtomicSpinWait supports RELAXED, ACQUIRE, or ACQUIRE_RELEASE
-          // semantics
-          if (arg.semantic != triton::MemSemantic::RELAXED &&
-              arg.semantic != triton::MemSemantic::ACQUIRE &&
-              arg.semantic != triton::MemSemantic::ACQUIRE_RELEASE) {
-            return absl::InvalidArgumentError(
-                "AtomicSpinWaitOp only supports RELAXED, ACQUIRE, or "
-                "ACQUIRE_RELEASE semantics");
-          }
-          return absl::OkStatus();
-        }
+      absl::Overload{
+          [](const GetThreadIdInstruction&) -> absl::Status {
+            // No memory semantic validation needed for GetThreadId
+            return absl::OkStatus();
+          },
+          [](const AtomicWriteInstruction& arg) -> absl::Status {
+            // AtomicWrite only supports RELAXED or RELEASE semantics
+            if (arg.semantic != MemSemantic::RELAXED &&
+                arg.semantic != MemSemantic::RELEASE) {
+              return absl::InvalidArgumentError(
+                  "AtomicWriteOp only supports RELAXED or RELEASE semantics");
+            }
+            return absl::OkStatus();
+          },
+          [](const AtomicSpinWaitInstruction& arg) -> absl::Status {
+            // AtomicSpinWait supports RELAXED, ACQUIRE, or ACQUIRE_RELEASE
+            // semantics
+            if (arg.semantic != MemSemantic::RELAXED &&
+                arg.semantic != MemSemantic::ACQUIRE &&
+                arg.semantic != MemSemantic::ACQUIRE_RELEASE) {
+              return absl::InvalidArgumentError(
+                  "AtomicSpinWaitOp only supports RELAXED, ACQUIRE, or "
+                  "ACQUIRE_RELEASE semantics");
+            }
+            return absl::OkStatus();
+          },
       },
       instruction);
 }
 
 namespace {
-
-// Helper to convert MemSyncScope to PTX scope string
-absl::string_view MemSyncScopeToPTXScope(triton::MemSyncScope scope) {
-  switch (scope) {
-    case triton::MemSyncScope::SYSTEM:
-      return "sys";
-    case triton::MemSyncScope::GPU:
-      return "gpu";
-    case triton::MemSyncScope::CTA:
-      return "cta";
-  }
-  LOG(FATAL) << "Unknown MemSyncScope value";
-}
 
 // Create LLVM ops for GetThreadIdInstruction
 mlir::Value CreateGetThreadIdOps(const LLVMOpCreationParams& params) {
@@ -352,7 +293,7 @@ mlir::Value CreateAtomicWriteOps(const AtomicWriteInstruction& instruction,
     {
     .reg .pred %%p<>;
     setp.ne.u32 %%p<>, $2, 0;
-    @%%p st.global.%s.%s.u32 [$0], $1;
+    @%%p<> st.global.%s.%s.u32 [$0], $1;
     }
   )";
     std::string atomic_write_asm = absl::StrFormat(
@@ -462,15 +403,16 @@ mlir::Value CreateLLVMOpsForInstruction(
     const ExternFunctionInstruction& instruction,
     const LLVMOpCreationParams& params) {
   return std::visit(
-      [&params](auto&& arg) -> mlir::Value {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, GetThreadIdInstruction>) {
-          return CreateGetThreadIdOps(params);
-        } else if constexpr (std::is_same_v<T, AtomicWriteInstruction>) {
-          return CreateAtomicWriteOps(arg, params);
-        } else if constexpr (std::is_same_v<T, AtomicSpinWaitInstruction>) {
-          return CreateAtomicSpinWaitOps(arg, params);
-        }
+      absl::Overload{
+          [&params](const GetThreadIdInstruction&) -> mlir::Value {
+            return CreateGetThreadIdOps(params);
+          },
+          [&params](const AtomicWriteInstruction& arg) -> mlir::Value {
+            return CreateAtomicWriteOps(arg, params);
+          },
+          [&params](const AtomicSpinWaitInstruction& arg) -> mlir::Value {
+            return CreateAtomicSpinWaitOps(arg, params);
+          },
       },
       instruction);
 }

--- a/xla/backends/gpu/codegen/triton/extern_function_helper.h
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper.h
@@ -1,0 +1,119 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_CODEGEN_TRITON_EXTERN_FUNCTION_HELPER_H_
+#define XLA_BACKENDS_GPU_CODEGEN_TRITON_EXTERN_FUNCTION_HELPER_H_
+
+#include <string>
+#include <variant>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton::xla {
+
+// Represents the different types of extern elementwise functions
+// used in Triton XLA passes.
+
+// Represents an atomic write operation
+struct AtomicWriteInstruction {
+  triton::MemSemantic semantic;
+  triton::MemSyncScope scope;
+
+  bool operator==(const AtomicWriteInstruction& other) const {
+    return semantic == other.semantic && scope == other.scope;
+  }
+};
+
+// Represents an atomic spin-wait operation
+struct AtomicSpinWaitInstruction {
+  triton::MemSemantic semantic;
+  triton::MemSyncScope scope;
+  Comparator comparator;
+
+  bool operator==(const AtomicSpinWaitInstruction& other) const {
+    return semantic == other.semantic && scope == other.scope &&
+           comparator == other.comparator;
+  }
+};
+
+// Represents a get thread ID operation
+struct GetThreadIdInstruction {
+  bool operator==(const GetThreadIdInstruction&) const { return true; }
+};
+
+// Variant type that can hold any of the supported instruction types
+using ExternFunctionInstruction =
+    std::variant<AtomicWriteInstruction, AtomicSpinWaitInstruction,
+                 GetThreadIdInstruction>;
+
+// Parses a function name string into an ExternFunctionInstruction variant.
+// Returns an error status if the function name is invalid or doesn't match
+// any known pattern.
+//
+// Supported patterns:
+// - "xla_atomic_write_<semantic>_<scope>"
+// - "xla_atomic_spin_wait_<semantic>_<scope>_<comparator>"
+// - "xla_get_thread_id"
+//
+// Where:
+// - <semantic>: relaxed, acquire, release, acq_rel
+// - <scope>: system, gpu, cta
+// - <comparator>: eq, lt
+absl::StatusOr<ExternFunctionInstruction> ParseExternFunctionName(
+    absl::string_view func_name);
+
+// Serializes an ExternFunctionInstruction back to its string representation.
+// This is the inverse of ParseExternFunctionName.
+std::string SerializeExternFunctionName(
+    const ExternFunctionInstruction& instruction);
+
+// Validates that the memory semantic is appropriate for the instruction type.
+// Returns an error status if validation fails.
+absl::Status ValidateMemorySemantic(
+    const ExternFunctionInstruction& instruction);
+
+// Target backend for code generation
+enum class TargetBackend {
+  CUDA,
+  ROCM,
+};
+
+// Parameters for creating LLVM operations from an instruction
+struct LLVMOpCreationParams {
+  mlir::OpBuilder& builder;
+  mlir::Location loc;
+  TargetBackend target;
+  mlir::ValueRange
+      operands;  // Operands from the call (ptr, value/expected, mask?)
+};
+
+// Creates the appropriate LLVM operations for the given instruction.
+// This function generates the complete LLVM IR implementation for the
+// instruction, including control flow for masked operations and loops for
+// spin-wait operations.
+//
+// Returns the result value that should replace the original call operation.
+// For operations that don't produce a meaningful result (like atomic_write),
+// returns a poison value.
+mlir::Value CreateLLVMOpsForInstruction(
+    const ExternFunctionInstruction& instruction,
+    const LLVMOpCreationParams& params);
+
+}  // namespace mlir::triton::xla
+
+#endif  // XLA_BACKENDS_GPU_CODEGEN_TRITON_EXTERN_FUNCTION_HELPER_H_

--- a/xla/backends/gpu/codegen/triton/extern_function_helper.h
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper.h
@@ -65,13 +65,18 @@ using ExternFunctionInstruction =
 // Returns an error status if the function name is invalid or doesn't match
 // any known pattern.
 //
+// Function name format: xla_<functionname>_<arg1>_<arg2>_...
+// - Token[0]: "xla" (prefix)
+// - Token[1]: function name
+// - Token[2+]: arguments (if any)
+//
 // Supported patterns:
-// - "xla_atomic_write_<semantic>_<scope>"
-// - "xla_atomic_spin_wait_<semantic>_<scope>_<comparator>"
-// - "xla_get_thread_id"
+// - "xla_getthreadid" (2 tokens: no arguments)
+// - "xla_atomicwrite_<semantic>_<scope>" (4 tokens)
+// - "xla_atomicspinwait_<semantic>_<scope>_<comparator>" (5 tokens)
 //
 // Where:
-// - <semantic>: relaxed, acquire, release, acq_rel
+// - <semantic>: relaxed, acquire, release, acqrel
 // - <scope>: system, gpu, cta
 // - <comparator>: eq, lt
 absl::StatusOr<ExternFunctionInstruction> ParseExternFunctionName(

--- a/xla/backends/gpu/codegen/triton/extern_function_helper_test.cc
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper_test.cc
@@ -1,0 +1,410 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
+
+#include <string>
+#include <variant>
+
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton::xla {
+namespace {
+
+using ::absl_testing::IsOk;
+using ::absl_testing::StatusIs;
+using ::testing::HasSubstr;
+
+class ExternFunctionNameTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    context_.loadDialect<LLVM::LLVMDialect>();
+    context_.loadDialect<triton::TritonDialect>();
+  }
+
+  mlir::MLIRContext context_;
+};
+
+// Test parsing GetThreadId instruction
+TEST_F(ExternFunctionNameTest, ParseGetThreadId) {
+  auto result = ParseExternFunctionName("xla_get_thread_id");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_TRUE(std::holds_alternative<GetThreadIdInstruction>(*result));
+}
+
+// Test parsing AtomicWrite instructions
+TEST_F(ExternFunctionNameTest, ParseAtomicWriteRelaxedGpu) {
+  auto result = ParseExternFunctionName("xla_atomic_write_relaxed_gpu");
+  ASSERT_THAT(result, IsOk());
+
+  ASSERT_TRUE(std::holds_alternative<AtomicWriteInstruction>(*result));
+  auto& instruction = std::get<AtomicWriteInstruction>(*result);
+  EXPECT_EQ(instruction.semantic, triton::MemSemantic::RELAXED);
+  EXPECT_EQ(instruction.scope, triton::MemSyncScope::GPU);
+}
+
+TEST_F(ExternFunctionNameTest, ParseAtomicWriteReleaseSystem) {
+  auto result = ParseExternFunctionName("xla_atomic_write_release_system");
+  ASSERT_THAT(result, IsOk());
+
+  ASSERT_TRUE(std::holds_alternative<AtomicWriteInstruction>(*result));
+  auto& instruction = std::get<AtomicWriteInstruction>(*result);
+  EXPECT_EQ(instruction.semantic, triton::MemSemantic::RELEASE);
+  EXPECT_EQ(instruction.scope, triton::MemSyncScope::SYSTEM);
+}
+
+TEST_F(ExternFunctionNameTest, ParseAtomicWriteAcqRelCta) {
+  auto result = ParseExternFunctionName("xla_atomic_write_acq_rel_cta");
+  ASSERT_THAT(result, IsOk());
+
+  ASSERT_TRUE(std::holds_alternative<AtomicWriteInstruction>(*result));
+  auto& instruction = std::get<AtomicWriteInstruction>(*result);
+  EXPECT_EQ(instruction.semantic, triton::MemSemantic::ACQUIRE_RELEASE);
+  EXPECT_EQ(instruction.scope, triton::MemSyncScope::CTA);
+}
+
+// Test parsing AtomicSpinWait instructions
+TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitRelaxedGpuEq) {
+  auto result = ParseExternFunctionName("xla_atomic_spin_wait_relaxed_gpu_eq");
+  ASSERT_THAT(result, IsOk());
+
+  ASSERT_TRUE(std::holds_alternative<AtomicSpinWaitInstruction>(*result));
+  auto& instruction = std::get<AtomicSpinWaitInstruction>(*result);
+  EXPECT_EQ(instruction.semantic, triton::MemSemantic::RELAXED);
+  EXPECT_EQ(instruction.scope, triton::MemSyncScope::GPU);
+  EXPECT_EQ(instruction.comparator, Comparator::EQ);
+}
+
+TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitAcquireSystemLt) {
+  auto result =
+      ParseExternFunctionName("xla_atomic_spin_wait_acquire_system_lt");
+  ASSERT_THAT(result, IsOk());
+
+  ASSERT_TRUE(std::holds_alternative<AtomicSpinWaitInstruction>(*result));
+  auto& instruction = std::get<AtomicSpinWaitInstruction>(*result);
+  EXPECT_EQ(instruction.semantic, triton::MemSemantic::ACQUIRE);
+  EXPECT_EQ(instruction.scope, triton::MemSyncScope::SYSTEM);
+  EXPECT_EQ(instruction.comparator, Comparator::LT);
+}
+
+TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitAcqRelCtaEq) {
+  auto result = ParseExternFunctionName("xla_atomic_spin_wait_acq_rel_cta_eq");
+  ASSERT_THAT(result, IsOk());
+
+  ASSERT_TRUE(std::holds_alternative<AtomicSpinWaitInstruction>(*result));
+  auto& instruction = std::get<AtomicSpinWaitInstruction>(*result);
+  EXPECT_EQ(instruction.semantic, triton::MemSemantic::ACQUIRE_RELEASE);
+  EXPECT_EQ(instruction.scope, triton::MemSyncScope::CTA);
+  EXPECT_EQ(instruction.comparator, Comparator::EQ);
+}
+
+// Test parsing invalid function names
+TEST_F(ExternFunctionNameTest, ParseInvalidFunctionName) {
+  auto result = ParseExternFunctionName("invalid_function_name");
+  EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
+                               HasSubstr("Unknown extern function name")));
+}
+
+TEST_F(ExternFunctionNameTest, ParseInvalidAtomicWrite) {
+  auto result = ParseExternFunctionName("xla_atomic_write_invalid_gpu");
+  EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
+                               HasSubstr("Unknown memory semantic")));
+}
+
+TEST_F(ExternFunctionNameTest, ParseInvalidScope) {
+  auto result = ParseExternFunctionName("xla_atomic_write_relaxed_invalid");
+  EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
+                               HasSubstr("Unknown memory sync scope")));
+}
+
+TEST_F(ExternFunctionNameTest, ParseInvalidComparator) {
+  auto result =
+      ParseExternFunctionName("xla_atomic_spin_wait_relaxed_gpu_invalid");
+  EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
+                               HasSubstr("Unknown comparator")));
+}
+
+// Test serialization
+TEST_F(ExternFunctionNameTest, SerializeGetThreadId) {
+  GetThreadIdInstruction instruction;
+  std::string result = SerializeExternFunctionName(instruction);
+  EXPECT_EQ(result, "xla_get_thread_id");
+}
+
+TEST_F(ExternFunctionNameTest, SerializeAtomicWrite) {
+  AtomicWriteInstruction instruction{.semantic = triton::MemSemantic::RELEASE,
+                                     .scope = triton::MemSyncScope::GPU};
+  std::string result = SerializeExternFunctionName(instruction);
+  EXPECT_EQ(result, "xla_atomic_write_release_gpu");
+}
+
+TEST_F(ExternFunctionNameTest, SerializeAtomicWriteAcqRel) {
+  AtomicWriteInstruction instruction{
+      .semantic = triton::MemSemantic::ACQUIRE_RELEASE,
+      .scope = triton::MemSyncScope::SYSTEM};
+  std::string result = SerializeExternFunctionName(instruction);
+  EXPECT_EQ(result, "xla_atomic_write_acq_rel_system");
+}
+
+TEST_F(ExternFunctionNameTest, SerializeAtomicSpinWait) {
+  AtomicSpinWaitInstruction instruction{
+      .semantic = triton::MemSemantic::ACQUIRE,
+      .scope = triton::MemSyncScope::CTA,
+      .comparator = Comparator::LT};
+  std::string result = SerializeExternFunctionName(instruction);
+  EXPECT_EQ(result, "xla_atomic_spin_wait_acquire_cta_lt");
+}
+
+// Test round-trip (parse then serialize)
+TEST_F(ExternFunctionNameTest, RoundTripGetThreadId) {
+  std::string original = "xla_get_thread_id";
+  auto parsed = ParseExternFunctionName(original);
+  ASSERT_THAT(parsed, IsOk());
+  std::string serialized = SerializeExternFunctionName(*parsed);
+  EXPECT_EQ(original, serialized);
+}
+
+TEST_F(ExternFunctionNameTest, RoundTripAtomicWrite) {
+  std::string original = "xla_atomic_write_relaxed_gpu";
+  auto parsed = ParseExternFunctionName(original);
+  ASSERT_THAT(parsed, IsOk());
+  std::string serialized = SerializeExternFunctionName(*parsed);
+  EXPECT_EQ(original, serialized);
+}
+
+TEST_F(ExternFunctionNameTest, RoundTripAtomicSpinWait) {
+  std::string original = "xla_atomic_spin_wait_acquire_system_lt";
+  auto parsed = ParseExternFunctionName(original);
+  ASSERT_THAT(parsed, IsOk());
+  std::string serialized = SerializeExternFunctionName(*parsed);
+  EXPECT_EQ(original, serialized);
+}
+
+// Test memory semantic validation
+TEST_F(ExternFunctionNameTest, ValidateGetThreadIdAlwaysValid) {
+  GetThreadIdInstruction instruction;
+  EXPECT_THAT(ValidateMemorySemantic(instruction), IsOk());
+}
+
+TEST_F(ExternFunctionNameTest, ValidateAtomicWriteRelaxed) {
+  AtomicWriteInstruction instruction{.semantic = triton::MemSemantic::RELAXED,
+                                     .scope = triton::MemSyncScope::GPU};
+  EXPECT_THAT(ValidateMemorySemantic(instruction), IsOk());
+}
+
+TEST_F(ExternFunctionNameTest, ValidateAtomicWriteRelease) {
+  AtomicWriteInstruction instruction{.semantic = triton::MemSemantic::RELEASE,
+                                     .scope = triton::MemSyncScope::GPU};
+  EXPECT_THAT(ValidateMemorySemantic(instruction), IsOk());
+}
+
+TEST_F(ExternFunctionNameTest, ValidateAtomicWriteAcquireInvalid) {
+  AtomicWriteInstruction instruction{.semantic = triton::MemSemantic::ACQUIRE,
+                                     .scope = triton::MemSyncScope::GPU};
+  EXPECT_THAT(ValidateMemorySemantic(instruction),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("RELAXED or RELEASE")));
+}
+
+TEST_F(ExternFunctionNameTest, ValidateAtomicSpinWaitRelaxed) {
+  AtomicSpinWaitInstruction instruction{
+      .semantic = triton::MemSemantic::RELAXED,
+      .scope = triton::MemSyncScope::GPU,
+      .comparator = Comparator::EQ};
+  EXPECT_THAT(ValidateMemorySemantic(instruction), IsOk());
+}
+
+TEST_F(ExternFunctionNameTest, ValidateAtomicSpinWaitAcquire) {
+  AtomicSpinWaitInstruction instruction{
+      .semantic = triton::MemSemantic::ACQUIRE,
+      .scope = triton::MemSyncScope::GPU,
+      .comparator = Comparator::EQ};
+  EXPECT_THAT(ValidateMemorySemantic(instruction), IsOk());
+}
+
+TEST_F(ExternFunctionNameTest, ValidateAtomicSpinWaitReleaseInvalid) {
+  AtomicSpinWaitInstruction instruction{
+      .semantic = triton::MemSemantic::RELEASE,
+      .scope = triton::MemSyncScope::GPU,
+      .comparator = Comparator::EQ};
+  EXPECT_THAT(ValidateMemorySemantic(instruction),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("RELAXED, ACQUIRE, or ACQUIRE_RELEASE")));
+}
+
+// Test LLVM operation creation - verify correct inline assembly
+TEST_F(ExternFunctionNameTest, CreateGetThreadIdOpsCUDA) {
+  mlir::OwningOpRef<mlir::ModuleOp> module =
+      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context_));
+  mlir::OpBuilder builder(&context_);
+  builder.setInsertionPointToEnd(module->getBody());
+
+  auto i32_type = builder.getI32Type();
+  auto func_type = LLVM::LLVMFunctionType::get(i32_type, {});
+  auto func = LLVM::LLVMFuncOp::create(builder, builder.getUnknownLoc(),
+                                       "test_func", func_type);
+  auto* entry_block = func.addEntryBlock(builder);
+  builder.setInsertionPointToStart(entry_block);
+
+  GetThreadIdInstruction instruction;
+  LLVMOpCreationParams params{.builder = builder,
+                              .loc = builder.getUnknownLoc(),
+                              .target = TargetBackend::CUDA,
+                              .operands = {}};
+
+  mlir::Value result = CreateLLVMOpsForInstruction(instruction, params);
+  ASSERT_TRUE(result != nullptr);
+  EXPECT_TRUE(result.getType().isInteger(32));
+
+  // Verify inline assembly was created
+  auto* defining_op = result.getDefiningOp();
+  ASSERT_TRUE(defining_op != nullptr);
+  auto asm_op = mlir::dyn_cast<LLVM::InlineAsmOp>(defining_op);
+  ASSERT_TRUE(asm_op != nullptr);
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("mov.u32"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("%tid.x"));
+}
+
+TEST_F(ExternFunctionNameTest, CreateAtomicWriteOpsVerifyPTXAssembly) {
+  mlir::OwningOpRef<mlir::ModuleOp> module =
+      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context_));
+  mlir::OpBuilder builder(&context_);
+  builder.setInsertionPointToEnd(module->getBody());
+
+  auto i32_type = builder.getI32Type();
+  auto ptr_type = LLVM::LLVMPointerType::get(&context_);
+  auto func_type = LLVM::LLVMFunctionType::get(i32_type, {ptr_type, i32_type});
+  auto func = LLVM::LLVMFuncOp::create(builder, builder.getUnknownLoc(),
+                                       "test_func", func_type);
+  auto* entry_block = func.addEntryBlock(builder);
+  builder.setInsertionPointToStart(entry_block);
+
+  AtomicWriteInstruction instruction{.semantic = triton::MemSemantic::RELEASE,
+                                     .scope = triton::MemSyncScope::GPU};
+
+  llvm::SmallVector<mlir::Value> operands = {entry_block->getArgument(0),
+                                             entry_block->getArgument(1)};
+  LLVMOpCreationParams params{.builder = builder,
+                              .loc = builder.getUnknownLoc(),
+                              .target = TargetBackend::CUDA,
+                              .operands = operands};
+
+  mlir::Value result = CreateLLVMOpsForInstruction(instruction, params);
+  ASSERT_TRUE(result != nullptr);
+  EXPECT_TRUE(result.getType().isInteger(32));
+
+  // Verify inline assembly was created with correct PTX instruction
+  auto* defining_op = result.getDefiningOp();
+  ASSERT_TRUE(defining_op != nullptr);
+  auto asm_op = mlir::dyn_cast<LLVM::InlineAsmOp>(defining_op);
+  ASSERT_TRUE(asm_op != nullptr);
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("st.global"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("gpu"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("release"));
+}
+
+TEST_F(ExternFunctionNameTest, CreateAtomicSpinWaitOpsVerifyPTXAssembly) {
+  mlir::OwningOpRef<mlir::ModuleOp> module =
+      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context_));
+  mlir::OpBuilder builder(&context_);
+  builder.setInsertionPointToEnd(module->getBody());
+
+  auto i32_type = builder.getI32Type();
+  auto ptr_type = LLVM::LLVMPointerType::get(&context_);
+  auto func_type = LLVM::LLVMFunctionType::get(i32_type, {ptr_type, i32_type});
+  auto func = LLVM::LLVMFuncOp::create(builder, builder.getUnknownLoc(),
+                                       "test_func", func_type);
+  auto* entry_block = func.addEntryBlock(builder);
+  builder.setInsertionPointToStart(entry_block);
+
+  AtomicSpinWaitInstruction instruction{
+      .semantic = triton::MemSemantic::ACQUIRE,
+      .scope = triton::MemSyncScope::GPU,
+      .comparator = Comparator::EQ};
+
+  llvm::SmallVector<mlir::Value> operands = {entry_block->getArgument(0),
+                                             entry_block->getArgument(1)};
+  LLVMOpCreationParams params{.builder = builder,
+                              .loc = builder.getUnknownLoc(),
+                              .target = TargetBackend::CUDA,
+                              .operands = operands};
+
+  mlir::Value result = CreateLLVMOpsForInstruction(instruction, params);
+  ASSERT_TRUE(result != nullptr);
+  EXPECT_TRUE(result.getType().isInteger(32));
+
+  // Verify inline assembly was created with correct PTX instructions
+  auto* defining_op = result.getDefiningOp();
+  ASSERT_TRUE(defining_op != nullptr);
+  auto asm_op = mlir::dyn_cast<LLVM::InlineAsmOp>(defining_op);
+  ASSERT_TRUE(asm_op != nullptr);
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("ld.global"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("gpu"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("acquire"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("setp.eq"));
+}
+
+TEST_F(ExternFunctionNameTest, CreateAtomicSpinWaitOpsVerifyComparator) {
+  mlir::OwningOpRef<mlir::ModuleOp> module =
+      mlir::ModuleOp::create(mlir::UnknownLoc::get(&context_));
+  mlir::OpBuilder builder(&context_);
+  builder.setInsertionPointToEnd(module->getBody());
+
+  auto i32_type = builder.getI32Type();
+  auto ptr_type = LLVM::LLVMPointerType::get(&context_);
+  auto func_type = LLVM::LLVMFunctionType::get(i32_type, {ptr_type, i32_type});
+  auto func = LLVM::LLVMFuncOp::create(builder, builder.getUnknownLoc(),
+                                       "test_func", func_type);
+  auto* entry_block = func.addEntryBlock(builder);
+  builder.setInsertionPointToStart(entry_block);
+
+  AtomicSpinWaitInstruction instruction{
+      .semantic = triton::MemSemantic::RELAXED,
+      .scope = triton::MemSyncScope::SYSTEM,
+      .comparator = Comparator::LT};
+
+  llvm::SmallVector<mlir::Value> operands = {entry_block->getArgument(0),
+                                             entry_block->getArgument(1)};
+  LLVMOpCreationParams params{.builder = builder,
+                              .loc = builder.getUnknownLoc(),
+                              .target = TargetBackend::CUDA,
+                              .operands = operands};
+
+  mlir::Value result = CreateLLVMOpsForInstruction(instruction, params);
+  ASSERT_TRUE(result != nullptr);
+
+  // Verify inline assembly was created with correct comparator
+  auto* defining_op = result.getDefiningOp();
+  ASSERT_TRUE(defining_op != nullptr);
+  auto asm_op = mlir::dyn_cast<LLVM::InlineAsmOp>(defining_op);
+  ASSERT_TRUE(asm_op != nullptr);
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("ld.global"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("sys"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("relaxed"));
+  EXPECT_THAT(asm_op.getAsmString().str(), HasSubstr("setp.lt"));
+}
+
+}  // namespace
+}  // namespace mlir::triton::xla

--- a/xla/backends/gpu/codegen/triton/extern_function_helper_test.cc
+++ b/xla/backends/gpu/codegen/triton/extern_function_helper_test.cc
@@ -49,14 +49,14 @@ class ExternFunctionNameTest : public ::testing::Test {
 
 // Test parsing GetThreadId instruction
 TEST_F(ExternFunctionNameTest, ParseGetThreadId) {
-  auto result = ParseExternFunctionName("xla_get_thread_id");
+  auto result = ParseExternFunctionName("xla_getthreadid");
   ASSERT_THAT(result, IsOk());
   EXPECT_TRUE(std::holds_alternative<GetThreadIdInstruction>(*result));
 }
 
 // Test parsing AtomicWrite instructions
 TEST_F(ExternFunctionNameTest, ParseAtomicWriteRelaxedGpu) {
-  auto result = ParseExternFunctionName("xla_atomic_write_relaxed_gpu");
+  auto result = ParseExternFunctionName("xla_atomicwrite_relaxed_gpu");
   ASSERT_THAT(result, IsOk());
 
   ASSERT_TRUE(std::holds_alternative<AtomicWriteInstruction>(*result));
@@ -66,7 +66,7 @@ TEST_F(ExternFunctionNameTest, ParseAtomicWriteRelaxedGpu) {
 }
 
 TEST_F(ExternFunctionNameTest, ParseAtomicWriteReleaseSystem) {
-  auto result = ParseExternFunctionName("xla_atomic_write_release_system");
+  auto result = ParseExternFunctionName("xla_atomicwrite_release_system");
   ASSERT_THAT(result, IsOk());
 
   ASSERT_TRUE(std::holds_alternative<AtomicWriteInstruction>(*result));
@@ -76,7 +76,7 @@ TEST_F(ExternFunctionNameTest, ParseAtomicWriteReleaseSystem) {
 }
 
 TEST_F(ExternFunctionNameTest, ParseAtomicWriteAcqRelCta) {
-  auto result = ParseExternFunctionName("xla_atomic_write_acq_rel_cta");
+  auto result = ParseExternFunctionName("xla_atomicwrite_acqrel_cta");
   ASSERT_THAT(result, IsOk());
 
   ASSERT_TRUE(std::holds_alternative<AtomicWriteInstruction>(*result));
@@ -87,7 +87,7 @@ TEST_F(ExternFunctionNameTest, ParseAtomicWriteAcqRelCta) {
 
 // Test parsing AtomicSpinWait instructions
 TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitRelaxedGpuEq) {
-  auto result = ParseExternFunctionName("xla_atomic_spin_wait_relaxed_gpu_eq");
+  auto result = ParseExternFunctionName("xla_atomicspinwait_relaxed_gpu_eq");
   ASSERT_THAT(result, IsOk());
 
   ASSERT_TRUE(std::holds_alternative<AtomicSpinWaitInstruction>(*result));
@@ -98,8 +98,7 @@ TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitRelaxedGpuEq) {
 }
 
 TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitAcquireSystemLt) {
-  auto result =
-      ParseExternFunctionName("xla_atomic_spin_wait_acquire_system_lt");
+  auto result = ParseExternFunctionName("xla_atomicspinwait_acquire_system_lt");
   ASSERT_THAT(result, IsOk());
 
   ASSERT_TRUE(std::holds_alternative<AtomicSpinWaitInstruction>(*result));
@@ -110,7 +109,7 @@ TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitAcquireSystemLt) {
 }
 
 TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitAcqRelCtaEq) {
-  auto result = ParseExternFunctionName("xla_atomic_spin_wait_acq_rel_cta_eq");
+  auto result = ParseExternFunctionName("xla_atomicspinwait_acqrel_cta_eq");
   ASSERT_THAT(result, IsOk());
 
   ASSERT_TRUE(std::holds_alternative<AtomicSpinWaitInstruction>(*result));
@@ -124,24 +123,24 @@ TEST_F(ExternFunctionNameTest, ParseAtomicSpinWaitAcqRelCtaEq) {
 TEST_F(ExternFunctionNameTest, ParseInvalidFunctionName) {
   auto result = ParseExternFunctionName("invalid_function_name");
   EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
-                               HasSubstr("Unknown extern function name")));
+                               HasSubstr("Invalid extern function name")));
 }
 
 TEST_F(ExternFunctionNameTest, ParseInvalidAtomicWrite) {
-  auto result = ParseExternFunctionName("xla_atomic_write_invalid_gpu");
+  auto result = ParseExternFunctionName("xla_atomicwrite_invalid_gpu");
   EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
                                HasSubstr("Unknown memory semantic")));
 }
 
 TEST_F(ExternFunctionNameTest, ParseInvalidScope) {
-  auto result = ParseExternFunctionName("xla_atomic_write_relaxed_invalid");
+  auto result = ParseExternFunctionName("xla_atomicwrite_relaxed_invalid");
   EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
                                HasSubstr("Unknown memory sync scope")));
 }
 
 TEST_F(ExternFunctionNameTest, ParseInvalidComparator) {
   auto result =
-      ParseExternFunctionName("xla_atomic_spin_wait_relaxed_gpu_invalid");
+      ParseExternFunctionName("xla_atomicspinwait_relaxed_gpu_invalid");
   EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
                                HasSubstr("Unknown comparator")));
 }
@@ -150,14 +149,14 @@ TEST_F(ExternFunctionNameTest, ParseInvalidComparator) {
 TEST_F(ExternFunctionNameTest, SerializeGetThreadId) {
   GetThreadIdInstruction instruction;
   std::string result = SerializeExternFunctionName(instruction);
-  EXPECT_EQ(result, "xla_get_thread_id");
+  EXPECT_EQ(result, "xla_getthreadid");
 }
 
 TEST_F(ExternFunctionNameTest, SerializeAtomicWrite) {
   AtomicWriteInstruction instruction{.semantic = triton::MemSemantic::RELEASE,
                                      .scope = triton::MemSyncScope::GPU};
   std::string result = SerializeExternFunctionName(instruction);
-  EXPECT_EQ(result, "xla_atomic_write_release_gpu");
+  EXPECT_EQ(result, "xla_atomicwrite_release_gpu");
 }
 
 TEST_F(ExternFunctionNameTest, SerializeAtomicWriteAcqRel) {
@@ -165,7 +164,7 @@ TEST_F(ExternFunctionNameTest, SerializeAtomicWriteAcqRel) {
       .semantic = triton::MemSemantic::ACQUIRE_RELEASE,
       .scope = triton::MemSyncScope::SYSTEM};
   std::string result = SerializeExternFunctionName(instruction);
-  EXPECT_EQ(result, "xla_atomic_write_acq_rel_system");
+  EXPECT_EQ(result, "xla_atomicwrite_acqrel_system");
 }
 
 TEST_F(ExternFunctionNameTest, SerializeAtomicSpinWait) {
@@ -174,12 +173,12 @@ TEST_F(ExternFunctionNameTest, SerializeAtomicSpinWait) {
       .scope = triton::MemSyncScope::CTA,
       .comparator = Comparator::LT};
   std::string result = SerializeExternFunctionName(instruction);
-  EXPECT_EQ(result, "xla_atomic_spin_wait_acquire_cta_lt");
+  EXPECT_EQ(result, "xla_atomicspinwait_acquire_cta_lt");
 }
 
 // Test round-trip (parse then serialize)
 TEST_F(ExternFunctionNameTest, RoundTripGetThreadId) {
-  std::string original = "xla_get_thread_id";
+  std::string original = "xla_getthreadid";
   auto parsed = ParseExternFunctionName(original);
   ASSERT_THAT(parsed, IsOk());
   std::string serialized = SerializeExternFunctionName(*parsed);
@@ -187,7 +186,7 @@ TEST_F(ExternFunctionNameTest, RoundTripGetThreadId) {
 }
 
 TEST_F(ExternFunctionNameTest, RoundTripAtomicWrite) {
-  std::string original = "xla_atomic_write_relaxed_gpu";
+  std::string original = "xla_atomicwrite_relaxed_gpu";
   auto parsed = ParseExternFunctionName(original);
   ASSERT_THAT(parsed, IsOk());
   std::string serialized = SerializeExternFunctionName(*parsed);
@@ -195,7 +194,7 @@ TEST_F(ExternFunctionNameTest, RoundTripAtomicWrite) {
 }
 
 TEST_F(ExternFunctionNameTest, RoundTripAtomicSpinWait) {
-  std::string original = "xla_atomic_spin_wait_acquire_system_lt";
+  std::string original = "xla_atomicspinwait_acquire_system_lt";
   auto parsed = ParseExternFunctionName(original);
   ASSERT_THAT(parsed, IsOk());
   std::string serialized = SerializeExternFunctionName(*parsed);


### PR DESCRIPTION
📝 Summary of Changes
This PR is the first PR in a series of four.

PR 1/4: https://github.com/openxla/xla/pull/40462 <= This PR
PR 2/4: https://github.com/openxla/xla/pull/40460 
PR 3/4: https://github.com/openxla/xla/pull/40463
PR 4/4: https://github.com/openxla/xla/pull/40464

This PR adds utility functions to convert `extern_elementwise` function names into LLVM inline PTX assembly handling scopes and semantics.
This PR does not modify the lowering of atomic operations triton_xla.atomic_write, triton_xla.atomic_spin_wait and triton_xla.get_tid, it only adds helpers and tests them.

🎯 Justification
This PR is part of a rework of the AllReduce triton support to facilitate the enabling of different target GPUs (starting with ROCm).
Prior to these PRs, the triton_xla.get_tid, triton_xla.atomic_write and triton_xla.atomic_spin_wait operations were lowered using PTX assembly. Therefore, AllReduce triton backend was only available for CUDA target.
These PRs aim to unify the lowering of triton_xla.atomic_write and triton_xla.atomic_spin_wait and triton_xla.get_tid operations for CUDA and ROCm targets.

This PR enables to add functions that handle `extern_elementwise` function names and transform them into a a suitable LLVM code handling scopes and semantics. This conversion is carried out in helper functions rather than directly within the conversion pass, in order to facilitate testing.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature 

🧪 Unit Tests:
This PR includes a test xla/backends/gpu/codegen/triton/extern_function_helper_test.cc