### PR TITLE
[XLA:GPU][ONEAPI] Oneapi plugin support for Intel GPU (part1) - sycl name changes to oneapi

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1937,7 +1937,7 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
 #if TENSORFLOW_USE_ROCM
   auto pjrt_platform_name = xla::RocmName();
 #elif TENSORFLOW_USE_SYCL
-  auto pjrt_platform_name = xla::SyclName();
+  auto pjrt_platform_name = xla::OneapiName();
 #else   // TENSORFLOW_USE_ROCM
   auto pjrt_platform_name = xla::CudaName();
 #endif  // TENSORFLOW_USE_ROCM

--- a/xla/pjrt/gpu/tfrt/tfrt_gpu_client.cc
+++ b/xla/pjrt/gpu/tfrt/tfrt_gpu_client.cc
@@ -1305,7 +1305,7 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetTfrtGpuClientInternal(
 #if TENSORFLOW_USE_ROCM
   const auto* pjrt_platform_name = xla::RocmName();
 #elif TENSORFLOW_USE_SYCL
-  const auto* pjrt_platform_name = xla::SyclName();
+  const auto* pjrt_platform_name = xla::OneapiName();
 #else   // TENSORFLOW_USE_ROCM
   const auto* pjrt_platform_name = xla::CudaName();
 #endif  // TENSORFLOW_USE_ROCM

--- a/xla/pjrt/pjrt_compiler.h
+++ b/xla/pjrt/pjrt_compiler.h
@@ -63,6 +63,12 @@ inline const char* OneapiName() {
   static constexpr char kOneapiName[] = "oneapi";
   return kOneapiName;
 }
+// Temporarily keep SyclName() as there are references to it in Tensorflow.
+// TODO(intel-tf): Remove this function once Tensorflow is updated to use
+// OneapiName() instead of SyclName()
+inline const char* SyclName() {
+  return OneapiName();
+}
 inline const char* TpuName() {
   static constexpr char kTpuName[] = "tpu";
   return kTpuName;

--- a/xla/pjrt/pjrt_compiler.h
+++ b/xla/pjrt/pjrt_compiler.h
@@ -59,9 +59,9 @@ inline const char* RocmName() {
   static constexpr char kRocmName[] = "rocm";
   return kRocmName;
 }
-inline const char* SyclName() {
-  static constexpr char kSyclName[] = "sycl";
-  return kSyclName;
+inline const char* OneapiName() {
+  static constexpr char kOneapiName[] = "oneapi";
+  return kOneapiName;
 }
 inline const char* TpuName() {
   static constexpr char kTpuName[] = "tpu";
@@ -79,9 +79,16 @@ inline PjRtPlatformId RocmId() {
   static const PjRtPlatformId kRocmId = tsl::Fingerprint64(RocmName());
   return kRocmId;
 }
+inline PjRtPlatformId OneapiId() {
+  static const PjRtPlatformId kOneapiId = tsl::Fingerprint64(OneapiName());
+  return kOneapiId;
+}
+
+// Temporarily keep SyclId() as there are references to it in Jaxlib.
+// TODO(intel-tf): Remove this function once Jaxlib is updated to use
+// OneapId() instead of SyclId()
 inline PjRtPlatformId SyclId() {
-  static const PjRtPlatformId kSyclId = tsl::Fingerprint64(SyclName());
-  return kSyclId;
+  return OneapiId();
 }
 inline PjRtPlatformId TpuId() {
   static const PjRtPlatformId kTpuId = tsl::Fingerprint64(TpuName());

--- a/xla/pjrt/profiling/device_time_measurement.h
+++ b/xla/pjrt/profiling/device_time_measurement.h
@@ -85,7 +85,7 @@ void RecordDeviceTimeMeasurement(
 inline DeviceTimeMeasurement::DeviceType GetDeviceType(
     PjRtPlatformId platform_id) {
   if (platform_id == CudaId() || platform_id == RocmId() ||
-      platform_id == SyclId()) {
+      platform_id == OneapiId()) {
     return DeviceTimeMeasurement::DeviceType::kGpu;
   }
   if (platform_id == TpuId()) {

--- a/xla/python/pjrt_ifrt/pjrt_executable.cc
+++ b/xla/python/pjrt_ifrt/pjrt_executable.cc
@@ -861,7 +861,7 @@ PjRtLoadedExecutable::Execute(absl::Span<ArrayRef> args,
   auto callbacks = std::make_unique<std::vector<void*>>();
   // Forward callbacks via FFI's ExecutionContext for CPU/GPU platforms only.
   if (platform_id == CpuId() || platform_id == CudaId() ||
-      platform_id == RocmId() || platform_id == SyclId()) {
+      platform_id == RocmId() || platform_id == OneapiId()) {
     for (const auto& loaded_host_callback : *all_loaded_host_callbacks_) {
       auto* ffi_loaded_host_callback =
           llvm::dyn_cast<PjRtFfiLoadedHostCallback>(loaded_host_callback.get());

--- a/xla/service/hlo_runner_pjrt.cc
+++ b/xla/service/hlo_runner_pjrt.cc
@@ -938,7 +938,7 @@ bool HloRunnerPjRt::HasProperty(const HloRunnerPropertyTag::Type tag) const {
     return pjrt_client_->platform_name() == CudaName();
   }
   if (tag == HloRunnerPropertyTag::kUsingGpuOneAPI) {
-    return pjrt_client_->platform_name() == SyclName();
+    return pjrt_client_->platform_name() == OneapiName();
   }
   return false;
 }


### PR DESCRIPTION
This PR changes several names from sycl to oneAPI in preparation for adding support for oneAPI in PJRT plugin code.