### PR TITLE
[XLA:GPU] update cudnn frontend to 1.22.1

### DIFF
--- a/third_party/cudnn_frontend/workspace.bzl
+++ b/third_party/cudnn_frontend/workspace.bzl
@@ -7,7 +7,7 @@ def repo():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "453d4650e6a25ede58fbbd7077c64ebe92734218d474ec7371bb13fa6d2181fa",
-        strip_prefix = "cudnn-frontend-1.16.1",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.16.1.zip"),
+        sha256 = "4abb1568ad8d27a99fe987193be6c8bf71980beade115fe11bd27ef5e2c23e45",
+        strip_prefix = "cudnn-frontend-1.22.1",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.22.1.zip"),
     )

--- a/xla/tsl/cuda/cudart.symbols
+++ b/xla/tsl/cuda/cudart.symbols
@@ -231,6 +231,7 @@ cudaIpcGetEventHandle
 cudaIpcGetMemHandle
 cudaIpcOpenEventHandle
 cudaIpcOpenMemHandle
+cudaKernelSetAttributeForDevice
 cudaLaunchCooperativeKernel
 cudaLaunchCooperativeKernelMultiDevice
 cudaLaunchCooperativeKernel_ptsz
@@ -240,6 +241,7 @@ cudaLaunchKernel
 cudaLaunchKernelExC
 cudaLaunchKernelExC_ptsz
 cudaLaunchKernel_ptsz
+cudaLibraryUnload
 cudaMalloc
 cudaMalloc3D
 cudaMalloc3DArray


### PR DESCRIPTION
📝 Summary of Changes
update cudnn frontend version to 1.22.1. This includes API to invoke cuDNN grouped gemm.
