### PR TITLE
Remove no_oss tags

### DIFF
--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -1201,7 +1201,6 @@ xla_test(
     backend_tags = {
         "gpu": [
             "multi_gpu",
-            "no_oss",
         ],
     },
     backends = ["gpu"],
@@ -1234,7 +1233,6 @@ xla_test(
     backend_tags = {
         "gpu": [
             "multi_gpu",
-            "no_oss",
         ],
     },
     backends = [
@@ -1546,7 +1544,6 @@ xla_test(
     backend_tags = {
         "gpu": [
             "multi_gpu",
-            "no_oss",
         ],
     },
     backends = ["gpu"],

--- a/xla/tools/multihost_hlo_runner/BUILD
+++ b/xla/tools/multihost_hlo_runner/BUILD
@@ -240,7 +240,6 @@ xla_test(
         ],
         "gpu": [
             "multi_gpu",
-            "no_oss",
             "nomsan",
         ],
         "nvgpu_any": [


### PR DESCRIPTION
📝 Summary of Changes
This PR removes `no_oss` tag from several tests:
```
//xla/backends/gpu/tests:collective_ops_command_buffer_test
//xla/backends/gpu/tests:collective_pipeline_parallelism_test
//xla/backends/gpu/tests:replicated_io_feed_test
//xla/tools/multihost_hlo_runner:functional_hlo_runner_test
```

🎯 Justification
The following tests are unnecessarily skipped in CI due to `no_oss` tag. 

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
/

🧪 Unit Tests:
/

🧪 Execution Tests:
/
