### PR TITLE
[ROCm] Use AMD-specific allocate-shared-memory pass in Triton pipeline

### DIFF
--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -157,7 +157,7 @@ static void MakeLLIR(mlir::OpPassManager* pm,
   pm->addPass(mlir::createSCFToControlFlowPass());
   pm->addPass(mlir::createInlinerPass());
   pm->addPass(mlir::createConvertIndexToLLVMPass());
-  pm->addPass(mt::gpu::createAllocateSharedMemory());
+  pm->addPass(mt::createAllocateAMDGPUSharedMemory());
   pm->addPass(mt::gpu::createTritonGPUGlobalScratchAllocationPass());
   pm->addPass(mt::gpu::createTritonGPUGlobalScratchAllocationPass());
   pm->addPass(


### PR DESCRIPTION
Replace the generic pass with the AMD-specific one matching what upstream Triton's AMD backend does.