### PR TITLE
[XLA:GPU] Merge CommandType into Thunk::Kind

### DIFF
--- a/xla/backends/gpu/runtime/command.cc
+++ b/xla/backends/gpu/runtime/command.cc
@@ -15,31 +15,19 @@ limitations under the License.
 
 #include "xla/backends/gpu/runtime/command.h"
 
-#include <string>
-
 namespace xla::gpu {
 
-std::string CommandTypeString(CommandType type) {
-  switch (type) {
-#define CASE_CMD_STRING(enum_name, cmd_name, ...) \
-  case CommandType::enum_name:                    \
-    return cmd_name;
-    XLA_GPU_COMMAND_LIST(CASE_CMD_STRING)
-#undef CASE_CMD_STRING
-  }
-}
-
-bool IsCollectiveCommand(CommandType type) {
-  switch (type) {
-    case CommandType::kAllGatherCmd:
-    case CommandType::kAllReduceCmd:
-    case CommandType::kAllToAllCmd:
-    case CommandType::kCollectiveBroadcastCmd:
-    case CommandType::kCollectivePermuteCmd:
-    case CommandType::kRaggedAllToAllCmd:
-    case CommandType::kReduceScatterCmd:
-    case CommandType::kRecvCmd:
-    case CommandType::kSendCmd:
+bool IsCollectiveCommand(Thunk::Kind kind) {
+  switch (kind) {
+    case Thunk::Kind::kAllGatherCmd:
+    case Thunk::Kind::kAllReduceCmd:
+    case Thunk::Kind::kAllToAllCmd:
+    case Thunk::Kind::kCollectiveBroadcastCmd:
+    case Thunk::Kind::kCollectivePermuteCmd:
+    case Thunk::Kind::kRaggedAllToAllCmd:
+    case Thunk::Kind::kReduceScatterCmd:
+    case Thunk::Kind::kRecvCmd:
+    case Thunk::Kind::kSendCmd:
       return true;
     default:
       return false;

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_RUNTIME_COMMAND_H_
 #define XLA_BACKENDS_GPU_RUNTIME_COMMAND_H_
 
-#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -38,64 +37,13 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/platform.h"
-#include "tsl/platform/casts.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 
-//===----------------------------------------------------------------------===//
-// CommandType
-//===----------------------------------------------------------------------===//
-
-// clang-format off
-#define XLA_GPU_COMMAND_LIST(V)                              \
-  V(kEmptyCmd, "EmptyCmd")                                   \
-  V(kChildCmd, "ChildCmd")                                   \
-  V(kTracedCommand, "TracedCommand")       \
-  V(kComputationIdCmd, "ComputationIdCmd")                   \
-  V(kLaunchCmd, "LaunchCmd")                                 \
-  V(kCustomKernelLaunchCmd, "CustomKernelLaunchCmd")         \
-  V(kCublasLtCmd, "CublasLtCmd")                             \
-  V(kCuDnnCmd, "CuDnnCmd")                                   \
-  V(kGemmCmd, "GemmCmd")                                     \
-  V(kMemcpyDeviceToDeviceCmd, "MemcpyDeviceToDeviceCmd")     \
-  V(kMemzeroCmd, "MemzeroCmd")                               \
-  V(kMemset32Cmd, "Memset32Cmd")                             \
-  V(kCaseCmd, "CaseCmd")                                     \
-  V(kWhileCmd, "WhileCmd")                                   \
-  V(kCustomCallCmd, "CustomCallCmd")                         \
-  V(kBarrierCmd, "BarrierCmd")                               \
-  V(kCollectiveCmd, "CollectiveCmd")                         \
-  V(kAllReduceCmd, "AllReduceCmd")                           \
-  V(kReduceScatterCmd, "ReduceScatterCmd")                   \
-  V(kAllToAllCmd, "AllToAllCmd")                             \
-  V(kAllGatherCmd, "AllGatherCmd")                           \
-  V(kCollectiveBroadcastCmd, "CollectiveBroadcastCmd")       \
-  V(kCollectivePermuteCmd, "CollectivePermuteCmd")           \
-  V(kRaggedAllToAllCmd, "RaggedAllToAllCmd")                 \
-  V(kRecvCmd, "RecvCmd")                                     \
-  V(kSendCmd, "SendCmd")                                     \
-  V(kAsyncDone, "AsyncDone")                                 \
-  V(kDynamicSliceFusionCmd, "DynamicSliceFusionCmd")         \
-  V(kDynamicSliceCopyFusionCmd, "DynamicSliceCopyFusionCmd") \
-  V(kUnknownCmd, "UnknownCmd") \
-  // clang-format on
-
-enum class CommandType : int32_t {
-#define DECLARE_ENUM(enum_name, cmd_name, ...) enum_name,
-  XLA_GPU_COMMAND_LIST(DECLARE_ENUM)
-#undef DECLARE_ENUM
-};
-
-std::string CommandTypeString(CommandType type);
-
-template <typename Sink>
-void AbslStringify(Sink& sink, CommandType type) {
-  sink.Append(CommandTypeString(type));
-}
-
-// Returns true if command type corresponds to a collective operation.
-bool IsCollectiveCommand(CommandType type);
+// Returns true if a Thunk::Kind corresponds to a collective command.
+bool IsCollectiveCommand(Thunk::Kind kind);
 
 //===----------------------------------------------------------------------===//
 // Command
@@ -127,11 +75,9 @@ bool IsCollectiveCommand(CommandType type);
 // done with a state manager.
 class Command : public Thunk {
  public:
-  explicit Command(CommandType cmd_type,
+  explicit Command(Thunk::Kind kind,
                    se::StreamPriority priority = se::StreamPriority::Default)
-      : Thunk(Thunk::Kind::kCommand, ThunkInfo{}),
-        cmd_type_(cmd_type),
-        priority_(priority) {
+      : Thunk(kind, ThunkInfo{}), priority_(priority) {
     token_ = Resource::Create(Resource::kToken);
   }
 
@@ -214,12 +160,11 @@ class Command : public Thunk {
   // Returns true if command implemented as a nested command buffer.
   virtual bool IsNestedCommandBuffer() const { return false; }
 
-  CommandType command_type() const { return cmd_type_; }
   se::StreamPriority priority() const { return priority_; }
   void set_priority(se::StreamPriority priority) { priority_ = priority; }
 
   std::string ToString(int indent) const override {
-    return CommandTypeString(cmd_type_);
+    return std::string(KindToString(kind()));
   }
 
   // Recursively walks all the commands nested inside *this one and calls
@@ -237,8 +182,6 @@ class Command : public Thunk {
   absl::Status WalkNested(Walker callback) override { return absl::OkStatus(); }
 
  private:
-  CommandType cmd_type_;
-
   // The token resource is used to specify additional dependency across
   // commands, like control dependency across HLO operators, and LHS scheduling
   // dependency.
@@ -251,7 +194,7 @@ class Command : public Thunk {
 
 // Returns true if command is a collective one.
 inline bool IsCollectiveCommand(const Command& cmd) {
-  return IsCollectiveCommand(cmd.command_type());
+  return IsCollectiveCommand(cmd.kind());
 }
 
 //===----------------------------------------------------------------------===//
@@ -300,7 +243,7 @@ class AsyncStartCommand : public Command {
 class AsyncDoneCommand : public Command {
  public:
   explicit AsyncDoneCommand(const AsyncStartCommand* async_start)
-      : Command(CommandType::kAsyncDone), async_start_(async_start) {
+      : Command(Thunk::Kind::kAsyncDoneCmd), async_start_(async_start) {
     DCHECK(async_start_) << "AsyncStart command must be not null";
   }
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -113,13 +113,13 @@ limitations under the License.
 #include "xla/stream_executor/trace_command_buffer_factory.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/types.h"  // IWYU pragma: keep
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/profiler/lib/scoped_annotation.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -313,8 +313,8 @@ absl::StatusOr<se::CommandBuffer*> TracedCommandBuffer::GetOrTraceCommandBuffer(
 // TracedCommandBufferCmd
 //===----------------------------------------------------------------------===//
 
-TracedCommandBufferCmd::TracedCommandBufferCmd(CommandType cmd_type)
-    : Command(cmd_type) {}
+TracedCommandBufferCmd::TracedCommandBufferCmd(Thunk::Kind kind)
+    : Command(kind) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
 TracedCommandBufferCmd::RecordTracedCommand(
@@ -351,7 +351,7 @@ TracedCommandBufferCmd::RecordTracedCommand(
 // EmptyCmd
 //===----------------------------------------------------------------------===//
 
-EmptyCmd::EmptyCmd() : Command(CommandType::kEmptyCmd) {}
+EmptyCmd::EmptyCmd() : Command(Thunk::Kind::kEmptyCmd) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
     const Thunk::ExecuteParams& execute_params,
@@ -373,7 +373,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> EmptyCmd::Record(
 //===----------------------------------------------------------------------===//
 
 ComputationIdCmd::ComputationIdCmd(BufferAllocation::Slice dest, Kind kind)
-    : Command(CommandType::kComputationIdCmd), dest_(dest), kind_(kind) {}
+    : Command(Thunk::Kind::kComputationIdCmd), dest_(dest), kind_(kind) {}
 
 Command::BufferUses ComputationIdCmd::buffer_uses() const {
   return {BufferUse::Write(dest_, ShapeUtil::MakeShape(S32, {}))};
@@ -423,7 +423,7 @@ LaunchCmd::LaunchCmd(
     absl::Span<const BufferUse::MemoryAccess> args_access,
     LaunchDimensions dims, int64_t shmem_bytes,
     std::optional<stream_executor::gpu::TmaMetadata> tma_metadata, bool use_pdl)
-    : Command(CommandType::kLaunchCmd),
+    : Command(Thunk::Kind::kLaunchCmd),
       kernel_name_(std::move(kernel_name)),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
@@ -531,7 +531,7 @@ CustomKernelLaunchCmd::CustomKernelLaunchCmd(
     absl::Span<const ShapedSlice> args,
     absl::Span<const BufferUse::MemoryAccess> args_access,
     CustomKernel custom_kernel)
-    : Command(CommandType::kCustomKernelLaunchCmd),
+    : Command(Thunk::Kind::kCustomKernelLaunchCmd),
       args_(args.begin(), args.end()),
       args_access_(args_access.begin(), args_access.end()),
       custom_kernel_(std::move(custom_kernel)) {}
@@ -611,7 +611,7 @@ Command::BufferUses CustomKernelLaunchCmd::buffer_uses() const {
 MemcpyDeviceToDeviceCmd::MemcpyDeviceToDeviceCmd(ShapedSlice dst,
                                                  ShapedSlice src,
                                                  int64_t num_bytes)
-    : Command(CommandType::kMemcpyDeviceToDeviceCmd),
+    : Command(Thunk::Kind::kMemcpyDeviceToDeviceCmd),
       dst_(dst),
       src_(src),
       num_bytes_(num_bytes) {
@@ -662,7 +662,7 @@ Command::BufferUses MemcpyDeviceToDeviceCmd::buffer_uses() const {
 //===----------------------------------------------------------------------===//
 
 MemzeroCmd::MemzeroCmd(ShapedSlice dst)
-    : Command(CommandType::kMemzeroCmd), dst_(dst) {}
+    : Command(Thunk::Kind::kMemzeroCmd), dst_(dst) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> MemzeroCmd::Record(
     const Thunk::ExecuteParams& execute_params,
@@ -701,7 +701,7 @@ Command::BufferUses MemzeroCmd::buffer_uses() const {
 //===----------------------------------------------------------------------===//
 
 Memset32Cmd::Memset32Cmd(BufferAllocation::Slice dst, uint32_t bit_pattern)
-    : Command(CommandType::kMemset32Cmd),
+    : Command(Thunk::Kind::kMemset32Cmd),
       dst_(dst),
       bit_pattern_(bit_pattern) {}
 
@@ -743,7 +743,7 @@ Command::BufferUses Memset32Cmd::buffer_uses() const {
 //===----------------------------------------------------------------------===//
 
 ChildCmd::ChildCmd(CommandExecutor child_commands)
-    : Command(CommandType::kChildCmd),
+    : Command(Thunk::Kind::kChildCmd),
       child_commands_(std::move(child_commands)) {}
 
 absl::Status ChildCmd::Initialize(const Thunk::InitializeParams& params) {
@@ -790,7 +790,7 @@ absl::Status ChildCmd::WalkNested(
 //===----------------------------------------------------------------------===//
 
 CaseCmd::CaseCmd(ShapedSlice index, std::vector<CommandExecutor> branches)
-    : Command(CommandType::kCaseCmd),
+    : Command(Thunk::Kind::kCaseCmd),
       index_(index),
       index_is_bool_(index.shape.element_type() == PRED),
       branches_(std::move(branches)) {}
@@ -858,7 +858,7 @@ absl::Status CaseCmd::WalkNested(
 WhileCmd::WhileCmd(BufferAllocation::Slice pred, CommandExecutor cond_commands,
                    CommandExecutor body_commands,
                    std::optional<int64_t> trip_count, bool enable_loop_unroll)
-    : Command(CommandType::kWhileCmd),
+    : Command(Thunk::Kind::kWhileCmd),
       pred_(pred),
       cond_commands_(std::move(cond_commands)),
       body_commands_(std::move(body_commands)),
@@ -1002,7 +1002,7 @@ GemmCmd::GemmCmd(GemmConfig config, const BufferAllocation::Slice& lhs_buffer,
                  const BufferAllocation::Slice& output_buffer,
                  std::optional<BufferAllocation::Slice> workspace,
                  bool deterministic)
-    : TracedCommandBufferCmd(CommandType::kGemmCmd),
+    : TracedCommandBufferCmd(Thunk::Kind::kGemmCmd),
       config_(std::move(config)),
       lhs_buffer_(lhs_buffer),
       rhs_buffer_(rhs_buffer),
@@ -1066,7 +1066,7 @@ Command::BufferUses GemmCmd::buffer_uses() const {
 //===----------------------------------------------------------------------===//
 
 CublasLtCmd::CublasLtCmd(const CublasLtMatmulThunk& matmul_thunk)
-    : TracedCommandBufferCmd(CommandType::kCublasLtCmd), thunk_(matmul_thunk) {}
+    : TracedCommandBufferCmd(Thunk::Kind::kCublasLtCmd), thunk_(matmul_thunk) {}
 
 absl::Status CublasLtCmd::Initialize(const Thunk::InitializeParams& params) {
   return thunk_.Initialize(params);
@@ -1163,7 +1163,7 @@ Command::BufferUses CublasLtCmd::buffer_uses() const {
 
 CuDnnCmd::CuDnnCmd(absl::Span<const ShapedSlice> args,
                    const std::shared_ptr<se::dnn::LazyDnnGraph> graph)
-    : TracedCommandBufferCmd(CommandType::kCuDnnCmd),
+    : TracedCommandBufferCmd(Thunk::Kind::kCuDnnCmd),
       args_(args.cbegin(), args.cend()),
       graph_(graph) {}
 
@@ -1428,9 +1428,8 @@ Command::BufferUses CustomCallCmd::buffer_uses() const {
 // CollectiveCmd
 //===----------------------------------------------------------------------===//
 
-CollectiveCmd::CollectiveCmd(CommandType cmd_type, CollectiveConfig config)
-    : Command(cmd_type, se::StreamPriority::Highest),
-      config_(std::move(config)) {}
+CollectiveCmd::CollectiveCmd(Thunk::Kind kind, CollectiveConfig config)
+    : Command(kind, se::StreamPriority::Highest), config_(std::move(config)) {}
 
 absl::Status CollectiveCmd::Prepare(const Thunk::PrepareParams& params) {
   TF_RET_CHECK(params.collective_params &&
@@ -1482,7 +1481,7 @@ CollectiveCmd::RecordTracedCommand(
 AllReduceCmd::AllReduceCmd(CollectiveConfig config,
                            ReductionKind reduction_kind,
                            absl::Span<const CollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(CommandType::kAllReduceCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kAllReduceCmd, std::move(config)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1549,7 +1548,7 @@ Command::BufferUses AllReduceCmd::buffer_uses() const {
 ReduceScatterCmd::ReduceScatterCmd(
     CollectiveConfig config, ReductionKind reduction_kind,
     absl::Span<const CollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(CommandType::kReduceScatterCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kReduceScatterCmd, std::move(config)),
       reduction_kind_(reduction_kind),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1615,7 +1614,7 @@ Command::BufferUses ReduceScatterCmd::buffer_uses() const {
 
 AllToAllCmd::AllToAllCmd(CollectiveConfig config, bool has_split_dimension,
                          absl::Span<const CollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(CommandType::kAllToAllCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kAllToAllCmd, std::move(config)),
       has_split_dimension_(has_split_dimension),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -1682,7 +1681,7 @@ Command::BufferUses AllToAllCmd::buffer_uses() const {
 
 AllGatherCmd::AllGatherCmd(CollectiveConfig config,
                            absl::Span<const CollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(CommandType::kAllGatherCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kAllGatherCmd, std::move(config)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*> AllGatherCmd::Record(
@@ -1746,7 +1745,7 @@ Command::BufferUses AllGatherCmd::buffer_uses() const {
 
 CollectiveBroadcastCmd::CollectiveBroadcastCmd(
     CollectiveConfig config, absl::Span<const CollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(CommandType::kCollectiveBroadcastCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kCollectiveBroadcastCmd, std::move(config)),
       buffers_(buffers.begin(), buffers.end()) {}
 
 absl::StatusOr<const se::CommandBuffer::Command*>
@@ -1810,7 +1809,7 @@ Command::BufferUses CollectiveBroadcastCmd::buffer_uses() const {
 
 RecvCmd::RecvCmd(CollectiveConfig config, P2PConfig p2p_config,
                  const CollectiveThunk::Buffer& buffer)
-    : CollectiveCmd(CommandType::kRecvCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kRecvCmd, std::move(config)),
       p2p_config_(std::move(p2p_config)),
       buffer_(buffer) {}
 
@@ -1897,7 +1896,7 @@ Command::BufferUses RecvCmd::buffer_uses() const {
 
 SendCmd::SendCmd(CollectiveConfig config, P2PConfig p2p_config,
                  const CollectiveThunk::Buffer& buffer)
-    : CollectiveCmd(CommandType::kSendCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kSendCmd, std::move(config)),
       p2p_config_(std::move(p2p_config)),
       buffer_(buffer) {}
 
@@ -1990,7 +1989,7 @@ Command::BufferUses SendCmd::buffer_uses() const {
 CollectivePermuteCmd::CollectivePermuteCmd(
     CollectiveConfig config, P2PConfig p2p_config,
     absl::Span<const CollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(CommandType::kCollectivePermuteCmd, std::move(config)),
+    : CollectiveCmd(Thunk::Kind::kCollectivePermuteCmd, std::move(config)),
       p2p_config_(std::move(p2p_config)),
       buffers_(buffers.begin(), buffers.end()) {}
 
@@ -2079,7 +2078,7 @@ DynamicSliceFusionCmd::DynamicSliceFusionCmd(
     std::optional<
         const DynamicSliceThunk::OffsetAsFunctionOfIndvarModulesMetadata*>
         offset_as_function_of_indvar_metadata)
-    : Command(CommandType::kDynamicSliceFusionCmd),
+    : Command(Thunk::Kind::kDynamicSliceFusionCmd),
       embedded_commands_(std::move(embedded_commands)),
       fake_allocations_(std::move(fake_allocations)),
       offset_as_function_of_indvar_metadata_(
@@ -2381,7 +2380,7 @@ absl::Status DynamicSliceFusionCmd::WalkNested(
 DynamicSliceCopyFusionCmd::DynamicSliceCopyFusionCmd(
     const ShapedSlice& source_buffer, const ShapedSlice& destination_buffer,
     uint64_t mem_size, DynamicMemcpyThunk::Offsets offsets)
-    : Command(CommandType::kDynamicSliceCopyFusionCmd),
+    : Command(Thunk::Kind::kDynamicSliceCopyFusionCmd),
       source_buffer_(source_buffer),
       destination_buffer_(destination_buffer),
       mem_size_(mem_size),
@@ -2464,7 +2463,7 @@ struct RaggedAllToAllCmdState : CommandState {
 RaggedAllToAllCmd::RaggedAllToAllCmd(
     RaggedAllToAllConfig ragged_all_to_all_config,
     absl::Span<const CollectiveThunk::Buffer> buffers)
-    : CollectiveCmd(CommandType::kRaggedAllToAllCmd,
+    : CollectiveCmd(Thunk::Kind::kRaggedAllToAllCmd,
                     ragged_all_to_all_config.config),
       ragged_all_to_all_config_(std::move(ragged_all_to_all_config)),
       buffers_(buffers.begin(), buffers.end()) {}

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -112,7 +112,7 @@ class TracedCommandBuffer : public CommandState {
 // A base class for commands implemented as tracing of stream activities.
 class TracedCommandBufferCmd : public Command {
  protected:
-  explicit TracedCommandBufferCmd(CommandType cmd_type);
+  explicit TracedCommandBufferCmd(Thunk::Kind kind);
 
   // Creates a command buffer by calling a user-provided `trace` function and
   // adds it as a nested command to `command_buffer`. Traced command buffers
@@ -470,7 +470,7 @@ class CustomCallCmd : public Command {
                 std::vector<NullableShapedSlice> operands,
                 std::vector<NullableShapedSlice> results,
                 absl::string_view opaque)
-      : Command(CommandType::kCustomCallCmd),
+      : Command(Thunk::Kind::kCustomCallCmd),
         target_name_(std::move(target_name)),
         call_target_(std::move(call_target)),
         opaque_(opaque),
@@ -483,7 +483,7 @@ class CustomCallCmd : public Command {
                 ffi::CallFrame call_frame, ThunkId thunk_id,
                 std::shared_ptr<ffi::ExecutionState> execution_state,
                 const HloComputation* called_computation)
-      : Command(CommandType::kCustomCallCmd),
+      : Command(Thunk::Kind::kCustomCallCmd),
         target_name_(std::move(target_name)),
         handler_(handler),
         call_frame_(std::move(call_frame)),
@@ -551,7 +551,7 @@ class CustomCallCmd : public Command {
 
 class CollectiveCmd : public Command {
  public:
-  CollectiveCmd(CommandType cmd_type, CollectiveConfig config);
+  CollectiveCmd(Thunk::Kind kind, CollectiveConfig config);
 
   absl::Status Prepare(const Thunk::PrepareParams& params) final;
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -97,7 +97,7 @@ static constexpr auto serialize =
 // buffer usage vector to the command buffer cmd commands.
 struct TestOnlyCommandBufferCmd : public Command {
   explicit TestOnlyCommandBufferCmd(Command::BufferUses buffers)
-      : Command(CommandType::kEmptyCmd, {}), buffers(buffers) {}
+      : Command(Thunk::Kind::kEmptyCmd, {}), buffers(buffers) {}
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams&, const RecordParams&, RecordAction,
@@ -112,7 +112,7 @@ struct TestOnlyCommandBufferCmd : public Command {
 
 class FakeCmd : public Command {
  public:
-  explicit FakeCmd() : Command(CommandType::kEmptyCmd, {}) {}
+  explicit FakeCmd() : Command(Thunk::Kind::kEmptyCmd, {}) {}
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams&, const RecordParams&, RecordAction,

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -368,7 +368,7 @@ static void VlogCommandSequenceDetails(const CommandSequence& commands) {
       }
     }
 
-    std::string cmd_name = CommandTypeString(cmd->command_type());
+    std::string cmd_name = std::string(Thunk::KindToString(cmd->kind()));
 
     if (has_input && !has_output && !has_temp) {
       input_count++;

--- a/xla/backends/gpu/runtime/thunk.cc
+++ b/xla/backends/gpu/runtime/thunk.cc
@@ -49,8 +49,8 @@ limitations under the License.
 #include "xla/service/service_executable_run_options.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/stream.h"
-#include "xla/util.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "xla/util.h"
 
 namespace xla::gpu {
 
@@ -158,7 +158,36 @@ ThunkKindProto Thunk::KindToProto(Kind kind) {
       return THUNK_KIND_COLLECTIVE_METADATA;
     case kCollectivePermute:
       return THUNK_KIND_COLLECTIVE_PERMUTE;
-    case kCommand:
+    case kAllGatherCmd:
+    case kAllReduceCmd:
+    case kAllToAllCmd:
+    case kAsyncDoneCmd:
+    case kBarrierCmd:
+    case kCaseCmd:
+    case kChildCmd:
+    case kCollectiveBroadcastCmd:
+    case kCollectiveCmd:
+    case kCollectivePermuteCmd:
+    case kComputationIdCmd:
+    case kCuDnnCmd:
+    case kCublasLtCmd:
+    case kCustomCallCmd:
+    case kCustomKernelLaunchCmd:
+    case kDynamicSliceCopyFusionCmd:
+    case kDynamicSliceFusionCmd:
+    case kEmptyCmd:
+    case kGemmCmd:
+    case kLaunchCmd:
+    case kMemcpyDeviceToDeviceCmd:
+    case kMemset32Cmd:
+    case kMemzeroCmd:
+    case kRaggedAllToAllCmd:
+    case kRecvCmd:
+    case kReduceScatterCmd:
+    case kSendCmd:
+    case kTracedCommand:
+    case kUnknownCmd:
+    case kWhileCmd:
       return THUNK_KIND_UNSPECIFIED;
     case kCommandBuffer:
       return THUNK_KIND_COMMAND_BUFFER;
@@ -363,30 +392,48 @@ absl::StatusOr<Thunk::Kind> Thunk::KindFromProto(ThunkKindProto kind) {
   switch (kind) {
     // # go/keep-sorted start
     CASE(kAllGather);
+    CASE(kAllGatherCmd);
     CASE(kAllReduce);
+    CASE(kAllReduceCmd);
     CASE(kAllToAll);
+    CASE(kAllToAllCmd);
     CASE(kAsyncDone);
+    CASE(kAsyncDoneCmd);
     CASE(kAsyncStart);
+    CASE(kBarrierCmd);
     CASE(kBuffersDebugChecksum);
     CASE(kBuffersDebugFloatCheck);
+    CASE(kCaseCmd);
+    CASE(kChildCmd);
     CASE(kCollectiveBroadcast);
+    CASE(kCollectiveBroadcastCmd);
+    CASE(kCollectiveCmd);
     CASE(kCollectiveKernel);
     CASE(kCollectiveMetadata);
     CASE(kCollectivePermute);
-    CASE(kCommand);
+    CASE(kCollectivePermuteCmd);
     CASE(kCommandBuffer);
+    CASE(kComputationIdCmd);
     CASE(kConditional);
     CASE(kConvolution);
     CASE(kConvolutionReorder);
     CASE(kCopy);
     CASE(kCopyDone);
     CASE(kCuDnn);
+    CASE(kCuDnnCmd);
+    CASE(kCublasLtCmd);
     CASE(kCublasLtMatmul);
     CASE(kCustomCall);
+    CASE(kCustomCallCmd);
     CASE(kCustomKernel);
+    CASE(kCustomKernelLaunchCmd);
     CASE(kDynamicSlice);
+    CASE(kDynamicSliceCopyFusionCmd);
+    CASE(kDynamicSliceFusionCmd);
+    CASE(kEmptyCmd);
     CASE(kFft);
     CASE(kGemm);
+    CASE(kGemmCmd);
     CASE(kGroupDone);
     CASE(kGroupStart);
     CASE(kHostExecuteDone);
@@ -397,8 +444,12 @@ absl::StatusOr<Thunk::Kind> Thunk::KindFromProto(ThunkKindProto kind) {
     CASE(kHostSendDone);
     CASE(kInfeed);
     CASE(kKernel);
+    CASE(kLaunchCmd);
+    CASE(kMemcpyDeviceToDeviceCmd);
     CASE(kMemset32BitValue);
+    CASE(kMemset32Cmd);
     CASE(kMemzero);
+    CASE(kMemzeroCmd);
     CASE(kNorm);
     CASE(kNvshmemAllReduce);
     CASE(kNvshmemCollectivePermute);
@@ -407,14 +458,21 @@ absl::StatusOr<Thunk::Kind> Thunk::KindFromProto(ThunkKindProto kind) {
     CASE(kOutfeed);
     CASE(kPartitionId);
     CASE(kRaggedAllToAll);
+    CASE(kRaggedAllToAllCmd);
     CASE(kRecv);
+    CASE(kRecvCmd);
     CASE(kReduceScatter);
+    CASE(kReduceScatterCmd);
     CASE(kReplicaId);
     CASE(kSelectK);
     CASE(kSend);
+    CASE(kSendCmd);
     CASE(kSequential);
+    CASE(kTracedCommand);
     CASE(kTriangularSolve);
+    CASE(kUnknownCmd);
     CASE(kWhile);
+    CASE(kWhileCmd);
     // # go/keep-sorted end
   }
 }

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -56,9 +56,9 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -101,30 +101,48 @@ class Thunk {
   enum Kind {
     // # go/keep-sorted start
     kAllGather,
+    kAllGatherCmd,
     kAllReduce,
+    kAllReduceCmd,
     kAllToAll,
+    kAllToAllCmd,
     kAsyncDone,
+    kAsyncDoneCmd,
     kAsyncStart,
+    kBarrierCmd,
     kBuffersDebugChecksum,
     kBuffersDebugFloatCheck,
+    kCaseCmd,
+    kChildCmd,
     kCollectiveBroadcast,
+    kCollectiveBroadcastCmd,
+    kCollectiveCmd,
     kCollectiveKernel,
     kCollectiveMetadata,
     kCollectivePermute,
-    kCommand,
+    kCollectivePermuteCmd,
     kCommandBuffer,
+    kComputationIdCmd,
     kConditional,
     kConvolution,
     kConvolutionReorder,
     kCopy,
     kCopyDone,
     kCuDnn,
+    kCuDnnCmd,
+    kCublasLtCmd,
     kCublasLtMatmul,
     kCustomCall,
+    kCustomCallCmd,
     kCustomKernel,
+    kCustomKernelLaunchCmd,
     kDynamicSlice,
+    kDynamicSliceCopyFusionCmd,
+    kDynamicSliceFusionCmd,
+    kEmptyCmd,
     kFft,
     kGemm,
+    kGemmCmd,
     kGroupDone,
     kGroupStart,
     kHostExecuteDone,
@@ -135,8 +153,12 @@ class Thunk {
     kHostSendDone,
     kInfeed,
     kKernel,
+    kLaunchCmd,
+    kMemcpyDeviceToDeviceCmd,
     kMemset32BitValue,
+    kMemset32Cmd,
     kMemzero,
+    kMemzeroCmd,
     kNorm,
     kNvshmemAllReduce,
     kNvshmemCollectivePermute,
@@ -145,14 +167,21 @@ class Thunk {
     kOutfeed,
     kPartitionId,
     kRaggedAllToAll,
+    kRaggedAllToAllCmd,
     kRecv,
+    kRecvCmd,
     kReduceScatter,
+    kReduceScatterCmd,
     kReplicaId,
     kSelectK,
     kSend,
+    kSendCmd,
     kSequential,
+    kTracedCommand,
     kTriangularSolve,
-    kWhile
+    kUnknownCmd,
+    kWhile,
+    kWhileCmd
     // go/keep-sorted end
   };
 


### PR DESCRIPTION
  Now that Command is a subclass of Thunk, the separate CommandType enum is redundant. Every Command instance already carries a Thunk::Kind via the inherited kind() accessor — there is no reason to maintain a parallel type identifier.

  This CL removes CommandType entirely and folds its values into Thunk::Kind as Command-specific entries (e.g. kEmptyCmd, kGemmCmd, kAllGatherCmd), following the same go/keep-sorted ordering used by the rest of the enum.

  Changes:
  - Remove CommandType enum, XLA_GPU_COMMAND_LIST macro, and CommandTypeString() from command.h/command.cc
  - Remove kCommand from Thunk::Kind; add 30 Command-specific Kind entries in sorted order
  - Command constructor now takes Thunk::Kind directly; cmd_type_ member and command_type() accessor removed — callers use the inherited kind()
  - IsCollectiveCommand now operates on Thunk::Kind instead of CommandType
  - KindToString and KindToProto in thunk.cc updated for the new kinds (Command kinds map to THUNK_KIND_UNSPECIFIED in proto, same as kCommand did)
  - TracedCommandBufferCmd and CollectiveCmd constructor signatures updated accordingly

  Note: CommandType::kAsyncDone was renamed to Thunk::Kind::kAsyncDoneCmd to avoid collision with the existing Thunk::Kind::kAsyncDone used by AsyncDoneThunk.
