### PR TITLE
[ROCm] Label FP8 fast accumulation as supported on ROCm 7

### DIFF
--- a/xla/service/gpu/dot_algorithm_support_test.cc
+++ b/xla/service/gpu/dot_algorithm_support_test.cc
@@ -167,6 +167,17 @@ TEST_P(DotAlgorithmSupportTest, AlgorithmIsSupportedFromCudaCapability) {
   if (const auto* ccc = gpu_cc.cuda_compute_capability()) {
     is_algorithm_supported =
         ccc->SupportsAllFeaturesOf(params.min_cuda_capability);
+
+    // CublasLt does not support FP8 fast accumulation.
+    DebugOptions debug_options = GetDebugOptionsForTest();
+    if (debug_options.xla_gpu_enable_cublaslt() &&
+        params.algorithm ==
+            PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32_FAST_ACCUM &&
+        params.lhs_storage_type == F8E4M3FN &&
+        params.rhs_storage_type == F8E4M3FN &&
+        params.output_storage_type == F8E5M2) {
+      is_algorithm_supported = false;
+    }
   } else if (const auto* rcc = gpu_cc.rocm_compute_capability()) {
     is_algorithm_supported = rcc->gfx9_mi100_or_later();
     if (GetDeviceDescription().runtime_version() < params.min_rocm_version &&

--- a/xla/service/gpu/dot_algorithm_support_test.cc
+++ b/xla/service/gpu/dot_algorithm_support_test.cc
@@ -188,17 +188,6 @@ TEST_P(DotAlgorithmSupportTest, AlgorithmIsSupportedFromCudaCapability) {
     }
   }
 
-  // CublasLt does not support FP8 fast accumulation.
-  DebugOptions debug_options = GetDebugOptionsForTest();
-  if (debug_options.xla_gpu_enable_cublaslt() &&
-      params.algorithm ==
-          PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32_FAST_ACCUM &&
-      params.lhs_storage_type == F8E4M3FN &&
-      params.rhs_storage_type == F8E4M3FN &&
-      params.output_storage_type == F8E5M2) {
-    is_algorithm_supported = false;
-  }
-
   if (is_algorithm_supported) {
     EXPECT_TRUE(Run(hlo_text)) << "Failed to run HLO: " << hlo_text;
 


### PR DESCRIPTION
📝 Summary of Changes
Set is_algorithm_supported to true since FP8 fast accumulation is supported on ROCm 7.

🎯 Justification
HLOs in test cases `dot_any_f8_any_f8_f32_fast_accum_with_lhs_f8e4m3fn_rhs_f8e4m3fn_output_f8e5m2_from_cc_8_9_rocm_63_no_restriction_*` run successfully on ROCm 7, so label them as supported. Requirement of minimum ROCm version with FP8 fast accumulation support should be 6.3.

🚀 Kind of Contribution
🐛 Bug Fix