### PR TITLE
[GPU] Infer collective-permute type by slice_sizes

### DIFF
--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -283,19 +283,17 @@ XlaOp XlaBuilderFriend::BuildCopyDone(XlaBuilder* builder, const XlaOp operand,
 XlaOp XlaBuilderFriend::BuildCollectivePermuteStart(
     XlaBuilder* builder, XlaOp operand,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, const bool inplace) {
+    const std::optional<ChannelHandle>& channel_id) {
   return builder->CollectivePermuteImpl(operand, source_target_pairs,
-                                        channel_id, /*async=*/true, inplace);
+                                        channel_id, /*async=*/true);
 }
 
 XlaOp XlaBuilderFriend::BuildCollectivePermuteStart(
     XlaBuilder* builder, absl::Span<const XlaOp> operands,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, const bool inplace) {
-  // TODO support multi-operand in-place collective permute
-  CHECK(!inplace);
+    const std::optional<ChannelHandle>& channel_id) {
   return builder->CollectivePermuteImpl(operands, source_target_pairs,
-                                        channel_id, /*async=*/true, inplace);
+                                        channel_id, /*async=*/true);
 }
 
 XlaOp XlaBuilderFriend::BuildCollectivePermuteDone(XlaBuilder* builder,
@@ -4476,26 +4474,23 @@ XlaOp XlaBuilder::CollectiveBroadcastImpl(
 XlaOp XlaBuilder::CollectivePermute(
     XlaOp operand,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, const bool inplace) {
+    const std::optional<ChannelHandle>& channel_id) {
   return CollectivePermuteImpl(operand, source_target_pairs, channel_id,
-                               /*async=*/false, inplace);
+                               /*async=*/false);
 }
 
 XlaOp XlaBuilder::CollectivePermute(
     absl::Span<const XlaOp> operands,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, const bool inplace) {
-  // TODO support multi-operand in-place collective permute
-  CHECK(!inplace);
+    const std::optional<ChannelHandle>& channel_id) {
   return CollectivePermuteImpl(operands, source_target_pairs, channel_id,
-                               /*async=*/false, inplace);
+                               /*async=*/false);
 }
 
 XlaOp XlaBuilder::CollectivePermuteImpl(
     XlaOp operand,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, bool async,
-    const bool inplace) {
+    const std::optional<ChannelHandle>& channel_id, bool async) {
   return ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     TF_ASSIGN_OR_RETURN(const Shape* operand_shape, GetShapePtr(operand));
     HloInstructionProto instr;
@@ -4503,10 +4498,10 @@ XlaOp XlaBuilder::CollectivePermuteImpl(
     if (async) {
       TF_ASSIGN_OR_RETURN(shape,
                           ShapeInference::InferCollectivePermuteStartShape(
-                              {operand_shape}, {}, inplace));
+                              {operand_shape}, {}, false));
     } else {
       TF_ASSIGN_OR_RETURN(shape, ShapeInference::InferCollectivePermuteShape(
-                                     {operand_shape}, inplace));
+                                     {operand_shape}, false));
     }
     *instr.mutable_shape() = shape.ToProto();
 
@@ -4529,10 +4524,7 @@ XlaOp XlaBuilder::CollectivePermuteImpl(
 XlaOp XlaBuilder::CollectivePermuteImpl(
     absl::Span<const XlaOp> operands,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, bool async,
-    const bool inplace) {
-  // TODO support multi-operand in-place collective permute
-  CHECK(!inplace);
+    const std::optional<ChannelHandle>& channel_id, bool async) {
   return ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     std::vector<const Shape*> operand_shapes;
     for (const auto& operand : operands) {
@@ -4545,10 +4537,10 @@ XlaOp XlaBuilder::CollectivePermuteImpl(
     if (async) {
       TF_ASSIGN_OR_RETURN(shape,
                           ShapeInference::InferCollectivePermuteStartShape(
-                              operand_shapes, {}, inplace));
+                              operand_shapes, {}, false));
     } else {
       TF_ASSIGN_OR_RETURN(shape, ShapeInference::InferCollectivePermuteShape(
-                                     operand_shapes, inplace));
+                                     operand_shapes, false));
     }
     *instr.mutable_shape() = shape.ToProto();
 
@@ -6239,19 +6231,17 @@ XlaOp CollectiveBroadcast(const XlaOp operand,
 XlaOp CollectivePermute(
     const XlaOp operand,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, const bool inplace) {
+    const std::optional<ChannelHandle>& channel_id) {
   return operand.builder()->CollectivePermute(operand, source_target_pairs,
-                                              channel_id, inplace);
+                                              channel_id);
 }
 
 XlaOp MultiCollectivePermute(
     absl::Span<const XlaOp> operands,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id, const bool inplace) {
-  // TODO support multi-operand in-place collective permute
-  CHECK(!inplace);
+    const std::optional<ChannelHandle>& channel_id) {
   return operands.at(0).builder()->CollectivePermute(
-      operands, source_target_pairs, channel_id, inplace);
+      operands, source_target_pairs, channel_id);
 }
 
 XlaOp ReplicaId(XlaBuilder* builder) { return builder->ReplicaId(); }

