### PR TITLE
[ROCm] Enable AllReduce ROCm Triton backend 4/4 

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -148,6 +148,7 @@ cc_library(
     ],
     hdrs = ["compilation_pipeline.h"],
     deps = [
+        ":extern_function_helper",
         "//xla/backends/gpu/codegen/emitters/transforms:passes",
         "//xla/backends/gpu/codegen/triton/transforms:passes",
         "//xla/backends/gpu/codegen/triton/transforms:triton_xla_implement_extern_element_wise_pass",
@@ -729,6 +730,7 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:NVVMDialect",
         "@llvm-project//mlir:Support",

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -38,7 +38,7 @@ limitations under the License.
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -98,9 +98,10 @@ using ReductionComputationEmitter = absl::AnyInvocable<xtile::TensorValue(
     mlir::ImplicitLocOpBuilder&, xtile::TensorValue, xtile::TensorValue)>;
 
 // The main memory space on a device (HBM).
+// Use GPU dialect address space which is platform-independent.
 static constexpr auto kGlobalAddressSpace =
-    static_cast<std::underlying_type_t<mlir::NVVM::NVVMMemorySpace>>(
-        mlir::NVVM::NVVMMemorySpace::Global);
+    static_cast<std::underlying_type_t<mlir::gpu::AddressSpace>>(
+        mlir::gpu::AddressSpace::Global);
 
 // Metadata arguments for the collective emitter.
 // device_rank, signal_value, signal_buffers.

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_cuda.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_cuda.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "nvidia/include/NVGPUToLLVM/Passes.h"
 #include "nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h"
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
 #include "xla/backends/gpu/codegen/triton/transforms/passes.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_cuda.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_cuda.cc
@@ -13,15 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "nvidia/hopper/include/Transforms/Passes.h"
-#include "nvidia/include/NVGPUToLLVM/Passes.h"
-#include "nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h"
 #include "absl/strings/str_format.h"
 #include "mlir/Conversion/NVVMToLLVM/NVVMToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "nvidia/include/NVGPUToLLVM/Passes.h"
+#include "nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h"
 #include "xla/backends/gpu/codegen/triton/transforms/passes.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
@@ -180,7 +180,8 @@ static void MakeLLIR(mlir::OpPassManager* pm,
 
   // Add XLA custom pass to implement extern_elementwise functions
   // This must run after MLIR->LLVM conversion but before final optimizations
-  pm->addPass(mt_xla::CreateTritonXLAImplementExternElementWisePass());
+  pm->addPass(mt_xla::CreateTritonXLAImplementExternElementWisePass(
+      mt_xla::TargetBackend::CUDA));
 }
 
 void CreateTritonCudaPipeline(

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -26,10 +26,12 @@ limitations under the License.
 #include "mlir/Transforms/Passes.h"
 #include "third_party/amd/include/TritonAMDGPUToLLVM/Passes.h"
 #include "third_party/amd/include/TritonAMDGPUTransforms/Passes.h"
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
 #include "xla/backends/gpu/codegen/triton/transforms/passes.h"
-#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -18,14 +18,15 @@ limitations under the License.
 #include <string>
 
 #include "absl/strings/str_cat.h"
-#include "third_party/amd/include/TritonAMDGPUToLLVM/Passes.h"
-#include "third_party/amd/include/TritonAMDGPUTransforms/Passes.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/IndexToLLVM/IndexToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
+#include "third_party/amd/include/TritonAMDGPUToLLVM/Passes.h"
+#include "third_party/amd/include/TritonAMDGPUTransforms/Passes.h"
+#include "xla/backends/gpu/codegen/triton/transforms/passes.h"
 #include "xla/stream_executor/device_description.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
@@ -179,6 +180,11 @@ static void MakeLLIR(mlir::OpPassManager* pm,
   }
   pm->addPass(mt::createConvertBuiltinFuncToLLVMPass(rocm_cc.gfx_version(),
                                                      /*ftz=*/true));
+
+  // Add XLA custom pass to implement extern_elementwise functions
+  // This must run after MLIR->LLVM conversion but before final optimizations
+  pm->addPass(mlir::triton::xla::CreateTritonXLAImplementExternElementWisePass(
+      mlir::triton::xla::TargetBackend::ROCM));
 }
 
 void CreateTritonRocmPipeline(

--- a/xla/backends/gpu/codegen/triton/transforms/passes.h
+++ b/xla/backends/gpu/codegen/triton/transforms/passes.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
+#include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"  // IWYU pragma: keep
 #include "xla/codegen/xtile/ir/xtile_dialect.h"  // IWYU pragma: keep
 
@@ -45,7 +46,8 @@ std::unique_ptr<mlir::Pass> CreateTritonXLAUnswitchLoopsPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerGetTidPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerAtomicsPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerBlockBarrierPass();
-std::unique_ptr<mlir::Pass> CreateTritonXLAImplementExternElementWisePass();
+std::unique_ptr<mlir::Pass> CreateTritonXLAImplementExternElementWisePass(
+    TargetBackend target);
 std::unique_ptr<mlir::Pass> CreateTritonXLAConvertUnsupportedTypesPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerRemoteAccessPass();
 std::unique_ptr<mlir::Pass> CreateTritonXLALowerXTilePass();

--- a/xla/backends/gpu/codegen/triton/transforms/passes.td
+++ b/xla/backends/gpu/codegen/triton/transforms/passes.td
@@ -284,10 +284,18 @@ def TritonXLAImplementExternElementWisePass
   let description = [{
     This pass implements custom atomic functions declared by tt.extern_elementwise
     operations using LLVM IR intrinsics and atomic operations with proper memory
-    ordering and sync scopes. It supports CUDA (NVPTX) backend.
+    ordering and sync scopes. It supports CUDA (NVPTX) and ROCM backends.
     It runs in the Triton pipeline after MLIR has been converted to LLVM dialect.
     The target backend must be specified via the target option.
   }];
+  let options = [
+    Option<"target_", "target", "TargetBackend", "TargetBackend::CUDA",
+           "Target backend (CUDA or ROCm).",
+           [{llvm::cl::values(
+               clEnumValN(TargetBackend::CUDA, "cuda", "CUDA (NVPTX) backend"),
+               clEnumValN(TargetBackend::ROCM, "rocm", "ROCm (AMDGPU) backend")
+           )}]>,
+  ];
 }
 
 def TritonXLAFoldReshapeAroundForLoopPass

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_implement_extern_atomics_rocm.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_implement_extern_atomics_rocm.mlir
@@ -1,19 +1,19 @@
-// RUN: xla-opt %s -triton-xla-implement-extern-element-wise="target=cuda" | FileCheck %s
+// RUN: xla-opt %s -triton-xla-implement-extern-element-wise="target=rocm" | FileCheck %s
 
-// Test CUDA implementation of extern_elementwise atomic functions
-// This pass operates on LLVM dialect and generates LLVM intrinsics
+// Test ROCm implementation of extern_elementwise atomic functions
+// This pass operates on LLVM dialect and generates LLVM intrinsics for AMD GPUs
 
 // Test unmasked operations
-module {
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa"} {
   // CHECK-LABEL: llvm.func @test_get_thread_id
   llvm.func @test_get_thread_id() -> i32 {
     // CHECK-NOT: llvm.call @xla_getthreadid
-    // CHECK: [[TID:%.*]] = llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.tid.x"() : () -> i32
+    // CHECK: [[TID:%.*]] = llvm.call_intrinsic "llvm.amdgcn.workitem.id.x"() : () -> i32
     // CHECK: llvm.return [[TID]]
     %tid = llvm.call @xla_getthreadid() : () -> i32
     llvm.return %tid : i32
   }
-  
+
   // CHECK-LABEL: llvm.func @test_atomic_write_unmasked
   llvm.func @test_atomic_write_unmasked(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicwrite_release_system_nomask
@@ -23,7 +23,7 @@ module {
     %result = llvm.call @xla_atomicwrite_release_system_nomask(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
-  
+
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_unmasked
   llvm.func @test_atomic_spin_wait_unmasked(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicspinwait_acquire_system_lt_nomask
@@ -37,7 +37,7 @@ module {
     %result = llvm.call @xla_atomicspinwait_acquire_system_lt_nomask(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
-  
+
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_eq
   llvm.func @test_atomic_spin_wait_eq(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
     // CHECK: llvm.br ^[[LOOP:.*]]
@@ -51,19 +51,6 @@ module {
     llvm.return %result : i32
   }
 
-  // CHECK-LABEL: llvm.func @test_atomic_spin_wait_ge
-  llvm.func @test_atomic_spin_wait_ge(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
-    // CHECK: llvm.br ^[[LOOP:.*]]
-    // CHECK: ^[[LOOP]]:
-    // CHECK:   [[LOADED:%.*]] = llvm.load %arg0 atomic acquire {alignment = 4 : i64} : !llvm.ptr<1> -> i32
-    // CHECK:   [[COND:%.*]] = llvm.icmp "uge" [[LOADED]], %arg1
-    // CHECK:   llvm.cond_br [[COND]], ^[[EXIT:.*]], ^[[LOOP]]
-    // CHECK: ^[[EXIT]]:
-    // CHECK:   llvm.return [[LOADED]]
-    %result = llvm.call @xla_atomicspinwait_acquire_system_ge_nomask(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
-    llvm.return %result : i32
-  }
-  
   // CHECK-LABEL: llvm.func @test_relaxed_ordering
   llvm.func @test_relaxed_ordering(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
     // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
@@ -72,25 +59,25 @@ module {
     %result = llvm.call @xla_atomicwrite_relaxed_system_nomask(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
-  
-  // CHECK-LABEL: llvm.func @test_gpu_scope
-  llvm.func @test_gpu_scope(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
+
+  // CHECK-LABEL: llvm.func @test_agent_scope
+  llvm.func @test_agent_scope(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
     // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
-    // CHECK: llvm.store %arg1, %arg0 atomic syncscope("device") release {alignment = 4 : i64} : i32, !llvm.ptr<1>
+    // CHECK: llvm.store %arg1, %arg0 atomic syncscope("agent") release {alignment = 4 : i64} : i32, !llvm.ptr<1>
     // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicwrite_release_gpu_nomask(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
-  
-  // CHECK-LABEL: llvm.func @test_cta_scope
-  llvm.func @test_cta_scope(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
+
+  // CHECK-LABEL: llvm.func @test_workgroup_scope
+  llvm.func @test_workgroup_scope(%ptr: !llvm.ptr<1>, %value: i32) -> i32 {
     // CHECK: [[POISON:%.*]] = llvm.mlir.poison : i32
-    // CHECK: llvm.store %arg1, %arg0 atomic syncscope("block") release {alignment = 4 : i64} : i32, !llvm.ptr<1>
+    // CHECK: llvm.store %arg1, %arg0 atomic syncscope("workgroup") release {alignment = 4 : i64} : i32, !llvm.ptr<1>
     // CHECK: llvm.return [[POISON]]
     %result = llvm.call @xla_atomicwrite_release_cta_nomask(%ptr, %value) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
-  
+
   // CHECK-LABEL: llvm.func @test_acquire_ordering
   llvm.func @test_acquire_ordering(%ptr: !llvm.ptr<1>, %expected: i32) -> i32 {
     // CHECK: llvm.br ^[[LOOP:.*]]
@@ -103,8 +90,15 @@ module {
     %result = llvm.call @xla_atomicspinwait_acquire_system_lt_nomask(%ptr, %expected) : (!llvm.ptr<1>, i32) -> i32
     llvm.return %result : i32
   }
-  
+
   // Extern function declarations (will be removed by the pass)
+  // CHECK-NOT: llvm.func @xla_getthreadid
+  // CHECK-NOT: llvm.func @xla_atomicwrite_release_system_nomask
+  // CHECK-NOT: llvm.func @xla_atomicwrite_relaxed_system_nomask
+  // CHECK-NOT: llvm.func @xla_atomicwrite_release_gpu_nomask
+  // CHECK-NOT: llvm.func @xla_atomicwrite_release_cta_nomask
+  // CHECK-NOT: llvm.func @xla_atomicspinwait_acquire_system_lt_nomask
+  // CHECK-NOT: llvm.func @xla_atomicspinwait_acquire_system_eq_nomask
   llvm.func @xla_getthreadid() -> i32
   llvm.func @xla_atomicwrite_release_system_nomask(!llvm.ptr<1>, i32) -> i32
   llvm.func @xla_atomicwrite_relaxed_system_nomask(!llvm.ptr<1>, i32) -> i32
@@ -112,11 +106,10 @@ module {
   llvm.func @xla_atomicwrite_release_cta_nomask(!llvm.ptr<1>, i32) -> i32
   llvm.func @xla_atomicspinwait_acquire_system_lt_nomask(!llvm.ptr<1>, i32) -> i32
   llvm.func @xla_atomicspinwait_acquire_system_eq_nomask(!llvm.ptr<1>, i32) -> i32
-  llvm.func @xla_atomicspinwait_acquire_system_ge_nomask(!llvm.ptr<1>, i32) -> i32
 }
 
 // Test masked operations in separate module to avoid function redefinition
-module {
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa"} {
   // CHECK-LABEL: llvm.func @test_atomic_write_masked
   llvm.func @test_atomic_write_masked(%ptr: !llvm.ptr<1>, %value: i32, %mask: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicwrite_release_system_mask
@@ -132,7 +125,7 @@ module {
     %result = llvm.call @xla_atomicwrite_release_system_mask(%ptr, %value, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
     llvm.return %result : i32
   }
-  
+
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_masked
   llvm.func @test_atomic_spin_wait_masked(%ptr: !llvm.ptr<1>, %expected: i32, %mask: i32) -> i32 {
     // CHECK-NOT: llvm.call @xla_atomicspinwait_acquire_system_lt_mask
@@ -148,7 +141,7 @@ module {
     %result = llvm.call @xla_atomicspinwait_acquire_system_lt_mask(%ptr, %expected, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
     llvm.return %result : i32
   }
-  
+
   // CHECK-LABEL: llvm.func @test_atomic_spin_wait_masked_eq
   llvm.func @test_atomic_spin_wait_masked_eq(%ptr: !llvm.ptr<1>, %expected: i32, %mask: i32) -> i32 {
     // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32)
@@ -164,24 +157,11 @@ module {
     llvm.return %result : i32
   }
 
-  // CHECK-LABEL: llvm.func @test_atomic_spin_wait_masked_ge
-  llvm.func @test_atomic_spin_wait_masked_ge(%ptr: !llvm.ptr<1>, %expected: i32, %mask: i32) -> i32 {
-    // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32)
-    // CHECK: [[MASK_NONZERO:%.*]] = llvm.icmp "ne" %arg2, [[ZERO]]
-    // CHECK: llvm.cond_br [[MASK_NONZERO]], ^[[LOOP:.*]], ^[[EXIT:.*]]([[ZERO]]
-    // CHECK: ^[[LOOP]]:
-    // CHECK:   [[LOADED:%.*]] = llvm.load %arg0 atomic acquire {alignment = 4 : i64} : !llvm.ptr<1> -> i32
-    // CHECK:   [[COND:%.*]] = llvm.icmp "uge" [[LOADED]], %arg1
-    // CHECK:   llvm.cond_br [[COND]], ^[[EXIT]]([[LOADED]] : i32), ^[[LOOP]]
-    // CHECK: ^[[EXIT]]([[RESULT:%.*]]: i32):
-    // CHECK:   llvm.return [[RESULT]]
-    %result = llvm.call @xla_atomicspinwait_acquire_system_ge_mask(%ptr, %expected, %mask) : (!llvm.ptr<1>, i32, i32) -> i32
-    llvm.return %result : i32
-  }
-  
-  // Extern function declarations for the masked operations.
+  // Extern function declarations for masked versions
+  // CHECK-NOT: llvm.func @xla_atomicwrite_release_system_mask
+  // CHECK-NOT: llvm.func @xla_atomicspinwait_acquire_system_lt_mask
+  // CHECK-NOT: llvm.func @xla_atomicspinwait_acquire_system_eq_mask
   llvm.func @xla_atomicwrite_release_system_mask(!llvm.ptr<1>, i32, i32) -> i32
   llvm.func @xla_atomicspinwait_acquire_system_lt_mask(!llvm.ptr<1>, i32, i32) -> i32
   llvm.func @xla_atomicspinwait_acquire_system_eq_mask(!llvm.ptr<1>, i32, i32) -> i32
-  llvm.func @xla_atomicspinwait_acquire_system_ge_mask(!llvm.ptr<1>, i32, i32) -> i32
 }

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_implement_extern_element_wise_pass.cc
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// CUDA-specific implementation of extern_elementwise atomic functions.
-// This pass runs in the Triton CUDA pipeline and inlines the implementations
+// GPU-specific implementation of extern_elementwise atomic functions.
+// This pass runs in the Triton GPU pipeline and inlines the implementations
 // of custom atomic functions by replacing llvm.call operations with LLVM
-// intrinsics.
+// intrinsics. Supports both CUDA and ROCM backends.
 
 #include <memory>
 #include <optional>
@@ -35,6 +35,7 @@ limitations under the License.
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "xla/backends/gpu/codegen/triton/extern_function_helper.h"
+#include "xla/backends/gpu/codegen/triton/transforms/passes.h"
 
 namespace mlir::triton::xla {
 
@@ -46,7 +47,8 @@ namespace {
 // Pattern to rewrite llvm.call operations to XLA extern functions
 class RewriteExternCallPattern : public OpRewritePattern<LLVM::CallOp> {
  public:
-  using OpRewritePattern<LLVM::CallOp>::OpRewritePattern;
+  explicit RewriteExternCallPattern(MLIRContext* context, TargetBackend target)
+      : OpRewritePattern<LLVM::CallOp>(context), target_(target) {}
 
   LogicalResult matchAndRewrite(LLVM::CallOp call_op,
                                 PatternRewriter& rewriter) const override {
@@ -78,7 +80,7 @@ class RewriteExternCallPattern : public OpRewritePattern<LLVM::CallOp> {
 
     LLVMOpCreationParams params{/*.builder=*/rewriter,
                                 /*.loc=*/call_op.getLoc(),
-                                /*.target=*/TargetBackend::CUDA,
+                                /*.target=*/target_,
                                 /*.operands=*/call_op.getOperands()};
 
     mlir::Value result = CreateLLVMOpsForInstruction(*parsed, params);
@@ -94,6 +96,9 @@ class RewriteExternCallPattern : public OpRewritePattern<LLVM::CallOp> {
     }
     return success();
   }
+
+ private:
+  TargetBackend target_;
 };
 
 // MLIR pass that inlines extern function calls with LLVM intrinsics
@@ -101,15 +106,18 @@ class TritonXLAImplementExternElementWisePass
     : public impl::TritonXLAImplementExternElementWisePassBase<
           TritonXLAImplementExternElementWisePass> {
  public:
-  using Base::Base;
+  using impl::TritonXLAImplementExternElementWisePassBase<
+      TritonXLAImplementExternElementWisePass>::
+      TritonXLAImplementExternElementWisePassBase;
 
  private:
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
     mlir::MLIRContext* context = &getContext();
 
+    // Apply rewrite patterns
     RewritePatternSet patterns(context);
-    patterns.add<RewriteExternCallPattern>(context);
+    patterns.add<RewriteExternCallPattern>(context, target_);
 
     if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
       return signalPassFailure();
@@ -119,8 +127,12 @@ class TritonXLAImplementExternElementWisePass
 
 }  // namespace
 
-std::unique_ptr<mlir::Pass> CreateTritonXLAImplementExternElementWisePass() {
-  return std::make_unique<TritonXLAImplementExternElementWisePass>();
-}
-
 }  // namespace mlir::triton::xla
+
+std::unique_ptr<mlir::Pass>
+mlir::triton::xla::CreateTritonXLAImplementExternElementWisePass(
+    TargetBackend target) {
+  TritonXLAImplementExternElementWisePassOptions options;
+  options.target_ = target;
+  return std::make_unique<TritonXLAImplementExternElementWisePass>(options);
+}

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -252,12 +252,16 @@ absl::Status IsAllReduceKernelSupported(
   if (!is_collective_kernel_enabled) {
     return absl::UnimplementedError("Collective kernel is not enabled.");
   }
-  const auto compute_capability = device_info.cuda_compute_capability();
-  if (!compute_capability.IsAtLeastHopper()) {
-    return absl::UnimplementedError(
-        absl::StrCat("Collective kernel is not supported for compute "
-                     "capability less than 9.0. Got ",
-                     compute_capability.ToString(), "."));
+  // Check if the device supports Triton collective codegen:
+  // CUDA: Requires compute capability 9.0+ (Hopper or newer)
+  // ROCm: All versions with Triton support are enabled
+  if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
+      !device_info.gpu_compute_capability().IsRocm()) {
+    return absl::UnimplementedError(absl::StrCat(
+        "Triton collective codegen requires CUDA compute capability >= 9.0 "
+        "(Hopper or newer) or a ROCm device with Triton support. "
+        "Got: ",
+        device_info.gpu_compute_capability().ToString(), "."));
   }
   // TODO(b/383125489): Support variadic arguments.
   if (num_operands != 1) {

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/rocm/rocm_executor.h"
 
-#include <unistd.h>
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -48,6 +46,7 @@ limitations under the License.
 #include "rocm/include/hip/hip_runtime.h"
 #include "rocm/include/hip/hip_version.h"
 #include "rocm/rocm_config.h"
+#include <unistd.h>
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -636,6 +635,23 @@ void RocmExecutor::UnloadKernel(const Kernel* kernel) {
 absl::Status RocmExecutor::Init() {
   TF_ASSIGN_OR_RETURN(device_, GetDevice(device_ordinal()));
   TF_ASSIGN_OR_RETURN(version_, GetGpuISAVersion(device_));
+
+  // Initialize peer access cache for all devices
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipGetDeviceCount(&device_count), "Failed to get device count"));
+  for (int i = 0; i < device_count; ++i) {
+    if (i == device_ordinal()) {
+      // A device can always access its own memory
+      peer_access_cache_[i] = true;
+      continue;
+    }
+
+    // Check peer access capability and cache the result
+    TF_ASSIGN_OR_RETURN(hipDevice_t peer_device, GetDevice(i));
+    peer_access_cache_[i] = CanEnablePeerAccess(device_, peer_device);
+  }
+
   // We initialize BLAS interfaces early here since otherwise it might create
   // us problems during hipBlasLt initialization under graph capture.
   // There is no real advantage of explicitly using 'lazy initialization' on
@@ -983,6 +999,20 @@ fft::FftSupport* RocmExecutor::AsFft() {
 
   fft_.reset(fft);
   return fft_.get();
+}
+
+bool RocmExecutor::CanEnablePeerAccessTo(int other_device_ordinal) {
+  // Check the cache first
+  auto it = peer_access_cache_.find(other_device_ordinal);
+  if (it != peer_access_cache_.end()) {
+    return it->second;
+  }
+
+  // If not in cache, log a warning and return false
+  LOG(WARNING) << "Attempting to enable peer access from: " << device_ordinal()
+               << " to: " << other_device_ordinal
+               << " which was not available during initialization.";
+  return false;
 }
 
 bool RocmExecutor::CanEnablePeerAccessTo(StreamExecutor* other) {

--- a/xla/stream_executor/rocm/rocm_executor.h
+++ b/xla/stream_executor/rocm/rocm_executor.h
@@ -98,6 +98,7 @@ class RocmExecutor : public GpuExecutor {
                                  uint64_t size) override;
   void DeallocateStream(Stream* stream) override;
   absl::Status EnablePeerAccessTo(StreamExecutor* other) override;
+  bool CanEnablePeerAccessTo(int other_device_ordinal) override;
   bool CanEnablePeerAccessTo(StreamExecutor* other) override;
   bool DeviceMemoryUsage(int64_t* free, int64_t* total) const override;
 
@@ -206,6 +207,9 @@ class RocmExecutor : public GpuExecutor {
   // Mutable because SetActive() (hipSetDevice) is logically const — it does
   // not change RocmContext state, but ScopedActivateContext takes non-const.
   mutable RocmContext rocm_context_;
+
+  // Cache of peer access capabilities. Populated during Init().
+  absl::flat_hash_map<int, bool> peer_access_cache_;
 };
 
 }  // namespace stream_executor::gpu


### PR DESCRIPTION
📝 Summary of Changes
This PR is the fourth PR in a series of four.

PR 1/4: https://github.com/openxla/xla/pull/40460 
PR 2/4: https://github.com/openxla/xla/pull/40462 
PR 3/4: https://github.com/openxla/xla/pull/40463
PR 4/4: https://github.com/openxla/xla/pull/40464 <= This PR

This PR enables the ROCm Triton backend for AllReduce (collective emitter).
To this end:
- It extends the `TritonXLAImplementExternElementWise` function so that it accepts a target input parameter and calls it within the ROCm Triton pipeline.
- it adds missing API to rocm_executor RocmExecutor::CanEnablePeerAccessTo(int other_device_ordinal) (this API is required to enable collective_emitter thunk).

🎯 Justification
This PR is part of a rework of the AllReduce triton support to facilitate the enabling of different target GPUs (starting with ROCm).
Prior to these PRs, the triton_xla.get_tid, triton_xla.atomic_write and triton_xla.atomic_spin_wait operations were lowered using PTX assembly. Therefore, AllReduce triton backend was only available for CUDA target.
These PR aim to unify the lowering of triton_xla.atomic_write and triton_xla.atomic_spin_wait and triton_xla.get_tid operations for CUDA and ROCm targets.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature

🧪 Unit Tests:
This PR includes a LIT test checking the lowering of atomic operations.

🧪 Execution Tests:
The existing test xla/tests:all_reduce_e2e_test is relevant for testing this support.