### PR TITLE
[XLA:GPU][codegen] Reconcile types for thread / block id comparisons

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -913,6 +913,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Support",

--- a/xla/service/gpu/ir_emission_utils.cc
+++ b/xla/service/gpu/ir_emission_utils.cc
@@ -234,13 +234,18 @@ bool IsContiguousSlice(const HloInstruction& instr) {
 }
 
 llvm::Value* IsBlock0Thread0(llvm::IRBuilderBase* b) {
-  llvm::Value* is_thread0 = b->CreateICmpEQ(
-      b->getInt32(0),
-      EmitCallToTargetIntrinsic(TargetIntrinsicID::kThreadIdx, {}, {}, b));
+  // On Intel GPUs, intrinsics may return a non-i32 integer type, so we first
+  // emit the intrinsic call to get the correct type for the compare
+  // instruction.
+  llvm::Value* tid =
+      EmitCallToTargetIntrinsic(TargetIntrinsicID::kThreadIdx, {}, {}, b);
+  llvm::Value* is_thread0 =
+      b->CreateICmpEQ(llvm::ConstantInt::get(tid->getType(), 0), tid);
 
-  llvm::Value* is_block0 = b->CreateICmpEQ(
-      b->getInt32(0),
-      EmitCallToTargetIntrinsic(TargetIntrinsicID::kBlockIdx, {}, {}, b));
+  llvm::Value* bid =
+      EmitCallToTargetIntrinsic(TargetIntrinsicID::kBlockIdx, {}, {}, b);
+  llvm::Value* is_block0 =
+      b->CreateICmpEQ(llvm::ConstantInt::get(bid->getType(), 0), bid);
   return b->CreateAnd(is_thread0, is_block0);
 }
 


### PR DESCRIPTION
Some backend target intrinsics might return integer types of varying widths. This PR ensures that the correct type is used and propagated.

This helps fix the `Invalid LLVM IR` seen in tests like `xla/service/gpu/tests/gpu_dyn_shape_test.cc` with SPIRV backend.