### PR TITLE
SynchronousMemZero: deprecate and replace with stream-ordered version

### DIFF
--- a/xla/backends/gpu/runtime/all_reduce_test.cc
+++ b/xla/backends/gpu/runtime/all_reduce_test.cc
@@ -154,13 +154,13 @@ class AllReduceKernelTest : public ::testing::Test,
           2 * aligned_input_size, aligned_input_size));
       TF_RET_CHECK(!output_buffers[i].is_null());
       TF_RETURN_IF_ERROR(
-          executor->SynchronousMemZero(&output_buffers[i], aligned_input_size));
+          streams[i]->MemZero(&output_buffers[i], aligned_input_size));
 
       signal_flags_buffers.emplace_back(allocated_buffers[i].GetByteSlice(
           3 * aligned_input_size, aligned_signal_size));
       TF_RET_CHECK(!signal_flags_buffers[i].is_null());
-      TF_RETURN_IF_ERROR(executor->SynchronousMemZero(&signal_flags_buffers[i],
-                                                      aligned_signal_size));
+      TF_RETURN_IF_ERROR(
+          streams[i]->MemZero(&signal_flags_buffers[i], aligned_signal_size));
       TF_RETURN_IF_ERROR(streams[i]->Memcpy(&input_buffers[i],
                                             input_data[i].data(), input_size));
       XLA_VLOG_DEVICE(1, i)

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -279,9 +279,10 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
       // the buffer. The kernel will take care of leaving the buffer in
       // correct state after use, so we don't need to zero out after
       // initialization.
