### PR TITLE
  [XLA:GPU] Fix missing P2P peer access in CudaMemoryReservation::SetAccess

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -859,7 +859,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@local_config_cuda//cuda:cuda_headers",
-        "@tsl//tsl/platform:statusor",
+        "//xla/tsl/platform:status_macros",
     ],
 )
 
@@ -929,6 +929,7 @@ xla_test(
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cuda_headers",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",
     ],

--- a/xla/stream_executor/cuda/cuda_memory_reservation.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation.cc
@@ -23,14 +23,15 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
 #include "xla/stream_executor/cuda/cuda_status.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
-#include "tsl/platform/statusor.h"
 
 namespace stream_executor::gpu {
 namespace {
@@ -52,19 +53,19 @@ CudaMemoryReservation::Create(StreamExecutor* executor, uint64_t size) {
   std::unique_ptr<ActivateContext> activation = executor->Activate();
 
   CUdevice device;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       cuda::ToStatus(cuDeviceGet(&device, executor->device_ordinal())));
 
   CUmemAllocationProp props = BuildAllocationProperties(device);
 
   size_t granularity = 0;
-  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
+  RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
       &granularity, &props, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
 
   uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
 
   CUdeviceptr ptr;
-  TF_RETURN_IF_ERROR(cuda::ToStatus(
+  RETURN_IF_ERROR(cuda::ToStatus(
       cuMemAddressReserve(&ptr, padded_size, granularity, 0, 0)));
 
   return std::unique_ptr<CudaMemoryReservation>(
@@ -96,12 +97,36 @@ absl::Status CudaMemoryReservation::Map(size_t reservation_offset,
 absl::Status CudaMemoryReservation::SetAccess(uint64_t reservation_offset,
                                               size_t size) {
   std::unique_ptr<ActivateContext> activation = executor_->Activate();
+
+  // Always grant access to the local device.
   CUmemAccessDesc desc = {};
   desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   desc.location.id = static_cast<int>(executor_->device_ordinal());
   desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  return cuda::ToStatus(
-      cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1));
+  RETURN_IF_ERROR(
+      cuda::ToStatus(cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
+                     "cuMemSetAccess for local device"));
+
+  // Grant access to all P2P-capable peer devices. VA-mapped memory does not
+  // automatically inherit peer access, so NCCL collective operations using
+  // NVLink to read/write peer GPU buffers will deadlock without this.
+  int device_count = 0;
+  RETURN_IF_ERROR(
+      cuda::ToStatus(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount"));
+  for (int peer = 0; peer < device_count; ++peer) {
+    if (peer == executor_->device_ordinal()) {
+      continue;
+    }
+    if (!executor_->CanEnablePeerAccessTo(peer)) {
+      continue;
+    }
+    desc.location.id = peer;
+    RETURN_IF_ERROR(cuda::ToStatus(
+        cuMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
+        "cuMemSetAccess for peer device"));
+  }
+
+  return absl::OkStatus();
 }
 
 absl::Status CudaMemoryReservation::UnMap(size_t offset, size_t size) {

--- a/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
+++ b/xla/stream_executor/cuda/cuda_memory_reservation_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/types/span.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
 #include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
 #include "xla/stream_executor/device_address.h"
@@ -56,11 +57,11 @@ class CudaMemoryReservationTest : public ::testing::Test {
  protected:
   void SetUp() override {
     TF_ASSERT_OK_AND_ASSIGN(
-        Platform * platform,
-        PlatformManager::PlatformWithId(cuda::kCudaPlatformId));
-    TF_ASSERT_OK_AND_ASSIGN(executor_, platform->ExecutorForDevice(0));
+        platform_, PlatformManager::PlatformWithId(cuda::kCudaPlatformId));
+    TF_ASSERT_OK_AND_ASSIGN(executor_, platform_->ExecutorForDevice(0));
   }
 
+  Platform* platform_ = nullptr;
   StreamExecutor* executor_ = nullptr;
 };
 
@@ -162,6 +163,60 @@ TEST_F(CudaMemoryReservationTest, TwoReservationsDifferentAddresses) {
                           CudaMemoryReservation::Create(executor_, kTestSize));
 
   EXPECT_NE(res1->address().opaque(), res2->address().opaque());
+}
+
+// Verifies that MapTo grants read/write access to the local device via
+// cuMemSetAccess, readable back via cuMemGetAccess.
+TEST_F(CudaMemoryReservationTest, SetAccessGrantsLocalDeviceAccess) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  CUmemLocation loc = {};
+  loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  loc.id = static_cast<int>(executor_->device_ordinal());
+  unsigned long long flags = 0;
+  CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
+  ASSERT_EQ(cuMemGetAccess(&flags, &loc, base_ptr), CUDA_SUCCESS);
+  EXPECT_EQ(flags, static_cast<unsigned long long>(
+                       CU_MEM_ACCESS_FLAGS_PROT_READWRITE));
+}
+
+// Verifies that MapTo grants read/write access to all P2P-capable peer devices,
+// not just the local device. Without this, NVLink P2P accesses to VA-mapped
+// buffers deadlock during NCCL collective operations (AllGather, ReduceScatter,
+// AllReduce).
+TEST_F(CudaMemoryReservationTest, SetAccessGrantsPeerDeviceAccess) {
+  if (platform_->VisibleDeviceCount() < 2) {
+    GTEST_SKIP() << "Test requires at least 2 GPUs, found "
+                 << platform_->VisibleDeviceCount();
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, CudaRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          CudaMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  CUdeviceptr base_ptr = reinterpret_cast<CUdeviceptr>(res->address().opaque());
+  for (int peer = 0; peer < platform_->VisibleDeviceCount(); ++peer) {
+    if (!executor_->CanEnablePeerAccessTo(peer)) continue;
+    CUmemLocation loc = {};
+    loc.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    loc.id = peer;
+    unsigned long long flags = 0;
+    ASSERT_EQ(cuMemGetAccess(&flags, &loc, base_ptr), CUDA_SUCCESS)
+        << "cuMemGetAccess failed for peer device " << peer;
+    EXPECT_EQ(flags, static_cast<unsigned long long>(
+                         CU_MEM_ACCESS_FLAGS_PROT_READWRITE))
+        << "Expected READWRITE access on peer device " << peer;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Problem

When VA remapping is active (CAPTURE_CMD_NEVER_UPDATE + DeviceAddressVmmAllocator), physical memory is mapped to reserved VA ranges via CudaMemoryReservation::MapTo → SetAccess. SetAccess previously called cuMemSetAccess only for the local device, leaving all peer GPUs without read/write access to the VA-mapped addresses.

On multi-GPU nodes with NVLink, NCCL collective operations (AllGather, ReduceScatter, AllReduce) require peer GPUs to directly access each other's buffers via P2P. Without the peer cuMemSetAccess calls, NVLink P2P accesses to VA-mapped buffers silently deadlock, hanging the entire training step indefinitely.

This was observed as a 56-minute hang after the first jit_train_step warmup thunk execution on an 8x B200 single-node FSDP workload (deepseek2-16b FP8 + MaxText).

Fix

In CudaMemoryReservation::SetAccess, iterate over all P2P-capable peer devices and call cuMemSetAccess for each, mirroring the existing behavior in CudaVmmAllocator::VmmAllocate.

Changes

xla/stream_executor/cuda/cuda_memory_reservation.cc: After granting local device access, enumerate all peer devices with cudaGetDeviceCount + CanEnablePeerAccessTo and issue cuMemSetAccess for each P2P-capable peer.