### PR TITLE
[ROCm] Fix sorting.hlo lit test on GCN

### DIFF
--- a/xla/backends/gpu/tests/sorting.hlo
+++ b/xla/backends/gpu/tests/sorting.hlo
@@ -1310,4 +1310,3 @@ ENTRY main {
 
 // CHECK-LABEL: source_filename = "sort"
 // CHECK-COUNT-312: xor i64
-// CHECK-GCN: xor i64


### PR DESCRIPTION
📝 Summary of Changes
Last check for xor instruction in hlo is now replaced with `CHECK-COUNT-312: xor i64` in commit
https://github.com/openxla/xla/commit/c3077ef394b1969e334e49f678e1bb6965fd9aaa


🎯 Justification
Fixes test break on ROCm

🚀 Kind of Contribution: 🧪 Tests


