### PR TITLE
[xla:gpu] Correctly merge attributes from combined collectives

### DIFF
--- a/xla/backends/gpu/transforms/collectives/BUILD
+++ b/xla/backends/gpu/transforms/collectives/BUILD
@@ -136,6 +136,7 @@ cc_library(
     hdrs = ["gpu_collective_combiner_utils.h"],
     deps = [
         ":collective_ops_utils",
+        "//xla:side_effect_util",
         "//xla:util",
         "//xla/hlo/ir:hlo",
         "//xla/service:collective_ops_utils",
@@ -146,6 +147,8 @@ cc_library(
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -161,6 +164,7 @@ xla_cc_test(
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/hlo/transforms/simplifiers:hlo_dce",
         "//xla/hlo/utils:hlo_query",
+        "//xla/service:collective_combiner_utils",
         "//xla/service:collective_pipeliner",
         "//xla/service:collective_pipeliner_utils",
         "//xla/service:hlo_module_config",
@@ -191,6 +195,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -206,6 +211,7 @@ xla_cc_test(
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/hlo/utils:hlo_matchers",
         "//xla/service:collective_utils",
+        "//xla/service/gpu:backend_configs_cc",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:status_matchers",
@@ -231,6 +237,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -245,6 +252,7 @@ xla_cc_test(
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/hlo/utils:hlo_matchers",
         "//xla/service:collective_utils",
+        "//xla/service/gpu:backend_configs_cc",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:status_matchers",
@@ -270,6 +278,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -284,6 +293,7 @@ xla_cc_test(
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/hlo/utils:hlo_matchers",
         "//xla/service:collective_utils",
+        "//xla/service/gpu:backend_configs_cc",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:status_matchers",

--- a/xla/backends/gpu/transforms/collectives/all_gather_combiner.cc
+++ b/xla/backends/gpu/transforms/collectives/all_gather_combiner.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/backends/gpu/transforms/collectives/collective_combiner_annotator.h"
 #include "xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -47,6 +48,8 @@ std::optional<AllGatherCombiner::GroupKey> DefaultCombinerKey(
     absl::StrAppend(&AllGatherCombiner::GetGroupKeyExtraArgs(*key),
                     " pipelined=true");
   }
+  AppendCombinerKeyFromFrontendAttr(
+      instruction, AllGatherCombiner::GetGroupKeyExtraArgs(*key));
   return key;
 }
 
@@ -63,11 +66,15 @@ std::optional<AllGatherCombiner::GroupKey> CustomCombinerKey(
   if (IsPipelinedCollective(*instruction)) {
     absl::StrAppend(&AllGatherCombiner::GetGroupKeyExtraArgs(*key),
                     " pipelined=true");
+    AppendCombinerKeyFromFrontendAttr(
+        instruction, AllGatherCombiner::GetGroupKeyExtraArgs(*key));
     return key;
   }
   if (IsCombinableSyncCollective(*instruction)) {
     absl::StrAppend(&AllGatherCombiner::GetGroupKeyExtraArgs(*key),
                     " sync=true");
+    AppendCombinerKeyFromFrontendAttr(
+        instruction, AllGatherCombiner::GetGroupKeyExtraArgs(*key));
     return key;
   }
   return std::nullopt;
@@ -78,9 +85,15 @@ std::optional<AllGatherCombiner::GroupKey> CustomCombinerKey(
 absl::StatusOr<bool> GpuAllGatherCombiner::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  auto post_combine = [](absl::Span<HloInstruction* const> to_combine,
+                         HloInstruction* combined) {
+    return MergeCollectiveBackendConfig(to_combine, combined);
+  };
+
   // Combiner threshold is specified. Running parent pass code.
   if (combine_threshold_in_bytes_ != default_combine_threshold_in_bytes_) {
-    return RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey);
+    return RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey,
+                              post_combine);
   }
 
   // Combiner threshold is not specified. We use heuristics.
@@ -91,18 +104,18 @@ absl::StatusOr<bool> GpuAllGatherCombiner::RunImpl(
 
   if (auto suggested_threshold = SuggestedCombinerThreshold(*module)) {
     combine_threshold_in_bytes_ = *suggested_threshold;
-    TF_ASSIGN_OR_RETURN(
-        bool combined,
-        RunWithKeyCombiner(module, execution_threads, CustomCombinerKey));
+    TF_ASSIGN_OR_RETURN(bool combined,
+                        RunWithKeyCombiner(module, execution_threads,
+                                           CustomCombinerKey, post_combine));
     changed |= combined;
   }
 
   // Use the default combiner thresholds after we combined pipelined and
   // synchronous collectives.
   combine_threshold_in_bytes_ = default_combine_threshold_in_bytes_;
-  TF_ASSIGN_OR_RETURN(
-      bool combined,
-      RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey));
+  TF_ASSIGN_OR_RETURN(bool combined,
+                      RunWithKeyCombiner(module, execution_threads,
+                                         DefaultCombinerKey, post_combine));
   changed |= combined;
   return changed;
 }

--- a/xla/backends/gpu/transforms/collectives/all_gather_combiner_test.cc
+++ b/xla/backends/gpu/transforms/collectives/all_gather_combiner_test.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/service/collective_utils.h"
+#include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/tsl/platform/statusor.h"
 
 namespace xla::gpu {
@@ -371,6 +372,107 @@ TEST_F(GpuAllGatherCombinerTest,
 
   EXPECT_THAT(RunCombiner(module.get(), kDefaultAllGatherCombineThreshold),
               absl_testing::IsOkAndHolds(false));
+}
+
+TEST_F(GpuAllGatherCombinerTest, CombinerKeyPreventsCombiingAcrossGroups) {
+  // Two all-gathers with combiner_key="layer_0" and one with
+  // combiner_key="layer_1". Only the first two should be combined.
+  constexpr absl::string_view kHloString = R"(
+HloModule module
+
+ENTRY entry {
+  p0 = f32[32] parameter(0)
+  p1 = f32[32] parameter(1)
+  p2 = f32[32] parameter(2)
+  ag0 = f32[128] all-gather(p0), dimensions={0}, replica_groups={},
+    frontend_attributes={combiner_key="layer_0"}
+  ag1 = f32[128] all-gather(p1), dimensions={0}, replica_groups={},
+    frontend_attributes={combiner_key="layer_0"}
+  ag2 = f32[128] all-gather(p2), dimensions={0}, replica_groups={},
+    frontend_attributes={combiner_key="layer_1"}
+  ROOT tuple = (f32[128], f32[128], f32[128]) tuple(ag0, ag1, ag2)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloString));
+  EXPECT_THAT(
+      RunCombiner(module.get(), /*combine_threshold_bytes=*/1024 * 1024),
+      absl_testing::IsOkAndHolds(true));
+
+  // ag0 and ag1 (layer_0) should be combined into one tuple all-gather.
+  // ag2 (layer_1) should remain separate.
+  int ag_count = 0;
+  for (const HloInstruction* instr :
+       module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kAllGather) {
+      ag_count++;
+    }
+  }
+  EXPECT_EQ(ag_count, 2);
+}
+
+TEST_F(GpuAllGatherCombinerTest, NoCombinerKeyCombinesFreely) {
+  // All-gathers without combiner_key should be combined as usual.
+  constexpr absl::string_view kHloString = R"(
+HloModule module
+
+ENTRY entry {
+  p0 = f32[32] parameter(0)
+  p1 = f32[32] parameter(1)
+  p2 = f32[32] parameter(2)
+  ag0 = f32[128] all-gather(p0), dimensions={0}, replica_groups={}
+  ag1 = f32[128] all-gather(p1), dimensions={0}, replica_groups={}
+  ag2 = f32[128] all-gather(p2), dimensions={0}, replica_groups={}
+  ROOT tuple = (f32[128], f32[128], f32[128]) tuple(ag0, ag1, ag2)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloString));
+  EXPECT_THAT(
+      RunCombiner(module.get(), /*combine_threshold_bytes=*/1024 * 1024),
+      absl_testing::IsOkAndHolds(true));
+
+  // All three should be combined into one.
+  int ag_count = 0;
+  for (const HloInstruction* instr :
+       module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kAllGather) {
+      ag_count++;
+    }
+  }
+  EXPECT_EQ(ag_count, 1);
+}
+
+TEST_F(GpuAllGatherCombinerTest, CombinedPipelinedRetainsBackendConfig) {
+  constexpr absl::string_view kHloString = R"(
+HloModule module
+
+ENTRY entry {
+  p0 = f32[32] parameter(0)
+  p1 = f32[32] parameter(1)
+  ag0 = f32[128] all-gather(p0), dimensions={0}, replica_groups={},
+    backend_config={"collective_backend_config": {"is_pipelined": true}}
+  ag1 = f32[128] all-gather(p1), dimensions={0}, replica_groups={},
+    backend_config={"collective_backend_config": {"is_pipelined": true}}
+  ROOT tuple = (f32[128], f32[128]) tuple(ag0, ag1)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloString));
+  EXPECT_THAT(
+      RunCombiner(module.get(), /*combine_threshold_bytes=*/1024 * 1024),
+      absl_testing::IsOkAndHolds(true));
+
+  // After combining, there should be exactly one all-gather.
+  const HloInstruction* combined =
+      module->entry_computation()->GetInstructionWithName("all-gather");
+  ASSERT_NE(combined, nullptr);
+  TF_ASSERT_OK_AND_ASSIGN(auto config,
+                          combined->backend_config<GpuBackendConfig>());
+  EXPECT_TRUE(config.collective_backend_config().is_pipelined());
 }
 
 }  // namespace

