### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Explicit NaN propagation for float minimum and maximum operations

### DIFF
--- a/xla/backends/cpu/codegen/fusion_compiler.cc
+++ b/xla/backends/cpu/codegen/fusion_compiler.cc
@@ -215,8 +215,8 @@ static std::unique_ptr<::mlir::Pass> CreateConvertMathToLLVMPass() {
 // their LLVM equivalent.
 static void AddGenericLoweringPasses(mlir::OpPassManager& pm,
                                      bool fast_min_max) {
-  pm.addNestedPass<mlir::func::FuncOp>(
-      emitters::CreateSimplifyArithPass(fast_min_max));
+  pm.addNestedPass<mlir::func::FuncOp>(emitters::CreateSimplifyArithPass(
+      fast_min_max, /*explicit_nan_propagation=*/false));
   pm.addPass(emitters::CreateExpandIntegerPowerPass());
   pm.addPass(emitters::CreateSimplifyAffinePass());
   pm.addPass(mlir::createCanonicalizerPass());

--- a/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
+++ b/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
@@ -561,7 +561,15 @@ void AddLoweringPasses(mlir::OpPassManager& pm,
   // simplify-affine has maximally folded expressions to work with.
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
-  pm.addNestedPass<FuncOp>(emitters::CreateSimplifyArithPass());
+  // LLVM SPIR-V backend does not use nan-propagiting float minimum/maximum
+  // (IEEE 754-2019) semantics, so we need to use explicit NaN propagation for
+  // min/max operations on oneAPI platform. This condition is exercised only if
+  // fast_min_max is false.
+  bool use_explicit_nan_propagation =
+      device.gpu_compute_capability().IsOneAPI();
+  pm.addNestedPass<FuncOp>(emitters::CreateSimplifyArithPass(
+      /*fast_min_max=*/false,
+      /*explicit_nan_propagation=*/use_explicit_nan_propagation));
   pm.addPass(emitters::CreateSimplifyAffinePass());
   pm.addPass(CreateConvertIndexTypePass());
   // simplify-affine lowers most affine.apply ops, but if it can't prove a

--- a/xla/codegen/emitters/transforms/passes.h
+++ b/xla/codegen/emitters/transforms/passes.h
@@ -49,7 +49,8 @@ std::unique_ptr<mlir::Pass> CreateLowerXlaLoopsToScfPass();
 std::unique_ptr<mlir::Pass> CreateMergePointersToSameSlicePass();
 std::unique_ptr<mlir::Pass> CreatePropagateSliceIndicesPass();
 std::unique_ptr<mlir::Pass> CreateSimplifyAffinePass();
-std::unique_ptr<mlir::Pass> CreateSimplifyArithPass(bool fast_min_max = false);
+std::unique_ptr<mlir::Pass> CreateSimplifyArithPass(
+    bool fast_min_max = false, bool explicit_nan_propagation = false);
 std::unique_ptr<mlir::Pass> CreateUnswitchLoopsPass();
 std::unique_ptr<mlir::Pass> CreateVectorizeLoadsAndStoresPass(
     const std::string& target_type = "gpu",

--- a/xla/codegen/emitters/transforms/passes.td
+++ b/xla/codegen/emitters/transforms/passes.td
@@ -232,6 +232,9 @@ def SimplifyArithPass : Pass<"xla-simplify-arith", "mlir::func::FuncOp"> {
   let options = [
     Option<"fast_min_max_", "fast_min_max", "bool", /*default=*/"false",
            "Use fast min/max (does not propagate nan).">,
+    Option<"explicit_nan_propagation_", "explicit_nan_propagation", "bool",
+           /*default=*/"false",
+           "Use explicit NaN propagation for min/max (OneAPI).">,
   ];
 
   let constructor = "CreateSimplifyArithPass()";

--- a/xla/codegen/emitters/transforms/simplify_arith.cc
+++ b/xla/codegen/emitters/transforms/simplify_arith.cc
@@ -262,6 +262,49 @@ struct RewriteMaximumF : OpRewritePattern<mlir::arith::MaximumFOp> {
   }
 };
 
+template <typename OpType, mlir::arith::CmpFPredicate Predicate>
+struct RewriteMinMaxFWithNaNPropagation : OpRewritePattern<OpType> {
+  using OpRewritePattern<OpType>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpType op,
+                                PatternRewriter& rewriter) const override {
+    // Check if either operand is NaN using ORD (ordered) predicate
+    // ORD returns true only if neither operand is NaN
+    auto is_neither_nan = mlir::arith::CmpFOp::create(
+        rewriter, op.getLoc(), mlir::arith::CmpFPredicate::ORD, op.getLhs(),
+        op.getRhs());
+
+    // Ordered comparison (returns false if either is NaN)
+    auto cmp = mlir::arith::CmpFOp::create(rewriter, op.getLoc(), Predicate,
+                                           op.getLhs(), op.getRhs());
+    auto selected = mlir::arith::SelectOp::create(
+        rewriter, op.getLoc(), op.getType(), cmp, op.getLhs(), op.getRhs());
+
+    // Create constant NaN
+    auto nan_const = rewriter.create<mlir::arith::ConstantOp>(
+        op.getLoc(),
+        rewriter.getFloatAttr(
+            op.getType(),
+            llvm::APFloat::getNaN(mlir::cast<mlir::FloatType>(op.getType())
+                                      .getFloatSemantics())));
+
+    // If either is NaN, return constant NaN; otherwise return selected
+    auto result =
+        mlir::arith::SelectOp::create(rewriter, op.getLoc(), op.getType(),
+                                      is_neither_nan, selected, nan_const);
+
+    rewriter.replaceOp(op, result);
+    return mlir::success();
+  }
+};
+
+using RewriteMinimumFWithNaNPropagation =
+    RewriteMinMaxFWithNaNPropagation<mlir::arith::MinimumFOp,
+                                     mlir::arith::CmpFPredicate::OLE>;
+using RewriteMaximumFWithNaNPropagation =
+    RewriteMinMaxFWithNaNPropagation<mlir::arith::MaximumFOp,
+                                     mlir::arith::CmpFPredicate::OGE>;
+
 static std::optional<Interval> GetSelectRange(mlir::Operation* sel) {
   // Match |x| implemented as (x >= 0) ? x : (0 - x).
   mlir::Value x = sel->getOperand(1);
@@ -397,9 +440,11 @@ class SimplifyArithPass
       RewriteTruncExtShuffle
     >(ctx);
 
-    if (fast_min_max_)
-    {
+    if (fast_min_max_) {
       patterns.add<RewriteMinimumF, RewriteMaximumF>(ctx);
+    } else if (explicit_nan_propagation_) {
+      patterns.add<RewriteMinimumFWithNaNPropagation,
+                   RewriteMaximumFWithNaNPropagation>(ctx);
     }
 
     // clang-format on
@@ -419,9 +464,11 @@ class SimplifyArithPass
 
 }  // namespace
 
-std::unique_ptr<mlir::Pass> CreateSimplifyArithPass(bool fast_min_max) {
+std::unique_ptr<mlir::Pass> CreateSimplifyArithPass(
+    bool fast_min_max, bool explicit_nan_propagation) {
   SimplifyArithPassOptions options;
   options.fast_min_max_ = fast_min_max;
+  options.explicit_nan_propagation_ = explicit_nan_propagation;
   return std::make_unique<SimplifyArithPass>(options);
 }
 


### PR DESCRIPTION
📝 Summary of Changes
The LLVM SPIR-V backend does not use nan-propagating float minimum/maximum (IEEE 754-2019) semantics, so we need to use explicit NaN propagation on oneAPI platform when `fast_min_max` flag is false in the `SimplifyArithPass`

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests: Unit Tests: This test `//xla/tests:fmax_fmin_test` is fixed with this PR.