### PR TITLE
[ROCm] Make generate_cub_scratch_size_test cuda-only as it is cuda specific

### DIFF
--- a/xla/backends/gpu/libraries/cub/BUILD
+++ b/xla/backends/gpu/libraries/cub/BUILD
@@ -79,6 +79,7 @@ cuda_library(
     testonly = True,
     srcs = ["generate_cub_scratch_size_lib.cu.cc"],
     hdrs = ["generate_cub_scratch_size_lib.cu.h"],
+    tags = ["cuda-only"],
     deps = [
         ":scratch_space_lookup_table_proto_cc",
         "//xla/tsl/platform:env",
@@ -101,8 +102,11 @@ xla_test(
         "gb200": ["full"],
         "gb300": ["full"],
     },
-    backends = ["gpu"],
+    backends = [
+        "gpu",
+    ],
     tags = [
+        "cuda-only",
         "no_oss",  # Stop this test from being run in OSS presubmits
         "notap",
     ],


### PR DESCRIPTION
📝 Summary of Changes
Adjust a backend tag for a cub_scratch_size tests as it is cuda specific

🎯 Justification
It breaks rocm build as it is not getting excluded from the list of tests when using 
filtering by tags

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