--- a/xla/backends/gpu/transforms/collectives/all_reduce_combiner.cc
+++ b/xla/backends/gpu/transforms/collectives/all_reduce_combiner.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/backends/gpu/transforms/collectives/collective_combiner_annotator.h"
 #include "xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -45,6 +46,8 @@ std::optional<AllReduceCombiner::GroupKey> DefaultCombinerKey(
     absl::StrAppend(&AllReduceCombiner::GetGroupKeyExtraArgs(*key),
                     " pipelined=true");
   }
+  AppendCombinerKeyFromFrontendAttr(
+      instruction, AllReduceCombiner::GetGroupKeyExtraArgs(*key));
   return key;
 }
 
@@ -61,11 +64,15 @@ std::optional<AllReduceCombiner::GroupKey> CustomCombinerKey(
   if (IsPipelinedCollective(*instruction)) {
     absl::StrAppend(&AllReduceCombiner::GetGroupKeyExtraArgs(*key),
                     " pipelined=true");
+    AppendCombinerKeyFromFrontendAttr(
+        instruction, AllReduceCombiner::GetGroupKeyExtraArgs(*key));
     return key;
   }
   if (IsCombinableSyncCollective(*instruction)) {
     absl::StrAppend(&AllReduceCombiner::GetGroupKeyExtraArgs(*key),
                     " sync=true");
+    AppendCombinerKeyFromFrontendAttr(
+        instruction, AllReduceCombiner::GetGroupKeyExtraArgs(*key));
     return key;
   }
   return std::nullopt;
@@ -76,9 +83,15 @@ std::optional<AllReduceCombiner::GroupKey> CustomCombinerKey(
 absl::StatusOr<bool> GpuAllReduceCombiner::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  auto post_combine = [](absl::Span<HloInstruction* const> to_combine,
+                         HloInstruction* combined) {
+    return MergeCollectiveBackendConfig(to_combine, combined);
+  };
+
   // Combiner threshold is specified. Running parent pass code.
   if (combine_threshold_in_bytes_ != default_combine_threshold_in_bytes_) {
-    return RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey);
+    return RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey,
+                              post_combine);
   }
 
   // Combiner threshold is not specified. We use heuristics.
@@ -89,18 +102,18 @@ absl::StatusOr<bool> GpuAllReduceCombiner::RunImpl(
 
   if (auto suggested_threshold = SuggestedCombinerThreshold(*module)) {
     combine_threshold_in_bytes_ = *suggested_threshold;
-    TF_ASSIGN_OR_RETURN(
-        bool combined,
-        RunWithKeyCombiner(module, execution_threads, CustomCombinerKey));
+    TF_ASSIGN_OR_RETURN(bool combined,
+                        RunWithKeyCombiner(module, execution_threads,
+                                           CustomCombinerKey, post_combine));
     changed |= combined;
   }
 
   // Use the default combiner thresholds after we combined pipelined and
   // synchronous collectives.
   combine_threshold_in_bytes_ = default_combine_threshold_in_bytes_;
-  TF_ASSIGN_OR_RETURN(
-      bool combined,
-      RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey));
+  TF_ASSIGN_OR_RETURN(bool combined,
+                      RunWithKeyCombiner(module, execution_threads,
+                                         DefaultCombinerKey, post_combine));
   changed |= combined;
   return changed;
 }

--- a/xla/backends/gpu/transforms/collectives/all_reduce_combiner_test.cc
+++ b/xla/backends/gpu/transforms/collectives/all_reduce_combiner_test.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/service/collective_utils.h"
+#include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/tsl/platform/statusor.h"
 
 namespace xla::gpu {
@@ -423,6 +424,41 @@ TEST_F(GpuAllReduceCombinerTest,
                                          suggested_threshold_bytes);
   EXPECT_THAT(RunCombiner(module.get(), kDefaultAllReduceCombineThreshold),
               absl_testing::IsOkAndHolds(false));
+}
+
+TEST_F(GpuAllReduceCombinerTest, CombinedPipelinedRetainsBackendConfig) {
+  constexpr absl::string_view kHloString = R"(
+HloModule module
+
+add {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT add = f32[] add(lhs, rhs)
+}
+
+ENTRY entry {
+  p0 = f32[128] parameter(0)
+  p1 = f32[128] parameter(1)
+  ar0 = f32[128] all-reduce(p0), to_apply=add, replica_groups={},
+    backend_config={"collective_backend_config": {"is_pipelined": true}}
+  ar1 = f32[128] all-reduce(p1), to_apply=add, replica_groups={},
+    backend_config={"collective_backend_config": {"is_pipelined": true}}
+  ROOT tuple = (f32[128], f32[128]) tuple(ar0, ar1)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloString));
+  EXPECT_THAT(
+      RunCombiner(module.get(), /*combine_threshold_bytes=*/1024 * 1024),
+      absl_testing::IsOkAndHolds(true));
+
+  const HloInstruction* combined =
+      module->entry_computation()->GetInstructionWithName("all-reduce");
+  ASSERT_NE(combined, nullptr);
+  TF_ASSERT_OK_AND_ASSIGN(auto config,
+                          combined->backend_config<GpuBackendConfig>());
+  EXPECT_TRUE(config.collective_backend_config().is_pipelined());
 }
 
 }  // namespace

--- a/xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.cc
+++ b/xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.cc
@@ -16,9 +16,12 @@ limitations under the License.
 #include "xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.h"
 
 #include <cstdint>
+#include <string>
 
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/types/span.h"
 #include "xla/backends/gpu/transforms/collectives/collective_ops_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
@@ -26,6 +29,7 @@ limitations under the License.
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/hlo_module_config.h"
+#include "xla/side_effect_util.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/tsl/platform/statusor.h"
@@ -89,6 +93,35 @@ bool EnableHeuristicCollectiveCombining(
           << (config.num_partitions() * config.replica_count())
           << " > NVLink slice size " << nvlink_slice_size;
   return true;
+}
+
+absl::Status MergeCollectiveBackendConfig(
+    absl::Span<HloInstruction* const> to_combine, HloInstruction* combined) {
+  TF_ASSIGN_OR_RETURN(auto config,
+                      combined->backend_config<gpu::GpuBackendConfig>());
+  bool any_pipelined = false;
+  for (const HloInstruction* inst : to_combine) {
+    auto src_config = inst->backend_config<GpuBackendConfig>();
+    if (src_config.ok() &&
+        src_config->collective_backend_config().is_pipelined()) {
+      any_pipelined = true;
+      break;
+    }
+  }
+  if (any_pipelined) {
+    config.mutable_collective_backend_config()->set_is_pipelined(true);
+  }
+  return combined->set_backend_config(config);
+}
+
+void AppendCombinerKeyFromFrontendAttr(const HloInstruction* instruction,
+                                       std::string& extra_args) {
+  if (instruction->has_frontend_attributes()) {
+    auto it = instruction->frontend_attributes().map().find(kCombinerKeyAttr);
+    if (it != instruction->frontend_attributes().map().end()) {
+      absl::StrAppend(&extra_args, " combiner_key=", it->second);
+    }
+  }
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.h
+++ b/xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.h
@@ -17,8 +17,10 @@ limitations under the License.
 #define XLA_BACKENDS_GPU_TRANSFORMS_COLLECTIVES_GPU_COLLECTIVE_COMBINER_UTILS_H_
 
 #include <cstdint>
+#include <string>
 
 #include "absl/status/status.h"
+#include "absl/types/span.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_schedule.h"
@@ -45,6 +47,17 @@ bool ContainsPipelinedInstruction(const HloModule& module);
 bool EnableHeuristicCollectiveCombining(
     const HloModuleConfig& config,
     const se::DeviceDescription& device_description, int64_t nvlink_slice_size);
+
+// Merges the CollectiveBackendConfig from all combined instructions onto the
+// target instruction. Currently merges the is_pipelined field: if any source
+// instruction is pipelined, the target is marked as pipelined.
+absl::Status MergeCollectiveBackendConfig(
+    absl::Span<HloInstruction* const> to_combine, HloInstruction* combined);
+
+// If the instruction has a "combiner_key" frontend attribute, appends it to
+// extra_args so that only collectives with matching keys are combined.
+void AppendCombinerKeyFromFrontendAttr(const HloInstruction* instruction,
+                                       std::string& extra_args);
 
 }  // namespace xla::gpu
 

