### PR TITLE
[ROCm] Cleanup GEMM Rewriter Tests

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -2535,8 +2535,6 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
          PrimitiveType::BF16, DataType::kBF16},
         {ComputationType::kF32, DataType::kFloat, PrimitiveType::F16,
          PrimitiveType::F16, DataType::kHalf},
-        {ComputationType::kF32, DataType::kFloat, PrimitiveType::S8,
-         PrimitiveType::S8, DataType::kFloat},
         {ComputationType::kF32, DataType::kFloat, PrimitiveType::F32,
          PrimitiveType::F32, DataType::kFloat},
     };
@@ -2563,6 +2561,14 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         absl::c_linear_search(extended_type_combinations,
                               std::make_tuple(compute_type, scale_type, a_dtype,
                                               b_dtype, output_dtype))) {
+      return true;
+    }
+
+    // S8 x S8 -> F32 is supported by cuBLAS/cuBLASLt but not by
+    // rocBLAS/hipblasLt.
+    if (is_cuda && a_dtype == PrimitiveType::S8 &&
+        b_dtype == PrimitiveType::S8 && output_dtype == DataType::kFloat &&
+        compute_type == ComputationType::kF32) {
       return true;
     }
 

--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -2439,6 +2439,11 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
          PrimitiveType::F64, DataType::kDouble},
         {ComputationType::kF64, DataType::kComplexDouble, PrimitiveType::C128,
          PrimitiveType::C128, DataType::kComplexDouble},
+
+        // S8 x S8 -> F32 is supported by cuBLAS/cuBLASLt but not by
+        // rocBLAS/hipblasLt.
+        {ComputationType::kF32, DataType::kFloat, PrimitiveType::S8,
+         PrimitiveType::S8, DataType::kFloat},
     };
     if (gpu_version_.IsCuda() &&
         absl::c_linear_search(supported_cublas_type_combinations,
@@ -2561,14 +2566,6 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         absl::c_linear_search(extended_type_combinations,
                               std::make_tuple(compute_type, scale_type, a_dtype,
                                               b_dtype, output_dtype))) {
-      return true;
-    }
-
-    // S8 x S8 -> F32 is supported by cuBLAS/cuBLASLt but not by
-    // rocBLAS/hipblasLt.
-    if (is_cuda && a_dtype == PrimitiveType::S8 &&
-        b_dtype == PrimitiveType::S8 && output_dtype == DataType::kFloat &&
-        compute_type == ComputationType::kF32) {
       return true;
     }
 

--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -2440,8 +2440,6 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         {ComputationType::kF64, DataType::kComplexDouble, PrimitiveType::C128,
          PrimitiveType::C128, DataType::kComplexDouble},
 
-        // S8 x S8 -> F32 is supported by cuBLAS/cuBLASLt but not by
-        // rocBLAS/hipblasLt.
         {ComputationType::kF32, DataType::kFloat, PrimitiveType::S8,
          PrimitiveType::S8, DataType::kFloat},
     };

--- a/xla/backends/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter_test.cc
@@ -1110,10 +1110,6 @@ ENTRY int8gemm {
 }
 
 TEST_F(GemmRewriteTest, Int8GemmRankGreaterThanTwo) {
-  if (IsRocm()) {
-    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
-  }
-
   const char* hlo_text = R"(
 HloModule int8gemm
 
@@ -1127,21 +1123,30 @@ ENTRY main.4 {
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 
-  if (IsRocm() ||
-      // Has at least Volta to support int8 GEMM.
-      HasCudaComputeCapability(se::CudaComputeCapability::Volta())) {
-    DebugOptions debug_options = GetDebugOptionsForTest();
-    std::string custom_call_target = debug_options.xla_gpu_enable_cublaslt()
-                                         ? "__cublas$lt$matmul"
-                                         : "__cublas$gemm";
+  DebugOptions debug_options = GetDebugOptionsForTest();
+  std::string custom_call_target = debug_options.xla_gpu_enable_cublaslt()
+                                       ? "__cublas$lt$matmul"
+                                       : "__cublas$gemm";
 
+  if (IsRocm()) {
+    // ROCm does not pad Int8 GEMM operands to multiples of 4.
     MatchOptimizedHlo(hlo_text,
                       absl::StrReplaceAll(
                           R"(
-; CHECK: [[GEMM:%[^ ]+]] = (s32[8,4]{1,0}, s8[{{[0-9]+}}]{0}) custom-call(s8[8,4]{1,0} %{{.*}}, s8[4,4]{0,1} %{{.*}}), custom_call_target="$0",
+; CHECK: {{.*}} custom-call(s8[8,2]{1,0} %{{.*}}, s8[2,4]{0,1} %{{.*}}), custom_call_target="$0"
   )",
                           {{"$0", custom_call_target}}),
                       /*print_operand_shape=*/true);
+  } else if (IsCuda()) {
+    if (HasCudaComputeCapability(se::CudaComputeCapability::Volta())) {
+      MatchOptimizedHlo(hlo_text,
+                        absl::StrReplaceAll(
+                            R"(
+; CHECK: {{.*}} custom-call(s8[8,4]{1,0} %{{.*}}, s8[4,4]{0,1} %{{.*}}), custom_call_target="$0"
+  )",
+                            {{"$0", custom_call_target}}),
+                        /*print_operand_shape=*/true);
+    }
   }
 }
 
