### PR TITLE
[xla] Allow exchanging mutable data via rendezvous

### DIFF
--- a/xla/backends/cpu/collectives/in_process_communicator.cc
+++ b/xla/backends/cpu/collectives/in_process_communicator.cc
@@ -124,7 +124,7 @@ static bool ByRank(const Participant* a, const Participant* b) {
 // Collects participants for an in-process collective operation.
 template <typename Participant>
 std::vector<Participant> CollectParticipants(
-    absl::Span<const Participant*> participants) {
+    absl::Span<Participant*> participants) {
   absl::c_sort(participants, ByRank<Participant>);
 
   std::vector<Participant> ret;
@@ -493,13 +493,13 @@ Future<> InProcessCommunicator::AllToAll(
   const RendezvousKey& key = cpu_executor->rendezvous_key();
 
   std::string name = absl::StrCat("all to all ", key.ToString());
-  AllToAllParticipant partiticipant{rank_,
-                                    {send_buffers.begin(), send_buffers.end()},
-                                    {recv_buffers.begin(), recv_buffers.end()}};
+  AllToAllParticipant participant{rank_,
+                                  {send_buffers.begin(), send_buffers.end()},
+                                  {recv_buffers.begin(), recv_buffers.end()}};
 
   TF_ASSIGN_OR_RETURN(
       auto op, Rendezvous<OpParticipants<AllToAllParticipant>>(
-                   name, key, partiticipant, key.num_local_participants,
+                   name, key, participant, key.num_local_participants,
                    CollectParticipants<AllToAllParticipant>, WarnStuckTimeout(),
                    TerminateTimeout()));
 

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -133,6 +133,7 @@ cc_library(
         "//xla:util",
         "//xla/core/collectives:rank_id",
         "//xla/service:rendezvous",
+        "//xla/tsl/util:unique_any",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
@@ -153,7 +154,6 @@ xla_cc_test(
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:test",
         "//xla/tsl/platform:test_main",
-        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/xla/backends/gpu/collectives/gpu_clique_rendezvous.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_rendezvous.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/backends/gpu/collectives/gpu_clique_rendezvous.h"
 
-#include <any>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -31,6 +30,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/service/rendezvous.h"
+#include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
 
 namespace xla::gpu {
@@ -53,7 +53,7 @@ struct GpuCliqueRendezvousKey {
 
 struct RankData {
   RankId rank;
-  std::any data;
+  tsl::UniqueAny data;
 };
 
 struct RankFormatter {
@@ -65,11 +65,11 @@ struct RankFormatter {
 }  // namespace
 
 GpuCliqueRendezvous::GpuCliqueRendezvous(
-    GpuCliqueKey clique_key, absl::btree_map<RankId, std::any> values)
+    GpuCliqueKey clique_key, absl::btree_map<RankId, tsl::UniqueAny> values)
     : clique_key_(std::move(clique_key)), values_(std::move(values)) {}
 
 absl::StatusOr<std::shared_ptr<GpuCliqueRendezvous>> GpuCliqueRendezvous::Join(
-    const GpuCliqueKey& clique_key, RankId rank, std::any data) {
+    const GpuCliqueKey& clique_key, RankId rank, tsl::UniqueAny data) {
   if (!clique_key.is_local()) {
     return InvalidArgument(
         "GpuClique rendezvous is not supported for non-local cliques");
@@ -84,14 +84,14 @@ absl::StatusOr<std::shared_ptr<GpuCliqueRendezvous>> GpuCliqueRendezvous::Join(
   RankData rendezvous_value = {rank, std::move(data)};
 
   // A callback for rendezvous to construct the GpuCliqueRendezvous.
-  auto callback = [&](absl::Span<const RankData*> values) {
+  auto callback = [&](absl::Span<RankData*> values) {
     VLOG(3) << absl::StrFormat("[ranks=%s] Complete gpu clique rendezvous: %s",
                                absl::StrJoin(values, ",", RankFormatter{}),
                                clique_key.ToString());
 
-    absl::btree_map<RankId, std::any> data;
-    for (const auto* value : values) {
-      data[value->rank] = std::move(value->data);
+    absl::btree_map<RankId, tsl::UniqueAny> data;
+    for (auto* value : values) {
+      data.emplace(value->rank, std::move(value->data));
     }
 
     return GpuCliqueRendezvous(clique_key, std::move(data));

--- a/xla/backends/gpu/collectives/gpu_clique_rendezvous.h
+++ b/xla/backends/gpu/collectives/gpu_clique_rendezvous.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_COLLECTIVES_GPU_CLIQUE_RENDEZVOUS_H_
 #define XLA_BACKENDS_GPU_COLLECTIVES_GPU_CLIQUE_RENDEZVOUS_H_
 
-#include <any>
 #include <functional>
 #include <memory>
 
@@ -24,6 +23,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/core/collectives/rank_id.h"
+#include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
 
 namespace xla::gpu {
@@ -40,7 +40,7 @@ class GpuCliqueRendezvous {
   // rendezvous synchronization to ensure that all ranks arrive to the barrier.
   // The result is collectively owned by all participants.
   static absl::StatusOr<std::shared_ptr<GpuCliqueRendezvous>> Join(
-      const GpuCliqueKey& clique_key, RankId rank, std::any data);
+      const GpuCliqueKey& clique_key, RankId rank, tsl::UniqueAny data);
 
   // Returns the clique key associated with this rendezvous object.
   const GpuCliqueKey& clique_key() const { return clique_key_; }
@@ -54,20 +54,36 @@ class GpuCliqueRendezvous {
       return NotFound("Data not found for rank %d", rank.value());
     }
 
-    if (std::any_cast<T>(&it->second) == nullptr) {
+    const T* ptr = tsl::any_cast<T>(&it->second);
+    if (ptr == nullptr) {
       return InvalidArgument("Data type mismatch for rank %d", rank.value());
     }
 
-    const T& data = std::any_cast<const T&>(it->second);
-    return std::reference_wrapper<const T>(data);
+    return std::reference_wrapper<const T>(*ptr);
+  }
+
+  // Returns a mutable reference to the value at the given rank.
+  template <typename T>
+  absl::StatusOr<std::reference_wrapper<T>> at(RankId rank) {
+    auto it = values_.find(rank);
+    if (it == values_.end()) {
+      return NotFound("Data not found for rank %d", rank.value());
+    }
+
+    T* ptr = tsl::any_cast<T>(&it->second);
+    if (ptr == nullptr) {
+      return InvalidArgument("Data type mismatch for rank %d", rank.value());
+    }
+
+    return std::reference_wrapper<T>(*ptr);
   }
 
  private:
   GpuCliqueRendezvous(GpuCliqueKey clique_key,
-                      absl::btree_map<RankId, std::any> values);
+                      absl::btree_map<RankId, tsl::UniqueAny> values);
 
   GpuCliqueKey clique_key_;
-  absl::btree_map<RankId, std::any> values_;
+  absl::btree_map<RankId, tsl::UniqueAny> values_;
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/gpu_clique_rendezvous_test.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_rendezvous_test.cc
@@ -15,12 +15,11 @@ limitations under the License.
 
 #include "xla/backends/gpu/collectives/gpu_clique_rendezvous.h"
 
-#include <any>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/runtime/device_id.h"
@@ -42,8 +41,7 @@ TEST(GpuCliqueRendezvousTest, TwoParticipants) {
 
   auto task = [&](int32_t id) {
     return [&, id] {
-      auto rendezvous = GpuCliqueRendezvous::Join(key, RankId(id),
-                                                  std::make_any<int32_t>(id));
+      auto rendezvous = GpuCliqueRendezvous::Join(key, RankId(id), int32_t{id});
       ASSERT_OK(rendezvous);
 
       GpuCliqueRendezvous& data = **rendezvous;
@@ -56,6 +54,69 @@ TEST(GpuCliqueRendezvousTest, TwoParticipants) {
   auto thread_pool = CreateThreadPool(2);
   thread_pool.Schedule(task(0));
   thread_pool.Schedule(task(1));
+}
+
+TEST(GpuCliqueRendezvousTest, MoveOnlyType) {
+  using MoveOnly = std::unique_ptr<int32_t>;
+
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+
+  GpuCliqueKey key({id0, id1}, /*num_local_participants=*/2);
+
+  auto task = [&](int32_t id) {
+    return [&, id] {
+      auto rendezvous = GpuCliqueRendezvous::Join(
+          key, RankId(id), std::make_unique<int32_t>(id * 10));
+      ASSERT_OK(rendezvous);
+
+      GpuCliqueRendezvous& data = **rendezvous;
+      ASSERT_EQ(*data.at<MoveOnly>(RankId(0))->get(), 0);
+      ASSERT_EQ(*data.at<MoveOnly>(RankId(1))->get(), 10);
+    };
+  };
+
+  auto thread_pool = CreateThreadPool(2);
+  thread_pool.Schedule(task(0));
+  thread_pool.Schedule(task(1));
+}
+
+TEST(GpuCliqueRendezvousTest, ThreeParticipants) {
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+  GlobalDeviceId id2 = GlobalDeviceId(2);
+
+  GpuCliqueKey key({id0, id1, id2}, /*num_local_participants=*/3);
+
+  auto task = [&](int32_t id) {
+    return [&, id] {
+      auto rendezvous =
+          GpuCliqueRendezvous::Join(key, RankId(id), std::string(1, 'a' + id));
+      ASSERT_OK(rendezvous);
+
+      GpuCliqueRendezvous& data = **rendezvous;
+      ASSERT_EQ(data.at<std::string>(RankId(0))->get(), "a");
+      ASSERT_EQ(data.at<std::string>(RankId(1))->get(), "b");
+      ASSERT_EQ(data.at<std::string>(RankId(2))->get(), "c");
+    };
+  };
+
+  auto thread_pool = CreateThreadPool(3);
+  thread_pool.Schedule(task(0));
+  thread_pool.Schedule(task(1));
+  thread_pool.Schedule(task(2));
+}
+
+TEST(GpuCliqueRendezvousTest, NonLocalCliqueReturnsError) {
+  GlobalDeviceId id0 = GlobalDeviceId(0);
+  GlobalDeviceId id1 = GlobalDeviceId(1);
+
+  // num_local_participants < total participants → non-local clique
+  GpuCliqueKey key({id0, id1}, /*num_local_participants=*/1);
+
+  auto rendezvous = GpuCliqueRendezvous::Join(key, RankId(0), int32_t{42});
+  ASSERT_FALSE(rendezvous.ok());
+  EXPECT_THAT(rendezvous.status().message(), ::testing::HasSubstr("non-local"));
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_memory.cc
+++ b/xla/backends/gpu/runtime/collective_memory.cc
@@ -49,12 +49,12 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_executor.h"
 #include "xla/stream_executor/gpu/multicast_memory.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/safe_reinterpret_cast.h"
 #include "xla/tsl/util/tied_ref.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -322,7 +322,7 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
 
     // A callback for rendezvous to allocate and map the multicast memory. We
     // do one round of rendezvous for each clique.
-    auto allocate = [&](absl::Span<const RendezvousParams*> params)
+    auto allocate = [&](absl::Span<RendezvousParams*> params)
         -> absl::StatusOr<MappedMulticastMemoryMap> {
       // Sort all participants by rank to get deterministic execution.
       absl::c_sort(params, RankCmp{});
@@ -460,7 +460,7 @@ absl::StatusOr<PeerMemoryMap> AcquirePeerMemory(
 
     // A callback for rendezvous to exchange peer allocation addresses with
     // all participating ranks.
-    auto exchange = [&](absl::Span<const RendezvousParams*> params)
+    auto exchange = [&](absl::Span<RendezvousParams*> params)
         -> absl::StatusOr<PeerMemoryMap> {
       // Sort all participants by rank to get deterministic execution.
       absl::c_sort(params, RankCmp{});

--- a/xla/service/rendezvous.h
+++ b/xla/service/rendezvous.h
@@ -78,8 +78,8 @@ namespace xla {
 // make easy to debug stuck and timed out attempts.
 template <typename R, typename K, typename V, typename Fn>
 absl::StatusOr<std::shared_ptr<R>> Rendezvous(
-    absl::string_view name, const K& key, const V& value, size_t num_threads,
-    Fn fn, absl::Duration warn_stuck_timeout = absl::InfiniteDuration(),
+    absl::string_view name, const K& key, V& value, size_t num_threads, Fn fn,
+    absl::Duration warn_stuck_timeout = absl::InfiniteDuration(),
     absl::Duration terminate_timeout = absl::InfiniteDuration());
 
 // A rendezvous for a group of threads that do not have any value arguments.
@@ -205,7 +205,7 @@ struct RendezvousState : public RendezvousStateSynchronization {
   explicit RendezvousState(size_t n_threads)
       : RendezvousStateSynchronization(n_threads), values(n_threads, nullptr) {}
 
-  std::vector<const V*> values;
+  std::vector<V*> values;
   absl::StatusOr<std::shared_ptr<R>> result;
 };
 
@@ -271,12 +271,12 @@ void AwaitAndLogIfStuck(RendezvousStateSynchronization& state, int32_t id,
 }  // namespace internal
 
 //===----------------------------------------------------------------------===//
-// Rendezvous implemenetation.
+// Rendezvous implementation.
 //===----------------------------------------------------------------------===//
 
 template <typename R, typename V, typename Fn>
-absl::StatusOr<std::shared_ptr<R>> InvokeRendezvous(
-    Fn fn, absl::Span<const V*> values) {
+absl::StatusOr<std::shared_ptr<R>> InvokeRendezvous(Fn fn,
+                                                    absl::Span<V*> values) {
   auto result = fn(values);
 
   if constexpr (internal::IsStatusOrResult<decltype(result)>::value) {
@@ -292,16 +292,15 @@ absl::StatusOr<std::shared_ptr<R>> InvokeRendezvous(
 
 template <typename R, typename K, typename V, typename Fn>
 absl::StatusOr<std::shared_ptr<R>> Rendezvous(
-    absl::string_view name, const K& key, const V& value, size_t num_threads,
-    Fn fn, absl::Duration warn_stuck_timeout,
-    absl::Duration terminate_timeout) {
+    absl::string_view name, const K& key, V& value, size_t num_threads, Fn fn,
+    absl::Duration warn_stuck_timeout, absl::Duration terminate_timeout) {
   // Check that `fn` is callable with a span of values.
-  static_assert(std::is_invocable_v<Fn, absl::Span<const V*>>,
+  static_assert(std::is_invocable_v<Fn, absl::Span<V*>>,
                 "invalid rendezvous function signature");
 
   // Fast-path (DO NOT REMOVE: the logic below doesn't work for single thread).
   if (num_threads == 1) {
-    const V* ptr = &value;
+    V* ptr = &value;
     return InvokeRendezvous<R, V>(std::move(fn), absl::MakeSpan(&ptr, 1));
   }
 
@@ -350,7 +349,7 @@ absl::StatusOr<std::shared_ptr<R>> Rendezvous(
     // the mutex to create a memory barrier that makes access to `state->result`
     // safe without any extra synchronization.
     tsl::profiler::TraceMe trace("InvokeRendezvous");
-    absl::Span<const V*> values(state->values.data(), num_threads);
+    absl::Span<V*> values(state->values.data(), num_threads);
 
     // Check that we have have exactly the number of participants we expect.
     CHECK_EQ(state.use_count(), num_threads)
@@ -376,8 +375,9 @@ template <typename R, typename K, typename Fn>
 absl::StatusOr<std::shared_ptr<R>> Rendezvous(
     absl::string_view name, const K& key, size_t num_threads, Fn fn,
     absl::Duration warn_stuck_timeout, absl::Duration terminate_timeout) {
+  std::nullopt_t nothing = std::nullopt;
   return Rendezvous<R, K, std::nullopt_t>(
-      name, key, std::nullopt, num_threads, [fn](auto) { return fn(); },
+      name, key, nothing, num_threads, [fn](auto) { return fn(); },
       warn_stuck_timeout, terminate_timeout);
 }
 
@@ -385,10 +385,10 @@ template <typename K>
 absl::Status Rendezvous(absl::string_view name, const K& key,
                         size_t num_threads, absl::Duration warn_stuck_timeout,
                         absl::Duration terminate_timeout) {
+  std::nullopt_t nothing = std::nullopt;
   return Rendezvous<std::nullopt_t, K, std::nullopt_t>(
-             name, key, std::nullopt, num_threads,
-             [](auto) { return std::nullopt; }, warn_stuck_timeout,
-             terminate_timeout)
+             name, key, nothing, num_threads, [](auto) { return std::nullopt; },
+             warn_stuck_timeout, terminate_timeout)
       .status();
 }
 

--- a/xla/service/rendezvous_test.cc
+++ b/xla/service/rendezvous_test.cc
@@ -77,14 +77,14 @@ TEST(RendezvousTest, TwoParticipantsWithValues) {
   absl::BlockingCounter counter(2);
   std::vector<std::shared_ptr<int32_t>> results(2);
 
-  auto accumulate = [](absl::Span<const int32_t* const> values) {
+  auto accumulate = [](absl::Span<int32_t*> values) {
     int32_t result = 0;
     for (const int32_t* value : values) result += *value;
     return result;
   };
 
   auto task = [&](int32_t id) {
-    return [&, id] {
+    return [&, id]() mutable {
       TF_ASSERT_OK_AND_ASSIGN(
           results[id],
           Rendezvous<int32_t>("rendezvous_test", 0, id, 2, accumulate));


### PR DESCRIPTION
Exchanging cost references is too limiting, some times we want to move local state into shared rendezvous result. Drop const qualifier from values passed to rendezvous!

Also use `tsl::UniqueAny` in `GpuCliqueRendezvous` to allow exchanging move-only values that can be moved-from