--- a/xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils_test.cc
+++ b/xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils_test.cc
@@ -16,7 +16,9 @@ limitations under the License.
 #include "xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.h"
 
 #include <cstdint>
+#include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/strings/string_view.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -26,6 +28,7 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/transforms/simplifiers/hlo_dce.h"
 #include "xla/hlo/utils/hlo_query.h"
+#include "xla/service/collective_combiner_utils.h"
 #include "xla/service/collective_pipeliner.h"
 #include "xla/service/collective_pipeliner_utils.h"
 #include "xla/service/gpu/backend_configs.pb.h"
@@ -38,6 +41,9 @@ limitations under the License.
 
 namespace xla::gpu {
 namespace {
+
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
 
 using CollectiveCombinerUtilsTest = HloHardwareIndependentTestBase;
 
@@ -584,6 +590,170 @@ TEST(EnableHeuristicCollectiveCombiningTest, DisabledByFlag) {
           se::CudaComputeCapability::Blackwell());
   EXPECT_FALSE(xla::gpu::EnableHeuristicCollectiveCombining(
       config, device_description, /*nvlink_slice_size=*/8));
+}
+
+TEST_F(CollectiveCombinerUtilsTest, MergeFrontendAttributesDeduplicates) {
+  constexpr absl::string_view kHloText = R"(
+    HloModule module
+
+    add {
+      lhs = bf16[] parameter(0)
+      rhs = bf16[] parameter(1)
+      ROOT add = bf16[] add(lhs, rhs)
+    }
+
+    ENTRY entry {
+      p0 = bf16[8] parameter(0)
+      ar.0 = bf16[8] all-reduce(p0), to_apply=add,
+        frontend_attributes={is_pipelinable="true", key_a="val_a"}
+      ROOT ar.1 = bf16[8] all-reduce(ar.0), to_apply=add,
+        frontend_attributes={is_pipelinable="true", key_b="val_b"}
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+  std::vector<HloInstruction*> instructions;
+  for (HloInstruction* instr :
+       module->entry_computation()->MakeInstructionPostOrder()) {
+    if (instr->opcode() == HloOpcode::kAllReduce) {
+      instructions.push_back(instr);
+    }
+  }
+  ASSERT_EQ(instructions.size(), 2);
+
+  FrontendAttributes merged = MergeFrontendAttributes(instructions);
+  EXPECT_THAT(merged.map(), UnorderedElementsAre(Pair("is_pipelinable", "true"),
+                                                 Pair("key_a", "val_a"),
+                                                 Pair("key_b", "val_b")));
+}
+
+TEST_F(CollectiveCombinerUtilsTest, MergeFrontendAttributesConflictingValues) {
+  constexpr absl::string_view kHloText = R"(
+    HloModule module
+
+    add {
+      lhs = bf16[] parameter(0)
+      rhs = bf16[] parameter(1)
+      ROOT add = bf16[] add(lhs, rhs)
+    }
+
+    ENTRY entry {
+      p0 = bf16[8] parameter(0)
+      ar.0 = bf16[8] all-reduce(p0), to_apply=add,
+        frontend_attributes={color="red"}
+      ROOT ar.1 = bf16[8] all-reduce(ar.0), to_apply=add,
+        frontend_attributes={color="blue"}
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+  std::vector<HloInstruction*> instructions;
+  for (HloInstruction* instr :
+       module->entry_computation()->MakeInstructionPostOrder()) {
+    if (instr->opcode() == HloOpcode::kAllReduce) {
+      instructions.push_back(instr);
+    }
+  }
+  ASSERT_EQ(instructions.size(), 2);
+
+  FrontendAttributes merged = MergeFrontendAttributes(instructions);
+  // Conflicting values sorted and comma-joined (btree_set order).
+  EXPECT_THAT(merged.map(), UnorderedElementsAre(Pair("color", "blue,red")));
+}
+
+TEST_F(CollectiveCombinerUtilsTest, MergeMetadataExtendsSourceLines) {
+  constexpr absl::string_view kHloText = R"(
+    HloModule module
+
+    add {
+      lhs = bf16[] parameter(0)
+      rhs = bf16[] parameter(1)
+      ROOT add = bf16[] add(lhs, rhs)
+    }
+
+    ENTRY entry {
+      p0 = bf16[8] parameter(0)
+      ar.0 = bf16[8] all-reduce(p0), to_apply=add
+      ROOT ar.1 = bf16[8] all-reduce(ar.0), to_apply=add
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+  std::vector<HloInstruction*> instructions;
+  for (HloInstruction* instr :
+       module->entry_computation()->MakeInstructionPostOrder()) {
+    if (instr->opcode() == HloOpcode::kAllReduce) {
+      instructions.push_back(instr);
+    }
+  }
+  ASSERT_EQ(instructions.size(), 2);
+
+  // Set metadata manually for testing.
+  OpMetadata md0;
+  md0.set_source_file("model.py");
+  md0.set_source_line(10);
+  md0.set_source_end_line(15);
+  md0.set_op_name("layer_0/ar");
+  instructions[0]->set_metadata(md0);
+
+  OpMetadata md1;
+  md1.set_source_file("model.py");
+  md1.set_source_line(5);
+  md1.set_source_end_line(20);
+  md1.set_op_name("layer_1/ar");
+  instructions[1]->set_metadata(md1);
+
+  OpMetadata merged = MergeMetadata(instructions);
+  // Source locations are concatenated as file:line pairs.
+  EXPECT_EQ(merged.source_file(), "model.py:10,model.py:5");
+  EXPECT_EQ(merged.source_line(), 0);
+  EXPECT_EQ(merged.source_end_line(), 0);
+  // No common '/' prefix between "layer_0/ar" and "layer_1/ar",
+  // so op_name is "(layer_0/ar:layer_1/ar)".
+  EXPECT_EQ(merged.op_name(), "(layer_0/ar:layer_1/ar)");
+}
+
+TEST_F(CollectiveCombinerUtilsTest,
+       MergeCollectiveBackendConfigPropagatesPipelined) {
+  constexpr absl::string_view kHloText = R"(
+    HloModule module
+
+    add {
+      lhs = bf16[] parameter(0)
+      rhs = bf16[] parameter(1)
+      ROOT add = bf16[] add(lhs, rhs)
+    }
+
+    ENTRY entry {
+      p0 = bf16[8] parameter(0)
+      ar.0 = bf16[8] all-reduce(p0), to_apply=add,
+        backend_config={"collective_backend_config": {"is_pipelined": true}}
+      ROOT ar.1 = bf16[8] all-reduce(ar.0), to_apply=add,
+        backend_config={"collective_backend_config": {"is_pipelined": false}}
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+  std::vector<HloInstruction*> instructions;
+  for (HloInstruction* instr :
+       module->entry_computation()->MakeInstructionPostOrder()) {
+    if (instr->opcode() == HloOpcode::kAllReduce) {
+      instructions.push_back(instr);
+    }
+  }
+  ASSERT_EQ(instructions.size(), 2);
+
+  // Use the second (non-pipelined) instruction as the combined target.
+  HloInstruction* combined = instructions[1];
+  ASSERT_FALSE(combined->backend_config<GpuBackendConfig>()
+                   ->collective_backend_config()
+                   .is_pipelined());
+
+  ASSERT_TRUE(MergeCollectiveBackendConfig(instructions, combined).ok());
+  // After merge, should be pipelined because at least one source was.
+  EXPECT_TRUE(combined->backend_config<GpuBackendConfig>()
+                  ->collective_backend_config()
+                  .is_pipelined());
 }
 
 }  // namespace

--- a/xla/backends/gpu/transforms/collectives/reduce_scatter_combiner.cc
+++ b/xla/backends/gpu/transforms/collectives/reduce_scatter_combiner.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/backends/gpu/transforms/collectives/collective_combiner_annotator.h"
 #include "xla/backends/gpu/transforms/collectives/gpu_collective_combiner_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -46,6 +47,8 @@ std::optional<ReduceScatterCombiner::GroupKey> DefaultCombinerKey(
     absl::StrAppend(&ReduceScatterCombiner::GetGroupKeyExtraArgs(*key),
                     " pipelined=true");
   }
+  AppendCombinerKeyFromFrontendAttr(
+      instruction, ReduceScatterCombiner::GetGroupKeyExtraArgs(*key));
   return key;
 }
 
@@ -61,11 +64,15 @@ std::optional<ReduceScatterCombiner::GroupKey> CustomCombinerKey(
   if (IsPipelinedCollective(*instruction)) {
     absl::StrAppend(&ReduceScatterCombiner::GetGroupKeyExtraArgs(*key),
                     " pipelined=true");
+    AppendCombinerKeyFromFrontendAttr(
+        instruction, ReduceScatterCombiner::GetGroupKeyExtraArgs(*key));
     return key;
   }
   if (IsCombinableSyncCollective(*instruction)) {
     absl::StrAppend(&ReduceScatterCombiner::GetGroupKeyExtraArgs(*key),
                     " sync=true");
+    AppendCombinerKeyFromFrontendAttr(
+        instruction, ReduceScatterCombiner::GetGroupKeyExtraArgs(*key));
     return key;
   }
   return std::nullopt;
@@ -76,9 +83,15 @@ std::optional<ReduceScatterCombiner::GroupKey> CustomCombinerKey(
 absl::StatusOr<bool> GpuReduceScatterCombiner::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  auto post_combine = [](absl::Span<HloInstruction* const> to_combine,
+                         HloInstruction* combined) {
+    return MergeCollectiveBackendConfig(to_combine, combined);
+  };
+
   // Combiner threshold is specified. Running parent pass code.
   if (combine_threshold_in_bytes_ != default_combine_threshold_in_bytes_) {
-    return RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey);
+    return RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey,
+                              post_combine);
   }
 
   // Combiner threshold is not specified. We use heuristics.
@@ -89,18 +102,18 @@ absl::StatusOr<bool> GpuReduceScatterCombiner::RunImpl(
 
   if (auto suggested_threshold = SuggestedCombinerThreshold(*module)) {
     combine_threshold_in_bytes_ = *suggested_threshold;
-    TF_ASSIGN_OR_RETURN(
-        bool combined,
-        RunWithKeyCombiner(module, execution_threads, CustomCombinerKey));
+    TF_ASSIGN_OR_RETURN(bool combined,
+                        RunWithKeyCombiner(module, execution_threads,
+                                           CustomCombinerKey, post_combine));
     changed |= combined;
   }
 
   // Use the default combiner thresholds after we combined pipelined and
   // synchronous collectives.
   combine_threshold_in_bytes_ = default_combine_threshold_in_bytes_;
-  TF_ASSIGN_OR_RETURN(
-      bool combined,
-      RunWithKeyCombiner(module, execution_threads, DefaultCombinerKey));
+  TF_ASSIGN_OR_RETURN(bool combined,
+                      RunWithKeyCombiner(module, execution_threads,
+                                         DefaultCombinerKey, post_combine));
   changed |= combined;
   return changed;
 }

--- a/xla/backends/gpu/transforms/collectives/reduce_scatter_combiner_test.cc
+++ b/xla/backends/gpu/transforms/collectives/reduce_scatter_combiner_test.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/service/collective_utils.h"
+#include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/tsl/platform/statusor.h"
 
 namespace xla::gpu {
@@ -392,6 +393,43 @@ TEST_F(GpuReduceScatterCombinerTest,
                                          suggested_threshold_bytes);
   EXPECT_THAT(RunCombiner(module.get(), kDefaultReduceScatterCombineThreshold),
               absl_testing::IsOkAndHolds(false));
+}
+
+TEST_F(GpuReduceScatterCombinerTest, CombinedPipelinedRetainsBackendConfig) {
+  constexpr absl::string_view kHloString = R"(
+HloModule module
+
+add {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT add = f32[] add(lhs, rhs)
+}
+
+ENTRY entry {
+  p0 = f32[128] parameter(0)
+  p1 = f32[128] parameter(1)
+  rs0 = f32[32] reduce-scatter(p0), dimensions={0}, to_apply=add,
+    replica_groups={},
+    backend_config={"collective_backend_config": {"is_pipelined": true}}
+  rs1 = f32[32] reduce-scatter(p1), dimensions={0}, to_apply=add,
+    replica_groups={},
+    backend_config={"collective_backend_config": {"is_pipelined": true}}
+  ROOT tuple = (f32[32], f32[32]) tuple(rs0, rs1)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloString));
+  EXPECT_THAT(
+      RunCombiner(module.get(), /*combine_threshold_bytes=*/1024 * 1024),
+      absl_testing::IsOkAndHolds(true));
+
+  const HloInstruction* combined =
+      module->entry_computation()->GetInstructionWithName("reduce-scatter");
+  ASSERT_NE(combined, nullptr);
+  TF_ASSERT_OK_AND_ASSIGN(auto config,
+                          combined->backend_config<GpuBackendConfig>());
+  EXPECT_TRUE(config.collective_backend_config().is_pipelined());
 }
 
 }  // namespace

