### PR TITLE
[ROCm] Fix LoadKernel to use refcounted module path for proper cleanup

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -188,7 +188,6 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
-        "@com_google_absl//absl/hash",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/numeric:int128",

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -682,12 +682,9 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
     const auto& cubin = spec.cuda_cubin_in_memory()->cubin_bytes;
     const char* hsaco = reinterpret_cast<const char*>(cubin.data());
     absl::MutexLock lock{in_memory_modules_mu_};
-    ModuleHandle module_handle = HsacoModuleHandle(hsaco, cubin.size());
-    hipModule_t& module = in_memory_modules_[module_handle];
-
-    if (module == nullptr) {
-      TF_ASSIGN_OR_RETURN(module, LoadHsaco(&rocm_context_, hsaco));
-    }
+    TF_ASSIGN_OR_RETURN(ModuleHandle module_handle,
+                        LoadModuleFromHsaco(hsaco, cubin.size()));
+    hipModule_t module = gpu_binary_to_module_.at(module_handle).first;
     kernel_to_gpu_binary_[rocm_kernel.get()] = module_handle;
 
     VLOG(2) << "getting function " << kernel_name << " from module " << module;

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -31,7 +31,6 @@ limitations under the License.
 
 #include "absl/base/casts.h"
 #include "absl/container/inlined_vector.h"
-#include "absl/hash/hash.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/numeric/int128.h"
@@ -178,17 +177,6 @@ absl::StatusOr<hipFunction_t> GetModuleFunction(Context* context,
                                                 const char* kernel_name) {
   ScopedActivateContext activated(context);
   CHECK(module != nullptr && kernel_name != nullptr);
-  // Check for pre-existing HIP errors before the call. On ROCm 7+
-  // the per-thread error state is sticky: successful HIP calls do
-  // not clear it, so a stale error from a prior operation would
-  // produce confusing diagnostics if we proceeded.
-  hipError_t pre_err = ::hipPeekAtLastError();
-  if (pre_err != hipSuccess) {
-    return absl::InternalError(
-        absl::StrCat("There was a HIP error before calling "
-                     "hipModuleGetFunction for kernel '",
-                     kernel_name, "': ", ToString(pre_err)));
-  }
   hipFunction_t function;
   TF_RETURN_IF_ERROR(
       ToStatus(wrap::hipModuleGetFunction(&function, module, kernel_name),
@@ -208,16 +196,6 @@ absl::Status GetModuleSymbol(Context* context, hipModule_t module,
         (dptr != nullptr || bytes != nullptr));
   return ToStatus(wrap::hipModuleGetGlobal(dptr, bytes, module, symbol_name),
                   absl::StrCat("Failed to get symbol '", symbol_name, "'"));
-}
-
-// Compute a content-based ModuleHandle from HSACO bytes.
-// Using a content hash instead of the raw data pointer avoids stale cache
-// entries when an HSACO buffer is freed and a new one is allocated at the
-// same address (pointer-reuse cache collision).
-ModuleHandle HsacoModuleHandle(const char* hsaco, size_t size) {
-  auto hash = absl::HashOf(absl::string_view(hsaco, size));
-  // Ensure hash is never 0 (ModuleHandle treats nullptr as invalid)
-  return ModuleHandle{reinterpret_cast<const void*>(hash | 1)};
 }
 
 // Unloads module from the current context via cuModuleUnload.
@@ -682,8 +660,7 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
     const auto& cubin = spec.cuda_cubin_in_memory()->cubin_bytes;
     const char* hsaco = reinterpret_cast<const char*>(cubin.data());
     absl::MutexLock lock{in_memory_modules_mu_};
-    TF_ASSIGN_OR_RETURN(ModuleHandle module_handle,
-                        LoadModuleFromHsaco(hsaco, cubin.size()));
+    TF_ASSIGN_OR_RETURN(ModuleHandle module_handle, LoadModuleFromHsaco(hsaco));
     hipModule_t module = gpu_binary_to_module_.at(module_handle).first;
     kernel_to_gpu_binary_[rocm_kernel.get()] = module_handle;
 
@@ -754,17 +731,16 @@ absl::StatusOr<ModuleHandle> RocmExecutor::LoadModule(
   // TODO(ROCm): Need  generic term instead of cubin/cuda/ptx
   if (spec.has_cuda_cubin_in_memory()) {
     absl::MutexLock lock{in_memory_modules_mu_};
-    const auto& cubin = spec.cuda_cubin_in_memory();
-    return LoadModuleFromHsaco(reinterpret_cast<const char*>(cubin.data()),
-                               cubin.size());
+    return LoadModuleFromHsaco(
+        reinterpret_cast<const char*>(spec.cuda_cubin_in_memory().data()));
   } else {
     return absl::InternalError("No HASCO binary found");
   }
 }
 
 absl::StatusOr<ModuleHandle> RocmExecutor::LoadModuleFromHsaco(
-    const char* hsaco, size_t size) {
-  ModuleHandle module_handle = HsacoModuleHandle(hsaco, size);
+    const char* hsaco) {
+  ModuleHandle module_handle{hsaco};
   uint64_t module_refcount;
   hipModule_t module;
   std::tie(module, module_refcount) = gpu_binary_to_module_[module_handle];

--- a/xla/stream_executor/rocm/rocm_executor.h
+++ b/xla/stream_executor/rocm/rocm_executor.h
@@ -140,8 +140,7 @@ class RocmExecutor : public GpuExecutor {
   absl::Status InitBlas();
 
   // Loads a module in HSACO format.
-  absl::StatusOr<ModuleHandle> LoadModuleFromHsaco(const char* hsaco,
-                                                   size_t size)
+  absl::StatusOr<ModuleHandle> LoadModuleFromHsaco(const char* hsaco)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
 
   bool UnloadGpuBinary(ModuleHandle module_handle)


### PR DESCRIPTION
📝 Summary of Changes
ROCm's RocmExecutor has two kernel/module loading paths with
different caching behavior:

  1. LoadModule → LoadModuleFromHsaco → populates both
     gpu_binary_to_module_ (refcounted) and in_memory_modules_
  2. LoadKernel → directly inserts into in_memory_modules_ only,
     bypassing gpu_binary_to_module_ entirely

When UnloadKernel calls UnloadGpuBinary, it only looks in
gpu_binary_to_module_ for cleanup. Since LoadKernel never populated
that map, the cleanup was a no-op: in_memory_modules_ entries and
loaded hipModule_t objects were never removed, leaking until
executor destruction.

This caused stale module cache entries when CustomKernelThunk's
owned HSACO buffers were freed and reallocated at the same address.
The cache returned old modules that didn't contain the expected
kernels, producing flaky hipErrorNotFound failures in sort and
LuSolve tests under xdist parallelism.

Fix by routing LoadKernel through LoadModuleFromHsaco, so every
loaded module participates in the refcount mechanism and is properly
cleaned up when the last kernel referencing it is destroyed.

🎯 Justification
my previous PR actually fixed this problem by adding content hashing but now that I have got to the bottom of the issue and found why stale cache happens in first place this is the fix I want to have and reverting my old fix : https://github.com/openxla/xla/pull/40419

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
