### PR TITLE
[ROCm] remove long flag for rocm scaled dot test

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -754,7 +754,6 @@ cc_library(
 
 xla_test(
     name = "hipblaslt_mx_execution_test",
-    timeout = "long",
     srcs = ["hipblaslt_mx_execution_test.cc"],
     backends = [
         "amdgpu_any",
@@ -778,7 +777,6 @@ xla_test(
 
 xla_test(
     name = "hipblaslt_test",
-    timeout = "long",
     srcs = ["hipblaslt_test.cc"],
     backends = [
         "amdgpu_any",


### PR DESCRIPTION
After the hipblaslt update (https://github.com/ROCm/rocm-libraries/commit/e3e085ac1592f3d1189d9e4a6d6c27a202ec696b), the test execution time is significantly reduced, so we remove the `long` tag.

```
//xla/backends/gpu/autotuner:hipblaslt_test
10 tests from 2 test suites ran. (48322 ms total)

//xla/backends/gpu/autotuner:hipblaslt_mx_execution_test
6 tests from 1 test suite ran. (69628 ms total)
```