### PR TITLE
  [XLA:GPU] Fix missing P2P peer access in CudaMemoryReservation::SetAccess

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -859,6 +859,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@local_config_cuda//cuda:cuda_headers",
+        "//xla/tsl/platform:status_macros",
         "@tsl//tsl/platform:statusor",
     ],
 )
@@ -929,6 +930,31 @@ xla_test(
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+xla_test(
+    name = "cuda_memory_reservation_multigpu_test",
+    srcs = ["cuda_memory_reservation_multigpu_test.cc"],
+    backend_tags = {
+        "gpu": ["multi_gpu"],
+    },
+    backends = ["gpu"],
+    tags = ["cuda-only"],
+    deps = [
+        ":cuda_memory_reservation",
+        ":cuda_platform_id",
+        ":cuda_raw_memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cuda_headers",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
     ],

--- a/xla/stream_executor/cuda/cuda_memory_reservation.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation.cc
@@ -23,12 +23,14 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
 #include "xla/stream_executor/cuda/cuda_status.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "tsl/platform/statusor.h"
 
@@ -96,12 +98,36 @@ absl::Status CudaMemoryReservation::Map(size_t reservation_offset,
 absl::Status CudaMemoryReservation::SetAccess(uint64_t reservation_offset,
                                               size_t size) {
   std::unique_ptr<ActivateContext> activation = executor_->Activate();
+
+  // Always grant access to the local device.
   CUmemAccessDesc desc = {};
   desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   desc.location.id = static_cast<int>(executor_->device_ordinal());
   desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  return cuda::ToStatus(
-      cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1));
+  RETURN_IF_ERROR(
+      cuda::ToStatus(cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
+                     "cuMemSetAccess for local device"));
+
+  // Grant access to all P2P-capable peer devices. VA-mapped memory does not
+  // automatically inherit peer access, so NCCL collective operations using
+  // NVLink to read/write peer GPU buffers will deadlock without this.
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(
+      cuda::ToStatus(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount"));
+  for (int peer = 0; peer < device_count; ++peer) {
+    if (peer == executor_->device_ordinal()) {
+      continue;
+    }
+    if (!executor_->CanEnablePeerAccessTo(peer)) {
+      continue;
+    }
+    desc.location.id = peer;
+    RETURN_IF_ERROR(cuda::ToStatus(
+        cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
+        "cuMemSetAccess for peer device"));
+  }
+
+  return absl::OkStatus();
 }
 
 absl::Status CudaMemoryReservation::UnMap(size_t offset, size_t size) {

--- a/xla/stream_executor/cuda/cuda_memory_reservation.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation.cc
@@ -102,7 +102,7 @@ absl::Status CudaMemoryReservation::SetAccess(uint64_t reservation_offset,
   // Always grant access to the local device.
   CUmemAccessDesc desc = {};
   desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  desc.location.id = static_cast<int>(executor_->device_ordinal());
+  desc.location.id = executor_->device_ordinal();
   desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   RETURN_IF_ERROR(
       cuda::ToStatus(cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
@@ -114,7 +114,7 @@ absl::Status CudaMemoryReservation::SetAccess(uint64_t reservation_offset,
   int device_count = 0;
   TF_RETURN_IF_ERROR(
       cuda::ToStatus(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount"));
-  for (int peer = 0; peer < device_count; ++peer) {
+  for (int32_t peer = 0; peer < device_count; ++peer) {
     if (peer == executor_->device_ordinal()) {
       continue;
     }

--- a/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
@@ -1,0 +1,84 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/stream_executor/cuda/cuda_memory_reservation.h"
+#include "xla/stream_executor/cuda/cuda_platform_id.h"
+#include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+// 1 MB — will be rounded up to the VMM granularity (typically 2 MB).
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class CudaMemoryReservationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    TF_ASSERT_OK_AND_ASSIGN(
+        platform_, PlatformManager::PlatformWithId(cuda::kCudaPlatformId));
+    TF_ASSERT_OK_AND_ASSIGN(executor_, platform_->ExecutorForDevice(0));
+  }
+
+  Platform* platform_ = nullptr;
+  StreamExecutor* executor_ = nullptr;
+};
+
+// Verifies that MapTo grants read/write access to all P2P-capable peer devices,
+// not just the local device. Without this, NVLink P2P accesses to VA-mapped
+// buffers deadlock during NCCL collective operations (AllGather, ReduceScatter,
+// AllReduce).
+TEST_F(CudaMemoryReservationTest, SetAccessGrantsPeerDeviceAccess) {
+  if (platform_->VisibleDeviceCount() < 2) {
+    GTEST_SKIP() << "Test requires at least 2 GPUs, found "
+                 << platform_->VisibleDeviceCount();
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
+  for (int peer = 0; peer < platform_->VisibleDeviceCount(); ++peer) {
+    if (!executor_->CanEnablePeerAccessTo(peer)) continue;
+    CUmemLocation loc = {};
+    loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    loc.id = peer;
+    unsigned long long flags = 0;
+    ASSERT_EQ(cuMemGetAccess(&flags, &loc, base_ptr), CUDA_SUCCESS)
+        << "cuMemGetAccess failed for peer device " << peer;
+    EXPECT_EQ(flags, static_cast<unsigned long long>(
+                         CU_MEM_ACCESS_FLAGS_PROT_READWRITE))
+        << "Expected READWRITE access on peer device " << peer;
+  }
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
@@ -66,7 +66,7 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsPeerDeviceAccess) {
   TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
 
   CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
-  for (int peer = 0; peer < platform_->VisibleDeviceCount(); ++peer) {
+  for (int32_t peer = 0; peer < platform_->VisibleDeviceCount(); ++peer) {
     if (!executor_->CanEnablePeerAccessTo(peer)) continue;
     CUmemLocation loc = {};
     loc.type = CU_MEM_LOCATION_TYPE_DEVICE;

--- a/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
@@ -73,7 +73,8 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsPeerDeviceAccess) {
     loc.id = peer;
     uint64_t flags = 0;
     ASSERT_EQ(
-        cuMemGetAccess(reinterpret_cast<cuuint64_t*>(&flags), &loc, base_ptr),
+        cuMemGetAccess(reinterpret_cast<unsigned long long*>(&flags),  // NOLINT
+                       &loc, base_ptr),
         CUDA_SUCCESS)
         << "cuMemGetAccess failed for peer device " << peer;
     EXPECT_EQ(flags, static_cast<uint64_t>(CU_MEM_ACCESS_FLAGS_PROT_READWRITE))

--- a/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
@@ -72,9 +72,9 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsPeerDeviceAccess) {
     loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
     loc.id = peer;
     uint64_t flags = 0;
-    ASSERT_EQ(cuMemGetAccess(reinterpret_cast<unsigned long long*>(&flags),
-                             &loc, base_ptr),
-              CUDA_SUCCESS)
+    ASSERT_EQ(
+        cuMemGetAccess(reinterpret_cast<cuuint64_t*>(&flags), &loc, base_ptr),
+        CUDA_SUCCESS)
         << "cuMemGetAccess failed for peer device " << peer;
     EXPECT_EQ(flags, static_cast<uint64_t>(CU_MEM_ACCESS_FLAGS_PROT_READWRITE))
         << "Expected READWRITE access on peer device " << peer;

--- a/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_multigpu_test.cc
@@ -71,11 +71,12 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsPeerDeviceAccess) {
     CUmemLocation loc = {};
     loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
     loc.id = peer;
-    unsigned long long flags = 0;
-    ASSERT_EQ(cuMemGetAccess(&flags, &loc, base_ptr), CUDA_SUCCESS)
+    uint64_t flags = 0;
+    ASSERT_EQ(cuMemGetAccess(reinterpret_cast<unsigned long long*>(&flags),
+                             &loc, base_ptr),
+              CUDA_SUCCESS)
         << "cuMemGetAccess failed for peer device " << peer;
-    EXPECT_EQ(flags, static_cast<unsigned long long>(
-                         CU_MEM_ACCESS_FLAGS_PROT_READWRITE))
+    EXPECT_EQ(flags, static_cast<uint64_t>(CU_MEM_ACCESS_FLAGS_PROT_READWRITE))
         << "Expected READWRITE access on peer device " << peer;
   }
 }

--- a/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
@@ -182,7 +182,8 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsLocalDeviceAccess) {
   uint64_t flags = 0;
   CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
   ASSERT_EQ(
-      cuMemGetAccess(reinterpret_cast<cuuint64_t*>(&flags), &loc, base_ptr),
+      cuMemGetAccess(reinterpret_cast<unsigned long long*>(&flags),  // NOLINT
+                     &loc, base_ptr),
       CUDA_SUCCESS);
   EXPECT_EQ(flags, static_cast<uint64_t>(CU_MEM_ACCESS_FLAGS_PROT_READWRITE));
 }

--- a/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
@@ -178,7 +178,7 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsLocalDeviceAccess) {
 
   CUmemLocation loc = {};
   loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  loc.id = static_cast<int>(executor_->device_ordinal());
+  loc.id = executor_->device_ordinal();
   uint64_t flags = 0;
   CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
   ASSERT_EQ(cuMemGetAccess(reinterpret_cast<unsigned long long*>(&flags), &loc,

--- a/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
@@ -179,11 +179,12 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsLocalDeviceAccess) {
   CUmemLocation loc = {};
   loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
   loc.id = static_cast<int>(executor_->device_ordinal());
-  unsigned long long flags = 0;
+  uint64_t flags = 0;
   CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
-  ASSERT_EQ(cuMemGetAccess(&flags, &loc, base_ptr), CUDA_SUCCESS);
-  EXPECT_EQ(flags, static_cast<unsigned long long>(
-                       CU_MEM_ACCESS_FLAGS_PROT_READWRITE));
+  ASSERT_EQ(cuMemGetAccess(reinterpret_cast<unsigned long long*>(&flags), &loc,
+                           base_ptr),
+            CUDA_SUCCESS);
+  EXPECT_EQ(flags, static_cast<uint64_t>(CU_MEM_ACCESS_FLAGS_PROT_READWRITE));
 }
 
 }  // namespace

--- a/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
@@ -181,9 +181,9 @@ TEST_F(CudaMemoryReservationTest, SetAccessGrantsLocalDeviceAccess) {
   loc.id = executor_->device_ordinal();
   uint64_t flags = 0;
   CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
-  ASSERT_EQ(cuMemGetAccess(reinterpret_cast<unsigned long long*>(&flags), &loc,
-                           base_ptr),
-            CUDA_SUCCESS);
+  ASSERT_EQ(
+      cuMemGetAccess(reinterpret_cast<cuuint64_t*>(&flags), &loc, base_ptr),
+      CUDA_SUCCESS);
   EXPECT_EQ(flags, static_cast<uint64_t>(CU_MEM_ACCESS_FLAGS_PROT_READWRITE));
 }
 

--- a/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/types/span.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
 #include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
 #include "xla/stream_executor/device_address.h"
@@ -56,11 +57,11 @@ class CudaMemoryReservationTest : public ::testing::Test {
  protected:
   void SetUp() override {
     TF_ASSERT_OK_AND_ASSIGN(
-        Platform * platform,
-        PlatformManager::PlatformWithId(cuda::kCudaPlatformId));
-    TF_ASSERT_OK_AND_ASSIGN(executor_, platform->ExecutorForDevice(0));
+        platform_, PlatformManager::PlatformWithId(cuda::kCudaPlatformId));
+    TF_ASSERT_OK_AND_ASSIGN(executor_, platform_->ExecutorForDevice(0));
   }
 
+  Platform* platform_ = nullptr;
   StreamExecutor* executor_ = nullptr;
 };
 
@@ -162,6 +163,27 @@ TEST_F(CudaMemoryReservationTest, TwoReservationsDifferentAddresses) {
                           CudaMemoryReservation::Create(executor_, kTestSize));
 
   EXPECT_NE(res1->address().opaque(), res2->address().opaque());
+}
+
+// Verifies that MapTo grants read/write access to the local device via
+// cuMemSetAccess, readable back via cuMemGetAccess.
+TEST_F(CudaMemoryReservationTest, SetAccessGrantsLocalDeviceAccess) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  CUmemLocation loc = {};
+  loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  loc.id = static_cast<int>(executor_->device_ordinal());
+  unsigned long long flags = 0;
+  CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
+  ASSERT_EQ(cuMemGetAccess(&flags, &loc, base_ptr), CUDA_SUCCESS);
+  EXPECT_EQ(flags, static_cast<unsigned long long>(
+                       CU_MEM_ACCESS_FLAGS_PROT_READWRITE));
 }
 
 }  // namespace


### PR DESCRIPTION
  Problem

  When VA remapping is active (CAPTURE_CMD_NEVER_UPDATE + DeviceAddressVmmAllocator), physical memory is mapped to reserved VA ranges via CudaMemoryReservation::MapTo → SetAccess. SetAccess previously called cuMemSetAccess only for the local device, leaving all peer GPUs without read/write access to the VA-mapped addresses.

  On multi-GPU nodes with NVLink, NCCL collective operations (AllGather, ReduceScatter, AllReduce) require peer GPUs to directly access each other's buffers via P2P. Without the peer cuMemSetAccess calls, NVLink P2P accesses to VA-mapped buffers silently deadlock, hanging the entire training step indefinitely.

  This was observed as a 56-minute hang after the first jit_train_step warmup thunk execution on an 8x B200 single-node FSDP workload (deepseek2-16b FP8 + MaxText).

  Fix

  In CudaMemoryReservation::SetAccess, iterate over all P2P-capable peer devices and call cuMemSetAccess for each, mirroring the existing behavior in CudaVmmAllocator::VmmAllocate.

  Changes

  - xla/stream_executor/cuda/cuda_memory_reservation.cc: After granting local device access, enumerate all peer devices with cudaGetDeviceCount + CanEnablePeerAccessTo and issue cuMemSetAccess for each P2P-capable peer.
