### PR TITLE
[XLA:GPU] Migrate MemzeroCmd into MemzeroThunk

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1768,6 +1768,7 @@ xla_test(
         ":memset_thunk",
         ":thunk",
         ":thunk_proto_cc",
+        "//xla:shape_util",
         "//xla/service:buffer_assignment",
         "//xla/service:executable",
         "//xla/service:platform_util",

--- a/xla/backends/gpu/runtime/command_buffer_cmd.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.cc
@@ -45,7 +45,6 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/codegen/kernels/custom_kernel.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/runtime/all_gather_thunk.h"
@@ -112,6 +111,7 @@ limitations under the License.
 #include "xla/stream_executor/trace_command_buffer_factory.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/util/unique_any.h"
 #include "xla/types.h"  // IWYU pragma: keep
@@ -304,45 +304,6 @@ Command::BufferUses CustomKernelLaunchCmd::buffer_uses() const {
     buffers.emplace_back(args_[i].slice, args_access_[i], args_[i].shape);
   }
   return buffers;
-}
-
-//===----------------------------------------------------------------------===//
-// MemzeroCmd
-//===----------------------------------------------------------------------===//
-
-MemzeroCmd::MemzeroCmd(ShapedSlice dst)
-    : Command(CommandType::kMemzeroCmd), dst_(dst) {}
-
-absl::StatusOr<const se::CommandBuffer::Command*> MemzeroCmd::Record(
-    const Thunk::ExecuteParams& execute_params,
-    const RecordParams& record_params, RecordAction record_action,
-    se::CommandBuffer* command_buffer) {
-  se::DeviceAddressBase dst =
-      execute_params.buffer_allocations->GetDeviceAddress(dst_.slice);
-
-  VLOG(5) << "MemzeroCmd:";
-  VLOG(5) << "  Dst: " << dst_ << " (" << dst.opaque() << ")";
-
-  if (dst_.slice.size() == 0) {
-    VLOG(5) << "Skip recording MemzeroCmd command of 0 bytes";
-    return nullptr;
-  }
-
-  return Handle(
-      std::move(record_action),
-      [&](absl::Span<const se::CommandBuffer::Command* const> dependencies) {
-        return command_buffer->CreateMemset(&dst, uint8_t{0},
-                                            /*num_elements=*/dst_.slice.size(),
-                                            dependencies);
-      },
-      [&](const se::CommandBuffer::Command* command) {
-        return command_buffer->UpdateMemset(command, &dst, uint8_t{0},
-                                            /*num_elements=*/dst_.slice.size());
-      });
-}
-
-Command::BufferUses MemzeroCmd::buffer_uses() const {
-  return {BufferUse::Write(dst_.slice, dst_.shape)};
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/runtime/command_buffer_cmd.h
+++ b/xla/backends/gpu/runtime/command_buffer_cmd.h
@@ -105,25 +105,6 @@ class CustomKernelLaunchCmd : public Command {
 };
 
 //===----------------------------------------------------------------------===//
-// MemzeroCmd
-//===----------------------------------------------------------------------===//
-
-class MemzeroCmd : public Command {
- public:
-  explicit MemzeroCmd(ShapedSlice dst);
-
-  absl::StatusOr<const se::CommandBuffer::Command*> Record(
-      const Thunk::ExecuteParams& execute_params,
-      const RecordParams& record_params, RecordAction record_action,
-      se::CommandBuffer* command_buffer) override;
-
-  BufferUses buffer_uses() const override;
-
- private:
-  ShapedSlice dst_;
-};
-
-//===----------------------------------------------------------------------===//
 // ChildCmd
 //===----------------------------------------------------------------------===//
 

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter.cc
@@ -35,7 +35,6 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/types/span.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/runtime/all_gather_thunk.h"
 #include "xla/backends/gpu/runtime/all_reduce_thunk.h"
 #include "xla/backends/gpu/runtime/all_to_all_thunk.h"
@@ -69,6 +68,7 @@ limitations under the License.
 #include "xla/service/buffer_assignment.h"
 #include "xla/status_macros.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 
 namespace xla::gpu {
@@ -110,11 +110,6 @@ static absl::StatusOr<std::unique_ptr<Command>> Convert(
     const DynamicMemcpyThunk& thunk) {
   return std::make_unique<DynamicSliceCopyFusionCmd>(
       thunk.source(), thunk.destination(), thunk.mem_size(), thunk.offsets());
-}
-
-static absl::StatusOr<std::unique_ptr<Command>> Convert(
-    const MemzeroThunk& thunk) {
-  return std::make_unique<MemzeroCmd>(thunk.destination());
 }
 
 static absl::StatusOr<std::unique_ptr<Command>> Convert(
@@ -316,7 +311,8 @@ static absl::Status AppendCommands(ConversionContext& ctx,
     case Thunk::Kind::kCublasLtMatmul:
       return append(Convert<CublasLtMatmulThunk>(thunk));
     case Thunk::Kind::kMemzero:
-      return append(Convert<MemzeroThunk>(thunk));
+      cmd_sequence.Append(static_cast<MemzeroThunk*>(&thunk));
+      return absl::OkStatus();
     case Thunk::Kind::kAllGather:
       return append(Convert<AllGatherThunk>(thunk));
     case Thunk::Kind::kAllReduce:

--- a/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_test.cc
@@ -737,7 +737,8 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
   CommandSequence outer_seq;
   outer_seq.Emplace<ChildCmd>(std::move(middle_executor));
   // Add another command at the outer level that still doesn't affect `c`.
-  outer_seq.Emplace<MemzeroCmd>(ShapedSlice{slice_b, shape});
+  outer_seq.Emplace<MemzeroThunk>(Thunk::ThunkInfo(),
+                                  ShapedSlice{slice_b, shape});
   TF_ASSERT_OK_AND_ASSIGN(
       CommandExecutor outer_executor,
       CommandExecutor::Create(std::move(outer_seq), serialize));
@@ -772,7 +773,7 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
   //
   // Outer graph (graph_1):
   //   Node 0: ChildCmd (graph_2)  -> depends on nothing
-  //   Node 1: MemzeroCmd (MEMSET) -> depends on Node 0
+  //   Node 1: MemzeroThunk (MEMSET) -> depends on Node 0
   //
   // Middle graph (graph_2, nested in ChildCmd):
   //   Node 0: ChildCmd (graph_3)                           -> depends on
@@ -788,10 +789,10 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
     ASSERT_NE(gpu_cmd_buffer, nullptr)
         << "Expected command buffer to be a GpuCommandBuffer";
 
-    // Verify outer level: 2 commands (ChildCmd, MemzeroCmd)
+    // Verify outer level: 2 commands (ChildCmd, MemzeroThunk)
     auto outer_commands = gpu_cmd_buffer->commands();
     ASSERT_EQ(outer_commands.size(), 2)
-        << "Outer level should have 2 commands: ChildCmd, MemzeroCmd";
+        << "Outer level should have 2 commands: ChildCmd, MemzeroThunk";
 
     // First command: GpuChildCommand (wrapping middle graph)
     auto* outer_child_cmd =
@@ -802,14 +803,14 @@ TEST(CommandBufferCmdTest, NestedChildCmdCreateAndUpdate) {
     ASSERT_NE(outer_child_cmd->command_buffer, nullptr)
         << "GpuChildCommand should have a nested command buffer";
 
-    // Second command: GpuCommand (MemzeroCmd)
+    // Second command: GpuCommand (MemzeroThunk)
     auto* outer_memzero_cmd =
         dynamic_cast<const se::gpu::GpuCommandBuffer::GpuCommand*>(
             outer_commands[1].get());
     ASSERT_NE(outer_memzero_cmd, nullptr)
-        << "Second outer command should be GpuCommand (MemzeroCmd)";
+        << "Second outer command should be GpuCommand (MemzeroThunk)";
     ASSERT_NE(outer_memzero_cmd->handle, nullptr)
-        << "MemzeroCmd should have a valid graph node handle";
+        << "MemzeroThunk should have a valid graph node handle";
 
     // Verify middle level (inside first ChildCmd): 3 commands
     auto* middle_gpu_buffer = dynamic_cast<se::gpu::GpuCommandBuffer*>(

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -226,7 +226,7 @@ TEST(CommandBufferThunkTest, DeviceToDeviceCopy) {
   ASSERT_EQ(dst, std::vector<int32_t>(4, 42));
 }
 
-TEST(CommandBufferThunkTest, MemzeroCmd) {
+TEST(CommandBufferThunkTest, MemzeroThunk) {
   se::StreamExecutor* stream_executor = GpuExecutor();
 
   TF_ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
@@ -246,7 +246,8 @@ TEST(CommandBufferThunkTest, MemzeroCmd) {
 
   // Prepare commands sequence for constructing command buffer.
   CommandSequence commands;
-  commands.Emplace<MemzeroCmd>(ShapedSlice{slice_a, shape});
+  commands.Emplace<MemzeroThunk>(Thunk::ThunkInfo(),
+                                 ShapedSlice{slice_a, shape});
   TF_ASSERT_OK_AND_ASSIGN(
       CommandExecutor executor,
       CommandExecutor::Create(std::move(commands), serialize));

--- a/xla/backends/gpu/runtime/memset_thunk.cc
+++ b/xla/backends/gpu/runtime/memset_thunk.cc
@@ -24,13 +24,13 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/shaped_slice.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/device_address.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 
@@ -41,6 +41,35 @@ absl::Status MemzeroThunk::ExecuteOnStream(const ExecuteParams& params) {
   se::DeviceAddressBase dest_data =
       params.buffer_allocations->GetDeviceAddress(dest_.slice);
   return params.stream->MemZero(&dest_data, dest_data.size());
+}
+
+absl::StatusOr<const se::CommandBuffer::Command*> MemzeroThunk::Record(
+    const Thunk::ExecuteParams& execute_params,
+    const RecordParams& record_params, RecordAction record_action,
+    se::CommandBuffer* command_buffer) {
+  se::DeviceAddressBase dest_data =
+      execute_params.buffer_allocations->GetDeviceAddress(dest_.slice);
+
+  VLOG(5) << "MemzeroThunk::Record";
+  VLOG(5) << "  dest: " << dest_ << " (" << dest_data.opaque() << ")";
+
+  if (dest_.slice.size() == 0) {
+    VLOG(5) << "Skip recording MemzeroThunk command of 0 bytes";
+    return nullptr;
+  }
+
+  if (auto* create = std::get_if<RecordCreate>(&record_action)) {
+    return command_buffer->CreateMemset(&dest_data, uint8_t{0},
+                                        /*num_elements=*/dest_.slice.size(),
+                                        create->dependencies);
+  }
+  if (auto* update = std::get_if<RecordUpdate>(&record_action)) {
+    RETURN_IF_ERROR(
+        command_buffer->UpdateMemset(update->command, &dest_data, uint8_t{0},
+                                     /*num_elements=*/dest_.slice.size()));
+    return update->command;
+  }
+  return Internal("Invalid record action");
 }
 
 absl::StatusOr<std::unique_ptr<MemzeroThunk>> MemzeroThunk::FromProto(

--- a/xla/backends/gpu/runtime/memset_thunk.h
+++ b/xla/backends/gpu/runtime/memset_thunk.h
@@ -39,12 +39,20 @@ namespace xla {
 namespace gpu {
 
 // Thunk that zeroes out a given chunk of memory.
-class MemzeroThunk : public Thunk {
+// Also implements Command so it can be recorded directly into command buffers.
+class MemzeroThunk : public Command {
  public:
   explicit MemzeroThunk(ThunkInfo thunk_info, const ShapedSlice& dest)
-      : Thunk(Kind::kMemzero, thunk_info), dest_(dest) {}
+      : Command(CommandType::kMemzeroCmd, Kind::kMemzero,
+                std::move(thunk_info)),
+        dest_(dest) {}
 
   absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+
+  absl::StatusOr<const se::CommandBuffer::Command*> Record(
+      const Thunk::ExecuteParams& execute_params,
+      const RecordParams& record_params, RecordAction record_action,
+      se::CommandBuffer* command_buffer) override;
 
   const ShapedSlice& destination() const { return dest_; }
 

--- a/xla/backends/gpu/runtime/memset_thunk_test.cc
+++ b/xla/backends/gpu/runtime/memset_thunk_test.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/platform_util.h"
 #include "xla/service/service_executable_run_options.h"
+#include "xla/shape_util.h"
 #include "xla/stream_executor/command_buffer.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/platform.h"
@@ -113,6 +114,135 @@ TEST(Memset32BitValueThunkTest, ProtoRoundTrip) {
 //===----------------------------------------------------------------------===//
 // Command buffer tests (Record)
 //===----------------------------------------------------------------------===//
+
+TEST(MemzeroThunkTest, RecordCommandBuffer) {
+  se::StreamExecutor* executor = GpuExecutor();
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+
+  int64_t length = 4;
+  int64_t byte_length = sizeof(uint32_t) * length;
+
+  se::DeviceAddress<uint32_t> dest =
+      executor->AllocateArray<uint32_t>(length, 0);
+  TF_ASSERT_OK(stream->Memset32(&dest, 0xFFFFFFFF, byte_length));
+
+  BufferAllocation alloc(/*index=*/0, byte_length, /*color=*/0);
+  BufferAllocation::Slice slice(&alloc, 0, byte_length);
+  ShapedSlice dest_slice{slice, ShapeUtil::MakeShape(F32, {length})};
+
+  MemzeroThunk thunk(Thunk::ThunkInfo(), dest_slice);
+
+  se::StreamExecutorAddressAllocator allocator(executor);
+  BufferAllocations buffer_allocations({dest}, 0, &allocator);
+
+  ServiceExecutableRunOptions run_options;
+  Thunk::ExecuteParams execute_params = Thunk::ExecuteParams::Create(
+      run_options, buffer_allocations, stream.get(),
+      /*command_buffer_trace_stream=*/nullptr,
+      /*collective_params=*/nullptr,
+      /*collective_cliques=*/nullptr,
+      /*collective_memory=*/nullptr);
+
+  CommandStateManager state;
+  Command::RecordParams record_params = {state};
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto command_buffer,
+      executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
+  TF_ASSERT_OK_AND_ASSIGN(
+      const se::CommandBuffer::Command* cmd,
+      thunk.Record(execute_params, record_params,
+                   Command::RecordCreate{/*dependencies=*/{}},
+                   command_buffer.get()));
+  ASSERT_NE(cmd, nullptr);
+  TF_ASSERT_OK(command_buffer->Finalize());
+  TF_ASSERT_OK(command_buffer->Submit(stream.get()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  std::vector<uint32_t> result(length, 0xFFFFFFFF);
+  TF_ASSERT_OK(stream->Memcpy(result.data(), dest, byte_length));
+  EXPECT_EQ(result, std::vector<uint32_t>(length, 0));
+}
+
+// Records into a command buffer, submits, then updates the buffer allocation
+// and re-submits to verify the same command node is reused.
+TEST(MemzeroThunkTest, RecordCommandBufferUpdate) {
+  se::StreamExecutor* executor = GpuExecutor();
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+
+  int64_t length = 4;
+  int64_t byte_length = sizeof(uint32_t) * length;
+
+  se::DeviceAddress<uint32_t> dest_first =
+      executor->AllocateArray<uint32_t>(length, 0);
+  se::DeviceAddress<uint32_t> dest_second =
+      executor->AllocateArray<uint32_t>(length, 0);
+  TF_ASSERT_OK(stream->Memset32(&dest_first, 0xFFFFFFFF, byte_length));
+  TF_ASSERT_OK(stream->Memset32(&dest_second, 0xFFFFFFFF, byte_length));
+
+  BufferAllocation alloc(/*index=*/0, byte_length, /*color=*/0);
+  BufferAllocation::Slice slice(&alloc, 0, byte_length);
+  ShapedSlice dest_slice{slice, ShapeUtil::MakeShape(F32, {length})};
+
+  MemzeroThunk thunk(Thunk::ThunkInfo(), dest_slice);
+
+  se::StreamExecutorAddressAllocator allocator(executor);
+
+  // First recording: RecordCreate pointing at dest_first.
+  BufferAllocations allocs_first({dest_first}, 0, &allocator);
+  ServiceExecutableRunOptions run_options;
+  Thunk::ExecuteParams params_first =
+      Thunk::ExecuteParams::Create(run_options, allocs_first, stream.get(),
+                                   /*command_buffer_trace_stream=*/nullptr,
+                                   /*collective_params=*/nullptr,
+                                   /*collective_cliques=*/nullptr,
+                                   /*collective_memory=*/nullptr);
+
+  CommandStateManager state;
+  Command::RecordParams record_params = {state};
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto command_buffer,
+      executor->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
+  TF_ASSERT_OK_AND_ASSIGN(
+      const se::CommandBuffer::Command* cmd,
+      thunk.Record(params_first, record_params,
+                   Command::RecordCreate{/*dependencies=*/{}},
+                   command_buffer.get()));
+  ASSERT_NE(cmd, nullptr);
+  TF_ASSERT_OK(command_buffer->Finalize());
+  TF_ASSERT_OK(command_buffer->Submit(stream.get()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  // Verify dest_first was zeroed.
+  std::vector<uint32_t> result_first(length, 0xFFFFFFFF);
+  TF_ASSERT_OK(stream->Memcpy(result_first.data(), dest_first, byte_length));
+  EXPECT_EQ(result_first, std::vector<uint32_t>(length, 0));
+
+  // Second recording: RecordUpdate pointing at dest_second.
+  BufferAllocations allocs_second({dest_second}, 0, &allocator);
+  Thunk::ExecuteParams params_second =
+      Thunk::ExecuteParams::Create(run_options, allocs_second, stream.get(),
+                                   /*command_buffer_trace_stream=*/nullptr,
+                                   /*collective_params=*/nullptr,
+                                   /*collective_cliques=*/nullptr,
+                                   /*collective_memory=*/nullptr);
+
+  TF_ASSERT_OK(command_buffer->Update());
+  TF_ASSERT_OK_AND_ASSIGN(
+      const se::CommandBuffer::Command* updated_cmd,
+      thunk.Record(params_second, record_params, Command::RecordUpdate{cmd},
+                   command_buffer.get()));
+  EXPECT_EQ(updated_cmd, cmd);  // same command node is reused
+  TF_ASSERT_OK(command_buffer->Finalize());
+  TF_ASSERT_OK(command_buffer->Submit(stream.get()));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  // Verify dest_second was zeroed.
+  std::vector<uint32_t> result_second(length, 0xFFFFFFFF);
+  TF_ASSERT_OK(stream->Memcpy(result_second.data(), dest_second, byte_length));
+  EXPECT_EQ(result_second, std::vector<uint32_t>(length, 0));
+}
 
 TEST(Memset32BitValueThunkTest, RecordCommandBuffer) {
   se::StreamExecutor* executor = GpuExecutor();


### PR DESCRIPTION
 Description

  Follows the same pattern as #40722 ([XLA:GPU] Migrate Memset32Cmd into Memset32BitValueThunk): eliminate the standalone MemzeroCmd wrapper class by making MemzeroThunk directly implement Command and provide its own Record() method.

  Before

  MemzeroThunk (a plain Thunk subclass) was converted by the command buffer emitter into a heap-allocated MemzeroCmd object via Convert<MemzeroThunk>(). This meant the same logical operation was split across two classes with duplicated state.

  After

  MemzeroThunk inherits from Command (using the protected three-argument constructor to preserve Kind::kMemzero), implements Record() directly, and is emplaced into the command sequence via static_cast — the same pattern as Memset32BitValueThunk, GemmThunk, KernelThunk, and DeviceToDeviceCopyThunk. MemzeroCmd is deleted entirely.

  Changes

  - memset_thunk.h/cc: MemzeroThunk now extends Command; Record() added
  - command_buffer_cmd.h/cc: MemzeroCmd class removed
  - command_buffer_cmd_emitter.cc: Convert(const MemzeroThunk&) helper removed; kMemzero case uses static_cast append
  - memset_thunk_test.cc: Added RecordCommandBuffer and RecordCommandBufferUpdate GPU tests for MemzeroThunk
  - command_buffer_thunk_test.cc, command_buffer_cmd_test.cc: Updated call sites

  Testing

  New MemzeroThunkTest::RecordCommandBuffer and MemzeroThunkTest::RecordCommandBufferUpdate tests cover the create and update paths. 