### PR TITLE
[xla:gpu] Cleanup GPU thunk APIs

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -363,7 +363,7 @@ cc_library(
         "//xla/runtime:resource_use",
         "//xla/service:buffer_assignment",
         "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/log",
@@ -2864,10 +2864,20 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "host_async_thunk",
+    hdrs = ["host_async_thunk.h"],
+    deps = [
+        ":thunk",
+        "//xla/tsl/lib/gtl:int_type",
+    ],
+)
+
+cc_library(
     name = "host_send_recv_thunk",
     srcs = ["host_send_recv_thunk.cc"],
     hdrs = ["host_send_recv_thunk.h"],
     deps = [
+        ":host_async_thunk",
         ":thunk",
         ":thunk_proto_cc",
         "//xla:shape_util",
@@ -2881,7 +2891,7 @@ cc_library(
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/concurrency:async_value",
         "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -2966,7 +2976,6 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/concurrency:future",
-        "//xla/tsl/lib/gtl:int_type",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/util:unique_any",
         "@com_google_absl//absl/base:nullability",
@@ -4017,6 +4026,7 @@ cc_library(
     srcs = ["host_execute_thunk.cc"],
     hdrs = ["host_execute_thunk.h"],
     deps = [
+        ":host_async_thunk",
         ":thunk",
         ":thunk_proto_cc",
         "//xla:executable_run_options",
@@ -4040,7 +4050,7 @@ cc_library(
         "//xla/tsl/framework:allocator",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -4166,7 +4176,7 @@ cc_library(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:semantic_version",
         "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -4273,7 +4283,7 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor/gpu:buffer_debug_log",
         "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -62,7 +62,7 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/status_macros.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 
 namespace xla::gpu {
@@ -128,12 +128,11 @@ static absl::StatusOr<std::unique_ptr<Command>> Convert(
 static absl::StatusOr<std::unique_ptr<Command>> Convert(
     const WhileThunk& thunk, const ConvertToCommandsOptions& options) {
   VLOG(1) << "WhileThunk: " << thunk.profile_annotation();
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       CommandExecutor cond_cmds,
       ConvertToCommands(thunk.condition_executor().thunks(), options));
-  TF_ASSIGN_OR_RETURN(
-      CommandExecutor body_cmds,
-      ConvertToCommands(thunk.body_executor().thunks(), options));
+  ASSIGN_OR_RETURN(CommandExecutor body_cmds,
+                   ConvertToCommands(thunk.body_executor().thunks(), options));
 
   return std::make_unique<WhileCmd>(
       thunk.condition_result_buffer(), std::move(cond_cmds),
@@ -164,16 +163,16 @@ static absl::StatusOr<std::unique_ptr<Command>> Convert(
     // For boolean predicates, we need to convert the branches in reverse order
     // because the first branch is the "false" branch and the second is "true"
     CHECK_EQ(thunk.branch_executors().size(), 2);
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         branch_cmds.emplace_back(),
         ConvertToCommands(thunk.branch_executors()[1].thunks(), options));
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         branch_cmds.emplace_back(),
         ConvertToCommands(thunk.branch_executors()[0].thunks(), options));
   } else {
     for (auto& branch_thunk : thunk.branch_executors()) {
-      TF_ASSIGN_OR_RETURN(CommandExecutor cmds,
-                          ConvertToCommands(branch_thunk.thunks(), options));
+      ASSIGN_OR_RETURN(CommandExecutor cmds,
+                       ConvertToCommands(branch_thunk.thunks(), options));
       branch_cmds.emplace_back(std::move(cmds));
     }
   }
@@ -236,7 +235,7 @@ static absl::StatusOr<std::unique_ptr<Command>> Convert(
 
 static absl::StatusOr<std::unique_ptr<Command>> Convert(
     const DynamicSliceThunk& thunk, const ConvertToCommandsOptions& options) {
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       CommandExecutor embedded_cmds,
       ConvertToCommands(thunk.get_embedded_executor().thunks(), options));
 
@@ -377,14 +376,9 @@ static absl::Status AppendCommands(ConversionContext& ctx,
       return AppendCommands(ctx, cmd_sequence, start.thunks(), options);
     }
 
-    // Async done thunks are no-ops in command buffers. Create an empty
-    // command only if needed as a dependency node.
+    // Async done thunks are no-ops in command buffers.
     case Thunk::Kind::kAsyncDone: {
-      if (thunk.control_predecessors().empty()) {
-        return absl::OkStatus();
-      }
-      return append(absl::StatusOr<std::unique_ptr<Command>>(
-          std::make_unique<EmptyCmd>()));
+      return absl::OkStatus();
     }
 
     case Thunk::Kind::kCommandBuffer:
@@ -409,7 +403,7 @@ static absl::Status AppendCommands(ConversionContext& ctx,
       concurrent_region_id_to_thunk_indices;
   std::vector<int64_t> concurrent_region_ids;
   for (const std::unique_ptr<Thunk>& thunk : sequence) {
-    TF_RETURN_IF_ERROR(AppendCommands(ctx, cmd_sequence, *thunk, options));
+    RETURN_IF_ERROR(AppendCommands(ctx, cmd_sequence, *thunk, options));
     int64_t index = cmd_sequence.size() - 1;
     thunk_to_index[thunk.get()] = index;
     if (thunk->concurrent_region_id().has_value()) {
@@ -443,16 +437,6 @@ static absl::Status AppendCommands(ConversionContext& ctx,
     }
   }
 
-  // Convert thunk control dependencies to token resource dependency, where the
-  // predecessor has the token write, and control successor does the token read.
-  for (const std::unique_ptr<Thunk>& thunk : sequence) {
-    for (const Thunk* control_predecessor : thunk->control_predecessors()) {
-      ctx.extra_resources[thunk_to_index[control_predecessor]].push_back(
-          ResourceUse::Read(
-              cmd_sequence[thunk_to_index[thunk.get()]]->token()));
-    }
-  }
-
   return absl::OkStatus();
 }
 
@@ -463,7 +447,7 @@ absl::StatusOr<CommandExecutor> ConvertToCommands(
       options.synchronization_mode);
   ConversionContext ctx;
   CommandSequence cmd_sequence;
-  TF_RETURN_IF_ERROR(AppendCommands(ctx, cmd_sequence, sequence, options));
+  RETURN_IF_ERROR(AppendCommands(ctx, cmd_sequence, sequence, options));
   return CommandExecutor::Create(std::move(cmd_sequence),
                                  options.synchronization_mode,
                                  std::move(ctx.extra_resources));

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass.cc
@@ -54,7 +54,7 @@ limitations under the License.
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "tsl/platform/platform.h"
@@ -276,11 +276,6 @@ static bool IsConvertible(const AsyncStartThunk& async_start_thunk,
 // Returns true if the given Thunk is convertible to a command buffer operation
 // based on the provided `config`.
 bool IsConvertible(const Thunk& thunk, const CommandBufferConfig& config) {
-  // Done thunks are noops in terms of command buffer.
-  if (thunk.IsAsyncDone()) {
-    return true;
-  }
-
   // Async start thunks are convertible if all nested thunks are convertible.
   if (thunk.kind() == Thunk::kAsyncStart) {
     return IsConvertible(static_cast<const AsyncStartThunk&>(thunk), config);
@@ -333,7 +328,7 @@ bool ThunkSequenceIsConvertible(const ThunkSequence& thunks,
     if (!IsConvertible(*thunk.get(), config)) {
       return false;
     }
-    if (thunk->IsAsyncStart() || thunk->kind() == Thunk::kAsyncStart) {
+    if (thunk->kind() == Thunk::kAsyncStart) {
       size_t region_size =
           CheckAsyncRegion(absl::MakeSpan(thunks).subspan(i), config);
       if (region_size == 0) {
@@ -371,20 +366,6 @@ size_t CheckAsyncRegion(absl::Span<const std::unique_ptr<Thunk>> thunks,
     // Check if thunk is convertible
     if (!IsConvertible(*thunk, config)) {
       return 0;  // All thunks in the region must be convertible.
-    }
-
-    // Track legacy async start thunks (collectives).
-    if (thunk->IsAsyncStart() && thunk->GetAsyncEventsUniqueId().has_value()) {
-      unpaired_ids.insert(thunk->GetAsyncEventsUniqueId()->value());
-    }
-
-    // Track legacy async done thunks (collectives).
-    if (thunk->IsAsyncDone() && thunk->GetAsyncEventsUniqueId().has_value()) {
-      auto it = unpaired_ids.find(thunk->GetAsyncEventsUniqueId()->value());
-      if (it == unpaired_ids.end()) {
-        return 0;  // Done without matching start in the region.
-      }
-      unpaired_ids.erase(it);
     }
 
     // Track AsyncStartThunk/AsyncDoneThunk pairs via AsyncExecutionId.
@@ -444,11 +425,11 @@ ConvertThunksToCommandBuffer(
   bool enable_loop_unroll = debug_options.xla_gpu_command_buffer_unroll_loops();
   DebugOptions::CommandBufferUpdateMode update_mode =
       debug_options.xla_gpu_command_buffer_update_mode();
-  TF_ASSIGN_OR_RETURN(CommandExecutor cmd_executor,
-                      ConvertToCommands(thunks_to_convert,
-                                        ConvertToCommandsOptions{
-                                            synchronization_mode,
-                                            enable_loop_unroll, update_mode}));
+  ASSIGN_OR_RETURN(CommandExecutor cmd_executor,
+                   ConvertToCommands(thunks_to_convert,
+                                     ConvertToCommandsOptions{
+                                         synchronization_mode,
+                                         enable_loop_unroll, update_mode}));
 
   std::string command_buffer_profile_annotation = absl::StrCat(
       "command_buffer",
@@ -506,7 +487,7 @@ absl::Status FlushCommandBuffer(
     return absl::OkStatus();
   }
 
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       auto cmd_buffer_thunk,
       ConvertThunksToCommandBuffer(std::move(current_command_buffer_thunks),
                                    synchronization_mode, debug_options));
@@ -542,10 +523,9 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
       GetCommandBufferConfig(debug_options, device_info, hlo_module);
   VLOG(1) << "Module " << module_name_
           << " CommandBufferConfig: " << config.ToString();
-  TF_ASSIGN_OR_RETURN(
-      CommandExecutor::SynchronizationMode synchronization_mode,
-      GetSynchronizationMode(
-          debug_options.xla_gpu_command_buffer_scheduling_mode()));
+  ASSIGN_OR_RETURN(CommandExecutor::SynchronizationMode synchronization_mode,
+                   GetSynchronizationMode(
+                       debug_options.xla_gpu_command_buffer_scheduling_mode()));
 
   bool changed = false;
 
@@ -565,7 +545,7 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
 
     // We always have to capture both corresponding start and done events in the
     // same command buffer.
-    if (thunk->IsAsyncStart() || thunk->kind() == Thunk::kAsyncStart) {
+    if (thunk->kind() == Thunk::kAsyncStart) {
       // Collect and check async region
       absl::Span<std::unique_ptr<Thunk>> region = CollectAndCheckAsyncRegion(
           absl::MakeSpan(original_thunks).subspan(i), config);
@@ -577,7 +557,7 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
         absl::c_move(region, std::back_inserter(current_command_buffer_thunks));
         continue;
       }
-    } else if (IsConvertible(*thunk.get(), config) && !thunk->IsAsyncDone() &&
+    } else if (IsConvertible(*thunk.get(), config) &&
                thunk->kind() != Thunk::kAsyncDone) {
       // Check if thunk is convertible and not an async done: async done thunks
       // can be only added to the current_command_buffer_thunks as part of a
@@ -589,19 +569,18 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
       // If a `WhileThunk` itself is not eligible for conversion into a
       // command buffer, we attempt to convert thunks within its body
       auto while_thunk = static_cast<WhileThunk*>(thunk.get());
-      TF_ASSIGN_OR_RETURN(
-          bool changed_in_body,
-          Run(&while_thunk->body_executor().thunks(), debug_options, hlo_module,
-              device_info, allocator));
+      ASSIGN_OR_RETURN(bool changed_in_body,
+                       Run(&while_thunk->body_executor().thunks(),
+                           debug_options, hlo_module, device_info, allocator));
       changed |= changed_in_body;
     } else if (thunk->kind() == Thunk::kConditional) {
       // If a `ConditionalThunk` itself is not eligible for conversion into a
       // command buffer, we attempt to convert thunks within its branches.
       auto conditional_thunk = static_cast<ConditionalThunk*>(thunk.get());
       for (auto& branch_executor : conditional_thunk->branch_executors()) {
-        TF_ASSIGN_OR_RETURN(bool changed_in_branch,
-                            Run(&branch_executor.thunks(), debug_options,
-                                hlo_module, device_info, allocator));
+        ASSIGN_OR_RETURN(bool changed_in_branch,
+                         Run(&branch_executor.thunks(), debug_options,
+                             hlo_module, device_info, allocator));
         changed |= changed_in_branch;
       }
     }
@@ -609,12 +588,12 @@ absl::StatusOr<bool> CommandBufferConversionPass::Run(
     // If the current thunk is not convertible, flush collected eligible thunk
     // to a command buffer thunk and add it to the processed sequence. Then add
     // non-convertible thunk to the sequence.
-    TF_RETURN_IF_ERROR(flush_command_buffer());
+    RETURN_IF_ERROR(flush_command_buffer());
     new_thunks.push_back(std::move(thunk));
   }
 
   // Flush the last command buffer.
-  TF_RETURN_IF_ERROR(flush_command_buffer());
+  RETURN_IF_ERROR(flush_command_buffer());
 
   *thunk_sequence = std::move(new_thunks);
   return changed;

--- a/xla/backends/gpu/runtime/host_async_thunk.h
+++ b/xla/backends/gpu/runtime/host_async_thunk.h
@@ -1,0 +1,47 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_HOST_ASYNC_THUNK_H_
+#define XLA_BACKENDS_GPU_RUNTIME_HOST_ASYNC_THUNK_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "xla/backends/gpu/runtime/thunk.h"
+#include "xla/tsl/lib/gtl/int_type.h"
+
+namespace xla::gpu {
+
+// Unique identifier for async events. The same identifier is expected to be
+// shared between a pair of host async start and corresponding done thunks.
+TSL_LIB_GTL_DEFINE_INT_TYPE(AsyncEventsUniqueId, uint64_t);
+
+// Base class for host async thunks that provides async event tracking APIs.
+// Host send/recv and host execute thunks inherit from this class.
+class HostAsyncThunk : public Thunk {
+ public:
+  using Thunk::Thunk;
+
+  virtual std::optional<AsyncEventsUniqueId> GetAsyncEventsUniqueId() const {
+    return std::nullopt;
+  }
+
+  virtual bool IsAsyncStart() const { return false; }
+  virtual bool IsAsyncDone() const { return false; }
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_HOST_ASYNC_THUNK_H_

--- a/xla/backends/gpu/runtime/host_execute_thunk.cc
+++ b/xla/backends/gpu/runtime/host_execute_thunk.cc
@@ -57,7 +57,7 @@ limitations under the License.
 #include "xla/tsl/concurrency/async_value_ref.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
 #include "tsl/platform/cpu_info.h"
@@ -222,7 +222,7 @@ absl::StatusOr<HostExecuteCallFrame> HostExecuteCallFrame::Create(
     absl::Span<HostExecuteStartThunk::SliceAndShape> results,
     const ProgramShape& program_shape) {
   tsl::profiler::TraceMe trace("HostExecuteCallFrame::Create");
-  TF_RETURN_IF_ERROR(ValidateArgsAndResults(args, results, program_shape));
+  RETURN_IF_ERROR(ValidateArgsAndResults(args, results, program_shape));
 
   std::vector<ShapeTree<HostOffloadingBuffer>> parameters;
   std::vector<std::unique_ptr<HostOffloadingAllocator::Buffer>> buffers;
@@ -236,7 +236,7 @@ absl::StatusOr<HostExecuteCallFrame> HostExecuteCallFrame::Create(
       auto buffer_allocation = buffer_allocations->GetDeviceAddress(slice);
       if (IsBufferOnDevice(device_to_host_stream, buffer_allocation.opaque())) {
         // Copy device memory to host memory.
-        TF_ASSIGN_OR_RETURN(
+        ASSIGN_OR_RETURN(
             buffers.emplace_back(),
             allocator.AllocateTransferBuffer(ShapeUtil::ByteSizeOf(shape)));
 
@@ -244,7 +244,7 @@ absl::StatusOr<HostExecuteCallFrame> HostExecuteCallFrame::Create(
             shape, HostOffloadingBuffer(buffers.back()->untyped_data(),
                                         buffers.back()->size_bytes())));
 
-        TF_RETURN_IF_ERROR(device_to_host_stream->Memcpy(
+        RETURN_IF_ERROR(device_to_host_stream->Memcpy(
             buffers.back()->untyped_data(), buffer_allocation,
             buffers.back()->size_bytes()));
       } else {
@@ -268,7 +268,7 @@ absl::StatusOr<HostExecuteCallFrame> HostExecuteCallFrame::Create(
       auto buffer_allocation = buffer_allocations->GetDeviceAddress(slice);
 
       if (IsBufferOnDevice(host_to_device_stream, buffer_allocation.opaque())) {
-        TF_ASSIGN_OR_RETURN(
+        ASSIGN_OR_RETURN(
             buffers.emplace_back(),
             allocator.AllocateTransferBuffer(ShapeUtil::ByteSizeOf(shape)));
         result_buffer = HostOffloadingBuffer(buffers.back()->untyped_data(),
@@ -314,13 +314,13 @@ absl::Status HostExecuteCallFrame::PublishResult() && {
     }
 
     auto shape = ShapeUtil::GetSubshape(result_.shape(), index);
-    TF_RETURN_IF_ERROR(host_to_device_stream_->Memcpy(
+    RETURN_IF_ERROR(host_to_device_stream_->Memcpy(
         &result_buffer, buffer.opaque_base(), buffer.size_in_bytes()));
   }
 
   // Move the backing buffers (allocated_buffers_) to the callback to ensure
   // that they are only destroyed after the memory copies are done.
-  TF_RETURN_IF_ERROR(host_to_device_stream_->DoHostCallbackWithStatus(
+  RETURN_IF_ERROR(host_to_device_stream_->DoHostCallbackWithStatus(
       [buffers = std::move(allocated_buffers_)]() {
         return absl::OkStatus();
       }));
@@ -339,8 +339,7 @@ HostExecuteAsyncEvents::CreateEvent(se::StreamExecutor* executor,
   VLOG(6) << "Adding event for executor at address " << executor
           << " and event id " << run_id.ToInt();
 
-  TF_ASSIGN_OR_RETURN(auto host_to_device_stream_event,
-                      executor->CreateEvent());
+  ASSIGN_OR_RETURN(auto host_to_device_stream_event, executor->CreateEvent());
 
   auto event = tsl::MakeConstructedAsyncValueRef<std::unique_ptr<se::Event>>(
       std::move(host_to_device_stream_event));
@@ -388,7 +387,7 @@ HostExecuteStartThunk::Create(
       std::move(thunk_info), host_offloading_executable_proto, std::move(args),
       std::move(results));
   if (host_offloading_executable_proto.has_aot_compilation_result()) {
-    TF_RETURN_IF_ERROR(thunk->LoadExecutable());
+    RETURN_IF_ERROR(thunk->LoadExecutable());
   }
   return thunk;
 }
@@ -403,9 +402,8 @@ absl::Status HostExecuteStartThunk::LoadExecutable() {
         "compilation result.");
   }
 
-  TF_ASSIGN_OR_RETURN(
-      executable_,
-      HostOffloadingNanoRtExecutable::LoadFromProto(executable_proto_));
+  ASSIGN_OR_RETURN(executable_, HostOffloadingNanoRtExecutable::LoadFromProto(
+                                    executable_proto_));
   return absl::OkStatus();
 }
 
@@ -413,7 +411,7 @@ HostExecuteStartThunk::HostExecuteStartThunk(
     Thunk::ThunkInfo thunk_info, const HloModule& hlo_module,
     absl::InlinedVector<HostExecuteStartThunk::SliceAndShape, 4> args,
     absl::InlinedVector<HostExecuteStartThunk::SliceAndShape, 4> results)
-    : Thunk(Thunk::Kind::kHostExecuteStart, std::move(thunk_info)),
+    : HostAsyncThunk(Thunk::Kind::kHostExecuteStart, std::move(thunk_info)),
       args_(std::move(args)),
       results_(std::move(results)),
       async_events_(std::make_shared<HostExecuteAsyncEvents>()) {
@@ -430,7 +428,7 @@ HostExecuteStartThunk::HostExecuteStartThunk(
     absl::InlinedVector<HostExecuteStartThunk::SliceAndShape, 4> args,
     absl::InlinedVector<HostExecuteStartThunk::SliceAndShape, 4> results,
     std::shared_ptr<HostExecuteAsyncEvents> async_events)
-    : Thunk(Thunk::Kind::kHostExecuteStart, std::move(thunk_info)),
+    : HostAsyncThunk(Thunk::Kind::kHostExecuteStart, std::move(thunk_info)),
       args_(std::move(args)),
       results_(std::move(results)),
       executable_proto_(host_offloading_executable_proto) {
@@ -451,14 +449,14 @@ absl::StatusOr<ThunkProto> HostExecuteStartThunk::ToProto() const {
 
   for (const auto& [slice, shape] : args_) {
     ShapedSliceProto* arg_proto = host_execute_start_thunk_proto->add_args();
-    TF_ASSIGN_OR_RETURN(*arg_proto->mutable_slice(), slice.ToProto());
+    ASSIGN_OR_RETURN(*arg_proto->mutable_slice(), slice.ToProto());
     *arg_proto->mutable_shape() = shape.ToProto();
   }
 
   for (const auto& [slice, shape] : results_) {
     ShapedSliceProto* result_proto =
         host_execute_start_thunk_proto->add_results();
-    TF_ASSIGN_OR_RETURN(*result_proto->mutable_slice(), slice.ToProto());
+    ASSIGN_OR_RETURN(*result_proto->mutable_slice(), slice.ToProto());
     *result_proto->mutable_shape() = shape.ToProto();
   }
 
@@ -484,18 +482,18 @@ HostExecuteStartThunk::FromProto(
           absl::InlinedVector<HostExecuteStartThunk::SliceAndShape, 4>&
               slices_and_shapes) -> absl::Status {
     for (const auto& shaped_slice_proto : shaped_slice_protos) {
-      TF_ASSIGN_OR_RETURN(auto slice,
-                          BufferAllocation::Slice::FromProto(
-                              shaped_slice_proto.slice(), buffer_allocations));
-      TF_ASSIGN_OR_RETURN(auto shape,
-                          Shape::FromProto(shaped_slice_proto.shape()));
+      ASSIGN_OR_RETURN(auto slice,
+                       BufferAllocation::Slice::FromProto(
+                           shaped_slice_proto.slice(), buffer_allocations));
+      ASSIGN_OR_RETURN(auto shape,
+                       Shape::FromProto(shaped_slice_proto.shape()));
       slices_and_shapes.push_back({slice, shape});
     }
     return absl::OkStatus();
   };
 
-  TF_RETURN_IF_ERROR(shaped_slice_from_proto(proto.args(), args));
-  TF_RETURN_IF_ERROR(shaped_slice_from_proto(proto.results(), results));
+  RETURN_IF_ERROR(shaped_slice_from_proto(proto.args(), args));
+  RETURN_IF_ERROR(shaped_slice_from_proto(proto.results(), results));
 
   // If async_events_map already contains an entry for the given unique id,
   // that means that the pairing done thunk is already serialized and we reuse
@@ -546,14 +544,14 @@ absl::Status HostExecuteStartThunk::ExecuteOnStream(
 
   // Wait on the compute stream to finish before copying data to host since we
   // might need to wait for producers to be finished.
-  TF_RETURN_IF_ERROR(device_to_host_stream->WaitFor(compute_stream));
+  RETURN_IF_ERROR(device_to_host_stream->WaitFor(compute_stream));
 
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       auto execute_event,
       async_events_->CreateEvent(params.host_to_device_stream->parent(),
                                  RunId(params.execution_id)));
 
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       auto tmp_call_frame,
       HostExecuteCallFrame::Create(
           params.device_to_host_stream, params.host_to_device_stream,
@@ -606,7 +604,7 @@ absl::Status HostExecuteStartThunk::ExecuteOnStream(
     execute_event_ptr.SetStateConcrete();
   };
 
-  TF_RETURN_IF_ERROR(device_to_host_stream->DoHostCallbackWithStatus(
+  RETURN_IF_ERROR(device_to_host_stream->DoHostCallbackWithStatus(
       [execute = std::move(execute),
        d2h_stream_executor = device_to_host_stream->parent()] {
         GetHostExecuteThreadPool(d2h_stream_executor)
@@ -630,7 +628,7 @@ HostExecuteStartThunk::GetAsyncEventsUniqueId() const {
 HostExecuteDoneThunk::HostExecuteDoneThunk(
     Thunk::ThunkInfo thunk_info,
     std::shared_ptr<HostExecuteAsyncEvents> async_events)
-    : Thunk(Thunk::Kind::kHostExecuteDone, std::move(thunk_info)),
+    : HostAsyncThunk(Thunk::Kind::kHostExecuteDone, std::move(thunk_info)),
       async_events_(std::move(async_events)) {
   CHECK(async_events_) << "async_events must not be null";
 }
@@ -675,9 +673,9 @@ absl::Status HostExecuteDoneThunk::Initialize(const InitializeParams& params) {
 
 absl::Status HostExecuteDoneThunk::ExecuteOnStream(
     const ExecuteParams& params) {
-  TF_ASSIGN_OR_RETURN(auto event, async_events_->ExtractEvent(
-                                      params.host_to_device_stream->parent(),
-                                      RunId(params.execution_id)));
+  ASSIGN_OR_RETURN(auto event, async_events_->ExtractEvent(
+                                   params.host_to_device_stream->parent(),
+                                   RunId(params.execution_id)));
 
   tsl::BlockUntilReady(event);
   if (event.IsError()) {
@@ -686,7 +684,7 @@ absl::Status HostExecuteDoneThunk::ExecuteOnStream(
 
   // We queue this event on the compute stream so that the host to device copy
   // finishes before the consumer of the data can start.
-  TF_RETURN_IF_ERROR(params.stream->WaitFor(event.get().get()));
+  RETURN_IF_ERROR(params.stream->WaitFor(event.get().get()));
 
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/host_execute_thunk.h
+++ b/xla/backends/gpu/runtime/host_execute_thunk.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
+#include "xla/backends/gpu/runtime/host_async_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/core/host_offloading/host_offloading_allocator.h"
@@ -75,7 +76,7 @@ using HostExecuteAsyncEventsMap =
     absl::flat_hash_map<AsyncEventsUniqueId,
                         std::shared_ptr<HostExecuteAsyncEvents>>;
 
-class HostExecuteStartThunk : public Thunk {
+class HostExecuteStartThunk : public HostAsyncThunk {
  public:
   struct SliceAndShape {
     BufferAllocation::Slice slice;
@@ -147,7 +148,7 @@ class HostExecuteStartThunk : public Thunk {
   std::shared_ptr<HostExecuteAsyncEvents> async_events_;
 };
 
-class HostExecuteDoneThunk : public Thunk {
+class HostExecuteDoneThunk : public HostAsyncThunk {
  public:
   explicit HostExecuteDoneThunk(
       Thunk::ThunkInfo thunk_info,

--- a/xla/backends/gpu/runtime/host_send_recv_thunk.cc
+++ b/xla/backends/gpu/runtime/host_send_recv_thunk.cc
@@ -41,7 +41,7 @@ limitations under the License.
 #include "xla/tsl/concurrency/async_value.h"
 #include "xla/tsl/concurrency/async_value_ref.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "tsl/profiler/lib/traceme.h"
 
 namespace xla::gpu {
@@ -110,7 +110,7 @@ HostSendThunk::HostSendThunk(
     int64_t channel_id, std::shared_ptr<HostSendRecvAsyncEvents> events,
     absl::flat_hash_map<std::string, std::string> frontend_attrs,
     std::optional<GlobalDeviceId> device_constraint)
-    : Thunk(Thunk::kHostSend, thunk_info),
+    : HostAsyncThunk(Thunk::kHostSend, thunk_info),
       shape_(shape),
       buffer_(buffer),
       channel_id_(channel_id),
@@ -123,8 +123,7 @@ absl::StatusOr<ThunkProto> HostSendThunk::ToProto() const {
   *proto.mutable_thunk_info() = thunk_info().ToProto();
   HostSendThunkProto& host_send_thunk_proto = *proto.mutable_host_send_thunk();
   *host_send_thunk_proto.mutable_shape() = shape_.ToProto();
-  TF_ASSIGN_OR_RETURN(*host_send_thunk_proto.mutable_buffer(),
-                      buffer_.ToProto());
+  ASSIGN_OR_RETURN(*host_send_thunk_proto.mutable_buffer(), buffer_.ToProto());
   host_send_thunk_proto.set_channel_id(channel_id_);
   for (const auto& [key, value] : frontend_attrs_) {
     host_send_thunk_proto.mutable_frontend_attrs()->insert({key, value});
@@ -146,8 +145,8 @@ absl::StatusOr<std::unique_ptr<HostSendThunk>> HostSendThunk::FromProto(
     ThunkInfo thunk_info, const HostSendThunkProto& proto,
     absl::Span<const BufferAllocation> allocations,
     HostSendRecvAsyncEventsMap& async_events_map) {
-  TF_ASSIGN_OR_RETURN(Shape shape, Shape::FromProto(proto.shape()));
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(Shape shape, Shape::FromProto(proto.shape()));
+  ASSIGN_OR_RETURN(
       BufferAllocation::Slice buffer,
       BufferAllocation::Slice::FromProto(proto.buffer(), allocations));
   std::optional<GlobalDeviceId> device_constraint;
@@ -169,8 +168,8 @@ absl::Status HostSendThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Send buffer: channel_id=" << channel_id_
           << "; shape=" << shape_.ToString();
 
-  TF_ASSIGN_OR_RETURN(bool skip,
-                      ShouldSkip("sending buffer", params, device_constraint_));
+  ASSIGN_OR_RETURN(bool skip,
+                   ShouldSkip("sending buffer", params, device_constraint_));
   if (skip) {
     return absl::OkStatus();
   }
@@ -181,7 +180,7 @@ absl::Status HostSendThunk::ExecuteOnStream(const ExecuteParams& params) {
   // Use device_to_host stream if it is available.
   se::Stream* stream = params.device_to_host_stream;
   if (stream) {
-    TF_RETURN_IF_ERROR(stream->WaitFor(params.stream));
+    RETURN_IF_ERROR(stream->WaitFor(params.stream));
   } else {
     stream = params.stream;
   }
@@ -191,7 +190,7 @@ absl::Status HostSendThunk::ExecuteOnStream(const ExecuteParams& params) {
 
   // Send buffer to a handler registered with the executable.
   if (auto* send = params.send_device_memory_function) {
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         AsyncValueRef<std::unique_ptr<se::Event>> done,
         (*send)(channel_id_, stream, shape_, src, frontend_attrs_));
     return events_->Emplace(stream->parent(), channel_id_, std::move(done));
@@ -218,7 +217,7 @@ HostSendDoneThunk::HostSendDoneThunk(
     ThunkInfo thunk_info, int64_t channel_id,
     std::shared_ptr<HostSendRecvAsyncEvents> events,
     std::optional<GlobalDeviceId> device_constraint)
-    : Thunk(Thunk::kHostSendDone, thunk_info),
+    : HostAsyncThunk(Thunk::kHostSendDone, thunk_info),
       channel_id_(channel_id),
       events_(std::move(events)),
       device_constraint_(device_constraint) {}
@@ -264,8 +263,8 @@ absl::StatusOr<std::unique_ptr<HostSendDoneThunk>> HostSendDoneThunk::FromProto(
 absl::Status HostSendDoneThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Wait for send completion: channel_id=" << channel_id_;
 
-  TF_ASSIGN_OR_RETURN(bool skip, ShouldSkip("waiting for send completion",
-                                            params, device_constraint_));
+  ASSIGN_OR_RETURN(bool skip, ShouldSkip("waiting for send completion", params,
+                                         device_constraint_));
   if (skip) {
     return absl::OkStatus();
   }
@@ -274,7 +273,7 @@ absl::Status HostSendDoneThunk::ExecuteOnStream(const ExecuteParams& params) {
       [&] { return TraceMeEncode("SendDone", {{"channel_id", channel_id_}}); });
 
   se::StreamExecutor* executor = params.stream->parent();
-  TF_ASSIGN_OR_RETURN(auto done_event, events_->Extract(executor, channel_id_));
+  ASSIGN_OR_RETURN(auto done_event, events_->Extract(executor, channel_id_));
 
   // Wait until send handler will record an event on the stream.
   BlockUntilReady(done_event.GetAsyncValue());
@@ -306,7 +305,7 @@ HostRecvThunk::HostRecvThunk(
     int64_t channel_id, std::shared_ptr<HostSendRecvAsyncEvents> events,
     absl::flat_hash_map<std::string, std::string> frontend_attrs,
     std::optional<GlobalDeviceId> device_constraint)
-    : Thunk(Thunk::kHostRecv, thunk_info),
+    : HostAsyncThunk(Thunk::kHostRecv, thunk_info),
       shape_(shape),
       buffer_(buffer),
       channel_id_(channel_id),
@@ -319,8 +318,7 @@ absl::StatusOr<ThunkProto> HostRecvThunk::ToProto() const {
   *proto.mutable_thunk_info() = thunk_info().ToProto();
   HostRecvThunkProto& host_recv_thunk_proto = *proto.mutable_host_recv_thunk();
   *host_recv_thunk_proto.mutable_shape() = shape_.ToProto();
-  TF_ASSIGN_OR_RETURN(*host_recv_thunk_proto.mutable_buffer(),
-                      buffer_.ToProto());
+  ASSIGN_OR_RETURN(*host_recv_thunk_proto.mutable_buffer(), buffer_.ToProto());
   host_recv_thunk_proto.set_channel_id(channel_id_);
   for (const auto& [key, value] : frontend_attrs_) {
     host_recv_thunk_proto.mutable_frontend_attrs()->insert({key, value});
@@ -342,8 +340,8 @@ absl::StatusOr<std::unique_ptr<HostRecvThunk>> HostRecvThunk::FromProto(
     ThunkInfo thunk_info, const HostRecvThunkProto& proto,
     absl::Span<const BufferAllocation> allocations,
     HostSendRecvAsyncEventsMap& async_events_map) {
-  TF_ASSIGN_OR_RETURN(Shape shape, Shape::FromProto(proto.shape()));
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(Shape shape, Shape::FromProto(proto.shape()));
+  ASSIGN_OR_RETURN(
       BufferAllocation::Slice buffer,
       BufferAllocation::Slice::FromProto(proto.buffer(), allocations));
   std::optional<GlobalDeviceId> device_constraint;
@@ -365,8 +363,8 @@ absl::Status HostRecvThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Recv buffer: channel_id=" << channel_id_
           << "; shape=" << shape_.ToString();
 
-  TF_ASSIGN_OR_RETURN(
-      bool skip, ShouldSkip("receiving buffer", params, device_constraint_));
+  ASSIGN_OR_RETURN(bool skip,
+                   ShouldSkip("receiving buffer", params, device_constraint_));
   if (skip) {
     return absl::OkStatus();
   }
@@ -377,7 +375,7 @@ absl::Status HostRecvThunk::ExecuteOnStream(const ExecuteParams& params) {
   // Use host_to_device stream if it is available.
   se::Stream* stream = params.host_to_device_stream;
   if (stream) {
-    TF_RETURN_IF_ERROR(stream->WaitFor(params.stream));
+    RETURN_IF_ERROR(stream->WaitFor(params.stream));
   } else {
     stream = params.stream;
   }
@@ -387,7 +385,7 @@ absl::Status HostRecvThunk::ExecuteOnStream(const ExecuteParams& params) {
 
   // Recv buffer from a handler registered with the run options.
   if (auto* recv = params.recv_device_memory_function) {
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         AsyncValueRef<std::unique_ptr<se::Event>> done,
         (*recv)(channel_id_, stream, shape_, &dst, frontend_attrs_));
     return events_->Emplace(stream->parent(), channel_id_, std::move(done));
@@ -414,7 +412,7 @@ HostRecvDoneThunk::HostRecvDoneThunk(
     ThunkInfo thunk_info, int64_t channel_id,
     std::shared_ptr<HostSendRecvAsyncEvents> events,
     std::optional<GlobalDeviceId> device_constraint)
-    : Thunk(Thunk::kHostRecvDone, thunk_info),
+    : HostAsyncThunk(Thunk::kHostRecvDone, thunk_info),
       channel_id_(channel_id),
       events_(std::move(events)),
       device_constraint_(device_constraint) {}
@@ -460,8 +458,8 @@ absl::StatusOr<std::unique_ptr<HostRecvDoneThunk>> HostRecvDoneThunk::FromProto(
 absl::Status HostRecvDoneThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Wait for recv completion: channel_id=" << channel_id_;
 
-  TF_ASSIGN_OR_RETURN(bool skip, ShouldSkip("waiting for recv completion",
-                                            params, device_constraint_));
+  ASSIGN_OR_RETURN(bool skip, ShouldSkip("waiting for recv completion", params,
+                                         device_constraint_));
   if (skip) {
     return absl::OkStatus();
   }
@@ -470,7 +468,7 @@ absl::Status HostRecvDoneThunk::ExecuteOnStream(const ExecuteParams& params) {
       [&] { return TraceMeEncode("RecvDone", {{"channel_id", channel_id_}}); });
 
   se::StreamExecutor* executor = params.stream->parent();
-  TF_ASSIGN_OR_RETURN(auto done_event, events_->Extract(executor, channel_id_));
+  ASSIGN_OR_RETURN(auto done_event, events_->Extract(executor, channel_id_));
 
   // Wait until send handler will record an event on the stream.
   BlockUntilReady(done_event.GetAsyncValue());

--- a/xla/backends/gpu/runtime/host_send_recv_thunk.h
+++ b/xla/backends/gpu/runtime/host_send_recv_thunk.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
+#include "xla/backends/gpu/runtime/host_async_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/runtime/buffer_use.h"
@@ -91,7 +92,7 @@ using HostSendRecvAsyncEventsMap =
 // HostSendThunk
 //===----------------------------------------------------------------------===//
 
-class HostSendThunk : public Thunk {
+class HostSendThunk : public HostAsyncThunk {
  public:
   static absl::StatusOr<std::unique_ptr<HostSendThunk>> FromProto(
       ThunkInfo thunk_info, const HostSendThunkProto& proto,
@@ -133,7 +134,7 @@ class HostSendThunk : public Thunk {
 // HostSendDoneThunk
 //===----------------------------------------------------------------------===//
 
-class HostSendDoneThunk : public Thunk {
+class HostSendDoneThunk : public HostAsyncThunk {
  public:
   static absl::StatusOr<std::unique_ptr<HostSendDoneThunk>> FromProto(
       ThunkInfo thunk_info, const HostSendDoneThunkProto& proto,
@@ -163,7 +164,7 @@ class HostSendDoneThunk : public Thunk {
 // HostRecvThunk
 //===----------------------------------------------------------------------===//
 
-class HostRecvThunk : public Thunk {
+class HostRecvThunk : public HostAsyncThunk {
  public:
   static absl::StatusOr<std::unique_ptr<HostRecvThunk>> FromProto(
       ThunkInfo thunk_info, const HostRecvThunkProto& proto,
@@ -205,7 +206,7 @@ class HostRecvThunk : public Thunk {
 // HostRecvDoneThunk
 //===----------------------------------------------------------------------===//
 
-class HostRecvDoneThunk : public Thunk {
+class HostRecvDoneThunk : public HostAsyncThunk {
  public:
   static absl::StatusOr<std::unique_ptr<HostRecvDoneThunk>> FromProto(
       ThunkInfo thunk_info, const HostRecvDoneThunkProto& proto,

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -58,17 +58,11 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/concurrency/future.h"
-#include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/util.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
-
-// Unique identifier for async events. The same identifier is expected to be
-// shared between a pair of StartThunk and corresponding DoneThunk. It is used
-// to collect async regions for a CommandBufferThunk.
-TSL_LIB_GTL_DEFINE_INT_TYPE(AsyncEventsUniqueId, uint64_t);
 
 // Thunk acts as the bridge between IrEmitter and GpuExecutable. It stores the
 // metadata IrEmitter generates for GpuExecutable to invoke an HloInstruction.
@@ -483,14 +477,6 @@ class Thunk {
       absl::AnyInvocable<absl::StatusOr<std::unique_ptr<Thunk>>(
           const ThunkProto&, absl::Span<const BufferAllocation>) const>;
 
-  void add_control_predecessor(const Thunk* control_predecessor) {
-    control_predecessors_.push_back(control_predecessor);
-  }
-
-  std::vector<const Thunk*> control_predecessors() const {
-    return control_predecessors_;
-  }
-
   // In scheduling mode kConcurrentRegions, thunks sequences are divided into
   // regions. Thunks can be executed concurrently within the same region, but
   // regions will be executed sequentially.
@@ -500,14 +486,6 @@ class Thunk {
   void set_concurrent_region_id(uint64_t concurrent_region_id) {
     concurrent_region_id_ = concurrent_region_id;
   }
-
-  virtual std::optional<AsyncEventsUniqueId> GetAsyncEventsUniqueId() const {
-    return std::nullopt;
-  }
-
-  virtual bool IsAsyncStart() const { return false; }
-
-  virtual bool IsAsyncDone() const { return false; }
 
   void set_profile_annotation(absl::string_view profile_annotation) {
     thunk_info_.profile_annotation = std::string(profile_annotation);
@@ -523,13 +501,6 @@ class Thunk {
  private:
   Kind kind_;
   ThunkInfo thunk_info_;
-
-  // The list of control predecessors of the thunk.
-  // Thunk needs to maintain the control dependency information because
-  // when it is executed by command buffer, and command buffer may execute the
-  // sequence in concurrent mode, and we should make sure that it does not
-  // violate the control dependency in the original computation.
-  std::vector<const Thunk*> control_predecessors_;
 
   // Used in scheduling mode kConcurrentRegions only. More details in the
   // comments on the getter method above.

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_checksum.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_checksum.cc
@@ -54,7 +54,7 @@ limitations under the License.
 #include "xla/stream_executor/gpu/buffer_debug_log.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
 
@@ -112,7 +112,6 @@ std::unique_ptr<Thunk> WrapWithChecksumThunk(
             Thunk::ThunkInfo(), log_slice, thunk->thunk_info().thunk_id,
             std::move(buffers_to_check_before),
             /*runs_before_checked_thunk=*/true, metadata_store);
-    thunk->add_control_predecessor(buffer_debug_before_thunk.get());
     thunk_and_checks.push_back(std::move(buffer_debug_before_thunk));
   }
 
@@ -124,14 +123,11 @@ std::unique_ptr<Thunk> WrapWithChecksumThunk(
         Thunk::ThunkInfo(), log_slice, thunk_ptr->thunk_info().thunk_id,
         std::move(buffers_to_check_after),
         /*runs_before_checked_thunk=*/false, metadata_store);
-    buffer_debug_after_thunk->add_control_predecessor(thunk_ptr);
     thunk_and_checks.push_back(std::move(buffer_debug_after_thunk));
   }
 
   auto wrapped_thunk = std::make_unique<SequentialThunk>(
       Thunk::ThunkInfo(), std::move(thunk_and_checks));
-  wrapped_thunk->add_control_predecessor(&predecessor_thunk);
-  successor_thunk.add_control_predecessor(wrapped_thunk.get());
   return wrapped_thunk;
 }
 
@@ -154,8 +150,8 @@ absl::Status DumpBufferDebugChecksumLog(
   auto buffer_debug_log =
       se::gpu::BufferDebugLog<BufferDebugLogEntry>::FromDeviceAddressUnchecked(
           log_buffer.device_memory());
-  TF_ASSIGN_OR_RETURN(std::vector<BufferDebugLogEntry> log_entries,
-                      buffer_debug_log.ReadFromDevice(*stream));
+  ASSIGN_OR_RETURN(std::vector<BufferDebugLogEntry> log_entries,
+                   buffer_debug_log.ReadFromDevice(*stream));
   BufferDebugLogProto buffer_debug_log_proto =
       metadata_store->EntriesToProto(log_entries);
 
@@ -224,14 +220,14 @@ absl::Status RunChecksumPassInternal(ThunkSequence* thunk_sequence,
   std::shared_ptr<BufferDebugLogEntryMetadataStore> metadata_store =
       std::make_shared<BufferDebugLogEntryMetadataStore>();
 
-  TF_ASSIGN_OR_RETURN(BufferAllocation * log_alloc,
-                      allocator.NewEmptyAllocation(kLogSizeBytes));
+  ASSIGN_OR_RETURN(BufferAllocation * log_alloc,
+                   allocator.NewEmptyAllocation(kLogSizeBytes));
   BufferAllocation::Slice log_slice(log_alloc, 0, log_alloc->size());
 
-  TF_ASSIGN_OR_RETURN(auto buffer_debug_init_thunk,
-                      CreateDebugInitThunk(log_slice, hlo_module));
+  ASSIGN_OR_RETURN(auto buffer_debug_init_thunk,
+                   CreateDebugInitThunk(log_slice, hlo_module));
 
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       auto buffer_debug_dump_thunk,
       CreateBufferDebugDumpThunk(metadata_store, log_slice, hlo_module));
 
@@ -248,7 +244,7 @@ absl::Status RunChecksumPassInternal(ThunkSequence* thunk_sequence,
                                  metadata_store);
   };
 
-  TF_RETURN_IF_ERROR(thunk_sequence->TransformNested(transform_callback));
+  RETURN_IF_ERROR(thunk_sequence->TransformNested(transform_callback));
 
   thunk_sequence->reserve(thunk_sequence->size() + 2);
   thunk_sequence->insert(thunk_sequence->begin(),

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
@@ -62,7 +62,7 @@ limitations under the License.
 #include "xla/stream_executor/gpu/buffer_debug_log.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
@@ -159,8 +159,8 @@ absl::StatusOr<std::unique_ptr<Thunk>> WrapWithFloatCheckThunk(
 
   const size_t temp_buffer_size_bytes =
       CalculateTempBufferSize(*thunk) * sizeof(xla::gpu::FloatCheckResult);
-  TF_ASSIGN_OR_RETURN(BufferAllocation * tmp_alloc,
-                      allocator.NewEmptyAllocation(temp_buffer_size_bytes));
+  ASSIGN_OR_RETURN(BufferAllocation * tmp_alloc,
+                   allocator.NewEmptyAllocation(temp_buffer_size_bytes));
   BufferAllocation::Slice tmp_slice(tmp_alloc, 0, tmp_alloc->size());
 
   VLOG(1) << "Wrapping thunk " << thunk->thunk_info().thunk_id
@@ -173,12 +173,9 @@ absl::StatusOr<std::unique_ptr<Thunk>> WrapWithFloatCheckThunk(
       std::make_unique<BuffersDebugFloatCheckThunk>(
           Thunk::ThunkInfo(), thunk_ptr->thunk_info(), log_slice, tmp_slice,
           std::move(buffers_to_check), std::move(metadata_store));
-  buffer_debug_float_check_thunk->add_control_predecessor(thunk_ptr);
   thunk_and_checks.push_back(std::move(buffer_debug_float_check_thunk));
   auto wrapped_thunk = std::make_unique<SequentialThunk>(
       Thunk::ThunkInfo(), std::move(thunk_and_checks));
-  wrapped_thunk->add_control_predecessor(&predecessor_thunk);
-  successor_thunk.add_control_predecessor(wrapped_thunk.get());
   return wrapped_thunk;
 }
 
@@ -313,8 +310,8 @@ absl::Status BufferDebugFloatCheck(
 
   auto buffer_debug_log = se::gpu::BufferDebugLog<BufferDebugFloatCheckEntry>::
       FromDeviceAddressUnchecked(log_buffer.device_memory());
-  TF_ASSIGN_OR_RETURN(std::vector<BufferDebugFloatCheckEntry> entries,
-                      buffer_debug_log.ReadFromDevice(*stream));
+  ASSIGN_OR_RETURN(std::vector<BufferDebugFloatCheckEntry> entries,
+                   buffer_debug_log.ReadFromDevice(*stream));
 
   std::vector<BufferDebugLogEntryId> entry_ids;
   entry_ids.reserve(entries.size());
@@ -422,14 +419,14 @@ absl::Status RunFloatCheckPassInternal(ThunkSequence* thunk_sequence,
   std::shared_ptr<BufferDebugLogEntryMetadataStore> metadata_store =
       std::make_shared<BufferDebugLogEntryMetadataStore>();
 
-  TF_ASSIGN_OR_RETURN(BufferAllocation * log_alloc,
-                      allocator.NewEmptyAllocation(kLogSizeBytes));
+  ASSIGN_OR_RETURN(BufferAllocation * log_alloc,
+                   allocator.NewEmptyAllocation(kLogSizeBytes));
   BufferAllocation::Slice log_slice(log_alloc, 0, log_alloc->size());
 
-  TF_ASSIGN_OR_RETURN(auto buffer_debug_init_thunk,
-                      CreateDebugInitThunk(log_slice, hlo_module));
+  ASSIGN_OR_RETURN(auto buffer_debug_init_thunk,
+                   CreateDebugInitThunk(log_slice, hlo_module));
 
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       auto buffer_debug_dump_thunk,
       CreateBufferDebugFloatCheckThunk(metadata_store, log_slice, hlo_module));
 
@@ -447,7 +444,7 @@ absl::Status RunFloatCheckPassInternal(ThunkSequence* thunk_sequence,
         allocator);
   };
 
-  TF_RETURN_IF_ERROR(thunk_sequence->TransformNested(transform_callback));
+  RETURN_IF_ERROR(thunk_sequence->TransformNested(transform_callback));
 
   thunk_sequence->reserve(thunk_sequence->size() + 2);
   thunk_sequence->insert(thunk_sequence->begin(),

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_saver_inserter.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_saver_inserter.cc
@@ -37,7 +37,7 @@ limitations under the License.
 #include "xla/service/shaped_slice.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
 
@@ -75,13 +75,12 @@ absl::StatusOr<std::unique_ptr<Thunk>> InsertBufferSaverCustomCall(
     info.profile_annotation =
         absl::StrCat("Buffer saver ", sequence[0]->profile_annotation());
 
-    TF_ASSIGN_OR_RETURN(
+    ASSIGN_OR_RETURN(
         auto log_thunk,
         CustomCallThunk::Create(
             info, std::string{kXlaGpuAppendToFileCustomCallTag}, {output},
             {std::nullopt}, attributes, hlo_module.entry_computation(), "GPU",
             stream_executor::GpuComputeCapability()));
-    log_thunk->add_control_predecessor(sequence[0].get());
     sequence.emplace_back(std::move(log_thunk));
   }
 

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -166,6 +166,7 @@ limitations under the License.
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/concurrency/future.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -174,7 +175,6 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/human_readable_json.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -1767,60 +1767,6 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
   return GetThunkSequence(std::move(start_thunk));
 }
 
-std::vector<const HloInstruction*> GetRealDependencyInstructions(
-    const HloInstruction* instr) {
-  std::vector<const HloInstruction*> real_deps;
-  switch (instr->opcode()) {
-    case HloOpcode::kSend:
-    case HloOpcode::kSendDone:
-    case HloOpcode::kRecv:
-    case HloOpcode::kRecvDone:
-      return {FindCanonicalSendRecvStartOp(instr)};
-    case HloOpcode::kAllGatherDone:
-    case HloOpcode::kAllReduceDone:
-    case HloOpcode::kAsyncDone:
-    case HloOpcode::kCollectivePermuteDone:
-    case HloOpcode::kCopyDone:
-      return {instr->operand(0)};
-    case HloOpcode::kAllGatherStart:
-    case HloOpcode::kAllReduceStart:
-    case HloOpcode::kAsyncStart:
-    case HloOpcode::kCollectivePermuteStart:
-    case HloOpcode::kCall:
-    case HloOpcode::kConditional:
-    case HloOpcode::kConstant:
-    case HloOpcode::kCustomCall:
-    case HloOpcode::kFusion:
-    case HloOpcode::kCopy:
-    case HloOpcode::kInfeed:
-    case HloOpcode::kOutfeed:
-    case HloOpcode::kPartitionId:
-    case HloOpcode::kFft:
-    case HloOpcode::kReplicaId:
-    case HloOpcode::kRngGetAndUpdateState:
-    case HloOpcode::kSort:
-    case HloOpcode::kWhile:
-    case HloOpcode::kCopyStart:
-      return {instr};
-    case HloOpcode::kAddDependency:
-    case HloOpcode::kAfterAll:
-    case HloOpcode::kTuple:
-      for (const HloInstruction* operand : instr->operands()) {
-        auto deps = GetRealDependencyInstructions(operand);
-        real_deps.insert(real_deps.end(), deps.begin(), deps.end());
-      }
-      return real_deps;
-    case HloOpcode::kBitcast:
-    case HloOpcode::kGetTupleElement: {
-      auto deps = GetRealDependencyInstructions(instr->operand(0));
-      real_deps.insert(real_deps.end(), deps.begin(), deps.end());
-    }
-      return real_deps;
-    default:
-      return {};
-  }
-}
-
 AsyncThunkSequence ThunkEmitter::EmitCollectiveGroupStartThunk(
     const HloInstruction* instr) {
   ThunkSequence thunks;
@@ -2827,28 +2773,6 @@ AsyncThunkSequence ThunkEmitter::EmitHloComputation(
             for (auto& thunk : thunks) {
               if (concurrent_region_id.has_value()) {
                 thunk->set_concurrent_region_id(concurrent_region_id.value());
-              }
-            }
-          }
-          for (const HloInstruction* control_predecessor :
-               instr->control_predecessors()) {
-            std::vector<const HloInstruction*> real_successors =
-                GetRealDependencyInstructions(instr);
-            std::vector<const HloInstruction*> real_predecessors =
-                GetRealDependencyInstructions(control_predecessor);
-            for (const HloInstruction* real_predecessor : real_predecessors) {
-              for (const HloInstruction* real_successor : real_successors) {
-                // if the instruction does not have a thunk, it is a degenerated
-                // instruction, and we skip it.
-                if (instr_to_thunk.contains(real_successor) &&
-                    instr_to_thunk.contains(real_predecessor)) {
-                  instr_to_thunk[real_successor]->add_control_predecessor(
-                      instr_to_thunk[real_predecessor]);
-                  VLOG(3) << "Add thunk control dependency for predecessor:  "
-                          << instr_to_thunk[real_predecessor]->ToString(0)
-                          << " successor: "
-                          << instr_to_thunk[real_successor]->ToString(0);
-                }
               }
             }
           }


### PR DESCRIPTION
1. Create a separate `HostAsyncThunk` for thunks that have async device to host communication and remove host-async-related APIs from base Thunk
2. Remove control dependencies from Thunk. Control dependencies is a pure compile-time thing used by XLA scheduler to create a schedule (i.e. to constraint peak memory). At run time we execute all thunks sequentially and rely on buffer and resource conflicts for ordering guarantees. If thunk ordering is required at run time, then it must be expressed with resources (all operations that produce/consume tokens have corresponding resources).
3. Remove support for legacy async thunks from command buffer converter, we don't have these thunks anymore.
4. Migrate to ASSIGN_OR_RETURN in all touched files.