### PR TITLE
[xla:gpu] Add analysis + pass to annotate compile time DS/DUS

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1344,6 +1344,79 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "dynamic_slice_analysis",
+    srcs = ["dynamic_slice_analysis.cc"],
+    hdrs = ["dynamic_slice_analysis.h"],
+    tags = ["gpu"],
+    deps = [
+        "//xla:literal",
+        "//xla:literal_util",
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/evaluator:hlo_evaluator",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:pattern_matcher",
+        "//xla/service/gpu:ir_emission_utils",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "dynamic_slice_analysis_test",
+    srcs = ["dynamic_slice_analysis_test.cc"],
+    tags = ["gpu"],
+    deps = [
+        ":dynamic_slice_analysis",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "dynamic_slice_annotator",
+    srcs = ["dynamic_slice_annotator.cc"],
+    hdrs = ["dynamic_slice_annotator.h"],
+    tags = ["gpu"],
+    deps = [
+        ":dynamic_slice_analysis",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+xla_cc_test(
+    name = "dynamic_slice_annotator_test",
+    srcs = ["dynamic_slice_annotator_test.cc"],
+    tags = ["gpu"],
+    deps = [
+        ":dynamic_slice_annotator",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/gpu:backend_configs_cc",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "dynamic_slice_fusion_rewriter",
     srcs = ["dynamic_slice_fusion_rewriter.cc"],
     hdrs = ["dynamic_slice_fusion_rewriter.h"],

--- a/xla/backends/gpu/transforms/dynamic_slice_analysis.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_analysis.cc
@@ -1,0 +1,610 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_analysis.h"
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/inlined_vector.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/hlo/evaluator/hlo_evaluator.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/literal.h"
+#include "xla/literal_util.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/service/pattern_matcher.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+//===-----------------------------------------------------------------------===/
+// DynamicSliceDescriptor
+//===-----------------------------------------------------------------------===/
+
+static std::optional<absl::InlinedVector<int64_t, 4>>
+ComputeByteStridesForSubByte(const Shape& shape) {
+  absl::InlinedVector<int64_t, 4> strides(shape.dimensions().size());
+  int64_t stride_in_bits = ShapeUtil::ElementSizeInBits(shape);
+  for (int32_t i : shape.layout().minor_to_major()) {
+    if (stride_in_bits % CHAR_BIT != 0) {
+      strides[i] = -1;
+    } else {
+      strides[i] = stride_in_bits / CHAR_BIT;
+    }
+    stride_in_bits *= shape.dimensions(i);
+  }
+  return strides;
+}
+
+static std::optional<absl::InlinedVector<int64_t, 4>> ComputeByteStrides(
+    const Shape& shape) {
+  auto strides = ShapeUtil::ByteStrides(shape);
+  if (strides) {
+    return strides;
+  }
+  return ComputeByteStridesForSubByte(shape);
+}
+
+static bool IsZeroOffset(const HloInstruction* slice, int32_t dim) {
+  return GetSliceSize(slice, dim) == slice->operand(0)->shape().dimensions(dim);
+}
+
+int32_t GetFirstOffsetOperandIndex(const HloInstruction* slice) {
+  CHECK(slice->opcode() == HloOpcode::kDynamicSlice ||
+        slice->opcode() == HloOpcode::kDynamicUpdateSlice);
+  return slice->opcode() == HloOpcode::kDynamicSlice ? 1 : 2;
+}
+
+int64_t GetSliceSize(const HloInstruction* slice, int32_t dim) {
+  if (slice->opcode() == HloOpcode::kDynamicSlice) {
+    return slice->dynamic_slice_sizes()[dim];
+  }
+  CHECK_EQ(slice->opcode(), HloOpcode::kDynamicUpdateSlice);
+  return slice->operand(1)->shape().dimensions(dim);
+}
+
+// Evaluates the total byte offset for a DS/DUS at a given induction variable
+// value by substituting into HloEvaluator.
+static absl::StatusOr<int64_t> EvaluateByteOffsetAtIteration(
+    const HloInstruction* instr, absl::Span<const int64_t> byte_strides,
+    const HloInstruction* induction_var, int64_t ivar_value) {
+  int32_t first_offset_index = GetFirstOffsetOperandIndex(instr);
+  int32_t rank = instr->operand(0)->shape().dimensions().size();
+
+  Literal ivar_literal(induction_var->shape());
+  RETURN_IF_ERROR(ivar_literal.SetIntegralAsS64({}, ivar_value));
+
+  absl::flat_hash_map<const HloInstruction*, const LiteralBase*> substitutions;
+  substitutions[induction_var] = &ivar_literal;
+
+  HloEvaluator evaluator(/*max_loop_iterations=*/0);
+  int64_t total_byte_offset = 0;
+
+  // Iterate over each dimension's offset operand of the DS/DUS.
+  for (int32_t i = 0; i < rank; ++i) {
+    const HloInstruction* operand = instr->operand(i + first_offset_index);
+
+    if (IsZeroOffset(instr, i)) {
+      continue;
+    }
+
+    if (byte_strides[i] < 0) {
+      return Internal("Non-byte-aligned dimension in slice.");
+    }
+
+    if (operand->opcode() == HloOpcode::kConstant) {
+      auto value = LiteralUtil::LiteralAsScalarInt64(operand->literal());
+      if (!value) {
+        return Internal("Failed to read constant offset.");
+      }
+      total_byte_offset += *value * byte_strides[i];
+      continue;
+    }
+
+    ASSIGN_OR_RETURN(Literal offset_literal,
+                     evaluator.Evaluate(operand, {}, true, substitutions));
+
+    auto offset_value = LiteralUtil::LiteralAsScalarInt64(offset_literal);
+    if (!offset_value) {
+      return Internal("Failed to evaluate dynamic offset.");
+    }
+
+    total_byte_offset += *offset_value * byte_strides[i];
+  }
+
+  return total_byte_offset;
+}
+
+// Attempts to identify a staggered induction variable created by loop
+// pipelining. The pipeliner peels the first iteration and creates a new tuple
+// slot that carries the induction variable value from the previous iteration.
+// Pattern: body parameter GTE(staggered_index), where the ROOT tuple assigns
+// GTE(param, ivar_index) to that slot.
+struct StaggeredVariable {
+  const HloInstruction* loop;
+  const HloInstruction* gte;
+  int64_t init_value;
+};
+
+static const HloInstruction* StripCopies(const HloInstruction* instr) {
+  while (instr->opcode() == HloOpcode::kCopy) {
+    instr = instr->operand(0);
+  }
+  return instr;
+}
+
+static std::optional<StaggeredVariable> TryResolveStaggeredVariable(
+    const HloInstruction* operand) {
+  namespace m = match;
+
+  // Step 1: The operand must be GTE(parameter), possibly through copies
+  // inserted by copy-insertion for scheduling.
+  const HloInstruction* gte = StripCopies(operand);
+  if (!Match(gte, m::GetTupleElement(m::Parameter()))) {
+    return std::nullopt;
+  }
+  const HloInstruction* param = gte->operand(0);
+  int64_t staggered_index = gte->tuple_index();
+
+  // Step 2: The parameter's parent computation must be the body of exactly
+  // one while loop.
+  const HloComputation* body = param->parent();
+  auto callers = body->caller_instructions(HloOpcode::kWhile);
+  if (callers.size() != 1) {
+    return std::nullopt;
+  }
+  const HloInstruction* while_loop = callers.front();
+  if (while_loop->while_body() != body) {
+    return std::nullopt;
+  }
+
+  // Step 3: The while loop must have annotated induction variable metadata
+  // (set by WhileLoopTripCountAnnotator). The operand's tuple index must
+  // differ from the primary induction variable — otherwise the standard
+  // ResolveFunctionalDependencyOnInductionVariable would have succeeded.
+  auto config = while_loop->backend_config<WhileLoopBackendConfig>();
+  if (!config.ok() || !config->has_known_induction_variable() ||
+      !config->has_known_init_step()) {
+    return std::nullopt;
+  }
+  int64_t ivar_index = config->known_induction_variable().tuple_index();
+  if (staggered_index == ivar_index) {
+    return std::nullopt;
+  }
+
+  // Step 4: Verify the pipelining pattern — the body ROOT tuple's element at
+  // staggered_index must be GTE(param, ivar_index), possibly through copies.
+  // This means the staggered slot receives the current induction variable
+  // value, making it carry the "previous iteration's" value on the next
+  // iteration.
+  const HloInstruction* root = body->root_instruction();
+  if (root->opcode() != HloOpcode::kTuple ||
+      staggered_index >= root->operand_count()) {
+    return std::nullopt;
+  }
+  const HloInstruction* staggered_update =
+      StripCopies(root->operand(staggered_index));
+  if (!Match(staggered_update,
+             m::GetTupleElement(m::Op().Is(param), ivar_index))) {
+    return std::nullopt;
+  }
+
+  // Step 5: Read the staggered slot's initial value from the while loop's
+  // init tuple. It must be a constant (possibly through copies) so we can
+  // compute the offset formula. Typically this is (init - step), e.g. 0 when
+  // init=1, step=1.
+  if (!Match(while_loop->operand(0), m::Tuple()) ||
+      staggered_index >= while_loop->operand(0)->operand_count()) {
+    return std::nullopt;
+  }
+  const HloInstruction* init_constant =
+      StripCopies(while_loop->operand(0)->operand(staggered_index));
+  if (init_constant->opcode() != HloOpcode::kConstant) {
+    return std::nullopt;
+  }
+  auto init_value = LiteralUtil::LiteralAsScalarInt64(init_constant->literal());
+  if (!init_value) {
+    return std::nullopt;
+  }
+
+  VLOG(3) << "Found staggered induction variable: " << operand->name()
+          << " (index=" << staggered_index << ", init=" << *init_value
+          << ") in " << while_loop->name();
+
+  return StaggeredVariable{while_loop, operand, *init_value};
+}
+
+// Counts the number of intervening while loops between `instr` and
+// `while_loop`. Returns 0 if `instr` is directly inside `while_loop`'s body.
+static int64_t ComputeLoopIndex(const HloInstruction* instr,
+                                const HloInstruction* while_loop) {
+  int64_t depth = 0;
+  for (const HloComputation* comp = instr->parent(); comp != nullptr;) {
+    auto callers = comp->caller_instructions(HloOpcode::kWhile);
+    if (callers.empty()) {
+      break;
+    }
+    const HloInstruction* caller = callers.front();
+    if (caller == while_loop) {
+      return depth;
+    }
+    depth++;
+    comp = caller->parent();
+  }
+  return depth;
+}
+
+absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
+    const HloInstruction* instr) {
+  // Step 1: Only analyze dynamic-slice and dynamic-update-slice instructions.
+  if (instr->opcode() != HloOpcode::kDynamicSlice &&
+      instr->opcode() != HloOpcode::kDynamicUpdateSlice) {
+    return std::nullopt;
+  }
+
+  // Step 2: The slice must be contiguous in memory (i.e. it slices along the
+  // most-major dimension only, with full extent in all minor dimensions).
+  if (!IsContiguousSlice(*instr)) {
+    VLOG(5) << "Slice is not contiguous: " << instr->name();
+    return std::nullopt;
+  }
+
+  // Step 3: Compute byte strides per dimension of the sliced buffer. These
+  // convert index offsets to byte offsets (e.g. f32[4,8] has byte strides
+  // [32, 4]: moving one position along dim0 skips 8*4=32 bytes).
+  const Shape& slice_input_shape = instr->operand(0)->shape();
+  std::optional<absl::InlinedVector<int64_t, 4>> strides =
+      ComputeByteStrides(slice_input_shape);
+  if (!strides) {
+    VLOG(5) << "Failed to get byte strides: " << instr->name();
+    return std::nullopt;
+  }
+
+  // Step 4: For each dynamic offset operand, resolve it to either a primary
+  // or staggered induction variable. Collect results into a vector; we
+  // validate consistency (same loop, same kind) after the loop.
+  int32_t first_offset_index = GetFirstOffsetOperandIndex(instr);
+  int32_t rank = slice_input_shape.dimensions().size();
+
+  struct ResolvedOffset {
+    const HloInstruction* loop;
+    const HloInstruction* ivar;
+    bool is_staggered;
+    int64_t staggered_init;
+  };
+
+  std::vector<ResolvedOffset> resolved_offsets;
+
+  // Iterate over each dimension's offset operand of the DS/DUS.
+  for (int32_t i = 0; i < rank; ++i) {
+    const HloInstruction* operand = instr->operand(i + first_offset_index);
+
+    // Skip dimensions where the slice covers the full extent or the offset is
+    // a compile-time constant — these don't depend on the induction variable.
+    if (IsZeroOffset(instr, i) || operand->opcode() == HloOpcode::kConstant) {
+      continue;
+    }
+
+    // Step 4a: Try the standard analysis — traces the operand through the
+    // computation graph back to a while loop's primary induction variable.
+    auto functional_dependency =
+        ResolveFunctionalDependencyOnInductionVariable(operand);
+    if (functional_dependency) {
+      resolved_offsets.push_back({functional_dependency->loop,
+                                  functional_dependency->induction_var,
+                                  /*is_staggered=*/false,
+                                  /*staggered_init=*/0});
+      continue;
+    }
+
+    // Step 4b: Standard analysis failed. It only recognizes the primary
+    // induction variable (or entries in dynamic_variable_tuple_indices), not
+    // staggered copies. Try to detect a staggered induction variable — a
+    // copy of the primary ivar at a different tuple index, created by
+    // CollectivePipeliner when it peels the first iteration.
+    auto staggered_var = TryResolveStaggeredVariable(operand);
+    if (staggered_var) {
+      resolved_offsets.push_back({staggered_var->loop, staggered_var->gte,
+                                  /*is_staggered=*/true,
+                                  staggered_var->init_value});
+      continue;
+    }
+
+    VLOG(5) << "Offset for dimension " << i << " is not statically known.";
+    return std::nullopt;
+  }
+
+  // Step 5: All offsets are constant — compute the static byte offset directly.
+  if (resolved_offsets.empty()) {
+    int64_t byte_offset = 0;
+    for (int32_t i = 0; i < rank; ++i) {
+      if (IsZeroOffset(instr, i)) {
+        continue;
+      }
+      const HloInstruction* operand = instr->operand(i + first_offset_index);
+      auto value = LiteralUtil::LiteralAsScalarInt64(operand->literal());
+      if (!value.has_value()) {
+        return std::nullopt;
+      }
+      byte_offset += *value * (*strides)[i];
+    }
+    return DynamicSliceDescriptor{std::nullopt, std::nullopt, byte_offset, 0};
+  }
+
+  // Step 5: All resolved offsets must be consistent — same while loop, same
+  // kind (all primary or all staggered), and same induction variable GTE.
+  const ResolvedOffset& front = resolved_offsets.front();
+  bool consistent = absl::c_all_of(resolved_offsets, [&](const auto& r) {
+    return r.loop == front.loop && r.is_staggered == front.is_staggered &&
+           r.ivar == front.ivar;
+  });
+
+  if (!consistent) {
+    VLOG(3) << "Skipping " << instr->name()
+            << ": inconsistent dynamic offsets (different loops, mixed "
+               "primary/staggered, or different induction variables).";
+    return std::nullopt;
+  }
+
+  const HloInstruction* while_loop = front.loop;
+  const HloInstruction* induction_var = front.ivar;
+  bool all_staggered = front.is_staggered;
+
+  // Step 6: Read the loop's init/step/trip_count from WhileLoopBackendConfig
+  // (set by WhileLoopTripCountAnnotator).
+  ASSIGN_OR_RETURN(auto loop_config,
+                   while_loop->backend_config<WhileLoopBackendConfig>());
+  if (!loop_config.has_known_init_step() ||
+      !loop_config.has_known_trip_count()) {
+    VLOG(5) << "Loop does not have known init/step/trip_count.";
+    return std::nullopt;
+  }
+
+  int64_t init = loop_config.known_init_step().init();
+  int64_t step = loop_config.known_init_step().step();
+  int64_t trip_count = loop_config.known_trip_count().n();
+
+  if (trip_count < 1) {
+    return std::nullopt;
+  }
+
+  // Step 7: For staggered variables, the iteration sequence uses the staggered
+  // init value rather than the primary induction variable's init. E.g. if the
+  // primary ivar starts at 1 with step 1, a staggered copy starts at 0.
+  int64_t effective_init =
+      all_staggered ? resolved_offsets.front().staggered_init : init;
+
+  // Step 8: Evaluate the byte offset for every iteration by substituting the
+  // induction variable value into HloEvaluator.
+  std::vector<int64_t> offsets(trip_count);
+  for (int64_t iter = 0; iter < trip_count; ++iter) {
+    int64_t ivar = effective_init + iter * step;
+    ASSIGN_OR_RETURN(offsets[iter], EvaluateByteOffsetAtIteration(
+                                        instr, *strides, induction_var, ivar));
+    VLOG(3) << instr->name() << ": iteration " << iter << " (ivar=" << ivar
+            << ") -> byte_offset=" << offsets[iter];
+  }
+
+  // Step 9: Verify linearity — all consecutive differences must be equal.
+  // This confirms the offset is an affine function of the iteration count:
+  //   byte_address = base + byte_offset + byte_stride * iteration
+  int64_t byte_offset = offsets[0];
+  int64_t byte_stride = (trip_count > 1) ? (offsets[1] - offsets[0]) : 0;
+
+  for (int64_t iter = 2; iter < trip_count; ++iter) {
+    int64_t actual_stride = offsets[iter] - offsets[iter - 1];
+    if (actual_stride != byte_stride) {
+      VLOG(3) << instr->name() << ": non-linear offset pattern at iteration "
+              << iter << ": stride " << actual_stride << " != " << byte_stride;
+      return std::nullopt;
+    }
+  }
+
+  VLOG(2) << instr->name() << ": linear pattern confirmed over " << trip_count
+          << " iterations: offset=" << byte_offset
+          << ", stride=" << byte_stride;
+
+  // Step 10: Compute the loop nesting depth (0 = direct child of while_loop).
+  int64_t loop_index = ComputeLoopIndex(instr, while_loop);
+  return DynamicSliceDescriptor{while_loop, loop_index, byte_offset,
+                                byte_stride};
+}
+
+//===-----------------------------------------------------------------------===/
+// DynamicSliceChain
+//===-----------------------------------------------------------------------===/
+
+// Walks a DS/DUS buffer operand (operand 0) back through bitcasts and DUS
+// chains to find the buffer root: either a GTE of a tuple parameter or a
+// non-tuple parameter directly. DUS chains arise when multiple updates write
+// to different slices of the same buffer sequentially:
+//
+//   buf = GTE(param, 1)
+//   updated1 = DUS(buf, v1, off1)
+//   updated2 = DUS(updated1, v2, off2)
+//
+// All three (buf, updated1, updated2) share the same buffer root.
+static const HloInstruction* TraceBufferSource(const HloInstruction* instr) {
+  const HloInstruction* buffer = instr->operand(0);
+  while (buffer->opcode() == HloOpcode::kBitcast ||
+         buffer->opcode() == HloOpcode::kDynamicUpdateSlice) {
+    buffer = buffer->operand(0);
+  }
+  if (buffer->opcode() == HloOpcode::kGetTupleElement &&
+      buffer->operand(0)->opcode() == HloOpcode::kParameter) {
+    return buffer;
+  }
+  if (buffer->opcode() == HloOpcode::kParameter) {
+    return buffer;
+  }
+  return nullptr;
+}
+
+absl::StatusOr<DynamicSliceChain> FindDynamicSliceChain(
+    const HloInstruction* instr) {
+  if (instr->opcode() != HloOpcode::kDynamicSlice &&
+      instr->opcode() != HloOpcode::kDynamicUpdateSlice) {
+    return Internal("FindDynamicSliceChain: expected DS or DUS, got %s",
+                    HloOpcodeString(instr->opcode()));
+  }
+
+  const HloComputation* computation = instr->parent();
+  auto callers = computation->caller_instructions(HloOpcode::kWhile);
+  if (callers.size() != 1 || callers.front()->while_body() != computation) {
+    return Internal("FindDynamicSliceChain: %s is not inside a while loop body",
+                    instr->name());
+  }
+
+  const HloInstruction* buffer = TraceBufferSource(instr);
+  if (buffer == nullptr) {
+    return Internal(
+        "FindDynamicSliceChain: buffer operand of %s does not trace back to a "
+        "parameter",
+        instr->name());
+  }
+
+  DynamicSliceChain result;
+  result.buffer = buffer;
+
+  for (const HloInstruction* other : computation->instructions()) {
+    if (other->opcode() != HloOpcode::kDynamicSlice &&
+        other->opcode() != HloOpcode::kDynamicUpdateSlice) {
+      continue;
+    }
+    const HloInstruction* other_buffer = TraceBufferSource(other);
+    if (other_buffer != buffer) {
+      continue;
+    }
+    if (auto* ds = DynCast<HloDynamicSliceInstruction>(other)) {
+      result.slices.push_back(ds);
+    } else if (auto* dus = DynCast<HloDynamicUpdateSliceInstruction>(other)) {
+      result.updates.push_back(dus);
+    }
+  }
+
+  // Find the last DUS in the chain: the one that is not consumed by another
+  // DUS in the set (i.e. its result feeds into the ROOT tuple or other non-DUS
+  // consumers).
+  for (const auto* dus : result.updates) {
+    bool is_consumed_by_another_dus = false;
+    for (const HloInstruction* user : dus->users()) {
+      auto* dus_user = DynCast<HloDynamicUpdateSliceInstruction>(user);
+      if (dus_user &&
+          absl::c_find(result.updates, dus_user) != result.updates.end()) {
+        is_consumed_by_another_dus = true;
+        break;
+      }
+    }
+    if (!is_consumed_by_another_dus) {
+      result.result = dus;
+      break;
+    }
+  }
+
+  return result;
+}
+
+std::optional<bool> IsNonOverlapping(const DynamicSliceChain& chain) {
+  struct SliceRange {
+    int64_t byte_offset;
+    int64_t byte_size;
+  };
+
+  auto analyze_instr = [](const HloInstruction* instr)
+      -> std::optional<std::pair<DynamicSliceDescriptor, int64_t>> {
+    auto result = AnalyzeDynamicSlice(instr);
+    if (!result.ok() || !result->has_value()) {
+      return std::nullopt;
+    }
+    int64_t slice_byte_size = ShapeUtil::ByteSizeOf(instr->operand(1)->shape());
+    return std::make_pair(**result, slice_byte_size);
+  };
+
+  // Only check DUS-vs-DUS overlap. DS reads and DUS writes to the same slice
+  // are allowed (the read happens before the write within an iteration).
+  std::vector<std::pair<DynamicSliceDescriptor, int64_t>> dus_descriptors;
+
+  for (const auto* dus : chain.updates) {
+    auto desc = analyze_instr(dus);
+    if (!desc.has_value()) {
+      return std::nullopt;
+    }
+    dus_descriptors.push_back(*std::move(desc));
+  }
+
+  if (dus_descriptors.size() <= 1) {
+    return true;
+  }
+
+  auto front_loop = dus_descriptors.front().first.while_loop;
+  if (!front_loop.has_value()) {
+    return std::nullopt;
+  }
+  const HloInstruction* while_loop = *front_loop;
+  for (const auto& [desc, _] : dus_descriptors) {
+    if (desc.while_loop != front_loop) {
+      return std::nullopt;
+    }
+  }
+
+  auto loop_config = while_loop->backend_config<WhileLoopBackendConfig>();
+  if (!loop_config.ok() || !loop_config->has_known_trip_count()) {
+    return std::nullopt;
+  }
+  int64_t trip_count = loop_config->known_trip_count().n();
+
+  for (int64_t iter = 0; iter < trip_count; ++iter) {
+    std::vector<SliceRange> ranges;
+    ranges.reserve(dus_descriptors.size());
+    for (const auto& [desc, byte_size] : dus_descriptors) {
+      int64_t offset = desc.byte_offset + desc.byte_stride * iter;
+      ranges.push_back({offset, byte_size});
+    }
+
+    for (size_t i = 0; i < ranges.size(); ++i) {
+      for (size_t j = i + 1; j < ranges.size(); ++j) {
+        int64_t start_i = ranges[i].byte_offset;
+        int64_t end_i = start_i + ranges[i].byte_size;
+        int64_t start_j = ranges[j].byte_offset;
+        int64_t end_j = start_j + ranges[j].byte_size;
+        if (start_i < end_j && start_j < end_i) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/dynamic_slice_analysis.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_analysis.cc
@@ -179,11 +179,11 @@ static std::optional<StaggeredVariable> TryResolveStaggeredVariable(
   // Step 2: The parameter's parent computation must be the body of exactly
   // one while loop.
   const HloComputation* body = param->parent();
-  auto callers = body->caller_instructions(HloOpcode::kWhile);
-  if (callers.size() != 1) {
+  auto maybe_while_loop = body->GetUniqueCaller(HloOpcode::kWhile);
+  if (!maybe_while_loop.has_value()) {
     return std::nullopt;
   }
-  const HloInstruction* while_loop = callers.front();
+  const HloInstruction* while_loop = *maybe_while_loop;
   if (while_loop->while_body() != body) {
     return std::nullopt;
   }
@@ -244,26 +244,6 @@ static std::optional<StaggeredVariable> TryResolveStaggeredVariable(
   return StaggeredVariable{while_loop, operand, *init_value};
 }
 
-// Counts the number of intervening while loops between `instr` and
-// `while_loop`. Returns 0 if `instr` is directly inside `while_loop`'s body.
-static int64_t ComputeLoopIndex(const HloInstruction* instr,
-                                const HloInstruction* while_loop) {
-  int64_t depth = 0;
-  for (const HloComputation* comp = instr->parent(); comp != nullptr;) {
-    auto callers = comp->caller_instructions(HloOpcode::kWhile);
-    if (callers.empty()) {
-      break;
-    }
-    const HloInstruction* caller = callers.front();
-    if (caller == while_loop) {
-      return depth;
-    }
-    depth++;
-    comp = caller->parent();
-  }
-  return depth;
-}
-
 absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
     const HloInstruction* instr) {
   // Step 1: Only analyze dynamic-slice and dynamic-update-slice instructions.
@@ -301,6 +281,7 @@ absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
     const HloInstruction* ivar;
     bool is_staggered;
     int64_t staggered_init;
+    int64_t loop_index;
   };
 
   std::vector<ResolvedOffset> resolved_offsets;
@@ -320,10 +301,13 @@ absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
     auto functional_dependency =
         ResolveFunctionalDependencyOnInductionVariable(operand);
     if (functional_dependency) {
+      // ResolveFunctionalDependencyOnInductionVariable guarantees exactly one
+      // while loop in the chain (returns nullopt otherwise), so loop_index is
+      // 0.
       resolved_offsets.push_back({functional_dependency->loop,
                                   functional_dependency->induction_var,
-                                  /*is_staggered=*/false,
-                                  /*staggered_init=*/0});
+                                  /*is_staggered=*/false, /*staggered_init=*/0,
+                                  /*loop_index=*/0});
       continue;
     }
 
@@ -336,7 +320,8 @@ absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
     if (staggered_var) {
       resolved_offsets.push_back({staggered_var->loop, staggered_var->gte,
                                   /*is_staggered=*/true,
-                                  staggered_var->init_value});
+                                  staggered_var->init_value,
+                                  /*loop_index=*/0});
       continue;
     }
 
@@ -366,7 +351,7 @@ absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
   const ResolvedOffset& front = resolved_offsets.front();
   bool consistent = absl::c_all_of(resolved_offsets, [&](const auto& r) {
     return r.loop == front.loop && r.is_staggered == front.is_staggered &&
-           r.ivar == front.ivar;
+           r.ivar == front.ivar && r.loop_index == front.loop_index;
   });
 
   if (!consistent) {
@@ -434,9 +419,7 @@ absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
           << " iterations: offset=" << byte_offset
           << ", stride=" << byte_stride;
 
-  // Step 10: Compute the loop nesting depth (0 = direct child of while_loop).
-  int64_t loop_index = ComputeLoopIndex(instr, while_loop);
-  return DynamicSliceDescriptor{while_loop, loop_index, byte_offset,
+  return DynamicSliceDescriptor{while_loop, front.loop_index, byte_offset,
                                 byte_stride};
 }
 
@@ -479,8 +462,9 @@ absl::StatusOr<DynamicSliceChain> FindDynamicSliceChain(
   }
 
   const HloComputation* computation = instr->parent();
-  auto callers = computation->caller_instructions(HloOpcode::kWhile);
-  if (callers.size() != 1 || callers.front()->while_body() != computation) {
+  auto maybe_caller = computation->GetUniqueCaller(HloOpcode::kWhile);
+  if (!maybe_caller.has_value() ||
+      (*maybe_caller)->while_body() != computation) {
     return Internal("FindDynamicSliceChain: %s is not inside a while loop body",
                     instr->name());
   }

--- a/xla/backends/gpu/transforms/dynamic_slice_analysis.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_analysis.h
@@ -48,6 +48,10 @@ struct DynamicSliceDescriptor {
 
   // Index into the while loop nest (0 = innermost, 1 = one level up, etc.).
   // Nullopt when the offset is fully static.
+  //
+  // Currently always 0 (loop analysis resolves offsets only from the
+  // immediately enclosing while loop), but the runtime supports arbitrary loop
+  // nesting depths.
   std::optional<int64_t> loop_index;
 
   // Byte offset into the buffer at iteration 0 (or the static byte offset).

--- a/xla/backends/gpu/transforms/dynamic_slice_analysis.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_analysis.h
@@ -1,0 +1,135 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_ANALYSIS_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_ANALYSIS_H_
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+
+namespace xla::gpu {
+
+//===-----------------------------------------------------------------------===/
+// DynamicSliceDescriptor
+//===-----------------------------------------------------------------------===/
+
+// Fully resolved description of a dynamic-slice or dynamic-update-slice whose
+// offset is either a linear function of a parent while loop's induction
+// variable, or fully static (all-constant offsets).
+//
+// Loop-dependent case (byte_stride != 0):
+//   buffer address at iteration i = base + byte_offset + byte_stride * i
+//   while_loop and loop_index are set.
+//
+// Fully static case (byte_stride == 0):
+//   buffer address = base + byte_offset
+//   while_loop and loop_index are nullopt.
+struct DynamicSliceDescriptor {
+  // The while loop whose induction variable drives the slice offset.
+  // Nullopt when the offset is fully static (all-constant offsets).
+  std::optional<const HloInstruction*> while_loop;
+
+  // Index into the while loop nest (0 = innermost, 1 = one level up, etc.).
+  // Nullopt when the offset is fully static.
+  std::optional<int64_t> loop_index;
+
+  // Byte offset into the buffer at iteration 0 (or the static byte offset).
+  int64_t byte_offset;
+
+  // Byte stride per loop iteration. Zero when the offset is fully static.
+  int64_t byte_stride;
+};
+
+// Analyzes a dynamic-slice or dynamic-update-slice instruction and resolves its
+// runtime offset into a DynamicSliceDescriptor. Handles two cases:
+//
+//  1. Loop-dependent offsets: at least one offset operand depends on a parent
+//     while loop's induction variable. Evaluates the offset expression for all
+//     loop iterations using HloEvaluator, verifies linearity (constant stride),
+//     and returns byte_offset, byte_stride, while_loop, and loop_index.
+//
+//  2. Fully static offsets: all offset operands are compile-time constants.
+//     Computes the byte offset directly and returns byte_stride=0 with
+//     while_loop and loop_index unset.
+//
+// Returns nullopt when the instruction is not a DS/DUS, the slice is not
+// contiguous, an offset depends on runtime data that is not an induction
+// variable, or the offset pattern is not linear.
+absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
+    const HloInstruction* instr);
+
+// Returns the index of the first offset operand for a DS or DUS instruction.
+int32_t GetFirstOffsetOperandIndex(const HloInstruction* slice);
+
+// Returns the slice size in the given dimension for a DS or DUS instruction.
+int64_t GetSliceSize(const HloInstruction* slice, int32_t dim);
+
+//===-----------------------------------------------------------------------===/
+// DynamicSliceChain
+//===-----------------------------------------------------------------------===/
+
+// All dynamic-slice (DS) and dynamic-update-slice (DUS) operations that access
+// the same underlying buffer in a while loop body. The buffer enters as a
+// parameter tuple element and exits through the ROOT tuple. DS reads from the
+// buffer and DUS writes to it (aliasing parameter with result).
+//
+// DUS operations can form chains: each DUS writes to the result of the
+// previous, building up the final buffer value:
+//   buf = GTE(param, 1)
+//   updated1 = DUS(buf, v1, off1)       <-- first write
+//   updated2 = DUS(updated1, v2, off2)  <-- second write, chains from first
+//   ROOT tuple(..., updated2, ...)
+//
+// DS operations read from the input value (before any DUS):
+//   slice = DS(buf, ivar, 0)            <-- reads from original buffer
+//
+// Here {slice} and {updated1, updated2} form a DynamicSliceChain.
+struct DynamicSliceChain {
+  // Buffer source: GTE(parameter) for tuple parameters, or parameter directly.
+  const HloInstruction* buffer = nullptr;
+
+  // The last DUS in the chain whose result feeds into the ROOT tuple, or
+  // nullptr if there are no DUS updates. For the example above, this is
+  // updated2.
+  const HloInstruction* result = nullptr;
+
+  std::vector<const HloDynamicSliceInstruction*> slices;
+  std::vector<const HloDynamicUpdateSliceInstruction*> updates;
+};
+
+// Finds the set of all DS/DUS operations in a while loop body that access the
+// same underlying buffer as `instr`. The instruction must be a dynamic-slice or
+// dynamic-update-slice. Traces the buffer operand back through bitcasts and DUS
+// chains to find the source parameter element, then collects all DS/DUS in the
+// computation that share the same source. Also identifies the last DUS in the
+// chain (the one whose result feeds into the ROOT tuple).
+absl::StatusOr<DynamicSliceChain> FindDynamicSliceChain(
+    const HloInstruction* instr);
+
+// Returns true if all DUS operations in the chain write to non-overlapping byte
+// ranges at every loop iteration. DS reads are not checked — it is valid for a
+// DS and DUS to access the same slice (read before write within an iteration).
+// Returns nullopt if any DUS cannot be analyzed (e.g. non-linear offsets or
+// missing loop metadata).
+std::optional<bool> IsNonOverlapping(const DynamicSliceChain& chain);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_ANALYSIS_H_

--- a/xla/backends/gpu/transforms/dynamic_slice_analysis_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_analysis_test.cc
@@ -1,0 +1,769 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_analysis.h"
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+
+namespace xla::gpu {
+namespace {
+
+using DynamicSliceAnalysisTest = HloHardwareIndependentTestBase;
+
+// Helper: runs AnalyzeDynamicSlice on an instruction by name in the "body"
+// computation.
+absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeByName(
+    HloModule* module, absl::string_view name) {
+  auto* instr =
+      module->GetComputationWithName("body")->GetInstructionWithName(name);
+  return AnalyzeDynamicSlice(instr);
+}
+
+// DS with init=0, step=1 on dim0 of s32[4,8,8].
+// dim0 byte_stride = 8*8*4 = 256. offset = 0*256 = 0, stride = 1*256 = 256.
+TEST_F(DynamicSliceAnalysisTest, DsForwardStep1) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      slice = s32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "slice"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_THAT(desc->loop_index, ::testing::Optional(0));
+  EXPECT_EQ(desc->byte_offset, 0);
+  EXPECT_EQ(desc->byte_stride, 256);
+}
+
+// DUS with init=0, step=1, offset at dim0 (ivar) and dim1=constant(1).
+// s32[4,8,8]: dim0 stride=256, dim1 stride=32. offset=0+1*32=32, stride=256.
+TEST_F(DynamicSliceAnalysisTest, DusForwardStep1) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      val = s32[1,1,8] constant({{{1,2,3,4,5,6,7,8}}})
+      c1 = s32[] constant(1)
+      c0 = s32[] constant(0)
+      updated = s32[4,8,8] dynamic-update-slice(input, val, ivar, c1, c0)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8,8]) tuple(next_ivar, updated)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "updated"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_THAT(desc->loop_index, ::testing::Optional(0));
+  EXPECT_EQ(desc->byte_offset, 32);
+  EXPECT_EQ(desc->byte_stride, 256);
+}
+
+// DS with init=2, step=3 on s32[8,8,8]. dim0 stride=256.
+// offset = 2*256 = 512, stride = 3*256 = 768.
+TEST_F(DynamicSliceAnalysisTest, NonTrivialInitAndStep) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[8,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      slice = s32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      c3 = s32[] constant(3)
+      next_ivar = s32[] add(ivar, c3)
+      ROOT result = (s32[], s32[8,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c8 = s32[] constant(8)
+      ROOT cmp = pred[] compare(ivar, c8), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[8,8,8] parameter(0)
+      c2 = s32[] constant(2)
+      tuple = (s32[], s32[8,8,8]) tuple(c2, input)
+      ROOT while = (s32[], s32[8,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"2"},
+                          "known_init_step":{"init":"2","step":"3"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "slice"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_THAT(desc->loop_index, ::testing::Optional(0));
+  EXPECT_EQ(desc->byte_offset, 2 * 256);
+  EXPECT_EQ(desc->byte_stride, 3 * 256);
+}
+
+// Backward: init=3, step=-1 on s32[4,8,8]. dim0 stride=256.
+// offset = 3*256 = 768, stride = -1*256 = -256.
+TEST_F(DynamicSliceAnalysisTest, BackwardStep) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      slice = s32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      cn1 = s32[] constant(-1)
+      next_ivar = s32[] add(ivar, cn1)
+      ROOT result = (s32[], s32[4,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c0 = s32[] constant(0)
+      ROOT cmp = pred[] compare(ivar, c0), direction=GE
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c3 = s32[] constant(3)
+      tuple = (s32[], s32[4,8,8]) tuple(c3, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"3","step":"-1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "slice"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_THAT(desc->loop_index, ::testing::Optional(0));
+  EXPECT_EQ(desc->byte_offset, 3 * 256);
+  EXPECT_EQ(desc->byte_stride, -256);
+}
+
+// Forward step=2: init=0, step=2 on s32[8,8,8]. stride = 2*256 = 512.
+TEST_F(DynamicSliceAnalysisTest, ForwardStepTwo) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[8,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      slice = s32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      c2 = s32[] constant(2)
+      next_ivar = s32[] add(ivar, c2)
+      ROOT result = (s32[], s32[8,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c8 = s32[] constant(8)
+      ROOT cmp = pred[] compare(ivar, c8), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[8,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[8,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[8,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"2"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "slice"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_THAT(desc->loop_index, ::testing::Optional(0));
+  EXPECT_EQ(desc->byte_offset, 0);
+  EXPECT_EQ(desc->byte_stride, 2 * 256);
+}
+
+// Backward step=-2: init=6, step=-2 on s32[8,8,8].
+// offset = 6*256 = 1536, stride = -2*256 = -512.
+TEST_F(DynamicSliceAnalysisTest, BackwardStepTwo) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[8,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      slice = s32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      cn2 = s32[] constant(-2)
+      next_ivar = s32[] add(ivar, cn2)
+      ROOT result = (s32[], s32[8,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c0 = s32[] constant(0)
+      ROOT cmp = pred[] compare(ivar, c0), direction=GE
+    }
+
+    ENTRY main {
+      input = s32[8,8,8] parameter(0)
+      c6 = s32[] constant(6)
+      tuple = (s32[], s32[8,8,8]) tuple(c6, input)
+      ROOT while = (s32[], s32[8,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"6","step":"-2"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "slice"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_THAT(desc->loop_index, ::testing::Optional(0));
+  EXPECT_EQ(desc->byte_offset, 6 * 256);
+  EXPECT_EQ(desc->byte_stride, -2 * 256);
+}
+
+// Staggered induction variable after loop pipelining. DUS offset comes from
+// tuple index 3 which carries the previous iteration's ivar value.
+// f32[4,4]: dim0 stride=16. Staggered init=0, step=1. offset=0, stride=16.
+TEST_F(DynamicSliceAnalysisTest, StaggeredInductionVariable) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], f32[4,8], f32[4,4], s32[]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[4,8] get-tuple-element(p0), index=1
+      output = f32[4,4] get-tuple-element(p0), index=2
+      prev_ivar = s32[] get-tuple-element(p0), index=3
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      val = f32[1,4] constant({{1,2,3,4}})
+      dus = f32[4,4] dynamic-update-slice(output, val, prev_ivar, c0)
+      ROOT result = (s32[], f32[4,8], f32[4,4], s32[])
+          tuple(next_ivar, input, dus, ivar)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8], f32[4,4], s32[]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[4,8] parameter(0)
+      c0 = f32[] constant(0)
+      output = f32[4,4] broadcast(c0), dimensions={}
+      c0_s32 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      tuple = (s32[], f32[4,8], f32[4,4], s32[])
+          tuple(c1, input, output, c0_s32)
+      ROOT while = (s32[], f32[4,8], f32[4,4], s32[]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"3"},
+                          "known_init_step":{"init":"1","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "dus"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_THAT(desc->loop_index, ::testing::Optional(0));
+  EXPECT_EQ(desc->byte_offset, 0);
+  EXPECT_EQ(desc->byte_stride, 16);
+}
+
+// DS with all constant offsets inside a while loop body returns a static
+// descriptor (stride=0, no loop).
+TEST_F(DynamicSliceAnalysisTest, AllConstantOffsetsInLoop) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      slice = s32[1,8,8] dynamic-slice(input, c1, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "slice"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_FALSE(desc->while_loop.has_value());
+  EXPECT_FALSE(desc->loop_index.has_value());
+  // s32[4,8,8] dim0 byte_stride = 8*8*4 = 256. offset = 1*256 = 256.
+  EXPECT_EQ(desc->byte_offset, 256);
+  EXPECT_EQ(desc->byte_stride, 0);
+}
+
+// DUS with all constant offsets inside a while loop body returns a static
+// descriptor.
+TEST_F(DynamicSliceAnalysisTest, AllConstantDusOffsetsInLoop) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = s32[4,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      val = s32[1,8] constant({{1,2,3,4,5,6,7,8}})
+      updated = s32[4,8] dynamic-update-slice(buf, val, c1, c0)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8]) tuple(next_ivar, updated)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeByName(module.get(), "updated"));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_FALSE(desc->while_loop.has_value());
+  EXPECT_FALSE(desc->loop_index.has_value());
+  // s32[4,8] dim0 byte_stride = 8*4 = 32. offset = 1*32 = 32.
+  EXPECT_EQ(desc->byte_offset, 32);
+  EXPECT_EQ(desc->byte_stride, 0);
+}
+
+// DS with constant offsets (not in a while loop) returns a static descriptor.
+TEST_F(DynamicSliceAnalysisTest, StaticDsOutsideLoop) {
+  constexpr absl::string_view kHlo = R"(
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c1 = s32[] constant(1)
+      c0 = s32[] constant(0)
+      ROOT slice = s32[1,8] dynamic-slice(input, c1, c0),
+          dynamic_slice_sizes={1,8}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* slice = module->entry_computation()->root_instruction();
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeDynamicSlice(slice));
+  ASSERT_TRUE(desc.has_value());
+  EXPECT_FALSE(desc->while_loop.has_value());
+  EXPECT_FALSE(desc->loop_index.has_value());
+  // s32[4,8] dim0 byte_stride = 8*4 = 32. offset = 1*32 = 32.
+  EXPECT_EQ(desc->byte_offset, 32);
+  EXPECT_EQ(desc->byte_stride, 0);
+}
+
+// DS with data-dependent offset (not an ivar) returns nullopt.
+TEST_F(DynamicSliceAnalysisTest, DataDependentDsReturnsNullopt) {
+  constexpr absl::string_view kHlo = R"(
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      offset = s32[] parameter(1)
+      c0 = s32[] constant(0)
+      ROOT slice = s32[1,8] dynamic-slice(input, offset, c0),
+          dynamic_slice_sizes={1,8}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* slice = module->entry_computation()->root_instruction();
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeDynamicSlice(slice));
+  EXPECT_FALSE(desc.has_value());
+}
+
+//===-----------------------------------------------------------------------===/
+// FindDynamicSliceChain
+//===-----------------------------------------------------------------------===/
+
+// DS and DUS on the same parameter are collected into one set.
+TEST_F(DynamicSliceAnalysisTest, FindSetDsAndDusSameBuffer) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = s32[4,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      slice = s32[1,8] dynamic-slice(buf, ivar, c0),
+          dynamic_slice_sizes={1,8}
+      val = s32[1,8] constant({{1,2,3,4,5,6,7,8}})
+      updated = s32[4,8] dynamic-update-slice(buf, val, ivar, c0)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8]) tuple(next_ivar, updated)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* body = module->GetComputationWithName("body");
+  auto* slice = body->GetInstructionWithName("slice");
+  auto* updated = body->GetInstructionWithName("updated");
+
+  ASSERT_OK_AND_ASSIGN(auto chain, FindDynamicSliceChain(slice));
+  EXPECT_EQ(chain.slices.size(), 1);
+  EXPECT_EQ(chain.updates.size(), 1);
+  EXPECT_NE(std::find(chain.slices.begin(), chain.slices.end(),
+                      Cast<HloDynamicSliceInstruction>(slice)),
+            chain.slices.end());
+  EXPECT_NE(std::find(chain.updates.begin(), chain.updates.end(),
+                      Cast<HloDynamicUpdateSliceInstruction>(updated)),
+            chain.updates.end());
+  EXPECT_EQ(chain.result, updated);
+}
+
+// DS on one buffer does not include DUS on a different buffer.
+TEST_F(DynamicSliceAnalysisTest, FindSetSeparateBuffers) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf0 = s32[4,8] get-tuple-element(p0), index=1
+      buf1 = s32[4,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      slice = s32[1,8] dynamic-slice(buf0, ivar, c0),
+          dynamic_slice_sizes={1,8}
+      val = s32[1,8] constant({{1,2,3,4,5,6,7,8}})
+      updated = s32[4,8] dynamic-update-slice(buf1, val, ivar, c0)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8], s32[4,8]) tuple(next_ivar, buf0, updated)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input0 = s32[4,8] parameter(0)
+      input1 = s32[4,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8], s32[4,8]) tuple(c0, input0, input1)
+      ROOT while = (s32[], s32[4,8], s32[4,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* body = module->GetComputationWithName("body");
+  auto* slice = body->GetInstructionWithName("slice");
+
+  ASSERT_OK_AND_ASSIGN(auto chain, FindDynamicSliceChain(slice));
+  EXPECT_EQ(chain.slices.size(), 1);
+  EXPECT_EQ(chain.updates.size(), 0);
+  EXPECT_EQ(chain.result, nullptr);
+}
+
+// Two DUS operations chained on the same buffer: DUS(DUS(buf, v1, off1), v2,
+// off2). Both are collected and `result` points to the last one.
+TEST_F(DynamicSliceAnalysisTest, FindSetDusChain) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = s32[4,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c4 = s32[] constant(4)
+      c1 = s32[] constant(1)
+      val = s32[1,4] constant({{1,2,3,4}})
+      dus0 = s32[4,8] dynamic-update-slice(buf, val, ivar, c0)
+      dus1 = s32[4,8] dynamic-update-slice(dus0, val, ivar, c4)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8]) tuple(next_ivar, dus1)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* body = module->GetComputationWithName("body");
+  auto* dus0 = body->GetInstructionWithName("dus0");
+  auto* dus1 = body->GetInstructionWithName("dus1");
+
+  ASSERT_OK_AND_ASSIGN(auto chain, FindDynamicSliceChain(dus0));
+  EXPECT_EQ(chain.updates.size(), 2);
+  EXPECT_NE(std::find(chain.updates.begin(), chain.updates.end(),
+                      Cast<HloDynamicUpdateSliceInstruction>(dus0)),
+            chain.updates.end());
+  EXPECT_NE(std::find(chain.updates.begin(), chain.updates.end(),
+                      Cast<HloDynamicUpdateSliceInstruction>(dus1)),
+            chain.updates.end());
+  EXPECT_EQ(chain.result, dus1);
+}
+
+//===-----------------------------------------------------------------------===/
+// IsNonOverlapping
+//===-----------------------------------------------------------------------===/
+
+// DS and DUS on the same range: non-overlapping because only DUS writes are
+// checked (DS reads are allowed to alias with DUS writes).
+TEST_F(DynamicSliceAnalysisTest, DsAndDusSameRangeIsNonOverlapping) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = s32[4,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      slice = s32[1,8] dynamic-slice(buf, ivar, c0),
+          dynamic_slice_sizes={1,8}
+      val = s32[1,8] constant({{1,2,3,4,5,6,7,8}})
+      updated = s32[4,8] dynamic-update-slice(buf, val, ivar, c0)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8]) tuple(next_ivar, updated)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* slice =
+      module->GetComputationWithName("body")->GetInstructionWithName("slice");
+  ASSERT_OK_AND_ASSIGN(auto chain, FindDynamicSliceChain(slice));
+  auto result = IsNonOverlapping(chain);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(*result);
+}
+
+// Two DUS writing to different offsets (constant dim1 differs) are
+// non-overlapping.
+TEST_F(DynamicSliceAnalysisTest, NonOverlappingTwoDus) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = s32[4,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c4 = s32[] constant(4)
+      c1 = s32[] constant(1)
+      val = s32[1,4] constant({{1,2,3,4}})
+      dus0 = s32[4,8] dynamic-update-slice(buf, val, ivar, c0)
+      dus1 = s32[4,8] dynamic-update-slice(buf, val, ivar, c4)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8]) tuple(next_ivar, dus1)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* dus0 =
+      module->GetComputationWithName("body")->GetInstructionWithName("dus0");
+  ASSERT_OK_AND_ASSIGN(auto chain, FindDynamicSliceChain(dus0));
+  EXPECT_EQ(chain.updates.size(), 2);
+  auto result = IsNonOverlapping(chain);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(*result);
+}
+
+// Two DUS writing to the same offset — overlapping.
+TEST_F(DynamicSliceAnalysisTest, OverlappingTwoDus) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = s32[4,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      val = s32[1,8] constant({{1,2,3,4,5,6,7,8}})
+      dus0 = s32[4,8] dynamic-update-slice(buf, val, ivar, c0)
+      dus1 = s32[4,8] dynamic-update-slice(dus0, val, ivar, c0)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8]) tuple(next_ivar, dus1)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* dus0 =
+      module->GetComputationWithName("body")->GetInstructionWithName("dus0");
+  ASSERT_OK_AND_ASSIGN(auto chain, FindDynamicSliceChain(dus0));
+  EXPECT_EQ(chain.updates.size(), 2);
+  auto result = IsNonOverlapping(chain);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(*result);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/dynamic_slice_annotator.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_annotator.cc
@@ -1,0 +1,76 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_annotator.h"
+
+#include <string>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/transforms/dynamic_slice_analysis.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+
+namespace xla::gpu {
+
+absl::StatusOr<bool> DynamicSliceAnnotator::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool has_changed = false;
+
+  for (HloComputation* computation :
+       module->MakeNonfusionComputations(execution_threads)) {
+    for (HloInstruction* instr : computation->instructions()) {
+      if (instr->opcode() != HloOpcode::kDynamicSlice &&
+          instr->opcode() != HloOpcode::kDynamicUpdateSlice) {
+        continue;
+      }
+
+      ASSIGN_OR_RETURN(auto descriptor, AnalyzeDynamicSlice(instr));
+      if (!descriptor) {
+        continue;
+      }
+
+      ASSIGN_OR_RETURN(auto backend_config,
+                       instr->backend_config<GpuBackendConfig>());
+      auto* ds_config = backend_config.mutable_dynamic_slice_config();
+      if (descriptor->loop_index.has_value()) {
+        ds_config->set_loop_index(*descriptor->loop_index);
+      }
+      ds_config->set_byte_offset(descriptor->byte_offset);
+      ds_config->set_byte_stride(descriptor->byte_stride);
+      RETURN_IF_ERROR(instr->set_backend_config(backend_config));
+
+      VLOG(2) << "Annotated " << instr->name() << " with DynamicSliceConfig:"
+              << " loop_index="
+              << (descriptor->loop_index.has_value()
+                      ? std::to_string(*descriptor->loop_index)
+                      : "none")
+              << ", offset=" << descriptor->byte_offset
+              << ", stride=" << descriptor->byte_stride;
+      has_changed = true;
+    }
+  }
+
+  return has_changed;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/dynamic_slice_annotator.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_annotator.h
@@ -1,0 +1,43 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_ANNOTATOR_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_ANNOTATOR_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla::gpu {
+
+// Annotates dynamic-slice and dynamic-update-slice instructions with a
+// DynamicSliceConfig backend config (offset + stride * iteration). Handles
+// both loop-dependent offsets (linear function of a while loop's induction
+// variable, stride != 0) and fully static offsets (all constants, stride = 0).
+class DynamicSliceAnnotator : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "dynamic-slice-annotator"; }
+
+ protected:
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_ANNOTATOR_H_

--- a/xla/backends/gpu/transforms/dynamic_slice_annotator_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_annotator_test.cc
@@ -1,0 +1,160 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_annotator.h"
+
+#include <memory>
+#include <optional>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status_matchers.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+using DynamicSliceAnnotatorTest = HloHardwareIndependentTestBase;
+
+std::optional<DynamicSliceConfig> GetDynamicSliceConfig(
+    const HloInstruction* instr) {
+  auto config = instr->backend_config<GpuBackendConfig>();
+  if (!config.ok() || !config->has_dynamic_slice_config()) {
+    return std::nullopt;
+  }
+  return config->dynamic_slice_config();
+}
+
+TEST_F(DynamicSliceAnnotatorTest, AnnotatesDsInWhileLoop) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      slice = s32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+  EXPECT_THAT(DynamicSliceAnnotator().Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+
+  auto* slice =
+      module->GetComputationWithName("body")->GetInstructionWithName("slice");
+  auto config = GetDynamicSliceConfig(slice);
+  ASSERT_TRUE(config.has_value());
+  EXPECT_EQ(config->loop_index(), 0);
+  EXPECT_EQ(config->byte_offset(), 0);
+  EXPECT_EQ(config->byte_stride(), 256);
+}
+
+TEST_F(DynamicSliceAnnotatorTest, AnnotatesDusInWhileLoop) {
+  constexpr absl::string_view kHlo = R"(
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      val = s32[1,1,8] constant({{{1,2,3,4,5,6,7,8}}})
+      c1 = s32[] constant(1)
+      c0 = s32[] constant(0)
+      updated = s32[4,8,8] dynamic-update-slice(input, val, ivar, c1, c0)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8,8]) tuple(next_ivar, updated)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+  EXPECT_THAT(DynamicSliceAnnotator().Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+
+  auto* updated =
+      module->GetComputationWithName("body")->GetInstructionWithName("updated");
+  auto config = GetDynamicSliceConfig(updated);
+  ASSERT_TRUE(config.has_value());
+  EXPECT_EQ(config->loop_index(), 0);
+  EXPECT_EQ(config->byte_offset(), 32);
+  EXPECT_EQ(config->byte_stride(), 256);
+}
+
+TEST_F(DynamicSliceAnnotatorTest, AnnotatesConstantOffsetOutsideWhileLoop) {
+  constexpr absl::string_view kHlo = R"(
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      c1 = s32[] constant(1)
+      c0 = s32[] constant(0)
+      ROOT slice = s32[1,8] dynamic-slice(input, c1, c0),
+          dynamic_slice_sizes={1,8}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+  EXPECT_THAT(DynamicSliceAnnotator().Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+
+  auto* slice = module->entry_computation()->root_instruction();
+  auto config = GetDynamicSliceConfig(slice);
+  ASSERT_TRUE(config.has_value());
+  EXPECT_FALSE(config->has_loop_index());
+  EXPECT_EQ(config->byte_offset(), 32);
+  EXPECT_EQ(config->byte_stride(), 0);
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
- Add `DynamicSliceAnalysis` — analyzes dynamic-slice (DS) and dynamic-update-slice (DUS) instructions whose offsets are a linear function of a parent while loop's induction variable. Evaluates offset expressions via `HloEvaluator`, verifies constant stride, and returns `{loop_index, byte_offset, byte_stride}`. Also supports finding all DS/DUS operations on the same buffer (`FindDynamicSliceChain`) and checking non-overlapping access (`IsNonOverlapping`).
- Add `DynamicSliceAnnotator` — an `HloModulePass` that runs the analysis on every DS/DUS in while loop bodies and stamps successfully-analyzed instructions with a `DynamicSliceConfig` backend config (offset + stride * iteration).
- Add `DynamicSliceConfig` proto to `GpuBackendConfig` to carry the annotation through the pipeline.

This is groundwork for the v2 dynamic-slice fusion, which replaces the legacy offset-table approach with host-side loop state for offset computation, enabling support for arbitrary hero computations inside dynamic-slice fusions.