### PR TITLE
[ROCm] Enable scaled dot for ROCm.

### DIFF
--- a/xla/backends/gpu/autotuner/hipblaslt.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt.cc
@@ -119,15 +119,6 @@ bool IsValidMxScaledDot(const HloInstruction* scaled_dot) {
     return false;
   }
 
-  int64_t batch_size = 1;
-  for (int64_t dim : dot_dims.lhs_batch_dimensions()) {
-    batch_size *= lhs_shape.dimensions(dim);
-  }
-  if (batch_size != 1) {
-    VLOG(2) << "hipBLASLt MX: batch_size > 1 not supported, got " << batch_size;
-    return false;
-  }
-
   int64_t m = 1;
   for (int64_t i = 0; i < lhs_shape.dimensions().size(); ++i) {
     if (!absl::c_linear_search(dot_dims.lhs_batch_dimensions(), i) &&

--- a/xla/backends/gpu/autotuner/triton.cc
+++ b/xla/backends/gpu/autotuner/triton.cc
@@ -119,13 +119,6 @@ TritonBackend::GetSupportedConfigs(const HloInstruction& instr) {
       hlo_query::GetFirstInstructionWithOpcode(
           *instr.fused_instructions_computation(), HloOpcode::kScaledDot);
   if (scaled_dot_instr != nullptr) {
-    // Triton scaled dot emitter is not supported on ROCm; skip to allow
-    // other backends (e.g. HipblasLtBackend) to handle kScaledDot.
-    const auto& gpu_cc =
-        target_config().device_description.gpu_compute_capability();
-    if (gpu_cc.IsRocm()) {
-      return std::vector<std::unique_ptr<BackendConfig>>();
-    }
     return GetSupportedConfigsForScaledDot(scaled_dot_instr);
   }
   return std::vector<std::unique_ptr<BackendConfig>>();

--- a/xla/backends/gpu/autotuner/triton_test.cc
+++ b/xla/backends/gpu/autotuner/triton_test.cc
@@ -166,9 +166,6 @@ TEST_F(TritonBackendTest, GetSupportedConfigs) {
 }
 
 TEST_F(TritonBackendTest, GetSupportedConfigsForScaledDot) {
-  if (target_config_.device_description.gpu_compute_capability().IsRocm()) {
-    GTEST_SKIP() << "Triton scaled dot not supported on ROCm.";
-  }
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kScaledDotHlo));
   HloInstruction* fusion_instr =
@@ -180,9 +177,6 @@ TEST_F(TritonBackendTest, GetSupportedConfigsForScaledDot) {
 }
 
 TEST_F(TritonBackendTest, GetAndApplyConfigForScaledDot) {
-  if (target_config_.device_description.gpu_compute_capability().IsRocm()) {
-    GTEST_SKIP() << "Triton scaled dot not supported on ROCm.";
-  }
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kScaledDotHlo));
   HloInstruction* fusion_instr =
@@ -449,10 +443,6 @@ TEST_F(TritonBackendTest, VerifyHopperConfigsAreDifferentFromBlackwell) {
 }
 
 TEST_F(TritonBackendTest, ScaledDotConfigsAreGenerated) {
-  if (target_config_.device_description.gpu_compute_capability().IsRocm()) {
-    GTEST_SKIP() << "Not supported on ROCm.";
-  }
-
   se::CudaComputeCapability blackwell_cap{se::CudaComputeCapability::kBlackwell,
                                           /*minor=*/0};
   target_config_.device_description.set_gpu_compute_capability(

--- a/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_convert_unsupported_types.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/triton_xla_convert_unsupported_types.mlir
@@ -27,6 +27,20 @@ module {
     %17 = arith.bitcast %extracted_tile_2 : tensor<1x16xf8E8M0FNU> to tensor<1x16xi8>
     %18 = tt.trans %17 {order = array<i32: 1, 0>} : tensor<1x16xi8> -> tensor<16x1xi8>
     %19 = tt.dot_scaled %extracted_tile scale %16, %extracted_tile_1 scale %18, %cst lhs = e4m3 rhs = e4m3 {fastMath = true} : tensor<16x32xf8E4M3FN>, tensor<16x1xi8> * tensor<32x16xf8E4M3FN>, tensor<16x1xi8> -> tensor<16x16xf32>
+    // arith.constant with f8E8M0FNU dense → i8
+    %cst_scale = arith.constant dense<5.877470e-39> : tensor<16x1xf8E8M0FNU>
+    // CHECK-DAG: %[[CST_SCALE:.*]] = arith.constant dense<0> : tensor<16x1xi8>
+    // tensor.extract from 0-d f8E8M0FNU tensor → i8
+    %cst_scalar = arith.constant dense<5.877470e-39> : tensor<f8E8M0FNU>
+    // CHECK-DAG: %[[CST_SCALAR:.*]] = arith.constant dense<0> : tensor<i8>
+    %extracted_scalar = tensor.extract %cst_scalar[] : tensor<f8E8M0FNU>
+    // CHECK: %[[EXTRACTED:.*]] = tensor.extract %[[CST_SCALAR]][] : tensor<i8>
+    // arith.select with f8E8M0FNU operands → i8 (mask derived from
+    // non-constant values to prevent constant folding)
+    %mask = arith.cmpi sge, %16, %18 : tensor<16x1xi8>
+    // CHECK: %[[MASK:.*]] = arith.cmpi sge, {{.*}} : tensor<16x1xi8>
+    %selected = arith.select %mask, %extracted_tile_0, %cst_scale : tensor<16x1xi1>, tensor<16x1xf8E8M0FNU>
+    // CHECK: %[[SELECTED:.*]] = arith.select %[[MASK]], %[[arg_1]], %[[CST_SCALE]] : tensor<16x1xi1>, tensor<16x1xi8>
     xtile.return
   }
 }

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_convert_unsupported_types.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_convert_unsupported_types.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "llvm/Support/Casting.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -62,6 +63,29 @@ struct GenericOpConversionPattern final : public OpConversionPattern<OpType> {
       result.setType(converter->convertType(result.getType()));
     }
     rewriter.replaceOp(op, replacement);
+    return success();
+  }
+};
+
+struct ConstantOpConversionPattern final
+    : public OpConversionPattern<arith::ConstantOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      arith::ConstantOp op, arith::ConstantOp::Adaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Type new_type = getTypeConverter()->convertType(op.getType());
+    if (new_type == op.getType()) {
+      return failure();
+    }
+    auto dense_attr = llvm::dyn_cast<DenseElementsAttr>(op.getValue());
+    if (!dense_attr) {
+      return failure();
+    }
+    auto new_shaped_type = llvm::cast<ShapedType>(new_type);
+    auto new_attr = DenseElementsAttr::getFromRawBuffer(
+        new_shaped_type, dense_attr.getRawData());
+    rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, new_attr);
     return success();
   }
 };
