### PR TITLE
[ROCm] Fix rocPRIM API change for scan config in TheRock >= 7.12

### DIFF
--- a/xla/stream_executor/rocm/cub_scan_kernel_rocm_impl.cu.cc
+++ b/xla/stream_executor/rocm/cub_scan_kernel_rocm_impl.cu.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "rocm/include/rocprim/device/detail/device_config_helper.hpp"
 #include "rocm/include/rocprim/device/device_scan.hpp"
 #include "rocm/include/rocprim/functional.hpp"
+#include "rocm/rocm_config.h"
 #include "xla/stream_executor/rocm/cub_scan_kernel_rocm.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/tsl/platform/errors.h"
@@ -34,17 +35,30 @@ namespace stream_executor::rocm {
 
 namespace {
 
-// Architecture-aware tuning from rocPRIM's autotuned scan config.
+// Architecture-aware tuning from rocPRIM's scan config.
 template <typename T>
 struct ScanConfig {
+#if TF_ROCM_VERSION >= 71200
+  static constexpr rocprim::detail::scan_config_params kConfig =
+      rocprim::detail::scan_config_params_base<T>();
+  static constexpr int kBlockSize = kConfig.kernel_config.block_size;
+  static constexpr int kItemsPerThread = kConfig.kernel_config.items_per_thread;
+#else
   using RocprimConfig =
       typename rocprim::detail::default_scan_config_base<T>::type;
   static constexpr int kBlockSize = RocprimConfig::block_size;
   static constexpr int kItemsPerThread = RocprimConfig::items_per_thread;
+#endif
   static constexpr int kTileSize = kBlockSize * kItemsPerThread;
+#if TF_ROCM_VERSION >= 71200
+  static constexpr auto kLoadMethod = kConfig.block_load_method;
+  static constexpr auto kStoreMethod = kConfig.block_store_method;
+  static constexpr auto kScanAlgorithm = kConfig.block_scan_method;
+#else
   static constexpr auto kLoadMethod = RocprimConfig::block_load_method;
   static constexpr auto kStoreMethod = RocprimConfig::block_store_method;
   static constexpr auto kScanAlgorithm = RocprimConfig::block_scan_method;
+#endif
 };
 
 template <typename T>


### PR DESCRIPTION
rocPRIM removed `rocprim::detail::default_scan_config_base<T>` in TheRock 7.12+ and replaced it with the constexpr function `rocprim::detail::scan_config_params_base<T>()`. The new API returns a `scan_config_params` struct where block_size and items_per_thread are nested inside a `kernel_config` member.

Add `#if TF_ROCM_VERSION >= 71200` guards so the scan kernel compiles against both the old (ROCm < 7.12) and new (TheRock >= 7.12) rocPRIM headers.

📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
