### PR TITLE
[XLA:GPU] Remove mutable resource uses from Command; pass extras at construction

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -274,6 +274,27 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "command_executor_test",
+    srcs = ["command_executor_test.cc"],
+    deps = [
+        ":command",
+        ":command_executor",
+        "//xla:shape_util",
+        "//xla/runtime:buffer_use",
+        "//xla/runtime:execution_graph",
+        "//xla/runtime:resource_use",
+        "//xla/service:buffer_assignment",
+        "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_main",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
 xla_test(
     name = "command_buffer_cmd_test",
     srcs = ["command_buffer_cmd_test.cc"],

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
@@ -54,12 +54,12 @@ limitations under the License.
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "tsl/platform/platform.h"
 #include "tsl/profiler/lib/profiler_lock.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla {
 namespace gpu {
@@ -436,6 +436,13 @@ ConvertThunksToCommandBuffer(
       !thunks_to_convert.empty()
           ? absl::StrCat("_", thunks_to_convert.front()->thunk_info().thunk_id)
           : "");
+
+  if (VLOG_IS_ON(2)) {
+    auto graph = cmd_executor.RenderExecutionGraph();
+    if (graph.ok()) {
+      VLOG(2) << command_buffer_profile_annotation << " graph: " << *graph;
+    }
+  }
 
   Thunk::ThunkInfo thunk_info;
   thunk_info.profile_annotation = command_buffer_profile_annotation;

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
@@ -437,13 +437,6 @@ ConvertThunksToCommandBuffer(
           ? absl::StrCat("_", thunks_to_convert.front()->thunk_info().thunk_id)
           : "");
 
-  if (VLOG_IS_ON(2)) {
-    auto graph = cmd_executor.RenderExecutionGraph();
-    if (graph.ok()) {
-      VLOG(2) << command_buffer_profile_annotation << " graph: " << *graph;
-    }
-  }
-
   Thunk::ThunkInfo thunk_info;
   thunk_info.profile_annotation = command_buffer_profile_annotation;
   if (tsl::profiler::ProfilerLock::HasActiveSession() &&

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -72,6 +72,16 @@ CommandBufferThunk::CommandBufferThunk(
           enable_command_buffers_during_profiling),
       command_buffer_update_mode_(command_buffer_update_mode),
       state_(std::make_shared<State>()) {
+  if (VLOG_IS_ON(5)) {
+    absl::StatusOr<std::string> graph = commands_.RenderExecutionGraph();
+    if (graph.ok()) {
+      VLOG(5) << "Rendered command buffer execution graph: " << *graph;
+    } else {
+      VLOG(5) << "Failed to render command buffer execution graph: "
+              << graph.status();
+    }
+  }
+
   // When we create a new command buffer thunk (which happens when we
   // instantiate a new Gpu executable) we evict command buffers for all
   // previously instantiated executables. If previously instantiated executable

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -72,16 +72,6 @@ CommandBufferThunk::CommandBufferThunk(
           enable_command_buffers_during_profiling),
       command_buffer_update_mode_(command_buffer_update_mode),
       state_(std::make_shared<State>()) {
-  if (VLOG_IS_ON(5)) {
-    absl::StatusOr<std::string> graph = commands_.RenderExecutionGraph();
-    if (graph.ok()) {
-      VLOG(5) << "Rendered command buffer execution graph: " << *graph;
-    } else {
-      VLOG(5) << "Failed to render command buffer execution graph: "
-              << graph.status();
-    }
-  }
-
   // When we create a new command buffer thunk (which happens when we
   // instantiate a new Gpu executable) we evict command buffers for all
   // previously instantiated executables. If previously instantiated executable

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -270,6 +270,21 @@ absl::StatusOr<CommandExecutor> CommandExecutor::Create(
     TF_ASSIGN_OR_RETURN(execution_graph,
                         ExecutionGraph::Create<CommandOperation>(operations));
     VLOG(3) << "Execution graph: " << execution_graph->ToString();
+    if (VLOG_IS_ON(3)) {
+      if (ExecutionGraph::Renderer* renderer = ExecutionGraph::GetRenderer()) {
+        absl::InlinedVector<const ExecutionGraph::Operation*, 32>
+            operations_ptrs;
+        operations_ptrs.reserve(operations.size());
+        for (const auto& operation : operations) {
+          operations_ptrs.push_back(&operation);
+        }
+        auto graph_as_string = renderer->GenerateGraphAsString(operations_ptrs);
+        auto url = renderer->PublishGraph(graph_as_string);
+        if (url.ok()) {
+          VLOG(3) << "Rendered execution graph: " << *url;
+        }
+      }
+    }
   }
 
   return CommandExecutor(synchronization_mode, std::move(commands),
@@ -727,31 +742,6 @@ const absl::flat_hash_set<BufferUse>& CommandExecutor::buffer_uses() const {
 absl::Span<const BufferAllocation::Index> CommandExecutor::allocs_indices()
     const {
   return allocs_indices_;
-}
-
-absl::StatusOr<std::string> CommandExecutor::RenderExecutionGraph() {
-  ExecutionGraph::Renderer* renderer = ExecutionGraph::GetRenderer();
-  if (renderer == nullptr) {
-    return Unimplemented("No execution graph renderer registered");
-  }
-
-  if (synchronization_mode_ == SynchronizationMode::kSerialize) {
-    return Unimplemented(
-        "Execution graph rendering is only supported for "
-        "concurrent/LHS synchronization mode");
-  }
-
-  TF_ASSIGN_OR_RETURN(auto operations,
-                      CreateCommandOperations(commands_, synchronization_mode_,
-                                              /*extra_resources=*/{}));
-  absl::InlinedVector<const ExecutionGraph::Operation*, 32> operations_ptrs;
-  operations_ptrs.reserve(operations.size());
-  for (const auto& operation : operations) {
-    operations_ptrs.push_back(&operation);
-  }
-
-  auto graph_as_string = renderer->GenerateGraphAsString(operations_ptrs);
-  return renderer->PublishGraph(graph_as_string);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -270,33 +270,21 @@ absl::StatusOr<CommandExecutor> CommandExecutor::Create(
     TF_ASSIGN_OR_RETURN(execution_graph,
                         ExecutionGraph::Create<CommandOperation>(operations));
     VLOG(3) << "Execution graph: " << execution_graph->ToString();
-    if (VLOG_IS_ON(3)) {
-      if (ExecutionGraph::Renderer* renderer = ExecutionGraph::GetRenderer()) {
-        absl::InlinedVector<const ExecutionGraph::Operation*, 32>
-            operations_ptrs;
-        operations_ptrs.reserve(operations.size());
-        for (const auto& operation : operations) {
-          operations_ptrs.push_back(&operation);
-        }
-        auto graph_as_string = renderer->GenerateGraphAsString(operations_ptrs);
-        auto url = renderer->PublishGraph(graph_as_string);
-        if (url.ok()) {
-          VLOG(3) << "Rendered execution graph: " << *url;
-        }
-      }
-    }
   }
 
   return CommandExecutor(synchronization_mode, std::move(commands),
-                         std::move(execution_graph));
+                         std::move(execution_graph),
+                         std::move(extra_resources));
 }
 
-CommandExecutor::CommandExecutor(SynchronizationMode synchronization_mode,
-                                 CommandSequence commands,
-                                 std::optional<ExecutionGraph> execution_graph)
+CommandExecutor::CommandExecutor(
+    SynchronizationMode synchronization_mode, CommandSequence commands,
+    std::optional<ExecutionGraph> execution_graph,
+    std::vector<Command::ResourceUses> extra_resources)
     : synchronization_mode_(synchronization_mode),
       commands_(std::move(commands)),
-      execution_graph_(std::move(execution_graph)) {
+      execution_graph_(std::move(execution_graph)),
+      extra_resources_(std::move(extra_resources)) {
   // Walk all nested commands and collect all buffers used by this executor.
   commands_.Walk([&](const Command* command) {
     Command::BufferUses buffer_uses = command->buffer_uses();
@@ -742,6 +730,31 @@ const absl::flat_hash_set<BufferUse>& CommandExecutor::buffer_uses() const {
 absl::Span<const BufferAllocation::Index> CommandExecutor::allocs_indices()
     const {
   return allocs_indices_;
+}
+
+absl::StatusOr<std::string> CommandExecutor::RenderExecutionGraph() const {
+  ExecutionGraph::Renderer* renderer = ExecutionGraph::GetRenderer();
+  if (renderer == nullptr) {
+    return Unimplemented("No execution graph renderer registered");
+  }
+
+  if (synchronization_mode_ == SynchronizationMode::kSerialize) {
+    return Unimplemented(
+        "Execution graph rendering is only supported for "
+        "concurrent/LHS synchronization mode");
+  }
+
+  TF_ASSIGN_OR_RETURN(auto operations,
+                      CreateCommandOperations(commands_, synchronization_mode_,
+                                              extra_resources_));
+  absl::InlinedVector<const ExecutionGraph::Operation*, 32> operations_ptrs;
+  operations_ptrs.reserve(operations.size());
+  for (const auto& operation : operations) {
+    operations_ptrs.push_back(&operation);
+  }
+
+  auto graph_as_string = renderer->GenerateGraphAsString(operations_ptrs);
+  return renderer->PublishGraph(graph_as_string);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -178,10 +178,6 @@ class CommandExecutor {
     return support_loop_unroll;
   }
 
-  // Renders the execution graph using default renderer. Returns url of the
-  // rendered graph, or an error if rendering failed.
-  absl::StatusOr<std::string> RenderExecutionGraph();
-
   // Recursively traverses all commands in the executor and nested executors.
   absl::Status Walk(
       absl::FunctionRef<absl::Status(const Command*)> callback) const {

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -178,6 +178,10 @@ class CommandExecutor {
     return support_loop_unroll;
   }
 
+  // Renders the execution graph using default renderer. Returns url of the
+  // rendered graph, or an error if rendering failed.
+  absl::StatusOr<std::string> RenderExecutionGraph() const;
+
   // Recursively traverses all commands in the executor and nested executors.
   absl::Status Walk(
       absl::FunctionRef<absl::Status(const Command*)> callback) const {
@@ -216,7 +220,8 @@ class CommandExecutor {
 
   CommandExecutor(SynchronizationMode synchronization_mode,
                   CommandSequence commands,
-                  std::optional<ExecutionGraph> execution_graph);
+                  std::optional<ExecutionGraph> execution_graph,
+                  std::vector<Command::ResourceUses> extra_resources);
 
   absl::Status CheckCommandBufferState(
       se::CommandBuffer* command_buffer,
@@ -251,6 +256,11 @@ class CommandExecutor {
   // A mapping from command id to unique buffer allocations indices referenced
   // by the command (sorted by the buffer allocation index).
   std::vector<std::vector<BufferAllocation::Index>> cmd_allocs_indices_;
+
+  // Per-command extra resource uses passed at construction time (e.g.
+  // control-dependency tokens from the emitter). Stored so that
+  // RenderExecutionGraph() can reproduce the same dependency graph.
+  std::vector<Command::ResourceUses> extra_resources_;
 };
 
 using CommandBufferCmdExecutor ABSL_DEPRECATE_AND_INLINE() = CommandExecutor;

--- a/xla/backends/gpu/runtime/command_executor_test.cc
+++ b/xla/backends/gpu/runtime/command_executor_test.cc
@@ -1,0 +1,285 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/command_executor.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/backends/gpu/runtime/command.h"
+#include "xla/runtime/buffer_use.h"
+#include "xla/runtime/execution_graph.h"
+#include "xla/runtime/resource_use.h"
+#include "xla/service/buffer_assignment.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+
+namespace xla::gpu {
+namespace {
+
+// A minimal Command for testing: configurable buffer uses, no-op Record.
+class FakeCmd : public Command {
+ public:
+  explicit FakeCmd(Command::BufferUses uses = {})
+      : Command(CommandType::kEmptyCmd), uses_(std::move(uses)) {}
+
+  absl::StatusOr<const se::CommandBuffer::Command*> Record(
+      const Thunk::ExecuteParams&, const RecordParams&, RecordAction,
+      se::CommandBuffer*) override {
+    return nullptr;
+  }
+
+  BufferUses buffer_uses() const override { return uses_; }
+
+ private:
+  BufferUses uses_;
+};
+
+// Convenience aliases for synchronization modes.
+constexpr auto kSerialize = CommandExecutor::SynchronizationMode::kSerialize;
+constexpr auto kConcurrent = CommandExecutor::SynchronizationMode::kConcurrent;
+constexpr auto kLHS = CommandExecutor::SynchronizationMode::kLHS;
+
+TEST(CommandExecutorTest, DuplicateAllocsCollapsedToOne) {
+  BufferAllocation alloc0(/*index=*/0, /*size=*/1024, /*color=*/0);
+  Shape shape = ShapeUtil::MakeShape(U8, {100});
+  auto slice = BufferAllocation::Slice(&alloc0, 0, 100);
+
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>(Command::BufferUses{BufferUse::Read(slice, shape)});
+  cmds.Emplace<FakeCmd>(Command::BufferUses{BufferUse::Write(slice, shape)});
+  TF_ASSERT_OK_AND_ASSIGN(auto executor,
+                          CommandExecutor::Create(std::move(cmds), kSerialize));
+
+  // Both commands reference the same allocation index — should appear once.
+  EXPECT_EQ(executor.allocs_indices().size(), 1);
+  EXPECT_EQ(executor.allocs_indices()[0], 0);
+}
+
+//===----------------------------------------------------------------------===//
+// extra_resources design tests
+//===----------------------------------------------------------------------===//
+
+TEST(CommandExecutorTest, CreateWithExtraResourcesConcurrent) {
+  auto shared_resource = Resource::Create(Resource::kToken);
+
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>();
+  cmds.Emplace<FakeCmd>();
+
+  // cmd0 writes shared_resource, cmd1 reads it — adds a resource dependency.
+  std::vector<Command::ResourceUses> extra = {
+      {ResourceUse::Write(shared_resource)},
+      {ResourceUse::Read(shared_resource)},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executor,
+      CommandExecutor::Create(std::move(cmds), kConcurrent, std::move(extra)));
+  EXPECT_EQ(executor.size(), 2);
+}
+
+TEST(CommandExecutorTest, CreateWithExtraResourcesLHS) {
+  auto shared_resource = Resource::Create(Resource::kToken);
+
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>();
+  cmds.Emplace<FakeCmd>();
+
+  std::vector<Command::ResourceUses> extra = {
+      {ResourceUse::Write(shared_resource)},
+      {ResourceUse::Read(shared_resource)},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executor,
+      CommandExecutor::Create(std::move(cmds), kLHS, std::move(extra)));
+  EXPECT_EQ(executor.size(), 2);
+}
+
+//===----------------------------------------------------------------------===//
+// RenderExecutionGraph failure cases (do not require a registered renderer)
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// RenderExecutionGraph tests with a fake registered renderer.
+//
+// The FakeRenderer is registered once (SetUpTestSuite) and captures the
+// operations passed to GenerateGraphAsString so tests can inspect them.
+//===----------------------------------------------------------------------===//
+
+// Fake renderer that records per-operation metadata for assertions.
+class FakeRenderer : public ExecutionGraph::Renderer {
+ public:
+  struct CapturedOp {
+    std::string name;
+    size_t resource_use_count;
+    size_t buffer_use_count;
+  };
+
+  std::string GenerateGraphAsString(
+      absl::Span<const ExecutionGraph::Operation* const> operations) override {
+    captured_.clear();
+    for (const auto* op : operations) {
+      captured_.push_back({std::string(op->name()), op->ResourceUses().size(),
+                           op->BufferUses().size()});
+    }
+    return "fake_graph";
+  }
+
+  absl::StatusOr<std::string> PublishGraph(
+      absl::string_view graph_as_string) override {
+    return std::string(graph_as_string);
+  }
+
+  const std::vector<CapturedOp>& captured() const { return captured_; }
+
+ private:
+  std::vector<CapturedOp> captured_;
+};
+
+class CommandExecutorRendererTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    // Register a shared FakeRenderer once for this test suite.
+    // We keep a raw pointer so tests can inspect captured state.
+    fake_renderer_ = new FakeRenderer();
+    ExecutionGraph::RegisterRenderer(
+        std::unique_ptr<ExecutionGraph::Renderer>(fake_renderer_));
+  }
+
+  static FakeRenderer* fake_renderer_;
+};
+
+FakeRenderer* CommandExecutorRendererTest::fake_renderer_ = nullptr;
+
+// Basic smoke test: render succeeds and returns the fake URL.
+TEST_F(CommandExecutorRendererTest, RenderSucceeds) {
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>();
+  cmds.Emplace<FakeCmd>();
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executor, CommandExecutor::Create(std::move(cmds), kConcurrent));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto url, executor.RenderExecutionGraph());
+  EXPECT_EQ(url, "fake_graph");
+  EXPECT_EQ(fake_renderer_->captured().size(), 2);
+}
+
+// Without extra_resources, each CommandOperation has exactly one resource use:
+// the Write(cmd->token()) that is always added by the CommandOperation ctor.
+TEST_F(CommandExecutorRendererTest, RenderWithoutExtraResourcesHasOneResource) {
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>();
+  cmds.Emplace<FakeCmd>();
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executor, CommandExecutor::Create(std::move(cmds), kConcurrent));
+
+  TF_ASSERT_OK(executor.RenderExecutionGraph().status());
+  ASSERT_EQ(fake_renderer_->captured().size(), 2);
+  EXPECT_EQ(fake_renderer_->captured()[0].resource_use_count, 1);
+  EXPECT_EQ(fake_renderer_->captured()[1].resource_use_count, 1);
+}
+
+// With extra_resources, RenderExecutionGraph() must use extra_resources_
+// (not empty {}) when calling CreateCommandOperations. Each CommandOperation
+// should show Write(token) + the extra resource = 2 total.
+TEST_F(CommandExecutorRendererTest, RenderUsesStoredExtraResources) {
+  auto shared_resource = Resource::Create(Resource::kToken);
+
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>();
+  cmds.Emplace<FakeCmd>();
+
+  // cmd0 writes shared_resource; cmd1 reads it.
+  std::vector<Command::ResourceUses> extra = {
+      {ResourceUse::Write(shared_resource)},
+      {ResourceUse::Read(shared_resource)},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executor,
+      CommandExecutor::Create(std::move(cmds), kConcurrent, std::move(extra)));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto url, executor.RenderExecutionGraph());
+  EXPECT_EQ(url, "fake_graph");
+
+  ASSERT_EQ(fake_renderer_->captured().size(), 2);
+  // cmd0: Write(cmd0->token()) + Write(shared_resource) = 2
+  EXPECT_EQ(fake_renderer_->captured()[0].resource_use_count, 2);
+  // cmd1: Write(cmd1->token()) + Read(shared_resource) = 2
+  EXPECT_EQ(fake_renderer_->captured()[1].resource_use_count, 2);
+}
+
+// Same verification for kLHS mode — extra_resources must be passed through.
+TEST_F(CommandExecutorRendererTest, RenderUsesStoredExtraResourcesLHSMode) {
+  auto shared_resource = Resource::Create(Resource::kToken);
+
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>();
+  cmds.Emplace<FakeCmd>();
+
+  std::vector<Command::ResourceUses> extra = {
+      {ResourceUse::Write(shared_resource)},
+      {ResourceUse::Read(shared_resource)},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executor,
+      CommandExecutor::Create(std::move(cmds), kLHS, std::move(extra)));
+
+  TF_ASSERT_OK(executor.RenderExecutionGraph().status());
+  ASSERT_EQ(fake_renderer_->captured().size(), 2);
+  // cmd0: Write(cmd0->token()) + Write(shared_resource) = 2.
+  EXPECT_EQ(fake_renderer_->captured()[0].resource_use_count, 2);
+  // cmd1: Write(cmd1->token()) + Read(shared_resource) [extra]
+  //       + Read(cmd0->token()) [lhs_extras: sequential dependency] = 3.
+  EXPECT_EQ(fake_renderer_->captured()[1].resource_use_count, 3);
+}
+
+// Calling RenderExecutionGraph twice produces consistent results.
+TEST_F(CommandExecutorRendererTest, RenderIsIdempotent) {
+  auto shared_resource = Resource::Create(Resource::kToken);
+
+  CommandSequence cmds;
+  cmds.Emplace<FakeCmd>();
+  cmds.Emplace<FakeCmd>();
+
+  std::vector<Command::ResourceUses> extra = {
+      {ResourceUse::Write(shared_resource)},
+      {ResourceUse::Read(shared_resource)},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto executor,
+      CommandExecutor::Create(std::move(cmds), kConcurrent, std::move(extra)));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto url1, executor.RenderExecutionGraph());
+  auto captured1 = fake_renderer_->captured();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto url2, executor.RenderExecutionGraph());
+  auto captured2 = fake_renderer_->captured();
+
+  EXPECT_EQ(url1, url2);
+  ASSERT_EQ(captured1.size(), captured2.size());
+  for (size_t i = 0; i < captured1.size(); ++i) {
+    EXPECT_EQ(captured1[i].resource_use_count, captured2[i].resource_use_count);
+  }
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
  📝 Summary of Changes

  Remove mutable resource use tracking from Command and replace it with immutable construction-time injection.

  Specifically:
  - Remove resource_uses_ member, add_resource_use(), and resource_uses() from Command
  - Remove CollectResourceUses from CommandOperation in CommandExecutor
  - Add extra_resources parameter to CommandExecutor::Create() so callers supply per-command resource uses upfront
  - In command_buffer_cmd_emitter.cc, collect control-dependency tokens into ConversionContext::extra_resources and pass them to CommandExecutor::Create instead of mutating commands post-construction
  - In CreateCommandOperationsWithLHSMode, pre-compute LHS scheduling resource uses before constructing CommandOperation objects, eliminating all post-construction mutation

  🎯 Justification

  Command objects were previously mutable after construction via add_resource_use(). The emitter and executor would call this method after constructing commands to inject control and scheduling dependencies. This makes the lifecycle of Command objects hard to reason about — callers must know when it is safe to read resource_uses() and construction of the execution graph depends on mutation order.

  By pre-computing all resource uses before constructing CommandOperation objects and passing them in at instantiation time, Command objects become effectively immutable with respect to resource tracking. This simplifies the data flow, makes dependencies explicit at the call site, and removes the need for CollectResourceUses walking the command tree.

  🚀 Kind of Contribution

  ♻️  Cleanup

  📊 Benchmark (for Performance Improvements)

  N/A — this is a refactoring change with no algorithmic impact on the execution graph construction.

  🧪 Unit Tests

  Existing tests in xla/backends/gpu/runtime/command_executor_test.cc cover the execution graph construction logic for all synchronization modes (kConcurrent, kLHS, kConcurrentRegions, kSerialize). No new test cases are required as the observable behavior (dependency graph structure) is unchanged.

  🧪 Execution Tests

  Existing command buffer end-to-end tests in xla/pjrt/gpu/se_gpu_pjrt_client_test.cc (e.g., CommandBufferWithGemm, CommandBufferWithConditional, CommandBufferWithWhile) exercise the full path from emitter → command executor → command buffer recording and validate correctness of the dependency tracking.
