### PR TITLE
[XLA:GPU] Implement PutSignal, Signal, and WaitSignal on NcclCommunicator

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -294,6 +294,7 @@ xla_cc_test(
         ":gpu_clique_key",
         ":gpu_collectives",
         ":gpu_communicator",
+        ":nccl_communicator",
         ":nccl_or_rccl_collectives",
         "//xla:future",
         "//xla:xla_data_proto_cc",

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -294,7 +294,6 @@ xla_cc_test(
         ":gpu_clique_key",
         ":gpu_collectives",
         ":gpu_communicator",
-        ":nccl_communicator",
         ":nccl_or_rccl_collectives",
         "//xla:future",
         "//xla:xla_data_proto_cc",

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -147,6 +147,10 @@ class GpuCollectives : public Collectives {
   // Returns true if GPU collectives support device-initiated communication.
   virtual bool SupportsDeviceComm() const { return false; }
 
+  // Returns true iff communicator supports one-sided RMA operations
+  // (PutSignal, Signal, WaitSignal).
+  virtual bool SupportsOneSidedComm() const { return false; }
+
   // Returns minimum alignment requirement for symmetric memory.
   virtual size_t SymmetricMemoryAlignment() const { return 1; }
 

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -147,8 +147,9 @@ class GpuCollectives : public Collectives {
   // Returns true if GPU collectives support device-initiated communication.
   virtual bool SupportsDeviceComm() const { return false; }
 
-  // Returns true iff communicator supports one-sided RMA operations
-  // (PutSignal, Signal, WaitSignal).
+  // Returns true iff the one-sided RMA API (PutSignal, Signal, WaitSignal) is
+  // available. This is a compile-time check; it does not guarantee that the
+  // communicator topology supports host RMA at runtime.
   virtual bool SupportsOneSidedComm() const { return false; }
 
   // Returns minimum alignment requirement for symmetric memory.

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
+#include "xla/backends/gpu/collectives/nccl_communicator.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/communicator.h"
@@ -451,6 +452,105 @@ TEST_P(GpuAbortCollectivesTest, Abort) {
 
 INSTANTIATE_TEST_SUITE_P(GpuAbortCollectives, GpuAbortCollectivesTest,
                          testing::Values(true, false));
+
+#if NCCL_VERSION_CODE >= 22900
+
+TEST(GpuCollectivesTest, PutAndWaitSignal) {
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       se::PlatformManager::PlatformWithName("CUDA"));
+
+  if (platform->VisibleDeviceCount() < 2) {
+    GTEST_SKIP() << "Test requires at least 2 GPUs";
+  }
+
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                       CreateExecutors(platform, 2));
+
+  if (!executors[0]->CanEnablePeerAccessTo(executors[1])) {
+    GTEST_SKIP() << "Test requires peer access between devices";
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto comms, CreateCommunicators(executors, {kD0, kD1}));
+
+  if (!absl::c_all_of(comms, [](auto& c) { return c->SupportsDeviceComm(); })) {
+    GTEST_SKIP() << "GPU communicators do not support symmetric memory";
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto allocators, CreateMemoryAllocators(executors));
+
+  constexpr size_t kNumFloats = 4;
+  constexpr size_t kNumBytes = kNumFloats * sizeof(float);
+
+  ASSERT_OK_AND_ASSIGN(auto send_allocs, Allocate(allocators, kNumBytes));
+  ASSERT_OK_AND_ASSIGN(auto recv_allocs, Allocate(allocators, kNumBytes));
+
+  ASSERT_OK_AND_ASSIGN(auto stream0, executors[0]->CreateStream());
+  ASSERT_OK_AND_ASSIGN(auto stream1, executors[1]->CreateStream());
+
+  float h_send0[] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float h_send1[] = {5.0f, 6.0f, 7.0f, 8.0f};
+
+  se::DeviceAddressBase send0_addr = send_allocs[0]->address();
+  se::DeviceAddressBase send1_addr = send_allocs[1]->address();
+  se::DeviceAddressBase recv0_addr = recv_allocs[0]->address();
+  se::DeviceAddressBase recv1_addr = recv_allocs[1]->address();
+
+  ASSERT_OK(stream0->Memcpy(&send0_addr, h_send0, kNumBytes));
+  ASSERT_OK(stream1->Memcpy(&send1_addr, h_send1, kNumBytes));
+  ASSERT_OK(stream0->MemZero(&recv0_addr, kNumBytes));
+  ASSERT_OK(stream1->MemZero(&recv1_addr, kNumBytes));
+  ASSERT_OK(stream0->BlockHostUntilDone());
+  ASSERT_OK(stream1->BlockHostUntilDone());
+
+  tsl::thread::ThreadPool pool(tsl::Env::Default(), "collectives", 2);
+  tsl::Executor& exec = *pool.AsExecutor();
+
+  auto fsymm_send = CreateSymmetricMemory(exec, comms, send_allocs);
+  ASSERT_OK_AND_ASSIGN(auto symm_send,
+                       AwaitSymmetricMemory(std::move(fsymm_send)));
+
+  auto fsymm_recv = CreateSymmetricMemory(exec, comms, recv_allocs);
+  ASSERT_OK_AND_ASSIGN(auto symm_recv,
+                       AwaitSymmetricMemory(std::move(fsymm_recv)));
+
+  NcclSignalDesc signal_desc(0, 0);
+
+  auto f0 = MakeFutureOn<void>(exec, [&]() -> absl::Status {
+    GpuCollectives::Executor gpu_exec(stream0.get());
+    TF_RETURN_IF_ERROR(comms[0]
+                           ->Put(send0_addr, symm_recv[0].get(), 0, kNumBytes,
+                                 RankId(1), gpu_exec)
+                           .Await());
+    return comms[0]->WaitSignal(RankId(1), 1, signal_desc, gpu_exec).Await();
+  });
+
+  auto f1 = MakeFutureOn<void>(exec, [&]() -> absl::Status {
+    GpuCollectives::Executor gpu_exec(stream1.get());
+    TF_RETURN_IF_ERROR(comms[1]
+                           ->Put(send1_addr, symm_recv[1].get(), 0, kNumBytes,
+                                 RankId(0), gpu_exec)
+                           .Await());
+    return comms[1]->WaitSignal(RankId(0), 1, signal_desc, gpu_exec).Await();
+  });
+
+  ASSERT_OK(f0.Await());
+  ASSERT_OK(f1.Await());
+
+  ASSERT_OK(stream0->BlockHostUntilDone());
+  ASSERT_OK(stream1->BlockHostUntilDone());
+
+  float h_recv0[kNumFloats];
+  float h_recv1[kNumFloats];
+  ASSERT_OK(stream0->Memcpy(h_recv0, recv0_addr, kNumBytes));
+  ASSERT_OK(stream1->Memcpy(h_recv1, recv1_addr, kNumBytes));
+  ASSERT_OK(stream0->BlockHostUntilDone());
+  ASSERT_OK(stream1->BlockHostUntilDone());
+
+  EXPECT_THAT(h_recv0, testing::ElementsAre(5.0f, 6.0f, 7.0f, 8.0f));
+  EXPECT_THAT(h_recv1, testing::ElementsAre(1.0f, 2.0f, 3.0f, 4.0f));
+}
+
+#endif  // NCCL_VERSION_CODE >= 22900
 
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -453,8 +453,6 @@ TEST_P(GpuAbortCollectivesTest, Abort) {
 INSTANTIATE_TEST_SUITE_P(GpuAbortCollectives, GpuAbortCollectivesTest,
                          testing::Values(true, false));
 
-#if NCCL_VERSION_CODE >= 22900
-
 TEST(GpuCollectivesTest, PutAndWaitSignal) {
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
                        se::PlatformManager::PlatformWithName("CUDA"));
@@ -472,8 +470,9 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
 
   ASSERT_OK_AND_ASSIGN(auto comms, CreateCommunicators(executors, {kD0, kD1}));
 
-  if (!absl::c_all_of(comms, [](auto& c) { return c->SupportsDeviceComm(); })) {
-    GTEST_SKIP() << "GPU communicators do not support symmetric memory";
+  if (!absl::c_all_of(comms,
+                      [](auto& c) { return c->SupportsOneSidedComm(); })) {
+    GTEST_SKIP() << "GPU communicators do not support one-sided RMA";
   }
 
   ASSERT_OK_AND_ASSIGN(auto allocators, CreateMemoryAllocators(executors));
@@ -549,8 +548,6 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
   EXPECT_THAT(h_recv0, testing::ElementsAre(5.0f, 6.0f, 7.0f, 8.0f));
   EXPECT_THAT(h_recv1, testing::ElementsAre(1.0f, 2.0f, 3.0f, 4.0f));
 }
-
-#endif  // NCCL_VERSION_CODE >= 22900
 
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -31,7 +31,6 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
-#include "xla/backends/gpu/collectives/nccl_communicator.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/communicator.h"
@@ -512,7 +511,7 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
   ASSERT_OK_AND_ASSIGN(auto symm_recv,
                        AwaitSymmetricMemory(std::move(fsymm_recv)));
 
-  NcclSignalDesc signal_desc(0, 0);
+  GpuSignalDesc signal_desc(0, 0);
 
   auto f0 = MakeFutureOn<void>(exec, [&]() -> absl::Status {
     GpuCollectives::Executor gpu_exec(stream0.get());

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -468,12 +468,12 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
     GTEST_SKIP() << "Test requires peer access between devices";
   }
 
-  ASSERT_OK_AND_ASSIGN(auto comms, CreateCommunicators(executors, {kD0, kD1}));
-
-  if (!absl::c_all_of(comms,
-                      [](auto& c) { return c->SupportsOneSidedComm(); })) {
-    GTEST_SKIP() << "GPU communicators do not support one-sided RMA";
+  GpuCollectives* collectives = GpuCollectives::Default("GPU");
+  if (!collectives->SupportsOneSidedComm()) {
+    GTEST_SKIP() << "GPU collectives do not support one-sided RMA";
   }
+
+  ASSERT_OK_AND_ASSIGN(auto comms, CreateCommunicators(executors, {kD0, kD1}));
 
   ASSERT_OK_AND_ASSIGN(auto allocators, CreateMemoryAllocators(executors));
 

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -120,6 +120,10 @@ class GpuCommunicator : public Communicator {
   // Returns true iff communicator supports device-initiated communication.
   virtual bool SupportsDeviceComm() const { return false; }
 
+  // Returns true iff communicator supports one-sided RMA operations
+  // (PutSignal, Signal, WaitSignal).
+  virtual bool SupportsOneSidedComm() const { return false; }
+
   // Creates a new device communicator linked to *this GPU communicator object.
   virtual absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>>
   CreateDeviceComm(const GpuDeviceCommunicator::Requirements& requirements) {

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -120,8 +120,9 @@ class GpuCommunicator : public Communicator {
   // Returns true iff communicator supports device-initiated communication.
   virtual bool SupportsDeviceComm() const { return false; }
 
-  // Returns true iff communicator supports one-sided RMA operations
-  // (PutSignal, Signal, WaitSignal).
+  // Returns true iff one-sided RMA operations (PutSignal, Signal, WaitSignal)
+  // are supported by this communicator. Implementations may query the
+  // underlying communicator properties to determine topology-dependent support.
   virtual bool SupportsOneSidedComm() const { return false; }
 
   // Creates a new device communicator linked to *this GPU communicator object.

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -39,6 +39,17 @@ limitations under the License.
 
 namespace xla::gpu {
 
+class GpuSignalDesc : public Communicator::SignalDesc {
+ public:
+  GpuSignalDesc(int sig_idx, int ctx) : sig_idx_(sig_idx), ctx_(ctx) {}
+  int sig_idx() const { return sig_idx_; }
+  int ctx() const { return ctx_; }
+
+ private:
+  int sig_idx_;
+  int ctx_;
+};
+
 // Platform-specific handle to the underlying communicator implementation. It
 // allows exporting collective communication primitives created and owned by
 // the XLA runtime to external libraries, for example via FFI calls.

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -59,12 +59,12 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 #include "tsl/platform/numbers.h"
 #include "tsl/profiler/lib/traceme.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -233,6 +233,10 @@ absl::StatusOr<CliqueId> NcclCollectives::CreateUniqueCliqueId() const {
 
 bool NcclCollectives::SupportsDeviceComm() const {
   return NCCL_VERSION_CODE >= 22800;
+}
+
+bool NcclCollectives::SupportsOneSidedComm() const {
+  return NCCL_VERSION_CODE >= 22900;
 }
 
 size_t NcclCollectives::SymmetricMemoryAlignment() const {

--- a/xla/backends/gpu/collectives/nccl_collectives.h
+++ b/xla/backends/gpu/collectives/nccl_collectives.h
@@ -42,6 +42,7 @@ class NcclCollectives : public GpuCollectives {
   bool IsImplemented() const final { return true; }
 
   bool SupportsDeviceComm() const final;
+  bool SupportsOneSidedComm() const final;
 
   size_t SymmetricMemoryAlignment() const final;
 

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -251,6 +251,14 @@ bool NcclCommunicator::SupportsDeviceComm() const {
 #endif  // NCCL_VERSION_CODE >= 22800
 }
 
+bool NcclCommunicator::SupportsOneSidedComm() const {
+#if NCCL_VERSION_CODE >= 22900
+  return true;
+#else
+  return false;
+#endif  // NCCL_VERSION_CODE >= 22900
+}
+
 absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>>
 NcclCommunicator::CreateDeviceComm(
     const GpuDeviceCommunicator::Requirements& requirements) {
@@ -963,7 +971,10 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
                                          size_t offset, size_t count,
                                          RankId peer,
                                          const Executor& executor) {
-#if NCCL_VERSION_CODE >= 22900
+  if (!SupportsOneSidedComm()) {
+    return Unimplemented("Put requires NCCL >= 2.29.0 (current: %d)",
+                         NCCL_VERSION_CODE);
+  }
   if (cancel_->IsCancelled()) {
     return FailedPrecondition("NcclCommunicator aborted");
   }
@@ -977,23 +988,24 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
       stream->parent()->device_ordinal(), send_buffer.opaque(), peer_win,
       offset, count, peer.value(), comm_, stream);
 
-  TF_RETURN_IF_ERROR(XLA_NCCL_STATUS(ncclPutSignal(
-      send_buffer.opaque(), count, ncclInt8, peer.value(), peer_win.win(),
-      offset, 0, 0, 0, comm_, AsCudaStream(stream))));
+#if NCCL_VERSION_CODE >= 22900
+  XLA_NCCL_RETURN_IF_ERROR(ncclPutSignal(send_buffer.opaque(), count, ncclInt8,
+                                         peer.value(), peer_win.win(), offset,
+                                         0, 0, 0, comm_, AsCudaStream(stream)));
+#endif
   if (group_nesting_level_ == 0) {
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
-#else
-  return Unimplemented("NCCL PutSignal requires NCCL >= 2.29.0 (current: %d)",
-                       NCCL_VERSION_CODE);
-#endif
 }
 
 absl::Status NcclCommunicator::LaunchSignal(RankId peer,
                                             const SignalDesc& signal_desc,
                                             const Executor& executor) {
-#if NCCL_VERSION_CODE >= 22900
+  if (!SupportsOneSidedComm()) {
+    return Unimplemented("Signal requires NCCL >= 2.29.0 (current: %d)",
+                         NCCL_VERSION_CODE);
+  }
   if (cancel_->IsCancelled()) {
     return FailedPrecondition("NcclCommunicator aborted");
   }
@@ -1007,23 +1019,24 @@ absl::Status NcclCommunicator::LaunchSignal(RankId peer,
       stream->parent()->device_ordinal(), peer.value(), nccl_desc.sig_idx(),
       nccl_desc.ctx(), comm_, stream);
 
-  TF_RETURN_IF_ERROR(XLA_NCCL_STATUS(
-      ncclSignal(peer.value(), nccl_desc.sig_idx(), nccl_desc.ctx(), 0, comm_,
-                 AsCudaStream(stream))));
+#if NCCL_VERSION_CODE >= 22900
+  XLA_NCCL_RETURN_IF_ERROR(ncclSignal(peer.value(), nccl_desc.sig_idx(),
+                                      nccl_desc.ctx(), 0, comm_,
+                                      AsCudaStream(stream)));
+#endif
   if (group_nesting_level_ == 0) {
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
-#else
-  return Unimplemented("NCCL Signal requires NCCL >= 2.29.0 (current: %d)",
-                       NCCL_VERSION_CODE);
-#endif
 }
 
 absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
                                                 const SignalDesc& signal_desc,
                                                 const Executor& executor) {
-#if NCCL_VERSION_CODE >= 22900
+  if (!SupportsOneSidedComm()) {
+    return Unimplemented("WaitSignal requires NCCL >= 2.29.0 (current: %d)",
+                         NCCL_VERSION_CODE);
+  }
   if (cancel_->IsCancelled()) {
     return FailedPrecondition("NcclCommunicator aborted");
   }
@@ -1037,22 +1050,20 @@ absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
       stream->parent()->device_ordinal(), peer.value(), op_cnt,
       nccl_desc.sig_idx(), nccl_desc.ctx(), comm_, stream);
 
+#if NCCL_VERSION_CODE >= 22900
   ncclWaitSignalDesc_t desc;
   desc.peer = peer.value();
   desc.opCnt = op_cnt;
   desc.sigIdx = nccl_desc.sig_idx();
   desc.ctx = nccl_desc.ctx();
 
-  TF_RETURN_IF_ERROR(
-      XLA_NCCL_STATUS(ncclWaitSignal(1, &desc, comm_, AsCudaStream(stream))));
+  XLA_NCCL_RETURN_IF_ERROR(
+      ncclWaitSignal(1, &desc, comm_, AsCudaStream(stream)));
+#endif
   if (group_nesting_level_ == 0) {
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
-#else
-  return Unimplemented("NCCL WaitSignal requires NCCL >= 2.29.0 (current: %d)",
-                       NCCL_VERSION_CODE);
-#endif
 }
 
 std::string NcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -252,11 +252,17 @@ bool NcclCommunicator::SupportsDeviceComm() const {
 }
 
 bool NcclCommunicator::SupportsOneSidedComm() const {
-#if NCCL_VERSION_CODE >= 22900
+#if NCCL_VERSION_CODE >= 22907
+  ncclCommProperties_t props = NCCL_COMM_PROPERTIES_INITIALIZER;
+  if (ncclCommQueryProperties(comm_, &props) == ncclSuccess) {
+    return props.hostRmaSupport;
+  }
+  return false;
+#elif NCCL_VERSION_CODE >= 22900
   return true;
 #else
   return false;
-#endif  // NCCL_VERSION_CODE >= 22900
+#endif
 }
 
 absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>>

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -998,6 +998,8 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
   XLA_NCCL_RETURN_IF_ERROR(ncclPutSignal(send_buffer.opaque(), count, ncclInt8,
                                          peer.value(), peer_win.win(), offset,
                                          0, 0, 0, comm_, AsCudaStream(stream)));
+#else
+  return Unimplemented("Put requires NCCL >= 2.29.0");
 #endif
   if (group_nesting_level_ == 0) {
     TF_RETURN_IF_ERROR(PollUntilDone());
@@ -1017,7 +1019,7 @@ absl::Status NcclCommunicator::LaunchSignal(RankId peer,
   }
   se::Stream* stream = ToStream(executor);
 
-  const auto& nccl_desc = tsl::down_cast<const NcclSignalDesc&>(signal_desc);
+  const auto& nccl_desc = tsl::down_cast<const GpuSignalDesc&>(signal_desc);
 
   VLOG(3) << absl::StreamFormat(
       "[%d] Launch NCCL Signal operation; peer=%d; sig_idx=%d; ctx=%d; "
@@ -1029,6 +1031,8 @@ absl::Status NcclCommunicator::LaunchSignal(RankId peer,
   XLA_NCCL_RETURN_IF_ERROR(ncclSignal(peer.value(), nccl_desc.sig_idx(),
                                       nccl_desc.ctx(), 0, comm_,
                                       AsCudaStream(stream)));
+#else
+  return Unimplemented("Signal requires NCCL >= 2.29.0");
 #endif
   if (group_nesting_level_ == 0) {
     TF_RETURN_IF_ERROR(PollUntilDone());
@@ -1048,7 +1052,7 @@ absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
   }
   se::Stream* stream = ToStream(executor);
 
-  const auto& nccl_desc = tsl::down_cast<const NcclSignalDesc&>(signal_desc);
+  const auto& nccl_desc = tsl::down_cast<const GpuSignalDesc&>(signal_desc);
 
   VLOG(3) << absl::StreamFormat(
       "[%d] Launch NCCL WaitSignal operation; peer=%d; op_cnt=%d; "
@@ -1065,6 +1069,8 @@ absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
 
   XLA_NCCL_RETURN_IF_ERROR(
       ncclWaitSignal(1, &desc, comm_, AsCudaStream(stream)));
+#else
+  return Unimplemented("WaitSignal requires NCCL >= 2.29.0");
 #endif
   if (group_nesting_level_ == 0) {
     TF_RETURN_IF_ERROR(PollUntilDone());

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -963,19 +963,96 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
                                          size_t offset, size_t count,
                                          RankId peer,
                                          const Executor& executor) {
-  return Unimplemented("NCCL Put is not yet implemented");
+#if NCCL_VERSION_CODE >= 22900
+  if (cancel_->IsCancelled()) {
+    return FailedPrecondition("NcclCommunicator aborted");
+  }
+  se::Stream* stream = ToStream(executor);
+
+  auto& peer_win = tsl::down_cast<NcclSymmetricMemory&>(*recv_buffer);
+
+  VLOG(3) << absl::StreamFormat(
+      "[%d] Launch NCCL Put operation; send_buffer=%p; peer_win=%v; "
+      "offset=%d; count=%d; peer=%d; comm=%p; stream=%p",
+      stream->parent()->device_ordinal(), send_buffer.opaque(), peer_win,
+      offset, count, peer.value(), comm_, stream);
+
+  TF_RETURN_IF_ERROR(XLA_NCCL_STATUS(ncclPutSignal(
+      send_buffer.opaque(), count, ncclInt8, peer.value(), peer_win.win(),
+      offset, 0, 0, 0, comm_, AsCudaStream(stream))));
+  if (group_nesting_level_ == 0) {
+    TF_RETURN_IF_ERROR(PollUntilDone());
+  }
+  return absl::OkStatus();
+#else
+  return Unimplemented("NCCL PutSignal requires NCCL >= 2.29.0 (current: %d)",
+                       NCCL_VERSION_CODE);
+#endif
 }
 
 absl::Status NcclCommunicator::LaunchSignal(RankId peer,
                                             const SignalDesc& signal_desc,
                                             const Executor& executor) {
-  return Unimplemented("NCCL Signal is not yet implemented");
+#if NCCL_VERSION_CODE >= 22900
+  if (cancel_->IsCancelled()) {
+    return FailedPrecondition("NcclCommunicator aborted");
+  }
+  se::Stream* stream = ToStream(executor);
+
+  const auto& nccl_desc = tsl::down_cast<const NcclSignalDesc&>(signal_desc);
+
+  VLOG(3) << absl::StreamFormat(
+      "[%d] Launch NCCL Signal operation; peer=%d; sig_idx=%d; ctx=%d; "
+      "comm=%p; stream=%p",
+      stream->parent()->device_ordinal(), peer.value(), nccl_desc.sig_idx(),
+      nccl_desc.ctx(), comm_, stream);
+
+  TF_RETURN_IF_ERROR(XLA_NCCL_STATUS(
+      ncclSignal(peer.value(), nccl_desc.sig_idx(), nccl_desc.ctx(), 0, comm_,
+                 AsCudaStream(stream))));
+  if (group_nesting_level_ == 0) {
+    TF_RETURN_IF_ERROR(PollUntilDone());
+  }
+  return absl::OkStatus();
+#else
+  return Unimplemented("NCCL Signal requires NCCL >= 2.29.0 (current: %d)",
+                       NCCL_VERSION_CODE);
+#endif
 }
 
 absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
                                                 const SignalDesc& signal_desc,
                                                 const Executor& executor) {
-  return Unimplemented("NCCL WaitSignal is not yet implemented");
+#if NCCL_VERSION_CODE >= 22900
+  if (cancel_->IsCancelled()) {
+    return FailedPrecondition("NcclCommunicator aborted");
+  }
+  se::Stream* stream = ToStream(executor);
+
+  const auto& nccl_desc = tsl::down_cast<const NcclSignalDesc&>(signal_desc);
+
+  VLOG(3) << absl::StreamFormat(
+      "[%d] Launch NCCL WaitSignal operation; peer=%d; op_cnt=%d; "
+      "sig_idx=%d; ctx=%d; comm=%p; stream=%p",
+      stream->parent()->device_ordinal(), peer.value(), op_cnt,
+      nccl_desc.sig_idx(), nccl_desc.ctx(), comm_, stream);
+
+  ncclWaitSignalDesc_t desc;
+  desc.peer = peer.value();
+  desc.opCnt = op_cnt;
+  desc.sigIdx = nccl_desc.sig_idx();
+  desc.ctx = nccl_desc.ctx();
+
+  TF_RETURN_IF_ERROR(
+      XLA_NCCL_STATUS(ncclWaitSignal(1, &desc, comm_, AsCudaStream(stream))));
+  if (group_nesting_level_ == 0) {
+    TF_RETURN_IF_ERROR(PollUntilDone());
+  }
+  return absl::OkStatus();
+#else
+  return Unimplemented("NCCL WaitSignal requires NCCL >= 2.29.0 (current: %d)",
+                       NCCL_VERSION_CODE);
+#endif
 }
 
 std::string NcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -52,7 +52,7 @@ limitations under the License.
 #if NCCL_VERSION_CODE >= 22800
 // Device initiated collective operations were added in NCCL 2.28.0.
 #include "third_party/nccl/nccl_device.h"  // IWYU pragma: keep
-#endif                                          // NCCL_VERSION_CODE >= 22800
+#endif                                     // NCCL_VERSION_CODE >= 22800
 
 namespace xla::gpu {
 
@@ -102,6 +102,7 @@ class NcclCommunicator : public GpuCommunicator {
   }
 
   bool SupportsDeviceComm() const final;
+  bool SupportsOneSidedComm() const final;
 
   absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>> CreateDeviceComm(
       const GpuDeviceCommunicator::Requirements& requirements) final;

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -56,16 +56,7 @@ limitations under the License.
 
 namespace xla::gpu {
 
-class NcclSignalDesc final : public Communicator::SignalDesc {
- public:
-  NcclSignalDesc(int sig_idx, int ctx) : sig_idx_(sig_idx), ctx_(ctx) {}
-  int sig_idx() const { return sig_idx_; }
-  int ctx() const { return ctx_; }
-
- private:
-  int sig_idx_;
-  int ctx_;
-};
+using NcclSignalDesc = GpuSignalDesc;
 
 // XLA collectives communicator wrapping an NCCL communicator.
 class NcclCommunicator : public GpuCommunicator {

--- a/xla/backends/gpu/collectives/nccl_symmetric_memory.h
+++ b/xla/backends/gpu/collectives/nccl_symmetric_memory.h
@@ -36,6 +36,7 @@ class NcclSymmetricMemory final : public SymmetricMemory {
       ncclComm_t comm, stream_executor::DeviceAddressBase addr);
 
   stream_executor::DeviceAddressBase addr() const override { return addr_; }
+  ncclWindow_t win() const { return win_; }
 
   std::string ToString() const final;
 


### PR DESCRIPTION
📝 Summary of Changes
Implements the one-sided RMA stubs from PR #38943 using ncclPutSignal, ncclSignal, and ncclWaitSignal (NCCL 2.29+). 

🎯 Justification
Enables NCCL one-sided communication on the communicator so higher-level patterns (e.g. ragged all-to-all, custom FFI kernels) can use direct remote memory access with symmetric buffers.

🚀 Kind of Contribution
✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
Added to xla/backends/gpu/collectives/gpu_collectives_test.cc

🧪 Execution Tests:
N/A