-      TF_RETURN_IF_ERROR(params.executor->SynchronousMemZero(
+      TF_RETURN_IF_ERROR(params.stream->MemZero(
           memory_state->signal_buffers_handle.address_ptr(),
           memory_state->signal_buffers_handle.address().size()));
+      TF_RETURN_IF_ERROR(params.stream->BlockHostUntilDone());
       // Create a kernel for execution.
       std::unique_ptr<se::Kernel> kernel = nullptr;
       if (!kernel_name_.empty()) {

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -2549,14 +2549,19 @@ absl::StatusOr<const se::CommandBuffer::Command*> RaggedAllToAllCmd::Record(
             }
 
             // Zero buffers synchronously (Safe during graph construction)
-            state_status = executor->SynchronousMemZero(
+            state_status = execute_params.stream->MemZero(
                 state->barrier_signal_buffer.address_ptr(), signal_buf_bytes);
             if (!state_status.ok()) {
               return nullptr;
             }
 
-            state_status = executor->SynchronousMemZero(
+            state_status = execute_params.stream->MemZero(
                 state->barrier_signal_value.address_ptr(), sizeof(uint32_t));
+            if (!state_status.ok()) {
+              return nullptr;
+            }
+
+            state_status = execute_params.stream->BlockHostUntilDone();
             if (!state_status.ok()) {
               return nullptr;
             }

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
@@ -115,12 +115,6 @@ RaggedAllToAllConfig GetRaggedAllToAllConfig(
   return config;
 }
 
-absl::Status SynchronousMemZero(se::StreamExecutor* executor,
-                                const se::MemoryAllocation& memory_allocation) {
-  se::DeviceAddressBase device_address = memory_allocation.address();
-  return executor->SynchronousMemZero(&device_address, device_address.size());
-}
-
 // Loads the offsets and sizes of the input and output ragged tensors from
 // device memory.
 //
@@ -340,13 +334,24 @@ absl::StatusOr<RaggedAllToAllStreamState*> RaggedAllToAllThunk::InitializeOnce(
                      collective_allocator->Allocate(
                          MultiGpuBarrierKernel::kMaxPeers * sizeof(void*)));
 
-    // 3. Zero-out BOTH buffers using SynchronousMemZero.
-    RETURN_IF_ERROR(
-        SynchronousMemZero(executor, *state->barrier_signal_buffer));
+    // 3. Zero-out BOTH buffers using MemZero.
+    {
+      se::DeviceAddressBase barrier_signal_buffer =
+          state->barrier_signal_buffer->address();
+      RETURN_IF_ERROR(params.stream->MemZero(&barrier_signal_buffer,
+                                             barrier_signal_buffer.size()));
+    }
 
     // Initialize the counter to 0.
     // This is ok, as the MultiGpuBarrierKernel pre-increments signal_value.
-    RETURN_IF_ERROR(SynchronousMemZero(executor, *state->barrier_signal_value));
+    {
+      se::DeviceAddressBase barrier_signal_value =
+          state->barrier_signal_value->address();
+      RETURN_IF_ERROR(params.stream->MemZero(&barrier_signal_value,
+                                             barrier_signal_value.size()));
+    }
+
+    RETURN_IF_ERROR(params.stream->BlockHostUntilDone());
   }
 
   RaggedAllToAllStreamState* state_ptr = state.get();

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -1297,15 +1297,17 @@ bool CudaExecutor::HostMemoryUnregister(void* location) {
 absl::Status CudaExecutor::SynchronousMemZero(DeviceAddressBase* location,
                                               uint64_t size) {
   std::unique_ptr<ActivateContext> activation = Activate();
-  CUdeviceptr cuda_location = AsCudaDevicePtr(location);
-  if (reinterpret_cast<uintptr_t>(location->opaque()) % sizeof(uint32_t) == 0 &&
-      size % sizeof(uint32_t) == 0) {
-    return cuda::ToStatus(
-        cuMemsetD32(cuda_location, 0x0, size / sizeof(uint32_t)),
-        "Failed to memset memory");
-  }
-  return cuda::ToStatus(cuMemsetD8(cuda_location, 0x0, size),
-                        "Failed to memset memory");
+  // cuMemset calls are usually asynchronous with respect to the host and issue
+  // operations on the default stream. XLA's streams are non-blocking
+  // (CU_STREAM_NON_BLOCKING) and, therefore, not ordered with respect to the
+  // default stream.
+  // https://docs.nvidia.com/cuda/cuda-driver-api/api-sync-behavior.html#api-sync-behavior__memset
+  // If an appropriate stream is available at the call site, use it instead of
+  // this method.
+  TF_ASSIGN_OR_RETURN(std::unique_ptr<Stream> stream,
+                      StreamExecutor::CreateStream());
+  TF_RETURN_IF_ERROR(stream->MemZero(location, size));
+  return stream->BlockHostUntilDone();
 }
 
 absl::Status CudaExecutor::SynchronousMemcpy(DeviceAddressBase* gpu_dst,

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -192,9 +192,12 @@ class StreamExecutor {
   virtual bool SynchronizeAllActivity() = 0;
 
   // Blocks the caller while "size" bytes are zeroed out (in POD fashion) at the
-  // given location in device memory.
-  virtual absl::Status SynchronousMemZero(DeviceAddressBase* location,
-                                          uint64_t size) = 0;
+  // given location in device memory. This is deprecated in favour of the
+  // stream-ordered MemZero API.
+  [[deprecated(
+      "Use stream-ordered MemZero + BlockHostUntilReady "
+      "instead.")]] virtual absl::Status
+  SynchronousMemZero(DeviceAddressBase* location, uint64_t size) = 0;
 
   // Returns a DeviceAddressBase representing the range [base, base + size)
   // for the given DeviceAddressBase, such that location is contained within the


### PR DESCRIPTION
📝 Summary of Changes
- Deprecate `StreamExecutor::SynchronousMemZero`, recommending the use of `Stream::MemZero` and `Stream::BlockHostUntilReady` intead
  - Change the implementation of `SynchronousMemZero` to follow this recommendation (with the creation + destruction of a temporary stream) on the CUDA platform and thereby honour its documented synchronisation behaviour
  - Without this change, `SynchronousMemZero` actually issues a default-stream asynchronous operation (https://docs.nvidia.com/cuda/cuda-driver-api/api-sync-behavior.html#api-sync-behavior__memset), which can cause data races.
- Update all OSS call sites of `SynchronousMemZero` to use other APIs
  - If there are no Google-internal call sites, we can also just delete it.

https://github.com/jax-ml/jax/pull/35716 was an analogous fix in Mosaic GPU.

🎯 Justification
https://github.com/openxla/xla/pull/40007 enabled one-shot collective kernels that depend on signal values being initialised to zero by `SynchronousMemZero`. Because this was racy, this led to deadlocks in those kernels and hangs in multi-GPU JAX tests. It is the probable root cause of the timeouts in https://github.com/jax-ml/jax/actions/runs/24230292412/job/70740235047, for example.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
n/a

🧪 Unit Tests:
n/a

🧪 Execution Tests:
Not added.