### PR TITLE
  [xla:gpu] Remove Command::IsTracedCommand() virtual API

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -137,6 +137,7 @@ cc_library(
     deps = [
         ":annotation",
         ":command",
+        ":command_buffer_cmd",
         ":command_state",
         ":thunk",
         "//xla:util",
@@ -594,6 +595,7 @@ cc_library(
     hdrs = ["command_buffer_thunk.h"],
     deps = [
         ":command",
+        ":command_buffer_cmd",
         ":command_executor",
         ":command_state",
         ":sequential_thunk",  # build_cleaner: keep

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -215,10 +215,6 @@ class Command : public Thunk {
   // ensure that all ranks execute NCCL command update.
   virtual bool requires_initialization() const { return false; }
 
-  // Returns true if this command is implemented via CUDA stream activity
-  // tracing (i.e. a subclass of TracedCommandBufferCmd).
-  virtual bool IsTracedCommand() const { return false; }
-
   // Returns true if command supports loop unroll, the while loop can be
   // unrolled only if it has pre-known trip count and also all commands from the
   // body commands are unrollable.

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -112,8 +112,6 @@ class TracedCommandBuffer : public CommandState {
 // A base class for commands implemented as tracing of stream activities.
 class TracedCommandBufferCmd : public Command {
  public:
-  bool IsTracedCommand() const override { return true; }
-
  protected:
   explicit TracedCommandBufferCmd(CommandType cmd_type);
 
@@ -515,8 +513,6 @@ class CollectiveCmd : public Command {
   CollectiveCmd(CommandType cmd_type, CollectiveConfig config);
 
   absl::Status Prepare(const Thunk::PrepareParams& params) final;
-
-  bool IsTracedCommand() const override { return true; }
 
   bool requires_initialization() const final { return true; }
 

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "xla/backends/gpu/runtime/command.h"
+#include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_executor.h"
 #include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
@@ -103,7 +104,9 @@ CommandBufferThunk::CommandBufferThunk(
   if (command_buffer_update_mode_ == DebugOptions::CAPTURE_CMD_NEVER_UPDATE) {
     bool found = false;
     CHECK_OK(commands_.Walk([&](const Command* command) -> absl::Status {
-      if (!found && command->IsTracedCommand()) {
+      if (!found &&
+          (dynamic_cast<const TracedCommandBufferCmd*>(command) != nullptr ||
+           dynamic_cast<const CollectiveCmd*>(command) != nullptr)) {
         found = true;
         std::optional<BufferAllocation::Index> min_idx;
         for (const auto& use : command->buffer_uses()) {

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -39,6 +39,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/backends/gpu/runtime/annotation.h"
 #include "xla/backends/gpu/runtime/command.h"
+#include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_state.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/runtime/buffer_use.h"
@@ -570,14 +571,15 @@ absl::Status CommandExecutor::RecordUpdate(
     // VA-remapped to fixed offsets within the reserved VA range, so their
     // recorded addresses remain valid across executions — no update is needed.
     //
-    // Note: CollectiveCmd satisfies both IsTracedCommand() and
+    // Note: CollectiveCmd satisfies both this check and
     // requires_initialization(), but the requires_initialization() check below
-    // is intentionally unreachable for traced commands in this mode. Because
+    // is intentionally unreachable for these commands in this mode. Because
     // their buffer addresses are stable (VA-mapped), re-initialization is
     // unnecessary.
     if (record_params.command_buffer_update_mode ==
             DebugOptions::CAPTURE_CMD_NEVER_UPDATE &&
-        command->IsTracedCommand()) {
+        (dynamic_cast<const TracedCommandBufferCmd*>(command) != nullptr ||
+         dynamic_cast<const CollectiveCmd*>(command) != nullptr)) {
       VLOG(3) << "Skipping update for traced command " << id
               << " (CAPTURE_CMD_NEVER_UPDATE mode)";
       return true;

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -732,6 +732,7 @@ cc_library(
         "//xla/backends/gpu/runtime:collective_memory_requests",
         "//xla/backends/gpu/runtime:collective_params",
         "//xla/backends/gpu/runtime:command",
+        "//xla/backends/gpu/runtime:command_buffer_cmd",
         "//xla/backends/gpu/runtime:command_buffer_conversion_pass",
         "//xla/backends/gpu/runtime:command_buffer_thunk",
         "//xla/backends/gpu/runtime:nvshmem_collective_thunk",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -56,6 +56,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/collective_memory_requests.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/backends/gpu/runtime/command.h"
+#include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_buffer_conversion_pass.h"
 #include "xla/backends/gpu/runtime/command_buffer_thunk.h"
 #include "xla/backends/gpu/runtime/nvshmem_collective_thunk.h"
@@ -181,7 +182,7 @@ class GpuExecutableThunkPassBufferAllocator : public ThunkPassBufferAllocator {
       BufferAllocation::Index start_idx)
       : next_idx_(start_idx) {}
 
-  absl::StatusOr<BufferAllocation* absl_nonnull> NewEmptyAllocation(
+  absl::StatusOr<BufferAllocation * absl_nonnull> NewEmptyAllocation(
       int64_t size) override {
     allocations_.push_back(BufferAllocation(next_idx_++, size, /*color=*/0));
     return &allocations_.back();
@@ -430,7 +431,8 @@ GpuExecutable::GpuExecutable(
             if (cbt == nullptr) return absl::OkStatus();
             return cbt->WalkCommands([&](const Command* cmd) -> absl::Status {
               if (update_mode == DebugOptions::CAPTURE_CMD_NEVER_UPDATE &&
-                  !cmd->IsTracedCommand()) {
+                  dynamic_cast<const TracedCommandBufferCmd*>(cmd) == nullptr &&
+                  dynamic_cast<const CollectiveCmd*>(cmd) == nullptr) {
                 return absl::OkStatus();
               }
               for (const BufferUse& use : cmd->buffer_uses()) {


### PR DESCRIPTION
  Removes the `Command::IsTracedCommand()` virtual method and replaces
  all three call sites with explicit `dynamic_cast` checks against the
  two concrete base classes that previously overrode it:
  `TracedCommandBufferCmd` and `CollectiveCmd`.

  The virtual API added indirection without benefit — callers already
  hold `Command*` pointers and the set of "traced" command types is
  well-defined by the class hierarchy. Using `dynamic_cast` directly
  makes the type relationship explicit and removes the API surface from
  the base class.

  Changes:
  - Remove `virtual bool IsTracedCommand()` from `Command`
  - Remove `bool IsTracedCommand() const override` from
    `TracedCommandBufferCmd` and `CollectiveCmd`
  - Replace all three call sites in `command_executor.cc`,
    `command_buffer_thunk.cc`, and `gpu_executable.cc` with
    `dynamic_cast<const TracedCommandBufferCmd*>` /
    `dynamic_cast<const CollectiveCmd*>` checks
  - Add `:command_buffer_cmd` to BUILD deps of `command_executor`,
    `command_buffer_thunk`, and `gpu_executable`

