### PR TITLE
Limit GetSymbolicTileAnalysis to low-rank tensors

### DIFF
--- a/xla/backends/cpu/codegen/tiled/tiled_fusion_emitter.cc
+++ b/xla/backends/cpu/codegen/tiled/tiled_fusion_emitter.cc
@@ -218,6 +218,23 @@ static bool IsSupportedInstruction(const HloInstruction& inst) {
 
 absl::StatusOr<SymbolicTileAnalysis> GetSymbolicTileAnalysis(
     mlir::MLIRContext& context, const HloFusionInstruction& fusion) {
+    // Large tensor ranks cause the underlying constraint solver to perform poorly
+    // So limit to low-rank tensors to prevent excess memory usage and hangs
+    constexpr int kMaxRank = 8;
+    for (const xla::HloInstruction* instruction : fusion.fused_instructions()) {
+      if (instruction->shape().dimensions_size() > kMaxRank) {
+        return Internal(
+            "Unsupported fusion in EmitGeneric: tensor rank too large");
+      }
+
+      for (const xla::HloInstruction* operand : instruction->operands()) {
+        if (operand->shape().dimensions_size() > kMaxRank) {
+          return Internal(
+              "Unsupported fusion in EmitGeneric: tensor rank too large");
+        }
+      }
+  }
+
   auto constraints_builder = TiledEmitterConstraints::GetBuilder();
   auto symbolic_tile_analysis_or = SymbolicTileAnalysis::AnalyzeComputation(
       *fusion.fused_instructions_computation(), &context, constraints_builder);


### PR DESCRIPTION
Limits `GetSymbolicTileAnalysis` to tensors with small rank in the cpu backend's fusion emitter. Resolves #41173 

Commit https://github.com/openxla/xla/commit/67f96462735fc3eb8433d394544aa23bfd8c7306 (https://github.com/openxla/xla/pull/36510) introduced a regression where compilation hangs and OOMs in workloads that work with high-rank tensors.

This issue was reported twice downstream in the jax repository:
* https://github.com/jax-ml/jax/issues/35646
* https://github.com/jax-ml/jax/issues/35958

🐛 Bug Fix, ⚡️ Performance Improvement,

# Jax Benchmark

Before: Hangs/OOM
After: <3s

```python
import os
os.environ["CUDA_VISIBLE_DEVICES"] = ""

import numpy as np
import jax.numpy as jnp
import jax

rng = np.random.default_rng(42)
p_arrays = [rng.normal(size=(2, 2, 2)).astype("float32") for _ in range(10)]
h_arrays = [rng.normal(size=(2, 2, 2, 2)).astype("float32") for _ in range(10)]

p_arrays = [jnp.array(arr) for arr in p_arrays]
h_arrays = [jnp.array(arr) for arr in h_arrays]

def loss(p, h):
    x125661750437408 = jnp.tensordot(p[7], p[8], ((1,), (0,),))
    x125661750438656 = jnp.tensordot(x125661750437408, p[9], ((2,), (0,),))
    x125661750433664 = jnp.tensordot(p[5], p[6], ((1,), (0,),))
    x125661750441632 = jnp.tensordot(x125661750438656, x125661750433664, ((0,), (2,),))
    x125669778169216 = jnp.tensordot(p[1], p[2], ((1,), (0,),))
    x125661750440192 = jnp.tensordot(x125669778169216, p[0], ((0,), (1,),))
    x125661750438080 = jnp.tensordot(p[3], p[4], ((1,), (0,),))
    x125661750436160 = jnp.tensordot(x125661750440192, x125661750438080, ((1,), (0,),))
    x125661750438560 = jnp.tensordot(x125661750436160, x125661750441632, ((2, 5,), (2, 4,),))
    x125661750442496 = jnp.tensordot(h[1], h[2], ((1,), (0,),))
    x125661750442112 = jnp.tensordot(h[0], h[9], ((0,), (1,),))
    x125661750432800 = jnp.tensordot(x125661750442112, x125661750442496, ((0,), (0,),))
    x125661750432608 = jnp.tensordot(x125661750438560, x125661750432800, ((0, 1, 2, 7,), (5, 8, 0, 3,),))
    x125661750432992 = jnp.tensordot(h[7], h[8], ((1,), (0,),))
    x125661750432032 = jnp.tensordot(x125661750432608, x125661750432992, ((2, 3, 7,), (1, 4, 3,),))
    x125661750431072 = jnp.tensordot(h[5], h[6], ((1,), (0,),))
    x125661750432224 = jnp.tensordot(h[3], h[4], ((1,), (0,),))
    x125661750430496 = jnp.tensordot(x125661750432224, x125661750431072, ((3,), (0,),))
    x125661750430208 = jnp.tensordot(x125661750432032, x125661750430496, ((0, 1, 2, 3, 7, 9,), (1, 3, 5, 8, 0, 7,),))
    x125661750429536 = jnp.tensordot(p[5], p[6], ((1,), (0,),))
    x125661750429440 = jnp.tensordot(x125661750429536, p[4], ((0,), (1,),))
    x125661750429248 = jnp.tensordot(p[7], p[8], ((1,), (0,),))
    x125661750428576 = jnp.tensordot(x125661750429440, x125661750429248, ((1,), (0,),))
    x125661750429056 = jnp.tensordot(x125661750430208, x125661750428576, ((4, 5, 7, 8, 9,), (4, 6, 3, 0, 1,),))
    x125661750428960 = jnp.tensordot(x125661750429056, p[9], ((1, 6,), (2, 0,),))
    x125661750428288 = jnp.tensordot(x125661750428960, p[0], ((0, 5,), (2, 0,),))
    x125661750428192 = jnp.tensordot(x125661750428288, p[1], ((0, 4,), (2, 0,),))
    x125661750428096 = jnp.tensordot(x125661750428192, p[2], ((0, 3,), (2, 0,),))
    x125661750428000 = jnp.tensordot(x125661750428096, p[3], ((0, 1, 2,), (2, 1, 0,),))
    return x125661750428000

loss(p_arrays, h_arrays)
```