### PR TITLE
[xla:gpu] Remove unused IsNestedCommandBuffer API

### DIFF
--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -37,9 +37,9 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/platform.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/xla.pb.h"
 #include "tsl/platform/casts.h"
-#include "xla/tsl/platform/status_macros.h"
 
 namespace xla::gpu {
 
@@ -231,9 +231,6 @@ class Command : public Thunk {
   virtual bool force_update() const { return false; }
 
   std::shared_ptr<Resource> token() const { return token_; }
-
-  // Returns true if command implemented as a nested command buffer.
-  virtual bool IsNestedCommandBuffer() const { return false; }
 
   CommandType command_type() const { return cmd_type_; }
   se::StreamPriority priority() const { return priority_; }

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -356,8 +356,6 @@ class GemmCmd : public TracedCommandBufferCmd {
 
   BufferUses buffer_uses() const override;
 
-  bool IsNestedCommandBuffer() const final { return true; }
-
  private:
   const GemmConfig config_;
   const BufferAllocation::Slice lhs_buffer_;
@@ -385,8 +383,6 @@ class CublasLtCmd : public TracedCommandBufferCmd {
 
   BufferUses buffer_uses() const override;
 
-  bool IsNestedCommandBuffer() const final { return true; }
-
  private:
   CublasLtMatmulThunk thunk_;
 };
@@ -408,8 +404,6 @@ class CuDnnCmd : public TracedCommandBufferCmd {
       se::CommandBuffer* command_buffer) override;
 
   BufferUses buffer_uses() const override;
-
-  bool IsNestedCommandBuffer() const final { return true; }
 
  private:
   std::vector<ShapedSlice> args_;
@@ -461,7 +455,6 @@ class CustomCallCmd : public Command {
       se::CommandBuffer* command_buffer) override;
 
   BufferUses buffer_uses() const override;
-  bool IsNestedCommandBuffer() const final { return true; }
 
  private:
   absl::StatusOr<const se::CommandBuffer::Command*> RecordLegacyCustomCall(
@@ -519,8 +512,6 @@ class CollectiveCmd : public Command {
   bool IsTracedCommand() const override { return true; }
 
   bool requires_initialization() const final { return true; }
-
-  bool IsNestedCommandBuffer() const final { return true; }
 
   absl::StatusOr<const se::CommandBuffer::Command*> RecordTracedCommand(
       const Thunk::ExecuteParams& execute_params,
@@ -732,8 +723,6 @@ class DynamicSliceFusionCmd : public Command {
   bool force_update() const final { return true; }
 
   bool requires_initialization() const final;
-
-  bool IsNestedCommandBuffer() const final { return true; }
 
   absl::Status WalkNested(
       absl::FunctionRef<absl::Status(Thunk*)> callback) override;


### PR DESCRIPTION
The API was declared but never called anywhere in the codebase.

