### PR TITLE
[xla:gpu] Add dynamic-slice defuser pass

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1385,6 +1385,32 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "dynamic_slice_defuser",
+    srcs = ["dynamic_slice_defuser.cc"],
+    hdrs = ["dynamic_slice_defuser.h"],
+    tags = ["gpu"],
+    deps = [
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+xla_cc_test(
+    name = "dynamic_slice_defuser_test",
+    srcs = ["dynamic_slice_defuser_test.cc"],
+    tags = ["gpu"],
+    deps = [
+        ":dynamic_slice_defuser",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "explicit_collectives_group_async_wrapper",
     srcs = ["explicit_collectives_group_async_wrapper.cc"],
     hdrs = ["explicit_collectives_group_async_wrapper.h"],

--- a/xla/backends/gpu/transforms/dynamic_slice_defuser.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_defuser.cc
@@ -1,0 +1,86 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_defuser.h"
+
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/tsl/platform/status_macros.h"
+
+namespace xla::gpu {
+
+namespace {
+
+bool IsNoOp(const HloInstruction* instr) {
+  return instr->opcode() == HloOpcode::kBitcast;
+}
+
+bool IsTrivialDynamicSliceFusion(const HloInstruction* instr) {
+  if (instr->opcode() != HloOpcode::kFusion ||
+      instr->fusion_kind() != HloInstruction::FusionKind::kLoop) {
+    return false;
+  }
+
+  const HloInstruction* root = instr->fused_expression_root();
+  if (root->opcode() != HloOpcode::kDynamicSlice &&
+      root->opcode() != HloOpcode::kDynamicUpdateSlice) {
+    return false;
+  }
+
+  for (const HloInstruction* fused_instr :
+       instr->fused_instructions_computation()->instructions()) {
+    if (fused_instr->opcode() == HloOpcode::kParameter || fused_instr == root ||
+        IsNoOp(fused_instr) || fused_instr->opcode() == HloOpcode::kConstant) {
+      continue;
+    }
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace
+
+absl::StatusOr<bool> DynamicSliceDefuser::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+
+  for (HloComputation* computation :
+       module->MakeNonfusionComputations(execution_threads)) {
+    std::vector<HloInstruction*> to_defuse;
+    for (HloInstruction* instr : computation->instructions()) {
+      if (IsTrivialDynamicSliceFusion(instr)) {
+        to_defuse.push_back(instr);
+      }
+    }
+
+    for (HloInstruction* fusion : to_defuse) {
+      RETURN_IF_ERROR(fusion->Defuse());
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/dynamic_slice_defuser.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_defuser.h
@@ -1,0 +1,48 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_DEFUSER_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_DEFUSER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla::gpu {
+
+// Defuses trivial kLoop fusions whose root is a DynamicSlice or
+// DynamicUpdateSlice and whose only other non-parameter instructions are
+// no-ops (bitcasts) and constants.
+//
+// These trivial fusions are created by priority-fusion absorbing bitcasts
+// into DS/DUS instructions. They hide the DS/DUS from downstream passes
+// like DynamicSliceAnnotator and DynamicSliceFusionRewriterV2 which need
+// to see them in raw form. FusionWrapper re-wraps them later if needed.
+//
+class DynamicSliceDefuser : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "dynamic-slice-defuser"; }
+
+ protected:
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_DEFUSER_H_

--- a/xla/backends/gpu/transforms/dynamic_slice_defuser_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_defuser_test.cc
@@ -1,0 +1,135 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_defuser.h"
+
+#include <optional>
+
+#include <gtest/gtest.h>
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+
+namespace xla::gpu {
+namespace {
+
+class DynamicSliceDefuserTest : public HloHardwareIndependentTestBase {};
+
+TEST_F(DynamicSliceDefuserTest, DefusesTrivialDUSFusion) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused_dus (p0: f32[4,64], p1: s32[], p2: f32[64]) -> f32[4,64] {
+      %p0 = f32[4,64]{1,0} parameter(0)
+      %p2 = f32[64]{0} parameter(2)
+      %bitcast = f32[1,64]{1,0} bitcast(%p2)
+      %p1 = s32[] parameter(1)
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[4,64]{1,0} dynamic-update-slice(%p0, %bitcast, %p1, %zero)
+    }
+
+    ENTRY main {
+      %buf = f32[4,64]{1,0} parameter(0)
+      %idx = s32[] parameter(1)
+      %update = f32[64]{0} parameter(2)
+      ROOT %fusion = f32[4,64]{1,0} fusion(%buf, %idx, %update),
+          kind=kLoop, calls=%fused_dus
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, DynamicSliceDefuser(), R"(
+    CHECK: ENTRY
+    CHECK-NOT: fusion
+    CHECK: bitcast(
+    CHECK: ROOT {{.*}} dynamic-update-slice(
+  )");
+}
+
+TEST_F(DynamicSliceDefuserTest, DefusesTrivialDSFusion) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused_ds (p0: f32[4,64], p1: s32[]) -> f32[1,64] {
+      %p0 = f32[4,64]{1,0} parameter(0)
+      %p1 = s32[] parameter(1)
+      %zero = s32[] constant(0)
+      ROOT %ds = f32[1,64]{1,0} dynamic-slice(%p0, %p1, %zero),
+          dynamic_slice_sizes={1,64}
+    }
+
+    ENTRY main {
+      %buf = f32[4,64]{1,0} parameter(0)
+      %idx = s32[] parameter(1)
+      ROOT %fusion = f32[1,64]{1,0} fusion(%buf, %idx),
+          kind=kLoop, calls=%fused_ds
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, DynamicSliceDefuser(), R"(
+    CHECK: ENTRY
+    CHECK-NOT: fusion
+    CHECK: ROOT {{.*}} dynamic-slice(
+  )");
+}
+
+TEST_F(DynamicSliceDefuserTest, DoesNotDefuseNonTrivialFusion) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused_comp (p0: f32[4,64], p1: f32[64]) -> f32[4,64] {
+      %p0 = f32[4,64]{1,0} parameter(0)
+      %p1 = f32[64]{0} parameter(1)
+      %bitcast = f32[1,64]{1,0} bitcast(%p1)
+      %zero = s32[] constant(0)
+      %dus = f32[4,64]{1,0} dynamic-update-slice(%p0, %bitcast, %zero, %zero)
+      ROOT %add = f32[4,64]{1,0} add(%dus, %p0)
+    }
+
+    ENTRY main {
+      %buf = f32[4,64]{1,0} parameter(0)
+      %update = f32[64]{0} parameter(1)
+      ROOT %fusion = f32[4,64]{1,0} fusion(%buf, %update),
+          kind=kLoop, calls=%fused_comp
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, DynamicSliceDefuser(), std::nullopt);
+}
+
+TEST_F(DynamicSliceDefuserTest, DoesNotDefuseCustomFusion) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused_dus (p0: f32[4,64], p1: s32[], p2: f32[64]) -> f32[4,64] {
+      %p0 = f32[4,64]{1,0} parameter(0)
+      %p2 = f32[64]{0} parameter(2)
+      %bitcast = f32[1,64]{1,0} bitcast(%p2)
+      %p1 = s32[] parameter(1)
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[4,64]{1,0} dynamic-update-slice(%p0, %bitcast, %p1, %zero)
+    }
+
+    ENTRY main {
+      %buf = f32[4,64]{1,0} parameter(0)
+      %idx = s32[] parameter(1)
+      %update = f32[64]{0} parameter(2)
+      ROOT %fusion = f32[4,64]{1,0} fusion(%buf, %idx, %update),
+          kind=kCustom, calls=%fused_dus
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, DynamicSliceDefuser(), std::nullopt);
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
- Add `DynamicSliceDefuser` — an `HloModulePass` that unwraps trivial `kLoop` fusions whose root is a `DynamicSlice` or `DynamicUpdateSlice` and whose only other non-parameter instructions are bitcasts and constants.
- These trivial fusions are created by priority-fusion absorbing bitcasts into DS/DUS instructions. They hide the DS/DUS from downstream passes (`DynamicSliceAnnotator`, `DynamicSliceFusionRewriterV2`) which need to see them in raw form. `FusionWrapper` re-wraps them later if needed.

This is part of the v2 dynamic-slice fusion work, ensuring DS/DUS instructions are visible to the analysis and annotation passes.