### PR TITLE
  [stream_executor] Fix DCHECK in CommandBufferThunk::GetOrCreateCommandBuffer for multi-GPU runs

### DIFF
--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -420,8 +420,13 @@ CommandBufferThunk::GetOrCreateCommandBuffer(
   auto emplaced = state_->command_buffers.emplace(
       key, std::make_shared<ExecutorCommandBuffer>(std::move(command_buffer)));
   // With kNumVaReservationSets=2, at most 2 command buffers should exist per
-  // executor (one per VA reservation set).
-  DCHECK_LE(state_->command_buffers.size(), static_cast<size_t>(2))
+  // executor (one per VA reservation set). A CommandBufferThunk may be shared
+  // across replicas (multiple executors), so count only entries for this
+  // executor rather than the total map size.
+  size_t count_for_executor = std::count_if(
+      state_->command_buffers.begin(), state_->command_buffers.end(),
+      [executor](const auto& entry) { return entry.first.first == executor; });
+  DCHECK_LE(count_for_executor, static_cast<size_t>(2))
       << "command_buffers map has more entries than expected VA reservation "
       << "sets for executor " << executor;
 


### PR DESCRIPTION
In a multi-GPU run, all replicas share the same compiled GpuExecutable and therefore the same CommandBufferThunk instances. Each replica calls GetOrCreateCommandBuffer with its own distinct StreamExecutor*, growing state_->command_buffers by one
  entry per GPU. On the 3rd GPU's first call, the total map size reaches 3 and the assertion fires:

  command_buffer_thunk.cc:424] Check failed: state_->command_buffers.size() <= static_cast<size_t>(2) (3 vs. 2)
  command_buffers map has more entries than expected VA reservation sets for executor 0x...

  This is a latent bug introduced with the CAPTURE_CMD_NEVER_UPDATE VA-remapping feature (PR #40173). It is not visible in normal builds because tensorflow.bazelrc sets common -c opt globally, which defines NDEBUG and turns all DCHECK_* into
  no-ops. It surfaces in debug builds (--config=dbg) on any multi-GPU machine with ≥3 devices.