### PR TITLE
Cross Host Data Transfers: Refactor ScheduleSendsOnLocalDevice into ScheduleTransfersOnLocalDevice

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -714,167 +714,187 @@ StreamExecutorGpuClient::CrossHostSendBuffers(
 
   // Schedule sends.
   for (auto& [device, send_idxs] : sends_by_device) {
+    GlobalDeviceId src_global_device_id = device->global_device_id();
+
     // Create a transfer event for transfers on this device.
     tsl::AsyncValueRef<BufferSequencingEvent> transfer_event =
         BufferSequencingEvent::Create(this->async_work_runner());
 
-    std::vector<tsl::RCReference<PjRtRawBuffer>> curr_raw_buffers;
-    curr_raw_buffers.reserve(send_idxs.size());
+    // Extract transfer dependencies, form transfer specs, and fulfill
+    // usage_event_promises.
     std::vector<tsl::RCReference<tsl::AsyncValue>> curr_transfer_dependency_avs;
-    std::vector<GlobalDeviceId> curr_dst_ids;
-    curr_dst_ids.reserve(send_idxs.size());
+    std::vector<CrossHostTransferSpec> transfer_specs;
+    transfer_specs.reserve(send_idxs.size());
 
     for (int idx : send_idxs) {
-      curr_raw_buffers.push_back(std::move(raw_buffers[idx]));
       for (tsl::RCReference<tsl::AsyncValue>& event :
            transfer_dependency_avs[idx]) {
         curr_transfer_dependency_avs.push_back(std::move(event));
       }
-      curr_dst_ids.push_back(dst_global_device_ids[idx]);
+      transfer_specs.push_back(CrossHostTransferSpec{
+          src_global_device_id, dst_global_device_ids[idx],
+          std::move(raw_buffers[idx])});
 
       usage_event_promises[idx]->Set(PjRtDeviceEventRef(transfer_event));
     }
 
-    ScheduleSendsOnLocalDevice(
-        device, std::move(transfer_event), std::move(curr_raw_buffers),
-        std::move(curr_transfer_dependency_avs), std::move(curr_dst_ids));
+    // Get the local_device_state and use it to schedule transfers. Fail
+    // transfers early if we cannot get the local_device_state.
+    absl::StatusOr<LocalDeviceState*> local_device_state =
+        tensorflow::down_cast<PjRtStreamExecutorDevice*>(device)
+            ->GetLocalDeviceState();
+    if (!local_device_state.ok()) {
+      SetEventAsError(transfer_event, local_device_state.status());
+      continue;
+    }
+
+    ScheduleTransfersOnLocalDevice(
+        *local_device_state, src_global_device_id, std::move(transfer_event),
+        std::move(curr_transfer_dependency_avs), std::move(transfer_specs));
   }
 
   return futures;
 }
 
-void StreamExecutorGpuClient::ScheduleSendsOnLocalDevice(
-    PjRtDevice* device,
+void StreamExecutorGpuClient::ScheduleTransfersOnLocalDevice(
+    LocalDeviceState* local_device_state, GlobalDeviceId device_id,
     tsl::AsyncValueRef<BufferSequencingEvent> transfer_event,
-    std::vector<tsl::RCReference<PjRtRawBuffer>> raw_buffers,
     std::vector<tsl::RCReference<tsl::AsyncValue>> transfer_dependency_avs,
-    std::vector<GlobalDeviceId> dst_global_device_ids) {
-  // Get the local device state, transfer stream, and prepare the send
-  // buffers. We associate the group of sends with a single usage_event.
-  LocalDeviceState* local_device_state;
-  se::Stream* stream;
-  std::vector<PreparedTransfer> prepared_sends;
-  prepared_sends.reserve(raw_buffers.size());
-
+    std::vector<CrossHostTransferSpec> transfer_specs) {
   tsl::profiler::TraceMe trace([&] {
     return tsl::profiler::TraceMeEncode(
         absl::StrFormat(
-            "[%v] StreamExecutorGpuClient::ScheduleSendsOnLocalDevice",
-            device->local_device_id()),
-        {{"num_buffers", raw_buffers.size()}});
+            "[%v] StreamExecutorGpuClient::ScheduleTransfersOnLocalDevice",
+            local_device_state->local_device_id()),
+        {{"num_buffers", transfer_specs.size()}});
   });
 
