### PR TITLE
[tsl] Make BFCAllocator respect requested alignment

### DIFF
--- a/xla/tsl/framework/BUILD
+++ b/xla/tsl/framework/BUILD
@@ -104,14 +104,10 @@ cc_library(
         "tracking_allocator.cc",
         "tracking_allocator.h",
     ],
-    hdrs = [
-        "allocator.h",
-    ],
+    hdrs = ["allocator.h"],
     features = ["parse_headers"],
     visibility = ["//visibility:public"],
     deps = [
-        ":numeric_types",
-        ":type_traits",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
@@ -126,9 +122,9 @@ cc_library(
             "//xla/tsl/platform:env_impl",
             "//xla/tsl/platform:logging",
             "//xla/tsl/platform:macros",
+            "//xla/tsl/platform:types",
             "@tsl//tsl/platform:platform_port",
             "@tsl//tsl/platform:thread_annotations",
-            "//xla/tsl/platform:types",
         ],
         otherwise = [
             "//xla/tsl/lib/gtl:inlined_vector",
@@ -163,14 +159,11 @@ cc_library(
         "//third_party/xprof:__subpackages__",
     ]),
     deps = [
-        ":numeric_types",
-        ":type_traits",
         "//xla/tsl/lib/gtl:inlined_vector",
         "//xla/tsl/platform:logging",
         "//xla/tsl/platform:macros",
         "//xla/tsl/platform:types",
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:thread_annotations",
@@ -200,16 +193,32 @@ cc_library(
         "//xla/tsl/platform:types",
         "//xla/tsl/profiler/utils:trace_filter_utils",
         "//xla/tsl/protobuf:bfc_memory_map_proto_cc",
-        "//xla/tsl/util:safe_reinterpret_cast",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/numeric:bits",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@tsl//tsl/platform:numbers",
         "@tsl//tsl/platform:stacktrace",
         "@tsl//tsl/profiler/lib:scoped_memory_debug_annotation",
         "@tsl//tsl/profiler/lib:traceme",
+    ],
+)
+
+tsl_cc_test(
+    name = "bfc_allocator_test",
+    srcs = ["bfc_allocator_test.cc"],
+    deps = [
+        ":allocator",
+        ":bfc_allocator",
+        "//xla/tsl/platform:env_impl",  # buildcleaner: keep
+        "//xla/tsl/platform:test",
+        "@com_google_absl//absl/base",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:platform_port",
     ],
 )
 

--- a/xla/tsl/framework/allocator.h
+++ b/xla/tsl/framework/allocator.h
@@ -16,18 +16,15 @@ limitations under the License.
 #ifndef XLA_TSL_FRAMEWORK_ALLOCATOR_H_
 #define XLA_TSL_FRAMEWORK_ALLOCATOR_H_
 
-#include <stdlib.h>
-
+#include <cstdint>
 #include <functional>
-#include <limits>
 #include <optional>
+#include <string>
+#include <vector>
 
-#include "absl/strings/string_view.h"
-#include "xla/tsl/framework/numeric_types.h"
-#include "xla/tsl/framework/type_traits.h"
+#include <stdlib.h>
 #include "xla/tsl/platform/logging.h"
 #include "xla/tsl/platform/macros.h"
-#include "xla/tsl/platform/types.h"
 #include "tsl/platform/numa.h"
 
 namespace tsl {
@@ -108,7 +105,7 @@ struct AllocatorStats {
 enum class AllocatorMemoryType {
   kUnknown = 0,       // Memory type unknown.
   kDevice = 1,        // Memory on device.
-  kHostPageable = 2,  // Memory on host and it is pagable.
+  kHostPageable = 2,  // Memory on host and it is pageable.
   kHostPinned = 3,    // Memory on host and it is pinned.
 };
 
@@ -404,7 +401,7 @@ class SubAllocator {
   virtual ~SubAllocator() {}
   // Allocates at least num_bytes. Returns actual number of bytes allocated in
   // bytes_received. The caller can safely use the full bytes_received sized
-  // buffer following the returend pointer.
+  // buffer following the returned pointer.
   virtual void* Alloc(size_t alignment, size_t num_bytes,
                       size_t* bytes_received) = 0;
   virtual void Free(void* ptr, size_t num_bytes) = 0;

--- a/xla/tsl/framework/bfc_allocator.cc
+++ b/xla/tsl/framework/bfc_allocator.cc
@@ -29,8 +29,10 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/base/casts.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/numeric/bits.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
@@ -39,7 +41,6 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/file_system.h"
 #include "xla/tsl/platform/logging.h"
-#include "xla/tsl/platform/types.h"
 #include "xla/tsl/profiler/utils/trace_filter_utils.h"
 #include "xla/tsl/protobuf/bfc_memory_map.pb.h"
 #include "tsl/platform/numbers.h"
@@ -173,6 +174,10 @@ bool BFCAllocator::Extend(size_t alignment, size_t rounded_bytes) {
     curr_region_allocation_bytes_ *= 2;
   }
 
+  CHECK_EQ(absl::bit_cast<uintptr_t>(mem_addr) & (kMinAllocationSize - 1), 0)
+      << "SubAllocator must return memory aligned to at least "
+      << kMinAllocationSize << " bytes, got " << mem_addr;
+
   VLOG(1) << "Extending allocation by "
           << strings::HumanReadableNumBytes(bytes_received) << " bytes for "
           << Name() << ".";
@@ -250,15 +255,14 @@ void BFCAllocator::DeallocateChunk(ChunkHandle h) {
 }
 
 void* BFCAllocator::AllocateRawInternalWithRetry(
-    size_t unused_alignment, size_t num_bytes,
+    size_t alignment, size_t num_bytes,
     const AllocationAttributes& allocation_attr) {
   // Fast path: Try once to allocate without getting the retry_helper_ involved
   uint64_t freed_by_count = 0;
   if (allocation_attr.freed_by_func != nullptr) {
     freed_by_count = (*allocation_attr.freed_by_func)();
   }
-  void* r =
-      AllocateRawInternal(unused_alignment, num_bytes, false, freed_by_count);
+  void* r = AllocateRawInternal(alignment, num_bytes, false, freed_by_count);
   if (r != nullptr) {
     return r;
   } else {
@@ -271,14 +275,15 @@ void* BFCAllocator::AllocateRawInternalWithRetry(
           }
           return AllocateRawInternal(a, nb, v, freed_by_count);
         },
-        kMaxMillisToWait, unused_alignment, num_bytes);
+        kMaxMillisToWait, alignment, num_bytes);
     return r;
   }
 }
 
-void* BFCAllocator::AllocateRaw(size_t unused_alignment, size_t num_bytes,
+void* BFCAllocator::AllocateRaw(size_t alignment, size_t num_bytes,
                                 const AllocationAttributes& allocation_attr) {
-  VLOG(3) << "AllocateRaw " << Name() << "  " << num_bytes;
+  VLOG(3) << "AllocateRaw " << Name() << " " << num_bytes
+          << " alignment=" << alignment;
   void* result = [&] {
     if (!opts_.allow_retry_on_failure || !allocation_attr.retry_on_failure) {
       // If we have globally disabled retry-on-failure and fail to allocate an
@@ -302,8 +307,8 @@ void* BFCAllocator::AllocateRaw(size_t unused_alignment, size_t num_bytes,
       if (allocation_attr.freed_by_func != nullptr) {
         freed_by_count = (*allocation_attr.freed_by_func)();
       }
-      void* res = AllocateRawInternal(unused_alignment, num_bytes,
-                                      dump_log_on_failure, freed_by_count);
+      void* res = AllocateRawInternal(alignment, num_bytes, dump_log_on_failure,
+                                      freed_by_count);
       if (res == nullptr) {
         int32_t counter_value = log_counter.load(std::memory_order_relaxed);
         if (counter_value < kMaxFailureLogs) {
@@ -321,7 +326,7 @@ void* BFCAllocator::AllocateRaw(size_t unused_alignment, size_t num_bytes,
       }
       return res;
     } else {
-      return AllocateRawInternalWithRetry(unused_alignment, num_bytes,
+      return AllocateRawInternalWithRetry(alignment, num_bytes,
                                           allocation_attr);
     }
   }();
@@ -431,8 +436,7 @@ void BFCAllocator::DeallocateRegions(
   }
 }
 
-void* BFCAllocator::AllocateRawInternal(size_t unused_alignment,
-                                        size_t num_bytes,
+void* BFCAllocator::AllocateRawInternal(size_t alignment, size_t num_bytes,
                                         bool dump_log_on_failure,
                                         uint64_t freed_before) {
   if (num_bytes == 0) {
@@ -444,6 +448,11 @@ void* BFCAllocator::AllocateRawInternal(size_t unused_alignment,
   // so all memory addresses are nicely byte aligned.
   size_t rounded_bytes = RoundedBytes(num_bytes);
 
+  // Alignment must be a power of two and at least kMinAllocationSize so that
+  // splitting for alignment always produces kMinAllocationSize-aligned chunks.
+  DCHECK(absl::has_single_bit(alignment)) << "alignment must be a power of 2";
+  alignment = std::max(alignment, kMinAllocationSize);
+
   // The BFC allocator tries to find the best fit first.
   BinNum bin_num = BinNumForSize(rounded_bytes);
 
@@ -452,15 +461,17 @@ void* BFCAllocator::AllocateRawInternal(size_t unused_alignment,
     // Merge timestamped chunks whose counts have become safe for general use.
     MergeTimestampedChunks(0);
   }
-  void* ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, freed_before);
+  void* ptr =
+      FindChunkPtr(bin_num, rounded_bytes, num_bytes, alignment, freed_before);
   if (ptr != nullptr) {
     AddTraceMe("MemoryAllocation", ptr);
     return ptr;
   }
 
   // Try to extend
-  if (Extend(unused_alignment, rounded_bytes)) {
-    ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, freed_before);
+  if (Extend(alignment, rounded_bytes)) {
+    ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, alignment,
+                       freed_before);
     if (ptr != nullptr) {
       AddTraceMe("MemoryAllocation", ptr);
       return ptr;
@@ -473,7 +484,8 @@ void* BFCAllocator::AllocateRawInternal(size_t unused_alignment,
     // timestamped chunks more aggressively until a free chunk of the necessary
     // size is formed.
     if (MergeTimestampedChunks(rounded_bytes)) {
-      ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, freed_before);
+      ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, alignment,
+                         freed_before);
       if (ptr != nullptr) {
         AddTraceMe("MemoryAllocation", ptr);
         return ptr;
@@ -486,8 +498,9 @@ void* BFCAllocator::AllocateRawInternal(size_t unused_alignment,
   // try deallocating free regions so that suballocator can combine them with
   // the unallocated bytes and form a larger region.
   if (DeallocateFreeRegions(rounded_bytes) &&
-      Extend(unused_alignment, rounded_bytes)) {
-    ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, freed_before);
+      Extend(alignment, rounded_bytes)) {
+    ptr = FindChunkPtr(bin_num, rounded_bytes, num_bytes, alignment,
+                       freed_before);
     if (ptr != nullptr) {
       AddTraceMe("MemoryAllocation", ptr);
       return ptr;
@@ -555,7 +568,7 @@ void BFCAllocator::AddTraceMe(absl::string_view traceme_name,
                                {"peak_bytes_in_use", stats_.peak_bytes_in_use},
                                {"requested_bytes", req_bytes},
                                {"allocation_bytes", alloc_bytes},
-                               {"addr", reinterpret_cast<uint64_t>(chunk_ptr)},
+                               {"addr", absl::bit_cast<uintptr_t>(chunk_ptr)},
                                {"tf_op", annotation.pending_op_name},
                                {"id", annotation.pending_step_id},
                                {"region_type", annotation.pending_region_type},
@@ -567,7 +580,8 @@ void BFCAllocator::AddTraceMe(absl::string_view traceme_name,
 }
 
 void* BFCAllocator::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
-                                 size_t num_bytes, uint64_t freed_before) {
+                                 size_t num_bytes, size_t alignment,
+                                 uint64_t freed_before) {
   // First identify the first bin that could satisfy rounded_bytes.
   for (; bin_num < kNumBins; bin_num++) {
     // Start searching from the first bin for the smallest chunk that fits
@@ -575,16 +589,42 @@ void* BFCAllocator::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
     Bin* b = BinFromIndex(bin_num);
     for (auto citer = b->free_chunks.begin(); citer != b->free_chunks.end();
          ++citer) {
-      const BFCAllocator::ChunkHandle h = (*citer);
+      BFCAllocator::ChunkHandle h = (*citer);
       BFCAllocator::Chunk* chunk = ChunkFromHandle(h);
       DCHECK(!chunk->in_use());
       if (freed_before > 0 && freed_before < chunk->freed_at_count) {
         continue;
       }
-      if (chunk->size >= rounded_bytes) {
+
+      // Compute how many bytes we need to skip at the front of this chunk
+      // to reach the requested alignment boundary.
+      uintptr_t ptr_int = absl::bit_cast<uintptr_t>(chunk->ptr);
+      size_t align_padding =
+          (alignment - (ptr_int & (alignment - 1))) % alignment;
+      // Round padding up to kMinAllocationSize so the prefix chunk is valid.
+      align_padding = RoundedBytes(align_padding);
+
+      if (chunk->size >= rounded_bytes + align_padding) {
         // We found an existing chunk that fits us that wasn't in use, so remove
         // it from the free bin structure prior to using.
         RemoveFreeChunkIterFromBin(&b->free_chunks, citer);
+
+        // If alignment requires it, split off the unaligned prefix as a
+        // separate free chunk.
+        if (align_padding > 0) {
+          SplitChunk(h, align_padding);
+          // After splitting, h still points to the prefix chunk (size =
+          // align_padding). The new aligned chunk is h's next and was
+          // inserted into a free bin by SplitChunk.
+          chunk = ChunkFromHandle(h);
+          // Put the prefix back into the free bin.
+          InsertFreeChunkIntoBin(h);
+          // Advance to the aligned chunk and remove it from its free bin
+          // so we can use it (and potentially split it again below).
+          h = chunk->next;
+          chunk = ChunkFromHandle(h);
+          RemoveFreeChunkFromBin(h);
+        }
 
         // If we can break the size of the chunk into two reasonably large
         // pieces, do don't waste more than max_internal_fragmentation_bytes on
@@ -1091,7 +1131,7 @@ void BFCAllocator::DumpMemoryLog(size_t num_bytes) {
       }
       std::string buf = absl::StrCat(
           (c->in_use() ? "InUse" : "Free "), " at ",
-          absl::Hex(reinterpret_cast<uint64_t>(c->ptr)), " of size ", c->size);
+          absl::Hex(absl::bit_cast<uintptr_t>(c->ptr)), " of size ", c->size);
 #ifdef TENSORFLOW_MEM_DEBUG
       if (ShouldRecordOpName()) {
         absl::StrAppend(&buf, " by op ", c->op_name, " action_count ",
@@ -1187,7 +1227,7 @@ MemoryDump BFCAllocator::RecordMemoryMapInternal() {
       const Chunk* c = ChunkFromHandle(h);
       tensorflow::MemChunk* mc = md.add_chunk();
       mc->set_in_use(c->in_use());
-      mc->set_address(reinterpret_cast<uint64_t>(c->ptr));
+      mc->set_address(absl::bit_cast<uintptr_t>(c->ptr));
       mc->set_size(c->size);
       mc->set_requested_size(c->requested_size);
       mc->set_bin(c->bin_num);

--- a/xla/tsl/framework/bfc_allocator.h
+++ b/xla/tsl/framework/bfc_allocator.h
@@ -24,8 +24,11 @@ limitations under the License.
 #include <deque>
 #include <memory>
 #include <optional>
+#include <set>
+#include <string>
 #include <vector>
 
+#include "absl/base/casts.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
@@ -36,8 +39,6 @@ limitations under the License.
 #include "xla/tsl/framework/shared_counter.h"
 #include "xla/tsl/lib/core/bits.h"
 #include "xla/tsl/platform/logging.h"
-#include "xla/tsl/platform/types.h"
-#include "xla/tsl/util/safe_reinterpret_cast.h"
 #include "tsl/platform/numbers.h"
 
 namespace tensorflow {
@@ -340,8 +341,8 @@ class BFCAllocator : public Allocator {
     }
 
     size_t IndexFor(const void* p) const {
-      std::uintptr_t p_int = safe_reinterpret_cast<std::uintptr_t>(p);
-      std::uintptr_t base_int = safe_reinterpret_cast<std::uintptr_t>(ptr_);
+      uintptr_t p_int = absl::bit_cast<uintptr_t>(p);
+      uintptr_t base_int = absl::bit_cast<uintptr_t>(ptr_);
       DCHECK_GE(p_int, base_int);
       DCHECK_LT(p_int, base_int + memory_size_);
       return static_cast<size_t>(((p_int - base_int) >> kMinAllocationBits));
@@ -368,7 +369,7 @@ class BFCAllocator : public Allocator {
   // This class is thread-compatible.
   class RegionManager {
    public:
-    RegionManager() {}
+    RegionManager() = default;
     ~RegionManager() {}
 
     void AddAllocationRegion(void* ptr, size_t memory_size) {
@@ -378,7 +379,7 @@ class BFCAllocator : public Allocator {
       regions_.insert(entry, AllocationRegion(ptr, memory_size));
     }
 
-    // Adds an alloation region for the given ptr and size, potentially
+    // Adds an allocation region for the given ptr and size, potentially
     // extending a region if ptr matches the end_ptr of an existing region.
     // If a region is extended, returns a pointer to the extended region so that
     // the BFC allocator can reason about chunkification.
@@ -472,9 +473,9 @@ class BFCAllocator : public Allocator {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Returns a pointer to an underlying allocated chunk of size
-  // 'rounded_bytes'.
+  // 'rounded_bytes' aligned to 'alignment'.
   void* FindChunkPtr(BinNum bin_num, size_t rounded_bytes, size_t num_bytes,
-                     uint64_t freed_before)
+                     size_t alignment, uint64_t freed_before)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Splits the chunk specified by 'h' into two chunks, one at least

--- a/xla/tsl/framework/bfc_allocator_test.cc
+++ b/xla/tsl/framework/bfc_allocator_test.cc
@@ -1,0 +1,225 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/tsl/framework/bfc_allocator.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <new>
+#include <random>
+#include <vector>
+
+#include "absl/base/casts.h"
+#include "xla/tsl/framework/allocator.h"
+#include "xla/tsl/platform/test.h"
+#include "tsl/platform/mem.h"
+
+namespace tsl {
+namespace {
+
+// Minimal SubAllocator backed by port::AlignedMalloc for host memory.
+class MallocSubAllocator : public SubAllocator {
+ public:
+  MallocSubAllocator() : SubAllocator({}, {}) {}
+
+  void* Alloc(size_t alignment, size_t num_bytes,
+              size_t* bytes_received) override {
+    void* ptr = port::AlignedMalloc(num_bytes,
+                                    static_cast<std::align_val_t>(alignment));
+    *bytes_received = num_bytes;
+    return ptr;
+  }
+
+  void Free(void* ptr, size_t num_bytes) override { port::AlignedFree(ptr); }
+
+  bool SupportsCoalescing() const override { return false; }
+};
+
+// Helper to check pointer alignment.
+bool IsAligned(const void* ptr, size_t alignment) {
+  return (absl::bit_cast<uintptr_t>(ptr) & (alignment - 1)) == 0;
+}
+
+TEST(BFCAllocatorTest, AllocateAndFree) {
+  BFCAllocator alloc(std::make_unique<MallocSubAllocator>(),
+                     /*total_memory=*/1 << 20, /*name=*/"test",
+                     BFCAllocator::Options{});
+
+  void* ptr = alloc.AllocateRaw(64, 512);
+  ASSERT_NE(ptr, nullptr);
+  alloc.DeallocateRaw(ptr);
+}
+
+TEST(BFCAllocatorTest, DefaultAlignment) {
+  BFCAllocator alloc(std::make_unique<MallocSubAllocator>(),
+                     /*total_memory=*/1 << 20, /*name=*/"test",
+                     BFCAllocator::Options{});
+
+  // BFC always returns pointers aligned to at least kAllocatorAlignment (64).
+  void* ptr = alloc.AllocateRaw(Allocator::kAllocatorAlignment, 1);
+  ASSERT_NE(ptr, nullptr);
+  EXPECT_TRUE(IsAligned(ptr, Allocator::kAllocatorAlignment));
+  alloc.DeallocateRaw(ptr);
+}
+
+// Parameterized test that verifies alignment is respected for various
+// power-of-two alignments from 32 bytes to 4096 bytes.
+class BFCAllocatorAlignmentTest : public ::testing::TestWithParam<size_t> {};
+
+TEST_P(BFCAllocatorAlignmentTest, RespectsRequestedAlignment) {
+  const size_t alignment = GetParam();
+  BFCAllocator alloc(std::make_unique<MallocSubAllocator>(),
+                     /*total_memory=*/1 << 20, /*name=*/"test",
+                     BFCAllocator::Options{});
+
+  // Allocate a small block first to push the arena cursor off any "lucky"
+  // alignment, then allocate with the requested alignment.
+  void* filler = alloc.AllocateRaw(Allocator::kAllocatorAlignment, 256);
+  ASSERT_NE(filler, nullptr);
+
+  constexpr int kTrials = 8;
+  void* ptrs[kTrials];
+
+  for (int i = 0; i < kTrials; ++i) {
+    ptrs[i] = alloc.AllocateRaw(alignment, 256);
+    ASSERT_NE(ptrs[i], nullptr);
+    EXPECT_TRUE(IsAligned(ptrs[i], alignment))
+        << "Allocation " << i << " at " << ptrs[i] << " not aligned to "
+        << alignment;
+  }
+
+  for (int i = 0; i < kTrials; ++i) {
+    alloc.DeallocateRaw(ptrs[i]);
+  }
+  alloc.DeallocateRaw(filler);
+}
+
+INSTANTIATE_TEST_SUITE_P(Alignments, BFCAllocatorAlignmentTest,
+                         ::testing::Values(32, 64, 128, 256, 512, 1024, 2048,
+                                           4096));
+
+// Stress test: allocate and free chunks of varying sizes and alignments in
+// randomized order across multiple iterations. This exercises chunk splitting,
+// alignment padding, coalescing on free, and reuse of freed chunks.
+TEST(BFCAllocatorTest, StressAllocFree) {
+  BFCAllocator alloc(std::make_unique<MallocSubAllocator>(),
+                     /*total_memory=*/16 << 20, /*name=*/"stress",
+                     BFCAllocator::Options{});
+
+  constexpr std::array<size_t, 5> kAlignments = {64, 256, 512, 1024, 4096};
+  constexpr std::array<size_t, 7> kSizes = {1, 128, 256, 700, 1024, 4096, 8192};
+  constexpr int kNumAllocs = kAlignments.size() * kSizes.size();
+  constexpr int kIterations = 20;
+
+  struct AllocSpec {
+    size_t alignment;
+    size_t size;
+  };
+
+  // Build 10 copies of each (alignment, size) pair = 350 allocations.
+  constexpr int kCopies = 10;
+  std::vector<AllocSpec> specs;
+  specs.reserve(kNumAllocs * kCopies);
+  for (int c = 0; c < kCopies; ++c) {
+    for (size_t align : kAlignments) {
+      for (size_t size : kSizes) {
+        specs.push_back({align, size});
+      }
+    }
+  }
+
+  std::mt19937 rng(42);
+
+  for (int iter = 0; iter < kIterations; ++iter) {
+    // Shuffle allocation order each iteration.
+    std::shuffle(specs.begin(), specs.end(), rng);
+
+    std::vector<void*> ptrs;
+    ptrs.reserve(specs.size());
+
+    // Allocate all.
+    for (const auto& spec : specs) {
+      void* ptr = alloc.AllocateRaw(spec.alignment, spec.size);
+      ASSERT_NE(ptr, nullptr)
+          << "Failed at iter=" << iter << " size=" << spec.size
+          << " alignment=" << spec.alignment;
+      EXPECT_TRUE(IsAligned(ptr, spec.alignment))
+          << "iter=" << iter << " ptr=" << ptr
+          << " alignment=" << spec.alignment;
+      ptrs.push_back(ptr);
+    }
+
+    // Shuffle deallocation order so free/coalesce paths vary.
+    std::shuffle(ptrs.begin(), ptrs.end(), rng);
+
+    for (void* ptr : ptrs) {
+      alloc.DeallocateRaw(ptr);
+    }
+  }
+}
+
+// SubAllocator that always returns 256-byte (kMinAllocationSize) aligned
+// memory but ignores higher alignment requests. This simulates GPU allocators
+// like DeviceMemAllocator where cudaMalloc returns 256-byte aligned memory
+// regardless of the requested alignment.
+class GpuLikeSubAllocator : public SubAllocator {
+ public:
+  GpuLikeSubAllocator() : SubAllocator({}, {}) {}
+
+  void* Alloc(size_t /*alignment*/, size_t num_bytes,
+              size_t* bytes_received) override {
+    // Always align to 256 bytes, ignoring the requested alignment.
+    void* ptr = port::AlignedMalloc(num_bytes, std::align_val_t{256});
+    *bytes_received = num_bytes;
+    return ptr;
+  }
+
+  void Free(void* ptr, size_t num_bytes) override { port::AlignedFree(ptr); }
+
+  bool SupportsCoalescing() const override { return false; }
+};
+
+// Verify that BFC still respects alignment even when the sub-allocator only
+// provides 256-byte aligned regions (as GPU sub-allocators do).
+TEST(BFCAllocatorTest, AlignmentWithGpuLikeSubAllocator) {
+  BFCAllocator alloc(std::make_unique<GpuLikeSubAllocator>(),
+                     /*total_memory=*/1 << 20, /*name=*/"gpu_like",
+                     BFCAllocator::Options{});
+
+  // Push the cursor off any lucky alignment.
+  void* filler = alloc.AllocateRaw(Allocator::kAllocatorAlignment, 256);
+  ASSERT_NE(filler, nullptr);
+
+  constexpr std::array<size_t, 4> kAlignments = {256, 512, 1024, 4096};
+  constexpr int kTrials = 8;
+
+  for (size_t alignment : kAlignments) {
+    for (int i = 0; i < kTrials; ++i) {
+      void* ptr = alloc.AllocateRaw(alignment, 256);
+      ASSERT_NE(ptr, nullptr);
+      EXPECT_TRUE(IsAligned(ptr, alignment))
+          << "ptr=" << ptr << " alignment=" << alignment;
+      alloc.DeallocateRaw(ptr);
+    }
+  }
+
+  alloc.DeallocateRaw(filler);
+}
+
+}  // namespace
+}  // namespace tsl


### PR DESCRIPTION
Add a first test for `BFCAllocator`! 😮 

`BFCAllocator` must respect required alignment, because we want to use it to allocate memory for symmetric collective operation that require 4096 byte alignment. Today we simply round up ALL allocation to 4096 bytes, and hope that BFC will return properly aligned pointer. This is very dangerous.

After this fix it will be possible to share one BFC allocator for regular XLA allocations and symmetric XLA allocation.

- Renamed `unused_alignment` → `alignment` throughout the allocation path
- `FindChunkPtr`: accepts `alignment` parameter. When a free chunk's pointer isn't aligned, computes the required padding, splits off the unaligned prefix as a free chunk, and returns the aligned remainder
- Extend: ensures sub-allocator is asked for at least `kMinAllocationSize` alignment; `CHECKs` that the returned memory meets this minimum