### PR TITLE
[NVIDIA GPU ] Move barrier out of loop in collective permute

### DIFF
--- a/xla/backends/gpu/runtime/nvshmem_collective_permute_thunk.cc
+++ b/xla/backends/gpu/runtime/nvshmem_collective_permute_thunk.cc
@@ -237,16 +237,15 @@ absl::Status RunCollectivePermute(P2PConfig::SourceTargetMapEntry source_target,
           RankId(*target_id), GpuCollectives::On(stream));
       TF_RETURN_IF_ERROR(send_future.Await());
     }
+  }
+  if (source_id) {
+    // NVSHMEM put/get API is one-way communication - the sender initiates the
+    // transfer and the receiver doesn't need to explicitly receive. We use a
+    // barrier here to ensure all puts have completed before proceeding.
+    VLOG(1) << "CollectivePermute: rank " << device_ordinal
+            << " receiving data from source " << *source_id;
 
-    if (source_id) {
-      // NVSHMEM put/get API is one-way communication - the sender initiates the
-      // transfer and the receiver doesn't need to explicitly receive. We use a
-      // barrier here to ensure all puts have completed before proceeding.
-      VLOG(1) << "CollectivePermute: rank " << device_ordinal
-              << " receiving data from source " << *source_id;
-
-      TF_RETURN_IF_ERROR(nvshmem_comm->Barrier(GpuCollectives::On(stream)));
-    }
+    TF_RETURN_IF_ERROR(nvshmem_comm->Barrier(GpuCollectives::On(stream)));
   }
 
   if (!source_id) {


### PR DESCRIPTION
📝 Summary of Changes
Move barrier out of the loop and run it only once per thunk call.
I know we are deprecating nvshmem but there are still users using it and nccl put is not yet integrated with cp yet.