--- a/xla/hlo/builder/xla_builder.h
+++ b/xla/hlo/builder/xla_builder.h
@@ -104,13 +104,11 @@ struct XlaBuilderFriend {
   static XlaOp BuildCollectivePermuteStart(
       XlaBuilder* builder, XlaOp operand,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id = std::nullopt,
-      const bool inplace = false);
+      const std::optional<ChannelHandle>& channel_id = std::nullopt);
   static XlaOp BuildCollectivePermuteStart(
       XlaBuilder* builder, absl::Span<const XlaOp> operands,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id = std::nullopt,
-      const bool inplace = false);
+      const std::optional<ChannelHandle>& channel_id = std::nullopt);
   static XlaOp BuildCollectivePermuteDone(XlaBuilder* builder, XlaOp operands,
                                           const Shape& shape);
 
@@ -982,14 +980,12 @@ class XlaBuilder {
   XlaOp CollectivePermute(
       XlaOp operand,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id = std::nullopt,
-      const bool inplace = false);
+      const std::optional<ChannelHandle>& channel_id = std::nullopt);
 
   XlaOp CollectivePermute(
       absl::Span<const XlaOp> operands,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id = std::nullopt,
-      const bool inplace = false);
+      const std::optional<ChannelHandle>& channel_id = std::nullopt);
 
   XlaOp ReplicaId();
 
@@ -1739,11 +1735,11 @@ class XlaBuilder {
   friend XlaOp CollectivePermute(
       XlaOp operand,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id, const bool inplace);
+      const std::optional<ChannelHandle>& channel_id);
   friend XlaOp MultiCollectivePermute(
       absl::Span<const XlaOp> operands,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id, const bool inplace);
+      const std::optional<ChannelHandle>& channel_id);
   friend XlaOp ReplicaId(XlaBuilder* builder);
   friend XlaOp SelectAndScatter(XlaOp operand, XlaComputationId select,
                                 absl::Span<const int64_t> window_dimensions,
@@ -1928,14 +1924,12 @@ class XlaBuilder {
   XlaOp CollectivePermuteImpl(
       XlaOp operand,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id, bool async,
-      const bool inplace);
+      const std::optional<ChannelHandle>& channel_id, bool async);
 
   XlaOp CollectivePermuteImpl(
       absl::Span<const XlaOp> operands,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-      const std::optional<ChannelHandle>& channel_id, bool async,
-      const bool inplace);
+      const std::optional<ChannelHandle>& channel_id, bool async);
 
   XlaOp ConditionalImpl(XlaOp branch_index,
                         absl::Span<XlaComputationId const> branch_computations,
@@ -2963,13 +2957,11 @@ XlaOp CollectiveBroadcast(
 XlaOp CollectivePermute(
     XlaOp operand,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id = std::nullopt,
-    const bool inplace = false);
+    const std::optional<ChannelHandle>& channel_id = std::nullopt);
 XlaOp MultiCollectivePermute(
     absl::Span<const XlaOp> operands,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
-    const std::optional<ChannelHandle>& channel_id = std::nullopt,
-    const bool inplace = false);
+    const std::optional<ChannelHandle>& channel_id = std::nullopt);
 
 // Enqueues an operation that returns the replica ID.
 XlaOp ReplicaId(XlaBuilder* builder);

--- a/xla/hlo/ir/hlo_instructions.cc
+++ b/xla/hlo/ir/hlo_instructions.cc
@@ -1390,7 +1390,6 @@ HloCollectivePermuteInstruction::HloCollectivePermuteInstruction(
     : HloChannelInstruction(opcode, shape, channel_id),
       source_target_pairs_(source_target_pairs) {
   AppendOperands(operands);
-  inplace_ = false;
 }
 
 HloCollectivePermuteInstruction::HloCollectivePermuteInstruction(
@@ -1408,7 +1407,6 @@ HloCollectivePermuteInstruction::HloCollectivePermuteInstruction(
   AppendOperand(output);
   AppendOperand(input_start_indices);
   AppendOperand(output_start_indices);
-  inplace_ = true;
 }
 
 void HloCollectivePermuteInstruction::ToProto(

--- a/xla/hlo/ir/hlo_instructions.h
+++ b/xla/hlo/ir/hlo_instructions.h
@@ -1038,7 +1038,9 @@ class HloCollectivePermuteInstruction : public HloChannelInstruction {
            hlo->opcode() == HloOpcode::kCollectivePermuteStart;
   }
 
-  bool inplace() const { return inplace_; }
+  // Whether this is an in-place collective permute (with dynamic slice
+  // operands). Derived from the presence of slice_sizes.
+  bool inplace() const { return !slice_sizes_.empty(); }
 
  private:
   void PrintExtraAttributesImpl(AttributePrinter& printer,
@@ -1055,7 +1057,6 @@ class HloCollectivePermuteInstruction : public HloChannelInstruction {
 
   const std::vector<std::pair<int64_t, int64_t>> source_target_pairs_;
   const std::vector<std::vector<int64_t>> slice_sizes_;
-  bool inplace_;
 };
 
 inline bool HloAllReduceInstructionBase::ClassOf(const HloInstruction* hlo) {


### PR DESCRIPTION
📝 Summary of Changes
Removed `inplace_` attribute in collective-permute. Rely on `slice_sizes` to infer if a collective-permute is in-place, since this attribute is specific to in-place.

🎯 Justification
HLO parser is not aware of the `inplace_` attribute, so it only works end-to-end but won't work when run from HLO. Its functionality can be substituted by inferring from a in-place specific attribute `slice_sizes`.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
No functionality change, existing tests.

🧪 Execution Tests:
No functionality change, existing tests.
