### PR TITLE
Fix sort comparison type mismatch causing tf.random.shuffle XLA failure

### DIFF
--- a/xla/mlir_hlo/mhlo/IR/hlo_ops.cc
+++ b/xla/mlir_hlo/mhlo/IR/hlo_ops.cc
@@ -7755,13 +7755,12 @@ SortOp createSortOp(PatternRewriter* rewriter, const Location& loc,
       mhlo::SortOp::create(*rewriter, loc, operands, dimension, isStable);
 
   // Use TOTALORDER comparison type instead of the default comparison if the
-  // element type is of type float.
+  // sort key (first element type) is a float. The comparison is performed on
+  // the first element type only (block arguments 0 and 1), so we must only
+  // examine the first element type.
   std::optional<StringRef> compareType = std::nullopt;
-  for (auto const& elementType : elementTypes)
-    if (isa<FloatType>(elementType)) {
-      compareType.emplace("TOTALORDER");
-      break;
-    }
+  if (!elementTypes.empty() && isa<FloatType>(elementTypes[0]))
+    compareType.emplace("TOTALORDER");
   buildSortComparisonBody(elementTypes, direction, compareType,
                           &sortOp.getComparator(), rewriter);
   return sortOp;


### PR DESCRIPTION
createSortOp was setting TOTALORDER whenever any element type was float, but the sort comparator only ever compares the first element type (the sort key). When shuffling a float tensor, the keys are i32 and the values are f32 — the loop found f32 and set TOTALORDER on the i32 comparison, which the HLO verifier rejects with "Expected comparison type SIGNED, actual: TOTALORDER".

The fix narrows the check to the first element type only, so integer keys correctly fall back to the default SIGNED comparison.