### PR TITLE
[ROCm] Fix gpu_compiler_test by relaxing an fp8 support check

### DIFF
--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -826,7 +826,7 @@ ENTRY main {
         (cuda_cc.IsAtLeastHopper() ||
          (cuda_cc.IsAtLeastAmpere() && lhs_type == F8E5M2 &&
           rhs_type == F8E5M2) ||
-         rocm_cc.has_ocp_fp8_support())
+         gpu_cc.IsRocm())
             ? triton_keep_types
             : cublas_convert_to_f16;
     ASSERT_OK_AND_ASSIGN(


### PR DESCRIPTION
Fixes gpu_compiler_test which broke on some ROCm devices after https://github.com/openxla/xla/commit/e742f5b857072ecbcebb82839bfc5e3d684cc21e. 

Chooses correct FileCheck pattern in `FloatNormalizationTest.Fp8Normalization` on devices without OCP fp8 support. With Triton enabled we check for a Triton fusion on all devices. 