### PR TITLE
Fix shape-dependent erf precision by adding saturation select

### DIFF
--- a/xla/codegen/emitters/transforms/expand_float_ops.cc
+++ b/xla/codegen/emitters/transforms/expand_float_ops.cc
@@ -98,13 +98,26 @@ struct RewriteErf32Pattern : public mlir::OpRewritePattern<mlir::math::ErfOp> {
       return r;
     };
 
-    Value x = op.getOperand();
-    x = ma::MaximumFOp::create(b, x, c(-kErfInvOneMinusHalfULP));
+    Value original_x = op.getOperand();
+    // For |x| >= kErfInvOneMinusHalfULP, erf(x) rounds to ±1 in f32, so
+    // return copysign(1, x) instead of evaluating the polynomial on the
+    // clamped input. Without this the polynomial evaluated at the clamp
+    // boundary gives ~0.9999998 (3 ULPs short of 1.0) for large x.
+    Value abs_x = mlir::math::AbsFOp::create(b, original_x);
+    Value saturates = ma::CmpFOp::create(b, ma::CmpFPredicate::OGE, abs_x,
+                                         c(kErfInvOneMinusHalfULP));
+    Value saturated_value =
+        mlir::math::CopySignOp::create(b, c(1.0f), original_x);
+
+    Value x = ma::MaximumFOp::create(b, original_x,
+                                     c(-kErfInvOneMinusHalfULP));
     x = ma::MinimumFOp::create(b, x, c(kErfInvOneMinusHalfULP));
     Value x2 = ma::MulFOp::create(b, x, x);
+    Value poly_result = ma::DivFOp::create(
+        b, ma::MulFOp::create(b, x, poly(x2, kAlpha)), poly(x2, kBeta));
 
-    rewriter.replaceOpWithNewOp<ma::DivFOp>(
-        op, ma::MulFOp::create(b, x, poly(x2, kAlpha)), poly(x2, kBeta));
+    rewriter.replaceOpWithNewOp<SelectOp>(op, saturates, saturated_value,
+                                          poly_result);
 
     return mlir::success();
   }

--- a/xla/codegen/emitters/transforms/tests/expand_float_ops.mlir
+++ b/xla/codegen/emitters/transforms/tests/expand_float_ops.mlir
@@ -28,6 +28,13 @@ module {
 
 // CHECK-LABEL: @erf
 // CHECK-NOT: erf
+// The lowering must include a saturation select so that erf(x) returns
+// exactly ±1 for |x| >= kErfInvOneMinusHalfULP, instead of evaluating the
+// polynomial on the clamped input (which gives ~0.9999998 for large x).
+// CHECK: math.absf
+// CHECK: arith.cmpf oge
+// CHECK: math.copysign
+// CHECK: arith.select
 
 // -----
 


### PR DESCRIPTION
## Summary
Fixes #41122

The scalar erf lowering in `expand_float_ops.cc` clamps input `x` to `[-kErfInvOneMinusHalfULP, +kErfInvOneMinusHalfULP]` and evaluates the rational polynomial, producing `0.9999998212` at the boundary instead of `1.0` (3 f32 ULPs off). The vector path in [`xla/codegen/intrinsic/erf.cc`](https://github.com/openxla/xla/blob/main/xla/codegen/intrinsic/erf.cc) already handles saturation correctly via a `select`; this adds the matching select to the scalar path.

## Context

This was diagnosed collaboratively in #41122:

- @wuyii8941 reported the shape-dependent precision issue and provided a side-by-side LLVM IR dump that isolated the divergence to the scalar-vs-vector lowering paths
- Follow-up investigation narrowed down that the polynomial coefficients are identical across both paths — only the saturation strategy differs
- @wuyii8941 confirmed a saturation select after [line 107](https://github.com/openxla/xla/blob/main/xla/codegen/emitters/transforms/expand_float_ops.cc#L107) as the correct fix direction

The [comment on line 83-84](https://github.com/openxla/xla/blob/main/xla/codegen/emitters/transforms/expand_float_ops.cc#L83-L84) documents the intended behavior (*"outside of which x should be +/-1"*) but the implementing code never enforced the `±1` fallback.

## Approach

Compute the saturation check on the original unclamped `x` before the clamp is applied:

```cpp
Value abs_x = math::AbsFOp::create(b, original_x);
Value saturates = ma::CmpFOp::create(b, CmpFPredicate::OGE, abs_x,
                                     c(kErfInvOneMinusHalfULP));
Value saturated_value = math::CopySignOp::create(b, c(1.0f), original_x);
// ... existing clamp + polynomial evaluation ...
rewriter.replaceOpWithNewOp<SelectOp>(op, saturates, saturated_value,
                                      poly_result);
```

For `x = 4.5`: `|4.5| >= 3.7439` → select returns `copysign(1.0, 4.5) = 1.0`.
For in-range `x`: select picks the polynomial result, unchanged from before.

## Testing

- Added CHECK lines to `expand_float_ops.mlir` verifying the lowering contains `math.absf`, `arith.cmpf oge`, `math.copysign`, and `arith.select`
- All 19 tests in `//xla/codegen/emitters/transforms/tests:tests` pass locally (`bazel test //xla/codegen/emitters/transforms/tests:tests`)

cc @wuyii8941 — you flagged this and confirmed the fix direction in the issue, feel free to take a look if interested.