### PR TITLE
[XLA:GPU][oneAPI] Add target config spec file for PVC

### DIFF
--- a/xla/backends/gpu/target_config/BUILD
+++ b/xla/backends/gpu/target_config/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/xla/backends/gpu/target_config/specs/pvc.txtpb
+++ b/xla/backends/gpu/target_config/specs/pvc.txtpb
@@ -1,0 +1,38 @@
+# Copyright 2026 The OpenXLA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gpu_device_info {
+  threads_per_block_limit: 1024
+  threads_per_warp: 32
+  shared_memory_per_block: 131072
+  shared_memory_per_core: 131072
+  threads_per_core_limit: 1024
+  core_count: 56
+  fpus_per_core: 128
+  block_dim_limit_x: 4294967295 
+  block_dim_limit_y: 4294967295
+  block_dim_limit_z: 4294967295
+  memory_bandwidth: 1228800000000
+  l2_cache_size: 201326592
+  clock_rate_ghz: 1.55
+  device_memory_size: 48946688000
+  shared_memory_per_block_optin: 131072
+  registers_per_core_limit: -1
+  registers_per_block_limit: -1
+  oneapi_compute_capability {
+    architecture: "PVC"
+  }
+}
+platform_name: "SYCL"
+device_description_str: "Intel(R) Data Center GPU Max 1100"

--- a/xla/backends/gpu/target_config/target_config.cc
+++ b/xla/backends/gpu/target_config/target_config.cc
@@ -65,6 +65,8 @@ absl::StatusOr<absl::string_view> GetEmbeddedGpuTargetConfigData(
       return get_mi200();
     case GpuModel::P100:
       return get_p100();
+    case GpuModel::PVC:
+      return get_pvc();
     case GpuModel::V100:
       return get_v100();
     case GpuModel::GB200:

--- a/xla/backends/gpu/target_config/target_config.h
+++ b/xla/backends/gpu/target_config/target_config.h
@@ -40,6 +40,7 @@ enum class GpuModel {
   H100_SXM,
   MI200,
   P100,
+  PVC,
   V100,
   GB200,
   GB300,

--- a/xla/backends/gpu/target_config/target_config_test.cc
+++ b/xla/backends/gpu/target_config/target_config_test.cc
@@ -72,6 +72,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"H100_SXM", GpuModel::H100_SXM, true},
         {"MI200", GpuModel::MI200, true},
         {"P100", GpuModel::P100, true},
+        {"PVC", GpuModel::PVC, true},
         {"V100", GpuModel::V100, true},
         {"GB200", GpuModel::GB200, true},
         {"GB300", GpuModel::GB300, true},


### PR DESCRIPTION
This PR adds a target config spec file for Intel's Data Center GPU Max, codenamed Ponte Vecchio (PVC). It also adds a corresponding entry for target config test.
