### PR TITLE
StreamExecutor::SynchronousMemZero: remove method deprecated in #40697

### DIFF
--- a/xla/backends/interpreter/executor.h
+++ b/xla/backends/interpreter/executor.h
@@ -97,10 +97,6 @@ class XlaInterpreterExecutor : public StreamExecutorCommon {
 
   // No "synchronize all activity" implemented for this platform at the moment.
   bool SynchronizeAllActivity() override { return true; }
-  absl::Status SynchronousMemZero(DeviceAddressBase* location,
-                                  uint64_t size) override {
-    return absl::InternalError("Interpreter can not memzero");
-  }
 
   absl::Status SynchronousMemcpy(DeviceAddressBase* dev_dst,
                                  const void* host_src, uint64_t size) override;

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -1294,22 +1294,6 @@ bool CudaExecutor::HostMemoryUnregister(void* location) {
   return HostUnregister(cuda_context_, location);
 }
 
-absl::Status CudaExecutor::SynchronousMemZero(DeviceAddressBase* location,
-                                              uint64_t size) {
-  std::unique_ptr<ActivateContext> activation = Activate();
-  // cuMemset calls are usually asynchronous with respect to the host and issue
-  // operations on the default stream. XLA's streams are non-blocking
-  // (CU_STREAM_NON_BLOCKING) and, therefore, not ordered with respect to the
-  // default stream.
-  // https://docs.nvidia.com/cuda/cuda-driver-api/api-sync-behavior.html#api-sync-behavior__memset
-  // If an appropriate stream is available at the call site, use it instead of
-  // this method.
-  TF_ASSIGN_OR_RETURN(std::unique_ptr<Stream> stream,
-                      StreamExecutor::CreateStream());
-  TF_RETURN_IF_ERROR(stream->MemZero(location, size));
-  return stream->BlockHostUntilDone();
-}
-
 absl::Status CudaExecutor::SynchronousMemcpy(DeviceAddressBase* gpu_dst,
                                              const void* host_src,
                                              uint64_t size) {

--- a/xla/stream_executor/cuda/cuda_executor.h
+++ b/xla/stream_executor/cuda/cuda_executor.h
@@ -93,8 +93,6 @@ class CudaExecutor : public GpuExecutor {
       Stream* stream, bool use_delay_kernel) override;
   absl::StatusOr<DeviceAddressBase> GetSymbol(
       const std::string& symbol_name, ModuleHandle module_handle) override;
-  absl::Status SynchronousMemZero(DeviceAddressBase* location,
-                                  uint64_t size) override;
   absl::Status SynchronousMemcpy(DeviceAddressBase* gpu_dst,
                                  const void* host_src, uint64_t size) override;
   absl::Status SynchronousMemcpy(void* host_dst,

--- a/xla/stream_executor/host/host_executor.cc
+++ b/xla/stream_executor/host/host_executor.cc
@@ -92,12 +92,6 @@ void HostExecutor::Deallocate(DeviceAddressBase* mem) {
   tsl::port::AlignedFree(mem->opaque());
 }
 
-absl::Status HostExecutor::SynchronousMemZero(DeviceAddressBase* location,
-                                              uint64_t size) {
-  memset(location->opaque(), 0, size);
-  return absl::OkStatus();
-}
-
 absl::Status HostExecutor::SynchronousMemcpy(DeviceAddressBase* gpu_dst,
                                              const void* host_src,
                                              uint64_t size) {

--- a/xla/stream_executor/host/host_executor.h
+++ b/xla/stream_executor/host/host_executor.h
@@ -68,8 +68,6 @@ class HostExecutor : public StreamExecutorCommon {
   }
 
   bool SynchronizeAllActivity() override { return true; }
-  absl::Status SynchronousMemZero(DeviceAddressBase* location,
-                                  uint64_t size) override;
 
   absl::Status SynchronousMemcpy(DeviceAddressBase* gpu_dst,
                                  const void* host_src, uint64_t size) override;

--- a/xla/stream_executor/mock_stream_executor.h
+++ b/xla/stream_executor/mock_stream_executor.h
@@ -70,8 +70,6 @@ class MockStreamExecutor : public StreamExecutor {
   MOCK_METHOD(absl::StatusOr<std::unique_ptr<MemoryAllocation>>,
               HostMemoryAllocate, (uint64_t size), (override));
   MOCK_METHOD(bool, SynchronizeAllActivity, (), (override));
-  MOCK_METHOD(absl::Status, SynchronousMemZero,
-              (DeviceAddressBase * location, uint64_t size), (override));
   MOCK_METHOD(absl::Status, SynchronousMemcpy,
               (DeviceAddressBase * device_dst, const void* host_src,
                uint64_t size),

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -922,20 +922,6 @@ bool RocmExecutor::HostMemoryUnregister(void* location) {
   return true;
 }
 
-absl::Status RocmExecutor::SynchronousMemZero(DeviceAddressBase* location,
-                                              uint64_t size) {
-  std::unique_ptr<ActivateContext> activation = Activate();
-  hipDeviceptr_t rocm_location = AsROCmDevicePtr(location);
-  if (reinterpret_cast<uintptr_t>(location->opaque()) % sizeof(uint32_t) == 0 &&
-      size % sizeof(uint32_t) == 0) {
-    return ToStatus(
-        wrap::hipMemsetD32(rocm_location, 0x0, size / sizeof(uint32_t)),
-        "Failed to memset memory");
-  }
-  return ToStatus(wrap::hipMemsetD8(rocm_location, 0x0, size),
-                  "Failed to memset memory");
-}
-
 absl::Status RocmExecutor::SynchronousMemcpy(DeviceAddressBase* gpu_dst,
                                              const void* host_src,
                                              uint64_t size) {

--- a/xla/stream_executor/rocm/rocm_executor.h
+++ b/xla/stream_executor/rocm/rocm_executor.h
@@ -91,8 +91,6 @@ class RocmExecutor : public GpuExecutor {
       Stream* stream, bool use_delay_kernel) override;
   absl::StatusOr<DeviceAddressBase> GetSymbol(
       const std::string& symbol_name, ModuleHandle module_handle) override;
-  absl::Status SynchronousMemZero(DeviceAddressBase* location,
-                                  uint64_t size) override;
   absl::Status SynchronousMemcpy(DeviceAddressBase* gpu_dst,
                                  const void* host_src, uint64_t size) override;
   absl::Status SynchronousMemcpy(void* host_dst,

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -191,14 +191,6 @@ class StreamExecutor {
   // Synchronizes all activity occurring in the StreamExecutor's context.
   virtual bool SynchronizeAllActivity() = 0;
 
-  // Blocks the caller while "size" bytes are zeroed out (in POD fashion) at the
-  // given location in device memory. This is deprecated in favour of the
-  // stream-ordered MemZero API.
-  [[deprecated(
-      "Use stream-ordered MemZero + BlockHostUntilReady "
-      "instead.")]] virtual absl::Status
-  SynchronousMemZero(DeviceAddressBase* location, uint64_t size) = 0;
-
   // Returns a DeviceAddressBase representing the range [base, base + size)
   // for the given DeviceAddressBase, such that location is contained within the
   // returned range.

--- a/xla/stream_executor/sycl/sycl_executor.cc
+++ b/xla/stream_executor/sycl/sycl_executor.cc
@@ -723,18 +723,6 @@ SyclExecutor::CreateEventBasedTimer(Stream* stream, bool use_delay_kernel) {
   return std::make_unique<SyclTimer>(std::move(timer));
 }
 
-absl::Status SyclExecutor::SynchronousMemZero(DeviceMemoryBase* location,
-                                              uint64_t size) {
-  if (reinterpret_cast<uintptr_t>(location->opaque()) % sizeof(uint32_t) == 0 &&
-      size % sizeof(uint32_t) == 0) {
-    return SynchronousMemsetUint32(sycl_context_.get(),
-                                   AsSyclDevicePtr(location), 0x0,
-                                   size / sizeof(uint32_t));
-  }
-  return SynchronousMemsetUint8(sycl_context_.get(), AsSyclDevicePtr(location),
-                                0x0, size);
-}
-
 absl::Status SyclExecutor::SynchronousMemcpy(DeviceMemoryBase* gpu_dst,
                                              const void* host_src,
                                              uint64_t size) {

--- a/xla/stream_executor/sycl/sycl_executor.h
+++ b/xla/stream_executor/sycl/sycl_executor.h
@@ -91,10 +91,6 @@ class SyclExecutor : public gpu::GpuExecutor {
   absl::StatusOr<std::unique_ptr<EventBasedTimer>> CreateEventBasedTimer(
       Stream* stream, bool use_delay_kernel) override;
 
-  // Sets the specified device memory to zero synchronously.
-  absl::Status SynchronousMemZero(DeviceMemoryBase* location,
-                                  uint64_t size) override;
-
   // Copies memory from host to device synchronously.
   absl::Status SynchronousMemcpy(DeviceMemoryBase* gpu_dst,
                                  const void* host_src, uint64_t size) override;

--- a/xla/stream_executor/tpu/tpu_executor.h
+++ b/xla/stream_executor/tpu/tpu_executor.h
@@ -136,10 +136,6 @@ class TpuExecutor : public tensorflow::tpu::TpuExecutorInterface {
       uint64_t size) override {
     LOG(FATAL) << "not yet implemented";
   }
-  absl::Status SynchronousMemZero(DeviceAddressBase* location,
-                                  uint64_t size) override {
-    LOG(FATAL) << "not yet implemented";
-  }
 
   SE_StreamExecutor* se_executor() { return executor_; }
 


### PR DESCRIPTION
📝 Summary of Changes
See #40697 for the deprecation. If a deprecated API is no longer used, it can be removed.

🎯 Justification
This will reduce temptation to add new usage of this method.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
n/a

🧪 Unit Tests:
n/a

🧪 Execution Tests:
n/a