### PR TITLE
Canonicalize custom element sizes on tuple leaf arrays in Literal::SetShape

### DIFF
--- a/xla/literal.cc
+++ b/xla/literal.cc
@@ -254,19 +254,21 @@ void Literal::SetShape(const Shape& shape) {
     shape_ = intered_shape_ptr;
     return;
   }
+
   auto owning_shape_ptr = std::make_unique<Shape>(shape);
-  if (!LayoutUtil::HasLayout(*owning_shape_ptr)) {
-    ShapeUtil::ForEachMutableLeafShape(
-        owning_shape_ptr.get(), [](Shape* subshape, const ShapeIndex& index) {
-          if (!subshape->has_layout()) {
-            LayoutUtil::SetToDefaultLayout(subshape);
-          }
-        });
-  }
-  if (owning_shape_ptr->IsArray() &&
-      LayoutUtil::HasCustomElementSizeInBits(*owning_shape_ptr)) {
-    owning_shape_ptr->mutable_layout()->set_element_size_in_bits(0);
-  }
+
+  ShapeUtil::ForEachMutableLeafShape(
+      owning_shape_ptr.get(),
+      [](Shape* subshape, const ShapeIndex& /*index*/) {
+        if (!subshape->has_layout()) {
+          LayoutUtil::SetToDefaultLayout(subshape);
+        }
+        if (subshape->IsArray() &&
+            LayoutUtil::HasCustomElementSizeInBits(*subshape)) {
+          subshape->mutable_layout()->set_element_size_in_bits(0);
+        }
+      });
+
   shape_ = std::move(owning_shape_ptr);
 }
 

--- a/xla/literal_test.cc
+++ b/xla/literal_test.cc
@@ -3400,5 +3400,26 @@ BENCHMARK_POPULATE(PopulateParallel);
 BENCHMARK_POPULATE(PopulateLinear);
 BENCHMARK_POPULATE(PopulateLinearParallel);
 
+
+TEST(LiteralTest, SetShapeClearsCustomElementSizeInBitsOnTupleLeafArrays) {
+  Shape leaf = ShapeUtil::MakeShape(F32, {1024});
+  LayoutUtil::SetToDefaultLayout(&leaf);
+  leaf.mutable_layout()->set_element_size_in_bits(1);
+
+  Shape tuple = ShapeUtil::MakeTupleShape({leaf});
+
+  Literal literal(tuple);
+
+  ASSERT_TRUE(literal.shape().IsTuple());
+  ASSERT_EQ(literal.shape().tuple_shapes_size(), 1);
+  ASSERT_TRUE(literal.shape().tuple_shapes(0).has_layout());
+  EXPECT_EQ(literal.shape().tuple_shapes(0).layout().element_size_in_bits(), 0);
+}
+
+
 }  // namespace
+
+
 }  // namespace xla
+
+


### PR DESCRIPTION
This change recursively canonicalizes custom `layout.element_size_in_bits` values on tuple-contained array leaves in `Literal::SetShape`.

Previously, root array shapes had their custom element sizes cleared, but tuple-contained leaf arrays could retain non-zero custom element sizes. This allowed an inconsistent state where literal buffer sizing honored the custom bit width while later typed materialization assumed a dense native representation.

By applying the canonicalization consistently across all leaf arrays, this change restores the invariant expected by literal allocation and typed population paths.