### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Fix CI build failures

### DIFF
--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -445,6 +445,7 @@ sycl_library(
     deps = [
         ":sycl_status",
         "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:errors",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -464,6 +465,7 @@ xla_test(
     deps = [
         ":sycl_gpu_runtime",
         "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:errors",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_googletest//:gtest_main",

--- a/xla/stream_executor/sycl/sycl_blas_lt.cc
+++ b/xla/stream_executor/sycl/sycl_blas_lt.cc
@@ -31,6 +31,13 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& config,
   return std::make_unique<MatmulPlan>(config, epilogue);
 }
 
+absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetGroupedMatmulPlan(
+    gpu::GroupedGemmConfig& config,
+    const std::vector<gpu::BlasLt::Epilogue>& epilogues) const {
+  return absl::UnimplementedError(
+      "Grouped GEMM is not supported for Sycl BlasLt");
+}
+
 absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
     Stream* stream, const gpu::BlasLt::MemoryArgs& args,
     blas::ProfileResult* profile_result) const {

--- a/xla/stream_executor/sycl/sycl_blas_lt.h
+++ b/xla/stream_executor/sycl/sycl_blas_lt.h
@@ -35,6 +35,10 @@ class BlasLt : public gpu::BlasLt {
   absl::StatusOr<BlasLt::MatmulPlanPtr> GetMatmulPlan(
       const gpu::GemmConfig& config, Epilogue epilogue) const override;
 
+  absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
+      gpu::GroupedGemmConfig& config,
+      const std::vector<Epilogue>& epilogues) const override;
+
   ~BlasLt() override = default;
 
   struct MatmulPlan : public gpu::BlasLt::MatmulPlan {

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "absl/base/call_once.h"
 #include "absl/synchronization/mutex.h"
+#include "xla/tsl/platform/errors.h"
 
 namespace stream_executor::sycl {
 

--- a/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/status/status_matchers.h"
 #include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/errors.h"
 
 namespace stream_executor::sycl {
 namespace {


### PR DESCRIPTION
This PR fixes oneAPI CI build failures due to

- missing header file `xla/tsl/platform/errors.h` in `xla/stream_executor/sycl/sycl_gpu_runtime.cc`
- missing definition of pure virtual function `GetGroupedMatmulPlan` in `xla/stream_executor/sycl/sycl_blas_lt.cc`
