### PR TITLE
[XLA:GPU] Allow swap of operands for some non commutative ops in cuDNN flex attention

### DIFF
--- a/xla/stream_executor/cuda/cudnn_sdpa_score_mod.cc
+++ b/xla/stream_executor/cuda/cudnn_sdpa_score_mod.cc
@@ -42,6 +42,25 @@ ScoreModFunc::ScoreModFunc(const xla::HloComputation* fwd_comp,
                            const xla::HloComputation* bwd_comp)
     : fwd_comp_(fwd_comp), bwd_comp_(bwd_comp) {}
 
+std::optional<cudnn_frontend::PointwiseMode_t>
+GetElementwiseModeIfOperandSwapped(cudnn_frontend::PointwiseMode_t pm) {
+  using m = cudnn_frontend::PointwiseMode_t;
+  switch (pm) {
+    case m::SUB:
+      return m::SUB;
+    case m::CMP_GE:
+      return m::CMP_LE;
+    case m::CMP_GT:
+      return m::CMP_LT;
+    case m::CMP_LE:
+      return m::CMP_GE;
+    case m::CMP_LT:
+      return m::CMP_GT;
+    default:
+      return std::nullopt;
+  }
+}
+
 std::optional<cudnn_frontend::PointwiseMode_t> GetElementwiseMode(
     const xla::HloInstruction& instruction) {
   const xla::HloOpcode opcode = instruction.opcode();
@@ -305,7 +324,7 @@ Tensor ScoreModFunc::Compile(
     } else if (hlo->IsElementwise()) {
       const auto compute_dtype =
           GetComputeDataType(hlo->shape().element_type());
-      const auto mode = GetElementwiseMode(*hlo);
+      auto mode = GetElementwiseMode(*hlo);
       if (!mode.has_value()) {
         LOG(FATAL) << "Unsupported elementwise operation: " << hlo->ToString()
                    << "\n";
@@ -325,9 +344,14 @@ Tensor ScoreModFunc::Compile(
         // make sure first operand is virtual
         // remove this once cuDNN supports this
         if (!is_virtual(0) && !HloOpcodeIsBinaryCommutative(hlo->opcode())) {
-          std::cerr << hlo->ToString() << "\n";
-          LOG(FATAL) << "first operand of cuDNN pointwise op is not virtual "
-                        "and op is not commutative.";
+          auto new_mode = GetElementwiseModeIfOperandSwapped(*mode);
+          if (new_mode) {
+            // We can swap the operands to WAR
+            mode = new_mode;
+          } else {
+            LOG(FATAL) << "first operand of cuDNN pointwise op is not "
+                          "virtual and op is not commutative.";
+          }
         }
         auto o0 = is_virtual(0) ? operand(0) : operand(1);
         auto o1 = is_virtual(0) ? operand(1) : operand(0);
@@ -349,6 +373,13 @@ Tensor ScoreModFunc::Compile(
           }
         }
         hlo_to_cudnn[hlo] = graph->pointwise(o0, o1, attrs);
+        if (hlo->opcode() == xla::HloOpcode::kSubtract && !is_virtual(0)) {
+          // insert negate here to get right result since we swaped operands
+          auto negate = cudnn_frontend::graph::Pointwise_attributes()
+                            .set_mode(cudnn_frontend::PointwiseMode_t::NEG)
+                            .set_compute_data_type(compute_dtype);
+          hlo_to_cudnn[hlo] = graph->pointwise(hlo_to_cudnn[hlo], negate);
+        }
       } else if (hlo->operand_count() == 3) {
         if (xla::HloPredicateIsNotOp<xla::HloOpcode::kSelect>(hlo)) {
           LOG(FATAL) << "Unimplemented elementwise operation:"

--- a/xla/stream_executor/cuda/cudnn_sdpa_score_mod_test.cc
+++ b/xla/stream_executor/cuda/cudnn_sdpa_score_mod_test.cc
@@ -74,6 +74,48 @@ TEST(CudnnSdpaScoreModTest, CompileFwd) {
   EXPECT_THAT(parsed_json["nodes"][0]["mode"], "MUL");
 }
 
+TEST(CudnnSdpaScoreModTest, CompileGraphWithReversedOperands) {
+  absl::string_view hlo = R"(
+  HloModule jit__unnamed_wrapped_function_
+
+  %rev (Arg_0: f32[4,4,1024,1024], Arg_1: f32[4,4,1024,1024]) -> f32[4,4,1024,1024] {
+    %Arg_0 = f32[4,4,1024,1024]{3,2,1,0} parameter(0)
+    %Arg_1 = f32[4,4,1024,1024]{3,2,1,0} parameter(1)
+    ROOT %sub.1 = f32[4,4,1024,1024]{3,2,1,0} subtract(%Arg_1, %Arg_0)
+  }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          xla::ParseAndReturnUnverifiedModule(hlo));
+  xla::HloComputation* comp = module->GetComputationWithName("rev");
+  ASSERT_NE(comp, nullptr);
+  int64_t uid = 0;
+  auto next_uid = [&]() -> int64_t { return uid++; };
+  Graph graph = std::make_shared<cudnn_frontend::graph::Graph>();
+  auto score_mod = std::make_shared<ScoreModFunc>(comp, nullptr);
+  EXPECT_THAT(score_mod->UpdateCudnnMap(*graph, next_uid),
+              absl_testing::IsOk());
+  Tensor attn_score =
+      graph->tensor(cudnn_frontend::graph::Tensor_attributes()
+                        .set_dim({4, 4, 1024, 1024})
+                        .set_stride({4194304, 1048576, 1024, 1})
+                        .set_data_type(cudnn_frontend::DataType_t::FLOAT)
+                        .set_uid(next_uid())
+                        .set_is_virtual(true));
+  auto output = score_mod->Forward(graph, attn_score);
+  std::string json_string = graph->print();
+  Json::Value parsed_json;
+  Json::Reader json_reader;
+  json_reader.parse(json_string, parsed_json,
+                    /* collectComments */ false);
+  EXPECT_TRUE(parsed_json.isObject());
+  // We reverse the operands of subtract because the first operand of sub is non
+  // virtual. A negate is needed to ensure correctness.
+  EXPECT_THAT(parsed_json["nodes"].size(), 2);
+  EXPECT_THAT(parsed_json["tensors"].size(), 4);
+  EXPECT_THAT(parsed_json["nodes"][0]["mode"], "SUB");
+  EXPECT_THAT(parsed_json["nodes"][1]["mode"], "NEG");
+}
+
 TEST(CudnnSdpaScoreModTest, CompileBwd) {
   absl::string_view hlo = R"(
   HloModule jit__unnamed_wrapped_function_


### PR DESCRIPTION
📝 Summary of Changes
cuDNN flex attention currently has restrictions that the first operand should be virtual (parameter isn't virtual, parameter 0 is an exception because it is managed by cuDNN). 
For commutative ops, operands can just be swapped. For non commutative ops like subtract, operands are swapped and a negate is added after. For divide, we error out because swapping operands with reciprocal are not safe when first operand has value 0. 