@@ -1218,10 +1223,6 @@ ENTRY int8gemm {
 }
 
 TEST_P(ParameterizedGemmRewriteTest, Int8GemmNotMultipleOfFour) {
-  if (IsRocm()) {
-    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
-  }
-
   const char* hlo_text = R"(
 HloModule int8gemm
 
@@ -1233,20 +1234,37 @@ ENTRY int8gemm {
   )";
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 
-  if (IsRocm() ||
-      HasCudaComputeCapability(se::CudaComputeCapability::Volta())) {
+  DebugOptions debug_options = GetDebugOptionsForTest();
+  std::string custom_call_target = debug_options.xla_gpu_enable_cublaslt()
+                                       ? "__cublas$lt$matmul"
+                                       : "__cublas$gemm";
+
+  if (IsRocm()) {
+    // ROCm does not pad Int8 GEMM operands to multiples of 4.
     MatchOptimizedHlo(hlo_text,
-                      R"(
-; CHECK: {{.*}} custom-call(s8[16,4]{1,0} [[A:%[^ ]+]], s8[4,12]{0,1} [[B:%[^ ]+]]), custom_call_target="<<CUBLAS_CUSTOM_CALL_TARGET_PLACEHOLDER>>"
+                      absl::StrReplaceAll(
+                          R"(
+; CHECK: {{.*}} custom-call(s8[13,4]{1,0} [[A:%[^ ]+]], s8[4,9]{0,1} [[B:%[^ ]+]]), custom_call_target="$0"
   )",
+                          {{"$0", custom_call_target}}),
                       /*print_operand_shape=*/true);
-  } else {
-    MatchOptimizedHlo(hlo_text,
-                      R"(
+  } else if (IsCuda()) {
+    if (HasCudaComputeCapability(se::CudaComputeCapability::Volta())) {
+      MatchOptimizedHlo(hlo_text,
+                        absl::StrReplaceAll(
+                            R"(
+; CHECK: {{.*}} custom-call(s8[16,4]{1,0} [[A:%[^ ]+]], s8[4,12]{0,1} [[B:%[^ ]+]]), custom_call_target="$0"
+  )",
+                            {{"$0", custom_call_target}}),
+                        /*print_operand_shape=*/true);
+    } else {
+      MatchOptimizedHlo(hlo_text,
+                        R"(
 ; CHECK: {{.*}} dot(s32[13,4]{1,0} [[A:%[^ ]+]], s32[4,9]{1,0} [[B:%[^ ]+]]), lhs_contracting_dims={1}, rhs_contracting_dims={0}
 
   )",
-                      /*print_operand_shape=*/true);
+                        /*print_operand_shape=*/true);
+    }
   }
 }
 

--- a/xla/backends/gpu/transforms/gemm_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter_test.cc
@@ -1269,10 +1269,6 @@ ENTRY int8gemm {
 }
 
 TEST_P(ParameterizedGemmRewriteTest, GemmTypeCombinationCheck) {
-  if (IsRocm()) {
-    GTEST_SKIP() << "DoBlasGemmWithAlgorithm is not yet implemented on ROCm";
-  }
-
   std::vector<std::tuple<absl::string_view, absl::string_view, bool>>
       type_combinations = {{"s8", "s8", true},
                            {"s32", "s32", true},
@@ -1282,11 +1278,18 @@ TEST_P(ParameterizedGemmRewriteTest, GemmTypeCombinationCheck) {
                            {"f64", "f64", true},
                            {"c64", "c64", true},
                            {"c128", "c128", true},
-                           // add mix type gemm
+                           // mix type gemm
                            {"s8", "s32", true},
-                           {"s8", "f32", true},
                            {"f16", "f32", true},
                            {"bf16", "f32", true}};
+
+  if (IsCuda()) {
+    // cuBLAS and cuBLASLt both support s8 x s8 -> f32 GEMM.
+    type_combinations.push_back({"s8", "f32", true});
+  } else if (IsRocm()) {
+    // Neither rocBLAS nor hipblasLt supports s8 x s8 -> f32 GEMM.
+    type_combinations.push_back({"s8", "f32", false});
+  }
 
   if (IsRocm() ||
       HasCudaComputeCapability(se::CudaComputeCapability::Ampere())) {


### PR DESCRIPTION
There are three tests in GemmRewriter that are skipped for ROCm, which are addressed in this PR.

The following two are due to the different padding strategies for ROCm and CUDA:
- GemmRewriteTest.Int8GemmRankGreaterThanTwo
- ParameterizedGemmRewriteTest.Int8GemmNotMultipleOfFour

The following one is due to the lack of support of S8 x S8 -> F32 on ROCm:
- ParameterizedGemmRewriteTest.GemmTypeCombinationCheck