### PR TITLE
Add missing NCCL one-sided comm symbols to nccl.symbols

### DIFF
--- a/xla/tsl/cuda/nccl.symbols
+++ b/xla/tsl/cuda/nccl.symbols
@@ -14,6 +14,7 @@ ncclCommInitAll
 ncclCommInitRank
 ncclCommInitRankConfig
 ncclCommInitRankScalable
+ncclCommQueryProperties
 ncclCommRegister
 ncclCommShrink
 ncclCommSplit
@@ -31,6 +32,7 @@ ncclGroupSimulateEnd
 ncclGroupStart
 ncclMemAlloc
 ncclMemFree
+ncclPutSignal
 ncclRecv
 ncclRedOpCreatePreMulSum
 ncclRedOpDestroy
@@ -38,6 +40,8 @@ ncclReduce
 ncclReduceScatter
 ncclResetDebugInit
 ncclSend
+ncclSignal
+ncclWaitSignal
 pncclAllGather
 pncclAllReduce
 pncclBcast
@@ -53,6 +57,7 @@ pncclCommInitAll
 pncclCommInitRank
 pncclCommInitRankConfig
 pncclCommInitRankScalable
+pncclCommQueryProperties
 pncclCommRegister
 pncclCommShrink
 pncclCommSplit
@@ -68,6 +73,7 @@ pncclGroupSimulateEnd
 pncclGroupStart
 pncclMemAlloc
 pncclMemFree
+pncclPutSignal
 pncclRecv
 pncclRedOpCreatePreMulSum
 pncclRedOpDestroy
@@ -75,3 +81,5 @@ pncclReduce
 pncclReduceScatter
 pncclResetDebugInit
 pncclSend
+pncclSignal
+pncclWaitSignal


### PR DESCRIPTION
📝 Summary of Changes
PR #40594 added calls to ncclCommQueryProperties, ncclPutSignal, ncclSignal, and ncclWaitSignal but did not register them in nccl.symbols, breaking all downstream builds with undefined symbol linker errors.

🎯 Justification
Build-breaking regression. Adds the missing entries. 

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
N/A

🧪 Execution Tests:
N/A
