### PR TITLE
[ROCm] Add missing ROCm dependencies to collective_perf_table_gen

### DIFF
--- a/xla/tools/BUILD
+++ b/xla/tools/BUILD
@@ -860,6 +860,9 @@ cc_library(
     ] + if_cuda([
         "//xla/service:gpu_plugin",
         "//xla/stream_executor:cuda_platform",
+    ]) + if_rocm([
+        "//xla/service:gpu_plugin",
+        "//xla/stream_executor:rocm_platform",
     ]),
     alwayslink = True,
 )


### PR DESCRIPTION
📝 Summary of Changes
Add missing ROCm dependencies to `collective_perf_table_gen`.

🎯 Justification
The `collective_perf_table_gen` tool was failing with the following message when used in ROCM environment:
```
F0000 00:00:1775746981.610944  177588 collective_perf_table_gen.cc:409] Check failed: pjrt_env is OK (NOT_FOUND: Could not find registered platform with name: "rocm". Available platform names are: )
*** Check failure stack trace: ***
    @     0x55b30c389204  absl::lts_20260107::log_internal::LogMessage::SendToLog()
    @     0x55b30c389186  absl::lts_20260107::log_internal::LogMessage::Flush()
    @     0x55b3011f0bf5  xla::gpu::CollectivePerfTableGen::GetPjRtEnv()
    @     0x55b3011f134e  xla::gpu::CollectivePerfTableGen::Compile()
    @     0x55b3011f1a82  xla::gpu::CollectivePerfTableGen::Profile()
    @     0x55b3011f30ae  xla::gpu::CollectivePerfTableGen::ComputeTable()
    @     0x55b3011ec6c7  main
    @     0x7f7295db71ca  (unknown)
    @     0x7f7295db728b  __libc_start_main
    @     0x55b3011e8ca5  _start
Aborted (core dumped)
```
Adding the missing dependencies to the BUILD file fixes this problem.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