--- a/xla/hlo/transforms/collectives/BUILD
+++ b/xla/hlo/transforms/collectives/BUILD
@@ -301,7 +301,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
     ],
 )
@@ -372,7 +372,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:statusor",
@@ -455,7 +455,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/xla/hlo/transforms/collectives/all_gather_combiner.cc
+++ b/xla/hlo/transforms/collectives/all_gather_combiner.cc
@@ -51,8 +51,9 @@ namespace {
 // Combines the elements of to_combine into a single AllGather op. All entries
 // in to_combine must be AllGather ops with exactly one operand and the same
 // preferred all_gather_dimension.
-absl::Status CombineAllGathers(absl::Span<HloInstruction* const> to_combine,
-                               bool combine_by_dim) {
+absl::Status CombineAllGathers(
+    absl::Span<HloInstruction* const> to_combine, bool combine_by_dim,
+    const AllGatherCombiner::PostCombineFn& post_combine) {
   if (to_combine.size() < 2) {
     return absl::OkStatus();
   }
@@ -112,7 +113,11 @@ absl::Status CombineAllGathers(absl::Span<HloInstruction* const> to_combine,
           /*constrain_layout=*/false, to_combine.front()->channel_id(),
           Cast<HloAllGatherInstruction>(to_combine.front())
               ->use_global_device_ids()));
-  combined->set_metadata(to_combine.front()->metadata());
+  combined->set_metadata(MergeMetadata(to_combine));
+  combined->set_frontend_attributes(MergeFrontendAttributes(to_combine));
+  if (post_combine != nullptr) {
+    TF_RETURN_IF_ERROR(post_combine(to_combine, combined));
+  }
 
   // We have to propagate the sharding manually because Domain instructions are
   // not guaranteed to preserve it for side effecting instructions.
@@ -195,6 +200,16 @@ absl::StatusOr<bool> AllGatherCombiner::RunWithKeyCombiner(
     absl::FunctionRef<std::optional<AllGatherCombiner::GroupKey>(
         const HloInstruction*, const HloDomainMap&, bool, bool)>
         combine_key) {
+  return RunWithKeyCombiner(module, execution_threads, combine_key, nullptr);
+}
+
+absl::StatusOr<bool> AllGatherCombiner::RunWithKeyCombiner(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads,
+    absl::FunctionRef<std::optional<AllGatherCombiner::GroupKey>(
+        const HloInstruction*, const HloDomainMap&, bool, bool)>
+        combine_key,
+    PostCombineFn post_combine) {
   VLOG(1) << "Running AllGatherCombiner with threshold of "
           << combine_threshold_in_bytes_ << " bytes";
 
@@ -228,7 +243,7 @@ absl::StatusOr<bool> AllGatherCombiner::RunWithKeyCombiner(
     };
     auto combine_fn =
         [&](absl::Span<HloInstruction* const> to_combine) -> absl::Status {
-      return CombineAllGathers(to_combine, combine_by_dim_);
+      return CombineAllGathers(to_combine, combine_by_dim_, post_combine);
     };
 
     TF_ASSIGN_OR_RETURN(

--- a/xla/hlo/transforms/collectives/all_gather_combiner.h
+++ b/xla/hlo/transforms/collectives/all_gather_combiner.h
@@ -16,10 +16,14 @@ limitations under the License.
 #ifndef XLA_HLO_TRANSFORMS_COLLECTIVES_ALL_GATHER_COMBINER_H_
 #define XLA_HLO_TRANSFORMS_COLLECTIVES_ALL_GATHER_COMBINER_H_
 
+#include <functional>
+
 #include "absl/container/flat_hash_set.h"
 #include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/pass/hlo_pass_interface.h"
@@ -63,6 +67,9 @@ class AllGatherCombiner : public HloModulePass {
       const HloInstruction* instruction, const HloDomainMap& domain_map,
       bool combine_by_dim, bool combine_different_dtypes = true);
 
+  using PostCombineFn = std::function<absl::Status(
+      absl::Span<HloInstruction* const>, HloInstruction*)>;
+
  protected:
   absl::StatusOr<bool> RunImpl(
       HloModule* module,
@@ -74,6 +81,14 @@ class AllGatherCombiner : public HloModulePass {
       absl::FunctionRef<std::optional<AllGatherCombiner::GroupKey>(
           const HloInstruction*, const HloDomainMap&, bool, bool)>
           combine_key);
+
+  absl::StatusOr<bool> RunWithKeyCombiner(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads,
+      absl::FunctionRef<std::optional<AllGatherCombiner::GroupKey>(
+          const HloInstruction*, const HloDomainMap&, bool, bool)>
+          combine_key,
+      PostCombineFn post_combine);
 
   // Combine all gather ops up to this threshold.
   int64_t combine_threshold_in_bytes_;

--- a/xla/hlo/transforms/collectives/all_gather_combiner_test.cc
+++ b/xla/hlo/transforms/collectives/all_gather_combiner_test.cc
@@ -640,11 +640,48 @@ TEST_F(AllGatherCombinerTest, PreservesMetadata) {
 
   OpMetadata metadata;
   metadata.set_op_type("test_type0");
-  metadata.set_op_name("test_name0");
+  metadata.set_op_name("(test_name0:test_name1)");
   Matcher<const HloInstruction*> combined_all_gather = op::Metadata(metadata);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Tuple(op::GetTupleElement(combined_all_gather, 0),
                         op::GetTupleElement(combined_all_gather, 1)));
+}
+
+TEST_F(AllGatherCombinerTest, PreservesFrontendAttributesAndMergedMetadata) {
+  absl::string_view hlo_string = R"(
+    HloModule Module
+
+    ENTRY entry {
+      param0 = f32[32] parameter(0)
+      param1 = f32[32] parameter(1)
+      allgather0 = f32[128] all-gather(param0), replica_groups={}, dimensions={0}, frontend_attributes={is_pipelinable="true", color="red"}, metadata={op_type="ag" op_name="model/layer/ag_0"}
+      allgather1 = f32[128] all-gather(param1), replica_groups={}, dimensions={0}, frontend_attributes={is_pipelinable="true", color="blue"}, metadata={op_type="ag" op_name="model/layer/ag_1"}
+      ROOT tuple = (f32[128], f32[128]) tuple(allgather0, allgather1)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  AllGatherCombiner combine(1024 * 1024, kMaxCombineCount,
+                            /*combine_by_dim=*/true);
+  ASSERT_EQ(AllGatherCount(*module), 2);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, combine.Run(module.get()));
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(AllGatherCount(*module), 1);
+
+  const HloInstruction* combined_ag = FindAllGathers(*module)[0];
+
+  // Frontend attributes: shared key with same value preserved as-is,
+  // conflicting values sorted and comma-joined.
+  ASSERT_TRUE(combined_ag->has_frontend_attributes());
+  const auto& attrs = combined_ag->frontend_attributes().map();
+  EXPECT_EQ(attrs.at("is_pipelinable"), "true");
+  EXPECT_EQ(attrs.at("color"), "blue,red");
+
+  // Metadata: common prefix "model/layer/" extracted, suffixes joined.
+  const OpMetadata& md = combined_ag->metadata();
+  EXPECT_EQ(md.op_type(), "ag");
+  EXPECT_EQ(md.op_name(), "model/layer/(ag_0:ag_1)");
 }
 
 }  // namespace

--- a/xla/hlo/transforms/collectives/all_reduce_combiner.cc
+++ b/xla/hlo/transforms/collectives/all_reduce_combiner.cc
@@ -51,7 +51,9 @@ namespace {
 // Combines the elements of to_combine into a single AllReduce op. All
 // entries in to_combine must be AllReduce ops with exactly one operand
 // and the same reduction operation.
-absl::Status CombineAllReduces(absl::Span<HloInstruction* const> to_combine) {
+absl::Status CombineAllReduces(
+    absl::Span<HloInstruction* const> to_combine,
+    const AllReduceCombiner::PostCombineFn& post_combine = nullptr) {
   if (to_combine.size() < 2) {
     return absl::OkStatus();
   }
@@ -90,7 +92,11 @@ absl::Status CombineAllReduces(absl::Span<HloInstruction* const> to_combine) {
           /*constrain_layout=*/false, to_combine.front()->channel_id(),
           Cast<HloAllReduceInstruction>(to_combine.front())
               ->use_global_device_ids()));
-  combined->set_metadata(to_combine.front()->metadata());
+  combined->set_metadata(MergeMetadata(to_combine));
+  combined->set_frontend_attributes(MergeFrontendAttributes(to_combine));
+  if (post_combine != nullptr) {
+    TF_RETURN_IF_ERROR(post_combine(to_combine, combined));
+  }
 
   // We have to propagate the sharding manually because Domain instructions are
   // not guaranteed to preserve it for side effecting instructions.
@@ -131,6 +137,16 @@ absl::StatusOr<bool> AllReduceCombiner::RunWithKeyCombiner(
     absl::FunctionRef<std::optional<AllReduceCombiner::GroupKey>(
         const HloInstruction*, const HloDomainMap&)>
         combine_key) {
+  return RunWithKeyCombiner(module, execution_threads, combine_key, nullptr);
+}
+
+absl::StatusOr<bool> AllReduceCombiner::RunWithKeyCombiner(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads,
+    absl::FunctionRef<std::optional<AllReduceCombiner::GroupKey>(
+        const HloInstruction*, const HloDomainMap&)>
+        combine_key,
+    PostCombineFn post_combine) {
   VLOG(1) << "Running AllReduceCombiner with threshold of "
           << combine_threshold_in_bytes_ << " bytes";
 
@@ -161,7 +177,10 @@ absl::StatusOr<bool> AllReduceCombiner::RunWithKeyCombiner(
     TF_ASSIGN_OR_RETURN(
         bool computation_changed,
         CombineInstructionsByKey<AllReduceCombiner::GroupKey>(
-            computation, key_fn, &CombineAllReduces,
+            computation, key_fn,
+            [&](absl::Span<HloInstruction* const> to_combine) -> absl::Status {
+              return CombineAllReduces(to_combine, post_combine);
+            },
             combine_threshold_in_bytes_, combine_threshold_count_));
     changed |= computation_changed;
   }

--- a/xla/hlo/transforms/collectives/all_reduce_combiner.h
+++ b/xla/hlo/transforms/collectives/all_reduce_combiner.h
@@ -17,14 +17,17 @@ limitations under the License.
 #define XLA_HLO_TRANSFORMS_COLLECTIVES_ALL_REDUCE_COMBINER_H_
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <tuple>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/pass/hlo_pass_interface.h"
@@ -54,6 +57,9 @@ class AllReduceCombiner : public HloModulePass {
   static std::optional<AllReduceCombiner::GroupKey> CombineKey(
       const HloInstruction* instruction, const HloDomainMap& domain_map);
 
+  using PostCombineFn = std::function<absl::Status(
+      absl::Span<HloInstruction* const>, HloInstruction*)>;
+
  protected:
   absl::StatusOr<bool> RunWithKeyCombiner(
       HloModule* module,
@@ -61,6 +67,14 @@ class AllReduceCombiner : public HloModulePass {
       absl::FunctionRef<std::optional<AllReduceCombiner::GroupKey>(
           const HloInstruction*, const HloDomainMap&)>
           combine_key);
+
+  absl::StatusOr<bool> RunWithKeyCombiner(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads,
+      absl::FunctionRef<std::optional<AllReduceCombiner::GroupKey>(
+          const HloInstruction*, const HloDomainMap&)>
+          combine_key,
+      PostCombineFn post_combine);
 
   absl::StatusOr<bool> RunImpl(
       HloModule* module,

--- a/xla/hlo/transforms/collectives/all_reduce_combiner_test.cc
+++ b/xla/hlo/transforms/collectives/all_reduce_combiner_test.cc
@@ -535,7 +535,7 @@ TEST_F(AllReduceCombinerTest, PreservesMetadata) {
   EXPECT_THAT(combine.Run(module.get()), absl_testing::IsOkAndHolds(true));
   OpMetadata metadata;
   metadata.set_op_type("test_type0");
-  metadata.set_op_name("test_name0");
+  metadata.set_op_name("(test_name0:test_name1)");
   auto combined_all_reduce = op::Metadata(metadata);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Tuple(op::GetTupleElement(combined_all_reduce, 0),

--- a/xla/hlo/transforms/collectives/collective_permute_combiner.cc
+++ b/xla/hlo/transforms/collectives/collective_permute_combiner.cc
@@ -127,6 +127,9 @@ absl::Status CombineCollectivePermutes(
             source_target_pairs, to_combine.front()->channel_id()));
   }
 
+  combined->set_metadata(MergeMetadata(to_combine));
+  combined->set_frontend_attributes(MergeFrontendAttributes(to_combine));
+
   // Replace all the smaller CollectivePermutes with either the combined
   // CollectivePermute or elements of the tuple output.
   for (int64_t i = 0; i < to_combine.size(); ++i) {

--- a/xla/hlo/transforms/collectives/collective_permute_combiner_test.cc
+++ b/xla/hlo/transforms/collectives/collective_permute_combiner_test.cc
@@ -535,5 +535,46 @@ ENTRY %Deduplicate () -> (f32[256], f32[256]) {
   EXPECT_TRUE(combined->shape().IsArray());
 }
 
+TEST_F(CollectivePermuteCombinerTest,
+       PreservesFrontendAttributesAndMergedMetadata) {
+  const char* const hlo_string = R"(
+HloModule CombineCollectivePermutes
+
+ENTRY %CombineCollectivePermutes () -> (f32[256], f32[512]) {
+  %constant = f64[] constant(42.3)
+  %broadcast = f32[256]{0} broadcast(f64[] %constant), dimensions={}
+  %collective-permute = f32[256]{0} collective-permute(f32[256]{0} %broadcast), source_target_pairs={{0,1},{1,0}}, channel_id=1, frontend_attributes={RESOURCE_TYPE="2",_scheduling_group="ring_attn_fwd_0"}, metadata={op_type="cp" op_name="model/ring/cp_0"}
+
+  %constant.1 = f64[] constant(42.3)
+  %broadcast.1 = f32[512]{0} broadcast(f64[] %constant.1), dimensions={}
+  %collective-permute.1 = f32[512]{0} collective-permute(f32[512]{0} %broadcast.1), source_target_pairs={{0,1},{1,0}}, channel_id=1, frontend_attributes={RESOURCE_TYPE="2",_scheduling_group="ring_attn_fwd_0"}, metadata={op_type="cp" op_name="model/ring/cp_1"}
+
+  ROOT %tuple = (f32[256]{0}, f32[512]{0}) tuple(%collective-permute, %collective-permute.1)
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  CollectivePermuteCombiner combine(1024 * 1024, kMaxCombineCount);
+  ASSERT_EQ(CollectivePermuteCount(*module), 2);
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, combine.Run(module.get()));
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(CollectivePermuteCount(*module), 1);
+
+  const HloInstruction* combined =
+      FindInstruction(module.get(), HloOpcode::kCollectivePermute);
+  ASSERT_NE(combined, nullptr);
+
+  // Frontend attributes: shared keys with same values preserved.
+  ASSERT_TRUE(combined->has_frontend_attributes());
+  const auto& attrs = combined->frontend_attributes().map();
+  EXPECT_EQ(attrs.at("RESOURCE_TYPE"), "2");
+  EXPECT_EQ(attrs.at("_scheduling_group"), "ring_attn_fwd_0");
+
+  // Metadata: common prefix "model/ring/" extracted, suffixes joined.
+  const OpMetadata& md = combined->metadata();
+  EXPECT_EQ(md.op_type(), "cp");
+  EXPECT_EQ(md.op_name(), "model/ring/(cp_0:cp_1)");
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -361,6 +361,7 @@ cc_library(
     hdrs = ["collective_permute_key.h"],
     deps = [
         ":hlo_domain_map",
+        "//xla:side_effect_util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "@com_google_absl//absl/algorithm:container",
@@ -2543,13 +2544,28 @@ cc_library(
         "//xla/hlo/analysis:hlo_reachability",
         "//xla/hlo/ir:hlo",
         "//xla/tsl/platform:errors",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "collective_combiner_utils_test",
+    srcs = ["collective_combiner_utils_test.cc"],
+    deps = [
+        ":collective_combiner_utils",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/parser:hlo_parser",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -6589,12 +6605,15 @@ cc_library(
         "//xla/hlo/analysis:hlo_reachability",
         "//xla/hlo/ir:hlo",
         "//xla/tsl/platform:errors",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/xla/service/collective_combiner_utils.cc
+++ b/xla/service/collective_combiner_utils.cc
@@ -20,12 +20,20 @@ limitations under the License.
 #include <cstdint>
 #include <iterator>
 #include <limits>
+#include <string>
 #include <vector>
 
+#include "absl/container/btree_map.h"
+#include "absl/container/btree_set.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/xla_data.pb.h"
 
 namespace xla {
 
@@ -48,6 +56,108 @@ int64_t FindMostFrequentGatherDim(
   int64_t most_frequent_dim = std::distance(
       frequency.begin(), std::max_element(frequency.begin(), frequency.end()));
   return most_frequent_dim < min_rank ? most_frequent_dim : 0;
+}
+
+FrontendAttributes MergeFrontendAttributes(
+    absl::Span<HloInstruction* const> to_combine) {
+  // Collect all unique values per key.
+  absl::btree_map<std::string, absl::btree_set<std::string>> key_to_values;
+  for (const HloInstruction* inst : to_combine) {
+    if (!inst->has_frontend_attributes()) continue;
+    for (const auto& [key, value] : inst->frontend_attributes().map()) {
+      key_to_values[key].insert(value);
+    }
+  }
+
+  // Build merged FrontendAttributes from the collected values.
+  FrontendAttributes merged;
+  for (const auto& [key, values] : key_to_values) {
+    (*merged.mutable_map())[key] = absl::StrJoin(values, ",");
+  }
+  return merged;
+}
+
+namespace {
+
+// Returns the longest common prefix of all strings, trimmed to the last '/'.
+std::string CommonPrefix(absl::Span<const std::string> names) {
+  if (names.empty()) return "";
+  absl::string_view prefix = names.front();
+  for (int64_t i = 1; i < names.size(); ++i) {
+    prefix = absl::FindLongestCommonPrefix(prefix, names[i]);
+  }
+  // Trim to last '/' boundary so we don't split in the middle of a name.
+  auto pos = prefix.rfind('/');
+  if (pos != absl::string_view::npos) {
+    return std::string(prefix.substr(0, pos + 1));
+  }
+  return "";
+}
+
+// Formats op_names as "common_prefix/(suffix1:suffix2:suffix3)".
+// If all names are identical, returns the name as-is.
+std::string MergeOpNames(absl::Span<const std::string> names) {
+  if (names.empty()) return "";
+  if (names.size() == 1) return names.front();
+
+  std::string prefix = CommonPrefix(names);
+  std::vector<std::string> suffixes;
+  suffixes.reserve(names.size());
+  for (const auto& name : names) {
+    suffixes.push_back(name.substr(prefix.size()));
+  }
+
+  // If all suffixes are the same (all names identical), return as-is.
+  bool all_same = true;
+  for (int64_t i = 1; i < suffixes.size(); ++i) {
+    if (suffixes[i] != suffixes[0]) {
+      all_same = false;
+      break;
+    }
+  }
+  if (all_same) return names.front();
+
+  return absl::StrCat(prefix, "(", absl::StrJoin(suffixes, ":"), ")");
+}
+
+}  // namespace
+
+OpMetadata MergeMetadata(absl::Span<HloInstruction* const> to_combine) {
+  if (to_combine.empty()) return OpMetadata();
+
+  // Start from the first instruction's metadata as base.
+  OpMetadata merged = to_combine.front()->metadata();
+
+  if (to_combine.size() == 1) return merged;
+
+  // Collect source file:line pairs and op_names.
+  std::vector<std::string> source_locations;
+  std::vector<std::string> op_names;
+  for (const HloInstruction* inst : to_combine) {
+    const OpMetadata& md = inst->metadata();
+    if (!md.source_file().empty()) {
+      source_locations.push_back(
+          absl::StrCat(md.source_file(), ":", md.source_line()));
+    }
+    if (!md.op_name().empty()) {
+      op_names.push_back(md.op_name());
+    }
+  }
+
+  // Concatenate source locations.
+  if (!source_locations.empty()) {
+    merged.set_source_file(absl::StrJoin(source_locations, ","));
+    // Clear line numbers since they're embedded in the concatenated string.
+    merged.set_source_line(0);
+    merged.set_source_end_line(0);
+  }
+
+  // Merge op_names with common prefix extraction.
+  if (!op_names.empty()) {
+    merged.set_op_name(MergeOpNames(op_names));
+  }
+
+  return merged;
 }
 
 }  // namespace xla

--- a/xla/service/collective_combiner_utils.h
+++ b/xla/service/collective_combiner_utils.h
@@ -42,6 +42,17 @@ namespace xla {
 // for all shapes involved, else returns 0.
 int64_t FindMostFrequentGatherDim(absl::Span<HloInstruction* const> to_combine);
 
+// Merges frontend_attributes from all instructions, deduplicating keys.
+// When two instructions have the same key with different values, the values
+// are joined with a comma.
+FrontendAttributes MergeFrontendAttributes(
+    absl::Span<HloInstruction* const> to_combine);
+
+// Merges metadata from all instructions. Uses the first instruction's metadata
+// as a base, then extends source_line/source_end_line to cover all instructions
+// from the same source file, and joins distinct op_names with commas.
+OpMetadata MergeMetadata(absl::Span<HloInstruction* const> to_combine);
+
 // Combines instructions with matching keys together.
 //
 // Instructions are combined in topological post-order.

--- a/xla/service/collective_combiner_utils_test.cc
+++ b/xla/service/collective_combiner_utils_test.cc
@@ -1,0 +1,260 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/collective_combiner_utils.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/parser/hlo_parser.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace {
+
+std::unique_ptr<HloModule> CreateModule(const std::string& hlo_string) {
+  auto module_or_status = ParseAndReturnUnverifiedModule(hlo_string);
+  if (!module_or_status.ok()) {
+    return nullptr;
+  }
+  return std::move(module_or_status.value());
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeFrontendAttributesEmpty) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      ROOT result = f32[8,32] copy(p0)
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* copy =
+      module->entry_computation()->GetInstructionWithName("result");
+  std::vector<HloInstruction*> instructions = {copy};
+
+  FrontendAttributes result = MergeFrontendAttributes(instructions);
+  EXPECT_TRUE(result.map().empty());
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeFrontendAttributesSingleInstruction) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      ROOT ag0 = f32[8,32] all-gather(p0), dimensions={0},
+            replica_groups={}, frontend_attributes={foo="bar"}
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* ag0 =
+      module->entry_computation()->GetInstructionWithName("ag0");
+  std::vector<HloInstruction*> instructions = {ag0};
+
+  FrontendAttributes result = MergeFrontendAttributes(instructions);
+  EXPECT_EQ(result.map().at("foo"), "bar");
+}
+
+TEST(CollectiveCombinerUtilsTest,
+     MergeFrontendAttributesDeduplicatesSharedKeys) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      p1 = f32[4,64] parameter(1)
+      ag0 = f32[8,32] all-gather(p0), dimensions={0},
+            replica_groups={}, frontend_attributes={key1="value1", key2="a"}
+      ag1 = f32[4,64] all-gather(p1), dimensions={1},
+            replica_groups={}, frontend_attributes={key1="value1", key2="b"}
+      ROOT result = (f32[8,32], f32[4,64]) tuple(ag0, ag1)
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* ag0 =
+      module->entry_computation()->GetInstructionWithName("ag0");
+  HloInstruction* ag1 =
+      module->entry_computation()->GetInstructionWithName("ag1");
+  std::vector<HloInstruction*> instructions = {ag0, ag1};
+
+  FrontendAttributes result = MergeFrontendAttributes(instructions);
+
+  // key1 has the same value in both → appears once.
+  EXPECT_EQ(result.map().at("key1"), "value1");
+
+  // key2 has different values → sorted and comma-joined (btree_set order).
+  EXPECT_EQ(result.map().at("key2"), "a,b");
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeFrontendAttributesSortedValues) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      p1 = f32[4,64] parameter(1)
+      p2 = f32[16,16] parameter(2)
+      ag0 = f32[8,32] all-gather(p0), dimensions={0},
+            replica_groups={}, frontend_attributes={key="zebra"}
+      ag1 = f32[4,64] all-gather(p1), dimensions={1},
+            replica_groups={}, frontend_attributes={key="apple"}
+      ag2 = f32[16,16] all-gather(p2), dimensions={1},
+            replica_groups={}, frontend_attributes={key="mango"}
+      ROOT result = (f32[8,32], f32[4,64], f32[16,16]) tuple(ag0, ag1, ag2)
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* ag0 =
+      module->entry_computation()->GetInstructionWithName("ag0");
+  HloInstruction* ag1 =
+      module->entry_computation()->GetInstructionWithName("ag1");
+  HloInstruction* ag2 =
+      module->entry_computation()->GetInstructionWithName("ag2");
+  std::vector<HloInstruction*> instructions = {ag0, ag1, ag2};
+
+  FrontendAttributes result = MergeFrontendAttributes(instructions);
+
+  // Values are sorted by btree_set.
+  EXPECT_EQ(result.map().at("key"), "apple,mango,zebra");
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeMetadataEmpty) {
+  std::vector<HloInstruction*> instructions;
+  OpMetadata result = MergeMetadata(instructions);
+  EXPECT_TRUE(result.source_file().empty());
+  EXPECT_TRUE(result.op_name().empty());
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeMetadataSingleInstruction) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      ROOT ag0 = f32[8,32] all-gather(p0), dimensions={0}, replica_groups={},
+            metadata={op_name="test_op" source_file="test.py" source_line=42}
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* ag0 =
+      module->entry_computation()->GetInstructionWithName("ag0");
+  std::vector<HloInstruction*> instructions = {ag0};
+
+  OpMetadata result = MergeMetadata(instructions);
+  EXPECT_EQ(result.op_name(), "test_op");
+  EXPECT_EQ(result.source_file(), "test.py");
+  EXPECT_EQ(result.source_line(), 42);
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeMetadataMultipleInstructions) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      p1 = f32[4,64] parameter(1)
+      ag0 = f32[8,32] all-gather(p0), dimensions={0}, replica_groups={},
+            metadata={op_name="op0" source_file="test.py" source_line=42}
+      ag1 = f32[4,64] all-gather(p1), dimensions={1}, replica_groups={},
+            metadata={op_name="op1" source_file="test.py" source_line=50}
+      ROOT result = (f32[8,32], f32[4,64]) tuple(ag0, ag1)
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* ag0 =
+      module->entry_computation()->GetInstructionWithName("ag0");
+  HloInstruction* ag1 =
+      module->entry_computation()->GetInstructionWithName("ag1");
+  std::vector<HloInstruction*> instructions = {ag0, ag1};
+
+  OpMetadata result = MergeMetadata(instructions);
+
+  // Source locations concatenated as file:line pairs.
+  EXPECT_EQ(result.source_file(), "test.py:42,test.py:50");
+  EXPECT_EQ(result.source_line(), 0);
+  EXPECT_EQ(result.source_end_line(), 0);
+
+  // No common '/' prefix → "(op0:op1)".
+  EXPECT_EQ(result.op_name(), "(op0:op1)");
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeMetadataIdenticalOpNames) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      p1 = f32[4,64] parameter(1)
+      ag0 = f32[8,32] all-gather(p0), dimensions={0}, replica_groups={},
+            metadata={op_name="identical_op" source_file="test.py" source_line=42}
+      ag1 = f32[4,64] all-gather(p1), dimensions={1}, replica_groups={},
+            metadata={op_name="identical_op" source_file="test.py" source_line=50}
+      ROOT result = (f32[8,32], f32[4,64]) tuple(ag0, ag1)
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* ag0 =
+      module->entry_computation()->GetInstructionWithName("ag0");
+  HloInstruction* ag1 =
+      module->entry_computation()->GetInstructionWithName("ag1");
+  std::vector<HloInstruction*> instructions = {ag0, ag1};
+
+  OpMetadata result = MergeMetadata(instructions);
+
+  // All names identical → returned as-is.
+  EXPECT_EQ(result.op_name(), "identical_op");
+}
+
+TEST(CollectiveCombinerUtilsTest, MergeMetadataCommonPrefixExtraction) {
+  auto module = CreateModule(R"(
+    HloModule test_module
+    ENTRY main {
+      p0 = f32[8,32] parameter(0)
+      p1 = f32[4,64] parameter(1)
+      p2 = f32[16,16] parameter(2)
+      ag0 = f32[8,32] all-gather(p0), dimensions={0}, replica_groups={},
+            metadata={op_name="module/layer/op_0" source_file="test.py" source_line=42}
+      ag1 = f32[4,64] all-gather(p1), dimensions={1}, replica_groups={},
+            metadata={op_name="module/layer/op_1" source_file="test.py" source_line=50}
+      ag2 = f32[16,16] all-gather(p2), dimensions={1}, replica_groups={},
+            metadata={op_name="module/layer/op_2" source_file="test.py" source_line=60}
+      ROOT result = (f32[8,32], f32[4,64], f32[16,16]) tuple(ag0, ag1, ag2)
+    }
+  )");
+  ASSERT_NE(module, nullptr);
+
+  HloInstruction* ag0 =
+      module->entry_computation()->GetInstructionWithName("ag0");
+  HloInstruction* ag1 =
+      module->entry_computation()->GetInstructionWithName("ag1");
+  HloInstruction* ag2 =
+      module->entry_computation()->GetInstructionWithName("ag2");
+  std::vector<HloInstruction*> instructions = {ag0, ag1, ag2};
+
+  OpMetadata result = MergeMetadata(instructions);
+
+  // Common prefix "module/layer/" extracted, suffixes joined with ':'.
+  EXPECT_EQ(result.op_name(), "module/layer/(op_0:op_1:op_2)");
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/service/collective_permute_key.cc
+++ b/xla/service/collective_permute_key.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/side_effect_util.h"
 #include "xla/xla_data.pb.h"
 
 namespace xla {
@@ -48,7 +49,18 @@ std::optional<CollectivePermuteKey> GetCollectivePermuteKey(
     // Canonicalize the source-target pairs so that the order does not matter.
     absl::c_sort(source_target_pairs);
   }
-  return CollectivePermuteKey{source_target_pairs};
+
+  // Include the combiner_key frontend attribute in the key so that
+  // collective-permutes with different keys are not combined.
+  std::string combiner_key;
+  if (instruction->has_frontend_attributes()) {
+    auto it = instruction->frontend_attributes().map().find(kCombinerKeyAttr);
+    if (it != instruction->frontend_attributes().map().end()) {
+      combiner_key = it->second;
+    }
+  }
+
+  return CollectivePermuteKey{source_target_pairs, combiner_key};
 }
 
 }  // namespace xla

--- a/xla/service/collective_permute_key.h
+++ b/xla/service/collective_permute_key.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -32,8 +33,11 @@ namespace xla {
 // Encapsulates all of the properties which must match for two
 // collective-permute instructions to be compatible with each other (and hence
 // be possible to combine the instructions).
+// The combiner_key field (from frontend_attributes) ensures that
+// collective-permutes with different keys are not combined.A
 using CollectivePermuteKey = std::tuple<
-    /*source_target_pairs*/ std::vector<std::pair<int64_t, int64_t>>>;
+    /*source_target_pairs=*/std::vector<std::pair<int64_t, int64_t>>,
+    /*combiner_key=*/std::string>;
 
 std::optional<CollectivePermuteKey> GetCollectivePermuteKey(
     const HloInstruction* instruction);

--- a/xla/service/reduce_scatter_combiner.cc
+++ b/xla/service/reduce_scatter_combiner.cc
@@ -80,7 +80,8 @@ int64_t FindMostFrequentScatterDim(
 // entries in to_combine must be ReduceScatter ops with exactly one operand
 // and the same reduction operation.
 absl::Status CombineReduceScatters(
-    absl::Span<HloInstruction* const> to_combine) {
+    absl::Span<HloInstruction* const> to_combine,
+    const ReduceScatterCombiner::PostCombineFn& post_combine = nullptr) {
   if (to_combine.size() < 2) {
     return absl::OkStatus();
   }
@@ -148,7 +149,11 @@ absl::Status CombineReduceScatters(
           Cast<HloReduceScatterInstruction>(to_combine.front())
               ->use_global_device_ids(),
           most_frequent_dim));
-  combined->set_metadata(to_combine.front()->metadata());
+  combined->set_metadata(MergeMetadata(to_combine));
+  combined->set_frontend_attributes(MergeFrontendAttributes(to_combine));
+  if (post_combine != nullptr) {
+    TF_RETURN_IF_ERROR(post_combine(to_combine, combined));
+  }
 
   // We have to propagate the sharding manually because Domain instructions are
   // not guaranteed to preserve it for side effecting instructions.
@@ -205,6 +210,16 @@ absl::StatusOr<bool> ReduceScatterCombiner::RunWithKeyCombiner(
     absl::FunctionRef<std::optional<ReduceScatterCombiner::GroupKey>(
         const HloInstruction*, const HloDomainMap&, bool)>
         combine_key) {
+  return RunWithKeyCombiner(module, execution_threads, combine_key, nullptr);
+}
+
+absl::StatusOr<bool> ReduceScatterCombiner::RunWithKeyCombiner(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads,
+    absl::FunctionRef<std::optional<ReduceScatterCombiner::GroupKey>(
+        const HloInstruction*, const HloDomainMap&, bool)>
+        combine_key,
+    PostCombineFn post_combine) {
   VLOG(1) << "Running ReduceScatterCombiner with threshold of "
           << combine_threshold_in_bytes_ << " bytes";
 
@@ -235,12 +250,16 @@ absl::StatusOr<bool> ReduceScatterCombiner::RunWithKeyCombiner(
     auto key_fn = [&](const HloInstruction* instruction) {
       return combine_key(instruction, *domain_map, combine_by_dim_);
     };
+    auto combine_fn =
+        [&](absl::Span<HloInstruction* const> to_combine) -> absl::Status {
+      return CombineReduceScatters(to_combine, post_combine);
+    };
 
     TF_ASSIGN_OR_RETURN(
         bool computation_changed,
         CombineInstructionsByKey<ReduceScatterCombiner::GroupKey>(
-            computation, key_fn, &CombineReduceScatters,
-            combine_threshold_in_bytes_, combine_threshold_count_));
+            computation, key_fn, combine_fn, combine_threshold_in_bytes_,
+            combine_threshold_count_));
     changed |= computation_changed;
   }
 

--- a/xla/service/reduce_scatter_combiner.h
+++ b/xla/service/reduce_scatter_combiner.h
@@ -17,14 +17,17 @@ limitations under the License.
 #define XLA_SERVICE_REDUCE_SCATTER_COMBINER_H_
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <tuple>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/pass/hlo_pass_interface.h"
@@ -57,6 +60,9 @@ class ReduceScatterCombiner : public HloModulePass {
       const HloInstruction* instruction, const HloDomainMap& domain_map,
       bool combine_by_dim);
 
+  using PostCombineFn = std::function<absl::Status(
+      absl::Span<HloInstruction* const>, HloInstruction*)>;
+
  protected:
   absl::StatusOr<bool> RunWithKeyCombiner(
       HloModule* module,
@@ -64,6 +70,14 @@ class ReduceScatterCombiner : public HloModulePass {
       absl::FunctionRef<std::optional<ReduceScatterCombiner::GroupKey>(
           const HloInstruction*, const HloDomainMap&, bool)>
           combine_key);
+
+  absl::StatusOr<bool> RunWithKeyCombiner(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads,
+      absl::FunctionRef<std::optional<ReduceScatterCombiner::GroupKey>(
+          const HloInstruction*, const HloDomainMap&, bool)>
+          combine_key,
+      PostCombineFn post_combine);
 
   absl::StatusOr<bool> RunImpl(
       HloModule* module,

--- a/xla/service/reduce_scatter_combiner_test.cc
+++ b/xla/service/reduce_scatter_combiner_test.cc
@@ -375,7 +375,7 @@ TEST_F(ReduceScatterCombinerTest, PreservesMetadata) {
                           RunPass(hlo_string, /*expect_change=*/true));
   OpMetadata metadata;
   metadata.set_op_type("test_type0");
-  metadata.set_op_name("test_name0");
+  metadata.set_op_name("(test_name0:test_name1)");
   auto combined_reduce_scatter = op::Metadata(metadata);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
               op::Tuple(op::GetTupleElement(combined_reduce_scatter, 0),

--- a/xla/side_effect_util.cc
+++ b/xla/side_effect_util.cc
@@ -98,4 +98,7 @@ const char kNumHyperparameters[] = "_num_hyperparameters";
 const char kLogTag[] = "_xla_log_tag";
 
 const char kXlaTableNameAttr[] = "_xla_table_name";
+
+const char kCombinerKeyAttr[] = "combiner_key";
+
 }  // namespace xla

--- a/xla/side_effect_util.h
+++ b/xla/side_effect_util.h
@@ -121,6 +121,11 @@ extern const char kLogTag[];
 
 // XLA frontend attribute for specifying the table name for SparseDenseMatmulOp.
 extern const char kXlaTableNameAttr[];
+
+// Frontend attribute key used to control which collectives can be combined.
+// Collectives with different combiner_key values will not be combined together.
+extern const char kCombinerKeyAttr[];
+
 }  // namespace xla
 
 #endif  // XLA_SIDE_EFFECT_UTIL_H_


### PR DESCRIPTION
- Add merging of `frontend_attributes`, `metadata`, and `backend_config` when combining collective operations (all-gather, all-reduce, reduce-scatter, collective-permute)
- Support `combiner_key` frontend attribute to control which collectives can be combined together
- Wire `MergeCollectiveBackendConfig` into all GPU-level collective combiners via `post_combine` callbacks


This fixes a major problem with collective combiners that drop metadata from profiles and makes it impossible to attribute collectives from xprof back to original JAX program.