### PR TITLE
[XLA:GPU][oneAPI ]Add SYCL platform support to HLO optimization tools and tests

### DIFF
--- a/xla/tools/hlo_opt/BUILD
+++ b/xla/tools/hlo_opt/BUILD
@@ -2,6 +2,10 @@ load(
     "@local_config_rocm//rocm:build_defs.bzl",
     "if_rocm_is_configured",
 )
+load(
+    "@local_config_sycl//sycl:build_defs.bzl",
+    "if_sycl_is_configured",
+)
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//xla:lit.bzl", "enforce_glob", "lit_test_suite")
 load(
@@ -152,6 +156,8 @@ cc_library(
         "//xla/stream_executor:cuda_platform",
     ]) + if_rocm_is_configured([
         "//xla/stream_executor:rocm_platform",
+    ]) + if_sycl_is_configured([
+        "//xla/stream_executor:sycl_platform",
     ]),
     alwayslink = True,  # Initializer needs to run.
 )
@@ -244,6 +250,9 @@ lit_test_suite(
     ]) + if_rocm_is_configured([
         "--param=PTX=GCN",
         "--param=GPU=mi200",
+    ]) + if_sycl_is_configured([
+        "--param=PTX=ONEAPI",
+        "--param=GPU=bmg_g21",
     ]),
     cfg = "//xla:lit.cfg.py",
     data = [":test_utilities"],

--- a/xla/tools/hlo_opt/tests/gpu_hlo_llvm.hlo
+++ b/xla/tools/hlo_opt/tests/gpu_hlo_llvm.hlo
@@ -25,6 +25,7 @@ HloModule Test, is_scheduled=true
 // CHECK-LABEL: wrapped_b
 // CHECK-PTX:     call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
 // CHECK-GCN:     call i32 @llvm.amdgcn.workitem.id.x()
+// CHECK-ONEAPI:  @_Z12get_local_idj(i32 0)
 fused_computation {
   param_0 = f32[100,200]{1,0} parameter(0)
   ROOT b.1 = f32[100,200]{0,1} copy(f32[100,200]{1,0} param_0)

--- a/xla/tools/hlo_opt/tests/gpu_hlo_unoptimized_llvm.hlo
+++ b/xla/tools/hlo_opt/tests/gpu_hlo_unoptimized_llvm.hlo
@@ -2,6 +2,7 @@
 
 // CHECK-PTX:     define ptx_kernel void @fusion
 // CHECK-GCN:     define amdgpu_kernel void @fusion
+// CHECK-ONEAPI:  define spir_kernel void @fusion
 // CHECK:         br i1
 // CHECK:         br label
 


### PR DESCRIPTION
This PR fixes the ONEAPI HLO OPT tests. Some tests were failing because SYCL Platform was not included in the build. 

The following //xla/tools/hlo_opt:tests/gpu_hlo.hlo.test and similar tests were fixed. 




