### PR TITLE
[XLA:GPU] allow custom call with both layout and computation

### DIFF
--- a/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
+++ b/xla/hlo/translate/mhlo_to_hlo/mlir_hlo_to_hlo.cc
@@ -2594,14 +2594,6 @@ LogicalResult ExportXlaOp(CustomCallOp op, OpLoweringContext ctx) {
     return op.emitOpError()
            << "cannot export with more than one called computations";
 
-  // Custom call can be exported either with called computation or with layout
-  // attributes. The XlaBuilder API does not allow both.
-  if (!op.getCalledComputations().empty() && op.getOperandLayouts() &&
-      op.getResultLayouts()) {
-    return op.emitOpError() << "cannot export if both called computation and "
-                               "layouts are specified";
-  }
-
   auto xla_api_version = xla::ConvertCustomCallApiVersion(op.getApiVersion());
   if (!xla_api_version.ok()) return failure();
 


### PR DESCRIPTION
📝 Summary of Changes
Allow custom call with both layout constraints and attached computation. Previously removed in https://github.com/openxla/xla/pull/27276. But added again in https://github.com/openxla/xla/commit/b9751a50e43363b13e967e9cbfcacad577f71f90.

🎯 Justification
Useful for cuDNN Flex Attention Support where attached computation is used to represent additional computation on attention score and layout constraints are used for cuDNN layout constraints.

🧪 Unit Tests:
CustomCallTest.WithCalledComputationAndLayouts