@@ -140,14 +164,18 @@ class TritonXLAConvertUnsupportedTypesPass
     RewritePatternSet patterns(ctx);
     patterns.add<
         // go/keep-sorted start
+        ConstantOpConversionPattern,
         GenericOpConversionPattern<::xla::xtile::ExtractTileOp>,
         GenericOpConversionPattern<::xla::xtile::InsertTileOp>,
         GenericOpConversionPattern<BroadcastOp>,
         GenericOpConversionPattern<DotScaledOp>,
         GenericOpConversionPattern<ExpandDimsOp>,
         GenericOpConversionPattern<ReshapeOp>,
+        GenericOpConversionPattern<SplatOp>,
         GenericOpConversionPattern<TransOp>,
-        GenericOpConversionPattern<arith::BitcastOp>
+        GenericOpConversionPattern<arith::BitcastOp>,
+        GenericOpConversionPattern<arith::SelectOp>,
+        GenericOpConversionPattern<tensor::ExtractOp>
         // go/keep-sorted end
         >(converter, ctx);
     scf::populateSCFStructuralTypeConversions(converter, patterns);


### PR DESCRIPTION
📝 Summary of Changes
Enable scaled dot on ROCm, updated corresponding unit tests.

🎯 Justification
supported by triton and hipblaslt

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
//xla/backends/gpu/autotuner:triton_test_amdgpu_any
//xla/backends/gpu/autotuner:hipblaslt_test_amdgpu_any

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