-  auto setup_sends = [&]() -> absl::Status {
-    TF_ASSIGN_OR_RETURN(local_device_state, GetLocalDeviceState(device));
-    stream = local_device_state->GetDeviceToDeviceStream();
+  se::Stream* stream = local_device_state->GetDeviceToDeviceStream();
+  std::vector<PreparedTransfer> prepared_transfers;
+  prepared_transfers.reserve(transfer_specs.size());
+
+  auto prepare_transfers = [&]() -> absl::Status {
     gpu::GpuCollectives* gpu_collectives =
         gpu::GpuCollectives::Default(stream->parent()->GetPlatform()->Name());
 
     gpu::AcquiredCliquesMap acquired_cliques_map;
-    for (int i = 0; i < raw_buffers.size(); ++i) {
-      absl::StatusOr<PreparedTransfer> prepared_send =
+    for (int i = 0; i < transfer_specs.size(); ++i) {
+      bool is_sender = device_id == transfer_specs[i].src_global_device_id;
+      TF_ASSIGN_OR_RETURN(
+          PreparedTransfer prepared_transfer,
           PrepareTransfer(this, gpu_collectives, stream,
-                          device->global_device_id(), dst_global_device_ids[i],
-                          raw_buffers[i], acquired_cliques_map, transfer_event,
-                          /*is_sender=*/true);
+                          transfer_specs[i].src_global_device_id,
+                          transfer_specs[i].dst_global_device_id,
+                          std::move(transfer_specs[i].raw_buffer),
+                          acquired_cliques_map, transfer_event, is_sender));
 
-      if (!prepared_send.ok()) {
-        SetEventAsError(transfer_event, prepared_send.status());
-        return prepared_send.status();
-      }
-
-      prepared_sends.push_back(*std::move(prepared_send));
+      prepared_transfers.push_back(std::move(prepared_transfer));
     }
 
     return absl::OkStatus();
   };
 
-  if (absl::Status status = setup_sends(); !status.ok()) {
+  if (absl::Status status = prepare_transfers(); !status.ok()) {
+    FulfillDeviceEvent(this, local_device_state, stream, transfer_event,
+                       status);
     return;
   }
 
-  // Form the closure called for each group of sends.
-  auto launch_send_group = [](gpu::GpuCommunicator* gpu_communicator,
-                              absl::Span<PreparedTransfer> prepared_sends,
-                              se::Stream* stream) -> absl::Status {
-    for (PreparedTransfer& prepared_send : prepared_sends) {
-      // Launch the send.
+  // Form the closure called for each group of transfers.
+  auto launch_transfer_group =
+      [](gpu::GpuCommunicator* gpu_communicator,
+         absl::Span<PreparedTransfer> prepared_transfers,
+         se::Stream* stream) -> absl::Status {
+    for (PreparedTransfer& prepared_transfer : prepared_transfers) {
+      // Launch the transfer.
       auto mem = tensorflow::down_cast<PjRtStreamExecutorRawBuffer*>(
-                     prepared_send.raw_buffer_.get())
+                     prepared_transfer.raw_buffer_.get())
                      ->device_buffer();
-      TF_RETURN_IF_ERROR(gpu_communicator->LaunchSend(
-          /*send_buffer=*/mem->mem(),
-          /*dtype=*/U8,
-          /*count=*/mem->mem().size(),
-          /*peer=*/RankId(1),
-          /*executor=*/gpu::GpuCollectives::On(*stream)));
+      if (prepared_transfer.is_sender_) {
+        TF_RETURN_IF_ERROR(gpu_communicator->LaunchSend(
+            /*send_buffer=*/mem->mem(),
+            /*dtype=*/U8,
+            /*count=*/mem->mem().size(),
+            /*peer=*/RankId(1),
+            /*executor=*/gpu::GpuCollectives::On(*stream)));
+      } else {
+        TF_RETURN_IF_ERROR(gpu_communicator->LaunchRecv(
+            /*send_buffer=*/mem->mem(),
+            /*dtype=*/U8,
+            /*count=*/mem->mem().size(),
+            /*peer=*/RankId(0),
+            /*executor=*/gpu::GpuCollectives::On(*stream)));
+      }
     }
     return absl::OkStatus();
   };
 
   // Form the closure to schedule on the device's execute thread.
-  auto execute_sends_fn = [this, local_device_state, stream,
-                           transfer_dependency_avs =
-                               std::move(transfer_dependency_avs),
-                           prepared_sends = std::move(prepared_sends),
-                           launch_send_group = std::move(launch_send_group),
-                           transfer_event =
-                               std::move(transfer_event)]() mutable {
-    // Wait for transfer dependencies.
-    if (auto status =
-            WaitForAsyncValueRefsOnStream(transfer_dependency_avs, stream);
-        !status.ok()) {
-      FulfillDeviceEvent(this, local_device_state, stream, transfer_event,
-                         status);
-      return;
-    }
-
-    // Group transfers by GPU clique.
-    absl::flat_hash_map<gpu::GpuCliqueKey, std::vector<PreparedTransfer>>
-        grouped_sends = GroupTransfersByCliqueKey(std::move(prepared_sends));
-
-    // Transfers for a particular clique are executed as a group. This
-    // vector holds group futures for each clique_key in grouped_sends.
-    std::vector<Future<>> group_futures;
-    group_futures.reserve(grouped_sends.size());
-
-    for (auto& [clique_key, curr_sends] : grouped_sends) {
-      tsl::profiler::TraceMe trace([&k = clique_key] {
-        return tsl::profiler::TraceMeEncode("LaunchSend", {{"clique", k}});
-      });
-
-      // Get the communicator on which we will execute this group of
-      // transfers. We assume each clique key is associated with a unique
-      // communicator, so we just take the communicator of the first
-      // transfer_idx of this clique key.
-      gpu::GpuCommunicator* gpu_communicator =
-          curr_sends[0].clique_and_communicator_.second;
-
-      // Launch the group of transfers.
-      group_futures.push_back(gpu_communicator->GroupExecute(
-          [&launch_send_group, &curr_sends = curr_sends,
-           stream](gpu::GpuCommunicator* gpu_comm) -> absl::Status {
-            return launch_send_group(gpu_comm, absl::MakeSpan(curr_sends),
-                                     stream);
-          }));
-    }
-
-    // On a separate thread pool, await group futures and fulfill buffer
-    // sequencing events and promises.
-    Future<> all_sends_future = JoinFutures(group_futures);
-
-    all_sends_future.OnReady(
-        *async_work_runner(), [this, local_device_state, stream, transfer_event,
-                               grouped_sends = std::move(grouped_sends)](
-                                  const absl::Status& status) mutable {
-          // Add transfer_event onto the stream.
+  auto execute_transfers_fn =
+      [this, local_device_state, stream,
+       transfer_dependency_avs = std::move(transfer_dependency_avs),
+       prepared_transfers = std::move(prepared_transfers),
+       launch_transfer_group = std::move(launch_transfer_group),
+       transfer_event = std::move(transfer_event)]() mutable {
+        // Wait for transfer dependencies.
+        if (auto status =
+                WaitForAsyncValueRefsOnStream(transfer_dependency_avs, stream);
+            !status.ok()) {
           FulfillDeviceEvent(this, local_device_state, stream, transfer_event,
                              status);
-        });
-  };
+          return;
+        }
+
+        // Group transfers by GPU clique.
+        absl::flat_hash_map<gpu::GpuCliqueKey, std::vector<PreparedTransfer>>
+            grouped_transfers =
+                GroupTransfersByCliqueKey(std::move(prepared_transfers));
+
+        // Transfers for a particular clique are executed as a group. This
+        // vector holds group futures for each clique_key in grouped_sends.
+        std::vector<Future<>> group_futures;
+        group_futures.reserve(grouped_transfers.size());
+
+        for (auto& [clique_key, curr_transfers] : grouped_transfers) {
+          tsl::profiler::TraceMe trace([&k = clique_key] {
+            return tsl::profiler::TraceMeEncode("LaunchTransfer",
+                                                {{"clique", k}});
+          });
+
+          // Get the communicator on which we will execute this group of
+          // transfers. We assume each clique key is associated with a unique
+          // communicator, so we just take the communicator of the first
+          // transfer_idx of this clique key.
+          gpu::GpuCommunicator* gpu_communicator =
+              curr_transfers[0].clique_and_communicator_.second;
+
+          // Launch the group of transfers.
+          group_futures.push_back(gpu_communicator->GroupExecute(
+              [&launch_transfer_group, &curr_transfers = curr_transfers,
+               stream](gpu::GpuCommunicator* gpu_comm) -> absl::Status {
+                return launch_transfer_group(
+                    gpu_comm, absl::MakeSpan(curr_transfers), stream);
+              }));
+        }
+
+        // On a separate thread pool, await group futures and fulfill buffer
+        // sequencing events and promises.
+        Future<> all_transfers_future = JoinFutures(group_futures);
+
+        all_transfers_future.OnReady(
+            *async_work_runner(),
+            [this, local_device_state, stream, transfer_event,
+             grouped_transfers = std::move(grouped_transfers)](
+                const absl::Status& status) mutable {
+              // Add transfer_event onto the stream.
+              FulfillDeviceEvent(this, local_device_state, stream,
+                                 transfer_event, status);
+            });
+      };
 
   // Schedule transfers on the execute thread.
-  local_device_state->execute_thread()->Schedule(std::move(execute_sends_fn));
+  local_device_state->execute_thread()->Schedule(
+      std::move(execute_transfers_fn));
 }
 
 // Prepare a receive buffer on a given device for receiving data as part of a

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -545,7 +545,7 @@ absl::StatusOr<PreparedTransfer> PrepareTransfer(
   // Form the GPU clique key.
   // TODO(asrao, mwhittaker): Supply correct incarnations when creating the
   // clique key.
-  gpu::GpuCliqueKey clique_key = gpu::GpuCliqueKey(
+  const gpu::GpuCliqueKey clique_key = gpu::GpuCliqueKey(
       /*devices=*/{src_device, dst_device},
       /*num_local_participants=*/1);
 
@@ -693,7 +693,7 @@ StreamExecutorGpuClient::CrossHostSendBuffers(
                 [&](tsl::RCReference<CommonPjRtRawBuffer> buf_raw_buffer,
                     std::vector<tsl::RCReference<tsl::AsyncValue>>
                         buf_definition_events) mutable
-                    -> absl::StatusOr<PjRtDeviceEventRef> {
+                -> absl::StatusOr<PjRtDeviceEventRef> {
                   // Keep raw_buffer alive until the usage_event completes,
                   // preventing the allocation from being freed while the
                   // send is in-flight.
@@ -713,8 +713,8 @@ StreamExecutorGpuClient::CrossHostSendBuffers(
   }
 
   // Schedule sends.
-  for (auto& [device, send_idxs] : sends_by_device) {
-    GlobalDeviceId src_global_device_id = device->global_device_id();
+  for (const auto& [device, send_idxs] : sends_by_device) {
+    const GlobalDeviceId src_global_device_id = device->global_device_id();
 
     // Create a transfer event for transfers on this device.
     tsl::AsyncValueRef<BufferSequencingEvent> transfer_event =
@@ -779,7 +779,8 @@ void StreamExecutorGpuClient::ScheduleTransfersOnLocalDevice(
 
     gpu::AcquiredCliquesMap acquired_cliques_map;
     for (int i = 0; i < transfer_specs.size(); ++i) {
-      bool is_sender = device_id == transfer_specs[i].src_global_device_id;
+      const bool is_sender =
+          device_id == transfer_specs[i].src_global_device_id;
       TF_ASSIGN_OR_RETURN(
           PreparedTransfer prepared_transfer,
           PrepareTransfer(this, gpu_collectives, stream,
@@ -810,6 +811,11 @@ void StreamExecutorGpuClient::ScheduleTransfersOnLocalDevice(
       auto mem = tensorflow::down_cast<PjRtStreamExecutorRawBuffer*>(
                      prepared_transfer.raw_buffer_.get())
                      ->device_buffer();
+
+      // We always set `peer` to RankId(1) if we are the sender, and RankId(0)
+      // if we are the receiver. This is because `PrepareTransfer()` always
+      // acquires a GPU clique where the sender is rank 0 and the receiver is
+      // rank 1.
       if (prepared_transfer.is_sender_) {
         TF_RETURN_IF_ERROR(gpu_communicator->LaunchSend(
             /*send_buffer=*/mem->mem(),

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -220,12 +220,17 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
   // Helpers for cross host transfers.
   absl::Duration cross_host_transfer_timeout_ = absl::Minutes(3);
 
-  void ScheduleSendsOnLocalDevice(
-      PjRtDevice* device,
+  struct CrossHostTransferSpec {
+    GlobalDeviceId src_global_device_id;
+    GlobalDeviceId dst_global_device_id;
+    tsl::RCReference<PjRtRawBuffer> raw_buffer;
+  };
+
+  void ScheduleTransfersOnLocalDevice(
+      LocalDeviceState* local_device_state, GlobalDeviceId device_id,
       tsl::AsyncValueRef<BufferSequencingEvent> transfer_event,
-      std::vector<tsl::RCReference<PjRtRawBuffer>> raw_buffers,
       std::vector<tsl::RCReference<tsl::AsyncValue>> transfer_dependency_avs,
-      std::vector<GlobalDeviceId> dst_global_device_ids);
+      std::vector<CrossHostTransferSpec> transfer_specs);
 
   struct PrepareReceiveBufferResult {
     std::unique_ptr<PjRtBuffer> buffer;


### PR DESCRIPTION
📝 Summary of Changes
This PR builds on [XLA #40585](https://github.com/openxla/xla/pull/40585), and is the next in a sequence of PRs that will refactor cross-host data transfer implementations to eventually rely on a shared helper function `CrossHostTransferBuffers`. `CrossHostTransferBuffers` is planned to eventually be integrated into the PJRT APIs to enable receiving data into preallocated receive buffers (this feature is being planned in collaboration with @gspschmid, @emilyfertig, and @pschuh). As part of implementing `CrossHostTransferBuffers`, this PR introduces a `CrossHostTransferSpec` struct and refactors `ScheduleSendsOnLocalDevice` into a more general `ScheduleTransfersOnLocalDevice`.

This PR also cleans up some of the error handling around the `prepare_transfers` closure inside `ScheduleTransfersOnLocalDevice` (formerly the `setup_sends` closure inside `ScheduleSendsOnLocalDevice`). Previously, if we got an error when we tried to extract the `LocalDeviceState`, we failed to set the `transfer_event` as an error. The current changes make sure that the error from `prepare_transfers` is always propagated through the transfer event.

🎯 Justification
It is difficult to achieve good comm/compute overlap with cross-host data transfers as the current implementation always allocates receive-buffers 'just-in-time', and because the GPU memory allocator blocks on the compute stream. `CrossHostTransferBuffers` will enable users to receive into preallocated receive buffers, making it easier to avoid the allocator blocking issue. This PR is a step towards implementing `CrossHostTransferBuffers`.

🚀 Kind of Contribution
♻️ Cleanup (eventually ✨ New Feature)

🧪 Unit Tests:
This PR only refactors the implementation of `CrossHost{Send/Receive}Buffers`, so the pre-existing unit tests for those methods already test this PR.

🧪 Execution Tests:
Verified that [these 4 correctness tests](https://gist.github.com/rao-ashish/24ac0df0cb18243c649ac535964b31b8) continue to pass.