### PR TITLE
Gpu profiler deadlock ending up in DelayKernel timeout when autotuning in parallel

### DIFF
--- a/xla/backends/gpu/autotuner/gpu_profiler.cc
+++ b/xla/backends/gpu/autotuner/gpu_profiler.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "xla/backends/autotuner/profiler.h"
@@ -41,6 +42,7 @@ limitations under the License.
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/service/gpu/matmul_utils.h"
+#include "xla/service/gpu/stream_executor_util.h"
 #include "xla/service/maybe_owning_device_address.h"
 #include "xla/service/service_executable_run_options.h"
 #include "xla/service/shaped_buffer.h"
@@ -314,6 +316,7 @@ absl::Status GpuProfiler::CheckInputBuffers(InputBuffers& buffers) {
   if (options_.redzone_padding_bytes == 0) {
     return absl::OkStatus();
   }
+  absl::ReaderMutexLock gpu_lock(&GetGpuMutex(stream_executor_));
   const GpuInputBuffers& gpu_buffers =
       tsl::down_cast<const GpuInputBuffers&>(buffers);
   const RedzoneBuffers& rz_buffers = gpu_buffers.redzone_buffers;
@@ -329,6 +332,7 @@ absl::Status GpuProfiler::CheckInputBuffers(InputBuffers& buffers) {
 absl::Status GpuProfiler::CheckOutputBuffer(ScopedShapedBuffer& output,
                                             ScopedShapedBuffer& reference,
                                             float rtol) {
+  absl::ReaderMutexLock gpu_lock(&GetGpuMutex(stream_executor_));
   return ShapeUtil::ForEachLeafShapeWithStatus(
       reference.on_device_shape(),
       [&](const Shape& subshape, const ShapeIndex& index) -> absl::Status {

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -462,6 +462,38 @@ GpuExecutable::GpuExecutable(
 }
 
 GpuExecutable::~GpuExecutable() {
+  // Take reader locks on the per-device GPU mutex for all executors this
+  // executable has initialized modules on. This prevents cuModuleUnload
+  // (triggered by kernel/thunk destruction below) from racing with the
+  // DelayKernel used during autotuning profiling. The profiler holds the
+  // writer lock while the DelayKernel is active; taking reader locks here
+  // ensures we wait for profiling to finish before unloading modules.
+  std::vector<se::StreamExecutor*> executors;
+  {
+    absl::MutexLock lock(&module_handle_mutex_);
+    executors.reserve(module_handles_.size());
+    for (const auto& module_handle : module_handles_) {
+      executors.push_back(module_handle.first);
+    }
+  }
+
+  std::vector<std::unique_ptr<absl::ReaderMutexLock>> gpu_locks;
+  gpu_locks.reserve(executors.size());
+  for (se::StreamExecutor* executor : executors) {
+    gpu_locks.push_back(
+        std::make_unique<absl::ReaderMutexLock>(&GetGpuMutex(executor)));
+  }
+
+  // Explicitly destroy thunks and module handles under the reader locks.
+  // Thunk destruction triggers kernel unloading (CudaExecutor::UnloadKernel ->
+  // cuModuleUnload). This must happen while we hold reader locks to prevent
+  // cuModuleUnload from racing with the DelayKernel on another thread.
+  thunk_executor_.reset();
+  {
+    absl::MutexLock lock(&module_handle_mutex_);
+    module_handles_.clear();
+  }
+
   if (has_module() && enable_debug_info_manager_) {
     XlaDebugInfoManager::Get()->UnregisterModule(module().unique_id());
   }


### PR DESCRIPTION
📝 Summary of Changes
This PR improves parallel compilation with `PJRT_Cient_Compile` when autotuning is enabled.

Autotuning relies on a DelayKernel to ensure that the start event is recorded just before the profiled kernel. It's a simple spin loop that keeps the GPU busy until the host could schedule the start & end recording and the profiled kernel launches. Once that's done the host changes a semaphore to signal that the spin loop can stop. This works fine when a single `PJRT_Cient_Compile` is called. But when calling in parallel, we're seeing DelayKernel timing out all the time.

After some investigation, it's due to CUDA calls such as `cuMemcpyDtoHAsync` that block while the DelayKernel spins in the same stream. The problem is that this then blocks further calls like `cuRecordEvent`, and now the start/end event recording cannot be scheduled and we end up in a deadlock between a thread that wants to profile and another one that intends to check input or output buffers. The deadlock is only "solved" through the timeout mechanism.

The first commit takes the gpu lock in shared mode to avoid the checks to execute simultaneously with the profiling. That solves almost all deadlocks. But I still noticed a few deadlocks because of `cuModuleUnload`within the `ScopedModuleHandle` desctructor. It's more complicated to prevent any conflicts here. So I propose here one fairly minimal solution that ensures we have a shared lock before calling the destructors, but I'm not sure whether that's acceptable.

🎯 Justification
Today compiling multiple program in parallel with `PJRT_Cient_Compile` is slower for us than compiling them sequentially. Given that auto-tuning takes a significant amount of time and needs to happen at start-up we want to minimize it as much as possible.

I've tested on the 5090 (CUDA 13.1 / 590.48.01) and 4090 (CUDA 13 / 580.95.05).

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
