### PR TITLE
[xla:gpu] Delete special case for calls to command buffers

### DIFF
--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -166,6 +166,7 @@ limitations under the License.
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/concurrency/future.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -174,7 +175,6 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/human_readable_json.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 namespace {
@@ -385,64 +385,6 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitSliceToDynamic(
                                                ir_emitter_context_));
   kernel_modules_.push_back(std::move(local_llvm_module));
   return thunk_sequence;
-}
-
-AsyncThunkSequence ThunkEmitter::EmitCommandBufferThunk(
-    const HloInstruction* instr) {
-  // Spawn a new ThunkEmitter to emit thunks for the command buffer computation.
-  // Then convert emitted thunks to a sequence of Commands. The resulting thunk
-  // added to the thunk sequence is a CommandBufferThunk. Thunks emitted from
-  // the command buffer computation are discarded.
-  DCHECK_EQ(instr->called_computations().size(), 1);
-  const HloComputation* command_buffer = instr->called_computations().front();
-
-  Thunk::ThunkInfo thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(
-      instr, ir_emitter_context_->GetNextThunkId());
-  return EmitHloComputation(command_buffer)
-      .Map([thunk_info = std::move(thunk_info),
-            &debug_options = ir_emitter_context_->debug_options()](
-               ThunkSequence thunk_sequence) -> absl::StatusOr<ThunkSequence> {
-        // Maybe serialize all commands in a sequence by forcing barriers
-        // between all recorded commands. This guarantees that we execute
-        // all device operations in the exact same order as a thunk
-        // sequence.
-        CommandExecutor::SynchronizationMode synchronization_mode;
-        auto mode = debug_options.xla_gpu_command_buffer_scheduling_mode();
-        switch (mode) {
-          case DebugOptions::SERIALIZE:
-            synchronization_mode =
-                CommandExecutor::SynchronizationMode::kSerialize;
-            break;
-          case DebugOptions::CONCURRENT:
-            synchronization_mode =
-                CommandExecutor::SynchronizationMode::kConcurrent;
-            break;
-          case DebugOptions::LHS:
-            synchronization_mode = CommandExecutor::SynchronizationMode::kLHS;
-            break;
-          default:
-            return Internal("Unsupported command buffer scheduling mode: %d",
-                            mode);
-        }
-
-        bool enable_loop_unroll =
-            debug_options.xla_gpu_command_buffer_unroll_loops();
-        DebugOptions::CommandBufferUpdateMode update_mode =
-            debug_options.xla_gpu_command_buffer_update_mode();
-        ASSIGN_OR_RETURN(
-            CommandExecutor cmd_executor,
-            ConvertToCommands(
-                thunk_sequence,
-                ConvertToCommandsOptions{synchronization_mode,
-                                         enable_loop_unroll, update_mode}));
-
-        return GetThunkSequence(std::make_unique<CommandBufferThunk>(
-            std::move(cmd_executor), std::move(thunk_info),
-            std::make_unique<SequentialThunk>(Thunk::ThunkInfo{},
-                                              std::move(thunk_sequence)),
-            debug_options.xla_enable_command_buffers_during_profiling(),
-            update_mode));
-      });
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitConvolutionThunk(
@@ -1472,6 +1414,13 @@ AsyncThunkSequence ThunkEmitter::EmitWhile(const HloInstruction* instr) {
             std::move(info), std::move(pred), std::move(cond_thunks),
             std::move(body_thunks), trip_count));
       });
+}
+
+AsyncThunkSequence ThunkEmitter::EmitCallComputation(
+    const HloInstruction* instr) {
+  DCHECK_EQ(instr->called_computations().size(), 1);
+  const HloComputation* computation = instr->called_computations().front();
+  return EmitHloComputation(computation);
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRngGetAndUpdateState(
@@ -2756,7 +2705,7 @@ AsyncThunkSequence ThunkEmitter::EmitHloInstruction(const HloInstruction* hlo,
     case HloOpcode::kAsyncStart:
       return EmitAsyncStart(hlo);
     case HloOpcode::kCall:
-      return EmitCommandBufferThunk(hlo);
+      return EmitCallComputation(hlo);
     case HloOpcode::kCollectivePermuteDone:
       return IsNvshmemCollective(hlo) ? EmitNvshmemAsyncDone(hlo)
                                       : EmitCollectiveAsyncDone(hlo);

--- a/xla/service/gpu/thunk_emitter.h
+++ b/xla/service/gpu/thunk_emitter.h
@@ -91,14 +91,14 @@ class ThunkEmitter {
 
   AsyncThunkSequence EmitAsyncStart(const HloInstruction* instr);
 
+  AsyncThunkSequence EmitCallComputation(const HloInstruction* hlo);
+
   absl::StatusOr<ThunkSequence> EmitAsyncComputation(const HloInstruction* hlo);
 
   absl::StatusOr<ThunkSequence> EmitAsyncCustomCallStart(
       const HloInstruction* hlo);
 
   absl::StatusOr<ThunkSequence> EmitAsyncDone(const HloInstruction* hlo);
-
-  AsyncThunkSequence EmitCommandBufferThunk(const HloInstruction* instr);
 
   absl::StatusOr<ThunkSequence> EmitCollectiveAsyncDone(
       const HloInstruction* hlo);


### PR DESCRIPTION
This is leftovers from the era when calls were ONLY command buffers. Today we use a command buffer pass that uses thunks, and calls can be anything!