### PR TITLE
RedzoneAllocatorKernel: update name to avoid confusion

### DIFF
--- a/xla/stream_executor/cuda/redzone_allocator_kernel_cuda.cu.cc
+++ b/xla/stream_executor/cuda/redzone_allocator_kernel_cuda.cu.cc
@@ -29,5 +29,5 @@ GPU_KERNEL_REGISTRY_REGISTER_KERNEL_STATICALLY(
           absl::bit_cast<void*>(
               &stream_executor::gpu::RedzoneAllocatorKernelImpl),
 
-          "repeat_buffer_kernel", arity);
+          "redzone_allocator_kernel", arity);
     }));

--- a/xla/stream_executor/rocm/redzone_allocator_kernel_rocm.cu.cc
+++ b/xla/stream_executor/rocm/redzone_allocator_kernel_rocm.cu.cc
@@ -28,5 +28,5 @@ GPU_KERNEL_REGISTRY_REGISTER_KERNEL_STATICALLY(
           absl::bit_cast<void*>(
               &stream_executor::gpu::RedzoneAllocatorKernelImpl),
 
-          "repeat_buffer_kernel", arity);
+          "redzone_allocator_kernel", arity);
     }));


### PR DESCRIPTION
📝 Summary of Changes
Gives the redzone allocator kernel a corresponding name, rather than naming it the same as the repeat buffer kernel (presumably copy-pasta).

🎯 Justification
I was confused by this when debugging, now others don't have to be.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
n/a

🧪 Unit Tests:
n/a

🧪 Execution Tests:
n/a