### PR TITLE
[ROCm] Separate OCP and NANOO FP8 collective ops E2E tests

### DIFF
--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/array.h"
@@ -87,6 +88,20 @@ class CollectiveOpsTestE2E : public CollectiveOpsE2ETestBase {
            GetDebugOptionsForTest().xla_gpu_enable_cublaslt();
   }
 
+  // MI300X (gfx942) uses NANOO FP8 types (f8e4m3fnuz/f8e5m2fnuz), while
+  // CUDA and MI350+ use OCP/IEEE types (f8e4m3fn/f8e5m2). The HLO test
+  // strings are written with OCP types; this replaces them with NANOO types
+  // when running on MI300X so the GEMM rewriter can produce FP8 custom calls.
+  std::string ReplaceFp8Types(absl::string_view hlo_text) {
+    if (Capability().IsRocm() &&
+        Capability().rocm_compute_capability()->has_nanoo_fp8_support() &&
+        !Capability().rocm_compute_capability()->has_ocp_fp8_support()) {
+      return absl::StrReplaceAll(
+          hlo_text, {{"f8e4m3fn", "f8e4m3fnuz"}, {"f8e5m2", "f8e5m2fnuz"}});
+    }
+    return std::string(hlo_text);
+  }
+
   void CollectiveOpsVerifyF8Matmul(absl::string_view hlo_text,
                                    const DebugOptions& options) {
     if (!HasFp8Support()) {
@@ -99,11 +114,12 @@ class CollectiveOpsTestE2E : public CollectiveOpsE2ETestBase {
                    << " devices (" << device_count() << " available)";
     }
 
+    std::string replaced_hlo = ReplaceFp8Types(hlo_text);
     HloModuleConfig config = GetModuleConfigForTest(
         /*replica_count=*/kNumReplicas, /*num_partitions=*/kNumPartitions);
     config.set_debug_options(options);
     TF_ASSERT_OK_AND_ASSIGN(auto module,
-                            ParseAndReturnVerifiedModule(hlo_text, config));
+                            ParseAndReturnVerifiedModule(replaced_hlo, config));
 
     TF_ASSERT_OK_AND_ASSIGN(auto executable,
                             CreateExecutable(std::move(module),
@@ -1277,6 +1293,7 @@ class CollectiveOpsTestE2EWindowedNonWindowed : public CollectiveOpsTestE2E {
                    << " devices (" << device_count() << " available)";
     }
 
+    std::string replaced_hlo = ReplaceFp8Types(hlo_text);
     HloModuleConfig config = GetModuleConfigForTest(
         /*replica_count=*/kNumReplicas, /*num_partitions=*/kNumPartitions);
 
@@ -1288,8 +1305,9 @@ class CollectiveOpsTestE2EWindowedNonWindowed : public CollectiveOpsTestE2E {
     }
 
     // Run with reference config.
-    TF_ASSERT_OK_AND_ASSIGN(auto ref_module,
-                            ParseAndReturnVerifiedModule(hlo_text, config));
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto ref_module,
+        ParseAndReturnVerifiedModule(replaced_hlo, config));
     ASSERT_OK_AND_ASSIGN(auto ref_executable,
                          CreateExecutable(std::move(ref_module),
                                           /*run_hlo_passes=*/true));
@@ -1314,8 +1332,9 @@ class CollectiveOpsTestE2EWindowedNonWindowed : public CollectiveOpsTestE2E {
     debug_options.set_xla_gpu_multi_streamed_windowed_einsum(true);
     debug_options.set_xla_gpu_experimental_enable_alltoall_windowed_einsum(
         enable_a2a_rewrite);
-    TF_ASSERT_OK_AND_ASSIGN(auto module,
-                            ParseAndReturnVerifiedModule(hlo_text, config));
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto module,
+        ParseAndReturnVerifiedModule(replaced_hlo, config));
 
     TF_ASSERT_OK_AND_ASSIGN(
         ExecutionResult execution_result,

--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -92,10 +92,13 @@ class CollectiveOpsTestE2E : public CollectiveOpsE2ETestBase {
   // CUDA and MI350+ use OCP/IEEE types (f8e4m3fn/f8e5m2). The HLO test
   // strings are written with OCP types; this replaces them with NANOO types
   // when running on MI300X so the GEMM rewriter can produce FP8 custom calls.
+  // Note: the input HLO must not already contain FNUZ type strings, as the
+  // substring replacement of "f8e4m3fn" would also match inside "f8e4m3fnuz".
   std::string ReplaceFp8Types(absl::string_view hlo_text) {
-    if (Capability().IsRocm() &&
-        Capability().rocm_compute_capability()->has_nanoo_fp8_support() &&
-        !Capability().rocm_compute_capability()->has_ocp_fp8_support()) {
+    const auto& cap = Capability();
+    if (cap.IsRocm() &&
+        cap.rocm_compute_capability()->has_nanoo_fp8_support() &&
+        !cap.rocm_compute_capability()->has_ocp_fp8_support()) {
       return absl::StrReplaceAll(
           hlo_text, {{"f8e4m3fn", "f8e4m3fnuz"}, {"f8e5m2", "f8e5m2fnuz"}});
     }

--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -27,7 +27,6 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/array.h"
@@ -88,21 +87,11 @@ class CollectiveOpsTestE2E : public CollectiveOpsE2ETestBase {
            GetDebugOptionsForTest().xla_gpu_enable_cublaslt();
   }
 
-  // MI300X (gfx942) uses NANOO FP8 types (f8e4m3fnuz/f8e5m2fnuz), while
-  // CUDA and MI350+ use OCP/IEEE types (f8e4m3fn/f8e5m2). The HLO test
-  // strings are written with OCP types; this replaces them with NANOO types
-  // when running on MI300X so the GEMM rewriter can produce FP8 custom calls.
-  // Note: the input HLO must not already contain FNUZ type strings, as the
-  // substring replacement of "f8e4m3fn" would also match inside "f8e4m3fnuz".
-  std::string ReplaceFp8Types(absl::string_view hlo_text) {
-    const auto& cap = Capability();
-    if (cap.IsRocm() &&
-        cap.rocm_compute_capability()->has_nanoo_fp8_support() &&
-        !cap.rocm_compute_capability()->has_ocp_fp8_support()) {
-      return absl::StrReplaceAll(
-          hlo_text, {{"f8e4m3fn", "f8e4m3fnuz"}, {"f8e5m2", "f8e5m2fnuz"}});
-    }
-    return std::string(hlo_text);
+  // Ref: https://rocm.docs.amd.com/projects/HIP/en/latest/reference/low_fp_types.html#id4
+  bool IsNanooFp8Only() {
+    return Capability().IsRocm() &&
+           Capability().rocm_compute_capability()->has_nanoo_fp8_support() &&
+           !Capability().rocm_compute_capability()->has_ocp_fp8_support();
   }
 
   void CollectiveOpsVerifyF8Matmul(absl::string_view hlo_text,
@@ -117,12 +106,11 @@ class CollectiveOpsTestE2E : public CollectiveOpsE2ETestBase {
                    << " devices (" << device_count() << " available)";
     }
 
-    std::string replaced_hlo = ReplaceFp8Types(hlo_text);
     HloModuleConfig config = GetModuleConfigForTest(
         /*replica_count=*/kNumReplicas, /*num_partitions=*/kNumPartitions);
     config.set_debug_options(options);
     TF_ASSERT_OK_AND_ASSIGN(auto module,
-                            ParseAndReturnVerifiedModule(replaced_hlo, config));
+                            ParseAndReturnVerifiedModule(hlo_text, config));
 
     TF_ASSERT_OK_AND_ASSIGN(auto executable,
                             CreateExecutable(std::move(module),
@@ -1296,7 +1284,6 @@ class CollectiveOpsTestE2EWindowedNonWindowed : public CollectiveOpsTestE2E {
                    << " devices (" << device_count() << " available)";
     }
 
-    std::string replaced_hlo = ReplaceFp8Types(hlo_text);
     HloModuleConfig config = GetModuleConfigForTest(
         /*replica_count=*/kNumReplicas, /*num_partitions=*/kNumPartitions);
 
@@ -1310,7 +1297,7 @@ class CollectiveOpsTestE2EWindowedNonWindowed : public CollectiveOpsTestE2E {
     // Run with reference config.
     TF_ASSERT_OK_AND_ASSIGN(
         auto ref_module,
-        ParseAndReturnVerifiedModule(replaced_hlo, config));
+        ParseAndReturnVerifiedModule(hlo_text, config));
     ASSERT_OK_AND_ASSIGN(auto ref_executable,
                          CreateExecutable(std::move(ref_module),
                                           /*run_hlo_passes=*/true));
@@ -1337,7 +1324,7 @@ class CollectiveOpsTestE2EWindowedNonWindowed : public CollectiveOpsTestE2E {
         enable_a2a_rewrite);
     TF_ASSERT_OK_AND_ASSIGN(
         auto module,
-        ParseAndReturnVerifiedModule(replaced_hlo, config));
+        ParseAndReturnVerifiedModule(hlo_text, config));
 
     TF_ASSERT_OK_AND_ASSIGN(
         ExecutionResult execution_result,
@@ -1379,6 +1366,9 @@ ENTRY main.12 {
 }
 
 TEST_F(CollectiveOpsTestE2EWindowedNonWindowed, WindowedEinsumE2EAllGatherF8) {
+  if (IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires OCP FP8 (f8e4m3fn) support.";
+  }
   absl::string_view kModuleReplicatedStr = R"(
 HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(f8e4m3fn[2,16,48]{2,1,0}, f8e4m3fn[48,192]{1,0}, bf16[], bf16[])->bf16[2,16,192]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
 
@@ -1416,6 +1406,9 @@ ENTRY main {
 
 TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
        WindowedEinsumE2EAllGatherReshapeF8) {
+  if (IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires OCP FP8 (f8e4m3fn) support.";
+  }
   absl::string_view kModuleReplicatedStr = R"(
 HloModule windowed_einsum_e2e_all_gather_multi_consumer_f8, entry_computation_layout={(f8e4m3fn[2,16,48]{2,1,0}, f8e4m3fn[2,24,192]{2,1,0}, bf16[], bf16[])->bf16[2,16,192]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
 
@@ -1454,6 +1447,9 @@ ENTRY main {
 
 TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
        WindowedEinsumE2EAllGatherMultiConsumerF8) {
+  if (IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires OCP FP8 (f8e4m3fn) support.";
+  }
   absl::string_view kModuleReplicatedStr = R"(
 HloModule windowed_einsum_e2e_all_gather_multi_consumer_f8, entry_computation_layout={(f8e4m3fn[2,16,48]{2,1,0}, f8e4m3fn[48,192]{1,0}, f8e4m3fn[48,192]{1,0}, bf16[], bf16[], bf16[])->bf16[2,16,192]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
 
@@ -1497,6 +1493,9 @@ ENTRY main {
 
 TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
        WindowedEinsumE2EReduceScatterF8) {
+  if (IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires OCP FP8 (f8e4m3fn) support.";
+  }
   absl::string_view kModuleReplicatedStr = R"(
 HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(f8e4m3fn[2,16,192]{2,1,0}, f8e4m3fn[192,48]{1,0}, bf16[], bf16[])->bf16[2,16,48]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
 
@@ -1523,6 +1522,161 @@ ENTRY main {
 
   // Verify the creation of FP8 GEMM Custom Calls on Hopper and newer
   // architectures.
+  DebugOptions opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
+  opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  opts.set_xla_gpu_graph_min_graph_size(200);
+  opts.set_xla_gpu_enable_triton_gemm(false);
+  opts.add_xla_disable_hlo_passes("dot-merger");
+  CollectiveOpsVerifyF8Matmul(kModuleReplicatedStr, opts);
+}
+
+// FNUZ FP8 (f8e4m3fnuz/f8e5m2fnuz) variants of the windowed einsum tests
+// for platforms that only support FNUZ/NANOO FP8, not OCP FP8.
+// Ref: https://rocm.docs.amd.com/projects/HIP/en/latest/reference/low_fp_types.html#id4
+
+TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
+       WindowedEinsumE2EAllGatherFnuzF8) {
+  if (!IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires NANOO FP8 (f8e4m3fnuz) support.";
+  }
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(f8e4m3fnuz[2,16,48]{2,1,0}, f8e4m3fnuz[48,192]{1,0}, bf16[], bf16[])->bf16[2,16,192]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
+
+ENTRY main {
+  lhs = f8e4m3fnuz[2,16,48]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  rhs = f8e4m3fnuz[48,192]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  scale_lhs = bf16[] parameter(2)
+  scale_rhs = bf16[] parameter(3)
+  scale_lhs_bcast = bf16[2,16,48]{2,1,0} broadcast(scale_lhs), dimensions={}
+  scale_rhs_bcast = bf16[48,192]{1,0} broadcast(scale_rhs), dimensions={}
+  lhs_bf16 = bf16[2,16,48]{2,1,0} convert(lhs)
+  rhs_bf16 = bf16[48,192]{1,0} convert(rhs)
+  lhs_scaled = bf16[2,16,48]{2,1,0} multiply(scale_lhs_bcast, lhs_bf16)
+  rhs_scaled = bf16[48,192]{1,0} multiply(scale_rhs_bcast, rhs_bf16)
+  dot = bf16[2,16,192]{2,1,0} dot(lhs_scaled, rhs_scaled), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  ROOT custom-call = bf16[2,16,192]{2,1,0} custom-call(dot), custom_call_target="Sharding", sharding={devices=[1,1,4]<=[4]}
+} // main
+)";
+
+  CollectiveOpsCompareWindowedNonWindowed(kModuleReplicatedStr,
+                                          /*disable_dot_merger=*/true);
+
+  DebugOptions opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
+  opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  opts.set_xla_gpu_graph_min_graph_size(200);
+  opts.set_xla_gpu_enable_triton_gemm(false);
+  opts.add_xla_disable_hlo_passes("dot-merger");
+  CollectiveOpsVerifyF8Matmul(kModuleReplicatedStr, opts);
+}
+
+TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
+       WindowedEinsumE2EAllGatherReshapeFnuzF8) {
+  if (!IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires NANOO FP8 (f8e4m3fnuz) support.";
+  }
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule windowed_einsum_e2e_all_gather_reshape_fnuz_f8, entry_computation_layout={(f8e4m3fnuz[2,16,48]{2,1,0}, f8e4m3fnuz[2,24,192]{2,1,0}, bf16[], bf16[])->bf16[2,16,192]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
+
+ENTRY main {
+  lhs = f8e4m3fnuz[2,16,48]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  rhs = f8e4m3fnuz[2,24,192]{2,1,0} parameter(1), sharding={devices=[1,1,4]<=[4]}
+  scale_lhs = bf16[] parameter(2)
+  scale_rhs = bf16[] parameter(3)
+  scale_lhs_bcast = bf16[2,16,48]{2,1,0} broadcast(scale_rhs), dimensions={}
+  scale_rhs_bcast = bf16[2,24,192]{2,1,0} broadcast(scale_lhs), dimensions={}
+  lhs_bf16 = bf16[2,16,48]{2,1,0} convert(lhs)
+  rhs_bf16 = bf16[2,24,192]{2,1,0} convert(rhs)
+  lhs_scaled = bf16[2,16,48]{2,1,0} multiply(scale_lhs_bcast, lhs_bf16)
+  rhs_scaled = bf16[2,24,192]{2,1,0} multiply(scale_rhs_bcast, rhs_bf16)
+  rhs_reshaped = bf16[48,192]{1,0} reshape(rhs_scaled)
+  dot = bf16[2,16,192]{2,1,0} dot(lhs_scaled, rhs_reshaped), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  ROOT custom-call = bf16[2,16,192]{2,1,0} custom-call(dot), custom_call_target="Sharding", sharding={devices=[1,1,4]<=[4]}
+} // main
+)";
+
+  CollectiveOpsCompareWindowedNonWindowed(kModuleReplicatedStr,
+                                          /*disable_dot_merger=*/true);
+
+  DebugOptions opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
+  opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  opts.set_xla_gpu_graph_min_graph_size(200);
+  opts.set_xla_gpu_enable_triton_gemm(false);
+  opts.add_xla_disable_hlo_passes("dot-merger");
+  CollectiveOpsVerifyF8Matmul(kModuleReplicatedStr, opts);
+}
+
+TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
+       WindowedEinsumE2EAllGatherMultiConsumerFnuzF8) {
+  if (!IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires NANOO FP8 (f8e4m3fnuz) support.";
+  }
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule windowed_einsum_e2e_all_gather_multi_consumer_fnuz_f8, entry_computation_layout={(f8e4m3fnuz[2,16,48]{2,1,0}, f8e4m3fnuz[48,192]{1,0}, f8e4m3fnuz[48,192]{1,0}, bf16[], bf16[], bf16[])->bf16[2,16,192]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
+
+ENTRY main {
+  lhs = f8e4m3fnuz[2,16,48]{2,1,0} parameter(0), sharding={devices=[1,4,1]<=[4]}
+  rhs0 = f8e4m3fnuz[48,192]{1,0} parameter(1), sharding={devices=[1,4]<=[4]}
+  scale_lhs = bf16[] parameter(3)
+  scale_rhs0 = bf16[] parameter(4)
+  scale_lhs_bcast = bf16[2,16,48]{2,1,0} broadcast(scale_lhs), dimensions={}
+  scale_rhs0_bcast = bf16[48,192]{1,0} broadcast(scale_rhs0), dimensions={}
+  lhs_bf16 = bf16[2,16,48]{2,1,0} convert(lhs)
+  rhs0_bf16 = bf16[48,192]{1,0} convert(rhs0)
+  lhs_scaled = bf16[2,16,48]{2,1,0} multiply(scale_lhs_bcast, lhs_bf16)
+  rhs0_scaled = bf16[48,192]{1,0} multiply(scale_rhs0_bcast, rhs0_bf16)
+  dot0 = bf16[2,16,192]{2,1,0} dot(lhs_scaled, rhs0_scaled), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  rhs1 = f8e4m3fnuz[48,192]{1,0} parameter(2), sharding={devices=[1,4]<=[4]}
+  scale_rhs1 = bf16[] parameter(5)
+  scale_rhs1_bcast = bf16[48,192]{1,0} broadcast(scale_rhs1), dimensions={}
+  rhs1_bf16 = bf16[48,192]{1,0} convert(rhs1)
+  rhs1_scaled = bf16[48,192]{1,0} multiply(scale_rhs1_bcast, rhs1_bf16)
+  dot1 = bf16[2,16,192]{2,1,0} dot(lhs_scaled, rhs1_scaled), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  ROOT add = bf16[2,16,192]{2,1,0} add(dot0, dot1)
+} // main
+)";
+
+  CollectiveOpsCompareWindowedNonWindowed(kModuleReplicatedStr,
+                                          /*disable_dot_merger=*/true);
+
+  DebugOptions opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
+  opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
+  opts.set_xla_gpu_graph_min_graph_size(200);
+  opts.set_xla_gpu_enable_triton_gemm(false);
+  opts.add_xla_disable_hlo_passes("dot-merger");
+  CollectiveOpsVerifyF8Matmul(kModuleReplicatedStr, opts);
+}
+
+TEST_F(CollectiveOpsTestE2EWindowedNonWindowed,
+       WindowedEinsumE2EReduceScatterFnuzF8) {
+  if (!IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires NANOO FP8 (f8e4m3fnuz) support.";
+  }
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule pjit__unnamed_wrapped_function_, entry_computation_layout={(f8e4m3fnuz[2,16,192]{2,1,0}, f8e4m3fnuz[192,48]{1,0}, bf16[], bf16[])->bf16[2,16,48]{2,1,0}}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
+
+ENTRY main {
+  lhs = f8e4m3fnuz[2,16,192]{2,1,0} parameter(0), sharding={devices=[1,1,4]<=[4]}
+  rhs = f8e4m3fnuz[192,48]{1,0} parameter(1), sharding={devices=[4,1]<=[4]}
+  scale_lhs = bf16[] parameter(2)
+  scale_rhs = bf16[] parameter(3)
+  scale_lhs_bcast = bf16[2,16,192]{2,1,0} broadcast(scale_lhs), dimensions={}
+  scale_rhs_bcast = bf16[192,48]{1,0} broadcast(scale_rhs), dimensions={}
+  lhs_bf16 = bf16[2,16,192]{2,1,0} convert(lhs)
+  rhs_bf16 = bf16[192,48]{1,0} convert(rhs)
+  lhs_scaled = bf16[2,16,192]{2,1,0} multiply(scale_lhs_bcast, lhs_bf16)
+  rhs_scaled = bf16[192,48]{1,0} multiply(scale_rhs_bcast, rhs_bf16)
+  dot = bf16[2,16,48]{2,1,0} dot(lhs_scaled, rhs_scaled), lhs_contracting_dims={2}, rhs_contracting_dims={0}
+  ROOT custom-call = bf16[2,16,48]{2,1,0} custom-call(dot), custom_call_target="Sharding", sharding={devices=[1,4,1]<=[4]}
+} // main
+)";
+
+  CollectiveOpsCompareWindowedNonWindowed(kModuleReplicatedStr,
+                                          /*disable_dot_merger=*/true);
+
   DebugOptions opts = GetDebugOptionsForTest();
   opts.set_xla_gpu_threshold_for_windowed_einsum_mib(0);
   opts.set_xla_gpu_multi_streamed_windowed_einsum(true);
@@ -1628,10 +1782,11 @@ ENTRY entry {
 }
 
 TEST_F(CollectiveOpsTestE2E, CollectivePipelinerF8) {
-  // Verify that FP8 patterns are preserved when collectives are pipelined so
-  // the GEMM rewriter can create FP8 matmuls.
   if (!HasFp8Support()) {
-    GTEST_SKIP() << "Test requires Hopper or newer architecture.";
+    GTEST_SKIP() << "Test requires FP8 support.";
+  }
+  if (IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires OCP FP8 (f8e4m3fn) support.";
   }
 
   absl::string_view kModuleReplicatedStr = R"(
@@ -1650,6 +1805,63 @@ while_body {
   partial_dot_output = bf16[512,128] get-tuple-element(input), index=5
   lhs_f8 = f8e4m3fn[128,128] convert(lhs)
   rhs_f8 = f8e4m3fn[32,128] convert(rhs)
+  lhs_bf16 = bf16[128,128] convert(lhs_f8)
+  rhs_bf16 = bf16[32,128] convert(rhs_f8)
+  scale_lhs = bf16[] get-tuple-element(input), index=3
+  scale_rhs = bf16[] get-tuple-element(input), index=4
+  scale_lhs_bcast = bf16[128,128] broadcast(scale_lhs), dimensions={}
+  scale_rhs_bcast = bf16[32,128] broadcast(scale_rhs), dimensions={}
+  lhs_scaled = bf16[128,128] multiply(lhs_bf16, scale_lhs_bcast)
+  rhs_scaled = bf16[32,128] multiply(rhs_bf16, scale_rhs_bcast)
+  rhs_scaled_all_gathered = bf16[128,128] all-gather(rhs_scaled), channel_id=1, use_global_device_ids=true, dimensions={0}, replica_groups={{0,1,2,3}}
+  dot = bf16[128,128] dot(lhs_scaled, rhs_scaled_all_gathered), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+  c0 = s32[] constant(0)
+  size = s32[] constant(128)
+  iteration_offset = s32[] multiply(loop_counter, size)
+  updated_dot_output = bf16[512,128] dynamic-update-slice(partial_dot_output, dot, iteration_offset, c0)
+  c1 = s32[] constant(1)
+  loop_counter_plus_one = s32[] add(loop_counter, c1)
+  ROOT tuple = (s32[], bf16[128,128], bf16[32,128], bf16[], bf16[], bf16[512,128]) tuple(loop_counter_plus_one, lhs, rhs, scale_lhs, scale_rhs, updated_dot_output)
+}
+ENTRY entry {
+  c0 = s32[] constant(0)
+  lhs = bf16[128,128] parameter(0)
+  rhs = bf16[32,128] parameter(1)
+  scale_lhs = bf16[] parameter(2)
+  scale_rhs = bf16[] parameter(3)
+  result_buffer = bf16[512,128] constant(0.)
+  while_input = (s32[], bf16[128,128], bf16[32,128], bf16[], bf16[], bf16[512,128]) tuple(c0, lhs, rhs, scale_lhs, scale_rhs, result_buffer)
+  while = (s32[], bf16[128,128], bf16[32,128], bf16[], bf16[], bf16[512,128]) while(while_input), condition=while_cond, body=while_body
+  ROOT dot_output = bf16[512,128] get-tuple-element(while), index=5
+}
+)";
+
+  auto opts = GetDebugOptionsForTest();
+  opts.set_xla_gpu_enable_triton_gemm(false);
+  CollectiveOpsVerifyF8Matmul(kModuleReplicatedStr, opts);
+}
+
+TEST_F(CollectiveOpsTestE2E, CollectivePipelinerFnuzF8) {
+  if (!IsNanooFp8Only()) {
+    GTEST_SKIP() << "Test requires NANOO FP8 (f8e4m3fnuz) support.";
+  }
+
+  absl::string_view kModuleReplicatedStr = R"(
+HloModule module, entry_computation_layout={(bf16[128,128], bf16[32,128], bf16[], bf16[])->bf16[512,128]}, allow_spmd_sharding_propagation_to_parameters={false,false,false,false}, num_partitions=4
+while_cond {
+  input = (s32[], bf16[128,128], bf16[32,128], bf16[], bf16[], bf16[512,128]) parameter(0)
+  loop_counter = s32[] get-tuple-element(input), index=0
+  c4 = s32[] constant(4)
+  ROOT compare = pred[] compare(loop_counter, c4), direction=LT
+}
+while_body {
+  input = (s32[], bf16[128,128], bf16[32,128], bf16[], bf16[], bf16[512,128]) parameter(0)
+  loop_counter = s32[] get-tuple-element(input), index=0
+  lhs = bf16[128,128] get-tuple-element(input), index=1
+  rhs = bf16[32,128] get-tuple-element(input), index=2
+  partial_dot_output = bf16[512,128] get-tuple-element(input), index=5
+  lhs_f8 = f8e4m3fnuz[128,128] convert(lhs)
+  rhs_f8 = f8e4m3fnuz[32,128] convert(rhs)
   lhs_bf16 = bf16[128,128] convert(lhs_f8)
   rhs_bf16 = bf16[32,128] convert(rhs_f8)
   scale_lhs = bf16[] get-tuple-element(input), index=3


### PR DESCRIPTION
## Summary
The 5 FP8 collective ops E2E tests use OCP FP8 types (`f8e4m3fn`/`f8e5m2`), which are
not supported on NANOO-only platforms. 
This PR properly separates the tests by FP8 variant:
- **Skip OCP FP8 tests** on NANOO-only platforms (no OCP FP8 support)
- **Add dedicated FNUZ FP8 tests** with native `f8e4m3fnuz`/`f8e5m2fnuz` HLO
- **Add `IsNanooFp8Only()`** helper to detect NANOO-only platforms
Ref: https://rocm.docs.amd.com/projects/HIP/en/latest/reference/low_fp_types.html#id4
## New FNUZ FP8 tests
- `CollectivePipelinerFnuzF8`
- `WindowedEinsumE2EAllGatherFnuzF8`
- `WindowedEinsumE2EAllGatherReshapeFnuzF8`
- `WindowedEinsumE2EAllGatherMultiConsumerFnuzF8`
- `WindowedEinsumE2EReduceScatterFnuzF8`
## Test results (NANOO-only platform)
PASSED: 5 (all FNUZ FP8 tests)
SKIPPED: 5 (all OCP FP8 tests — correctly skipped)
FAILED: 0