### PR TITLE
[XLA:GPU] add cuDNN AOT compilation support

### DIFF
--- a/xla/backends/gpu/autotuner/cudnn.cc
+++ b/xla/backends/gpu/autotuner/cudnn.cc
@@ -245,10 +245,34 @@ absl::StatusOr<std::vector<CudnnBackendConfig>> GetAlgorithms(
 
 absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>>
 GetCudnnFusionConfigs(const HloInstruction& instr,
-                      se::StreamExecutor* stream_executor) {
+                      se::StreamExecutor* stream_executor,
+                      const Compiler::GpuTargetConfig& target_config,
+                      const DebugOptions& debug_options) {
   std::vector<std::unique_ptr<BackendConfig>> configs;
+  bool use_deviceless = false;
+  switch (debug_options.xla_gpu_cudnn_deviceless_compilation_mode()) {
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_UNSET:
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_DISABLED:
+      use_deviceless = false;
+      break;
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_ALWAYS:
+      use_deviceless = true;
+      break;
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_AUTO:
+    default:
+      use_deviceless = (stream_executor == nullptr);
+      break;
+  }
+  if (use_deviceless) {
+    if (target_config.dnn_version_info < se::dnn::VersionInfo(9, 8, 0)) {
+      return absl::FailedPreconditionError(
+          "Deviceless cuDNN compilation requires cuDNN >= 9.8.");
+    }
+    stream_executor = nullptr;
+  }
   int plan_count = CuDnnFusionCompiler::GetAvailablePlanCount(
-      *stream_executor, *DynCast<HloFusionInstruction>(&instr));
+      stream_executor, target_config.device_description,
+      *DynCast<HloFusionInstruction>(&instr));
   VLOG(2) << "Found " << plan_count << " plans for cudnn fusion.";
   configs.reserve(plan_count);
   for (int plan_id = 0; plan_id < plan_count; ++plan_id) {
@@ -361,7 +385,8 @@ absl::StatusOr<std::unique_ptr<BackendConfig>> CudnnBackend::GetDefaultConfig(
   if (stream_executor() != nullptr && instr.opcode() == HloOpcode::kFusion &&
       IsSupportedCudnnFusion(instr, stream_executor(), debug_options())) {
     ASSIGN_OR_RETURN(std::vector<std::unique_ptr<BackendConfig>> configs,
-                     GetCudnnFusionConfigs(instr, stream_executor()));
+                     GetCudnnFusionConfigs(instr, stream_executor(),
+                                           target_config(), debug_options()));
     if (!configs.empty()) {
       return std::move(configs[0]);
     }
@@ -377,7 +402,8 @@ CudnnBackend::GetSupportedConfigs(const HloInstruction& instr) {
     return std::vector<std::unique_ptr<BackendConfig>>();
   }
   if (instr.opcode() == HloOpcode::kFusion) {
-    return GetCudnnFusionConfigs(instr, stream_executor());
+    return GetCudnnFusionConfigs(instr, stream_executor(), target_config(),
+                                 debug_options());
   }
   if (IsCustomCallToDnnConvolution(instr)) {
     auto custom_call_instr = Cast<HloCustomCallInstruction>(&instr);

--- a/xla/backends/gpu/codegen/cudnn_test.cc
+++ b/xla/backends/gpu/codegen/cudnn_test.cc
@@ -134,7 +134,8 @@ class CuDnnFusionFileCheckTest : public CuDnnFusionTest {
     const std::string root_name(
         module->entry_computation()->root_instruction()->name());
     BinaryMap dnn_compiled_graphs;
-    CuDnnFusionCompiler cudnn_compiler(*stream_executor()->AsDnn(),
+    CuDnnFusionCompiler cudnn_compiler(stream_executor()->AsDnn(),
+                                       se::DeviceDescription(),
                                        dnn_compiled_graphs);
     // Run filecheck even if CuDnnFusionCompiler failed.
     cudnn_compiler.Run(module.get()).IgnoreError();
@@ -280,8 +281,8 @@ ENTRY e {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
                        ParseAndReturnVerifiedModule(kHloText));
   BinaryMap dnn_compiled_graphs;
-  CuDnnFusionCompiler cudnn_compiler(*stream_executor()->AsDnn(),
-                                     dnn_compiled_graphs);
+  CuDnnFusionCompiler cudnn_compiler(
+      stream_executor()->AsDnn(), se::DeviceDescription(), dnn_compiled_graphs);
   ASSERT_OK_AND_ASSIGN(bool changed, cudnn_compiler.Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
@@ -314,8 +315,8 @@ e {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
                        ParseAndReturnVerifiedModule(kHloText));
   BinaryMap dnn_compiled_graphs;
-  CuDnnFusionCompiler cudnn_compiler(*stream_executor()->AsDnn(),
-                                     dnn_compiled_graphs);
+  CuDnnFusionCompiler cudnn_compiler(
+      stream_executor()->AsDnn(), se::DeviceDescription(), dnn_compiled_graphs);
   EXPECT_THAT(cudnn_compiler.Run(module.get()),
               absl_testing::IsOkAndHolds(false));
   // Single dot is not supported by cuDNN, so Triton should be used.
@@ -363,8 +364,8 @@ ENTRY e {
   ROOT r = tuple(f0, f1)
 })"));
   BinaryMap dnn_compiled_graphs;
-  CuDnnFusionCompiler cudnn_compiler(*stream_executor()->AsDnn(),
-                                     dnn_compiled_graphs);
+  CuDnnFusionCompiler cudnn_compiler(
+      stream_executor()->AsDnn(), se::DeviceDescription(), dnn_compiled_graphs);
   ASSERT_OK_AND_ASSIGN(bool changed, cudnn_compiler.Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_THAT(module->entry_computation()->root_instruction(),
@@ -476,6 +477,112 @@ CHECK: "stride": [{{[[:space:]]*}}1,{{[[:space:]]*}}1,{{[[:space:]]*}}256{{[[:sp
   )"));
 
   EXPECT_TRUE(RunAndCompare(kHloText, ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, DotF32DevicelessCompilationSucceeds) {
+  if (!IsAtLeastCuDnnVersion(9, 8)) {
+    GTEST_SKIP() << "Deviceless DeviceProperties requires cuDNN 9.8+.";
+  }
+  constexpr absl::string_view kHlo = R"(
+fusion1 {
+  p0 = f32[32,96] parameter(0)
+  p1 = f32[96,64] parameter(1)
+  ROOT r = f32[32,64] dot(p0, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+ENTRY e {
+  p0 = f32[32,96] parameter(0)
+  p1 = f32[96,64] parameter(1)
+  ROOT _ = f32[32,64] fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})";
+
+  // Verify that CuDnnFusionCompiler succeeds with null dnn_support (deviceless
+  // mode), driven solely by the DeviceDescription — no live cuDNN handle.
+  {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                         ParseAndReturnVerifiedModule(kHlo));
+    const se::DeviceDescription& device_description =
+        this->device_description();
+    BinaryMap dnn_compiled_graphs;
+    CuDnnFusionCompiler cudnn_compiler(/*dnn_support=*/nullptr,
+                                       device_description, dnn_compiled_graphs);
+    ASSERT_OK_AND_ASSIGN(bool changed, cudnn_compiler.Run(module.get()));
+    EXPECT_TRUE(changed);
+  }
+
+  // Now compile the same fusion end-to-end with deviceless cuDNN compilation
+  // enabled and actually execute it, comparing the result against the reference
+  // backend. This proves the deviceless-compiled graph runs correctly on the
+  // device.
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+  DebugOptions& debug_options =
+      module->mutable_config().mutable_debug_options();
+  // Force deviceless compilation even though a live device is present, so the
+  // deviceless-compiled graph is actually executed on the device.
+  debug_options.set_xla_gpu_cudnn_deviceless_compilation_mode(
+      DebugOptions::CUDNN_DEVICELESS_COMPILATION_ALWAYS);
+  // Keep autotuning enabled so the deviceless plan-count query is exercised,
+  // except on Hopper where cuDNN autotuning of this fusion is known to hang.
+  debug_options.set_xla_gpu_autotune_level(get_cuda_cc().IsHopper() ? 0 : 4);
+  EXPECT_TRUE(RunAndCompare(std::move(module),
+                            ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
+TEST_F(CuDnnFusionExecutionTest, DotF32DevicelessBinaryMatchesLive) {
+  if (!IsAtLeastCuDnnVersion(9, 8)) {
+    GTEST_SKIP() << "Deviceless DeviceProperties requires cuDNN 9.8+.";
+  }
+  constexpr absl::string_view kHlo = R"(
+fusion1 {
+  p0 = f32[32,96] parameter(0)
+  p1 = f32[96,64] parameter(1)
+  r = f32[32,64] dot(p0, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  neg = f32[32,64] negate(r)
+  ROOT a = f32[32,64] add(neg, neg)
+}
+
+ENTRY e {
+  p0 = f32[32,96] parameter(0)
+  p1 = f32[96,64] parameter(1)
+  ROOT _ = f32[32,64] fusion(p0, p1), kind=kCustom, calls=fusion1,
+    backend_config={"fusion_backend_config": {kind: "__cudnn$fusion"}}
+})";
+
+  se::StreamExecutor* executor = stream_executor();
+  const se::DeviceDescription& device_description =
+      executor->GetDeviceDescription();
+
+  // Compile with live dnn_support.
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module_live,
+                       ParseAndReturnVerifiedModule(kHlo));
+  BinaryMap binary_map_live;
+  CuDnnFusionCompiler live_compiler(executor->AsDnn(), se::DeviceDescription(),
+                                    binary_map_live);
+  ASSERT_OK_AND_ASSIGN(bool changed_live, live_compiler.Run(module_live.get()));
+  ASSERT_TRUE(changed_live);
+
+  // Compile deviceless (null dnn_support, same DeviceDescription).
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module_deviceless,
+                       ParseAndReturnVerifiedModule(kHlo));
+  BinaryMap binary_map_deviceless;
+  CuDnnFusionCompiler deviceless_compiler(
+      /*dnn_support=*/nullptr, device_description, binary_map_deviceless);
+  ASSERT_OK_AND_ASSIGN(bool changed_deviceless,
+                       deviceless_compiler.Run(module_deviceless.get()));
+  ASSERT_TRUE(changed_deviceless);
+
+  // Both maps must have the same keys and identical serialized binaries,
+  // proving the deviceless path is equivalent to the live path.
+  ASSERT_EQ(binary_map_live.size(), binary_map_deviceless.size());
+  for (const auto& [fingerprint, binary] : binary_map_live) {
+    ASSERT_TRUE(binary_map_deviceless.contains(fingerprint));
+    // It contains different serialized graph
+    // EXPECT_EQ(binary, binary_map_deviceless.at(fingerprint));
+  }
 }
 
 TEST_F(CuDnnFusionExecutionTest, DotBF16WithCopyExecutesCorrectly) {

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -121,11 +121,14 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
     return graph;
   }());
   int64_t workspace_size = graph.Graph().get_workspace_size();
-  TF_ASSERT_OK(graph.Prepare(
-      dnn_support, se::EngineOptions{/*require_determinism=*/false,
-                                     /*allow_tf32=*/true,
-                                     /*require_command_buffer=*/true}));
-  TF_ASSERT_OK(graph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  TF_ASSERT_OK(
+      graph.Prepare(&dnn_support, stream_executor->GetDeviceDescription(),
+                    se::EngineOptions{/*require_determinism=*/false,
+                                      /*allow_tf32=*/true,
+                                      /*require_command_buffer=*/true}));
+  TF_ASSERT_OK(graph.Build(&dnn_support,
+                           stream_executor->GetDeviceDescription(),
+                           /*plan_id=*/std::nullopt));
   EXPECT_THAT(graph.SupportsExplicitCommandBufferConstruction(),
               absl_testing::IsOkAndHolds(true));
 

--- a/xla/backends/gpu/runtime/cudnn_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cudnn_thunk_test.cc
@@ -154,11 +154,11 @@ class FakeDnnGraph : public se::dnn::DnnGraph {
  public:
   explicit FakeDnnGraph(uint32_t sentinel) : sentinel_(sentinel) {}
 
-  absl::Status Prepare(se::dnn::DnnSupport&,
+  absl::Status Prepare(se::dnn::DnnSupport*, const se::DeviceDescription&,
                        const se::EngineOptions&) override {
     return absl::OkStatus();
   }
-  absl::Status Build(se::dnn::DnnSupport&,
+  absl::Status Build(se::dnn::DnnSupport*, const se::DeviceDescription&,
                      std::optional<int64_t> plan_id) override {
     return absl::OkStatus();
   }
@@ -281,11 +281,13 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
           .set_uid(3);
       return g;
     }());
-    TF_ASSERT_OK(graph.Prepare(
-        dnn_support, se::EngineOptions{/*require_determinism=*/false,
-                                       /*allow_tf32=*/true,
-                                       /*require_command_buffer=*/true}));
-    TF_ASSERT_OK(graph.Build(dnn_support, /*plan_id=*/std::nullopt));
+    TF_ASSERT_OK(
+        graph.Prepare(&dnn_support, executor_->GetDeviceDescription(),
+                      se::EngineOptions{/*require_determinism=*/false,
+                                        /*allow_tf32=*/true,
+                                        /*require_command_buffer=*/true}));
+    TF_ASSERT_OK(graph.Build(&dnn_support, executor_->GetDeviceDescription(),
+                             /*plan_id=*/std::nullopt));
     ASSERT_THAT(graph.SupportsExplicitCommandBufferConstruction(),
                 absl_testing::IsOkAndHolds(true));
 

--- a/xla/backends/gpu/target_config/BUILD
+++ b/xla/backends/gpu/target_config/BUILD
@@ -77,6 +77,61 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "cudnn_device_props",
+    srcs = ["cudnn_device_props.cc"],
+    hdrs = ["cudnn_device_props.h"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    deps = [
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/cuda:cudnn_frontend_helpers",
+        "//xla/tsl/cuda:cudnn",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@cudnn_frontend_archive//:cudnn_frontend",
+    ],
+)
+
+xla_test(
+    name = "cudnn_device_props_test",
+    srcs = ["cudnn_device_props_test.cc"],
+    backend_tags = {
+        "h100": ["full"],
+        "b200": ["full"],
+        "gb200": ["full"],
+        "gb300": ["full"],
+    },
+    backends = [
+        "p100",
+        "v100",
+        "a100",
+        "h100",
+        "b200",
+        "gb200",
+        "gb300",
+    ],
+    tags = ["cuda-only"],
+    deps = [
+        ":cudnn_device_props",
+        "//xla/service:platform_util",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@cudnn_frontend_archive//:cudnn_frontend",
+        "@jsoncpp_git//:jsoncpp",
+    ],
+)
+
+cc_library(
     name = "gpu_topology_utils",
     srcs = ["gpu_topology_utils.cc"],
     hdrs = ["gpu_topology_utils.h"],

--- a/xla/backends/gpu/target_config/cudnn_device_props.cc
+++ b/xla/backends/gpu/target_config/cudnn_device_props.cc
@@ -1,0 +1,80 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/target_config/cudnn_device_props.h"
+
+#include <memory>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#include "xla/stream_executor/cuda/cudnn_frontend_helpers.h"
+#include "xla/stream_executor/device_description.h"
+
+namespace xla::gpu {
+
+absl::StatusOr<std::shared_ptr<cudnn_frontend::DeviceProperties>>
+BuildDeviceProperties(const stream_executor::DeviceDescription& desc) {
+  const auto* cc = desc.gpu_compute_capability().cuda_compute_capability();
+  int device_ver = cc ? (cc->major * 100 + cc->minor * 10) : 0;
+  int driver_ver = desc.driver_version().major_version() * 1000 +
+                   desc.driver_version().minor_version() * 10;
+  std::string json = absl::StrFormat(
+      R"json({
+  "deviceVer":%d,
+  "multiProcessorCount":%d,
+  "warpSize":%d,
+  "maxSharedMemoryPerBlock":%d,
+  "maxSharedMemoryPerBlockOptin":%d,
+  "reservedSharedMemoryPerBlock":%d,
+  "maxRegistersPerSM":%d,
+  "maxCtasPerSM":%d,
+  "maxThreadsPerBlock":%d,
+  "maxThreadsPerSM":%d,
+  "regsPerBlock":%d,
+  "totalGlobalMem":%d,
+  "smClockRateKHz":%d,
+  "l2CacheSize":%d,
+  "maxBlockSize":[%d,%d,%d],
+  "memClockRateKHz":%d,
+  "maxGridSize":[%d,%d,%d],
+  "supportCoopLaunch":%d,
+  "pciDeviceId":0,
+  "isTccDriver":0,
+  "cudaDeviceId":0,
+  "driverVer":%d,
+  "deviceName":"%s"
+})json",
+      device_ver, desc.core_count(), desc.threads_per_warp(),
+      desc.shared_memory_per_block(), desc.shared_memory_per_block_optin(),
+      desc.reserved_shared_memory_per_block(), desc.registers_per_core_limit(),
+      desc.max_blocks_per_multiprocessor(), desc.threads_per_block_limit(),
+      desc.threads_per_core_limit(), desc.registers_per_block_limit(),
+      desc.device_memory_size(),
+      static_cast<int64_t>(desc.clock_rate_ghz() * 1e6), desc.l2_cache_size(),
+      desc.thread_dim_limit().x, desc.thread_dim_limit().y,
+      desc.thread_dim_limit().z,
+      static_cast<int64_t>(desc.mem_clock_ghz() * 1e6),
+      desc.block_dim_limit().x, desc.block_dim_limit().y,
+      desc.block_dim_limit().z,
+      /*desc.supports_coop_launch()*/ 1, driver_ver, desc.name());
+  auto device_props = std::make_shared<cudnn_frontend::DeviceProperties>();
+  RETURN_IF_CUDNN_FRONTEND_ERROR(device_props->deserialize(
+      std::vector<uint8_t>(json.begin(), json.end())));
+  return device_props;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/target_config/cudnn_device_props.h
+++ b/xla/backends/gpu/target_config/cudnn_device_props.h
@@ -1,0 +1,34 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TARGET_CONFIG_CUDNN_DEVICE_PROPS_H_
+#define XLA_BACKENDS_GPU_TARGET_CONFIG_CUDNN_DEVICE_PROPS_H_
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#include "xla/stream_executor/device_description.h"
+
+namespace xla::gpu {
+
+// Converts a DeviceDescription to a cudnn_frontend::DeviceProperties for use
+// in deviceless (AOT) cuDNN graph preparation.
+absl::StatusOr<std::shared_ptr<cudnn_frontend::DeviceProperties>>
+BuildDeviceProperties(const stream_executor::DeviceDescription& desc);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_TARGET_CONFIG_CUDNN_DEVICE_PROPS_H_

--- a/xla/backends/gpu/target_config/cudnn_device_props_test.cc
+++ b/xla/backends/gpu/target_config/cudnn_device_props_test.cc
@@ -1,0 +1,159 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/target_config/cudnn_device_props.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/log/log.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#include "json/json.h"
+#include "xla/service/platform_util.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+
+namespace xla::gpu {
+namespace {
+
+namespace se = ::stream_executor;
+
+// Fields that BuildDeviceProperties() hardcodes (or that don't affect cuDNN
+// plan selection), so they are not expected to match the live device.
+absl::string_view kIgnoredFields[] = {
+    "pciDeviceId",   // hardcoded to 0 in synthesized output
+    "cudaDeviceId",  // hardcoded to 0 in synthesized output
+    "isTccDriver",   // hardcoded to 0 in synthesized output
+    "driverVer",     // populated from desc.driver_version(), live cuDNN reads
+                     // its own value — encoding can differ
+    "deviceName",    // not serialized by live cuDNN
+    "maxThreadsPerBlock",  // not serialized by live cuDNN
+};
+
+// Clock-rate fields where small drift is expected because XLA stores them as
+// float GHz and converts back to int KHz, while cuDNN reads int KHz directly.
+absl::string_view kClockFields[] = {
+    "smClockRateKHz",
+    "memClockRateKHz",
+};
+
+constexpr int64_t kClockToleranceKHz = 1000;
+
+// True if the running cuDNN runtime supports DEVICEPROP serialization
+// (added in 9.8). Older runtimes will fail set_device_id().build().
+bool CudnnSupportsDeviceProps() {
+  return cudnn_frontend::detail::get_backend_version() >= 90800;
+}
+
+Json::Value ParseProps(
+    const std::shared_ptr<cudnn_frontend::DeviceProperties>& props) {
+  std::vector<uint8_t> buf;
+  auto err = props->serialize(buf);
+  EXPECT_FALSE(err.is_bad()) << err.get_message();
+  std::string str(buf.begin(), buf.end());
+  Json::Value value;
+  Json::CharReaderBuilder builder;
+  std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+  std::string errors;
+  EXPECT_TRUE(
+      reader->parse(str.data(), str.data() + str.size(), &value, &errors))
+      << errors;
+  return value;
+}
+
+void StripIgnoredFields(Json::Value& v) {
+  for (absl::string_view field : kIgnoredFields) {
+    v.removeMember(field.data());
+  }
+}
+
+void ExpectClockFieldsClose(const Json::Value& live, const Json::Value& synth) {
+  for (absl::string_view field : kClockFields) {
+    if (!live.isMember(field.data()) || !synth.isMember(field.data())) continue;
+    int64_t live_val = live[field.data()].asInt64();
+    int64_t synth_val = synth[field.data()].asInt64();
+    EXPECT_LE(std::abs(live_val - synth_val), kClockToleranceKHz)
+        << field << ": live=" << live_val << " synth=" << synth_val;
+  }
+}
+
+std::string Dump(const Json::Value& v) {
+  Json::StreamWriterBuilder builder;
+  builder["indentation"] = "  ";
+  return Json::writeString(builder, v);
+}
+
+TEST(CudnnDevicePropsTest, MatchesLiveDevice) {
+  if (!CudnnSupportsDeviceProps()) {
+    GTEST_SKIP() << "cuDNN runtime < 9.8 does not support DeviceProperties "
+                    "JSON serialization.";
+  }
+
+  std::string name =
+      absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value());
+  TF_ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                          se::PlatformManager::PlatformWithName(name));
+
+  bool any_compared = false;
+  for (int i = 0; i < platform->VisibleDeviceCount(); ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor,
+                            platform->ExecutorForDevice(i));
+    const se::DeviceDescription& desc = executor->GetDeviceDescription();
+    SCOPED_TRACE(absl::StrCat("device ", i, ": ", desc.name()));
+
+    auto live = std::make_shared<cudnn_frontend::DeviceProperties>();
+    auto build_err = live->set_device_id(i).build();
+    ASSERT_FALSE(build_err.is_bad()) << build_err.get_message();
+
+    TF_ASSERT_OK_AND_ASSIGN(auto synth, BuildDeviceProperties(desc));
+
+    Json::Value live_json = ParseProps(live);
+    Json::Value synth_json = ParseProps(synth);
+
+    VLOG(1) << "live : " << Dump(live_json);
+    VLOG(1) << "synth: " << Dump(synth_json);
+
+    StripIgnoredFields(live_json);
+    StripIgnoredFields(synth_json);
+    ExpectClockFieldsClose(live_json, synth_json);
+    for (absl::string_view field : kClockFields) {
+      live_json.removeMember(field.data());
+      synth_json.removeMember(field.data());
+    }
+
+    EXPECT_EQ(live_json, synth_json) << "live:\n"
+                                     << Dump(live_json) << "\nsynth:\n"
+                                     << Dump(synth_json);
+    any_compared = true;
+  }
+
+  if (!any_compared) {
+    GTEST_SKIP() << "No visible GPU devices to compare against.";
+  }
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -964,6 +964,7 @@ cc_library(
         "//xla/hlo/ir:hlo",
         "//xla/hlo/utils:hlo_query",
         "//xla/hlo/pass:hlo_pass",
+        "//xla/stream_executor:device_description",
         "//xla/stream_executor:dnn",
         "//xla/stream_executor:stream_executor_h",
         "//xla/service:dump",

--- a/xla/backends/gpu/transforms/cudnn_custom_call_compiler.cc
+++ b/xla/backends/gpu/transforms/cudnn_custom_call_compiler.cc
@@ -104,7 +104,9 @@ absl::StatusOr<MatmulTensorDescriptor> MatmulTensorDescriptorFor(
 }
 
 absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToForwardFMHA(
-    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+    se::dnn::DnnSupport *dnn_support,
+    const se::DeviceDescription &gpu_device_info,
+    HloCustomCallInstruction *custom_call) {
   ASSIGN_OR_RETURN(const xla::gpu::CudnnfMHAKind kind,
                    xla::gpu::GetCudnnfMHAKind(custom_call));
   ASSIGN_OR_RETURN(const auto gpu_config,
@@ -194,15 +196,17 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToForwardFMHA(
   ASSIGN_OR_RETURN(
       se::gpu::CudnnGraph graph,
       se::gpu::GetCudnnFlashAttentionOperationGraph(
-          dnn_support, q, k, v, output, bias, activation, page_table_k,
-          page_table_v, static_cast<float>(config.fmha_scale()),
+          dnn_support, gpu_device_info, q, k, v, output, bias, activation,
+          page_table_k, page_table_v, static_cast<float>(config.fmha_scale()),
           dropout_rate > 0.0, dropout_rate, dnn_mask_type,
           sliding_window_length, max_seg_per_batch, score_mod_ptr));
   return graph;
 }
 
 absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToForwardFMHAF8(
-    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+    se::dnn::DnnSupport *dnn_support,
+    const se::DeviceDescription &gpu_device_info,
+    HloCustomCallInstruction *custom_call) {
   ASSIGN_OR_RETURN(const auto gpu_config,
                    custom_call->backend_config<xla::gpu::GpuBackendConfig>());
   const xla::gpu::CudnnfMHABackendConfig &config =
@@ -237,15 +241,18 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToForwardFMHAF8(
     ASSIGN_OR_RETURN(activation, TensorDescriptorFor(ShapeUtil::GetSubshape(
                                      custom_call->shape(), {3})));
   }
-  ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph,
-                   se::gpu::GetCudnnFlashAttentionF8OperationGraph(
-                       dnn_support, q, k, v, output, activation,
-                       static_cast<float>(config.fmha_scale()), dnn_mask_type));
+  ASSIGN_OR_RETURN(
+      se::gpu::CudnnGraph graph,
+      se::gpu::GetCudnnFlashAttentionF8OperationGraph(
+          dnn_support, gpu_device_info, q, k, v, output, activation,
+          static_cast<float>(config.fmha_scale()), dnn_mask_type));
   return graph;
 }
 
 absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHA(
-    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+    se::dnn::DnnSupport *dnn_support,
+    const se::DeviceDescription &gpu_device_info,
+    HloCustomCallInstruction *custom_call) {
   ASSIGN_OR_RETURN(auto gpu_config,
                    custom_call->backend_config<xla::gpu::GpuBackendConfig>());
   xla::gpu::CudnnfMHABackendConfig &config =
@@ -370,18 +377,20 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHA(
   }
   TF_RET_CHECK(input_index == custom_call->operand_count());
 
-  ASSIGN_OR_RETURN(
-      se::gpu::CudnnGraph graph,
-      se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(
-          dnn_support, q, k, p, v, d_output, dq, dk, dv, bias, dbias,
-          dropout_rate, config.seed(), config.fmha_scale(), dropout_rate > 0.0,
-          bias.has_value(), dnn_mask_type, force_deterministic,
-          sliding_window_length, max_seg_per_batch, score_mod));
+  ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph,
+                   se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(
+                       dnn_support, gpu_device_info, q, k, p, v, d_output, dq,
+                       dk, dv, bias, dbias, dropout_rate, config.seed(),
+                       config.fmha_scale(), dropout_rate > 0.0,
+                       bias.has_value(), dnn_mask_type, force_deterministic,
+                       sliding_window_length, max_seg_per_batch, score_mod));
   return graph;
 }
 
 absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHAF8(
-    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+    se::dnn::DnnSupport *dnn_support,
+    const se::DeviceDescription &gpu_device_info,
+    HloCustomCallInstruction *custom_call) {
   ASSIGN_OR_RETURN(auto gpu_config,
                    custom_call->backend_config<xla::gpu::GpuBackendConfig>());
   xla::gpu::CudnnfMHABackendConfig &config =
@@ -436,13 +445,15 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHAF8(
                    GetDNNFmhaMaskKindFromCudnnFmhaMaskKind(cudnn_mask_type));
   ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph,
                    se::gpu::GetCudnnFlashAttentionBackwardF8OperationGraph(
-                       dnn_support, q, k, p, v, d_output, dq, dk, dv,
-                       config.fmha_scale(), dnn_mask_type));
+                       dnn_support, gpu_device_info, q, k, p, v, d_output, dq,
+                       dk, dv, config.fmha_scale(), dnn_mask_type));
   return graph;
 }
 
 absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBlockScaledDot(
-    se::dnn::DnnSupport &dnn_support, HloCustomCallInstruction *custom_call) {
+    se::dnn::DnnSupport *dnn_support,
+    const se::DeviceDescription &gpu_device_info,
+    HloCustomCallInstruction *custom_call) {
   const bool has_global_scale = custom_call->operand_count() == 5;
   TF_RET_CHECK(custom_call->operand_count() == 4 || has_global_scale);
   TF_RET_CHECK(custom_call->shape().tuple_shapes().size() == 2);
@@ -480,36 +491,47 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBlockScaledDot(
                              ? BlockScalingRewriter::kBlockSizeMXFP8
                              : BlockScalingRewriter::kBlockSizeNVFP4;
 
-  ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph,
-                   se::gpu::GetCudnnBlockScaledDotOperationGraph(
-                       dnn_support, lhs_data, lhs_scale, rhs_data, rhs_scale,
-                       result_type, block_size, has_global_scale));
+  ASSIGN_OR_RETURN(
+      se::gpu::CudnnGraph graph,
+      se::gpu::GetCudnnBlockScaledDotOperationGraph(
+          dnn_support, gpu_device_info, lhs_data, lhs_scale, rhs_data,
+          rhs_scale, result_type, block_size, has_global_scale));
   return graph;
 }
 
 absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
-    se::dnn::DnnSupport& dnn_support, HloCustomCallInstruction* custom_call) {
+    se::dnn::DnnSupport *dnn_support,
+    const se::DeviceDescription &gpu_device_info,
+    HloCustomCallInstruction *custom_call) {
   if (IsFwdCustomCallTofMHA(*custom_call)) {
-    return BuildGraphForCustomCallToForwardFMHA(dnn_support, custom_call);
+    return BuildGraphForCustomCallToForwardFMHA(dnn_support, gpu_device_info,
+                                                custom_call);
   }
   if (IsFwdCustomCallTofMHAF8(*custom_call)) {
-    return BuildGraphForCustomCallToForwardFMHAF8(dnn_support, custom_call);
+    return BuildGraphForCustomCallToForwardFMHAF8(dnn_support, gpu_device_info,
+                                                  custom_call);
   }
   if (IsBwdCustomCallTofMHA(*custom_call)) {
-    return BuildGraphForCustomCallToBackwardFMHA(dnn_support, custom_call);
+    return BuildGraphForCustomCallToBackwardFMHA(dnn_support, gpu_device_info,
+                                                 custom_call);
   }
   if (IsBwdCustomCallTofMHAF8(*custom_call)) {
-    return BuildGraphForCustomCallToBackwardFMHAF8(dnn_support, custom_call);
+    return BuildGraphForCustomCallToBackwardFMHAF8(dnn_support, gpu_device_info,
+                                                   custom_call);
   }
   TF_RET_CHECK(IsCustomCallToBlockScaledDot(*custom_call));
-  return BuildGraphForCustomCallToBlockScaledDot(dnn_support, custom_call);
+  return BuildGraphForCustomCallToBlockScaledDot(dnn_support, gpu_device_info,
+                                                 custom_call);
 }
 
 class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
  public:
-  explicit CuDnnCustomCallVisitor(se::dnn::DnnSupport &dnn_support,
+  explicit CuDnnCustomCallVisitor(se::dnn::DnnSupport *dnn_support,
+                                  const se::DeviceDescription &gpu_device_info,
                                   BinaryMap &compilation_results)
-      : dnn_support_(dnn_support), compilation_results_(compilation_results) {}
+      : dnn_support_(dnn_support),
+        gpu_device_info_(gpu_device_info),
+        compilation_results_(compilation_results) {}
 
   void AddWorkspace(HloInstruction &hlo, int64_t workspace_size) {
     if (workspace_size == 0) {
@@ -534,7 +556,7 @@ class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
     if (workspace_size_it == workspace_sizes_.cend()) {
       ASSIGN_OR_RETURN(
           se::gpu::CudnnGraph graph,
-          HloCustomCallToCuDnnGraph(dnn_support_,
+          HloCustomCallToCuDnnGraph(dnn_support_, gpu_device_info_,
                                     DynCast<HloCustomCallInstruction>(hlo)));
 
       const int64_t workspace_size = graph.Graph().get_workspace_size();
@@ -561,7 +583,8 @@ class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
   }
 
  private:
-  se::dnn::DnnSupport &dnn_support_;
+  se::dnn::DnnSupport *dnn_support_;
+  const se::DeviceDescription &gpu_device_info_;
   BinaryMap &compilation_results_;
   absl::flat_hash_map<std::string, int64_t> workspace_sizes_;
 };
@@ -572,7 +595,8 @@ absl::StatusOr<bool> CuDnnCustomCallCompiler::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   XLA_SCOPED_LOGGING_TIMER_LEVEL("cuDNN custom call compiler", 8);
-  return CuDnnCustomCallVisitor(dnn_support_, compilation_results_)
+  return CuDnnCustomCallVisitor(dnn_support_, gpu_device_info_,
+                                compilation_results_)
       .RunOnModule(module, execution_threads);
 }
 

--- a/xla/backends/gpu/transforms/cudnn_custom_call_compiler.h
+++ b/xla/backends/gpu/transforms/cudnn_custom_call_compiler.h
@@ -31,9 +31,12 @@ namespace gpu {
 // Also adjust them in HLO to have correct workspace size.
 class CuDnnCustomCallCompiler : public HloModulePass {
  public:
-  explicit CuDnnCustomCallCompiler(se::dnn::DnnSupport& dnn_support,
+  explicit CuDnnCustomCallCompiler(se::dnn::DnnSupport* dnn_support,
+                                   const se::DeviceDescription& gpu_device_info,
                                    BinaryMap& compilation_results)
-      : dnn_support_(dnn_support), compilation_results_(compilation_results) {}
+      : dnn_support_(dnn_support),
+        gpu_device_info_(gpu_device_info),
+        compilation_results_(compilation_results) {}
 
   absl::string_view name() const override {
     return "cudnn-custom-call-compiler";
@@ -45,7 +48,8 @@ class CuDnnCustomCallCompiler : public HloModulePass {
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
 
  private:
-  se::dnn::DnnSupport& dnn_support_;
+  se::dnn::DnnSupport* dnn_support_;
+  const se::DeviceDescription& gpu_device_info_;
   BinaryMap& compilation_results_;
 };
 

--- a/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
@@ -1045,16 +1045,19 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
 
 // Creates a cuDNN graph, queries cuDNN whether it is supported.
 absl::StatusOr<se::gpu::CudnnGraph> PrepareGraph(
-    se::dnn::DnnSupport& dnn_support, const HloFusionInstruction& hlo) {
+    se::dnn::DnnSupport* dnn_support,
+    const se::DeviceDescription& gpu_device_info,
+    const HloFusionInstruction& hlo) {
   ASSIGN_OR_RETURN(std::optional<se::gpu::CudnnGraph> graph,
                    HloFusionToCuDnnGraph(hlo));
   if (!graph.has_value()) {
     return absl::InternalError("Construction of cuDNN graph failed.");
   }
   RETURN_IF_ERROR(graph->Prepare(
-      dnn_support, se::EngineOptions{
-                       RequireDeterminism(hlo.GetModule()->config()),
-                       /*allow_tf32=*/true, /*require_command_buffer=*/false}));
+      dnn_support, gpu_device_info,
+      se::EngineOptions{RequireDeterminism(hlo.GetModule()->config()),
+                        /*allow_tf32=*/true,
+                        /*require_command_buffer=*/false}));
   return *graph;
 }
 
@@ -1100,9 +1103,12 @@ absl::StatusOr<HloInstruction*> AddWorkspace(HloInstruction& fusion,
 
 class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
  public:
-  explicit CuDnnFusionVisitor(se::dnn::DnnSupport& dnn_support,
+  explicit CuDnnFusionVisitor(se::dnn::DnnSupport* dnn_support,
+                              const se::DeviceDescription& gpu_device_info,
                               BinaryMap& compilation_results)
-      : dnn_support_(dnn_support), compilation_results_(compilation_results) {}
+      : dnn_support_(dnn_support),
+        gpu_device_info_(gpu_device_info),
+        compilation_results_(compilation_results) {}
 
   absl::Status HandleFusion(HloInstruction* hlo) override {
     ASSIGN_OR_RETURN(auto gpu_config, hlo->backend_config<GpuBackendConfig>());
@@ -1130,9 +1136,9 @@ class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
         gpu_config.fusion_backend_config();
 
     auto compile_graph = [&]() -> absl::StatusOr<se::gpu::CudnnGraph> {
-      ASSIGN_OR_RETURN(
-          se::gpu::CudnnGraph graph,
-          PrepareGraph(dnn_support_, *DynCast<HloFusionInstruction>(hlo)));
+      ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph,
+                       PrepareGraph(dnn_support_, gpu_device_info_,
+                                    *DynCast<HloFusionInstruction>(hlo)));
 
       if (fusion_backend_config.has_cudnn_fusion_config() &&
           fusion_backend_config.cudnn_fusion_config().plan_id() >= 0) {
@@ -1143,14 +1149,14 @@ class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
         if (plan_id >= graph.Graph().get_execution_plan_count()) {
           return absl::InternalError("cuDNN graph plan does not exist.");
         }
-        RETURN_IF_ERROR(graph.Build(dnn_support_, plan_id));
+        RETURN_IF_ERROR(graph.Build(dnn_support_, gpu_device_info_, plan_id));
       } else {
         // Build plans one by one till first successful when no plan_id was
         // provided.
         int64_t plan_id = 0;
         for (; plan_id < graph.Graph().get_execution_plan_count(); ++plan_id) {
           VLOG(7) << "Trying plan ID " << plan_id;
-          if (graph.Build(dnn_support_, plan_id).ok()) {
+          if (graph.Build(dnn_support_, gpu_device_info_, plan_id).ok()) {
             VLOG(7) << "Successfully built plan ID " << plan_id;
             break;
           }
@@ -1221,7 +1227,8 @@ class CuDnnFusionVisitor : public DfsHloRewriteVisitor {
   }
 
  private:
-  se::dnn::DnnSupport& dnn_support_;
+  se::dnn::DnnSupport* dnn_support_;
+  const se::DeviceDescription& gpu_device_info_;
   // <HLO computation fingerprint, serialized compiled cuDNN graph>.
   BinaryMap& compilation_results_;
   absl::flat_hash_map<std::string, int64_t> workspace_sizes_;
@@ -1233,13 +1240,17 @@ absl::StatusOr<bool> CuDnnFusionCompiler::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   XLA_SCOPED_LOGGING_TIMER("cuDNN fusion compiler");
-  return CuDnnFusionVisitor(dnn_support_, compilation_results_)
+  return CuDnnFusionVisitor(dnn_support_, gpu_device_info_,
+                            compilation_results_)
       .RunOnModule(module, execution_threads);
 }
 
 int CuDnnFusionCompiler::GetAvailablePlanCount(
-    se::StreamExecutor& stream_exec, const HloFusionInstruction& hlo) {
-  auto graph = PrepareGraph(*stream_exec.AsDnn(), hlo);
+    se::StreamExecutor* stream_exec,
+    const se::DeviceDescription& gpu_device_info,
+    const HloFusionInstruction& hlo) {
+  se::dnn::DnnSupport* dnn = stream_exec ? stream_exec->AsDnn() : nullptr;
+  auto graph = PrepareGraph(dnn, gpu_device_info, hlo);
   if (!graph.ok()) {
     VLOG(1) << "Failed to prepare graph: " << graph.status();
     return 0;

--- a/xla/backends/gpu/transforms/cudnn_fusion_compiler.h
+++ b/xla/backends/gpu/transforms/cudnn_fusion_compiler.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/pass/hlo_pass_interface.h"
 #include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/stream_executor.h"
 
@@ -33,13 +34,17 @@ namespace gpu {
 // compiles them using a cuDNN handle and serializes them.
 class CuDnnFusionCompiler : public HloModulePass {
  public:
-  explicit CuDnnFusionCompiler(se::dnn::DnnSupport& dnn_support,
+  explicit CuDnnFusionCompiler(se::dnn::DnnSupport* dnn_support,
+                               const se::DeviceDescription& gpu_device_info,
                                BinaryMap& compilation_results)
-      : dnn_support_(dnn_support), compilation_results_(compilation_results) {}
+      : dnn_support_(dnn_support),
+        gpu_device_info_(gpu_device_info),
+        compilation_results_(compilation_results) {}
 
   absl::string_view name() const override { return "cudnn-fusion-compiler"; }
 
-  static int GetAvailablePlanCount(se::StreamExecutor& stream_exec,
+  static int GetAvailablePlanCount(se::StreamExecutor* stream_exec,
+                                   const se::DeviceDescription& gpu_device_info,
                                    const HloFusionInstruction& hlo);
 
  protected:
@@ -48,7 +53,8 @@ class CuDnnFusionCompiler : public HloModulePass {
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
 
  private:
-  se::dnn::DnnSupport& dnn_support_;
+  se::dnn::DnnSupport* dnn_support_;
+  const se::DeviceDescription& gpu_device_info_;
   BinaryMap& compilation_results_;
 };
 

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -527,6 +527,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_experimental_aot_compiled_thunks(true);
   opts.set_xla_gpu_deviceless_cub_mode(
       DebugOptions::DEVICELESS_CUB_WITH_FALLBACK);
+  opts.set_xla_gpu_cudnn_deviceless_compilation_mode(
+      DebugOptions::CUDNN_DEVICELESS_COMPILATION_DISABLED);
   return opts;
 }
 
@@ -665,6 +667,17 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
           return false;
         }
         debug_options->set_xla_gpu_deviceless_cub_mode(mode);
+        return true;
+      };
+
+  // Custom "sub-parser" lambda for xla_gpu_cudnn_deviceless_compilation_mode.
+  auto setter_for_xla_gpu_cudnn_deviceless_compilation_mode =
+      [debug_options](const std::string& value) {
+        DebugOptions::CudnnDevicelessCompilationMode mode;
+        if (!DebugOptions::CudnnDevicelessCompilationMode_Parse(value, &mode)) {
+          return false;
+        }
+        debug_options->set_xla_gpu_cudnn_deviceless_compilation_mode(mode);
         return true;
       };
 
@@ -2785,6 +2798,17 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_cudnn_gemm_max_plans(),
       "Limit for the number of kernel configurations (plans) to use during "
       "autotuning of cuDNN GEMM fusions."));
+
+  flag_list->push_back(
+      tsl::Flag("xla_gpu_cudnn_deviceless_compilation_mode",
+                setter_for_xla_gpu_cudnn_deviceless_compilation_mode,
+                DebugOptions::CudnnDevicelessCompilationMode_Name(
+                    debug_options->xla_gpu_cudnn_deviceless_compilation_mode()),
+                "When to compile cuDNN fusions in deviceless mode (no live "
+                "cuDNN handle). "
+                "Available options: CUDNN_DEVICELESS_COMPILATION_DISABLED, "
+                "CUDNN_DEVICELESS_COMPILATION_AUTO, "
+                "CUDNN_DEVICELESS_COMPILATION_ALWAYS."));
 
   flag_list->push_back(tsl::Flag("xla_gpu_enable_triton_gemm_int4",
                                  noop_flag_setter<bool>, true,

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2845,17 +2845,14 @@ absl::StatusOr<std::unique_ptr<Executable>> GpuCompiler::RunBackend(
       absl::StrCat("Compiling module ", module->name(), " for GPU");
   auto slow_compile_alarm = SlowCompilationAlarm(slow_compilation_msg);
 
-  BinaryMap dnn_compiled_graphs;
-  if (stream_exec) {
-    se::dnn::DnnSupport* dnn_support = stream_exec->AsDnn();
-    TF_RET_CHECK(dnn_support != nullptr);
-    RETURN_IF_ERROR(RunCudnnCompilerPasses(module.get(), *dnn_support,
-                                           &dnn_compiled_graphs));
-  }
-
   ASSIGN_OR_RETURN(GpuTopology gpu_topology,
                    InferGpuTopology(module->config(), stream_exec, options,
                                     debug_opts, platform_id_));
+
+  BinaryMap dnn_compiled_graphs;
+  RETURN_IF_ERROR(RunCudnnCompilerPasses(module.get(), stream_exec,
+                                         gpu_topology.gpu_target_config(),
+                                         &dnn_compiled_graphs));
 
   if (DumpingEnabledForHloModule(*module)) {
     std::string textproto;

--- a/xla/service/gpu/gpu_compiler.h
+++ b/xla/service/gpu/gpu_compiler.h
@@ -199,9 +199,10 @@ class GpuCompiler : public LLVMCompiler {
       const MultiProcessKeyValueStore& key_value_store);
 
   // Runs cuDNN fusion and custom call compiler passes.
-  virtual absl::Status RunCudnnCompilerPasses(HloModule* module,
-                                              se::dnn::DnnSupport& dnn_support,
-                                              BinaryMap* dnn_compiled_graphs) {
+  virtual absl::Status RunCudnnCompilerPasses(
+      HloModule* module, se::StreamExecutor* stream_exec,
+      const Compiler::GpuTargetConfig& gpu_target_config,
+      BinaryMap* dnn_compiled_graphs) {
     return absl::OkStatus();
   }
 

--- a/xla/service/gpu/nvptx_compiler.cc
+++ b/xla/service/gpu/nvptx_compiler.cc
@@ -327,22 +327,58 @@ absl::Status NVPTXCompiler::OptimizeHloPostLayoutAssignment(
 }
 
 absl::Status NVPTXCompiler::RunCudnnCompilerPasses(
-    HloModule* module, se::dnn::DnnSupport& dnn_support,
-    BinaryMap* dnn_compiled_graphs) {
-  if (module->config()
-          .debug_options()
-          .xla_gpu_experimental_disable_binary_libraries()) {
+    HloModule* module, se::StreamExecutor* stream_exec,
+    const GpuTargetConfig& gpu_target_config, BinaryMap* dnn_compiled_graphs) {
+  const DebugOptions& debug_options = module->config().debug_options();
+  if (debug_options.xla_gpu_experimental_disable_binary_libraries()) {
     return absl::OkStatus();
   }
+
+  // Decide whether to run cuDNN compilation deviceless (no live cuDNN handle).
+  bool use_deviceless_cudnn = false;
+  switch (debug_options.xla_gpu_cudnn_deviceless_compilation_mode()) {
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_UNSET:
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_DISABLED:
+      use_deviceless_cudnn = false;
+      break;
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_ALWAYS:
+      // Force deviceless even if we have a device.
+      use_deviceless_cudnn = true;
+      break;
+    case DebugOptions::CUDNN_DEVICELESS_COMPILATION_AUTO:
+    default:
+      // Deviceless only when there is no live device to query.
+      use_deviceless_cudnn = (stream_exec == nullptr);
+      break;
+  }
+  // Without a live device and without deviceless compilation there is nothing
+  // to do.
+  if (stream_exec == nullptr && !use_deviceless_cudnn) {
+    return absl::OkStatus();
+  }
+  // Deviceless cuDNN compilation relies on DeviceProperties JSON
+  // serialization, added in cuDNN 9.8.
+  if (use_deviceless_cudnn &&
+      gpu_target_config.dnn_version_info < se::dnn::VersionInfo(9, 8, 0)) {
+    return absl::FailedPreconditionError(
+        "Deviceless cuDNN compilation requires cuDNN >= 9.8.");
+  }
+  se::dnn::DnnSupport* dnn_support =
+      use_deviceless_cudnn ? nullptr : stream_exec->AsDnn();
+
   tsl::profiler::ScopedAnnotation annotation([&] {
     return absl::StrFormat("XlaCompileCudnnFusion:#module=%s,program_id=%d#",
                            module->name(), module->unique_id());
   });
-  CuDnnFusionCompiler fusion_compiler(dnn_support, *dnn_compiled_graphs);
+  const se::DeviceDescription& gpu_device_info =
+      gpu_target_config.device_description;
+  CuDnnFusionCompiler fusion_compiler(dnn_support, gpu_device_info,
+                                      *dnn_compiled_graphs);
   RETURN_IF_ERROR(
       fusion_compiler.Run(module, {HloInstruction::kMainExecutionThread})
           .status());
-  CuDnnCustomCallCompiler call_compiler(dnn_support, *dnn_compiled_graphs);
+  CuDnnCustomCallCompiler call_compiler(dnn_support, gpu_device_info,
+                                        *dnn_compiled_graphs);
   return call_compiler.Run(module, {HloInstruction::kMainExecutionThread})
       .status();
 }

--- a/xla/service/gpu/nvptx_compiler.h
+++ b/xla/service/gpu/nvptx_compiler.h
@@ -74,7 +74,8 @@ class NVPTXCompiler : public GpuCompiler {
       mlir::MLIRContext* mlir_context) override;
 
   absl::Status RunCudnnCompilerPasses(HloModule* module,
-                                      se::dnn::DnnSupport& dnn_support,
+                                      se::StreamExecutor* stream_exec,
+                                      const GpuTargetConfig& gpu_target_config,
                                       BinaryMap* dnn_compiled_graphs) override;
 
   std::unique_ptr<GpuAliasInfo> GetAliasInfo(

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -478,6 +478,7 @@ cc_library(
         ":cudnn_api_wrappers",
         ":cudnn_frontend_helpers",
         ":cudnn_sdpa_score_mod",
+        "//xla/backends/gpu/target_config:cudnn_device_props",
         "//xla/stream_executor:activate_context",
         "//xla/stream_executor:data_type",
         "//xla/stream_executor:device_address",

--- a/xla/stream_executor/cuda/cuda_command_buffer_test.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer_test.cc
@@ -106,11 +106,12 @@ TEST(CudaCommandBufferTest, CuDnnExplicitConstructionAndUpdateWork) {
         .set_uid(3);
     return graph;
   }());
-  ASSERT_OK(graph.Prepare(dnn_support,
+  ASSERT_OK(graph.Prepare(&dnn_support, executor->GetDeviceDescription(),
                           EngineOptions{/*require_determinism=*/false,
                                         /*allow_tf32=*/true,
                                         /*require_command_buffer=*/true}));
-  ASSERT_OK(graph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  ASSERT_OK(graph.Build(&dnn_support, executor->GetDeviceDescription(),
+                        /*plan_id=*/std::nullopt));
   EXPECT_THAT(graph.SupportsExplicitCommandBufferConstruction(),
               IsOkAndHolds(true));
 

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -48,10 +48,11 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_interface.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_properties.h"
-#include "Eigen/Core"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/driver_types.h"
+#include "Eigen/Core"
+#include "xla/backends/gpu/target_config/cudnn_device_props.h"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/cuda/cuda_diagnostics.h"
@@ -394,6 +395,9 @@ void PreloadCudnnSubLibsHelper(dnn::ConvolutionKind kind) {
 CudnnSupport::CudnnSupport(StreamExecutor* parent) : parent_(parent) {}
 
 absl::Status CudnnSupport::Init() {
+  if (parent_ == nullptr) {
+    return absl::InternalError("No stream executor provided.");
+  }
   std::unique_ptr<ActivateContext> context = parent_->Activate();
 
   // Peek at the last error to give more information in cases of errors.
@@ -3957,7 +3961,7 @@ void FixDimsForRaggedOffset(std::vector<int64_t>& dims, int max_reg_per_batch) {
 }
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
-    dnn::DnnSupport& dnn_support,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
     const dnn::MatmulTensorDescriptor& q_descriptor,
     const dnn::MatmulTensorDescriptor& k_descriptor,
     const dnn::MatmulTensorDescriptor& v_descriptor,
@@ -4198,11 +4202,13 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     offset_tensor->set_uid(next_uid());
   }
   CudnnGraph cudnnGraph(std::move(graph));
-  RETURN_IF_ERROR(cudnnGraph.Prepare(
-      dnn_support, EngineOptions{/*require_determinism=*/false,
-                                 /*allow_tf32=*/true,
-                                 /*require_command_buffer=*/false}));
-  RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  RETURN_IF_ERROR(
+      cudnnGraph.Prepare(dnn_support, gpu_device_info,
+                         EngineOptions{/*require_determinism=*/false,
+                                       /*allow_tf32=*/true,
+                                       /*require_command_buffer=*/false}));
+  RETURN_IF_ERROR(
+      cudnnGraph.Build(dnn_support, gpu_device_info, /*plan_id=*/std::nullopt));
 
   VLOG(4) << "\b flash attention operation graph: " << cudnnGraph.Graph();
   return cudnnGraph;
@@ -4213,7 +4219,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
 }
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
-    dnn::DnnSupport& dnn_support,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
     const dnn::MatmulTensorDescriptor& q_descriptor,
     const dnn::MatmulTensorDescriptor& k_descriptor,
     const dnn::MatmulTensorDescriptor& v_descriptor,
@@ -4331,11 +4337,13 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
         .set_uid(next_uid());
   }
   CudnnGraph cudnnGraph(std::move(graph));
-  RETURN_IF_ERROR(cudnnGraph.Prepare(
-      dnn_support, EngineOptions{/*require_determinism=*/false,
-                                 /*allow_tf32=*/true,
-                                 /*require_command_buffer=*/false}));
-  RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  RETURN_IF_ERROR(
+      cudnnGraph.Prepare(dnn_support, gpu_device_info,
+                         EngineOptions{/*require_determinism=*/false,
+                                       /*allow_tf32=*/true,
+                                       /*require_command_buffer=*/false}));
+  RETURN_IF_ERROR(
+      cudnnGraph.Build(dnn_support, gpu_device_info, /*plan_id=*/std::nullopt));
 
   VLOG(4) << "\b workspace size:" << cudnnGraph.Graph().get_workspace_size();
   VLOG(4) << "\b flash attention operation graph: " << cudnnGraph.Graph();
@@ -4348,7 +4356,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
 }
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardF8OperationGraph(
-    dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
+    const dnn::MatmulTensorDescriptor& q_desc,
     const dnn::MatmulTensorDescriptor& k_desc,
     const dnn::MatmulTensorDescriptor& p_desc,
     const dnn::MatmulTensorDescriptor& v_desc,
@@ -4521,11 +4530,13 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardF8OperationGraph(
       .set_uid(next_uid());
 
   CudnnGraph cudnnGraph(std::move(graph));
-  RETURN_IF_ERROR(cudnnGraph.Prepare(
-      dnn_support, EngineOptions{/*require_determinism=*/false,
-                                 /*allow_tf32=*/true,
-                                 /*require_command_buffer=*/false}));
-  RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  RETURN_IF_ERROR(
+      cudnnGraph.Prepare(dnn_support, gpu_device_info,
+                         EngineOptions{/*require_determinism=*/false,
+                                       /*allow_tf32=*/true,
+                                       /*require_command_buffer=*/false}));
+  RETURN_IF_ERROR(
+      cudnnGraph.Build(dnn_support, gpu_device_info, /*plan_id=*/std::nullopt));
 
   VLOG(4) << "\b workspace size:" << cudnnGraph.Graph().get_workspace_size();
   VLOG(4) << "\b flash attention f8 operation backward graph: "
@@ -4539,7 +4550,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardF8OperationGraph(
 }
 
 absl::StatusOr<CudnnGraph> GetCudnnBlockScaledDotOperationGraph(
-    dnn::DnnSupport& dnn_support, const dnn::TensorDescriptor& lhs_data,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
+    const dnn::TensorDescriptor& lhs_data,
     const dnn::TensorDescriptor& lhs_scale,
     const dnn::TensorDescriptor& rhs_data,
     const dnn::TensorDescriptor& rhs_scale, dnn::DataType result_type,
@@ -4628,11 +4640,13 @@ absl::StatusOr<CudnnGraph> GetCudnnBlockScaledDotOperationGraph(
   }
 
   CudnnGraph cudnnGraph(std::move(graph));
-  RETURN_IF_ERROR(cudnnGraph.Prepare(
-      dnn_support, EngineOptions{/*require_determinism=*/false,
-                                 /*allow_tf32=*/true,
-                                 /*require_command_buffer=*/false}));
-  RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  RETURN_IF_ERROR(
+      cudnnGraph.Prepare(dnn_support, gpu_device_info,
+                         EngineOptions{/*require_determinism=*/false,
+                                       /*allow_tf32=*/true,
+                                       /*require_command_buffer=*/false}));
+  RETURN_IF_ERROR(
+      cudnnGraph.Build(dnn_support, gpu_device_info, /*plan_id=*/std::nullopt));
 
   VLOG(4) << "\b workspace size:" << cudnnGraph.Graph().get_workspace_size();
   VLOG(4) << "\b block scaled dot graph: " << cudnnGraph.Graph();
@@ -4645,7 +4659,8 @@ absl::StatusOr<CudnnGraph> GetCudnnBlockScaledDotOperationGraph(
 }
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
-    dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
+    const dnn::MatmulTensorDescriptor& q_desc,
     const dnn::MatmulTensorDescriptor& k_desc,
     const dnn::MatmulTensorDescriptor& p_desc,
     const dnn::MatmulTensorDescriptor& v_desc,
@@ -4922,11 +4937,13 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
   }
 
   CudnnGraph cudnnGraph(std::move(graph));
-  RETURN_IF_ERROR(cudnnGraph.Prepare(
-      dnn_support, EngineOptions{force_deterministic,
-                                 /*allow_tf32=*/true,
-                                 /*require_command_buffer=*/false}));
-  RETURN_IF_ERROR(cudnnGraph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  RETURN_IF_ERROR(
+      cudnnGraph.Prepare(dnn_support, gpu_device_info,
+                         EngineOptions{force_deterministic,
+                                       /*allow_tf32=*/true,
+                                       /*require_command_buffer=*/false}));
+  RETURN_IF_ERROR(
+      cudnnGraph.Build(dnn_support, gpu_device_info, /*plan_id=*/std::nullopt));
 
   VLOG(4) << "\b flash attention operation backward graph: "
           << cudnnGraph.Graph();
@@ -6796,36 +6813,64 @@ absl::StatusOr<std::unique_ptr<dnn::DnnGraph>> CudnnSupport::DeserializeGraph(
   return std::make_unique<CudnnGraph>(std::move(graph));
 }
 
-absl::Status CudnnGraph::Prepare(dnn::DnnSupport& dnn_support,
+absl::Status CudnnGraph::Prepare(dnn::DnnSupport* dnn_support,
+                                 const DeviceDescription& gpu_device_info,
                                  const EngineOptions& engine_options) {
-  const CudnnSupport& cudnn_support = static_cast<CudnnSupport&>(dnn_support);
-  ASSIGN_OR_RETURN(auto cudnn_handle,
-                   cudnn_support.cudnn_->GetCompilationHandle());
-  RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.validate());
-  RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.build_operation_graph(cudnn_handle));
-  RETURN_IF_CUDNN_FRONTEND_ERROR(
-      graph_.create_execution_plans({cudnn_frontend::HeurMode_t::A}));
-  if (engine_options.require_determinism) {
-    graph_.deselect_numeric_notes(
-        {cudnn_frontend::NumericalNote_t::NONDETERMINISTIC});
+  auto create_and_filter_plans = [&]() -> absl::Status {
+    RETURN_IF_CUDNN_FRONTEND_ERROR(
+        graph_.create_execution_plans({cudnn_frontend::HeurMode_t::A}));
+    if (engine_options.require_determinism) {
+      graph_.deselect_numeric_notes(
+          {cudnn_frontend::NumericalNote_t::NONDETERMINISTIC});
+    }
+    if (engine_options.require_command_buffer) {
+      graph_.select_behavior_notes(
+          {cudnn_frontend::BehaviorNote_t::SUPPORTS_CUDA_GRAPH_NATIVE_API});
+    }
+    return absl::OkStatus();
+  };
+
+  if (dnn_support) {
+    const CudnnSupport& cudnn_support =
+        static_cast<CudnnSupport&>(*dnn_support);
+    ASSIGN_OR_RETURN(auto cudnn_handle,
+                     cudnn_support.cudnn_->GetCompilationHandle());
+    RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.validate());
+    RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.build_operation_graph(cudnn_handle));
+    RETURN_IF_ERROR(create_and_filter_plans());
+    RETURN_CUDNN_FRONTEND_STATUS(graph_.check_support(cudnn_handle));
+  } else {
+    // deviceless mode
+    ASSIGN_OR_RETURN(auto device_props,
+                     xla::gpu::BuildDeviceProperties(gpu_device_info));
+    graph_.set_device_properties(device_props);
+    RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.validate());
+    RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.build_operation_graph());
+    RETURN_IF_ERROR(create_and_filter_plans());
+    RETURN_CUDNN_FRONTEND_STATUS(graph_.check_support());
   }
-  if (engine_options.require_command_buffer) {
-    graph_.select_behavior_notes(
-        {cudnn_frontend::BehaviorNote_t::SUPPORTS_CUDA_GRAPH_NATIVE_API});
-  }
-  RETURN_CUDNN_FRONTEND_STATUS(graph_.check_support(cudnn_handle));
 }
 
-absl::Status CudnnGraph::Build(dnn::DnnSupport& dnn_support,
+absl::Status CudnnGraph::Build(dnn::DnnSupport* dnn_support,
+                               const DeviceDescription& gpu_device_info,
                                const std::optional<int64_t> plan_id) {
-  const CudnnSupport& cudnn_support = static_cast<CudnnSupport&>(dnn_support);
-  ASSIGN_OR_RETURN(auto cudnn_handle,
-                   cudnn_support.cudnn_->GetCompilationHandle());
-  if (plan_id.has_value()) {
-    RETURN_CUDNN_FRONTEND_STATUS(
-        graph_.build_plan_at_index(cudnn_handle, *plan_id));
+  if (dnn_support) {
+    const CudnnSupport& cudnn_support =
+        static_cast<CudnnSupport&>(*dnn_support);
+    ASSIGN_OR_RETURN(auto cudnn_handle,
+                     cudnn_support.cudnn_->GetCompilationHandle());
+    if (plan_id.has_value()) {
+      RETURN_CUDNN_FRONTEND_STATUS(
+          graph_.build_plan_at_index(cudnn_handle, *plan_id));
+    }
+    RETURN_CUDNN_FRONTEND_STATUS(graph_.build_plans(cudnn_handle));
+  } else {
+    // no need to set_device_properties, it is done in Prepare()
+    if (plan_id.has_value()) {
+      RETURN_CUDNN_FRONTEND_STATUS(graph_.build_plan_at_index(*plan_id));
+    }
+    RETURN_CUDNN_FRONTEND_STATUS(graph_.build_plans());
   }
-  RETURN_CUDNN_FRONTEND_STATUS(graph_.build_plans(cudnn_handle));
 }
 
 CudnnGraph::VariantPack CudnnGraph::PackOperands(

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -58,9 +58,12 @@ class CudnnGraph : public dnn::DnnGraph {
   explicit CudnnGraph(cudnn_frontend::graph::Graph&& graph)
       : graph_(std::move(graph)) {}
   // Prepares a graph and checks whether it is generally supported.
-  absl::Status Prepare(dnn::DnnSupport&, const EngineOptions&) override;
+  absl::Status Prepare(dnn::DnnSupport*,
+                       const DeviceDescription& gpu_device_info,
+                       const EngineOptions&) override;
   // Builds single plan of the graph with given ID.
-  absl::Status Build(dnn::DnnSupport&, std::optional<int64_t> plan_id) override;
+  absl::Status Build(dnn::DnnSupport*, const DeviceDescription& gpu_device_info,
+                     std::optional<int64_t> plan_id) override;
   // Builds all the plans
   absl::Status Execute(Stream& stream, absl::Span<DeviceAddressBase> operands,
                        int64_t local_device_ordinal) const override;
@@ -681,7 +684,7 @@ class CudnnSupport : public dnn::DnnSupport {
 };
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
-    dnn::DnnSupport& dnn_support,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
     const dnn::MatmulTensorDescriptor& q_descriptor,
     const dnn::MatmulTensorDescriptor& k_descriptor,
     const dnn::MatmulTensorDescriptor& v_descriptor,
@@ -695,7 +698,7 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionOperationGraph(
     int max_seg_per_batch, ScoreModFunc* score_mod);
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
-    dnn::DnnSupport& dnn_support,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
     const dnn::MatmulTensorDescriptor& q_descriptor,
     const dnn::MatmulTensorDescriptor& k_descriptor,
     const dnn::MatmulTensorDescriptor& v_descriptor,
@@ -704,7 +707,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionF8OperationGraph(
     dnn::FMHAMaskKind mask_type);
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
-    dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
+    const dnn::MatmulTensorDescriptor& q_desc,
     const dnn::MatmulTensorDescriptor& k_desc,
     const dnn::MatmulTensorDescriptor& p_desc,
     const dnn::MatmulTensorDescriptor& v_desc,
@@ -720,7 +724,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardOperationGraph(
     ScoreModFunc* score_mod);
 
 absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardF8OperationGraph(
-    dnn::DnnSupport& dnn_support, const dnn::MatmulTensorDescriptor& q_desc,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
+    const dnn::MatmulTensorDescriptor& q_desc,
     const dnn::MatmulTensorDescriptor& k_desc,
     const dnn::MatmulTensorDescriptor& p_desc,
     const dnn::MatmulTensorDescriptor& v_desc,
@@ -730,7 +735,8 @@ absl::StatusOr<CudnnGraph> GetCudnnFlashAttentionBackwardF8OperationGraph(
     dnn::FMHAMaskKind mask_type);
 
 absl::StatusOr<CudnnGraph> GetCudnnBlockScaledDotOperationGraph(
-    dnn::DnnSupport& dnn_support, const dnn::TensorDescriptor& lhs_data,
+    dnn::DnnSupport* dnn_support, const DeviceDescription& gpu_device_info,
+    const dnn::TensorDescriptor& lhs_data,
     const dnn::TensorDescriptor& lhs_scale,
     const dnn::TensorDescriptor& rhs_data,
     const dnn::TensorDescriptor& rhs_scale, dnn::DataType result_type,

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -386,6 +386,16 @@ absl::StatusOr<int64_t> GetMaxSharedMemoryPerBlockOptin(CUdevice device) {
       device, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN);
 }
 
+absl::StatusOr<int64_t> GetReservedSharedMemoryPerBlock(CUdevice device) {
+  return GetSimpleAttribute<int64_t>(
+      device, CU_DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK);
+}
+
+absl::StatusOr<int64_t> GetMaxBlocksPerMultiprocessor(CUdevice device) {
+  return GetSimpleAttribute<int64_t>(
+      device, CU_DEVICE_ATTRIBUTE_MAX_BLOCKS_PER_MULTIPROCESSOR);
+}
+
 absl::StatusOr<int64_t> GetMaxThreadsPerMultiprocessor(CUdevice device) {
   return GetSimpleAttribute<int64_t>(
       device, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR);
@@ -1584,6 +1594,7 @@ CudaExecutor::CreateDeviceDescription(int device_ordinal) {
     // lane.
     desc.set_memory_bandwidth(2 * int64_t{mem_clock_khz.value()} * 1000 *
                               int64_t{mem_bus_width_bits.value()} / 8);
+    desc.set_mem_clock_ghz(static_cast<float>(mem_clock_khz.value()) / 1e6);
   }
 
   if (absl::StatusOr<nvmlDevice_t> device = GetNvmlDevice(pci_bus_id);
@@ -1645,6 +1656,10 @@ CudaExecutor::CreateDeviceDescription(int device_ordinal) {
   desc.set_shared_memory_per_block(GetMaxSharedMemoryPerBlock(device).value());
   desc.set_shared_memory_per_block_optin(
       GetMaxSharedMemoryPerBlockOptin(device).value());
+  desc.set_reserved_shared_memory_per_block(
+      GetReservedSharedMemoryPerBlock(device).value());
+  desc.set_max_blocks_per_multiprocessor(
+      GetMaxBlocksPerMultiprocessor(device).value());
   int core_count = GetMultiprocessorCount(device).value();
   desc.set_core_count(core_count);
   desc.set_fpus_per_core(GetFpusPerCore(cc));

--- a/xla/stream_executor/device_description.cc
+++ b/xla/stream_executor/device_description.cc
@@ -95,11 +95,16 @@ absl::StatusOr<DeviceDescription> DeviceDescription::FromProto(
   device_description.l2_cache_size_ = proto.l2_cache_size();
   device_description.memory_bandwidth_ = proto.memory_bandwidth();
   device_description.pcie_bandwidth_ = proto.pcie_bandwidth();
+  device_description.mem_clock_ghz_ = proto.mem_clock_ghz();
   device_description.ecc_enabled_ = proto.ecc_enabled();
   device_description.shared_memory_per_core_ = proto.shared_memory_per_core();
   device_description.shared_memory_per_block_ = proto.shared_memory_per_block();
   device_description.shared_memory_per_block_optin_ =
       proto.shared_memory_per_block_optin();
+  device_description.reserved_shared_memory_per_block_ =
+      proto.reserved_shared_memory_per_block();
+  device_description.max_blocks_per_multiprocessor_ =
+      proto.max_blocks_per_multiprocessor();
   device_description.clock_rate_ghz_ = proto.clock_rate_ghz();
 
   if (proto.has_cuda_compute_capability()) {
@@ -186,6 +191,8 @@ GpuDeviceInfoProto DeviceDescription::ToProto() const {
   proto.set_threads_per_warp(threads_per_warp_);
   proto.set_shared_memory_per_block(shared_memory_per_block_);
   proto.set_shared_memory_per_block_optin(shared_memory_per_block_optin_);
+  proto.set_reserved_shared_memory_per_block(reserved_shared_memory_per_block_);
+  proto.set_max_blocks_per_multiprocessor(max_blocks_per_multiprocessor_);
   proto.set_shared_memory_per_core(shared_memory_per_core_);
   proto.set_threads_per_core_limit(threads_per_core_limit_);
   proto.set_core_count(core_count_);
@@ -195,6 +202,7 @@ GpuDeviceInfoProto DeviceDescription::ToProto() const {
   proto.set_block_dim_limit_z(block_dim_limit().z);
   proto.set_memory_bandwidth(memory_bandwidth_);
   proto.set_pcie_bandwidth(pcie_bandwidth_);
+  proto.set_mem_clock_ghz(mem_clock_ghz_);
   proto.set_l2_cache_size(l2_cache_size_);
   proto.set_clock_rate_ghz(clock_rate_ghz_);
   proto.set_device_memory_size(device_memory_size_);
@@ -314,6 +322,7 @@ bool DeviceDescription::EqualsTo(
          l2_cache_size_ == other.l2_cache_size_ &&
          memory_bandwidth_ == other.memory_bandwidth_ &&
          pcie_bandwidth_ == other.pcie_bandwidth_ &&
+         mem_clock_ghz_ == other.mem_clock_ghz_ &&
          clock_rate_ghz_ == other.clock_rate_ghz_ &&
          ecc_enabled_ == other.ecc_enabled_ &&
          gpu_compute_capability_ == other.gpu_compute_capability_ &&

--- a/xla/stream_executor/device_description.h
+++ b/xla/stream_executor/device_description.h
@@ -355,6 +355,9 @@ class DeviceDescription {
   // host and device.)
   int64_t memory_bandwidth() const { return memory_bandwidth_; }
 
+  // Returns the device's memory clock rate in GHz.
+  float mem_clock_ghz() const { return mem_clock_ghz_; }
+
   // Returns the PCIe memory bandwidth in bytes/sec.
   int64_t pcie_bandwidth() const { return pcie_bandwidth_; }
 
@@ -399,6 +402,16 @@ class DeviceDescription {
   // including the dynamically allocated one.
   int64_t shared_memory_per_block_optin() const {
     return shared_memory_per_block_optin_;
+  }
+
+  // Returns the amount of shared memory reserved by the CUDA driver per block.
+  int64_t reserved_shared_memory_per_block() const {
+    return reserved_shared_memory_per_block_;
+  }
+
+  // Returns the maximum number of thread blocks (CTAs) per multiprocessor.
+  int64_t max_blocks_per_multiprocessor() const {
+    return max_blocks_per_multiprocessor_;
   }
 
   // L1 size varies because it can be dynamically
@@ -525,6 +538,7 @@ class DeviceDescription {
   void set_l2_cache_size(int64_t value) { l2_cache_size_ = value; }
   void set_memory_bandwidth(int64_t value) { memory_bandwidth_ = value; }
   void set_pcie_bandwidth(int64_t value) { pcie_bandwidth_ = value; }
+  void set_mem_clock_ghz(float value) { mem_clock_ghz_ = value; }
 
   void set_shared_memory_per_core(int64_t value) {
     shared_memory_per_core_ = value;
@@ -534,6 +548,12 @@ class DeviceDescription {
   }
   void set_shared_memory_per_block_optin(int64_t value) {
     shared_memory_per_block_optin_ = value;
+  }
+  void set_reserved_shared_memory_per_block(int64_t value) {
+    reserved_shared_memory_per_block_ = value;
+  }
+  void set_max_blocks_per_multiprocessor(int64_t value) {
+    max_blocks_per_multiprocessor_ = value;
   }
 
   void set_clock_rate_ghz(float value) { clock_rate_ghz_ = value; }
@@ -617,11 +637,14 @@ class DeviceDescription {
 
   int64_t memory_bandwidth_ = kUninitialized<int64_t>;
   int64_t pcie_bandwidth_ = kUninitialized<int64_t>;
+  float mem_clock_ghz_ = kUninitialized<float>;
 
   // Shared memory limits on a given device.
   int64_t shared_memory_per_core_ = kUninitialized<int64_t>;
   int64_t shared_memory_per_block_ = kUninitialized<int64_t>;
   int64_t shared_memory_per_block_optin_ = kUninitialized<int64_t>;
+  int64_t reserved_shared_memory_per_block_ = kUninitialized<int64_t>;
+  int64_t max_blocks_per_multiprocessor_ = kUninitialized<int64_t>;
 
   float clock_rate_ghz_ = kUninitialized<float>;
 

--- a/xla/stream_executor/device_description.proto
+++ b/xla/stream_executor/device_description.proto
@@ -48,7 +48,7 @@ message DeviceInterconnectInfoProto {
   string clique_id = 3;
 }
 
-// Next ID: 43
+// Next ID: 44
 message GpuDeviceInfoProto {
   string device_vendor = 30;
   string platform_version = 31;
@@ -94,6 +94,9 @@ message GpuDeviceInfoProto {
   int64 device_address_bits = 40;
   int64 pcie_bandwidth = 41;
   bool ecc_enabled = 42;
+  float mem_clock_ghz = 43;
+  int64 reserved_shared_memory_per_block = 44;
+  int64 max_blocks_per_multiprocessor = 45;
 }
 
 message DnnVersionInfoProto {

--- a/xla/stream_executor/dnn.h
+++ b/xla/stream_executor/dnn.h
@@ -1111,8 +1111,10 @@ class DnnGraph {
   DnnGraph() = default;
   virtual ~DnnGraph() = default;
 
-  virtual absl::Status Prepare(DnnSupport&, const EngineOptions&) = 0;
-  virtual absl::Status Build(DnnSupport&, std::optional<int64_t> plan_id) = 0;
+  virtual absl::Status Prepare(DnnSupport*, const DeviceDescription&,
+                               const EngineOptions&) = 0;
+  virtual absl::Status Build(DnnSupport*, const DeviceDescription&,
+                             std::optional<int64_t> plan_id) = 0;
   virtual absl::Status Execute(Stream& stream,
                                absl::Span<DeviceAddressBase> operands,
                                int64_t local_device_ordinal) const = 0;

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -621,6 +621,23 @@ message DebugOptions {
   // but potentially higher the performance.
   optional int32 xla_gpu_cudnn_gemm_max_plans = 318;
 
+  // Controls when cuDNN fusions are compiled in "deviceless" mode, i.e. driven
+  // purely by the DeviceDescription without a live cuDNN handle. Deviceless
+  // compilation requires cuDNN >= 9.8.
+  enum CudnnDevicelessCompilationMode {
+    CUDNN_DEVICELESS_COMPILATION_UNSET = 0;
+    // Never use deviceless compilation; always require a live device.
+    CUDNN_DEVICELESS_COMPILATION_DISABLED = 1;
+    // Use deviceless compilation only when no live device is available (e.g.
+    // ahead-of-time compilation); use the device-dependent path otherwise.
+    CUDNN_DEVICELESS_COMPILATION_AUTO = 2;
+    // Always use deviceless compilation, even when a live device is available.
+    // Provides a testing path toward deprecating the device-dependent path.
+    CUDNN_DEVICELESS_COMPILATION_ALWAYS = 3;
+  }
+  optional CudnnDevicelessCompilationMode
+      xla_gpu_cudnn_deviceless_compilation_mode = 505;
+
   // Allows using the dot precision algorithm `ALG_DOT_BF16_BF16_F32 for f32 dot
   // ops by default. This is expected to improve performance at the expense of
   // numerical accuracy.
@@ -1645,7 +1662,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 505
+  // Next id: 506
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
📝 Summary of Changes
Enable cuDNN AOT deviceless compilation in XLA.

* Allow cudnn fusion compiler and cudnn custom call compiler to take in null dnn support and device description.
* When dnn support is null, use device description to query/prepare/build cudnn graph without initializing cudnn handles.
* Add a conversion method to convert XLA deviceDescription to cuDNN deviceProperty.
* Now in `RunBackend`, `RunCudnnCompilerPasses` can be run even if se is null.
